### PR TITLE
feat(app, api-client): add custom labware support

### DIFF
--- a/api-client/src/protocols/createProtocol.ts
+++ b/api-client/src/protocols/createProtocol.ts
@@ -8,10 +8,7 @@ export function createProtocol(
   files: File[]
 ): ResponsePromise<Protocol> {
   const formData = new FormData()
-  // NOTE(bc, 2021-11-03): We're only expecting one file for now, because currently the
-  // api can only handle one under the "files" key, replace this with multi file capabilities
-  // during custom labware support pass
-  formData.append('files', files[0], files[0].name)
+  files.forEach(file => formData.append('files', file, file.name))
 
   return request<Protocol, FormData>(POST, '/protocols', formData, config)
 }

--- a/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
+++ b/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
@@ -14,6 +14,7 @@ import * as RobotSelectors from '../../../redux/robot/selectors'
 import * as calibrationSelectors from '../../../redux/calibration/selectors'
 import * as discoverySelectors from '../../../redux/discovery/selectors'
 import * as protocolSelectors from '../../../redux/protocol/selectors'
+import * as customLabwareSelectors from '../../../redux/custom-labware/selectors'
 import * as protocolUtils from '../../../redux/protocol/utils'
 import { useProtocolDetails } from '../../RunDetails/hooks'
 import { ConfirmExitProtocolUploadModal } from '../ConfirmExitProtocolUploadModal'
@@ -26,6 +27,7 @@ jest.mock('../../../redux/protocol/selectors')
 jest.mock('../../../redux/protocol/utils')
 jest.mock('../../../redux/discovery/selectors')
 jest.mock('../../../redux/calibration/selectors')
+jest.mock('../../../redux/custom-labware/selectors')
 jest.mock('../../RunDetails/hooks')
 jest.mock('../hooks/useCurrentProtocolRun')
 jest.mock('../hooks/useCloseCurrentRun')
@@ -59,6 +61,9 @@ const mockUseProtocolDetails = useProtocolDetails as jest.MockedFunction<
 const mockGetConnectedRobotName = RobotSelectors.getConnectedRobotName as jest.MockedFunction<
   typeof RobotSelectors.getConnectedRobotName
 >
+const mockGetValidCustomLabwareFiles = customLabwareSelectors.getValidCustomLabwareFiles as jest.MockedFunction<
+  typeof customLabwareSelectors.getValidCustomLabwareFiles
+>
 
 const queryClient = new QueryClient()
 
@@ -78,6 +83,7 @@ describe('ProtocolUpload', () => {
     getCalibrationStatus.mockReturnValue(mockCalibrationStatus)
     ingestProtocolFile.mockImplementation((_f, _s, _e) => {})
     mockGetConnectedRobotName.mockReturnValue('robotName')
+    mockGetValidCustomLabwareFiles.mockReturnValue({} as any)
     when(mockConfirmExitProtocolUploadModal)
       .calledWith(
         componentPropsMatcher({
@@ -96,7 +102,6 @@ describe('ProtocolUpload', () => {
       isProtocolRunLoaded: true,
     })
   })
-
   afterEach(() => {
     resetAllWhenMocks()
     jest.resetAllMocks()

--- a/app/src/organisms/ProtocolUpload/index.tsx
+++ b/app/src/organisms/ProtocolUpload/index.tsx
@@ -88,8 +88,7 @@ export function ProtocolUpload(): JSX.Element {
   }, [uploadError])
 
   const handleUpload = (file: File): void => {
-    const protocolFiles = [file]
-    customLabwareFiles.forEach(labwareFile => protocolFiles.push(labwareFile))
+    const protocolFiles = [file, ...customLabwareFiles]
     clearError()
     ingestProtocolFile(
       file,

--- a/app/src/organisms/ProtocolUpload/index.tsx
+++ b/app/src/organisms/ProtocolUpload/index.tsx
@@ -28,6 +28,7 @@ import { useCloseCurrentRun } from './hooks/useCloseCurrentRun'
 import { loadProtocol } from '../../redux/protocol/actions'
 import { ingestProtocolFile } from '../../redux/protocol/utils'
 import { getConnectedRobotName } from '../../redux/robot/selectors'
+import { getValidCustomLabwareFiles } from '../../redux/custom-labware/selectors'
 
 import { ConfirmExitProtocolUploadModal } from './ConfirmExitProtocolUploadModal'
 
@@ -54,6 +55,9 @@ export function ProtocolUpload(): JSX.Element {
 
   const { closeCurrentRun, isProtocolRunLoaded } = useCloseCurrentRun()
   const robotName = useSelector((state: State) => getConnectedRobotName(state))
+  const customLabwareFiles = useSelector((state: State) =>
+    getValidCustomLabwareFiles(state)
+  )
 
   const logger = useLogger(__filename)
   const [uploadError, setUploadError] = React.useState<
@@ -84,12 +88,14 @@ export function ProtocolUpload(): JSX.Element {
   }, [uploadError])
 
   const handleUpload = (file: File): void => {
+    const protocolFiles = [file]
+    customLabwareFiles.forEach(labwareFile => protocolFiles.push(labwareFile))
     clearError()
     ingestProtocolFile(
       file,
       (file, data) => {
         dispatch(loadProtocol(file, data))
-        createProtocolRun([file])
+        createProtocolRun(protocolFiles)
       },
       (errorKey, errorDetails) => {
         logger.warn(errorKey)

--- a/app/src/redux/custom-labware/__fixtures__/index.ts
+++ b/app/src/redux/custom-labware/__fixtures__/index.ts
@@ -38,6 +38,11 @@ export const mockValidLabware: Types.ValidLabwareFile = {
   },
 }
 
+export const mockValidLabwareFile: File = new File(
+  [JSON.stringify(mockValidLabware.definition)],
+  mockValidLabware.filename
+)
+
 export const mockInvalidLabware: Types.InvalidLabwareFile = {
   type: 'INVALID_LABWARE_FILE',
   filename: 'b.json',

--- a/app/src/redux/custom-labware/__tests__/selectors.test.ts
+++ b/app/src/redux/custom-labware/__tests__/selectors.test.ts
@@ -104,6 +104,36 @@ describe('custom labware selectors', () => {
         { ...Fixtures.mockValidLabware, filename: 'foo.json' },
       ],
     },
+
+    {
+      name: 'getValidCustomLabwareFiles',
+      selector: selectors.getValidCustomLabwareFiles,
+      state: {
+        labware: {
+          addFailureFile: null,
+          addFailureMessage: null,
+          listFailureMessage: null,
+          filenames: [
+            Fixtures.mockValidLabware.filename,
+            Fixtures.mockInvalidLabware.filename,
+            'foo.json',
+          ],
+          filesByName: {
+            [Fixtures.mockValidLabware.filename]: Fixtures.mockValidLabware,
+            [Fixtures.mockInvalidLabware.filename]: Fixtures.mockInvalidLabware,
+            'foo.json': {
+              ...Fixtures.mockValidLabware,
+              filename: 'foo.json',
+            } as ValidLabwareFile,
+          },
+        },
+      } as any,
+      expected: expect.arrayContaining([
+        Fixtures.mockValidLabwareFile,
+        Fixtures.mockValidLabwareFile,
+      ]),
+    },
+
     {
       name: 'getAddLabwareFailure',
       selector: selectors.getAddLabwareFailure,

--- a/app/src/redux/custom-labware/selectors.ts
+++ b/app/src/redux/custom-labware/selectors.ts
@@ -54,7 +54,6 @@ export const getValidCustomLabwareFiles: (
   state: State
 ) => File[] = createSelector(getValidCustomLabware, labware => {
   const labwareFiles = labware.map(lw => {
-    console.log('labware', lw)
     const jsonDefinition = JSON.stringify(lw.definition)
     return new File([jsonDefinition], lw.filename)
   })

--- a/app/src/redux/custom-labware/selectors.ts
+++ b/app/src/redux/custom-labware/selectors.ts
@@ -50,6 +50,17 @@ export const getValidCustomLabware: (
   labware.filter((f): f is ValidLabwareFile => f.type === VALID_LABWARE_FILE)
 )
 
+export const getValidCustomLabwareFiles: (
+  state: State
+) => File[] = createSelector(getValidCustomLabware, labware => {
+  const labwareFiles = labware.map(lw => {
+    console.log('labware', lw)
+    const jsonDefinition = JSON.stringify(lw.definition)
+    return new File([jsonDefinition], lw.filename)
+  })
+  return labwareFiles
+})
+
 export const getAddLabwareFailure: (
   state: State
 ) => {


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Add support for custom labware on protocol upload
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

1. Create new custom labware selector to convert labware defs into JSON files
2. Append all custom labware files to protocol file array and send all on protocol upload

# Review requests

<!--
Describe any requests for your reviewers here.
-->
This is blocked by https://github.com/Opentrons/opentrons/pull/9017 so the e2e flow isn't testable unless you pull down this branch and rebase on top of `runner_custom-labware`.

# Risk assessment
Medium - this is going to merge before the above PR
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
