### PR TITLE
refactor(protocol-engine): Make minor comment and documentation fixups

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/load_module.py
+++ b/api/src/opentrons/protocol_engine/commands/load_module.py
@@ -17,11 +17,12 @@ class LoadModuleParams(BaseModel):
     model: ModuleModel = Field(
         ...,
         description=(
-            "The model name of the module to load."
+            "The exact model name of the module to load."
             "\n\n"
-            "If a different version of this module is physically connected,"
-            " the load will succeed"
-            " if it's deemed compatible with the version you requested."
+            "In the future,"
+            " this command may change so that the load will succeed"
+            " if the physically attached module is merely compatible"
+            " with the version you requested."
         ),
     )
 

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -222,7 +222,8 @@ class EquipmentHandler:
             raise ModuleNotAttachedError("Could not fetch modules attached") from e
 
         for mod in available:
-            # TODO (spp, 2021-11-22: make this accept compatible module models)
+            # TODO (spp, 2021-11-22): make this accept compatible module models
+            # and update LoadModule command docs accordingly
             if mod.model() == model.value:
                 if not self._state_store.modules.get_by_serial(
                     mod.device_info["serial"]

--- a/api/src/opentrons/protocol_runner/legacy_labware_offset_provider.py
+++ b/api/src/opentrons/protocol_runner/legacy_labware_offset_provider.py
@@ -1,7 +1,4 @@
 """Interfaces to provide ProtocolEngine labware offsets to PAPIv2 protocols."""
-# TODO(mc, 2021-11-23): this module is missing tests. They would have
-# informed the proper shape / dependency model for this unit, so this may
-# change as tests are added.
 
 from typing import Optional
 


### PR DESCRIPTION
# Changelog

* Remove an obsolete `# todo` about missing tests. This got resolved in commit 37e5226b33838a2813d3ead8142ed112f1def1e5 of PR #8910.
* Update the `loadModule` command description to describe how I *think* compatible loading currently works. I've sort of lost track, though, so I could be wrong. @sanni-t or @mcous, please confirm this.

   Assuming this is correct: I know this behavior is going to get changed soon anyway, but it's an easy update to fix the docstring here. And I'd rather not leave wrong docstrings hanging around, just in case we defer fixing this or decide to go with a different approach.