### PR TITLE
fix(api): loosen numpy spec in setup.py

### DIFF
--- a/api/setup.py
+++ b/api/setup.py
@@ -58,7 +58,11 @@ INSTALL_REQUIRES = [
     "aionotify==0.2.0",
     "anyio==3.3.0",
     "jsonschema==3.0.2",
-    "numpy==1.15.1",
+    # TODO(mc, 2021-09-28): this spec does not match the Pipfile, and is
+    # intentionally loose to avoid installation problems for end-users.
+    # This discrepency should be resolved:
+    # https://github.com/Opentrons/opentrons/issues/8416
+    "numpy>=1.15.1,<2",
     "pydantic==1.4",
     "pyserial==3.5",
     "systemd-python==234; sys_platform=='linux'",


### PR DESCRIPTION
## Overview

My #8228 PR matched the version spec's in `api/Pipfile` with `api/setup.py`. This included tightening the `setup.py` spec of numpy from `numpy>=1.15.1` to `numpy==1.15.1`. Since `numpy@1.15.1` does not contain prebuilt wheels for any Python versions past 3.7, this broke installation of the `opentrons` PyPI package for any user on a later version of Python without a working C compiler.

This PR loosens the `numpy` spec back to where it was, with a TODO pointing to #8416 for resolution in the next mainline release.

## Changelog

- Loosen numpy spec in setup.py from `==1.15.1`, to `>=1.15.1,<2`

## Review requests

- [ ] This makes sense

## Risk assessment

Low, though this does highlight several areas where we were already at risk:

- We have users on Python 3.8 and 3.9 (and probably 3.10, which is imminent) and we do not dissuade people from doing this
- We do not run automated CI on any versions of Python other than 3.7
- We do not have automated testing of installing and running the `opentrons` CLI package
    - If we were to have this automated testing, we should make sure the machine has no C compiler to ensure it's testing "typical" usage