### PR TITLE
refactor(app): execute home as part of prep commands

### DIFF
--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
@@ -219,8 +219,17 @@ export function useLabwarePositionCheck(
     }) as Command[]) ?? []
   // TC open lid commands come from the LPC command generator
   const TCOpenCommands = LPCCommands.filter(isTCOpenCommand) ?? []
+  const homeCommand: Command = {
+    commandType: 'home',
+    id: uuidv4(),
+    params: {},
+  }
   // prepCommands will be run when a user starts LPC
-  const prepCommands: Command[] = [...loadCommands, ...TCOpenCommands]
+  const prepCommands: Command[] = [
+    homeCommand,
+    ...loadCommands,
+    ...TCOpenCommands,
+  ]
   // LPCMovementCommands will be run during the guided LPC flow
   const LPCMovementCommands: LabwarePositionCheckMovementCommand[] = LPCCommands.filter(
     (

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
@@ -226,9 +226,9 @@ export function useLabwarePositionCheck(
   }
   // prepCommands will be run when a user starts LPC
   const prepCommands: Command[] = [
-    homeCommand,
     ...loadCommands,
     ...TCOpenCommands,
+    homeCommand,
   ]
   // LPCMovementCommands will be run during the guided LPC flow
   const LPCMovementCommands: LabwarePositionCheckMovementCommand[] = LPCCommands.filter(

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -406,3 +406,12 @@ export interface ProtocolResource {
   analyses: PendingProtocolAnalysis[] | CompletedProtocolAnalysis[]
   files: ResourceFile[]
 }
+
+export interface MotorAxis {
+  X: 'x'
+  Y: 'y'
+  LEFT_Z: 'leftZ'
+  RIGHT_Z: 'rightZ'
+  LEFT_PLUNGER: 'leftPlunger'
+  RIGHT_PLUNGER: 'rightPlunger'
+}

--- a/shared-data/protocol/types/schemaV6/command/gantry.ts
+++ b/shared-data/protocol/types/schemaV6/command/gantry.ts
@@ -1,4 +1,5 @@
 import type { CommonCommandInfo } from '.'
+import type { MotorAxis } from '../../../../js/types'
 export interface MoveToSlotCommand extends CommonCommandInfo {
   commandType: 'moveToSlot'
   params: MoveToSlotParams
@@ -88,5 +89,5 @@ interface SavePositionParams {
 }
 
 interface HomeParams {
-  axes?: string
+  axes?: MotorAxis
 }

--- a/shared-data/protocol/types/schemaV6/command/gantry.ts
+++ b/shared-data/protocol/types/schemaV6/command/gantry.ts
@@ -24,12 +24,18 @@ export interface SavePositionCommand extends CommonCommandInfo {
   params: SavePositionParams
   result?: {}
 }
+export interface HomeCommand extends CommonCommandInfo {
+  commandType: 'home'
+  params: HomeParams
+  result?: {}
+}
 export type GantryCommand =
   | MoveToSlotCommand
   | MoveToWellCommand
   | MoveToCoordinatesCommand
   | MoveRelativeCommand
   | SavePositionCommand
+  | HomeCommand
 
 interface MoveToSlotParams {
   pipetteId: string
@@ -79,4 +85,8 @@ interface MoveRelativeParams {
 interface SavePositionParams {
   pipetteId: string // pipette to use in measurement
   positionId?: string // position ID, auto-assigned if left blank
+}
+
+interface HomeParams {
+  axes?: string
 }


### PR DESCRIPTION


<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
The robot is homed at the beginning of LPC to avoid the `MustHomeError` triggered by a `savePositionCommand`.
closes #8850
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- Added `HomeCommand` type to schemaV6 command types.
- Added `homeCommand` to `prepCommands` list.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- [ ] Check that the robot is homing before LPC begins.
(Tested on my robot and looks good!)
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
