### PR TITLE
fix(api): check home status in move_rel

### DIFF
--- a/api/src/opentrons/drivers/smoothie_drivers/simulator.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/simulator.py
@@ -12,12 +12,18 @@ from opentrons.drivers.types import MoveSplits
 class SimulatingDriver:
     def __init__(self) -> None:
         self._steps_per_mm: Dict[str, float] = {}
+        self._homed_flags: Dict[str, bool] = {}
+
+    @property
+    def homed_flags(self) -> Dict[str, bool]:
+        return self._homed_flags
 
     async def home(self, axis: str = AXES, disabled: str = DISABLE_AXES) -> None:
-        pass
+        for ax in axis:
+            self._homed_flags[axis] = True
 
     async def _smoothie_reset(self) -> None:
-        pass
+        self._homed_flags.clear()
 
     async def read_pipette_id(self, mount: str) -> Optional[str]:
         pass

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -1034,7 +1034,9 @@ class API(HardwareAPILike):
                 )
                 or not self._current_position
             ):
-                raise MustHomeError()
+                raise MustHomeError(
+                    "Cannot make a relative move because absolute position is unknown"
+                )
         elif not fail_on_not_homed and not self._current_position:
             await self.home()
 

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -1037,7 +1037,7 @@ class API(HardwareAPILike):
                 raise MustHomeError(
                     "Cannot make a relative move because absolute position is unknown"
                 )
-        elif not fail_on_not_homed and not self._current_position:
+        elif not self._current_position:
             await self.home()
 
         primary_mount = mounts[0]

--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -121,8 +121,11 @@ class Controller:
         await self._smoothie_driver.update_position()
         return self._smoothie_driver.position
 
-    def homed_flags(self) -> Dict[str, bool]:
-        return self._smoothie_driver.homed_flags
+    def is_homed(self, axes: Sequence[str]) -> bool:
+        for axis in axes:
+            if not self._smoothie_driver.homed_flags.get(axis, False):
+                return False
+        return True
 
     async def move(
         self,

--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -121,6 +121,9 @@ class Controller:
         await self._smoothie_driver.update_position()
         return self._smoothie_driver.position
 
+    def homed_flags(self) -> Dict[str, bool]:
+        return self._smoothie_driver.homed_flags
+
     async def move(
         self,
         target_position: Dict[str, float],

--- a/api/src/opentrons/hardware_control/ot3controller.py
+++ b/api/src/opentrons/hardware_control/ot3controller.py
@@ -52,6 +52,9 @@ class OT3Controller:
         self._gpio_dev = SimulatingGPIOCharDev("simulated")
         self._module_controls: Optional[AttachedModulesControl] = None
 
+    def homed_flags(self) -> Dict[str, bool]:
+        return {}
+
     @property
     def gpio_chardev(self) -> GPIODriverLike:
         """Get the GPIO device."""

--- a/api/src/opentrons/hardware_control/ot3controller.py
+++ b/api/src/opentrons/hardware_control/ot3controller.py
@@ -52,9 +52,6 @@ class OT3Controller:
         self._gpio_dev = SimulatingGPIOCharDev("simulated")
         self._module_controls: Optional[AttachedModulesControl] = None
 
-    def homed_flags(self) -> Dict[str, bool]:
-        return {}
-
     @property
     def gpio_chardev(self) -> GPIODriverLike:
         """Get the GPIO device."""
@@ -76,6 +73,9 @@ class OT3Controller:
     def module_controls(self, module_controls: AttachedModulesControl) -> None:
         """Set the module controls"""
         self._module_controls = module_controls
+
+    def is_homed(self, axes: Sequence[str]) -> bool:
+        return True
 
     async def update_position(self) -> AxisValueMap:
         """Get the current position."""

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -175,8 +175,11 @@ class Simulator:
     async def update_position(self) -> Dict[str, float]:
         return self._position
 
-    def homed_flags(self) -> Dict[str, bool]:
-        return self._smoothie_driver.homed_flags
+    def is_homed(self, axes: Sequence[str]) -> bool:
+        for axis in axes:
+            if not self._smoothie_driver.homed_flags.get(axis, False):
+                return False
+        return True
 
     async def move(
         self,

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -175,6 +175,9 @@ class Simulator:
     async def update_position(self) -> Dict[str, float]:
         return self._position
 
+    def homed_flags(self) -> Dict[str, bool]:
+        return self._smoothie_driver.homed_flags
+
     async def move(
         self,
         target_position: Dict[str, float],


### PR DESCRIPTION
move_rel (and move_to and current_position) have the problem of checking
if the system is homed by checking if the internal _current_position
dict is truthy. Really all that does is check if the hardware controller
has ever fetched the current position from the smoothie - really nothing
to do with homing.

Homing status is kept in the smoothie driver but hadn't previously been
exposed to the hardware controller.

We can check if the axes that will move during a move call are homed by
exposing that homed-flag data up to the hardware controller and checking
it in place of the is-the-position-known check.

Unfortunately, this breaks a lot of tests! That almost certainly means
the tests are wrong, because if these functions were being called on a
real unhomed robot they'd cause exceptions; but there's a lot of wrong
tests.

For now, gate the new behavior on a default-False optional argument to
specifically move_rel, but we should fix this in the future.

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
