### PR TITLE
refactor(app): LPC only move secondary pipette to tip racks that it uses

### DIFF
--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/getTwoPipettePositionCheckSteps.test.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/getTwoPipettePositionCheckSteps.test.ts
@@ -11,7 +11,7 @@ const protocolWithTC = _uncastedProtocolWithTC as ProtocolFileV5<any>
 
 describe('getTwoPipettePositionCheckSteps', () => {
   it('should move to all tipracks that the secondary pipette uses, move to all tipracks with that the primary pipette uses, pick up a tip at the final tiprack that the primary pipette uses, move to all remaining labware, and drop the tip back in the tiprack that the primary pipette uses', () => {
-    const primaryPipetteId = 'c235a5a0-0042-11ec-8258-f7ffdf5ad45a' // this is just taken from the protocol fixture
+    const primaryPipetteId = '50d23e00-0042-11ec-8258-f7ffdf5ad45a' // this is just taken from the protocol fixture
     const secondaryPipetteId = 'c235a5a0-0042-11ec-8258-f7ffdf5ad45a'
     const labware = protocolMultipleTipracks.labware
     const labwareDefinitions = protocolMultipleTipracks.labwareDefinitions
@@ -23,15 +23,6 @@ describe('getTwoPipettePositionCheckSteps', () => {
     const tiprackInSlot2Id = 'e24818a0-0042-11ec-8258-f7ffdf5ad45a'
     const resevoirId =
       '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1'
-
-    const moveToWellSecondaryPipetteFirstTiprack: Command = {
-      command: 'moveToWell',
-      params: {
-        pipette: secondaryPipetteId,
-        labware: tiprackInSlot1Id,
-        well: 'A1',
-      },
-    }
 
     const moveToWellSeconaryPipetteSecondTiprack: Command = {
       command: 'moveToWell',
@@ -51,20 +42,11 @@ describe('getTwoPipettePositionCheckSteps', () => {
       },
     }
 
-    const moveToWellPrimaryPipetteSecondTiprack: Command = {
-      command: 'moveToWell',
-      params: {
-        pipette: primaryPipetteId,
-        labware: tiprackInSlot2Id,
-        well: 'A1',
-      },
-    }
-
-    const pickupTipAtLastTiprack: Command = {
+    const pickupTipAtLastTiprackPrimaryPipetteUses: Command = {
       command: 'pickUpTip',
       params: {
         pipette: primaryPipetteId,
-        labware: tiprackInSlot2Id,
+        labware: tiprackInSlot1Id,
         well: 'A1',
       },
     }
@@ -78,21 +60,16 @@ describe('getTwoPipettePositionCheckSteps', () => {
       },
     }
 
-    const dropTipIntoLastTiprack: Command = {
+    const dropTipIntoLastTiprackPrimaryPipetteUses: Command = {
       command: 'dropTip',
       params: {
         pipette: primaryPipetteId,
-        labware: tiprackInSlot2Id,
+        labware: tiprackInSlot1Id,
         well: 'A1',
       },
     }
 
     const allSteps: LabwarePositionCheckStep[] = [
-      {
-        labwareId: tiprackInSlot1Id,
-        section: SECTIONS.SECONDARY_PIPETTE_TIPRACKS,
-        commands: [moveToWellSecondaryPipetteFirstTiprack],
-      },
       {
         labwareId: tiprackInSlot2Id,
         section: SECTIONS.SECONDARY_PIPETTE_TIPRACKS,
@@ -104,14 +81,9 @@ describe('getTwoPipettePositionCheckSteps', () => {
         commands: [moveToWellPrimaryPipetteFirstTiprack],
       },
       {
-        labwareId: tiprackInSlot2Id,
+        labwareId: tiprackInSlot1Id,
         section: SECTIONS.PRIMARY_PIPETTE_TIPRACKS,
-        commands: [moveToWellPrimaryPipetteSecondTiprack],
-      },
-      {
-        labwareId: tiprackInSlot2Id,
-        section: SECTIONS.PRIMARY_PIPETTE_TIPRACKS,
-        commands: [pickupTipAtLastTiprack],
+        commands: [pickupTipAtLastTiprackPrimaryPipetteUses],
       },
       {
         labwareId: resevoirId,
@@ -119,9 +91,9 @@ describe('getTwoPipettePositionCheckSteps', () => {
         commands: [moveToWellFirstLabware],
       },
       {
-        labwareId: tiprackInSlot2Id,
+        labwareId: tiprackInSlot1Id,
         section: SECTIONS.RETURN_TIP,
-        commands: [dropTipIntoLastTiprack],
+        commands: [dropTipIntoLastTiprackPrimaryPipetteUses],
       },
     ]
 
@@ -137,7 +109,7 @@ describe('getTwoPipettePositionCheckSteps', () => {
     ).toEqual(allSteps)
   })
   it('should move to all tipracks that the secondary pipette uses, move to all tipracks with the primary pipette uses, pick up a tip at the final tiprack that the primary pipette uses, move to all remaining labware (and open TC lid), and drop the tip back in the tiprack that the primary pipette uses', () => {
-    const primaryPipetteId = 'c235a5a0-0042-11ec-8258-f7ffdf5ad45a' // this is just taken from the protocol fixture
+    const primaryPipetteId = '50d23e00-0042-11ec-8258-f7ffdf5ad45a' // this is just taken from the protocol fixture
     const secondaryPipetteId = 'c235a5a0-0042-11ec-8258-f7ffdf5ad45a'
     const labware = protocolWithTC.labware
     const labwareDefinitions = protocolWithTC.labwareDefinitions
@@ -152,15 +124,6 @@ describe('getTwoPipettePositionCheckSteps', () => {
       '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1'
     const TCWellPlateId =
       '1dc0c050-0122-11ec-88a3-f1745cf9b36c:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1'
-
-    const moveToWellCommandSecondaryPipetteFirstTiprack: Command = {
-      command: 'moveToWell',
-      params: {
-        pipette: secondaryPipetteId,
-        labware: tiprackInSlot1Id,
-        well: 'A1',
-      },
-    }
 
     const moveToWellSeconaryPipetteSecondTiprack: Command = {
       command: 'moveToWell',
@@ -180,20 +143,11 @@ describe('getTwoPipettePositionCheckSteps', () => {
       },
     }
 
-    const moveToWellPrimaryPipetteSecondTiprack: Command = {
-      command: 'moveToWell',
-      params: {
-        pipette: primaryPipetteId,
-        labware: tiprackInSlot2Id,
-        well: 'A1',
-      },
-    }
-
-    const pickupTipAtLastTiprack: Command = {
+    const pickupTipAtLastTiprackPrimaryPipetteUses: Command = {
       command: 'pickUpTip',
       params: {
         pipette: primaryPipetteId,
-        labware: tiprackInSlot2Id,
+        labware: tiprackInSlot1Id,
         well: 'A1',
       },
     }
@@ -223,21 +177,16 @@ describe('getTwoPipettePositionCheckSteps', () => {
       },
     }
 
-    const dropTipIntoLastTiprack: Command = {
+    const dropTipIntoLastTiprackPrimaryPipetteUses: Command = {
       command: 'dropTip',
       params: {
         pipette: primaryPipetteId,
-        labware: tiprackInSlot2Id,
+        labware: tiprackInSlot1Id,
         well: 'A1',
       },
     }
 
     const allSteps: LabwarePositionCheckStep[] = [
-      {
-        labwareId: tiprackInSlot1Id,
-        section: SECTIONS.SECONDARY_PIPETTE_TIPRACKS,
-        commands: [moveToWellCommandSecondaryPipetteFirstTiprack],
-      },
       {
         labwareId: tiprackInSlot2Id,
         section: SECTIONS.SECONDARY_PIPETTE_TIPRACKS,
@@ -249,14 +198,9 @@ describe('getTwoPipettePositionCheckSteps', () => {
         commands: [moveToWellPrimaryPipetteFirstTiprack],
       },
       {
-        labwareId: tiprackInSlot2Id,
+        labwareId: tiprackInSlot1Id,
         section: SECTIONS.PRIMARY_PIPETTE_TIPRACKS,
-        commands: [moveToWellPrimaryPipetteSecondTiprack],
-      },
-      {
-        labwareId: tiprackInSlot2Id,
-        section: SECTIONS.PRIMARY_PIPETTE_TIPRACKS,
-        commands: [pickupTipAtLastTiprack],
+        commands: [pickupTipAtLastTiprackPrimaryPipetteUses],
       },
       {
         labwareId: resevoirId,
@@ -269,9 +213,9 @@ describe('getTwoPipettePositionCheckSteps', () => {
         commands: [openTCLidCommand, moveToWellAfterOpeningTCLidCommand],
       },
       {
-        labwareId: tiprackInSlot2Id,
+        labwareId: tiprackInSlot1Id,
         section: SECTIONS.RETURN_TIP,
-        commands: [dropTipIntoLastTiprack],
+        commands: [dropTipIntoLastTiprackPrimaryPipetteUses],
       },
     ]
 

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/utils/getTwoPipettePositionCheckSteps.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/utils/getTwoPipettePositionCheckSteps.ts
@@ -47,6 +47,15 @@ export const getTwoPipettePositionCheckSteps = (args: {
     labwareDefinitions
   )
 
+  const orderedTiprackIdsThatOnlySecondaryPipetteUses = orderedTiprackIdsThatSecondaryPipetteUses.filter(
+    tiprackId => !orderedTiprackIdsThatPrimaryPipetteUses.includes(tiprackId)
+  )
+
+  const remainingTiprackIdsThatPrimaryPipetteUses = orderedTiprackIdsThatPrimaryPipetteUses.filter(
+    tiprackId =>
+      !orderedTiprackIdsThatOnlySecondaryPipetteUses.includes(tiprackId)
+  )
+
   const orderedLabwareIds = getLabwareIdsInOrder(
     labware,
     labwareDefinitions,
@@ -54,20 +63,20 @@ export const getTwoPipettePositionCheckSteps = (args: {
   )
 
   const moveSecondaryPipetteToTiprackSteps = getMoveToTiprackSteps(
-    orderedTiprackIdsThatSecondaryPipetteUses,
+    orderedTiprackIdsThatOnlySecondaryPipetteUses,
     secondaryPipetteId,
     SECTIONS.SECONDARY_PIPETTE_TIPRACKS
   )
 
   const movePrimaryPipetteToTiprackSteps = getMoveToTiprackSteps(
-    orderedTiprackIdsThatPrimaryPipetteUses,
+    remainingTiprackIdsThatPrimaryPipetteUses,
     primaryPipetteId,
     SECTIONS.PRIMARY_PIPETTE_TIPRACKS
   )
 
   const lastTiprackId =
-    orderedTiprackIdsThatPrimaryPipetteUses[
-      orderedTiprackIdsThatPrimaryPipetteUses.length - 1
+    remainingTiprackIdsThatPrimaryPipetteUses[
+      remainingTiprackIdsThatPrimaryPipetteUses.length - 1
     ]
 
   const pickupTipFromLastTiprackStep = getPickupTipStep(


### PR DESCRIPTION
# Overview

This PR changes the LPC 2 pipette flow so that:
(1) the secondary pipette only moves to tip racks it uses
(2) the primary pipette only moves to tip racks it uses
(3) the primary pipettte picks up a tip at the last tip rack it uses
(4) the primary pipettte drops its tip at the last tip rack it uses

closes #8517

# Review requests
- [ ] review logic changes in src code
- [ ] review test to make sure we're asserting the right sequence of commands

# Risk assessment
Low