### PR TITLE
refactor(api): rely on the aspirate function for air gap

### DIFF
--- a/api/src/opentrons/protocol_api/paired_instrument_context.py
+++ b/api/src/opentrons/protocol_api/paired_instrument_context.py
@@ -635,7 +635,7 @@ class PairedInstrumentContext(CommandPublisher):
             raise RuntimeError("No previous Well cached to perform air gap")
         target = loc.labware.as_well().top(height)
         self._implementation.move_to(target)
-        self._implementation.aspirate(volume=c_vol, location=loc, rate=1.0)
+        self._implementation.air_gap(volume=c_vol, rate=1.0)
         return self
 
     @requires_version(2, 7)

--- a/api/src/opentrons/protocol_api/paired_instrument_context.py
+++ b/api/src/opentrons/protocol_api/paired_instrument_context.py
@@ -634,8 +634,7 @@ class PairedInstrumentContext(CommandPublisher):
         if not loc or not loc.labware.is_well:
             raise RuntimeError("No previous Well cached to perform air gap")
         target = loc.labware.as_well().top(height)
-        self._implementation.move_to(target)
-        self._implementation.air_gap(volume=c_vol, rate=1.0)
+        self._implementation.aspirate(volume=c_vol, location=target, rate=1.0)
         return self
 
     @requires_version(2, 7)

--- a/api/src/opentrons/protocols/context/protocol_api/paired_instrument.py
+++ b/api/src/opentrons/protocols/context/protocol_api/paired_instrument.py
@@ -163,9 +163,6 @@ class PairedInstrument(AbstractPairedInstrument):
 
         self._hw_manager.hardware.aspirate(self._pair_policy, volume, rate)
 
-    def air_gap(self, volume: float, rate: float) -> None:
-        self._hw_manager.hardware.aspirate(self._pair_policy, volume, rate)
-
     def dispense(self, volume: float, location: types.Location, rate: float) -> None:
         if location != self._ctx.get_last_location():
             self.move_to(location)

--- a/api/src/opentrons/protocols/context/protocol_api/paired_instrument.py
+++ b/api/src/opentrons/protocols/context/protocol_api/paired_instrument.py
@@ -163,6 +163,9 @@ class PairedInstrument(AbstractPairedInstrument):
 
         self._hw_manager.hardware.aspirate(self._pair_policy, volume, rate)
 
+    def air_gap(self, volume: float, rate: float) -> None:
+        self._hw_manager.hardware.aspirate(self._pair_policy, volume, rate)
+
     def dispense(self, volume: float, location: types.Location, rate: float) -> None:
         if location != self._ctx.get_last_location():
             self.move_to(location)


### PR DESCRIPTION
## Overview

A bug fix to the non-supported `pipette twinning` feature.

Since we're already passing in the target location to the aspirate function, we should be able to rely on the logic in this function for moving to the correct position.

## Changelog

- Remove the initial move before aspirating within the air gap function
- Added in some tests about pipette movement during air gap

## Review requests
Test on a robot

## Note
 I have not yet tested on a robot whether this will fix the bug or not, hence why this is a draft PR.

# Risk assessment

Low. Unsupported feature.
