### PR TITLE
refactor(app): confirm exit modal to appear over run details and run panel

### DIFF
--- a/app/src/organisms/RunDetails/index.tsx
+++ b/app/src/organisms/RunDetails/index.tsx
@@ -19,6 +19,7 @@ import {
   useConditionalConfirm,
 } from '@opentrons/components'
 import { Page } from '../../atoms/Page'
+import { Portal } from '../../App/portal'
 import { useProtocolDetails } from './hooks'
 import { useRunStatus, useRunStartTime } from '../RunTimeControl/hooks'
 import { ConfirmCancelModal } from '../../pages/Run/RunLog'
@@ -28,7 +29,6 @@ import { useCurrentRunControls } from '../../pages/Run/RunLog/hooks'
 import { CommandList } from './CommandList'
 
 import styles from '../ProtocolUpload/styles.css'
-import { Portal } from '../../App/portal'
 
 export function RunDetails(): JSX.Element | null {
   const { t } = useTranslation(['run_details', 'shared'])

--- a/app/src/organisms/RunDetails/index.tsx
+++ b/app/src/organisms/RunDetails/index.tsx
@@ -28,6 +28,7 @@ import { useCurrentRunControls } from '../../pages/Run/RunLog/hooks'
 import { CommandList } from './CommandList'
 
 import styles from '../ProtocolUpload/styles.css'
+import { Portal } from '../../App/portal'
 
 export function RunDetails(): JSX.Element | null {
   const { t } = useTranslation(['run_details', 'shared'])
@@ -116,10 +117,12 @@ export function RunDetails(): JSX.Element | null {
   return (
     <>
       {showCloseConfirmExit && (
-        <ConfirmExitProtocolUploadModal
-          exit={confirmCloseExit}
-          back={cancelCloseExit}
-        />
+        <Portal level="top">
+          <ConfirmExitProtocolUploadModal
+            exit={confirmCloseExit}
+            back={cancelCloseExit}
+          />
+        </Portal>
       )}
       <Page titleBarProps={titleBarProps}>
         {showConfirmExit ? <ConfirmCancelModal onClose={cancelExit} /> : null}


### PR DESCRIPTION
closes #9053

# Overview

This PR adds a portal to the confirm exit modal so it appears over the run details and run panel rather than only appearing over the run details.

<img width="1027" alt="Screen Shot 2021-12-10 at 11 42 04" src="https://user-images.githubusercontent.com/66035149/145609776-243e116d-2542-4dee-808b-c1b704b9b156.png">

# Changelog

- added top level portal

# Review requests

- make sure it matches AC of ticket

# Risk assessment

low, behind ff