### PR TITLE
fix(app): fix LPC summary screen offset flickering and offsets not "sticking"

### DIFF
--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
@@ -37,7 +37,9 @@ export const SummaryScreen = (props: {
   const introInfo = useIntroInfo()
   const { protocolData } = useProtocolDetails()
   useLabwareOffsets(savePositionCommandData, protocolData as ProtocolFile<{}>)
-    .then(offsets => setLabwareOffsets(offsets))
+    .then(offsets => {
+      labwareOffsets.length === 0 && setLabwareOffsets(offsets)
+    })
     .catch((e: Error) =>
       console.error(`error getting labware offsetsL ${e.message}`)
     )

--- a/app/src/organisms/ProtocolUpload/hooks/useOffsetData.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useOffsetData.ts
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import reduce from 'lodash/reduce'
 import { IDENTITY_VECTOR } from '@opentrons/shared-data'
 import { useHost } from '@opentrons/react-api-client'
@@ -13,6 +14,14 @@ export function useOffsetDataByLabwareId(
 ): Promise<LabwareOffsetData> {
   const host = useHost()
   const currentRunId = useCurrentRunId()
+  const [labwareOffsetDataPromise, setLabwareOffsetDataPromise] = useState<
+    Promise<LabwareOffsetData>
+  >(() => new Promise(() => {}))
+  const [
+    isLabwareOffsetComputed,
+    setIsLabwareOffsetComputed,
+  ] = useState<boolean>(false)
+
   // make sure we have exactly two save position command ids per labware id
   Object.entries(savePositionCommandData).forEach(([labwareId, commandIds]) => {
     if (commandIds.length !== 2) {
@@ -22,53 +31,58 @@ export function useOffsetDataByLabwareId(
     }
   })
 
-  return reduce<SavePositionCommandData, Promise<LabwareOffsetData>>(
-    savePositionCommandData,
-    (acc, commandIds, labwareId): Promise<LabwareOffsetData> => {
-      const firstPosition: Promise<VectorOffset> = getCommand(
-        host as HostConfig,
-        currentRunId as string,
-        commandIds[0]
-      ).then(result => {
-        return result.data.data.result.position
-      })
-
-      const secondPosition: Promise<VectorOffset> = getCommand(
-        host as HostConfig,
-        currentRunId as string,
-        commandIds[1]
-      ).then(result => {
-        return result.data.data.result.position
-      })
-
-      const labwareOffset: Promise<LabwareOffsetData> = Promise.all([
-        firstPosition,
-        secondPosition,
-      ])
-        .then(positions => {
-          const p1 = positions[0]
-          const p2 = positions[1]
-          const { x: firstX, y: firstY, z: firstZ } = p1
-          const { x: secondX, y: secondY, z: secondZ } = p2
-          return {
-            [labwareId]: {
-              x: secondX - firstX,
-              y: secondY - firstY,
-              z: secondZ - firstZ,
-            },
-          }
-        })
-        .catch((e: Error) => {
-          console.error(`error calculating labware offset: ${e.message}`)
-          return { [labwareId]: IDENTITY_VECTOR }
+  if (!isLabwareOffsetComputed) {
+    const offsets = reduce<SavePositionCommandData, Promise<LabwareOffsetData>>(
+      savePositionCommandData,
+      (acc, commandIds, labwareId): Promise<LabwareOffsetData> => {
+        const firstPosition: Promise<VectorOffset> = getCommand(
+          host as HostConfig,
+          currentRunId as string,
+          commandIds[0]
+        ).then(result => {
+          return result.data.data.result.position
         })
 
-      return acc.then(offsetData => {
-        return labwareOffset.then(labwareOffset => {
-          return { ...offsetData, ...labwareOffset }
+        const secondPosition: Promise<VectorOffset> = getCommand(
+          host as HostConfig,
+          currentRunId as string,
+          commandIds[1]
+        ).then(result => {
+          return result.data.data.result.position
         })
-      })
-    },
-    Promise.resolve({})
-  )
+
+        const labwareOffset: Promise<LabwareOffsetData> = Promise.all([
+          firstPosition,
+          secondPosition,
+        ])
+          .then(positions => {
+            const p1 = positions[0]
+            const p2 = positions[1]
+            const { x: firstX, y: firstY, z: firstZ } = p1
+            const { x: secondX, y: secondY, z: secondZ } = p2
+            return {
+              [labwareId]: {
+                x: secondX - firstX,
+                y: secondY - firstY,
+                z: secondZ - firstZ,
+              },
+            }
+          })
+          .catch((e: Error) => {
+            console.error(`error calculating labware offset: ${e.message}`)
+            return { [labwareId]: IDENTITY_VECTOR }
+          })
+
+        return acc.then(offsetData => {
+          return labwareOffset.then(labwareOffset => {
+            return { ...offsetData, ...labwareOffset }
+          })
+        })
+      },
+      Promise.resolve({})
+    )
+    setLabwareOffsetDataPromise(offsets)
+    setIsLabwareOffsetComputed(true)
+  }
+  return labwareOffsetDataPromise
 }


### PR DESCRIPTION
# Overview

This PR fixes the LPC summary screen offset flickering that was occurring on non dev builds. It also should fix the issue where it would take a long time for labware offsets to show up on the labware setup deckmap. This is because we were spamming the robot server with a bunch of requests to get `savePosition` command info, when in reality we only need to do this once. 

closes #9051 closes #9134

# Changelog

- Fix LPC summary screen offset flickering
- Fix offsets not being applied at the end of LPC


# Review requests
Run through LPC, on the summary screen offsets should no longer flicker, and you should quickly see the offsets applied on the deckmap after you confirm them.

# Risk assessment
Low