### PR TITLE
feat(can): raise error when an error frame is detected.

### DIFF
--- a/hardware/opentrons_hardware/drivers/can_bus/driver.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/driver.py
@@ -9,6 +9,8 @@ from can import Notifier, Bus, AsyncBufferedReader, Message, util
 
 from .arbitration_id import ArbitrationId
 from .message import CanMessage
+from .errors import ErrorFrameCanError
+
 
 if platform.system() == "Darwin":
     # TODO (amit, 2021-09-29): remove hacks to support `pcan` when we don't
@@ -112,9 +114,15 @@ class CanDriver:
 
         Returns:
             A can message
+
+        Raises:
+            ErrorFrameCanError
         """
         ...
         m: Message = await self._reader.get_message()
+        if m.is_error_frame:
+            raise ErrorFrameCanError(message=repr(m))
+
         return CanMessage(
             arbitration_id=ArbitrationId(id=m.arbitration_id), data=m.data
         )

--- a/hardware/opentrons_hardware/drivers/can_bus/errors.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/errors.py
@@ -1,0 +1,15 @@
+"""Can bus errors."""
+
+
+class CanError(Exception):
+    """Can bus error."""
+
+    def __init__(self, message: str) -> None:
+        """Constructor."""
+        super().__init__(message)
+
+
+class ErrorFrameCanError(CanError):
+    """An error frame was received on the can bus."""
+
+    pass


### PR DESCRIPTION
# Overview

We need to check for CAN bus error frames and raise an exception.

# Changelog

Raise an exception when the message is marked as error frame.

# Review requests

None

# Risk assessment

None