### PR TITLE
feat(ot3): OT3Controller backend for hardware controller

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -29,6 +29,7 @@ from .util import use_or_initialize_loop, DeckTransformState, check_motion_bound
 from .pipette import Pipette, generate_hardware_configs, load_from_config_and_check_skip
 from .controller import Controller
 from .simulator import Simulator
+from .ot3controller import OT3Controller
 from .constants import (
     SHAKE_OFF_TIPS_SPEED,
     SHAKE_OFF_TIPS_DROP_DISTANCE,
@@ -83,7 +84,7 @@ class API(HardwareAPILike):
 
     def __init__(
         self,
-        backend: Union[Controller, Simulator],
+        backend: Union[Controller, Simulator, OT3Controller],
         loop: asyncio.AbstractEventLoop,
         config: RobotConfig,
     ) -> None:

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -259,6 +259,21 @@ class API(HardwareAPILike):
         await backend.watch()
         return api_instance
 
+    @classmethod
+    async def build_ot3_controller(
+        cls,
+        attached_instruments: Dict[top_types.Mount, Dict[str, Optional[str]]] = None,
+        attached_modules: List[str] = None,
+        config: RobotConfig = None,
+        loop: asyncio.AbstractEventLoop = None,
+        strict_attached_instruments: bool = True,
+    ) -> "API":
+        """Build an ot3 hardware controller."""
+        checked_loop = use_or_initialize_loop(loop)
+        checked_config = config or robot_configs.load()
+        backend = await OT3Controller.build(checked_config)
+        return cls(backend, loop=checked_loop, config=checked_config)
+
     def __repr__(self):
         return "<{} using backend {}>".format(type(self), type(self._backend))
 

--- a/api/src/opentrons/hardware_control/ot3controller.py
+++ b/api/src/opentrons/hardware_control/ot3controller.py
@@ -1,0 +1,217 @@
+"""OT3 Hardware Controller Backend."""
+
+from __future__ import annotations
+import asyncio
+from contextlib import contextmanager
+import logging
+from typing import Dict, List, Optional, Tuple, TYPE_CHECKING, Sequence, Generator
+
+from opentrons.config.types import RobotConfig
+from opentrons.drivers.rpi_drivers.gpio_simulator import SimulatingGPIOCharDev
+from opentrons.types import Mount
+
+from .module_control import AttachedModulesControl
+from .types import BoardRevision, Axis
+
+if TYPE_CHECKING:
+    from opentrons_shared_data.pipette.dev_types import PipetteName
+    from .dev_types import (
+        AttachedInstruments,
+        InstrumentHardwareConfigs,
+    )
+    from opentrons.drivers.rpi_drivers.dev_types import GPIODriverLike
+
+log = logging.getLogger(__name__)
+
+
+AxisValueMap = Dict[str, float]
+
+
+class OT3Controller:
+    """OT3 Hardware Controller Backend."""
+
+    @classmethod
+    async def build(cls, config: RobotConfig) -> OT3Controller:
+        """Create the OT3Controller instance.
+
+        Args:
+            config: Robot configuration
+
+        Returns:
+            Instance.
+        """
+        return cls(config)
+
+    def __init__(self, config: RobotConfig) -> None:
+        """Construct.
+
+        Args:
+            config: Robot configuration
+        """
+        self._configuration = config
+        self._gpio_dev = SimulatingGPIOCharDev("simulated")
+        self._module_controls: Optional[AttachedModulesControl] = None
+
+    @property
+    def gpio_chardev(self) -> GPIODriverLike:
+        """Get the GPIO device."""
+        return self._gpio_dev
+
+    @property
+    def board_revision(self) -> BoardRevision:
+        """Get the board revision"""
+        return BoardRevision.UNKNOWN
+
+    @property
+    def module_controls(self) -> AttachedModulesControl:
+        """Get the module controls."""
+        if self._module_controls is None:
+            raise AttributeError("Module controls not found.")
+        return self._module_controls
+
+    @module_controls.setter
+    def module_controls(self, module_controls: AttachedModulesControl) -> None:
+        """Set the module controls"""
+        self._module_controls = module_controls
+
+    async def update_position(self) -> AxisValueMap:
+        """Get the current position."""
+        return {}
+
+    async def move(
+        self,
+        target_position: AxisValueMap,
+        home_flagged_axes: bool = True,
+        speed: Optional[float] = None,
+        axis_max_speeds: Optional[AxisValueMap] = None,
+    ) -> None:
+        """Move to a position.
+
+        Args:
+            target_position: Map of axis to position.
+            home_flagged_axes: Whether to home afterwords.
+            speed: Optional speed
+            axis_max_speeds: Optional map of axis to speed.
+
+        Returns:
+            None
+        """
+        return None
+
+    async def home(self, axes: Optional[List[str]] = None) -> AxisValueMap:
+        """Home axes.
+
+        Args:
+            axes: Optional list of axes.
+
+        Returns:
+            Homed position.
+        """
+        return {}
+
+    async def fast_home(self, axes: Sequence[str], margin: float) -> AxisValueMap:
+        """Fast home axes.
+
+        Args:
+            axes: List of axes to home.
+            margin: Margin
+
+        Returns:
+            New position.
+        """
+        return {}
+
+    async def get_attached_instruments(
+        self, expected: Dict[Mount, PipetteName]
+    ) -> AttachedInstruments:
+        """Get attached instruments.
+
+        Args:
+            expected: Which mounts are expected.
+
+        Returns:
+            A map of mount to pipette name.
+        """
+        return {}
+
+    def set_active_current(self, axis_currents: Dict[Axis, float]) -> None:
+        """Set the active current.
+
+        Args:
+            axis_currents: Axes' currents
+
+        Returns:
+            None
+        """
+        return None
+
+    @contextmanager
+    def save_current(self) -> Generator[None, None, None]:
+        """Save the current."""
+        yield
+
+    async def watch(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Watch hardware events."""
+        return None
+
+    @property
+    def axis_bounds(self) -> Dict[Axis, Tuple[float, float]]:
+        """Get the axis bounds."""
+        return {}
+
+    @property
+    def fw_version(self) -> Optional[str]:
+        """Get the firmware version."""
+        return None
+
+    async def update_firmware(
+        self, filename: str, loop: asyncio.AbstractEventLoop, modeset: bool
+    ) -> str:
+        """Update the firmware."""
+        return "Done"
+
+    def engaged_axes(self) -> Dict[str, bool]:
+        """Get engaged axes."""
+        return {}
+
+    async def disengage_axes(self, axes: List[str]) -> None:
+        """Disengage axes."""
+        return None
+
+    def set_lights(self, button: Optional[bool], rails: Optional[bool]) -> None:
+        """Set the light states."""
+        return None
+
+    def get_lights(self) -> Dict[str, bool]:
+        """Get the light state."""
+        return {}
+
+    def pause(self) -> None:
+        """Pause the controller activity."""
+        return None
+
+    def resume(self) -> None:
+        """Resume the controller activity."""
+        return None
+
+    async def halt(self) -> None:
+        """Halt the motors."""
+        return None
+
+    async def hard_halt(self) -> None:
+        """Halt the motors."""
+        return None
+
+    async def probe(self, axis: str, distance: float) -> AxisValueMap:
+        """Probe."""
+        return {}
+
+    def clean_up(self) -> None:
+        """Clean up."""
+        return None
+
+    async def configure_mount(
+        self, mount: Mount, config: InstrumentHardwareConfigs
+    ) -> None:
+        """Configure a mount."""
+        return None

--- a/api/src/opentrons/tools/args_handler.py
+++ b/api/src/opentrons/tools/args_handler.py
@@ -1,7 +1,7 @@
 import argparse
 from typing import Tuple, cast
 
-from opentrons.hardware_control import API
+from opentrons.hardware_control import API, Controller
 from opentrons.drivers.smoothie_drivers import SmoothieDriver
 
 
@@ -15,5 +15,5 @@ def root_argparser(description: str = None):
 
 async def build_driver(port: str = None) -> Tuple[API, SmoothieDriver]:
     hardware = await API.build_hardware_controller(port=port)
-    driver = cast(SmoothieDriver, hardware._backend._smoothie_driver)
-    return hardware, driver
+    backend: Controller = cast(Controller, hardware._backend)
+    return hardware, backend._smoothie_driver


### PR DESCRIPTION
# Overview

This adds a `OT3Controller` class which acts as an alternative backend for the `API` class.

# Changelog

- Created `OT3Controller` class. it defines the minimal interface to be a backend for `API`. All the methods are no-ops.
- Add `API.build_ot3controller` method to create an `API` with `OT3Controller` backend.

# Review requests

The real plan is to move hardware control into a separate process in the `opentrons_hardware` package. This class allows us to build robot-server -> ot3 integration without waiting on a hardware control daemon.

# Risk assessment

None