### PR TITLE
feat(app): add Labware Offset Link in LPC

### DIFF
--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/LabwareOffsetModal.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/LabwareOffsetModal.tsx
@@ -27,7 +27,7 @@ import styles from '../../styles.css'
 
 const ROBOT_CAL_HELP_ARTICLE =
   'https://support.opentrons.com/en/articles/3499692-how-positional-calibration-works-on-the-ot-2'
-const OFFSET_DATA_HELP_ARTICLE = 
+const OFFSET_DATA_HELP_ARTICLE =
   'http://support.opentrons.com/en/articles/5742955-how-labware-offsets-work-on-the-ot-2'
 interface LabwareOffsetModalProps {
   onCloseClick: () => unknown

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/LabwareOffsetModal.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/LabwareOffsetModal.tsx
@@ -27,8 +27,8 @@ import styles from '../../styles.css'
 
 const ROBOT_CAL_HELP_ARTICLE =
   'https://support.opentrons.com/en/articles/3499692-how-positional-calibration-works-on-the-ot-2'
-
-const OFFSET_DATA_HELP_ARTICLE = '#' //  TODO IMMEDIATELY: REPLACE WITH ACTUAL LINK
+const OFFSET_DATA_HELP_ARTICLE = 
+  'http://support.opentrons.com/en/articles/5742955-how-labware-offsets-work-on-the-ot-2'
 interface LabwareOffsetModalProps {
   onCloseClick: () => unknown
 }

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareOffsetModal.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareOffsetModal.test.tsx
@@ -64,7 +64,9 @@ describe('LabwareOffsetModal', () => {
       getByRole('link', {
         name: 'Learn more about Labware Offset Data',
       }).getAttribute('href')
-    ).toBe('#') // replace when we have an actual link
+    ).toBe(
+      'http://support.opentrons.com/en/articles/5742955-how-labware-offsets-work-on-the-ot-2'
+    )
   })
   it('should call onCloseClick when the close button is pressed', () => {
     const { getByRole } = render(props)


### PR DESCRIPTION
closes #8963

# Overview

This PR adds the missing Labware Offset link in the `LabwareOffsetModal`

# Changelog

- added missing link

# Review requests

- make sure link opens in a new browser. The link isn't created yet.

# Risk assessment

low, behind ff