### PR TITLE
revert(robot-server): revert attach pipette code back to using the mount

### DIFF
--- a/robot-server/tests/service/legacy/routers/test_control.py
+++ b/robot-server/tests/service/legacy/routers/test_control.py
@@ -2,7 +2,7 @@ from asyncio import Event
 from mock import call, MagicMock
 
 import pytest
-from opentrons.hardware_control.types import Axis
+from opentrons.hardware_control.types import Axis, CriticalPoint
 from opentrons.types import Mount, Point
 
 from robot_server.errors import ApiError
@@ -118,14 +118,22 @@ def test_move_mount(api_client, hardware_move):
 
     hardware_move.gantry_position.assert_has_calls(
         [
-            call(Mount.RIGHT),
+            call(Mount.RIGHT, critical_point=CriticalPoint.MOUNT),
             call(Mount.RIGHT),
         ]
     )
     hardware_move.move_to.assert_has_calls(
         [
-            call(Mount.RIGHT, Point(100.0, 200.0, 0.0)),
-            call(Mount.RIGHT, Point(100.0, 200.0, 50.0)),
+            call(
+                Mount.RIGHT,
+                Point(100.0, 200.0, 0.0),
+                critical_point=CriticalPoint.MOUNT,
+            ),
+            call(
+                Mount.RIGHT,
+                Point(100.0, 200.0, 50.0),
+                critical_point=CriticalPoint.MOUNT,
+            ),
         ]
     )
 
@@ -141,16 +149,18 @@ def test_move_pipette(api_client, hardware_move):
     assert res.status_code == 200
     assert res.json() == {"message": "Move complete. New position: (50.0, 100.0, 25.0)"}
 
+    hardware_move.cache_instruments.assert_called_once()
+
     hardware_move.gantry_position.assert_has_calls(
         [
-            call(Mount.LEFT),
+            call(Mount.LEFT, critical_point=None),
             call(Mount.LEFT),
         ]
     )
     hardware_move.move_to.assert_has_calls(
         [
-            call(Mount.LEFT, Point(50.0, 100.0, 0.0)),
-            call(Mount.LEFT, Point(50.0, 100.0, 25.0)),
+            call(Mount.LEFT, Point(50.0, 100.0, 0.0), critical_point=None),
+            call(Mount.LEFT, Point(50.0, 100.0, 25.0), critical_point=None),
         ]
     )
 


### PR DESCRIPTION
# Overview

The original bug was that GEN1 pipettes would crash during pipette attach. However, this code change
caused other issues with pipette attach (see #8562). After testing on 3 different robots in 4.5.0, we determined that the original bug reported was unable to be reproduced (#8288).

closes #8562

# Changelog

- revert pipette attach changes

# Review requests
Test on a robot, with a GEN1 multi if you have one.

# Risk assessment

Low.
