### PR TITLE
fix: Change links to networks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
     # Uncomment lines below to override the pipette(s) loaded by emulator
     #environment:
     #  OT_EMULATOR_smoothie: '{"right": {"model": "p300_multi"}, "left": {"model": "p20_single_v2.0"}}'
+    networks:
+      - container-network
   robot-server:
     build: .
     command: uvicorn "robot_server:app" --host 0.0.0.0 --port 31950 --ws wsproto --reload
@@ -26,8 +28,8 @@ services:
       OT_API_CONFIG_DIR: /config
       OT_SMOOTHIE_EMULATOR_URI: socket://emulator:9996
       OT_EMULATOR_module_server: '{"host": "emulator"}'
-    links:
-      - 'emulator'
+    networks:
+      - container-network
     depends_on:
       - 'emulator'
     volumes:
@@ -35,21 +37,24 @@ services:
   tempdeck:
     build: .
     command: python3 -m opentrons.hardware_control.emulation.scripts.run_module_emulator tempdeck emulator
-    links:
-      - 'emulator'
+    networks:
+      - container-network
     depends_on:
       - 'emulator'
   thermocycler:
     build: .
     command: python3 -m opentrons.hardware_control.emulation.scripts.run_module_emulator thermocycler emulator
-    links:
-      - 'emulator'
+    networks:
+      - container-network
     depends_on:
       - 'emulator'
   magdeck:
     build: .
     command: python3 -m opentrons.hardware_control.emulation.scripts.run_module_emulator magdeck emulator
-    links:
-      - 'emulator'
+    networks:
+      - container-network
     depends_on:
       - 'emulator'
+
+networks:
+  container-network:


### PR DESCRIPTION
# Overview

Links are deprecated. Using networks instead
See https://docs.docker.com/compose/compose-file/compose-file-v3/#links

# Changelog

- Remove links and replace with networks

# Review requests

One of the downsides of using networks over links is that containers will not share env vars. @amitlissack I don't see any of that going on. Did you links just for networking?

# Risk assessment

As long as above review request is not a problem, then risk is low. 
Tested bringing up system with compose file and everything works.
