### PR TITLE
chore(gcode): reduce time of gcode-testing

### DIFF
--- a/g-code-testing/g_code_test_data/http/http_settings.py
+++ b/g-code-testing/g_code_test_data/http/http_settings.py
@@ -12,5 +12,5 @@ HTTP_SETTINGS = Settings(
 )
 
 
-S3_BASE: Final = "http"
+S3_BASE: Final = "dev/http"
 """Base of files in s3"""

--- a/g-code-testing/g_code_test_data/protocol/protocol_configurations.py
+++ b/g-code-testing/g_code_test_data/protocol/protocol_configurations.py
@@ -15,8 +15,13 @@ SWIFT_SMOOTHIE_SETTINGS = Settings(
     smoothie=SmoothieSettings(
         left=PipetteSettings(model="p20_single_v2.0", id="P20SV202020070101"),
         right=PipetteSettings(model="p300_multi_v2.1", id="P20SV202020070101"),
-    )
+    ),
 )
+
+# Set up the temperature ramp.
+SWIFT_SMOOTHIE_SETTINGS.thermocycler.lid_temperature.degrees_per_tick = 50
+SWIFT_SMOOTHIE_SETTINGS.thermocycler.plate_temperature.degrees_per_tick = 50
+SWIFT_SMOOTHIE_SETTINGS.tempdeck.temperature.degrees_per_tick = 50
 
 
 S3_BASE: Final = "protocol"
@@ -59,7 +64,7 @@ TWO_MODULES = ProtocolGCodeConfirmConfig(
         smoothie=SmoothieSettings(
             left=PipetteSettings(model="p300_single_v2.1", id="P20SV202020070101"),
             right=PipetteSettings(model="p20_multi_v2.1", id="P20SV202020070101"),
-        )
+        ),
     )
 )
 

--- a/g-code-testing/g_code_test_data/protocol/protocol_configurations.py
+++ b/g-code-testing/g_code_test_data/protocol/protocol_configurations.py
@@ -24,7 +24,7 @@ SWIFT_SMOOTHIE_SETTINGS.thermocycler.plate_temperature.degrees_per_tick = 50
 SWIFT_SMOOTHIE_SETTINGS.tempdeck.temperature.degrees_per_tick = 50
 
 
-S3_BASE: Final = "protocol"
+S3_BASE: Final = "dev/protocol"
 """Base path of files in s3."""
 
 ##################

--- a/g-code-testing/g_code_test_data/protocol/protocols/2_modules_1s_1m_v2.py
+++ b/g-code-testing/g_code_test_data/protocol/protocols/2_modules_1s_1m_v2.py
@@ -31,7 +31,7 @@ def run(ctx):
 
     # Magnetic Module Testing
     magdeck.engage(height=10)
-    ctx.delay(seconds=30)
+    ctx.delay(seconds=1)
     magdeck.disengage()
     ctx.comment(f"mag status {magdeck.status}")
     magdeck.engage()

--- a/g-code-testing/g_code_test_data/protocol/protocols/swift_smoke.py
+++ b/g-code-testing/g_code_test_data/protocol/protocols/swift_smoke.py
@@ -82,8 +82,9 @@ def run(protocol_context):
     # Run Enzymatic Prep Profile
     thermocycler.close_lid()
     thermocycler.set_block_temperature(70)
-    thermocycler.set_block_temperature(32, hold_time_minutes=1)
-    thermocycler.set_block_temperature(64.5, hold_time_minutes=1)
+    # Changed from hold_time_minutes to hold_time_seconds for faster running in CI
+    thermocycler.set_block_temperature(32, hold_time_seconds=1)
+    thermocycler.set_block_temperature(64.5, hold_time_seconds=1)
     thermocycler.set_block_temperature(4)
     thermocycler.deactivate_lid()
     thermocycler.open_lid()
@@ -271,10 +272,10 @@ def run(protocol_context):
 
     COVER_TEMP = 105
     PLATE_TEMP_PRE = 4
-    PLATE_TEMP_HOLD_1 = (97, 5)  # 30)
-    PLATE_TEMP_HOLD_2 = (97, 5)  # 10)
-    PLATE_TEMP_HOLD_3 = (59.5, 5)  # 30)
-    PLATE_TEMP_HOLD_4 = (67.3, 5)  # 30)
+    PLATE_TEMP_HOLD_1 = (97, 1)  # 30)
+    PLATE_TEMP_HOLD_2 = (97, 1)  # 10)
+    PLATE_TEMP_HOLD_3 = (59.5, 1)  # 30)
+    PLATE_TEMP_HOLD_4 = (67.3, 1)  # 30)
     # PLATE_TEMP_HOLD_5 = (72, 300)
     PLATE_TEMP_POST = 4
     NUM_CYCLES = 5

--- a/g-code-testing/g_code_test_data/protocol/protocols/swift_turbo.py
+++ b/g-code-testing/g_code_test_data/protocol/protocols/swift_turbo.py
@@ -110,7 +110,8 @@ def run(protocol_context):
         p20.blow_out(well.top(-7))
         p20.drop_tip()
 
-    thermocycler.set_block_temperature(20.2, hold_time_minutes=2)
+    # Changed from hold_time_minutes to hold_time_seconds for faster running in CI
+    thermocycler.set_block_temperature(20.2, hold_time_seconds=1)
     thermocycler.set_block_temperature(4)
 
     """Ligation Purification"""
@@ -272,10 +273,10 @@ def run(protocol_context):
 
     COVER_TEMP = 105
     PLATE_TEMP_PRE = 4
-    PLATE_TEMP_HOLD_1 = (97, 2)  # 30)
-    PLATE_TEMP_HOLD_2 = (97, 2)  # 10)
-    PLATE_TEMP_HOLD_3 = (59.5, 2)  # 30)
-    PLATE_TEMP_HOLD_4 = (67.3, 2)  # 30)
+    PLATE_TEMP_HOLD_1 = (97, 1)  # 30)
+    PLATE_TEMP_HOLD_2 = (97, 1)  # 10)
+    PLATE_TEMP_HOLD_3 = (59.5, 1)  # 30)
+    PLATE_TEMP_HOLD_4 = (67.3, 1)  # 30)
     # PLATE_TEMP_HOLD_5 = (72, 300)
     PLATE_TEMP_POST = 4
     NUM_CYCLES = 5

--- a/g-code-testing/g_code_test_data/protocol/protocols/swift_turbo.py
+++ b/g-code-testing/g_code_test_data/protocol/protocols/swift_turbo.py
@@ -83,8 +83,9 @@ def run(protocol_context):
     # Run Enzymatic Prep Profile
     thermocycler.close_lid()
     thermocycler.set_lid_temperature(70)
-    thermocycler.set_block_temperature(32, hold_time_minutes=1)
-    thermocycler.set_block_temperature(64.5, hold_time_minutes=1)
+    # Changed from hold_time_minutes to hold_time_seconds for faster running in CI
+    thermocycler.set_block_temperature(32, hold_time_seconds=1)
+    thermocycler.set_block_temperature(64.5, hold_time_seconds=1)
     thermocycler.set_block_temperature(4)
     thermocycler.deactivate_lid()
     thermocycler.open_lid()


### PR DESCRIPTION
# Overview

The gcode protocol tests take many minutes to complete. The reasons:
- 1 minute hold times in thermocycler temperature set commands.
- 5 second hold times in execute cycle steps for thermocycler.
- 2 degree per second temperature rate for tempdeck and thermocycler

This is a PR into the emulation refactor phase 2 branch. The changes in that branch will require updating the master files in S3. Seemed like a good opportunity to do some optimizations.

# Changelog

- change hold times to 1 second from 1 minute
- change execute cycle steps to hold for 1 second down from 5 seconds.
- 50 degree per second ramp rate 

# Review requests


# Risk assessment

None