### PR TITLE
fix(api): check pipette names in simulator

### DIFF
--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -218,7 +218,7 @@ class Simulator:
             expected_instr
             and found_model
             and (
-                not found_model.startswith(expected_instr)
+                configs[found_model]["name"] != expected_instr
                 and expected_instr not in back_compat
             )
         ):


### PR DESCRIPTION
This function hadn't been updated to do name-based checking rather than
prefix-based checking for pipettes in simulation. Fixes an issue where
you couldn't simulate a gen2 pipette on command line with an
attached-hardware specification (the app was fine because it doesn't use
strict checking).
