### PR TITLE
refactor(app): pUR FF Removal: Nav

### DIFF
--- a/app/src/App/__tests__/hooks.test.tsx
+++ b/app/src/App/__tests__/hooks.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { when } from 'jest-when'
 import { renderHook } from '@testing-library/react-hooks'
 import { createStore } from 'redux'
 import { I18nextProvider } from 'react-i18next'
@@ -12,7 +11,6 @@ import {
   getConnectedRobotPipettesCalibrated,
   getDeckCalibrationOk,
 } from '../../redux/nav'
-import { useFeatureFlag } from '../../redux/config'
 import { getConnectedRobot } from '../../redux/discovery'
 import { useNavLocations, useRunLocation } from '../hooks'
 import { useCurrentProtocolRun } from '../../organisms/ProtocolUpload/hooks'
@@ -42,9 +40,6 @@ const mockGetNavbarLocations = getNavbarLocations as jest.MockedFunction<
 >
 const mockUseCurrentProtocolRun = useCurrentProtocolRun as jest.MockedFunction<
   typeof useCurrentProtocolRun
->
-const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<
-  typeof useFeatureFlag
 >
 
 describe('useRunLocation', () => {
@@ -111,7 +106,7 @@ describe('useRunLocation', () => {
   })
 
   describe('useNavLocations', () => {
-    it('should return the 4 nav items when PUR enabled', () => {
+    it('should return the 4 nav items', () => {
       mockGetConnectedRobot.mockReturnValue({} as any)
       mockGetConnectedRobotPipettesMatch.mockReturnValue(true)
       mockGetConnectedRobotPipettesCalibrated.mockReturnValue(true)
@@ -121,27 +116,8 @@ describe('useRunLocation', () => {
         protocolRecord: {},
         runRecord: {},
       } as any)
-      when(mockUseFeatureFlag)
-        .calledWith('preProtocolFlowWithoutRPC')
-        .mockReturnValue(true)
       const { result } = renderHook(useNavLocations, { wrapper })
       expect(result.current.length).toBe(4)
-    })
-    it('should return the 5 nav items when PUR feature flag is not set', () => {
-      mockGetConnectedRobot.mockReturnValue({} as any)
-      mockGetConnectedRobotPipettesMatch.mockReturnValue(true)
-      mockGetConnectedRobotPipettesCalibrated.mockReturnValue(true)
-      mockGetDeckCalibrationOk.mockReturnValue(true)
-      mockGetNavbarLocations.mockReturnValue([0, 1, 2, 3, 4] as any)
-      mockUseCurrentProtocolRun.mockReturnValue({
-        protocolRecord: {},
-        runRecord: {},
-      } as any)
-      when(mockUseFeatureFlag)
-        .calledWith('preProtocolFlowWithoutRPC')
-        .mockReturnValue(false)
-      const { result } = renderHook(useNavLocations, { wrapper })
-      expect(result.current.length).toBe(5)
     })
   })
 })

--- a/app/src/App/hooks.ts
+++ b/app/src/App/hooks.ts
@@ -6,7 +6,6 @@ import {
   getConnectedRobotPipettesCalibrated,
   getDeckCalibrationOk,
 } from '../redux/nav'
-import { useFeatureFlag } from '../redux/config'
 import { getConnectedRobot } from '../redux/discovery'
 import { useCurrentProtocolRun } from '../organisms/ProtocolUpload/hooks'
 import { NavLocation } from '../redux/nav/types'
@@ -38,17 +37,11 @@ export function useRunLocation(): NavLocation {
 }
 
 export function useNavLocations(): NavLocation[] {
-  const isPreProtocolFlowWithoutRPC = useFeatureFlag(
-    'preProtocolFlowWithoutRPC'
-  )
-  const [robots, upload, calibrate, legacyRun, more] = useSelector(
-    getNavbarLocations
-  )
+  const [robots, upload, more] = useSelector(getNavbarLocations)
 
   const runLocation = useRunLocation()
 
-  const legacyLocations = [robots, upload, calibrate, legacyRun, more]
   const navLocations = [robots, upload, runLocation, more]
 
-  return isPreProtocolFlowWithoutRPC ? navLocations : legacyLocations
+  return navLocations
 }

--- a/app/src/redux/config/constants.ts
+++ b/app/src/redux/config/constants.ts
@@ -5,7 +5,6 @@ export const CONFIG_VERSION_LATEST: 1 = 1
 export const DEV_INTERNAL_FLAGS: DevInternalFlag[] = [
   'allPipetteConfig',
   'enableBundleUpload',
-  'preProtocolFlowWithoutRPC',
 ]
 
 // action type constants

--- a/app/src/redux/config/schema-types.ts
+++ b/app/src/redux/config/schema-types.ts
@@ -6,10 +6,7 @@ export type UpdateChannel = 'latest' | 'beta' | 'alpha'
 
 export type DiscoveryCandidates = string | string[]
 
-export type DevInternalFlag =
-  | 'allPipetteConfig'
-  | 'enableBundleUpload'
-  | 'preProtocolFlowWithoutRPC'
+export type DevInternalFlag = 'allPipetteConfig' | 'enableBundleUpload'
 
 export type FeatureFlags = Partial<Record<DevInternalFlag, boolean | undefined>>
 

--- a/app/src/redux/nav/__tests__/selectors.test.ts
+++ b/app/src/redux/nav/__tests__/selectors.test.ts
@@ -97,22 +97,6 @@ const EXPECTED_UPLOAD = {
   disabledReason: expect.any(String),
 }
 
-const EXPECTED_CALIBRATE = {
-  id: 'calibrate',
-  path: '/calibrate',
-  title: 'Calibrate',
-  iconName: 'ot-calibrate',
-  disabledReason: expect.any(String),
-}
-
-const EXPECTED_RUN = {
-  id: 'run',
-  path: '/run',
-  title: 'Run',
-  iconName: 'ot-run',
-  disabledReason: expect.any(String),
-}
-
 const EXPECTED_MORE = {
   id: 'more',
   path: '/more',
@@ -120,6 +104,8 @@ const EXPECTED_MORE = {
   iconName: 'dots-horizontal',
   notificationReason: null,
 }
+
+// TODO(sb, 2020-11-23) rip out unneccessary tests during PUR cleanup
 
 describe('nav selectors', () => {
   const mockState: State = { mockState: true } as any
@@ -158,14 +144,6 @@ describe('nav selectors', () => {
           ...EXPECTED_UPLOAD,
           disabledReason: expect.stringMatching(/connect to a robot/),
         },
-        {
-          ...EXPECTED_CALIBRATE,
-          disabledReason: expect.stringMatching(/connect to a robot/),
-        },
-        {
-          ...EXPECTED_RUN,
-          disabledReason: expect.stringMatching(/connect to a robot/),
-        },
         EXPECTED_MORE,
       ],
     },
@@ -178,14 +156,6 @@ describe('nav selectors', () => {
       expected: [
         EXPECTED_ROBOTS,
         { ...EXPECTED_UPLOAD, disabledReason: null },
-        {
-          ...EXPECTED_CALIBRATE,
-          disabledReason: expect.stringMatching(/load a protocol/),
-        },
-        {
-          ...EXPECTED_RUN,
-          disabledReason: expect.stringMatching(/load a protocol/),
-        },
         EXPECTED_MORE,
       ],
     },
@@ -202,11 +172,6 @@ describe('nav selectors', () => {
           ...EXPECTED_UPLOAD,
           disabledReason: expect.stringMatching(/while a run is in progress/),
         },
-        {
-          ...EXPECTED_CALIBRATE,
-          disabledReason: expect.stringMatching(/while a run is in progress/),
-        },
-        EXPECTED_RUN,
         EXPECTED_MORE,
       ],
     },
@@ -220,14 +185,6 @@ describe('nav selectors', () => {
       expected: [
         EXPECTED_ROBOTS,
         { ...EXPECTED_UPLOAD, disabledReason: null },
-        {
-          ...EXPECTED_CALIBRATE,
-          disabledReason: expect.stringMatching(/with runnable steps/),
-        },
-        {
-          ...EXPECTED_RUN,
-          disabledReason: expect.stringMatching(/with runnable steps/),
-        },
         EXPECTED_MORE,
       ],
     },
@@ -245,14 +202,6 @@ describe('nav selectors', () => {
       expected: [
         EXPECTED_ROBOTS,
         { ...EXPECTED_UPLOAD, disabledReason: null },
-        {
-          ...EXPECTED_CALIBRATE,
-          disabledReason: expect.stringMatching(/pipettes do not match/),
-        },
-        {
-          ...EXPECTED_RUN,
-          disabledReason: expect.stringMatching(/pipettes do not match/),
-        },
         EXPECTED_MORE,
       ],
     },
@@ -271,14 +220,6 @@ describe('nav selectors', () => {
       expected: [
         EXPECTED_ROBOTS,
         { ...EXPECTED_UPLOAD, disabledReason: null },
-        {
-          ...EXPECTED_CALIBRATE,
-          disabledReason: expect.stringMatching(/calibrate all pipettes/),
-        },
-        {
-          ...EXPECTED_RUN,
-          disabledReason: expect.stringMatching(/calibrate all pipettes/),
-        },
         EXPECTED_MORE,
       ],
     },
@@ -298,14 +239,6 @@ describe('nav selectors', () => {
           ...EXPECTED_UPLOAD,
           disabledReason: expect.stringMatching(/calibrate your deck/i),
         },
-        {
-          ...EXPECTED_CALIBRATE,
-          disabledReason: expect.stringMatching(/load a protocol/i),
-        },
-        {
-          ...EXPECTED_RUN,
-          disabledReason: expect.stringMatching(/load a protocol/i),
-        },
         EXPECTED_MORE,
       ],
     },
@@ -319,24 +252,10 @@ describe('nav selectors', () => {
         mockGetCommands.mockReturnValue([
           { id: 0, description: 'Foo', handledAt: null, children: [] },
         ] as any)
-        mockGetProtocolPipettesMatching.mockReturnValue(true)
-        mockGetProtocolPipettesCalibrated.mockReturnValue(true)
-      },
-      after: () => {
-        expect(mockGetProtocolPipettesMatching).toHaveBeenCalledWith(
-          mockState,
-          mockRobot.name
-        )
-        expect(mockGetProtocolPipettesCalibrated).toHaveBeenCalledWith(
-          mockState,
-          mockRobot.name
-        )
       },
       expected: [
         EXPECTED_ROBOTS,
         { ...EXPECTED_UPLOAD, disabledReason: null },
-        { ...EXPECTED_CALIBRATE, disabledReason: null },
-        { ...EXPECTED_RUN, disabledReason: null },
         EXPECTED_MORE,
       ],
     },
@@ -350,11 +269,6 @@ describe('nav selectors', () => {
       expected: [
         EXPECTED_ROBOTS,
         { ...EXPECTED_UPLOAD, disabledReason: null },
-        {
-          ...EXPECTED_CALIBRATE,
-          disabledReason: expect.stringMatching(/reset your protocol/),
-        },
-        EXPECTED_RUN,
         EXPECTED_MORE,
       ],
     },
@@ -367,8 +281,6 @@ describe('nav selectors', () => {
       expected: [
         EXPECTED_ROBOTS,
         EXPECTED_UPLOAD,
-        EXPECTED_CALIBRATE,
-        EXPECTED_RUN,
         {
           ...EXPECTED_MORE,
           notificationReason: expect.stringMatching(/app update is available/),
@@ -384,8 +296,6 @@ describe('nav selectors', () => {
       expected: [
         EXPECTED_ROBOTS,
         EXPECTED_UPLOAD,
-        EXPECTED_CALIBRATE,
-        EXPECTED_RUN,
         {
           ...EXPECTED_MORE,
           notificationReason: expect.stringMatching(
@@ -413,8 +323,6 @@ describe('nav selectors', () => {
           notificationReason: expect.stringMatching(/update is available/),
         },
         { ...EXPECTED_UPLOAD, disabledReason: null },
-        EXPECTED_CALIBRATE,
-        EXPECTED_RUN,
         EXPECTED_MORE,
       ],
     },
@@ -429,8 +337,6 @@ describe('nav selectors', () => {
       expected: [
         EXPECTED_ROBOTS,
         { ...EXPECTED_UPLOAD, disabledReason: null },
-        EXPECTED_CALIBRATE,
-        EXPECTED_RUN,
         EXPECTED_MORE,
       ],
     },

--- a/app/src/redux/nav/__tests__/selectors.test.ts
+++ b/app/src/redux/nav/__tests__/selectors.test.ts
@@ -129,7 +129,6 @@ describe('nav selectors', () => {
     mockGetFeatureFlags.mockReturnValue({
       allPipetteConfig: false,
       enableBundleUpload: false,
-      preProtocolFlowWithoutRPC: false,
     })
     mockGetConnectedRobot.mockReturnValue(null)
     mockGetProtocolData.mockReturnValue(null)

--- a/app/src/redux/nav/selectors.ts
+++ b/app/src/redux/nav/selectors.ts
@@ -219,10 +219,8 @@ export const getNavbarLocations: (
 ) => NavLocation[] = createSelector(
   getRobotsLocation,
   getUploadLocation,
-  getCalibrateLocation,
-  getRunLocation,
   getMoreLocation,
-  (robots, upload, calibrate, run, more) => {
-    return [robots, upload, calibrate, run, more]
+  (robots, upload, more) => {
+    return [robots, upload, more]
   }
 )


### PR DESCRIPTION
close #8873

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Remove FF from Navigation
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
All instances of `preProtocolFlowWithoutRPC` and their logic should be removed from the following locations within the nav.

- [ ] opentrons/app/src/App/hooks.ts
- [ ] opentrons/app/src/App/__tests__/hooks.test.tsx
- [ ] opentrons/app/src/redux/nav/__tests__/selectors.test.ts

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Verify that the new nav loads whether FF is on or off
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
