### PR TITLE
refactor(protocol-engine): add savePosition command

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/__init__.py
@@ -89,6 +89,13 @@ from .pause import (
     PauseCommandType,
 )
 
+from .save_position import (
+    SavePosition,
+    SavePositionData,
+    SavePositionRequest,
+    SavePositionResult,
+    SavePositionCommandType,
+)
 
 from .custom import (
     Custom,
@@ -165,6 +172,12 @@ __all__ = [
     "PauseRequest",
     "PauseResult",
     "PauseCommandType",
+    # save position command models
+    "SavePosition",
+    "SavePositionData",
+    "SavePositionRequest",
+    "SavePositionResult",
+    "SavePositionCommandType",
     # custom command models
     "Custom",
     "CustomData",

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -49,6 +49,13 @@ from .pause import (
     PauseCommandType,
 )
 
+from .save_position import (
+    SavePosition,
+    SavePositionRequest,
+    SavePositionResult,
+    SavePositionCommandType,
+)
+
 from .custom import (
     Custom,
     CustomResult,
@@ -65,6 +72,7 @@ Command = Union[
     MoveToWell,
     PickUpTip,
     Pause,
+    SavePosition,
     Custom,
 ]
 
@@ -78,6 +86,7 @@ CommandType = Union[
     MoveToWellCommandType,
     PickUpTipCommandType,
     PauseCommandType,
+    SavePositionCommandType,
     CustomCommandType,
 ]
 
@@ -91,6 +100,7 @@ CommandRequest = Union[
     MoveToWellRequest,
     PickUpTipRequest,
     PauseRequest,
+    SavePositionRequest,
 ]
 
 CommandResult = Union[
@@ -103,5 +113,6 @@ CommandResult = Union[
     MoveToWellResult,
     PickUpTipResult,
     PauseResult,
+    SavePositionResult,
     CustomResult,
 ]

--- a/api/src/opentrons/protocol_engine/commands/save_position.py
+++ b/api/src/opentrons/protocol_engine/commands/save_position.py
@@ -1,0 +1,86 @@
+"""Save pipette position command request, result, and implementation models."""
+
+from __future__ import annotations
+from pydantic import BaseModel, Field
+from typing import Optional, Type
+from typing_extensions import Literal
+
+from opentrons.types import MountType, Point
+
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandRequest
+
+SavePositionCommandType = Literal["savePosition"]
+
+"""
+{
+    commandType: "savePosition",
+    data: {
+        pipetteId: string,    // pipette to use in measurement
+        positionId: string | null | undefined,  // position ID, auto-assigned if left blank
+    },
+    result: {
+        positionId: string,
+        position: { x: number, y: number, z: number }
+    }
+}
+"""
+
+
+class SavePositionData(BaseModel):
+    """Data needed to save a pipette's current position."""
+
+    pipetteId: str = Field(
+        ..., description="Unique identifier of the pipette in question."
+    )
+    positionId: Optional[str] = Field(
+        None,
+        description="An optional ID to assign to this command instance. "
+        "Auto-assigned if not defined.",
+    )
+
+
+class SavePositionResult(BaseModel):
+    """Result data from executing a savePosition."""
+
+    positionId: str = Field(
+        ..., description="An ID to reference this position in subsequent requests."
+    )
+    position: Point = Field(
+        ...,
+        description="The (x,y,z) coordinates of the pipette's critical point "
+        "in deck space.",
+    )
+
+
+class SavePositionImplementation(
+    AbstractCommandImpl[SavePositionData, SavePositionResult]
+):
+    """Save position command implementation."""
+
+    async def execute(self, data: SavePositionData) -> SavePositionResult:
+        """Check the requested pipette's current position."""
+        result = await self._movement.save_position(
+            pipette_id=data.pipetteId, position_id=data.positionId
+        )
+        return SavePositionResult(
+            positionId=result.positionId, position=result.position
+        )
+
+
+class SavePosition(BaseCommand[SavePositionData, SavePositionResult]):
+    """Save Position command model."""
+
+    commandType: SavePositionCommandType = "savePosition"
+    data: SavePositionData
+    result: Optional[SavePositionResult]
+
+    _ImplementationCls: Type[SavePositionImplementation] = SavePositionImplementation
+
+
+class SavePositionRequest(BaseCommandRequest[SavePositionData]):
+    """Save position command creation request model."""
+
+    commandType: SavePositionCommandType = "savePosition"
+    data: SavePositionData
+
+    _CommandCls: Type[SavePosition] = SavePosition

--- a/api/src/opentrons/protocol_engine/commands/save_position.py
+++ b/api/src/opentrons/protocol_engine/commands/save_position.py
@@ -5,25 +5,10 @@ from pydantic import BaseModel, Field
 from typing import Optional, Type
 from typing_extensions import Literal
 
-from opentrons.types import MountType, Point
-
+from ..types import DeckPoint
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandRequest
 
 SavePositionCommandType = Literal["savePosition"]
-
-"""
-{
-    commandType: "savePosition",
-    data: {
-        pipetteId: string,    // pipette to use in measurement
-        positionId: string | null | undefined,  // position ID, auto-assigned if left blank
-    },
-    result: {
-        positionId: string,
-        position: { x: number, y: number, z: number }
-    }
-}
-"""
 
 
 class SavePositionData(BaseModel):
@@ -45,7 +30,7 @@ class SavePositionResult(BaseModel):
     positionId: str = Field(
         ..., description="An ID to reference this position in subsequent requests."
     )
-    position: Point = Field(
+    position: DeckPoint = Field(
         ...,
         description="The (x,y,z) coordinates of the pipette's critical point "
         "in deck space.",

--- a/api/src/opentrons/protocol_engine/execution/__init__.py
+++ b/api/src/opentrons/protocol_engine/execution/__init__.py
@@ -4,7 +4,7 @@ from .create_queue_worker import create_queue_worker
 from .command_executor import CommandExecutor
 from .queue_worker import QueueWorker
 from .equipment import EquipmentHandler, LoadedLabwareData, LoadedPipetteData
-from .movement import MovementHandler
+from .movement import MovementHandler, SavedPositionData
 from .pipetting import PipettingHandler
 from .run_control import RunControlHandler
 
@@ -16,6 +16,7 @@ __all__ = [
     "LoadedLabwareData",
     "LoadedPipetteData",
     "MovementHandler",
+    "SavedPositionData",
     "PipettingHandler",
     "RunControlHandler",
     "QueueWorker",

--- a/api/src/opentrons/protocol_engine/execution/movement.py
+++ b/api/src/opentrons/protocol_engine/execution/movement.py
@@ -81,10 +81,9 @@ class MovementHandler:
             )
 
     async def save_position(
-        self, pipette_id: str, position_id: str
+        self, pipette_id: str, position_id: Optional[str]
     ) -> SavedPositionData:
         """Get the pipette position and save to state."""
-
         pipette_location = self._state_store.motion.get_pipette_location(
             pipette_id=pipette_id,
         )

--- a/api/src/opentrons/protocol_engine/state/motion.py
+++ b/api/src/opentrons/protocol_engine/state/motion.py
@@ -67,7 +67,6 @@ class MotionView:
             )
         ):
             critical_point = CriticalPoint.XY_CENTER
-
         return PipetteLocationData(mount=mount, critical_point=critical_point)
 
     def get_movement_waypoints(

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -69,6 +69,14 @@ class CalibrationOffset(BaseModel):
     z: float
 
 
+class DeckPoint(BaseModel):
+    """Coordinates of a point in deck space."""
+
+    x: float
+    y: float
+    z: float
+
+
 # TODO(mc, 2021-04-16): reconcile with opentrons_shared_data
 # shared-data/python/opentrons_shared_data/pipette/dev_types.py
 class PipetteName(str, Enum):

--- a/api/tests/opentrons/protocol_engine/commands/test_save_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_save_position.py
@@ -1,0 +1,46 @@
+"""Test save position command."""
+from decoy import Decoy
+
+from opentrons.types import MountType, Point
+from opentrons.protocol_engine.execution import (
+    EquipmentHandler,
+    MovementHandler,
+    PipettingHandler,
+    RunControlHandler,
+    SavedPositionData,
+)
+
+from opentrons.protocol_engine.commands.save_position import (
+    SavePositionData,
+    SavePositionResult,
+    SavePositionImplementation,
+)
+
+
+async def test_save_position_implementation(
+    decoy: Decoy,
+    equipment: EquipmentHandler,
+    movement: MovementHandler,
+    pipetting: PipettingHandler,
+    run_control: RunControlHandler,
+) -> None:
+    """A SavePosition command should have an execution implementation."""
+    subject = SavePositionImplementation(
+        equipment=equipment,
+        movement=movement,
+        pipetting=pipetting,
+        run_control=run_control,
+    )
+    data = SavePositionData(
+        pipetteId="abc",
+        positionId="123",
+    )
+    decoy.when(
+        await movement.save_position(
+            pipette_id="abc",
+            position_id="123",
+        )
+    ).then_return(SavedPositionData(positionId="123", position=Point(x=1, y=2, z=3)))
+
+    result = await subject.execute(data)
+    assert result == SavePositionResult(positionId="123", position=Point(x=1, y=2, z=3))

--- a/api/tests/opentrons/protocol_engine/commands/test_save_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_save_position.py
@@ -1,7 +1,7 @@
 """Test save position command."""
 from decoy import Decoy
 
-from opentrons.types import MountType, Point
+from opentrons.protocol_engine.types import DeckPoint
 from opentrons.protocol_engine.execution import (
     EquipmentHandler,
     MovementHandler,
@@ -40,7 +40,11 @@ async def test_save_position_implementation(
             pipette_id="abc",
             position_id="123",
         )
-    ).then_return(SavedPositionData(positionId="123", position=Point(x=1, y=2, z=3)))
+    ).then_return(
+        SavedPositionData(positionId="123", position=DeckPoint(x=1, y=2, z=3))
+    )
 
     result = await subject.execute(data)
-    assert result == SavePositionResult(positionId="123", position=Point(x=1, y=2, z=3))
+    assert result == SavePositionResult(
+        positionId="123", position=DeckPoint(x=1, y=2, z=3)
+    )

--- a/api/tests/opentrons/protocol_engine/execution/mock_defs.py
+++ b/api/tests/opentrons/protocol_engine/execution/mock_defs.py
@@ -1,0 +1,23 @@
+"""Shared mock definitions."""
+from dataclasses import dataclass, field
+from typing import cast, Dict
+
+from opentrons.types import Mount
+from opentrons.hardware_control.dev_types import PipetteDict
+
+
+@dataclass(frozen=True)
+class MockPipettes:
+    """Dummy pipette data to use in liquid handling collabortation tests."""
+
+    left_config: PipetteDict = field(
+        default_factory=lambda: cast(PipetteDict, {"name": "p300_single"})
+    )
+    right_config: PipetteDict = field(
+        default_factory=lambda: cast(PipetteDict, {"name": "p300_multi"})
+    )
+
+    @property
+    def by_mount(self) -> Dict[Mount, PipetteDict]:
+        """Get a mock hw.attached_instruments map."""
+        return {Mount.LEFT: self.left_config, Mount.RIGHT: self.right_config}

--- a/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
@@ -217,8 +217,9 @@ async def test_save_position(
     ).then_return(Point(1, 1, 1))
 
     result = await handler.save_position(pipette_id="pipette-id", position_id="123")
-    assert result == SavedPositionData(positionId="123",
-                                       position=DeckPoint(x=1, y=1, z=1))
+    assert result == SavedPositionData(
+        positionId="123", position=DeckPoint(x=1, y=1, z=1)
+    )
 
 
 @pytest.mark.parametrize(
@@ -235,9 +236,9 @@ async def test_save_position_different_cp(
     hardware_api: HardwareAPI,
     handler: MovementHandler,
     mock_hw_pipettes: MockPipettes,
-    unverified_cp,
-    tip_length,
-    verified_cp,
+    unverified_cp: CriticalPoint,
+    tip_length: float,
+    verified_cp: CriticalPoint,
 ) -> None:
     """Test that `save_position` selects correct critical point."""
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
@@ -8,14 +8,32 @@ from opentrons.hardware_control.types import CriticalPoint
 from opentrons.motion_planning import Waypoint
 
 from opentrons.protocol_engine import WellLocation, WellOrigin, WellOffset
-from opentrons.protocol_engine.state import StateStore, PipetteLocationData, CurrentWell
-from opentrons.protocol_engine.execution.movement import MovementHandler
+from opentrons.protocol_engine.state import (
+    StateStore,
+    PipetteLocationData,
+    CurrentWell,
+    HardwarePipette,
+)
+from opentrons.protocol_engine.execution.movement import (
+    MovementHandler,
+    SavedPositionData,
+)
+
+from .mock_defs import MockPipettes
 
 
 @pytest.fixture
 def hardware_api(decoy: Decoy) -> HardwareAPI:
     """Get a mock in the shape of a HardwareAPI."""
     return decoy.mock(cls=HardwareAPI)
+
+
+@pytest.fixture
+def mock_hw_pipettes(hardware_api: HardwareAPI) -> MockPipettes:
+    """Get mock pipette configs and attach them to the mock HW controller."""
+    mock_hw_pipettes = MockPipettes()
+    hardware_api.attached_instruments = mock_hw_pipettes.by_mount  # type: ignore[misc]
+    return mock_hw_pipettes
 
 
 @pytest.fixture
@@ -169,4 +187,81 @@ async def test_move_to_well_from_starting_location(
             abs_position=Point(1, 2, 3),
             critical_point=CriticalPoint.XY_CENTER,
         ),
+    )
+
+
+async def test_save_position(
+    decoy: Decoy,
+    state_store: StateStore,
+    hardware_api: HardwareAPI,
+    handler: MovementHandler,
+) -> None:
+    """Test that `save_position` fetches gantry position from hardwareAPI."""
+    decoy.when(
+        state_store.motion.get_pipette_location(
+            pipette_id="pipette-id",
+        )
+    ).then_return(
+        PipetteLocationData(
+            mount=MountType.LEFT,
+            critical_point=CriticalPoint.XY_CENTER,
+        )
+    )
+
+    decoy.when(
+        await hardware_api.gantry_position(
+            mount=Mount.LEFT,
+            critical_point=CriticalPoint.XY_CENTER,
+        )
+    ).then_return(Point(1, 1, 1))
+
+    result = await handler.save_position(pipette_id="pipette-id", position_id="123")
+    assert result == SavedPositionData(positionId="123", position=Point(1, 1, 1))
+
+
+@pytest.mark.parametrize(
+    argnames=["unverified_cp", "tip_length", "verified_cp"],
+    argvalues=[
+        [None, 0, CriticalPoint.NOZZLE],
+        [None, 999, CriticalPoint.TIP],
+        [CriticalPoint.XY_CENTER, 999, CriticalPoint.XY_CENTER],
+    ],
+)
+async def test_save_position_different_cp(
+    decoy: Decoy,
+    state_store: StateStore,
+    hardware_api: HardwareAPI,
+    handler: MovementHandler,
+    mock_hw_pipettes: MockPipettes,
+    unverified_cp,
+    tip_length,
+    verified_cp,
+) -> None:
+    """Test that `save_position` selects correct critical point."""
+    decoy.when(
+        state_store.motion.get_pipette_location(
+            pipette_id="pipette-id",
+        )
+    ).then_return(
+        PipetteLocationData(
+            mount=MountType.LEFT,
+            critical_point=unverified_cp,
+        )
+    )
+
+    mock_hw_pipettes.left_config.update({"tip_length": tip_length})
+    decoy.when(
+        state_store.pipettes.get_hardware_pipette(
+            pipette_id="pipette-id",
+            attached_pipettes=mock_hw_pipettes.by_mount,
+        )
+    ).then_return(
+        HardwarePipette(mount=Mount.LEFT, config=mock_hw_pipettes.left_config)
+    )
+    await handler.save_position(pipette_id="pipette-id", position_id="123")
+    decoy.verify(
+        await hardware_api.gantry_position(
+            mount=Mount.LEFT,
+            critical_point=verified_cp,
+        )
     )

--- a/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
@@ -1,8 +1,7 @@
 """Pipetting command handler."""
 import pytest
-from dataclasses import dataclass, field
 from decoy import Decoy
-from typing import cast, Dict, Tuple
+from typing import Tuple
 
 from opentrons.types import Mount
 from opentrons.hardware_control.api import API as HardwareAPI
@@ -18,22 +17,7 @@ from opentrons.protocol_engine.state import (
 from opentrons.protocol_engine.execution.movement import MovementHandler
 from opentrons.protocol_engine.execution.pipetting import PipettingHandler
 
-
-@dataclass(frozen=True)
-class MockPipettes:
-    """Dummy pipette data to use in liquid handling collabortation tests."""
-
-    left_config: PipetteDict = field(
-        default_factory=lambda: cast(PipetteDict, {"name": "p300_single"})
-    )
-    right_config: PipetteDict = field(
-        default_factory=lambda: cast(PipetteDict, {"name": "p300_multi"})
-    )
-
-    @property
-    def by_mount(self) -> Dict[Mount, PipetteDict]:
-        """Get a mock hw.attached_instruments map."""
-        return {Mount.LEFT: self.left_config, Mount.RIGHT: self.right_config}
+from .mock_defs import MockPipettes
 
 
 @pytest.fixture


### PR DESCRIPTION
# Overview

Closes #8425.

# Changelog

- added `save_position.py` to PE `/commands` which adds the command request & result models and links the implementation class
- added the command implementation in `MovementHandler` 
- added tests

# Review requests

- [ ] Code looks good
- [ ] I was conflicted between adding the implementation to `PipettingHandler` and `MovementHandler`. In the end went with `MovementHandler` since position stuff felt more in-line with movement than with liquid handling. Let me know if you have strong opinions against it.
- [ ] Try running it on an actual robot if you have one. I have smoke tested on dev server and it seems to work correctly.
Steps followed (Used [this Postman collection](https://gist.github.com/SyntaxColoring/5901b2093c1b391ec377217a7ac64111) for sending requests):
1. Start a `basic` protocol.
2. `POST` a `loadPipette` command.
3. `POST` a `play` action.
4. `GET` the `pipetteId` from `loadPipette` command result.
5. `POST` a robot home command (**Very important**).
6. `POST` the `savePosition` command
```
{
    "data": {
        "commandType": "savePosition",
        "data": {
            "pipetteId": "your-pipette-id"
        }
    }
}
```
6. `GET` the result using savePosition command's ID.

# Caveat

Protocol Engine error handling is still in the works. If there's an error/ exception raised during execution of this command (like a `MustHomeError`), the command simply returns with a status of `failed`. The error is not shown in the response and we are left to check the server logs for the error. I couldn't find a quick solution to this so will punt the error handling to a separate ticket in order to prevent a scope creep.

# Risk assessment

Low. Doesn't meddle with anything unrelated to querying the pipette's position.
