### PR TITLE
refactor(api): Refactor mapping of legacy labware and pipette loads

### DIFF
--- a/api/src/opentrons/equipment_broker.py
+++ b/api/src/opentrons/equipment_broker.py
@@ -1,0 +1,56 @@
+"""A simple pub/sub message broker for monitoring equipment loads."""
+
+
+from typing import Callable, Generic, Set, TypeVar
+
+
+_MessageT = TypeVar("_MessageT")
+
+
+class EquipmentBroker(Generic[_MessageT]):
+    """A simple pub/sub message broker.
+
+    This is currently meant for monitoring equipment loads
+    (pipette, labware, and module loads)
+    on an APIv2 `ProtocolContext`.
+
+    This duplicates much of `opentrons.broker.Broker`,
+    which covers most other APIv2 events, like aspirates and moves,
+    but doesn't cover equipment loads.
+    To cover equipment loads, we felt more comfortable
+    duplicating `opentrons.broker.Broker`'s responsibilities here
+    than attempting to extend it without breaking anything.
+    """
+
+    def __init__(self) -> None:  # noqa: D107
+        self._callbacks: Set[Callable[[_MessageT], None]] = set()
+
+    def subscribe(self, callback: Callable[[_MessageT], None]) -> Callable[[], None]:
+        """Register ``callback`` to be called by a subsequent `publish`.
+
+        You must not subscribe the same callback again
+        unless you first unsubscribe it.
+
+        Returns:
+            A function that you can call to unsubscribe ``callback``.
+            You must not call it more than once.
+        """
+
+        def unsubscribe() -> None:
+            self._callbacks.remove(callback)
+
+        self._callbacks.add(callback)
+        return unsubscribe
+
+    def publish(self, message: _MessageT) -> None:
+        """Call every subscribed callback, with ``message`` as the argument.
+
+        The order in which the callbacks are called is undefined.
+
+        If any callback raises an exception, it's propagated,
+        and any remaining callbacks will be left uncalled.
+        """
+        # Callback order is undefined because
+        # Python sets don't preserve insertion order.
+        for callback in self._callbacks:
+            callback(message)

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -74,6 +74,15 @@ class ProtocolContext(CommandPublisher):
 
     """
 
+    on_labware_loaded: Optional[Callable[[Labware], None]] = None
+    """For internal Opentrons use only.
+
+    For every successful labware load, this callback will be called with the
+    labware object.
+
+    :meta private:
+    """
+
     def __init__(
         self,
         implementation: AbstractProtocol,
@@ -338,7 +347,10 @@ class ProtocolContext(CommandPublisher):
         implementation = self._implementation.load_labware_from_definition(
             labware_def=labware_def, location=location, label=label
         )
-        return Labware(implementation=implementation)
+        result = Labware(implementation=implementation)
+        if self.on_labware_loaded:
+            self.on_labware_loaded(result)
+        return result
 
     @requires_version(2, 0)
     def load_labware(
@@ -378,7 +390,10 @@ class ProtocolContext(CommandPublisher):
             namespace=namespace,
             version=version,
         )
-        return Labware(implementation=implementation)
+        result = Labware(implementation=implementation)
+        if self.on_labware_loaded:
+            self.on_labware_loaded(result)
+        return result
 
     @requires_version(2, 0)
     def load_labware_by_name(

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -115,11 +115,11 @@ class ProtocolContext(CommandPublisher):
         self._unsubscribe_commands: Optional[Callable[[], None]] = None
         self.clear_commands()
 
-        self._labware_loaded_broker = EquipmentBroker[LabwareLoadInfo]()
-        self._instrument_loaded_broker = EquipmentBroker[InstrumentLoadInfo]()
+        self._labware_load_broker = EquipmentBroker[LabwareLoadInfo]()
+        self._instrument_load_broker = EquipmentBroker[InstrumentLoadInfo]()
 
     @property
-    def labware_loaded_broker(self) -> EquipmentBroker[LabwareLoadInfo]:
+    def labware_load_broker(self) -> EquipmentBroker[LabwareLoadInfo]:
         """For internal Opentrons use only.
 
         :meta private:
@@ -130,17 +130,17 @@ class ProtocolContext(CommandPublisher):
         Only :py:obj:`ProtocolContext` is allowed to publish to this broker.
         Calling code may only subscribe or unsubscribe.
         """
-        return self._labware_loaded_broker
+        return self._labware_load_broker
 
     @property
-    def instrument_loaded_broker(self) -> EquipmentBroker[InstrumentLoadInfo]:
+    def instrument_load_broker(self) -> EquipmentBroker[InstrumentLoadInfo]:
         """For internal Opentrons use only.
 
         :meta private:
 
-        Like `labware_loaded_broker`, but for pipettes.
+        Like `labware_load_broker`, but for pipettes.
         """
-        return self._instrument_loaded_broker
+        return self._instrument_load_broker
 
     @classmethod
     def build_using(
@@ -372,7 +372,7 @@ class ProtocolContext(CommandPublisher):
         result = Labware(implementation=implementation)
 
         result_namespace, result_load_name, result_version = result.uri.split("/")
-        self.labware_loaded_broker.publish(
+        self.labware_load_broker.publish(
             LabwareLoadInfo(
                 labware_definition=result._implementation.get_definition(),
                 labware_namespace=result_namespace,
@@ -425,7 +425,7 @@ class ProtocolContext(CommandPublisher):
         result = Labware(implementation=implementation)
 
         result_namespace, result_load_name, result_version = result.uri.split("/")
-        self.labware_loaded_broker.publish(
+        self.labware_load_broker.publish(
             LabwareLoadInfo(
                 labware_definition=result._implementation.get_definition(),
                 labware_namespace=result_namespace,
@@ -638,7 +638,7 @@ class ProtocolContext(CommandPublisher):
         )
         self._instruments[checked_mount] = new_instr
 
-        self.instrument_loaded_broker.publish(
+        self.instrument_load_broker.publish(
             InstrumentLoadInfo(
                 instrument_load_name=instrument_name,
                 mount=checked_mount,

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -83,6 +83,12 @@ class ProtocolContext(CommandPublisher):
     :meta private:
     """
 
+    on_instrument_loaded: Optional[Callable[[InstrumentContext], None]] = None
+    """Like :py:obj:`on_labware_loaded`, but for pipettes.
+
+    :meta private:
+    """
+
     def __init__(
         self,
         implementation: AbstractProtocol,
@@ -348,7 +354,7 @@ class ProtocolContext(CommandPublisher):
             labware_def=labware_def, location=location, label=label
         )
         result = Labware(implementation=implementation)
-        if self.on_labware_loaded:
+        if self.on_labware_loaded is not None:
             self.on_labware_loaded(result)
         return result
 
@@ -391,7 +397,7 @@ class ProtocolContext(CommandPublisher):
             version=version,
         )
         result = Labware(implementation=implementation)
-        if self.on_labware_loaded:
+        if self.on_labware_loaded is not None:
             self.on_labware_loaded(result)
         return result
 
@@ -595,6 +601,10 @@ class ProtocolContext(CommandPublisher):
             tip_racks=tip_racks,
         )
         self._instruments[checked_mount] = new_instr
+
+        if self.on_instrument_loaded is not None:
+            self.on_instrument_loaded(new_instr)
+
         return new_instr
 
     @property  # type: ignore

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -116,7 +116,7 @@ class ProtocolContext(CommandPublisher):
         self.clear_commands()
 
         self._labware_loaded_broker = EquipmentBroker[LabwareLoadInfo]()
-        self._instrument_loaded_broker = EquipmentBroker[InstrumentContext]()
+        self._instrument_loaded_broker = EquipmentBroker[InstrumentLoadInfo]()
 
     @property
     def labware_loaded_broker(self) -> EquipmentBroker[LabwareLoadInfo]:
@@ -133,7 +133,7 @@ class ProtocolContext(CommandPublisher):
         return self._labware_loaded_broker
 
     @property
-    def instrument_loaded_broker(self) -> EquipmentBroker[InstrumentContext]:
+    def instrument_loaded_broker(self) -> EquipmentBroker[InstrumentLoadInfo]:
         """For internal Opentrons use only.
 
         :meta private:
@@ -638,7 +638,12 @@ class ProtocolContext(CommandPublisher):
         )
         self._instruments[checked_mount] = new_instr
 
-        self.instrument_loaded_broker.publish(new_instr)
+        self.instrument_loaded_broker.publish(
+            InstrumentLoadInfo(
+                instrument_load_name=instrument_name,
+                mount=checked_mount,
+            )
+        )
 
         return new_instr
 
@@ -817,6 +822,19 @@ class LabwareLoadInfo:
     labware_load_name: str
     labware_version: int
     deck_slot: types.DeckSlotName
+
+
+@dataclass(frozen=True)
+class InstrumentLoadInfo:
+    """For Opentrons internal use only.
+
+    :meta private:
+
+    Like `LabwareLoadInfo`, but for instruments (pipettes).
+    """
+
+    instrument_load_name: str
+    mount: types.Mount
 
 
 _MessageT = TypeVar("_MessageT")

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -777,7 +777,6 @@ class ProtocolContext(CommandPublisher):
 _MessageT = TypeVar("_MessageT")
 
 
-_CallbackT = Callable[[_MessageT], None]
 
 
 class EquipmentBroker(Generic[_MessageT]):
@@ -800,9 +799,9 @@ class EquipmentBroker(Generic[_MessageT]):
     """
 
     def __init__(self) -> None:
-        self._callbacks: Set[_CallbackT] = set()
+        self._callbacks: Set[Callable[[_MessageT], None]] = set()
 
-    def subscribe(self, callback: _CallbackT) -> Callable[[], None]:
+    def subscribe(self, callback: Callable[[_MessageT], None]) -> Callable[[], None]:
         """Register ``callback`` to be called by a subsequent `publish`.
 
         You must not subscribe the same callback again

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -818,6 +818,8 @@ class LabwareLoadInfo:
     """
 
     labware_definition: "LabwareDefinition"
+    # todo(mm, 2021-10-11): Namespace, load name, and version can be derived from the
+    # definition. Should they be removed from here?
     labware_namespace: str
     labware_load_name: str
     labware_version: int

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -1,7 +1,7 @@
 """Translate events from a legacy ``ProtocolContext`` into Protocol Engine commands."""
 
 from collections import defaultdict
-from typing import Any, Dict, List, Set
+from typing import Dict, List
 import logging
 
 from opentrons.types import DeckSlotName, MountType
@@ -10,7 +10,7 @@ from opentrons.commands.types import CommandMessage as LegacyCommand
 from opentrons.protocol_engine import commands as pe_commands, types as pe_types
 from opentrons.protocols.models.labware_definition import LabwareDefinition
 
-from .legacy_wrappers import LegacyPipetteContext, LegacyModuleContext, LegacyLabware
+from .legacy_wrappers import LegacyPipetteContext, LegacyLabware
 
 
 class LegacyCommandData(pe_commands.CustomData):
@@ -27,16 +27,10 @@ class LegacyCommandMapper:
         """Initialize the command mapper."""
         self._running_commands: Dict[str, List[pe_commands.Command]] = defaultdict(list)
         self._command_count: Dict[str, int] = defaultdict(lambda: 0)
-        self._loaded_pipette_mounts: Set[str] = set()
-        self._loaded_labware_slots: Set[int] = set()
-        self._loaded_module_slots: Set[int] = set()
 
     def map_brokered_command(
         self,
         command: LegacyCommand,
-        loaded_pipettes: Dict[str, LegacyPipetteContext],
-        loaded_modules: Dict[int, LegacyModuleContext[Any]],
-        loaded_labware: Dict[int, LegacyLabware],
     ) -> List[pe_commands.Command]:
         """Map a legacy Broker command to ProtocolEngine commands."""
         command_type = command["name"]

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -139,7 +139,7 @@ class LegacyCommandMapper:
                 pipetteName=pe_types.PipetteName(
                     instrument_load_info.instrument_load_name
                 ),
-                mount=MountType(instrument_load_info.mount),
+                mount=MountType(str(instrument_load_info.mount).lower()),
             ),
             result=pe_commands.LoadPipetteResult(
                 pipetteId=f"pipette-{count}",

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -38,7 +38,7 @@ class LegacyCommandMapper:
         loaded_modules: Dict[int, LegacyModuleContext[Any]],
         loaded_labware: Dict[int, LegacyLabware],
     ) -> List[pe_commands.Command]:
-        """Map a Broker command to a ProtocolEngine command."""
+        """Map a legacy Broker command to ProtocolEngine commands."""
         command_type = command["name"]
         command_text = command["payload"]["text"]
         stage = command["$"]

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -29,7 +29,7 @@ class LegacyCommandMapper:
         self._loaded_labware_slots: Set[int] = set()
         self._loaded_module_slots: Set[int] = set()
 
-    def map(
+    def map_brokered_command(
         self,
         command: LegacyCommand,
         loaded_pipettes: Dict[str, LegacyPipetteContext],

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -30,7 +30,7 @@ class LegacyCommandMapper:
         self._running_commands: Dict[str, List[pe_commands.Command]] = defaultdict(list)
         self._command_count: Dict[str, int] = defaultdict(lambda: 0)
 
-    def map_brokered_command(
+    def map_command(
         self,
         command: LegacyCommand,
     ) -> List[pe_commands.Command]:

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -9,7 +9,10 @@ from opentrons.commands.types import CommandMessage as LegacyCommand
 from opentrons.protocol_engine import commands as pe_commands, types as pe_types
 from opentrons.protocols.models.labware_definition import LabwareDefinition
 
-from .legacy_wrappers import LegacyPipetteContext, LegacyLabwareLoadInfo
+from .legacy_wrappers import (
+    LegacyInstrumentLoadInfo,
+    LegacyLabwareLoadInfo,
+)
 
 
 class LegacyCommandData(pe_commands.CustomData):
@@ -106,14 +109,12 @@ class LegacyCommandMapper:
         return [load_labware_command]
 
     def map_instrument_loaded(
-        self, loaded_instrument: LegacyPipetteContext
+        self, instrument_load_info: LegacyInstrumentLoadInfo
     ) -> List[pe_commands.Command]:
         """Map a legacy instrument (pipette) load to Protocol Engine commands."""
         now = utc_now()
 
         count = self._command_count["LOAD_PIPETTE"]
-        name = loaded_instrument.name
-        mount = loaded_instrument.mount
 
         load_pipette_command = pe_commands.LoadPipette(
             id=f"commands.LOAD_PIPETTE-{count}",
@@ -122,8 +123,10 @@ class LegacyCommandMapper:
             startedAt=now,
             completedAt=now,
             data=pe_commands.LoadPipetteData(
-                pipetteName=pe_types.PipetteName(name),
-                mount=MountType(mount),
+                pipetteName=pe_types.PipetteName(
+                    instrument_load_info.instrument_load_name
+                ),
+                mount=MountType(instrument_load_info.mount),
             ),
             result=pe_commands.LoadPipetteResult(
                 pipetteId=f"pipette-{count}",

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -75,7 +75,7 @@ class LegacyCommandMapper:
 
         return results
 
-    def map_labware_loaded(
+    def map_labware_load(
         self,
         labware_load_info: LegacyLabwareLoadInfo,
     ) -> List[pe_commands.Command]:
@@ -108,7 +108,7 @@ class LegacyCommandMapper:
         self._command_count["LOAD_LABWARE"] = count + 1
         return [load_labware_command]
 
-    def map_instrument_loaded(
+    def map_instrument_load(
         self, instrument_load_info: LegacyInstrumentLoadInfo
     ) -> List[pe_commands.Command]:
         """Map a legacy instrument (pipette) load to Protocol Engine commands."""

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -36,8 +36,8 @@ class LegacyCommandMapper:
     def map_command(
         self,
         command: LegacyCommand,
-    ) -> List[pe_commands.Command]:
-        """Map a legacy Broker command to ProtocolEngine commands.
+    ) -> pe_commands.Command:
+        """Map a legacy Broker command to a ProtocolEngine command.
 
         A "before" message from the Broker
         is mapped to a ``RUNNING`` ProtocolEngine command.
@@ -54,7 +54,6 @@ class LegacyCommandMapper:
 
         command_id = f"{command_type}-0"
         now = utc_now()
-        results: List[pe_commands.Command] = []
 
         if stage == "before":
             count = self._command_count[command_type]
@@ -73,7 +72,7 @@ class LegacyCommandMapper:
             self._command_count[command_type] = count + 1
             self._running_commands[command_type].append(engine_command)
 
-            results.append(engine_command)
+            return engine_command
 
         else:
             running_command = self._running_commands[command_type].pop()
@@ -84,15 +83,13 @@ class LegacyCommandMapper:
                 }
             )
 
-            results.append(completed_command)
-
-        return results
+            return completed_command
 
     def map_labware_load(
         self,
         labware_load_info: LegacyLabwareLoadInfo,
-    ) -> List[pe_commands.Command]:
-        """Map a legacy labware load to ProtocolEngine commands."""
+    ) -> pe_commands.Command:
+        """Map a legacy labware load to a ProtocolEngine command."""
         now = utc_now()
 
         count = self._command_count["LOAD_LABWARE"]
@@ -119,12 +116,12 @@ class LegacyCommandMapper:
         )
 
         self._command_count["LOAD_LABWARE"] = count + 1
-        return [load_labware_command]
+        return load_labware_command
 
     def map_instrument_load(
         self, instrument_load_info: LegacyInstrumentLoadInfo
-    ) -> List[pe_commands.Command]:
-        """Map a legacy instrument (pipette) load to ProtocolEngine commands."""
+    ) -> pe_commands.Command:
+        """Map a legacy instrument (pipette) load to a ProtocolEngine command."""
         now = utc_now()
 
         count = self._command_count["LOAD_PIPETTE"]
@@ -147,4 +144,4 @@ class LegacyCommandMapper:
         )
 
         self._command_count["LOAD_PIPETTE"] = count + 1
-        return [load_pipette_command]
+        return load_pipette_command

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -1,4 +1,5 @@
-"""Customize the ProtocolEngine to control and track state of legacy protocols."""
+"""Translate events from a legacy ``ProtocolContext`` into Protocol Engine commands."""
+
 from collections import defaultdict
 from typing import Any, Dict, List, Set
 

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -23,7 +23,10 @@ class LegacyCommandData(pe_commands.CustomData):
 
 
 class LegacyCommandMapper:
-    """Map broker commands to protocol engine commands."""
+    """Map broker commands to protocol engine commands.
+
+    Each protocol should use its own instance of this class.
+    """
 
     def __init__(self) -> None:
         """Initialize the command mapper."""
@@ -34,7 +37,17 @@ class LegacyCommandMapper:
         self,
         command: LegacyCommand,
     ) -> List[pe_commands.Command]:
-        """Map a legacy Broker command to ProtocolEngine commands."""
+        """Map a legacy Broker command to ProtocolEngine commands.
+
+        A "before" message from the Broker
+        is mapped to a ``RUNNING`` ProtocolEngine command.
+
+        An "after" message from the Broker
+        is mapped to a ``SUCCEEDED`` ProtocolEngine command.
+        It has the same ID as the original ``RUNNING`` command,
+        so when you send it to the ProtocolEngine, it will update the original
+        command's status in-place.
+        """
         command_type = command["name"]
         command_text = command["payload"]["text"]
         stage = command["$"]
@@ -79,7 +92,7 @@ class LegacyCommandMapper:
         self,
         labware_load_info: LegacyLabwareLoadInfo,
     ) -> List[pe_commands.Command]:
-        """Map a legacy labware load to Protocol Engine commands."""
+        """Map a legacy labware load to ProtocolEngine commands."""
         now = utc_now()
 
         count = self._command_count["LOAD_LABWARE"]
@@ -111,7 +124,7 @@ class LegacyCommandMapper:
     def map_instrument_load(
         self, instrument_load_info: LegacyInstrumentLoadInfo
     ) -> List[pe_commands.Command]:
-        """Map a legacy instrument (pipette) load to Protocol Engine commands."""
+        """Map a legacy instrument (pipette) load to ProtocolEngine commands."""
         now = utc_now()
 
         count = self._command_count["LOAD_PIPETTE"]

--- a/api/src/opentrons/protocol_runner/legacy_context_plugin.py
+++ b/api/src/opentrons/protocol_runner/legacy_context_plugin.py
@@ -11,6 +11,26 @@ from .legacy_wrappers import LegacyLabware, LegacyPipetteContext, LegacyProtocol
 from .legacy_command_mapper import LegacyCommandMapper
 
 
+# todo(mm, 2021-10-07): This class may cause threading bugs.
+#
+#
+# Problem 1 -- unsynchronized concurrent access to Protocol Engine state...
+#
+# The "main" thread, where FastAPI serves HTTP requests,
+# assumes exclusive access to the ProtocolEngine and its state.
+#
+# Meanwhile, the legacy ProtocolContext will be issuing command events from its
+# background thread. Our reactions to those command events will also run in the
+# background thread. But our reactions will modify Protocol Engine state, which may
+# conflict with unrelated Protocol Engine accesses from the main FastAPI thread.
+#
+#
+# Problem 2 -- unsynchronized concurrent access to legacy ProtocolContext state...
+#
+# We currently add and remove subscriptions on the legacy ProtocolContext in direct
+# reaction to receiving play and stop actions from Protocol Engine. To be correct, we
+# need to guarantee that, when we do this, the legacy ProtocolContext will be inactive.
+# It's not clear whether we currently accomplish this.
 class LegacyContextPlugin(AbstractPlugin):
     """A ProtocolEngine plugin wrapping a legacy ProtocolContext.
 

--- a/api/src/opentrons/protocol_runner/legacy_context_plugin.py
+++ b/api/src/opentrons/protocol_runner/legacy_context_plugin.py
@@ -72,10 +72,8 @@ class LegacyContextPlugin(AbstractPlugin):
         # but fix unreleased as of mypy 0.910.
         self._subscriptions_are_set_up: bool = False
         self._unsubscribe_from_main_broker: Optional[Callable[[], None]] = None
-        self._unsubscribe_from_labware_loaded_broker: Optional[
-            Callable[[], None]
-        ] = None
-        self._unsubscribe_from_instrument_loaded_broker: Optional[
+        self._unsubscribe_from_labware_load_broker: Optional[Callable[[], None]] = None
+        self._unsubscribe_from_instrument_load_broker: Optional[
             Callable[[], None]
         ] = None
 
@@ -98,13 +96,13 @@ class LegacyContextPlugin(AbstractPlugin):
             topic="command",
             handler=self._dispatch_legacy_command,
         )
-        self._unsubscribe_from_labware_loaded_broker = (
-            self._protocol_context.labware_loaded_broker.subscribe(
+        self._unsubscribe_from_labware_load_broker = (
+            self._protocol_context.labware_load_broker.subscribe(
                 callback=self._dispatch_labware_loaded
             )
         )
-        self._unsubscribe_from_instrument_loaded_broker = (
-            self._protocol_context.instrument_loaded_broker.subscribe(
+        self._unsubscribe_from_instrument_load_broker = (
+            self._protocol_context.instrument_load_broker.subscribe(
                 callback=self._dispatch_instrument_loaded
             )
         )
@@ -113,11 +111,11 @@ class LegacyContextPlugin(AbstractPlugin):
     def _tear_down_subscriptions(self) -> None:
         if self._subscriptions_are_set_up:
             assert self._unsubscribe_from_main_broker is not None
-            assert self._unsubscribe_from_labware_loaded_broker is not None
-            assert self._unsubscribe_from_instrument_loaded_broker is not None
+            assert self._unsubscribe_from_labware_load_broker is not None
+            assert self._unsubscribe_from_instrument_load_broker is not None
             self._unsubscribe_from_main_broker()
-            self._unsubscribe_from_labware_loaded_broker()
-            self._unsubscribe_from_instrument_loaded_broker()
+            self._unsubscribe_from_labware_load_broker()
+            self._unsubscribe_from_instrument_load_broker()
             self._subscriptions_are_set_up = False
 
     def _dispatch_legacy_command(self, command: LegacyCommand) -> None:
@@ -129,7 +127,7 @@ class LegacyContextPlugin(AbstractPlugin):
     def _dispatch_labware_loaded(
         self, labware_load_info: LegacyLabwareLoadInfo
     ) -> None:
-        pe_commands = self._legacy_command_mapper.map_labware_loaded(
+        pe_commands = self._legacy_command_mapper.map_labware_load(
             labware_load_info=labware_load_info
         )
 
@@ -139,7 +137,7 @@ class LegacyContextPlugin(AbstractPlugin):
     def _dispatch_instrument_loaded(
         self, instrument_load_info: LegacyInstrumentLoadInfo
     ) -> None:
-        pe_commands = self._legacy_command_mapper.map_instrument_loaded(
+        pe_commands = self._legacy_command_mapper.map_instrument_load(
             instrument_load_info=instrument_load_info
         )
 

--- a/api/src/opentrons/protocol_runner/legacy_context_plugin.py
+++ b/api/src/opentrons/protocol_runner/legacy_context_plugin.py
@@ -8,8 +8,8 @@ from opentrons.hardware_control.types import PauseType as HardwarePauseType
 from opentrons.protocol_engine import AbstractPlugin, actions as pe_actions
 
 from .legacy_wrappers import (
+    LegacyInstrumentLoadInfo,
     LegacyLabwareLoadInfo,
-    LegacyPipetteContext,
     LegacyProtocolContext,
 )
 from .legacy_command_mapper import LegacyCommandMapper
@@ -137,10 +137,10 @@ class LegacyContextPlugin(AbstractPlugin):
             self.dispatch(pe_actions.UpdateCommandAction(command=c))
 
     def _dispatch_instrument_loaded(
-        self, loaded_instrument: LegacyPipetteContext
+        self, instrument_load_info: LegacyInstrumentLoadInfo
     ) -> None:
         pe_commands = self._legacy_command_mapper.map_instrument_loaded(
-            loaded_instrument=loaded_instrument
+            instrument_load_info=instrument_load_info
         )
 
         for c in pe_commands:

--- a/api/src/opentrons/protocol_runner/legacy_context_plugin.py
+++ b/api/src/opentrons/protocol_runner/legacy_context_plugin.py
@@ -1,4 +1,4 @@
-"""Customize the ProtocolEngine to control and track state of legacy protocols."""
+"""Customize the ProtocolEngine to monitor and conrol legacy (APIv2) protocols."""
 from __future__ import annotations
 from typing import Callable, Optional
 
@@ -25,8 +25,9 @@ class LegacyContextPlugin(AbstractPlugin):
 
     1. Play/pause the protocol run using the HardwareAPI, as was done before
        the ProtocolEngine existed.
-    2. Subscribe to the message broker commands and insert them into
-       ProtocolEngine state for purely progress tracking purposes.
+    2. Subscribe to what is being done with the legacy ProtocolContext,
+       and insert matching commands into ProtocolEngine state for
+       purely progress-tracking purposes.
     """
 
     def __init__(

--- a/api/src/opentrons/protocol_runner/legacy_context_plugin.py
+++ b/api/src/opentrons/protocol_runner/legacy_context_plugin.py
@@ -59,7 +59,7 @@ class LegacyContextPlugin(AbstractPlugin):
             self._unsubscribe_broker()
 
     def _dispatch_legacy_command(self, command: LegacyCommand) -> None:
-        pe_commands = self._legacy_command_mapper.map(
+        pe_commands = self._legacy_command_mapper.map_brokered_command(
             command=command,
             loaded_pipettes=self._protocol_context.loaded_instruments,
             loaded_modules=self._protocol_context.loaded_modules,

--- a/api/src/opentrons/protocol_runner/legacy_context_plugin.py
+++ b/api/src/opentrons/protocol_runner/legacy_context_plugin.py
@@ -96,12 +96,7 @@ class LegacyContextPlugin(AbstractPlugin):
             self._subscriptions_are_set_up = False
 
     def _dispatch_legacy_command(self, command: LegacyCommand) -> None:
-        pe_commands = self._legacy_command_mapper.map_brokered_command(
-            command=command,
-            loaded_pipettes=self._protocol_context.loaded_instruments,
-            loaded_modules=self._protocol_context.loaded_modules,
-            loaded_labware=self._protocol_context.loaded_labwares,
-        )
+        pe_commands = self._legacy_command_mapper.map_brokered_command(command=command)
 
         for c in pe_commands:
             self.dispatch(pe_actions.UpdateCommandAction(command=c))

--- a/api/src/opentrons/protocol_runner/legacy_context_plugin.py
+++ b/api/src/opentrons/protocol_runner/legacy_context_plugin.py
@@ -96,12 +96,12 @@ class LegacyContextPlugin(AbstractPlugin):
         )
         self._unsubscribe_from_labware_loaded_broker = (
             self._protocol_context.labware_loaded_broker.subscribe(
-                self._dispatch_labware_loaded
+                callback=self._dispatch_labware_loaded
             )
         )
         self._unsubscribe_from_instrument_loaded_broker = (
             self._protocol_context.instrument_loaded_broker.subscribe(
-                self._dispatch_instrument_loaded
+                callback=self._dispatch_instrument_loaded
             )
         )
         self._subscriptions_are_set_up = True

--- a/api/src/opentrons/protocol_runner/legacy_context_plugin.py
+++ b/api/src/opentrons/protocol_runner/legacy_context_plugin.py
@@ -1,4 +1,4 @@
-"""Customize the ProtocolEngine to monitor and conrol legacy (APIv2) protocols."""
+"""Customize the ProtocolEngine to monitor and control legacy (APIv2) protocols."""
 from __future__ import annotations
 from typing import Callable, Optional
 

--- a/api/src/opentrons/protocol_runner/legacy_context_plugin.py
+++ b/api/src/opentrons/protocol_runner/legacy_context_plugin.py
@@ -7,7 +7,11 @@ from opentrons.hardware_control import API as HardwareAPI
 from opentrons.hardware_control.types import PauseType as HardwarePauseType
 from opentrons.protocol_engine import AbstractPlugin, actions as pe_actions
 
-from .legacy_wrappers import LegacyLabware, LegacyPipetteContext, LegacyProtocolContext
+from .legacy_wrappers import (
+    LegacyLabwareLoadInfo,
+    LegacyPipetteContext,
+    LegacyProtocolContext,
+)
 from .legacy_command_mapper import LegacyCommandMapper
 
 
@@ -122,9 +126,11 @@ class LegacyContextPlugin(AbstractPlugin):
         for c in pe_commands:
             self.dispatch(pe_actions.UpdateCommandAction(command=c))
 
-    def _dispatch_labware_loaded(self, loaded_labware: LegacyLabware) -> None:
+    def _dispatch_labware_loaded(
+        self, labware_load_info: LegacyLabwareLoadInfo
+    ) -> None:
         pe_commands = self._legacy_command_mapper.map_labware_loaded(
-            loaded_labware=loaded_labware
+            labware_load_info=labware_load_info
         )
 
         for c in pe_commands:

--- a/api/src/opentrons/protocol_runner/legacy_context_plugin.py
+++ b/api/src/opentrons/protocol_runner/legacy_context_plugin.py
@@ -119,7 +119,7 @@ class LegacyContextPlugin(AbstractPlugin):
             self._subscriptions_are_set_up = False
 
     def _dispatch_legacy_command(self, command: LegacyCommand) -> None:
-        pe_commands = self._legacy_command_mapper.map_brokered_command(command=command)
+        pe_commands = self._legacy_command_mapper.map_command(command=command)
 
         for c in pe_commands:
             self.dispatch(pe_actions.UpdateCommandAction(command=c))

--- a/api/src/opentrons/protocol_runner/legacy_context_plugin.py
+++ b/api/src/opentrons/protocol_runner/legacy_context_plugin.py
@@ -119,27 +119,21 @@ class LegacyContextPlugin(AbstractPlugin):
             self._subscriptions_are_set_up = False
 
     def _dispatch_legacy_command(self, command: LegacyCommand) -> None:
-        pe_commands = self._legacy_command_mapper.map_command(command=command)
-
-        for c in pe_commands:
-            self.dispatch(pe_actions.UpdateCommandAction(command=c))
+        pe_command = self._legacy_command_mapper.map_command(command=command)
+        self.dispatch(pe_actions.UpdateCommandAction(command=pe_command))
 
     def _dispatch_labware_loaded(
         self, labware_load_info: LegacyLabwareLoadInfo
     ) -> None:
-        pe_commands = self._legacy_command_mapper.map_labware_load(
+        pe_command = self._legacy_command_mapper.map_labware_load(
             labware_load_info=labware_load_info
         )
-
-        for c in pe_commands:
-            self.dispatch(pe_actions.UpdateCommandAction(command=c))
+        self.dispatch(pe_actions.UpdateCommandAction(command=pe_command))
 
     def _dispatch_instrument_loaded(
         self, instrument_load_info: LegacyInstrumentLoadInfo
     ) -> None:
-        pe_commands = self._legacy_command_mapper.map_instrument_load(
+        pe_command = self._legacy_command_mapper.map_instrument_load(
             instrument_load_info=instrument_load_info
         )
-
-        for c in pe_commands:
-            self.dispatch(pe_actions.UpdateCommandAction(command=c))
+        self.dispatch(pe_actions.UpdateCommandAction(command=pe_command))

--- a/api/src/opentrons/protocol_runner/legacy_wrappers.py
+++ b/api/src/opentrons/protocol_runner/legacy_wrappers.py
@@ -14,7 +14,9 @@ from opentrons.protocol_api import (
     ProtocolContext as LegacyProtocolContext,
     InstrumentContext as LegacyPipetteContext,
 )
-from opentrons.protocol_api.labware import Labware as LegacyLabware
+from opentrons.protocol_api.protocol_context import (
+    LabwareLoadInfo as LegacyLabwareLoadInfo,
+)
 from opentrons.protocol_api.contexts import ModuleContext as LegacyModuleContext
 
 
@@ -103,7 +105,7 @@ __all__ = [
     "LegacyProtocolContext",
     "LegacyPipetteContext",
     "LegacyModuleContext",
-    "LegacyLabware",
+    "LegacyLabwareLoadInfo",
     "LegacyProtocol",
     "LegacyJsonProtocol",
     "LegacyPythonProtocol",

--- a/api/src/opentrons/protocol_runner/legacy_wrappers.py
+++ b/api/src/opentrons/protocol_runner/legacy_wrappers.py
@@ -9,11 +9,11 @@ from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.context.protocol_api.protocol_context import (
     ProtocolContextImplementation as LegacyContextImplementation,
 )
-
 from opentrons.protocol_api import (
     ProtocolContext as LegacyProtocolContext,
     InstrumentContext as LegacyPipetteContext,
 )
+from opentrons.protocol_api.labware import Labware as LegacyLabware
 from opentrons.protocol_api.protocol_context import (
     InstrumentLoadInfo as LegacyInstrumentLoadInfo,
     LabwareLoadInfo as LegacyLabwareLoadInfo,
@@ -102,13 +102,15 @@ class LegacyExecutor:
 
 
 __all__ = [
-    "LegacyPythonProtocol",
+    # Re-exports of main public API stuff:
     "LegacyProtocolContext",
+    "LegacyLabware",
     "LegacyPipetteContext",
     "LegacyModuleContext",
-    "LegacyInstrumentLoadInfo",
-    "LegacyLabwareLoadInfo",
+    # Re-exports of internal stuff:
     "LegacyProtocol",
     "LegacyJsonProtocol",
     "LegacyPythonProtocol",
+    "LegacyLabwareLoadInfo",
+    "LegacyInstrumentLoadInfo",
 ]

--- a/api/src/opentrons/protocol_runner/legacy_wrappers.py
+++ b/api/src/opentrons/protocol_runner/legacy_wrappers.py
@@ -15,6 +15,7 @@ from opentrons.protocol_api import (
     InstrumentContext as LegacyPipetteContext,
 )
 from opentrons.protocol_api.protocol_context import (
+    InstrumentLoadInfo as LegacyInstrumentLoadInfo,
     LabwareLoadInfo as LegacyLabwareLoadInfo,
 )
 from opentrons.protocol_api.contexts import ModuleContext as LegacyModuleContext
@@ -105,6 +106,7 @@ __all__ = [
     "LegacyProtocolContext",
     "LegacyPipetteContext",
     "LegacyModuleContext",
+    "LegacyInstrumentLoadInfo",
     "LegacyLabwareLoadInfo",
     "LegacyProtocol",
     "LegacyJsonProtocol",

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -20,7 +20,7 @@ def test_map_before_command() -> None:
     }
 
     subject = LegacyCommandMapper()
-    (result,) = subject.map(legacy_command, {}, {}, {})
+    (result,) = subject.map_brokered_command(legacy_command, {}, {}, {})
 
     assert result == pe_commands.Custom.construct(
         id="command.PAUSE-0",
@@ -51,8 +51,8 @@ def test_map_after_command() -> None:
 
     subject = LegacyCommandMapper()
 
-    _ = subject.map(legacy_command_start, {}, {}, {})
-    (result,) = subject.map(legacy_command_end, {}, {}, {})
+    _ = subject.map_brokered_command(legacy_command_start, {}, {}, {})
+    (result,) = subject.map_brokered_command(legacy_command_end, {}, {}, {})
 
     assert result == pe_commands.Custom.construct(
         id="command.PAUSE-0",
@@ -95,10 +95,10 @@ def test_command_stack() -> None:
     }
 
     subject = LegacyCommandMapper()
-    (result_1,) = subject.map(legacy_command_1, {}, {}, {})
-    (result_2,) = subject.map(legacy_command_2, {}, {}, {})
-    (result_3,) = subject.map(legacy_command_3, {}, {}, {})
-    (result_4,) = subject.map(legacy_command_4, {}, {}, {})
+    (result_1,) = subject.map_brokered_command(legacy_command_1, {}, {}, {})
+    (result_2,) = subject.map_brokered_command(legacy_command_2, {}, {}, {})
+    (result_3,) = subject.map_brokered_command(legacy_command_3, {}, {}, {})
+    (result_4,) = subject.map_brokered_command(legacy_command_4, {}, {}, {})
 
     assert result_1 == pe_commands.Custom.construct(
         id="command.PAUSE-0",

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -20,7 +20,7 @@ def test_map_before_command() -> None:
     }
 
     subject = LegacyCommandMapper()
-    (result,) = subject.map_brokered_command(legacy_command, {}, {}, {})
+    (result,) = subject.map_brokered_command(legacy_command)
 
     assert result == pe_commands.Custom.construct(
         id="command.PAUSE-0",
@@ -51,8 +51,8 @@ def test_map_after_command() -> None:
 
     subject = LegacyCommandMapper()
 
-    _ = subject.map_brokered_command(legacy_command_start, {}, {}, {})
-    (result,) = subject.map_brokered_command(legacy_command_end, {}, {}, {})
+    _ = subject.map_brokered_command(legacy_command_start)
+    (result,) = subject.map_brokered_command(legacy_command_end)
 
     assert result == pe_commands.Custom.construct(
         id="command.PAUSE-0",
@@ -95,10 +95,10 @@ def test_command_stack() -> None:
     }
 
     subject = LegacyCommandMapper()
-    (result_1,) = subject.map_brokered_command(legacy_command_1, {}, {}, {})
-    (result_2,) = subject.map_brokered_command(legacy_command_2, {}, {}, {})
-    (result_3,) = subject.map_brokered_command(legacy_command_3, {}, {}, {})
-    (result_4,) = subject.map_brokered_command(legacy_command_4, {}, {}, {})
+    (result_1,) = subject.map_brokered_command(legacy_command_1)
+    (result_2,) = subject.map_brokered_command(legacy_command_2)
+    (result_3,) = subject.map_brokered_command(legacy_command_3)
+    (result_4,) = subject.map_brokered_command(legacy_command_4)
 
     assert result_1 == pe_commands.Custom.construct(
         id="command.PAUSE-0",

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -6,6 +6,7 @@ from opentrons.commands.types import PauseMessage
 from opentrons.protocol_engine import (
     CalibrationOffset,
     DeckSlotLocation,
+    PipetteName,
     commands as pe_commands,
 )
 from opentrons.protocol_runner.legacy_command_mapper import (
@@ -13,10 +14,11 @@ from opentrons.protocol_runner.legacy_command_mapper import (
     LegacyCommandData,
 )
 from opentrons.protocol_runner.legacy_wrappers import (
+    LegacyInstrumentLoadInfo,
     LegacyLabwareLoadInfo,
 )
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
-from opentrons.types import DeckSlotName
+from opentrons.types import DeckSlotName, Mount, MountType
 
 
 def test_map_before_command() -> None:
@@ -184,4 +186,26 @@ def test_map_labware_load(minimal_labware_def: LabwareDefinition) -> None:
     )
 
     output = LegacyCommandMapper().map_labware_load(input)
+    assert output[0] == expected_output
+
+
+def test_map_instrument_load() -> None:
+    """It should correctly map an instrument load."""
+    input = LegacyInstrumentLoadInfo(
+        instrument_load_name="p1000_single_gen2",
+        mount=Mount.LEFT,
+    )
+    expected_output = pe_commands.LoadPipette.construct(
+        id=matchers.IsA(str),
+        status=pe_commands.CommandStatus.SUCCEEDED,
+        createdAt=matchers.IsA(datetime),
+        startedAt=matchers.IsA(datetime),
+        completedAt=matchers.IsA(datetime),
+        data=pe_commands.LoadPipetteData.construct(
+            pipetteName=PipetteName.P1000_SINGLE_GEN2, mount=MountType.LEFT
+        ),
+        result=pe_commands.LoadPipetteResult.construct(pipetteId=matchers.IsA(str)),
+    )
+
+    output = LegacyCommandMapper().map_instrument_load(input)
     assert output[0] == expected_output

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -179,7 +179,8 @@ def test_map_labware_load(minimal_labware_def: LabwareDefinition) -> None:
         ),
         result=pe_commands.LoadLabwareResult.construct(
             labwareId=matchers.IsA(str),
-            # Trusting that the labware definition gets passed through corectly.
+            # Trusting that the exact fields within in the labware definition
+            # get passed through corectly.
             definition=matchers.Anything(),
             calibration=CalibrationOffset(x=0, y=0, z=0),
         ),

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -31,7 +31,7 @@ def test_map_before_command() -> None:
     }
 
     subject = LegacyCommandMapper()
-    (result,) = subject.map_command(legacy_command)
+    result = subject.map_command(legacy_command)
 
     assert result == pe_commands.Custom.construct(
         id="command.PAUSE-0",
@@ -63,7 +63,7 @@ def test_map_after_command() -> None:
     subject = LegacyCommandMapper()
 
     _ = subject.map_command(legacy_command_start)
-    (result,) = subject.map_command(legacy_command_end)
+    result = subject.map_command(legacy_command_end)
 
     assert result == pe_commands.Custom.construct(
         id="command.PAUSE-0",
@@ -106,10 +106,10 @@ def test_command_stack() -> None:
     }
 
     subject = LegacyCommandMapper()
-    (result_1,) = subject.map_command(legacy_command_1)
-    (result_2,) = subject.map_command(legacy_command_2)
-    (result_3,) = subject.map_command(legacy_command_3)
-    (result_4,) = subject.map_command(legacy_command_4)
+    result_1 = subject.map_command(legacy_command_1)
+    result_2 = subject.map_command(legacy_command_2)
+    result_3 = subject.map_command(legacy_command_3)
+    result_4 = subject.map_command(legacy_command_4)
 
     assert result_1 == pe_commands.Custom.construct(
         id="command.PAUSE-0",
@@ -187,7 +187,7 @@ def test_map_labware_load(minimal_labware_def: LabwareDefinition) -> None:
     )
 
     output = LegacyCommandMapper().map_labware_load(input)
-    assert output[0] == expected_output
+    assert output == expected_output
 
 
 def test_map_instrument_load() -> None:
@@ -209,4 +209,4 @@ def test_map_instrument_load() -> None:
     )
 
     output = LegacyCommandMapper().map_instrument_load(input)
-    assert output[0] == expected_output
+    assert output == expected_output

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -20,7 +20,7 @@ def test_map_before_command() -> None:
     }
 
     subject = LegacyCommandMapper()
-    (result,) = subject.map_brokered_command(legacy_command)
+    (result,) = subject.map_command(legacy_command)
 
     assert result == pe_commands.Custom.construct(
         id="command.PAUSE-0",
@@ -51,8 +51,8 @@ def test_map_after_command() -> None:
 
     subject = LegacyCommandMapper()
 
-    _ = subject.map_brokered_command(legacy_command_start)
-    (result,) = subject.map_brokered_command(legacy_command_end)
+    _ = subject.map_command(legacy_command_start)
+    (result,) = subject.map_command(legacy_command_end)
 
     assert result == pe_commands.Custom.construct(
         id="command.PAUSE-0",
@@ -95,10 +95,10 @@ def test_command_stack() -> None:
     }
 
     subject = LegacyCommandMapper()
-    (result_1,) = subject.map_brokered_command(legacy_command_1)
-    (result_2,) = subject.map_brokered_command(legacy_command_2)
-    (result_3,) = subject.map_brokered_command(legacy_command_3)
-    (result_4,) = subject.map_brokered_command(legacy_command_4)
+    (result_1,) = subject.map_command(legacy_command_1)
+    (result_2,) = subject.map_command(legacy_command_2)
+    (result_3,) = subject.map_command(legacy_command_3)
+    (result_4,) = subject.map_command(legacy_command_4)
 
     assert result_1 == pe_commands.Custom.construct(
         id="command.PAUSE-0",

--- a/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
@@ -157,7 +157,7 @@ def test_broker_messages(
     )
 
     decoy.when(legacy_command_mapper.map_command(command=legacy_command)).then_return(
-        [engine_command]
+        engine_command
     )
 
     handler(legacy_command)

--- a/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
@@ -17,6 +17,14 @@ from opentrons.protocol_runner.legacy_command_mapper import LegacyCommandMapper
 from opentrons.protocol_runner.legacy_context_plugin import LegacyContextPlugin
 from opentrons.protocol_runner.legacy_wrappers import (
     LegacyProtocolContext,
+    LegacyLabwareLoadInfo,
+    LegacyInstrumentLoadInfo,
+)
+
+from opentrons.types import DeckSlotName, Mount
+
+from opentrons_shared_data.labware.dev_types import (
+    LabwareDefinition as LabwareDefinitionDict,
 )
 
 
@@ -132,36 +140,101 @@ def test_broker_messages(
     legacy_command_mapper: LegacyCommandMapper,
     action_dispatcher: pe_actions.ActionDispatcher,
     subject: LegacyContextPlugin,
+    minimal_labware_def: LabwareDefinitionDict,
 ) -> None:
     """It should map broker messages to ProtocolEngine commands."""
     subject.handle_action(pe_actions.PlayAction())
 
-    handler_captor = matchers.Captor()
+    main_handler_captor = matchers.Captor()
+    load_labware_handler_captor = matchers.Captor()
+    load_instrument_handler_captor = matchers.Captor()
+
     decoy.verify(
-        legacy_context.broker.subscribe(topic="command", handler=handler_captor)
+        legacy_context.broker.subscribe(topic="command", handler=main_handler_captor)
+    )
+    decoy.verify(
+        legacy_context.labware_load_broker.subscribe(
+            callback=load_labware_handler_captor
+        )
+    )
+    decoy.verify(
+        legacy_context.instrument_load_broker.subscribe(
+            callback=load_instrument_handler_captor
+        )
     )
 
-    handler: Callable[[LegacyCommand], None] = handler_captor.value
+    main_handler: Callable[[LegacyCommand], None] = main_handler_captor.value
+    load_labware_handler: Callable[
+        [LegacyLabwareLoadInfo], None
+    ] = load_labware_handler_captor.value
+    load_instrument_handler: Callable[
+        [LegacyInstrumentLoadInfo], None
+    ] = load_instrument_handler_captor.value
 
-    legacy_command: PauseMessage = {
+    input_main_broker_command: PauseMessage = {
         "$": "before",
         "meta": {},
         "name": "command.PAUSE",
         "payload": {"userMessage": "hello world", "text": "hello world"},
     }
-    engine_command = pe_commands.Custom(
-        id="command-id",
+    input_load_labware_info = LegacyLabwareLoadInfo(
+        labware_definition=minimal_labware_def,
+        labware_namespace="some_namespace",
+        labware_load_name="some_load_name",
+        labware_version=123,
+        deck_slot=DeckSlotName.SLOT_1,
+    )
+    input_load_instrument_info = LegacyInstrumentLoadInfo(
+        instrument_load_name="some_load_name", mount=Mount.LEFT
+    )
+
+    dummy_main_command = pe_commands.Custom(
+        id="command-id-1",
+        status=pe_commands.CommandStatus.RUNNING,
+        createdAt=datetime(year=2021, month=1, day=1),
+        data=pe_commands.CustomData(message="hello world"),  # type: ignore[call-arg]
+    )
+    dummy_labware_command = pe_commands.Custom(
+        id="command-id-2",
+        status=pe_commands.CommandStatus.RUNNING,
+        createdAt=datetime(year=2021, month=1, day=1),
+        data=pe_commands.CustomData(message="hello world"),  # type: ignore[call-arg]
+    )
+    dummy_instrument_command = pe_commands.Custom(
+        id="command-id-3",
         status=pe_commands.CommandStatus.RUNNING,
         createdAt=datetime(year=2021, month=1, day=1),
         data=pe_commands.CustomData(message="hello world"),  # type: ignore[call-arg]
     )
 
-    decoy.when(legacy_command_mapper.map_command(command=legacy_command)).then_return(
-        engine_command
-    )
+    decoy.when(
+        legacy_command_mapper.map_command(command=input_main_broker_command)
+    ).then_return(dummy_main_command)
+    decoy.when(
+        legacy_command_mapper.map_labware_load(
+            labware_load_info=input_load_labware_info
+        )
+    ).then_return(dummy_labware_command)
+    decoy.when(
+        legacy_command_mapper.map_instrument_load(
+            instrument_load_info=input_load_instrument_info
+        )
+    ).then_return(dummy_instrument_command)
 
-    handler(legacy_command)
+    main_handler(input_main_broker_command)
+    load_labware_handler(input_load_labware_info)
+    load_instrument_handler(input_load_instrument_info)
 
     decoy.verify(
-        action_dispatcher.dispatch(pe_actions.UpdateCommandAction(engine_command))
+        action_dispatcher.dispatch(pe_actions.UpdateCommandAction(dummy_main_command))
+    )
+    decoy.verify(
+        action_dispatcher.dispatch(
+            pe_actions.UpdateCommandAction(dummy_labware_command)
+        )
+    )
+    decoy.verify(
+        action_dispatcher.dispatch(
+            pe_actions.UpdateCommandAction(dummy_instrument_command)
+        )
     )

--- a/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
@@ -17,9 +17,6 @@ from opentrons.protocol_runner.legacy_command_mapper import LegacyCommandMapper
 from opentrons.protocol_runner.legacy_context_plugin import LegacyContextPlugin
 from opentrons.protocol_runner.legacy_wrappers import (
     LegacyProtocolContext,
-    LegacyPipetteContext,
-    LegacyModuleContext,
-    LegacyLabware,
 )
 
 
@@ -149,21 +146,8 @@ def test_broker_messages(
         data=pe_commands.CustomData(message="hello world"),  # type: ignore[call-arg]
     )
 
-    pipette = decoy.mock(cls=LegacyPipetteContext)
-    module = decoy.mock(cls=LegacyModuleContext)
-    labware = decoy.mock(cls=LegacyLabware)
-
-    legacy_context.loaded_instruments = {"left": pipette}  # type: ignore[misc]
-    legacy_context.loaded_modules = {3: module}  # type: ignore[misc]
-    legacy_context.loaded_labwares = {5: labware}  # type: ignore[misc]
-
     decoy.when(
-        legacy_command_mapper.map_brokered_command(
-            command=legacy_command,
-            loaded_pipettes={"left": pipette},
-            loaded_modules={3: module},
-            loaded_labware={5: labware},
-        )
+        legacy_command_mapper.map_brokered_command(command=legacy_command)
     ).then_return([engine_command])
 
     handler(legacy_command)

--- a/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
@@ -156,9 +156,9 @@ def test_broker_messages(
         data=pe_commands.CustomData(message="hello world"),  # type: ignore[call-arg]
     )
 
-    decoy.when(
-        legacy_command_mapper.map_brokered_command(command=legacy_command)
-    ).then_return([engine_command])
+    decoy.when(legacy_command_mapper.map_command(command=legacy_command)).then_return(
+        [engine_command]
+    )
 
     handler(legacy_command)
 

--- a/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
@@ -158,7 +158,7 @@ def test_broker_messages(
     legacy_context.loaded_labwares = {5: labware}  # type: ignore[misc]
 
     decoy.when(
-        legacy_command_mapper.map(
+        legacy_command_mapper.map_brokered_command(
             command=legacy_command,
             loaded_pipettes={"left": pipette},
             loaded_modules={3: module},

--- a/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
@@ -111,11 +111,11 @@ def test_broker_subscribe_unsubscribe(
     ).then_return(main_unsubscribe)
 
     decoy.when(
-        legacy_context.labware_loaded_broker.subscribe(callback=matchers.Anything())
+        legacy_context.labware_load_broker.subscribe(callback=matchers.Anything())
     ).then_return(labware_unsubscribe)
 
     decoy.when(
-        legacy_context.instrument_loaded_broker.subscribe(callback=matchers.Anything())
+        legacy_context.instrument_load_broker.subscribe(callback=matchers.Anything())
     ).then_return(instrument_unsubscribe)
 
     subject.handle_action(pe_actions.PlayAction())

--- a/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
@@ -230,7 +230,9 @@ def test_instrument_load_broker_messages(
 
     handler_captor = matchers.Captor()
 
-    decoy.verify(legacy_context.instrument_load_broker.subscribe(callback=handler_captor))
+    decoy.verify(
+        legacy_context.instrument_load_broker.subscribe(callback=handler_captor)
+    )
 
     handler: Callable[[LegacyInstrumentLoadInfo], None] = handler_captor.value
 


### PR DESCRIPTION
# Overview

This PR follows up from #8402 with an incremental refactor.

# Changelog

* For simplicity, instead of diffing the lists of loaded labware and loaded pipettes, subscribe to labware load and pipette load events, and map them 1:1. This is as discussed in https://github.com/Opentrons/opentrons/pull/8402#issuecomment-930559780.
* Other minor refactors.

# Review requests

## Code review

* Given our uncertainty about how to test this, is it worth adding `LegacyContextPlugin` unit tests for labware loads and pipette loads, right now?
* I have left GitHub code review comments calling out the things I'm concerned about.

## Smoke test plan

Upload and run PAPIv2 or JSON Schema v4 or lower protocols, and verify:

* Commands are still mapped to naive `commandType: custom` wrappers
* Labware and pipette loads are still reflected
    * Labware and pipette loads should now be in the same order as they appeared in the protocol

# Risk assessment

No risk to production code *yet,* since this is behind a feature flag.

Some risk that this will break what was implemented in #8402.
