### PR TITLE
refactor(hardware): add current position to payload

### DIFF
--- a/hardware/opentrons_hardware/drivers/can_bus/messages/payloads.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/messages/payloads.py
@@ -107,6 +107,6 @@ class MoveCompletedPayload(MoveGroupRequestPayload):
     """Notification of a completed move group."""
 
     seq_id: utils.UInt8Field
-    current_position: utils.UInt64Field
+    current_position: utils.UInt32Field
     ack_id: utils.UInt8Field
     node_id: utils.UInt8Field

--- a/hardware/opentrons_hardware/drivers/can_bus/messages/payloads.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/messages/payloads.py
@@ -107,5 +107,6 @@ class MoveCompletedPayload(MoveGroupRequestPayload):
     """Notification of a completed move group."""
 
     seq_id: utils.UInt8Field
+    current_position: utils.UInt64Field
     ack_id: utils.UInt8Field
     node_id: utils.UInt8Field

--- a/hardware/tests/opentrons_hardware/drivers/can_bus/test_can_messenger.py
+++ b/hardware/tests/opentrons_hardware/drivers/can_bus/test_can_messenger.py
@@ -28,7 +28,7 @@ from opentrons_hardware.drivers.can_bus.messages.payloads import (
     MoveCompletedPayload,
     MoveGroupRequestPayload,
 )
-from opentrons_hardware.utils import UInt8Field
+from opentrons_hardware.utils import UInt8Field, UInt32Field
 
 
 @pytest.fixture
@@ -62,8 +62,9 @@ def subject(mock_driver: AsyncMock) -> CanMessenger:
                 payload=MoveCompletedPayload(
                     group_id=UInt8Field(1),
                     seq_id=UInt8Field(2),
-                    ack_id=UInt8Field(3),
-                    node_id=UInt8Field(4),
+                    current_position=UInt32Field(3),
+                    ack_id=UInt8Field(4),
+                    node_id=UInt8Field(5),
                 )
             ),
         ],

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -306,6 +306,7 @@ class MockSendMoveCompleter:
                     payload = MoveCompletedPayload(
                         group_id=message.payload.group_id,
                         seq_id=UInt8Field(seq_id),
+                        current_position=UInt32Field(0),
                         node_id=UInt8Field(node.value),
                         ack_id=UInt8Field(0),
                     )


### PR DESCRIPTION
The MoveCompleted message now returns the current position when a move finishes.