### PR TITLE
fix(app): ignore lpc commands when reconciling run and analysis for run log

### DIFF
--- a/app/src/organisms/RunDetails/CommandList.tsx
+++ b/app/src/organisms/RunDetails/CommandList.tsx
@@ -45,7 +45,9 @@ export function CommandList(): JSX.Element | null {
   const { runRecord } = useCurrentProtocolRun()
   const runStatus = useRunStatus()
   const runDataCommands = runRecord?.data.commands
-  const firstPlayTimestamp = runRecord?.data.actions.find(action => action.actionType === 'play')?.createdAt
+  const firstPlayTimestamp = runRecord?.data.actions.find(
+    action => action.actionType === 'play'
+  )?.createdAt
 
   const analysisCommandsWithStatus =
     protocolData?.commands != null
@@ -56,31 +58,42 @@ export function CommandList(): JSX.Element | null {
       : []
   const allProtocolCommands: Command[] =
     protocolData != null ? analysisCommandsWithStatus : []
-  const lastProtocolSetupCommand = last(allProtocolCommands
-    .filter(
-      command =>
-        ['loadLabware' ,'loadPipette', 'loadModule'].includes(command.commandType)
-    )) ?? null
-  const lastProtocolSetupIndex = allProtocolCommands.findIndex(command => command.id === lastProtocolSetupCommand?.id)
+  const lastProtocolSetupCommand =
+    last(
+      allProtocolCommands.filter(command =>
+        ['loadLabware', 'loadPipette', 'loadModule'].includes(
+          command.commandType
+        )
+      )
+    ) ?? null
+  const lastProtocolSetupIndex = allProtocolCommands.findIndex(
+    command => command.id === lastProtocolSetupCommand?.id
+  )
 
-  const protocolSetupCommandList = lastProtocolSetupCommand != null
-    ? allProtocolCommands.slice(0, lastProtocolSetupIndex + 1)
-    : []
-  const postSetupAnticipatedCommands: Command[] = lastProtocolSetupCommand != null
-    ? allProtocolCommands.slice(lastProtocolSetupIndex + 1)
-    : allProtocolCommands
-
+  const protocolSetupCommandList =
+    lastProtocolSetupCommand != null
+      ? allProtocolCommands.slice(0, lastProtocolSetupIndex + 1)
+      : []
+  const postSetupAnticipatedCommands: Command[] =
+    lastProtocolSetupCommand != null
+      ? allProtocolCommands.slice(lastProtocolSetupIndex + 1)
+      : allProtocolCommands
 
   let currentCommandList: Array<
     Command | RunCommandSummary
   > = postSetupAnticipatedCommands
-  if (runDataCommands != null && runDataCommands.length > 0 && firstPlayTimestamp != null) {
-    const firstPostPlayRunCommandIndex = runDataCommands.findIndex(command => (
-      command.id === postSetupAnticipatedCommands[0]?.id
-    ))
-    const postPlayRunCommands = firstPostPlayRunCommandIndex >= 0
-      ? runDataCommands.slice(firstPostPlayRunCommandIndex)
-      : []
+  if (
+    runDataCommands != null &&
+    runDataCommands.length > 0 &&
+    firstPlayTimestamp != null
+  ) {
+    const firstPostPlayRunCommandIndex = runDataCommands.findIndex(
+      command => command.id === postSetupAnticipatedCommands[0]?.id
+    )
+    const postPlayRunCommands =
+      firstPostPlayRunCommandIndex >= 0
+        ? runDataCommands.slice(firstPostPlayRunCommandIndex)
+        : []
 
     console.log('PP ', postPlayRunCommands[0])
     // const postPlayRunCommands = runDataCommands.filter(command => (
@@ -91,9 +104,7 @@ export function CommandList(): JSX.Element | null {
     const remainingAnticipatedCommands = dropWhile(
       postSetupAnticipatedCommands,
       anticipatedCommand =>
-        runDataCommands.some(
-          runC => runC.id === anticipatedCommand.id
-        )
+        runDataCommands.some(runC => runC.id === anticipatedCommand.id)
     )
 
     const isProtocolDeterministic = postPlayRunCommands.reduce(

--- a/app/src/organisms/RunDetails/CommandList.tsx
+++ b/app/src/organisms/RunDetails/CommandList.tsx
@@ -43,6 +43,7 @@ export function CommandList(): JSX.Element | null {
   const protocolData: ProtocolFile<{}> | null = useProtocolDetails()
     .protocolData
   const { runRecord } = useCurrentProtocolRun()
+  const runStatus = useRunStatus()
   const runDataCommands = runRecord?.data.commands
   const firstPlayTimestamp = runRecord?.data.actions.find(action => action.actionType === 'play')?.createdAt
 
@@ -58,31 +59,30 @@ export function CommandList(): JSX.Element | null {
   const lastProtocolSetupCommand = last(allProtocolCommands
     .filter(
       command =>
-        !['loadLabware' ,'loadPipette', 'loadModule'].includes(command.commandType)
+        ['loadLabware' ,'loadPipette', 'loadModule'].includes(command.commandType)
     )) ?? null
   const lastProtocolSetupIndex = allProtocolCommands.findIndex(command => command.id === lastProtocolSetupCommand?.id)
 
   const protocolSetupCommandList = lastProtocolSetupCommand != null
-    ? allProtocolCommands.slice(
-      0,
-      lastProtocolSetupIndex + 1
-    )
+    ? allProtocolCommands.slice(0, lastProtocolSetupIndex + 1)
     : []
   const postSetupAnticipatedCommands: Command[] = lastProtocolSetupCommand != null
-    ? allProtocolCommands.slice(
-      lastProtocolSetupIndex + 1
-    )
+    ? allProtocolCommands.slice(lastProtocolSetupIndex + 1)
     : allProtocolCommands
 
 
   let currentCommandList: Array<
     Command | RunCommandSummary
   > = postSetupAnticipatedCommands
-  if (runDataCommands != null && runDataCommands.length > 0) {
-
-    const postPlayRunCommands = runDataCommands.slice(runDataCommands.findIndex(command => (
+  if (runDataCommands != null && runDataCommands.length > 0 && firstPlayTimestamp != null) {
+    const firstPostPlayRunCommandIndex = runDataCommands.findIndex(command => (
       command.id === postSetupAnticipatedCommands[0]?.id
-    )))
+    ))
+    const postPlayRunCommands = firstPostPlayRunCommandIndex >= 0
+      ? runDataCommands.slice(firstPostPlayRunCommandIndex)
+      : []
+
+    console.log('PP ', postPlayRunCommands[0])
     // const postPlayRunCommands = runDataCommands.filter(command => (
     //   'createdAt' in command &&
     //   command?.createdAt != null &&
@@ -110,8 +110,8 @@ export function CommandList(): JSX.Element | null {
       ? [...postPlayRunCommands, ...remainingAnticipatedCommands]
       : [...postPlayRunCommands]
   }
+  console.log(currentCommandList[0], postSetupAnticipatedCommands[0])
 
-  const runStatus = useRunStatus()
   if (protocolData == null || runStatus == null) return null
 
   let alertItemTitle

--- a/app/src/organisms/RunDetails/CommandList.tsx
+++ b/app/src/organisms/RunDetails/CommandList.tsx
@@ -95,12 +95,6 @@ export function CommandList(): JSX.Element | null {
         ? runDataCommands.slice(firstPostPlayRunCommandIndex)
         : []
 
-    console.log('PP ', postPlayRunCommands[0])
-    // const postPlayRunCommands = runDataCommands.filter(command => (
-    //   'createdAt' in command &&
-    //   command?.createdAt != null &&
-    //   new Date(command?.createdAt) < new Date(firstPlayTimestamp)
-    // ))
     const remainingAnticipatedCommands = dropWhile(
       postSetupAnticipatedCommands,
       anticipatedCommand =>
@@ -121,7 +115,6 @@ export function CommandList(): JSX.Element | null {
       ? [...postPlayRunCommands, ...remainingAnticipatedCommands]
       : [...postPlayRunCommands]
   }
-  console.log(currentCommandList[0], postSetupAnticipatedCommands[0])
 
   if (protocolData == null || runStatus == null) return null
 

--- a/app/src/organisms/RunDetails/Fixture_commandSummary.json
+++ b/app/src/organisms/RunDetails/Fixture_commandSummary.json
@@ -74,7 +74,8 @@
           "commandType": "custom",
           "status": "anticipated"
         }
-      ]
+      ],
+      "actions": []
     }
   }
 }

--- a/app/src/organisms/RunDetails/__tests__/CommandList.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/CommandList.test.tsx
@@ -65,6 +65,7 @@ describe('CommandList', () => {
         // @ts-expect-error not a full match of RunData type
         data: {
           commands: [],
+          actions: [],
         },
       },
     })
@@ -105,7 +106,7 @@ describe('CommandList', () => {
       ).length
     ).toEqual(17)
   })
-  it('renders only the first step if the current run info is present and has not updated', () => {
+  it('renders only anticipated steps if the current run info is present and has not updated', () => {
     // @ts-expect-error not a full match of RunData type
     mockUseCurrentProtocolRun.mockReturnValue(fixtureCommandSummary)
     const { getAllByText } = render()
@@ -113,7 +114,7 @@ describe('CommandList', () => {
       getAllByText(
         'Picking up tip from A1 of Opentrons 96 Tip Rack 300 µL on 1'
       ).length
-    ).toEqual(1)
+    ).toEqual(17)
   })
   it('renders the protocol failed banner', () => {
     mockUseRunStatus.mockReturnValue('failed')


### PR DESCRIPTION
# Overview

Ensure that we are not mistaking commands that are issued by LPC before a run is started as commands
that should map to anticipated commands from the analysis

# Review requests

- [ ] Start a protocol after running the Labware Position Check. The commands list should maintain all of the expected commands

# Risk assessment
 low
