### PR TITLE
refactor(engine): map legacy pick up tips commands to PE commands

### DIFF
--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -1,11 +1,12 @@
 """Translate events from a legacy ``ProtocolContext`` into Protocol Engine commands."""
 
 from collections import defaultdict
+from datetime import datetime
 from typing import Dict, List
 
 from opentrons.types import MountType, DeckSlotName
 from opentrons.util.helpers import utc_now
-from opentrons.commands.types import CommandMessage as LegacyCommand
+from opentrons.commands import types as legacy_command_types
 from opentrons.protocol_engine import commands as pe_commands, types as pe_types
 from opentrons.protocols.models.labware_definition import LabwareDefinition
 
@@ -13,6 +14,8 @@ from .legacy_wrappers import (
     LegacyInstrumentLoadInfo,
     LegacyLabwareLoadInfo,
     LegacyModuleLoadInfo,
+    LegacyPipetteContext,
+    LegacyWell,
 )
 
 
@@ -33,8 +36,12 @@ class LegacyCommandMapper:
         """Initialize the command mapper."""
         self._running_commands: Dict[str, List[pe_commands.Command]] = defaultdict(list)
         self._command_count: Dict[str, int] = defaultdict(lambda: 0)
+        self._labware_id_by_slot: Dict[DeckSlotName, str] = {}
+        self._pipette_id_by_mount: Dict[MountType, str] = {}
 
-    def map_command(self, command: LegacyCommand) -> pe_commands.Command:
+    def map_command(
+        self, command: legacy_command_types.CommandMessage
+    ) -> pe_commands.Command:
         """Map a legacy Broker command to a ProtocolEngine command.
 
         A "before" message from the Broker
@@ -47,7 +54,6 @@ class LegacyCommandMapper:
         command's status in-place.
         """
         command_type = command["name"]
-        command_text = command["payload"]["text"]
         command_error = command["error"]
         stage = command["$"]
 
@@ -57,16 +63,7 @@ class LegacyCommandMapper:
         if stage == "before":
             count = self._command_count[command_type]
             command_id = f"{command_type}-{count}"
-            engine_command = pe_commands.Custom(
-                id=command_id,
-                status=pe_commands.CommandStatus.RUNNING,
-                createdAt=now,
-                startedAt=now,
-                params=LegacyCommandParams(
-                    legacyCommandType=command_type,
-                    legacyCommandText=command_text,
-                ),
-            )
+            engine_command = self._build_initial_command(command, command_id, now)
 
             self._command_count[command_type] = count + 1
             self._running_commands[command_type].append(engine_command)
@@ -96,25 +93,25 @@ class LegacyCommandMapper:
     ) -> pe_commands.Command:
         """Map a legacy labware load to a ProtocolEngine command."""
         now = utc_now()
-
         count = self._command_count["LOAD_LABWARE"]
+        command_id = f"commands.LOAD_LABWARE-{count}"
+        labware_id = f"labware-{count}"
+        slot_name = labware_load_info.deck_slot
 
         load_labware_command = pe_commands.LoadLabware(
-            id=f"commands.LOAD_LABWARE-{count}",
+            id=command_id,
             status=pe_commands.CommandStatus.SUCCEEDED,
             createdAt=now,
             startedAt=now,
             completedAt=now,
             params=pe_commands.LoadLabwareParams(
-                location=pe_types.DeckSlotLocation(
-                    slotName=labware_load_info.deck_slot
-                ),
+                location=pe_types.DeckSlotLocation(slotName=slot_name),
                 loadName=labware_load_info.labware_load_name,
                 namespace=labware_load_info.labware_namespace,
                 version=labware_load_info.labware_version,
             ),
             result=pe_commands.LoadLabwareResult(
-                labwareId=f"labware-{count}",
+                labwareId=labware_id,
                 definition=LabwareDefinition.parse_obj(
                     labware_load_info.labware_definition
                 ),
@@ -123,6 +120,7 @@ class LegacyCommandMapper:
         )
 
         self._command_count["LOAD_LABWARE"] = count + 1
+        self._labware_id_by_slot[slot_name] = labware_id
         return load_labware_command
 
     def map_instrument_load(
@@ -131,11 +129,13 @@ class LegacyCommandMapper:
     ) -> pe_commands.Command:
         """Map a legacy instrument (pipette) load to a ProtocolEngine command."""
         now = utc_now()
-
         count = self._command_count["LOAD_PIPETTE"]
+        command_id = f"commands.LOAD_PIPETTE-{count}"
+        pipette_id = f"pipette-{count}"
+        mount = MountType(str(instrument_load_info.mount).lower())
 
         load_pipette_command = pe_commands.LoadPipette(
-            id=f"commands.LOAD_PIPETTE-{count}",
+            id=command_id,
             status=pe_commands.CommandStatus.SUCCEEDED,
             createdAt=now,
             startedAt=now,
@@ -144,14 +144,13 @@ class LegacyCommandMapper:
                 pipetteName=pe_types.PipetteName(
                     instrument_load_info.instrument_load_name
                 ),
-                mount=MountType(str(instrument_load_info.mount).lower()),
+                mount=mount,
             ),
-            result=pe_commands.LoadPipetteResult(
-                pipetteId=f"pipette-{count}",
-            ),
+            result=pe_commands.LoadPipetteResult(pipetteId=pipette_id),
         )
 
         self._command_count["LOAD_PIPETTE"] = count + 1
+        self._pipette_id_by_mount[mount] = pipette_id
         return load_pipette_command
 
     def map_module_load(
@@ -192,3 +191,52 @@ class LegacyCommandMapper:
         )
         self._command_count["LOAD_MODULE"] = count + 1
         return load_module_command
+
+    def _build_initial_command(
+        self,
+        command: legacy_command_types.CommandMessage,
+        command_id: str,
+        now: datetime,
+    ) -> pe_commands.Command:
+        engine_command: pe_commands.Command
+
+        if (
+            command["name"] == legacy_command_types.PICK_UP_TIP
+            and "instrument" in command["payload"]
+            and "location" in command["payload"]
+            and isinstance(command["payload"]["location"], LegacyWell)  # type: ignore  # noqa: E501
+        ):
+            pipette: LegacyPipetteContext = command["payload"]["instrument"]  # type: ignore  # noqa: E501
+            well: LegacyWell = command["payload"]["location"]  # type: ignore  # noqa: E501
+            mount = MountType(pipette.mount)
+            slot = DeckSlotName.from_primitive(well.parent.parent)  # type: ignore[arg-type] # noqa: E501
+            well_name = well.well_name
+
+            labware_id = self._labware_id_by_slot[slot]
+            pipette_id = self._pipette_id_by_mount[mount]
+
+            engine_command = pe_commands.PickUpTip(
+                id=command_id,
+                status=pe_commands.CommandStatus.RUNNING,
+                createdAt=now,
+                startedAt=now,
+                params=pe_commands.PickUpTipParams(
+                    pipetteId=pipette_id,
+                    labwareId=labware_id,
+                    wellName=well_name,
+                ),
+            )
+
+        else:
+            engine_command = pe_commands.Custom(
+                id=command_id,
+                status=pe_commands.CommandStatus.RUNNING,
+                createdAt=now,
+                startedAt=now,
+                params=LegacyCommandParams(
+                    legacyCommandType=command["name"],
+                    legacyCommandText=command["payload"]["text"],
+                ),
+            )
+
+        return engine_command

--- a/api/src/opentrons/protocol_runner/legacy_wrappers.py
+++ b/api/src/opentrons/protocol_runner/legacy_wrappers.py
@@ -13,7 +13,7 @@ from opentrons.protocol_api import (
     ProtocolContext as LegacyProtocolContext,
     InstrumentContext as LegacyPipetteContext,
 )
-from opentrons.protocol_api.labware import Labware as LegacyLabware
+from opentrons.protocol_api.labware import Labware as LegacyLabware, Well as LegacyWell
 from opentrons.protocol_api.protocol_context import (
     InstrumentLoadInfo as LegacyInstrumentLoadInfo,
     LabwareLoadInfo as LegacyLabwareLoadInfo,
@@ -131,6 +131,7 @@ __all__ = [
     # Re-exports of main public API stuff:
     "LegacyProtocolContext",
     "LegacyLabware",
+    "LegacyWell",
     "LegacyPipetteContext",
     "LegacyModuleContext",
     # Re-exports of internal stuff:

--- a/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_command_mapper.py
@@ -1,0 +1,173 @@
+"""Test legacy command mapping in an end-to-end environment.
+
+Legacy ProtocolContext objects are prohibitively difficult to instansiate
+and mock in an isolated unit test environment.
+"""
+import pytest
+import textwrap
+from datetime import datetime
+from pathlib import Path
+from decoy import matchers
+
+from opentrons.protocols.api_support.types import APIVersion
+from opentrons.protocol_engine import commands
+from opentrons.protocol_runner import (
+    ProtocolSource,
+    PythonPreAnalysis,
+    create_simulating_runner,
+)
+
+
+PICK_UP_TIP_PROTOCOL = textwrap.dedent(
+    """
+    # my protocol
+    metadata = {
+        "apiLevel": "2.11",
+    }
+
+    def run(ctx):
+        tip_rack_1 = ctx.load_labware(
+            load_name="opentrons_96_tiprack_300ul",
+            location="1",
+        )
+        tip_rack_2 = ctx.load_labware(
+            load_name="opentrons_96_tiprack_300ul",
+            location="2",
+        )
+
+        pipette_left = ctx.load_instrument(
+            instrument_name="p300_single",
+            mount="left",
+            tip_racks=[tip_rack_1],
+        )
+        pipette_right = ctx.load_instrument(
+            instrument_name="p300_multi",
+            mount="right",
+        )
+
+        pipette_left.pick_up_tip(
+            location=tip_rack_1.wells_by_name()["A1"],
+        )
+        pipette_right.pick_up_tip(
+            location=tip_rack_2.wells_by_name()["A2"].top(),
+        )
+
+        pipette_left.drop_tip()
+        pipette_left.pick_up_tip()
+    """
+)
+
+
+@pytest.fixture
+def pick_up_tip_protocol_file(tmp_path: Path) -> Path:
+    """Put the pick up tip mapping test protocol on disk."""
+    file_path = tmp_path / "protocol-name.py"
+    file_path.write_text(PICK_UP_TIP_PROTOCOL)
+    return file_path
+
+
+async def test_legacy_pick_up_tip(pick_up_tip_protocol_file: Path) -> None:
+    """It should map legacy pick up tip commands."""
+    protocol_source = ProtocolSource(
+        files=[pick_up_tip_protocol_file],
+        pre_analysis=PythonPreAnalysis(metadata={}, api_version=APIVersion(2, 11)),
+    )
+
+    subject = await create_simulating_runner()
+    result = await subject.run(protocol_source)
+    commands_result = result.commands
+
+    tiprack_1_result_captor = matchers.Captor()
+    tiprack_2_result_captor = matchers.Captor()
+    pipette_left_result_captor = matchers.Captor()
+    pipette_right_result_captor = matchers.Captor()
+
+    assert len(commands_result) == 8
+
+    assert commands_result[0] == commands.LoadLabware.construct(
+        id=matchers.IsA(str),
+        status=commands.CommandStatus.SUCCEEDED,
+        createdAt=matchers.IsA(datetime),
+        startedAt=matchers.IsA(datetime),
+        completedAt=matchers.IsA(datetime),
+        params=matchers.Anything(),
+        result=tiprack_1_result_captor,
+    )
+
+    assert commands_result[1] == commands.LoadLabware.construct(
+        id=matchers.IsA(str),
+        status=commands.CommandStatus.SUCCEEDED,
+        createdAt=matchers.IsA(datetime),
+        startedAt=matchers.IsA(datetime),
+        completedAt=matchers.IsA(datetime),
+        params=matchers.Anything(),
+        result=tiprack_2_result_captor,
+    )
+
+    assert commands_result[2] == commands.LoadPipette.construct(
+        id=matchers.IsA(str),
+        status=commands.CommandStatus.SUCCEEDED,
+        createdAt=matchers.IsA(datetime),
+        startedAt=matchers.IsA(datetime),
+        completedAt=matchers.IsA(datetime),
+        params=matchers.Anything(),
+        result=pipette_left_result_captor,
+    )
+
+    assert commands_result[3] == commands.LoadPipette.construct(
+        id=matchers.IsA(str),
+        status=commands.CommandStatus.SUCCEEDED,
+        createdAt=matchers.IsA(datetime),
+        startedAt=matchers.IsA(datetime),
+        completedAt=matchers.IsA(datetime),
+        params=matchers.Anything(),
+        result=pipette_right_result_captor,
+    )
+
+    # TODO(mc, 2021-11-11): not sure why I have to dict-access these properties
+    # might be a bug in Decoy, might be something weird that Pydantic does
+    tiprack_1_id = tiprack_1_result_captor.value["labwareId"]
+    tiprack_2_id = tiprack_2_result_captor.value["labwareId"]
+    pipette_left_id = pipette_left_result_captor.value["pipetteId"]
+    pipette_right_id = pipette_right_result_captor.value["pipetteId"]
+
+    assert commands_result[4] == commands.PickUpTip.construct(
+        id=matchers.IsA(str),
+        status=commands.CommandStatus.SUCCEEDED,
+        createdAt=matchers.IsA(datetime),
+        startedAt=matchers.IsA(datetime),
+        completedAt=matchers.IsA(datetime),
+        params=commands.PickUpTipParams(
+            pipetteId=pipette_left_id,
+            labwareId=tiprack_1_id,
+            wellName="A1",
+        ),
+    )
+
+    assert commands_result[5] == commands.PickUpTip.construct(
+        id=matchers.IsA(str),
+        status=commands.CommandStatus.SUCCEEDED,
+        createdAt=matchers.IsA(datetime),
+        startedAt=matchers.IsA(datetime),
+        completedAt=matchers.IsA(datetime),
+        params=commands.PickUpTipParams(
+            pipetteId=pipette_right_id,
+            labwareId=tiprack_2_id,
+            wellName="A2",
+        ),
+    )
+
+    # skip checking drop tip command at index 6
+
+    assert commands_result[7] == commands.PickUpTip.construct(
+        id=matchers.IsA(str),
+        status=commands.CommandStatus.SUCCEEDED,
+        createdAt=matchers.IsA(datetime),
+        startedAt=matchers.IsA(datetime),
+        completedAt=matchers.IsA(datetime),
+        params=commands.PickUpTipParams(
+            pipetteId=pipette_left_id,
+            labwareId=tiprack_1_id,
+            wellName="B1",
+        ),
+    )

--- a/api/tests/opentrons/protocol_runner/smoke_tests/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/test_protocol_runner.py
@@ -30,7 +30,6 @@ from opentrons.protocol_runner import (
     PythonPreAnalysis,
     create_simulating_runner,
 )
-from opentrons.protocol_runner.legacy_command_mapper import LegacyCommandParams
 
 
 async def test_runner_with_python(python_protocol_file: Path) -> None:
@@ -162,15 +161,16 @@ async def test_runner_with_legacy_python(legacy_python_protocol_file: Path) -> N
     assert expected_pipette in pipettes_result
     assert expected_labware in labware_result
 
-    expected_command = commands.Custom.construct(
+    expected_command = commands.PickUpTip.construct(
         id=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
         completedAt=matchers.IsA(datetime),
-        params=LegacyCommandParams(
-            legacyCommandType="command.PICK_UP_TIP",
-            legacyCommandText="Picking up tip from A1 of Opentrons 96 Tip Rack 300 µL on 1",  # noqa: E501
+        params=commands.PickUpTipParams(
+            pipetteId=pipette_id_captor.value,
+            labwareId=labware_id_captor.value,
+            wellName="A1",
         ),
         result=None,
     )
@@ -211,15 +211,16 @@ async def test_runner_with_legacy_json(legacy_json_protocol_file: Path) -> None:
     assert expected_pipette in pipettes_result
     assert expected_labware in labware_result
 
-    expected_command = commands.Custom.construct(
+    expected_command = commands.PickUpTip.construct(
         id=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
         completedAt=matchers.IsA(datetime),
-        params=LegacyCommandParams(
-            legacyCommandType="command.PICK_UP_TIP",
-            legacyCommandText="Picking up tip from A1 of Opentrons 96 Tip Rack 300 µL on 1",  # noqa: E501
+        params=commands.PickUpTipParams(
+            pipetteId=pipette_id_captor.value,
+            labwareId=labware_id_captor.value,
+            wellName="A1",
         ),
         result=None,
     )


### PR DESCRIPTION
## Overview

This PR attempts to map legacy PickUpTip message broker commands to PE commands, with enough data so LPC can determine which pipettes use which tipracks.

Closes #8717

## Changelog

Bit of a messy one here because we're dealing with legacy code. Elected to go smoke-test style on this one because we're dealing with legacy structures, so we need refactor safety, not greenfield architecture direction.

## Review requests

See if you can break it. With overal engine/runner error handling in its current state, "breaking it" probably involves triggering errors that get completely swallowed. Sorry about that

## Risk assessment

Low