### PR TITLE
fix(app): show protocol setup loading state after protocol record creation

### DIFF
--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/LabwareOffsetModal.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/LabwareOffsetModal.tsx
@@ -27,8 +27,8 @@ import styles from '../../styles.css'
 
 const ROBOT_CAL_HELP_ARTICLE =
   'https://support.opentrons.com/en/articles/3499692-how-positional-calibration-works-on-the-ot-2'
-
-const OFFSET_DATA_HELP_ARTICLE = '#' //  TODO IMMEDIATELY: REPLACE WITH ACTUAL LINK
+const OFFSET_DATA_HELP_ARTICLE =
+  'http://support.opentrons.com/en/articles/5742955-how-labware-offsets-work-on-the-ot-2'
 interface LabwareOffsetModalProps {
   onCloseClick: () => unknown
 }

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareOffsetModal.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareOffsetModal.test.tsx
@@ -64,7 +64,9 @@ describe('LabwareOffsetModal', () => {
       getByRole('link', {
         name: 'Learn more about Labware Offset Data',
       }).getAttribute('href')
-    ).toBe('#') // replace when we have an actual link
+    ).toBe(
+      'http://support.opentrons.com/en/articles/5742955-how-labware-offsets-work-on-the-ot-2'
+    )
   })
   it('should call onCloseClick when the close button is pressed', () => {
     const { getByRole } = render(props)

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/index.tsx
@@ -144,7 +144,7 @@ export function RunSetupCard(): JSX.Element | null {
       >
         {t('setup_for_run')}
       </Text>
-      {protocolData != null ? (
+      {protocolData == null ? (
         <RunSetupLoader />
       ) : (
         <>

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/index.tsx
@@ -65,15 +65,6 @@ export function RunSetupCard(): JSX.Element | null {
     LABWARE_SETUP_KEY,
   ])
 
-  const [isLoading, setIsLoading] = React.useState<Boolean>(true)
-
-  // Set loader to false once protocolData contains data and is not null
-  React.useEffect(() => {
-    if (protocolData != null) {
-      setIsLoading(false)
-    }
-  }, [protocolData])
-
   React.useEffect(() => {
     if (protocolData != null && protocolHasModules(protocolData)) {
       setStepKeysInOrder([
@@ -96,7 +87,7 @@ export function RunSetupCard(): JSX.Element | null {
     return () => clearTimeout(initialExpandTimer)
   }, [Boolean(protocolData), protocolData?.commands])
 
-  if (protocolData == null || robot == null) return null
+  if (robot == null) return null
 
   const StepDetailMap: Record<
     StepKey,
@@ -128,7 +119,7 @@ export function RunSetupCard(): JSX.Element | null {
       ),
       description: t(`${MODULE_SETUP_KEY}_description`, {
         count:
-          'modules' in protocolData
+          protocolData != null && 'modules' in protocolData
             ? Object.keys(protocolData.modules).length
             : 0,
       }),
@@ -153,7 +144,7 @@ export function RunSetupCard(): JSX.Element | null {
       >
         {t('setup_for_run')}
       </Text>
-      {isLoading ? (
+      {protocolData != null ? (
         <RunSetupLoader />
       ) : (
         <>


### PR DESCRIPTION
# Overview

In order to give more immediate user feed back, this ensures that the run set up card section of the protocol setup page renders a spinner if the protocol record or run record are not fully resolved yet. This is especially helpful for longer protocols that might take a while to analyze.

# Changelog

- Render the `RunSetupCard` 's loading spinner in the case that protocol analysis data had not fully resolved.

# Review requests

- [ ] Upload a protocol, you should see the `MetadataCard` load very quickly as the `RunSetupCard` should have a loading spinner until the analysis is complete. 

# Risk assessment
 low
