### PR TITLE
refactor(robot-server): adjust types to prevent implicit Any's in generics

### DIFF
--- a/robot-server/mypy.ini
+++ b/robot-server/mypy.ini
@@ -12,9 +12,7 @@ check_untyped_defs = True
 warn_redundant_casts = True
 strict_equality = True
 warn_unused_ignores = True
-
-# TODO(mc, 2021-10-02): fix ~25 anys in generics
-# disallow_any_generics = True
+disallow_any_generics = True
 
 # TODO(mc, 2021-10-02): fix ~150 untyped call errors
 # disallow_untyped_calls = True

--- a/robot-server/robot_server/hardware.py
+++ b/robot-server/robot_server/hardware.py
@@ -26,7 +26,7 @@ from .settings import get_settings
 log = logging.getLogger(__name__)
 
 _hw_api = AppStateValue[HardwareAPI]("hardware_api")
-_init_task = AppStateValue[asyncio.Task]("hardware_init_task")
+_init_task = AppStateValue["asyncio.Task[None]"]("hardware_init_task")
 _event_unsubscribe = AppStateValue[Callable[[], None]]("hardware_event_unsubscribe")
 
 

--- a/robot-server/robot_server/robot/calibration/check/models.py
+++ b/robot-server/robot_server/robot/calibration/check/models.py
@@ -3,6 +3,7 @@ from typing_extensions import Literal
 from functools import partial
 from pydantic import BaseModel, Field
 
+from opentrons_shared_data.labware.dev_types import LabwareDefinition
 from ..helper_classes import RequiredLabware, AttachedPipette
 
 OffsetVector = Tuple[float, float, float]
@@ -97,7 +98,7 @@ class SessionCreateParams(BaseModel):
         description="Whether to use a calibration block in the"
         "calibration health check flow.",
     )
-    tipRacks: List[dict] = Field(
+    tipRacks: List[LabwareDefinition] = Field(
         [],
         description="A list of labware definitions to use in"
         "calibration health check",
@@ -113,7 +114,7 @@ class CalibrationCheckSessionStatus(BaseModel):
     comparisonsByPipette: ComparisonStatePerPipette
     labware: List[RequiredLabware]
     activeTipRack: RequiredLabware
-    supportedCommands: List[Optional[str]] = Field(
+    supportedCommands: List[str] = Field(
         ..., description="A list of supported commands for this user flow"
     )
 

--- a/robot-server/robot_server/robot/calibration/check/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/check/user_flow.py
@@ -69,7 +69,7 @@ from .constants import (
 from ..errors import CalibrationError
 
 if TYPE_CHECKING:
-    from opentrons_shared_data.labware import LabwareDefinition
+    from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 MODULE_LOG = logging.getLogger(__name__)
 
@@ -196,10 +196,10 @@ class CheckCalibrationUserFlow:
         return self._get_hw_pipettes()[0]
 
     @property
-    def supported_commands(self) -> List:
+    def supported_commands(self) -> List[str]:
         return self._supported_commands.supported()
 
-    async def transition(self, tiprackDefinition: Optional[dict] = None):
+    async def transition(self, tiprackDefinition: Optional["LabwareDefinition"] = None):
         pass
 
     async def change_active_pipette(self):
@@ -532,7 +532,7 @@ class CheckCalibrationUserFlow:
                 rank=info_pip.rank.value,
                 mount=str(info_pip.mount),
                 serial=hw_pip.pipette_id,  # type: ignore[arg-type]
-                defaultTipracks=info_pip.default_tipracks,  # type: ignore[arg-type]
+                defaultTipracks=info_pip.default_tipracks,
             )
             for hw_pip, info_pip in zip(hw_pips, info_pips)
         ]
@@ -555,7 +555,7 @@ class CheckCalibrationUserFlow:
             rank=self.active_pipette.rank.value,
             mount=str(self.mount),
             serial=self.hw_pipette.pipette_id,  # type: ignore[arg-type]
-            defaultTipracks=self.active_pipette.default_tipracks,  # type: ignore[arg-type]  # noqa: E501
+            defaultTipracks=self.active_pipette.default_tipracks,
         )
 
     def _determine_threshold(self) -> Point:

--- a/robot-server/robot_server/robot/calibration/check/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/check/user_flow.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional, Tuple, Awaitable, Callable, Dict, Any, TYPE_CHECKING
+from typing import List, Optional, Tuple, Awaitable, Callable, Dict, Any
 from typing_extensions import Literal
 
 from opentrons.calibration_storage import get, helpers, modify, types as cal_types
@@ -20,6 +20,8 @@ from opentrons.protocol_api import labware
 from opentrons.protocols.api_support.constants import OPENTRONS_NAMESPACE
 from opentrons.config import feature_flags as ff
 from opentrons.protocols.geometry.deck import Deck
+
+from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 from robot_server.robot.calibration.constants import (
     SHORT_TRASH_DECK,
@@ -68,9 +70,6 @@ from .constants import (
 )
 from ..errors import CalibrationError
 
-if TYPE_CHECKING:
-    from opentrons_shared_data.labware.dev_types import LabwareDefinition
-
 MODULE_LOG = logging.getLogger(__name__)
 
 """
@@ -89,7 +88,7 @@ class CheckCalibrationUserFlow:
         self,
         hardware: "ThreadManager",
         has_calibration_block: bool = False,
-        tip_rack_defs: Optional[List["LabwareDefinition"]] = None,
+        tip_rack_defs: Optional[List[LabwareDefinition]] = None,
     ):
         self._hardware = hardware
         self._state_machine = CalibrationCheckStateMachine()
@@ -115,7 +114,7 @@ class CheckCalibrationUserFlow:
         ) = self._get_current_calibrations()
         self._check_valid_calibrations()
 
-        self._tip_racks: Optional[List["LabwareDefinition"]] = tip_rack_defs
+        self._tip_racks: Optional[List[LabwareDefinition]] = tip_rack_defs
         self._active_pipette, self._pip_info = self._select_starting_pipette()
 
         self._has_calibration_block = has_calibration_block
@@ -199,7 +198,7 @@ class CheckCalibrationUserFlow:
     def supported_commands(self) -> List[str]:
         return self._supported_commands.supported()
 
-    async def transition(self, tiprackDefinition: Optional["LabwareDefinition"] = None):
+    async def transition(self, tiprackDefinition: Optional[LabwareDefinition] = None):
         pass
 
     async def change_active_pipette(self):
@@ -387,7 +386,7 @@ class CheckCalibrationUserFlow:
     def _is_checking_both_mounts(self):
         return len(self._pip_info) == 2
 
-    def _get_volume_from_tiprack_def(self, tip_rack_def: "LabwareDefinition") -> float:
+    def _get_volume_from_tiprack_def(self, tip_rack_def: LabwareDefinition) -> float:
         first_well = tip_rack_def["wells"]["A1"]
         return float(first_well["totalLiquidVolume"])
 
@@ -414,7 +413,7 @@ class CheckCalibrationUserFlow:
 
     @staticmethod
     def _get_tr_lw(
-        tip_rack_def: Optional["LabwareDefinition"],
+        tip_rack_def: Optional[LabwareDefinition],
         existing_calibration: PipetteOffsetByPipetteMount,
         volume: float,
         position: Location,

--- a/robot-server/robot_server/robot/calibration/deck/models.py
+++ b/robot-server/robot_server/robot/calibration/deck/models.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import List, Optional
+from typing import List
 
 from ..helper_classes import AttachedPipette, RequiredLabware
 
@@ -12,7 +12,7 @@ class DeckCalibrationSessionStatus(BaseModel):
         ..., description="Current step of deck calibration user flow"
     )
     labware: List[RequiredLabware]
-    supportedCommands: List[Optional[str]] = Field(
+    supportedCommands: List[str] = Field(
         ..., description="A list of supported commands for this user flow"
     )
 

--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -55,7 +55,7 @@ from ..helper_classes import RequiredLabware, AttachedPipette, SupportedCommands
 
 if TYPE_CHECKING:
     from .dev_types import SavedPoints, ExpectedPoints
-    from opentrons_shared_data.labware import LabwareDefinition
+    from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 
 MODULE_LOG = logging.getLogger(__name__)
@@ -157,7 +157,7 @@ class DeckCalibrationUserFlow:
         self._tip_origin_pt = None
 
     @property
-    def supported_commands(self) -> List:
+    def supported_commands(self) -> List[str]:
         return self._supported_commands.supported()
 
     @property
@@ -270,7 +270,7 @@ class DeckCalibrationUserFlow:
     async def get_current_point(self, critical_point: CriticalPoint = None) -> Point:
         return await self._hardware.gantry_position(self._mount, critical_point)
 
-    async def load_labware(self, tiprackDefinition: dict):
+    async def load_labware(self, tiprackDefinition: "LabwareDefinition"):
         self._supported_commands.loadLabware = False
         if tiprackDefinition:
             verified_definition = labware.verify_definition(tiprackDefinition)

--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -10,7 +10,6 @@ from typing import (
     Optional,
     Tuple,
     Union,
-    TYPE_CHECKING,
 )
 
 from opentrons.calibration_storage import get, delete
@@ -24,6 +23,8 @@ from opentrons.protocol_api import labware
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.types import Mount, Point, Location
 from opentrons.util import linal
+
+from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 from robot_server.robot.calibration.constants import TIP_RACK_LOOKUP_BY_MAX_VOL
 from robot_server.service.errors import RobotServerError
@@ -50,12 +51,9 @@ from .constants import (
     SAVE_POINT_STATE_MAP,
 )
 from .state_machine import DeckCalibrationStateMachine
+from .dev_types import SavedPoints, ExpectedPoints
 from ..errors import CalibrationError
 from ..helper_classes import RequiredLabware, AttachedPipette, SupportedCommands
-
-if TYPE_CHECKING:
-    from .dev_types import SavedPoints, ExpectedPoints
-    from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 
 MODULE_LOG = logging.getLogger(__name__)
@@ -216,7 +214,7 @@ class DeckCalibrationUserFlow:
             )[0]
 
     def _get_tip_rack_lw(
-        self, tiprack_definition: Optional["LabwareDefinition"] = None
+        self, tiprack_definition: Optional[LabwareDefinition] = None
     ) -> labware.Labware:
         if tiprack_definition:
             return labware.load_from_definition(
@@ -270,7 +268,7 @@ class DeckCalibrationUserFlow:
     async def get_current_point(self, critical_point: CriticalPoint = None) -> Point:
         return await self._hardware.gantry_position(self._mount, critical_point)
 
-    async def load_labware(self, tiprackDefinition: "LabwareDefinition"):
+    async def load_labware(self, tiprackDefinition: LabwareDefinition):
         self._supported_commands.loadLabware = False
         if tiprackDefinition:
             verified_definition = labware.verify_definition(tiprackDefinition)

--- a/robot-server/robot_server/robot/calibration/helper_classes.py
+++ b/robot-server/robot_server/robot/calibration/helper_classes.py
@@ -4,13 +4,10 @@ from opentrons.types import Mount
 from enum import Enum
 from dataclasses import dataclass, fields
 from pydantic import BaseModel, Field
+
+from opentrons_shared_data.labware.dev_types import LabwareDefinition
 from opentrons.protocol_api import labware
 from opentrons.types import DeckLocation
-
-
-if typing.TYPE_CHECKING:
-    from opentrons.protocol_api.labware import Labware
-    from opentrons_shared_data.labware import LabwareDefinition
 
 
 class RobotHealthCheck(Enum):
@@ -64,8 +61,8 @@ class PipetteInfo:
     mount: Mount
     max_volume: int
     channels: int
-    tip_rack: "Labware"
-    default_tipracks: typing.List["LabwareDefinition"]
+    tip_rack: labware.Labware
+    default_tipracks: typing.List[LabwareDefinition]
 
 
 @dataclass
@@ -111,7 +108,7 @@ class AttachedPipette(BaseModel):
     )
     mount: str = Field(None, description="The mount this pipette attached to")
     serial: str = Field(None, description="The serial number of the attached pipette")
-    defaultTipracks: typing.List[dict] = Field(
+    defaultTipracks: typing.List[LabwareDefinition] = Field(
         None, description="A list of default tipracks for this pipette"
     )
 
@@ -127,7 +124,7 @@ class RequiredLabware(BaseModel):
     namespace: str
     version: str
     isTiprack: bool
-    definition: dict
+    definition: LabwareDefinition
 
     @classmethod
     def from_lw(cls, lw: labware.Labware, slot: typing.Optional[DeckLocation] = None):
@@ -142,9 +139,7 @@ class RequiredLabware(BaseModel):
             namespace=lw_def["namespace"],
             version=str(lw_def["version"]),
             isTiprack=lw.is_tiprack,
-            # TODO(mc, 2020-09-17): LabwareDefinition does not match
-            # Dict[any,any] expected by cls
-            definition=lw_def,  # type: ignore[arg-type]
+            definition=lw_def,
         )
 
 

--- a/robot-server/robot_server/robot/calibration/models.py
+++ b/robot-server/robot_server/robot/calibration/models.py
@@ -1,6 +1,8 @@
 from typing import Optional
 from pydantic import BaseModel, Field
 
+from opentrons_shared_data.labware.dev_types import LabwareDefinition
+
 
 class SessionCreateParams(BaseModel):
     """
@@ -20,7 +22,7 @@ class SessionCreateParams(BaseModel):
         "is performed, this is ignored, but it should always be "
         "specified.",
     )
-    tipRackDefinition: Optional[dict] = Field(
+    tipRackDefinition: Optional[LabwareDefinition] = Field(
         None,
         description="The full labware definition of the tip rack to "
         "calibrate. If not specified, then a default will be "

--- a/robot-server/robot_server/robot/calibration/pipette_offset/models.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/models.py
@@ -17,7 +17,7 @@ class PipetteOffsetCalibrationSessionStatus(BaseModel):
         description="Does tip length calibration data exist for "
         "this pipette and tip rack combination",
     )
-    supportedCommands: List[Optional[str]] = Field(
+    supportedCommands: List[str] = Field(
         ..., description="A list of supported commands for this user flow"
     )
     nextSteps: Optional[NextSteps] = Field(

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -7,7 +7,6 @@ from typing import (
     List,
     Optional,
     Union,
-    TYPE_CHECKING,
     Tuple,
 )
 
@@ -51,8 +50,7 @@ from .state_machine import (
     PipetteOffsetWithTipLengthStateMachine,
 )
 
-if TYPE_CHECKING:
-    from opentrons_shared_data.labware import LabwareDefinition
+from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 
 MODULE_LOG = logging.getLogger(__name__)
@@ -80,7 +78,7 @@ class PipetteOffsetCalibrationUserFlow:
         mount: Mount = Mount.RIGHT,
         recalibrate_tip_length: bool = False,
         has_calibration_block: bool = False,
-        tip_rack_def: Optional["LabwareDefinition"] = None,
+        tip_rack_def: Optional[LabwareDefinition] = None,
     ):
 
         self._hardware = hardware
@@ -198,7 +196,7 @@ class PipetteOffsetCalibrationUserFlow:
             tipLength=self._hw_pipette.config.tip_length,
             mount=str(self._mount),
             serial=self._hw_pipette.pipette_id,
-            defaultTipracks=self._default_tipracks,  # type: ignore[arg-type]
+            defaultTipracks=self._default_tipracks,
         )
 
     def get_required_labware(self) -> List[RequiredLabware]:
@@ -255,7 +253,10 @@ class PipetteOffsetCalibrationUserFlow:
     async def get_current_point(self, critical_point: Optional[CriticalPoint]) -> Point:
         return await self._hardware.gantry_position(self._mount, critical_point)
 
-    async def load_labware(self, tiprackDefinition: Optional[dict] = None):
+    async def load_labware(
+        self,
+        tiprackDefinition: Optional[LabwareDefinition] = None,
+    ):
         self._supported_commands.loadLabware = False
         if tiprackDefinition:
             verified_definition = labware.verify_definition(tiprackDefinition)
@@ -282,7 +283,7 @@ class PipetteOffsetCalibrationUserFlow:
         self._tip_origin_pt = None
 
     @property
-    def supported_commands(self) -> List:
+    def supported_commands(self) -> List[str]:
         return self._supported_commands.supported()
 
     async def move_to_tip_rack(self):
@@ -337,7 +338,7 @@ class PipetteOffsetCalibrationUserFlow:
 
     @staticmethod
     def _get_tr_lw(
-        tip_rack_def: Optional["LabwareDefinition"],
+        tip_rack_def: Optional[LabwareDefinition],
         existing_calibration: Optional[PipetteOffsetByPipetteMount],
         volume: float,
         position: Location,
@@ -366,7 +367,7 @@ class PipetteOffsetCalibrationUserFlow:
 
     def _load_tip_rack(
         self,
-        tip_rack_def: Optional["LabwareDefinition"],
+        tip_rack_def: Optional[LabwareDefinition],
         existing_calibration: Optional[PipetteOffsetByPipetteMount],
     ):
         """

--- a/robot-server/robot_server/robot/calibration/tip_length/models.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/models.py
@@ -15,7 +15,7 @@ class TipCalibrationSessionStatus(BaseModel):
         None, description="Next Available Steps in Session"
     )
     labware: List[RequiredLabware]
-    supportedCommands: List[Optional[str]] = Field(
+    supportedCommands: List[str] = Field(
         ..., description="A list of supported commands for this user flow"
     )
 

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -1,10 +1,13 @@
 import logging
-from typing import Dict, Awaitable, Callable, Any, Set, List, Optional, TYPE_CHECKING
+from typing import Dict, Awaitable, Callable, Any, Set, List, Optional
+
 from opentrons.types import Mount, Point, Location
 from opentrons.config import feature_flags as ff
 from opentrons.hardware_control import ThreadManager, CriticalPoint, Pipette
 from opentrons.protocol_api import labware
 from opentrons.protocols.geometry.deck import Deck
+
+from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 from robot_server.robot.calibration import util
 from robot_server.service.errors import RobotServerError
@@ -21,10 +24,6 @@ from ..constants import (
 )
 from .constants import TipCalibrationState as State, TIP_RACK_SLOT
 from .state_machine import TipCalibrationStateMachine
-
-if TYPE_CHECKING:
-    from opentrons_shared_data.labware import LabwareDefinition
-
 
 MODULE_LOG = logging.getLogger(__name__)
 
@@ -46,7 +45,7 @@ class TipCalibrationUserFlow:
         hardware: ThreadManager,
         mount: Mount,
         has_calibration_block: bool,
-        tip_rack: "LabwareDefinition",
+        tip_rack: LabwareDefinition,
     ):
         self._hardware = hardware
         self._mount = mount
@@ -119,7 +118,7 @@ class TipCalibrationUserFlow:
         self._tip_origin_pt = None
 
     @property
-    def supported_commands(self) -> List:
+    def supported_commands(self) -> List[str]:
         return self._supported_commands.supported()
 
     @property
@@ -134,7 +133,7 @@ class TipCalibrationUserFlow:
             tipLength=self._hw_pipette.config.tip_length,
             mount=str(self._mount),
             serial=self._hw_pipette.pipette_id,
-            defaultTipracks=self._default_tipracks,  # type: ignore[arg-type]
+            defaultTipracks=self._default_tipracks,
         )
 
     def get_required_labware(self) -> List[RequiredLabware]:
@@ -164,7 +163,10 @@ class TipCalibrationUserFlow:
             f"from {self._current_state} to {next_state}"
         )
 
-    async def load_labware(self, tiprackDefinition: Optional[dict] = None):
+    async def load_labware(
+        self,
+        tiprackDefinition: Optional[LabwareDefinition] = None,
+    ):
         pass
 
     async def move_to_tip_rack(self):
@@ -190,7 +192,7 @@ class TipCalibrationUserFlow:
     def _get_default_tip_length(self) -> float:
         tiprack: labware.Labware = self._deck[TIP_RACK_SLOT]  # type: ignore
         full_length = tiprack.tip_length
-        overlap_dict: Dict = self._hw_pipette.config.tip_overlap
+        overlap_dict: Dict[str, float] = self._hw_pipette.config.tip_overlap
         overlap = overlap_dict.get(tiprack.uri, 0)
         return full_length - overlap
 
@@ -232,7 +234,7 @@ class TipCalibrationUserFlow:
             await self.return_tip()
         await self._hardware.home()
 
-    def _get_tip_rack_lw(self, tip_rack_def: "LabwareDefinition") -> labware.Labware:
+    def _get_tip_rack_lw(self, tip_rack_def: LabwareDefinition) -> labware.Labware:
         try:
             return labware.load_from_definition(
                 tip_rack_def, self._deck.position_for(TIP_RACK_SLOT)

--- a/robot-server/robot_server/robot/calibration/util.py
+++ b/robot-server/robot_server/robot/calibration/util.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     from .pipette_offset.user_flow import PipetteOffsetCalibrationUserFlow
     from .check.user_flow import CheckCalibrationUserFlow
     from opentrons_shared_data.pipette.dev_types import LabwareUri
-    from opentrons_shared_data.labware import LabwareDefinition
+    from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 ValidState = Union[
     TipCalibrationState,

--- a/robot-server/robot_server/service/errors.py
+++ b/robot-server/robot_server/service/errors.py
@@ -2,7 +2,7 @@
 # robot_server/errors/error_responses.py and robot_server/errors/global_errors.py
 from dataclasses import dataclass, asdict
 from enum import Enum
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 from starlette import status as status_codes
 
 from robot_server.errors import ApiError, ErrorSource, ErrorDetails, ErrorResponse
@@ -37,7 +37,7 @@ class RobotServerError(ApiError):
         error_id: str = "UncategorizedError",
         links: Optional[ResourceLinks] = None,
         source: Optional[ErrorSource] = None,
-        meta: Optional[Dict] = None,
+        meta: Optional[Dict[str, Any]] = None,
         *fmt_args,
         **fmt_kw_args
     ):

--- a/robot-server/robot_server/service/legacy/rpc/rpc.py
+++ b/robot-server/robot_server/service/legacy/rpc/rpc.py
@@ -28,8 +28,8 @@ PONG_MESSAGE = 5
 
 class ClientWriterTask(typing.NamedTuple):
     socket: WebSocket
-    queue: asyncio.Queue
-    task: asyncio.Task
+    queue: "asyncio.Queue[typing.Dict[str, typing.Any]]"
+    task: "asyncio.Task[None]"
 
 
 class RPCServer(object):
@@ -91,7 +91,10 @@ class RPCServer(object):
             except Exception:
                 log.exception("send_task for socket {} threw:".format(_id))
 
-        async def send_task(socket_: WebSocket, queue_: asyncio.Queue):
+        async def send_task(
+            socket_: WebSocket,
+            queue_: "asyncio.Queue[typing.Dict[str, typing.Any]]",
+        ):
             while True:
                 payload = await queue_.get()
                 if socket_.client_state == WebSocketState.DISCONNECTED:
@@ -100,7 +103,9 @@ class RPCServer(object):
 
                 await socket_.send_json(payload)
 
-        queue: asyncio.Queue = asyncio.Queue(loop=self.loop)
+        queue: "asyncio.Queue[typing.Dict[str, typing.Any]]" = asyncio.Queue(
+            loop=self.loop
+        )
         task = self.loop.create_task(send_task(socket, queue))
         task.add_done_callback(task_done)
         log.debug(f"Send task for {_id} started")

--- a/robot-server/robot_server/service/protocol/contents.py
+++ b/robot-server/robot_server/service/protocol/contents.py
@@ -23,7 +23,7 @@ DIR_SUFFIX = "._proto_dir"
 @dataclass
 class Contents:
     protocol_file: FileMeta
-    directory: TemporaryDirectory
+    directory: "TemporaryDirectory[str]"
     support_files: typing.List[FileMeta] = field(default_factory=list)
 
 

--- a/robot-server/robot_server/service/session/command_execution/command.py
+++ b/robot-server/robot_server/service/session/command_execution/command.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from dataclasses import dataclass, field
-from typing import Optional, Generic, TypeVar
+from typing import Any, Optional, Generic, TypeVar
 
 from robot_server.service.session.models.command import CommandStatus, RequestTypes
 from robot_server.service.session.models.common import IdentifierType, create_identifier
@@ -34,7 +34,7 @@ class Command:
 class CompletedCommand:
     request: RequestTypes
     meta: CommandMeta
-    result: CommandResult
+    result: CommandResult[Any]
 
 
 def create_command(request: RequestTypes) -> Command:

--- a/robot-server/robot_server/service/session/models/command.py
+++ b/robot-server/robot_server/service/session/models/command.py
@@ -24,6 +24,7 @@ from typing_extensions import Literal
 from pydantic import BaseModel, Field
 from pydantic.generics import GenericModel
 
+from opentrons_shared_data.labware.dev_types import LabwareDefinition
 from opentrons.util.helpers import utc_now
 from opentrons.protocol_engine import commands
 
@@ -41,7 +42,7 @@ from robot_server.service.json_api import ResponseModel, RequestModel, ResponseD
 
 
 class LoadLabwareByDefinitionRequestData(BaseModel):
-    tiprackDefinition: typing.Optional[dict] = Field(
+    tiprackDefinition: typing.Optional[LabwareDefinition] = Field(
         None, description="The tiprack definition to load into a user flow"
     )
 

--- a/robot-server/robot_server/service/session/session_types/check_session.py
+++ b/robot-server/robot_server/service/session/session_types/check_session.py
@@ -1,4 +1,4 @@
-from typing import Awaitable, cast, TYPE_CHECKING
+from typing import Awaitable, cast
 
 from robot_server.robot.calibration.check.user_flow import CheckCalibrationUserFlow
 from robot_server.robot.calibration.check.models import (
@@ -29,9 +29,6 @@ from robot_server.service.session.errors import (
     CommandExecutionException,
     UnsupportedFeature,
 )
-
-if TYPE_CHECKING:
-    from opentrons_shared_data.labware import LabwareDefinition
 
 
 class CheckSessionCommandExecutor(CallableExecutor):
@@ -75,7 +72,7 @@ class CheckSession(BaseSession):
             calibration_check = CheckCalibrationUserFlow(
                 configuration.hardware,
                 has_calibration_block=has_calibration_block,
-                tip_rack_defs=[cast("LabwareDefinition", rack) for rack in tip_racks],
+                tip_rack_defs=[rack for rack in tip_racks],
             )
         except AssertionError as e:
             raise SessionCreationException(str(e))

--- a/robot-server/robot_server/service/session/session_types/pipette_offset_calibration.py
+++ b/robot-server/robot_server/service/session/session_types/pipette_offset_calibration.py
@@ -28,7 +28,7 @@ from ..models.session import SessionType, PipetteOffsetCalibrationResponseAttrib
 from ..errors import UnsupportedFeature
 
 if TYPE_CHECKING:
-    from opentrons_shared_data.labware import LabwareDefinition
+    from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 log = logging.getLogger(__name__)
 

--- a/robot-server/robot_server/service/session/session_types/protocol/execution/worker.py
+++ b/robot-server/robot_server/service/session/session_types/protocol/execution/worker.py
@@ -40,7 +40,9 @@ class _Worker:
         self._loop = loop
         self._listener = listener
         # For passing WorkerDirective from main to worker task
-        self._async_command_queue: asyncio.Queue = asyncio.Queue(maxsize=1)
+        self._async_command_queue: "asyncio.Queue[WorkerDirective]" = asyncio.Queue(
+            maxsize=1
+        )
         # Protocol running WorkerDirective handling task
         self._async_command_task = self._loop.create_task(self._runner_task())
 

--- a/robot-server/tests/sessions/router/test_commands_router.py
+++ b/robot-server/tests/sessions/router/test_commands_router.py
@@ -18,6 +18,7 @@ from opentrons.protocol_engine import (
 
 from robot_server.service.json_api import ResponseModel
 from robot_server.sessions.session_models import (
+    Session,
     BasicSession,
     SessionStatus,
     SessionCommandSummary,
@@ -31,14 +32,14 @@ from robot_server.sessions.router.commands_router import (
 
 
 @pytest.fixture
-def get_session(decoy: Decoy) -> Callable[..., Awaitable[ResponseModel]]:
+def get_session(decoy: Decoy) -> Callable[..., Awaitable[ResponseModel[Session]]]:
     """Get a mock version of the get_session route handler."""
     return decoy.mock(func=real_get_session)
 
 
 @pytest.fixture(autouse=True)
 def setup_app(
-    get_session: Callable[..., Awaitable[ResponseModel]],
+    get_session: Callable[..., Awaitable[ResponseModel[Session]]],
     app: FastAPI,
 ) -> None:
     """Setup the FastAPI app with commands routes and dependencies."""
@@ -48,7 +49,7 @@ def setup_app(
 
 async def test_get_session_commands(
     decoy: Decoy,
-    get_session: Callable[..., Awaitable[ResponseModel]],
+    get_session: Callable[..., Awaitable[ResponseModel[Session]]],
     async_client: AsyncClient,
 ) -> None:
     """It should return a list of all commands in a session."""


### PR DESCRIPTION
## Overview

This PR continues the work of #8289 by turning on the `disallow_any_generics` rule, which prevents you from allowing `Any` to sneak in if you forget to add type parameters to generic types:

```py
# bad
foo: dict  # > implicitly becomes Dict[Any, Any]
foo: Dict  # > implicitly becomes Dict[Any, Any]

# good
foo: Dict[str, float]
```

## Changelog

- refactor(robot-server): adjust types to prevent implicit Any's in generics

## Review requests

- [ ] Code looks good
- [ ] Changes only touch type annotations

## Risk assessment

If CI is green and the change set only includes type annotations, this is pretty low risk. If one wanted to smoke test, this PR mostly affects the calibration flows
