### PR TITLE
fix(app): fix module status card error on run page

### DIFF
--- a/app/src/pages/Run/RunPanel/ModuleLiveStatusCards/index.tsx
+++ b/app/src/pages/Run/RunPanel/ModuleLiveStatusCards/index.tsx
@@ -21,8 +21,8 @@ export const ModuleLiveStatusCards = (): JSX.Element | null => {
   const controlDisabledReason = useSelector(getModuleControlsDisabled)
   const [expandedCard, setExpandedCard] = React.useState(
     isEmpty(moduleInfoById)
-      ? Object.entries(moduleInfoById)[0][1].attachedModuleMatch?.serial
-      : ''
+      ? ''
+      : Object.entries(moduleInfoById)[0][1].attachedModuleMatch?.serial
   )
   const prevModuleCountRef = React.useRef<number>(
     Object.keys(moduleInfoById).length


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR fixes an error that was causing the Run page to blank due to an incorrect ternary made in the following PR: #8643.

# Changelog

- Reversed values in ternary due to usage of `isEmpty`

# Review requests

- When loading a protocol with modules, make sure the Run page does not blank when clicking the Run tab.

# Risk assessment

low
