### PR TITLE
fix(app, shared-data): splice out first set of setup commands from run log only

### DIFF
--- a/app/src/organisms/RunDetails/CommandList.tsx
+++ b/app/src/organisms/RunDetails/CommandList.tsx
@@ -1,5 +1,4 @@
 import dropWhile from 'lodash/dropWhile'
-import last from 'lodash/last'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import {
@@ -58,26 +57,20 @@ export function CommandList(): JSX.Element | null {
       : []
   const allProtocolCommands: Command[] =
     protocolData != null ? analysisCommandsWithStatus : []
-  const lastProtocolSetupCommand =
-    last(
-      allProtocolCommands.filter(command =>
-        ['loadLabware', 'loadPipette', 'loadModule'].includes(
-          command.commandType
-        )
-      )
-    ) ?? null
-  const lastProtocolSetupIndex = allProtocolCommands.findIndex(
-    command => command.id === lastProtocolSetupCommand?.id
-  )
 
-  const protocolSetupCommandList =
-    lastProtocolSetupCommand != null
-      ? allProtocolCommands.slice(0, lastProtocolSetupIndex + 1)
-      : []
-  const postSetupAnticipatedCommands: Command[] =
-    lastProtocolSetupCommand != null
-      ? allProtocolCommands.slice(lastProtocolSetupIndex + 1)
-      : allProtocolCommands
+  const firstNonSetupIndex = allProtocolCommands.findIndex(
+    command =>
+      command.commandType !== 'loadLabware' &&
+      command.commandType !== 'loadPipette' &&
+      command.commandType !== 'loadModule'
+  )
+  const protocolSetupCommandList = allProtocolCommands.slice(
+    0,
+    firstNonSetupIndex
+  )
+  const postSetupAnticipatedCommands: Command[] = allProtocolCommands.slice(
+    firstNonSetupIndex
+  )
 
   let currentCommandList: Array<
     Command | RunCommandSummary
@@ -185,6 +178,7 @@ export function CommandList(): JSX.Element | null {
                   id={`RunDetails_ProtocolSetup_CommandList`}
                   flexDirection={DIRECTION_COLUMN}
                   marginLeft={SPACING_1}
+                  paddingLeft={SPACING_2}
                 >
                   {protocolSetupCommandList?.map(command => {
                     return (

--- a/app/src/organisms/RunDetails/CommandText.tsx
+++ b/app/src/organisms/RunDetails/CommandText.tsx
@@ -72,14 +72,8 @@ export function CommandText(props: Props): JSX.Element {
           commandOrSummary.params?.message ?? commandOrSummary.commandType
         break
       }
-      case 'loadLabware': {
-        messageNode = <ProtocolSetupInfo setupCommand={commandOrSummary} />
-        break
-      }
-      case 'loadPipette': {
-        messageNode = <ProtocolSetupInfo setupCommand={commandOrSummary} />
-        break
-      }
+      case 'loadLabware':
+      case 'loadPipette':
       case 'loadModule': {
         messageNode = <ProtocolSetupInfo setupCommand={commandOrSummary} />
         break

--- a/app/src/organisms/RunDetails/CommandText.tsx
+++ b/app/src/organisms/RunDetails/CommandText.tsx
@@ -8,6 +8,7 @@ import {
 } from '@opentrons/components'
 import type { RunCommandSummary } from '@opentrons/api-client'
 import { Command, getLabwareDisplayName } from '@opentrons/shared-data'
+import { ProtocolSetupInfo } from './ProtocolSetupInfo'
 
 import { useProtocolDetails } from './hooks'
 
@@ -70,6 +71,23 @@ export function CommandText(props: Props): JSX.Element {
         messageNode =
           commandOrSummary.params?.legacyCommandText ??
           commandOrSummary.commandType
+        break
+      }
+      case 'pause': {
+        messageNode =
+          commandOrSummary.params?.message ?? commandOrSummary.commandType
+        break
+      }
+      case 'loadLabware': {
+        messageNode = <ProtocolSetupInfo setupCommand={commandOrSummary} />
+        break
+      }
+      case 'loadPipette': {
+        messageNode = <ProtocolSetupInfo setupCommand={commandOrSummary} />
+        break
+      }
+      case 'loadModule': {
+        messageNode = <ProtocolSetupInfo setupCommand={commandOrSummary} />
         break
       }
       default: {

--- a/app/src/organisms/RunDetails/CommandText.tsx
+++ b/app/src/organisms/RunDetails/CommandText.tsx
@@ -67,10 +67,9 @@ export function CommandText(props: Props): JSX.Element {
         )
         break
       }
-      case 'custom': {
+      case 'pause': {
         messageNode =
-          commandOrSummary.params?.legacyCommandText ??
-          commandOrSummary.commandType
+          commandOrSummary.params?.message ?? commandOrSummary.commandType
         break
       }
       case 'loadLabware': {
@@ -83,6 +82,12 @@ export function CommandText(props: Props): JSX.Element {
       }
       case 'loadModule': {
         messageNode = <ProtocolSetupInfo setupCommand={commandOrSummary} />
+        break
+      }
+      case 'custom': {
+        messageNode =
+          commandOrSummary.params?.legacyCommandText ??
+          commandOrSummary.commandType
         break
       }
       default: {

--- a/app/src/organisms/RunDetails/CommandText.tsx
+++ b/app/src/organisms/RunDetails/CommandText.tsx
@@ -73,11 +73,6 @@ export function CommandText(props: Props): JSX.Element {
           commandOrSummary.commandType
         break
       }
-      case 'pause': {
-        messageNode =
-          commandOrSummary.params?.message ?? commandOrSummary.commandType
-        break
-      }
       case 'loadLabware': {
         messageNode = <ProtocolSetupInfo setupCommand={commandOrSummary} />
         break

--- a/app/src/organisms/RunDetails/ProtocolSetupInfo.tsx
+++ b/app/src/organisms/RunDetails/ProtocolSetupInfo.tsx
@@ -120,7 +120,7 @@ export const ProtocolSetupInfo = (
   }
   return (
     <Box
-      padding={`${SPACING_1} ${SPACING_2} ${SPACING_1} ${SPACING_2}`}
+      padding={`${SPACING_1} ${SPACING_2} ${SPACING_1} 0`}
       fontSize={FONT_SIZE_BODY_1}
     >
       {SetupCommandText}

--- a/app/src/organisms/RunDetails/__tests__/CommandList.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/CommandList.test.tsx
@@ -104,7 +104,7 @@ describe('CommandList', () => {
       getAllByText(
         'Picking up tip from A1 of Opentrons 96 Tip Rack 300 µL on 1'
       ).length
-    ).toEqual(17)
+    ).toEqual(26)
   })
   it('renders only anticipated steps if the current run info is present and has not updated', () => {
     // @ts-expect-error not a full match of RunData type
@@ -114,7 +114,7 @@ describe('CommandList', () => {
       getAllByText(
         'Picking up tip from A1 of Opentrons 96 Tip Rack 300 µL on 1'
       ).length
-    ).toEqual(17)
+    ).toEqual(26)
   })
   it('renders the protocol failed banner', () => {
     mockUseRunStatus.mockReturnValue('failed')

--- a/app/src/organisms/RunDetails/__tests__/CommandList.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/CommandList.test.tsx
@@ -9,8 +9,6 @@ import { useCurrentProtocolRun } from '../../ProtocolUpload/hooks'
 import { useRunStatus } from '../../RunTimeControl/hooks'
 import { ProtocolSetupInfo } from '../ProtocolSetupInfo'
 import { CommandList } from '../CommandList'
-import _uncastedSimpleV6Protocol from '@opentrons/shared-data/protocol/fixtures/6/simpleV6.json'
-import { schemaV6Adapter } from '@opentrons/shared-data/js/helpers/schemaV6Adapter'
 import fixtureAnalysis from '@opentrons/app/src/organisms/RunDetails/Fixture_analysis.json'
 import fixtureCommandSummary from '@opentrons/app/src/organisms/RunDetails/Fixture_commandSummary.json'
 import { CommandItem } from '../CommandItem'
@@ -21,7 +19,6 @@ jest.mock('../ProtocolSetupInfo')
 jest.mock('../CommandItem')
 jest.mock('../../RunTimeControl/hooks')
 jest.mock('../../ProtocolUpload/hooks')
-jest.mock('@opentrons/shared-data/js/helpers/schemaV6Adapter')
 jest.mock('@opentrons/components/src/alerts')
 
 const mockUseProtocolDetails = useProtocolDetails as jest.MockedFunction<
@@ -36,14 +33,10 @@ const mockUseRunStatus = useRunStatus as jest.MockedFunction<
 const mockProtocolSetupInfo = ProtocolSetupInfo as jest.MockedFunction<
   typeof ProtocolSetupInfo
 >
-const mockSchemaV6Adapter = schemaV6Adapter as jest.MockedFunction<
-  typeof schemaV6Adapter
->
 const mockCommandItem = CommandItem as jest.MockedFunction<typeof CommandItem>
 
 const mockAlertItem = AlertItem as jest.MockedFunction<typeof AlertItem>
 
-const simpleV6Protocol = (_uncastedSimpleV6Protocol as unknown) as ProtocolFile<{}>
 const _fixtureAnalysis = (fixtureAnalysis as unknown) as ProtocolFile<{}>
 
 const render = () => {
@@ -55,7 +48,7 @@ const render = () => {
 describe('CommandList', () => {
   beforeEach(() => {
     when(mockUseProtocolDetails).calledWith().mockReturnValue({
-      protocolData: simpleV6Protocol,
+      protocolData: _fixtureAnalysis,
       displayName: 'mock display name',
     })
     mockUseCurrentProtocolRun.mockReturnValue({
@@ -71,8 +64,6 @@ describe('CommandList', () => {
     })
     mockUseRunStatus.mockReturnValue('idle')
     mockProtocolSetupInfo.mockReturnValue(<div>Mock ProtocolSetup Info</div>)
-
-    mockSchemaV6Adapter.mockReturnValue(_fixtureAnalysis)
 
     when(mockCommandItem).mockReturnValue(
       <div>Picking up tip from A1 of Opentrons 96 Tip Rack 300 µL on 1</div>
@@ -104,7 +95,7 @@ describe('CommandList', () => {
       getAllByText(
         'Picking up tip from A1 of Opentrons 96 Tip Rack 300 µL on 1'
       ).length
-    ).toEqual(26)
+    ).toEqual(9)
   })
   it('renders only anticipated steps if the current run info is present and has not updated', () => {
     // @ts-expect-error not a full match of RunData type
@@ -114,7 +105,7 @@ describe('CommandList', () => {
       getAllByText(
         'Picking up tip from A1 of Opentrons 96 Tip Rack 300 µL on 1'
       ).length
-    ).toEqual(26)
+    ).toEqual(9)
   })
   it('renders the protocol failed banner', () => {
     mockUseRunStatus.mockReturnValue('failed')

--- a/app/src/organisms/RunDetails/__tests__/CommandText.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/CommandText.test.tsx
@@ -43,6 +43,16 @@ const MOCK_COMMAND_DETAILS = {
   completedAt: 'end timestamp',
 } as Command
 
+const MOCK_PAUSE_COMMAND = {
+  id: '1234',
+  commandType: 'pause',
+  params: { message: 'THIS IS THE PAUSE MESSAGE' },
+  status: 'running',
+  result: {},
+  startedAt: 'start timestamp',
+  completedAt: 'end timestamp',
+}
+
 describe('CommandText', () => {
   beforeEach(() => {
     mockUseProtocolDetails.mockReturnValue({ protocolData: {} } as any)
@@ -58,6 +68,14 @@ describe('CommandText', () => {
       } as Command,
     })
     getByText('legacy command text')
+  })
+  it('renders correct command text for pause commands', () => {
+    const { getByText } = render({
+      commandOrSummary: {
+        ...MOCK_PAUSE_COMMAND,
+      } as Command,
+    })
+    getByText('THIS IS THE PAUSE MESSAGE')
   })
 
   it('renders correct command text for pick up tip', () => {

--- a/app/src/organisms/RunDetails/__tests__/CommandText.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/CommandText.test.tsx
@@ -7,11 +7,13 @@ import { useProtocolDetails } from '../hooks'
 import { useLabwareRenderInfoById } from '../../ProtocolSetup/hooks'
 import { getLabwareLocation } from '../../ProtocolSetup/utils/getLabwareLocation'
 import { getLabwareDisplayName } from '@opentrons/shared-data'
+import { ProtocolSetupInfo } from './../ProtocolSetupInfo'
 import type { Command } from '@opentrons/shared-data/protocol/types/schemaV6/command'
 
 jest.mock('../hooks')
 jest.mock('../../ProtocolSetup/hooks')
 jest.mock('../../ProtocolSetup/utils/getLabwareLocation')
+jest.mock('./../ProtocolSetupInfo')
 jest.mock('@opentrons/shared-data/js/helpers')
 
 const mockUseProtocolDetails = useProtocolDetails as jest.MockedFunction<
@@ -25,6 +27,9 @@ const mockGetLabwareDisplayName = getLabwareDisplayName as jest.MockedFunction<
 >
 const mockGetLabwareLocation = getLabwareLocation as jest.MockedFunction<
   typeof getLabwareLocation
+>
+const mockProtocolSetupInfo = ProtocolSetupInfo as jest.MockedFunction<
+  typeof ProtocolSetupInfo
 >
 
 const render = (props: React.ComponentProps<typeof CommandText>) => {
@@ -53,10 +58,21 @@ const MOCK_PAUSE_COMMAND = {
   completedAt: 'end timestamp',
 }
 
+const MOCK_LOAD_COMMAND = {
+  id: '1234',
+  commandType: 'loadModule',
+  params: {},
+  status: 'running',
+  result: {},
+  startedAt: 'start timestamp',
+  completedAt: 'end timestamp',
+}
+
 describe('CommandText', () => {
   beforeEach(() => {
     mockUseProtocolDetails.mockReturnValue({ protocolData: {} } as any)
     mockUseLabwareRenderInfoById.mockReturnValue({} as any)
+    mockProtocolSetupInfo.mockReturnValue(<div>Mock Protocol Setup Step</div>)
   })
   it('renders correct command text for custom legacy commands', () => {
     const { getByText } = render({
@@ -76,6 +92,14 @@ describe('CommandText', () => {
       } as Command,
     })
     getByText('THIS IS THE PAUSE MESSAGE')
+  })
+  it('renders correct command text for load commands', () => {
+    const { getByText } = render({
+      commandOrSummary: {
+        ...MOCK_LOAD_COMMAND,
+      } as Command,
+    })
+    getByText('Mock Protocol Setup Step')
   })
 
   it('renders correct command text for pick up tip', () => {

--- a/shared-data/protocol/fixtures/6/simpleV6.json
+++ b/shared-data/protocol/fixtures/6/simpleV6.json
@@ -1444,6 +1444,14 @@
       }
     },
     {
+      "commandType": "pause",
+      "id": "18abc123",
+      "params": {
+        "message": "pause command"
+      }
+    },
+
+    {
       "commandType": "moveToCoordinates",
       "id": "16abc123",
       "params": {

--- a/shared-data/protocol/schemas/6.json
+++ b/shared-data/protocol/schemas/6.json
@@ -1108,7 +1108,25 @@
               }
             }
           },
-
+          {
+            "description": "Pause: This command pauses the run.",
+            "type": "object",
+            "required": ["id", "commandType"],
+            "properties": {
+              "id": { "type": "string" },
+              "commandType": {
+                "enum": ["pause"]
+              },
+              "params": {
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "Optional message the user can set for their pause command"
+                  }
+                }
+              }
+            }
+          },
           {
             "description": "Custom: This command is meant to allow non-canonical commands to be included in the commands list.",
             "type": "object",

--- a/shared-data/protocol/types/schemaV6/command/index.ts
+++ b/shared-data/protocol/types/schemaV6/command/index.ts
@@ -2,7 +2,7 @@ import type { PipettingCommand } from './pipetting'
 import type { GantryCommand } from './gantry'
 import type { ModuleCommand } from './module'
 import type { SetupCommand } from './setup'
-import type { TimingCommand } from './timing'
+import type { TimingCommand, PauseCommand } from './timing'
 
 // NOTE: these key/value pairs will only be present on commands at analysis/run time
 // they pertain only to the actual execution status of a command on hardware, as opposed to
@@ -29,6 +29,7 @@ export type Command =
   | ModuleCommand // directed at a hardware module
   | SetupCommand // only effecting robot's equipment setup (pipettes, labware, modules, liquid), no hardware side-effects
   | TimingCommand // effecting the timing of command execution
+  | PauseCommand // effecting the timing of command execution
   | ({
       commandType: 'custom'
       params: { [key: string]: any }

--- a/shared-data/protocol/types/schemaV6/command/timing.ts
+++ b/shared-data/protocol/types/schemaV6/command/timing.ts
@@ -9,3 +9,12 @@ interface DelayParams {
   wait: number | true
   message?: string
 }
+
+export interface PauseCommand extends CommonCommandInfo {
+  commandType: 'pause'
+  params: PauseParams
+}
+
+interface PauseParams {
+  message?: string
+}


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
Fix pause, delay commands being spliced out of run log by editing what we pull into the setup commands section

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
1. Splice out setup commands only until first instance of a non-setup command instead of last instance of a setup command
2. Add `pause` command to schema v6
3. Display pause message in run log if it exists

# Review requests

<!--
Describe any requests for your reviewers here.
-->
- [ ] Look over schema v6 changes 
- [ ] Test run flow with a protocol that includes delay command, pause command, and a setup command in the middle of the protocol

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Low