### PR TITLE
fix(app): display error and close run if protocol analysis is not-ok

### DIFF
--- a/app/src/App/__tests__/hooks.test.tsx
+++ b/app/src/App/__tests__/hooks.test.tsx
@@ -13,7 +13,7 @@ import {
 } from '../../redux/nav'
 import { getConnectedRobot } from '../../redux/discovery'
 import { useNavLocations, useRunLocation } from '../hooks'
-import { useCurrentProtocolRun } from '../../organisms/ProtocolUpload/hooks'
+import { useCloseCurrentRun } from '../../organisms/ProtocolUpload/hooks'
 
 import type { Store } from 'redux'
 import type { State } from '../../redux/types'
@@ -38,8 +38,8 @@ const mockGetDeckCalibrationOk = getDeckCalibrationOk as jest.MockedFunction<
 const mockGetNavbarLocations = getNavbarLocations as jest.MockedFunction<
   typeof getNavbarLocations
 >
-const mockUseCurrentProtocolRun = useCurrentProtocolRun as jest.MockedFunction<
-  typeof useCurrentProtocolRun
+const mockUseCloseCurrentRun = useCloseCurrentRun as jest.MockedFunction<
+  typeof useCloseCurrentRun
 >
 
 describe('useRunLocation', () => {
@@ -58,9 +58,9 @@ describe('useRunLocation', () => {
       mockGetConnectedRobotPipettesMatch.mockReturnValue(true)
       mockGetConnectedRobotPipettesCalibrated.mockReturnValue(true)
       mockGetDeckCalibrationOk.mockReturnValue(true)
-      mockUseCurrentProtocolRun.mockReturnValue({
-        protocolRecord: {},
-        runRecord: {},
+      mockUseCloseCurrentRun.mockReturnValue({
+        closeCurrentRun: () => null,
+        isProtocolRunLoaded: true,
       } as any)
     })
     afterEach(() => {
@@ -73,9 +73,9 @@ describe('useRunLocation', () => {
       expect(disabledReason).toBe('Please connect to a robot to proceed')
     })
     it('should tell user to load a protocol', () => {
-      mockUseCurrentProtocolRun.mockReturnValue({
-        protocolRecord: null,
-        runRecord: null,
+      mockUseCloseCurrentRun.mockReturnValue({
+        closeCurrentRun: () => null,
+        isProtocolRunLoaded: false,
       } as any)
       const { result } = renderHook(useRunLocation, { wrapper })
       const { disabledReason } = result.current
@@ -112,9 +112,9 @@ describe('useRunLocation', () => {
       mockGetConnectedRobotPipettesCalibrated.mockReturnValue(true)
       mockGetDeckCalibrationOk.mockReturnValue(true)
       mockGetNavbarLocations.mockReturnValue([0, 1, 2, 3, 4] as any)
-      mockUseCurrentProtocolRun.mockReturnValue({
-        protocolRecord: {},
-        runRecord: {},
+      mockUseCloseCurrentRun.mockReturnValue({
+        closeCurrentRun: () => null,
+        isProtocolRunLoaded: true,
       } as any)
       const { result } = renderHook(useNavLocations, { wrapper })
       expect(result.current.length).toBe(4)

--- a/app/src/App/hooks.ts
+++ b/app/src/App/hooks.ts
@@ -7,7 +7,7 @@ import {
   getDeckCalibrationOk,
 } from '../redux/nav'
 import { getConnectedRobot } from '../redux/discovery'
-import { useCurrentProtocolRun } from '../organisms/ProtocolUpload/hooks'
+import { useCloseCurrentRun } from '../organisms/ProtocolUpload/hooks'
 import { NavLocation } from '../redux/nav/types'
 
 export function useRunLocation(): NavLocation {
@@ -17,12 +17,11 @@ export function useRunLocation(): NavLocation {
   const pipettesCalibrated = useSelector(getConnectedRobotPipettesCalibrated)
   const deckCalOk = useSelector(getDeckCalibrationOk)
 
-  const { protocolRecord, runRecord } = useCurrentProtocolRun()
+  const { isProtocolRunLoaded } = useCloseCurrentRun()
 
   let disabledReason = null
   if (!robot) disabledReason = t('please_connect_to_a_robot')
-  else if (protocolRecord == null || runRecord == null)
-    disabledReason = t('please_load_a_protocol')
+  else if (!isProtocolRunLoaded) disabledReason = t('please_load_a_protocol')
   else if (!pipettesMatch) disabledReason = t('attached_pipettes_do_not_match')
   else if (!pipettesCalibrated) disabledReason = t('pipettes_not_calibrated')
   else if (!deckCalOk) disabledReason = t('calibrate_deck_to_proceed')

--- a/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
+++ b/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
@@ -93,7 +93,7 @@ describe('ProtocolUpload', () => {
       .mockReturnValue({} as any)
     when(mockUseCloseProtocolRun).calledWith().mockReturnValue({
       closeCurrentRun: jest.fn(),
-      isClosingCurrentRun: false,
+      isProtocolRunLoaded: true,
     })
   })
 
@@ -110,6 +110,10 @@ describe('ProtocolUpload', () => {
         runRecord: null,
         createProtocolRun: jest.fn(),
       } as any)
+    when(mockUseCloseProtocolRun).calledWith().mockReturnValue({
+      closeCurrentRun: jest.fn(),
+      isProtocolRunLoaded: false,
+    })
     mockGetConnectedRobotName.mockReturnValue(null)
     const { queryByText } = render()[0]
     expect(queryByText('Organization/Author')).toBeNull()
@@ -155,7 +159,7 @@ describe('ProtocolUpload', () => {
     const mockCloseCurrentRun = jest.fn()
     when(mockUseCloseProtocolRun).calledWith().mockReturnValue({
       closeCurrentRun: mockCloseCurrentRun,
-      isClosingCurrentRun: false,
+      isProtocolRunLoaded: true,
     })
 
     const [{ getByRole, getByText }] = render()
@@ -176,11 +180,16 @@ describe('ProtocolUpload', () => {
         runRecord: null,
         createProtocolRun: jest.fn(),
       } as any)
+    when(mockUseCloseProtocolRun).calledWith().mockReturnValue({
+      closeCurrentRun: jest.fn(),
+      isProtocolRunLoaded: false,
+    })
+
     const { getByText } = render()[0]
     getByText('Open a protocol to run on robotName')
   })
 
-  it('renders empty state input if the current run is being closed', () => {
+  it('renders empty state input if the current run is being closed or has a not-ok status', () => {
     getProtocolFile.mockReturnValue(withModulesProtocol as any)
     when(mockUseCurrentProtocolRun)
       .calledWith()
@@ -192,10 +201,42 @@ describe('ProtocolUpload', () => {
     const mockCloseCurrentRun = jest.fn()
     when(mockUseCloseProtocolRun).calledWith().mockReturnValue({
       closeCurrentRun: mockCloseCurrentRun,
-      isClosingCurrentRun: true,
+      isProtocolRunLoaded: false,
     })
 
     const [{ getByText }] = render()
     getByText('Open a protocol to run on robotName')
+  })
+
+  it('renders an error if protocol has a not-ok result', () => {
+    getProtocolFile.mockReturnValue(withModulesProtocol as any)
+    when(mockUseCurrentProtocolRun)
+      .calledWith()
+      .mockReturnValue({
+        protocolRecord: {
+          data: {
+            analyses: [
+              {
+                result: 'not-ok',
+                errors: [
+                  {
+                    detail: 'FAKE ERROR',
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        runRecord: {},
+        createProtocolRun: jest.fn(),
+      } as any)
+    const mockCloseCurrentRun = jest.fn()
+    when(mockUseCloseProtocolRun).calledWith().mockReturnValue({
+      closeCurrentRun: mockCloseCurrentRun,
+      isProtocolRunLoaded: false,
+    })
+
+    const [{ getByText }] = render()
+    getByText('FAKE ERROR')
   })
 })

--- a/app/src/organisms/ProtocolUpload/hooks/useCloseCurrentRun.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useCloseCurrentRun.ts
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {
   useStopRunMutation,
   useDismissCurrentRunMutation,
@@ -24,14 +25,14 @@ type CloseCallback = (options?: UseDismissCurrentRunMutationOptions) => void
 
 export function useCloseCurrentRun(): {
   closeCurrentRun: CloseCallback
-  isClosingCurrentRun: boolean
+  isProtocolRunLoaded: boolean
 } {
   const currentRunId = useCurrentRunId()
   const {
     dismissCurrentRun,
     isLoading: isDismissing,
   } = useDismissCurrentRunMutation()
-  const { runRecord } = useCurrentProtocolRun()
+  const { protocolRecord, runRecord } = useCurrentProtocolRun()
 
   const { stopRun } = useStopRunMutation()
   const { deleteRun } = useDeleteRunMutation()
@@ -62,5 +63,20 @@ export function useCloseCurrentRun(): {
       }
     }
   }
-  return { closeCurrentRun, isClosingCurrentRun: isDismissing }
+  const closeCurrentRunCallback = React.useCallback(closeCurrentRun, [
+    deleteRun,
+    dismissCurrentRun,
+    runRecord,
+    stopRun,
+    currentRunId,
+  ])
+  console.log(protocolRecord.data.analyses[0])
+  return {
+    closeCurrentRun: closeCurrentRunCallback,
+    isProtocolRunLoaded:
+      !isDismissing &&
+      runRecord != null &&
+      protocolRecord != null &&
+      protocolRecord.data.analyses[0].result !== 'not-ok',
+  }
 }

--- a/app/src/organisms/ProtocolUpload/hooks/useCloseCurrentRun.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useCloseCurrentRun.ts
@@ -70,13 +70,18 @@ export function useCloseCurrentRun(): {
     stopRun,
     currentRunId,
   ])
-  console.log(protocolRecord.data.analyses[0])
+
+  const analysisNotOk =
+    protocolRecord != null &&
+    'result' in protocolRecord.data?.analyses[0] &&
+    protocolRecord.data?.analyses[0]?.result === 'not-ok'
+
   return {
     closeCurrentRun: closeCurrentRunCallback,
     isProtocolRunLoaded:
       !isDismissing &&
       runRecord != null &&
       protocolRecord != null &&
-      protocolRecord.data.analyses[0].result !== 'not-ok',
+      !analysisNotOk,
   }
 }

--- a/app/src/organisms/ProtocolUpload/hooks/useCloseCurrentRun.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useCloseCurrentRun.ts
@@ -72,9 +72,9 @@ export function useCloseCurrentRun(): {
   ])
 
   const analysisNotOk =
-    protocolRecord != null &&
-    'result' in protocolRecord.data?.analyses[0] &&
-    protocolRecord.data?.analyses[0]?.result === 'not-ok'
+    protocolRecord?.data?.analyses[0] != null &&
+    'result' in protocolRecord.data.analyses[0] &&
+    protocolRecord.data.analyses[0].result === 'not-ok'
 
   return {
     closeCurrentRun: closeCurrentRunCallback,

--- a/app/src/organisms/ProtocolUpload/index.tsx
+++ b/app/src/organisms/ProtocolUpload/index.tsx
@@ -36,6 +36,7 @@ import type { ErrorObject } from 'ajv'
 import type { Dispatch, State } from '../../redux/types'
 
 import styles from './styles.css'
+import { protocol } from 'electron/main'
 
 const VALIDATION_ERROR_T_MAP: { [errorKey: string]: string } = {
   INVALID_FILE_TYPE: 'invalid_file_type',
@@ -65,7 +66,12 @@ export function ProtocolUpload(): JSX.Element {
   }
 
   React.useEffect(() => {
-    if (protocolRecord?.data?.analyses[0]?.result === 'not-ok') {
+    if (
+      protocolRecord != null &&
+      'result' in protocolRecord?.data?.analyses[0] &&
+      protocolRecord?.data?.analyses[0]?.result === 'not-ok'
+    ) {
+      console.log(protocolRecord?.data.analyses[0].errors[0])
       setUploadError([
         VALIDATION_ERROR_T_MAP.ANALYSIS_ERROR,
         protocolRecord?.data.analyses[0].errors[0].detail as string,

--- a/app/src/organisms/ProtocolUpload/index.tsx
+++ b/app/src/organisms/ProtocolUpload/index.tsx
@@ -36,7 +36,6 @@ import type { ErrorObject } from 'ajv'
 import type { Dispatch, State } from '../../redux/types'
 
 import styles from './styles.css'
-import { protocol } from 'electron/main'
 
 const VALIDATION_ERROR_T_MAP: { [errorKey: string]: string } = {
   INVALID_FILE_TYPE: 'invalid_file_type',
@@ -67,11 +66,10 @@ export function ProtocolUpload(): JSX.Element {
 
   React.useEffect(() => {
     if (
-      protocolRecord != null &&
-      'result' in protocolRecord?.data?.analyses[0] &&
-      protocolRecord?.data?.analyses[0]?.result === 'not-ok'
+      protocolRecord?.data?.analyses[0] != null &&
+      'result' in protocolRecord.data.analyses[0] &&
+      protocolRecord.data.analyses[0].result === 'not-ok'
     ) {
-      console.log(protocolRecord?.data.analyses[0].errors[0])
       setUploadError([
         VALIDATION_ERROR_T_MAP.ANALYSIS_ERROR,
         protocolRecord?.data.analyses[0].errors[0].detail as string,

--- a/app/src/organisms/RunDetails/__tests__/RunDetails.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/RunDetails.test.tsx
@@ -15,14 +15,14 @@ import { i18n } from '../../../i18n'
 import { CommandList } from '../CommandList'
 import { useProtocolDetails } from '../hooks'
 import { useRunStatus } from '../../RunTimeControl/hooks'
-import { useCurrentProtocolRun } from '../../ProtocolUpload/hooks/useCurrentProtocolRun'
+import { useCloseCurrentRun } from '../../ProtocolUpload/hooks/useCloseCurrentRun'
 import _uncastedSimpleV6Protocol from '@opentrons/shared-data/protocol/fixtures/6/simpleV6.json'
 import type { ProtocolFile } from '@opentrons/shared-data'
 
 jest.mock('../hooks')
 jest.mock('../CommandList')
 jest.mock('../../RunTimeControl/hooks')
-jest.mock('../../ProtocolUpload/hooks/useCurrentProtocolRun')
+jest.mock('../../ProtocolUpload/hooks/useCloseCurrentRun')
 
 const mockUseProtocolDetails = useProtocolDetails as jest.MockedFunction<
   typeof useProtocolDetails
@@ -33,8 +33,8 @@ const mockUseRunStatus = useRunStatus as jest.MockedFunction<
   typeof useRunStatus
 >
 
-const mockUseCurrentProtocolRun = useCurrentProtocolRun as jest.MockedFunction<
-  typeof useCurrentProtocolRun
+const mockUseCloseCurrentRun = useCloseCurrentRun as jest.MockedFunction<
+  typeof useCloseCurrentRun
 >
 
 const simpleV6Protocol = (_uncastedSimpleV6Protocol as unknown) as ProtocolFile<{}>
@@ -57,12 +57,11 @@ describe('RunDetails', () => {
       displayName: 'mock display name',
     })
     when(mockCommandList).mockReturnValue(<div>Mock Command List</div>)
-    when(mockUseCurrentProtocolRun)
+    when(mockUseCloseCurrentRun)
       .calledWith()
       .mockReturnValue({
-        protocolRecord: { data: { analyses: [] } },
-        runRecord: {},
-        createProtocolRun: jest.fn(),
+        isProtocolRunLoaded: false,
+        closeCurrentRun: jest.fn(),
       } as any)
   })
 

--- a/app/src/organisms/RunDetails/index.tsx
+++ b/app/src/organisms/RunDetails/index.tsx
@@ -24,7 +24,6 @@ import { useRunStatus, useRunStartTime } from '../RunTimeControl/hooks'
 import { ConfirmCancelModal } from '../../pages/Run/RunLog'
 import { ConfirmExitProtocolUploadModal } from '../ProtocolUpload/ConfirmExitProtocolUploadModal'
 import { useCloseCurrentRun } from '../ProtocolUpload/hooks/useCloseCurrentRun'
-import { useCurrentProtocolRun } from '../ProtocolUpload/hooks'
 import { useCurrentRunControls } from '../../pages/Run/RunLog/hooks'
 import { CommandList } from './CommandList'
 
@@ -33,10 +32,9 @@ import styles from '../ProtocolUpload/styles.css'
 export function RunDetails(): JSX.Element | null {
   const { t } = useTranslation(['run_details', 'shared'])
   const { displayName } = useProtocolDetails()
-  const { protocolRecord, runRecord } = useCurrentProtocolRun()
   const runStatus = useRunStatus()
   const startTime = useRunStartTime()
-  const { closeCurrentRun } = useCloseCurrentRun()
+  const { closeCurrentRun, isProtocolRunLoaded } = useCloseCurrentRun()
 
   // display an idle status as 'running' in the UI after a run has started
   const adjustedRunStatus: RunStatus | null =
@@ -67,7 +65,7 @@ export function RunDetails(): JSX.Element | null {
     cancel: cancelCloseExit,
   } = useConditionalConfirm(handleCloseProtocol, true)
 
-  if (protocolRecord == null || runRecord == null) {
+  if (isProtocolRunLoaded) {
     return <Redirect to="/upload" />
   }
 

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -384,6 +384,13 @@ export interface LoadedLabware {
     slot: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12
   }
 }
+interface AnalysisError {
+  id: string
+  detail: string
+  errorType: string
+  createdAt: string
+}
+
 export interface CompletedProtocolAnalysis {
   id: string
   status?: 'completed'
@@ -391,7 +398,7 @@ export interface CompletedProtocolAnalysis {
   pipettes: LoadedPipette[]
   labware: LoadedLabware[]
   commands: Command[]
-  errors: string[]
+  errors: AnalysisError[]
 }
 
 export interface ResourceFile {


### PR DESCRIPTION
fix #8984

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
If a protocol analysis result is `not-ok` we should display the error and close the protocol run.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

1. Display error if protocol run is not-ok
2. Add `isProtocolRunLoaded` boolean as return value to `useCloseCurrentRun`
3. use `isProtocolRunLoaded` in relevant places

# Review requests

<!--
Describe any requests for your reviewers here.
-->
Upload a protocol that will fail analysis and make sure:
- [ ]  error appears as expected
- [ ] you return to the empty protocol state
- [ ] the run tab is still disabled

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Low