### PR TITLE
refactor(protocol-engine): Rename `ModuleModels` to `ModuleModel`

### DIFF
--- a/api/src/opentrons/protocol_engine/__init__.py
+++ b/api/src/opentrons/protocol_engine/__init__.py
@@ -28,7 +28,7 @@ from .types import (
     WellLocation,
     WellOrigin,
     WellOffset,
-    ModuleModels,
+    ModuleModel,
     ModuleDefinition,
 )
 
@@ -63,7 +63,7 @@ __all__ = [
     "WellLocation",
     "WellOrigin",
     "WellOffset",
-    "ModuleModels",
+    "ModuleModel",
     "ModuleDefinition",
     # plugins
     "AbstractPlugin",

--- a/api/src/opentrons/protocol_engine/commands/load_module.py
+++ b/api/src/opentrons/protocol_engine/commands/load_module.py
@@ -5,7 +5,7 @@ from typing_extensions import Literal
 from pydantic import BaseModel, Field
 
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
-from ..types import DeckSlotLocation, ModuleModels, ModuleDefinition
+from ..types import DeckSlotLocation, ModuleModel, ModuleDefinition
 
 
 LoadModuleCommandType = Literal["loadModule"]
@@ -14,9 +14,8 @@ LoadModuleCommandType = Literal["loadModule"]
 class LoadModuleParams(BaseModel):
     """Payload required to load a module."""
 
-    model: ModuleModels = Field(
+    model: ModuleModel = Field(
         ...,
-        example="magneticModuleV1",
         description=(
             "The model name of the module to load."
             "\n\n"

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -25,7 +25,7 @@ from ..types import (
     PipetteName,
     DeckSlotLocation,
     LabwareOffsetLocation,
-    ModuleModels,
+    ModuleModel,
     ModuleDefinition,
 )
 
@@ -180,7 +180,7 @@ class EquipmentHandler:
         return LoadedPipetteData(pipette_id=pipette_id)
 
     async def load_module(
-        self, model: ModuleModels, location: DeckSlotLocation, module_id: Optional[str]
+        self, model: ModuleModel, location: DeckSlotLocation, module_id: Optional[str]
     ) -> LoadedModuleData:
         """Ensure the required module is attached.
 
@@ -210,7 +210,7 @@ class EquipmentHandler:
             definition=definition,
         )
 
-    async def _get_hardware_module(self, model: ModuleModels) -> AbstractModule:
+    async def _get_hardware_module(self, model: ModuleModel) -> AbstractModule:
         hw_model = module_model_from_string(model.value)
         model_type = resolve_module_type(hw_model)
 

--- a/api/src/opentrons/protocol_engine/resources/module_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/module_data_provider.py
@@ -3,14 +3,14 @@ from opentrons.protocols.geometry.module_geometry import (
     _load_v2_module_def,
     module_model_from_string,
 )
-from ..types import ModuleModels, ModuleDefinition
+from ..types import ModuleModel, ModuleDefinition
 
 
 class ModuleDataProvider:
     """Module data provider."""
 
     @staticmethod
-    def get_module_definition(model: ModuleModels) -> ModuleDefinition:
+    def get_module_definition(model: ModuleModel) -> ModuleDefinition:
         """Get the module definition."""
         legacy_model = module_model_from_string(model.value)
         return ModuleDefinition.parse_obj(

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -5,7 +5,7 @@ from numpy import array, dot
 
 from ..types import (
     LoadedModule,
-    ModuleModels,
+    ModuleModel,
     ModuleDefinition,
     DeckSlotLocation,
     ModuleDimensions,
@@ -25,7 +25,7 @@ class ModuleState:
 
     # TODO (spp, 2021-11-24): remove definition_by_model and
     #  unconditionally fetch definitions from ModuleDataProvider
-    definition_by_model: Dict[ModuleModels, ModuleDefinition]
+    definition_by_model: Dict[ModuleModel, ModuleDefinition]
 
 
 class ModuleStore(HasState[ModuleState], HandlesActions):
@@ -95,7 +95,7 @@ class ModuleView(HasState[ModuleState]):
         """Module definition by ID."""
         return self.get(module_id).definition
 
-    def get_definition_by_model(self, model: ModuleModels) -> ModuleDefinition:
+    def get_definition_by_model(self, model: ModuleModel) -> ModuleDefinition:
         """Return module definition by model."""
         try:
             return self._state.definition_by_model[model]

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -126,8 +126,7 @@ class MotorAxis(str, Enum):
     RIGHT_PLUNGER = "rightPlunger"
 
 
-# TODO(mc, 2021-11-24): s/ModuleModels/ModuleModel/
-class ModuleModels(str, Enum):
+class ModuleModel(str, Enum):
     """All available modules' models."""
 
     TEMPERATURE_MODULE_V1 = "temperatureModuleV1"
@@ -189,7 +188,7 @@ class LoadedModule(BaseModel):
     """A module that has been loaded."""
 
     id: str
-    model: ModuleModels
+    model: ModuleModel
     location: DeckSlotLocation
     definition: ModuleDefinition
     # TODO(mc, 2021-11-24): make serial non-optional
@@ -203,7 +202,7 @@ class LabwareOffsetLocation(BaseModel):
         ...,
         description="The deck slot the offset applies to",
     )
-    moduleModel: Optional[ModuleModels] = Field(
+    moduleModel: Optional[ModuleModel] = Field(
         None,
         description="The module model the labware will be loaded onto, if applicable",
     )

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -39,12 +39,12 @@ class LegacyContextCommandError(ProtocolEngineError):
     """An error returned when a PAPIv2 ProtocolContext command fails."""
 
 
-LEGACY_TO_PE_MODULE: Dict[LegacyModuleModel, pe_types.ModuleModels] = {
-    LegacyMagneticModuleModel.MAGNETIC_V1: pe_types.ModuleModels.MAGNETIC_MODULE_V1,
-    LegacyMagneticModuleModel.MAGNETIC_V2: pe_types.ModuleModels.MAGNETIC_MODULE_V2,
-    LegacyTemperatureModuleModel.TEMPERATURE_V1: pe_types.ModuleModels.TEMPERATURE_MODULE_V1,  # noqa: E501
-    LegacyTemperatureModuleModel.TEMPERATURE_V2: pe_types.ModuleModels.TEMPERATURE_MODULE_V2,  # noqa: E501
-    LegacyThermocyclerModuleModel.THERMOCYCLER_V1: pe_types.ModuleModels.THERMOCYCLER_MODULE_V1,  # noqa: E501
+LEGACY_TO_PE_MODULE: Dict[LegacyModuleModel, pe_types.ModuleModel] = {
+    LegacyMagneticModuleModel.MAGNETIC_V1: pe_types.ModuleModel.MAGNETIC_MODULE_V1,
+    LegacyMagneticModuleModel.MAGNETIC_V2: pe_types.ModuleModel.MAGNETIC_MODULE_V2,
+    LegacyTemperatureModuleModel.TEMPERATURE_V1: pe_types.ModuleModel.TEMPERATURE_MODULE_V1,  # noqa: E501
+    LegacyTemperatureModuleModel.TEMPERATURE_V2: pe_types.ModuleModel.TEMPERATURE_MODULE_V2,  # noqa: E501
+    LegacyThermocyclerModuleModel.THERMOCYCLER_V1: pe_types.ModuleModel.THERMOCYCLER_MODULE_V1,  # noqa: E501
 }
 
 
@@ -65,7 +65,7 @@ class LegacyCommandMapper:
         self._module_id_by_slot: Dict[DeckSlotName, str] = {}
         self._module_data_provider = module_data_provider or ModuleDataProvider()
         self._module_definition_by_model: Dict[
-            pe_types.ModuleModels, pe_types.ModuleDefinition
+            pe_types.ModuleModel, pe_types.ModuleDefinition
         ] = {}
 
     def map_command(

--- a/api/src/opentrons/protocol_runner/legacy_labware_offset_provider.py
+++ b/api/src/opentrons/protocol_runner/legacy_labware_offset_provider.py
@@ -11,7 +11,7 @@ from opentrons.protocol_api.labware_offset_provider import (
     AbstractLabwareOffsetProvider as AbstractLegacyLabwareOffsetProvider,
 )
 
-from opentrons.protocol_engine import LabwareOffsetLocation, ModuleModels
+from opentrons.protocol_engine import LabwareOffsetLocation, ModuleModel
 from opentrons.protocol_engine.state import LabwareView
 
 
@@ -34,7 +34,7 @@ class LegacyLabwareOffsetProvider(AbstractLegacyLabwareOffsetProvider):
             location=LabwareOffsetLocation(
                 slotName=deck_slot,
                 moduleModel=(
-                    None if module_model is None else ModuleModels(module_model)
+                    None if module_model is None else ModuleModel(module_model)
                 ),
             ),
         )

--- a/api/tests/opentrons/protocol_engine/commands/test_load_module.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_module.py
@@ -4,7 +4,7 @@ from decoy import Decoy
 from opentrons.types import DeckSlotName
 from opentrons.protocol_engine.types import (
     DeckSlotLocation,
-    ModuleModels,
+    ModuleModel,
     ModuleDefinition,
 )
 from opentrons.protocol_engine.execution import (
@@ -39,14 +39,14 @@ async def test_load_module_implementation(
     )
 
     data = LoadModuleParams(
-        model=ModuleModels.TEMPERATURE_MODULE_V1,
+        model=ModuleModel.TEMPERATURE_MODULE_V1,
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
         moduleId="some-id",
     )
 
     decoy.when(
         await equipment.load_module(
-            model=ModuleModels.TEMPERATURE_MODULE_V1,
+            model=ModuleModel.TEMPERATURE_MODULE_V1,
             location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
             module_id="some-id",
         )

--- a/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
@@ -25,7 +25,7 @@ from opentrons.protocol_engine.types import (
     LabwareOffset,
     LabwareOffsetVector,
     LabwareOffsetLocation,
-    ModuleModels,
+    ModuleModel,
     ModuleDefinition,
 )
 
@@ -271,7 +271,7 @@ async def test_load_labware_on_module(
     decoy.when(state_store.modules.get("module-id")).then_return(
         LoadedModule(
             id="module-id",
-            model=ModuleModels.THERMOCYCLER_MODULE_V1,
+            model=ModuleModel.THERMOCYCLER_MODULE_V1,
             location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
             serial="module-serial",
             definition=tempdeck_v1_def,
@@ -283,7 +283,7 @@ async def test_load_labware_on_module(
             definition_uri="opentrons-test/load-name/1",
             location=LabwareOffsetLocation(
                 slotName=DeckSlotName.SLOT_3,
-                moduleModel=ModuleModels.THERMOCYCLER_MODULE_V1,
+                moduleModel=ModuleModel.THERMOCYCLER_MODULE_V1,
             ),
         )
     ).then_return(
@@ -293,7 +293,7 @@ async def test_load_labware_on_module(
             definitionUri="opentrons-test/load-name/1",
             location=LabwareOffsetLocation(
                 slotName=DeckSlotName.SLOT_3,
-                moduleModel=ModuleModels.THERMOCYCLER_MODULE_V1,
+                moduleModel=ModuleModel.THERMOCYCLER_MODULE_V1,
             ),
             vector=LabwareOffsetVector(x=1, y=2, z=3),
         )
@@ -428,11 +428,11 @@ async def test_load_module(
     """It should load a module, returning its ID, serial & definition in result."""
     decoy.when(model_utils.generate_id()).then_return("unique-id")
     decoy.when(
-        state_store.modules.get_definition_by_model(ModuleModels.TEMPERATURE_MODULE_V1)
+        state_store.modules.get_definition_by_model(ModuleModel.TEMPERATURE_MODULE_V1)
     ).then_raise(ModuleDefinitionDoesNotExistError("oh no"))
 
     decoy.when(
-        module_data_provider.get_module_definition(ModuleModels.TEMPERATURE_MODULE_V1)
+        module_data_provider.get_module_definition(ModuleModel.TEMPERATURE_MODULE_V1)
     ).then_return(tempdeck_v1_def)
 
     decoy.when(
@@ -448,7 +448,7 @@ async def test_load_module(
         definition=tempdeck_v1_def,
     )
     result = await subject.load_module(
-        model=ModuleModels.TEMPERATURE_MODULE_V1,
+        model=ModuleModel.TEMPERATURE_MODULE_V1,
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
         module_id=None,
     )
@@ -471,6 +471,6 @@ async def test_get_hardware_module(
     ).then_return(([], simulating_module_fixture))
 
     assert (
-        await subject._get_hardware_module(ModuleModels.TEMPERATURE_MODULE_V1)
+        await subject._get_hardware_module(ModuleModel.TEMPERATURE_MODULE_V1)
         == simulating_module_fixture
     )

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -16,7 +16,7 @@ from opentrons.protocol_engine.types import (
     LabwareOffsetVector,
     LabwareOffsetLocation,
     LoadedLabware,
-    ModuleModels,
+    ModuleModel,
 )
 
 from opentrons.protocol_engine.state.labware import LabwareState, LabwareView
@@ -505,7 +505,7 @@ def test_find_applicable_labware_offset() -> None:
         definitionUri="on-module-definition-uri",
         location=LabwareOffsetLocation(
             slotName=DeckSlotName.SLOT_1,
-            moduleModel=ModuleModels.TEMPERATURE_MODULE_V1,
+            moduleModel=ModuleModel.TEMPERATURE_MODULE_V1,
         ),
         vector=LabwareOffsetVector(x=3, y=3, z=3),
     )
@@ -529,7 +529,7 @@ def test_find_applicable_labware_offset() -> None:
             definition_uri="on-module-definition-uri",
             location=LabwareOffsetLocation(
                 slotName=DeckSlotName.SLOT_1,
-                moduleModel=ModuleModels.TEMPERATURE_MODULE_V1,
+                moduleModel=ModuleModel.TEMPERATURE_MODULE_V1,
             ),
         )
         == offset_3

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -8,14 +8,14 @@ from opentrons.protocol_engine.types import (
     LoadedModule,
     DeckSlotLocation,
     ModuleDefinition,
-    ModuleModels,
+    ModuleModel,
 )
 from opentrons.protocol_engine.state.modules import ModuleView, ModuleState
 
 
 def get_module_view(
     modules_by_id: Optional[Dict[str, LoadedModule]] = None,
-    definition_by_model: Optional[Dict[ModuleModels, ModuleDefinition]] = None,
+    definition_by_model: Optional[Dict[ModuleModel, ModuleDefinition]] = None,
 ) -> ModuleView:
     """Get a module view test subject with the specified state."""
     state = ModuleState(
@@ -36,7 +36,7 @@ def test_get_module_data(tempdeck_v1_def: ModuleDefinition) -> None:
     """It should get module data from state by ID."""
     module_data = LoadedModule(
         id="module-id",
-        model=ModuleModels.THERMOCYCLER_MODULE_V1,
+        model=ModuleModel.THERMOCYCLER_MODULE_V1,
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
         serial="module-serial",
         definition=tempdeck_v1_def,
@@ -50,14 +50,14 @@ def test_get_all_modules(tempdeck_v1_def: ModuleDefinition) -> None:
     """It should return all modules in state."""
     module1 = LoadedModule(
         id="module-1",
-        model=ModuleModels.TEMPERATURE_MODULE_V1,
+        model=ModuleModel.TEMPERATURE_MODULE_V1,
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
         serial="serial-1",
         definition=tempdeck_v1_def,
     )
     module2 = LoadedModule(
         id="module-2",
-        model=ModuleModels.MAGNETIC_MODULE_V1,
+        model=ModuleModel.MAGNETIC_MODULE_V1,
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2),
         serial="serial-2",
         definition=tempdeck_v1_def,
@@ -70,7 +70,7 @@ def test_get_definition_by_id(tempdeck_v1_def: ModuleDefinition) -> None:
     """It should return a loaded module's definition by ID."""
     module_data = LoadedModule(
         id="module-id",
-        model=ModuleModels.TEMPERATURE_MODULE_V2,
+        model=ModuleModel.TEMPERATURE_MODULE_V2,
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
         serial="module-serial",
         definition=tempdeck_v1_def,
@@ -82,10 +82,10 @@ def test_get_definition_by_id(tempdeck_v1_def: ModuleDefinition) -> None:
 def test_get_definition_by_model(tempdeck_v1_def: ModuleDefinition) -> None:
     """It should return the cached definition of a specific module model."""
     subject = get_module_view(
-        definition_by_model={ModuleModels.TEMPERATURE_MODULE_V1: tempdeck_v1_def}
+        definition_by_model={ModuleModel.TEMPERATURE_MODULE_V1: tempdeck_v1_def}
     )
     assert (
-        subject.get_definition_by_model(ModuleModels.TEMPERATURE_MODULE_V1)
+        subject.get_definition_by_model(ModuleModel.TEMPERATURE_MODULE_V1)
         == tempdeck_v1_def
     )
 
@@ -93,24 +93,24 @@ def test_get_definition_by_model(tempdeck_v1_def: ModuleDefinition) -> None:
 def test_raise_error_if_no_definition(tempdeck_v1_def: ModuleDefinition) -> None:
     """It should raise if definition for given model not found."""
     subject = get_module_view(
-        definition_by_model={ModuleModels.TEMPERATURE_MODULE_V1: tempdeck_v1_def}
+        definition_by_model={ModuleModel.TEMPERATURE_MODULE_V1: tempdeck_v1_def}
     )
     with pytest.raises(errors.ModuleDefinitionDoesNotExistError):
-        subject.get_definition_by_model(ModuleModels.MAGNETIC_MODULE_V2)
+        subject.get_definition_by_model(ModuleModel.MAGNETIC_MODULE_V2)
 
 
 def test_get_module_by_serial(tempdeck_v1_def: ModuleDefinition) -> None:
     """It should get a particular loaded module for a given module serial number."""
     module1 = LoadedModule(
         id="module-1",
-        model=ModuleModels.TEMPERATURE_MODULE_V2,
+        model=ModuleModel.TEMPERATURE_MODULE_V2,
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
         serial="serial-1",
         definition=tempdeck_v1_def,
     )
     module2 = LoadedModule(
         id="module-2",
-        model=ModuleModels.MAGNETIC_MODULE_V2,
+        model=ModuleModel.MAGNETIC_MODULE_V2,
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2),
         serial="serial-2",
         definition=tempdeck_v1_def,
@@ -124,7 +124,7 @@ def test_get_location(tempdeck_v1_def: ModuleDefinition) -> None:
     module_id = "unique-id"
     module = LoadedModule(
         id=module_id,
-        model=ModuleModels.MAGNETIC_MODULE_V2,
+        model=ModuleModel.MAGNETIC_MODULE_V2,
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2),
         serial="serial-1",
         definition=tempdeck_v1_def,
@@ -140,7 +140,7 @@ def test_get_dimensions(tempdeck_v1_def: ModuleDefinition) -> None:
     module_id = "unique-id"
     module = LoadedModule(
         id=module_id,
-        model=ModuleModels.MAGNETIC_MODULE_V2,
+        model=ModuleModel.MAGNETIC_MODULE_V2,
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2),
         serial="serial-1",
         definition=tempdeck_v1_def,

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -8,7 +8,7 @@ from opentrons.protocol_engine import (
     DeckSlotLocation,
     ModuleLocation,
     PipetteName,
-    ModuleModels,
+    ModuleModel,
     ModuleDefinition,
     commands as pe_commands,
     actions as pe_actions,
@@ -285,7 +285,7 @@ def test_map_module_load(
         module_serial="module-serial",
     )
     decoy.when(
-        module_data_provider.get_module_definition(ModuleModels.MAGNETIC_MODULE_V2)
+        module_data_provider.get_module_definition(ModuleModel.MAGNETIC_MODULE_V2)
     ).then_return(test_definition)
     expected_output = pe_commands.LoadModule.construct(
         id=matchers.IsA(str),
@@ -294,7 +294,7 @@ def test_map_module_load(
         startedAt=matchers.IsA(datetime),
         completedAt=matchers.IsA(datetime),
         params=pe_commands.LoadModuleParams.construct(
-            model=ModuleModels.MAGNETIC_MODULE_V2,
+            model=ModuleModel.MAGNETIC_MODULE_V2,
             location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
             moduleId=matchers.IsA(str),
         ),

--- a/api/tests/opentrons/protocol_runner/test_legacy_labware_offset_provider.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_labware_offset_provider.py
@@ -11,7 +11,7 @@ from opentrons.protocol_engine import (
     LabwareOffset,
     LabwareOffsetVector,
     LabwareOffsetLocation,
-    ModuleModels,
+    ModuleModel,
 )
 from opentrons.protocol_engine.state import LabwareView
 from opentrons.protocol_runner.legacy_labware_offset_provider import (
@@ -41,7 +41,7 @@ def test_find_something(
             definition_uri="some_namespace/some_load_name/123",
             location=LabwareOffsetLocation(
                 slotName=DeckSlotName.SLOT_1,
-                moduleModel=ModuleModels.TEMPERATURE_MODULE_V1,
+                moduleModel=ModuleModel.TEMPERATURE_MODULE_V1,
             ),
         )
     ).then_return(
@@ -76,7 +76,7 @@ def test_find_nothing(
         definition_uri="some_namespace/some_load_name/123",
         location=LabwareOffsetLocation(
             slotName=DeckSlotName.SLOT_1,
-            moduleModel=ModuleModels.TEMPERATURE_MODULE_V1,
+            moduleModel=ModuleModel.TEMPERATURE_MODULE_V1,
         ),
     )
 


### PR DESCRIPTION
# Overview

This renames our internal `ModuleModels` enum to `ModuleModel`, resolving a todo. This shouldn't cause any outward-facing API changes.

# Review requests

Skim the code changes and double-check that my find-and-replace didn't do any collateral damage.

# Risk assessment

Very low, as long as linting and tests pass.
