### PR TITLE
refactor(engine): allow ProtocolRunner to stop engine with error

### DIFF
--- a/api/src/opentrons/protocol_engine/actions/actions.py
+++ b/api/src/opentrons/protocol_engine/actions/actions.py
@@ -5,7 +5,7 @@ reactions in objects that subscribe to the pipeline, like the StateStore.
 """
 
 from dataclasses import dataclass
-from typing import Union
+from typing import Optional, Union
 
 from ..commands import Command
 
@@ -14,21 +14,17 @@ from ..commands import Command
 class PlayAction:
     """Start or resume processing commands in the engine."""
 
-    pass
-
 
 @dataclass(frozen=True)
 class PauseAction:
     """Pause processing commands in the engine."""
-
-    pass
 
 
 @dataclass(frozen=True)
 class StopAction:
     """Stop processing commands in the engine, marking the engine status as done."""
 
-    pass
+    error: Optional[Exception] = None
 
 
 @dataclass(frozen=True)

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -51,6 +51,9 @@ class CommandStore(HasState[CommandState], HandlesActions):
             self._state = replace(self._state, is_running=False)
 
         elif isinstance(action, StopAction):
+            # TODO(mc, 2021-10-12): handle `StopAction(error=Something)`
+            # - add errors to command state
+            # - allow StopAction to mark an in-progress command as failed
             self._state = replace(self._state, is_running=False, stop_requested=True)
 
 

--- a/api/src/opentrons/protocol_runner/protocol_runner.py
+++ b/api/src/opentrons/protocol_runner/protocol_runner.py
@@ -108,7 +108,7 @@ class ProtocolRunner:
 
         # ensure the engine is stopped gracefully once the
         # protocol file stops issuing commands
-        self._task_queue.add_cleanup_func(
+        self._task_queue.set_cleanup_func(
             func=self._protocol_engine.stop,
         )
 
@@ -151,14 +151,14 @@ class ProtocolRunner:
         for request in commands:
             self._protocol_engine.add_command(request=request)
 
-        self._task_queue.add_run_func(
+        self._task_queue.set_run_func(
             func=self._protocol_engine.wait_until_complete,
         )
 
     def _load_python(self, protocol_source: ProtocolSource) -> None:
         protocol = self._python_file_reader.read(protocol_source)
         context = self._python_context_creator.create(self._protocol_engine)
-        self._task_queue.add_run_func(
+        self._task_queue.set_run_func(
             func=self._python_executor.execute,
             protocol=protocol,
             context=context,
@@ -178,7 +178,7 @@ class ProtocolRunner:
             )
         )
 
-        self._task_queue.add_run_func(
+        self._task_queue.set_run_func(
             func=self._legacy_executor.execute,
             protocol=protocol,
             context=context,

--- a/api/src/opentrons/protocol_runner/task_queue.py
+++ b/api/src/opentrons/protocol_runner/task_queue.py
@@ -1,22 +1,23 @@
 """Asynchronous task queue to accomplish a protocol run."""
 import asyncio
-from enum import Enum
-from typing import Any, Awaitable, Callable, Dict, NamedTuple, Optional, Tuple
+import logging
+from functools import partial
+from typing import Any, Awaitable, Callable, Optional
+from typing_extensions import Protocol as Callback
 
 
-class TaskQueuePhase(str, Enum):
-    """Phase in which to run a given task."""
-
-    RUN = "run"
-    CLEANUP = "cleanup"
+log = logging.getLogger(__name__)
 
 
-class TaskQueueEntry(NamedTuple):
-    """An entry in the task queue."""
+class CleanupFunc(Callback):
+    """Expected cleanup function signature."""
 
-    func: Callable[..., Awaitable[Any]]
-    args: Tuple[Any, ...]
-    kwargs: Dict[str, Any]
+    def __call__(self, error: Optional[Exception]) -> Any:
+        """Cleanup, optionally taking an error thrown.
+
+        Return value will not be used.
+        """
+        ...
 
 
 class TaskQueue:
@@ -27,40 +28,35 @@ class TaskQueue:
 
     def __init__(self) -> None:
         """Initialize the TaskQueue."""
-        self._run_entry: Optional[TaskQueueEntry] = None
-        self._cleanup_entry: Optional[TaskQueueEntry] = None
+        self._run_func: Optional[Callable[[], Any]] = None
+        self._cleanup_func: Optional[CleanupFunc] = None
         self._run_task: Optional["asyncio.Task[None]"] = None
         self._run_started_event: asyncio.Event = asyncio.Event()
 
-    def add(
+    def add_run_func(
         self,
-        phase: TaskQueuePhase,
         func: Callable[..., Awaitable[Any]],
-        *args: Any,
         **kwargs: Any,
     ) -> None:
-        """Add a task to the queue.
+        """Add the protocol run task to the queue.
 
-        Two phases are available: TaskQueuePhase.RUN and TaskQueuePhase.CLEANUP.
-        Each phase may contain no tasks or one task. The RUN task will be run first,
-        if present, and the CLEANUP task will run second. The CLEANUP task will run
-        regardless of the success or failure of the RUN task.
+        The "run" task will be run first, before the "cleanup" task.
         """
-        entry = TaskQueueEntry(func=func, args=args, kwargs=kwargs)
+        self._run_func = partial(func, **kwargs)
 
-        if phase == TaskQueuePhase.RUN:
-            self._run_entry = entry
-        else:
-            self._cleanup_entry = entry
+    def add_cleanup_func(self, func: CleanupFunc) -> None:
+        """Add the run cleanup task to the queue.
 
-    def is_started(self) -> bool:
-        """Get whether the task queue has started running."""
-        return self._run_task is not None
+        The "cleanup" task will run after the "run" task, and will be passed
+        any exceptions raised by the "run" task.
+        """
+        self._cleanup_func = func
 
     def start(self) -> None:
         """Start running tasks in the queue."""
-        self._run_task = asyncio.create_task(self._run())
-        self._run_started_event.set()
+        if self._run_task is None:
+            self._run_task = asyncio.create_task(self._run())
+            self._run_started_event.set()
 
     async def join(self) -> None:
         """Wait for the background run task to complete, propagating errors."""
@@ -70,15 +66,19 @@ class TaskQueue:
             await self._run_task
 
     async def _run(self) -> None:
-        run_entry = self._run_entry
-        cleanup_entry = self._cleanup_entry
+        error = None
 
         try:
-            await self._run_task_entry(run_entry)
+            if self._run_func is not None:
+                await self._run_func()
+        except Exception as e:
+            error = e
         finally:
-            await self._run_task_entry(cleanup_entry)
-
-    @staticmethod
-    async def _run_task_entry(entry: Optional[TaskQueueEntry]) -> None:
-        if entry:
-            await entry.func(*entry.args, **entry.kwargs)
+            if self._cleanup_func is not None:
+                await self._cleanup_func(error=error)
+            elif error:
+                log.warning(
+                    "Exception raised during protocol run was not handled",
+                    exc_info=error,
+                )
+                raise error

--- a/api/src/opentrons/protocol_runner/task_queue.py
+++ b/api/src/opentrons/protocol_runner/task_queue.py
@@ -33,7 +33,7 @@ class TaskQueue:
         self._run_task: Optional["asyncio.Task[None]"] = None
         self._run_started_event: asyncio.Event = asyncio.Event()
 
-    def add_run_func(
+    def set_run_func(
         self,
         func: Callable[..., Awaitable[Any]],
         **kwargs: Any,
@@ -44,7 +44,7 @@ class TaskQueue:
         """
         self._run_func = partial(func, **kwargs)
 
-    def add_cleanup_func(self, func: CleanupFunc) -> None:
+    def set_cleanup_func(self, func: CleanupFunc) -> None:
         """Add the run cleanup task to the queue.
 
         The "cleanup" task will run after the "run" task, and will be passed
@@ -54,9 +54,10 @@ class TaskQueue:
 
     def start(self) -> None:
         """Start running tasks in the queue."""
+        self._run_started_event.set()
+
         if self._run_task is None:
             self._run_task = asyncio.create_task(self._run())
-            self._run_started_event.set()
 
     async def join(self) -> None:
         """Wait for the background run task to complete, propagating errors."""

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -232,6 +232,25 @@ async def test_stop(
     )
 
 
+async def test_stop_with_Error(
+    decoy: Decoy,
+    action_dispatcher: ActionDispatcher,
+    queue_worker: QueueWorker,
+    hardware_api: HardwareAPI,
+    subject: ProtocolEngine,
+) -> None:
+    """It should be able to stop the engine."""
+    error = RuntimeError("oh no")
+
+    await subject.stop(error=error)
+
+    decoy.verify(
+        action_dispatcher.dispatch(StopAction(error=error)),
+        await queue_worker.join(),
+        await hardware_api.stop(home_after=False),
+    )
+
+
 async def test_stop_stops_hardware_if_queue_worker_join_fails(
     decoy: Decoy,
     queue_worker: QueueWorker,
@@ -252,22 +271,16 @@ async def test_stop_stops_hardware_if_queue_worker_join_fails(
     )
 
 
-async def test_stop_after_wait(
+async def test_wait_until_complete(
     decoy: Decoy,
     state_store: StateStore,
-    action_dispatcher: ActionDispatcher,
-    queue_worker: QueueWorker,
-    hardware_api: HardwareAPI,
     subject: ProtocolEngine,
 ) -> None:
     """It should be able to stop the engine after waiting for commands to complete."""
-    await subject.stop(wait_until_complete=True)
+    await subject.wait_until_complete()
 
     decoy.verify(
-        await state_store.wait_for(condition=state_store.commands.get_all_complete),
-        action_dispatcher.dispatch(StopAction()),
-        await queue_worker.join(),
-        await hardware_api.stop(home_after=False),
+        await state_store.wait_for(condition=state_store.commands.get_all_complete)
     )
 
 

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -232,7 +232,7 @@ async def test_stop(
     )
 
 
-async def test_stop_with_Error(
+async def test_stop_with_error(
     decoy: Decoy,
     action_dispatcher: ActionDispatcher,
     queue_worker: QueueWorker,

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner.py
@@ -214,8 +214,8 @@ def test_load_json(
                 data=pe_commands.PauseData(message="goodbye")
             )
         ),
-        task_queue.add_run_func(func=protocol_engine.wait_until_complete),
-        task_queue.add_cleanup_func(func=protocol_engine.stop),
+        task_queue.set_run_func(func=protocol_engine.wait_until_complete),
+        task_queue.set_cleanup_func(func=protocol_engine.stop),
     )
 
 
@@ -247,12 +247,12 @@ def test_load_python(
     subject.load(python_protocol_source)
 
     decoy.verify(
-        task_queue.add_run_func(
+        task_queue.set_run_func(
             func=python_executor.execute,
             protocol=python_protocol,
             context=protocol_context,
         ),
-        task_queue.add_cleanup_func(func=protocol_engine.stop),
+        task_queue.set_cleanup_func(func=protocol_engine.stop),
     )
 
 
@@ -296,12 +296,12 @@ def test_load_legacy_python(
 
     decoy.verify(
         protocol_engine.add_plugin(matchers.IsA(LegacyContextPlugin)),
-        task_queue.add_run_func(
+        task_queue.set_run_func(
             func=legacy_executor.execute,
             protocol=legacy_protocol,
             context=legacy_context,
         ),
-        task_queue.add_cleanup_func(func=protocol_engine.stop),
+        task_queue.set_cleanup_func(func=protocol_engine.stop),
     )
 
 
@@ -342,10 +342,10 @@ def test_load_legacy_json(
 
     decoy.verify(
         protocol_engine.add_plugin(matchers.IsA(LegacyContextPlugin)),
-        task_queue.add_run_func(
+        task_queue.set_run_func(
             func=legacy_executor.execute,
             protocol=legacy_protocol,
             context=legacy_context,
         ),
-        task_queue.add_cleanup_func(func=protocol_engine.stop),
+        task_queue.set_cleanup_func(func=protocol_engine.stop),
     )

--- a/api/tests/opentrons/protocol_runner/test_task_queue.py
+++ b/api/tests/opentrons/protocol_runner/test_task_queue.py
@@ -58,7 +58,7 @@ async def test_cleanup_runs_second(decoy: Decoy) -> None:
 
 
 async def test_cleanup_gets_run_error(decoy: Decoy) -> None:
-    """It should run the "run" and "cleanup" funcs in order."""
+    """It should verify "cleanup" func gets error raised in "run" func."
     run_func = decoy.mock(is_async=True)
     cleanup_func = decoy.mock(is_async=True)
     error = RuntimeError("Oh no!")

--- a/api/tests/opentrons/protocol_runner/test_task_queue.py
+++ b/api/tests/opentrons/protocol_runner/test_task_queue.py
@@ -58,7 +58,7 @@ async def test_cleanup_runs_second(decoy: Decoy) -> None:
 
 
 async def test_cleanup_gets_run_error(decoy: Decoy) -> None:
-    """It should verify "cleanup" func gets error raised in "run" func."
+    """It should verify "cleanup" func gets error raised in "run" func."""
     run_func = decoy.mock(is_async=True)
     cleanup_func = decoy.mock(is_async=True)
     error = RuntimeError("Oh no!")

--- a/api/tests/opentrons/protocol_runner/test_task_queue.py
+++ b/api/tests/opentrons/protocol_runner/test_task_queue.py
@@ -4,24 +4,24 @@ from decoy import Decoy
 from opentrons.protocol_runner.task_queue import TaskQueue
 
 
-async def test_add_run_func(decoy: Decoy) -> None:
+async def test_set_run_func(decoy: Decoy) -> None:
     """It should be able to add a task for the "run" phase."""
     run_func = decoy.mock(is_async=True)
 
     subject = TaskQueue()
-    subject.add_run_func(func=run_func)
+    subject.set_run_func(func=run_func)
     subject.start()
     await subject.join()
 
     decoy.verify(await run_func())
 
 
-async def test_add_cleanup_func(decoy: Decoy) -> None:
+async def test_set_cleanup_func(decoy: Decoy) -> None:
     """It should be able to add a task for the "cleanup" phase."""
     cleanup_func = decoy.mock(is_async=True)
 
     subject = TaskQueue()
-    subject.add_cleanup_func(func=cleanup_func)
+    subject.set_cleanup_func(func=cleanup_func)
     subject.start()
     await subject.join()
 
@@ -33,7 +33,7 @@ async def test_passes_args(decoy: Decoy) -> None:
     run_func = decoy.mock(is_async=True)
 
     subject = TaskQueue()
-    subject.add_run_func(func=run_func, hello="world")
+    subject.set_run_func(func=run_func, hello="world")
     subject.start()
     await subject.join()
 
@@ -46,8 +46,8 @@ async def test_cleanup_runs_second(decoy: Decoy) -> None:
     cleanup_func = decoy.mock(is_async=True)
 
     subject = TaskQueue()
-    subject.add_run_func(func=run_func)
-    subject.add_cleanup_func(func=cleanup_func)
+    subject.set_run_func(func=run_func)
+    subject.set_cleanup_func(func=cleanup_func)
     subject.start()
     await subject.join()
 
@@ -66,8 +66,8 @@ async def test_cleanup_gets_run_error(decoy: Decoy) -> None:
     decoy.when(await run_func()).then_raise(error)
 
     subject = TaskQueue()
-    subject.add_run_func(func=run_func)
-    subject.add_cleanup_func(func=cleanup_func)
+    subject.set_run_func(func=run_func)
+    subject.set_cleanup_func(func=cleanup_func)
     subject.start()
     await subject.join()
 
@@ -92,8 +92,8 @@ async def test_start_runs_stuff_once(decoy: Decoy) -> None:
     cleanup_func = decoy.mock(is_async=True)
 
     subject = TaskQueue()
-    subject.add_run_func(func=run_func)
-    subject.add_cleanup_func(func=cleanup_func)
+    subject.set_run_func(func=run_func)
+    subject.set_cleanup_func(func=cleanup_func)
     subject.start()
     subject.start()
     await subject.join()


### PR DESCRIPTION
## Overview

This PR bites off a chunk of #8490 by allowing `ProtocolEngine.stop` to take an error. This PR does not teach the engine how to handle that error, but it _does_ teach the `ProtocolRunner` how to feed the error into the engine.

Will followup with another PR with the state changes necessary to track errors fed into the engine this way and link them to commands, if applicable.

## Changelog

- refactor(engine): allow ProtocolRunner to stop engine with error

## Review requests

Code review seems sufficient on this one! Smoke tests are still passing, and manual testing is probably more useful on the next PR that will attempt to report these errors back in Session state.

This PR _probably_ means errors in Python/legacy protocols are swallowed more completely than they were before this PR. I'd like us to ignore that problem until the follow-up PR, since the goal of that PR will be to completely stop swallowing these errors.

Otherwise, I'm open to suggestions on the `TaskQueue` collaborator! It's now in a place where both `self._run_func` and `self._cleanup_func` are marked (and treated) as independently optional, which isn't the case in actual usage, where as of this PR, they'll either be both defined or both `None`

## Risk assessment

Low. Feature flagged, automated smoke tests passing
