### PR TITLE
refactor(app): change text maxWidth so text only falls on 2 lines

### DIFF
--- a/app/src/organisms/ProtocolUpload/index.tsx
+++ b/app/src/organisms/ProtocolUpload/index.tsx
@@ -16,7 +16,7 @@ import {
   SPACING_6,
   TEXT_TRANSFORM_UPPERCASE,
   FONT_SIZE_BIG,
-  SPACING_7,
+  SPACING_8,
 } from '@opentrons/components'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
@@ -186,7 +186,7 @@ function ProtocolLoader(): JSX.Element | null {
       <Text
         textAlign={ALIGN_CENTER}
         as={'h3'}
-        maxWidth={SPACING_7}
+        maxWidth={SPACING_8}
         textTransform={TEXT_TRANSFORM_UPPERCASE}
         marginTop={SPACING_6}
         color={C_DARK_GRAY}


### PR DESCRIPTION
closes #9048

# Overview

This PR changes the text maxwidth so long robot names + text don't span 3 lines and only span 2 lines:
<img width="1030" alt="Screen Shot 2021-12-10 at 08 56 55" src="https://user-images.githubusercontent.com/66035149/145585432-6d807279-8e6b-4dab-9b1a-a1e33918e14a.png">

# Changelog

- changed `maxWidth`

# Review requests

- test on a robot with a long name and/or refer to the above photo 😄 

# Risk assessment

low, behind ff
