### PR TITLE
refactor(app): fully wire up LPC success toast

### DIFF
--- a/app/src/App/index.tsx
+++ b/app/src/App/index.tsx
@@ -55,7 +55,9 @@ export const AppComponent = (): JSX.Element => {
           <Route path="/calibrate" component={CalibratePanel} />
           <Route path="/run" component={RunPanel} />
         </Switch>
+        <TopPortalRoot />
         <Box position={POSITION_RELATIVE} width="100%" height="100%">
+          <ModalPortalRoot />
           <Switch>
             <Route path="/robots/:name?">
               <Robots />
@@ -74,10 +76,8 @@ export const AppComponent = (): JSX.Element => {
             </Route>
             <Redirect exact from="/" to="/robots" />
           </Switch>
-          <ModalPortalRoot />
           <Alerts />
         </Box>
-        <TopPortalRoot />
       </Flex>
     </ApiHostProvider>
   )

--- a/app/src/assets/localization/en/protocol_info.json
+++ b/app/src/assets/localization/en/protocol_info.json
@@ -47,5 +47,6 @@
   "rerunning_protocol_modal_body": "<block>Opentrons displays the connected robot’s last protocol run on on the Protocol Upload page. If you run again, Opentrons loads this protocol and applies Labware Offset data if any exists.</block><block>Clicking “Run Again” will take you directly to the Run tab. If you’d like to review the deck setup or run Labware Position Check before running the protocol, navigate to the Protocol tab.</block><block>If you recalibrate your robot, it will clear the last run from the upload page.</block>",
   "rerunning_protocol_modal_link": "Learn more about Labware Offset Data",
   "no_labware_offset_data": "No Labware Offset data",
-  "labware_positon_check_complete_toast": "Labware Position Check complete. {{num_offsets}} Labware Offsets created."
+  "labware_positon_check_complete_toast": "Labware Position Check complete. {{num_offsets}} Labware Offsets created.",
+  "no_labware_offsets": "No"
 }

--- a/app/src/organisms/ProtocolSetup/LabwareOffsetSuccessToast.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwareOffsetSuccessToast.tsx
@@ -7,8 +7,8 @@ import {
   SPACING_2,
 } from '@opentrons/components'
 import { useTranslation } from 'react-i18next'
-import { useCurrentProtocolRun } from '../ProtocolUpload/hooks'
 import { Portal } from '../../App/portal'
+import { useCurrentProtocolRun } from '../ProtocolUpload/hooks'
 
 interface LabwareOffsetSuccessToastProps {
   onCloseClick: () => unknown
@@ -22,7 +22,7 @@ export function LabwareOffsetSuccessToast(
   const labwareOffsets = currentRunData?.labwareOffsets
 
   return (
-    <Portal level="top">
+    <Portal level="page">
       <Flex
         flexDirection={DIRECTION_COLUMN}
         padding={`${SPACING_1} ${SPACING_2}`}

--- a/app/src/organisms/ProtocolSetup/LabwareOffsetSuccessToast.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwareOffsetSuccessToast.tsx
@@ -8,6 +8,7 @@ import {
 } from '@opentrons/components'
 import { useTranslation } from 'react-i18next'
 import { useCurrentProtocolRun } from '../ProtocolUpload/hooks'
+import { Portal } from '../../App/portal'
 
 interface LabwareOffsetSuccessToastProps {
   onCloseClick: () => unknown
@@ -21,17 +22,22 @@ export function LabwareOffsetSuccessToast(
   const labwareOffsets = currentRunData?.labwareOffsets
 
   return (
-    <Flex
-      flexDirection={DIRECTION_COLUMN}
-      padding={`${SPACING_1} ${SPACING_2}`}
-    >
-      <AlertItem
-        type="success"
-        onCloseClick={() => props.onCloseClick}
-        title={t('labware_positon_check_complete_toast', {
-          num_offsets: labwareOffsets?.length,
-        })}
-      />
-    </Flex>
+    <Portal level="top">
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        padding={`${SPACING_1} ${SPACING_2}`}
+      >
+        <AlertItem
+          type="success"
+          onCloseClick={() => props.onCloseClick}
+          title={t('labware_positon_check_complete_toast', {
+            num_offsets:
+              labwareOffsets?.length === 0
+                ? t('no_labware_offsets')
+                : labwareOffsets?.length,
+          })}
+        />
+      </Flex>
+    </Portal>
   )
 }

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
@@ -98,7 +98,7 @@ export const SummaryScreen = (props: {
           onClick={() => {
             props.onLabwarePositionCheckComplete()
             props.onCloseClick()
-            applyLabwareOffsets
+            applyLabwareOffsets()
           }}
         >
           {t('close_and_apply_offset_data')}

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
@@ -23,6 +23,7 @@ import { LabwareOffsetsSummary } from './LabwareOffsetsSummary'
 import { useIntroInfo, useLabwareOffsets, LabwareOffsets } from './hooks'
 import type { SavePositionCommandData } from './types'
 import type { ProtocolFile } from '@opentrons/shared-data'
+import { LabwareOffsetSuccessToast } from '../LabwareOffsetSuccessToast'
 
 export const SummaryScreen = (props: {
   savePositionCommandData: SavePositionCommandData
@@ -39,6 +40,8 @@ export const SummaryScreen = (props: {
     )
   const { createLabwareOffsets } = useCreateLabwareOffsetsMutation()
   const { runRecord } = useCurrentProtocolRun()
+  const [showLPCSuccessToast, setShowLPCSuccessToast] = React.useState(true)
+
   if (introInfo == null) return null
   if (protocolData == null) return null
   const labwareIds = Object.keys(protocolData.labware)
@@ -92,6 +95,14 @@ export const SummaryScreen = (props: {
           title={t('close_and_apply_offset_data')}
           backgroundColor={C_BLUE}
           onClick={applyLabwareOffsets}
+          onClick={() =>
+            showLPCSuccessToast && (
+              <LabwareOffsetSuccessToast
+                onCloseClick={() => setShowLPCSuccessToast(false)}
+              />
+            )
+          }
+          id={'Lpc_summaryScreen_applyOffsetButton'}
         >
           {t('close_and_apply_offset_data')}
         </PrimaryBtn>

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
@@ -23,10 +23,11 @@ import { LabwareOffsetsSummary } from './LabwareOffsetsSummary'
 import { useIntroInfo, useLabwareOffsets, LabwareOffsets } from './hooks'
 import type { SavePositionCommandData } from './types'
 import type { ProtocolFile } from '@opentrons/shared-data'
-import { LabwareOffsetSuccessToast } from '../LabwareOffsetSuccessToast'
 
 export const SummaryScreen = (props: {
   savePositionCommandData: SavePositionCommandData
+  onLabwarePositionCheckComplete: () => void
+  onCloseClick: () => unknown
 }): JSX.Element | null => {
   const { savePositionCommandData } = props
   const [labwareOffsets, setLabwareOffsets] = React.useState<LabwareOffsets>([])
@@ -40,7 +41,6 @@ export const SummaryScreen = (props: {
     )
   const { createLabwareOffsets } = useCreateLabwareOffsetsMutation()
   const { runRecord } = useCurrentProtocolRun()
-  const [showLPCSuccessToast, setShowLPCSuccessToast] = React.useState(true)
 
   if (introInfo == null) return null
   if (protocolData == null) return null
@@ -94,15 +94,12 @@ export const SummaryScreen = (props: {
         <PrimaryBtn
           title={t('close_and_apply_offset_data')}
           backgroundColor={C_BLUE}
-          onClick={applyLabwareOffsets}
-          onClick={() =>
-            showLPCSuccessToast && (
-              <LabwareOffsetSuccessToast
-                onCloseClick={() => setShowLPCSuccessToast(false)}
-              />
-            )
-          }
           id={'Lpc_summaryScreen_applyOffsetButton'}
+          onClick={() => {
+            props.onLabwarePositionCheckComplete()
+            props.onCloseClick()
+            applyLabwareOffsets
+          }}
         >
           {t('close_and_apply_offset_data')}
         </PrimaryBtn>

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/LabwarePositionCheck.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/LabwarePositionCheck.test.tsx
@@ -58,6 +58,7 @@ describe('LabwarePositionCheck', () => {
   beforeEach(() => {
     props = {
       onCloseClick: jest.fn(),
+      onLabwarePositionCheckComplete: jest.fn(),
     }
     when(mockUseSteps)
       .calledWith()

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { when } from 'jest-when'
+import { fireEvent } from '@testing-library/dom'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../../i18n'
 import { useProtocolDetails } from '../../../RunDetails/hooks'
@@ -9,15 +10,12 @@ import { SummaryScreen } from '../SummaryScreen'
 import { LabwareOffsetsSummary } from '../LabwareOffsetsSummary'
 import { useIntroInfo, useLabwareOffsets } from '../hooks'
 import { Section } from '../types'
-import { LabwareOffsetSuccessToast } from '../../LabwareOffsetSuccessToast'
-import { fireEvent, getByText, screen } from '@testing-library/dom'
 
 jest.mock('../SectionList')
 jest.mock('../hooks')
 jest.mock('../DeckMap')
 jest.mock('../../../RunDetails/hooks')
 jest.mock('../LabwareOffsetsSummary')
-jest.mock('../../LabwareOffsetSuccessToast')
 
 const mockSectionList = SectionList as jest.MockedFunction<typeof SectionList>
 const mockUseIntroInfo = useIntroInfo as jest.MockedFunction<
@@ -26,7 +24,6 @@ const mockUseIntroInfo = useIntroInfo as jest.MockedFunction<
 const mockUseProtocolDetails = useProtocolDetails as jest.MockedFunction<
   typeof useProtocolDetails
 >
-
 const mockDeckmap = DeckMap as jest.MockedFunction<typeof DeckMap>
 
 const mockLabwareOffsetsSummary = LabwareOffsetsSummary as jest.MockedFunction<
@@ -34,9 +31,6 @@ const mockLabwareOffsetsSummary = LabwareOffsetsSummary as jest.MockedFunction<
 >
 const mockUseLabwareOffsets = useLabwareOffsets as jest.MockedFunction<
   typeof useLabwareOffsets
->
-const mockLabwareOffsetsSuccessToast = LabwareOffsetSuccessToast as jest.MockedFunction<
-  typeof LabwareOffsetSuccessToast
 >
 
 const MOCK_SECTIONS = ['PRIMARY_PIPETTE_TIPRACKS' as Section]
@@ -51,6 +45,8 @@ const render = () => {
   return renderWithProviders(
     <SummaryScreen
       savePositionCommandData={{ someLabwareIf: ['commandId1', 'commandId2'] }}
+      onLabwarePositionCheckComplete={jest.fn()}
+      onCloseClick={jest.fn()}
     />,
     {
       i18nInstance: i18n,
@@ -62,9 +58,6 @@ describe('SummaryScreen', () => {
   beforeEach(() => {
     mockSectionList.mockReturnValue(<div>Mock SectionList</div>)
     mockDeckmap.mockReturnValue(<div>Mock DeckMap</div>)
-    mockLabwareOffsetsSuccessToast.mockReturnValue(
-      <div>Mock LabwareOffsetSuccessToast</div>
-    )
     mockLabwareOffsetsSummary.mockReturnValue(
       <div>Mock Labware Offsets Summary </div>
     )
@@ -107,13 +100,11 @@ describe('SummaryScreen', () => {
     getByText('Mock Labware Offsets Summary')
     getByText('Labware Position Check Complete')
   })
-  it('renders button and clicks it', () => {
+  it('renders apply offset button and clicks it', () => {
     const { getByRole } = render()
-    expect(screen.queryByText('Mock LabwareOffsetSuccessToast')).toBeNull()
     const button = getByRole('button', {
       name: 'Close and apply labware offset data',
     })
     fireEvent.click(button)
-    expect(screen.queryByText('Mock LabwareOffsetSuccessToast')).not.toBeNull()
   })
 })

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { when } from 'jest-when'
-import { fireEvent, getByText } from '@testing-library/dom'
+import { fireEvent } from '@testing-library/dom'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../../i18n'
 import { useProtocolDetails } from '../../../RunDetails/hooks'

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { when } from 'jest-when'
-import { fireEvent } from '@testing-library/dom'
+import { fireEvent, getByText } from '@testing-library/dom'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../../i18n'
 import { useProtocolDetails } from '../../../RunDetails/hooks'
@@ -41,21 +41,21 @@ const LABWARE_DEF = {
   ordering: [['A1', 'A2']],
 }
 
-const render = () => {
-  return renderWithProviders(
-    <SummaryScreen
-      savePositionCommandData={{ someLabwareIf: ['commandId1', 'commandId2'] }}
-      onLabwarePositionCheckComplete={jest.fn()}
-      onCloseClick={jest.fn()}
-    />,
-    {
-      i18nInstance: i18n,
-    }
-  )[0]
+const render = (props: React.ComponentProps<typeof SummaryScreen>) => {
+  return renderWithProviders(<SummaryScreen {...props} />, {
+    i18nInstance: i18n,
+  })[0]
 }
 
 describe('SummaryScreen', () => {
+  let props: React.ComponentProps<typeof SummaryScreen>
+
   beforeEach(() => {
+    props = {
+      savePositionCommandData: { someLabwareIf: ['commandId1', 'commandId2'] },
+      onLabwarePositionCheckComplete: jest.fn(),
+      onCloseClick: jest.fn(),
+    }
     mockSectionList.mockReturnValue(<div>Mock SectionList</div>)
     mockDeckmap.mockReturnValue(<div>Mock DeckMap</div>)
     mockLabwareOffsetsSummary.mockReturnValue(
@@ -94,17 +94,21 @@ describe('SummaryScreen', () => {
       } as any)
   })
   it('renders Summary Screen with all components and header', () => {
-    const { getByText } = render()
+    const { getByText } = render(props)
     getByText('Mock SectionList')
     getByText('Mock DeckMap')
     getByText('Mock Labware Offsets Summary')
     getByText('Labware Position Check Complete')
   })
   it('renders apply offset button and clicks it', () => {
-    const { getByRole } = render()
+    const { getByRole } = render(props)
+    expect(props.onCloseClick).not.toHaveBeenCalled()
+    expect(props.onLabwarePositionCheckComplete).not.toHaveBeenCalled()
     const button = getByRole('button', {
       name: 'Close and apply labware offset data',
     })
     fireEvent.click(button)
+    expect(props.onCloseClick).toHaveBeenCalled()
+    expect(props.onLabwarePositionCheckComplete).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
@@ -9,12 +9,15 @@ import { SummaryScreen } from '../SummaryScreen'
 import { LabwareOffsetsSummary } from '../LabwareOffsetsSummary'
 import { useIntroInfo, useLabwareOffsets } from '../hooks'
 import { Section } from '../types'
+import { LabwareOffsetSuccessToast } from '../../LabwareOffsetSuccessToast'
+import { fireEvent, getByText, screen } from '@testing-library/dom'
 
 jest.mock('../SectionList')
 jest.mock('../hooks')
 jest.mock('../DeckMap')
 jest.mock('../../../RunDetails/hooks')
 jest.mock('../LabwareOffsetsSummary')
+jest.mock('../../LabwareOffsetSuccessToast')
 
 const mockSectionList = SectionList as jest.MockedFunction<typeof SectionList>
 const mockUseIntroInfo = useIntroInfo as jest.MockedFunction<
@@ -31,6 +34,9 @@ const mockLabwareOffsetsSummary = LabwareOffsetsSummary as jest.MockedFunction<
 >
 const mockUseLabwareOffsets = useLabwareOffsets as jest.MockedFunction<
   typeof useLabwareOffsets
+>
+const mockLabwareOffsetsSuccessToast = LabwareOffsetSuccessToast as jest.MockedFunction<
+  typeof LabwareOffsetSuccessToast
 >
 
 const MOCK_SECTIONS = ['PRIMARY_PIPETTE_TIPRACKS' as Section]
@@ -56,6 +62,9 @@ describe('SummaryScreen', () => {
   beforeEach(() => {
     mockSectionList.mockReturnValue(<div>Mock SectionList</div>)
     mockDeckmap.mockReturnValue(<div>Mock DeckMap</div>)
+    mockLabwareOffsetsSuccessToast.mockReturnValue(
+      <div>Mock LabwareOffsetSuccessToast</div>
+    )
     mockLabwareOffsetsSummary.mockReturnValue(
       <div>Mock Labware Offsets Summary </div>
     )
@@ -100,6 +109,11 @@ describe('SummaryScreen', () => {
   })
   it('renders button and clicks it', () => {
     const { getByRole } = render()
-    getByRole('button', { name: 'Close and apply labware offset data' })
+    expect(screen.queryByText('Mock LabwareOffsetSuccessToast')).toBeNull()
+    const button = getByRole('button', {
+      name: 'Close and apply labware offset data',
+    })
+    fireEvent.click(button)
+    expect(screen.queryByText('Mock LabwareOffsetSuccessToast')).not.toBeNull()
   })
 })

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
@@ -23,6 +23,7 @@ import type { SavePositionCommandData } from './types'
 
 interface LabwarePositionCheckModalProps {
   onCloseClick: () => unknown
+  onLabwarePositionCheckComplete: () => void
 }
 export const LabwarePositionCheck = (
   props: LabwarePositionCheckModalProps
@@ -34,7 +35,6 @@ export const LabwarePositionCheck = (
     setSavePositionCommandData,
   ] = React.useState<SavePositionCommandData>({})
   const [isRestartingRun, setIsRestartingRun] = React.useState<boolean>(false)
-
   const {
     confirm: confirmExitLPC,
     showConfirmation,
@@ -139,7 +139,11 @@ export const LabwarePositionCheck = (
           },
         }}
       >
-        <SummaryScreen savePositionCommandData={savePositionCommandData}/>
+        <SummaryScreen
+          savePositionCommandData={savePositionCommandData}
+          onLabwarePositionCheckComplete={props.onLabwarePositionCheckComplete}
+          onCloseClick={props.onCloseClick}
+        />
       </ModalPage>
     )
   } else if (currentCommandIndex !== 0) {

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
@@ -139,7 +139,7 @@ export const LabwarePositionCheck = (
           },
         }}
       >
-        <SummaryScreen savePositionCommandData={savePositionCommandData} />
+        <SummaryScreen savePositionCommandData={savePositionCommandData}/>
       </ModalPage>
     )
   } else if (currentCommandIndex !== 0) {

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareSetup.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareSetup.test.tsx
@@ -350,16 +350,26 @@ describe('LabwareSetup', () => {
     const { getByText } = render()
     getByText('mock extra attention warning with magnetic module and TC')
   })
-  it('should render close LPC', () => {
+  it('should render Labware Offset Success toast when LPC is closed', () => {
+    const { getByRole, getByText } = render()
     expect(screen.queryByText('mock LabwareOffsetSuccessToast')).toBeNull()
-    const { getByText, getByRole } = render()
     const button = getByRole('button', {
       name: 'run labware position check',
     })
     fireEvent.click(button)
     const LPC = getByText('mock Labware Position Check')
-
     fireEvent.click(LPC)
-    expect(screen.queryByText('mock Labware Position CHeck')).toBeNull()
+    when(mockLabwarePostionCheck)
+      .calledWith(
+        componentPropsMatcher({
+          onLabwarePositionCheckComplete: expect.anything(),
+        })
+      )
+      .mockImplementation(({ onLabwarePositionCheckComplete }) => (
+        <div onClick={onLabwarePositionCheckComplete}>
+          mock LabwarePositionCheck
+        </div>
+      ))
+    expect(screen.queryByText('mock LabwarePositionCheck')).toBeNull()
   })
 })

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareSetup.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareSetup.test.tsx
@@ -8,6 +8,7 @@ import {
   LabwareRender,
   RobotWorkSpace,
   Module,
+  anyProps,
 } from '@opentrons/components'
 import {
   inferModuleOrientationFromXCoordinate,
@@ -149,12 +150,8 @@ describe('LabwareSetup', () => {
         <div onClick={onCloseClick}>mock LabwareOffsetModal </div>
       ))
     when(mockLabwareOffsetSuccessToast)
-      .calledWith(
-        componentPropsMatcher({
-          onCloseClick: expect.anything(),
-        })
-      )
-      .mockReturnValue(<div>mock LabwareOffsetSuccessToast </div>)
+      .calledWith(anyProps())
+      .mockReturnValue(<div>mock Labware Success Toast</div>)
 
     when(mockLabwareRender)
       .mockReturnValue(<div></div>) // this (default) empty div will be returned when LabwareRender isn't called with expected labware definition
@@ -353,16 +350,16 @@ describe('LabwareSetup', () => {
     const { getByText } = render()
     getByText('mock extra attention warning with magnetic module and TC')
   })
-  it('should render LPC success toast when apply LPC offsets button is clicked', () => {
+  it('should render close LPC', () => {
     expect(screen.queryByText('mock LabwareOffsetSuccessToast')).toBeNull()
-    when(mockLabwarePostionCheck)
-      .calledWith(
-        partialComponentPropsMatcher({
-          onLabwarePositionCheckComplete: expect.anything(),
-        })
-      )
-      .mockImplementation(({ onLabwarePositionCheckComplete }) => (
-        <div onClick={onLabwarePositionCheckComplete}></div>
-      ))
+    const { getByText, getByRole } = render()
+    const button = getByRole('button', {
+      name: 'run labware position check',
+    })
+    fireEvent.click(button)
+    const LPC = getByText('mock Labware Position Check')
+
+    fireEvent.click(LPC)
+    expect(screen.queryByText('mock Labware Position CHeck')).toBeNull()
   })
 })

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareSetup.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareSetup.test.tsx
@@ -19,6 +19,7 @@ import fixture_tiprack_300_ul from '@opentrons/shared-data/labware/fixtures/2/fi
 import standardDeckDef from '@opentrons/shared-data/deck/definitions/2/ot2_standard.json'
 import { fireEvent, screen } from '@testing-library/react'
 import { i18n } from '../../../../../i18n'
+import { LabwareOffsetSuccessToast } from '../../../LabwareOffsetSuccessToast'
 import { LabwarePositionCheck } from '../../../LabwarePositionCheck'
 import {
   useModuleRenderInfoById,
@@ -38,6 +39,7 @@ jest.mock('../LabwareInfoOverlay')
 jest.mock('../ExtraAttentionWarning')
 jest.mock('../../../hooks')
 jest.mock('../utils/getModuleTypesThatRequireExtraAttention')
+jest.mock('../../../LabwareOffsetSuccessToast')
 jest.mock('@opentrons/components', () => {
   const actualComponents = jest.requireActual('@opentrons/components')
   return {
@@ -86,6 +88,9 @@ const mockUseModuleRenderInfoById = useModuleRenderInfoById as jest.MockedFuncti
 >
 const mockLabwarePostionCheck = LabwarePositionCheck as jest.MockedFunction<
   typeof LabwarePositionCheck
+>
+const mockLabwareOffsetSuccessToast = LabwareOffsetSuccessToast as jest.MockedFunction<
+  typeof LabwareOffsetSuccessToast
 >
 
 const deckSlotsById = standardDeckDef.locations.orderedSlots.reduce(
@@ -143,6 +148,13 @@ describe('LabwareSetup', () => {
       .mockImplementation(({ onCloseClick }) => (
         <div onClick={onCloseClick}>mock LabwareOffsetModal </div>
       ))
+    when(mockLabwareOffsetSuccessToast)
+      .calledWith(
+        componentPropsMatcher({
+          onCloseClick: expect.anything(),
+        })
+      )
+      .mockReturnValue(<div>mock LabwareOffsetSuccessToast </div>)
 
     when(mockLabwareRender)
       .mockReturnValue(<div></div>) // this (default) empty div will be returned when LabwareRender isn't called with expected labware definition
@@ -340,5 +352,17 @@ describe('LabwareSetup', () => {
 
     const { getByText } = render()
     getByText('mock extra attention warning with magnetic module and TC')
+  })
+  it('should render LPC success toast when apply LPC offsets button is clicked', () => {
+    expect(screen.queryByText('mock LabwareOffsetSuccessToast')).toBeNull()
+    when(mockLabwarePostionCheck)
+      .calledWith(
+        partialComponentPropsMatcher({
+          onLabwarePositionCheckComplete: expect.anything(),
+        })
+      )
+      .mockImplementation(({ onLabwarePositionCheckComplete }) => (
+        <div onClick={onLabwarePositionCheckComplete}></div>
+      ))
   })
 })

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
@@ -33,6 +33,7 @@ import { LabwareInfoOverlay } from './LabwareInfoOverlay'
 import { LabwareOffsetModal } from './LabwareOffsetModal'
 import { getModuleTypesThatRequireExtraAttention } from './utils/getModuleTypesThatRequireExtraAttention'
 import { ExtraAttentionWarning } from './ExtraAttentionWarning'
+import { LabwareOffsetSuccessToast } from '../../LabwareOffsetSuccessToast'
 
 const DECK_LAYER_BLOCKLIST = [
   'calibrationMarkings',
@@ -66,8 +67,15 @@ export const LabwareSetup = (): JSX.Element | null => {
     showLabwarePositionCheckModal,
     setShowLabwarePositionCheckModal,
   ] = React.useState<boolean>(false)
+  const [showLPCSuccessToast, setShowLPCSuccessToast] = React.useState(false)
+
   return (
     <React.Fragment>
+      {showLPCSuccessToast && (
+        <LabwareOffsetSuccessToast
+          onCloseClick={() => setShowLPCSuccessToast(false)}
+        />
+      )}
       {showLabwareHelpModal && (
         <LabwareOffsetModal
           onCloseClick={() => setShowLabwareHelpModal(false)}
@@ -76,6 +84,7 @@ export const LabwareSetup = (): JSX.Element | null => {
       {showLabwarePositionCheckModal && (
         <LabwarePositionCheck
           onCloseClick={() => setShowLabwarePositionCheckModal(false)}
+          onLabwarePositionCheckComplete={() => setShowLPCSuccessToast(true)}
         />
       )}
       <Flex flex="1" maxHeight="85vh" flexDirection={DIRECTION_COLUMN}>

--- a/app/src/organisms/ProtocolSetup/__tests__/LabwareOffsetSuccessToast.test.tsx
+++ b/app/src/organisms/ProtocolSetup/__tests__/LabwareOffsetSuccessToast.test.tsx
@@ -15,6 +15,7 @@ import {
   RUN_ACTION_TYPE_PAUSE,
   RUN_ACTION_TYPE_PLAY,
   RUN_STATUS_SUCCEEDED,
+  LabwareOffset,
 } from '@opentrons/api-client'
 
 jest.mock('@opentrons/components/src/alerts')
@@ -57,16 +58,16 @@ const mockNoOffsetsRun: RunData = {
   pipettes: [],
   labware: [],
 }
-const mock2OffsetsRun: RunData = {
+const mock1OffsetsRun: RunData = {
   id: RUN_ID_2,
   createdAt: '2021-10-07T18:44:49.366581+00:00',
   labwareOffsets: [
-    {
+    ({
       id: 'id',
       definitionUri: 'definitionUri',
-      location: location,
+      location: 'a location',
       offset: { x: 1, y: 1, z: 1 },
-    },
+    } as unknown) as LabwareOffset,
   ],
   status: RUN_STATUS_SUCCEEDED,
   protocolId: PROTOCOL_ID,
@@ -120,18 +121,24 @@ describe(' LabwareOffsetSuccessToast', () => {
 
   it('renders LPC success toast and is clickable with 0 offsets', () => {
     const { getByText } = render(props)
+    expect(getByText('No Labware Offsets created')).toHaveStyle(
+      'backgroundColor: c-bg-success'
+    )
     const successToast = getByText('No Labware Offsets created')
     fireEvent.click(successToast)
   })
-  it('renders LPC success toast and is clickable with 2 offsets', () => {
-    mockAlertItem.mockReturnValue(<div>2 Labware Offsets created</div>)
+  it('renders LPC success toast and is clickable with 1 offset', () => {
+    mockAlertItem.mockReturnValue(<div>1 Labware Offsets created</div>)
     when(mockUseCurrentProtocolRun)
       .calledWith()
       .mockReturnValue({
-        runRecord: { data: mock2OffsetsRun },
+        runRecord: { data: mock1OffsetsRun },
       } as UseCurrentProtocolRun)
     const { getByText } = render(props)
-    const successToast = getByText('2 Labware Offsets created')
+    expect(getByText('1 Labware Offsets created')).toHaveStyle(
+      'backgroundColor: c-success'
+    )
+    const successToast = getByText('1 Labware Offsets created')
     fireEvent.click(successToast)
   })
 })

--- a/app/src/organisms/ProtocolSetup/__tests__/LabwareOffsetSuccessToast.test.tsx
+++ b/app/src/organisms/ProtocolSetup/__tests__/LabwareOffsetSuccessToast.test.tsx
@@ -1,14 +1,97 @@
 import * as React from 'react'
 import '@testing-library/jest-dom'
-import { renderWithProviders } from '@opentrons/components'
-import { AlertItem } from '@opentrons/components/src/alerts'
-import { i18n } from '../../../i18n'
 import { fireEvent } from '@testing-library/dom'
+import { when } from 'jest-when'
+import { renderWithProviders } from '@opentrons/components'
+import { i18n } from '../../../i18n'
+import { AlertItem } from '@opentrons/components/src/alerts'
 import { LabwareOffsetSuccessToast } from '../LabwareOffsetSuccessToast'
+import {
+  UseCurrentProtocolRun,
+  useCurrentProtocolRun,
+} from '../../ProtocolUpload/hooks'
+import {
+  RunData,
+  RUN_ACTION_TYPE_PAUSE,
+  RUN_ACTION_TYPE_PLAY,
+  RUN_STATUS_SUCCEEDED,
+} from '@opentrons/api-client'
 
 jest.mock('@opentrons/components/src/alerts')
+jest.mock('../../ProtocolUpload/hooks')
 
 const mockAlertItem = AlertItem as jest.MockedFunction<typeof AlertItem>
+const mockUseCurrentProtocolRun = useCurrentProtocolRun as jest.MockedFunction<
+  typeof useCurrentProtocolRun
+>
+
+const PROTOCOL_ID = '1'
+const RUN_ID_2 = '2'
+const COMMAND_ID = '4'
+
+const mockNoOffsetsRun: RunData = {
+  id: RUN_ID_2,
+  createdAt: '2021-10-07T18:44:49.366581+00:00',
+  labwareOffsets: [],
+  status: RUN_STATUS_SUCCEEDED,
+  protocolId: PROTOCOL_ID,
+  actions: [
+    {
+      id: '1',
+      createdAt: '2021-10-25T12:54:53.366581+00:00',
+      actionType: RUN_ACTION_TYPE_PLAY,
+    },
+    {
+      id: '2',
+      createdAt: '2021-10-25T13:23:31.366581+00:00',
+      actionType: RUN_ACTION_TYPE_PAUSE,
+    },
+    {
+      id: '3',
+      createdAt: '2021-10-25T13:26:42.366581+00:00',
+      actionType: RUN_ACTION_TYPE_PLAY,
+    },
+  ],
+  commands: [{ id: COMMAND_ID, commandType: 'custom', status: 'succeeded' }],
+  errors: [],
+  pipettes: [],
+  labware: [],
+}
+const mock2OffsetsRun: RunData = {
+  id: RUN_ID_2,
+  createdAt: '2021-10-07T18:44:49.366581+00:00',
+  labwareOffsets: [
+    {
+      id: 'id',
+      definitionUri: 'definitionUri',
+      location: location,
+      offset: { x: 1, y: 1, z: 1 },
+    },
+  ],
+  status: RUN_STATUS_SUCCEEDED,
+  protocolId: PROTOCOL_ID,
+  actions: [
+    {
+      id: '1',
+      createdAt: '2021-10-25T12:54:53.366581+00:00',
+      actionType: RUN_ACTION_TYPE_PLAY,
+    },
+    {
+      id: '2',
+      createdAt: '2021-10-25T13:23:31.366581+00:00',
+      actionType: RUN_ACTION_TYPE_PAUSE,
+    },
+    {
+      id: '3',
+      createdAt: '2021-10-25T13:26:42.366581+00:00',
+      actionType: RUN_ACTION_TYPE_PLAY,
+    },
+  ],
+  commands: [{ id: COMMAND_ID, commandType: 'custom', status: 'succeeded' }],
+  errors: [],
+  pipettes: [],
+  labware: [],
+}
 
 const render = (
   props: React.ComponentProps<typeof LabwareOffsetSuccessToast>
@@ -23,7 +106,12 @@ describe(' LabwareOffsetSuccessToast', () => {
 
   beforeEach(() => {
     props = { onCloseClick: jest.fn() }
-    mockAlertItem.mockReturnValue(<div>Mock AlertItem</div>)
+    mockAlertItem.mockReturnValue(<div>No Labware Offsets created</div>)
+    when(mockUseCurrentProtocolRun)
+      .calledWith()
+      .mockReturnValue({
+        runRecord: { data: mockNoOffsetsRun },
+      } as UseCurrentProtocolRun)
   })
 
   afterEach(() => {
@@ -32,7 +120,18 @@ describe(' LabwareOffsetSuccessToast', () => {
 
   it('renders LPC success toast and is clickable', () => {
     const { getByText } = render(props)
-    const successToast = getByText('Mock AlertItem')
+    const successToast = getByText('No Labware Offsets created')
+    fireEvent.click(successToast)
+  })
+  it('renders LPC success toast and is clickable', () => {
+    mockAlertItem.mockReturnValue(<div>2 Labware Offsets created</div>)
+    when(mockUseCurrentProtocolRun)
+      .calledWith()
+      .mockReturnValue({
+        runRecord: { data: mock2OffsetsRun },
+      } as UseCurrentProtocolRun)
+    const { getByText } = render(props)
+    const successToast = getByText('2 Labware Offsets created')
     fireEvent.click(successToast)
   })
 })

--- a/app/src/organisms/ProtocolSetup/__tests__/LabwareOffsetSuccessToast.test.tsx
+++ b/app/src/organisms/ProtocolSetup/__tests__/LabwareOffsetSuccessToast.test.tsx
@@ -131,7 +131,7 @@ describe(' LabwareOffsetSuccessToast', () => {
   })
   it('renders LPC success toast and is clickable with 1 offset', () => {
     mockAlertItem.mockReturnValue(<div>1 Labware Offsets created</div>)
-    const { getByText, getByTestId } = render(props)
+    const { getByText } = render(props)
     when(mockUseCurrentProtocolRun)
       .calledWith()
       .mockReturnValue({

--- a/app/src/organisms/ProtocolSetup/__tests__/LabwareOffsetSuccessToast.test.tsx
+++ b/app/src/organisms/ProtocolSetup/__tests__/LabwareOffsetSuccessToast.test.tsx
@@ -118,12 +118,12 @@ describe(' LabwareOffsetSuccessToast', () => {
     jest.resetAllMocks()
   })
 
-  it('renders LPC success toast and is clickable', () => {
+  it('renders LPC success toast and is clickable with 0 offsets', () => {
     const { getByText } = render(props)
     const successToast = getByText('No Labware Offsets created')
     fireEvent.click(successToast)
   })
-  it('renders LPC success toast and is clickable', () => {
+  it('renders LPC success toast and is clickable with 2 offsets', () => {
     mockAlertItem.mockReturnValue(<div>2 Labware Offsets created</div>)
     when(mockUseCurrentProtocolRun)
       .calledWith()

--- a/app/src/organisms/ProtocolSetup/__tests__/LabwareOffsetSuccessToast.test.tsx
+++ b/app/src/organisms/ProtocolSetup/__tests__/LabwareOffsetSuccessToast.test.tsx
@@ -1,8 +1,12 @@
 import * as React from 'react'
 import '@testing-library/jest-dom'
-import { fireEvent } from '@testing-library/dom'
+import { fireEvent, screen } from '@testing-library/dom'
 import { when } from 'jest-when'
-import { renderWithProviders, anyProps } from '@opentrons/components'
+import {
+  renderWithProviders,
+  anyProps,
+  partialComponentPropsMatcher,
+} from '@opentrons/components'
 import { i18n } from '../../../i18n'
 import { AlertItem } from '@opentrons/components/src/alerts'
 import { LabwareOffsetSuccessToast } from '../LabwareOffsetSuccessToast'
@@ -129,19 +133,27 @@ describe(' LabwareOffsetSuccessToast', () => {
     const successToast = getByText('No Labware Offsets created')
     fireEvent.click(successToast)
   })
-  it('renders LPC success toast and is clickable with 1 offset', () => {
+  it('renders LPC success toast and closes succcess toast where run has 1 offset', () => {
     mockAlertItem.mockReturnValue(<div>1 Labware Offsets created</div>)
-    const { getByText } = render(props)
     when(mockUseCurrentProtocolRun)
       .calledWith()
       .mockReturnValue({
         runRecord: { data: mock1OffsetsRun },
       } as UseCurrentProtocolRun)
+    const { getByText } = render(props)
     expect(getByText('1 Labware Offsets created')).toHaveStyle(
       'backgroundColor: c-success'
     )
-    const successToast = getByText('1 Labware Offsets created')
-    fireEvent.click(successToast)
-    expect(successToast).toBeTruthy()
+    fireEvent.click(getByText('1 Labware Offsets created'))
+    when(mockAlertItem)
+      .calledWith(
+        partialComponentPropsMatcher({
+          onCloseClick: expect.anything(),
+        })
+      )
+      .mockImplementation(({ onCloseClick }) => (
+        <div onClick={onCloseClick}>mock LPC text </div>
+      ))
+    expect(screen.queryByText('mock LPC text')).toBeNull()
   })
 })

--- a/app/src/organisms/ProtocolSetup/__tests__/LabwareOffsetSuccessToast.test.tsx
+++ b/app/src/organisms/ProtocolSetup/__tests__/LabwareOffsetSuccessToast.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import '@testing-library/jest-dom'
 import { fireEvent } from '@testing-library/dom'
 import { when } from 'jest-when'
-import { renderWithProviders } from '@opentrons/components'
+import { renderWithProviders, anyProps } from '@opentrons/components'
 import { i18n } from '../../../i18n'
 import { AlertItem } from '@opentrons/components/src/alerts'
 import { LabwareOffsetSuccessToast } from '../LabwareOffsetSuccessToast'
@@ -107,7 +107,9 @@ describe(' LabwareOffsetSuccessToast', () => {
 
   beforeEach(() => {
     props = { onCloseClick: jest.fn() }
-    mockAlertItem.mockReturnValue(<div>No Labware Offsets created</div>)
+    when(mockAlertItem)
+      .calledWith(anyProps())
+      .mockReturnValue(<div>No Labware Offsets created</div>)
     when(mockUseCurrentProtocolRun)
       .calledWith()
       .mockReturnValue({
@@ -129,16 +131,17 @@ describe(' LabwareOffsetSuccessToast', () => {
   })
   it('renders LPC success toast and is clickable with 1 offset', () => {
     mockAlertItem.mockReturnValue(<div>1 Labware Offsets created</div>)
+    const { getByText, getByTestId } = render(props)
     when(mockUseCurrentProtocolRun)
       .calledWith()
       .mockReturnValue({
         runRecord: { data: mock1OffsetsRun },
       } as UseCurrentProtocolRun)
-    const { getByText } = render(props)
     expect(getByText('1 Labware Offsets created')).toHaveStyle(
       'backgroundColor: c-success'
     )
     const successToast = getByText('1 Labware Offsets created')
     fireEvent.click(successToast)
+    expect(successToast).toBeTruthy()
   })
 })

--- a/app/src/organisms/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/organisms/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -1,25 +1,19 @@
 import * as React from 'react'
 import '@testing-library/jest-dom'
-import { fireEvent } from '@testing-library/dom'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../i18n'
 import { RunSetupCard } from '../RunSetupCard'
 import { MetadataCard } from '../MetadataCard'
-import { LabwareOffsetSuccessToast } from '../LabwareOffsetSuccessToast'
 import { ProtocolSetup } from '..'
 
 jest.mock('../MetadataCard')
 jest.mock('../RunSetupCard')
-jest.mock('../LabwareOffsetSuccessToast')
 
 const mockMetadataCard = MetadataCard as jest.MockedFunction<
   typeof MetadataCard
 >
 const mockRunSetupCard = RunSetupCard as jest.MockedFunction<
   typeof RunSetupCard
->
-const mockLabwareOffsetSuccessToast = LabwareOffsetSuccessToast as jest.MockedFunction<
-  typeof LabwareOffsetSuccessToast
 >
 
 describe('ProtocolSetup', () => {
@@ -32,20 +26,12 @@ describe('ProtocolSetup', () => {
   beforeEach(() => {
     mockMetadataCard.mockReturnValue(<div>Mock MetadataCard</div>)
     mockRunSetupCard.mockReturnValue(<div>Mock ReunSetupCard</div>)
-    mockLabwareOffsetSuccessToast.mockReturnValue(
-      <div>Mock LabwareOffsetSuccessToast</div>
-    )
   })
 
   it('renders metadata and run setup card', () => {
     const { getByText } = render()
     getByText('Mock MetadataCard')
     getByText('Mock ReunSetupCard')
-  })
-  it('renders LPC success toast and is clickable', () => {
-    const { getByText } = render()
-    const successToast = getByText('Mock LabwareOffsetSuccessToast')
-    fireEvent.click(successToast)
   })
   it('renders feedback link', () => {
     const { getByText, getByRole } = render()

--- a/app/src/organisms/ProtocolSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/index.tsx
@@ -11,7 +11,6 @@ import {
   Link,
   SPACING_1,
 } from '@opentrons/components'
-import { LabwareOffsetSuccessToast } from './LabwareOffsetSuccessToast'
 import { RunSetupCard } from './RunSetupCard'
 import { MetadataCard } from './MetadataCard'
 
@@ -20,34 +19,26 @@ const feedbackFormLink =
 
 export function ProtocolSetup(): JSX.Element {
   const { t } = useTranslation(['protocol_setup'])
-  const [showLPCSuccessToast, setShowLPCSuccessToast] = React.useState(true)
 
   return (
-    <>
-      {showLPCSuccessToast && (
-        <LabwareOffsetSuccessToast
-          onCloseClick={() => setShowLPCSuccessToast(false)}
-        />
-      )}
-      <Flex
-        flexDirection={DIRECTION_COLUMN}
-        alignItems={ALIGN_CENTER}
-        padding={`${SPACING_1} ${SPACING_3} ${SPACING_3} ${SPACING_3}`}
+    <Flex
+      flexDirection={DIRECTION_COLUMN}
+      alignItems={ALIGN_CENTER}
+      padding={`${SPACING_1} ${SPACING_3} ${SPACING_3} ${SPACING_3}`}
+    >
+      <MetadataCard />
+      <RunSetupCard />
+      <Text
+        fontSize={FONT_SIZE_BODY_2}
+        paddingTop={SPACING_3}
+        color={C_DARK_GRAY}
       >
-        <MetadataCard />
-        <RunSetupCard />
-        <Text
-          fontSize={FONT_SIZE_BODY_2}
-          paddingTop={SPACING_3}
-          color={C_DARK_GRAY}
-        >
-          {t('protocol_upload_revamp_feedback')}
-          <Link href={feedbackFormLink} external>
-            {' '}
-            {t('feedback_form_link')}
-          </Link>
-        </Text>
-      </Flex>
-    </>
+        {t('protocol_upload_revamp_feedback')}
+        <Link href={feedbackFormLink} external>
+          {' '}
+          {t('feedback_form_link')}
+        </Link>
+      </Text>
+    </Flex>
   )
 }


### PR DESCRIPTION
# Overview

closes #8486 and addresses TODO comment in PR #8830 
This PR finishes wiring up the LPC Success Toast after a user clicks on the `Close and apply labware offset data` CTA at the end of LPC

# Changelog

- remove `labwareOffsetSuccessTosast` in `ProtocolSetup` and add to `LabwareSetup/index`
- make a few UI changes mentioned in the TODO comment

# Review requests

- had to rearrange `app/index` a little bit to change where the toast was rendered in order to make it render on top of `ProtocolSetup` and not on the left or right side. - review this change to make sure it's ok
- I ran this on a robot and it works fine but should probably double check on another robot and call out any bugs

# Risk assessment

low, behind ff