### PR TITLE
feat(app): delete v6 adapter pick up tip shim

### DIFF
--- a/shared-data/js/helpers/schemaV6Adapter.ts
+++ b/shared-data/js/helpers/schemaV6Adapter.ts
@@ -1,5 +1,4 @@
 import { getLabwareDisplayName } from '.'
-import { PickUpTipCommand } from '../../protocol/types/schemaV6/command/pipetting'
 import type { LoadLabwareCommand } from '../../protocol/types/schemaV6/command/setup'
 import type { Command, ProtocolFile } from '../../protocol'
 import type { PipetteName } from '../pipettes'
@@ -69,33 +68,12 @@ export const schemaV6Adapter = (
         }
       }, {})
 
-    // This is a temporary hack that should be deleted as soon as pickup tip command mapping is implemented in protocol engine
-    const commands = protocolAnalyses.commands.map((command, index) => {
-      if (command.id.includes('PICK_UP_TIP')) {
-        const shimmedPickupTipCommand: PickUpTipCommand = {
-          id: index.toString(),
-          commandType: 'pickUpTip',
-          params: {
-            pipetteId: index % 2 === 0 ? 'pipette-0' : 'pipette-1',
-            labwareId: index % 2 === 0 ? 'labware-1' : 'labware-3',
-            wellName: 'A1',
-          },
-          result: {
-            pipetteId: index % 2 === 0 ? 'pipette-0' : 'pipette-1',
-            labwareId: index % 2 === 0 ? 'labware-1' : 'labware-3',
-          },
-        }
-        return shimmedPickupTipCommand
-      }
-      return command
-    })
-
     // @ts-expect-error this is a v6 like object that does not quite match the v6 spec at the moment
     return {
       pipettes,
       labware,
       labwareDefinitions,
-      commands,
+      commands: protocolAnalyses.commands,
     }
   }
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions


### PR DESCRIPTION
# Overview

Now that [pick up tip commands are being returned by PE](https://github.com/Opentrons/opentrons/pull/8728), we don't need the adapter shim. 

# Risk assessment

Low
