### PR TITLE
fix(app): fix broken tooltip translation for LPC CTA when modules not detected

### DIFF
--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
@@ -104,7 +104,7 @@ export const LabwareSetup = (): JSX.Element | null => {
   } else if (calibrationIncomplete) {
     lpcDisabledReason = t('lpc_disabled_calibration_not_complete')
   } else if (moduleSetupIncomplete) {
-    lpcDisabledReason = t('lpc_disabled_modules_not_connected"')
+    lpcDisabledReason = t('lpc_disabled_modules_not_connected')
   } else if (runStatus != null && runStatus !== RUN_STATUS_IDLE) {
     lpcDisabledReason = t('labware_position_check_not_available')
   } else if (


### PR DESCRIPTION
# Overview

Fixed malformed translation key for the hover tooltip on the LPC CTA when disabled due to missing modules.

# Risk assessment

low