### PR TITLE
refactor(app): Fix typo in half connectable robot toast

### DIFF
--- a/app/src/assets/localization/en/robot_connection.json
+++ b/app/src/assets/localization/en/robot_connection.json
@@ -22,5 +22,12 @@
   "success_banner": "{{robot}} successfully connected",
   "title": "connectivity",
   "wired": "wired",
-  "wireless": "wireless"
+  "wireless": "wireless",
+  "unresponsive_title": "Unable to establish connection with robot",
+  "health_status_ok": "responding to requests",
+  "health_status_not_ok": "not responding correctly to requests",
+  "health_status_unreachable": "unreachable",
+  "server_message": "<block>Your OT-2's API server is {{status}} at IP address {{ip}}.</block><block>We recommend the following troubleshooting steps:</block><ol><li>Power-cycle your robot</li><li>If power-cycling does not work, please update your robot's software  <br />(Note: your robot's update server is still responding and should accept an update.)</li></ol>",
+  "no_server_message": "<block>This OT-2 has been seen recently, but it is currently {{status}} at IP address {{ip}}.</block><block>We recommend power-cycling your robot.</block>",
+  "last_resort": "If your robot remains unresponsive, please reach out to our Support team."
 }

--- a/app/src/pages/Robots/RobotSettings/ReachableRobotBanner.tsx
+++ b/app/src/pages/Robots/RobotSettings/ReachableRobotBanner.tsx
@@ -59,7 +59,7 @@ const SERVER_MESSAGE = (status: HealthStatus, ip: string): JSX.Element => (
       </li>
       <li>
         <p>
-          If power-cycling does not work, please update your {"robot's"}
+          If power-cycling does not work, please update your {"robot's"}{' '}
           software
           <br />
           (Note: your {"robot's"} update server is still responding and should

--- a/app/src/pages/Robots/RobotSettings/ReachableRobotBanner.tsx
+++ b/app/src/pages/Robots/RobotSettings/ReachableRobotBanner.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useTranslation, Trans } from 'react-i18next'
 import { AlertItem } from '@opentrons/components'
 import styles from './styles.css'
 
@@ -8,96 +9,51 @@ import {
   HEALTH_STATUS_UNREACHABLE,
 } from '../../../redux/discovery'
 
-import type {
-  ReachableRobot,
-  HealthStatus,
-} from '../../../redux/discovery/types'
+import type { ReachableRobot } from '../../../redux/discovery/types'
 
-interface State {
-  dismissed: boolean
-}
+export function ReachableRobotBanner(
+  props: ReachableRobot
+): JSX.Element | null {
+  const { t } = useTranslation('robot_connection')
+  const [dismissed, setDismissed] = React.useState(false)
 
-// TODO(bc, 2020-12-07): i18n
-const UNRESPONSIVE_TITLE = 'Unable to establish connection with robot'
+  const { ip, healthStatus, serverHealthStatus } = props
+  const isVisible = !dismissed
 
-const STATUS_DESCRIPTION = {
-  [HEALTH_STATUS_OK]: 'responding to requests',
-  [HEALTH_STATUS_NOT_OK]: 'not responding correctly to requests',
-  [HEALTH_STATUS_UNREACHABLE]: 'not reachable',
-}
-
-const LAST_RESORT = (
-  <p>
-    If your robot remains unresponsive, please reach out to our Support team.
-  </p>
-)
-
-const NO_SERVER_MESSAGE = (
-  serverStatus: HealthStatus,
-  ip: string
-): JSX.Element => (
-  <div className={styles.banner}>
-    <p>
-      This OT-2 has been seen recently, but it is currently{' '}
-      {STATUS_DESCRIPTION[serverStatus]} at IP address {ip}.
-    </p>
-    <p>We recommend power-cycling your robot.</p>
-    {LAST_RESORT}
-  </div>
-)
-
-const SERVER_MESSAGE = (status: HealthStatus, ip: string): JSX.Element => (
-  <div className={styles.banner}>
-    <p>
-      Your {"OT-2's"} API server is {STATUS_DESCRIPTION[status]} at IP address{' '}
-      {ip}.
-    </p>
-    <p>We recommend the following troubleshooting steps:</p>
-    <ol>
-      <li>
-        <p>Power-cycle your robot</p>
-      </li>
-      <li>
-        <p>
-          If power-cycling does not work, please update your {"robot's"}{' '}
-          software
-          <br />
-          (Note: your {"robot's"} update server is still responding and should
-          accept an update.)
-        </p>
-      </li>
-    </ol>
-    {LAST_RESORT}
-  </div>
-)
-
-export class ReachableRobotBanner extends React.Component<
-  ReachableRobot,
-  State
-> {
-  constructor(props: ReachableRobot) {
-    super(props)
-    this.state = { dismissed: false }
+  const STATUS_DESCRIPTION = {
+    [HEALTH_STATUS_OK]: t('health_status_ok'),
+    [HEALTH_STATUS_NOT_OK]: t('health_status_not_ok'),
+    [HEALTH_STATUS_UNREACHABLE]: t('health_status_unreachable'),
   }
-
-  render(): JSX.Element | null {
-    const { ip, healthStatus, serverHealthStatus } = this.props
-    const isVisible = !this.state.dismissed
-    const message =
-      serverHealthStatus === HEALTH_STATUS_OK
-        ? SERVER_MESSAGE(healthStatus, ip)
-        : NO_SERVER_MESSAGE(serverHealthStatus, ip)
-
-    if (!isVisible) return null
-
-    return (
-      <AlertItem
-        type="warning"
-        onCloseClick={() => this.setState({ dismissed: true })}
-        title={UNRESPONSIVE_TITLE}
-      >
-        {message}
-      </AlertItem>
+  const message =
+    serverHealthStatus === HEALTH_STATUS_OK ? (
+      <Trans
+        t={t}
+        i18nKey="server_message"
+        tOptions={{ status: STATUS_DESCRIPTION[healthStatus], ip: ip }}
+        components={{ block: <p />, ol: <ol />, li: <li />, br: <br /> }}
+      />
+    ) : (
+      <Trans
+        t={t}
+        i18nKey="no_server_message"
+        tOptions={{ status: STATUS_DESCRIPTION[serverHealthStatus], ip: ip }}
+        components={{ block: <p /> }}
+      />
     )
-  }
+
+  if (!isVisible) return null
+
+  return (
+    <AlertItem
+      type="warning"
+      onCloseClick={() => setDismissed(true)}
+      title={t('unresponsive_title')}
+    >
+      <div className={styles.banner}>
+        {message}
+        <p>{t('last_resort')}</p>
+      </div>
+    </AlertItem>
+  )
 }


### PR DESCRIPTION
# Overview
This PR serves as its own ticket. While testing other PRs for PUR and LPC I noticed a lack of a space between the words robot's and server `robot'sserver` in the alert/notification when a robot is discoverable but not fully booted or connectable (bullet point 2). This PR adds the space and fixes this. Pedantic I know, but might as well fix em up before the next release.


<img width="646" alt="Screen Shot 2021-11-05 at 3 10 30 PM" src="https://user-images.githubusercontent.com/3430313/140566674-15c857c9-38cb-4f9f-985a-562339590886.png">
# Changelog

- refactor(app): Fix typo in half connectable robot toast
- refactor(app): Convert `ReachableRobotBanner` to i118n

# Review requests

You will not be able to see this without a robot. If you do:

1. `make -C app dev`
2. THEN turn on your robot so its half loaded when discovery takes place
3. observe the alert above and there should be a space between all words. 
4. click on a fully connectable robot
5. turn that robot off
6. alert should read "This OT-2 has been seen recently,..."


# Risk assessment

Medium. Had to really move things around to make sure everything was in i18n. 