### PR TITLE
fix(api): thermocycler error handling

### DIFF
--- a/api/src/opentrons/drivers/asyncio/communication/async_serial.py
+++ b/api/src/opentrons/drivers/asyncio/communication/async_serial.py
@@ -19,7 +19,7 @@ class AsyncSerial:
         timeout: Optional[float] = None,
         write_timeout: Optional[float] = None,
         loop: Optional[asyncio.AbstractEventLoop] = None,
-        reset_buffer_before_write: bool = True,
+        reset_buffer_before_write: bool = False,
     ) -> AsyncSerial:
         """
         Create an AsyncSerial instance.
@@ -30,7 +30,8 @@ class AsyncSerial:
             timeout: optional timeout in seconds
             write_timeout: optional write timeout in seconds
             loop: optional event loop. if None get_running_loop will be used
-            reset_buffer_before_write: reset the serial input buffer before writing to it
+            reset_buffer_before_write: reset the serial input buffer before
+             writing to it
         """
         loop = loop or asyncio.get_running_loop()
         executor = ThreadPoolExecutor(max_workers=1)
@@ -43,8 +44,12 @@ class AsyncSerial:
                 write_timeout=write_timeout,
             ),
         )
-        return cls(serial=serial, executor=executor, loop=loop,
-                   reset_buffer_before_write=reset_buffer_before_write)
+        return cls(
+            serial=serial,
+            executor=executor,
+            loop=loop,
+            reset_buffer_before_write=reset_buffer_before_write,
+        )
 
     def __init__(
         self,

--- a/api/src/opentrons/drivers/asyncio/communication/async_serial.py
+++ b/api/src/opentrons/drivers/asyncio/communication/async_serial.py
@@ -19,6 +19,7 @@ class AsyncSerial:
         timeout: Optional[float] = None,
         write_timeout: Optional[float] = None,
         loop: Optional[asyncio.AbstractEventLoop] = None,
+        reset_buffer_before_write: bool = True,
     ) -> AsyncSerial:
         """
         Create an AsyncSerial instance.
@@ -29,6 +30,7 @@ class AsyncSerial:
             timeout: optional timeout in seconds
             write_timeout: optional write timeout in seconds
             loop: optional event loop. if None get_running_loop will be used
+            reset_buffer_before_write: reset the serial input buffer before writing to it
         """
         loop = loop or asyncio.get_running_loop()
         executor = ThreadPoolExecutor(max_workers=1)
@@ -41,13 +43,15 @@ class AsyncSerial:
                 write_timeout=write_timeout,
             ),
         )
-        return cls(serial=serial, executor=executor, loop=loop)
+        return cls(serial=serial, executor=executor, loop=loop,
+                   reset_buffer_before_write=reset_buffer_before_write)
 
     def __init__(
         self,
         serial: Serial,
         executor: ThreadPoolExecutor,
         loop: asyncio.AbstractEventLoop,
+        reset_buffer_before_write: bool,
     ) -> None:
         """
         Constructor
@@ -60,6 +64,7 @@ class AsyncSerial:
         self._serial = serial
         self._executor = executor
         self._loop = loop
+        self._reset_buffer_before_write = reset_buffer_before_write
 
     async def read_until(self, match: bytes, timeout: Optional[float] = None) -> bytes:
         """
@@ -107,7 +112,8 @@ class AsyncSerial:
             None
         """
         with self._timeout_override("write_timeout", timeout):
-            self._serial.reset_input_buffer()
+            if self._reset_buffer_before_write:
+                self._serial.reset_input_buffer()
             self._serial.write(data=data)
 
     async def open(self) -> None:

--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -25,6 +25,7 @@ class SerialConnection:
         loop: Optional[asyncio.AbstractEventLoop] = None,
         error_keyword: Optional[str] = None,
         alarm_keyword: Optional[str] = None,
+        reset_buffer_before_write: bool = True,
     ) -> SerialConnection:
         """
         Create a connection.
@@ -43,11 +44,13 @@ class SerialConnection:
             alarm_keyword: optional string that will cause an
                            AlarmResponse exception when detected
                            (default: alarm)
+            reset_buffer_before_write: reset the serial input buffer before writing to it
 
         Returns: SerialConnection
         """
         serial = await AsyncSerial.create(
-            port=port, baud_rate=baud_rate, timeout=timeout, loop=loop
+            port=port, baud_rate=baud_rate, timeout=timeout, loop=loop,
+            reset_buffer_before_write=reset_buffer_before_write
         )
         name = name or port
         return cls(

--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -25,7 +25,7 @@ class SerialConnection:
         loop: Optional[asyncio.AbstractEventLoop] = None,
         error_keyword: Optional[str] = None,
         alarm_keyword: Optional[str] = None,
-        reset_buffer_before_write: bool = True,
+        reset_buffer_before_write: bool = False,
     ) -> SerialConnection:
         """
         Create a connection.
@@ -44,13 +44,17 @@ class SerialConnection:
             alarm_keyword: optional string that will cause an
                            AlarmResponse exception when detected
                            (default: alarm)
-            reset_buffer_before_write: reset the serial input buffer before writing to it
+            reset_buffer_before_write: whether to reset the read buffer before
+              every write
 
         Returns: SerialConnection
         """
         serial = await AsyncSerial.create(
-            port=port, baud_rate=baud_rate, timeout=timeout, loop=loop,
-            reset_buffer_before_write=reset_buffer_before_write
+            port=port,
+            baud_rate=baud_rate,
+            timeout=timeout,
+            loop=loop,
+            reset_buffer_before_write=reset_buffer_before_write,
         )
         name = name or port
         return cls(

--- a/api/src/opentrons/drivers/mag_deck/driver.py
+++ b/api/src/opentrons/drivers/mag_deck/driver.py
@@ -71,6 +71,7 @@ class MagDeckDriver(AbstractMagDeckDriver):
             timeout=DEFAULT_MAG_DECK_TIMEOUT,
             ack=MAG_DECK_ACK,
             loop=loop,
+            reset_buffer_before_write=False,
         )
         return cls(connection=connection)
 

--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -110,6 +110,7 @@ class SmoothieDriver:
             name="smoothie",
             timeout=DEFAULT_EXECUTE_TIMEOUT,
             ack=SMOOTHIE_ACK,
+            reset_buffer_before_write=True,
         )
         gpio_chardev = gpio_chardev or SimulatingGPIOCharDev("simulated")
 
@@ -424,6 +425,7 @@ class SmoothieDriver:
                 name="smoothie",
                 timeout=DEFAULT_EXECUTE_TIMEOUT,
                 ack=SMOOTHIE_ACK,
+                reset_buffer_before_write=True,
             )
             self.simulating = False
         except SerialException:

--- a/api/src/opentrons/drivers/temp_deck/driver.py
+++ b/api/src/opentrons/drivers/temp_deck/driver.py
@@ -65,6 +65,7 @@ class TempDeckDriver(AbstractTempDeckDriver):
             timeout=DEFAULT_TEMP_DECK_TIMEOUT,
             ack=TEMP_DECK_ACK,
             loop=loop,
+            reset_buffer_before_write=False,
         )
         return cls(connection=connection)
 

--- a/api/src/opentrons/drivers/thermocycler/driver.py
+++ b/api/src/opentrons/drivers/thermocycler/driver.py
@@ -71,6 +71,7 @@ class ThermocyclerDriver(AbstractThermocyclerDriver):
             timeout=DEFAULT_TC_TIMEOUT,
             ack=TC_ACK,
             loop=loop,
+            reset_buffer_before_write=False,
         )
         return cls(connection=connection)
 

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -613,6 +613,7 @@ class API(HardwareAPILike):
         self._log.warning("Pause with message: {}".format(message))
         for cb in self._callbacks:
             cb(message)
+        self._log.info("****** Done going through callbacks ******")
         self.pause(PauseType.PAUSE)
 
     def resume(self, pause_type: PauseType):

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -16,6 +16,7 @@ from typing import (
     cast,
     overload,
     Sequence,
+    Set,
 )
 
 from opentrons_shared_data.pipette import name_config
@@ -47,7 +48,8 @@ from .types import (
     NoTipAttachedError,
     DoorState,
     DoorStateNotification,
-    HardwareEvent,
+    ErrorMessageNotification,
+    HardwareEventHandler,
     PipettePair,
     TipAttachedError,
     HardwareAction,
@@ -100,7 +102,7 @@ class API(HardwareAPILike):
         self._loop = loop
 
         self._execution_manager = ExecutionManager(loop=loop)
-        self._callbacks: set = set()
+        self._callbacks: Set[HardwareEventHandler] = set()
         # {'X': 0.0, 'Y': 0.0, 'Z': 0.0, 'A': 0.0, 'B': 0.0, 'C': 0.0}
         self._current_position: Dict[Axis, float] = {}
 
@@ -307,9 +309,7 @@ class API(HardwareAPILike):
             self._robot_calibration.deck_calibration
         )
 
-    def register_callback(
-        self, cb: Callable[[Union[str, HardwareEvent]], None]
-    ) -> Callable[[], None]:
+    def register_callback(self, cb: HardwareEventHandler) -> Callable[[], None]:
         """Allows the caller to register a callback, and returns a closure
         that can be used to unregister the provided callback
         """
@@ -609,11 +609,11 @@ class API(HardwareAPILike):
 
         asyncio.run_coroutine_threadsafe(_chained_calls(), self._loop)
 
-    def pause_with_message(self, message):
-        self._log.warning("Pause with message: {}".format(message))
+    def pause_with_message(self, message: str):
+        self._log.warning(f"Pause with message: {message}")
+        notification = ErrorMessageNotification(message=message)
         for cb in self._callbacks:
-            cb(message)
-        self._log.info("****** Done going through callbacks ******")
+            cb(notification)
         self.pause(PauseType.PAUSE)
 
     def resume(self, pause_type: PauseType):

--- a/api/src/opentrons/hardware_control/dev_types.py
+++ b/api/src/opentrons/hardware_control/dev_types.py
@@ -15,8 +15,6 @@ from opentrons_shared_data.pipette.dev_types import (
 )
 
 from opentrons.drivers.types import MoveSplit
-from .types import HardwareEventType
-
 from opentrons.types import Mount
 from opentrons.config.pipette_config import PipetteConfig
 
@@ -25,9 +23,6 @@ class HasLoop(Protocol):
     @property
     def loop(self) -> asyncio.AbstractEventLoop:
         ...
-
-
-DoorStateNotificationType = Literal[HardwareEventType.DOOR_SWITCH_CHANGE]
 
 
 class InstrumentSpec(TypedDict):

--- a/api/src/opentrons/hardware_control/emulation/thermocycler.py
+++ b/api/src/opentrons/hardware_control/emulation/thermocycler.py
@@ -24,6 +24,12 @@ VERSION = "v1.1.0"
 class ThermocyclerEmulator(AbstractEmulator):
     """Thermocycler emulator"""
 
+    _lid_temperature: Temperature
+    _plate_temperature: TemperatureWithHold
+    lid_status: ThermocyclerLidStatus
+    plate_volume: util.OptionalValue[float]
+    plate_ramp_rate: util.OptionalValue[float]
+
     def __init__(self, parser: Parser) -> None:
         self.reset()
         self._parser = parser
@@ -35,8 +41,8 @@ class ThermocyclerEmulator(AbstractEmulator):
         return None if not joined else joined
 
     def reset(self):
-        self._lid_temperate = Temperature(per_tick=2, current=util.TEMPERATURE_ROOM)
-        self._plate_temperate = TemperatureWithHold(
+        self._lid_temperature = Temperature(per_tick=2, current=util.TEMPERATURE_ROOM)
+        self._plate_temperature = TemperatureWithHold(
             per_tick=2, current=util.TEMPERATURE_ROOM
         )
         self.lid_status = ThermocyclerLidStatus.OPEN
@@ -61,14 +67,14 @@ class ThermocyclerEmulator(AbstractEmulator):
             assert isinstance(
                 temperature, float
             ), f"invalid temperature '{temperature}'"
-            self._lid_temperate.set_target(temperature)
+            self._lid_temperature.set_target(temperature)
         elif command.gcode == GCODE.GET_LID_TEMP:
             res = (
-                f"T:{util.OptionalValue(self._lid_temperate.target)} "
-                f"C:{self._lid_temperate.current} "
+                f"T:{util.OptionalValue(self._lid_temperature.target)} "
+                f"C:{self._lid_temperature.current} "
                 f"H:none Total_H:none"
             )
-            self._lid_temperate.tick()
+            self._lid_temperature.tick()
             return res
         elif command.gcode == GCODE.EDIT_PID_PARAMS:
             pass
@@ -76,18 +82,20 @@ class ThermocyclerEmulator(AbstractEmulator):
             for prefix, value in command.params.items():
                 assert isinstance(value, float), f"invalid value '{value}'"
                 if prefix == "S":
-                    self._plate_temperate.set_target(value)
+                    self._plate_temperature.set_target(value)
                 elif prefix == "V":
                     self.plate_volume.val = value
                 elif prefix == "H":
-                    self._plate_temperate.set_hold(value)
+                    self._plate_temperature.set_hold(value)
         elif command.gcode == GCODE.GET_PLATE_TEMP:
-            plate_target = util.OptionalValue(self._plate_temperate.target)
-            plate_current = self._plate_temperate.current
+            plate_target = util.OptionalValue(self._plate_temperature.target)
+            plate_current = self._plate_temperature.current
             plate_time_remaining = util.OptionalValue(
-                self._plate_temperate.time_remaining
+                self._plate_temperature.time_remaining
             )
-            plate_total_hold_time = util.OptionalValue(self._plate_temperate.total_hold)
+            plate_total_hold_time = util.OptionalValue(
+                self._plate_temperature.total_hold
+            )
 
             res = (
                 f"T:{plate_target} "
@@ -95,17 +103,17 @@ class ThermocyclerEmulator(AbstractEmulator):
                 f"H:{plate_time_remaining} "
                 f"Total_H:{plate_total_hold_time} "
             )
-            self._plate_temperate.tick()
+            self._plate_temperature.tick()
             return res
         elif command.gcode == GCODE.SET_RAMP_RATE:
             self.plate_ramp_rate.val = command.params["S"]
         elif command.gcode == GCODE.DEACTIVATE_ALL:
-            self._plate_temperate.deactivate(temperature=util.TEMPERATURE_ROOM)
-            self._lid_temperate.deactivate(temperature=util.TEMPERATURE_ROOM)
+            self._plate_temperature.deactivate(temperature=util.TEMPERATURE_ROOM)
+            self._lid_temperature.deactivate(temperature=util.TEMPERATURE_ROOM)
         elif command.gcode == GCODE.DEACTIVATE_LID:
-            self._lid_temperate.deactivate(temperature=util.TEMPERATURE_ROOM)
+            self._lid_temperature.deactivate(temperature=util.TEMPERATURE_ROOM)
         elif command.gcode == GCODE.DEACTIVATE_BLOCK:
-            self._plate_temperate.deactivate(temperature=util.TEMPERATURE_ROOM)
+            self._plate_temperature.deactivate(temperature=util.TEMPERATURE_ROOM)
         elif command.gcode == GCODE.DEVICE_INFO:
             return f"serial:{SERIAL} model:{MODEL} version:{VERSION}"
         return None

--- a/api/src/opentrons/hardware_control/execution_manager.py
+++ b/api/src/opentrons/hardware_control/execution_manager.py
@@ -1,10 +1,6 @@
 import asyncio
-import logging
 from typing import Set
 from .types import ExecutionState, ExecutionCancelledError
-
-
-log = logging.getLogger(__name__)
 
 
 class ExecutionManager:
@@ -61,7 +57,6 @@ class ExecutionManager:
 
     async def wait_for_is_running(self):
         async with self._condition:
-            log.info(f"******** self._state is: {self._state} ********")
             if self._state == ExecutionState.PAUSED:
                 await self._condition.wait()
                 if self._state == ExecutionState.CANCELLED:

--- a/api/src/opentrons/hardware_control/execution_manager.py
+++ b/api/src/opentrons/hardware_control/execution_manager.py
@@ -1,6 +1,10 @@
 import asyncio
+import logging
 from typing import Set
 from .types import ExecutionState, ExecutionCancelledError
+
+
+log = logging.getLogger(__name__)
 
 
 class ExecutionManager:
@@ -57,6 +61,7 @@ class ExecutionManager:
 
     async def wait_for_is_running(self):
         async with self._condition:
+            log.info(f"******** self._state is: {self._state} ********")
             if self._state == ExecutionState.PAUSED:
                 await self._condition.wait()
                 if self._state == ExecutionState.CANCELLED:

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -57,7 +57,6 @@ class AttachedModulesControl:
             usb_port=usb_port,
             which=model,
             simulating=self.api.is_simulator,
-            interrupt_callback=self.api.pause_with_message,
             loop=loop,
             execution_manager=self.api._execution_manager,
             sim_model=sim_model,

--- a/api/src/opentrons/hardware_control/modules/__init__.py
+++ b/api/src/opentrons/hardware_control/modules/__init__.py
@@ -6,7 +6,6 @@ from .update import update_firmware
 from .utils import MODULE_HW_BY_NAME, build
 from .types import (
     ThermocyclerStep,
-    InterruptCallback,
     UploadFunction,
     BundledFirmware,
     UpdateError,
@@ -22,7 +21,6 @@ __all__ = [
     "TempDeck",
     "MagDeck",
     "Thermocycler",
-    "InterruptCallback",
     "UploadFunction",
     "BundledFirmware",
     "UpdateError",

--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -30,7 +30,6 @@ class MagDeck(mod_abc.AbstractModule):
         port: str,
         usb_port: USBPort,
         execution_manager: ExecutionManager,
-        interrupt_callback: types.InterruptCallback = None,
         simulating=False,
         loop: asyncio.AbstractEventLoop = None,
         sim_model: str = None,

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -8,7 +8,7 @@ from opentrons.config import IS_ROBOT, ROBOT_FIRMWARE_DIR
 from opentrons.hardware_control.util import use_or_initialize_loop
 from opentrons.drivers.rpi_drivers.types import USBPort
 from ..execution_manager import ExecutionManager
-from .types import BundledFirmware, UploadFunction, InterruptCallback, LiveData
+from .types import BundledFirmware, UploadFunction, LiveData
 
 mod_log = logging.getLogger(__name__)
 
@@ -23,7 +23,6 @@ class AbstractModule(abc.ABC):
         port: str,
         usb_port: USBPort,
         execution_manager: ExecutionManager,
-        interrupt_callback: InterruptCallback = None,
         simulating: bool = False,
         loop: asyncio.AbstractEventLoop = None,
         sim_model: str = None,

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -117,10 +117,7 @@ class TempDeck(mod_abc.AbstractModule):
 
     async def wait_next_poll(self) -> None:
         """Wait for the next poll to complete."""
-        try:
-            await self._listener.wait_next_poll()
-        except asyncio.CancelledError:
-            log.exception("Error while waiting for poll.")
+        await self._listener.wait_next_poll()
 
     async def set_temperature(self, celsius: float) -> None:
         """

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -119,7 +119,10 @@ class TempDeck(mod_abc.AbstractModule):
 
     async def wait_next_poll(self) -> None:
         """Wait for the next poll to complete."""
-        await self._listener.wait_next_poll()
+        try:
+            await self._listener.wait_next_poll()
+        except Exception:
+            log.exception("Error while waiting for poll.")
 
     async def set_temperature(self, celsius: float) -> None:
         """

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -312,3 +312,4 @@ class TempdeckListener(WaitableListener[Temperature]):
         """On error."""
         if self._callback:
             self._callback(str(exc))
+        super().on_error(exc)

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -350,8 +350,8 @@ class Thermocycler(mod_abc.AbstractModule):
         """Wait for the next poll to complete."""
         try:
             await self._listener.wait_next_poll()
-        except Exception as e:
-            raise ThermocyclerError(str(e))
+        except Exception:
+            MODULE_LOG.exception("Error while waiting for poll.")
 
     @property
     def lid_target(self) -> Optional[float]:

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -345,10 +345,7 @@ class Thermocycler(mod_abc.AbstractModule):
 
     async def wait_next_poll(self) -> None:
         """Wait for the next poll to complete."""
-        try:
-            await self._listener.wait_next_poll()
-        except asyncio.CancelledError:
-            raise ThermocyclerError("Error while waiting for poll.")
+        await self._listener.wait_next_poll()
 
     @property
     def lid_target(self) -> Optional[float]:

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -311,7 +311,7 @@ class Thermocycler(mod_abc.AbstractModule):
             return
 
         while self._listener.lid_status != TemperatureStatus.HOLDING:
-            await self._listener.wait_next_poll()
+            await self.wait_next_poll()
 
     async def _wait_for_temp(self) -> None:
         """
@@ -348,7 +348,10 @@ class Thermocycler(mod_abc.AbstractModule):
 
     async def wait_next_poll(self) -> None:
         """Wait for the next poll to complete."""
-        await self._listener.wait_next_poll()
+        try:
+            await self._listener.wait_next_poll()
+        except Exception as e:
+            raise ThermocyclerError(str(e))
 
     @property
     def lid_target(self) -> Optional[float]:
@@ -571,3 +574,4 @@ class ThermocyclerListener(WaitableListener[PolledData]):
         """On error."""
         if self._callback:
             self._callback(str(exc))
+        return super().on_error(exc)

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -241,6 +241,7 @@ class Thermocycler(mod_abc.AbstractModule):
         # Wait for target temperature to be set.
         retries = 0
         while self.target != temperature or not self.hold_time_probably_set(hold_time):
+            await self.wait_for_is_running()
             # Wait for the poller to update
             await self.wait_next_poll()
             retries += 1
@@ -289,6 +290,7 @@ class Thermocycler(mod_abc.AbstractModule):
         # Wait for target to be set
         retries = 0
         while self.lid_target != temperature:
+            await self.wait_for_is_running()
             # Wait for the poller to update
             await self.wait_next_poll()
             retries += 1

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -520,7 +520,10 @@ class Thermocycler(mod_abc.AbstractModule):
         """
         self._in_error_state = True
         MODULE_LOG.error(
-            f"Thermocycler has encountered an unrecoverable error: {str(cause)}"
+            f"Thermocycler has encountered an unrecoverable error: {str(cause)}. "
+            f"Please refer to support article at "
+            f"https://support.opentrons.com/en/articles/3469797-thermocycler-module"
+            f" for troubleshooting."
         )
         self._poller.stop()
         asyncio.run_coroutine_threadsafe(self._driver.disconnect(), self._loop)

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -405,7 +405,11 @@ class Thermocycler(mod_abc.AbstractModule):
 
     @property
     def status(self) -> str:
-        return self._listener.plate_status if not self._in_error_state else TemperatureStatus.ERROR
+        return (
+            self._listener.plate_status
+            if not self._in_error_state
+            else TemperatureStatus.ERROR
+        )
 
     @property
     def device_info(self) -> Mapping[str, str]:

--- a/api/src/opentrons/hardware_control/modules/types.py
+++ b/api/src/opentrons/hardware_control/modules/types.py
@@ -26,8 +26,6 @@ if TYPE_CHECKING:
 
 ThermocyclerStep = Dict[str, float]
 
-InterruptCallback = Callable[[str], None]
-
 UploadFunction = Callable[[str, str, Dict[str, Any]], Awaitable[Tuple[bool, str]]]
 
 LiveData = Mapping[str, Union[str, Mapping[str, Union[float, str, None]]]]

--- a/api/src/opentrons/hardware_control/modules/utils.py
+++ b/api/src/opentrons/hardware_control/modules/utils.py
@@ -7,7 +7,6 @@ from opentrons.drivers.rpi_drivers.types import USBPort
 from . import update, tempdeck, magdeck, thermocycler, types  # noqa: F401
 from .mod_abc import AbstractModule
 from ..execution_manager import ExecutionManager
-from .types import InterruptCallback
 
 
 log = logging.getLogger(__name__)
@@ -22,7 +21,6 @@ async def build(
     which: str,
     simulating: bool,
     usb_port: USBPort,
-    interrupt_callback: InterruptCallback,
     loop: asyncio.AbstractEventLoop,
     execution_manager: ExecutionManager,
     sim_model: str = None,
@@ -30,7 +28,6 @@ async def build(
     return await MODULE_HW_BY_NAME[which].build(
         port,
         usb_port,
-        interrupt_callback=interrupt_callback,
         simulating=simulating,
         loop=loop,
         execution_manager=execution_manager,

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -3,12 +3,10 @@ import asyncio
 import enum
 import logging
 from dataclasses import dataclass
-from typing import cast, Tuple, Union, List, TYPE_CHECKING
+from typing import cast, Tuple, Union, List, Callable
 from typing_extensions import Literal
 from opentrons import types as top_types
 
-if TYPE_CHECKING:
-    from .dev_types import DoorStateNotificationType
 
 MODULE_LOG = logging.getLogger(__name__)
 
@@ -80,18 +78,29 @@ class DoorState(enum.Enum):
 
 class HardwareEventType(enum.Enum):
     DOOR_SWITCH_CHANGE = enum.auto()
+    ERROR_MESSAGE = enum.auto()
 
 
 @dataclass
 class DoorStateNotification:
-    event: "DoorStateNotificationType" = HardwareEventType.DOOR_SWITCH_CHANGE
+    event: Literal[
+        HardwareEventType.DOOR_SWITCH_CHANGE
+    ] = HardwareEventType.DOOR_SWITCH_CHANGE
     new_state: DoorState = DoorState.CLOSED
     blocking: bool = False
 
 
+@dataclass
+class ErrorMessageNotification:
+    message: str
+    event: Literal[HardwareEventType.ERROR_MESSAGE] = HardwareEventType.ERROR_MESSAGE
+
+
 # new event types get new dataclasses
 # when we add more event types we add them here
-HardwareEvent = Union[DoorStateNotification]
+HardwareEvent = Union[DoorStateNotification, ErrorMessageNotification]
+
+HardwareEventHandler = Callable[[HardwareEvent], None]
 
 
 class HardwareAPILike(abc.ABC):

--- a/api/tests/opentrons/drivers/asyncio/communication/test_async_serial.py
+++ b/api/tests/opentrons/drivers/asyncio/communication/test_async_serial.py
@@ -34,7 +34,12 @@ async def subject(
     loop: asyncio.AbstractEventLoop, mock_serial: MagicMock
 ) -> AsyncSerial:
     """The test subject."""
-    return AsyncSerial(serial=mock_serial, executor=ThreadPoolExecutor(), loop=loop)
+    return AsyncSerial(
+        serial=mock_serial,
+        executor=ThreadPoolExecutor(),
+        loop=loop,
+        reset_buffer_before_write=False,
+    )
 
 
 @pytest.mark.parametrize(

--- a/api/tests/opentrons/hardware_control/modules/test_hc_magdeck.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_magdeck.py
@@ -21,7 +21,6 @@ async def test_sim_initialization(loop, usb_port):
         usb_port=usb_port,
         which="magdeck",
         simulating=True,
-        interrupt_callback=lambda x: None,
         loop=loop,
         execution_manager=ExecutionManager(loop=loop),
     )
@@ -34,7 +33,6 @@ async def test_sim_data(loop, usb_port):
         usb_port=usb_port,
         which="magdeck",
         simulating=True,
-        interrupt_callback=lambda x: None,
         loop=loop,
         execution_manager=ExecutionManager(loop=loop),
     )
@@ -53,7 +51,6 @@ async def test_sim_state_update(loop, usb_port):
         usb_port=usb_port,
         which="magdeck",
         simulating=True,
-        interrupt_callback=lambda x: None,
         loop=loop,
         execution_manager=ExecutionManager(loop=loop),
     )
@@ -71,7 +68,6 @@ async def test_revision_model_parsing(loop, usb_port):
         "magdeck",
         True,
         usb_port,
-        lambda x: None,
         loop=loop,
         execution_manager=ExecutionManager(loop=loop),
     )

--- a/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
@@ -1,6 +1,5 @@
 import pytest
 from mock import AsyncMock
-from opentrons.drivers.mag_deck import AbstractMagDeckDriver
 from opentrons.drivers.temp_deck import AbstractTempDeckDriver
 from opentrons.hardware_control import modules, ExecutionManager
 

--- a/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
@@ -22,7 +22,6 @@ async def test_sim_initialization(loop, usb_port):
         usb_port=usb_port,
         which="tempdeck",
         simulating=True,
-        interrupt_callback=lambda x: None,
         loop=loop,
         execution_manager=ExecutionManager(loop=loop),
     )

--- a/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
@@ -1,4 +1,7 @@
 import pytest
+from mock import AsyncMock
+from opentrons.drivers.mag_deck import AbstractMagDeckDriver
+from opentrons.drivers.temp_deck import AbstractTempDeckDriver
 from opentrons.hardware_control import modules, ExecutionManager
 
 
@@ -90,3 +93,20 @@ async def test_revision_model_parsing(loop, usb_port):
     assert mag.model() == "temperatureModuleV1"
     mag._device_info["model"] = "temp_deck_v1.1"
     assert mag.model() == "temperatureModuleV1"
+
+
+async def test_poll_error(loop, usb_port) -> None:
+    mock_driver = AsyncMock(spec=AbstractTempDeckDriver)
+    mock_driver.get_temperature.side_effect = ValueError("hello!")
+
+    magdeck = modules.TempDeck(
+        port="",
+        usb_port=usb_port,
+        execution_manager=AsyncMock(spec=ExecutionManager),
+        driver=mock_driver,
+        device_info={},
+        loop=loop,
+        polling_frequency=1,
+    )
+    with pytest.raises(ValueError, match="hello!"):
+        await magdeck.wait_next_poll()

--- a/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
@@ -23,7 +23,6 @@ async def test_sim_initialization(loop, usb_port):
         usb_port=usb_port,
         which="thermocycler",
         simulating=True,
-        interrupt_callback=lambda x: None,
         loop=loop,
         execution_manager=ExecutionManager(loop=loop),
     )
@@ -37,7 +36,6 @@ async def test_lid(loop, usb_port):
         usb_port=usb_port,
         which="thermocycler",
         simulating=True,
-        interrupt_callback=lambda x: None,
         loop=loop,
         execution_manager=ExecutionManager(loop=loop),
     )
@@ -65,7 +63,6 @@ async def test_sim_state(loop, usb_port):
         usb_port=usb_port,
         which="thermocycler",
         simulating=True,
-        interrupt_callback=lambda x: None,
         loop=loop,
         execution_manager=ExecutionManager(loop=loop),
     )
@@ -88,7 +85,6 @@ async def test_sim_update(loop, usb_port):
         usb_port=usb_port,
         which="thermocycler",
         simulating=True,
-        interrupt_callback=lambda x: None,
         loop=loop,
         execution_manager=ExecutionManager(loop=loop),
     )
@@ -158,7 +154,6 @@ async def set_temperature_subject(
     hw_tc = modules.Thermocycler(
         port="/dev/ot_module_sim_thermocycler0",
         usb_port=usb_port,
-        interrupt_callback=lambda x: None,
         loop=loop,
         execution_manager=ExecutionManager(loop=loop),
         driver=simulator_set_plate_spy,

--- a/api/tests/opentrons/hardware_control/test_modules.py
+++ b/api/tests/opentrons/hardware_control/test_modules.py
@@ -106,7 +106,6 @@ async def test_module_update_integration(monkeypatch, loop):
         usb_port=usb_port,
         which="tempdeck",
         simulating=True,
-        interrupt_callback=lambda x: None,
         loop=loop,
         execution_manager=ExecutionManager(loop=loop),
         sim_model="temperatureModuleV2",
@@ -137,7 +136,6 @@ async def test_module_update_integration(monkeypatch, loop):
         usb_port=usb_port,
         which="magdeck",
         simulating=True,
-        interrupt_callback=lambda x: None,
         loop=loop,
         execution_manager=ExecutionManager(loop=loop),
     )
@@ -154,7 +152,6 @@ async def test_module_update_integration(monkeypatch, loop):
         usb_port=usb_port,
         which="thermocycler",
         simulating=True,
-        interrupt_callback=lambda x: None,
         loop=loop,
         execution_manager=ExecutionManager(loop=loop),
     )

--- a/api/tests/opentrons/hardware_control/test_poller.py
+++ b/api/tests/opentrons/hardware_control/test_poller.py
@@ -1,5 +1,6 @@
+import pytest
 from mock import AsyncMock, MagicMock
-from opentrons.hardware_control.poller import Poller, Listener, Reader
+from opentrons.hardware_control.poller import Poller, Listener, Reader, WaitableListener
 
 
 async def test_poll_error() -> None:
@@ -31,3 +32,20 @@ async def test_notify() -> None:
 
     listener.on_poll.assert_called_once_with(23)
     listener.on_terminated.assert_called_once()
+
+
+async def test_await_poll_error() -> None:
+    """It should raise in wait_next_poll if reader raises."""
+    exc = AssertionError()
+
+    async def raiser():
+        raise exc
+
+    reader = AsyncMock(spec=Reader)
+    reader.read.side_effect = raiser
+    listener = WaitableListener[int]()
+
+    p: Poller[int] = Poller(interval_seconds=0.01, reader=reader, listener=listener)
+    with pytest.raises(exc.__class__):
+        await listener.wait_next_poll()
+    await p.stop_and_wait()

--- a/robot-server/emulator.env
+++ b/robot-server/emulator.env
@@ -2,7 +2,6 @@
 OT_ROBOT_SERVER_ws_domain_socket=
 # Set up URIs for emulator
 OT_SMOOTHIE_EMULATOR_URI=socket://127.0.0.1:9996
-# Thermocycler driver requires root access
-# OT_THERMOCYCLER_EMULATOR_URI=socket://localhost:9997
+OT_THERMOCYCLER_EMULATOR_URI=socket://localhost:9997
 OT_TEMPERATURE_EMULATOR_URI=socket://localhost:9998
 OT_MAGNETIC_EMULATOR_URI=socket://localhost:9999

--- a/robot-server/tests/service/legacy/routers/test_modules.py
+++ b/robot-server/tests/service/legacy/routers/test_modules.py
@@ -24,7 +24,6 @@ def magdeck():
             usb_port=usb_port,
             which="magdeck",
             simulating=True,
-            interrupt_callback=lambda x: None,
             execution_manager=ExecutionManager(loop=asyncio.get_event_loop()),
             loop=asyncio.get_event_loop(),
         )
@@ -49,7 +48,6 @@ def tempdeck():
             usb_port=usb_port,
             which="tempdeck",
             simulating=True,
-            interrupt_callback=lambda x: None,
             execution_manager=ExecutionManager(loop=asyncio.get_event_loop()),
             loop=asyncio.get_event_loop(),
         )
@@ -75,7 +73,6 @@ def thermocycler():
             usb_port=usb_port,
             which="thermocycler",
             simulating=True,
-            interrupt_callback=lambda x: None,
             execution_manager=ExecutionManager(loop=asyncio.get_event_loop()),
             loop=asyncio.get_event_loop(),
         )


### PR DESCRIPTION
# Overview

The thermocycler can enter an error state that is unrecoverable. It's important to notify the user of this state so they can contact support.

There were a number of bugs related to Thermocycler error handling. Some new (introduced in 4.6) and some ancient.

### New Bug
4.6 added asyncio smoothie driver. The smoothie driver has always required clearing the Serial read buffer between writes. This has to do with smoothie echoing and emitting a variety of nonsense. 
This resetting of the buffer had a bad side effect on the thermocycler. The TC FW writes error messages asynchronously. Not in response to commands. The buffer reset was erasing the error messages. 

### Old Bug
At some point the hardware controller added a callback mechanism for events. Perhaps this event was always a string (?).
At some point door events were emitted on this channel. The listener is the RPC session expecting `DoorEventNotification` object. 
`API.pause_with_message` (the error handler for TC) was calling the callback with a string causing an unhandled exception in the RPC Session event handler.

closes #8393 

# Changelog

### New Bug
Add `reset_buffer_before_write` to `AsyncSerial` constructor. Only the Smoothie driver sets this to `True`.

### Old Bug
Added `ErrorMessageNotification` to `HardwareEvent` type. `API.pause_with_message` sends an `ErrorMessageNotification` which is properly handled by RPC Session.

### New behaviour
- When an error is encountered by TC module the module enters an error state. In this state, polling of the TC stops, the connection to the TC is closed, and the status becomes `error`. This status is visible in the `GET /modules` endpoint response.
- The interrupt_callback is removed. It is RPC only and not long for this world.

# Review requests

I tested using hardware emulators.

Test on robot. 

# Risk assessment

High