### PR TITLE
 feat(app): Add labware position check overview modal 

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -68,5 +68,9 @@
   "calibration_ready": "Calibration ready",
   "run_disabled_modules_not_connected": "Make sure all modules are connected before proceeding to run",
   "run_disabled_calibration_not_complete": "Make sure robot calibration is complete before proceeding to run",
-  "run_disabled_modules_and_calibration_not_complete": "Make sure robot calibration is complete and all modules are connected before proceeding to run"
+  "run_disabled_modules_and_calibration_not_complete": "Make sure robot calibration is complete and all modules are connected before proceeding to run",
+  "labware_position_check": "Labware Position Check",
+  "labware_position_check_overview": "Labware Position Check Overview",
+  "position_check_description": "Labware Position Check check jogs your pipette(s) to each labware on the deck to ensure the OT-2 will move accurately during a protocol run. You will use {{number_of_tips}} from the {{labware_name}} in Slot {{labware_slot}} to check this protocol’s labware.",
+  "start_position_check": "begin labware position check, move to slot {{initial_labware_slot}}"
 }

--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -69,7 +69,7 @@
   "run_disabled_modules_not_connected": "Make sure all modules are connected before proceeding to run",
   "run_disabled_calibration_not_complete": "Make sure robot calibration is complete before proceeding to run",
   "run_disabled_modules_and_calibration_not_complete": "Make sure robot calibration is complete and all modules are connected before proceeding to run",
-  "labware_position_check": "Labware Position Check",
+  "labware_position_check_title": "Labware Position Check",
   "labware_position_check_overview": "Labware Position Check Overview",
   "position_check_description": "Labware Position Check check jogs your pipette(s) to each labware on the deck to ensure the OT-2 will move accurately during a protocol run. You will use {{number_of_tips}} tip from the {{labware_name}} in Slot {{labware_slot}} to check this protocol’s labware.",
   "position_check_description_plural": "Labware Position Check check jogs your pipette(s) to each labware on the deck to ensure the OT-2 will move accurately during a protocol run. You will use {{number_of_tips}} tips from the {{labware_name}} in Slot {{labware_slot}} to check this protocol’s labware.",

--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -71,6 +71,7 @@
   "run_disabled_modules_and_calibration_not_complete": "Make sure robot calibration is complete and all modules are connected before proceeding to run",
   "labware_position_check": "Labware Position Check",
   "labware_position_check_overview": "Labware Position Check Overview",
-  "position_check_description": "Labware Position Check check jogs your pipette(s) to each labware on the deck to ensure the OT-2 will move accurately during a protocol run. You will use {{number_of_tips}} from the {{labware_name}} in Slot {{labware_slot}} to check this protocol’s labware.",
+  "position_check_description": "Labware Position Check check jogs your pipette(s) to each labware on the deck to ensure the OT-2 will move accurately during a protocol run. You will use {{number_of_tips}} tip from the {{labware_name}} in Slot {{labware_slot}} to check this protocol’s labware.",
+  "position_check_description_plural": "Labware Position Check check jogs your pipette(s) to each labware on the deck to ensure the OT-2 will move accurately during a protocol run. You will use {{number_of_tips}} tips from the {{labware_name}} in Slot {{labware_slot}} to check this protocol’s labware.",
   "start_position_check": "begin labware position check, move to slot {{initial_labware_slot}}"
 }

--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -74,8 +74,8 @@
   "position_check_description": "Labware Position Check check jogs your pipette(s) to each labware on the deck to ensure the OT-2 will move accurately during a protocol run. You will use {{number_of_tips}} tip from the {{labware_name}} in Slot {{labware_slot}} to check this protocol’s labware.",
   "position_check_description_plural": "Labware Position Check check jogs your pipette(s) to each labware on the deck to ensure the OT-2 will move accurately during a protocol run. You will use {{number_of_tips}} tips from the {{labware_name}} in Slot {{labware_slot}} to check this protocol’s labware.",
   "start_position_check": "begin labware position check, move to slot {{initial_labware_slot}}",
-  "secondary_pipette_tipracks_section": "Check tipracks with Secondary Pipette",
-  "primary_pipette_tipracks_section": "Check tipracks with Primary Pipette",
-  "check_remaining_labware_with_primary_pipette_section": "Check remaining labware with Primary Pipette",
+  "secondary_pipette_tipracks_section": "Check tipracks with {{secondary_mount}} Pipette",
+  "primary_pipette_tipracks_section": "Check tipracks with {{primary_mount}} Pipette",
+  "check_remaining_labware_with_primary_pipette_section": "Check remaining labware with {{primary_mount}} Pipette",
   "return_tip_section": "Return tip"
 }

--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -73,5 +73,9 @@
   "labware_position_check_overview": "Labware Position Check Overview",
   "position_check_description": "Labware Position Check check jogs your pipette(s) to each labware on the deck to ensure the OT-2 will move accurately during a protocol run. You will use {{number_of_tips}} tip from the {{labware_name}} in Slot {{labware_slot}} to check this protocol’s labware.",
   "position_check_description_plural": "Labware Position Check check jogs your pipette(s) to each labware on the deck to ensure the OT-2 will move accurately during a protocol run. You will use {{number_of_tips}} tips from the {{labware_name}} in Slot {{labware_slot}} to check this protocol’s labware.",
-  "start_position_check": "begin labware position check, move to slot {{initial_labware_slot}}"
+  "start_position_check": "begin labware position check, move to slot {{initial_labware_slot}}",
+  "secondary_pipette_tipracks_section": "Check tipracks with Secondary Pipette",
+  "primary_pipette_tipracks_section": "Check tipracks with Primary Pipette",
+  "check_remaining_labware_with_primary_pipette_section": "Check remaining labware with Primary Pipette",
+  "return_tip_section": "Return tip"
 }

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/PositionCheckNav.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/PositionCheckNav.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+
+import {
+  Flex,
+  Box,
+  ALIGN_CENTER,
+  SIZE_1,
+  SPACING_2,
+  SPACING_5,
+  C_WHITE,
+  C_NEAR_WHITE,
+  C_DARK_GRAY,
+  TEXT_ALIGN_CENTER,
+  FONT_SIZE_CAPTION,
+} from '@opentrons/components'
+
+import type { Section } from './types'
+
+interface Props {
+  sections: Section[]
+  primaryPipetteMount: string
+  secondaryPipetteMount: string
+}
+
+export function PositionCheckNav(props: Props): JSX.Element {
+  const { sections, primaryPipetteMount, secondaryPipetteMount } = props
+  const { t } = useTranslation(['protocol_setup', 'shared'])
+  return (
+    <Box
+      fontSize={FONT_SIZE_CAPTION}
+      padding={SPACING_2}
+      width="13.25rem"
+      marginLeft={SPACING_5}
+      boxShadow="1px 1px 1px rgba(0, 0, 0, 0.25)"
+      borderRadius="4px"
+      backgroundColor={C_NEAR_WHITE}
+    >
+      {sections.map((section, index) => (
+        <Flex key={index} padding={SPACING_2} alignItems={ALIGN_CENTER}>
+          <Box
+            width={SIZE_1}
+            height={SIZE_1}
+            lineHeight={SIZE_1}
+            backgroundColor={C_DARK_GRAY}
+            color={C_WHITE}
+            borderRadius="50%"
+            marginRight={SPACING_2}
+            textAlign={TEXT_ALIGN_CENTER}
+          >
+            {index + 1}
+          </Box>
+          <Box maxWidth="85%">
+            {t(`${section.toLowerCase()}_section`, {
+              primary_mount: `${
+                primaryPipetteMount.charAt(0).toUpperCase() +
+                primaryPipetteMount.slice(1)
+              }`,
+              secondary_mount: `${
+                secondaryPipetteMount.charAt(0).toUpperCase() +
+                secondaryPipetteMount.slice(1)
+              }`,
+            })}
+          </Box>
+        </Flex>
+      ))}
+    </Box>
+  )
+}

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/PositionCheckNav.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/PositionCheckNav.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
+import capitalize from 'lodash/capitalize'
 
 import {
   Flex,
@@ -25,7 +26,7 @@ interface Props {
 
 export function PositionCheckNav(props: Props): JSX.Element {
   const { sections, primaryPipetteMount, secondaryPipetteMount } = props
-  const { t } = useTranslation(['protocol_setup', 'shared'])
+  const { t } = useTranslation('protocol_setup')
   return (
     <Box
       fontSize={FONT_SIZE_CAPTION}
@@ -52,14 +53,8 @@ export function PositionCheckNav(props: Props): JSX.Element {
           </Box>
           <Box maxWidth="85%">
             {t(`${section.toLowerCase()}_section`, {
-              primary_mount: `${
-                primaryPipetteMount.charAt(0).toUpperCase() +
-                primaryPipetteMount.slice(1)
-              }`,
-              secondary_mount: `${
-                secondaryPipetteMount.charAt(0).toUpperCase() +
-                secondaryPipetteMount.slice(1)
-              }`,
+              primary_mount: capitalize(primaryPipetteMount),
+              secondary_mount: capitalize(secondaryPipetteMount),
             })}
           </Box>
         </Flex>

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/hooks.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/hooks.test.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react'
+import { when } from 'jest-when'
+import { Provider } from 'react-redux'
+import { createStore, Store } from 'redux'
+import { renderHook } from '@testing-library/react-hooks'
+import { getPipetteNameSpecs, PipetteName } from '@opentrons/shared-data'
+import { getProtocolData } from '../../../../redux/protocol'
+import * as hooks from '../hooks'
+import { getLabwarePositionCheckSteps } from '../getLabwarePositionCheckSteps'
+
+jest.mock('@opentrons/shared-data')
+jest.mock('../getLabwarePositionCheckSteps')
+jest.mock('../../../../redux/protocol')
+
+const PRIMARY_PIPETTE_ID = 'PRIMARY_PIPETTE_ID'
+const PRIMARY_PIPETTE_NAME = 'PRIMARY_PIPETTE_NAME' as PipetteName
+const PRIMARY_PIPETTE_NUM_CHANNELS = 8
+const SECONDARY_PIPETTE_ID = 'SECONDARY_PIPETTE_ID'
+const SECONDARY_PIPETTE_NAME = 'SECONDARY_PIPETTE_NAME'
+
+const PICKUP_TIP_LABWARE_ID = 'PICKUP_TIP_LABWARE_ID'
+const PICKUP_TIP_LABWARE_SLOT = '3'
+const PICKUP_TIP_LABWARE_DISPLAY_NAME = 'PICKUP_TIP_LABWARE_DISPLAY_NAME'
+
+const mockGetProtocolData = getProtocolData as jest.MockedFunction<
+  typeof getProtocolData
+>
+
+const mockGetPipetteNameSpecs = getPipetteNameSpecs as jest.MockedFunction<
+  typeof getPipetteNameSpecs
+>
+const mockGetLabwarePositionCheckSteps = getLabwarePositionCheckSteps as jest.MockedFunction<
+  typeof getLabwarePositionCheckSteps
+>
+
+const store: Store<any> = createStore(jest.fn(), {})
+
+describe('useIntroInfo', () => {
+  beforeEach(() => {
+    mockGetLabwarePositionCheckSteps.mockReturnValue([
+      {
+        labwareId: PICKUP_TIP_LABWARE_ID,
+        section: '',
+        commands: [
+          {
+            command: 'pickUpTip',
+            params: {
+              pipette: PRIMARY_PIPETTE_ID,
+              labware: PICKUP_TIP_LABWARE_ID,
+            },
+          },
+        ],
+      } as any,
+    ])
+    mockGetProtocolData.mockReturnValue({
+      labware: {
+        [PICKUP_TIP_LABWARE_ID]: {
+          slot: PICKUP_TIP_LABWARE_SLOT,
+          displayName: PICKUP_TIP_LABWARE_DISPLAY_NAME,
+        },
+      },
+      pipettes: {
+        [PRIMARY_PIPETTE_ID]: {
+          name: PRIMARY_PIPETTE_NAME,
+          mount: 'left',
+        },
+        [SECONDARY_PIPETTE_ID]: {
+          name: SECONDARY_PIPETTE_NAME,
+          mount: 'right',
+        },
+      },
+    } as any)
+
+    when(mockGetPipetteNameSpecs)
+      .calledWith(PRIMARY_PIPETTE_NAME)
+      .mockReturnValue({ channels: PRIMARY_PIPETTE_NUM_CHANNELS } as any)
+  })
+  it('should gather all labware position check intro screen data', () => {
+    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+      <Provider store={store}>{children}</Provider>
+    )
+    const { result } = renderHook(hooks.useIntroInfo, { wrapper })
+    const {
+      primaryTipRackSlot,
+      primaryTipRackName,
+      primaryPipetteMount,
+      secondaryPipetteMount,
+      numberOfTips,
+      firstStepLabwareSlot,
+    } = result.current as any
+    expect(primaryTipRackSlot).toBe(PICKUP_TIP_LABWARE_SLOT)
+    expect(primaryTipRackName).toBe(PICKUP_TIP_LABWARE_DISPLAY_NAME)
+    expect(primaryPipetteMount).toBe('left')
+    expect(secondaryPipetteMount).toBe('right')
+    expect(numberOfTips).toBe(8)
+    expect(firstStepLabwareSlot).toBe(PICKUP_TIP_LABWARE_SLOT)
+  })
+})

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks.ts
@@ -72,6 +72,9 @@ export function useIntroInfo(): IntroInfo | null {
     labware: pickUpTipLabwareId,
   } = (pickUpTipStep.commands[0] as PickUpTipCommand).params
   const primaryPipetteName = protocolData.pipettes[primaryPipetteId].name
+  const primaryPipetteMount = protocolData.pipettes[primaryPipetteId].mount
+  const secondaryPipetteMount =
+    protocolData.pipettes[primaryPipetteId].mount === 'right' ? 'left' : 'right'
   const primaryPipetteSpecs =
     primaryPipetteName != null
       ? getPipetteNameSpecs(primaryPipetteName as PipetteName)
@@ -100,6 +103,8 @@ export function useIntroInfo(): IntroInfo | null {
   return {
     primaryTipRackSlot,
     primaryTipRackName,
+    primaryPipetteMount,
+    secondaryPipetteMount,
     numberOfTips,
     firstStepLabwareSlot,
     sections,

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks.ts
@@ -20,7 +20,7 @@ export function useSteps(): LabwarePositionCheckStep[] {
 export function useSections(): string[] {
   const steps = useSteps()
   return steps.reduce<string[]>(
-    (acc, step) => (step.section in acc ? acc : [...acc, step.section]),
+    (acc, step) => (acc.includes(step.section) ? acc : [...acc, step.section]),
     []
   )
 }
@@ -51,6 +51,8 @@ interface IntroInfo {
 }
 export function useIntroInfo(): IntroInfo | null {
   const protocolData = useSelector((state: State) => getProtocolData(state))
+  const steps = useSteps()
+  const sections = useSections()
   if (
     protocolData == null ||
     !('pipettes' in protocolData) ||
@@ -59,11 +61,7 @@ export function useIntroInfo(): IntroInfo | null {
     return null // this state should never be reached
 
   // find which tiprack primary pipette will use for check
-  const steps = getLabwarePositionCheckSteps(protocolData)
-  const sections = steps.reduce<string[]>(
-    (acc, step) => (step.section in acc ? acc : [...acc, step.section]),
-    []
-  )
+
   const pickUpTipStep = steps.find(
     step => step.commands[0].command === 'pickUpTip'
   )

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks.ts
@@ -5,7 +5,11 @@ import { getPipetteNameSpecs } from '@opentrons/shared-data'
 
 import type { PipetteName } from '@opentrons/shared-data'
 import type { State } from '../../../redux/types'
-import type { PickUpTipCommand, LabwarePositionCheckStep } from './types'
+import type {
+  PickUpTipCommand,
+  LabwarePositionCheckStep,
+  Section,
+} from './types'
 
 interface LabwareIdsBySection {
   [section: string]: string[]
@@ -17,9 +21,9 @@ export function useSteps(): LabwarePositionCheckStep[] {
   return getLabwarePositionCheckSteps(protocolData)
 }
 
-export function useSections(): string[] {
+export function useSections(): Section[] {
   const steps = useSteps()
-  return steps.reduce<string[]>(
+  return steps.reduce<Section[]>(
     (acc, step) => (acc.includes(step.section) ? acc : [...acc, step.section]),
     []
   )
@@ -45,9 +49,11 @@ export function useLabwareIdsBySection(): LabwareIdsBySection {
 interface IntroInfo {
   primaryTipRackSlot: string
   primaryTipRackName: string
+  primaryPipetteMount: string
+  secondaryPipetteMount: string
   numberOfTips: number
   firstStepLabwareSlot: string
-  sections: string[]
+  sections: Section[]
 }
 export function useIntroInfo(): IntroInfo | null {
   const protocolData = useSelector((state: State) => getProtocolData(state))

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks.ts
@@ -1,0 +1,109 @@
+import { useSelector } from 'react-redux'
+import { getLabwarePositionCheckSteps } from './getLabwarePositionCheckSteps'
+import { getProtocolData } from '../../../redux/protocol'
+import { getPipetteNameSpecs } from '@opentrons/shared-data'
+
+import type { PipetteName } from '@opentrons/shared-data'
+import type { State } from '../../../redux/types'
+import type { PickUpTipCommand, LabwarePositionCheckStep } from './types'
+
+interface LabwareIdsBySection {
+  [section: string]: string[]
+}
+
+export function useSteps(): LabwarePositionCheckStep[] {
+  const protocolData = useSelector((state: State) => getProtocolData(state))
+  if (protocolData == null) return [] // this state should never be reached
+  return getLabwarePositionCheckSteps(protocolData)
+}
+
+export function useSections(): string[] {
+  const steps = useSteps()
+  return steps.reduce<string[]>(
+    (acc, step) => (step.section in acc ? acc : [...acc, step.section]),
+    []
+  )
+}
+
+export function useLabwareIdsBySection(): LabwareIdsBySection {
+  const steps = useSteps()
+  const sections = useSections()
+  return sections.reduce((labwareIdsBySection, section) => {
+    return {
+      ...labwareIdsBySection,
+      [section]: steps.reduce<string[]>(
+        (labwareIds, step) =>
+          step.section === section
+            ? [...labwareIds, step.labwareId]
+            : labwareIds,
+        []
+      ),
+    }
+  }, {})
+}
+
+interface IntroInfo {
+  primaryTipRackSlot: string
+  primaryTipRackName: string
+  numberOfTips: number
+  firstStepLabwareSlot: string
+  sections: string[]
+}
+export function useIntroInfo(): IntroInfo | null {
+  const protocolData = useSelector((state: State) => getProtocolData(state))
+  if (
+    protocolData == null ||
+    !('pipettes' in protocolData) ||
+    !('labware' in protocolData)
+  )
+    return null // this state should never be reached
+
+  // find which tiprack primary pipette will use for check
+  const steps = getLabwarePositionCheckSteps(protocolData)
+  const sections = steps.reduce<string[]>(
+    (acc, step) => (step.section in acc ? acc : [...acc, step.section]),
+    []
+  )
+  const pickUpTipStep = steps.find(
+    step => step.commands[0].command === 'pickUpTip'
+  )
+  if (pickUpTipStep == null) return null // this state should never be reached
+
+  const {
+    pipette: primaryPipetteId,
+    labware: pickUpTipLabwareId,
+  } = (pickUpTipStep.commands[0] as PickUpTipCommand).params
+  const primaryPipetteName = protocolData.pipettes[primaryPipetteId].name
+  const primaryPipetteSpecs =
+    primaryPipetteName != null
+      ? getPipetteNameSpecs(primaryPipetteName as PipetteName)
+      : null
+  const pickUpTipLabware = protocolData.labware[pickUpTipLabwareId]
+  // find name and slot number for tiprack used for check
+  const primaryTipRackName =
+    'displayName' in pickUpTipLabware ? pickUpTipLabware?.displayName : null
+  const primaryTipRackSlot = pickUpTipLabware.slot
+
+  // find how many channels pipette for check has for dynmic text
+  const numberOfTips = primaryPipetteSpecs?.channels
+
+  // find the slot for the first labware that will be checked for button
+  const firstTiprackToCheckId = steps[0].labwareId
+  const firstStepLabwareSlot = protocolData.labware[firstTiprackToCheckId].slot
+
+  if (
+    primaryTipRackSlot == null ||
+    primaryTipRackName == null ||
+    numberOfTips == null ||
+    firstStepLabwareSlot == null
+  )
+    return null // this state should never be reached
+
+  return {
+    primaryTipRackSlot,
+    primaryTipRackName,
+    numberOfTips,
+    firstStepLabwareSlot,
+    sections,
+  }
+}

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
@@ -1,0 +1,214 @@
+import * as React from 'react'
+import { useSelector } from 'react-redux'
+import { useTranslation } from 'react-i18next'
+import map from 'lodash/map'
+import {
+  LabwareRender,
+  ModuleViz,
+  RobotWorkSpace,
+  ModalPage,
+  PrimaryBtn,
+  Text,
+  Flex,
+  Box,
+  TEXT_TRANSFORM_UPPERCASE,
+  FONT_WEIGHT_SEMIBOLD,
+  JUSTIFY_SPACE_BETWEEN,
+  JUSTIFY_CENTER,
+  C_BLUE,
+  SPACING_3,
+  FONT_SIZE_BODY_2,
+  ALIGN_CENTER,
+  LINE_HEIGHT_COPY,
+} from '@opentrons/components'
+import {
+  getModuleType,
+  inferModuleOrientationFromXCoordinate,
+  getPipetteNameSpecs,
+} from '@opentrons/shared-data'
+import standardDeckDef from '@opentrons/shared-data/deck/definitions/2/ot2_standard.json'
+import { Portal } from '../../../App/portal'
+import { getProtocolData } from '../../../redux/protocol'
+import { getModuleRenderCoords } from '../utils/getModuleRenderCoords'
+import { getLabwareRenderCoords } from '../utils/getLabwareRenderCoords'
+import { getPrimaryPipetteId } from './utils/getPrimaryPipetteId'
+import { getLabwarePositionCheckSteps } from './getLabwarePositionCheckSteps'
+
+import { ModuleTag } from '../ModuleTag'
+import styles from '../styles.css'
+
+const DECK_LAYER_BLOCKLIST = [
+  'calibrationMarkings',
+  'fixedBase',
+  'doorStops',
+  'metalFrame',
+  'removalHandle',
+  'removableDeckOutline',
+  'screwHoles',
+]
+
+const DECK_MAP_VIEWBOX = '-80 -100 550 560'
+
+interface LabwarePositionCheckModalProps {
+  onCloseClick: () => unknown
+}
+
+export const LabwarePositionCheck = (
+  props: LabwarePositionCheckModalProps
+): JSX.Element | null => {
+  const { t } = useTranslation(['protocol_setup', 'shared'])
+  const [
+    currentLabwareCheckStep,
+    setCurrentLabwareCheckStep,
+  ] = React.useState<Number | null>(null)
+  // placeholder for next steps
+  console.log(currentLabwareCheckStep)
+
+  const protocolData = useSelector((state: State) => getProtocolData(state))
+  const moduleRenderCoords = getModuleRenderCoords(
+    protocolData,
+    standardDeckDef as any
+  )
+  const labwareRenderCoords = getLabwareRenderCoords(
+    protocolData,
+    standardDeckDef as any
+  )
+
+  // get the primary pipette info
+  const pipettes = protocolData.pipettes
+  const primaryPipetteId = getPrimaryPipetteId(pipettes)
+  const primaryPipetteSpecs = getPipetteNameSpecs(
+    pipettes[primaryPipetteId].name
+  )
+  // find how many channels pipette for check has for dynmic text
+  const channels = primaryPipetteSpecs.channels
+  const numTipsText = channels === 1 ? '1 tip' : `${channels} tips`
+
+  // find which tiprack primary pipette will use for check
+  const steps = getLabwarePositionCheckSteps(protocolData)
+  const pickUpTipStep = steps.find(
+    step => step.commands[0].command === 'pickUpTip'
+  )
+  const pickUpTipLabwareId = pickUpTipStep.labwareId
+  const pickUpTipLabware = protocolData.labware[pickUpTipLabwareId]
+  // find name and slot number for tiprack used for check
+  const name = pickUpTipLabware.displayName
+  const slot = pickUpTipLabware.slot
+
+  // find the slot for the first labware that will be checked for button
+  const firstTiprackToCheckId = steps[0].labwareId
+  const firstLabwareSlot = protocolData.labware[firstTiprackToCheckId].slot
+
+  return (
+    <Portal level="top">
+      <ModalPage
+        className={styles.modal}
+        contentsClassName={styles.modal_contents}
+        titleBar={{
+          title: t('labware_position_check'),
+          back: {
+            onClick: props.onCloseClick,
+            title: t('shared:exit'),
+            children: t('shared:exit'),
+          },
+        }}
+      >
+        <Box margin={SPACING_3}>
+          <Text
+            as={'h3'}
+            textTransform={TEXT_TRANSFORM_UPPERCASE}
+            fontWeight={FONT_WEIGHT_SEMIBOLD}
+          >
+            {t('labware_position_check_overview')}
+          </Text>
+          <Text
+            as={'p'}
+            fontSize={FONT_SIZE_BODY_2}
+            lineHeight={LINE_HEIGHT_COPY}
+          >
+            {t('position_check_description', {
+              number_of_tips: numTipsText,
+              labware_name: name,
+              labware_slot: slot,
+            })}
+          </Text>
+          <Flex
+            justifyContent={JUSTIFY_SPACE_BETWEEN}
+            alignItems={ALIGN_CENTER}
+          >
+            <Box width="210px" marginLeft="4rem">
+              {/* This is a placeholder for next PR */}
+              <Text>TODO</Text>
+              <ul style={{ fontSize: '.5rem' }}>
+                {steps.map((step, index) => (
+                  <li key={index}>{step.section}</li>
+                ))}
+              </ul>
+            </Box>
+            <Box width="65%" padding={SPACING_3}>
+              <RobotWorkSpace
+                deckDef={standardDeckDef as any}
+                viewBox={DECK_MAP_VIEWBOX}
+                className={styles.deck_map}
+                deckLayerBlocklist={DECK_LAYER_BLOCKLIST}
+                id={'LabwarePositionCheck_deckMap'}
+              >
+                {() => {
+                  return (
+                    <React.Fragment>
+                      {map(moduleRenderCoords, ({ x, y, moduleModel }) => {
+                        const orientation = inferModuleOrientationFromXCoordinate(
+                          x
+                        )
+                        return (
+                          <React.Fragment
+                            key={`LabwareSetup_Module_${moduleModel}_${x}${y}`}
+                          >
+                            <ModuleViz
+                              x={x}
+                              y={y}
+                              orientation={orientation}
+                              moduleType={getModuleType(moduleModel)}
+                            />
+                            <ModuleTag
+                              x={x}
+                              y={y}
+                              moduleModel={moduleModel}
+                              orientation={orientation}
+                            />
+                          </React.Fragment>
+                        )
+                      })}
+                      {map(labwareRenderCoords, ({ x, y, labwareDef }) => {
+                        return (
+                          <React.Fragment
+                            key={`LabwareSetup_Labware_${labwareDef.metadata.displayName}_${x}${y}`}
+                          >
+                            <g transform={`translate(${x},${y})`}>
+                              <LabwareRender definition={labwareDef} />
+                            </g>
+                          </React.Fragment>
+                        )
+                      })}
+                    </React.Fragment>
+                  )
+                }}
+              </RobotWorkSpace>
+            </Box>
+          </Flex>
+          <Flex justifyContent={JUSTIFY_CENTER} marginTop="-3rem">
+            <PrimaryBtn
+              title="proceed to check"
+              backgroundColor={C_BLUE}
+              onClick={() => setCurrentLabwareCheckStep(0)}
+            >
+              {t('start_position_check', {
+                initial_labware_slot: firstLabwareSlot,
+              })}
+            </PrimaryBtn>
+          </Flex>
+        </Box>
+      </ModalPage>
+    </Portal>
+  )
+}

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
@@ -80,7 +80,7 @@ export const LabwarePositionCheck = (
       <ModalPage
         contentsClassName={styles.modal_contents}
         titleBar={{
-          title: t('labware_position_check'),
+          title: t('labware_position_check_title'),
           back: {
             onClick: props.onCloseClick,
             title: t('shared:exit'),

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
@@ -57,7 +57,7 @@ export const LabwarePositionCheck = (
   const [
     currentLabwareCheckStep,
     setCurrentLabwareCheckStep,
-  ] = React.useState<String | null>(null)
+  ] = React.useState<Number | null>(null)
   // placeholder for next steps
   console.log(currentLabwareCheckStep)
   const moduleRenderInfoById = useModuleRenderInfoById()
@@ -78,7 +78,6 @@ export const LabwarePositionCheck = (
   return (
     <Portal level="top">
       <ModalPage
-        className={styles.modal}
         contentsClassName={styles.modal_contents}
         titleBar={{
           title: t('labware_position_check'),

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 import map from 'lodash/map'
 import {
@@ -24,14 +23,10 @@ import {
 import {
   THERMOCYCLER_MODULE_V1,
   inferModuleOrientationFromXCoordinate,
-  getPipetteNameSpecs,
 } from '@opentrons/shared-data'
 import standardDeckDef from '@opentrons/shared-data/deck/definitions/2/ot2_standard.json'
 import { Portal } from '../../../App/portal'
-import { getProtocolData } from '../../../redux/protocol'
 import { useModuleRenderInfoById, useLabwareRenderInfoById } from '../hooks'
-import { getPrimaryPipetteId } from './utils/getPrimaryPipetteId'
-import { getLabwarePositionCheckSteps } from './getLabwarePositionCheckSteps'
 import { useIntroInfo } from './hooks'
 
 import styles from '../styles.css'
@@ -115,10 +110,9 @@ export const LabwarePositionCheck = (
           >
             <Box width="210px" marginLeft="4rem">
               {/* This is a placeholder for next PR */}
-              <Text>TODO</Text>
               <ul style={{ fontSize: '.5rem' }}>
                 {sections.map((section, index) => (
-                  <li key={index}>{section}</li>
+                  <li key={index}>{t(`${section.toLowerCase()}_section`)}</li>
                 ))}
               </ul>
             </Box>
@@ -133,28 +127,33 @@ export const LabwarePositionCheck = (
                 {() => {
                   return (
                     <React.Fragment>
-                      {map(moduleRenderInfoById, ({ x, y, moduleDef, nestedLabwareDef }) => (
-                        <Module
-                        key={`LabwareSetup_Module_${moduleDef.model}_${x}${y}`}
-                        x={x}
-                        y={y}
-                        orientation={inferModuleOrientationFromXCoordinate(x)}
-                        def={moduleDef}
-                        innerProps={
-                          moduleDef.model === THERMOCYCLER_MODULE_V1
-                            ? { lidMotorState: 'open' }
-                            : {}
-                        }
-                        >
-                          {nestedLabwareDef != null ? (
-                            <React.Fragment
-                              key={`LabwareSetup_Labware_${nestedLabwareDef.metadata.displayName}_${x}${y}`}
-                            >
-                              <LabwareRender definition={nestedLabwareDef} />
-                            </React.Fragment>
-                          ) : null}
-                        </Module>
-                      ))}
+                      {map(
+                        moduleRenderInfoById,
+                        ({ x, y, moduleDef, nestedLabwareDef }) => (
+                          <Module
+                            key={`LabwareSetup_Module_${moduleDef.model}_${x}${y}`}
+                            x={x}
+                            y={y}
+                            orientation={inferModuleOrientationFromXCoordinate(
+                              x
+                            )}
+                            def={moduleDef}
+                            innerProps={
+                              moduleDef.model === THERMOCYCLER_MODULE_V1
+                                ? { lidMotorState: 'open' }
+                                : {}
+                            }
+                          >
+                            {nestedLabwareDef != null ? (
+                              <React.Fragment
+                                key={`LabwareSetup_Labware_${nestedLabwareDef.metadata.displayName}_${x}${y}`}
+                              >
+                                <LabwareRender definition={nestedLabwareDef} />
+                              </React.Fragment>
+                            ) : null}
+                          </Module>
+                        )
+                      )}
 
                       {map(labwareRenderInfoById, ({ x, y, labwareDef }) => {
                         return (
@@ -180,7 +179,7 @@ export const LabwarePositionCheck = (
               onClick={() => setCurrentLabwareCheckStep(0)}
             >
               {t('start_position_check', {
-                initial_labware_slot: firstLabwareSlot,
+                initial_labware_slot: firstStepLabwareSlot,
               })}
             </PrimaryBtn>
           </Flex>

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import map from 'lodash/map'
+
 import {
   LabwareRender,
   Module,
@@ -14,10 +15,11 @@ import {
   FONT_WEIGHT_SEMIBOLD,
   JUSTIFY_SPACE_BETWEEN,
   JUSTIFY_CENTER,
+  ALIGN_CENTER,
   C_BLUE,
   SPACING_3,
+  SPACING_4,
   FONT_SIZE_BODY_2,
-  ALIGN_CENTER,
   LINE_HEIGHT_COPY,
 } from '@opentrons/components'
 import {
@@ -27,6 +29,7 @@ import {
 import standardDeckDef from '@opentrons/shared-data/deck/definitions/2/ot2_standard.json'
 import { Portal } from '../../../App/portal'
 import { useModuleRenderInfoById, useLabwareRenderInfoById } from '../hooks'
+import { PositionCheckNav } from './PositionCheckNav'
 import { useIntroInfo } from './hooks'
 
 import styles from '../styles.css'
@@ -54,17 +57,19 @@ export const LabwarePositionCheck = (
   const [
     currentLabwareCheckStep,
     setCurrentLabwareCheckStep,
-  ] = React.useState<Number | null>(null)
-  const moduleRenderInfoById = useModuleRenderInfoById()
-  const labwareRenderInfoById = useLabwareRenderInfoById()
+  ] = React.useState<String | null>(null)
   // placeholder for next steps
   console.log(currentLabwareCheckStep)
-
+  const moduleRenderInfoById = useModuleRenderInfoById()
+  const labwareRenderInfoById = useLabwareRenderInfoById()
   const introInfo = useIntroInfo()
+
   if (introInfo == null) return null
   const {
     primaryTipRackSlot,
     primaryTipRackName,
+    primaryPipetteMount,
+    secondaryPipetteMount,
     numberOfTips,
     firstStepLabwareSlot,
     sections,
@@ -108,14 +113,12 @@ export const LabwarePositionCheck = (
             justifyContent={JUSTIFY_SPACE_BETWEEN}
             alignItems={ALIGN_CENTER}
           >
-            <Box width="210px" marginLeft="4rem">
-              {/* This is a placeholder for next PR */}
-              <ul style={{ fontSize: '.5rem' }}>
-                {sections.map((section, index) => (
-                  <li key={index}>{t(`${section.toLowerCase()}_section`)}</li>
-                ))}
-              </ul>
-            </Box>
+            <PositionCheckNav
+              sections={sections}
+              primaryPipetteMount={primaryPipetteMount}
+              secondaryPipetteMount={secondaryPipetteMount}
+            />
+
             <Box width="65%" padding={SPACING_3}>
               <RobotWorkSpace
                 deckDef={standardDeckDef as any}
@@ -131,7 +134,7 @@ export const LabwarePositionCheck = (
                         moduleRenderInfoById,
                         ({ x, y, moduleDef, nestedLabwareDef }) => (
                           <Module
-                            key={`LabwareSetup_Module_${moduleDef.model}_${x}${y}`}
+                            key={`LabwarePositionCheck_Module_${moduleDef.model}_${x}${y}`}
                             x={x}
                             y={y}
                             orientation={inferModuleOrientationFromXCoordinate(
@@ -146,7 +149,7 @@ export const LabwarePositionCheck = (
                           >
                             {nestedLabwareDef != null ? (
                               <React.Fragment
-                                key={`LabwareSetup_Labware_${nestedLabwareDef.metadata.displayName}_${x}${y}`}
+                                key={`LabwarePositionCheck_Labware_${nestedLabwareDef.metadata.displayName}_${x}${y}`}
                               >
                                 <LabwareRender definition={nestedLabwareDef} />
                               </React.Fragment>
@@ -158,7 +161,7 @@ export const LabwarePositionCheck = (
                       {map(labwareRenderInfoById, ({ x, y, labwareDef }) => {
                         return (
                           <React.Fragment
-                            key={`LabwareSetup_Labware_${labwareDef.metadata.displayName}_${x}${y}`}
+                            key={`LabwarePositionCheck_Labware_${labwareDef.metadata.displayName}_${x}${y}`}
                           >
                             <g transform={`translate(${x},${y})`}>
                               <LabwareRender definition={labwareDef} />
@@ -172,9 +175,15 @@ export const LabwarePositionCheck = (
               </RobotWorkSpace>
             </Box>
           </Flex>
-          <Flex justifyContent={JUSTIFY_CENTER} marginTop="-3rem">
+          <Flex
+            justifyContent={JUSTIFY_CENTER}
+            marginTop="-4rem"
+            marginBottom={SPACING_4}
+          >
             <PrimaryBtn
-              title="proceed to check"
+              title={t('start_position_check', {
+                initial_labware_slot: firstStepLabwareSlot,
+              })}
               backgroundColor={C_BLUE}
               onClick={() => setCurrentLabwareCheckStep(0)}
             >

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/utils/labware.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/utils/labware.ts
@@ -111,9 +111,11 @@ export const getLabwareIdsInOrder = (
       const isTiprack = getIsTiprack(labwareDef)
       if (!isTiprack && labwareId !== FIXED_TRASH_ID) {
         let slot = currentLabware.slot
-        const isOnTopOfModule = Object.keys(modules).some(
-          moduleId => moduleId === currentLabware.slot
-        )
+        const isOnTopOfModule =
+          modules != null &&
+          Object.keys(modules).some(
+            moduleId => moduleId === currentLabware.slot
+          )
         if (isOnTopOfModule) {
           slot = modules[slot].slot
         }

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/utils/stepCreators.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/utils/stepCreators.ts
@@ -14,6 +14,7 @@ const getIsLabwareOnTopOfTC = (
 ): boolean => {
   const labwareSlot = labware[labwareId].slot
   return (
+    modules != null &&
     Object.keys(modules).some(moduleId => moduleId === labwareSlot) &&
     getModuleType(modules[labwareSlot].model) === THERMOCYCLER_MODULE_TYPE
   )

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
@@ -24,6 +24,7 @@ import {
   THERMOCYCLER_MODULE_V1,
 } from '@opentrons/shared-data'
 import standardDeckDef from '@opentrons/shared-data/deck/definitions/2/ot2_standard.json'
+import { LabwarePositionCheck } from '../../LabwarePositionCheck'
 import { LabwareInfoOverlay } from './LabwareInfoOverlay'
 import { LabwareSetupModal } from './LabwareSetupModal'
 import { getModuleTypesThatRequireExtraAttention } from './utils/getModuleTypesThatRequireExtraAttention'
@@ -59,11 +60,20 @@ export const LabwareSetup = (): JSX.Element | null => {
   const moduleTypesThatRequireExtraAttention = getModuleTypesThatRequireExtraAttention(
     moduleModels
   )
+  const [
+    showLabwarePositionCheckModal,
+    setShowLabwarePositionCheckModal,
+  ] = React.useState<boolean>(false)
   return (
     <React.Fragment>
       {showLabwareHelpModal && (
         <LabwareSetupModal
           onCloseClick={() => setShowLabwareHelpModal(false)}
+        />
+      )}
+      {showLabwarePositionCheckModal && (
+        <LabwarePositionCheck
+          onCloseClick={() => setShowLabwarePositionCheckModal(false)}
         />
       )}
       <Flex
@@ -148,7 +158,8 @@ export const LabwareSetup = (): JSX.Element | null => {
         <Flex justifyContent={JUSTIFY_CENTER}>
           <SecondaryBtn
             title={t('check_labware_positions')}
-            onClick={() => console.log('check labware positions!')}
+            marginRight={SPACING_3}
+            onClick={() => setShowLabwarePositionCheckModal(true)}
             color={C_BLUE}
             id={'LabwareSetup_checkLabwarePositionsButton'}
           >

--- a/components/src/primitives/style-props.ts
+++ b/components/src/primitives/style-props.ts
@@ -45,6 +45,7 @@ const BORDER_PROPS = [
   'borderRadius',
   'borderWidth',
   'borderColor',
+  'boxShadow',
 ] as const
 
 const FLEXBOX_PROPS = [

--- a/components/src/primitives/types.ts
+++ b/components/src/primitives/types.ts
@@ -44,6 +44,7 @@ export interface BorderProps {
   borderRadius?: string | number
   borderWidth?: string | number
   borderColor?: string
+  boxShadow?: string
 }
 
 export interface FlexboxProps {


### PR DESCRIPTION
# Overview

This PR addresses #8215 by adding the labware position check overview modal without hover/hightlight/animations

# Changelog

-  feat(app): Add labware position check overview modal 

# Review requests

Single pipette protocol
- [ ] description references {num channels} as number of tips to be used
- [ ] description references tip rack name and slot number to pick up from
- [ ] step navigation only references a single pipette
- [ ] button references slot number of the tip rack to pick up tip from 

Two pipette protocol
- [ ] description references {num channels} as number of tips to be used
- [ ] description references tip rack name and slot number to pick up from
- [ ] step navigation only references secondary pipette to check, then primary pipette to check
- [ ] button references slot number of the tip rack to to check with secondary pipette

# Risk assessment

App Low, single modal hidden behind FF
