### PR TITLE
refactor(app): remove explicit null check in query hooks

### DIFF
--- a/react-api-client/src/protocols/useProtocolQuery.ts
+++ b/react-api-client/src/protocols/useProtocolQuery.ts
@@ -16,7 +16,7 @@ export function useProtocolQuery(
     ...options,
     enabled:
       host !== null &&
-      protocolId !== null &&
+      protocolId != null &&
       (enablePolling == null || enablePolling),
     refetchInterval:
       enablePolling != null

--- a/react-api-client/src/runs/useRunQuery.ts
+++ b/react-api-client/src/runs/useRunQuery.ts
@@ -16,7 +16,7 @@ export function useRunQuery(
         response => response.data
       ),
     {
-      enabled: host !== null && runId !== null,
+      enabled: host !== null && runId != null,
       ...options,
     }
   )


### PR DESCRIPTION
# Overview

This PR stops networks requests being made to to `/runs/undefined` that were happening because the React query was not getting correctly disabled when `protocolId` is `undefined`

# Changelog

- Fix network requests to undefined runs endpoint


# Review requests
Run a protocol, cancel the protocol, open your network tab, you should no longer see requests to `/runs/undefined` in your network tab

# Risk assessment
Low