### PR TITLE
refactor(app): routes for next gen app

### DIFF
--- a/app/src/App/NextGenApp.tsx
+++ b/app/src/App/NextGenApp.tsx
@@ -1,22 +1,188 @@
 import * as React from 'react'
-import { Redirect, Route, Switch } from 'react-router-dom'
+import { NavLink, Redirect, Route, Switch } from 'react-router-dom'
+import styled from 'styled-components'
+
+import {
+  Box,
+  Flex,
+  BORDER_SOLID_LIGHT,
+  DIRECTION_COLUMN,
+  FLEX_NONE,
+  POSITION_RELATIVE,
+  SIZE_4,
+  SPACING_2,
+} from '@opentrons/components'
 
 import { AppSettings } from '../pages/More/AppSettings'
+
+interface RouteProps {
+  /**
+   * the component rendered by a route match
+   * drop developed components into slots held by placeholder div components
+   */
+  component: () => JSX.Element
+  exact?: boolean
+  /**
+   * a route/page name to render in the temp nav bar
+   */
+  name: string
+  /**
+   * the path for navigation linking, for example to push to a default tab
+   * some of these links are temp (and params hardcoded) until final nav and breadcrumbs implemented
+   */
+  navLinkTo?: string
+  path: string
+  /**
+   * navigational tier, for temp nav and perhaps breadcrumb when implemented
+   */
+  tier: number
+}
+
+const TempNavBarLink = styled(NavLink)<{ tier: number; lastRoute: boolean }>`
+  padding-left: ${props => (props.tier - 1) * 5}px;
+  margin-top: ${props => (props.lastRoute ? 'auto' : 0)};
+`
+
+/**
+ * a temp nav bar to facilitate app navigation during development until breadcrumbs are implemented
+ * @param routes
+ * @returns {JSX.Element}
+ */
+function TempNavBar({ routes }: { routes: RouteProps[] }): JSX.Element {
+  const navRoutes = routes.filter(
+    ({ navLinkTo }: RouteProps) => navLinkTo != null
+  )
+  return (
+    <Flex
+      flexDirection={DIRECTION_COLUMN}
+      flex={FLEX_NONE}
+      width={SIZE_4}
+      borderRight={BORDER_SOLID_LIGHT}
+      margin={SPACING_2}
+    >
+      {navRoutes.map(({ name, navLinkTo, tier }: RouteProps, i: number) => (
+        <TempNavBarLink
+          key={name}
+          to={navLinkTo as string}
+          lastRoute={i === navRoutes.length - 1}
+          tier={tier}
+        >
+          {name}
+        </TempNavBarLink>
+      ))}
+    </Flex>
+  )
+}
 
 /**
  * Component for the next gen app routes and navigation
  * @returns {JSX.Element}
  */
 export function NextGenApp(): JSX.Element {
+  // TODO(bh, 2021-12-10): i18n for route name once final nav/breadcrumbs implemented
+  const nextGenRoutes: RouteProps[] = [
+    {
+      component: () => <div>protocols landing</div>,
+      exact: true,
+      name: 'Protocols',
+      navLinkTo: '/protocols',
+      path: '/protocols',
+      tier: 1,
+    },
+    {
+      component: () => <div>protocol details</div>,
+      exact: true,
+      name: 'Protocol Details',
+      navLinkTo: '/protocols/1', // temp
+      path: '/protocols/:protocolId',
+      tier: 2,
+    },
+    {
+      component: () => <div>deck setup</div>,
+      name: 'Deck Setup',
+      navLinkTo: '/protocols/1/deck-setup', // temp
+      path: '/protocols/:protocolId/deck-setup',
+      tier: 3,
+    },
+    {
+      component: () => <div>labware landing</div>,
+      name: 'Labware',
+      navLinkTo: '/labware',
+      // labwareId param is for details slideout
+      path: '/labware/:labwareId?',
+      tier: 1,
+    },
+    {
+      component: () => <div>devices landing</div>,
+      exact: true,
+      name: 'Devices',
+      navLinkTo: '/devices',
+      path: '/devices',
+      tier: 1,
+    },
+    {
+      component: () => <div>device details</div>,
+      exact: true,
+      name: 'Device Details',
+      navLinkTo: '/devices/otie', // temp
+      path: '/devices/:deviceName',
+      tier: 2,
+    },
+    {
+      component: () => <div>robot settings</div>,
+      exact: true,
+      name: 'Robot Settings',
+      navLinkTo: '/devices/otie/robot-settings/calibration', // temp
+      // robot settings tabs params: 'calibration' | 'networking' | 'advanced'
+      path: '/devices/:deviceName/robot-settings/:robotSettingsTab',
+      tier: 3,
+    },
+    {
+      component: () => <div>protocol runs landing</div>,
+      exact: true,
+      name: 'Protocol Runs',
+      navLinkTo: '/devices/otie/protocol-runs', // temp
+      path: '/devices/:deviceName/protocol-runs',
+      tier: 3,
+    },
+    {
+      component: () => <div>protocol run details page</div>,
+      name: 'Run Details',
+      // navLinkTo: '/devices/otie/protocol-runs/setup', // temp
+      // run details tabs params: 'setup' | 'run'
+      path: '/devices/:deviceName/protocol-runs/:runDetailsTab',
+      tier: 4,
+    },
+    {
+      component: AppSettings,
+      name: 'App Settings',
+      navLinkTo: '/app-settings/feature-flags',
+      // app settings tabs params: 'general' | 'privacy' | 'advanced' | 'feature-flags'
+      path: '/app-settings/:appSettingsTab',
+      tier: 1,
+    },
+  ]
   return (
-    <Switch>
-      <Route path="/app-settings">
-        <AppSettings />
-      </Route>
-      {/* this redirect from /robots is necessary because the existing app <Redirect /> to /robots renders before feature flags load */}
-      <Redirect from="/robots" to="/app-settings" />
-      {/* this redirects from the existing app settings page on next gen app feature flag toggle */}
-      <Redirect from="/more" to="/app-settings" />
-    </Switch>
+    <>
+      <TempNavBar routes={nextGenRoutes} />
+      <Box position={POSITION_RELATIVE} width="100%" height="100%">
+        <Switch>
+          {nextGenRoutes.map(({ component, exact, path }: RouteProps) => {
+            return (
+              <Route
+                key={path}
+                component={component}
+                exact={exact}
+                path={path}
+              />
+            )
+          })}
+          {/* this redirect from /robots is necessary because the existing app <Redirect /> to /robots renders before feature flags load */}
+          <Redirect from="/robots" to="/app-settings/feature-flags" />
+          {/* this redirects from the existing app settings page on next gen app feature flag toggle */}
+          <Redirect from="/more" to="/app-settings/feature-flags" />
+        </Switch>
+      </Box>
+    </>
   )
 }

--- a/app/src/App/__tests__/App.test.tsx
+++ b/app/src/App/__tests__/App.test.tsx
@@ -120,8 +120,8 @@ describe('top level App component', () => {
     expect(wrapper.exists(ConnectPanel)).toBe(true)
   })
 
-  it('should redirect to /more from /app-settings', () => {
-    const { wrapper } = render('/app-settings')
+  it('should redirect to /more from /app-settings/feature-flags', () => {
+    const { wrapper } = render('/app-settings/feature-flags')
     expect(wrapper.exists(More)).toBe(true)
     expect(wrapper.exists(MorePanel)).toBe(true)
   })

--- a/app/src/App/__tests__/NextGenApp.test.tsx
+++ b/app/src/App/__tests__/NextGenApp.test.tsx
@@ -21,7 +21,7 @@ const render = (path = '/') => {
 
 describe('NextGenApp', () => {
   it('renders an AppSettings component', () => {
-    const [{ getByText }] = render('/app-settings')
+    const [{ getByText }] = render('/app-settings/feature-flags')
     expect(getByText('Mock AppSettings')).toBeTruthy()
   })
 
@@ -31,6 +31,10 @@ describe('NextGenApp', () => {
   })
 
   it('renders an AppSettings component from /more', () => {
+    const [{ getByText }] = render('/more')
+    expect(getByText('Mock AppSettings')).toBeTruthy()
+  })
+  it('renders a nav bar with a protocols from /more', () => {
     const [{ getByText }] = render('/more')
     expect(getByText('Mock AppSettings')).toBeTruthy()
   })

--- a/app/src/App/index.tsx
+++ b/app/src/App/index.tsx
@@ -83,7 +83,7 @@ export const AppComponent = (): JSX.Element => {
                 </Route>
                 <Redirect exact from="/" to="/robots" />
                 {/* redirect after next gen app feature flag toggle */}
-                <Redirect exact from="/app-settings" to="/more" />
+                <Redirect exact from="/app-settings/feature-flags" to="/more" />
               </Switch>
               <Alerts />
             </Box>


### PR DESCRIPTION
# Overview

this sketches out the routes for next gen app based on the [Milestone 1 Sitemap](https://images.zenhubusercontent.com/5e20a4f595a33208d0d768ab/7554e44f-1e07-4270-86b8-685a015525ed). react router params to be pulled from the route for page level hooks/data fetching: `protocolId`, `labwareId`, `deviceName`, and for tab navigation: `robotSettingsTab`, `runDetailsTab`, `appSettingsTab`

much of this is temporary until breadcrumbs and the navigation bar are implemented. in the meantime, TempNavBar will render all routes on the left side of the app to allow page navigation. once landing pages and breadcrumbs are implemented, TempNavBar should be adjusted or removed.

<img width="1136" alt="Screen Shot 2021-12-21 at 11 13 53 AM" src="https://user-images.githubusercontent.com/29845468/146963907-48c4aa12-e1f7-4069-8cfd-939fdad889d3.png">

closes #8805

# Changelog

 - Adds routes for Next Gen App

# Review requests

read through the `nextGenRoutes` in `NextGenApp.tsx`, look over the shape of `RouteProps`

# Risk assessment

low
