### PR TITLE
refactor(engine): dodge thermocycler when moving pipettes

### DIFF
--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -210,6 +210,17 @@ class LabwareView(HasState[LabwareState]):
 
         return Point(x=position[0], y=position[1], z=position[2])
 
+    def get_slot_center_position(self, slot: DeckSlotName) -> Point:
+        """Get the (x, y, z) position of the center of the slot."""
+        slot_def = self.get_slot_definition(slot)
+        position = slot_def["position"]
+
+        return Point(
+            x=position[0] + slot_def["boundingBox"]["xDimension"] / 2,
+            y=position[1] + slot_def["boundingBox"]["yDimension"] / 2,
+            z=position[2] + slot_def["boundingBox"]["zDimension"] / 2,
+        )
+
     def get_definition_by_uri(self, uri: LabwareUri) -> LabwareDefinition:
         """Get the labware definition matching loadName namespace and version."""
         try:

--- a/api/src/opentrons/protocol_engine/state/motion.py
+++ b/api/src/opentrons/protocol_engine/state/motion.py
@@ -109,7 +109,7 @@ class MotionView:
                 if self._geometry.should_dodge_thermocycler(
                     from_labware_id=location.labware_id, to_labware_id=labware_id
                 ):
-                    slot_5_center = self._labware.get_slot_position(
+                    slot_5_center = self._labware.get_slot_center_position(
                         slot=DeckSlotName.SLOT_5
                     )
                     extra_waypoints = [(slot_5_center.x, slot_5_center.y)]

--- a/api/src/opentrons/protocol_engine/state/motion.py
+++ b/api/src/opentrons/protocol_engine/state/motion.py
@@ -12,35 +12,10 @@ from opentrons.motion_planning import (
 )
 
 from .. import errors
-from ..types import (
-    WellLocation,
-    DeckSlotLocation,
-    LabwareLocation,
-    ModuleLocation,
-    ModuleModel,
-)
+from ..types import WellLocation
 from .labware import LabwareView
 from .pipettes import PipetteView, CurrentWell
 from .geometry import GeometryView
-from .modules import ModuleView
-
-
-BAD_PAIRS = [
-    ("1", "12"),
-    ("12", "1"),
-    ("4", "12"),
-    ("12", "4"),
-    ("4", "9"),
-    ("9", "4"),
-    ("4", "8"),
-    ("8", "4"),
-    ("1", "8"),
-    ("8", "1"),
-    ("4", "11"),
-    ("11", "4"),
-    ("1", "11"),
-    ("11", "1"),
-]
 
 
 @dataclass(frozen=True)
@@ -59,13 +34,11 @@ class MotionView:
         labware_view: LabwareView,
         pipette_view: PipetteView,
         geometry_view: GeometryView,
-        module_view: ModuleView,
     ) -> None:
         """Initialize a MotionState instance."""
         self._labware = labware_view
         self._pipettes = pipette_view
         self._geometry = geometry_view
-        self._module = module_view
 
     def get_pipette_location(
         self,
@@ -129,17 +102,19 @@ class MotionView:
                 else MoveType.DIRECT
             )
             min_travel_z = self._geometry.get_labware_highest_z(labware_id)
-            if self._should_dodge_thermocycler(
-                    from_loc=self._labware.get_location(location.labware_id),
-                    to_loc=self._labware.get_location(labware_id)):
-                slot_5_center = self._labware.get_slot_position(
-                    slot=DeckSlotName.SLOT_5)
-                extra_waypoints = [(slot_5_center.x, slot_5_center.y)]
         else:
             move_type = MoveType.GENERAL_ARC
             min_travel_z = self._geometry.get_all_labware_highest_z()
+            if location is not None:
+                if self._geometry.should_dodge_thermocycler(
+                    from_labware_id=location.labware_id, to_labware_id=labware_id
+                ):
+                    slot_5_center = self._labware.get_slot_position(
+                        slot=DeckSlotName.SLOT_5
+                    )
+                    extra_waypoints = [(slot_5_center.x, slot_5_center.y)]
             # TODO (spp, 11-29-2021): Should log some kind of warning that pipettes
-            #  could crash onto the thermocycler
+            #  could crash onto the thermocycler if current well is not known.
 
         try:
             # TODO(mc, 2021-01-08): inject `get_waypoints` via constructor
@@ -155,27 +130,3 @@ class MotionView:
             )
         except MotionPlanningError as error:
             raise errors.FailedToPlanMoveError(str(error))
-
-    def _should_dodge_thermocycler(
-        self, from_loc: LabwareLocation, to_loc: LabwareLocation
-    ) -> bool:
-        """
-        Decide if the requested path would cross the thermocycler, if installed.
-
-        Returns True if we need to dodge, False otherwise
-        """
-
-        def get_slot_name(location: LabwareLocation) -> DeckSlotName:
-            slot_name: DeckSlotName
-            if isinstance(location, DeckSlotLocation):
-                slot_name = location.slotName
-            else:
-                slot_name = self._module.get_location(location.moduleId).slotName
-            return slot_name
-
-        if ModuleModel.THERMOCYCLER_MODULE_V1 in [mod.model
-                                                  for mod in self._module.get_all()]:
-            transit = (get_slot_name(from_loc).value, get_slot_name(to_loc).value)
-            if transit in BAD_PAIRS:
-                return True
-        return False

--- a/api/src/opentrons/protocol_engine/state/motion.py
+++ b/api/src/opentrons/protocol_engine/state/motion.py
@@ -16,6 +16,7 @@ from ..types import WellLocation
 from .labware import LabwareView
 from .pipettes import PipetteView, CurrentWell
 from .geometry import GeometryView
+from .modules import ModuleView
 
 
 @dataclass(frozen=True)
@@ -34,11 +35,13 @@ class MotionView:
         labware_view: LabwareView,
         pipette_view: PipetteView,
         geometry_view: GeometryView,
+        module_view: ModuleView,
     ) -> None:
         """Initialize a MotionState instance."""
         self._labware = labware_view
         self._pipettes = pipette_view
         self._geometry = geometry_view
+        self._module = module_view
 
     def get_pipette_location(
         self,
@@ -106,8 +109,11 @@ class MotionView:
             move_type = MoveType.GENERAL_ARC
             min_travel_z = self._geometry.get_all_labware_highest_z()
             if location is not None:
-                if self._geometry.should_dodge_thermocycler(
-                    from_labware_id=location.labware_id, to_labware_id=labware_id
+                if self._module.should_dodge_thermocycler(
+                    from_slot=self._geometry.get_ancestor_slot_name(
+                        location.labware_id
+                    ),
+                    to_slot=self._geometry.get_ancestor_slot_name(labware_id),
                 ):
                     slot_5_center = self._labware.get_slot_center_position(
                         slot=DeckSlotName.SLOT_5

--- a/api/src/opentrons/protocol_engine/state/state.py
+++ b/api/src/opentrons/protocol_engine/state/state.py
@@ -197,6 +197,7 @@ class StateStore(StateView, ActionHandler):
             labware_view=self._labware,
             pipette_view=self._pipettes,
             geometry_view=self._geometry,
+            module_view=self._modules,
         )
 
     def _update_state_views(self) -> None:

--- a/api/src/opentrons/protocol_engine/state/state.py
+++ b/api/src/opentrons/protocol_engine/state/state.py
@@ -197,7 +197,6 @@ class StateStore(StateView, ActionHandler):
             labware_view=self._labware,
             pipette_view=self._pipettes,
             geometry_view=self._geometry,
-            module_view=self._modules,
         )
 
     def _update_state_views(self) -> None:

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -648,7 +648,7 @@ def test_thermocycler_dodging(
     decoy: Decoy,
     labware_view: LabwareView,
     module_view: ModuleView,
-    minimal_module_def: ModuleDefinition,
+    tempdeck_v1_def: ModuleDefinition,
     subject: GeometryView,
     from_slot: DeckSlotName,
     to_slot: DeckSlotName,
@@ -681,7 +681,7 @@ def test_thermocycler_dodging(
                 id="module-1",
                 model=ModuleModel.THERMOCYCLER_MODULE_V1,
                 location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
-                definition=minimal_module_def,
+                definition=tempdeck_v1_def,
             )
         ]
     )

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -376,7 +376,7 @@ def test_get_slot_position(standard_deck_def: DeckDefinitionV2) -> None:
 
 
 def test_get_slot_center_position(standard_deck_def: DeckDefinitionV2) -> None:
-    """It should get the absoluation location of a deck slot's center."""
+    """It should get the absolute location of a deck slot's center."""
     subject = get_labware_view(deck_definition=standard_deck_def)
 
     slot_def = standard_deck_def["locations"]["orderedSlots"][1]

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -379,13 +379,7 @@ def test_get_slot_center_position(standard_deck_def: DeckDefinitionV2) -> None:
     """It should get the absolute location of a deck slot's center."""
     subject = get_labware_view(deck_definition=standard_deck_def)
 
-    slot_def = standard_deck_def["locations"]["orderedSlots"][1]
-    slot_pos = slot_def["position"]
-    expected_center = Point(
-        x=slot_pos[0] + slot_def["boundingBox"]["xDimension"] / 2,
-        y=slot_pos[1] + slot_def["boundingBox"]["yDimension"] / 2,
-        z=slot_pos[2] + slot_def["boundingBox"]["zDimension"] / 2,
-    )
+    expected_center = Point(x=196.5, y=43.0, z=0.0)
     result = subject.get_slot_center_position(DeckSlotName.SLOT_2)
     assert result == expected_center
 

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -375,6 +375,21 @@ def test_get_slot_position(standard_deck_def: DeckDefinitionV2) -> None:
     assert result == Point(x=slot_pos[0], y=slot_pos[1], z=slot_pos[2])
 
 
+def test_get_slot_center_position(standard_deck_def: DeckDefinitionV2) -> None:
+    """It should get the absoluation location of a deck slot's center."""
+    subject = get_labware_view(deck_definition=standard_deck_def)
+
+    slot_def = standard_deck_def["locations"]["orderedSlots"][1]
+    slot_pos = slot_def["position"]
+    expected_center = Point(
+        x=slot_pos[0] + slot_def["boundingBox"]["xDimension"] / 2,
+        y=slot_pos[1] + slot_def["boundingBox"]["yDimension"] / 2,
+        z=slot_pos[2] + slot_def["boundingBox"]["zDimension"] / 2,
+    )
+    result = subject.get_slot_center_position(DeckSlotName.SLOT_2)
+    assert result == expected_center
+
+
 def test_get_labware_offset_vector() -> None:
     """It should get a labware's offset vector."""
     labware_without_offset = LoadedLabware(

--- a/api/tests/opentrons/protocol_engine/state/test_motion_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_motion_view.py
@@ -2,9 +2,9 @@
 import pytest
 from decoy import Decoy
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Optional, Sequence, Tuple
 
-from opentrons.types import Point, MountType
+from opentrons.types import Point, MountType, DeckSlotName
 from opentrons.hardware_control.types import CriticalPoint
 from opentrons.motion_planning import MoveType, get_waypoints
 
@@ -21,13 +21,6 @@ from opentrons.protocol_engine.state.labware import LabwareView
 from opentrons.protocol_engine.state.pipettes import PipetteView, CurrentWell
 from opentrons.protocol_engine.state.geometry import GeometryView
 from opentrons.protocol_engine.state.motion import MotionView
-from opentrons.protocol_engine.state.modules import ModuleView
-
-
-@pytest.fixture
-def module_view(decoy: Decoy) -> ModuleView:
-    """Get a mock in the shape of a GeometryView."""
-    return decoy.mock(cls=ModuleView)
 
 
 @pytest.fixture
@@ -35,14 +28,12 @@ def subject(
     labware_view: LabwareView,
     pipette_view: PipetteView,
     geometry_view: GeometryView,
-    module_view: ModuleView,
 ) -> MotionView:
     """Get a MotionView with its dependencies mocked out."""
     return MotionView(
         labware_view=labware_view,
         pipette_view=pipette_view,
         geometry_view=geometry_view,
-        module_view=module_view,
     )
 
 
@@ -197,6 +188,8 @@ class WaypointSpec:
     labware_z: Optional[float] = None
     all_labware_z: Optional[float] = None
     max_travel_z: float = 50
+    should_dodge_thermocycler: bool = False
+    extra_waypoints: Sequence[Tuple[float, float]] = ()
 
 
 # TODO(mc, 2021-01-14): these tests probably need to be rethought; this fixture
@@ -265,6 +258,18 @@ class WaypointSpec:
             ),
             expected_move_type=MoveType.GENERAL_ARC,
         ),
+        WaypointSpec(
+            name="General arc with extra waypoints to dodge thermocycler",
+            location=CurrentWell(
+                pipette_id="pipette-id",
+                labware_id="other-labware-id",
+                well_name="A1",
+            ),
+            all_labware_z=20,
+            should_dodge_thermocycler=True,
+            expected_move_type=MoveType.GENERAL_ARC,
+            extra_waypoints=[(123, 456)],
+        )
         # TODO(mc, 2021-01-08): add test for override current location
     ],
 )
@@ -311,6 +316,20 @@ def test_get_movement_waypoints(
 
     decoy.when(pipette_view.get_current_well()).then_return(spec.location)
 
+    if spec.location:
+        decoy.when(
+            geometry_view.should_dodge_thermocycler(
+                from_labware_id=spec.location.labware_id, to_labware_id=spec.labware_id
+            )
+        ).then_return(spec.should_dodge_thermocycler)
+
+    if spec.should_dodge_thermocycler:
+        decoy.when(
+            labware_view.get_slot_position(slot=DeckSlotName.SLOT_5)
+        ).then_return(
+            Point(x=spec.extra_waypoints[0][0], y=spec.extra_waypoints[0][1], z=0)
+        )
+
     result = subject.get_movement_waypoints(
         pipette_id=spec.pipette_id,
         labware_id=spec.labware_id,
@@ -329,7 +348,7 @@ def test_get_movement_waypoints(
         min_travel_z=min_travel_z,
         dest=spec.dest,
         dest_cp=spec.expected_dest_cp,
-        xy_waypoints=[],
+        xy_waypoints=spec.extra_waypoints,
     )
 
     assert result == expected

--- a/api/tests/opentrons/protocol_engine/state/test_motion_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_motion_view.py
@@ -21,6 +21,13 @@ from opentrons.protocol_engine.state.labware import LabwareView
 from opentrons.protocol_engine.state.pipettes import PipetteView, CurrentWell
 from opentrons.protocol_engine.state.geometry import GeometryView
 from opentrons.protocol_engine.state.motion import MotionView
+from opentrons.protocol_engine.state.modules import ModuleView
+
+
+@pytest.fixture
+def module_view(decoy: Decoy) -> ModuleView:
+    """Get a mock in the shape of a GeometryView."""
+    return decoy.mock(cls=ModuleView)
 
 
 @pytest.fixture
@@ -28,12 +35,14 @@ def subject(
     labware_view: LabwareView,
     pipette_view: PipetteView,
     geometry_view: GeometryView,
+    module_view: ModuleView,
 ) -> MotionView:
     """Get a MotionView with its dependencies mocked out."""
     return MotionView(
         labware_view=labware_view,
         pipette_view=pipette_view,
         geometry_view=geometry_view,
+        module_view=module_view,
     )
 
 

--- a/api/tests/opentrons/protocol_engine/state/test_motion_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_motion_view.py
@@ -325,9 +325,9 @@ def test_get_movement_waypoints(
 
     if spec.should_dodge_thermocycler:
         decoy.when(
-            labware_view.get_slot_position(slot=DeckSlotName.SLOT_5)
+            labware_view.get_slot_center_position(slot=DeckSlotName.SLOT_5)
         ).then_return(
-            Point(x=spec.extra_waypoints[0][0], y=spec.extra_waypoints[0][1], z=0)
+            Point(x=spec.extra_waypoints[0][0], y=spec.extra_waypoints[0][1], z=123)
         )
 
     result = subject.get_movement_waypoints(


### PR DESCRIPTION
Addresses #8911

# Overview

Makes the pipettes move around the thermocycler instead of over it/ crashing into it. The logic is copied from the legacy movement planning code as is. It adds an intermediate waypoint over slot 5 when performing a move that would otherwise have to go over the slots containing a thermocycler.

# Changelog

- added thermocycler dodging to `motion.py`: pipettes will move through slot 5 to dodge.
- added `should_dodge_thermocycler` function to ~`geometry.py`~ `ModuleView`
- updated tests

# Review requests

- The above logic needs tracking of current well. What should happen if `current_well` is not known?
- Is this missing anything?
- Test on a real robot. Give it a move from and to locations that are in the `BAD_PAIRS`, once with thermocycler loaded and once without and make sure that the movement is routed over slot 5 when thermocycler is present.

# Risk assessment

Medium. Should only affect limited set of movements when thermocycler is being used. 
