### PR TITLE
feat(api): Remove legacy LC reset from robot settings

### DIFF
--- a/api/src/opentrons/config/reset.py
+++ b/api/src/opentrons/config/reset.py
@@ -25,7 +25,6 @@ class CommonResetOption(NamedTuple):
 class ResetOptionId(str, Enum):
     """The available reset options"""
 
-    labware_calibration = "labwareCalibration"
     boot_scripts = "bootScripts"
     deck_calibration = "deckCalibration"
     pipette_offset = "pipetteOffsetCalibrations"
@@ -33,9 +32,6 @@ class ResetOptionId(str, Enum):
 
 
 _settings_reset_options = {
-    ResetOptionId.labware_calibration: CommonResetOption(
-        name="Labware Calibration", description="Clear labware calibration"
-    ),
     ResetOptionId.boot_scripts: CommonResetOption(
         name="Boot Scripts", description="Clear custom boot scripts"
     ),
@@ -65,9 +61,6 @@ def reset(options: Set[ResetOptionId]) -> None:
     :param options: the parts to reset
     """
     log.info("Reset requested for %s", options)
-
-    if ResetOptionId.labware_calibration in options:
-        reset_labware_calibration()
 
     if ResetOptionId.boot_scripts in options:
         reset_boot_scripts()

--- a/api/tests/opentrons/config/test_reset.py
+++ b/api/tests/opentrons/config/test_reset.py
@@ -10,18 +10,6 @@ def mock_reset_boot_scripts():
 
 
 @pytest.fixture
-def mock_reset_labware_calibration():
-    with patch("opentrons.config.reset.reset_labware_calibration") as m:
-        yield m
-
-
-@pytest.fixture
-def mock_labware():
-    with patch("opentrons.config.reset.delete") as m:
-        yield m
-
-
-@pytest.fixture
 def mock_reset_pipette_offset():
     with patch("opentrons.config.reset.reset_pipette_offset") as m:
         yield m
@@ -47,13 +35,11 @@ def mock_cal_storage_delete():
 
 def test_reset_empty_set(
     mock_reset_boot_scripts,
-    mock_reset_labware_calibration,
     mock_reset_pipette_offset,
     mock_reset_deck_calibration,
     mock_reset_tip_length_calibrations,
 ):
     reset.reset(set())
-    mock_reset_labware_calibration.assert_not_called()
     mock_reset_boot_scripts.assert_not_called()
     mock_reset_pipette_offset.assert_not_called()
     mock_reset_deck_calibration.assert_not_called()
@@ -62,7 +48,6 @@ def test_reset_empty_set(
 
 def test_reset_all_set(
     mock_reset_boot_scripts,
-    mock_reset_labware_calibration,
     mock_reset_pipette_offset,
     mock_reset_deck_calibration,
     mock_reset_tip_length_calibrations,
@@ -70,23 +55,15 @@ def test_reset_all_set(
     reset.reset(
         {
             reset.ResetOptionId.boot_scripts,
-            reset.ResetOptionId.labware_calibration,
             reset.ResetOptionId.deck_calibration,
             reset.ResetOptionId.pipette_offset,
             reset.ResetOptionId.tip_length_calibrations,
         }
     )
-    mock_reset_labware_calibration.assert_called_once()
     mock_reset_boot_scripts.assert_called_once()
     mock_reset_pipette_offset.assert_called_once()
     mock_reset_deck_calibration.assert_called_once()
     mock_reset_tip_length_calibrations.assert_called_once()
-
-
-def test_labware_calibration_reset(mock_labware):
-    reset.reset_labware_calibration()
-    # Check side effecting function calls
-    mock_labware.clear_calibrations.assert_called_once()
 
 
 def test_deck_calibration_reset(mock_cal_storage_delete):

--- a/robot-server/tests/integration/test_settings_reset_options.tavern.yaml
+++ b/robot-server/tests/integration/test_settings_reset_options.tavern.yaml
@@ -6,53 +6,23 @@ marks:
 stages:
   - name: Reset Options GET request returns correct option
     request:
-      url: "{host:s}:{port:d}/settings/reset/options"
+      url: '{host:s}:{port:d}/settings/reset/options'
       method: GET
     response:
       status_code: 200
       json:
-        options:
-        - id: labwareCalibration
-          name: Labware Calibration
-          description: !re_search "Clear labware calibration"
         - id: bootScripts
           name: Boot Scripts
           description: Clear custom boot scripts
         - id: deckCalibration
           name: Deck Calibration
-          description: !re_search "Clear deck calibration"
+          description: !re_search 'Clear deck calibration'
         - id: pipetteOffsetCalibrations
           name: Pipette Offset Calibrations
-          description: !re_search "Clear pipette offset calibrations"
+          description: !re_search 'Clear pipette offset calibrations'
         - id: tipLengthCalibrations
           name: Tip Length Calibrations
-          description: !re_search "Clear tip length calibrations"
----
-test_name: POST Reset labwareCalibration option
-marks:
-  - usefixtures:
-      - run_server
-stages:
-  - name: POST Reset labwareCalibration true
-    request:
-      url: "{host:s}:{port:d}/settings/reset"
-      method: POST
-      json:
-        labwareCalibration: true
-    response:
-      status_code: 200
-      json:
-        message: "Options 'labware_calibration' were reset"
-  - name: POST Reset labwareCalibration false
-    request:
-      url: "{host:s}:{port:d}/settings/reset"
-      method: POST
-      json:
-        labwareCalibration: false
-    response:
-      status_code: 200
-      json:
-        message: "Nothing to do"
+          description: !re_search 'Clear tip length calibrations'
 ---
 test_name: POST Reset bootScripts option
 marks:
@@ -61,7 +31,7 @@ marks:
 stages:
   - name: POST Reset bootScripts true
     request:
-      url: "{host:s}:{port:d}/settings/reset"
+      url: '{host:s}:{port:d}/settings/reset'
       method: POST
       json:
         bootScripts: true
@@ -71,14 +41,14 @@ stages:
         message: "Options 'boot_scripts' were reset"
   - name: POST Reset bootScripts false
     request:
-      url: "{host:s}:{port:d}/settings/reset"
+      url: '{host:s}:{port:d}/settings/reset'
       method: POST
       json:
         bootScripts: false
     response:
       status_code: 200
       json:
-        message: "Nothing to do"
+        message: 'Nothing to do'
 ---
 test_name: POST Reset deck calibration option
 marks:
@@ -87,7 +57,7 @@ marks:
 stages:
   - name: POST Reset deckCalibration true
     request:
-      url: "{host:s}:{port:d}/settings/reset"
+      url: '{host:s}:{port:d}/settings/reset'
       method: POST
       json:
         deckCalibration: true
@@ -97,14 +67,14 @@ stages:
         message: "Options 'deck_calibration' were reset"
   - name: POST Reset deckCalibration false
     request:
-      url: "{host:s}:{port:d}/settings/reset"
+      url: '{host:s}:{port:d}/settings/reset'
       method: POST
       json:
         deckCalibration: false
     response:
       status_code: 200
       json:
-        message: "Nothing to do"
+        message: 'Nothing to do'
 ---
 test_name: POST Reset pipette offset calibrations option
 marks:
@@ -113,7 +83,7 @@ marks:
 stages:
   - name: POST Reset pipetteOffsetCalibrations true
     request:
-      url: "{host:s}:{port:d}/settings/reset"
+      url: '{host:s}:{port:d}/settings/reset'
       method: POST
       json:
         pipetteOffsetCalibrations: true
@@ -123,14 +93,14 @@ stages:
         message: "Options 'pipette_offset' were reset"
   - name: POST Reset pipetteOffsetCalibrations false
     request:
-      url: "{host:s}:{port:d}/settings/reset"
+      url: '{host:s}:{port:d}/settings/reset'
       method: POST
       json:
         pipetteOffsetCalibrations: false
     response:
       status_code: 200
       json:
-        message: "Nothing to do"
+        message: 'Nothing to do'
 ---
 test_name: POST Reset non existant option
 marks:
@@ -139,11 +109,11 @@ marks:
 stages:
   - name: POST Reset non existant option
     request:
-      url: "{host:s}:{port:d}/settings/reset"
+      url: '{host:s}:{port:d}/settings/reset'
       method: POST
       json:
         doesNotExist: true
     response:
       status_code: 422
       json:
-        message: !re_search "value is not a valid enumeration member"
+        message: !re_search 'value is not a valid enumeration member'

--- a/robot-server/tests/integration/test_settings_reset_options.tavern.yaml
+++ b/robot-server/tests/integration/test_settings_reset_options.tavern.yaml
@@ -11,18 +11,19 @@ stages:
     response:
       status_code: 200
       json:
-        - id: bootScripts
-          name: Boot Scripts
-          description: Clear custom boot scripts
-        - id: deckCalibration
-          name: Deck Calibration
-          description: !re_search 'Clear deck calibration'
-        - id: pipetteOffsetCalibrations
-          name: Pipette Offset Calibrations
-          description: !re_search 'Clear pipette offset calibrations'
-        - id: tipLengthCalibrations
-          name: Tip Length Calibrations
-          description: !re_search 'Clear tip length calibrations'
+        options:
+          - id: bootScripts
+            name: Boot Scripts
+            description: Clear custom boot scripts
+          - id: deckCalibration
+            name: Deck Calibration
+            description: !re_search 'Clear deck calibration'
+          - id: pipetteOffsetCalibrations
+            name: Pipette Offset Calibrations
+            description: !re_search 'Clear pipette offset calibrations'
+          - id: tipLengthCalibrations
+            name: Tip Length Calibrations
+            description: !re_search 'Clear tip length calibrations'
 ---
 test_name: POST Reset bootScripts option
 marks:

--- a/robot-server/tests/service/legacy/routers/test_settings.py
+++ b/robot-server/tests/service/legacy/routers/test_settings.py
@@ -214,7 +214,6 @@ def test_available_resets(api_client):
             [
                 "deckCalibration",
                 "pipetteOffsetCalibrations",
-                "labwareCalibration",
                 "bootScripts",
                 "tipLengthCalibrations",
             ]
@@ -237,7 +236,6 @@ def mock_reset():
         # None true
         [
             {
-                "labwareCalibration": False,
                 "deckCalibration": False,
                 "bootScripts": False,
                 "pipetteOffsetCalibrations": False,
@@ -248,21 +246,18 @@ def mock_reset():
         # All set
         [
             {
-                "labwareCalibration": True,
                 "bootScripts": True,
                 "pipetteOffsetCalibrations": True,
                 "tipLengthCalibrations": True,
                 "deckCalibration": True,
             },
             {
-                ResetOptionId.labware_calibration,
                 ResetOptionId.boot_scripts,
                 ResetOptionId.deck_calibration,
                 ResetOptionId.pipette_offset,
                 ResetOptionId.tip_length_calibrations,
             },
         ],
-        [{"labwareCalibration": True}, {ResetOptionId.labware_calibration}],
         [{"bootScripts": True}, {ResetOptionId.boot_scripts}],
         [{"pipetteOffsetCalibrations": True}, {ResetOptionId.pipette_offset}],
         [{"tipLengthCalibrations": True}, {ResetOptionId.tip_length_calibrations}],


### PR DESCRIPTION
# Overview

closes #8283. shout out to @SyntaxColoring for helping with the tests!

# Changelog

- refactor(app): Remove legacy LC reset from robot settings

# Review requests

put this PRs build on your robot
click the factory reset button
- [ ] labware calibration is no longer an option

# Risk assessment

medium (invloves robot software)
