### PR TITLE
refactor(react-api-client): disable window focus refetch

### DIFF
--- a/react-api-client/src/api/ApiClientProvider.tsx
+++ b/react-api-client/src/api/ApiClientProvider.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react'
 import { QueryClient, QueryClientProvider } from 'react-query'
 
-const queryClient = new QueryClient()
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+    },
+  },
+})
 
 export interface ApiClientProviderProps {
   children?: React.ReactNode


### PR DESCRIPTION
# Overview

this should eliminate the handful of extra api calls that happen on window focus. react-query does this by default, but it isn't necessary and shouldn't be relied on for data fetching, either.

closes #9042

# Changelog

 - Disables react-query window focus refetching

# Review requests

click on and off of the app, check that the network tab doesn't show additional requests (aside from ongoing polling)

# Risk assessment

low
