### PR TITLE
feat(app): add dynamic section + labware highlighting to LPC intro screen

### DIFF
--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/DeckMap.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/DeckMap.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react'
+import map from 'lodash/map'
+
+import { LabwareRender, Module, RobotWorkSpace } from '@opentrons/components'
+import {
+  THERMOCYCLER_MODULE_V1,
+  inferModuleOrientationFromXCoordinate,
+} from '@opentrons/shared-data'
+import standardDeckDef from '@opentrons/shared-data/deck/definitions/2/ot2_standard.json'
+import { useModuleRenderInfoById, useLabwareRenderInfoById } from '../hooks'
+
+import styles from '../styles.css'
+
+const DECK_MAP_VIEWBOX = '-80 -100 550 560'
+const DECK_LAYER_BLOCKLIST = [
+  'calibrationMarkings',
+  'fixedBase',
+  'doorStops',
+  'metalFrame',
+  'removalHandle',
+  'removableDeckOutline',
+  'screwHoles',
+]
+
+export const DeckMap = (): JSX.Element => {
+  const moduleRenderInfoById = useModuleRenderInfoById()
+  const labwareRenderInfoById = useLabwareRenderInfoById()
+  return (
+    <RobotWorkSpace
+      deckDef={standardDeckDef as any}
+      viewBox={DECK_MAP_VIEWBOX}
+      className={styles.deck_map}
+      deckLayerBlocklist={DECK_LAYER_BLOCKLIST}
+      id={'LabwarePositionCheck_deckMap'}
+    >
+      {() => {
+        return (
+          <React.Fragment>
+            {map(
+              moduleRenderInfoById,
+              ({ x, y, moduleDef, nestedLabwareDef }) => (
+                <Module
+                  key={`LabwarePositionCheck_Module_${moduleDef.model}_${x}${y}`}
+                  x={x}
+                  y={y}
+                  orientation={inferModuleOrientationFromXCoordinate(x)}
+                  def={moduleDef}
+                  innerProps={
+                    moduleDef.model === THERMOCYCLER_MODULE_V1
+                      ? { lidMotorState: 'open' }
+                      : {}
+                  }
+                >
+                  {nestedLabwareDef != null ? (
+                    <React.Fragment
+                      key={`LabwarePositionCheck_Labware_${nestedLabwareDef.metadata.displayName}_${x}${y}`}
+                    >
+                      <LabwareRender definition={nestedLabwareDef} />
+                    </React.Fragment>
+                  ) : null}
+                </Module>
+              )
+            )}
+
+            {map(labwareRenderInfoById, ({ x, y, labwareDef }) => {
+              return (
+                <React.Fragment
+                  key={`LabwarePositionCheck_Labware_${labwareDef.metadata.displayName}_${x}${y}`}
+                >
+                  <g transform={`translate(${x},${y})`}>
+                    <LabwareRender definition={labwareDef} />
+                  </g>
+                </React.Fragment>
+              )
+            })}
+          </React.Fragment>
+        )
+      }}
+    </RobotWorkSpace>
+  )
+}

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/DeckMap.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/DeckMap.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react'
 import map from 'lodash/map'
-
-import { LabwareRender, Module, RobotWorkSpace } from '@opentrons/components'
+import {
+  LabwareRender,
+  Module,
+  RobotWorkSpace,
+  C_SELECTED_DARK,
+} from '@opentrons/components'
 import {
   THERMOCYCLER_MODULE_V1,
   inferModuleOrientationFromXCoordinate,
@@ -22,7 +26,12 @@ const DECK_LAYER_BLOCKLIST = [
   'screwHoles',
 ]
 
-export const DeckMap = (): JSX.Element => {
+interface DeckMapProps {
+  labwareIdsToHighlight?: string[]
+}
+
+export const DeckMap = (props: DeckMapProps): JSX.Element => {
+  const { labwareIdsToHighlight } = props
   const moduleRenderInfoById = useModuleRenderInfoById()
   const labwareRenderInfoById = useLabwareRenderInfoById()
   return (
@@ -38,7 +47,7 @@ export const DeckMap = (): JSX.Element => {
           <React.Fragment>
             {map(
               moduleRenderInfoById,
-              ({ x, y, moduleDef, nestedLabwareDef }) => (
+              ({ x, y, moduleDef, nestedLabwareDef, nestedLabwareId }) => (
                 <Module
                   key={`LabwarePositionCheck_Module_${moduleDef.model}_${x}${y}`}
                   x={x}
@@ -56,19 +65,41 @@ export const DeckMap = (): JSX.Element => {
                       key={`LabwarePositionCheck_Labware_${nestedLabwareDef.metadata.displayName}_${x}${y}`}
                     >
                       <LabwareRender definition={nestedLabwareDef} />
+                      {nestedLabwareId != null &&
+                        labwareIdsToHighlight?.includes(nestedLabwareId) ===
+                          true && (
+                          <rect
+                            width={nestedLabwareDef.dimensions.xDimension - 2}
+                            height={nestedLabwareDef.dimensions.yDimension - 2}
+                            fill={'none'}
+                            stroke={C_SELECTED_DARK}
+                            strokeWidth={'3px'}
+                            data-testid={`DeckMap_module_${nestedLabwareId}_highlight`}
+                          />
+                        )}
                     </React.Fragment>
                   ) : null}
                 </Module>
               )
             )}
 
-            {map(labwareRenderInfoById, ({ x, y, labwareDef }) => {
+            {map(labwareRenderInfoById, ({ x, y, labwareDef }, labwareId) => {
               return (
                 <React.Fragment
                   key={`LabwarePositionCheck_Labware_${labwareDef.metadata.displayName}_${x}${y}`}
                 >
                   <g transform={`translate(${x},${y})`}>
                     <LabwareRender definition={labwareDef} />
+                    {labwareIdsToHighlight?.includes(labwareId) === true && (
+                      <rect
+                        width={labwareDef.dimensions.xDimension - 2}
+                        height={labwareDef.dimensions.yDimension - 2}
+                        fill={'none'}
+                        stroke={C_SELECTED_DARK}
+                        strokeWidth={'3px'}
+                        data-testid={`DeckMap_${labwareId}_highlight`}
+                      />
+                    )}
                   </g>
                 </React.Fragment>
               )

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/IntroScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/IntroScreen.tsx
@@ -21,7 +21,7 @@ import { PositionCheckNav } from './PositionCheckNav'
 import { DeckMap } from './DeckMap'
 import { useIntroInfo, useLabwareIdsBySection } from './hooks'
 
-const INTERVAL_MS = 3000
+export const INTERVAL_MS = 3000
 
 export const IntroScreen = (props: {
   setCurrentLabwareCheckStep: (stepNumber: number) => void

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/IntroScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/IntroScreen.tsx
@@ -5,6 +5,7 @@ import {
   Text,
   Flex,
   Box,
+  useInterval,
   TEXT_TRANSFORM_UPPERCASE,
   FONT_WEIGHT_SEMIBOLD,
   JUSTIFY_SPACE_BETWEEN,
@@ -18,13 +19,21 @@ import {
 } from '@opentrons/components'
 import { PositionCheckNav } from './PositionCheckNav'
 import { DeckMap } from './DeckMap'
-import { useIntroInfo } from './hooks'
+import { useIntroInfo, useLabwareIdsBySection } from './hooks'
+
+const INTERVAL_MS = 3000
 
 export const IntroScreen = (props: {
   setCurrentLabwareCheckStep: (stepNumber: number) => void
 }): JSX.Element | null => {
   const introInfo = useIntroInfo()
+  const labwareIdsBySection = useLabwareIdsBySection()
   const { t } = useTranslation(['labware_position_check', 'shared'])
+
+  const [sectionIndex, setSectionIndex] = React.useState<number>(0)
+  const rotateSectionIndex = (): void =>
+    setSectionIndex((sectionIndex + 1) % sections.length)
+  useInterval(rotateSectionIndex, INTERVAL_MS)
 
   if (introInfo == null) return null
   const {
@@ -33,6 +42,9 @@ export const IntroScreen = (props: {
     firstStepLabwareSlot,
     sections,
   } = introInfo
+
+  const currentSection = sections[sectionIndex]
+  const labwareIdsToHighlight = labwareIdsBySection[currentSection]
 
   return (
     <Box margin={SPACING_3}>
@@ -53,11 +65,12 @@ export const IntroScreen = (props: {
       <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} alignItems={ALIGN_CENTER}>
         <PositionCheckNav
           sections={sections}
+          currentSection={currentSection}
           primaryPipetteMount={primaryPipetteMount}
           secondaryPipetteMount={secondaryPipetteMount}
         />
         <Box width="60%" padding={SPACING_3}>
-          <DeckMap />
+          <DeckMap labwareIdsToHighlight={labwareIdsToHighlight} />
         </Box>
       </Flex>
       <Flex justifyContent={JUSTIFY_CENTER} marginBottom={SPACING_4}>

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/IntroScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/IntroScreen.tsx
@@ -1,11 +1,6 @@
 import * as React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
-import map from 'lodash/map'
-
 import {
-  LabwareRender,
-  Module,
-  RobotWorkSpace,
   PrimaryBtn,
   Text,
   Flex,
@@ -21,35 +16,14 @@ import {
   SPACING_4,
   FONT_SIZE_BODY_2,
 } from '@opentrons/components'
-import {
-  THERMOCYCLER_MODULE_V1,
-  inferModuleOrientationFromXCoordinate,
-} from '@opentrons/shared-data'
-import standardDeckDef from '@opentrons/shared-data/deck/definitions/2/ot2_standard.json'
-import { useModuleRenderInfoById, useLabwareRenderInfoById } from '../hooks'
 import { PositionCheckNav } from './PositionCheckNav'
+import { DeckMap } from './DeckMap'
 import { useIntroInfo } from './hooks'
-
-import styles from '../styles.css'
-
-const DECK_LAYER_BLOCKLIST = [
-  'calibrationMarkings',
-  'fixedBase',
-  'doorStops',
-  'metalFrame',
-  'removalHandle',
-  'removableDeckOutline',
-  'screwHoles',
-]
-
-const DECK_MAP_VIEWBOX = '-80 -100 570 540'
 
 export const IntroScreen = (props: {
   setCurrentLabwareCheckStep: (stepNumber: number) => void
 }): JSX.Element | null => {
   const introInfo = useIntroInfo()
-  const moduleRenderInfoById = useModuleRenderInfoById()
-  const labwareRenderInfoById = useLabwareRenderInfoById()
   const { t } = useTranslation(['labware_position_check', 'shared'])
 
   if (introInfo == null) return null
@@ -82,58 +56,8 @@ export const IntroScreen = (props: {
           primaryPipetteMount={primaryPipetteMount}
           secondaryPipetteMount={secondaryPipetteMount}
         />
-        <Box width="60%" paddingTop={SPACING_3}>
-          <RobotWorkSpace
-            deckDef={standardDeckDef as any}
-            viewBox={DECK_MAP_VIEWBOX}
-            className={styles.deck_map}
-            deckLayerBlocklist={DECK_LAYER_BLOCKLIST}
-            id={'LabwarePositionCheck_deckMap'}
-          >
-            {() => {
-              return (
-                <React.Fragment>
-                  {map(
-                    moduleRenderInfoById,
-                    ({ x, y, moduleDef, nestedLabwareDef }) => (
-                      <Module
-                        key={`LabwarePositionCheck_Module_${moduleDef.model}_${x}${y}`}
-                        x={x}
-                        y={y}
-                        orientation={inferModuleOrientationFromXCoordinate(x)}
-                        def={moduleDef}
-                        innerProps={
-                          moduleDef.model === THERMOCYCLER_MODULE_V1
-                            ? { lidMotorState: 'open' }
-                            : {}
-                        }
-                      >
-                        {nestedLabwareDef != null ? (
-                          <React.Fragment
-                            key={`LabwarePositionCheck_Labware_${nestedLabwareDef.metadata.displayName}_${x}${y}`}
-                          >
-                            <LabwareRender definition={nestedLabwareDef} />
-                          </React.Fragment>
-                        ) : null}
-                      </Module>
-                    )
-                  )}
-
-                  {map(labwareRenderInfoById, ({ x, y, labwareDef }) => {
-                    return (
-                      <React.Fragment
-                        key={`LabwarePositionCheck_Labware_${labwareDef.metadata.displayName}_${x}${y}`}
-                      >
-                        <g transform={`translate(${x},${y})`}>
-                          <LabwareRender definition={labwareDef} />
-                        </g>
-                      </React.Fragment>
-                    )
-                  })}
-                </React.Fragment>
-              )
-            }}
-          </RobotWorkSpace>
+        <Box width="60%" padding={SPACING_3}>
+          <DeckMap />
         </Box>
       </Flex>
       <Flex justifyContent={JUSTIFY_CENTER} marginBottom={SPACING_4}>

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/PositionCheckNav.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/PositionCheckNav.tsx
@@ -14,26 +14,24 @@ import {
   C_DARK_GRAY,
   TEXT_ALIGN_CENTER,
   FONT_SIZE_CAPTION,
-  useInterval,
   Text,
 } from '@opentrons/components'
 import type { Section } from './types'
-
-const INTERVAL_MS = 3000
 interface Props {
   sections: Section[]
+  currentSection: Section
   primaryPipetteMount: string
   secondaryPipetteMount: string
 }
 
 export function PositionCheckNav(props: Props): JSX.Element {
-  const { sections, primaryPipetteMount, secondaryPipetteMount } = props
+  const {
+    currentSection,
+    sections,
+    primaryPipetteMount,
+    secondaryPipetteMount,
+  } = props
   const { t } = useTranslation('labware_position_check')
-  const [sectionIndex, setSectionIndex] = React.useState<number>(0)
-  const rotateSectionIndex = (): void =>
-    setSectionIndex((sectionIndex + 1) % sections.length)
-  useInterval(rotateSectionIndex, INTERVAL_MS)
-  const currentSection = sections[sectionIndex]
 
   return (
     <Box

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/PositionCheckNav.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/PositionCheckNav.tsx
@@ -14,10 +14,13 @@ import {
   C_DARK_GRAY,
   TEXT_ALIGN_CENTER,
   FONT_SIZE_CAPTION,
+  useInterval,
+  Text,
 } from '@opentrons/components'
-
+import { useLabwareIdsBySection } from './hooks'
 import type { Section } from './types'
 
+const INTERVAL_MS = 3000
 interface Props {
   sections: Section[]
   primaryPipetteMount: string
@@ -27,6 +30,10 @@ interface Props {
 export function PositionCheckNav(props: Props): JSX.Element {
   const { sections, primaryPipetteMount, secondaryPipetteMount } = props
   const { t } = useTranslation('labware_position_check')
+  const labwareIdsBySection = useLabwareIdsBySection()
+  useInterval(() => sectionsByLabwareId[0], INTERVAL_MS, true)
+  const sectionsByLabwareId = Object.keys(labwareIdsBySection)
+
   return (
     <Box
       fontSize={FONT_SIZE_CAPTION}
@@ -43,7 +50,9 @@ export function PositionCheckNav(props: Props): JSX.Element {
             width={SIZE_1}
             height={SIZE_1}
             lineHeight={SIZE_1}
-            backgroundColor={C_DARK_GRAY}
+            backgroundColor={
+              section === sectionsByLabwareId[0] ? '#00c3e6' : C_DARK_GRAY
+            }
             color={C_WHITE}
             borderRadius="50%"
             marginRight={SPACING_2}
@@ -52,10 +61,16 @@ export function PositionCheckNav(props: Props): JSX.Element {
             {index + 1}
           </Box>
           <Box maxWidth="85%">
-            {t(`${section.toLowerCase()}_section`, {
-              primary_mount: capitalize(primaryPipetteMount),
-              secondary_mount: capitalize(secondaryPipetteMount),
-            })}
+            <Text
+              color={
+                section === sectionsByLabwareId[0] ? '#00c3e6' : C_DARK_GRAY
+              }
+            >
+              {t(`${section.toLowerCase()}_section`, {
+                primary_mount: capitalize(primaryPipetteMount),
+                secondary_mount: capitalize(secondaryPipetteMount),
+              })}
+            </Text>
           </Box>
         </Flex>
       ))}

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/PositionCheckNav.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/PositionCheckNav.tsx
@@ -17,7 +17,6 @@ import {
   useInterval,
   Text,
 } from '@opentrons/components'
-import { useLabwareIdsBySection } from './hooks'
 import type { Section } from './types'
 
 const INTERVAL_MS = 3000
@@ -30,9 +29,10 @@ interface Props {
 export function PositionCheckNav(props: Props): JSX.Element {
   const { sections, primaryPipetteMount, secondaryPipetteMount } = props
   const { t } = useTranslation('labware_position_check')
-  const labwareIdsBySection = useLabwareIdsBySection()
-  useInterval(() => sectionsByLabwareId[0], INTERVAL_MS, true)
-  const sectionsByLabwareId = Object.keys(labwareIdsBySection)
+  const [sectionIndex, setSectionIndex] = React.useState<number>(0) 
+  const rotateSectionIndex = () => setSectionIndex((sectionIndex+1) % sections.length) 
+  useInterval(rotateSectionIndex, INTERVAL_MS, true)
+  const currentSection = sections[sectionIndex]
 
   return (
     <Box
@@ -51,7 +51,7 @@ export function PositionCheckNav(props: Props): JSX.Element {
             height={SIZE_1}
             lineHeight={SIZE_1}
             backgroundColor={
-              section === sectionsByLabwareId[0] ? '#00c3e6' : C_DARK_GRAY
+              section === currentSection ? '#00c3e6' : C_DARK_GRAY
             }
             color={C_WHITE}
             borderRadius="50%"
@@ -63,7 +63,7 @@ export function PositionCheckNav(props: Props): JSX.Element {
           <Box maxWidth="85%">
             <Text
               color={
-                section === sectionsByLabwareId[0] ? '#00c3e6' : C_DARK_GRAY
+                section === currentSection ? '#00c3e6' : C_DARK_GRAY
               }
             >
               {t(`${section.toLowerCase()}_section`, {

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/PositionCheckNav.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/PositionCheckNav.tsx
@@ -29,9 +29,10 @@ interface Props {
 export function PositionCheckNav(props: Props): JSX.Element {
   const { sections, primaryPipetteMount, secondaryPipetteMount } = props
   const { t } = useTranslation('labware_position_check')
-  const [sectionIndex, setSectionIndex] = React.useState<number>(0) 
-  const rotateSectionIndex = () => setSectionIndex((sectionIndex+1) % sections.length) 
-  useInterval(rotateSectionIndex, INTERVAL_MS, true)
+  const [sectionIndex, setSectionIndex] = React.useState<number>(0)
+  const rotateSectionIndex = (): void =>
+    setSectionIndex((sectionIndex + 1) % sections.length)
+  useInterval(rotateSectionIndex, INTERVAL_MS)
   const currentSection = sections[sectionIndex]
 
   return (
@@ -61,11 +62,7 @@ export function PositionCheckNav(props: Props): JSX.Element {
             {index + 1}
           </Box>
           <Box maxWidth="85%">
-            <Text
-              color={
-                section === currentSection ? '#00c3e6' : C_DARK_GRAY
-              }
-            >
+            <Text color={section === currentSection ? '#00c3e6' : C_DARK_GRAY}>
               {t(`${section.toLowerCase()}_section`, {
                 primary_mount: capitalize(primaryPipetteMount),
                 secondary_mount: capitalize(secondaryPipetteMount),

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/DeckMap.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/DeckMap.test.tsx
@@ -1,0 +1,155 @@
+import * as React from 'react'
+import { when, resetAllWhenMocks } from 'jest-when'
+import { render } from '@testing-library/react'
+import {
+  LabwareRender,
+  Module,
+  RobotWorkSpace,
+  componentPropsMatcher,
+  partialComponentPropsMatcher,
+} from '@opentrons/components'
+import {
+  inferModuleOrientationFromXCoordinate,
+  LabwareDefinition2,
+  ModuleModel,
+  ModuleType,
+} from '@opentrons/shared-data'
+import fixture_tiprack_300_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_300_ul.json'
+import standardDeckDef from '@opentrons/shared-data/deck/definitions/2/ot2_standard.json'
+import { useLabwareRenderInfoById, useModuleRenderInfoById } from '../../hooks'
+import { DeckMap } from '../DeckMap'
+
+jest.mock('../../hooks')
+jest.mock('@opentrons/components', () => {
+  const actualComponents = jest.requireActual('@opentrons/components')
+  return {
+    ...actualComponents,
+    Module: jest.fn(() => <div>mock Module</div>),
+    RobotWorkSpace: jest.fn(() => <div>mock RobotWorkSpace</div>),
+    LabwareRender: jest.fn(() => <div>mock LabwareRender</div>),
+  }
+})
+jest.mock('@opentrons/shared-data', () => {
+  const actualSharedData = jest.requireActual('@opentrons/shared-data')
+  return {
+    ...actualSharedData,
+    inferModuleOrientationFromXCoordinate: jest.fn(),
+  }
+})
+
+const STUBBED_ORIENTATION_VALUE = 'left'
+const MOCK_MAGNETIC_MODULE_COORDS = [10, 20, 0]
+const MOCK_300_UL_TIPRACK_COORDS = [30, 40, 0]
+const mockMagneticModule = {
+  labwareOffset: { x: 5, y: 5, z: 5 },
+  moduleId: 'someMagneticModule',
+  model: 'magneticModuleV2' as ModuleModel,
+  type: 'magneticModuleType' as ModuleType,
+}
+const LABWARE_ID_TO_HIGHLIGHT = 'LABWARE_ID_TO_HIGHLIGHT'
+const ANOTHER_LABWARE_ID_TO_HIGHLIGHT = 'ANOTHER_LABWARE_ID_TO_HIGHLIGHT'
+
+const mockModule = Module as jest.MockedFunction<typeof Module>
+const mockRobotWorkSpace = RobotWorkSpace as jest.MockedFunction<
+  typeof RobotWorkSpace
+>
+const mockLabwareRender = LabwareRender as jest.MockedFunction<
+  typeof LabwareRender
+>
+const mockUseLabwareRenderInfoById = useLabwareRenderInfoById as jest.MockedFunction<
+  typeof useLabwareRenderInfoById
+>
+const mockUseModuleRenderInfoById = useModuleRenderInfoById as jest.MockedFunction<
+  typeof useModuleRenderInfoById
+>
+
+const mockInferModuleOrientationFromXCoordinate = inferModuleOrientationFromXCoordinate as jest.MockedFunction<
+  typeof inferModuleOrientationFromXCoordinate
+>
+
+describe('LPC DeckMap', () => {
+  beforeEach(() => {
+    when(mockRobotWorkSpace)
+      .mockReturnValue(<div></div>) // this (default) empty div will be returned when RobotWorkSpace isn't called with expected props
+      .calledWith(
+        partialComponentPropsMatcher({
+          deckDef: standardDeckDef,
+          children: expect.anything(),
+        })
+      )
+      .mockImplementation(({ children }) => (
+        <svg>
+          {/* @ts-expect-error children won't be null since we checked for expect.anything() above */}
+          {children()}
+        </svg>
+      ))
+
+    when(mockLabwareRender)
+      .mockReturnValue(<div></div>)
+      .calledWith(
+        componentPropsMatcher({
+          definition: fixture_tiprack_300_ul,
+        })
+      )
+      .mockReturnValue(
+        <div>
+          mock labware render of {fixture_tiprack_300_ul.metadata.displayName}
+        </div>
+      )
+
+    when(mockModule)
+      .calledWith(
+        partialComponentPropsMatcher({
+          def: mockMagneticModule,
+          x: MOCK_MAGNETIC_MODULE_COORDS[0],
+          y: MOCK_MAGNETIC_MODULE_COORDS[1],
+        })
+      )
+      .mockImplementation(({ children }) => (
+        <div>mock module with children {children}</div>
+      ))
+
+    when(mockInferModuleOrientationFromXCoordinate)
+      .calledWith(expect.anything())
+      .mockReturnValue(STUBBED_ORIENTATION_VALUE)
+
+    when(mockUseLabwareRenderInfoById)
+      .calledWith()
+      .mockReturnValue({
+        [LABWARE_ID_TO_HIGHLIGHT]: {
+          labwareDef: fixture_tiprack_300_ul as LabwareDefinition2,
+          x: MOCK_300_UL_TIPRACK_COORDS[0],
+          y: MOCK_300_UL_TIPRACK_COORDS[1],
+          z: MOCK_300_UL_TIPRACK_COORDS[2],
+        },
+      })
+
+    when(mockUseModuleRenderInfoById)
+      .calledWith()
+      .mockReturnValue({
+        [mockMagneticModule.moduleId]: {
+          x: MOCK_MAGNETIC_MODULE_COORDS[0],
+          y: MOCK_MAGNETIC_MODULE_COORDS[1],
+          z: MOCK_MAGNETIC_MODULE_COORDS[2],
+          moduleDef: mockMagneticModule as any,
+          nestedLabwareDef: fixture_tiprack_300_ul as LabwareDefinition2,
+          nestedLabwareId: ANOTHER_LABWARE_ID_TO_HIGHLIGHT,
+        },
+      })
+  })
+  afterEach(() => {
+    resetAllWhenMocks()
+  })
+  it('should render a deckmap with labware highlighted', () => {
+    const { getByTestId } = render(
+      <DeckMap
+        labwareIdsToHighlight={[
+          LABWARE_ID_TO_HIGHLIGHT,
+          ANOTHER_LABWARE_ID_TO_HIGHLIGHT,
+        ]}
+      />
+    )
+    getByTestId(`DeckMap_${LABWARE_ID_TO_HIGHLIGHT}_highlight`)
+    getByTestId(`DeckMap_module_${ANOTHER_LABWARE_ID_TO_HIGHLIGHT}_highlight`)
+  })
+})

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/GenericStepScreen.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/GenericStepScreen.test.tsx
@@ -3,7 +3,7 @@ import { when } from 'jest-when'
 import {
   partialComponentPropsMatcher,
   renderWithProviders,
-} from '@opentrons/components/src/testing/utils'
+} from '@opentrons/components'
 import { i18n } from '../../../../i18n'
 import { GenericStepScreen } from '../GenericStepScreen'
 import { LabwarePositionCheckStepDetail } from '../LabwarePositionCheckStepDetail'

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/IntroScreen.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/IntroScreen.test.tsx
@@ -11,7 +11,7 @@ import { LabwareDefinition2 } from '@opentrons/shared-data'
 import fixture_tiprack_300_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_300_ul.json'
 import { useModuleRenderInfoById, useLabwareRenderInfoById } from '../../hooks'
 import { PositionCheckNav } from '../PositionCheckNav'
-import { useIntroInfo } from '../hooks'
+import { useIntroInfo, useLabwareIdsBySection } from '../hooks'
 import { IntroScreen } from '../IntroScreen'
 import type { Section } from '../types'
 import { fireEvent } from '@testing-library/dom'
@@ -32,6 +32,9 @@ const mockUseModuleRenderInfoById = useModuleRenderInfoById as jest.MockedFuncti
 >
 const mockUseLabwareRenderInfoById = useLabwareRenderInfoById as jest.MockedFunction<
   typeof useLabwareRenderInfoById
+>
+const mockUseLabwareIdsBySection = useLabwareIdsBySection as jest.MockedFunction<
+  typeof useLabwareIdsBySection
 >
 const mockUseIntroInfo = useIntroInfo as jest.MockedFunction<
   typeof useIntroInfo
@@ -89,6 +92,7 @@ describe('IntroScreen', () => {
           z: MOCK_300_UL_TIPRACK_COORDS[2],
         },
       })
+    when(mockUseLabwareIdsBySection).calledWith().mockReturnValue({})
     when(mockUseModuleRenderInfoById).calledWith().mockReturnValue({})
 
     when(mockUseIntroInfo).calledWith().mockReturnValue({

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/IntroScreen.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/IntroScreen.test.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react'
-import { when } from 'jest-when'
+import { when, resetAllWhenMocks } from 'jest-when'
 import {
+  RobotWorkSpace,
+  useInterval,
   partialComponentPropsMatcher,
   renderWithProviders,
-} from '@opentrons/components/src/testing/utils'
-import { RobotWorkSpace } from '@opentrons/components'
+} from '@opentrons/components'
 import { i18n } from '../../../../i18n'
 import standardDeckDef from '@opentrons/shared-data/deck/definitions/2/ot2_standard.json'
 import { LabwareDefinition2 } from '@opentrons/shared-data'
@@ -12,7 +13,7 @@ import fixture_tiprack_300_ul from '@opentrons/shared-data/labware/fixtures/2/fi
 import { useModuleRenderInfoById, useLabwareRenderInfoById } from '../../hooks'
 import { PositionCheckNav } from '../PositionCheckNav'
 import { useIntroInfo, useLabwareIdsBySection } from '../hooks'
-import { IntroScreen } from '../IntroScreen'
+import { IntroScreen, INTERVAL_MS } from '../IntroScreen'
 import type { Section } from '../types'
 import { fireEvent } from '@testing-library/dom'
 
@@ -24,6 +25,7 @@ jest.mock('@opentrons/components', () => {
   return {
     ...actualComponents,
     RobotWorkSpace: jest.fn(() => <div>mock RobotWorkSpace</div>),
+    useInterval: jest.fn(),
   }
 })
 
@@ -39,6 +41,7 @@ const mockUseLabwareIdsBySection = useLabwareIdsBySection as jest.MockedFunction
 const mockUseIntroInfo = useIntroInfo as jest.MockedFunction<
   typeof useIntroInfo
 >
+const mockUseInterval = useInterval as jest.MockedFunction<typeof useInterval>
 const mockPositionCheckNav = PositionCheckNav as jest.MockedFunction<
   typeof PositionCheckNav
 >
@@ -106,6 +109,10 @@ describe('IntroScreen', () => {
     })
     mockPositionCheckNav.mockReturnValue(<div>Mock Position Check Nav</div>)
   })
+  afterEach(() => {
+    resetAllWhenMocks()
+    jest.resetAllMocks()
+  })
 
   it('renders correct heading and position_check_description', () => {
     const { getByRole, getByText } = render(props)
@@ -128,5 +135,9 @@ describe('IntroScreen', () => {
     })
     fireEvent.click(genericStepScreenButton)
     expect(props.setCurrentLabwareCheckStep).toHaveBeenCalled()
+  })
+  it('should should rotate through the active section', () => {
+    render(props)
+    expect(mockUseInterval.mock.calls[0][1]).toBe(INTERVAL_MS)
   })
 })

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/LabwarePositionCheck.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/LabwarePositionCheck.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { resetAllWhenMocks, when } from 'jest-when'
-import { renderWithProviders } from '@opentrons/components/src/testing/utils'
+import { renderWithProviders } from '@opentrons/components'
 import { fireEvent } from '@testing-library/dom'
 import { i18n } from '../../../../i18n'
 import { LabwarePositionCheck } from '../index'

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/LabwarePositionCheckStepDetailModal.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/LabwarePositionCheckStepDetailModal.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { fireEvent } from '@testing-library/react'
-import { renderWithProviders } from '@opentrons/components/src/testing/utils'
+import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../../i18n'
 import { LabwarePositionCheckStepDetailModal } from '../LabwarePositionCheckStepDetailModal'
 

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks.ts
@@ -11,8 +11,8 @@ import type {
   Section,
 } from './types'
 
-interface LabwareIdsBySection {
-  [section: string]: string[]
+type LabwareIdsBySection = {
+  [section in Section]?: string[]
 }
 
 export function useSteps(): LabwarePositionCheckStep[] {
@@ -32,18 +32,21 @@ export function useSections(): Section[] {
 export function useLabwareIdsBySection(): LabwareIdsBySection {
   const steps = useSteps()
   const sections = useSections()
-  return sections.reduce((labwareIdsBySection, section) => {
-    return {
-      ...labwareIdsBySection,
-      [section]: steps.reduce<string[]>(
-        (labwareIds, step) =>
-          step.section === section
-            ? [...labwareIds, step.labwareId]
-            : labwareIds,
-        []
-      ),
-    }
-  }, {})
+  return sections.reduce<LabwareIdsBySection>(
+    (labwareIdsBySection, section) => {
+      return {
+        ...labwareIdsBySection,
+        [section]: steps.reduce<string[]>(
+          (labwareIds, step) =>
+            step.section === section
+              ? [...labwareIds, step.labwareId]
+              : labwareIds,
+          []
+        ),
+      }
+    },
+    {}
+  )
 }
 
 interface IntroInfo {

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareSetup.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareSetup.test.tsx
@@ -258,6 +258,7 @@ describe('LabwareSetup', () => {
           z: MOCK_MAGNETIC_MODULE_COORDS[2],
           moduleDef: mockMagneticModule as any,
           nestedLabwareDef: null,
+          nestedLabwareId: null,
         },
         [mockTCModule.moduleId]: {
           x: MOCK_TC_COORDS[0],
@@ -265,6 +266,7 @@ describe('LabwareSetup', () => {
           z: MOCK_TC_COORDS[2],
           moduleDef: mockTCModule,
           nestedLabwareDef: null,
+          nestedLabwareId: null,
         },
       })
 

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/__tests__/ModuleSetup.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/__tests__/ModuleSetup.test.tsx
@@ -222,6 +222,7 @@ describe('ModuleSetup', () => {
           z: MOCK_MAGNETIC_MODULE_COORDS[2],
           moduleDef: mockMagneticModule as any,
           nestedLabwareDef: null,
+          nestedLabwareId: null,
         },
         [mockTCModule.moduleId]: {
           x: MOCK_TC_COORDS[0],
@@ -229,6 +230,7 @@ describe('ModuleSetup', () => {
           z: MOCK_TC_COORDS[2],
           moduleDef: mockTCModule,
           nestedLabwareDef: null,
+          nestedLabwareId: null,
         },
       })
 
@@ -274,6 +276,7 @@ describe('ModuleSetup', () => {
           z: MOCK_MAGNETIC_MODULE_COORDS[2],
           moduleDef: mockMagneticModule as any,
           nestedLabwareDef: null,
+          nestedLabwareId: null,
         },
         [mockTCModule.moduleId]: {
           x: MOCK_TC_COORDS[0],
@@ -281,6 +284,7 @@ describe('ModuleSetup', () => {
           z: MOCK_TC_COORDS[2],
           moduleDef: mockTCModule,
           nestedLabwareDef: null,
+          nestedLabwareId: null,
         },
       })
     when(mockGetAttachedModules)

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/__tests__/ModuleSetup.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/__tests__/ModuleSetup.test.tsx
@@ -187,6 +187,7 @@ describe('ModuleSetup', () => {
           z: MOCK_MAGNETIC_MODULE_COORDS[2],
           moduleDef: mockMagneticModule as any,
           nestedLabwareDef: null,
+          nestedLabwareId: null,
         },
         [mockMagneticModule.moduleId]: {
           x: MOCK_MAGNETIC_MODULE_COORDS[0],
@@ -194,6 +195,7 @@ describe('ModuleSetup', () => {
           z: MOCK_MAGNETIC_MODULE_COORDS[2],
           moduleDef: mockMagneticModule as any,
           nestedLabwareDef: null,
+          nestedLabwareId: null,
         },
       })
 

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/__tests__/hooks.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/__tests__/hooks.test.tsx
@@ -79,6 +79,7 @@ describe('useMissingModuleIds', () => {
           z: 0,
           moduleDef: mockMagneticModuleDef as any,
           nestedLabwareDef: null,
+          nestedLabwareId: null,
         },
       })
 

--- a/app/src/organisms/ProtocolSetup/__tests__/getModuleRenderInfo.test.ts
+++ b/app/src/organisms/ProtocolSetup/__tests__/getModuleRenderInfo.test.ts
@@ -40,6 +40,7 @@ describe('getModuleRenderInfo', () => {
             _protocolWithMagTempTC.labware[MAG_LW_ID]
               .definitionId as keyof typeof _protocolWithMagTempTC.labwareDefinitions
           ],
+        nestedLabwareId: MAG_LW_ID,
       },
       [TEMP_MOD_ID]: {
         x: SLOT_3_COORDS[0],
@@ -51,6 +52,7 @@ describe('getModuleRenderInfo', () => {
             _protocolWithMagTempTC.labware[TEMP_LW_ID]
               .definitionId as keyof typeof _protocolWithMagTempTC.labwareDefinitions
           ],
+        nestedLabwareId: TEMP_LW_ID,
       },
       [TC_ID]: {
         x: SLOT_7_COORDS[0],
@@ -62,6 +64,7 @@ describe('getModuleRenderInfo', () => {
             _protocolWithMagTempTC.labware[TC_LW_ID]
               .definitionId as keyof typeof _protocolWithMagTempTC.labwareDefinitions
           ],
+        nestedLabwareId: TC_LW_ID,
       },
     }
 

--- a/app/src/organisms/ProtocolSetup/utils/getModuleRenderInfo.ts
+++ b/app/src/organisms/ProtocolSetup/utils/getModuleRenderInfo.ts
@@ -1,4 +1,4 @@
-import find from 'lodash/find'
+import findKey from 'lodash/findKey'
 import reduce from 'lodash/reduce'
 import {
   DeckDefinition,
@@ -16,6 +16,7 @@ export interface ModuleRenderInfoById {
     z: number
     moduleDef: ModuleDefinition
     nestedLabwareDef: LabwareDefinition2 | null
+    nestedLabwareId: string | null
   }
 }
 
@@ -28,10 +29,12 @@ export const getModuleRenderInfo = (
       protocolData.modules,
       (acc, module, moduleId) => {
         const moduleDef = getModuleDef2(module.model)
-        const nestedLabware = find(
+        const nestedLabwareId = findKey(
           protocolData.labware,
           lw => lw.slot === moduleId
         )
+        const nestedLabware =
+          nestedLabwareId != null ? protocolData.labware[nestedLabwareId] : null
         const nestedLabwareDef =
           nestedLabware != null
             ? protocolData.labwareDefinitions[nestedLabware.definitionId]
@@ -56,13 +59,14 @@ export const getModuleRenderInfo = (
               z: 0,
               moduleDef,
               nestedLabwareDef,
+              nestedLabwareId,
             },
           }
         }
         const [x, y, z] = slotPosition
         return {
           ...acc,
-          [moduleId]: { x, y, z, moduleDef, nestedLabwareDef },
+          [moduleId]: { x, y, z, moduleDef, nestedLabwareDef, nestedLabwareId },
         }
       },
       {}

--- a/components/src/testing/utils/matchers.ts
+++ b/components/src/testing/utils/matchers.ts
@@ -3,15 +3,22 @@ import type { Matcher } from '@testing-library/react'
 
 // these are needed because under the hood react calls components with two arguments (props and some second argument nobody seems to know)
 // https://github.com/timkindberg/jest-when/issues/66
+// use componentPropsMatcher if you want to verify ALL props being passed into a component
 export const componentPropsMatcher = (matcher: unknown): any =>
   // @ts-expect-error(sa, 2021-08-03): when.allArgs not part of type definition yet for jest-when
   when.allArgs((args, equals) => equals(args[0], matcher))
 
+// use partialComponentPropsMatcher to only verify the props you pass into partialComponentPropsMatcher
 export const partialComponentPropsMatcher = (argsToMatch: unknown): any =>
   // @ts-expect-error(sa, 2021-08-03): when.allArgs not part of type definition yet for jest-when
   when.allArgs((args, equals) =>
     equals(args[0], expect.objectContaining(argsToMatch))
   )
+
+// use argAtIndex to only verify arguments at a specific index
+export const argAtIndex = (index: number, matcher: unknown): any =>
+  // @ts-expect-error(sa, 2021-08-03): when.allArgs not part of type definition yet for jest-when
+  when.allArgs((args, equals) => equals(args[index], matcher))
 
 export const anyProps = (): any => partialComponentPropsMatcher({})
 


### PR DESCRIPTION
# Overview
This is a tag team PR by me and @jerader!

This PR adds dynamic highlighting to the section list component and deckmap component on the LPC intro screen.

closes #8467
# Changelog

- Add dynamic section + labware highlighting to LPC intro screen
# Review requests

- [ ] Code review
- [ ] In the LPC intro screen verify that the active session name rotates every 3 seconds, and highlights the active section
- [ ] In the LPC intro screen verify that labware that pertain to the active section get highlighted, and also rotate every 3 seconds

# Risk assessment
Low
