### PR TITLE
refactor(app): update Error message in Run Failed banner and tooltip

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -84,7 +84,7 @@
   "loading_labware_offsets": "Loading labware offsets",
   "protocol_upload_revamp_feedback": "Have feedback about this experience?",
   "feedback_form_link": "Let us know!",
-  "labware_position_check_not_available": "Labware Position Check is not available once a run has started",
+  "labware_position_check_not_available": "Labware Position Check is not available after run has started",
   "recalibrating_tip_length_not_available": "Recalibrating a tip length is not available once a run has started",
   "recalibrating_not_available": "Recalibrating Tip Length calibrations and Labware Position Check is not available.",
   "protocol_can_be_closed": "This protocol can now be closed.",

--- a/app/src/organisms/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/organisms/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -89,8 +89,7 @@ describe('ProtocolSetup', () => {
   it('renders a protocol run failed banner when run is failed', () => {
     mockUseRunStatus.mockReturnValue(RUN_STATUS_FAILED)
     const { queryByText } = render()
-    const bannerText =
-      'Protocol run failed. Recalibrating Tip Length calibrations and Labware Position Check is not available.'
+    const bannerText = 'Protocol run failed.'
     expect(queryByText(bannerText)).toBeTruthy()
   })
   it('renders a protocol run canceled banner when a run stop is requested', () => {

--- a/app/src/organisms/ProtocolSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/index.tsx
@@ -56,9 +56,7 @@ export function ProtocolSetup(): JSX.Element {
     alertTitle = `${t('protocol_run_complete')} ${t('protocol_can_be_closed')}`
   } else if (runStatus === RUN_STATUS_FAILED) {
     alertType = 'error'
-    alertTitle = `${t('protocol_run_failed')} ${t(
-      'recalibrating_not_available'
-    )}`
+    alertTitle = `${t('protocol_run_failed')} `
   } else if (
     runStatus === RUN_STATUS_STOPPED ||
     runStatus === RUN_STATUS_STOP_REQUESTED


### PR DESCRIPTION
closes #9008

# Overview

This PR changes the text on the `Protocol run failed` banner in the accordion steps as well as updates the tooltip text when the LPC button is disabled when the run is in progress

# Changelog

- updates tooltip and banner text

# Review requests

- review AC and figma. 

Here is a picture of the banner:
<img width="960" alt="Screen Shot 2021-12-08 at 13 07 30" src="https://user-images.githubusercontent.com/66035149/145260716-d09e7fd4-fb12-4e4c-b93a-fcd9c2c5b61c.png">

Here is a picture of the tooltip: 
<img width="567" alt="Screen Shot 2021-12-08 at 13 10 24" src="https://user-images.githubusercontent.com/66035149/145261066-1abf3a5f-263f-41dc-8e92-bab96c53f5e9.png">


# Risk assessment
 low, behind ff
