### PR TITLE
refactor(app): move apply labware offsets to hook and out of summary screen

### DIFF
--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
@@ -19,18 +19,32 @@ import { useLPCSuccessToast } from '../hooks'
 import { DeckMap } from './DeckMap'
 import { SectionList } from './SectionList'
 import { LabwareOffsetsSummary } from './LabwareOffsetsSummary'
-import { useIntroInfo, LabwareOffsets } from './hooks'
+import { useIntroInfo, LabwareOffsets, useLabwareOffsets } from './hooks'
+import type { ProtocolFile } from '@opentrons/shared-data'
+import type { SavePositionCommandData } from './types'
 
 export const SummaryScreen = (props: {
   labwareOffsets: LabwareOffsets
   applyLabwareOffsets: () => void
   onCloseClick: () => unknown
+  setLabwareOffsets: (active: LabwareOffsets) => void
+  savePositionCommandData: SavePositionCommandData
 }): JSX.Element | null => {
-  const { labwareOffsets, applyLabwareOffsets } = props
+  const {
+    labwareOffsets,
+    applyLabwareOffsets,
+    savePositionCommandData,
+    setLabwareOffsets,
+  } = props
   const { t } = useTranslation('labware_position_check')
   const introInfo = useIntroInfo()
   const { protocolData } = useProtocolDetails()
   const { setShowLPCSuccessToast } = useLPCSuccessToast()
+  useLabwareOffsets(savePositionCommandData, protocolData as ProtocolFile<{}>)
+    .then(offsets => setLabwareOffsets(offsets))
+    .catch((e: Error) =>
+      console.error(`error getting labware offsets ${e.message}`)
+    )
   if (introInfo == null) return null
   if (protocolData == null) return null
   const labwareIds = Object.keys(protocolData.labware)

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
@@ -19,32 +19,18 @@ import { useLPCSuccessToast } from '../hooks'
 import { DeckMap } from './DeckMap'
 import { SectionList } from './SectionList'
 import { LabwareOffsetsSummary } from './LabwareOffsetsSummary'
-import { useIntroInfo, LabwareOffsets, useLabwareOffsets } from './hooks'
-import type { ProtocolFile } from '@opentrons/shared-data'
-import type { SavePositionCommandData } from './types'
+import { useIntroInfo, LabwareOffsets } from './hooks'
 
 export const SummaryScreen = (props: {
   labwareOffsets: LabwareOffsets
   applyLabwareOffsets: () => void
   onCloseClick: () => unknown
-  setLabwareOffsets: (active: LabwareOffsets) => void
-  savePositionCommandData: SavePositionCommandData
 }): JSX.Element | null => {
-  const {
-    labwareOffsets,
-    applyLabwareOffsets,
-    savePositionCommandData,
-    setLabwareOffsets,
-  } = props
+  const { labwareOffsets, applyLabwareOffsets } = props
   const { t } = useTranslation('labware_position_check')
   const introInfo = useIntroInfo()
   const { protocolData } = useProtocolDetails()
   const { setShowLPCSuccessToast } = useLPCSuccessToast()
-  useLabwareOffsets(savePositionCommandData, protocolData as ProtocolFile<{}>)
-    .then(offsets => setLabwareOffsets(offsets))
-    .catch((e: Error) =>
-      console.error(`error getting labware offsets ${e.message}`)
-    )
   if (introInfo == null) return null
   if (protocolData == null) return null
   const labwareIds = Object.keys(protocolData.labware)

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
@@ -66,10 +66,8 @@ describe('SummaryScreen', () => {
 
   beforeEach(() => {
     props = {
-      savePositionCommandData: { someLabwareIf: ['commandId1', 'commandId2'] },
       onCloseClick: jest.fn(),
       applyLabwareOffsets: jest.fn(),
-      setLabwareOffsets: jest.fn(),
       labwareOffsets: MOCK_LABWARE_OFFSETS,
     }
     mockSectionList.mockReturnValue(<div>Mock SectionList</div>)

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
@@ -46,6 +46,14 @@ const PRIMARY_PIPETTE_NAME = 'PRIMARY_PIPETTE_NAME'
 const LABWARE_DEF = {
   ordering: [['A1', 'A2']],
 }
+const MOCK_LABWARE_OFFSETS = {
+  labwareId: 'id',
+  LabwareOffsetLocation: { slotName: 'slot' },
+  labwareDefinitionUri: 'uri',
+  displayLocation: 'location',
+  displayName: 'name',
+  vestor: { x: 0, y: 0, z: 0 },
+} as any
 
 const render = (props: React.ComponentProps<typeof SummaryScreen>) => {
   return renderWithProviders(<SummaryScreen {...props} />, {
@@ -60,6 +68,9 @@ describe('SummaryScreen', () => {
     props = {
       savePositionCommandData: { someLabwareIf: ['commandId1', 'commandId2'] },
       onCloseClick: jest.fn(),
+      applyLabwareOffsets: jest.fn(),
+      setLabwareOffsets: jest.fn(),
+      labwareOffsets: MOCK_LABWARE_OFFSETS,
     }
     mockSectionList.mockReturnValue(<div>Mock SectionList</div>)
     mockDeckmap.mockReturnValue(<div>Mock DeckMap</div>)
@@ -112,7 +123,7 @@ describe('SummaryScreen', () => {
     getByText('Mock Labware Offsets Summary')
     getByText('Labware Position Check Complete')
   })
-  it('renders apply offset button and clicks it', () => {
+  it('renders apply offset button and clicks it and applies labwareOffsets, renders success toast, and closes modal', () => {
     const mockSetShowLPCSuccessToast = jest.fn()
     when(mockUseLPCSuccessToast)
       .calledWith()
@@ -128,5 +139,6 @@ describe('SummaryScreen', () => {
     })
     expect(props.onCloseClick).toHaveBeenCalled()
     expect(mockSetShowLPCSuccessToast).toHaveBeenCalled()
+    expect(props.applyLabwareOffsets).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
@@ -48,7 +48,7 @@ const LABWARE_DEF = {
 }
 const MOCK_LABWARE_OFFSETS = {
   labwareId: 'id',
-  LabwareOffsetLocation: { slotName: 'slot' },
+  labwareOffsetLocation: { slotName: 'slot' },
   labwareDefinitionUri: 'uri',
   displayLocation: 'location',
   displayName: 'name',

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
@@ -35,10 +35,7 @@ import type {
   LabwareOffsetCreateData,
   AnonymousCommand,
 } from '@opentrons/api-client'
-import type {
-  Command,
-  ProtocolFile,
-} from '@opentrons/shared-data/protocol/types/schemaV6'
+import type { Command, ProtocolFile } from '@opentrons/shared-data'
 import type { SetupCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
 import type { DropTipCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/pipetting'
 import type {
@@ -57,7 +54,7 @@ import type {
   LabwarePositionCheckStep,
   SavePositionCommandData,
 } from '../types'
-import { LabwareOffsets, useLabwareOffsets } from './useLabwareOffsets'
+import { LabwareOffsets } from './useLabwareOffsets'
 
 export type LabwarePositionCheckUtils =
   | {
@@ -72,8 +69,9 @@ export type LabwarePositionCheckUtils =
       onUnsuccessfulPickUpTip: () => void
       jog: Jog
       ctaText: string
-      applyLabwareOffsets: () => void
       labwareOffsets: LabwareOffsets
+      applyLabwareOffsets: () => void
+      setLabwareOffsets: (active: LabwareOffsets) => void
     }
   | { error: Error }
 
@@ -199,13 +197,6 @@ export function useLabwarePositionCheck(
   const [currentCommandIndex, setCurrentCommandIndex] = React.useState<number>(
     0
   )
-  const { protocolData } = useProtocolDetails()
-  const [labwareOffsets, setLabwareOffsets] = React.useState<LabwareOffsets>([])
-  useLabwareOffsets(savePositionCommandData, protocolData as ProtocolFile<{}>)
-    .then(offsets => setLabwareOffsets(offsets))
-    .catch((e: Error) =>
-      console.error(`error getting labware offsetsL ${e.message}`)
-    )
   const [
     pendingMovementCommandData,
     setPendingMovementCommandData,
@@ -233,6 +224,8 @@ export function useLabwarePositionCheck(
   const dispatch = useDispatch()
   const robotName = useSelector(getConnectedRobotName)
   const attachedModules = useSelector(getAttachedModulesForConnectedRobot)
+  const { protocolData } = useProtocolDetails()
+  const [labwareOffsets, setLabwareOffsets] = React.useState<LabwareOffsets>([])
 
   const LPCCommands = LPCSteps.reduce<LabwarePositionCheckCommand[]>(
     (commands, currentStep) => {
@@ -670,7 +663,6 @@ export function useLabwarePositionCheck(
         console.error(`error issuing jog command: ${e.message}`)
       })
   }
-
   const applyLabwareOffsets = (): void => {
     if (labwareOffsets.length > 0) {
       labwareOffsets.forEach(labwareOffset => {
@@ -704,7 +696,8 @@ export function useLabwarePositionCheck(
     titleText,
     isLoading,
     showPickUpTipConfirmationModal,
-    applyLabwareOffsets,
     labwareOffsets,
+    applyLabwareOffsets,
+    setLabwareOffsets,
   }
 }

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
@@ -112,7 +112,6 @@ export const LabwarePositionCheck = (
     jog,
     labwareOffsets,
     applyLabwareOffsets,
-    setLabwareOffsets,
   } = labwarePositionCheckUtils
 
   let modalContent: JSX.Element
@@ -178,7 +177,6 @@ export const LabwarePositionCheck = (
           labwareOffsets={labwareOffsets}
           onCloseClick={props.onCloseClick}
           applyLabwareOffsets={applyLabwareOffsets}
-          setLabwareOffsets={setLabwareOffsets}
           savePositionCommandData={savePositionCommandData}
         />
       </ModalPage>

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
@@ -112,6 +112,7 @@ export const LabwarePositionCheck = (
     jog,
     labwareOffsets,
     applyLabwareOffsets,
+    setLabwareOffsets,
   } = labwarePositionCheckUtils
 
   let modalContent: JSX.Element
@@ -177,6 +178,8 @@ export const LabwarePositionCheck = (
           labwareOffsets={labwareOffsets}
           onCloseClick={props.onCloseClick}
           applyLabwareOffsets={applyLabwareOffsets}
+          setLabwareOffsets={setLabwareOffsets}
+          savePositionCommandData={savePositionCommandData}
         />
       </ModalPage>
     )

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/index.tsx
@@ -110,6 +110,8 @@ export const LabwarePositionCheck = (
     titleText,
     isLoading,
     jog,
+    labwareOffsets,
+    applyLabwareOffsets,
   } = labwarePositionCheckUtils
 
   let modalContent: JSX.Element
@@ -172,8 +174,9 @@ export const LabwarePositionCheck = (
         }}
       >
         <SummaryScreen
-          savePositionCommandData={savePositionCommandData}
+          labwareOffsets={labwareOffsets}
           onCloseClick={props.onCloseClick}
+          applyLabwareOffsets={applyLabwareOffsets}
         />
       </ModalPage>
     )


### PR DESCRIPTION
closes #8905 

# Overview

This PR moves apply labware offset logic from the LPC summary screen and into the `useLabwarePostionCheck` hook

# Changelog

- refactored the logic and also extended a few props

# Review requests

- Run through LPC on your robot and make sure it gets through it successfully.  I tested a handful of protocols on my robot and it worked but would be ideal to run on another robot to make sure this refactor didn't break anything

Note: there is no test file for `useLabwarePositionCheck` at the moment, that can be addressed in a follow up ticket: #9140 

# Risk assessment

low, behind ff