### PR TITLE
refactor(app, react-api-client, shared-data): add conditional protocol resource polling

### DIFF
--- a/react-api-client/src/protocols/useProtocolQuery.ts
+++ b/react-api-client/src/protocols/useProtocolQuery.ts
@@ -4,18 +4,32 @@ import { useHost } from '../api'
 import type { HostConfig, Protocol } from '@opentrons/api-client'
 import type { UseQueryOptions } from 'react-query'
 
+const POLLING_INTERVAL = 1000
+
 export function useProtocolQuery(
   protocolId: string | null,
-  options?: UseQueryOptions<Protocol | null>
+  options?: UseQueryOptions<Protocol | null>,
+  enablePolling?: boolean
 ): UseQueryResult<Protocol | null> {
   const host = useHost()
+  const allOptions: UseQueryOptions<Protocol | null> = {
+    ...options,
+    enabled:
+      host !== null &&
+      protocolId !== null &&
+      (enablePolling == null || enablePolling),
+    refetchInterval:
+      enablePolling != null
+        ? options?.refetchInterval ?? POLLING_INTERVAL
+        : false,
+  }
   const query = useQuery(
     [host, 'protocols', protocolId],
     () =>
       getProtocol(host as HostConfig, protocolId as string).then(
         response => response.data
       ),
-    { enabled: host !== null && protocolId !== null, ...options }
+    allOptions
   )
 
   return query

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -410,7 +410,7 @@ export interface ProtocolResource {
   createdAt: string
   protocolType: 'json' | 'python'
   metadata: ProtocolMetadata
-  analyses: PendingProtocolAnalysis[] | CompletedProtocolAnalysis[]
+  analyses: Array<PendingProtocolAnalysis | CompletedProtocolAnalysis>
   files: ResourceFile[]
 }
 


### PR DESCRIPTION
# Overview

This PR adds conditional polling to the protocol resource while analysis is pending. Once analysis is complete, we stop polling as it's no longer necessary. 

Closes #9034

# Changelog
- Add conditional protocol resource polling

# Review requests
Upload a protocol, inspect your network tab, you should see a poll every 1 second to the protocol endpoint (after the protocol resource is created)

This also means that you should no longer end up in a state where the loading spinner runs indefinitely, and you should't have to click around for it to go away

# Risk assessment
Low