### PR TITLE
fix(app): continue to clone run even after receiving a conflict when run is stopped

### DIFF
--- a/app/src/organisms/ProtocolUpload/hooks/__tests__/useCloneRun.test.tsx
+++ b/app/src/organisms/ProtocolUpload/hooks/__tests__/useCloneRun.test.tsx
@@ -5,7 +5,6 @@ import { QueryClient, QueryClientProvider } from 'react-query'
 import {
   useRunQuery,
   useHost,
-  useStopRunMutation,
   useCreateRunMutation,
 } from '@opentrons/react-api-client'
 import { useCloneRun } from '../useCloneRun'
@@ -15,9 +14,6 @@ import type { HostConfig } from '@opentrons/api-client'
 jest.mock('@opentrons/react-api-client')
 
 const mockUseHost = useHost as jest.MockedFunction<typeof useHost>
-const mockUseStopRunMutation = useStopRunMutation as jest.MockedFunction<
-  typeof useStopRunMutation
->
 const mockUseRunQuery = useRunQuery as jest.MockedFunction<typeof useRunQuery>
 const mockUseCreateRunMutation = useCreateRunMutation as jest.MockedFunction<
   typeof useCreateRunMutation
@@ -33,7 +29,15 @@ describe('useCloneRun hook', () => {
     when(mockUseHost).calledWith().mockReturnValue(HOST_CONFIG)
     when(mockUseRunQuery)
       .calledWith(RUN_ID)
-      .mockReturnValue({ data: { data: { id: RUN_ID } } } as any)
+      .mockReturnValue({
+        data: {
+          data: {
+            id: RUN_ID,
+            protocolId: 'protocolId',
+            labwareOffsets: 'someOffset',
+          },
+        },
+      } as any)
     when(mockUseCreateRunMutation)
       .calledWith(expect.anything())
       .mockReturnValue({ createRun: jest.fn() } as any)
@@ -49,11 +53,16 @@ describe('useCloneRun hook', () => {
   })
 
   it('should return a function that when called, calls stop run with the run id', async () => {
-    const mockStopRun = jest.fn()
-    mockUseStopRunMutation.mockReturnValue({ stopRun: mockStopRun } as any)
+    const mockCreateRun = jest.fn()
+    mockUseCreateRunMutation.mockReturnValue({
+      createRun: mockCreateRun,
+    } as any)
 
     const { result } = renderHook(() => useCloneRun(RUN_ID), { wrapper })
     result.current && result.current()
-    expect(mockStopRun).toHaveBeenCalledWith(RUN_ID)
+    expect(mockCreateRun).toHaveBeenCalledWith({
+      protocolId: 'protocolId',
+      labwareOffsets: 'someOffset',
+    })
   })
 })

--- a/app/src/organisms/ProtocolUpload/hooks/useCloneRun.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useCloneRun.ts
@@ -26,6 +26,12 @@ export function useCloneRun(runId: string | null): () => void {
         createRun({ protocolId, labwareOffsets })
       }
     },
+    onError: (error: AxiosError) => {
+      if (runRecord != null) {
+        const { protocolId, labwareOffsets } = runRecord.data
+        createRun({ protocolId, labwareOffsets })
+      }
+    },
   })
 
   return () => runId != null && stopThenCloneRun(runId)

--- a/app/src/organisms/ProtocolUpload/hooks/useCloneRun.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useCloneRun.ts
@@ -18,7 +18,7 @@ export function useCloneRun(runId: string | null): () => void {
         )
     },
   })
-  const cloneRun = () => {
+  const cloneRun = (): void => {
     if (runRecord != null) {
       const { protocolId, labwareOffsets } = runRecord.data
       createRun({ protocolId, labwareOffsets })

--- a/app/src/organisms/ProtocolUpload/hooks/useCloneRun.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useCloneRun.ts
@@ -2,7 +2,6 @@ import { useQueryClient } from 'react-query'
 import {
   useHost,
   useRunQuery,
-  useStopRunMutation,
   useCreateRunMutation,
 } from '@opentrons/react-api-client'
 
@@ -19,20 +18,12 @@ export function useCloneRun(runId: string | null): () => void {
         )
     },
   })
-  const { stopRun: stopThenCloneRun } = useStopRunMutation({
-    onSuccess: _data => {
-      if (runRecord != null) {
-        const { protocolId, labwareOffsets } = runRecord.data
-        createRun({ protocolId, labwareOffsets })
-      }
-    },
-    onError: (error: AxiosError) => {
-      if (runRecord != null) {
-        const { protocolId, labwareOffsets } = runRecord.data
-        createRun({ protocolId, labwareOffsets })
-      }
-    },
-  })
+  const cloneRun = () => {
+    if (runRecord != null) {
+      const { protocolId, labwareOffsets } = runRecord.data
+      createRun({ protocolId, labwareOffsets })
+    }
+  }
 
-  return () => runId != null && stopThenCloneRun(runId)
+  return cloneRun
 }


### PR DESCRIPTION
# Overview

The stop action is not idempotent, so we need to continue to clone a run even if the robot reports that a run has already been stopped.

# Review requests

- run a run, then clone it

# Risk assessment

low