### PR TITLE
refactor(protocol-engine): ensure engine stays active for `basic` session

### DIFF
--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -150,6 +150,13 @@ class CommandView(HasState[CommandState]):
         """
         return self._state.stop_requested
 
+    def get_is_stopped(self) -> bool:
+        """Get whether an engine stop has completed."""
+        return self._state.stop_requested and not any(
+            c.status == CommandStatus.RUNNING
+            for c in self._state.commands_by_id.values()
+        )
+
     def validate_action_allowed(self, action: Union[PlayAction, PauseAction]) -> None:
         """Validate if a PlayAction or PauseAction is allowed, raising if not.
 

--- a/api/src/opentrons/protocol_runner/protocol_runner.py
+++ b/api/src/opentrons/protocol_runner/protocol_runner.py
@@ -106,16 +106,19 @@ class ProtocolRunner:
             else:
                 self._load_legacy(protocol_source)
 
+        # ensure the engine is stopped gracefully once the
+        # protocol file stops issuing commands
+        self._task_queue.add(
+            phase=TaskQueuePhase.CLEANUP,
+            func=self._protocol_engine.stop,
+            wait_until_complete=True,
+        )
+
     def play(self) -> None:
         """Start or resume the run."""
         self._protocol_engine.play()
 
         if not self._task_queue.is_started():
-            self._task_queue.add(
-                phase=TaskQueuePhase.CLEANUP,
-                func=self._protocol_engine.stop,
-                wait_until_complete=True,
-            )
             self._task_queue.start()
 
     def pause(self) -> None:

--- a/api/tests/opentrons/protocol_engine/state/test_command_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view.py
@@ -235,6 +235,36 @@ def test_get_stop_requested() -> None:
     assert subject.get_stop_requested() is False
 
 
+def test_get_is_stopped() -> None:
+    """It should return true if stop requested and no command running."""
+    completed_command = create_completed_command(command_id="command-id-1")
+    running_command = create_running_command(command_id="command-id-2")
+    pending_command = create_pending_command(command_id="command-id-3")
+    failed_command = create_failed_command(command_id="command-id-4")
+
+    subject = get_command_view(
+        stop_requested=False,
+        commands_by_id=(),
+    )
+    assert subject.get_is_stopped() is False
+
+    subject = get_command_view(
+        stop_requested=True,
+        commands_by_id=[("command-id-2", running_command)],
+    )
+    assert subject.get_is_stopped() is False
+
+    subject = get_command_view(
+        stop_requested=True,
+        commands_by_id=[
+            ("command-id-1", completed_command),
+            ("command-id-3", pending_command),
+            ("command-id-4", failed_command),
+        ],
+    )
+    assert subject.get_is_stopped() is True
+
+
 class ActionAllowedSpec(NamedTuple):
     """Spec data to test CommandView.validate_action_allowed."""
 

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner.py
@@ -142,11 +142,6 @@ async def test_play_starts_run(
 
     decoy.verify(
         protocol_engine.play(),
-        task_queue.add(
-            phase=TaskQueuePhase.CLEANUP,
-            func=protocol_engine.stop,
-            wait_until_complete=True,
-        ),
         task_queue.start(),
     )
 
@@ -212,6 +207,7 @@ def test_load_json(
     json_file_reader: JsonFileReader,
     json_command_translator: JsonCommandTranslator,
     protocol_engine: ProtocolEngine,
+    task_queue: TaskQueue,
     subject: ProtocolRunner,
 ) -> None:
     """It should load a JSON protocol file."""
@@ -242,6 +238,11 @@ def test_load_json(
             request=pe_commands.PauseRequest(
                 data=pe_commands.PauseData(message="goodbye")
             )
+        ),
+        task_queue.add(
+            phase=TaskQueuePhase.CLEANUP,
+            func=protocol_engine.stop,
+            wait_until_complete=True,
         ),
     )
 
@@ -280,7 +281,11 @@ def test_load_python(
             protocol=python_protocol,
             context=protocol_context,
         ),
-        times=1,
+        task_queue.add(
+            phase=TaskQueuePhase.CLEANUP,
+            func=protocol_engine.stop,
+            wait_until_complete=True,
+        ),
     )
 
 
@@ -330,6 +335,11 @@ def test_load_legacy_python(
             protocol=legacy_protocol,
             context=legacy_context,
         ),
+        task_queue.add(
+            phase=TaskQueuePhase.CLEANUP,
+            func=protocol_engine.stop,
+            wait_until_complete=True,
+        ),
     )
 
 
@@ -375,5 +385,10 @@ def test_load_legacy_json(
             func=legacy_executor.execute,
             protocol=legacy_protocol,
             context=legacy_context,
+        ),
+        task_queue.add(
+            phase=TaskQueuePhase.CLEANUP,
+            func=protocol_engine.stop,
+            wait_until_complete=True,
         ),
     )

--- a/robot-server/robot_server/sessions/router/base_router.py
+++ b/robot-server/robot_server/sessions/router/base_router.py
@@ -232,7 +232,7 @@ async def remove_session_by_id(
         engine_store: ProtocolEngine storage and control.
     """
     try:
-        if engine_store.engine.state_view.commands.get_is_running():
+        if not engine_store.engine.state_view.commands.get_is_stopped():
             raise SessionRunning().as_error(status.HTTP_409_CONFLICT)
     except EngineMissingError:
         pass

--- a/robot-server/robot_server/sessions/router/base_router.py
+++ b/robot-server/robot_server/sessions/router/base_router.py
@@ -51,7 +51,7 @@ class SessionAlreadyActive(ErrorDetails):
 class SessionRunning(ErrorDetails):
     """An error if one tries to delete a session that is running."""
 
-    id: Literal["SessionRunning"] = "SessionStillRunning"
+    id: Literal["SessionRunning"] = "SessionRunning"
     title: str = "Session Running"
     detail: str = (
         "Session is currently running. Allow the session to finish or"


### PR DESCRIPTION
## Overview

This PR follows up on #8396 by ensuring that, once a `play` action is issued to a `basic` session, the ProtocolEngine remains active and will immediately execute any further commands that get `POST`'d. Closes #8070.

## Changelog

- Only add implicit cleanup via `ProtocolEngine.stop` if the `ProtocolRunner` is running a protocol file
    - In other words, require an _explicit_ `stop` action from the client if running a `basic` session
    - Without a `stop`, the engine (and its `QueueWorker`) will remain in a running, processing new commands as they come in
- Require the `ProtocolEngine` to be stopped before the server will accept a `DELETE /sessions/:session_id`

## Review requests

- [ ] Code and test changes make sense
- [ ] Smoke test

### Smoke test

The smoke test should be valid on either a real robot or a dev server using the [Postman testing collection](https://gist.github.com/mcous/7dde93b6ea83753b86b0d84b40ba07f6), which has been updated to test this PR.

1. `POST /sessions { sessionType: basic }`
2. `POST /sessions/:session_id/actions { actionType: play }`
3. `POST /sessions/:session_id/commands { commandType: loadPipette }`
    - [ ] Load pipette command should run and succeed
    - [ ] Session status should show `running` if you `GET /sessions/:session_id`
4. `POST /sessions/:session_id/commands { commandType: moveToWell }`
    - Use the pipette ID from the `loadPipette` result and the `fixedTrash`, `A1` as the labware ID and well name
    - [ ] Move to well command should run and succeed
5. `DELETE /sessions/:session_id`
    - [ ] Request should `409`
6. `POST /sessions/:session_id/actions { actionType: stop}`
7. `DELETE /sessions/:session_id`
    - [ ] Request should `200`

## Risk assessment

Low, feature flag
