### PR TITLE
refactor(app): fix labware on top of module renders in labware setup step

### DIFF
--- a/app/src/organisms/ProtocolSetup/utils/getProtocolModulesInfo.ts
+++ b/app/src/organisms/ProtocolSetup/utils/getProtocolModulesInfo.ts
@@ -44,7 +44,7 @@ export const getProtocolModulesInfo = (
               (command: LoadLabwareCommand) =>
                 'moduleId' in command.params.location &&
                 command.params.location.moduleId === moduleId
-            )?.params.labwareId ?? null
+            )?.result?.labwareId ?? null
 
         const nestedLabware =
           nestedLabwareId != null ? protocolData.labware[nestedLabwareId] : null


### PR DESCRIPTION
# Overview

This PR fixes an issue @jerader found where labware on top of modules were not being rendered in the labware setup step

# Review requests

Upload a protocol with labware on top of modules, the labware should render in the labware setup accordion step

# Risk assessment
Low