### PR TITLE
fix(opentrons-hardware): setup.py in opentrons-hardware.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,8 +124,9 @@ push-update-server:
 push: export host=$(usb_host)
 push:
 	$(if $(host),@echo "Pushing to $(host)",$(error host variable required))
-	$(MAKE) -C $(HARDWARE_DIR) push-no-restart
-	sleep 1
+	# TODO (amit, 2021-09-28): re-enable when opentrons-hardware is worth deploying.
+	# $(MAKE) -C $(HARDWARE_DIR) push-no-restart
+	# sleep 1
 	$(MAKE) -C $(API_DIR) push-no-restart
 	sleep 1
 	$(MAKE) -C $(SHARED_DATA_DIR) push-no-restart

--- a/hardware/setup.py
+++ b/hardware/setup.py
@@ -70,7 +70,7 @@ if __name__ == "__main__":
         maintainer=AUTHOR,
         maintainer_email=EMAIL,
         keywords=KEYWORDS,
-        long_description=read("README.rst"),
+        long_description=read("README.md"),
         packages=PACKAGES,
         zip_safe=False,
         classifiers=CLASSIFIERS,


### PR DESCRIPTION
# Overview

`make push` broke due to `opentrons-hardware` not being able to build. 

# Changelog

- fix `setup.py` in opentrons-hardware so make push works.
- disable pushing of opentrons-hardware in root makefile.

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
