### PR TITLE
chore: Fix docs-build CI not running when a commit touches a docs path

### DIFF
--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -1,11 +1,25 @@
-# This workflow builds API docs on branch pushes that touch the parts
-# of the api/ project that are used by the docs; the docs source themselves;
-# or the CI/makefile tooling used to build the docs.
+# This workflow builds API docs when either:
+#
+# * A commit is tagged like "docs@foo".
+#
+# * Someone pushes, to any branch, a commit that touches any of:
+#   * The parts of the api/ project that are used by the docs.
+#   * The docs source themselves;
+#   * The CI/makefile tooling used to build the docs.
+
 
 name: 'API docs build'
 
 on:
   push:
+    tags:
+      - 'docs@*'
+    branches:
+      # We don't want to do any filtering based on branch name.
+      # But because we specified `tags`, we need to specify `branches` too,
+      # or else GitHub will only run this workflow for tag matches
+      # and not for path matches.
+      - '**'
     paths:
       - 'api/src/opentrons/protocol_api/**'
       - 'api/docs/**'
@@ -13,8 +27,6 @@ on:
       - '.github/actions/python/**'
       - '.github/actions/webstack/deploy-to-sandbox/**'
       - '.github/workflows/utils.js'
-    tags:
-      - 'docs@*'
   workflow_dispatch:
 
 


### PR DESCRIPTION
# Overview

Our `docs-build` CI workflow has not been automatically running for a while. (Since #7790, it looks like?) See the [workflow run history](https://github.com/Opentrons/opentrons/actions/workflows/docs-build.yaml).

This PR takes a stab at fixing it.

# Changelog

* Instead of not specifying a branch filter, specify a branch filter with an allow-everything wildcard `**`.
    * The [GitHub Actions docs say](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onpushpull_requestbranchestags): "If you define only `tags` or only `branches`, the workflow won't run for events affecting the undefined Git ref." We defined `tags` and not `branches`, so maybe this is what it means?
    * I don't know if this will actually work.

# Review requests

## Code review

* My new comment in the `.yaml` file is a correct summary of what we want to happen.
* The fix looks plausible.

## Test plan

We will know that this worked if:

* [ ] Docs start building for any commit that touches a docs source file. So, for example, #8452 should gain a docs-build check. (I will probably need to add a new commit to that PR's branch to re-trigger it.)
* [ ] Docs continue to build when we push tags like `docs@foo`.
    * I'm scared to push a tag like this myself because I don't fully understand our deployment pipeline. **Can someone confirm that it will only deploy to a sandbox, and not to the live docs.opentrons.com site?** If so, we can test this by pushing a dummy tag and then deleting it.
* [x] Docs continue to not build on other commits.
    * Edit after having merged this: This looks good. See 37e2a44c5b0ebe76cc6fc45ca6e2898b0c02c4ad, for example.

Unfortunately, I think merging this into `edge` is the easiest way to test it.

# Risk assessment

Low because this CI has already been not running, so it's unlikely that this will make things any worse.

The risk is that this will break the `docs@foo` tag behavior. See the test plan notes above.