### PR TITLE
refactor(api): Small improvements to button blinking during hardware initialization

### DIFF
--- a/api/src/opentrons/__init__.py
+++ b/api/src/opentrons/__init__.py
@@ -164,12 +164,14 @@ async def initialize() -> API:
     # is returned. Do our own blinking here to keep it going while we home the robot.
     blink_task = asyncio.create_task(_blink())
 
-    if not ff.disable_home_on_boot():
-        log.info("Homing Z axes")
-        await hardware.home_z()
+    try:
+        if not ff.disable_home_on_boot():
+            log.info("Homing Z axes")
+            await hardware.home_z()
 
-    blink_task.cancel()
-    await asyncio.gather(blink_task, return_exceptions=True)
-    await hardware.set_lights(button=True)
+        await hardware.set_lights(button=True)
 
-    return hardware
+        return hardware
+    finally:
+        blink_task.cancel()
+        await blink_task

--- a/api/src/opentrons/__init__.py
+++ b/api/src/opentrons/__init__.py
@@ -159,6 +159,9 @@ async def initialize() -> API:
             await hardware.set_lights(button=False)
             await asyncio.sleep(0.5)
 
+    # While the hardware was initializing in _create_hardware_api(), it blinked the
+    # front button light. But that blinking stops when the completed hardware object
+    # is returned. Do our own blinking here to keep it going while we home the robot.
     blink_task = asyncio.create_task(_blink())
 
     if not ff.disable_home_on_boot():

--- a/api/src/opentrons/__init__.py
+++ b/api/src/opentrons/__init__.py
@@ -174,4 +174,7 @@ async def initialize() -> API:
         return hardware
     finally:
         blink_task.cancel()
-        await blink_task
+        try:
+            await blink_task
+        except asyncio.CancelledError:
+            pass

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -223,6 +223,7 @@ class API(HardwareAPILike):
             return api_instance
         finally:
             blink_task.cancel()
+            await blink_task
 
     @classmethod
     async def build_hardware_simulator(

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -223,7 +223,10 @@ class API(HardwareAPILike):
             return api_instance
         finally:
             blink_task.cancel()
-            await blink_task
+            try:
+                await blink_task
+            except asyncio.CancelledError:
+                pass
 
     @classmethod
     async def build_hardware_simulator(


### PR DESCRIPTION
# Overview

This PR makes a few small improvements to how we blink the front button light while hardware is initializing.

# Changelog

See my inline comments.

# Review requests

A code review is probably sufficient here.

After #8580 is merged, I will push this to an OT-2 and smoke-test that this does not interfere with the blinking that happens while `robot-server` initializes hardware and homes the gantry.

# Risk assessment

Low. Changes are small and self-contained.