### PR TITLE
refactor(app): Load pipette centering images and fix styling

### DIFF
--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwarePositionCheckStepDetailModal.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/LabwarePositionCheckStepDetailModal.tsx
@@ -22,12 +22,23 @@ import {
   SPACING_5,
   Text,
   TEXT_TRANSFORM_UPPERCASE,
+  POSITION_RELATIVE,
+  POSITION_ABSOLUTE,
+  C_DARK_GRAY,
 } from '@opentrons/components'
 import { Portal } from '../../../App/portal'
 import styles from '../styles.css'
 
 interface LabwarePositionCheckStepDetailModalProps {
   onCloseClick: () => unknown
+}
+
+const POSITION_IMGS = {
+  modalNozzle1: require('../../../assets/images/lpc_modal_nozzle_1.jpg'),
+  modalNozzle2: require('../../../assets/images/lpc_modal_nozzle_not_centered_1.jpg'),
+  modalNozzle3: require('../../../assets/images/lpc_modal_nozzle_2.jpg'),
+  modalNozzle4: require('../../../assets/images/lpc_modal_nozzle_not_centered_2.jpg'),
+  modalNozzle5: require('../../../assets/images/lpc_modal_nozzle_paper.jpg'),
 }
 
 export const LabwarePositionCheckStepDetailModal = (
@@ -60,107 +71,102 @@ export const LabwarePositionCheckStepDetailModal = (
           </Text>
           <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
             <Box
-              style={{
-                backgroundImage: `url(../../../assets/images/lpc_modal_nozzle_1.jpg)`,
-                backgroundSize: 'cover',
-              }}
-              marginRight={SPACING_1}
+              position={POSITION_RELATIVE}
               width="50%"
+              marginRight={SPACING_1}
             >
+              <img src={POSITION_IMGS.modalNozzle1} width="100%" />
               <Text
-                color={C_NEAR_WHITE}
                 as={'h5'}
-                fontWeight={FONT_WEIGHT_SEMIBOLD}
-                marginTop={SPACING_2}
+                position={POSITION_ABSOLUTE}
+                top={SPACING_2}
                 marginLeft={SPACING_3}
                 marginRight={SPACING_4}
+                color={C_NEAR_WHITE}
+                fontWeight={FONT_WEIGHT_SEMIBOLD}
               >
                 {t('labware_step_detail_modal_nozzle_image_1_text')}
               </Text>
             </Box>
             <Box
-              style={{
-                backgroundImage: `url(../../../assets/images/lpc_modal_nozzle_not_centered_1.jpg)`,
-                backgroundSize: 'cover',
-              }}
-              marginLeft={SPACING_1}
+              position={POSITION_RELATIVE}
               width="50%"
+              marginLeft={SPACING_1}
             >
-              <Box height="18rem">
-                <Text
-                  color={C_NEAR_WHITE}
-                  as={'h5'}
-                  fontWeight={FONT_WEIGHT_SEMIBOLD}
-                  marginTop={SPACING_2}
-                  marginLeft={SPACING_3}
-                  marginRight={SPACING_4}
-                >
-                  {t('labware_step_detail_modal_nozzle_image_2_text')}
-                </Text>
-                <Text
-                  color={'#ff5b5b'}
-                  as={'h5'}
-                  fontWeight={FONT_WEIGHT_SEMIBOLD}
-                  marginTop={'4.5rem'}
-                  marginLeft={'8.5rem'}
-                >
-                  {t('labware_step_detail_modal_nozzle_image_2_nozzle_text')}
-                </Text>
-              </Box>
+              <img src={POSITION_IMGS.modalNozzle2} width="100%" />
+
+              <Text
+                position={POSITION_ABSOLUTE}
+                top={SPACING_2}
+                marginLeft={SPACING_3}
+                color={C_NEAR_WHITE}
+                as={'h5'}
+                fontWeight={FONT_WEIGHT_SEMIBOLD}
+              >
+                {t('labware_step_detail_modal_nozzle_image_2_text')}
+              </Text>
+              <Text
+                as={'h5'}
+                position={POSITION_ABSOLUTE}
+                top="35%"
+                left="40%"
+                color={'#ff5b5b'}
+                fontWeight={FONT_WEIGHT_SEMIBOLD}
+              >
+                {t('labware_step_detail_modal_nozzle_image_2_nozzle_text')}
+              </Text>
             </Box>
           </Flex>
           <Text
             as={'h4'}
-            fontWeight={FONT_WEIGHT_SEMIBOLD}
             marginTop={SPACING_3}
             marginBottom={SPACING_3}
+            fontWeight={FONT_WEIGHT_SEMIBOLD}
           >
             {t('labware_step_detail_modal_nozzle_or_tip')}
           </Text>
           <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
             <Box
-              style={{
-                backgroundImage: `url(../../../assets/images/lpc_modal_nozzle_2.jpg)`,
-                backgroundSize: 'cover',
-                flex: '1 1 31%',
-              }}
+              position={POSITION_RELATIVE}
+              flex="1 1 31%"
               marginRight={SPACING_1}
             >
+              <img src={POSITION_IMGS.modalNozzle3} width="100%" />
               <Text
-                color={C_NEAR_WHITE}
                 as={'h5'}
-                fontWeight={FONT_WEIGHT_SEMIBOLD}
-                marginTop={SPACING_2}
+                position={POSITION_ABSOLUTE}
+                top={SPACING_2}
                 marginLeft={SPACING_3}
-                marginRight={SPACING_4}
+                fontWeight={FONT_WEIGHT_SEMIBOLD}
+                color={C_NEAR_WHITE}
               >
                 {t('labware_step_detail_modal_nozzle_or_tip_image_1_text')}
               </Text>
             </Box>
             <Box
-              style={{
-                backgroundImage: `url(../../../assets/images/lpc_modal_nozzle_not_centered_2.jpg)`,
-                backgroundSize: 'cover',
-                flex: '1 1 31%',
-              }}
+              position={POSITION_RELATIVE}
+              flex="1 1 31%"
               marginRight={SPACING_1}
               marginLeft={SPACING_1}
             >
+              <img src={POSITION_IMGS.modalNozzle4} width="100%" />
               <Text
-                color={C_NEAR_WHITE}
                 as={'h5'}
-                fontWeight={FONT_WEIGHT_SEMIBOLD}
-                marginTop={SPACING_2}
+                position={POSITION_ABSOLUTE}
+                top={SPACING_2}
                 marginLeft={SPACING_3}
+                color={C_NEAR_WHITE}
+                fontWeight={FONT_WEIGHT_SEMIBOLD}
               >
                 {t('labware_step_detail_modal_nozzle_or_tip_image_2_text')}
               </Text>
               <Text
-                color={'#ff5b5b'}
                 as={'h5'}
-                fontWeight={FONT_WEIGHT_SEMIBOLD}
-                marginTop={'1.7rem'}
+                position={POSITION_ABSOLUTE}
+                top="25%"
                 marginLeft={'6.7rem'}
+                color={'#ff5b5b'}
+                fontWeight={FONT_WEIGHT_SEMIBOLD}
               >
                 {t(
                   'labware_step_detail_modal_nozzle_or_tip_image_2_nozzle_text'
@@ -169,22 +175,22 @@ export const LabwarePositionCheckStepDetailModal = (
             </Box>
 
             <Box
-              style={{
-                backgroundImage: `url(../../../assets/images/lpc_modal_nozzle_paper.jpg)`,
-                backgroundSize: 'cover',
-                flex: '1 1 31%',
-              }}
+              position={POSITION_RELATIVE}
+              flex="1 1 31%"
               marginLeft={SPACING_1}
             >
-              <Box backgroundColor={C_LIGHT_GRAY}>
+              <img src={POSITION_IMGS.modalNozzle5} width="100%" />
+              <Box
+                position={POSITION_ABSOLUTE}
+                bottom="0.3rem"
+                backgroundColor={C_LIGHT_GRAY}
+              >
                 <Text
                   as={'h6'}
+                  margin={SPACING_2}
+                  padding={SPACING_1}
                   fontWeight={FONT_WEIGHT_SEMIBOLD}
-                  color={'#4a4a4a'}
-                  paddingTop={SPACING_1}
-                  paddingLeft={SPACING_1}
-                  marginTop={'11.18rem'}
-                  marginLeft={SPACING_2}
+                  color={C_DARK_GRAY}
                 >
                   {t('labware_step_detail_modal_nozzle_or_tip_image_3_text')}
                 </Text>


### PR DESCRIPTION
# Overview

This PR serves as its own ticket. Pipette centering images were not loading in the beta branch so this PR cleans up a bunch of styling and loads the images correctly.

# Changelog

- refactor(app): Load pipette centering images and fix styling

# Review requests

I recommend grabbing this branch from the  builds channel since the problem didn't show itself in dev. 
start LPC
click to `how to tell if pipette is centered` link to open modal
- [ ] images and text should all render

# Risk assessment

Low mainly image and css cleanup in app
