### PR TITLE
refactor(app): fix type error

### DIFF
--- a/app/src/organisms/RunDetails/CommandText.tsx
+++ b/app/src/organisms/RunDetails/CommandText.tsx
@@ -47,6 +47,10 @@ export function CommandText(props: Props): JSX.Element {
       }
       case 'pickUpTip': {
         const { wellName, labwareId } = commandOrSummary.params
+        const labwareLocation = getLabwareLocation(labwareId, commands)
+        if (!('slotName' in labwareLocation)) {
+          throw new Error('expected tip rack to be in a slot')
+        }
         messageNode = (
           <Trans
             t={t}
@@ -56,7 +60,7 @@ export function CommandText(props: Props): JSX.Element {
               labware: getLabwareDisplayName(
                 labwareRenderInfoById[labwareId].labwareDef
               ),
-              labware_location: getLabwareLocation(labwareId, commands),
+              labware_location: labwareLocation.slotName,
             }}
           />
         )

--- a/app/src/organisms/RunDetails/__tests__/CommandText.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/CommandText.test.tsx
@@ -68,7 +68,7 @@ describe('CommandText', () => {
       .mockReturnValue('fake_display_name')
     when(mockGetLabwareLocation)
       .calledWith(labwareId, [])
-      .mockReturnValue('fake_labware_location')
+      .mockReturnValue({ slotName: 'fake_labware_location' })
     mockUseLabwareRenderInfoById.mockReturnValue({
       labwareId: {
         labwareDef: 'fake_def',


### PR DESCRIPTION
# Overview

Got too eager and hit the merge button too soon. This fixes a type error caused by a combo of a refactor I made to `getLabwareLocation`, and a PR that got merged before mine that used the old implementation of `getLabwareLocation`.


