### PR TITLE
refactor(app): make protocol setup whole background gray

### DIFF
--- a/app/src/organisms/ProtocolSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/index.tsx
@@ -22,6 +22,7 @@ import {
   Text,
   Link,
   SPACING_1,
+  C_NEAR_WHITE,
 } from '@opentrons/components'
 
 import { useRunStatus } from '../RunTimeControl/hooks'
@@ -75,6 +76,7 @@ export function ProtocolSetup(): JSX.Element {
         </Box>
       ) : null}
       <Flex
+        backgroundColor={C_NEAR_WHITE}
         flexDirection={DIRECTION_COLUMN}
         padding={`${SPACING_1} ${SPACING_3} ${SPACING_3} ${SPACING_3}`}
       >


### PR DESCRIPTION
closes #9120

# Overview

This makes the background behind the accordion steps and metadata card the same light gray color `C_NEAR_WHITE` 

<img width="961" alt="Screen Shot 2021-12-16 at 09 29 52" src="https://user-images.githubusercontent.com/66035149/146390529-35bd5368-3789-40c3-a0bc-f167a9b68497.png">


# Changelog

- Added background color to `protocolSetup/index`

# Review requests

- review above picture, review on your own robot - it is a super subtle difference and hard to see

# Risk assessment

low, behind ff