### PR TITLE
feat(app): save position right after executing movement command

### DIFF
--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
@@ -335,6 +335,7 @@ export function useLabwarePositionCheck(
       .then(response => {
         if (prevCommand.commandType !== 'pickUpTip') {
           const commandId = response.data.id
+          console.log('add spcd second', prevCommand.params.labwareId)
           addSavePositionCommandData(commandId, prevCommand.params.labwareId)
         }
         // later in the promise chain we may need to incorporate in flight offsets into
@@ -445,6 +446,7 @@ export function useLabwarePositionCheck(
             command: createCommandData(savePositionCommand),
           }).then(response => {
             const commandId = response.data.id
+            console.log('add spcd first', currentCommand.params.labwareId)
             addSavePositionCommandData(
               commandId,
               currentCommand.params.labwareId
@@ -524,6 +526,19 @@ export function useLabwarePositionCheck(
         const commandId = response.data.id
         setPendingMovementCommandData({
           commandId,
+        })
+        const savePositionCommand: SavePositionCommand = {
+          commandType: 'savePosition',
+          id: uuidv4(),
+          params: { pipetteId: currentCommand.params.pipetteId },
+        }
+        createCommand({
+          runId: currentRun?.data?.id as string,
+          command: createCommandData(savePositionCommand),
+        }).then(response => {
+          const commandId = response.data.id
+          console.log('add spcd begin', currentCommand.params.labwareId)
+          addSavePositionCommandData(commandId, currentCommand.params.labwareId)
         })
         setCurrentCommandIndex(currentCommandIndex + 1)
       })

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
@@ -330,12 +330,9 @@ export function useLabwarePositionCheck(
       runId: currentRun?.data?.id as string,
       command: createCommandData(savePositionCommand),
     })
-      // add the saved command id so we can use it to query locations later
-      // if the previous command was a pickup tip, we have already verified that labware's position
       .then(response => {
-        if (prevCommand.commandType !== 'pickUpTip') {
+        if (prevCommand.commandType === 'moveToWell') {
           const commandId = response.data.id
-          console.log('add spcd second', prevCommand.params.labwareId)
           addSavePositionCommandData(commandId, prevCommand.params.labwareId)
         }
         // later in the promise chain we may need to incorporate in flight offsets into
@@ -446,7 +443,6 @@ export function useLabwarePositionCheck(
             command: createCommandData(savePositionCommand),
           }).then(response => {
             const commandId = response.data.id
-            console.log('add spcd first', currentCommand.params.labwareId)
             addSavePositionCommandData(
               commandId,
               currentCommand.params.labwareId
@@ -537,7 +533,6 @@ export function useLabwarePositionCheck(
           command: createCommandData(savePositionCommand),
         }).then(response => {
           const commandId = response.data.id
-          console.log('add spcd begin', currentCommand.params.labwareId)
           addSavePositionCommandData(commandId, currentCommand.params.labwareId)
         })
         setCurrentCommandIndex(currentCommandIndex + 1)

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
@@ -30,10 +30,18 @@ export const LabwarePositionCheck = (
 ): JSX.Element | null => {
   const { t } = useTranslation(['labware_position_check', 'shared'])
   const restartRun = useRestartRun()
-  const [
-    savePositionCommandData,
-    setSavePositionCommandData,
-  ] = React.useState<SavePositionCommandData>({})
+  const [savePositionCommandData, savePositionCommandDataDispatch] = React.useReducer((state: {[labwareId: string]: string[]}, action: {labwareId: string, commandId: string}) => {
+    const {labwareId, commandId} = action
+    const nextCommandList = state[labwareId] != null
+        ? // if there are already two command ids, overwrite the second one with the new one coming in
+          // this is used when there is an unsuccessful pick up tip, and additional pick up tip attempts occur
+          [state[labwareId][0], commandId]
+        : [commandId]
+    return {
+      ...state,
+      [labwareId]: nextCommandList
+    }
+  }, {})
   const [isRestartingRun, setIsRestartingRun] = React.useState<boolean>(false)
   const {
     confirm: confirmExitLPC,
@@ -46,15 +54,8 @@ export const LabwarePositionCheck = (
     commandId: string,
     labwareId: string
   ): void => {
-    setSavePositionCommandData({
-      ...savePositionCommandData,
-      [labwareId]:
-        savePositionCommandData[labwareId] != null
-          ? // if there are already two command ids, overwrite the second one with the new one coming in
-            // this is used when there is an unsuccessful pick up tip, and additional pick up tip attempts occur
-            [savePositionCommandData[labwareId][0], commandId]
-          : [commandId],
-    })
+    console.log('save positionc ommand data ' , savePositionCommandData, labwareId, commandId)
+    savePositionCommandDataDispatch({labwareId, commandId})
   }
   const labwarePositionCheckUtils = useLabwarePositionCheck(
     addSavePositionCommandData,

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
@@ -19,7 +19,6 @@ import { ConfirmPickUpTipModal } from './ConfirmPickUpTipModal'
 import { ExitPreventionModal } from './ExitPreventionModal'
 
 import styles from '../styles.css'
-import type { SavePositionCommandData } from './types'
 
 interface LabwarePositionCheckModalProps {
   onCloseClick: () => unknown
@@ -30,18 +29,28 @@ export const LabwarePositionCheck = (
 ): JSX.Element | null => {
   const { t } = useTranslation(['labware_position_check', 'shared'])
   const restartRun = useRestartRun()
-  const [savePositionCommandData, savePositionCommandDataDispatch] = React.useReducer((state: {[labwareId: string]: string[]}, action: {labwareId: string, commandId: string}) => {
-    const {labwareId, commandId} = action
-    const nextCommandList = state[labwareId] != null
-        ? // if there are already two command ids, overwrite the second one with the new one coming in
-          // this is used when there is an unsuccessful pick up tip, and additional pick up tip attempts occur
-          [state[labwareId][0], commandId]
-        : [commandId]
-    return {
-      ...state,
-      [labwareId]: nextCommandList
-    }
-  }, {})
+  const [
+    savePositionCommandData,
+    savePositionCommandDataDispatch,
+  ] = React.useReducer(
+    (
+      state: { [labwareId: string]: string[] },
+      action: { labwareId: string; commandId: string }
+    ) => {
+      const { labwareId, commandId } = action
+      const nextCommandList =
+        state[labwareId] != null
+          ? // if there are already two command ids, overwrite the second one with the new one coming in
+            // this is used when there is an unsuccessful pick up tip, and additional pick up tip attempts occur
+            [state[labwareId][0], commandId]
+          : [commandId]
+      return {
+        ...state,
+        [labwareId]: nextCommandList,
+      }
+    },
+    {}
+  )
   const [isRestartingRun, setIsRestartingRun] = React.useState<boolean>(false)
   const {
     confirm: confirmExitLPC,
@@ -54,8 +63,7 @@ export const LabwarePositionCheck = (
     commandId: string,
     labwareId: string
   ): void => {
-    console.log('save positionc ommand data ' , savePositionCommandData, labwareId, commandId)
-    savePositionCommandDataDispatch({labwareId, commandId})
+    savePositionCommandDataDispatch({ labwareId, commandId })
   }
   const labwarePositionCheckUtils = useLabwarePositionCheck(
     addSavePositionCommandData,


### PR DESCRIPTION
# Overview

This PR changes when `savePosition` commands get executed to avoid a race condition. It also changes the local state updater that keeps track of `savePosition` command ids to use `useReducer` instead of `useState` so that state updates that depend on previous states work as expected.

closes #8921 

# Changelog

- Execute LPC save position commands right after movement commands

# Review requests
Run through LPC quickly, you should no longer see an error like this: `Uncaught Error: expected exactly two save position commands ids for labware id: foo, but got X` 

# Risk assessment

Low