### PR TITLE
feat(app): add missing URL to RerunningProtocolModal

### DIFF
--- a/app/src/organisms/ProtocolUpload/RerunningProtocolModal.tsx
+++ b/app/src/organisms/ProtocolUpload/RerunningProtocolModal.tsx
@@ -30,7 +30,8 @@ interface RerunningProtocolModalProps {
   onCloseClick: () => unknown
 }
 
-const UPLOAD_PROTOCOL_URL = '#' //   TODO IMMEDIATELY get actual link - Emily said this url isn't created it
+const UPLOAD_PROTOCOL_URL =
+  'http://support.opentrons.com/en/articles/5742955-how-labware-offsets-work-on-the-ot-2'
 
 export const RerunningProtocolModal = (
   props: RerunningProtocolModalProps

--- a/app/src/organisms/ProtocolUpload/hooks/__tests__/RerunningProtocolModal.test.tsx
+++ b/app/src/organisms/ProtocolUpload/hooks/__tests__/RerunningProtocolModal.test.tsx
@@ -40,7 +40,9 @@ describe('RerunningProtocolModal', () => {
       getByRole('link', {
         name: 'Learn more about Labware Offset Data',
       }).getAttribute('href')
-    ).toBe('#') //   TODO IMMEDIATELY replace with actual link
+    ).toBe(
+      'http://support.opentrons.com/en/articles/5742955-how-labware-offsets-work-on-the-ot-2'
+    )
   })
   it('should call onCloseClick when the close button is pressed', () => {
     const { getByRole } = render(props)


### PR DESCRIPTION
# Overview

closes #8801

# Changelog

- adds missing link to `RerunningProtocolModal` 

# Review requests

- make sure link works and links to a page (the page doesn't exist yet though so you should see a page not found) 

# Risk assessment

low, behind ff