### PR TITLE
feat(can): generate can constants header file

### DIFF
--- a/hardware/opentrons_hardware/drivers/can_bus/__init__.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/__init__.py
@@ -4,12 +4,9 @@ from .driver import CanDriver
 from .message import CanMessage
 from .arbitration_id import (
     ArbitrationId,
-    NodeId,
-    FunctionCode,
-    MessageId,
     ArbitrationIdParts,
 )
-
+from .constants import NodeId, FunctionCode, MessageId
 
 __all__ = [
     "CanMessage",

--- a/hardware/opentrons_hardware/drivers/can_bus/arbitration_id.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/arbitration_id.py
@@ -1,6 +1,5 @@
 """Can bus arbitration id."""
 from __future__ import annotations
-from enum import Enum
 import ctypes
 
 
@@ -50,25 +49,3 @@ class ArbitrationId(ctypes.Union):
     def __repr__(self) -> str:
         """Return string representation of class."""
         return f"id: 0x{self.id:x}, " f"parts: {self.parts}"
-
-
-class NodeId(int, Enum):
-    """Can bus arbitration id node id."""
-
-    broadcast = 0x00
-    host = 0x10
-    pipette = 0x20
-    gantry = 0x40
-
-
-class FunctionCode(int, Enum):
-    """Can bus arbitration id function code."""
-
-    network_management = 0x0
-
-
-class MessageId(int, Enum):
-    """Can bus arbitration id message id."""
-
-    device_info_request = 0x3002
-    device_info_response = 0x3003

--- a/hardware/opentrons_hardware/drivers/can_bus/constants.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/constants.py
@@ -1,0 +1,51 @@
+"""Constants for can bus."""
+from enum import Enum
+
+
+class NodeId(int, Enum):
+    """Can bus arbitration id node id."""
+
+    broadcast = 0x00
+    host = 0x10
+    pipette = 0x20
+    gantry = 0x40
+
+
+class FunctionCode(int, Enum):
+    """Can bus arbitration id function code."""
+
+    network_management = 0x0
+    sync = 0x2
+    error = 0x4
+    command = 0x10
+    status = 0x12
+    parameters = 0x14
+    bootloader = 0x7C
+    heartbeat = 0x7E
+
+
+class MessageId(int, Enum):
+    """Can bus arbitration id message id."""
+
+    heartbeat_request = 0x3FFF
+    heartbeat_response = 0x3FFE
+
+    device_info_request = 0x3002
+    device_info_response = 0x3003
+
+    stop_request = 0x00
+
+    get_status_request = 0x01
+    get_status_response = 0x05
+
+    move_request = 0x10
+
+    setup_request = 0x02
+
+    set_speed_request = 0x03
+
+    get_speed_request = 0x04
+    get_speed_response = 0x11
+    write_eeprom = 0x2001
+    read_eeprom_request = 0x2002
+    read_eeprom_response = 0x2003

--- a/hardware/opentrons_hardware/scripts/generate_header.py
+++ b/hardware/opentrons_hardware/scripts/generate_header.py
@@ -1,0 +1,49 @@
+"""Script to generate c++ header file of canbus constants."""
+import argparse
+import io
+from pathlib import Path
+
+from opentrons_hardware.drivers.can_bus import (
+    CanDriver,
+    MessageId,
+    FunctionCode,
+    NodeId,
+    CanMessage,
+    ArbitrationId,
+    ArbitrationIdParts,
+)
+
+
+def run(file: Path) -> None:
+    """Entry point for script."""
+    with io.StringIO() as output:
+        output.write("/********************************************\n")
+        output.write("* This is a generated file. Do not modify.  *\n")
+        output.write("********************************************/\n")
+        output.write("#pragma once\n")
+
+        # Function code
+        output.write("/* Function code definitions. */\n")
+        output.write(f"enum class {FunctionCode.__name__} {{\n")
+        for i in FunctionCode:
+            output.write(f"  {i.name} = 0x{i.value:x},\n")
+
+        output.write("}\n")
+
+
+        file.write_text(output.getvalue())
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate a C++ header file defining CANBUS constants.")
+    parser.add_argument(
+        "--target",
+        type=str,
+        required=True,
+        help="path of header file to generate",
+    )
+
+    args = parser.parse_args()
+
+    run(Path(args.target))
+

--- a/hardware/opentrons_hardware/scripts/generate_header.py
+++ b/hardware/opentrons_hardware/scripts/generate_header.py
@@ -1,16 +1,14 @@
 """Script to generate c++ header file of canbus constants."""
 import argparse
 import io
+from enum import Enum
 from pathlib import Path
+from typing import Type
 
 from opentrons_hardware.drivers.can_bus import (
-    CanDriver,
     MessageId,
     FunctionCode,
     NodeId,
-    CanMessage,
-    ArbitrationId,
-    ArbitrationIdParts,
 )
 
 
@@ -20,22 +18,28 @@ def run(file: Path) -> None:
         output.write("/********************************************\n")
         output.write("* This is a generated file. Do not modify.  *\n")
         output.write("********************************************/\n")
-        output.write("#pragma once\n")
+        output.write("#pragma once\n\n")
 
-        # Function code
-        output.write("/* Function code definitions. */\n")
-        output.write(f"enum class {FunctionCode.__name__} {{\n")
-        for i in FunctionCode:
-            output.write(f"  {i.name} = 0x{i.value:x},\n")
-
-        output.write("}\n")
-
+        write_enum(FunctionCode, output)
+        write_enum(MessageId, output)
+        write_enum(NodeId, output)
 
         file.write_text(output.getvalue())
 
 
+def write_enum(e: Type[Enum], output: io.StringIO) -> None:
+    """Generate enum class from enumeration."""
+    output.write(f"/** {e.__doc__} */\n")
+    output.write(f"enum class {e.__name__} {{\n")
+    for i in e:
+        output.write(f"  {i.name} = 0x{i.value:x},\n")
+    output.write("}\n\n")
+
+
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Generate a C++ header file defining CANBUS constants.")
+    parser = argparse.ArgumentParser(
+        description="Generate a C++ header file defining CANBUS constants."
+    )
     parser.add_argument(
         "--target",
         type=str,
@@ -46,4 +50,3 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     run(Path(args.target))
-

--- a/hardware/opentrons_hardware/scripts/generate_header.py
+++ b/hardware/opentrons_hardware/scripts/generate_header.py
@@ -1,15 +1,40 @@
 """Script to generate c++ header file of canbus constants."""
+from __future__ import annotations
 import argparse
 import io
 from enum import Enum
 from pathlib import Path
-from typing import Type
+from typing import Type, Any
 
 from opentrons_hardware.drivers.can_bus import (
     MessageId,
     FunctionCode,
     NodeId,
 )
+
+
+class block:
+    def __init__(self, output: io.StringIO, start: str, terminate: str) -> None:
+        """
+        Construct a code block context manager.
+
+        Args:
+            output: the buffer in which to write
+            start: the text that begins the block
+            terminate: the text that ends the block
+        """
+        self._output = output
+        self._start = start
+        self._terminate = terminate
+
+    def __enter__(self) -> block:
+        """Enter the context manager."""
+        self._output.write(self._start)
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        """Exit the context manager."""
+        self._output.write(self._terminate)
 
 
 def run(file: Path) -> None:
@@ -29,21 +54,28 @@ def generate(output: io.StringIO) -> None:
     output.write("* This is a generated file. Do not modify.  *\n")
     output.write("********************************************/\n")
     output.write("#pragma once\n\n")
-    write_enum(FunctionCode, output)
-    write_enum(MessageId, output)
-    write_enum(NodeId, output)
+    with block(
+        output=output,
+        start="namespace can_ids {\n\n",
+        terminate="} // namespace can_ids\n\n",
+    ):
+        write_enum(FunctionCode, output)
+        write_enum(MessageId, output)
+        write_enum(NodeId, output)
 
 
 def write_enum(e: Type[Enum], output: io.StringIO) -> None:
     """Generate enum class from enumeration."""
     output.write(f"/** {e.__doc__} */\n")
-    output.write(f"enum class {e.__name__} {{\n")
-    for i in e:
-        output.write(f"  {i.name} = 0x{i.value:x},\n")
-    output.write("};\n\n")
+    with block(
+        output=output, start=f"enum class {e.__name__} {{\n", terminate="};\n\n"
+    ):
+        for i in e:
+            output.write(f"  {i.name} = 0x{i.value:x},\n")
 
 
-if __name__ == "__main__":
+def main() -> None:
+    """Entry point."""
     parser = argparse.ArgumentParser(
         description="Generate a C++ header file defining CANBUS constants."
     )
@@ -57,3 +89,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     run(Path(args.target))
+
+
+if __name__ == "__main__":
+    main()

--- a/hardware/opentrons_hardware/scripts/generate_header.py
+++ b/hardware/opentrons_hardware/scripts/generate_header.py
@@ -14,9 +14,10 @@ from opentrons_hardware.drivers.can_bus import (
 
 
 class block:
+    """C block generator."""
+
     def __init__(self, output: io.StringIO, start: str, terminate: str) -> None:
-        """
-        Construct a code block context manager.
+        """Construct a code block context manager.
 
         Args:
             output: the buffer in which to write

--- a/hardware/opentrons_hardware/scripts/generate_header.py
+++ b/hardware/opentrons_hardware/scripts/generate_header.py
@@ -15,16 +15,23 @@ from opentrons_hardware.drivers.can_bus import (
 def run(file: Path) -> None:
     """Entry point for script."""
     with io.StringIO() as output:
-        output.write("/********************************************\n")
-        output.write("* This is a generated file. Do not modify.  *\n")
-        output.write("********************************************/\n")
-        output.write("#pragma once\n\n")
+        generate(output)
 
-        write_enum(FunctionCode, output)
-        write_enum(MessageId, output)
-        write_enum(NodeId, output)
+        output_string = output.getvalue()
+        file.write_text(output_string)
 
-        file.write_text(output.getvalue())
+        print(output_string)
+
+
+def generate(output: io.StringIO) -> None:
+    """Generate source code into output."""
+    output.write("/********************************************\n")
+    output.write("* This is a generated file. Do not modify.  *\n")
+    output.write("********************************************/\n")
+    output.write("#pragma once\n\n")
+    write_enum(FunctionCode, output)
+    write_enum(MessageId, output)
+    write_enum(NodeId, output)
 
 
 def write_enum(e: Type[Enum], output: io.StringIO) -> None:
@@ -33,7 +40,7 @@ def write_enum(e: Type[Enum], output: io.StringIO) -> None:
     output.write(f"enum class {e.__name__} {{\n")
     for i in e:
         output.write(f"  {i.name} = 0x{i.value:x},\n")
-    output.write("}\n\n")
+    output.write("};\n\n")
 
 
 if __name__ == "__main__":

--- a/hardware/opentrons_hardware/scripts/identify.py
+++ b/hardware/opentrons_hardware/scripts/identify.py
@@ -52,7 +52,6 @@ async def wait_responses(can_driver: CanDriver) -> None:
 
 async def run(interface: str, bitrate: int, channel: Optional[str] = None) -> None:
     """Entry point for script."""
-    ...
     driver = await CanDriver.build(
         bitrate=bitrate, interface=interface, channel=channel
     )
@@ -72,7 +71,7 @@ if __name__ == "__main__":
         "--interface",
         type=str,
         required=True,
-        help="the interface to use (ie: virtual, pcan, socketcan",
+        help="the interface to use (ie: virtual, pcan, socketcan)",
     )
     parser.add_argument(
         "--bitrate", type=int, default=250000, required=False, help="the bitrate"

--- a/hardware/opentrons_hardware/scripts/identify.py
+++ b/hardware/opentrons_hardware/scripts/identify.py
@@ -65,7 +65,8 @@ async def run(interface: str, bitrate: int, channel: Optional[str] = None) -> No
         driver.shutdown()
 
 
-if __name__ == "__main__":
+def main() -> None:
+    """Entry point."""
     parser = argparse.ArgumentParser(description="Identify peripherals on the can bus.")
     parser.add_argument(
         "--interface",
@@ -83,3 +84,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     asyncio.run(run(args.interface, args.bitrate, args.channel))
+
+
+if __name__ == "__main__":
+    main()

--- a/hardware/setup.py
+++ b/hardware/setup.py
@@ -76,4 +76,10 @@ if __name__ == "__main__":
         classifiers=CLASSIFIERS,
         install_requires=INSTALL_REQUIRES,
         include_package_data=True,
+        entry_points={
+            "console_scripts": [
+                "opentrons_generate_header = opentrons_hardware.scripts.generate_header:main",
+                "opentrons_canbus_identify = opentrons_hardware.scripts.identify:main",
+            ]
+        },
     )

--- a/hardware/setup.py
+++ b/hardware/setup.py
@@ -78,7 +78,7 @@ if __name__ == "__main__":
         include_package_data=True,
         entry_points={
             "console_scripts": [
-                "opentrons_generate_header = opentrons_hardware.scripts.generate_header:main",
+                "opentrons_generate_header = opentrons_hardware.scripts.generate_header:main",  # noqa: E501
                 "opentrons_canbus_identify = opentrons_hardware.scripts.identify:main",
             ]
         },


### PR DESCRIPTION
# Overview

This aims to provide a single source for all our can ids. The approach is to keep the ids in a python file in the mono repo. `generate_header` script can generate a `.h` file for the firmware. 

That means that `ot3-firmware` will pull the mono repo (or `opentrons-hardware` from pypy) during build.

# Review requests

What do we think of this approach?

Would we prefer a JSON/YAML file generating python and C?

# Risk assessment

None