### PR TITLE
feat(app): show correct number of offsets in rerun protocol section

### DIFF
--- a/app/src/organisms/ProtocolUpload/UploadInput.tsx
+++ b/app/src/organisms/ProtocolUpload/UploadInput.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react'
 import { format, parseISO } from 'date-fns'
+import { useSelector } from 'react-redux'
+import { css } from 'styled-components'
+import { Trans, useTranslation } from 'react-i18next'
 import {
   Icon,
   Text,
@@ -30,17 +33,15 @@ import {
   SPACING_2,
   JUSTIFY_START,
 } from '@opentrons/components'
-import { css } from 'styled-components'
-import { Trans, useTranslation } from 'react-i18next'
-import { useMostRecentRunId } from './hooks/useMostRecentRunId'
-import { useSelector } from 'react-redux'
-import { State } from '../../redux/types'
+import { useProtocolQuery, useRunQuery } from '@opentrons/react-api-client'
+import { getLatestLabwareOffsetCount } from '../ProtocolSetup/LabwarePositionCheck/utils/getLatestLabwareOffsetCount'
+import { useProtocolDetails } from '../RunDetails/hooks'
 import { getConnectedRobotName } from '../../redux/robot/selectors'
 import { Divider } from '../../atoms/structure'
-import { useProtocolQuery, useRunQuery } from '@opentrons/react-api-client'
-import { useProtocolDetails } from '../RunDetails/hooks'
+import { useMostRecentRunId } from './hooks/useMostRecentRunId'
 import { RerunningProtocolModal } from './RerunningProtocolModal'
 import { useCloneRun } from './hooks'
+import type { State } from '../../redux/types'
 
 const PROTOCOL_LIBRARY_URL = 'https://protocols.opentrons.com'
 const PROTOCOL_DESIGNER_URL = 'https://designer.opentrons.com'
@@ -140,6 +141,8 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
         ${DROP_ZONE_STYLES} ${DRAG_OVER_STYLES}
       `
     : DROP_ZONE_STYLES
+
+  const labwareOffsetCount = getLatestLabwareOffsetCount(labwareOffsets ?? [])
 
   return (
     <Flex
@@ -266,16 +269,14 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
                 {t('labware_offset_data_title')}
               </Text>
               <Flex css={FONT_BODY_1_DARK}>
-                {labwareOffsets != null && labwareOffsets.length === 0 ? (
+                {labwareOffsetCount === 0 ? (
                   <Text>{t('no_labware_offset_data')}</Text>
                 ) : (
-                  labwareOffsets != null && (
-                    <Trans
-                      t={t}
-                      i18nKey="labware_offsets_info"
-                      values={{ number: labwareOffsets.length }}
-                    />
-                  )
+                  <Trans
+                    t={t}
+                    i18nKey="labware_offsets_info"
+                    values={{ number: labwareOffsetCount }}
+                  />
                 )}
               </Flex>
             </Flex>

--- a/app/src/organisms/ProtocolUpload/__tests__/UploadInput.test.tsx
+++ b/app/src/organisms/ProtocolUpload/__tests__/UploadInput.test.tsx
@@ -18,7 +18,7 @@ import { useProtocolQuery, useRunQuery } from '@opentrons/react-api-client'
 import { RerunningProtocolModal } from '../RerunningProtocolModal'
 import { useCloneRun } from '../hooks'
 import type { ProtocolFile } from '@opentrons/shared-data'
-import type { LabwareOffset, VectorOffset } from '@opentrons/api-client'
+import type { LabwareOffset } from '@opentrons/api-client'
 
 jest.mock('../hooks/useMostRecentRunId')
 jest.mock('@opentrons/react-api-client')

--- a/app/src/organisms/ProtocolUpload/__tests__/UploadInput.test.tsx
+++ b/app/src/organisms/ProtocolUpload/__tests__/UploadInput.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { when } from 'jest-when'
+import { when, resetAllWhenMocks } from 'jest-when'
 import '@testing-library/jest-dom'
 import { fireEvent, screen } from '@testing-library/react'
 import {
@@ -7,16 +7,18 @@ import {
   nestedTextMatcher,
   renderWithProviders,
 } from '@opentrons/components'
+import _uncastedSimpleV6Protocol from '@opentrons/shared-data/protocol/fixtures/6/simpleV6.json'
 import { i18n } from '../../../i18n'
 import * as RobotSelectors from '../../../redux/robot/selectors'
 import { useProtocolDetails } from '../../RunDetails/hooks'
+import { getLatestLabwareOffsetCount } from '../../ProtocolSetup/LabwarePositionCheck/utils/getLatestLabwareOffsetCount'
 import { UploadInput } from '../UploadInput'
 import { useMostRecentRunId } from '../hooks/useMostRecentRunId'
 import { useProtocolQuery, useRunQuery } from '@opentrons/react-api-client'
-import _uncastedSimpleV6Protocol from '@opentrons/shared-data/protocol/fixtures/6/simpleV6.json'
 import { RerunningProtocolModal } from '../RerunningProtocolModal'
 import { useCloneRun } from '../hooks'
 import type { ProtocolFile } from '@opentrons/shared-data'
+import type { LabwareOffset, VectorOffset } from '@opentrons/api-client'
 
 jest.mock('../hooks/useMostRecentRunId')
 jest.mock('@opentrons/react-api-client')
@@ -24,6 +26,9 @@ jest.mock('../../RunDetails/hooks')
 jest.mock('../../../redux/robot/selectors')
 jest.mock('../hooks')
 jest.mock('../RerunningProtocolModal')
+jest.mock(
+  '../../ProtocolSetup/LabwarePositionCheck/utils/getLatestLabwareOffsetCount'
+)
 
 const mockUseMostRecentRunId = useMostRecentRunId as jest.MockedFunction<
   typeof useMostRecentRunId
@@ -36,13 +41,14 @@ const mockGetConnectedRobotName = RobotSelectors.getConnectedRobotName as jest.M
   typeof RobotSelectors.getConnectedRobotName
 >
 const mockUseCloneRun = useCloneRun as jest.MockedFunction<typeof useCloneRun>
-
 const mockUseProtocolQuery = useProtocolQuery as jest.MockedFunction<
   typeof useProtocolQuery
 >
-
 const mockRerunningProtocolModal = RerunningProtocolModal as jest.MockedFunction<
   typeof RerunningProtocolModal
+>
+const mockGetLatestLabwareOffsetCount = getLatestLabwareOffsetCount as jest.MockedFunction<
+  typeof getLatestLabwareOffsetCount
 >
 
 const simpleV6Protocol = (_uncastedSimpleV6Protocol as unknown) as ProtocolFile<{}>
@@ -55,11 +61,19 @@ const render = (props: React.ComponentProps<typeof UploadInput>) => {
 
 describe('UploadInput', () => {
   let props = {} as React.ComponentProps<typeof UploadInput>
+  let mockOffsets: LabwareOffset[]
 
   beforeEach(() => {
     props = {
       onUpload: jest.fn(),
     }
+    mockOffsets = [
+      {
+        definitionUri: 'mockUri',
+        location: { slotName: '3' },
+        vector: { x: 5, y: 5, z: 5 },
+      },
+    ]
     mockGetConnectedRobotName.mockReturnValue('robotName')
     mockUseMostRecentRunId.mockReturnValue('RunId')
     when(mockUseProtocolDetails).calledWith().mockReturnValue({
@@ -73,38 +87,44 @@ describe('UploadInput', () => {
           data: {
             protocolId: 'ProtocolId',
             createdAt: '2021-11-12T19:39:19.668514+00:00',
-            labwareOffsets: [{ x: 5, y: 5, z: 5 }],
+            labwareOffsets: mockOffsets,
           },
         },
       } as any)
     mockUseCloneRun.mockReturnValue(jest.fn())
-  })
-  when(mockUseProtocolQuery)
-    .calledWith('ProtocolId')
-    .mockReturnValue({
-      data: {
+    when(mockUseProtocolQuery)
+      .calledWith('ProtocolId')
+      .mockReturnValue({
         data: {
-          protocolType: 'python',
-          createdAt: 'now',
-          id: 'ProtocolId',
-          metadata: {},
-          analyses: {},
-          files: [{ name: 'name', role: 'main' }],
+          data: {
+            protocolType: 'python',
+            createdAt: 'now',
+            id: 'ProtocolId',
+            metadata: {},
+            analyses: {},
+            files: [{ name: 'name', role: 'main' }],
+          },
         },
-      },
-    } as any)
+      } as any)
 
-  when(mockRerunningProtocolModal)
-    .calledWith(
-      componentPropsMatcher({
-        onCloseClick: expect.anything(),
-      })
-    )
-    .mockImplementation(({ onCloseClick }) => (
-      <div onClick={onCloseClick}>Mock Rerunning Protocol Modal</div>
-    ))
+    when(mockRerunningProtocolModal)
+      .calledWith(
+        componentPropsMatcher({
+          onCloseClick: expect.anything(),
+        })
+      )
+      .mockImplementation(({ onCloseClick }) => (
+        <div onClick={onCloseClick}>Mock Rerunning Protocol Modal</div>
+      ))
+
+    when(mockGetLatestLabwareOffsetCount)
+      .calledWith(mockOffsets)
+      .mockReturnValue(0)
+  })
+
   afterEach(() => {
-    jest.resetAllMocks()
+    resetAllWhenMocks()
+    jest.restoreAllMocks()
   })
 
   it('renders correct contents for empty state', () => {
@@ -150,6 +170,9 @@ describe('UploadInput', () => {
     )
   })
   it('renders the correct latest protocol uplaoded info', () => {
+    when(mockGetLatestLabwareOffsetCount)
+      .calledWith(mockOffsets)
+      .mockReturnValue(1)
     const { getByText } = render(props)
     getByText('robotName’s last run')
     getByText('mock display name')
@@ -174,6 +197,7 @@ describe('UploadInput', () => {
           },
         },
       } as any)
+    when(mockGetLatestLabwareOffsetCount).calledWith([]).mockReturnValue(0)
     const { getByText } = render(props)
     getByText('No Labware Offset data')
   })


### PR DESCRIPTION
# Overview

This PR fixes the number of labware offsets shown in the rerun protocol section. 

Note: @smb2268 fixes the util used in this PR in https://github.com/Opentrons/opentrons/pull/8919


# Review requests

Redundant/identity offsets should not get counted in the rerun protocol section

# Risk assessment

Low
