### PR TITLE
refactor(protocol-engine): Centralize labware offset resource models under Protocol Engine

### DIFF
--- a/api/src/opentrons/protocol_engine/__init__.py
+++ b/api/src/opentrons/protocol_engine/__init__.py
@@ -15,7 +15,7 @@ from .plugins import AbstractPlugin
 from .types import (
     LabwareOffset,
     LabwareOffsetCreate,
-    CalibrationOffset,
+    LabwareOffsetVector,
     DeckSlotLocation,
     Dimensions,
     EngineStatus,
@@ -45,7 +45,7 @@ __all__ = [
     # public value interfaces and models
     "LabwareOffset",
     "LabwareOffsetCreate",
-    "CalibrationOffset",
+    "LabwareOffsetVector",
     "DeckSlotLocation",
     "Dimensions",
     "EngineStatus",

--- a/api/src/opentrons/protocol_engine/__init__.py
+++ b/api/src/opentrons/protocol_engine/__init__.py
@@ -13,6 +13,8 @@ from .state import State, StateView
 from .plugins import AbstractPlugin
 
 from .types import (
+    LabwareOffset,
+    LabwareOffsetCreate,
     CalibrationOffset,
     DeckSlotLocation,
     Dimensions,
@@ -41,6 +43,8 @@ __all__ = [
     "State",
     "StateView",
     # public value interfaces and models
+    "LabwareOffset",
+    "LabwareOffsetCreate",
     "CalibrationOffset",
     "DeckSlotLocation",
     "Dimensions",

--- a/api/src/opentrons/protocol_engine/commands/load_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/load_labware.py
@@ -6,7 +6,7 @@ from typing_extensions import Literal
 
 from opentrons.protocols.models import LabwareDefinition
 
-from ..types import LabwareLocation, CalibrationOffset
+from ..types import LabwareLocation, LabwareOffsetVector
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 LoadLabwareCommandType = Literal["loadLabware"]
@@ -49,7 +49,7 @@ class LoadLabwareResult(BaseModel):
         ...,
         description="The full definition data for this labware.",
     )
-    calibration: CalibrationOffset = Field(
+    calibration: LabwareOffsetVector = Field(
         ...,
         description="Calibration offset data for this labware at load time.",
     )
@@ -74,7 +74,7 @@ class LoadLabwareImplementation(
         return LoadLabwareResult(
             labwareId=loaded_labware.labware_id,
             definition=loaded_labware.definition,
-            calibration=CalibrationOffset(x=x_offset, y=y_offset, z=z_offset),
+            calibration=LabwareOffsetVector(x=x_offset, y=y_offset, z=z_offset),
         )
 
 

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -17,7 +17,7 @@ from opentrons.calibration_storage.helpers import uri_from_details
 from .. import errors
 from ..resources import DeckFixedLabware
 from ..commands import Command, LoadLabwareResult, AddLabwareDefinitionResult
-from ..types import CalibrationOffset, LabwareLocation, LoadedLabware, Dimensions
+from ..types import LabwareOffsetVector, LabwareLocation, LoadedLabware, Dimensions
 from ..actions import Action, UpdateCommandAction
 from .abstract_store import HasState, HandlesActions
 
@@ -27,7 +27,7 @@ class LabwareState:
     """State of all loaded labware resources."""
 
     labware_by_id: Dict[str, LoadedLabware]
-    calibrations_by_id: Dict[str, CalibrationOffset]
+    calibrations_by_id: Dict[str, LabwareOffsetVector]
     definitions_by_uri: Dict[str, LabwareDefinition]
     deck_definition: DeckDefinitionV2
 
@@ -65,7 +65,7 @@ class LabwareStore(HasState[LabwareState], HandlesActions):
             for fixed_labware in deck_fixed_labware
         }
         calibrations_by_id = {
-            fixed_labware.labware_id: CalibrationOffset(x=0, y=0, z=0)
+            fixed_labware.labware_id: LabwareOffsetVector(x=0, y=0, z=0)
             for fixed_labware in deck_fixed_labware
         }
 
@@ -274,7 +274,7 @@ class LabwareView(HasState[LabwareState]):
             z=dims.zDimension,
         )
 
-    def get_calibration_offset(self, labware_id: str) -> CalibrationOffset:
+    def get_calibration_offset(self, labware_id: str) -> LabwareOffsetVector:
         """Get the labware's calibration offset."""
         try:
             return self._state.calibrations_by_id[labware_id]

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -61,14 +61,6 @@ class Dimensions:
     z: float
 
 
-class CalibrationOffset(BaseModel):
-    """Calibration offset from nominal to actual position."""
-
-    x: float
-    y: float
-    z: float
-
-
 class DeckPoint(BaseModel):
     """Coordinates of a point in deck space."""
 
@@ -113,6 +105,14 @@ class LoadedLabware(BaseModel):
     location: LabwareLocation
 
 
+class LabwareOffsetVector(BaseModel):
+    """Offset, in deck coordinates from nominal to actual position."""
+
+    x: float
+    y: float
+    z: float
+
+
 class LabwareOffsetCreate(BaseModel):
     """Create request data for a labware offset."""
 
@@ -121,7 +121,7 @@ class LabwareOffsetCreate(BaseModel):
         ...,
         description="Where the labware is located on the robot.",
     )
-    offset: CalibrationOffset = Field(
+    offset: LabwareOffsetVector = Field(
         ...,
         description="The offset applied to matching labware.",
     )
@@ -141,7 +141,7 @@ class LabwareOffset(BaseModel):
         ...,
         description="Where the labware is located on the robot.",
     )
-    offset: CalibrationOffset = Field(
+    offset: LabwareOffsetVector = Field(
         ...,
         description="The offset applied to matching labware.",
     )

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -111,3 +111,37 @@ class LoadedLabware(BaseModel):
     loadName: str
     definitionUri: str
     location: LabwareLocation
+
+
+class LabwareOffsetCreate(BaseModel):
+    """Create request data for a labware offset."""
+
+    definitionUri: str = Field(..., description="The URI for the labware's definition.")
+    location: LabwareLocation = Field(
+        ...,
+        description="Where the labware is located on the robot.",
+    )
+    offset: CalibrationOffset = Field(
+        ...,
+        description="The offset applied to matching labware.",
+    )
+
+
+class LabwareOffset(BaseModel):
+    """An offset that the robot adds to a pipette's position when it moves to a labware.
+
+    During the run, if a labware is loaded whose definition URI and location
+    both match what's found here, the given offset will be added to all
+    pipette movements that use that labware as a reference point.
+    """
+
+    id: str = Field(..., description="Unique labware offset record identifier.")
+    definitionUri: str = Field(..., description="The URI for the labware's definition.")
+    location: LabwareLocation = Field(
+        ...,
+        description="Where the labware is located on the robot.",
+    )
+    offset: CalibrationOffset = Field(
+        ...,
+        description="The offset applied to matching labware.",
+    )

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -118,7 +118,7 @@ class LegacyCommandMapper:
                 definition=LabwareDefinition.parse_obj(
                     labware_load_info.labware_definition
                 ),
-                calibration=pe_types.CalibrationOffset(x=0, y=0, z=0),
+                calibration=pe_types.LabwareOffsetVector(x=0, y=0, z=0),
             ),
         )
 

--- a/api/tests/opentrons/protocol_api_experimental/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/test_protocol_context.py
@@ -5,7 +5,7 @@ from decoy import Decoy
 from opentrons_shared_data.labware import dev_types
 
 from opentrons.protocols.models import LabwareDefinition
-from opentrons.protocol_engine import CalibrationOffset, commands
+from opentrons.protocol_engine import LabwareOffsetVector, commands
 from opentrons.protocol_engine.clients import SyncClient
 
 from opentrons.protocol_api_experimental.types import (
@@ -142,7 +142,7 @@ def test_load_labware(
         commands.LoadLabwareResult(
             labwareId="abc123",
             definition=LabwareDefinition.parse_obj(minimal_labware_def),
-            calibration=CalibrationOffset(x=1, y=2, z=3),
+            calibration=LabwareOffsetVector(x=1, y=2, z=3),
         )
     )
 
@@ -174,7 +174,7 @@ def test_load_labware_default_namespace_and_version(
         commands.LoadLabwareResult(
             labwareId="abc123",
             definition=minimal_labware_def,
-            calibration=CalibrationOffset(x=1, y=2, z=3),
+            calibration=LabwareOffsetVector(x=1, y=2, z=3),
         )
     )
 

--- a/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
@@ -16,7 +16,7 @@ from opentrons.types import DeckSlotName, MountType
 from opentrons.protocol_engine import DeckSlotLocation, PipetteName, commands
 from opentrons.protocol_engine.clients import SyncClient, AbstractSyncTransport
 from opentrons.protocol_engine.types import (
-    CalibrationOffset,
+    LabwareOffsetVector,
     WellOrigin,
     WellOffset,
     WellLocation,
@@ -55,7 +55,7 @@ def stubbed_load_labware_result(
     result = commands.LoadLabwareResult(
         labwareId="abc123",
         definition=tip_rack_def,
-        calibration=CalibrationOffset(x=1, y=2, z=3),
+        calibration=LabwareOffsetVector(x=1, y=2, z=3),
     )
 
     decoy.when(transport.execute_command(request=request)).then_return(result)

--- a/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
@@ -3,7 +3,7 @@ from decoy import Decoy
 
 from opentrons.types import DeckSlotName
 from opentrons.protocols.models import LabwareDefinition
-from opentrons.protocol_engine.types import CalibrationOffset, DeckSlotLocation
+from opentrons.protocol_engine.types import LabwareOffsetVector, DeckSlotLocation
 from opentrons.protocol_engine.execution import (
     LoadedLabwareData,
     EquipmentHandler,
@@ -62,5 +62,5 @@ async def test_load_labware_implementation(
     assert result == LoadLabwareResult(
         labwareId="labware-id",
         definition=well_plate_def,
-        calibration=CalibrationOffset(x=1, y=2, z=3),
+        calibration=LabwareOffsetVector(x=1, y=2, z=3),
     )

--- a/api/tests/opentrons/protocol_engine/state/command_fixtures.py
+++ b/api/tests/opentrons/protocol_engine/state/command_fixtures.py
@@ -7,7 +7,7 @@ from opentrons.types import MountType
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.protocol_engine import commands as cmd
 from opentrons.protocol_engine.types import (
-    CalibrationOffset,
+    LabwareOffsetVector,
     PipetteName,
     WellLocation,
     LabwareLocation,
@@ -92,7 +92,7 @@ def create_load_labware_command(
     labware_id: str,
     location: LabwareLocation,
     definition: LabwareDefinition,
-    calibration: CalibrationOffset,
+    calibration: LabwareOffsetVector,
 ) -> cmd.LoadLabware:
     """Create a completed LoadLabware command."""
     params = cmd.LoadLabwareParams(

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -11,7 +11,7 @@ from opentrons.types import Point, DeckSlotName
 
 from opentrons.protocol_engine import errors
 from opentrons.protocol_engine.types import (
-    CalibrationOffset,
+    LabwareOffsetVector,
     DeckSlotLocation,
     LoadedLabware,
     WellLocation,
@@ -101,7 +101,7 @@ def test_get_labware_highest_z(
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
     )
     slot_pos = Point(1, 2, 3)
-    calibration_offset = CalibrationOffset(x=1, y=-2, z=3)
+    calibration_offset = LabwareOffsetVector(x=1, y=-2, z=3)
 
     decoy.when(labware_view.get("labware-id")).then_return(labware_data)
     decoy.when(labware_view.get_definition("labware-id")).then_return(well_plate_def)
@@ -139,8 +139,8 @@ def test_get_all_labware_highest_z(
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
     )
 
-    plate_offset = CalibrationOffset(x=1, y=-2, z=3)
-    reservoir_offset = CalibrationOffset(x=1, y=-2, z=3)
+    plate_offset = LabwareOffsetVector(x=1, y=-2, z=3)
+    reservoir_offset = LabwareOffsetVector(x=1, y=-2, z=3)
 
     decoy.when(labware_view.get_all()).then_return([plate, reservoir])
     decoy.when(labware_view.get("plate-id")).then_return(plate)
@@ -184,7 +184,7 @@ def test_get_labware_position(
         definitionUri="definition-uri",
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
     )
-    calibration_offset = CalibrationOffset(x=1, y=-2, z=3)
+    calibration_offset = LabwareOffsetVector(x=1, y=-2, z=3)
     slot_pos = Point(4, 5, 6)
 
     decoy.when(labware_view.get("labware-id")).then_return(labware_data)
@@ -219,7 +219,7 @@ def test_get_well_position(
         definitionUri="definition-uri",
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
     )
-    calibration_offset = CalibrationOffset(x=1, y=-2, z=3)
+    calibration_offset = LabwareOffsetVector(x=1, y=-2, z=3)
     slot_pos = Point(4, 5, 6)
     well_def = well_plate_def.wells["B2"]
 
@@ -258,7 +258,7 @@ def test_get_well_position_with_top_offset(
         definitionUri="definition-uri",
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
     )
-    calibration_offset = CalibrationOffset(x=1, y=-2, z=3)
+    calibration_offset = LabwareOffsetVector(x=1, y=-2, z=3)
     slot_pos = Point(4, 5, 6)
     well_def = well_plate_def.wells["B2"]
 
@@ -304,7 +304,7 @@ def test_get_well_position_with_bottom_offset(
         definitionUri="definition-uri",
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
     )
-    calibration_offset = CalibrationOffset(x=1, y=-2, z=3)
+    calibration_offset = LabwareOffsetVector(x=1, y=-2, z=3)
     slot_pos = Point(4, 5, 6)
     well_def = well_plate_def.wells["B2"]
 

--- a/api/tests/opentrons/protocol_engine/state/test_labware_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_store.py
@@ -8,7 +8,7 @@ from opentrons.types import DeckSlotName
 
 from opentrons.protocol_engine.resources import DeckFixedLabware
 from opentrons.protocol_engine.types import (
-    CalibrationOffset,
+    LabwareOffsetVector,
     DeckSlotLocation,
     LoadedLabware,
 )
@@ -58,7 +58,7 @@ def test_initial_state(
                 location=DeckSlotLocation(slotName=DeckSlotName.FIXED_TRASH),
             )
         },
-        calibrations_by_id={"fixedTrash": CalibrationOffset(x=0, y=0, z=0)},
+        calibrations_by_id={"fixedTrash": LabwareOffsetVector(x=0, y=0, z=0)},
         definitions_by_uri={expected_trash_uri: fixed_trash_def},
     )
 
@@ -72,7 +72,7 @@ def test_handles_load_labware(
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
         labware_id="test-labware-id",
         definition=well_plate_def,
-        calibration=CalibrationOffset(x=1, y=2, z=3),
+        calibration=LabwareOffsetVector(x=1, y=2, z=3),
     )
 
     expected_definition_uri = uri_from_details(
@@ -94,7 +94,7 @@ def test_handles_load_labware(
 
     assert subject.state.definitions_by_uri[expected_definition_uri] == well_plate_def
 
-    assert subject.state.calibrations_by_id["test-labware-id"] == CalibrationOffset(
+    assert subject.state.calibrations_by_id["test-labware-id"] == LabwareOffsetVector(
         x=1, y=2, z=3
     )
 

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -9,7 +9,7 @@ from opentrons.types import DeckSlotName, Point
 
 from opentrons.protocol_engine import errors
 from opentrons.protocol_engine.types import (
-    CalibrationOffset,
+    LabwareOffsetVector,
     DeckSlotLocation,
     Dimensions,
     LoadedLabware,
@@ -49,7 +49,7 @@ tip_rack = LoadedLabware(
 
 def get_labware_view(
     labware_by_id: Optional[Dict[str, LoadedLabware]] = None,
-    calibrations_by_id: Optional[Dict[str, CalibrationOffset]] = None,
+    calibrations_by_id: Optional[Dict[str, LabwareOffsetVector]] = None,
     definitions_by_uri: Optional[Dict[str, LabwareDefinition]] = None,
     deck_definition: Optional[DeckDefinitionV2] = None,
 ) -> LabwareView:
@@ -368,7 +368,7 @@ def test_get_slot_position(standard_deck_def: DeckDefinitionV2) -> None:
 
 def test_get_calibration_offset() -> None:
     """It should get a labware's calibrated offset."""
-    offset = CalibrationOffset(x=1, y=2, z=3)
+    offset = LabwareOffsetVector(x=1, y=2, z=3)
     subject = get_labware_view(calibrations_by_id={"labware-id": offset})
 
     result = subject.get_calibration_offset("labware-id")

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from opentrons.commands.types import PauseMessage
 from opentrons.protocol_engine import (
-    CalibrationOffset,
+    LabwareOffsetVector,
     DeckSlotLocation,
     PipetteName,
     commands as pe_commands,
@@ -218,7 +218,7 @@ def test_map_labware_load(minimal_labware_def: LabwareDefinition) -> None:
             # Trusting that the exact fields within in the labware definition
             # get passed through correctly.
             definition=matchers.Anything(),
-            calibration=CalibrationOffset(x=0, y=0, z=0),
+            calibration=LabwareOffsetVector(x=0, y=0, z=0),
         ),
     )
 

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -7,9 +7,10 @@ from opentrons.protocol_engine import (
     CommandStatus,
     CommandType,
     EngineStatus as RunStatus,
-    LabwareLocation,
     LoadedPipette,
     LoadedLabware,
+    LabwareOffset,
+    LabwareOffsetCreate,
 )
 from robot_server.service.json_api import ResourceModel
 from .action_models import RunAction
@@ -21,34 +22,6 @@ class RunCommandSummary(ResourceModel):
     id: str = Field(..., description="Unique command identifier.")
     commandType: CommandType = Field(..., description="Specific type of command.")
     status: CommandStatus = Field(..., description="Execution status of the command.")
-
-
-class LabwareOffsetVector(BaseModel):
-    """An offset to apply to labware, in deck coordinates."""
-
-    x: float
-    y: float
-    z: float
-
-
-class LabwareOffset(BaseModel):
-    """An offset that the robot adds to a pipette's position when it moves to a labware.
-
-    During the run, if a labware is loaded whose definition URI and location
-    both match what's found here, the given offset will be added to all
-    pipette movements that use that labware as a reference point.
-    """
-
-    id: str = Field(..., description="Unique labware offset record identifier.")
-    definitionUri: str = Field(..., description="The URI for the labware's definition.")
-    location: LabwareLocation = Field(
-        ...,
-        description="Where the labware is located on the robot.",
-    )
-    offset: LabwareOffsetVector = Field(
-        ...,
-        description="The offset applied to matching labware.",
-    )
 
 
 class Run(ResourceModel):
@@ -90,20 +63,6 @@ class Run(ResourceModel):
             "Protocol resource being run, if any. If not present, the run may"
             " still be used to execute protocol commands over HTTP."
         ),
-    )
-
-
-class LabwareOffsetCreate(BaseModel):
-    """Create request data for a labware offset."""
-
-    definitionUri: str = Field(..., description="The URI for the labware's definition.")
-    location: LabwareLocation = Field(
-        ...,
-        description="Where the labware is located on the robot.",
-    )
-    offset: LabwareOffsetVector = Field(
-        ...,
-        description="The offset applied to matching labware.",
     )
 
 


### PR DESCRIPTION
# Overview

A refactor towards implementing #8523.

# Changelog

* Move models expressing labware offsets from `robot_server` to `opentrons.protocol_engine`. This is a step towards making labware offsets a runtime-modifiable Protocol-Engine–owned resource. For the public-facing HTTP API, `robot_server` simply imports these models and uses them wholesale, the same way it uses Protocol Engine command models wholesale.
* Rename `CalibrationOffset` to `LabwareOffsetVector`.
    * The App+UI squad has been firm that the Labware Position Check, and the adjustments that it applies, do not constitute a "calibration."
    * Also, this model, representing the x/y/z adjustment, is no longer the whole "offset." The "offset" is now a resource that has a unique ID, and a labware URI matcher, and a location matcher *in addition* to the x/y/z adjustment.

# Review requests

Code review should be sufficient, as long as CI passes. Double check nothing snuck in other than the changes listed above.

# Risk assessment

Low. These models aren't used for anything behavioral, yet.
