### PR TITLE
feat(api): remove Calibrate to Bottom from Robot Settings

### DIFF
--- a/api/src/opentrons/api/calibration.py
+++ b/api/src/opentrons/api/calibration.py
@@ -268,10 +268,7 @@ class CalibrationManager(RobotBusy):
         # Reset calibration so we don’t actually calibrate the offset
         # relative to the old calibration
         container._container.set_calibration(Point(0, 0, 0))
-        if ff.calibrate_to_bottom() and not (container._container.is_tiprack):
-            orig = _well0(container._container).geometry.bottom()
-        else:
-            orig = _well0(container._container).geometry.top()
+        orig = _well0(container._container).geometry.top()
         delta = here - orig
         labware.save_calibration(container._container, delta)
 

--- a/api/src/opentrons/api/calibration.py
+++ b/api/src/opentrons/api/calibration.py
@@ -6,7 +6,6 @@ from copy import copy
 from typing import Any, cast, Callable, Optional, Union, Set, TypeVar
 from typing_extensions import TypedDict, Literal, Final
 
-from opentrons.config import feature_flags as ff
 from opentrons.broker import Broker
 from opentrons.types import Point, Mount, Location
 from opentrons.protocol_api import labware

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -418,6 +418,16 @@ def _migrate11to12(previous: SettingsMap) -> SettingsMap:
     return newmap
 
 
+def _migrate12to13(previous: SettingsMap) -> SettingsMap:
+    """Migrate to version 13 of the feature flags file.
+
+    - Removes deprecated calibrateToBottom option
+    """
+    removals = ["calibrateToBottom"]
+    newmap = {k: v for k, v in previous.items() if k not in removals}
+    return newmap
+
+
 _MIGRATIONS = [
     _migrate0to1,
     _migrate1to2,
@@ -431,6 +441,7 @@ _MIGRATIONS = [
     _migrate9to10,
     _migrate10to11,
     _migrate11to12,
+    _migrate12to13
 ]
 """
 List of all migrations to apply, indexed by (version - 1). See _migrate below

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -117,13 +117,6 @@ settings = [
         description="Trash box is 55mm tall (rather than the 77mm default)",
     ),
     SettingDefinition(
-        _id="calibrateToBottom",
-        old_id="calibrate-to-bottom",
-        title="Calibrate to bottom",
-        description="Calibrate using the bottom-center of well A1 for each"
-        " labware (rather than the top-center)",
-    ),
-    SettingDefinition(
         _id="deckCalibrationDots",
         old_id="dots-deck-type",
         title="Deck calibration to dots",

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -441,7 +441,7 @@ _MIGRATIONS = [
     _migrate9to10,
     _migrate10to11,
     _migrate11to12,
-    _migrate12to13
+    _migrate12to13,
 ]
 """
 List of all migrations to apply, indexed by (version - 1). See _migrate below

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -5,10 +5,6 @@ def short_fixed_trash() -> bool:
     return advs.get_setting_with_env_overload("shortFixedTrash")
 
 
-def calibrate_to_bottom() -> bool:
-    return advs.get_setting_with_env_overload("calibrateToBottom")
-
-
 def dots_deck_type() -> bool:
     return advs.get_setting_with_env_overload("deckCalibrationDots")
 

--- a/api/tests/opentrons/api/test_calibration.py
+++ b/api/tests/opentrons/api/test_calibration.py
@@ -113,30 +113,6 @@ async def test_update_container_offset_v2(main_router, model):
 
 
 @pytest.mark.api2_only
-async def test_jog_calibrate_bottom_v2(main_router, model, calibrate_bottom_flag):
-
-    # Check that the feature flag correctly implements calibrate to bottom
-    container = model.container._container
-    height = container.wells()[0].geometry._depth
-    old_bottom = container.wells()[0].bottom().point
-
-    main_router.calibration_manager.home(model.instrument)
-    main_router.calibration_manager.move_to(model.instrument, model.container)
-    main_router.calibration_manager.jog(model.instrument, 1, "x")
-    main_router.calibration_manager.jog(model.instrument, 2, "y")
-    main_router.calibration_manager.jog(model.instrument, 3, "z")
-    main_router.calibration_manager.jog(model.instrument, -height, "z")
-
-    main_router.calibration_manager.update_container_offset(
-        model.container, model.instrument
-    )
-
-    assert list(model.container._container.wells()[0].bottom().point) == pytest.approx(
-        old_bottom + Point(1, 2, 3)
-    )
-
-
-@pytest.mark.api2_only
 async def test_jog_calibrate_top_v2(main_router, model):
 
     # Check that the old behavior remains the same without the feature flag

--- a/api/tests/opentrons/config/test_advanced_settings.py
+++ b/api/tests/opentrons/config/test_advanced_settings.py
@@ -121,6 +121,7 @@ async def test_get_all_adv_settings_lru_cache(
     advanced_settings.get_all_adv_settings()
     mock_read_settings_file.assert_not_called()
 
+
 async def test_restart_required(
     loop,
     restore_restart_required,
@@ -148,6 +149,7 @@ async def test_restart_required(
             assert advanced_settings.is_restart_required() is False
             await advanced_settings.set_adv_setting(_id, True)
             assert advanced_settings.is_restart_required() is True
+
 
 @pytest.mark.parametrize(
     argnames=["v", "expected_level"],

--- a/api/tests/opentrons/config/test_advanced_settings.py
+++ b/api/tests/opentrons/config/test_advanced_settings.py
@@ -113,9 +113,6 @@ async def test_get_all_adv_settings_lru_cache(
     advanced_settings.get_all_adv_settings()
     mock_read_settings_file.assert_not_called()
     mock_read_settings_file.reset_mock()
-    # Updating will invalidate cache
-    await advanced_settings.set_adv_setting("calibrateToBottom", True)
-    mock_read_settings_file.reset_mock()
     # Cache should not be used
     advanced_settings.get_all_adv_settings()
     mock_read_settings_file.assert_called_once()
@@ -123,25 +120,6 @@ async def test_get_all_adv_settings_lru_cache(
     # Should use cache
     advanced_settings.get_all_adv_settings()
     mock_read_settings_file.assert_not_called()
-
-
-async def test_on_change_called(
-    loop,
-    mock_read_settings_file,
-    mock_settings_values,
-    mock_write_settings_file,
-    restore_restart_required,
-):
-    _id = "calibrateToBottom"
-    with patch("opentrons.config.advanced_settings.SettingDefinition.on_change") as m:
-
-        async def on_change(v):
-            pass
-
-        m.side_effect = on_change
-        await advanced_settings.set_adv_setting(_id, True)
-        m.assert_called_once_with(True)
-
 
 async def test_restart_required(
     loop,
@@ -170,19 +148,6 @@ async def test_restart_required(
             assert advanced_settings.is_restart_required() is False
             await advanced_settings.set_adv_setting(_id, True)
             assert advanced_settings.is_restart_required() is True
-
-
-def test_get_setting_use_env_overload(mock_read_settings_file, mock_settings_values):
-    with patch("os.environ", new={"OT_API_FF_calibrateToBottom": "TRUE"}):
-        v = advanced_settings.get_setting_with_env_overload("calibrateToBottom")
-        assert v is not mock_settings_values["calibrateToBottom"]
-
-
-def test_get_setting_with_env_overload(mock_read_settings_file, mock_settings_values):
-    with patch("os.environ", new={}):
-        v = advanced_settings.get_setting_with_env_overload("calibrateToBottom")
-        assert v is mock_settings_values["calibrateToBottom"]
-
 
 @pytest.mark.parametrize(
     argnames=["v", "expected_level"],

--- a/api/tests/opentrons/config/test_advanced_settings.py
+++ b/api/tests/opentrons/config/test_advanced_settings.py
@@ -113,6 +113,9 @@ async def test_get_all_adv_settings_lru_cache(
     advanced_settings.get_all_adv_settings()
     mock_read_settings_file.assert_not_called()
     mock_read_settings_file.reset_mock()
+    # Updating will invalidate cache
+    await advanced_settings.set_adv_setting("enableDoorSafetySwitch", True)
+    mock_read_settings_file.reset_mock()
     # Cache should not be used
     advanced_settings.get_all_adv_settings()
     mock_read_settings_file.assert_called_once()

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -14,7 +14,6 @@ def migrated_file_version() -> int:
 def default_file_settings() -> Dict[str, Optional[bool]]:
     return {
         "shortFixedTrash": None,
-        "calibrateToBottom": None,
         "deckCalibrationDots": None,
         "disableHomeOnBoot": None,
         "useOldAspirationFunctions": None,
@@ -35,7 +34,6 @@ def empty_settings():
 def version_less():
     return {
         "shortFixedTrash": True,
-        "calibrateToBottom": True,
         "deckCalibrationDots": True,
         "disableHomeOnBoot": True,
         "useOldAspirationFunctions": True,
@@ -47,7 +45,6 @@ def v1_config():
     return {
         "_version": 1,
         "shortFixedTrash": True,
-        "calibrateToBottom": True,
         "deckCalibrationDots": True,
         "disableHomeOnBoot": True,
         "useProtocolApi2": None,
@@ -231,7 +228,6 @@ def test_migrates_versionless_old_config(migrated_file_version, default_file_set
     expected.update(
         {
             "shortFixedTrash": None,
-            "calibrateToBottom": None,
             "deckCalibrationDots": True,
             "disableHomeOnBoot": None,
         }
@@ -259,7 +255,6 @@ def test_ensures_config():
     ) == {
         "_version": 3,
         "shortFixedTrash": False,
-        "calibrateToBottom": None,
         "deckCalibrationDots": None,
         "disableHomeOnBoot": None,
         "useOldAspirationFunctions": None,

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -7,7 +7,7 @@ from opentrons.config.advanced_settings import _migrate, _ensure
 
 @pytest.fixture
 def migrated_file_version() -> int:
-    return 12
+    return 13
 
 
 @pytest.fixture
@@ -34,6 +34,7 @@ def empty_settings():
 def version_less():
     return {
         "shortFixedTrash": True,
+        "calibrateToBottom": True,
         "deckCalibrationDots": True,
         "disableHomeOnBoot": True,
         "useOldAspirationFunctions": True,
@@ -45,6 +46,7 @@ def v1_config():
     return {
         "_version": 1,
         "shortFixedTrash": True,
+        "calibrateToBottom": True,
         "deckCalibrationDots": True,
         "disableHomeOnBoot": True,
         "useProtocolApi2": None,
@@ -175,6 +177,14 @@ def v12_config(v11_config):
     return r
 
 
+@pytest.fixture
+def v13_config(v12_config):
+    r = v12_config.copy()
+    r.pop("calibrateToBottom")
+    r.update({"_version": 13})
+    return r
+
+
 @pytest.fixture(
     scope="session",
     params=[
@@ -192,6 +202,7 @@ def v12_config(v11_config):
         lazy_fixture("v10_config"),
         lazy_fixture("v11_config"),
         lazy_fixture("v12_config"),
+        lazy_fixture("v13_config"),
     ],
 )
 def old_settings(request):

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -110,13 +110,6 @@ def is_robot(monkeypatch):
 
 # -------feature flag fixtures-------------
 @pytest.fixture
-async def calibrate_bottom_flag():
-    await config.advanced_settings.set_adv_setting("calibrateToBottom", True)
-    yield
-    await config.advanced_settings.set_adv_setting("calibrateToBottom", False)
-
-
-@pytest.fixture
 async def short_trash_flag():
     await config.advanced_settings.set_adv_setting("shortFixedTrash", True)
     yield

--- a/robot-server/tests/integration/test_settings.tavern.yaml
+++ b/robot-server/tests/integration/test_settings.tavern.yaml
@@ -7,7 +7,7 @@ stages:
   - name: Settings GET request returns correct info
     request:
       method: GET
-      url: '{host:s}:{port:d}/settings'test_
+      url: '{host:s}:{port:d}/settings'
     response:
       status_code: 200
       json:

--- a/robot-server/tests/integration/test_settings.tavern.yaml
+++ b/robot-server/tests/integration/test_settings.tavern.yaml
@@ -7,7 +7,7 @@ stages:
   - name: Settings GET request returns correct info
     request:
       method: GET
-      url: '{host:s}:{port:d}/settings'
+      url: '{host:s}:{port:d}/settings'test_
     response:
       status_code: 200
       json:
@@ -16,12 +16,6 @@ stages:
             old_id: short-fixed-trash
             title: Short (55mm) fixed trash
             description: !re_search 'Trash box is 55mm tall'
-            restart_required: false
-            value: !anything
-          - id: calibrateToBottom
-            old_id: calibrate-to-bottom
-            title: Calibrate to bottom
-            description: !re_search 'Calibrate using the bottom-center'
             restart_required: false
             value: !anything
           - id: deckCalibrationDots
@@ -78,7 +72,6 @@ marks:
       key: id
       vals:
         - shortFixedTrash
-        - calibrateToBottom
         - deckCalibrationDots
         - disableHomeOnBoot
         - useOldAspirationFunctions
@@ -116,7 +109,6 @@ marks:
       key: id
       vals:
         - shortFixedTrash
-        - calibrateToBottom
         - deckCalibrationDots
         - disableHomeOnBoot
         - useOldAspirationFunctions


### PR DESCRIPTION
closes #9096 

# Overview

This PR removes the `Calibrate to Bottom` settings in the robot settings

# Changelog

- removes instances of `Calibrate to Bottom` from several files

# Review requests

- put the build from this Pr on your robot and factory reset and/or restart server - `Calibrate to Bottom` should no longer be an option

# Risk assessment

Low, behind ff
