### PR TITLE
fix(api): fix pipette twinning tip rack sorting

### DIFF
--- a/api/src/opentrons/protocol_api/paired_instrument_context.py
+++ b/api/src/opentrons/protocol_api/paired_instrument_context.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING, Union, Tuple, List, Optional, Dict
-from collections import OrderedDict
 
 
 from opentrons.protocols.api_support.labware_like import LabwareLike

--- a/api/src/opentrons/protocol_api/paired_instrument_context.py
+++ b/api/src/opentrons/protocol_api/paired_instrument_context.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING, Union, Tuple, List, Optional, Dict
+from collections import OrderedDict
 
 
 from opentrons.protocols.api_support.labware_like import LabwareLike
@@ -63,9 +64,12 @@ class PairedInstrumentContext(CommandPublisher):
         }
         self._api_version = api_version
         self._log = log_parent.getChild(repr(self))
-        self._tip_racks = list(
-            set(primary_instrument.tip_racks) & set(secondary_instrument.tip_racks)
-        )
+
+        self._tip_racks = [
+            tr
+            for tr in primary_instrument.tip_racks
+            if tr in secondary_instrument.tip_racks
+        ]
         self._pair_policy = pair_policy
 
         self._starting_tip: Union[Well, None] = None
@@ -249,7 +253,6 @@ class PairedInstrumentContext(CommandPublisher):
         secondary_target = self._get_secondary_target(tiprack, target)
         primary_pipette = self._instruments[self._pair_policy.primary]
         tip_length = primary_pipette._tip_length_for(tiprack)
-
         instruments = list(self._instruments.values())
         targets = [target, secondary_target]
 

--- a/api/tests/opentrons/protocol_api/test_paired_context.py
+++ b/api/tests/opentrons/protocol_api/test_paired_context.py
@@ -1,11 +1,11 @@
 import pytest
 from unittest import mock
 
+
 from opentrons.hardware_control import API
 from opentrons.types import Mount, Point, Location
 from opentrons.protocol_api import paired_instrument_context as pc
 from opentrons.hardware_control.pipette import Pipette
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import]
 
 
 @pytest.fixture


### PR DESCRIPTION
# Overview

Do not rely on python sets to decide the order of a list, since the order is not guaranteed.


# Changelog

- Use regular list comprehension to get rid of duplicates in list(s) and keep only the intersection of the two lists.
- Added test to check tiprack list order

# Review requests

Test on a robot, using this protocol:
```
#!/usr/bin/env python
# coding: utf-8

# In[ ]:


from opentrons import protocol_api, types
import math

metadata = {
    'protocolName': 'Test for changing tip racks during paired pipette pick_up_tip',
    'apiLevel': '2.11'
    }

def run(protocol: protocol_api.ProtocolContext):
    #Labware
    tiprack_ten = protocol.load_labware('opentrons_96_tiprack_1000ul', 10)
    tiprack_five = protocol.load_labware('opentrons_96_tiprack_1000ul', 5)
    wellplate = protocol.load_labware('nest_96_wellplate_100ul_pcr_full_skirt', 3)

    #Pipette
    p1000L = protocol.load_instrument('p1000_single_gen2', mount='left', tip_racks=[tiprack_five, tiprack_ten])
    p1000R = protocol.load_instrument('p1000_single_gen2', mount='right', tip_racks=[tiprack_ten, tiprack_five])

    #pair pipettes: right pipette as secondary
    paired_pipette = p1000L.pair_with(p1000R)

    #Lights On if Off
    if protocol.rail_lights_on==False:
        protocol.set_rail_lights(True)

    #Protocol
    #Column1,5
    
    #testing to see how the default .pick_up_tip changes 
    #for the paired pipette variable across multiple runs

    paired_pipette.pick_up_tip()
    protocol.home()
    paired_pipette.return_tip()
    
    paired_pipette.pick_up_tip()
    protocol.home()
    paired_pipette.return_tip()
    
```

The robot should now move to the correct tiprack for pickup tip (which is tiprack_five).

# Risk assessment
Low.