### PR TITLE
refactor(api): add yocto config for ot3

### DIFF
--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -45,19 +45,27 @@ log = logging.getLogger(__file__)
 IS_WIN = sys.platform.startswith("win")
 IS_OSX = sys.platform == "darwin"
 IS_LINUX = sys.platform.startswith("linux")
-IS_ROBOT = bool(IS_LINUX and os.environ.get("RUNNING_ON_PI"))
+IS_ROBOT = bool(IS_LINUX and (os.environ.get("RUNNING_ON_PI") or os.environ.get("RUNNING_ON_VERDIN")))
 #: This is the correct thing to check to see if we’re running on a robot
 IS_VIRTUAL = bool(os.environ.get("ENABLE_VIRTUAL_SMOOTHIE"))
 
 
 class SystemArchitecture(Enum):
     HOST = auto()
-    BALENA = auto()
     BUILDROOT = auto()
+    YOCTO = auto()
 
+ROBOT_FIRMWARE_DIR: Optional[Path] = None
+#: The path to firmware files for modules
 
 ARCHITECTURE: SystemArchitecture = SystemArchitecture.HOST
 #: The system architecture running
+
+JUPYTER_NOTEBOOK_ROOT_DIR: Optional[Path] = None
+#: The path to the root dir for Jupyter
+
+JUPYTER_NOTEBOOK_LABWARE_DIR: Optional[Path] = None
+#: The path to labware installs for jupyter
 
 OT_SYSTEM_VERSION = "0.0.0"
 #: The semver string of the system
@@ -66,7 +74,8 @@ OT_SYSTEM_VERSION = "0.0.0"
 if IS_ROBOT:
     if "OT_SYSTEM_VERSION" in os.environ:
         OT_SYSTEM_VERSION = os.environ["OT_SYSTEM_VERSION"]
-        ARCHITECTURE = SystemArchitecture.BALENA
+        ARCHITECTURE = SystemArchitecture.YOCTO
+        ROBOT_FIRMWARE_DIR: Optional[Path] = Path("/lib/firmware/")
     else:
         try:
             with open("/etc/VERSION.json") as vj:
@@ -75,21 +84,15 @@ if IS_ROBOT:
             ARCHITECTURE = SystemArchitecture.BUILDROOT
         except Exception:
             log.exception("Could not find version file in /etc/VERSION.json")
+        ROBOT_FIRMWARE_DIR: Optional[Path] = Path("/usr/lib/firmware/")
     JUPYTER_NOTEBOOK_ROOT_DIR: Optional[Path] = Path("/var/lib/jupyter/notebooks/")
     JUPYTER_NOTEBOOK_LABWARE_DIR: Optional[Path] = (
         JUPYTER_NOTEBOOK_ROOT_DIR / "labware"  # type: ignore[operator]
     )
-    ROBOT_FIRMWARE_DIR: Optional[Path] = Path("/usr/lib/firmware/")
-else:
-    JUPYTER_NOTEBOOK_ROOT_DIR = None
-    JUPYTER_NOTEBOOK_LABWARE_DIR = None
-    ROBOT_FIRMWARE_DIR = None
 
 
 def name() -> str:
-    if IS_ROBOT and ARCHITECTURE == SystemArchitecture.BALENA:
-        return "opentrons-{}".format(os.environ.get("RESIN_DEVICE_NAME_AT_INIT", "dev"))
-    if IS_ROBOT and ARCHITECTURE == SystemArchitecture.BUILDROOT:
+    if IS_ROBOT and ARCHITECTURE in (SystemArchitecture.BUILDROOT, SystemArchitecture.YOCTO):
         try:
             return (
                 subprocess.check_output(["hostnamectl", "--pretty", "status"])
@@ -290,7 +293,7 @@ def load_and_migrate() -> Dict[str, Path]:
     a default config and makes sure all directories required exist (though
     the files in them may not).
     """
-    if IS_ROBOT:
+    if IS_ROBOT and ARCHITECTURE != SystemArchitecture.YOCTO:
         _migrate_robot()
     base = infer_config_base_dir()
     base.mkdir(parents=True, exist_ok=True)

--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -45,7 +45,10 @@ log = logging.getLogger(__file__)
 IS_WIN = sys.platform.startswith("win")
 IS_OSX = sys.platform == "darwin"
 IS_LINUX = sys.platform.startswith("linux")
-IS_ROBOT = bool(IS_LINUX and (os.environ.get("RUNNING_ON_PI") or os.environ.get("RUNNING_ON_VERDIN")))
+IS_ROBOT = bool(
+    IS_LINUX
+    and (os.environ.get("RUNNING_ON_PI") or os.environ.get("RUNNING_ON_VERDIN"))
+)
 #: This is the correct thing to check to see if we’re running on a robot
 IS_VIRTUAL = bool(os.environ.get("ENABLE_VIRTUAL_SMOOTHIE"))
 
@@ -54,6 +57,7 @@ class SystemArchitecture(Enum):
     HOST = auto()
     BUILDROOT = auto()
     YOCTO = auto()
+
 
 ROBOT_FIRMWARE_DIR: Optional[Path] = None
 #: The path to firmware files for modules
@@ -75,7 +79,7 @@ if IS_ROBOT:
     if "OT_SYSTEM_VERSION" in os.environ:
         OT_SYSTEM_VERSION = os.environ["OT_SYSTEM_VERSION"]
         ARCHITECTURE = SystemArchitecture.YOCTO
-        ROBOT_FIRMWARE_DIR: Optional[Path] = Path("/lib/firmware/")
+        ROBOT_FIRMWARE_DIR = Path("/lib/firmware/")
     else:
         try:
             with open("/etc/VERSION.json") as vj:
@@ -84,15 +88,16 @@ if IS_ROBOT:
             ARCHITECTURE = SystemArchitecture.BUILDROOT
         except Exception:
             log.exception("Could not find version file in /etc/VERSION.json")
-        ROBOT_FIRMWARE_DIR: Optional[Path] = Path("/usr/lib/firmware/")
-    JUPYTER_NOTEBOOK_ROOT_DIR: Optional[Path] = Path("/var/lib/jupyter/notebooks/")
-    JUPYTER_NOTEBOOK_LABWARE_DIR: Optional[Path] = (
-        JUPYTER_NOTEBOOK_ROOT_DIR / "labware"  # type: ignore[operator]
-    )
+        ROBOT_FIRMWARE_DIR = Path("/usr/lib/firmware/")
+    JUPYTER_NOTEBOOK_ROOT_DIR = Path("/var/lib/jupyter/notebooks/")
+    JUPYTER_NOTEBOOK_LABWARE_DIR = JUPYTER_NOTEBOOK_ROOT_DIR / "labware"
 
 
 def name() -> str:
-    if IS_ROBOT and ARCHITECTURE in (SystemArchitecture.BUILDROOT, SystemArchitecture.YOCTO):
+    if IS_ROBOT and ARCHITECTURE in (
+        SystemArchitecture.BUILDROOT,
+        SystemArchitecture.YOCTO,
+    ):
         try:
             return (
                 subprocess.check_output(["hostnamectl", "--pretty", "status"])

--- a/api/src/opentrons/system/nmcli.py
+++ b/api/src/opentrons/system/nmcli.py
@@ -297,9 +297,11 @@ class CONNECTION_TYPES(enum.Enum):
 
 class NETWORK_IFACES(enum.Enum):
     """Network interface names that we manage here."""
+
     WIFI = {
-        config.SystemArchitecture.BUILDROOT: 'wlan0',
-        config.SystemArchitecture.YOCTO: 'mlan0'}.get(config.ARCHITECTURE, 'wlan0')
+        config.SystemArchitecture.BUILDROOT: "wlan0",
+        config.SystemArchitecture.YOCTO: "mlan0",
+    }.get(config.ARCHITECTURE, "wlan0")
     ETH_LL = "eth0"
 
 

--- a/api/src/opentrons/system/nmcli.py
+++ b/api/src/opentrons/system/nmcli.py
@@ -297,8 +297,9 @@ class CONNECTION_TYPES(enum.Enum):
 
 class NETWORK_IFACES(enum.Enum):
     """Network interface names that we manage here."""
-
-    WIFI = "wlan0"
+    WIFI = {
+        config.SystemArchitecture.BUILDROOT: 'wlan0',
+        config.SystemArchitecture.YOCTO: 'mlan0'}.get(config.ARCHITECTURE, 'wlan0')
     ETH_LL = "eth0"
 
 
@@ -451,12 +452,7 @@ def _add_eap_args(eap_args: Dict[str, str]) -> List[str]:
             if ta["type"] == "file":
                 # Keyfiles must be prepended with file:// so nm-cli
                 # knows that we’re not giving it DER-encoded blobs
-                if config.ARCHITECTURE == config.SystemArchitecture.BALENA:
-                    _make_host_symlink_if_necessary()
-                    path = _rewrite_key_path_to_host_path(eap_args[ta["name"]])
-                else:
-                    path = eap_args[ta["name"]]
-                val = "file://" + path
+                val = "file://" + eap_args[ta["name"]]
             else:
                 val = eap_args[ta["name"]]
             args += ["802-1x." + ta["nmName"], val]
@@ -483,7 +479,7 @@ def _build_con_add_cmd(
         "autoconnect",
         "yes",
         "ifname",
-        "wlan0",
+        NETWORK_IFACES.WIFI.value,
         "type",
         "wifi",
         "con-name",

--- a/api/src/opentrons/util/logging_config.py
+++ b/api/src/opentrons/util/logging_config.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 from opentrons.config import CONFIG, ARCHITECTURE, SystemArchitecture
 
 
-def _balena_config(level_value: int) -> Dict[str, Any]:
+def _host_config(level_value: int) -> Dict[str, Any]:
     serial_log_filename = CONFIG["serial_log_file"]
     api_log_filename = CONFIG["api_log_file"]
     return {
@@ -98,11 +98,6 @@ def _buildroot_config(level_value: int) -> Dict[str, Any]:
             "__main__": {"handlers": ["api"], "level": level_value},
         },
     }
-
-
-def _host_config(level_value: int) -> Dict[str, Any]:
-    """Host logging, for now the same as balena logging"""
-    return _balena_config(level_value)
 
 
 def _config(arch: SystemArchitecture, level_value: int) -> Dict[str, Any]:

--- a/api/src/opentrons/util/logging_config.py
+++ b/api/src/opentrons/util/logging_config.py
@@ -107,7 +107,7 @@ def _host_config(level_value: int) -> Dict[str, Any]:
 
 def _config(arch: SystemArchitecture, level_value: int) -> Dict[str, Any]:
     return {
-        SystemArchitecture.BALENA: _balena_config,
+        SystemArchitecture.YOCTO: _buildroot_config,
         SystemArchitecture.BUILDROOT: _buildroot_config,
         SystemArchitecture.HOST: _host_config,
     }[arch](level_value)


### PR DESCRIPTION
This removes the legacy and unused BALENA SystemArchitecture and
replaces it with YOCTO, which will serve for the OT3. We use this to
anchor some yocto-specific customizations, such as
- A different firmware directory
- A different name for the wifi network iface
- Probably more coming
