### PR TITLE
chore(python): upgrade decoy dev dep to 1.8.0

### DIFF
--- a/api/Pipfile
+++ b/api/Pipfile
@@ -26,7 +26,7 @@ flake8 = "~=3.9.0"
 flake8-annotations = "~=2.6.2"
 flake8-docstrings = "~=1.6.0"
 flake8-noqa = "~=1.1.0"
-decoy = "~=1.6.7"
+decoy = "~=1.8.0"
 black = "==21.7b0"
 # pytest dependencies on windows, spec'd here to force lockfile inclusion
 # https://github.com/pypa/pipenv/issues/4408#issuecomment-668324177

--- a/api/Pipfile.lock
+++ b/api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "aa36b16cef152fa459791cd1586a21427c205be372ade16c2b6cb25f781c18d1"
+            "sha256": "28ec424561a1caf7066f38ba9f577362e5676422a24b1e5ab4b7c3a656d80ec2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -239,11 +239,11 @@
         },
         "decoy": {
             "hashes": [
-                "sha256:9247f7a2f38df480971da73bff852d558ef8127d62bc03057d9aa8fc58b93408",
-                "sha256:fc561328d982d46ddd2df9ec6faf6babfe4f4240b57037ec38f522809f102364"
+                "sha256:00ab91aff1b26eb356d8768321b1c5404b4a481c94f77254ae4cbde5d7e2d8d4",
+                "sha256:5ba9e8f986ed7878afdf01eb5f8d6e3367104bf0bde4c34be881d500ea248b83"
             ],
             "index": "pypi",
-            "version": "==1.6.7"
+            "version": "==1.8.0"
         },
         "docutils": {
             "hashes": [
@@ -1150,7 +1150,7 @@
                 "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
                 "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.26.7"
         },
         "webencodings": {

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -121,7 +121,7 @@ def test_map_after_with_error_command() -> None:
         command_id="command.PAUSE-0",
         error_id=matchers.IsA(str),
         failed_at=matchers.IsA(datetime),
-        error=matchers.ErrorMatching(  # type: ignore[arg-type]
+        error=matchers.ErrorMatching(
             LegacyContextCommandError,
             match="oh no",
         ),

--- a/g-code-testing/Pipfile
+++ b/g-code-testing/Pipfile
@@ -29,7 +29,7 @@ flake8-annotations = "~=2.6.2"
 flake8-docstrings = "~=1.6.0"
 flake8-noqa = "~=1.1.0"
 black = "==21.7b0"
-decoy = "~=1.6.7"
+decoy = "~=1.8.0"
 
 [requires]
 python_version = "3.7"

--- a/g-code-testing/Pipfile.lock
+++ b/g-code-testing/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4812cbfa65dab70bb0f86842eba2c2e1abfd5cdee09e3b51593db600f7f06c46"
+            "sha256": "4e0968fbbcd4ea9f8fb1ab3eb204c47c91168f8fa2476cd4968e87ab269fa014"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -370,6 +370,14 @@
             "markers": "python_version >= '3.6'",
             "version": "==3.7.4.post0"
         },
+        "aiosignal": {
+            "hashes": [
+                "sha256:26e62109036cd181df6e6ad646f91f0dcfd05fe16d0cb924138ff2ab75d64e3a",
+                "sha256:78ed67db6c7b7ced4f98e495e572106d5c432a93e1ddd1bf475e1dc05f5b7df2"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.2.0"
+        },
         "appdirs": {
             "hashes": [
                 "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41",
@@ -384,6 +392,14 @@
             ],
             "markers": "python_full_version >= '3.5.3'",
             "version": "==3.0.1"
+        },
+        "asynctest": {
+            "hashes": [
+                "sha256:5da6118a7e6d6b54d83a8f7197769d046922a44d2a99c21382f0a6e4fadae676",
+                "sha256:c27862842d15d83e6a34eb0b2866c323880eb3a75e4485b079ea11748fd77fac"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==0.13.0"
         },
         "attrs": {
             "hashes": [
@@ -424,6 +440,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==4.0.0"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:735e240d9a8506778cd7a453d97e817e536bb1fc29f4f6961ce297b9c7a917b0",
+                "sha256:83fcdeb225499d6344c8f7f34684c2981270beacc32ede2e669e94f7fa544405"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==2.0.8"
         },
         "click": {
             "hashes": [
@@ -488,16 +512,16 @@
                 "sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d",
                 "sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_full_version < '4.0.0'",
             "version": "==5.5"
         },
         "decoy": {
             "hashes": [
-                "sha256:9247f7a2f38df480971da73bff852d558ef8127d62bc03057d9aa8fc58b93408",
-                "sha256:fc561328d982d46ddd2df9ec6faf6babfe4f4240b57037ec38f522809f102364"
+                "sha256:00ab91aff1b26eb356d8768321b1c5404b4a481c94f77254ae4cbde5d7e2d8d4",
+                "sha256:5ba9e8f986ed7878afdf01eb5f8d6e3367104bf0bde4c34be881d500ea248b83"
             ],
             "index": "pypi",
-            "version": "==1.6.7"
+            "version": "==1.8.0"
         },
         "diff-match-patch": {
             "hashes": [
@@ -545,6 +569,84 @@
             ],
             "index": "pypi",
             "version": "==1.1.0"
+        },
+        "frozenlist": {
+            "hashes": [
+                "sha256:01d79515ed5aa3d699b05f6bdcf1fe9087d61d6b53882aa599a10853f0479c6c",
+                "sha256:0a7c7cce70e41bc13d7d50f0e5dd175f14a4f1837a8549b0936ed0cbe6170bf9",
+                "sha256:11ff401951b5ac8c0701a804f503d72c048173208490c54ebb8d7bb7c07a6d00",
+                "sha256:14a5cef795ae3e28fb504b73e797c1800e9249f950e1c964bb6bdc8d77871161",
+                "sha256:16eef427c51cb1203a7c0ab59d1b8abccaba9a4f58c4bfca6ed278fc896dc193",
+                "sha256:16ef7dd5b7d17495404a2e7a49bac1bc13d6d20c16d11f4133c757dd94c4144c",
+                "sha256:181754275d5d32487431a0a29add4f897968b7157204bc1eaaf0a0ce80c5ba7d",
+                "sha256:1cf63243bc5f5c19762943b0aa9e0d3fb3723d0c514d820a18a9b9a5ef864315",
+                "sha256:1cfe6fef507f8bac40f009c85c7eddfed88c1c0d38c75e72fe10476cef94e10f",
+                "sha256:1fef737fd1388f9b93bba8808c5f63058113c10f4e3c0763ced68431773f72f9",
+                "sha256:25b358aaa7dba5891b05968dd539f5856d69f522b6de0bf34e61f133e077c1a4",
+                "sha256:26f602e380a5132880fa245c92030abb0fc6ff34e0c5500600366cedc6adb06a",
+                "sha256:28e164722ea0df0cf6d48c4d5bdf3d19e87aaa6dfb39b0ba91153f224b912020",
+                "sha256:2de5b931701257d50771a032bba4e448ff958076380b049fd36ed8738fdb375b",
+                "sha256:3457f8cf86deb6ce1ba67e120f1b0128fcba1332a180722756597253c465fc1d",
+                "sha256:351686ca020d1bcd238596b1fa5c8efcbc21bffda9d0efe237aaa60348421e2a",
+                "sha256:406aeb340613b4b559db78d86864485f68919b7141dec82aba24d1477fd2976f",
+                "sha256:41de4db9b9501679cf7cddc16d07ac0f10ef7eb58c525a1c8cbff43022bddca4",
+                "sha256:41f62468af1bd4e4b42b5508a3fe8cc46a693f0cdd0ca2f443f51f207893d837",
+                "sha256:4766632cd8a68e4f10f156a12c9acd7b1609941525569dd3636d859d79279ed3",
+                "sha256:47b2848e464883d0bbdcd9493c67443e5e695a84694efff0476f9059b4cb6257",
+                "sha256:4a495c3d513573b0b3f935bfa887a85d9ae09f0627cf47cad17d0cc9b9ba5c38",
+                "sha256:4ad065b2ebd09f32511ff2be35c5dfafee6192978b5a1e9d279a5c6e121e3b03",
+                "sha256:4c457220468d734e3077580a3642b7f682f5fd9507f17ddf1029452450912cdc",
+                "sha256:4f52d0732e56906f8ddea4bd856192984650282424049c956857fed43697ea43",
+                "sha256:54a1e09ab7a69f843cd28fefd2bcaf23edb9e3a8d7680032c8968b8ac934587d",
+                "sha256:5a72eecf37eface331636951249d878750db84034927c997d47f7f78a573b72b",
+                "sha256:5df31bb2b974f379d230a25943d9bf0d3bc666b4b0807394b131a28fca2b0e5f",
+                "sha256:66a518731a21a55b7d3e087b430f1956a36793acc15912e2878431c7aec54210",
+                "sha256:6790b8d96bbb74b7a6f4594b6f131bd23056c25f2aa5d816bd177d95245a30e3",
+                "sha256:68201be60ac56aff972dc18085800b6ee07973c49103a8aba669dee3d71079de",
+                "sha256:6e105013fa84623c057a4381dc8ea0361f4d682c11f3816cc80f49a1f3bc17c6",
+                "sha256:705c184b77565955a99dc360f359e8249580c6b7eaa4dc0227caa861ef46b27a",
+                "sha256:72cfbeab7a920ea9e74b19aa0afe3b4ad9c89471e3badc985d08756efa9b813b",
+                "sha256:735f386ec522e384f511614c01d2ef9cf799f051353876b4c6fb93ef67a6d1ee",
+                "sha256:82d22f6e6f2916e837c91c860140ef9947e31194c82aaeda843d6551cec92f19",
+                "sha256:83334e84a290a158c0c4cc4d22e8c7cfe0bba5b76d37f1c2509dabd22acafe15",
+                "sha256:84e97f59211b5b9083a2e7a45abf91cfb441369e8bb6d1f5287382c1c526def3",
+                "sha256:87521e32e18a2223311afc2492ef2d99946337da0779ddcda77b82ee7319df59",
+                "sha256:878ebe074839d649a1cdb03a61077d05760624f36d196884a5cafb12290e187b",
+                "sha256:89fdfc84c6bf0bff2ff3170bb34ecba8a6911b260d318d377171429c4be18c73",
+                "sha256:8b4c7665a17c3a5430edb663e4ad4e1ad457614d1b2f2b7f87052e2ef4fa45ca",
+                "sha256:8b54cdd2fda15467b9b0bfa78cee2ddf6dbb4585ef23a16e14926f4b076dfae4",
+                "sha256:94728f97ddf603d23c8c3dd5cae2644fa12d33116e69f49b1644a71bb77b89ae",
+                "sha256:954b154a4533ef28bd3e83ffdf4eadf39deeda9e38fb8feaf066d6069885e034",
+                "sha256:977a1438d0e0d96573fd679d291a1542097ea9f4918a8b6494b06610dfeefbf9",
+                "sha256:9ade70aea559ca98f4b1b1e5650c45678052e76a8ab2f76d90f2ac64180215a2",
+                "sha256:9b6e21e5770df2dea06cb7b6323fbc008b13c4a4e3b52cb54685276479ee7676",
+                "sha256:a0d3ffa8772464441b52489b985d46001e2853a3b082c655ec5fad9fb6a3d618",
+                "sha256:a37594ad6356e50073fe4f60aa4187b97d15329f2138124d252a5a19c8553ea4",
+                "sha256:a8d86547a5e98d9edd47c432f7a14b0c5592624b496ae9880fb6332f34af1edc",
+                "sha256:aa44c4740b4e23fcfa259e9dd52315d2b1770064cde9507457e4c4a65a04c397",
+                "sha256:acc4614e8d1feb9f46dd829a8e771b8f5c4b1051365d02efb27a3229048ade8a",
+                "sha256:af2a51c8a381d76eabb76f228f565ed4c3701441ecec101dd18be70ebd483cfd",
+                "sha256:b2ae2f5e9fa10805fb1c9adbfefaaecedd9e31849434be462c3960a0139ed729",
+                "sha256:b46f997d5ed6d222a863b02cdc9c299101ee27974d9bbb2fd1b3c8441311c408",
+                "sha256:bc93f5f62df3bdc1f677066327fc81f92b83644852a31c6aa9b32c2dde86ea7d",
+                "sha256:bfbaa08cf1452acad9cb1c1d7b89394a41e712f88df522cea1a0f296b57782a0",
+                "sha256:c1e8e9033d34c2c9e186e58279879d78c94dd365068a3607af33f2bc99357a53",
+                "sha256:c5328ed53fdb0a73c8a50105306a3bc013e5ca36cca714ec4f7bd31d38d8a97f",
+                "sha256:c6a9d84ee6427b65a81fc24e6ef589cb794009f5ca4150151251c062773e7ed2",
+                "sha256:c98d3c04701773ad60d9545cd96df94d955329efc7743fdb96422c4b669c633b",
+                "sha256:cb3957c39668d10e2b486acc85f94153520a23263b6401e8f59422ef65b9520d",
+                "sha256:e63ad0beef6ece06475d29f47d1f2f29727805376e09850ebf64f90777962792",
+                "sha256:e74f8b4d8677ebb4015ac01fcaf05f34e8a1f22775db1f304f497f2f88fdc697",
+                "sha256:e7d0dd3e727c70c2680f5f09a0775525229809f1a35d8552b92ff10b2b14f2c2",
+                "sha256:ec6cf345771cdb00791d271af9a0a6fbfc2b6dd44cb753f1eeaa256e21622adb",
+                "sha256:ed58803563a8c87cf4c0771366cf0ad1aa265b6b0ae54cbbb53013480c7ad74d",
+                "sha256:f0081a623c886197ff8de9e635528fd7e6a387dccef432149e25c13946cb0cd0",
+                "sha256:f025f1d6825725b09c0038775acab9ae94264453a696cc797ce20c0769a7b367",
+                "sha256:f5f3b2942c3b8b9bfe76b408bbaba3d3bb305ee3693e8b1d631fe0a0d4f93673",
+                "sha256:fbd4844ff111449f3bbe20ba24fbb906b5b1c2384d0f3287c9f7da2354ce6d23"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.2.0"
         },
         "idna": {
             "hashes": [
@@ -916,7 +1018,7 @@
                 "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4",
                 "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_full_version < '4.0.0'",
             "version": "==1.26.6"
         },
         "yarl": {

--- a/robot-server/Pipfile
+++ b/robot-server/Pipfile
@@ -21,7 +21,7 @@ flake8 = "~=3.9.0"
 flake8-annotations = "~=2.6.2"
 flake8-docstrings = "~=1.6.0"
 flake8-noqa = "~=1.1.0"
-decoy = "~=1.6.7"
+decoy = "~=1.8.0"
 httpx = "==0.18.*"
 black = "==21.7b0"
 # pytest dependencies on windows, spec'd here to force lockfile inclusion

--- a/robot-server/Pipfile.lock
+++ b/robot-server/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8418ceb4563439fe0a3a54b19ed63e61bc7ab9a3a277209a24141b2c28a40a83"
+            "sha256": "b9f8de14b5aec8db006e3970566b8b4c68b0d3ae3727eabdce966d40bd840c57"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -591,11 +591,11 @@
         },
         "decoy": {
             "hashes": [
-                "sha256:9247f7a2f38df480971da73bff852d558ef8127d62bc03057d9aa8fc58b93408",
-                "sha256:fc561328d982d46ddd2df9ec6faf6babfe4f4240b57037ec38f522809f102364"
+                "sha256:00ab91aff1b26eb356d8768321b1c5404b4a481c94f77254ae4cbde5d7e2d8d4",
+                "sha256:5ba9e8f986ed7878afdf01eb5f8d6e3367104bf0bde4c34be881d500ea248b83"
             ],
             "index": "pypi",
-            "version": "==1.6.7"
+            "version": "==1.8.0"
         },
         "docopt": {
             "hashes": [


### PR DESCRIPTION
## Overview

This PR upgrades Decoy to v1.8.0 for the following changes:


### Bug Fixes

* **matchers:** use isinstance() for matchers.IsA rather than type() ([#88](https://github.com/mcous/decoy/issues/88)) ([be6c780](https://github.com/mcous/decoy/commit/be6c780))
* fix name argument type anotation in Decoy.mock ([1a59098](https://github.com/mcous/decoy/commit/1a59098))
* **matchers:** ensure ErrorMatching return type matches spec ([#86](https://github.com/mcous/decoy/issues/86)) ([c60af56](https://github.com/mcous/decoy/commit/c60af56))
* **verify:** improve verify traceback and error messages ([#66](https://github.com/mcous/decoy/issues/66)) ([9e74b36](https://github.com/mcous/decoy/commit/9e74b36))

### Features

* allow spec-less mocks to be named ([#85](https://github.com/mcous/decoy/issues/85)) ([dbc4813](https://github.com/mcous/decoy/commit/dbc4813)), closes [#79](https://github.com/mcous/decoy/issues/79)
* match args leniently according to spec signature ([#89](https://github.com/mcous/decoy/issues/89)) ([fbbe941](https://github.com/mcous/decoy/commit/fbbe941)), closes [#78](https://github.com/mcous/decoy/issues/78)
* allow extra arguments to be ignored ([#61](https://github.com/mcous/decoy/issues/61)) ([d1ba0d3](https://github.com/mcous/decoy/commit/d1ba0d3)), closes [#60](https://github.com/mcous/decoy/issues/60)


## Changelog

- chore(python): upgrade decoy dev dep to 1.8.0

## Review requests

- [ ] Tests and lints pass locally as well as in CI

## Risk assessment

Low, dev dep for Python unit tests
