### PR TITLE
refactor(robot-server): retrieve state of previous runs

### DIFF
--- a/robot-server/robot_server/runs/router/actions_router.py
+++ b/robot-server/robot_server/runs/router/actions_router.py
@@ -4,6 +4,8 @@ from datetime import datetime
 from typing import Union
 from typing_extensions import Literal
 
+from opentrons.protocol_engine.errors import ProtocolEngineStoppedError
+
 from robot_server.errors import ErrorDetails, ErrorResponse
 from robot_server.service.dependencies import get_current_time, get_unique_id
 from robot_server.service.json_api import RequestModel, ResponseModel
@@ -11,7 +13,7 @@ from robot_server.service.json_api import RequestModel, ResponseModel
 from ..run_store import RunStore, RunNotFoundError
 from ..run_view import RunView
 from ..action_models import RunAction, RunActionType, RunActionCreateData
-from ..engine_store import EngineStore, EngineMissingError
+from ..engine_store import EngineStore
 from ..dependencies import get_run_store, get_engine_store
 from .base_router import RunNotFound, RunStopped
 
@@ -32,7 +34,7 @@ class RunActionNotAllowed(ErrorDetails):
     status_code=status.HTTP_201_CREATED,
     response_model=ResponseModel[RunAction],
     responses={
-        status.HTTP_400_BAD_REQUEST: {
+        status.HTTP_409_CONFLICT: {
             "model": ErrorResponse[Union[RunActionNotAllowed, RunStopped]],
         },
         status.HTTP_404_NOT_FOUND: {"model": ErrorResponse[RunNotFound]},
@@ -60,21 +62,22 @@ async def create_run_action(
     """
     try:
         prev_run = run_store.get(run_id=runId)
+    except RunNotFoundError as e:
+        raise RunNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
 
-        if not prev_run.is_current:
-            raise RunStopped(detail=f"Run {runId} is not the current run").as_error(
-                status.HTTP_400_BAD_REQUEST
-            )
-
-        action, next_run = run_view.with_action(
-            run=prev_run,
-            action_id=action_id,
-            action_data=request_body.data,
-            created_at=created_at,
+    if not prev_run.is_current:
+        raise RunStopped(detail=f"Run {runId} is not the current run").as_error(
+            status.HTTP_409_CONFLICT
         )
 
-        # TODO(mc, 2021-07-06): add a dependency to verify that a given
-        # action is allowed
+    action, next_run = run_view.with_action(
+        run=prev_run,
+        action_id=action_id,
+        action_data=request_body.data,
+        created_at=created_at,
+    )
+
+    try:
         if action.actionType == RunActionType.PLAY:
             engine_store.runner.play()
         elif action.actionType == RunActionType.PAUSE:
@@ -82,10 +85,8 @@ async def create_run_action(
         if action.actionType == RunActionType.STOP:
             await engine_store.runner.stop()
 
-    except RunNotFoundError as e:
-        raise RunNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
-    except EngineMissingError as e:
-        raise RunActionNotAllowed(detail=str(e)).as_error(status.HTTP_400_BAD_REQUEST)
+    except ProtocolEngineStoppedError as e:
+        raise RunActionNotAllowed(detail=str(e)).as_error(status.HTTP_409_CONFLICT)
 
     run_store.upsert(run=next_run)
 

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -39,6 +39,10 @@ class _AbstractRun(ResourceModel):
     runType: RunType = Field(..., description="Specific run type.")
     createdAt: datetime = Field(..., description="When the run was created")
     status: RunStatus = Field(..., description="Execution status of the run")
+    current: bool = Field(
+        ...,
+        description="Whether this Run is currently controlling the robot",
+    )
     actions: List[RunAction] = Field(
         ...,
         description="Client-initiated run control actions.",

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -41,7 +41,10 @@ class _AbstractRun(ResourceModel):
     status: RunStatus = Field(..., description="Execution status of the run")
     current: bool = Field(
         ...,
-        description="Whether this Run is currently controlling the robot",
+        description=(
+            "Whether this run is currently controlling the robot."
+            " There can be, at most, one current run."
+        ),
     )
     actions: List[RunAction] = Field(
         ...,

--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -1,5 +1,5 @@
 """Runs' in-memory store."""
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime
 from typing import Dict, List
 
@@ -19,6 +19,7 @@ class RunResource:
     create_data: RunCreateData
     created_at: datetime
     actions: List[RunAction]
+    is_current: bool
 
 
 class RunNotFoundError(ValueError):
@@ -46,6 +47,11 @@ class RunStore:
         Returns:
             The resource that was added to the store.
         """
+        if run.is_current is True:
+            for target_id, target in self._runs_by_id.items():
+                if target.is_current and target_id != run.run_id:
+                    self._runs_by_id[target_id] = replace(target, is_current=False)
+
         self._runs_by_id[run.run_id] = run
 
         return run

--- a/robot-server/robot_server/runs/run_view.py
+++ b/robot-server/robot_server/runs/run_view.py
@@ -52,6 +52,7 @@ class RunView:
             created_at=created_at,
             create_data=create_data or BasicRunCreateData(),
             actions=[],
+            is_current=True,
         )
 
     @staticmethod
@@ -97,8 +98,12 @@ class RunView:
     ) -> Run:
         """Transform a run resource into its public response model.
 
-        Arguments:
+        Args:
             run: Internal resource representation of the run.
+            commands: Commands from ProtocolEngine state.
+            pipettes: Pipettes from ProtocolEngine state.
+            labware: Labware from ProtocolEngine state.
+            engine_status: Status from ProtocolEngine state.
 
         Returns:
             Run response model representing the same resource.
@@ -114,6 +119,7 @@ class RunView:
                 id=run.run_id,
                 createParams=create_data.createParams,
                 createdAt=run.created_at,
+                current=run.is_current,
                 actions=run.actions,
                 commands=command_summaries,
                 pipettes=pipettes,
@@ -126,6 +132,7 @@ class RunView:
                 id=run.run_id,
                 createParams=create_data.createParams,
                 createdAt=run.created_at,
+                current=run.is_current,
                 actions=run.actions,
                 commands=command_summaries,
                 pipettes=pipettes,

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -7,6 +7,7 @@ from decoy import Decoy
 from opentrons.protocol_engine import (
     CommandStatus,
     EngineStatus,
+    StateView,
     commands as pe_commands,
     errors as pe_errors,
 )
@@ -14,7 +15,6 @@ from opentrons.protocol_engine import (
 from robot_server.errors import ApiError
 from robot_server.service.json_api import RequestModel, ResponseModel
 from robot_server.runs.run_models import (
-    Run,
     BasicRun,
     BasicRunCreateParams,
     RunCommandSummary,
@@ -28,10 +28,23 @@ from robot_server.runs.router.commands_router import (
 
 
 async def test_post_run_command(decoy: Decoy, engine_store: EngineStore) -> None:
-    """It should add the requested command to the Protocol Engine and return it."""
+    """It should add the requested command to the ProtocolEngine and return it."""
     command_request = pe_commands.PauseRequest(
         data=pe_commands.PauseData(message="Hello")
     )
+
+    run = BasicRun(
+        id="run-id",
+        createParams=BasicRunCreateParams(),
+        createdAt=datetime(year=2021, month=1, day=1),
+        status=EngineStatus.RUNNING,
+        current=True,
+        actions=[],
+        commands=[],
+        pipettes=[],
+        labware=[],
+    )
+
     output_command = pe_commands.Pause(
         id="abc123",
         createdAt=datetime(year=2021, month=1, day=1),
@@ -45,10 +58,44 @@ async def test_post_run_command(decoy: Decoy, engine_store: EngineStore) -> None
     )
 
     response = await post_run_command(
-        request_body=RequestModel(data=command_request), engine_store=engine_store
+        request_body=RequestModel(data=command_request),
+        engine_store=engine_store,
+        run=ResponseModel(data=run),
     )
 
     assert response.data == output_command
+
+
+async def test_post_run_command_not_current(
+    decoy: Decoy,
+    engine_store: EngineStore,
+) -> None:
+    """It should 400 if you try to add commands to non-current run."""
+    command_request = pe_commands.PauseRequest(
+        data=pe_commands.PauseData(message="Hello")
+    )
+
+    run = BasicRun(
+        id="run-id",
+        createParams=BasicRunCreateParams(),
+        createdAt=datetime(year=2021, month=1, day=1),
+        status=EngineStatus.RUNNING,
+        current=False,
+        actions=[],
+        commands=[],
+        pipettes=[],
+        labware=[],
+    )
+
+    with pytest.raises(ApiError) as exc_info:
+        await post_run_command(
+            request_body=RequestModel(data=command_request),
+            engine_store=engine_store,
+            run=ResponseModel(data=run),
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.content["errors"][0]["id"] == "RunStopped"
 
 
 async def test_get_run_commands() -> None:
@@ -59,20 +106,19 @@ async def test_get_run_commands() -> None:
         status=CommandStatus.RUNNING,
     )
 
-    run_response = ResponseModel[Run](
-        data=BasicRun(
-            id="run-id",
-            createParams=BasicRunCreateParams(),
-            createdAt=datetime(year=2021, month=1, day=1),
-            status=EngineStatus.RUNNING,
-            actions=[],
-            commands=[command_summary],
-            pipettes=[],
-            labware=[],
-        )
+    run = BasicRun(
+        id="run-id",
+        createParams=BasicRunCreateParams(),
+        createdAt=datetime(year=2021, month=1, day=1),
+        status=EngineStatus.RUNNING,
+        current=True,
+        actions=[],
+        commands=[command_summary],
+        pipettes=[],
+        labware=[],
     )
 
-    response = await get_run_commands(run=run_response)
+    response = await get_run_commands(run=ResponseModel(data=run))
 
     assert response.data == [command_summary]
 
@@ -82,6 +128,12 @@ async def test_get_run_command_by_id(
     engine_store: EngineStore,
 ) -> None:
     """It should return full details about a command by ID."""
+    command_summary = RunCommandSummary(
+        id="command-id",
+        commandType="moveToWell",
+        status=CommandStatus.RUNNING,
+    )
+
     command = pe_commands.MoveToWell(
         id="command-id",
         status=CommandStatus.RUNNING,
@@ -89,11 +141,28 @@ async def test_get_run_command_by_id(
         data=pe_commands.MoveToWellData(pipetteId="a", labwareId="b", wellName="c"),
     )
 
-    decoy.when(engine_store.engine.state_view.commands.get("command-id")).then_return(
-        command
+    run = BasicRun(
+        id="run-id",
+        createParams=BasicRunCreateParams(),
+        createdAt=datetime(year=2021, month=1, day=1),
+        status=EngineStatus.RUNNING,
+        current=True,
+        actions=[],
+        commands=[command_summary],
+        pipettes=[],
+        labware=[],
     )
 
-    response = await get_run_command(commandId="command-id", engine_store=engine_store)
+    engine_state = decoy.mock(cls=StateView)
+
+    decoy.when(engine_store.get_state("run-id")).then_return(engine_state)
+    decoy.when(engine_state.commands.get("command-id")).then_return(command)
+
+    response = await get_run_command(
+        commandId="command-id",
+        engine_store=engine_store,
+        run=ResponseModel(data=run),
+    )
 
     assert response.data == command
 
@@ -105,11 +174,28 @@ async def test_get_run_command_missing_command(
     """It should 404 if you attempt to get a non-existent command."""
     key_error = pe_errors.CommandDoesNotExistError("oh no")
 
-    decoy.when(engine_store.engine.state_view.commands.get("command-id")).then_raise(
-        key_error
+    run = BasicRun(
+        id="run-id",
+        createParams=BasicRunCreateParams(),
+        createdAt=datetime(year=2021, month=1, day=1),
+        status=EngineStatus.RUNNING,
+        current=True,
+        actions=[],
+        commands=[],
+        pipettes=[],
+        labware=[],
     )
 
+    engine_state = decoy.mock(cls=StateView)
+    decoy.when(engine_store.get_state("run-id")).then_return(engine_state)
+    decoy.when(engine_state.commands.get("command-id")).then_raise(key_error)
+
     with pytest.raises(ApiError) as exc_info:
-        await get_run_command(commandId="command-id", engine_store=engine_store)
+        await get_run_command(
+            commandId="command-id",
+            engine_store=engine_store,
+            run=ResponseModel(data=run),
+        )
+
     assert exc_info.value.status_code == 404
     assert exc_info.value.content["errors"][0]["detail"] == "oh no"

--- a/robot-server/tests/runs/test_run_store.py
+++ b/robot-server/tests/runs/test_run_store.py
@@ -18,6 +18,7 @@ def test_add_run() -> None:
         create_data=BasicRunCreateData(),
         created_at=datetime.now(),
         actions=[],
+        is_current=True,
     )
 
     subject = RunStore()
@@ -33,12 +34,14 @@ def test_update_run() -> None:
         create_data=BasicRunCreateData(),
         created_at=datetime(year=2021, month=1, day=1, hour=1, minute=1, second=1),
         actions=[],
+        is_current=True,
     )
     updated_run = RunResource(
         run_id="identical-run-id",
         create_data=BasicRunCreateData(),
         created_at=datetime(year=2022, month=2, day=2, hour=2, minute=2, second=2),
         actions=[],
+        is_current=True,
     )
 
     subject = RunStore()
@@ -56,6 +59,7 @@ def test_get_run() -> None:
         create_data=BasicRunCreateData(),
         created_at=datetime.now(),
         actions=[],
+        is_current=False,
     )
 
     subject = RunStore()
@@ -81,12 +85,14 @@ def test_get_all_runs() -> None:
         create_data=BasicRunCreateData(),
         created_at=datetime.now(),
         actions=[],
+        is_current=False,
     )
     run_2 = RunResource(
         run_id="run-id-2",
         create_data=BasicRunCreateData(),
         created_at=datetime.now(),
         actions=[],
+        is_current=True,
     )
 
     subject = RunStore()
@@ -105,6 +111,7 @@ def test_remove_run() -> None:
         create_data=BasicRunCreateData(),
         created_at=datetime.now(),
         actions=[],
+        is_current=True,
     )
 
     subject = RunStore()
@@ -122,3 +129,29 @@ def test_remove_run_missing_id() -> None:
 
     with pytest.raises(RunNotFoundError, match="run-id"):
         subject.remove(run_id="run-id")
+
+
+def test_add_run_current_run_deactivates() -> None:
+    """Adding a current run should mark all others as not current."""
+    run_1 = RunResource(
+        run_id="run-id-1",
+        create_data=BasicRunCreateData(),
+        created_at=datetime.now(),
+        actions=[],
+        is_current=True,
+    )
+
+    run_2 = RunResource(
+        run_id="run-id-2",
+        create_data=BasicRunCreateData(),
+        created_at=datetime.now(),
+        actions=[],
+        is_current=True,
+    )
+
+    subject = RunStore()
+    subject.upsert(run_1)
+    subject.upsert(run_2)
+
+    assert subject.get("run-id-1").is_current is False
+    assert subject.get("run-id-2").is_current is True

--- a/robot-server/tests/runs/test_run_view.py
+++ b/robot-server/tests/runs/test_run_view.py
@@ -42,7 +42,9 @@ def test_create_run_resource_from_none() -> None:
 
     subject = RunView()
     result = subject.as_resource(
-        run_id="run-id", created_at=created_at, create_data=create_data
+        run_id="run-id",
+        created_at=created_at,
+        create_data=create_data,
     )
 
     assert result == RunResource(
@@ -50,6 +52,7 @@ def test_create_run_resource_from_none() -> None:
         create_data=BasicRunCreateData(),
         created_at=created_at,
         actions=[],
+        is_current=True,
     )
 
 
@@ -68,6 +71,7 @@ def test_create_run_resource() -> None:
         create_data=create_data,
         created_at=created_at,
         actions=[],
+        is_current=True,
     )
 
 
@@ -88,6 +92,7 @@ def test_create_protocol_run_resource() -> None:
         create_data=create_data,
         created_at=created_at,
         actions=[],
+        is_current=True,
     )
 
 
@@ -113,11 +118,13 @@ current_time = datetime.now()
                 ),
                 created_at=current_time,
                 actions=[],
+                is_current=True,
             ),
             BasicRun(
                 id="run-id",
                 createdAt=current_time,
                 status=EngineStatus.READY_TO_RUN,
+                current=True,
                 createParams=BasicRunCreateParams(
                     labwareOffsets=[
                         LabwareOffset(
@@ -141,11 +148,13 @@ current_time = datetime.now()
                 ),
                 created_at=current_time,
                 actions=[],
+                is_current=False,
             ),
             ProtocolRun(
                 id="run-id",
                 createdAt=current_time,
                 status=EngineStatus.READY_TO_RUN,
+                current=False,
                 createParams=ProtocolRunCreateParams(protocolId="protocol-id"),
                 actions=[],
                 commands=[],
@@ -155,10 +164,7 @@ current_time = datetime.now()
         ),
     ),
 )
-def test_to_response(
-    run_resource: RunResource,
-    expected_response: Run,
-) -> None:
+def test_to_response(run_resource: RunResource, expected_response: Run) -> None:
     """It should create the correct type of run."""
     subject = RunView()
     result = subject.as_response(
@@ -178,6 +184,7 @@ def test_to_response_maps_commands() -> None:
         create_data=BasicRunCreateData(),
         created_at=datetime(year=2021, month=1, day=1),
         actions=[],
+        is_current=True,
     )
 
     command_1 = pe_commands.LoadPipette(
@@ -211,6 +218,7 @@ def test_to_response_maps_commands() -> None:
         createParams=BasicRunCreateParams(),
         createdAt=datetime(year=2021, month=1, day=1),
         status=EngineStatus.RUNNING,
+        current=True,
         actions=[],
         commands=[
             RunCommandSummary(
@@ -236,6 +244,7 @@ def test_to_response_adds_equipment() -> None:
         create_data=BasicRunCreateData(),
         created_at=datetime(year=2021, month=1, day=1),
         actions=[],
+        is_current=True,
     )
 
     labware = LoadedLabware(
@@ -265,6 +274,7 @@ def test_to_response_adds_equipment() -> None:
         createParams=BasicRunCreateParams(),
         createdAt=datetime(year=2021, month=1, day=1),
         status=EngineStatus.RUNNING,
+        current=True,
         actions=[],
         commands=[],
         pipettes=[pipette],
@@ -281,6 +291,7 @@ def test_create_action(current_time: datetime) -> None:
         create_data=BasicRunCreateData(),
         created_at=run_created_at,
         actions=[],
+        is_current=True,
     )
 
     command_data = RunActionCreateData(
@@ -306,4 +317,5 @@ def test_create_action(current_time: datetime) -> None:
         create_data=BasicRunCreateData(),
         created_at=run_created_at,
         actions=[action_result],
+        is_current=True,
     )


### PR DESCRIPTION
## Overview

This PR allows a new run to be created after a previous run has stopped. It adds the `current` flag to the Run model, but leaves the rest of #8594 alone for a future PR (adding entry to `links`, allowing `current: false` to be patched).

Closes #8470

## Changelog

- refactor(runs): retrieve state of previous runs

## Review requests

I've updated the [Postman collection](https://gist.github.com/mcous/7dde93b6ea83753b86b0d84b40ba07f6) to hit `/runs` instead of `/sessions`

Happy path:

1. Create a run
2. Stop the run
3. Create a new run

Things to ensure:

- [ ] Cannot create a new run if current one is not stopped
- [ ] Can create a new run after last one has stopped
- [ ] New run is "current", old one is marked `current: false`
- [ ] Cannot issue commands to non-current run
- [ ] Cannot issue actions to non-current run

## Risk assessment

Low. Feature flagged, on it's way to a beta release for full validation
