### PR TITLE
 refactor(app): lPC intro screen overflow

### DIFF
--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/DeckMap.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/DeckMap.tsx
@@ -17,7 +17,7 @@ import standardDeckDef from '@opentrons/shared-data/deck/definitions/2/ot2_stand
 import { useModuleRenderInfoById, useLabwareRenderInfoById } from '../hooks'
 import styles from '../styles.css'
 
-const DECK_MAP_VIEWBOX = '-80 -100 550 560'
+const DECK_MAP_VIEWBOX = '-80 -20 550 460'
 const DECK_LAYER_BLOCKLIST = [
   'calibrationMarkings',
   'fixedBase',
@@ -103,9 +103,9 @@ export const DeckMap = (props: DeckMapProps): JSX.Element | null => {
                             <circle
                               cx="0"
                               cy="0"
-                              r={260}
+                              r={230}
                               fill={C_WHITE}
-                              transform={`translate(270,265)`}
+                              transform={`translate(273,235)`}
                               data-testid={`DeckMap_module_${nestedLabwareId}_whiteBackground`}
                             />
                             <Icon
@@ -148,9 +148,9 @@ export const DeckMap = (props: DeckMapProps): JSX.Element | null => {
                       <circle
                         cx="0"
                         cy="0"
-                        r={260}
+                        r={230}
                         fill={C_WHITE}
-                        transform={`translate(270,265)`}
+                        transform={`translate(273,235)`}
                         data-testid={`DeckMap_${labwareId}_whiteBackground`}
                       />
                       <Icon

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/GenericStepScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/GenericStepScreen.tsx
@@ -61,7 +61,7 @@ export const GenericStepScreen = (
               completedSections={completedSections}
             />
           </Flex>
-          <Flex justifyContent={JUSTIFY_CENTER}>
+          <Flex justifyContent={JUSTIFY_CENTER} paddingTop={SPACING_3}>
             <DeckMap
               labwareIdsToHighlight={labwareIdsToHighlight}
               completedLabwareIdSections={

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/IntroScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/IntroScreen.tsx
@@ -14,7 +14,6 @@ import {
   ALIGN_CENTER,
   SPACING_2,
   SPACING_3,
-  SPACING_4,
   FONT_SIZE_BODY_2,
   SPACING_6,
 } from '@opentrons/components'

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/IntroScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/IntroScreen.tsx
@@ -87,11 +87,11 @@ export const IntroScreen = (props: {
             secondaryPipetteMount={secondaryPipetteMount}
           />
         </Flex>
-        <Box width="60%" padding={SPACING_3}>
+        <Box width="60%" padding={SPACING_2}>
           <DeckMap labwareIdsToHighlight={labwareIdsToHighlight} />
         </Box>
       </Flex>
-      <Flex justifyContent={JUSTIFY_CENTER} marginBottom={SPACING_4}>
+      <Flex justifyContent={JUSTIFY_CENTER} marginBottom={SPACING_3}>
         <NewPrimaryBtn
           title={t('start_position_check', {
             initial_labware_slot: firstTiprackSlot,

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
@@ -10,6 +10,7 @@ import {
   JUSTIFY_START,
   NewPrimaryBtn,
   SPACING_3,
+  SPACING_1,
   SPACING_4,
   Text,
   TEXT_TRANSFORM_UPPERCASE,
@@ -83,14 +84,17 @@ export const SummaryScreen = (props: {
       </Text>
       <Flex justifyContent={JUSTIFY_START} alignItems={ALIGN_START}>
         <Flex flex={'1 1 10%'} flexDirection={DIRECTION_COLUMN}>
-          <SectionList
-            primaryPipetteMount={primaryPipetteMount}
-            secondaryPipetteMount={secondaryPipetteMount}
-            sections={sections}
-            completedSections={sections}
-          />
-
-          <DeckMap completedLabwareIdSections={labwareIds} />
+          <Flex paddingLeft={SPACING_3}>
+            <SectionList
+              primaryPipetteMount={primaryPipetteMount}
+              secondaryPipetteMount={secondaryPipetteMount}
+              sections={sections}
+              completedSections={sections}
+            />
+          </Flex>
+          <Flex paddingTop={SPACING_1}>
+            <DeckMap completedLabwareIdSections={labwareIds} />
+          </Flex>
         </Flex>
         <Flex flex={'1 1 45%'}>
           <LabwareOffsetsSummary offsetData={labwareOffsets} />

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
@@ -10,7 +10,7 @@ import {
   JUSTIFY_START,
   NewPrimaryBtn,
   SPACING_3,
-  SPACING_1,
+  SPACING_2,
   SPACING_4,
   Text,
   TEXT_TRANSFORM_UPPERCASE,
@@ -84,7 +84,7 @@ export const SummaryScreen = (props: {
       </Text>
       <Flex justifyContent={JUSTIFY_START} alignItems={ALIGN_START}>
         <Flex flex={'1 1 10%'} flexDirection={DIRECTION_COLUMN}>
-          <Flex paddingLeft={SPACING_3}>
+          <Flex paddingLeft={SPACING_4}>
             <SectionList
               primaryPipetteMount={primaryPipetteMount}
               secondaryPipetteMount={secondaryPipetteMount}
@@ -92,7 +92,7 @@ export const SummaryScreen = (props: {
               completedSections={sections}
             />
           </Flex>
-          <Flex paddingTop={SPACING_1}>
+          <Flex paddingTop={SPACING_2}>
             <DeckMap completedLabwareIdSections={labwareIds} />
           </Flex>
         </Flex>


### PR DESCRIPTION
closes # 8958

# Overview

This PR fixes the styling on the intro screen in LPC so you don't have to scroll down to press the button, even when the offset banner is shown.
<img width="978" alt="Screen Shot 2021-12-08 at 13 30 22" src="https://user-images.githubusercontent.com/66035149/145266804-933ea917-0482-4375-8788-758edc8ed682.png">

<img width="981" alt="Screen Shot 2021-12-08 at 13 30 44" src="https://user-images.githubusercontent.com/66035149/145266853-394bb418-6039-45f2-8b10-7bc74bc25004.png">

# Changelog

- I changed the deckmap viewbox so I had to tweak the `genericStepScreen` and `summaryScreen` components a bit as well. 

This is how `genericStepScreen` looks: 
<img width="970" alt="Screen Shot 2021-12-08 at 13 38 58" src="https://user-images.githubusercontent.com/66035149/145267209-4ba86602-a648-4685-8e6e-02ece821e1aa.png">

This is how `summaryScreen` looks:
<img width="978" alt="Screen Shot 2021-12-08 at 14 00 11" src="https://user-images.githubusercontent.com/66035149/145267821-2a78d469-0aa5-45e3-9eb8-6445c78bfca4.png">

# Review requests

- make sure it matches figma and test on a robot. Also review code to make sure there isn't unnecessary styling

# Risk assessment

low, behind ff
