### PR TITLE
refactor(engine): add `home` command

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -871,7 +871,7 @@ class API(HardwareAPILike):
             or not self._current_position
         ):
             raise MustHomeError(
-                "Current position of {str(mount)} pipette is unknown, please home."
+                f"Current position of {str(mount)} pipette is unknown, please home."
             )
 
         elif not self._current_position and not refresh:

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -857,7 +857,7 @@ class API(HardwareAPILike):
         the nozzle will be returned.
         """
         if not self._current_position and not refresh:
-            raise MustHomeError
+            raise MustHomeError("Current position is unknown; please home motors.")
         async with self._motion_lock:
             if refresh:
                 self._current_position = self._deck_from_smoothie(

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -839,8 +839,11 @@ class API(HardwareAPILike):
     async def current_position(
         self,
         mount: top_types.Mount,
-        critical_point: CriticalPoint = None,
+        critical_point: Optional[CriticalPoint] = None,
         refresh: bool = False,
+        # TODO(mc, 2021-11-15): combine with `refresh` for more reliable
+        # position reporting when motors are not homed
+        fail_on_not_homed: bool = False,
     ) -> Dict[Axis, float]:
         """Return the postion (in deck coords) of the critical point of the
         specified mount.
@@ -855,8 +858,23 @@ class API(HardwareAPILike):
         the next one down is returned - for instance, if there is no tip on the
         specified mount but `CriticalPoint.TIP` was specified, the position of
         the nozzle will be returned.
+
+        If `fail_on_not_homed` is `True`, this method will raise a `MustHomeError`
+        if any of the relavent axes are not homed, regardless of `refresh`.
         """
-        if not self._current_position and not refresh:
+        z_ax = Axis.by_mount(mount)
+        plunger_ax = Axis.of_plunger(mount)
+        position_axes = [Axis.X, Axis.Y, z_ax, plunger_ax]
+
+        if fail_on_not_homed and (
+            not self._backend.is_homed([str(a) for a in position_axes])
+            or not self._current_position
+        ):
+            raise MustHomeError(
+                "Current position of {str(mount)} pipette is unknown, please home."
+            )
+
+        elif not self._current_position and not refresh:
             raise MustHomeError("Current position is unknown; please home motors.")
         async with self._motion_lock:
             if refresh:
@@ -867,8 +885,7 @@ class API(HardwareAPILike):
                 offset = top_types.Point(0, 0, 0)
             else:
                 offset = top_types.Point(*self._config.left_mount_offset)
-            z_ax = Axis.by_mount(mount)
-            plunger_ax = Axis.of_plunger(mount)
+
             cp = self._critical_point_for(mount, critical_point)
             return {
                 Axis.X: self._current_position[Axis.X] + offset[0] + cp.x,
@@ -882,6 +899,9 @@ class API(HardwareAPILike):
         mount: top_types.Mount,
         critical_point: CriticalPoint = None,
         refresh: bool = False,
+        # TODO(mc, 2021-11-15): combine with `refresh` for more reliable
+        # position reporting when motors are not homed
+        fail_on_not_homed: bool = False,
     ) -> top_types.Point:
         """Return the position of the critical point as pertains to the gantry
 
@@ -893,8 +913,16 @@ class API(HardwareAPILike):
 
         `refresh` if set to True, update the cached position using the
         smoothie driver (see :py:meth:`current_position`).
+
+        If `fail_on_not_homed` is `True`, this method will raise a `MustHomeError`
+        if any of the relavent axes are not homed, regardless of `refresh`.
         """
-        cur_pos = await self.current_position(mount, critical_point, refresh)
+        cur_pos = await self.current_position(
+            mount,
+            critical_point,
+            refresh,
+            fail_on_not_homed,
+        )
         return top_types.Point(
             x=cur_pos[Axis.X], y=cur_pos[Axis.Y], z=cur_pos[Axis.by_mount(mount)]
         )
@@ -1025,7 +1053,7 @@ class API(HardwareAPILike):
         homed moves it will raise a MustHomeError. Otherwise, it will home the axis.
         """
 
-        # TODO: Remove the fail_if_not_homed and make this the behavior all the time.
+        # TODO: Remove the fail_on_not_homed and make this the behavior all the time.
         # Having the optional arg makes the bug stick around in existing code and we
         # really want to fix it when we're not gearing up for a release.
         mounts = self._mounts(mount)

--- a/api/src/opentrons/protocol_engine/commands/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/__init__.py
@@ -72,6 +72,14 @@ from .load_module import (
     LoadModuleCommandType,
 )
 
+from .home import (
+    Home,
+    HomeParams,
+    HomeCreate,
+    HomeResult,
+    HomeCommandType,
+)
+
 from .move_relative import (
     MoveRelative,
     MoveRelativeParams,
@@ -154,6 +162,12 @@ __all__ = [
     "LoadModuleParams",
     "LoadModuleResult",
     "LoadModuleCommandType",
+    # home command models
+    "Home",
+    "HomeParams",
+    "HomeCreate",
+    "HomeResult",
+    "HomeCommandType",
     # move relative command models
     "MoveRelative",
     "MoveRelativeParams",

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -36,6 +36,7 @@ from .load_pipette import (
     LoadPipetteCommandType,
 )
 
+from .home import Home, HomeCreate, HomeResult, HomeCommandType
 
 from .move_relative import (
     MoveRelative,
@@ -86,6 +87,7 @@ Command = Union[
     LoadLabware,
     LoadModule,
     LoadPipette,
+    Home,
     MoveRelative,
     MoveToWell,
     PickUpTip,
@@ -102,6 +104,7 @@ CommandType = Union[
     LoadLabwareCommandType,
     LoadModuleCommandType,
     LoadPipetteCommandType,
+    HomeCommandType,
     MoveRelativeCommandType,
     MoveToWellCommandType,
     PickUpTipCommandType,
@@ -118,6 +121,7 @@ CommandCreate = Union[
     LoadLabwareCreate,
     LoadModuleCreate,
     LoadPipetteCreate,
+    HomeCreate,
     MoveRelativeCreate,
     MoveToWellCreate,
     PickUpTipCreate,
@@ -133,6 +137,7 @@ CommandResult = Union[
     LoadLabwareResult,
     LoadModuleResult,
     LoadPipetteResult,
+    HomeResult,
     MoveRelativeResult,
     MoveToWellResult,
     PickUpTipResult,

--- a/api/src/opentrons/protocol_engine/commands/home.py
+++ b/api/src/opentrons/protocol_engine/commands/home.py
@@ -18,7 +18,8 @@ class HomeParams(BaseModel):
         None,
         description=(
             "Axes to return to their home positions. If omitted,"
-            " will home all motors."
+            " will home all motors. Extra axes may be implicitly homed"
+            " to ensure accurate homing of the explicitly specified axes."
         ),
     )
 

--- a/api/src/opentrons/protocol_engine/commands/home.py
+++ b/api/src/opentrons/protocol_engine/commands/home.py
@@ -1,0 +1,60 @@
+"""Home command payload, result, and implementation models."""
+from __future__ import annotations
+from pydantic import BaseModel, Field
+from typing import Optional, Sequence, Type
+from typing_extensions import Literal
+
+from ..types import MotorAxis
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+
+HomeCommandType = Literal["home"]
+
+
+class HomeParams(BaseModel):
+    """Payload required for a Home command."""
+
+    axes: Optional[Sequence[MotorAxis]] = Field(
+        None,
+        description=(
+            "Axes to return to their home positions. If omitted,"
+            " will home all motors."
+        ),
+    )
+
+
+class HomeResult(BaseModel):
+    """Result data from the execution of a Home command."""
+
+
+class HomeImplementation(AbstractCommandImpl[HomeParams, HomeResult]):
+    """Home command implementation."""
+
+    async def execute(self, params: HomeParams) -> HomeResult:
+        """Home some or all motors to establish positional accuracy."""
+        await self._movement.home(axes=params.axes)
+        return HomeResult()
+
+
+class Home(BaseCommand[HomeParams, HomeResult]):
+    """Command to send some (or all) motors to their home positions.
+
+    Homing a motor re-establishes positional accuracy the first time a motor
+    is used, or any time the motor "loses" its position, for example, after
+    a halt or after a collision.
+    """
+
+    commandType: HomeCommandType = "home"
+    params: HomeParams
+    result: Optional[HomeResult]
+
+    _ImplementationCls: Type[HomeImplementation] = HomeImplementation
+
+
+class HomeCreate(BaseCommandCreate[HomeParams]):
+    """Data to create a Home command."""
+
+    commandType: HomeCommandType = "home"
+    params: HomeParams
+
+    _CommandCls: Type[Home] = Home

--- a/api/src/opentrons/protocol_engine/execution/movement.py
+++ b/api/src/opentrons/protocol_engine/execution/movement.py
@@ -1,18 +1,29 @@
 """Movement command handling."""
-from typing import Optional
+from typing import Dict, Optional, Sequence
 from dataclasses import dataclass
 
 from opentrons.types import Point
 from opentrons.hardware_control.api import API as HardwareAPI
 from opentrons.hardware_control.types import (
     CriticalPoint,
+    Axis as HardwareAxis,
     MustHomeError as HardwareMustHomeError,
 )
 
-from ..types import WellLocation, DeckPoint, MovementAxis
+from ..types import WellLocation, DeckPoint, MovementAxis, MotorAxis
 from ..state import StateStore, CurrentWell
 from ..errors import MustHomeError
 from ..resources import ModelUtils
+
+
+MOTOR_AXIS_TO_HARDWARE_AXIS: Dict[MotorAxis, HardwareAxis] = {
+    MotorAxis.X: HardwareAxis.X,
+    MotorAxis.Y: HardwareAxis.Y,
+    MotorAxis.LEFT_Z: HardwareAxis.Z,
+    MotorAxis.RIGHT_Z: HardwareAxis.A,
+    MotorAxis.LEFT_PLUNGER: HardwareAxis.B,
+    MotorAxis.RIGHT_PLUNGER: HardwareAxis.C,
+}
 
 
 @dataclass(frozen=True)
@@ -134,11 +145,13 @@ class MovementHandler:
             else:
                 pip_cp = CriticalPoint.NOZZLE
 
-        # TODO (spp, 2021-11-3): Handle MustHomeError case
-        point = await self._hardware_api.gantry_position(
-            mount=hw_mount,
-            critical_point=pip_cp,
-        )
+        try:
+            point = await self._hardware_api.gantry_position(
+                mount=hw_mount,
+                critical_point=pip_cp,
+            )
+        except HardwareMustHomeError as e:
+            raise MustHomeError(str(e)) from e
 
         position_id = position_id or self._model_utils.generate_id()
 
@@ -146,3 +159,14 @@ class MovementHandler:
             positionId=position_id,
             position=DeckPoint(x=point.x, y=point.y, z=point.z),
         )
+
+    async def home(self, axes: Optional[Sequence[MotorAxis]]) -> None:
+        """Send the requested axes to their "home" positions.
+
+        If axes is `None`, will home all motors.
+        """
+        hardware_axes = None
+        if axes:
+            hardware_axes = [MOTOR_AXIS_TO_HARDWARE_AXIS[a] for a in axes]
+
+        await self._hardware_api.home(axes=hardware_axes)

--- a/api/src/opentrons/protocol_engine/execution/movement.py
+++ b/api/src/opentrons/protocol_engine/execution/movement.py
@@ -149,6 +149,7 @@ class MovementHandler:
             point = await self._hardware_api.gantry_position(
                 mount=hw_mount,
                 critical_point=pip_cp,
+                fail_on_not_homed=True,
             )
         except HardwareMustHomeError as e:
             raise MustHomeError(str(e)) from e
@@ -166,7 +167,7 @@ class MovementHandler:
         If axes is `None`, will home all motors.
         """
         hardware_axes = None
-        if axes:
+        if axes is not None:
             hardware_axes = [MOTOR_AXIS_TO_HARDWARE_AXIS[a] for a in axes]
 
         await self._hardware_api.home(axes=hardware_axes)

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -17,6 +17,7 @@ from ..commands import (
     MoveToWellResult,
     PickUpTipResult,
     DropTipResult,
+    HomeResult,
 )
 from ..actions import Action, UpdateCommandAction
 from .abstract_store import HasState, HandlesActions
@@ -85,6 +86,9 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                     well_name=command.params.wellName,
                 ),
             )
+        # TODO(mc, 2021-11-12): wipe out current_well on movement failures, too
+        elif isinstance(command.result, HomeResult):
+            self._state = replace(self._state, current_well=None)
 
         if isinstance(command.result, LoadPipetteResult):
             pipette_id = command.result.pipetteId

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -113,6 +113,17 @@ class MovementAxis(str, Enum):
     Z = "z"
 
 
+class MotorAxis(str, Enum):
+    """Motor axis on which to issue a home command."""
+
+    X = "x"
+    Y = "y"
+    LEFT_Z = "leftZ"
+    RIGHT_Z = "rightZ"
+    LEFT_PLUNGER = "leftPlunger"
+    RIGHT_PLUNGER = "rightPluger"
+
+
 class LabwareOffsetVector(BaseModel):
     """Offset, in deck coordinates from nominal to actual position."""
 

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -121,7 +121,7 @@ class MotorAxis(str, Enum):
     LEFT_Z = "leftZ"
     RIGHT_Z = "rightZ"
     LEFT_PLUNGER = "leftPlunger"
-    RIGHT_PLUNGER = "rightPluger"
+    RIGHT_PLUNGER = "rightPlunger"
 
 
 class LabwareOffsetVector(BaseModel):

--- a/api/tests/opentrons/protocol_engine/commands/test_home.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_home.py
@@ -1,0 +1,63 @@
+"""Test move relative commands."""
+from decoy import Decoy
+
+from opentrons.protocol_engine.types import MotorAxis
+
+from opentrons.protocol_engine.execution import (
+    EquipmentHandler,
+    MovementHandler,
+    PipettingHandler,
+    RunControlHandler,
+)
+
+from opentrons.protocol_engine.commands.home import (
+    HomeParams,
+    HomeResult,
+    HomeImplementation,
+)
+
+
+async def test_home_implementation(
+    decoy: Decoy,
+    equipment: EquipmentHandler,
+    movement: MovementHandler,
+    pipetting: PipettingHandler,
+    run_control: RunControlHandler,
+) -> None:
+    """A Home command should have an execution implementation."""
+    subject = HomeImplementation(
+        equipment=equipment,
+        movement=movement,
+        pipetting=pipetting,
+        run_control=run_control,
+    )
+
+    data = HomeParams(axes=[MotorAxis.X, MotorAxis.Y])
+
+    result = await subject.execute(data)
+
+    assert result == HomeResult()
+    decoy.verify(await movement.home(axes=[MotorAxis.X, MotorAxis.Y]))
+
+
+async def test_home_all_implementation(
+    decoy: Decoy,
+    equipment: EquipmentHandler,
+    movement: MovementHandler,
+    pipetting: PipettingHandler,
+    run_control: RunControlHandler,
+) -> None:
+    """A Home command should have an execution implementation."""
+    subject = HomeImplementation(
+        equipment=equipment,
+        movement=movement,
+        pipetting=pipetting,
+        run_control=run_control,
+    )
+
+    data = HomeParams()
+
+    result = await subject.execute(data)
+
+    assert result == HomeResult()
+    decoy.verify(await movement.home(axes=None))

--- a/api/tests/opentrons/protocol_engine/commands/test_home.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_home.py
@@ -1,4 +1,4 @@
-"""Test move relative commands."""
+"""Test home commands."""
 from decoy import Decoy
 
 from opentrons.protocol_engine.types import MotorAxis
@@ -47,7 +47,7 @@ async def test_home_all_implementation(
     pipetting: PipettingHandler,
     run_control: RunControlHandler,
 ) -> None:
-    """A Home command should have an execution implementation."""
+    """It should pass axes=None along to the movement handler."""
     subject = HomeImplementation(
         equipment=equipment,
         movement=movement,

--- a/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
@@ -386,7 +386,7 @@ async def test_save_position_must_home(
     hardware_api: HardwareAPI,
     subject: MovementHandler,
 ) -> None:
-    """It should propogate a must home error."""
+    """It should propagate a must home error."""
     decoy.when(
         state_store.motion.get_pipette_location(
             pipette_id="pipette-id",

--- a/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
@@ -316,6 +316,7 @@ async def test_save_position(
         await hardware_api.gantry_position(
             mount=Mount.LEFT,
             critical_point=CriticalPoint.XY_CENTER,
+            fail_on_not_homed=True,
         )
     ).then_return(Point(1, 1, 1))
 
@@ -370,6 +371,7 @@ async def test_save_position_different_cp(
         await hardware_api.gantry_position(
             mount=Mount.LEFT,
             critical_point=verified_cp,
+            fail_on_not_homed=True,
         )
     ).then_return(Point(1, 1, 1))
 
@@ -402,6 +404,7 @@ async def test_save_position_must_home(
         await hardware_api.gantry_position(
             mount=Mount.LEFT,
             critical_point=CriticalPoint.XY_CENTER,
+            fail_on_not_homed=True,
         )
     ).then_raise(HardwareMustHomeError("oh no"))
 
@@ -441,3 +444,6 @@ async def test_home(
 
     await subject.home(axes=None)
     decoy.verify(await hardware_api.home(axes=None), times=1)
+
+    await subject.home(axes=[])
+    decoy.verify(await hardware_api.home(axes=[]), times=1)


### PR DESCRIPTION
## Overview

See title. Necessary for LPC if the user experiences a collision

## Changelog

- Add home command
- Add state reaction to clear last accessed well upon home
- Add `MustHomeError` to `savePosition` command

## Review requests

- [ ] Code looks good
- [ ] Tests look good
- [ ] Works on robot

## Risk assessment

Low
