### PR TITLE
fix(api): Improve metadata parse error messages and fix metadata typechecking

### DIFF
--- a/api/src/opentrons/protocol_runner/pre_analysis.py
+++ b/api/src/opentrons/protocol_runner/pre_analysis.py
@@ -113,11 +113,7 @@ def _analyze_python(
 
     try:
         metadata = extract_python_metadata(module_ast)
-    except Exception as exception:
-        # todo(mm, 2021-09-13):
-        # Characterize how extract_python_metadata() is allowed to fail,
-        # make it raise a good exception type to indicate that failure,
-        # and catch that exception type here.
+    except ValueError as exception:
         raise PythonMetadataError() from exception
 
     try:

--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -237,7 +237,6 @@ def extract_metadata(parsed: ast.Module) -> Metadata:
             # expressions that aren't statically or "safely" evaluable, like
             # `{"o": object()}` or `{"s": "abc"[0]}`.
             except ValueError as exception:
-                # todo(mm, 2021-09-21): Raise a custom exception type.
                 raise ValueError(
                     "Could not read the contents of the metadata dict."
                     " Make sure it doesn't contain any complex expressions, such as"
@@ -249,7 +248,6 @@ def extract_metadata(parsed: ast.Module) -> Metadata:
             assert isinstance(evaluated_literal, dict)
 
             for key, value in evaluated_literal.items():
-                # todo(mm, 2021-09-21): Raise a custom exception type.
                 if not isinstance(key, str):
                     raise ValueError(
                         f'metadata keys must be strings, but "{key}"'

--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -250,13 +250,13 @@ def extract_metadata(parsed: ast.Module) -> Metadata:
             for key, value in evaluated_literal.items():
                 if not isinstance(key, str):
                     raise ValueError(
-                        f'metadata keys must be strings, but "{key}"'
-                        f" has type {type(key)}"
+                        f'metadata keys must be strings, but key "{key}"'
+                        f' has type "{type(key).__name__}".'
                     )
                 if not isinstance(value, str):
                     raise ValueError(
-                        f"metadata values must be strings, but {value}"
-                        f" has type {type(value)}"
+                        f'metadata values must be strings, but value "{value}"'
+                        f' has type "{type(value).__name__}".'
                     )
 
             metadata = evaluated_literal

--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -209,20 +209,60 @@ def parse(
 
 
 def extract_metadata(parsed: ast.Module) -> Metadata:
+    """Return the contents of a Python protocol's ``metadata`` block.
+
+    Returns:
+        The contents of module's ``metadata`` block, if succeeded.
+
+        ``{}``, if the module never assigns a dict to a variable named  ``metadata``.
+
+    Raises:
+        ``ValueError``, if `parsed` does assign a dict to a variable named ``metadata``,
+        but either:
+
+        * That dict is not statically parsable
+        * That dict contains unsupported types
+    """
     metadata: Metadata = {}
     assigns = [obj for obj in parsed.body if isinstance(obj, ast.Assign)]
     for obj in assigns:
-        # XXX This seems brittle and could probably do with
-        # - enough love that we can remove the type: ignores
-        # - some thought about exactly what types are allowed in metadata
         if (
             isinstance(obj.targets[0], ast.Name)
             and obj.targets[0].id == "metadata"
             and isinstance(obj.value, ast.Dict)
         ):
-            keys = [k.s for k in obj.value.keys]  # type: ignore
-            values = [v.s for v in obj.value.values]  # type: ignore
-            metadata = dict(zip(keys, values))
+            try:
+                evaluated_literal = ast.literal_eval(obj.value)
+            # Undocumented, but ast.literal_eval() seems to raise ValueError for
+            # expressions that aren't statically or "safely" evaluable, like
+            # `{"o": object()}` or `{"s": "abc"[0]}`.
+            except ValueError as exception:
+                # todo(mm, 2021-09-21): Raise a custom exception type.
+                raise ValueError(
+                    "Could not read the contents of the metadata dict."
+                    " Make sure it doesn't contain any complex expressions, such as"
+                    " function calls or array indexings."
+                ) from exception
+
+            # ast.literal_eval() is typed as returning Any, but we're pretty sure it
+            # should return a dict in this case because we passed it an ast.Dict.
+            assert isinstance(evaluated_literal, dict)
+
+            for key, value in evaluated_literal.items():
+                # todo(mm, 2021-09-21): Raise a custom exception type.
+                if not isinstance(key, str):
+                    raise ValueError(
+                        f'metadata keys must be strings, but "{key}"'
+                        f" has type {type(key)}"
+                    )
+                if not isinstance(value, str):
+                    raise ValueError(
+                        f"metadata values must be strings, but {value}"
+                        f" has type {type(value)}"
+                    )
+
+            metadata = evaluated_literal
+
     return metadata
 
 

--- a/api/src/opentrons/protocols/types.py
+++ b/api/src/opentrons/protocols/types.py
@@ -10,7 +10,11 @@ if TYPE_CHECKING:
     )
     from .api_support.types import APIVersion
 
-Metadata = Dict[str, Union[str, int]]
+
+# This metadata type reflects existing behavior,
+# but there's no reason we couldn't change this to allow types other than strings.
+# Issue for fleshing out metadata spec: github.com/Opentrons/opentrons/issues/8334
+Metadata = Dict[str, str]
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
# Overview

Closes #8352.

# Changelog

* Rely on the handy Python standard library function [`ast.literal_eval()`](https://docs.python.org/3.7/library/ast.html#ast.literal_eval]) to read the `metadata` dict. We still need to traverse the AST manually to find the node representing the dict, but once we have it, `ast.literal_eval()` extracts the dict's keys and values more safely and maintainably than we were doing before.
* Explicitly validate that the dict's keys and values are of a supported type, and raise a descriptive error if they aren't. Formerly, this would raise an obscure `AttributeError`.
* Adjust `opentrons.protocols.types.Metadata` so that it does not allow `int` values, making `str` the only supported type. This reflects reality; as far as I can tell, `extract_metadata()` has, for a long time, been failing for `int`s. Further thinking of what should be allowed in metadata is ticketed as #8334.
* **Technically a breaking change:** Before, we allowed *byte literals* to appear in metadata. For example, {"key": b"value"}`. Now, we do not.
    * It looks like it was unintentional that we allowed this in the first place, since it was contrary to the function's return type annotation.
    * I doubt any protocols in the wild relied on this. But I will double-check with Applications Engineering and Support.


# Review requests

* Code review: The functionality of `extract_metadata()` appears to have been preserved.
  * It does not allow anything that was not already allowed before.
  * It does not forbid anything that was not already forbidden before, except for byte literals.
  * Edge cases (missing metadata, invalid metadata) behave the same.
* Did https://github.com/Opentrons/opentrons/issues/8352#issuecomment-924137124 miss any important test cases?
* [x] @SyntaxColoring to confirm with Applications Engineering and Support that we've never seen metadata with byte literals
* [x] Smoke tests: Upload a protocol with good metadata and confirm that it succeeds. Upload a protocol with bad metadata and confirm that the error message is descriptive.
    * @SyntaxColoring tested on a local dev server.


# Risk assessment

I think pretty low. I tried to keep this minimally-scoped. I am, however, unfamiliar with this part of the code, so I could be missing something.