### PR TITLE
refactor(app): rename Labware Offset modal title

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -6,7 +6,7 @@
   "labware_setup_step_description": "Position full tip racks and labware in the deck slots as shown in the deck map.",
   "labware_setup_step_title": "Labware Setup",
   "labware_help_link_title": "See How Labware Offsets Work",
-  "how_offset_data_works_title": "How Offset Data Works",
+  "how_offset_data_works_title": "How Labware Offsets Work",
   "position_offset_overiew_and_description": "<h4>Positional Adjustments Overview</h4><block>The OT-2 provides two types of positional adjustments. The first type is robot calibration: Deck calibration, Tip Length calibration and Pipette Offset calibration. These calibrations ensure the OT-2 moves to the expected positions on the deck. It is essential to have good robot calibration before creating any labware offsets and running protocols.</block>",
   "learn_more_about_robot_cal_offset_modal_link": "Learn more about Robot Calibration",
   "creating_labware_offset_data": "<h4>Creating Labware Offset Data During Labware Position Check</h4><block>Labware Position Check is a guided workflow that helps you verify the position of every labware on the deck for an added degree of precision in your protocol. When you check a labware, the OT-2’s pipette nozzle or attached tip will stop at the center of the A1 well. If the pipette nozzle or tip is not centered, you can reveal the OT-2’s jog controls to make an adjustment. This Labware Offset will be applied to the entire labware. Offset data is measured to the nearest 1/10th mm and can be made in the X, Y and/or Z directions.</block>",

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareOffsetModal.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareOffsetModal.test.tsx
@@ -18,7 +18,9 @@ describe('LabwareOffsetModal', () => {
 
   it('should render the correct header', () => {
     const { getByRole } = render(props)
-    expect(getByRole('heading', { name: 'How Offset Data Works' })).toBeTruthy()
+    expect(
+      getByRole('heading', { name: 'How Labware Offsets Work' })
+    ).toBeTruthy()
   })
   it('should render the correct body', () => {
     const { getByRole, getByText } = render(props)


### PR DESCRIPTION
closes #9078

# Overview

This PR changes the modal title to match the new design:
<img width="926" alt="Screen Shot 2021-12-13 at 12 09 02" src="https://user-images.githubusercontent.com/66035149/145857367-fff04866-6c6b-4cd6-9520-c6022ddec6f4.png">


# Changelog

- a quick update to the json file and test

# Review requests

- review above image, or on your robot

# Risk assessment

love, behind ff
