### PR TITLE
perf(protocol-engine): avoid iterating all commands for every state update

### DIFF
--- a/api/src/opentrons/protocol_engine/actions/actions.py
+++ b/api/src/opentrons/protocol_engine/actions/actions.py
@@ -90,7 +90,11 @@ class UpdateCommandAction:
 
 @dataclass(frozen=True)
 class FailCommandAction:
-    """Mark a given command as failed."""
+    """Mark a given command as failed.
+
+    The given command and all currently queued commands will be marked
+    as failed due to the given error.
+    """
 
     # TODO(mc, 2021-11-12): we'll likely need to add the command params
     # to this payload for state reaction purposes

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -147,9 +147,7 @@ class ProtocolEngine:
         await self._hardware_api.stop(home_after=False)
         self._action_dispatcher.dispatch(HardwareStoppedAction())
 
-    # TODO(mc, 2021-12-27): if called, this causes state updates to become
-    # O(n^2) on command list length. This method is only "used" by JSON v6
-    # execution so will need refactoring to bring that into prod
+    # TODO(mc, 2021-12-27): commands.get_all_complete not yet implemented
     async def wait_until_complete(self) -> None:
         """Wait until there are no more commands to execute.
 

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -128,7 +128,6 @@ class ProtocolEngine:
         """
         command = self.add_command(request)
 
-        # TODO(mc, 2021-12-28): this logic isn't correct, see TODO in CommandView
         await self._state_store.wait_for(
             condition=self._state_store.commands.get_is_complete,
             command_id=command.id,

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -128,6 +128,7 @@ class ProtocolEngine:
         """
         command = self.add_command(request)
 
+        # TODO(mc, 2021-12-28): this logic isn't correct, see TODO in CommandView
         await self._state_store.wait_for(
             condition=self._state_store.commands.get_is_complete,
             command_id=command.id,

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -146,6 +146,9 @@ class ProtocolEngine:
         await self._hardware_api.stop(home_after=False)
         self._action_dispatcher.dispatch(HardwareStoppedAction())
 
+    # TODO(mc, 2021-12-27): if called, this causes state updates to become
+    # O(n^2) on command list length. This method is only "used" by JSON v6
+    # execution so will need refactoring to bring that into prod
     async def wait_until_complete(self) -> None:
         """Wait until there are no more commands to execute.
 

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -125,6 +125,11 @@ class CommandStore(HasState[CommandState], HandlesActions):
             self._state.commands_by_id[command.id] = command
             self._state.queued_command_ids.pop(command.id, None)
 
+            if command.status == CommandStatus.RUNNING:
+                self._state.running_command_id = command.id
+            elif self._state.running_command_id == command.id:
+                self._state.running_command_id = None
+
         elif isinstance(action, FailCommandAction):
             error_occurrence = ErrorOccurrence.construct(
                 id=action.error_id,
@@ -147,6 +152,9 @@ class CommandStore(HasState[CommandState], HandlesActions):
                         "status": CommandStatus.FAILED,
                     }
                 )
+
+            if self._state.running_command_id == command_id:
+                self._state.running_command_id = None
 
             self._state.errors_by_id[action.error_id] = error_occurrence
             self._state.queued_command_ids.clear()

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -42,7 +42,7 @@ class CommandState:
         should_report_result: Whether the engine should report a success or
             failure status once stopped. If unset, the engine will simply
             report "stopped." Once set, this flag cannot be unset.
-        queued_command_ids: The IDs commands with execution pending in FIFO order.
+        queued_command_ids: The IDs of queued commands in FIFO order.
         commands_by_id: All command resources, in insertion order, mapped
             by their unique IDs.
         errors_by_id: All error occurrences, mapped by their unique IDs.
@@ -210,7 +210,7 @@ class CommandView(HasState[CommandState]):
         if not self._state.is_running_queue:
             return None
 
-        if len(self._state.queued_command_ids) >= 1:
+        if len(self._state.queued_command_ids) > 0:
             return self._state.queued_command_ids[0]
 
         return None

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -298,7 +298,6 @@ class CommandView(HasState[CommandState]):
             action_desc = "play" if isinstance(action, PlayAction) else "pause"
             raise ProtocolEngineStoppedError(f"Cannot {action_desc} a stopped engine.")
 
-    # TODO(mc, 2021-12-28): reject adding commands to a stopped engine
     def get_status(self) -> EngineStatus:
         """Get the current execution status of the engine."""
         if self._state.should_report_result:

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -156,7 +156,7 @@ class CommandStore(HasState[CommandState], HandlesActions):
                     }
                 )
 
-            if self._state.running_command_id == command_id:
+            if self._state.running_command_id == action.command_id:
                 self._state.running_command_id = None
 
             self._state.errors_by_id[action.error_id] = error_occurrence

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import re
 from collections import defaultdict
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Dict, List, Optional, Sequence
 
 from opentrons_shared_data.deck.dev_types import DeckDefinitionV2, SlotDefV2
@@ -38,7 +38,7 @@ from .abstract_store import HasState, HandlesActions
 _TRASH_LOCATION = DeckSlotLocation(slotName=DeckSlotName.FIXED_TRASH)
 
 
-@dataclass(frozen=True)
+@dataclass
 class LabwareState:
     """State of all loaded labware resources."""
 
@@ -117,10 +117,7 @@ class LabwareStore(HasState[LabwareState], HandlesActions):
                 load_name=action.definition.parameters.loadName,
                 version=action.definition.version,
             )
-            definitions_by_uri = self._state.definitions_by_uri.copy()
-            definitions_by_uri[uri] = action.definition
-
-            self._state = replace(self._state, definitions_by_uri=definitions_by_uri)
+            self._state.definitions_by_uri[uri] = action.definition
 
     def _handle_command(self, command: Command) -> None:
         """Modify state in reaction to a command."""
@@ -136,8 +133,7 @@ class LabwareStore(HasState[LabwareState], HandlesActions):
                 version=command.result.definition.version,
             )
 
-            new_labware_by_id = self._state.labware_by_id.copy()
-            new_labware_by_id[labware_id] = LoadedLabware(
+            self._state.labware_by_id[labware_id] = LoadedLabware(
                 id=labware_id,
                 location=command.params.location,
                 loadName=command.result.definition.parameters.loadName,
@@ -145,14 +141,7 @@ class LabwareStore(HasState[LabwareState], HandlesActions):
                 offsetId=command.result.offsetId,
             )
 
-            new_definitions_by_uri = self._state.definitions_by_uri.copy()
-            new_definitions_by_uri[definition_uri] = command.result.definition
-
-            self._state = replace(
-                self._state,
-                labware_by_id=new_labware_by_id,
-                definitions_by_uri=new_definitions_by_uri,
-            )
+            self._state.definitions_by_uri[definition_uri] = command.result.definition
 
     def _add_labware_offset(self, labware_offset: LabwareOffset) -> None:
         """Add a new labware offset to state.
@@ -163,9 +152,7 @@ class LabwareStore(HasState[LabwareState], HandlesActions):
         """
         assert labware_offset.id not in self._state.labware_offsets_by_id
 
-        new_labware_offsets = self._state.labware_offsets_by_id.copy()
-        new_labware_offsets[labware_offset.id] = labware_offset
-        self._state = replace(self._state, labware_offsets_by_id=new_labware_offsets)
+        self._state.labware_offsets_by_id[labware_offset.id] = labware_offset
 
 
 class LabwareView(HasState[LabwareState]):

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -1,5 +1,5 @@
 """Basic modules data state and store."""
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Dict, List, Optional, NamedTuple
 from numpy import array, dot
 
@@ -43,7 +43,7 @@ THERMOCYCLER_SLOT_TRANSITS_TO_DODGE = [
 ]
 
 
-@dataclass(frozen=True)
+@dataclass
 class ModuleState:
     """Basic module data state and getter methods."""
 
@@ -71,8 +71,8 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
     def _handle_command(self, command: Command) -> None:
         if isinstance(command.result, LoadModuleResult):
             module_id = command.result.moduleId
-            new_modules_by_id = self._state.modules_by_id.copy()
-            new_modules_by_id[module_id] = LoadedModule(
+
+            self._state.modules_by_id[module_id] = LoadedModule(
                 id=module_id,
                 model=command.params.model,
                 location=command.params.location,
@@ -80,14 +80,9 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
                 definition=command.result.definition,
             )
 
-            new_definition_by_model = self._state.definition_by_model.copy()
-            new_definition_by_model[command.params.model] = command.result.definition
-
-            self._state = replace(
-                self._state,
-                modules_by_id=new_modules_by_id,
-                definition_by_model=new_definition_by_model,
-            )
+            self._state.definition_by_model[
+                command.params.model
+            ] = command.result.definition
 
 
 class ModuleView(HasState[ModuleState]):

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -54,6 +54,8 @@ class ModuleState:
     definition_by_model: Dict[ModuleModel, ModuleDefinition]
 
 
+# TODO(mc, 2021-12-28): ModuleStore is entirely untested. See
+# https://github.com/Opentrons/opentrons/issues/8914
 class ModuleStore(HasState[ModuleState], HandlesActions):
     """Module state container."""
 

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -1,6 +1,6 @@
 """Basic pipette data state and store."""
 from __future__ import annotations
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Dict, List, Mapping, Optional
 
 from opentrons.hardware_control.dev_types import PipetteDict
@@ -40,7 +40,7 @@ class CurrentWell:
     well_name: str
 
 
-@dataclass(frozen=True)
+@dataclass
 class PipetteState:
     """Basic pipette data state and getter methods."""
 
@@ -78,61 +78,38 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                 DispenseResult,
             ),
         ):
-            self._state = replace(
-                self._state,
-                current_well=CurrentWell(
-                    pipette_id=command.params.pipetteId,
-                    labware_id=command.params.labwareId,
-                    well_name=command.params.wellName,
-                ),
+            self._state.current_well = CurrentWell(
+                pipette_id=command.params.pipetteId,
+                labware_id=command.params.labwareId,
+                well_name=command.params.wellName,
             )
         # TODO(mc, 2021-11-12): wipe out current_well on movement failures, too
         elif isinstance(command.result, HomeResult):
-            self._state = replace(self._state, current_well=None)
+            self._state.current_well = None
 
         if isinstance(command.result, LoadPipetteResult):
             pipette_id = command.result.pipetteId
-            pipettes_by_id = self._state.pipettes_by_id.copy()
-            aspirated_volume_by_id = self._state.aspirated_volume_by_id.copy()
 
-            pipettes_by_id[pipette_id] = LoadedPipette(
+            self._state.pipettes_by_id[pipette_id] = LoadedPipette(
                 id=pipette_id,
                 pipetteName=command.params.pipetteName,
                 mount=command.params.mount,
             )
-            aspirated_volume_by_id[pipette_id] = 0
-
-            self._state = replace(
-                self._state,
-                pipettes_by_id=pipettes_by_id,
-                aspirated_volume_by_id=aspirated_volume_by_id,
-            )
+            self._state.aspirated_volume_by_id[pipette_id] = 0
 
         elif isinstance(command.result, AspirateResult):
             pipette_id = command.params.pipetteId
-            aspirated_volume_by_id = self._state.aspirated_volume_by_id.copy()
-
             previous_volume = self._state.aspirated_volume_by_id[pipette_id]
             next_volume = previous_volume + command.result.volume
-            aspirated_volume_by_id[pipette_id] = next_volume
 
-            self._state = replace(
-                self._state,
-                aspirated_volume_by_id=aspirated_volume_by_id,
-            )
+            self._state.aspirated_volume_by_id[pipette_id] = next_volume
 
         elif isinstance(command.result, DispenseResult):
             pipette_id = command.params.pipetteId
-            aspirated_volume_by_id = self._state.aspirated_volume_by_id.copy()
-
             previous_volume = self._state.aspirated_volume_by_id[pipette_id]
             next_volume = max(0, previous_volume - command.result.volume)
-            aspirated_volume_by_id[pipette_id] = next_volume
 
-            self._state = replace(
-                self._state,
-                aspirated_volume_by_id=aspirated_volume_by_id,
-            )
+            self._state.aspirated_volume_by_id[pipette_id] = next_volume
 
 
 class PipetteView(HasState[PipetteState]):

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -17,6 +17,7 @@ class EngineStatus(str, Enum):
     PAUSED = "paused"
     STOP_REQUESTED = "stop-requested"
     STOPPED = "stopped"
+    FINISHING = "finishing"
     FAILED = "failed"
     SUCCEEDED = "succeeded"
 

--- a/api/src/opentrons/protocol_runner/legacy_context_plugin.py
+++ b/api/src/opentrons/protocol_runner/legacy_context_plugin.py
@@ -54,7 +54,7 @@ class LegacyContextPlugin(AbstractPlugin):
         self._hardware_api = hardware_api
         self._protocol_context = protocol_context
         self._legacy_command_mapper = legacy_command_mapper or LegacyCommandMapper()
-        self._unsubcribe: Optional[ContextUnsubscribe] = None
+        self._unsubscribe: Optional[ContextUnsubscribe] = None
 
     def setup(self) -> None:
         """Set up subscriptions to the context's message brokers."""

--- a/api/tests/opentrons/protocol_engine/state/command_fixtures.py
+++ b/api/tests/opentrons/protocol_engine/state/command_fixtures.py
@@ -58,6 +58,7 @@ def create_failed_command(
     command_key: str = "command-key",
     command_type: str = "command-type",
     error_id: str = "error-id",
+    created_at: datetime = datetime(year=2021, month=1, day=1),
     completed_at: datetime = datetime(year=2022, month=2, day=2),
     params: Optional[BaseModel] = None,
 ) -> cmd.Command:
@@ -67,7 +68,7 @@ def create_failed_command(
         cmd.BaseCommand(
             id=command_id,
             key=command_key,
-            createdAt=datetime(year=2021, month=1, day=1),
+            createdAt=created_at,
             commandType=command_type,
             status=cmd.CommandStatus.FAILED,
             params=params or BaseModel(),

--- a/api/tests/opentrons/protocol_engine/state/test_command_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_store.py
@@ -16,7 +16,6 @@ from opentrons.protocol_engine.state.commands import (
 )
 
 from opentrons.protocol_engine.actions import (
-    Action,
     QueueCommandAction,
     UpdateCommandAction,
     FailCommandAction,

--- a/api/tests/opentrons/protocol_engine/state/test_command_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_store.py
@@ -253,7 +253,7 @@ def test_running_command_id(completed_update: Action) -> None:
 
 
 def test_command_failure_clears_queue() -> None:
-    """It should queue on QueueCommandAction and unqueue on UpdateCommandAction."""
+    """It should clear the command queue on command failure."""
     queue_1 = QueueCommandAction(
         request=commands.PauseCreate(params=commands.PauseParams()),
         created_at=datetime(year=2021, month=1, day=1),

--- a/api/tests/opentrons/protocol_engine/state/test_command_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view.py
@@ -1,6 +1,6 @@
 """Labware state store tests."""
 import pytest
-from collections import OrderedDict, deque
+from collections import OrderedDict
 from contextlib import nullcontext as does_not_raise
 from datetime import datetime
 from typing import Dict, List, NamedTuple, Optional, Sequence, Tuple, Type, Union
@@ -32,7 +32,7 @@ def get_command_view(
         should_report_result=should_report_result,
         is_hardware_stopped=is_hardware_stopped,
         should_stop=should_stop,
-        queued_command_ids=deque(queued_command_ids),
+        queued_command_ids=OrderedDict((i, True) for i in queued_command_ids),
         commands_by_id=OrderedDict(commands_by_id),
         errors_by_id=errors_by_id or {},
     )

--- a/api/tests/opentrons/protocol_engine/state/test_command_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view.py
@@ -74,7 +74,7 @@ def test_get_all() -> None:
     assert subject.get_all() == [command_1, command_2, command_3]
 
 
-def test_get_next_queued_returns_first_pending() -> None:
+def test_get_next_queued_returns_first_queued() -> None:
     """It should return the next queued command ID."""
     subject = get_command_view(
         is_running_queue=True,


### PR DESCRIPTION
## Overview

This PR refactors the logic used to lookup the next queued command ID. Previously, this logic was O(n) in the worst case, and it was called by the engine's `QueueWorker` on every single state update. Legacy protocol execution triggered the worst case due to its bypass of the `queued` command state.

Closes #9109, closes #8739. Hopefully also has an impact on #9133.

## Changelog

- Maintain a separate list of queued command IDs to ensure queue lookup is always O(1)
- Maintain PE state in mutable dataclasses vs immutable ones
    - Were not using immutability at the store level
    - Going mutable gets us benefits for performance _and_ typesafety
    - If/when we need immutability, we should evaluate a performant library
- Further improve run status reporting to remove reliance on iterating over the commands and errors lists 

**Important:** This PR _also_ removes the "bail on first PE command failure" logic because:

- It was easier to avoid re-implementing it
- We don't really want to keep the behavior, per #8739

This **does not affect protocol running bails**, just bails during the "live" LPC portion. **This probably has client-facing impacts**.

### Client callouts

- The session status will no longer switch back and forth between `running` and `idle` during the non-LPC phase of the run
- A failed command during LPC will not make the run unusable, nor will it interfere with run status reporting
- A new run status has been added: `finishing`. This status is set when the run has completed and the robot is currently shutting down the hardware (and, in the future, dropping tips and homing)

## Review requests

- [ ] Smoke tests of complex protocol analyses and runs
- [ ] Smoke tests of LPC

## Risk assessment

Medium low
