### PR TITLE
refactor(protocol-engine): add ability to simulate pause

### DIFF
--- a/api/src/opentrons/protocol_engine/create_protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/create_protocol_engine.py
@@ -3,14 +3,18 @@ from opentrons.hardware_control.api import API as HardwareAPI
 
 from .protocol_engine import ProtocolEngine
 from .resources import DeckDataProvider
-from .state import StateStore
+from .state import StateStore, EngineConfigs
 
 
-async def create_protocol_engine(hardware_api: HardwareAPI) -> ProtocolEngine:
+async def create_protocol_engine(
+    hardware_api: HardwareAPI,
+    configs: EngineConfigs = EngineConfigs(),
+) -> ProtocolEngine:
     """Create a ProtocolEngine instance.
 
     Arguments:
         hardware_api: Hardware control API to pass down to dependencies.
+        configs: Protocol Engine configurations.
     """
     # TODO(mc, 2020-11-18): check short trash FF
     deck_data = DeckDataProvider()
@@ -22,6 +26,7 @@ async def create_protocol_engine(hardware_api: HardwareAPI) -> ProtocolEngine:
     state_store = StateStore(
         deck_definition=deck_definition,
         deck_fixed_labware=deck_fixed_labware,
+        configs=configs,
     )
 
     return ProtocolEngine(state_store=state_store, hardware_api=hardware_api)

--- a/api/src/opentrons/protocol_engine/execution/run_control.py
+++ b/api/src/opentrons/protocol_engine/execution/run_control.py
@@ -20,8 +20,8 @@ class RunControlHandler:
 
     async def pause(self) -> None:
         """Issue a PauseAction to the store, pausing the run."""
-        self._action_dispatcher.dispatch(PauseAction())
-
-        await self._state_store.wait_for(
-            condition=self._state_store.commands.get_is_running
-        )
+        if not self._state_store.get_configs().ignore_pause:
+            self._action_dispatcher.dispatch(PauseAction())
+            await self._state_store.wait_for(
+                condition=self._state_store.commands.get_is_running
+            )

--- a/api/src/opentrons/protocol_engine/state/__init__.py
+++ b/api/src/opentrons/protocol_engine/state/__init__.py
@@ -6,7 +6,7 @@ from .labware import LabwareState, LabwareView
 from .pipettes import PipetteState, PipetteView, HardwarePipette, CurrentWell
 from .geometry import GeometryView, TipGeometry
 from .motion import MotionView, PipetteLocationData
-
+from .configs import EngineConfigs
 
 __all__ = [
     # top level state value and interfaces
@@ -30,4 +30,5 @@ __all__ = [
     # computed motion state
     "MotionView",
     "PipetteLocationData",
+    "EngineConfigs",
 ]

--- a/api/src/opentrons/protocol_engine/state/configs.py
+++ b/api/src/opentrons/protocol_engine/state/configs.py
@@ -1,6 +1,5 @@
-# Use for simulating pause commands.. engine_state.config.ignore_pause
+"""Configurations for the Engine."""
 from dataclasses import dataclass
-from .abstract_store import HasState
 
 
 @dataclass(frozen=True)
@@ -8,23 +7,3 @@ class EngineConfigs:
     """Configurations for Protocol Engine."""
 
     ignore_pause: bool = False
-
-
-# create an engineconfigs view that would be used in state store
-# or use a `get_configs()` method instead of configs() property. Both will make it easier to test
-
-
-# class EngineConfigsView(HasState[EngineConfigs]):
-#     """Read-only configs state view."""
-#     _state = EngineConfigs
-#
-#     def __init__(self, state: EngineConfigs) -> None:
-#         """Initialize the computed view of Engine Configs state.
-#
-#         Arguments:
-#             state: Engine Configs state dataclass.
-#         """
-#         self._state = state
-#
-#     def get(self) -> EngineConfigs:
-#         """Get Engine config data"""

--- a/api/src/opentrons/protocol_engine/state/configs.py
+++ b/api/src/opentrons/protocol_engine/state/configs.py
@@ -1,0 +1,30 @@
+# Use for simulating pause commands.. engine_state.config.ignore_pause
+from dataclasses import dataclass
+from .abstract_store import HasState
+
+
+@dataclass(frozen=True)
+class EngineConfigs:
+    """Configurations for Protocol Engine."""
+
+    ignore_pause: bool = False
+
+
+# create an engineconfigs view that would be used in state store
+# or use a `get_configs()` method instead of configs() property. Both will make it easier to test
+
+
+# class EngineConfigsView(HasState[EngineConfigs]):
+#     """Read-only configs state view."""
+#     _state = EngineConfigs
+#
+#     def __init__(self, state: EngineConfigs) -> None:
+#         """Initialize the computed view of Engine Configs state.
+#
+#         Arguments:
+#             state: Engine Configs state dataclass.
+#         """
+#         self._state = state
+#
+#     def get(self) -> EngineConfigs:
+#         """Get Engine config data"""

--- a/api/src/opentrons/protocol_engine/state/state.py
+++ b/api/src/opentrons/protocol_engine/state/state.py
@@ -95,6 +95,7 @@ class StateStore(StateView, ActionHandler):
                 labware state.
             deck_fixed_labware: Labware definitions from the deck
                 definition to preload into labware state.
+            configs: Configurations for the engine.
             change_notifier: Internal state change notifier.
         """
         self._command_store = CommandStore()

--- a/api/src/opentrons/protocol_engine/state/state.py
+++ b/api/src/opentrons/protocol_engine/state/state.py
@@ -16,6 +16,7 @@ from .labware import LabwareState, LabwareStore, LabwareView
 from .pipettes import PipetteState, PipetteStore, PipetteView
 from .geometry import GeometryView
 from .motion import MotionView
+from .configs import EngineConfigs
 
 
 ReturnT = TypeVar("ReturnT")
@@ -39,6 +40,7 @@ class StateView(HasState[State]):
     _pipettes: PipetteView
     _geometry: GeometryView
     _motion: MotionView
+    _configs: EngineConfigs
 
     @property
     def commands(self) -> CommandView:
@@ -65,6 +67,11 @@ class StateView(HasState[State]):
         """Get state view selectors for derived motion state."""
         return self._motion
 
+    # TODO (spp, 2021-10-19): make this a property once EngineConfigsView is added.
+    def get_configs(self) -> EngineConfigs:
+        """Get Protocol Engine configurations."""
+        return self._configs
+
 
 class StateStore(StateView, ActionHandler):
     """ProtocolEngine state store.
@@ -78,6 +85,7 @@ class StateStore(StateView, ActionHandler):
         self,
         deck_definition: DeckDefinitionV2,
         deck_fixed_labware: Sequence[DeckFixedLabware],
+        configs: EngineConfigs = EngineConfigs(),
         change_notifier: Optional[ChangeNotifier] = None,
     ) -> None:
         """Initialize a StateStore and its substores.
@@ -101,7 +109,7 @@ class StateStore(StateView, ActionHandler):
             self._pipette_store,
             self._labware_store,
         ]
-
+        self._configs = configs
         self._change_notifier = change_notifier or ChangeNotifier()
         self._initialize_state()
 

--- a/api/src/opentrons/protocol_runner/create_simulating_runner.py
+++ b/api/src/opentrons/protocol_runner/create_simulating_runner.py
@@ -2,6 +2,7 @@
 
 from opentrons.hardware_control import API as HardwareAPI
 from opentrons.protocol_engine import create_protocol_engine
+from opentrons.protocol_engine.state import EngineConfigs
 from .protocol_runner import ProtocolRunner
 
 
@@ -35,7 +36,10 @@ async def create_simulating_runner() -> ProtocolRunner:
 
     # TODO(mc, 2021-08-25): this engine will not simulate pauses
     # https://github.com/Opentrons/opentrons/issues/8265
-    protocol_engine = await create_protocol_engine(hardware_api=simulating_hardware_api)
+    protocol_engine = await create_protocol_engine(
+        hardware_api=simulating_hardware_api,
+        configs=EngineConfigs(ignore_pause=True),
+    )
 
     return ProtocolRunner(
         protocol_engine=protocol_engine,

--- a/api/src/opentrons/protocol_runner/create_simulating_runner.py
+++ b/api/src/opentrons/protocol_runner/create_simulating_runner.py
@@ -34,13 +34,10 @@ async def create_simulating_runner() -> ProtocolRunner:
     # TODO(mc, 2021-08-25): move initial home to protocol engine
     await simulating_hardware_api.home()
 
-    # TODO(mc, 2021-08-25): this engine will not simulate pauses
-    # https://github.com/Opentrons/opentrons/issues/8265
     protocol_engine = await create_protocol_engine(
         hardware_api=simulating_hardware_api,
         configs=EngineConfigs(ignore_pause=True),
     )
-
     return ProtocolRunner(
         protocol_engine=protocol_engine,
         hardware_api=simulating_hardware_api,

--- a/api/tests/opentrons/protocol_engine/execution/test_run_control_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_run_control_handler.py
@@ -5,6 +5,7 @@ from decoy import Decoy
 from opentrons.protocol_engine.state import StateStore
 from opentrons.protocol_engine.actions import ActionDispatcher, PauseAction
 from opentrons.protocol_engine.execution.run_control import RunControlHandler
+from opentrons.protocol_engine.state import EngineConfigs
 
 
 @pytest.fixture
@@ -38,9 +39,21 @@ async def test_pause(
     subject: RunControlHandler,
 ) -> None:
     """It should be able to execute a pause."""
+    decoy.when(state_store.get_configs()).then_return(EngineConfigs(ignore_pause=False))
     await subject.pause()
-
     decoy.verify(
         action_dispatcher.dispatch(PauseAction()),
         await state_store.wait_for(condition=state_store.commands.get_is_running),
     )
+
+
+async def test_pause_analysis(
+    decoy: Decoy,
+    state_store: StateStore,
+    action_dispatcher: ActionDispatcher,
+    subject: RunControlHandler,
+) -> None:
+    """It should no op during a protocol analysis."""
+    decoy.when(state_store.get_configs()).then_return(EngineConfigs(ignore_pause=True))
+    await subject.pause()
+    decoy.verify(action_dispatcher.dispatch(PauseAction()), times=0)


### PR DESCRIPTION
# Overview

Closes #8265 
This PR enables the protocol engine to run analysis on protocols that include pause commands.

# Changelog

Added EngineConfigs dataclass to protocol engine StateStore which has an `ignore_pause` member that the run controller references during protocol execution. We anticipate this dataclass would you be used for more configurations in the future (although right now there's just the one).

# Review requests

- Whether code looks good
- I have smoke tested on dev server with a python protocol but feel free to do any additional testing

# Risk assessment

Low/None. Behind feature flag. Affects mostly only pause command.
