### PR TITLE
refactor(react-api-client): make useCreateProtocolMutation callback take files as params

### DIFF
--- a/react-api-client/src/protocols/__tests__/useCreateProtocolMutation.test.tsx
+++ b/react-api-client/src/protocols/__tests__/useCreateProtocolMutation.test.tsx
@@ -61,15 +61,12 @@ describe('useCreateProtocolMutation hook', () => {
       .calledWith(HOST_CONFIG, createProtocolData)
       .mockRejectedValue('oh no')
 
-    const { result, waitFor } = renderHook(
-      () => useCreateProtocolMutation(createProtocolData),
-      {
-        wrapper,
-      }
-    )
+    const { result, waitFor } = renderHook(() => useCreateProtocolMutation(), {
+      wrapper,
+    })
 
     expect(result.current.data).toBeUndefined()
-    result.current.createProtocol()
+    result.current.createProtocol(createProtocolData)
     await waitFor(() => {
       console.log(result.current.status)
       return result.current.status !== 'loading'
@@ -83,13 +80,10 @@ describe('useCreateProtocolMutation hook', () => {
       .calledWith(HOST_CONFIG, createProtocolData)
       .mockResolvedValue({ data: PROTOCOL_RESPONSE } as Response<Protocol>)
 
-    const { result, waitFor } = renderHook(
-      () => useCreateProtocolMutation(createProtocolData),
-      {
-        wrapper,
-      }
-    )
-    act(() => result.current.createProtocol())
+    const { result, waitFor } = renderHook(() => useCreateProtocolMutation(), {
+      wrapper,
+    })
+    act(() => result.current.createProtocol(createProtocolData))
 
     await waitFor(() => result.current.data != null)
 

--- a/react-api-client/src/protocols/useCreateProtocolMutation.ts
+++ b/react-api-client/src/protocols/useCreateProtocolMutation.ts
@@ -11,23 +11,23 @@ import type { HostConfig, Protocol } from '@opentrons/api-client'
 export type UseCreateProtocolMutationResult = UseMutationResult<
   Protocol,
   unknown,
-  void
+  File[]
 > & {
-  createProtocol: UseMutateFunction<Protocol, unknown, void>
+  createProtocol: UseMutateFunction<Protocol, unknown, File[]>
 }
 
-export function useCreateProtocolMutation(
-  protocolFiles: File[]
-): UseCreateProtocolMutationResult {
+export function useCreateProtocolMutation(): UseCreateProtocolMutationResult {
   const host = useHost()
   const queryClient = useQueryClient()
 
-  const mutation = useMutation<Protocol, unknown>([host, 'protocols'], () =>
-    createProtocol(host as HostConfig, protocolFiles).then(response => {
-      const protocolId = response.data.data.id
-      queryClient.setQueryData([host, 'protocols', protocolId], response.data)
-      return response.data
-    })
+  const mutation = useMutation<Protocol, unknown, File[]>(
+    [host, 'protocols'],
+    (protocolFiles: File[]) =>
+      createProtocol(host as HostConfig, protocolFiles).then(response => {
+        const protocolId = response.data.data.id
+        queryClient.setQueryData([host, 'protocols', protocolId], response.data)
+        return response.data
+      })
   )
   return {
     ...mutation,


### PR DESCRIPTION
# Overview

Instead of passing the protocol files to the useCresteProtocolMutation hook, pass them as a
parameter to the callback function that the hook returns.

# Review requests

- does the code look ok

# Risk assessment

low, currently unused code