### PR TITLE
fix(api): wait for poll before awaiting tempdeck temperature

### DIFF
--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -135,6 +135,7 @@ class TempDeck(mod_abc.AbstractModule):
         """
         await self.wait_for_is_running()
         await self._driver.set_temperature(celsius=celsius)
+        await self.wait_next_poll()
 
         async def _wait():
             # Wait until we reach the target temperature.
@@ -168,17 +169,7 @@ class TempDeck(mod_abc.AbstractModule):
         await self.wait_for_is_running()
         await self.wait_next_poll()
 
-        if self.target is not None:
-            # Validity of an awaiting temperature is almost unpredictable when no target
-            # is set, as it will depend on ambient temperatures.
-            if not (self.temperature <= awaiting_temperature <= self.target) and not (
-                self.target <= awaiting_temperature <= self.temperature
-            ):
-                raise TempdeckError(
-                    f"await_temperature of {awaiting_temperature} is "
-                    f"unreachable with a target of {self.target} when"
-                    f" current temperature is {self.temperature}."
-                )
+        self._validate_awaiting_temperature(awaiting_temperature)
 
         async def _await_temperature():
             if self.status == TemperatureStatus.HEATING:
@@ -191,6 +182,26 @@ class TempDeck(mod_abc.AbstractModule):
         t = self._loop.create_task(_await_temperature())
         await self.make_cancellable(t)
         await t
+
+    def _validate_awaiting_temperature(self, awaiting_temperature: float) -> None:
+        """Verify that the temperature we are awaiting is reachable.
+
+        This is a runtime validation with the goal of avoiding forever waits
+        while running a protocol.
+        """
+        if self.target is None:
+            # Validity of an awaiting temperature is almost unpredictable when no target
+            # is set, as it will depend on ambient temperatures.
+            return
+
+        if not (self.temperature <= awaiting_temperature <= self.target) and not (
+            self.target <= awaiting_temperature <= self.temperature
+        ):
+            raise TempdeckError(
+                f"await_temperature of {awaiting_temperature} is "
+                f"unreachable with a target of {self.target} when"
+                f" current temperature is {self.temperature}."
+            )
 
     async def deactivate(self):
         """Stop heating/cooling and turn off the fan"""

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -162,6 +162,9 @@ class TempDeck(mod_abc.AbstractModule):
         Polls temperature module's temperature until
         the specified temperature is reached
         """
+        if self.is_simulated:
+            return
+
         await self.wait_for_is_running()
         await self.wait_next_poll()
 
@@ -171,12 +174,11 @@ class TempDeck(mod_abc.AbstractModule):
             if not (self.temperature <= awaiting_temperature <= self.target) and not (
                 self.target <= awaiting_temperature <= self.temperature
             ):
-                raise TempdeckError(f"await_temperature of {awaiting_temperature} is "
-                                    f"unreachable with a target of {self.target} when"
-                                    f" current temperature is {self.temperature}.")
-
-        if self.is_simulated:
-            return
+                raise TempdeckError(
+                    f"await_temperature of {awaiting_temperature} is "
+                    f"unreachable with a target of {self.target} when"
+                    f" current temperature is {self.temperature}."
+                )
 
         async def _await_temperature():
             if self.status == TemperatureStatus.HEATING:

--- a/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
@@ -5,7 +5,6 @@ from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.hardware_control import ExecutionManager
 from opentrons.hardware_control.emulation.app import TEMPDECK_PORT
 from opentrons.hardware_control.modules import TempDeck
-from opentrons.hardware_control.modules.tempdeck import TempdeckError
 
 
 @pytest.fixture
@@ -89,35 +88,6 @@ async def test_start_set_temperature_heat(tempdeck) -> None:
         "status": "holding at target",
         "data": {"currentTemp": new_temp, "targetTemp": new_temp},
     }
-
-
-@pytest.mark.parametrize(
-    argnames="start_temp,target_temp,await_temp",
-    argvalues=[
-        [20.0, 40.0, 41.0],
-        [20.0, 40.0, 19.0],
-        [50.0, 30.0, 25.0],
-        [50.0, 30.0, 55.0],
-    ],
-)
-async def test_invalid_await_temperature(
-    tempdeck, start_temp, target_temp, await_temp
-) -> None:
-    """It should raise error when awaiting an unreachable temperature."""
-    await tempdeck.start_set_temperature(start_temp)
-    await tempdeck.wait_next_poll()
-    # Get tempdeck to start_temp
-    await tempdeck.await_temperature(start_temp)
-
-    # Set new target and check that error is raised for all unreachable await temps
-    await tempdeck.start_set_temperature(target_temp)
-    with pytest.raises(
-        TempdeckError,
-        match=f"{await_temp} is unreachable"
-        f" with a target of {target_temp} when"
-        f" current temperature is {start_temp}",
-    ):
-        await tempdeck.await_temperature(awaiting_temperature=await_temp)
 
 
 async def test_deactivate(tempdeck) -> None:

--- a/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
@@ -95,7 +95,9 @@ async def test_start_set_temperature_heat(tempdeck) -> None:
     argnames="start_temp,target_temp,await_temp",
     argvalues=[
         [20.0, 40.0, 41.0],
+        [20.0, 40.0, 19.0],
         [50.0, 30.0, 25.0],
+        [50.0, 30.0, 55.0],
     ],
 )
 async def test_invalid_await_temperature(

--- a/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
@@ -94,8 +94,8 @@ async def test_start_set_temperature_heat(tempdeck) -> None:
 @pytest.mark.parametrize(
     argnames="start_temp,target_temp,await_temp",
     argvalues=[
-        [20, 40, 41],
-        [50, 30, 25],
+        [20.0, 40.0, 41.0],
+        [50.0, 30.0, 25.0],
     ],
 )
 async def test_invalid_await_temperature(
@@ -109,7 +109,12 @@ async def test_invalid_await_temperature(
 
     # Set new target and check that error is raised for all unreachable await temps
     await tempdeck.start_set_temperature(target_temp)
-    with pytest.raises(TempdeckError, match="is unreachable with a target of"):
+    with pytest.raises(
+        TempdeckError,
+        match=f"{await_temp} is unreachable"
+        f" with a target of {target_temp} when"
+        f" current temperature is {start_temp}",
+    ):
         await tempdeck.await_temperature(awaiting_temperature=await_temp)
 
 

--- a/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
@@ -93,12 +93,15 @@ async def test_start_set_temperature_heat(tempdeck) -> None:
 
 @pytest.mark.parametrize(
     argnames="start_temp,target_temp,await_temp",
-    argvalues=[[20, 40, 41],
-               [50, 30, 25], ],
+    argvalues=[
+        [20, 40, 41],
+        [50, 30, 25],
+    ],
 )
 async def test_invalid_await_temperature(
-        tempdeck, start_temp, target_temp, await_temp) -> None:
-    """It should raise error when awaiting an unreachable temperature. """
+    tempdeck, start_temp, target_temp, await_temp
+) -> None:
+    """It should raise error when awaiting an unreachable temperature."""
     await tempdeck.start_set_temperature(start_temp)
     await tempdeck.wait_next_poll()
     # Get tempdeck to start_temp
@@ -106,7 +109,7 @@ async def test_invalid_await_temperature(
 
     # Set new target and check that error is raised for all unreachable await temps
     await tempdeck.start_set_temperature(target_temp)
-    with pytest.raises(TempdeckError, match="set to unreachable temperature"):
+    with pytest.raises(TempdeckError, match="is unreachable with a target of"):
         await tempdeck.await_temperature(awaiting_temperature=await_temp)
 
 

--- a/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
@@ -5,6 +5,7 @@ from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.hardware_control import ExecutionManager
 from opentrons.hardware_control.emulation.app import TEMPDECK_PORT
 from opentrons.hardware_control.modules import TempDeck
+from opentrons.hardware_control.modules.tempdeck import TempdeckError
 
 
 @pytest.fixture
@@ -88,6 +89,25 @@ async def test_start_set_temperature_heat(tempdeck) -> None:
         "status": "holding at target",
         "data": {"currentTemp": new_temp, "targetTemp": new_temp},
     }
+
+
+@pytest.mark.parametrize(
+    argnames="start_temp,target_temp,await_temp",
+    argvalues=[[20, 40, 41],
+               [50, 30, 25], ],
+)
+async def test_invalid_await_temperature(
+        tempdeck, start_temp, target_temp, await_temp) -> None:
+    """It should raise error when awaiting an unreachable temperature. """
+    await tempdeck.start_set_temperature(start_temp)
+    await tempdeck.wait_next_poll()
+    # Get tempdeck to start_temp
+    await tempdeck.await_temperature(start_temp)
+
+    # Set new target and check that error is raised for all unreachable await temps
+    await tempdeck.start_set_temperature(target_temp)
+    with pytest.raises(TempdeckError, match="set to unreachable temperature"):
+        await tempdeck.await_temperature(awaiting_temperature=await_temp)
 
 
 async def test_deactivate(tempdeck) -> None:


### PR DESCRIPTION
# Overview

Closes #8275 

Fixes a bug caused due to the use of tempdeck `status` property _before_ fetching the latest/current status. A `wait_for_poll` is necessary to make sure all our cached values, like the tempdeck's `status` property, are updated before using them.
~Also recognized a case where certain awaiting temperatures would be unreachable and result in waiting in the loop forever.~

# Changelog

- added `wait_for_poll()` awaits in both `await_temperature()` and `set_temperature()`

# Review requests

- Code looks okay and I'm not introducing any regressions
- If you have a tempdeck, test that an `await_temperature` immediately after a `start_set_temperature` in a python protocol actually waits for the temperature. You can also check this using a PD protocol by adding a 'Pause until temperature' step right after a 'Set temperature' step.


Test protocol:
```
metadata={"apiLevel": "2.11"}

def run(ctx):
    temp_mod = ctx.load_module('temperature module gen2', 1)
    temp_plate = temp_mod.load_labware('biorad_96_wellplate_200ul_pcr')
    temp_mod.start_set_temperature(40)
    temp_mod.await_temperature(40)  # Should wait until temp reaches 40C
    ctx.pause(msg='Reached first temp. Press resume to continue.')
    temp_mod.set_temperature(50) # Should wait until temp reaches 50C
```

# Risk assessment

Low to None. It's a simple bug fix.