### PR TITLE
feat(app): use module model when applying labware offsets

### DIFF
--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -1,5 +1,7 @@
-import type { Command as FullCommand } from '@opentrons/shared-data'
-import type { LabwareLocation } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
+import type {
+  Command as FullCommand,
+  ModuleModel,
+} from '@opentrons/shared-data'
 
 export const RUN_STATUS_IDLE: 'idle' = 'idle'
 export const RUN_STATUS_RUNNING: 'running' = 'running'
@@ -42,7 +44,7 @@ export interface LabwareOffset {
   id: string
   createdAt: string
   definitionUri: string
-  location: LabwareLocation
+  location: LabwareOffsetLocation
   vector: VectorOffset
 }
 
@@ -88,9 +90,13 @@ export interface RunCommandSummary {
   result?: any
 }
 
+export interface LabwareOffsetLocation {
+  slotName: string
+  moduleModel?: ModuleModel
+}
 export interface LabwareOffsetCreateData {
   definitionUri: string
-  location: LabwareLocation
+  location: LabwareOffsetLocation
   vector: VectorOffset
 }
 

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
@@ -58,7 +58,7 @@ export const SummaryScreen = (props: {
             runId: runRecord?.data.id as string,
             data: {
               definitionUri: labwareOffset.labwareDefinitionUri,
-              location: labwareOffset.labwareLocation,
+              location: labwareOffset.labwareOffsetLocation,
               vector: labwareOffset.vector,
             },
           }).catch((e: Error) => {

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/useLabwareOffsets.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/useLabwareOffsets.ts
@@ -7,12 +7,12 @@ import {
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import { getLabwareLocation } from '../../utils/getLabwareLocation'
+import { getLabwareOffsetLocation } from '../../utils/getLabwareOffsetLocation'
 import { getModuleInitialLoadInfo } from '../../utils/getModuleInitialLoadInfo'
 import { getLabwareDefinitionUri } from '../../utils/getLabwareDefinitionUri'
 import { useOffsetDataByLabwareId } from '../../../ProtocolUpload/hooks/useOffsetData'
-import type { VectorOffset } from '@opentrons/api-client'
+import type { LabwareOffsetLocation, VectorOffset } from '@opentrons/api-client'
 import type { SavePositionCommandData } from '../types'
-import type { LabwareLocation } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
 
 const getDisplayLocation = (
   labwareId: string,
@@ -50,7 +50,7 @@ const getDisplayLocation = (
 
 export type LabwareOffsets = Array<{
   labwareId: string
-  labwareLocation: LabwareLocation
+  labwareOffsetLocation: LabwareOffsetLocation
   labwareDefinitionUri: string
   displayLocation: string
   displayName: string
@@ -69,9 +69,10 @@ export const useLabwareOffsets = (
     savePositionCommandData,
     (labwareOffsets, _commandIds, labwareId) => {
       const displayLocation = getDisplayLocation(labwareId, protocolData, t)
-      const labwareLocation = getLabwareLocation(
+      const labwareOffsetLocation = getLabwareOffsetLocation(
         labwareId,
-        protocolData.commands
+        protocolData.commands,
+        protocolData.modules
       )
       const labwareDefinitionUri = getLabwareDefinitionUri(
         labwareId,
@@ -86,7 +87,7 @@ export const useLabwareOffsets = (
           ...labwareOffsets,
           {
             labwareId,
-            labwareLocation,
+            labwareOffsetLocation,
             labwareDefinitionUri,
             displayLocation,
             displayName,

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
@@ -22,8 +22,9 @@ import { sendModuleCommand } from '../../../../redux/modules'
 import { getConnectedRobotName } from '../../../../redux/robot/selectors'
 import { getAttachedModulesForConnectedRobot } from '../../../../redux/modules/selectors'
 import { getLabwareDefinitionUri } from '../../utils/getLabwareDefinitionUri'
-import { useSteps } from './useSteps'
 import { getModuleInitialLoadInfo } from '../../utils/getModuleInitialLoadInfo'
+import { getLabwareOffsetLocation } from '../../utils/getLabwareOffsetLocation'
+import { useSteps } from './useSteps'
 import type {
   HostConfig,
   RunCommandSummary,
@@ -441,13 +442,18 @@ export function useLabwarePositionCheck(
           createCommand({
             runId: currentRun?.data?.id as string,
             command: createCommandData(savePositionCommand),
-          }).then(response => {
-            const commandId = response.data.id
-            addSavePositionCommandData(
-              commandId,
-              currentCommand.params.labwareId
-            )
           })
+            .then(response => {
+              const commandId = response.data.id
+              addSavePositionCommandData(
+                commandId,
+                currentCommand.params.labwareId
+              )
+            })
+            .catch((e: Error) => {
+              console.error(`error saving position: ${e.message}`)
+              setError(e)
+            })
         }
         setCurrentCommandIndex(currentCommandIndex + 1)
       })
@@ -471,7 +477,11 @@ export function useLabwarePositionCheck(
             labwareId,
             protocolData?.labware
           ),
-          location: getLabwareLocation(labwareId, protocolData?.commands ?? []),
+          location: getLabwareOffsetLocation(
+            labwareId,
+            protocolData?.commands ?? [],
+            protocolData?.modules ?? {}
+          ),
           vector: IDENTITY_VECTOR,
         }
         return [...acc, identityOffset]

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/utils/__tests__/getLatestLabwareOffsetCount.test.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/utils/__tests__/getLatestLabwareOffsetCount.test.ts
@@ -57,20 +57,20 @@ describe('getLatestLabwareOffsetCount', () => {
     ]
     expect(getLatestLabwareOffsetCount(labwareOffsets)).toBe(1)
   })
-  it('should return 1 when there are two offset records with the same labware and module id', () => {
+  it('should return 1 when there are two offset records with the same labware and module location', () => {
     const labwareOffsets: LabwareOffset[] = [
       {
         id: 'someID1',
         createdAt: '2021-11-30',
         definitionUri: 'some_definitionUri',
-        location: { moduleId: 'some_module' },
+        location: { slotName: '1', moduleModel: 'temperatureModuleV1' },
         vector: { x: 1, y: 0, z: 0 },
       },
       {
         id: 'someID2',
         createdAt: '2021-11-29',
         definitionUri: 'some_definitionUri',
-        location: { moduleId: 'some_module' },
+        location: { slotName: '1', moduleModel: 'temperatureModuleV1' },
         vector: { x: 1, y: 2, z: 3 },
       },
     ]
@@ -82,14 +82,14 @@ describe('getLatestLabwareOffsetCount', () => {
         id: 'someID1',
         createdAt: '2021-11-29',
         definitionUri: 'some_definitionUri',
-        location: { moduleId: 'some_module' },
+        location: { slotName: '2' },
         vector: { x: 0, y: 0, z: 0 },
       },
       {
         id: 'someID2',
         createdAt: '2021-11-29',
         definitionUri: 'some_definitionUri',
-        location: { moduleId: 'some_module' },
+        location: { slotName: '3' },
         vector: { x: 0, y: 0, z: 0 },
       },
     ]
@@ -108,7 +108,7 @@ describe('getLatestLabwareOffsetCount', () => {
         id: 'someID2',
         createdAt: '2021-11-29',
         definitionUri: 'some_definitionUri',
-        location: { moduleId: 'some_module' },
+        location: { slotName: '1', moduleModel: 'temperatureModuleV1' },
         vector: { x: 1, y: 0, z: 0 },
       },
     ]
@@ -134,14 +134,16 @@ describe('getLatestLabwareOffsetCount', () => {
         id: 'someId3',
         createdAt: '2021-11-29',
         definitionUri: 'another_definitionUri',
-        location: { moduleId: 'some_module' },
+        location: { slotName: '1', moduleModel: 'temperatureModuleV1' },
+
         vector: { x: 0, y: 0, z: 0 },
       },
       {
         id: 'someId4',
         createdAt: '2021-11-30',
         definitionUri: 'another_definitionUri',
-        location: { moduleId: 'some_module' },
+        location: { slotName: '1', moduleModel: 'temperatureModuleV1' },
+
         vector: { x: 1, y: 0, z: 0 },
       },
     ]
@@ -167,14 +169,16 @@ describe('getLatestLabwareOffsetCount', () => {
         id: 'someId3',
         createdAt: '2021-12-29',
         definitionUri: 'another_definitionUri',
-        location: { moduleId: 'some_module' },
+        location: { slotName: '1', moduleModel: 'temperatureModuleV1' },
+
         vector: { x: 0, y: 0, z: 0 },
       },
       {
         id: 'someId4',
         createdAt: '2021-11-30',
         definitionUri: 'another_definitionUri',
-        location: { moduleId: 'some_module' },
+        location: { slotName: '1', moduleModel: 'temperatureModuleV1' },
+
         vector: { x: 1, y: 0, z: 0 },
       },
     ]

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/utils/getLatestLabwareOffsetCount.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/utils/getLatestLabwareOffsetCount.ts
@@ -23,7 +23,9 @@ export const getLatestLabwareOffsetCount = (
       const location = offset.location
       const definitionUri = offset.definitionUri
       const locationKey =
-        'slotName' in location ? location.slotName : location.moduleId
+        location.moduleModel != null
+          ? `${location.moduleModel}_${location.slotName}`
+          : location.slotName
       // key by definition uri AND location, because labware offsets are tied to a combo of both of these attributes
       return `${definitionUri}_${locationKey}`
     }

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/LabwareInfoOverlay.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/LabwareInfoOverlay.tsx
@@ -60,9 +60,9 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element => {
     ),
     offset => {
       const locationKey =
-        'slotName' in offset.location
-          ? offset.location?.slotName
-          : offset.location.moduleId
+        offset.location.moduleModel != null
+          ? `${offset.location.moduleModel}_${offset.location.slotName}`
+          : offset.location.slotName
       return `${offset.definitionUri}_${locationKey}`
     }
   )

--- a/app/src/organisms/ProtocolSetup/utils/__test__/getLabwareOffsetLocation.test.tsx
+++ b/app/src/organisms/ProtocolSetup/utils/__test__/getLabwareOffsetLocation.test.tsx
@@ -1,0 +1,59 @@
+import { when, resetAllWhenMocks } from 'jest-when'
+import _uncastedProtocolWithTC from '@opentrons/shared-data/protocol/fixtures/6/multipleTipracksWithTC.json'
+import { getLabwareOffsetLocation } from '../getLabwareOffsetLocation'
+import { getLabwareLocation } from '../getLabwareLocation'
+import { getModuleInitialLoadInfo } from '../getModuleInitialLoadInfo'
+import type { ProtocolFile } from '@opentrons/shared-data'
+
+jest.mock('../getLabwareLocation')
+jest.mock('../getModuleInitialLoadInfo')
+
+const protocolWithTC = (_uncastedProtocolWithTC as unknown) as ProtocolFile<{}>
+
+const mockGetLabwareLocation = getLabwareLocation as jest.MockedFunction<
+  typeof getLabwareLocation
+>
+const mockGetModuleInitialLoadInfo = getModuleInitialLoadInfo as jest.MockedFunction<
+  typeof getModuleInitialLoadInfo
+>
+
+describe('getLabwareOffsetLocation', () => {
+  let MOCK_LABWARE_ID: string
+  let MOCK_COMMANDS: ProtocolFile<{}>['commands']
+  let MOCK_MODULES: ProtocolFile<{}>['modules']
+  beforeEach(() => {
+    MOCK_LABWARE_ID = 'some_labware'
+    MOCK_COMMANDS = protocolWithTC.commands
+    MOCK_MODULES = protocolWithTC.modules
+  })
+  afterEach(() => {
+    resetAllWhenMocks()
+    jest.restoreAllMocks()
+  })
+  it('should return just the slot name if the labware is not on top of a module', () => {
+    const MOCK_SLOT = '2'
+    when(mockGetLabwareLocation)
+      .calledWith(MOCK_LABWARE_ID, MOCK_COMMANDS)
+      .mockReturnValue({ slotName: MOCK_SLOT })
+
+    expect(
+      getLabwareOffsetLocation(MOCK_LABWARE_ID, MOCK_COMMANDS, MOCK_MODULES)
+    ).toEqual({ slotName: MOCK_SLOT })
+  })
+  it('should return the slot name and module model if the labware is on top of a module', () => {
+    const TCIdInProtocol =
+      '18f0c1b0-0122-11ec-88a3-f1745cf9b36c:thermocyclerModuleType' // this is just taken from the protocol fixture
+    const TCModelInProtocol = 'thermocyclerModuleV1'
+    const MOCK_SLOT = '2'
+    when(mockGetLabwareLocation)
+      .calledWith(MOCK_LABWARE_ID, MOCK_COMMANDS)
+      .mockReturnValue({ moduleId: TCIdInProtocol })
+    when(mockGetModuleInitialLoadInfo)
+      .calledWith(TCIdInProtocol, MOCK_COMMANDS)
+      .mockReturnValue({ location: { slotName: MOCK_SLOT } } as any)
+
+    expect(
+      getLabwareOffsetLocation(MOCK_LABWARE_ID, MOCK_COMMANDS, MOCK_MODULES)
+    ).toEqual({ slotName: MOCK_SLOT, moduleModel: TCModelInProtocol })
+  })
+})

--- a/app/src/organisms/ProtocolSetup/utils/getLabwareOffsetLocation.ts
+++ b/app/src/organisms/ProtocolSetup/utils/getLabwareOffsetLocation.ts
@@ -1,0 +1,28 @@
+import { getLabwareLocation } from './getLabwareLocation'
+import { getModuleInitialLoadInfo } from './getModuleInitialLoadInfo'
+import type { LabwareOffsetLocation } from '@opentrons/api-client'
+import { ProtocolFile } from '@opentrons/shared-data'
+
+// this logic to derive the LabwareOffsetLocation from the LabwareLocation
+// is required because the backend needs to know a module's model (not its ID)
+// in order to apply offsets. This logic should be removed once the backend can
+// accept a module id as a labware's location (to match the LabwareLocation interface)
+export const getLabwareOffsetLocation = (
+  labwareId: string,
+  commands: ProtocolFile<{}>['commands'],
+  modules: ProtocolFile<{}>['modules']
+): LabwareOffsetLocation => {
+  let location: LabwareOffsetLocation
+  const labwareLocation = getLabwareLocation(labwareId, commands)
+  if ('moduleId' in labwareLocation) {
+    const moduleModel = modules[labwareLocation.moduleId].model
+    const slotName = getModuleInitialLoadInfo(
+      labwareLocation.moduleId,
+      commands
+    ).location.slotName
+    location = { slotName, moduleModel }
+  } else {
+    location = labwareLocation
+  }
+  return location
+}


### PR DESCRIPTION
# Overview

This PR enables users to apply labware offsets to labware on top of modules.

Previously, the client expected the server to accept a `moduleId` when applying labware offets, but the server actually expects a `moduleModel` along with a `slotName`. 

closes #8987 
# Changelog

- Use module model when applying labware offsets

# Review requests
Start LPC with a protocol that has modules, in your network tab you should see a successful `POST` request to `/labware_offsets` applying identity offsets to the labware that sits on the module.

During LPC apply offsets to the labware with modules, after LPC you should see the offsets displayed in the labware setup step.
# Risk assessment
Low
