### PR TITLE
fix(can):  binary serializable build will ignore extra bytes.

### DIFF
--- a/hardware/opentrons_hardware/utils/binary_serializable.py
+++ b/hardware/opentrons_hardware/utils/binary_serializable.py
@@ -141,6 +141,13 @@ class BinarySerializable:
     def build(cls, data: bytes) -> BinarySerializable:
         """Create a BinarySerializable from a byte buffer.
 
+        The byte buffer must be at least enough bytes to satisfy all fields.
+
+        Extra bytes will be ignored. This is for two reasons:
+            - CANFD requires padding to round byte lengths to fixed sizes.
+            - To accommodate extracting multiple  BinarySerializable objects
+            from a stream of bytes.
+
         Args:
             data: Byte buffer
 

--- a/hardware/opentrons_hardware/utils/binary_serializable.py
+++ b/hardware/opentrons_hardware/utils/binary_serializable.py
@@ -148,7 +148,10 @@ class BinarySerializable:
             cls
         """
         try:
-            b = struct.unpack(cls._get_format_string(), data)
+            format_string = cls._get_format_string()
+            size = cls.get_size()
+            # ignore bytes beyond the size of message.
+            b = struct.unpack(format_string, data[:size])
             args = {v.name: v.type.build(b[i]) for i, v in enumerate(fields(cls))}
             # Mypy is not liking constructing the derived types.
             return cls(**args)  # type: ignore[call-arg]
@@ -171,6 +174,11 @@ class BinarySerializable:
             raise InvalidFieldException(f"All fields must be of type {BinaryFieldBase}")
 
         return format_string
+
+    @classmethod
+    def get_size(cls) -> int:
+        """Get the size of the serializable in bytes."""
+        return struct.calcsize(cls._get_format_string())
 
 
 class LittleEndianMixIn:

--- a/hardware/tests/utils/test_binary_serializable.py
+++ b/hardware/tests/utils/test_binary_serializable.py
@@ -51,7 +51,12 @@ def subject() -> TestClass:
     )
 
 
-def test_serialize_length(subject: TestClass) -> None:
+def test_get_size(subject: TestClass) -> None:
+    """It should return the data size in bytes."""
+    assert subject.get_size() == 30
+
+
+def test_get_length(subject: TestClass) -> None:
     """It should serialize with correct data length in bytes."""
     assert len(subject.serialize()) == 30
 
@@ -72,6 +77,21 @@ def test_deserialize() -> None:
         ull=utils.UInt64Field(7),
         ll=utils.Int64Field(8),
     )
+
+
+def test_deserialize_ignore_extra(subject: TestClass) -> None:
+    """It should ignore extra bytes when deserializing."""
+    data = subject.serialize()
+    data += b"123212521"
+    new = TestClass.build(data)
+    assert new == subject
+
+
+def test_deserialize_not_enough_data(subject: TestClass) -> None:
+    """It should ignore extra bytes when deserializing."""
+    data = b"123212521"
+    with pytest.raises(utils.InvalidFieldException):
+        TestClass.build(data)
 
 
 def test_serdes(subject: TestClass) -> None:


### PR DESCRIPTION
# Overview

Due the way CAN FD encodes data length (see below), messages may contain more bytes than the message payload defines. 

We should tolerate this in our payload deserialization.

# CAN FD

CAN messages encode the payload length in 4 bits. For classic CAN this was not an issue as 8 bytes was the maximum length. For CAN FD the maximum length was increased to 64 bytes. 

The way data lengths up to 64 bytes are encoded into 4 bits is a look up table:
```
length -> byte length
0 -> 0 
1 -> 1
2 -> 2
3 -> 3
4 -> 4
5 -> 5
6 -> 6
7 -> 7
8 -> 8
9 -> 12
10 -> 16
11 -> 20
12 -> 24
13 -> 32
14 -> 48
15 -> 64
```

If a message payload requires only 10 bytes we have to use an encoded length of 9 and transmit 12 bytes. So the reader can ignore the two bytes added for padding.

# Changelog

- Add `BinarySerializable.get_size`
- `BinarySerializable.build` will ignore bytes beyond those required to build the object.

# Review requests



# Risk assessment

None