### PR TITLE
refactor(api): lock reads to pipettes in the hardware controller

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -454,7 +454,8 @@ class API(HardwareAPILike):
         for mount, name in checked_require.items():
             if name not in name_config():
                 raise RuntimeError(f"{name} is not a valid pipette name")
-        found = await self._backend.get_attached_instruments(checked_require)
+        async with self._motion_lock:
+            found = await self._backend.get_attached_instruments(checked_require)
 
         for mount, instrument_data in found.items():
             config = instrument_data.get("config")

--- a/api/tests/opentrons/drivers/smoothie_drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/smoothie_drivers/test_driver.py
@@ -180,7 +180,7 @@ async def test_clear_limit_switch(
     """
     cmd_list = []
 
-    def write_mock(command, retries, timeout):
+    async def write_mock(command, retries, timeout):
         cmd_list.append(command.build())
         if constants.GCODE.MOVE in command:
             raise AlarmResponse(port="", response="ALARM: Hard limit +C")


### PR DESCRIPTION
# Overview

We should not allow any motor movement commands to be sent to the smoothie while we are trying to
read from the eeprom of the pipettes, otherwise the read might fail.

This issue was less prevalent previously because our smoothie commands weren't asynchronous and we also had a serial lock in smoothie. Since we pushed most of the lock handling to the hardware controller, I decided to make the change inside `cache_instruments` itself.

closes #8576.


# Changelog

- Add a lock around the reads for serial and model of pipettes.

# Review requests

Please test on a robot.

# Test Plan
1. Try to reproduce bug described in #8576. I had most success with a non-calibrated pipette and executing `attached pipette` then `pipette calibration` in immediate succession.
2. Push branch to robot
3. Perform factory reset
4. Perform the same test as step 1. You should still be able to see your pipettes, and calibration should have saved successfully.
5. Do other random things that make a call to `cache_instruments` such as running a protocol, and a few attach/detaches in succession. You should attach different pipette types one after the other to make sure that everything still caches correctly.

# To-Do
I will put in a follow-up PR to have fail-safes for the pipette serial number being `none` which was the original red herring to #8576.

# Risk assessment

Medium. Affects cache instruments function.
