### PR TITLE
refactor(robot-server): Log mutations on /runs and /protocols

### DIFF
--- a/robot-server/robot_server/protocols/protocol_analyzer.py
+++ b/robot-server/robot_server/protocols/protocol_analyzer.py
@@ -1,8 +1,13 @@
 """Protocol analysis module."""
+import logging
+
 from opentrons.protocol_runner import ProtocolRunner
 
 from .protocol_store import ProtocolResource
 from .analysis_store import AnalysisStore
+
+
+log = logging.getLogger(__name__)
 
 
 class ProtocolAnalyzer:
@@ -24,6 +29,8 @@ class ProtocolAnalyzer:
     ) -> None:
         """Analyze a given protocol, storing the analysis when complete."""
         result = await self._protocol_runner.run(protocol_resource.source)
+
+        log.info(f'Completed analysis "{analysis_id}".')
 
         self._analysis_store.update(
             analysis_id=analysis_id,

--- a/robot-server/robot_server/protocols/router.py
+++ b/robot-server/robot_server/protocols/router.py
@@ -1,5 +1,7 @@
 """Router for /protocols endpoints."""
+import logging
 from datetime import datetime
+
 from fastapi import APIRouter, Depends, File, UploadFile, status
 from typing import List
 from typing_extensions import Literal
@@ -25,6 +27,9 @@ from .dependencies import (
     get_analysis_store,
     get_protocol_analyzer,
 )
+
+
+log = logging.getLogger(__name__)
 
 
 class ProtocolNotFound(ErrorDetails):
@@ -117,6 +122,9 @@ async def create_protocol(
         files=[ProtocolFile(name=f.name, role=f.role) for f in source.files],
     )
 
+    log.info(
+        f'Created protocol "{protocol_id}"' f' and started analysis "{analysis_id}".'
+    )
     return SimpleResponseModel(data=data)
 
 

--- a/robot-server/robot_server/runs/router/actions_router.py
+++ b/robot-server/robot_server/runs/router/actions_router.py
@@ -1,4 +1,6 @@
 """Router for /runs actions endpoints."""
+import logging
+
 from fastapi import APIRouter, Depends, status
 from datetime import datetime
 from typing import Union
@@ -17,6 +19,8 @@ from ..engine_store import EngineStore
 from ..dependencies import get_run_store, get_engine_store
 from .base_router import RunNotFound, RunStopped
 
+
+log = logging.getLogger(__name__)
 actions_router = APIRouter()
 
 
@@ -30,7 +34,7 @@ class RunActionNotAllowed(ErrorDetails):
 @actions_router.post(
     path="/runs/{runId}/actions",
     summary="Issue a control action to the run",
-    description=("Provide an action in order to control execution of the run."),
+    description="Provide an action in order to control execution of the run.",
     status_code=status.HTTP_201_CREATED,
     response_model=SimpleResponseModel[RunAction],
     response_model_exclude_none=True,
@@ -80,10 +84,13 @@ async def create_run_action(
 
     try:
         if action.actionType == RunActionType.PLAY:
+            log.info(f'Playing run "{runId}".')
             engine_store.runner.play()
         elif action.actionType == RunActionType.PAUSE:
+            log.info(f'Pausing run "{runId}".')
             engine_store.runner.pause()
         elif action.actionType == RunActionType.STOP:
+            log.info(f'Stopping run "{runId}".')
             await engine_store.runner.stop()
 
     except ProtocolEngineStoppedError as e:

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -2,11 +2,13 @@
 
 Contains routes dealing primarily with `Run` models.
 """
-from fastapi import APIRouter, Depends, status
+import logging
 from datetime import datetime
-from pydantic import BaseModel, Field
 from typing import Optional, Union
 from typing_extensions import Literal
+
+from fastapi import APIRouter, Depends, status
+from pydantic import BaseModel, Field
 
 from opentrons.protocol_engine import LabwareOffsetCreate
 
@@ -39,6 +41,8 @@ from ..run_models import (
 from ..engine_store import EngineStore, EngineConflictError
 from ..dependencies import get_run_store, get_engine_store
 
+
+log = logging.getLogger(__name__)
 base_router = APIRouter()
 
 
@@ -149,6 +153,7 @@ async def create_run(
     )
 
     run_store.upsert(run=run)
+    log.info(f'Created run "{run_id}".')
 
     data = Run(
         id=run_id,
@@ -355,7 +360,8 @@ async def add_labware_offset(
             status.HTTP_409_CONFLICT
         )
 
-    engine_store.engine.add_labware_offset(request_body.data)
+    added_offset = engine_store.engine.add_labware_offset(request_body.data)
+    log.info(f'Added labware offset "{added_offset.id}"' f' to run "{runId}".')
 
     engine_state = engine_store.get_state(run.run_id)
     data = Run(
@@ -433,6 +439,7 @@ async def update_run(
             raise RunNotIdle().as_error(status.HTTP_409_CONFLICT)
 
         run_store.upsert(run)
+        log.info(f'Marked run "{runId}" as not current.')
 
     engine_state = engine_store.get_state(run.run_id)
 

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -153,7 +153,7 @@ async def create_run(
     )
 
     run_store.upsert(run=run)
-    log.info(f'Created run "{run_id}".')
+    log.info(f'Created protocol run "{run_id}" from protocol "{protocol_id}".')
 
     data = Run(
         id=run_id,

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -655,6 +655,17 @@ async def test_add_labware_offset(
     decoy.when(engine_state.commands.get_all_errors()).then_return([])
     decoy.when(engine_state.pipettes.get_all()).then_return([])
     decoy.when(engine_state.labware.get_all()).then_return([])
+    decoy.when(
+        engine_store.engine.add_labware_offset(labware_offset_request)
+    ).then_return(
+        pe_types.LabwareOffset(
+            id="labware-offset-id",
+            createdAt=datetime(year=2021, month=1, day=1),
+            definitionUri="labware-definition-uri",
+            location=pe_types.LabwareOffsetLocation(slotName=DeckSlotName.SLOT_1),
+            vector=pe_types.LabwareOffsetVector(x=0, y=0, z=0),
+        )
+    )
     # Tests for run POST and GET should already cover passing the engine's labware
     # offsets to the client when .get_labware_offsets() returns a non-empty list.
     decoy.when(engine_state.labware.get_labware_offsets()).then_return([])
@@ -668,7 +679,6 @@ async def test_add_labware_offset(
         engine_store=engine_store,
         run_store=run_store,
     )
-    decoy.verify(engine_store.engine.add_labware_offset(labware_offset_request))
 
     assert response == SimpleResponseModel(data=expected_response)
 


### PR DESCRIPTION
# Overview

In certain `/runs` and `/protocols` HTTP endpoints, log the relevant resource IDs.

When weird stuff happens in the field, this is intended to preserve a basic timeline of major events, to help us troubleshoot.

Uvicorn already logs when endpoints are hit, but those logs don't include any info about the request or response body.

Closes #8979.

# Changelog

* When a protocol is uploaded, log its ID and its analysis's ID.
* When an analysis completes, log its ID.
* When a run is created, log its ID and the ID of the protocol it was created with, if any.
* **When a play/pause/stop action is issued, log which action it was, and the ID of the run it was issued on.**
    * This is the important change, really.
* When a run is marked not-current, log its ID.

I chose not to add logging to the following endpoints:

* `DELETE /runs/{id}`
* `DELETE /protocols/{id}`
* `POST /runs/{id}/commands`

Because the run or protocol ID is part of the URL, so it's already printed in Uvicorn's access logs.

# Review requests

Anything else we want to log?

# Risk assessment

Very low.
