### PR TITLE
refactor(app): add scaffolding for non-rpc run detail page behind feature flag

### DIFF
--- a/app/src/assets/localization/en/index.ts
+++ b/app/src/assets/localization/en/index.ts
@@ -7,6 +7,7 @@ import robot_calibration from './robot_calibration.json'
 import robot_connection from './robot_connection.json'
 import robot_controls from './robot_controls.json'
 import robot_info from './robot_info.json'
+import run_details from './run_details.json'
 import top_navigation from './top_navigation.json'
 
 export const en = {
@@ -19,5 +20,6 @@ export const en = {
   robot_connection,
   robot_controls,
   robot_info,
+  run_details,
   top_navigation,
 }

--- a/app/src/assets/localization/en/run_details.json
+++ b/app/src/assets/localization/en/run_details.json
@@ -1,3 +1,14 @@
 {
-  "protocol_title": "Protocol - {{protocol_name}}"
+  "pause_run": "Pause Run",
+  "protocol_title": "Protocol - {{protocol_name}}",
+  "reset_run": "Reset Run",
+  "resume_run": "Resume Run",
+  "run_protocol": "Run Protocol",
+  "run_status": "Status: {{status}}",
+  "start_run": "Start Run",
+  "status_canceled": "Canceled",
+  "status_finished": "Finished",
+  "status_loaded": "Not started",
+  "status_paused": "Paused",
+  "status_running": "Running"
 }

--- a/app/src/assets/localization/en/run_details.json
+++ b/app/src/assets/localization/en/run_details.json
@@ -1,0 +1,3 @@
+{
+  "protocol_title": "Protocol - {{protocol_name}}"
+}

--- a/app/src/organisms/RunDetails/hooks.ts
+++ b/app/src/organisms/RunDetails/hooks.ts
@@ -6,11 +6,13 @@ import type { State } from '../../redux/types'
 
 interface ProtocolDetails {
   displayName: string | null
-  protocolData: ProtocolFileV5<{}> // TODO: IMMEDIATELY update to ProtocolFileV6 once schema is complete
+  protocolData: ProtocolFileV5<{}> | null // TODO: IMMEDIATELY update to ProtocolFileV6 once schema is complete
 }
 
 export function useProtocolDetails(): ProtocolDetails {
-  const protocolData = useSelector((state: State) => getProtocolData(state))
+  const protocolData = useSelector((state: State) =>
+    getProtocolData(state)
+  ) as ProtocolFileV5<{}> | null
   const displayName = useSelector((state: State) => getProtocolName(state))
   return { displayName, protocolData }
 }

--- a/app/src/organisms/RunDetails/hooks.ts
+++ b/app/src/organisms/RunDetails/hooks.ts
@@ -1,4 +1,3 @@
-import path from 'path'
 import { useSelector } from 'react-redux'
 import { getProtocolData, getProtocolName } from '../../redux/protocol'
 

--- a/app/src/organisms/RunDetails/hooks.ts
+++ b/app/src/organisms/RunDetails/hooks.ts
@@ -1,0 +1,17 @@
+import path from 'path'
+import { useSelector } from 'react-redux'
+import { getProtocolData, getProtocolName } from '../../redux/protocol'
+
+import type { ProtocolFileV5 } from '@opentrons/shared-data'
+import type { State } from '../../redux/types'
+
+interface ProtocolDetails {
+  displayName: string | null
+  protocolData: ProtocolFileV5<{}> // TODO: IMMEDIATELY update to ProtocolFileV6 once schema is complete
+}
+
+export function useProtocolDetails(): ProtocolDetails {
+  const protocolData = useSelector((state: State) => getProtocolData(state))
+  const displayName = useSelector((state: State) => getProtocolName(state))
+  return { displayName, protocolData }
+}

--- a/app/src/organisms/RunDetails/index.tsx
+++ b/app/src/organisms/RunDetails/index.tsx
@@ -1,19 +1,20 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Flex, Text } from '@opentrons/components'
+import { Flex, Text, DIRECTION_COLUMN } from '@opentrons/components'
 import { Page } from '../../atoms/Page'
 import { useProtocolDetails } from './hooks'
 
 
-export function RunDetails(): JSX.Element {
+export function RunDetails(): JSX.Element | null {
   const { t } = useTranslation('run_details')
   const {displayName, protocolData} = useProtocolDetails()
+  if (protocolData == null) return null
 
   const titleBarProps = { title: t('protocol_title', { protocol_name: displayName}) }
 
   return (
     <Page titleBarProps={titleBarProps}>
-      <Flex>
+      <Flex flexDirection={DIRECTION_COLUMN}>
         {'commands' in  protocolData ? protocolData.commands.map(command => (
           <Flex>
             <Text>{command.command}</Text>

--- a/app/src/organisms/RunDetails/index.tsx
+++ b/app/src/organisms/RunDetails/index.tsx
@@ -4,22 +4,25 @@ import { Flex, Text, DIRECTION_COLUMN } from '@opentrons/components'
 import { Page } from '../../atoms/Page'
 import { useProtocolDetails } from './hooks'
 
-
 export function RunDetails(): JSX.Element | null {
   const { t } = useTranslation('run_details')
-  const {displayName, protocolData} = useProtocolDetails()
+  const { displayName, protocolData } = useProtocolDetails()
   if (protocolData == null) return null
 
-  const titleBarProps = { title: t('protocol_title', { protocol_name: displayName}) }
+  const titleBarProps = {
+    title: t('protocol_title', { protocol_name: displayName }),
+  }
 
   return (
     <Page titleBarProps={titleBarProps}>
       <Flex flexDirection={DIRECTION_COLUMN}>
-        {'commands' in  protocolData ? protocolData.commands.map(command => (
-          <Flex>
-            <Text>{command.command}</Text>
-          </Flex>
-        )): null}
+        {'commands' in protocolData
+          ? protocolData.commands.map(command => (
+              <Flex>
+                <Text>{command.command}</Text>
+              </Flex>
+            ))
+          : null}
       </Flex>
     </Page>
   )

--- a/app/src/organisms/RunDetails/index.tsx
+++ b/app/src/organisms/RunDetails/index.tsx
@@ -17,8 +17,8 @@ export function RunDetails(): JSX.Element | null {
     <Page titleBarProps={titleBarProps}>
       <Flex flexDirection={DIRECTION_COLUMN}>
         {'commands' in protocolData
-          ? protocolData.commands.map(command => (
-              <Flex>
+          ? protocolData.commands.map((command, index) => (
+              <Flex key={index}>
                 <Text>{command.command}</Text>
               </Flex>
             ))

--- a/app/src/organisms/RunDetails/index.tsx
+++ b/app/src/organisms/RunDetails/index.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { Flex, Text } from '@opentrons/components'
+import { Page } from '../../atoms/Page'
+import { useProtocolDetails } from './hooks'
+
+
+export function RunDetails(): JSX.Element {
+  const { t } = useTranslation('run_details')
+  const {displayName, protocolData} = useProtocolDetails()
+
+  const titleBarProps = { title: t('protocol_title', { protocol_name: displayName}) }
+
+  return (
+    <Page titleBarProps={titleBarProps}>
+      <Flex>
+        {'commands' in  protocolData ? protocolData.commands.map(command => (
+          <Flex>
+            <Text>{command.command}</Text>
+          </Flex>
+        )): null}
+      </Flex>
+    </Page>
+  )
+}

--- a/app/src/organisms/RunTimeControl/hooks.ts
+++ b/app/src/organisms/RunTimeControl/hooks.ts
@@ -5,13 +5,13 @@ interface RunControls {
 }
 
 export function useRunControls(): RunControls {
-  const play = () => {
+  const play = (): void => {
     console.log('TODO: wire up to protocol play endpoint')
   }
-  const pause = () => {
+  const pause = (): void => {
     console.log('TODO: wire up to protocol pause endpoint')
   }
-  const reset = () => {
+  const reset = (): void => {
     console.log('TODO: wire up to protocol reset endpoint')
   }
   return { play, pause, reset }

--- a/app/src/organisms/RunTimeControl/hooks.ts
+++ b/app/src/organisms/RunTimeControl/hooks.ts
@@ -1,0 +1,33 @@
+interface RunControls {
+  play: () => void
+  pause: () => void
+  reset: () => void
+}
+
+export function useRunControls(): RunControls {
+  const play = () => {
+    console.log('TODO: wire up to protocol play endpoint')
+  }
+  const pause = () => {
+    console.log('TODO: wire up to protocol pause endpoint')
+  }
+  const reset = () => {
+    console.log('TODO: wire up to protocol reset endpoint')
+  }
+  return { play, pause, reset }
+}
+
+// TODO: IMMEDIATELY replace with real status enum type from server run status
+type RunStatus = 'loaded' | 'running' | 'paused' | 'finished' | 'canceled'
+export function useRunStatus(): RunStatus {
+  const runStatus = 'loaded'
+  return runStatus
+}
+
+export function useRunDisabledReason(): string | null {
+  /* TODO: IMMEDIATELY return reasons for "protocol analysis incomplete" ,
+   "protocol is being canceled", "required modules not detected",
+   "required pipettes not detected", "isBlocked?"
+  */
+  return null
+}

--- a/app/src/organisms/RunTimeControl/index.tsx
+++ b/app/src/organisms/RunTimeControl/index.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  ALIGN_STRETCH,
+  DIRECTION_COLUMN,
+  Flex,
+  PrimaryBtn,
+  SPACING_1,
+  Text,
+} from '@opentrons/components'
+import { useRunControls, useRunDisabledReason, useRunStatus } from './hooks'
+
+export function RunTimeControl(): JSX.Element {
+  const { t } = useTranslation('run_details')
+  const runStatus = useRunStatus()
+  const {play, pause, reset} = useRunControls()
+
+  let callToActionText = ''
+  let action = () => {}
+  if (runStatus === 'loaded') {
+    callToActionText = t('start_run')
+    action = play
+  } else if (runStatus === 'running') {
+    callToActionText = t('pause_run')
+    action = pause
+  } else if (runStatus === 'paused') {
+    callToActionText = t('resume_run')
+    action = play
+  } else if (runStatus === 'finished') {
+    callToActionText = t('reset_run')
+    action = reset
+  } else if (runStatus === 'canceled') {
+    callToActionText = t('reset_run')
+    action = reset
+  }
+
+  return (
+      <Flex flexDirection={DIRECTION_COLUMN} margin={SPACING_1}>
+        <Text>{t('run_status', {status: t(`status_${runStatus}`)})}</Text>
+          {
+            runStatus !== 'loaded'
+              ?  (<Text>TODO: INSERT RUN TIMER HERE</Text>)
+              : null
+          }
+        <PrimaryBtn onClick={action} alignSelf={ALIGN_STRETCH}>
+          {callToActionText}
+        </PrimaryBtn>
+      </Flex>
+  )
+}

--- a/app/src/organisms/RunTimeControl/index.tsx
+++ b/app/src/organisms/RunTimeControl/index.tsx
@@ -13,7 +13,7 @@ import { useRunControls, useRunDisabledReason, useRunStatus } from './hooks'
 export function RunTimeControl(): JSX.Element {
   const { t } = useTranslation('run_details')
   const runStatus = useRunStatus()
-  const {play, pause, reset} = useRunControls()
+  const { play, pause, reset } = useRunControls()
 
   let callToActionText = ''
   let action = () => {}
@@ -35,16 +35,12 @@ export function RunTimeControl(): JSX.Element {
   }
 
   return (
-      <Flex flexDirection={DIRECTION_COLUMN} margin={SPACING_1}>
-        <Text>{t('run_status', {status: t(`status_${runStatus}`)})}</Text>
-          {
-            runStatus !== 'loaded'
-              ?  (<Text>TODO: INSERT RUN TIMER HERE</Text>)
-              : null
-          }
-        <PrimaryBtn onClick={action} alignSelf={ALIGN_STRETCH}>
-          {callToActionText}
-        </PrimaryBtn>
-      </Flex>
+    <Flex flexDirection={DIRECTION_COLUMN} margin={SPACING_1}>
+      <Text>{t('run_status', { status: t(`status_${runStatus}`) })}</Text>
+      {runStatus !== 'loaded' ? <Text>TODO: INSERT RUN TIMER HERE</Text> : null}
+      <PrimaryBtn onClick={action} alignSelf={ALIGN_STRETCH}>
+        {callToActionText}
+      </PrimaryBtn>
+    </Flex>
   )
 }

--- a/app/src/organisms/RunTimeControl/index.tsx
+++ b/app/src/organisms/RunTimeControl/index.tsx
@@ -8,7 +8,7 @@ import {
   SPACING_1,
   Text,
 } from '@opentrons/components'
-import { useRunControls, useRunDisabledReason, useRunStatus } from './hooks'
+import { useRunControls, useRunStatus } from './hooks'
 
 export function RunTimeControl(): JSX.Element {
   const { t } = useTranslation('run_details')
@@ -16,7 +16,7 @@ export function RunTimeControl(): JSX.Element {
   const { play, pause, reset } = useRunControls()
 
   let callToActionText = ''
-  let action = () => {}
+  let action = (): void => {}
   if (runStatus === 'loaded') {
     callToActionText = t('start_run')
     action = play

--- a/app/src/pages/Run/RunPanel/__tests__/RunPanel.test.tsx
+++ b/app/src/pages/Run/RunPanel/__tests__/RunPanel.test.tsx
@@ -33,28 +33,24 @@ describe('RunSetupCard', () => {
 
   beforeEach(() => {
     when(mockRunTimer)
-      .mockReturnValue(<div></div>) // this (default) empty div will be returned when ModuleSetup isn't called with expected props
       .calledWith(partialComponentPropsMatcher({}))
       .mockImplementation(() => (
         <div>Mock Run Timer</div>
       ))
 
     when(mockRunControls)
-      .mockReturnValue(<div></div>) // this (default) empty div will be returned when ModuleSetup isn't called with expected props
       .calledWith(partialComponentPropsMatcher({}))
       .mockImplementation(() => (
         <div>Mock Run Controls</div>
       ))
 
     when(mockModuleLiveStatusCards)
-      .mockReturnValue(<div></div>) // this (default) empty div will be returned when ModuleSetup isn't called with expected props
       .calledWith(partialComponentPropsMatcher({}))
       .mockImplementation(() => (
         <div>Mock Module Live Status Cards</div>
       ))
 
     when(mockRunTimeControl)
-      .mockReturnValue(<div></div>) // this (default) empty div will be returned when ModuleSetup isn't called with expected props
       .calledWith(partialComponentPropsMatcher({}))
       .mockImplementation(() => (
         <div>Mock Run Time Control</div>

--- a/app/src/pages/Run/RunPanel/__tests__/RunPanel.test.tsx
+++ b/app/src/pages/Run/RunPanel/__tests__/RunPanel.test.tsx
@@ -21,14 +21,10 @@ jest.mock('../ModuleLiveStatusCards')
 jest.mock('../../../../redux/config')
 jest.mock('../../../../organisms/RunTimeControl')
 
-const mockRunTimer = RunTimer as jest.MockedFunction<typeof RunTimer>
+const mockRunTimer = RunTimer as jest.Mock
 const mockRunControls = RunControls as jest.MockedFunction<typeof RunControls>
-const mockModuleLiveStatusCards = ModuleLiveStatusCards as jest.MockedFunction<
-  typeof ModuleLiveStatusCards
->
-const mockRunTimeControl = RunTimeControl as jest.MockedFunction<
-  typeof RunTimeControl
->
+const mockModuleLiveStatusCards = ModuleLiveStatusCards as jest.Mock
+const mockRunTimeControl = RunTimeControl as jest.Mock
 const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<
   typeof useFeatureFlag
 >
@@ -40,15 +36,12 @@ describe('RunSetupCard', () => {
     when(mockRunTimer)
       .calledWith(partialComponentPropsMatcher({}))
       .mockImplementation(() => <div>Mock Run Timer</div>)
-
     when(mockRunControls)
       .calledWith(partialComponentPropsMatcher({}))
       .mockImplementation(() => <div>Mock Run Controls</div>)
-
     when(mockModuleLiveStatusCards)
       .calledWith(partialComponentPropsMatcher({}))
       .mockImplementation(() => <div>Mock Module Live Status Cards</div>)
-
     when(mockRunTimeControl)
       .calledWith(partialComponentPropsMatcher({}))
       .mockImplementation(() => <div>Mock Run Time Control</div>)

--- a/app/src/pages/Run/RunPanel/__tests__/RunPanel.test.tsx
+++ b/app/src/pages/Run/RunPanel/__tests__/RunPanel.test.tsx
@@ -1,0 +1,107 @@
+import * as React from 'react'
+import { when } from 'jest-when'
+import '@testing-library/jest-dom'
+import {
+  partialComponentPropsMatcher,
+  renderWithProviders,
+} from '@opentrons/components/__utils__'
+
+import { i18n } from '../../../../i18n'
+
+import { useFeatureFlag } from '../../../../redux/config'
+import { RunTimeControl } from '../../../../organisms/RunTimeControl'
+import { RunTimer } from '../RunTimer'
+import { RunControls } from '../RunControls'
+import { ModuleLiveStatusCards } from '../ModuleLiveStatusCards'
+import { RunPanelComponent } from '../'
+
+jest.mock('../RunTimer')
+jest.mock('../RunControls')
+jest.mock('../ModuleLiveStatusCards')
+jest.mock('../../../../redux/config')
+jest.mock('../../../../organisms/RunTimeControl')
+
+const mockRunTimer = RunTimer as jest.MockedFunction<typeof RunTimer>
+const mockRunControls = RunControls as jest.MockedFunction<typeof RunControls>
+const mockModuleLiveStatusCards = ModuleLiveStatusCards as jest.MockedFunction<typeof ModuleLiveStatusCards>
+const mockRunTimeControl = RunTimeControl as jest.MockedFunction<typeof RunTimeControl>
+const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<typeof useFeatureFlag>
+
+
+describe('RunSetupCard', () => {
+  let render: () => ReturnType<typeof renderWithProviders>
+
+  beforeEach(() => {
+    when(mockRunTimer)
+      .mockReturnValue(<div></div>) // this (default) empty div will be returned when ModuleSetup isn't called with expected props
+      .calledWith(partialComponentPropsMatcher({}))
+      .mockImplementation(() => (
+        <div>Mock Run Timer</div>
+      ))
+
+    when(mockRunControls)
+      .mockReturnValue(<div></div>) // this (default) empty div will be returned when ModuleSetup isn't called with expected props
+      .calledWith(partialComponentPropsMatcher({}))
+      .mockImplementation(() => (
+        <div>Mock Run Controls</div>
+      ))
+
+    when(mockModuleLiveStatusCards)
+      .mockReturnValue(<div></div>) // this (default) empty div will be returned when ModuleSetup isn't called with expected props
+      .calledWith(partialComponentPropsMatcher({}))
+      .mockImplementation(() => (
+        <div>Mock Module Live Status Cards</div>
+      ))
+
+    when(mockRunTimeControl)
+      .mockReturnValue(<div></div>) // this (default) empty div will be returned when ModuleSetup isn't called with expected props
+      .calledWith(partialComponentPropsMatcher({}))
+      .mockImplementation(() => (
+        <div>Mock Run Time Control</div>
+      ))
+
+    render = () => {
+      return renderWithProviders(
+        <RunPanelComponent
+          disabled={true}
+          modulesReady={true}
+          isReadyToRun={true}
+          isPaused={true}
+          isRunning={true}
+          isBlocked={true}
+          onRunClick={() => {}}
+          onPauseClick={() => {}}
+          onResumeClick={() => {}}
+          onResetClick={() => {}}
+        />
+        , { i18nInstance: i18n }
+      )
+    }
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('renders legacy run panel components when usePreProtocolWithoutRPC ff is not set', () => {
+    when(mockUseFeatureFlag)
+      .calledWith('preProtocolFlowWithoutRPC')
+      .mockReturnValue(false)
+    const { getByText } = render()
+    getByText('Mock Run Timer')
+    getByText('Mock Run Controls')
+    getByText('Mock Module Live Status Cards')
+    expect(mockRunTimeControl).not.toHaveBeenCalled()
+  })
+
+  it('renders new run panel components when usePreProtocolWithoutRPC ff is set', () => {
+    when(mockUseFeatureFlag)
+      .calledWith('preProtocolFlowWithoutRPC')
+      .mockReturnValue(true)
+    const { getByText } = render()
+    getByText('Mock Run Time Control')
+    getByText('Mock Module Live Status Cards')
+    expect(mockRunTimer).not.toHaveBeenCalled()
+    expect(mockRunControls).not.toHaveBeenCalled()
+  })
+})

--- a/app/src/pages/Run/RunPanel/__tests__/RunPanel.test.tsx
+++ b/app/src/pages/Run/RunPanel/__tests__/RunPanel.test.tsx
@@ -23,10 +23,15 @@ jest.mock('../../../../organisms/RunTimeControl')
 
 const mockRunTimer = RunTimer as jest.MockedFunction<typeof RunTimer>
 const mockRunControls = RunControls as jest.MockedFunction<typeof RunControls>
-const mockModuleLiveStatusCards = ModuleLiveStatusCards as jest.MockedFunction<typeof ModuleLiveStatusCards>
-const mockRunTimeControl = RunTimeControl as jest.MockedFunction<typeof RunTimeControl>
-const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<typeof useFeatureFlag>
-
+const mockModuleLiveStatusCards = ModuleLiveStatusCards as jest.MockedFunction<
+  typeof ModuleLiveStatusCards
+>
+const mockRunTimeControl = RunTimeControl as jest.MockedFunction<
+  typeof RunTimeControl
+>
+const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<
+  typeof useFeatureFlag
+>
 
 describe('RunSetupCard', () => {
   let render: () => ReturnType<typeof renderWithProviders>
@@ -34,27 +39,19 @@ describe('RunSetupCard', () => {
   beforeEach(() => {
     when(mockRunTimer)
       .calledWith(partialComponentPropsMatcher({}))
-      .mockImplementation(() => (
-        <div>Mock Run Timer</div>
-      ))
+      .mockImplementation(() => <div>Mock Run Timer</div>)
 
     when(mockRunControls)
       .calledWith(partialComponentPropsMatcher({}))
-      .mockImplementation(() => (
-        <div>Mock Run Controls</div>
-      ))
+      .mockImplementation(() => <div>Mock Run Controls</div>)
 
     when(mockModuleLiveStatusCards)
       .calledWith(partialComponentPropsMatcher({}))
-      .mockImplementation(() => (
-        <div>Mock Module Live Status Cards</div>
-      ))
+      .mockImplementation(() => <div>Mock Module Live Status Cards</div>)
 
     when(mockRunTimeControl)
       .calledWith(partialComponentPropsMatcher({}))
-      .mockImplementation(() => (
-        <div>Mock Run Time Control</div>
-      ))
+      .mockImplementation(() => <div>Mock Run Time Control</div>)
 
     render = () => {
       return renderWithProviders(
@@ -69,8 +66,8 @@ describe('RunSetupCard', () => {
           onPauseClick={() => {}}
           onResumeClick={() => {}}
           onResetClick={() => {}}
-        />
-        , { i18nInstance: i18n }
+        />,
+        { i18nInstance: i18n }
       )
     }
   })

--- a/app/src/pages/Run/RunPanel/index.tsx
+++ b/app/src/pages/Run/RunPanel/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { connect } from 'react-redux'
+import { useTranslation } from 'react-i18next'
 
 import {
   actions as robotActions,
@@ -11,6 +12,8 @@ import { SidePanel, SidePanelGroup } from '@opentrons/components'
 import { RunTimer } from './RunTimer'
 import { RunControls } from './RunControls'
 import { ModuleLiveStatusCards } from './ModuleLiveStatusCards'
+import { useFeatureFlag } from '../../../redux/config'
+import { RunTimeControl } from '../../../organisms/RunTimeControl'
 
 import type { MapDispatchToProps } from 'react-redux'
 import type { State } from '../../../redux/types'
@@ -53,26 +56,35 @@ const mapDispatchToProps: MapDispatchToProps<DP, {}> = dispatch => ({
 })
 
 function RunPanelComponent(props: Props): JSX.Element {
-  return (
-    <SidePanel title="Execute Run">
-      <SidePanelGroup>
-        <RunTimer />
-        <RunControls
-          disabled={props.disabled}
-          modulesReady={props.modulesReady}
-          isReadyToRun={props.isReadyToRun}
-          isPaused={props.isPaused}
-          isRunning={props.isRunning}
-          isBlocked={props.isBlocked}
-          onRunClick={props.onRunClick}
-          onPauseClick={props.onPauseClick}
-          onResumeClick={props.onResumeClick}
-          onResetClick={props.onResetClick}
-        />
-      </SidePanelGroup>
-      <ModuleLiveStatusCards />
-    </SidePanel>
-  )
+  const { t } = useTranslation('run_details')
+  const isNewProtocolRunPanel = useFeatureFlag('preProtocolFlowWithoutRPC')
+
+  return isNewProtocolRunPanel
+    ? (
+      <SidePanel title={t('run_protocol')}>
+        <RunTimeControl />
+        <ModuleLiveStatusCards />
+      </SidePanel>
+    ) : (
+      <SidePanel title="Execute Run">
+        <SidePanelGroup>
+          <RunTimer />
+          <RunControls
+            disabled={props.disabled}
+            modulesReady={props.modulesReady}
+            isReadyToRun={props.isReadyToRun}
+            isPaused={props.isPaused}
+            isRunning={props.isRunning}
+            isBlocked={props.isBlocked}
+            onRunClick={props.onRunClick}
+            onPauseClick={props.onPauseClick}
+            onResumeClick={props.onResumeClick}
+            onResetClick={props.onResetClick}
+          />
+        </SidePanelGroup>
+        <ModuleLiveStatusCards />
+      </SidePanel>
+    )
 }
 
 export const RunPanel = connect(

--- a/app/src/pages/Run/RunPanel/index.tsx
+++ b/app/src/pages/Run/RunPanel/index.tsx
@@ -59,32 +59,31 @@ export function RunPanelComponent(props: Props): JSX.Element {
   const { t } = useTranslation('run_details')
   const isNewProtocolRunPanel = useFeatureFlag('preProtocolFlowWithoutRPC')
 
-  return isNewProtocolRunPanel
-    ? (
-      <SidePanel title={t('run_protocol')}>
-        <RunTimeControl />
-        <ModuleLiveStatusCards />
-      </SidePanel>
-    ) : (
-      <SidePanel title="Execute Run">
-        <SidePanelGroup>
-          <RunTimer />
-          <RunControls
-            disabled={props.disabled}
-            modulesReady={props.modulesReady}
-            isReadyToRun={props.isReadyToRun}
-            isPaused={props.isPaused}
-            isRunning={props.isRunning}
-            isBlocked={props.isBlocked}
-            onRunClick={props.onRunClick}
-            onPauseClick={props.onPauseClick}
-            onResumeClick={props.onResumeClick}
-            onResetClick={props.onResetClick}
-          />
-        </SidePanelGroup>
-        <ModuleLiveStatusCards />
-      </SidePanel>
-    )
+  return isNewProtocolRunPanel ? (
+    <SidePanel title={t('run_protocol')}>
+      <RunTimeControl />
+      <ModuleLiveStatusCards />
+    </SidePanel>
+  ) : (
+    <SidePanel title="Execute Run">
+      <SidePanelGroup>
+        <RunTimer />
+        <RunControls
+          disabled={props.disabled}
+          modulesReady={props.modulesReady}
+          isReadyToRun={props.isReadyToRun}
+          isPaused={props.isPaused}
+          isRunning={props.isRunning}
+          isBlocked={props.isBlocked}
+          onRunClick={props.onRunClick}
+          onPauseClick={props.onPauseClick}
+          onResumeClick={props.onResumeClick}
+          onResetClick={props.onResetClick}
+        />
+      </SidePanelGroup>
+      <ModuleLiveStatusCards />
+    </SidePanel>
+  )
 }
 
 export const RunPanel = connect(

--- a/app/src/pages/Run/RunPanel/index.tsx
+++ b/app/src/pages/Run/RunPanel/index.tsx
@@ -55,7 +55,7 @@ const mapDispatchToProps: MapDispatchToProps<DP, {}> = dispatch => ({
   onResetClick: () => dispatch(robotActions.refreshSession()),
 })
 
-function RunPanelComponent(props: Props): JSX.Element {
+export function RunPanelComponent(props: Props): JSX.Element {
   const { t } = useTranslation('run_details')
   const isNewProtocolRunPanel = useFeatureFlag('preProtocolFlowWithoutRPC')
 

--- a/app/src/pages/Run/__tests__/Run.test.tsx
+++ b/app/src/pages/Run/__tests__/Run.test.tsx
@@ -3,85 +3,44 @@ import { when } from 'jest-when'
 import '@testing-library/jest-dom'
 import { StaticRouter } from 'react-router-dom'
 import {
-  partialComponentPropsMatcher,
+  componentPropsMatcher,
   renderWithProviders,
 } from '@opentrons/components/__utils__'
 
 import { i18n } from '../../../i18n'
 
 import { useFeatureFlag } from '../../../redux/config'
-import * as robotSelectors from '../../../redux/robot/selectors'
-import { getProtocolFilename } from '../../../redux/protocol/selectors'
 import { RunDetails } from '../../../organisms/RunDetails'
 import { Run } from '../'
-
-import type { State } from '../../../redux/types'
 
 jest.mock('../../../redux/config')
 jest.mock('../../../redux/robot/selectors')
 jest.mock('../../../redux/protocol/selectors')
 jest.mock('../../../organisms/RunDetails')
+jest.mock('../../../organisms/SessionHeader', () => ({
+  SessionHeader: () => <div>Mock Session Header</div>,
+}))
+jest.mock('../RunLog', () => ({ RunLog: () => <div>Mock Run Log</div> }))
 
-const mockRunDetails = RunDetails as jest.MockedFunction<typeof RunDetails>
+const mockRunDetails = RunDetails as any
 const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<
   typeof useFeatureFlag
 >
-const mockGetCommands = robotSelectors.getCommands as jest.MockedFunction<
-  typeof robotSelectors.getCommands
->
-const mockGetSessionStatus = robotSelectors.getSessionStatus as jest.MockedFunction<
-  typeof robotSelectors.getSessionStatus
->
-const mockGetSessionStatusInfo = robotSelectors.getSessionStatusInfo as jest.MockedFunction<
-  typeof robotSelectors.getSessionStatusInfo
->
-const mockGetCancelInProgress = robotSelectors.getCancelInProgress as jest.MockedFunction<
-  typeof robotSelectors.getCancelInProgress
->
-const mockGetSessionLoadInProgress = robotSelectors.getSessionLoadInProgress as jest.MockedFunction<
-  typeof robotSelectors.getSessionLoadInProgress
->
-const mockGetProtocolFilename = getProtocolFilename as jest.MockedFunction<
-  typeof getProtocolFilename
->
-
-const MOCK_STATE: State = { robot: {} } as any
 
 describe('Run Page', () => {
   let render: () => ReturnType<typeof renderWithProviders>
 
   beforeEach(() => {
     when(mockRunDetails)
-      .calledWith(partialComponentPropsMatcher({}))
-      .mockImplementation(() => <div>Mock Run Details</div>)
-    when(mockGetCommands).calledWith(expect.anything()).mockReturnValue([])
-    when(mockGetSessionStatus)
-      .calledWith(expect.anything())
-      .mockReturnValue('loaded')
-    when(mockGetSessionStatusInfo)
-      .calledWith(expect.anything())
-      .mockReturnValue({
-        message: null,
-        changedAt: null,
-        estimatedDuration: null,
-        userMessage: null,
-      })
-    when(mockGetCancelInProgress)
-      .calledWith(expect.anything())
-      .mockReturnValue(false)
-    when(mockGetSessionLoadInProgress)
-      .calledWith(expect.anything())
-      .mockReturnValue(false)
-    when(mockGetProtocolFilename)
-      .calledWith(expect.anything())
-      .mockReturnValue('fake_protocol_name')
+      .calledWith(componentPropsMatcher({}))
+      .mockReturnValue(<div>Mock Run Details</div>) // this (default) empty div will be returned when LabwareInfoOverlay isn't called with expected props
 
     render = () => {
       return renderWithProviders(
         <StaticRouter>
           <Run />
         </StaticRouter>,
-        { i18nInstance: i18n, initialState: MOCK_STATE }
+        { i18nInstance: i18n }
       )
     }
   })
@@ -90,13 +49,14 @@ describe('Run Page', () => {
     jest.resetAllMocks()
   })
 
-  // it('renders legacy run page when usePreProtocolWithoutRPC ff is not set', () => {
-  //   when(mockUseFeatureFlag)
-  //     .calledWith('preProtocolFlowWithoutRPC')
-  //     .mockReturnValue(false)
-  //   const { getByText } = render()
-  //   expect(mockRunDetails).not.toHaveBeenCalled()
-  // })
+  it('renders legacy run page when usePreProtocolWithoutRPC ff is not set', () => {
+    when(mockUseFeatureFlag)
+      .calledWith('preProtocolFlowWithoutRPC')
+      .mockReturnValue(false)
+    const { getByText } = render()
+    getByText('Mock Run Log')
+    expect(mockRunDetails).not.toHaveBeenCalled()
+  })
 
   it('renders new run page when usePreProtocolWithoutRPC ff is set', () => {
     when(mockUseFeatureFlag)

--- a/app/src/pages/Run/__tests__/Run.test.tsx
+++ b/app/src/pages/Run/__tests__/Run.test.tsx
@@ -23,13 +23,27 @@ jest.mock('../../../redux/protocol/selectors')
 jest.mock('../../../organisms/RunDetails')
 
 const mockRunDetails = RunDetails as jest.MockedFunction<typeof RunDetails>
-const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<typeof useFeatureFlag>
-const mockGetCommands = robotSelectors.getCommands as jest.MockedFunction<typeof robotSelectors.getCommands>
-const mockGetSessionStatus = robotSelectors.getSessionStatus as jest.MockedFunction<typeof robotSelectors.getSessionStatus>
-const mockGetSessionStatusInfo = robotSelectors.getSessionStatusInfo as jest.MockedFunction<typeof robotSelectors.getSessionStatusInfo>
-const mockGetCancelInProgress = robotSelectors.getCancelInProgress as jest.MockedFunction<typeof robotSelectors.getCancelInProgress>
-const mockGetSessionLoadInProgress = robotSelectors.getSessionLoadInProgress as jest.MockedFunction<typeof robotSelectors.getSessionLoadInProgress>
-const mockGetProtocolFilename = getProtocolFilename as jest.MockedFunction<typeof getProtocolFilename>
+const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<
+  typeof useFeatureFlag
+>
+const mockGetCommands = robotSelectors.getCommands as jest.MockedFunction<
+  typeof robotSelectors.getCommands
+>
+const mockGetSessionStatus = robotSelectors.getSessionStatus as jest.MockedFunction<
+  typeof robotSelectors.getSessionStatus
+>
+const mockGetSessionStatusInfo = robotSelectors.getSessionStatusInfo as jest.MockedFunction<
+  typeof robotSelectors.getSessionStatusInfo
+>
+const mockGetCancelInProgress = robotSelectors.getCancelInProgress as jest.MockedFunction<
+  typeof robotSelectors.getCancelInProgress
+>
+const mockGetSessionLoadInProgress = robotSelectors.getSessionLoadInProgress as jest.MockedFunction<
+  typeof robotSelectors.getSessionLoadInProgress
+>
+const mockGetProtocolFilename = getProtocolFilename as jest.MockedFunction<
+  typeof getProtocolFilename
+>
 
 const MOCK_STATE: State = { robot: {} } as any
 
@@ -39,18 +53,19 @@ describe('Run Page', () => {
   beforeEach(() => {
     when(mockRunDetails)
       .calledWith(partialComponentPropsMatcher({}))
-      .mockImplementation(() => (
-        <div>Mock Run Details</div>
-      ))
-    when(mockGetCommands)
-      .calledWith(expect.anything())
-      .mockReturnValue([])
+      .mockImplementation(() => <div>Mock Run Details</div>)
+    when(mockGetCommands).calledWith(expect.anything()).mockReturnValue([])
     when(mockGetSessionStatus)
       .calledWith(expect.anything())
       .mockReturnValue('loaded')
     when(mockGetSessionStatusInfo)
       .calledWith(expect.anything())
-      .mockReturnValue({message: null, changedAt: null, estimatedDuration: null, userMessage: null})
+      .mockReturnValue({
+        message: null,
+        changedAt: null,
+        estimatedDuration: null,
+        userMessage: null,
+      })
     when(mockGetCancelInProgress)
       .calledWith(expect.anything())
       .mockReturnValue(false)
@@ -65,8 +80,8 @@ describe('Run Page', () => {
       return renderWithProviders(
         <StaticRouter>
           <Run />
-        </StaticRouter>
-        , { i18nInstance: i18n, initialState: MOCK_STATE }
+        </StaticRouter>,
+        { i18nInstance: i18n, initialState: MOCK_STATE }
       )
     }
   })

--- a/app/src/pages/Run/__tests__/Run.test.tsx
+++ b/app/src/pages/Run/__tests__/Run.test.tsx
@@ -33,7 +33,7 @@ describe('Run Page', () => {
   beforeEach(() => {
     when(mockRunDetails)
       .calledWith(componentPropsMatcher({}))
-      .mockReturnValue(<div>Mock Run Details</div>) // this (default) empty div will be returned when LabwareInfoOverlay isn't called with expected props
+      .mockReturnValue(<div>Mock Run Details</div>)
 
     render = () => {
       return renderWithProviders(

--- a/app/src/pages/Run/__tests__/Run.test.tsx
+++ b/app/src/pages/Run/__tests__/Run.test.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react'
+import { when } from 'jest-when'
+import '@testing-library/jest-dom'
+import { StaticRouter } from 'react-router-dom'
+import {
+  partialComponentPropsMatcher,
+  renderWithProviders,
+} from '@opentrons/components/__utils__'
+
+import { i18n } from '../../../i18n'
+
+import { useFeatureFlag } from '../../../redux/config'
+import * as robotSelectors from '../../../redux/robot/selectors'
+import { getProtocolFilename } from '../../../redux/protocol/selectors'
+import { RunDetails } from '../../../organisms/RunDetails'
+import { Run } from '../'
+
+import type { State } from '../../../redux/types'
+
+jest.mock('../../../redux/config')
+jest.mock('../../../redux/robot/selectors')
+jest.mock('../../../redux/protocol/selectors')
+jest.mock('../../../organisms/RunDetails')
+
+const mockRunDetails = RunDetails as jest.MockedFunction<typeof RunDetails>
+const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<typeof useFeatureFlag>
+const mockGetCommands = robotSelectors.getCommands as jest.MockedFunction<typeof robotSelectors.getCommands>
+const mockGetSessionStatus = robotSelectors.getSessionStatus as jest.MockedFunction<typeof robotSelectors.getSessionStatus>
+const mockGetSessionStatusInfo = robotSelectors.getSessionStatusInfo as jest.MockedFunction<typeof robotSelectors.getSessionStatusInfo>
+const mockGetCancelInProgress = robotSelectors.getCancelInProgress as jest.MockedFunction<typeof robotSelectors.getCancelInProgress>
+const mockGetSessionLoadInProgress = robotSelectors.getSessionLoadInProgress as jest.MockedFunction<typeof robotSelectors.getSessionLoadInProgress>
+const mockGetProtocolFilename = getProtocolFilename as jest.MockedFunction<typeof getProtocolFilename>
+
+const MOCK_STATE: State = { robot: {} } as any
+
+describe('Run Page', () => {
+  let render: () => ReturnType<typeof renderWithProviders>
+
+  beforeEach(() => {
+    when(mockRunDetails)
+      .calledWith(partialComponentPropsMatcher({}))
+      .mockImplementation(() => (
+        <div>Mock Run Details</div>
+      ))
+    when(mockGetCommands)
+      .calledWith(expect.anything())
+      .mockReturnValue([])
+    when(mockGetSessionStatus)
+      .calledWith(expect.anything())
+      .mockReturnValue('loaded')
+    when(mockGetSessionStatusInfo)
+      .calledWith(expect.anything())
+      .mockReturnValue({message: null, changedAt: null, estimatedDuration: null, userMessage: null})
+    when(mockGetCancelInProgress)
+      .calledWith(expect.anything())
+      .mockReturnValue(false)
+    when(mockGetSessionLoadInProgress)
+      .calledWith(expect.anything())
+      .mockReturnValue(false)
+    when(mockGetProtocolFilename)
+      .calledWith(expect.anything())
+      .mockReturnValue('fake_protocol_name')
+
+    render = () => {
+      return renderWithProviders(
+        <StaticRouter>
+          <Run />
+        </StaticRouter>
+        , { i18nInstance: i18n, initialState: MOCK_STATE }
+      )
+    }
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  // it('renders legacy run page when usePreProtocolWithoutRPC ff is not set', () => {
+  //   when(mockUseFeatureFlag)
+  //     .calledWith('preProtocolFlowWithoutRPC')
+  //     .mockReturnValue(false)
+  //   const { getByText } = render()
+  //   expect(mockRunDetails).not.toHaveBeenCalled()
+  // })
+
+  it('renders new run page when usePreProtocolWithoutRPC ff is set', () => {
+    when(mockUseFeatureFlag)
+      .calledWith('preProtocolFlowWithoutRPC')
+      .mockReturnValue(true)
+    const { getByText } = render()
+    getByText('Mock Run Details')
+  })
+})

--- a/app/src/pages/Run/index.tsx
+++ b/app/src/pages/Run/index.tsx
@@ -10,9 +10,7 @@ export function Run(): JSX.Element {
 
   return isNewProtocolRunPage
     ? (
-      <Page titleBarProps={{ title: <SessionHeader /> }}>
-        <RunDetails />
-      </Page>
+      <RunDetails />
     ) : (
       <Page titleBarProps={{ title: <SessionHeader /> }}>
         <RunLog />

--- a/app/src/pages/Run/index.tsx
+++ b/app/src/pages/Run/index.tsx
@@ -1,13 +1,21 @@
-// run task component
 import * as React from 'react'
 import { Page } from '../../atoms/Page'
 import { SessionHeader } from '../../organisms/SessionHeader'
+import { RunDetails } from '../../organisms/RunDetails'
+import { useFeatureFlag } from '../../redux/config'
 import { RunLog } from './RunLog'
 
 export function Run(): JSX.Element {
-  return (
-    <Page titleBarProps={{ title: <SessionHeader /> }}>
-      <RunLog />
-    </Page>
-  )
+  const isNewProtocolRunPage = useFeatureFlag('preProtocolFlowWithoutRPC')
+
+  return isNewProtocolRunPage
+    ? (
+      <Page titleBarProps={{ title: <SessionHeader /> }}>
+        <RunDetails />
+      </Page>
+    ) : (
+      <Page titleBarProps={{ title: <SessionHeader /> }}>
+        <RunLog />
+      </Page>
+    )
 }

--- a/app/src/pages/Run/index.tsx
+++ b/app/src/pages/Run/index.tsx
@@ -8,12 +8,11 @@ import { RunLog } from './RunLog'
 export function Run(): JSX.Element {
   const isNewProtocolRunPage = useFeatureFlag('preProtocolFlowWithoutRPC')
 
-  return isNewProtocolRunPage
-    ? (
-      <RunDetails />
-    ) : (
-      <Page titleBarProps={{ title: <SessionHeader /> }}>
-        <RunLog />
-      </Page>
-    )
+  return isNewProtocolRunPage ? (
+    <RunDetails />
+  ) : (
+    <Page titleBarProps={{ title: <SessionHeader /> }}>
+      <RunLog />
+    </Page>
+  )
 }


### PR DESCRIPTION
# Overview

Create new run detail page and panel components that are rendered in place of their current
counterparts when the `usePreProtocolFlowWithoutRPC` feature flag is set.

Closes #8403

# Changelog

- use the `usePreProtocolFlowWithoutRPC` feature flag to branch `RunPage` and `RunPanel` contents between RPC implementation and blank canvas for commands based implementation.

# Review requests

- [ ] Proceed to the Run tab and confirm that the new components render in place of the old run log and controls   

# Risk assessment

Low
