### PR TITLE
fix(robot-server): ensure background tasks do not affect requests

### DIFF
--- a/api/src/opentrons/calibration_storage/delete.py
+++ b/api/src/opentrons/calibration_storage/delete.py
@@ -10,7 +10,7 @@ from opentrons import config
 from opentrons.types import Mount
 
 
-def clear_calibrations():
+def clear_calibrations() -> None:
     """
     Delete all calibration files for labware. This includes deleting tip-length
     data for tipracks.

--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -533,7 +533,7 @@ def write_config(config_data: Dict[str, Path], path: Path = None):
         )
 
 
-def reload():
+def reload() -> None:
     global CONFIG
     CONFIG.clear()
     CONFIG.update(load_and_migrate())
@@ -553,9 +553,9 @@ CONFIG = load_and_migrate()
 #: are config element names
 
 
-def get_tip_length_cal_path():
+def get_tip_length_cal_path() -> Path:
     return get_opentrons_path("tip_length_calibration_dir")
 
 
-def get_custom_tiprack_def_path():
+def get_custom_tiprack_def_path() -> Path:
     return get_opentrons_path("custom_tiprack_dir")

--- a/api/src/opentrons/hardware_control/threaded_async_lock.py
+++ b/api/src/opentrons/hardware_control/threaded_async_lock.py
@@ -23,7 +23,7 @@ class ThreadedAsyncLock:
     ``async with`` or a synchronous context manager using ``with``.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._thread_lock = threading.Lock()
 
     def lock(self) -> "_Internal":

--- a/api/src/opentrons/protocols/geometry/deck.py
+++ b/api/src/opentrons/protocols/geometry/deck.py
@@ -42,7 +42,7 @@ class CalibrationPosition:
 
 
 class Deck(UserDict):
-    def __init__(self, load_name=STANDARD_DECK):
+    def __init__(self, load_name: str = STANDARD_DECK) -> None:
         super().__init__()
         row_offset = 90.5
         col_offset = 132.5

--- a/robot-server/.flake8
+++ b/robot-server/.flake8
@@ -33,6 +33,4 @@ per-file-ignores =
     tests/robot/*:ANN,D
     tests/service/*:ANN,D
     tests/conftest.py:ANN,D
-    tests/test_app.py:ANN,D
-    tests/test_hardware_wrapper.py:ANN,D
     tests/test_util.py:ANN,D

--- a/robot-server/mypy.ini
+++ b/robot-server/mypy.ini
@@ -12,14 +12,6 @@ warn_required_dynamic_aliases = True
 warn_untyped_fields = True
 
 
-# TODO(mc, 2021-09-08): upgrade FastAPI and remove this override
-[mypy-fastapi.*]
-no_implicit_reexport = False
-
-# TODO(mc, 2021-09-08): upgrade Pydantic and remove this override
-[mypy-pydantic.*]
-no_implicit_optional = False
-
 # TODO(mc, 2021-09-08): fix and remove any / all of the
 # overrides below whenever able
 
@@ -43,9 +35,3 @@ disallow_untyped_calls = False
 disallow_incomplete_defs = False
 # ~15 errors
 warn_return_any = False
-
-# ~25 errors, total
-[mypy-tests.conftest]
-disallow_untyped_defs = False
-disallow_untyped_calls = False
-disallow_incomplete_defs = False

--- a/robot-server/robot_server/app.py
+++ b/robot-server/robot_server/app.py
@@ -1,7 +1,7 @@
 """Main FastAPI application."""
 import asyncio
 import logging
-from fastapi import FastAPI, Depends
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from opentrons import __version__
@@ -12,7 +12,6 @@ from .hardware import initialize_hardware, cleanup_hardware
 from .service import initialize_logging
 from .service.dependencies import get_protocol_manager
 from .service.legacy.rpc import cleanup_rpc_server
-from .versioning import set_version_headers
 
 log = logging.getLogger(__name__)
 
@@ -28,7 +27,6 @@ app = FastAPI(
     ),
     version=__version__,
     exception_handlers=exception_handlers,
-    dependencies=[Depends(set_version_headers)],
 )
 
 # cors

--- a/robot-server/robot_server/app.py
+++ b/robot-server/robot_server/app.py
@@ -1,11 +1,8 @@
 """Main FastAPI application."""
 import asyncio
 import logging
-from fastapi import FastAPI
+from fastapi import FastAPI, Depends
 from fastapi.middleware.cors import CORSMiddleware
-from starlette.responses import Response
-from starlette.requests import Request
-from starlette.middleware.base import RequestResponseEndpoint
 
 from opentrons import __version__
 
@@ -15,7 +12,7 @@ from .hardware import initialize_hardware, cleanup_hardware
 from .service import initialize_logging
 from .service.dependencies import get_protocol_manager
 from .service.legacy.rpc import cleanup_rpc_server
-from . import constants
+from .versioning import set_version_headers
 
 log = logging.getLogger(__name__)
 
@@ -30,14 +27,9 @@ app = FastAPI(
         "`patternProperties` behavior."
     ),
     version=__version__,
+    exception_handlers=exception_handlers,
+    dependencies=[Depends(set_version_headers)],
 )
-
-# exception handlers
-# TODO(mc, 2021-05-10): after upgrade to FastAPI > 0.61.2, we can pass these
-# to FastAPI's `exception_handlers` arg instead. Current version has bug, see:
-# https://github.com/tiangolo/fastapi/pull/1924
-for exc_cls, handler in exception_handlers.items():
-    app.add_exception_handler(exc_cls, handler)
 
 # cors
 app.add_middleware(
@@ -75,21 +67,3 @@ async def on_shutdown() -> None:
 
     for e in shutdown_errors:
         log.warning("Error during shutdown", exc_info=e)
-
-
-@app.middleware("http")
-async def api_version_response_header(
-    request: Request,
-    call_next: RequestResponseEndpoint,
-) -> Response:
-    """Attach Opentrons-Version headers to responses."""
-    # Attach the version the request state. Optional dependency
-    #  check_version_header will override this value if check passes.
-    request.state.api_version = constants.API_VERSION
-
-    response: Response = await call_next(request)
-
-    # Put the api version in the response header
-    response.headers[constants.API_VERSION_HEADER] = str(request.state.api_version)
-    response.headers[constants.MIN_API_VERSION_HEADER] = str(constants.MIN_API_VERSION)
-    return response

--- a/robot-server/robot_server/constants.py
+++ b/robot-server/robot_server/constants.py
@@ -1,43 +1,6 @@
 """Global constants for the HTTP API server."""
-
-from typing_extensions import Literal, Final
-
-API_VERSION: Final = 2
-"""The current version of the HTTP API used by the server.
-
-This value will be incremented any time the schema of a request or response
-is changed. The value is separate from the overall application version.
-"""
+from typing_extensions import Final
 
 
-MIN_API_VERSION: Final = 2
-"""The minimum HTTP API version supported by the server.
-
-Incrementing this value would be considered a breaking change to the overall
-application, and would result in a major version bump of the software.
-"""
-
-
-API_VERSION_HEADER: Final = "Opentrons-Version"
-"""Custom header to specify which HTTP API version is being requested or served.
-
-Mandatory in requests and response. Can be used by the server and clients to
-negotiate and migrate requests and responses to a version both parties understand.
-"""
-
-
-MIN_API_VERSION_HEADER: Final = "Opentrons-Min-Version"
-"""Header to specify the server's minumum supported HTTP API version.
-
-Mandatory in all responses, not used in requests.
-"""
-
-
-API_VERSION_LATEST_TYPE = Literal["*"]
-
-API_VERSION_LATEST: API_VERSION_LATEST_TYPE = "*"
-"""Version head value meaning 'give me the latest avilable version'"""
-
-
-V1_TAG = "v1"
+V1_TAG: Final[str] = "v1"
 """Tag applied to legacy endpoints that are still supported in HTTP API v2."""

--- a/robot-server/robot_server/errors/exception_handlers.py
+++ b/robot-server/robot_server/errors/exception_handlers.py
@@ -8,6 +8,12 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from traceback import format_exception, format_exception_only
 from typing import Any, Callable, Coroutine, Dict, Optional, Sequence, Type, Union
 
+from robot_server.versioning import (
+    API_VERSION,
+    MIN_API_VERSION,
+    API_VERSION_HEADER,
+    MIN_API_VERSION_HEADER,
+)
 from robot_server.constants import V1_TAG
 from .global_errors import UnexpectedError, BadRequest, InvalidRequest
 
@@ -67,6 +73,10 @@ async def handle_api_error(request: Request, error: ApiError) -> JSONResponse:
     return JSONResponse(
         status_code=error.status_code,
         content=error.content,
+        headers={
+            MIN_API_VERSION_HEADER: f"{MIN_API_VERSION}",
+            API_VERSION_HEADER: f"{API_VERSION}",
+        },
     )
 
 

--- a/robot-server/robot_server/router.py
+++ b/robot-server/robot_server/router.py
@@ -9,7 +9,7 @@ from .health import health_router
 from .protocols import protocols_router
 from .sessions import sessions_router
 from .system import system_router
-from .versioning import verify_version
+from .versioning import check_version_header
 from .service.legacy.routers import legacy_routes
 from .service.session.router import router as deprecated_session_router
 from .service.pipette_offset.router import router as pip_os_router
@@ -34,7 +34,7 @@ router.include_router(
 router.include_router(
     router=health_router,
     tags=["Health", V1_TAG],
-    dependencies=[Depends(verify_version)],
+    dependencies=[Depends(check_version_header)],
     responses={
         status.HTTP_422_UNPROCESSABLE_ENTITY: {
             "model": LegacyErrorResponse,
@@ -47,55 +47,55 @@ if enable_protocol_engine():
     router.include_router(
         router=sessions_router,
         tags=["Session Management"],
-        dependencies=[Depends(verify_version)],
+        dependencies=[Depends(check_version_header)],
     )
 
     router.include_router(
         router=protocols_router,
         tags=["Protocol Management"],
-        dependencies=[Depends(verify_version)],
+        dependencies=[Depends(check_version_header)],
     )
 
 else:
     router.include_router(
         router=deprecated_session_router,
         tags=["Session Management"],
-        dependencies=[Depends(verify_version)],
+        dependencies=[Depends(check_version_header)],
     )
 
     router.include_router(
         router=deprecated_protocol_router,
         tags=["Protocol Management"],
-        dependencies=[Depends(verify_version)],
+        dependencies=[Depends(check_version_header)],
     )
 
 
 router.include_router(
     router=labware_router,
     tags=["Labware Calibration Management"],
-    dependencies=[Depends(verify_version)],
+    dependencies=[Depends(check_version_header)],
 )
 
 router.include_router(
     router=pip_os_router,
     tags=["Pipette Offset Calibration Management"],
-    dependencies=[Depends(verify_version)],
+    dependencies=[Depends(check_version_header)],
 )
 
 router.include_router(
     router=tl_router,
     tags=["Tip Length Calibration Management"],
-    dependencies=[Depends(verify_version)],
+    dependencies=[Depends(check_version_header)],
 )
 
 router.include_router(
     router=notifications_router,
     tags=["Notification Server Management"],
-    dependencies=[Depends(verify_version)],
+    dependencies=[Depends(check_version_header)],
 )
 
 router.include_router(
     router=system_router,
     tags=["System Control"],
-    dependencies=[Depends(verify_version)],
+    dependencies=[Depends(check_version_header)],
 )

--- a/robot-server/robot_server/router.py
+++ b/robot-server/robot_server/router.py
@@ -9,7 +9,7 @@ from .health import health_router
 from .protocols import protocols_router
 from .sessions import sessions_router
 from .system import system_router
-from .service.dependencies import check_version_header
+from .versioning import verify_version
 from .service.legacy.routers import legacy_routes
 from .service.session.router import router as deprecated_session_router
 from .service.pipette_offset.router import router as pip_os_router
@@ -34,7 +34,7 @@ router.include_router(
 router.include_router(
     router=health_router,
     tags=["Health", V1_TAG],
-    dependencies=[Depends(check_version_header)],
+    dependencies=[Depends(verify_version)],
     responses={
         status.HTTP_422_UNPROCESSABLE_ENTITY: {
             "model": LegacyErrorResponse,
@@ -47,55 +47,55 @@ if enable_protocol_engine():
     router.include_router(
         router=sessions_router,
         tags=["Session Management"],
-        dependencies=[Depends(check_version_header)],
+        dependencies=[Depends(verify_version)],
     )
 
     router.include_router(
         router=protocols_router,
         tags=["Protocol Management"],
-        dependencies=[Depends(check_version_header)],
+        dependencies=[Depends(verify_version)],
     )
 
 else:
     router.include_router(
         router=deprecated_session_router,
         tags=["Session Management"],
-        dependencies=[Depends(check_version_header)],
+        dependencies=[Depends(verify_version)],
     )
 
     router.include_router(
         router=deprecated_protocol_router,
         tags=["Protocol Management"],
-        dependencies=[Depends(check_version_header)],
+        dependencies=[Depends(verify_version)],
     )
 
 
 router.include_router(
     router=labware_router,
     tags=["Labware Calibration Management"],
-    dependencies=[Depends(check_version_header)],
+    dependencies=[Depends(verify_version)],
 )
 
 router.include_router(
     router=pip_os_router,
     tags=["Pipette Offset Calibration Management"],
-    dependencies=[Depends(check_version_header)],
+    dependencies=[Depends(verify_version)],
 )
 
 router.include_router(
     router=tl_router,
     tags=["Tip Length Calibration Management"],
-    dependencies=[Depends(check_version_header)],
+    dependencies=[Depends(verify_version)],
 )
 
 router.include_router(
     router=notifications_router,
     tags=["Notification Server Management"],
-    dependencies=[Depends(check_version_header)],
+    dependencies=[Depends(verify_version)],
 )
 
 router.include_router(
     router=system_router,
     tags=["System Control"],
-    dependencies=[Depends(check_version_header)],
+    dependencies=[Depends(verify_version)],
 )

--- a/robot-server/robot_server/service/dependencies.py
+++ b/robot-server/robot_server/service/dependencies.py
@@ -1,30 +1,16 @@
-import typing
 from datetime import datetime, timezone
-from typing_extensions import Literal
 from uuid import uuid4
-from fastapi import Depends, Header, Request, status
+from fastapi import Depends
 
 from opentrons.hardware_control import ThreadManager, ThreadedAsyncLock
 
-from robot_server import constants, util, errors
+from robot_server.util import call_once
 from robot_server.hardware import get_hardware
 from robot_server.service.session.manager import SessionManager
 from robot_server.service.protocol.manager import ProtocolManager
 
 
-class OutdatedApiVersionResponse(errors.ErrorDetails):
-    """An error returned when you request an outdated HTTP API version."""
-
-    id: Literal["OutdatedAPIVersion"] = "OutdatedAPIVersion"
-    title: str = "Requested HTTP API version no longer supported"
-    detail: str = (
-        f"HTTP API version {constants.MIN_API_VERSION - 1} is "
-        "no longer supported. Please upgrade your Opentrons "
-        "App or other HTTP API client."
-    )
-
-
-@util.call_once
+@call_once
 async def get_motion_lock() -> ThreadedAsyncLock:
     """
     Get the single motion lock.
@@ -34,13 +20,13 @@ async def get_motion_lock() -> ThreadedAsyncLock:
     return ThreadedAsyncLock()
 
 
-@util.call_once
+@call_once
 async def get_protocol_manager() -> ProtocolManager:
     """The single protocol manager instance"""
     return ProtocolManager()
 
 
-@util.call_once
+@call_once
 async def get_session_manager(
     hardware: ThreadManager = Depends(get_hardware),
     motion_lock: ThreadedAsyncLock = Depends(get_motion_lock),
@@ -52,33 +38,6 @@ async def get_session_manager(
         motion_lock=motion_lock,
         protocol_manager=protocol_manager,
     )
-
-
-async def check_version_header(
-    request: Request,
-    opentrons_version: typing.Union[int, constants.API_VERSION_LATEST_TYPE] = Header(
-        ...,
-        description=(
-            f"The requested HTTP API version must be at least "
-            f"'{constants.MIN_API_VERSION}' or higher. To use the latest "
-            f"version unconditionally, specify '{constants.API_VERSION_LATEST}'"
-        ),
-    ),
-) -> None:
-    """Dependency that will check that Opentrons-Version header meets
-    requirements."""
-    # Get the maximum version accepted by client
-    requested_version = (
-        int(opentrons_version)
-        if opentrons_version != constants.API_VERSION_LATEST
-        else constants.API_VERSION
-    )
-
-    if requested_version < constants.MIN_API_VERSION:
-        raise OutdatedApiVersionResponse().as_error(status.HTTP_400_BAD_REQUEST)
-    else:
-        # Attach the api version to request's state dict
-        request.state.api_version = min(requested_version, constants.API_VERSION)
 
 
 async def get_unique_id() -> str:

--- a/robot-server/robot_server/service/legacy/models/settings.py
+++ b/robot-server/robot_server/service/legacy/models/settings.py
@@ -173,8 +173,6 @@ class BasePipetteSettingFields(BaseModel):
 PipetteSettingsFields = create_model(
     "PipetteSettingsFields",
     __base__=BasePipetteSettingFields,
-    __config__=None,
-    __validators__=None,
     **{  # type: ignore[arg-type]
         conf: (PipetteSettingsField, None)
         for conf in MUTABLE_CONFIGS

--- a/robot-server/robot_server/service/legacy/routers/__init__.py
+++ b/robot-server/robot_server/service/legacy/routers/__init__.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends
 
-from robot_server.service.dependencies import check_version_header
+from robot_server.versioning import verify_version
 
 from . import (
     networking,
@@ -20,49 +20,49 @@ legacy_routes = APIRouter()
 legacy_routes.include_router(
     router=networking.router,
     tags=["Networking"],
-    dependencies=[Depends(check_version_header)],
+    dependencies=[Depends(verify_version)],
 )
 
 legacy_routes.include_router(
     router=control.router,
     tags=["Control"],
-    dependencies=[Depends(check_version_header)],
+    dependencies=[Depends(verify_version)],
 )
 
 legacy_routes.include_router(
     router=settings.router,
     tags=["Settings"],
-    dependencies=[Depends(check_version_header)],
+    dependencies=[Depends(verify_version)],
 )
 
 legacy_routes.include_router(
     router=deck_calibration.router,
     tags=["Deck Calibration"],
-    dependencies=[Depends(check_version_header)],
+    dependencies=[Depends(verify_version)],
 )
 
 legacy_routes.include_router(
     router=modules.router,
     tags=["Modules"],
-    dependencies=[Depends(check_version_header)],
+    dependencies=[Depends(verify_version)],
 )
 
 legacy_routes.include_router(
     router=pipettes.router,
     tags=["Pipettes"],
-    dependencies=[Depends(check_version_header)],
+    dependencies=[Depends(verify_version)],
 )
 
 legacy_routes.include_router(
     router=motors.router,
     tags=["Motors"],
-    dependencies=[Depends(check_version_header)],
+    dependencies=[Depends(verify_version)],
 )
 
 legacy_routes.include_router(
     router=camera.router,
     tags=["Camera"],
-    dependencies=[Depends(check_version_header)],
+    dependencies=[Depends(verify_version)],
 )
 
 # logs routes are exempt from version header requirements

--- a/robot-server/robot_server/service/legacy/routers/__init__.py
+++ b/robot-server/robot_server/service/legacy/routers/__init__.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends
 
-from robot_server.versioning import verify_version
+from robot_server.versioning import check_version_header, set_version_response_headers
 
 from . import (
     networking,
@@ -20,55 +20,56 @@ legacy_routes = APIRouter()
 legacy_routes.include_router(
     router=networking.router,
     tags=["Networking"],
-    dependencies=[Depends(verify_version)],
+    dependencies=[Depends(check_version_header)],
 )
 
 legacy_routes.include_router(
     router=control.router,
     tags=["Control"],
-    dependencies=[Depends(verify_version)],
+    dependencies=[Depends(check_version_header)],
 )
 
 legacy_routes.include_router(
     router=settings.router,
     tags=["Settings"],
-    dependencies=[Depends(verify_version)],
+    dependencies=[Depends(check_version_header)],
 )
 
 legacy_routes.include_router(
     router=deck_calibration.router,
     tags=["Deck Calibration"],
-    dependencies=[Depends(verify_version)],
+    dependencies=[Depends(check_version_header)],
 )
 
 legacy_routes.include_router(
     router=modules.router,
     tags=["Modules"],
-    dependencies=[Depends(verify_version)],
+    dependencies=[Depends(check_version_header)],
 )
 
 legacy_routes.include_router(
     router=pipettes.router,
     tags=["Pipettes"],
-    dependencies=[Depends(verify_version)],
+    dependencies=[Depends(check_version_header)],
 )
 
 legacy_routes.include_router(
     router=motors.router,
     tags=["Motors"],
-    dependencies=[Depends(verify_version)],
+    dependencies=[Depends(check_version_header)],
 )
 
 legacy_routes.include_router(
     router=camera.router,
     tags=["Camera"],
-    dependencies=[Depends(verify_version)],
+    dependencies=[Depends(check_version_header)],
 )
 
 # logs routes are exempt from version header requirements
 legacy_routes.include_router(
     router=logs.router,
     tags=["Logs"],
+    dependencies=[Depends(set_version_response_headers)],
 )
 
 # RPC websocket route is exempt from version header requirements

--- a/robot-server/robot_server/service/legacy/routers/logs.py
+++ b/robot-server/robot_server/service/legacy/routers/logs.py
@@ -16,6 +16,7 @@ IDENTIFIER_TO_SYSLOG_ID: Dict[LogIdentifier, str] = {
 @router.get("/logs/{log_identifier}", description="Get logs from the robot.")
 async def get_logs(
     log_identifier: LogIdentifier,
+    response: Response,
     format: LogFormat = Query(LogFormat.text, title="Log format type"),
     records: int = Query(
         log_control.DEFAULT_RECORDS,
@@ -31,4 +32,8 @@ async def get_logs(
     }
     format_type, media_type = modes[format]
     output = await log_control.get_records_dumb(syslog_id, records, format_type)
-    return Response(content=output.decode("utf-8"), media_type=media_type)
+    return Response(
+        content=output.decode("utf-8"),
+        media_type=media_type,
+        headers=dict(response.headers),
+    )

--- a/robot-server/robot_server/service/protocol/manager.py
+++ b/robot-server/robot_server/service/protocol/manager.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 class ProtocolManager:
     MAX_COUNT = get_settings().protocol_manager_max_protocols
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._protocols: typing.Dict[str, UploadedProtocol] = {}
 
     def create(

--- a/robot-server/robot_server/versioning.py
+++ b/robot-server/robot_server/versioning.py
@@ -55,10 +55,10 @@ async def check_version_header(
         ),
     ),
 ) -> None:
-    """Get the Opentrons-Version headers and set them in state and response headers.
+    """Get the request's version header and prepare state and response.
 
-    This function hooks into FastAPI via `fastapi.depends`, and should be used
-    as a router or application level dependency.
+    This function should be used inside a `fastapi.Depends` as a router
+    or application dependency.
     """
     if opentrons_version == LATEST_API_VERSION_HEADER_VALUE:
         api_version = API_VERSION
@@ -80,13 +80,11 @@ async def check_version_header(
     response.headers[MIN_API_VERSION_HEADER] = f"{MIN_API_VERSION}"
 
 
-async def set_version_response_headers(request: Request, response: Response) -> None:
+async def set_version_response_headers(response: Response) -> None:
     """Set Opentrons-Version headers on the response, without checking the request.
 
-    This function hooks into FastAPI via `fastapi.depends`, and should be used
-    as a router or application level dependency.
+    This function should be used inside a `fastapi.Depends` as a router
+    or application dependency.
     """
-    api_version = getattr(request.state, "api_version", API_VERSION)
-
-    response.headers[API_VERSION_HEADER] = f"{api_version}"
+    response.headers[API_VERSION_HEADER] = f"{API_VERSION}"
     response.headers[MIN_API_VERSION_HEADER] = f"{MIN_API_VERSION}"

--- a/robot-server/robot_server/versioning.py
+++ b/robot-server/robot_server/versioning.py
@@ -1,0 +1,100 @@
+"""HTTP API versioning logic, utilities, and dependencies."""
+from fastapi import Depends, Header, Request, Response, status
+from typing import Union
+from typing_extensions import Literal, Final
+
+from robot_server.errors import ErrorDetails
+
+API_VERSION: Final[int] = 2
+"""The current version of the HTTP API used by the server.
+
+This value will be incremented any time the schema of a request or response
+is changed. The value is separate from the overall application version.
+"""
+
+MIN_API_VERSION: Final[int] = 2
+"""The minimum HTTP API version supported by the server.
+
+Incrementing this value would be considered a breaking change to the overall
+application, and would result in a major version bump of the software.
+"""
+
+API_VERSION_HEADER: Final[str] = "Opentrons-Version"
+"""Custom header to specify which HTTP API version is being requested or served.
+
+Mandatory in requests and response. Can be used by the server and clients to
+negotiate and migrate requests and responses to a version both parties understand.
+"""
+
+MIN_API_VERSION_HEADER: Final[str] = "Opentrons-Min-Version"
+"""Header to specify the server's minumum supported HTTP API version.
+
+Mandatory in all responses, not used in requests.
+"""
+
+LATEST_API_VERSION_HEADER_VALUE: Literal["*"] = "*"
+"""Version head value meaning 'give me the latest avilable version'"""
+
+
+class OutdatedApiVersionResponse(ErrorDetails):
+    """An error returned when you request an outdated HTTP API version."""
+
+    id: Literal["OutdatedAPIVersion"] = "OutdatedAPIVersion"
+    title: str = "Requested HTTP API version no longer supported"
+
+
+async def set_version_headers(
+    request: Request,
+    response: Response,
+    opentrons_version: Union[int, Literal["*"]] = Header(
+        ...,
+        description=(
+            "The HTTP API version to use for this request. Must be "
+            f"'{MIN_API_VERSION}' or higher. To use the latest "
+            f"version unconditionally, specify '{LATEST_API_VERSION_HEADER_VALUE}'"
+        ),
+    ),
+) -> None:
+    """Set Opentrons-Version headers on the request and response.
+
+    This function hooks into FastAPI via `fastapi.depends`, and can be
+    used as a router-level dependency.
+
+    Arguments:
+        opentrons_version: The value of an incoming `Opentrons-Version` header.
+        request: The request object, used to set request state.
+        response: A mutable future response, used to set outgoing headers
+    """
+    if opentrons_version == LATEST_API_VERSION_HEADER_VALUE:
+        api_version = API_VERSION
+    else:
+        api_version = min(API_VERSION, int(opentrons_version))
+
+    request.state.api_version = api_version
+    response.headers[API_VERSION_HEADER] = f"{api_version}"
+    response.headers[MIN_API_VERSION_HEADER] = f"{MIN_API_VERSION}"
+
+
+async def verify_version(
+    request: Request,
+    _: None = Depends(set_version_headers),
+) -> None:
+    """Check the requested API version, and raise an error if invalid.
+
+    This function hooks into FastAPI via `fastapi.depends`, and can be
+    used as a router-level dependency.
+
+    Arguments:
+        request: The request object, used to get request state.
+    """
+    api_version = request.state.api_version
+
+    if api_version < MIN_API_VERSION:
+        error_detail = (
+            f"The requested API version '{api_version}' is not supported."
+            f" '{API_VERSION_HEADER}' must be at least '{MIN_API_VERSION}'."
+            f" Please upgrade your Opentrons App or other HTTP API client."
+        )
+        raise OutdatedApiVersionResponse(detail=error_detail).as_error(
+            status.HTTP_400_BAD_REQUEST
+        )

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -20,7 +20,12 @@ from typing_extensions import NoReturn
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 from opentrons import config
-from opentrons.hardware_control import API, HardwareAPILike, ThreadedAsyncLock
+from opentrons.hardware_control import (
+    API,
+    HardwareAPILike,
+    ThreadedAsyncLock,
+    ThreadManager,
+)
 from opentrons.protocols.context.protocol_api.labware import LabwareImplementation
 from opentrons.calibration_storage import delete, modify, helpers
 from opentrons.protocol_api import labware
@@ -28,8 +33,8 @@ from opentrons.types import Point, Mount
 from opentrons.protocols.geometry.deck import Deck
 
 from robot_server.app import app
-from robot_server.constants import API_VERSION_HEADER, API_VERSION_LATEST
-from robot_server.service.dependencies import get_hardware
+from robot_server.hardware import get_hardware
+from robot_server.versioning import API_VERSION_HEADER, LATEST_API_VERSION_HEADER_VALUE
 from robot_server.service.protocol.manager import ProtocolManager
 from robot_server.service.session.manager import SessionManager
 
@@ -79,7 +84,7 @@ def override_hardware(hardware: MagicMock) -> None:
 @pytest.fixture
 def api_client(override_hardware: None) -> TestClient:
     client = TestClient(app)
-    client.headers.update({API_VERSION_HEADER: API_VERSION_LATEST})
+    client.headers.update({API_VERSION_HEADER: LATEST_API_VERSION_HEADER_VALUE})
     return client
 
 
@@ -88,19 +93,19 @@ def api_client_no_errors(override_hardware: None) -> TestClient:
     """An API client that won't raise server exceptions.
     Use only to test 500 pages; never use this for other tests."""
     client = TestClient(app, raise_server_exceptions=False)
-    client.headers.update({API_VERSION_HEADER: API_VERSION_LATEST})
+    client.headers.update({API_VERSION_HEADER: LATEST_API_VERSION_HEADER_VALUE})
     return client
 
 
 @pytest.fixture(scope="session")
-def request_session():
+def request_session() -> requests.Session:
     session = requests.Session()
-    session.headers.update({API_VERSION_HEADER: API_VERSION_LATEST})
+    session.headers.update({API_VERSION_HEADER: LATEST_API_VERSION_HEADER_VALUE})
     return session
 
 
 @pytest.fixture(scope="session")
-def server_temp_directory():
+def server_temp_directory() -> Iterator[str]:
     new_dir = tempfile.mkdtemp()
     os.environ["OT_API_CONFIG_DIR"] = new_dir
     config.reload()
@@ -112,7 +117,9 @@ def server_temp_directory():
 
 
 @pytest.fixture(scope="session")
-def run_server(request_session, server_temp_directory):
+def run_server(
+    request_session: requests.Session, server_temp_directory: str
+) -> Iterator["subprocess.Popen[Any]"]:
     """Run the robot server in a background process."""
     # In order to collect coverage we run using `coverage`.
     # `-a` is to append to existing `.coverage` file.
@@ -161,7 +168,7 @@ def run_server(request_session, server_temp_directory):
 
 
 @pytest.fixture
-def attach_pipettes(server_temp_directory):
+def attach_pipettes(server_temp_directory: str) -> Iterator[None]:
     import json
 
     pipette = {"dropTipShake": True, "model": "p300_multi_v1"}
@@ -176,7 +183,7 @@ def attach_pipettes(server_temp_directory):
 
 
 @pytest.fixture
-def set_up_index_file_temporary_directory(server_temp_directory):
+def set_up_index_file_temporary_directory(server_temp_directory: str) -> None:
     delete.clear_calibrations()
     deck = Deck()
     labware_list = [
@@ -194,7 +201,7 @@ def set_up_index_file_temporary_directory(server_temp_directory):
 
 
 @pytest.fixture
-def set_up_pipette_offset_temp_directory(server_temp_directory):
+def set_up_pipette_offset_temp_directory(server_temp_directory: str) -> None:
     attached_pip_list = ["123", "321"]
     mount_list = [Mount.LEFT, Mount.RIGHT]
     definition = labware.get_labware_definition("opentrons_96_filtertiprack_200ul")
@@ -210,7 +217,7 @@ def set_up_pipette_offset_temp_directory(server_temp_directory):
 
 
 @pytest.fixture
-def set_up_tip_length_temp_directory(server_temp_directory):
+def set_up_tip_length_temp_directory(server_temp_directory: str) -> None:
     attached_pip_list = ["123", "321"]
     tip_length_list = [30.5, 31.5]
     definition = labware.get_labware_definition("opentrons_96_filtertiprack_200ul")
@@ -223,13 +230,13 @@ def set_up_tip_length_temp_directory(server_temp_directory):
 
 
 @pytest.fixture
-def set_up_deck_calibration_temp_directory(server_temp_directory):
+def set_up_deck_calibration_temp_directory(server_temp_directory: str) -> None:
     attitude = [[1.0008, 0.0052, 0.0], [-0.0, 0.992, 0.0], [0.0, 0.0, 1.0]]
     modify.save_robot_deck_attitude(attitude, "pip_1", "fakehash")
 
 
 @pytest.fixture
-def session_manager(hardware) -> SessionManager:
+def session_manager(hardware: ThreadManager) -> SessionManager:
     return SessionManager(
         hardware=hardware,
         motion_lock=ThreadedAsyncLock(),
@@ -238,7 +245,9 @@ def session_manager(hardware) -> SessionManager:
 
 
 @pytest.fixture
-def set_enable_http_protocol_sessions(request_session) -> Iterator[None]:
+def set_enable_http_protocol_sessions(
+    request_session: requests.Session,
+) -> Iterator[None]:
     """For integration tests that need to set then clear the
     enableHttpProtocolSessions feature flag"""
     url = "http://localhost:31950/settings"

--- a/robot-server/tests/integration/test_version_headers.tavern.yaml
+++ b/robot-server/tests/integration/test_version_headers.tavern.yaml
@@ -1,0 +1,70 @@
+---
+test_name: Version headers
+
+marks:
+  - usefixtures:
+      - run_server
+
+stages:
+  - name: Successful request contains version headers
+    request:
+      url: '{host:s}:{port:d}/health'
+      method: GET
+    response:
+      status_code: 200
+      headers:
+        Opentrons-Version: '2'
+        Opentrons-Min-Version: '2'
+
+  - name: Version too high request contains version headers
+    request:
+      url: '{host:s}:{port:d}/health'
+      method: GET
+      headers:
+        Opentrons-Version: '1337'
+    response:
+      status_code: 200
+      headers:
+        Opentrons-Version: '2'
+        Opentrons-Min-Version: '2'
+
+  - name: Latest version request contains version headers
+    request:
+      url: '{host:s}:{port:d}/health'
+      method: GET
+      headers:
+        Opentrons-Version: '*'
+    response:
+      status_code: 200
+      headers:
+        Opentrons-Version: '2'
+        Opentrons-Min-Version: '2'
+
+  - name: Version too low request contains version headers
+    request:
+      url: '{host:s}:{port:d}/health'
+      method: GET
+      headers:
+        Opentrons-Version: '1'
+    response:
+      status_code: 400
+      json:
+        errors:
+          - id: 'OutdatedAPIVersion'
+            title: 'Requested HTTP API version no longer supported'
+            detail: The requested API version '1' is not supported. 'Opentrons-Version' must be at least '2'. Please upgrade your Opentrons App or other HTTP API client.
+      headers:
+        Opentrons-Version: '2'
+        Opentrons-Min-Version: '2'
+
+  - name: Version missing request contains version headers
+    request:
+      url: '{host:s}:{port:d}/health'
+      method: GET
+      headers:
+        Opentrons-Version: ''
+    response:
+      status_code: 422
+      headers:
+        Opentrons-Version: '2'
+        Opentrons-Min-Version: '2'

--- a/robot-server/tests/test_app.py
+++ b/robot-server/tests/test_app.py
@@ -32,6 +32,5 @@ def test_api_versioning_non_versions_endpoints(
     """It should not enforce versioning requirements on some endpoints."""
     del api_client.headers["Opentrons-Version"]
     resp = api_client.get(path)
-    print(resp.headers)
     assert resp.status_code != status.HTTP_422_UNPROCESSABLE_ENTITY
     assert resp.headers.get(API_VERSION_HEADER) == str(API_VERSION)

--- a/robot-server/tests/test_app.py
+++ b/robot-server/tests/test_app.py
@@ -1,47 +1,16 @@
+"""Tests for FastAPI application object of the robot server."""
 import pytest
 from mock import MagicMock, patch
 from http import HTTPStatus
 from fastapi.testclient import TestClient
-from typing import Dict, Iterator
+from typing import Iterator
 
-from robot_server.constants import (
-    API_VERSION_HEADER,
-    MIN_API_VERSION_HEADER,
-    API_VERSION,
-    API_VERSION_LATEST,
-    MIN_API_VERSION,
-)
-
-
-@pytest.mark.parametrize(
-    argnames=["headers", "expected_version"],
-    argvalues=[
-        [
-            {API_VERSION_HEADER: str(API_VERSION)},
-            API_VERSION,
-        ],
-        [
-            {API_VERSION_HEADER: str(API_VERSION + 3)},
-            API_VERSION,
-        ],
-        [
-            {API_VERSION_HEADER: str(API_VERSION_LATEST)},
-            API_VERSION,
-        ],
-    ],
-)
-def test_api_versioning(
-    api_client: TestClient,
-    headers: Dict[str, str],
-    expected_version: int,
-) -> None:
-    resp = api_client.get("/settings", headers=headers)
-    assert resp.headers.get(API_VERSION_HEADER) == str(expected_version)
-    assert resp.headers.get(MIN_API_VERSION_HEADER) == str(MIN_API_VERSION)
+from robot_server.versioning import API_VERSION_HEADER, API_VERSION
 
 
 @pytest.fixture
 def mock_log_control() -> Iterator[MagicMock]:
+    """Patch out the log retrieval logic."""
     with patch("opentrons.system.log_control.get_records_dumb") as p:
         p.return_value = b""
         yield p
@@ -50,9 +19,6 @@ def mock_log_control() -> Iterator[MagicMock]:
 @pytest.mark.parametrize(
     argnames="path",
     argvalues=[
-        "/openapi.json",
-        "/redoc",
-        "/docs",
         "/logs/serial.log",
         "/logs/api.log",
         "/logs/some-random-journald-thing",
@@ -64,43 +30,8 @@ def test_api_versioning_non_versions_endpoints(
     path: str,
     mock_log_control: MagicMock,
 ) -> None:
+    """It should not enforce versioning requirements on some endpoints."""
     del api_client.headers["Opentrons-Version"]
     resp = api_client.get(path)
     assert resp.headers.get(API_VERSION_HEADER) == str(API_VERSION)
     assert resp.status_code != HTTPStatus.BAD_REQUEST
-
-
-def test_api_version_too_low(api_client: TestClient) -> None:
-    """It should reject any API version lower than 2."""
-    resp = api_client.get("/settings", headers={API_VERSION_HEADER: "1"})
-
-    assert resp.status_code == HTTPStatus.BAD_REQUEST
-    assert resp.headers.get(API_VERSION_HEADER) == str(API_VERSION)
-    assert resp.json()["errors"] == [
-        {
-            "id": "OutdatedAPIVersion",
-            "title": "Requested HTTP API version no longer supported",
-            "detail": (
-                "HTTP API version 1 is no longer supported. Please upgrade "
-                "your Opentrons App or other HTTP API client."
-            ),
-        }
-    ]
-
-
-@pytest.mark.parametrize(
-    argnames="path",
-    argvalues=[
-        "/sessions",
-        "/protocols",
-        "/system/time",
-        "/calibration/pipette_offset",
-        "/calibration/tip_length",
-    ],
-)
-def test_api_version_missing(api_client: TestClient, path: str) -> None:
-    """It should reject any request without an version header."""
-    del api_client.headers["Opentrons-Version"]
-    resp = api_client.get(path)
-
-    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY

--- a/robot-server/tests/test_app.py
+++ b/robot-server/tests/test_app.py
@@ -1,7 +1,7 @@
 """Tests for FastAPI application object of the robot server."""
 import pytest
 from mock import MagicMock, patch
-from http import HTTPStatus
+from fastapi import status
 from fastapi.testclient import TestClient
 from typing import Iterator
 
@@ -21,7 +21,6 @@ def mock_log_control() -> Iterator[MagicMock]:
     argvalues=[
         "/logs/serial.log",
         "/logs/api.log",
-        "/logs/some-random-journald-thing",
         "/",
     ],
 )
@@ -33,5 +32,6 @@ def test_api_versioning_non_versions_endpoints(
     """It should not enforce versioning requirements on some endpoints."""
     del api_client.headers["Opentrons-Version"]
     resp = api_client.get(path)
+    print(resp.headers)
+    assert resp.status_code != status.HTTP_422_UNPROCESSABLE_ENTITY
     assert resp.headers.get(API_VERSION_HEADER) == str(API_VERSION)
-    assert resp.status_code != HTTPStatus.BAD_REQUEST

--- a/robot-server/tests/test_versioning.py
+++ b/robot-server/tests/test_versioning.py
@@ -1,0 +1,73 @@
+"""Tests for API versioning logic.
+
+These tests are to ensure API versioning plays nicely with FastAPI. Header
+and response tests are in `tests/integration/test_version_headers.tavern.yaml`.
+"""
+import pytest
+from fastapi import FastAPI, APIRouter, Request, Depends
+from fastapi.testclient import TestClient
+from typing import Dict
+
+from robot_server.errors import exception_handlers
+from robot_server.versioning import API_VERSION, set_version_headers
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    """Get a FastAPI application."""
+    return FastAPI(exception_handlers=exception_handlers)
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    """Get a TestClient for the FastAPI application fixture."""
+    return TestClient(app)
+
+
+def test_set_version_headers(app: FastAPI, client: TestClient) -> None:
+    """It should put Opentrons-Version header in request state."""
+
+    @app.get("/foobar")
+    def _get_foobar(
+        request: Request,
+        _: None = Depends(set_version_headers),
+    ) -> Dict[str, str]:
+        assert request.state.api_version == 2
+        return {"hello": "world"}
+
+    result = client.get("/foobar", headers={"Opentrons-Version": "2"})
+    assert result.status_code == 200
+
+
+def test_set_version_headers_on_route(app: FastAPI, client: TestClient) -> None:
+    """It should set version state with a route dependency."""
+    router = APIRouter(dependencies=[Depends(set_version_headers)])
+
+    @router.get("/foobar")
+    def _get_foobar(request: Request) -> Dict[str, str]:
+        assert request.state.api_version == 2
+        return {"hello": "world"}
+
+    app.include_router(router)
+
+    result = client.get("/foobar", headers={"Opentrons-Version": "2"})
+    assert result.status_code == 200
+
+
+def test_uses_latest_available_version(app: FastAPI, client: TestClient) -> None:
+    """It should set state according to the latest available version.
+
+    A client may request a later version than is available, and the server
+    should let that client know it's responding with an earlier version.
+    """
+
+    @app.get("/foobar")
+    def _get_foobar(
+        request: Request,
+        _: None = Depends(set_version_headers),
+    ) -> Dict[str, str]:
+        assert request.state.api_version == API_VERSION
+        return {"hello": "world"}
+
+    result = client.get("/foobar", headers={"Opentrons-Version": "1337"})
+    assert result.status_code == 200

--- a/robot-server/tests/test_versioning.py
+++ b/robot-server/tests/test_versioning.py
@@ -9,7 +9,7 @@ from fastapi.testclient import TestClient
 from typing import Dict
 
 from robot_server.errors import exception_handlers
-from robot_server.versioning import API_VERSION, set_version_headers
+from robot_server.versioning import API_VERSION, check_version_header
 
 
 @pytest.fixture
@@ -24,13 +24,13 @@ def client(app: FastAPI) -> TestClient:
     return TestClient(app)
 
 
-def test_set_version_headers(app: FastAPI, client: TestClient) -> None:
+def test_check_version_headers(app: FastAPI, client: TestClient) -> None:
     """It should put Opentrons-Version header in request state."""
 
     @app.get("/foobar")
     def _get_foobar(
         request: Request,
-        _: None = Depends(set_version_headers),
+        _: None = Depends(check_version_header),
     ) -> Dict[str, str]:
         assert request.state.api_version == 2
         return {"hello": "world"}
@@ -41,7 +41,7 @@ def test_set_version_headers(app: FastAPI, client: TestClient) -> None:
 
 def test_set_version_headers_on_route(app: FastAPI, client: TestClient) -> None:
     """It should set version state with a route dependency."""
-    router = APIRouter(dependencies=[Depends(set_version_headers)])
+    router = APIRouter(dependencies=[Depends(check_version_header)])
 
     @router.get("/foobar")
     def _get_foobar(request: Request) -> Dict[str, str]:
@@ -64,7 +64,7 @@ def test_uses_latest_available_version(app: FastAPI, client: TestClient) -> None
     @app.get("/foobar")
     def _get_foobar(
         request: Request,
-        _: None = Depends(set_version_headers),
+        _: None = Depends(check_version_header),
     ) -> Dict[str, str]:
         assert request.state.api_version == API_VERSION
         return {"hello": "world"}

--- a/robot-server/tests/test_versioning.py
+++ b/robot-server/tests/test_versioning.py
@@ -24,7 +24,7 @@ def client(app: FastAPI) -> TestClient:
     return TestClient(app)
 
 
-def test_check_version_headers(app: FastAPI, client: TestClient) -> None:
+def test_check_version_header(app: FastAPI, client: TestClient) -> None:
     """It should put Opentrons-Version header in request state."""
 
     @app.get("/foobar")
@@ -39,7 +39,7 @@ def test_check_version_headers(app: FastAPI, client: TestClient) -> None:
     assert result.status_code == 200
 
 
-def test_set_version_headers_on_route(app: FastAPI, client: TestClient) -> None:
+def test_check_version_header_on_route(app: FastAPI, client: TestClient) -> None:
     """It should set version state with a route dependency."""
     router = APIRouter(dependencies=[Depends(check_version_header)])
 
@@ -54,7 +54,7 @@ def test_set_version_headers_on_route(app: FastAPI, client: TestClient) -> None:
     assert result.status_code == 200
 
 
-def test_uses_latest_available_version(app: FastAPI, client: TestClient) -> None:
+def test_check_version_header_fallback(app: FastAPI, client: TestClient) -> None:
     """It should set state according to the latest available version.
 
     A client may request a later version than is available, and the server


### PR DESCRIPTION
## Overview

Due to [an existing bug in Starlette](https://github.com/encode/starlette/issues/919), our custom middleware that adds the response headers `Opentrons-Version` and `Opentrons-Min-Version` would cause any request that comes in while a background task is running to wait until that potentially very long running task is finished.

In new HTTP endpoints that deal with protocol runs, this is a bad problem!

This change fixes the issue by moving response version header responsibilities to a FastAPI dependency rather than
middleware/

## Changelog

- Replace existing request header version check dependency and response header middleware with:
    - An app-level dependency to read request headers, set request state, and set response headers
    - A router-level dependency to enforce the version check on any routes that need it
- Ensure that error responses still contain version headers

**Note:** with this change, FastAPI provided endpoints like `openapi.json`, `/docs`, etc. **no longer have Opentrons-Version headers**. I'm ok with this, but be loud about it if you're not. The only solution if we think we need those headers is to go back to middleware.

## Review requests

- [ ] `/logs` endpoints and RPC websocket endpoint work without version headers
    - [ ] `/logs` endpoint still has version headers in response
- [ ] FastAPI endpoints `/docs`, `/openapi.json`, etc, still work without version headers
- [ ] All other endpoints require request headers and set response headers correctly

## Risk assessment

I replaced most versioning tests with Tavern integration tests because they offer the highest degree of safety and reliability for this functionality. Given these integration tests are in place, I think this is a pretty low risk PR
