### PR TITLE
refactor(engine): report stopped when hardware is stopped

### DIFF
--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -281,10 +281,7 @@ class CommandView(HasState[CommandState]):
 
     def get_is_stopped(self) -> bool:
         """Get whether an engine stop has completed."""
-        return self._state.should_stop and not any(
-            c.status == CommandStatus.RUNNING
-            for c in self._state.commands_by_id.values()
-        )
+        return self._state.is_hardware_stopped
 
     # TODO(mc, 2021-12-07): reject adding commands to a stopped engine
     def validate_action_allowed(self, action: Union[PlayAction, PauseAction]) -> None:

--- a/api/tests/opentrons/protocol_engine/state/test_command_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view.py
@@ -244,31 +244,10 @@ def test_get_should_stop() -> None:
 
 def test_get_is_stopped() -> None:
     """It should return true if stop requested and no command running."""
-    completed_command = create_completed_command(command_id="command-id-1")
-    running_command = create_running_command(command_id="command-id-2")
-    pending_command = create_pending_command(command_id="command-id-3")
-    failed_command = create_failed_command(command_id="command-id-4")
-
-    subject = get_command_view(
-        should_stop=False,
-        commands_by_id=(),
-    )
+    subject = get_command_view(is_hardware_stopped=False)
     assert subject.get_is_stopped() is False
 
-    subject = get_command_view(
-        should_stop=True,
-        commands_by_id=[("command-id-2", running_command)],
-    )
-    assert subject.get_is_stopped() is False
-
-    subject = get_command_view(
-        should_stop=True,
-        commands_by_id=[
-            ("command-id-1", completed_command),
-            ("command-id-3", pending_command),
-            ("command-id-4", failed_command),
-        ],
-    )
+    subject = get_command_view(is_hardware_stopped=True)
     assert subject.get_is_stopped() is True
 
 


### PR DESCRIPTION
## Overview

I believe this fixes #9003.

## Changelog

Report engine stopped when hardware is stopped. This `get_is_stopped` selector is what allows certain actions (like un-currenting a run) to proceed in `/runs` controllers.

## Review requests

Try (and hopefully fail) to reproduce #9003

## Risk assessment

Low! The hardware stopped flag is a lot more reliable than the status of commands for determining this logic.
