### PR TITLE
refactor(app): make protocol upload failed banner absolute

### DIFF
--- a/app/src/organisms/ProtocolUpload/index.tsx
+++ b/app/src/organisms/ProtocolUpload/index.tsx
@@ -193,21 +193,27 @@ export function ProtocolUpload(): JSX.Element {
       {showConfirmModalExit && <ConfirmCancelModal onClose={cancelModalExit} />}
       <Page titleBarProps={titleBarProps}>
         {uploadError != null && (
-          <AlertItem
-            type="warning"
-            onCloseClick={clearError}
-            title={t('protocol_upload_failed')}
+          <Flex
+            position="absolute"
+            flexDirection={DIRECTION_COLUMN}
+            width="100%"
           >
-            {t(VALIDATION_ERROR_T_MAP[uploadError[0]])}
-            {typeof uploadError[1] === 'string' ? (
-              <Text>{uploadError[1]}</Text>
-            ) : (
-              uploadError[1] != null &&
-              uploadError[1].map((errorObject, i) => (
-                <Text key={i}>{JSON.stringify(errorObject)}</Text>
-              ))
-            )}
-          </AlertItem>
+            <AlertItem
+              type="warning"
+              onCloseClick={clearError}
+              title={t('protocol_upload_failed')}
+            >
+              {t(VALIDATION_ERROR_T_MAP[uploadError[0]])}
+              {typeof uploadError[1] === 'string' ? (
+                <Text>{uploadError[1]}</Text>
+              ) : (
+                uploadError[1] != null &&
+                uploadError[1].map((errorObject, i) => (
+                  <Text key={i}>{JSON.stringify(errorObject)}</Text>
+                ))
+              )}
+            </AlertItem>
+          </Flex>
         )}
 
         <Box


### PR DESCRIPTION
closes #9050

# Overview
this PR makes the protocol upload failed banner absolute so it doesn't take up a ton of room and cause extra space above the protocol upload stuff (which looks weird especially if the error is long)

<img width="968" alt="Screen Shot 2021-12-13 at 16 02 10" src="https://user-images.githubusercontent.com/66035149/145890795-a72c76e1-494b-401d-bab9-9a4ad5352b07.png">
<img width="965" alt="Screen Shot 2021-12-13 at 16 02 42" src="https://user-images.githubusercontent.com/66035149/145890797-e397328a-c7b6-4ad3-8cb0-ecdcd78680be.png">

# Changelog

- make alert item position absolute

# Review requests

- review above images, test on a robot 😁 

# Risk assessment

low, behind ff
