### PR TITLE
feat(app): add Comment text above comment commands in run details

### DIFF
--- a/app/src/organisms/RunDetails/CommandItem.tsx
+++ b/app/src/organisms/RunDetails/CommandItem.tsx
@@ -75,10 +75,9 @@ export function CommandItem(props: CommandItemProps): JSX.Element | null {
     refetch: refetchCommandDetails,
   } = useCommandQuery(currentRunId, commandOrSummary.id)
   const isComment =
-    (commandDetails?.data.commandType === 'custom' &&
-      commandDetails !== null &&
-      Object.values(commandDetails.data.params).includes('command.COMMENT')) ||
-    commandOrSummary?.id.includes('COMMENT')
+    commandDetails?.data.commandType === 'custom' &&
+    commandDetails !== null &&
+    Object.values(commandDetails.data.params).includes('command.COMMENT')
 
   React.useEffect(() => {
     refetchCommandDetails()

--- a/app/src/organisms/RunDetails/CommandItem.tsx
+++ b/app/src/organisms/RunDetails/CommandItem.tsx
@@ -21,6 +21,7 @@ import {
   SPACING_1,
   SPACING_3,
   TEXT_TRANSFORM_UPPERCASE,
+  C_MED_DARK_GRAY,
 } from '@opentrons/components'
 import { css } from 'styled-components'
 import { CommandTimer } from './CommandTimer'
@@ -63,6 +64,7 @@ const WRAPPER_STYLE_BY_STATUS: {
 }
 export function CommandItem(props: CommandItemProps): JSX.Element | null {
   const { commandOrSummary, runStatus } = props
+  const { t } = useTranslation('run_details')
   const commandStatus =
     runStatus !== RUN_STATUS_IDLE && commandOrSummary.status != null
       ? commandOrSummary.status
@@ -91,6 +93,19 @@ export function CommandItem(props: CommandItemProps): JSX.Element | null {
       {commandStatus === 'running' ? (
         <CurrentCommandLabel runStatus={runStatus} />
       ) : null}
+      {commandStatus === 'failed' ? <CommandFailedMessage /> : null}
+      {commandDetails?.data.id.includes('COMMENT') ||
+      commandOrSummary.id.includes('COMMENT') ? (
+        <Flex
+          textTransform={TEXT_TRANSFORM_UPPERCASE}
+          fontSize={FONT_SIZE_CAPTION}
+          color={C_MED_DARK_GRAY}
+          marginBottom={SPACING_1}
+          marginLeft={SPACING_1}
+        >
+          {t('comment_step')}{' '}
+        </Flex>
+      ) : null}
       <Flex flexDirection={DIRECTION_ROW}>
         {['running', 'failed', 'succeeded'].includes(commandStatus) ? (
           <CommandTimer
@@ -98,7 +113,6 @@ export function CommandItem(props: CommandItemProps): JSX.Element | null {
             commandCompletedAt={commandDetails?.data.completedAt}
           />
         ) : null}
-        {commandStatus === 'failed' ? <CommandFailedMessage /> : null}
         <CommandText
           commandOrSummary={commandDetails?.data ?? commandOrSummary}
         />

--- a/app/src/organisms/RunDetails/CommandItem.tsx
+++ b/app/src/organisms/RunDetails/CommandItem.tsx
@@ -106,7 +106,7 @@ export function CommandItem(props: CommandItemProps): JSX.Element | null {
           marginBottom={SPACING_1}
           marginLeft={SPACING_1}
         >
-          {t('comment_step')}{' '}
+          {t('comment_step')}
         </Flex>
       ) : null}
       <Flex flexDirection={DIRECTION_ROW}>

--- a/app/src/organisms/RunDetails/CommandItem.tsx
+++ b/app/src/organisms/RunDetails/CommandItem.tsx
@@ -75,8 +75,11 @@ export function CommandItem(props: CommandItemProps): JSX.Element | null {
     refetch: refetchCommandDetails,
   } = useCommandQuery(currentRunId, commandOrSummary.id)
   const isComment =
-    commandDetails?.data.id.includes('COMMENT') ||
-    commandOrSummary.id.includes('COMMENT')
+    (commandDetails?.data.commandType === 'custom' &&
+      commandDetails !== null &&
+      Object.values(commandDetails.data.params).includes('command.COMMENT')) ||
+    commandOrSummary?.id.includes('COMMENT')
+
   React.useEffect(() => {
     refetchCommandDetails()
   }, [commandStatus])

--- a/app/src/organisms/RunDetails/CommandItem.tsx
+++ b/app/src/organisms/RunDetails/CommandItem.tsx
@@ -74,10 +74,20 @@ export function CommandItem(props: CommandItemProps): JSX.Element | null {
     data: commandDetails,
     refetch: refetchCommandDetails,
   } = useCommandQuery(currentRunId, commandOrSummary.id)
-  const isComment =
+
+  let isComment = false
+  if (
+    'params' in commandOrSummary &&
+    'legacyCommandType' in commandOrSummary.params
+  ) {
+    isComment = commandOrSummary.params.legacyCommandType === 'command.COMMENT'
+  } else if (
     commandDetails?.data.commandType === 'custom' &&
-    'legacyCommandType' in commandDetails.data.params &&
-    commandDetails.data.params.legacyCommandType === 'command.COMMENT'
+    'legacyCommandType' in commandDetails?.data.params
+  ) {
+    isComment =
+      commandDetails.data.params.legacyCommandType === 'command.COMMENT'
+  }
 
   React.useEffect(() => {
     refetchCommandDetails()

--- a/app/src/organisms/RunDetails/CommandItem.tsx
+++ b/app/src/organisms/RunDetails/CommandItem.tsx
@@ -76,8 +76,8 @@ export function CommandItem(props: CommandItemProps): JSX.Element | null {
   } = useCommandQuery(currentRunId, commandOrSummary.id)
   const isComment =
     commandDetails?.data.commandType === 'custom' &&
-    commandDetails !== null &&
-    Object.values(commandDetails.data.params).includes('command.COMMENT')
+    'legacyCommandType' in commandDetails.data.params &&
+    commandDetails.data.params.legacyCommandType === 'command.COMMENT'
 
   React.useEffect(() => {
     refetchCommandDetails()

--- a/app/src/organisms/RunDetails/CommandItem.tsx
+++ b/app/src/organisms/RunDetails/CommandItem.tsx
@@ -69,13 +69,14 @@ export function CommandItem(props: CommandItemProps): JSX.Element | null {
     runStatus !== RUN_STATUS_IDLE && commandOrSummary.status != null
       ? commandOrSummary.status
       : 'queued'
-
   const currentRunId = useCurrentRunId()
   const {
     data: commandDetails,
     refetch: refetchCommandDetails,
   } = useCommandQuery(currentRunId, commandOrSummary.id)
-
+  const isComment =
+    commandDetails?.data.id.includes('COMMENT') ||
+    commandOrSummary.id.includes('COMMENT')
   React.useEffect(() => {
     refetchCommandDetails()
   }, [commandStatus])
@@ -94,8 +95,7 @@ export function CommandItem(props: CommandItemProps): JSX.Element | null {
         <CurrentCommandLabel runStatus={runStatus} />
       ) : null}
       {commandStatus === 'failed' ? <CommandFailedMessage /> : null}
-      {commandDetails?.data.id.includes('COMMENT') ||
-      commandOrSummary.id.includes('COMMENT') ? (
+      {isComment ? (
         <Flex
           textTransform={TEXT_TRANSFORM_UPPERCASE}
           fontSize={FONT_SIZE_CAPTION}
@@ -107,7 +107,8 @@ export function CommandItem(props: CommandItemProps): JSX.Element | null {
         </Flex>
       ) : null}
       <Flex flexDirection={DIRECTION_ROW}>
-        {['running', 'failed', 'succeeded'].includes(commandStatus) ? (
+        {['running', 'failed', 'succeeded'].includes(commandStatus) &&
+        !isComment ? (
           <CommandTimer
             commandStartedAt={commandDetails?.data.startedAt}
             commandCompletedAt={commandDetails?.data.completedAt}

--- a/app/src/organisms/RunDetails/__tests__/CommandItem.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/CommandItem.test.tsx
@@ -41,7 +41,7 @@ const MOCK_COMMAND = {
 const MOCK_COMMENT_COMMAND = {
   id: 'COMMENT',
   commandType: 'custom',
-  params: {},
+  params: { legacyCommand: 'command.COMMENT' },
   status: 'running',
   result: {},
 } as Command
@@ -57,7 +57,7 @@ const MOCK_COMMAND_DETAILS = {
 const MOCK_COMMAND_DETAILS_COMMENT = {
   id: 'COMMENT',
   commandType: 'custom',
-  params: {},
+  params: { legacyCommand: 'command.COMMENT' },
   status: 'running',
   result: {},
   startedAt: 'start timestamp',

--- a/app/src/organisms/RunDetails/__tests__/CommandItem.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/CommandItem.test.tsx
@@ -41,8 +41,8 @@ const MOCK_COMMAND = {
 const MOCK_COMMENT_COMMAND = {
   id: 'COMMENT',
   commandType: 'custom',
-  params: { legacyCommand: 'command.COMMENT' },
-  status: 'running',
+  params: { legacyCommandType: 'command.COMMENT' },
+  status: 'queued',
   result: {},
 } as Command
 const MOCK_COMMAND_DETAILS = {
@@ -57,8 +57,8 @@ const MOCK_COMMAND_DETAILS = {
 const MOCK_COMMAND_DETAILS_COMMENT = {
   id: 'COMMENT',
   commandType: 'custom',
-  params: { legacyCommand: 'command.COMMENT' },
-  status: 'running',
+  params: { legacyCommandType: 'command.COMMENT' },
+  status: 'queued',
   result: {},
   startedAt: 'start timestamp',
   completedAt: 'end timestamp',
@@ -143,7 +143,7 @@ describe('Run Details Command item', () => {
         refetch: jest.fn(),
       } as any)
     const props = {
-      commandOrSummary: { ...MOCK_COMMENT_COMMAND, status: 'running' },
+      commandOrSummary: { ...MOCK_COMMENT_COMMAND, status: 'queued' },
       runStatus: 'running',
     } as React.ComponentProps<typeof CommandItem>
     const { getByText } = render(props)

--- a/app/src/organisms/RunDetails/__tests__/CommandItem.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/CommandItem.test.tsx
@@ -149,6 +149,5 @@ describe('Run Details Command item', () => {
     const { getByText } = render(props)
     expect(getByText('Comment')).toHaveStyle('backgroundColor: C_NEAR_WHITE')
     getByText('Mock Command Text')
-    getByText('Mock Command Timer')
   })
 })

--- a/app/src/organisms/RunDetails/__tests__/CommandItem.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/CommandItem.test.tsx
@@ -38,8 +38,24 @@ const MOCK_COMMAND = {
   status: 'running',
   result: {},
 } as Command
+const MOCK_COMMENT_COMMAND = {
+  id: 'COMMENT',
+  commandType: 'custom',
+  params: {},
+  status: 'running',
+  result: {},
+} as Command
 const MOCK_COMMAND_DETAILS = {
   id: '123',
+  commandType: 'custom',
+  params: {},
+  status: 'running',
+  result: {},
+  startedAt: 'start timestamp',
+  completedAt: 'end timestamp',
+} as Command
+const MOCK_COMMAND_DETAILS_COMMENT = {
+  id: 'COMMENT',
   commandType: 'custom',
   params: {},
   status: 'running',
@@ -115,6 +131,23 @@ describe('Run Details Command item', () => {
     expect(getByText('Current Step - Paused by User')).toHaveStyle(
       'backgroundColor: C_POWDER_BLUE'
     )
+    getByText('Mock Command Text')
+    getByText('Mock Command Timer')
+  })
+
+  it('renders the comment text when the command is a comment', () => {
+    when(mockUseCommandQuery)
+      .calledWith(RUN_ID, MOCK_COMMENT_COMMAND.id)
+      .mockReturnValue({
+        data: { data: MOCK_COMMAND_DETAILS_COMMENT },
+        refetch: jest.fn(),
+      } as any)
+    const props = {
+      commandOrSummary: { ...MOCK_COMMENT_COMMAND, status: 'running' },
+      runStatus: 'running',
+    } as React.ComponentProps<typeof CommandItem>
+    const { getByText } = render(props)
+    expect(getByText('Comment')).toHaveStyle('backgroundColor: C_NEAR_WHITE')
     getByText('Mock Command Text')
     getByText('Mock Command Timer')
   })


### PR DESCRIPTION
closes #9040

# Overview

This PR adds the Comment text above command commands in the run details page.
<img width="662" alt="Screen Shot 2021-12-09 at 14 22 05" src="https://user-images.githubusercontent.com/66035149/145462013-616be82f-6691-446e-b8d5-ab30c298b8cb.png">


<img width="659" alt="Screen Shot 2021-12-09 at 13 22 15" src="https://user-images.githubusercontent.com/66035149/145455054-bb440ad9-f8ff-4b4a-97ef-6031cd48ef66.png">

# Changelog

- added onto `CommandItem` component

# Review requests

- I tested on my robot, test on your robot if you want as well. NOTE: only comments written in python protocols are supported!
- review figma

# Risk assessment

low, behind ff
