### PR TITLE
refactor(app): add pause protocol icon and text to run log

### DIFF
--- a/app/src/organisms/RunDetails/CommandItem.tsx
+++ b/app/src/organisms/RunDetails/CommandItem.tsx
@@ -89,6 +89,8 @@ export function CommandItem(props: CommandItemProps): JSX.Element | null {
       commandDetails.data.params.legacyCommandType === 'command.COMMENT'
   }
 
+  const isPause = commandOrSummary.commandType === 'pause'
+
   React.useEffect(() => {
     refetchCommandDetails()
   }, [commandStatus])
@@ -116,6 +118,23 @@ export function CommandItem(props: CommandItemProps): JSX.Element | null {
           marginLeft={SPACING_1}
         >
           {t('comment_step')}
+        </Flex>
+      ) : null}
+      {isPause ? (
+        <Flex
+          textTransform={TEXT_TRANSFORM_UPPERCASE}
+          fontSize={FONT_SIZE_CAPTION}
+          color={C_MED_DARK_GRAY}
+          marginBottom={SPACING_1}
+          marginLeft={SPACING_1}
+        >
+          <Icon
+            name="pause"
+            width={SPACING_3}
+            paddingRight={SPACING_2}
+            color={C_DARK_GRAY}
+          />
+          {t('pause_protocol')}
         </Flex>
       ) : null}
       <Flex flexDirection={DIRECTION_ROW}>

--- a/app/src/organisms/RunDetails/__tests__/CommandItem.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/CommandItem.test.tsx
@@ -63,6 +63,22 @@ const MOCK_COMMAND_DETAILS_COMMENT = {
   startedAt: 'start timestamp',
   completedAt: 'end timestamp',
 } as Command
+const MOCK_PAUSE_COMMAND = {
+  id: 'PAUSE',
+  commandType: 'pause',
+  params: {},
+  status: 'queued',
+  result: {},
+} as Command
+const MOCK_COMMAND_DETAILS_PAUSE = {
+  id: 'PAUSE',
+  commandType: 'pause',
+  params: {},
+  status: 'queued',
+  result: {},
+  startedAt: 'start timestamp',
+  completedAt: 'end timestamp',
+} as Command
 describe('Run Details Command item', () => {
   beforeEach(() => {
     mockCommandText.mockReturnValue(<div>Mock Command Text</div>)
@@ -149,5 +165,21 @@ describe('Run Details Command item', () => {
     const { getByText } = render(props)
     expect(getByText('Comment')).toHaveStyle('backgroundColor: C_NEAR_WHITE')
     getByText('Mock Command Text')
+  })
+  it('renders the pause text when the command is a pause', () => {
+    when(mockUseCommandQuery)
+      .calledWith(RUN_ID, MOCK_PAUSE_COMMAND.id)
+      .mockReturnValue({
+        data: { data: MOCK_COMMAND_DETAILS_PAUSE },
+        refetch: jest.fn(),
+      } as any)
+    const props = {
+      commandOrSummary: { ...MOCK_PAUSE_COMMAND, status: 'queued' },
+      runStatus: 'paused',
+    } as React.ComponentProps<typeof CommandItem>
+    const { getByText } = render(props)
+    expect(getByText('Pause protocol')).toHaveStyle(
+      'backgroundColor: C_NEAR_WHITE'
+    )
   })
 })


### PR DESCRIPTION
# Overview

This PR adds a pause icon and Pause Protocol text to the run log for pause commands. closes #9098

<img width="930" alt="Screen Shot 2021-12-15 at 4 35 23 PM" src="https://user-images.githubusercontent.com/14794021/146275663-0ac6cb92-c5ee-4c60-b621-6c6578ed3953.png">

# Changelog

- Added conditional to render pause icon + text
- Increased test coverage for pauses

# Review requests

- Check that the "Pause Protocol" text and icon is rendering in the run log for pause steps.

# Risk assessment

low, stylistic
