### PR TITLE
refactor(app): remove intercom chat launcher from the app

### DIFF
--- a/app/src/redux/support/__tests__/intercom-binding.test.ts
+++ b/app/src/redux/support/__tests__/intercom-binding.test.ts
@@ -79,6 +79,7 @@ describe('calling the intercom js api', () => {
     expect(intercom).toHaveBeenCalledWith('boot', {
       user_id: 'dummy-user',
       some: 'prop',
+      hide_default_launcher: true,
     })
   })
 
@@ -92,6 +93,7 @@ describe('calling the intercom js api', () => {
       some: 'value',
       other: 'value',
       user_id: 'dummy',
+      hide_default_launcher: true,
     })
   })
 
@@ -101,6 +103,7 @@ describe('calling the intercom js api', () => {
       some: 'value',
       other: 'value',
       user_id: 'dummy',
+      hide_default_launcher: true,
     })
   })
 

--- a/app/src/redux/support/intercom-binding.ts
+++ b/app/src/redux/support/intercom-binding.ts
@@ -24,6 +24,7 @@ export const bootIntercom = (props: IntercomPayload): void => {
     const iprops = {
       ...props,
       user_id: userId,
+      hide_default_launcher: true,
     }
     log.debug('Booting intercom', props)
     global.Intercom(Constants.INTERCOM_BOOT, iprops)
@@ -35,6 +36,7 @@ export const updateIntercomProfile = (props: IntercomPayload): void => {
     const iprops = {
       ...props,
       user_id: userId,
+      hide_default_launcher: true,
     }
     log.debug('Updating intercom profile', props)
     global.Intercom(Constants.INTERCOM_UPDATE, iprops)


### PR DESCRIPTION
# Overview

Ahead of a switch to another support chat service, remove the intercom chat launcher from the app

Closes #8768 

# Changelog

- disable the app's intercom chat launcher

# Review requests

- [ ] download the most recent app build of this branch. Regardless of your privacy settings, you should never see the intercom support chat icon at the bottom right corner of the app window

# Risk assessment

low