### PR TITLE
refactor(app): make consistent close and cancel run modals

### DIFF
--- a/app/src/assets/localization/en/protocol_info.json
+++ b/app/src/assets/localization/en/protocol_info.json
@@ -50,5 +50,6 @@
   "labware_positon_check_complete_toast_no_offsets": "Labware Position Check complete. No Labware Offsets created.",
   "labware_positon_check_complete_toast_with_offsets": "Labware Position Check complete. {{count}} Labware Offset created.",
   "labware_positon_check_complete_toast_with_offsets_plural": "Labware Position Check complete. {{count}} Labware Offsets created.",
-  "protocol_loading": "Opening Protocol On {{robot_name}}"
+  "protocol_loading": "Opening Protocol On {{robot_name}}",
+  "cancel_run": "Cancel Run"
 }

--- a/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
+++ b/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
@@ -238,7 +238,7 @@ describe('ProtocolUpload', () => {
       <div>mock confirm cancel modal</div>
     )
     const [{ getByRole }] = render()
-    const button = getByRole('button', { name: 'close' })
+    const button = getByRole('button', { name: 'Cancel Run' })
     fireEvent.click(button)
     expect(screen.queryByText('mock confirm cancel modal')).not.toBeNull()
   })

--- a/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
+++ b/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { resetAllWhenMocks, when } from 'jest-when'
 import { QueryClient, QueryClientProvider } from 'react-query'
 import { fireEvent, screen } from '@testing-library/react'
+import { RUN_STATUS_IDLE, RUN_STATUS_RUNNING } from '@opentrons/api-client'
 import {
   renderWithProviders,
   componentPropsMatcher,
@@ -16,9 +17,11 @@ import * as discoverySelectors from '../../../redux/discovery/selectors'
 import * as protocolSelectors from '../../../redux/protocol/selectors'
 import * as customLabwareSelectors from '../../../redux/custom-labware/selectors'
 import * as protocolUtils from '../../../redux/protocol/utils'
+import { ConfirmCancelModal } from '../../../pages/Run/RunLog'
 import { useProtocolDetails } from '../../RunDetails/hooks'
 import { ConfirmExitProtocolUploadModal } from '../ConfirmExitProtocolUploadModal'
 import { mockCalibrationStatus } from '../../../redux/calibration/__fixtures__'
+import { useRunStatus } from '../../RunTimeControl/hooks'
 import { useCurrentProtocolRun } from '../hooks/useCurrentProtocolRun'
 import { useCloseCurrentRun } from '../hooks/useCloseCurrentRun'
 import { ProtocolUpload } from '..'
@@ -33,6 +36,8 @@ jest.mock('../hooks/useCurrentProtocolRun')
 jest.mock('../hooks/useCloseCurrentRun')
 jest.mock('../ConfirmExitProtocolUploadModal')
 jest.mock('../../../redux/robot/selectors')
+jest.mock('../../RunTimeControl/hooks')
+jest.mock('../../../pages/Run/RunLog')
 
 const getProtocolFile = protocolSelectors.getProtocolFile as jest.MockedFunction<
   typeof protocolSelectors.getProtocolFile
@@ -49,6 +54,9 @@ const getCalibrationStatus = calibrationSelectors.getCalibrationStatus as jest.M
 const mockConfirmExitProtocolUploadModal = ConfirmExitProtocolUploadModal as jest.MockedFunction<
   typeof ConfirmExitProtocolUploadModal
 >
+const mockUseRunStatus = useRunStatus as jest.MockedFunction<
+  typeof useRunStatus
+>
 const mockUseCurrentProtocolRun = useCurrentProtocolRun as jest.MockedFunction<
   typeof useCurrentProtocolRun
 >
@@ -57,6 +65,9 @@ const mockUseCloseProtocolRun = useCloseCurrentRun as jest.MockedFunction<
 >
 const mockUseProtocolDetails = useProtocolDetails as jest.MockedFunction<
   typeof useProtocolDetails
+>
+const mockConfirmCancelModal = ConfirmCancelModal as jest.MockedFunction<
+  typeof ConfirmCancelModal
 >
 const mockGetConnectedRobotName = RobotSelectors.getConnectedRobotName as jest.MockedFunction<
   typeof RobotSelectors.getConnectedRobotName
@@ -101,6 +112,7 @@ describe('ProtocolUpload', () => {
       closeCurrentRun: jest.fn(),
       isProtocolRunLoaded: true,
     })
+    when(mockUseRunStatus).calledWith().mockReturnValue(RUN_STATUS_IDLE)
   })
   afterEach(() => {
     resetAllWhenMocks()
@@ -211,6 +223,24 @@ describe('ProtocolUpload', () => {
 
     const [{ getByText }] = render()
     getByText('Open a protocol to run on robotName')
+  })
+
+  it('renders the cancel button, button is clickable, and cancel modal is rendered', () => {
+    when(mockUseCurrentProtocolRun)
+      .calledWith()
+      .mockReturnValue({
+        protocolRecord: { data: { analyses: [] } },
+        runRecord: {},
+        createProtocolRun: jest.fn(),
+      } as any)
+    when(mockUseRunStatus).calledWith().mockReturnValue(RUN_STATUS_RUNNING)
+    when(mockConfirmCancelModal).mockReturnValue(
+      <div>mock confirm cancel modal</div>
+    )
+    const [{ getByRole }] = render()
+    const button = getByRole('button', { name: 'close' })
+    fireEvent.click(button)
+    expect(screen.queryByText('mock confirm cancel modal')).not.toBeNull()
   })
 
   it('renders an error if protocol has a not-ok result', () => {

--- a/app/src/organisms/ProtocolUpload/index.tsx
+++ b/app/src/organisms/ProtocolUpload/index.tsx
@@ -17,8 +17,10 @@ import {
   TEXT_TRANSFORM_UPPERCASE,
   FONT_SIZE_BIG,
   SPACING_8,
-  C_BLUE,
-  C_WHITE,
+  NewAlertPrimaryBtn,
+  LINE_HEIGHT_SOLID,
+  SPACING_3,
+  SPACING_2,
 } from '@opentrons/components'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
@@ -134,29 +136,48 @@ export function ProtocolUpload(): JSX.Element {
     cancel: cancelModalExit,
   } = useConditionalConfirm(cancelRunAndExit, true)
 
-  const titleBarProps = isProtocolRunLoaded
-    ? {
-        title: t('protocol_title', {
-          protocol_name: protocolRecord?.data?.metadata?.protocolName ?? '',
-        }),
-        back: {
-          onClick:
-            runStatus === RUN_STATUS_RUNNING ||
-            runStatus === RUN_STATUS_PAUSED ||
-            runStatus === RUN_STATUS_PAUSE_REQUESTED
-              ? confirmCancelModalExit
-              : confirmExit,
-          title: t('shared:close'),
-          children: t('shared:close'),
-          iconName: 'close' as const,
-        },
-        className: styles.reverse_titlebar_items,
-      }
-    : {
-        title: (
-          <Text>{t('upload_and_simulate', { robot_name: robotName })}</Text>
-        ),
-      }
+  const cancelRunButton = (
+    <NewAlertPrimaryBtn
+      onClick={confirmCancelModalExit}
+      lineHeight={LINE_HEIGHT_SOLID}
+      marginX={SPACING_3}
+      paddingRight={SPACING_2}
+      paddingLeft={SPACING_2}
+    >
+      {t('cancel_run')}
+    </NewAlertPrimaryBtn>
+  )
+  const isRunInMotion =
+    runStatus === RUN_STATUS_RUNNING ||
+    runStatus === RUN_STATUS_PAUSED ||
+    runStatus === RUN_STATUS_PAUSE_REQUESTED
+
+  let titleBarProps
+  if (isProtocolRunLoaded && !isRunInMotion) {
+    titleBarProps = {
+      title: t('protocol_title', {
+        protocol_name: protocolRecord?.data?.metadata?.protocolName ?? '',
+      }),
+      back: {
+        onClick: confirmExit,
+        title: t('shared:close'),
+        children: t('shared:close'),
+        iconName: 'close' as const,
+      },
+      className: styles.reverse_titlebar_items,
+    }
+  } else if (isRunInMotion) {
+    titleBarProps = {
+      title: t('protocol_title', {
+        protocol_name: protocolRecord?.data?.metadata?.protocolName ?? '',
+      }),
+      rightNode: cancelRunButton,
+    }
+  } else {
+    titleBarProps = {
+      title: <Text>{t('upload_and_simulate', { robot_name: robotName })}</Text>,
+    }
+  }
 
   const pageContents = isProtocolRunLoaded ? (
     <ProtocolSetup />
@@ -169,14 +190,7 @@ export function ProtocolUpload(): JSX.Element {
       {showConfirmExit && (
         <ConfirmExitProtocolUploadModal exit={confirmExit} back={cancelExit} />
       )}
-      {showConfirmModalExit && (
-        <ConfirmCancelModal
-          onClose={cancelModalExit}
-          secondaryBtnColor={C_BLUE}
-          primaryBtnColor={C_BLUE}
-          primaryBtnColorText={C_WHITE}
-        />
-      )}
+      {showConfirmModalExit && <ConfirmCancelModal onClose={cancelModalExit} />}
       <Page titleBarProps={titleBarProps}>
         {uploadError != null && (
           <AlertItem

--- a/app/src/organisms/RunDetails/index.tsx
+++ b/app/src/organisms/RunDetails/index.tsx
@@ -7,9 +7,6 @@ import {
   RUN_STATUS_RUNNING,
   RUN_STATUS_PAUSED,
   RUN_STATUS_PAUSE_REQUESTED,
-  RUN_STATUS_STOPPED,
-  RUN_STATUS_FAILED,
-  RUN_STATUS_SUCCEEDED,
 } from '@opentrons/api-client'
 import {
   NewAlertPrimaryBtn,
@@ -17,6 +14,8 @@ import {
   SPACING_2,
   SPACING_3,
   useConditionalConfirm,
+  C_BLUE,
+  C_WHITE,
 } from '@opentrons/components'
 import { Page } from '../../atoms/Page'
 import { Portal } from '../../App/portal'
@@ -93,11 +92,7 @@ export function RunDetails(): JSX.Element | null {
       title: t('protocol_title', { protocol_name: displayName }),
       rightNode: cancelRunButton,
     }
-  } else if (
-    adjustedRunStatus === RUN_STATUS_SUCCEEDED ||
-    adjustedRunStatus === RUN_STATUS_STOPPED ||
-    adjustedRunStatus === RUN_STATUS_FAILED
-  ) {
+  } else {
     titleBarProps = {
       title: t('protocol_title', { protocol_name: displayName }),
       back: {
@@ -107,10 +102,6 @@ export function RunDetails(): JSX.Element | null {
         iconName: 'close' as const,
       },
       className: styles.reverse_titlebar_items,
-    }
-  } else {
-    titleBarProps = {
-      title: t('protocol_title', { protocol_name: displayName }),
     }
   }
 
@@ -125,7 +116,14 @@ export function RunDetails(): JSX.Element | null {
         </Portal>
       )}
       <Page titleBarProps={titleBarProps}>
-        {showConfirmExit ? <ConfirmCancelModal onClose={cancelExit} /> : null}
+        {showConfirmExit ? (
+          <ConfirmCancelModal
+            onClose={cancelExit}
+            secondaryBtnColor={C_BLUE}
+            primaryBtnColor={C_BLUE}
+            primaryBtnColorText={C_WHITE}
+          />
+        ) : null}
         <CommandList />
       </Page>
     </>

--- a/app/src/organisms/RunDetails/index.tsx
+++ b/app/src/organisms/RunDetails/index.tsx
@@ -14,8 +14,6 @@ import {
   SPACING_2,
   SPACING_3,
   useConditionalConfirm,
-  C_BLUE,
-  C_WHITE,
 } from '@opentrons/components'
 import { Page } from '../../atoms/Page'
 import { Portal } from '../../App/portal'
@@ -116,14 +114,7 @@ export function RunDetails(): JSX.Element | null {
         </Portal>
       )}
       <Page titleBarProps={titleBarProps}>
-        {showConfirmExit ? (
-          <ConfirmCancelModal
-            onClose={cancelExit}
-            secondaryBtnColor={C_BLUE}
-            primaryBtnColor={C_BLUE}
-            primaryBtnColorText={C_WHITE}
-          />
-        ) : null}
+        {showConfirmExit ? <ConfirmCancelModal onClose={cancelExit} /> : null}
         <CommandList />
       </Page>
     </>

--- a/app/src/pages/Run/RunLog/ConfirmCancelModal.tsx
+++ b/app/src/pages/Run/RunLog/ConfirmCancelModal.tsx
@@ -1,18 +1,26 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { AlertModal } from '@opentrons/components'
+import { AlertModal, SecondaryBtn, SPACING_3 } from '@opentrons/components'
 
 import { Portal } from '../../../App/portal'
 import { useCurrentRunControls } from './hooks'
 
 export interface ConfirmCancelModalProps {
   onClose: () => unknown
+  secondaryBtnColor?: string
+  primaryBtnColor?: string
+  primaryBtnColorText?: string
 }
 
 export function ConfirmCancelModal(
   props: ConfirmCancelModalProps
 ): JSX.Element {
-  const { onClose } = props
+  const {
+    onClose,
+    secondaryBtnColor,
+    primaryBtnColor,
+    primaryBtnColorText,
+  } = props
   const { stopRun } = useCurrentRunControls()
   const { t } = useTranslation('run_details')
 
@@ -26,8 +34,25 @@ export function ConfirmCancelModal(
       <AlertModal
         heading={t('cancel_run_modal_heading')}
         buttons={[
-          { children: t('cancel_run_modal_back'), onClick: onClose },
-          { children: t('cancel_run_modal_confirm'), onClick: cancel },
+          {
+            Component: () => (
+              <SecondaryBtn onClick={onClose} color={secondaryBtnColor}>
+                {t('cancel_run_modal_back')}
+              </SecondaryBtn>
+            ),
+          },
+          {
+            Component: () => (
+              <SecondaryBtn
+                onClick={cancel}
+                marginLeft={SPACING_3}
+                backgroundColor={primaryBtnColor}
+                color={primaryBtnColorText}
+              >
+                {t('cancel_run_modal_confirm')}
+              </SecondaryBtn>
+            ),
+          },
         ]}
         alertOverlay
       >

--- a/app/src/pages/Run/RunLog/ConfirmCancelModal.tsx
+++ b/app/src/pages/Run/RunLog/ConfirmCancelModal.tsx
@@ -1,26 +1,23 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { AlertModal, SecondaryBtn, SPACING_3 } from '@opentrons/components'
+import {
+  AlertModal,
+  NewPrimaryBtn,
+  NewSecondaryBtn,
+  SPACING_3,
+} from '@opentrons/components'
 
 import { Portal } from '../../../App/portal'
 import { useCurrentRunControls } from './hooks'
 
 export interface ConfirmCancelModalProps {
   onClose: () => unknown
-  secondaryBtnColor?: string
-  primaryBtnColor?: string
-  primaryBtnColorText?: string
 }
 
 export function ConfirmCancelModal(
   props: ConfirmCancelModalProps
 ): JSX.Element {
-  const {
-    onClose,
-    secondaryBtnColor,
-    primaryBtnColor,
-    primaryBtnColorText,
-  } = props
+  const { onClose } = props
   const { stopRun } = useCurrentRunControls()
   const { t } = useTranslation('run_details')
 
@@ -36,21 +33,16 @@ export function ConfirmCancelModal(
         buttons={[
           {
             Component: () => (
-              <SecondaryBtn onClick={onClose} color={secondaryBtnColor}>
+              <NewSecondaryBtn onClick={onClose}>
                 {t('cancel_run_modal_back')}
-              </SecondaryBtn>
+              </NewSecondaryBtn>
             ),
           },
           {
             Component: () => (
-              <SecondaryBtn
-                onClick={cancel}
-                marginLeft={SPACING_3}
-                backgroundColor={primaryBtnColor}
-                color={primaryBtnColorText}
-              >
+              <NewPrimaryBtn onClick={cancel} marginLeft={SPACING_3}>
                 {t('cancel_run_modal_confirm')}
-              </SecondaryBtn>
+              </NewPrimaryBtn>
             ),
           },
         ]}

--- a/app/src/pages/Run/__tests__/ConfirmCancelModal.test.tsx
+++ b/app/src/pages/Run/__tests__/ConfirmCancelModal.test.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react'
+import { renderWithProviders } from '@opentrons/components'
+import { fireEvent } from '@testing-library/react'
+import { i18n } from '../../../i18n'
+import { ConfirmCancelModal } from '../RunLog'
+
+const render = (props: React.ComponentProps<typeof ConfirmCancelModal>) => {
+  return renderWithProviders(<ConfirmCancelModal {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+describe('ConfirmCancelModal', () => {
+  let props: React.ComponentProps<typeof ConfirmCancelModal>
+  beforeEach(() => {
+    props = { onClose: jest.fn() }
+  })
+
+  it('should render the correct title', () => {
+    const { getByText } = render(props)
+    getByText('Are you sure you want to cancel this run?')
+  })
+  it('should render the correct body', () => {
+    const { getByText } = render(props)
+    getByText(
+      'Doing so will terminate this run, drop any attached tips in the trash container and home your robot.'
+    )
+    getByText(
+      'Additionally, any hardware modules used within the protocol will remain active and maintain their current states until deactivated.'
+    )
+  })
+  it('should render both buttons', () => {
+    const { getByRole } = render(props)
+    expect(props.onClose).not.toHaveBeenCalled()
+    getByRole('button', { name: 'yes, cancel run' })
+    getByRole('button', { name: 'no, go back' })
+  })
+  it('should call yes cancel run button', () => {
+    const { getByRole } = render(props)
+    expect(props.onClose).not.toHaveBeenCalled()
+    const closeButton = getByRole('button', { name: 'yes, cancel run' })
+    fireEvent.click(closeButton)
+    expect(props.onClose).toHaveBeenCalled()
+  })
+  it('should call No go back button', () => {
+    const { getByRole } = render(props)
+    const closeButton = getByRole('button', { name: 'no, go back' })
+    fireEvent.click(closeButton)
+    expect(props.onClose).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
closes #9066

# Overview

This PR makes the closing or cancelling a run modal consistent whether you are closing/cancelling on the run details page or the protocol accordion steps page.
<img width="959" alt="Screen Shot 2021-12-10 at 13 16 12" src="https://user-images.githubusercontent.com/66035149/145623470-6b9de66a-89ed-4e68-8339-faf23000726c.png">

<img width="964" alt="Screen Shot 2021-12-10 at 13 16 25" src="https://user-images.githubusercontent.com/66035149/145623491-44d302dc-ac8d-492c-a496-129b05e13167.png">


# Changelog

- had to extend the props in `ConfirmCloseModal` in order to make the buttons blue because I noticed that the modal is used in other areas of the repo
- made a test for `ConfirmCloseModal` because i noticed it was missing
- added a bunch of stuff to `ProtocolUpload` component to add the `ConfirmCloseModal` when you cancel during a run

# Review requests

- test the 3 flows on a robot to make sure it looks good. I did test on my robot already. But also, [here](https://www.figma.com/file/JCQNOTTK9tTmYPhRqeOfSj/Milestone-0%3A-Protocol-Upload-Revamp?node-id=9896%3A204063) are the 3 flows outlined on figma.
- review my changes on `CloseConfirmModal` to make sure it is ok since that component is used all over the repo (NOTE: you'll see that I used `secondaryBtn` for both buttons, this is because the original modal before I added the button colors has both of the buttons as secondary button stylings)

# Risk assessment

low, behind ff
