### PR TITLE
fix(app): show empty protocol upload page if current run is being dimissed

### DIFF
--- a/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
+++ b/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
@@ -94,7 +94,10 @@ describe('ProtocolUpload', () => {
       .mockReturnValue({} as any)
     when(mockUseCloseProtocolRun)
       .calledWith()
-      .mockReturnValue({closeCurrentRun: jest.fn(), isClosingCurrentRun: false})
+      .mockReturnValue({
+        closeCurrentRun: jest.fn(),
+        isClosingCurrentRun: false,
+      })
   })
 
   afterEach(() => {
@@ -155,7 +158,10 @@ describe('ProtocolUpload', () => {
     const mockCloseCurrentRun = jest.fn()
     when(mockUseCloseProtocolRun)
       .calledWith()
-      .mockReturnValue({closeCurrentRun: mockCloseCurrentRun, isClosingCurrentRun: false})
+      .mockReturnValue({
+        closeCurrentRun: mockCloseCurrentRun,
+        isClosingCurrentRun: false,
+      })
 
     const [{ getByRole, getByText }, store] = render()
     fireEvent.click(getByRole('button', { name: 'close' }))
@@ -192,7 +198,10 @@ describe('ProtocolUpload', () => {
     const mockCloseCurrentRun = jest.fn()
     when(mockUseCloseProtocolRun)
       .calledWith()
-      .mockReturnValue({closeCurrentRun: mockCloseCurrentRun, isClosingCurrentRun: true})
+      .mockReturnValue({
+        closeCurrentRun: mockCloseCurrentRun,
+        isClosingCurrentRun: true,
+      })
 
     const [{ getByText }] = render()
     getByText('Open a protocol to run on robotName')

--- a/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
+++ b/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
@@ -92,12 +92,10 @@ describe('ProtocolUpload', () => {
     when(mockUseProtocolDetails)
       .calledWith()
       .mockReturnValue({} as any)
-    when(mockUseCloseProtocolRun)
-      .calledWith()
-      .mockReturnValue({
-        closeCurrentRun: jest.fn(),
-        isClosingCurrentRun: false,
-      })
+    when(mockUseCloseProtocolRun).calledWith().mockReturnValue({
+      closeCurrentRun: jest.fn(),
+      isClosingCurrentRun: false,
+    })
   })
 
   afterEach(() => {
@@ -156,12 +154,10 @@ describe('ProtocolUpload', () => {
         createProtocolRun: jest.fn(),
       } as any)
     const mockCloseCurrentRun = jest.fn()
-    when(mockUseCloseProtocolRun)
-      .calledWith()
-      .mockReturnValue({
-        closeCurrentRun: mockCloseCurrentRun,
-        isClosingCurrentRun: false,
-      })
+    when(mockUseCloseProtocolRun).calledWith().mockReturnValue({
+      closeCurrentRun: mockCloseCurrentRun,
+      isClosingCurrentRun: false,
+    })
 
     const [{ getByRole, getByText }, store] = render()
     fireEvent.click(getByRole('button', { name: 'close' }))
@@ -196,12 +192,10 @@ describe('ProtocolUpload', () => {
         createProtocolRun: jest.fn(),
       } as any)
     const mockCloseCurrentRun = jest.fn()
-    when(mockUseCloseProtocolRun)
-      .calledWith()
-      .mockReturnValue({
-        closeCurrentRun: mockCloseCurrentRun,
-        isClosingCurrentRun: true,
-      })
+    when(mockUseCloseProtocolRun).calledWith().mockReturnValue({
+      closeCurrentRun: mockCloseCurrentRun,
+      isClosingCurrentRun: true,
+    })
 
     const [{ getByText }] = render()
     getByText('Open a protocol to run on robotName')

--- a/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
+++ b/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
@@ -149,10 +149,10 @@ describe('ProtocolUpload', () => {
         runRecord: {},
         createProtocolRun: jest.fn(),
       } as any)
-    const mockCloseProtocolRun = jest.fn()
+    const mockCloseCurrentRun = jest.fn()
     when(mockUseCloseProtocolRun)
       .calledWith()
-      .mockReturnValue(mockCloseProtocolRun)
+      .mockReturnValue({closeCurrentRun: mockCloseCurrentRun, isClosingCurrentRun: false})
 
     const [{ getByRole, getByText }, store] = render()
     fireEvent.click(getByRole('button', { name: 'close' }))
@@ -162,7 +162,7 @@ describe('ProtocolUpload', () => {
       screen.queryByText('mock confirm exit protocol upload modal')
     ).toBeNull()
     expect(store.dispatch).toHaveBeenCalledWith(closeProtocol())
-    expect(mockCloseProtocolRun).toHaveBeenCalled()
+    expect(mockCloseCurrentRun).toHaveBeenCalled()
   })
 
   it('calls ingest protocol if handleUpload', () => {
@@ -174,6 +174,24 @@ describe('ProtocolUpload', () => {
         createProtocolRun: jest.fn(),
       } as any)
     const { getByText } = render()[0]
+    getByText('Open a protocol to run on robotName')
+  })
+
+  it('renders empty state input if the current run is being closed', () => {
+    getProtocolFile.mockReturnValue(withModulesProtocol as any)
+    when(mockUseCurrentProtocolRun)
+      .calledWith()
+      .mockReturnValue({
+        protocolRecord: {},
+        runRecord: {},
+        createProtocolRun: jest.fn(),
+      } as any)
+    const mockCloseCurrentRun = jest.fn()
+    when(mockUseCloseProtocolRun)
+      .calledWith()
+      .mockReturnValue({closeCurrentRun: mockCloseCurrentRun, isClosingCurrentRun: true})
+
+    const [{getByText }] = render()
     getByText('Open a protocol to run on robotName')
   })
 })

--- a/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
+++ b/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
@@ -92,6 +92,9 @@ describe('ProtocolUpload', () => {
     when(mockUseProtocolDetails)
       .calledWith()
       .mockReturnValue({} as any)
+    when(mockUseCloseProtocolRun)
+      .calledWith()
+      .mockReturnValue({closeCurrentRun: jest.fn(), isClosingCurrentRun: false})
   })
 
   afterEach(() => {
@@ -191,7 +194,7 @@ describe('ProtocolUpload', () => {
       .calledWith()
       .mockReturnValue({closeCurrentRun: mockCloseCurrentRun, isClosingCurrentRun: true})
 
-    const [{getByText }] = render()
+    const [{ getByText }] = render()
     getByText('Open a protocol to run on robotName')
   })
 })

--- a/app/src/organisms/ProtocolUpload/hooks/useCloneRun.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useCloneRun.ts
@@ -22,6 +22,8 @@ export function useCloneRun(runId: string | null): () => void {
     if (runRecord != null) {
       const { protocolId, labwareOffsets } = runRecord.data
       createRun({ protocolId, labwareOffsets })
+    } else {
+      console.info('failed to clone run record, source run record not found')
     }
   }
 

--- a/app/src/organisms/ProtocolUpload/hooks/useCloseCurrentRun.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useCloseCurrentRun.ts
@@ -38,7 +38,7 @@ export function useCloseCurrentRun(): {
 
   const closeCurrentRun = (
     options: UseDismissCurrentRunMutationOptions = {}
-  ) => {
+  ): void => {
     if (currentRunId != null) {
       const status = runRecord?.data.status
       if (isStoppedState(status as RunStatus)) {

--- a/app/src/organisms/ProtocolUpload/hooks/useCloseCurrentRun.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useCloseCurrentRun.ts
@@ -20,17 +20,25 @@ const isStoppedState = (status: RunStatus): boolean => {
   return false
 }
 
-export function useCloseCurrentRun(): (
-  options?: UseDismissCurrentRunMutationOptions
-) => void {
+type CloseCallback = (options?: UseDismissCurrentRunMutationOptions) => void
+
+export function useCloseCurrentRun(): {
+  closeCurrentRun: CloseCallback
+  isClosingCurrentRun: boolean
+} {
   const currentRunId = useCurrentRunId()
-  const { dismissCurrentRun } = useDismissCurrentRunMutation()
+  const {
+    dismissCurrentRun,
+    isLoading: isDismissing,
+  } = useDismissCurrentRunMutation()
   const { runRecord } = useCurrentProtocolRun()
 
   const { stopRun } = useStopRunMutation()
   const { deleteRun } = useDeleteRunMutation()
 
-  return (options: UseDismissCurrentRunMutationOptions = {}) => {
+  const closeCurrentRun = (
+    options: UseDismissCurrentRunMutationOptions = {}
+  ) => {
     if (currentRunId != null) {
       const status = runRecord?.data.status
       if (isStoppedState(status as RunStatus)) {
@@ -54,4 +62,5 @@ export function useCloseCurrentRun(): (
       }
     }
   }
+  return { closeCurrentRun, isClosingCurrentRun: isDismissing }
 }

--- a/app/src/organisms/ProtocolUpload/hooks/useRestartRun.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useRestartRun.ts
@@ -1,24 +1,16 @@
-import { useDeleteRunMutation } from '@opentrons/react-api-client'
 import { useCloneRun } from './useCloneRun'
 import { useCloseCurrentRun } from './useCloseCurrentRun'
 import { useMostRecentRunId } from './useMostRecentRunId'
 
 export function useRestartRun(): () => void {
   const mostRecentRunId = useMostRecentRunId()
-  const closeCurrentRun = useCloseCurrentRun()
-  const { deleteRun } = useDeleteRunMutation()
+  const { closeCurrentRun } = useCloseCurrentRun()
   const cloneRun = useCloneRun(mostRecentRunId as string)
 
   return () => {
     if (mostRecentRunId != null) {
       closeCurrentRun({
-        onSuccess: () => {
-          deleteRun(mostRecentRunId, {
-            onSuccess: () => {
-              cloneRun()
-            },
-          })
-        },
+        onSuccess: cloneRun,
       })
     }
   }

--- a/app/src/organisms/ProtocolUpload/index.tsx
+++ b/app/src/organisms/ProtocolUpload/index.tsx
@@ -38,7 +38,7 @@ export function ProtocolUpload(): JSX.Element {
     runRecord,
     protocolRecord,
   } = useCurrentProtocolRun()
-  const {closeCurrentRun, isClosingCurrentRun} = useCloseCurrentRun()
+  const { closeCurrentRun, isClosingCurrentRun } = useCloseCurrentRun()
   const hasCurrentRun = runRecord != null && protocolRecord != null
   const robotName = useSelector((state: State) => getConnectedRobotName(state))
 
@@ -78,24 +78,25 @@ export function ProtocolUpload(): JSX.Element {
     cancel: cancelExit,
   } = useConditionalConfirm(handleCloseProtocol, true)
 
-  const titleBarProps = !isClosingCurrentRun && hasCurrentRun
-    ? {
-        title: t('protocol_title', {
-          protocol_name: protocolRecord?.data?.metadata?.protocolName ?? '',
-        }),
-        back: {
-          onClick: confirmExit,
-          title: t('shared:close'),
-          children: t('shared:close'),
-          iconName: 'close' as const,
-        },
-        className: styles.reverse_titlebar_items,
-      }
-    : {
-        title: (
-          <Text>{t('upload_and_simulate', { robot_name: robotName })}</Text>
-        ),
-      }
+  const titleBarProps =
+    !isClosingCurrentRun && hasCurrentRun
+      ? {
+          title: t('protocol_title', {
+            protocol_name: protocolRecord?.data?.metadata?.protocolName ?? '',
+          }),
+          back: {
+            onClick: confirmExit,
+            title: t('shared:close'),
+            children: t('shared:close'),
+            iconName: 'close' as const,
+          },
+          className: styles.reverse_titlebar_items,
+        }
+      : {
+          title: (
+            <Text>{t('upload_and_simulate', { robot_name: robotName })}</Text>
+          ),
+        }
 
   return (
     <>

--- a/app/src/organisms/ProtocolUpload/index.tsx
+++ b/app/src/organisms/ProtocolUpload/index.tsx
@@ -38,8 +38,8 @@ export function ProtocolUpload(): JSX.Element {
     runRecord,
     protocolRecord,
   } = useCurrentProtocolRun()
-  const hasCurrentRun = runRecord != null && protocolRecord != null
   const {closeCurrentRun, isClosingCurrentRun} = useCloseCurrentRun()
+  const hasCurrentRun = runRecord != null && protocolRecord != null
   const robotName = useSelector((state: State) => getConnectedRobotName(state))
 
   const logger = useLogger(__filename)
@@ -78,7 +78,7 @@ export function ProtocolUpload(): JSX.Element {
     cancel: cancelExit,
   } = useConditionalConfirm(handleCloseProtocol, true)
 
-  const titleBarProps = hasCurrentRun
+  const titleBarProps = !isClosingCurrentRun && hasCurrentRun
     ? {
         title: t('protocol_title', {
           protocol_name: protocolRecord?.data?.metadata?.protocolName ?? '',
@@ -121,7 +121,7 @@ export function ProtocolUpload(): JSX.Element {
           width="100%"
           backgroundColor={C_NEAR_WHITE}
         >
-          {!isClosingCurrentRun && runRecord != null && protocolRecord != null ? (
+          {!isClosingCurrentRun && hasCurrentRun ? (
             <ProtocolSetup />
           ) : (
             <UploadInput onUpload={handleUpload} />

--- a/app/src/organisms/ProtocolUpload/index.tsx
+++ b/app/src/organisms/ProtocolUpload/index.tsx
@@ -39,7 +39,7 @@ export function ProtocolUpload(): JSX.Element {
     protocolRecord,
   } = useCurrentProtocolRun()
   const hasCurrentRun = runRecord != null && protocolRecord != null
-  const closeProtocolRun = useCloseCurrentRun()
+  const {closeCurrentRun, isClosingCurrentRun} = useCloseCurrentRun()
   const robotName = useSelector((state: State) => getConnectedRobotName(state))
 
   const logger = useLogger(__filename)
@@ -69,7 +69,7 @@ export function ProtocolUpload(): JSX.Element {
 
   const handleCloseProtocol: React.MouseEventHandler = _event => {
     dispatch(closeProtocol())
-    closeProtocolRun()
+    closeCurrentRun()
   }
 
   const {
@@ -121,7 +121,7 @@ export function ProtocolUpload(): JSX.Element {
           width="100%"
           backgroundColor={C_NEAR_WHITE}
         >
-          {runRecord != null && protocolRecord != null ? (
+          {!isClosingCurrentRun && runRecord != null && protocolRecord != null ? (
             <ProtocolSetup />
           ) : (
             <UploadInput onUpload={handleUpload} />


### PR DESCRIPTION
# Overview

Show the protocol upload empty state if the current run is being dismissed

Closes #8953 

# Review requests
- [ ] close a protocol run, you should be immediately brought back to the protocol upload empty state
# Risk assessment

low