### PR TITLE
feat(app): rewire connect to robot

### DIFF
--- a/app/src/pages/Robots/ConnectPanel/RobotItem.tsx
+++ b/app/src/pages/Robots/ConnectPanel/RobotItem.tsx
@@ -7,6 +7,7 @@ import {
   actions as RobotActions,
   selectors as RobotSelectors,
 } from '../../../redux/robot'
+import { useFeatureFlag } from '../../../redux/config'
 import { getBuildrootUpdateAvailable, UPGRADE } from '../../../redux/buildroot'
 import { CONNECTABLE } from '../../../redux/discovery'
 import { RobotListItem } from './RobotListItem'
@@ -34,12 +35,15 @@ export function RobotItemComponent(props: RobotItemProps): JSX.Element {
     (state: State) => RobotSelectors.getConnectRequest(state).inProgress
   )
   const dispatch = useDispatch<Dispatch>()
+  const isUploadWithoutRPC = useFeatureFlag('preProtocolFlowWithoutRPC')
+
+  const connect = isUploadWithoutRPC
+    ? RobotActions.connect
+    : RobotActions.legacyConnect
 
   const handleToggleConnect = (): void => {
     if (!connectInProgress) {
-      const action = isConnected
-        ? RobotActions.disconnect()
-        : RobotActions.connect(name)
+      const action = isConnected ? RobotActions.disconnect() : connect(name)
 
       dispatch(action)
     }

--- a/app/src/pages/Robots/RobotSettings/StatusCard.tsx
+++ b/app/src/pages/Robots/RobotSettings/StatusCard.tsx
@@ -19,6 +19,7 @@ import {
 } from '@opentrons/components'
 import { CONNECTABLE } from '../../../redux/discovery'
 import { LabeledValue } from '../../../atoms/structure'
+import { useFeatureFlag } from '../../../redux/config'
 
 import type { Dispatch } from '../../../redux/types'
 import type { ViewableRobot } from '../../../redux/discovery/types'
@@ -47,11 +48,17 @@ export function StatusCard(props: Props): JSX.Element {
     status = sessionStatus
   }
 
+  const isUploadWithoutRPC = useFeatureFlag('preProtocolFlowWithoutRPC')
+
+  const connect = isUploadWithoutRPC
+    ? robotActions.connect
+    : robotActions.legacyConnect
+
   const handleClick: React.MouseEventHandler = () => {
     if (connected) {
       dispatch(robotActions.disconnect())
     } else {
-      dispatch(robotActions.connect(robot.name))
+      dispatch(connect(robot.name))
     }
   }
 

--- a/app/src/pages/Robots/RobotSettings/__tests__/StatusCard.test.tsx
+++ b/app/src/pages/Robots/RobotSettings/__tests__/StatusCard.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { when, resetAllWhenMocks } from 'jest-when'
 import { SecondaryBtn, Icon, mountWithProviders } from '@opentrons/components'
 import { i18n } from '../../../../i18n'
 
@@ -7,11 +8,13 @@ import {
   actions as RobotActions,
   selectors as RobotSelectors,
 } from '../../../../redux/robot'
+import { useFeatureFlag } from '../../../../redux/config'
 import { StatusCard } from '../StatusCard'
 
 import type { ViewableRobot } from '../../../../redux/discovery/types'
 
 jest.mock('../../../../redux/robot/selectors')
+jest.mock('../../../../redux/config')
 
 const getSessionStatus = RobotSelectors.getSessionStatus as jest.MockedFunction<
   typeof RobotSelectors.getSessionStatus
@@ -19,6 +22,10 @@ const getSessionStatus = RobotSelectors.getSessionStatus as jest.MockedFunction<
 
 const getConnectRequest = RobotSelectors.getConnectRequest as jest.MockedFunction<
   typeof RobotSelectors.getConnectRequest
+>
+
+const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<
+  typeof useFeatureFlag
 >
 
 describe('RobotSettings StatusCard', () => {
@@ -41,6 +48,7 @@ describe('RobotSettings StatusCard', () => {
 
   afterEach(() => {
     jest.resetAllMocks()
+    resetAllWhenMocks()
   })
 
   it('should have a connect button', () => {
@@ -50,7 +58,25 @@ describe('RobotSettings StatusCard', () => {
     expect(button.html()).toContain('connect')
   })
 
-  it('dispatch connect on connect button click if disconnected', () => {
+  it('dispatch connect on connect button click if disconnected and usePreProtocolWithoutRPC ff is NOT set', () => {
+    when(mockUseFeatureFlag)
+      .calledWith('preProtocolFlowWithoutRPC')
+      .mockReturnValue(false)
+
+    const { wrapper, store } = render()
+    const button = wrapper.find(SecondaryBtn)
+
+    button.invoke('onClick')?.({} as React.MouseEvent)
+    expect(store.dispatch).toHaveBeenCalledWith(
+      RobotActions.legacyConnect(Fixtures.mockConnectableRobot.name)
+    )
+  })
+
+  it('dispatch connect on connect button click if disconnected and usePreProtocolWithoutRPC ff is set', () => {
+    when(mockUseFeatureFlag)
+      .calledWith('preProtocolFlowWithoutRPC')
+      .mockReturnValue(true)
+
     const { wrapper, store } = render()
     const button = wrapper.find(SecondaryBtn)
 

--- a/app/src/redux/robot-admin/epic/__tests__/syncTimeOnConnectEpic.test.ts
+++ b/app/src/redux/robot-admin/epic/__tests__/syncTimeOnConnectEpic.test.ts
@@ -13,7 +13,7 @@ import { syncTimeOnConnectEpic } from '../syncTimeOnConnectEpic'
 import type { Action } from '../../../types'
 
 const createConnectAction = (robotName: string): Action =>
-  RobotActions.connect(robotName) as any
+  RobotActions.legacyConnect(robotName) as any
 
 const createTimeSuccessResponse = (
   time: Date

--- a/app/src/redux/robot-admin/epic/syncTimeOnConnectEpic.ts
+++ b/app/src/redux/robot-admin/epic/syncTimeOnConnectEpic.ts
@@ -13,7 +13,7 @@ import type { ConnectAction, LegacyConnectAction } from '../../robot/actions'
 const SYNC_THRESHOLD_SEC = 60
 
 const mapActionToFetchRequest = (
-  action: LegacyConnectAction
+  action: LegacyConnectAction | ConnectAction
 ): RobotApiRequestOptions => {
   return { method: GET, path: Constants.SYSTEM_TIME_PATH }
 }
@@ -32,7 +32,10 @@ const createUpdateRequest = (date: Date): RobotApiRequestOptions => {
 
 export const syncTimeOnConnectEpic: Epic = (action$, state$) => {
   return action$.pipe(
-    ofType<Action, LegacyConnectAction | ConnectAction>('robot:LEGACY_CONNECT', 'robot:CONNECT'),
+    ofType<Action, LegacyConnectAction | ConnectAction>(
+      'robot:LEGACY_CONNECT',
+      'robot:CONNECT'
+    ),
     withRobotHost(state$, action => action.payload.name),
     // TODO(mc, 2020-09-08): only fetch if health.links.systemTime exists,
     // see TODO in robot-server/robot_server/service/legacy/models/health.py

--- a/app/src/redux/robot-admin/epic/syncTimeOnConnectEpic.ts
+++ b/app/src/redux/robot-admin/epic/syncTimeOnConnectEpic.ts
@@ -8,12 +8,12 @@ import * as Constants from '../constants'
 
 import type { Action, Epic } from '../../types'
 import type { RobotApiRequestOptions } from '../../robot-api/types'
-import type { ConnectAction } from '../../robot/actions'
+import type { ConnectAction, LegacyConnectAction } from '../../robot/actions'
 
 const SYNC_THRESHOLD_SEC = 60
 
 const mapActionToFetchRequest = (
-  action: ConnectAction
+  action: LegacyConnectAction
 ): RobotApiRequestOptions => {
   return { method: GET, path: Constants.SYSTEM_TIME_PATH }
 }
@@ -32,7 +32,7 @@ const createUpdateRequest = (date: Date): RobotApiRequestOptions => {
 
 export const syncTimeOnConnectEpic: Epic = (action$, state$) => {
   return action$.pipe(
-    ofType<Action, ConnectAction>('robot:CONNECT'),
+    ofType<Action, LegacyConnectAction | ConnectAction>('robot:LEGACY_CONNECT', 'robot:CONNECT'),
     withRobotHost(state$, action => action.payload.name),
     // TODO(mc, 2020-09-08): only fetch if health.links.systemTime exists,
     // see TODO in robot-server/robot_server/service/legacy/models/health.py

--- a/app/src/redux/robot/actions.ts
+++ b/app/src/redux/robot/actions.ts
@@ -3,13 +3,20 @@ import type { Error } from '../types'
 import type { ProtocolData } from '../protocol/types'
 import type { Mount, Slot, Axis, Direction, SessionUpdate } from './types'
 
-export interface ConnectAction {
-  type: 'robot:CONNECT'
+export interface LegacyConnectAction {
+  type: 'robot:LEGACY_CONNECT'
   payload: {
     name: string
   }
   meta: {
     robotCommand: true
+  }
+}
+
+export interface ConnectAction {
+  type: 'robot:CONNECT'
+  payload: {
+    name: string
   }
 }
 
@@ -277,6 +284,7 @@ export const actionTypes = {
 
 // TODO(mc, 2018-01-23): NEW ACTION TYPES GO HERE
 export type Action =
+  | LegacyConnectAction
   | ConnectAction
   | ConnectResponseAction
   | DisconnectAction
@@ -313,9 +321,9 @@ export type Action =
   | CancelResponseAction
 
 export const actions = {
-  connect(name: string): ConnectAction {
+  connect(name: string): LegacyConnectAction {
     return {
-      type: 'robot:CONNECT',
+      type: 'robot:LEGACY_CONNECT',
       payload: { name },
       meta: { robotCommand: true },
     }

--- a/app/src/redux/robot/actions.ts
+++ b/app/src/redux/robot/actions.ts
@@ -285,7 +285,6 @@ export const actionTypes = {
   CANCEL_RESPONSE: 'robot:CANCEL_RESPONSE',
 } as const
 
-// TODO(mc, 2018-01-23): NEW ACTION TYPES GO HERE
 export type Action =
   | LegacyConnectAction
   | ConnectAction

--- a/app/src/redux/robot/actions.ts
+++ b/app/src/redux/robot/actions.ts
@@ -18,6 +18,9 @@ export interface ConnectAction {
   payload: {
     name: string
   }
+  meta: {
+    robotCommand: true
+  }
 }
 
 export interface ConnectResponseAction {
@@ -321,9 +324,18 @@ export type Action =
   | CancelResponseAction
 
 export const actions = {
-  connect(name: string): LegacyConnectAction {
+  // legacyConnect will construct an RPC client and update state
+  legacyConnect(name: string): LegacyConnectAction {
     return {
       type: 'robot:LEGACY_CONNECT',
+      payload: { name },
+      meta: { robotCommand: true },
+    }
+  },
+  // connect will NOT construct an RPC client
+  connect(name: string): ConnectAction {
+    return {
+      type: 'robot:CONNECT',
       payload: { name },
       meta: { robotCommand: true },
     }

--- a/app/src/redux/robot/api-client/__tests__/create-sessions.test.js
+++ b/app/src/redux/robot/api-client/__tests__/create-sessions.test.js
@@ -55,7 +55,7 @@ describe('RPC API client - session creation', () => {
       return _flush()
     }
 
-    return sendToClient(RobotActions.connect(mockRobot.name))
+    return sendToClient(RobotActions.legacyConnect(mockRobot.name))
   })
 
   afterEach(() => {

--- a/app/src/redux/robot/api-client/client.js
+++ b/app/src/redux/robot/api-client/client.js
@@ -94,7 +94,6 @@ export function client(dispatch) {
 
   // legacyConnect sets up the RPC client
   function legacyConnect(state, action) {
-    console.log('legacy connect being called!')
     if (selectors.getConnectRequest(state).inProgress) return
     if (rpcClient) disconnect()
 

--- a/app/src/redux/robot/api-client/client.js
+++ b/app/src/redux/robot/api-client/client.js
@@ -94,6 +94,7 @@ export function client(dispatch) {
 
   // legacyConnect sets up the RPC client
   function legacyConnect(state, action) {
+    console.log('legacy connect being called!')
     if (selectors.getConnectRequest(state).inProgress) return
     if (rpcClient) disconnect()
 

--- a/app/src/redux/robot/reducer/connection.ts
+++ b/app/src/redux/robot/reducer/connection.ts
@@ -3,6 +3,7 @@ import type { Action } from '../../types'
 
 import type {
   ConnectAction,
+  LegacyConnectAction,
   ConnectResponseAction,
   ClearConnectResponseAction,
   DisconnectAction,
@@ -37,6 +38,7 @@ export function connectionReducer(
   if (state == null) return INITIAL_STATE
 
   switch (action.type) {
+    case 'robot:LEGACY_CONNECT':
     case 'robot:CONNECT':
       return handleConnect(state, action)
 
@@ -61,7 +63,7 @@ export function connectionReducer(
 
 function handleConnect(
   state: ConnectionState,
-  action: ConnectAction
+  action: LegacyConnectAction | ConnectAction
 ): ConnectionState {
   const {
     payload: { name },

--- a/app/src/redux/robot/test/actions.test.ts
+++ b/app/src/redux/robot/test/actions.test.ts
@@ -3,9 +3,19 @@ import { actions, actionTypes } from '../'
 import type { SessionUpdate } from '../types'
 
 describe('robot actions', () => {
-  it('CONNECT action', () => {
+  it('LEGACY_CONNECT action', () => {
     const expected = {
       type: 'robot:LEGACY_CONNECT',
+      payload: { name: 'ot' },
+      meta: { robotCommand: true },
+    }
+
+    expect(actions.legacyConnect('ot')).toEqual(expected)
+  })
+
+  it('CONNECT action', () => {
+    const expected = {
+      type: 'robot:CONNECT',
       payload: { name: 'ot' },
       meta: { robotCommand: true },
     }

--- a/app/src/redux/robot/test/actions.test.ts
+++ b/app/src/redux/robot/test/actions.test.ts
@@ -5,7 +5,7 @@ import type { SessionUpdate } from '../types'
 describe('robot actions', () => {
   it('CONNECT action', () => {
     const expected = {
-      type: 'robot:CONNECT',
+      type: 'robot:LEGACY_CONNECT',
       payload: { name: 'ot' },
       meta: { robotCommand: true },
     }

--- a/app/src/redux/robot/test/api-client.test.ts
+++ b/app/src/redux/robot/test/api-client.test.ts
@@ -117,7 +117,7 @@ describe('api client', () => {
   } as any
 
   const sendConnect = (): Promise<unknown> =>
-    sendToClient(STATE, actions.connect(ROBOT_NAME))
+    sendToClient(STATE, actions.legacyConnect(ROBOT_NAME))
 
   const sendDisconnect = (): Promise<unknown> =>
     sendToClient(STATE, actions.disconnect())
@@ -231,7 +231,7 @@ describe('api client', () => {
         },
       } as any
 
-      return sendToClient(state, actions.connect(ROBOT_NAME)).then(() => {
+      return sendToClient(state, actions.legacyConnect(ROBOT_NAME)).then(() => {
         expect(RpcClient).toHaveBeenCalledTimes(0)
       })
     })

--- a/app/src/redux/robot/test/connection-reducer.test.ts
+++ b/app/src/redux/robot/test/connection-reducer.test.ts
@@ -31,7 +31,7 @@ describe('robot reducer - connection', () => {
       },
     } as any
     const action: Action = {
-      type: 'robot:CONNECT',
+      type: 'robot:LEGACY_CONNECT',
       payload: { name: 'ot' },
       meta: {} as any,
     }
@@ -54,7 +54,7 @@ describe('robot reducer - connection', () => {
       },
     } as any
     const action: Action = {
-      type: 'robot:CONNECT',
+      type: 'robot:LEGACY_CONNECT',
       payload: { name: 'someone-else' },
       meta: {} as any,
     }

--- a/app/src/redux/robot/test/connection-reducer.test.ts
+++ b/app/src/redux/robot/test/connection-reducer.test.ts
@@ -19,7 +19,7 @@ describe('robot reducer - connection', () => {
     })
   })
 
-  it('handles CONNECT action', () => {
+  it('handles LEGACY_CONNECT action', () => {
     const state: RobotState = {
       connection: {
         connectedTo: null,
@@ -42,7 +42,30 @@ describe('robot reducer - connection', () => {
     })
   })
 
-  it('handles CONNECT action if connect already in flight', () => {
+  it('handles CONNECT action', () => {
+    const state: RobotState = {
+      connection: {
+        connectedTo: null,
+        connectRequest: {
+          inProgress: false,
+          error: new Error('AH'),
+          name: '',
+        },
+      },
+    } as any
+    const action: Action = {
+      type: 'robot:CONNECT',
+      payload: { name: 'ot' },
+      meta: {} as any,
+    }
+
+    expect(getState(reducer(state, action))).toEqual({
+      connectedTo: null,
+      connectRequest: { inProgress: true, error: null, name: 'ot' },
+    })
+  })
+
+  it('handles LEGACY_CONNECT action if connect already in flight', () => {
     const state: RobotState = {
       connection: {
         connectedTo: null,
@@ -55,6 +78,29 @@ describe('robot reducer - connection', () => {
     } as any
     const action: Action = {
       type: 'robot:LEGACY_CONNECT',
+      payload: { name: 'someone-else' },
+      meta: {} as any,
+    }
+
+    expect(getState(reducer(state, action))).toEqual({
+      connectedTo: null,
+      connectRequest: { inProgress: true, error: null, name: 'ot' },
+    })
+  })
+
+  it('handles CONNECT action if connect already in flight', () => {
+    const state: RobotState = {
+      connection: {
+        connectedTo: null,
+        connectRequest: {
+          inProgress: true,
+          error: null,
+          name: 'ot',
+        },
+      },
+    } as any
+    const action: Action = {
+      type: 'robot:CONNECT',
       payload: { name: 'someone-else' },
       meta: {} as any,
     }


### PR DESCRIPTION
# Overview

Pairing credit to @b-cooper!

This PR makes it so that in the new pre protocol flow without RPC, connecting to a robot does NOT establish an RPC connection. 

This means that we should now be able to connect to a robot while the`Enable Experimental Protocol Engine` FF is on. 

closes #8552

# Changelog
- Remove RPC connection in new pre protocol flow 

# Review requests

- code review
- you should be able to connect to a robot while the `__DEV__ Pre Protocol Flow Without RPC` and `Enable Experimental Protocol Engine` FFs are on. 
# Risk assessment

Low