### PR TITLE
refactor(app): poll protocol resource until analysis completes

### DIFF
--- a/app/src/organisms/ProtocolSetup/RunSetupCard/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/index.tsx
@@ -74,7 +74,7 @@ export function RunSetupCard(): JSX.Element | null {
       INITIAL_EXPAND_DELAY_MS
     )
     return () => clearTimeout(initialExpandTimer)
-  }, [Boolean(protocolData)])
+  }, [Boolean(protocolData), protocolData?.commands])
 
   if (protocolData == null || robot == null) return null
 

--- a/app/src/organisms/ProtocolUpload/hooks/useCurrentProtocolRun.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useCurrentProtocolRun.ts
@@ -33,7 +33,7 @@ export function useCurrentProtocolRun(): UseCurrentProtocolRun {
 
   React.useEffect(() => {
     if (protocolRecord?.data.analyses.length === 0) {
-      const intervalId = setInterval(() => {
+      const intervalId = setInterval(function () {
         refetchProtocol()
       }, REFETCH_INTERVAL)
 

--- a/app/src/organisms/ProtocolUpload/hooks/useCurrentProtocolRun.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useCurrentProtocolRun.ts
@@ -33,7 +33,10 @@ export function useCurrentProtocolRun(): UseCurrentProtocolRun {
 
   React.useEffect(() => {
     if (protocolRecord?.data.analyses.length === 0) {
-      const intervalId = setInterval(refetchProtocol, REFETCH_INTERVAL)
+      const intervalId = setInterval(() => {
+        refetchProtocol()
+      }, REFETCH_INTERVAL)
+
       return () => clearInterval(intervalId)
     }
   }, [protocolRecord?.data.analyses])

--- a/app/src/organisms/ProtocolUpload/hooks/useCurrentProtocolRun.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useCurrentProtocolRun.ts
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import { useQueryClient } from 'react-query'
 import {
   useHost,
@@ -26,9 +27,16 @@ export function useCurrentProtocolRun(): UseCurrentProtocolRun {
   const { data: runRecord } = useRunQuery(currentRunId, {
     refetchInterval: REFETCH_INTERVAL,
   })
-  const { data: protocolRecord } = useProtocolQuery(
+  const { data: protocolRecord, refetch: refetchProtocol } = useProtocolQuery(
     (runRecord?.data?.protocolId as string) ?? null
   )
+
+  React.useEffect(() => {
+    if (protocolRecord?.data.analyses.length === 0) {
+      const intervalId = setInterval(refetchProtocol, REFETCH_INTERVAL)
+      return () => clearInterval(intervalId)
+    }
+  }, [protocolRecord?.data.analyses])
 
   const { createRun } = useCreateRunMutation({
     onSuccess: () => {


### PR DESCRIPTION
# Overview

Let's refetch the protocol record every second as long as it contains no completed analyses.

Also, because the current protocol run is being used in the nav now, we should be fetching the protocol and run records as soon as the user connects to a robot. 

# Review requests

- [ ] upload a particularly large protocol.  You should land on the protocol setup page, and without navigating away, the setup steps should render as soon as analysis is complete.
- [ ] Confirm that if you disconnect from a robot that has a loaded protocol and current run record, you should be able to reconnect to the robot and navigate directly to the run tab without having to click into the upload tab first.

# Risk assessment

low