### PR TITLE
feat(hardware): CAN over plain old socket

### DIFF
--- a/hardware/opentrons_hardware/drivers/can_bus/abstract_driver.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/abstract_driver.py
@@ -1,7 +1,7 @@
 """The can bus transport."""
 from __future__ import annotations
 from abc import ABC, abstractmethod
-from .message import CanMessage
+from opentrons_ot3_firmware import CanMessage
 
 
 class AbstractCanDriver(ABC):

--- a/hardware/opentrons_hardware/drivers/can_bus/abstract_driver.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/abstract_driver.py
@@ -1,0 +1,53 @@
+"""The can bus transport."""
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from .message import CanMessage
+
+
+class AbstractCanDriver(ABC):
+    """Can driver interface."""
+
+    @abstractmethod
+    async def send(self, message: CanMessage) -> None:
+        """Send a can message.
+
+        Args:
+            message: The message to send.
+
+        Returns:
+            None
+        """
+        ...
+
+    @abstractmethod
+    async def read(self) -> CanMessage:
+        """Read a message.
+
+        Returns:
+            A can message
+
+        Raises:
+            ErrorFrameCanError
+        """
+        ...
+
+    def __aiter__(self) -> AbstractCanDriver:
+        """Enter iterator.
+
+        Returns:
+            CanDriver
+        """
+        return self
+
+    async def __anext__(self) -> CanMessage:
+        """Async next.
+
+        Returns:
+            CanMessage
+        """
+        return await self.read()
+
+    @abstractmethod
+    def shutdown(self) -> None:
+        """Stop the driver."""
+        ...

--- a/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
@@ -5,12 +5,10 @@ import logging
 
 from opentrons_hardware.drivers.can_bus import (
     CanDriver,
-
 )
 from opentrons_ot3_firmware.arbitration_id import (
     ArbitrationId,
     ArbitrationIdParts,
-
 )
 from opentrons_ot3_firmware.message import CanMessage
 from opentrons_ot3_firmware.constants import NodeId, MessageId

--- a/hardware/opentrons_hardware/drivers/can_bus/driver.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/driver.py
@@ -10,6 +10,7 @@ from can import Notifier, Bus, AsyncBufferedReader, Message, util
 from opentrons_ot3_firmware.arbitration_id import ArbitrationId
 from opentrons_ot3_firmware.message import CanMessage
 from .errors import ErrorFrameCanError
+from .abstract_driver import AbstractCanDriver
 
 log = logging.getLogger(__name__)
 
@@ -33,7 +34,7 @@ if platform.system() == "Darwin":
     # end super bad monkey patch
 
 
-class CanDriver:
+class CanDriver(AbstractCanDriver):
     """The can driver."""
 
     DEFAULT_CAN_NETWORK = "can0"
@@ -141,19 +142,3 @@ class CanDriver:
         return CanMessage(
             arbitration_id=ArbitrationId(id=m.arbitration_id), data=m.data
         )
-
-    def __aiter__(self) -> CanDriver:
-        """Enter iterator.
-
-        Returns:
-            CanDriver
-        """
-        return self
-
-    async def __anext__(self) -> CanMessage:
-        """Async next.
-
-        Returns:
-            CanMessage
-        """
-        return await self.read()

--- a/hardware/opentrons_hardware/drivers/can_bus/socket_driver.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/socket_driver.py
@@ -6,7 +6,7 @@ import asyncio
 from typing import List
 
 from . import ArbitrationId
-from .message import CanMessage
+from opentrons_ot3_firmware import CanMessage
 from .abstract_driver import AbstractCanDriver
 
 

--- a/hardware/opentrons_hardware/drivers/can_bus/socket_driver.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/socket_driver.py
@@ -1,0 +1,104 @@
+"""A driver that emulates CAN over socket."""
+from __future__ import annotations
+import logging
+import struct
+import asyncio
+from typing import List
+
+from . import ArbitrationId
+from .message import CanMessage
+from .abstract_driver import AbstractCanDriver
+
+
+log = logging.getLogger(__name__)
+
+
+class SocketDriver(AbstractCanDriver):
+    """A driver that emulates CAN over socket."""
+
+    _server: asyncio.AbstractServer
+
+    def __init__(
+        self, server: asyncio.AbstractServer, connection_handler: ConnectionHandler
+    ) -> None:
+        """Constructor.
+
+        Args:
+            server: the server
+            connection_handler: the connection handler
+        """
+        self._server = server
+        self._connection_handler = connection_handler
+
+    @classmethod
+    async def build(cls, port: int) -> SocketDriver:
+        """Create a socket driver.
+
+        Args:
+            port: The port to listen on.
+
+        Returns:
+            A new instance.
+        """
+        log.info(f"Listening on {port}")
+        connection_handler = ConnectionHandler()
+        server = await asyncio.start_server(connection_handler, port=port)
+        return SocketDriver(server, connection_handler)
+
+    async def send(self, message: CanMessage) -> None:
+        """Send a message."""
+        self._connection_handler.send(message)
+
+    async def read(self) -> CanMessage:
+        """Read a message."""
+        return await self._connection_handler.read()
+
+    def shutdown(self) -> None:
+        """Shutdown the driver."""
+        self._server.close()
+
+
+class ConnectionHandler:
+    """The class that manages client connections."""
+
+    _writers: List[asyncio.StreamWriter]
+    _queue: asyncio.Queue[CanMessage]
+
+    def __init__(self) -> None:
+        """Constructor."""
+        self._writers = []
+        self._queue = asyncio.Queue()
+
+    async def __call__(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        """Server accept connection callback."""
+        log.info("Handling new connection")
+
+        self._writers.append(writer)
+
+        while True:
+            header = await reader.read(8)
+            arbitration_id, length = struct.unpack(">LL", header)
+            if length > 0:
+                data = await reader.read(length)
+            else:
+                data = b""
+            self._queue.put_nowait(
+                CanMessage(arbitration_id=ArbitrationId(arbitration_id), data=data)
+            )
+
+    def send(self, message: CanMessage) -> None:
+        """Send message to all connections."""
+        if message.data:
+            data = struct.pack(
+                ">LLp", message.arbitration_id.id, len(message.data), message.data
+            )
+        else:
+            data = struct.pack(">LL", message.arbitration_id.id, len(message.data))
+        for w in self._writers:
+            w.write(data)
+
+    async def read(self) -> CanMessage:
+        """Read a message."""
+        return await self._queue.get()

--- a/hardware/opentrons_hardware/drivers/can_bus/socket_driver.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/socket_driver.py
@@ -91,12 +91,12 @@ class ConnectionHandler:
 
     def send(self, message: CanMessage) -> None:
         """Send message to all connections."""
-        if message.data:
-            data = struct.pack(
-                ">LLp", message.arbitration_id.id, len(message.data), message.data
-            )
-        else:
-            data = struct.pack(">LL", message.arbitration_id.id, len(message.data))
+        data = struct.pack(
+            f">LL{len(message.data)}s",
+            message.arbitration_id.id,
+            len(message.data),
+            message.data,
+        )
         for w in self._writers:
             w.write(data)
 

--- a/hardware/opentrons_hardware/drivers/can_bus/socket_driver.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/socket_driver.py
@@ -80,12 +80,13 @@ class ConnectionHandler:
         while True:
             header = await reader.read(8)
             arbitration_id, length = struct.unpack(">LL", header)
+
             if length > 0:
                 data = await reader.read(length)
             else:
                 data = b""
             self._queue.put_nowait(
-                CanMessage(arbitration_id=ArbitrationId(arbitration_id), data=data)
+                CanMessage(arbitration_id=ArbitrationId(id=arbitration_id), data=data)
             )
 
     def send(self, message: CanMessage) -> None:

--- a/hardware/opentrons_hardware/scripts/can_args.py
+++ b/hardware/opentrons_hardware/scripts/can_args.py
@@ -1,5 +1,9 @@
 """ArgumentParser setup for a can device."""
-from argparse import ArgumentParser
+from argparse import ArgumentParser, Namespace
+
+from opentrons_hardware.drivers.can_bus import CanDriver
+from opentrons_hardware.drivers.can_bus.abstract_driver import AbstractCanDriver
+from opentrons_hardware.drivers.can_bus.socket_driver import SocketDriver
 
 
 def add_can_args(parser: ArgumentParser) -> ArgumentParser:
@@ -14,7 +18,7 @@ def add_can_args(parser: ArgumentParser) -> ArgumentParser:
         "--interface",
         type=str,
         required=True,
-        help="the interface to use (ie: virtual, pcan, socketcan)",
+        help="the interface to use (ie: opentrons, virtual, pcan, socketcan)",
     )
     parser.add_argument(
         "--bitrate", type=int, default=250000, required=False, help="the bitrate"
@@ -22,4 +26,28 @@ def add_can_args(parser: ArgumentParser) -> ArgumentParser:
     parser.add_argument(
         "--channel", type=str, default=None, required=False, help="optional channel"
     )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=9898,
+        required=False,
+        help="port to use for opentrons interface",
+    )
     return parser
+
+
+async def build_driver(args: Namespace) -> AbstractCanDriver:
+    """Create the driver.
+
+    Args:
+        args: arguments created by using `add_can_args`
+
+    Returns:
+        A driver.
+    """
+    if args.interface == "opentrons":
+        return await SocketDriver.build(port=args.port)
+    else:
+        return await CanDriver.build(
+            interface=args.interface, bitrate=args.bitrate, channel=args.channel
+        )

--- a/hardware/opentrons_hardware/scripts/can_comm.py
+++ b/hardware/opentrons_hardware/scripts/can_comm.py
@@ -7,7 +7,6 @@ from enum import Enum
 from logging.config import dictConfig
 from typing import Type, Sequence, Callable, cast
 
-from opentrons_hardware.drivers.can_bus import CanDriver
 from opentrons_ot3_firmware.constants import (
     MessageId,
     NodeId,

--- a/hardware/tests/opentrons_hardware/drivers/can_bus/test_can_messenger.py
+++ b/hardware/tests/opentrons_hardware/drivers/can_bus/test_can_messenger.py
@@ -8,7 +8,6 @@ from mock import AsyncMock, Mock
 
 from opentrons_ot3_firmware.constants import (
     NodeId,
-
     MessageId,
 )
 

--- a/hardware/tests/test_scripts/test_can_comm.py
+++ b/hardware/tests/test_scripts/test_can_comm.py
@@ -11,7 +11,6 @@ from opentrons_ot3_firmware.message import (
 from opentrons_ot3_firmware.arbitration_id import (
     ArbitrationId,
     ArbitrationIdParts,
-
 )
 from opentrons_ot3_firmware.messages.payloads import (
     DeviceInfoResponsePayload,


### PR DESCRIPTION
# Overview

Enable CAN over plain socket. This is available for easy simulation on non-Linux machines. 

# Changelog

`AbstractCanDriver` is the ABC for `CanDriver` (python-can) and `SocketDriver` (socket).

# Review requests

This is the companion to https://github.com/Opentrons/ot3-firmware/pull/165

# Risk assessment

 None