### PR TITLE
fix(app): fix missing null checks in protocol setup

### DIFF
--- a/app/src/organisms/RunDetails/CommandList.tsx
+++ b/app/src/organisms/RunDetails/CommandList.tsx
@@ -146,74 +146,76 @@ export function CommandList(): JSX.Element | null {
         >
           {t('protocol_steps')}
         </Flex>
-        <Flex margin={SPACING_1}>
-          {showProtocolSetupInfo ? (
-            <React.Fragment>
-              <Flex
-                flexDirection={DIRECTION_COLUMN}
-                flex={'auto'}
-                backgroundColor={C_NEAR_WHITE}
-                marginLeft={SPACING_2}
-              >
+        {protocolSetupCommandList.length > 0 && (
+          <Flex margin={SPACING_1}>
+            {showProtocolSetupInfo ? (
+              <React.Fragment>
                 <Flex
-                  justifyContent={JUSTIFY_SPACE_BETWEEN}
-                  color={C_MED_DARK_GRAY}
-                  padding={SPACING_2}
-                >
-                  <Text
-                    textTransform={TEXT_TRANSFORM_UPPERCASE}
-                    fontSize={FONT_SIZE_CAPTION}
-                    id={`RunDetails_ProtocolSetupTitle`}
-                  >
-                    {t('protocol_setup')}
-                  </Text>
-                  <Btn
-                    size={SIZE_1}
-                    onClick={() => setShowProtocolSetupInfo(false)}
-                  >
-                    <Icon name="chevron-up" color={C_MED_DARK_GRAY}></Icon>
-                  </Btn>
-                </Flex>
-                <Flex
-                  id={`RunDetails_ProtocolSetup_CommandList`}
                   flexDirection={DIRECTION_COLUMN}
-                  marginLeft={SPACING_1}
-                  paddingLeft={SPACING_2}
+                  flex={'auto'}
+                  backgroundColor={C_NEAR_WHITE}
+                  marginLeft={SPACING_2}
                 >
-                  {protocolSetupCommandList?.map(command => {
-                    return (
-                      <ProtocolSetupInfo
-                        key={command.id}
-                        setupCommand={command as Command}
-                      />
-                    )
-                  })}
+                  <Flex
+                    justifyContent={JUSTIFY_SPACE_BETWEEN}
+                    color={C_MED_DARK_GRAY}
+                    padding={SPACING_2}
+                  >
+                    <Text
+                      textTransform={TEXT_TRANSFORM_UPPERCASE}
+                      fontSize={FONT_SIZE_CAPTION}
+                      id={`RunDetails_ProtocolSetupTitle`}
+                    >
+                      {t('protocol_setup')}
+                    </Text>
+                    <Btn
+                      size={SIZE_1}
+                      onClick={() => setShowProtocolSetupInfo(false)}
+                    >
+                      <Icon name="chevron-up" color={C_MED_DARK_GRAY}></Icon>
+                    </Btn>
+                  </Flex>
+                  <Flex
+                    id={`RunDetails_ProtocolSetup_CommandList`}
+                    flexDirection={DIRECTION_COLUMN}
+                    marginLeft={SPACING_1}
+                    paddingLeft={SPACING_2}
+                  >
+                    {protocolSetupCommandList?.map(command => {
+                      return (
+                        <ProtocolSetupInfo
+                          key={command.id}
+                          setupCommand={command as Command}
+                        />
+                      )
+                    })}
+                  </Flex>
                 </Flex>
-              </Flex>
-            </React.Fragment>
-          ) : (
-            <Btn
-              width={'100%'}
-              role={'link'}
-              onClick={() => setShowProtocolSetupInfo(true)}
-              margin={SPACING_1}
-            >
-              <Flex
-                fontSize={FONT_SIZE_CAPTION}
-                justifyContent={JUSTIFY_SPACE_BETWEEN}
-                textTransform={TEXT_TRANSFORM_UPPERCASE}
-                color={C_MED_DARK_GRAY}
-                backgroundColor={C_NEAR_WHITE}
-                marginLeft={SPACING_1}
+              </React.Fragment>
+            ) : (
+              <Btn
+                width={'100%'}
+                role={'link'}
+                onClick={() => setShowProtocolSetupInfo(true)}
+                margin={SPACING_1}
               >
-                <Flex padding={SPACING_2}>{t('protocol_setup')}</Flex>
-                <Flex>
-                  <Icon name={'chevron-left'} width={SIZE_1} />
+                <Flex
+                  fontSize={FONT_SIZE_CAPTION}
+                  justifyContent={JUSTIFY_SPACE_BETWEEN}
+                  textTransform={TEXT_TRANSFORM_UPPERCASE}
+                  color={C_MED_DARK_GRAY}
+                  backgroundColor={C_NEAR_WHITE}
+                  marginLeft={SPACING_1}
+                >
+                  <Flex padding={SPACING_2}>{t('protocol_setup')}</Flex>
+                  <Flex>
+                    <Icon name={'chevron-left'} width={SIZE_1} />
+                  </Flex>
                 </Flex>
-              </Flex>
-            </Btn>
-          )}
-        </Flex>
+              </Btn>
+            )}
+          </Flex>
+        )}
 
         <Flex
           fontSize={FONT_SIZE_CAPTION}

--- a/app/src/organisms/RunDetails/ProtocolSetupInfo.tsx
+++ b/app/src/organisms/RunDetails/ProtocolSetupInfo.tsx
@@ -27,8 +27,9 @@ export const ProtocolSetupInfo = (
   if (protocolData == null) return null
   if (setupCommand === undefined) return null
   if (
-    setupCommand.result?.definition?.metadata.displayName.includes('Trash') ===
-    true
+    setupCommand.result?.definition?.metadata?.displayName?.includes(
+      'Trash'
+    ) === true
   ) {
     return null
   }


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
Fix bug where missing metadata on commands caused a white screen when expanding protocol setup steps
# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
Add null check for metadata in protocol setup steps
Hide protocol setup heading if there aren't any

# Review requests

<!--
Describe any requests for your reviewers here.
-->
Open [this protocol](https://opentrons.slack.com/archives/C02JZQB567R/p1639591093017100?thread_ts=1639590996.016800&cid=C02JZQB567R), navigate to the run tab and expand the protocol setup steps. They should expand as expected.

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
low