### PR TITLE
build: fix warnings and errors in top-level setup and teardown targets

### DIFF
--- a/.github/actions/python/setup/action.yaml
+++ b/.github/actions/python/setup/action.yaml
@@ -15,7 +15,7 @@ runs:
         fi
     - shell: bash
       run: |
-        npm install --global shx@0.2.2
+        npm install --global shx@0.3.3
         pip install pipenv==2021.5.29
     - shell: bash
       run: 'make -C ${{ inputs.project }} setup'

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -47,13 +47,15 @@ setup:
 	$(pipenv) sync $(pipenv_opts)
 	$(pipenv) run pip freeze
 
-
 .PHONY: teardown
 teardown:
 	$(pipenv) --rm
 
-dist/opentrons_hardware-%-py2.py3-none-any.whl: setup.py $(ot_sources)
+.PHONY: clean
+clean:
 	$(clean_cmd)
+
+dist/opentrons_hardware-%-py2.py3-none-any.whl: setup.py $(ot_sources)
 	$(python) setup.py $(wheel_opts) bdist_wheel
 	$(SHX) rm -rf build
 	$(SHX) ls dist

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "rehype-urls": "^1.0.0",
     "reselect-tools": "^0.0.7",
     "script-ext-html-webpack-plugin": "^2.1.4",
-    "shx": "^0.2.2",
+    "shx": "^0.3.3",
     "style-loader": "^1.1.3",
     "stylelint": "^11.0.0",
     "stylelint-config-standard": "^19.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8955,11 +8955,6 @@ es6-error@^4.1.1:
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
   integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
 
-es6-object-assign@^1.0.3:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
-  integrity sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=
-
 es6-promise@^4.0.3, es6-promise@^4.1.1:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
@@ -19071,10 +19066,10 @@ shell-quote@1.7.2:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
 
-shelljs@^0.7.3:
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
-  integrity sha1-3svPh0sNHl+3LhSxZKloMEjprLM=
+shelljs@^0.8.4:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
+  integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"
@@ -19085,14 +19080,13 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-shx@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/shx/-/shx-0.2.2.tgz#0a304d020b0edf1306ad81570e80f0346df58a39"
-  integrity sha1-CjBNAgsO3xMGrYFXDoDwNG31ijk=
+shx@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/shx/-/shx-0.3.3.tgz#681a88c7c10db15abe18525349ed474f0f1e7b9f"
+  integrity sha512-nZJ3HFWVoTSyyB+evEKjJ1STiixGztlqwKLTUNV5KqMWtGey9fTd4KU1gdZ1X9BV6215pswQ/Jew9NsuS/fNDA==
   dependencies:
-    es6-object-assign "^1.0.3"
-    minimist "^1.2.0"
-    shelljs "^0.7.3"
+    minimist "^1.2.3"
+    shelljs "^0.8.4"
 
 side-channel@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
## Overview

Top level `make setup` and `make teardown` were issuing warnings / failing on my machine after the #8226 and #8343. This PR fixes these issues:

- `shx` was outdated for Node v14
- `hardware/Makefile` was missing `clean` target

## Review requests

- [ ] `make setup` works on your machine
- [ ] `make teardown` works on your machine

Note: unrelated to this PR, building the native `usb-detection` package sometimes fails on my macOS machine in the big `make setup`. It's working for me in `make setup-js` (and it's working in CI), so this seems like something that we should keep an eye on but is relatively low risk.

## Risk assessment

N/A, these are local-development-only build targets
