### PR TITLE
feat(app): LPC final summary screen scaffolding

### DIFF
--- a/app/src/assets/localization/en/labware_position_check.json
+++ b/app/src/assets/localization/en/labware_position_check.json
@@ -29,5 +29,7 @@
   "labware_offsets_summary_deckslot": "Deck Slot",
   "labware_offsets_summary_labware": "Labware",
   "labware_offsets_summary_offset": "Labware Offset Data",
-  "close_and_apply_offset_data": "Close and apply labware offset data"
+  "close_and_apply_offset_data": "Close and apply labware offset data",
+  "offset_values": "<bold>X</bold> {{x_offset}} <bold>Y</bold> {{y_offset}} <bold>Z</bold> {{z_offset}}",
+  "no_labware_offsets": "No Labware Offsets"
 }

--- a/app/src/assets/localization/en/labware_position_check.json
+++ b/app/src/assets/localization/en/labware_position_check.json
@@ -26,10 +26,9 @@
   "reveal_jog_controls": "Reveal jog controls",
   "lpc_complete_summary_screen_heading": "Labware Position Check Complete",
   "labware_offsets_summary_title": "Labware Offsets to be applied to this run",
-  "labware_offsets_summary_deckslot": "Deck Slot",
+  "labware_offsets_summary_location": "Location",
   "labware_offsets_summary_labware": "Labware",
   "labware_offsets_summary_offset": "Labware Offset Data",
   "close_and_apply_offset_data": "Close and apply labware offset data",
-  "offset_values": "<bold>X</bold> {{x_offset}} <bold>Y</bold> {{y_offset}} <bold>Z</bold> {{z_offset}}",
   "no_labware_offsets": "No Labware Offsets"
 }

--- a/app/src/assets/localization/en/labware_position_check.json
+++ b/app/src/assets/localization/en/labware_position_check.json
@@ -23,5 +23,11 @@
   "labware_step_detail_modal_nozzle_or_tip_image_3_text": "If you’re having trouble, slide 1 sheet of printer paper between the nozzle and the tip. A single piece of paper should barely pass between them.",
   "start_position_check": "begin labware position check, move to Slot {{initial_labware_slot}}",
   "jog_controls_adjustment": "Need to make an adjustment?",
-  "reveal_jog_controls": "Reveal jog controls"
+  "reveal_jog_controls": "Reveal jog controls",
+  "lpc_complete_summary_screen_heading": "Labware Position Check Complete",
+  "labware_offsets_summary_title": "Labware Offsets to be applied to this run",
+  "labware_offsets_summary_deckslot": "Deck Slot",
+  "labware_offsets_summary_labware": "Labware",
+  "labware_offsets_summary_offset": "Labware Offset Data",
+  "close_and_apply_offset_data": "Close and apply labware offset data"
 }

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/GenericStepScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/GenericStepScreen.tsx
@@ -53,7 +53,7 @@ export const GenericStepScreen = (
           />
         </Flex>
       </Flex>
-      <Flex flex={'1 1 60%'} padding={SPACING_3}>
+      <Flex padding={SPACING_3}>
         <LabwarePositionCheckStepDetail selectedStep={props.selectedStep} />
       </Flex>
     </Flex>

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/GenericStepScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/GenericStepScreen.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react'
 import {
   ALIGN_CENTER,
-  Box,
   DIRECTION_COLUMN,
   Flex,
   JUSTIFY_CENTER,
   JUSTIFY_SPACE_BETWEEN,
   SPACING_3,
-  SPACING_5,
+  SPACING_4,
 } from '@opentrons/components'
 import { LabwarePositionCheckStepDetail } from './LabwarePositionCheckStepDetail'
 import { SectionList } from './SectionList'
@@ -30,31 +29,33 @@ export const GenericStepScreen = (
   const labwareIdsToHighlight = labwareIdsBySection[sections[sectionIndex]]
 
   return (
-    <Box margin={SPACING_3}>
-      <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} alignItems={ALIGN_CENTER}>
-        <Flex flexDirection={DIRECTION_COLUMN}>
-          <Flex marginRight={SPACING_5}>
-            <SectionList
-              primaryPipetteMount={primaryPipetteMount}
-              secondaryPipetteMount={secondaryPipetteMount}
-              sections={sections}
-              currentSection={sections[sectionIndex]}
-              completedSections={[sections[sectionIndex - 1]]}
-            />
-          </Flex>
-          <Flex justifyContent={JUSTIFY_CENTER}>
-            <DeckMap
-              labwareIdsToHighlight={labwareIdsToHighlight}
-              completedLabwareIdSections={
-                labwareIdsBySection[sections[sectionIndex - 1]]
-              }
-            />
-          </Flex>
+    <Flex
+      justifyContent={JUSTIFY_SPACE_BETWEEN}
+      alignItems={ALIGN_CENTER}
+      margin={SPACING_3}
+    >
+      <Flex flexDirection={DIRECTION_COLUMN}>
+        <Flex marginLeft={SPACING_4}>
+          <SectionList
+            primaryPipetteMount={primaryPipetteMount}
+            secondaryPipetteMount={secondaryPipetteMount}
+            sections={sections}
+            currentSection={sections[sectionIndex]}
+            completedSections={[sections[sectionIndex - 1]]}
+          />
         </Flex>
-        <Box width="60%" padding={SPACING_3}>
-          <LabwarePositionCheckStepDetail selectedStep={props.selectedStep} />
-        </Box>
+        <Flex justifyContent={JUSTIFY_CENTER}>
+          <DeckMap
+            labwareIdsToHighlight={labwareIdsToHighlight}
+            completedLabwareIdSections={
+              labwareIdsBySection[sections[sectionIndex - 1]]
+            }
+          />
+        </Flex>
       </Flex>
-    </Box>
+      <Flex flex={'1 1 60%'} padding={SPACING_3}>
+        <LabwarePositionCheckStepDetail selectedStep={props.selectedStep} />
+      </Flex>
+    </Flex>
   )
 }

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/IntroScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/IntroScreen.tsx
@@ -16,6 +16,7 @@ import {
   SPACING_3,
   SPACING_4,
   FONT_SIZE_BODY_2,
+  SPACING_6,
 } from '@opentrons/components'
 import { SectionList } from './SectionList'
 import { DeckMap } from './DeckMap'
@@ -63,12 +64,14 @@ export const IntroScreen = (props: {
         }}
       ></Trans>
       <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} alignItems={ALIGN_CENTER}>
-        <SectionList
-          sections={sections}
-          currentSection={currentSection}
-          primaryPipetteMount={primaryPipetteMount}
-          secondaryPipetteMount={secondaryPipetteMount}
-        />
+        <Flex marginLeft={SPACING_6}>
+          <SectionList
+            sections={sections}
+            currentSection={currentSection}
+            primaryPipetteMount={primaryPipetteMount}
+            secondaryPipetteMount={secondaryPipetteMount}
+          />
+        </Flex>
         <Box width="60%" padding={SPACING_3}>
           <DeckMap labwareIdsToHighlight={labwareIdsToHighlight} />
         </Box>

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwareOffsetsSummary.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwareOffsetsSummary.tsx
@@ -87,9 +87,9 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
             </Text>
             {getOffsetDataInfo().map(({ deckSlot }) => {
               return (
-                <Flex key={deckSlot} height="30%" css={FONT_BODY_1_DARK}>
+                <Box key={deckSlot} height="30%" css={FONT_BODY_1_DARK}>
                   {deckSlot}
-                </Flex>
+                </Box>
               )
             })}
           </Box>
@@ -106,9 +106,9 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
             >
               {t('labware_offsets_summary_labware')}
             </Text>
-            {getOffsetDataInfo().map(({ labware }) => {
+            {getOffsetDataInfo().map(({ labware }, index) => {
               return (
-                <Flex key={labware} height="30%" css={FONT_BODY_1_DARK}>
+                <Flex key={index} height={'30%'} css={FONT_BODY_1_DARK}>
                   {labware}
                 </Flex>
               )
@@ -129,11 +129,11 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
             </Text>
             {offsetData.map(({ x, y, z }) => {
               return x === 0 && y === 0 && z === 0 ? (
-                <Flex height="30%" css={FONT_BODY_1_DARK}>
+                <Flex height={'30%'} css={FONT_BODY_1_DARK}>
                   {t('no_labware_offsets')}
                 </Flex>
               ) : (
-                <Flex height="30%" css={FONT_BODY_1_DARK}>
+                <Flex height={'30%'} css={FONT_BODY_1_DARK}>
                   <Text as={'span'} marginRight={'0.15rem'}>
                     <strong>X</strong>
                   </Text>

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwareOffsetsSummary.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwareOffsetsSummary.tsx
@@ -55,14 +55,14 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
 
   return (
     <React.Fragment>
-      <Flex
+      <Box
         padding={SPACING_4}
-        justifyContent={JUSTIFY_CENTER}
         boxShadow="1px 1px 1px rgba(0, 0, 0, 0.25)"
         borderRadius="4px"
         backgroundColor={C_NEAR_WHITE}
         flexDirection={DIRECTION_COLUMN}
         width="106%"
+        height="20rem"
       >
         <Text
           as={'h5'}
@@ -87,9 +87,9 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
             </Text>
             {getOffsetDataInfo().map(({ deckSlot }) => {
               return (
-                <Text marginBottom={SPACING_3} css={FONT_BODY_1_DARK}>
+                <Flex key={deckSlot} height="30%" css={FONT_BODY_1_DARK}>
                   {deckSlot}
-                </Text>
+                </Flex>
               )
             })}
           </Box>
@@ -108,9 +108,9 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
             </Text>
             {getOffsetDataInfo().map(({ labware }) => {
               return (
-                <Text marginBottom={SPACING_3} css={FONT_BODY_1_DARK}>
+                <Flex key={labware} height="30%" css={FONT_BODY_1_DARK}>
                   {labware}
-                </Text>
+                </Flex>
               )
             })}
           </Box>
@@ -128,12 +128,12 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
               {t('labware_offsets_summary_offset')}
             </Text>
             {offsetData.map(({ x, y, z }) => {
-              return x == 0 && y == 0 && z == 0 ? (
-                <Text marginBottom={SPACING_3} css={FONT_BODY_1_DARK}>
+              return x === 0 && y === 0 && z === 0 ? (
+                <Flex height="30%" css={FONT_BODY_1_DARK}>
                   {t('no_labware_offsets')}
-                </Text>
+                </Flex>
               ) : (
-                <Box marginBottom={SPACING_3} css={FONT_BODY_1_DARK}>
+                <Flex height="30%" css={FONT_BODY_1_DARK}>
                   <Text as={'span'} marginRight={'0.15rem'}>
                     <strong>X</strong>
                   </Text>
@@ -152,12 +152,12 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
                   <Text as={'span'} marginRight={'0.4rem'}>
                     {z}
                   </Text>
-                </Box>
+                </Flex>
               )
             })}
           </Box>
         </Flex>
-      </Flex>
+      </Box>
     </React.Fragment>
   )
 }

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwareOffsetsSummary.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwareOffsetsSummary.tsx
@@ -18,32 +18,32 @@ import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 
 const getOffsetDataInfo = (): Array<{
-  deckSlot: string
+  location: string
   labware: string
   offsetData: { x: number; y: number; z: number }
 }> => [
   {
-    deckSlot: 'Slot 1',
-    labware: 'Opentrons 96 100mL Tiprack in Temperature Module GEN2',
+    location: 'Temperature Module GEN 2 in Deck Slot 1',
+    labware: 'Opentrons 96 100mL Tiprack',
     offsetData: { x: 1.1, y: 2.1, z: 3.1 },
   },
   {
-    deckSlot: 'Slot 3',
+    location: 'Deck Slot 3',
     labware: 'Opentrons 96 Tip Rack 20µL',
     offsetData: { x: 0.0, y: -1.2, z: 1.1 },
   },
   {
-    deckSlot: 'Slot 5',
+    location: 'Deck Slot 5',
     labware: 'Opentrons Mixed Tube Rack',
     offsetData: { x: 5.1, y: 2.2, z: 3.1 },
   },
   {
-    deckSlot: 'Slot 6',
+    location: 'Deck Slot 6',
     labware: 'Opentrons Mixed Tube Rack',
     offsetData: { x: 0.0, y: 0.0, z: 0.0 },
   },
   {
-    deckSlot: 'Slot 7',
+    location: 'Thermocycler',
     labware: 'Opentrons Mixed Tube Rack',
     offsetData: { x: 0.0, y: 0.0, z: 0.0 },
   },
@@ -55,7 +55,7 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
 
   return (
     <React.Fragment>
-      <Box
+      <Flex
         padding={SPACING_4}
         boxShadow="1px 1px 1px rgba(0, 0, 0, 0.25)"
         borderRadius="4px"
@@ -73,7 +73,7 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
         </Text>
         <Flex flexDirection={DIRECTION_ROW} justifyContent={JUSTIFY_CENTER}>
           <Box
-            width="20%"
+            width="30%"
             flexDirection={DIRECTION_COLUMN}
             justifyContent={JUSTIFY_CENTER}
           >
@@ -83,18 +83,18 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
               color={C_DISABLED}
               fontSize={FONT_SIZE_CAPTION}
             >
-              {t('labware_offsets_summary_deckslot')}
+              {t('labware_offsets_summary_location')}
             </Text>
-            {getOffsetDataInfo().map(({ deckSlot }) => {
+            {getOffsetDataInfo().map(({ location }) => {
               return (
-                <Box key={deckSlot} height="30%" css={FONT_BODY_1_DARK}>
-                  {deckSlot}
+                <Box key={location} height="30%" css={FONT_BODY_1_DARK}>
+                  {location}
                 </Box>
               )
             })}
           </Box>
           <Box
-            width="50%"
+            width="40%"
             flexDirection={DIRECTION_COLUMN}
             justifyContent={JUSTIFY_CENTER}
           >
@@ -157,7 +157,7 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
             })}
           </Box>
         </Flex>
-      </Box>
+      </Flex>
     </React.Fragment>
   )
 }

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwareOffsetsSummary.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwareOffsetsSummary.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useTranslation } from 'react-i18next'
 import {
   Box,
   C_DISABLED,
@@ -15,7 +16,6 @@ import {
   Text,
   TEXT_TRANSFORM_UPPERCASE,
 } from '@opentrons/components'
-import { useTranslation } from 'react-i18next'
 
 const getOffsetDataInfo = (): Array<{
   location: string
@@ -71,11 +71,7 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
           {t('labware_offsets_summary_title')}
         </Text>
         <Flex flexDirection={DIRECTION_ROW} justifyContent={JUSTIFY_CENTER}>
-          <Box
-            width="30%"
-            flexDirection={DIRECTION_COLUMN}
-            justifyContent={JUSTIFY_CENTER}
-          >
+          <Box width="30%" justifyContent={JUSTIFY_CENTER}>
             <Text
               textTransform={TEXT_TRANSFORM_UPPERCASE}
               marginBottom={SPACING_3}
@@ -96,11 +92,7 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
               )
             })}
           </Box>
-          <Box
-            width="40%"
-            flexDirection={DIRECTION_COLUMN}
-            justifyContent={JUSTIFY_CENTER}
-          >
+          <Box width="40%" justifyContent={JUSTIFY_CENTER}>
             <Text
               textTransform={TEXT_TRANSFORM_UPPERCASE}
               marginBottom={SPACING_3}
@@ -121,11 +113,7 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
               )
             })}
           </Box>
-          <Box
-            width="30%"
-            flexDirection={DIRECTION_COLUMN}
-            justifyContent={JUSTIFY_CENTER}
-          >
+          <Box width="30%" justifyContent={JUSTIFY_CENTER}>
             <Text
               textTransform={TEXT_TRANSFORM_UPPERCASE}
               marginBottom={SPACING_3}
@@ -134,9 +122,13 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
             >
               {t('labware_offsets_summary_offset')}
             </Text>
-            {offsetData.map(({ x, y, z }) => {
+            {offsetData.map(({ x, y, z }, index) => {
               return x === 0 && y === 0 && z === 0 ? (
-                <Flex marginBottom={SPACING_3} css={FONT_BODY_1_DARK}>
+                <Flex
+                  key={index}
+                  marginBottom={SPACING_3}
+                  css={FONT_BODY_1_DARK}
+                >
                   {t('no_labware_offsets')}
                 </Flex>
               ) : (
@@ -144,19 +136,19 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
                   <Text as={'span'} marginRight={'0.15rem'}>
                     <strong>X</strong>
                   </Text>
-                  <Text as={'span'} marginRight={'0.4rem'}>
+                  <Text key={x} as={'span'} marginRight={'0.4rem'}>
                     {x}
                   </Text>
                   <Text as={'span'} marginRight={'0.15rem'}>
                     <strong>Y</strong>
                   </Text>
-                  <Text as={'span'} marginRight={'0.4rem'}>
+                  <Text key={y} as={'span'} marginRight={'0.4rem'}>
                     {y}
                   </Text>
                   <Text as={'span'} marginRight={'0.15rem'}>
                     <strong>Z</strong>
                   </Text>
-                  <Text as={'span'} marginRight={'0.4rem'}>
+                  <Text key={z} as={'span'} marginRight={'0.4rem'}>
                     {z}
                   </Text>
                 </Flex>

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwareOffsetsSummary.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwareOffsetsSummary.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {
   Box,
   C_DISABLED,
@@ -14,7 +15,6 @@ import {
   Text,
   TEXT_TRANSFORM_UPPERCASE,
 } from '@opentrons/components'
-import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 
 const getOffsetDataInfo = (): Array<{

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwareOffsetsSummary.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwareOffsetsSummary.tsx
@@ -23,7 +23,7 @@ const getOffsetDataInfo = (): Array<{
   offsetData: { x: number; y: number; z: number }
 }> => [
   {
-    location: 'Temperature Module GEN 2 in Deck Slot 1',
+    location: 'Temperature Module',
     labware: 'Opentrons 96 100mL Tiprack',
     offsetData: { x: 1.1, y: 2.1, z: 3.1 },
   },
@@ -62,7 +62,6 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
         backgroundColor={C_NEAR_WHITE}
         flexDirection={DIRECTION_COLUMN}
         width="106%"
-        height="20rem"
       >
         <Text
           as={'h5'}
@@ -87,7 +86,11 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
             </Text>
             {getOffsetDataInfo().map(({ location }) => {
               return (
-                <Box key={location} height="30%" css={FONT_BODY_1_DARK}>
+                <Box
+                  key={location}
+                  marginBottom={SPACING_3}
+                  css={FONT_BODY_1_DARK}
+                >
                   {location}
                 </Box>
               )
@@ -108,7 +111,11 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
             </Text>
             {getOffsetDataInfo().map(({ labware }, index) => {
               return (
-                <Flex key={index} height={'30%'} css={FONT_BODY_1_DARK}>
+                <Flex
+                  key={index}
+                  marginBottom={SPACING_3}
+                  css={FONT_BODY_1_DARK}
+                >
                   {labware}
                 </Flex>
               )
@@ -129,11 +136,11 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
             </Text>
             {offsetData.map(({ x, y, z }) => {
               return x === 0 && y === 0 && z === 0 ? (
-                <Flex height={'30%'} css={FONT_BODY_1_DARK}>
+                <Flex marginBottom={SPACING_3} css={FONT_BODY_1_DARK}>
                   {t('no_labware_offsets')}
                 </Flex>
               ) : (
-                <Flex height={'30%'} css={FONT_BODY_1_DARK}>
+                <Flex marginBottom={SPACING_3} css={FONT_BODY_1_DARK}>
                   <Text as={'span'} marginRight={'0.15rem'}>
                     <strong>X</strong>
                   </Text>

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwareOffsetsSummary.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwareOffsetsSummary.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import {
-  C_DISABLED,
+  C_MED_GRAY,
   C_NEAR_WHITE,
   DIRECTION_COLUMN,
   DIRECTION_ROW,
@@ -12,8 +12,10 @@ import {
   JUSTIFY_CENTER,
   SPACING_3,
   SPACING_4,
+  SPACING_1,
   Text,
   TEXT_TRANSFORM_UPPERCASE,
+  SPACING_2,
 } from '@opentrons/components'
 
 const getOffsetDataInfo = (): Array<{
@@ -55,12 +57,12 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
   return (
     <React.Fragment>
       <Flex
+        flex={'auto'}
         padding={SPACING_4}
         boxShadow="1px 1px 1px rgba(0, 0, 0, 0.25)"
         borderRadius="4px"
         backgroundColor={C_NEAR_WHITE}
         flexDirection={DIRECTION_COLUMN}
-        width="106%"
       >
         <Text
           as={'h5'}
@@ -69,16 +71,16 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
         >
           {t('labware_offsets_summary_title')}
         </Text>
-        <Flex flexDirection={DIRECTION_ROW} justifyContent={JUSTIFY_CENTER}>
+        <Flex flexDirection={DIRECTION_ROW}>
           <Flex
-            flex={'1 1 30%'}
+            flex={'auto'}
             flexDirection={DIRECTION_COLUMN}
             justifyContent={JUSTIFY_CENTER}
           >
             <Text
               textTransform={TEXT_TRANSFORM_UPPERCASE}
               marginBottom={SPACING_3}
-              color={C_DISABLED}
+              color={C_MED_GRAY}
               fontSize={FONT_SIZE_CAPTION}
             >
               {t('labware_offsets_summary_location')}
@@ -96,14 +98,14 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
             })}
           </Flex>
           <Flex
-            flex={'1 1 40%'}
+            flex={'auto'}
             flexDirection={DIRECTION_COLUMN}
             justifyContent={JUSTIFY_CENTER}
           >
             <Text
               textTransform={TEXT_TRANSFORM_UPPERCASE}
               marginBottom={SPACING_3}
-              color={C_DISABLED}
+              color={C_MED_GRAY}
               fontSize={FONT_SIZE_CAPTION}
             >
               {t('labware_offsets_summary_labware')}
@@ -121,14 +123,14 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
             })}
           </Flex>
           <Flex
-            flex={'1 1 30%'}
+            flex={'auto'}
             flexDirection={DIRECTION_COLUMN}
             justifyContent={JUSTIFY_CENTER}
           >
             <Text
               textTransform={TEXT_TRANSFORM_UPPERCASE}
               marginBottom={SPACING_3}
-              color={C_DISABLED}
+              color={C_MED_GRAY}
               fontSize={FONT_SIZE_CAPTION}
             >
               {t('labware_offsets_summary_offset')}
@@ -144,22 +146,22 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
                 </Flex>
               ) : (
                 <Flex marginBottom={SPACING_3} css={FONT_BODY_1_DARK}>
-                  <Text as={'span'} marginRight={'0.15rem'}>
+                  <Text as={'span'} marginRight={SPACING_1}>
                     <strong>X</strong>
                   </Text>
-                  <Text key={x} as={'span'} marginRight={'0.4rem'}>
+                  <Text key={x} as={'span'} marginRight={SPACING_2}>
                     {x}
                   </Text>
-                  <Text as={'span'} marginRight={'0.15rem'}>
+                  <Text as={'span'} marginRight={SPACING_1}>
                     <strong>Y</strong>
                   </Text>
-                  <Text key={y} as={'span'} marginRight={'0.4rem'}>
+                  <Text key={y} as={'span'} marginRight={SPACING_2}>
                     {y}
                   </Text>
-                  <Text as={'span'} marginRight={'0.15rem'}>
+                  <Text as={'span'} marginRight={SPACING_1}>
                     <strong>Z</strong>
                   </Text>
-                  <Text key={z} as={'span'} marginRight={'0.4rem'}>
+                  <Text key={z} as={'span'} marginRight={SPACING_2}>
                     {z}
                   </Text>
                 </Flex>

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwareOffsetsSummary.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwareOffsetsSummary.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import {
-  Box,
   C_DISABLED,
   C_NEAR_WHITE,
   DIRECTION_COLUMN,
@@ -71,7 +70,11 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
           {t('labware_offsets_summary_title')}
         </Text>
         <Flex flexDirection={DIRECTION_ROW} justifyContent={JUSTIFY_CENTER}>
-          <Box width="30%" justifyContent={JUSTIFY_CENTER}>
+          <Flex
+            flex={'1 1 30%'}
+            flexDirection={DIRECTION_COLUMN}
+            justifyContent={JUSTIFY_CENTER}
+          >
             <Text
               textTransform={TEXT_TRANSFORM_UPPERCASE}
               marginBottom={SPACING_3}
@@ -82,17 +85,21 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
             </Text>
             {getOffsetDataInfo().map(({ location }) => {
               return (
-                <Box
+                <Flex
                   key={location}
                   marginBottom={SPACING_3}
                   css={FONT_BODY_1_DARK}
                 >
                   {location}
-                </Box>
+                </Flex>
               )
             })}
-          </Box>
-          <Box width="40%" justifyContent={JUSTIFY_CENTER}>
+          </Flex>
+          <Flex
+            flex={'1 1 40%'}
+            flexDirection={DIRECTION_COLUMN}
+            justifyContent={JUSTIFY_CENTER}
+          >
             <Text
               textTransform={TEXT_TRANSFORM_UPPERCASE}
               marginBottom={SPACING_3}
@@ -112,8 +119,12 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
                 </Flex>
               )
             })}
-          </Box>
-          <Box width="30%" justifyContent={JUSTIFY_CENTER}>
+          </Flex>
+          <Flex
+            flex={'1 1 30%'}
+            flexDirection={DIRECTION_COLUMN}
+            justifyContent={JUSTIFY_CENTER}
+          >
             <Text
               textTransform={TEXT_TRANSFORM_UPPERCASE}
               marginBottom={SPACING_3}
@@ -154,7 +165,7 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
                 </Flex>
               )
             })}
-          </Box>
+          </Flex>
         </Flex>
       </Flex>
     </React.Fragment>

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwareOffsetsSummary.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwareOffsetsSummary.tsx
@@ -145,7 +145,11 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
                   {t('no_labware_offsets')}
                 </Flex>
               ) : (
-                <Flex marginBottom={SPACING_3} css={FONT_BODY_1_DARK}>
+                <Flex
+                  key={index}
+                  marginBottom={SPACING_3}
+                  css={FONT_BODY_1_DARK}
+                >
                   <Text as={'span'} marginRight={SPACING_1}>
                     <strong>X</strong>
                   </Text>

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwareOffsetsSummary.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwareOffsetsSummary.tsx
@@ -1,13 +1,14 @@
 import {
+  Box,
   C_DISABLED,
   C_NEAR_WHITE,
   DIRECTION_COLUMN,
   DIRECTION_ROW,
   Flex,
+  FONT_BODY_1_DARK,
   FONT_SIZE_CAPTION,
   FONT_WEIGHT_SEMIBOLD,
   JUSTIFY_CENTER,
-  JUSTIFY_SPACE_BETWEEN,
   SPACING_3,
   SPACING_4,
   Text,
@@ -24,38 +25,39 @@ const getOffsetDataInfo = (): Array<{
   {
     deckSlot: 'Slot 1',
     labware: 'Opentrons 96 100mL Tiprack in Temperature Module GEN2',
-    offsetData: { x: 1, y: 2, z: 3 },
+    offsetData: { x: 1.1, y: 2.1, z: 3.1 },
   },
   {
     deckSlot: 'Slot 3',
     labware: 'Opentrons 96 Tip Rack 20µL',
-    offsetData: { x: 0, y: 2, z: 1 },
+    offsetData: { x: 0.0, y: -1.2, z: 1.1 },
   },
   {
     deckSlot: 'Slot 5',
     labware: 'Opentrons Mixed Tube Rack',
-    offsetData: { x: 5, y: 2, z: 3 },
+    offsetData: { x: 5.1, y: 2.2, z: 3.1 },
   },
   {
     deckSlot: 'Slot 6',
     labware: 'Opentrons Mixed Tube Rack',
-    offsetData: { x: 0, y: 0, z: 0 },
+    offsetData: { x: 0.0, y: 0.0, z: 0.0 },
   },
   {
     deckSlot: 'Slot 7',
     labware: 'Opentrons Mixed Tube Rack',
-    offsetData: { x: 0, y: 0, z: 0 },
+    offsetData: { x: 0.0, y: 0.0, z: 0.0 },
   },
 ]
 
 export const LabwareOffsetsSummary = (): JSX.Element | null => {
   const { t } = useTranslation('labware_position_check')
+  const offsetData = getOffsetDataInfo().map(({ offsetData }) => offsetData)
+
   return (
     <React.Fragment>
       <Flex
         padding={SPACING_4}
         justifyContent={JUSTIFY_CENTER}
-        marginTop={SPACING_4}
         boxShadow="1px 1px 1px rgba(0, 0, 0, 0.25)"
         borderRadius="4px"
         backgroundColor={C_NEAR_WHITE}
@@ -69,31 +71,91 @@ export const LabwareOffsetsSummary = (): JSX.Element | null => {
         >
           {t('labware_offsets_summary_title')}
         </Text>
-        <Flex flexDirection={DIRECTION_ROW} justifyContent={JUSTIFY_SPACE_BETWEEN}>
-          <Text
-            textTransform={TEXT_TRANSFORM_UPPERCASE}
-            marginBottom={SPACING_3}
-            color={C_DISABLED}
-            fontSize={FONT_SIZE_CAPTION}
+        <Flex flexDirection={DIRECTION_ROW} justifyContent={JUSTIFY_CENTER}>
+          <Box
+            width="20%"
+            flexDirection={DIRECTION_COLUMN}
+            justifyContent={JUSTIFY_CENTER}
           >
-            {t('labware_offsets_summary_deckslot')}
-          </Text>
-          <Text
-            textTransform={TEXT_TRANSFORM_UPPERCASE}
-            marginBottom={SPACING_3}
-            color={C_DISABLED}
-            fontSize={FONT_SIZE_CAPTION}
+            <Text
+              textTransform={TEXT_TRANSFORM_UPPERCASE}
+              marginBottom={SPACING_3}
+              color={C_DISABLED}
+              fontSize={FONT_SIZE_CAPTION}
+            >
+              {t('labware_offsets_summary_deckslot')}
+            </Text>
+            {getOffsetDataInfo().map(({ deckSlot }) => {
+              return (
+                <Text marginBottom={SPACING_3} css={FONT_BODY_1_DARK}>
+                  {deckSlot}
+                </Text>
+              )
+            })}
+          </Box>
+          <Box
+            width="50%"
+            flexDirection={DIRECTION_COLUMN}
+            justifyContent={JUSTIFY_CENTER}
           >
-            {t('labware_offsets_summary_labware')}
-          </Text>
-          <Text
-            textTransform={TEXT_TRANSFORM_UPPERCASE}
-            marginBottom={SPACING_3}
-            color={C_DISABLED}
-            fontSize={FONT_SIZE_CAPTION}
+            <Text
+              textTransform={TEXT_TRANSFORM_UPPERCASE}
+              marginBottom={SPACING_3}
+              color={C_DISABLED}
+              fontSize={FONT_SIZE_CAPTION}
+            >
+              {t('labware_offsets_summary_labware')}
+            </Text>
+            {getOffsetDataInfo().map(({ labware }) => {
+              return (
+                <Text marginBottom={SPACING_3} css={FONT_BODY_1_DARK}>
+                  {labware}
+                </Text>
+              )
+            })}
+          </Box>
+          <Box
+            width="30%"
+            flexDirection={DIRECTION_COLUMN}
+            justifyContent={JUSTIFY_CENTER}
           >
-            {t('labware_offsets_summary_offset')}
-          </Text>
+            <Text
+              textTransform={TEXT_TRANSFORM_UPPERCASE}
+              marginBottom={SPACING_3}
+              color={C_DISABLED}
+              fontSize={FONT_SIZE_CAPTION}
+            >
+              {t('labware_offsets_summary_offset')}
+            </Text>
+            {offsetData.map(({ x, y, z }) => {
+              return x == 0 && y == 0 && z == 0 ? (
+                <Text marginBottom={SPACING_3} css={FONT_BODY_1_DARK}>
+                  {t('no_labware_offsets')}
+                </Text>
+              ) : (
+                <Box marginBottom={SPACING_3} css={FONT_BODY_1_DARK}>
+                  <Text as={'span'} marginRight={'0.15rem'}>
+                    <strong>X</strong>
+                  </Text>
+                  <Text as={'span'} marginRight={'0.4rem'}>
+                    {x}
+                  </Text>
+                  <Text as={'span'} marginRight={'0.15rem'}>
+                    <strong>Y</strong>
+                  </Text>
+                  <Text as={'span'} marginRight={'0.4rem'}>
+                    {y}
+                  </Text>
+                  <Text as={'span'} marginRight={'0.15rem'}>
+                    <strong>Z</strong>
+                  </Text>
+                  <Text as={'span'} marginRight={'0.4rem'}>
+                    {z}
+                  </Text>
+                </Box>
+              )
+            })}
+          </Box>
         </Flex>
       </Flex>
     </React.Fragment>

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwareOffsetsSummary.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwareOffsetsSummary.tsx
@@ -1,0 +1,101 @@
+import {
+  C_DISABLED,
+  C_NEAR_WHITE,
+  DIRECTION_COLUMN,
+  DIRECTION_ROW,
+  Flex,
+  FONT_SIZE_CAPTION,
+  FONT_WEIGHT_SEMIBOLD,
+  JUSTIFY_CENTER,
+  JUSTIFY_SPACE_BETWEEN,
+  SPACING_3,
+  SPACING_4,
+  Text,
+  TEXT_TRANSFORM_UPPERCASE,
+} from '@opentrons/components'
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+
+const getOffsetDataInfo = (): Array<{
+  deckSlot: string
+  labware: string
+  offsetData: { x: number; y: number; z: number }
+}> => [
+  {
+    deckSlot: 'Slot 1',
+    labware: 'Opentrons 96 100mL Tiprack in Temperature Module GEN2',
+    offsetData: { x: 1, y: 2, z: 3 },
+  },
+  {
+    deckSlot: 'Slot 3',
+    labware: 'Opentrons 96 Tip Rack 20µL',
+    offsetData: { x: 0, y: 2, z: 1 },
+  },
+  {
+    deckSlot: 'Slot 5',
+    labware: 'Opentrons Mixed Tube Rack',
+    offsetData: { x: 5, y: 2, z: 3 },
+  },
+  {
+    deckSlot: 'Slot 6',
+    labware: 'Opentrons Mixed Tube Rack',
+    offsetData: { x: 0, y: 0, z: 0 },
+  },
+  {
+    deckSlot: 'Slot 7',
+    labware: 'Opentrons Mixed Tube Rack',
+    offsetData: { x: 0, y: 0, z: 0 },
+  },
+]
+
+export const LabwareOffsetsSummary = (): JSX.Element | null => {
+  const { t } = useTranslation('labware_position_check')
+  return (
+    <React.Fragment>
+      <Flex
+        padding={SPACING_4}
+        justifyContent={JUSTIFY_CENTER}
+        marginTop={SPACING_4}
+        boxShadow="1px 1px 1px rgba(0, 0, 0, 0.25)"
+        borderRadius="4px"
+        backgroundColor={C_NEAR_WHITE}
+        flexDirection={DIRECTION_COLUMN}
+        width="106%"
+      >
+        <Text
+          as={'h5'}
+          fontWeight={FONT_WEIGHT_SEMIBOLD}
+          marginBottom={SPACING_3}
+        >
+          {t('labware_offsets_summary_title')}
+        </Text>
+        <Flex flexDirection={DIRECTION_ROW} justifyContent={JUSTIFY_SPACE_BETWEEN}>
+          <Text
+            textTransform={TEXT_TRANSFORM_UPPERCASE}
+            marginBottom={SPACING_3}
+            color={C_DISABLED}
+            fontSize={FONT_SIZE_CAPTION}
+          >
+            {t('labware_offsets_summary_deckslot')}
+          </Text>
+          <Text
+            textTransform={TEXT_TRANSFORM_UPPERCASE}
+            marginBottom={SPACING_3}
+            color={C_DISABLED}
+            fontSize={FONT_SIZE_CAPTION}
+          >
+            {t('labware_offsets_summary_labware')}
+          </Text>
+          <Text
+            textTransform={TEXT_TRANSFORM_UPPERCASE}
+            marginBottom={SPACING_3}
+            color={C_DISABLED}
+            fontSize={FONT_SIZE_CAPTION}
+          >
+            {t('labware_offsets_summary_offset')}
+          </Text>
+        </Flex>
+      </Flex>
+    </React.Fragment>
+  )
+}

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SectionList.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SectionList.tsx
@@ -7,7 +7,6 @@ import {
   ALIGN_CENTER,
   SIZE_1,
   SPACING_2,
-  SPACING_5,
   C_WHITE,
   C_NEAR_WHITE,
   C_DARK_GRAY,
@@ -44,7 +43,6 @@ export function SectionList(props: Props): JSX.Element {
       fontSize={FONT_SIZE_CAPTION}
       padding={SPACING_3}
       width="14rem"
-      marginLeft={SPACING_5}
       boxShadow="1px 1px 1px rgba(0, 0, 0, 0.25)"
       borderRadius="4px"
       backgroundColor={C_NEAR_WHITE}

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SectionList.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SectionList.tsx
@@ -23,7 +23,7 @@ import {
 import type { Section } from './types'
 interface Props {
   sections: Section[]
-  currentSection: Section
+  currentSection?: Section
   primaryPipetteMount: string
   secondaryPipetteMount: string
   completedSections?: Section[]

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
@@ -41,7 +41,7 @@ export const SummaryScreen = (): JSX.Element | null => {
         {t('lpc_complete_summary_screen_heading')}
       </Text>
       <Flex justifyContent={JUSTIFY_START} alignItems={ALIGN_START}>
-        <Flex flex={'1 1 40%'} flexDirection={DIRECTION_COLUMN}>
+        <Flex flex={'auto'} flexDirection={DIRECTION_COLUMN}>
           <SectionList
             primaryPipetteMount={primaryPipetteMount}
             secondaryPipetteMount={secondaryPipetteMount}
@@ -51,7 +51,7 @@ export const SummaryScreen = (): JSX.Element | null => {
 
           <DeckMap completedLabwareIdSections={labwareIds} />
         </Flex>
-        <Flex flex={'1 1 80%'} marginRight={SPACING_4}>
+        <Flex flex={'auto'} marginRight={SPACING_4}>
           <LabwareOffsetsSummary />
         </Flex>
       </Flex>

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
@@ -18,25 +18,17 @@ import { useTranslation } from 'react-i18next'
 import { DeckMap } from './DeckMap'
 import { SectionList } from './SectionList'
 import { LabwareOffsetsSummary } from './LabwareOffsetsSummary'
-import { useIntroInfo, useLabwareIdsBySection } from './hooks'
+import { useIntroInfo } from './hooks'
+import { useProtocolDetails } from '../../RunDetails/hooks'
 
 export const SummaryScreen = (): JSX.Element | null => {
   const { t } = useTranslation('labware_position_check')
   const introInfo = useIntroInfo()
-  const labwareIdsBySection = useLabwareIdsBySection()
+  const { protocolData } = useProtocolDetails()
   if (introInfo == null) return null
+  if (protocolData == null) return null
+  const labwareIds = Object.keys(protocolData.labware)
   const { sections, primaryPipetteMount, secondaryPipetteMount } = introInfo
-  const primaryPipetteTiprackIds = labwareIdsBySection[sections[0]]
-  const secondaryPipetteLabwareIds = labwareIdsBySection[sections[1]]
-  const remainingLabwareIds = labwareIdsBySection[sections[2]]
-  const returnTipId = labwareIdsBySection[sections[3]]
-  //  @ts-expect-error, even if primaryPipettetiprackIds is undefined, we still want to concat all the arrays
-  const combinedSectionsLabwareIds = primaryPipetteTiprackIds.concat(
-    // @ts-expect-error, even if array is undefined, we still want to concat
-    remainingLabwareIds,
-    secondaryPipetteLabwareIds,
-    returnTipId
-  )
 
   return (
     <Box margin={SPACING_3}>
@@ -50,7 +42,7 @@ export const SummaryScreen = (): JSX.Element | null => {
         {t('lpc_complete_summary_screen_heading')}
       </Text>
       <Flex justifyContent={JUSTIFY_START} alignItems={ALIGN_START}>
-        <Box width="55%" flexDirection={DIRECTION_COLUMN}>
+        <Box width="50%" flexDirection={DIRECTION_COLUMN}>
           <SectionList
             primaryPipetteMount={primaryPipetteMount}
             secondaryPipetteMount={secondaryPipetteMount}
@@ -58,7 +50,7 @@ export const SummaryScreen = (): JSX.Element | null => {
             completedSections={sections}
           />
           <Flex justifyContent={JUSTIFY_CENTER}>
-            <DeckMap completedLabwareIdSections={combinedSectionsLabwareIds} />
+            <DeckMap completedLabwareIdSections={labwareIds} />
           </Flex>
         </Box>
         <Box width="80%" height="100%" marginRight={SPACING_4}>
@@ -68,7 +60,7 @@ export const SummaryScreen = (): JSX.Element | null => {
       <Flex justifyContent={JUSTIFY_CENTER} marginBottom={SPACING_4}>
         <PrimaryBtn
           title={t('close_and_apply_offset_data')}
-          backgroundColor={C_BLUE} // TODO: hook up CTA
+          backgroundColor={C_BLUE} // TODO immediately: hook up CTA
         >
           {t('close_and_apply_offset_data')}
         </PrimaryBtn>

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
@@ -4,7 +4,6 @@ import {
   ALIGN_START,
   Box,
   C_BLUE,
-  DIRECTION_COLUMN,
   Flex,
   FONT_WEIGHT_SEMIBOLD,
   JUSTIFY_CENTER,
@@ -41,8 +40,12 @@ export const SummaryScreen = (): JSX.Element | null => {
       >
         {t('lpc_complete_summary_screen_heading')}
       </Text>
-      <Flex justifyContent={JUSTIFY_START} alignItems={ALIGN_START}>
-        <Box width="50%" flexDirection={DIRECTION_COLUMN}>
+      <Flex
+        justifyContent={JUSTIFY_START}
+        alignItems={ALIGN_START}
+        marginLeft="-2.5rem" // TODO remove negative margin when fixing SectionList marginLeft
+      >
+        <Box width="50%">
           <SectionList
             primaryPipetteMount={primaryPipetteMount}
             secondaryPipetteMount={secondaryPipetteMount}

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {
   ALIGN_START,
   Box,
@@ -13,12 +14,11 @@ import {
   Text,
   TEXT_TRANSFORM_UPPERCASE,
 } from '@opentrons/components'
-import * as React from 'react'
+import { useTranslation } from 'react-i18next'
 import { DeckMap } from './DeckMap'
 import { SectionList } from './SectionList'
 import { LabwareOffsetsSummary } from './LabwareOffsetsSummary'
 import { useIntroInfo, useLabwareIdsBySection } from './hooks'
-import { useTranslation } from 'react-i18next'
 
 export const SummaryScreen = (): JSX.Element | null => {
   const { t } = useTranslation('labware_position_check')
@@ -26,6 +26,17 @@ export const SummaryScreen = (): JSX.Element | null => {
   const labwareIdsBySection = useLabwareIdsBySection()
   if (introInfo == null) return null
   const { sections, primaryPipetteMount, secondaryPipetteMount } = introInfo
+  const primaryPipetteTiprackIds = labwareIdsBySection[sections[0]]
+  const secondaryPipetteLabwareIds = labwareIdsBySection[sections[1]]
+  const remainingLabwareIds = labwareIdsBySection[sections[2]]
+  const returnTipId = labwareIdsBySection[sections[3]]
+  //  @ts-expect-error, even if primaryPipettetiprackIds is undefined, we still want to concat all the arrays
+  const combinedSectionsLabwareIds = primaryPipetteTiprackIds.concat(
+    // @ts-expect-error, even if array is undefined, we still want to concat
+    remainingLabwareIds,
+    secondaryPipetteLabwareIds,
+    returnTipId
+  )
 
   return (
     <Box margin={SPACING_3}>
@@ -44,23 +55,13 @@ export const SummaryScreen = (): JSX.Element | null => {
             primaryPipetteMount={primaryPipetteMount}
             secondaryPipetteMount={secondaryPipetteMount}
             sections={sections}
-            completedSections={[
-              sections[0],
-              sections[1],
-              sections[2],
-              sections[3],
-            ]}
+            completedSections={sections}
           />
           <Flex justifyContent={JUSTIFY_CENTER}>
-            <DeckMap
-              completedLabwareIdSections={
-                (labwareIdsBySection[sections[0]],
-                labwareIdsBySection[sections[1]],labwareIdsBySection[sections[2]])
-              }
-            />
+            <DeckMap completedLabwareIdSections={combinedSectionsLabwareIds} />
           </Flex>
         </Box>
-        <Box width="80%" marginRight={SPACING_4}>
+        <Box width="80%" height="100%" marginRight={SPACING_4}>
           <LabwareOffsetsSummary />
         </Box>
       </Flex>

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useTranslation } from 'react-i18next'
 import {
   ALIGN_START,
   Box,
@@ -14,12 +15,11 @@ import {
   Text,
   TEXT_TRANSFORM_UPPERCASE,
 } from '@opentrons/components'
-import { useTranslation } from 'react-i18next'
+import { useProtocolDetails } from '../../RunDetails/hooks'
 import { DeckMap } from './DeckMap'
 import { SectionList } from './SectionList'
 import { LabwareOffsetsSummary } from './LabwareOffsetsSummary'
 import { useIntroInfo } from './hooks'
-import { useProtocolDetails } from '../../RunDetails/hooks'
 
 export const SummaryScreen = (): JSX.Element | null => {
   const { t } = useTranslation('labware_position_check')

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react'
+
+const getOffsetDataInfo = (): Array<{
+  deckSlot: string
+  labware: string
+  offsetData: { x: number; y: number; z: number }
+}> => [
+  {
+    deckSlot: 'Slot 1',
+    labware: 'Opentrons 96 100mL Tiprack in Temperature Module GEN2',
+    offsetData: { x: 1, y: 2, z: 3 },
+  },
+  {
+    deckSlot: 'Slot 3',
+    labware: 'Opentrons 96 Tip Rack 20µL',
+    offsetData: { x: 0, y: 2, z: 1 },
+  },
+  {
+    deckSlot: 'Slot 5',
+    labware: 'Opentrons Mixed Tube Rack',
+    offsetData: { x: 5, y: 2, z: 3 },
+  },
+  {
+    deckSlot: 'Slot 6',
+    labware: 'Opentrons Mixed Tube Rack',
+    offsetData: { x: 0, y: 0, z: 0 },
+  },
+  {
+    deckSlot: 'Slot 7',
+    labware: 'Opentrons Mixed Tube Rack',
+    offsetData: { x: 0, y: 0, z: 0 },
+  },
+]
+
+export const SummaryScreen = (): JSX.Element => <div>summary screen</div>

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
@@ -41,7 +41,7 @@ export const SummaryScreen = (): JSX.Element | null => {
         {t('lpc_complete_summary_screen_heading')}
       </Text>
       <Flex justifyContent={JUSTIFY_START} alignItems={ALIGN_START}>
-        <Flex flex={'auto'} flexDirection={DIRECTION_COLUMN}>
+        <Flex flex={'1 1 10%'} flexDirection={DIRECTION_COLUMN}>
           <SectionList
             primaryPipetteMount={primaryPipetteMount}
             secondaryPipetteMount={secondaryPipetteMount}
@@ -51,7 +51,7 @@ export const SummaryScreen = (): JSX.Element | null => {
 
           <DeckMap completedLabwareIdSections={labwareIds} />
         </Flex>
-        <Flex flex={'auto'} marginRight={SPACING_4}>
+        <Flex flex={'1 1 45%'}>
           <LabwareOffsetsSummary />
         </Flex>
       </Flex>

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
@@ -2,8 +2,8 @@ import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   ALIGN_START,
-  Box,
   C_BLUE,
+  DIRECTION_COLUMN,
   Flex,
   FONT_WEIGHT_SEMIBOLD,
   JUSTIFY_CENTER,
@@ -30,7 +30,7 @@ export const SummaryScreen = (): JSX.Element | null => {
   const { sections, primaryPipetteMount, secondaryPipetteMount } = introInfo
 
   return (
-    <Box margin={SPACING_3}>
+    <Flex margin={SPACING_3} flexDirection={DIRECTION_COLUMN}>
       <Text
         as={'h3'}
         textTransform={TEXT_TRANSFORM_UPPERCASE}
@@ -40,25 +40,20 @@ export const SummaryScreen = (): JSX.Element | null => {
       >
         {t('lpc_complete_summary_screen_heading')}
       </Text>
-      <Flex
-        justifyContent={JUSTIFY_START}
-        alignItems={ALIGN_START}
-        marginLeft="-2.5rem" // TODO remove negative margin when fixing SectionList marginLeft
-      >
-        <Box width="50%">
+      <Flex justifyContent={JUSTIFY_START} alignItems={ALIGN_START}>
+        <Flex flex={'1 1 40%'} flexDirection={DIRECTION_COLUMN}>
           <SectionList
             primaryPipetteMount={primaryPipetteMount}
             secondaryPipetteMount={secondaryPipetteMount}
             sections={sections}
             completedSections={sections}
           />
-          <Flex justifyContent={JUSTIFY_CENTER}>
-            <DeckMap completedLabwareIdSections={labwareIds} />
-          </Flex>
-        </Box>
-        <Box width="80%" height="100%" marginRight={SPACING_4}>
+
+          <DeckMap completedLabwareIdSections={labwareIds} />
+        </Flex>
+        <Flex flex={'1 1 80%'} marginRight={SPACING_4}>
           <LabwareOffsetsSummary />
-        </Box>
+        </Flex>
       </Flex>
       <Flex justifyContent={JUSTIFY_CENTER} marginBottom={SPACING_4}>
         <PrimaryBtn
@@ -68,6 +63,6 @@ export const SummaryScreen = (): JSX.Element | null => {
           {t('close_and_apply_offset_data')}
         </PrimaryBtn>
       </Flex>
-    </Box>
+    </Flex>
   )
 }

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
@@ -6,7 +6,7 @@ import {
   Flex,
   FONT_WEIGHT_SEMIBOLD,
   JUSTIFY_CENTER,
-  JUSTIFY_SPACE_BETWEEN,
+  JUSTIFY_START,
   PrimaryBtn,
   SPACING_3,
   SPACING_4,
@@ -26,7 +26,6 @@ export const SummaryScreen = (): JSX.Element | null => {
   const labwareIdsBySection = useLabwareIdsBySection()
   if (introInfo == null) return null
   const { sections, primaryPipetteMount, secondaryPipetteMount } = introInfo
-  const allSections = sections.length
 
   return (
     <Box margin={SPACING_3}>
@@ -35,29 +34,33 @@ export const SummaryScreen = (): JSX.Element | null => {
         textTransform={TEXT_TRANSFORM_UPPERCASE}
         fontWeight={FONT_WEIGHT_SEMIBOLD}
         marginBottom={SPACING_3}
+        marginLeft={SPACING_3}
       >
         {t('lpc_complete_summary_screen_heading')}
       </Text>
-      <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} alignItems={ALIGN_START}>
+      <Flex justifyContent={JUSTIFY_START} alignItems={ALIGN_START}>
         <Box width="55%" flexDirection={DIRECTION_COLUMN}>
           <SectionList
             primaryPipetteMount={primaryPipetteMount}
             secondaryPipetteMount={secondaryPipetteMount}
             sections={sections}
             completedSections={[
-              sections[allSections - 1],
-              sections[allSections - 2],
-              sections[allSections - 3],
-              sections[allSections - 4],
+              sections[0],
+              sections[1],
+              sections[2],
+              sections[3],
             ]}
           />
           <Flex justifyContent={JUSTIFY_CENTER}>
             <DeckMap
-              completedLabwareIdSections={labwareIdsBySection[sections[0]]}
+              completedLabwareIdSections={
+                (labwareIdsBySection[sections[0]],
+                labwareIdsBySection[sections[1]],labwareIdsBySection[sections[2]])
+              }
             />
           </Flex>
         </Box>
-        <Box width="70%" marginRight={SPACING_4}>
+        <Box width="80%" marginRight={SPACING_4}>
           <LabwareOffsetsSummary />
         </Box>
       </Flex>

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
@@ -1,4 +1,27 @@
+import {
+  ALIGN_CENTER,
+  Box,
+  C_BLUE,
+  C_NEAR_WHITE,
+  DIRECTION_COLUMN,
+  Flex,
+  FONT_WEIGHT_SEMIBOLD,
+  JUSTIFY_CENTER,
+  JUSTIFY_SPACE_BETWEEN,
+  JUSTIFY_START,
+  PrimaryBtn,
+  SPACING_3,
+  SPACING_4,
+  SPACING_5,
+  Text,
+  TEXT_TRANSFORM_UPPERCASE,
+} from '@opentrons/components'
 import * as React from 'react'
+import { DeckMap } from './DeckMap'
+import { SectionList } from './SectionList'
+import { LabwareOffsetsSummary } from './LabwareOffsetsSummary'
+import { useIntroInfo, useLabwareIdsBySection } from './hooks'
+import { useTranslation } from 'react-i18next'
 
 const getOffsetDataInfo = (): Array<{
   deckSlot: string
@@ -31,5 +54,69 @@ const getOffsetDataInfo = (): Array<{
     offsetData: { x: 0, y: 0, z: 0 },
   },
 ]
+interface SummaryScreenProps {
+  onCloseClick: () => unknown
+}
 
-export const SummaryScreen = (): JSX.Element => <div>summary screen</div>
+export const SummaryScreen = (props: SummaryScreenProps): JSX.Element | null => {
+  const { t } = useTranslation('labware_position_check')
+  const introInfo = useIntroInfo()
+  const labwareIdsBySection = useLabwareIdsBySection()
+  if (introInfo == null) return null
+  const { sections, primaryPipetteMount, secondaryPipetteMount } = introInfo
+  const allSections = sections.length
+
+  return (
+    <Box margin={SPACING_3}>
+      <Text
+        as={'h3'}
+        textTransform={TEXT_TRANSFORM_UPPERCASE}
+        fontWeight={FONT_WEIGHT_SEMIBOLD}
+        marginBottom={SPACING_3}
+      >
+        {t('lpc_complete_summary_screen_heading')}
+      </Text>
+      <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} alignItems={ALIGN_CENTER}>
+        <Flex flexDirection={DIRECTION_COLUMN}>
+          <Flex marginRight={SPACING_5}>
+            <SectionList
+              primaryPipetteMount={primaryPipetteMount}
+              secondaryPipetteMount={secondaryPipetteMount}
+              sections={sections}
+              completedSections={[
+                sections[allSections - 1],
+                sections[allSections - 2],
+                sections[allSections - 3],
+                sections[allSections - 4],
+              ]}
+            />
+          </Flex>
+          <Flex justifyContent={JUSTIFY_CENTER}>
+            <DeckMap
+              completedLabwareIdSections={
+                labwareIdsBySection[
+                  (sections[sections.length - 1],
+                  sections[sections.length - 2],
+                  sections[sections.length - 3],
+                  sections[sections.length - 4])
+                ]
+              }
+            />
+          </Flex>
+        </Flex>
+        <Box width="60%" padding={SPACING_3}>
+          <LabwareOffsetsSummary />
+        </Box>
+      </Flex>
+      <Flex justifyContent={JUSTIFY_CENTER} marginBottom={SPACING_4}>
+        <PrimaryBtn
+          title={t('close_and_apply_offset_data')}
+          backgroundColor={C_BLUE}
+          onClick={() => props.onCloseClick}
+        >
+          {t('close_and_apply_offset_data')}
+        </PrimaryBtn>
+      </Flex>
+    </Box>
+  )
+}

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
@@ -1,18 +1,15 @@
 import {
-  ALIGN_CENTER,
+  ALIGN_START,
   Box,
   C_BLUE,
-  C_NEAR_WHITE,
   DIRECTION_COLUMN,
   Flex,
   FONT_WEIGHT_SEMIBOLD,
   JUSTIFY_CENTER,
   JUSTIFY_SPACE_BETWEEN,
-  JUSTIFY_START,
   PrimaryBtn,
   SPACING_3,
   SPACING_4,
-  SPACING_5,
   Text,
   TEXT_TRANSFORM_UPPERCASE,
 } from '@opentrons/components'
@@ -23,42 +20,7 @@ import { LabwareOffsetsSummary } from './LabwareOffsetsSummary'
 import { useIntroInfo, useLabwareIdsBySection } from './hooks'
 import { useTranslation } from 'react-i18next'
 
-const getOffsetDataInfo = (): Array<{
-  deckSlot: string
-  labware: string
-  offsetData: { x: number; y: number; z: number }
-}> => [
-  {
-    deckSlot: 'Slot 1',
-    labware: 'Opentrons 96 100mL Tiprack in Temperature Module GEN2',
-    offsetData: { x: 1, y: 2, z: 3 },
-  },
-  {
-    deckSlot: 'Slot 3',
-    labware: 'Opentrons 96 Tip Rack 20µL',
-    offsetData: { x: 0, y: 2, z: 1 },
-  },
-  {
-    deckSlot: 'Slot 5',
-    labware: 'Opentrons Mixed Tube Rack',
-    offsetData: { x: 5, y: 2, z: 3 },
-  },
-  {
-    deckSlot: 'Slot 6',
-    labware: 'Opentrons Mixed Tube Rack',
-    offsetData: { x: 0, y: 0, z: 0 },
-  },
-  {
-    deckSlot: 'Slot 7',
-    labware: 'Opentrons Mixed Tube Rack',
-    offsetData: { x: 0, y: 0, z: 0 },
-  },
-]
-interface SummaryScreenProps {
-  onCloseClick: () => unknown
-}
-
-export const SummaryScreen = (props: SummaryScreenProps): JSX.Element | null => {
+export const SummaryScreen = (): JSX.Element | null => {
   const { t } = useTranslation('labware_position_check')
   const introInfo = useIntroInfo()
   const labwareIdsBySection = useLabwareIdsBySection()
@@ -76,43 +38,33 @@ export const SummaryScreen = (props: SummaryScreenProps): JSX.Element | null => 
       >
         {t('lpc_complete_summary_screen_heading')}
       </Text>
-      <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} alignItems={ALIGN_CENTER}>
-        <Flex flexDirection={DIRECTION_COLUMN}>
-          <Flex marginRight={SPACING_5}>
-            <SectionList
-              primaryPipetteMount={primaryPipetteMount}
-              secondaryPipetteMount={secondaryPipetteMount}
-              sections={sections}
-              completedSections={[
-                sections[allSections - 1],
-                sections[allSections - 2],
-                sections[allSections - 3],
-                sections[allSections - 4],
-              ]}
-            />
-          </Flex>
+      <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} alignItems={ALIGN_START}>
+        <Box width="55%" flexDirection={DIRECTION_COLUMN}>
+          <SectionList
+            primaryPipetteMount={primaryPipetteMount}
+            secondaryPipetteMount={secondaryPipetteMount}
+            sections={sections}
+            completedSections={[
+              sections[allSections - 1],
+              sections[allSections - 2],
+              sections[allSections - 3],
+              sections[allSections - 4],
+            ]}
+          />
           <Flex justifyContent={JUSTIFY_CENTER}>
             <DeckMap
-              completedLabwareIdSections={
-                labwareIdsBySection[
-                  (sections[sections.length - 1],
-                  sections[sections.length - 2],
-                  sections[sections.length - 3],
-                  sections[sections.length - 4])
-                ]
-              }
+              completedLabwareIdSections={labwareIdsBySection[sections[0]]}
             />
           </Flex>
-        </Flex>
-        <Box width="60%" padding={SPACING_3}>
+        </Box>
+        <Box width="70%" marginRight={SPACING_4}>
           <LabwareOffsetsSummary />
         </Box>
       </Flex>
       <Flex justifyContent={JUSTIFY_CENTER} marginBottom={SPACING_4}>
         <PrimaryBtn
           title={t('close_and_apply_offset_data')}
-          backgroundColor={C_BLUE}
-          onClick={() => props.onCloseClick}
+          backgroundColor={C_BLUE} // TODO: hook up CTA
         >
           {t('close_and_apply_offset_data')}
         </PrimaryBtn>

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/LabwareOffsetsSummary.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/LabwareOffsetsSummary.test.tsx
@@ -13,7 +13,7 @@ describe('LabwareOffsetsSummary', () => {
   it('renders correct header and summary categories', () => {
     const { getByRole, getByText } = render()
     getByRole('heading', { name: 'Labware Offsets to be applied to this run' })
-    getByText('Deck Slot')
+    getByText('Location')
     getByText('Labware')
     getByText('Labware Offset Data')
   })

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/LabwareOffsetsSummary.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/LabwareOffsetsSummary.test.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react'
+import { renderWithProviders } from '@opentrons/components'
+import { i18n } from '../../../../i18n'
+import { LabwareOffsetsSummary } from '../LabwareOffsetsSummary'
+
+const render = () => {
+  return renderWithProviders(<LabwareOffsetsSummary />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+describe('LabwareOffsetsSummary', () => {
+  it('renders correct header and summary categories', () => {
+    const { getByRole, getByText } = render()
+    getByRole('heading', { name: 'Labware Offsets to be applied to this run' })
+    getByText('Deck Slot')
+    getByText('Labware')
+    getByText('Labware Offset Data')
+  })
+})

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/LabwarePositionCheck.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/LabwarePositionCheck.test.tsx
@@ -7,16 +7,22 @@ import { LabwarePositionCheck } from '../index'
 import { GenericStepScreen } from '../GenericStepScreen'
 import { IntroScreen } from '../IntroScreen'
 import { useSteps } from '../hooks'
+import { SummaryScreen } from '../SummaryScreen'
 import { LabwarePositionCheckStep } from '../types'
 
 jest.mock('../GenericStepScreen')
 jest.mock('../IntroScreen')
+jest.mock('../SummaryScreen')
 jest.mock('../hooks')
 
 const mockGenericStepScreen = GenericStepScreen as jest.MockedFunction<
   typeof GenericStepScreen
 >
 const mockIntroScreen = IntroScreen as jest.MockedFunction<typeof IntroScreen>
+const mockSummaryScreen = SummaryScreen as jest.MockedFunction<
+  typeof SummaryScreen
+>
+
 const mockUseSteps = useSteps as jest.MockedFunction<typeof useSteps>
 
 const PICKUP_TIP_LABWARE_ID = 'PICKUP_TIP_LABWARE_ID'
@@ -52,7 +58,8 @@ describe('LabwarePositionCheck', () => {
           section: 'PRIMARY_PIPETTE_TIPRACKS',
         } as LabwarePositionCheckStep,
       ])
-    mockIntroScreen.mockReturnValue(<div>Mock Intro Screen Component </div>)
+    mockIntroScreen.mockReturnValue(null)
+    mockSummaryScreen.mockReturnValue(<div>Mock Summary Screen Component </div>)
     mockGenericStepScreen.mockReturnValue(null)
   })
   afterEach(() => {
@@ -78,8 +85,15 @@ describe('LabwarePositionCheck', () => {
     expect(props.onCloseClick).toHaveBeenCalled()
   })
 
-  it('renders LabwarePositionCheck with IntroScreen component', () => {
+  it('renders LabwarePositionCheck with Summary Screen component', () => {
     const { getByText } = render(props)
-    getByText('Mock Intro Screen Component')
+    getByText('Mock Summary Screen Component')
   })
+
+  // TODO: fix this when LabwarePositionCheck/index is final and the isComplete boolean is final
+  // it('renders LabwarePositionCheck with IntroScreen component', () => {
+  //   mockIntroScreen.mockReturnValue(<div>Mock IntroScreen Component</div>)
+  //   const { getByText } = render(props)
+  //   getByText('Mock IntroScreen Component')
+  // })
 })

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/LabwarePositionCheck.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/LabwarePositionCheck.test.tsx
@@ -90,10 +90,6 @@ describe('LabwarePositionCheck', () => {
     getByText('Mock Summary Screen Component')
   })
 
-  // TODO: fix this when LabwarePositionCheck/index is final and the isComplete boolean is final
-  // it('renders LabwarePositionCheck with IntroScreen component', () => {
-  //   mockIntroScreen.mockReturnValue(<div>Mock IntroScreen Component</div>)
-  //   const { getByText } = render(props)
-  //   getByText('Mock IntroScreen Component')
-  // })
+  // TODO: IMMEDIATELY fix this when LabwarePositionCheck/index is final and the isComplete boolean is final
+  it.todo('renders LabwarePositionCheck with IntroScreen component')
 })

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
@@ -2,12 +2,12 @@ import * as React from 'react'
 import { when } from 'jest-when'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../../i18n'
+import { useProtocolDetails } from '../../../RunDetails/hooks'
 import { SectionList } from '../SectionList'
 import { DeckMap } from '../DeckMap'
 import { SummaryScreen } from '../SummaryScreen'
 import { LabwareOffsetsSummary } from '../LabwareOffsetsSummary'
 import { useIntroInfo } from '../hooks'
-import { useProtocolDetails } from '../../../RunDetails/hooks'
 import { Section } from '../types'
 
 jest.mock('../SectionList')

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
@@ -1,3 +1,68 @@
-describe('Summary Screen', () => {
-  it.todo('should render the summary screen', () => {})
+import * as React from 'react'
+import { when } from 'jest-when'
+import { renderWithProviders } from '@opentrons/components'
+import { i18n } from '../../../../i18n'
+import { SectionList } from '../SectionList'
+import { DeckMap } from '../DeckMap'
+import { SummaryScreen } from '../SummaryScreen'
+import { LabwareOffsetsSummary } from '../LabwareOffsetsSummary'
+import { useIntroInfo, useLabwareIdsBySection } from '../hooks'
+import { Section } from '../types'
+
+jest.mock('../SectionList')
+jest.mock('../hooks')
+jest.mock('../DeckMap')
+jest.mock('../LabwareOffsetsSummary')
+
+const mockSectionList = SectionList as jest.MockedFunction<typeof SectionList>
+const mockUseIntroInfo = useIntroInfo as jest.MockedFunction<
+  typeof useIntroInfo
+>
+const mockUseLabwareIdsBySection = useLabwareIdsBySection as jest.MockedFunction<
+  typeof useLabwareIdsBySection
+>
+const mockDeckmap = DeckMap as jest.MockedFunction<typeof DeckMap>
+
+const mockLabwareOffsetsSummary = LabwareOffsetsSummary as jest.MockedFunction<
+  typeof LabwareOffsetsSummary
+>
+
+const MOCK_SECTIONS = ['PRIMARY_PIPETTE_TIPRACKS' as Section]
+
+const render = () => {
+  return renderWithProviders(<SummaryScreen />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+describe('SummaryScreen', () => {
+  beforeEach(() => {
+    mockSectionList.mockReturnValue(<div>Mock SectionList</div>)
+    mockDeckmap.mockReturnValue(<div>Mock DeckMap</div>)
+    mockLabwareOffsetsSummary.mockReturnValue(
+      <div>Mock Labware Offsets Summary </div>
+    )
+    mockUseLabwareIdsBySection.mockReturnValue({})
+
+    when(mockUseIntroInfo).calledWith().mockReturnValue({
+      primaryTipRackSlot: '1',
+      primaryTipRackName: 'Opentrons 96 Filter Tip Rack 200 µL',
+      primaryPipetteMount: 'left',
+      secondaryPipetteMount: '',
+      numberOfTips: 1,
+      firstStepLabwareSlot: '2',
+      sections: MOCK_SECTIONS,
+    })
+  })
+  it('renders Summary Screen with all components and header', () => {
+    const { getByText } = render()
+    getByText('Mock SectionList')
+    getByText('Mock DeckMap')
+    getByText('Mock Labware Offsets Summary')
+    getByText('Labware Position Check Complete')
+  })
+  it('renders button and clicks it', () => {
+    const { getByRole } = render()
+    getByRole('button', { name: 'Close and apply labware offset data' })
+  })
 })

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
@@ -6,21 +6,24 @@ import { SectionList } from '../SectionList'
 import { DeckMap } from '../DeckMap'
 import { SummaryScreen } from '../SummaryScreen'
 import { LabwareOffsetsSummary } from '../LabwareOffsetsSummary'
-import { useIntroInfo, useLabwareIdsBySection } from '../hooks'
+import { useIntroInfo } from '../hooks'
+import { useProtocolDetails } from '../../../RunDetails/hooks'
 import { Section } from '../types'
 
 jest.mock('../SectionList')
 jest.mock('../hooks')
 jest.mock('../DeckMap')
+jest.mock('../../../RunDetails/hooks')
 jest.mock('../LabwareOffsetsSummary')
 
 const mockSectionList = SectionList as jest.MockedFunction<typeof SectionList>
 const mockUseIntroInfo = useIntroInfo as jest.MockedFunction<
   typeof useIntroInfo
 >
-const mockUseLabwareIdsBySection = useLabwareIdsBySection as jest.MockedFunction<
-  typeof useLabwareIdsBySection
+const mockUseProtocolDetails = useProtocolDetails as jest.MockedFunction<
+  typeof useProtocolDetails
 >
+
 const mockDeckmap = DeckMap as jest.MockedFunction<typeof DeckMap>
 
 const mockLabwareOffsetsSummary = LabwareOffsetsSummary as jest.MockedFunction<
@@ -28,6 +31,12 @@ const mockLabwareOffsetsSummary = LabwareOffsetsSummary as jest.MockedFunction<
 >
 
 const MOCK_SECTIONS = ['PRIMARY_PIPETTE_TIPRACKS' as Section]
+const LABWARE_DEF_ID = 'LABWARE_DEF_ID'
+const PRIMARY_PIPETTE_ID = 'PRIMARY_PIPETTE_ID'
+const PRIMARY_PIPETTE_NAME = 'PRIMARY_PIPETTE_NAME'
+const LABWARE_DEF = {
+  ordering: [['A1', 'A2']],
+}
 
 const render = () => {
   return renderWithProviders(<SummaryScreen />, {
@@ -42,7 +51,6 @@ describe('SummaryScreen', () => {
     mockLabwareOffsetsSummary.mockReturnValue(
       <div>Mock Labware Offsets Summary </div>
     )
-    mockUseLabwareIdsBySection.mockReturnValue({})
 
     when(mockUseIntroInfo).calledWith().mockReturnValue({
       primaryTipRackSlot: '1',
@@ -53,6 +61,29 @@ describe('SummaryScreen', () => {
       firstStepLabwareSlot: '2',
       sections: MOCK_SECTIONS,
     })
+
+    when(mockUseProtocolDetails)
+      .calledWith()
+      .mockReturnValue({
+        protocolData: {
+          labware: {
+            '1d57fc10-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_96_filtertiprack_200ul/1': {
+              slot: '1',
+              displayName: 'someDislpayName',
+              definitionId: LABWARE_DEF_ID,
+            },
+          },
+          labwareDefinitions: {
+            [LABWARE_DEF_ID]: LABWARE_DEF,
+          },
+          pipettes: {
+            [PRIMARY_PIPETTE_ID]: {
+              name: PRIMARY_PIPETTE_NAME,
+              mount: 'left',
+            },
+          },
+        },
+      } as any)
   })
   it('renders Summary Screen with all components and header', () => {
     const { getByText } = render()

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
@@ -1,0 +1,3 @@
+describe('Summary Screen', () => {
+  it.todo('should render the summary screen', () => {})
+})

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
@@ -38,7 +38,7 @@ export const LabwarePositionCheck = (
         }}
       >
         {isComplete ? (
-          <SummaryScreen onCloseClick={props.onCloseClick} />
+          <SummaryScreen/>
         ) : currentLabwareCheckStep !== null ? (
           <GenericStepScreen
             setCurrentLabwareCheckStep={setCurrentLabwareCheckStep}

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
@@ -5,12 +5,15 @@ import { Portal } from '../../../App/portal'
 import { useSteps } from './hooks'
 import { IntroScreen } from './IntroScreen'
 import { GenericStepScreen } from './GenericStepScreen'
+import { SummaryScreen } from './SummaryScreen'
 
 import styles from '../styles.css'
 
 interface LabwarePositionCheckModalProps {
   onCloseClick: () => unknown
 }
+
+const isComplete = true // TODO: replace this with isComplete boolean from useLabwarePositionCheck
 
 export const LabwarePositionCheck = (
   props: LabwarePositionCheckModalProps
@@ -34,7 +37,9 @@ export const LabwarePositionCheck = (
           },
         }}
       >
-        {currentLabwareCheckStep !== null ? (
+        {isComplete ? (
+          <SummaryScreen />
+        ) : currentLabwareCheckStep !== null ? (
           <GenericStepScreen
             setCurrentLabwareCheckStep={setCurrentLabwareCheckStep}
             selectedStep={steps[currentLabwareCheckStep]}

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
@@ -38,7 +38,7 @@ export const LabwarePositionCheck = (
         }}
       >
         {isComplete ? (
-          <SummaryScreen/>
+          <SummaryScreen />
         ) : currentLabwareCheckStep !== null ? (
           <GenericStepScreen
             setCurrentLabwareCheckStep={setCurrentLabwareCheckStep}

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
@@ -38,7 +38,7 @@ export const LabwarePositionCheck = (
         }}
       >
         {isComplete ? (
-          <SummaryScreen />
+          <SummaryScreen onCloseClick={props.onCloseClick} />
         ) : currentLabwareCheckStep !== null ? (
           <GenericStepScreen
             setCurrentLabwareCheckStep={setCurrentLabwareCheckStep}


### PR DESCRIPTION
# Overview

addresses #8219, this creates the final summary screen scaffolding

# Changelog

- created `SummaryScreen` and `LabwareOffsetsSummary` components

# Review requests

- review styling to make sure it matches the [figma](https://www.figma.com/file/JCQNOTTK9tTmYPhRqeOfSj/Milestone-0%3A-Protocol-Upload-Revamp?node-id=4071%3A20429)

# Risk assessment

low, behind ff