### PR TITLE
fix(app): update protocol upload failed banner style

### DIFF
--- a/app/src/organisms/ProtocolUpload/index.tsx
+++ b/app/src/organisms/ProtocolUpload/index.tsx
@@ -201,7 +201,7 @@ export function ProtocolUpload(): JSX.Element {
             width="100%"
           >
             <AlertItem
-              type="warning"
+              type="error"
               onCloseClick={clearError}
               title={t('protocol_upload_failed')}
             >


### PR DESCRIPTION
# Overview

This PR updates the style prop for the protocol upload failed banner. closes #9097.

Before:
![Screen Shot 2022-01-03 at 3 00 40 PM](https://user-images.githubusercontent.com/14794021/147976086-81545957-3fc0-4490-beb7-1be4ea527e3a.png)

After:
![Screen Shot 2022-01-03 at 3 00 26 PM](https://user-images.githubusercontent.com/14794021/147976105-62ce729c-de24-4584-92eb-188d13bae167.png)


# Changelog

- Changed `AlertItem` type prop to `error`

# Review requests

- Check that the protocol upload failed banner shows the error style and not the warning style.

# Risk assessment

low