### PR TITLE
refactor(app): protocol Upload Empty State Recent Run Listing

### DIFF
--- a/app/src/assets/localization/en/protocol_info.json
+++ b/app/src/assets/localization/en/protocol_info.json
@@ -35,7 +35,7 @@
   "exit_modal_go_back": "No, go back",
   "exit_modal_exit": "Yes, close now",
   "exit_modal_body": "Are you sure you want to close this protocol?",
-  "robotName_last_run": "{{robot_name}}'s last run",
+  "robotName_last_run": "{{robot_name}}’s last run",
   "rerunning_protocol_modal_title": "See How Rerunning a protocol works",
   "protocol_name_title": "Protocol name",
   "run_timestamp_title": "Run timestamp",

--- a/app/src/assets/localization/en/protocol_info.json
+++ b/app/src/assets/localization/en/protocol_info.json
@@ -35,7 +35,7 @@
   "exit_modal_go_back": "No, go back",
   "exit_modal_exit": "Yes, close now",
   "exit_modal_body": "Are you sure you want to close this protocol?",
-  "robotName_last_run": "{{robot_name}}’s last run",
+  "robot_name_last_run": "{{robot_name}}’s last run",
   "rerunning_protocol_modal_title": "See How Rerunning a Protocol Works",
   "protocol_name_title": "Protocol name",
   "run_timestamp_title": "Run timestamp",
@@ -46,5 +46,5 @@
   "rerunning_protocol_modal_header": "How Rerunning A Protocol Works",
   "rerunning_protocol_modal_body": "<block>Opentrons displays the connected robot’s last protocol run on on the Protocol Upload page. If you run again, Opentrons loads this protocol and applies Labware Offset data if any exists.</block><block>Clicking “Run Again” will take you directly to the Run tab. If you’d like to review the deck setup or run Labware Position Check before running the protocol, navigate to the Protocol tab.</block><block>If you recalibrate your robot, it will clear the last run from the upload page.</block>",
   "rerunning_protocol_modal_link": "Learn more about Labware Offset Data",
-  "no_labware_offset_Data": "No Labware Offset data"
+  "no_labware_offset_data": "No Labware Offset data"
 }

--- a/app/src/assets/localization/en/protocol_info.json
+++ b/app/src/assets/localization/en/protocol_info.json
@@ -1,5 +1,5 @@
 {
-  "browse_protocol_library": "Browse Our Protocol Library",
+  "browse_protocol_library": "Launch Opentrons Protocol library",
   "choose_file": "Choose File...",
   "continue_proceed_to_calibrate": "Proceed to Calibrate",
   "continue_verify_calibrations": "Verify pipette and labware calibrations",
@@ -18,7 +18,7 @@
   "labware_legacy_definition": "N/A",
   "labware_cal_description": "Calibrated offset from labware origin point",
   "last_updated": "Last Updated",
-  "launch_protocol_designer": "Launch Protocol Designer",
+  "launch_protocol_designer": "Launch Opentrons Protocol Designer",
   "modules_title": "Required Modules",
   "no_protocol_yet": "Don't have a protocol yet?",
   "open_a_protocol": "Open a protocol to get started",
@@ -30,9 +30,16 @@
   "required_cal_data_title": "Calibration Data",
   "simulation_in_progress": "Simulation in Progress",
   "update_robot_for_custom_labware": "You have custom labware definitions saved to your app, but this robot needs to be updated before you can use these definitions with Python protocols",
-  "upload_and_simulate": "Upload and Simulate Protocol",
+  "upload_and_simulate": "Open a protocol to run on {{robot_name}}",
   "exit_modal_heading": "Confirm Close Protocol",
   "exit_modal_go_back": "No, go back",
   "exit_modal_exit": "Yes, close now",
-  "exit_modal_body": "Are you sure you want to close this protocol?"
+  "exit_modal_body": "Are you sure you want to close this protocol?",
+  "robotName_last_run": "{{robot_name}}'s last run",
+  "rerunning_protocol_modal_title": "See How Rerunning a protocol works",
+  "protocol_name_title": "Protocol name",
+  "run_timestamp_title": "Run timestamp",
+  "labware_offset_data_title": "Labware Offset data",
+  "timestamp": "+{{index}}",
+  "run_again_btn": "Run again"
 }

--- a/app/src/assets/localization/en/protocol_info.json
+++ b/app/src/assets/localization/en/protocol_info.json
@@ -1,5 +1,5 @@
 {
-  "browse_protocol_library": "Launch Opentrons Protocol library",
+  "browse_protocol_library": "Launch Opentrons Protocol Library",
   "choose_file": "Choose File...",
   "continue_proceed_to_calibrate": "Proceed to Calibrate",
   "continue_verify_calibrations": "Verify pipette and labware calibrations",
@@ -36,7 +36,7 @@
   "exit_modal_exit": "Yes, close now",
   "exit_modal_body": "Are you sure you want to close this protocol?",
   "robotName_last_run": "{{robot_name}}’s last run",
-  "rerunning_protocol_modal_title": "See How Rerunning a protocol works",
+  "rerunning_protocol_modal_title": "See How Rerunning a Protocol Works",
   "protocol_name_title": "Protocol name",
   "run_timestamp_title": "Run timestamp",
   "labware_offset_data_title": "Labware Offset data",
@@ -44,7 +44,7 @@
   "run_again_btn": "Run again",
   "labware_offsets_info": "{{number}} Labware Offsets",
   "rerunning_protocol_modal_header": "How Rerunning A Protocol Works",
-  "rerunning_protocol_modal_body": "<block>Opentrons displays the connected robot’s last protocol run on on the Protocol Upload page. If you run again, Opentrons loads this protocol and applies Labware Offset data if any exists.</block><block>Clicking “Run Again” will take you directly to the Run tab. If you’d like to review the deck setup or run Labware Position Check before running the protocol, navigate to the Protocol tab.</block>",
+  "rerunning_protocol_modal_body": "<block>Opentrons displays the connected robot’s last protocol run on on the Protocol Upload page. If you run again, Opentrons loads this protocol and applies Labware Offset data if any exists.</block><block>Clicking “Run Again” will take you directly to the Run tab. If you’d like to review the deck setup or run Labware Position Check before running the protocol, navigate to the Protocol tab.</block><block>If you recalibrate your robot, it will clear the last run from the upload page.</block>",
   "rerunning_protocol_modal_link": "Learn more about Labware Offset Data",
   "no_labware_offset_Data": "No Labware Offset data"
 }

--- a/app/src/assets/localization/en/protocol_info.json
+++ b/app/src/assets/localization/en/protocol_info.json
@@ -41,5 +41,10 @@
   "run_timestamp_title": "Run timestamp",
   "labware_offset_data_title": "Labware Offset data",
   "timestamp": "+{{index}}",
-  "run_again_btn": "Run again"
+  "run_again_btn": "Run again",
+  "labware_offsets_info": "{{number}} Labware Offsets",
+  "rerunning_protocol_modal_header": "How Rerunning A Protocol Works",
+  "rerunning_protocol_modal_body": "<block>Opentrons displays the connected robot’s last protocol run on on the Protocol Upload page. If you run again, Opentrons loads this protocol and applies Labware Offset data if any exists.</block><block>Clicking “Run Again” will take you directly to the Run tab. If you’d like to review the deck setup or run Labware Position Check before running the protocol, navigate to the Protocol tab.</block>",
+  "rerunning_protocol_modal_link": "Learn more about Labware Offset Data",
+  "no_labware_offset_Data": "No Labware Offset data"
 }

--- a/app/src/organisms/ProtocolUpload/RerunningProtocolModal.tsx
+++ b/app/src/organisms/ProtocolUpload/RerunningProtocolModal.tsx
@@ -1,0 +1,94 @@
+import * as React from 'react'
+import { useTranslation, Trans } from 'react-i18next'
+import {
+  Text,
+  Flex,
+  Link,
+  Box,
+  Icon,
+  BaseModal,
+  PrimaryBtn,
+  SPACING_3,
+  SPACING_4,
+  SIZE_1,
+  SIZE_2,
+  SIZE_4,
+  C_BLUE,
+  FONT_HEADER_DARK,
+  FONT_BODY_1_DARK,
+  DIRECTION_ROW,
+  FONT_WEIGHT_SEMIBOLD,
+  FONT_SIZE_BODY_1,
+  ALIGN_CENTER,
+  JUSTIFY_SPACE_BETWEEN,
+  SPACING_1,
+  DIRECTION_COLUMN,
+  SPACING_2,
+} from '@opentrons/components'
+import { Portal } from '../../App/portal'
+
+interface RerunningProtocolModalProps {
+  onCloseClick: () => unknown
+}
+
+const UPLOAD_PROTOCOL_URL = '' //   TODO IMMEDIATELY GET ACTUAL LINK
+
+export const RerunningProtocolModal = (
+  props: RerunningProtocolModalProps
+): JSX.Element => {
+  const { t } = useTranslation(['protocol_info', 'shared'])
+
+  return (
+    <Portal level={'top'}>
+      <BaseModal borderRadius={SIZE_1}>
+        <Flex flexDirection={DIRECTION_COLUMN}>
+          <Flex
+            flexDirection={DIRECTION_ROW}
+            alignItems={ALIGN_CENTER}
+            justifyContent={JUSTIFY_SPACE_BETWEEN}
+            marginBottom={SPACING_3}
+          >
+            <Text css={FONT_HEADER_DARK}>
+              {t('rerunning_protocol_modal_header')}
+            </Text>
+            <Box
+              onClick={props.onCloseClick}
+              id={'RerunningProtocolModal_xButton'}
+            >
+              <Icon name={'close'} size={SIZE_2} />
+            </Box>
+          </Flex>
+          <Trans
+            t={t}
+            i18nKey={`rerunning_protocol_modal_body`}
+            components={{
+              block: <Text css={FONT_BODY_1_DARK} marginTop={SPACING_1} />,
+            }}
+          />
+          <Link
+            fontSize={FONT_SIZE_BODY_1}
+            color={C_BLUE}
+            href={UPLOAD_PROTOCOL_URL}
+            marginTop={SPACING_2}
+            id={'RerunningProtocol_ModalLink'}
+            rel="noopener noreferrer"
+          >
+            {t('rerunning_protocol_modal_link')}
+            <Icon name={'open-in-new'} marginLeft={SPACING_1} size="10px" />
+          </Link>
+          <Box textAlign={ALIGN_CENTER} marginTop={SPACING_4}>
+            <PrimaryBtn
+              onClick={props.onCloseClick}
+              width={SIZE_4}
+              backgroundColor={C_BLUE}
+              name="close"
+              id={'RobotCalModal_closeButton'}
+            >
+              {t('shared:close')}
+            </PrimaryBtn>
+          </Box>
+        </Flex>
+      </BaseModal>
+    </Portal>
+  )
+}

--- a/app/src/organisms/ProtocolUpload/RerunningProtocolModal.tsx
+++ b/app/src/organisms/ProtocolUpload/RerunningProtocolModal.tsx
@@ -69,7 +69,7 @@ export const RerunningProtocolModal = (
             color={C_BLUE}
             href={UPLOAD_PROTOCOL_URL}
             marginTop={SPACING_2}
-            id={'RerunningProtocol_ModalLink'}
+            id={'RerunningProtocolModal_Link'}
             rel="noopener noreferrer"
           >
             {t('rerunning_protocol_modal_link')}
@@ -81,7 +81,7 @@ export const RerunningProtocolModal = (
               width={SIZE_4}
               backgroundColor={C_BLUE}
               name="close"
-              id={'RobotCalModal_closeButton'}
+              id={'RerunningProtocolModal_closeButton'}
             >
               {t('shared:close')}
             </PrimaryBtn>

--- a/app/src/organisms/ProtocolUpload/RerunningProtocolModal.tsx
+++ b/app/src/organisms/ProtocolUpload/RerunningProtocolModal.tsx
@@ -30,7 +30,7 @@ interface RerunningProtocolModalProps {
   onCloseClick: () => unknown
 }
 
-const UPLOAD_PROTOCOL_URL = '' //   TODO IMMEDIATELY get actual link - Emily said this url isn't created it
+const UPLOAD_PROTOCOL_URL = '#' //   TODO IMMEDIATELY get actual link - Emily said this url isn't created it
 
 export const RerunningProtocolModal = (
   props: RerunningProtocolModalProps

--- a/app/src/organisms/ProtocolUpload/RerunningProtocolModal.tsx
+++ b/app/src/organisms/ProtocolUpload/RerunningProtocolModal.tsx
@@ -17,7 +17,6 @@ import {
   FONT_HEADER_DARK,
   FONT_BODY_1_DARK,
   DIRECTION_ROW,
-  FONT_WEIGHT_SEMIBOLD,
   FONT_SIZE_BODY_1,
   ALIGN_CENTER,
   JUSTIFY_SPACE_BETWEEN,
@@ -31,7 +30,7 @@ interface RerunningProtocolModalProps {
   onCloseClick: () => unknown
 }
 
-const UPLOAD_PROTOCOL_URL = '' //   TODO IMMEDIATELY GET ACTUAL LINK
+const UPLOAD_PROTOCOL_URL = '' //   TODO IMMEDIATELY get actual link - Emily said this url isn't created it
 
 export const RerunningProtocolModal = (
   props: RerunningProtocolModalProps

--- a/app/src/organisms/ProtocolUpload/UploadInput.tsx
+++ b/app/src/organisms/ProtocolUpload/UploadInput.tsx
@@ -87,7 +87,7 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
   const cloneMostRecentRun = useCloneRun(
     mostRecentRunId != null ? mostRecentRunId : ''
   )
-  //If mostRecentRun is null, the CTA that uses cloneRun won't appear so this will never be reached
+  //  If mostRecentRun is null, the CTA that uses cloneRun won't appear so this will never be reached
   const robotName = useSelector((state: State) => getConnectedRobotName(state))
   const fileInput = React.useRef<HTMLInputElement>(null)
   const [isFileOverDropZone, setIsFileOverDropZone] = React.useState<boolean>(

--- a/app/src/organisms/ProtocolUpload/UploadInput.tsx
+++ b/app/src/organisms/ProtocolUpload/UploadInput.tsx
@@ -84,16 +84,16 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
   )
   const mostRecentProtocol = mostRecentProtocolInfo?.data?.data
   const protocolData = useProtocolDetails()
+  //  If mostRecentRun is null, the CTA that uses cloneRun won't appear so this will never be reached
   const cloneMostRecentRun = useCloneRun(
     mostRecentRunId != null ? mostRecentRunId : ''
   )
-  //  If mostRecentRun is null, the CTA that uses cloneRun won't appear so this will never be reached
   const robotName = useSelector((state: State) => getConnectedRobotName(state))
   const fileInput = React.useRef<HTMLInputElement>(null)
   const [isFileOverDropZone, setIsFileOverDropZone] = React.useState<boolean>(
     false
   )
-  const [rerunningProtocolModal, setRerunningProtocolModal] = React.useState(
+  const [rerunningProtocolModal, showRerunningProtocolModal] = React.useState(
     false
   )
   const labwareOffsets = mostRecentRun?.labwareOffsets
@@ -153,7 +153,7 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
     >
       {rerunningProtocolModal && (
         <RerunningProtocolModal
-          onCloseClick={() => setRerunningProtocolModal(false)}
+          onCloseClick={() => showRerunningProtocolModal(false)}
         />
       )}
       <PrimaryBtn
@@ -202,14 +202,14 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
           >
             <Trans
               t={t}
-              i18nKey="robotName_last_run"
+              i18nKey="robot_name_last_run"
               values={{ robot_name: robotName }}
             />
             <Link
               role={'link'}
               fontSize={FONT_SIZE_BODY_1}
               color={C_BLUE}
-              onClick={() => setRerunningProtocolModal(true)}
+              onClick={() => showRerunningProtocolModal(true)}
               id={'RerunningProtocol_Modal'}
               data-testid={'RerunningProtocol_ModalLink'}
             >
@@ -267,7 +267,7 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
               </Text>
               <Flex css={FONT_BODY_1_DARK}>
                 {labwareOffsets != null && labwareOffsets.length === 0 ? (
-                  <Text>{t('no_labware_offset_Data')}</Text>
+                  <Text>{t('no_labware_offset_data')}</Text>
                 ) : (
                   labwareOffsets != null && (
                     <Trans

--- a/app/src/organisms/ProtocolUpload/UploadInput.tsx
+++ b/app/src/organisms/ProtocolUpload/UploadInput.tsx
@@ -192,7 +192,7 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
           onChange={onChange}
         />
       </label>
-      {/* {mostRecentRun === null ? null : ( */}
+      {mostRecentRun === null ? null : (
       <Flex flexDirection={DIRECTION_COLUMN} width={'80%'}>
         <Divider marginY={SPACING_3} />
         <Flex
@@ -292,7 +292,7 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
           </Flex>
         </Flex>
       </Flex>
-      {/* )} */}
+      )}
       <hr style={{ borderTop: `1px solid ${C_LIGHT_GRAY}`, width: '80%' }} />
       <Text
         role="complementary"

--- a/app/src/organisms/ProtocolUpload/UploadInput.tsx
+++ b/app/src/organisms/ProtocolUpload/UploadInput.tsx
@@ -30,7 +30,6 @@ import {
   FONT_SIZE_BODY_1,
   SPACING_2,
   JUSTIFY_START,
-  Btn,
 } from '@opentrons/components'
 import { css } from 'styled-components'
 import { Trans, useTranslation } from 'react-i18next'
@@ -83,8 +82,8 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
   const mostRecentRun = useMostRecentRunId()
   const runQuery = useRunQuery(mostRecentRun)
   const protocolData = useProtocolDetails()
-  const robotName = useSelector((state: State) => getConnectedRobotName(state))
   const cloneRun = useCloneRun(mostRecentRun != null ? mostRecentRun : '')
+  const robotName = useSelector((state: State) => getConnectedRobotName(state))
   const fileInput = React.useRef<HTMLInputElement>(null)
   const [isFileOverDropZone, setIsFileOverDropZone] = React.useState<boolean>(
     false
@@ -136,7 +135,7 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
 
   const fullRunTimestamp = runQuery.data?.data.createdAt
   const indexToSplit = fullRunTimestamp?.indexOf('T')
-  if (fullRunTimestamp == null) return null
+  if (fullRunTimestamp == null) return null //  This state should never be reached since if null, protocol empty state won't show latest protocol run data
   const date = fullRunTimestamp?.slice(0, indexToSplit)
   const timeAndUTC =
     indexToSplit != null ? fullRunTimestamp?.slice(indexToSplit + 1) : ''
@@ -193,106 +192,107 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
           onChange={onChange}
         />
       </label>
-      {mostRecentRun === null ? null : (
-        <Flex flexDirection={DIRECTION_COLUMN} width={'80%'}>
-          <Divider marginY={SPACING_3} />
-          <Flex
-            justifyContent={JUSTIFY_SPACE_BETWEEN}
-            flex={'auto'}
-            marginBottom={SPACING_2}
+      {/* {mostRecentRun === null ? null : ( */}
+      <Flex flexDirection={DIRECTION_COLUMN} width={'80%'}>
+        <Divider marginY={SPACING_3} />
+        <Flex
+          justifyContent={JUSTIFY_SPACE_BETWEEN}
+          flex={'auto'}
+          marginBottom={SPACING_2}
+        >
+          <Trans
+            t={t}
+            i18nKey="robotName_last_run"
+            values={{ robot_name: robotName }}
+          />
+          <Link
+            role={'link'}
+            fontSize={FONT_SIZE_BODY_1}
+            color={C_BLUE}
+            onClick={() => setRerunningProtocolModal(true)}
+            id={'RerunningProtocol_Modal'}
+            data-testid={'RerunningProtocol_ModalLink'}
           >
-            <Trans
-              t={t}
-              i18nKey="robotName_last_run"
-              values={{ robot_name: robotName }}
-            />
-            <Btn
-              as={Link}
-              fontSize={FONT_SIZE_BODY_1}
-              color={C_BLUE}
-              onClick={() => setRerunningProtocolModal(true)}
-              id={'RerunningProtocol_Modal'}
+            {t('rerunning_protocol_modal_title')}
+          </Link>
+        </Flex>
+        <Flex
+          flexDirection={DIRECTION_ROW}
+          alignItems={ALIGN_CENTER}
+          marginBottom={SPACING_4}
+        >
+          <Flex
+            flex={'auto'}
+            flexDirection={DIRECTION_COLUMN}
+            justifyContent={JUSTIFY_CENTER}
+          >
+            <Text
+              marginBottom={SPACING_1}
+              color={C_MED_GRAY}
+              fontSize={FONT_SIZE_CAPTION}
             >
-              {t('rerunning_protocol_modal_title')}
-            </Btn>
+              {t('protocol_name_title')}
+            </Text>
+            <Flex css={FONT_BODY_1_DARK}>
+              {protocolName != null ? protocolName : <Text>{FILE_NAME}</Text>}
+            </Flex>
           </Flex>
           <Flex
-            flexDirection={DIRECTION_ROW}
-            alignItems={ALIGN_CENTER}
-            marginBottom={SPACING_4}
+            flex={'auto'}
+            flexDirection={DIRECTION_COLUMN}
+            justifyContent={JUSTIFY_CENTER}
           >
-            <Flex
-              flex={'auto'}
-              flexDirection={DIRECTION_COLUMN}
-              justifyContent={JUSTIFY_CENTER}
+            <Text
+              marginBottom={SPACING_1}
+              color={C_MED_GRAY}
+              fontSize={FONT_SIZE_CAPTION}
             >
-              <Text
-                marginBottom={SPACING_1}
-                color={C_MED_GRAY}
-                fontSize={FONT_SIZE_CAPTION}
-              >
-                {t('protocol_name_title')}
-              </Text>
-              <Flex css={FONT_BODY_1_DARK}>
-                {protocolName != null ? protocolName : <Text>{FILE_NAME}</Text>}
-              </Flex>
+              {t('run_timestamp_title')}
+            </Text>
+            <Flex css={FONT_BODY_1_DARK} flexDirection={DIRECTION_ROW}>
+              <Flex marginRight={SPACING_1}>{date}</Flex>
+              <Flex marginRight={SPACING_1}>{time}</Flex>
+              <Flex>{UTC}</Flex>
             </Flex>
-            <Flex
-              flex={'auto'}
-              flexDirection={DIRECTION_COLUMN}
-              justifyContent={JUSTIFY_CENTER}
+          </Flex>
+          <Flex
+            flex={'auto'}
+            flexDirection={DIRECTION_COLUMN}
+            justifyContent={JUSTIFY_CENTER}
+          >
+            <Text
+              marginBottom={SPACING_1}
+              color={C_MED_GRAY}
+              fontSize={FONT_SIZE_CAPTION}
             >
-              <Text
-                marginBottom={SPACING_1}
-                color={C_MED_GRAY}
-                fontSize={FONT_SIZE_CAPTION}
-              >
-                {t('run_timestamp_title')}
-              </Text>
-              <Flex css={FONT_BODY_1_DARK} flexDirection={DIRECTION_ROW}>
-                <Flex marginRight={SPACING_1}>{date}</Flex>
-                <Flex marginRight={SPACING_1}>{time}</Flex>
-                <Flex>{UTC}</Flex>
-              </Flex>
+              {t('labware_offset_data_title')}
+            </Text>
+            <Flex css={FONT_BODY_1_DARK}>
+              {labwareOffsets != null && labwareOffsets.length === 0 ? (
+                <Text>{t('no_labware_offset_Data')}</Text>
+              ) : (
+                labwareOffsets != null && (
+                  <Trans
+                    t={t}
+                    i18nKey="labware_offsets_info"
+                    values={{ number: labwareOffsets.length }}
+                  />
+                )
+              )}
             </Flex>
-            <Flex
-              flex={'auto'}
-              flexDirection={DIRECTION_COLUMN}
-              justifyContent={JUSTIFY_CENTER}
+          </Flex>
+          <Flex>
+            <SecondaryBtn
+              onClick={() => cloneRun}
+              color={C_BLUE}
+              id={'UploadInput_runAgainButton'}
             >
-              <Text
-                marginBottom={SPACING_1}
-                color={C_MED_GRAY}
-                fontSize={FONT_SIZE_CAPTION}
-              >
-                {t('labware_offset_data_title')}
-              </Text>
-              <Flex css={FONT_BODY_1_DARK}>
-                {labwareOffsets != null && labwareOffsets.length === 0 ? (
-                  <Text>{t('no_labware_offset_Data')}</Text>
-                ) : (
-                  labwareOffsets != null && (
-                    <Trans
-                      t={t}
-                      i18nKey="labware_offsets_info"
-                      values={{ number: labwareOffsets.length }}
-                    />
-                  )
-                )}
-              </Flex>
-            </Flex>
-            <Flex>
-              <SecondaryBtn
-                onClick={cloneRun}
-                color={C_BLUE}
-                id={'UploadInput_runAgainButton'}
-              >
-                {t('run_again_btn')}
-              </SecondaryBtn>
-            </Flex>
+              {t('run_again_btn')}
+            </SecondaryBtn>
           </Flex>
         </Flex>
-      )}
+      </Flex>
+      {/* )} */}
       <hr style={{ borderTop: `1px solid ${C_LIGHT_GRAY}`, width: '80%' }} />
       <Text
         role="complementary"

--- a/app/src/organisms/ProtocolUpload/UploadInput.tsx
+++ b/app/src/organisms/ProtocolUpload/UploadInput.tsx
@@ -105,7 +105,6 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
   const fullRunTimestamp = mostRecentRun?.createdAt
   if (fullRunTimestamp == null) return null //  This state should never be reached since if null, protocol empty state won't show latest protocol run data
   const runTimestamp = format(parseISO(fullRunTimestamp), 'yyyy-MM-dd pp xxxxx')
-  console.log(runTimestamp)
 
   const handleDrop: React.DragEventHandler<HTMLLabelElement> = e => {
     e.preventDefault()

--- a/app/src/organisms/ProtocolUpload/UploadInput.tsx
+++ b/app/src/organisms/ProtocolUpload/UploadInput.tsx
@@ -21,7 +21,6 @@ import {
   JUSTIFY_CENTER,
   C_BLUE,
   SPACING_1,
-  C_LIGHT_GRAY,
   DIRECTION_ROW,
   JUSTIFY_SPACE_BETWEEN,
   FONT_SIZE_CAPTION,
@@ -87,7 +86,8 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
   const protocolData = useProtocolDetails()
   const cloneMostRecentRun = useCloneRun(
     mostRecentRunId != null ? mostRecentRunId : ''
-  ) // If mostRecentRun is null, the CTA that uses cloneRun won't appear so this will never be reached
+  )
+  //If mostRecentRun is null, the CTA that uses cloneRun won't appear so this will never be reached
   const robotName = useSelector((state: State) => getConnectedRobotName(state))
   const fileInput = React.useRef<HTMLInputElement>(null)
   const [isFileOverDropZone, setIsFileOverDropZone] = React.useState<boolean>(
@@ -105,6 +105,7 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
   const fullRunTimestamp = mostRecentRun?.createdAt
   if (fullRunTimestamp == null) return null //  This state should never be reached since if null, protocol empty state won't show latest protocol run data
   const runTimestamp = format(parseISO(fullRunTimestamp), 'yyyy-MM-dd pp xxxxx')
+  console.log(runTimestamp)
 
   const handleDrop: React.DragEventHandler<HTMLLabelElement> = e => {
     e.preventDefault()
@@ -289,9 +290,9 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
               </SecondaryBtn>
             </Flex>
           </Flex>
+          <Divider />
         </Flex>
       )}
-      <hr style={{ borderTop: `1px solid ${C_LIGHT_GRAY}`, width: '80%' }} />
       <Text
         role="complementary"
         as="h4"

--- a/app/src/organisms/ProtocolUpload/UploadInput.tsx
+++ b/app/src/organisms/ProtocolUpload/UploadInput.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-
+import { format, parseISO } from 'date-fns'
 import {
   Icon,
   Text,
@@ -134,15 +134,8 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
     : DROP_ZONE_STYLES
 
   const fullRunTimestamp = runQuery.data?.data.createdAt
-  const indexToSplit = fullRunTimestamp?.indexOf('T')
   if (fullRunTimestamp == null) return null //  This state should never be reached since if null, protocol empty state won't show latest protocol run data
-  const date = fullRunTimestamp?.slice(0, indexToSplit)
-  const timeAndUTC =
-    indexToSplit != null ? fullRunTimestamp?.slice(indexToSplit + 1) : ''
-  const timeToSplit = timeAndUTC.indexOf('.')
-  const time = timeAndUTC.slice(0, timeToSplit)
-
-  const UTC = timeAndUTC?.slice(timeToSplit + 7)
+  const runTimestamp = format(parseISO(fullRunTimestamp), 'yyyy-MM-dd pp xxxxx')
 
   return (
     <Flex
@@ -193,105 +186,103 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
         />
       </label>
       {mostRecentRun === null ? null : (
-      <Flex flexDirection={DIRECTION_COLUMN} width={'80%'}>
-        <Divider marginY={SPACING_3} />
-        <Flex
-          justifyContent={JUSTIFY_SPACE_BETWEEN}
-          flex={'auto'}
-          marginBottom={SPACING_2}
-        >
-          <Trans
-            t={t}
-            i18nKey="robotName_last_run"
-            values={{ robot_name: robotName }}
-          />
-          <Link
-            role={'link'}
-            fontSize={FONT_SIZE_BODY_1}
-            color={C_BLUE}
-            onClick={() => setRerunningProtocolModal(true)}
-            id={'RerunningProtocol_Modal'}
-            data-testid={'RerunningProtocol_ModalLink'}
-          >
-            {t('rerunning_protocol_modal_title')}
-          </Link>
-        </Flex>
-        <Flex
-          flexDirection={DIRECTION_ROW}
-          alignItems={ALIGN_CENTER}
-          marginBottom={SPACING_4}
-        >
+        <Flex flexDirection={DIRECTION_COLUMN} width={'80%'}>
+          <Divider marginY={SPACING_3} />
           <Flex
+            justifyContent={JUSTIFY_SPACE_BETWEEN}
             flex={'auto'}
-            flexDirection={DIRECTION_COLUMN}
-            justifyContent={JUSTIFY_CENTER}
+            marginBottom={SPACING_2}
           >
-            <Text
-              marginBottom={SPACING_1}
-              color={C_MED_GRAY}
-              fontSize={FONT_SIZE_CAPTION}
-            >
-              {t('protocol_name_title')}
-            </Text>
-            <Flex css={FONT_BODY_1_DARK}>
-              {protocolName != null ? protocolName : <Text>{FILE_NAME}</Text>}
-            </Flex>
-          </Flex>
-          <Flex
-            flex={'auto'}
-            flexDirection={DIRECTION_COLUMN}
-            justifyContent={JUSTIFY_CENTER}
-          >
-            <Text
-              marginBottom={SPACING_1}
-              color={C_MED_GRAY}
-              fontSize={FONT_SIZE_CAPTION}
-            >
-              {t('run_timestamp_title')}
-            </Text>
-            <Flex css={FONT_BODY_1_DARK} flexDirection={DIRECTION_ROW}>
-              <Flex marginRight={SPACING_1}>{date}</Flex>
-              <Flex marginRight={SPACING_1}>{time}</Flex>
-              <Flex>{UTC}</Flex>
-            </Flex>
-          </Flex>
-          <Flex
-            flex={'auto'}
-            flexDirection={DIRECTION_COLUMN}
-            justifyContent={JUSTIFY_CENTER}
-          >
-            <Text
-              marginBottom={SPACING_1}
-              color={C_MED_GRAY}
-              fontSize={FONT_SIZE_CAPTION}
-            >
-              {t('labware_offset_data_title')}
-            </Text>
-            <Flex css={FONT_BODY_1_DARK}>
-              {labwareOffsets != null && labwareOffsets.length === 0 ? (
-                <Text>{t('no_labware_offset_Data')}</Text>
-              ) : (
-                labwareOffsets != null && (
-                  <Trans
-                    t={t}
-                    i18nKey="labware_offsets_info"
-                    values={{ number: labwareOffsets.length }}
-                  />
-                )
-              )}
-            </Flex>
-          </Flex>
-          <Flex>
-            <SecondaryBtn
-              onClick={() => cloneRun}
+            <Trans
+              t={t}
+              i18nKey="robotName_last_run"
+              values={{ robot_name: robotName }}
+            />
+            <Link
+              role={'link'}
+              fontSize={FONT_SIZE_BODY_1}
               color={C_BLUE}
-              id={'UploadInput_runAgainButton'}
+              onClick={() => setRerunningProtocolModal(true)}
+              id={'RerunningProtocol_Modal'}
+              data-testid={'RerunningProtocol_ModalLink'}
             >
-              {t('run_again_btn')}
-            </SecondaryBtn>
+              {t('rerunning_protocol_modal_title')}
+            </Link>
+          </Flex>
+          <Flex
+            flexDirection={DIRECTION_ROW}
+            alignItems={ALIGN_CENTER}
+            marginBottom={SPACING_4}
+          >
+            <Flex
+              flex={'auto'}
+              flexDirection={DIRECTION_COLUMN}
+              justifyContent={JUSTIFY_CENTER}
+            >
+              <Text
+                marginBottom={SPACING_1}
+                color={C_MED_GRAY}
+                fontSize={FONT_SIZE_CAPTION}
+              >
+                {t('protocol_name_title')}
+              </Text>
+              <Flex css={FONT_BODY_1_DARK}>
+                {protocolName != null ? protocolName : <Text>{FILE_NAME}</Text>}
+              </Flex>
+            </Flex>
+            <Flex
+              flex={'auto'}
+              flexDirection={DIRECTION_COLUMN}
+              justifyContent={JUSTIFY_CENTER}
+            >
+              <Text
+                marginBottom={SPACING_1}
+                color={C_MED_GRAY}
+                fontSize={FONT_SIZE_CAPTION}
+              >
+                {t('run_timestamp_title')}
+              </Text>
+              <Flex css={FONT_BODY_1_DARK} flexDirection={DIRECTION_ROW}>
+                {runTimestamp}
+              </Flex>
+            </Flex>
+            <Flex
+              flex={'auto'}
+              flexDirection={DIRECTION_COLUMN}
+              justifyContent={JUSTIFY_CENTER}
+            >
+              <Text
+                marginBottom={SPACING_1}
+                color={C_MED_GRAY}
+                fontSize={FONT_SIZE_CAPTION}
+              >
+                {t('labware_offset_data_title')}
+              </Text>
+              <Flex css={FONT_BODY_1_DARK}>
+                {labwareOffsets != null && labwareOffsets.length === 0 ? (
+                  <Text>{t('no_labware_offset_Data')}</Text>
+                ) : (
+                  labwareOffsets != null && (
+                    <Trans
+                      t={t}
+                      i18nKey="labware_offsets_info"
+                      values={{ number: labwareOffsets.length }}
+                    />
+                  )
+                )}
+              </Flex>
+            </Flex>
+            <Flex>
+              <SecondaryBtn
+                onClick={() => cloneRun}
+                color={C_BLUE}
+                id={'UploadInput_runAgainButton'}
+              >
+                {t('run_again_btn')}
+              </SecondaryBtn>
+            </Flex>
           </Flex>
         </Flex>
-      </Flex>
       )}
       <hr style={{ borderTop: `1px solid ${C_LIGHT_GRAY}`, width: '80%' }} />
       <Text

--- a/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
+++ b/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
@@ -10,6 +10,7 @@ import withModulesProtocol from '@opentrons/shared-data/protocol/fixtures/4/test
 
 import { i18n } from '../../../i18n'
 import { mockConnectedRobot } from '../../../redux/discovery/__fixtures__'
+import * as RobotSelectors from '../../../redux/robot/selectors'
 import * as calibrationSelectors from '../../../redux/calibration/selectors'
 import * as discoverySelectors from '../../../redux/discovery/selectors'
 import * as protocolSelectors from '../../../redux/protocol/selectors'
@@ -30,6 +31,7 @@ jest.mock('../../RunDetails/hooks')
 jest.mock('../hooks/useCurrentProtocolRun')
 jest.mock('../hooks/useCloseCurrentRun')
 jest.mock('../ConfirmExitProtocolUploadModal')
+jest.mock('../../../redux/robot/selectors')
 
 const getProtocolFile = protocolSelectors.getProtocolFile as jest.MockedFunction<
   typeof protocolSelectors.getProtocolFile
@@ -55,6 +57,9 @@ const mockUseCloseProtocolRun = useCloseCurrentRun as jest.MockedFunction<
 const mockUseProtocolDetails = useProtocolDetails as jest.MockedFunction<
   typeof useProtocolDetails
 >
+const mockGetConnectedRobotName = RobotSelectors.getConnectedRobotName as jest.MockedFunction<
+  typeof RobotSelectors.getConnectedRobotName
+>
 
 const queryClient = new QueryClient()
 
@@ -73,6 +78,7 @@ describe('ProtocolUpload', () => {
     getConnectedRobot.mockReturnValue(mockConnectedRobot)
     getCalibrationStatus.mockReturnValue(mockCalibrationStatus)
     ingestProtocolFile.mockImplementation((_f, _s, _e) => {})
+    mockGetConnectedRobotName.mockReturnValue('robotName')
     when(mockConfirmExitProtocolUploadModal)
       .calledWith(
         componentPropsMatcher({
@@ -101,9 +107,8 @@ describe('ProtocolUpload', () => {
         runRecord: null,
         createProtocolRun: jest.fn(),
       } as any)
-    const { getByRole, queryByText } = render()[0]
-
-    expect(getByRole('button', { name: 'Choose File...' })).toBeTruthy()
+    mockGetConnectedRobotName.mockReturnValue(null)
+    const { queryByText } = render()[0]
     expect(queryByText('Organization/Author')).toBeNull()
   })
   it('renders Protocol Setup if file loaded', () => {
@@ -116,7 +121,6 @@ describe('ProtocolUpload', () => {
         createProtocolRun: jest.fn(),
       } as any)
     const { queryByRole, getByText } = render()[0]
-
     expect(queryByRole('button', { name: 'Choose File...' })).toBeNull()
     expect(getByText('Organization/Author')).toBeTruthy()
   })
@@ -167,18 +171,7 @@ describe('ProtocolUpload', () => {
         runRecord: null,
         createProtocolRun: jest.fn(),
       } as any)
-    const { getByTestId } = render()[0]
-
-    const protocolFile = new File(
-      [JSON.stringify(withModulesProtocol)],
-      'fixture_protocol.json'
-    )
-    const input = getByTestId('file_input')
-    fireEvent.change(input, { target: { files: [protocolFile] } })
-    expect(ingestProtocolFile).toHaveBeenCalledWith(
-      protocolFile,
-      expect.any(Function),
-      expect.any(Function)
-    )
+    const { getByText } = render()[0]
+    getByText('Open a protocol to run on robotName')
   })
 })

--- a/app/src/organisms/ProtocolUpload/__tests__/UploadInput.test.tsx
+++ b/app/src/organisms/ProtocolUpload/__tests__/UploadInput.test.tsx
@@ -4,6 +4,7 @@ import '@testing-library/jest-dom'
 import { fireEvent, screen } from '@testing-library/react'
 import {
   componentPropsMatcher,
+  nestedTextMatcher,
   renderWithProviders,
 } from '@opentrons/components'
 import { i18n } from '../../../i18n'
@@ -154,7 +155,9 @@ describe('UploadInput', () => {
     getByText('mock display name')
     getByText('Protocol name')
     getByText('Run timestamp')
-    getByText('2021-11-12 7:39:19 PM +00:00')
+    //  Had to use nestedTextMatcher to avoid testing for the changing timezones
+    getByText(nestedTextMatcher('2021-11-12'))
+    getByText(nestedTextMatcher(':39:19'))
     getByText('Labware Offset data')
     getByText('1 Labware Offsets')
     getByText('See How Rerunning a Protocol Works')

--- a/app/src/organisms/ProtocolUpload/__tests__/UploadInput.test.tsx
+++ b/app/src/organisms/ProtocolUpload/__tests__/UploadInput.test.tsx
@@ -134,9 +134,7 @@ describe('UploadInput', () => {
     getByText('mock display name')
     getByText('Protocol name')
     getByText('Run timestamp')
-    getByText('2021-11-12')
-    getByText('19:39:19')
-    getByText('+00:00')
+    getByText('2021-11-12 2:39:19 PM -05:00')
     getByText('Labware Offset data')
     getByText('1 Labware Offsets')
     getByText('See How Rerunning a Protocol Works')
@@ -148,7 +146,7 @@ describe('UploadInput', () => {
       .mockReturnValue({
         data: {
           data: {
-            createdAt: 'createdAt this time',
+            createdAt: '2021-11-12T19:39:19.668514+00:00',
             labwareOffsets: [],
           },
         },

--- a/app/src/organisms/ProtocolUpload/__tests__/UploadInput.test.tsx
+++ b/app/src/organisms/ProtocolUpload/__tests__/UploadInput.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { when } from 'jest-when'
 import '@testing-library/jest-dom'
-import { fireEvent } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import {
   componentPropsMatcher,
   renderWithProviders,
@@ -36,7 +36,7 @@ const mockGetConnectedRobotName = RobotSelectors.getConnectedRobotName as jest.M
 >
 const mockUseCloneRun = useCloneRun as jest.MockedFunction<typeof useCloneRun>
 
-const mockRerunningProtoolModal = RerunningProtocolModal as jest.MockedFunction<
+const mockRerunningProtocolModal = RerunningProtocolModal as jest.MockedFunction<
   typeof RerunningProtocolModal
 >
 
@@ -73,7 +73,7 @@ describe('UploadInput', () => {
       } as any)
     mockUseCloneRun.mockReturnValue(jest.fn())
   })
-  when(mockRerunningProtoolModal)
+  when(mockRerunningProtocolModal)
     .calledWith(
       componentPropsMatcher({
         onCloseClick: expect.anything(),
@@ -97,7 +97,7 @@ describe('UploadInput', () => {
       /Don't have a protocol yet\?/i
     )
     expect(
-      getByRole('link', { name: 'Launch Opentrons Protocol library' })
+      getByRole('link', { name: 'Launch Opentrons Protocol Library' })
     ).toBeTruthy()
     expect(
       getByRole('link', { name: 'Launch Opentrons Protocol Designer' })
@@ -121,7 +121,7 @@ describe('UploadInput', () => {
   it('renders empty state when no previous protocol was uploaded', () => {
     const { getByText, getByRole } = render(props)
     mockUseMostRecentRunId.mockReturnValue(null)
-    getByText('Launch Opentrons Protocol library')
+    getByText('Launch Opentrons Protocol Library')
     getByText('Launch Opentrons Protocol Designer')
     getByText('Drag and drop protocol file here')
     expect(getByRole('complementary')).toHaveTextContent(
@@ -139,7 +139,7 @@ describe('UploadInput', () => {
     getByText('+00:00')
     getByText('Labware Offset data')
     getByText('1 Labware Offsets')
-    getByText('See How Rerunning a protocol works')
+    getByText('See How Rerunning a Protocol Works')
     getByText('Run again')
   })
   it('renders No Offset data', () => {
@@ -156,10 +156,44 @@ describe('UploadInput', () => {
     const { getByText } = render(props)
     getByText('No Labware Offset data')
   })
-  it('clicks on run again button', () => {
+  it('renders run again button', () => {
     const { getByRole } = render(props)
+    mockUseCloneRun.mockReturnValue(jest.fn())
     const button = getByRole('button', { name: 'Run again' })
+    expect(button).not.toBeDisabled()
     fireEvent.click(button)
+  })
+  it('renders correct link text', () => {
+    const { getByRole } = render(props)
+    getByRole('link', {
+      name: 'See How Rerunning a Protocol Works',
+    })
+    expect(screen.queryByText('Mock Rerunning Protocol Modal')).toBeNull()
+  })
+  it('renders modal when link is clicked', () => {
+    mockRerunningProtocolModal.mockReturnValue(
+      <div>Mock Rerunning Protocol Modal</div>
+    )
+    const { getByText, getByRole } = render(props)
+    const openModal = getByRole('link', {
+      name: 'See How Rerunning a Protocol Works',
+    })
+    fireEvent.click(openModal)
+    getByText('Mock Rerunning Protocol Modal')
+  })
+  it('renders null if run timestamp is null', () => {
+    when(mockUseRunQuery)
+      .calledWith('RunId')
+      .mockReturnValue({
+        data: {
+          data: {
+            createdAt: null,
+            labwareOffsets: [],
+          },
+        },
+      } as any)
+    const { container } = render(props)
+    expect(container.firstChild).toBeNull()
   })
   //  TODO immediately: wait for CPX to add fileName
   it.todo('renders file Name when protocol display name is null')

--- a/app/src/organisms/ProtocolUpload/__tests__/UploadInput.test.tsx
+++ b/app/src/organisms/ProtocolUpload/__tests__/UploadInput.test.tsx
@@ -154,7 +154,7 @@ describe('UploadInput', () => {
     getByText('mock display name')
     getByText('Protocol name')
     getByText('Run timestamp')
-    getByText('2021-11-12 2:39:19 PM -05:00')
+    getByText('2021-11-12 7:39:19 PM +00:00')
     getByText('Labware Offset data')
     getByText('1 Labware Offsets')
     getByText('See How Rerunning a Protocol Works')

--- a/app/src/organisms/ProtocolUpload/__tests__/UploadInput.test.tsx
+++ b/app/src/organisms/ProtocolUpload/__tests__/UploadInput.test.tsx
@@ -11,7 +11,7 @@ import * as RobotSelectors from '../../../redux/robot/selectors'
 import { useProtocolDetails } from '../../RunDetails/hooks'
 import { UploadInput } from '../UploadInput'
 import { useMostRecentRunId } from '../hooks/useMostRecentRunId'
-import { useRunQuery } from '@opentrons/react-api-client'
+import { useProtocolQuery, useRunQuery } from '@opentrons/react-api-client'
 import _uncastedSimpleV6Protocol from '@opentrons/shared-data/protocol/fixtures/6/simpleV6.json'
 import { RerunningProtocolModal } from '../RerunningProtocolModal'
 import { useCloneRun } from '../hooks'
@@ -35,6 +35,10 @@ const mockGetConnectedRobotName = RobotSelectors.getConnectedRobotName as jest.M
   typeof RobotSelectors.getConnectedRobotName
 >
 const mockUseCloneRun = useCloneRun as jest.MockedFunction<typeof useCloneRun>
+
+const mockUseProtocolQuery = useProtocolQuery as jest.MockedFunction<
+  typeof useProtocolQuery
+>
 
 const mockRerunningProtocolModal = RerunningProtocolModal as jest.MockedFunction<
   typeof RerunningProtocolModal
@@ -66,6 +70,7 @@ describe('UploadInput', () => {
       .mockReturnValue({
         data: {
           data: {
+            protocolId: 'ProtocolId',
             createdAt: '2021-11-12T19:39:19.668514+00:00',
             labwareOffsets: [{ x: 5, y: 5, z: 5 }],
           },
@@ -73,6 +78,21 @@ describe('UploadInput', () => {
       } as any)
     mockUseCloneRun.mockReturnValue(jest.fn())
   })
+  when(mockUseProtocolQuery)
+    .calledWith('ProtocolId')
+    .mockReturnValue({
+      data: {
+        data: {
+          protocolType: 'python',
+          createdAt: 'now',
+          id: 'ProtocolId',
+          metadata: {},
+          analyses: {},
+          files: [{ name: 'name', role: 'main' }],
+        },
+      },
+    } as any)
+
   when(mockRerunningProtocolModal)
     .calledWith(
       componentPropsMatcher({
@@ -193,6 +213,28 @@ describe('UploadInput', () => {
     const { container } = render(props)
     expect(container.firstChild).toBeNull()
   })
-  //  TODO immediately: wait for CPX to add fileName
-  it.todo('renders file Name when protocol display name is null')
+  it('renders file name if Protocol name is null', () => {
+    when(mockUseProtocolQuery)
+      .calledWith('ProtocolId')
+      .mockReturnValue({
+        data: {
+          data: {
+            protocolType: 'python',
+            createdAt: 'now',
+            id: 'ProtocolId',
+            metadata: {},
+            analyses: {},
+            files: [{ name: 'name', role: 'main' }],
+          },
+        },
+      } as any)
+
+    when(mockUseProtocolDetails)
+      .calledWith()
+      .mockReturnValue({
+        protocolData: { displayName: null },
+      } as any)
+    const { getByText } = render(props)
+    getByText('name')
+  })
 })

--- a/app/src/organisms/ProtocolUpload/hooks/__tests__/RerunningProtocolModal.test.tsx
+++ b/app/src/organisms/ProtocolUpload/hooks/__tests__/RerunningProtocolModal.test.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react'
+import { fireEvent } from '@testing-library/react'
+import { renderWithProviders } from '@opentrons/components'
+import { RerunningProtocolModal } from '../../RerunningProtocolModal'
+import { i18n } from '../../../../i18n'
+
+const render = (props: React.ComponentProps<typeof RerunningProtocolModal>) => {
+  return renderWithProviders(<RerunningProtocolModal {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+describe('RerunningProtocolModal', () => {
+  let props: React.ComponentProps<typeof RerunningProtocolModal>
+  beforeEach(() => {
+    props = { onCloseClick: jest.fn() }
+  })
+
+  it('should render the correct header', () => {
+    const { getByText } = render(props)
+    getByText('How Rerunning A Protocol Works')
+  })
+  it('should render the correct body', () => {
+    const { getByText } = render(props)
+
+    getByText(
+      'Opentrons displays the connected robot’s last protocol run on on the Protocol Upload page. If you run again, Opentrons loads this protocol and applies Labware Offset data if any exists.'
+    )
+    getByText(
+      'Clicking “Run Again” will take you directly to the Run tab. If you’d like to review the deck setup or run Labware Position Check before running the protocol, navigate to the Protocol tab.'
+    )
+  })
+
+  it('should render a link to robot cal', () => {
+    const { getByRole } = render(props)
+    expect(
+      getByRole('link', {
+        name: 'Learn more about Labware Offset Data',
+      }).getAttribute('href')
+    ).toBe('') //   TODO IMMEDIATELY replace with actual link
+  })
+  it('should call onCloseClick when the close button is pressed', () => {
+    const { getByRole } = render(props)
+    expect(props.onCloseClick).not.toHaveBeenCalled()
+    const closeButton = getByRole('button', { name: 'close' })
+    fireEvent.click(closeButton)
+    expect(props.onCloseClick).toHaveBeenCalled()
+  })
+})

--- a/app/src/organisms/ProtocolUpload/hooks/__tests__/RerunningProtocolModal.test.tsx
+++ b/app/src/organisms/ProtocolUpload/hooks/__tests__/RerunningProtocolModal.test.tsx
@@ -29,6 +29,9 @@ describe('RerunningProtocolModal', () => {
     getByText(
       'Clicking “Run Again” will take you directly to the Run tab. If you’d like to review the deck setup or run Labware Position Check before running the protocol, navigate to the Protocol tab.'
     )
+    getByText(
+      'If you recalibrate your robot, it will clear the last run from the upload page.'
+    )
   })
 
   it('should render a link to robot cal', () => {
@@ -37,7 +40,7 @@ describe('RerunningProtocolModal', () => {
       getByRole('link', {
         name: 'Learn more about Labware Offset Data',
       }).getAttribute('href')
-    ).toBe('') //   TODO IMMEDIATELY replace with actual link
+    ).toBe('#') //   TODO IMMEDIATELY replace with actual link
   })
   it('should call onCloseClick when the close button is pressed', () => {
     const { getByRole } = render(props)

--- a/app/src/organisms/ProtocolUpload/index.tsx
+++ b/app/src/organisms/ProtocolUpload/index.tsx
@@ -6,8 +6,8 @@ import {
   C_NEAR_WHITE,
   useConditionalConfirm,
 } from '@opentrons/components'
-import { useTranslation } from 'react-i18next'
-import { useDispatch } from 'react-redux'
+import { Trans, useTranslation } from 'react-i18next'
+import { useDispatch, useSelector } from 'react-redux'
 import { Page } from '../../atoms/Page'
 import { UploadInput } from './UploadInput'
 import { ProtocolSetup } from '../ProtocolSetup'
@@ -15,12 +15,13 @@ import { useCurrentProtocolRun } from './hooks/useCurrentProtocolRun'
 import { useCloseCurrentRun } from './hooks/useCloseCurrentRun'
 import { loadProtocol, closeProtocol } from '../../redux/protocol/actions'
 import { ingestProtocolFile } from '../../redux/protocol/utils'
+import { getConnectedRobotName } from '../../redux/robot/selectors'
 
 import { ConfirmExitProtocolUploadModal } from './ConfirmExitProtocolUploadModal'
 
 import { useLogger } from '../../logger'
 import type { ErrorObject } from 'ajv'
-import type { Dispatch } from '../../redux/types'
+import type { Dispatch, State } from '../../redux/types'
 
 const VALIDATION_ERROR_T_MAP: { [errorKey: string]: string } = {
   INVALID_FILE_TYPE: 'invalid_file_type',
@@ -37,6 +38,7 @@ export function ProtocolUpload(): JSX.Element {
   } = useCurrentProtocolRun()
   const hasCurrentRun = runRecord != null && protocolRecord != null
   const closeProtocolRun = useCloseCurrentRun()
+   const robotName = useSelector((state: State) => getConnectedRobotName(state))
 
   const logger = useLogger(__filename)
   const [uploadError, setUploadError] = React.useState<
@@ -87,7 +89,13 @@ export function ProtocolUpload(): JSX.Element {
         },
       }
     : {
-        title: t('upload_and_simulate'),
+        title: (
+          <Trans
+            t={t}
+            i18nKey="upload_and_simulate"
+            values={{ robot_name: robotName }}
+          />
+        ),
       }
 
   return (

--- a/app/src/organisms/ProtocolUpload/index.tsx
+++ b/app/src/organisms/ProtocolUpload/index.tsx
@@ -38,7 +38,7 @@ export function ProtocolUpload(): JSX.Element {
   } = useCurrentProtocolRun()
   const hasCurrentRun = runRecord != null && protocolRecord != null
   const closeProtocolRun = useCloseCurrentRun()
-   const robotName = useSelector((state: State) => getConnectedRobotName(state))
+  const robotName = useSelector((state: State) => getConnectedRobotName(state))
 
   const logger = useLogger(__filename)
   const [uploadError, setUploadError] = React.useState<
@@ -91,6 +91,7 @@ export function ProtocolUpload(): JSX.Element {
     : {
         title: (
           <Trans
+            id={'file_input'}
             t={t}
             i18nKey="upload_and_simulate"
             values={{ robot_name: robotName }}

--- a/app/src/organisms/ProtocolUpload/index.tsx
+++ b/app/src/organisms/ProtocolUpload/index.tsx
@@ -6,7 +6,7 @@ import {
   C_NEAR_WHITE,
   useConditionalConfirm,
 } from '@opentrons/components'
-import { Trans, useTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { Page } from '../../atoms/Page'
 import { UploadInput } from './UploadInput'
@@ -90,12 +90,7 @@ export function ProtocolUpload(): JSX.Element {
       }
     : {
         title: (
-          <Trans
-            id={'file_input'}
-            t={t}
-            i18nKey="upload_and_simulate"
-            values={{ robot_name: robotName }}
-          />
+          <Text>{t('upload_and_simulate', { robot_name: robotName })}</Text>
         ),
       }
 

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -393,10 +393,16 @@ export interface CompletedProtocolAnalysis {
   commands: Command[]
   errors: string[]
 }
+
+export interface ResourceFile {
+  name: string
+  role: string
+}
 export interface ProtocolResource {
   id: string
   createdAt: string
   protocolType: 'json' | 'python'
   metadata: ProtocolMetadata
   analyses: PendingProtocolAnalysis[] | CompletedProtocolAnalysis[]
+  files: ResourceFile[]
 }


### PR DESCRIPTION
# Overview

closes #8464 

# Changelog

- creates  `RerunningProtocolModal` and adds on to `UploadInfo` component 

# Review requests

- review AC on ticket and review styling to make sure it matches [figma](https://www.figma.com/file/JCQNOTTK9tTmYPhRqeOfSj/Milestone-0%3A-Protocol-Upload-Revamp?node-id=6957%3A167940)
- the link in the `RerunningProtocolModal` is empty for now since we are still waiting on support to write the article

# Risk assessment

low, behind ff