### PR TITLE
feat(can): add messages for enabling and disabling motors

### DIFF
--- a/hardware/opentrons_hardware/drivers/can_bus/constants.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/constants.py
@@ -39,6 +39,9 @@ class MessageId(int, Enum):
     get_status_request = 0x01
     get_status_response = 0x05
 
+    enable_motor_request = 0x06
+    disable_motor_request = 0x07
+
     move_request = 0x10
 
     setup_request = 0x02

--- a/hardware/opentrons_hardware/drivers/can_bus/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/messages/message_definitions.py
@@ -53,7 +53,9 @@ class EnableMotorRequest:  # noqa: D101
 
 @dataclass
 class DisableMotorRequest:  # noqa: D101
-    message_id: Literal[MessageId.disable_motor_request] = MessageId.disable_motor_request
+    message_id: Literal[
+        MessageId.disable_motor_request
+    ] = MessageId.disable_motor_request
     payload_type: Type[BinarySerializable] = payloads.EmptyMessage
 
 

--- a/hardware/opentrons_hardware/drivers/can_bus/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/messages/message_definitions.py
@@ -47,13 +47,13 @@ class GetStatusRequest:  # noqa: D101
 
 @dataclass
 class EnableMotorRequest:  # noqa: D101
-    message_id: Literal[MessageId.enable_motor_request] = MessageId.get_status_request
+    message_id: Literal[MessageId.enable_motor_request] = MessageId.enable_motor_request
     payload_type: Type[BinarySerializable] = payloads.EmptyMessage
 
 
 @dataclass
 class DisableMotorRequest:  # noqa: D101
-    message_id: Literal[MessageId.disable_motor_request] = MessageId.get_status_request
+    message_id: Literal[MessageId.disable_motor_request] = MessageId.disable_motor_request
     payload_type: Type[BinarySerializable] = payloads.EmptyMessage
 
 

--- a/hardware/opentrons_hardware/drivers/can_bus/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/messages/message_definitions.py
@@ -46,6 +46,18 @@ class GetStatusRequest:  # noqa: D101
 
 
 @dataclass
+class EnableMotorRequest:  # noqa: D101
+    message_id: Literal[MessageId.enable_motor_request] = MessageId.get_status_request
+    payload_type: Type[BinarySerializable] = payloads.EmptyMessage
+
+
+@dataclass
+class DisableMotorRequest:  # noqa: D101
+    message_id: Literal[MessageId.disable_motor_request] = MessageId.get_status_request
+    payload_type: Type[BinarySerializable] = payloads.EmptyMessage
+
+
+@dataclass
 class GetStatusResponse:  # noqa: D101
     message_id: Literal[MessageId.get_status_response] = MessageId.get_status_response
     payload_type: Type[BinarySerializable] = payloads.EmptyMessage

--- a/hardware/opentrons_hardware/drivers/can_bus/messages/messages.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/messages/messages.py
@@ -15,6 +15,8 @@ MessageDefinition = Union[
     defs.StopRequest,
     defs.GetStatusRequest,
     defs.GetStatusResponse,
+    defs.EnableMotorRequest,
+    defs.DisableMotorRequest,
     defs.MoveRequest,
     defs.SetupRequest,
     defs.GetSpeedRequest,


### PR DESCRIPTION
# Overview
We should be able to enable and disable motors on command using CAN.


# Changelog
- add new message ids
- add new message payloads

# Review requests
Please check to make sure I didn't miss anything.


# Risk assessment

None.
