### PR TITLE
feat(app): show loader when setup for runs steps are still loading

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -78,5 +78,6 @@
   "calibration_ready": "Calibration ready",
   "run_disabled_modules_not_connected": "Make sure all modules are connected before proceeding to run",
   "run_disabled_calibration_not_complete": "Make sure robot calibration is complete before proceeding to run",
-  "run_disabled_modules_and_calibration_not_complete": "Make sure robot calibration is complete and all modules are connected before proceeding to run"
+  "run_disabled_modules_and_calibration_not_complete": "Make sure robot calibration is complete and all modules are connected before proceeding to run",
+  "loading_protocol_details": "Loading details..."
 }

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/index.tsx
@@ -8,15 +8,23 @@ import {
   Icon,
   SPACING_2,
   SPACING_3,
+  SPACING_4,
+  SPACING_5,
   SPACING_7,
   SIZE_1,
   DIRECTION_ROW,
   ALIGN_START,
+  ALIGN_CENTER,
+  JUSTIFY_SPACE_BETWEEN,
+  FONT_WEIGHT_REGULAR,
+  FONT_SIZE_BODY_2,
   FONT_WEIGHT_SEMIBOLD,
   FONT_SIZE_BODY_1,
   C_WHITE,
   COLOR_SUCCESS,
   COLOR_WARNING,
+  C_LIGHT_GRAY,
+  C_DARK_GRAY,
 } from '@opentrons/components'
 import { protocolHasModules } from '@opentrons/shared-data'
 import { Divider } from '../../../atoms/structure'
@@ -47,10 +55,18 @@ export function RunSetupCard(): JSX.Element | null {
   const calibrationStatus = useSelector((state: State) => {
     return getProtocolCalibrationComplete(state, robotName)
   })
-
   const [expandedStepKey, setExpandedStepKey] = React.useState<StepKey | null>(
     null
   )
+  const [isLoading, setIsLoading] = React.useState<Boolean>(true)
+
+  // Set loader to false once protocolData contains data and is not null
+  React.useEffect(() => {
+    if (protocolData != null) {
+      setIsLoading(false)
+    }
+  }, [protocolData])
+
   if (
     protocolData == null ||
     robot == null ||
@@ -118,57 +134,88 @@ export function RunSetupCard(): JSX.Element | null {
       >
         {t('setup_for_run')}
       </Text>
-      {stepsKeysInOrder.map((stepKey, index) => (
-        <React.Fragment key={stepKey}>
+      {isLoading ? (
+        <>
+          <Flex justifyContent={ALIGN_CENTER}>
+            <Icon
+              name="ot-spinner"
+              width={SPACING_5}
+              marginTop={SPACING_4}
+              marginBottom={SPACING_4}
+              color={C_LIGHT_GRAY}
+              spin
+            />
+          </Flex>
+          <Flex justifyContent={ALIGN_CENTER}>
+            <Text
+              justifyContent={JUSTIFY_SPACE_BETWEEN}
+              as={'h3'}
+              color={C_DARK_GRAY}
+              marginBottom={SPACING_5}
+              fontWeight={FONT_WEIGHT_REGULAR}
+              fontSize={FONT_SIZE_BODY_2}
+            >
+              {t('loading_protocol_details')}
+            </Text>
+          </Flex>
+        </>
+      ) : (
+        <>
+          {stepsKeysInOrder.map((stepKey, index) => (
+            <React.Fragment key={stepKey}>
+              <Divider marginY={SPACING_3} />
+              <CollapsibleStep
+                expanded={stepKey === expandedStepKey}
+                label={t('step', { index: index + 1 })}
+                title={t(`${stepKey}_title`)}
+                description={StepDetailMap[stepKey].description}
+                toggleExpanded={() =>
+                  stepKey === expandedStepKey
+                    ? setExpandedStepKey(null)
+                    : setExpandedStepKey(stepKey)
+                }
+                rightAlignedNode={
+                  stepKey === ROBOT_CALIBRATION_STEP_KEY ? (
+                    <Flex
+                      flexDirection={DIRECTION_ROW}
+                      alignItems={ALIGN_START}
+                      marginLeft={SPACING_7}
+                    >
+                      <Icon
+                        size={SIZE_1}
+                        color={
+                          calibrationStatus.complete
+                            ? COLOR_SUCCESS
+                            : COLOR_WARNING
+                        }
+                        marginRight={SPACING_2}
+                        name={
+                          calibrationStatus.complete
+                            ? 'check-circle'
+                            : 'alert-circle'
+                        }
+                        id={'RunSetupCard_calibrationIcon'}
+                      />
+                      <Text
+                        fontSize={FONT_SIZE_BODY_1}
+                        id={'RunSetupCard_calibrationText'}
+                      >
+                        {calibrationStatus.complete
+                          ? t('calibration_ready')
+                          : t('calibration_needed')}
+                      </Text>
+                    </Flex>
+                  ) : null
+                }
+              >
+                {StepDetailMap[stepKey].stepInternals}
+              </CollapsibleStep>
+            </React.Fragment>
+          ))}
           <Divider marginY={SPACING_3} />
-          <CollapsibleStep
-            expanded={stepKey === expandedStepKey}
-            label={t('step', { index: index + 1 })}
-            title={t(`${stepKey}_title`)}
-            description={StepDetailMap[stepKey].description}
-            toggleExpanded={() =>
-              stepKey === expandedStepKey
-                ? setExpandedStepKey(null)
-                : setExpandedStepKey(stepKey)
-            }
-            rightAlignedNode={
-              stepKey === ROBOT_CALIBRATION_STEP_KEY ? (
-                <Flex
-                  flexDirection={DIRECTION_ROW}
-                  alignItems={ALIGN_START}
-                  marginLeft={SPACING_7}
-                >
-                  <Icon
-                    size={SIZE_1}
-                    color={
-                      calibrationStatus.complete ? COLOR_SUCCESS : COLOR_WARNING
-                    }
-                    marginRight={SPACING_2}
-                    name={
-                      calibrationStatus.complete
-                        ? 'check-circle'
-                        : 'alert-circle'
-                    }
-                    id={'RunSetupCard_calibrationIcon'}
-                  />
-                  <Text
-                    fontSize={FONT_SIZE_BODY_1}
-                    id={'RunSetupCard_calibrationText'}
-                  >
-                    {calibrationStatus.complete
-                      ? t('calibration_ready')
-                      : t('calibration_needed')}
-                  </Text>
-                </Flex>
-              ) : null
-            }
-          >
-            {StepDetailMap[stepKey].stepInternals}
-          </CollapsibleStep>
-        </React.Fragment>
-      ))}
-      <Divider marginY={SPACING_3} />
-      <ProceedToRunCta />
+          <ProceedToRunCta />
+        </>
+      )}
     </Card>
   )
 }

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/index.tsx
@@ -25,6 +25,8 @@ import {
   COLOR_WARNING,
   C_LIGHT_GRAY,
   C_DARK_GRAY,
+  JUSTIFY_CENTER,
+  DIRECTION_COLUMN,
 } from '@opentrons/components'
 import { protocolHasModules } from '@opentrons/shared-data'
 import { Divider } from '../../../atoms/structure'
@@ -152,30 +154,7 @@ export function RunSetupCard(): JSX.Element | null {
         {t('setup_for_run')}
       </Text>
       {isLoading ? (
-        <>
-          <Flex justifyContent={ALIGN_CENTER}>
-            <Icon
-              name="ot-spinner"
-              width={SPACING_5}
-              marginTop={SPACING_4}
-              marginBottom={SPACING_4}
-              color={C_LIGHT_GRAY}
-              spin
-            />
-          </Flex>
-          <Flex justifyContent={ALIGN_CENTER}>
-            <Text
-              justifyContent={JUSTIFY_SPACE_BETWEEN}
-              as={'h3'}
-              color={C_DARK_GRAY}
-              marginBottom={SPACING_5}
-              fontWeight={FONT_WEIGHT_REGULAR}
-              fontSize={FONT_SIZE_BODY_2}
-            >
-              {t('loading_protocol_details')}
-            </Text>
-          </Flex>
-        </>
+        <RunSetupLoader />
       ) : (
         <>
           {stepsKeysInOrder.map((stepKey, index) => (
@@ -234,5 +213,37 @@ export function RunSetupCard(): JSX.Element | null {
         </>
       )}
     </Card>
+  )
+}
+
+function RunSetupLoader(): JSX.Element | null {
+  const { t } = useTranslation('protocol_setup')
+  return (
+    <>
+      <Flex
+        justifyContent={JUSTIFY_CENTER}
+        flexDirection={DIRECTION_COLUMN}
+        alignItems={ALIGN_CENTER}
+      >
+        <Icon
+          name="ot-spinner"
+          width={SPACING_5}
+          marginTop={SPACING_4}
+          marginBottom={SPACING_4}
+          color={C_LIGHT_GRAY}
+          spin
+        />
+        <Text
+          justifyContent={JUSTIFY_SPACE_BETWEEN}
+          as={'h3'}
+          color={C_DARK_GRAY}
+          marginBottom={SPACING_5}
+          fontWeight={FONT_WEIGHT_REGULAR}
+          fontSize={FONT_SIZE_BODY_2}
+        >
+          {t('loading_protocol_details')}
+        </Text>
+      </Flex>
+    </>
   )
 }


### PR DESCRIPTION


<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR adds a loader to the run steps while details are still loading. closes #8777.

Preview:
<img width="1022" alt="Screen Shot 2021-11-19 at 5 17 21 PM" src="https://user-images.githubusercontent.com/14794021/142701109-e98689d0-d19d-46fb-b05a-2769ab33ff00.png">


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- Added `isLoading` state variable in `RunSetupCard` component to conditionally render while `protocolData` is `null`.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- [ ] Check the loader is rendering and disappearing before and after protocol run steps are loaded.

**Note**: There appears to be a peripheral issue/bug where you have to switch pages in order for the entire `RunSetupCard` component to render.
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low, stylistic additions
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
