### PR TITLE
refactor(api): send "after" messages if command raises and engine is enabled

### DIFF
--- a/api/.flake8
+++ b/api/.flake8
@@ -33,7 +33,6 @@ per-file-ignores =
     src/opentrons/calibration_storage/*:ANN,D
     src/opentrons/cli/*:ANN,D
     src/opentrons/commands/*:D
-    src/opentrons/commands/util.py:ANN,D
     src/opentrons/config/*:ANN,D
     src/opentrons/data_storage/*:ANN,D
     src/opentrons/deck_calibration/*:ANN,D

--- a/api/mypy.ini
+++ b/api/mypy.ini
@@ -29,13 +29,6 @@ disallow_incomplete_defs = False
 no_implicit_optional = False
 warn_return_any = False
 
-# ~20 errors
-[mypy-opentrons.commands.*]
-disallow_untyped_defs = False
-disallow_any_generics = False
-disallow_untyped_calls = False
-no_implicit_optional = False
-
 # ~60 errors
 [mypy-opentrons.config.*]
 disallow_any_generics = False
@@ -133,11 +126,6 @@ disallow_untyped_calls = False
 # ~5 errors
 [mypy-tests.opentrons.calibration_storage.*]
 disallow_untyped_defs = False
-
-# ~5 errors
-[mypy-tests.opentrons.commands.*]
-disallow_untyped_defs = False
-disallow_untyped_calls = False
 
 # ~5 errors
 [mypy-tests.opentrons.config.*]

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -302,7 +302,7 @@ class Session(RobotBusy):
         #: The current state
         self.stateInfo: "StateInfo" = {}
         #: A message associated with the current state
-        self.commands: List[command_types.CommandMessage] = []
+        self.commands: List[Dict[str, Any]] = []
         self.command_log: Dict[int, int] = {}
         self.errors: List[Error] = []
 

--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -145,11 +145,13 @@ def transform_volumes(volumes: Union[float, int]) -> float:
 
 
 @overload
-def transform_volumes(volumes: List[Union[float]]) -> List[float]:
+def transform_volumes(volumes: List[float]) -> List[float]:
     ...
 
 
-def transform_volumes(volumes):
+def transform_volumes(
+    volumes: Union[float, int, List[float]]
+) -> Union[float, List[float]]:
     if not isinstance(volumes, list):
         return float(volumes)
     else:
@@ -178,7 +180,7 @@ def mix(
 
 
 def blow_out(
-    instrument: InstrumentContext, location: Union[Well, Location, None]
+    instrument: InstrumentContext, location: Union[Well, Location]
 ) -> command_types.BlowOutCommand:
     location_text = stringify_location(location)
     text = "Blowing out"

--- a/api/src/opentrons/commands/helpers.py
+++ b/api/src/opentrons/commands/helpers.py
@@ -1,23 +1,27 @@
-from typing import Union, Sequence, List, Any
+from typing import List, Union
 
 from opentrons.protocol_api.labware import Well
 from opentrons.types import Location
 
 
-CommandLocation = Union[Location, None, Sequence, Well]
+CommandLocation = Union[Location, Well]
 
 
-def listify(location: Any) -> List:
+def listify(
+    location: Union[CommandLocation, List[CommandLocation]]
+) -> List[CommandLocation]:
     if isinstance(location, list):
         try:
             return listify(location[0])
         except IndexError:
-            return [location]
+            # TODO(mc, 2021-10-20): this looks like a bug; should this
+            # return an empty list, instead?
+            return [location]  # type: ignore[list-item]
     else:
         return [location]
 
 
-def _stringify_new_loc(loc: Union[Location, Well]) -> str:
+def _stringify_new_loc(loc: CommandLocation) -> str:
     if isinstance(loc, Location):
         if loc.labware.is_empty:
             return str(loc.point)
@@ -29,6 +33,6 @@ def _stringify_new_loc(loc: Union[Location, Well]) -> str:
         raise TypeError(loc)
 
 
-def stringify_location(location: CommandLocation) -> str:
+def stringify_location(location: Union[CommandLocation, List[CommandLocation]]) -> str:
     loc_str_list = [_stringify_new_loc(loc) for loc in listify(location)]
     return ", ".join(loc_str_list)

--- a/api/src/opentrons/commands/paired_commands.py
+++ b/api/src/opentrons/commands/paired_commands.py
@@ -15,7 +15,7 @@ Apiv2Locations = Sequence[Union["Location", "Well"]]
 Apiv2Instruments = Sequence["InstrumentContext"]
 
 
-def combine_locations(location: Sequence) -> str:
+def combine_locations(location: Apiv2Locations) -> str:
     if len(location) > 1:
         loc1 = stringify_location(location[0])
         loc2 = stringify_location(location[1])

--- a/api/src/opentrons/commands/paired_commands.py
+++ b/api/src/opentrons/commands/paired_commands.py
@@ -32,13 +32,12 @@ def paired_aspirate(
     volume: float,
     locations: Apiv2Locations,
     rate: float,
-    pub_type: str,
 ) -> command_types.AspirateCommand:
     loc_text = combine_locations(locations)
     flow_rate = min(
         rate * FlowRates(instr._implementation).aspirate for instr in instruments
     )
-    text_type = f"{pub_type}: Aspirating "
+    text_type = "Paired Pipettes: Aspirating "
     text_content = f"{volume} uL from {loc_text} at {flow_rate} uL/sec"
     text = text_type + text_content
     return {
@@ -58,13 +57,12 @@ def paired_dispense(
     volume: float,
     locations: Apiv2Locations,
     rate: float,
-    pub_type: str,
 ) -> command_types.DispenseCommand:
     loc_text = combine_locations(locations)
     flow_rate = min(
         rate * FlowRates(instr._implementation).dispense for instr in instruments
     )
-    text_type = f"{pub_type}: Dispensing "
+    text_type = "Paired Pipettes: Dispensing "
     text_content = f"{volume} uL into {loc_text} at {flow_rate} uL/sec"
     text = text_type + text_content
     return {
@@ -84,9 +82,8 @@ def paired_mix(
     locations: Optional[Apiv2Locations],
     repetitions: int,
     volume: float,
-    pub_type: str,
 ) -> command_types.MixCommand:
-    text_type = f"{pub_type}: Mixing "
+    text_type = "Paired Pipettes: Mixing "
     text_content = "{repetitions} times with a volume of {volume} ul"
     text = text_type + text_content
     return {
@@ -102,9 +99,9 @@ def paired_mix(
 
 
 def paired_blow_out(
-    instruments: Apiv2Instruments, locations: Optional[Apiv2Locations], pub_type: str
+    instruments: Apiv2Instruments, locations: Optional[Apiv2Locations]
 ) -> command_types.BlowOutCommand:
-    text = f"{pub_type}: Blowing out"
+    text = "Paired Pipettes: Blowing out"
 
     if locations is not None:
         location_text = combine_locations(locations)
@@ -117,9 +114,9 @@ def paired_blow_out(
 
 
 def paired_touch_tip(
-    instruments: Apiv2Instruments, locations: Optional[Apiv2Locations], pub_type: str
+    instruments: Apiv2Instruments, locations: Optional[Apiv2Locations]
 ) -> command_types.TouchTipCommand:
-    text = f"{pub_type}: Touching tip"
+    text = "Paired Pipettes: Touching tip"
 
     if locations is not None:
         location_text = combine_locations(locations)
@@ -141,10 +138,10 @@ def return_tip() -> command_types.ReturnTipCommand:
 
 
 def paired_pick_up_tip(
-    instruments: Apiv2Instruments, locations: Apiv2Locations, pub_type: str
+    instruments: Apiv2Instruments, locations: Apiv2Locations
 ) -> command_types.PickUpTipCommand:
     location_text = combine_locations(locations)
-    text = f"{pub_type}: Picking up tip from {location_text}"
+    text = f"Paired Pipettes: Picking up tip from {location_text}"
     return {
         "name": command_types.PICK_UP_TIP,
         "payload": {"instruments": instruments, "locations": locations, "text": text},
@@ -152,10 +149,10 @@ def paired_pick_up_tip(
 
 
 def paired_drop_tip(
-    instruments: Apiv2Instruments, locations: Apiv2Locations, pub_type: str
+    instruments: Apiv2Instruments, locations: Apiv2Locations
 ) -> command_types.DropTipCommand:
     location_text = combine_locations(locations)
-    text = f"{pub_type}: Dropping tip into {location_text}"
+    text = f"Paired Pipettes: Dropping tip into {location_text}"
     return {
         "name": command_types.DROP_TIP,
         "payload": {"instruments": instruments, "locations": locations, "text": text},
@@ -163,10 +160,10 @@ def paired_drop_tip(
 
 
 def paired_move_to(
-    instruments: Apiv2Instruments, locations: Apiv2Locations, pub_type: str
+    instruments: Apiv2Instruments, locations: Apiv2Locations
 ) -> command_types.MoveToCommand:
     location_text = combine_locations(locations)
-    text = f"{pub_type}: Moving to {location_text}"
+    text = f"Paired Pipettes: Moving to {location_text}"
     return {
         "name": command_types.MOVE_TO,
         "payload": {"instruments": instruments, "locations": locations, "text": text},

--- a/api/src/opentrons/commands/protocol_commands.py
+++ b/api/src/opentrons/commands/protocol_commands.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-
+from typing import Optional
 from . import types as command_types
 
 
@@ -9,7 +9,7 @@ def comment(msg: str) -> command_types.CommentCommand:
 
 
 def delay(
-    seconds: float, minutes: float, msg: str = None
+    seconds: float, minutes: float, msg: Optional[str] = None
 ) -> command_types.DelayCommand:
     td = timedelta(minutes=minutes, seconds=seconds)
     actual_min, actual_sec = divmod(td.total_seconds(), 60)
@@ -27,7 +27,7 @@ def delay(
     }
 
 
-def pause(msg: str = None) -> command_types.PauseCommand:
+def pause(msg: Optional[str] = None) -> command_types.PauseCommand:
     text = "Pausing robot operation"
     if msg:
         text = text + ": {}".format(msg)

--- a/api/src/opentrons/commands/publisher.py
+++ b/api/src/opentrons/commands/publisher.py
@@ -1,60 +1,109 @@
 import functools
 import inspect
 from contextlib import contextmanager
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Generic,
-    Iterator,
-    Mapping,
-    Optional,
-    Tuple,
-    TypeVar,
-    cast,
-)
+from typing import Any, Callable, Iterator, Optional, TypeVar, cast
 
 from opentrons.broker import Broker
 from opentrons.config import feature_flags
 from . import types as command_types
 
 
-CacheT = TypeVar("CacheT")
-
-
-class InspectMemoizer(Generic[CacheT]):
-    def __init__(self, method: Callable[[Any], CacheT]) -> None:
-        self._method = method
-        self._cache: Dict[Callable, CacheT] = {}
-
-    def get(self, f: Callable) -> CacheT:
-        v = self._cache.get(f)
-        if not v:
-            v = self._method(f)
-            self._cache[f] = v
-        return v
-
-
-signature_cache = InspectMemoizer(inspect.signature)
-"""Cache inspect.signature method calls"""
-getfullargspec_cache = InspectMemoizer(inspect.getfullargspec)
-"""Cache inspect.getfullargspec method calls"""
-
-
 class CommandPublisher:
+    """An object with a `Broker` dependency used to publish commands."""
+
     def __init__(self, broker: Optional[Broker]) -> None:
-        self._broker = broker or Broker()
+        """Initialize the publisher with a Broker."""
+        self._broker = broker or Broker()  # type: ignore[no-untyped-call]
 
     @property
     def broker(self) -> Broker:
+        """Get the publisher's Broker."""
         return self._broker
 
     @broker.setter
     def broker(self, broker: Broker) -> None:
+        """Set the publisher's Broker."""
         self._broker = broker
 
 
-CmdFunction = Callable[..., command_types.Command]
+CommandMessageCreator = Callable[..., command_types.Command]
+"""A function that creates a Command dictionary message."""
+
+FuncT = TypeVar("FuncT", bound=Callable[..., Any])
+"""A function wrapped by the @publish decorator."""
+
+
+def publish(command: CommandMessageCreator) -> Callable[[FuncT], FuncT]:
+    """Publish messages before and after the decorated function has run."""
+    message_creator_sig = _inspect_signature(command)
+    message_creator_params = set(message_creator_sig.parameters.keys())
+
+    def _decorator(func: FuncT) -> FuncT:
+        @functools.wraps(
+            func,
+            updated=list(functools.WRAPPER_UPDATES) + ["__globals__"],
+        )
+        def _decorated(*args: Any, **kwargs: Any) -> Any:
+            broker = getattr(args[0], "broker", None)
+
+            assert isinstance(
+                broker, Broker
+            ), "Only methods of CommandPublisher classes should be decorated."
+
+            # get the values of func arguments, including defaults
+            func_sig = _inspect_signature(func)
+            bound_func_args = func_sig.bind(*args, **kwargs)
+            bound_func_args.apply_defaults()
+            func_args = bound_func_args.arguments
+
+            message_creator_args = {
+                p: func_args[p] for p in message_creator_params if p in func_args
+            }
+
+            # TODO (artyom, 20170927): we are doing this to be able to use
+            # the decorator in Instrument class methods, in which case
+            # self is effectively an instrument.
+            # To narrow the scope of this hack, we are checking if the
+            # command is expecting instrument first.
+            if "instrument" in message_creator_params:
+                # We are also checking if call arguments have 'self' and
+                # don't have instruments specified, in which case
+                # instruments should take precedence.
+                if "instrument" not in message_creator_args and "self" in func_args:
+                    message_creator_args["instrument"] = func_args["self"]
+
+            command_message = command(**message_creator_args)
+
+            with publish_context(broker=broker, command=command_message):
+                return func(*args, **kwargs)
+
+        return cast(FuncT, _decorated)
+
+    return _decorator
+
+
+@contextmanager
+def publish_context(broker: Broker, command: command_types.Command) -> Iterator[None]:
+    """Publish messages before and after the `with` block has run."""
+    capture_errors = feature_flags.enable_protocol_engine()
+    error = None
+
+    _do_publish(broker=broker, command=command, when="before", error=None)
+    try:
+        yield
+    except Exception as e:
+        # TODO(mc, 2021-10-19): put this capture behind the PE feature flag
+        error = e
+        raise e
+    finally:
+        if error is None or capture_errors is True:
+            _do_publish(broker=broker, command=command, when="after", error=error)
+
+
+@functools.lru_cache(maxsize=None)
+def _inspect_signature(func: Callable[..., Any]) -> inspect.Signature:
+    """Inspect function signatures, memoized because it is called very often."""
+    return inspect.signature(func)
 
 
 def _do_publish(
@@ -78,90 +127,3 @@ def _do_publish(
         broker.logger.info(f"{name}: {payload_str}")
 
     broker.publish(topic=command_types.COMMAND, message=message)
-
-
-FuncT = TypeVar("FuncT", bound=Callable[..., Any])
-
-
-def publish(command: CmdFunction) -> Callable[[FuncT], FuncT]:
-    """Publish events both before and after the decorated function has run."""
-    getfullargspec = getfullargspec_cache.get(command)
-
-    def _decorator(f: FuncT) -> FuncT:
-        @functools.wraps(
-            f, updated=functools.WRAPPER_UPDATES + ("__globals__",)  # type: ignore[operator]  # noqa: E501
-        )
-        def _decorated(*args: Any, **kwargs: Any) -> Any:
-            broker = getattr(args[0], "broker", None)
-
-            assert isinstance(
-                broker, Broker
-            ), "Only methods of CommandPublisher classes should be decorated."
-
-            call_args = _get_args(f, args, kwargs)
-            command_args = dict(
-                zip(
-                    reversed(getfullargspec.args),
-                    reversed(getfullargspec.defaults or []),
-                )
-            )
-
-            # TODO (artyom, 20170927): we are doing this to be able to use
-            # the decorator in Instrument class methods, in which case
-            # self is effectively an instrument.
-            # To narrow the scope of this hack, we are checking if the
-            # command is expecting instrument first.
-            if "instrument" in getfullargspec.args:
-                # We are also checking if call arguments have 'self' and
-                # don't have instruments specified, in which case
-                # instruments should take precedence.
-                if "instrument" not in call_args and "self" in call_args:
-                    call_args["instrument"] = call_args["self"]
-
-            command_args.update(
-                {
-                    key: call_args[key]
-                    for key in (set(getfullargspec.args) & call_args.keys())
-                }
-            )
-            command_message = command(**command_args)
-
-            with publish_context(broker=broker, command=command_message):
-                return f(*args, **kwargs)
-
-        return cast(FuncT, _decorated)
-
-    return _decorator
-
-
-@contextmanager
-def publish_context(broker: Broker, command: command_types.Command) -> Iterator[None]:
-    capture_errors = feature_flags.enable_protocol_engine()
-    error = None
-
-    _do_publish(broker=broker, command=command, when="before", error=None)
-    try:
-        yield
-    except Exception as e:
-        # TODO(mc, 2021-10-19): put this capture behind the PE feature flag
-        error = e
-        raise e
-    finally:
-        if error is None or capture_errors is True:
-            _do_publish(broker=broker, command=command, when="after", error=error)
-
-
-def _get_args(f: Callable, args: Tuple, kwargs: Mapping[str, Any]) -> Dict[str, Any]:
-    # Create the initial dictionary with args that have defaults
-    res = {}
-    sig = signature_cache.get(f)
-    ismethod = inspect.ismethod(f)
-    if ismethod and args[0] is f.__self__:  # type: ignore
-        args = args[1:]
-    if ismethod:
-        res["self"] = f.__self__  # type: ignore
-
-    bound = sig.bind(*args, **kwargs)
-    bound.apply_defaults()
-    res.update(bound.arguments)
-    return res

--- a/api/src/opentrons/commands/publisher.py
+++ b/api/src/opentrons/commands/publisher.py
@@ -139,8 +139,8 @@ def publish_context(broker: Broker, command: command_types.Command) -> Iterator[
     capture_errors = feature_flags.enable_protocol_engine()
     error = None
 
+    _do_publish(broker=broker, command=command, when="before", error=None)
     try:
-        _do_publish(broker=broker, command=command, when="before", error=None)
         yield
     except Exception as e:
         # TODO(mc, 2021-10-19): put this capture behind the PE feature flag

--- a/api/src/opentrons/commands/publisher.py
+++ b/api/src/opentrons/commands/publisher.py
@@ -113,7 +113,7 @@ def publish_context(broker: Broker, command: CommandPayload) -> Iterator[None]:
         yield
     except Exception as e:
         error = e
-        raise e
+        raise
     finally:
         if error is None or capture_errors is True:
             _do_publish(broker=broker, command=command, when="after", error=error)

--- a/api/src/opentrons/commands/types.py
+++ b/api/src/opentrons/commands/types.py
@@ -571,10 +571,15 @@ MessageSequenceId = Union[Literal["before"], Literal["after"]]
 
 
 CommandMessageSequence = TypedDict("CommandMessageSequence", {"$": MessageSequenceId})
-CommandMessageMeta = TypedDict("CommandMessageMeta", {"meta": Any}, total=False)
+
+CommandMessageOptional = TypedDict(
+    "CommandMessageOptional",
+    {"meta": Any, "error": Exception},
+    total=False,
+)
 
 
-class CommandMessageFields(CommandMessageMeta, CommandMessageSequence):
+class CommandMessageFields(CommandMessageOptional, CommandMessageSequence):
     pass
 
 

--- a/api/src/opentrons/commands/types.py
+++ b/api/src/opentrons/commands/types.py
@@ -570,17 +570,10 @@ CommandPayload = Union[
 MessageSequenceId = Union[Literal["before"], Literal["after"]]
 
 
-CommandMessageSequence = TypedDict("CommandMessageSequence", {"$": MessageSequenceId})
-
-CommandMessageError = TypedDict(
-    "CommandMessageError",
-    {"error": Exception},
-    total=False,
+CommandMessageFields = TypedDict(
+    "CommandMessageFields",
+    {"$": MessageSequenceId, "error": Optional[Exception]},
 )
-
-
-class CommandMessageFields(CommandMessageError, CommandMessageSequence):
-    pass
 
 
 class MoveToMessage(CommandMessageFields, MoveToCommand):

--- a/api/src/opentrons/commands/types.py
+++ b/api/src/opentrons/commands/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing_extensions import Literal, Final, TypedDict
-from typing import Optional, List, Sequence, TYPE_CHECKING, Union, Any
+from typing import Optional, List, Sequence, TYPE_CHECKING, Union
 from opentrons.hardware_control.modules import ThermocyclerStep
 
 if TYPE_CHECKING:
@@ -572,14 +572,14 @@ MessageSequenceId = Union[Literal["before"], Literal["after"]]
 
 CommandMessageSequence = TypedDict("CommandMessageSequence", {"$": MessageSequenceId})
 
-CommandMessageOptional = TypedDict(
-    "CommandMessageOptional",
-    {"meta": Any, "error": Exception},
+CommandMessageError = TypedDict(
+    "CommandMessageError",
+    {"error": Exception},
     total=False,
 )
 
 
-class CommandMessageFields(CommandMessageOptional, CommandMessageSequence):
+class CommandMessageFields(CommandMessageError, CommandMessageSequence):
     pass
 
 

--- a/api/src/opentrons/commands/util.py
+++ b/api/src/opentrons/commands/util.py
@@ -1,24 +1,17 @@
-from typing import Any, List
+from typing import Any, Dict, Iterator, List, Tuple
+from opentrons.api.dev_types import CommandShortId
 
 
-def session_listify(location: Any) -> List:
-    if isinstance(location, list):
-        try:
-            return session_listify(location[0])
-        except IndexError:
-            return [location]
-    else:
-        return [location]
-
-
-def from_list(commands):
+def from_list(commands: List[CommandShortId]) -> List[Dict[str, Any]]:
     """
     Given a list of tuples of form (depth, text)
     that represents a DFS traversal of a command tree,
     returns a dictionary representing command tree.
     """
 
-    def subtrees(commands, level):
+    def subtrees(
+        commands: List[CommandShortId], level: int
+    ) -> Iterator[Tuple[CommandShortId, List[CommandShortId]]]:
         if not commands:
             return
 
@@ -34,7 +27,7 @@ def from_list(commands):
                 acc.clear()
         yield (parent, acc)
 
-    def walk(commands, level=0):
+    def walk(commands: List[CommandShortId], level: int = 0) -> List[Dict[str, Any]]:
         return [
             {
                 "description": key["description"],

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -297,7 +297,7 @@ class API(HardwareAPILike):
         """
         The lru cache decorator is currently not supported by the
         ThreadManager. To work around this, we need to wrap the
-        actualy function around a dummy outer function.
+        actually function around a dummy outer function.
 
         Once decorators are more fully supported, we can remove this.
         """

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -297,7 +297,7 @@ class API(HardwareAPILike):
         """
         The lru cache decorator is currently not supported by the
         ThreadManager. To work around this, we need to wrap the
-        actually function around a dummy outer function.
+        actual function around a dummy outer function.
 
         Once decorators are more fully supported, we can remove this.
         """

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -409,7 +409,7 @@ class InstrumentContext(CommandPublisher):
 
     @requires_version(2, 0)
     def blow_out(
-        self, location: Union[types.Location, Well] = None
+        self, location: Optional[Union[types.Location, Well]] = None
     ) -> InstrumentContext:
         """
         Blow liquid out of the tip.
@@ -464,7 +464,7 @@ class InstrumentContext(CommandPublisher):
             broker=self.broker,
             command=cmds.blow_out(
                 instrument=self,
-                location=location or self._ctx.location_cache,
+                location=location or self._ctx.location_cache,  # type: ignore[arg-type]
             ),
         ):
             self._implementation.blow_out()

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import logging
+from contextlib import nullcontext
 from typing import List, Optional, Sequence, TYPE_CHECKING, Union
 from opentrons.broker import Broker
 from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons import types, hardware_control as hc
 from opentrons.commands import commands as cmds
-from opentrons.commands.publisher import CommandPublisher, do_publish, publish
+from opentrons.commands.publisher import CommandPublisher, publish, publish_context
 from opentrons.hardware_control.types import PipettePair
 from opentrons.protocols.advanced_control.mix import mix_from_kwargs
 from opentrons.protocols.api_support.instrument import (
@@ -227,31 +228,17 @@ class InstrumentContext(CommandPublisher):
 
         c_vol = self._implementation.get_available_volume() if not volume else volume
 
-        do_publish(
-            self.broker,
-            cmds.aspirate,
-            self.aspirate,
-            "before",
-            None,
-            None,
-            self,
-            c_vol,
-            dest,
-            rate,
-        )
-        self._implementation.aspirate(volume=c_vol, rate=rate)
-        do_publish(
-            self.broker,
-            cmds.aspirate,
-            self.aspirate,
-            "after",
-            self,
-            None,
-            self,
-            c_vol,
-            dest,
-            rate,
-        )
+        with publish_context(
+            broker=self.broker,
+            command=cmds.aspirate(
+                instrument=self,
+                volume=c_vol,
+                location=dest,
+                rate=rate,
+            ),
+        ):
+            self._implementation.aspirate(volume=c_vol, rate=rate)
+
         return self
 
     @requires_version(2, 0)
@@ -335,31 +322,17 @@ class InstrumentContext(CommandPublisher):
 
         c_vol = self.current_volume if not volume else volume
 
-        do_publish(
-            self.broker,
-            cmds.dispense,
-            self.dispense,
-            "before",
-            None,
-            None,
-            self,
-            c_vol,
-            loc,
-            rate,
-        )
-        self._implementation.dispense(volume=c_vol, rate=rate)
-        do_publish(
-            self.broker,
-            cmds.dispense,
-            self.dispense,
-            "after",
-            self,
-            None,
-            self,
-            c_vol,
-            loc,
-            rate,
-        )
+        with publish_context(
+            broker=self.broker,
+            command=cmds.dispense(
+                instrument=self,
+                volume=c_vol,
+                location=loc,
+                rate=rate,
+            ),
+        ):
+            self._implementation.dispense(volume=c_vol, rate=rate)
+
         return self
 
     @requires_version(2, 0)
@@ -416,36 +389,22 @@ class InstrumentContext(CommandPublisher):
 
         c_vol = self._implementation.get_available_volume() if not volume else volume
 
-        do_publish(
-            self.broker,
-            cmds.mix,
-            self.mix,
-            "before",
-            None,
-            None,
-            self,
-            repetitions,
-            c_vol,
-            location,
-        )
-        self.aspirate(volume, location, rate)
-        while repetitions - 1 > 0:
+        with publish_context(
+            broker=self.broker,
+            command=cmds.mix(
+                instrument=self,
+                repetitions=repetitions,
+                volume=c_vol,
+                location=location,
+            ),
+        ):
+            self.aspirate(volume, location, rate)
+            while repetitions - 1 > 0:
+                self.dispense(volume, rate=rate)
+                self.aspirate(volume, rate=rate)
+                repetitions -= 1
             self.dispense(volume, rate=rate)
-            self.aspirate(volume, rate=rate)
-            repetitions -= 1
-        self.dispense(volume, rate=rate)
-        do_publish(
-            self.broker,
-            cmds.mix,
-            self.mix,
-            "after",
-            None,
-            None,
-            self,
-            repetitions,
-            c_vol,
-            location,
-        )
+
         return self
 
     @requires_version(2, 0)
@@ -501,27 +460,15 @@ class InstrumentContext(CommandPublisher):
                 "knows where it is."
             )
 
-        do_publish(
-            self.broker,
-            cmds.blow_out,
-            self.blow_out,
-            "before",
-            None,
-            None,
-            self,
-            location or self._ctx.location_cache,
-        )
-        self._implementation.blow_out()
-        do_publish(
-            self.broker,
-            cmds.blow_out,
-            self.blow_out,
-            "after",
-            None,
-            None,
-            self,
-            location or self._ctx.location_cache,
-        )
+        with publish_context(
+            broker=self.broker,
+            command=cmds.blow_out(
+                instrument=self,
+                location=location or self._ctx.location_cache,
+            ),
+        ):
+            self._implementation.blow_out()
+
         return self
 
     def _determine_speed(self, speed: float):
@@ -769,36 +716,19 @@ class InstrumentContext(CommandPublisher):
 
         assert tiprack.is_tiprack, "{} is not a tiprack".format(str(tiprack))
         validate_tiprack(self.name, tiprack, logger)
-        do_publish(
-            self.broker,
-            cmds.pick_up_tip,
-            self.pick_up_tip,
-            "before",
-            None,
-            None,
-            self,
-            location=target,
-        )
 
-        self.move_to(target.top(), publish=False)
-
-        self._implementation.pick_up_tip(
-            well=target._impl,
-            tip_length=self._tip_length_for(tiprack),
-            presses=presses,
-            increment=increment,
-        )
-        # Note that the hardware API pick_up_tip action includes homing z after
-        do_publish(
-            self.broker,
-            cmds.pick_up_tip,
-            self.pick_up_tip,
-            "after",
-            self,
-            None,
-            self,
-            location=target,
-        )
+        with publish_context(
+            broker=self.broker,
+            command=cmds.pick_up_tip(instrument=self, location=target),
+        ):
+            self.move_to(target.top(), publish=False)
+            self._implementation.pick_up_tip(
+                well=target._impl,
+                tip_length=self._tip_length_for(tiprack),
+                presses=presses,
+                increment=increment,
+            )
+            # Note that the hardware API pick_up_tip action includes homing z after
 
         tiprack.use_tips(target, self.channels)
         self._last_tip_picked_up_from = target
@@ -906,29 +836,13 @@ class InstrumentContext(CommandPublisher):
                 "tiprack.wells()[0].top()) or a Well (e.g. tiprack.wells()[0]."
                 " However, it is a {}".format(location)
             )
-        do_publish(
-            self.broker,
-            cmds.drop_tip,
-            self.drop_tip,
-            "before",
-            None,
-            None,
-            self,
-            location=target,
-        )
-        self.move_to(target, publish=False)
 
-        self._implementation.drop_tip(home_after=home_after)
-        do_publish(
-            self.broker,
-            cmds.drop_tip,
-            self.drop_tip,
-            "after",
-            self,
-            None,
-            self,
-            location=target,
-        )
+        with publish_context(
+            broker=self.broker,
+            command=cmds.drop_tip(instrument=self, location=target),
+        ):
+            self.move_to(target, publish=False)
+            self._implementation.drop_tip(home_after=home_after)
 
         if (
             self.api_version < APIVersion(2, 2)
@@ -956,13 +870,11 @@ class InstrumentContext(CommandPublisher):
         :returns: This instance.
         """
 
-        def home_dummy(mount):
-            pass
-
         mount_name = self._implementation.get_mount().name.lower()
-        do_publish(self.broker, cmds.home, home_dummy, "before", None, None, mount_name)
-        self._implementation.home()
-        do_publish(self.broker, cmds.home, home_dummy, "after", self, None, mount_name)
+
+        with publish_context(broker=self.broker, command=cmds.home(mount_name)):
+            self._implementation.home()
+
         return self
 
     @requires_version(2, 0)
@@ -1273,34 +1185,25 @@ class InstrumentContext(CommandPublisher):
             if isinstance(mod, ThermocyclerContext):
                 mod.flag_unsafe_move(to_loc=location, from_loc=from_loc)
 
+        publish_ctx = nullcontext()
+
         if publish:
-            do_publish(
-                self.broker,
-                cmds.move_to,
-                self.move_to,
-                "before",
-                None,
-                None,
-                self,
-                location or self._ctx.location_cache,
+            publish_ctx = publish_context(
+                broker=self.broker,
+                command=cmds.move_to(
+                    instrument=self,
+                    location=location or self._ctx.location_cache,  # type: ignore[arg-type]  # noqa: E501
+                ),
             )
-        self._implementation.move_to(
-            location=location,
-            force_direct=force_direct,
-            minimum_z_height=minimum_z_height,
-            speed=speed,
-        )
-        if publish:
-            do_publish(
-                self.broker,
-                cmds.move_to,
-                self.move_to,
-                "after",
-                None,
-                None,
-                self,
-                location or self._ctx.location_cache,
+
+        with publish_ctx:
+            self._implementation.move_to(
+                location=location,
+                force_direct=force_direct,
+                minimum_z_height=minimum_z_height,
+                speed=speed,
             )
+
         return self
 
     @property  # type: ignore
@@ -1347,7 +1250,7 @@ class InstrumentContext(CommandPublisher):
         .. note::
           This property is equivalent to :py:attr:`speed`; the only
           difference is the units in which this property is specified.
-          specifiying this property uses the units of the volumetric flow rate
+          specifying this property uses the units of the volumetric flow rate
           of liquid into or out of the tip, while :py:attr:`speed` uses the
           units of the linear speed of the plunger inside the pipette.
           Because :py:attr:`speed` and :py:attr:`flow_rate` modify the

--- a/api/src/opentrons/protocol_api/paired_instrument_context.py
+++ b/api/src/opentrons/protocol_api/paired_instrument_context.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Union, Tuple, List, Optional, Dict
 from opentrons.protocols.api_support.labware_like import LabwareLike
 from opentrons import types, hardware_control as hc
 from opentrons.commands import paired_commands as cmds
-from opentrons.commands.publisher import CommandPublisher, publish_paired, publish
+from opentrons.commands.publisher import CommandPublisher, publish, publish_context
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.context.paired_instrument import AbstractPairedInstrument
 
@@ -252,16 +252,16 @@ class PairedInstrumentContext(CommandPublisher):
 
         instruments = list(self._instruments.values())
         targets = [target, secondary_target]
-        publish_paired(
-            self.broker, cmds.paired_pick_up_tip, "before", None, instruments, targets
-        )
-        self._implementation.pick_up_tip(
-            target, secondary_target, tiprack, presses, increment, tip_length
-        )
-        self._last_tip_picked_up_from = target
-        publish_paired(
-            self.broker, cmds.paired_pick_up_tip, "after", self, instruments, targets
-        )
+
+        with publish_context(
+            broker=self.broker,
+            command=cmds.paired_pick_up_tip(instruments=instruments, locations=targets),
+        ):
+            self._implementation.pick_up_tip(
+                target, secondary_target, tiprack, presses, increment, tip_length
+            )
+            self._last_tip_picked_up_from = target
+
         return self
 
     @requires_version(2, 7)
@@ -299,7 +299,7 @@ class PairedInstrumentContext(CommandPublisher):
         :type location: :py:class:`.types.Location` or :py:class:`.Well` or
                         None
         :param home_after: Whether to home the plunger after dropping the tip
-                           (defaults to ``True``). The plungeer must home after
+                           (defaults to ``True``). The plunger must home after
                            dropping tips because the ejector shroud that pops
                            the tip off the end of the pipette is driven by the
                            plunger motor, and may skip steps when dropping the
@@ -307,7 +307,7 @@ class PairedInstrumentContext(CommandPublisher):
 
         :returns: This instance
 
-        :raises TyepError: If a location is not relative to a well.
+        :raises TypeError: If a location is not relative to a well.
         """
         is_trash = False
         tiprack = None
@@ -350,13 +350,13 @@ class PairedInstrumentContext(CommandPublisher):
             ]
         else:
             targets = [target]
-        publish_paired(
-            self.broker, cmds.paired_drop_tip, "before", None, instruments, targets
-        )
-        self._implementation.drop_tip(target, home_after)
-        publish_paired(
-            self.broker, cmds.paired_drop_tip, "after", self, instruments, targets
-        )
+
+        with publish_context(
+            broker=self.broker,
+            command=cmds.paired_drop_tip(instruments=instruments, locations=targets),
+        ):
+            self._implementation.drop_tip(target, home_after)
+
         self._last_tip_picked_up_from = None
         return self
 
@@ -364,7 +364,7 @@ class PairedInstrumentContext(CommandPublisher):
     def aspirate(
         self,
         volume: Optional[float] = None,
-        location: Union[types.Location, Well] = None,
+        location: Optional[Union[types.Location, Well]] = None,
         rate: float = 1.0,
     ) -> PairedInstrumentContext:
         """
@@ -448,35 +448,26 @@ class PairedInstrumentContext(CommandPublisher):
         if checked_location.labware.is_well:
             well = checked_location.labware.as_well()
             labware = well.parent
-            locations = [checked_location, self._get_secondary_target(labware, well)]
+            locations: List[Union[types.Location, Well]] = [
+                checked_location,
+                self._get_secondary_target(labware, well),
+            ]
         else:
             locations = [checked_location]
 
-        publish_paired(
-            self.broker,
-            cmds.paired_aspirate,
-            "before",
-            None,
-            instruments,
-            c_vol,
-            locations,
-            rate,
-        )
+        with publish_context(
+            broker=self.broker,
+            command=cmds.paired_aspirate(
+                instruments=instruments,
+                volume=c_vol,
+                locations=locations,
+                rate=rate,
+            ),
+        ):
+            self._implementation.aspirate(
+                volume=c_vol, location=checked_location, rate=rate
+            )
 
-        self._implementation.aspirate(
-            volume=c_vol, location=checked_location, rate=rate
-        )
-
-        publish_paired(
-            self.broker,
-            cmds.paired_aspirate,
-            "after",
-            self,
-            instruments,
-            c_vol,
-            locations,
-            rate,
-        )
         return self
 
     @requires_version(2, 7)
@@ -576,31 +567,19 @@ class PairedInstrumentContext(CommandPublisher):
         else:
             locations = [checked_location]
 
-        publish_paired(
-            self.broker,
-            cmds.paired_dispense,
-            "before",
-            None,
-            instruments,
-            c_vol,
-            locations,
-            rate,
-        )
+        with publish_context(
+            broker=self.broker,
+            command=cmds.paired_dispense(
+                instruments=instruments,
+                volume=c_vol,
+                locations=locations,
+                rate=rate,
+            ),
+        ):
+            self._implementation.dispense(
+                volume=c_vol, location=checked_location, rate=rate
+            )
 
-        self._implementation.dispense(
-            volume=c_vol, location=checked_location, rate=rate
-        )
-
-        publish_paired(
-            self.broker,
-            cmds.paired_dispense,
-            "after",
-            self,
-            instruments,
-            c_vol,
-            locations,
-            rate,
-        )
         return self
 
     @publish(command=cmds.air_gap)
@@ -712,13 +691,13 @@ class PairedInstrumentContext(CommandPublisher):
             locations = self._get_locations(loc)
 
         instruments = list(self._instruments.values())
-        publish_paired(
-            self.broker, cmds.paired_blow_out, "before", None, instruments, locations
-        )
-        self._implementation.blow_out(loc)
-        publish_paired(
-            self.broker, cmds.paired_blow_out, "after", self, instruments, locations
-        )
+
+        with publish_context(
+            broker=self.broker,
+            command=cmds.paired_blow_out(instruments=instruments, locations=locations),
+        ):
+            self._implementation.blow_out(loc)
+
         return self
 
     @requires_version(2, 7)
@@ -780,32 +759,23 @@ class PairedInstrumentContext(CommandPublisher):
         locations: Optional[List] = None
         if location:
             locations = self._get_locations(location)
-        publish_paired(
-            self.broker,
-            cmds.paired_mix,
-            "before",
-            None,
-            instruments,
-            locations,
-            repetitions,
-            c_vol,
-        )
-        self.aspirate(volume, location, rate)
-        while repetitions - 1 > 0:
+
+        with publish_context(
+            broker=self.broker,
+            command=cmds.paired_mix(
+                instruments=instruments,
+                locations=locations,
+                repetitions=repetitions,
+                volume=c_vol,
+            ),
+        ):
+            self.aspirate(volume, location, rate)
+            while repetitions - 1 > 0:
+                self.dispense(volume, rate=rate)
+                self.aspirate(volume, rate=rate)
+                repetitions -= 1
             self.dispense(volume, rate=rate)
-            self.aspirate(volume, rate=rate)
-            repetitions -= 1
-        self.dispense(volume, rate=rate)
-        publish_paired(
-            self.broker,
-            cmds.paired_mix,
-            "after",
-            self,
-            instruments,
-            locations,
-            repetitions,
-            c_vol,
-        )
+
         return self
 
     @requires_version(2, 7)
@@ -893,13 +863,14 @@ class PairedInstrumentContext(CommandPublisher):
                 self._get_secondary_target(location.parent, location),
             ]
 
-        publish_paired(
-            self.broker, cmds.paired_touch_tip, "before", None, instruments, locations
-        )
-        self._implementation.touch_tip(well.as_well(), radius, v_offset, checked_speed)
-        publish_paired(
-            self.broker, cmds.paired_touch_tip, "after", self, instruments, locations
-        )
+        with publish_context(
+            broker=self.broker,
+            command=cmds.paired_touch_tip(instruments=instruments, locations=locations),
+        ):
+            self._implementation.touch_tip(
+                well.as_well(), radius, v_offset, checked_speed
+            )
+
         return self
 
     @publish(command=cmds.return_tip)
@@ -948,17 +919,24 @@ class PairedInstrumentContext(CommandPublisher):
                       :py:attr:`.ProtocolContext.max_speeds`.
         """
         instruments = list(self._instruments.values())
-        locations: Optional[List] = None
+        locations: Optional[List[Union[types.Location, Well]]] = None
+
+        # TODO(mc, 2021-10-19): `location` is typed as non-optional, how would
+        # this condition ever be falsey?
         if location:
             locations = self._get_locations(location)
 
-        publish_paired(
-            self.broker, cmds.paired_move_to, "before", None, instruments, locations
-        )
-        self._implementation.move_to(location, force_direct, minimum_z_height, speed)
-        publish_paired(
-            self.broker, cmds.paired_move_to, "after", None, instruments, locations
-        )
+        with publish_context(
+            broker=self.broker,
+            command=cmds.paired_move_to(
+                instruments=instruments,
+                locations=locations,  # type: ignore[arg-type]
+            ),
+        ):
+            self._implementation.move_to(
+                location, force_direct, minimum_z_height, speed
+            )
+
         return self
 
     def _next_available_tip(self) -> Tuple[Labware, Well]:

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -47,6 +47,7 @@ class LegacyCommandMapper:
         """
         command_type = command["name"]
         command_text = command["payload"]["text"]
+        command_error = command["error"]
         stage = command["$"]
 
         command_id = f"{command_type}-0"
@@ -73,10 +74,16 @@ class LegacyCommandMapper:
 
         else:
             running_command = self._running_commands[command_type].pop()
+            completed_status = (
+                pe_commands.CommandStatus.SUCCEEDED
+                if command_error is None
+                else pe_commands.CommandStatus.FAILED
+            )
             completed_command = running_command.copy(
                 update={
-                    "status": pe_commands.CommandStatus.SUCCEEDED,
+                    "status": completed_status,
                     "completedAt": now,
+                    "error": str(command_error) if command_error is not None else None,
                 }
             )
 

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -33,10 +33,7 @@ class LegacyCommandMapper:
         self._running_commands: Dict[str, List[pe_commands.Command]] = defaultdict(list)
         self._command_count: Dict[str, int] = defaultdict(lambda: 0)
 
-    def map_command(
-        self,
-        command: LegacyCommand,
-    ) -> pe_commands.Command:
+    def map_command(self, command: LegacyCommand) -> pe_commands.Command:
         """Map a legacy Broker command to a ProtocolEngine command.
 
         A "before" message from the Broker
@@ -119,7 +116,8 @@ class LegacyCommandMapper:
         return load_labware_command
 
     def map_instrument_load(
-        self, instrument_load_info: LegacyInstrumentLoadInfo
+        self,
+        instrument_load_info: LegacyInstrumentLoadInfo,
     ) -> pe_commands.Command:
         """Map a legacy instrument (pipette) load to a ProtocolEngine command."""
         now = utc_now()

--- a/api/tests/opentrons/broker/test_broker.py
+++ b/api/tests/opentrons/broker/test_broker.py
@@ -1,10 +1,10 @@
 from opentrons.commands.publisher import CommandPublisher, publish
 
 
-def my_command(arg1, meta=None, arg2="", arg3=""):
+def my_command(arg1, arg2="", arg3=""):
     return {
         "name": "command",
-        "payload": {"description": meta.format(arg1=arg1, arg2=arg2, arg3=arg3)},
+        "payload": {"description": f"arg1:{arg1}, arg2:{arg2}, arg3:{arg3}"},
     }
 
 
@@ -12,17 +12,17 @@ class FakeClass(CommandPublisher):
     def __init__(self):
         super().__init__(None)
 
-    @publish(command=my_command, meta="{arg1} {arg2} {arg3}")
+    @publish(command=my_command)
     def A(self, arg1, arg2, arg3="foo"):
         self.B(0)
         return 100
 
-    @publish(command=my_command, meta="{arg1} {arg2} {arg3}")
+    @publish(command=my_command)
     def C(self, arg1, arg2, arg3="bar"):
         self.B(0)
         return 100
 
-    @publish(command=my_command, meta="{arg1}")
+    @publish(command=my_command)
     def B(self, arg1):
         return None
 
@@ -50,11 +50,11 @@ def test_add_listener():
     fake_obj.C(3, 4)
 
     expected = [
-        {"level": 1, "description": "0 1 foo"},
-        {"level": 2, "description": "0"},
-        {"level": 1, "description": "2"},
-        {"level": 1, "description": "3 4 bar"},
-        {"level": 2, "description": "0"},
+        {"level": 1, "description": "arg1:0, arg2:1, arg3:foo"},
+        {"level": 2, "description": "arg1:0, arg2:, arg3:"},
+        {"level": 1, "description": "arg1:2, arg2:, arg3:"},
+        {"level": 1, "description": "arg1:3, arg2:4, arg3:bar"},
+        {"level": 2, "description": "arg1:0, arg2:, arg3:"},
     ]
 
     assert calls == expected

--- a/api/tests/opentrons/commands/test_protocol_commands.py
+++ b/api/tests/opentrons/commands/test_protocol_commands.py
@@ -20,7 +20,13 @@ from opentrons.commands import protocol_commands
         [1.0001, 0, 1.0001, 0, "Delaying for 0 minutes and 1.0 seconds"],
     ],
 )
-def test_delay(seconds, minutes, expected_seconds, expected_minutes, expected_text):
+def test_delay(
+    seconds: int,
+    minutes: int,
+    expected_seconds: int,
+    expected_minutes: int,
+    expected_text: str,
+) -> None:
     command = protocol_commands.delay(seconds, minutes)
     name = command["name"]
     payload = command["payload"]
@@ -31,7 +37,7 @@ def test_delay(seconds, minutes, expected_seconds, expected_minutes, expected_te
     assert payload["text"] == expected_text
 
 
-def test_delay_with_message():
+def test_delay_with_message() -> None:
     """It should allow a message to be appended to the delay text."""
     command = protocol_commands.delay(seconds=1, minutes=1, msg="Waiting...")
 

--- a/api/tests/opentrons/commands/test_publisher.py
+++ b/api/tests/opentrons/commands/test_publisher.py
@@ -6,7 +6,7 @@ from decoy import Decoy, matchers
 from typing import Any, Dict, AsyncIterator, cast
 from opentrons.config import advanced_settings
 from opentrons.broker import Broker
-from opentrons.commands.types import Command
+from opentrons.commands.types import Command as CommandDict
 from opentrons.commands.publisher import CommandPublisher, publish, publish_context
 
 
@@ -36,11 +36,14 @@ def test_publish_decorator(decoy: Decoy, broker: Broker) -> None:
     """It should publish "before" and "after" messages for decorated methods."""
     _act = decoy.mock()
 
-    def _get_command_payload(foo: str, bar: int) -> Dict[str, Any]:
-        return {"name": "some_command", "payload": {"foo": foo, "bar": bar}}
+    def _get_command_payload(foo: str, bar: int) -> CommandDict:
+        return cast(
+            CommandDict,
+            {"name": "some_command", "payload": {"foo": foo, "bar": bar}},
+        )
 
     class _Subject(CommandPublisher):
-        @publish(command=_get_command_payload)  # type: ignore[arg-type]
+        @publish(command=_get_command_payload)
         def act(self, foo: str, bar: int) -> None:
             _act()
 
@@ -74,11 +77,14 @@ def test_publish_decorator_with_arg_defaults(decoy: Decoy, broker: Broker) -> No
     """It should pass method argument defaults to the command creator."""
     _act = decoy.mock()
 
-    def _get_command_payload(foo: str, bar: int) -> Dict[str, Any]:
-        return {"name": "some_command", "payload": {"foo": foo, "bar": bar}}
+    def _get_command_payload(foo: str, bar: int) -> CommandDict:
+        return cast(
+            CommandDict,
+            {"name": "some_command", "payload": {"foo": foo, "bar": bar}},
+        )
 
     class _Subject(CommandPublisher):
-        @publish(command=_get_command_payload)  # type: ignore[arg-type]
+        @publish(command=_get_command_payload)
         def act(self, foo: str, bar: int = 42) -> None:
             _act()
 
@@ -225,7 +231,7 @@ def test_publish_context(decoy: Decoy, broker: Broker) -> None:
     _act = decoy.mock()
 
     command = cast(
-        Command,
+        CommandDict,
         {"name": "some_command", "payload": {"foo": "hello", "bar": 42}},
     )
 
@@ -264,7 +270,7 @@ def test_publish_context_with_error(
     enable_protocol_engine: None,
 ) -> None:
     command = cast(
-        Command,
+        CommandDict,
         {"name": "some_command", "payload": {"foo": "hello", "bar": 42}},
     )
 
@@ -305,7 +311,7 @@ def test_publish_context_with_error_no_engine(
 ) -> None:
     """It should not capture errors if the engine FF is off."""
     command = cast(
-        Command,
+        CommandDict,
         {"name": "some_command", "payload": {"foo": "hello", "bar": 42}},
     )
 

--- a/api/tests/opentrons/commands/test_publisher.py
+++ b/api/tests/opentrons/commands/test_publisher.py
@@ -1,0 +1,328 @@
+"""Tests for opentrons.commands.publisher."""
+from __future__ import annotations
+
+import pytest
+from decoy import Decoy, matchers
+from typing import Any, Dict, AsyncIterator, cast
+from opentrons.config import advanced_settings
+from opentrons.broker import Broker
+from opentrons.commands.types import Command
+from opentrons.commands.publisher import CommandPublisher, publish, publish_context
+
+
+@pytest.fixture
+def broker(decoy: Decoy) -> Broker:
+    """Return a mocked out Broker."""
+    return decoy.mock(cls=Broker)
+
+
+@pytest.fixture
+def engine_is_enabled() -> bool:
+    return True
+
+
+@pytest.fixture
+async def enable_protocol_engine(engine_is_enabled: bool) -> AsyncIterator[None]:
+    """Temporarily set the enableProtocolEngine feature flag."""
+    prev_setting = advanced_settings.get_adv_setting("enableProtocolEngine")
+    prev_value = prev_setting.value if prev_setting is not None else False
+
+    await advanced_settings.set_adv_setting("enableProtocolEngine", engine_is_enabled)
+    yield
+    await advanced_settings.set_adv_setting("enableProtocolEngine", prev_value)
+
+
+def test_publish_decorator(decoy: Decoy, broker: Broker) -> None:
+    """It should publish "before" and "after" messages for decorated methods."""
+    _act = decoy.mock()
+
+    def _get_command_payload(foo: str, bar: int) -> Dict[str, Any]:
+        return {"name": "some_command", "payload": {"foo": foo, "bar": bar}}
+
+    class _Subject(CommandPublisher):
+        @publish(command=_get_command_payload)  # type: ignore[arg-type]
+        def act(self, foo: str, bar: int) -> None:
+            _act()
+
+    subject = _Subject(broker=broker)
+    subject.act("hello", 42)
+
+    decoy.verify(
+        broker.publish(
+            topic="command",
+            message={
+                "$": "before",
+                "name": "some_command",
+                "payload": {"foo": "hello", "bar": 42},
+                "error": None,
+            },
+        ),
+        _act(),
+        broker.publish(
+            topic="command",
+            message={
+                "$": "after",
+                "name": "some_command",
+                "payload": {"foo": "hello", "bar": 42},
+                "error": None,
+            },
+        ),
+    )
+
+
+def test_publish_decorator_with_arg_defaults(decoy: Decoy, broker: Broker) -> None:
+    """It should pass method argument defaults to the command creator."""
+    _act = decoy.mock()
+
+    def _get_command_payload(foo: str, bar: int) -> Dict[str, Any]:
+        return {"name": "some_command", "payload": {"foo": foo, "bar": bar}}
+
+    class _Subject(CommandPublisher):
+        @publish(command=_get_command_payload)  # type: ignore[arg-type]
+        def act(self, foo: str, bar: int = 42) -> None:
+            _act()
+
+    subject = _Subject(broker=broker)
+    subject.act("hello")
+
+    decoy.verify(
+        broker.publish(
+            topic="command",
+            message={
+                "$": "before",
+                "name": "some_command",
+                "payload": {"foo": "hello", "bar": 42},
+                "error": None,
+            },
+        ),
+        _act(),
+        broker.publish(
+            topic="command",
+            message={
+                "$": "after",
+                "name": "some_command",
+                "payload": {"foo": "hello", "bar": 42},
+                "error": None,
+            },
+        ),
+    )
+
+
+def test_publish_decorator_with_error(
+    decoy: Decoy,
+    broker: Broker,
+    enable_protocol_engine: None,
+) -> None:
+    """It should capture an exception and place it in the "after" message."""
+    _act = decoy.mock()
+
+    def _get_command_payload(foo: str, bar: int) -> Dict[str, Any]:
+        return {"name": "some_command", "payload": {"foo": foo, "bar": bar}}
+
+    class _Subject(CommandPublisher):
+        @publish(command=_get_command_payload)  # type: ignore[arg-type]
+        def act(self, foo: str, bar: int) -> None:
+            _act()
+
+    decoy.when(_act()).then_raise(RuntimeError("oh no"))
+
+    subject = _Subject(broker=broker)
+
+    with pytest.raises(RuntimeError, match="oh no"):
+        subject.act("hello", 42)
+
+    decoy.verify(
+        broker.publish(
+            topic="command",
+            message={
+                "$": "before",
+                "name": "some_command",
+                "payload": {"foo": "hello", "bar": 42},
+                "error": None,
+            },
+        ),
+        broker.publish(
+            topic="command",
+            message={
+                "$": "after",
+                "name": "some_command",
+                "payload": {"foo": "hello", "bar": 42},
+                "error": matchers.IsA(RuntimeError),
+            },
+        ),
+    )
+
+
+@pytest.mark.parametrize("engine_is_enabled", [False])
+def test_publish_decorator_with_error_no_engine(
+    decoy: Decoy,
+    broker: Broker,
+    enable_protocol_engine: None,
+) -> None:
+    """It should not capture errors if engine FF is off."""
+    _act = decoy.mock()
+
+    def _get_command_payload(foo: str, bar: int) -> Dict[str, Any]:
+        return {"name": "some_command", "payload": {"foo": foo, "bar": bar}}
+
+    class _Subject(CommandPublisher):
+        @publish(command=_get_command_payload)  # type: ignore[arg-type]
+        def act(self, foo: str, bar: int) -> None:
+            _act()
+
+    decoy.when(_act()).then_raise(RuntimeError("oh no"))
+
+    subject = _Subject(broker=broker)
+
+    with pytest.raises(RuntimeError, match="oh no"):
+        subject.act("hello", 42)
+
+    decoy.verify(
+        broker.publish(topic="command", message=matchers.DictMatching({"$": "after"})),
+        times=0,
+    )
+
+
+def test_publish_decorator_remaps_instrument(decoy: Decoy, broker: Broker) -> None:
+    """It should pass "self" to command creator arguments named "instrument"."""
+    _act = decoy.mock()
+
+    def _get_command_payload(foo: str, instrument: _Subject) -> Dict[str, Any]:
+        return {
+            "name": "some_command",
+            "payload": {"foo": foo, "bar": instrument.bar},
+        }
+
+    class _Subject(CommandPublisher):
+        bar: int = 42
+
+        @publish(command=_get_command_payload)  # type: ignore[arg-type]
+        def act(self, foo: str) -> None:
+            _act()
+
+    subject = _Subject(broker=broker)
+
+    subject.act("hello")
+
+    decoy.verify(
+        broker.publish(
+            topic="command",
+            message={
+                "$": "before",
+                "name": "some_command",
+                "payload": {"foo": "hello", "bar": 42},
+                "error": None,
+            },
+        ),
+        _act(),
+        broker.publish(
+            topic="command",
+            message={
+                "$": "after",
+                "name": "some_command",
+                "payload": {"foo": "hello", "bar": 42},
+                "error": None,
+            },
+        ),
+    )
+
+
+def test_publish_context(decoy: Decoy, broker: Broker) -> None:
+    _act = decoy.mock()
+
+    command = cast(
+        Command,
+        {"name": "some_command", "payload": {"foo": "hello", "bar": 42}},
+    )
+
+    def _published_func(foo: str, bar: int) -> None:
+        _act()
+
+    with publish_context(broker=broker, command=command):
+        _published_func("hello", 42)
+
+    decoy.verify(
+        broker.publish(
+            topic="command",
+            message={
+                "$": "before",
+                "name": "some_command",
+                "payload": {"foo": "hello", "bar": 42},
+                "error": None,
+            },
+        ),
+        _act(),
+        broker.publish(
+            topic="command",
+            message={
+                "$": "after",
+                "name": "some_command",
+                "payload": {"foo": "hello", "bar": 42},
+                "error": None,
+            },
+        ),
+    )
+
+
+def test_publish_context_with_error(
+    decoy: Decoy,
+    broker: Broker,
+    enable_protocol_engine: None,
+) -> None:
+    command = cast(
+        Command,
+        {"name": "some_command", "payload": {"foo": "hello", "bar": 42}},
+    )
+
+    def _published_func(foo: str, bar: int) -> None:
+        raise RuntimeError("oh no")
+
+    with pytest.raises(RuntimeError, match="oh no"):
+        with publish_context(broker=broker, command=command):
+            _published_func("hello", 42)
+
+    decoy.verify(
+        broker.publish(
+            topic="command",
+            message={
+                "$": "before",
+                "name": "some_command",
+                "payload": {"foo": "hello", "bar": 42},
+                "error": None,
+            },
+        ),
+        broker.publish(
+            topic="command",
+            message={
+                "$": "after",
+                "name": "some_command",
+                "payload": {"foo": "hello", "bar": 42},
+                "error": matchers.IsA(RuntimeError),
+            },
+        ),
+    )
+
+
+@pytest.mark.parametrize("engine_is_enabled", [False])
+def test_publish_context_with_error_no_engine(
+    decoy: Decoy,
+    broker: Broker,
+    enable_protocol_engine: None,
+) -> None:
+    """It should not capture errors if the engine FF is off."""
+    command = cast(
+        Command,
+        {"name": "some_command", "payload": {"foo": "hello", "bar": 42}},
+    )
+
+    def _published_func(foo: str, bar: int) -> None:
+        raise RuntimeError("oh no")
+
+    with pytest.raises(RuntimeError, match="oh no"):
+        with publish_context(broker=broker, command=command):
+            _published_func("hello", 42)
+
+    decoy.verify(
+        broker.publish(topic="command", message=matchers.DictMatching({"$": "after"})),
+        times=0,
+    )

--- a/api/tests/opentrons/commands/test_publisher.py
+++ b/api/tests/opentrons/commands/test_publisher.py
@@ -114,7 +114,6 @@ def test_publish_decorator_with_error(
     enable_protocol_engine: None,
 ) -> None:
     """It should capture an exception and place it in the "after" message."""
-    _act = decoy.mock()
 
     def _get_command_payload(foo: str, bar: int) -> Dict[str, Any]:
         return {"name": "some_command", "payload": {"foo": foo, "bar": bar}}
@@ -122,9 +121,7 @@ def test_publish_decorator_with_error(
     class _Subject(CommandPublisher):
         @publish(command=_get_command_payload)  # type: ignore[arg-type]
         def act(self, foo: str, bar: int) -> None:
-            _act()
-
-    decoy.when(_act()).then_raise(RuntimeError("oh no"))
+            raise RuntimeError("oh no")
 
     subject = _Subject(broker=broker)
 
@@ -160,7 +157,6 @@ def test_publish_decorator_with_error_no_engine(
     enable_protocol_engine: None,
 ) -> None:
     """It should not capture errors if engine FF is off."""
-    _act = decoy.mock()
 
     def _get_command_payload(foo: str, bar: int) -> Dict[str, Any]:
         return {"name": "some_command", "payload": {"foo": foo, "bar": bar}}
@@ -168,9 +164,7 @@ def test_publish_decorator_with_error_no_engine(
     class _Subject(CommandPublisher):
         @publish(command=_get_command_payload)  # type: ignore[arg-type]
         def act(self, foo: str, bar: int) -> None:
-            _act()
-
-    decoy.when(_act()).then_raise(RuntimeError("oh no"))
+            raise RuntimeError("oh no")
 
     subject = _Subject(broker=broker)
 

--- a/api/tests/opentrons/commands/test_tree.py
+++ b/api/tests/opentrons/commands/test_tree.py
@@ -1,7 +1,7 @@
 from opentrons.commands.util import from_list
 
 
-def test_command_tree():
+def test_command_tree() -> None:
     commands = from_list(
         [
             {"level": 0, "description": "A", "id": 0},

--- a/api/tests/opentrons/data/testosaur_v2.py
+++ b/api/tests/opentrons/data/testosaur_v2.py
@@ -14,6 +14,8 @@ def run(ctx):
     tr = ctx.load_labware("opentrons_96_tiprack_300ul", 1)
     right = ctx.load_instrument("p300_single", types.Mount.RIGHT, [tr])
     lw = ctx.load_labware("corning_96_wellplate_360ul_flat", 2)
+
+    right.touch_tip()
     right.pick_up_tip()
     right.aspirate(10, lw.wells()[0].bottom())
     right.dispense(10, lw.wells()[1].bottom())

--- a/api/tests/opentrons/data/testosaur_v2.py
+++ b/api/tests/opentrons/data/testosaur_v2.py
@@ -14,8 +14,6 @@ def run(ctx):
     tr = ctx.load_labware("opentrons_96_tiprack_300ul", 1)
     right = ctx.load_instrument("p300_single", types.Mount.RIGHT, [tr])
     lw = ctx.load_labware("corning_96_wellplate_360ul_flat", 2)
-
-    right.touch_tip()
     right.pick_up_tip()
     right.aspirate(10, lw.wells()[0].bottom())
     right.dispense(10, lw.wells()[1].bottom())

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -25,7 +25,6 @@ def test_map_before_command() -> None:
     """It should map a "before" message to a running command."""
     legacy_command: PauseMessage = {
         "$": "before",
-        "meta": {},
         "name": "command.PAUSE",
         "payload": {"userMessage": "hello world", "text": "hello world"},
     }
@@ -49,13 +48,11 @@ def test_map_after_command() -> None:
     """It should map an "after" message to a completed command."""
     legacy_command_start: PauseMessage = {
         "$": "before",
-        "meta": {},
         "name": "command.PAUSE",
         "payload": {"userMessage": "hello world", "text": "hello world"},
     }
     legacy_command_end: PauseMessage = {
         "$": "after",
-        "meta": {},
         "name": "command.PAUSE",
         "payload": {"userMessage": "hello world", "text": "hello world"},
     }
@@ -82,25 +79,21 @@ def test_command_stack() -> None:
     """It should maintain a command stack to map IDs."""
     legacy_command_1: PauseMessage = {
         "$": "before",
-        "meta": {},
         "name": "command.PAUSE",
         "payload": {"userMessage": "hello", "text": "hello"},
     }
     legacy_command_2: PauseMessage = {
         "$": "before",
-        "meta": {},
         "name": "command.PAUSE",
         "payload": {"userMessage": "goodbye", "text": "goodbye"},
     }
     legacy_command_3: PauseMessage = {
         "$": "after",
-        "meta": {},
         "name": "command.PAUSE",
         "payload": {"userMessage": "hello world", "text": "goodbye"},
     }
     legacy_command_4: PauseMessage = {
         "$": "after",
-        "meta": {},
         "name": "command.PAUSE",
         "payload": {"userMessage": "hello world", "text": "hello"},
     }

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -46,7 +46,7 @@ def test_map_before_command() -> None:
 
 
 def test_map_after_command() -> None:
-    """It should map an "after" message to a completed command."""
+    """It should map an "after" message to a succeeded command."""
     legacy_command_start: PauseMessage = {
         "$": "before",
         "name": "command.PAUSE",
@@ -79,7 +79,7 @@ def test_map_after_command() -> None:
 
 
 def test_map_after_with_error_command() -> None:
-    """It should map an "after" message to a completed command."""
+    """It should map an "after" message to a failed command."""
     legacy_command_start: PauseMessage = {
         "$": "before",
         "name": "command.PAUSE",

--- a/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
@@ -155,6 +155,7 @@ def test_main_broker_messages(
         "$": "before",
         "name": "command.PAUSE",
         "payload": {"userMessage": "hello world", "text": "hello world"},
+        "error": None,
     }
     engine_command = pe_commands.Custom(
         id="command-id",

--- a/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
@@ -153,7 +153,6 @@ def test_main_broker_messages(
 
     legacy_command: PauseMessage = {
         "$": "before",
-        "meta": {},
         "name": "command.PAUSE",
         "payload": {"userMessage": "hello world", "text": "hello world"},
     }


### PR DESCRIPTION
## Overview

In order to accurately map PAPIv2 commands to ProtocolEngine command facades, the ProtocolEngine needs to know if a PAPIv2 command fails in order to mark the command in state. In the existing implementation of the `Broker` and the `command` topic, `"after"` messages are only sent if the command successfully runs. If the command fails, no signal is sent anywhere, except for a `raise` that _may_ propogate to the `run` call, but only if the protocol author does not have their own try/except in place.

This PR changes this behavior if the `enableProtocolEngine` feature flag is set. When the engine is enabled, the publish logic will attempt to capture any error raised and include it in the `after` message.

Closes #8490 

## Changelog

I made the following observations about the existing broker messages for commands:

- All commands' message payloads are static in practice
    - In actual usage, the payloads solely contain information from the method's arguments
- The return value of the method is never used in the command message payload
- In `publish` and `do_publish`, the `meta` argument was never used
    - In fact, it couldn't be used without causing an error to be raised due to mismatched function args
- In `publish_paired`, the `pub_type` argument is never set to anything other than its default

From there, I made the following changes:

- Added a `publish_context` ContextManager to replace public usage of `do_publish`
    - Takes the broker and a static message payload
        - This gets us typechecking of the command messages, which we did not have with `do_publish`
    - The ContextManager publishes `before` message on `__enter__` and the `after` message on `__exit__`
    - If the `enabledProtocolEngine` feature flag is set, errors will be captured from the CM's `yield` and added to the command message
- Move weird argument parsing logic to live entirely in the method decorator
    - Now, the method decorator only exists to do that argument parsing
    - It delegates before/after logic to the ContextManager
- Replaced all usage of `do_publish` and `publish_paired` with `publish_context`
    - This involved ditching the unused `pub_type` argument
- Added unit tests for `opentrons.commands.publisher`, which did not exist
    - Since this is legacy code, logic and collaboration are mixed a little willy-nilly
    - Doing some dirty testing seemed better than doing no testing here

## Review requests

- [ ] Smoke test PAPIv2 protocols with the FF off heavily!
    - These command messages drive the run log, so this is important
- [ ] Smoke test PAPIv2 protocols in `opentrons_simulate` and `opentrons_execute`
- [ ] PAPIv2 protocols run on the engine-based `/protocols` endpoints no longer get stuck if a protocol method raises
- [] Make sure this doesn't mess with tracebacks

## Risk assessment

**Medium risk.** Intended behavior change is well feature flagged, and changes were made attempting to get good unit test coverage, but this code is both important and super super old.
