### PR TITLE
refactor(robot-server): Stop `opentrons-gpio-setup` before trying to control the front button light

### DIFF
--- a/api/src/opentrons/drivers/rpi_drivers/gpio.py
+++ b/api/src/opentrons/drivers/rpi_drivers/gpio.py
@@ -68,6 +68,11 @@ class GPIOCharDev:
             return line
 
         if name == "blue_button":
+            # todo(mm, 2021-10-22): See if we can remove these retries.
+            # They may have been to paper over a former race condition where, during
+            # boot, the robot server would start initializing hardware before the
+            # standalone light-blinking process ot-blinkenlights was guaranteed to
+            # have relinquished its handle on the blue button GPIO line.
             return _retry_request_line(3)
         else:
             return _retry_request_line()

--- a/robot-server/opentrons-robot-server.service
+++ b/robot-server/opentrons-robot-server.service
@@ -7,13 +7,6 @@ After=nginx.service
 
 After=opentrons-status-leds.service
 
-# Both this service and opentrons-gpio-setup.service
-# acquire the GPIO line to control the OT-2's front button light.
-# Stop opentrons-gpio-setup.service before starting this service,
-# so they don't conflict and cause a "device already in use" error.
-Conflicts=opentrons-gpio-setup.service
-After=opentrrons-gpio-setup.service
-
 
 [Service]
 

--- a/robot-server/opentrons-robot-server.service
+++ b/robot-server/opentrons-robot-server.service
@@ -1,19 +1,31 @@
 [Unit]
+
 Description=Opentrons Robot HTTP Server
+
 Requires=nginx.service
 After=nginx.service
+
 After=opentrons-status-leds.service
 
+# Both this service and opentrons-gpio-setup.service
+# acquire the GPIO line to control the OT-2's front button light.
+# Stop opentrons-gpio-setup.service before starting this service,
+# so they don't conflict and cause a "device already in use" error.
+Conflicts=opentrons-gpio-setup.service
+After=opentrrons-gpio-setup.service
+
+
 [Service]
+
 Type=notify
 # "--lifespan on" ensures errors in startup and shutdown handlers won't be hidden.
 # See github.com/encode/starlette/issues/1138, fixed in Starlette v0.16.0?
 ExecStart=uvicorn robot_server:app --uds /run/aiohttp.sock --ws wsproto --lifespan on
-# Stop the button blinking
-ExecStartPost=systemctl stop opentrons-gpio-setup.service
 Environment=OT_SMOOTHIE_ID=AMA RUNNING_ON_PI=true
 Restart=on-failure
 TimeoutStartSec=3min
 
+
 [Install]
+
 WantedBy=opentrons.target

--- a/robot-server/robot_server/hardware.py
+++ b/robot-server/robot_server/hardware.py
@@ -1,7 +1,6 @@
 """Hardware API wrapper module for initialization and management."""
 import asyncio
 import logging
-import subprocess
 from pathlib import Path
 from fastapi import Depends, status
 from typing import Callable, Union, cast
@@ -109,50 +108,73 @@ async def get_hardware(app_state: AppState = Depends(get_app_state)) -> Hardware
     return hardware_api
 
 
-async def _initialize_hardware_api(app_state: AppState) -> None:
+async def _initialize_hardware_api(app_state: AppState) -> None:  # noqa: C901
     """Initialize the HardwareAPI and attach it to global state."""
-    app_settings = get_settings()
-    simulator_config = app_settings.simulator_configuration_file_path
-    use_thread_manager = feature_flags.enable_protocol_engine() is False
+    try:
+        app_settings = get_settings()
+        simulator_config = app_settings.simulator_configuration_file_path
+        use_thread_manager = feature_flags.enable_protocol_engine() is False
 
-    systemd_available = IS_ROBOT and ARCHITECTURE != SystemArchitecture.HOST
+        systemd_available = IS_ROBOT and ARCHITECTURE != SystemArchitecture.HOST
 
-    if systemd_available:
-        # During boot, opentrons-gpio-setup.service will be blinking the
-        # front button light. Kill it here and wait for it to exit so it releases
-        # that GPIO line. Otherwise, our hardware initialization would get a
-        # "device already in use" error.
-        subprocess.run(
-            ["systemctl", "stop", "opentrons-gpio-setup"],
-            check=True,
-        )
-        log.info("Stopped opentrons-gpio-setup.")
+        if systemd_available:
+            # During boot, opentrons-gpio-setup.service will be blinking the
+            # front button light. Kill it here and wait for it to exit so it releases
+            # that GPIO line. Otherwise, our hardware initialization would get a
+            # "device already in use" error.
+            service_to_stop = "opentrons-gpio-setup"
+            command = ["systemctl", "stop", service_to_stop]
+            subprocess = await asyncio.create_subprocess_exec(
+                *command,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await subprocess.communicate()
+            if subprocess.returncode == 0:
+                log.info(f"Stopped {service_to_stop}.")
+            else:
+                raise RuntimeError(
+                    f"Error stopping {service_to_stop}.",
+                    {
+                        "returncode": subprocess.returncode,
+                        "stdout": stdout,
+                        "stderr": stderr,
+                    },
+                )
 
-    if simulator_config:
-        simulator_config_path = Path(simulator_config)
-        log.info(f"Loading simulator from {simulator_config_path}")
+        if simulator_config:
+            simulator_config_path = Path(simulator_config)
+            log.info(f"Loading simulator from {simulator_config_path}")
 
-        if use_thread_manager:
-            thread_manager = ThreadManager(load_simulator, simulator_config_path)
-            hardware_api = cast(HardwareAPI, thread_manager)
+            if use_thread_manager:
+                thread_manager = ThreadManager(load_simulator, simulator_config_path)
+                hardware_api = cast(HardwareAPI, thread_manager)
+            else:
+                hardware_api = await load_simulator(path=simulator_config_path)
+
         else:
-            hardware_api = await load_simulator(path=simulator_config_path)
+            hardware_api = await initialize_api()
 
-    else:
-        hardware_api = await initialize_api()
+        _initialize_event_watchers(app_state, hardware_api)
+        _hw_api.set_on(app_state, hardware_api)
 
-    _initialize_event_watchers(app_state, hardware_api)
-    _hw_api.set_on(app_state, hardware_api)
+        if systemd_available:
+            try:
+                import systemd.daemon  # type: ignore
 
-    if systemd_available:
-        try:
-            import systemd.daemon  # type: ignore
+                systemd.daemon.notify("READY=1")
+            except ImportError:
+                pass
 
-            systemd.daemon.notify("READY=1")
-        except ImportError:
-            pass
+        log.info("Opentrons hardware API initialized")
 
-    log.info("Opentrons hardware API initialized")
+    except Exception:
+        # todo(mm, 2021-10-22): Logging this exception should be the responsibility
+        # of calling code, but currently, nothing catches exceptions raised from
+        # this background initialization task. Once that's fixed, this log.error()
+        # should be removed,
+        log.exception("Exception during hardware background initialization.")
+        raise
 
 
 # TODO(mc, 2021-09-01): if we're ever going to actually use the notification


### PR DESCRIPTION
# Overview

This PR is a quick workaround for a problem on our `edge` branch builds where `robot-server` fails to start up.

# Background on the problem

[`opentrons-gpio-setup`](https://github.com/Opentrons/buildroot/blob/a0b6147b4c02b55f8c2157da4e47f36f25cd2a6f/board/opentrons/ot2/rootfs-overlay/etc/systemd/system/opentrons-gpio-setup.service), aka [`ot-blinkenlights`](https://github.com/Opentrons/buildroot/blob/a0b6147b4c02b55f8c2157da4e47f36f25cd2a6f/board/opentrons/ot2/rootfs-overlay/usr/bin/ot-blinkenlights), is a standalone service that blinks the OT-2's front button light during startup, independently of other services.

Later, `opentrons-robot-server` starts up, and it *also* wants to blink the button. The intent seems to have been for it to work like this:

1. `opentrons-gpio-setup` is running.
2. `opentrons-robot-server` begins starting up. Meanwhile, `opentrons-gpio-setup` continues blinking the light in the background.
3. Eventually, when `opentrons-robot-server` is ready, it takes over blinking duty from `opentrons-gpio-setup`.
    
    Importantly, things are arranged so that `opentrons-gpio-setup` is shut down just before this happens, to avoid a "device busy" conflict from the two processes attempting to acquire the same GPIO line at once.
4. `opentrons-robot-server` does some slow hardware initialization stuff and homes the gantry, while it does its own blinking.
5. Finally, `opentrons-robot-server` sets the button solid blue when it's done initializing.

This had been working for a while.

But #8536 affected step (3). It changed the relative timing so that, at the point where `opentrons-robot-server` starts blinking the light, `opentrons-gpio-setup` is still running and trying to blink it itself. This causes a "device busy" error inside `opentrons-robot-server`, preventing it from fully initializing.

And all along, even when this was working, it was kind of dicey. We did the mutual exclusion in step (3) by [configuring systemd](https://github.com/Opentrons/opentrons/blob/fb3f40458ad86e430030d4a750e74d30bc6aca08/robot-server/opentrons-robot-server.service#L12-L13) to shut down `opentrons-gpio-setup` when `opentrons-robot-server` tells systemd it's done initializing. The problems that I see with this are:

* It's inherently racy. Stopping `opentrons-gpio-setup` when `opentrons-robot-server` is "done initializing" doesn't guarantee that `opentrons-gpio-setup` will be totally dead by the time `opentrons-robot-server` attempts to acquire the GPIO line. If it's not, we'll get the same "device busy" conflict.
* Even if that worked, it's unintuitive to me for a process to send a "done initializing" update as a synchronization mechanism for making it safe for that process to *continue* initializing.

# Changelog

~~Make `opentrons-robot-server` and `opentrons-gpio-setup` mutually exclusive at the systemd service level. systemd now will not let the two services run at the same time. Before starting `opentrons-robot-server`, systemd will automatically stop `opentrons-gpio-setup` and wait for it to exit.~~

Edit: The approach  has changed. See the thread below.

# Caveat

~~Unfortunately, in practice, this workaround makes things look like this:~~

1. ~~You flip on the OT-2's power switch. The OT-2 starts booting.~~
2. ~~If `opentrons-gpio-setup` even gets the chance to run at all, `systemd` will very quickly stop it, because it wants to start `opentrons-robot-server` now.~~
3. ~~**The robot will spend ~1m45s without the light blinking.** Most of this is spent inside `opentrons-robot-server`, after it's started, but before it's gotten to the point where it's able to blink the light.~~
4. ~~`opentrons-robot-server` will finally blink the light for a few seconds as it does some hardware initialization stuff and homes the gantry.~~
5. ~~`opentrons-robot-server` will finally turn the button solid blue.~~

~~This is certainly something we'll have to improve before the next release. 1m45s without the light blinking makes it look like the boot has completely failed.~~

# Options for real solutions

I'd like to kick further investigation of these into another issue/PR, but here are some options off the top of my head for fixing the above caveat:

* Somehow rework `opentrons-robot-server` so it doesn't take 1m45s to get to the point where it blinks the front button. If this is possible, it would even let us get rid of the separate `opentrons-gpio-setup` service.
* Keep `opentrons-gpio-setup`, but find a more robust way for `opentrons-robot-server` to signal it to back off when it's ready to take over button-blinking. Maybe `opentrons-robot-server` would send `opentrons-gpio-setup` a custom dbus message, or something.
* Keep `opentrons-gpio-setup`, but make `opentrons-robot-server` synchronously stop it before taking over button-blinking. Doing `subprocess.run(["systemctl", "stop", "opentrons-gpio-setup"])` could I guess, but that feels icky to me.
    * [Edit: This PR has changed to do this. See the thread below.]
* Go back closer to the way things were before #8536. Move `opentrons-robot-server`'s "done initializing" update earlier, so `opentrons-gpio-setup` has time to stop, in practice. I think this would be a bummer; for reasons described above, this was dicey even though it happened to work.

# Review requests

* ~~Are we okay with the 1m45s caveat described above?~~
* Manual testing:
    
   I've tested on a non-refresh OT-2 and confirmed that this works as described above. ~~If you want to test yourself, you need to SSH in, `mount -o remount,rw /`, and manually edit `/etc/systemd/system/opentrons-robot-server.service` (e.g. with `vi`). `make push` will *not* update this file.~~

# Risk assessment

Low-ish. For now, I think this is the simplest, smallest change that's guaranteed to solve the immediate problem. But it does affect systemd service dependencies, which are inter-repo and difficult to reason about.
