### PR TITLE
feat(robot-server): allow a run and a legacy session to exist simultaneously

### DIFF
--- a/robot-server/robot_server/router.py
+++ b/robot-server/robot_server/router.py
@@ -64,10 +64,10 @@ else:
     )
 
 router.include_router(
-        router=deprecated_session_router,
-        tags=["Session Management"],
-        dependencies=[Depends(check_version_header)],
-    )
+    router=deprecated_session_router,
+    tags=["Session Management"],
+    dependencies=[Depends(check_version_header)],
+)
 
 router.include_router(
     router=labware_router,

--- a/robot-server/robot_server/router.py
+++ b/robot-server/robot_server/router.py
@@ -58,17 +58,16 @@ if enable_protocol_engine():
 
 else:
     router.include_router(
-        router=deprecated_session_router,
-        tags=["Session Management"],
-        dependencies=[Depends(check_version_header)],
-    )
-
-    router.include_router(
         router=deprecated_protocol_router,
         tags=["Protocol Management"],
         dependencies=[Depends(check_version_header)],
     )
 
+router.include_router(
+        router=deprecated_session_router,
+        tags=["Session Management"],
+        dependencies=[Depends(check_version_header)],
+    )
 
 router.include_router(
     router=labware_router,


### PR DESCRIPTION
# Overview

Closes #8613 

# Changelog

- `router.py`: Moved the addition of legacy sessions router outside of the PE ff check

# Review requests

- Using the dev app, check if you can perform deck/ pipette-offset/ tip-length calibrations with the Protocol Engine FF ON as well as OFF. 
I have smoke tested on the dev server and performed a pipette offset calibration on my OT2. So, if testing on a robot, someone can check if deck calibration &/or tip length calibration works correctly. Also, check if there's a difference in performance with the PE flag ON vs OFF.

# Risk assessment

- Low for non-PE since this should not cause any change. 
- Medium-High for PE since it allows runs & sessions to exist at the same time, which could lead to resource access issues if not implemented correctly. The good thing is that the robot-server creates only one instance of the hardware api, which is passed to both legacy sessions and PE-backed runs. But the use of those sessions and runs need to be managed well by the client so as to not create situations where a session unpredictably changes the underlying robot state such that the run state is not longer valid; and vice versa.
