### PR TITLE
fix(app): initially expand correct setup step with modules and cal complete

### DIFF
--- a/app/src/organisms/ProtocolSetup/RunSetupCard/CollapsibleStep.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/CollapsibleStep.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { css } from 'styled-components'
 import {
   Icon,
   Flex,
@@ -27,12 +28,23 @@ interface CollapsibleStepProps {
   rightAlignedNode: React.ReactNode
 }
 
+const EXPANDED_STYLE = css`
+  transition: max-height 300ms ease-in, visibility 400ms ease;
+  visibility: visible;
+  max-height: 100vh;
+  overflow: hidden;
+`
+const COLLAPSED_STYLE = css`
+  transition: max-height 500ms ease-out;
+  visibility: hidden;
+  max-height: 0vh;
+  overflow: hidden;
+`
 export function CollapsibleStep({
   expanded,
   title,
   description,
   label,
-  id,
   toggleExpanded,
   children,
   rightAlignedNode,
@@ -70,15 +82,7 @@ export function CollapsibleStep({
         {rightAlignedNode != null ? rightAlignedNode : null}
         <Icon size={SIZE_1} name={expanded ? 'minus' : 'plus'} />
       </Flex>
-      <Box
-        maxHeight={expanded ? '100vh' : '0vh'}
-        transition={
-          expanded ? 'max-height 500ms ease-in' : 'max-height 500ms ease-out'
-        }
-        overflow="hidden"
-      >
-        {children}
-      </Box>
+      <Box css={expanded ? EXPANDED_STYLE : COLLAPSED_STYLE}>{children}</Box>
     </Flex>
   )
 }

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/__tests__/RunSetupCard.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/__tests__/RunSetupCard.test.tsx
@@ -257,7 +257,7 @@ describe('RunSetupCard', () => {
     } as any)
 
     const { queryByText, getByText } = render()
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await new Promise(resolve => setTimeout(resolve, 1000))
     expect(getByText('Mock Labware Setup')).toBeVisible()
     expect(queryByText(/mock module setup/i)).toBeNull()
   })
@@ -267,7 +267,7 @@ describe('RunSetupCard', () => {
     } as any)
 
     const { queryByText, getByText } = render()
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await new Promise(resolve => setTimeout(resolve, 1000))
     expect(getByText('Mock Module Setup')).toBeVisible()
     expect(queryByText(/mock labware setup/i)).not.toBeVisible()
   })
@@ -278,7 +278,7 @@ describe('RunSetupCard', () => {
     mockUseProtocolCalibrationStatus.mockReturnValue({ complete: false })
 
     const { queryByText, getByText } = render()
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await new Promise(resolve => setTimeout(resolve, 1000))
     expect(getByText('Mock Robot Calibration')).toBeVisible()
     expect(queryByText(/mock labware setup/i)).not.toBeVisible()
   })
@@ -289,7 +289,7 @@ describe('RunSetupCard', () => {
     mockUseProtocolCalibrationStatus.mockReturnValue({ complete: false })
 
     const { queryByText, getByText } = render()
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await new Promise(resolve => setTimeout(resolve, 1000))
     expect(getByText('Mock Robot Calibration')).toBeVisible()
     expect(queryByText(/mock module setup/i)).not.toBeVisible()
   })

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/__tests__/RunSetupCard.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/__tests__/RunSetupCard.test.tsx
@@ -251,4 +251,46 @@ describe('RunSetupCard', () => {
     fireEvent.click(proceedToRun)
     getByText('Mock Proceed To Run')
   })
+  it('defaults to labware step expanded if calibration complete and no modules present', async () => {
+    mockUseProtocolDetails.mockReturnValue({
+      protocolData: noModulesProtocol,
+    } as any)
+
+    const { queryByText, getByText } = render()
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    expect(getByText('Mock Labware Setup')).toBeVisible()
+    expect(queryByText(/mock module setup/i)).toBeNull()
+  })
+  it('defaults to module step expanded if calibration complete and modules present', async () => {
+    mockUseProtocolDetails.mockReturnValue({
+      protocolData: withModulesProtocol,
+    } as any)
+
+    const { queryByText, getByText } = render()
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    expect(getByText('Mock Module Setup')).toBeVisible()
+    expect(queryByText(/mock labware setup/i)).not.toBeVisible()
+  })
+  it('defaults to robot cal expanded if calibration incomplete and no modules present', async () => {
+    mockUseProtocolDetails.mockReturnValue({
+      protocolData: noModulesProtocol,
+    } as any)
+    mockUseProtocolCalibrationStatus.mockReturnValue({ complete: false })
+
+    const { queryByText, getByText } = render()
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    expect(getByText('Mock Robot Calibration')).toBeVisible()
+    expect(queryByText(/mock labware setup/i)).not.toBeVisible()
+  })
+  it('defaults to robot cal expanded if calibration incomplete and modules present', async () => {
+    mockUseProtocolDetails.mockReturnValue({
+      protocolData: withModulesProtocol,
+    } as any)
+    mockUseProtocolCalibrationStatus.mockReturnValue({ complete: false })
+
+    const { queryByText, getByText } = render()
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    expect(getByText('Mock Robot Calibration')).toBeVisible()
+    expect(queryByText(/mock module setup/i)).not.toBeVisible()
+  })
 })

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/index.tsx
@@ -66,20 +66,23 @@ export function RunSetupCard(): JSX.Element | null {
   ])
 
   React.useEffect(() => {
+    let nextStepKeysInOrder = stepsKeysInOrder
     if (protocolData != null && protocolHasModules(protocolData)) {
-      setStepKeysInOrder([
+      nextStepKeysInOrder = [
         ROBOT_CALIBRATION_STEP_KEY,
         MODULE_SETUP_KEY,
         LABWARE_SETUP_KEY,
-      ])
+      ]
     }
     let initialExpandedStepKey: StepKey = ROBOT_CALIBRATION_STEP_KEY
     if (calibrationStatus.complete) {
       initialExpandedStepKey =
-        stepsKeysInOrder[
-          stepsKeysInOrder.findIndex(v => v === ROBOT_CALIBRATION_STEP_KEY) + 1
+        nextStepKeysInOrder[
+          nextStepKeysInOrder.findIndex(v => v === ROBOT_CALIBRATION_STEP_KEY) +
+            1
         ]
     }
+    setStepKeysInOrder(nextStepKeysInOrder)
     const initialExpandTimer = setTimeout(
       () => setExpandedStepKey(initialExpandedStepKey),
       INITIAL_EXPAND_DELAY_MS


### PR DESCRIPTION
Fixes a bug where users would be brought to the labware setup step initially instead of the module
setup step initially in the case that their robot calibration is complete.  Also adds transition
aware async unit tests for this functionality and a tweak to the collapsible step visibility
transition

Closes #9127

# Changelog

- add visibility property to `CollapsibleStep` collapse/expand transition
- consider actual next step key list when calculating initially expanded step key index

# Review requests

upload protocol with modules:

- [ ] if calibration is not complete, the robot calibration step should be expanded initially,
- [ ] if calibration is complete, the module setup step should be expanded initially

upload protocol without modules:

- [ ] if calibration is not complete, the robot calibration step should be expanded initially,
- [ ] if calibration is complete, the labware setup step should be expanded initially

# Risk assessment

low