### PR TITLE
feat(app): wire up labware setup accordion step labware offsets

### DIFF
--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -1,4 +1,5 @@
-import { Command as FullCommand } from '@opentrons/shared-data'
+import type { Command as FullCommand } from '@opentrons/shared-data'
+import type { LabwareLocation } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
 
 export const RUN_STATUS_IDLE: 'idle' = 'idle'
 export const RUN_STATUS_RUNNING: 'running' = 'running'
@@ -40,7 +41,7 @@ export interface VectorOffset {
 export interface LabwareOffset {
   id: string
   definitionUri: string
-  location: Location
+  location: LabwareLocation
   offset: VectorOffset
 }
 

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/LabwareInfoOverlay.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/LabwareInfoOverlay.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import isEqual from 'lodash/isEqual'
 import { useTranslation } from 'react-i18next'
 import {
   getLabwareDisplayName,
@@ -18,15 +19,33 @@ import {
   JUSTIFY_FLEX_END,
   FONT_SIZE_TINY,
 } from '@opentrons/components'
+import { useCurrentProtocolRun } from '../../../ProtocolUpload/hooks'
+import { useLabwareDefinitionUri } from '../../hooks'
+import { getLabwareLocation } from '../../utils/getLabwareLocation'
+import { useProtocolDetails } from '../../../RunDetails/hooks'
 interface LabwareInfoProps {
   displayName: string
+  labwareId: string
 }
 
-const FAKE_OFFSET_DATA = { x: 1.2, y: 2.3, z: 4.4 } // TODO IMMEDIATELY: replace with real data when available
-// Also, if offset data does not exist for a piece of labware, the offseet data should not be rendered at all
 const LabwareInfo = (props: LabwareInfoProps): JSX.Element => {
-  const { displayName } = props
+  const { displayName, labwareId } = props
   const { t } = useTranslation('protocol_setup')
+  const { protocolData } = useProtocolDetails()
+  const labwareDefinitionUri = useLabwareDefinitionUri(labwareId)
+  const { runRecord } = useCurrentProtocolRun()
+  const labwareLocation = getLabwareLocation(
+    labwareId,
+    protocolData?.commands ?? []
+  )
+
+  const labwareOffsets = runRecord?.data.labwareOffsets
+  const labwareOffset = labwareOffsets?.find(
+    offsetRecord =>
+      offsetRecord.definitionUri === labwareDefinitionUri &&
+      isEqual(offsetRecord.location, labwareLocation)
+  )?.offset
+
   return (
     <Box
       flexDirection={'column'}
@@ -36,68 +55,73 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element => {
       color={C_WHITE}
     >
       <Text margin={SPACING_1}>{displayName}</Text>
-      <Text
-        marginX={SPACING_1}
-        fontWeight={FONT_WEIGHT_SEMIBOLD}
-        textTransform={'uppercase'}
-      >
-        {t('offset_title')}
-      </Text>
-      <Box marginX={SPACING_1} marginBottom={SPACING_1}>
-        <Text
-          as={'span'}
-          fontWeight={FONT_WEIGHT_SEMIBOLD}
-          marginRight={'0.15rem'}
-        >
-          X
-        </Text>
-        <Text
-          as={'span'}
-          fontWeight={FONT_WEIGHT_REGULAR}
-          marginRight={'0.35rem'}
-        >
-          {FAKE_OFFSET_DATA.x.toFixed(1)}
-        </Text>
-        <Text
-          as={'span'}
-          fontWeight={FONT_WEIGHT_SEMIBOLD}
-          marginRight={'0.15rem'}
-        >
-          Y
-        </Text>
-        <Text
-          as={'span'}
-          fontWeight={FONT_WEIGHT_REGULAR}
-          marginRight={'0.35rem'}
-        >
-          {FAKE_OFFSET_DATA.y.toFixed(1)}
-        </Text>
-        <Text
-          as={'span'}
-          fontWeight={FONT_WEIGHT_SEMIBOLD}
-          marginRight={'0.15rem'}
-        >
-          Z
-        </Text>
-        <Text
-          as={'span'}
-          fontWeight={FONT_WEIGHT_REGULAR}
-          marginRight={'0.35rem'}
-        >
-          {FAKE_OFFSET_DATA.z.toFixed(1)}
-        </Text>
-      </Box>
+      {labwareOffset != null && (
+        <>
+          <Text
+            marginX={SPACING_1}
+            fontWeight={FONT_WEIGHT_SEMIBOLD}
+            textTransform={'uppercase'}
+          >
+            {t('offset_title')}
+          </Text>
+          <Box marginX={SPACING_1} marginBottom={SPACING_1}>
+            <Text
+              as={'span'}
+              fontWeight={FONT_WEIGHT_SEMIBOLD}
+              marginRight={'0.15rem'}
+            >
+              X
+            </Text>
+            <Text
+              as={'span'}
+              fontWeight={FONT_WEIGHT_REGULAR}
+              marginRight={'0.35rem'}
+            >
+              {labwareOffset.x.toFixed(1)}
+            </Text>
+            <Text
+              as={'span'}
+              fontWeight={FONT_WEIGHT_SEMIBOLD}
+              marginRight={'0.15rem'}
+            >
+              Y
+            </Text>
+            <Text
+              as={'span'}
+              fontWeight={FONT_WEIGHT_REGULAR}
+              marginRight={'0.35rem'}
+            >
+              {labwareOffset.y.toFixed(1)}
+            </Text>
+            <Text
+              as={'span'}
+              fontWeight={FONT_WEIGHT_SEMIBOLD}
+              marginRight={'0.15rem'}
+            >
+              Z
+            </Text>
+            <Text
+              as={'span'}
+              fontWeight={FONT_WEIGHT_REGULAR}
+              marginRight={'0.35rem'}
+            >
+              {labwareOffset.z.toFixed(1)}
+            </Text>
+          </Box>
+        </>
+      )}
     </Box>
   )
 }
 
 interface LabwareInfoOverlayProps {
   definition: LabwareDefinition2
+  labwareId: string
 }
 export const LabwareInfoOverlay = (
   props: LabwareInfoOverlayProps
 ): JSX.Element => {
-  const { definition } = props
+  const { definition, labwareId } = props
   const width = definition.dimensions.xDimension
   const height = definition.dimensions.yDimension
   return (
@@ -111,7 +135,10 @@ export const LabwareInfoOverlay = (
         justifyContent: JUSTIFY_FLEX_END,
       }}
     >
-      <LabwareInfo displayName={getLabwareDisplayName(definition)} />
+      <LabwareInfo
+        displayName={getLabwareDisplayName(definition)}
+        labwareId={labwareId}
+      />
     </RobotCoordsForeignDiv>
   )
 }

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareInfoOverlay.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareInfoOverlay.test.tsx
@@ -5,9 +5,18 @@ import {
   LabwareDefinition2,
 } from '@opentrons/shared-data'
 import fixture_tiprack_300_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_300_ul.json'
-import { renderWithProviders } from '@opentrons/components'
+import { nestedTextMatcher, renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../../../i18n'
+import { useCurrentProtocolRun } from '../../../../ProtocolUpload/hooks'
+import { useProtocolDetails } from '../../../../RunDetails/hooks'
+import { getLabwareLocation } from '../../../utils/getLabwareLocation'
 import { LabwareInfoOverlay } from '../LabwareInfoOverlay'
+import { useLabwareDefinitionUri } from '../../../hooks'
+
+jest.mock('../../../../ProtocolUpload/hooks')
+jest.mock('../../../utils/getLabwareLocation')
+jest.mock('../../../../RunDetails/hooks')
+jest.mock('../../../hooks')
 
 jest.mock('@opentrons/shared-data', () => {
   const actualSharedData = jest.requireActual('@opentrons/shared-data')
@@ -31,31 +40,96 @@ const render = (props: React.ComponentProps<typeof LabwareInfoOverlay>) => {
 const mockGetLabwareDisplayName = getLabwareDisplayName as jest.MockedFunction<
   typeof getLabwareDisplayName
 >
+const mockUseCurrentProtocolRun = useCurrentProtocolRun as jest.MockedFunction<
+  typeof useCurrentProtocolRun
+>
+const mockUseProtocolDetails = useProtocolDetails as jest.MockedFunction<
+  typeof useProtocolDetails
+>
+const mockGetLabwareLocation = getLabwareLocation as jest.MockedFunction<
+  typeof getLabwareLocation
+>
+const mockUseLabwareDefinitionUri = useLabwareDefinitionUri as jest.MockedFunction<
+  typeof useLabwareDefinitionUri
+>
+const MOCK_LABWARE_ID = 'some_labware_id'
+const MOCK_LABWARE_DEFINITION_ID = 'some_labware_definition_id'
+const MOCK_LABWARE_DEFINITION_URI = 'some_labware_definition_uri'
+const MOCK_SLOT_NAME = '4'
+const MOCK_LABWARE_OFFSET = { x: 1, y: 2, z: 3 }
 
 describe('LabwareInfoOverlay', () => {
   let props: React.ComponentProps<typeof LabwareInfoOverlay>
   beforeEach(() => {
     props = {
       definition: fixture_tiprack_300_ul as LabwareDefinition2,
+      labwareId: MOCK_LABWARE_ID,
     }
     when(mockGetLabwareDisplayName)
       .calledWith(props.definition)
       .mockReturnValue('mock display name')
+
+    when(mockUseProtocolDetails)
+      .calledWith()
+      .mockReturnValue({
+        protocolData: {
+          commands: [],
+          labware: {
+            [MOCK_LABWARE_ID]: {
+              definitionId: MOCK_LABWARE_DEFINITION_ID,
+            },
+          },
+        },
+      } as any)
+
+    when(mockUseCurrentProtocolRun)
+      .calledWith()
+      .mockReturnValue({} as any)
+
+    when(mockGetLabwareLocation)
+      .calledWith(MOCK_LABWARE_ID, [])
+      .mockReturnValue({ slotName: MOCK_SLOT_NAME })
+
+    when(mockUseLabwareDefinitionUri)
+      .calledWith(MOCK_LABWARE_ID)
+      .mockReturnValue(MOCK_LABWARE_DEFINITION_URI)
   })
   afterEach(() => {
     resetAllWhenMocks()
+    jest.restoreAllMocks()
   })
 
   it('should render the labware display name', () => {
     const { getByText } = render(props)
     getByText('mock display name')
   })
-  it('should render the offset data label', () => {
+
+  it('should render NOT render the offset data label when offset data does not exist', () => {
+    const { queryByText } = render(props)
+    expect(queryByText('Labware Offsets')).toBeNull()
+  })
+
+  it('should render the offset data when offset data exists', () => {
+    when(mockUseCurrentProtocolRun)
+      .calledWith()
+      .mockReturnValue({
+        runRecord: {
+          data: {
+            labwareOffsets: [
+              {
+                id: '1',
+                definitionUri: MOCK_LABWARE_DEFINITION_URI,
+                location: { slotName: MOCK_SLOT_NAME },
+                offset: MOCK_LABWARE_OFFSET,
+              },
+            ],
+          },
+        },
+      } as any)
     const { getByText } = render(props)
     getByText('Offset Data')
-  })
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('should render labware offset data', () => {
-    // implement when data is available
+    getByText(nestedTextMatcher('X1.0'))
+    getByText(nestedTextMatcher('Y2.0'))
+    getByText(nestedTextMatcher('Z3.0'))
   })
 })

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareSetup.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareSetup.test.tsx
@@ -159,7 +159,9 @@ describe('LabwareSetup', () => {
 
     when(mockLabwareInfoOverlay)
       .mockReturnValue(<div></div>) // this (default) empty div will be returned when LabwareInfoOverlay isn't called with expected props
-      .calledWith(componentPropsMatcher({ definition: fixture_tiprack_300_ul }))
+      .calledWith(
+        partialComponentPropsMatcher({ definition: fixture_tiprack_300_ul })
+      )
       .mockReturnValue(
         <div>
           mock labware info overlay of{' '}
@@ -277,7 +279,7 @@ describe('LabwareSetup', () => {
           nestedLabwareDef: null,
           nestedLabwareId: null,
         },
-      })
+      } as any)
 
     when(mockModule)
       .calledWith(

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
@@ -102,7 +102,7 @@ export const LabwareSetup = (): JSX.Element | null => {
               <React.Fragment>
                 {map(
                   moduleRenderInfoById,
-                  ({ x, y, moduleDef, nestedLabwareDef }) => (
+                  ({ x, y, moduleDef, nestedLabwareDef, nestedLabwareId }) => (
                     <Module
                       key={`LabwareSetup_Module_${moduleDef.model}_${x}${y}`}
                       x={x}
@@ -120,24 +120,33 @@ export const LabwareSetup = (): JSX.Element | null => {
                           key={`LabwareSetup_Labware_${nestedLabwareDef.metadata.displayName}_${x}${y}`}
                         >
                           <LabwareRender definition={nestedLabwareDef} />
-                          <LabwareInfoOverlay definition={nestedLabwareDef} />
+                          <LabwareInfoOverlay
+                            definition={nestedLabwareDef}
+                            labwareId={nestedLabwareId}
+                          />
                         </React.Fragment>
                       ) : null}
                     </Module>
                   )
                 )}
-                {map(labwareRenderInfoById, ({ x, y, labwareDef }) => {
-                  return (
-                    <React.Fragment
-                      key={`LabwareSetup_Labware_${labwareDef.metadata.displayName}_${x}${y}`}
-                    >
-                      <g transform={`translate(${x},${y})`}>
-                        <LabwareRender definition={labwareDef} />
-                        <LabwareInfoOverlay definition={labwareDef} />
-                      </g>
-                    </React.Fragment>
-                  )
-                })}
+                {map(
+                  labwareRenderInfoById,
+                  ({ x, y, labwareDef }, labwareId) => {
+                    return (
+                      <React.Fragment
+                        key={`LabwareSetup_Labware_${labwareDef.metadata.displayName}_${x}${y}`}
+                      >
+                        <g transform={`translate(${x},${y})`}>
+                          <LabwareRender definition={labwareDef} />
+                          <LabwareInfoOverlay
+                            definition={labwareDef}
+                            labwareId={labwareId}
+                          />
+                        </g>
+                      </React.Fragment>
+                    )
+                  }
+                )}
               </React.Fragment>
             )
           }}

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/__tests__/ModuleSetup.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/__tests__/ModuleSetup.test.tsx
@@ -197,7 +197,7 @@ describe('ModuleSetup', () => {
           nestedLabwareDef: null,
           nestedLabwareId: null,
         },
-      })
+      } as any)
 
     when(mockModuleInfo)
       .calledWith(
@@ -234,7 +234,7 @@ describe('ModuleSetup', () => {
           nestedLabwareDef: null,
           nestedLabwareId: null,
         },
-      })
+      } as any)
 
     when(mockModuleInfo)
       .calledWith(
@@ -288,7 +288,7 @@ describe('ModuleSetup', () => {
           nestedLabwareDef: null,
           nestedLabwareId: null,
         },
-      })
+      } as any)
     when(mockGetAttachedModules)
       .calledWith(undefined as any, MOCK_ROBOT_NAME)
       .mockReturnValue([

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/hooks/__tests__/useMissingModuleIds.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/hooks/__tests__/useMissingModuleIds.test.tsx
@@ -77,7 +77,7 @@ describe('useMissingModuleIds', () => {
           z: 0,
           moduleDef: mockMagneticModuleDef as any,
           nestedLabwareDef: null,
-          nestedLabwareId: null,
+          nestedLabwareId: '',
         },
       })
 

--- a/app/src/organisms/ProtocolSetup/__tests__/hooks.test.tsx
+++ b/app/src/organisms/ProtocolSetup/__tests__/hooks.test.tsx
@@ -1,19 +1,25 @@
 // tests for the HostConfig context and hook
 import * as React from 'react'
-import { when } from 'jest-when'
+import { when, resetAllWhenMocks } from 'jest-when'
 import { Provider } from 'react-redux'
 import { createStore } from 'redux'
 import { renderHook } from '@testing-library/react-hooks'
-import { useProtocolMetadata } from '../hooks'
+import { useProtocolMetadata, useLabwareDefinitionUri } from '../hooks'
 import { useCurrentProtocolRun } from '../../ProtocolUpload/hooks'
+import { useProtocolDetails } from '../../RunDetails/hooks'
 
 import type { Store } from 'redux'
 import type { State } from '../../../redux/types'
 
 jest.mock('../../ProtocolUpload/hooks')
+jest.mock('../../RunDetails/hooks')
 
 const mockUseCurrentProtocolRun = useCurrentProtocolRun as jest.MockedFunction<
   typeof useCurrentProtocolRun
+>
+
+const mockUseProtocolDetails = useProtocolDetails as jest.MockedFunction<
+  typeof useProtocolDetails
 >
 
 describe('useProtocolMetadata', () => {
@@ -55,5 +61,37 @@ describe('useProtocolMetadata', () => {
     expect(lastUpdated).toBe(123456)
     expect(creationMethod).toBe('json')
     expect(description).toBe('DESCRIPTION')
+  })
+})
+
+// NOTE: this test and util should be deleted once we have a better identifier to look up labware offsets
+// for now, this mapper will just strip the "id" out of labwareDefinitionIds so consumers don't need to worry
+// about the concept of labwareDefinitionIds vs labwareDefinitionUris
+describe('useLabwareDefinitionUri', () => {
+  const MOCK_LABWARE_ID = 'some_labware'
+  const MOCK_DEFINITION_URI = 'some_labware_definition_uri'
+  beforeEach(() => {
+    when(mockUseProtocolDetails)
+      .calledWith()
+      .mockReturnValue({
+        protocolData: {
+          labware: {
+            [MOCK_LABWARE_ID]: {
+              definitionId: `${MOCK_DEFINITION_URI}_id`,
+              displayName: 'some dope labware',
+            },
+          },
+        },
+      } as any)
+  })
+  afterEach(() => {
+    jest.restoreAllMocks()
+    resetAllWhenMocks()
+  })
+  it('should return the definition uri of a given labware', () => {
+    const { result } = renderHook(() =>
+      useLabwareDefinitionUri(MOCK_LABWARE_ID)
+    )
+    expect(result.current).toBe(MOCK_DEFINITION_URI)
   })
 })

--- a/app/src/organisms/ProtocolSetup/hooks.ts
+++ b/app/src/organisms/ProtocolSetup/hooks.ts
@@ -53,3 +53,17 @@ export function usePipetteMount(
     )?.params.mount ?? null
   )
 }
+
+// NOTE: this hook should be deleted once we have a better identifier to look up labware offsets
+// for now, this mapper will just strip the "id" out of labwareDefinitionIds so consumers don't need to worry
+// about the concept of labwareDefinitionIds vs labwareDefinitionUris
+export function useLabwareDefinitionUri(labwareId: string): string {
+  const { protocolData } = useProtocolDetails()
+  const labwareDefinitionId = protocolData?.labware[labwareId].definitionId
+  if (labwareDefinitionId == null) {
+    throw new Error(
+      'expected to be able to find labware definition id for labware, but could not'
+    )
+  }
+  return labwareDefinitionId.substring(0, labwareDefinitionId.length - 3)
+}

--- a/app/src/organisms/ProtocolSetup/utils/getModuleRenderInfo.ts
+++ b/app/src/organisms/ProtocolSetup/utils/getModuleRenderInfo.ts
@@ -17,7 +17,7 @@ export interface ModuleRenderInfoById {
     z: number
     moduleDef: ModuleDefinition
     nestedLabwareDef: LabwareDefinition2 | null
-    nestedLabwareId: string | null
+    nestedLabwareId: string
   }
 }
 
@@ -39,7 +39,7 @@ export const getModuleRenderInfo = (
             (command: LoadLabwareCommand) =>
               'moduleId' in command.params.location &&
               command.params.location.moduleId === moduleId
-          )?.params.labwareId
+          )?.params.labwareId as string
 
         const nestedLabware =
           nestedLabwareId != null ? protocolData.labware[nestedLabwareId] : null


### PR DESCRIPTION
# Overview

This PR wires up labware offsets to the labware setup accordion step.

Note: since we can't yet apply labware offsets on the robot server, no labware offsets will be rendered. Logic is all there + unit tests are passing so as long as the contract does not change this should just start working once CPX finishes their backend work.

closes #8859

# Changelog

- Wire up labware setup accordion step labware offsets

# Risk assessment
Low
