### PR TITLE
fix(app): prevent white screen when restarting and closing protocols

### DIFF
--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/LabwareInfoOverlay.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/LabwareInfoOverlay.tsx
@@ -43,7 +43,8 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
   const { t } = useTranslation('protocol_setup')
   const { protocolData } = useProtocolDetails()
   const { runRecord } = useCurrentProtocolRun()
-
+  // protocolData should never be null as we don't render the `ProtocolSetup` unless we have an analysis
+  // but we're experiencing a zombie children issue, see https://github.com/Opentrons/opentrons/pull/9091
   if (protocolData == null) {
     return null
   }

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/LabwareInfoOverlay.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/LabwareInfoOverlay.tsx
@@ -38,15 +38,20 @@ const labwareDisplayNameStyle = css`
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
 `
-const LabwareInfo = (props: LabwareInfoProps): JSX.Element => {
+const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
   const { displayName, labwareId } = props
   const { t } = useTranslation('protocol_setup')
   const { protocolData } = useProtocolDetails()
+  const { runRecord } = useCurrentProtocolRun()
+
+  if (protocolData == null) {
+    return null
+  }
+
   const labwareDefinitionUri = getLabwareDefinitionUri(
     labwareId,
     protocolData?.labware
   )
-  const { runRecord } = useCurrentProtocolRun()
   const labwareLocation = getLabwareLocation(
     labwareId,
     protocolData?.commands ?? []

--- a/app/src/organisms/RunDetails/CommandText.tsx
+++ b/app/src/organisms/RunDetails/CommandText.tsx
@@ -13,7 +13,6 @@ import { useProtocolDetails } from './hooks'
 
 import { getLabwareLocation } from '../ProtocolSetup/utils/getLabwareLocation'
 import { useLabwareRenderInfoById } from '../ProtocolSetup/hooks'
-import protocolData from '../../../../notify-server/.mypy_cache/3.7/opentrons/protocols/context/protocol.data.json'
 
 interface Props {
   commandOrSummary: Command | RunCommandSummary
@@ -45,6 +44,8 @@ export function CommandText(props: Props): JSX.Element | null {
         break
       }
       case 'pickUpTip': {
+        // protocolData should never be null as we don't render the `RunDetails` unless we have an analysis
+        // but we're experiencing a zombie children issue, see https://github.com/Opentrons/opentrons/pull/9091
         if (protocolData == null) {
           return null
         }

--- a/app/src/organisms/RunDetails/CommandText.tsx
+++ b/app/src/organisms/RunDetails/CommandText.tsx
@@ -13,17 +13,16 @@ import { useProtocolDetails } from './hooks'
 
 import { getLabwareLocation } from '../ProtocolSetup/utils/getLabwareLocation'
 import { useLabwareRenderInfoById } from '../ProtocolSetup/hooks'
+import protocolData from '../../../../notify-server/.mypy_cache/3.7/opentrons/protocols/context/protocol.data.json'
 
 interface Props {
   commandOrSummary: Command | RunCommandSummary
 }
-export function CommandText(props: Props): JSX.Element {
+export function CommandText(props: Props): JSX.Element | null {
   const { commandOrSummary } = props
   const { t } = useTranslation('run_details')
   const { protocolData } = useProtocolDetails()
   const labwareRenderInfoById = useLabwareRenderInfoById()
-
-  const commands = protocolData?.commands ?? []
 
   let messageNode = null
   if ('params' in commandOrSummary) {
@@ -46,8 +45,14 @@ export function CommandText(props: Props): JSX.Element {
         break
       }
       case 'pickUpTip': {
+        if (protocolData == null) {
+          return null
+        }
         const { wellName, labwareId } = commandOrSummary.params
-        const labwareLocation = getLabwareLocation(labwareId, commands)
+        const labwareLocation = getLabwareLocation(
+          labwareId,
+          protocolData.commands
+        )
         if (!('slotName' in labwareLocation)) {
           throw new Error('expected tip rack to be in a slot')
         }

--- a/app/src/organisms/RunDetails/__tests__/CommandText.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/CommandText.test.tsx
@@ -45,7 +45,9 @@ const MOCK_COMMAND_DETAILS = {
 
 describe('CommandText', () => {
   beforeEach(() => {
-    mockUseProtocolDetails.mockReturnValue({ protocolData: {} } as any)
+    mockUseProtocolDetails.mockReturnValue({
+      protocolData: { commands: [] },
+    } as any)
     mockUseLabwareRenderInfoById.mockReturnValue({} as any)
   })
   it('renders correct command text for custom legacy commands', () => {


### PR DESCRIPTION
# Overview
This PR adds a null check inside of components that are receiving stale data.

It seems as though we're experiencing a [Zombie Children](https://github.com/reduxjs/react-redux/issues/1556) esque problem, where children are not being unmounted when they should be, and as a result are receiving stale data and erroring out. 

I'm not sure what's causing this, but this quick fix should make the problem go away. There is certainly more work on our end to do in terms of optimizing state updates/network requests, but until we figure out why this is happening this fix shoul do.

closes #9082 and #9083

# Changelog

- Rrevent white screen when restarting and closing protocols

# Review requests

Note — before testing, you'll need to actually build the app locally. This is because the white screen issues only occur on actual builds (not when building on a dev server). Follow the instructions in the `app-shell` `README` (i.e. run `make package` from inside `app-shell`) and open the build that gets generated in `./dist/mac/Opentrons.app/Contents/MacOS/Opentrons`.

Go through the repro steps in the tickets above, you should no longer see whitescreens.
# Risk assessment
Low