### PR TITLE
feat(app): show offset deletion warning if previous offsets exist

### DIFF
--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -39,6 +39,7 @@ export interface VectorOffset {
   z: number
 }
 export interface LabwareOffset {
+  createdAt: string
   definitionUri: string
   location: LabwareLocation
   vector: VectorOffset

--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -39,7 +39,7 @@ export interface VectorOffset {
   z: number
 }
 export interface LabwareOffset {
-  createdAt: string
+  createdAt?: string
   definitionUri: string
   location: LabwareLocation
   vector: VectorOffset

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/IntroScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/IntroScreen.tsx
@@ -19,6 +19,8 @@ import {
   FONT_SIZE_BODY_2,
   SPACING_6,
 } from '@opentrons/components'
+import { useCurrentProtocolRun } from '../../ProtocolUpload/hooks'
+import { getLatestLabwareOffsetCount } from '../LabwarePositionCheck/utils/getLatestLabwareOffsetCount'
 import { SectionList } from './SectionList'
 import { DeckMap } from './DeckMap'
 import { useIntroInfo, useLabwareIdsBySection } from './hooks'
@@ -31,6 +33,12 @@ export const IntroScreen = (props: {
   const introInfo = useIntroInfo()
   const labwareIdsBySection = useLabwareIdsBySection()
   const { t } = useTranslation(['labware_position_check', 'shared'])
+
+  const currentProtocolRun = useCurrentProtocolRun()
+  const currentRunData = currentProtocolRun.runRecord?.data
+  const labwareOffsetCount = getLatestLabwareOffsetCount(
+    currentRunData?.labwareOffsets ?? []
+  )
 
   const [sectionIndex, setSectionIndex] = React.useState<number>(0)
   const rotateSectionIndex = (): void =>
@@ -65,7 +73,12 @@ export const IntroScreen = (props: {
           block: <Text fontSize={FONT_SIZE_BODY_2} marginBottom={SPACING_2} />,
         }}
       ></Trans>
-      <AlertItem type="warning" title={t('labware_offsets_deleted_warning')} />
+      {labwareOffsetCount !== 0 && (
+        <AlertItem
+          type="warning"
+          title={t('labware_offsets_deleted_warning')}
+        />
+      )}
       <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} alignItems={ALIGN_CENTER}>
         <Flex marginLeft={SPACING_6}>
           <SectionList

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/IntroScreen.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/IntroScreen.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { fireEvent } from '@testing-library/dom'
 import { when, resetAllWhenMocks } from 'jest-when'
 import {
   RobotWorkSpace,
@@ -11,15 +12,23 @@ import standardDeckDef from '@opentrons/shared-data/deck/definitions/2/ot2_stand
 import { LabwareDefinition2 } from '@opentrons/shared-data'
 import fixture_tiprack_300_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_300_ul.json'
 import { useModuleRenderInfoById, useLabwareRenderInfoById } from '../../hooks'
+import {
+  UseCurrentProtocolRun,
+  useCurrentProtocolRun,
+} from '../../../ProtocolUpload/hooks'
+import { getLatestLabwareOffsetCount } from '../../LabwarePositionCheck/utils/getLatestLabwareOffsetCount'
 import { SectionList } from '../SectionList'
 import { useIntroInfo, useLabwareIdsBySection } from '../hooks'
 import { IntroScreen, INTERVAL_MS } from '../IntroScreen'
 import type { Section } from '../types'
-import { fireEvent } from '@testing-library/dom'
+import type { LabwareOffset } from '@opentrons/api-client'
 
 jest.mock('../hooks')
 jest.mock('../SectionList')
 jest.mock('../../hooks')
+jest.mock('../../../ProtocolUpload/hooks')
+jest.mock('../../LabwarePositionCheck/utils/getLatestLabwareOffsetCount')
+
 jest.mock('@opentrons/components', () => {
   const actualComponents = jest.requireActual('@opentrons/components')
   return {
@@ -46,6 +55,13 @@ const mockSectionList = SectionList as jest.MockedFunction<typeof SectionList>
 const mockRobotWorkSpace = RobotWorkSpace as jest.MockedFunction<
   typeof RobotWorkSpace
 >
+const mockUseCurrentProtocolRun = useCurrentProtocolRun as jest.MockedFunction<
+  typeof useCurrentProtocolRun
+>
+const mockGetLatestLabwareOffsetCount = getLatestLabwareOffsetCount as jest.MockedFunction<
+  typeof getLatestLabwareOffsetCount
+>
+
 const deckSlotsById = standardDeckDef.locations.orderedSlots.reduce(
   (acc, deckSlot) => ({ ...acc, [deckSlot.id]: deckSlot }),
   {}
@@ -61,11 +77,19 @@ const render = (props: React.ComponentProps<typeof IntroScreen>) => {
 
 describe('IntroScreen', () => {
   let props: React.ComponentProps<typeof IntroScreen>
+  let mockOffsets: LabwareOffset[]
 
   beforeEach(() => {
     props = {
       beginLPC: jest.fn(),
     }
+    mockOffsets = [
+      {
+        definitionUri: 'some_def_uri',
+        location: { slotName: '4' },
+        vector: { x: 1, y: 1, z: 1 },
+      },
+    ]
     when(mockRobotWorkSpace)
       .mockReturnValue(<div></div>) // this (default) empty div will be returned when RobotWorkSpace isn't called with expected props
       .calledWith(
@@ -103,6 +127,11 @@ describe('IntroScreen', () => {
       sections: MOCK_SECTIONS,
     })
     mockSectionList.mockReturnValue(<div>Mock Section List</div>)
+    when(mockUseCurrentProtocolRun)
+      .calledWith()
+      .mockReturnValue({
+        runRecord: { data: { labwareOffsets: mockOffsets } },
+      } as UseCurrentProtocolRun)
   })
   afterEach(() => {
     resetAllWhenMocks()
@@ -120,9 +149,6 @@ describe('IntroScreen', () => {
     getByText(
       'When you check a labware, the OT-2’s pipette nozzle or attached tip will stop at the center of the A1 well. If the pipette nozzle or tip is not centered, you can reveal the OT-2’s jog controls to make an adjustment. This Labware Offset will be applied to the entire labware. Offset data is measured to the nearest 1/10th mm and can be made in the X, Y and/or Z directions.'
     )
-    getByText(
-      'Once you begin Labware Position Check, previously created Labware Offsets will be discarded.'
-    )
     getByText('Mock Section List')
   })
   it('should call beginLPC when the CTA button is pressed', () => {
@@ -137,5 +163,25 @@ describe('IntroScreen', () => {
   it('should should rotate through the active section', () => {
     render(props)
     expect(mockUseInterval.mock.calls[0][1]).toBe(INTERVAL_MS)
+  })
+  it('should render offset deletion alert if there are previous offsets', () => {
+    when(mockGetLatestLabwareOffsetCount)
+      .calledWith(mockOffsets)
+      .mockReturnValue(2)
+    const { getByText } = render(props)
+    getByText(
+      'Once you begin Labware Position Check, previously created Labware Offsets will be discarded.'
+    )
+  })
+  it('should not render offset deletion alert if there are no previous offsets', () => {
+    when(mockGetLatestLabwareOffsetCount)
+      .calledWith(mockOffsets)
+      .mockReturnValue(0)
+    const { queryByText } = render(props)
+    expect(
+      queryByText(
+        'Once you begin Labware Position Check, previously created Labware Offsets will be discarded.'
+      )
+    ).toBeNull()
   })
 })

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/utils/__tests__/getLatestLabwareOffsetCount.test.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/utils/__tests__/getLatestLabwareOffsetCount.test.ts
@@ -10,6 +10,7 @@ describe('getLatestLabwareOffsetCount', () => {
   it('should return 1 when there is one offset record', () => {
     const labwareOffsets: LabwareOffset[] = [
       {
+        createdAt: '2021-11-29',
         definitionUri: 'some_definitionUri',
         location: { slotName: '1' },
         vector: { x: 1, y: 0, z: 0 },
@@ -20,11 +21,13 @@ describe('getLatestLabwareOffsetCount', () => {
   it('should return 2 when there are two offset records with different labware', () => {
     const labwareOffsets: LabwareOffset[] = [
       {
+        createdAt: '2021-11-29',
         definitionUri: 'some_definitionUri',
         location: { slotName: '1' },
         vector: { x: 1, y: 0, z: 0 },
       },
       {
+        createdAt: '2021-11-29',
         definitionUri: 'another_definitionUri',
         location: { slotName: '2' },
         vector: { x: 1, y: 2, z: 3 },
@@ -35,11 +38,13 @@ describe('getLatestLabwareOffsetCount', () => {
   it('should return 1 when there are two offset records with the same labware and slot', () => {
     const labwareOffsets: LabwareOffset[] = [
       {
+        createdAt: '2021-11-29',
         definitionUri: 'some_definitionUri',
         location: { slotName: '1' },
         vector: { x: 1, y: 0, z: 0 },
       },
       {
+        createdAt: '2021-11-30',
         definitionUri: 'some_definitionUri',
         location: { slotName: '1' },
         vector: { x: 1, y: 2, z: 3 },
@@ -50,11 +55,13 @@ describe('getLatestLabwareOffsetCount', () => {
   it('should return 1 when there are two offset records with the same labware and module id', () => {
     const labwareOffsets: LabwareOffset[] = [
       {
+        createdAt: '2021-11-30',
         definitionUri: 'some_definitionUri',
         location: { moduleId: 'some_module' },
         vector: { x: 1, y: 0, z: 0 },
       },
       {
+        createdAt: '2021-11-29',
         definitionUri: 'some_definitionUri',
         location: { moduleId: 'some_module' },
         vector: { x: 1, y: 2, z: 3 },
@@ -65,11 +72,13 @@ describe('getLatestLabwareOffsetCount', () => {
   it('should return 0 when all offsets are identity offsets', () => {
     const labwareOffsets: LabwareOffset[] = [
       {
+        createdAt: '2021-11-29',
         definitionUri: 'some_definitionUri',
         location: { moduleId: 'some_module' },
         vector: { x: 0, y: 0, z: 0 },
       },
       {
+        createdAt: '2021-11-29',
         definitionUri: 'some_definitionUri',
         location: { moduleId: 'some_module' },
         vector: { x: 0, y: 0, z: 0 },
@@ -80,11 +89,13 @@ describe('getLatestLabwareOffsetCount', () => {
   it('should not count offsets to the trash', () => {
     const labwareOffsets: LabwareOffset[] = [
       {
+        createdAt: '2021-11-29',
         definitionUri: 'fixedTrash',
         location: { slotName: '12' },
         vector: { x: 0, y: 0, z: 0 },
       },
       {
+        createdAt: '2021-11-29',
         definitionUri: 'some_definitionUri',
         location: { moduleId: 'some_module' },
         vector: { x: 1, y: 0, z: 0 },
@@ -95,26 +106,59 @@ describe('getLatestLabwareOffsetCount', () => {
   it('should return only new offsets when the previous entries were identity offsets', () => {
     const labwareOffsets: LabwareOffset[] = [
       {
+        createdAt: '2021-11-29',
         definitionUri: 'some_definitionUri',
         location: { slotName: '3' },
         vector: { x: 0, y: 0, z: 0 },
       },
       {
-        definitionUri: 'another_definitionUri',
-        location: { moduleId: 'some_module' },
-        vector: { x: 0, y: 0, z: 0 },
-      },
-      {
+        createdAt: '2021-11-30',
         definitionUri: 'some_definitionUri',
         location: { slotName: '3' },
         vector: { x: 1, y: 0, z: 0 },
       },
       {
+        createdAt: '2021-11-29',
+        definitionUri: 'another_definitionUri',
+        location: { moduleId: 'some_module' },
+        vector: { x: 0, y: 0, z: 0 },
+      },
+      {
+        createdAt: '2021-11-30',
         definitionUri: 'another_definitionUri',
         location: { moduleId: 'some_module' },
         vector: { x: 1, y: 0, z: 0 },
       },
     ]
     expect(getLatestLabwareOffsetCount(labwareOffsets)).toBe(2)
+  })
+  it('should return only zero offsets when the newest entries are identity offsets', () => {
+    const labwareOffsets: LabwareOffset[] = [
+      {
+        createdAt: '2021-12-29',
+        definitionUri: 'some_definitionUri',
+        location: { slotName: '3' },
+        vector: { x: 0, y: 0, z: 0 },
+      },
+      {
+        createdAt: '2021-11-30',
+        definitionUri: 'some_definitionUri',
+        location: { slotName: '3' },
+        vector: { x: 1, y: 0, z: 0 },
+      },
+      {
+        createdAt: '2021-12-29',
+        definitionUri: 'another_definitionUri',
+        location: { moduleId: 'some_module' },
+        vector: { x: 0, y: 0, z: 0 },
+      },
+      {
+        createdAt: '2021-11-30',
+        definitionUri: 'another_definitionUri',
+        location: { moduleId: 'some_module' },
+        vector: { x: 1, y: 0, z: 0 },
+      },
+    ]
+    expect(getLatestLabwareOffsetCount(labwareOffsets)).toBe(0)
   })
 })

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/utils/getLatestLabwareOffsetCount.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/utils/getLatestLabwareOffsetCount.ts
@@ -14,7 +14,8 @@ export const getLatestLabwareOffsetCount = (
   // labware offsets are in order of creation, we want to use the most recent ones
   const orderedLabwareOffsets = labwareOffsets
     .slice()
-    .sort((a, b) => a.date - b.date)
+    // @ts-expect-error sort allows subtraction of dates
+    .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
 
   const filteredLabwareOffsets = uniqBy(
     orderedLabwareOffsets,

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/utils/getLatestLabwareOffsetCount.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/utils/getLatestLabwareOffsetCount.ts
@@ -29,18 +29,18 @@ export const getLatestLabwareOffsetCount = (
     }
   )
 
-  const uniqueOffsetCount = filteredLabwareOffsets.reduce<
-    LabwareOffset[],
-    number
-  >((acc: number, offset: LabwareOffset) => {
-    const vector = offset.vector
-    if (
-      !isEqual(location, TRASH_LOCATION) &&
-      !isEqual(vector, IDENTITY_VECTOR)
-    ) {
-      return acc + 1
-    }
-    return acc
-  }, 0)
+  const uniqueOffsetCount = filteredLabwareOffsets.reduce<number>(
+    (acc: number, offset: LabwareOffset) => {
+      const vector = offset.vector
+      if (
+        !isEqual(location, TRASH_LOCATION) &&
+        !isEqual(vector, IDENTITY_VECTOR)
+      ) {
+        return acc + 1
+      }
+      return acc
+    },
+    0
+  )
   return uniqueOffsetCount
 }

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/utils/getLatestLabwareOffsetCount.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/utils/getLatestLabwareOffsetCount.ts
@@ -1,7 +1,7 @@
 import isEqual from 'lodash/isEqual'
+import uniqBy from 'lodash/uniqBy'
 import { IDENTITY_VECTOR } from '@opentrons/shared-data'
 import type { LabwareOffset } from '@opentrons/api-client'
-
 const TRASH_LOCATION = { slotName: '12' }
 
 // this util counts all "relevant" labware offsets that a user would care about
@@ -11,25 +11,35 @@ const TRASH_LOCATION = { slotName: '12' }
 export const getLatestLabwareOffsetCount = (
   labwareOffsets: LabwareOffset[]
 ): number => {
-  const uniqueLabwareInstances = labwareOffsets.reduce<Set<string>>(
-    (uniqueLabwareInstances, offset) => {
+  // labware offsets are in order of creation, we want to use the most recent ones
+  const orderedLabwareOffsets = labwareOffsets
+    .slice()
+    .sort((a, b) => a.date - b.date)
+
+  const filteredLabwareOffsets = uniqBy(
+    orderedLabwareOffsets,
+    (offset: LabwareOffset) => {
       const location = offset.location
       const definitionUri = offset.definitionUri
-      const vector = offset.vector
       const locationKey =
         'slotName' in location ? location.slotName : location.moduleId
       // key by definition uri AND location, because labware offsets are tied to a combo of both of these attributes
-      const id = `${definitionUri}_${locationKey}`
-      if (
-        !uniqueLabwareInstances.has(id) &&
-        !isEqual(location, TRASH_LOCATION) &&
-        !isEqual(vector, IDENTITY_VECTOR)
-      ) {
-        return uniqueLabwareInstances.add(id)
-      }
-      return uniqueLabwareInstances
-    },
-    new Set()
+      return `${definitionUri}_${locationKey}`
+    }
   )
-  return uniqueLabwareInstances.size
+
+  const uniqueOffsetCount = filteredLabwareOffsets.reduce<
+    LabwareOffset[],
+    number
+  >((acc: number, offset: LabwareOffset) => {
+    const vector = offset.vector
+    if (
+      !isEqual(location, TRASH_LOCATION) &&
+      !isEqual(vector, IDENTITY_VECTOR)
+    ) {
+      return acc + 1
+    }
+    return acc
+  }, 0)
+  return uniqueOffsetCount
 }


### PR DESCRIPTION
close #8841

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
Show alert warning on LPC intro screen indicating previous offsets will be deleted _only_ if previous offsets exist
# Changelog
Put alert behind check for existing labware offsets
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->
Confirm alert is present when previous offsets exist
Confirm alert is not present when no offsets exist
# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Low