### PR TITLE
refactor(robot-server): consolidate runs into a single Run model

### DIFF
--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -39,12 +39,15 @@ class LabwareOffset(BaseModel):
     pipette movements that use that labware as a reference point.
     """
 
+    id: str = Field(..., description="Unique labware offset record identifier.")
     definitionUri: str = Field(..., description="The URI for the labware's definition.")
     location: LabwareLocation = Field(
-        ..., description="Where the labware is located on the robot."
+        ...,
+        description="Where the labware is located on the robot.",
     )
     offset: LabwareOffsetVector = Field(
-        ..., description="The offset applied to matching labware."
+        ...,
+        description="The offset applied to matching labware.",
     )
 
 
@@ -90,12 +93,30 @@ class Run(ResourceModel):
     )
 
 
+class LabwareOffsetCreate(BaseModel):
+    """Create request data for a labware offset."""
+
+    definitionUri: str = Field(..., description="The URI for the labware's definition.")
+    location: LabwareLocation = Field(
+        ...,
+        description="Where the labware is located on the robot.",
+    )
+    offset: LabwareOffsetVector = Field(
+        ...,
+        description="The offset applied to matching labware.",
+    )
+
+
 class RunCreate(BaseModel):
     """Create request data for a new run."""
 
     protocolId: Optional[str] = Field(
         None,
         description="Protocol resource ID that this run will be using, if applicable.",
+    )
+    labwareOffsets: List[LabwareOffsetCreate] = Field(
+        default_factory=list,
+        description="Labware offsets to apply as labware are loaded.",
     )
 
 

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -1,9 +1,7 @@
 """Request and response models for run resources."""
-from enum import Enum
 from datetime import datetime
 from pydantic import BaseModel, Field
-from typing import List, Optional, Union
-from typing_extensions import Literal
+from typing import List, Optional
 
 from opentrons.protocol_engine import (
     CommandStatus,
@@ -17,51 +15,12 @@ from robot_server.service.json_api import ResourceModel
 from .action_models import RunAction
 
 
-class RunType(str, Enum):
-    """All available run types."""
-
-    BASIC = "basic"
-    PROTOCOL = "protocol"
-
-
 class RunCommandSummary(ResourceModel):
     """A stripped down model of a full Command for usage in a Run response."""
 
     id: str = Field(..., description="Unique command identifier.")
     commandType: CommandType = Field(..., description="Specific type of command.")
     status: CommandStatus = Field(..., description="Execution status of the command.")
-
-
-class _AbstractRun(ResourceModel):
-    """Base run resource model."""
-
-    id: str = Field(..., description="Unique run identifier.")
-    runType: RunType = Field(..., description="Specific run type.")
-    createdAt: datetime = Field(..., description="When the run was created")
-    status: RunStatus = Field(..., description="Execution status of the run")
-    current: bool = Field(
-        ...,
-        description=(
-            "Whether this run is currently controlling the robot."
-            " There can be, at most, one current run."
-        ),
-    )
-    actions: List[RunAction] = Field(
-        ...,
-        description="Client-initiated run control actions.",
-    )
-    commands: List[RunCommandSummary] = Field(
-        ...,
-        description="Protocol commands queued, running, or executed for the run.",
-    )
-    pipettes: List[LoadedPipette] = Field(
-        ...,
-        description="Pipettes that have been loaded into the run.",
-    )
-    labware: List[LoadedLabware] = Field(
-        ...,
-        description="Labware that has been loaded into the run.",
-    )
 
 
 class LabwareOffsetVector(BaseModel):
@@ -89,68 +48,59 @@ class LabwareOffset(BaseModel):
     )
 
 
-class BasicRunCreateParams(BaseModel):
-    """Creation parameters for a basic run."""
+class Run(ResourceModel):
+    """Run resource model."""
 
-    labwareOffsets: List[LabwareOffset] = Field(default_factory=list)
-
-
-class BasicRunCreateData(BaseModel):
-    """Creation request data for a basic run."""
-
-    runType: Literal[RunType.BASIC] = Field(
-        RunType.BASIC,
-        description="The run type to create.",
-    )
-    # TODO(mc, 2021-05-25): how hard would it be to rename this field to `config`?
-    createParams: BasicRunCreateParams = Field(
-        default_factory=BasicRunCreateParams,
-        description="Parameters to set run behaviors at creation time.",
-    )
-
-
-class BasicRun(_AbstractRun):
-    """A run to execute commands without a previously loaded protocol file."""
-
-    runType: Literal[RunType.BASIC] = RunType.BASIC
-
-    createParams: BasicRunCreateParams
-
-
-class ProtocolRunCreateParams(BaseModel):
-    """Creation parameters for a protocol run."""
-
-    protocolId: str = Field(
+    id: str = Field(..., description="Unique run identifier.")
+    createdAt: datetime = Field(..., description="When the run was created")
+    status: RunStatus = Field(..., description="Execution status of the run")
+    current: bool = Field(
         ...,
-        description="Unique identifier of the protocol this run will execute.",
+        description=(
+            "Whether this run is currently controlling the robot."
+            " There can be, at most, one current run."
+        ),
     )
-
-    labwareOffsets: List[LabwareOffset] = Field(default_factory=list)
-
-
-class ProtocolRunCreateData(BaseModel):
-    """Creation request data for a protocol run."""
-
-    runType: Literal[RunType.PROTOCOL] = Field(
-        RunType.PROTOCOL,
-        description="The run type to create.",
-    )
-    # TODO(mc, 2021-05-25): how hard would it be to rename this field to `config`?
-    createParams: ProtocolRunCreateParams = Field(
+    actions: List[RunAction] = Field(
         ...,
-        description="Parameters to set run behaviors at creation time.",
+        description="Client-initiated run control actions.",
+    )
+    commands: List[RunCommandSummary] = Field(
+        ...,
+        description="Protocol commands queued, running, or executed for the run.",
+    )
+    pipettes: List[LoadedPipette] = Field(
+        ...,
+        description="Pipettes that have been loaded into the run.",
+    )
+    labware: List[LoadedLabware] = Field(
+        ...,
+        description="Labware that has been loaded into the run.",
+    )
+    labwareOffsets: List[LabwareOffset] = Field(
+        default_factory=list,
+        description="Labware offsets to apply as labware are loaded.",
+    )
+    protocolId: Optional[str] = Field(
+        None,
+        description=(
+            "Protocol resource being run, if any. If not present, the run may"
+            " still be used to execute protocol commands over HTTP."
+        ),
     )
 
 
-class ProtocolRun(_AbstractRun):
-    """A run to execute commands with a previously loaded protocol file."""
+class RunCreate(BaseModel):
+    """Create request data for a new run."""
 
-    runType: Literal[RunType.PROTOCOL] = RunType.PROTOCOL
-    createParams: ProtocolRunCreateParams
+    protocolId: Optional[str] = Field(
+        None,
+        description="Protocol resource ID that this run will be using, if applicable.",
+    )
 
 
 class RunUpdate(BaseModel):
-    """Update request data for a run."""
+    """Update request data for an existing run."""
 
     current: Optional[bool] = Field(
         None,
@@ -159,14 +109,3 @@ class RunUpdate(BaseModel):
             " Setting `current` to `false` will deactivate the run."
         ),
     )
-
-
-RunCreateData = Union[
-    BasicRunCreateData,
-    ProtocolRunCreateData,
-]
-
-Run = Union[
-    BasicRun,
-    ProtocolRun,
-]

--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -1,9 +1,8 @@
 """Runs' in-memory store."""
 from dataclasses import dataclass, replace
 from datetime import datetime
-from typing import Dict, List
+from typing import Dict, List, Optional
 
-from .run_models import RunCreateData
 from .action_models import RunAction
 
 
@@ -16,7 +15,7 @@ class RunResource:
     """
 
     run_id: str
-    create_data: RunCreateData
+    protocol_id: Optional[str]
     created_at: datetime
     actions: List[RunAction]
     is_current: bool

--- a/robot-server/robot_server/runs/run_view.py
+++ b/robot-server/robot_server/runs/run_view.py
@@ -1,7 +1,7 @@
 """Run response model factory."""
 from dataclasses import replace
 from datetime import datetime
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 from opentrons.protocol_engine import (
     Command as ProtocolEngineCommand,
@@ -12,16 +12,7 @@ from opentrons.protocol_engine import (
 
 from .run_store import RunResource
 from .action_models import RunAction, RunActionCreateData
-from .run_models import (
-    Run,
-    RunCreateData,
-    BasicRun,
-    BasicRunCreateData,
-    ProtocolRun,
-    ProtocolRunCreateData,
-    RunCommandSummary,
-    RunUpdate,
-)
+from .run_models import Run, RunUpdate, RunCommandSummary
 
 
 class RunView:
@@ -30,31 +21,6 @@ class RunView:
     Resources consumed and returned by this class will be treated as
     immutable.
     """
-
-    @staticmethod
-    def as_resource(
-        run_id: str,
-        created_at: datetime,
-        create_data: Optional[RunCreateData],
-    ) -> RunResource:
-        """Create a new run resource instance from its create data.
-
-        Arguments:
-            run_id: Unique identifier.
-            created_at: Resource creation timestamp.
-            create_data: Data used to create the run.
-
-        Returns:
-            The run in its internal resource representation, for use in
-                the `RunStore` and other classes.
-        """
-        return RunResource(
-            run_id=run_id,
-            created_at=created_at,
-            create_data=create_data or BasicRunCreateData(),
-            actions=[],
-            is_current=True,
-        )
 
     @staticmethod
     def with_update(run: RunResource, update: RunUpdate) -> RunResource:
@@ -123,36 +89,19 @@ class RunView:
         Returns:
             Run response model representing the same resource.
         """
-        create_data = run.create_data
         command_summaries = [
             RunCommandSummary(id=c.id, commandType=c.commandType, status=c.status)
             for c in commands
         ]
 
-        if isinstance(create_data, BasicRunCreateData):
-            return BasicRun(
-                id=run.run_id,
-                createParams=create_data.createParams,
-                createdAt=run.created_at,
-                current=run.is_current,
-                actions=run.actions,
-                commands=command_summaries,
-                pipettes=pipettes,
-                labware=labware,
-                status=engine_status,
-            )
-
-        if isinstance(create_data, ProtocolRunCreateData):
-            return ProtocolRun(
-                id=run.run_id,
-                createParams=create_data.createParams,
-                createdAt=run.created_at,
-                current=run.is_current,
-                actions=run.actions,
-                commands=command_summaries,
-                pipettes=pipettes,
-                labware=labware,
-                status=engine_status,
-            )
-
-        raise ValueError(f"Invalid run resource {run}")
+        return Run(
+            id=run.run_id,
+            protocolId=run.protocol_id,
+            createdAt=run.created_at,
+            current=run.is_current,
+            actions=run.actions,
+            commands=command_summaries,
+            pipettes=pipettes,
+            labware=labware,
+            status=engine_status,
+        )

--- a/robot-server/tests/runs/router/test_actions_router.py
+++ b/robot-server/tests/runs/router/test_actions_router.py
@@ -8,7 +8,7 @@ from httpx import AsyncClient
 
 from tests.helpers import verify_response
 from opentrons.protocol_engine.errors import ProtocolEngineStoppedError
-from robot_server.runs.run_models import BasicRunCreateData
+
 from robot_server.runs.run_view import RunView
 from robot_server.runs.engine_store import EngineStore
 from robot_server.runs.run_store import (
@@ -33,7 +33,7 @@ from robot_server.runs.router.actions_router import (
 
 prev_run = RunResource(
     run_id="run-id",
-    create_data=BasicRunCreateData(),
+    protocol_id=None,
     created_at=datetime(year=2021, month=1, day=1),
     actions=[],
     is_current=True,
@@ -70,7 +70,7 @@ def test_create_play_action(
 
     next_run = RunResource(
         run_id="run-id",
-        create_data=BasicRunCreateData(),
+        protocol_id=None,
         created_at=datetime(year=2021, month=1, day=1),
         actions=[action],
         is_current=True,
@@ -136,7 +136,7 @@ def test_create_run_action_without_runner(
 
     next_run = RunResource(
         run_id="run-id",
-        create_data=BasicRunCreateData(),
+        protocol_id=None,
         created_at=datetime(year=2021, month=1, day=1),
         actions=[actions],
         is_current=True,
@@ -179,7 +179,7 @@ def test_create_run_action_not_current(
     """It should 409 if the run is not current."""
     prev_run = RunResource(
         run_id="run-id",
-        create_data=BasicRunCreateData(),
+        protocol_id=None,
         created_at=datetime(year=2021, month=1, day=1),
         actions=[],
         is_current=False,
@@ -217,7 +217,7 @@ def test_create_pause_action(
 
     next_run = RunResource(
         run_id="run-id",
-        create_data=BasicRunCreateData(),
+        protocol_id=None,
         created_at=datetime(year=2021, month=1, day=1),
         actions=[action],
         is_current=True,
@@ -259,7 +259,7 @@ async def test_create_stop_action(
 
     next_run = RunResource(
         run_id="run-id",
-        create_data=BasicRunCreateData(),
+        protocol_id=None,
         created_at=datetime(year=2021, month=1, day=1),
         actions=[action],
         is_current=True,

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -14,11 +14,7 @@ from opentrons.protocol_engine import (
 
 from robot_server.errors import ApiError
 from robot_server.service.json_api import RequestModel, ResponseModel
-from robot_server.runs.run_models import (
-    BasicRun,
-    BasicRunCreateParams,
-    RunCommandSummary,
-)
+from robot_server.runs.run_models import Run, RunCommandSummary
 from robot_server.runs.engine_store import EngineStore
 from robot_server.runs.router.commands_router import (
     post_run_command,
@@ -33,9 +29,9 @@ async def test_post_run_command(decoy: Decoy, engine_store: EngineStore) -> None
         data=pe_commands.PauseData(message="Hello")
     )
 
-    run = BasicRun(
+    run = Run(
         id="run-id",
-        createParams=BasicRunCreateParams(),
+        protocolId=None,
         createdAt=datetime(year=2021, month=1, day=1),
         status=EngineStatus.RUNNING,
         current=True,
@@ -75,9 +71,9 @@ async def test_post_run_command_not_current(
         data=pe_commands.PauseData(message="Hello")
     )
 
-    run = BasicRun(
+    run = Run(
         id="run-id",
-        createParams=BasicRunCreateParams(),
+        protocolId=None,
         createdAt=datetime(year=2021, month=1, day=1),
         status=EngineStatus.RUNNING,
         current=False,
@@ -106,9 +102,9 @@ async def test_get_run_commands() -> None:
         status=CommandStatus.RUNNING,
     )
 
-    run = BasicRun(
+    run = Run(
         id="run-id",
-        createParams=BasicRunCreateParams(),
+        protocolId=None,
         createdAt=datetime(year=2021, month=1, day=1),
         status=EngineStatus.RUNNING,
         current=True,
@@ -141,9 +137,9 @@ async def test_get_run_command_by_id(
         data=pe_commands.MoveToWellData(pipetteId="a", labwareId="b", wellName="c"),
     )
 
-    run = BasicRun(
+    run = Run(
         id="run-id",
-        createParams=BasicRunCreateParams(),
+        protocolId=None,
         createdAt=datetime(year=2021, month=1, day=1),
         status=EngineStatus.RUNNING,
         current=True,
@@ -174,9 +170,9 @@ async def test_get_run_command_missing_command(
     """It should 404 if you attempt to get a non-existent command."""
     key_error = pe_errors.CommandDoesNotExistError("oh no")
 
-    run = BasicRun(
+    run = Run(
         id="run-id",
-        createParams=BasicRunCreateParams(),
+        protocolId=None,
         createdAt=datetime(year=2021, month=1, day=1),
         status=EngineStatus.RUNNING,
         current=True,

--- a/robot-server/tests/runs/test_run_store.py
+++ b/robot-server/tests/runs/test_run_store.py
@@ -2,20 +2,14 @@
 import pytest
 from datetime import datetime
 
-from robot_server.runs.run_models import BasicRunCreateData
-
-from robot_server.runs.run_store import (
-    RunStore,
-    RunResource,
-    RunNotFoundError,
-)
+from robot_server.runs.run_store import RunStore, RunResource, RunNotFoundError
 
 
 def test_add_run() -> None:
-    """It should be able to create a basic run from a None data argument."""
+    """It should be able to add a new run to the store."""
     run = RunResource(
         run_id="run-id",
-        create_data=BasicRunCreateData(),
+        protocol_id=None,
         created_at=datetime.now(),
         actions=[],
         is_current=True,
@@ -31,14 +25,14 @@ def test_update_run() -> None:
     """It should be able to update a run in the store."""
     run = RunResource(
         run_id="identical-run-id",
-        create_data=BasicRunCreateData(),
+        protocol_id=None,
         created_at=datetime(year=2021, month=1, day=1, hour=1, minute=1, second=1),
         actions=[],
         is_current=True,
     )
     updated_run = RunResource(
         run_id="identical-run-id",
-        create_data=BasicRunCreateData(),
+        protocol_id=None,
         created_at=datetime(year=2022, month=2, day=2, hour=2, minute=2, second=2),
         actions=[],
         is_current=True,
@@ -56,7 +50,7 @@ def test_get_run() -> None:
     """It can get a previously stored run entry."""
     run = RunResource(
         run_id="run-id",
-        create_data=BasicRunCreateData(),
+        protocol_id=None,
         created_at=datetime.now(),
         actions=[],
         is_current=False,
@@ -82,14 +76,14 @@ def test_get_all_runs() -> None:
     """It can get all created runs."""
     run_1 = RunResource(
         run_id="run-id-1",
-        create_data=BasicRunCreateData(),
+        protocol_id=None,
         created_at=datetime.now(),
         actions=[],
         is_current=False,
     )
     run_2 = RunResource(
         run_id="run-id-2",
-        create_data=BasicRunCreateData(),
+        protocol_id=None,
         created_at=datetime.now(),
         actions=[],
         is_current=True,
@@ -108,7 +102,7 @@ def test_remove_run() -> None:
     """It can remove and return a previously stored run entry."""
     run = RunResource(
         run_id="run-id",
-        create_data=BasicRunCreateData(),
+        protocol_id=None,
         created_at=datetime.now(),
         actions=[],
         is_current=True,
@@ -135,7 +129,7 @@ def test_add_run_current_run_deactivates() -> None:
     """Adding a current run should mark all others as not current."""
     run_1 = RunResource(
         run_id="run-id-1",
-        create_data=BasicRunCreateData(),
+        protocol_id=None,
         created_at=datetime.now(),
         actions=[],
         is_current=True,
@@ -143,7 +137,7 @@ def test_add_run_current_run_deactivates() -> None:
 
     run_2 = RunResource(
         run_id="run-id-2",
-        create_data=BasicRunCreateData(),
+        protocol_id=None,
         created_at=datetime.now(),
         actions=[],
         is_current=True,

--- a/robot-server/tests/runs/test_run_view.py
+++ b/robot-server/tests/runs/test_run_view.py
@@ -1,5 +1,4 @@
 """Tests for the run resource model builder."""
-import pytest
 from datetime import datetime
 
 from opentrons.types import DeckSlotName, MountType
@@ -15,19 +14,7 @@ from opentrons.protocol_engine import (
 
 from robot_server.runs.run_store import RunResource
 from robot_server.runs.run_view import RunView
-from robot_server.runs.run_models import (
-    Run,
-    BasicRun,
-    BasicRunCreateData,
-    BasicRunCreateParams,
-    ProtocolRun,
-    ProtocolRunCreateData,
-    ProtocolRunCreateParams,
-    RunCommandSummary,
-    LabwareOffset,
-    LabwareOffsetVector,
-    RunUpdate,
-)
+from robot_server.runs.run_models import Run, RunUpdate, RunCommandSummary
 
 from robot_server.runs.action_models import (
     RunAction,
@@ -36,137 +23,16 @@ from robot_server.runs.action_models import (
 )
 
 
-def test_create_run_resource_from_none() -> None:
-    """It should create a basic run from create_data=None."""
-    created_at = datetime.now()
-    create_data = None
-
-    subject = RunView()
-    result = subject.as_resource(
-        run_id="run-id",
-        created_at=created_at,
-        create_data=create_data,
-    )
-
-    assert result == RunResource(
-        run_id="run-id",
-        create_data=BasicRunCreateData(),
-        created_at=created_at,
-        actions=[],
-        is_current=True,
-    )
-
-
-def test_create_run_resource() -> None:
-    """It should create a run with create_data specified."""
-    created_at = datetime.now()
-    create_data = BasicRunCreateData()
-
-    subject = RunView()
-    result = subject.as_resource(
-        run_id="run-id", created_at=created_at, create_data=create_data
-    )
-
-    assert result == RunResource(
-        run_id="run-id",
-        create_data=create_data,
-        created_at=created_at,
-        actions=[],
-        is_current=True,
-    )
-
-
-def test_create_protocol_run_resource() -> None:
-    """It should create a protocol run resource view."""
-    created_at = datetime.now()
-    create_data = ProtocolRunCreateData(
-        createParams=ProtocolRunCreateParams(protocolId="protocol-id")
-    )
-
-    subject = RunView()
-    result = subject.as_resource(
-        run_id="run-id", created_at=created_at, create_data=create_data
-    )
-
-    assert result == RunResource(
-        run_id="run-id",
-        create_data=create_data,
-        created_at=created_at,
-        actions=[],
-        is_current=True,
-    )
-
-
-current_time = datetime.now()
-
-
-@pytest.mark.parametrize(
-    ("run_resource", "expected_response"),
-    (
-        (
-            RunResource(
-                run_id="run-id",
-                create_data=BasicRunCreateData(
-                    createParams=BasicRunCreateParams(
-                        labwareOffsets=[
-                            LabwareOffset(
-                                definitionUri="my-labware-definition-uri",
-                                location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
-                                offset=LabwareOffsetVector(x=1, y=2, z=3),
-                            )
-                        ]
-                    )
-                ),
-                created_at=current_time,
-                actions=[],
-                is_current=True,
-            ),
-            BasicRun(
-                id="run-id",
-                createdAt=current_time,
-                status=EngineStatus.READY_TO_RUN,
-                current=True,
-                createParams=BasicRunCreateParams(
-                    labwareOffsets=[
-                        LabwareOffset(
-                            definitionUri="my-labware-definition-uri",
-                            location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
-                            offset=LabwareOffsetVector(x=1, y=2, z=3),
-                        )
-                    ]
-                ),
-                actions=[],
-                commands=[],
-                pipettes=[],
-                labware=[],
-            ),
-        ),
-        (
-            RunResource(
-                run_id="run-id",
-                create_data=ProtocolRunCreateData(
-                    createParams=ProtocolRunCreateParams(protocolId="protocol-id")
-                ),
-                created_at=current_time,
-                actions=[],
-                is_current=False,
-            ),
-            ProtocolRun(
-                id="run-id",
-                createdAt=current_time,
-                status=EngineStatus.READY_TO_RUN,
-                current=False,
-                createParams=ProtocolRunCreateParams(protocolId="protocol-id"),
-                actions=[],
-                commands=[],
-                pipettes=[],
-                labware=[],
-            ),
-        ),
-    ),
-)
-def test_to_response(run_resource: RunResource, expected_response: Run) -> None:
+def test_to_response() -> None:
     """It should create the correct type of run."""
+    run_resource = RunResource(
+        run_id="run-id",
+        protocol_id=None,
+        created_at=datetime(year=2021, month=1, day=1),
+        actions=[],
+        is_current=True,
+    )
+
     subject = RunView()
     result = subject.as_response(
         run=run_resource,
@@ -175,14 +41,25 @@ def test_to_response(run_resource: RunResource, expected_response: Run) -> None:
         labware=[],
         engine_status=EngineStatus.READY_TO_RUN,
     )
-    assert result == expected_response
+
+    assert result == Run(
+        id="run-id",
+        protocolId=None,
+        createdAt=datetime(year=2021, month=1, day=1),
+        status=EngineStatus.READY_TO_RUN,
+        current=True,
+        actions=[],
+        commands=[],
+        pipettes=[],
+        labware=[],
+    )
 
 
 def test_to_response_maps_commands() -> None:
     """It should map ProtocolEngine commands to RunCommandSummary models."""
     run_resource = RunResource(
         run_id="run-id",
-        create_data=BasicRunCreateData(),
+        protocol_id="protocol-id",
         created_at=datetime(year=2021, month=1, day=1),
         actions=[],
         is_current=True,
@@ -214,9 +91,9 @@ def test_to_response_maps_commands() -> None:
         engine_status=EngineStatus.RUNNING,
     )
 
-    assert result == BasicRun(
+    assert result == Run(
         id="run-id",
-        createParams=BasicRunCreateParams(),
+        protocolId="protocol-id",
         createdAt=datetime(year=2021, month=1, day=1),
         status=EngineStatus.RUNNING,
         current=True,
@@ -242,7 +119,7 @@ def test_to_response_adds_equipment() -> None:
     """It should add ProtocolEngine equipment to Session response model."""
     run_resource = RunResource(
         run_id="run-id",
-        create_data=BasicRunCreateData(),
+        protocol_id=None,
         created_at=datetime(year=2021, month=1, day=1),
         actions=[],
         is_current=True,
@@ -270,9 +147,9 @@ def test_to_response_adds_equipment() -> None:
         engine_status=EngineStatus.RUNNING,
     )
 
-    assert result == BasicRun(
+    assert result == Run(
         id="run-id",
-        createParams=BasicRunCreateParams(),
+        protocolId=None,
         createdAt=datetime(year=2021, month=1, day=1),
         status=EngineStatus.RUNNING,
         current=True,
@@ -289,7 +166,7 @@ def test_create_action(current_time: datetime) -> None:
 
     run = RunResource(
         run_id="run-id",
-        create_data=BasicRunCreateData(),
+        protocol_id="protocol-id",
         created_at=run_created_at,
         actions=[],
         is_current=True,
@@ -315,7 +192,7 @@ def test_create_action(current_time: datetime) -> None:
 
     assert run_result == RunResource(
         run_id="run-id",
-        create_data=BasicRunCreateData(),
+        protocol_id="protocol-id",
         created_at=run_created_at,
         actions=[action_result],
         is_current=True,
@@ -326,7 +203,7 @@ def test_with_update() -> None:
     """It should update a run resource to not current."""
     run = RunResource(
         run_id="run-id",
-        create_data=BasicRunCreateData(),
+        protocol_id="protocol-id",
         created_at=datetime(year=2021, month=1, day=1),
         actions=[],
         is_current=True,
@@ -338,7 +215,7 @@ def test_with_update() -> None:
 
     assert result == RunResource(
         run_id="run-id",
-        create_data=BasicRunCreateData(),
+        protocol_id="protocol-id",
         created_at=datetime(year=2021, month=1, day=1),
         actions=[],
         is_current=False,


### PR DESCRIPTION
## Overview

As discussed in Slack, this is a simplification PR to remove the unnecessary distinction between a BasicRun and a ProtocolRun.

## Changelog

- Instead of two different types of runs, there is now one `Run`, which may optionally point to a `protocolId` if it's there to run a protocol

## Review requests

Code changes make sense. **This back-end PR requires a corresponding front-end PR**

## Risk assessment

Low
