### PR TITLE
refactor(protocol-timer): do not log warnings for no-duration commands

### DIFF
--- a/api/src/opentrons/protocols/duration/estimator.py
+++ b/api/src/opentrons/protocols/duration/estimator.py
@@ -89,7 +89,8 @@ class DurationEstimator:
         payload = message["payload"]
 
         # We cannot handle paired pipette messages
-        if "instruments" in payload or "locations" in payload:
+        # locations also applies to transfer commands
+        if "instruments" in payload:
             logger.warning(
                 f"Paired pipettes are not supported by the duration estimator. "
                 f"Command '{payload['text']}' cannot be estimated properly."
@@ -164,6 +165,15 @@ class DurationEstimator:
             duration = self.on_thermocycler_deactivate_lid(payload=payload)
         elif message_name == types.THERMOCYCLER_OPEN:
             duration = self.on_thermocycler_lid_open(payload=payload)
+        elif message_name == types.TRANSFER:
+            # Already accounted for in other steps
+            pass
+        elif message_name == types.DISTRIBUTE:
+            pass
+        elif message_name == types.CONSOLIDATE:
+            pass
+        elif message_name == types.COMMENT:
+            pass
         else:
             logger.warning(
                 f"Command type '{message_name}' is not yet supported by the "
@@ -291,7 +301,6 @@ class DurationEstimator:
         # So we are defaulting to 0.5 seconds
         duration = 0.5
         logger.info(f"blowing_out_for {duration} seconds, in slot {curr_slot}")
-
         return duration
 
     def on_touch_tip(self, payload) -> float:
@@ -304,7 +313,6 @@ class DurationEstimator:
         # depth = plate['A1'].diameter
         duration = 0.5
         logger.info(f"touch_tip for {duration} seconds")
-
         return duration
 
     def on_delay(self, payload) -> float:
@@ -394,7 +402,6 @@ class DurationEstimator:
         duration = 24
         thermoaction = "closing"
         logger.info(f"thermocation =  {thermoaction}")
-
         return duration
 
     def on_thermocycler_lid_open(self, payload) -> float:
@@ -402,7 +409,6 @@ class DurationEstimator:
         duration = 24
         thermoaction = "opening"
         logger.info(f"thermocation =  {thermoaction}")
-
         return duration
 
     def on_thermocycler_deactivate_lid(self, payload) -> float:
@@ -410,7 +416,6 @@ class DurationEstimator:
         duration = 23
         thermoaction = "Deactivating"
         logger.info(f"thermocation =  {thermoaction}")
-
         return duration
 
     def on_tempdeck_set_temp(self, payload) -> float:


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Exception handling on line 93 caught transfers because it was using
```python3 
 if "instruments"  or "locations" in payload:
```

Which would catch [transfers](https://github.com/Opentrons/opentrons/blob/0e5191147652fbe8c0d50ccdf0e6f0ba3f33e0d9/api/src/opentrons/commands/commands.py)
since both pair_with and transfers take the **locations** argument. 

<img width="697" alt="Screen Shot 2021-09-20 at 10 33 38 PM" src="https://user-images.githubusercontent.com/65437763/134103037-ef1803b3-3661-4626-a866-71490deba410.png">


Also to accommodate  our error catcher I added the commands 
` types.TRANSFER, types.CONSOLIDATE, types.COMMENT `

since they are supported by the duration estimator, but don't add/subtrack time from the total run time.
``` Python3
logger.warning(
                f"Command type '{message_name}' is not yet supported by the "
                f"duration estimator."
            )
```

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

Maybe I should have added a #ToDo to warn folks that they have to add their own pause times? 

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

Low. Only changed estimator.py and ensured that it only caught relevant errors (pair_with, protocol.pause, etc.). 
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
