### PR TITLE
refactor(app): Remove run time estimate from metadata card

### DIFF
--- a/app/src/organisms/ProtocolSetup/MetadataCard.tsx
+++ b/app/src/organisms/ProtocolSetup/MetadataCard.tsx
@@ -40,7 +40,7 @@ export function MetadataCard(): JSX.Element {
           id={'MetadataCard_protocolCreationMethod'}
         />
       </Flex>
-      <Flex marginTop={SPACING_2} flex={'auto'}>
+      <Flex marginTop={SPACING_2}>
         <LabeledValue
           flex={6}
           label={t('description')}

--- a/app/src/organisms/ProtocolSetup/MetadataCard.tsx
+++ b/app/src/organisms/ProtocolSetup/MetadataCard.tsx
@@ -47,6 +47,12 @@ export function MetadataCard(): JSX.Element {
           value={description || '-'}
           id={'MetadataCard_protocolDescription'}
         />
+        {/* <LabeledValue TODO: add estimated run time back in when ready
+          flex={2}
+          label={t('estimated_run_time')}
+          value={'-'}
+          id={'MetadataCard_protocolEstRunTime'}
+        /> */}
       </Flex>
     </Card>
   )

--- a/app/src/organisms/ProtocolSetup/MetadataCard.tsx
+++ b/app/src/organisms/ProtocolSetup/MetadataCard.tsx
@@ -40,18 +40,12 @@ export function MetadataCard(): JSX.Element {
           id={'MetadataCard_protocolCreationMethod'}
         />
       </Flex>
-      <Flex marginTop={SPACING_2}>
+      <Flex marginTop={SPACING_2} flex={'auto'}>
         <LabeledValue
           flex={6}
           label={t('description')}
           value={description || '-'}
           id={'MetadataCard_protocolDescription'}
-        />
-        <LabeledValue
-          flex={2}
-          label={t('estimated_run_time')}
-          value={'-'}
-          id={'MetadataCard_protocolEstRunTime'}
         />
       </Flex>
     </Card>

--- a/app/src/organisms/ProtocolSetup/__tests__/MetadataCard.test.tsx
+++ b/app/src/organisms/ProtocolSetup/__tests__/MetadataCard.test.tsx
@@ -44,8 +44,5 @@ describe('MetadataCard', () => {
     expect(getByText('Description').nextElementSibling).toHaveTextContent(
       /this describes the protocol/i
     )
-    expect(
-      getByText('Estimated Run Time').nextElementSibling
-    ).toHaveTextContent(/-/i)
   })
 })

--- a/app/src/organisms/ProtocolSetup/__tests__/MetadataCard.test.tsx
+++ b/app/src/organisms/ProtocolSetup/__tests__/MetadataCard.test.tsx
@@ -44,5 +44,9 @@ describe('MetadataCard', () => {
     expect(getByText('Description').nextElementSibling).toHaveTextContent(
       /this describes the protocol/i
     )
+    // TODO: add estimated run time back in when ready
+    // expect(
+    //   getByText('Estimated Run Time').nextElementSibling
+    // ).toHaveTextContent(/-/i)
   })
 })


### PR DESCRIPTION

# Overview

closes #8551 

# Changelog

- comments out estimated runtime for now

# Review requests

- review ticket to make sure it matches the AC (I chose to comment out the info instead of deleting it since the ticket says to remove 'for now')

# Risk assessment

low, behind ff
