### PR TITLE
feat(api): opentrons_simulate gets duration estimation

### DIFF
--- a/api/src/opentrons/protocols/duration/__init__.py
+++ b/api/src/opentrons/protocols/duration/__init__.py
@@ -1,0 +1,6 @@
+from .estimator import DurationEstimator
+
+
+__all__ = [
+    "DurationEstimator"
+]

--- a/api/src/opentrons/protocols/duration/__init__.py
+++ b/api/src/opentrons/protocols/duration/__init__.py
@@ -1,6 +1,4 @@
 from .estimator import DurationEstimator
 
 
-__all__ = [
-    "DurationEstimator"
-]
+__all__ = ["DurationEstimator"]

--- a/api/src/opentrons/protocols/duration/errors.py
+++ b/api/src/opentrons/protocols/duration/errors.py
@@ -1,5 +1,5 @@
 class DurationEstimatorException(Exception):
     def __init__(self, message):
-        super(Exception, self).__init__(
+        super().__init__(
             f"Error encountered while estimating protocol duration: '{message}'"
         )

--- a/api/src/opentrons/protocols/duration/errors.py
+++ b/api/src/opentrons/protocols/duration/errors.py
@@ -1,0 +1,5 @@
+class DurationEstimatorException(Exception):
+    def __init__(self, message):
+        super(Exception, self).__init__(
+            f"Error encountered while estimating protocol duration: '{message}'"
+        )

--- a/api/src/opentrons/protocols/duration/estimator.py
+++ b/api/src/opentrons/protocols/duration/estimator.py
@@ -1,0 +1,12 @@
+from opentrons.commands import types
+
+
+class DurationEstimator:
+    def __init__(self):
+        pass
+
+    def get_total_duration(self) -> float:
+        return 0
+
+    def on_message(self, message: types.CommandMessage) -> None:
+        pass

--- a/api/src/opentrons/protocols/duration/estimator.py
+++ b/api/src/opentrons/protocols/duration/estimator.py
@@ -47,6 +47,8 @@ class DurationEstimator:
     def __init__(self):
         # Which slot the last command was in.
         self._last_deckslot = None
+        # todo(mm, 2021-09-08): Support protocols with more than one
+        # Temperature or Thermocycler Module.
         self._last_temperature_module_temperature = START_MODULE_TEMPERATURE
         self._last_thermocycler_module_temperature = START_MODULE_TEMPERATURE
         # Per step time estimate.

--- a/api/src/opentrons/protocols/duration/estimator.py
+++ b/api/src/opentrons/protocols/duration/estimator.py
@@ -124,6 +124,10 @@ class DurationEstimator:
             The duration in seconds
         """
         duration = 0.0
+        # TODO (al 2021-09-09):
+        #  - Make this into a map
+        #  - Remove "# noqa: C901"
+        #  - type the payload in the on_X methods.
         if message_name == types.PICK_UP_TIP:
             duration = self.on_pick_up_tip(payload=payload)
         elif message_name == types.DROP_TIP:
@@ -156,6 +160,11 @@ class DurationEstimator:
             duration = self.on_thermocycler_deactivate_lid(payload=payload)
         elif message_name == types.THERMOCYCLER_OPEN:
             duration = self.on_thermocycler_lid_open(payload=payload)
+        else:
+            logger.warning(
+                f"Command type '{message_name}' is not yet supported by the "
+                f"duration estimator."
+            )
         return duration
 
     def on_pick_up_tip(self, payload) -> float:

--- a/api/src/opentrons/protocols/duration/estimator.py
+++ b/api/src/opentrons/protocols/duration/estimator.py
@@ -7,6 +7,7 @@ import functools
 
 from dataclasses import dataclass
 
+from opentrons.protocols.geometry.deck import Deck
 from opentrons.commands import types
 from opentrons.protocols.api_support.labware_like import LabwareLike
 from opentrons.protocols.duration.errors import DurationEstimatorException
@@ -29,6 +30,8 @@ THERMO_HIGH_THRESH: Final = 70.0
 
 START_MODULE_TEMPERATURE: Final = 25.0
 
+STARTING_SLOT: Final[str] = "12"
+
 
 logger = logging.getLogger(__name__)
 
@@ -46,13 +49,14 @@ class DurationEstimator:
 
     def __init__(self):
         # Which slot the last command was in.
-        self._last_deckslot = None
+        self._last_deckslot = STARTING_SLOT
         # todo(mm, 2021-09-08): Support protocols with more than one
         # Temperature or Thermocycler Module.
         self._last_temperature_module_temperature = START_MODULE_TEMPERATURE
         self._last_thermocycler_module_temperature = START_MODULE_TEMPERATURE
         # Per step time estimate.
         self._increments: List[TimerEntry] = []
+        self._deck = Deck()
 
     def get_total_duration(self) -> float:
         """Return the total duration"""
@@ -96,7 +100,8 @@ class DurationEstimator:
             raise DurationEstimatorException(str(e))
 
         if location:
-            self._last_deckslot = self.get_slot(location)
+            slot = self.get_slot(location)
+            self._last_deckslot = slot if slot else self._last_deckslot
 
         self._increments.append(
             TimerEntry(
@@ -164,7 +169,7 @@ class DurationEstimator:
         gantry_speed = instrument.default_speed
 
         deck_travel_time = self.calc_deck_movement_time(
-            curr_slot, prev_slot, gantry_speed
+            self._deck, curr_slot, prev_slot, gantry_speed
         )
 
         # The time to pick up tip is 4 seconds. Determined by testing on hardware.
@@ -186,7 +191,7 @@ class DurationEstimator:
         prev_slot = self._last_deckslot
         gantry_speed = instrument.default_speed
         deck_travel_time = self.calc_deck_movement_time(
-            curr_slot, prev_slot, gantry_speed
+            self._deck, curr_slot, prev_slot, gantry_speed
         )
         # TODO (al, 2021-09-08): Should we be checking for drop tip home_after = False?
 
@@ -224,7 +229,7 @@ class DurationEstimator:
 
         gantry_speed = instrument.default_speed
         deck_travel_time = self.calc_deck_movement_time(
-            curr_slot, prev_slot, gantry_speed
+            self._deck, curr_slot, prev_slot, gantry_speed
         )
         duration = deck_travel_time + z_total_time + aspiration_time
         logger.info(
@@ -255,7 +260,7 @@ class DurationEstimator:
 
         gantry_speed = instrument.default_speed
         deck_travel_time = self.calc_deck_movement_time(
-            curr_slot, prev_slot, gantry_speed
+            self._deck, curr_slot, prev_slot, gantry_speed
         )
 
         duration = deck_travel_time + z_total_time + dispense_time
@@ -360,7 +365,7 @@ class DurationEstimator:
         logger.info(
             f"temperatures {sum(cycling_counter)}, "
             f"hold_times {total_hold_time} , cycles are {cycle_count}, "
-            f"{duration} boop"
+            f"{duration}"
         )
         return duration
 
@@ -462,61 +467,39 @@ class DurationEstimator:
             return LabwareLike(location).first_parent()
 
     @staticmethod
-    def calc_deck_movement_time(current_slot, previous_slot, gantry_speed):
-        y_dist = 88.9
-        x_dist = 133.35
+    def calc_deck_movement_time(
+        deck: Deck, current_slot: Optional[str], previous_slot: str, gantry_speed: float
+    ) -> float:
         # Quick summary we set coordinates for each deck slot and found ways
         # to move between deck slots.
         # Each deck slot is a key for a coordinate value
         # Moving between coordinate values
-        start_point_pip = (2 * x_dist, 3 * y_dist)
-
-        deck_centers = {
-            "1": (0, 0),
-            "2": (x_dist, 0),
-            "3": (2 * x_dist, 0),
-            "4": (0, y_dist),
-            "5": (x_dist, y_dist),
-            "6": (2 * x_dist, y_dist),
-            "7": (0, 2 * y_dist),
-            "8": (x_dist, 2 * y_dist),
-            "9": (2 * x_dist, 2 * y_dist),
-            "10": (0, 3 * y_dist),
-            "11": (x_dist, 3 * y_dist),
-            "12": (2 * x_dist, 3 * y_dist),
-        }
-
-        current_deck_center = deck_centers.get(current_slot)
-        if not current_deck_center:
+        if not current_slot:
             raise DurationEstimatorException(
                 f"Current slot '{current_slot}' is not valid."
             )
 
-        if previous_slot is None:
-            init_x_diff = abs((current_deck_center[0]) - (start_point_pip[0]))
-            init_y_diff = abs((current_deck_center[1]) - (start_point_pip[1]))
-            init_deck_d = math.sqrt((init_x_diff ** 2) + (init_y_diff ** 2))
-            deck_movement_time = init_deck_d / gantry_speed
-            return deck_movement_time
-        else:
-            previous_deck_center = deck_centers.get(previous_slot)
-            if not previous_deck_center:
-                raise DurationEstimatorException(
-                    f"Previous slot '{current_slot}' is not valid."
-                )
-            x_difference = abs(current_deck_center[0] - previous_deck_center[0])
-            y_difference = abs(current_deck_center[1] - previous_deck_center[1])
+        previous_deck_center = deck.position_for(previous_slot)
+        if not previous_deck_center:
+            raise DurationEstimatorException(
+                f"Previous slot '{current_slot}' is not valid."
+            )
+        current_deck_center = deck.position_for(current_slot)
 
-            if x_difference == 0 and y_difference == 0:
-                # Inter slot movement defaults to half a second.
-                deck_movement_time = 0.5
-            else:
-                deck_distance = math.sqrt((x_difference ** 2) + (y_difference ** 2))
-                deck_movement_time = deck_distance / gantry_speed
-            return deck_movement_time
+        x_difference = abs(current_deck_center.point.x - previous_deck_center.point.x)
+        y_difference = abs(current_deck_center.point.y - previous_deck_center.point.y)
+
+        if x_difference == 0 and y_difference == 0:
+            # Inter slot movement defaults to half a second.
+            deck_movement_time = 0.5
+        else:
+            deck_distance = math.sqrt((x_difference ** 2) + (y_difference ** 2))
+            deck_movement_time = deck_distance / gantry_speed
+        return deck_movement_time
 
     @staticmethod
     def z_time(is_module: bool, gantry_speed: float) -> float:
+        # TODO (al, 2021-09-08): Use definitions from protocol context objects.
         z_default_labware_height = 177.8
         z_default_module_height = 95.25
         # 177.8 - 82.55 Where did we get 177.8 from?
@@ -533,6 +516,16 @@ class DurationEstimator:
 
     @staticmethod
     def rate_high(temp0: float, temp1: float) -> float:
+        """
+        Calculate temp deck temperature change to a high temperature.
+
+        Args:
+            temp0: Current
+            temp1: Target
+
+        Returns:
+            Duration in seconds.
+        """
         val = 0.0
         if temp0 >= TEMP_MOD_HIGH_THRESH:
             val = abs(temp1 - temp0) / TEMP_MOD_RATE_HIGH_AND_ABOVE
@@ -548,6 +541,16 @@ class DurationEstimator:
 
     @staticmethod
     def rate_mid(temp0: float, temp1: float) -> float:
+        """
+        Calculate temp deck temperature change to a medium temperature.
+
+        Args:
+            temp0: Current
+            temp1: Target
+
+        Returns:
+            Duration in seconds.
+        """
         val = 0.0
         if TEMP_MOD_LOW_THRESH <= temp0 <= TEMP_MOD_HIGH_THRESH:
             val = abs(temp1 - temp0) / TEMP_MOD_RATE_LOW_TO_HIGH
@@ -565,6 +568,16 @@ class DurationEstimator:
     # How to handle temperatures where one of them is low temp
     @staticmethod
     def rate_low(temp0: float, temp1: float) -> float:
+        """
+        Calculate temp deck temperature change to a low temperature.
+
+        Args:
+            temp0: Current
+            temp1: Target
+
+        Returns:
+            Duration in seconds.
+        """
         val = 0.0
         if temp0 <= TEMP_MOD_LOW_THRESH:
             val = abs(temp1 - temp0) / TEMP_MOD_RATE_ZERO_TO_LOW

--- a/api/src/opentrons/protocols/duration/estimator.py
+++ b/api/src/opentrons/protocols/duration/estimator.py
@@ -2,7 +2,7 @@ import logging
 from typing import Optional, List
 from typing_extensions import Final
 
-import numpy as np  # type: ignore
+import math
 import functools
 
 from dataclasses import dataclass
@@ -495,7 +495,7 @@ class DurationEstimator:
         if previous_slot is None:
             init_x_diff = abs((current_deck_center[0]) - (start_point_pip[0]))
             init_y_diff = abs((current_deck_center[1]) - (start_point_pip[1]))
-            init_deck_d = np.sqrt((init_x_diff ** 2) + (init_y_diff ** 2))
+            init_deck_d = math.sqrt((init_x_diff ** 2) + (init_y_diff ** 2))
             deck_movement_time = init_deck_d / gantry_speed
             return deck_movement_time
         else:
@@ -511,7 +511,7 @@ class DurationEstimator:
                 # Inter slot movement defaults to half a second.
                 deck_movement_time = 0.5
             else:
-                deck_distance = np.sqrt((x_difference ** 2) + (y_difference ** 2))
+                deck_distance = math.sqrt((x_difference ** 2) + (y_difference ** 2))
                 deck_movement_time = deck_distance / gantry_speed
             return deck_movement_time
 

--- a/api/src/opentrons/protocols/duration/estimator.py
+++ b/api/src/opentrons/protocols/duration/estimator.py
@@ -42,6 +42,10 @@ class TimerEntry:
     duration: float
 
 
+# TODO (al, 2021-09-09): Write doc strings for each method detailing how the
+#  duration is computed.
+
+
 class DurationEstimator:
     """
     Broker listener that calculates the duration of protocol steps.
@@ -124,7 +128,7 @@ class DurationEstimator:
             The duration in seconds
         """
         duration = 0.0
-        # TODO (al 2021-09-09):
+        # TODO (al, 2021-09-09):
         #  - Make this into a map
         #  - Remove "# noqa: C901"
         #  - type the payload in the on_X methods.

--- a/api/src/opentrons/protocols/duration/estimator.py
+++ b/api/src/opentrons/protocols/duration/estimator.py
@@ -1,12 +1,607 @@
+import logging
+from typing import Optional, List
+
+import numpy as np
+import math
+import functools
+
+from dataclasses import dataclass
+
 from opentrons.commands import types
+from opentrons.protocols.api_support.labware_like import LabwareLike
+from opentrons.types import Location
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TimerEntry:
+    command: types.CommandMessage
+    duration: float
 
 
 class DurationEstimator:
     def __init__(self):
-        pass
+        # Which slot the last command was in.
+        self._last_deckslot = None
+        self._last_temperature_module_temperature = 25
+        self._last_thermocyler_module_temperature = 25
+        # Per step time estimate.
+        self._increments: List[TimerEntry] = []
+        ## New
+        self._labware_locations = []
 
     def get_total_duration(self) -> float:
-        return 0
+        """Return the total duration"""
+        return functools.reduce(
+            lambda acc, val: acc + val.duration,
+            self._increments,
+            0.0
+        )
 
     def on_message(self, message: types.CommandMessage) -> None:
-        pass
+        # logging.info(f"Got new message: {message}")
+
+        # The shape of CommandMessage and the message types are defined in this file:
+        #     opentrons/api/src/opentrons/commands/types.py
+        # It's not easy to decipher :)
+
+        # Extract the message name
+        message_name = message['name']
+        # Whether this message comes before or after the command is being executed..
+        after = message['$'] == 'after'
+        # The actual payload of the command that varies by message. This should be
+        # familiar from your script.
+        payload = message['payload']
+        duration = 0.0
+
+        location = payload.get('location')
+
+        ## This helps us handle previous deck slots with lists instead of OOP.
+        ## Before we were having issues because there are two instances in each deck slot movement, before and after
+        ## Before would have the right value and after would have the self._last_deckslot equal to the self.get_slot(location)
+        ## As that sentence implies, this means that the code said the prev_slot was always equalt to the current slot
+        # (which were both equal to self.get_slot(location).
+        ## Alex Copperman made this
+
+        # makes sure there is one set of information
+
+        # First step is to pick_up_tips
+        if message_name == types.PICK_UP_TIP:
+            duration = self.on_pick_up_tip(payload=payload, after=after)
+        elif message_name == types.DROP_TIP:
+            duration = self.on_drop_tip(payload=payload, after=after)
+        # second step is to aspirate
+        elif message_name == types.ASPIRATE:
+            duration = self.on_aspirate(payload=payload, after=after)
+        elif message_name == types.DISPENSE:
+            duration = self.on_dispense(payload=payload, after=after)
+
+        ## I think we should add touch_tip and air gap because airgap isn't covered the same way
+        elif message_name == types.BLOW_OUT:
+            duration = self.on_blow_out(payload=payload, after=after)
+        elif message_name == types.TOUCH_TIP:
+            duration = self.on_touch_tip(payload=payload, after=after)
+        elif message_name == types.DELAY:
+            duration = self.on_delay(payload=payload, after=after)
+        elif message_name == types.TEMPDECK_SET_TEMP:
+            duration = self.on_tempdeck_set_temp(payload=payload, after=after)
+        elif message_name == types.TEMPDECK_DEACTIVATE:
+            duration = self.on_tempdeck_deactivate(payload=payload, after=after)
+        elif message_name == types.TEMPDECK_AWAIT_TEMP:
+            duration = self.on_tempdeck_await_temp(payload=payload, after=after)
+        elif message_name == types.THERMOCYCLER_SET_BLOCK_TEMP:
+            duration = self.on_thermocyler_block_temp(payload=payload, after=after)
+        elif message_name == types.THERMOCYCLER_EXECUTE_PROFILE:
+            duration = self.on_execute_profile(payload=payload, after=after)
+        elif message_name == types.THERMOCYCLER_SET_LID_TEMP:
+            duration = self.on_thermocyler_set_lid_temp(payload=payload, after=after)
+        elif message_name == types.THERMOCYCLER_CLOSE:
+            duration = self.on_thermocyler_lid_close(payload=payload, after=after)
+        elif message_name == types.THERMOCYCLER_DEACTIVATE_LID:
+            duration = self.on_thermocyler_deactivate_lid(payload=payload, after=after)
+        elif message_name == types.THERMOCYCLER_OPEN:
+            duration = self.on_thermocyler_lid_open(payload=payload, after=after)
+
+        if after:
+            self._last_deckslot = self.get_slot(location)
+            self._increments.append(
+                TimerEntry(
+                    command=message,
+                    duration=duration,
+                )
+            )
+
+        # add result to results.
+
+
+        # store last deckslot
+
+        # self._last_deckslot = self.get_slot(location)
+        ## We need exception handling for location == None otherwise it won't work
+
+    ## command.THERMOCYCLER_SET_LID_TEMP
+    ## command.THERMOCYCLER_CLOSE
+    ## command.THERMOCYCLER_DEACTIVATE_LID
+
+    def on_pick_up_tip(
+            self,
+            payload,
+            after: bool) -> float:
+
+        # The instrument is opentrons/api/src/opentrons/protocol_api/instrument_context.py
+        instrument = payload['instrument']
+
+        # The location is either a Well or a Labware: see opentrons/api/src/opentrons/protocol_api/labware.py
+        location = payload['location']
+        prev_slot = self._last_deckslot
+        curr_slot = self.get_slot(location)
+
+        gantry_speed = instrument.default_speed
+
+        deck_travel_time = self.calc_deck_movement_time(curr_slot, prev_slot, gantry_speed)
+
+        duration = deck_travel_time + 4
+
+        if after:
+            logger.info(f"{instrument.name} picked up tip from slot {curr_slot} the duration is {duration}")
+            return duration
+
+        # return duration
+
+    def on_drop_tip(
+            self,
+            payload,
+            after: bool) -> float:
+        # How long this took
+        duration = 0
+        # The instrument is opentrons/api/src/opentrons/protocol_api/instrument_context.py
+        instrument = payload['instrument']
+        # The location is either a Well or a Labware: see opentrons/api/src/opentrons/protocol_api/labware.py
+        location = payload['location']
+        # Use the utility to get the  slot
+        ## We are going to once again use our "deck movement" set up. This should be in pickup, drop tip, aspirate, dispense
+        location = payload['location']
+        curr_slot = self.get_slot(location)
+        ## this one disagrees with me.
+        prev_slot = self._last_deckslot
+        gantry_speed = instrument.default_speed
+        deck_travel_time = self.calc_deck_movement_time(curr_slot, prev_slot, gantry_speed)
+        ## Should we be checking for drop tip home_after = False?
+        ## we need to add default 10 second drop tip time
+        duration = deck_travel_time + 10
+        # let's only log the message after the pick up tip is done.
+
+        if after:
+            logger.info(f"{instrument.name}, drop tip duration is {duration}")
+            return duration
+
+        # return duration
+
+    def on_aspirate(
+            self,
+            payload,
+            after: bool) -> float:
+        # How long this took
+        duration = 0
+        ## General aspiration code
+        instrument = payload['instrument']
+        volume = payload['volume']
+        rate = payload['rate'] * instrument.flow_rate.aspirate
+
+        aspiration_time = volume / rate
+
+        # okay lets add that in to duration.
+
+        # now lets handle the aspiration z-axis code.
+        location = payload['location']
+        slot = self.get_slot(location)
+        slot_module = location.labware.parent.parent.is_module
+        slot_module = 0
+        gantry_speed = instrument.default_speed
+        if slot_module == True:
+            slot_module = 1
+        else:
+            slot_module = 0
+        Z_total_time = self.Z_time(slot_module, gantry_speed)
+
+        ## We are going to once again use our "deck movement" set up. This should be in pickup, drop tip, aspirate, dispense
+        location = payload['location']
+        prev_slot = self._last_deckslot
+        curr_slot = self.get_slot(location)
+
+        gantry_speed = instrument.default_speed
+        deck_travel_time = self.calc_deck_movement_time(curr_slot, prev_slot, gantry_speed)
+        duration = deck_travel_time + Z_total_time + aspiration_time
+        if after:
+            logger.info(f"{instrument.name} aspirate from {slot}, the duration is {duration}")
+            return duration
+
+    def on_dispense(
+            self,
+            payload,
+            after: bool) -> float:
+        ## General code for aspiration/dispense
+        duration = 0
+        instrument = payload['instrument']
+        volume = payload['volume']
+        rate = payload['rate'] * instrument.flow_rate.dispense
+        dispense_time = volume / rate
+
+        # define variables
+
+        location = payload['location']
+        slot = self.get_slot(location)
+        slot_module = location.labware.parent.parent.is_module
+
+        gantry_speed = instrument.default_speed
+        if slot_module == True:
+            slot_module = 1
+        else:
+            slot_module = 0
+        Z_total_time = self.Z_time(slot_module, gantry_speed)
+        ## We are going to once again use our "deck movement" set up. This should be in pickup, drop tip, aspirate, dispense
+        location = payload['location']
+        prev_slot = self._last_deckslot
+        curr_slot = self.get_slot(location)
+
+        gantry_speed = instrument.default_speed
+        deck_travel_time = self.calc_deck_movement_time(curr_slot, prev_slot, gantry_speed)
+
+        duration = deck_travel_time + Z_total_time + dispense_time
+
+        if after:
+            logger.info(f"{instrument.name} dispensed from {slot}, the duration is {duration}")
+            return duration
+
+    # self.on_blow_out(payload=payload, after=after)
+
+    def on_blow_out(
+            self,
+            payload,
+            after: bool) -> float:
+        location = payload['location']
+        duration = 0
+        prev_slot = self._last_deckslot
+        curr_slot = self.get_slot(location)
+        duration = 0.5
+        if after:
+            ## Note will need to multiply minutes by 60
+            logger.info(f"blowing_out_for {duration} seconds, in slot {curr_slot}")
+
+            return duration
+
+    # self.on_touch_tip(payload=payload, after=after)
+    def on_touch_tip(
+            self,
+            payload,
+            after: bool) -> float:
+        '''
+        location = payload['location']
+        duration = 0
+        prev_slot = self._last_deckslot
+        curr_slot = self.get_slot(location)
+        duration = 0.5
+        '''
+        ## base assumption
+        duration = 0.5
+        if after:
+            ## Note will need to multiply minutes by 60
+            logger.info(f"touch_tip for {duration} seconds")
+
+            return duration
+
+    def on_delay(
+            self,
+            payload,
+            after: bool) -> float:
+        ## Specialist Code: This is code that doesn't fit pickup, drop_tip, aspirate, and dispense
+        # Explanation: we are gathering seconds and minutes here
+        duration = 0
+        seconds_delay = payload['seconds']
+        minutes_delay = payload['minutes']
+        duration = seconds_delay + minutes_delay * 60
+        if after:
+            ## Note will need to multiply minutes by 60
+            logger.info(f"delay for {seconds_delay} seconds and {minutes_delay} minutes")
+
+            return duration
+
+    def on_thermocyler_block_temp(
+            self,
+            payload,
+            after: bool) -> float:
+        # How long this took
+        duration = 0
+
+        temperature = payload['temperature']
+        hold_time = payload['hold_time']
+        temp0 = self._last_thermocyler_module_temperature
+        temp1 = temperature
+        temperature_changing_time = self.thermocyler_handler(temp0, temp1)
+        if hold_time is None:
+            hold_time = 0
+        else:
+            hold_time = float(hold_time)
+
+        duration = temperature_changing_time + hold_time
+        if after:
+            ## Note will need to multiply minutes by 60
+            logger.info(f"hold for {hold_time} seconds and set temp for {temperature} C total duration {duration}")
+
+            return duration
+
+    def on_execute_profile(
+            self,
+            payload,
+            after: bool) -> float:
+        # How long this took
+        duration = 0
+
+        ## This is a bit copy and paste needs to be beautified
+
+        profile_total_steps = payload['steps']
+        thermocyler_temperatures = [self._last_thermocyler_module_temperature]
+        thermocyler_hold_times = []
+        cycle_count = float(payload['text'].split(' ')[2])
+
+        ''' 
+        We are going to need to treat this theromcyler part a bit differently for a bit and just send out total times
+        '''
+        for step in profile_total_steps:
+            thermocyler_temperatures.append(float(step['temperature']))
+            thermocyler_hold_times.append(float(step['hold_time_seconds']))
+        ## Initializing variable
+        total_hold_time = 0
+        total_hold_time = float(cycle_count) * float(sum(thermocyler_hold_times))
+        # This takes care of the cumulative hold time
+        #### WE DON't Have a way to deal with this currently in the way we have things set up.
+        cycling = 0
+        cycling_counter = []
+        thermocyler_temperatures.pop(0)
+        for thermocyler_counter in range(0, len(thermocyler_temperatures)):
+            # cycling_counter.append(thermocyler_handler(float(temp_update_thermocyler[thermocyler_counter-1]), float(temp_update_thermocyler[thermocyler_counter])))
+            cycling_counter.append(self.thermocyler_handler(float(thermocyler_temperatures[thermocyler_counter - 1]),
+                                                  float(thermocyler_temperatures[thermocyler_counter])))
+
+        ## Sum hold time and cycling temp time
+        duration = sum(cycling_counter) + total_hold_time
+        self._last_thermocyler_module_temperature = float(thermocyler_temperatures[-1])
+
+        cycling_counter = []
+        if after:
+            ## Note will need to multiply minutes by 60
+            logger.info(f"\ temperatures {sum(cycling_counter)}, hold_times {total_hold_time} , cycles are {cycle_count}, {duration} boop")
+            return duration
+
+    def on_thermocyler_set_lid_temp(self,
+                                    payload,
+                                    after: bool) -> float:
+        # How long this took
+        duration = 60
+        thermoaction = 'set lid temperature'
+        if after:
+            logger.info(f"\ thermocation =  {thermoaction}")
+            return duration
+
+    def on_thermocyler_lid_close(self,
+                                 payload,
+                                 after: bool) -> float:
+        # How long this took
+        duration = 24
+        thermoaction = 'closing'
+        if after:
+            logger.info(f"\ thermocation =  {thermoaction}")
+
+            return duration
+
+    def on_thermocyler_lid_open(self,
+                                payload,
+                                after: bool) -> float:
+        # How long this took
+        duration = 24
+        thermoaction = 'opening'
+        if after:
+            logger.info(f"\ thermocation =  {thermoaction}")
+
+            return duration
+
+    def on_thermocyler_deactivate_lid(self,
+                                      payload,
+                                      after: bool) -> float:
+        # How long this took
+        duration = 23
+        thermoaction = 'Deactivating'
+        if after:
+            logger.info(f"\ thermocation =  {thermoaction}")
+
+            return duration
+
+    def on_tempdeck_set_temp(self,
+                             payload,
+                             after: bool) -> float:
+        duration = 0.0
+        temperature_tempdeck = payload['celsius']
+        temp0 = self._last_temperature_module_temperature
+        temp1 = float(temperature_tempdeck)
+        duration = self.temperature_module(temp0, temp1)
+        self._last_temperature_module_temperature = temp0
+        if after:
+            logger.info(f"tempdeck {duration} ")
+            return duration
+
+
+    def thermocyler_handler(self, temp0, temp1):
+        total = []
+        if temp1 - temp0 > 0:
+            # heating up!
+            if temp1 > 70:
+                # the temp1 part that's over 70 is
+                total.append(abs(temp1 - 70) / (2))
+                # the temp1 part that's under 70 is:
+                total.append(abs(70 - temp0) / 4)
+            else:
+                total.append(abs(temp1 - temp0) / 4)
+        ## This is where the error is. if it's 10 and 94 this would not
+        ## @Matt please look into this
+        elif temp1 - temp0 < 0:
+            if temp1 >= 70:
+                total.append(abs(temp1 - temp0) / 2)
+
+            else:
+                if temp1 >= 23:
+                    total.append(abs(temp1 - temp0) / 1)
+
+
+                else:
+                    # 70 to 23 2 C/s
+                    total.append(abs(temp0 - 23) / 0.5)
+                    # 23 to temp1 0.1 C/s
+                    total.append(abs(temp1 - 23) / 0.1)
+
+        return sum(total)
+
+    def temperature_module(self, temp0, temp1: float) -> float:
+        timing_gather = []
+        if temp1 == temp0:
+            timing_gather.append(0)
+        if temp1 > 37:
+            timing_gather.append(sum(self.rate_high(temp0, temp1)))
+        if temp1 >= 25 and temp1 <= 37:
+            timing_gather.append(sum(self.rate_mid(temp0, temp1)))
+        if temp1 < 25:
+            timing_gather.append(sum(self.rate_low(temp0, temp1)))
+        return sum(timing_gather)
+
+    def on_tempdeck_deactivate(self,
+                               payload,
+                               after: bool) -> float:
+        duration = 0.0
+        if after:
+            logger.info(f"tempdeck deactivating")
+            return duration
+
+    def on_tempdeck_await_temp(self,
+                               payload,
+                               after: bool) -> float:
+        duration = 0.0
+        if after:
+            logger.info(f"tempdeck awaiting temperature")
+            return duration
+
+    @staticmethod
+    def get_slot(location) -> Optional[str]:
+        """A utility function to extract the slot number from the location."""
+        if isinstance(location, Location):
+            return location.labware.first_parent()
+        else:
+            return LabwareLike(location).first_parent()
+
+    @staticmethod
+    def calc_deck_movement_time(current_slot, previous_slot, gantry_speed):
+        Y_dist = 88.9
+        X_dist = 133.35
+
+        ## why is
+        Start_point_pip = (2 * X_dist, 3 * Y_dist)
+
+        deck_movement_time = 0
+
+        deck_centers = {'1': (0, 0), '2': (X_dist, 0),
+                        '3': (2 * X_dist, 0), '4': (0, Y_dist),
+                        '5': (X_dist, Y_dist), '6': (2 * X_dist, Y_dist),
+                        '7': (0, 2 * Y_dist), '8': (X_dist, 2 * Y_dist),
+                        '9': (2 * X_dist, 2 * Y_dist), '10': (0, 3 * Y_dist),
+                        '11': (X_dist, 3 * Y_dist), '12': (2 * X_dist, 3 * Y_dist)}
+
+        current_deck_center = deck_centers.get(current_slot)
+
+        if previous_slot == None:
+            init_x_diff = abs((current_deck_center[0]) - (Start_point_pip[0]))
+            init_y_diff = abs((current_deck_center[1]) - (Start_point_pip[1]))
+            init_deck_d = np.sqrt((init_x_diff ** 2) + (init_y_diff ** 2))
+            deck_movement_time = init_deck_d / gantry_speed
+            return deck_movement_time
+        else:
+            previous_deck_center = deck_centers.get(previous_slot)
+            x_difference = abs(current_deck_center[0] - previous_deck_center[0])
+            y_difference = abs(current_deck_center[1] - previous_deck_center[1])
+
+            if x_difference and y_difference == 0:
+                deck_movement_time = 0.5
+            else:
+                deck_distance = np.sqrt((x_difference ** 2) + (y_difference ** 2))
+                deck_movement_time = deck_distance / gantry_speed
+            return deck_movement_time
+
+    @staticmethod
+    def Z_time(piece, gantry_speed):
+        Z_default_labware_height = 177.8
+        Z_default_module_height = 95.25  # 177.8 - 82.55 Where did we get 177.8 from?
+        ## Would it be better to just use https://docs.opentrons.com/v2/new_protocol_api.html#opentrons.protocol_api.labware.Well.top
+        # labware.top() ?
+
+        if piece == 0:
+            Z_time = Z_default_module_height / gantry_speed
+        else:
+            Z_time = Z_default_labware_height / gantry_speed
+
+        return Z_time
+
+    # Static
+    def rate_high(self, temp0, temp1):
+        rate_zero_to_amb = 0.0875
+        rate_ambient_to_37 = 0.2
+        rate_37_to_95 = 0.3611111111
+        low = 25
+        val = []
+        if temp0 >= 37:
+            val.append(abs(temp1 - temp0) / rate_37_to_95)
+        if temp0 > 25 and temp0 <= 37:
+            val.append(abs(temp0 - 37) / (rate_ambient_to_37))
+            val.append(abs(temp1 - 37) / (rate_37_to_95))
+        if temp0 <= 25:
+            # the temp1 part that's under 25 is:
+            val.append(abs(25 - temp0) / rate_zero_to_amb)
+            val.append(abs(25 - temp1) / rate_37_to_95)
+
+        return val
+
+    # Static
+    def rate_mid(self, temp0, temp1):
+        rate_zero_to_amb = 0.0875
+        rate_37_to_95 = 0.3611111111
+        val = []
+        rate_ambient_to_37 = (37 - 25) / 60
+        if temp0 >= 25 and temp0 <= 37:
+            val.append(abs(temp1 - temp0) / rate_ambient_to_37)
+
+        if temp0 < 25:
+            # the temp1 part that's over 25 is
+            val.append(abs(temp1 - 25) / rate_ambient_to_37)
+            # the temp0 part that's under 25 is:
+            val.append(abs(25 - temp0) / rate_zero_to_amb)
+        if temp0 > 37:
+            val.append(abs(temp0 - 37) / rate_37_to_95)
+            # the temp1 part that's under 25 is:
+            val.append(abs(37 - temp1) / rate_zero_to_amb)
+        return val
+
+    # Static
+    def rate_low(self, temp0, temp1):
+        rate_zero_to_amb = 0.0875
+        rate_ambient_to_37 = 0.2
+        rate_37_to_95 = 0.3611111111
+        val = []
+        if temp0 <= 25:
+            val.append(abs(temp1 - temp0) / rate_zero_to_amb)
+        if temp0 > 25 and temp0 <= 37:
+            # the temp0 part that's over 25 is
+            val.append(abs(temp0 - 25) / (rate_ambient_to_37))
+            # the temp1 part that's under 25 is:
+            val.append(abs(25 - temp1) / rate_zero_to_amb)
+        if temp0 > 37:
+            val.append(abs(temp0 - 37) / (rate_ambient_to_37))
+            # the temp1 part that's under 25 is:
+            val.append(abs(37 - temp1) / rate_zero_to_amb)
+        return val

--- a/api/src/opentrons/protocols/duration/estimator.py
+++ b/api/src/opentrons/protocols/duration/estimator.py
@@ -1,15 +1,23 @@
 import logging
 from typing import Optional, List
+from typing_extensions import Final
 
-import numpy as np
-import math
+import numpy as np  # type: ignore
 import functools
 
 from dataclasses import dataclass
 
 from opentrons.commands import types
 from opentrons.protocols.api_support.labware_like import LabwareLike
+from opentrons.protocols.duration.errors import DurationEstimatorException
 from opentrons.types import Location
+
+TEMP_MOD_RATE_HIGH_AND_ABOVE: Final = 0.3611111111
+TEMP_MOD_RATE_LOW_TO_HIGH: Final = 0.2
+TEMP_MOD_RATE_ZERO_TO_LOW: Final = 0.0875
+TEMP_MOD_LOW_THRESH: Final = 25.0
+TEMP_MOD_HIGH_THRESH: Final = 37.0
+START_MODULE_TEMPERATURE: Final = 25.0
 
 logger = logging.getLogger(__name__)
 
@@ -21,15 +29,16 @@ class TimerEntry:
 
 
 class DurationEstimator:
+    """
+    Broker listener that calculates the duration of protocol steps.
+    """
     def __init__(self):
         # Which slot the last command was in.
         self._last_deckslot = None
-        self._last_temperature_module_temperature = 25
-        self._last_thermocyler_module_temperature = 25
+        self._last_temperature_module_temperature = START_MODULE_TEMPERATURE
+        self._last_thermocyler_module_temperature = START_MODULE_TEMPERATURE
         # Per step time estimate.
         self._increments: List[TimerEntry] = []
-        ## New
-        self._labware_locations = []
 
     def get_total_duration(self) -> float:
         """Return the total duration"""
@@ -40,280 +49,253 @@ class DurationEstimator:
         )
 
     def on_message(self, message: types.CommandMessage) -> None:
-        # logging.info(f"Got new message: {message}")
+        """
+        Message handler for Broker events.
 
-        # The shape of CommandMessage and the message types are defined in this file:
-        #     opentrons/api/src/opentrons/commands/types.py
-        # It's not easy to decipher :)
+        Args:
+            message: A protocol message
+
+        Returns:
+            None
+        """
+        # Whether this message comes before or after the command is being executed..
+        if message['$'] != 'after':
+            # We only want to process the afters.
+            return
 
         # Extract the message name
         message_name = message['name']
-        # Whether this message comes before or after the command is being executed..
-        after = message['$'] == 'after'
-        # The actual payload of the command that varies by message. This should be
-        # familiar from your script.
+        # The actual payload of the command that varies by message.
         payload = message['payload']
-        duration = 0.0
 
-        location = payload.get('location')
-
-        ## This helps us handle previous deck slots with lists instead of OOP.
-        ## Before we were having issues because there are two instances in each deck slot movement, before and after
-        ## Before would have the right value and after would have the self._last_deckslot equal to the self.get_slot(location)
-        ## As that sentence implies, this means that the code said the prev_slot was always equalt to the current slot
-        # (which were both equal to self.get_slot(location).
-        ## Alex Copperman made this
-
-        # makes sure there is one set of information
-
-        # First step is to pick_up_tips
-        if message_name == types.PICK_UP_TIP:
-            duration = self.on_pick_up_tip(payload=payload, after=after)
-        elif message_name == types.DROP_TIP:
-            duration = self.on_drop_tip(payload=payload, after=after)
-        # second step is to aspirate
-        elif message_name == types.ASPIRATE:
-            duration = self.on_aspirate(payload=payload, after=after)
-        elif message_name == types.DISPENSE:
-            duration = self.on_dispense(payload=payload, after=after)
-
-        ## I think we should add touch_tip and air gap because airgap isn't covered the same way
-        elif message_name == types.BLOW_OUT:
-            duration = self.on_blow_out(payload=payload, after=after)
-        elif message_name == types.TOUCH_TIP:
-            duration = self.on_touch_tip(payload=payload, after=after)
-        elif message_name == types.DELAY:
-            duration = self.on_delay(payload=payload, after=after)
-        elif message_name == types.TEMPDECK_SET_TEMP:
-            duration = self.on_tempdeck_set_temp(payload=payload, after=after)
-        elif message_name == types.TEMPDECK_DEACTIVATE:
-            duration = self.on_tempdeck_deactivate(payload=payload, after=after)
-        elif message_name == types.TEMPDECK_AWAIT_TEMP:
-            duration = self.on_tempdeck_await_temp(payload=payload, after=after)
-        elif message_name == types.THERMOCYCLER_SET_BLOCK_TEMP:
-            duration = self.on_thermocyler_block_temp(payload=payload, after=after)
-        elif message_name == types.THERMOCYCLER_EXECUTE_PROFILE:
-            duration = self.on_execute_profile(payload=payload, after=after)
-        elif message_name == types.THERMOCYCLER_SET_LID_TEMP:
-            duration = self.on_thermocyler_set_lid_temp(payload=payload, after=after)
-        elif message_name == types.THERMOCYCLER_CLOSE:
-            duration = self.on_thermocyler_lid_close(payload=payload, after=after)
-        elif message_name == types.THERMOCYCLER_DEACTIVATE_LID:
-            duration = self.on_thermocyler_deactivate_lid(payload=payload, after=after)
-        elif message_name == types.THERMOCYCLER_OPEN:
-            duration = self.on_thermocyler_lid_open(payload=payload, after=after)
-
-        if after:
-            self._last_deckslot = self.get_slot(location)
-            self._increments.append(
-                TimerEntry(
-                    command=message,
-                    duration=duration,
-                )
+        # We cannot handle paired pipette messages
+        if 'instruments' in payload or 'locations' in payload:
+            logger.warning(
+                f"Paired pipettes are not supported by the duration estimator. "
+                f"Command '{payload['text']}' cannot be estimated properly."
             )
+            return
 
-        # add result to results.
+        location = payload.get('location')  # type: ignore
 
+        try:
+            duration = self.handle_message(message_name, payload)
+        except Exception as e:
+            raise DurationEstimatorException(str(e))
 
-        # store last deckslot
+        if location:
+            self._last_deckslot = self.get_slot(location)
 
-        # self._last_deckslot = self.get_slot(location)
-        ## We need exception handling for location == None otherwise it won't work
+        self._increments.append(
+            TimerEntry(
+                command=message,
+                duration=duration,
+            )
+        )
 
-    ## command.THERMOCYCLER_SET_LID_TEMP
-    ## command.THERMOCYCLER_CLOSE
-    ## command.THERMOCYCLER_DEACTIVATE_LID
+    def handle_message(  # noqa: C901
+            self, message_name: str, payload: types.CommandPayload
+    ) -> float:
+        """
+        Handle the message payload
+
+        Args:
+            message_name: Name of message
+            payload: The command payload
+
+        Returns:
+            The duration in seconds
+        """
+        duration = 0.0
+        if message_name == types.PICK_UP_TIP:
+            duration = self.on_pick_up_tip(payload=payload)
+        elif message_name == types.DROP_TIP:
+            duration = self.on_drop_tip(payload=payload)
+        elif message_name == types.ASPIRATE:
+            duration = self.on_aspirate(payload=payload)
+        elif message_name == types.DISPENSE:
+            duration = self.on_dispense(payload=payload)
+        elif message_name == types.BLOW_OUT:
+            duration = self.on_blow_out(payload=payload)
+        elif message_name == types.TOUCH_TIP:
+            duration = self.on_touch_tip(payload=payload)
+        elif message_name == types.DELAY:
+            duration = self.on_delay(payload=payload)
+        elif message_name == types.TEMPDECK_SET_TEMP:
+            duration = self.on_tempdeck_set_temp(payload=payload)
+        elif message_name == types.TEMPDECK_DEACTIVATE:
+            duration = self.on_tempdeck_deactivate(payload=payload)
+        elif message_name == types.TEMPDECK_AWAIT_TEMP:
+            duration = self.on_tempdeck_await_temp(payload=payload)
+        elif message_name == types.THERMOCYCLER_SET_BLOCK_TEMP:
+            duration = self.on_thermocyler_block_temp(payload=payload)
+        elif message_name == types.THERMOCYCLER_EXECUTE_PROFILE:
+            duration = self.on_execute_profile(payload=payload)
+        elif message_name == types.THERMOCYCLER_SET_LID_TEMP:
+            duration = self.on_thermocyler_set_lid_temp(payload=payload)
+        elif message_name == types.THERMOCYCLER_CLOSE:
+            duration = self.on_thermocyler_lid_close(payload=payload)
+        elif message_name == types.THERMOCYCLER_DEACTIVATE_LID:
+            duration = self.on_thermocyler_deactivate_lid(payload=payload)
+        elif message_name == types.THERMOCYCLER_OPEN:
+            duration = self.on_thermocyler_lid_open(payload=payload)
+        return duration
 
     def on_pick_up_tip(
             self,
-            payload,
-            after: bool) -> float:
-
-        # The instrument is opentrons/api/src/opentrons/protocol_api/instrument_context.py
+            payload) -> float:
+        """Handle a pick up tip event"""
         instrument = payload['instrument']
 
-        # The location is either a Well or a Labware: see opentrons/api/src/opentrons/protocol_api/labware.py
         location = payload['location']
         prev_slot = self._last_deckslot
         curr_slot = self.get_slot(location)
 
         gantry_speed = instrument.default_speed
 
-        deck_travel_time = self.calc_deck_movement_time(curr_slot, prev_slot, gantry_speed)
+        deck_travel_time = self.calc_deck_movement_time(
+            curr_slot, prev_slot, gantry_speed
+        )
 
         duration = deck_travel_time + 4
 
-        if after:
-            logger.info(f"{instrument.name} picked up tip from slot {curr_slot} the duration is {duration}")
-            return duration
-
-        # return duration
+        logger.info(f"{instrument.name} picked up tip from slot "
+                    f"{curr_slot} the duration is {duration}")
+        return duration
 
     def on_drop_tip(
             self,
-            payload,
-            after: bool) -> float:
-        # How long this took
-        duration = 0
-        # The instrument is opentrons/api/src/opentrons/protocol_api/instrument_context.py
+            payload) -> float:
         instrument = payload['instrument']
-        # The location is either a Well or a Labware: see opentrons/api/src/opentrons/protocol_api/labware.py
-        location = payload['location']
-        # Use the utility to get the  slot
-        ## We are going to once again use our "deck movement" set up. This should be in pickup, drop tip, aspirate, dispense
+        # We are going to once again use our "deck movement" set up. This should
+        # be in pickup, drop tip, aspirate, dispense
         location = payload['location']
         curr_slot = self.get_slot(location)
-        ## this one disagrees with me.
+        # this one disagrees with me.
         prev_slot = self._last_deckslot
         gantry_speed = instrument.default_speed
-        deck_travel_time = self.calc_deck_movement_time(curr_slot, prev_slot, gantry_speed)
-        ## Should we be checking for drop tip home_after = False?
-        ## we need to add default 10 second drop tip time
+        deck_travel_time = self.calc_deck_movement_time(
+            curr_slot, prev_slot, gantry_speed
+        )
+        # Should we be checking for drop tip home_after = False?
+        # we need to add default 10 second drop tip time
         duration = deck_travel_time + 10
         # let's only log the message after the pick up tip is done.
 
-        if after:
-            logger.info(f"{instrument.name}, drop tip duration is {duration}")
-            return duration
-
-        # return duration
+        logger.info(f"{instrument.name}, drop tip duration is {duration}")
+        return duration
 
     def on_aspirate(
             self,
-            payload,
-            after: bool) -> float:
-        # How long this took
-        duration = 0
-        ## General aspiration code
+            payload) -> float:
+        # General aspiration code
         instrument = payload['instrument']
         volume = payload['volume']
         rate = payload['rate'] * instrument.flow_rate.aspirate
 
         aspiration_time = volume / rate
 
-        # okay lets add that in to duration.
-
         # now lets handle the aspiration z-axis code.
         location = payload['location']
         slot = self.get_slot(location)
-        slot_module = location.labware.parent.parent.is_module
-        slot_module = 0
+        slot_module = 1 if location.labware.parent.parent.is_module else 0
         gantry_speed = instrument.default_speed
-        if slot_module == True:
-            slot_module = 1
-        else:
-            slot_module = 0
-        Z_total_time = self.Z_time(slot_module, gantry_speed)
+        z_total_time = self.z_time(slot_module, gantry_speed)
 
-        ## We are going to once again use our "deck movement" set up. This should be in pickup, drop tip, aspirate, dispense
+        # We are going to once again use our "deck movement" set up. This
+        # should be in pickup, drop tip, aspirate, dispense
         location = payload['location']
         prev_slot = self._last_deckslot
         curr_slot = self.get_slot(location)
 
         gantry_speed = instrument.default_speed
-        deck_travel_time = self.calc_deck_movement_time(curr_slot, prev_slot, gantry_speed)
-        duration = deck_travel_time + Z_total_time + aspiration_time
-        if after:
-            logger.info(f"{instrument.name} aspirate from {slot}, the duration is {duration}")
-            return duration
+        deck_travel_time = self.calc_deck_movement_time(
+            curr_slot, prev_slot, gantry_speed
+        )
+        duration = deck_travel_time + z_total_time + aspiration_time
+        logger.info(f"{instrument.name} aspirate from {slot}, "
+                    f"the duration is {duration}")
+        return duration
 
     def on_dispense(
             self,
-            payload,
-            after: bool) -> float:
-        ## General code for aspiration/dispense
-        duration = 0
+            payload) -> float:
+        # General code for aspiration/dispense
         instrument = payload['instrument']
         volume = payload['volume']
         rate = payload['rate'] * instrument.flow_rate.dispense
         dispense_time = volume / rate
 
         # define variables
-
         location = payload['location']
         slot = self.get_slot(location)
-        slot_module = location.labware.parent.parent.is_module
-
+        slot_module = 1 if location.labware.parent.parent.is_module else 0
         gantry_speed = instrument.default_speed
-        if slot_module == True:
-            slot_module = 1
-        else:
-            slot_module = 0
-        Z_total_time = self.Z_time(slot_module, gantry_speed)
-        ## We are going to once again use our "deck movement" set up. This should be in pickup, drop tip, aspirate, dispense
+
+        z_total_time = self.z_time(slot_module, gantry_speed)
+        # We are going to once again use our "deck movement" set up.
+        # This should be in pickup, drop tip, aspirate, dispense
         location = payload['location']
         prev_slot = self._last_deckslot
         curr_slot = self.get_slot(location)
 
         gantry_speed = instrument.default_speed
-        deck_travel_time = self.calc_deck_movement_time(curr_slot, prev_slot, gantry_speed)
+        deck_travel_time = self.calc_deck_movement_time(
+            curr_slot, prev_slot, gantry_speed
+        )
 
-        duration = deck_travel_time + Z_total_time + dispense_time
+        duration = deck_travel_time + z_total_time + dispense_time
 
-        if after:
-            logger.info(f"{instrument.name} dispensed from {slot}, the duration is {duration}")
-            return duration
-
-    # self.on_blow_out(payload=payload, after=after)
+        logger.info(
+            f"{instrument.name} dispensed from {slot}, the duration is {duration}"
+        )
+        return duration
 
     def on_blow_out(
             self,
-            payload,
-            after: bool) -> float:
+            payload) -> float:
         location = payload['location']
-        duration = 0
-        prev_slot = self._last_deckslot
         curr_slot = self.get_slot(location)
         duration = 0.5
-        if after:
-            ## Note will need to multiply minutes by 60
-            logger.info(f"blowing_out_for {duration} seconds, in slot {curr_slot}")
+        # Note will need to multiply minutes by 60
+        logger.info(f"blowing_out_for {duration} seconds, in slot {curr_slot}")
 
-            return duration
+        return duration
 
-    # self.on_touch_tip(payload=payload, after=after)
     def on_touch_tip(
             self,
-            payload,
-            after: bool) -> float:
-        '''
+            payload) -> float:
+        """
         location = payload['location']
         duration = 0
         prev_slot = self._last_deckslot
         curr_slot = self.get_slot(location)
         duration = 0.5
-        '''
-        ## base assumption
+        """
+        # base assumption
         duration = 0.5
-        if after:
-            ## Note will need to multiply minutes by 60
-            logger.info(f"touch_tip for {duration} seconds")
+        # Note will need to multiply minutes by 60
+        logger.info(f"touch_tip for {duration} seconds")
 
-            return duration
+        return duration
 
     def on_delay(
             self,
-            payload,
-            after: bool) -> float:
-        ## Specialist Code: This is code that doesn't fit pickup, drop_tip, aspirate, and dispense
+            payload) -> float:
+        # Specialist Code: This is code that doesn't fit pickup, drop_tip,
+        # aspirate, and dispense
         # Explanation: we are gathering seconds and minutes here
-        duration = 0
         seconds_delay = payload['seconds']
         minutes_delay = payload['minutes']
         duration = seconds_delay + minutes_delay * 60
-        if after:
-            ## Note will need to multiply minutes by 60
-            logger.info(f"delay for {seconds_delay} seconds and {minutes_delay} minutes")
+        # Note will need to multiply minutes by 60
+        logger.info(f"delay for {seconds_delay} seconds and {minutes_delay} minutes")
 
-            return duration
+        return duration
 
     def on_thermocyler_block_temp(
             self,
-            payload,
-            after: bool) -> float:
-        # How long this took
-        duration = 0
-
+            payload) -> float:
         temperature = payload['temperature']
         hold_time = payload['hold_time']
         temp0 = self._last_thermocyler_module_temperature
@@ -325,111 +307,97 @@ class DurationEstimator:
             hold_time = float(hold_time)
 
         duration = temperature_changing_time + hold_time
-        if after:
-            ## Note will need to multiply minutes by 60
-            logger.info(f"hold for {hold_time} seconds and set temp for {temperature} C total duration {duration}")
+        # Note will need to multiply minutes by 60
+        logger.info(f"hold for {hold_time} seconds and set temp for {temperature}"
+                    f" C total duration {duration}")
 
-            return duration
+        return duration
 
     def on_execute_profile(
             self,
-            payload,
-            after: bool) -> float:
-        # How long this took
-        duration = 0
-
-        ## This is a bit copy and paste needs to be beautified
+            payload) -> float:
+        # This is a bit copy and paste needs to be beautified
 
         profile_total_steps = payload['steps']
-        thermocyler_temperatures = [self._last_thermocyler_module_temperature]
+        thermocyler_temperatures = [float(self._last_thermocyler_module_temperature)]
         thermocyler_hold_times = []
         cycle_count = float(payload['text'].split(' ')[2])
 
-        ''' 
-        We are going to need to treat this theromcyler part a bit differently for a bit and just send out total times
-        '''
+        # We are going to need to treat this theromcyler part a bit differently
+        # for a bit and just send out total times
         for step in profile_total_steps:
             thermocyler_temperatures.append(float(step['temperature']))
             thermocyler_hold_times.append(float(step['hold_time_seconds']))
-        ## Initializing variable
-        total_hold_time = 0
+        # Initializing variable
         total_hold_time = float(cycle_count) * float(sum(thermocyler_hold_times))
         # This takes care of the cumulative hold time
-        #### WE DON't Have a way to deal with this currently in the way we have things set up.
-        cycling = 0
+        # WE DON't Have a way to deal with this currently in the way we
+        # have things set up.
         cycling_counter = []
         thermocyler_temperatures.pop(0)
         for thermocyler_counter in range(0, len(thermocyler_temperatures)):
-            # cycling_counter.append(thermocyler_handler(float(temp_update_thermocyler[thermocyler_counter-1]), float(temp_update_thermocyler[thermocyler_counter])))
-            cycling_counter.append(self.thermocyler_handler(float(thermocyler_temperatures[thermocyler_counter - 1]),
-                                                  float(thermocyler_temperatures[thermocyler_counter])))
+            cycling_counter.append(
+                self.thermocyler_handler(
+                    float(thermocyler_temperatures[thermocyler_counter - 1]),
+                    float(thermocyler_temperatures[thermocyler_counter])
+                )
+            )
 
-        ## Sum hold time and cycling temp time
-        duration = sum(cycling_counter) + total_hold_time
-        self._last_thermocyler_module_temperature = float(thermocyler_temperatures[-1])
+        # Sum hold time and cycling temp time
+        duration = float(sum(cycling_counter) + total_hold_time)
+        self._last_thermocyler_module_temperature = thermocyler_temperatures[-1]
 
         cycling_counter = []
-        if after:
-            ## Note will need to multiply minutes by 60
-            logger.info(f"\ temperatures {sum(cycling_counter)}, hold_times {total_hold_time} , cycles are {cycle_count}, {duration} boop")
-            return duration
+        # Note will need to multiply minutes by 60
+        logger.info(f"temperatures {sum(cycling_counter)}, "
+                    f"hold_times {total_hold_time} , cycles are {cycle_count}, "
+                    f"{duration} boop")
+        return duration
 
     def on_thermocyler_set_lid_temp(self,
-                                    payload,
-                                    after: bool) -> float:
+                                    payload) -> float:
         # How long this took
         duration = 60
         thermoaction = 'set lid temperature'
-        if after:
-            logger.info(f"\ thermocation =  {thermoaction}")
-            return duration
+        logger.info(f"thermocation =  {thermoaction}")
+        return duration
 
     def on_thermocyler_lid_close(self,
-                                 payload,
-                                 after: bool) -> float:
+                                 payload) -> float:
         # How long this took
         duration = 24
         thermoaction = 'closing'
-        if after:
-            logger.info(f"\ thermocation =  {thermoaction}")
+        logger.info(f"thermocation =  {thermoaction}")
 
-            return duration
+        return duration
 
     def on_thermocyler_lid_open(self,
-                                payload,
-                                after: bool) -> float:
+                                payload) -> float:
         # How long this took
         duration = 24
         thermoaction = 'opening'
-        if after:
-            logger.info(f"\ thermocation =  {thermoaction}")
+        logger.info(f"thermocation =  {thermoaction}")
 
-            return duration
+        return duration
 
     def on_thermocyler_deactivate_lid(self,
-                                      payload,
-                                      after: bool) -> float:
+                                      payload) -> float:
         # How long this took
         duration = 23
         thermoaction = 'Deactivating'
-        if after:
-            logger.info(f"\ thermocation =  {thermoaction}")
+        logger.info(f"thermocation =  {thermoaction}")
 
-            return duration
+        return duration
 
     def on_tempdeck_set_temp(self,
-                             payload,
-                             after: bool) -> float:
-        duration = 0.0
+                             payload) -> float:
         temperature_tempdeck = payload['celsius']
         temp0 = self._last_temperature_module_temperature
         temp1 = float(temperature_tempdeck)
         duration = self.temperature_module(temp0, temp1)
         self._last_temperature_module_temperature = temp0
-        if after:
-            logger.info(f"tempdeck {duration} ")
-            return duration
-
+        logger.info(f"tempdeck {duration} ")
+        return duration
 
     def thermocyler_handler(self, temp0, temp1):
         total = []
@@ -437,13 +405,13 @@ class DurationEstimator:
             # heating up!
             if temp1 > 70:
                 # the temp1 part that's over 70 is
-                total.append(abs(temp1 - 70) / (2))
+                total.append(abs(temp1 - 70) / 2)
                 # the temp1 part that's under 70 is:
                 total.append(abs(70 - temp0) / 4)
             else:
                 total.append(abs(temp1 - temp0) / 4)
-        ## This is where the error is. if it's 10 and 94 this would not
-        ## @Matt please look into this
+        # This is where the error is. if it's 10 and 94 this would not
+        # @Matt please look into this
         elif temp1 - temp0 < 0:
             if temp1 >= 70:
                 total.append(abs(temp1 - temp0) / 2)
@@ -451,8 +419,6 @@ class DurationEstimator:
             else:
                 if temp1 >= 23:
                     total.append(abs(temp1 - temp0) / 1)
-
-
                 else:
                     # 70 to 23 2 C/s
                     total.append(abs(temp0 - 23) / 0.5)
@@ -465,29 +431,25 @@ class DurationEstimator:
         timing_gather = []
         if temp1 == temp0:
             timing_gather.append(0)
-        if temp1 > 37:
+        if temp1 > TEMP_MOD_HIGH_THRESH:
             timing_gather.append(sum(self.rate_high(temp0, temp1)))
-        if temp1 >= 25 and temp1 <= 37:
+        if TEMP_MOD_LOW_THRESH <= temp1 <= TEMP_MOD_HIGH_THRESH:
             timing_gather.append(sum(self.rate_mid(temp0, temp1)))
-        if temp1 < 25:
+        if temp1 < TEMP_MOD_LOW_THRESH:
             timing_gather.append(sum(self.rate_low(temp0, temp1)))
         return sum(timing_gather)
 
     def on_tempdeck_deactivate(self,
-                               payload,
-                               after: bool) -> float:
+                               payload) -> float:
         duration = 0.0
-        if after:
-            logger.info(f"tempdeck deactivating")
-            return duration
+        logger.info("tempdeck deactivating")
+        return duration
 
     def on_tempdeck_await_temp(self,
-                               payload,
-                               after: bool) -> float:
+                               payload) -> float:
         duration = 0.0
-        if after:
-            logger.info(f"tempdeck awaiting temperature")
-            return duration
+        logger.info("tempdeck awaiting temperature")
+        return duration
 
     @staticmethod
     def get_slot(location) -> Optional[str]:
@@ -499,31 +461,37 @@ class DurationEstimator:
 
     @staticmethod
     def calc_deck_movement_time(current_slot, previous_slot, gantry_speed):
-        Y_dist = 88.9
-        X_dist = 133.35
+        y_dist = 88.9
+        x_dist = 133.35
 
-        ## why is
-        Start_point_pip = (2 * X_dist, 3 * Y_dist)
+        # why is
+        start_point_pip = (2 * x_dist, 3 * y_dist)
 
-        deck_movement_time = 0
-
-        deck_centers = {'1': (0, 0), '2': (X_dist, 0),
-                        '3': (2 * X_dist, 0), '4': (0, Y_dist),
-                        '5': (X_dist, Y_dist), '6': (2 * X_dist, Y_dist),
-                        '7': (0, 2 * Y_dist), '8': (X_dist, 2 * Y_dist),
-                        '9': (2 * X_dist, 2 * Y_dist), '10': (0, 3 * Y_dist),
-                        '11': (X_dist, 3 * Y_dist), '12': (2 * X_dist, 3 * Y_dist)}
+        deck_centers = {'1': (0, 0), '2': (x_dist, 0),
+                        '3': (2 * x_dist, 0), '4': (0, y_dist),
+                        '5': (x_dist, y_dist), '6': (2 * x_dist, y_dist),
+                        '7': (0, 2 * y_dist), '8': (x_dist, 2 * y_dist),
+                        '9': (2 * x_dist, 2 * y_dist), '10': (0, 3 * y_dist),
+                        '11': (x_dist, 3 * y_dist), '12': (2 * x_dist, 3 * y_dist)}
 
         current_deck_center = deck_centers.get(current_slot)
+        if not current_deck_center:
+            raise DurationEstimatorException(
+                f"Current slot '{current_slot}' is not valid."
+            )
 
-        if previous_slot == None:
-            init_x_diff = abs((current_deck_center[0]) - (Start_point_pip[0]))
-            init_y_diff = abs((current_deck_center[1]) - (Start_point_pip[1]))
+        if previous_slot is None:
+            init_x_diff = abs((current_deck_center[0]) - (start_point_pip[0]))
+            init_y_diff = abs((current_deck_center[1]) - (start_point_pip[1]))
             init_deck_d = np.sqrt((init_x_diff ** 2) + (init_y_diff ** 2))
             deck_movement_time = init_deck_d / gantry_speed
             return deck_movement_time
         else:
             previous_deck_center = deck_centers.get(previous_slot)
+            if not previous_deck_center:
+                raise DurationEstimatorException(
+                    f"Previous slot '{current_slot}' is not valid."
+                )
             x_difference = abs(current_deck_center[0] - previous_deck_center[0])
             y_difference = abs(current_deck_center[1] - previous_deck_center[1])
 
@@ -535,73 +503,64 @@ class DurationEstimator:
             return deck_movement_time
 
     @staticmethod
-    def Z_time(piece, gantry_speed):
-        Z_default_labware_height = 177.8
-        Z_default_module_height = 95.25  # 177.8 - 82.55 Where did we get 177.8 from?
-        ## Would it be better to just use https://docs.opentrons.com/v2/new_protocol_api.html#opentrons.protocol_api.labware.Well.top
+    def z_time(piece, gantry_speed):
+        z_default_labware_height = 177.8
+        z_default_module_height = 95.25  # 177.8 - 82.55 Where did we get 177.8 from?
+        # Would it be better to just use
+        # https://docs.opentrons.com/v2/new_protocol_api.html#opentrons.protocol_api.labware.Well.top  # noqa: E501
         # labware.top() ?
 
         if piece == 0:
-            Z_time = Z_default_module_height / gantry_speed
+            z_time = z_default_module_height / gantry_speed
         else:
-            Z_time = Z_default_labware_height / gantry_speed
+            z_time = z_default_labware_height / gantry_speed
 
-        return Z_time
+        return z_time
 
-    # Static
-    def rate_high(self, temp0, temp1):
-        rate_zero_to_amb = 0.0875
-        rate_ambient_to_37 = 0.2
-        rate_37_to_95 = 0.3611111111
-        low = 25
+    @staticmethod
+    def rate_high(temp0, temp1):
         val = []
-        if temp0 >= 37:
-            val.append(abs(temp1 - temp0) / rate_37_to_95)
-        if temp0 > 25 and temp0 <= 37:
-            val.append(abs(temp0 - 37) / (rate_ambient_to_37))
-            val.append(abs(temp1 - 37) / (rate_37_to_95))
-        if temp0 <= 25:
-            # the temp1 part that's under 25 is:
-            val.append(abs(25 - temp0) / rate_zero_to_amb)
-            val.append(abs(25 - temp1) / rate_37_to_95)
+        if temp0 >= TEMP_MOD_HIGH_THRESH:
+            val.append(abs(temp1 - temp0) / TEMP_MOD_RATE_HIGH_AND_ABOVE)
+        if TEMP_MOD_LOW_THRESH < temp0 <= TEMP_MOD_HIGH_THRESH:
+            val.append(abs(temp0 - TEMP_MOD_HIGH_THRESH) / TEMP_MOD_RATE_LOW_TO_HIGH)
+            val.append(abs(temp1 - TEMP_MOD_HIGH_THRESH) / TEMP_MOD_RATE_HIGH_AND_ABOVE)
+        if temp0 <= TEMP_MOD_LOW_THRESH:
+            # the temp1 part that's under TEMP_MOD_HIGH_THRESH is:
+            val.append(abs(TEMP_MOD_LOW_THRESH - temp0) / TEMP_MOD_RATE_ZERO_TO_LOW)
+            val.append(abs(TEMP_MOD_LOW_THRESH - temp1) / TEMP_MOD_RATE_HIGH_AND_ABOVE)
 
         return val
 
-    # Static
-    def rate_mid(self, temp0, temp1):
-        rate_zero_to_amb = 0.0875
-        rate_37_to_95 = 0.3611111111
+    @staticmethod
+    def rate_mid(temp0, temp1):
         val = []
-        rate_ambient_to_37 = (37 - 25) / 60
-        if temp0 >= 25 and temp0 <= 37:
-            val.append(abs(temp1 - temp0) / rate_ambient_to_37)
+        if TEMP_MOD_LOW_THRESH <= temp0 <= TEMP_MOD_HIGH_THRESH:
+            val.append(abs(temp1 - temp0) / TEMP_MOD_RATE_LOW_TO_HIGH)
 
-        if temp0 < 25:
-            # the temp1 part that's over 25 is
-            val.append(abs(temp1 - 25) / rate_ambient_to_37)
-            # the temp0 part that's under 25 is:
-            val.append(abs(25 - temp0) / rate_zero_to_amb)
-        if temp0 > 37:
-            val.append(abs(temp0 - 37) / rate_37_to_95)
-            # the temp1 part that's under 25 is:
-            val.append(abs(37 - temp1) / rate_zero_to_amb)
+        if temp0 < TEMP_MOD_LOW_THRESH:
+            # the temp1 part that's over TEMP_MOD_HIGH_THRESH is
+            val.append(abs(temp1 - TEMP_MOD_LOW_THRESH) / TEMP_MOD_RATE_LOW_TO_HIGH)
+            # the temp0 part that's under TEMP_MOD_HIGH_THRESH is:
+            val.append(abs(TEMP_MOD_LOW_THRESH - temp0) / TEMP_MOD_RATE_ZERO_TO_LOW)
+        if temp0 > TEMP_MOD_HIGH_THRESH:
+            val.append(abs(temp0 - TEMP_MOD_HIGH_THRESH) / TEMP_MOD_RATE_HIGH_AND_ABOVE)
+            # the temp1 part that's under TEMP_MOD_HIGH_THRESH is:
+            val.append(abs(TEMP_MOD_HIGH_THRESH - temp1) / TEMP_MOD_RATE_ZERO_TO_LOW)
         return val
 
-    # Static
-    def rate_low(self, temp0, temp1):
-        rate_zero_to_amb = 0.0875
-        rate_ambient_to_37 = 0.2
-        rate_37_to_95 = 0.3611111111
+    @staticmethod
+    def rate_low(temp0, temp1):
         val = []
-        if temp0 <= 25:
-            val.append(abs(temp1 - temp0) / rate_zero_to_amb)
-        if temp0 > 25 and temp0 <= 37:
-            # the temp0 part that's over 25 is
-            val.append(abs(temp0 - 25) / (rate_ambient_to_37))
-            # the temp1 part that's under 25 is:
-            val.append(abs(25 - temp1) / rate_zero_to_amb)
-        if temp0 > 37:
-            val.append(abs(temp0 - 37) / (rate_ambient_to_37))
-            # the temp1 part that's under 25 is:
-            val.append(abs(37 - temp1) / rate_zero_to_amb)
+        if temp0 <= TEMP_MOD_LOW_THRESH:
+            val.append(abs(temp1 - temp0) / TEMP_MOD_RATE_ZERO_TO_LOW)
+        if TEMP_MOD_LOW_THRESH < temp0 <= TEMP_MOD_HIGH_THRESH:
+            # the temp0 part that's over TEMP_MOD_HIGH_THRESH is
+            val.append(abs(temp0 - TEMP_MOD_LOW_THRESH) / TEMP_MOD_RATE_LOW_TO_HIGH)
+            # the temp1 part that's under TEMP_MOD_HIGH_THRESH is:
+            val.append(abs(TEMP_MOD_LOW_THRESH - temp1) / TEMP_MOD_RATE_ZERO_TO_LOW)
+        if temp0 > TEMP_MOD_HIGH_THRESH:
+            val.append(abs(temp0 - TEMP_MOD_HIGH_THRESH) / TEMP_MOD_RATE_LOW_TO_HIGH)
+            # the temp1 part that's under TEMP_MOD_HIGH_THRESH is:
+            val.append(abs(TEMP_MOD_HIGH_THRESH - temp1) / TEMP_MOD_RATE_ZERO_TO_LOW)
         return val

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -247,15 +247,16 @@ def bundle_from_sim(
     )
 
 
-def simulate(protocol_file: TextIO,
-             file_name: str = None,
-             custom_labware_paths: List[str] = None,
-             custom_data_paths: List[str] = None,
-             propagate_logs: bool = False,
-             hardware_simulator_file_path: str = None,
-             duration_estimator: Optional[DurationEstimator] = None,
-             log_level: str = 'warning') -> Tuple[List[Mapping[str, Any]],
-                                                  Optional[BundleContents]]:
+def simulate(
+    protocol_file: TextIO,
+    file_name: str = None,
+    custom_labware_paths: List[str] = None,
+    custom_data_paths: List[str] = None,
+    propagate_logs: bool = False,
+    hardware_simulator_file_path: str = None,
+    duration_estimator: Optional[DurationEstimator] = None,
+    log_level: str = "warning",
+) -> Tuple[List[Mapping[str, Any]], Optional[BundleContents]]:
     """
     Simulate the protocol itself.
 
@@ -357,9 +358,7 @@ def simulate(protocol_file: TextIO,
         extra_labware=gpa_extras,
     )
     broker = context.broker
-    scraper = CommandScraper(stack_logger,
-                             log_level,
-                             broker)
+    scraper = CommandScraper(stack_logger, log_level, broker)
     if duration_estimator:
         broker.subscribe(command_types.COMMAND, duration_estimator.on_message)
 
@@ -514,18 +513,22 @@ def get_arguments(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         parser = _get_bundle_args(parser)
 
     parser.add_argument(
-        '-e', '--estimate-duration', action="store_true",
+        "-e",
+        "--estimate-duration",
+        action="store_true",
         # TODO (AL, 2021-07-26): Better wording.
-        help='Estimate how long the protocol will take to complete.'
-             'This is a beta feature.'
+        help="Estimate how long the protocol will take to complete."
+        "This is a beta feature.",
     )
 
     parser.add_argument(
-        'protocol', metavar='PROTOCOL',
-        type=argparse.FileType('rb'),
-        help='The protocol file to simulate. If you pass \'-\', you can pipe '
-        'the protocol via stdin; this could be useful if you want to use this '
-        'utility as part of an automated workflow.')
+        "protocol",
+        metavar="PROTOCOL",
+        type=argparse.FileType("rb"),
+        help="The protocol file to simulate. If you pass '-', you can pipe "
+        "the protocol via stdin; this could be useful if you want to use this "
+        "utility as part of an automated workflow.",
+    )
     parser.add_argument(
         "-v",
         "--version",
@@ -581,13 +584,12 @@ def main() -> int:
     runlog, maybe_bundle = simulate(
         args.protocol,
         args.protocol.name,
-        getattr(args, 'custom_labware_path', []),
-        getattr(args, 'custom_data_path', [])
-        + getattr(args, 'custom_data_file', []),
+        getattr(args, "custom_labware_path", []),
+        getattr(args, "custom_data_path", []) + getattr(args, "custom_data_file", []),
         duration_estimator=duration_estimator,
-        hardware_simulator_file_path=getattr(args,
-                                             'custom_hardware_simulator_file'),
-        log_level=args.log_level)
+        hardware_simulator_file_path=getattr(args, "custom_hardware_simulator_file"),
+        log_level=args.log_level,
+    )
 
     if maybe_bundle:
         bundle_name = getattr(args, "bundle", None)

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -603,7 +603,13 @@ def main() -> int:
         print(format_runlog(runlog))
 
     if duration_estimator:
-        print("estimate: ", duration_estimator.get_total_duration())
+        duration_seconds = duration_estimator.get_total_duration()
+        hours = int(duration_seconds / 60 / 60)
+        minutes = int((duration_seconds % (60 * 60)) / 60)
+        print("--------------------------------------------------------------")
+        print(f"Estimated protocol duration: {hours}h:{minutes}m")
+        print("--------------------------------------------------------------")
+        print("WARNING: Protocol duration estimation is an experimental feature")
 
     return 0
 

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -519,7 +519,7 @@ def get_arguments(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         action="store_true",
         # TODO (AL, 2021-07-26): Better wording.
         help="Estimate how long the protocol will take to complete."
-        "This is a beta feature.",
+        " This is an experimental feature.",
     )
 
     parser.add_argument(

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -344,40 +344,29 @@ def simulate(
     )
     bundle_contents: Optional[BundleContents] = None
 
-    if getattr(protocol, "api_level", APIVersion(2, 0)) < APIVersion(2, 0):
-
-        def _simulate_v1():
-            opentrons.robot.disconnect()
-            opentrons.robot.reset()
-            scraper = CommandScraper(stack_logger, log_level, opentrons.robot.broker)
-            exec(protocol.contents, {})  # type: ignore
-            return scraper
-
-        scraper = _simulate_v1()
-    else:
-        # we want a None literal rather than empty dict so get_protocol_api
-        # will look for custom labware if this is a robot
-        gpa_extras = getattr(protocol, "extra_labware", None) or None
-        context = get_protocol_api(
-            getattr(protocol, "api_level", MAX_SUPPORTED_VERSION),
-            bundled_labware=getattr(protocol, "bundled_labware", None),
-            bundled_data=getattr(protocol, "bundled_data", None),
-            hardware_simulator=hardware_simulator,
-            extra_labware=gpa_extras,
-        )
-        broker = context.broker
-        scraper = CommandScraper(stack_logger, log_level, broker)
-        try:
-            execute.run_protocol(protocol, context)
-            if (
-                isinstance(protocol, PythonProtocol)
-                and protocol.api_level >= APIVersion(2, 0)
-                and protocol.bundled_labware is None
-                and allow_bundle()
-            ):
-                bundle_contents = bundle_from_sim(protocol, context)
-        finally:
-            context.cleanup()
+    # we want a None literal rather than empty dict so get_protocol_api
+    # will look for custom labware if this is a robot
+    gpa_extras = getattr(protocol, "extra_labware", None) or None
+    context = get_protocol_api(
+        getattr(protocol, "api_level", MAX_SUPPORTED_VERSION),
+        bundled_labware=getattr(protocol, "bundled_labware", None),
+        bundled_data=getattr(protocol, "bundled_data", None),
+        hardware_simulator=hardware_simulator,
+        extra_labware=gpa_extras,
+    )
+    broker = context.broker
+    scraper = CommandScraper(stack_logger, log_level, broker)
+    try:
+        execute.run_protocol(protocol, context)
+        if (
+            isinstance(protocol, PythonProtocol)
+            and protocol.api_level >= APIVersion(2, 0)
+            and protocol.bundled_labware is None
+            and allow_bundle()
+        ):
+            bundle_contents = bundle_from_sim(protocol, context)
+    finally:
+        context.cleanup()
 
     return scraper.commands, bundle_contents
 

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -304,7 +304,8 @@ def simulate(
                               :py:attr:`.ProtocolContext.bundled_data`.
     :param hardware_simulator_file_path: A path to a JSON file defining a
                                          hardware simulator.
-    :param duration_estimator: Optional duration estimator object.
+    :param duration_estimator: For internal use only.
+                               Optional duration estimator object.
     :param propagate_logs: Whether this function should allow logs from the
                            Opentrons stack to propagate up to the root handler.
                            This can be useful if you're integrating this

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -29,6 +29,7 @@ from typing import (
 import opentrons
 from opentrons.hardware_control.simulator_setup import load_simulator
 from opentrons.protocol_api import MAX_SUPPORTED_VERSION
+from opentrons.protocols.duration import DurationEstimator
 from opentrons.protocols.execution import execute
 import opentrons.broker
 from opentrons.config import IS_ROBOT, JUPYTER_NOTEBOOK_LABWARE_DIR
@@ -252,7 +253,7 @@ def simulate(protocol_file: TextIO,
              custom_data_paths: List[str] = None,
              propagate_logs: bool = False,
              hardware_simulator_file_path: str = None,
-             estimate_duration: bool = False,
+             duration_estimator: Optional[DurationEstimator] = None,
              log_level: str = 'warning') -> Tuple[List[Mapping[str, Any]],
                                                   Optional[BundleContents]]:
     """
@@ -302,8 +303,7 @@ def simulate(protocol_file: TextIO,
                               :py:attr:`.ProtocolContext.bundled_data`.
     :param hardware_simulator_file_path: A path to a JSON file defining a
                                          hardware simulator.
-    :param estimate_duration: Whether this function should estimate how long
-                              the protocol will take to run.
+    :param duration_estimator: Optional duration estimator object.
     :param propagate_logs: Whether this function should allow logs from the
                            Opentrons stack to propagate up to the root handler.
                            This can be useful if you're integrating this
@@ -357,7 +357,12 @@ def simulate(protocol_file: TextIO,
         extra_labware=gpa_extras,
     )
     broker = context.broker
-    scraper = CommandScraper(stack_logger, log_level, broker)
+    scraper = CommandScraper(stack_logger,
+                             log_level,
+                             broker)
+    if duration_estimator:
+        broker.subscribe(command_types.COMMAND, duration_estimator.on_message)
+
     try:
         execute.run_protocol(protocol, context)
         if (
@@ -571,13 +576,15 @@ def main() -> int:
     args = parser.parse_args()
     # Try to migrate api v1 containers if needed
 
+    duration_estimator = DurationEstimator() if args.estimate_duration else None
+
     runlog, maybe_bundle = simulate(
         args.protocol,
         args.protocol.name,
         getattr(args, 'custom_labware_path', []),
         getattr(args, 'custom_data_path', [])
         + getattr(args, 'custom_data_file', []),
-        estimate_duration=args.estimate_duration,
+        duration_estimator=duration_estimator,
         hardware_simulator_file_path=getattr(args,
                                              'custom_hardware_simulator_file'),
         log_level=args.log_level)
@@ -594,6 +601,9 @@ def main() -> int:
 
     if args.output == "runlog":
         print(format_runlog(runlog))
+
+    if duration_estimator:
+        print("estimate: ", duration_estimator.get_total_duration())
 
     return 0
 

--- a/api/tests/opentrons/protocols/duration/test_estimator.py
+++ b/api/tests/opentrons/protocols/duration/test_estimator.py
@@ -1,0 +1,195 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from opentrons.commands import types
+from opentrons.protocol_api import InstrumentContext
+from opentrons.protocols.duration.estimator import (
+    DurationEstimator,
+    TEMP_MOD_HIGH_THRESH,
+    TEMP_MOD_RATE_HIGH_AND_ABOVE,
+    TEMP_MOD_LOW_THRESH,
+    TEMP_MOD_RATE_LOW_TO_HIGH,
+    TEMP_MOD_RATE_ZERO_TO_LOW,
+    THERMO_HIGH_THRESH,
+    THERMO_LOW_THRESH,
+)
+
+
+@pytest.fixture
+def subject() -> DurationEstimator:
+    """The test subject."""
+    return DurationEstimator()
+
+
+@pytest.fixture
+def mock_instrument() -> MagicMock:
+    """A mock instrument context."""
+    return MagicMock(spec=InstrumentContext)
+
+
+def test_ignore_before(subject: DurationEstimator):
+    """It should ignore before commands."""
+    message = types.DelayMessage(
+        payload=types.DelayCommandPayload(minutes=1, seconds=1)
+    )
+    message["$"] = "before"
+    message["name"] = "command.DELAY"
+    subject.on_message(message)
+    assert subject.get_total_duration() == 0
+
+
+def test_pick_up_tip(subject: DurationEstimator, mock_instrument: MagicMock):
+    """It should time a pick up tip."""
+    mock_instrument.default_speed = 1
+    # Movement in same slot
+    subject._last_deckslot = "1"
+    message = types.PickUpTipCommand(
+        payload=types.PickUpTipCommandPayload(location="1", instrument=mock_instrument))
+    message["$"] = "after"
+    message["name"] = types.PICK_UP_TIP
+    subject.on_message(message)
+    assert subject.get_total_duration() == 4.5
+
+
+def test_drop_tip(subject: DurationEstimator, mock_instrument: MagicMock):
+    """It should time a drop tip."""
+    mock_instrument.default_speed = 1
+    # Movement in same slot
+    subject._last_deckslot = "1"
+    message = types.DropTipCommand(
+        payload=types.DropTipCommandPayload(location="1", instrument=mock_instrument))
+    message["$"] = "after"
+    message["name"] = types.DROP_TIP
+    subject.on_message(message)
+    assert subject.get_total_duration() == 10.5
+
+
+def test_blow_out(subject: DurationEstimator):
+    """It should time a blowout."""
+    message = types.BlowOutMessage(payload=types.BlowOutCommandPayload(location=None))
+    message["$"] = "after"
+    message["name"] = types.BLOW_OUT
+    subject.on_message(message)
+    assert subject.get_total_duration() == 0.5
+
+
+def test_touch_tip(subject: DurationEstimator):
+    """It should time a touch tip."""
+    message = types.TouchTipMessage(payload=types.TouchTipCommandPayload())
+    message["$"] = "after"
+    message["name"] = types.TOUCH_TIP
+    subject.on_message(message)
+    assert subject.get_total_duration() == 0.5
+
+
+def test_delay(subject: DurationEstimator):
+    """It should time a delay."""
+    message = types.DelayMessage(
+        payload=types.DelayCommandPayload(minutes=1, seconds=1)
+    )
+    message["$"] = "after"
+    message["name"] = types.DELAY
+    subject.on_message(message)
+    assert subject.get_total_duration() == 61
+
+
+@pytest.mark.parametrize(
+    argnames=["current", "target", "expected_duration"],
+    argvalues=[
+        # No change in temperature
+        [1, 1, 0],
+        # To a high temperature from a high temperature
+        [
+            TEMP_MOD_HIGH_THRESH,
+            TEMP_MOD_HIGH_THRESH + 1,
+            1 / TEMP_MOD_RATE_HIGH_AND_ABOVE,
+        ],
+        # To a medium temperature from a medium temperature
+        [
+            TEMP_MOD_LOW_THRESH + 1,
+            TEMP_MOD_HIGH_THRESH - 1,
+            ((TEMP_MOD_HIGH_THRESH - 1) - (TEMP_MOD_LOW_THRESH + 1))
+            / TEMP_MOD_RATE_LOW_TO_HIGH,
+        ],
+        # To a low temperature from a low temperature
+        [
+            TEMP_MOD_LOW_THRESH - 1,
+            TEMP_MOD_LOW_THRESH - 2,
+            1 / TEMP_MOD_RATE_ZERO_TO_LOW,
+        ],
+    ],
+)
+def test_temperature_module(
+    subject: DurationEstimator, current: float, target: float, expected_duration: float
+):
+    """It should compute the duration of a temperature change correctly."""
+    assert subject.temperature_module(current, target) == expected_duration
+
+
+def test_thermocycler_set_lid_temp(subject: DurationEstimator):
+    """It should compute the duration of a set lid temp."""
+    message = types.ThermocyclerSetLidTempCommand(
+        payload=types.ThermocyclerSetLidTempCommandPayload()
+    )
+    message["$"] = "after"
+    message["name"] = types.THERMOCYCLER_SET_LID_TEMP
+    subject.on_message(message)
+    assert subject.get_total_duration() == 60
+
+
+def test_thermocycler_lid_close(subject: DurationEstimator):
+    """It should compute the duration of a lid close."""
+    message = types.ThermocyclerCloseMessage(
+        payload=types.ThermocyclerCloseCommandPayload()
+    )
+    message["$"] = "after"
+    message["name"] = types.THERMOCYCLER_CLOSE
+    subject.on_message(message)
+    assert subject.get_total_duration() == 24
+
+
+def test_thermocycler_lid_open(subject: DurationEstimator):
+    """It should compute the duration of a lid open."""
+    message = types.ThermocyclerCloseMessage(
+        payload=types.ThermocyclerCloseCommandPayload()
+    )
+    message["$"] = "after"
+    message["name"] = types.THERMOCYCLER_CLOSE
+    subject.on_message(message)
+    assert subject.get_total_duration() == 24
+
+
+def test_thermocycler_deactivate_lid(subject: DurationEstimator):
+    """It should compute the duration of a lid open."""
+    message = types.ThermocyclerDeactivateMessage(
+        payload=types.ThermocyclerDeactivateLidCommandPayload()
+    )
+    message["$"] = "after"
+    message["name"] = types.THERMOCYCLER_DEACTIVATE_LID
+    subject.on_message(message)
+    assert subject.get_total_duration() == 23
+
+
+@pytest.mark.parametrize(
+    argnames=["current", "target", "expected_duration"],
+    argvalues=[
+        # No change in temperature
+        [1, 1, 0],
+        # Heating above high threshold
+        [10, THERMO_HIGH_THRESH + 5, (5 / 2) + ((THERMO_HIGH_THRESH - 10) / 4)],
+        # Heating below high threshold
+        [THERMO_HIGH_THRESH - 10, THERMO_HIGH_THRESH - 5, (5 / 4)],
+        # Cooling above high threshold
+        [THERMO_HIGH_THRESH + 20, THERMO_HIGH_THRESH + 10, (10 / 2)],
+        # Cooling above low threshold
+        [THERMO_LOW_THRESH + 20, THERMO_LOW_THRESH + 10, 10],
+        # Cooling below low threshold
+        [THERMO_LOW_THRESH - 10, THERMO_LOW_THRESH - 20, (10 / 0.5) + (20 / 0.1)],
+    ],
+)
+def test_thermocycler_handler(
+    subject: DurationEstimator, current: float, target: float, expected_duration: float
+):
+    """It should compute the duration of a temperature change correctly."""
+    assert subject.thermocyler_handler(current, target) == expected_duration

--- a/api/tests/opentrons/protocols/duration/test_estimator.py
+++ b/api/tests/opentrons/protocols/duration/test_estimator.py
@@ -45,7 +45,8 @@ def test_pick_up_tip(subject: DurationEstimator, mock_instrument: MagicMock):
     # Movement in same slot
     subject._last_deckslot = "1"
     message = types.PickUpTipCommand(
-        payload=types.PickUpTipCommandPayload(location="1", instrument=mock_instrument))
+        payload=types.PickUpTipCommandPayload(location="1", instrument=mock_instrument)
+    )
     message["$"] = "after"
     message["name"] = types.PICK_UP_TIP
     subject.on_message(message)
@@ -58,7 +59,8 @@ def test_drop_tip(subject: DurationEstimator, mock_instrument: MagicMock):
     # Movement in same slot
     subject._last_deckslot = "1"
     message = types.DropTipCommand(
-        payload=types.DropTipCommandPayload(location="1", instrument=mock_instrument))
+        payload=types.DropTipCommandPayload(location="1", instrument=mock_instrument)
+    )
     message["$"] = "after"
     message["name"] = types.DROP_TIP
     subject.on_message(message)

--- a/api/tests/opentrons/protocols/duration/test_estimator.py
+++ b/api/tests/opentrons/protocols/duration/test_estimator.py
@@ -192,4 +192,4 @@ def test_thermocycler_handler(
     subject: DurationEstimator, current: float, target: float, expected_duration: float
 ):
     """It should compute the duration of a temperature change correctly."""
-    assert subject.thermocyler_handler(current, target) == expected_duration
+    assert subject.thermocycler_handler(current, target) == expected_duration


### PR DESCRIPTION
# Overview

This PR adds `-e` command line argument to `opentrons_simulate` which prints out an estimated run time for the protocol like so:

```
--------------------------------------------------------------
Estimated protocol duration: 0h:3m
--------------------------------------------------------------
WARNING: Protocol duration estimation is an experimental feature
```

The code is the brainchild of @alexjoel42 and @Matt-Zwimpfer. The algorithm was created using our technical docs, empirical measurements, help from science team, and good old fashioned maths. A white paper is in progress.

When discussing an initial release we decided a low risk approach would be as an option in the CLI simulator. We believe that this feature has a bright future: integration with run app, itemized estimation, increased accuracy, protocol engine integration.

We would very much like to release this in `4.6` in a few weeks. 

# Changelog

- added package `opentrons.protocols.duration`.
- class `DurationEstimator` implements the estimation. 
- added `-e` to `opentrons_simulate`. when this option is present, a `DurationEstimator` is constructed and its `on_message` method is attached to the simulators broker to listen for protocol events. Finally, when simulation completes a message is printed out using `DurationEstimator.get_total_duration`.
- removed v1 protocol api  from `opentrons_simulate`.

# Review requests

Wording? 
Docs?
Explanations?

# Risk assessment

Very low. This is behind an entirely optional flag and is clearly marked as beta and experimental.