### PR TITLE
refactor(engine): support pipette back-compat

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -532,6 +532,7 @@ class API(HardwareAPILike):
                 "default_aspirate_flow_rates",
                 "default_blow_out_flow_rates",
                 "default_dispense_flow_rates",
+                "back_compat_names",
             ]
 
             instr_dict = instr.as_dict()

--- a/api/src/opentrons/hardware_control/dev_types.py
+++ b/api/src/opentrons/hardware_control/dev_types.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 # and are only relevant for static typechecking. this file should only
 # be imported if typing.TYPE_CHECKING is True
 import asyncio
-from typing import Optional, Dict, Union
+from typing import Optional, Dict, List, Union
 
 from typing_extensions import Protocol, TypedDict, Literal
 
@@ -45,6 +45,7 @@ ONE_CHANNEL = Literal[1]
 class PipetteDict(TypedDict):
     name: PipetteName
     model: PipetteModel
+    back_compat_names: List[PipetteName]
     pipette_id: str
     display_name: str
     min_volume: float

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -177,8 +177,11 @@ class PipetteView(HasState[PipetteState]):
 
         if hw_config is None:
             raise errors.PipetteNotAttachedError(f"No pipetted attached on {mount}")
-        # TODO(mc, 2020-11-12): support hw_pipette.act_as
-        elif hw_config["name"] != pipette_name:
+
+        elif (
+            hw_config["name"] != pipette_name
+            and pipette_name not in hw_config["back_compat_names"]
+        ):
             raise errors.PipetteNotAttachedError(
                 f"Found {hw_config['name']} on {mount}, "
                 f"but {pipette_id} is a {pipette_name}"


### PR DESCRIPTION
## Overview

Little PR to support pipette back-compat in the engine when issuing commands with a pipetteId

## Changelog

- refactor(engine): support pipette back-compat

## Review requests

Smoke test on a robot if you are able, but otherwise check out the code. This is working for me in the dev server.

## Risk assessment

Low, but makes a very minor change to `opentrons.hardware_control.api` to add `back_compat_names` to `PipetteDict`