### PR TITLE
refactor(app): display offsets for labware on top of modules

### DIFF
--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/LabwareInfoOverlay.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/LabwareInfoOverlay.tsx
@@ -19,7 +19,7 @@ import {
   FONT_SIZE_CAPTION,
 } from '@opentrons/components'
 import { useCurrentProtocolRun } from '../../../ProtocolUpload/hooks'
-import { getLabwareLocation } from '../../utils/getLabwareLocation'
+import { getLabwareOffsetLocation } from '../../utils/getLabwareOffsetLocation'
 import { useProtocolDetails } from '../../../RunDetails/hooks'
 import { getLabwareDefinitionUri } from '../../utils/getLabwareDefinitionUri'
 
@@ -53,9 +53,10 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
     labwareId,
     protocolData?.labware
   )
-  const labwareLocation = getLabwareLocation(
+  const labwareLocation = getLabwareOffsetLocation(
     labwareId,
-    protocolData?.commands ?? []
+    protocolData?.commands ?? [],
+    protocolData.modules
   )
 
   const labwareOffsets = runRecord?.data.labwareOffsets ?? []


### PR DESCRIPTION
# Overview

This PR displays offsets for labware on top of modules in the labware setup screen. Closes #9149 

# Changelog

- Display offsets for labware on top of modules
 
# Review requests
Add labware offsets (non identity) to a labware on top of a module
Offsets should show up in the deckmap
# Risk assessment
Low
