### PR TITLE
refactor(robot-server): add protocol files names to Protocol response

### DIFF
--- a/robot-server/robot_server/protocols/protocol_models.py
+++ b/robot-server/robot_server/protocols/protocol_models.py
@@ -16,6 +16,26 @@ class ProtocolType(str, Enum):
     PYTHON = "python"
 
 
+class ProtocolFileRole(str, Enum):
+    """The purpose of a given file in a Protocol.
+
+    Args:
+        MAIN: The protocol's main file. In a JSON protocol, this is will
+            be the JSON file. In a Python protocol, this is the file
+            that exports the main `run` method.
+    """
+
+    MAIN = "main"
+
+
+class ProtocolFile(BaseModel):
+    """A file in a protocol."""
+
+    # TODO(mc, 2021-11-12): add unique ID to file resource
+    name: str = Field(..., description="The file's basename, including extension")
+    role: ProtocolFileRole = Field(..., description="The file's role in the protocol.")
+
+
 class Metadata(BaseModel):
     """Extra, nonessential information about the protocol.
 
@@ -56,6 +76,8 @@ class Protocol(ResourceModel):
             " when this protocol was *authored.*)"
         ),
     )
+
+    files: Sequence[ProtocolFile]
 
     protocolType: ProtocolType = Field(
         ...,

--- a/robot-server/robot_server/protocols/response_builder.py
+++ b/robot-server/robot_server/protocols/response_builder.py
@@ -3,9 +3,15 @@ from typing import List
 
 from opentrons.protocol_runner import PreAnalysis, JsonPreAnalysis
 
-from .protocol_store import ProtocolResource
-from .protocol_models import Protocol, ProtocolType, Metadata
 from .analysis_models import ProtocolAnalysis
+from .protocol_store import ProtocolResource
+from .protocol_models import (
+    Protocol,
+    ProtocolType,
+    ProtocolFile,
+    ProtocolFileRole,
+    Metadata,
+)
 
 
 def _pre_analysis_to_protocol_type(pre_analysis: PreAnalysis) -> ProtocolType:
@@ -38,4 +44,10 @@ class ResponseBuilder:
             protocolType=_pre_analysis_to_protocol_type(resource.pre_analysis),
             metadata=Metadata.parse_obj(resource.pre_analysis.metadata),
             analyses=analyses,
+            files=[
+                # TODO(mc, 2021-11-12): don't report all files as main. Move
+                # role determination to PreAnalyzer
+                ProtocolFile(name=f.name, role=ProtocolFileRole.MAIN)
+                for f in resource.files
+            ],
         )

--- a/robot-server/tests/protocols/test_protocols_router.py
+++ b/robot-server/tests/protocols/test_protocols_router.py
@@ -84,6 +84,7 @@ async def test_get_protocols(
         protocolType=ProtocolType.PYTHON,
         metadata=Metadata(),
         analyses=[analysis_1],
+        files=[],
     )
     protocol_2 = Protocol(
         id="123",
@@ -91,6 +92,7 @@ async def test_get_protocols(
         protocolType=ProtocolType.JSON,
         metadata=Metadata(),
         analyses=[analysis_2],
+        files=[],
     )
 
     decoy.when(protocol_store.get_all()).then_return([resource_1, resource_2])
@@ -134,6 +136,7 @@ async def test_get_protocol_by_id(
         protocolType=ProtocolType.PYTHON,
         metadata=Metadata(),
         analyses=[analysis],
+        files=[],
     )
 
     decoy.when(protocol_store.get(protocol_id="protocol-id")).then_return(resource)
@@ -203,6 +206,7 @@ async def test_create_protocol(
         protocolType=ProtocolType.JSON,
         metadata=Metadata.parse_obj(metadata_as_dict),
         analyses=[analysis],
+        files=[],
     )
 
     decoy.when(pre_analyzer.analyze([protocol_file])).then_return(pre_analysis)

--- a/robot-server/tests/protocols/test_response_builder.py
+++ b/robot-server/tests/protocols/test_response_builder.py
@@ -1,15 +1,92 @@
 """Tests for the protocol response model builder."""
+import pytest
 from datetime import datetime
+from pathlib import Path
+from typing import List, NamedTuple
 
-from opentrons.protocol_runner.pre_analysis import JsonPreAnalysis
+from opentrons.protocols.api_support.types import APIVersion
+from opentrons.protocol_runner.pre_analysis import (
+    PreAnalysis,
+    JsonPreAnalysis,
+    PythonPreAnalysis,
+)
+
 from robot_server.protocols.protocol_store import ProtocolResource
-from robot_server.protocols.protocol_models import Protocol, ProtocolType, Metadata
 from robot_server.protocols.analysis_models import PendingAnalysis
 from robot_server.protocols.response_builder import ResponseBuilder
+from robot_server.protocols.protocol_models import (
+    Protocol,
+    ProtocolType,
+    ProtocolFile,
+    ProtocolFileRole,
+    Metadata,
+)
 
 
-def test_create_single_json_file_response() -> None:
-    """It should create a response for a single-file JSON `ProtocolResource`."""
+class SingleFileSpec(NamedTuple):
+    """Test data for single-file protocol responses."""
+
+    expected_result: Protocol
+    files: List[Path]
+    pre_analysis: PreAnalysis
+    protocol_id: str = "protocol-id"
+    created_at: datetime = datetime(year=2021, month=1, day=1)
+
+
+@pytest.mark.parametrize(
+    SingleFileSpec._fields,
+    [
+        SingleFileSpec(
+            expected_result=Protocol(
+                id="protocol-id",
+                createdAt=datetime(year=2021, month=1, day=1),
+                protocolType=ProtocolType.JSON,
+                metadata=Metadata(),
+                analyses=[],
+                files=[
+                    ProtocolFile(name="my-protocol.json", role=ProtocolFileRole.MAIN)
+                ],
+            ),
+            files=[Path("/dev/null/my-protocol.json")],
+            pre_analysis=JsonPreAnalysis(schema_version=123, metadata={}),
+        ),
+        SingleFileSpec(
+            expected_result=Protocol(
+                id="protocol-id",
+                createdAt=datetime(year=2021, month=1, day=1),
+                protocolType=ProtocolType.PYTHON,
+                metadata=Metadata(),
+                analyses=[],
+                files=[ProtocolFile(name="my-protocol.py", role=ProtocolFileRole.MAIN)],
+            ),
+            files=[Path("/dev/null/my-protocol.py")],
+            pre_analysis=PythonPreAnalysis(api_version=APIVersion(2, 11), metadata={}),
+        ),
+    ],
+)
+def test_single_file_response(
+    expected_result: Protocol,
+    files: List[Path],
+    pre_analysis: PreAnalysis,
+    protocol_id: str,
+    created_at: datetime,
+) -> None:
+    """It should create a response for single-file protocols."""
+    protocol_resource = ProtocolResource(
+        protocol_id=protocol_id,
+        pre_analysis=pre_analysis,
+        created_at=created_at,
+        files=files,
+    )
+
+    subject = ResponseBuilder()
+    result = subject.build(resource=protocol_resource, analyses=[])
+
+    assert result == expected_result
+
+
+def test_metadata_in_response() -> None:
+    """It should add pre-analysis metadata to the response."""
     metadata_as_dict = {
         "a_string": "hello",
         "an_int": 9001,
@@ -35,4 +112,5 @@ def test_create_single_json_file_response() -> None:
         metadata=Metadata.parse_obj(metadata_as_dict),
         createdAt=datetime(year=2021, month=1, day=1),
         analyses=[protocol_analysis],
+        files=[],
     )


### PR DESCRIPTION
## Overview

Closes #8545


### Example response

```json
{
    "data": {
        "id": "450c598a-cd1a-44a8-af3f-f38fabec0ef3",
        "createdAt": "2021-11-12T18:25:36.704477+00:00",
        "files": [
            {
                "name": "testosaur_v2.py",
                "role": "main"
            }
        ],
        "protocolType": "python",
        "metadata": {
            "protocolName": "Testosaur",
            "apiLevel": "2.0",
            "source": "Opentrons Repository",
            "author": "Opentrons <engineering@opentrons.com>",
            "description": "A variant on \"Dinosaur\" for testing"
        },
        "analyses": [
            {
                "id": "f3c775cf-96c0-4583-aebc-de5a49f2e6e7",
                "status": "pending"
            }
        ]
    },
    "links": null
}
```

## Changelog

- refactor(robot-server): add protocol files names to Protocol response

## Review requests

- [ ] Tests + code check out
- [ ] TODOs check out
- [ ] Endpoint works

## Risk assessment

Low