### PR TITLE
feat(app): add loader to LPC summary screen

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -81,6 +81,7 @@
   "run_disabled_calibration_not_complete": "Make sure robot calibration is complete before proceeding to run",
   "run_disabled_modules_and_calibration_not_complete": "Make sure robot calibration is complete and all modules are connected before proceeding to run",
   "loading_protocol_details": "Loading details...",
+  "loading_labware_offsets": "Loading labware offsets",
   "protocol_upload_revamp_feedback": "Have feedback about this experience?",
   "feedback_form_link": "Let us know!",
   "labware_position_check_not_available": "Labware Position Check is not available once a run has started",

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwareOffsetsSummary.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwareOffsetsSummary.tsx
@@ -31,33 +31,31 @@ interface LabwareOffsetSummary {
 const OffsetDataLoader = (): JSX.Element | null => {
   const { t } = useTranslation('protocol_setup')
   return (
-    <>
-      <Flex
-        justifyContent={JUSTIFY_CENTER}
-        flexDirection={DIRECTION_COLUMN}
-        alignItems={ALIGN_CENTER}
+    <Flex
+      justifyContent={JUSTIFY_CENTER}
+      flexDirection={DIRECTION_COLUMN}
+      alignItems={ALIGN_CENTER}
+    >
+      <Text
+        as={'h3'}
+        color={C_DARK_GRAY}
+        marginTop={SPACING_4}
+        fontWeight={FONT_WEIGHT_SEMIBOLD}
+        fontSize={FONT_SIZE_BODY_2}
+        textTransform={TEXT_TRANSFORM_UPPERCASE}
       >
-        <Text
-          as={'h3'}
-          color={C_DARK_GRAY}
-          marginTop={SPACING_4}
-          fontWeight={FONT_WEIGHT_SEMIBOLD}
-          fontSize={FONT_SIZE_BODY_2}
-          textTransform={TEXT_TRANSFORM_UPPERCASE}
-        >
-          {t('loading_labware_offsets')}
-        </Text>
-        <Icon
-          name="ot-spinner"
-          id={`LabwareOffsetsSummary_loadingSpinner`}
-          width={SPACING_5}
-          marginTop={SPACING_4}
-          marginBottom={SPACING_4}
-          color={C_MED_GRAY}
-          spin
-        />
-      </Flex>
-    </>
+        {t('loading_labware_offsets')}
+      </Text>
+      <Icon
+        name="ot-spinner"
+        id={`LabwareOffsetsSummary_loadingSpinner`}
+        width={SPACING_5}
+        marginTop={SPACING_4}
+        marginBottom={SPACING_4}
+        color={C_MED_GRAY}
+        spin
+      />
+    </Flex>
   )
 }
 

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwareOffsetsSummary.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwareOffsetsSummary.tsx
@@ -1,27 +1,169 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import {
+  ALIGN_CENTER,
+  C_DARK_GRAY,
   C_MED_GRAY,
   C_NEAR_WHITE,
   DIRECTION_COLUMN,
   DIRECTION_ROW,
   Flex,
   FONT_BODY_1_DARK,
+  FONT_SIZE_BODY_2,
   FONT_SIZE_CAPTION,
   FONT_WEIGHT_SEMIBOLD,
+  Icon,
   JUSTIFY_CENTER,
+  SPACING_1,
+  SPACING_2,
   SPACING_3,
   SPACING_4,
-  SPACING_1,
-  Text,
+  SPACING_5,
   TEXT_TRANSFORM_UPPERCASE,
-  SPACING_2,
+  Text,
 } from '@opentrons/components'
 import type { LabwareOffsets } from './hooks/useLabwareOffsets'
 
 interface LabwareOffsetSummary {
   offsetData: LabwareOffsets
 }
+
+const OffsetDataLoader = (): JSX.Element | null => {
+  const { t } = useTranslation('protocol_setup')
+  return (
+    <>
+      <Flex
+        justifyContent={JUSTIFY_CENTER}
+        flexDirection={DIRECTION_COLUMN}
+        alignItems={ALIGN_CENTER}
+      >
+        <Text
+          as={'h3'}
+          color={C_DARK_GRAY}
+          marginTop={SPACING_4}
+          fontWeight={FONT_WEIGHT_SEMIBOLD}
+          fontSize={FONT_SIZE_BODY_2}
+          textTransform={TEXT_TRANSFORM_UPPERCASE}
+        >
+          {t('loading_labware_offsets')}
+        </Text>
+        <Icon
+          name="ot-spinner"
+          id={`LabwareOffsetsSummary_loadingSpinner`}
+          width={SPACING_5}
+          marginTop={SPACING_4}
+          marginBottom={SPACING_4}
+          color={C_MED_GRAY}
+          spin
+        />
+      </Flex>
+    </>
+  )
+}
+
+const SummaryData = (props: LabwareOffsetSummary): JSX.Element => {
+  const { offsetData } = props
+  const { t } = useTranslation('labware_position_check')
+  return (
+    <Flex flexDirection={DIRECTION_ROW}>
+      <Flex
+        flex={'auto'}
+        flexDirection={DIRECTION_COLUMN}
+        justifyContent={JUSTIFY_CENTER}
+      >
+        <Text
+          textTransform={TEXT_TRANSFORM_UPPERCASE}
+          marginBottom={SPACING_3}
+          color={C_MED_GRAY}
+          fontSize={FONT_SIZE_CAPTION}
+        >
+          {t('labware_offsets_summary_location')}
+        </Text>
+        {offsetData.map(({ displayLocation: location }) => {
+          return (
+            <Flex
+              key={location}
+              marginBottom={SPACING_3}
+              css={FONT_BODY_1_DARK}
+            >
+              {location}
+            </Flex>
+          )
+        })}
+      </Flex>
+      <Flex
+        flex={'auto'}
+        flexDirection={DIRECTION_COLUMN}
+        justifyContent={JUSTIFY_CENTER}
+      >
+        <Text
+          textTransform={TEXT_TRANSFORM_UPPERCASE}
+          marginBottom={SPACING_3}
+          color={C_MED_GRAY}
+          fontSize={FONT_SIZE_CAPTION}
+        >
+          {t('labware_offsets_summary_labware')}
+        </Text>
+        {offsetData.map(({ displayName: labware }, index) => {
+          return (
+            <Flex
+              key={`${labware}_${index}`}
+              marginBottom={SPACING_3}
+              css={FONT_BODY_1_DARK}
+            >
+              {labware}
+            </Flex>
+          )
+        })}
+      </Flex>
+      <Flex
+        flex={'auto'}
+        flexDirection={DIRECTION_COLUMN}
+        justifyContent={JUSTIFY_CENTER}
+      >
+        <Text
+          textTransform={TEXT_TRANSFORM_UPPERCASE}
+          marginBottom={SPACING_3}
+          color={C_MED_GRAY}
+          fontSize={FONT_SIZE_CAPTION}
+        >
+          {t('labware_offsets_summary_offset')}
+        </Text>
+        {offsetData
+          .map(({ vector }) => vector)
+          .map(({ x, y, z }, index) => {
+            return x === 0 && y === 0 && z === 0 ? (
+              <Flex key={index} marginBottom={SPACING_3} css={FONT_BODY_1_DARK}>
+                {t('no_labware_offsets')}
+              </Flex>
+            ) : (
+              <Flex key={index} marginBottom={SPACING_3} css={FONT_BODY_1_DARK}>
+                <Text as={'strong'} marginRight={SPACING_1}>
+                  X
+                </Text>
+                <Text as={'span'} marginRight={SPACING_2}>
+                  {x.toFixed(2)}
+                </Text>
+                <Text as={'strong'} marginRight={SPACING_1}>
+                  Y
+                </Text>
+                <Text as={'span'} marginRight={SPACING_2}>
+                  {y.toFixed(2)}
+                </Text>
+                <Text as={'strong'} marginRight={SPACING_1}>
+                  Z
+                </Text>
+                <Text as={'span'} marginRight={SPACING_2}>
+                  {z.toFixed(2)}
+                </Text>
+              </Flex>
+            )
+          })}
+      </Flex>
+    </Flex>
+  )
+}
+
 export const LabwareOffsetsSummary = (
   props: LabwareOffsetSummary
 ): JSX.Element | null => {
@@ -44,110 +186,11 @@ export const LabwareOffsetsSummary = (
         >
           {t('labware_offsets_summary_title')}
         </Text>
-        <Flex flexDirection={DIRECTION_ROW}>
-          <Flex
-            flex={'auto'}
-            flexDirection={DIRECTION_COLUMN}
-            justifyContent={JUSTIFY_CENTER}
-          >
-            <Text
-              textTransform={TEXT_TRANSFORM_UPPERCASE}
-              marginBottom={SPACING_3}
-              color={C_MED_GRAY}
-              fontSize={FONT_SIZE_CAPTION}
-            >
-              {t('labware_offsets_summary_location')}
-            </Text>
-            {offsetData.map(({ displayLocation: location }) => {
-              return (
-                <Flex
-                  key={location}
-                  marginBottom={SPACING_3}
-                  css={FONT_BODY_1_DARK}
-                >
-                  {location}
-                </Flex>
-              )
-            })}
-          </Flex>
-          <Flex
-            flex={'auto'}
-            flexDirection={DIRECTION_COLUMN}
-            justifyContent={JUSTIFY_CENTER}
-          >
-            <Text
-              textTransform={TEXT_TRANSFORM_UPPERCASE}
-              marginBottom={SPACING_3}
-              color={C_MED_GRAY}
-              fontSize={FONT_SIZE_CAPTION}
-            >
-              {t('labware_offsets_summary_labware')}
-            </Text>
-            {offsetData.map(({ displayName: labware }, index) => {
-              return (
-                <Flex
-                  key={`${labware}_${index}`}
-                  marginBottom={SPACING_3}
-                  css={FONT_BODY_1_DARK}
-                >
-                  {labware}
-                </Flex>
-              )
-            })}
-          </Flex>
-          <Flex
-            flex={'auto'}
-            flexDirection={DIRECTION_COLUMN}
-            justifyContent={JUSTIFY_CENTER}
-          >
-            <Text
-              textTransform={TEXT_TRANSFORM_UPPERCASE}
-              marginBottom={SPACING_3}
-              color={C_MED_GRAY}
-              fontSize={FONT_SIZE_CAPTION}
-            >
-              {t('labware_offsets_summary_offset')}
-            </Text>
-            {offsetData
-              .map(({ vector }) => vector)
-              .map(({ x, y, z }, index) => {
-                return x === 0 && y === 0 && z === 0 ? (
-                  <Flex
-                    key={index}
-                    marginBottom={SPACING_3}
-                    css={FONT_BODY_1_DARK}
-                  >
-                    {t('no_labware_offsets')}
-                  </Flex>
-                ) : (
-                  <Flex
-                    key={index}
-                    marginBottom={SPACING_3}
-                    css={FONT_BODY_1_DARK}
-                  >
-                    <Text as={'strong'} marginRight={SPACING_1}>
-                      X
-                    </Text>
-                    <Text as={'span'} marginRight={SPACING_2}>
-                      {x.toFixed(2)}
-                    </Text>
-                    <Text as={'strong'} marginRight={SPACING_1}>
-                      Y
-                    </Text>
-                    <Text as={'span'} marginRight={SPACING_2}>
-                      {y.toFixed(2)}
-                    </Text>
-                    <Text as={'strong'} marginRight={SPACING_1}>
-                      Z
-                    </Text>
-                    <Text as={'span'} marginRight={SPACING_2}>
-                      {z.toFixed(2)}
-                    </Text>
-                  </Flex>
-                )
-              })}
-          </Flex>
-        </Flex>
+        {offsetData.length === 0 ? (
+          <OffsetDataLoader />
+        ) : (
+          <SummaryData offsetData={offsetData} />
+        )}
       </Flex>
     </React.Fragment>
   )

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/LabwareOffsetsSummary.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/LabwareOffsetsSummary.test.tsx
@@ -3,15 +3,38 @@ import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../../i18n'
 import { LabwareOffsetsSummary } from '../LabwareOffsetsSummary'
 
-const render = () => {
-  return renderWithProviders(<LabwareOffsetsSummary offsetData={[]} />, {
+const render = (props: React.ComponentProps<typeof LabwareOffsetsSummary>) => {
+  return renderWithProviders(<LabwareOffsetsSummary {...props} />, {
     i18nInstance: i18n,
   })[0]
 }
 
 describe('LabwareOffsetsSummary', () => {
+  let props: React.ComponentProps<typeof LabwareOffsetsSummary>
+  beforeEach(() => {
+    props = { offsetData: [] }
+  })
+  it('renders a loading spinner while the offset diffs are being calculated', () => {
+    const { container, getByRole } = render(props)
+    getByRole('heading', { name: 'Labware Offsets to be applied to this run' })
+    expect(
+      container.querySelector('#LabwareOffsetsSummary_loadingSpinner')
+    ).toBeInTheDocument()
+  })
   it('renders correct header and summary categories', () => {
-    const { getByRole, getByText } = render()
+    props = {
+      offsetData: [
+        {
+          labwareId: 'some_id',
+          labwareOffsetLocation: { slotName: '1' },
+          labwareDefinitionUri: 'some_def_uri',
+          displayLocation: 'some_location',
+          displayName: 'some_name',
+          vector: { x: 1, y: 1, z: 1 },
+        },
+      ],
+    }
+    const { getByRole, getByText } = render(props)
     getByRole('heading', { name: 'Labware Offsets to be applied to this run' })
     getByText('Location')
     getByText('Labware')

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { when } from 'jest-when'
+import { when, resetAllWhenMocks } from 'jest-when'
 import { act } from 'react-dom/test-utils'
 import { fireEvent } from '@testing-library/dom'
 import { renderWithProviders } from '@opentrons/components'
@@ -100,6 +100,10 @@ describe('SummaryScreen', () => {
     when(mockUseLPCSuccessToast)
       .calledWith()
       .mockReturnValue({ setShowLPCSuccessToast: () => null })
+  })
+  afterEach(() => {
+    resetAllWhenMocks()
+    jest.restoreAllMocks()
   })
   it('renders Summary Screen with all components and header', () => {
     const { getByText } = render(props)


### PR DESCRIPTION
# Overview
This PR adds a loader to the LPC summary screen while offset diffs are being calculated.

closes #9001 
# Changelog
- Add loader to LPC summary screen

# Review requests

Go through LPC, at the final summary screen you should see a loader appear for a few seconds while the offset diffs get calculated.

(sceenshot below)

![Screen Shot 2021-12-07 at 1 58 56 PM](https://user-images.githubusercontent.com/5788529/145096768-457fb826-8aac-4a02-ab94-b454f1356b49.png)


# Risk assessment
Low
