### PR TITLE
refactor(protocol-engine): Support enqueuing protocol commands on a basic session over HTTP

### DIFF
--- a/robot-server/robot_server/sessions/router/commands_router.py
+++ b/robot-server/robot_server/sessions/router/commands_router.py
@@ -28,7 +28,7 @@ class CommandNotFound(ErrorDetails):
 # todo(mm, 2021-09-23): Should this return a summary, instead of a full command?
 @commands_router.post(
     path="/sessions/{sessionId}/commands",
-    summary="Add protocol commands to the session",
+    summary="Enqueue a protocol command",
     description=(
         "Add a single protocol command to the session. "
         "The command is placed at the back of the queue."

--- a/robot-server/robot_server/sessions/router/commands_router.py
+++ b/robot-server/robot_server/sessions/router/commands_router.py
@@ -42,7 +42,7 @@ class CommandNotFound(ErrorDetails):
         status.HTTP_404_NOT_FOUND: {"model": ErrorResponse[SessionNotFound]},
     },
 )
-async def post_session_commands(
+async def post_session_command(
     command_request: pe_commands.CommandRequest,
     engine_store: EngineStore = Depends(get_engine_store),
     session: ResponseModel[Session] = Depends(get_session),

--- a/robot-server/robot_server/sessions/router/commands_router.py
+++ b/robot-server/robot_server/sessions/router/commands_router.py
@@ -24,6 +24,34 @@ class CommandNotFound(ErrorDetails):
     title: str = "Session Command Not Found"
 
 
+# todo(mm, 2021-09-23): Should this accept a list of commands, instead of just one?
+# todo(mm, 2021-09-23): Should this return a summary, instead of a full command?
+@commands_router.post(
+    path="/sessions/{sessionId}/commands",
+    summary="Add protocol commands to the session",
+    description=(
+        "Add a single protocol command to the session. "
+        "The command is placed at the back of the queue."
+        "\n\n"
+        "A summary of the added command is returned. "
+        "See `GET /sessions/{sessionId}/commands/{commandId}` to get its details."
+    ),
+    status_code=status.HTTP_200_OK,
+    response_model=ResponseModel[pe_commands.Command],
+    responses={
+        status.HTTP_404_NOT_FOUND: {"model": ErrorResponse[SessionNotFound]},
+    },
+)
+async def post_session_commands(
+    command_request: pe_commands.CommandRequest,
+    engine_store: EngineStore = Depends(get_engine_store),
+    session: ResponseModel[Session] = Depends(get_session),
+) -> ResponseModel[pe_commands.Command]:
+    """Fix before merge: Docstring."""
+    command = engine_store.engine.add_command(command_request)
+    return ResponseModel[pe_commands.Command](data=command)
+
+
 @commands_router.get(
     path="/sessions/{sessionId}/commands",
     summary="Get a list of all protocol commands in the session",

--- a/robot-server/robot_server/sessions/router/commands_router.py
+++ b/robot-server/robot_server/sessions/router/commands_router.py
@@ -25,16 +25,12 @@ class CommandNotFound(ErrorDetails):
 
 
 # todo(mm, 2021-09-23): Should this accept a list of commands, instead of just one?
-# todo(mm, 2021-09-23): Should this return a summary, instead of a full command?
 @commands_router.post(
     path="/sessions/{sessionId}/commands",
     summary="Enqueue a protocol command",
     description=(
         "Add a single protocol command to the session. "
         "The command is placed at the back of the queue."
-        "\n\n"
-        "A summary of the added command is returned. "
-        "See `GET /sessions/{sessionId}/commands/{commandId}` to get its details."
     ),
     status_code=status.HTTP_200_OK,
     response_model=ResponseModel[pe_commands.Command],
@@ -47,7 +43,17 @@ async def post_session_command(
     engine_store: EngineStore = Depends(get_engine_store),
     session: ResponseModel[Session] = Depends(get_session),
 ) -> ResponseModel[pe_commands.Command]:
-    """Fix before merge: Docstring."""
+    """Enqueue a protocol command.
+
+    Arguments:
+        commandRequest: The request for the command that the client wants to
+            enqueue.
+        engine_store: Used to retrieve the `ProtocolEngine` on which the new
+            command will be enqueued.
+        session: Session response model, provided by the route handler for
+            `GET /session/{sessionId}`. Present to ensure 404 if session
+            not found.
+    """
     command = engine_store.engine.add_command(command_request)
     return ResponseModel[pe_commands.Command](data=command)
 

--- a/robot-server/robot_server/sessions/router/commands_router.py
+++ b/robot-server/robot_server/sessions/router/commands_router.py
@@ -6,7 +6,11 @@ from typing_extensions import Literal
 from opentrons.protocol_engine import commands as pe_commands, errors as pe_errors
 
 from robot_server.errors import ErrorDetails, ErrorResponse
-from robot_server.service.json_api import ResponseModel, MultiResponseModel
+from robot_server.service.json_api import (
+    RequestModel,
+    ResponseModel,
+    MultiResponseModel,
+)
 
 from ..session_models import Session, SessionCommandSummary
 from ..schema_models import SessionCommandResponse
@@ -39,22 +43,22 @@ class CommandNotFound(ErrorDetails):
     },
 )
 async def post_session_command(
-    command_request: pe_commands.CommandRequest,
+    request_body: RequestModel[pe_commands.CommandRequest],
     engine_store: EngineStore = Depends(get_engine_store),
     session: ResponseModel[Session] = Depends(get_session),
 ) -> ResponseModel[pe_commands.Command]:
     """Enqueue a protocol command.
 
     Arguments:
-        command_request: The request for the command that the client wants to
-            enqueue.
+        request_body: The request containing the command that the client wants
+            to enqueue.
         engine_store: Used to retrieve the `ProtocolEngine` on which the new
             command will be enqueued.
         session: Session response model, provided by the route handler for
             `GET /session/{sessionId}`. Present to ensure 404 if session
             not found.
     """
-    command = engine_store.engine.add_command(command_request)
+    command = engine_store.engine.add_command(request_body.data)
     return ResponseModel[pe_commands.Command](data=command)
 
 

--- a/robot-server/robot_server/sessions/router/commands_router.py
+++ b/robot-server/robot_server/sessions/router/commands_router.py
@@ -46,7 +46,7 @@ async def post_session_command(
     """Enqueue a protocol command.
 
     Arguments:
-        commandRequest: The request for the command that the client wants to
+        command_request: The request for the command that the client wants to
             enqueue.
         engine_store: Used to retrieve the `ProtocolEngine` on which the new
             command will be enqueued.

--- a/robot-server/tests/sessions/router/test_commands_router.py
+++ b/robot-server/tests/sessions/router/test_commands_router.py
@@ -12,7 +12,7 @@ from opentrons.protocol_engine import (
 )
 
 from robot_server.errors import ApiError
-from robot_server.service.json_api import ResponseModel
+from robot_server.service.json_api import RequestModel, ResponseModel
 from robot_server.sessions.session_models import (
     Session,
     BasicSession,
@@ -44,7 +44,7 @@ async def test_post_session_command(decoy: Decoy, engine_store: EngineStore) -> 
     )
 
     response = await post_session_command(
-        command_request=command_request, engine_store=engine_store
+        request_body=RequestModel(data=command_request), engine_store=engine_store
     )
 
     assert response.data == output_command


### PR DESCRIPTION
# Overview

This PR partially implements #8070. It accomplishes:

> * A client may `POST` to `/sessions/:id/commands` to queue up a command in the Protocol Engine
> * A client may use the existing `POST /sesions/:id/actions` endpoints to start, pause, and resume executing the queued commands

It does *not* address:

> * Currently the ProtocolRunner + cleanup wil interfere with keeping the engine active after a play, because it will shut down the engine as soon as the queue is exhausted

# Review requests

* To do: Figure out how to test this on a real robot.

# Risk assessment

Low. This only touches feature-flagged code.