### PR TITLE
refactor(app): limit network requests to command details endpoints

### DIFF
--- a/app/src/organisms/RunDetails/CommandItem.tsx
+++ b/app/src/organisms/RunDetails/CommandItem.tsx
@@ -33,7 +33,11 @@ import {
 } from '@opentrons/api-client'
 import { useCommandQuery } from '@opentrons/react-api-client'
 import { useCurrentRunId } from '../ProtocolUpload/hooks/useCurrentRunId'
-import type { RunStatus, RunCommandSummary } from '@opentrons/api-client'
+import type {
+  CommandDetail,
+  RunStatus,
+  RunCommandSummary,
+} from '@opentrons/api-client'
 
 import type {
   Command,
@@ -43,6 +47,7 @@ import type {
 export interface CommandItemProps {
   commandOrSummary: Command | RunCommandSummary
   runStatus?: RunStatus
+  commandDetail?: CommandDetail
 }
 
 const WRAPPER_STYLE_BY_STATUS: {

--- a/app/src/organisms/RunDetails/CommandItem.tsx
+++ b/app/src/organisms/RunDetails/CommandItem.tsx
@@ -146,7 +146,7 @@ export function CommandItem(props: CommandItemProps): JSX.Element | null {
           />
         ) : null}
         <CommandText
-          commandOrSummary={commandDetails?.data ?? commandOrSummary}
+          commandDetailsOrSummary={commandDetails?.data ?? commandOrSummary}
         />
       </Flex>
     </Flex>

--- a/app/src/organisms/RunDetails/CommandItem.tsx
+++ b/app/src/organisms/RunDetails/CommandItem.tsx
@@ -31,8 +31,6 @@ import {
   RUN_STATUS_PAUSE_REQUESTED,
   RUN_STATUS_PAUSED,
 } from '@opentrons/api-client'
-import { useCommandQuery } from '@opentrons/react-api-client'
-import { useCurrentRunId } from '../ProtocolUpload/hooks/useCurrentRunId'
 import type {
   CommandDetail,
   RunStatus,
@@ -47,7 +45,7 @@ import type {
 export interface CommandItemProps {
   commandOrSummary: Command | RunCommandSummary
   runStatus?: RunStatus
-  commandDetail?: CommandDetail
+  commandDetails?: CommandDetail
 }
 
 const WRAPPER_STYLE_BY_STATUS: {
@@ -68,17 +66,12 @@ const WRAPPER_STYLE_BY_STATUS: {
   },
 }
 export function CommandItem(props: CommandItemProps): JSX.Element | null {
-  const { commandOrSummary, runStatus } = props
+  const { commandOrSummary, commandDetails, runStatus } = props
   const { t } = useTranslation('run_details')
   const commandStatus =
     runStatus !== RUN_STATUS_IDLE && commandOrSummary.status != null
       ? commandOrSummary.status
       : 'queued'
-  const currentRunId = useCurrentRunId()
-  const {
-    data: commandDetails,
-    refetch: refetchCommandDetails,
-  } = useCommandQuery(currentRunId, commandOrSummary.id)
 
   let isComment = false
   if (
@@ -95,10 +88,6 @@ export function CommandItem(props: CommandItemProps): JSX.Element | null {
   }
 
   const isPause = commandOrSummary.commandType === 'pause'
-
-  React.useEffect(() => {
-    refetchCommandDetails()
-  }, [commandStatus])
 
   const WRAPPER_STYLE = css`
     font-size: ${FONT_SIZE_BODY_1};

--- a/app/src/organisms/RunDetails/CommandList.tsx
+++ b/app/src/organisms/RunDetails/CommandList.tsx
@@ -22,7 +22,7 @@ import {
   Box,
 } from '@opentrons/components'
 import { useRunStatus } from '../RunTimeControl/hooks'
-import { useProtocolDetails } from './hooks'
+import { useCommandDetailsById, useProtocolDetails } from './hooks'
 import { useCurrentProtocolRun } from '../ProtocolUpload/hooks'
 import { ProtocolSetupInfo } from './ProtocolSetupInfo'
 import { CommandItem } from './CommandItem'
@@ -43,6 +43,7 @@ export function CommandList(): JSX.Element | null {
     .protocolData
   const { runRecord } = useCurrentProtocolRun()
   const runStatus = useRunStatus()
+  const commandDetailsById = useCommandDetailsById()
   const runDataCommands = runRecord?.data.commands
   const firstPlayTimestamp = runRecord?.data.actions.find(
     action => action.actionType === 'play'
@@ -255,6 +256,7 @@ export function CommandList(): JSX.Element | null {
                     <CommandItem
                       commandOrSummary={command}
                       runStatus={runStatus}
+                      commandDetail={commandDetailsById[command.id]}
                     />
                   </Flex>
                 </Flex>

--- a/app/src/organisms/RunDetails/CommandList.tsx
+++ b/app/src/organisms/RunDetails/CommandList.tsx
@@ -256,7 +256,7 @@ export function CommandList(): JSX.Element | null {
                     <CommandItem
                       commandOrSummary={command}
                       runStatus={runStatus}
-                      commandDetail={commandDetailsById[command.id]}
+                      commandDetails={commandDetailsById[command.id]}
                     />
                   </Flex>
                 </Flex>

--- a/app/src/organisms/RunDetails/CommandText.tsx
+++ b/app/src/organisms/RunDetails/CommandText.tsx
@@ -39,7 +39,9 @@ export function CommandText(props: Props): JSX.Element | null {
             >
               {t('comment')}
             </Flex>
-            {commandDetailsOrSummary != null ? commandDetailsOrSummary.result : null}
+            {commandDetailsOrSummary != null
+              ? commandDetailsOrSummary.result
+              : null}
           </>
         )
         break
@@ -75,13 +77,16 @@ export function CommandText(props: Props): JSX.Element | null {
       }
       case 'pause': {
         messageNode =
-          commandDetailsOrSummary.params?.message ?? commandDetailsOrSummary.commandType
+          commandDetailsOrSummary.params?.message ??
+          commandDetailsOrSummary.commandType
         break
       }
       case 'loadLabware':
       case 'loadPipette':
       case 'loadModule': {
-        messageNode = <ProtocolSetupInfo setupCommand={commandDetailsOrSummary} />
+        messageNode = (
+          <ProtocolSetupInfo setupCommand={commandDetailsOrSummary} />
+        )
         break
       }
       case 'custom': {

--- a/app/src/organisms/RunDetails/CommandText.tsx
+++ b/app/src/organisms/RunDetails/CommandText.tsx
@@ -16,18 +16,18 @@ import { getLabwareLocation } from '../ProtocolSetup/utils/getLabwareLocation'
 import { useLabwareRenderInfoById } from '../ProtocolSetup/hooks'
 
 interface Props {
-  commandOrSummary: Command | RunCommandSummary
+  commandDetailsOrSummary: Command | RunCommandSummary
 }
 export function CommandText(props: Props): JSX.Element | null {
-  const { commandOrSummary } = props
+  const { commandDetailsOrSummary } = props
   const { t } = useTranslation('run_details')
   const { protocolData } = useProtocolDetails()
   const labwareRenderInfoById = useLabwareRenderInfoById()
 
   let messageNode = null
-  if ('params' in commandOrSummary) {
+  if ('params' in commandDetailsOrSummary) {
     // params will not exist on command summaries
-    switch (commandOrSummary.commandType) {
+    switch (commandDetailsOrSummary.commandType) {
       case 'delay': {
         // TODO: IMMEDIATELY address displaying real comments
         messageNode = (
@@ -39,7 +39,7 @@ export function CommandText(props: Props): JSX.Element | null {
             >
               {t('comment')}
             </Flex>
-            {commandOrSummary != null ? commandOrSummary.result : null}
+            {commandDetailsOrSummary != null ? commandDetailsOrSummary.result : null}
           </>
         )
         break
@@ -50,7 +50,7 @@ export function CommandText(props: Props): JSX.Element | null {
         if (protocolData == null) {
           return null
         }
-        const { wellName, labwareId } = commandOrSummary.params
+        const { wellName, labwareId } = commandDetailsOrSummary.params
         const labwareLocation = getLabwareLocation(
           labwareId,
           protocolData.commands
@@ -75,29 +75,29 @@ export function CommandText(props: Props): JSX.Element | null {
       }
       case 'pause': {
         messageNode =
-          commandOrSummary.params?.message ?? commandOrSummary.commandType
+          commandDetailsOrSummary.params?.message ?? commandDetailsOrSummary.commandType
         break
       }
       case 'loadLabware':
       case 'loadPipette':
       case 'loadModule': {
-        messageNode = <ProtocolSetupInfo setupCommand={commandOrSummary} />
+        messageNode = <ProtocolSetupInfo setupCommand={commandDetailsOrSummary} />
         break
       }
       case 'custom': {
         messageNode =
-          commandOrSummary.params?.legacyCommandText ??
-          commandOrSummary.commandType
+          commandDetailsOrSummary.params?.legacyCommandText ??
+          commandDetailsOrSummary.commandType
         break
       }
       default: {
-        messageNode = commandOrSummary.commandType
+        messageNode = commandDetailsOrSummary.commandType
         break
       }
     }
   } else {
     // this must be a run command summary
-    messageNode = commandOrSummary.commandType
+    messageNode = commandDetailsOrSummary.commandType
   }
 
   return (

--- a/app/src/organisms/RunDetails/__tests__/CommandList.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/CommandList.test.tsx
@@ -4,7 +4,7 @@ import { fireEvent } from '@testing-library/dom'
 import { i18n } from '../../../i18n'
 import { renderWithProviders } from '@opentrons/components'
 import { AlertItem } from '@opentrons/components/src/alerts'
-import { useProtocolDetails } from '../hooks'
+import { useCommandDetailsById, useProtocolDetails } from '../hooks'
 import { useCurrentProtocolRun } from '../../ProtocolUpload/hooks'
 import { useRunStatus } from '../../RunTimeControl/hooks'
 import { ProtocolSetupInfo } from '../ProtocolSetupInfo'
@@ -21,6 +21,9 @@ jest.mock('../../RunTimeControl/hooks')
 jest.mock('../../ProtocolUpload/hooks')
 jest.mock('@opentrons/components/src/alerts')
 
+const mockUseCommandDetailsById = useCommandDetailsById as jest.MockedFunction<
+  typeof useCommandDetailsById
+>
 const mockUseProtocolDetails = useProtocolDetails as jest.MockedFunction<
   typeof useProtocolDetails
 >
@@ -51,6 +54,7 @@ describe('CommandList', () => {
       protocolData: _fixtureAnalysis,
       displayName: 'mock display name',
     })
+    mockUseCommandDetailsById.mockReturnValue({})
     mockUseCurrentProtocolRun.mockReturnValue({
       createProtocolRun: () => {},
       protocolRecord: null,

--- a/app/src/organisms/RunDetails/__tests__/CommandText.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/CommandText.test.tsx
@@ -78,7 +78,7 @@ describe('CommandText', () => {
   })
   it('renders correct command text for custom legacy commands', () => {
     const { getByText } = render({
-      commandOrSummary: {
+      commandDetailsOrSummary: {
         ...MOCK_COMMAND_DETAILS,
         params: {
           legacyCommandText: 'legacy command text',
@@ -89,7 +89,7 @@ describe('CommandText', () => {
   })
   it('renders correct command text for pause commands', () => {
     const { getByText } = render({
-      commandOrSummary: {
+      commandDetailsOrSummary: {
         ...MOCK_PAUSE_COMMAND,
       } as Command,
     })
@@ -97,7 +97,7 @@ describe('CommandText', () => {
   })
   it('renders correct command text for load commands', () => {
     const { getByText } = render({
-      commandOrSummary: {
+      commandDetailsOrSummary: {
         ...MOCK_LOAD_COMMAND,
       } as Command,
     })
@@ -119,7 +119,7 @@ describe('CommandText', () => {
       },
     } as any)
     const { getByText } = render({
-      commandOrSummary: {
+      commandDetailsOrSummary: {
         ...MOCK_COMMAND_DETAILS,
         commandType: 'pickUpTip',
         params: {

--- a/app/src/organisms/RunDetails/__tests__/hooks.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/hooks.test.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react'
+import { QueryClient, QueryClientProvider } from 'react-query'
+import { when, resetAllWhenMocks } from 'jest-when'
+import { useHost, useRunQuery } from '@opentrons/react-api-client'
+import { useCurrentRunId } from '../../ProtocolUpload/hooks/useCurrentRunId'
+import { renderHook } from '@testing-library/react-hooks'
+import { useCommandDetailsById, REFETCH_INTERVAL } from '../hooks'
+
+jest.mock('@opentrons/react-api-client')
+jest.mock('../../ProtocolUpload/hooks/useCurrentRunId')
+
+const mockUseHost = useHost as jest.MockedFunction<typeof useHost>
+const mockUseCurrentRunId = useCurrentRunId as jest.MockedFunction<
+  typeof useCurrentRunId
+>
+const mockUseRunQuery = useRunQuery as jest.MockedFunction<typeof useRunQuery>
+
+const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+  <QueryClientProvider client={new QueryClient()}>
+    {children}
+  </QueryClientProvider>
+)
+
+describe('useCommandDetailsById', () => {
+  let MOCK_RUN_ID: string
+  beforeEach(() => {
+    MOCK_RUN_ID = 'mock_run_id'
+    when(mockUseHost)
+      .calledWith()
+      .mockReturnValue({} as any)
+    when(mockUseCurrentRunId).calledWith().mockReturnValue(MOCK_RUN_ID)
+    when(mockUseRunQuery)
+      .calledWith(MOCK_RUN_ID, { refetchInterval: REFETCH_INTERVAL })
+      .mockReturnValue({ data: null } as any)
+  })
+  afterEach(() => {
+    resetAllWhenMocks()
+    jest.restoreAllMocks()
+  })
+  it('should return an empty object when there is no host', () => {
+    const { result } = renderHook(useCommandDetailsById, { wrapper })
+    expect(result.current).toEqual({})
+  })
+  it('should return an empty object when there is no run record', () => {})
+  it('should return an empty object when there is no current run id', () => {})
+})

--- a/app/src/organisms/RunDetails/__tests__/hooks.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/hooks.test.tsx
@@ -7,6 +7,7 @@ import { renderHook } from '@testing-library/react-hooks'
 import { useCommandDetailsById, REFETCH_INTERVAL } from '../hooks'
 
 jest.mock('@opentrons/react-api-client')
+jest.mock('@opentrons/api-client')
 jest.mock('../../ProtocolUpload/hooks/useCurrentRunId')
 
 const mockUseHost = useHost as jest.MockedFunction<typeof useHost>
@@ -23,24 +24,61 @@ const wrapper: React.FunctionComponent<{}> = ({ children }) => (
 
 describe('useCommandDetailsById', () => {
   let MOCK_RUN_ID: string
+  let MOCK_HOST: any
   beforeEach(() => {
     MOCK_RUN_ID = 'mock_run_id'
-    when(mockUseHost)
-      .calledWith()
-      .mockReturnValue({} as any)
+    MOCK_HOST = {}
+    when(mockUseHost).calledWith().mockReturnValue(MOCK_HOST)
     when(mockUseCurrentRunId).calledWith().mockReturnValue(MOCK_RUN_ID)
     when(mockUseRunQuery)
       .calledWith(MOCK_RUN_ID, { refetchInterval: REFETCH_INTERVAL })
-      .mockReturnValue({ data: null } as any)
+      .mockReturnValue({ data: {} } as any)
   })
   afterEach(() => {
     resetAllWhenMocks()
     jest.restoreAllMocks()
   })
   it('should return an empty object when there is no host', () => {
+    when(mockUseHost).calledWith().mockReturnValue(null)
     const { result } = renderHook(useCommandDetailsById, { wrapper })
     expect(result.current).toEqual({})
   })
-  it('should return an empty object when there is no run record', () => {})
-  it('should return an empty object when there is no current run id', () => {})
+  it('should return an empty object when there is no run record', () => {
+    when(mockUseRunQuery)
+      .calledWith(MOCK_RUN_ID, { refetchInterval: REFETCH_INTERVAL })
+      .mockReturnValue({ data: null } as any)
+    const { result } = renderHook(useCommandDetailsById, { wrapper })
+    expect(result.current).toEqual({})
+  })
+  it('should return an empty object when there is no current run id', () => {
+    when(mockUseCurrentRunId).calledWith().mockReturnValue(null)
+    when(mockUseRunQuery)
+      .calledWith(null, { refetchInterval: REFETCH_INTERVAL })
+      .mockReturnValue({ data: {} } as any)
+    const { result } = renderHook(useCommandDetailsById, { wrapper })
+    expect(result.current).toEqual({})
+  })
+  // TODO: Figure out why the test below is not working. renderHook seems to unmount the hook before internal state updates and I'm not sure why
+  it.todo('should fetch the command details of new commands') //, async () => {
+  // when(mockUseRunQuery)
+  //   .calledWith(MOCK_RUN_ID, { refetchInterval: REFETCH_INTERVAL })
+  //   .mockReturnValue({
+  //     data: {
+  //       data: { commands: [{ id: 'COMMAND_1' }, { id: 'COMMAND_2' }] },
+  //     },
+  //   } as any)
+  // when(mockGetCommand)
+  //   .calledWith(MOCK_HOST, MOCK_RUN_ID, 'COMMAND_1')
+  //   .mockResolvedValue({ data: 'command 1 data!' } as any)
+  // when(mockGetCommand)
+  //   .calledWith(MOCK_HOST, MOCK_RUN_ID, 'COMMAND_2')
+  //   .mockResolvedValue({ data: 'command 2 data!' } as any)
+  // const { result, waitFor } = renderHook(useCommandDetailsById, { wrapper })
+  // await waitFor(() => {
+  //   expect(result.current).toEqual({
+  //     COMMAND_1: 'command 1 data!',
+  //     COMMAND_2: 'command 2 data!',
+  //   })
+  // })
+  //   })
 })

--- a/app/src/organisms/RunDetails/hooks.ts
+++ b/app/src/organisms/RunDetails/hooks.ts
@@ -1,9 +1,13 @@
 import { useEffect, useRef, useState } from 'react'
 import last from 'lodash/last'
+import { schemaV6Adapter } from '@opentrons/shared-data'
+import { useHost, useRunQuery } from '@opentrons/react-api-client'
+import { getCommand } from '@opentrons/api-client'
 import { useCurrentProtocolRun } from '../ProtocolUpload/hooks'
-import { schemaV6Adapter, ProtocolFile } from '@opentrons/shared-data'
 import { formatInterval } from '../RunTimeControl/utils'
-
+import { useCurrentRunId } from '../ProtocolUpload/hooks/useCurrentRunId'
+import type { CommandDetail } from '@opentrons/api-client'
+import type { ProtocolFile } from '@opentrons/shared-data'
 interface ProtocolDetails {
   displayName: string | null
   protocolData: ProtocolFile<{}> | null
@@ -81,4 +85,65 @@ export function useFormatRunTimestamp(): (timestamp: string) => string | null {
     if (firstPlayAction == null) return null // run is unstarted
     return formatInterval(firstPlayAction.createdAt, timestamp)
   }
+}
+const REFETCH_INTERVAL = 1000
+interface CommandDetailsById {
+  [commandId: string]: CommandDetail
+}
+export function useCommandDetailsById(): CommandDetailsById {
+  const [
+    commandDetailsById,
+    setCommandDetailsById,
+  ] = useState<CommandDetailsById>({})
+  const host = useHost()
+  const currentRunId = useCurrentRunId()
+  const { data: runRecord } = useRunQuery(currentRunId, {
+    refetchInterval: REFETCH_INTERVAL,
+  })
+
+  if (host == null) {
+    console.error('need host to fetch command details')
+    return {}
+  }
+  if (runRecord == null) {
+    console.error('need run record to fetch command details')
+    return {}
+  }
+  if (currentRunId == null) {
+    console.error('need current run id to fetch command details')
+    return {}
+  }
+
+  const runDataCommands = runRecord.data.commands
+  const commandIdsToFetch = runDataCommands.reduce<Set<string>>(
+    (commandIds, command) => {
+      if (!(command.id in commandDetailsById)) {
+        // fetch if we have not seen this command before
+        return commandIds.add(command.id)
+      } else if (
+        // fetch if the status has changed, so we can get new startedAt and completedAt values
+        command.id in commandDetailsById &&
+        commandDetailsById[command.id].data.status !== command.status
+      ) {
+        return commandIds.add(command.id)
+      }
+      return commandIds
+    },
+    new Set()
+  )
+  // consider chunking network requests the event that there are a large amount of network requests to make
+  commandIdsToFetch.forEach(commandId => {
+    getCommand(host, currentRunId, commandId)
+      .then(response =>
+        setCommandDetailsById(prevCommandDetailsById => ({
+          ...prevCommandDetailsById,
+          [commandId]: response.data,
+        }))
+      )
+      .catch((e: Error) => {
+        console.error(`error fetching command details: ${e.message}`)
+      })
+  })
+
+  return commandDetailsById
 }

--- a/app/src/organisms/RunDetails/hooks.ts
+++ b/app/src/organisms/RunDetails/hooks.ts
@@ -86,7 +86,7 @@ export function useFormatRunTimestamp(): (timestamp: string) => string | null {
     return formatInterval(firstPlayAction.createdAt, timestamp)
   }
 }
-const REFETCH_INTERVAL = 1000
+export const REFETCH_INTERVAL = 1000
 interface CommandDetailsById {
   [commandId: string]: CommandDetail
 }

--- a/app/src/organisms/RunDetails/hooks.ts
+++ b/app/src/organisms/RunDetails/hooks.ts
@@ -131,7 +131,7 @@ export function useCommandDetailsById(): CommandDetailsById {
     },
     new Set()
   )
-  // consider chunking network requests the event that there are a large amount of network requests to make
+  // consider chunking network requests in the event that there are a large amount of network requests to make
   commandIdsToFetch.forEach(commandId => {
     getCommand(host, currentRunId, commandId)
       .then(response =>


### PR DESCRIPTION
# Overview

closes #9147
# Changelog

- Limit network requests to command details endpoints

# Review requests
Upload a protocol with a lot of steps, navigate to the run tab and investigate the network tab in your dev tools. There should only be a handful of network requests that get run at a time.

# Risk assessment
Low
