### PR TITLE
fix(robot-server): use the current critical point when moving pipettes

### DIFF
--- a/robot-server/tests/service/legacy/routers/test_control.py
+++ b/robot-server/tests/service/legacy/routers/test_control.py
@@ -2,7 +2,7 @@ from asyncio import Event
 from mock import call, MagicMock
 
 import pytest
-from opentrons.hardware_control.types import Axis, CriticalPoint
+from opentrons.hardware_control.types import Axis
 from opentrons.types import Mount, Point
 
 from robot_server.errors import ApiError

--- a/robot-server/tests/service/legacy/routers/test_control.py
+++ b/robot-server/tests/service/legacy/routers/test_control.py
@@ -116,11 +116,9 @@ def test_move_mount(api_client, hardware_move):
         "message": "Move complete. New position: (100.0, 200.0, 50.0)"
     }
 
-    hardware_move.cache_instruments.assert_called_once()
-
     hardware_move.gantry_position.assert_has_calls(
         [
-            call(Mount.RIGHT, critical_point=CriticalPoint.MOUNT),
+            call(Mount.RIGHT),
             call(Mount.RIGHT),
         ]
     )
@@ -128,13 +126,11 @@ def test_move_mount(api_client, hardware_move):
         [
             call(
                 Mount.RIGHT,
-                Point(100.0, 200.0, 0.0),
-                critical_point=CriticalPoint.MOUNT,
+                Point(100.0, 200.0, 0.0)
             ),
             call(
                 Mount.RIGHT,
-                Point(100.0, 200.0, 50.0),
-                critical_point=CriticalPoint.MOUNT,
+                Point(100.0, 200.0, 50.0)
             ),
         ]
     )
@@ -151,18 +147,17 @@ def test_move_pipette(api_client, hardware_move):
     assert res.status_code == 200
     assert res.json() == {"message": "Move complete. New position: (50.0, 100.0, 25.0)"}
 
-    hardware_move.cache_instruments.assert_called_once()
 
     hardware_move.gantry_position.assert_has_calls(
         [
-            call(Mount.LEFT, critical_point=None),
+            call(Mount.LEFT),
             call(Mount.LEFT),
         ]
     )
     hardware_move.move_to.assert_has_calls(
         [
-            call(Mount.LEFT, Point(50.0, 100.0, 0.0), critical_point=None),
-            call(Mount.LEFT, Point(50.0, 100.0, 25.0), critical_point=None),
+            call(Mount.LEFT, Point(50.0, 100.0, 0.0)),
+            call(Mount.LEFT, Point(50.0, 100.0, 25.0)),
         ]
     )
 

--- a/robot-server/tests/service/legacy/routers/test_control.py
+++ b/robot-server/tests/service/legacy/routers/test_control.py
@@ -124,14 +124,8 @@ def test_move_mount(api_client, hardware_move):
     )
     hardware_move.move_to.assert_has_calls(
         [
-            call(
-                Mount.RIGHT,
-                Point(100.0, 200.0, 0.0)
-            ),
-            call(
-                Mount.RIGHT,
-                Point(100.0, 200.0, 50.0)
-            ),
+            call(Mount.RIGHT, Point(100.0, 200.0, 0.0)),
+            call(Mount.RIGHT, Point(100.0, 200.0, 50.0)),
         ]
     )
 
@@ -146,7 +140,6 @@ def test_move_pipette(api_client, hardware_move):
     res = api_client.post("/robot/move", json=data)
     assert res.status_code == 200
     assert res.json() == {"message": "Move complete. New position: (50.0, 100.0, 25.0)"}
-
 
     hardware_move.gantry_position.assert_has_calls(
         [


### PR DESCRIPTION
# Overview

We should not be providing our own critical point of 'Mount' when moving a gantry that could
potentially have pipettes on it. We should instead rely on the hardware controller to determine the
correct critical point.

closes #8288.

# Changelog
- Do not use the default "mount" critical point which is only valid for GEN2 pipettes when moving to the deck from the http endpoint. 

# Review requests

@alexjoel42 and @Matt-Zwimpfer, since you guys were able to best reproduce this can you please test on a robot? Happy to help you get that setup when you have the time.

# Risk assessment
- Low/Medium. Although it affects robot movement, we are no longer relying on a hard-coded number for the critical point, so since there aren't any crashes happening in protocols wrt to critical points then there shouldn't be any crashing during the pipette attach/change flow.