### PR TITLE
refactor(engine): ensure IDs of legacy command errors are mapped correctly

### DIFF
--- a/api/src/opentrons/commands/types.py
+++ b/api/src/opentrons/commands/types.py
@@ -572,7 +572,7 @@ MessageSequenceId = Union[Literal["before"], Literal["after"]]
 
 CommandMessageFields = TypedDict(
     "CommandMessageFields",
-    {"$": MessageSequenceId, "error": Optional[Exception]},
+    {"$": MessageSequenceId, "id": str, "error": Optional[Exception]},
 )
 
 

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -92,10 +92,11 @@ class LegacyCommandMapper:
         """
         command_type = command["name"]
         command_error = command["error"]
-        broker_id = command["id"]
         stage = command["$"]
+        # TODO(mc, 2021-12-08): use message ID as command ID directly once
+        # https://github.com/Opentrons/opentrons/issues/8986 is resolved
+        broker_id = command["id"]
 
-        command_id = f"{command_type}-0"
         now = ModelUtils.get_timestamp()
 
         if stage == "before":

--- a/api/tests/opentrons/commands/test_publisher.py
+++ b/api/tests/opentrons/commands/test_publisher.py
@@ -33,11 +33,15 @@ def test_publish_decorator(decoy: Decoy, broker: Broker) -> None:
     subject = _Subject(broker=broker)
     subject.act("hello", 42)
 
+    before_message_id = matchers.Captor()
+    after_message_id = matchers.Captor()
+
     decoy.verify(
         broker.publish(
             topic="command",
             message={
                 "$": "before",
+                "id": before_message_id,
                 "name": "some_command",
                 "payload": {"foo": "hello", "bar": 42},
                 "error": None,
@@ -48,12 +52,15 @@ def test_publish_decorator(decoy: Decoy, broker: Broker) -> None:
             topic="command",
             message={
                 "$": "after",
+                "id": after_message_id,
                 "name": "some_command",
                 "payload": {"foo": "hello", "bar": 42},
                 "error": None,
             },
         ),
     )
+
+    assert before_message_id.value == after_message_id.value
 
 
 def test_publish_decorator_with_arg_defaults(decoy: Decoy, broker: Broker) -> None:
@@ -79,6 +86,7 @@ def test_publish_decorator_with_arg_defaults(decoy: Decoy, broker: Broker) -> No
             topic="command",
             message={
                 "$": "before",
+                "id": matchers.IsA(str),
                 "name": "some_command",
                 "payload": {"foo": "hello", "bar": 42},
                 "error": None,
@@ -89,6 +97,7 @@ def test_publish_decorator_with_arg_defaults(decoy: Decoy, broker: Broker) -> No
             topic="command",
             message={
                 "$": "after",
+                "id": matchers.IsA(str),
                 "name": "some_command",
                 "payload": {"foo": "hello", "bar": 42},
                 "error": None,
@@ -113,11 +122,15 @@ def test_publish_decorator_with_error(decoy: Decoy, broker: Broker) -> None:
     with pytest.raises(RuntimeError, match="oh no"):
         subject.act("hello", 42)
 
+    before_message_id = matchers.Captor()
+    after_message_id = matchers.Captor()
+
     decoy.verify(
         broker.publish(
             topic="command",
             message={
                 "$": "before",
+                "id": before_message_id,
                 "name": "some_command",
                 "payload": {"foo": "hello", "bar": 42},
                 "error": None,
@@ -127,12 +140,15 @@ def test_publish_decorator_with_error(decoy: Decoy, broker: Broker) -> None:
             topic="command",
             message={
                 "$": "after",
+                "id": after_message_id,
                 "name": "some_command",
                 "payload": {"foo": "hello", "bar": 42},
                 "error": matchers.IsA(RuntimeError),
             },
         ),
     )
+
+    assert before_message_id.value == after_message_id.value
 
 
 def test_publish_decorator_remaps_instrument(decoy: Decoy, broker: Broker) -> None:
@@ -161,6 +177,7 @@ def test_publish_decorator_remaps_instrument(decoy: Decoy, broker: Broker) -> No
             topic="command",
             message={
                 "$": "before",
+                "id": matchers.IsA(str),
                 "name": "some_command",
                 "payload": {"foo": "hello", "bar": 42},
                 "error": None,
@@ -171,6 +188,7 @@ def test_publish_decorator_remaps_instrument(decoy: Decoy, broker: Broker) -> No
             topic="command",
             message={
                 "$": "after",
+                "id": matchers.IsA(str),
                 "name": "some_command",
                 "payload": {"foo": "hello", "bar": 42},
                 "error": None,
@@ -193,11 +211,15 @@ def test_publish_context(decoy: Decoy, broker: Broker) -> None:
     with publish_context(broker=broker, command=command):
         _published_func("hello", 42)
 
+    before_message_id = matchers.Captor()
+    after_message_id = matchers.Captor()
+
     decoy.verify(
         broker.publish(
             topic="command",
             message={
                 "$": "before",
+                "id": before_message_id,
                 "name": "some_command",
                 "payload": {"foo": "hello", "bar": 42},
                 "error": None,
@@ -208,12 +230,15 @@ def test_publish_context(decoy: Decoy, broker: Broker) -> None:
             topic="command",
             message={
                 "$": "after",
+                "id": after_message_id,
                 "name": "some_command",
                 "payload": {"foo": "hello", "bar": 42},
                 "error": None,
             },
         ),
     )
+
+    assert before_message_id.value == after_message_id.value
 
 
 def test_publish_context_with_error(decoy: Decoy, broker: Broker) -> None:
@@ -229,11 +254,15 @@ def test_publish_context_with_error(decoy: Decoy, broker: Broker) -> None:
         with publish_context(broker=broker, command=command):
             _published_func("hello", 42)
 
+    before_message_id = matchers.Captor()
+    after_message_id = matchers.Captor()
+
     decoy.verify(
         broker.publish(
             topic="command",
             message={
                 "$": "before",
+                "id": before_message_id,
                 "name": "some_command",
                 "payload": {"foo": "hello", "bar": 42},
                 "error": None,
@@ -243,9 +272,12 @@ def test_publish_context_with_error(decoy: Decoy, broker: Broker) -> None:
             topic="command",
             message={
                 "$": "after",
+                "id": after_message_id,
                 "name": "some_command",
                 "payload": {"foo": "hello", "bar": 42},
                 "error": matchers.IsA(RuntimeError),
             },
         ),
     )
+
+    assert before_message_id.value == after_message_id.value

--- a/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
@@ -162,6 +162,7 @@ async def test_main_broker_messages(
 
     legacy_command: PauseMessage = {
         "$": "before",
+        "id": "message-id",
         "name": "command.PAUSE",
         "payload": {"userMessage": "hello", "text": "hello"},
         "error": None,


### PR DESCRIPTION
## Overview

Fixes #9021

## Changelog

- Generate a unique ID per broker `before`/`after` pair to ensure unambiguous linking
- Do not hardcode the command ID of failed commands to `{command_type}-0` 🙈 

## Review requests

Create a protocol where:

- A command of one type succeeds
- Then later, a command *of the same type* fails

The error should be attached to the later command, not the first command

## Risk assessment

Low, fixes a very silly bug and makes broker command > PE command identity linking explicit rather than a weird, stack based inference thing.
