### PR TITLE
refactor(app): show exit button on LPC robot motion and confirm tip p…

### DIFF
--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/ConfirmPickUpTipModal.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/ConfirmPickUpTipModal.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react'
 import {
-  BaseModal,
-  BORDER_RADIUS_1,
   C_BLUE,
   C_WHITE,
   DIRECTION_COLUMN,
@@ -11,7 +9,6 @@ import {
   JUSTIFY_FLEX_END,
   NewPrimaryBtn,
   NewSecondaryBtn,
-  OVERLAY_BLACK_90,
   SPACING_1,
   SPACING_3,
   SPACING_5,
@@ -29,44 +26,42 @@ export const ConfirmPickUpTipModal = (props: Props): JSX.Element => {
   const { t } = useTranslation(['labware_position_check'])
 
   return (
-    <BaseModal borderRadius={BORDER_RADIUS_1} overlayColor={OVERLAY_BLACK_90}>
-      <Flex flexDirection={DIRECTION_COLUMN}>
-        <Text
-          as={'h4'}
-          textTransform={TEXT_TRANSFORM_UPPERCASE}
-          fontWeight={FONT_WEIGHT_SEMIBOLD}
-          marginBottom={SPACING_3}
-          marginLeft={SPACING_1}
-        >
-          {t('confirm_pick_up_tip_modal_title')}
-        </Text>
-        <Flex
-          flexDirection={DIRECTION_ROW}
-          justifyContent={JUSTIFY_FLEX_END}
-          paddingTop={SPACING_5}
-        >
-          <Flex paddingRight={SPACING_3}>
-            <NewSecondaryBtn
-              onClick={props.onDeny}
-              width={'auto'}
-              backgroundColor={C_WHITE}
-              color={C_BLUE}
-              id={'ConfirmPickUpTipModal_Deny'}
-            >
-              {t('confirm_pick_up_tip_modal_try_again_text')}
-            </NewSecondaryBtn>
-          </Flex>
-          <NewPrimaryBtn
-            onClick={props.onConfirm}
+    <Flex flexDirection={DIRECTION_COLUMN}>
+      <Text
+        as={'h4'}
+        textTransform={TEXT_TRANSFORM_UPPERCASE}
+        fontWeight={FONT_WEIGHT_SEMIBOLD}
+        marginBottom={SPACING_3}
+        marginLeft={SPACING_1}
+      >
+        {t('confirm_pick_up_tip_modal_title')}
+      </Text>
+      <Flex
+        flexDirection={DIRECTION_ROW}
+        justifyContent={JUSTIFY_FLEX_END}
+        paddingTop={SPACING_5}
+      >
+        <Flex paddingRight={SPACING_3}>
+          <NewSecondaryBtn
+            onClick={props.onDeny}
             width={'auto'}
-            backgroundColor={C_BLUE}
-            color={C_WHITE}
+            backgroundColor={C_WHITE}
+            color={C_BLUE}
             id={'ConfirmPickUpTipModal_Deny'}
           >
-            {props.confirmText}
-          </NewPrimaryBtn>
+            {t('confirm_pick_up_tip_modal_try_again_text')}
+          </NewSecondaryBtn>
         </Flex>
+        <NewPrimaryBtn
+          onClick={props.onConfirm}
+          width={'auto'}
+          backgroundColor={C_BLUE}
+          color={C_WHITE}
+          id={'ConfirmPickUpTipModal_Deny'}
+        >
+          {props.confirmText}
+        </NewPrimaryBtn>
       </Flex>
-    </BaseModal>
+    </Flex>
   )
 }

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/RobotMotionLoadingModal.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/RobotMotionLoadingModal.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next'
 import {
   Flex,
   Icon,
-  Modal,
   Text,
   SPACING_2,
   SPACING_3,
@@ -20,7 +19,6 @@ import {
   FONT_SIZE_DEFAULT,
   JUSTIFY_SPACE_BETWEEN,
 } from '@opentrons/components'
-import styles from '../styles.css'
 
 interface RobotMotionLoadingModalProps {
   title: string
@@ -32,7 +30,7 @@ export const RobotMotionLoadingModal = (
   const { t } = useTranslation('labware_position_check')
 
   return (
-    <Modal className={styles.modal} contentsClassName={styles.modal_contents}>
+    <>
       <Text
         as={'h3'}
         marginBottom={SPACING_3}
@@ -74,6 +72,6 @@ export const RobotMotionLoadingModal = (
           </Text>
         </Flex>
       </Flex>
-    </Modal>
+    </>
   )
 }

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/ConfirmPickUpTipModal.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/ConfirmPickUpTipModal.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { resetAllWhenMocks } from 'jest-when'
-import { BaseModal, renderWithProviders } from '@opentrons/components'
+import { ModalPage, renderWithProviders } from '@opentrons/components'
 import { ConfirmPickUpTipModal } from '../ConfirmPickUpTipModal'
 import { i18n } from '../../../../i18n'
 
@@ -8,16 +8,25 @@ jest.mock('@opentrons/components', () => {
   const actualComponents = jest.requireActual('@opentrons/components')
   return {
     ...actualComponents,
-    BaseModal: jest.fn(() => <div></div>),
+    ModalPage: jest.fn(() => <div></div>),
   }
 })
 
-const mockBaseModal = BaseModal as jest.MockedFunction<typeof BaseModal>
+const mockModalPage = ModalPage as jest.MockedFunction<typeof ModalPage>
 
 const render = (props: React.ComponentProps<typeof ConfirmPickUpTipModal>) => {
-  return renderWithProviders(<ConfirmPickUpTipModal {...props} />, {
-    i18nInstance: i18n,
-  })[0]
+  return renderWithProviders(
+    <ModalPage
+      titleBar={{
+        title: 'modal page title',
+      }}
+    >
+      <ConfirmPickUpTipModal {...props} />
+    </ModalPage>,
+    {
+      i18nInstance: i18n,
+    }
+  )[0]
 }
 
 describe('ConfirmPickUpTipModal', () => {
@@ -29,7 +38,7 @@ describe('ConfirmPickUpTipModal', () => {
       onDeny: jest.fn(),
       confirmText: 'confirm text',
     }
-    mockBaseModal.mockReturnValue(<div>mock alert item</div>)
+    mockModalPage.mockReturnValue(<div>mock alert item</div>)
   })
   afterEach(() => {
     resetAllWhenMocks()

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
@@ -114,7 +114,21 @@ export const LabwarePositionCheck = (
 
   let modalContent: JSX.Element
   if (isLoading) {
-    modalContent = <RobotMotionLoadingModal title={titleText} />
+    modalContent = (
+      <ModalPage
+        contentsClassName={styles.modal_contents}
+        titleBar={{
+          title: t('labware_position_check_title'),
+          back: {
+            onClick: confirmExitLPC,
+            title: t('shared:exit'),
+            children: t('shared:exit'),
+          },
+        }}
+      >
+        <RobotMotionLoadingModal title={titleText} />
+      </ModalPage>
+    )
   } else if (showConfirmation) {
     modalContent = (
       <ExitPreventionModal
@@ -124,11 +138,23 @@ export const LabwarePositionCheck = (
     )
   } else if (showPickUpTipConfirmationModal) {
     modalContent = (
-      <ConfirmPickUpTipModal
-        confirmText={ctaText}
-        onConfirm={proceed}
-        onDeny={onUnsuccessfulPickUpTip}
-      />
+      <ModalPage
+        contentsClassName={styles.modal_contents}
+        titleBar={{
+          title: t('labware_position_check_title'),
+          back: {
+            onClick: confirmExitLPC,
+            title: t('shared:exit'),
+            children: t('shared:exit'),
+          },
+        }}
+      >
+        <ConfirmPickUpTipModal
+          confirmText={ctaText}
+          onConfirm={proceed}
+          onDeny={onUnsuccessfulPickUpTip}
+        />
+      </ModalPage>
     )
   } else if (isComplete) {
     modalContent = (


### PR DESCRIPTION

# Overview

This PR adds the ModalPage wrapper to the RobotMotionLoadingModal and ConfirmPickUpTipModal

<img width="1016" alt="Screen Shot 2021-12-08 at 1 30 55 PM" src="https://user-images.githubusercontent.com/14794021/145266580-2d916561-0bed-47b8-98e0-561122fe1aa7.png">

<img width="1021" alt="Screen Shot 2021-12-08 at 1 31 51 PM" src="https://user-images.githubusercontent.com/14794021/145266601-e548b000-8d7c-481c-9db6-4ab14f4bda92.png">

closes #9009

# Changelog

- Wrapped the `RobotMotionLoadingModal` and `ConfirmPickUpTipModal` with `ModalPage` in LPC.
- Updated corresponding test for `ConfirmPickUpTipModal`
 
# Review requests

- Check that the Exit button and title are showing when the `RobotMotionLoadingModal` and `ConfirmPickUpTipModal` are displayed.

# Risk assessment
low
