### PR TITLE
feat(app): place LPC success modal above metadata card

### DIFF
--- a/app/src/organisms/ProtocolSetup/LabwareOffsetSuccessToast.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwareOffsetSuccessToast.tsx
@@ -1,13 +1,6 @@
 import * as React from 'react'
-import {
-  DIRECTION_COLUMN,
-  Flex,
-  AlertItem,
-  SPACING_1,
-  SPACING_2,
-} from '@opentrons/components'
+import { AlertItem } from '@opentrons/components'
 import { useTranslation } from 'react-i18next'
-import { Portal } from '../../App/portal'
 import { useCurrentProtocolRun } from '../ProtocolUpload/hooks'
 import { getLatestLabwareOffsetCount } from './LabwarePositionCheck/utils/getLatestLabwareOffsetCount'
 
@@ -25,23 +18,16 @@ export function LabwareOffsetSuccessToast(
   )
 
   return (
-    <Portal level="page">
-      <Flex
-        flexDirection={DIRECTION_COLUMN}
-        padding={`${SPACING_1} ${SPACING_2}`}
-      >
-        <AlertItem
-          type="success"
-          onCloseClick={props.onCloseClick}
-          title={
-            labwareOffsetCount === 0
-              ? t('labware_positon_check_complete_toast_no_offsets')
-              : t('labware_positon_check_complete_toast_with_offsets', {
-                  count: labwareOffsetCount,
-                })
-          }
-        />
-      </Flex>
-    </Portal>
+    <AlertItem
+      type="success"
+      onCloseClick={props.onCloseClick}
+      title={
+        labwareOffsetCount === 0
+          ? t('labware_positon_check_complete_toast_no_offsets')
+          : t('labware_positon_check_complete_toast_with_offsets', {
+              count: labwareOffsetCount,
+            })
+      }
+    />
   )
 }

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
@@ -104,7 +104,7 @@ export const SummaryScreen = (props: {
           id={'Lpc_summaryScreen_applyOffsetButton'}
           onClick={() => {
             applyLabwareOffsets()
-            setShowLPCSuccessToast(true)
+            setShowLPCSuccessToast()
             props.onCloseClick()
           }}
         >

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
@@ -19,6 +19,7 @@ import { IDENTITY_VECTOR } from '@opentrons/shared-data'
 import { useCreateLabwareOffsetMutation } from '@opentrons/react-api-client'
 import { useProtocolDetails } from '../../RunDetails/hooks'
 import { useCurrentProtocolRun } from '../../ProtocolUpload/hooks'
+import { useLPCSuccessToast } from '../hooks'
 import { DeckMap } from './DeckMap'
 import { SectionList } from './SectionList'
 import { LabwareOffsetsSummary } from './LabwareOffsetsSummary'
@@ -28,7 +29,6 @@ import type { ProtocolFile } from '@opentrons/shared-data'
 
 export const SummaryScreen = (props: {
   savePositionCommandData: SavePositionCommandData
-  onLabwarePositionCheckComplete: () => void
   onCloseClick: () => unknown
 }): JSX.Element | null => {
   const { savePositionCommandData } = props
@@ -43,6 +43,7 @@ export const SummaryScreen = (props: {
     )
   const { createLabwareOffset } = useCreateLabwareOffsetMutation()
   const { runRecord } = useCurrentProtocolRun()
+  const { setShowLPCSuccessToast } = useLPCSuccessToast()
 
   if (introInfo == null) return null
   if (protocolData == null) return null
@@ -103,7 +104,7 @@ export const SummaryScreen = (props: {
           id={'Lpc_summaryScreen_applyOffsetButton'}
           onClick={() => {
             applyLabwareOffsets()
-            props.onLabwarePositionCheckComplete()
+            setShowLPCSuccessToast(true)
             props.onCloseClick()
           }}
         >

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/LabwarePositionCheck.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/LabwarePositionCheck.test.tsx
@@ -58,7 +58,6 @@ describe('LabwarePositionCheck', () => {
   beforeEach(() => {
     props = {
       onCloseClick: jest.fn(),
-      onLabwarePositionCheckComplete: jest.fn(),
     }
     when(mockUseSteps)
       .calledWith()

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
@@ -23,7 +23,6 @@ import type { SavePositionCommandData } from './types'
 
 interface LabwarePositionCheckModalProps {
   onCloseClick: () => unknown
-  onLabwarePositionCheckComplete: () => void
 }
 export const LabwarePositionCheck = (
   props: LabwarePositionCheckModalProps
@@ -141,7 +140,6 @@ export const LabwarePositionCheck = (
       >
         <SummaryScreen
           savePositionCommandData={savePositionCommandData}
-          onLabwarePositionCheckComplete={props.onLabwarePositionCheckComplete}
           onCloseClick={props.onCloseClick}
         />
       </ModalPage>

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareSetup.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareSetup.test.tsx
@@ -387,11 +387,7 @@ describe('LabwareSetup', () => {
           onLabwarePositionCheckComplete: expect.anything(),
         })
       )
-      .mockImplementation(({ onLabwarePositionCheckComplete }) => (
-        <div onClick={onLabwarePositionCheckComplete}>
-          mock LabwarePositionCheck
-        </div>
-      ))
+      .mockReturnValue(<div>mock LabwarePositionCheck</div>)
     expect(screen.queryByText('mock LabwarePositionCheck')).toBeNull()
   })
 })

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
@@ -41,7 +41,6 @@ import { LabwareInfoOverlay } from './LabwareInfoOverlay'
 import { LabwareOffsetModal } from './LabwareOffsetModal'
 import { getModuleTypesThatRequireExtraAttention } from './utils/getModuleTypesThatRequireExtraAttention'
 import { ExtraAttentionWarning } from './ExtraAttentionWarning'
-import { LabwareOffsetSuccessToast } from '../../LabwareOffsetSuccessToast'
 
 const DECK_LAYER_BLOCKLIST = [
   'calibrationMarkings',
@@ -81,15 +80,9 @@ export const LabwareSetup = (): JSX.Element | null => {
     showLabwarePositionCheckModal,
     setShowLabwarePositionCheckModal,
   ] = React.useState<boolean>(false)
-  const [showLPCSuccessToast, setShowLPCSuccessToast] = React.useState(false)
 
   return (
     <React.Fragment>
-      {showLPCSuccessToast && (
-        <LabwareOffsetSuccessToast
-          onCloseClick={() => setShowLPCSuccessToast(false)}
-        />
-      )}
       {showLabwareHelpModal && (
         <LabwareOffsetModal
           onCloseClick={() => setShowLabwareHelpModal(false)}
@@ -98,7 +91,6 @@ export const LabwareSetup = (): JSX.Element | null => {
       {showLabwarePositionCheckModal && (
         <LabwarePositionCheck
           onCloseClick={() => setShowLabwarePositionCheckModal(false)}
-          onLabwarePositionCheckComplete={() => setShowLPCSuccessToast(true)}
         />
       )}
       <Flex flex="1" maxHeight="85vh" flexDirection={DIRECTION_COLUMN}>

--- a/app/src/organisms/ProtocolSetup/hooks.ts
+++ b/app/src/organisms/ProtocolSetup/hooks.ts
@@ -109,11 +109,11 @@ export function usePipetteMount(
 
 // this context is used to trigger an LPC success toast render from an LPC component lower in the tree
 export const LPCSuccessToastContext = createContext<{
-  setShowLPCSuccessToast: (val: boolean) => void
+  setShowLPCSuccessToast: () => void
 }>({ setShowLPCSuccessToast: () => null })
 
 export function useLPCSuccessToast(): {
-  setShowLPCSuccessToast: (val: boolean) => void
+  setShowLPCSuccessToast: () => void
 } {
   const { setShowLPCSuccessToast } = useContext(LPCSuccessToastContext)
   return { setShowLPCSuccessToast }

--- a/app/src/organisms/ProtocolSetup/hooks.ts
+++ b/app/src/organisms/ProtocolSetup/hooks.ts
@@ -1,3 +1,4 @@
+import { useContext, createContext } from 'react'
 import standardDeckDef from '@opentrons/shared-data/deck/definitions/2/ot2_standard.json'
 import { checkModuleCompatibility } from '@opentrons/shared-data'
 import { useProtocolDetails } from '../RunDetails/hooks'
@@ -104,4 +105,16 @@ export function usePipetteMount(
         command.params.pipetteId === pipetteId
     )?.params.mount ?? null
   )
+}
+
+// this context is used to trigger an LPC success toast render from an LPC component lower in the tree
+export const LPCSuccessToastContext = createContext<{
+  setShowLPCSuccessToast: (val: boolean) => void
+}>({ setShowLPCSuccessToast: () => null })
+
+export function useLPCSuccessToast(): {
+  setShowLPCSuccessToast: (val: boolean) => void
+} {
+  const { setShowLPCSuccessToast } = useContext(LPCSuccessToastContext)
+  return { setShowLPCSuccessToast }
 }

--- a/app/src/organisms/ProtocolSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/index.tsx
@@ -34,7 +34,7 @@ const feedbackFormLink =
   'https://docs.google.com/forms/d/e/1FAIpQLSd6oSV82IfgzSi5t_FP6n_pB_Y8wPGmAgFHsiiFho9qhxr-UQ/viewform'
 
 export function ProtocolSetup(): JSX.Element {
-  const [showLPCSuccessToast, setShowLPCSuccessToast] = React.useState(true)
+  const [showLPCSuccessToast, setShowLPCSuccessToast] = React.useState(false)
   const { t } = useTranslation(['protocol_setup'])
 
   const runStatus = useRunStatus()

--- a/app/src/organisms/ProtocolSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/index.tsx
@@ -88,7 +88,7 @@ export function ProtocolSetup(): JSX.Element {
         <MetadataCard />
         <LPCSuccessToastContext.Provider
           value={{
-            setShowLPCSuccessToast,
+            setShowLPCSuccessToast: () => setShowLPCSuccessToast(true),
           }}
         >
           <RunSetupCard />

--- a/app/src/organisms/ProtocolSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/index.tsx
@@ -13,7 +13,6 @@ import {
   DIRECTION_COLUMN,
   SPACING_2,
   SPACING_3,
-  ALIGN_CENTER,
   FONT_SIZE_BODY_2,
   C_DARK_GRAY,
   AlertItem,
@@ -28,11 +27,14 @@ import {
 import { useRunStatus } from '../RunTimeControl/hooks'
 import { RunSetupCard } from './RunSetupCard'
 import { MetadataCard } from './MetadataCard'
+import { LPCSuccessToastContext } from './hooks'
+import { LabwareOffsetSuccessToast } from './LabwareOffsetSuccessToast'
 
 const feedbackFormLink =
   'https://docs.google.com/forms/d/e/1FAIpQLSd6oSV82IfgzSi5t_FP6n_pB_Y8wPGmAgFHsiiFho9qhxr-UQ/viewform'
 
 export function ProtocolSetup(): JSX.Element {
+  const [showLPCSuccessToast, setShowLPCSuccessToast] = React.useState(true)
   const { t } = useTranslation(['protocol_setup'])
 
   const runStatus = useRunStatus()
@@ -76,11 +78,21 @@ export function ProtocolSetup(): JSX.Element {
       ) : null}
       <Flex
         flexDirection={DIRECTION_COLUMN}
-        alignItems={ALIGN_CENTER}
         padding={`${SPACING_1} ${SPACING_3} ${SPACING_3} ${SPACING_3}`}
       >
+        {showLPCSuccessToast && (
+          <LabwareOffsetSuccessToast
+            onCloseClick={() => setShowLPCSuccessToast(false)}
+          />
+        )}
         <MetadataCard />
-        <RunSetupCard />
+        <LPCSuccessToastContext.Provider
+          value={{
+            setShowLPCSuccessToast,
+          }}
+        >
+          <RunSetupCard />
+        </LPCSuccessToastContext.Provider>
         <Text
           fontSize={FONT_SIZE_BODY_2}
           paddingTop={SPACING_3}


### PR DESCRIPTION
# Overview

This PR changes the location of the LPC success toast to be rendered above the metadata card on the protocol setup screen.

Note: This was tested on @jerader's robot and seems to work

closes #8918 

# Review requests

Code review
Play with the success toast after completing LPC

# Risk assessment
Low
