### PR TITLE
fix(app): prevent run canceled banner from disappearing

### DIFF
--- a/app/src/organisms/RunDetails/CommandList.tsx
+++ b/app/src/organisms/RunDetails/CommandList.tsx
@@ -108,14 +108,14 @@ export function CommandList(): JSX.Element | null {
       ? [...postPlayRunCommands, ...remainingAnticipatedCommands]
       : [...postPlayRunCommands]
   }
-
+  console.log(runStatus)
   if (protocolData == null || runStatus == null) return null
 
   let alertItemTitle
   if (runStatus === 'failed') {
     alertItemTitle = t('protocol_run_failed')
   }
-  if (runStatus === 'stop-requested') {
+  if (runStatus === 'stop-requested' || runStatus === 'stopped') {
     alertItemTitle = t('protocol_run_canceled')
   }
   if (runStatus === 'succeeded') {
@@ -127,11 +127,14 @@ export function CommandList(): JSX.Element | null {
       <Flex flexDirection={DIRECTION_COLUMN} flex={'auto'}>
         {runStatus === 'failed' ||
         runStatus === 'succeeded' ||
-        runStatus === 'stop-requested' ? (
+        runStatus === 'stop-requested' ||
+        runStatus === 'stopped' ? (
           <Box padding={SPACING_2}>
             <AlertItem
               type={
-                runStatus === 'stop-requested' || runStatus === 'failed'
+                runStatus === 'stop-requested' ||
+                runStatus === 'failed' ||
+                runStatus === 'stopped'
                   ? 'error'
                   : 'success'
               }

--- a/app/src/organisms/RunDetails/CommandList.tsx
+++ b/app/src/organisms/RunDetails/CommandList.tsx
@@ -108,7 +108,7 @@ export function CommandList(): JSX.Element | null {
       ? [...postPlayRunCommands, ...remainingAnticipatedCommands]
       : [...postPlayRunCommands]
   }
-  console.log(runStatus)
+
   if (protocolData == null || runStatus == null) return null
 
   let alertItemTitle

--- a/app/src/organisms/RunDetails/__tests__/CommandList.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/CommandList.test.tsx
@@ -117,7 +117,9 @@ describe('CommandList', () => {
     expect(getByText('Protocol Run Failed')).toHaveStyle('color: Error_dark')
   })
   it('renders the protocol canceled banner', () => {
-    mockUseRunStatus.mockReturnValue('stop-requested')
+    mockUseRunStatus
+      .mockReturnValue('stop-requested')
+      .mockReturnValue('stopped')
     mockAlertItem.mockReturnValue(<div>Protocol Run Canceled</div>)
     const { getByText } = render()
     expect(getByText('Protocol Run Canceled')).toHaveStyle(

--- a/app/src/organisms/RunDetails/__tests__/CommandList.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/CommandList.test.tsx
@@ -116,10 +116,17 @@ describe('CommandList', () => {
     )
     expect(getByText('Protocol Run Failed')).toHaveStyle('color: Error_dark')
   })
-  it('renders the protocol canceled banner', () => {
-    mockUseRunStatus
-      .mockReturnValue('stop-requested')
-      .mockReturnValue('stopped')
+  it('renders the protocol canceled banner when the status is stop-requested', () => {
+    mockUseRunStatus.mockReturnValue('stop-requested')
+    mockAlertItem.mockReturnValue(<div>Protocol Run Canceled</div>)
+    const { getByText } = render()
+    expect(getByText('Protocol Run Canceled')).toHaveStyle(
+      'backgroundColor: Error_light'
+    )
+    expect(getByText('Protocol Run Canceled')).toHaveStyle('color: Error_dark')
+  })
+  it('renders the protocol canceled banner when the status is stopped', () => {
+    mockUseRunStatus.mockReturnValue('stopped')
     mockAlertItem.mockReturnValue(<div>Protocol Run Canceled</div>)
     const { getByText } = render()
     expect(getByText('Protocol Run Canceled')).toHaveStyle(


### PR DESCRIPTION

# Overview

This PR fixes the issue where the run canceled banner disappears after a few seconds.

closes #9108

![image](https://user-images.githubusercontent.com/14794021/147972101-7e7ff56e-2721-410c-90ad-9635248dc33e.png)


# Changelog

- Added `stopped` run status to the conditional that displays the status alert.
- Updated corresponding test

# Review requests

- Check that when you cancel a run the alert box for the run does not disappear.

# Risk assessment

low