### PR TITLE
refactor(app): update run status for rendering cancel run

### DIFF
--- a/app/src/organisms/RunDetails/index.tsx
+++ b/app/src/organisms/RunDetails/index.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { RUN_STATUS_RUNNING } from '@opentrons/api-client'
+import {
+  RunStatus,
+  RUN_STATUS_IDLE,
+  RUN_STATUS_RUNNING,
+} from '@opentrons/api-client'
 import {
   PrimaryBtn,
   BORDER_WIDTH_DEFAULT,
@@ -14,7 +18,7 @@ import {
 } from '@opentrons/components'
 import { Page } from '../../atoms/Page'
 import { useProtocolDetails } from './hooks'
-import { useRunStatus } from '../RunTimeControl/hooks'
+import { useRunStatus, useRunStartTime } from '../RunTimeControl/hooks'
 import { ConfirmCancelModal } from '../../pages/Run/RunLog'
 import { useCurrentRunControls } from '../../pages/Run/RunLog/hooks'
 import { CommandList } from './CommandList'
@@ -23,6 +27,14 @@ export function RunDetails(): JSX.Element | null {
   const { t } = useTranslation('run_details')
   const { displayName } = useProtocolDetails()
   const runStatus = useRunStatus()
+  const startTime = useRunStartTime()
+
+  // display an idle status as 'running' in the UI after a run has started
+  const adjustedRunStatus: RunStatus | null =
+    runStatus === RUN_STATUS_IDLE && startTime != null
+      ? RUN_STATUS_RUNNING
+      : runStatus
+
   const { pauseRun } = useCurrentRunControls()
 
   const cancelRunAndExit = (): void => {
@@ -53,7 +65,7 @@ export function RunDetails(): JSX.Element | null {
   )
 
   const titleBarProps =
-    runStatus === RUN_STATUS_RUNNING
+    adjustedRunStatus === RUN_STATUS_RUNNING
       ? {
           title: t('protocol_title', { protocol_name: displayName }),
           rightNode: cancelRunButton,

--- a/app/src/pages/Run/RunLog/ConfirmCancelModal.tsx
+++ b/app/src/pages/Run/RunLog/ConfirmCancelModal.tsx
@@ -26,8 +26,8 @@ export function ConfirmCancelModal(
       <AlertModal
         heading={t('cancel_run_modal_heading')}
         buttons={[
-          { children: t('cancel_run_modal_confirm'), onClick: onClose },
-          { children: t('cancel_run_modal_back'), onClick: cancel },
+          { children: t('cancel_run_modal_back'), onClick: onClose },
+          { children: t('cancel_run_modal_confirm'), onClick: cancel },
         ]}
         alertOverlay
       >


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR is an update to the wiring up of the cancel run button and modal

# Changelog

- Create adjusted run status that considers an `idle` status as `running` to render the cancel run button consistently once a play action has been triggered.
- Place the copies for the buttons in the modal in the correct positions.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

- [ ] Check that the cancel run button is rendering properly and is able to trigger a stop action on a run.
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
