### PR TITLE
refactor(protocol-engine): Do not catch TypeError from find_modules()

### DIFF
--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -214,12 +214,9 @@ class EquipmentHandler:
         hw_model = module_model_from_string(model.value)
         model_type = resolve_module_type(hw_model)
 
-        try:
-            available, simulating = await self._hardware_api.find_modules(
-                by_model=hw_model, resolved_type=model_type
-            )
-        except TypeError as e:
-            raise ModuleNotAttachedError("Could not fetch modules attached") from e
+        available, simulating = await self._hardware_api.find_modules(
+            by_model=hw_model, resolved_type=model_type
+        )
 
         for mod in available:
             # TODO (spp, 2021-11-22): make this accept compatible module models


### PR DESCRIPTION
# Overview

`find_modules()` returns a tuple that we unpack into two parts: `available` and `simulating`. We were catching `TypeError` at this unpacking step in case the element counts were ever mismatched.

However, from `find_modules()`'s type annotation, its contract is to *always* return a 2-element tuple. This unpacking should never fail, so the `except TypeError` is unnecessary. This PR removes it.

From slack conversations with @sanni-t, when we added this `except TypeError` in #8877, it might have been because we misinterpreted a test error message related to how we had our mocks set up, making us think that this check was necessary.

# Review requests

As long as tests continue to pass, I think code review should be sufficient.

# Risk assessment

Low. If unpacking *does* fail here unexpectedly, it's still an error, as it should be. It's just an internal error instead of a nice `ModuleNotAttachedError`.