### PR TITLE
refactor(app): fix summary screen unique key error

### DIFF
--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwareOffsetsSummary.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwareOffsetsSummary.tsx
@@ -86,7 +86,7 @@ export const LabwareOffsetsSummary = (
             {offsetData.map(({ displayName: labware }, index) => {
               return (
                 <Flex
-                  key={index}
+                  key={`${labware}_${index}`}
                   marginBottom={SPACING_3}
                   css={FONT_BODY_1_DARK}
                 >
@@ -128,19 +128,19 @@ export const LabwareOffsetsSummary = (
                     <Text as={'strong'} marginRight={SPACING_1}>
                       X
                     </Text>
-                    <Text key={x} as={'span'} marginRight={SPACING_2}>
+                    <Text as={'span'} marginRight={SPACING_2}>
                       {x.toFixed(2)}
                     </Text>
                     <Text as={'strong'} marginRight={SPACING_1}>
                       Y
                     </Text>
-                    <Text key={y} as={'span'} marginRight={SPACING_2}>
+                    <Text as={'span'} marginRight={SPACING_2}>
                       {y.toFixed(2)}
                     </Text>
                     <Text as={'strong'} marginRight={SPACING_1}>
                       Z
                     </Text>
-                    <Text key={z} as={'span'} marginRight={SPACING_2}>
+                    <Text as={'span'} marginRight={SPACING_2}>
                       {z.toFixed(2)}
                     </Text>
                   </Flex>


### PR DESCRIPTION
# Overview
This PR fixes the duplicate react key error triggered by the LPC summary screen
# Review requests

Go through LPC all the way to the summary screen, you should no longer see this error: 


<img width="922" alt="Screen Shot 2021-11-30 at 12 22 25" src="https://user-images.githubusercontent.com/5788529/144114279-b9220e82-d24e-4712-95aa-65dd9ba8dcc4.png">

# Risk assessment

Low
