### PR TITLE
refactor(protocol-engine): Allow PATCHing a run's labware offsets

### DIFF
--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -136,7 +136,7 @@ async def create_run(
 
 @base_router.patch(
     path="/runs/{runId}",
-    summary="Modify a run.",
+    summary="Modify a run",
     description="Modify a run that was previously created via `POST /runs`.",
     status_code=status.HTTP_200_OK,
     # TODO(mc, 2021-06-23): mypy >= 0.780 broke Unions as `response_model`

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -142,6 +142,9 @@ async def create_run(
     # TODO(mc, 2021-06-23): mypy >= 0.780 broke Unions as `response_model`
     # see https://github.com/tiangolo/fastapi/issues/2279
     response_model=RunResponse,  # type: ignore[arg-type]
+    responses={
+        status.HTTP_404_NOT_FOUND: {"model": ErrorResponse[RunNotFound]},
+    },
 )
 async def patch_run(
     runId: str,

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -147,12 +147,7 @@ class PatchLabwareOffsetsRequest(BaseModel):
 
     labwareOffsets: List[LabwareOffset] = Field(
         ...,
-        description=(
-            "Labware offsets to replace the existing list."
-            "\n\n"
-            "You may only `PATCH` this field"
-            ' while the run\'s `status` is `"ready-to-run"`.'
-        ),
+        description="Labware offsets to replace the existing list."
     )
 
 

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -142,10 +142,37 @@ class ProtocolRun(_AbstractRun):
     createParams: ProtocolRunCreateParams
 
 
+class PatchLabwareOffsetsRequest(BaseModel):
+    """A request to change the run's labware offsets."""
+
+    labwareOffsets: List[LabwareOffset] = Field(
+        ...,
+        description=(
+            "Labware offsets to replace the existing list."
+            "\n\n"
+            "You may only `PATCH` this field"
+            ' while the run\'s `status` is `"ready-to-run"`.'
+        ),
+    )
+
+
 RunCreateData = Union[
     BasicRunCreateData,
     ProtocolRunCreateData,
 ]
+
+
+# todo(mm, 2021-11-08):
+# When runs have a `current: bool` field, and we allow patching it,
+# create a separate patch request model for just that field,
+# and add it to this union.
+#
+# We limit PATCHing to one field at a time to make our error handling a little more
+# foolproof: we don't have to handle the case where one field has valid new data but
+# the other has invalid new data. Clients currently have no pressing need to PATCH
+# multiple fields at once, anyway.
+RunPatchRequest = Union[PatchLabwareOffsetsRequest]
+
 
 Run = Union[
     BasicRun,

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -28,9 +28,6 @@ from robot_server.runs.run_models import (
     ProtocolRun,
     ProtocolRunCreateData,
     ProtocolRunCreateParams,
-    PatchLabwareOffsetsRequest,
-    LabwareOffset,
-    LabwareOffsetVector,
 )
 
 from robot_server.runs.engine_store import (
@@ -276,67 +273,6 @@ async def test_create_run_conflict(
         expected_status=409,
         expected_errors=RunAlreadyActive(detail="oh no"),
     )
-
-
-def test_patch_labware_offsets(
-    decoy: Decoy,
-    run_view: RunView,
-    run_store: RunStore,
-    engine_store: EngineStore,
-    client: TestClient,
-) -> None:
-    """It should upsert a run with new labware offsets."""
-    created_at = datetime.now()
-
-    original_run = RunResource(
-        run_id="run-id",
-        create_data=BasicRunCreateData(
-            createParams=BasicRunCreateParams(labwareOffsets=[])
-        ),
-        created_at=created_at,
-        actions=[],
-    )
-
-    updated_labware_offsets = [
-        LabwareOffset(
-            definitionUri="my-labware-definition-uri",
-            location=pe_types.DeckSlotLocation(slot=DeckSlotName.SLOT_1),
-            offset=LabwareOffsetVector(x=1.1, y=2.2, z=3.3),
-        )
-    ]
-
-    expected_updated_run = RunResource(
-        run_id="run-id",
-        create_data=BasicRunCreateData(
-            createParams=BasicRunCreateParams(labwareOffsets=updated_labware_offsets)
-        ),
-        created_at=created_at,
-        actions=[],
-    )
-
-    patch_request = PatchLabwareOffsetsRequest(labwareOffsets=updated_labware_offsets)
-    print(patch_request.json())
-
-    decoy.when(run_store.get(run_id="run-id")).then_return(original_run)
-    decoy.when(run_store.upsert(expected_updated_run)).then_return(expected_updated_run)
-
-    response = client.patch("/runs/run-id", json=patch_request.json())
-
-    print(response.json())
-    raise NotImplementedError()
-
-    # verify_response(response, expected_status=200, expected_data=expected_updated_run)
-
-
-def test_patch_labware_offsets_with_bad_id(
-    decoy: Decoy,
-    run_view: RunView,
-    run_store: RunStore,
-    engine_store: EngineStore,
-    client: TestClient,
-) -> None:
-    """It should return an error if the client tries to PATCH a nonexistent run."""
-    raise NotImplementedError()
 
 
 def test_get_run(

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -275,6 +275,45 @@ async def test_create_run_conflict(
     )
 
 
+def test_patch_labware_offsets(
+    decoy: Decoy,
+    run_view: RunView,
+    run_store: RunStore,
+    engine_store: EngineStore,
+    client: TestClient,
+) -> None:
+    """It should update a run's labware offsets."""
+    created_at = datetime.now()
+
+    original_create_data = BasicRunCreateData(
+        createParams=BasicRunCreateParams(
+            labwareOffsets=[]
+        )
+    )
+
+    original_run = RunResource(
+        run_id="run-id",
+        create_data=original_create_data,
+        created_at=created_at,
+        actions=[]
+    )
+
+    updated_labware_offsets: List[Any] = []
+
+    expected_updated_create_data = BasicRunCreateData(
+        createParams=BasicRunCreateParams(
+            labwareOffsets=updated_labware_offsets
+        )
+    )
+
+    expected_updated_run = RunResource(
+        run_id="run-id",
+        create_data=expected_updated_create_data,
+        created_at=created_at,
+        actions=[]
+    )
+
+
 def test_get_run(
     decoy: Decoy,
     run_view: RunView,


### PR DESCRIPTION
# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

Low. These offsets are presently unused.

# Still to do

* This needs router tests.
* `PATCH`ing should probably be disallowed when the run status is anything other than `ready-to-run`.
    * If we stick with the current plan of merging basic runs and protocol runs into a single hybrid run type, this is blocked by us fleshing that out. How does the client choose whether offsets apply to the basic part or the protocol part?
    * If we abort and go back to the backup plan of having a basic run on top of a `current` but inactive protocol run, this is blocked by me need to refresh my memory on how run statuses work with basic runs.
* These offsets still aren't actually used anywhere. See #8523.
* Now that the `labwareOffsets` list is mutable via `PATCH` after the resource was originally created via `POST`, `createParams` is a confusing place for the client to find the mutated value. Move `labwareOffsets` to a top-level
field? Remove it from `createParams`?
