### PR TITLE
feat(can): Hardware move group schedule

### DIFF
--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -68,7 +68,7 @@ test:
 
 .PHONY: test-with-emulator
 test-with-emulator:
-	$(pytest) -m 'requires_emulator' $(tests) $(test_opts)
+	$(pytest) $(tests) $(test_opts)
 
 .PHONY: lint
 lint:

--- a/hardware/opentrons_hardware/hardware_control/constants.py
+++ b/hardware/opentrons_hardware/hardware_control/constants.py
@@ -1,0 +1,6 @@
+"""Hardware Control Constants."""
+from typing_extensions import Final
+
+
+interrupts_per_sec: Final = 8500000
+"""The number of motor interrupts per second."""

--- a/hardware/opentrons_hardware/hardware_control/motion.py
+++ b/hardware/opentrons_hardware/hardware_control/motion.py
@@ -72,7 +72,7 @@ def create(
             ]
         )
 
-    # Move x
+    # Move y
     dy = deltas.get(NodeId.gantry_y, 0)
     if dy:
         move_groups.append(

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -79,9 +79,14 @@ class MoveGroupRunner:
                         ),
                     )
 
-    async def _move(self, can_messenge: CanMessenger) -> None:
+    async def _move(self, can_messenger: CanMessenger) -> None:
         """Run all the move groups."""
-        pass
+        scheduler = MoveScheduler(self._move_groups)
+        try:
+            can_messenger.add_listener(scheduler)
+            await scheduler.run(can_messenger)
+        finally:
+            can_messenger.remove_listener(scheduler)
 
 
 class MoveScheduler(MessageListener):

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -1,0 +1,133 @@
+"""Class that schedules motion on can bus."""
+import asyncio
+import logging
+from opentrons_hardware.drivers.can_bus import NodeId
+from opentrons_hardware.drivers.can_bus.can_messenger import (
+    CanMessenger,
+    MessageListener,
+)
+from opentrons_hardware.drivers.can_bus.messages import MessageDefinition
+from opentrons_hardware.drivers.can_bus.messages.message_definitions import (
+    ClearMoveGroupRequest,
+    AddLinearMoveRequest,
+    MoveCompleted,
+    ExecuteMoveGroupRequest,
+)
+from opentrons_hardware.drivers.can_bus.messages.payloads import (
+    MoveGroupRequestPayload,
+    AddLinearMoveRequestPayload,
+    ExecuteMoveGroupRequestPayload,
+)
+from opentrons_hardware.hardware_control.constants import interrupts_per_sec
+from opentrons_hardware.hardware_control.motion import MoveGroups
+from opentrons_hardware.utils import UInt8Field, UInt16Field, Int16Field
+
+
+log = logging.getLogger(__name__)
+
+
+class MoveGroupRunner:
+    """A move command scheduler."""
+
+    def __init__(self, move_groups: MoveGroups) -> None:
+        """Constructor.
+
+        Args:
+            move_groups: The move groups to run.
+        """
+        self._move_groups = move_groups
+
+    async def run(self, can_messenger: CanMessenger) -> None:
+        """Run the move group.
+
+        Args:
+            can_messenger: a can messenger
+        """
+        await self._clear_groups(can_messenger)
+        await self._send_groups(can_messenger)
+        await self._move(can_messenger)
+
+    async def _clear_groups(self, can_messenger: CanMessenger) -> None:
+        """Send commands to clear the message groups."""
+        for i, g in enumerate(self._move_groups):
+            await can_messenger.send(
+                node_id=NodeId.broadcast,
+                message=ClearMoveGroupRequest(
+                    payload=MoveGroupRequestPayload(group_id=UInt8Field(i))
+                ),
+            )
+
+    async def _send_groups(self, can_messenger: CanMessenger) -> None:
+        """Send commands to set up the message groups."""
+        for group_i, group in enumerate(self._move_groups):
+            for seq_i, sequence in enumerate(group):
+                for node, step in sequence.items():
+                    await can_messenger.send(
+                        node_id=node,
+                        message=AddLinearMoveRequest(
+                            payload=AddLinearMoveRequestPayload(
+                                group_id=UInt8Field(group_i),
+                                seq_id=UInt8Field(seq_i),
+                                duration=UInt16Field(
+                                    int(step.duration_sec * interrupts_per_sec)
+                                ),
+                                acceleration=Int16Field(0),
+                                velocity=Int16Field(
+                                    int(interrupts_per_sec * step.velocity_mm_sec)
+                                ),
+                            )
+                        ),
+                    )
+
+    async def _move(self, can_messenge: CanMessenger) -> None:
+        """Run all the move groups."""
+        pass
+
+
+class MoveScheduler(MessageListener):
+    """A message listener that manages the sending of execute move group messages."""
+
+    def __init__(self, move_groups: MoveGroups) -> None:
+        """Constructor."""
+        # For each move group create a set identifying the node and seq id.
+        self._moves = []
+        for move_group in move_groups:
+            move_set = set()
+            for seq_id, move in enumerate(move_group):
+                move_set.update(set((k.value, seq_id) for k in move.keys()))
+            self._moves.append(move_set)
+
+        self._event = asyncio.Event()
+
+    def on_message(self, message: MessageDefinition) -> None:
+        """Incoming message handler."""
+        if isinstance(message, MoveCompleted):
+            seq_id = message.payload.seq_id.value
+            node_id = message.payload.node_id.value
+            group_id = message.payload.group_id.value
+            self._moves[group_id].remove((node_id, seq_id))
+            if not self._moves[group_id]:
+                log.info(f"Move group {group_id} has completed.")
+                self._event.set()
+
+    async def run(self, can_messenger: CanMessenger) -> None:
+        """Start each move group after the prior has completed."""
+        for group_id in range(len(self._moves)):
+            self._event.clear()
+
+            log.info(f"Executing move group {group_id}.")
+
+            await can_messenger.send(
+                node_id=NodeId.broadcast,
+                message=ExecuteMoveGroupRequest(
+                    payload=ExecuteMoveGroupRequestPayload(
+                        group_id=UInt8Field(group_id),
+                        # TODO (al, 2021-11-8): The triggers should be populated
+                        #  with actual values.
+                        start_trigger=UInt8Field(0),
+                        cancel_trigger=UInt8Field(0),
+                    )
+                ),
+            )
+
+            await self._event.wait()

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_scheduler.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_scheduler.py
@@ -1,6 +1,6 @@
 """Tests for the move scheduler."""
 import pytest
-from mock import AsyncMock, call
+from mock import AsyncMock, call, MagicMock
 
 from opentrons_hardware.drivers.can_bus import NodeId
 from opentrons_hardware.drivers.can_bus.can_messenger import MessageListener
@@ -271,6 +271,15 @@ async def test_multi_send_setup_commands(
             )
         ),
     )
+
+
+async def test_move() -> None:
+    """It should register to listen for messages."""
+    subject = MoveGroupRunner(move_groups=[])
+    mock_can_messenger = MagicMock()
+    await subject._move(mock_can_messenger)
+    mock_can_messenger.add_listener.assert_called_once()
+    mock_can_messenger.remove_listener.assert_called_once()
 
 
 class MockSendMoveCompleter:

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_scheduler.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_scheduler.py
@@ -1,0 +1,373 @@
+"""Tests for the move scheduler."""
+import pytest
+from mock import AsyncMock, call
+
+from opentrons_hardware.drivers.can_bus import NodeId
+from opentrons_hardware.drivers.can_bus.can_messenger import MessageListener
+from opentrons_hardware.drivers.can_bus.messages.message_definitions import (
+    AddLinearMoveRequest,
+)
+from opentrons_hardware.drivers.can_bus.messages.payloads import (
+    MoveGroupRequestPayload,
+    AddLinearMoveRequestPayload,
+    MoveCompletedPayload,
+    ExecuteMoveGroupRequestPayload,
+)
+from opentrons_hardware.hardware_control.constants import interrupts_per_sec
+from opentrons_hardware.hardware_control.motion import (
+    MoveGroups,
+    MoveGroupSingleAxisStep,
+)
+from opentrons_hardware.hardware_control.move_group_runner import (
+    MoveGroupRunner,
+    MoveScheduler,
+)
+from opentrons_hardware.drivers.can_bus.messages import (
+    message_definitions as md,
+    MessageDefinition,
+)
+from opentrons_hardware.utils import UInt8Field, Int16Field, UInt16Field
+
+
+@pytest.fixture
+def mock_can_messenger() -> AsyncMock:
+    """Mock communication."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def move_group_single() -> MoveGroups:
+    """Move group with one move."""
+    return [
+        [
+            {
+                NodeId.head: MoveGroupSingleAxisStep(
+                    distance_mm=0, velocity_mm_sec=2, duration_sec=123
+                )
+            }
+        ]
+    ]
+
+
+@pytest.fixture
+def move_group_multiple() -> MoveGroups:
+    """Move group with multiple moves."""
+    return [
+        # Group 0
+        [
+            {
+                NodeId.head: MoveGroupSingleAxisStep(
+                    distance_mm=0, velocity_mm_sec=235, duration_sec=2142
+                ),
+            }
+        ],
+        # Group 1
+        [
+            {
+                NodeId.gantry_x: MoveGroupSingleAxisStep(
+                    distance_mm=0, velocity_mm_sec=22, duration_sec=1
+                ),
+                NodeId.gantry_y: MoveGroupSingleAxisStep(
+                    distance_mm=0, velocity_mm_sec=23, duration_sec=0
+                ),
+            }
+        ],
+        # Group 2
+        [
+            {
+                NodeId.pipette: MoveGroupSingleAxisStep(
+                    distance_mm=12, velocity_mm_sec=-23, duration_sec=1234
+                ),
+            },
+            {
+                NodeId.pipette: MoveGroupSingleAxisStep(
+                    distance_mm=12, velocity_mm_sec=23, duration_sec=1234
+                ),
+            },
+        ],
+    ]
+
+
+async def test_single_group_clear(
+    mock_can_messenger: AsyncMock, move_group_single: MoveGroups
+) -> None:
+    """It should send a clear group command before setup."""
+    subject = MoveGroupRunner(move_groups=move_group_single)
+    await subject._clear_groups(can_messenger=mock_can_messenger)
+    mock_can_messenger.send.assert_called_with(
+        node_id=NodeId.broadcast,
+        message=md.ClearMoveGroupRequest(
+            payload=MoveGroupRequestPayload(group_id=UInt8Field(0))
+        ),
+    )
+
+
+async def test_multi_group_clear(
+    mock_can_messenger: AsyncMock, move_group_multiple: MoveGroups
+) -> None:
+    """It should send a clear group command before setup."""
+    subject = MoveGroupRunner(move_groups=move_group_multiple)
+    await subject._clear_groups(can_messenger=mock_can_messenger)
+    for i in range(len(move_group_multiple)):
+        mock_can_messenger.send.assert_any_call(
+            node_id=NodeId.broadcast,
+            message=md.ClearMoveGroupRequest(
+                payload=MoveGroupRequestPayload(group_id=UInt8Field(i))
+            ),
+        )
+
+
+async def test_single_send_setup_commands(
+    mock_can_messenger: AsyncMock, move_group_single: MoveGroups
+) -> None:
+    """It should send all the move group set up commands."""
+    subject = MoveGroupRunner(move_groups=move_group_single)
+    await subject._send_groups(can_messenger=mock_can_messenger)
+    mock_can_messenger.send.assert_any_call(
+        node_id=NodeId.head,
+        message=AddLinearMoveRequest(
+            payload=AddLinearMoveRequestPayload(
+                group_id=UInt8Field(0),
+                seq_id=UInt8Field(0),
+                velocity=Int16Field(
+                    int(
+                        move_group_single[0][0][NodeId.head].velocity_mm_sec
+                        * interrupts_per_sec
+                    )
+                ),
+                acceleration=Int16Field(0),
+                duration=UInt16Field(
+                    int(
+                        move_group_single[0][0][NodeId.head].duration_sec
+                        * interrupts_per_sec
+                    )
+                ),
+            )
+        ),
+    )
+
+
+async def test_multi_send_setup_commands(
+    mock_can_messenger: AsyncMock, move_group_multiple: MoveGroups
+) -> None:
+    """It should send all the move group set up commands."""
+    subject = MoveGroupRunner(move_groups=move_group_multiple)
+    await subject._send_groups(can_messenger=mock_can_messenger)
+
+    # Group 0
+    mock_can_messenger.send.assert_any_call(
+        node_id=NodeId.head,
+        message=AddLinearMoveRequest(
+            payload=AddLinearMoveRequestPayload(
+                group_id=UInt8Field(0),
+                seq_id=UInt8Field(0),
+                velocity=Int16Field(
+                    int(
+                        move_group_multiple[0][0][NodeId.head].velocity_mm_sec
+                        * interrupts_per_sec
+                    )
+                ),
+                acceleration=Int16Field(0),
+                duration=UInt16Field(
+                    int(
+                        move_group_multiple[0][0][NodeId.head].duration_sec
+                        * interrupts_per_sec
+                    )
+                ),
+            )
+        ),
+    )
+
+    # Group 1
+    mock_can_messenger.send.assert_any_call(
+        node_id=NodeId.gantry_x,
+        message=AddLinearMoveRequest(
+            payload=AddLinearMoveRequestPayload(
+                group_id=UInt8Field(1),
+                seq_id=UInt8Field(0),
+                velocity=Int16Field(
+                    int(
+                        move_group_multiple[1][0][NodeId.gantry_x].velocity_mm_sec
+                        * interrupts_per_sec
+                    )
+                ),
+                acceleration=Int16Field(0),
+                duration=UInt16Field(
+                    int(
+                        move_group_multiple[1][0][NodeId.gantry_x].duration_sec
+                        * interrupts_per_sec
+                    )
+                ),
+            )
+        ),
+    )
+
+    mock_can_messenger.send.assert_any_call(
+        node_id=NodeId.gantry_y,
+        message=AddLinearMoveRequest(
+            payload=AddLinearMoveRequestPayload(
+                group_id=UInt8Field(1),
+                seq_id=UInt8Field(0),
+                velocity=Int16Field(
+                    int(
+                        move_group_multiple[1][0][NodeId.gantry_y].velocity_mm_sec
+                        * interrupts_per_sec
+                    )
+                ),
+                acceleration=Int16Field(0),
+                duration=UInt16Field(
+                    int(
+                        move_group_multiple[1][0][NodeId.gantry_y].duration_sec
+                        * interrupts_per_sec
+                    )
+                ),
+            )
+        ),
+    )
+
+    # Group 2
+    mock_can_messenger.send.assert_any_call(
+        node_id=NodeId.pipette,
+        message=AddLinearMoveRequest(
+            payload=AddLinearMoveRequestPayload(
+                group_id=UInt8Field(2),
+                seq_id=UInt8Field(0),
+                velocity=Int16Field(
+                    int(
+                        move_group_multiple[2][0][NodeId.pipette].velocity_mm_sec
+                        * interrupts_per_sec
+                    )
+                ),
+                acceleration=Int16Field(0),
+                duration=UInt16Field(
+                    int(
+                        move_group_multiple[2][0][NodeId.pipette].duration_sec
+                        * interrupts_per_sec
+                    )
+                ),
+            )
+        ),
+    )
+
+    mock_can_messenger.send.assert_any_call(
+        node_id=NodeId.pipette,
+        message=AddLinearMoveRequest(
+            payload=AddLinearMoveRequestPayload(
+                group_id=UInt8Field(2),
+                seq_id=UInt8Field(1),
+                velocity=Int16Field(
+                    int(
+                        move_group_multiple[2][1][NodeId.pipette].velocity_mm_sec
+                        * interrupts_per_sec
+                    )
+                ),
+                acceleration=Int16Field(0),
+                duration=UInt16Field(
+                    int(
+                        move_group_multiple[2][1][NodeId.pipette].duration_sec
+                        * interrupts_per_sec
+                    )
+                ),
+            )
+        ),
+    )
+
+
+class MockSendMoveCompleter:
+    """Side effect mock of CanMessenger.send that immediately completes moves."""
+
+    def __init__(self, move_groups: MoveGroups, listener: MessageListener) -> None:
+        """Constructor."""
+        self._move_groups = move_groups
+        self._listener = listener
+
+    async def mock_send(
+        self,
+        node_id: NodeId,
+        message: MessageDefinition,
+    ) -> None:
+        """Mock send function."""
+        if isinstance(message, md.ExecuteMoveGroupRequest):
+            # Iterate through each move in each sequence and send a move
+            # completed for it.
+            for seq_id, moves in enumerate(
+                self._move_groups[message.payload.group_id.value]
+            ):
+                for node in moves.keys():
+                    payload = MoveCompletedPayload(
+                        group_id=message.payload.group_id,
+                        seq_id=UInt8Field(seq_id),
+                        node_id=UInt8Field(node.value),
+                        ack_id=UInt8Field(0),
+                    )
+                    self._listener.on_message(md.MoveCompleted(payload=payload))
+
+
+async def test_single_move(
+    mock_can_messenger: AsyncMock, move_group_single: MoveGroups
+) -> None:
+    """It should send a start group command."""
+    subject = MoveScheduler(move_groups=move_group_single)
+    mock_sender = MockSendMoveCompleter(move_group_single, subject)
+    mock_can_messenger.send.side_effect = mock_sender.mock_send
+    await subject.run(can_messenger=mock_can_messenger)
+
+    mock_can_messenger.send.assert_has_calls(
+        calls=[
+            call(
+                node_id=NodeId.broadcast,
+                message=md.ExecuteMoveGroupRequest(
+                    payload=ExecuteMoveGroupRequestPayload(
+                        group_id=UInt8Field(0),
+                        cancel_trigger=UInt8Field(0),
+                        start_trigger=UInt8Field(0),
+                    )
+                ),
+            )
+        ]
+    )
+
+
+async def test_multi_group_move(
+    mock_can_messenger: AsyncMock, move_group_multiple: MoveGroups
+) -> None:
+    """It should start next group once the prior has completed."""
+    subject = MoveScheduler(move_groups=move_group_multiple)
+    mock_sender = MockSendMoveCompleter(move_group_multiple, subject)
+    mock_can_messenger.send.side_effect = mock_sender.mock_send
+    await subject.run(can_messenger=mock_can_messenger)
+
+    mock_can_messenger.send.assert_has_calls(
+        calls=[
+            call(
+                node_id=NodeId.broadcast,
+                message=md.ExecuteMoveGroupRequest(
+                    payload=ExecuteMoveGroupRequestPayload(
+                        group_id=UInt8Field(0),
+                        cancel_trigger=UInt8Field(0),
+                        start_trigger=UInt8Field(0),
+                    )
+                ),
+            ),
+            call(
+                node_id=NodeId.broadcast,
+                message=md.ExecuteMoveGroupRequest(
+                    payload=ExecuteMoveGroupRequestPayload(
+                        group_id=UInt8Field(1),
+                        cancel_trigger=UInt8Field(0),
+                        start_trigger=UInt8Field(0),
+                    )
+                ),
+            ),
+            call(
+                node_id=NodeId.broadcast,
+                message=md.ExecuteMoveGroupRequest(
+                    payload=ExecuteMoveGroupRequestPayload(
+                        group_id=UInt8Field(2),
+                        cancel_trigger=UInt8Field(0),
+                        start_trigger=UInt8Field(0),
+                    )
+                ),
+            ),
+        ]
+    )


### PR DESCRIPTION
# Overview

`MoveGroupRunner` to send can messages to set up move groups and run them.

# Changelog


# Review requests



# Risk assessment

None