### PR TITLE
fix(app): block LPC when a protocol does not have a tip rack loaded

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -95,5 +95,6 @@
   "protocol_run_complete": "Protocol run complete.",
   "protocol_run_failed": "Protocol run failed.",
   "protocol_run_canceled": "Protocol run canceled.",
-  "labware_position_check_not_available_empty_protocol": "Labware Position Check requires that the protocol loads labware and pipettes"
+  "labware_position_check_not_available_empty_protocol": "Labware Position Check requires that the protocol loads labware and pipettes",
+  "lpc_disabled_no_tipracks_loaded": "Labware Position Check requires that the protocol loads a tip rack"
 }

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareSetup.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareSetup.test.tsx
@@ -252,7 +252,7 @@ describe('LabwareSetup', () => {
           labware: {
             [mockLabwarePositionCheckStepTipRack.labwareId]: {
               slot: '1',
-              displayName: 'someDislpayName',
+              displayName: 'someDisplayName',
               definitionId: LABWARE_DEF_ID,
             },
           },
@@ -404,7 +404,7 @@ describe('LabwareSetup', () => {
       name: 'run labware position check',
     })
     fireEvent.click(button)
-    getByText('mock Labware Position Check')
+    getByText('run labware position check')
   })
   it('should render a disabled button when a run has been started', () => {
     mockUseRunStatus.mockReturnValue(RUN_STATUS_RUNNING)
@@ -440,7 +440,7 @@ describe('LabwareSetup', () => {
       name: 'run labware position check',
     })
     fireEvent.click(button)
-    const LPC = getByText('mock Labware Position Check')
+    const LPC = getByText('run labware position check')
     fireEvent.click(LPC)
     when(mockLabwarePostionCheck)
       .calledWith(
@@ -493,5 +493,32 @@ describe('LabwareSetup', () => {
     })
     fireEvent.click(button)
     expect(queryByText('mock Labware Position Check')).toBeNull()
+  })
+  it('should render a disabled button when a protocol does not load a tip rack', () => {
+    mockUseProtocolDetails.mockReturnValue({
+      protocolData: {
+        labware: {
+          'labware-0': {
+            slot: '1',
+            displayName: 'someDisplayName',
+            definitionId: LABWARE_DEF_ID,
+          },
+        },
+        labwareDefinitions: {
+          [LABWARE_DEF_ID]: { parameters: { isTiprack: false } },
+        },
+        pipettes: {
+          [PRIMARY_PIPETTE_ID]: {
+            name: PRIMARY_PIPETTE_NAME,
+            mount: 'left',
+          },
+        },
+      },
+    } as any)
+    const { getByRole } = render()
+    const button = getByRole('button', {
+      name: 'run labware position check',
+    })
+    expect(button).toBeDisabled()
   })
 })

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import map from 'lodash/map'
 import isEmpty from 'lodash/isEmpty'
+import some from 'lodash/some'
 import { useTranslation } from 'react-i18next'
 import { RUN_STATUS_IDLE } from '@opentrons/api-client'
 import {
@@ -91,15 +92,10 @@ export const LabwareSetup = (): JSX.Element | null => {
   const moduleAndCalibrationIncomplete =
     missingModuleIds.length > 0 && !isEverythingCalibrated
 
-  let tipRackLoadedInProtocol: boolean = false
-
-  if (protocolData != null) {
-    for (const def in protocolData?.labwareDefinitions) {
-      if (protocolData?.labwareDefinitions[def].parameters?.isTiprack) {
-        tipRackLoadedInProtocol = true
-      }
-    }
-  }
+  const tipRackLoadedInProtocol: boolean = some(
+    protocolData?.labwareDefinitions,
+    def => def.parameters?.isTiprack
+  )
 
   let lpcDisabledReason: string | null = null
 

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
@@ -3,6 +3,7 @@ import map from 'lodash/map'
 import isEmpty from 'lodash/isEmpty'
 import { useTranslation } from 'react-i18next'
 import { RUN_STATUS_IDLE } from '@opentrons/api-client'
+import { useSteps } from '../../LabwarePositionCheck/hooks/useSteps'
 import {
   Btn,
   Flex,
@@ -72,6 +73,7 @@ export const LabwareSetup = (): JSX.Element | null => {
     showLabwareHelpModal,
     setShowLabwareHelpModal,
   ] = React.useState<boolean>(false)
+  const steps = useSteps() ?? []
 
   const moduleModels = map(
     moduleRenderInfoById,
@@ -106,6 +108,8 @@ export const LabwareSetup = (): JSX.Element | null => {
     isEmpty(protocolData?.labware)
   ) {
     lpcDisabledReason = t('labware_position_check_not_available_empty_protocol')
+  } else if (steps[0]?.labwareId == null) {
+    lpcDisabledReason = t('lpc_disabled_no_tipracks_loaded')
   }
 
   return (

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
@@ -3,7 +3,6 @@ import map from 'lodash/map'
 import isEmpty from 'lodash/isEmpty'
 import { useTranslation } from 'react-i18next'
 import { RUN_STATUS_IDLE } from '@opentrons/api-client'
-import { useSteps } from '../../LabwarePositionCheck/hooks/useSteps'
 import {
   Btn,
   Flex,
@@ -73,7 +72,6 @@ export const LabwareSetup = (): JSX.Element | null => {
     showLabwareHelpModal,
     setShowLabwareHelpModal,
   ] = React.useState<boolean>(false)
-  const steps = useSteps() ?? []
 
   const moduleModels = map(
     moduleRenderInfoById,
@@ -93,6 +91,16 @@ export const LabwareSetup = (): JSX.Element | null => {
   const moduleAndCalibrationIncomplete =
     missingModuleIds.length > 0 && !isEverythingCalibrated
 
+  let tipRackLoadedInProtocol: boolean = false
+
+  if (protocolData != null) {
+    for (const def in protocolData?.labwareDefinitions) {
+      if (protocolData?.labwareDefinitions[def].parameters?.isTiprack) {
+        tipRackLoadedInProtocol = true
+      }
+    }
+  }
+  console.log(protocolData)
   let lpcDisabledReason: string | null = null
 
   if (moduleAndCalibrationIncomplete) {
@@ -108,7 +116,7 @@ export const LabwareSetup = (): JSX.Element | null => {
     isEmpty(protocolData?.labware)
   ) {
     lpcDisabledReason = t('labware_position_check_not_available_empty_protocol')
-  } else if (steps[0]?.labwareId == null) {
+  } else if (!tipRackLoadedInProtocol) {
     lpcDisabledReason = t('lpc_disabled_no_tipracks_loaded')
   }
 

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
@@ -100,7 +100,7 @@ export const LabwareSetup = (): JSX.Element | null => {
       }
     }
   }
-  console.log(protocolData)
+
   let lpcDisabledReason: string | null = null
 
   if (moduleAndCalibrationIncomplete) {


### PR DESCRIPTION
# Overview

The white screen behavior described in the ticket below seems to occur when a tip rack is not loaded in the protocol. This PR blocks the LPC CTA when a protocol that is uploaded does not have a tip rack loaded. 

closes #9090

![Screen Shot 2021-12-17 at 4 53 37 PM](https://user-images.githubusercontent.com/14794021/146613024-0af8f912-0d8b-432b-bcf2-176a9e3bbd65.png)

# Changelog

- Added conditional to check if there is a primary tip rack in the protocol

# Review requests

- Check that when a protocol is loaded **without** a tip rack LPC is disabled.
- Check that when a protocol is loaded **with** a tip rack LPC is enabled.

Protocol with No Tip Rack:
```
metadata = {"apiLevel": "2.11"}

def run(protocol):

    # No Tip Rack
    plate = protocol.load_labware("biorad_96_wellplate_200ul_pcr", 2)
    pipette = protocol.load_instrument("p300_single_gen2", mount="right")
```

Protocol with Tip Rack:
```
metadata = {"apiLevel": "2.11"}

def run(protocol):

    # With Tip Rack
    p300racks = [protocol.load_labware('opentrons_96_tiprack_300ul', '3')]
    plate = protocol.load_labware("biorad_96_wellplate_200ul_pcr", 2)
    pipette = protocol.load_instrument("p300_single_gen2", mount="right")
```

# Risk assessment
low
