### PR TITLE
fix(robot-server): avoid LabwareDefinition type in cal models

### DIFF
--- a/api/src/opentrons/calibration_storage/helpers.py
+++ b/api/src/opentrons/calibration_storage/helpers.py
@@ -38,6 +38,11 @@ def convert_to_dict(obj) -> Dict:
     return asdict(obj, dict_factory=dict_filter_none)
 
 
+# TODO(mc, 2021-11-09): this hashing function may produce different hashes
+# for semantically identical labware defs. For example, a value of `10` will
+# produce a different hash than a value of `10.0`. Hashing should be produce
+# identical hashes for `==` values. This could be done by running defs through
+# Pydantic or simliar rather via json.dumps
 def hash_labware_def(labware_def: "LabwareDefinition") -> str:
     """
     Helper function to take in a labware definition and return

--- a/robot-server/robot_server/robot/calibration/check/models.py
+++ b/robot-server/robot_server/robot/calibration/check/models.py
@@ -1,9 +1,8 @@
-from typing import Optional, List
+from typing import Any, Dict, Optional, List
 from typing_extensions import Literal
 from functools import partial
 from pydantic import BaseModel, Field
 
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
 from ..helper_classes import RequiredLabware, AttachedPipette
 
 # NOTE: this would be more accurately typed as
@@ -105,7 +104,7 @@ class SessionCreateParams(BaseModel):
         description="Whether to use a calibration block in the"
         "calibration health check flow.",
     )
-    tipRacks: List[LabwareDefinition] = Field(
+    tipRacks: List[Dict[str, Any]] = Field(
         [],
         description="A list of labware definitions to use in"
         "calibration health check",

--- a/robot-server/robot_server/robot/calibration/check/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/check/user_flow.py
@@ -536,7 +536,7 @@ class CheckCalibrationUserFlow:
                 rank=info_pip.rank.value,
                 mount=str(info_pip.mount),
                 serial=hw_pip.pipette_id,  # type: ignore[arg-type]
-                defaultTipracks=info_pip.default_tipracks,
+                defaultTipracks=info_pip.default_tipracks,  # type: ignore[arg-type]
             )
             for hw_pip, info_pip in zip(hw_pips, info_pips)
         ]
@@ -559,7 +559,9 @@ class CheckCalibrationUserFlow:
             rank=self.active_pipette.rank.value,
             mount=str(self.mount),
             serial=self.hw_pipette.pipette_id,  # type: ignore[arg-type]
-            defaultTipracks=self.active_pipette.default_tipracks,
+            defaultTipracks=(
+                self.active_pipette.default_tipracks  # type: ignore[arg-type]
+            ),
         )
 
     def _determine_threshold(self) -> Point:

--- a/robot-server/robot_server/robot/calibration/helper_classes.py
+++ b/robot-server/robot_server/robot/calibration/helper_classes.py
@@ -108,7 +108,7 @@ class AttachedPipette(BaseModel):
     )
     mount: str = Field(None, description="The mount this pipette attached to")
     serial: str = Field(None, description="The serial number of the attached pipette")
-    defaultTipracks: typing.List[LabwareDefinition] = Field(
+    defaultTipracks: typing.List[typing.Dict[str, typing.Any]] = Field(
         None, description="A list of default tipracks for this pipette"
     )
 
@@ -124,7 +124,7 @@ class RequiredLabware(BaseModel):
     namespace: str
     version: str
     isTiprack: bool
-    definition: LabwareDefinition
+    definition: typing.Dict[str, typing.Any]
 
     @classmethod
     def from_lw(cls, lw: labware.Labware, slot: typing.Optional[DeckLocation] = None):
@@ -140,7 +140,7 @@ class RequiredLabware(BaseModel):
             namespace=lw_def["namespace"],
             version=str(lw_def["version"]),
             isTiprack=lw.is_tiprack,
-            definition=lw_def,
+            definition=typing.cast(typing.Dict[str, typing.Any], lw_def),
         )
 
 

--- a/robot-server/robot_server/robot/calibration/models.py
+++ b/robot-server/robot_server/robot/calibration/models.py
@@ -1,7 +1,5 @@
-from typing import Optional
+from typing import Any, Dict, Optional
 from pydantic import BaseModel, Field
-
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 
 class SessionCreateParams(BaseModel):
@@ -22,7 +20,7 @@ class SessionCreateParams(BaseModel):
         "is performed, this is ignored, but it should always be "
         "specified.",
     )
-    tipRackDefinition: Optional[LabwareDefinition] = Field(
+    tipRackDefinition: Optional[Dict[str, Any]] = Field(
         None,
         description="The full labware definition of the tip rack to "
         "calibrate. If not specified, then a default will be "

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -1,4 +1,5 @@
 import logging
+import json
 from typing import (
     Any,
     Awaitable,
@@ -50,6 +51,7 @@ from .state_machine import (
     PipetteOffsetWithTipLengthStateMachine,
 )
 
+from opentrons_shared_data.labware import load_definition
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 
@@ -196,7 +198,7 @@ class PipetteOffsetCalibrationUserFlow:
             tipLength=self._hw_pipette.config.tip_length,
             mount=str(self._mount),
             serial=self._hw_pipette.pipette_id,
-            defaultTipracks=self._default_tipracks,
+            defaultTipracks=self._default_tipracks,  # type: ignore[arg-type]
         )
 
     def get_required_labware(self) -> List[RequiredLabware]:
@@ -440,9 +442,20 @@ class PipetteOffsetCalibrationUserFlow:
                 cur_pt = await self.get_current_point(
                     critical_point=CriticalPoint.FRONT_NOZZLE
                 )
+
+            defn = self._tip_rack._implementation.get_definition()
+            print("DEF", json.dumps(defn))
             tiprack_hash = helpers.hash_labware_def(
                 self._tip_rack._implementation.get_definition()
             )
+            print("HASH", tiprack_hash)
+
+            direct_defn = load_definition(
+                defn["parameters"]["loadName"], defn["version"]
+            )
+            print("ALT DEF", json.dumps(direct_defn))
+            print("ALT HASH", helpers.hash_labware_def(direct_defn))
+
             offset = self._cal_ref_point - cur_pt
             modify.save_pipette_calibration(
                 offset=offset,

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -1,5 +1,4 @@
 import logging
-import json
 from typing import (
     Any,
     Awaitable,
@@ -51,7 +50,6 @@ from .state_machine import (
     PipetteOffsetWithTipLengthStateMachine,
 )
 
-from opentrons_shared_data.labware import load_definition
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 
@@ -442,20 +440,9 @@ class PipetteOffsetCalibrationUserFlow:
                 cur_pt = await self.get_current_point(
                     critical_point=CriticalPoint.FRONT_NOZZLE
                 )
-
-            defn = self._tip_rack._implementation.get_definition()
-            print("DEF", json.dumps(defn))
             tiprack_hash = helpers.hash_labware_def(
                 self._tip_rack._implementation.get_definition()
             )
-            print("HASH", tiprack_hash)
-
-            direct_defn = load_definition(
-                defn["parameters"]["loadName"], defn["version"]
-            )
-            print("ALT DEF", json.dumps(direct_defn))
-            print("ALT HASH", helpers.hash_labware_def(direct_defn))
-
             offset = self._cal_ref_point - cur_pt
             modify.save_pipette_calibration(
                 offset=offset,

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -133,7 +133,7 @@ class TipCalibrationUserFlow:
             tipLength=self._hw_pipette.config.tip_length,
             mount=str(self._mount),
             serial=self._hw_pipette.pipette_id,
-            defaultTipracks=self._default_tipracks,
+            defaultTipracks=self._default_tipracks,  # type: ignore[arg-type]
         )
 
     def get_required_labware(self) -> List[RequiredLabware]:

--- a/robot-server/robot_server/service/session/models/command.py
+++ b/robot-server/robot_server/service/session/models/command.py
@@ -24,7 +24,6 @@ from typing_extensions import Literal
 from pydantic import BaseModel, Field
 from pydantic.generics import GenericModel
 
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
 from opentrons.util.helpers import utc_now
 from opentrons.protocol_engine import commands
 
@@ -47,7 +46,7 @@ from robot_server.service.json_api import (
 
 
 class LoadLabwareByDefinitionRequestData(BaseModel):
-    tiprackDefinition: typing.Optional[LabwareDefinition] = Field(
+    tiprackDefinition: typing.Optional[typing.Dict[str, typing.Any]] = Field(
         None, description="The tiprack definition to load into a user flow"
     )
 

--- a/robot-server/robot_server/service/session/session_types/check_session.py
+++ b/robot-server/robot_server/service/session/session_types/check_session.py
@@ -72,9 +72,7 @@ class CheckSession(BaseSession):
             calibration_check = CheckCalibrationUserFlow(
                 configuration.hardware,
                 has_calibration_block=has_calibration_block,
-                # TODO(mc, 2021-09-09): convert to an explicit clone if necessary,
-                # otherwise remove redundant list comprehension
-                tip_rack_defs=[rack for rack in tip_racks],
+                tip_rack_defs=tip_racks,  # type: ignore[arg-type]
             )
         except AssertionError as e:
             raise SessionCreationException(str(e))


### PR DESCRIPTION
## Overview

This PR fixes #8654

If a `LabwareDefinition` TypedDict is present in a `BaseModel`, Pydantic will coerce input values. PR #8329 added `LabwareDefinition` to the type signatures of calibration models, because that was accurate typing of the values in play. However, because they were Pydantic models, Pydantic started validating (and coercing) inputs.

Specifically, values that were types as `float`s that are present in the definition JSON file without a decimal point had a decimal point added, e.g. `"totalLiquidVolume": 10` became `"totalLiquidVolume": 10.0`

From there, the labware hashing produced different hashes, even though the JSON was completely semantically equivalent.

## Changelog

Reverted all references to `opentrons_shared_data.labware.dev_types.LabwareDefinition` added by #8329, reverting them to their previous (sometimes implicit) setting of `Dict[str, Any]`.

## Review requests

Please verify that #8654 is, indeed, fixed.

## Risk assessment

I want to say low, but the presence of this bug in the first place shows that messing with type annotations is not a completely risk-free activity if Pydantic is involved.