### PR TITLE
fix(app): add null protection for empty file array on protocol upload

### DIFF
--- a/app/src/organisms/ProtocolUpload/UploadInput.tsx
+++ b/app/src/organisms/ProtocolUpload/UploadInput.tsx
@@ -100,7 +100,7 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
   const protocolName = protocolData.displayName
   const fileName =
     mostRecentProtocol != null
-      ? mostRecentProtocol.files.find(file => file.role === 'main')?.name
+      ? mostRecentProtocol.files?.find(file => file.role === 'main')?.name
       : null
   const fullRunTimestamp = mostRecentRun?.createdAt
   if (fullRunTimestamp == null) return null //  This state should never be reached since if null, protocol empty state won't show latest protocol run data


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Fix bug where null files array was breaking the protocol upload page
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
add null protection for empty file array on protocol upload
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->
Verify that you can upload a protocol file when there is no previously loaded protocol on the robot

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
