### PR TITLE
fix(hardware): add setup.cfg in order to conform to wheel naming standard.

### DIFF
--- a/hardware/setup.cfg
+++ b/hardware/setup.cfg
@@ -1,0 +1,11 @@
+[bdist_wheel]
+universal = 1
+
+[metadata]
+license_file = ../LICENSE
+
+[pep8]
+ignore = E221,E222
+
+[aliases]
+test=pytest


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

from @mcous 
```
Anyone have any idea why the api , shared-data/python, robot-server, etc. spit out {name}-{version}-py2.py3-none-any.whl but hardware spits out opentrons_hardware-4.5.0-py3-none-any.whl (no py2 in the wheel name)?
```

I forgot to add `setup.cfg` which defines bdist_wheel:universal=1.


# Changelog

Add setup.cfg

# Review requests


# Risk assessment

None