### PR TITLE
fix(app): fix bug in which runs and protocols were being queried with empty string params

### DIFF
--- a/app/src/assets/localization/en/protocol_info.json
+++ b/app/src/assets/localization/en/protocol_info.json
@@ -41,7 +41,7 @@
   "run_timestamp_title": "Run timestamp",
   "labware_offset_data_title": "Labware Offset data",
   "timestamp": "+{{index}}",
-  "run_again_btn": "Run again",
+  "run_again": "Run again",
   "labware_offsets_info": "{{number}} Labware Offsets",
   "rerunning_protocol_modal_header": "How Rerunning A Protocol Works",
   "rerunning_protocol_modal_body": "<block>Opentrons displays the connected robot’s last protocol run on on the Protocol Upload page. If you run again, Opentrons loads this protocol and applies Labware Offset data if any exists.</block><block>Clicking “Run Again” will take you directly to the Run tab. If you’d like to review the deck setup or run Labware Position Check before running the protocol, navigate to the Protocol tab.</block><block>If you recalibrate your robot, it will clear the last run from the upload page.</block>",

--- a/app/src/organisms/ProtocolUpload/UploadInput.tsx
+++ b/app/src/organisms/ProtocolUpload/UploadInput.tsx
@@ -282,7 +282,7 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
                 color={C_BLUE}
                 id={'UploadInput_runAgainButton'}
               >
-                {t('run_again_btn')}
+                {t('run_again')}
               </SecondaryBtn>
             </Flex>
           </Flex>

--- a/app/src/organisms/ProtocolUpload/UploadInput.tsx
+++ b/app/src/organisms/ProtocolUpload/UploadInput.tsx
@@ -80,13 +80,13 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
   const runQuery = useRunQuery(mostRecentRunId)
   const mostRecentRun = runQuery.data?.data
   const mostRecentProtocolInfo = useProtocolQuery(
-    (mostRecentRun?.protocolId as string) ?? ''
+    (mostRecentRun?.protocolId as string) ?? null
   )
   const mostRecentProtocol = mostRecentProtocolInfo?.data?.data
   const protocolData = useProtocolDetails()
   //  If mostRecentRun is null, the CTA that uses cloneRun won't appear so this will never be reached
   const cloneMostRecentRun = useCloneRun(
-    mostRecentRunId != null ? mostRecentRunId : ''
+    mostRecentRunId != null ? mostRecentRunId : null
   )
   const robotName = useSelector((state: State) => getConnectedRobotName(state))
   const fileInput = React.useRef<HTMLInputElement>(null)
@@ -98,13 +98,10 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
   )
   const labwareOffsets = mostRecentRun?.labwareOffsets
   const protocolName = protocolData.displayName
-  const fileName =
-    mostRecentProtocol != null
-      ? mostRecentProtocol.files?.find(file => file.role === 'main')?.name
+  const mostRecentRunFileName =
+    mostRecentProtocol != null && mostRecentProtocol.files != null
+      ? mostRecentProtocol.files.find(file => file.role === 'main')?.name
       : null
-  const fullRunTimestamp = mostRecentRun?.createdAt
-  if (fullRunTimestamp == null) return null //  This state should never be reached since if null, protocol empty state won't show latest protocol run data
-  const runTimestamp = format(parseISO(fullRunTimestamp), 'yyyy-MM-dd pp xxxxx')
 
   const handleDrop: React.DragEventHandler<HTMLLabelElement> = e => {
     e.preventDefault()
@@ -234,7 +231,7 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
                 {t('protocol_name_title')}
               </Text>
               <Flex css={FONT_BODY_1_DARK}>
-                {protocolName != null ? protocolName : fileName}
+                {protocolName != null ? protocolName : mostRecentRunFileName}
               </Flex>
             </Flex>
             <Flex
@@ -250,7 +247,7 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
                 {t('run_timestamp_title')}
               </Text>
               <Flex css={FONT_BODY_1_DARK} flexDirection={DIRECTION_ROW}>
-                {runTimestamp}
+                {format(parseISO(mostRecentRun?.createdAt), 'yyyy-MM-dd pp xxxxx')}
               </Flex>
             </Flex>
             <Flex

--- a/app/src/organisms/ProtocolUpload/UploadInput.tsx
+++ b/app/src/organisms/ProtocolUpload/UploadInput.tsx
@@ -247,7 +247,10 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
                 {t('run_timestamp_title')}
               </Text>
               <Flex css={FONT_BODY_1_DARK} flexDirection={DIRECTION_ROW}>
-                {format(parseISO(mostRecentRun.createdAt), 'yyyy-MM-dd pp xxxxx')}
+                {format(
+                  parseISO(mostRecentRun.createdAt),
+                  'yyyy-MM-dd pp xxxxx'
+                )}
               </Flex>
             </Flex>
             <Flex

--- a/app/src/organisms/ProtocolUpload/UploadInput.tsx
+++ b/app/src/organisms/ProtocolUpload/UploadInput.tsx
@@ -189,7 +189,7 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
           onChange={onChange}
         />
       </label>
-      {mostRecentRunId === null ? null : (
+      {mostRecentRun == null ? null : (
         <Flex flexDirection={DIRECTION_COLUMN} width={'80%'}>
           <Divider marginY={SPACING_3} />
           <Flex
@@ -247,7 +247,7 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
                 {t('run_timestamp_title')}
               </Text>
               <Flex css={FONT_BODY_1_DARK} flexDirection={DIRECTION_ROW}>
-                {format(parseISO(mostRecentRun?.createdAt), 'yyyy-MM-dd pp xxxxx')}
+                {format(parseISO(mostRecentRun.createdAt), 'yyyy-MM-dd pp xxxxx')}
               </Flex>
             </Flex>
             <Flex

--- a/app/src/organisms/ProtocolUpload/__tests__/UploadInput.test.tsx
+++ b/app/src/organisms/ProtocolUpload/__tests__/UploadInput.test.tsx
@@ -202,19 +202,15 @@ describe('UploadInput', () => {
     fireEvent.click(openModal)
     getByText('Mock Rerunning Protocol Modal')
   })
-  it('renders null if run timestamp is null', () => {
+  it('renders null if run is null', () => {
     when(mockUseRunQuery)
       .calledWith('RunId')
       .mockReturnValue({
-        data: {
-          data: {
-            createdAt: null,
-            labwareOffsets: [],
-          },
-        },
+        data: null,
       } as any)
-    const { container } = render(props)
-    expect(container.firstChild).toBeNull()
+
+    const { queryByText } = render(props)
+    expect(queryByText('Run Again')).toBeNull()
   })
   it('renders file name if Protocol name is null', () => {
     when(mockUseProtocolQuery)

--- a/app/src/organisms/ProtocolUpload/hooks/useCloneRun.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useCloneRun.ts
@@ -28,5 +28,5 @@ export function useCloneRun(runId: string | null): () => void {
     },
   })
 
-  return () => stopThenCloneRun(runId)
+  return () => runId != null && stopThenCloneRun(runId)
 }

--- a/app/src/organisms/ProtocolUpload/hooks/useCloneRun.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useCloneRun.ts
@@ -6,7 +6,7 @@ import {
   useCreateRunMutation,
 } from '@opentrons/react-api-client'
 
-export function useCloneRun(runId: string): () => void {
+export function useCloneRun(runId: string | null): () => void {
   const host = useHost()
   const queryClient = useQueryClient()
   const { data: runRecord } = useRunQuery(runId)


### PR DESCRIPTION
# Overview

fix bug that was causing the protocol upload page to white screen

# Changelog

If we don't have an id, pass null to the api-client functions instead of an empty string

# Review requests

- [ ] check that the app properly displays the protocol upload empty and loaded states

# Risk assessment

low