### PR TITLE
refactor(api): Fix forgotten `await`s in `smoothie` fixture

### DIFF
--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -259,16 +259,16 @@ def model(request, hardware, loop):
 
 
 @pytest.fixture
-def smoothie(monkeypatch):
+async def smoothie(monkeypatch):
     from opentrons.drivers.smoothie_drivers import SmoothieDriver
     from opentrons.config import robot_configs
 
     monkeypatch.setenv("ENABLE_VIRTUAL_SMOOTHIE", "true")
     driver = SmoothieDriver(robot_configs.load(), SimulatingGPIOCharDev("simulated"))
-    driver.connect()
+    await driver.connect()
     yield driver
     try:
-        driver.disconnect()
+        await driver.disconnect()
     except AttributeError:
         # if the test disconnected
         pass


### PR DESCRIPTION
# Overview

This resolves these warnings from `make -C api test`:

```
tests/opentrons/drivers/smoothie_drivers/v3_0_0/test_driver_position_cache.py::test_driver_init[pyloop]
tests/opentrons/drivers/smoothie_drivers/v3_0_0/test_driver_position_cache.py::test_home[pyloop]
tests/opentrons/drivers/smoothie_drivers/v3_0_0/test_driver_position_cache.py::test_move[pyloop-target_movement0-expected_new_position0]
tests/opentrons/drivers/smoothie_drivers/v3_0_0/test_driver_position_cache.py::test_move[pyloop-target_movement1-expected_new_position1]
tests/opentrons/drivers/smoothie_drivers/v3_0_0/test_driver_position_cache.py::test_move[pyloop-target_movement2-expected_new_position2]
tests/opentrons/hardware_control/test_paired_pipettes.py::test_move_currents[pyloop]
tests/opentrons/hardware_control/test_paired_pipettes.py::test_tip_action_currents[pyloop]
  /Users/maxpm/Code/Opentrons/opentrons/api/tests/opentrons/conftest.py:268: RuntimeWarning: coroutine 'SmoothieDriver.connect' was never awaited
    driver.connect()

tests/opentrons/drivers/smoothie_drivers/v3_0_0/test_driver_position_cache.py::test_driver_init[pyloop]
tests/opentrons/drivers/smoothie_drivers/v3_0_0/test_driver_position_cache.py::test_home[pyloop]
tests/opentrons/drivers/smoothie_drivers/v3_0_0/test_driver_position_cache.py::test_move[pyloop-target_movement0-expected_new_position0]
tests/opentrons/drivers/smoothie_drivers/v3_0_0/test_driver_position_cache.py::test_move[pyloop-target_movement1-expected_new_position1]
tests/opentrons/drivers/smoothie_drivers/v3_0_0/test_driver_position_cache.py::test_move[pyloop-target_movement2-expected_new_position2]
tests/opentrons/hardware_control/test_paired_pipettes.py::test_move_currents[pyloop]
tests/opentrons/hardware_control/test_paired_pipettes.py::test_tip_action_currents[pyloop]
  /Users/maxpm/Code/Opentrons/opentrons/api/tests/opentrons/conftest.py:271: RuntimeWarning: coroutine 'SmoothieDriver.disconnect' was never awaited
    driver.disconnect()
```

# Changelog

* Make the `smoothie` fixture `tests/opentrons/conftext.py` `async def` instead of `def`.
* Change `driver.connect()` to `await driver.connect()`, and ditto for `driver.disconnect()`.

# Review requests

I'm not familiar with this Smoothie code (test or production), so this is a pretty dumb port from non-async to async. Are there any gotchas to porting it like this?

# Risk assessment

Low risk. Changes are to tests only.
