### PR TITLE
feat(ot3): ot3 hardware controller move

### DIFF
--- a/.github/workflows/hardware-lint-test.yaml
+++ b/.github/workflows/hardware-lint-test.yaml
@@ -69,6 +69,8 @@ jobs:
         run: make -C hardware lint
 
       - name: Test
+        env:
+          CAN_CHANNEL: vcan0
         run: make -C hardware test-with-emulator
 
       - name: Code Coverage

--- a/api/Pipfile
+++ b/api/Pipfile
@@ -36,3 +36,4 @@ types-mock = "==4.0.1"
 types-setuptools = "==57.0.2"
 opentrons-shared-data = {editable = true, path = "../shared-data/python"}
 opentrons = {editable = true, path = "."}
+opentrons-hardware = {editable = true, path = "./../hardware"}

--- a/api/Pipfile.lock
+++ b/api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "71dd87c18a60e74c14e6594d6e5e531a33fd7a153d62451f395e7028746fe675"
+            "sha256": "aa36b16cef152fa459791cd1586a21427c205be372ade16c2b6cb25f781c18d1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -17,6 +17,14 @@
     },
     "default": {},
     "develop": {
+        "aenum": {
+            "hashes": [
+                "sha256:1d494e4d3b3e3e95389aee420203d945776d2430ee9a3d4f162e267b3a7ec3a6",
+                "sha256:a3e86312ca58611236900b77e863d2b9034dfe8956a089a2935b55974eb33f1f",
+                "sha256:c3dba3d5482d09ea371651d8da08cb21e0b8a826970bb08a3b30789b4a7b91a9"
+            ],
+            "version": "==3.1.3"
+        },
         "aiohttp": {
             "hashes": [
                 "sha256:02f46fc0e3c5ac58b80d4d56eb0a7c7d97fcef69ace9326289fb9f1955e65cfe",
@@ -67,6 +75,14 @@
             ],
             "version": "==0.2.0"
         },
+        "aiosignal": {
+            "hashes": [
+                "sha256:26e62109036cd181df6e6ad646f91f0dcfd05fe16d0cb924138ff2ab75d64e3a",
+                "sha256:78ed67db6c7b7ced4f98e495e572106d5c432a93e1ddd1bf475e1dc05f5b7df2"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.2.0"
+        },
         "alabaster": {
             "hashes": [
                 "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359",
@@ -96,6 +112,14 @@
             ],
             "markers": "python_full_version >= '3.5.3'",
             "version": "==3.0.1"
+        },
+        "asynctest": {
+            "hashes": [
+                "sha256:5da6118a7e6d6b54d83a8f7197769d046922a44d2a99c21382f0a6e4fadae676",
+                "sha256:c27862842d15d83e6a34eb0b2866c323880eb3a75e4485b079ea11748fd77fac"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==0.13.0"
         },
         "atomicwrites": {
             "hashes": [
@@ -268,6 +292,84 @@
             "index": "pypi",
             "version": "==1.1.0"
         },
+        "frozenlist": {
+            "hashes": [
+                "sha256:01d79515ed5aa3d699b05f6bdcf1fe9087d61d6b53882aa599a10853f0479c6c",
+                "sha256:0a7c7cce70e41bc13d7d50f0e5dd175f14a4f1837a8549b0936ed0cbe6170bf9",
+                "sha256:11ff401951b5ac8c0701a804f503d72c048173208490c54ebb8d7bb7c07a6d00",
+                "sha256:14a5cef795ae3e28fb504b73e797c1800e9249f950e1c964bb6bdc8d77871161",
+                "sha256:16eef427c51cb1203a7c0ab59d1b8abccaba9a4f58c4bfca6ed278fc896dc193",
+                "sha256:16ef7dd5b7d17495404a2e7a49bac1bc13d6d20c16d11f4133c757dd94c4144c",
+                "sha256:181754275d5d32487431a0a29add4f897968b7157204bc1eaaf0a0ce80c5ba7d",
+                "sha256:1cf63243bc5f5c19762943b0aa9e0d3fb3723d0c514d820a18a9b9a5ef864315",
+                "sha256:1cfe6fef507f8bac40f009c85c7eddfed88c1c0d38c75e72fe10476cef94e10f",
+                "sha256:1fef737fd1388f9b93bba8808c5f63058113c10f4e3c0763ced68431773f72f9",
+                "sha256:25b358aaa7dba5891b05968dd539f5856d69f522b6de0bf34e61f133e077c1a4",
+                "sha256:26f602e380a5132880fa245c92030abb0fc6ff34e0c5500600366cedc6adb06a",
+                "sha256:28e164722ea0df0cf6d48c4d5bdf3d19e87aaa6dfb39b0ba91153f224b912020",
+                "sha256:2de5b931701257d50771a032bba4e448ff958076380b049fd36ed8738fdb375b",
+                "sha256:3457f8cf86deb6ce1ba67e120f1b0128fcba1332a180722756597253c465fc1d",
+                "sha256:351686ca020d1bcd238596b1fa5c8efcbc21bffda9d0efe237aaa60348421e2a",
+                "sha256:406aeb340613b4b559db78d86864485f68919b7141dec82aba24d1477fd2976f",
+                "sha256:41de4db9b9501679cf7cddc16d07ac0f10ef7eb58c525a1c8cbff43022bddca4",
+                "sha256:41f62468af1bd4e4b42b5508a3fe8cc46a693f0cdd0ca2f443f51f207893d837",
+                "sha256:4766632cd8a68e4f10f156a12c9acd7b1609941525569dd3636d859d79279ed3",
+                "sha256:47b2848e464883d0bbdcd9493c67443e5e695a84694efff0476f9059b4cb6257",
+                "sha256:4a495c3d513573b0b3f935bfa887a85d9ae09f0627cf47cad17d0cc9b9ba5c38",
+                "sha256:4ad065b2ebd09f32511ff2be35c5dfafee6192978b5a1e9d279a5c6e121e3b03",
+                "sha256:4c457220468d734e3077580a3642b7f682f5fd9507f17ddf1029452450912cdc",
+                "sha256:4f52d0732e56906f8ddea4bd856192984650282424049c956857fed43697ea43",
+                "sha256:54a1e09ab7a69f843cd28fefd2bcaf23edb9e3a8d7680032c8968b8ac934587d",
+                "sha256:5a72eecf37eface331636951249d878750db84034927c997d47f7f78a573b72b",
+                "sha256:5df31bb2b974f379d230a25943d9bf0d3bc666b4b0807394b131a28fca2b0e5f",
+                "sha256:66a518731a21a55b7d3e087b430f1956a36793acc15912e2878431c7aec54210",
+                "sha256:6790b8d96bbb74b7a6f4594b6f131bd23056c25f2aa5d816bd177d95245a30e3",
+                "sha256:68201be60ac56aff972dc18085800b6ee07973c49103a8aba669dee3d71079de",
+                "sha256:6e105013fa84623c057a4381dc8ea0361f4d682c11f3816cc80f49a1f3bc17c6",
+                "sha256:705c184b77565955a99dc360f359e8249580c6b7eaa4dc0227caa861ef46b27a",
+                "sha256:72cfbeab7a920ea9e74b19aa0afe3b4ad9c89471e3badc985d08756efa9b813b",
+                "sha256:735f386ec522e384f511614c01d2ef9cf799f051353876b4c6fb93ef67a6d1ee",
+                "sha256:82d22f6e6f2916e837c91c860140ef9947e31194c82aaeda843d6551cec92f19",
+                "sha256:83334e84a290a158c0c4cc4d22e8c7cfe0bba5b76d37f1c2509dabd22acafe15",
+                "sha256:84e97f59211b5b9083a2e7a45abf91cfb441369e8bb6d1f5287382c1c526def3",
+                "sha256:87521e32e18a2223311afc2492ef2d99946337da0779ddcda77b82ee7319df59",
+                "sha256:878ebe074839d649a1cdb03a61077d05760624f36d196884a5cafb12290e187b",
+                "sha256:89fdfc84c6bf0bff2ff3170bb34ecba8a6911b260d318d377171429c4be18c73",
+                "sha256:8b4c7665a17c3a5430edb663e4ad4e1ad457614d1b2f2b7f87052e2ef4fa45ca",
+                "sha256:8b54cdd2fda15467b9b0bfa78cee2ddf6dbb4585ef23a16e14926f4b076dfae4",
+                "sha256:94728f97ddf603d23c8c3dd5cae2644fa12d33116e69f49b1644a71bb77b89ae",
+                "sha256:954b154a4533ef28bd3e83ffdf4eadf39deeda9e38fb8feaf066d6069885e034",
+                "sha256:977a1438d0e0d96573fd679d291a1542097ea9f4918a8b6494b06610dfeefbf9",
+                "sha256:9ade70aea559ca98f4b1b1e5650c45678052e76a8ab2f76d90f2ac64180215a2",
+                "sha256:9b6e21e5770df2dea06cb7b6323fbc008b13c4a4e3b52cb54685276479ee7676",
+                "sha256:a0d3ffa8772464441b52489b985d46001e2853a3b082c655ec5fad9fb6a3d618",
+                "sha256:a37594ad6356e50073fe4f60aa4187b97d15329f2138124d252a5a19c8553ea4",
+                "sha256:a8d86547a5e98d9edd47c432f7a14b0c5592624b496ae9880fb6332f34af1edc",
+                "sha256:aa44c4740b4e23fcfa259e9dd52315d2b1770064cde9507457e4c4a65a04c397",
+                "sha256:acc4614e8d1feb9f46dd829a8e771b8f5c4b1051365d02efb27a3229048ade8a",
+                "sha256:af2a51c8a381d76eabb76f228f565ed4c3701441ecec101dd18be70ebd483cfd",
+                "sha256:b2ae2f5e9fa10805fb1c9adbfefaaecedd9e31849434be462c3960a0139ed729",
+                "sha256:b46f997d5ed6d222a863b02cdc9c299101ee27974d9bbb2fd1b3c8441311c408",
+                "sha256:bc93f5f62df3bdc1f677066327fc81f92b83644852a31c6aa9b32c2dde86ea7d",
+                "sha256:bfbaa08cf1452acad9cb1c1d7b89394a41e712f88df522cea1a0f296b57782a0",
+                "sha256:c1e8e9033d34c2c9e186e58279879d78c94dd365068a3607af33f2bc99357a53",
+                "sha256:c5328ed53fdb0a73c8a50105306a3bc013e5ca36cca714ec4f7bd31d38d8a97f",
+                "sha256:c6a9d84ee6427b65a81fc24e6ef589cb794009f5ca4150151251c062773e7ed2",
+                "sha256:c98d3c04701773ad60d9545cd96df94d955329efc7743fdb96422c4b669c633b",
+                "sha256:cb3957c39668d10e2b486acc85f94153520a23263b6401e8f59422ef65b9520d",
+                "sha256:e63ad0beef6ece06475d29f47d1f2f29727805376e09850ebf64f90777962792",
+                "sha256:e74f8b4d8677ebb4015ac01fcaf05f34e8a1f22775db1f304f497f2f88fdc697",
+                "sha256:e7d0dd3e727c70c2680f5f09a0775525229809f1a35d8552b92ff10b2b14f2c2",
+                "sha256:ec6cf345771cdb00791d271af9a0a6fbfc2b6dd44cb753f1eeaa256e21622adb",
+                "sha256:ed58803563a8c87cf4c0771366cf0ad1aa265b6b0ae54cbbb53013480c7ad74d",
+                "sha256:f0081a623c886197ff8de9e635528fd7e6a387dccef432149e25c13946cb0cd0",
+                "sha256:f025f1d6825725b09c0038775acab9ae94264453a696cc797ce20c0769a7b367",
+                "sha256:f5f3b2942c3b8b9bfe76b408bbaba3d3bb305ee3693e8b1d631fe0a0d4f93673",
+                "sha256:fbd4844ff111449f3bbe20ba24fbb906b5b1c2384d0f3287c9f7da2354ce6d23"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.2.0"
+        },
         "idna": {
             "hashes": [
                 "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
@@ -319,6 +421,7 @@
                 "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298",
                 "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64",
                 "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b",
+                "sha256:04635854b943835a6ea959e948d19dcd311762c5c0c6e1f0e16ee57022669194",
                 "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567",
                 "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff",
                 "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724",
@@ -326,6 +429,7 @@
                 "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646",
                 "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35",
                 "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6",
+                "sha256:20dca64a3ef2d6e4d5d615a3fd418ad3bde77a47ec8a23d984a12b5b4c74491a",
                 "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6",
                 "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad",
                 "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26",
@@ -333,27 +437,36 @@
                 "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac",
                 "sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7",
                 "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6",
+                "sha256:4296f2b1ce8c86a6aea78613c34bb1a672ea0e3de9c6ba08a960efe0b0a09047",
                 "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75",
                 "sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f",
+                "sha256:4dc8f9fb58f7364b63fd9f85013b780ef83c11857ae79f2feda41e270468dd9b",
                 "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135",
                 "sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8",
                 "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a",
                 "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a",
+                "sha256:5b6d930f030f8ed98e3e6c98ffa0652bdb82601e7a016ec2ab5d7ff23baa78d1",
                 "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9",
                 "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864",
                 "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914",
+                "sha256:6300b8454aa6930a24b9618fbb54b5a68135092bc666f7b06901f897fa5c2fee",
+                "sha256:63f3268ba69ace99cab4e3e3b5840b03340efed0948ab8f78d2fd87ee5442a4f",
                 "sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18",
                 "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8",
                 "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2",
                 "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d",
                 "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b",
                 "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b",
+                "sha256:89c687013cb1cd489a0f0ac24febe8c7a666e6e221b783e53ac50ebf68e45d86",
+                "sha256:8d206346619592c6200148b01a2142798c989edcb9c896f9ac9722a99d4e77e6",
                 "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f",
                 "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb",
                 "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833",
                 "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28",
+                "sha256:9f02365d4e99430a12647f09b6cc8bab61a6564363f313126f775eb4f6ef798e",
                 "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415",
                 "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902",
+                "sha256:aca6377c0cb8a8253e493c6b451565ac77e98c2951c45f913e0b52facdcff83f",
                 "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d",
                 "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9",
                 "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d",
@@ -361,10 +474,14 @@
                 "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066",
                 "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c",
                 "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1",
+                "sha256:cdfba22ea2f0029c9261a4bd07e830a8da012291fbe44dc794e488b6c9bb353a",
+                "sha256:d6c7ebd4e944c85e2c3421e612a7057a2f48d478d79e61800d81468a8d842207",
                 "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f",
                 "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53",
+                "sha256:deb993cacb280823246a026e3b2d81c493c53de6acfd5e6bfe31ab3402bb37dd",
                 "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134",
                 "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85",
+                "sha256:f0567c4dc99f264f49fe27da5f735f414c4e7e7dd850cfd8e69f0862d7c74ea9",
                 "sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5",
                 "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94",
                 "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509",
@@ -549,6 +666,10 @@
         "opentrons": {
             "editable": true,
             "path": "."
+        },
+        "opentrons-hardware": {
+            "editable": true,
+            "path": "./../hardware"
         },
         "opentrons-shared-data": {
             "editable": true,
@@ -741,6 +862,13 @@
             ],
             "index": "pypi",
             "version": "==2.2.1"
+        },
+        "python-can": {
+            "hashes": [
+                "sha256:2d3c223b7adc4dd46ce258d4a33b7e0dbb6c339e002faa40ee4a69d5fdce9449"
+            ],
+            "markers": "python_version >= '2.7'",
+            "version": "==3.3.4"
         },
         "pytz": {
             "hashes": [
@@ -1022,7 +1150,7 @@
                 "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
                 "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_full_version < '4.0.0'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==1.26.7"
         },
         "webencodings": {
@@ -1039,6 +1167,63 @@
             ],
             "index": "pypi",
             "version": "==0.30.0"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:086218a72ec7d986a3eddb7707c8c4526d677c7b35e355875a0fe2918b059179",
+                "sha256:0877fe981fd76b183711d767500e6b3111378ed2043c145e21816ee589d91096",
+                "sha256:0a017a667d1f7411816e4bf214646d0ad5b1da2c1ea13dec6c162736ff25a374",
+                "sha256:0cb23d36ed03bf46b894cfec777eec754146d68429c30431c99ef28482b5c1df",
+                "sha256:1fea9cd438686e6682271d36f3481a9f3636195578bab9ca3382e2f5f01fc185",
+                "sha256:220a869982ea9023e163ba915077816ca439489de6d2c09089b219f4e11b6785",
+                "sha256:25b1b1d5df495d82be1c9d2fad408f7ce5ca8a38085e2da41bb63c914baadff7",
+                "sha256:2dded5496e8f1592ec27079b28b6ad2a1ef0b9296d270f77b8e4a3a796cf6909",
+                "sha256:2ebdde19cd3c8cdf8df3fc165bc7827334bc4e353465048b36f7deeae8ee0918",
+                "sha256:43e69ffe47e3609a6aec0fe723001c60c65305784d964f5007d5b4fb1bc6bf33",
+                "sha256:46f7f3af321a573fc0c3586612db4decb7eb37172af1bc6173d81f5b66c2e068",
+                "sha256:47f0a183743e7f71f29e4e21574ad3fa95676136f45b91afcf83f6a050914829",
+                "sha256:498e6217523111d07cd67e87a791f5e9ee769f9241fcf8a379696e25806965af",
+                "sha256:4b9c458732450ec42578b5642ac53e312092acf8c0bfce140ada5ca1ac556f79",
+                "sha256:51799ca950cfee9396a87f4a1240622ac38973b6df5ef7a41e7f0b98797099ce",
+                "sha256:5601f44a0f38fed36cc07db004f0eedeaadbdcec90e4e90509480e7e6060a5bc",
+                "sha256:5f223101f21cfd41deec8ce3889dc59f88a59b409db028c469c9b20cfeefbe36",
+                "sha256:610f5f83dd1e0ad40254c306f4764fcdc846641f120c3cf424ff57a19d5f7ade",
+                "sha256:6a03d9917aee887690aa3f1747ce634e610f6db6f6b332b35c2dd89412912bca",
+                "sha256:705e2af1f7be4707e49ced9153f8d72131090e52be9278b5dbb1498c749a1e32",
+                "sha256:766b32c762e07e26f50d8a3468e3b4228b3736c805018e4b0ec8cc01ecd88125",
+                "sha256:77416e6b17926d953b5c666a3cb718d5945df63ecf922af0ee576206d7033b5e",
+                "sha256:778fd096ee96890c10ce96187c76b3e99b2da44e08c9e24d5652f356873f6709",
+                "sha256:78dea98c81915bbf510eb6a3c9c24915e4660302937b9ae05a0947164248020f",
+                "sha256:7dd215e4e8514004c8d810a73e342c536547038fb130205ec4bba9f5de35d45b",
+                "sha256:7dde79d007cd6dfa65afe404766057c2409316135cb892be4b1c768e3f3a11cb",
+                "sha256:81bd7c90d28a4b2e1df135bfbd7c23aee3050078ca6441bead44c42483f9ebfb",
+                "sha256:85148f4225287b6a0665eef08a178c15097366d46b210574a658c1ff5b377489",
+                "sha256:865c0b50003616f05858b22174c40ffc27a38e67359fa1495605f96125f76640",
+                "sha256:87883690cae293541e08ba2da22cacaae0a092e0ed56bbba8d018cc486fbafbb",
+                "sha256:8aab36778fa9bba1a8f06a4919556f9f8c7b33102bd71b3ab307bb3fecb21851",
+                "sha256:8c73c1a2ec7c98d7eaded149f6d225a692caa1bd7b2401a14125446e9e90410d",
+                "sha256:936503cb0a6ed28dbfa87e8fcd0a56458822144e9d11a49ccee6d9a8adb2ac44",
+                "sha256:944b180f61f5e36c0634d3202ba8509b986b5fbaf57db3e94df11abee244ba13",
+                "sha256:96b81ae75591a795d8c90edc0bfaab44d3d41ffc1aae4d994c5aa21d9b8e19a2",
+                "sha256:981da26722bebb9247a0601e2922cedf8bb7a600e89c852d063313102de6f2cb",
+                "sha256:ae9de71eb60940e58207f8e71fe113c639da42adb02fb2bcbcaccc1ccecd092b",
+                "sha256:b73d4b78807bd299b38e4598b8e7bd34ed55d480160d2e7fdaabd9931afa65f9",
+                "sha256:d4a5f6146cfa5c7ba0134249665acd322a70d1ea61732723c7d3e8cc0fa80755",
+                "sha256:dd91006848eb55af2159375134d724032a2d1d13bcc6f81cd8d3ed9f2b8e846c",
+                "sha256:e05e60ff3b2b0342153be4d1b597bbcfd8330890056b9619f4ad6b8d5c96a81a",
+                "sha256:e6906d6f48437dfd80464f7d7af1740eadc572b9f7a4301e7dd3d65db285cacf",
+                "sha256:e92d0d4fa68ea0c02d39f1e2f9cb5bc4b4a71e8c442207433d8db47ee79d7aa3",
+                "sha256:e94b7d9deaa4cc7bac9198a58a7240aaf87fe56c6277ee25fa5b3aa1edebd229",
+                "sha256:ea3e746e29d4000cd98d572f3ee2a6050a4f784bb536f4ac1f035987fc1ed83e",
+                "sha256:ec7e20258ecc5174029a0f391e1b948bf2906cd64c198a9b8b281b811cbc04de",
+                "sha256:ec9465dd69d5657b5d2fa6133b3e1e989ae27d29471a672416fd729b429eb554",
+                "sha256:f122ccd12fdc69628786d0c947bdd9cb2733be8f800d88b5a37c57f1f1d73c10",
+                "sha256:f99c0489258086308aad4ae57da9e8ecf9e1f3f30fa35d5e170b4d4896554d80",
+                "sha256:f9c51d9af9abb899bd34ace878fbec8bf357b3194a10c4e8e0a25512826ef056",
+                "sha256:fd76c47f20984b43d93de9a82011bb6e5f8325df6c9ed4d8310029a55fa361ea"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.13.3"
         },
         "yarl": {
             "hashes": [

--- a/api/src/opentrons/__init__.py
+++ b/api/src/opentrons/__init__.py
@@ -101,7 +101,7 @@ def should_use_ot3() -> bool:
     """Return true if ot3 hardware controller should be used."""
     if enable_ot3_hardware_controller():
         try:
-            from opentrons_hardware.drivers.can_bus import CanDriver   # noqa: F401
+            from opentrons_hardware.drivers.can_bus import CanDriver  # noqa: F401
 
             return True
         except ModuleNotFoundError:

--- a/api/src/opentrons/__init__.py
+++ b/api/src/opentrons/__init__.py
@@ -101,11 +101,11 @@ def should_use_ot3() -> bool:
     """Return true if ot3 hardware controller should be used."""
     if enable_ot3_hardware_controller():
         try:
-            from opentrons_hardware.drivers.can_bus import CanDriver
+            from opentrons_hardware.drivers.can_bus import CanDriver   # noqa: F401
+
             return True
         except ModuleNotFoundError:
             log.exception("Cannot use OT3 Hardware controller.")
-            pass
     return False
 
 

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -174,6 +174,15 @@ settings = [
         ),
         restart_required=True,
     ),
+    SettingDefinition(
+        _id="enableOT3HardwareController",
+        title="Enable experimental OT3 hardware controller",
+        description=(
+            "Do not enable. This is an Opentrons-internal setting to test "
+            "new hardware."
+        ),
+        restart_required=True,
+    ),
 ]
 
 if ARCHITECTURE == SystemArchitecture.BUILDROOT:
@@ -406,6 +415,16 @@ def _migrate10to11(previous: SettingsMap) -> SettingsMap:
     return newmap
 
 
+def _migrate11to12(previous: SettingsMap) -> SettingsMap:
+    """Migrate to version 12 of the feature flags file.
+
+    - Adds the enableOT3HardwareController config element.
+    """
+    newmap = {k: v for k, v in previous.items()}
+    newmap["enableOT3HardwareController"] = None
+    return newmap
+
+
 _MIGRATIONS = [
     _migrate0to1,
     _migrate1to2,
@@ -418,6 +437,7 @@ _MIGRATIONS = [
     _migrate8to9,
     _migrate9to10,
     _migrate10to11,
+    _migrate11to12,
 ]
 """
 List of all migrations to apply, indexed by (version - 1). See _migrate below

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -31,3 +31,9 @@ def enable_http_protocol_sessions() -> bool:
 
 def disable_fast_protocol_upload() -> bool:
     return advs.get_setting_with_env_overload("disableFastProtocolUpload")
+
+
+def enable_ot3_hardware_controller() -> bool:
+    """Get whether to use the ot3 hardware controller."""
+
+    return advs.get_setting_with_env_overload("enableOT3HardwareController")

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -282,6 +282,7 @@ class API(HardwareAPILike):
         checked_loop = use_or_initialize_loop(loop)
         checked_config = config or robot_configs.load()
         backend = await OT3Controller.build(checked_config)
+        await backend.setup_motors()
         return cls(backend, loop=checked_loop, config=checked_config)
 
     def __repr__(self):

--- a/api/src/opentrons/hardware_control/ot3controller.py
+++ b/api/src/opentrons/hardware_control/ot3controller.py
@@ -69,6 +69,11 @@ class OT3Controller:
         self._gpio_dev = SimulatingGPIOCharDev("simulated")
         self._module_controls: Optional[AttachedModulesControl] = None
         self._messenger = CanMessenger(driver=driver)
+        self._position = {
+            NodeId.head: 0,
+            NodeId.gantry_x: 0,
+            NodeId.gantry_y: 0,
+        }
 
     @property
     def gpio_chardev(self) -> GPIODriverLike:
@@ -106,6 +111,7 @@ class OT3Controller:
                 ret['X'] = pos
             elif node == NodeId.gantry_y:
                 ret['Y'] = pos
+        log.info(f"update_position: {ret}")
         return ret
 
     async def move(
@@ -126,6 +132,7 @@ class OT3Controller:
         Returns:
             None
         """
+        log.info(f"move: {target_position}")
         target: Dict[NodeId, float] = {}
         for axis, pos in target_position.items():
             if axis in {'A', 'Z'}:

--- a/api/src/opentrons/hardware_control/ot3controller.py
+++ b/api/src/opentrons/hardware_control/ot3controller.py
@@ -102,8 +102,12 @@ class OT3Controller:
 
     async def update_position(self) -> AxisValueMap:
         """Get the current position."""
-        ret: AxisValueMap = {}
-        for node, pos in self._position.items():
+        return self._axis_convert(self._position)
+
+    @staticmethod
+    def _axis_convert(position: Dict[NodeId, float]) -> AxisValueMap:
+        ret: AxisValueMap = {"A": 0, "B": 0, "C": 0, "X": 0, "Y": 0, "Z": 0}
+        for node, pos in position.items():
             if node == NodeId.head:
                 ret['A'] = pos
                 ret['Z'] = pos
@@ -155,7 +159,12 @@ class OT3Controller:
         Returns:
             Homed position.
         """
-        return {}
+        self._position = {
+            NodeId.head: 0,
+            NodeId.gantry_x: 0,
+            NodeId.gantry_y: 0,
+        }
+        return self._axis_convert(self._position)
 
     async def fast_home(self, axes: Sequence[str], margin: float) -> AxisValueMap:
         """Fast home axes.
@@ -167,7 +176,12 @@ class OT3Controller:
         Returns:
             New position.
         """
-        return {}
+        self._position = {
+            NodeId.head: 0,
+            NodeId.gantry_x: 0,
+            NodeId.gantry_y: 0,
+        }
+        return self._axis_convert(self._position)
 
     async def get_attached_instruments(
         self, expected: Dict[Mount, PipetteName]
@@ -205,7 +219,9 @@ class OT3Controller:
     @property
     def axis_bounds(self) -> Dict[Axis, Tuple[float, float]]:
         """Get the axis bounds."""
-        return {}
+        # TODO (AL, 2021-11-18): The bounds need to be defined
+        phony_bounds = (0, 10000)
+        return {Axis.A: phony_bounds, Axis.B: phony_bounds, Axis.C: phony_bounds, Axis.X: phony_bounds, Axis.Y: phony_bounds, Axis.Z: phony_bounds}
 
     @property
     def fw_version(self) -> Optional[str]:

--- a/api/src/opentrons/hardware_control/ot3controller.py
+++ b/api/src/opentrons/hardware_control/ot3controller.py
@@ -15,6 +15,11 @@ try:
     from opentrons_hardware.drivers.can_bus.constants import NodeId
     from opentrons_hardware.hardware_control.motion import create
     from opentrons_hardware.hardware_control.move_group_runner import MoveGroupRunner
+    from opentrons_hardware.drivers.can_bus.messages.message_definitions import (
+        SetupRequest,
+        EnableMotorRequest,
+    )
+    from opentrons_hardware.drivers.can_bus.messages.payloads import EmptyPayload
 except ModuleNotFoundError:
     pass
 
@@ -71,6 +76,17 @@ class OT3Controller:
             NodeId.gantry_x: 0,
             NodeId.gantry_y: 0,
         }
+
+    async def setup_motors(self) -> None:
+        """Set up the motors."""
+        await self._messenger.send(
+            node_id=NodeId.broadcast,
+            message=SetupRequest(payload=EmptyPayload()),
+        )
+        await self._messenger.send(
+            node_id=NodeId.broadcast,
+            message=EnableMotorRequest(payload=EmptyPayload()),
+        )
 
     @property
     def gpio_chardev(self) -> GPIODriverLike:
@@ -133,7 +149,7 @@ class OT3Controller:
         Returns:
             None
         """
-        log.info(f"move: {target_position}")
+        log.debug(f"move: {target_position}")
         target: Dict[NodeId, float] = {}
         for axis, pos in target_position.items():
             if axis in {"A", "Z"}:

--- a/api/src/opentrons/hardware_control/ot3controller.py
+++ b/api/src/opentrons/hardware_control/ot3controller.py
@@ -16,11 +16,7 @@ try:
     from opentrons_hardware.hardware_control.motion import create
     from opentrons_hardware.hardware_control.move_group_runner import MoveGroupRunner
 except ModuleNotFoundError:
-    CanDriver = None
-    CanMessenger = None
-    NodeId = None
-    create = None
-    MoveGroupRunner = None
+    pass
 
 from .module_control import AttachedModulesControl
 from .types import BoardRevision, Axis
@@ -110,12 +106,12 @@ class OT3Controller:
         ret: AxisValueMap = {"A": 0, "B": 0, "C": 0, "X": 0, "Y": 0, "Z": 0}
         for node, pos in position.items():
             if node == NodeId.head:
-                ret['A'] = pos
-                ret['Z'] = pos
+                ret["A"] = pos
+                ret["Z"] = pos
             elif node == NodeId.gantry_x:
-                ret['X'] = pos
+                ret["X"] = pos
             elif node == NodeId.gantry_y:
-                ret['Y'] = pos
+                ret["Y"] = pos
         log.info(f"update_position: {ret}")
         return ret
 
@@ -140,11 +136,11 @@ class OT3Controller:
         log.info(f"move: {target_position}")
         target: Dict[NodeId, float] = {}
         for axis, pos in target_position.items():
-            if axis in {'A', 'Z'}:
+            if axis in {"A", "Z"}:
                 target[NodeId.head] = pos
-            elif axis == 'X':
+            elif axis == "X":
                 target[NodeId.gantry_x] = pos
-            elif axis == 'Y':
+            elif axis == "Y":
                 target[NodeId.gantry_y] = pos
         move_group = create(origin=self._position, target=target, speed=speed or 5000.0)
         runner = MoveGroupRunner(move_groups=move_group)
@@ -222,7 +218,14 @@ class OT3Controller:
         """Get the axis bounds."""
         # TODO (AL, 2021-11-18): The bounds need to be defined
         phony_bounds = (0, 10000)
-        return {Axis.A: phony_bounds, Axis.B: phony_bounds, Axis.C: phony_bounds, Axis.X: phony_bounds, Axis.Y: phony_bounds, Axis.Z: phony_bounds}
+        return {
+            Axis.A: phony_bounds,
+            Axis.B: phony_bounds,
+            Axis.C: phony_bounds,
+            Axis.X: phony_bounds,
+            Axis.Y: phony_bounds,
+            Axis.Z: phony_bounds,
+        }
 
     @property
     def fw_version(self) -> Optional[str]:

--- a/api/src/opentrons/hardware_control/ot3controller.py
+++ b/api/src/opentrons/hardware_control/ot3controller.py
@@ -69,6 +69,7 @@ class OT3Controller:
         self._gpio_dev = SimulatingGPIOCharDev("simulated")
         self._module_controls: Optional[AttachedModulesControl] = None
         self._messenger = CanMessenger(driver=driver)
+        self._messenger.start()
         self._position = {
             NodeId.head: 0,
             NodeId.gantry_x: 0,

--- a/api/src/opentrons/util/logging_config.py
+++ b/api/src/opentrons/util/logging_config.py
@@ -95,6 +95,10 @@ def _buildroot_config(level_value: int) -> Dict[str, Any]:
                 "handlers": ["api"],
                 "level": level_value,
             },
+            "opentrons_hardware": {
+                "handlers": ["api"],
+                "level": level_value,
+            },
             "__main__": {"handlers": ["api"], "level": level_value},
         },
     }

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -22,6 +22,7 @@ def default_file_settings() -> Dict[str, Optional[bool]]:
         "enableDoorSafetySwitch": None,
         "enableHttpProtocolSessions": None,
         "disableFastProtocolUpload": None,
+        "enableOT3HardwareController": None,
     }
 
 
@@ -165,6 +166,18 @@ def v11_config(v10_config):
     return r
 
 
+@pytest.fixture
+def v12_config(v11_config):
+    r = v11_config.copy()
+    r.update(
+        {
+            "_version": 12,
+            "enableOT3HardwareController": True,
+        }
+    )
+    return r
+
+
 @pytest.fixture(
     scope="session",
     params=[
@@ -181,6 +194,7 @@ def v11_config(v10_config):
         lazy_fixture("v9_config"),
         lazy_fixture("v10_config"),
         lazy_fixture("v11_config"),
+        lazy_fixture("v12_config"),
     ],
 )
 def old_settings(request):
@@ -253,4 +267,5 @@ def test_ensures_config():
         "enableDoorSafetySwitch": None,
         "enableHttpProtocolSessions": None,
         "disableFastProtocolUpload": None,
+        "enableOT3HardwareController": None,
     }

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -7,7 +7,7 @@ from opentrons.config.advanced_settings import _migrate, _ensure
 
 @pytest.fixture
 def migrated_file_version() -> int:
-    return 11
+    return 12
 
 
 @pytest.fixture

--- a/hardware/opentrons_hardware/drivers/can_bus/__init__.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/__init__.py
@@ -7,6 +7,8 @@ from .arbitration_id import (
     ArbitrationIdParts,
 )
 from .constants import NodeId, FunctionCode, MessageId
+from .can_messenger import CanMessenger
+
 
 __all__ = [
     "CanMessage",
@@ -16,4 +18,5 @@ __all__ = [
     "FunctionCode",
     "MessageId",
     "ArbitrationIdParts",
+    "CanMessenger",
 ]

--- a/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
@@ -58,7 +58,7 @@ class CanMessenger:
             )
         )
         data = message.payload.serialize()
-        log.debug(
+        log.info(
             f"Sending -->\n\tarbitration_id: {arbitration_id},\n\t"
             f"payload: {message.payload}"
         )
@@ -101,7 +101,7 @@ class CanMessenger:
             if message_definition:
                 try:
                     build = message_definition.payload_type.build(message.data)
-                    log.debug(
+                    log.info(
                         f"Received <--\n\tarbitration_id: {message.arbitration_id},\n\t"
                         f"payload: {build}"
                     )

--- a/hardware/opentrons_hardware/drivers/can_bus/constants.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/constants.py
@@ -11,6 +11,8 @@ class NodeId(int, Enum):
     gantry_x = 0x30
     gantry_y = 0x40
     head = 0x50
+    head_l = 0x51
+    head_r = 0x52
 
 
 class FunctionCode(int, Enum):

--- a/hardware/opentrons_hardware/drivers/can_bus/driver.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/driver.py
@@ -34,7 +34,7 @@ if platform.system() == "Darwin":
 class CanDriver:
     """The can driver."""
 
-    DEFAULT_CAN_NETWORK = "vcan0"
+    DEFAULT_CAN_NETWORK = "can0"
     DEFAULT_CAN_INTERFACE = "socketcan"
     DEFAULT_CAN_BITRATE = 0
 

--- a/hardware/opentrons_hardware/drivers/can_bus/driver.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/driver.py
@@ -38,7 +38,7 @@ class CanDriver:
 
     DEFAULT_CAN_NETWORK = "can0"
     DEFAULT_CAN_INTERFACE = "socketcan"
-    DEFAULT_CAN_BITRATE = 0
+    DEFAULT_CAN_BITRATE = 250000
 
     def __init__(self, bus: Bus, loop: asyncio.AbstractEventLoop) -> None:
         """Constructor.

--- a/hardware/opentrons_hardware/drivers/can_bus/driver.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/driver.py
@@ -87,7 +87,7 @@ class CanDriver:
                 bitrate=bitrate,
                 interface=interface,
                 fd=True,
-                **extra_kwargs
+                **extra_kwargs,
             ),
             loop=asyncio.get_event_loop(),
         )

--- a/hardware/opentrons_hardware/drivers/can_bus/driver.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/driver.py
@@ -1,6 +1,6 @@
 """The can bus transport."""
 from __future__ import annotations
-
+import logging
 import asyncio
 import platform
 from typing import Optional
@@ -10,6 +10,8 @@ from can import Notifier, Bus, AsyncBufferedReader, Message, util
 from .arbitration_id import ArbitrationId
 from .message import CanMessage
 from .errors import ErrorFrameCanError
+
+log = logging.getLogger(__name__)
 
 
 if platform.system() == "Darwin":
@@ -68,6 +70,7 @@ class CanDriver:
         Returns:
             A CanDriver instance.
         """
+        log.info(f"CAN connect: {interface}-{channel}-{bitrate}")
         extra_kwargs = {}
         if interface == "pcan":
             # Special FDCAN parameters for use of PCAN driver.

--- a/hardware/opentrons_hardware/hardware_control/motion.py
+++ b/hardware/opentrons_hardware/hardware_control/motion.py
@@ -81,7 +81,7 @@ def create(
                     NodeId.gantry_y: MoveGroupSingleAxisStep(
                         distance_mm=dy,
                         velocity_mm_sec=speed if dy > 0 else -speed,
-                        duration_sec=abs(dx) / speed,
+                        duration_sec=abs(dy) / speed,
                     )
                 }
             ]

--- a/hardware/opentrons_hardware/hardware_control/motion.py
+++ b/hardware/opentrons_hardware/hardware_control/motion.py
@@ -39,49 +39,20 @@ def create(
     """
     # Raise KeyError if axis is missing from origin
     deltas = {ax: target[ax] - origin[ax] for ax in target.keys()}
+    # head (as opposed to head_l and head_r) is not an acceptable target for motion
+    deltas.pop(NodeId.head, None)
 
     move_groups = []
-
-    # First move head
-    dza = deltas.get(NodeId.head, 0)
-    if dza:
+    for axis_node, axis_delta in deltas.items():
+        if not axis_delta:
+            continue
         move_groups.append(
             [
                 {
-                    NodeId.head: MoveGroupSingleAxisStep(
-                        distance_mm=dza,
-                        velocity_mm_sec=speed if dza > 0 else -speed,
-                        duration_sec=abs(dza) / speed,
-                    )
-                }
-            ]
-        )
-
-    # Move x
-    dx = deltas.get(NodeId.gantry_x, 0)
-    if dx:
-        move_groups.append(
-            [
-                {
-                    NodeId.gantry_x: MoveGroupSingleAxisStep(
-                        distance_mm=dx,
-                        velocity_mm_sec=speed if dx > 0 else -speed,
-                        duration_sec=abs(dx) / speed,
-                    )
-                }
-            ]
-        )
-
-    # Move y
-    dy = deltas.get(NodeId.gantry_y, 0)
-    if dy:
-        move_groups.append(
-            [
-                {
-                    NodeId.gantry_y: MoveGroupSingleAxisStep(
-                        distance_mm=dy,
-                        velocity_mm_sec=speed if dy > 0 else -speed,
-                        duration_sec=abs(dy) / speed,
+                    axis_node: MoveGroupSingleAxisStep(
+                        distance_mm=axis_delta,
+                        velocity_mm_sec=speed if axis_delta > 0 else -speed,
+                        duration_sec=abs(axis_delta) / speed,
                     )
                 }
             ]

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -12,9 +12,6 @@ from opentrons_hardware.drivers.can_bus.messages.message_definitions import (
     AddLinearMoveRequest,
     MoveCompleted,
     ExecuteMoveGroupRequest,
-    SetupRequest,
-    EnableMotorRequest,
-    DisableMotorRequest,
 )
 from opentrons_hardware.drivers.can_bus.messages.payloads import (
     AddLinearMoveRequestPayload,
@@ -52,11 +49,7 @@ class MoveGroupRunner:
 
         await self._clear_groups(can_messenger)
         await self._send_groups(can_messenger)
-        await self._setup_motors(can_messenger)
-        try:
-            await self._move(can_messenger)
-        finally:
-            await self._teardown_motors(can_messenger)
+        await self._move(can_messenger)
 
     async def _clear_groups(self, can_messenger: CanMessenger) -> None:
         """Send commands to clear the message groups."""
@@ -95,24 +88,6 @@ class MoveGroupRunner:
             await scheduler.run(can_messenger)
         finally:
             can_messenger.remove_listener(scheduler)
-
-    async def _setup_motors(self, can_messenger: CanMessenger) -> None:
-        """Set up the motors for motion."""
-        await can_messenger.send(
-            node_id=NodeId.broadcast,
-            message=SetupRequest(payload=EmptyPayload()),
-        )
-        await can_messenger.send(
-            node_id=NodeId.broadcast,
-            message=EnableMotorRequest(payload=EmptyPayload()),
-        )
-
-    async def _teardown_motors(self, can_messenger: CanMessenger) -> None:
-        """Tear down motors after motion."""
-        await can_messenger.send(
-            node_id=NodeId.broadcast,
-            message=DisableMotorRequest(payload=EmptyPayload()),
-        )
 
 
 class MoveScheduler(MessageListener):

--- a/hardware/tests/opentrons_hardware/hardware_control/test_motion.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_motion.py
@@ -8,7 +8,7 @@ def test_create_just_head() -> None:
     expected = [
         [
             {
-                NodeId.head: MoveGroupSingleAxisStep(
+                NodeId.head_l: MoveGroupSingleAxisStep(
                     distance_mm=-2, velocity_mm_sec=-0.25, duration_sec=8
                 ),
             }
@@ -16,8 +16,8 @@ def test_create_just_head() -> None:
     ]
     assert (
         create(
-            origin={NodeId.head: 4},
-            target={NodeId.head: 2},
+            origin={NodeId.head_l: 4},
+            target={NodeId.head_l: 2},
             speed=0.25,
         )
         == expected
@@ -57,7 +57,7 @@ def test_create_all() -> None:
     expected = [
         [
             {
-                NodeId.head: MoveGroupSingleAxisStep(
+                NodeId.head_l: MoveGroupSingleAxisStep(
                     distance_mm=4, velocity_mm_sec=0.05, duration_sec=80
                 ),
             }
@@ -79,8 +79,8 @@ def test_create_all() -> None:
     ]
     assert (
         create(
-            origin={NodeId.head: 0, NodeId.gantry_x: 0, NodeId.gantry_y: 0},
-            target={NodeId.head: 4, NodeId.gantry_x: 2, NodeId.gantry_y: 2},
+            origin={NodeId.head_l: 0, NodeId.gantry_x: 0, NodeId.gantry_y: 0},
+            target={NodeId.head_l: 4, NodeId.gantry_x: 2, NodeId.gantry_y: 2},
             speed=0.05,
         )
         == expected

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -275,38 +275,6 @@ async def test_multi_send_setup_commands(
     )
 
 
-async def test_setup_motors(
-    mock_can_messenger: AsyncMock, move_group_multiple: MoveGroups
-) -> None:
-    """It should set the motors for movement."""
-    subject = MoveGroupRunner(move_groups=move_group_multiple)
-    await subject._setup_motors(can_messenger=mock_can_messenger)
-    mock_can_messenger.send.assert_has_calls(
-        [
-            call(
-                node_id=NodeId.broadcast,
-                message=md.SetupRequest(payload=EmptyPayload()),
-            ),
-            call(
-                node_id=NodeId.broadcast,
-                message=md.EnableMotorRequest(payload=EmptyPayload()),
-            ),
-        ]
-    )
-
-
-async def test_teardown_motors(
-    mock_can_messenger: AsyncMock, move_group_multiple: MoveGroups
-) -> None:
-    """It should tear down the motors after movement."""
-    subject = MoveGroupRunner(move_groups=move_group_multiple)
-    await subject._teardown_motors(can_messenger=mock_can_messenger)
-    mock_can_messenger.send.assert_called_once_with(
-        node_id=NodeId.broadcast,
-        message=md.DisableMotorRequest(payload=EmptyPayload()),
-    )
-
-
 async def test_move() -> None:
     """It should register to listen for messages."""
     subject = MoveGroupRunner(move_groups=[])

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -88,6 +88,13 @@ def move_group_multiple() -> MoveGroups:
     ]
 
 
+async def test_no_groups_do_nothing(mock_can_messenger: AsyncMock) -> None:
+    """It should not send any commands if there are no moves."""
+    subject = MoveGroupRunner(move_groups=[])
+    await subject.run(mock_can_messenger)
+    mock_can_messenger.send.assert_not_called()
+
+
 async def test_single_group_clear(
     mock_can_messenger: AsyncMock, move_group_single: MoveGroups
 ) -> None:
@@ -265,6 +272,38 @@ async def test_multi_send_setup_commands(
                 ),
             )
         ),
+    )
+
+
+async def test_setup_motors(
+    mock_can_messenger: AsyncMock, move_group_multiple: MoveGroups
+) -> None:
+    """It should set the motors for movement."""
+    subject = MoveGroupRunner(move_groups=move_group_multiple)
+    await subject._setup_motors(can_messenger=mock_can_messenger)
+    mock_can_messenger.send.assert_has_calls(
+        [
+            call(
+                node_id=NodeId.broadcast,
+                message=md.SetupRequest(payload=EmptyPayload()),
+            ),
+            call(
+                node_id=NodeId.broadcast,
+                message=md.EnableMotorRequest(payload=EmptyPayload()),
+            ),
+        ]
+    )
+
+
+async def test_teardown_motors(
+    mock_can_messenger: AsyncMock, move_group_multiple: MoveGroups
+) -> None:
+    """It should tear down the motors after movement."""
+    subject = MoveGroupRunner(move_groups=move_group_multiple)
+    await subject._teardown_motors(can_messenger=mock_can_messenger)
+    mock_can_messenger.send.assert_called_once_with(
+        node_id=NodeId.broadcast,
+        message=md.DisableMotorRequest(payload=EmptyPayload()),
     )
 
 

--- a/robot-server/Pipfile
+++ b/robot-server/Pipfile
@@ -48,3 +48,4 @@ idna = "==3.2"
 click = "==8.0.1"
 numpy = "==1.15.1"
 zipp = "==3.5.0"
+opentrons-hardware = {editable = true, path = "./../hardware"}

--- a/robot-server/Pipfile.lock
+++ b/robot-server/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2ea20e9acd5059c70011021e067f7d40c0f222e13a0da6aa6184ecbe56e24fe9"
+            "sha256": "8418ceb4563439fe0a3a54b19ed63e61bc7ab9a3a277209a24141b2c28a40a83"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,14 @@
         ]
     },
     "default": {
+        "aenum": {
+            "hashes": [
+                "sha256:1d494e4d3b3e3e95389aee420203d945776d2430ee9a3d4f162e267b3a7ec3a6",
+                "sha256:a3e86312ca58611236900b77e863d2b9034dfe8956a089a2935b55974eb33f1f",
+                "sha256:c3dba3d5482d09ea371651d8da08cb21e0b8a826970bb08a3b30789b4a7b91a9"
+            ],
+            "version": "==3.1.3"
+        },
         "aionotify": {
             "hashes": [
                 "sha256:385e1becfaac2d9f4326673033d53912ef9565b6febdedbec593ee966df392c6",
@@ -136,6 +144,10 @@
             "editable": true,
             "path": "./../api"
         },
+        "opentrons-hardware": {
+            "editable": true,
+            "path": "./../hardware"
+        },
         "opentrons-shared-data": {
             "editable": true,
             "path": "./../shared-data/python"
@@ -201,6 +213,13 @@
                 "sha256:c4451db6ba391ca6ca299fb3ec7bae67a5c55dde170964c7a14ceefec02f2cf0"
             ],
             "version": "==3.5"
+        },
+        "python-can": {
+            "hashes": [
+                "sha256:2d3c223b7adc4dd46ce258d4a33b7e0dbb6c339e002faa40ee4a69d5fdce9449"
+            ],
+            "markers": "python_version >= '2.7'",
+            "version": "==3.3.4"
         },
         "python-dotenv": {
             "hashes": [
@@ -303,6 +322,63 @@
             "index": "pypi",
             "version": "==0.14.0"
         },
+        "wrapt": {
+            "hashes": [
+                "sha256:086218a72ec7d986a3eddb7707c8c4526d677c7b35e355875a0fe2918b059179",
+                "sha256:0877fe981fd76b183711d767500e6b3111378ed2043c145e21816ee589d91096",
+                "sha256:0a017a667d1f7411816e4bf214646d0ad5b1da2c1ea13dec6c162736ff25a374",
+                "sha256:0cb23d36ed03bf46b894cfec777eec754146d68429c30431c99ef28482b5c1df",
+                "sha256:1fea9cd438686e6682271d36f3481a9f3636195578bab9ca3382e2f5f01fc185",
+                "sha256:220a869982ea9023e163ba915077816ca439489de6d2c09089b219f4e11b6785",
+                "sha256:25b1b1d5df495d82be1c9d2fad408f7ce5ca8a38085e2da41bb63c914baadff7",
+                "sha256:2dded5496e8f1592ec27079b28b6ad2a1ef0b9296d270f77b8e4a3a796cf6909",
+                "sha256:2ebdde19cd3c8cdf8df3fc165bc7827334bc4e353465048b36f7deeae8ee0918",
+                "sha256:43e69ffe47e3609a6aec0fe723001c60c65305784d964f5007d5b4fb1bc6bf33",
+                "sha256:46f7f3af321a573fc0c3586612db4decb7eb37172af1bc6173d81f5b66c2e068",
+                "sha256:47f0a183743e7f71f29e4e21574ad3fa95676136f45b91afcf83f6a050914829",
+                "sha256:498e6217523111d07cd67e87a791f5e9ee769f9241fcf8a379696e25806965af",
+                "sha256:4b9c458732450ec42578b5642ac53e312092acf8c0bfce140ada5ca1ac556f79",
+                "sha256:51799ca950cfee9396a87f4a1240622ac38973b6df5ef7a41e7f0b98797099ce",
+                "sha256:5601f44a0f38fed36cc07db004f0eedeaadbdcec90e4e90509480e7e6060a5bc",
+                "sha256:5f223101f21cfd41deec8ce3889dc59f88a59b409db028c469c9b20cfeefbe36",
+                "sha256:610f5f83dd1e0ad40254c306f4764fcdc846641f120c3cf424ff57a19d5f7ade",
+                "sha256:6a03d9917aee887690aa3f1747ce634e610f6db6f6b332b35c2dd89412912bca",
+                "sha256:705e2af1f7be4707e49ced9153f8d72131090e52be9278b5dbb1498c749a1e32",
+                "sha256:766b32c762e07e26f50d8a3468e3b4228b3736c805018e4b0ec8cc01ecd88125",
+                "sha256:77416e6b17926d953b5c666a3cb718d5945df63ecf922af0ee576206d7033b5e",
+                "sha256:778fd096ee96890c10ce96187c76b3e99b2da44e08c9e24d5652f356873f6709",
+                "sha256:78dea98c81915bbf510eb6a3c9c24915e4660302937b9ae05a0947164248020f",
+                "sha256:7dd215e4e8514004c8d810a73e342c536547038fb130205ec4bba9f5de35d45b",
+                "sha256:7dde79d007cd6dfa65afe404766057c2409316135cb892be4b1c768e3f3a11cb",
+                "sha256:81bd7c90d28a4b2e1df135bfbd7c23aee3050078ca6441bead44c42483f9ebfb",
+                "sha256:85148f4225287b6a0665eef08a178c15097366d46b210574a658c1ff5b377489",
+                "sha256:865c0b50003616f05858b22174c40ffc27a38e67359fa1495605f96125f76640",
+                "sha256:87883690cae293541e08ba2da22cacaae0a092e0ed56bbba8d018cc486fbafbb",
+                "sha256:8aab36778fa9bba1a8f06a4919556f9f8c7b33102bd71b3ab307bb3fecb21851",
+                "sha256:8c73c1a2ec7c98d7eaded149f6d225a692caa1bd7b2401a14125446e9e90410d",
+                "sha256:936503cb0a6ed28dbfa87e8fcd0a56458822144e9d11a49ccee6d9a8adb2ac44",
+                "sha256:944b180f61f5e36c0634d3202ba8509b986b5fbaf57db3e94df11abee244ba13",
+                "sha256:96b81ae75591a795d8c90edc0bfaab44d3d41ffc1aae4d994c5aa21d9b8e19a2",
+                "sha256:981da26722bebb9247a0601e2922cedf8bb7a600e89c852d063313102de6f2cb",
+                "sha256:ae9de71eb60940e58207f8e71fe113c639da42adb02fb2bcbcaccc1ccecd092b",
+                "sha256:b73d4b78807bd299b38e4598b8e7bd34ed55d480160d2e7fdaabd9931afa65f9",
+                "sha256:d4a5f6146cfa5c7ba0134249665acd322a70d1ea61732723c7d3e8cc0fa80755",
+                "sha256:dd91006848eb55af2159375134d724032a2d1d13bcc6f81cd8d3ed9f2b8e846c",
+                "sha256:e05e60ff3b2b0342153be4d1b597bbcfd8330890056b9619f4ad6b8d5c96a81a",
+                "sha256:e6906d6f48437dfd80464f7d7af1740eadc572b9f7a4301e7dd3d65db285cacf",
+                "sha256:e92d0d4fa68ea0c02d39f1e2f9cb5bc4b4a71e8c442207433d8db47ee79d7aa3",
+                "sha256:e94b7d9deaa4cc7bac9198a58a7240aaf87fe56c6277ee25fa5b3aa1edebd229",
+                "sha256:ea3e746e29d4000cd98d572f3ee2a6050a4f784bb536f4ac1f035987fc1ed83e",
+                "sha256:ec7e20258ecc5174029a0f391e1b948bf2906cd64c198a9b8b281b811cbc04de",
+                "sha256:ec9465dd69d5657b5d2fa6133b3e1e989ae27d29471a672416fd729b429eb554",
+                "sha256:f122ccd12fdc69628786d0c947bdd9cb2733be8f800d88b5a37c57f1f1d73c10",
+                "sha256:f99c0489258086308aad4ae57da9e8ecf9e1f3f30fa35d5e170b4d4896554d80",
+                "sha256:f9c51d9af9abb899bd34ace878fbec8bf357b3194a10c4e8e0a25512826ef056",
+                "sha256:fd76c47f20984b43d93de9a82011bb6e5f8325df6c9ed4d8310029a55fa361ea"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.13.3"
+        },
         "wsproto": {
             "hashes": [
                 "sha256:868776f8456997ad0d9720f7322b746bbe9193751b5b290b7f924659377c8c38",
@@ -364,6 +440,14 @@
             "markers": "python_version >= '3.6'",
             "version": "==3.7.4.post0"
         },
+        "aiosignal": {
+            "hashes": [
+                "sha256:26e62109036cd181df6e6ad646f91f0dcfd05fe16d0cb924138ff2ab75d64e3a",
+                "sha256:78ed67db6c7b7ced4f98e495e572106d5c432a93e1ddd1bf475e1dc05f5b7df2"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.2.0"
+        },
         "anyio": {
             "hashes": [
                 "sha256:929a6852074397afe1d989002aa96d457e3e1e5441357c60d03e7eea0e65e1b0",
@@ -394,6 +478,14 @@
             ],
             "markers": "python_full_version >= '3.5.3'",
             "version": "==3.0.1"
+        },
+        "asynctest": {
+            "hashes": [
+                "sha256:5da6118a7e6d6b54d83a8f7197769d046922a44d2a99c21382f0a6e4fadae676",
+                "sha256:c27862842d15d83e6a34eb0b2866c323880eb3a75e4485b079ea11748fd77fac"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==0.13.0"
         },
         "atomicwrites": {
             "hashes": [
@@ -557,6 +649,84 @@
             ],
             "index": "pypi",
             "version": "==1.1.0"
+        },
+        "frozenlist": {
+            "hashes": [
+                "sha256:01d79515ed5aa3d699b05f6bdcf1fe9087d61d6b53882aa599a10853f0479c6c",
+                "sha256:0a7c7cce70e41bc13d7d50f0e5dd175f14a4f1837a8549b0936ed0cbe6170bf9",
+                "sha256:11ff401951b5ac8c0701a804f503d72c048173208490c54ebb8d7bb7c07a6d00",
+                "sha256:14a5cef795ae3e28fb504b73e797c1800e9249f950e1c964bb6bdc8d77871161",
+                "sha256:16eef427c51cb1203a7c0ab59d1b8abccaba9a4f58c4bfca6ed278fc896dc193",
+                "sha256:16ef7dd5b7d17495404a2e7a49bac1bc13d6d20c16d11f4133c757dd94c4144c",
+                "sha256:181754275d5d32487431a0a29add4f897968b7157204bc1eaaf0a0ce80c5ba7d",
+                "sha256:1cf63243bc5f5c19762943b0aa9e0d3fb3723d0c514d820a18a9b9a5ef864315",
+                "sha256:1cfe6fef507f8bac40f009c85c7eddfed88c1c0d38c75e72fe10476cef94e10f",
+                "sha256:1fef737fd1388f9b93bba8808c5f63058113c10f4e3c0763ced68431773f72f9",
+                "sha256:25b358aaa7dba5891b05968dd539f5856d69f522b6de0bf34e61f133e077c1a4",
+                "sha256:26f602e380a5132880fa245c92030abb0fc6ff34e0c5500600366cedc6adb06a",
+                "sha256:28e164722ea0df0cf6d48c4d5bdf3d19e87aaa6dfb39b0ba91153f224b912020",
+                "sha256:2de5b931701257d50771a032bba4e448ff958076380b049fd36ed8738fdb375b",
+                "sha256:3457f8cf86deb6ce1ba67e120f1b0128fcba1332a180722756597253c465fc1d",
+                "sha256:351686ca020d1bcd238596b1fa5c8efcbc21bffda9d0efe237aaa60348421e2a",
+                "sha256:406aeb340613b4b559db78d86864485f68919b7141dec82aba24d1477fd2976f",
+                "sha256:41de4db9b9501679cf7cddc16d07ac0f10ef7eb58c525a1c8cbff43022bddca4",
+                "sha256:41f62468af1bd4e4b42b5508a3fe8cc46a693f0cdd0ca2f443f51f207893d837",
+                "sha256:4766632cd8a68e4f10f156a12c9acd7b1609941525569dd3636d859d79279ed3",
+                "sha256:47b2848e464883d0bbdcd9493c67443e5e695a84694efff0476f9059b4cb6257",
+                "sha256:4a495c3d513573b0b3f935bfa887a85d9ae09f0627cf47cad17d0cc9b9ba5c38",
+                "sha256:4ad065b2ebd09f32511ff2be35c5dfafee6192978b5a1e9d279a5c6e121e3b03",
+                "sha256:4c457220468d734e3077580a3642b7f682f5fd9507f17ddf1029452450912cdc",
+                "sha256:4f52d0732e56906f8ddea4bd856192984650282424049c956857fed43697ea43",
+                "sha256:54a1e09ab7a69f843cd28fefd2bcaf23edb9e3a8d7680032c8968b8ac934587d",
+                "sha256:5a72eecf37eface331636951249d878750db84034927c997d47f7f78a573b72b",
+                "sha256:5df31bb2b974f379d230a25943d9bf0d3bc666b4b0807394b131a28fca2b0e5f",
+                "sha256:66a518731a21a55b7d3e087b430f1956a36793acc15912e2878431c7aec54210",
+                "sha256:6790b8d96bbb74b7a6f4594b6f131bd23056c25f2aa5d816bd177d95245a30e3",
+                "sha256:68201be60ac56aff972dc18085800b6ee07973c49103a8aba669dee3d71079de",
+                "sha256:6e105013fa84623c057a4381dc8ea0361f4d682c11f3816cc80f49a1f3bc17c6",
+                "sha256:705c184b77565955a99dc360f359e8249580c6b7eaa4dc0227caa861ef46b27a",
+                "sha256:72cfbeab7a920ea9e74b19aa0afe3b4ad9c89471e3badc985d08756efa9b813b",
+                "sha256:735f386ec522e384f511614c01d2ef9cf799f051353876b4c6fb93ef67a6d1ee",
+                "sha256:82d22f6e6f2916e837c91c860140ef9947e31194c82aaeda843d6551cec92f19",
+                "sha256:83334e84a290a158c0c4cc4d22e8c7cfe0bba5b76d37f1c2509dabd22acafe15",
+                "sha256:84e97f59211b5b9083a2e7a45abf91cfb441369e8bb6d1f5287382c1c526def3",
+                "sha256:87521e32e18a2223311afc2492ef2d99946337da0779ddcda77b82ee7319df59",
+                "sha256:878ebe074839d649a1cdb03a61077d05760624f36d196884a5cafb12290e187b",
+                "sha256:89fdfc84c6bf0bff2ff3170bb34ecba8a6911b260d318d377171429c4be18c73",
+                "sha256:8b4c7665a17c3a5430edb663e4ad4e1ad457614d1b2f2b7f87052e2ef4fa45ca",
+                "sha256:8b54cdd2fda15467b9b0bfa78cee2ddf6dbb4585ef23a16e14926f4b076dfae4",
+                "sha256:94728f97ddf603d23c8c3dd5cae2644fa12d33116e69f49b1644a71bb77b89ae",
+                "sha256:954b154a4533ef28bd3e83ffdf4eadf39deeda9e38fb8feaf066d6069885e034",
+                "sha256:977a1438d0e0d96573fd679d291a1542097ea9f4918a8b6494b06610dfeefbf9",
+                "sha256:9ade70aea559ca98f4b1b1e5650c45678052e76a8ab2f76d90f2ac64180215a2",
+                "sha256:9b6e21e5770df2dea06cb7b6323fbc008b13c4a4e3b52cb54685276479ee7676",
+                "sha256:a0d3ffa8772464441b52489b985d46001e2853a3b082c655ec5fad9fb6a3d618",
+                "sha256:a37594ad6356e50073fe4f60aa4187b97d15329f2138124d252a5a19c8553ea4",
+                "sha256:a8d86547a5e98d9edd47c432f7a14b0c5592624b496ae9880fb6332f34af1edc",
+                "sha256:aa44c4740b4e23fcfa259e9dd52315d2b1770064cde9507457e4c4a65a04c397",
+                "sha256:acc4614e8d1feb9f46dd829a8e771b8f5c4b1051365d02efb27a3229048ade8a",
+                "sha256:af2a51c8a381d76eabb76f228f565ed4c3701441ecec101dd18be70ebd483cfd",
+                "sha256:b2ae2f5e9fa10805fb1c9adbfefaaecedd9e31849434be462c3960a0139ed729",
+                "sha256:b46f997d5ed6d222a863b02cdc9c299101ee27974d9bbb2fd1b3c8441311c408",
+                "sha256:bc93f5f62df3bdc1f677066327fc81f92b83644852a31c6aa9b32c2dde86ea7d",
+                "sha256:bfbaa08cf1452acad9cb1c1d7b89394a41e712f88df522cea1a0f296b57782a0",
+                "sha256:c1e8e9033d34c2c9e186e58279879d78c94dd365068a3607af33f2bc99357a53",
+                "sha256:c5328ed53fdb0a73c8a50105306a3bc013e5ca36cca714ec4f7bd31d38d8a97f",
+                "sha256:c6a9d84ee6427b65a81fc24e6ef589cb794009f5ca4150151251c062773e7ed2",
+                "sha256:c98d3c04701773ad60d9545cd96df94d955329efc7743fdb96422c4b669c633b",
+                "sha256:cb3957c39668d10e2b486acc85f94153520a23263b6401e8f59422ef65b9520d",
+                "sha256:e63ad0beef6ece06475d29f47d1f2f29727805376e09850ebf64f90777962792",
+                "sha256:e74f8b4d8677ebb4015ac01fcaf05f34e8a1f22775db1f304f497f2f88fdc697",
+                "sha256:e7d0dd3e727c70c2680f5f09a0775525229809f1a35d8552b92ff10b2b14f2c2",
+                "sha256:ec6cf345771cdb00791d271af9a0a6fbfc2b6dd44cb753f1eeaa256e21622adb",
+                "sha256:ed58803563a8c87cf4c0771366cf0ad1aa265b6b0ae54cbbb53013480c7ad74d",
+                "sha256:f0081a623c886197ff8de9e635528fd7e6a387dccef432149e25c13946cb0cd0",
+                "sha256:f025f1d6825725b09c0038775acab9ae94264453a696cc797ce20c0769a7b367",
+                "sha256:f5f3b2942c3b8b9bfe76b408bbaba3d3bb305ee3693e8b1d631fe0a0d4f93673",
+                "sha256:fbd4844ff111449f3bbe20ba24fbb906b5b1c2384d0f3287c9f7da2354ce6d23"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.2.0"
         },
         "graphviz": {
             "hashes": [
@@ -1212,7 +1382,7 @@
                 "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
                 "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_full_version < '4.0.0'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.26.7"
         },
         "uvicorn": {

--- a/robot-server/robot_server/hardware.py
+++ b/robot-server/robot_server/hardware.py
@@ -6,7 +6,7 @@ from fastapi import Depends, status
 from typing import Callable, Union
 from typing_extensions import Literal
 
-from opentrons import initialize as initialize_api
+from opentrons import initialize as initialize_api, should_use_ot3
 from opentrons.config import IS_ROBOT, ARCHITECTURE, SystemArchitecture
 from opentrons.util.helpers import utc_now
 from opentrons.hardware_control import API as HardwareAPI
@@ -115,7 +115,7 @@ async def _initialize_hardware_api(app_state: AppState) -> None:
         simulator_config = app_settings.simulator_configuration_file_path
         systemd_available = IS_ROBOT and ARCHITECTURE != SystemArchitecture.HOST
 
-        if systemd_available:
+        if systemd_available and not should_use_ot3():
             # During boot, opentrons-gpio-setup.service will be blinking the
             # front button light. Kill it here and wait for it to exit so it releases
             # that GPIO line. Otherwise, our hardware initialization would get a

--- a/robot-server/tests/integration/test_settings.tavern.yaml
+++ b/robot-server/tests/integration/test_settings.tavern.yaml
@@ -60,6 +60,12 @@ stages:
             description: !re_search 'This setting is deprecated'
             restart_required: true
             value: !anything
+          - id: enableOT3HardwareController
+            old_id: Null
+            title: Enable experimental OT3 hardware controller
+            description: !re_search 'Opentrons-internal setting to test new hardware'
+            restart_required: true
+            value: !anything
         links: !anydict
 
 ---


### PR DESCRIPTION
# Overview

It's a start.

# Changelog

- adding `enableOT3HardwareController` feature flag.
- use feature flag to use `OT3Controller`.
- ot3 controller connects to can bus
- move command implemented.

# Review requests



# Risk assessment

HIGH. This cannot be merged until we validate that it doesn't interfere with OT2 operation.