### PR TITLE
refactor(protocol-engine): Add models for the load module command

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -1,4 +1,5 @@
 """Union types of concrete command definitions."""
+
 from typing import Union
 
 from .add_labware_definition import (
@@ -19,6 +20,13 @@ from .load_labware import (
     LoadLabwareRequest,
     LoadLabwareResult,
     LoadLabwareCommandType,
+)
+
+from .load_module import (
+    LoadModule,
+    LoadModuleRequest,
+    LoadModuleResult,
+    LoadModuleCommandType,
 )
 
 from .load_pipette import (
@@ -61,6 +69,7 @@ Command = Union[
     Dispense,
     DropTip,
     LoadLabware,
+    LoadModule,
     LoadPipette,
     MoveToWell,
     PickUpTip,
@@ -74,6 +83,7 @@ CommandType = Union[
     DispenseCommandType,
     DropTipCommandType,
     LoadLabwareCommandType,
+    LoadModuleCommandType,
     LoadPipetteCommandType,
     MoveToWellCommandType,
     PickUpTipCommandType,
@@ -87,6 +97,7 @@ CommandRequest = Union[
     DispenseRequest,
     DropTipRequest,
     LoadLabwareRequest,
+    LoadModuleRequest,
     LoadPipetteRequest,
     MoveToWellRequest,
     PickUpTipRequest,
@@ -99,6 +110,7 @@ CommandResult = Union[
     DispenseResult,
     DropTipResult,
     LoadLabwareResult,
+    LoadModuleResult,
     LoadPipetteResult,
     MoveToWellResult,
     PickUpTipResult,

--- a/api/src/opentrons/protocol_engine/commands/load_module.py
+++ b/api/src/opentrons/protocol_engine/commands/load_module.py
@@ -45,8 +45,10 @@ class LoadModuleData(BaseModel):
 
     moduleId: Optional[str] = Field(
         None,
-        description="An optional ID to assign to this module. If None, an ID "
-        "will be generated.",
+        description=(
+            "An optional ID to assign to this module."
+            " If None, an ID will be generated."
+        ),
     )
 
 

--- a/api/src/opentrons/protocol_engine/commands/load_module.py
+++ b/api/src/opentrons/protocol_engine/commands/load_module.py
@@ -1,0 +1,82 @@
+"""Implementation, request models, and response models for the load module command."""
+
+from typing import Optional, Type
+from typing_extensions import Literal
+
+from pydantic import BaseModel, Field
+
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandRequest
+from ..types import DeckSlotLocation
+
+
+LoadModuleCommandType = Literal["loadModule"]
+
+
+class LoadModuleData(BaseModel):
+    """Data required to load a module."""
+
+    # todo(mm, 2021-11-01): Use an enum instead of a str. shared-data defines the
+    # possible model names.
+    model: str = Field(
+        ...,
+        example="magneticModuleV1",
+        description="""The model name of the module to load.
+
+        If a different version of this module is physically connected, the load will
+        succeed if it's deemed compatible with the version you requested.
+        """,
+    )
+
+    # Note: Our assumption here that a module's position can be boiled down to a
+    # single deck slot precludes loading a Thermocycler in its special "shifted slightly
+    # to the left" position. This is okay for now because neither the Python Protocol
+    # API nor Protocol Designer attempt to support it, either.
+    location: DeckSlotLocation = Field(
+        ...,
+        description="""The location into which this module should be loaded.
+
+        For the Thermocycler Module, which occupies multiple deck slots,
+        this should be the front-most occupied slot (normally slot 7).
+        """,
+    )
+
+    moduleId: Optional[str] = Field(
+        None,
+        description="An optional ID to assign to this module. If None, an ID "
+        "will be generated.",
+    )
+
+
+class LoadModuleResult(BaseModel):
+    """The results of loading a module."""
+
+    moduleId: str = Field(
+        description="An ID to reference this module in subsequent commands."
+    )
+
+
+class LoadModuleImplementation(AbstractCommandImpl[LoadModuleData, LoadModuleResult]):
+    """The implementation of the load module command."""
+
+    async def execute(self, data: LoadModuleData) -> LoadModuleResult:
+        """Check that the requested module is attached and assign its identifier."""
+        raise NotImplementedError()
+
+
+class LoadModule(BaseCommand[LoadModuleData, LoadModuleResult]):
+    """The model for a load module command."""
+
+    commandType: LoadModuleCommandType = "loadModule"
+    data: LoadModuleData
+    result: Optional[LoadModuleResult]
+
+    _ImplementationCls: Type[LoadModuleImplementation] = LoadModuleImplementation
+
+
+class LoadModuleRequest(BaseCommandRequest[LoadModuleData]):
+    """The model for a creation request for a load module command."""
+
+    commandType: LoadModuleCommandType = "loadModule"
+    data: LoadModuleData
+
+    _CommandCls: Type[LoadModule] = LoadModule

--- a/api/src/opentrons/protocol_engine/commands/load_module.py
+++ b/api/src/opentrons/protocol_engine/commands/load_module.py
@@ -20,11 +20,13 @@ class LoadModuleData(BaseModel):
     model: str = Field(
         ...,
         example="magneticModuleV1",
-        description="""The model name of the module to load.
-
-        If a different version of this module is physically connected, the load will
-        succeed if it's deemed compatible with the version you requested.
-        """,
+        description=(
+            "The model name of the module to load."
+            "\n\n"
+            "If a different version of this module is physically connected,"
+            " the load will succeed"
+            " if it's deemed compatible with the version you requested."
+        )
     )
 
     # Note: Our assumption here that a module's position can be boiled down to a
@@ -33,11 +35,12 @@ class LoadModuleData(BaseModel):
     # API nor Protocol Designer attempt to support it, either.
     location: DeckSlotLocation = Field(
         ...,
-        description="""The location into which this module should be loaded.
-
-        For the Thermocycler Module, which occupies multiple deck slots,
-        this should be the front-most occupied slot (normally slot 7).
-        """,
+        description=(
+            "The location into which this module should be loaded."
+            "\n\n"
+            "For the Thermocycler Module, which occupies multiple deck slots,"
+            " this should be the front-most occupied slot (normally slot 7)."
+        )
     )
 
     moduleId: Optional[str] = Field(

--- a/api/src/opentrons/protocol_engine/commands/load_module.py
+++ b/api/src/opentrons/protocol_engine/commands/load_module.py
@@ -26,7 +26,7 @@ class LoadModuleData(BaseModel):
             "If a different version of this module is physically connected,"
             " the load will succeed"
             " if it's deemed compatible with the version you requested."
-        )
+        ),
     )
 
     # Note: Our assumption here that a module's position can be boiled down to a
@@ -40,7 +40,7 @@ class LoadModuleData(BaseModel):
             "\n\n"
             "For the Thermocycler Module, which occupies multiple deck slots,"
             " this should be the front-most occupied slot (normally slot 7)."
-        )
+        ),
     )
 
     moduleId: Optional[str] = Field(

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -21,7 +21,7 @@ class EngineStatus(str, Enum):
 
 
 class DeckSlotLocation(BaseModel):
-    """Location for labware placed in a single slot."""
+    """The location of something placed in a single deck slot."""
 
     slot: DeckSlotName
 

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -27,7 +27,7 @@ class DeckSlotLocation(BaseModel):
 
 
 LabwareLocation = Union[DeckSlotLocation]
-"""Union of all legal labware locations."""
+"""Union of all locations where it's legal to load a labware."""
 
 
 class WellOrigin(str, Enum):


### PR DESCRIPTION
# Overview

This PR adds public-facing models for a `loadModule` Protocol Engine command. This is the first step to implementing #8207.

# Changelog

* Add public-facing models for `LoadModuleRequest`, `LoadModuleResult`, and `LoadModule`.
* If you attempt to actually execute a `LoadModule` command through Protocol Engine, it will currently raise a `NotImplementedError`.

# Review requests

Review the command model by either:

* reading the Python code
* running `make -C dev OT_API_FF_enableProtocolEngine=1` and inspecting the run management endpoints at http://localhost:31950/redoc or http://localhost:31950/docs.

Make sure:

* We agree with the basic premise. That is, we have a `loadModule` command that:
    1. takes a string representing the kind of module to load
    2. when executed, makes sure that that module is physically connected
    3. upon success, returns a unique ID representing that physical module
* We agree with naming the field `model`, as opposed to `modelName`, `name`, `loadName`, or something else. `model` is taken from [the current draft of JSON protocol v6](https://github.com/Opentrons/opentrons/blob/0f339f45de238183b2c433e67f839363d5177582/shared-data/protocol/schemas/6.json#L266-L282). Note that this is inconsistent with the `loadPipette` command, which takes a `pipetteName`, not a `pipetteModel`.
* We agree that the above field should take camelCase values like `magneticModuleV1` instead of Python Protocol API values like `magnetic module`. Again, this is taken from [the current draft of JSON protocol v6](https://github.com/Opentrons/opentrons/blob/0f339f45de238183b2c433e67f839363d5177582/shared-data/protocol/schemas/6.json#L266-L282), and again, this is inconsistent with the `loadPipette` command.
* We agree with the "compatible loading" behavior of `model` that I've documented.
* We agree that we're not worried about Thermocycler positioning, for now.


# Risk assessment

No risk to functionality, but this is a fairly important API, so we should make sure it's specced right.