### PR TITLE
feat(can): PCAN does FD.

### DIFF
--- a/hardware/opentrons_hardware/drivers/can_bus/driver.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/driver.py
@@ -20,10 +20,13 @@ if platform.system() == "Darwin":
     from can.interfaces.pcan import basic
 
     basic.TPCANMsgMac = basic.TPCANMsg
+    basic.TPCANMsgFDMac = basic.TPCANMsgFD
     basic.TPCANTimestampMac = basic.TPCANTimestamp
+
     from can.interfaces.pcan import pcan
 
     pcan.TPCANMsgMac = pcan.TPCANMsg
+    pcan.TPCANMsgFDMac = pcan.TPCANMsgFD
     pcan.TPCANTimestampMac = pcan.TPCANTimestamp
     # end super bad monkey patch
 
@@ -65,14 +68,24 @@ class CanDriver:
         Returns:
             A CanDriver instance.
         """
-        # TODO (amit, 2021-09-29): remove hacks to support `pcan` when we don't
-        #  need it anymore.
-        #  pcan will not initialize when `fd` is True. looks like it's
-        #  this issue https://forum.peak-system.com/viewtopic.php?t=5646
-        #  Luckily we can still send `fd` messages using `pcan`.
-        fd = True if interface != "pcan" else False
+        extra_kwargs = {}
+        if interface == "pcan":
+            # Special FDCAN parameters for use of PCAN driver.
+            extra_kwargs = {
+                "f_clock_mhz": 20,
+                "nom_brp": 5,
+                "nom_tseg1": 13,
+                "nom_tseg2": 2,
+                "nom_sjw": 16,
+            }
         return CanDriver(
-            bus=Bus(channel=channel, bitrate=bitrate, interface=interface, fd=fd),
+            bus=Bus(
+                channel=channel,
+                bitrate=bitrate,
+                interface=interface,
+                fd=True,
+                **extra_kwargs
+            ),
             loop=asyncio.get_event_loop(),
         )
 

--- a/hardware/opentrons_hardware/drivers/can_bus/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/messages/message_definitions.py
@@ -1,4 +1,4 @@
-"""Defintion of CAN messages."""
+"""Definition of CAN messages."""
 from dataclasses import dataclass
 from typing import Type
 

--- a/hardware/opentrons_hardware/drivers/can_bus/messages/messages.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/messages/messages.py
@@ -48,6 +48,6 @@ def get_definition(message_id: MessageId) -> Optional[MessageDefinition]:
     for i in get_args(MessageDefinition):
         if i.message_id == message_id:
             # get args returns Tuple[Any...]
-            return i  # type: ignore
+            return i  # type: ignore[no-any-return]
 
     return None

--- a/hardware/opentrons_hardware/utils/binary_serializable.py
+++ b/hardware/opentrons_hardware/utils/binary_serializable.py
@@ -135,10 +135,13 @@ class BinarySerializable:
         Returns:
             cls
         """
-        b = struct.unpack(cls._get_format_string(), data)
-        args = {v.name: v.type.build(b[i]) for i, v in enumerate(fields(cls))}
-        # Mypy is not liking constructing the derived types.
-        return cls(**args)  # type: ignore
+        try:
+            b = struct.unpack(cls._get_format_string(), data)
+            args = {v.name: v.type.build(b[i]) for i, v in enumerate(fields(cls))}
+            # Mypy is not liking constructing the derived types.
+            return cls(**args)  # type: ignore[call-arg]
+        except struct.error as e:
+            raise InvalidFieldException(str(e))
 
     @classmethod
     def _get_format_string(cls) -> str:


### PR DESCRIPTION
# Overview

`python-can`'s  PCAN interface (the driver used by our CAN analyzers) requires really low level set up when enabling FD. 

# Changelog

Set up the FD can parameters when using PCAN driver. 
A little better error handling and logging.

# Review requests

Please test the `can_comm` script  with the FW in this PR. https://github.com/Opentrons/ot3-firmware/pull/125

# Risk assessment

Moderate. Could break our CAN comms.