### PR TITLE
refactor(engine): add command key field

### DIFF
--- a/api/src/opentrons/protocol_engine/actions/actions.py
+++ b/api/src/opentrons/protocol_engine/actions/actions.py
@@ -76,6 +76,7 @@ class QueueCommandAction:
     """Add a command request to the queue."""
 
     command_id: str
+    command_key: str
     created_at: datetime
     request: CommandCreate
 

--- a/api/src/opentrons/protocol_engine/commands/command.py
+++ b/api/src/opentrons/protocol_engine/commands/command.py
@@ -49,13 +49,26 @@ class BaseCommand(GenericModel, Generic[CommandParamsT, CommandResultT]):
     your own subclass per specific command type.
     """
 
-    id: str = Field(..., description="Unique identifier for a particular command")
+    id: str = Field(
+        ...,
+        description="Unique identifier of this particular command instance",
+    )
     createdAt: datetime = Field(..., description="Command creation timestamp")
     commandType: str = Field(
         ...,
         description=(
             "Specific command type that determines data requirements and "
             "execution behavior"
+        ),
+    )
+    key: str = Field(
+        ...,
+        description=(
+            "An identifier representing this command as a step in a protocol."
+            " A command's `key` will be unique within a given run, but stable"
+            " across all runs that perform the same exact procedure. Thus,"
+            " `key` be used to compare/match commands across multiple runs"
+            " of the same protocol."
         ),
     )
     status: CommandStatus = Field(..., description="Command execution status")

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -104,6 +104,9 @@ class ProtocolEngine:
         action = QueueCommandAction(
             request=request,
             command_id=command_id,
+            # TODO(mc, 2021-12-13): generate a command key from params and state
+            # https://github.com/Opentrons/opentrons/issues/8986
+            command_key=command_id,
             created_at=self._model_utils.get_timestamp(),
         )
         self._action_dispatcher.dispatch(action)

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -83,6 +83,7 @@ class CommandStore(HasState[CommandState], HandlesActions):
             # For now, unit tests cover mapping every request type
             queued_command = action.request._CommandCls.construct(
                 id=action.command_id,
+                key=action.command_key,
                 createdAt=action.created_at,
                 params=action.request.params,  # type: ignore[arg-type]
                 status=CommandStatus.QUEUED,

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -159,6 +159,7 @@ class LegacyCommandMapper:
 
         load_labware_command = pe_commands.LoadLabware.construct(
             id=command_id,
+            key=command_id,
             status=pe_commands.CommandStatus.SUCCEEDED,
             createdAt=now,
             startedAt=now,
@@ -198,6 +199,7 @@ class LegacyCommandMapper:
 
         load_pipette_command = pe_commands.LoadPipette.construct(
             id=command_id,
+            key=command_id,
             status=pe_commands.CommandStatus.SUCCEEDED,
             createdAt=now,
             startedAt=now,
@@ -222,6 +224,7 @@ class LegacyCommandMapper:
         now = ModelUtils.get_timestamp()
 
         count = self._command_count["LOAD_MODULE"]
+        command_id = f"commands.LOAD_MODULE-{count}"
         module_id = f"module-{count}"
         module_model = LEGACY_TO_PE_MODULE[module_load_info.module_model]
 
@@ -235,7 +238,8 @@ class LegacyCommandMapper:
         ) or self._module_data_provider.get_module_definition(module_model)
 
         load_module_command = pe_commands.LoadModule.construct(
-            id=f"commands.LOAD_MODULE-{count}",
+            id=command_id,
+            key=command_id,
             status=pe_commands.CommandStatus.SUCCEEDED,
             createdAt=now,
             startedAt=now,
@@ -283,6 +287,7 @@ class LegacyCommandMapper:
 
             engine_command = pe_commands.PickUpTip.construct(
                 id=command_id,
+                key=command_id,
                 status=pe_commands.CommandStatus.RUNNING,
                 createdAt=now,
                 startedAt=now,
@@ -296,6 +301,7 @@ class LegacyCommandMapper:
         elif command["name"] == legacy_command_types.PAUSE:
             engine_command = pe_commands.Pause.construct(
                 id=command_id,
+                key=command_id,
                 status=pe_commands.CommandStatus.RUNNING,
                 createdAt=now,
                 startedAt=now,
@@ -307,6 +313,7 @@ class LegacyCommandMapper:
         else:
             engine_command = pe_commands.Custom.construct(
                 id=command_id,
+                key=command_id,
                 status=pe_commands.CommandStatus.RUNNING,
                 createdAt=now,
                 startedAt=now,

--- a/api/tests/opentrons/protocol_engine/clients/test_child_thread_transport.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_child_thread_transport.py
@@ -45,6 +45,7 @@ async def test_execute_command(
     decoy.when(await engine.add_and_execute_command(request=cmd_request)).then_return(
         commands.MoveToWell(
             id="cmd-id",
+            key="cmd-key",
             status=commands.CommandStatus.SUCCEEDED,
             params=cmd_data,
             result=cmd_result,
@@ -75,6 +76,7 @@ async def test_execute_command_failure(
     decoy.when(await engine.add_and_execute_command(request=cmd_request)).then_return(
         commands.MoveToWell(
             id="cmd-id",
+            key="cmd-key",
             params=cmd_data,
             status=commands.CommandStatus.FAILED,
             errorId="error-id",

--- a/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
@@ -138,6 +138,7 @@ async def test_execute(
         Command,
         _TestCommand(
             id="command-id",
+            key="command-key",
             createdAt=datetime(year=2021, month=1, day=1),
             status=CommandStatus.QUEUED,
             params=command_params,
@@ -148,6 +149,7 @@ async def test_execute(
         Command,
         _TestCommand(
             id="command-id",
+            key="command-key",
             createdAt=datetime(year=2021, month=1, day=1),
             startedAt=datetime(year=2022, month=2, day=2),
             status=CommandStatus.RUNNING,
@@ -159,6 +161,7 @@ async def test_execute(
         Command,
         _TestCommand(
             id="command-id",
+            key="command-key",
             createdAt=datetime(year=2021, month=1, day=1),
             startedAt=datetime(year=2022, month=2, day=2),
             completedAt=datetime(year=2023, month=3, day=3),
@@ -243,6 +246,7 @@ async def test_execute_raises_protocol_engine_error(
         Command,
         _TestCommand(
             id="command-id",
+            key="command-key",
             createdAt=datetime(year=2021, month=1, day=1),
             status=CommandStatus.QUEUED,
             params=command_params,
@@ -253,6 +257,7 @@ async def test_execute_raises_protocol_engine_error(
         Command,
         _TestCommand(
             id="command-id",
+            key="command-key",
             createdAt=datetime(year=2021, month=1, day=1),
             startedAt=datetime(year=2022, month=2, day=2),
             status=CommandStatus.RUNNING,

--- a/api/tests/opentrons/protocol_engine/state/command_fixtures.py
+++ b/api/tests/opentrons/protocol_engine/state/command_fixtures.py
@@ -13,8 +13,9 @@ from opentrons.protocol_engine.types import (
 )
 
 
-def create_pending_command(
+def create_queued_command(
     command_id: str = "command-id",
+    command_key: str = "command-key",
     command_type: str = "command-type",
     params: Optional[BaseModel] = None,
 ) -> cmd.Command:
@@ -23,6 +24,7 @@ def create_pending_command(
         cmd.Command,
         cmd.BaseCommand(
             id=command_id,
+            key=command_key,
             commandType=command_type,
             createdAt=datetime(year=2021, month=1, day=1),
             status=cmd.CommandStatus.QUEUED,
@@ -33,6 +35,7 @@ def create_pending_command(
 
 def create_running_command(
     command_id: str = "command-id",
+    command_key: str = "command-key",
     command_type: str = "command-type",
     params: Optional[BaseModel] = None,
 ) -> cmd.Command:
@@ -41,6 +44,7 @@ def create_running_command(
         cmd.Command,
         cmd.BaseCommand(
             id=command_id,
+            key=command_key,
             createdAt=datetime(year=2021, month=1, day=1),
             commandType=command_type,
             status=cmd.CommandStatus.RUNNING,
@@ -51,6 +55,7 @@ def create_running_command(
 
 def create_failed_command(
     command_id: str = "command-id",
+    command_key: str = "command-key",
     command_type: str = "command-type",
     error_id: str = "error-id",
     completed_at: datetime = datetime(year=2022, month=2, day=2),
@@ -61,6 +66,7 @@ def create_failed_command(
         cmd.Command,
         cmd.BaseCommand(
             id=command_id,
+            key=command_key,
             createdAt=datetime(year=2021, month=1, day=1),
             commandType=command_type,
             status=cmd.CommandStatus.FAILED,
@@ -71,8 +77,9 @@ def create_failed_command(
     )
 
 
-def create_completed_command(
+def create_succeeded_command(
     command_id: str = "command-id",
+    command_key: str = "command-key",
     command_type: str = "command-type",
     params: Optional[BaseModel] = None,
     result: Optional[BaseModel] = None,
@@ -82,6 +89,7 @@ def create_completed_command(
         cmd.Command,
         cmd.BaseCommand(
             id=command_id,
+            key=command_key,
             createdAt=datetime(year=2021, month=1, day=1),
             commandType=command_type,
             status=cmd.CommandStatus.SUCCEEDED,
@@ -112,6 +120,7 @@ def create_load_labware_command(
 
     return cmd.LoadLabware(
         id="command-id",
+        key="command-key",
         status=cmd.CommandStatus.SUCCEEDED,
         createdAt=datetime.now(),
         params=params,
@@ -130,6 +139,7 @@ def create_load_pipette_command(
 
     return cmd.LoadPipette(
         id="command-id",
+        key="command-key",
         status=cmd.CommandStatus.SUCCEEDED,
         createdAt=datetime.now(),
         params=params,
@@ -156,6 +166,7 @@ def create_aspirate_command(
 
     return cmd.Aspirate(
         id="command-id",
+        key="command-key",
         status=cmd.CommandStatus.SUCCEEDED,
         createdAt=datetime.now(),
         params=params,
@@ -182,6 +193,7 @@ def create_dispense_command(
 
     return cmd.Dispense(
         id="command-id",
+        key="command-key",
         status=cmd.CommandStatus.SUCCEEDED,
         createdAt=datetime.now(),
         params=params,
@@ -205,6 +217,7 @@ def create_pick_up_tip_command(
 
     return cmd.PickUpTip(
         id="command-id",
+        key="command-key",
         status=cmd.CommandStatus.SUCCEEDED,
         createdAt=datetime.now(),
         params=data,
@@ -228,6 +241,7 @@ def create_drop_tip_command(
 
     return cmd.DropTip(
         id="command-id",
+        key="command-key",
         status=cmd.CommandStatus.SUCCEEDED,
         createdAt=datetime.now(),
         params=params,
@@ -251,6 +265,7 @@ def create_move_to_well_command(
 
     return cmd.MoveToWell(
         id="command-id",
+        key="command-key",
         status=cmd.CommandStatus.SUCCEEDED,
         createdAt=datetime.now(),
         params=params,

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -210,7 +210,8 @@ def test_home_clears_current_well(subject: PipetteStore) -> None:
         well_name="well-name",
     )
     home_command = cmd.Home(
-        id="command-id",
+        id="command-id-2",
+        key="command-key-2",
         status=cmd.CommandStatus.SUCCEEDED,
         createdAt=datetime(year=2021, month=1, day=1),
         params=cmd.HomeParams(),

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -120,6 +120,7 @@ def test_add_command(
 
     queued_command = commands.LoadPipette(
         id="command-id",
+        key="command-key",
         status=commands.CommandStatus.QUEUED,
         createdAt=created_at,
         params=params,
@@ -136,6 +137,7 @@ def test_add_command(
         action_dispatcher.dispatch(
             QueueCommandAction(
                 command_id="command-id",
+                command_key="command-id",
                 created_at=created_at,
                 request=request,
             )
@@ -164,6 +166,7 @@ async def test_execute_command(
 
     queued_command = commands.LoadPipette(
         id="command-id",
+        key="command-key",
         status=commands.CommandStatus.QUEUED,
         createdAt=created_at,
         params=params,
@@ -171,6 +174,7 @@ async def test_execute_command(
 
     executed_command = commands.LoadPipette(
         id="command-id",
+        key="command-key",
         status=commands.CommandStatus.SUCCEEDED,
         createdAt=created_at,
         startedAt=created_at,
@@ -193,6 +197,7 @@ async def test_execute_command(
         action_dispatcher.dispatch(
             QueueCommandAction(
                 command_id="command-id",
+                command_key="command-id",
                 created_at=created_at,
                 request=request,
             )

--- a/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_command_mapper.py
@@ -83,6 +83,7 @@ async def test_legacy_pick_up_tip(
 
     assert commands_result[0] == commands.LoadLabware.construct(
         id=matchers.IsA(str),
+        key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
@@ -93,6 +94,7 @@ async def test_legacy_pick_up_tip(
 
     assert commands_result[1] == commands.LoadLabware.construct(
         id=matchers.IsA(str),
+        key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
@@ -103,6 +105,7 @@ async def test_legacy_pick_up_tip(
 
     assert commands_result[2] == commands.LoadPipette.construct(
         id=matchers.IsA(str),
+        key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
@@ -113,6 +116,7 @@ async def test_legacy_pick_up_tip(
 
     assert commands_result[3] == commands.LoadPipette.construct(
         id=matchers.IsA(str),
+        key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
@@ -130,6 +134,7 @@ async def test_legacy_pick_up_tip(
 
     assert commands_result[4] == commands.PickUpTip.construct(
         id=matchers.IsA(str),
+        key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
@@ -143,6 +148,7 @@ async def test_legacy_pick_up_tip(
 
     assert commands_result[5] == commands.PickUpTip.construct(
         id=matchers.IsA(str),
+        key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
@@ -158,6 +164,7 @@ async def test_legacy_pick_up_tip(
 
     assert commands_result[7] == commands.PickUpTip.construct(
         id=matchers.IsA(str),
+        key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),

--- a/api/tests/opentrons/protocol_runner/smoke_tests/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/test_protocol_runner.py
@@ -70,6 +70,7 @@ async def test_runner_with_python(
 
     expected_command = commands.PickUpTip.construct(
         id=matchers.IsA(str),
+        key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
@@ -124,6 +125,7 @@ async def test_runner_with_json(
 
     expected_command = commands.PickUpTip.construct(
         id=matchers.IsA(str),
+        key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
@@ -180,6 +182,7 @@ async def test_runner_with_legacy_python(
 
     expected_command = commands.PickUpTip.construct(
         id=matchers.IsA(str),
+        key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
@@ -236,6 +239,7 @@ async def test_runner_with_legacy_json(
 
     expected_command = commands.PickUpTip.construct(
         id=matchers.IsA(str),
+        key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -53,6 +53,7 @@ def test_map_before_command() -> None:
         pe_actions.UpdateCommandAction(
             pe_commands.Custom.construct(
                 id="command.COMMENT-0",
+                key="command.COMMENT-0",
                 status=pe_commands.CommandStatus.RUNNING,
                 createdAt=matchers.IsA(datetime),
                 startedAt=matchers.IsA(datetime),
@@ -91,6 +92,7 @@ def test_map_after_command() -> None:
         pe_actions.UpdateCommandAction(
             pe_commands.Custom.construct(
                 id="command.COMMENT-0",
+                key="command.COMMENT-0",
                 status=pe_commands.CommandStatus.SUCCEEDED,
                 createdAt=matchers.IsA(datetime),
                 startedAt=matchers.IsA(datetime),
@@ -182,6 +184,7 @@ def test_command_stack() -> None:
         pe_actions.UpdateCommandAction(
             pe_commands.Custom.construct(
                 id="command.COMMENT-0",
+                key="command.COMMENT-0",
                 status=pe_commands.CommandStatus.RUNNING,
                 createdAt=matchers.IsA(datetime),
                 startedAt=matchers.IsA(datetime),
@@ -194,6 +197,7 @@ def test_command_stack() -> None:
         pe_actions.UpdateCommandAction(
             pe_commands.Custom.construct(
                 id="command.COMMENT-1",
+                key="command.COMMENT-1",
                 status=pe_commands.CommandStatus.RUNNING,
                 createdAt=matchers.IsA(datetime),
                 startedAt=matchers.IsA(datetime),
@@ -206,6 +210,7 @@ def test_command_stack() -> None:
         pe_actions.UpdateCommandAction(
             pe_commands.Custom.construct(
                 id="command.COMMENT-0",
+                key="command.COMMENT-0",
                 status=pe_commands.CommandStatus.SUCCEEDED,
                 createdAt=matchers.IsA(datetime),
                 startedAt=matchers.IsA(datetime),
@@ -238,6 +243,7 @@ def test_map_labware_load(minimal_labware_def: LabwareDefinition) -> None:
     )
     expected_output = pe_commands.LoadLabware.construct(
         id=matchers.IsA(str),
+        key=matchers.IsA(str),
         status=pe_commands.CommandStatus.SUCCEEDED,
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
@@ -269,6 +275,7 @@ def test_map_instrument_load() -> None:
     )
     expected_output = pe_commands.LoadPipette.construct(
         id=matchers.IsA(str),
+        key=matchers.IsA(str),
         status=pe_commands.CommandStatus.SUCCEEDED,
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
@@ -301,6 +308,7 @@ def test_map_module_load(
     ).then_return(test_definition)
     expected_output = pe_commands.LoadModule.construct(
         id=matchers.IsA(str),
+        key=matchers.IsA(str),
         status=pe_commands.CommandStatus.SUCCEEDED,
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
@@ -336,6 +344,7 @@ def test_map_module_labware_load(minimal_labware_def: LabwareDefinition) -> None
 
     expected_output = pe_commands.LoadLabware.construct(
         id=matchers.IsA(str),
+        key=matchers.IsA(str),
         status=pe_commands.CommandStatus.SUCCEEDED,
         createdAt=matchers.IsA(datetime),
         startedAt=matchers.IsA(datetime),
@@ -386,6 +395,7 @@ def test_map_pause() -> None:
         pe_actions.UpdateCommandAction(
             pe_commands.Pause.construct(
                 id="command.PAUSE-0",
+                key="command.PAUSE-0",
                 status=pe_commands.CommandStatus.RUNNING,
                 createdAt=matchers.IsA(datetime),
                 startedAt=matchers.IsA(datetime),
@@ -395,6 +405,7 @@ def test_map_pause() -> None:
         pe_actions.UpdateCommandAction(
             pe_commands.Pause.construct(
                 id="command.PAUSE-0",
+                key="command.PAUSE-0",
                 status=pe_commands.CommandStatus.SUCCEEDED,
                 createdAt=matchers.IsA(datetime),
                 startedAt=matchers.IsA(datetime),

--- a/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
@@ -172,6 +172,7 @@ async def test_main_broker_messages(
     }
     engine_command = pe_commands.Custom(
         id="command-id",
+        key="command-key",
         status=pe_commands.CommandStatus.RUNNING,
         createdAt=datetime(year=2021, month=1, day=1),
         params=pe_commands.CustomParams(message="hello"),  # type: ignore[call-arg]
@@ -218,6 +219,7 @@ async def test_labware_load_broker_messages(
 
     engine_command = pe_commands.Custom(
         id="command-id",
+        key="command-key",
         status=pe_commands.CommandStatus.RUNNING,
         createdAt=datetime(year=2021, month=1, day=1),
         params=pe_commands.CustomParams(message="hello"),  # type: ignore[call-arg]
@@ -259,6 +261,7 @@ async def test_instrument_load_broker_messages(
 
     engine_command = pe_commands.Custom(
         id="command-id",
+        key="command-key",
         status=pe_commands.CommandStatus.RUNNING,
         createdAt=datetime(year=2021, month=1, day=1),
         params=pe_commands.CustomParams(message="hello"),  # type: ignore[call-arg]
@@ -302,6 +305,7 @@ async def test_module_load_broker_messages(
     )
     engine_command = pe_commands.Custom(
         id="command-id",
+        key="command-key",
         status=pe_commands.CommandStatus.RUNNING,
         createdAt=datetime(year=2021, month=1, day=1),
         params=pe_commands.CustomParams(message="hello"),  # type: ignore[call-arg]

--- a/robot-server/tests/protocols/test_analysis_store.py
+++ b/robot-server/tests/protocols/test_analysis_store.py
@@ -87,6 +87,7 @@ command_analysis_specs: List[CommandAnalysisSpec] = [
         commands=[
             pe_commands.Pause(
                 id="pause-1",
+                key="command-key",
                 status=pe_commands.CommandStatus.SUCCEEDED,
                 createdAt=datetime(year=2021, month=1, day=1),
                 params=pe_commands.PauseParams(message="hello world"),

--- a/robot-server/tests/protocols/test_protocol_analyzer.py
+++ b/robot-server/tests/protocols/test_protocol_analyzer.py
@@ -64,6 +64,7 @@ async def test_analyze(
 
     analysis_command = pe_commands.Pause(
         id="command-id",
+        key="command-key",
         status=pe_commands.CommandStatus.SUCCEEDED,
         createdAt=datetime(year=2022, month=2, day=2),
         params=pe_commands.PauseParams(message="hello world"),

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -290,6 +290,7 @@ async def test_get_run(
 
     command = pe_commands.Pause(
         id="command-id",
+        key="command-key",
         status=pe_commands.CommandStatus.QUEUED,
         createdAt=datetime(year=2021, month=1, day=1),
         params=pe_commands.PauseParams(message="hello world"),
@@ -370,6 +371,7 @@ async def test_get_run_with_errors(
 
     command = pe_commands.Pause(
         id="command-id",
+        key="command-key",
         status=pe_commands.CommandStatus.FAILED,
         createdAt=datetime(year=2022, month=2, day=2),
         params=pe_commands.PauseParams(message="hello world"),

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -45,6 +45,7 @@ async def test_create_run_command(decoy: Decoy, engine_store: EngineStore) -> No
 
     output_command = pe_commands.Pause(
         id="abc123",
+        key="command-key",
         createdAt=datetime(year=2021, month=1, day=1),
         status=CommandStatus.QUEUED,
         params=pe_commands.PauseParams(message="Hello"),
@@ -138,6 +139,7 @@ async def test_get_run_command_by_id(
 
     command = pe_commands.MoveToWell(
         id="command-id",
+        key="command-key",
         status=CommandStatus.RUNNING,
         createdAt=datetime(year=2022, month=2, day=2),
         params=pe_commands.MoveToWellParams(pipetteId="a", labwareId="b", wellName="c"),


### PR DESCRIPTION
## Overview

This PR adds a `key` field to command models for cross-run comparison. Closes #9058, but does not yet do anything for #8986.

Companion front-end ticket: #9079 

## Changelog

- refactor(engine): add command key field
    - This field is only correctly populated for PAPIv2 protocols at the moment

## Review requests

Good for just a code review on this one until we can get the FE in place for e2e testing.

## Risk assessment

Low, field addition only