### PR TITLE
fix(can): show parsed messages in log.

### DIFF
--- a/hardware/opentrons_hardware/scripts/can_comm.py
+++ b/hardware/opentrons_hardware/scripts/can_comm.py
@@ -43,7 +43,16 @@ async def listen_task(can_driver: CanDriver) -> None:
 
     """
     async for message in can_driver:
-        log.info(f"Received <-- {message}")
+        message_definition = get_definition(
+            MessageId(message.arbitration_id.parts.message_id)
+        )
+        if message_definition:
+            log.info(
+                f"Received <-- \n\traw: {message}, "
+                f"\n\tparsed: {message_definition.payload_type.build(message.data)}"
+            )
+        else:
+            log.info(f"Received <-- \traw: {message}")
 
 
 def create_choices(enum_type: Type[Enum]) -> Sequence[str]:
@@ -141,7 +150,7 @@ def prompt_message(get_user_input: GetInputFunc, output_func: OutputFunc) -> Can
         ),
         data=data,
     )
-    log.info(f"Sending --> {can_message}")
+    log.info(f"Sending --> \n\traw: {can_message}")
     return can_message
 
 

--- a/hardware/opentrons_hardware/utils/binary_serializable.py
+++ b/hardware/opentrons_hardware/utils/binary_serializable.py
@@ -5,10 +5,6 @@ import struct
 from dataclasses import dataclass, fields, astuple
 from typing import TypeVar, Generic
 
-from typing_extensions import Final
-
-format_string_attribute: Final = "__struct_format_string__"
-
 
 class BinarySerializableException(BaseException):
     """Exception."""
@@ -151,20 +147,14 @@ class BinarySerializable:
         Returns:
             a string
         """
-        format_string: str = getattr(cls, format_string_attribute, None)
-        if format_string is None:
-            dataclass_fields = fields(cls)
-            try:
-                format_string = (
-                    f"{cls.ENDIAN}{''.join(v.type.FORMAT for v in dataclass_fields)}"
-                )
-            except AttributeError:
-                raise InvalidFieldException(
-                    f"All fields must be of type {BinaryFieldBase}"
-                )
+        dataclass_fields = fields(cls)
+        try:
+            format_string = (
+                f"{cls.ENDIAN}{''.join(v.type.FORMAT for v in dataclass_fields)}"
+            )
+        except AttributeError:
+            raise InvalidFieldException(f"All fields must be of type {BinaryFieldBase}")
 
-            # Cache it on the cls.
-            setattr(cls, format_string_attribute, format_string)
         return format_string
 
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

We are using the can comm script a lot. Looking at long bytes trying to decipher what they mean is dumb. This PR adds displaying of parsed messages in the log.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

Removed my ill conceived format string caching.

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

None