### PR TITLE
feat(hardware): serializing dataclasses for can message contents

### DIFF
--- a/.github/workflows/hardware-lint-test.yaml
+++ b/.github/workflows/hardware-lint-test.yaml
@@ -67,9 +67,6 @@ jobs:
         run: make -C hardware lint
 
       - name: Test
-        run: make -C hardware test
-
-      - name: Test with emulator
         run: make -C hardware test-with-emulator
 
       - name: Code Coverage

--- a/.github/workflows/hardware-lint-test.yaml
+++ b/.github/workflows/hardware-lint-test.yaml
@@ -69,6 +69,9 @@ jobs:
       - name: Test
         run: make -C hardware test
 
+      - name: Test with emulator
+        run: make -C hardware test-with-emulator
+
       - name: Code Coverage
         uses: 'codecov/codecov-action@v2'
         with:

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -66,6 +66,10 @@ wheel: $(wheel_file)
 test:
 	$(pytest) -m 'not requires_emulator' $(tests) $(test_opts)
 
+.PHONY: test_with_emulator
+test_with_emulator:
+	$(pytest) -m 'requires_emulator' $(tests) $(test_opts)
+
 .PHONY: lint
 lint:
 	$(python) -m mypy opentrons_hardware tests

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -66,8 +66,8 @@ wheel: $(wheel_file)
 test:
 	$(pytest) -m 'not requires_emulator' $(tests) $(test_opts)
 
-.PHONY: test_with_emulator
-test_with_emulator:
+.PHONY: test-with-emulator
+test-with-emulator:
 	$(pytest) -m 'requires_emulator' $(tests) $(test_opts)
 
 .PHONY: lint

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -64,7 +64,7 @@ wheel: $(wheel_file)
 
 .PHONY: test
 test:
-	$(pytest) $(tests) $(test_opts)
+	$(pytest) -m 'not requires_emulator' $(tests) $(test_opts)
 
 .PHONY: lint
 lint:

--- a/hardware/opentrons_hardware/utils/__init__.py
+++ b/hardware/opentrons_hardware/utils/__init__.py
@@ -1,0 +1,23 @@
+from .binary_serializable import (
+    BinarySerializable,
+    LittleEndianBinarySerializable,
+    ulong_field,
+    long_field,
+    short_field,
+    ushort_field,
+    byte_field,
+    ubyte_field,
+    FieldMetaData,
+)
+
+__all__ = [
+    "BinarySerializable",
+    "LittleEndianBinarySerializable",
+    "ulong_field",
+    "long_field",
+    "short_field",
+    "ushort_field",
+    "byte_field",
+    "ubyte_field",
+    "FieldMetaData",
+]

--- a/hardware/opentrons_hardware/utils/__init__.py
+++ b/hardware/opentrons_hardware/utils/__init__.py
@@ -9,6 +9,8 @@ from .binary_serializable import (
     UInt8Field,
     UInt16Field,
     UInt32Field,
+    BinarySerializableException,
+    InvalidFieldException,
 )
 
 __all__ = [
@@ -20,4 +22,6 @@ __all__ = [
     "UInt8Field",
     "UInt16Field",
     "UInt32Field",
+    "BinarySerializableException",
+    "InvalidFieldException",
 ]

--- a/hardware/opentrons_hardware/utils/__init__.py
+++ b/hardware/opentrons_hardware/utils/__init__.py
@@ -1,23 +1,23 @@
+"""Utils package."""
+
 from .binary_serializable import (
     BinarySerializable,
     LittleEndianBinarySerializable,
-    ulong_field,
-    long_field,
-    short_field,
-    ushort_field,
-    byte_field,
-    ubyte_field,
-    FieldMetaData,
+    Int8Field,
+    Int16Field,
+    Int32Field,
+    UInt8Field,
+    UInt16Field,
+    UInt32Field,
 )
 
 __all__ = [
     "BinarySerializable",
     "LittleEndianBinarySerializable",
-    "ulong_field",
-    "long_field",
-    "short_field",
-    "ushort_field",
-    "byte_field",
-    "ubyte_field",
-    "FieldMetaData",
+    "Int8Field",
+    "Int16Field",
+    "Int32Field",
+    "UInt8Field",
+    "UInt16Field",
+    "UInt32Field",
 ]

--- a/hardware/opentrons_hardware/utils/binary_serializable.py
+++ b/hardware/opentrons_hardware/utils/binary_serializable.py
@@ -103,6 +103,9 @@ class BinarySerializable:
     Data will be packed big endian.
     """
 
+    ENDIAN = ">"
+    """The big endian format string"""
+
     def serialize(self) -> bytes:
         """Serialize into a byte buffer.
 
@@ -150,9 +153,6 @@ class BinarySerializable:
             # Cache it on the cls.
             setattr(cls, format_string_attribute, format_string)
         return format_string
-
-    ENDIAN = ">"
-    """The big endian format string"""
 
 
 class LittleEndianMixIn:

--- a/hardware/opentrons_hardware/utils/binary_serializable.py
+++ b/hardware/opentrons_hardware/utils/binary_serializable.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+import struct
+from dataclasses import dataclass, fields, field, astuple
+from functools import partial
+from typing_extensions import TypedDict, Final
+
+format_string_attribute: Final = "__struct_format_string__"
+
+
+class FieldMetaData(TypedDict):
+    format: str
+
+
+ulong = FieldMetaData(format="L")
+long = FieldMetaData(format="l")
+ushort = FieldMetaData(format="H")
+short = FieldMetaData(format="h")
+ubyte = FieldMetaData(format="B")
+byte = FieldMetaData(format="b")
+
+
+ulong_field = partial(field, metadata=ulong)
+long_field = partial(field, metadata=long)
+ushort_field = partial(field, metadata=ushort)
+short_field = partial(field, metadata=short)
+ubyte_field = partial(field, metadata=ubyte)
+byte_field = partial(field, metadata=byte)
+
+
+@dataclass
+class BinarySerializable:
+    """Base class of a dataclass that can be serialized/desiarilized into bytes.
+
+    Each field must have the FieldMetaData metadata value defining the format string
+    used by `struct` package to pack/unpack the field.
+
+    Data will be packed big endian.
+    """
+
+    def serialize(self) -> bytes:
+        """
+        Serialize into a byte buffer.
+
+        Returns:
+            Byte buffer
+        """
+        vals = [x for x in astuple(self)]
+        return struct.pack(self._get_format_string(), *vals)
+
+    @classmethod
+    def build(cls, data: bytes) -> BinarySerializable:
+        """
+        Create a BinarySerializable from a byte buffer.
+
+        Args:
+            data: Byte buffer
+
+        Returns:
+            cls
+        """
+        b = struct.unpack(cls._get_format_string(), data)
+        args = {v.name: b[i] for i, v in enumerate(fields(cls))}
+        return cls(**args)
+
+    @classmethod
+    def _get_format_string(cls) -> str:
+        """
+        Get the `struct` format string for this class.
+
+        Returns:
+            a string
+        """
+        format_string: str = getattr(cls, format_string_attribute, None)
+        if format_string is None:
+            dataclass_fields = fields(cls)
+            format_string = (
+                f"{cls.ENDIAN}{''.join(v.metadata['format'] for v in dataclass_fields)}"
+            )
+            # Cache it on the cls.
+            setattr(cls, format_string_attribute, format_string)
+        return format_string
+
+    ENDIAN = ">"
+    """The big endian format string"""
+
+
+class LittleEndianMixIn:
+    """Mix in to use with BinarySerializable to use little endian packing."""
+
+    ENDIAN = "<"
+    """The little endian format string"""
+
+
+class LittleEndianBinarySerializable(LittleEndianMixIn, BinarySerializable):
+    """Little endian binary serializable"""
+
+    ...

--- a/hardware/opentrons_hardware/utils/binary_serializable.py
+++ b/hardware/opentrons_hardware/utils/binary_serializable.py
@@ -95,10 +95,10 @@ class Int8Field(BinaryFieldBase[int]):
 
 @dataclass
 class BinarySerializable:
-    """Base class of a dataclass that can be serialized/desiarilized into bytes.
+    """Base class of a dataclass that can be serialized/deserialized into bytes.
 
     Each field must have the FieldMetaData metadata value defining the format string
-    used by `struct` package to pack/unback the field.
+    used by `struct` package to pack/unpack the field.
 
     Data will be packed big endian.
     """

--- a/hardware/tests/utils/__init__.py
+++ b/hardware/tests/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utils package tests."""

--- a/hardware/tests/utils/test_binary_serializable.py
+++ b/hardware/tests/utils/test_binary_serializable.py
@@ -34,17 +34,20 @@ class TestClass(utils.BinarySerializable):
 def subject() -> TestClass:
     """The test subject."""
     return TestClass(
+        # 1 bytes each
         ub=utils.UInt8Field(8),
         b=utils.Int8Field(-8),
+        # 2 bytes each
         us=utils.UInt16Field(16),
         s=utils.Int16Field(-16),
+        # 4 bytes each
         ul=utils.UInt32Field(32),
         l=utils.Int32Field(-32),
     )
 
 
 def test_serialize_length(subject: TestClass) -> None:
-    """It should serialize with correct data length."""
+    """It should serialize with correct data length in bytes."""
     assert len(subject.serialize()) == 14
 
 
@@ -63,6 +66,7 @@ def test_deserialize() -> None:
 
 def test_serdes(subject: TestClass) -> None:
     """It should serialize a deserialized instance correctly."""
+    # Deserialize a serialized instance. They should be the same.
     new = TestClass.build(subject.serialize())
     assert new == subject
 
@@ -75,20 +79,24 @@ class LittleEndianTestClass(utils.LittleEndianBinarySerializable):
     l: utils.Int32Field
 
 
-def test_deserialize_little_endian() -> None:
+@pytest.fixture
+def little_endian_data() -> bytes:
+    """Little endian data fixture."""
+    return b"\x00\x00\x00\x05\x00\x00\x00\x06"
+
+
+def test_deserialize_little_endian(little_endian_data: bytes) -> None:
     """It should deserialize little endian data correctly."""
-    data = b"\x00\x00\x00\x05\x00\x00\x00\x06"
-    assert LittleEndianTestClass.build(data) == LittleEndianTestClass(
+    assert LittleEndianTestClass.build(little_endian_data) == LittleEndianTestClass(
         ul=utils.UInt32Field(0x05000000), l=utils.Int32Field(0x06000000)
     )
 
 
-def test_serialize_little_endian() -> None:
+def test_serialize_little_endian(little_endian_data: bytes) -> None:
     """It should serialize little endian data correctly."""
-    data = b"\x00\x00\x00\x05\x00\x00\x00\x06"
     assert (
         LittleEndianTestClass(
             ul=utils.UInt32Field(0x05000000), l=utils.Int32Field(0x06000000)
         ).serialize()
-        == data
+        == little_endian_data
     )

--- a/hardware/tests/utils/test_binary_serializable.py
+++ b/hardware/tests/utils/test_binary_serializable.py
@@ -5,6 +5,19 @@ from dataclasses import dataclass
 from opentrons_hardware import utils
 
 
+def test_fields_must_be_binary_fields() -> None:
+    """It should raise an error when a field is not BinaryFieldBase type."""
+
+    @dataclass
+    class Failing(utils.BinarySerializable):
+        """Test class type."""
+
+        a: int
+
+    with pytest.raises(utils.InvalidFieldException):
+        Failing(a=123).serialize()
+
+
 @dataclass
 class TestClass(utils.BinarySerializable):
     """Test class type."""
@@ -31,12 +44,12 @@ def subject() -> TestClass:
 
 
 def test_serialize_length(subject: TestClass) -> None:
-    """Test that serialized data length is correct."""
+    """It should serialize with correct data length."""
     assert len(subject.serialize()) == 14
 
 
 def test_deserialize() -> None:
-    """Test that we deserialize data correctly."""
+    """It should deserialize data correctly."""
     data = b"\x01\x02\x00\x03\x00\x04\x00\x00\x00\x05\x00\x00\x00\x06"
     assert TestClass.build(data) == TestClass(
         ub=utils.UInt8Field(1),
@@ -49,7 +62,7 @@ def test_deserialize() -> None:
 
 
 def test_serdes(subject: TestClass) -> None:
-    """Test that deserializing a serialized instance works."""
+    """It should serialize a deserialized instance correctly."""
     new = TestClass.build(subject.serialize())
     assert new == subject
 
@@ -63,7 +76,7 @@ class LittleEndianTestClass(utils.LittleEndianBinarySerializable):
 
 
 def test_deserialize_little_endian() -> None:
-    """Test that we deserialize data correctly."""
+    """It should deserialize little endian data correctly."""
     data = b"\x00\x00\x00\x05\x00\x00\x00\x06"
     assert LittleEndianTestClass.build(data) == LittleEndianTestClass(
         ul=utils.UInt32Field(0x05000000), l=utils.Int32Field(0x06000000)
@@ -71,7 +84,7 @@ def test_deserialize_little_endian() -> None:
 
 
 def test_serialize_little_endian() -> None:
-    """Test that we serialize data correctly."""
+    """It should serialize little endian data correctly."""
     data = b"\x00\x00\x00\x05\x00\x00\x00\x06"
     assert (
         LittleEndianTestClass(

--- a/hardware/tests/utils/test_binary_serializable.py
+++ b/hardware/tests/utils/test_binary_serializable.py
@@ -6,51 +6,75 @@ from opentrons_hardware import utils
 
 
 @dataclass
-class MyTestClass(utils.BinarySerializable):
-    ub: int = utils.ubyte_field()
-    b: int = utils.byte_field()
-    us: int = utils.ushort_field()
-    s: int = utils.short_field()
-    ul: int = utils.ulong_field()
-    l: int = utils.long_field()
+class TestClass(utils.BinarySerializable):
+    """Test class type."""
+
+    ub: utils.UInt8Field
+    b: utils.Int8Field
+    us: utils.UInt16Field
+    s: utils.Int16Field
+    ul: utils.UInt32Field
+    l: utils.Int32Field
 
 
 @pytest.fixture
-def subject() -> MyTestClass:
+def subject() -> TestClass:
     """The test subject."""
-    return MyTestClass(ub=8, b=-8, us=16, s=-16, ul=32, l=-32)
+    return TestClass(
+        ub=utils.UInt8Field(8),
+        b=utils.Int8Field(-8),
+        us=utils.UInt16Field(16),
+        s=utils.Int16Field(-16),
+        ul=utils.UInt32Field(32),
+        l=utils.Int32Field(-32),
+    )
 
 
-def test_serialize_length(subject: MyTestClass) -> None:
+def test_serialize_length(subject: TestClass) -> None:
     """Test that serialized data length is correct."""
     assert len(subject.serialize()) == 14
 
 
 def test_deserialize() -> None:
     """Test that we deserialize data correctly."""
-    data = b'\x01\x02\x00\x03\x00\x04\x00\x00\x00\x05\x00\x00\x00\x06'
-    assert MyTestClass.build(data) == MyTestClass(ub=1, b=2, us=3, s=4, ul=5, l=6)
+    data = b"\x01\x02\x00\x03\x00\x04\x00\x00\x00\x05\x00\x00\x00\x06"
+    assert TestClass.build(data) == TestClass(
+        ub=utils.UInt8Field(1),
+        b=utils.Int8Field(2),
+        us=utils.UInt16Field(3),
+        s=utils.Int16Field(4),
+        ul=utils.UInt32Field(5),
+        l=utils.Int32Field(6),
+    )
 
 
-def test_serdes(subject: MyTestClass) -> None:
+def test_serdes(subject: TestClass) -> None:
     """Test that deserializing a serialized instance works."""
-    new = MyTestClass.build(subject.serialize())
+    new = TestClass.build(subject.serialize())
     assert new == subject
 
 
 @dataclass
 class LittleEndianTestClass(utils.LittleEndianBinarySerializable):
-    ul: int = utils.ulong_field()
-    l: int = utils.long_field()
+    """Little endian test class."""
+    ul: utils.UInt32Field
+    l: utils.Int32Field
 
 
 def test_deserialize_little_endian() -> None:
     """Test that we deserialize data correctly."""
-    data = b'\x00\x00\x00\x05\x00\x00\x00\x06'
-    assert LittleEndianTestClass.build(data) == LittleEndianTestClass(ul=0x05000000, l=0x06000000)
+    data = b"\x00\x00\x00\x05\x00\x00\x00\x06"
+    assert LittleEndianTestClass.build(data) == LittleEndianTestClass(
+        ul=utils.UInt32Field(0x05000000), l=utils.Int32Field(0x06000000)
+    )
 
 
 def test_serialize_little_endian() -> None:
     """Test that we serialize data correctly."""
-    data = b'\x00\x00\x00\x05\x00\x00\x00\x06'
-    assert LittleEndianTestClass(ul=0x05000000, l=0x06000000).serialize() == data
+    data = b"\x00\x00\x00\x05\x00\x00\x00\x06"
+    assert (
+        LittleEndianTestClass(
+            ul=utils.UInt32Field(0x05000000), l=utils.Int32Field(0x06000000)
+        ).serialize()
+        == data
+    )

--- a/hardware/tests/utils/test_binary_serializable.py
+++ b/hardware/tests/utils/test_binary_serializable.py
@@ -1,0 +1,56 @@
+"""Binary serializable tests."""
+
+import pytest
+from dataclasses import dataclass
+from opentrons_hardware import utils
+
+
+@dataclass
+class MyTestClass(utils.BinarySerializable):
+    ub: int = utils.ubyte_field()
+    b: int = utils.byte_field()
+    us: int = utils.ushort_field()
+    s: int = utils.short_field()
+    ul: int = utils.ulong_field()
+    l: int = utils.long_field()
+
+
+@pytest.fixture
+def subject() -> MyTestClass:
+    """The test subject."""
+    return MyTestClass(ub=8, b=-8, us=16, s=-16, ul=32, l=-32)
+
+
+def test_serialize_length(subject: MyTestClass) -> None:
+    """Test that serialized data length is correct."""
+    assert len(subject.serialize()) == 14
+
+
+def test_deserialize() -> None:
+    """Test that we deserialize data correctly."""
+    data = b'\x01\x02\x00\x03\x00\x04\x00\x00\x00\x05\x00\x00\x00\x06'
+    assert MyTestClass.build(data) == MyTestClass(ub=1, b=2, us=3, s=4, ul=5, l=6)
+
+
+def test_serdes(subject: MyTestClass) -> None:
+    """Test that deserializing a serialized instance works."""
+    new = MyTestClass.build(subject.serialize())
+    assert new == subject
+
+
+@dataclass
+class LittleEndianTestClass(utils.LittleEndianBinarySerializable):
+    ul: int = utils.ulong_field()
+    l: int = utils.long_field()
+
+
+def test_deserialize_little_endian() -> None:
+    """Test that we deserialize data correctly."""
+    data = b'\x00\x00\x00\x05\x00\x00\x00\x06'
+    assert LittleEndianTestClass.build(data) == LittleEndianTestClass(ul=0x05000000, l=0x06000000)
+
+
+def test_serialize_little_endian() -> None:
+    """Test that we serialize data correctly."""
+    data = b'\x00\x00\x00\x05\x00\x00\x00\x06'
+    assert LittleEndianTestClass(ul=0x05000000, l=0x06000000).serialize() == data

--- a/hardware/tests/utils/test_binary_serializable.py
+++ b/hardware/tests/utils/test_binary_serializable.py
@@ -57,6 +57,7 @@ def test_serdes(subject: TestClass) -> None:
 @dataclass
 class LittleEndianTestClass(utils.LittleEndianBinarySerializable):
     """Little endian test class."""
+
     ul: utils.UInt32Field
     l: utils.Int32Field
 


### PR DESCRIPTION
# Overview

Setting up further can messaging support by having dataclasses that can be serialized/deserialized into byte buffers.

Wanted to get this up before moving to implementing can message building in detail.

# Changelog

- have `make test` skip tests that require emulator
- add utils package with `BinarySerializable` class. 

# Review requests


# Risk assessment

None