### PR TITLE
refactor(app): PUR wire up protocol metadata to protocol record

### DIFF
--- a/app/src/organisms/ProtocolSetup/MetadataCard.tsx
+++ b/app/src/organisms/ProtocolSetup/MetadataCard.tsx
@@ -6,6 +6,7 @@ import {
   SPACING_2,
   SPACING_3,
   C_WHITE,
+  TEXT_TRANSFORM_CAPITALIZE,
 } from '@opentrons/components'
 import { LabeledValue } from '../../atoms/structure'
 
@@ -16,7 +17,12 @@ const DATE_FORMAT = 'PPpp'
 
 export function MetadataCard(): JSX.Element {
   const { t } = useTranslation('protocol_info')
-  const { author, lastUpdated, method, description } = useProtocolMetadata()
+  const {
+    author,
+    lastUpdated,
+    description,
+    creationMethod,
+  } = useProtocolMetadata()
 
   return (
     <Card width="100%" padding={SPACING_3} backgroundColor={C_WHITE}>
@@ -34,9 +40,10 @@ export function MetadataCard(): JSX.Element {
           id={'MetadataCard_protocolLastUpdated'}
         />
         <LabeledValue
+          textTransform={TEXT_TRANSFORM_CAPITALIZE}
           flex={2}
           label={t('creation_method')}
-          value={method || '-'}
+          value={creationMethod || '-'}
           id={'MetadataCard_protocolCreationMethod'}
         />
       </Flex>

--- a/app/src/organisms/ProtocolSetup/__tests__/MetadataCard.test.tsx
+++ b/app/src/organisms/ProtocolSetup/__tests__/MetadataCard.test.tsx
@@ -21,7 +21,7 @@ describe('MetadataCard', () => {
     useProtocolMetadata.mockReturnValue({
       author: 'Anne McLaren',
       lastUpdated: 1624916984418, // epoch time for UTC-4 "Jun 28, 2021, 5:49:44 PM"
-      method: 'custom protocol creator application',
+      creationMethod: 'json',
       description: 'this describes the protocol',
     })
   })
@@ -39,7 +39,7 @@ describe('MetadataCard', () => {
       /Jun 2[89], 2021, [1-9]?[1-9]:[1-9]9:44 PM/i
     ) // loose check to compensate for different TZ's
     expect(getByText('Creation Method').nextElementSibling).toHaveTextContent(
-      /custom protocol creator application/i
+      /json/i
     )
     expect(getByText('Description').nextElementSibling).toHaveTextContent(
       /this describes the protocol/i

--- a/app/src/organisms/ProtocolSetup/__tests__/hooks.test.tsx
+++ b/app/src/organisms/ProtocolSetup/__tests__/hooks.test.tsx
@@ -1,36 +1,40 @@
 // tests for the HostConfig context and hook
 import * as React from 'react'
+import { when } from 'jest-when'
 import { Provider } from 'react-redux'
 import { createStore } from 'redux'
 import { renderHook } from '@testing-library/react-hooks'
 import { useProtocolMetadata } from '../hooks'
-import * as protocolSelectors from '../../../redux/protocol/selectors'
+import { useCurrentProtocolRun } from '../../ProtocolUpload/hooks'
 
 import type { Store } from 'redux'
 import type { State } from '../../../redux/types'
 
-jest.mock('../../../redux/protocol/selectors')
+jest.mock('../../ProtocolUpload/hooks')
 
-const getProtocolAuthor = protocolSelectors.getProtocolAuthor as jest.MockedFunction<
-  typeof protocolSelectors.getProtocolAuthor
->
-const getProtocolLastUpdated = protocolSelectors.getProtocolLastUpdated as jest.MockedFunction<
-  typeof protocolSelectors.getProtocolLastUpdated
->
-const getProtocolMethod = protocolSelectors.getProtocolMethod as jest.MockedFunction<
-  typeof protocolSelectors.getProtocolMethod
->
-const getProtocolDescription = protocolSelectors.getProtocolDescription as jest.MockedFunction<
-  typeof protocolSelectors.getProtocolDescription
+const mockUseCurrentProtocolRun = useCurrentProtocolRun as jest.MockedFunction<
+  typeof useCurrentProtocolRun
 >
 
 describe('useProtocolMetadata', () => {
   const store: Store<State> = createStore(jest.fn(), {})
 
-  getProtocolAuthor.mockReturnValue('author name')
-  getProtocolLastUpdated.mockReturnValue(8675309)
-  getProtocolMethod.mockReturnValue('imaginary editor')
-  getProtocolDescription.mockReturnValue('stubbed protocol description')
+  when(mockUseCurrentProtocolRun)
+    .calledWith()
+    .mockReturnValue({
+      protocolRecord: {
+        data: {
+          protocolType: 'json',
+          metadata: {
+            author: 'AUTHOR',
+            description: 'DESCRIPTION',
+            lastModified: 123456,
+          },
+        },
+      },
+      runRecord: {},
+      createProtocolRun: jest.fn(),
+    } as any)
 
   beforeEach(() => {
     store.dispatch = jest.fn()
@@ -45,11 +49,11 @@ describe('useProtocolMetadata', () => {
       <Provider store={store}>{children}</Provider>
     )
     const { result } = renderHook(useProtocolMetadata, { wrapper })
-    const { author, lastUpdated, method, description } = result.current
+    const { author, lastUpdated, creationMethod, description } = result.current
 
-    expect(author).toBe('author name')
-    expect(lastUpdated).toBe(8675309)
-    expect(method).toBe('imaginary editor')
-    expect(description).toBe('stubbed protocol description')
+    expect(author).toBe('AUTHOR')
+    expect(lastUpdated).toBe(123456)
+    expect(creationMethod).toBe('json')
+    expect(description).toBe('DESCRIPTION')
   })
 })

--- a/app/src/organisms/ProtocolSetup/hooks.ts
+++ b/app/src/organisms/ProtocolSetup/hooks.ts
@@ -18,8 +18,8 @@ interface ProtocolMetadata {
 
 export function useProtocolMetadata(): ProtocolMetadata {
   const currentProtocolRun = useCurrentProtocolRun()
-  const protocolMetadata = currentProtocolRun.protocolRecord?.data.metadata
-  const creationMethod = currentProtocolRun.protocolRecord?.data.protocolType
+  const protocolMetadata = currentProtocolRun.protocolRecord?.data?.metadata
+  const creationMethod = currentProtocolRun.protocolRecord?.data?.protocolType
   const author = protocolMetadata?.author
   const description = protocolMetadata?.description
   const lastUpdated = protocolMetadata?.lastModified

--- a/app/src/organisms/ProtocolSetup/hooks.ts
+++ b/app/src/organisms/ProtocolSetup/hooks.ts
@@ -1,38 +1,30 @@
-import { useSelector } from 'react-redux'
 import standardDeckDef from '@opentrons/shared-data/deck/definitions/2/ot2_standard.json'
-
-import {
-  getProtocolAuthor,
-  getProtocolLastUpdated,
-  getProtocolMethod,
-  getProtocolDescription,
-} from '../../redux/protocol'
 import { useProtocolDetails } from '../RunDetails/hooks'
 import { getModuleRenderInfo } from './utils/getModuleRenderInfo'
 import { getLabwareRenderInfo } from './utils/getLabwareRenderInfo'
+import { useCurrentProtocolRun } from '../ProtocolUpload/hooks'
 
 import type { ModuleRenderInfoById } from './utils/getModuleRenderInfo'
 import type { LabwareRenderInfoById } from './utils/getLabwareRenderInfo'
-import type { State } from '../../redux/types'
 import type { Command } from '@opentrons/shared-data/protocol/types/schemaV6'
 import type { LoadPipetteCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
+
 interface ProtocolMetadata {
-  author: string | null
-  lastUpdated: number | null
-  method: string | null
-  description: string | null
+  author?: string
+  lastUpdated?: number | null
+  description?: string | null
+  creationMethod?: 'json' | 'python'
 }
 
 export function useProtocolMetadata(): ProtocolMetadata {
-  const author = useSelector((state: State) => getProtocolAuthor(state))
-  const lastUpdated = useSelector((state: State) =>
-    getProtocolLastUpdated(state)
-  )
-  const method = useSelector((state: State) => getProtocolMethod(state))
-  const description = useSelector((state: State) =>
-    getProtocolDescription(state)
-  )
-  return { author, lastUpdated, method, description }
+  const currentProtocolRun = useCurrentProtocolRun()
+  const protocolMetadata = currentProtocolRun.protocolRecord?.data.metadata
+  const creationMethod = currentProtocolRun.protocolRecord?.data.protocolType
+  const author = protocolMetadata?.author
+  const description = protocolMetadata?.description
+  const lastUpdated = protocolMetadata?.lastModified
+
+  return { author, lastUpdated, description, creationMethod }
 }
 
 export function useModuleRenderInfoById(): ModuleRenderInfoById {

--- a/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
+++ b/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
@@ -86,6 +86,13 @@ describe('ProtocolUpload', () => {
     when(mockUseProtocolDetails)
       .calledWith()
       .mockReturnValue({} as any)
+    when(mockUseCurrentProtocolRun)
+      .calledWith()
+      .mockReturnValue({
+        protocolRecord: { data: { analyses: [] } },
+        runRecord: {},
+        createProtocolRun: jest.fn(),
+      } as any)
   })
 
   afterEach(() => {
@@ -108,13 +115,6 @@ describe('ProtocolUpload', () => {
   })
   it('renders Protocol Setup if file loaded', () => {
     getProtocolFile.mockReturnValue(withModulesProtocol as any)
-    when(mockUseCurrentProtocolRun)
-      .calledWith()
-      .mockReturnValue({
-        protocolRecord: { data: { analyses: [] } },
-        runRecord: {},
-        createProtocolRun: jest.fn(),
-      } as any)
     const { queryByRole, getByText } = render()[0]
 
     expect(queryByRole('button', { name: 'Choose File...' })).toBeNull()
@@ -123,13 +123,6 @@ describe('ProtocolUpload', () => {
 
   it('opens up the confirm close protocol modal when clicked', () => {
     getProtocolFile.mockReturnValue(withModulesProtocol as any)
-    when(mockUseCurrentProtocolRun)
-      .calledWith()
-      .mockReturnValue({
-        protocolRecord: {},
-        runRecord: {},
-        createProtocolRun: jest.fn(),
-      } as any)
     const { getByRole, getByText } = render()[0]
     fireEvent.click(getByRole('button', { name: 'close' }))
     getByText('mock confirm exit protocol upload modal')
@@ -137,13 +130,6 @@ describe('ProtocolUpload', () => {
 
   it('closes the confirm close protocol modal when Yes, close now is clicked', () => {
     getProtocolFile.mockReturnValue(withModulesProtocol as any)
-    when(mockUseCurrentProtocolRun)
-      .calledWith()
-      .mockReturnValue({
-        protocolRecord: {},
-        runRecord: {},
-        createProtocolRun: jest.fn(),
-      } as any)
     const mockCloseProtocolRun = jest.fn()
     when(mockUseCloseProtocolRun)
       .calledWith()

--- a/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
+++ b/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
@@ -86,13 +86,6 @@ describe('ProtocolUpload', () => {
     when(mockUseProtocolDetails)
       .calledWith()
       .mockReturnValue({} as any)
-    when(mockUseCurrentProtocolRun)
-      .calledWith()
-      .mockReturnValue({
-        protocolRecord: { data: { analyses: [] } },
-        runRecord: {},
-        createProtocolRun: jest.fn(),
-      } as any)
   })
 
   afterEach(() => {
@@ -115,6 +108,13 @@ describe('ProtocolUpload', () => {
   })
   it('renders Protocol Setup if file loaded', () => {
     getProtocolFile.mockReturnValue(withModulesProtocol as any)
+    when(mockUseCurrentProtocolRun)
+      .calledWith()
+      .mockReturnValue({
+        protocolRecord: { data: { analyses: [] } },
+        runRecord: {},
+        createProtocolRun: jest.fn(),
+      } as any)
     const { queryByRole, getByText } = render()[0]
 
     expect(queryByRole('button', { name: 'Choose File...' })).toBeNull()
@@ -123,17 +123,33 @@ describe('ProtocolUpload', () => {
 
   it('opens up the confirm close protocol modal when clicked', () => {
     getProtocolFile.mockReturnValue(withModulesProtocol as any)
+    when(mockUseCurrentProtocolRun)
+      .calledWith()
+      .mockReturnValue({
+        protocolRecord: {},
+        runRecord: {},
+        createProtocolRun: jest.fn(),
+      } as any)
     const { getByRole, getByText } = render()[0]
+
     fireEvent.click(getByRole('button', { name: 'close' }))
     getByText('mock confirm exit protocol upload modal')
   })
 
   it('closes the confirm close protocol modal when Yes, close now is clicked', () => {
     getProtocolFile.mockReturnValue(withModulesProtocol as any)
+    when(mockUseCurrentProtocolRun)
+      .calledWith()
+      .mockReturnValue({
+        protocolRecord: {},
+        runRecord: {},
+        createProtocolRun: jest.fn(),
+      } as any)
     const mockCloseProtocolRun = jest.fn()
     when(mockUseCloseProtocolRun)
       .calledWith()
       .mockReturnValue(mockCloseProtocolRun)
+
     const [{ getByRole, getByText }, store] = render()
     fireEvent.click(getByRole('button', { name: 'close' }))
     const mockCloseModal = getByText('mock confirm exit protocol upload modal')


### PR DESCRIPTION

# Overview

closes #8592 

# Changelog

- uses `useCurrentProtocolRun` to get all the metadata info and wires that up to `useProtocolMetadata` hook

# Review requests

- review AC of ticket

# Risk assessment

low, behind ff
