### PR TITLE
chore: Change name of emulation repo in Github action

### DIFF
--- a/.github/workflows/hardware-lint-test.yaml
+++ b/.github/workflows/hardware-lint-test.yaml
@@ -41,9 +41,11 @@ jobs:
       - name: Checkout firmware repo
         uses: actions/checkout@v2
 
-        # Don't specify ot3-firmware-commit-id input var to get it to pull main from ot3-firmware
       - name: Run OT-3 Emulator
-        uses: Opentrons/ot3-emulator@v1.1
+        uses: Opentrons/opentrons-emulation@v1.1
+        with:
+          ot3-firmware-commit-id: latest
+          modules-commit-id: latest
 
       - name: Checkout opentrons repo
         uses: 'actions/checkout@v2'


### PR DESCRIPTION
Changing name of `ot3-emulator` repo to `opentrons-emulation`. This PR fixes the Github Action to point to the correct repo name