### PR TITLE
refactor(app): Move LPC toast above metadata & make sticky

### DIFF
--- a/app/src/organisms/ProtocolSetup/LabwareOffsetSuccessToast.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwareOffsetSuccessToast.tsx
@@ -4,6 +4,8 @@ import { useTranslation } from 'react-i18next'
 import { useCurrentProtocolRun } from '../ProtocolUpload/hooks'
 import { getLatestLabwareOffsetCount } from './LabwarePositionCheck/utils/getLatestLabwareOffsetCount'
 
+import styles from './styles.css'
+
 interface LabwareOffsetSuccessToastProps {
   onCloseClick: () => unknown
 }
@@ -21,6 +23,7 @@ export function LabwareOffsetSuccessToast(
     <AlertItem
       type="success"
       onCloseClick={props.onCloseClick}
+      className={styles.sticky_alert}
       title={
         labwareOffsetCount === 0
           ? t('labware_positon_check_complete_toast_no_offsets')

--- a/app/src/organisms/ProtocolSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/index.tsx
@@ -78,16 +78,16 @@ export function ProtocolSetup(): JSX.Element {
         flexDirection={DIRECTION_COLUMN}
         padding={`${SPACING_1} ${SPACING_3} ${SPACING_3} ${SPACING_3}`}
       >
-        {showLPCSuccessToast && (
-          <LabwareOffsetSuccessToast
-            onCloseClick={() => setShowLPCSuccessToast(false)}
-          />
-        )}
         <LPCSuccessToastContext.Provider
           value={{
             setShowLPCSuccessToast: () => setShowLPCSuccessToast(true),
           }}
         >
+          {showLPCSuccessToast && (
+            <LabwareOffsetSuccessToast
+              onCloseClick={() => setShowLPCSuccessToast(false)}
+            />
+          )}
           <MetadataCard />
           <RunSetupCard />
         </LPCSuccessToastContext.Provider>

--- a/app/src/organisms/ProtocolSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/index.tsx
@@ -83,12 +83,12 @@ export function ProtocolSetup(): JSX.Element {
             onCloseClick={() => setShowLPCSuccessToast(false)}
           />
         )}
-        <MetadataCard />
         <LPCSuccessToastContext.Provider
           value={{
             setShowLPCSuccessToast: () => setShowLPCSuccessToast(true),
           }}
         >
+          <MetadataCard />
           <RunSetupCard />
         </LPCSuccessToastContext.Provider>
         <Text

--- a/app/src/organisms/ProtocolSetup/styles.css
+++ b/app/src/organisms/ProtocolSetup/styles.css
@@ -15,3 +15,10 @@
   max-height: 100%;
   overflow-y: auto;
 }
+
+.sticky_alert {
+  position: fixed;
+  top: 3rem;
+  width: 89.5%;
+  z-index: 100;
+}

--- a/app/src/organisms/ProtocolSetup/styles.css
+++ b/app/src/organisms/ProtocolSetup/styles.css
@@ -17,8 +17,7 @@
 }
 
 .sticky_alert {
-  position: fixed;
+  position: sticky;
   top: 3rem;
-  width: 89.5%;
   z-index: 100;
 }


### PR DESCRIPTION
# Overview

closes #9010 by moving LPC success toast above main content,

# Changelog

- refactor(app): Move LPC toast above metadata

# Review requests

run through LPC
close it out
- [ ] success toast should be above metadata at top of the page

# Risk assessment
low, just some small DOM stuff in the app
