### PR TITLE
feat(app): add ids to elements labware setup section

### DIFF
--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/ExtraAttentionWarning.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/ExtraAttentionWarning.tsx
@@ -56,6 +56,7 @@ const ModuleWarning = (props: {
           a: (
             <Btn
               as={'span'}
+              id={`ExtraAttentionWarning_${snakeCase(moduleName)}_link`}
               alignSelf={ALIGN_FLEX_END}
               onClick={props.onLinkClick}
               textDecoration={TEXT_DECORATION_UNDERLINE}
@@ -96,7 +97,11 @@ export const ExtraAttentionWarning = (
             <Box size={SIZE_2} paddingY={SPACING_1} paddingRight={SPACING_2}>
               <Icon name="alert-circle" color={COLOR_WARNING} />
             </Box>
-            <Text as="h4" marginY={SPACING_2}>
+            <Text
+              as="h4"
+              marginY={SPACING_2}
+              id={`ExtraAttentionWarning_title`}
+            >
               {t('extra_attention_warning_title')}
             </Text>
           </Flex>


### PR DESCRIPTION
# Overview
This PR adds ids to elements in the labware setup section. I copied these from the ticket, some of them already had indentifiers:

- [ ] Labware Setup text — `id="RunSetupCard_labware_setup_step"`
- [ ] Some labware and modules require extra attention text — `id="ExtraAttentionWarning_title"`
- [ ]  Securing labware to the Magnetic Module — `id="ExtraAttentionWarning_magnetic_module_link"`
- [ ]  Securing labware to the Thermocycler —`id="ExtraAttentionWarning_thermocycler_link"`
- [ ] Labware help — `data-test="LabwareSetup_helpLink"`

closes #8447

# Changelog
- Add ids to elements in the labware setup section:

# Risk assessment
Low
