### PR TITLE
refactor(app): fix cancel button styling

### DIFF
--- a/app/src/organisms/ProtocolUpload/index.tsx
+++ b/app/src/organisms/ProtocolUpload/index.tsx
@@ -17,10 +17,11 @@ import {
   TEXT_TRANSFORM_UPPERCASE,
   FONT_SIZE_BIG,
   SPACING_8,
-  NewAlertPrimaryBtn,
   LINE_HEIGHT_SOLID,
   SPACING_3,
   SPACING_2,
+  NewSecondaryBtn,
+  C_ERROR_DARK,
 } from '@opentrons/components'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
@@ -137,15 +138,16 @@ export function ProtocolUpload(): JSX.Element {
   } = useConditionalConfirm(cancelRunAndExit, true)
 
   const cancelRunButton = (
-    <NewAlertPrimaryBtn
+    <NewSecondaryBtn
       onClick={confirmCancelModalExit}
       lineHeight={LINE_HEIGHT_SOLID}
       marginX={SPACING_3}
       paddingRight={SPACING_2}
       paddingLeft={SPACING_2}
+      color={C_ERROR_DARK}
     >
       {t('cancel_run')}
-    </NewAlertPrimaryBtn>
+    </NewSecondaryBtn>
   )
   const isRunInMotion =
     runStatus === RUN_STATUS_RUNNING ||

--- a/app/src/organisms/RunDetails/index.tsx
+++ b/app/src/organisms/RunDetails/index.tsx
@@ -9,11 +9,12 @@ import {
   RUN_STATUS_PAUSE_REQUESTED,
 } from '@opentrons/api-client'
 import {
-  NewAlertPrimaryBtn,
   LINE_HEIGHT_SOLID,
   SPACING_2,
   SPACING_3,
+  C_ERROR_DARK,
   useConditionalConfirm,
+  NewSecondaryBtn,
 } from '@opentrons/components'
 import { Page } from '../../atoms/Page'
 import { Portal } from '../../App/portal'
@@ -68,15 +69,16 @@ export function RunDetails(): JSX.Element | null {
   }
 
   const cancelRunButton = (
-    <NewAlertPrimaryBtn
+    <NewSecondaryBtn
       onClick={cancelRunAndExit}
       lineHeight={LINE_HEIGHT_SOLID}
       marginX={SPACING_3}
       paddingRight={SPACING_2}
       paddingLeft={SPACING_2}
+      color={C_ERROR_DARK}
     >
       {t('cancel_run')}
-    </NewAlertPrimaryBtn>
+    </NewSecondaryBtn>
   )
 
   let titleBarProps


### PR DESCRIPTION
# Overview

This PR fixes the cancel button styling, per Figma design. closes #9052

Before:
![image](https://user-images.githubusercontent.com/14794021/145875994-1604c384-ee4f-47b1-89b3-89c58e22c0bd.png)

After:
![Screen Shot 2021-12-13 at 2 07 23 PM](https://user-images.githubusercontent.com/14794021/145875662-409c46e7-14c7-4c1a-aa95-df82391248e3.png)

# Changelog

- Fix the styling of the Cancel Run button

# Review requests

- Make sure it matches the Figma design [here](https://www.figma.com/file/JCQNOTTK9tTmYPhRqeOfSj/Milestone-0%3A-Protocol-Upload-Revamp?node-id=7799%3A178332)

# Risk assessment

Low
