### PR TITLE
refactor(engine): align command models with JSON schema and HTTP API

### DIFF
--- a/api/src/opentrons/protocol_api_experimental/labware.py
+++ b/api/src/opentrons/protocol_api_experimental/labware.py
@@ -74,7 +74,7 @@ class Labware:  # noqa: D101
         parent = self._engine_client.state.labware.get_location(
             labware_id=self._labware_id
         )
-        return str(parent.slot)
+        return str(parent.slotName)
 
     # TODO(mc, 2021-05-03): document removal of name setter
     @property

--- a/api/src/opentrons/protocol_api_experimental/protocol_context.py
+++ b/api/src/opentrons/protocol_api_experimental/protocol_context.py
@@ -86,7 +86,7 @@ class ProtocolContext:  # noqa: D101
 
         result = self._engine_client.load_labware(
             load_name=load_name,
-            location=DeckSlotLocation(slot=DeckSlotName.from_primitive(location)),
+            location=DeckSlotLocation(slotName=DeckSlotName.from_primitive(location)),
             # TODO(mc, 2021-04-22): make sure this default is compatible with using
             # namespace=None to load custom labware in PAPIv3
             namespace=namespace or "opentrons",

--- a/api/src/opentrons/protocol_engine/__init__.py
+++ b/api/src/opentrons/protocol_engine/__init__.py
@@ -8,7 +8,7 @@ protocol state and side-effects like robot movements.
 from .create_protocol_engine import create_protocol_engine
 from .protocol_engine import ProtocolEngine
 from .errors import ProtocolEngineError
-from .commands import Command, CommandRequest, CommandStatus, CommandType
+from .commands import Command, CommandCreate, CommandStatus, CommandType
 from .state import State, StateView
 from .plugins import AbstractPlugin
 
@@ -34,7 +34,7 @@ __all__ = [
     "ProtocolEngineError",
     # top level command unions and values
     "Command",
-    "CommandRequest",
+    "CommandCreate",
     "CommandStatus",
     "CommandType",
     # state interfaces and models

--- a/api/src/opentrons/protocol_engine/actions/actions.py
+++ b/api/src/opentrons/protocol_engine/actions/actions.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional, Union
 
-from ..commands import Command, CommandRequest
+from ..commands import Command, CommandCreate
 
 
 @dataclass(frozen=True)
@@ -33,7 +33,7 @@ class QueueCommandAction:
 
     command_id: str
     created_at: datetime
-    request: CommandRequest
+    request: CommandCreate
 
 
 @dataclass(frozen=True)

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -28,9 +28,9 @@ class SyncClient:
         namespace: str,
         version: int,
     ) -> commands.LoadLabwareResult:
-        """Execute a LoadLabwareRequest and return the result."""
-        request = commands.LoadLabwareRequest(
-            data=commands.LoadLabwareData(
+        """Execute a LoadLabwareCreate and return the result."""
+        request = commands.LoadLabwareCreate(
+            params=commands.LoadLabwareParams(
                 location=location,
                 loadName=load_name,
                 namespace=namespace,
@@ -46,9 +46,9 @@ class SyncClient:
         pipette_name: PipetteName,
         mount: MountType,
     ) -> commands.LoadPipetteResult:
-        """Execute a LoadPipetteRequest and return the result."""
-        request = commands.LoadPipetteRequest(
-            data=commands.LoadPipetteData(
+        """Execute a LoadPipetteCreate and return the result."""
+        request = commands.LoadPipetteCreate(
+            params=commands.LoadPipetteParams(
                 pipetteName=pipette_name,
                 mount=mount,
             )
@@ -63,9 +63,9 @@ class SyncClient:
         labware_id: str,
         well_name: str,
     ) -> commands.PickUpTipResult:
-        """Execute a PickUpTipRequest and return the result."""
-        request = commands.PickUpTipRequest(
-            data=commands.PickUpTipData(
+        """Execute a PickUpTipCreate and return the result."""
+        request = commands.PickUpTipCreate(
+            params=commands.PickUpTipParams(
                 pipetteId=pipette_id,
                 labwareId=labware_id,
                 wellName=well_name,
@@ -81,9 +81,9 @@ class SyncClient:
         labware_id: str,
         well_name: str,
     ) -> commands.DropTipResult:
-        """Execute a DropTipRequest and return the result."""
-        request = commands.DropTipRequest(
-            data=commands.DropTipData(
+        """Execute a DropTipCreate and return the result."""
+        request = commands.DropTipCreate(
+            params=commands.DropTipParams(
                 pipetteId=pipette_id,
                 labwareId=labware_id,
                 wellName=well_name,
@@ -100,9 +100,9 @@ class SyncClient:
         well_location: WellLocation,
         volume: float,
     ) -> commands.AspirateResult:
-        """Execute an ``AspirateRequest``, returning the result."""
-        request = commands.AspirateRequest(
-            data=commands.AspirateData(
+        """Execute an ``AspirateCreate``, returning the result."""
+        request = commands.AspirateCreate(
+            params=commands.AspirateParams(
                 pipetteId=pipette_id,
                 labwareId=labware_id,
                 wellName=well_name,
@@ -122,9 +122,9 @@ class SyncClient:
         well_location: WellLocation,
         volume: float,
     ) -> commands.DispenseResult:
-        """Execute a ``DispenseRequest``, returning the result."""
-        request = commands.DispenseRequest(
-            data=commands.DispenseData(
+        """Execute a ``DispenseCreate``, returning the result."""
+        request = commands.DispenseCreate(
+            params=commands.DispenseParams(
                 pipetteId=pipette_id,
                 labwareId=labware_id,
                 wellName=well_name,
@@ -136,7 +136,7 @@ class SyncClient:
         return cast(commands.DispenseResult, result)
 
     def pause(self, message: Optional[str]) -> commands.PauseResult:
-        """Execute a ``PauseRequest``, returning the result."""
-        request = commands.PauseRequest(data=commands.PauseData(message=message))
+        """Execute a ``PauseCreate``, returning the result."""
+        request = commands.PauseCreate(params=commands.PauseParams(message=message))
         result = self._transport.execute_command(request=request)
         return cast(commands.PauseResult, result)

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -28,7 +28,7 @@ class SyncClient:
         namespace: str,
         version: int,
     ) -> commands.LoadLabwareResult:
-        """Execute a LoadLabwareCreate and return the result."""
+        """Execute a LoadLabware command and return the result."""
         request = commands.LoadLabwareCreate(
             params=commands.LoadLabwareParams(
                 location=location,
@@ -46,7 +46,7 @@ class SyncClient:
         pipette_name: PipetteName,
         mount: MountType,
     ) -> commands.LoadPipetteResult:
-        """Execute a LoadPipetteCreate and return the result."""
+        """Execute a LoadPipette command and return the result."""
         request = commands.LoadPipetteCreate(
             params=commands.LoadPipetteParams(
                 pipetteName=pipette_name,
@@ -63,7 +63,7 @@ class SyncClient:
         labware_id: str,
         well_name: str,
     ) -> commands.PickUpTipResult:
-        """Execute a PickUpTipCreate and return the result."""
+        """Execute a PickUpTip command and return the result."""
         request = commands.PickUpTipCreate(
             params=commands.PickUpTipParams(
                 pipetteId=pipette_id,
@@ -81,7 +81,7 @@ class SyncClient:
         labware_id: str,
         well_name: str,
     ) -> commands.DropTipResult:
-        """Execute a DropTipCreate and return the result."""
+        """Execute a DropTip command and return the result."""
         request = commands.DropTipCreate(
             params=commands.DropTipParams(
                 pipetteId=pipette_id,
@@ -100,7 +100,7 @@ class SyncClient:
         well_location: WellLocation,
         volume: float,
     ) -> commands.AspirateResult:
-        """Execute an ``AspirateCreate``, returning the result."""
+        """Execute an ``Aspirate`` command and return the result."""
         request = commands.AspirateCreate(
             params=commands.AspirateParams(
                 pipetteId=pipette_id,
@@ -122,7 +122,7 @@ class SyncClient:
         well_location: WellLocation,
         volume: float,
     ) -> commands.DispenseResult:
-        """Execute a ``DispenseCreate``, returning the result."""
+        """Execute a ``Dispense`` command and return the result."""
         request = commands.DispenseCreate(
             params=commands.DispenseParams(
                 pipetteId=pipette_id,
@@ -136,7 +136,7 @@ class SyncClient:
         return cast(commands.DispenseResult, result)
 
     def pause(self, message: Optional[str]) -> commands.PauseResult:
-        """Execute a ``PauseCreate``, returning the result."""
+        """Execute a ``Pause`` command and return the result."""
         request = commands.PauseCreate(params=commands.PauseParams(message=message))
         result = self._transport.execute_command(request=request)
         return cast(commands.PauseResult, result)

--- a/api/src/opentrons/protocol_engine/clients/transports.py
+++ b/api/src/opentrons/protocol_engine/clients/transports.py
@@ -5,7 +5,7 @@ from asyncio import AbstractEventLoop, run_coroutine_threadsafe
 from ..protocol_engine import ProtocolEngine
 from ..errors import ProtocolEngineError
 from ..state import StateView
-from ..commands import CommandRequest, CommandResult
+from ..commands import CommandCreate, CommandResult
 
 
 class AbstractSyncTransport(ABC):
@@ -18,7 +18,7 @@ class AbstractSyncTransport(ABC):
         ...
 
     @abstractmethod
-    def execute_command(self, request: CommandRequest) -> CommandResult:
+    def execute_command(self, request: CommandCreate) -> CommandResult:
         """Execute a ProtocolEngine command, blocking until the command completes.
 
         Args:
@@ -60,7 +60,7 @@ class ChildThreadTransport(AbstractSyncTransport):
         """Get a view of the Protocol Engine's state."""
         return self._engine.state_view
 
-    def execute_command(self, request: CommandRequest) -> CommandResult:
+    def execute_command(self, request: CommandCreate) -> CommandResult:
         """Execute a command synchronously on the main thread."""
         command = run_coroutine_threadsafe(
             self._engine.add_and_execute_command(request=request),

--- a/api/src/opentrons/protocol_engine/commands/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/__init__.py
@@ -13,92 +13,92 @@ they are part of the public input / output of the engine, and need validation
 and/or schema generation.
 """
 
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandRequest, CommandStatus
-from .command_unions import Command, CommandRequest, CommandResult, CommandType
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, CommandStatus
+from .command_unions import Command, CommandCreate, CommandResult, CommandType
 
 from .add_labware_definition import (
     AddLabwareDefinition,
-    AddLabwareDefinitionData,
-    AddLabwareDefinitionRequest,
+    AddLabwareDefinitionParams,
+    AddLabwareDefinitionCreate,
     AddLabwareDefinitionResult,
     AddLabwareDefinitionCommandType,
 )
 
 from .aspirate import (
     Aspirate,
-    AspirateData,
-    AspirateRequest,
+    AspirateParams,
+    AspirateCreate,
     AspirateResult,
     AspirateCommandType,
 )
 
 from .dispense import (
     Dispense,
-    DispenseData,
-    DispenseRequest,
+    DispenseParams,
+    DispenseCreate,
     DispenseResult,
     DispenseCommandType,
 )
 
 from .drop_tip import (
     DropTip,
-    DropTipData,
-    DropTipRequest,
+    DropTipParams,
+    DropTipCreate,
     DropTipResult,
     DropTipCommandType,
 )
 
 from .load_labware import (
     LoadLabware,
-    LoadLabwareData,
-    LoadLabwareRequest,
+    LoadLabwareParams,
+    LoadLabwareCreate,
     LoadLabwareResult,
     LoadLabwareCommandType,
 )
 
 from .load_pipette import (
     LoadPipette,
-    LoadPipetteData,
-    LoadPipetteRequest,
+    LoadPipetteParams,
+    LoadPipetteCreate,
     LoadPipetteResult,
     LoadPipetteCommandType,
 )
 
 from .move_to_well import (
     MoveToWell,
-    MoveToWellData,
-    MoveToWellRequest,
+    MoveToWellParams,
+    MoveToWellCreate,
     MoveToWellResult,
     MoveToWellCommandType,
 )
 
 from .pick_up_tip import (
     PickUpTip,
-    PickUpTipData,
-    PickUpTipRequest,
+    PickUpTipParams,
+    PickUpTipCreate,
     PickUpTipResult,
     PickUpTipCommandType,
 )
 
 from .pause import (
     Pause,
-    PauseData,
-    PauseRequest,
+    PauseParams,
+    PauseCreate,
     PauseResult,
     PauseCommandType,
 )
 
 from .save_position import (
     SavePosition,
-    SavePositionData,
-    SavePositionRequest,
+    SavePositionParams,
+    SavePositionCreate,
     SavePositionResult,
     SavePositionCommandType,
 )
 
 from .custom import (
     Custom,
-    CustomData,
+    CustomParams,
     CustomResult,
     CustomCommandType,
 )
@@ -107,77 +107,77 @@ from .custom import (
 __all__ = [
     # command type unions
     "Command",
-    "CommandRequest",
+    "CommandCreate",
     "CommandResult",
     "CommandType",
     # base interfaces
     "AbstractCommandImpl",
     "BaseCommand",
-    "BaseCommandRequest",
+    "BaseCommandCreate",
     "CommandStatus",
     # load labware command models
     "LoadLabware",
-    "LoadLabwareRequest",
-    "LoadLabwareData",
+    "LoadLabwareCreate",
+    "LoadLabwareParams",
     "LoadLabwareResult",
     "LoadLabwareCommandType",
     # add labware definition command models
     "AddLabwareDefinition",
-    "AddLabwareDefinitionRequest",
-    "AddLabwareDefinitionData",
+    "AddLabwareDefinitionCreate",
+    "AddLabwareDefinitionParams",
     "AddLabwareDefinitionResult",
     "AddLabwareDefinitionCommandType",
     # load pipette command models
     "LoadPipette",
-    "LoadPipetteRequest",
-    "LoadPipetteData",
+    "LoadPipetteCreate",
+    "LoadPipetteParams",
     "LoadPipetteResult",
     "LoadPipetteCommandType",
     # move to well command models
     "MoveToWell",
-    "MoveToWellRequest",
-    "MoveToWellData",
+    "MoveToWellCreate",
+    "MoveToWellParams",
     "MoveToWellResult",
     "MoveToWellCommandType",
     # pick up tip command models
     "PickUpTip",
-    "PickUpTipRequest",
-    "PickUpTipData",
+    "PickUpTipCreate",
+    "PickUpTipParams",
     "PickUpTipResult",
     "PickUpTipCommandType",
     # drop tip command models
     "DropTip",
-    "DropTipRequest",
-    "DropTipData",
+    "DropTipCreate",
+    "DropTipParams",
     "DropTipResult",
     "DropTipCommandType",
     # aspirate command models
     "Aspirate",
-    "AspirateRequest",
-    "AspirateData",
+    "AspirateCreate",
+    "AspirateParams",
     "AspirateResult",
     "AspirateCommandType",
     # dispense command models
     "Dispense",
-    "DispenseRequest",
-    "DispenseData",
+    "DispenseCreate",
+    "DispenseParams",
     "DispenseResult",
     "DispenseCommandType",
     # pause command models
     "Pause",
-    "PauseData",
-    "PauseRequest",
+    "PauseParams",
+    "PauseCreate",
     "PauseResult",
     "PauseCommandType",
     # save position command models
     "SavePosition",
-    "SavePositionData",
-    "SavePositionRequest",
+    "SavePositionParams",
+    "SavePositionCreate",
     "SavePositionResult",
     "SavePositionCommandType",
     # custom command models
     "Custom",
-    "CustomData",
+    "CustomParams",
     "CustomResult",
     "CustomCommandType",
 ]

--- a/api/src/opentrons/protocol_engine/commands/add_labware_definition.py
+++ b/api/src/opentrons/protocol_engine/commands/add_labware_definition.py
@@ -5,19 +5,19 @@ from typing import Optional, Type
 from typing_extensions import Literal
 
 from opentrons.protocols.models import LabwareDefinition
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandRequest
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 AddLabwareDefinitionCommandType = Literal["addLabwareDefinition"]
 
 
-class AddLabwareDefinitionData(BaseModel):
-    """Data required to add a labware definition."""
+class AddLabwareDefinitionParams(BaseModel):
+    """Parameters required to add a labware definition."""
 
     definition: LabwareDefinition = Field(..., description="The labware definition.")
 
 
 class AddLabwareDefinitionResult(BaseModel):
-    """Result of add labware request."""
+    """Result data from execution of an AddLabware command."""
 
     loadName: str = Field(
         ...,
@@ -34,28 +34,29 @@ class AddLabwareDefinitionResult(BaseModel):
 
 
 class AddLabwareDefinitionImplementation(
-    AbstractCommandImpl[AddLabwareDefinitionData, AddLabwareDefinitionResult]
+    AbstractCommandImpl[AddLabwareDefinitionParams, AddLabwareDefinitionResult]
 ):
     """Add labware command implementation."""
 
     async def execute(
-        self, data: AddLabwareDefinitionData
+        self,
+        params: AddLabwareDefinitionParams,
     ) -> AddLabwareDefinitionResult:
         """Execute the add labware definition request."""
         return AddLabwareDefinitionResult(
-            loadName=data.definition.parameters.loadName,
-            namespace=data.definition.namespace,
-            version=data.definition.version,
+            loadName=params.definition.parameters.loadName,
+            namespace=params.definition.namespace,
+            version=params.definition.version,
         )
 
 
 class AddLabwareDefinition(
-    BaseCommand[AddLabwareDefinitionData, AddLabwareDefinitionResult]
+    BaseCommand[AddLabwareDefinitionParams, AddLabwareDefinitionResult]
 ):
     """Add labware definition command resource."""
 
     commandType: AddLabwareDefinitionCommandType = "addLabwareDefinition"
-    data: AddLabwareDefinitionData
+    params: AddLabwareDefinitionParams
     result: Optional[AddLabwareDefinitionResult]
 
     _ImplementationCls: Type[
@@ -63,10 +64,10 @@ class AddLabwareDefinition(
     ] = AddLabwareDefinitionImplementation
 
 
-class AddLabwareDefinitionRequest(BaseCommandRequest[AddLabwareDefinitionData]):
+class AddLabwareDefinitionCreate(BaseCommandCreate[AddLabwareDefinitionParams]):
     """Add labware definition command creation request."""
 
     commandType: AddLabwareDefinitionCommandType = "addLabwareDefinition"
-    data: AddLabwareDefinitionData
+    params: AddLabwareDefinitionParams
 
     _CommandCls: Type[AddLabwareDefinition] = AddLabwareDefinition

--- a/api/src/opentrons/protocol_engine/commands/aspirate.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate.py
@@ -4,54 +4,54 @@ from typing import Optional, Type
 from typing_extensions import Literal
 
 
-from .pipetting_common import BaseLiquidHandlingData, BaseLiquidHandlingResult
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandRequest
+from .pipetting_common import BaseLiquidHandlingParams, BaseLiquidHandlingResult
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 AspirateCommandType = Literal["aspirate"]
 
 
-class AspirateData(BaseLiquidHandlingData):
-    """Data required to aspirate from a specific well."""
+class AspirateParams(BaseLiquidHandlingParams):
+    """Parameters required to aspirate from a specific well."""
 
     pass
 
 
 class AspirateResult(BaseLiquidHandlingResult):
-    """Result data from the execution of a AspirateRequest."""
+    """Result data from execution of an Aspirate command."""
 
     pass
 
 
-class AspirateImplementation(AbstractCommandImpl[AspirateData, AspirateResult]):
+class AspirateImplementation(AbstractCommandImpl[AspirateParams, AspirateResult]):
     """Aspirate command implementation."""
 
-    async def execute(self, data: AspirateData) -> AspirateResult:
+    async def execute(self, params: AspirateParams) -> AspirateResult:
         """Move to and aspirate from the requested well."""
         volume = await self._pipetting.aspirate(
-            pipette_id=data.pipetteId,
-            labware_id=data.labwareId,
-            well_name=data.wellName,
-            well_location=data.wellLocation,
-            volume=data.volume,
+            pipette_id=params.pipetteId,
+            labware_id=params.labwareId,
+            well_name=params.wellName,
+            well_location=params.wellLocation,
+            volume=params.volume,
         )
 
         return AspirateResult(volume=volume)
 
 
-class Aspirate(BaseCommand[AspirateData, AspirateResult]):
+class Aspirate(BaseCommand[AspirateParams, AspirateResult]):
     """Aspirate command model."""
 
     commandType: AspirateCommandType = "aspirate"
-    data: AspirateData
+    params: AspirateParams
     result: Optional[AspirateResult]
 
     _ImplementationCls: Type[AspirateImplementation] = AspirateImplementation
 
 
-class AspirateRequest(BaseCommandRequest[AspirateData]):
+class AspirateCreate(BaseCommandCreate[AspirateParams]):
     """Create aspirate command request model."""
 
     commandType: AspirateCommandType = "aspirate"
-    data: AspirateData
+    params: AspirateParams
 
     _CommandCls: Type[Aspirate] = Aspirate

--- a/api/src/opentrons/protocol_engine/commands/command.py
+++ b/api/src/opentrons/protocol_engine/commands/command.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Generic, Optional, TypeVar
 if TYPE_CHECKING:
     from opentrons.protocol_engine import execution
 
-CommandDataT = TypeVar("CommandDataT", bound=BaseModel)
+CommandParamsT = TypeVar("CommandParamsT", bound=BaseModel)
 
 CommandResultT = TypeVar("CommandResultT", bound=BaseModel)
 
@@ -25,7 +25,7 @@ class CommandStatus(str, Enum):
     FAILED = "failed"
 
 
-class BaseCommandRequest(GenericModel, Generic[CommandDataT]):
+class BaseCommandCreate(GenericModel, Generic[CommandParamsT]):
     """Base class for command creation requests.
 
     You shouldn't use this class directly; instead, use or define
@@ -39,10 +39,10 @@ class BaseCommandRequest(GenericModel, Generic[CommandDataT]):
             "execution behavior"
         ),
     )
-    data: CommandDataT = Field(..., description="Command execution data payload")
+    params: CommandParamsT = Field(..., description="Command execution data payload")
 
 
-class BaseCommand(GenericModel, Generic[CommandDataT, CommandResultT]):
+class BaseCommand(GenericModel, Generic[CommandParamsT, CommandResultT]):
     """Base command model.
 
     You shouldn't use this class directly; instead, use or define
@@ -59,7 +59,7 @@ class BaseCommand(GenericModel, Generic[CommandDataT, CommandResultT]):
         ),
     )
     status: CommandStatus = Field(..., description="Command execution status")
-    data: CommandDataT = Field(..., description="Command execution data payload")
+    params: CommandParamsT = Field(..., description="Command execution data payload")
     result: Optional[CommandResultT] = Field(
         None,
         description="Command execution result data, if succeeded",
@@ -81,7 +81,7 @@ class BaseCommand(GenericModel, Generic[CommandDataT, CommandResultT]):
 
 class AbstractCommandImpl(
     ABC,
-    Generic[CommandDataT, CommandResultT],
+    Generic[CommandParamsT, CommandResultT],
 ):
     """Abstract command creation and execution implementation.
 
@@ -106,6 +106,6 @@ class AbstractCommandImpl(
         self._run_control = run_control
 
     @abstractmethod
-    async def execute(self, data: CommandDataT) -> CommandResultT:
+    async def execute(self, params: CommandParamsT) -> CommandResultT:
         """Execute the command, mapping data from execution into a response model."""
         ...

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -4,62 +4,62 @@ from typing import Union
 
 from .add_labware_definition import (
     AddLabwareDefinition,
-    AddLabwareDefinitionRequest,
+    AddLabwareDefinitionCreate,
     AddLabwareDefinitionResult,
     AddLabwareDefinitionCommandType,
 )
 
-from .aspirate import Aspirate, AspirateRequest, AspirateResult, AspirateCommandType
+from .aspirate import Aspirate, AspirateCreate, AspirateResult, AspirateCommandType
 
-from .dispense import Dispense, DispenseRequest, DispenseResult, DispenseCommandType
+from .dispense import Dispense, DispenseCreate, DispenseResult, DispenseCommandType
 
-from .drop_tip import DropTip, DropTipRequest, DropTipResult, DropTipCommandType
+from .drop_tip import DropTip, DropTipCreate, DropTipResult, DropTipCommandType
 
 from .load_labware import (
     LoadLabware,
-    LoadLabwareRequest,
+    LoadLabwareCreate,
     LoadLabwareResult,
     LoadLabwareCommandType,
 )
 
 from .load_module import (
     LoadModule,
-    LoadModuleRequest,
+    LoadModuleCreate,
     LoadModuleResult,
     LoadModuleCommandType,
 )
 
 from .load_pipette import (
     LoadPipette,
-    LoadPipetteRequest,
+    LoadPipetteCreate,
     LoadPipetteResult,
     LoadPipetteCommandType,
 )
 
 from .move_to_well import (
     MoveToWell,
-    MoveToWellRequest,
+    MoveToWellCreate,
     MoveToWellResult,
     MoveToWellCommandType,
 )
 
 from .pick_up_tip import (
     PickUpTip,
-    PickUpTipRequest,
+    PickUpTipCreate,
     PickUpTipResult,
     PickUpTipCommandType,
 )
 
 from .pause import (
     Pause,
-    PauseRequest,
+    PauseCreate,
     PauseResult,
     PauseCommandType,
 )
 
 from .save_position import (
     SavePosition,
-    SavePositionRequest,
+    SavePositionCreate,
     SavePositionResult,
     SavePositionCommandType,
 )
@@ -100,18 +100,18 @@ CommandType = Union[
     CustomCommandType,
 ]
 
-CommandRequest = Union[
-    AddLabwareDefinitionRequest,
-    AspirateRequest,
-    DispenseRequest,
-    DropTipRequest,
-    LoadLabwareRequest,
-    LoadModuleRequest,
-    LoadPipetteRequest,
-    MoveToWellRequest,
-    PickUpTipRequest,
-    PauseRequest,
-    SavePositionRequest,
+CommandCreate = Union[
+    AddLabwareDefinitionCreate,
+    AspirateCreate,
+    DispenseCreate,
+    DropTipCreate,
+    LoadLabwareCreate,
+    LoadModuleCreate,
+    LoadPipetteCreate,
+    MoveToWellCreate,
+    PickUpTipCreate,
+    PauseCreate,
+    SavePositionCreate,
 ]
 
 CommandResult = Union[

--- a/api/src/opentrons/protocol_engine/commands/custom.py
+++ b/api/src/opentrons/protocol_engine/commands/custom.py
@@ -19,7 +19,7 @@ from .command import BaseCommand, AbstractCommandImpl
 CustomCommandType = Literal["custom"]
 
 
-class CustomData(BaseModel):
+class CustomParams(BaseModel):
     """Payload used by a custom command."""
 
     class Config:
@@ -37,21 +37,21 @@ class CustomResult(BaseModel):
         extra = Extra.allow
 
 
-class CustomImplementation(AbstractCommandImpl[CustomData, CustomResult]):
+class CustomImplementation(AbstractCommandImpl[CustomParams, CustomResult]):
     """Aspirate command implementation."""
 
     # TODO(mc, 2021-09-24): figure out how a plugin can specify a custom command
     # implementation. For now, raise so we remember not to allow this to happen.
-    async def execute(self, data: CustomData) -> CustomResult:
+    async def execute(self, params: CustomParams) -> CustomResult:
         """A custom command cannot be executed directly."""
         raise NotImplementedError("Custom commands cannot be executed directly.")
 
 
-class Custom(BaseCommand[CustomData, CustomResult]):
+class Custom(BaseCommand[CustomParams, CustomResult]):
     """Custom command model."""
 
     commandType: CustomCommandType = "custom"
-    data: CustomData
+    params: CustomParams
     result: Optional[CustomResult]
 
     _ImplementationCls: Type[CustomImplementation] = CustomImplementation

--- a/api/src/opentrons/protocol_engine/commands/dispense.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense.py
@@ -3,55 +3,55 @@ from __future__ import annotations
 from typing import Optional, Type
 from typing_extensions import Literal
 
-from .pipetting_common import BaseLiquidHandlingData, BaseLiquidHandlingResult
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandRequest
+from .pipetting_common import BaseLiquidHandlingParams, BaseLiquidHandlingResult
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 
 DispenseCommandType = Literal["dispense"]
 
 
-class DispenseData(BaseLiquidHandlingData):
-    """Data required to dispense to a specific well."""
+class DispenseParams(BaseLiquidHandlingParams):
+    """Payload required to dispense to a specific well."""
 
     pass
 
 
 class DispenseResult(BaseLiquidHandlingResult):
-    """Result data from the execution of a DispenseRequest."""
+    """Result data from the execution of a Dispense command."""
 
     pass
 
 
-class DispenseImplementation(AbstractCommandImpl[DispenseData, DispenseResult]):
+class DispenseImplementation(AbstractCommandImpl[DispenseParams, DispenseResult]):
     """Dispense command implementation."""
 
-    async def execute(self, data: DispenseData) -> DispenseResult:
+    async def execute(self, params: DispenseParams) -> DispenseResult:
         """Move to and dispense to the requested well."""
         volume = await self._pipetting.dispense(
-            pipette_id=data.pipetteId,
-            labware_id=data.labwareId,
-            well_name=data.wellName,
-            well_location=data.wellLocation,
-            volume=data.volume,
+            pipette_id=params.pipetteId,
+            labware_id=params.labwareId,
+            well_name=params.wellName,
+            well_location=params.wellLocation,
+            volume=params.volume,
         )
 
         return DispenseResult(volume=volume)
 
 
-class Dispense(BaseCommand[DispenseData, DispenseResult]):
+class Dispense(BaseCommand[DispenseParams, DispenseResult]):
     """Dispense command model."""
 
     commandType: DispenseCommandType = "dispense"
-    data: DispenseData
+    params: DispenseParams
     result: Optional[DispenseResult]
 
     _ImplementationCls: Type[DispenseImplementation] = DispenseImplementation
 
 
-class DispenseRequest(BaseCommandRequest[DispenseData]):
+class DispenseCreate(BaseCommandCreate[DispenseParams]):
     """Create dispense command request model."""
 
     commandType: DispenseCommandType = "dispense"
-    data: DispenseData
+    params: DispenseParams
 
     _CommandCls: Type[Dispense] = Dispense

--- a/api/src/opentrons/protocol_engine/commands/drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip.py
@@ -4,52 +4,52 @@ from pydantic import BaseModel
 from typing import Optional, Type
 from typing_extensions import Literal
 
-from .pipetting_common import BasePipettingData
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandRequest
+from .pipetting_common import BasePipettingParams
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 DropTipCommandType = Literal["dropTip"]
 
 
-class DropTipData(BasePipettingData):
-    """Data required to drop a tip in a specific well."""
+class DropTipParams(BasePipettingParams):
+    """Payload required to drop a tip in a specific well."""
 
     pass
 
 
 class DropTipResult(BaseModel):
-    """Result data from the execution of a DropTipRequest."""
+    """Result data from the execution of a DropTip command."""
 
     pass
 
 
-class DropTipImplementation(AbstractCommandImpl[DropTipData, DropTipResult]):
+class DropTipImplementation(AbstractCommandImpl[DropTipParams, DropTipResult]):
     """Drop tip command implementation."""
 
-    async def execute(self, data: DropTipData) -> DropTipResult:
+    async def execute(self, params: DropTipParams) -> DropTipResult:
         """Move to and drop a tip using the requested pipette."""
         await self._pipetting.drop_tip(
-            pipette_id=data.pipetteId,
-            labware_id=data.labwareId,
-            well_name=data.wellName,
+            pipette_id=params.pipetteId,
+            labware_id=params.labwareId,
+            well_name=params.wellName,
         )
 
         return DropTipResult()
 
 
-class DropTip(BaseCommand[DropTipData, DropTipResult]):
+class DropTip(BaseCommand[DropTipParams, DropTipResult]):
     """Drop tip command model."""
 
     commandType: DropTipCommandType = "dropTip"
-    data: DropTipData
+    params: DropTipParams
     result: Optional[DropTipResult]
 
     _ImplementationCls: Type[DropTipImplementation] = DropTipImplementation
 
 
-class DropTipRequest(BaseCommandRequest[DropTipData]):
+class DropTipCreate(BaseCommandCreate[DropTipParams]):
     """Drop tip command creation request model."""
 
     commandType: DropTipCommandType = "dropTip"
-    data: DropTipData
+    params: DropTipParams
 
     _CommandCls: Type[DropTip] = DropTip

--- a/api/src/opentrons/protocol_engine/commands/load_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/load_labware.py
@@ -7,13 +7,13 @@ from typing_extensions import Literal
 from opentrons.protocols.models import LabwareDefinition
 
 from ..types import LabwareLocation, CalibrationOffset
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandRequest
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 LoadLabwareCommandType = Literal["loadLabware"]
 
 
-class LoadLabwareData(BaseModel):
-    """Data required to load a labware into a slot."""
+class LoadLabwareParams(BaseModel):
+    """Payload required to load a labware into a slot."""
 
     location: LabwareLocation = Field(
         ...,
@@ -39,7 +39,7 @@ class LoadLabwareData(BaseModel):
 
 
 class LoadLabwareResult(BaseModel):
-    """Result data from the execution of a LoadLabwareRequest."""
+    """Result data from the execution of a LoadLabware command."""
 
     labwareId: str = Field(
         ...,
@@ -56,18 +56,18 @@ class LoadLabwareResult(BaseModel):
 
 
 class LoadLabwareImplementation(
-    AbstractCommandImpl[LoadLabwareData, LoadLabwareResult]
+    AbstractCommandImpl[LoadLabwareParams, LoadLabwareResult]
 ):
     """Load labware command implementation."""
 
-    async def execute(self, data: LoadLabwareData) -> LoadLabwareResult:
+    async def execute(self, params: LoadLabwareParams) -> LoadLabwareResult:
         """Load definition and calibration data necessary for a labware."""
         loaded_labware = await self._equipment.load_labware(
-            load_name=data.loadName,
-            namespace=data.namespace,
-            version=data.version,
-            location=data.location,
-            labware_id=data.labwareId,
+            load_name=params.loadName,
+            namespace=params.namespace,
+            version=params.version,
+            location=params.location,
+            labware_id=params.labwareId,
         )
         x_offset, y_offset, z_offset = loaded_labware.calibration
 
@@ -78,20 +78,20 @@ class LoadLabwareImplementation(
         )
 
 
-class LoadLabware(BaseCommand[LoadLabwareData, LoadLabwareResult]):
+class LoadLabware(BaseCommand[LoadLabwareParams, LoadLabwareResult]):
     """Load labware command resource model."""
 
     commandType: LoadLabwareCommandType = "loadLabware"
-    data: LoadLabwareData
+    params: LoadLabwareParams
     result: Optional[LoadLabwareResult]
 
     _ImplementationCls: Type[LoadLabwareImplementation] = LoadLabwareImplementation
 
 
-class LoadLabwareRequest(BaseCommandRequest[LoadLabwareData]):
+class LoadLabwareCreate(BaseCommandCreate[LoadLabwareParams]):
     """Load labware command creation request."""
 
     commandType: LoadLabwareCommandType = "loadLabware"
-    data: LoadLabwareData
+    params: LoadLabwareParams
 
     _CommandCls: Type[LoadLabware] = LoadLabware

--- a/api/src/opentrons/protocol_engine/commands/load_module.py
+++ b/api/src/opentrons/protocol_engine/commands/load_module.py
@@ -5,15 +5,15 @@ from typing_extensions import Literal
 
 from pydantic import BaseModel, Field
 
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandRequest
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 from ..types import DeckSlotLocation
 
 
 LoadModuleCommandType = Literal["loadModule"]
 
 
-class LoadModuleData(BaseModel):
-    """Data required to load a module."""
+class LoadModuleParams(BaseModel):
+    """Payload required to load a module."""
 
     # todo(mm, 2021-11-01): Use an enum instead of a str. shared-data defines the
     # possible model names.
@@ -60,28 +60,28 @@ class LoadModuleResult(BaseModel):
     )
 
 
-class LoadModuleImplementation(AbstractCommandImpl[LoadModuleData, LoadModuleResult]):
+class LoadModuleImplementation(AbstractCommandImpl[LoadModuleParams, LoadModuleResult]):
     """The implementation of the load module command."""
 
-    async def execute(self, data: LoadModuleData) -> LoadModuleResult:
+    async def execute(self, params: LoadModuleParams) -> LoadModuleResult:
         """Check that the requested module is attached and assign its identifier."""
-        raise NotImplementedError()
+        raise NotImplementedError("LoadModule command not yet implemented")
 
 
-class LoadModule(BaseCommand[LoadModuleData, LoadModuleResult]):
+class LoadModule(BaseCommand[LoadModuleParams, LoadModuleResult]):
     """The model for a load module command."""
 
     commandType: LoadModuleCommandType = "loadModule"
-    data: LoadModuleData
+    params: LoadModuleParams
     result: Optional[LoadModuleResult]
 
     _ImplementationCls: Type[LoadModuleImplementation] = LoadModuleImplementation
 
 
-class LoadModuleRequest(BaseCommandRequest[LoadModuleData]):
+class LoadModuleCreate(BaseCommandCreate[LoadModuleParams]):
     """The model for a creation request for a load module command."""
 
     commandType: LoadModuleCommandType = "loadModule"
-    data: LoadModuleData
+    params: LoadModuleParams
 
     _CommandCls: Type[LoadModule] = LoadModule

--- a/api/src/opentrons/protocol_engine/commands/load_pipette.py
+++ b/api/src/opentrons/protocol_engine/commands/load_pipette.py
@@ -7,13 +7,13 @@ from typing_extensions import Literal
 from opentrons.types import MountType
 
 from ..types import PipetteName
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandRequest
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 LoadPipetteCommandType = Literal["loadPipette"]
 
 
-class LoadPipetteData(BaseModel):
-    """Data needed to load a pipette on to a mount."""
+class LoadPipetteParams(BaseModel):
+    """Payload needed to load a pipette on to a mount."""
 
     pipetteName: PipetteName = Field(
         ...,
@@ -40,35 +40,35 @@ class LoadPipetteResult(BaseModel):
 
 
 class LoadPipetteImplementation(
-    AbstractCommandImpl[LoadPipetteData, LoadPipetteResult]
+    AbstractCommandImpl[LoadPipetteParams, LoadPipetteResult]
 ):
     """Load pipette command implementation."""
 
-    async def execute(self, data: LoadPipetteData) -> LoadPipetteResult:
+    async def execute(self, params: LoadPipetteParams) -> LoadPipetteResult:
         """Check that requested pipette is attached and assign its identifier."""
         loaded_pipette = await self._equipment.load_pipette(
-            pipette_name=data.pipetteName,
-            mount=data.mount,
-            pipette_id=data.pipetteId,
+            pipette_name=params.pipetteName,
+            mount=params.mount,
+            pipette_id=params.pipetteId,
         )
 
         return LoadPipetteResult(pipetteId=loaded_pipette.pipette_id)
 
 
-class LoadPipette(BaseCommand[LoadPipetteData, LoadPipetteResult]):
+class LoadPipette(BaseCommand[LoadPipetteParams, LoadPipetteResult]):
     """Load pipette command model."""
 
     commandType: LoadPipetteCommandType = "loadPipette"
-    data: LoadPipetteData
+    params: LoadPipetteParams
     result: Optional[LoadPipetteResult]
 
     _ImplementationCls: Type[LoadPipetteImplementation] = LoadPipetteImplementation
 
 
-class LoadPipetteRequest(BaseCommandRequest[LoadPipetteData]):
+class LoadPipetteCreate(BaseCommandCreate[LoadPipetteParams]):
     """Load pipette command creation request model."""
 
     commandType: LoadPipetteCommandType = "loadPipette"
-    data: LoadPipetteData
+    params: LoadPipetteParams
 
     _CommandCls: Type[LoadPipette] = LoadPipette

--- a/api/src/opentrons/protocol_engine/commands/move_to_well.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_well.py
@@ -4,15 +4,15 @@ from pydantic import BaseModel
 from typing import Optional, Type
 from typing_extensions import Literal
 
-from .pipetting_common import BasePipettingData
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandRequest
+from .pipetting_common import BasePipettingParams
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 
 MoveToWellCommandType = Literal["moveToWell"]
 
 
-class MoveToWellData(BasePipettingData):
-    """Data required to move a pipette to a specific well."""
+class MoveToWellParams(BasePipettingParams):
+    """Payload required to move a pipette to a specific well."""
 
     pass
 
@@ -23,34 +23,34 @@ class MoveToWellResult(BaseModel):
     pass
 
 
-class MoveToWellImplementation(AbstractCommandImpl[MoveToWellData, MoveToWellResult]):
+class MoveToWellImplementation(AbstractCommandImpl[MoveToWellParams, MoveToWellResult]):
     """Move to well command implementation."""
 
-    async def execute(self, data: MoveToWellData) -> MoveToWellResult:
+    async def execute(self, params: MoveToWellParams) -> MoveToWellResult:
         """Move the requested pipette to the requested well."""
         await self._movement.move_to_well(
-            pipette_id=data.pipetteId,
-            labware_id=data.labwareId,
-            well_name=data.wellName,
+            pipette_id=params.pipetteId,
+            labware_id=params.labwareId,
+            well_name=params.wellName,
         )
 
         return MoveToWellResult()
 
 
-class MoveToWell(BaseCommand[MoveToWellData, MoveToWellResult]):
+class MoveToWell(BaseCommand[MoveToWellParams, MoveToWellResult]):
     """Move to well command model."""
 
     commandType: MoveToWellCommandType = "moveToWell"
-    data: MoveToWellData
+    params: MoveToWellParams
     result: Optional[MoveToWellResult]
 
     _ImplementationCls: Type[MoveToWellImplementation] = MoveToWellImplementation
 
 
-class MoveToWellRequest(BaseCommandRequest[MoveToWellData]):
+class MoveToWellCreate(BaseCommandCreate[MoveToWellParams]):
     """Move to well command creation request model."""
 
     commandType: MoveToWellCommandType = "moveToWell"
-    data: MoveToWellData
+    params: MoveToWellParams
 
     _CommandCls: Type[MoveToWell] = MoveToWell

--- a/api/src/opentrons/protocol_engine/commands/pause.py
+++ b/api/src/opentrons/protocol_engine/commands/pause.py
@@ -4,14 +4,14 @@ from pydantic import BaseModel, Field
 from typing import Optional, Type
 from typing_extensions import Literal
 
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandRequest
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 
 PauseCommandType = Literal["pause"]
 
 
-class PauseData(BaseModel):
-    """Data required to pause the protocol."""
+class PauseParams(BaseModel):
+    """Payload required to pause the protocol."""
 
     message: Optional[str] = Field(
         None,
@@ -25,29 +25,29 @@ class PauseResult(BaseModel):
     pass
 
 
-class PauseImplementation(AbstractCommandImpl[PauseData, PauseResult]):
+class PauseImplementation(AbstractCommandImpl[PauseParams, PauseResult]):
     """Pause command implementation."""
 
-    async def execute(self, data: PauseData) -> PauseResult:
+    async def execute(self, params: PauseParams) -> PauseResult:
         """Dispatch a PauseAction to the store to pause the protocol."""
         await self._run_control.pause()
         return PauseResult()
 
 
-class Pause(BaseCommand[PauseData, PauseResult]):
+class Pause(BaseCommand[PauseParams, PauseResult]):
     """Pause command model."""
 
     commandType: PauseCommandType = "pause"
-    data: PauseData
+    params: PauseParams
     result: Optional[PauseResult]
 
     _ImplementationCls: Type[PauseImplementation] = PauseImplementation
 
 
-class PauseRequest(BaseCommandRequest[PauseData]):
+class PauseCreate(BaseCommandCreate[PauseParams]):
     """Pause command request model."""
 
     commandType: PauseCommandType = "pause"
-    data: PauseData
+    params: PauseParams
 
     _CommandCls: Type[Pause] = Pause

--- a/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
@@ -4,15 +4,15 @@ from pydantic import BaseModel
 from typing import Optional, Type
 from typing_extensions import Literal
 
-from .pipetting_common import BasePipettingData
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandRequest
+from .pipetting_common import BasePipettingParams
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 
 PickUpTipCommandType = Literal["pickUpTip"]
 
 
-class PickUpTipData(BasePipettingData):
-    """Data needed to move a pipette to a specific well."""
+class PickUpTipParams(BasePipettingParams):
+    """Payload needed to move a pipette to a specific well."""
 
     pass
 
@@ -23,34 +23,34 @@ class PickUpTipResult(BaseModel):
     pass
 
 
-class PickUpTipImplementation(AbstractCommandImpl[PickUpTipData, PickUpTipResult]):
+class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, PickUpTipResult]):
     """Pick up tip command implementation."""
 
-    async def execute(self, data: PickUpTipData) -> PickUpTipResult:
+    async def execute(self, params: PickUpTipParams) -> PickUpTipResult:
         """Move to and pick up a tip using the requested pipette."""
         await self._pipetting.pick_up_tip(
-            pipette_id=data.pipetteId,
-            labware_id=data.labwareId,
-            well_name=data.wellName,
+            pipette_id=params.pipetteId,
+            labware_id=params.labwareId,
+            well_name=params.wellName,
         )
 
         return PickUpTipResult()
 
 
-class PickUpTip(BaseCommand[PickUpTipData, PickUpTipResult]):
+class PickUpTip(BaseCommand[PickUpTipParams, PickUpTipResult]):
     """Pick up tip command model."""
 
     commandType: PickUpTipCommandType = "pickUpTip"
-    data: PickUpTipData
+    params: PickUpTipParams
     result: Optional[PickUpTipResult]
 
     _ImplementationCls: Type[PickUpTipImplementation] = PickUpTipImplementation
 
 
-class PickUpTipRequest(BaseCommandRequest[PickUpTipData]):
+class PickUpTipCreate(BaseCommandCreate[PickUpTipParams]):
     """Pick up tip command creation request model."""
 
     commandType: PickUpTipCommandType = "pickUpTip"
-    data: PickUpTipData
+    params: PickUpTipParams
 
     _CommandCls: Type[PickUpTip] = PickUpTip

--- a/api/src/opentrons/protocol_engine/commands/pipetting_common.py
+++ b/api/src/opentrons/protocol_engine/commands/pipetting_common.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, Field
 from ..types import WellLocation
 
 
-class BasePipettingData(BaseModel):
+class BasePipettingParams(BaseModel):
     """Base class for data payloads of commands that interact with wells."""
 
     pipetteId: str = Field(
@@ -21,7 +21,7 @@ class BasePipettingData(BaseModel):
     )
 
 
-class BaseLiquidHandlingData(BasePipettingData):
+class BaseLiquidHandlingParams(BasePipettingParams):
     """Base class for data payloads of commands that handle liquid."""
 
     volume: float = Field(

--- a/api/src/opentrons/protocol_engine/commands/save_position.py
+++ b/api/src/opentrons/protocol_engine/commands/save_position.py
@@ -6,13 +6,13 @@ from typing import Optional, Type
 from typing_extensions import Literal
 
 from ..types import DeckPoint
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandRequest
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 SavePositionCommandType = Literal["savePosition"]
 
 
-class SavePositionData(BaseModel):
-    """Data needed to save a pipette's current position."""
+class SavePositionParams(BaseModel):
+    """Payload needed to save a pipette's current position."""
 
     pipetteId: str = Field(
         ..., description="Unique identifier of the pipette in question."
@@ -38,34 +38,36 @@ class SavePositionResult(BaseModel):
 
 
 class SavePositionImplementation(
-    AbstractCommandImpl[SavePositionData, SavePositionResult]
+    AbstractCommandImpl[SavePositionParams, SavePositionResult]
 ):
     """Save position command implementation."""
 
-    async def execute(self, data: SavePositionData) -> SavePositionResult:
+    async def execute(self, params: SavePositionParams) -> SavePositionResult:
         """Check the requested pipette's current position."""
         result = await self._movement.save_position(
-            pipette_id=data.pipetteId, position_id=data.positionId
+            pipette_id=params.pipetteId,
+            position_id=params.positionId,
         )
         return SavePositionResult(
-            positionId=result.positionId, position=result.position
+            positionId=result.positionId,
+            position=result.position,
         )
 
 
-class SavePosition(BaseCommand[SavePositionData, SavePositionResult]):
+class SavePosition(BaseCommand[SavePositionParams, SavePositionResult]):
     """Save Position command model."""
 
     commandType: SavePositionCommandType = "savePosition"
-    data: SavePositionData
+    params: SavePositionParams
     result: Optional[SavePositionResult]
 
     _ImplementationCls: Type[SavePositionImplementation] = SavePositionImplementation
 
 
-class SavePositionRequest(BaseCommandRequest[SavePositionData]):
+class SavePositionCreate(BaseCommandCreate[SavePositionParams]):
     """Save position command creation request model."""
 
     commandType: SavePositionCommandType = "savePosition"
-    data: SavePositionData
+    params: SavePositionParams
 
     _CommandCls: Type[SavePosition] = SavePosition

--- a/api/src/opentrons/protocol_engine/errors/__init__.py
+++ b/api/src/opentrons/protocol_engine/errors/__init__.py
@@ -22,7 +22,7 @@ class UnexpectedProtocolError(ProtocolEngineError):
 
 
 class FailedToLoadPipetteError(ProtocolEngineError):
-    """An error raised when executing a LoadPipetteCreate fails.
+    """An error raised when executing a LoadPipette command fails.
 
     This failure may be caused by:
     - An incorrect pipette already attached to the mount

--- a/api/src/opentrons/protocol_engine/errors/__init__.py
+++ b/api/src/opentrons/protocol_engine/errors/__init__.py
@@ -22,7 +22,7 @@ class UnexpectedProtocolError(ProtocolEngineError):
 
 
 class FailedToLoadPipetteError(ProtocolEngineError):
-    """An error raised when executing a LoadPipetteRequest fails.
+    """An error raised when executing a LoadPipetteCreate fails.
 
     This failure may be caused by:
     - An incorrect pipette already attached to the mount

--- a/api/src/opentrons/protocol_engine/execution/command_executor.py
+++ b/api/src/opentrons/protocol_engine/execution/command_executor.py
@@ -68,8 +68,10 @@ class CommandExecutor:
         result = None
         error = None
         try:
-            log.debug(f"Executing {command.id}, {command.commandType}, {command.data}")
-            result = await command_impl.execute(command.data)  # type: ignore[arg-type]
+            log.debug(
+                f"Executing {command.id}, {command.commandType}, {command.params}"
+            )
+            result = await command_impl.execute(command.params)  # type: ignore[arg-type]  # noqa: E501
             completed_status = CommandStatus.SUCCEEDED
         except Exception as e:
             log.warn(

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -3,7 +3,7 @@ from typing import Optional
 from opentrons.hardware_control import API as HardwareAPI
 
 from .resources import ModelUtils
-from .commands import Command, CommandRequest
+from .commands import Command, CommandCreate
 from .execution import QueueWorker, create_queue_worker
 from .state import StateStore, StateView
 from .plugins import AbstractPlugin
@@ -79,7 +79,7 @@ class ProtocolEngine:
         self._state_store.commands.validate_action_allowed(action)
         self._action_dispatcher.dispatch(action)
 
-    def add_command(self, request: CommandRequest) -> Command:
+    def add_command(self, request: CommandCreate) -> Command:
         """Add a command to the `ProtocolEngine`'s queue.
 
         Arguments:
@@ -99,7 +99,7 @@ class ProtocolEngine:
 
         return self._state_store.commands.get(command_id)
 
-    async def add_and_execute_command(self, request: CommandRequest) -> Command:
+    async def add_and_execute_command(self, request: CommandCreate) -> Command:
         """Add a command to the queue and wait for it to complete.
 
         The engine must be started by calling `play` before the command will

--- a/api/src/opentrons/protocol_engine/resources/deck_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/deck_data_provider.py
@@ -53,7 +53,7 @@ class DeckDataProvider:
             slot = cast(Optional[str], fixture.get("slot"))
 
             if load_name is not None and slot is not None:
-                location = DeckSlotLocation(slot=DeckSlotName.from_primitive(slot))
+                location = DeckSlotLocation(slotName=DeckSlotName.from_primitive(slot))
                 definition = await self._labware_data.get_labware_definition(
                     load_name=load_name,
                     namespace="opentrons",

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -52,7 +52,7 @@ class CommandStore(HasState[CommandState], HandlesActions):
             queued_command = action.request._CommandCls(
                 id=action.command_id,
                 createdAt=action.created_at,
-                data=action.request.data,  # type: ignore[arg-type]
+                params=action.request.params,  # type: ignore[arg-type]
                 status=CommandStatus.QUEUED,
             )
             commands_by_id = self._state.commands_by_id.copy()

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -54,14 +54,14 @@ class GeometryView:
     def get_labware_parent_position(self, labware_id: str) -> Point:
         """Get the position of the labware's parent slot (deck or module)."""
         labware_data = self._labware.get(labware_id)
-        slot_pos = self._labware.get_slot_position(labware_data.location.slot)
+        slot_pos = self._labware.get_slot_position(labware_data.location.slotName)
 
         return slot_pos
 
     def get_labware_origin_position(self, labware_id: str) -> Point:
         """Get the position of the labware's origin, without calibration."""
         labware_data = self._labware.get(labware_id)
-        slot_pos = self._labware.get_slot_position(labware_data.location.slot)
+        slot_pos = self._labware.get_slot_position(labware_data.location.slotName)
         origin_offset = self._labware.get_definition(labware_id).cornerOffsetFromSlot
 
         return Point(

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -98,7 +98,7 @@ class LabwareStore(HasState[LabwareState], HandlesActions):
             calibrations_by_id[labware_id] = command.result.calibration
             labware_by_id[labware_id] = LoadedLabware(
                 id=labware_id,
-                location=command.data.location,
+                location=command.params.location,
                 loadName=command.result.definition.parameters.loadName,
                 definitionUri=definition_uri,
             )
@@ -117,7 +117,7 @@ class LabwareStore(HasState[LabwareState], HandlesActions):
                 version=command.result.version,
             )
             definitions_by_uri = self._state.definitions_by_uri.copy()
-            definitions_by_uri[definition_uri] = command.data.definition
+            definitions_by_uri[definition_uri] = command.params.definition
             self._state = replace(self._state, definitions_by_uri=definitions_by_uri)
 
 

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -80,9 +80,9 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             self._state = replace(
                 self._state,
                 current_well=CurrentWell(
-                    pipette_id=command.data.pipetteId,
-                    labware_id=command.data.labwareId,
-                    well_name=command.data.wellName,
+                    pipette_id=command.params.pipetteId,
+                    labware_id=command.params.labwareId,
+                    well_name=command.params.wellName,
                 ),
             )
 
@@ -93,8 +93,8 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
 
             pipettes_by_id[pipette_id] = LoadedPipette(
                 id=pipette_id,
-                pipetteName=command.data.pipetteName,
-                mount=command.data.mount,
+                pipetteName=command.params.pipetteName,
+                mount=command.params.mount,
             )
             aspirated_volume_by_id[pipette_id] = 0
 
@@ -105,7 +105,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             )
 
         elif isinstance(command.result, AspirateResult):
-            pipette_id = command.data.pipetteId
+            pipette_id = command.params.pipetteId
             aspirated_volume_by_id = self._state.aspirated_volume_by_id.copy()
 
             previous_volume = self._state.aspirated_volume_by_id[pipette_id]
@@ -118,7 +118,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             )
 
         elif isinstance(command.result, DispenseResult):
-            pipette_id = command.data.pipetteId
+            pipette_id = command.params.pipetteId
             aspirated_volume_by_id = self._state.aspirated_volume_by_id.copy()
 
             previous_volume = self._state.aspirated_volume_by_id[pipette_id]

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -23,7 +23,7 @@ class EngineStatus(str, Enum):
 class DeckSlotLocation(BaseModel):
     """The location of something placed in a single deck slot."""
 
-    slot: DeckSlotName
+    slotName: DeckSlotName
 
 
 LabwareLocation = Union[DeckSlotLocation]
@@ -62,7 +62,7 @@ class Dimensions:
 
 
 class CalibrationOffset(BaseModel):
-    """Calibration offset from nomimal to actual position."""
+    """Calibration offset from nominal to actual position."""
 
     x: float
     y: float

--- a/api/src/opentrons/protocol_runner/json_command_translator.py
+++ b/api/src/opentrons/protocol_runner/json_command_translator.py
@@ -189,8 +189,8 @@ class JsonCommandTranslator:
         if command.params.wait is not True:
             raise NotImplementedError("Delay translation not yet implemented.")
 
-        data = pe_commands.PauseParams(message=command.params.message)
-        return pe_commands.PauseCreate(params=data)
+        params = pe_commands.PauseParams(message=command.params.message)
+        return pe_commands.PauseCreate(params=params)
 
     def _magnetic_module_engage(
         self,

--- a/api/src/opentrons/protocol_runner/json_command_translator.py
+++ b/api/src/opentrons/protocol_runner/json_command_translator.py
@@ -25,9 +25,9 @@ class JsonCommandTranslator:
     def translate(
         self,
         protocol: models.JsonProtocol,
-    ) -> List[pe_commands.CommandRequest]:
+    ) -> List[pe_commands.CommandCreate]:
         """Return all Protocol Engine commands required to run the given protocol."""
-        result: List[pe_commands.CommandRequest] = []
+        result: List[pe_commands.CommandCreate] = []
 
         for pipette_id, pipette in protocol.pipettes.items():
             result.append(self._translate_load_pipette(pipette_id, pipette))
@@ -50,10 +50,10 @@ class JsonCommandTranslator:
     def _translate_command(
         self,
         command: models.json_protocol.AllCommands,
-    ) -> pe_commands.CommandRequest:
+    ) -> pe_commands.CommandCreate:
         try:
             h = self._COMMAND_TO_NAME[command.command]
-            return cast(pe_commands.CommandRequest, getattr(self, h)(command))
+            return cast(pe_commands.CommandCreate, getattr(self, h)(command))
         except KeyError:
             raise CommandTranslatorError(f"'{command.command}' is not recognized.")
         except AttributeError:
@@ -63,9 +63,9 @@ class JsonCommandTranslator:
 
     def _translate_add_labware_definition(
         self, labware_definition: models.LabwareDefinition
-    ) -> pe_commands.AddLabwareDefinitionRequest:
-        return pe_commands.AddLabwareDefinitionRequest(
-            data=pe_commands.AddLabwareDefinitionData(definition=labware_definition)
+    ) -> pe_commands.AddLabwareDefinitionCreate:
+        return pe_commands.AddLabwareDefinitionCreate(
+            params=pe_commands.AddLabwareDefinitionParams(definition=labware_definition)
         )
 
     def _translate_load_labware(
@@ -73,7 +73,7 @@ class JsonCommandTranslator:
         labware_id: str,
         labware: models.json_protocol.Labware,
         labware_definitions: Dict[str, models.LabwareDefinition],
-    ) -> pe_commands.LoadLabwareRequest:
+    ) -> pe_commands.LoadLabwareCreate:
         """Translate a JSON labware data into a LoadLabware command.
 
         Args:
@@ -84,8 +84,8 @@ class JsonCommandTranslator:
             labware_definitions: The JSON protocol's collection of labware definitions.
         """
         definition = labware_definitions[labware.definitionId]
-        return pe_commands.LoadLabwareRequest(
-            data=pe_commands.LoadLabwareData(
+        return pe_commands.LoadLabwareCreate(
+            params=pe_commands.LoadLabwareParams(
                 location=DeckSlotLocation(
                     slot=DeckSlotName.from_primitive(labware.slot)
                 ),
@@ -100,9 +100,9 @@ class JsonCommandTranslator:
         self,
         pipette_id: str,
         pipette: models.json_protocol.Pipettes,
-    ) -> pe_commands.LoadPipetteRequest:
-        return pe_commands.LoadPipetteRequest(
-            data=pe_commands.LoadPipetteData(
+    ) -> pe_commands.LoadPipetteCreate:
+        return pe_commands.LoadPipetteCreate(
+            params=pe_commands.LoadPipetteParams(
                 pipetteName=PipetteName(pipette.name),
                 mount=MountType(pipette.mount),
                 pipetteId=pipette_id,
@@ -112,9 +112,9 @@ class JsonCommandTranslator:
     def _aspirate(
         self,
         command: models.json_protocol.LiquidCommand,
-    ) -> pe_commands.AspirateRequest:
-        return pe_commands.AspirateRequest(
-            data=pe_commands.AspirateData(
+    ) -> pe_commands.AspirateCreate:
+        return pe_commands.AspirateCreate(
+            params=pe_commands.AspirateParams(
                 pipetteId=command.params.pipette,
                 labwareId=command.params.labware,
                 wellName=command.params.well,
@@ -129,9 +129,9 @@ class JsonCommandTranslator:
     def _dispense(
         self,
         command: models.json_protocol.LiquidCommand,
-    ) -> pe_commands.DispenseRequest:
-        return pe_commands.DispenseRequest(
-            data=pe_commands.DispenseData(
+    ) -> pe_commands.DispenseCreate:
+        return pe_commands.DispenseCreate(
+            params=pe_commands.DispenseParams(
                 pipetteId=command.params.pipette,
                 labwareId=command.params.labware,
                 wellName=command.params.well,
@@ -155,9 +155,9 @@ class JsonCommandTranslator:
     def _pick_up(
         self,
         command: models.json_protocol.PickUpDropTipCommand,
-    ) -> pe_commands.PickUpTipRequest:
-        return pe_commands.PickUpTipRequest(
-            data=pe_commands.PickUpTipData(
+    ) -> pe_commands.PickUpTipCreate:
+        return pe_commands.PickUpTipCreate(
+            params=pe_commands.PickUpTipParams(
                 pipetteId=command.params.pipette,
                 labwareId=command.params.labware,
                 wellName=command.params.well,
@@ -167,9 +167,9 @@ class JsonCommandTranslator:
     def _drop_tip(
         self,
         command: models.json_protocol.PickUpDropTipCommand,
-    ) -> pe_commands.DropTipRequest:
-        return pe_commands.DropTipRequest(
-            data=pe_commands.DropTipData(
+    ) -> pe_commands.DropTipCreate:
+        return pe_commands.DropTipCreate(
+            params=pe_commands.DropTipParams(
                 pipetteId=command.params.pipette,
                 labwareId=command.params.labware,
                 wellName=command.params.well,
@@ -185,12 +185,12 @@ class JsonCommandTranslator:
     def _delay(
         self,
         command: models.json_protocol.DelayCommand,
-    ) -> pe_commands.PauseRequest:
+    ) -> pe_commands.PauseCreate:
         if command.params.wait is not True:
             raise NotImplementedError("Delay translation not yet implemented.")
 
-        data = pe_commands.PauseData(message=command.params.message)
-        return pe_commands.PauseRequest(data=data)
+        data = pe_commands.PauseParams(message=command.params.message)
+        return pe_commands.PauseCreate(params=data)
 
     def _magnetic_module_engage(
         self,

--- a/api/src/opentrons/protocol_runner/json_command_translator.py
+++ b/api/src/opentrons/protocol_runner/json_command_translator.py
@@ -87,7 +87,7 @@ class JsonCommandTranslator:
         return pe_commands.LoadLabwareCreate(
             params=pe_commands.LoadLabwareParams(
                 location=DeckSlotLocation(
-                    slot=DeckSlotName.from_primitive(labware.slot)
+                    slotName=DeckSlotName.from_primitive(labware.slot)
                 ),
                 loadName=definition.parameters.loadName,
                 namespace=definition.namespace,

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -15,7 +15,7 @@ from .legacy_wrappers import (
 )
 
 
-class LegacyCommandData(pe_commands.CustomData):
+class LegacyCommandData(pe_commands.CustomParams):
     """Custom command data payload for mapped legacy commands."""
 
     legacyCommandType: str
@@ -61,7 +61,7 @@ class LegacyCommandMapper:
                 status=pe_commands.CommandStatus.RUNNING,
                 createdAt=now,
                 startedAt=now,
-                data=LegacyCommandData(
+                params=LegacyCommandData(
                     legacyCommandType=command_type,
                     legacyCommandText=command_text,
                 ),
@@ -104,7 +104,7 @@ class LegacyCommandMapper:
             createdAt=now,
             startedAt=now,
             completedAt=now,
-            data=pe_commands.LoadLabwareData(
+            params=pe_commands.LoadLabwareParams(
                 location=pe_types.DeckSlotLocation(slot=labware_load_info.deck_slot),
                 loadName=labware_load_info.labware_load_name,
                 namespace=labware_load_info.labware_namespace,
@@ -137,7 +137,7 @@ class LegacyCommandMapper:
             createdAt=now,
             startedAt=now,
             completedAt=now,
-            data=pe_commands.LoadPipetteData(
+            params=pe_commands.LoadPipetteParams(
                 pipetteName=pe_types.PipetteName(
                     instrument_load_info.instrument_load_name
                 ),

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -15,7 +15,7 @@ from .legacy_wrappers import (
 )
 
 
-class LegacyCommandData(pe_commands.CustomParams):
+class LegacyCommandParams(pe_commands.CustomParams):
     """Custom command data payload for mapped legacy commands."""
 
     legacyCommandType: str
@@ -61,7 +61,7 @@ class LegacyCommandMapper:
                 status=pe_commands.CommandStatus.RUNNING,
                 createdAt=now,
                 startedAt=now,
-                params=LegacyCommandData(
+                params=LegacyCommandParams(
                     legacyCommandType=command_type,
                     legacyCommandText=command_text,
                 ),
@@ -105,7 +105,9 @@ class LegacyCommandMapper:
             startedAt=now,
             completedAt=now,
             params=pe_commands.LoadLabwareParams(
-                location=pe_types.DeckSlotLocation(slot=labware_load_info.deck_slot),
+                location=pe_types.DeckSlotLocation(
+                    slotName=labware_load_info.deck_slot
+                ),
                 loadName=labware_load_info.labware_load_name,
                 namespace=labware_load_info.labware_namespace,
                 version=labware_load_info.labware_version,

--- a/api/tests/opentrons/protocol_api_experimental/test_labware.py
+++ b/api/tests/opentrons/protocol_api_experimental/test_labware.py
@@ -67,7 +67,7 @@ def test_labware_deck_slot_parent(
     """It should return a deck slot name if labware is loaded on the deck."""
     decoy.when(
         engine_client.state.labware.get_location(labware_id="labware-id")
-    ).then_return(DeckSlotLocation(slot=DeckSlotName.SLOT_5))
+    ).then_return(DeckSlotLocation(slotName=DeckSlotName.SLOT_5))
 
     assert subject.parent == "5"
 

--- a/api/tests/opentrons/protocol_api_experimental/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/test_protocol_context.py
@@ -133,7 +133,7 @@ def test_load_labware(
     """It should use the engine to load a labware in a slot."""
     decoy.when(
         engine_client.load_labware(
-            location=DeckSlotLocation(slot=DeckSlotName.SLOT_5),
+            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_5),
             load_name="some_labware",
             namespace="opentrons",
             version=1,
@@ -165,7 +165,7 @@ def test_load_labware_default_namespace_and_version(
     """It should default namespace to "opentrons" and version to 1."""
     decoy.when(
         engine_client.load_labware(
-            location=DeckSlotLocation(slot=DeckSlotName.SLOT_5),
+            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_5),
             load_name="some_labware",
             namespace="opentrons",
             version=1,

--- a/api/tests/opentrons/protocol_engine/clients/test_child_thread_transport.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_child_thread_transport.py
@@ -34,19 +34,19 @@ async def test_execute_command(
     subject: ChildThreadTransport,
 ) -> None:
     """It should execute a command synchronously in a child thread."""
-    cmd_data = commands.MoveToWellData(
+    cmd_data = commands.MoveToWellParams(
         pipetteId="pipette-id",
         labwareId="labware-id",
         wellName="A1",
     )
     cmd_result = commands.MoveToWellResult()
-    cmd_request = commands.MoveToWellRequest(data=cmd_data)
+    cmd_request = commands.MoveToWellCreate(params=cmd_data)
 
     decoy.when(await engine.add_and_execute_command(request=cmd_request)).then_return(
         commands.MoveToWell(
             id="cmd-id",
             status=commands.CommandStatus.SUCCEEDED,
-            data=cmd_data,
+            params=cmd_data,
             result=cmd_result,
             createdAt=datetime.now(),
         )
@@ -65,17 +65,17 @@ async def test_execute_command_failure(
     subject: ChildThreadTransport,
 ) -> None:
     """It should execute a load labware command."""
-    cmd_data = commands.MoveToWellData(
+    cmd_data = commands.MoveToWellParams(
         pipetteId="pipette-id",
         labwareId="labware-id",
         wellName="A1",
     )
-    cmd_request = commands.MoveToWellRequest(data=cmd_data)
+    cmd_request = commands.MoveToWellCreate(params=cmd_data)
 
     decoy.when(await engine.add_and_execute_command(request=cmd_request)).then_return(
         commands.MoveToWell(
             id="cmd-id",
-            data=cmd_data,
+            params=cmd_data,
             status=commands.CommandStatus.FAILED,
             error="oh no",
             createdAt=datetime.now(),

--- a/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
@@ -44,7 +44,7 @@ def stubbed_load_labware_result(
     """Set up the protocol engine with default stubbed response for load labware."""
     request = commands.LoadLabwareCreate(
         params=commands.LoadLabwareParams(
-            location=DeckSlotLocation(slot=DeckSlotName.SLOT_5),
+            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_5),
             loadName="some_labware",
             namespace="opentrons",
             version=1,
@@ -69,7 +69,7 @@ def test_load_labware(
 ) -> None:
     """It should execute a load labware command."""
     result = subject.load_labware(
-        location=DeckSlotLocation(slot=DeckSlotName.SLOT_5),
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_5),
         load_name="some_labware",
         namespace="opentrons",
         version=1,

--- a/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
@@ -42,8 +42,8 @@ def stubbed_load_labware_result(
     tip_rack_def: LabwareDefinition,
 ) -> commands.LoadLabwareResult:
     """Set up the protocol engine with default stubbed response for load labware."""
-    request = commands.LoadLabwareRequest(
-        data=commands.LoadLabwareData(
+    request = commands.LoadLabwareCreate(
+        params=commands.LoadLabwareParams(
             location=DeckSlotLocation(slot=DeckSlotName.SLOT_5),
             loadName="some_labware",
             namespace="opentrons",
@@ -84,8 +84,8 @@ def test_load_pipette(
     subject: SyncClient,
 ) -> None:
     """It should execute a load pipette command and return its result."""
-    request = commands.LoadPipetteRequest(
-        data=commands.LoadPipetteData(
+    request = commands.LoadPipetteCreate(
+        params=commands.LoadPipetteParams(
             pipetteName=PipetteName.P300_SINGLE,
             mount=MountType.RIGHT,
         )
@@ -109,8 +109,8 @@ def test_pick_up_tip(
     subject: SyncClient,
 ) -> None:
     """It should execute a pick up tip command."""
-    request = commands.PickUpTipRequest(
-        data=commands.PickUpTipData(pipetteId="123", labwareId="456", wellName="A2")
+    request = commands.PickUpTipCreate(
+        params=commands.PickUpTipParams(pipetteId="123", labwareId="456", wellName="A2")
     )
     response = commands.PickUpTipResult()
 
@@ -127,8 +127,8 @@ def test_drop_tip(
     subject: SyncClient,
 ) -> None:
     """It should execute a drop up tip command."""
-    request = commands.DropTipRequest(
-        data=commands.DropTipData(pipetteId="123", labwareId="456", wellName="A2")
+    request = commands.DropTipCreate(
+        params=commands.DropTipParams(pipetteId="123", labwareId="456", wellName="A2")
     )
     response = commands.DropTipResult()
 
@@ -145,8 +145,8 @@ def test_aspirate(
     subject: SyncClient,
 ) -> None:
     """It should send an AspirateCommand through the transport."""
-    request = commands.AspirateRequest(
-        data=commands.AspirateData(
+    request = commands.AspirateCreate(
+        params=commands.AspirateParams(
             pipetteId="123",
             labwareId="456",
             wellName="A2",
@@ -184,8 +184,8 @@ def test_dispense(
     subject: SyncClient,
 ) -> None:
     """It should execute a dispense command."""
-    request = commands.DispenseRequest(
-        data=commands.DispenseData(
+    request = commands.DispenseCreate(
+        params=commands.DispenseParams(
             pipetteId="123",
             labwareId="456",
             wellName="A2",
@@ -220,7 +220,7 @@ def test_pause(
     subject: SyncClient,
 ) -> None:
     """It should execute a pause command."""
-    request = commands.PauseRequest(data=commands.PauseData(message="hello world"))
+    request = commands.PauseCreate(params=commands.PauseParams(message="hello world"))
     response = commands.PauseResult()
 
     decoy.when(transport.execute_command(request=request)).then_return(response)

--- a/api/tests/opentrons/protocol_engine/commands/test_add_labware_definition.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_add_labware_definition.py
@@ -10,7 +10,7 @@ from opentrons.protocol_engine.execution import (
 )
 
 from opentrons.protocol_engine.commands.add_labware_definition import (
-    AddLabwareDefinitionData,
+    AddLabwareDefinitionParams,
     AddLabwareDefinitionResult,
     AddLabwareDefinitionImplementation,
 )
@@ -32,7 +32,7 @@ async def test_add_labware_implementation(
         run_control=run_control,
     )
 
-    data = AddLabwareDefinitionData(definition=well_plate_def)
+    data = AddLabwareDefinitionParams(definition=well_plate_def)
     result = await subject.execute(data)
 
     assert result == AddLabwareDefinitionResult(

--- a/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
@@ -10,7 +10,7 @@ from opentrons.protocol_engine.execution import (
 )
 
 from opentrons.protocol_engine.commands.aspirate import (
-    AspirateData,
+    AspirateParams,
     AspirateResult,
     AspirateImplementation,
 )
@@ -33,7 +33,7 @@ async def test_aspirate_implementation(
 
     location = WellLocation(origin=WellOrigin.BOTTOM, offset=WellOffset(x=0, y=0, z=1))
 
-    data = AspirateData(
+    data = AspirateParams(
         pipetteId="abc",
         labwareId="123",
         wellName="A3",

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense.py
@@ -11,7 +11,7 @@ from opentrons.protocol_engine.execution import (
 
 
 from opentrons.protocol_engine.commands.dispense import (
-    DispenseData,
+    DispenseParams,
     DispenseResult,
     DispenseImplementation,
 )
@@ -24,7 +24,7 @@ async def test_dispense_implementation(
     pipetting: PipettingHandler,
     run_control: RunControlHandler,
 ) -> None:
-    """A PickUpTipRequest should have an execution implementation."""
+    """A PickUpTipCreate should have an execution implementation."""
     subject = DispenseImplementation(
         equipment=equipment,
         movement=movement,
@@ -34,7 +34,7 @@ async def test_dispense_implementation(
 
     location = WellLocation(origin=WellOrigin.BOTTOM, offset=WellOffset(x=0, y=0, z=1))
 
-    data = DispenseData(
+    data = DispenseParams(
         pipetteId="abc",
         labwareId="123",
         wellName="A3",

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
@@ -8,7 +8,7 @@ from opentrons.protocol_engine.execution import (
 )
 
 from opentrons.protocol_engine.commands.drop_tip import (
-    DropTipData,
+    DropTipParams,
     DropTipResult,
     DropTipImplementation,
 )
@@ -29,7 +29,7 @@ async def test_drop_tip_implementation(
         run_control=run_control,
     )
 
-    data = DropTipData(
+    data = DropTipParams(
         pipetteId="abc",
         labwareId="123",
         wellName="A3",

--- a/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
@@ -12,7 +12,7 @@ from opentrons.protocol_engine.execution import (
     RunControlHandler,
 )
 from opentrons.protocol_engine.commands.load_labware import (
-    LoadLabwareData,
+    LoadLabwareParams,
     LoadLabwareResult,
     LoadLabwareImplementation,
 )
@@ -34,7 +34,7 @@ async def test_load_labware_implementation(
         run_control=run_control,
     )
 
-    data = LoadLabwareData(
+    data = LoadLabwareParams(
         location=DeckSlotLocation(slot=DeckSlotName.SLOT_3),
         loadName="some-load-name",
         namespace="opentrons-test",

--- a/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
@@ -35,7 +35,7 @@ async def test_load_labware_implementation(
     )
 
     data = LoadLabwareParams(
-        location=DeckSlotLocation(slot=DeckSlotName.SLOT_3),
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
         loadName="some-load-name",
         namespace="opentrons-test",
         version=1,
@@ -43,7 +43,7 @@ async def test_load_labware_implementation(
 
     decoy.when(
         await equipment.load_labware(
-            location=DeckSlotLocation(slot=DeckSlotName.SLOT_3),
+            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
             load_name="some-load-name",
             namespace="opentrons-test",
             version=1,

--- a/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
@@ -12,7 +12,7 @@ from opentrons.protocol_engine.execution import (
     RunControlHandler,
 )
 from opentrons.protocol_engine.commands.load_pipette import (
-    LoadPipetteData,
+    LoadPipetteParams,
     LoadPipetteResult,
     LoadPipetteImplementation,
 )
@@ -33,7 +33,7 @@ async def test_load_pipette_implementation(
         run_control=run_control,
     )
 
-    data = LoadPipetteData(
+    data = LoadPipetteParams(
         pipetteName=PipetteName.P300_SINGLE,
         mount=MountType.LEFT,
         pipetteId="some id",

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_well.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_well.py
@@ -9,7 +9,7 @@ from opentrons.protocol_engine.execution import (
 )
 
 from opentrons.protocol_engine.commands.move_to_well import (
-    MoveToWellData,
+    MoveToWellParams,
     MoveToWellResult,
     MoveToWellImplementation,
 )
@@ -30,7 +30,7 @@ async def test_move_to_well_implementation(
         run_control=run_control,
     )
 
-    data = MoveToWellData(
+    data = MoveToWellParams(
         pipetteId="abc",
         labwareId="123",
         wellName="A3",

--- a/api/tests/opentrons/protocol_engine/commands/test_pause.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_pause.py
@@ -9,7 +9,7 @@ from opentrons.protocol_engine.execution import (
 )
 
 from opentrons.protocol_engine.commands.pause import (
-    PauseData,
+    PauseParams,
     PauseResult,
     PauseImplementation,
 )
@@ -30,7 +30,7 @@ async def test_pause_implementation(
         run_control=run_control,
     )
 
-    data = PauseData(message="hello world")
+    data = PauseParams(message="hello world")
 
     result = await subject.execute(data)
 

--- a/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
@@ -9,7 +9,7 @@ from opentrons.protocol_engine.execution import (
 )
 
 from opentrons.protocol_engine.commands.pick_up_tip import (
-    PickUpTipData,
+    PickUpTipParams,
     PickUpTipResult,
     PickUpTipImplementation,
 )
@@ -30,7 +30,7 @@ async def test_pick_up_tip_implementation(
         run_control=run_control,
     )
 
-    data = PickUpTipData(
+    data = PickUpTipParams(
         pipetteId="abc",
         labwareId="123",
         wellName="A3",

--- a/api/tests/opentrons/protocol_engine/commands/test_save_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_save_position.py
@@ -11,7 +11,7 @@ from opentrons.protocol_engine.execution import (
 )
 
 from opentrons.protocol_engine.commands.save_position import (
-    SavePositionData,
+    SavePositionParams,
     SavePositionResult,
     SavePositionImplementation,
 )
@@ -31,7 +31,7 @@ async def test_save_position_implementation(
         pipetting=pipetting,
         run_control=run_control,
     )
-    data = SavePositionData(
+    params = SavePositionParams(
         pipetteId="abc",
         positionId="123",
     )
@@ -44,7 +44,8 @@ async def test_save_position_implementation(
         SavedPositionData(positionId="123", position=DeckPoint(x=1, y=2, z=3))
     )
 
-    result = await subject.execute(data)
+    result = await subject.execute(params)
     assert result == SavePositionResult(
-        positionId="123", position=DeckPoint(x=1, y=2, z=3)
+        positionId="123",
+        position=DeckPoint(x=1, y=2, z=3),
     )

--- a/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
@@ -90,7 +90,7 @@ def subject(
     )
 
 
-class _TestCommandData(BaseModel):
+class _TestCommandParams(BaseModel):
     foo: str = "foo"
 
 
@@ -98,8 +98,8 @@ class _TestCommandResult(BaseModel):
     bar: str = "bar"
 
 
-class _TestCommandImpl(AbstractCommandImpl[_TestCommandData, _TestCommandResult]):
-    async def execute(self, data: _TestCommandData) -> _TestCommandResult:
+class _TestCommandImpl(AbstractCommandImpl[_TestCommandParams, _TestCommandResult]):
+    async def execute(self, params: _TestCommandParams) -> _TestCommandResult:
         raise NotImplementedError()
 
 
@@ -118,16 +118,16 @@ async def test_execute(
     TestCommandImplCls = decoy.mock(func=_TestCommandImpl)
     command_impl = decoy.mock(cls=_TestCommandImpl)
 
-    class _TestCommand(BaseCommand[_TestCommandData, _TestCommandResult]):
+    class _TestCommand(BaseCommand[_TestCommandParams, _TestCommandResult]):
         commandType: str = "testCommand"
-        data: _TestCommandData
+        params: _TestCommandParams
         result: Optional[_TestCommandResult]
 
         @property
         def _ImplementationCls(self) -> Type[_TestCommandImpl]:
             return TestCommandImplCls
 
-    command_data = _TestCommandData()
+    command_params = _TestCommandParams()
     command_result = _TestCommandResult()
 
     queued_command = cast(
@@ -136,7 +136,7 @@ async def test_execute(
             id="command-id",
             createdAt=datetime(year=2021, month=1, day=1),
             status=CommandStatus.QUEUED,
-            data=command_data,
+            params=command_params,
         ),
     )
 
@@ -147,7 +147,7 @@ async def test_execute(
             createdAt=datetime(year=2021, month=1, day=1),
             startedAt=datetime(year=2022, month=2, day=2),
             status=CommandStatus.RUNNING,
-            data=command_data,
+            params=command_params,
         ),
     )
 
@@ -159,7 +159,7 @@ async def test_execute(
             startedAt=datetime(year=2022, month=2, day=2),
             completedAt=datetime(year=2023, month=3, day=3),
             status=CommandStatus.SUCCEEDED,
-            data=command_data,
+            params=command_params,
             result=command_result,
         ),
     )
@@ -179,7 +179,7 @@ async def test_execute(
         command_impl  # type: ignore[arg-type]
     )
 
-    decoy.when(await command_impl.execute(command_data)).then_return(command_result)
+    decoy.when(await command_impl.execute(command_params)).then_return(command_result)
 
     decoy.when(model_utils.get_timestamp()).then_return(
         datetime(year=2022, month=2, day=2),
@@ -209,16 +209,16 @@ async def test_execute_raises_protocol_engine_error(
     TestCommandImplCls = decoy.mock(func=_TestCommandImpl)
     command_impl = decoy.mock(cls=_TestCommandImpl)
 
-    class _TestCommand(BaseCommand[_TestCommandData, _TestCommandResult]):
+    class _TestCommand(BaseCommand[_TestCommandParams, _TestCommandResult]):
         commandType: str = "testCommand"
-        data: _TestCommandData
+        params: _TestCommandParams
         result: Optional[_TestCommandResult]
 
         @property
         def _ImplementationCls(self) -> Type[_TestCommandImpl]:
             return TestCommandImplCls
 
-    command_data = _TestCommandData()
+    command_params = _TestCommandParams()
     command_error = ProtocolEngineError("oh no")
 
     queued_command = cast(
@@ -227,7 +227,7 @@ async def test_execute_raises_protocol_engine_error(
             id="command-id",
             createdAt=datetime(year=2021, month=1, day=1),
             status=CommandStatus.QUEUED,
-            data=command_data,
+            params=command_params,
         ),
     )
 
@@ -238,7 +238,7 @@ async def test_execute_raises_protocol_engine_error(
             createdAt=datetime(year=2021, month=1, day=1),
             startedAt=datetime(year=2022, month=2, day=2),
             status=CommandStatus.RUNNING,
-            data=command_data,
+            params=command_params,
         ),
     )
 
@@ -250,7 +250,7 @@ async def test_execute_raises_protocol_engine_error(
             startedAt=datetime(year=2022, month=2, day=2),
             completedAt=datetime(year=2023, month=3, day=3),
             status=CommandStatus.FAILED,
-            data=command_data,
+            params=command_params,
             error="oh no",
         ),
     )
@@ -270,7 +270,7 @@ async def test_execute_raises_protocol_engine_error(
         command_impl  # type: ignore[arg-type]
     )
 
-    decoy.when(await command_impl.execute(command_data)).then_raise(command_error)
+    decoy.when(await command_impl.execute(command_params)).then_raise(command_error)
 
     decoy.when(model_utils.get_timestamp()).then_return(
         datetime(year=2022, month=2, day=2),

--- a/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
@@ -86,12 +86,12 @@ async def test_load_labware(
     decoy.when(
         await labware_data_provider.get_labware_calibration(
             definition=minimal_labware_def,
-            location=DeckSlotLocation(slot=DeckSlotName.SLOT_3),
+            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
         )
     ).then_return((1, 2, 3))
 
     result = await subject.load_labware(
-        location=DeckSlotLocation(slot=DeckSlotName.SLOT_3),
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
         load_name="load-name",
         namespace="opentrons-test",
         version=1,
@@ -129,12 +129,12 @@ async def test_load_labware_uses_provided_id(
     decoy.when(
         await labware_data_provider.get_labware_calibration(
             definition=minimal_labware_def,
-            location=DeckSlotLocation(slot=DeckSlotName.SLOT_3),
+            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
         )
     ).then_return((1, 2, 3))
 
     result = await subject.load_labware(
-        location=DeckSlotLocation(slot=DeckSlotName.SLOT_3),
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
         load_name="load-name",
         namespace="opentrons-test",
         version=1,
@@ -172,12 +172,12 @@ async def test_load_labware_uses_loaded_labware_def(
     decoy.when(
         await labware_data_provider.get_labware_calibration(
             definition=minimal_labware_def,
-            location=DeckSlotLocation(slot=DeckSlotName.SLOT_3),
+            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
         )
     ).then_return((1, 2, 3))
 
     result = await subject.load_labware(
-        location=DeckSlotLocation(slot=DeckSlotName.SLOT_3),
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
         load_name="load-name",
         namespace="opentrons-test",
         version=1,

--- a/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
@@ -85,7 +85,7 @@ async def test_handle_pick_up_tip_request(
     mock_hw_pipettes: MockPipettes,
     handler: PipettingHandler,
 ) -> None:
-    """It should handle a PickUpTipRequest properly."""
+    """It should handle a PickUpTipCreate properly."""
     decoy.when(
         state_store.pipettes.get_hardware_pipette(
             pipette_id="pipette-id",
@@ -140,7 +140,7 @@ async def test_handle_drop_up_tip_request(
     mock_hw_pipettes: MockPipettes,
     handler: PipettingHandler,
 ) -> None:
-    """It should handle a DropTipRequest properly."""
+    """It should handle a DropTipCreate properly."""
     decoy.when(
         state_store.pipettes.get_hardware_pipette(
             pipette_id="pipette-id",

--- a/api/tests/opentrons/protocol_engine/resources/test_deck_data_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_deck_data_provider.py
@@ -65,7 +65,7 @@ async def test_get_deck_labware_fixtures(
     assert result == [
         DeckFixedLabware(
             labware_id="fixedTrash",
-            location=DeckSlotLocation(slot=DeckSlotName.FIXED_TRASH),
+            location=DeckSlotLocation(slotName=DeckSlotName.FIXED_TRASH),
             definition=fixed_trash_def,
         )
     ]
@@ -92,7 +92,7 @@ async def test_get_deck_labware_fixtures_short_trash(
     assert result == [
         DeckFixedLabware(
             labware_id="fixedTrash",
-            location=DeckSlotLocation(slot=DeckSlotName.FIXED_TRASH),
+            location=DeckSlotLocation(slotName=DeckSlotName.FIXED_TRASH),
             definition=short_fixed_trash_def,
         )
     ]

--- a/api/tests/opentrons/protocol_engine/resources/test_labware_data_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_labware_data_provider.py
@@ -43,7 +43,7 @@ async def test_labware_data_gets_calibration(
 
         result = await LabwareDataProvider().get_labware_calibration(
             well_plate_def,
-            DeckSlotLocation(slot=DeckSlotName.SLOT_5),
+            DeckSlotLocation(slotName=DeckSlotName.SLOT_5),
         )
 
         as_type_dict = cast(dev_types.LabwareDefinition, well_plate_def.dict())

--- a/api/tests/opentrons/protocol_engine/state/command_fixtures.py
+++ b/api/tests/opentrons/protocol_engine/state/command_fixtures.py
@@ -17,7 +17,7 @@ from opentrons.protocol_engine.types import (
 def create_pending_command(
     command_id: str = "command-id",
     command_type: str = "command-type",
-    data: Optional[BaseModel] = None,
+    params: Optional[BaseModel] = None,
 ) -> cmd.Command:
     """Given command data, build a pending command model."""
     return cast(
@@ -27,7 +27,7 @@ def create_pending_command(
             commandType=command_type,
             createdAt=datetime(year=2021, month=1, day=1),
             status=cmd.CommandStatus.QUEUED,
-            data=data or BaseModel(),
+            params=params or BaseModel(),
         ),
     )
 
@@ -35,7 +35,7 @@ def create_pending_command(
 def create_running_command(
     command_id: str = "command-id",
     command_type: str = "command-type",
-    data: Optional[BaseModel] = None,
+    params: Optional[BaseModel] = None,
 ) -> cmd.Command:
     """Given command data, build a running command model."""
     return cast(
@@ -45,7 +45,7 @@ def create_running_command(
             createdAt=datetime(year=2021, month=1, day=1),
             commandType=command_type,
             status=cmd.CommandStatus.RUNNING,
-            data=data or BaseModel(),
+            params=params or BaseModel(),
         ),
     )
 
@@ -53,7 +53,7 @@ def create_running_command(
 def create_failed_command(
     command_id: str = "command-id",
     command_type: str = "command-type",
-    data: Optional[BaseModel] = None,
+    params: Optional[BaseModel] = None,
 ) -> cmd.Command:
     """Given command data, build a failed command model."""
     return cast(
@@ -63,7 +63,7 @@ def create_failed_command(
             createdAt=datetime(year=2021, month=1, day=1),
             commandType=command_type,
             status=cmd.CommandStatus.FAILED,
-            data=data or BaseModel(),
+            params=params or BaseModel(),
         ),
     )
 
@@ -71,7 +71,7 @@ def create_failed_command(
 def create_completed_command(
     command_id: str = "command-id",
     command_type: str = "command-type",
-    data: Optional[BaseModel] = None,
+    params: Optional[BaseModel] = None,
     result: Optional[BaseModel] = None,
 ) -> cmd.Command:
     """Given command data and result, build a completed command model."""
@@ -82,7 +82,7 @@ def create_completed_command(
             createdAt=datetime(year=2021, month=1, day=1),
             commandType=command_type,
             status=cmd.CommandStatus.SUCCEEDED,
-            data=data or BaseModel(),
+            params=params or BaseModel(),
             result=result or BaseModel(),
         ),
     )
@@ -95,7 +95,7 @@ def create_load_labware_command(
     calibration: CalibrationOffset,
 ) -> cmd.LoadLabware:
     """Create a completed LoadLabware command."""
-    data = cmd.LoadLabwareData(
+    params = cmd.LoadLabwareParams(
         loadName=definition.parameters.loadName,
         namespace=definition.namespace,
         version=definition.version,
@@ -113,7 +113,7 @@ def create_load_labware_command(
         id="command-id",
         status=cmd.CommandStatus.SUCCEEDED,
         createdAt=datetime.now(),
-        data=data,
+        params=params,
         result=result,
     )
 
@@ -122,7 +122,7 @@ def create_add_definition_command(
     definition: LabwareDefinition,
 ) -> cmd.AddLabwareDefinition:
     """Create a completed AddLabwareDefinition command."""
-    data = cmd.AddLabwareDefinitionData(definition=definition)
+    params = cmd.AddLabwareDefinitionParams(definition=definition)
 
     result = cmd.AddLabwareDefinitionResult(
         loadName=definition.parameters.loadName,
@@ -134,7 +134,7 @@ def create_add_definition_command(
         id="command-id",
         status=cmd.CommandStatus.SUCCEEDED,
         createdAt=datetime.now(),
-        data=data,
+        params=params,
         result=result,
     )
 
@@ -145,14 +145,14 @@ def create_load_pipette_command(
     mount: MountType,
 ) -> cmd.LoadPipette:
     """Get a completed LoadPipette command."""
-    data = cmd.LoadPipetteData(pipetteName=pipette_name, mount=mount)
+    params = cmd.LoadPipetteParams(pipetteName=pipette_name, mount=mount)
     result = cmd.LoadPipetteResult(pipetteId=pipette_id)
 
     return cmd.LoadPipette(
         id="command-id",
         status=cmd.CommandStatus.SUCCEEDED,
         createdAt=datetime.now(),
-        data=data,
+        params=params,
         result=result,
     )
 
@@ -165,7 +165,7 @@ def create_aspirate_command(
     well_location: Optional[WellLocation] = None,
 ) -> cmd.Aspirate:
     """Get a completed Aspirate command."""
-    data = cmd.AspirateData(
+    params = cmd.AspirateParams(
         pipetteId=pipette_id,
         labwareId=labware_id,
         wellName=well_name,
@@ -178,7 +178,7 @@ def create_aspirate_command(
         id="command-id",
         status=cmd.CommandStatus.SUCCEEDED,
         createdAt=datetime.now(),
-        data=data,
+        params=params,
         result=result,
     )
 
@@ -191,7 +191,7 @@ def create_dispense_command(
     well_location: Optional[WellLocation] = None,
 ) -> cmd.Dispense:
     """Get a completed Dispense command."""
-    data = cmd.DispenseData(
+    params = cmd.DispenseParams(
         pipetteId=pipette_id,
         labwareId=labware_id,
         wellName=well_name,
@@ -204,7 +204,7 @@ def create_dispense_command(
         id="command-id",
         status=cmd.CommandStatus.SUCCEEDED,
         createdAt=datetime.now(),
-        data=data,
+        params=params,
         result=result,
     )
 
@@ -215,7 +215,7 @@ def create_pick_up_tip_command(
     well_name: str = "A1",
 ) -> cmd.PickUpTip:
     """Get a completed PickUpTip command."""
-    data = cmd.PickUpTipData(
+    data = cmd.PickUpTipParams(
         pipetteId=pipette_id,
         labwareId=labware_id,
         wellName=well_name,
@@ -227,7 +227,7 @@ def create_pick_up_tip_command(
         id="command-id",
         status=cmd.CommandStatus.SUCCEEDED,
         createdAt=datetime.now(),
-        data=data,
+        params=data,
         result=result,
     )
 
@@ -238,7 +238,7 @@ def create_drop_tip_command(
     well_name: str = "A1",
 ) -> cmd.DropTip:
     """Get a completed DropTip command."""
-    data = cmd.DropTipData(
+    params = cmd.DropTipParams(
         pipetteId=pipette_id,
         labwareId=labware_id,
         wellName=well_name,
@@ -250,7 +250,7 @@ def create_drop_tip_command(
         id="command-id",
         status=cmd.CommandStatus.SUCCEEDED,
         createdAt=datetime.now(),
-        data=data,
+        params=params,
         result=result,
     )
 
@@ -261,7 +261,7 @@ def create_move_to_well_command(
     well_name: str = "A1",
 ) -> cmd.MoveToWell:
     """Get a completed MoveToWell command."""
-    data = cmd.MoveToWellData(
+    params = cmd.MoveToWellParams(
         pipetteId=pipette_id,
         labwareId=labware_id,
         wellName=well_name,
@@ -273,6 +273,6 @@ def create_move_to_well_command(
         id="command-id",
         status=cmd.CommandStatus.SUCCEEDED,
         createdAt=datetime.now(),
-        data=data,
+        params=params,
         result=result,
     )

--- a/api/tests/opentrons/protocol_engine/state/test_command_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_store.py
@@ -94,7 +94,7 @@ class QueueCommandSpec(NamedTuple):
         QueueCommandSpec(
             command_request=commands.LoadLabwareCreate(
                 params=commands.LoadLabwareParams(
-                    location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+                    location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
                     loadName="load-name",
                     namespace="namespace",
                     version=42,

--- a/api/tests/opentrons/protocol_engine/state/test_command_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_store.py
@@ -39,7 +39,7 @@ def test_initial_state() -> None:
 class QueueCommandSpec(NamedTuple):
     """Test data for the QueueCommandAction."""
 
-    command_request: commands.CommandRequest
+    command_request: commands.CommandCreate
     expected_cls: Type[commands.Command]
     created_at: datetime = datetime(year=2021, month=1, day=1)
     command_id: str = "command-id"
@@ -49,8 +49,8 @@ class QueueCommandSpec(NamedTuple):
     QueueCommandSpec._fields,
     [
         QueueCommandSpec(
-            command_request=commands.AddLabwareDefinitionRequest(
-                data=commands.AddLabwareDefinitionData.construct(
+            command_request=commands.AddLabwareDefinitionCreate(
+                params=commands.AddLabwareDefinitionParams.construct(
                     # TODO(mc, 2021-06-25): do not mock out LabwareDefinition
                     definition=cast(LabwareDefinition, {"mockDefinition": True})
                 ),
@@ -58,8 +58,8 @@ class QueueCommandSpec(NamedTuple):
             expected_cls=commands.AddLabwareDefinition,
         ),
         QueueCommandSpec(
-            command_request=commands.AspirateRequest(
-                data=commands.AspirateData(
+            command_request=commands.AspirateCreate(
+                params=commands.AspirateParams(
                     pipetteId="pipette-id",
                     labwareId="labware-id",
                     wellName="well-name",
@@ -70,8 +70,8 @@ class QueueCommandSpec(NamedTuple):
             expected_cls=commands.Aspirate,
         ),
         QueueCommandSpec(
-            command_request=commands.DispenseRequest(
-                data=commands.DispenseData(
+            command_request=commands.DispenseCreate(
+                params=commands.DispenseParams(
                     pipetteId="pipette-id",
                     labwareId="labware-id",
                     wellName="well-name",
@@ -82,8 +82,8 @@ class QueueCommandSpec(NamedTuple):
             expected_cls=commands.Dispense,
         ),
         QueueCommandSpec(
-            command_request=commands.DropTipRequest(
-                data=commands.DropTipData(
+            command_request=commands.DropTipCreate(
+                params=commands.DropTipParams(
                     pipetteId="pipette-id",
                     labwareId="labware-id",
                     wellName="well-name",
@@ -92,8 +92,8 @@ class QueueCommandSpec(NamedTuple):
             expected_cls=commands.DropTip,
         ),
         QueueCommandSpec(
-            command_request=commands.LoadLabwareRequest(
-                data=commands.LoadLabwareData(
+            command_request=commands.LoadLabwareCreate(
+                params=commands.LoadLabwareParams(
                     location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
                     loadName="load-name",
                     namespace="namespace",
@@ -103,8 +103,8 @@ class QueueCommandSpec(NamedTuple):
             expected_cls=commands.LoadLabware,
         ),
         QueueCommandSpec(
-            command_request=commands.LoadPipetteRequest(
-                data=commands.LoadPipetteData(
+            command_request=commands.LoadPipetteCreate(
+                params=commands.LoadPipetteParams(
                     mount=MountType.LEFT,
                     pipetteName=PipetteName.P300_SINGLE,
                 ),
@@ -112,8 +112,8 @@ class QueueCommandSpec(NamedTuple):
             expected_cls=commands.LoadPipette,
         ),
         QueueCommandSpec(
-            command_request=commands.PickUpTipRequest(
-                data=commands.PickUpTipData(
+            command_request=commands.PickUpTipCreate(
+                params=commands.PickUpTipParams(
                     pipetteId="pipette-id",
                     labwareId="labware-id",
                     wellName="well-name",
@@ -122,8 +122,8 @@ class QueueCommandSpec(NamedTuple):
             expected_cls=commands.PickUpTip,
         ),
         QueueCommandSpec(
-            command_request=commands.MoveToWellRequest(
-                data=commands.MoveToWellData(
+            command_request=commands.MoveToWellCreate(
+                params=commands.MoveToWellParams(
                     pipetteId="pipette-id",
                     labwareId="labware-id",
                     wellName="well-name",
@@ -132,15 +132,15 @@ class QueueCommandSpec(NamedTuple):
             expected_cls=commands.MoveToWell,
         ),
         QueueCommandSpec(
-            command_request=commands.PauseRequest(
-                data=commands.PauseData(message="hello world"),
+            command_request=commands.PauseCreate(
+                params=commands.PauseParams(message="hello world"),
             ),
             expected_cls=commands.Pause,
         ),
     ],
 )
 def test_command_store_queues_commands(
-    command_request: commands.CommandRequest,
+    command_request: commands.CommandCreate,
     expected_cls: Type[commands.Command],
     created_at: datetime,
     command_id: str,
@@ -155,7 +155,7 @@ def test_command_store_queues_commands(
         id=command_id,
         createdAt=created_at,
         status=commands.CommandStatus.QUEUED,
-        data=command_request.data,  # type: ignore[arg-type]
+        params=command_request.params,  # type: ignore[arg-type]
     )
 
     subject = CommandStore()

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -40,7 +40,7 @@ def test_get_labware_parent_position(
         id="labware-id",
         loadName="b",
         definitionUri=uri_from_details(namespace="a", load_name="b", version=1),
-        location=DeckSlotLocation(slot=DeckSlotName.SLOT_3),
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
     )
     decoy.when(labware_view.get("labware-id")).then_return(labware_data)
     decoy.when(labware_view.get_slot_position(DeckSlotName.SLOT_3)).then_return(
@@ -64,7 +64,7 @@ def test_get_labware_origin_position(
         id="labware-id",
         loadName="load-name",
         definitionUri="defintion-uri",
-        location=DeckSlotLocation(slot=DeckSlotName.SLOT_3),
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
     )
 
     decoy.when(labware_view.get("labware-id")).then_return(labware_data)
@@ -98,7 +98,7 @@ def test_get_labware_highest_z(
         id="labware-id",
         loadName="load-name",
         definitionUri="definition-uri",
-        location=DeckSlotLocation(slot=DeckSlotName.SLOT_3),
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
     )
     slot_pos = Point(1, 2, 3)
     calibration_offset = CalibrationOffset(x=1, y=-2, z=3)
@@ -130,13 +130,13 @@ def test_get_all_labware_highest_z(
         id="plate-id",
         loadName="plate-load-name",
         definitionUri="plate-definition-uri",
-        location=DeckSlotLocation(slot=DeckSlotName.SLOT_3),
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
     )
     reservoir = LoadedLabware(
         id="reservoir-id",
         loadName="reservoir-load-name",
         definitionUri="reservoir-definition-uri",
-        location=DeckSlotLocation(slot=DeckSlotName.SLOT_4),
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
     )
 
     plate_offset = CalibrationOffset(x=1, y=-2, z=3)
@@ -182,7 +182,7 @@ def test_get_labware_position(
         id="labware-id",
         loadName="load-name",
         definitionUri="definition-uri",
-        location=DeckSlotLocation(slot=DeckSlotName.SLOT_4),
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
     )
     calibration_offset = CalibrationOffset(x=1, y=-2, z=3)
     slot_pos = Point(4, 5, 6)
@@ -217,7 +217,7 @@ def test_get_well_position(
         id="labware-id",
         loadName="load-name",
         definitionUri="definition-uri",
-        location=DeckSlotLocation(slot=DeckSlotName.SLOT_4),
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
     )
     calibration_offset = CalibrationOffset(x=1, y=-2, z=3)
     slot_pos = Point(4, 5, 6)
@@ -256,7 +256,7 @@ def test_get_well_position_with_top_offset(
         id="labware-id",
         loadName="load-name",
         definitionUri="definition-uri",
-        location=DeckSlotLocation(slot=DeckSlotName.SLOT_4),
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
     )
     calibration_offset = CalibrationOffset(x=1, y=-2, z=3)
     slot_pos = Point(4, 5, 6)
@@ -302,7 +302,7 @@ def test_get_well_position_with_bottom_offset(
         id="labware-id",
         loadName="load-name",
         definitionUri="definition-uri",
-        location=DeckSlotLocation(slot=DeckSlotName.SLOT_4),
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
     )
     calibration_offset = CalibrationOffset(x=1, y=-2, z=3)
     slot_pos = Point(4, 5, 6)

--- a/api/tests/opentrons/protocol_engine/state/test_labware_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_store.py
@@ -29,7 +29,7 @@ def subject(
         deck_fixed_labware=[
             DeckFixedLabware(
                 labware_id="fixedTrash",
-                location=DeckSlotLocation(slot=DeckSlotName.FIXED_TRASH),
+                location=DeckSlotLocation(slotName=DeckSlotName.FIXED_TRASH),
                 definition=fixed_trash_def,
             )
         ],
@@ -55,7 +55,7 @@ def test_initial_state(
                 id="fixedTrash",
                 loadName=fixed_trash_def.parameters.loadName,
                 definitionUri=expected_trash_uri,
-                location=DeckSlotLocation(slot=DeckSlotName.FIXED_TRASH),
+                location=DeckSlotLocation(slotName=DeckSlotName.FIXED_TRASH),
             )
         },
         calibrations_by_id={"fixedTrash": CalibrationOffset(x=0, y=0, z=0)},
@@ -69,7 +69,7 @@ def test_handles_load_labware(
 ) -> None:
     """It should add the labware data to the state."""
     command = create_load_labware_command(
-        location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
         labware_id="test-labware-id",
         definition=well_plate_def,
         calibration=CalibrationOffset(x=1, y=2, z=3),
@@ -85,7 +85,7 @@ def test_handles_load_labware(
         id="test-labware-id",
         loadName=well_plate_def.parameters.loadName,
         definitionUri=expected_definition_uri,
-        location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
     )
 
     subject.handle_action(UpdateCommandAction(command=command))

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -21,28 +21,28 @@ from opentrons.protocol_engine.state.labware import LabwareState, LabwareView
 plate = LoadedLabware(
     id="plate-id",
     loadName="plate-load-name",
-    location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+    location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
     definitionUri="some-plate-uri",
 )
 
 reservoir = LoadedLabware(
     id="reservoir-id",
     loadName="reservoir-load-name",
-    location=DeckSlotLocation(slot=DeckSlotName.SLOT_2),
+    location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2),
     definitionUri="some-reservoir-uri",
 )
 
 tube_rack = LoadedLabware(
     id="tube-rack-id",
     loadName="tube-rack-load-name",
-    location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+    location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
     definitionUri="some-tube-rack-uri",
 )
 
 tip_rack = LoadedLabware(
     id="tip-rack-id",
     loadName="tip-rack-load-name",
-    location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+    location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
     definitionUri="some-tip-rack-uri",
 )
 
@@ -120,7 +120,7 @@ def test_get_labware_location() -> None:
 
     result = subject.get_location("plate-id")
 
-    assert result == DeckSlotLocation(slot=DeckSlotName.SLOT_1)
+    assert result == DeckSlotLocation(slotName=DeckSlotName.SLOT_1)
 
 
 def test_get_has_quirk(
@@ -267,7 +267,7 @@ def test_get_labware_uri_from_definition(tip_rack_def: LabwareDefinition) -> Non
     tip_rack = LoadedLabware(
         id="tip-rack-id",
         loadName="tip-rack-load-name",
-        location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
         definitionUri="some-tip-rack-uri",
     )
 

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -185,7 +185,7 @@ def test_movement_commands_update_current_well(
 ) -> None:
     """It should save the last used pipette, labware, and well for movement commands."""
     load_pipette_command = create_load_pipette_command(
-        pipette_id=command.data.pipetteId,  # type: ignore[arg-type, union-attr]
+        pipette_id=command.params.pipetteId,  # type: ignore[arg-type, union-attr]
         pipette_name=PipetteName.P300_SINGLE,
         mount=MountType.LEFT,
     )

--- a/api/tests/opentrons/protocol_engine/test_create_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_create_protocol_engine.py
@@ -30,6 +30,6 @@ async def test_create_engine_initializes_state_with_deck_geometry(
                 namespace=fixed_trash_def.namespace,
                 version=fixed_trash_def.version,
             ),
-            location=DeckSlotLocation(slot=DeckSlotName.FIXED_TRASH),
+            location=DeckSlotLocation(slotName=DeckSlotName.FIXED_TRASH),
         )
     ]

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -87,12 +87,12 @@ def test_add_command(
     subject: ProtocolEngine,
 ) -> None:
     """It should add a command to the state from a request."""
-    data = commands.LoadPipetteData(
+    data = commands.LoadPipetteParams(
         mount=MountType.LEFT,
         pipetteName=PipetteName.P300_SINGLE,
     )
 
-    request = commands.LoadPipetteRequest(data=data)
+    request = commands.LoadPipetteCreate(params=data)
 
     created_at = datetime(year=2021, month=1, day=1)
 
@@ -100,7 +100,7 @@ def test_add_command(
         id="command-id",
         status=commands.CommandStatus.QUEUED,
         createdAt=created_at,
-        data=data,
+        params=data,
     )
 
     decoy.when(model_utils.generate_id()).then_return("command-id")
@@ -133,18 +133,18 @@ async def test_execute_command(
     created_at = datetime(year=2021, month=1, day=1)
     completed_at = datetime(year=2023, month=3, day=3)
 
-    data = commands.LoadPipetteData(
+    data = commands.LoadPipetteParams(
         mount=MountType.LEFT,
         pipetteName=PipetteName.P300_SINGLE,
     )
 
-    request = commands.LoadPipetteRequest(data=data)
+    request = commands.LoadPipetteCreate(params=data)
 
     queued_command = commands.LoadPipette(
         id="command-id",
         status=commands.CommandStatus.QUEUED,
         createdAt=created_at,
-        data=data,
+        params=data,
     )
 
     executed_command = commands.LoadPipette(
@@ -153,7 +153,7 @@ async def test_execute_command(
         createdAt=created_at,
         startedAt=created_at,
         completedAt=completed_at,
-        data=data,
+        params=data,
     )
 
     decoy.when(model_utils.generate_id()).then_return("command-id")

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -87,12 +87,12 @@ def test_add_command(
     subject: ProtocolEngine,
 ) -> None:
     """It should add a command to the state from a request."""
-    data = commands.LoadPipetteParams(
+    params = commands.LoadPipetteParams(
         mount=MountType.LEFT,
         pipetteName=PipetteName.P300_SINGLE,
     )
 
-    request = commands.LoadPipetteCreate(params=data)
+    request = commands.LoadPipetteCreate(params=params)
 
     created_at = datetime(year=2021, month=1, day=1)
 
@@ -100,7 +100,7 @@ def test_add_command(
         id="command-id",
         status=commands.CommandStatus.QUEUED,
         createdAt=created_at,
-        params=data,
+        params=params,
     )
 
     decoy.when(model_utils.generate_id()).then_return("command-id")
@@ -133,18 +133,18 @@ async def test_execute_command(
     created_at = datetime(year=2021, month=1, day=1)
     completed_at = datetime(year=2023, month=3, day=3)
 
-    data = commands.LoadPipetteParams(
+    params = commands.LoadPipetteParams(
         mount=MountType.LEFT,
         pipetteName=PipetteName.P300_SINGLE,
     )
 
-    request = commands.LoadPipetteCreate(params=data)
+    request = commands.LoadPipetteCreate(params=params)
 
     queued_command = commands.LoadPipette(
         id="command-id",
         status=commands.CommandStatus.QUEUED,
         createdAt=created_at,
-        params=data,
+        params=params,
     )
 
     executed_command = commands.LoadPipette(
@@ -153,7 +153,7 @@ async def test_execute_command(
         createdAt=created_at,
         startedAt=created_at,
         completedAt=completed_at,
-        params=data,
+        params=params,
     )
 
     decoy.when(model_utils.generate_id()).then_return("command-id")

--- a/api/tests/opentrons/protocol_runner/test_json_command_translator.py
+++ b/api/tests/opentrons/protocol_runner/test_json_command_translator.py
@@ -70,9 +70,9 @@ def test_labware(
     minimal_labware_def: LabwareDefinition,
     minimal_labware_def2: LabwareDefinition,
 ) -> None:
-    """It should emit AddLabwareDefinitionRequest and LoadLabwareRequest objects.
+    """It should emit AddLabwareDefinitionCreate and LoadLabwareCreate objects.
 
-    A LoadLabwareRequest should always come after the AddLabwareDefinitionRequest
+    A LoadLabwareCreate should always come after the AddLabwareDefinitionCreate
     that it depends on.
     """
     definition_1 = models.LabwareDefinition.parse_obj(minimal_labware_def)
@@ -98,11 +98,11 @@ def test_labware(
     # "my-load-name", and then assert that the hard-coded string "my-load-name" is
     # what's used in the output Protocol Engine command.
 
-    expected_add_definition_request_1 = pe_commands.AddLabwareDefinitionRequest(
-        data=pe_commands.AddLabwareDefinitionData(definition=definition_1)
+    expected_add_definition_request_1 = pe_commands.AddLabwareDefinitionCreate(
+        params=pe_commands.AddLabwareDefinitionParams(definition=definition_1)
     )
-    expected_load_request_1 = pe_commands.LoadLabwareRequest(
-        data=pe_commands.LoadLabwareData(
+    expected_load_request_1 = pe_commands.LoadLabwareCreate(
+        params=pe_commands.LoadLabwareParams(
             location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
             loadName=definition_1.parameters.loadName,
             namespace=definition_1.namespace,
@@ -111,11 +111,11 @@ def test_labware(
         )
     )
 
-    expected_add_definition_request_2 = pe_commands.AddLabwareDefinitionRequest(
-        data=pe_commands.AddLabwareDefinitionData(definition=definition_2)
+    expected_add_definition_request_2 = pe_commands.AddLabwareDefinitionCreate(
+        params=pe_commands.AddLabwareDefinitionParams(definition=definition_2)
     )
-    expected_load_request_2 = pe_commands.LoadLabwareRequest(
-        data=pe_commands.LoadLabwareData(
+    expected_load_request_2 = pe_commands.LoadLabwareCreate(
+        params=pe_commands.LoadLabwareParams(
             location=DeckSlotLocation(slot=DeckSlotName.SLOT_2),
             loadName=definition_2.parameters.loadName,
             namespace=definition_2.namespace,
@@ -142,22 +142,22 @@ def test_labware(
 
 
 def test_pipettes(subject: JsonCommandTranslator) -> None:
-    """It should translate pipette specs into LoadPipetteRequest objects."""
+    """It should translate pipette specs into LoadPipetteCreate objects."""
     json_pipettes = {
         "abc123": models.json_protocol.Pipettes(mount="left", name="p20_single_gen2"),
         "def456": models.json_protocol.Pipettes(mount="right", name="p300_multi"),
     }
 
-    expected_request_1 = pe_commands.LoadPipetteRequest(
-        data=pe_commands.LoadPipetteData(
+    expected_request_1 = pe_commands.LoadPipetteCreate(
+        params=pe_commands.LoadPipetteParams(
             pipetteId="abc123",
             mount=MountType.LEFT,
             pipetteName=PipetteName.P20_SINGLE_GEN2,
         )
     )
 
-    expected_request_2 = pe_commands.LoadPipetteRequest(
-        data=pe_commands.LoadPipetteData(
+    expected_request_2 = pe_commands.LoadPipetteCreate(
+        params=pe_commands.LoadPipetteParams(
             pipetteId="def456",
             mount=MountType.RIGHT,
             pipetteName=PipetteName.P300_MULTI,
@@ -173,7 +173,7 @@ def test_pipettes(subject: JsonCommandTranslator) -> None:
 
 
 def test_aspirate(subject: JsonCommandTranslator) -> None:
-    """It should translate a JSON aspirate to a Protocol Engine AspirateRequest."""
+    """It should translate a JSON aspirate to a Protocol Engine AspirateCreate."""
     input_json_command = models.json_protocol.LiquidCommand(
         command="aspirate",
         params=models.json_protocol.Params(
@@ -186,8 +186,8 @@ def test_aspirate(subject: JsonCommandTranslator) -> None:
         ),
     )
     expected_output = [
-        pe_commands.AspirateRequest(
-            data=pe_commands.AspirateData(
+        pe_commands.AspirateCreate(
+            params=pe_commands.AspirateParams(
                 pipetteId="pipette-id-abc123",
                 labwareId="labware-id-def456",
                 volume=1.23,
@@ -205,7 +205,7 @@ def test_aspirate(subject: JsonCommandTranslator) -> None:
 
 
 def test_dispense(subject: JsonCommandTranslator) -> None:
-    """It should translate a JSON dispense to a ProtocolEngine DispenseRequest."""
+    """It should translate a JSON dispense to a ProtocolEngine DispenseCreate."""
     input_json_command = models.json_protocol.LiquidCommand(
         command="dispense",
         params=models.json_protocol.Params(
@@ -218,8 +218,8 @@ def test_dispense(subject: JsonCommandTranslator) -> None:
         ),
     )
     expected_output = [
-        pe_commands.DispenseRequest(
-            data=pe_commands.DispenseData(
+        pe_commands.DispenseCreate(
+            params=pe_commands.DispenseParams(
                 pipetteId="pipette-id-abc123",
                 labwareId="labware-id-def456",
                 volume=1.23,
@@ -237,7 +237,7 @@ def test_dispense(subject: JsonCommandTranslator) -> None:
 
 
 def test_drop_tip(subject: JsonCommandTranslator) -> None:
-    """It should translate a JSON drop tip to a ProtocolEngine DropTipRequest."""
+    """It should translate a JSON drop tip to a ProtocolEngine DropTipCreate."""
     input_json_command = models.json_protocol.PickUpDropTipCommand(
         command="dropTip",
         params=models.json_protocol.PipetteAccessParams(
@@ -245,8 +245,8 @@ def test_drop_tip(subject: JsonCommandTranslator) -> None:
         ),
     )
     expected_output = [
-        pe_commands.DropTipRequest(
-            data=pe_commands.DropTipData(
+        pe_commands.DropTipCreate(
+            params=pe_commands.DropTipParams(
                 pipetteId="pipette-id-abc123",
                 labwareId="labware-id-def456",
                 wellName="A1",
@@ -259,7 +259,7 @@ def test_drop_tip(subject: JsonCommandTranslator) -> None:
 
 
 def test_pick_up_tip(subject: JsonCommandTranslator) -> None:
-    """It should translate a JSON pick up tip to a ProtocolEngine PickUpTipRequest."""
+    """It should translate a JSON pick up tip to a ProtocolEngine PickUpTipCreate."""
     input_json_command = models.json_protocol.PickUpDropTipCommand(
         command="pickUpTip",
         params=models.json_protocol.PipetteAccessParams(
@@ -267,8 +267,8 @@ def test_pick_up_tip(subject: JsonCommandTranslator) -> None:
         ),
     )
     expected_output = [
-        pe_commands.PickUpTipRequest(
-            data=pe_commands.PickUpTipData(
+        pe_commands.PickUpTipCreate(
+            params=pe_commands.PickUpTipParams(
                 pipetteId="pipette-id-abc123",
                 labwareId="labware-id-def456",
                 wellName="A1",
@@ -281,7 +281,7 @@ def test_pick_up_tip(subject: JsonCommandTranslator) -> None:
 
 
 def test_pause(subject: JsonCommandTranslator) -> None:
-    """It should translate delay with wait=True to a PauseRequest."""
+    """It should translate delay with wait=True to a PauseCreate."""
     input_command = models.json_protocol.DelayCommand(
         command="delay",
         params=models.json_protocol.DelayCommandParams(
@@ -294,5 +294,5 @@ def test_pause(subject: JsonCommandTranslator) -> None:
     result = subject.translate(input_protocol)
 
     assert result == [
-        pe_commands.PauseRequest(data=pe_commands.PauseData(message="hello world"))
+        pe_commands.PauseCreate(params=pe_commands.PauseParams(message="hello world"))
     ]

--- a/api/tests/opentrons/protocol_runner/test_json_command_translator.py
+++ b/api/tests/opentrons/protocol_runner/test_json_command_translator.py
@@ -103,7 +103,7 @@ def test_labware(
     )
     expected_load_request_1 = pe_commands.LoadLabwareCreate(
         params=pe_commands.LoadLabwareParams(
-            location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
             loadName=definition_1.parameters.loadName,
             namespace=definition_1.namespace,
             version=definition_1.version,
@@ -116,7 +116,7 @@ def test_labware(
     )
     expected_load_request_2 = pe_commands.LoadLabwareCreate(
         params=pe_commands.LoadLabwareParams(
-            location=DeckSlotLocation(slot=DeckSlotName.SLOT_2),
+            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2),
             loadName=definition_2.parameters.loadName,
             namespace=definition_2.namespace,
             version=definition_2.version,

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -38,7 +38,7 @@ def test_map_before_command() -> None:
         status=pe_commands.CommandStatus.RUNNING,
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
-        data=LegacyCommandData(
+        params=LegacyCommandData(
             legacyCommandType="command.PAUSE",
             legacyCommandText="hello world",
         ),
@@ -71,7 +71,7 @@ def test_map_after_command() -> None:
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
         completedAt=matchers.IsA(datetime),
-        data=LegacyCommandData(
+        params=LegacyCommandData(
             legacyCommandType="command.PAUSE",
             legacyCommandText="hello world",
         ),
@@ -104,7 +104,7 @@ def test_map_after_with_error_command() -> None:
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
         completedAt=matchers.IsA(datetime),
-        data=LegacyCommandData(
+        params=LegacyCommandData(
             legacyCommandType="command.PAUSE",
             legacyCommandText="hello world",
         ),
@@ -150,7 +150,7 @@ def test_command_stack() -> None:
         status=pe_commands.CommandStatus.RUNNING,
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
-        data=LegacyCommandData(
+        params=LegacyCommandData(
             legacyCommandType="command.PAUSE",
             legacyCommandText="hello",
         ),
@@ -160,7 +160,7 @@ def test_command_stack() -> None:
         status=pe_commands.CommandStatus.RUNNING,
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
-        data=LegacyCommandData(
+        params=LegacyCommandData(
             legacyCommandType="command.PAUSE",
             legacyCommandText="goodbye",
         ),
@@ -171,7 +171,7 @@ def test_command_stack() -> None:
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
         completedAt=matchers.IsA(datetime),
-        data=LegacyCommandData(
+        params=LegacyCommandData(
             legacyCommandType="command.PAUSE",
             legacyCommandText="goodbye",
         ),
@@ -182,7 +182,7 @@ def test_command_stack() -> None:
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
         completedAt=matchers.IsA(datetime),
-        data=LegacyCommandData(
+        params=LegacyCommandData(
             legacyCommandType="command.PAUSE",
             legacyCommandText="hello",
         ),
@@ -204,7 +204,7 @@ def test_map_labware_load(minimal_labware_def: LabwareDefinition) -> None:
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
         completedAt=matchers.IsA(datetime),
-        data=pe_commands.LoadLabwareData.construct(
+        params=pe_commands.LoadLabwareParams.construct(
             location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
             namespace="some_namespace",
             loadName="some_load_name",
@@ -236,7 +236,7 @@ def test_map_instrument_load() -> None:
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
         completedAt=matchers.IsA(datetime),
-        data=pe_commands.LoadPipetteData.construct(
+        params=pe_commands.LoadPipetteParams.construct(
             pipetteName=PipetteName.P1000_SINGLE_GEN2, mount=MountType.LEFT
         ),
         result=pe_commands.LoadPipetteResult.construct(pipetteId=matchers.IsA(str)),

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -11,7 +11,7 @@ from opentrons.protocol_engine import (
 )
 from opentrons.protocol_runner.legacy_command_mapper import (
     LegacyCommandMapper,
-    LegacyCommandData,
+    LegacyCommandParams,
 )
 from opentrons.protocol_runner.legacy_wrappers import (
     LegacyInstrumentLoadInfo,
@@ -38,7 +38,7 @@ def test_map_before_command() -> None:
         status=pe_commands.CommandStatus.RUNNING,
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
-        params=LegacyCommandData(
+        params=LegacyCommandParams(
             legacyCommandType="command.PAUSE",
             legacyCommandText="hello world",
         ),
@@ -71,7 +71,7 @@ def test_map_after_command() -> None:
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
         completedAt=matchers.IsA(datetime),
-        params=LegacyCommandData(
+        params=LegacyCommandParams(
             legacyCommandType="command.PAUSE",
             legacyCommandText="hello world",
         ),
@@ -104,7 +104,7 @@ def test_map_after_with_error_command() -> None:
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
         completedAt=matchers.IsA(datetime),
-        params=LegacyCommandData(
+        params=LegacyCommandParams(
             legacyCommandType="command.PAUSE",
             legacyCommandText="hello world",
         ),
@@ -150,7 +150,7 @@ def test_command_stack() -> None:
         status=pe_commands.CommandStatus.RUNNING,
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
-        params=LegacyCommandData(
+        params=LegacyCommandParams(
             legacyCommandType="command.PAUSE",
             legacyCommandText="hello",
         ),
@@ -160,7 +160,7 @@ def test_command_stack() -> None:
         status=pe_commands.CommandStatus.RUNNING,
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
-        params=LegacyCommandData(
+        params=LegacyCommandParams(
             legacyCommandType="command.PAUSE",
             legacyCommandText="goodbye",
         ),
@@ -171,7 +171,7 @@ def test_command_stack() -> None:
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
         completedAt=matchers.IsA(datetime),
-        params=LegacyCommandData(
+        params=LegacyCommandParams(
             legacyCommandType="command.PAUSE",
             legacyCommandText="goodbye",
         ),
@@ -182,7 +182,7 @@ def test_command_stack() -> None:
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
         completedAt=matchers.IsA(datetime),
-        params=LegacyCommandData(
+        params=LegacyCommandParams(
             legacyCommandType="command.PAUSE",
             legacyCommandText="hello",
         ),
@@ -205,7 +205,7 @@ def test_map_labware_load(minimal_labware_def: LabwareDefinition) -> None:
         startedAt=matchers.IsA(datetime),
         completedAt=matchers.IsA(datetime),
         params=pe_commands.LoadLabwareParams.construct(
-            location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
             namespace="some_namespace",
             loadName="some_load_name",
             version=123,
@@ -214,7 +214,7 @@ def test_map_labware_load(minimal_labware_def: LabwareDefinition) -> None:
         result=pe_commands.LoadLabwareResult.construct(
             labwareId=matchers.IsA(str),
             # Trusting that the exact fields within in the labware definition
-            # get passed through corectly.
+            # get passed through correctly.
             definition=matchers.Anything(),
             calibration=CalibrationOffset(x=0, y=0, z=0),
         ),

--- a/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
@@ -154,14 +154,14 @@ def test_main_broker_messages(
     legacy_command: PauseMessage = {
         "$": "before",
         "name": "command.PAUSE",
-        "payload": {"userMessage": "hello world", "text": "hello world"},
+        "payload": {"userMessage": "hello", "text": "hello"},
         "error": None,
     }
     engine_command = pe_commands.Custom(
         id="command-id",
         status=pe_commands.CommandStatus.RUNNING,
         createdAt=datetime(year=2021, month=1, day=1),
-        data=pe_commands.CustomData(message="hello world"),  # type: ignore[call-arg]
+        params=pe_commands.CustomParams(message="hello"),  # type: ignore[call-arg]
     )
 
     decoy.when(legacy_command_mapper.map_command(command=legacy_command)).then_return(
@@ -204,7 +204,7 @@ def test_labware_load_broker_messages(
         id="command-id",
         status=pe_commands.CommandStatus.RUNNING,
         createdAt=datetime(year=2021, month=1, day=1),
-        data=pe_commands.CustomData(message="hello world"),  # type: ignore[call-arg]
+        params=pe_commands.CustomParams(message="hello"),  # type: ignore[call-arg]
     )
 
     decoy.when(
@@ -244,7 +244,7 @@ def test_instrument_load_broker_messages(
         id="command-id",
         status=pe_commands.CommandStatus.RUNNING,
         createdAt=datetime(year=2021, month=1, day=1),
-        data=pe_commands.CustomData(message="hello world"),  # type: ignore[call-arg]
+        params=pe_commands.CustomParams(message="hello"),  # type: ignore[call-arg]
     )
 
     decoy.when(

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner.py
@@ -194,9 +194,9 @@ def test_load_json(
 
     json_protocol = JsonProtocol.construct()  # type: ignore[call-arg]
 
-    commands: List[pe_commands.CommandRequest] = [
-        pe_commands.PauseRequest(data=pe_commands.PauseData(message="hello")),
-        pe_commands.PauseRequest(data=pe_commands.PauseData(message="goodbye")),
+    commands: List[pe_commands.CommandCreate] = [
+        pe_commands.PauseCreate(params=pe_commands.PauseParams(message="hello")),
+        pe_commands.PauseCreate(params=pe_commands.PauseParams(message="goodbye")),
     ]
 
     decoy.when(json_file_reader.read(json_protocol_source)).then_return(json_protocol)
@@ -206,13 +206,13 @@ def test_load_json(
 
     decoy.verify(
         protocol_engine.add_command(
-            request=pe_commands.PauseRequest(
-                data=pe_commands.PauseData(message="hello")
+            request=pe_commands.PauseCreate(
+                params=pe_commands.PauseParams(message="hello")
             )
         ),
         protocol_engine.add_command(
-            request=pe_commands.PauseRequest(
-                data=pe_commands.PauseData(message="goodbye")
+            request=pe_commands.PauseCreate(
+                params=pe_commands.PauseParams(message="goodbye")
             )
         ),
         task_queue.set_run_func(func=protocol_engine.wait_until_complete),

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner_smoke.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner_smoke.py
@@ -30,7 +30,7 @@ from opentrons.protocol_runner import (
     PythonPreAnalysis,
     create_simulating_runner,
 )
-from opentrons.protocol_runner.legacy_command_mapper import LegacyCommandData
+from opentrons.protocol_runner.legacy_command_mapper import LegacyCommandParams
 
 
 async def test_runner_with_python(python_protocol_file: Path) -> None:
@@ -57,7 +57,7 @@ async def test_runner_with_python(python_protocol_file: Path) -> None:
 
     expected_labware = LoadedLabware.construct(
         id=labware_id_captor,
-        location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
         loadName="opentrons_96_tiprack_300ul",
         definitionUri="opentrons/opentrons_96_tiprack_300ul/1",
     )
@@ -104,7 +104,7 @@ async def test_runner_with_json(json_protocol_file: Path) -> None:
 
     expected_labware = LoadedLabware(
         id="labware-id",
-        location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
         loadName="opentrons_96_tiprack_300ul",
         definitionUri="opentrons/opentrons_96_tiprack_300ul/1",
     )
@@ -154,7 +154,7 @@ async def test_runner_with_legacy_python(legacy_python_protocol_file: Path) -> N
 
     expected_labware = LoadedLabware.construct(
         id=labware_id_captor,
-        location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
         loadName="opentrons_96_tiprack_300ul",
         definitionUri="opentrons/opentrons_96_tiprack_300ul/1",
     )
@@ -168,7 +168,7 @@ async def test_runner_with_legacy_python(legacy_python_protocol_file: Path) -> N
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
         completedAt=matchers.IsA(datetime),
-        params=LegacyCommandData(
+        params=LegacyCommandParams(
             legacyCommandType="command.PICK_UP_TIP",
             legacyCommandText="Picking up tip from A1 of Opentrons 96 Tip Rack 300 µL on 1",  # noqa: E501
         ),
@@ -203,7 +203,7 @@ async def test_runner_with_legacy_json(legacy_json_protocol_file: Path) -> None:
 
     expected_labware = LoadedLabware.construct(
         id=labware_id_captor,
-        location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
         loadName="opentrons_96_tiprack_300ul",
         definitionUri="opentrons/opentrons_96_tiprack_300ul/1",
     )
@@ -217,7 +217,7 @@ async def test_runner_with_legacy_json(legacy_json_protocol_file: Path) -> None:
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
         completedAt=matchers.IsA(datetime),
-        params=LegacyCommandData(
+        params=LegacyCommandParams(
             legacyCommandType="command.PICK_UP_TIP",
             legacyCommandText="Picking up tip from A1 of Opentrons 96 Tip Rack 300 µL on 1",  # noqa: E501
         ),

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner_smoke.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner_smoke.py
@@ -71,7 +71,7 @@ async def test_runner_with_python(python_protocol_file: Path) -> None:
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
         completedAt=matchers.IsA(datetime),
-        data=commands.PickUpTipData(
+        params=commands.PickUpTipParams(
             pipetteId=pipette_id_captor.value,
             labwareId=labware_id_captor.value,
             wellName="A1",
@@ -118,7 +118,7 @@ async def test_runner_with_json(json_protocol_file: Path) -> None:
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
         completedAt=matchers.IsA(datetime),
-        data=commands.PickUpTipData(
+        params=commands.PickUpTipParams(
             pipetteId="pipette-id",
             labwareId="labware-id",
             wellName="A1",
@@ -168,7 +168,7 @@ async def test_runner_with_legacy_python(legacy_python_protocol_file: Path) -> N
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
         completedAt=matchers.IsA(datetime),
-        data=LegacyCommandData(
+        params=LegacyCommandData(
             legacyCommandType="command.PICK_UP_TIP",
             legacyCommandText="Picking up tip from A1 of Opentrons 96 Tip Rack 300 µL on 1",  # noqa: E501
         ),
@@ -217,7 +217,7 @@ async def test_runner_with_legacy_json(legacy_json_protocol_file: Path) -> None:
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
         completedAt=matchers.IsA(datetime),
-        data=LegacyCommandData(
+        params=LegacyCommandData(
             legacyCommandType="command.PICK_UP_TIP",
             legacyCommandText="Picking up tip from A1 of Opentrons 96 Tip Rack 300 µL on 1",  # noqa: E501
         ),

--- a/api/tests/opentrons/protocol_runner/test_python_context_creator.py
+++ b/api/tests/opentrons/protocol_runner/test_python_context_creator.py
@@ -54,4 +54,4 @@ async def test_wires_protocol_context_to_engine(
         labware_id=result.labware_id
     )
 
-    assert labware_location == DeckSlotLocation(slot=DeckSlotName.SLOT_1)
+    assert labware_location == DeckSlotLocation(slotName=DeckSlotName.SLOT_1)

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -42,8 +42,8 @@ class CommandNotFound(ErrorDetails):
         status.HTTP_404_NOT_FOUND: {"model": ErrorResponse[RunNotFound]},
     },
 )
-async def post_run_command(
-    request_body: RequestModel[pe_commands.CommandRequest],
+async def create_run_command(
+    request_body: RequestModel[pe_commands.CommandCreate],
     engine_store: EngineStore = Depends(get_engine_store),
     run: ResponseModel[Run, None] = Depends(get_run),
 ) -> ResponseModel[pe_commands.Command, None]:

--- a/robot-server/robot_server/service/session/models/command.py
+++ b/robot-server/robot_server/service/session/models/command.py
@@ -153,75 +153,75 @@ SimpleCommandResponse = SessionCommandResponse[
 """Response to :class:`~SimpleCommandRequest`"""
 
 
-LoadLabwareRequest = SessionCommandRequest[
+LoadLabwareCreate = SessionCommandRequest[
     Literal[EquipmentCommand.load_labware],
-    commands.LoadLabwareRequest,
+    commands.LoadLabwareCreate,
     commands.LoadLabwareResult,
 ]
 
 
 LoadLabwareResponse = SessionCommandResponse[
     Literal[EquipmentCommand.load_labware],
-    commands.LoadLabwareRequest,
+    commands.LoadLabwareCreate,
     commands.LoadLabwareResult,
 ]
 
 
 LoadInstrumentRequest = SessionCommandRequest[
     Literal[EquipmentCommand.load_pipette],
-    commands.LoadPipetteRequest,
+    commands.LoadPipetteCreate,
     commands.LoadPipetteResult,
 ]
 
 
 LoadInstrumentResponse = SessionCommandResponse[
     Literal[EquipmentCommand.load_pipette],
-    commands.LoadPipetteRequest,
+    commands.LoadPipetteCreate,
     commands.LoadPipetteResult,
 ]
 
 
-AspirateRequest = SessionCommandRequest[
-    Literal[PipetteCommand.aspirate], commands.AspirateRequest, commands.AspirateResult
+AspirateCreate = SessionCommandRequest[
+    Literal[PipetteCommand.aspirate], commands.AspirateCreate, commands.AspirateResult
 ]
 
 
 AspirateResponse = SessionCommandResponse[
-    Literal[PipetteCommand.aspirate], commands.AspirateRequest, commands.AspirateResult
+    Literal[PipetteCommand.aspirate], commands.AspirateCreate, commands.AspirateResult
 ]
 
 
-DispenseRequest = SessionCommandRequest[
-    Literal[PipetteCommand.dispense], commands.DispenseRequest, commands.DispenseResult
+DispenseCreate = SessionCommandRequest[
+    Literal[PipetteCommand.dispense], commands.DispenseCreate, commands.DispenseResult
 ]
 
 
 DispenseResponse = SessionCommandResponse[
-    Literal[PipetteCommand.dispense], commands.DispenseRequest, commands.DispenseResult
+    Literal[PipetteCommand.dispense], commands.DispenseCreate, commands.DispenseResult
 ]
 
 
-PickUpTipRequest = SessionCommandRequest[
+PickUpTipCreate = SessionCommandRequest[
     Literal[PipetteCommand.pick_up_tip],
-    commands.PickUpTipRequest,
+    commands.PickUpTipCreate,
     commands.PickUpTipResult,
 ]
 
 
 PickUpTipResponse = SessionCommandResponse[
     Literal[PipetteCommand.pick_up_tip],
-    commands.PickUpTipRequest,
+    commands.PickUpTipCreate,
     commands.PickUpTipResult,
 ]
 
 
-DropTipRequest = SessionCommandRequest[
-    Literal[PipetteCommand.drop_tip], commands.DropTipRequest, commands.DropTipResult
+DropTipCreate = SessionCommandRequest[
+    Literal[PipetteCommand.drop_tip], commands.DropTipCreate, commands.DropTipResult
 ]
 
 
 DropTipResponse = SessionCommandResponse[
-    Literal[PipetteCommand.drop_tip], commands.DropTipRequest, commands.DropTipResult
+    Literal[PipetteCommand.drop_tip], commands.DropTipCreate, commands.DropTipResult
 ]
 
 
@@ -265,12 +265,12 @@ SetHasCalibrationBlockResponse = SessionCommandResponse[
 
 RequestTypes = typing.Union[
     SimpleCommandRequest,
-    LoadLabwareRequest,
+    LoadLabwareCreate,
     LoadInstrumentRequest,
-    AspirateRequest,
-    DispenseRequest,
-    PickUpTipRequest,
-    DropTipRequest,
+    AspirateCreate,
+    DispenseCreate,
+    PickUpTipCreate,
+    DropTipCreate,
     JogRequest,
     SetHasCalibrationBlockRequest,
     LabwareByDefinitionRequest,

--- a/robot-server/tests/protocols/test_analysis_store.py
+++ b/robot-server/tests/protocols/test_analysis_store.py
@@ -64,7 +64,7 @@ def test_add_analysis_equipment() -> None:
         id="labware-id",
         loadName="load-name",
         definitionUri="namespace/load-name/42",
-        location=pe_types.DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+        location=pe_types.DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
     )
 
     pipette = pe_types.LoadedPipette(

--- a/robot-server/tests/protocols/test_analysis_store.py
+++ b/robot-server/tests/protocols/test_analysis_store.py
@@ -111,7 +111,7 @@ command_analysis_specs: List[CommandAnalysisSpec] = [
                 id="pause-1",
                 status=pe_commands.CommandStatus.SUCCEEDED,
                 createdAt=datetime(year=2021, month=1, day=1),
-                data=pe_commands.PauseData(message="hello world"),
+                params=pe_commands.PauseParams(message="hello world"),
                 result=pe_commands.PauseResult(),
             )
         ],
@@ -123,7 +123,7 @@ command_analysis_specs: List[CommandAnalysisSpec] = [
                 id="pause-1",
                 status=pe_commands.CommandStatus.FAILED,
                 createdAt=datetime(year=2021, month=1, day=1),
-                data=pe_commands.PauseData(message="hello world"),
+                params=pe_commands.PauseParams(message="hello world"),
                 error="Oh no!",
             )
         ],

--- a/robot-server/tests/protocols/test_protocol_analyzer.py
+++ b/robot-server/tests/protocols/test_protocol_analyzer.py
@@ -54,7 +54,7 @@ async def test_analyze(
         id="command-id",
         status=pe_commands.CommandStatus.SUCCEEDED,
         createdAt=datetime(year=2022, month=2, day=2),
-        data=pe_commands.PauseData(message="hello world"),
+        params=pe_commands.PauseParams(message="hello world"),
     )
 
     analysis_labware = pe_types.LoadedLabware(

--- a/robot-server/tests/protocols/test_protocol_analyzer.py
+++ b/robot-server/tests/protocols/test_protocol_analyzer.py
@@ -61,7 +61,7 @@ async def test_analyze(
         id="labware-id",
         loadName="load-name",
         definitionUri="namespace/load-name/42",
-        location=pe_types.DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+        location=pe_types.DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
     )
 
     analysis_pipette = pe_types.LoadedPipette(

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -247,7 +247,7 @@ async def test_get_run(
         id="command-id",
         status=pe_commands.CommandStatus.QUEUED,
         createdAt=datetime(year=2021, month=1, day=1),
-        data=pe_commands.PauseData(message="hello world"),
+        params=pe_commands.PauseParams(message="hello world"),
     )
 
     labware = pe_types.LoadedLabware(

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -254,7 +254,7 @@ async def test_get_run(
         id="labware-id",
         loadName="load-name",
         definitionUri="namespace/load-name/42",
-        location=pe_types.DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+        location=pe_types.DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
     )
 
     pipette = pe_types.LoadedPipette(

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -17,16 +17,16 @@ from robot_server.service.json_api import RequestModel, ResponseModel
 from robot_server.runs.run_models import Run, RunCommandSummary
 from robot_server.runs.engine_store import EngineStore
 from robot_server.runs.router.commands_router import (
-    post_run_command,
+    create_run_command,
     get_run_command,
     get_run_commands,
 )
 
 
-async def test_post_run_command(decoy: Decoy, engine_store: EngineStore) -> None:
+async def test_create_run_command(decoy: Decoy, engine_store: EngineStore) -> None:
     """It should add the requested command to the ProtocolEngine and return it."""
-    command_request = pe_commands.PauseRequest(
-        data=pe_commands.PauseData(message="Hello")
+    command_request = pe_commands.PauseCreate(
+        params=pe_commands.PauseParams(message="Hello")
     )
 
     run = Run(
@@ -45,7 +45,7 @@ async def test_post_run_command(decoy: Decoy, engine_store: EngineStore) -> None
         id="abc123",
         createdAt=datetime(year=2021, month=1, day=1),
         status=CommandStatus.QUEUED,
-        data=pe_commands.PauseData(message="Hello"),
+        params=pe_commands.PauseParams(message="Hello"),
         result=None,
     )
 
@@ -53,7 +53,7 @@ async def test_post_run_command(decoy: Decoy, engine_store: EngineStore) -> None
         output_command
     )
 
-    response = await post_run_command(
+    response = await create_run_command(
         request_body=RequestModel(data=command_request),
         engine_store=engine_store,
         run=ResponseModel(data=run, links=None),
@@ -62,13 +62,13 @@ async def test_post_run_command(decoy: Decoy, engine_store: EngineStore) -> None
     assert response.data == output_command
 
 
-async def test_post_run_command_not_current(
+async def test_create_run_command_not_current(
     decoy: Decoy,
     engine_store: EngineStore,
 ) -> None:
     """It should 400 if you try to add commands to non-current run."""
-    command_request = pe_commands.PauseRequest(
-        data=pe_commands.PauseData(message="Hello")
+    command_request = pe_commands.PauseCreate(
+        params=pe_commands.PauseParams(message="Hello")
     )
 
     run = Run(
@@ -84,7 +84,7 @@ async def test_post_run_command_not_current(
     )
 
     with pytest.raises(ApiError) as exc_info:
-        await post_run_command(
+        await create_run_command(
             request_body=RequestModel(data=command_request),
             engine_store=engine_store,
             run=ResponseModel(data=run, links=None),
@@ -134,7 +134,7 @@ async def test_get_run_command_by_id(
         id="command-id",
         status=CommandStatus.RUNNING,
         createdAt=datetime(year=2022, month=2, day=2),
-        data=pe_commands.MoveToWellData(pipetteId="a", labwareId="b", wellName="c"),
+        params=pe_commands.MoveToWellParams(pipetteId="a", labwareId="b", wellName="c"),
     )
 
     run = Run(

--- a/robot-server/tests/runs/test_run_view.py
+++ b/robot-server/tests/runs/test_run_view.py
@@ -129,7 +129,7 @@ def test_to_response_adds_equipment() -> None:
         id="labware-id",
         loadName="load-name",
         definitionUri="namespace/load-name/42",
-        location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
     )
 
     pipette = LoadedPipette(

--- a/robot-server/tests/runs/test_run_view.py
+++ b/robot-server/tests/runs/test_run_view.py
@@ -69,7 +69,7 @@ def test_to_response_maps_commands() -> None:
         id="command-1",
         status=CommandStatus.RUNNING,
         createdAt=datetime(year=2022, month=2, day=2),
-        data=pe_commands.LoadPipetteData(
+        params=pe_commands.LoadPipetteParams(
             mount=MountType.LEFT,
             pipetteName=PipetteName.P300_SINGLE,
         ),
@@ -79,7 +79,7 @@ def test_to_response_maps_commands() -> None:
         id="command-2",
         status=CommandStatus.QUEUED,
         createdAt=datetime(year=2023, month=3, day=3),
-        data=pe_commands.MoveToWellData(pipetteId="a", labwareId="b", wellName="c"),
+        params=pe_commands.MoveToWellParams(pipetteId="a", labwareId="b", wellName="c"),
     )
 
     subject = RunView()


### PR DESCRIPTION
## Overview

This PR aligns public `ProtocolEngine` command models with JSON API schema v6 and HTTP API conventions. Closes #8526

## Changelog

- The name of a command's payload field should be `params`
- The name of a slot location should be `slotName`
- Models that represent a creation request for a given resource should be named `ResourceNameCreate`

## Review requests

- [ ] Code review, make sure my find-and-replace's didn't catch anything they weren't supposed to
- [ ] Smoke test if you have time, but will require updating the Postman collections

## Risk assessment

Low