### PR TITLE
fix(api): 4.6.x set max speed fails

### DIFF
--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import asyncio
-from contextlib import contextmanager, ExitStack
+from contextlib import contextmanager, AsyncExitStack
 import logging
 from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING, Union, Sequence
 from typing_extensions import Final
@@ -129,9 +129,9 @@ class Controller:
         speed: float = None,
         axis_max_speeds: Dict[str, float] = None,
     ):
-        with ExitStack() as cmstack:
+        async with AsyncExitStack() as cmstack:
             if axis_max_speeds:
-                cmstack.enter_context(
+                await cmstack.enter_async_context(
                     self._smoothie_driver.restore_axis_max_speed(axis_max_speeds)
                 )
             await self._smoothie_driver.move(

--- a/api/tests/opentrons/drivers/smoothie_drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/smoothie_drivers/test_driver.py
@@ -328,3 +328,51 @@ def test_axis_bounds(smoothie: driver_3_0.SmoothieDriver) -> None:
     assert bounds == {
         k: (v if k != "Y" else Y_BOUND_OVERRIDE) for k, v in HOMED_POSITION.items()
     }
+
+
+async def test_set_max_speed(smoothie: driver_3_0.SmoothieDriver, mock_connection: AsyncMock) -> None:
+    """It should set the max speed."""
+    await smoothie.set_axis_max_speed({"A": 22, "B": 322})
+    cmds = [c.kwargs['command'].build().strip() for c in mock_connection.send_command.call_args_list]
+    assert cmds == ['M203.1 A22 B322', 'M400']
+
+
+async def test_restore_axis_max_speed(smoothie: driver_3_0.SmoothieDriver, mock_connection: AsyncMock) -> None:
+    """It should set then restore the max speed."""
+    smoothie._max_speed_settings = {"A": 1,  "B": 2, "C": 3, "X": 4, "Y": 5, "Z": 6}
+    async with smoothie.restore_axis_max_speed({"A": 6,  "B": 5, "C": 4, "X": 3, "Y": 2, "Z": 1}):
+        pass
+    cmds = [c.kwargs['command'].build().strip() for c in mock_connection.send_command.call_args_list]
+    assert cmds == [
+        # Set new max speed.
+        'M203.1 A6 B5 C4 X3 Y2 Z1',
+        'M400',
+        # Restore old.
+        'M203.1 A1 B2 C3 X4 Y5 Z6',
+        'M400'
+    ]
+
+
+async def test_speed(smoothie: driver_3_0.SmoothieDriver, mock_connection: AsyncMock) -> None:
+    """It should set the speed."""
+    await smoothie.set_speed(1)
+    cmds = [c.kwargs['command'].build().strip() for c in mock_connection.send_command.call_args_list]
+    # 60 is (speed * seconds_per_minute)
+    assert cmds == ['G0 F60', 'M400']
+
+
+async def test_restore_speed(smoothie: driver_3_0.SmoothieDriver, mock_connection: AsyncMock) -> None:
+    """It should set then restore the speed."""
+    smoothie._combined_speed = 3
+    async with smoothie.restore_speed(2):
+        pass
+    cmds = [c.kwargs['command'].build().strip() for c in mock_connection.send_command.call_args_list]
+    assert cmds == [
+        # Set speed.
+        'G0 F120',
+        'M400',
+        # Restore old.
+        'G0 F180',
+        'M400'
+
+    ]

--- a/api/tests/opentrons/drivers/smoothie_drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/smoothie_drivers/test_driver.py
@@ -330,49 +330,70 @@ def test_axis_bounds(smoothie: driver_3_0.SmoothieDriver) -> None:
     }
 
 
-async def test_set_max_speed(smoothie: driver_3_0.SmoothieDriver, mock_connection: AsyncMock) -> None:
+async def test_set_max_speed(
+    smoothie: driver_3_0.SmoothieDriver, mock_connection: AsyncMock
+) -> None:
     """It should set the max speed."""
     await smoothie.set_axis_max_speed({"A": 22, "B": 322})
-    cmds = [c.kwargs['command'].build().strip() for c in mock_connection.send_command.call_args_list]
-    assert cmds == ['M203.1 A22 B322', 'M400']
+    cmds = [
+        c.kwargs["command"].build().strip()
+        for c in mock_connection.send_command.call_args_list
+    ]
+    assert cmds == ["M203.1 A22 B322", "M400"]
 
 
-async def test_restore_axis_max_speed(smoothie: driver_3_0.SmoothieDriver, mock_connection: AsyncMock) -> None:
+async def test_restore_axis_max_speed(
+    smoothie: driver_3_0.SmoothieDriver, mock_connection: AsyncMock
+) -> None:
     """It should set then restore the max speed."""
-    smoothie._max_speed_settings = {"A": 1,  "B": 2, "C": 3, "X": 4, "Y": 5, "Z": 6}
-    async with smoothie.restore_axis_max_speed({"A": 6,  "B": 5, "C": 4, "X": 3, "Y": 2, "Z": 1}):
+    smoothie._max_speed_settings = {"A": 1, "B": 2, "C": 3, "X": 4, "Y": 5, "Z": 6}
+    async with smoothie.restore_axis_max_speed(
+        {"A": 6, "B": 5, "C": 4, "X": 3, "Y": 2, "Z": 1}
+    ):
         pass
-    cmds = [c.kwargs['command'].build().strip() for c in mock_connection.send_command.call_args_list]
+    cmds = [
+        c.kwargs["command"].build().strip()
+        for c in mock_connection.send_command.call_args_list
+    ]
     assert cmds == [
         # Set new max speed.
-        'M203.1 A6 B5 C4 X3 Y2 Z1',
-        'M400',
+        "M203.1 A6 B5 C4 X3 Y2 Z1",
+        "M400",
         # Restore old.
-        'M203.1 A1 B2 C3 X4 Y5 Z6',
-        'M400'
+        "M203.1 A1 B2 C3 X4 Y5 Z6",
+        "M400",
     ]
 
 
-async def test_speed(smoothie: driver_3_0.SmoothieDriver, mock_connection: AsyncMock) -> None:
+async def test_speed(
+    smoothie: driver_3_0.SmoothieDriver, mock_connection: AsyncMock
+) -> None:
     """It should set the speed."""
     await smoothie.set_speed(1)
-    cmds = [c.kwargs['command'].build().strip() for c in mock_connection.send_command.call_args_list]
+    cmds = [
+        c.kwargs["command"].build().strip()
+        for c in mock_connection.send_command.call_args_list
+    ]
     # 60 is (speed * seconds_per_minute)
-    assert cmds == ['G0 F60', 'M400']
+    assert cmds == ["G0 F60", "M400"]
 
 
-async def test_restore_speed(smoothie: driver_3_0.SmoothieDriver, mock_connection: AsyncMock) -> None:
+async def test_restore_speed(
+    smoothie: driver_3_0.SmoothieDriver, mock_connection: AsyncMock
+) -> None:
     """It should set then restore the speed."""
     smoothie._combined_speed = 3
     async with smoothie.restore_speed(2):
         pass
-    cmds = [c.kwargs['command'].build().strip() for c in mock_connection.send_command.call_args_list]
+    cmds = [
+        c.kwargs["command"].build().strip()
+        for c in mock_connection.send_command.call_args_list
+    ]
     assert cmds == [
         # Set speed.
-        'G0 F120',
-        'M400',
+        "G0 F120",
+        "M400",
         # Restore old.
-        'G0 F180',
-        'M400'
-
+        "G0 F180",
+        "M400",
     ]

--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -25,7 +25,7 @@ async def test_controller_must_home(hardware_api):
     home.assert_called_once()
 
 
-async def test_home_specific_sim(hardware_api, monkeypatch, is_robot):
+async def test_home_specific_sim(hardware_api):
     await hardware_api.home()
     await hardware_api.move_to(types.Mount.RIGHT, types.Point(0, 10, 20))
     # Avoid the autoretract when moving two difference instruments
@@ -56,7 +56,7 @@ async def test_retract(hardware_api):
     }
 
 
-async def test_move(hardware_api, is_robot):
+async def test_move(hardware_api):
     abs_position = types.Point(30, 20, 10)
     mount = types.Mount.RIGHT
     target_position1 = {
@@ -197,7 +197,7 @@ async def test_critical_point_applied(hardware_api, monkeypatch, is_robot):
     assert await hardware_api.current_position(types.Mount.RIGHT) == target
 
 
-async def test_new_critical_point_applied(hardware_api, monkeypatch, is_robot):
+async def test_new_critical_point_applied(hardware_api):
     await hardware_api.home()
     hardware_api._backend._attached_instruments = {
         types.Mount.LEFT: {"model": None, "id": None},


### PR DESCRIPTION
# Overview

This fixes a regression in `4.6.x`. `SmoothieDriver.restore_max_speeds` was awaiting the calls to `set_max_speed`.  

closes #8436 

# Changelog

- Added tests to prove out the issue.
- Made `restore_max_speeds` and `restore_speeds` into async generators.

# Review requests

Test on robot.

# Risk assessment

High. This is a critical bug fix that may require a hot-fix.