### PR TITLE
feat(app): add LPC Success Toast

### DIFF
--- a/app/src/assets/localization/en/protocol_info.json
+++ b/app/src/assets/localization/en/protocol_info.json
@@ -46,5 +46,6 @@
   "rerunning_protocol_modal_header": "How Rerunning A Protocol Works",
   "rerunning_protocol_modal_body": "<block>Opentrons displays the connected robot’s last protocol run on on the Protocol Upload page. If you run again, Opentrons loads this protocol and applies Labware Offset data if any exists.</block><block>Clicking “Run Again” will take you directly to the Run tab. If you’d like to review the deck setup or run Labware Position Check before running the protocol, navigate to the Protocol tab.</block><block>If you recalibrate your robot, it will clear the last run from the upload page.</block>",
   "rerunning_protocol_modal_link": "Learn more about Labware Offset Data",
-  "no_labware_offset_data": "No Labware Offset data"
+  "no_labware_offset_data": "No Labware Offset data",
+  "labware_positon_check_complete_toast": "Labware Position Check complete. {{num_offsets}} Labware Offsets created."
 }

--- a/app/src/organisms/ProtocolSetup/LabwareOffsetSuccessToast.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwareOffsetSuccessToast.tsx
@@ -17,7 +17,8 @@ export function LabwareOffsetSuccessToast(
 ): JSX.Element {
   const { t } = useTranslation('protocol_info')
   const currentProtocolRun = useCurrentProtocolRun()
-  const labwareOffsets = currentProtocolRun.runRecord?.data.labwareOffsets
+  const currentRunData = currentProtocolRun.runRecord?.data
+  const labwareOffsets = currentRunData?.labwareOffsets
 
   return (
     <Flex

--- a/app/src/organisms/ProtocolSetup/LabwareOffsetSuccessToast.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwareOffsetSuccessToast.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react'
+import {
+  DIRECTION_COLUMN,
+  Flex,
+  AlertItem,
+  SPACING_1,
+  SPACING_2,
+} from '@opentrons/components'
+import { useTranslation } from 'react-i18next'
+import { useCurrentProtocolRun } from '../ProtocolUpload/hooks'
+
+interface LabwareOffsetSuccessToastProps {
+  onCloseClick: () => unknown
+}
+export function LabwareOffsetSuccessToast(
+  props: LabwareOffsetSuccessToastProps
+): JSX.Element {
+  const { t } = useTranslation('protocol_info')
+  const currentProtocolRun = useCurrentProtocolRun()
+  const labwareOffsets = currentProtocolRun.runRecord?.data.labwareOffsets
+
+  return (
+    <Flex
+      flexDirection={DIRECTION_COLUMN}
+      padding={`${SPACING_1} ${SPACING_2}`}
+    >
+      <AlertItem
+        type="success"
+        onCloseClick={() => props.onCloseClick}
+        title={t('labware_positon_check_complete_toast', {
+          num_offsets: labwareOffsets?.length,
+        })}
+      />
+    </Flex>
+  )
+}

--- a/app/src/organisms/ProtocolSetup/__tests__/LabwareOffsetSuccessToast.test.tsx
+++ b/app/src/organisms/ProtocolSetup/__tests__/LabwareOffsetSuccessToast.test.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react'
+import '@testing-library/jest-dom'
+import { renderWithProviders } from '@opentrons/components'
+import { AlertItem } from '@opentrons/components/src/alerts'
+import { i18n } from '../../../i18n'
+import { fireEvent } from '@testing-library/dom'
+import { LabwareOffsetSuccessToast } from '../LabwareOffsetSuccessToast'
+
+jest.mock('@opentrons/components/src/alerts')
+
+const mockAlertItem = AlertItem as jest.MockedFunction<typeof AlertItem>
+
+const render = (
+  props: React.ComponentProps<typeof LabwareOffsetSuccessToast>
+) => {
+  return renderWithProviders(<LabwareOffsetSuccessToast {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+describe(' LabwareOffsetSuccessToast', () => {
+  let props: React.ComponentProps<typeof LabwareOffsetSuccessToast>
+
+  beforeEach(() => {
+    props = { onCloseClick: jest.fn() }
+    mockAlertItem.mockReturnValue(<div>Mock AlertItem</div>)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('renders LPC success toast and is clickable', () => {
+    const { getByText } = render(props)
+    const successToast = getByText('Mock AlertItem')
+    fireEvent.click(successToast)
+  })
+})

--- a/app/src/organisms/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/organisms/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react'
+import '@testing-library/jest-dom'
+import { renderWithProviders } from '@opentrons/components'
+import { AlertItem } from '@opentrons/components/src/alerts'
+import { i18n } from '../../../i18n'
+import { RunSetupCard } from '../RunSetupCard'
+import { MetadataCard } from '../MetadataCard'
+import { ProtocolSetup } from '..'
+import { fireEvent } from '@testing-library/dom'
+
+jest.mock('../MetadataCard')
+jest.mock('../RunSetupCard')
+jest.mock('@opentrons/components/src/alerts')
+
+const mockMetadataCard = MetadataCard as jest.MockedFunction<
+  typeof MetadataCard
+>
+const mockRunSetupCard = RunSetupCard as jest.MockedFunction<
+  typeof RunSetupCard
+>
+const mockAlertItem = AlertItem as jest.MockedFunction<typeof AlertItem>
+
+describe('ProtocolSetup', () => {
+  const render = () => {
+    return renderWithProviders(<ProtocolSetup />, { i18nInstance: i18n })[0]
+  }
+
+  beforeEach(() => {
+    mockMetadataCard.mockReturnValue(<div>Mock MetadataCard</div>)
+    mockRunSetupCard.mockReturnValue(<div>Mock ReunSetupCard</div>)
+    mockAlertItem.mockReturnValue(<div>Mock AlertItem</div>)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('renders metadata and run setup card', () => {
+    const { getByText } = render()
+    getByText('Mock MetadataCard')
+    getByText('Mock ReunSetupCard')
+  })
+  it('renders LPC success toast and is clickable', () => {
+    const { getByText } = render()
+    const successToast = getByText('Mock AlertItem')
+    fireEvent.click(successToast)
+  })
+})

--- a/app/src/organisms/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/organisms/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -1,16 +1,15 @@
 import * as React from 'react'
 import '@testing-library/jest-dom'
+import { fireEvent } from '@testing-library/dom'
 import { renderWithProviders } from '@opentrons/components'
-import { AlertItem } from '@opentrons/components/src/alerts'
-import { i18n } from '../../../i18n'
 import { RunSetupCard } from '../RunSetupCard'
 import { MetadataCard } from '../MetadataCard'
+import { LabwareOffsetSuccessToast } from '../LabwareOffsetSuccessToast'
 import { ProtocolSetup } from '..'
-import { fireEvent } from '@testing-library/dom'
 
 jest.mock('../MetadataCard')
 jest.mock('../RunSetupCard')
-jest.mock('@opentrons/components/src/alerts')
+jest.mock('../LabwareOffsetSuccessToast')
 
 const mockMetadataCard = MetadataCard as jest.MockedFunction<
   typeof MetadataCard
@@ -18,21 +17,21 @@ const mockMetadataCard = MetadataCard as jest.MockedFunction<
 const mockRunSetupCard = RunSetupCard as jest.MockedFunction<
   typeof RunSetupCard
 >
-const mockAlertItem = AlertItem as jest.MockedFunction<typeof AlertItem>
+const mockLabwareOffsetSuccessToast = LabwareOffsetSuccessToast as jest.MockedFunction<
+  typeof LabwareOffsetSuccessToast
+>
 
 describe('ProtocolSetup', () => {
   const render = () => {
-    return renderWithProviders(<ProtocolSetup />, { i18nInstance: i18n })[0]
+    return renderWithProviders(<ProtocolSetup />)[0]
   }
 
   beforeEach(() => {
     mockMetadataCard.mockReturnValue(<div>Mock MetadataCard</div>)
     mockRunSetupCard.mockReturnValue(<div>Mock ReunSetupCard</div>)
-    mockAlertItem.mockReturnValue(<div>Mock AlertItem</div>)
-  })
-
-  afterEach(() => {
-    jest.resetAllMocks()
+    mockLabwareOffsetSuccessToast.mockReturnValue(
+      <div>Mock LabwareOffsetSuccessToast</div>
+    )
   })
 
   it('renders metadata and run setup card', () => {
@@ -42,7 +41,7 @@ describe('ProtocolSetup', () => {
   })
   it('renders LPC success toast and is clickable', () => {
     const { getByText } = render()
-    const successToast = getByText('Mock AlertItem')
+    const successToast = getByText('Mock LabwareOffsetSuccessToast')
     fireEvent.click(successToast)
   })
 })

--- a/app/src/organisms/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/organisms/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import '@testing-library/jest-dom'
 import { fireEvent } from '@testing-library/dom'
 import { renderWithProviders } from '@opentrons/components'
+import { i18n } from '../../../i18n'
 import { RunSetupCard } from '../RunSetupCard'
 import { MetadataCard } from '../MetadataCard'
 import { LabwareOffsetSuccessToast } from '../LabwareOffsetSuccessToast'
@@ -23,7 +24,9 @@ const mockLabwareOffsetSuccessToast = LabwareOffsetSuccessToast as jest.MockedFu
 
 describe('ProtocolSetup', () => {
   const render = () => {
-    return renderWithProviders(<ProtocolSetup />)[0]
+    return renderWithProviders(<ProtocolSetup />, {
+      i18nInstance: i18n,
+    })[0]
   }
 
   beforeEach(() => {

--- a/app/src/organisms/ProtocolSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/index.tsx
@@ -20,7 +20,6 @@ import { LabwareOffsetSuccessToast } from './LabwareOffsetSuccessToast'
 
 export function ProtocolSetup(): JSX.Element {
   const { t } = useTranslation(['protocol_upload'])
-
   const [showLPCSuccessToast, setShowLPCSuccessToast] = React.useState(true)
 
   return (

--- a/app/src/organisms/ProtocolSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/index.tsx
@@ -9,6 +9,9 @@ import {
   Flex,
   Text,
   Link,
+  AlertItem,
+  SPACING_1,
+  SPACING_2,
 } from '@opentrons/components'
 import { RunSetupCard } from './RunSetupCard'
 import { MetadataCard } from './MetadataCard'
@@ -18,22 +21,39 @@ const feedbackFormLink =
 
 export function ProtocolSetup(): JSX.Element {
   const { t } = useTranslation('protocol_setup')
+  const [dismissed, setDismissed] = React.useState(false)
   return (
-    <Flex
-      flexDirection={DIRECTION_COLUMN}
-      padding={SPACING_3}
-      alignItems={ALIGN_CENTER}
-    >
-      <MetadataCard />
-      <RunSetupCard />
-      <Text
-        fontSize={FONT_SIZE_BODY_2}
-        paddingTop={SPACING_3}
-        color={C_DARK_GRAY}
+    <>
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        padding={`${SPACING_1} ${SPACING_2} ${SPACING_1} ${SPACING_2}`}
       >
-        {t('protocol_upload_revamp_feedback')}
-        <Link href={feedbackFormLink}> {t('feedback_form_link')}</Link>
-      </Text>
-    </Flex>
+        {!dismissed && (
+          <AlertItem
+            type="success"
+            onCloseClick={() => setDismissed(true)}
+            title={t('labware_positon_check_complete_toast', {
+              num_offsets: 2, //  TODO wire up num_offsets!
+            })}
+          />
+        )}
+      </Flex>
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        alignItems={ALIGN_CENTER}
+        padding={`${SPACING_1} ${SPACING_3} ${SPACING_3} ${SPACING_3}`}
+      >
+        <MetadataCard />
+        <RunSetupCard />
+        <Text
+          fontSize={FONT_SIZE_BODY_2}
+          paddingTop={SPACING_3}
+          color={C_DARK_GRAY}
+        >
+          {t('protocol_upload_revamp_feedback')}
+          <Link href={feedbackFormLink}> {t('feedback_form_link')}</Link>
+        </Text>
+      </Flex>
+    </>
   )
 }

--- a/app/src/organisms/ProtocolSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/index.tsx
@@ -20,18 +20,19 @@ const feedbackFormLink =
   'https://docs.google.com/forms/d/e/1FAIpQLSd6oSV82IfgzSi5t_FP6n_pB_Y8wPGmAgFHsiiFho9qhxr-UQ/viewform'
 
 export function ProtocolSetup(): JSX.Element {
-  const { t } = useTranslation('protocol_setup')
-  const [dismissed, setDismissed] = React.useState(false)
+  const { t } = useTranslation('protocol_info')
+  const [checkToastDismissed, setCheckToastDismissed] = React.useState(false)
+
   return (
     <>
       <Flex
         flexDirection={DIRECTION_COLUMN}
-        padding={`${SPACING_1} ${SPACING_2} ${SPACING_1} ${SPACING_2}`}
+        padding={`${SPACING_1} ${SPACING_2}`}
       >
-        {!dismissed && (
+        {!checkToastDismissed && (
           <AlertItem
             type="success"
-            onCloseClick={() => setDismissed(true)}
+            onCloseClick={() => setCheckToastDismissed(true)}
             title={t('labware_positon_check_complete_toast', {
               num_offsets: 2, //  TODO wire up num_offsets!
             })}

--- a/app/src/organisms/ProtocolSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/index.tsx
@@ -19,7 +19,7 @@ const feedbackFormLink =
   'https://docs.google.com/forms/d/e/1FAIpQLSd6oSV82IfgzSi5t_FP6n_pB_Y8wPGmAgFHsiiFho9qhxr-UQ/viewform'
 
 export function ProtocolSetup(): JSX.Element {
-  const { t } = useTranslation(['protocol_upload'])
+  const { t } = useTranslation(['protocol_setup'])
   const [showLPCSuccessToast, setShowLPCSuccessToast] = React.useState(true)
 
   return (

--- a/app/src/organisms/ProtocolSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/index.tsx
@@ -9,36 +9,27 @@ import {
   Flex,
   Text,
   Link,
-  AlertItem,
   SPACING_1,
-  SPACING_2,
 } from '@opentrons/components'
 import { RunSetupCard } from './RunSetupCard'
 import { MetadataCard } from './MetadataCard'
 
 const feedbackFormLink =
   'https://docs.google.com/forms/d/e/1FAIpQLSd6oSV82IfgzSi5t_FP6n_pB_Y8wPGmAgFHsiiFho9qhxr-UQ/viewform'
+import { LabwareOffsetSuccessToast } from './LabwareOffsetSuccessToast'
 
 export function ProtocolSetup(): JSX.Element {
-  const { t } = useTranslation('protocol_info')
-  const [checkToastDismissed, setCheckToastDismissed] = React.useState(false)
+  const { t } = useTranslation(['protocol_upload'])
+
+  const [showLPCSuccessToast, setShowLPCSuccessToast] = React.useState(true)
 
   return (
     <>
-      <Flex
-        flexDirection={DIRECTION_COLUMN}
-        padding={`${SPACING_1} ${SPACING_2}`}
-      >
-        {!checkToastDismissed && (
-          <AlertItem
-            type="success"
-            onCloseClick={() => setCheckToastDismissed(true)}
-            title={t('labware_positon_check_complete_toast', {
-              num_offsets: 2, //  TODO wire up num_offsets!
-            })}
-          />
-        )}
-      </Flex>
+      {showLPCSuccessToast && (
+        <LabwareOffsetSuccessToast
+          onCloseClick={() => setShowLPCSuccessToast(false)}
+        />
+      )}
       <Flex
         flexDirection={DIRECTION_COLUMN}
         alignItems={ALIGN_CENTER}

--- a/app/src/organisms/ProtocolSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/index.tsx
@@ -11,12 +11,12 @@ import {
   Link,
   SPACING_1,
 } from '@opentrons/components'
+import { LabwareOffsetSuccessToast } from './LabwareOffsetSuccessToast'
 import { RunSetupCard } from './RunSetupCard'
 import { MetadataCard } from './MetadataCard'
 
 const feedbackFormLink =
   'https://docs.google.com/forms/d/e/1FAIpQLSd6oSV82IfgzSi5t_FP6n_pB_Y8wPGmAgFHsiiFho9qhxr-UQ/viewform'
-import { LabwareOffsetSuccessToast } from './LabwareOffsetSuccessToast'
 
 export function ProtocolSetup(): JSX.Element {
   const { t } = useTranslation(['protocol_upload'])


### PR DESCRIPTION
# Overview

closes #8486 - currently only addresses the UI stuff in the ticket

# Changelog

- adds LPC success toast to `ProtocolSetup` and creates test

# Review requests

- review [figma](https://www.figma.com/file/JCQNOTTK9tTmYPhRqeOfSj/Milestone-0%3A-Protocol-Upload-Revamp?node-id=4213%3A52835)

# Risk assessment

low, behind ff