### PR TITLE
refactor(app): make jog control CTA buttons blue only in LPC

### DIFF
--- a/app/src/molecules/JogControls/DirectionControl.tsx
+++ b/app/src/molecules/JogControls/DirectionControl.tsx
@@ -9,7 +9,6 @@ import {
   Icon,
   HandleKeypress,
   ALIGN_CENTER,
-  C_BLUE,
 } from '@opentrons/components'
 import { ControlContainer } from './ControlContainer'
 

--- a/app/src/molecules/JogControls/DirectionControl.tsx
+++ b/app/src/molecules/JogControls/DirectionControl.tsx
@@ -112,6 +112,7 @@ interface DirectionControlProps {
   plane: Plane
   jog: Jog
   stepSize: number
+  buttonColor?: string
 }
 
 export function DirectionControl(props: DirectionControlProps): JSX.Element {
@@ -146,7 +147,7 @@ export function DirectionControl(props: DirectionControlProps): JSX.Element {
                 onClick={() => props.jog(axis, sign, props.stepSize)}
                 {...{ gridRow, gridColumn }}
               >
-                <Icon name={iconName} backgroundColor={C_BLUE} />
+                <Icon name={iconName} backgroundColor={props.buttonColor} />
               </PrimaryBtn>
             )
           )}

--- a/app/src/molecules/JogControls/StepSizeControl.tsx
+++ b/app/src/molecules/JogControls/StepSizeControl.tsx
@@ -20,7 +20,7 @@ export function StepSizeControl(props: StepSizeControlProps): JSX.Element {
   const { stepSizes, currentStepSize, setCurrentStepSize } = props
 
   const lpcRadiobuttonColor = cx({
-    [styles.radio_button]: props.isLPC
+    [styles.radio_button]: props.isLPC,
   })
 
   const increaseStepSize: () => void = () => {

--- a/app/src/molecules/JogControls/StepSizeControl.tsx
+++ b/app/src/molecules/JogControls/StepSizeControl.tsx
@@ -1,6 +1,6 @@
 // jog controls component
 import * as React from 'react'
-
+import cx from 'classnames'
 import { RadioGroup, HandleKeypress } from '@opentrons/components'
 import { ControlContainer } from './ControlContainer'
 import styles from './styles.css'
@@ -14,9 +14,14 @@ interface StepSizeControlProps {
   stepSizes: StepSize[]
   currentStepSize: StepSize
   setCurrentStepSize: (stepSize: StepSize) => void
+  isLPC?: boolean
 }
 export function StepSizeControl(props: StepSizeControlProps): JSX.Element {
   const { stepSizes, currentStepSize, setCurrentStepSize } = props
+
+  const lpcRadiobuttonColor = cx({
+    [styles.radio_button]: props.isLPC
+  })
 
   const increaseStepSize: () => void = () => {
     const i = stepSizes.indexOf(currentStepSize)
@@ -51,7 +56,7 @@ export function StepSizeControl(props: StepSizeControlProps): JSX.Element {
             value: `${stepSize}`,
           }))}
           onChange={handleStepSelect}
-          className={styles.radio_button}
+          className={lpcRadiobuttonColor}
         />
       </HandleKeypress>
     </ControlContainer>

--- a/app/src/molecules/JogControls/StepSizeControl.tsx
+++ b/app/src/molecules/JogControls/StepSizeControl.tsx
@@ -14,6 +14,7 @@ interface StepSizeControlProps {
   stepSizes: StepSize[]
   currentStepSize: StepSize
   setCurrentStepSize: (stepSize: StepSize) => void
+  //  TODO: remove this prop after all primary buttons are changed to blue in the next gen app work
   isLPC?: boolean
 }
 export function StepSizeControl(props: StepSizeControlProps): JSX.Element {

--- a/app/src/molecules/JogControls/index.tsx
+++ b/app/src/molecules/JogControls/index.tsx
@@ -25,7 +25,8 @@ export interface JogControlsProps extends StyleProps {
   planes?: Plane[]
   stepSizes?: StepSize[]
   auxiliaryControl?: React.ReactNode | null
-  buttonColor?: string
+  directionControlButtonColor?: string
+  //  TODO: remove this prop after all primary buttons are changed to blue in the next gen app work
   isLPC?: boolean
 }
 
@@ -61,7 +62,7 @@ export function JogControls(props: JogControlsProps): JSX.Element {
           plane={plane}
           jog={jog}
           stepSize={currentStepSize}
-          buttonColor={props.buttonColor}
+          buttonColor={props.directionControlButtonColor}
         />
       ))}
       {auxiliaryControl}

--- a/app/src/molecules/JogControls/index.tsx
+++ b/app/src/molecules/JogControls/index.tsx
@@ -25,12 +25,15 @@ export interface JogControlsProps extends StyleProps {
   planes?: Plane[]
   stepSizes?: StepSize[]
   auxiliaryControl?: React.ReactNode | null
+  buttonColor?: string
+  isLPC?: boolean
 }
 
 export { HORIZONTAL_PLANE, VERTICAL_PLANE }
 
 export function JogControls(props: JogControlsProps): JSX.Element {
   const {
+    isLPC,
     stepSizes = DEFAULT_STEP_SIZES,
     planes = [HORIZONTAL_PLANE, VERTICAL_PLANE],
     jog,
@@ -50,7 +53,8 @@ export function JogControls(props: JogControlsProps): JSX.Element {
       {...styleProps}
     >
       <StepSizeControl
-        {...{ currentStepSize, setCurrentStepSize, stepSizes }}
+        {...{ currentStepSize, setCurrentStepSize, stepSizes, isLPC
+      }}
       />
       {planes.map(plane => (
         <DirectionControl
@@ -58,6 +62,7 @@ export function JogControls(props: JogControlsProps): JSX.Element {
           plane={plane}
           jog={jog}
           stepSize={currentStepSize}
+          buttonColor={props.buttonColor}
         />
       ))}
       {auxiliaryControl}

--- a/app/src/molecules/JogControls/index.tsx
+++ b/app/src/molecules/JogControls/index.tsx
@@ -53,8 +53,7 @@ export function JogControls(props: JogControlsProps): JSX.Element {
       {...styleProps}
     >
       <StepSizeControl
-        {...{ currentStepSize, setCurrentStepSize, stepSizes, isLPC
-      }}
+        {...{ currentStepSize, setCurrentStepSize, stepSizes, isLPC }}
       />
       {planes.map(plane => (
         <DirectionControl

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwarePositionCheckStepDetail.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwarePositionCheckStepDetail.tsx
@@ -34,6 +34,7 @@ import levelWithTip from '../../../assets/images/lpc_level_with_tip.svg'
 import levelWithLabware from '../../../assets/images/lpc_level_with_labware.svg'
 import { Axis, Sign, StepSize } from '../../../molecules/JogControls/types'
 import type { LabwarePositionCheckStep } from './types'
+import { truncate } from 'lodash'
 
 const DECK_MAP_VIEWBOX = '-30 -20 170 115'
 interface LabwarePositionCheckStepDetailProps {
@@ -136,6 +137,8 @@ export const LabwarePositionCheckStepDetail = (
               stepSizes={[0.1, 1, 10]}
               planes={[HORIZONTAL_PLANE, VERTICAL_PLANE]}
               width="100%"
+              buttonColor={C_BLUE}
+              isLPC={true}
             />
           ) : (
             <Flex justifyContent={JUSTIFY_CENTER} marginTop={SPACING_2}>

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwarePositionCheckStepDetail.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwarePositionCheckStepDetail.tsx
@@ -136,7 +136,7 @@ export const LabwarePositionCheckStepDetail = (
               stepSizes={[0.1, 1, 10]}
               planes={[HORIZONTAL_PLANE, VERTICAL_PLANE]}
               width="100%"
-              buttonColor={C_BLUE}
+              directionControlButtonColor={C_BLUE}
               isLPC={true}
             />
           ) : (

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwarePositionCheckStepDetail.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwarePositionCheckStepDetail.tsx
@@ -34,7 +34,6 @@ import levelWithTip from '../../../assets/images/lpc_level_with_tip.svg'
 import levelWithLabware from '../../../assets/images/lpc_level_with_labware.svg'
 import { Axis, Sign, StepSize } from '../../../molecules/JogControls/types'
 import type { LabwarePositionCheckStep } from './types'
-import { truncate } from 'lodash'
 
 const DECK_MAP_VIEWBOX = '-30 -20 170 115'
 interface LabwarePositionCheckStepDetailProps {


### PR DESCRIPTION
# Overview

closes #8568 

# Changelog

- extends props in `DirectionControl`, `StepSizeControl`, and `jogControls/index` to take in button and radiogroup colors

# Review requests

- review ticket and AC

# Risk assessment

low, behind ff