### PR TITLE
refactor(protocol-engine): Add labware offsets to HTTP run models

### DIFF
--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -23,19 +23,6 @@ class RunType(str, Enum):
     PROTOCOL = "protocol"
 
 
-class AbstractRunCreateData(BaseModel):
-    """Request data sent when creating a run."""
-
-    runType: RunType = Field(
-        ...,
-        description="The run type to create.",
-    )
-    createParams: Optional[BaseModel] = Field(
-        None,
-        description="Parameters to set run behaviors at creation time.",
-    )
-
-
 class RunCommandSummary(ResourceModel):
     """A stripped down model of a full Command for usage in a Run response."""
 
@@ -74,10 +61,23 @@ class AbstractRun(ResourceModel):
     )
 
 
-class BasicRunCreateData(AbstractRunCreateData):
+class BasicRunCreateParams(BaseModel):
+    """Creation parameters for a basic run."""
+
+    pass
+
+
+class BasicRunCreateData(BaseModel):
     """Creation request data for a basic run."""
 
-    runType: Literal[RunType.BASIC] = RunType.BASIC
+    runType: Literal[RunType.BASIC] = Field(
+        RunType.BASIC,
+        description="The run type to create.",
+    )
+    createParams: BasicRunCreateParams = Field(
+        default_factory=BasicRunCreateParams,
+        description="Parameters to set run behaviors at creation time.",
+    )
 
 
 class BasicRun(AbstractRun):
@@ -95,11 +95,17 @@ class ProtocolRunCreateParams(BaseModel):
     )
 
 
-class ProtocolRunCreateData(AbstractRunCreateData):
+class ProtocolRunCreateData(BaseModel):
     """Creation request data for a protocol run."""
 
-    runType: Literal[RunType.PROTOCOL] = RunType.PROTOCOL
-    createParams: ProtocolRunCreateParams
+    runType: Literal[RunType.PROTOCOL] = Field(
+        RunType.PROTOCOL,
+        description="The run type to create.",
+    )
+    createParams: ProtocolRunCreateParams = Field(
+        ...,
+        description="Parameters to set run behaviors at creation time.",
+    )
 
 
 class ProtocolRun(AbstractRun):

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -9,6 +9,7 @@ from opentrons.protocol_engine import (
     CommandStatus,
     CommandType,
     EngineStatus as RunStatus,
+    LabwareLocation,
     LoadedPipette,
     LoadedLabware,
 )
@@ -60,6 +61,31 @@ class AbstractRun(ResourceModel):
     labware: List[LoadedLabware] = Field(
         ...,
         description="Labware that has been loaded into the run.",
+    )
+
+
+class LabwareOffsetVector(BaseModel):
+    """An offset to apply to labware, in deck coordinates."""
+
+    x: float
+    y: float
+    z: float
+
+
+class LabwareOffset(BaseModel):
+    """An offset that the robot adds to a pipette's position when it moves to a labware.
+
+    During the run, if a labware is loaded whose definition URI and location
+    both match what's found here, the given offset will be added to all
+    pipette movements that use that labware as a reference point.
+    """
+
+    definitionUri: str = Field(..., description="The URI for the labware's definition.")
+    location: LabwareLocation = Field(
+        ..., description="Where the labware is located on the robot."
+    )
+    offset: LabwareOffsetVector = Field(
+        ..., description="The offset applied to matching labware."
     )
 
 

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -41,11 +41,6 @@ class AbstractRun(ResourceModel):
     runType: RunType = Field(..., description="Specific run type.")
     createdAt: datetime = Field(..., description="When the run was created")
     status: RunStatus = Field(..., description="Execution status of the run")
-    # TODO(mc, 2021-05-25): how hard would it be to rename this field to `config`?
-    createParams: Optional[BaseModel] = Field(
-        None,
-        description="Configuration parameters for the run.",
-    )
     actions: List[RunAction] = Field(
         ...,
         description="Client-initiated run control actions.",
@@ -102,6 +97,7 @@ class BasicRunCreateData(BaseModel):
         RunType.BASIC,
         description="The run type to create.",
     )
+    # TODO(mc, 2021-05-25): how hard would it be to rename this field to `config`?
     createParams: BasicRunCreateParams = Field(
         default_factory=BasicRunCreateParams,
         description="Parameters to set run behaviors at creation time.",
@@ -130,6 +126,7 @@ class ProtocolRunCreateData(BaseModel):
         RunType.PROTOCOL,
         description="The run type to create.",
     )
+    # TODO(mc, 2021-05-25): how hard would it be to rename this field to `config`?
     createParams: ProtocolRunCreateParams = Field(
         ...,
         description="Parameters to set run behaviors at creation time.",

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -35,6 +35,8 @@ class AbstractRun(ResourceModel):
     """Base run resource model."""
 
     id: str = Field(..., description="Unique run identifier.")
+    # TODO(mm, 2021-10-28): runType is redundant with createParams.runType.
+    # Deprecate one or the other.
     runType: RunType = Field(..., description="Specific run type.")
     createdAt: datetime = Field(..., description="When the run was created")
     status: RunStatus = Field(..., description="Execution status of the run")

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -32,7 +32,7 @@ class RunCommandSummary(ResourceModel):
     status: CommandStatus = Field(..., description="Execution status of the command.")
 
 
-class AbstractRun(ResourceModel):
+class _AbstractRun(ResourceModel):
     """Base run resource model."""
 
     id: str = Field(..., description="Unique run identifier.")
@@ -102,7 +102,7 @@ class BasicRunCreateData(BaseModel):
     )
 
 
-class BasicRun(AbstractRun):
+class BasicRun(_AbstractRun):
     """A run to execute commands without a previously loaded protocol file."""
 
     runType: Literal[RunType.BASIC] = RunType.BASIC
@@ -135,7 +135,7 @@ class ProtocolRunCreateData(BaseModel):
     )
 
 
-class ProtocolRun(AbstractRun):
+class ProtocolRun(_AbstractRun):
     """A run to execute commands with a previously loaded protocol file."""
 
     runType: Literal[RunType.PROTOCOL] = RunType.PROTOCOL

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -36,8 +36,6 @@ class AbstractRun(ResourceModel):
     """Base run resource model."""
 
     id: str = Field(..., description="Unique run identifier.")
-    # TODO(mm, 2021-10-28): runType is redundant with createParams.runType.
-    # Deprecate one or the other.
     runType: RunType = Field(..., description="Specific run type.")
     createdAt: datetime = Field(..., description="When the run was created")
     status: RunStatus = Field(..., description="Execution status of the run")

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -2,7 +2,7 @@
 from enum import Enum
 from datetime import datetime
 from pydantic import BaseModel, Field
-from typing import List, Optional, Union
+from typing import List, Union
 from typing_extensions import Literal
 
 from opentrons.protocol_engine import (
@@ -87,7 +87,7 @@ class LabwareOffset(BaseModel):
 class BasicRunCreateParams(BaseModel):
     """Creation parameters for a basic run."""
 
-    pass
+    labwareOffsets: List[LabwareOffset] = Field(default_factory=list)
 
 
 class BasicRunCreateData(BaseModel):
@@ -109,6 +109,8 @@ class BasicRun(AbstractRun):
 
     runType: Literal[RunType.BASIC] = RunType.BASIC
 
+    createParams: BasicRunCreateParams
+
 
 class ProtocolRunCreateParams(BaseModel):
     """Creation parameters for a protocol run."""
@@ -117,6 +119,8 @@ class ProtocolRunCreateParams(BaseModel):
         ...,
         description="Unique identifier of the protocol this run will execute.",
     )
+
+    labwareOffsets: List[LabwareOffset] = Field(default_factory=list)
 
 
 class ProtocolRunCreateData(BaseModel):

--- a/robot-server/robot_server/runs/run_view.py
+++ b/robot-server/robot_server/runs/run_view.py
@@ -1,7 +1,7 @@
 """Run response model factory."""
 from dataclasses import replace
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 from opentrons.protocol_engine import (
     Command as ProtocolEngineCommand,
@@ -109,23 +109,28 @@ class RunView:
             for c in commands
         ]
 
-        response_fields: Dict[str, Any] = {
-            "id": run.run_id,
-            "createdAt": run.created_at,
-            "actions": run.actions,
-            "commands": command_summaries,
-            "pipettes": pipettes,
-            "labware": labware,
-            "status": engine_status,
-        }
-
-        # FIX BEFORE MERGE: This is probably a bug.
-
         if isinstance(create_data, BasicRunCreateData):
-            return BasicRun(**response_fields)
+            return BasicRun(
+                id=run.run_id,
+                createParams=create_data.createParams,
+                createdAt=run.created_at,
+                actions=run.actions,
+                commands=command_summaries,
+                pipettes=pipettes,
+                labware=labware,
+                status=engine_status,
+            )
 
         if isinstance(create_data, ProtocolRunCreateData):
-            response_fields["createParams"] = create_data.createParams
-            return ProtocolRun(**response_fields)
+            return ProtocolRun(
+                id=run.run_id,
+                createParams=create_data.createParams,
+                createdAt=run.created_at,
+                actions=run.actions,
+                commands=command_summaries,
+                pipettes=pipettes,
+                labware=labware,
+                status=engine_status,
+            )
 
         raise ValueError(f"Invalid run resource {run}")

--- a/robot-server/robot_server/runs/run_view.py
+++ b/robot-server/robot_server/runs/run_view.py
@@ -119,6 +119,8 @@ class RunView:
             "status": engine_status,
         }
 
+        # FIX BEFORE MERGE: This is probably a bug.
+
         if isinstance(create_data, BasicRunCreateData):
             return BasicRun(**response_fields)
 

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -24,6 +24,7 @@ from robot_server.runs.run_models import (
     RunCommandSummary,
     BasicRun,
     BasicRunCreateData,
+    BasicRunCreateParams,
     ProtocolRun,
     ProtocolRunCreateData,
     ProtocolRunCreateParams,
@@ -77,6 +78,7 @@ async def test_create_run(
     expected_response = BasicRun(
         id=unique_id,
         createdAt=current_time,
+        createParams=BasicRunCreateParams(),
         status=pe_types.EngineStatus.READY_TO_RUN,
         actions=[],
         commands=[],
@@ -312,6 +314,7 @@ def test_get_run(
 
     expected_response = BasicRun(
         id="run-id",
+        createParams=BasicRunCreateParams(),
         createdAt=created_at,
         status=pe_types.EngineStatus.READY_TO_RUN,
         actions=[],
@@ -402,6 +405,7 @@ def test_get_runs_not_empty(
 
     response_1 = BasicRun(
         id="unique-id-1",
+        createParams=BasicRunCreateParams(),
         createdAt=created_at_1,
         status=pe_types.EngineStatus.SUCCEEDED,
         actions=[],

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -16,6 +16,7 @@ from robot_server.service.json_api import RequestModel, ResponseModel
 from robot_server.runs.run_models import (
     Run,
     BasicRun,
+    BasicRunCreateParams,
     RunCommandSummary,
 )
 from robot_server.runs.engine_store import EngineStore
@@ -61,6 +62,7 @@ async def test_get_run_commands() -> None:
     run_response = ResponseModel[Run](
         data=BasicRun(
             id="run-id",
+            createParams=BasicRunCreateParams(),
             createdAt=datetime(year=2021, month=1, day=1),
             status=EngineStatus.RUNNING,
             actions=[],

--- a/robot-server/tests/runs/test_run_store.py
+++ b/robot-server/tests/runs/test_run_store.py
@@ -99,7 +99,7 @@ def test_get_all_runs() -> None:
 
 
 def test_remove_run() -> None:
-    """It can get a previously stored run entry."""
+    """It can remove and return a previously stored run entry."""
     run = RunResource(
         run_id="run-id",
         create_data=BasicRunCreateData(),

--- a/robot-server/tests/runs/test_run_view.py
+++ b/robot-server/tests/runs/test_run_view.py
@@ -118,16 +118,14 @@ current_time = datetime.now()
                 id="run-id",
                 createdAt=current_time,
                 status=EngineStatus.READY_TO_RUN,
-                createData=BasicRunCreateData(
-                    createParams=BasicRunCreateParams(
-                        labwareOffsets=[
-                            LabwareOffset(
-                                definitionUri="my-labware-definition-uri",
-                                location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
-                                offset=LabwareOffsetVector(x=1, y=2, z=3),
-                            )
-                        ]
-                    )
+                createParams=BasicRunCreateParams(
+                    labwareOffsets=[
+                        LabwareOffset(
+                            definitionUri="my-labware-definition-uri",
+                            location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+                            offset=LabwareOffsetVector(x=1, y=2, z=3),
+                        )
+                    ]
                 ),
                 actions=[],
                 commands=[],
@@ -210,6 +208,7 @@ def test_to_response_maps_commands() -> None:
 
     assert result == BasicRun(
         id="run-id",
+        createParams=BasicRunCreateParams(),
         createdAt=datetime(year=2021, month=1, day=1),
         status=EngineStatus.RUNNING,
         actions=[],
@@ -263,6 +262,7 @@ def test_to_response_adds_equipment() -> None:
 
     assert result == BasicRun(
         id="run-id",
+        createParams=BasicRunCreateParams(),
         createdAt=datetime(year=2021, month=1, day=1),
         status=EngineStatus.RUNNING,
         actions=[],

--- a/robot-server/tests/runs/test_run_view.py
+++ b/robot-server/tests/runs/test_run_view.py
@@ -19,10 +19,13 @@ from robot_server.runs.run_models import (
     Run,
     BasicRun,
     BasicRunCreateData,
+    BasicRunCreateParams,
     ProtocolRun,
     ProtocolRunCreateData,
     ProtocolRunCreateParams,
     RunCommandSummary,
+    LabwareOffset,
+    LabwareOffsetVector,
 )
 
 from robot_server.runs.action_models import (
@@ -97,7 +100,17 @@ current_time = datetime.now()
         (
             RunResource(
                 run_id="run-id",
-                create_data=BasicRunCreateData(),
+                create_data=BasicRunCreateData(
+                    createParams=BasicRunCreateParams(
+                        labwareOffsets=[
+                            LabwareOffset(
+                                definitionUri="my-labware-definition-uri",
+                                location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+                                offset=LabwareOffsetVector(x=1, y=2, z=3),
+                            )
+                        ]
+                    )
+                ),
                 created_at=current_time,
                 actions=[],
             ),
@@ -105,6 +118,17 @@ current_time = datetime.now()
                 id="run-id",
                 createdAt=current_time,
                 status=EngineStatus.READY_TO_RUN,
+                createData=BasicRunCreateData(
+                    createParams=BasicRunCreateParams(
+                        labwareOffsets=[
+                            LabwareOffset(
+                                definitionUri="my-labware-definition-uri",
+                                location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+                                offset=LabwareOffsetVector(x=1, y=2, z=3),
+                            )
+                        ]
+                    )
+                ),
                 actions=[],
                 commands=[],
                 pipettes=[],


### PR DESCRIPTION
# Overview

Allows an HTTP client to create a basic run or protocol run with labware offsets, and retrieve those offsets later. Closes #8476.

# Changelog

Client-facing changes:

* When `POST`ing a `protocolRun`, `createParams` now accepts a list of labware offsets. Formerly, a `protocolRun`'s `createParams` only contained `protocolId`.
    * The API is based on the specification in #8476.
    * The list defaults to `[]` if not provided.
* Same for `basicRun`. Formerly, a `basicRun`'s `createParams` was optional, and if provided, it contained nothing. Now, it's `basicRun`'s `createParams` may still be omitted; it will default to `{ "labwareOffsets": [] }`.
* The `createParams.labwareOffsets` that the client provided when `POST`ing the run can be retrieved later with `GET /runs` or `GET /runs/{id}`. If the client left `labwareOffsets` unspecified in the `POST`, the `GET` will return it as `[]`.

Internal-only changes:

* Rename `AbstractRun` to `_AbstractRun`. This class is basically being used as a private mixin to bring common fields into `ProtocolRun` and `BasicRun`. Code outside this module has no reason to use this class, and should use the union `Run` instead.
* Remove `createParams` from `_AbstractRun`. See the message on commit 669d58c for details.
* Eliminate `AbstractRunCreateData`. Similar reasons as above.
* Refactor some `run_view` code that converts from internal run models to client-facing run models so it doesn't subvert static typechecking. Update that same code to account for the fact that basic runs have `createData` now.


# Review requests

* Run `make -C robot-server dev OT_API_FF_enableProtocolEngine=1`, and visit http://localhost:31950/docs or http://localhost:31950/redoc in your browser to view the run management endpoints. Make sure the request and response models look reasonable.
* Do we agree with this plan to expand this to support loading modules later on:
  * As the `location` of a labware offset, the client will be able to provide something like `"location": {"module": { "loadName": "magnetic_module_gen2", "slot": 4 }`. The offset will then apply to any labware loaded on any Magnetic Module GEN2 in slot 4.
* Try playing with the `/runs` endpoints and create basic runs and protocol runs with and without labware offsets. Verify they're stored correctly. [This Postman collection](https://gist.github.com/SyntaxColoring/5901b2093c1b391ec377217a7ac64111) can be a good starting point. (You'd need to manually edit the request body to include labware offset data.)

# Risk assessment

Risk of accidental change to the client-facing API: Not really applicable. Since this only affects the `/runs` endpoints, which are thankfully now separate from the `/sessions` endpoints. We can do whatever we want to these.

Risk of breaking something about how we internally store models: Lowish. This does rework some of the model definitions, and there was a tricky thing in `RunView` that had to be caught and fixed. But if the smoke test passes now, it should be fine.
