### PR TITLE
refactor(engine): add labware on modules geometry

### DIFF
--- a/api/src/opentrons/protocol_api/labware_offset_provider.py
+++ b/api/src/opentrons/protocol_api/labware_offset_provider.py
@@ -26,7 +26,9 @@ class AbstractLabwareOffsetProvider(ABC):
     def find(
         self,
         labware_definition_uri: str,
-        # todo(mm, 2021-11-22): Use an enum, not a str, for the module model.
+        # todo(mm, 2021-11-22): When there's a good module model enum that's usable
+        # by both Protocol Engine and the legacy Python Protocol API, use that here
+        # instead of an unconstrained str.
         module_model: Optional[str],
         deck_slot: DeckSlotName,
     ) -> ProvidedLabwareOffset:

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -90,7 +90,7 @@ class ModuleContext(CommandPublisher, Generic[GeometryType]):
 
         provided_offset = self._ctx._labware_offset_provider.find(
             labware_definition_uri=labware.uri,
-            module_model=str(self.geometry.model),
+            module_model=str(self.geometry.model),  # fixme
             deck_slot=deck_slot,
         )
 

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -90,7 +90,7 @@ class ModuleContext(CommandPublisher, Generic[GeometryType]):
 
         provided_offset = self._ctx._labware_offset_provider.find(
             labware_definition_uri=labware.uri,
-            module_model=str(self.geometry.model),  # fixme
+            module_model=self.geometry.model.value,
             deck_slot=deck_slot,
         )
 

--- a/api/src/opentrons/protocol_engine/errors/__init__.py
+++ b/api/src/opentrons/protocol_engine/errors/__init__.py
@@ -20,6 +20,7 @@ from .exceptions import (
     WellOriginNotAllowedError,
     ModuleNotAttachedError,
     ModuleDefinitionDoesNotExistError,
+    ModuleIsNotThermocyclerError,
 )
 
 from .error_occurrence import ErrorOccurrence
@@ -45,6 +46,7 @@ __all__ = [
     "WellOriginNotAllowedError",
     "ModuleNotAttachedError",
     "ModuleDefinitionDoesNotExistError",
+    "ModuleIsNotThermocyclerError",
     # error occurrence models
     "ErrorOccurrence",
 ]

--- a/api/src/opentrons/protocol_engine/errors/exceptions.py
+++ b/api/src/opentrons/protocol_engine/errors/exceptions.py
@@ -94,3 +94,7 @@ class ModuleNotAttachedError(ProtocolEngineError):
 
 class ModuleDefinitionDoesNotExistError(ProtocolEngineError):
     """An error raised when referencing a module definition that does not exist."""
+
+
+class ModuleIsNotThermocyclerError(ProtocolEngineError):
+    """An error raised when performing thermocycler actions with a non-thermocycler."""

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -124,8 +124,9 @@ class EquipmentHandler:
             slot_name = location.slotName
             module_model = None
         else:
-            # TODO(mc, 2021-11-23): https://github.com/Opentrons/opentrons/issues/8242
-            raise NotImplementedError("Loading labware on modules not yet implemented")
+            module = self._state_store.modules.get(location.moduleId)
+            slot_name = module.location.slotName
+            module_model = module.model
 
         offset = self._state_store.labware.find_applicable_labware_offset(
             definition_uri=definition_uri,

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -13,6 +13,7 @@ from ..types import (
     WellOrigin,
     WellOffset,
     DeckSlotLocation,
+    ModuleLocation,
 )
 from .labware import LabwareView
 from .modules import ModuleView
@@ -132,8 +133,11 @@ class GeometryView:
         labware_pos = self.get_labware_position(lw_data.id)
         definition = self._labware.get_definition(lw_data.id)
         z_dim = definition.dimensions.zDimension
-
-        return labware_pos.z + z_dim
+        height_over_labware: float = 0
+        if isinstance(lw_data.location, ModuleLocation):
+            module_id = lw_data.location.moduleId
+            height_over_labware = self._modules.get_height_over_labware(module_id)
+        return labware_pos.z + z_dim + height_over_labware
 
     # TODO(mc, 2020-11-12): reconcile with existing protocol logic and include
     # data from tip-length calibration once v4.0.0 is in `edge`

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -38,17 +38,10 @@ class TipGeometry:
 class GeometryView:
     """Geometry computed state getters."""
 
-    _labware: LabwareView
-    _modules: ModuleView
-
-    def __init__(
-            self,
-            labware_view: LabwareView,
-            modules_view: ModuleView
-    ) -> None:
+    def __init__(self, labware_view: LabwareView, module_view: ModuleView) -> None:
         """Initialize a GeometryView instance."""
         self._labware = labware_view
-        self._modules = modules_view
+        self._modules = module_view
 
     # TODO: need updating for labware on modules?
     def get_labware_highest_z(self, labware_id: str) -> float:

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -13,8 +13,10 @@ from ..types import (
     WellOrigin,
     WellOffset,
     DeckSlotLocation,
+    ModuleLocation,
 )
 from .labware import LabwareView
+from .modules import ModuleView
 
 
 DEFAULT_TIP_DROP_HEIGHT_FACTOR = 0.5
@@ -37,17 +39,25 @@ class GeometryView:
     """Geometry computed state getters."""
 
     _labware: LabwareView
+    _modules: ModuleView
 
-    def __init__(self, labware_view: LabwareView) -> None:
+    def __init__(
+            self,
+            labware_view: LabwareView,
+            modules_view: ModuleView
+    ) -> None:
         """Initialize a GeometryView instance."""
         self._labware = labware_view
+        self._modules = modules_view
 
+    # TODO: need updating for labware on modules?
     def get_labware_highest_z(self, labware_id: str) -> float:
         """Get the highest Z-point of a labware."""
         labware_data = self._labware.get(labware_id)
 
         return self._get_highest_z_from_labware_data(labware_data)
 
+    # TODO: need updating for labware on modules?
     def get_all_labware_highest_z(self) -> float:
         """Get the highest Z-point across all labware."""
         return max(
@@ -63,8 +73,9 @@ class GeometryView:
         if isinstance(labware_data.location, DeckSlotLocation):
             slot_pos = self._labware.get_slot_position(labware_data.location.slotName)
             return slot_pos
-        else:
-            raise NotImplementedError("Not implemented for labware on modules")
+        elif isinstance(labware_data.location, ModuleLocation):
+            pos = self._modules.get_module_offset(labware_data.location.moduleId)
+            return Point(x=pos.x, y=pos.y, z=pos.z)
 
     def get_labware_origin_position(self, labware_id: str) -> Point:
         """Get the position of the labware's origin, without calibration."""

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -130,7 +130,9 @@ class ModuleView(HasState[ModuleState]):
         # Apply the slot transform, if any
         xform = array(xforms_ser)
         xformed = dot(xform, pre_transform)  # type: ignore[no-untyped-call]
-        return LabwareOffsetVector(x=xformed[0], y=xformed[1], z=xformed[2])
+        return LabwareOffsetVector(x=xformed[0],
+                                   y=xformed[1],
+                                   z=definition.labwareOffset.z)
 
     def get_overall_height(self, module_id: str) -> float:
         """Get the height of the module."""

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -130,9 +130,9 @@ class ModuleView(HasState[ModuleState]):
         # Apply the slot transform, if any
         xform = array(xforms_ser)
         xformed = dot(xform, pre_transform)  # type: ignore[no-untyped-call]
-        return LabwareOffsetVector(x=xformed[0],
-                                   y=xformed[1],
-                                   z=definition.labwareOffset.z)
+        return LabwareOffsetVector(
+            x=xformed[0], y=xformed[1], z=definition.labwareOffset.z
+        )
 
     def get_overall_height(self, module_id: str) -> float:
         """Get the height of the module."""

--- a/api/src/opentrons/protocol_engine/state/motion.py
+++ b/api/src/opentrons/protocol_engine/state/motion.py
@@ -29,10 +29,6 @@ class PipetteLocationData:
 class MotionView:
     """Complete motion planning state and getter methods."""
 
-    _labware: LabwareView
-    _pipette: PipetteView
-    _geometry: GeometryView
-
     def __init__(
         self,
         labware_view: LabwareView,

--- a/api/src/opentrons/protocol_engine/state/state.py
+++ b/api/src/opentrons/protocol_engine/state/state.py
@@ -189,7 +189,10 @@ class StateStore(StateView, ActionHandler):
         self._modules = ModuleView(state.modules)
 
         # Derived states
-        self._geometry = GeometryView(labware_view=self._labware)
+        self._geometry = GeometryView(
+            labware_view=self._labware,
+            module_view=self._modules,
+        )
         self._motion = MotionView(
             labware_view=self._labware,
             pipette_view=self._pipettes,

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -214,6 +214,7 @@ class ModuleDimensions(BaseModel):
 
     bareOverallHeight: float
     overLabwareHeight: float
+    lidHeight: Optional[float]
 
 
 class ModuleCalibrationPoint(BaseModel):
@@ -221,6 +222,10 @@ class ModuleCalibrationPoint(BaseModel):
 
     x: float
     y: float
+
+
+class ModuleSlotTransform(BaseModel):
+    """Affine transform offset types for modules."""
 
 
 class ModuleDefinition(BaseModel):

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -126,6 +126,7 @@ class MotorAxis(str, Enum):
     RIGHT_PLUNGER = "rightPlunger"
 
 
+# TODO(mc, 2021-11-24): s/ModuleModels/ModuleModel/
 class ModuleModels(str, Enum):
     """All available modules' models."""
 
@@ -188,9 +189,10 @@ class LoadedModule(BaseModel):
     """A module that has been loaded."""
 
     id: str
-    model: str
+    model: ModuleModels
     location: DeckSlotLocation
     definition: ModuleDefinition
+    # TODO(mc, 2021-11-24): make serial non-optional
     serial: Optional[str]
 
 

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -1,7 +1,5 @@
 """Public protocol engine value types and models."""
 
-from __future__ import annotations
-
 from datetime import datetime
 from enum import Enum
 from dataclasses import dataclass
@@ -128,12 +126,71 @@ class MotorAxis(str, Enum):
     RIGHT_PLUNGER = "rightPlunger"
 
 
+class ModuleModels(str, Enum):
+    """All available modules' models."""
+
+    TEMPERATURE_MODULE_V1 = "temperatureModuleV1"
+    TEMPERATURE_MODULE_V2 = "temperatureModuleV2"
+    MAGNETIC_MODULE_V1 = "magneticModuleV1"
+    MAGNETIC_MODULE_V2 = "magneticModuleV2"
+    THERMOCYCLER_MODULE_V1 = "thermocyclerModuleV1"
+
+
+class ModuleDimensions(BaseModel):
+    """Dimension type for modules."""
+
+    bareOverallHeight: float
+    overLabwareHeight: float
+
+
+class ModuleCalibrationPoint(BaseModel):
+    """Calibration Point type for module definition."""
+
+    x: float
+    y: float
+
+
 class LabwareOffsetVector(BaseModel):
     """Offset, in deck coordinates from nominal to actual position."""
 
     x: float
     y: float
     z: float
+
+
+class ModuleDefinition(BaseModel):
+    """Module definition class."""
+
+    otSharedSchema: str = Field("module/schemas/2", description="The current schema.")
+    moduleType: str = Field(
+        ..., description="Module type (Temperature/ Magnetic/ Thermocycler)"
+    )
+    model: str = Field(..., description="Model name of the module")
+    labwareOffset: LabwareOffsetVector = Field(
+        ..., description="Labware offset in x, y, z."
+    )
+    dimensions: ModuleDimensions = Field(..., description="Module dimension")
+    calibrationPoint: ModuleCalibrationPoint = Field(
+        ..., description="Calibration point of module."
+    )
+    displayName: str = Field(..., description="Display name.")
+    quirks: List[str] = Field(..., description="Module quirks")
+    slotTransforms: Dict[str, Any] = Field(
+        ..., description="Dictionary of transforms for each slot."
+    )
+    compatibleWith: List[str] = Field(
+        ..., description="List of module models this model is compatible with."
+    )
+
+
+class LoadedModule(BaseModel):
+    """A module that has been loaded."""
+
+    id: str
+    model: str
+    location: DeckSlotLocation
+    definition: ModuleDefinition
+    serial: Optional[str]
 
 
 class LabwareOffsetLocation(BaseModel):
@@ -200,62 +257,3 @@ class LoadedLabware(BaseModel):
             " so the default of (0, 0, 0) will be used."
         ),
     )
-
-
-class ModuleModels(str, Enum):
-    """All available modules' models."""
-
-    TEMPERATURE_MODULE_V1 = "temperatureModuleV1"
-    TEMPERATURE_MODULE_V2 = "temperatureModuleV2"
-    MAGNETIC_MODULE_V1 = "magneticModuleV1"
-    MAGNETIC_MODULE_V2 = "magneticModuleV2"
-    THERMOCYCLER_MODULE_V1 = "thermocyclerModuleV1"
-
-
-class ModuleDimensions(BaseModel):
-    """Dimension type for modules."""
-
-    bareOverallHeight: float
-    overLabwareHeight: float
-
-
-class ModuleCalibrationPoint(BaseModel):
-    """Calibration Point type for module definition."""
-
-    x: float
-    y: float
-
-
-class ModuleDefinition(BaseModel):
-    """Module definition class."""
-
-    otSharedSchema: str = Field("module/schemas/2", description="The current schema.")
-    moduleType: str = Field(
-        ..., description="Module type (Temperature/ Magnetic/ Thermocycler)"
-    )
-    model: str = Field(..., description="Model name of the module")
-    labwareOffset: LabwareOffsetVector = Field(
-        ..., description="Labware offset in x, y, z."
-    )
-    dimensions: ModuleDimensions = Field(..., description="Module dimension")
-    calibrationPoint: ModuleCalibrationPoint = Field(
-        ..., description="Calibration point of module."
-    )
-    displayName: str = Field(..., description="Display name.")
-    quirks: List[str] = Field(..., description="Module quirks")
-    slotTransforms: Dict[str, Any] = Field(
-        ..., description="Dictionary of transforms for each slot."
-    )
-    compatibleWith: List[str] = Field(
-        ..., description="List of module models this model is compatible with."
-    )
-
-
-class LoadedModule(BaseModel):
-    """A module that has been loaded."""
-
-    id: str
-    model: str
-    location: DeckSlotLocation
-    definition: ModuleDefinition
-    serial: Optional[str]

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -1,4 +1,7 @@
 """Public protocol engine value types and models."""
+
+from __future__ import annotations
+
 from datetime import datetime
 from enum import Enum
 from dataclasses import dataclass
@@ -140,8 +143,7 @@ class LabwareOffsetLocation(BaseModel):
         ...,
         description="The deck slot the offset applies to",
     )
-    # todo: enum
-    moduleModel: Optional[str] = Field(
+    moduleModel: Optional[ModuleModels] = Field(
         None,
         description="The module model the labware will be loaded onto, if applicable",
     )

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -140,6 +140,7 @@ class LabwareOffsetLocation(BaseModel):
         ...,
         description="The deck slot the offset applies to",
     )
+    # todo: enum
     moduleModel: Optional[str] = Field(
         None,
         description="The module model the labware will be loaded onto, if applicable",

--- a/api/src/opentrons/protocol_runner/legacy_labware_offset_provider.py
+++ b/api/src/opentrons/protocol_runner/legacy_labware_offset_provider.py
@@ -6,13 +6,13 @@
 from typing import Optional
 
 from opentrons.types import DeckSlotName, Point
-
-from opentrons.protocol_engine import LabwareOffsetLocation
-from opentrons.protocol_engine.state import LabwareView
 from opentrons.protocol_api.labware_offset_provider import (
     ProvidedLabwareOffset as LegacyProvidedLabwareOffset,
     AbstractLabwareOffsetProvider as AbstractLegacyLabwareOffsetProvider,
 )
+
+from opentrons.protocol_engine import LabwareOffsetLocation, ModuleModels
+from opentrons.protocol_engine.state import LabwareView
 
 
 class LegacyLabwareOffsetProvider(AbstractLegacyLabwareOffsetProvider):
@@ -25,7 +25,7 @@ class LegacyLabwareOffsetProvider(AbstractLegacyLabwareOffsetProvider):
     def find(
         self,
         labware_definition_uri: str,
-        module_model: Optional[str],  # todo: enum
+        module_model: Optional[str],
         deck_slot: DeckSlotName,
     ) -> LegacyProvidedLabwareOffset:
         """Look up an offset in ProtocolEngine state and return it, if one exists."""
@@ -33,7 +33,9 @@ class LegacyLabwareOffsetProvider(AbstractLegacyLabwareOffsetProvider):
             definition_uri=labware_definition_uri,
             location=LabwareOffsetLocation(
                 slotName=deck_slot,
-                moduleModel=module_model
+                moduleModel=(
+                    None if module_model is None else ModuleModels[module_model]
+                ),
             ),
         )
         if offset is None:

--- a/api/src/opentrons/protocol_runner/legacy_labware_offset_provider.py
+++ b/api/src/opentrons/protocol_runner/legacy_labware_offset_provider.py
@@ -25,19 +25,16 @@ class LegacyLabwareOffsetProvider(AbstractLegacyLabwareOffsetProvider):
     def find(
         self,
         labware_definition_uri: str,
-        module_model: Optional[str],
+        module_model: Optional[str],  # todo: enum
         deck_slot: DeckSlotName,
     ) -> LegacyProvidedLabwareOffset:
         """Look up an offset in ProtocolEngine state and return it, if one exists."""
-        if module_model is not None:
-            # TODO(mc, 2021-11-23): https://github.com/Opentrons/opentrons/issues/8242
-            raise NotImplementedError(
-                "Loading offsets for labware loaded atop modules"
-                " is not currently supported."
-            )
         offset = self._labware_view.find_applicable_labware_offset(
             definition_uri=labware_definition_uri,
-            location=LabwareOffsetLocation(slotName=deck_slot),
+            location=LabwareOffsetLocation(
+                slotName=deck_slot,
+                moduleModel=module_model
+            ),
         )
         if offset is None:
             return LegacyProvidedLabwareOffset(

--- a/api/src/opentrons/protocol_runner/legacy_labware_offset_provider.py
+++ b/api/src/opentrons/protocol_runner/legacy_labware_offset_provider.py
@@ -34,7 +34,7 @@ class LegacyLabwareOffsetProvider(AbstractLegacyLabwareOffsetProvider):
             location=LabwareOffsetLocation(
                 slotName=deck_slot,
                 moduleModel=(
-                    None if module_model is None else ModuleModels[module_model]
+                    None if module_model is None else ModuleModels(module_model)
                 ),
             ),
         )

--- a/api/src/opentrons/protocol_runner/task_queue.py
+++ b/api/src/opentrons/protocol_runner/task_queue.py
@@ -80,13 +80,13 @@ class TaskQueue:
             if self._run_func is not None:
                 await self._run_func()
         except Exception as e:
+            log.debug(
+                "Exception raised during protocol run",
+                exc_info=error,
+            )
             error = e
         finally:
             if self._cleanup_func is not None:
                 await self._cleanup_func(error=error)
             elif error:
-                log.warning(
-                    "Exception raised during protocol run was not handled",
-                    exc_info=error,
-                )
                 raise error

--- a/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
@@ -271,7 +271,7 @@ async def test_load_labware_on_module(
     decoy.when(state_store.modules.get("module-id")).then_return(
         LoadedModule(
             id="module-id",
-            model="module-model",
+            model=ModuleModels.THERMOCYCLER_MODULE_V1,
             location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
             serial="module-serial",
             definition=tempdeck_v1_def,
@@ -283,7 +283,7 @@ async def test_load_labware_on_module(
             definition_uri="opentrons-test/load-name/1",
             location=LabwareOffsetLocation(
                 slotName=DeckSlotName.SLOT_3,
-                moduleModel="module-model",
+                moduleModel=ModuleModels.THERMOCYCLER_MODULE_V1,
             ),
         )
     ).then_return(
@@ -293,7 +293,7 @@ async def test_load_labware_on_module(
             definitionUri="opentrons-test/load-name/1",
             location=LabwareOffsetLocation(
                 slotName=DeckSlotName.SLOT_3,
-                moduleModel="module-model",
+                moduleModel=ModuleModels.THERMOCYCLER_MODULE_V1,
             ),
             vector=LabwareOffsetVector(x=1, y=2, z=3),
         )

--- a/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
@@ -18,8 +18,10 @@ from opentrons.protocol_engine.errors import (
 )
 from opentrons.protocol_engine.types import (
     DeckSlotLocation,
+    ModuleLocation,
     PipetteName,
     LoadedPipette,
+    LoadedModule,
     LabwareOffset,
     LabwareOffsetVector,
     LabwareOffsetLocation,
@@ -247,6 +249,68 @@ async def test_load_labware_uses_loaded_labware_def(
             version=1,
         ),
         times=0,
+    )
+
+
+async def test_load_labware_on_module(
+    decoy: Decoy,
+    model_utils: ModelUtils,
+    state_store: StateStore,
+    labware_data_provider: LabwareDataProvider,
+    minimal_labware_def: LabwareDefinition,
+    tempdeck_v1_def: ModuleDefinition,
+    subject: EquipmentHandler,
+) -> None:
+    """It should load labware definition and offset data and generate an ID."""
+    decoy.when(model_utils.generate_id()).then_return("unique-id")
+
+    decoy.when(
+        state_store.labware.get_definition_by_uri(matchers.IsA(str))
+    ).then_return(minimal_labware_def)
+
+    decoy.when(state_store.modules.get("module-id")).then_return(
+        LoadedModule(
+            id="module-id",
+            model="module-model",
+            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
+            serial="module-serial",
+            definition=tempdeck_v1_def,
+        )
+    )
+
+    decoy.when(
+        state_store.labware.find_applicable_labware_offset(
+            definition_uri="opentrons-test/load-name/1",
+            location=LabwareOffsetLocation(
+                slotName=DeckSlotName.SLOT_3,
+                moduleModel="module-model",
+            ),
+        )
+    ).then_return(
+        LabwareOffset(
+            id="labware-offset-id",
+            createdAt=datetime(year=2021, month=1, day=2),
+            definitionUri="opentrons-test/load-name/1",
+            location=LabwareOffsetLocation(
+                slotName=DeckSlotName.SLOT_3,
+                moduleModel="module-model",
+            ),
+            vector=LabwareOffsetVector(x=1, y=2, z=3),
+        )
+    )
+
+    result = await subject.load_labware(
+        location=ModuleLocation(moduleId="module-id"),
+        load_name="load-name",
+        namespace="opentrons-test",
+        version=1,
+        labware_id=None,
+    )
+
+    assert result == LoadedLabwareData(
+        labware_id="unique-id",
+        definition=minimal_labware_def,
+        offsetId="labware-offset-id",
     )
 
 

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -167,6 +167,46 @@ def test_get_labware_highest_z(
     assert highest_z == (well_plate_def.dimensions.zDimension + 3 + 3)
 
 
+def test_get_module_labware_highest_z(
+    decoy: Decoy,
+    standard_deck_def: DeckDefinitionV2,
+    well_plate_def: LabwareDefinition,
+    labware_view: LabwareView,
+    module_view: ModuleView,
+    subject: GeometryView,
+) -> None:
+    """It should get the absolute location of a labware's highest Z point."""
+    labware_data = LoadedLabware(
+        id="labware-id",
+        loadName="load-name",
+        definitionUri="definition-uri",
+        location=ModuleLocation(moduleId="module-id"),
+        offsetId="offset-id",
+    )
+    slot_pos = Point(1, 2, 3)
+    calibration_offset = LabwareOffsetVector(x=1, y=-2, z=3)
+
+    decoy.when(labware_view.get("labware-id")).then_return(labware_data)
+    decoy.when(labware_view.get_definition("labware-id")).then_return(well_plate_def)
+    decoy.when(labware_view.get_labware_offset_vector("labware-id")).then_return(
+        calibration_offset
+    )
+    decoy.when(labware_view.get_slot_position(DeckSlotName.SLOT_3)).then_return(
+        slot_pos
+    )
+    decoy.when(module_view.get_location("module-id")).then_return(
+        DeckSlotLocation(slotName=DeckSlotName.SLOT_3)
+    )
+    decoy.when(module_view.get_module_offset("module-id")).then_return(
+        LabwareOffsetVector(x=4, y=5, z=6)
+    )
+    decoy.when(module_view.get_height_over_labware("module-id")).then_return(0.5)
+
+    highest_z = subject.get_labware_highest_z("labware-id")
+
+    assert highest_z == (well_plate_def.dimensions.zDimension + 3 + 3 + 6 + 0.5)
+
+
 def test_get_all_labware_highest_z(
     decoy: Decoy,
     standard_deck_def: DeckDefinitionV2,

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -338,6 +338,53 @@ def test_get_well_position(
     )
 
 
+def test_get_module_labware_well_position(
+        decoy: Decoy,
+        well_plate_def: LabwareDefinition,
+        standard_deck_def: DeckDefinitionV2,
+        labware_view: LabwareView,
+        module_view: ModuleView,
+        subject: GeometryView,
+) -> None:
+    """It should be able to get the position of a well top in a labware on module."""
+    labware_data = LoadedLabware(
+        id="labware-id",
+        loadName="load-name",
+        definitionUri="definition-uri",
+        location=ModuleLocation(moduleId="module-id"),
+        offsetId="offset-id",
+    )
+    calibration_offset = LabwareOffsetVector(x=1, y=-2, z=3)
+    slot_pos = Point(4, 5, 6)
+    well_def = well_plate_def.wells["B2"]
+
+    decoy.when(labware_view.get("labware-id")).then_return(labware_data)
+    decoy.when(labware_view.get_definition("labware-id")).then_return(well_plate_def)
+    decoy.when(labware_view.get_labware_offset_vector("labware-id")).then_return(
+        calibration_offset
+    )
+    decoy.when(labware_view.get_slot_position(DeckSlotName.SLOT_4)).then_return(
+        slot_pos
+    )
+    decoy.when(labware_view.get_well_definition("labware-id", "B2")).then_return(
+        well_def
+    )
+    decoy.when(module_view.get_location("module-id")).then_return(
+        DeckSlotLocation(slotName=DeckSlotName.SLOT_4)
+    )
+    decoy.when(module_view.get_module_offset("module-id")).then_return(
+        LabwareOffsetVector(x=4, y=5, z=6)
+    )
+
+    result = subject.get_well_position("labware-id", "B2")
+
+    assert result == Point(
+        x=slot_pos[0] + 1 + well_def.x + 4,
+        y=slot_pos[1] - 2 + well_def.y + 5,
+        z=slot_pos[2] + 3 + well_def.z + well_def.depth + 6,
+    )
+
+
 def test_get_well_position_with_top_offset(
     decoy: Decoy,
     well_plate_def: LabwareDefinition,

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -19,13 +19,26 @@ from opentrons.protocol_engine.types import (
     WellOffset,
 )
 from opentrons.protocol_engine.state.labware import LabwareView
+from opentrons.protocol_engine.state.modules import ModuleView
 from opentrons.protocol_engine.state.geometry import GeometryView
 
 
 @pytest.fixture
-def subject(labware_view: LabwareView) -> GeometryView:
+def labware_view(decoy: Decoy) -> LabwareView:
+    """Get a mock in the shape of a LabwareView."""
+    return decoy.mock(cls=LabwareView)
+
+
+@pytest.fixture
+def module_view(decoy: Decoy) -> ModuleView:
+    """Get a mock in the shape of a ModuleView."""
+    return decoy.mock(cls=ModuleView)
+
+
+@pytest.fixture
+def subject(labware_view: LabwareView, module_view: ModuleView) -> GeometryView:
     """Get a GeometryView with its store dependencies mocked out."""
-    return GeometryView(labware_view=labware_view)
+    return GeometryView(labware_view=labware_view, module_view=module_view)
 
 
 def test_get_labware_parent_position(

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -339,12 +339,12 @@ def test_get_well_position(
 
 
 def test_get_module_labware_well_position(
-        decoy: Decoy,
-        well_plate_def: LabwareDefinition,
-        standard_deck_def: DeckDefinitionV2,
-        labware_view: LabwareView,
-        module_view: ModuleView,
-        subject: GeometryView,
+    decoy: Decoy,
+    well_plate_def: LabwareDefinition,
+    standard_deck_def: DeckDefinitionV2,
+    labware_view: LabwareView,
+    module_view: ModuleView,
+    subject: GeometryView,
 ) -> None:
     """It should be able to get the position of a well top in a labware on module."""
     labware_data = LoadedLabware(

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -16,6 +16,7 @@ from opentrons.protocol_engine.types import (
     LabwareOffsetVector,
     LabwareOffsetLocation,
     LoadedLabware,
+    ModuleModels,
 )
 
 from opentrons.protocol_engine.state.labware import LabwareState, LabwareView
@@ -504,7 +505,7 @@ def test_find_applicable_labware_offset() -> None:
         definitionUri="on-module-definition-uri",
         location=LabwareOffsetLocation(
             slotName=DeckSlotName.SLOT_1,
-            moduleModel="tempdeck",
+            moduleModel=ModuleModels.TEMPERATURE_MODULE_V1,
         ),
         vector=LabwareOffsetVector(x=3, y=3, z=3),
     )
@@ -528,7 +529,7 @@ def test_find_applicable_labware_offset() -> None:
             definition_uri="on-module-definition-uri",
             location=LabwareOffsetLocation(
                 slotName=DeckSlotName.SLOT_1,
-                moduleModel="tempdeck",
+                moduleModel=ModuleModels.TEMPERATURE_MODULE_V1,
             ),
         )
         == offset_3

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -117,3 +117,32 @@ def test_get_module_by_serial(tempdeck_v1_def: ModuleDefinition) -> None:
     )
     subject = get_module_view(modules_by_id={"module-1": module1, "module-2": module2})
     assert subject.get_by_serial("serial-2") == module2
+
+
+def test_get_location(tempdeck_v1_def: ModuleDefinition) -> None:
+    """It should return the deck slot location of the module."""
+    module_id = "unique-id"
+    module = LoadedModule(
+        id=module_id,
+        model="model-1",
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2),
+        serial="serial-1",
+        definition=tempdeck_v1_def,
+    )
+    subject = get_module_view(modules_by_id={module_id: module})
+    assert subject.get_location(module_id=module_id) == DeckSlotLocation(
+        slotName=DeckSlotName.SLOT_2)
+
+
+def test_get_dimensions(tempdeck_v1_def: ModuleDefinition) -> None:
+    """It should return the dimensions of the specified module."""
+    module_id = "unique-id"
+    module = LoadedModule(
+        id=module_id,
+        model="model-1",
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2),
+        serial="serial-1",
+        definition=tempdeck_v1_def,
+    )
+    subject = get_module_view(modules_by_id={module_id: module})
+    assert subject.get_dimensions(module_id=module_id) == tempdeck_v1_def.dimensions

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -36,7 +36,7 @@ def test_get_module_data(tempdeck_v1_def: ModuleDefinition) -> None:
     """It should get module data from state by ID."""
     module_data = LoadedModule(
         id="module-id",
-        model="model-1",
+        model=ModuleModels.THERMOCYCLER_MODULE_V1,
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
         serial="module-serial",
         definition=tempdeck_v1_def,
@@ -50,14 +50,14 @@ def test_get_all_modules(tempdeck_v1_def: ModuleDefinition) -> None:
     """It should return all modules in state."""
     module1 = LoadedModule(
         id="module-1",
-        model="model-1",
+        model=ModuleModels.TEMPERATURE_MODULE_V1,
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
         serial="serial-1",
         definition=tempdeck_v1_def,
     )
     module2 = LoadedModule(
         id="module-2",
-        model="model-2",
+        model=ModuleModels.MAGNETIC_MODULE_V1,
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2),
         serial="serial-2",
         definition=tempdeck_v1_def,
@@ -70,7 +70,7 @@ def test_get_definition_by_id(tempdeck_v1_def: ModuleDefinition) -> None:
     """It should return a loaded module's definition by ID."""
     module_data = LoadedModule(
         id="module-id",
-        model="model-1",
+        model=ModuleModels.TEMPERATURE_MODULE_V2,
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
         serial="module-serial",
         definition=tempdeck_v1_def,
@@ -103,14 +103,14 @@ def test_get_module_by_serial(tempdeck_v1_def: ModuleDefinition) -> None:
     """It should get a particular loaded module for a given module serial number."""
     module1 = LoadedModule(
         id="module-1",
-        model="model-1",
+        model=ModuleModels.TEMPERATURE_MODULE_V2,
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
         serial="serial-1",
         definition=tempdeck_v1_def,
     )
     module2 = LoadedModule(
         id="module-2",
-        model="model-2",
+        model=ModuleModels.MAGNETIC_MODULE_V2,
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2),
         serial="serial-2",
         definition=tempdeck_v1_def,
@@ -124,14 +124,15 @@ def test_get_location(tempdeck_v1_def: ModuleDefinition) -> None:
     module_id = "unique-id"
     module = LoadedModule(
         id=module_id,
-        model="model-1",
+        model=ModuleModels.MAGNETIC_MODULE_V2,
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2),
         serial="serial-1",
         definition=tempdeck_v1_def,
     )
     subject = get_module_view(modules_by_id={module_id: module})
     assert subject.get_location(module_id=module_id) == DeckSlotLocation(
-        slotName=DeckSlotName.SLOT_2)
+        slotName=DeckSlotName.SLOT_2
+    )
 
 
 def test_get_dimensions(tempdeck_v1_def: ModuleDefinition) -> None:
@@ -139,7 +140,7 @@ def test_get_dimensions(tempdeck_v1_def: ModuleDefinition) -> None:
     module_id = "unique-id"
     module = LoadedModule(
         id=module_id,
-        model="model-1",
+        model=ModuleModels.MAGNETIC_MODULE_V2,
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2),
         serial="serial-1",
         definition=tempdeck_v1_def,

--- a/api/tests/opentrons/protocol_runner/test_legacy_labware_offset_provider.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_labware_offset_provider.py
@@ -1,0 +1,93 @@
+"""Unit tests for LegacyLabwareOffsetProvider."""
+
+
+from datetime import datetime
+
+import pytest
+from decoy import Decoy
+
+from opentrons.types import DeckSlotName, Point
+from opentrons.protocol_engine import (
+    LabwareOffset,
+    LabwareOffsetVector,
+    LabwareOffsetLocation,
+    ModuleModels,
+)
+from opentrons.protocol_engine.state import LabwareView
+from opentrons.protocol_runner.legacy_labware_offset_provider import (
+    LegacyLabwareOffsetProvider,
+    LegacyProvidedLabwareOffset,
+)
+
+
+@pytest.fixture
+def labware_view(decoy: Decoy) -> LabwareView:
+    """Return a mock LabwareView."""
+    return decoy.mock(cls=LabwareView)
+
+
+@pytest.fixture
+def subject(labware_view: LabwareView) -> LegacyLabwareOffsetProvider:
+    """Return a LegacyLabwareOffsetProvider depending on the mocked LabwareView."""
+    return LegacyLabwareOffsetProvider(labware_view=labware_view)
+
+
+def test_find_something(
+    subject: LegacyLabwareOffsetProvider, labware_view: LabwareView, decoy: Decoy
+) -> None:
+    """It should pass along simplified labware offset info from Protocol Engine."""
+    decoy.when(
+        labware_view.find_applicable_labware_offset(
+            definition_uri="some_namespace/some_load_name/123",
+            location=LabwareOffsetLocation(
+                slotName=DeckSlotName.SLOT_1,
+                moduleModel=ModuleModels.TEMPERATURE_MODULE_V1,
+            ),
+        )
+    ).then_return(
+        LabwareOffset(
+            # Subject should pass these along:
+            id="labware-offset-id",
+            vector=LabwareOffsetVector(x=1, y=2, z=3),
+            # Shouldn't matter; subject should throw these away:
+            definitionUri="result_definition_uri_should_not_matter",
+            location=LabwareOffsetLocation(slotName=DeckSlotName.SLOT_11),
+            createdAt=datetime(year=2021, month=1, day=1),
+        )
+    )
+
+    result = subject.find(
+        labware_definition_uri="some_namespace/some_load_name/123",
+        module_model="temperatureModuleV1",
+        deck_slot=DeckSlotName.SLOT_1,
+    )
+
+    assert result == LegacyProvidedLabwareOffset(
+        delta=Point(x=1, y=2, z=3),
+        offset_id="labware-offset-id",
+    )
+
+
+def test_find_nothing(
+    subject: LegacyLabwareOffsetProvider, labware_view: LabwareView, decoy: Decoy
+) -> None:
+    """It should return a zero offset when Protocol Engine has no offset to provide."""
+    decoy_call_rehearsal = labware_view.find_applicable_labware_offset(
+        definition_uri="some_namespace/some_load_name/123",
+        location=LabwareOffsetLocation(
+            slotName=DeckSlotName.SLOT_1,
+            moduleModel=ModuleModels.TEMPERATURE_MODULE_V1,
+        ),
+    )
+
+    decoy.when(decoy_call_rehearsal).then_return(None)
+
+    result = subject.find(
+        labware_definition_uri="some_namespace/some_load_name/123",
+        module_model="temperatureModuleV1",
+        deck_slot=DeckSlotName.SLOT_1,
+    )
+
+    assert result == LegacyProvidedLabwareOffset(
+        delta=Point(x=0, y=0, z=0), offset_id=None
+    )


### PR DESCRIPTION
## Overview

Closes #8242

## Changelog

Allow labware to be loaded on top of modules in Protocol Engine

## Review requests

- [ ] Code looks good
- [ ] LPC with temperature module and magnetic module should fully work
- [ ] LPC with thermocycler **may have issues** (ticketed as #8911)
    - Thermocycler closed lid height is not yet accounted for in PE movement planning (may not matter for LPC)
    - Moves to TC labware when lid is closed not yet rejected (may not matter for LPC, but also not good)
    - Moves with a lid-open TC will not attempt to dodge the TC (matters for LPC)

## Risk assessment

Low, if this all works!