### PR TITLE
feat(shared-data): add home command to v6 protocol schema

### DIFF
--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -407,11 +407,6 @@ export interface ProtocolResource {
   files: ResourceFile[]
 }
 
-export interface MotorAxis {
-  X: 'x'
-  Y: 'y'
-  LEFT_Z: 'leftZ'
-  RIGHT_Z: 'rightZ'
-  LEFT_PLUNGER: 'leftPlunger'
-  RIGHT_PLUNGER: 'rightPlunger'
-}
+export type MotorAxis = Array<
+  'x' | 'y' | 'leftZ' | 'rightZ' | 'leftPlunger' | 'rightPlunger'
+>

--- a/shared-data/protocol/fixtures/6/simpleV6.json
+++ b/shared-data/protocol/fixtures/6/simpleV6.json
@@ -1240,6 +1240,18 @@
   },
   "commands": [
     {
+      "commandType": "home",
+      "id": "00abc123",
+      "params": {}
+    },
+    {
+      "commandType": "home",
+      "id": "00abc123",
+      "params": {
+        "axes": ["x", "y", "leftZ", "rightZ", "leftPlunger", "rightPlunger"]
+      }
+    },
+    {
       "commandType": "loadPipette",
       "id": "0abc123",
       "params": {

--- a/shared-data/protocol/schemas/6.json
+++ b/shared-data/protocol/schemas/6.json
@@ -480,6 +480,35 @@
           },
 
           {
+            "description": "Home",
+            "type": "object",
+            "required": ["id", "commandType", "params"],
+            "properties": {
+              "id": { "type": "string" },
+              "commandType": { "enum": ["home"] },
+              "params": {
+                "type": "object",
+                "properties": {
+                  "axes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "x",
+                        "y",
+                        "leftZ",
+                        "rightZ",
+                        "leftPlunger",
+                        "rightPlunger"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+
+          {
             "description": "Delay Protocol Execution",
             "type": "object",
             "required": ["id", "commandType", "params"],


### PR DESCRIPTION
# Overview

This PR adds a `home` command to the v6 json protocol schema (and fixes the TS types that were slightly wrong)

closes #8892

# Changelog
- Add home command to v6 protocol schema

# Risk assessment
Low
