### PR TITLE
feat(app): LPC: warn about offset destruction

### DIFF
--- a/app/src/assets/localization/en/labware_position_check.json
+++ b/app/src/assets/localization/en/labware_position_check.json
@@ -43,7 +43,7 @@
   "check_labware_in_slot_title": "Check Labware {{labware_display_name}} in slot {{slot}}",
   "module_display_location_text": "{{moduleName}} in Deck Slot {{slot}}",
   "labware_display_location_text": "Deck Slot {{slot}}",
-  "labware_deleted_warning": "Once you begin Labware Position Check, previously created Labware Offsets will be discarded.",
+  "labware_offsets_deleted_warning": "Once you begin Labware Position Check, previously created Labware Offsets will be discarded.",
   "exit_screen_title": "Exit before completing Labware Position Check?",
   "exit_screen_subtitle": "If you exit now, all labware offsets will be discarded. This cannot be undone.",
   "exit_screen_go_back": "Go back to labware position check",

--- a/app/src/assets/localization/en/labware_position_check.json
+++ b/app/src/assets/localization/en/labware_position_check.json
@@ -42,5 +42,10 @@
   "returning_tip_title": "Returning tip in slot {{slot}}",
   "check_labware_in_slot_title": "Check Labware {{labware_display_name}} in slot {{slot}}",
   "module_display_location_text": "{{moduleName}} in Deck Slot {{slot}}",
-  "labware_display_location_text": "Deck Slot {{slot}}"
+  "labware_display_location_text": "Deck Slot {{slot}}",
+  "labware_deleted_warning": "Once you begin Labware Position Check, previously created Labware Offsets will be discarded.",
+  "exit_screen_title": "Exit before completing Labware Position Check?",
+  "exit_screen_subtitle": "If you exit now, all labware offsets will be discarded. This cannot be undone.",
+  "exit_screen_go_back": "Go back to labware position check",
+  "exit_screen_confirm_exit": "Exit and discard all labware offsets"
 }

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/ExitPreventionModal.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/ExitPreventionModal.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Flex,
+  Modal,
+  Text,
+  PrimaryBtn,
+  SecondaryBtn,
+  SPACING_2,
+  SPACING_3,
+  SPACING_4,
+  C_BLUE,
+  TEXT_TRANSFORM_UPPERCASE,
+  FONT_WEIGHT_SEMIBOLD,
+  ALIGN_CENTER,
+  JUSTIFY_SPACE_EVENLY,
+} from '@opentrons/components'
+import styles from '../styles.css'
+
+interface ExitPreventionModalProps {
+  onGoBack: () => void
+  onConfirmExit: () => void
+}
+
+export const ExitPreventionModal = (
+  props: ExitPreventionModalProps
+): JSX.Element => {
+  const { t } = useTranslation('labware_position_check')
+
+  return (
+    <Modal className={styles.modal} contentsClassName={styles.modal_contents}>
+      <Text
+        as={'h3'}
+        marginBottom={SPACING_3}
+        textTransform={TEXT_TRANSFORM_UPPERCASE}
+        fontWeight={FONT_WEIGHT_SEMIBOLD}
+        marginLeft={SPACING_3}
+      >
+        {t('exit_screen_title')}
+      </Text>
+      <Text marginBottom={SPACING_4} marginLeft={SPACING_3}>
+        {t('exit_screen_subtitle')}
+      </Text>
+      <Flex
+        padding={SPACING_2}
+        justifyContent={JUSTIFY_SPACE_EVENLY}
+        alignItems={ALIGN_CENTER}
+        width="100%"
+      >
+        <SecondaryBtn onClick={props.onGoBack} color={C_BLUE}>
+          {t('exit_screen_go_back')}
+        </SecondaryBtn>
+        <PrimaryBtn onClick={props.onConfirmExit} backgroundColor={C_BLUE}>
+          {t('exit_screen_confirm_exit')}
+        </PrimaryBtn>
+      </Flex>
+    </Modal>
+  )
+}

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/ExitPreventionModal.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/ExitPreventionModal.tsx
@@ -12,7 +12,6 @@ import {
   C_BLUE,
   TEXT_TRANSFORM_UPPERCASE,
   FONT_WEIGHT_SEMIBOLD,
-  ALIGN_CENTER,
   JUSTIFY_SPACE_EVENLY,
 } from '@opentrons/components'
 import styles from '../styles.css'
@@ -41,12 +40,7 @@ export const ExitPreventionModal = (
       <Text marginBottom={SPACING_4} marginLeft={SPACING_3}>
         {t('exit_screen_subtitle')}
       </Text>
-      <Flex
-        padding={SPACING_2}
-        justifyContent={JUSTIFY_SPACE_EVENLY}
-        alignItems={ALIGN_CENTER}
-        width="100%"
-      >
+      <Flex padding={SPACING_2} justifyContent={JUSTIFY_SPACE_EVENLY}>
         <SecondaryBtn onClick={props.onGoBack} color={C_BLUE}>
           {t('exit_screen_go_back')}
         </SecondaryBtn>

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/IntroScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/IntroScreen.tsx
@@ -65,7 +65,7 @@ export const IntroScreen = (props: {
           block: <Text fontSize={FONT_SIZE_BODY_2} marginBottom={SPACING_2} />,
         }}
       ></Trans>
-      <AlertItem type="warning" title={t('labware_deleted_warning')} />
+      <AlertItem type="warning" title={t('labware_offsets_deleted_warning')} />
       <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} alignItems={ALIGN_CENTER}>
         <Flex marginLeft={SPACING_6}>
           <SectionList

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/IntroScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/IntroScreen.tsx
@@ -5,6 +5,7 @@ import {
   Text,
   Flex,
   Box,
+  AlertItem,
   useInterval,
   TEXT_TRANSFORM_UPPERCASE,
   FONT_WEIGHT_SEMIBOLD,
@@ -64,6 +65,7 @@ export const IntroScreen = (props: {
           block: <Text fontSize={FONT_SIZE_BODY_2} marginBottom={SPACING_2} />,
         }}
       ></Trans>
+      <AlertItem type="warning" title={t('labware_deleted_warning')} />
       <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} alignItems={ALIGN_CENTER}>
         <Flex marginLeft={SPACING_6}>
           <SectionList

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/ExitPreventionModal.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/ExitPreventionModal.test.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react'
+import { fireEvent } from '@testing-library/react'
+import { ExitPreventionModal } from '../ExitPreventionModal'
+import { i18n } from '../../../../i18n'
+import { renderWithProviders } from '@opentrons/components'
+
+const render = (props: React.ComponentProps<typeof ExitPreventionModal>) => {
+  return renderWithProviders(<ExitPreventionModal {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+describe('Exit Prevention Modal', () => {
+  let props: React.ComponentProps<typeof ExitPreventionModal>
+  beforeEach(() => {
+    props = { onGoBack: jest.fn(), onConfirmExit: jest.fn() }
+  })
+  it('should render the correct header', () => {
+    const { getByRole } = render(props)
+    expect(
+      getByRole('heading', {
+        name: 'Exit before completing Labware Position Check?',
+      })
+    ).toBeTruthy()
+  })
+  it('should render the correct body text', () => {
+    const { getByText } = render(props)
+    getByText(
+      'If you exit now, all labware offsets will be discarded. This cannot be undone.'
+    )
+  })
+  it('should call onGoBack when left button is pressed', () => {
+    const { getByRole } = render(props)
+    const goBackButton = getByRole('button', {
+      name: 'Go back to labware position check',
+    })
+    fireEvent.click(goBackButton)
+    expect(props.onGoBack).toHaveBeenCalled()
+  })
+  it('should call onConfirmExit when right button is pressed', () => {
+    const { getByRole } = render(props)
+    const confirmExitButton = getByRole('button', {
+      name: 'Exit and discard all labware offsets',
+    })
+    fireEvent.click(confirmExitButton)
+    expect(props.onConfirmExit).toHaveBeenCalled()
+  })
+})

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/IntroScreen.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/IntroScreen.test.tsx
@@ -120,6 +120,9 @@ describe('IntroScreen', () => {
     getByText(
       'When you check a labware, the OT-2’s pipette nozzle or attached tip will stop at the center of the A1 well. If the pipette nozzle or tip is not centered, you can reveal the OT-2’s jog controls to make an adjustment. This Labware Offset will be applied to the entire labware. Offset data is measured to the nearest 1/10th mm and can be made in the X, Y and/or Z directions.'
     )
+    getByText(
+      'Once you begin Labware Position Check, previously created Labware Offsets will be discarded.'
+    )
     getByText('Mock Section List')
   })
   it('should call beginLPC when the CTA button is pressed', () => {

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/LabwarePositionCheck.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/LabwarePositionCheck.test.tsx
@@ -8,6 +8,7 @@ import { GenericStepScreen } from '../GenericStepScreen'
 import { IntroScreen } from '../IntroScreen'
 import { SummaryScreen } from '../SummaryScreen'
 import { RobotMotionLoadingModal } from '../RobotMotionLoadingModal'
+import { ExitPreventionModal } from '../ExitPreventionModal'
 import { useSteps, useLabwarePositionCheck } from '../hooks'
 import { LabwarePositionCheckStep } from '../types'
 
@@ -15,6 +16,7 @@ jest.mock('../GenericStepScreen')
 jest.mock('../IntroScreen')
 jest.mock('../SummaryScreen')
 jest.mock('../RobotMotionLoadingModal')
+jest.mock('../ExitPreventionModal')
 jest.mock('../hooks')
 
 const mockGenericStepScreen = GenericStepScreen as jest.MockedFunction<
@@ -26,6 +28,9 @@ const mockSummaryScreen = SummaryScreen as jest.MockedFunction<
 >
 const mockRobotMotionLoadingModal = RobotMotionLoadingModal as jest.MockedFunction<
   typeof RobotMotionLoadingModal
+>
+const mockExitPreventionModal = ExitPreventionModal as jest.MockedFunction<
+  typeof ExitPreventionModal
 >
 
 const mockUseSteps = useSteps as jest.MockedFunction<typeof useSteps>
@@ -83,6 +88,9 @@ describe('LabwarePositionCheck', () => {
     when(mockSummaryScreen)
       .calledWith(anyProps())
       .mockReturnValue(<div>Mock Summary Screen Component </div>)
+    when(mockExitPreventionModal)
+      .calledWith(anyProps())
+      .mockReturnValue(<div>Mock Exit Prevention Modal</div>)
   })
   afterEach(() => {
     resetAllWhenMocks()
@@ -97,14 +105,15 @@ describe('LabwarePositionCheck', () => {
       name: 'exit',
     })
   })
-  it('renders LabwarePositionCheck header and exit button is pressed', () => {
-    const { getByRole } = render(props)
+  it('prevention modal opens when exit button is pressed', () => {
+    const { getByRole, getByText } = render(props)
     expect(props.onCloseClick).not.toHaveBeenCalled()
     const exitButton = getByRole('button', {
       name: 'exit',
     })
     fireEvent.click(exitButton)
-    expect(props.onCloseClick).toHaveBeenCalled()
+    expect(mockExitPreventionModal).toHaveBeenCalled()
+    getByText('Mock Exit Prevention Modal')
   })
   // TODO: fix after wiring up
   it.todo('renders LabwarePositionCheck with Summary Screen component')

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
@@ -6,6 +6,7 @@ import {
   ModalPage,
   SPACING_2,
   Text,
+  useConditionalConfirm,
 } from '@opentrons/components'
 import { Portal } from '../../../App/portal'
 import { useRestartRun } from '../../ProtocolUpload/hooks/useRestartRun'
@@ -32,7 +33,12 @@ export const LabwarePositionCheck = (
     setSavePositionCommandData,
   ] = React.useState<SavePositionCommandData>({})
   const [isRestartingRun, setIsRestartingRun] = React.useState<boolean>(false)
-  const [exitAttempt, setExitAttempt] = React.useState(false)
+
+  const {
+    confirm: confirmExitLPC,
+    showConfirmation,
+    cancel: cancelExitLPC,
+  } = useConditionalConfirm(props.onCloseClick, true)
 
   // at the end of LPC, each labwareId will have 2 associated save position command ids which will be used to calculate the labware offsets
   const addSavePositionCommandData = (
@@ -95,14 +101,11 @@ export const LabwarePositionCheck = (
   let modalContent: JSX.Element
   if (isLoading) {
     modalContent = <RobotMotionLoadingModal title={titleText} />
-  } else if (exitAttempt) {
+  } else if (showConfirmation) {
     modalContent = (
       <ExitPreventionModal
-        onGoBack={() => setExitAttempt(false)}
-        onConfirmExit={() => {
-          setExitAttempt(false)
-          props.onCloseClick()
-        }}
+        onGoBack={cancelExitLPC}
+        onConfirmExit={confirmExitLPC}
       />
     )
   } else {
@@ -112,7 +115,7 @@ export const LabwarePositionCheck = (
         titleBar={{
           title: t('labware_position_check_title'),
           back: {
-            onClick: () => setExitAttempt(true),
+            onClick: confirmExitLPC,
             title: t('shared:exit'),
             children: t('shared:exit'),
           },

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
@@ -14,6 +14,7 @@ import { IntroScreen } from './IntroScreen'
 import { GenericStepScreen } from './GenericStepScreen'
 import { SummaryScreen } from './SummaryScreen'
 import { RobotMotionLoadingModal } from './RobotMotionLoadingModal'
+import { ExitPreventionModal } from './ExitPreventionModal'
 
 import styles from '../styles.css'
 import type { SavePositionCommandData } from './types'
@@ -31,6 +32,7 @@ export const LabwarePositionCheck = (
     setSavePositionCommandData,
   ] = React.useState<SavePositionCommandData>({})
   const [isRestartingRun, setIsRestartingRun] = React.useState<boolean>(false)
+  const [exitAttempt, setExitAttempt] = React.useState(false)
 
   // at the end of LPC, each labwareId will have 2 associated save position command ids which will be used to calculate the labware offsets
   const addSavePositionCommandData = (
@@ -97,13 +99,22 @@ export const LabwarePositionCheck = (
         titleBar={{
           title: t('labware_position_check_title'),
           back: {
-            onClick: props.onCloseClick,
+            onClick: () => setExitAttempt(true),
             title: t('shared:exit'),
             children: t('shared:exit'),
           },
         }}
       >
         {isLoading ? <RobotMotionLoadingModal title={titleText} /> : null}
+        {exitAttempt ? (
+          <ExitPreventionModal
+            onGoBack={() => setExitAttempt(false)}
+            onConfirmExit={() => {
+              setExitAttempt(false)
+              props.onCloseClick()
+            }}
+          />
+        ) : null}
         {isComplete ? (
           <SummaryScreen savePositionCommandData={savePositionCommandData} />
         ) : currentCommandIndex !== 0 ? (

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
@@ -92,8 +92,21 @@ export const LabwarePositionCheck = (
     jog,
   } = labwarePositionCheckUtils
 
-  return (
-    <Portal level="top">
+  let modalContent: JSX.Element
+  if (isLoading) {
+    modalContent = <RobotMotionLoadingModal title={titleText} />
+  } else if (exitAttempt) {
+    modalContent = (
+      <ExitPreventionModal
+        onGoBack={() => setExitAttempt(false)}
+        onConfirmExit={() => {
+          setExitAttempt(false)
+          props.onCloseClick()
+        }}
+      />
+    )
+  } else {
+    modalContent = (
       <ModalPage
         contentsClassName={styles.modal_contents}
         titleBar={{
@@ -105,16 +118,6 @@ export const LabwarePositionCheck = (
           },
         }}
       >
-        {isLoading ? <RobotMotionLoadingModal title={titleText} /> : null}
-        {exitAttempt ? (
-          <ExitPreventionModal
-            onGoBack={() => setExitAttempt(false)}
-            onConfirmExit={() => {
-              setExitAttempt(false)
-              props.onCloseClick()
-            }}
-          />
-        ) : null}
         {isComplete ? (
           <SummaryScreen savePositionCommandData={savePositionCommandData} />
         ) : currentCommandIndex !== 0 ? (
@@ -129,6 +132,7 @@ export const LabwarePositionCheck = (
           <IntroScreen beginLPC={beginLPC} />
         )}
       </ModalPage>
-    </Portal>
-  )
+    )
+  }
+  return <Portal level="top">{modalContent}</Portal>
 }


### PR DESCRIPTION
close #8684

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Add alert that previous offsets will be discarded, add exit prevention modal

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

1. Add alert to main LPC page warning that previous offsets will be discarded once you begin
2. Add exit prevention modal that warns all offsets will be discarded when you exit in the middle of the flow

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Confirm alert is present
Confirm that exit prevention modal appears when you press exit and modal buttons work as expected
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Low