### PR TITLE
feat(app): Display banners when stopped, failed, or succeeded

### DIFF
--- a/app/src/assets/localization/en/run_details.json
+++ b/app/src/assets/localization/en/run_details.json
@@ -45,5 +45,7 @@
   "comment": "Comment",
   "anticipated": "Anticipated steps",
   "protocol_steps": "Protocol steps",
-  "protocol_run_failed": "Protocol run failed"
+  "protocol_run_failed": "Protocol run failed",
+  "protocol_run_canceled": "Protocol run canceled",
+  "protocol_run_complete": "Protocol run complete"
 }

--- a/app/src/organisms/RunDetails/CommandList.tsx
+++ b/app/src/organisms/RunDetails/CommandList.tsx
@@ -15,15 +15,10 @@ import {
   FONT_HEADER_DARK,
   JUSTIFY_START,
   Text,
-  FONT_SIZE_DEFAULT,
   SPACING_2,
   C_NEAR_WHITE,
-  C_ERROR_LIGHT,
-  COLOR_ERROR,
-  SPACING_3,
-  SPACING_4,
-  ALIGN_CENTER,
   TEXT_TRANSFORM_CAPITALIZE,
+  AlertItem,
 } from '@opentrons/components'
 import { useRunStatus } from '../RunTimeControl/hooks'
 import { useProtocolDetails } from './hooks'
@@ -109,31 +104,36 @@ export function CommandList(): JSX.Element | null {
   const runStatus = useRunStatus()
   if (protocolData == null || runStatus == null) return null
 
+  const isCommandFailed =
+    currentCommandList?.some(command => command.status === 'failed') === true
+  let alertItemTitle
+  if (isCommandFailed) {
+    alertItemTitle = t('protocol_run_failed')
+  }
+  if (runStatus === 'stop-requested') {
+    alertItemTitle = t('protocol_run_canceled')
+  }
+  if (runStatus === 'succeeded') {
+    alertItemTitle = t('protocol_run_complete')
+  }
+
   return (
     <React.Fragment>
       <Flex flexDirection={DIRECTION_COLUMN} flex={'auto'}>
-        {currentCommandList?.some(command => command.status === 'failed') ===
-        true ? (
+        {isCommandFailed ||
+        runStatus === 'succeeded' ||
+        runStatus === 'stop-requested' ? (
           <Flex
             padding={SPACING_2}
             flexDirection={DIRECTION_COLUMN}
             flex="auto"
           >
-            <Flex
-              color={COLOR_ERROR}
-              backgroundColor={C_ERROR_LIGHT}
-              fontSize={FONT_SIZE_DEFAULT}
-              padding={SPACING_2}
-              border={`1px solid ${COLOR_ERROR}`}
-              alignItems={ALIGN_CENTER}
-            >
-              <Icon
-                name="information"
-                width={SPACING_4}
-                marginRight={SPACING_3}
-              />
-              {t('protocol_run_failed')}
-            </Flex>
+            <AlertItem
+              type={
+                isCommandFailed || runStatus === 'failed' ? 'error' : 'success'
+              }
+              title={alertItemTitle}
+            />
           </Flex>
         ) : null}
         <Flex

--- a/app/src/organisms/RunDetails/CommandList.tsx
+++ b/app/src/organisms/RunDetails/CommandList.tsx
@@ -19,6 +19,7 @@ import {
   C_NEAR_WHITE,
   TEXT_TRANSFORM_CAPITALIZE,
   AlertItem,
+  Box,
 } from '@opentrons/components'
 import { useRunStatus } from '../RunTimeControl/hooks'
 import { useProtocolDetails } from './hooks'
@@ -104,10 +105,8 @@ export function CommandList(): JSX.Element | null {
   const runStatus = useRunStatus()
   if (protocolData == null || runStatus == null) return null
 
-  const isCommandFailed =
-    currentCommandList?.some(command => command.status === 'failed') === true
   let alertItemTitle
-  if (isCommandFailed) {
+  if (runStatus === 'failed') {
     alertItemTitle = t('protocol_run_failed')
   }
   if (runStatus === 'stop-requested') {
@@ -120,21 +119,19 @@ export function CommandList(): JSX.Element | null {
   return (
     <React.Fragment>
       <Flex flexDirection={DIRECTION_COLUMN} flex={'auto'}>
-        {isCommandFailed ||
+        {runStatus === 'failed' ||
         runStatus === 'succeeded' ||
         runStatus === 'stop-requested' ? (
-          <Flex
-            padding={SPACING_2}
-            flexDirection={DIRECTION_COLUMN}
-            flex="auto"
-          >
+          <Box padding={SPACING_2}>
             <AlertItem
               type={
-                isCommandFailed || runStatus === 'failed' ? 'error' : 'success'
+                runStatus === 'stop-requested' || runStatus === 'failed'
+                  ? 'error'
+                  : 'success'
               }
               title={alertItemTitle}
             />
-          </Flex>
+          </Box>
         ) : null}
         <Flex
           paddingLeft={SPACING_2}

--- a/app/src/organisms/RunDetails/__tests__/CommandList.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/CommandList.test.tsx
@@ -3,6 +3,7 @@ import { when } from 'jest-when'
 import { fireEvent } from '@testing-library/dom'
 import { i18n } from '../../../i18n'
 import { renderWithProviders } from '@opentrons/components'
+import { AlertItem } from '@opentrons/components/src/alerts'
 import { useProtocolDetails } from '../hooks'
 import { useCurrentProtocolRun } from '../../ProtocolUpload/hooks'
 import { useRunStatus } from '../../RunTimeControl/hooks'
@@ -21,6 +22,7 @@ jest.mock('../CommandItem')
 jest.mock('../../RunTimeControl/hooks')
 jest.mock('../../ProtocolUpload/hooks')
 jest.mock('@opentrons/shared-data/js/helpers/schemaV6Adapter')
+jest.mock('@opentrons/components/src/alerts')
 
 const mockUseProtocolDetails = useProtocolDetails as jest.MockedFunction<
   typeof useProtocolDetails
@@ -38,6 +40,8 @@ const mockSchemaV6Adapter = schemaV6Adapter as jest.MockedFunction<
   typeof schemaV6Adapter
 >
 const mockCommandItem = CommandItem as jest.MockedFunction<typeof CommandItem>
+
+const mockAlertItem = AlertItem as jest.MockedFunction<typeof AlertItem>
 
 const simpleV6Protocol = (_uncastedSimpleV6Protocol as unknown) as ProtocolFile<{}>
 const _fixtureAnalysis = (fixtureAnalysis as unknown) as ProtocolFile<{}>
@@ -110,5 +114,45 @@ describe('CommandList', () => {
         'Picking up tip from A1 of Opentrons 96 Tip Rack 300 µL on 1'
       ).length
     ).toEqual(1)
+  })
+  it('renders the protocol failed banner', () => {
+    mockUseCurrentProtocolRun.mockReturnValue({
+      runRecord: {
+        // @ts-expect-error not a full match of RunData type
+        data: {
+          commands: [
+            {
+              commandType: 'loadPipette',
+              id: 'commands.LOAD_PIPETTE-0',
+              status: 'failed',
+            },
+          ],
+        },
+      },
+    })
+    mockAlertItem.mockReturnValue(<div>Protocol Run Failed</div>)
+    const { getByText } = render()
+    expect(getByText('Protocol Run Failed')).toHaveStyle(
+      'backgroundColor: Error_light'
+    )
+    expect(getByText('Protocol Run Failed')).toHaveStyle('color: Error_dark')
+  })
+  it('renders the protocol canceled banner', () => {
+    mockUseRunStatus.mockReturnValue('stop-requested')
+    mockAlertItem.mockReturnValue(<div>Protocol Run Canceled</div>)
+    const { getByText } = render()
+    expect(getByText('Protocol Run Canceled')).toHaveStyle(
+      'backgroundColor: Error_light'
+    )
+    expect(getByText('Protocol Run Canceled')).toHaveStyle('color: Error_dark')
+  })
+  it('renders the protocol completed banner', () => {
+    mockUseRunStatus.mockReturnValue('succeeded')
+    mockAlertItem.mockReturnValue(<div>Protocol Run Completed</div>)
+    const { getByText } = render()
+    expect(getByText('Protocol Run Completed')).toHaveStyle(
+      'backgroundColor: C_bg_success'
+    )
+    expect(getByText('Protocol Run Completed')).toHaveStyle('color: C_success')
   })
 })

--- a/app/src/organisms/RunDetails/__tests__/CommandList.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/CommandList.test.tsx
@@ -116,20 +116,7 @@ describe('CommandList', () => {
     ).toEqual(1)
   })
   it('renders the protocol failed banner', () => {
-    mockUseCurrentProtocolRun.mockReturnValue({
-      runRecord: {
-        // @ts-expect-error not a full match of RunData type
-        data: {
-          commands: [
-            {
-              commandType: 'loadPipette',
-              id: 'commands.LOAD_PIPETTE-0',
-              status: 'failed',
-            },
-          ],
-        },
-      },
-    })
+    mockUseRunStatus.mockReturnValue('failed')
     mockAlertItem.mockReturnValue(<div>Protocol Run Failed</div>)
     const { getByText } = render()
     expect(getByText('Protocol Run Failed')).toHaveStyle(


### PR DESCRIPTION
# Overview

closes #8573

# Changelog

- adds banners to the top of run details when run status is stopped, failed, or succeeded

# Review requests

- review AC from ticket and [figma](https://www.figma.com/file/JCQNOTTK9tTmYPhRqeOfSj/Milestone-0:-Protocol-Upload-Revamp?node-id=5629%3A145096) to make sure everything matches

# Risk assessment

low, behind ff