### PR TITLE
feat(hardware): support two head axes

### DIFF
--- a/hardware/opentrons_hardware/drivers/can_bus/constants.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/constants.py
@@ -11,6 +11,8 @@ class NodeId(int, Enum):
     gantry_x = 0x30
     gantry_y = 0x40
     head = 0x50
+    head_l = 0x51
+    head_r = 0x52
 
 
 class FunctionCode(int, Enum):

--- a/hardware/opentrons_hardware/hardware_control/motion.py
+++ b/hardware/opentrons_hardware/hardware_control/motion.py
@@ -39,49 +39,20 @@ def create(
     """
     # Raise KeyError if axis is missing from origin
     deltas = {ax: target[ax] - origin[ax] for ax in target.keys()}
+    # head (as opposed to head_l and head_r) is not an acceptable target for motion
+    deltas.pop(NodeId.head, None)
 
     move_groups = []
-
-    # First move head
-    dza = deltas.get(NodeId.head, 0)
-    if dza:
+    for axis_node, axis_delta in deltas.items():
+        if not axis_delta:
+            continue
         move_groups.append(
             [
                 {
-                    NodeId.head: MoveGroupSingleAxisStep(
-                        distance_mm=dza,
-                        velocity_mm_sec=speed if dza > 0 else -speed,
-                        duration_sec=abs(dza) / speed,
-                    )
-                }
-            ]
-        )
-
-    # Move x
-    dx = deltas.get(NodeId.gantry_x, 0)
-    if dx:
-        move_groups.append(
-            [
-                {
-                    NodeId.gantry_x: MoveGroupSingleAxisStep(
-                        distance_mm=dx,
-                        velocity_mm_sec=speed if dx > 0 else -speed,
-                        duration_sec=abs(dx) / speed,
-                    )
-                }
-            ]
-        )
-
-    # Move y
-    dy = deltas.get(NodeId.gantry_y, 0)
-    if dy:
-        move_groups.append(
-            [
-                {
-                    NodeId.gantry_y: MoveGroupSingleAxisStep(
-                        distance_mm=dy,
-                        velocity_mm_sec=speed if dy > 0 else -speed,
-                        duration_sec=abs(dy) / speed,
+                    axis_node: MoveGroupSingleAxisStep(
+                        distance_mm=axis_delta,
+                        velocity_mm_sec=speed if axis_delta > 0 else -speed,
+                        duration_sec=abs(axis_delta) / speed,
                     )
                 }
             ]

--- a/hardware/tests/opentrons_hardware/hardware_control/test_motion.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_motion.py
@@ -8,7 +8,7 @@ def test_create_just_head() -> None:
     expected = [
         [
             {
-                NodeId.head: MoveGroupSingleAxisStep(
+                NodeId.head_l: MoveGroupSingleAxisStep(
                     distance_mm=-2, velocity_mm_sec=-0.25, duration_sec=8
                 ),
             }
@@ -16,8 +16,8 @@ def test_create_just_head() -> None:
     ]
     assert (
         create(
-            origin={NodeId.head: 4},
-            target={NodeId.head: 2},
+            origin={NodeId.head_l: 4},
+            target={NodeId.head_l: 2},
             speed=0.25,
         )
         == expected
@@ -57,7 +57,7 @@ def test_create_all() -> None:
     expected = [
         [
             {
-                NodeId.head: MoveGroupSingleAxisStep(
+                NodeId.head_l: MoveGroupSingleAxisStep(
                     distance_mm=4, velocity_mm_sec=0.05, duration_sec=80
                 ),
             }
@@ -79,8 +79,8 @@ def test_create_all() -> None:
     ]
     assert (
         create(
-            origin={NodeId.head: 0, NodeId.gantry_x: 0, NodeId.gantry_y: 0},
-            target={NodeId.head: 4, NodeId.gantry_x: 2, NodeId.gantry_y: 2},
+            origin={NodeId.head_l: 0, NodeId.gantry_x: 0, NodeId.gantry_y: 0},
+            target={NodeId.head_l: 4, NodeId.gantry_x: 2, NodeId.gantry_y: 2},
             speed=0.05,
         )
         == expected


### PR DESCRIPTION
Add the head_l and head_r nodeids; refactor the move group creator to
iterate over provided axes rather than naming them explicitly and
therefore be able to handle the new node ids.
