### PR TITLE
refactor(app): jog correct pipette in LPC

### DIFF
--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
@@ -592,7 +592,7 @@ export function useLabwarePositionCheck(
     const moveRelCommand: AnonymousCommand = {
       commandType: 'moveRelative',
       params: {
-        pipetteId: currentCommand.params.pipetteId,
+        pipetteId: prevCommand.params.pipetteId,
         distance: step * dir,
         axis,
       },


### PR DESCRIPTION
# Overview

@b-cooper found a bug where in the 2 pipette workflow jogging moves the wrong pipette. This fixes that.

# Review requests

Go through the 2 pipette LPC flow and jog, it should work as expected now
# Risk assessment
Low
