### PR TITLE
refactor(app): Remove slot number header from Thermocycler control

### DIFF
--- a/app/src/pages/Run/RunPanel/ModuleLiveStatusCards/StatusCard.tsx
+++ b/app/src/pages/Run/RunPanel/ModuleLiveStatusCards/StatusCard.tsx
@@ -4,7 +4,7 @@ import { CollapsibleItem } from '@opentrons/components'
 
 interface Props {
   /** Slot number the module is in */
-  header: string
+  header?: string
   /** Title for the card */
   title: string
   /** Card Content, each child will be separated with a grey bottom border */
@@ -20,7 +20,7 @@ export function StatusCard(props: Props): JSX.Element {
     <CollapsibleItem
       className={styles.status_card}
       onCollapseToggle={props.toggleCard}
-      header={`Slot ${props.header}`}
+      header={props.header && `Slot ${props.header}`}
       title={props.title}
       collapsed={!props.isCardExpanded}
     >

--- a/app/src/pages/Run/RunPanel/ModuleLiveStatusCards/ThermocyclerCard.tsx
+++ b/app/src/pages/Run/RunPanel/ModuleLiveStatusCards/ThermocyclerCard.tsx
@@ -127,7 +127,6 @@ export const ThermocyclerCard = ({
     currentStepIndex != null
   return (
     <StatusCard
-      header={slot}
       title={getModuleDisplayName(module.model)}
       isCardExpanded={isCardExpanded}
       toggleCard={toggleCard}

--- a/app/src/pages/Run/RunPanel/ModuleLiveStatusCards/__tests__/StatusCard.test.tsx
+++ b/app/src/pages/Run/RunPanel/ModuleLiveStatusCards/__tests__/StatusCard.test.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react'
+import { screen, render } from '@testing-library/react'
+import { StatusCard } from '../StatusCard'
+
+describe('StatusCard headers', () => {
+  it('should render StatusCard Header', () => {
+    render(
+      <StatusCard
+        header={'1'}
+        title={'Magnetic Module GEN 2'}
+        isCardExpanded={false}
+        toggleCard={jest.fn()}
+      />
+    )
+    expect(screen.getByText(/Slot/)).toBeInTheDocument()
+  })
+
+  it('should NOT render StatusCard header', () => {
+    render(
+      <StatusCard
+        title={'Thermocycler Module'}
+        isCardExpanded={false}
+        toggleCard={jest.fn()}
+      />
+    )
+    expect(screen.queryByText(/Slot/)).toBeNull()
+  })
+})


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Closes #8371
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

- Remove slot number header from Thermocycler control in the Run Panel
- Added `StatusCard.test.tsx` to test the header prop.

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

- [ ] When a Thermocycler module is in a protocol and attached to the robot, it should appear in the side of the Run Panel with no slot number in the header.
- [ ] Test coverage for the header prop

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

- Low, removes the presence of a string

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
