### PR TITLE
refactor(robot-server): Treat JSON v5 and earlier protocols as legacy

### DIFF
--- a/api/src/opentrons/protocol_runner/legacy_wrappers.py
+++ b/api/src/opentrons/protocol_runner/legacy_wrappers.py
@@ -35,10 +35,18 @@ from opentrons.protocols.types import (
 from .protocol_source import ProtocolSource
 
 
+# The earliest Python Protocol API version ("apiLevel") where the protocol's simulation
+# and execution will be handled by Protocol Engine, rather than the legacy machinery.
+#
+# Note that even when simulation and execution are handled by the legacy machinery,
+# Protocol Engine still has some involvement for analyzing the simulation and
+# monitoring the execution.
 LEGACY_PYTHON_API_VERSION_CUTOFF = APIVersion(3, 0)
 
-# TODO(mc, 2021-09-21): remove this condition, cut off before 6 always
-LEGACY_JSON_SCHEMA_VERSION_CUTOFF = 5 if feature_flags.enable_protocol_engine() else 6
+
+# The earliest JSON protocol schema version where the protocol is executed directly by
+# Protocol Engine, rather than going through Python Protocol API v2.
+LEGACY_JSON_SCHEMA_VERSION_CUTOFF = 6
 
 
 class LegacyFileReader:

--- a/api/src/opentrons/protocol_runner/legacy_wrappers.py
+++ b/api/src/opentrons/protocol_runner/legacy_wrappers.py
@@ -3,7 +3,6 @@ import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 
-from opentrons.config import feature_flags
 from opentrons.hardware_control import API as HardwareAPI
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.context.protocol_api.protocol_context import (


### PR DESCRIPTION
# Overview

This PR ensures that when you upload a JSON v5 protocol over the HTTP API, it's treated as a "legacy protocol." This means its execution goes through the Python Protocol API, instead of Protocol Engine attempting to execute it directly. This matches the behavior of the legacy RPC system.

This is important for the Labware Position Check beta because it allows a much wider variety of protocols to pass analysis. Our support for uploading and analyzing a legacy protocol that uses hardware modules is better than our support for uploading and analyzing a "native Protocol Engine" protocol that uses hardware modules.

The only reason we weren't doing this before was artificial: we needed a way to test our handling of legacy vs. non-legacy JSON protocols, and JSON schema v6 didn't usably exist yet. See #8339. This is still a problem, but it's less urgent than the Labware Position Check beta concerns.

# Changelog

* Treat JSON protocols ≤ v5 as legacy, instead of ≤ v6.
* Add comments to explain how these cutoffs work.

# Review requests

* Do the comments make sense to you?
* Grab a JSON protocol that uses hardware modules and confirm that it analyzes successfully when `POST`ed to a dev server.

# Risk assessment

Low. We planned on doing this at some point, so things should be designed with this in mind.