### PR TITLE
refactor(app): ensure robot hostname is properly set on per-robot pages

### DIFF
--- a/app/src/App/index.tsx
+++ b/app/src/App/index.tsx
@@ -38,7 +38,7 @@ export const AppComponent = (): JSX.Element => {
   const connectedRobot = useSelector((state: State) => getConnectedRobot(state))
 
   return (
-    <ApiHostProvider hostname={connectedRobot != null ? connectedRobot.ip : ''}>
+    <ApiHostProvider hostname={connectedRobot?.ip ?? null}>
       <GlobalStyle />
       <Flex
         position={POSITION_FIXED}

--- a/app/src/pages/Robots/index.tsx
+++ b/app/src/pages/Robots/index.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import { useSelector } from 'react-redux'
 import { useRouteMatch, Redirect, useLocation } from 'react-router-dom'
+import { ApiHostProvider } from '@opentrons/react-api-client'
 
 import {
   CONNECTABLE,
@@ -47,20 +48,24 @@ export function Robots(): JSX.Element {
     )
   }
 
-  return robot.status === CONNECTABLE && instrumentsMatch ? (
-    <InstrumentSettings
-      robotName={robot.name}
-      robotDisplayName={robot.displayName}
-      url={instrumentsMatch.url}
-      path={instrumentsMatch.path}
-      pathname={location && location.pathname}
-    />
-  ) : robot.status === CONNECTABLE && modulesMatch ? (
-    <ModuleSettings
-      robotName={robot.name}
-      robotDisplayName={robot.displayName}
-    />
-  ) : (
-    <RobotSettings robot={robot} />
+  return (
+    <ApiHostProvider hostname={robot.ip}>
+      {robot.status === CONNECTABLE && instrumentsMatch ? (
+        <InstrumentSettings
+          robotName={robot.name}
+          robotDisplayName={robot.displayName}
+          url={instrumentsMatch.url}
+          path={instrumentsMatch.path}
+          pathname={location && location.pathname}
+        />
+      ) : robot.status === CONNECTABLE && modulesMatch ? (
+        <ModuleSettings
+          robotName={robot.name}
+          robotDisplayName={robot.displayName}
+        />
+      ) : (
+        <RobotSettings robot={robot} />
+      )}
+    </ApiHostProvider>
   )
 }

--- a/react-api-client/src/api/ApiHostProvider.tsx
+++ b/react-api-client/src/api/ApiHostProvider.tsx
@@ -4,17 +4,17 @@ import { HostConfig } from '@opentrons/api-client'
 export const ApiHostContext = React.createContext<HostConfig | null>(null)
 
 export interface ApiHostProviderProps {
-  hostname: string
+  hostname: string | null
   port?: number | null
   children?: React.ReactNode
 }
 
 export function ApiHostProvider(props: ApiHostProviderProps): JSX.Element {
   const { hostname, port = null, children } = props
-  const hostConfig = React.useMemo<HostConfig>(() => ({ hostname, port }), [
-    hostname,
-    port,
-  ])
+  const hostConfig = React.useMemo<HostConfig | null>(
+    () => (hostname !== null ? { hostname, port } : null),
+    [hostname, port]
+  )
 
   return (
     <ApiHostContext.Provider value={hostConfig}>

--- a/react-api-client/src/api/__tests__/useHost.test.tsx
+++ b/react-api-client/src/api/__tests__/useHost.test.tsx
@@ -11,6 +11,15 @@ describe('ApiHostProvider and useHost', () => {
     expect(result.current).toBe(null)
   })
 
+  it('should allow a hostname to be unset', () => {
+    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+      <ApiHostProvider hostname={null}>{children}</ApiHostProvider>
+    )
+    const { result } = renderHook(useHost, { wrapper })
+
+    expect(result.current).toBe(null)
+  })
+
   it('should allow a hostname to be set', () => {
     const wrapper: React.FunctionComponent<{}> = ({ children }) => (
       <ApiHostProvider hostname="localhost">{children}</ApiHostProvider>


### PR DESCRIPTION
## Overview

After testing 5.0.0-beta.0, I noticed two little problems:

- The app hands a non-nullish value to `ApiHostProvider` if there is no "connected" robot
  - This causes react-api-client hooks to think there _is_ a host with IP address `""`
  - This results in invalid HTTP requests at app launch, which you can see in the console
- The host for react-api-client in the app is _always_ set to the connected robot
  - This means any query hooks on a per-robot page will hit the connected robot instead of the page's robot
  - I'm not sure these hooks are used there yet, but seems like something that will bite us in the future 

## Changelog

- Allow `ApiHostProvider` to take `null` hostname, meaning "no host"
  - This correctly sets the `useHost` return to null, disabling queries
- Add another `<ApiHostProvider>` at the per-robot-page level
  - Any hooks on that page will now hit the page's robot, instead
 
## Review requests

- [ ] No error in console due to invalid URL at app launch

## Risk assessment

Low
