### PR TITLE
feat(app): disable start run until robot is ready

### DIFF
--- a/app/src/assets/localization/en/run_details.json
+++ b/app/src/assets/localization/en/run_details.json
@@ -52,5 +52,6 @@
   "protocol_steps": "Protocol steps",
   "protocol_run_failed": "Protocol run failed",
   "protocol_run_canceled": "Protocol run canceled",
-  "protocol_run_complete": "Protocol run complete"
+  "protocol_run_complete": "Protocol run complete",
+  "run_cta_disabled": "Complete required steps on Protocol tab before starting the run"
 }

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ProceedToRunCta.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ProceedToRunCta.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
-import every from 'lodash/every'
 import { NavLink } from 'react-router-dom'
-import { useMissingModuleIds, useCurrentRunPipetteInfoByMount } from './hooks'
+import { useMissingModuleIds, useProtocolCalibrationStatus } from './hooks'
 import { useTranslation } from 'react-i18next'
 import {
   Flex,
@@ -16,20 +15,7 @@ export const ProceedToRunCta = (): JSX.Element | null => {
   const { t } = useTranslation('protocol_setup')
   const [targetProps, tooltipProps] = useHoverTooltip()
   const missingModuleIds = useMissingModuleIds()
-  const pipetteInfoByMount = useCurrentRunPipetteInfoByMount()
-  const isEverythingCalibrated = every(pipetteInfoByMount, pipetteInfo => {
-    if (pipetteInfo != null) {
-      return (
-        pipetteInfo.pipetteCalDate != null &&
-        pipetteInfo.tipRacksForPipette.every(
-          tipRackInfo => tipRackInfo.lastModifiedDate != null
-        )
-      )
-    } else {
-      // if no pipette requested on mount
-      return true
-    }
-  })
+  const isEverythingCalibrated = useProtocolCalibrationStatus().complete
   const calibrationIncomplete =
     missingModuleIds.length === 0 && !isEverythingCalibrated
   const moduleSetupIncomplete =

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/__tests__/ProceedToRunCta.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/__tests__/ProceedToRunCta.test.tsx
@@ -5,8 +5,6 @@ import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../../i18n'
 import * as hooks from '../hooks'
 import { ProceedToRunCta } from '../ProceedToRunCta'
-import { mockPipetteInfo } from '../../../../redux/pipettes/__fixtures__'
-
 jest.mock('@opentrons/components', () => {
   const actualComponents = jest.requireActual('@opentrons/components')
   return {
@@ -20,8 +18,8 @@ jest.mock('../hooks')
 const mockUseMissingModuleIds = hooks.useMissingModuleIds as jest.MockedFunction<
   typeof hooks.useMissingModuleIds
 >
-const mockUseCurrentRunPipetteInfoByMount = hooks.useCurrentRunPipetteInfoByMount as jest.MockedFunction<
-  typeof hooks.useCurrentRunPipetteInfoByMount
+const mockUseProtocolCalibrationStatus = hooks.useProtocolCalibrationStatus as jest.MockedFunction<
+  typeof hooks.useProtocolCalibrationStatus
 >
 
 const render = () => {
@@ -36,9 +34,8 @@ const render = () => {
 }
 describe('ProceedToRunCta', () => {
   beforeEach(() => {
-    mockUseCurrentRunPipetteInfoByMount.mockReturnValue({
-      left: mockPipetteInfo,
-      right: null,
+    mockUseProtocolCalibrationStatus.mockReturnValue({
+      complete: true,
     })
   })
 
@@ -58,9 +55,8 @@ describe('ProceedToRunCta', () => {
   })
   it('should be disabled with modules not connected and calibration not completed tooltip if missing cal and moduleIds', async () => {
     mockUseMissingModuleIds.mockReturnValue(['temperatureModuleV1'])
-    mockUseCurrentRunPipetteInfoByMount.mockReturnValue({
-      left: { ...mockPipetteInfo, pipetteCalDate: null },
-      right: null,
+    mockUseProtocolCalibrationStatus.mockReturnValue({
+      complete: false,
     } as any)
     const { getByRole, getByText } = render()
     const button = getByRole('button', { name: 'Proceed to Run' })
@@ -71,9 +67,8 @@ describe('ProceedToRunCta', () => {
   })
   it('should be disabled with calibration not complete tooltip', async () => {
     mockUseMissingModuleIds.mockReturnValue([])
-    mockUseCurrentRunPipetteInfoByMount.mockReturnValue({
-      left: { ...mockPipetteInfo, pipetteCalDate: null },
-      right: null,
+    mockUseProtocolCalibrationStatus.mockReturnValue({
+      complete: false,
     } as any)
     const { getByRole, getByText } = render()
     const button = getByRole('button', { name: 'Proceed to Run' })

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/hooks/index.ts
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './useMissingModuleIds'
 export * from './useCurrentRunPipetteInfoByMount'
+export * from './useProtocolCalibrationStatus'

--- a/app/src/organisms/RunTimeControl/index.tsx
+++ b/app/src/organisms/RunTimeControl/index.tsx
@@ -16,6 +16,8 @@ import {
   IconName,
   PrimaryBtn,
   Text,
+  Tooltip,
+  useHoverTooltip,
   ALIGN_CENTER,
   ALIGN_STRETCH,
   BORDER_RADIUS_1,
@@ -30,7 +32,10 @@ import {
   SPACING_2,
   SPACING_3,
 } from '@opentrons/components'
-
+import {
+  useMissingModuleIds,
+  useProtocolCalibrationStatus,
+} from '../ProtocolSetup/RunSetupCard/hooks'
 import {
   useRunCompleteTime,
   useRunControls,
@@ -42,7 +47,10 @@ import { Timer } from './Timer'
 
 export function RunTimeControl(): JSX.Element | null {
   const { t } = useTranslation('run_details')
-
+  const missingModuleIds = useMissingModuleIds()
+  const isEverythingCalibrated = useProtocolCalibrationStatus().complete
+  const disableRunCta = !isEverythingCalibrated || missingModuleIds.length > 0
+  const [targetProps, tooltipProps] = useHoverTooltip()
   const runStatus = useRunStatus()
   const startTime = useRunStartTime()
   const pausedAt = useRunPauseTime()
@@ -107,12 +115,17 @@ export function RunTimeControl(): JSX.Element | null {
         justifyContent={JUSTIFY_CENTER}
         alignItems={ALIGN_CENTER}
         display={DISPLAY_FLEX}
+        disabled={disableRunCta}
+        {...targetProps}
       >
         {buttonIconName != null ? (
           <Icon name={buttonIconName} size={SIZE_1} marginRight={SPACING_2} />
         ) : null}
         <Text fontSize={FONT_SIZE_DEFAULT}>{buttonText}</Text>
       </PrimaryBtn>
+      {disableRunCta && (
+        <Tooltip {...tooltipProps}>{t('run_cta_disabled')}</Tooltip>
+      )}
     </Flex>
   ) : null
 }


### PR DESCRIPTION
close #8915

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Disable Start Run CTA until the robot is ready to run the protocol
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
Update "Proceed to Run" CTA with `useProtocolCalibrationStatus` 
Disable Start Run CTA if calibration is incomplete or modules are missing
Add tooltip to explain why Start Run CTA is disabled

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Check that CTA is disabled and tooltip appears as expected
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Low