### PR TITLE
refactor(protocol-engine): add plugin for play/pause support of PAPIv2

### DIFF
--- a/api/src/opentrons/protocol_engine/__init__.py
+++ b/api/src/opentrons/protocol_engine/__init__.py
@@ -10,6 +10,8 @@ from .protocol_engine import ProtocolEngine
 from .errors import ProtocolEngineError
 from .commands import Command, CommandRequest, CommandStatus, CommandType
 from .state import State, StateView
+from .plugins import AbstractPlugin
+
 from .types import (
     CalibrationOffset,
     DeckSlotLocation,
@@ -50,4 +52,6 @@ __all__ = [
     "WellLocation",
     "WellOrigin",
     "WellOffset",
+    # plugins
+    "AbstractPlugin",
 ]

--- a/api/src/opentrons/protocol_engine/actions/__init__.py
+++ b/api/src/opentrons/protocol_engine/actions/__init__.py
@@ -1,4 +1,4 @@
-"""ProtocolEngine action and plugin interfaces.
+"""ProtocolEngine action interfaces.
 
 Actions are the driver of state changes in the ProtocolEngine.
 """

--- a/api/src/opentrons/protocol_engine/actions/action_dispatcher.py
+++ b/api/src/opentrons/protocol_engine/actions/action_dispatcher.py
@@ -1,4 +1,6 @@
 """Action pipeline module."""
+from typing import List
+
 from .action_handler import ActionHandler
 from .actions import Action
 
@@ -13,8 +15,16 @@ class ActionDispatcher:
             sink: The action handler that all actions in the pipeline
                 are sent to.
         """
+        self._handlers: List[ActionHandler] = []
         self._sink = sink
+
+    def add_handler(self, handler: ActionHandler) -> None:
+        """Add an action handler to the pipeline before the sink."""
+        self._handlers.append(handler)
 
     def dispatch(self, action: Action) -> None:
         """Dispatch an action into the pipeline."""
+        for handler in self._handlers:
+            handler.handle_action(action)
+
         self._sink.handle_action(action)

--- a/api/src/opentrons/protocol_engine/plugins.py
+++ b/api/src/opentrons/protocol_engine/plugins.py
@@ -1,0 +1,57 @@
+"""Protocol engine plugin interface."""
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from typing import TypeVar
+
+from .actions import Action, ActionDispatcher, ActionHandler
+from .state import StateView
+
+
+PluginT = TypeVar("PluginT", bound="AbstractPlugin")
+
+
+class AbstractPlugin(ActionHandler, ABC):
+    """An ProtocolEngine plugin to customize engine behavior.
+
+    A plugin may customize behavior in one of two ways:
+
+    1. It can react to actions as they flow through the action pipeline,
+       before they hit the StateStore.
+    2. It can dispatch new actions into the pipeline.
+    """
+
+    @property
+    def state(self) -> StateView:
+        """Get the current ProtocolEngine state."""
+        return self._state
+
+    def dispatch(self, action: Action) -> None:
+        """Dispatch an action into the action pipeline."""
+        return self._action_dispatcher.dispatch(action)
+
+    @abstractmethod
+    def handle_action(self, action: Action) -> None:
+        """React to an action going through the pipeline.
+
+        When reacting to an action, `self.state` will not yet
+        reflect the change represented by the action, because
+        plugins receive actions before the StateStore.
+        """
+        ...
+
+    # NOTE: while this could be accomplished as a factory function,
+    # using a "protected" method allows for better typing of private
+    # plugin properties without having to declare them on the class
+    def _configure(
+        self: PluginT,
+        state: StateView,
+        action_dispatcher: ActionDispatcher,
+    ) -> PluginT:
+        """Insert a StateView and ActionDispatcher into the plugin.
+
+        This is a protected method that should only be called internally
+        by the ProtocolEngine during plugin setup.
+        """
+        self._state = state
+        self._action_dispatcher = action_dispatcher
+        return self

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -6,7 +6,7 @@ from .resources import ModelUtils
 from .commands import Command, CommandRequest, CommandMapper
 from .execution import QueueWorker, create_queue_worker
 from .state import StateStore, StateView
-
+from .plugins import AbstractPlugin
 from .actions import (
     ActionDispatcher,
     PlayAction,
@@ -61,6 +61,14 @@ class ProtocolEngine:
     def state_view(self) -> StateView:
         """Get an interface to retrieve calculated state values."""
         return self._state_store
+
+    def add_plugin(self, plugin: AbstractPlugin) -> None:
+        """Add a plugin to the engine to customize behavior."""
+        plugin._configure(
+            state=self._state_store,
+            action_dispatcher=self._action_dispatcher,
+        )
+        self._action_dispatcher.add_handler(plugin)
 
     def play(self) -> None:
         """Start or resume executing commands in the queue."""

--- a/api/src/opentrons/protocol_runner/legacy_context_plugin.py
+++ b/api/src/opentrons/protocol_runner/legacy_context_plugin.py
@@ -11,16 +11,18 @@ class LegacyContextPlugin(AbstractPlugin):
     """A ProtocolEngine plugin wrapping a legacy ProtocolContext.
 
     In the legacy ProtocolContext, protocol execution is accomplished
-    by direct communication with the HardwareAPI. This plugin wraps up
-    and hides this behavior, so the ProtocolEngine can support old
-    protocols without affecting or interfering with their execution.
+    by direct communication with the HardwareAPI, as opposed to an
+    intermediate layer like the ProtocolEngine. This plugin wraps up
+    and hides this behavior, so the ProtocolEngine can monitor and control
+    the run of a legacy protocol without affecting the execution of
+    the protocol commands themselves.
 
     This plugin allows a ProtocolEngine to:
 
     1. Play/pause the protocol run using the HardwareAPI, as was done before
        the ProtocolEngine existed.
-    2. Subscribe to the message broker commands and insert them into ProtocolEngine
-       state, for progress tracking rather than execution.
+    2. Subscribe to the message broker commands and insert them into
+       ProtocolEngine state for purely progress tracking purposes.
     """
 
     def __init__(

--- a/api/src/opentrons/protocol_runner/legacy_context_plugin.py
+++ b/api/src/opentrons/protocol_runner/legacy_context_plugin.py
@@ -1,0 +1,41 @@
+"""Customize the ProtocolEngine to control and track state of legacy protocols."""
+
+from opentrons.hardware_control import API as HardwareAPI
+from opentrons.hardware_control.types import PauseType as HardwarePauseType
+from opentrons.protocol_engine import AbstractPlugin, actions as pe_actions
+
+from .legacy_wrappers import LegacyProtocolContext
+
+
+class LegacyContextPlugin(AbstractPlugin):
+    """A ProtocolEngine plugin wrapping a legacy ProtocolContext.
+
+    In the legacy ProtocolContext, protocol execution is accomplished
+    by direct communication with the HardwareAPI. This plugin wraps up
+    and hides this behavior, so the ProtocolEngine can support old
+    protocols without affecting or interfering with their execution.
+
+    This plugin allows a ProtocolEngine to:
+
+    1. Play/pause the protocol run using the HardwareAPI, as was done before
+       the ProtocolEngine existed.
+    2. Subscribe the message broker commands and insert them into ProtocolEngine
+       state, for progress tracking rather than execution.
+    """
+
+    def __init__(
+        self,
+        hardware_api: HardwareAPI,
+        protocol_context: LegacyProtocolContext,
+    ) -> None:
+        """Initialize the plugin with its dependencies."""
+        self._hardware_api = hardware_api
+        self._protocol_context = protocol_context
+
+    def handle_action(self, action: pe_actions.Action) -> None:
+        """React to a ProtocolEngine action."""
+        if isinstance(action, pe_actions.PlayAction):
+            self._hardware_api.resume(HardwarePauseType.PAUSE)
+
+        elif isinstance(action, pe_actions.PauseAction):
+            self._hardware_api.pause(HardwarePauseType.PAUSE)

--- a/api/src/opentrons/protocol_runner/legacy_context_plugin.py
+++ b/api/src/opentrons/protocol_runner/legacy_context_plugin.py
@@ -19,7 +19,7 @@ class LegacyContextPlugin(AbstractPlugin):
 
     1. Play/pause the protocol run using the HardwareAPI, as was done before
        the ProtocolEngine existed.
-    2. Subscribe the message broker commands and insert them into ProtocolEngine
+    2. Subscribe to the message broker commands and insert them into ProtocolEngine
        state, for progress tracking rather than execution.
     """
 

--- a/api/src/opentrons/protocol_runner/protocol_runner.py
+++ b/api/src/opentrons/protocol_runner/protocol_runner.py
@@ -18,6 +18,7 @@ from .json_command_translator import JsonCommandTranslator
 from .python_file_reader import PythonFileReader
 from .python_context_creator import PythonContextCreator
 from .python_executor import PythonExecutor
+from .legacy_context_plugin import LegacyContextPlugin
 from .legacy_wrappers import (
     LEGACY_PYTHON_API_VERSION_CUTOFF,
     LEGACY_JSON_SCHEMA_VERSION_CUTOFF,
@@ -64,6 +65,7 @@ class ProtocolRunner:
     ) -> None:
         """Initialize the ProtocolRunner with its dependencies."""
         self._protocol_engine = protocol_engine
+        self._hardware_api = hardware_api
         self._task_queue = task_queue or TaskQueue()
         self._json_file_reader = json_file_reader or JsonFileReader()
         self._json_command_translator = (
@@ -166,6 +168,14 @@ class ProtocolRunner:
     ) -> None:
         protocol = self._legacy_file_reader.read(protocol_source)
         context = self._legacy_context_creator.create(protocol.api_level)
+
+        self._protocol_engine.add_plugin(
+            LegacyContextPlugin(
+                hardware_api=self._hardware_api,
+                protocol_context=context,
+            )
+        )
+
         self._task_queue.add(
             phase=TaskQueuePhase.RUN,
             func=self._legacy_executor.execute,

--- a/api/tests/opentrons/protocol_engine/actions/test_action_dispatcher.py
+++ b/api/tests/opentrons/protocol_engine/actions/test_action_dispatcher.py
@@ -18,3 +18,23 @@ def test_sink(decoy: Decoy) -> None:
     subject.dispatch(action)
 
     decoy.verify(sink.handle_action(action))
+
+
+def test_add_handler(decoy: Decoy) -> None:
+    """It should actions to handlers before the sink."""
+    action = PlayAction()
+
+    handler_1 = decoy.mock(cls=ActionHandler)
+    handler_2 = decoy.mock(cls=ActionHandler)
+    sink = decoy.mock(cls=ActionHandler)
+
+    subject = ActionDispatcher(sink=sink)
+    subject.add_handler(handler_1)
+    subject.add_handler(handler_2)
+    subject.dispatch(action)
+
+    decoy.verify(
+        handler_1.handle_action(action),
+        handler_2.handle_action(action),
+        sink.handle_action(action),
+    )

--- a/api/tests/opentrons/protocol_engine/test_plugins.py
+++ b/api/tests/opentrons/protocol_engine/test_plugins.py
@@ -32,7 +32,8 @@ def test_configure(
     """The engine should be able to configure the plugin."""
     action = PlayAction()
 
-    subject = _MyPlugin()._configure(
+    subject = _MyPlugin()
+    subject._configure(
         state=state_view,
         action_dispatcher=action_dispatcher,
     )

--- a/api/tests/opentrons/protocol_engine/test_plugins.py
+++ b/api/tests/opentrons/protocol_engine/test_plugins.py
@@ -1,0 +1,43 @@
+"""Tests for ProtocolEngine plugins."""
+import pytest
+from decoy import Decoy
+
+from opentrons.protocol_engine.state import StateView
+from opentrons.protocol_engine.plugins import AbstractPlugin
+from opentrons.protocol_engine.actions import ActionDispatcher, Action, PlayAction
+
+
+@pytest.fixture
+def state_view(decoy: Decoy) -> StateView:
+    """Get a mock StateView."""
+    return decoy.mock(cls=StateView)
+
+
+@pytest.fixture
+def action_dispatcher(decoy: Decoy) -> ActionDispatcher:
+    """Get a mock ActionDispatcher."""
+    return decoy.mock(cls=ActionDispatcher)
+
+
+class _MyPlugin(AbstractPlugin):
+    def handle_action(self, action: Action) -> None:
+        pass
+
+
+def test_configure(
+    decoy: Decoy,
+    state_view: StateView,
+    action_dispatcher: ActionDispatcher,
+) -> None:
+    """The engine should be able to configure the plugin."""
+    action = PlayAction()
+
+    subject = _MyPlugin()._configure(
+        state=state_view,
+        action_dispatcher=action_dispatcher,
+    )
+
+    subject.dispatch(action)
+
+    assert subject.state == state_view
+    decoy.verify(action_dispatcher.dispatch(action))

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -11,6 +11,7 @@ from opentrons.protocol_engine.commands import CommandMapper
 from opentrons.protocol_engine.execution import QueueWorker
 from opentrons.protocol_engine.resources import ModelUtils
 from opentrons.protocol_engine.state import StateStore
+from opentrons.protocol_engine.plugins import AbstractPlugin
 
 from opentrons.protocol_engine.actions import (
     ActionDispatcher,
@@ -284,4 +285,21 @@ async def test_halt(
         action_dispatcher.dispatch(StopAction()),
         queue_worker.cancel(),
         await hardware_api.halt(),
+    )
+
+
+def test_add_plugin(
+    decoy: Decoy,
+    state_store: StateStore,
+    action_dispatcher: ActionDispatcher,
+    subject: ProtocolEngine,
+) -> None:
+    """It should configure and add a plugin to the ActionDispatcher pipeline."""
+    plugin = decoy.mock(cls=AbstractPlugin)
+
+    subject.add_plugin(plugin)
+
+    decoy.verify(
+        plugin._configure(state=state_store, action_dispatcher=action_dispatcher),
+        action_dispatcher.add_handler(plugin),
     )

--- a/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
@@ -42,10 +42,12 @@ def subject(
     action_dispatcher: pe_actions.ActionDispatcher,
 ) -> LegacyContextPlugin:
     """Get a configured LegacyContextPlugin with its dependencies mocked out."""
-    return LegacyContextPlugin(
+    plugin = LegacyContextPlugin(
         hardware_api=hardware_api,
         protocol_context=legacy_context,
-    )._configure(state=state_view, action_dispatcher=action_dispatcher)
+    )
+    plugin._configure(state=state_view, action_dispatcher=action_dispatcher)
+    return plugin
 
 
 def test_play_action(

--- a/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
@@ -1,0 +1,72 @@
+"""Tests for the ProtocolRunner's LegacyContextPlugin."""
+import pytest
+from decoy import Decoy
+
+from opentrons.hardware_control import API as HardwareAPI
+from opentrons.hardware_control.types import PauseType
+from opentrons.protocol_engine import StateView, actions as pe_actions
+
+from opentrons.protocol_runner.legacy_wrappers import LegacyProtocolContext
+from opentrons.protocol_runner.legacy_context_plugin import LegacyContextPlugin
+
+
+@pytest.fixture
+def hardware_api(decoy: Decoy) -> HardwareAPI:
+    """Get a mocked out HardwareAPI dependency."""
+    return decoy.mock(cls=HardwareAPI)
+
+
+@pytest.fixture
+def legacy_context(decoy: Decoy) -> LegacyProtocolContext:
+    """Get a mocked out LegacyProtocolContext dependency."""
+    return decoy.mock(cls=LegacyProtocolContext)
+
+
+@pytest.fixture
+def state_view(decoy: Decoy) -> StateView:
+    """Get a mock StateView."""
+    return decoy.mock(cls=StateView)
+
+
+@pytest.fixture
+def action_dispatcher(decoy: Decoy) -> pe_actions.ActionDispatcher:
+    """Get a mock ActionDispatcher."""
+    return decoy.mock(cls=pe_actions.ActionDispatcher)
+
+
+@pytest.fixture
+def subject(
+    hardware_api: HardwareAPI,
+    legacy_context: LegacyProtocolContext,
+    state_view: StateView,
+    action_dispatcher: pe_actions.ActionDispatcher,
+) -> LegacyContextPlugin:
+    """Get a configured LegacyContextPlugin with its dependencies mocked out."""
+    return LegacyContextPlugin(
+        hardware_api=hardware_api,
+        protocol_context=legacy_context,
+    )._configure(state=state_view, action_dispatcher=action_dispatcher)
+
+
+def test_play_action(
+    decoy: Decoy,
+    hardware_api: HardwareAPI,
+    subject: LegacyContextPlugin,
+) -> None:
+    """It should resume the hardware controller upon a play action."""
+    action = pe_actions.PlayAction()
+    subject.handle_action(action)
+
+    decoy.verify(hardware_api.resume(PauseType.PAUSE))
+
+
+def test_pause_action(
+    decoy: Decoy,
+    hardware_api: HardwareAPI,
+    subject: LegacyContextPlugin,
+) -> None:
+    """It should pause the hardware controller upon a pause action."""
+    action = pe_actions.PauseAction()
+    subject.handle_action(action)
+
+    decoy.verify(hardware_api.pause(PauseType.PAUSE))

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner.py
@@ -1,6 +1,6 @@
 """Tests for the ProtocolRunner class."""
 import pytest
-from decoy import Decoy
+from decoy import Decoy, matchers
 from typing import List, cast
 
 from opentrons_shared_data.protocol.dev_types import JsonProtocol as JsonProtocolDict
@@ -22,6 +22,7 @@ from opentrons.protocol_runner.python_file_reader import (
 )
 from opentrons.protocol_runner.python_context_creator import PythonContextCreator
 from opentrons.protocol_runner.python_executor import PythonExecutor
+from opentrons.protocol_runner.legacy_context_plugin import LegacyContextPlugin
 from opentrons.protocol_runner.legacy_wrappers import (
     LegacyFileReader,
     LegacyContextCreator,
@@ -289,6 +290,7 @@ def test_load_legacy_python(
     legacy_context_creator: LegacyContextCreator,
     legacy_executor: LegacyExecutor,
     task_queue: TaskQueue,
+    protocol_engine: ProtocolEngine,
     subject: ProtocolRunner,
 ) -> None:
     """It should load a legacy context-based Python protocol."""
@@ -321,13 +323,13 @@ def test_load_legacy_python(
     subject.load(legacy_protocol_source)
 
     decoy.verify(
+        protocol_engine.add_plugin(matchers.IsA(LegacyContextPlugin)),
         task_queue.add(
             phase=TaskQueuePhase.RUN,
             func=legacy_executor.execute,
             protocol=legacy_protocol,
             context=legacy_context,
         ),
-        times=1,
     )
 
 
@@ -337,6 +339,7 @@ def test_load_legacy_json(
     legacy_context_creator: LegacyContextCreator,
     legacy_executor: LegacyExecutor,
     task_queue: TaskQueue,
+    protocol_engine: ProtocolEngine,
     subject: ProtocolRunner,
 ) -> None:
     """It should load a legacy context-based Python protocol."""
@@ -366,11 +369,11 @@ def test_load_legacy_json(
     subject.load(legacy_protocol_source)
 
     decoy.verify(
+        protocol_engine.add_plugin(matchers.IsA(LegacyContextPlugin)),
         task_queue.add(
             phase=TaskQueuePhase.RUN,
             func=legacy_executor.execute,
             protocol=legacy_protocol,
             context=legacy_context,
         ),
-        times=1,
     )


### PR DESCRIPTION
## Overview

Another PR for #8374, this time adding play/pause support for PAPIv2 protocols that are run through the ProtocolEngine infrastructure.

This PR loads a `LegacyContextPlugin` into the `ProtocolEngine` when the `ProtocolRunner` detects that it is running a "legacy" (PAIPv2 or JSON Schema v5) protocol.

## Changelog

- Create `AbstractPlugin` interface in `opentrons.protocol_engine`
- Add `add_plugin` method to `ProtocolMethod` that configures a given plugin and adds it into the `ActionDispatcher` pipeline before the `StateStore`
- Create a concrete `LegacyContextPlugin` implementation of `AbstractPlugin` that reacts to play/pause actions by calling the hardware controller, like the RPC `session.py` does
- Call `protocol_engine.add_plugin` in the `ProtocolRunner` when loading a "legacy" protocol

## Review requests

There will be one more PR in this line I think, so if you don't feel like smoke testing, a code and structure review is great, too! The smoke test plan on this one would be to issue `play` and `pause` actions to a PAPIv2 protocol session running on the "enable protocol engine" endpoints and see if it works.

## Risk assessment

Low, feature flagged
