### PR TITLE
refactor(app): add grey background to LPC CTA in labware setup

### DIFF
--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
@@ -26,6 +26,7 @@ import {
   DIRECTION_ROW,
   Box,
   FONT_WEIGHT_SEMIBOLD,
+  C_NEAR_WHITE,
 } from '@opentrons/components'
 import {
   inferModuleOrientationFromXCoordinate,
@@ -160,7 +161,7 @@ export const LabwareSetup = (): JSX.Element | null => {
             )
           }}
         </RobotWorkSpace>
-        <Flex flexDirection={DIRECTION_ROW}>
+        <Flex flexDirection={DIRECTION_ROW} backgroundColor={C_NEAR_WHITE}>
           <Box flexDirection={DIRECTION_COLUMN} width="65%">
             <Text
               color={C_DARK_GRAY}

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
@@ -27,6 +27,7 @@ import {
   Box,
   FONT_WEIGHT_SEMIBOLD,
   C_NEAR_WHITE,
+  SPACING_1,
 } from '@opentrons/components'
 import {
   inferModuleOrientationFromXCoordinate,
@@ -167,6 +168,7 @@ export const LabwareSetup = (): JSX.Element | null => {
               color={C_DARK_GRAY}
               fontWeight={FONT_WEIGHT_SEMIBOLD}
               marginLeft={SPACING_3}
+              marginTop={SPACING_3}
             >
               {t('lpc_and_offset_data_title')}
             </Text>
@@ -182,6 +184,7 @@ export const LabwareSetup = (): JSX.Element | null => {
               alignSelf={ALIGN_FLEX_END}
               onClick={() => setShowLabwareHelpModal(true)}
               data-test={'LabwareSetup_helpLink'}
+              marginTop={SPACING_3}
               marginBottom={SPACING_3}
             >
               {t('labware_help_link_title')}

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
@@ -27,7 +27,6 @@ import {
   Box,
   FONT_WEIGHT_SEMIBOLD,
   C_NEAR_WHITE,
-  SPACING_1,
 } from '@opentrons/components'
 import {
   inferModuleOrientationFromXCoordinate,


### PR DESCRIPTION
closes #8957

# Overview

This PR adds a grey background behind LPC CTA section on the bottom of Labware Setup Accordion

# Changelog

- add grey background behind LPC CTA section: 
<img width="929" alt="Screen Shot 2021-12-02 at 13 08 37" src="https://user-images.githubusercontent.com/66035149/144478856-0921d2e3-1672-425d-b331-12e2c47e3dc6.png">

# Review requests

- review and compare to [figma](https://www.figma.com/file/JCQNOTTK9tTmYPhRqeOfSj/Milestone-0%3A-Protocol-Upload-Revamp?node-id=3205%3A2194)

# Risk assessment

low, behind ff
