### PR TITLE
refactor(api): fix/suppress type errors to enable strict mode

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -50,14 +50,6 @@ ot_shared_data_sources := $(filter %.json,$(shell $(SHX) find ../shared-data/))
 ot_resources := $(filter %,$(shell $(SHX) find src/opentrons/resources))
 ot_sources := $(ot_py_sources) $(ot_shared_data_sources) $(ot_resources)
 
-# test modules to typecheck
-# TODO(mc, 2021-07-23): expand this to all tests
-ot_tests_to_typecheck := \
-	tests/opentrons/motion_planning \
-	tests/opentrons/protocol_api_experimental \
-	tests/opentrons/protocol_engine \
-	tests/opentrons/protocol_runner
-
 # Defined separately than the clean target so the wheel file doesn’t have to
 # depend on a PHONY target
 clean_cmd = $(SHX) rm -rf build dist .coverage coverage.xml '*.egg-info' '**/__pycache__' '**/*.pyc' 'src/**/.mypy_cache'
@@ -94,7 +86,7 @@ test:
 
 .PHONY: lint
 lint:
-	$(python) -m mypy src $(ot_tests_to_typecheck)
+	$(python) -m mypy src/opentrons tests/opentrons
 	$(python) -m black --check src tests setup.py
 	$(python) -m flake8 src tests setup.py
 

--- a/api/Makefile
+++ b/api/Makefile
@@ -86,7 +86,7 @@ test:
 
 .PHONY: lint
 lint:
-	$(python) -m mypy src/opentrons tests/opentrons
+	$(python) -m mypy src tests
 	$(python) -m black --check src tests setup.py
 	$(python) -m flake8 src tests setup.py
 

--- a/api/Pipfile
+++ b/api/Pipfile
@@ -33,8 +33,8 @@ black = "==21.7b0"
 # https://github.com/pypa/pipenv/issues/4408#issuecomment-668324177
 atomicwrites = {version="==1.4.0", sys_platform="== 'win32'"}
 colorama = {version="==0.4.4", sys_platform="== 'win32'"}
-types-mock = "*"
-types-setuptools = "*"
+types-mock = "==4.0.1"
+types-setuptools = "==57.0.2"
 
 [packages]
 opentrons-shared-data = {editable = true, path = "../shared-data/python"}

--- a/api/Pipfile
+++ b/api/Pipfile
@@ -9,7 +9,7 @@ python_version = "3.7"
 [dev-packages]
 opentrons = {editable = true, path = "."}
 coverage = "==5.1"
-mypy = "==0.800"
+mypy = "0.910"
 numpydoc = "==0.9.1"
 pytest = "==6.1.0"
 pytest-aiohttp = "==0.3.0"
@@ -33,6 +33,8 @@ black = "==21.7b0"
 # https://github.com/pypa/pipenv/issues/4408#issuecomment-668324177
 atomicwrites = {version="==1.4.0", sys_platform="== 'win32'"}
 colorama = {version="==0.4.4", sys_platform="== 'win32'"}
+types-mock = "*"
+types-setuptools = "*"
 
 [packages]
 opentrons-shared-data = {editable = true, path = "../shared-data/python"}

--- a/api/Pipfile.lock
+++ b/api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "28a7c870f7e0c5538e8b9bd1093d46f7d117a23afd020726ae8cecc67d9c7a4b"
+            "sha256": "c8839d496ca1bb44594c87424f5b35ea9ce788f2a2c35467cebc0f6599ac68aa"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -453,11 +453,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:9e04bf59076a15a9b6dd9c27806e8fcdf15280ba529c6a8cc3f4d5b4875bdd61",
-                "sha256:c4eb3dec5f697682e383a39701a7de11cd5c02daf8dd93534b69e3e6473f6b1b"
+                "sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15",
+                "sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==4.7.1"
+            "version": "==4.8.1"
         },
         "iniconfig": {
             "hashes": [
@@ -602,31 +602,32 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:0d2fc8beb99cd88f2d7e20d69131353053fbecea17904ee6f0348759302c52fa",
-                "sha256:2b216eacca0ec0ee124af9429bfd858d5619a0725ee5f88057e6e076f9eb1a7b",
-                "sha256:319ee5c248a7c3f94477f92a729b7ab06bf8a6d04447ef3aa8c9ba2aa47c6dcf",
-                "sha256:3e0c159a7853e3521e3f582adb1f3eac66d0b0639d434278e2867af3a8c62653",
-                "sha256:5615785d3e2f4f03ab7697983d82c4b98af5c321614f51b8f1034eb9ebe48363",
-                "sha256:5ff616787122774f510caeb7b980542a7cc2222be3f00837a304ea85cd56e488",
-                "sha256:6f8425fecd2ba6007e526209bb985ce7f49ed0d2ac1cc1a44f243380a06a84fb",
-                "sha256:74f5aa50d0866bc6fb8e213441c41e466c86678c800700b87b012ed11c0a13e0",
-                "sha256:90b6f46dc2181d74f80617deca611925d7e63007cf416397358aa42efb593e07",
-                "sha256:947126195bfe4709c360e89b40114c6746ae248f04d379dca6f6ab677aa07641",
-                "sha256:a301da58d566aca05f8f449403c710c50a9860782148332322decf73a603280b",
-                "sha256:aa9d4901f3ee1a986a3a79fe079ffbf7f999478c281376f48faa31daaa814e86",
-                "sha256:b9150db14a48a8fa114189bfe49baccdff89da8c6639c2717750c7ae62316738",
-                "sha256:b95068a3ce3b50332c40e31a955653be245666a4bc7819d3c8898aa9fb9ea496",
-                "sha256:ca7ad5aed210841f1e77f5f2f7d725b62c78fa77519312042c719ed2ab937876",
-                "sha256:d16c54b0dffb861dc6318a8730952265876d90c5101085a4bc56913e8521ba19",
-                "sha256:e0202e37756ed09daf4b0ba64ad2c245d357659e014c3f51d8cd0681ba66940a",
-                "sha256:e1c84c65ff6d69fb42958ece5b1255394714e0aac4df5ffe151bc4fe19c7600a",
-                "sha256:e32b7b282c4ed4e378bba8b8dfa08e1cfa6f6574067ef22f86bee5b1039de0c9",
-                "sha256:e3b8432f8df19e3c11235c4563a7250666dc9aa7cdda58d21b4177b20256ca9f",
-                "sha256:e497a544391f733eca922fdcb326d19e894789cd4ff61d48b4b195776476c5cf",
-                "sha256:f5fdf935a46aa20aa937f2478480ebf4be9186e98e49cc3843af9a5795a49a25"
+                "sha256:088cd9c7904b4ad80bec811053272986611b84221835e079be5bcad029e79dd9",
+                "sha256:0aadfb2d3935988ec3815952e44058a3100499f5be5b28c34ac9d79f002a4a9a",
+                "sha256:119bed3832d961f3a880787bf621634ba042cb8dc850a7429f643508eeac97b9",
+                "sha256:1a85e280d4d217150ce8cb1a6dddffd14e753a4e0c3cf90baabb32cefa41b59e",
+                "sha256:3c4b8ca36877fc75339253721f69603a9c7fdb5d4d5a95a1a1b899d8b86a4de2",
+                "sha256:3e382b29f8e0ccf19a2df2b29a167591245df90c0b5a2542249873b5c1d78212",
+                "sha256:42c266ced41b65ed40a282c575705325fa7991af370036d3f134518336636f5b",
+                "sha256:53fd2eb27a8ee2892614370896956af2ff61254c275aaee4c230ae771cadd885",
+                "sha256:704098302473cb31a218f1775a873b376b30b4c18229421e9e9dc8916fd16150",
+                "sha256:7df1ead20c81371ccd6091fa3e2878559b5c4d4caadaf1a484cf88d93ca06703",
+                "sha256:866c41f28cee548475f146aa4d39a51cf3b6a84246969f3759cb3e9c742fc072",
+                "sha256:a155d80ea6cee511a3694b108c4494a39f42de11ee4e61e72bc424c490e46457",
+                "sha256:adaeee09bfde366d2c13fe6093a7df5df83c9a2ba98638c7d76b010694db760e",
+                "sha256:b6fb13123aeef4a3abbcfd7e71773ff3ff1526a7d3dc538f3929a49b42be03f0",
+                "sha256:b94e4b785e304a04ea0828759172a15add27088520dc7e49ceade7834275bedb",
+                "sha256:c0df2d30ed496a08de5daed2a9ea807d07c21ae0ab23acf541ab88c24b26ab97",
+                "sha256:c6c2602dffb74867498f86e6129fd52a2770c48b7cd3ece77ada4fa38f94eba8",
+                "sha256:ceb6e0a6e27fb364fb3853389607cf7eb3a126ad335790fa1e14ed02fba50811",
+                "sha256:d9dd839eb0dc1bbe866a288ba3c1afc33a202015d2ad83b31e875b5905a079b6",
+                "sha256:e4dab234478e3bd3ce83bac4193b2ecd9cf94e720ddd95ce69840273bf44f6de",
+                "sha256:ec4e0cd079db280b6bdabdc807047ff3e199f334050db5cbb91ba3e959a67504",
+                "sha256:ecd2c3fe726758037234c93df7e98deb257fd15c24c9180dacf1ef829da5f921",
+                "sha256:ef565033fa5a958e62796867b1df10c40263ea9ded87164d67572834e57a174d"
             ],
             "index": "pypi",
-            "version": "==0.800"
+            "version": "==0.910"
         },
         "mypy-extensions": {
             "hashes": [
@@ -877,49 +878,49 @@
         },
         "regex": {
             "hashes": [
-                "sha256:03840a07a402576b8e3a6261f17eb88abd653ad4e18ec46ef10c9a63f8c99ebd",
-                "sha256:06ba444bbf7ede3890a912bd4904bb65bf0da8f0d8808b90545481362c978642",
-                "sha256:1f9974826aeeda32a76648fc677e3125ade379869a84aa964b683984a2dea9f1",
-                "sha256:330836ad89ff0be756b58758878409f591d4737b6a8cef26a162e2a4961c3321",
-                "sha256:38600fd58c2996829480de7d034fb2d3a0307110e44dae80b6b4f9b3d2eea529",
-                "sha256:3a195e26df1fbb40ebee75865f9b64ba692a5824ecb91c078cc665b01f7a9a36",
-                "sha256:41acdd6d64cd56f857e271009966c2ffcbd07ec9149ca91f71088574eaa4278a",
-                "sha256:45f97ade892ace20252e5ccecdd7515c7df5feeb42c3d2a8b8c55920c3551c30",
-                "sha256:4b0c211c55d4aac4309c3209833c803fada3fc21cdf7b74abedda42a0c9dc3ce",
-                "sha256:5d5209c3ba25864b1a57461526ebde31483db295fc6195fdfc4f8355e10f7376",
-                "sha256:615fb5a524cffc91ab4490b69e10ae76c1ccbfa3383ea2fad72e54a85c7d47dd",
-                "sha256:61e734c2bcb3742c3f454dfa930ea60ea08f56fd1a0eb52d8cb189a2f6be9586",
-                "sha256:640ccca4d0a6fcc6590f005ecd7b16c3d8f5d52174e4854f96b16f34c39d6cb7",
-                "sha256:6dbd51c3db300ce9d3171f4106da18fe49e7045232630fe3d4c6e37cb2b39ab9",
-                "sha256:71a904da8c9c02aee581f4452a5a988c3003207cb8033db426f29e5b2c0b7aea",
-                "sha256:8021dee64899f993f4b5cca323aae65aabc01a546ed44356a0965e29d7893c94",
-                "sha256:8b8d551f1bd60b3e1c59ff55b9e8d74607a5308f66e2916948cafd13480b44a3",
-                "sha256:93f9f720081d97acee38a411e861d4ce84cbc8ea5319bc1f8e38c972c47af49f",
-                "sha256:96f0c79a70642dfdf7e6a018ebcbea7ea5205e27d8e019cad442d2acfc9af267",
-                "sha256:9966337353e436e6ba652814b0a957a517feb492a98b8f9d3b6ba76d22301dcc",
-                "sha256:a34ba9e39f8269fd66ab4f7a802794ffea6d6ac500568ec05b327a862c21ce23",
-                "sha256:a49f85f0a099a5755d0a2cc6fc337e3cb945ad6390ec892332c691ab0a045882",
-                "sha256:a795829dc522227265d72b25d6ee6f6d41eb2105c15912c230097c8f5bfdbcdc",
-                "sha256:a89ca4105f8099de349d139d1090bad387fe2b208b717b288699ca26f179acbe",
-                "sha256:ac95101736239260189f426b1e361dc1b704513963357dc474beb0f39f5b7759",
-                "sha256:ae87ab669431f611c56e581679db33b9a467f87d7bf197ac384e71e4956b4456",
-                "sha256:b091dcfee169ad8de21b61eb2c3a75f9f0f859f851f64fdaf9320759a3244239",
-                "sha256:b511c6009d50d5c0dd0bab85ed25bc8ad6b6f5611de3a63a59786207e82824bb",
-                "sha256:b79dc2b2e313565416c1e62807c7c25c67a6ff0a0f8d83a318df464555b65948",
-                "sha256:bca14dfcfd9aae06d7d8d7e105539bd77d39d06caaae57a1ce945670bae744e0",
-                "sha256:c835c30f3af5c63a80917b72115e1defb83de99c73bc727bddd979a3b449e183",
-                "sha256:ccd721f1d4fc42b541b633d6e339018a08dd0290dc67269df79552843a06ca92",
-                "sha256:d6c2b1d78ceceb6741d703508cd0e9197b34f6bf6864dab30f940f8886e04ade",
-                "sha256:d6ec4ae13760ceda023b2e5ef1f9bc0b21e4b0830458db143794a117fdbdc044",
-                "sha256:d8b623fc429a38a881ab2d9a56ef30e8ea20c72a891c193f5ebbddc016e083ee",
-                "sha256:ea9753d64cba6f226947c318a923dadaf1e21cd8db02f71652405263daa1f033",
-                "sha256:ebbceefbffae118ab954d3cd6bf718f5790db66152f95202ebc231d58ad4e2c2",
-                "sha256:ecb6e7c45f9cd199c10ec35262b53b2247fb9a408803ed00ee5bb2b54aa626f5",
-                "sha256:ef9326c64349e2d718373415814e754183057ebc092261387a2c2f732d9172b2",
-                "sha256:f93a9d8804f4cec9da6c26c8cfae2c777028b4fdd9f49de0302e26e00bb86504",
-                "sha256:faf08b0341828f6a29b8f7dd94d5cf8cc7c39bfc3e67b78514c54b494b66915a"
+                "sha256:04f6b9749e335bb0d2f68c707f23bb1773c3fb6ecd10edf0f04df12a8920d468",
+                "sha256:08d74bfaa4c7731b8dac0a992c63673a2782758f7cfad34cf9c1b9184f911354",
+                "sha256:0fc1f8f06977c2d4f5e3d3f0d4a08089be783973fc6b6e278bde01f0544ff308",
+                "sha256:121f4b3185feaade3f85f70294aef3f777199e9b5c0c0245c774ae884b110a2d",
+                "sha256:1413b5022ed6ac0d504ba425ef02549a57d0f4276de58e3ab7e82437892704fc",
+                "sha256:1743345e30917e8c574f273f51679c294effba6ad372db1967852f12c76759d8",
+                "sha256:28fc475f560d8f67cc8767b94db4c9440210f6958495aeae70fac8faec631797",
+                "sha256:31a99a4796bf5aefc8351e98507b09e1b09115574f7c9dbb9cf2111f7220d2e2",
+                "sha256:328a1fad67445550b982caa2a2a850da5989fd6595e858f02d04636e7f8b0b13",
+                "sha256:473858730ef6d6ff7f7d5f19452184cd0caa062a20047f6d6f3e135a4648865d",
+                "sha256:4cde065ab33bcaab774d84096fae266d9301d1a2f5519d7bd58fc55274afbf7a",
+                "sha256:5f6a808044faae658f546dd5f525e921de9fa409de7a5570865467f03a626fc0",
+                "sha256:610b690b406653c84b7cb6091facb3033500ee81089867ee7d59e675f9ca2b73",
+                "sha256:66256b6391c057305e5ae9209941ef63c33a476b73772ca967d4a2df70520ec1",
+                "sha256:6eebf512aa90751d5ef6a7c2ac9d60113f32e86e5687326a50d7686e309f66ed",
+                "sha256:79aef6b5cd41feff359acaf98e040844613ff5298d0d19c455b3d9ae0bc8c35a",
+                "sha256:808ee5834e06f57978da3e003ad9d6292de69d2bf6263662a1a8ae30788e080b",
+                "sha256:8e44769068d33e0ea6ccdf4b84d80c5afffe5207aa4d1881a629cf0ef3ec398f",
+                "sha256:999ad08220467b6ad4bd3dd34e65329dd5d0df9b31e47106105e407954965256",
+                "sha256:9b006628fe43aa69259ec04ca258d88ed19b64791693df59c422b607b6ece8bb",
+                "sha256:9d05ad5367c90814099000442b2125535e9d77581855b9bee8780f1b41f2b1a2",
+                "sha256:a577a21de2ef8059b58f79ff76a4da81c45a75fe0bfb09bc8b7bb4293fa18983",
+                "sha256:a617593aeacc7a691cc4af4a4410031654f2909053bd8c8e7db837f179a630eb",
+                "sha256:abb48494d88e8a82601af905143e0de838c776c1241d92021e9256d5515b3645",
+                "sha256:ac88856a8cbccfc14f1b2d0b829af354cc1743cb375e7f04251ae73b2af6adf8",
+                "sha256:b4c220a1fe0d2c622493b0a1fd48f8f991998fb447d3cd368033a4b86cf1127a",
+                "sha256:b844fb09bd9936ed158ff9df0ab601e2045b316b17aa8b931857365ea8586906",
+                "sha256:bdc178caebd0f338d57ae445ef8e9b737ddf8fbc3ea187603f65aec5b041248f",
+                "sha256:c206587c83e795d417ed3adc8453a791f6d36b67c81416676cad053b4104152c",
+                "sha256:c61dcc1cf9fd165127a2853e2c31eb4fb961a4f26b394ac9fe5669c7a6592892",
+                "sha256:c7cb4c512d2d3b0870e00fbbac2f291d4b4bf2634d59a31176a87afe2777c6f0",
+                "sha256:d4a332404baa6665b54e5d283b4262f41f2103c255897084ec8f5487ce7b9e8e",
+                "sha256:d5111d4c843d80202e62b4fdbb4920db1dcee4f9366d6b03294f45ed7b18b42e",
+                "sha256:e1e8406b895aba6caa63d9fd1b6b1700d7e4825f78ccb1e5260551d168db38ed",
+                "sha256:e8690ed94481f219a7a967c118abaf71ccc440f69acd583cab721b90eeedb77c",
+                "sha256:ed283ab3a01d8b53de3a05bfdf4473ae24e43caee7dcb5584e86f3f3e5ab4374",
+                "sha256:ed4b50355b066796dacdd1cf538f2ce57275d001838f9b132fab80b75e8c84dd",
+                "sha256:ee329d0387b5b41a5dddbb6243a21cb7896587a651bebb957e2d2bb8b63c0791",
+                "sha256:f3bf1bc02bc421047bfec3343729c4bbbea42605bcfd6d6bfe2c07ade8b12d2a",
+                "sha256:f585cbbeecb35f35609edccb95efd95a3e35824cd7752b586503f7e6087303f1",
+                "sha256:f60667673ff9c249709160529ab39667d1ae9fd38634e006bec95611f632e759"
             ],
-            "version": "==2021.8.21"
+            "version": "==2021.8.28"
         },
         "requests": {
             "hashes": [
@@ -1104,6 +1105,22 @@
             ],
             "index": "pypi",
             "version": "==2.12.1"
+        },
+        "types-mock": {
+            "hashes": [
+                "sha256:1a470543be8de673e2ea14739622de3bfb8c9b10429f50338ba9ca1e868c15e9",
+                "sha256:1ad09970f4f5ec45a138ab1e88d032f010e851bccef7765b34737ed390bbc5c8"
+            ],
+            "index": "pypi",
+            "version": "==4.0.1"
+        },
+        "types-setuptools": {
+            "hashes": [
+                "sha256:4ead432cc394b8de5ee94a312494f3c730d21dbfef37f300a6ac5e742271d735",
+                "sha256:62c8dc465f29eeaad6b9025645138738d3df1cafc70cb0b14aea700946f2cbb7"
+            ],
+            "index": "pypi",
+            "version": "==57.0.2"
         },
         "typing-extensions": {
             "hashes": [

--- a/api/Pipfile.lock
+++ b/api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c8839d496ca1bb44594c87424f5b35ea9ce788f2a2c35467cebc0f6599ac68aa"
+            "sha256": "4f3264eeaf78ca4568edd6fd123820fde425a764b55296d6d25674d82b5d3247"
         },
         "pipfile-spec": 6,
         "requires": {

--- a/api/mypy.ini
+++ b/api/mypy.ini
@@ -4,7 +4,7 @@ show_error_codes = True
 warn_unused_configs = True
 strict = True
 # TODO(mc, 2021-09-13): remove these exclusions
-exclude = tests/opentrons/(algorithms|api|broker|calibration_storage|commands|config|data|drivers|hardware_control|protocol_api|protocols|system|tools|utils)
+exclude = tests/opentrons/(algorithms|api|broker|calibration_storage|commands|config|data|drivers|hardware_control|protocol_api|protocols|system|tools|util)
 
 [pydantic-mypy]
 init_forbid_extra = True
@@ -12,25 +12,150 @@ init_typed = True
 warn_required_dynamic_aliases = True
 warn_untyped_fields = True
 
-# TODO(mc, 2021-09-08): upgrade Pydantic and remove this override
-[mypy-pydantic.*]
-no_implicit_optional = False
-
 # TODO(mc, 2021-09-08): fix and remove any / all of the
 # overrides below whenever able
 
+# ~15 errors
+[mypy-opentrons.algorithms.*]
+disallow_any_generics = False
+warn_return_any = False
+
+# ~35 errors
+[mypy-opentrons.api.*]
+disallow_untyped_calls = False
+no_implicit_optional = False
+
+# ~60 errors
+[mypy-opentrons.calibration_storage.*]
+disallow_any_generics = False
+disallow_untyped_defs = False
+disallow_untyped_calls = False
+disallow_incomplete_defs = False
+no_implicit_optional = False
+warn_return_any = False
+
+# ~20 errors
+[mypy-opentrons.commands.*]
+disallow_untyped_defs = False
+disallow_any_generics = False
+disallow_untyped_calls = False
+no_implicit_optional = False
+
+# ~60 errors
+[mypy-opentrons.config.*]
+disallow_any_generics = False
+disallow_untyped_defs = False
+disallow_untyped_calls = False
+disallow_incomplete_defs = False
+no_implicit_optional = False
+warn_return_any = False
+
+# ~210 errors
+[mypy-opentrons.drivers.*]
+disallow_any_generics = False
+disallow_untyped_defs = False
+disallow_untyped_calls = False
+disallow_incomplete_defs = False
+no_implicit_optional = False
+warn_return_any = False
+
+# ~390 errors
+[mypy-opentrons.hardware_control.*]
+disallow_any_generics = False
+disallow_untyped_defs = False
+disallow_untyped_calls = False
+disallow_incomplete_defs = False
+no_implicit_optional = False
+warn_return_any = False
+
+# ~125 errors
+[mypy-opentrons.protocol_api.*]
+disallow_any_generics = False
+disallow_untyped_defs = False
+disallow_untyped_calls = False
+disallow_incomplete_defs = False
+no_implicit_optional = False
+warn_return_any = False
+
+# ~240 errors
 [mypy-opentrons.protocols.*]
 disallow_any_generics = False
 disallow_untyped_defs = False
 disallow_untyped_calls = False
 disallow_incomplete_defs = False
+no_implicit_optional = False
 warn_return_any = False
+
+# ~20 errors
+[mypy-opentrons.system.*]
+disallow_untyped_defs = False
+disallow_untyped_calls = False
+disallow_incomplete_defs = False
+no_implicit_optional = False
+warn_return_any = False
+
+# ~5 errors
+[mypy-opentrons.tools.*]
+disallow_untyped_defs = False
+disallow_untyped_calls = False
+disallow_incomplete_defs = False
 no_implicit_optional = False
 
-[mypy-tests.opentrons.conftest]
-# ~40 errors
-disallow_untyped_defs = False
-# ~10 errors
-disallow_untyped_calls = False
 # ~5 errors
+[mypy-opentrons.util.*]
+disallow_any_generics = False
+disallow_untyped_defs = False
 disallow_incomplete_defs = False
+warn_return_any = False
+
+# ~5 errors (`__init__.py` file)
+[mypy-opentrons]
+disallow_untyped_defs = False
+disallow_untyped_calls = False
+disallow_incomplete_defs = False
+
+# ~10 errors
+[mypy-opentrons.broker]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+# ~15 errors
+[mypy-opentrons.execute]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+disallow_untyped_calls = False
+no_implicit_optional = False
+
+# ~25 errors
+[mypy-opentrons.simulate]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+disallow_untyped_calls = False
+no_implicit_optional = False
+
+# ~5 errors
+[mypy-opentrons.types]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+# ~55 errors
+[mypy-tests.opentrons.conftest]
+disallow_untyped_defs = False
+disallow_untyped_calls = False
+disallow_incomplete_defs = False
+
+# ~25 errors (some suppressed by type: ignore)
+[mypy-tests.opentrons.test_execute]
+disallow_untyped_defs = False
+
+# 1 errors (some suppressed by type: ignore)
+[mypy-tests.opentrons.test_init]
+disallow_untyped_defs = False
+
+# ~10 errors (some suppressed by type: ignore)
+[mypy-tests.opentrons.test_simulate]
+disallow_untyped_defs = False
+
+# ~5 errors
+[mypy-tests.opentrons.test_types]
+disallow_untyped_defs = False

--- a/api/mypy.ini
+++ b/api/mypy.ini
@@ -3,8 +3,8 @@ plugins = pydantic.mypy, decoy.mypy
 show_error_codes = True
 warn_unused_configs = True
 strict = True
-# TODO(mc, 2021-09-13): remove these exclusions
-exclude = tests/opentrons/(algorithms|api|broker|calibration_storage|commands|config|data|drivers|hardware_control|protocol_api|protocols|system|tools|util)
+# TODO(mc, 2021-09-13): work through and remove these exclusions
+exclude = tests/opentrons/(hardware_control|protocol_api|protocols)/
 
 [pydantic-mypy]
 init_forbid_extra = True
@@ -138,6 +138,60 @@ no_implicit_optional = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
+# ~10 errors
+[mypy-tests.opentrons.algorithms.*]
+disallow_any_generics = False
+
+# ~30 errors
+[mypy-tests.opentrons.api.*]
+disallow_untyped_defs = False
+disallow_untyped_calls = False
+strict_equality = False
+warn_return_any = False
+
+# ~15 errors
+[mypy-tests.opentrons.broker.*]
+disallow_untyped_defs = False
+disallow_untyped_calls = False
+
+# ~5 errors
+[mypy-tests.opentrons.calibration_storage.*]
+disallow_untyped_defs = False
+
+# ~5 errors
+[mypy-tests.opentrons.commands.*]
+disallow_untyped_defs = False
+disallow_untyped_calls = False
+
+# ~5 errors
+[mypy-tests.opentrons.config.*]
+disallow_untyped_defs = False
+disallow_untyped_calls = False
+no_implicit_optional = False
+
+# ~5 errors
+[mypy-tests.opentrons.data.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+# ~30 errors
+[mypy-tests.opentrons.drivers.*]
+disallow_untyped_defs = False
+disallow_untyped_calls = False
+disallow_incomplete_defs = False
+
+# ~10 errors
+[mypy-tests.opentrons.system.*]
+disallow_untyped_defs = False
+disallow_untyped_calls = False
+disallow_incomplete_defs = False
+
+# ~10 errors
+[mypy-tests.opentrons.util.*]
+disallow_untyped_defs = False
+; disallow_untyped_calls = False
+; disallow_incomplete_defs = False
+
 # ~55 errors
 [mypy-tests.opentrons.conftest]
 disallow_untyped_defs = False
@@ -148,7 +202,7 @@ disallow_incomplete_defs = False
 [mypy-tests.opentrons.test_execute]
 disallow_untyped_defs = False
 
-# 1 errors (some suppressed by type: ignore)
+# 1 error (some suppressed by type: ignore)
 [mypy-tests.opentrons.test_init]
 disallow_untyped_defs = False
 

--- a/api/mypy.ini
+++ b/api/mypy.ini
@@ -1,41 +1,36 @@
 [mypy]
 plugins = pydantic.mypy, decoy.mypy
 show_error_codes = True
-
-# TODO(mc, 2021-09-02): replace the the following flags
-# with `strict = True` when able
 warn_unused_configs = True
-disallow_subclassing_any = True
-check_untyped_defs = True
-warn_redundant_casts = True
-strict_equality = True
-warn_unused_ignores = True
-disallow_untyped_decorators = True
-# disallow_any_generics = True
-# disallow_untyped_calls = True
-# disallow_untyped_defs = True
-# disallow_incomplete_defs = True
-# no_implicit_optional = True
-# warn_return_any = True
-# no_implicit_reexport = True
-
-# end strict mode flags
-
-
-[mypy-opentrons.server.serialize]
-check_untyped_defs = False
-
-[mypy-opentrons.server.rpc]
-check_untyped_defs = False
-
-[mypy-opentrons.tools.*]
-check_untyped_defs = False
-
-[mypy-opentrons.helpers.*]
-check_untyped_defs = False
+strict = True
+# TODO(mc, 2021-09-13): remove these exclusions
+exclude = tests/opentrons/(algorithms|api|broker|calibration_storage|commands|config|data|drivers|hardware_control|protocol_api|protocols|system|tools|utils)
 
 [pydantic-mypy]
 init_forbid_extra = True
 init_typed = True
 warn_required_dynamic_aliases = True
 warn_untyped_fields = True
+
+# TODO(mc, 2021-09-08): upgrade Pydantic and remove this override
+[mypy-pydantic.*]
+no_implicit_optional = False
+
+# TODO(mc, 2021-09-08): fix and remove any / all of the
+# overrides below whenever able
+
+[mypy-opentrons.protocols.*]
+disallow_any_generics = False
+disallow_untyped_defs = False
+disallow_untyped_calls = False
+disallow_incomplete_defs = False
+warn_return_any = False
+no_implicit_optional = False
+
+[mypy-tests.opentrons.conftest]
+# ~40 errors
+disallow_untyped_defs = False
+# ~10 errors
+disallow_untyped_calls = False
+# ~5 errors
+disallow_incomplete_defs = False

--- a/api/mypy.ini
+++ b/api/mypy.ini
@@ -3,7 +3,7 @@ plugins = pydantic.mypy, decoy.mypy
 show_error_codes = True
 warn_unused_configs = True
 strict = True
-# TODO(mc, 2021-09-13): work through and remove these exclusions
+# TODO(mc, 2021-09-12): work through and remove these exclusions
 exclude = tests/opentrons/(hardware_control|protocol_api|protocols)/
 
 [pydantic-mypy]

--- a/api/src/opentrons/algorithms/types.py
+++ b/api/src/opentrons/algorithms/types.py
@@ -21,7 +21,7 @@ class GenericNode(Generic[VertexName]):
     """
 
     name: VertexName
-    sub_names: List[str]
+    sub_names: List[VertexName]
 
     def __hash__(self) -> int:
         """Hash function.

--- a/api/src/opentrons/api/calibration.py
+++ b/api/src/opentrons/api/calibration.py
@@ -28,7 +28,7 @@ def _well0(cont: labware.Labware) -> labware.Well:
     return cont.wells()[0]
 
 
-Func = TypeVar("Func", bound=Callable)
+Func = TypeVar("Func", bound=Callable[..., Any])
 
 
 def _home_if_first_call(func: Func) -> Func:

--- a/api/src/opentrons/api/models.py
+++ b/api/src/opentrons/api/models.py
@@ -2,13 +2,14 @@ from typing import cast, List, Optional, Tuple
 from opentrons.types import Point
 from opentrons.protocol_api import labware, InstrumentContext, ProtocolContext
 
-from opentrons.protocols.geometry import module_geometry
+from opentrons.hardware_control.modules.types import ModuleType
+from opentrons.protocols.geometry.module_geometry import ModuleGeometry
 
 
 def _get_parent_slot_and_position(
     labware_obj: labware.Labware,
 ) -> Tuple[str, Optional[Point]]:
-    if isinstance(labware_obj.parent, (module_geometry.ModuleGeometry)):
+    if isinstance(labware_obj.parent, (ModuleGeometry)):
         return (cast(str, labware_obj.parent.parent), labware_obj.parent.labware_offset)
     else:
         return (cast(str, labware_obj.parent), None)
@@ -74,14 +75,12 @@ class Instrument:
 
 
 class Module:
-    def __init__(
-        self, module: module_geometry.ModuleGeometry, context: ProtocolContext
-    ) -> None:
+    def __init__(self, module: ModuleGeometry, context: ProtocolContext) -> None:
         self.id = id(module)
         _type_lookup = {
-            module_geometry.ModuleType.MAGNETIC: "magdeck",
-            module_geometry.ModuleType.TEMPERATURE: "tempdeck",
-            module_geometry.ModuleType.THERMOCYCLER: "thermocycler",
+            ModuleType.MAGNETIC: "magdeck",
+            ModuleType.TEMPERATURE: "tempdeck",
+            ModuleType.THERMOCYCLER: "thermocycler",
         }
         self.name = _type_lookup[module.module_type]
         self.model = module.model.value

--- a/api/src/opentrons/commands/publisher.py
+++ b/api/src/opentrons/commands/publisher.py
@@ -1,6 +1,6 @@
 import functools
 import inspect
-from typing import Any, Callable, cast, Dict, Tuple, Mapping, Generic, TypeVar
+from typing import Any, Callable, Dict, Generic, Mapping, Optional, Tuple, TypeVar, cast
 from opentrons.broker import Broker
 from . import types as command_types
 
@@ -28,7 +28,7 @@ getfullargspec_cache = InspectMemoizer(inspect.getfullargspec)
 
 
 class CommandPublisher:
-    def __init__(self, broker: Broker) -> None:
+    def __init__(self, broker: Optional[Broker]) -> None:
         self._broker = broker or Broker()
 
     @property

--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import logging
 import json
 import numbers
-from typing import Any, Dict, List, Union, Tuple, Sequence, TYPE_CHECKING
+from typing import Any, Dict, List, Mapping, Union, Tuple, Sequence, TYPE_CHECKING
 
 from opentrons import config
 from opentrons.config import feature_flags as ff
@@ -245,7 +245,7 @@ def piecewise_volume_conversion(ul: float, sequence: List[List[float]]) -> float
     raise IndexError()
 
 
-TypeOverrides = Dict[str, Union[float, bool, None]]
+TypeOverrides = Mapping[str, Union[float, bool, None]]
 
 
 def validate_overrides(data: TypeOverrides, config_model: Dict) -> None:

--- a/api/src/opentrons/drivers/temp_deck/driver.py
+++ b/api/src/opentrons/drivers/temp_deck/driver.py
@@ -15,9 +15,10 @@ from typing import Dict, Optional
 from enum import Enum
 
 from opentrons.drivers import utils
+from opentrons.drivers.types import Temperature
 from opentrons.drivers.command_builder import CommandBuilder
 from opentrons.drivers.asyncio.communication import SerialConnection
-from opentrons.drivers.temp_deck.abstract import AbstractTempDeckDriver, Temperature
+from opentrons.drivers.temp_deck.abstract import AbstractTempDeckDriver
 
 log = logging.getLogger(__name__)
 

--- a/api/src/opentrons/drivers/temp_deck/simulator.py
+++ b/api/src/opentrons/drivers/temp_deck/simulator.py
@@ -1,6 +1,7 @@
 from typing import Optional, Dict
 
-from opentrons.drivers.temp_deck.abstract import AbstractTempDeckDriver, Temperature
+from opentrons.drivers.types import Temperature
+from opentrons.drivers.temp_deck.abstract import AbstractTempDeckDriver
 
 TEMP_DECK_MODELS = {
     "temperatureModuleV1": "temp_deck_v1.1",

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -11,7 +11,8 @@ functions are available elsewhere.
 """
 
 from .adapters import SynchronousAdapter
-from .api import API, PauseManager
+from .api import API
+from .pause_manager import PauseManager
 from .controller import Controller
 from .simulator import Simulator
 from .pipette import Pipette

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -619,7 +619,7 @@ class API(HardwareAPILike):
 
         asyncio.run_coroutine_threadsafe(_chained_calls(), self._loop)
 
-    async def halt(self):
+    async def halt(self) -> None:
         """Immediately stop motion.
 
         Calls to :py:meth:`stop` through the synch adapter while other calls

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -114,7 +114,7 @@ class TempDeck(mod_abc.AbstractModule):
         return self._model_from_revision(self._device_info.get("model"))
 
     @classmethod
-    def bootloader(cls) -> mod_abc.UploadFunction:
+    def bootloader(cls) -> types.UploadFunction:
         return update.upload_via_avrdude
 
     async def wait_next_poll(self) -> None:

--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -6,6 +6,8 @@ from dataclasses import asdict, replace
 import logging
 from typing import Any, Dict, Optional, Set, Tuple, Union, TYPE_CHECKING
 
+from opentrons_shared_data.pipette import name_config as pipette_name_config
+
 from opentrons.types import Point
 from opentrons.calibration_storage.types import PipetteOffsetByPipetteMount
 from opentrons.config import pipette_config, robot_configs
@@ -87,7 +89,7 @@ class Pipette:
         assert name in self._config.back_compat_names + [
             self.name
         ], f"{self._name} is not back-compatible with {name}"
-        name_conf = pipette_config.name_config()
+        name_conf = pipette_name_config()
         bc_conf = name_conf[name]
         self.working_volume = bc_conf["maxVolume"]
         self.update_config_item("min_volume", bc_conf["minVolume"])

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -16,6 +16,7 @@ from typing import (
 from collections import OrderedDict
 
 from opentrons.hardware_control import SynchronousAdapter, ThreadManager
+from opentrons.hardware_control.modules.types import ModuleType
 from opentrons import types
 from opentrons.commands import protocol_commands as cmds, types as cmd_types
 from opentrons.commands.publisher import CommandPublisher, publish
@@ -30,7 +31,7 @@ from opentrons.protocols.types import Protocol
 from .labware import Labware
 from opentrons.protocols.context.labware import AbstractLabware
 from opentrons.protocols.context.protocol import AbstractProtocol
-from opentrons.protocols.geometry.module_geometry import ModuleGeometry, ModuleType
+from opentrons.protocols.geometry.module_geometry import ModuleGeometry
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 from .instrument_context import InstrumentContext

--- a/api/src/opentrons/protocol_api_experimental/pipette_context.py
+++ b/api/src/opentrons/protocol_api_experimental/pipette_context.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Optional, Union, Sequence, List
+from typing import Any, Optional, Union, Sequence, List
 
-from .labware import Well, Labware
+from .labware import Labware
+from .well import Well
 
-from opentrons import APIVersion, types
+from opentrons import types
+from opentrons.protocols.api_support.types import APIVersion
 from opentrons.hardware_control.dev_types import PipetteDict
 
 # todo(mm, 2021-04-09): Duplicate these classes in this package to
@@ -88,7 +90,7 @@ class PipetteContext:  # noqa: D101
     def aspirate(  # noqa: D102
         self,
         volume: Optional[float] = None,
-        location: Union[types.Location, Well] = None,
+        location: Optional[Union[types.Location, Well]] = None,
         rate: float = 1.0,
     ) -> PipetteContext:
 
@@ -128,7 +130,7 @@ class PipetteContext:  # noqa: D101
     def dispense(  # noqa: D102
         self,
         volume: Optional[float] = None,
-        location: Union[types.Location, Well] = None,
+        location: Optional[Union[types.Location, Well]] = None,
         rate: float = 1.0,
     ) -> PipetteContext:
 
@@ -161,14 +163,14 @@ class PipetteContext:  # noqa: D101
         self,
         repetitions: int = 1,
         volume: Optional[float] = None,
-        location: Union[types.Location, Well] = None,
+        location: Optional[Union[types.Location, Well]] = None,
         rate: float = 1.0,
     ) -> PipetteContext:
         raise NotImplementedError()
 
     def blow_out(  # noqa: D102
         self,
-        location: Union[types.Location, Well] = None,
+        location: Optional[Union[types.Location, Well]] = None,
     ) -> PipetteContext:
         raise NotImplementedError()
 
@@ -193,7 +195,7 @@ class PipetteContext:  # noqa: D101
 
     def pick_up_tip(  # noqa: D102
         self,
-        location: Union[types.Location, Well] = None,
+        location: Optional[Union[types.Location, Well]] = None,
         presses: Optional[int] = None,
         increment: Optional[float] = None,
     ) -> PipetteContext:
@@ -217,7 +219,7 @@ class PipetteContext:  # noqa: D101
 
     def drop_tip(  # noqa: D102
         self,
-        location: Union[types.Location, Well] = None,
+        location: Optional[Union[types.Location, Well]] = None,
         home_after: bool = True,
     ) -> PipetteContext:
         # TODO(al, 2021-04-12): What about home_after?
@@ -241,33 +243,36 @@ class PipetteContext:  # noqa: D101
     def home_plunger(self) -> PipetteContext:  # noqa: D102
         raise NotImplementedError()
 
+    # TODO(mc, 2021-09-13): explicitely type kwargs, remove args
     def distribute(  # noqa: D102
         self,
         volume: Union[float, Sequence[float]],
         source: Well,
         dest: List[Well],
-        *args,  # noqa: ANN002
-        **kwargs,  # noqa: ANN003
+        *args: Any,
+        **kwargs: Any,
     ) -> PipetteContext:
         raise NotImplementedError()
 
+    # TODO(mc, 2021-09-13): explicitely type kwargs, remove args
     def consolidate(  # noqa: D102
         self,
         volume: Union[float, Sequence[float]],
         source: List[Well],
         dest: Well,
-        *args,  # noqa: ANN002
-        **kwargs,  # noqa: ANN003
+        *args: Any,
+        **kwargs: Any,
     ) -> PipetteContext:
         raise NotImplementedError()
 
+    # TODO(mc, 2021-09-13): explicitely type kwargs
     def transfer(  # noqa: D102
         self,
         volume: Union[float, Sequence[float]],
         source: AdvancedLiquidHandling,
         dest: AdvancedLiquidHandling,
         trash: bool = True,
-        **kwargs,  # noqa: ANN003
+        **kwargs: Any,
     ) -> PipetteContext:
         raise NotImplementedError()
 

--- a/api/src/opentrons/protocol_api_experimental/pipette_context.py
+++ b/api/src/opentrons/protocol_api_experimental/pipette_context.py
@@ -243,7 +243,7 @@ class PipetteContext:  # noqa: D101
     def home_plunger(self) -> PipetteContext:  # noqa: D102
         raise NotImplementedError()
 
-    # TODO(mc, 2021-09-13): explicitely type kwargs, remove args
+    # TODO(mc, 2021-09-12): explicitely type kwargs, remove args
     def distribute(  # noqa: D102
         self,
         volume: Union[float, Sequence[float]],
@@ -254,7 +254,7 @@ class PipetteContext:  # noqa: D101
     ) -> PipetteContext:
         raise NotImplementedError()
 
-    # TODO(mc, 2021-09-13): explicitely type kwargs, remove args
+    # TODO(mc, 2021-09-12): explicitely type kwargs, remove args
     def consolidate(  # noqa: D102
         self,
         volume: Union[float, Sequence[float]],
@@ -265,7 +265,7 @@ class PipetteContext:  # noqa: D101
     ) -> PipetteContext:
         raise NotImplementedError()
 
-    # TODO(mc, 2021-09-13): explicitely type kwargs
+    # TODO(mc, 2021-09-12): explicitely type kwargs
     def transfer(  # noqa: D102
         self,
         volume: Union[float, Sequence[float]],

--- a/api/src/opentrons/protocol_engine/execution/queue_worker.py
+++ b/api/src/opentrons/protocol_engine/execution/queue_worker.py
@@ -28,7 +28,7 @@ class QueueWorker:
         """
         self._state_store: StateStore = state_store
         self._command_executor: CommandExecutor = command_executor
-        self._worker_task: Optional[asyncio.Task] = None
+        self._worker_task: Optional["asyncio.Task[None]"] = None
 
     def start(self) -> None:
         """Start processing jobs.

--- a/api/src/opentrons/protocol_engine/resources/deck_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/deck_data_provider.py
@@ -49,8 +49,8 @@ class DeckDataProvider:
 
         for fixture in deck_definition["locations"]["fixtures"]:
             labware_id = fixture["id"]
-            load_name = cast(Optional[str], fixture.get("labware", None))
-            slot = cast(Optional[str], fixture.get("slot", None))
+            load_name = cast(Optional[str], fixture.get("labware"))
+            slot = cast(Optional[str], fixture.get("slot"))
 
             if load_name is not None and slot is not None:
                 location = DeckSlotLocation(slot=DeckSlotName.from_primitive(slot))

--- a/api/src/opentrons/protocol_engine/resources/deck_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/deck_data_provider.py
@@ -1,6 +1,6 @@
 """Deck data resource provider."""
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, cast
 from typing_extensions import final
 
 from opentrons_shared_data.deck import load as load_deck
@@ -49,8 +49,8 @@ class DeckDataProvider:
 
         for fixture in deck_definition["locations"]["fixtures"]:
             labware_id = fixture["id"]
-            load_name = fixture.get("labware")  # type: ignore[misc]
-            slot = fixture.get("slot")  # type: ignore[misc]
+            load_name = cast(Optional[str], fixture.get("labware", None))
+            slot = cast(Optional[str], fixture.get("slot", None))
 
             if load_name is not None and slot is not None:
                 location = DeckSlotLocation(slot=DeckSlotName.from_primitive(slot))

--- a/api/src/opentrons/protocol_runner/json_command_translator.py
+++ b/api/src/opentrons/protocol_runner/json_command_translator.py
@@ -1,5 +1,5 @@
 """Translation of JSON protocol commands into ProtocolEngine commands."""
-from typing import Dict, List
+from typing import Dict, List, cast
 
 from opentrons.types import DeckSlotName, MountType
 from opentrons.protocols import models
@@ -52,7 +52,7 @@ class JsonCommandTranslator:
     ) -> pe_commands.CommandRequest:
         try:
             h = self._COMMAND_TO_NAME[command.command]
-            return getattr(self, h)(command)
+            return cast(pe_commands.CommandRequest, getattr(self, h)(command))
         except KeyError:
             raise CommandTranslatorError(f"'{command.command}' is not recognized.")
         except AttributeError:

--- a/api/src/opentrons/protocol_runner/python_file_reader.py
+++ b/api/src/opentrons/protocol_runner/python_file_reader.py
@@ -15,7 +15,7 @@ class PythonProtocol:
 
     def run(self, context: ProtocolContext) -> None:
         """Call the protocol module's run method."""
-        return self._protocol_module.run(context)  # type: ignore[attr-defined]
+        self._protocol_module.run(context)  # type: ignore[attr-defined]
 
 
 class PythonFileReader:
@@ -33,6 +33,11 @@ class PythonFileReader:
             name="protocol",
             location=protocol_file.files[0],
         )
+
+        # TODO(mc, 2021-09-13): figure out why this would happen and raise
+        # a well defined error accordingly
+        assert spec is not None, "Unable to load module spec from file"
+
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)  # type: ignore[union-attr]
 

--- a/api/src/opentrons/protocol_runner/python_file_reader.py
+++ b/api/src/opentrons/protocol_runner/python_file_reader.py
@@ -34,7 +34,7 @@ class PythonFileReader:
             location=protocol_file.files[0],
         )
 
-        # TODO(mc, 2021-09-13): figure out why this would happen and raise
+        # TODO(mc, 2021-09-12): figure out why this would happen and raise
         # a well defined error accordingly
         assert spec is not None, "Unable to load module spec from file"
 

--- a/api/src/opentrons/protocol_runner/task_queue.py
+++ b/api/src/opentrons/protocol_runner/task_queue.py
@@ -29,7 +29,7 @@ class TaskQueue:
         """Initialize the TaskQueue."""
         self._run_entry: Optional[TaskQueueEntry] = None
         self._cleanup_entry: Optional[TaskQueueEntry] = None
-        self._run_task: Optional[asyncio.Task] = None
+        self._run_task: Optional["asyncio.Task[None]"] = None
         self._run_started_event: asyncio.Event = asyncio.Event()
 
     def add(

--- a/api/src/opentrons/protocols/context/protocol.py
+++ b/api/src/opentrons/protocols/context/protocol.py
@@ -8,9 +8,10 @@ from typing import Dict, Optional, Union
 
 from opentrons import types
 from opentrons.hardware_control import SynchronousAdapter, ThreadManager
+from opentrons.hardware_control.modules.types import ModuleType
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.protocols.geometry.deck_item import DeckItem
-from opentrons.protocols.geometry.module_geometry import ModuleGeometry, ModuleType
+from opentrons.protocols.geometry.module_geometry import ModuleGeometry
 from opentrons.protocols.context.instrument import AbstractInstrument
 from opentrons.protocols.api_support.util import AxisMaxSpeeds, HardwareManager
 from opentrons.protocols.context.labware import AbstractLabware

--- a/api/src/opentrons/protocols/context/simulator/instrument_context.py
+++ b/api/src/opentrons/protocols/context/simulator/instrument_context.py
@@ -1,9 +1,10 @@
 import typing
 
-from opentrons import types, APIVersion
+from opentrons import types
 from opentrons.hardware_control import NoTipAttachedError, TipAttachedError
 from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.hardware_control.types import HardwareAction
+from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 from opentrons.protocols.api_support.labware_like import LabwareLike
 from opentrons.protocols.api_support.util import FlowRates, PlungerSpeeds, Clearances

--- a/api/src/opentrons/protocols/duration/estimator.py
+++ b/api/src/opentrons/protocols/duration/estimator.py
@@ -96,7 +96,7 @@ class DurationEstimator:
             )
             return
 
-        location = payload.get("location")  # type: ignore
+        location = payload.get("location")
 
         try:
             duration = self.handle_message(message_name, payload)

--- a/api/src/opentrons/protocols/geometry/deck.py
+++ b/api/src/opentrons/protocols/geometry/deck.py
@@ -8,9 +8,9 @@ from opentrons.protocol_api.labware import load as load_lw, Labware
 from opentrons.protocols.api_support.constants import STANDARD_DECK
 from opentrons.protocols.api_support.labware_like import LabwareLike
 from opentrons.protocols.geometry.deck_item import DeckItem
+from opentrons.hardware_control.modules.types import ModuleType
 from opentrons.protocols.geometry.module_geometry import (
     ModuleGeometry,
-    ModuleType,
     ThermocyclerGeometry,
 )
 from opentrons_shared_data.deck import load as load_deck
@@ -261,16 +261,12 @@ class Deck(UserDict):
     def get_fixed_trash(self) -> Optional[Labware]:
         fixtures = self._definition["locations"]["fixtures"]
         ft = next((f for f in fixtures if f["id"] == FIXED_TRASH_ID), None)
-        return (
-            self.data[self._check_name(ft.get("slot"))] if ft else None  # type: ignore
-        )
+        return self.data[self._check_name(ft.get("slot"))] if ft else None
 
     def get_non_fixture_slots(self) -> List[types.DeckLocation]:
         fixtures = self._definition["locations"]["fixtures"]
         fixture_slots = {
-            self._check_name(f.get("slot"))  # type: ignore[misc]
-            for f in fixtures
-            if f.get("slot")  # type: ignore[misc]
+            self._check_name(f.get("slot")) for f in fixtures if f.get("slot")
         }
         return [s for s in self.data.keys() if s not in fixture_slots]
 

--- a/api/src/opentrons/protocols/geometry/module_geometry.py
+++ b/api/src/opentrons/protocols/geometry/module_geometry.py
@@ -468,7 +468,7 @@ def load_module_from_definition(
                                  defaults to :py:attr:`.MAX_SUPPORTED_VERSION`.
     """
     api_level = api_level or MAX_SUPPORTED_VERSION
-    # def not yet discriminated, mypy complains sadly
+    # def not yet discriminated, mypy returns `object` type
     schema = definition.get("$otSharedSchema")
     if not schema:
         # v1 definitions don't have schema versions

--- a/api/src/opentrons/protocols/geometry/module_geometry.py
+++ b/api/src/opentrons/protocols/geometry/module_geometry.py
@@ -469,7 +469,7 @@ def load_module_from_definition(
     """
     api_level = api_level or MAX_SUPPORTED_VERSION
     # def not yet discriminated, mypy complains sadly
-    schema = definition.get("$otSharedSchema")  # type: ignore
+    schema = definition.get("$otSharedSchema")
     if not schema:
         # v1 definitions don't have schema versions
         # but unfortunately we can't tell mypy that because it can only

--- a/api/src/opentrons/util/entrypoint_util.py
+++ b/api/src/opentrons/util/entrypoint_util.py
@@ -4,7 +4,7 @@
 import logging
 from json import JSONDecodeError
 import pathlib
-from typing import Dict, List, TYPE_CHECKING
+from typing import Dict, Sequence, Union, TYPE_CHECKING
 
 from jsonschema import ValidationError  # type: ignore
 
@@ -16,7 +16,9 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
-def labware_from_paths(paths: List[str]) -> Dict[str, "LabwareDefinition"]:
+def labware_from_paths(
+    paths: Sequence[Union[str, pathlib.Path]]
+) -> Dict[str, "LabwareDefinition"]:
     labware_defs: Dict[str, "LabwareDefinition"] = {}
 
     for strpath in paths:
@@ -44,7 +46,7 @@ def labware_from_paths(paths: List[str]) -> Dict[str, "LabwareDefinition"]:
     return labware_defs
 
 
-def datafiles_from_paths(paths: List[str]) -> Dict[str, bytes]:
+def datafiles_from_paths(paths: Sequence[Union[str, pathlib.Path]]) -> Dict[str, bytes]:
     datafiles: Dict[str, bytes] = {}
     for strpath in paths:
         log.info(f"data files: checking path {strpath}")

--- a/api/tests/opentrons/algorithms/__init__.py
+++ b/api/tests/opentrons/algorithms/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for opentrons.algorithms."""

--- a/api/tests/opentrons/algorithms/test_dfs.py
+++ b/api/tests/opentrons/algorithms/test_dfs.py
@@ -1,13 +1,13 @@
 """Test the DFS module.
 
-Generic testing of a depth first search algo
+Generic testing of a depth first search algorithm.
 """
 from pathlib import Path
 
 import pytest
 import json
 import os
-from typing import Callable, List, Tuple, Any
+from typing import Any, Callable, List, Set, Tuple, Union
 
 from opentrons.algorithms import dfs, types
 
@@ -49,10 +49,10 @@ def dfs_graph(request: Any) -> Tuple[dfs.DFS, str]:
     """
     graph = request.param[0]
     _type = request.param[1]
-    yield dfs.DFS(graph), _type
+    return dfs.DFS(graph), _type
 
 
-def test_vertices(dfs_graph: dfs.DFS) -> None:
+def test_vertices(dfs_graph: Tuple[dfs.DFS, str]) -> None:
     """Test vertices.
 
     Test adding and removing the vertices of a graph.
@@ -62,6 +62,7 @@ def test_vertices(dfs_graph: dfs.DFS) -> None:
     """
     _dfs, _type = dfs_graph
     graph = _dfs.graph
+    additional_vertex: Union[types.GenericNode[str], types.GenericNode[int]]
     if _type == "string":
         additional_vertex = types.GenericNode(name="K", sub_names=["H", "J", "A"])
     else:
@@ -75,7 +76,7 @@ def test_vertices(dfs_graph: dfs.DFS) -> None:
     assert vertex_obj not in graph._sorted_graph
 
 
-def test_neighbors(dfs_graph: dfs.DFS) -> None:
+def test_neighbors(dfs_graph: Tuple[dfs.DFS, str]) -> None:
     """Test neighbors.
 
     Test adding neighbors to a vertex.
@@ -84,10 +85,10 @@ def test_neighbors(dfs_graph: dfs.DFS) -> None:
     _dfs, _type = dfs_graph
     graph = _dfs.graph
     if _type == "string":
-        key = "A"
-        neighbor = "J"
-        og_neighbors = ["B", "E"]
-        sorted_neighbors = ["B", "E", "J"]
+        key: Union[str, int] = "A"
+        neighbor: Union[str, int] = "J"
+        og_neighbors: Union[List[str], List[int]] = ["B", "E"]
+        sorted_neighbors: Union[List[str], List[int]] = ["B", "E", "J"]
     else:
         key = 1
         neighbor = 4
@@ -101,7 +102,7 @@ def test_neighbors(dfs_graph: dfs.DFS) -> None:
     assert vertex.neighbors == og_neighbors
 
 
-def test_depth_first_search(dfs_graph: dfs.DFS) -> None:
+def test_depth_first_search(dfs_graph: Tuple[dfs.DFS, str]) -> None:
     """Test the depth first search algorithm.
 
     The method should dig down into the bottom leaf node
@@ -109,6 +110,7 @@ def test_depth_first_search(dfs_graph: dfs.DFS) -> None:
     """
     _dfs, _type = dfs_graph
     visited_vertices = _dfs.dfs()
+    sort: Union[Set[str], Set[int]]
     if _type == "string":
         sort = {"A", "B", "F", "G", "C", "J", "I", "H", "D", "E"}
     else:

--- a/api/tests/opentrons/api/test_calibration.py
+++ b/api/tests/opentrons/api/test_calibration.py
@@ -1,12 +1,12 @@
 import pytest
 from unittest import mock
 from functools import partial
-from tests.opentrons.conftest import state
+from tests.opentrons.conftest import state as _state
 from opentrons.types import Point, Mount
 from opentrons.hardware_control import CriticalPoint, API
 from opentrons.hardware_control.types import MotionChecks
 
-state = partial(state, "calibration")
+state = partial(_state, "calibration")
 
 
 @pytest.mark.api2_only

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -90,8 +90,8 @@ async def test_load_and_run_v2(main_router, protocol, protocol_file, loop):
 def test_accumulate():
     res = _accumulate(
         [
-            (["a"], ["d"], ["g", "h"], [("l", "m")]),
-            (["b", "c"], ["e", "f"], ["i"], [("m", "n")]),
+            (["a"], ["d"], ["g", "h"], [("l", "m")]),  # type: ignore[list-item]
+            (["b", "c"], ["e", "f"], ["i"], [("m", "n")]),  # type: ignore[list-item]
         ]
     )
 

--- a/api/tests/opentrons/config/test_advanced_settings.py
+++ b/api/tests/opentrons/config/test_advanced_settings.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import patch
 
-from opentrons.config import advanced_settings, CONFIG
+from opentrons.config import advanced_settings, ARCHITECTURE, CONFIG
 
 
 @pytest.fixture
@@ -54,6 +54,7 @@ def test_get_advanced_setting_found(
 ):
     for k, v in mock_settings_values.items():
         s = advanced_settings.get_adv_setting(k)
+        assert s is not None
         assert s.value == v
         assert s.definition == advanced_settings.settings_by_id[k]
 
@@ -199,7 +200,7 @@ async def test_disable_log_integration_side_effect(loop, v, expected_level):
         mock_log_control.set_syslog_level.side_effect = set_syslog_level
         with patch(
             "opentrons.config.advanced_settings.ARCHITECTURE",
-            new=advanced_settings.ARCHITECTURE.BUILDROOT,
+            new=ARCHITECTURE.BUILDROOT,
         ):
             s = advanced_settings.DisableLogIntegrationSettingDefinition()
             await s.on_change(v)
@@ -215,7 +216,7 @@ async def test_disable_log_integration_side_effect_error(loop):
         mock_log_control.set_syslog_level.side_effect = set_syslog_level
         with patch(
             "opentrons.config.advanced_settings.ARCHITECTURE",
-            new=advanced_settings.ARCHITECTURE.BUILDROOT,
+            new=ARCHITECTURE.BUILDROOT,
         ):
             s = advanced_settings.DisableLogIntegrationSettingDefinition()
             with pytest.raises(advanced_settings.SettingException):

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -1,7 +1,7 @@
 from typing import Dict, Optional
 
 import pytest
-from pytest_lazyfixture import lazy_fixture
+from pytest_lazyfixture import lazy_fixture  # type: ignore[import]
 from opentrons.config.advanced_settings import _migrate, _ensure
 
 

--- a/api/tests/opentrons/config/test_pipette_config.py
+++ b/api/tests/opentrons/config/test_pipette_config.py
@@ -247,10 +247,8 @@ def test_validate_overrides_fail(
     ],
 )
 def test_validate_overrides_pass(override_field, mock_pipette_config_model):
-    assert (
-        pipette_config.validate_overrides(override_field, mock_pipette_config_model)  # type: ignore[func-returns-value]  # noqa: E501
-        is None
-    )
+    # calling validate_overrides should not raise
+    pipette_config.validate_overrides(override_field, mock_pipette_config_model)
 
 
 @pytest.fixture

--- a/api/tests/opentrons/config/test_robots_config.py
+++ b/api/tests/opentrons/config/test_robots_config.py
@@ -4,6 +4,7 @@ import os
 import pytest
 
 from opentrons.config import CONFIG, robot_configs
+from opentrons.config.types import CurrentDict
 from opentrons.hardware_control.types import BoardRevision
 
 legacy_dummy_settings = {
@@ -127,7 +128,7 @@ def test_load_legacy_gantry_cal():
 
 def test_load_currents():
     legacy = {"X": 2.0, "Y": 0.5, "Z": 0.2, "A": 0.1, "B": 0.5, "C": 0.7}
-    default = {
+    default: CurrentDict = {
         "default": {"X": 0.1, "Y": 0.3, "Z": 0.1, "A": 0.2, "B": 0.1, "C": 0.2},
         "B": {"X": 0.2, "Y": 0.1, "Z": 0.5, "A": 0.6, "B": 0.7, "C": 0.8},
         "2.1": {"X": 1, "Y": 2, "Z": 3, "A": 4, "B": 5, "C": 7},

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -9,9 +9,9 @@ from opentrons.protocols.context.protocol_api.protocol_context import (
 )
 
 try:
-    import aionotify
+    import aionotify  # type: ignore[import]
 except (OSError, ModuleNotFoundError):
-    aionotify = None  # type: ignore
+    aionotify = None
 import asyncio
 import os
 import io
@@ -32,6 +32,7 @@ from opentrons.hardware_control import API, ThreadManager, ThreadedAsyncLock
 from opentrons.protocol_api import ProtocolContext
 from opentrons.types import Mount, Location, Point
 
+from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 Session = namedtuple("Session", ["server", "socket", "token", "call"])
 
@@ -185,15 +186,18 @@ async def hardware(request, loop, virtual_smoothie_env):
 @pytest.fixture
 def main_router(loop, virtual_smoothie_env, hardware):
     router = MainRouter(hardware=hardware, loop=loop, lock=ThreadedAsyncLock())
-    router.wait_until = partial(
+    # TODO(mc, 2021-09-13): What is this mocking? `MainRouter` does not
+    # have a `wait_until` method
+    router.wait_until = partial(  # type: ignore[attr-defined]
         wait_until, notifications=router.notifications, loop=loop
     )
     yield router
 
 
 async def wait_until(matcher, notifications, timeout=1, loop=None):
-    result = []
-    for coro in iter(notifications.__anext__, None):
+    # TODO(mc, 2021-09-03): see TODO above about `wait_until`
+    result = []  # type: ignore[var-annotated]
+    for coro in iter(notifications.__anext__, None):  # type: ignore[var-annotated]
         done, pending = await asyncio.wait([coro], timeout=timeout)
 
         if pending:
@@ -217,6 +221,9 @@ def data_dir() -> str:
     return os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
 
 
+Model = namedtuple("Model", ["robot", "instrument", "container"])
+
+
 def build_v2_model(h, lw_name, loop):
     ctx = ProtocolContext(
         implementation=ProtocolContextImplementation(hardware=h), loop=loop
@@ -228,7 +235,8 @@ def build_v2_model(h, lw_name, loop):
     instrument = models.Instrument(pip, [], ctx)
     plate = ctx.load_labware(lw_name or "corning_96_wellplate_360ul_flat", 1)
     container = models.Container(plate, [], context=ctx)
-    return namedtuple("model", "robot instrument container")(
+
+    return Model(
         robot=h,
         instrument=instrument,
         container=container,
@@ -414,7 +422,7 @@ def get_bundle_fixture():
         if fixture_name == "simple_bundle":
             with open(fixture_dir / "protocol.py", "r") as f:
                 result["contents"] = f.read()
-            with open(fixture_dir / "data.txt", "rb") as f:
+            with open(fixture_dir / "data.txt", "rb") as f:  # type: ignore[assignment]
                 result["bundled_data"] = {"data.txt": f.read()}
             with open(fixture_dir / "custom_labware.json", "r") as f:
                 custom_labware = json.load(f)
@@ -492,7 +500,7 @@ def get_bundle_fixture():
 
 
 @pytest.fixture
-def minimal_labware_def() -> dict:
+def minimal_labware_def() -> LabwareDefinition:
     return {
         "metadata": {
             "displayName": "minimal labware",
@@ -537,7 +545,7 @@ def minimal_labware_def() -> dict:
 
 
 @pytest.fixture
-def minimal_labware_def2() -> dict:
+def minimal_labware_def2() -> LabwareDefinition:
     return {
         "metadata": {
             "displayName": "other test labware",

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -186,7 +186,7 @@ async def hardware(request, loop, virtual_smoothie_env):
 @pytest.fixture
 def main_router(loop, virtual_smoothie_env, hardware):
     router = MainRouter(hardware=hardware, loop=loop, lock=ThreadedAsyncLock())
-    # TODO(mc, 2021-09-13): What is this mocking? `MainRouter` does not
+    # TODO(mc, 2021-09-12): What is this mocking? `MainRouter` does not
     # have a `wait_until` method
     router.wait_until = partial(  # type: ignore[attr-defined]
         wait_until, notifications=router.notifications, loop=loop

--- a/api/tests/opentrons/drivers/asyncio/communication/test_async_serial.py
+++ b/api/tests/opentrons/drivers/asyncio/communication/test_async_serial.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import pytest
 from mock import MagicMock, PropertyMock, call
-from serial import Serial
+from serial import Serial  # type: ignore[import]
 from opentrons.drivers.asyncio.communication import AsyncSerial
 
 

--- a/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
+++ b/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
@@ -25,7 +25,7 @@ def ack() -> str:
 @pytest.fixture
 def subject(mock_serial_port: AsyncMock, ack: str) -> SerialConnection:
     """Create the test subject."""
-    SerialConnection.RETRY_WAIT_TIME = 0
+    SerialConnection.RETRY_WAIT_TIME = 0  # type: ignore[attr-defined]
     return SerialConnection(
         serial=mock_serial_port,
         ack=ack,

--- a/api/tests/opentrons/drivers/rpi_drivers/test_usb.py
+++ b/api/tests/opentrons/drivers/rpi_drivers/test_usb.py
@@ -1,6 +1,7 @@
 import pytest
-
 from mock import patch, MagicMock
+from typing import Iterator
+
 from opentrons.hardware_control.modules.types import ModuleAtPort
 from opentrons.hardware_control.types import BoardRevision
 from opentrons.drivers.rpi_drivers.usb import USBBus
@@ -44,8 +45,8 @@ filtered_port_refresh = [
 
 
 @pytest.fixture
-def usb_bus() -> USBBus:
-    @staticmethod
+def usb_bus() -> Iterator[USBBus]:
+    @staticmethod  # type: ignore[misc]
     def fake_read_bus():
         return fake_bus_og
 
@@ -54,10 +55,10 @@ def usb_bus() -> USBBus:
 
 
 @pytest.fixture(params=[BoardRevision.OG, BoardRevision.A])
-def usb_revision(request) -> USBBus:
+def usb_revision(request) -> Iterator[USBBus]:
     revision = request.param
 
-    @staticmethod
+    @staticmethod  # type: ignore[misc]
     def fake_read_bus():
         if revision == BoardRevision.OG:
             return fake_bus_og
@@ -115,7 +116,7 @@ def test_unplug_device(usb_bus: USBBus) -> None:
     copy_bus.remove(u)
     copy_ports.remove("1-1.3/1-1.3:1.0/tty/ttyACM1/dev")
 
-    usb_bus.read_bus = MagicMock(return_value=copy_bus)
+    usb_bus.read_bus = MagicMock(return_value=copy_bus)  # type: ignore[assignment]
     usb_bus.sort_ports()
 
     expected_ports = [USBPort.build(p, usb_bus._board_revision) for p in copy_ports]
@@ -128,14 +129,14 @@ def test_sorted_usb_bus(usb_bus: USBBus) -> None:
 
 
 def test_modify_module_list(usb_bus: USBBus):
-    usb_bus.read_symlink = MagicMock(return_value="ttyACM1")
+    usb_bus.read_symlink = MagicMock(return_value="ttyACM1")  # type: ignore[assignment]
     mod_at_port_list = [
         ModuleAtPort(name="temperature module", port="dev/ot_module_temperature_module")
     ]
     updated_list = usb_bus.match_virtual_ports(mod_at_port_list)
     assert updated_list[0].usb_port == usb_bus.usb_dev[0]
 
-    usb_bus.read_symlink = MagicMock(return_value="ttyACM2")
+    usb_bus.read_symlink = MagicMock(return_value="ttyACM2")  # type: ignore[assignment]
     mod_at_port_list = [
         ModuleAtPort(name="magnetic module", port="dev/ot_module_magnetic_module")
     ]

--- a/api/tests/opentrons/drivers/smoothie_drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/smoothie_drivers/test_driver.py
@@ -13,6 +13,7 @@ from opentrons.drivers.smoothie_drivers.constants import (
 from opentrons.drivers.rpi_drivers.gpio_simulator import SimulatingGPIOCharDev
 
 from opentrons.drivers.smoothie_drivers import driver_3_0, constants
+from opentrons.drivers.smoothie_drivers.errors import SmoothieError
 
 
 @pytest.fixture
@@ -35,7 +36,7 @@ def smoothie(mock_connection: AsyncMock, sim_gpio) -> driver_3_0.SmoothieDriver:
     d = driver_3_0.SmoothieDriver(
         connection=mock_connection, config=robot_configs.load(), gpio_chardev=sim_gpio
     )
-    yield d
+    return d
 
 
 def position(x, y, z, a, b, c):
@@ -193,7 +194,7 @@ async def test_clear_limit_switch(
     mock_connection.send_command.side_effect = write_mock
 
     # This will cause a limit-switch error and not back off
-    with pytest.raises(driver_3_0.SmoothieError):
+    with pytest.raises(SmoothieError):
         await smoothie.move({"C": 100})
 
     assert [c.strip() for c in cmd_list] == [
@@ -269,7 +270,7 @@ async def test_home_flagged_axes(
     expected: str,
 ) -> None:
     """It should only home un-homed axes."""
-    smoothie.home = AsyncMock()
+    smoothie.home = AsyncMock()  # type: ignore[assignment]
     await smoothie.update_homed_flags(home_flags)
 
     await smoothie.home_flagged_axes(axes_string=axis_string)
@@ -289,7 +290,7 @@ async def test_home_flagged_axes_no_call(
     smoothie: driver_3_0.SmoothieDriver, home_flags: Dict[str, bool], axis_string: str
 ) -> None:
     """It should not home homed axes."""
-    smoothie.home = AsyncMock()
+    smoothie.home = AsyncMock()  # type: ignore[assignment]
     await smoothie.update_homed_flags(home_flags)
 
     await smoothie.home_flagged_axes(axes_string=axis_string)

--- a/api/tests/opentrons/drivers/smoothie_drivers/test_parse_utils.py
+++ b/api/tests/opentrons/drivers/smoothie_drivers/test_parse_utils.py
@@ -36,6 +36,7 @@ def test_parse_pipette_data():
     mount = "L"
     good_data = mount + ": " + utils.string_to_hex(msg)
     parsed = parse_utils.parse_instrument_data(good_data).get(mount)
+    assert parsed
     assert parsed.decode() == msg
 
 

--- a/api/tests/opentrons/drivers/temp_deck/test_driver.py
+++ b/api/tests/opentrons/drivers/temp_deck/test_driver.py
@@ -2,13 +2,13 @@ from mock import AsyncMock
 import pytest
 
 from opentrons.drivers.asyncio.communication.serial_connection import SerialConnection
-from opentrons.drivers.temp_deck.abstract import Temperature
 from opentrons.drivers.temp_deck.driver import (
     TempDeckDriver,
     TEMP_DECK_COMMAND_TERMINATOR,
 )
 from opentrons.drivers.command_builder import CommandBuilder
 from opentrons.drivers.utils import TEMPDECK_GCODE_ROUNDING_PRECISION
+from opentrons.drivers.types import Temperature
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_engine/commands/test_command_mapper.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_command_mapper.py
@@ -5,14 +5,9 @@ from pydantic import BaseModel
 from typing import Type, cast
 from opentrons.protocols.models import LabwareDefinition
 
-from opentrons.types import MountType
+from opentrons.types import MountType, DeckSlotName
 from opentrons.protocol_engine import commands
-from opentrons.protocol_engine.types import (
-    DeckSlotLocation,
-    DeckSlotName,
-    PipetteName,
-    WellLocation,
-)
+from opentrons.protocol_engine.types import DeckSlotLocation, PipetteName, WellLocation
 
 
 @pytest.mark.parametrize(

--- a/api/tests/opentrons/protocol_engine/state/test_motion_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_motion_view.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from opentrons.types import Point, MountType
 from opentrons.hardware_control.types import CriticalPoint
-from opentrons.protocols.geometry.planning import MoveType, get_waypoints
+from opentrons.motion_planning import MoveType, get_waypoints
 
 from opentrons.protocol_engine import errors
 from opentrons.protocol_engine.types import (

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_view.py
@@ -16,7 +16,7 @@ from opentrons.protocol_engine.state.pipettes import (
 
 def get_pipette_view(
     pipettes_by_id: Optional[Dict[str, LoadedPipette]] = None,
-    aspirated_volume_by_id: Dict[str, float] = None,
+    aspirated_volume_by_id: Optional[Dict[str, float]] = None,
     current_well: Optional[CurrentWell] = None,
 ) -> PipetteView:
     """Get a pipette view test subject with the specified state."""

--- a/api/tests/opentrons/protocol_runner/test_json_command_translator.py
+++ b/api/tests/opentrons/protocol_runner/test_json_command_translator.py
@@ -2,6 +2,7 @@
 import pytest
 from typing import Any, Dict, List
 
+from opentrons_shared_data.labware.dev_types import LabwareDefinition
 from opentrons.types import DeckSlotName, MountType
 from opentrons.protocols import models
 from opentrons.protocol_runner.json_command_translator import JsonCommandTranslator
@@ -65,8 +66,8 @@ def _make_json_protocol(
 
 def test_labware(
     subject: JsonCommandTranslator,
-    minimal_labware_def: dict,
-    minimal_labware_def2: dict,
+    minimal_labware_def: LabwareDefinition,
+    minimal_labware_def2: LabwareDefinition,
 ) -> None:
     """It should emit AddLabwareDefinitionRequest and LoadLabwareRequest objects.
 

--- a/api/tests/opentrons/system/test_nmcli.py
+++ b/api/tests/opentrons/system/test_nmcli.py
@@ -180,13 +180,13 @@ GENERAL.STATE:100 (connected)"""
         "type": "ethernet",
     }
 
-    async def mock_call(cmd):
+    async def dummy_error_mock_call(cmd):
         if "connectivity" in cmd:
             return "full", ""
         else:
             return "", "this is a dummy error"
 
-    monkeypatch.setattr(nmcli, "_call", mock_call)
+    monkeypatch.setattr(nmcli, "_call", dummy_error_mock_call)
     assert await nmcli.is_connected() == "full"
     with pytest.raises(ValueError, match="this is a dummy error"):
         await nmcli.iface_info(nmcli.NETWORK_IFACES.WIFI)

--- a/api/tests/opentrons/system/test_wifi.py
+++ b/api/tests/opentrons/system/test_wifi.py
@@ -61,14 +61,20 @@ def test_eap_check_option():
     # Required arguments that are not specified should raise
     with pytest.raises(wifi.ConfigureArgsError):
         wifi._eap_check_option_ok(
-            {"name": "test-opt", "required": True, "displayName": "Test Option"},
+            {
+                "name": "test-opt",
+                # TODO(mc, 2021-09-13): typechecking expects string
+                "required": True,  # type: ignore[dict-item]
+                "displayName": "Test Option",
+            },
             {"eapType": "test"},
         )
     # Non-required arguments that are not specified should not raise
     wifi._eap_check_option_ok(
         {
             "name": "test-1",
-            "required": False,
+            # TODO(mc, 2021-09-13): typechecking expects string
+            "required": False,  # type: ignore[dict-item]
             "type": "string",
             "displayName": "Test Option",
         },
@@ -81,7 +87,8 @@ def test_eap_check_option():
             {
                 "name": "identity",
                 "displayName": "Username",
-                "required": True,
+                # TODO(mc, 2021-09-13): typechecking expects string
+                "required": True,  # type: ignore[dict-item]
                 "type": "string",
             },
             {"identity": 2, "eapType": "test"},
@@ -89,7 +96,8 @@ def test_eap_check_option():
     wifi._eap_check_option_ok(
         {
             "name": "identity",
-            "required": True,
+            # TODO(mc, 2021-09-13): typechecking expects string
+            "required": True,  # type: ignore[dict-item]
             "displayName": "Username",
             "type": "string",
         },
@@ -99,7 +107,8 @@ def test_eap_check_option():
         wifi._eap_check_option_ok(
             {
                 "name": "password",
-                "required": True,
+                # TODO(mc, 2021-09-13): typechecking expects string
+                "required": True,  # type: ignore[dict-item]
                 "displayName": "Password",
                 "type": "password",
             },
@@ -108,7 +117,8 @@ def test_eap_check_option():
     wifi._eap_check_option_ok(
         {
             "name": "password",
-            "required": True,
+            # TODO(mc, 2021-09-13): typechecking expects string
+            "required": True,  # type: ignore[dict-item]
             "displayName": "password",
             "type": "password",
         },
@@ -119,7 +129,8 @@ def test_eap_check_option():
             {
                 "name": "phase2CaCert",
                 "displayName": "some file who cares",
-                "required": True,
+                # TODO(mc, 2021-09-13): typechecking expects string
+                "required": True,  # type: ignore[dict-item]
                 "type": "file",
             },
             {"phase2CaCert": 2, "eapType": "test"},
@@ -127,7 +138,8 @@ def test_eap_check_option():
     wifi._eap_check_option_ok(
         {
             "name": "phase2CaCert",
-            "required": True,
+            # TODO(mc, 2021-09-13): typechecking expects string
+            "required": True,  # type: ignore[dict-item]
             "displayName": "hello",
             "type": "file",
         },
@@ -165,15 +177,17 @@ async def test_key_lifecycle(loop, wifi_keys_tempdir):
             with open(path, "w") as f:
                 f.write(str(random.getrandbits(2048)))
 
-            with open(path, "rb") as f:
-                add_response = wifi.add_key(fn, f.read())
+            # TODO(mc, 2021-09-13): use pathlib
+            with open(path, "rb") as f:  # type: ignore[assignment]
+                add_response = wifi.add_key(fn, f.read())  # type: ignore[arg-type]
                 assert add_response.created is True
                 assert add_response.key.file == fn
                 results[fn] = add_response
 
         # We should not be able to upload a duplicate
-        with open(os.path.join(source_td, "test1.pem"), "rb") as f:
-            add_response = wifi.add_key("test1.pem", f.read())
+        # TODO(mc, 2021-09-13): use pathlib
+        with open(os.path.join(source_td, "test1.pem"), "rb") as f:  # type: ignore[assignment]  # noqa: E501
+            add_response = wifi.add_key("test1.pem", f.read())  # type: ignore[arg-type]
             assert add_response.created is False
 
         # We should be able to see them all

--- a/api/tests/opentrons/system/test_wifi.py
+++ b/api/tests/opentrons/system/test_wifi.py
@@ -63,7 +63,7 @@ def test_eap_check_option():
         wifi._eap_check_option_ok(
             {
                 "name": "test-opt",
-                # TODO(mc, 2021-09-13): typechecking expects string
+                # TODO(mc, 2021-09-12): typechecking expects string
                 "required": True,  # type: ignore[dict-item]
                 "displayName": "Test Option",
             },
@@ -73,7 +73,7 @@ def test_eap_check_option():
     wifi._eap_check_option_ok(
         {
             "name": "test-1",
-            # TODO(mc, 2021-09-13): typechecking expects string
+            # TODO(mc, 2021-09-12): typechecking expects string
             "required": False,  # type: ignore[dict-item]
             "type": "string",
             "displayName": "Test Option",
@@ -87,7 +87,7 @@ def test_eap_check_option():
             {
                 "name": "identity",
                 "displayName": "Username",
-                # TODO(mc, 2021-09-13): typechecking expects string
+                # TODO(mc, 2021-09-12): typechecking expects string
                 "required": True,  # type: ignore[dict-item]
                 "type": "string",
             },
@@ -96,7 +96,7 @@ def test_eap_check_option():
     wifi._eap_check_option_ok(
         {
             "name": "identity",
-            # TODO(mc, 2021-09-13): typechecking expects string
+            # TODO(mc, 2021-09-12): typechecking expects string
             "required": True,  # type: ignore[dict-item]
             "displayName": "Username",
             "type": "string",
@@ -107,7 +107,7 @@ def test_eap_check_option():
         wifi._eap_check_option_ok(
             {
                 "name": "password",
-                # TODO(mc, 2021-09-13): typechecking expects string
+                # TODO(mc, 2021-09-12): typechecking expects string
                 "required": True,  # type: ignore[dict-item]
                 "displayName": "Password",
                 "type": "password",
@@ -117,7 +117,7 @@ def test_eap_check_option():
     wifi._eap_check_option_ok(
         {
             "name": "password",
-            # TODO(mc, 2021-09-13): typechecking expects string
+            # TODO(mc, 2021-09-12): typechecking expects string
             "required": True,  # type: ignore[dict-item]
             "displayName": "password",
             "type": "password",
@@ -129,7 +129,7 @@ def test_eap_check_option():
             {
                 "name": "phase2CaCert",
                 "displayName": "some file who cares",
-                # TODO(mc, 2021-09-13): typechecking expects string
+                # TODO(mc, 2021-09-12): typechecking expects string
                 "required": True,  # type: ignore[dict-item]
                 "type": "file",
             },
@@ -138,7 +138,7 @@ def test_eap_check_option():
     wifi._eap_check_option_ok(
         {
             "name": "phase2CaCert",
-            # TODO(mc, 2021-09-13): typechecking expects string
+            # TODO(mc, 2021-09-12): typechecking expects string
             "required": True,  # type: ignore[dict-item]
             "displayName": "hello",
             "type": "file",
@@ -177,7 +177,7 @@ async def test_key_lifecycle(loop, wifi_keys_tempdir):
             with open(path, "w") as f:
                 f.write(str(random.getrandbits(2048)))
 
-            # TODO(mc, 2021-09-13): use pathlib
+            # TODO(mc, 2021-09-12): use pathlib
             with open(path, "rb") as f:  # type: ignore[assignment]
                 add_response = wifi.add_key(fn, f.read())  # type: ignore[arg-type]
                 assert add_response.created is True
@@ -185,7 +185,7 @@ async def test_key_lifecycle(loop, wifi_keys_tempdir):
                 results[fn] = add_response
 
         # We should not be able to upload a duplicate
-        # TODO(mc, 2021-09-13): use pathlib
+        # TODO(mc, 2021-09-12): use pathlib
         with open(os.path.join(source_td, "test1.pem"), "rb") as f:  # type: ignore[assignment]  # noqa: E501
             add_response = wifi.add_key("test1.pem", f.read())  # type: ignore[arg-type]
             assert add_response.created is False

--- a/api/tests/opentrons/test_execute.py
+++ b/api/tests/opentrons/test_execute.py
@@ -6,6 +6,7 @@ import mock
 
 import pytest
 
+from opentrons_shared_data.pipette.dev_types import PipetteModel
 from opentrons import execute, types
 from opentrons.hardware_control import controller, api
 from opentrons.protocols.execution.errors import ExceptionInProtocolError
@@ -36,11 +37,11 @@ def test_execute_function_apiv2(
 ):
 
     mock_get_attached_instr.return_value[types.Mount.LEFT] = {
-        "config": load("p10_single_v1.5"),  # type: ignore[arg-type]
+        "config": load(PipetteModel("p10_single_v1.5")),
         "id": "testid",
     }
     mock_get_attached_instr.return_value[types.Mount.RIGHT] = {
-        "config": load("p300_single_v1.5"),  # type: ignore[arg-type]
+        "config": load(PipetteModel("p300_single_v1.5")),
         "id": "testid2",
     }
     entries = []
@@ -52,8 +53,8 @@ def test_execute_function_apiv2(
     execute.execute(protocol.filelike, "testosaur_v2.py", emit_runlog=emit_runlog)
     assert [item["payload"]["text"] for item in entries if item["$"] == "before"] == [
         "Picking up tip from A1 of Opentrons 96 Tip Rack 300 µL on 1",
-        "Aspirating 10.0 uL from A1 of Corning 96 Well Plate 360 µL Flat on 2 at 150.0 uL/sec",  # noqa: E501,
-        "Dispensing 10.0 uL into B1 of Corning 96 Well Plate 360 µL Flat on 2 at 300.0 uL/sec",  # noqa: E501,
+        "Aspirating 10.0 uL from A1 of Corning 96 Well Plate 360 µL Flat on 2 at 150.0 uL/sec",  # noqa: E501
+        "Dispensing 10.0 uL into B1 of Corning 96 Well Plate 360 µL Flat on 2 at 300.0 uL/sec",  # noqa: E501
         "Dropping tip into H12 of Opentrons 96 Tip Rack 300 µL on 1",
     ]
 
@@ -70,7 +71,7 @@ def test_execute_function_json_v3_apiv2(
         entries.append(entry)
 
     mock_get_attached_instr.return_value[types.Mount.LEFT] = {
-        "config": load("p10_single_v1.5"),  # type: ignore[arg-type]
+        "config": load(PipetteModel("p10_single_v1.5")),
         "id": "testid",
     }
     execute.execute(filelike, "simple.json", emit_runlog=emit_runlog)
@@ -98,7 +99,7 @@ def test_execute_function_json_v4_apiv2(
         entries.append(entry)
 
     mock_get_attached_instr.return_value[types.Mount.LEFT] = {
-        "config": load("p10_single_v1.5"),  # type: ignore[arg-type]
+        "config": load(PipetteModel("p10_single_v1.5")),
         "id": "testid",
     }
     execute.execute(filelike, "simple.json", emit_runlog=emit_runlog)
@@ -126,7 +127,7 @@ def test_execute_function_json_v5_apiv2(
         entries.append(entry)
 
     mock_get_attached_instr.return_value[types.Mount.LEFT] = {
-        "config": load("p10_single_v1.5"),  # type: ignore[arg-type]
+        "config": load(PipetteModel("p10_single_v1.5")),
         "id": "testid",
     }
     execute.execute(filelike, "simple.json", emit_runlog=emit_runlog)
@@ -155,7 +156,7 @@ def test_execute_function_bundle_apiv2(
         entries.append(entry)
 
     mock_get_attached_instr.return_value[types.Mount.LEFT] = {
-        "config": load("p10_single_v1.5"),  # type: ignore[arg-type]
+        "config": load(PipetteModel("p10_single_v1.5")),
         "id": "testid",
     }
     execute.execute(bundle["filelike"], "simple_bundle.zip", emit_runlog=emit_runlog)
@@ -192,7 +193,7 @@ def test_execute_extra_labware(
         entries.append(entry)
 
     mock_get_attached_instr.return_value[types.Mount.RIGHT] = {
-        "config": load("p300_single_v2.0"),  # type: ignore[arg-type]
+        "config": load(PipetteModel("p300_single_v2.0")),
         "id": "testid",
     }
     # make sure we can load labware explicitly

--- a/api/tests/opentrons/test_execute.py
+++ b/api/tests/opentrons/test_execute.py
@@ -36,11 +36,11 @@ def test_execute_function_apiv2(
 ):
 
     mock_get_attached_instr.return_value[types.Mount.LEFT] = {
-        "config": load("p10_single_v1.5"),
+        "config": load("p10_single_v1.5"),  # type: ignore[arg-type]
         "id": "testid",
     }
     mock_get_attached_instr.return_value[types.Mount.RIGHT] = {
-        "config": load("p300_single_v1.5"),
+        "config": load("p300_single_v1.5"),  # type: ignore[arg-type]
         "id": "testid2",
     }
     entries = []
@@ -70,7 +70,7 @@ def test_execute_function_json_v3_apiv2(
         entries.append(entry)
 
     mock_get_attached_instr.return_value[types.Mount.LEFT] = {
-        "config": load("p10_single_v1.5"),
+        "config": load("p10_single_v1.5"),  # type: ignore[arg-type]
         "id": "testid",
     }
     execute.execute(filelike, "simple.json", emit_runlog=emit_runlog)
@@ -98,7 +98,7 @@ def test_execute_function_json_v4_apiv2(
         entries.append(entry)
 
     mock_get_attached_instr.return_value[types.Mount.LEFT] = {
-        "config": load("p10_single_v1.5"),
+        "config": load("p10_single_v1.5"),  # type: ignore[arg-type]
         "id": "testid",
     }
     execute.execute(filelike, "simple.json", emit_runlog=emit_runlog)
@@ -126,7 +126,7 @@ def test_execute_function_json_v5_apiv2(
         entries.append(entry)
 
     mock_get_attached_instr.return_value[types.Mount.LEFT] = {
-        "config": load("p10_single_v1.5"),
+        "config": load("p10_single_v1.5"),  # type: ignore[arg-type]
         "id": "testid",
     }
     execute.execute(filelike, "simple.json", emit_runlog=emit_runlog)
@@ -155,7 +155,7 @@ def test_execute_function_bundle_apiv2(
         entries.append(entry)
 
     mock_get_attached_instr.return_value[types.Mount.LEFT] = {
-        "config": load("p10_single_v1.5"),
+        "config": load("p10_single_v1.5"),  # type: ignore[arg-type]
         "id": "testid",
     }
     execute.execute(bundle["filelike"], "simple_bundle.zip", emit_runlog=emit_runlog)
@@ -192,7 +192,7 @@ def test_execute_extra_labware(
         entries.append(entry)
 
     mock_get_attached_instr.return_value[types.Mount.RIGHT] = {
-        "config": load("p300_single_v2.0"),
+        "config": load("p300_single_v2.0"),  # type: ignore[arg-type]
         "id": "testid",
     }
     # make sure we can load labware explicitly
@@ -211,7 +211,9 @@ def test_execute_extra_labware(
     with pytest.raises(ExceptionInProtocolError, match=".*FileNotFoundError.*"):
         execute.execute(protocol.filelike, "custom_labware.py")
     no_lw = execute.get_protocol_api("2.0")
-    assert not no_lw._implementation._extra_labware
+
+    # TODO(mc, 2021-09-13): `_extra_labware` is not defined on `AbstractProtocol`
+    assert not no_lw._implementation._extra_labware  # type: ignore[attr-defined]
     protocol.filelike.seek(0)
     monkeypatch.setattr(execute, "IS_ROBOT", True)
     monkeypatch.setattr(execute, "JUPYTER_NOTEBOOK_LABWARE_DIR", fixturedir)
@@ -223,7 +225,10 @@ def test_execute_extra_labware(
 
     # make sure the extra labware loaded by default is right
     ctx = execute.get_protocol_api("2.0")
-    assert len(ctx._implementation._extra_labware.keys()) == len(os.listdir(fixturedir))
+    # TODO(mc, 2021-09-13): `_extra_labware` is not defined on `AbstractProtocol`
+    assert len(
+        ctx._implementation._extra_labware.keys()  # type: ignore[attr-defined]
+    ) == len(os.listdir(fixturedir))
 
     assert ctx.load_labware("fixture_12_trough", 1, namespace="fixture")
 

--- a/api/tests/opentrons/test_execute.py
+++ b/api/tests/opentrons/test_execute.py
@@ -212,7 +212,7 @@ def test_execute_extra_labware(
         execute.execute(protocol.filelike, "custom_labware.py")
     no_lw = execute.get_protocol_api("2.0")
 
-    # TODO(mc, 2021-09-13): `_extra_labware` is not defined on `AbstractProtocol`
+    # TODO(mc, 2021-09-12): `_extra_labware` is not defined on `AbstractProtocol`
     assert not no_lw._implementation._extra_labware  # type: ignore[attr-defined]
     protocol.filelike.seek(0)
     monkeypatch.setattr(execute, "IS_ROBOT", True)
@@ -225,7 +225,7 @@ def test_execute_extra_labware(
 
     # make sure the extra labware loaded by default is right
     ctx = execute.get_protocol_api("2.0")
-    # TODO(mc, 2021-09-13): `_extra_labware` is not defined on `AbstractProtocol`
+    # TODO(mc, 2021-09-12): `_extra_labware` is not defined on `AbstractProtocol`
     assert len(
         ctx._implementation._extra_labware.keys()  # type: ignore[attr-defined]
     ) == len(os.listdir(fixturedir))

--- a/api/tests/opentrons/test_simulate.py
+++ b/api/tests/opentrons/test_simulate.py
@@ -89,7 +89,8 @@ def test_simulate_extra_labware(protocol, protocol_file, monkeypatch):
     with pytest.raises(ExceptionInProtocolError, match=".*FileNotFoundError.*"):
         simulate.simulate(protocol.filelike, "custom_labware.py")
     no_lw = simulate.get_protocol_api("2.0")
-    assert not no_lw._implementation._extra_labware
+    # TODO(mc, 2021-09-13): `_extra_labware` is not defined on `AbstractProtocol`
+    assert not no_lw._implementation._extra_labware  # type: ignore[attr-defined]
     protocol.filelike.seek(0)
     monkeypatch.setattr(simulate, "IS_ROBOT", True)
     monkeypatch.setattr(simulate, "JUPYTER_NOTEBOOK_LABWARE_DIR", fixturedir)
@@ -99,7 +100,10 @@ def test_simulate_extra_labware(protocol, protocol_file, monkeypatch):
 
     # make sure the extra labware loaded by default is right
     ctx = simulate.get_protocol_api("2.0")
-    assert len(ctx._implementation._extra_labware.keys()) == len(os.listdir(fixturedir))
+    # TODO(mc, 2021-09-13): `_extra_labware` is not defined on `AbstractProtocol`
+    assert len(
+        ctx._implementation._extra_labware.keys()  # type: ignore[attr-defined]
+    ) == len(os.listdir(fixturedir))
 
     assert ctx.load_labware("fixture_12_trough", 1, namespace="fixture")
 

--- a/api/tests/opentrons/test_simulate.py
+++ b/api/tests/opentrons/test_simulate.py
@@ -89,7 +89,7 @@ def test_simulate_extra_labware(protocol, protocol_file, monkeypatch):
     with pytest.raises(ExceptionInProtocolError, match=".*FileNotFoundError.*"):
         simulate.simulate(protocol.filelike, "custom_labware.py")
     no_lw = simulate.get_protocol_api("2.0")
-    # TODO(mc, 2021-09-13): `_extra_labware` is not defined on `AbstractProtocol`
+    # TODO(mc, 2021-09-12): `_extra_labware` is not defined on `AbstractProtocol`
     assert not no_lw._implementation._extra_labware  # type: ignore[attr-defined]
     protocol.filelike.seek(0)
     monkeypatch.setattr(simulate, "IS_ROBOT", True)
@@ -100,7 +100,7 @@ def test_simulate_extra_labware(protocol, protocol_file, monkeypatch):
 
     # make sure the extra labware loaded by default is right
     ctx = simulate.get_protocol_api("2.0")
-    # TODO(mc, 2021-09-13): `_extra_labware` is not defined on `AbstractProtocol`
+    # TODO(mc, 2021-09-12): `_extra_labware` is not defined on `AbstractProtocol`
     assert len(
         ctx._implementation._extra_labware.keys()  # type: ignore[attr-defined]
     ) == len(os.listdir(fixturedir))

--- a/api/tests/opentrons/test_types.py
+++ b/api/tests/opentrons/test_types.py
@@ -4,19 +4,19 @@ from opentrons.types import Point, Location
 
 def test_point_mul():
     a = Point(1, 2, 3)
-    b = 2
+    b: float = 2
     assert a * b == Point(2, 4, 6)
 
     b = 3.1
     assert a * b == Point(3.1, 6.2, 9.3)
 
     with pytest.raises(TypeError):
-        a * a
+        a * a  # type: ignore[operator]
 
 
 def test_point_rmul():
     a = Point(1, 2, 3)
-    b = 2
+    b: float = 2
     assert b * a == Point(2, 4, 6)
 
     b = 3.1

--- a/api/tests/opentrons/tools/test_pipette_memory.py
+++ b/api/tests/opentrons/tools/test_pipette_memory.py
@@ -96,7 +96,7 @@ pipette_barcode_to_model = {
 }
 
 
-def test_parse_model_from_barcode():
+def test_parse_model_from_barcode() -> None:
     for barcode, model in pipette_barcode_to_model.items():
         assert write_pipette_memory._parse_model_from_barcode(barcode) == model
 

--- a/api/tests/opentrons/util/test_linal.py
+++ b/api/tests/opentrons/util/test_linal.py
@@ -1,19 +1,23 @@
 from math import pi, sin, cos
 from opentrons.util.linal import solve, add_z, apply_transform, solve_attitude
-from numpy.linalg import inv
-import numpy as np
+from numpy.linalg import inv  # type: ignore[import]
+import numpy as np  # type: ignore[import]
 
 
 def test_solve():
     theta = pi / 3.0  # 60 deg
     scale = 2.0
 
-    expected = [[cos(0), sin(0)], [cos(pi / 2), sin(pi / 2)], [cos(pi), sin(pi)]]
+    expected = [
+        (cos(0), sin(0)),
+        (cos(pi / 2), sin(pi / 2)),
+        (cos(pi), sin(pi)),
+    ]
 
     actual = [
-        [cos(theta) * scale + 0.5, sin(theta) * scale + 0.25],
-        [cos(theta + pi / 2) * scale + 0.5, sin(theta + pi / 2) * scale + 0.25],
-        [cos(theta + pi) * scale + 0.5, sin(theta + pi) * scale + 0.25],
+        (cos(theta) * scale + 0.5, sin(theta) * scale + 0.25),
+        (cos(theta + pi / 2) * scale + 0.5, sin(theta + pi / 2) * scale + 0.25),
+        (cos(theta + pi) * scale + 0.5, sin(theta + pi) * scale + 0.25),
     ]
 
     X = solve(expected, actual)

--- a/robot-server/Pipfile
+++ b/robot-server/Pipfile
@@ -28,8 +28,8 @@ black = "==21.7b0"
 # https://github.com/pypa/pipenv/issues/4408#issuecomment-668324177
 atomicwrites = {version="==1.4.0", sys_platform="== 'win32'"}
 colorama = {version="==0.4.4", sys_platform="== 'win32'"}
-types-requests = "*"
-types-mock = "*"
+types-requests = "==2.25.6"
+types-mock = "==4.0.1"
 
 [packages]
 opentrons = {editable = true, path = "../api"}

--- a/robot-server/Pipfile
+++ b/robot-server/Pipfile
@@ -16,7 +16,7 @@ requests = "==2.26.0"
 tavern = "~=1.6"
 graphviz = "==0.17"
 mock = "~=4.0.2"
-mypy = "==0.812.0"
+mypy = "0.910"
 flake8 = "~=3.9.0"
 flake8-annotations = "~=2.6.2"
 flake8-docstrings = "~=1.6.0"
@@ -28,6 +28,8 @@ black = "==21.7b0"
 # https://github.com/pypa/pipenv/issues/4408#issuecomment-668324177
 atomicwrites = {version="==1.4.0", sys_platform="== 'win32'"}
 colorama = {version="==0.4.4", sys_platform="== 'win32'"}
+types-requests = "*"
+types-mock = "*"
 
 [packages]
 opentrons = {editable = true, path = "../api"}

--- a/robot-server/Pipfile.lock
+++ b/robot-server/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "941ce011465678624e24716e7a61035ce19c6cd9c46ebc4e6de8c149d30861ab"
+            "sha256": "e1ea93d14b93dc1e8cd04e4815fdbdb534cfa2f3a3ef8d55974a3d61d263001a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -498,7 +498,7 @@
                 "sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d",
                 "sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_full_version < '4.0.0'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==5.5"
         },
         "decoy": {
@@ -1160,7 +1160,7 @@
                 "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4",
                 "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_full_version < '4.0.0'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==1.26.6"
         },
         "uvicorn": {

--- a/robot-server/Pipfile.lock
+++ b/robot-server/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8db5c689fed650f5524ca04a6788e9563143137053476db54ab28830c9aabed5"
+            "sha256": "941ce011465678624e24716e7a61035ce19c6cd9c46ebc4e6de8c149d30861ab"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -81,11 +81,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:9e04bf59076a15a9b6dd9c27806e8fcdf15280ba529c6a8cc3f4d5b4875bdd61",
-                "sha256:c4eb3dec5f697682e383a39701a7de11cd5c02daf8dd93534b69e3e6473f6b1b"
+                "sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15",
+                "sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==4.7.1"
+            "version": "==4.8.1"
         },
         "jsonschema": {
             "hashes": [
@@ -498,7 +498,7 @@
                 "sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d",
                 "sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_full_version < '4.0.0'",
             "version": "==5.5"
         },
         "decoy": {
@@ -604,11 +604,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:9e04bf59076a15a9b6dd9c27806e8fcdf15280ba529c6a8cc3f4d5b4875bdd61",
-                "sha256:c4eb3dec5f697682e383a39701a7de11cd5c02daf8dd93534b69e3e6473f6b1b"
+                "sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15",
+                "sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==4.7.1"
+            "version": "==4.8.1"
         },
         "iniconfig": {
             "hashes": [
@@ -685,31 +685,32 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:0d0a87c0e7e3a9becdfbe936c981d32e5ee0ccda3e0f07e1ef2c3d1a817cf73e",
-                "sha256:25adde9b862f8f9aac9d2d11971f226bd4c8fbaa89fb76bdadb267ef22d10064",
-                "sha256:28fb5479c494b1bab244620685e2eb3c3f988d71fd5d64cc753195e8ed53df7c",
-                "sha256:2f9b3407c58347a452fc0736861593e105139b905cca7d097e413453a1d650b4",
-                "sha256:33f159443db0829d16f0a8d83d94df3109bb6dd801975fe86bacb9bf71628e97",
-                "sha256:3f2aca7f68580dc2508289c729bd49ee929a436208d2b2b6aab15745a70a57df",
-                "sha256:499c798053cdebcaa916eef8cd733e5584b5909f789de856b482cd7d069bdad8",
-                "sha256:4eec37370483331d13514c3f55f446fc5248d6373e7029a29ecb7b7494851e7a",
-                "sha256:552a815579aa1e995f39fd05dde6cd378e191b063f031f2acfe73ce9fb7f9e56",
-                "sha256:5873888fff1c7cf5b71efbe80e0e73153fe9212fafdf8e44adfe4c20ec9f82d7",
-                "sha256:61a3d5b97955422964be6b3baf05ff2ce7f26f52c85dd88db11d5e03e146a3a6",
-                "sha256:674e822aa665b9fd75130c6c5f5ed9564a38c6cea6a6432ce47eafb68ee578c5",
-                "sha256:7ce3175801d0ae5fdfa79b4f0cfed08807af4d075b402b7e294e6aa72af9aa2a",
-                "sha256:9743c91088d396c1a5a3c9978354b61b0382b4e3c440ce83cf77994a43e8c521",
-                "sha256:9f94aac67a2045ec719ffe6111df543bac7874cee01f41928f6969756e030564",
-                "sha256:a26f8ec704e5a7423c8824d425086705e381b4f1dfdef6e3a1edab7ba174ec49",
-                "sha256:abf7e0c3cf117c44d9285cc6128856106183938c68fd4944763003decdcfeb66",
-                "sha256:b09669bcda124e83708f34a94606e01b614fa71931d356c1f1a5297ba11f110a",
-                "sha256:cd07039aa5df222037005b08fbbfd69b3ab0b0bd7a07d7906de75ae52c4e3119",
-                "sha256:d23e0ea196702d918b60c8288561e722bf437d82cb7ef2edcd98cfa38905d506",
-                "sha256:d65cc1df038ef55a99e617431f0553cd77763869eebdf9042403e16089fe746c",
-                "sha256:d7da2e1d5f558c37d6e8c1246f1aec1e7349e4913d8fb3cb289a35de573fe2eb"
+                "sha256:088cd9c7904b4ad80bec811053272986611b84221835e079be5bcad029e79dd9",
+                "sha256:0aadfb2d3935988ec3815952e44058a3100499f5be5b28c34ac9d79f002a4a9a",
+                "sha256:119bed3832d961f3a880787bf621634ba042cb8dc850a7429f643508eeac97b9",
+                "sha256:1a85e280d4d217150ce8cb1a6dddffd14e753a4e0c3cf90baabb32cefa41b59e",
+                "sha256:3c4b8ca36877fc75339253721f69603a9c7fdb5d4d5a95a1a1b899d8b86a4de2",
+                "sha256:3e382b29f8e0ccf19a2df2b29a167591245df90c0b5a2542249873b5c1d78212",
+                "sha256:42c266ced41b65ed40a282c575705325fa7991af370036d3f134518336636f5b",
+                "sha256:53fd2eb27a8ee2892614370896956af2ff61254c275aaee4c230ae771cadd885",
+                "sha256:704098302473cb31a218f1775a873b376b30b4c18229421e9e9dc8916fd16150",
+                "sha256:7df1ead20c81371ccd6091fa3e2878559b5c4d4caadaf1a484cf88d93ca06703",
+                "sha256:866c41f28cee548475f146aa4d39a51cf3b6a84246969f3759cb3e9c742fc072",
+                "sha256:a155d80ea6cee511a3694b108c4494a39f42de11ee4e61e72bc424c490e46457",
+                "sha256:adaeee09bfde366d2c13fe6093a7df5df83c9a2ba98638c7d76b010694db760e",
+                "sha256:b6fb13123aeef4a3abbcfd7e71773ff3ff1526a7d3dc538f3929a49b42be03f0",
+                "sha256:b94e4b785e304a04ea0828759172a15add27088520dc7e49ceade7834275bedb",
+                "sha256:c0df2d30ed496a08de5daed2a9ea807d07c21ae0ab23acf541ab88c24b26ab97",
+                "sha256:c6c2602dffb74867498f86e6129fd52a2770c48b7cd3ece77ada4fa38f94eba8",
+                "sha256:ceb6e0a6e27fb364fb3853389607cf7eb3a126ad335790fa1e14ed02fba50811",
+                "sha256:d9dd839eb0dc1bbe866a288ba3c1afc33a202015d2ad83b31e875b5905a079b6",
+                "sha256:e4dab234478e3bd3ce83bac4193b2ecd9cf94e720ddd95ce69840273bf44f6de",
+                "sha256:ec4e0cd079db280b6bdabdc807047ff3e199f334050db5cbb91ba3e959a67504",
+                "sha256:ecd2c3fe726758037234c93df7e98deb257fd15c24c9180dacf1ef829da5f921",
+                "sha256:ef565033fa5a958e62796867b1df10c40263ea9ded87164d67572834e57a174d"
             ],
             "index": "pypi",
-            "version": "==0.812.0"
+            "version": "==0.910"
         },
         "mypy-extensions": {
             "hashes": [
@@ -749,11 +750,11 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
-                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+                "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
+                "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.13.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.0.0"
         },
         "py": {
             "hashes": [
@@ -831,11 +832,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b",
-                "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"
+                "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89",
+                "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"
             ],
             "index": "pypi",
-            "version": "==6.2.4"
+            "version": "==6.2.5"
         },
         "pytest-aiohttp": {
             "hashes": [
@@ -930,49 +931,49 @@
         },
         "regex": {
             "hashes": [
-                "sha256:03840a07a402576b8e3a6261f17eb88abd653ad4e18ec46ef10c9a63f8c99ebd",
-                "sha256:06ba444bbf7ede3890a912bd4904bb65bf0da8f0d8808b90545481362c978642",
-                "sha256:1f9974826aeeda32a76648fc677e3125ade379869a84aa964b683984a2dea9f1",
-                "sha256:330836ad89ff0be756b58758878409f591d4737b6a8cef26a162e2a4961c3321",
-                "sha256:38600fd58c2996829480de7d034fb2d3a0307110e44dae80b6b4f9b3d2eea529",
-                "sha256:3a195e26df1fbb40ebee75865f9b64ba692a5824ecb91c078cc665b01f7a9a36",
-                "sha256:41acdd6d64cd56f857e271009966c2ffcbd07ec9149ca91f71088574eaa4278a",
-                "sha256:45f97ade892ace20252e5ccecdd7515c7df5feeb42c3d2a8b8c55920c3551c30",
-                "sha256:4b0c211c55d4aac4309c3209833c803fada3fc21cdf7b74abedda42a0c9dc3ce",
-                "sha256:5d5209c3ba25864b1a57461526ebde31483db295fc6195fdfc4f8355e10f7376",
-                "sha256:615fb5a524cffc91ab4490b69e10ae76c1ccbfa3383ea2fad72e54a85c7d47dd",
-                "sha256:61e734c2bcb3742c3f454dfa930ea60ea08f56fd1a0eb52d8cb189a2f6be9586",
-                "sha256:640ccca4d0a6fcc6590f005ecd7b16c3d8f5d52174e4854f96b16f34c39d6cb7",
-                "sha256:6dbd51c3db300ce9d3171f4106da18fe49e7045232630fe3d4c6e37cb2b39ab9",
-                "sha256:71a904da8c9c02aee581f4452a5a988c3003207cb8033db426f29e5b2c0b7aea",
-                "sha256:8021dee64899f993f4b5cca323aae65aabc01a546ed44356a0965e29d7893c94",
-                "sha256:8b8d551f1bd60b3e1c59ff55b9e8d74607a5308f66e2916948cafd13480b44a3",
-                "sha256:93f9f720081d97acee38a411e861d4ce84cbc8ea5319bc1f8e38c972c47af49f",
-                "sha256:96f0c79a70642dfdf7e6a018ebcbea7ea5205e27d8e019cad442d2acfc9af267",
-                "sha256:9966337353e436e6ba652814b0a957a517feb492a98b8f9d3b6ba76d22301dcc",
-                "sha256:a34ba9e39f8269fd66ab4f7a802794ffea6d6ac500568ec05b327a862c21ce23",
-                "sha256:a49f85f0a099a5755d0a2cc6fc337e3cb945ad6390ec892332c691ab0a045882",
-                "sha256:a795829dc522227265d72b25d6ee6f6d41eb2105c15912c230097c8f5bfdbcdc",
-                "sha256:a89ca4105f8099de349d139d1090bad387fe2b208b717b288699ca26f179acbe",
-                "sha256:ac95101736239260189f426b1e361dc1b704513963357dc474beb0f39f5b7759",
-                "sha256:ae87ab669431f611c56e581679db33b9a467f87d7bf197ac384e71e4956b4456",
-                "sha256:b091dcfee169ad8de21b61eb2c3a75f9f0f859f851f64fdaf9320759a3244239",
-                "sha256:b511c6009d50d5c0dd0bab85ed25bc8ad6b6f5611de3a63a59786207e82824bb",
-                "sha256:b79dc2b2e313565416c1e62807c7c25c67a6ff0a0f8d83a318df464555b65948",
-                "sha256:bca14dfcfd9aae06d7d8d7e105539bd77d39d06caaae57a1ce945670bae744e0",
-                "sha256:c835c30f3af5c63a80917b72115e1defb83de99c73bc727bddd979a3b449e183",
-                "sha256:ccd721f1d4fc42b541b633d6e339018a08dd0290dc67269df79552843a06ca92",
-                "sha256:d6c2b1d78ceceb6741d703508cd0e9197b34f6bf6864dab30f940f8886e04ade",
-                "sha256:d6ec4ae13760ceda023b2e5ef1f9bc0b21e4b0830458db143794a117fdbdc044",
-                "sha256:d8b623fc429a38a881ab2d9a56ef30e8ea20c72a891c193f5ebbddc016e083ee",
-                "sha256:ea9753d64cba6f226947c318a923dadaf1e21cd8db02f71652405263daa1f033",
-                "sha256:ebbceefbffae118ab954d3cd6bf718f5790db66152f95202ebc231d58ad4e2c2",
-                "sha256:ecb6e7c45f9cd199c10ec35262b53b2247fb9a408803ed00ee5bb2b54aa626f5",
-                "sha256:ef9326c64349e2d718373415814e754183057ebc092261387a2c2f732d9172b2",
-                "sha256:f93a9d8804f4cec9da6c26c8cfae2c777028b4fdd9f49de0302e26e00bb86504",
-                "sha256:faf08b0341828f6a29b8f7dd94d5cf8cc7c39bfc3e67b78514c54b494b66915a"
+                "sha256:04f6b9749e335bb0d2f68c707f23bb1773c3fb6ecd10edf0f04df12a8920d468",
+                "sha256:08d74bfaa4c7731b8dac0a992c63673a2782758f7cfad34cf9c1b9184f911354",
+                "sha256:0fc1f8f06977c2d4f5e3d3f0d4a08089be783973fc6b6e278bde01f0544ff308",
+                "sha256:121f4b3185feaade3f85f70294aef3f777199e9b5c0c0245c774ae884b110a2d",
+                "sha256:1413b5022ed6ac0d504ba425ef02549a57d0f4276de58e3ab7e82437892704fc",
+                "sha256:1743345e30917e8c574f273f51679c294effba6ad372db1967852f12c76759d8",
+                "sha256:28fc475f560d8f67cc8767b94db4c9440210f6958495aeae70fac8faec631797",
+                "sha256:31a99a4796bf5aefc8351e98507b09e1b09115574f7c9dbb9cf2111f7220d2e2",
+                "sha256:328a1fad67445550b982caa2a2a850da5989fd6595e858f02d04636e7f8b0b13",
+                "sha256:473858730ef6d6ff7f7d5f19452184cd0caa062a20047f6d6f3e135a4648865d",
+                "sha256:4cde065ab33bcaab774d84096fae266d9301d1a2f5519d7bd58fc55274afbf7a",
+                "sha256:5f6a808044faae658f546dd5f525e921de9fa409de7a5570865467f03a626fc0",
+                "sha256:610b690b406653c84b7cb6091facb3033500ee81089867ee7d59e675f9ca2b73",
+                "sha256:66256b6391c057305e5ae9209941ef63c33a476b73772ca967d4a2df70520ec1",
+                "sha256:6eebf512aa90751d5ef6a7c2ac9d60113f32e86e5687326a50d7686e309f66ed",
+                "sha256:79aef6b5cd41feff359acaf98e040844613ff5298d0d19c455b3d9ae0bc8c35a",
+                "sha256:808ee5834e06f57978da3e003ad9d6292de69d2bf6263662a1a8ae30788e080b",
+                "sha256:8e44769068d33e0ea6ccdf4b84d80c5afffe5207aa4d1881a629cf0ef3ec398f",
+                "sha256:999ad08220467b6ad4bd3dd34e65329dd5d0df9b31e47106105e407954965256",
+                "sha256:9b006628fe43aa69259ec04ca258d88ed19b64791693df59c422b607b6ece8bb",
+                "sha256:9d05ad5367c90814099000442b2125535e9d77581855b9bee8780f1b41f2b1a2",
+                "sha256:a577a21de2ef8059b58f79ff76a4da81c45a75fe0bfb09bc8b7bb4293fa18983",
+                "sha256:a617593aeacc7a691cc4af4a4410031654f2909053bd8c8e7db837f179a630eb",
+                "sha256:abb48494d88e8a82601af905143e0de838c776c1241d92021e9256d5515b3645",
+                "sha256:ac88856a8cbccfc14f1b2d0b829af354cc1743cb375e7f04251ae73b2af6adf8",
+                "sha256:b4c220a1fe0d2c622493b0a1fd48f8f991998fb447d3cd368033a4b86cf1127a",
+                "sha256:b844fb09bd9936ed158ff9df0ab601e2045b316b17aa8b931857365ea8586906",
+                "sha256:bdc178caebd0f338d57ae445ef8e9b737ddf8fbc3ea187603f65aec5b041248f",
+                "sha256:c206587c83e795d417ed3adc8453a791f6d36b67c81416676cad053b4104152c",
+                "sha256:c61dcc1cf9fd165127a2853e2c31eb4fb961a4f26b394ac9fe5669c7a6592892",
+                "sha256:c7cb4c512d2d3b0870e00fbbac2f291d4b4bf2634d59a31176a87afe2777c6f0",
+                "sha256:d4a332404baa6665b54e5d283b4262f41f2103c255897084ec8f5487ce7b9e8e",
+                "sha256:d5111d4c843d80202e62b4fdbb4920db1dcee4f9366d6b03294f45ed7b18b42e",
+                "sha256:e1e8406b895aba6caa63d9fd1b6b1700d7e4825f78ccb1e5260551d168db38ed",
+                "sha256:e8690ed94481f219a7a967c118abaf71ccc440f69acd583cab721b90eeedb77c",
+                "sha256:ed283ab3a01d8b53de3a05bfdf4473ae24e43caee7dcb5584e86f3f3e5ab4374",
+                "sha256:ed4b50355b066796dacdd1cf538f2ce57275d001838f9b132fab80b75e8c84dd",
+                "sha256:ee329d0387b5b41a5dddbb6243a21cb7896587a651bebb957e2d2bb8b63c0791",
+                "sha256:f3bf1bc02bc421047bfec3343729c4bbbea42605bcfd6d6bfe2c07ade8b12d2a",
+                "sha256:f585cbbeecb35f35609edccb95efd95a3e35824cd7752b586503f7e6087303f1",
+                "sha256:f60667673ff9c249709160529ab39667d1ae9fd38634e006bec95611f632e759"
             ],
-            "version": "==2021.8.21"
+            "version": "==2021.8.28"
         },
         "requests": {
             "hashes": [
@@ -998,11 +999,11 @@
         },
         "ruamel.yaml": {
             "hashes": [
-                "sha256:4185fcfa9e037fea9ffd0bb6172354a03ec98c21e462355d72e068c74e493512",
-                "sha256:b59c548ba6a2a99a97a842db2321c5adf28470d1decb04bdd82ce9535936a2fa"
+                "sha256:1a771fc92d3823682b7f0893ad56cb5a5c87c48e62b5399d6f42c8759a583b33",
+                "sha256:ea21da1198c4b41b8e7a259301cc9710d3b972bf8ba52f06218478e6802dd1f1"
             ],
             "markers": "python_version >= '3'",
-            "version": "==0.17.14"
+            "version": "==0.17.16"
         },
         "ruamel.yaml.clib": {
             "hashes": [
@@ -1072,10 +1073,10 @@
         },
         "tavern": {
             "hashes": [
-                "sha256:cc67add75211091aee4efc83fa0b532f62cb556f9e6827e9aa3cea3bae4efdc9"
+                "sha256:20ea1e57db264307c7fe9a8968380afd49a80fae04e5a1d1d4e8507975179f28"
             ],
             "index": "pypi",
-            "version": "==1.16.0"
+            "version": "==1.16.1"
         },
         "toml": {
             "hashes": [
@@ -1129,6 +1130,22 @@
             "markers": "python_version < '3.8'",
             "version": "==1.4.3"
         },
+        "types-mock": {
+            "hashes": [
+                "sha256:1a470543be8de673e2ea14739622de3bfb8c9b10429f50338ba9ca1e868c15e9",
+                "sha256:1ad09970f4f5ec45a138ab1e88d032f010e851bccef7765b34737ed390bbc5c8"
+            ],
+            "index": "pypi",
+            "version": "==4.0.1"
+        },
+        "types-requests": {
+            "hashes": [
+                "sha256:a5a305b43ea57bf64d6731f89816946a405b591eff6de28d4c0fd58422cee779",
+                "sha256:e21541c0f55c066c491a639309159556dd8c5833e49fcde929c4c47bdb0002ee"
+            ],
+            "index": "pypi",
+            "version": "==2.25.6"
+        },
         "typing-extensions": {
             "hashes": [
                 "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497",
@@ -1143,7 +1160,7 @@
                 "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4",
                 "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_full_version < '4.0.0'",
             "version": "==1.26.6"
         },
         "uvicorn": {

--- a/robot-server/mypy.ini
+++ b/robot-server/mypy.ini
@@ -1,14 +1,16 @@
 [mypy]
-plugins = pydantic.mypy,decoy.mypy
+plugins = pydantic.mypy, decoy.mypy
 show_error_codes = True
-exclude = tests/(robot|service)
 strict = True
+# TODO(mc, 2021-09-13): remove these exclusions
+exclude = tests/(robot|service)
 
 [pydantic-mypy]
 init_forbid_extra = True
 init_typed = True
 warn_required_dynamic_aliases = True
 warn_untyped_fields = True
+
 
 # TODO(mc, 2021-09-08): upgrade FastAPI and remove this override
 [mypy-fastapi.*]

--- a/robot-server/mypy.ini
+++ b/robot-server/mypy.ini
@@ -2,7 +2,7 @@
 plugins = pydantic.mypy, decoy.mypy
 show_error_codes = True
 strict = True
-# TODO(mc, 2021-09-13): remove these exclusions
+# TODO(mc, 2021-09-12): remove these exclusions
 exclude = tests/(robot|service)
 
 [pydantic-mypy]


### PR DESCRIPTION
## Overview

Follow-up PR to #8329 to also enable strict mode in new modules in the `api` project.

**This PR is _much_ smaller than it seems.** Most of the diff is `mypy.ini` override configs and `Pipfile.lock`s

## Changelog

- Upgrade `mypy` in `api` and `robot-server`
- Turn on `strict = True` in `api/mypy.ini`
- Suppress most errors with overrides in `mypy.ini`
- Fix some errors that only involved type annotations and/or explicit import paths
- Fix some errors in tests using code changes (e.g. add `assert foo is not None` before `assert foo.value == 42`)
- `type: ignore` the rest

## Review requests

- Changes in source are type only unless called out
    - If called out, changes seem reasonable
- CI is green / stuff works locally
    - **Note**: dev deps have changed, so remember to `make setup` in both `api` and `robot-server` 

## Risk assessment

Low
