### PR TITLE
feat(can): create clear all move groups request.

### DIFF
--- a/hardware/opentrons_hardware/drivers/can_bus/constants.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/constants.py
@@ -60,6 +60,7 @@ class MessageId(int, Enum):
     get_move_group_response = 0x17
     execute_move_group_request = 0x18
     clear_move_group_request = 0x19
+    clear_all_move_groups_request = 0x1B
     move_group_completed = 0x1A
     move_completed = 0x13
     get_move_status_request = 0x30

--- a/hardware/opentrons_hardware/drivers/can_bus/constants.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/constants.py
@@ -59,8 +59,7 @@ class MessageId(int, Enum):
     get_move_group_request = 0x16
     get_move_group_response = 0x17
     execute_move_group_request = 0x18
-    clear_move_group_request = 0x19
-    clear_all_move_groups_request = 0x1B
+    clear_all_move_groups_request = 0x19
     move_group_completed = 0x1A
     move_completed = 0x13
     get_move_status_request = 0x30

--- a/hardware/opentrons_hardware/drivers/can_bus/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/messages/message_definitions.py
@@ -158,15 +158,6 @@ class ExecuteMoveGroupRequest:  # noqa: D101
 
 
 @dataclass
-class ClearMoveGroupRequest:  # noqa: D101
-    payload: payloads.MoveGroupRequestPayload
-    payload_type: Type[BinarySerializable] = payloads.MoveGroupRequestPayload
-    message_id: Literal[
-        MessageId.clear_move_group_request
-    ] = MessageId.clear_move_group_request
-
-
-@dataclass
 class ClearAllMoveGroupsRequest:  # noqa: D101
     payload: payloads.EmptyPayload
     payload_type: Type[BinarySerializable] = payloads.EmptyPayload

--- a/hardware/opentrons_hardware/drivers/can_bus/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/messages/message_definitions.py
@@ -167,6 +167,15 @@ class ClearMoveGroupRequest:  # noqa: D101
 
 
 @dataclass
+class ClearAllMoveGroupsRequest:  # noqa: D101
+    payload: payloads.EmptyPayload
+    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+    message_id: Literal[
+        MessageId.clear_all_move_groups_request
+    ] = MessageId.clear_all_move_groups_request
+
+
+@dataclass
 class MoveGroupCompleted:  # noqa: D101
     payload: payloads.MoveGroupCompletedPayload
     payload_type: Type[BinarySerializable] = payloads.MoveGroupCompletedPayload

--- a/hardware/opentrons_hardware/drivers/can_bus/messages/messages.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/messages/messages.py
@@ -29,6 +29,7 @@ MessageDefinition = Union[
     defs.GetMoveGroupResponse,
     defs.ExecuteMoveGroupRequest,
     defs.ClearMoveGroupRequest,
+    defs.ClearAllMoveGroupsRequest,
     defs.MoveGroupCompleted,
     defs.MoveCompleted,
     defs.GetMoveStatusRequest,

--- a/hardware/opentrons_hardware/drivers/can_bus/messages/messages.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/messages/messages.py
@@ -28,7 +28,6 @@ MessageDefinition = Union[
     defs.GetMoveGroupRequest,
     defs.GetMoveGroupResponse,
     defs.ExecuteMoveGroupRequest,
-    defs.ClearMoveGroupRequest,
     defs.ClearAllMoveGroupsRequest,
     defs.MoveGroupCompleted,
     defs.MoveCompleted,

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -8,15 +8,15 @@ from opentrons_hardware.drivers.can_bus.can_messenger import (
 )
 from opentrons_hardware.drivers.can_bus.messages import MessageDefinition
 from opentrons_hardware.drivers.can_bus.messages.message_definitions import (
-    ClearMoveGroupRequest,
+    ClearAllMoveGroupsRequest,
     AddLinearMoveRequest,
     MoveCompleted,
     ExecuteMoveGroupRequest,
 )
 from opentrons_hardware.drivers.can_bus.messages.payloads import (
-    MoveGroupRequestPayload,
     AddLinearMoveRequestPayload,
     ExecuteMoveGroupRequestPayload,
+    EmptyPayload,
 )
 from opentrons_hardware.hardware_control.constants import interrupts_per_sec
 from opentrons_hardware.hardware_control.motion import MoveGroups
@@ -49,13 +49,10 @@ class MoveGroupRunner:
 
     async def _clear_groups(self, can_messenger: CanMessenger) -> None:
         """Send commands to clear the message groups."""
-        for i, g in enumerate(self._move_groups):
-            await can_messenger.send(
-                node_id=NodeId.broadcast,
-                message=ClearMoveGroupRequest(
-                    payload=MoveGroupRequestPayload(group_id=UInt8Field(i))
-                ),
-            )
+        await can_messenger.send(
+            node_id=NodeId.broadcast,
+            message=ClearAllMoveGroupsRequest(payload=EmptyPayload()),
+        )
 
     async def _send_groups(self, can_messenger: CanMessenger) -> None:
         """Send commands to set up the message groups."""

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -8,9 +8,9 @@ from opentrons_hardware.drivers.can_bus.messages.message_definitions import (
     AddLinearMoveRequest,
 )
 from opentrons_hardware.drivers.can_bus.messages.payloads import (
-    MoveGroupRequestPayload,
     AddLinearMoveRequestPayload,
     MoveCompletedPayload,
+    EmptyPayload,
     ExecuteMoveGroupRequestPayload,
 )
 from opentrons_hardware.hardware_control.constants import interrupts_per_sec
@@ -94,11 +94,9 @@ async def test_single_group_clear(
     """It should send a clear group command before setup."""
     subject = MoveGroupRunner(move_groups=move_group_single)
     await subject._clear_groups(can_messenger=mock_can_messenger)
-    mock_can_messenger.send.assert_called_with(
+    mock_can_messenger.send.assert_called_once_with(
         node_id=NodeId.broadcast,
-        message=md.ClearMoveGroupRequest(
-            payload=MoveGroupRequestPayload(group_id=UInt8Field(0))
-        ),
+        message=md.ClearAllMoveGroupsRequest(payload=EmptyPayload()),
     )
 
 
@@ -108,13 +106,10 @@ async def test_multi_group_clear(
     """It should send a clear group command before setup."""
     subject = MoveGroupRunner(move_groups=move_group_multiple)
     await subject._clear_groups(can_messenger=mock_can_messenger)
-    for i in range(len(move_group_multiple)):
-        mock_can_messenger.send.assert_any_call(
-            node_id=NodeId.broadcast,
-            message=md.ClearMoveGroupRequest(
-                payload=MoveGroupRequestPayload(group_id=UInt8Field(i))
-            ),
-        )
+    mock_can_messenger.send.assert_called_once_with(
+        node_id=NodeId.broadcast,
+        message=md.ClearAllMoveGroupsRequest(payload=EmptyPayload()),
+    )
 
 
 async def test_single_send_setup_commands(


### PR DESCRIPTION
# Overview

There is no real use case for sending commands to clear only some motion groups. We should clear them all.

# Changelog

- Add ability to send a message that clears all the motion groups. 
- Removed the message that removes one group at a time.

# Review requests


# Risk assessment

None