### PR TITLE
chore: Remove mentions of obsolete Balena Makefile targets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -367,7 +367,7 @@ from github. You can do this via:
 make push host=${some_other_ip_address}
 ```
 
-To put the robot server on a test robot, if it's on buildroot do:
+To put the robot server on a test robot, do:
 
 ```shell
 # push the current contents of the api directory to robot for testing
@@ -375,16 +375,6 @@ To put the robot server on a test robot, if it's on buildroot do:
 make push-api
 # takes optional host variable for other robots
 make push-api host=${some_other_ip_address}
-```
-
-and if it's still on balena do:
-
-```shell
-# push the current contents of the api directory to robot for testing
-# defaults to currently connected ethernet robot
-make -C api push-balena
-# takes optional host variable for other robots
-make -C api push-balena host=${some_other_ip_address}
 ```
 
 To SSH into the robot, do

--- a/Makefile
+++ b/Makefile
@@ -108,21 +108,11 @@ deploy-py:
 	$(MAKE) -C $(API_DIR) deploy
 	$(MAKE) -C $(SHARED_DATA_DIR) deploy-py
 
-.PHONY: push-api-balena
-push-api-balena: export host = $(usb_host)
-push-api-balena:
-	$(if $(host),@echo "Pushing to $(host)",$(error host variable required))
-	$(MAKE) -C $(API_DIR) push-balena
-	$(MAKE) -C $(API_DIR) restart
-
 .PHONY: push-api
 push-api: export host = $(usb_host)
 push-api:
 	$(if $(host),@echo "Pushing to $(host)",$(error host variable required))
 	$(MAKE) -C $(API_DIR) push
-
-.PHONY: push-api-buildroot
-push-api-buildroot: push-api
 
 .PHONY: push-update-server
 push-update-server: export host = $(usb_host)


### PR DESCRIPTION
# Overview

Balena-based system images have long been obsolete, and it's very unlikely that we will ever want to install modern `api`, `robot-server`, etc. on a Balena-based robot. So:

* Remove the `push-api-balena` target from top-level Makefile.
    * This referred to a `push-balena` target in the `api` Makefile that appears to already have been removed.
* Remove `push-api-buildroot` target from top-level Makefile, because you can just use `push-api` for that now.
* Update the relevant section of `CONTRIBUTING.md`.

# Review requests

Anything else I missed, off the top of your head?

# Risk assessment

No risk.
