### PR TITLE
fix(app): show cancel run when paused

### DIFF
--- a/app/src/organisms/RunDetails/index.tsx
+++ b/app/src/organisms/RunDetails/index.tsx
@@ -4,6 +4,8 @@ import {
   RunStatus,
   RUN_STATUS_IDLE,
   RUN_STATUS_RUNNING,
+  RUN_STATUS_PAUSED,
+  RUN_STATUS_PAUSE_REQUESTED,
 } from '@opentrons/api-client'
 import {
   PrimaryBtn,
@@ -65,7 +67,9 @@ export function RunDetails(): JSX.Element | null {
   )
 
   const titleBarProps =
-    adjustedRunStatus === RUN_STATUS_RUNNING
+    adjustedRunStatus === RUN_STATUS_RUNNING ||
+    adjustedRunStatus === RUN_STATUS_PAUSED ||
+    adjustedRunStatus === RUN_STATUS_PAUSE_REQUESTED
       ? {
           title: t('protocol_title', { protocol_name: displayName }),
           rightNode: cancelRunButton,


### PR DESCRIPTION
# Overview

Shows the Cancel Run button when protocol status is `paused` or `pause-requested`

# Changelog

- Added to conditional

# Review requests

- Check it is showing the cancel run when paused

# Risk assessment

Low
