### PR TITLE
feat(app): wire up calibration status to protocol details

### DIFF
--- a/app/src/organisms/ProtocolSetup/RunSetupCard/hooks/__tests__/useProtocolCalibrationStatus.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/hooks/__tests__/useProtocolCalibrationStatus.test.tsx
@@ -68,7 +68,6 @@ describe('useProtocolCalibrationStatus hook', () => {
       left: {
         requestedPipetteMatch: 'incompatible',
         pipetteCalDate: null,
-        // @ts-expect-error partial type match
         pipetteSpecs: {
           displayName: 'pipette 1',
         },
@@ -81,7 +80,7 @@ describe('useProtocolCalibrationStatus hook', () => {
         ],
       },
       right: null,
-    })
+    } as any)
     const { result } = renderHook(useProtocolCalibrationStatus, { wrapper })
     expect(result.current).toMatchObject({
       complete: false,
@@ -96,7 +95,6 @@ describe('useProtocolCalibrationStatus hook', () => {
       left: {
         requestedPipetteMatch: 'match',
         pipetteCalDate: null,
-        // @ts-expect-error partial type match
         pipetteSpecs: {
           displayName: 'pipette 1',
         },
@@ -109,7 +107,7 @@ describe('useProtocolCalibrationStatus hook', () => {
         ],
       },
       right: null,
-    })
+    } as any)
     const { result } = renderHook(useProtocolCalibrationStatus, { wrapper })
     expect(result.current).toMatchObject({
       complete: false,
@@ -124,21 +122,19 @@ describe('useProtocolCalibrationStatus hook', () => {
       left: {
         requestedPipetteMatch: 'match',
         pipetteCalDate: '2020-08-30T10:02',
-        // @ts-expect-error partial type match
         pipetteSpecs: {
           displayName: 'pipette 1',
         },
         tipRacksForPipette: [
           {
             displayName: 'Mock TipRack Definition',
-            // @ts-expect-error incorrect type
             lastModifiedDate: null,
             tipRackDef: mockTipRackDefinition,
           },
         ],
       },
       right: null,
-    })
+    } as any)
     const { result } = renderHook(useProtocolCalibrationStatus, { wrapper })
     expect(result.current).toMatchObject({
       complete: false,
@@ -153,7 +149,6 @@ describe('useProtocolCalibrationStatus hook', () => {
       left: {
         requestedPipetteMatch: 'match',
         pipetteCalDate: '2020-08-30T10:02',
-        // @ts-expect-error partial type match
         pipetteSpecs: {
           displayName: 'pipette 1',
         },
@@ -166,7 +161,7 @@ describe('useProtocolCalibrationStatus hook', () => {
         ],
       },
       right: null,
-    })
+    } as any)
     const { result } = renderHook(useProtocolCalibrationStatus, { wrapper })
     expect(result.current).toMatchObject({
       complete: true,

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/hooks/__tests__/useProtocolCalibrationStatus.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/hooks/__tests__/useProtocolCalibrationStatus.test.tsx
@@ -1,27 +1,175 @@
 import * as React from 'react'
+import { renderHook } from '@testing-library/react-hooks'
 import { when, resetAllWhenMocks } from 'jest-when'
 import { Provider } from 'react-redux'
 import { createStore } from 'redux'
-import * as discoverySelectors from '../../../../../redux/discovery/selectors'
-import { useModuleRenderInfoById } from '../../../hooks'
-import { getAttachedModules } from '../../../../../redux/modules'
-import { mockConnectedRobot } from '../../../../../redux/discovery/__fixtures__'
-import { renderHook } from '@testing-library/react-hooks'
-import { useMissingModuleIds } from '..'
+import { getConnectedRobotName } from '../../../../../redux/robot/selectors'
+import { getDeckCalibrationStatus } from '../../../../../redux/calibration/selectors'
+import { mockTipRackDefinition } from '../../../../../redux/custom-labware/__fixtures__'
+import { useCurrentRunPipetteInfoByMount } from '../useCurrentRunPipetteInfoByMount'
+import { useProtocolCalibrationStatus } from '../useProtocolCalibrationStatus'
 import type { Store } from 'redux'
 import type { State } from '../../../../../redux/types'
-import type { ModuleModel, ModuleType } from '@opentrons/shared-data'
 
-jest.mock('../../../hooks')
-jest.mock('../../../../../redux/modules')
-jest.mock('../../../../../redux/discovery/selectors')
+jest.mock('../../../../../redux/robot/selectors')
+jest.mock('../../../../../redux/calibration/selectors')
+jest.mock('../useCurrentRunPipetteInfoByMount')
 
-const mockUseModuleRenderInfoById = useModuleRenderInfoById as jest.MockedFunction<
-  typeof useModuleRenderInfoById
+const mockGetConnectedRobotName = getConnectedRobotName as jest.MockedFunction<
+  typeof getConnectedRobotName
 >
-const mockGetConnectedRobot = discoverySelectors.getConnectedRobot as jest.MockedFunction<
-  typeof discoverySelectors.getConnectedRobot
+const mockGetDeckCalibrationStatus = getDeckCalibrationStatus as jest.MockedFunction<
+  typeof getDeckCalibrationStatus
 >
-const mockGetAttachedModules = getAttachedModules as jest.MockedFunction<
-  typeof getAttachedModules
+const mockUseCurrentRunPipetteInfoByMount = useCurrentRunPipetteInfoByMount as jest.MockedFunction<
+  typeof useCurrentRunPipetteInfoByMount
 >
+
+describe('useProtocolCalibrationStatus hook', () => {
+  const store: Store<State> = createStore(jest.fn(), {})
+
+  beforeEach(() => {
+    store.dispatch = jest.fn()
+
+    when(mockGetConnectedRobotName)
+      .calledWith(undefined as any)
+      .mockReturnValue('robot name')
+
+    when(mockGetDeckCalibrationStatus)
+      .calledWith(undefined as any, 'robot name')
+      .mockReturnValue('OK')
+
+    when(mockUseCurrentRunPipetteInfoByMount).calledWith().mockReturnValue({
+      left: null,
+      right: null,
+    })
+  })
+
+  afterEach(() => {
+    resetAllWhenMocks()
+    jest.restoreAllMocks()
+  })
+  it('should return deck cal failure if not calibrated', () => {
+    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+      <Provider store={store}>{children}</Provider>
+    )
+    mockGetDeckCalibrationStatus.mockReturnValue('BAD_CALIBRATION')
+    const { result } = renderHook(useProtocolCalibrationStatus, { wrapper })
+    expect(result.current).toMatchObject({
+      complete: false,
+      reason: 'calibrate_deck_failure_reason',
+    })
+  })
+  it('should return attach pipette if missing', () => {
+    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+      <Provider store={store}>{children}</Provider>
+    )
+    mockUseCurrentRunPipetteInfoByMount.mockReturnValue({
+      left: {
+        requestedPipetteMatch: 'incompatible',
+        pipetteCalDate: null,
+        // @ts-expect-error partial type match
+        pipetteSpecs: {
+          displayName: 'pipette 1',
+        },
+        tipRacksForPipette: [
+          {
+            displayName: 'Mock TipRack Definition',
+            lastModifiedDate: '',
+            tipRackDef: mockTipRackDefinition,
+          },
+        ],
+      },
+      right: null,
+    })
+    const { result } = renderHook(useProtocolCalibrationStatus, { wrapper })
+    expect(result.current).toMatchObject({
+      complete: false,
+      reason: 'attach_pipette_failure_reason',
+    })
+  })
+  it('should return calibrate pipette if cal date null', () => {
+    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+      <Provider store={store}>{children}</Provider>
+    )
+    mockUseCurrentRunPipetteInfoByMount.mockReturnValue({
+      left: {
+        requestedPipetteMatch: 'match',
+        pipetteCalDate: null,
+        // @ts-expect-error partial type match
+        pipetteSpecs: {
+          displayName: 'pipette 1',
+        },
+        tipRacksForPipette: [
+          {
+            displayName: 'Mock TipRack Definition',
+            lastModifiedDate: '',
+            tipRackDef: mockTipRackDefinition,
+          },
+        ],
+      },
+      right: null,
+    })
+    const { result } = renderHook(useProtocolCalibrationStatus, { wrapper })
+    expect(result.current).toMatchObject({
+      complete: false,
+      reason: 'calibrate_pipette_failure_reason',
+    })
+  })
+  it('should return calibrate tip rack if cal date null', () => {
+    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+      <Provider store={store}>{children}</Provider>
+    )
+    mockUseCurrentRunPipetteInfoByMount.mockReturnValue({
+      left: {
+        requestedPipetteMatch: 'match',
+        pipetteCalDate: '2020-08-30T10:02',
+        // @ts-expect-error partial type match
+        pipetteSpecs: {
+          displayName: 'pipette 1',
+        },
+        tipRacksForPipette: [
+          {
+            displayName: 'Mock TipRack Definition',
+            // @ts-expect-error incorrect type
+            lastModifiedDate: null,
+            tipRackDef: mockTipRackDefinition,
+          },
+        ],
+      },
+      right: null,
+    })
+    const { result } = renderHook(useProtocolCalibrationStatus, { wrapper })
+    expect(result.current).toMatchObject({
+      complete: false,
+      reason: 'calibrate_tiprack_failure_reason',
+    })
+  })
+  it('should return complete if everything is calibrated', () => {
+    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+      <Provider store={store}>{children}</Provider>
+    )
+    mockUseCurrentRunPipetteInfoByMount.mockReturnValue({
+      left: {
+        requestedPipetteMatch: 'match',
+        pipetteCalDate: '2020-08-30T10:02',
+        // @ts-expect-error partial type match
+        pipetteSpecs: {
+          displayName: 'pipette 1',
+        },
+        tipRacksForPipette: [
+          {
+            displayName: 'Mock TipRack Definition',
+            lastModifiedDate: '2020-08-30T10:02',
+            tipRackDef: mockTipRackDefinition,
+          },
+        ],
+      },
+      right: null,
+    })
+    const { result } = renderHook(useProtocolCalibrationStatus, { wrapper })
+    expect(result.current).toMatchObject({
+      complete: true,
+    })
+  })
+})

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/hooks/__tests__/useProtocolCalibrationStatus.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/hooks/__tests__/useProtocolCalibrationStatus.test.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react'
+import { when, resetAllWhenMocks } from 'jest-when'
+import { Provider } from 'react-redux'
+import { createStore } from 'redux'
+import * as discoverySelectors from '../../../../../redux/discovery/selectors'
+import { useModuleRenderInfoById } from '../../../hooks'
+import { getAttachedModules } from '../../../../../redux/modules'
+import { mockConnectedRobot } from '../../../../../redux/discovery/__fixtures__'
+import { renderHook } from '@testing-library/react-hooks'
+import { useMissingModuleIds } from '..'
+import type { Store } from 'redux'
+import type { State } from '../../../../../redux/types'
+import type { ModuleModel, ModuleType } from '@opentrons/shared-data'
+
+jest.mock('../../../hooks')
+jest.mock('../../../../../redux/modules')
+jest.mock('../../../../../redux/discovery/selectors')
+
+const mockUseModuleRenderInfoById = useModuleRenderInfoById as jest.MockedFunction<
+  typeof useModuleRenderInfoById
+>
+const mockGetConnectedRobot = discoverySelectors.getConnectedRobot as jest.MockedFunction<
+  typeof discoverySelectors.getConnectedRobot
+>
+const mockGetAttachedModules = getAttachedModules as jest.MockedFunction<
+  typeof getAttachedModules
+>

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/hooks/useProtocolCalibrationStatus.ts
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/hooks/useProtocolCalibrationStatus.ts
@@ -1,0 +1,68 @@
+import { useSelector } from 'react-redux'
+import { useCurrentRunPipetteInfoByMount } from './useCurrentRunPipetteInfoByMount'
+import { getConnectedRobotName } from '../../../../redux/robot/selectors'
+import { getDeckCalibrationStatus } from '../../../../redux/calibration/selectors'
+import { MATCH, INEXACT_MATCH } from '../../../../redux/pipettes'
+
+import type { State } from '../../../../redux/types'
+
+export interface ProtocolCalibrationStatus {
+  complete: boolean
+  reason?:
+    | 'calibrate_deck_failure_reason'
+    | 'calibrate_tiprack_failure_reason'
+    | 'calibrate_pipette_failure_reason'
+    | 'attach_pipette_failure_reason'
+}
+
+export function useProtocolCalibrationStatus(): ProtocolCalibrationStatus {
+  const robotName =
+    useSelector((state: State) => getConnectedRobotName(state)) ?? ''
+  const deckCalStatus = useSelector((state: State) =>
+    getDeckCalibrationStatus(state, robotName)
+  )
+  const currentRunPipetteInfoByMount = useCurrentRunPipetteInfoByMount()
+  const currentRunPipetteInfoValues = Object.values(
+    currentRunPipetteInfoByMount
+  )
+
+  if (deckCalStatus !== 'OK') {
+    return {
+      complete: false,
+      reason: 'calibrate_deck_failure_reason',
+    }
+  }
+  let calibrationStatus: ProtocolCalibrationStatus = {
+    complete: true,
+  }
+  currentRunPipetteInfoValues.forEach(pipette => {
+    pipette?.tipRacksForPipette.forEach(tiprack => {
+      if (tiprack.lastModifiedDate == null) {
+        calibrationStatus = {
+          complete: false,
+          reason: 'calibrate_tiprack_failure_reason',
+        }
+      }
+    })
+  })
+  currentRunPipetteInfoValues.forEach(pipette => {
+    if (pipette !== null && pipette.pipetteCalDate == null) {
+      calibrationStatus = {
+        complete: false,
+        reason: 'calibrate_pipette_failure_reason',
+      }
+    }
+  })
+  currentRunPipetteInfoValues.forEach(pipette => {
+    const pipetteIsMatch =
+      pipette?.requestedPipetteMatch === MATCH ||
+      pipette?.requestedPipetteMatch === INEXACT_MATCH
+    if (pipette !== null && !pipetteIsMatch) {
+      calibrationStatus = {
+        complete: false,
+        reason: 'attach_pipette_failure_reason',
+      }
+    }
+  })
+  return calibrationStatus
+}

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/index.tsx
@@ -21,7 +21,7 @@ import {
 import { protocolHasModules } from '@opentrons/shared-data'
 import { Divider } from '../../../atoms/structure'
 import { getConnectedRobot } from '../../../redux/discovery/selectors'
-import { getProtocolCalibrationComplete } from '../../../redux/calibration/selectors'
+import { useProtocolCalibrationStatus } from '../RunSetupCard/hooks/useProtocolCalibrationStatus'
 import { useProtocolDetails } from '../../RunDetails/hooks'
 import { CollapsibleStep } from './CollapsibleStep'
 import { ProceedToRunCta } from './ProceedToRunCta'
@@ -43,10 +43,7 @@ export function RunSetupCard(): JSX.Element | null {
   const { t } = useTranslation('protocol_setup')
   const { protocolData } = useProtocolDetails()
   const robot = useSelector((state: State) => getConnectedRobot(state))
-  const robotName = robot?.name != null ? robot?.name : ''
-  const calibrationStatus = useSelector((state: State) => {
-    return getProtocolCalibrationComplete(state, robotName)
-  })
+  const calibrationStatus = useProtocolCalibrationStatus()
 
   const [expandedStepKey, setExpandedStepKey] = React.useState<StepKey | null>(
     null

--- a/app/src/organisms/ProtocolSetup/__tests__/RunSetupCard.test.tsx
+++ b/app/src/organisms/ProtocolSetup/__tests__/RunSetupCard.test.tsx
@@ -24,6 +24,7 @@ import {
 } from '../../../redux/pipettes'
 import { mockCalibrationStatus } from '../../../redux/calibration/__fixtures__'
 import * as calibrationSelectors from '../../../redux/calibration/selectors'
+import { useProtocolCalibrationStatus } from '../RunSetupCard/hooks/useProtocolCalibrationStatus'
 import { useProtocolDetails } from '../../RunDetails/hooks'
 import { RunSetupCard } from '../RunSetupCard'
 import { ModuleSetup } from '../RunSetupCard/ModuleSetup'
@@ -39,6 +40,7 @@ import type {
 jest.mock('../../../redux/discovery/selectors')
 jest.mock('../../../redux/pipettes/selectors')
 jest.mock('../../../redux/calibration/selectors')
+jest.mock('../RunSetupCard/hooks/useProtocolCalibrationStatus')
 jest.mock('../../RunDetails/hooks')
 jest.mock('../RunSetupCard/LabwareSetup')
 jest.mock('../RunSetupCard/ModuleSetup')
@@ -85,8 +87,8 @@ const mockGetDeckCalData = calibrationSelectors.getDeckCalibrationData as jest.M
   typeof calibrationSelectors.getDeckCalibrationData
 >
 
-const mockGetProtocolCalibrationComplete = calibrationSelectors.getProtocolCalibrationComplete as jest.MockedFunction<
-  typeof calibrationSelectors.getProtocolCalibrationComplete
+const mockUseProtocolCalibrationStatus = useProtocolCalibrationStatus as jest.MockedFunction<
+  typeof useProtocolCalibrationStatus
 >
 
 const render = () => {
@@ -103,7 +105,7 @@ describe('RunSetupCard', () => {
     mockGetDeckCalData.mockReturnValue(
       mockCalibrationStatus.deckCalibration.data
     )
-    mockGetProtocolCalibrationComplete.mockReturnValue({ complete: true })
+    mockUseProtocolCalibrationStatus.mockReturnValue({ complete: true })
     mockUseProtocolDetails.mockReturnValue({
       protocolData: noModulesProtocol,
     } as any)
@@ -149,7 +151,7 @@ describe('RunSetupCard', () => {
       })
     })
     it('renders calibration needed when robot cal not complete', () => {
-      mockGetProtocolCalibrationComplete.mockReturnValue({ complete: false })
+      mockUseProtocolCalibrationStatus.mockReturnValue({ complete: false })
       const { getByText } = render()
       getByText('Calibration needed')
     })

--- a/app/src/organisms/RunDetails/ProtocolSetupInfo.tsx
+++ b/app/src/organisms/RunDetails/ProtocolSetupInfo.tsx
@@ -7,10 +7,7 @@ import {
   SPACING_2,
 } from '@opentrons/components'
 import { getModuleDisplayName, ProtocolFile } from '@opentrons/shared-data'
-import { getProtocolPipetteTipRackCalInfo } from '../../redux/pipettes'
-import { getConnectedRobot } from '../../redux/discovery'
-import { State } from '../../redux/types'
-import { useSelector } from 'react-redux'
+import { useCurrentRunPipetteInfoByMount } from '../ProtocolSetup/RunSetupCard/hooks'
 import { useProtocolDetails } from './hooks'
 import type { Command } from '@opentrons/shared-data/protocol/types/schemaV6'
 
@@ -25,11 +22,8 @@ export const ProtocolSetupInfo = (
   const { t } = useTranslation('run_details')
   const protocolData: ProtocolFile<{}> | null = useProtocolDetails()
     .protocolData
-  const robot = useSelector((state: State) => getConnectedRobot(state))
-  const robotName = robot?.name != null ? robot?.name : ''
-  const protocolPipetteData = useSelector((state: State) =>
-    getProtocolPipetteTipRackCalInfo(state, robotName)
-  )
+
+  const protocolPipetteData = useCurrentRunPipetteInfoByMount()
   if (protocolData == null) return null
   if (setupCommand === undefined) return null
   if (
@@ -51,7 +45,7 @@ export const ProtocolSetupInfo = (
         id={`RunDetails_PipetteSetup`}
         i18nKey={'load_pipette_protocol_setup'}
         values={{
-          pipette_name: pipetteData.pipetteDisplayName,
+          pipette_name: pipetteData.pipetteSpecs.displayName,
           mount_name: setupCommand.params.mount === 'left' ? 'Left' : 'Right',
         }}
       />

--- a/app/src/organisms/RunDetails/__tests__/ProtocolSetupInfo.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/ProtocolSetupInfo.test.tsx
@@ -4,8 +4,6 @@ import { nestedTextMatcher, renderWithProviders } from '@opentrons/components'
 import fixture_96_plate from '@opentrons/shared-data/labware/fixtures/2/fixture_96_plate.json'
 import _uncastedSimpleV6Protocol from '@opentrons/shared-data/protocol/fixtures/6/simpleV6.json'
 import { i18n } from '../../../i18n'
-import * as discoverySelectors from '../../../redux/discovery/selectors'
-import { mockConnectedRobot } from '../../../redux/discovery/__fixtures__'
 import {
   useCurrentRunPipetteInfoByMount,
   PipetteInfo,
@@ -20,16 +18,12 @@ import type {
 
 jest.mock('../hooks')
 jest.mock('../../ProtocolSetup/RunSetupCard/hooks')
-jest.mock('../../../redux/discovery/selectors')
 
 const mockUseProtocolDetails = useProtocolDetails as jest.MockedFunction<
   typeof useProtocolDetails
 >
 const mockUseCurrentRunPipetteInfoByMount = useCurrentRunPipetteInfoByMount as jest.MockedFunction<
   typeof useCurrentRunPipetteInfoByMount
->
-const mockGetConnectedRobot = discoverySelectors.getConnectedRobot as jest.MockedFunction<
-  typeof discoverySelectors.getConnectedRobot
 >
 
 const simpleV6Protocol = (_uncastedSimpleV6Protocol as unknown) as ProtocolFile<{}>
@@ -191,7 +185,6 @@ describe('ProtocolSetupInfo', () => {
         },
       } as any)
     mockUseCurrentRunPipetteInfoByMount.mockReturnValue(mockPipetteInfoByMount)
-    mockGetConnectedRobot.mockReturnValue(mockConnectedRobot)
   })
 
   it('should render correct command when commandType is loadLabware', () => {

--- a/app/src/organisms/RunDetails/__tests__/ProtocolSetupInfo.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/ProtocolSetupInfo.test.tsx
@@ -4,10 +4,7 @@ import { nestedTextMatcher, renderWithProviders } from '@opentrons/components'
 import fixture_96_plate from '@opentrons/shared-data/labware/fixtures/2/fixture_96_plate.json'
 import _uncastedSimpleV6Protocol from '@opentrons/shared-data/protocol/fixtures/6/simpleV6.json'
 import { i18n } from '../../../i18n'
-import {
-  useCurrentRunPipetteInfoByMount,
-  PipetteInfo,
-} from '../../ProtocolSetup/RunSetupCard/hooks'
+import { useCurrentRunPipetteInfoByMount } from '../../ProtocolSetup/RunSetupCard/hooks'
 import { ProtocolSetupInfo } from '../ProtocolSetupInfo'
 import { useProtocolDetails } from '../hooks'
 import type {
@@ -129,15 +126,14 @@ const mockLabwarePositionCheckStepTipRack = {
   ],
 } as any
 
-const mockPipetteInfo: PipetteInfo = {
+const mockPipetteInfo = {
   requestedPipetteMatch: 'incompatible',
   pipetteCalDate: null,
-  // @ts-expect-error partial type match
   pipetteSpecs: {
     displayName: 'P10 Single-Channel',
   },
   tipRacksForPipette: [],
-}
+} as any
 
 const mockPipetteInfoByMount = {
   left: mockPipetteInfo,

--- a/app/src/organisms/RunDetails/__tests__/ProtocolSetupInfo.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/ProtocolSetupInfo.test.tsx
@@ -5,9 +5,11 @@ import fixture_96_plate from '@opentrons/shared-data/labware/fixtures/2/fixture_
 import _uncastedSimpleV6Protocol from '@opentrons/shared-data/protocol/fixtures/6/simpleV6.json'
 import { i18n } from '../../../i18n'
 import * as discoverySelectors from '../../../redux/discovery/selectors'
-import { ProtocolPipetteTipRackCalDataByMount } from '../../../redux/pipettes/types'
 import { mockConnectedRobot } from '../../../redux/discovery/__fixtures__'
-import { getProtocolPipetteTipRackCalInfo } from '../../../redux/pipettes'
+import {
+  useCurrentRunPipetteInfoByMount,
+  PipetteInfo,
+} from '../../ProtocolSetup/RunSetupCard/hooks'
 import { ProtocolSetupInfo } from '../ProtocolSetupInfo'
 import { useProtocolDetails } from '../hooks'
 import type {
@@ -17,15 +19,14 @@ import type {
 } from '@opentrons/shared-data'
 
 jest.mock('../hooks')
-jest.mock('../../../redux/pipettes/types')
+jest.mock('../../ProtocolSetup/RunSetupCard/hooks')
 jest.mock('../../../redux/discovery/selectors')
-jest.mock('../../../redux/pipettes')
 
 const mockUseProtocolDetails = useProtocolDetails as jest.MockedFunction<
   typeof useProtocolDetails
 >
-const mockGetProtocolPipetteTiprackData = getProtocolPipetteTipRackCalInfo as jest.MockedFunction<
-  typeof getProtocolPipetteTipRackCalInfo
+const mockUseCurrentRunPipetteInfoByMount = useCurrentRunPipetteInfoByMount as jest.MockedFunction<
+  typeof useCurrentRunPipetteInfoByMount
 >
 const mockGetConnectedRobot = discoverySelectors.getConnectedRobot as jest.MockedFunction<
   typeof discoverySelectors.getConnectedRobot
@@ -134,10 +135,18 @@ const mockLabwarePositionCheckStepTipRack = {
   ],
 } as any
 
-const mockProtocolPipetteTipRackCalData: ProtocolPipetteTipRackCalDataByMount = {
-  left: {
-    pipetteDisplayName: 'P10 Single-Channel',
+const mockPipetteInfo: PipetteInfo = {
+  requestedPipetteMatch: 'incompatible',
+  pipetteCalDate: null,
+  // @ts-expect-error partial type match
+  pipetteSpecs: {
+    displayName: 'P10 Single-Channel',
   },
+  tipRacksForPipette: [],
+}
+
+const mockPipetteInfoByMount = {
+  left: mockPipetteInfo,
   right: null,
 } as any
 
@@ -181,9 +190,7 @@ describe('ProtocolSetupInfo', () => {
           },
         },
       } as any)
-    mockGetProtocolPipetteTiprackData.mockReturnValue(
-      mockProtocolPipetteTipRackCalData
-    )
+    mockUseCurrentRunPipetteInfoByMount.mockReturnValue(mockPipetteInfoByMount)
     mockGetConnectedRobot.mockReturnValue(mockConnectedRobot)
   })
 

--- a/app/src/redux/calibration/pipette-offset/selectors.ts
+++ b/app/src/redux/calibration/pipette-offset/selectors.ts
@@ -11,7 +11,7 @@ export const getPipetteOffsetCalibrations: (
     return []
   }
   const calibrations =
-    state.calibration[robotName]?.pipetteOffsetCalibrations?.data || []
+    state?.calibration[robotName]?.pipetteOffsetCalibrations?.data || []
   return calibrations
 }
 

--- a/app/src/redux/calibration/tip-length/selectors.ts
+++ b/app/src/redux/calibration/tip-length/selectors.ts
@@ -11,7 +11,7 @@ export const getTipLengthCalibrations: (
     return []
   }
   const calibrations =
-    state.calibration[robotName]?.tipLengthCalibrations?.data || []
+    state?.calibration[robotName]?.tipLengthCalibrations?.data || []
   return calibrations
 }
 

--- a/app/src/redux/pipettes/selectors.ts
+++ b/app/src/redux/pipettes/selectors.ts
@@ -40,7 +40,7 @@ export const getAttachedPipettes: (
   robotName: string | null
 ) => Types.AttachedPipettesByMount = createSelector(
   (state: State, robotName: string | null) =>
-    robotName ? state.pipettes[robotName]?.attachedByMount : null,
+    robotName ? state?.pipettes[robotName]?.attachedByMount : null,
   attachedByMount => {
     return Constants.PIPETTE_MOUNTS.reduce<Types.AttachedPipettesByMount>(
       (result, mount) => {


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
Replace remaining rpc dependencies with new hooks

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
1. Create `useProtocolCalibrationStatus` hook and test to replace `getProtocolCalibrationComplete ` selector
2. Replace usage of `getProtocolCalibrationComplete` with `useProtocolCalibrationStatus`
3. Replace remaining references of `getProtocolPipetteTipRackCalInfo` with `useCurrentRunPipetteInfoByMount`

# Review requests

<!--
Describe any requests for your reviewers here.
-->
Ensure robot calibration status is still accurate

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Low