### PR TITLE
feat(robot-server): Expose robot model in health

### DIFF
--- a/robot-server/robot_server/health/models.py
+++ b/robot-server/robot_server/health/models.py
@@ -1,6 +1,7 @@
 """HTTP request and response models for /health endpoints."""
 import typing
 from pydantic import BaseModel, Field
+from opentrons_shared_data.deck.dev_types import RobotModel
 
 
 class HealthLinks(BaseModel):
@@ -36,6 +37,10 @@ class Health(BaseModel):
         description="The robot's name. In most cases the same as its "
         "mDNS advertisement domain name, but this can get out "
         "of sync. Mostly useful for user-facing titles.",
+    )
+    robot_model: RobotModel = Field(
+        ...,
+        description="Which model of Opentrons robot this is",
     )
     api_version: str = Field(
         ...,

--- a/robot-server/robot_server/health/router.py
+++ b/robot-server/robot_server/health/router.py
@@ -44,7 +44,9 @@ async def get_health(hardware: HardwareAPI = Depends(get_hardware)) -> Health:
         system_version=config.OT_SYSTEM_VERSION,
         maximum_protocol_api_version=list(protocol_api.MAX_SUPPORTED_VERSION),
         minimum_protocol_api_version=list(protocol_api.MIN_SUPPORTED_VERSION),
-        robot_model='OT-3 Standard' if enable_ot3_hardware_controller() else 'OT-2 Standard',
+        robot_model="OT-3 Standard"
+        if enable_ot3_hardware_controller()
+        else "OT-2 Standard",
         links=HealthLinks(
             apiLog="/logs/api.log",
             serialLog="/logs/serial.log",

--- a/robot-server/robot_server/health/router.py
+++ b/robot-server/robot_server/health/router.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, Depends, status
 
 from opentrons import __version__, config, protocol_api
 from opentrons.hardware_control import API as HardwareAPI
+from opentrons.config.feature_flags import enable_ot3_hardware_controller
 
 from robot_server.hardware import get_hardware
 from robot_server.service.legacy.models import V1BasicResponse
@@ -43,6 +44,7 @@ async def get_health(hardware: HardwareAPI = Depends(get_hardware)) -> Health:
         system_version=config.OT_SYSTEM_VERSION,
         maximum_protocol_api_version=list(protocol_api.MAX_SUPPORTED_VERSION),
         minimum_protocol_api_version=list(protocol_api.MIN_SUPPORTED_VERSION),
+        robot_model='OT-3 Standard' if enable_ot3_hardware_controller() else 'OT-2 Standard',
         links=HealthLinks(
             apiLog="/logs/api.log",
             serialLog="/logs/serial.log",

--- a/robot-server/tests/health/test_health_router.py
+++ b/robot-server/tests/health/test_health_router.py
@@ -20,7 +20,7 @@ def test_get_health(api_client: TestClient, hardware: MagicMock) -> None:
         "system_version": "0.0.0",
         "minimum_protocol_api_version": list(MIN_SUPPORTED_VERSION),
         "maximum_protocol_api_version": list(MAX_SUPPORTED_VERSION),
-        'robot_model': 'OT-2 Standard',
+        "robot_model": "OT-2 Standard",
         "links": {
             "apiLog": "/logs/api.log",
             "serialLog": "/logs/serial.log",

--- a/robot-server/tests/health/test_health_router.py
+++ b/robot-server/tests/health/test_health_router.py
@@ -20,6 +20,7 @@ def test_get_health(api_client: TestClient, hardware: MagicMock) -> None:
         "system_version": "0.0.0",
         "minimum_protocol_api_version": list(MIN_SUPPORTED_VERSION),
         "maximum_protocol_api_version": list(MAX_SUPPORTED_VERSION),
+        'robot_model': 'OT-2 Standard',
         "links": {
             "apiLog": "/logs/api.log",
             "serialLog": "/logs/serial.log",

--- a/robot-server/tests/integration/fixtures.py
+++ b/robot-server/tests/integration/fixtures.py
@@ -14,6 +14,7 @@ def check_health_response(response: Response) -> None:
         "board_revision": "2.1",
         "logs": ["/logs/serial.log", "/logs/api.log", "/logs/server.log"],
         "system_version": config.OT_SYSTEM_VERSION,
+        "robot_model": "OT-2 Standard",
         "minimum_protocol_api_version": minimum_version,
         "maximum_protocol_api_version": maximum_version,
         "links": {

--- a/shared-data/js/constants.ts
+++ b/shared-data/js/constants.ts
@@ -77,3 +77,5 @@ export const MODULE_TYPES = [
 export const GEN_ONE_MULTI_PIPETTES = ['p10_multi', 'p50_multi', 'p300_multi']
 
 export const IDENTITY_VECTOR = { x: 0, y: 0, z: 0 }
+
+export const ROBOT_MODELS = ['OT-2 Standard', 'OT-3 Standard']

--- a/shared-data/python/opentrons_shared_data/deck/__init__.py
+++ b/shared-data/python/opentrons_shared_data/deck/__init__.py
@@ -2,15 +2,9 @@
 opentrons_shared_data.deck: types and bindings for deck definitions
 """
 from typing import overload, TYPE_CHECKING
-import enum
 import json
 
 from .. import load_shared_data
-
-class RobotModel(enum.Enum):
-    OT2_STANDARD: str = "OT-2 Standard"
-    OT3_STANDARD: str = "OT-3 Standard"
-
 
 if TYPE_CHECKING:
     from .dev_types import (DeckSchema, DeckDefinition,

--- a/shared-data/python/opentrons_shared_data/deck/__init__.py
+++ b/shared-data/python/opentrons_shared_data/deck/__init__.py
@@ -2,9 +2,15 @@
 opentrons_shared_data.deck: types and bindings for deck definitions
 """
 from typing import overload, TYPE_CHECKING
+import enum
 import json
 
 from .. import load_shared_data
+
+class RobotModel(enum.Enum):
+    OT2_STANDARD: str = "OT-2 Standard"
+    OT3_STANDARD: str = "OT-3 Standard"
+
 
 if TYPE_CHECKING:
     from .dev_types import (DeckSchema, DeckDefinition,

--- a/shared-data/python/opentrons_shared_data/deck/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/deck/dev_types.py
@@ -16,13 +16,16 @@ DeckSchemaVersion1 = Literal[1]
 DeckSchema = NewType('DeckSchema', Dict[str, Any])
 
 
+RobotModel = Union[Literal['OT-2 Standard'], Literal['OT-3 Standard']]
+
+
 class Metadata(TypedDict, total=False):
     displayName: str
     tags: List[str]
 
 
 class Robot(TypedDict):
-    model: Literal['OT-2 Standard']
+    model: RobotModel
 
 
 class BoundingBox(TypedDict):


### PR DESCRIPTION
The robot server `/health` model now has a `robot_model` element containing either `OT-2 Standard` or `OT-3 Standard`. This may be used by HTTP clients to determine what kind of robot they are talking to.