### PR TITLE
fix(api): set serial timeouts for transactions

### DIFF
--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -134,19 +134,18 @@ class SerialConnection:
 
         Raises: SerialException
         """
-        async with self._send_data_lock:
-            return await self._send_data(data=data, retries=retries, timeout=timeout)
+        async with self._send_data_lock, self._serial.timeout_override(
+            "timeout", timeout
+        ):
+            return await self._send_data(data=data, retries=retries)
 
-    async def _send_data(
-        self, data: str, retries: int = 0, timeout: Optional[float] = None
-    ) -> str:
+    async def _send_data(self, data: str, retries: int = 0) -> str:
         """
         Send data and return the response.
 
         Args:
             data: The data to send.
             retries: number of times to retry in case of timeout
-            timeout: optional override of default timeout in seconds
 
         Returns: The command response
 
@@ -158,7 +157,7 @@ class SerialConnection:
             log.debug(f"{self.name}: Write -> {data_encode!r}")
             await self._serial.write(data=data_encode)
 
-            response = await self._serial.read_until(match=self._ack, timeout=timeout)
+            response = await self._serial.read_until(match=self._ack)
             log.debug(f"{self.name}: Read <- {response!r}")
 
             if self._ack in response:

--- a/api/tests/opentrons/drivers/asyncio/communication/test_async_serial.py
+++ b/api/tests/opentrons/drivers/asyncio/communication/test_async_serial.py
@@ -57,7 +57,8 @@ async def test_write_timeout_override(
 ):
     """It should override the timeout and return to default after the call."""
     mock_write_timeout_prop.return_value = default
-    await subject.write(b"", override)
+    async with subject.timeout_override("write_timeout", override):
+        await subject.write(b"")
 
     # Three calls: read, override, reset default.
     assert mock_write_timeout_prop.call_args_list == [
@@ -74,7 +75,7 @@ async def test_write_timeout_override(
         [5, 6],
     ],
 )
-async def test_read_timeout_override(
+async def test_timeout_override(
     subject: AsyncSerial,
     mock_timeout_prop: PropertyMock,
     default: Optional[int],
@@ -82,7 +83,8 @@ async def test_read_timeout_override(
 ):
     """It should override the timeout and return to default after the call."""
     mock_timeout_prop.return_value = default
-    await subject.read_until(b"", override)
+    async with subject.timeout_override("timeout", override):
+        await subject.read_until(b"")
 
     # Three calls: read, override, reset default.
     assert mock_timeout_prop.call_args_list == [call(), call(override), call(default)]
@@ -104,7 +106,8 @@ async def test_write_timeout_dont_override(
 ):
     """It should not override the timeout if not necessary."""
     mock_write_timeout_prop.return_value = default
-    await subject.write(b"", override)
+    async with subject.timeout_override("write_timeout", override):
+        await subject.write(b"")
 
     mock_write_timeout_prop.assert_called_once()
 
@@ -125,6 +128,7 @@ async def test_read_timeout_dont_override(
 ):
     """It should not override the timeout if not necessary."""
     mock_timeout_prop.return_value = default
-    await subject.read_until(b"", override)
+    async with subject.timeout_override("timeout", override):
+        await subject.read_until(b"")
 
     mock_timeout_prop.assert_called_once()

--- a/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
+++ b/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
@@ -46,10 +46,9 @@ async def test_send_command(
 
     await subject.send_data(data="send data")
 
+    mock_serial_port.timeout_override.assert_called_once_with("timeout", None)
     mock_serial_port.write.assert_called_once_with(data=b"send data")
-    mock_serial_port.read_until.assert_called_once_with(
-        match=ack.encode(), timeout=None
-    )
+    mock_serial_port.read_until.assert_called_once_with(match=ack.encode())
 
 
 async def test_send_command_with_retry(
@@ -61,13 +60,14 @@ async def test_send_command_with_retry(
 
     await subject.send_data(data="send data", retries=1)
 
+    mock_serial_port.timeout_override.assert_called_once_with("timeout", None)
     mock_serial_port.write.assert_has_calls(
         calls=[call(data=b"send data"), call(data=b"send data")]
     )
     mock_serial_port.read_until.assert_has_calls(
         calls=[
-            call(match=ack.encode(), timeout=None),
-            call(match=ack.encode(), timeout=None),
+            call(match=ack.encode()),
+            call(match=ack.encode()),
         ]
     )
 


### PR DESCRIPTION
The async-serial refactor changed serial timeouts to be set for
individual serial actions (aka a single call to serial.write or
serial.read_until), rather than a write-read transaction pair as it
previously had been. While this shouldn't be a problem, and isn't a
problem on the OT-2, OSX, or desktop Linux, it is in fact a problem on
Windows: https://github.com/pyserial/pyserial/issues/394

The tl;dr is that the pyserial win32 implementation does a full port
reconfigure when you change a timeout. On specifically FTDI devices, as
with test engineering running an OT-2 test fixture by connecting the
motor controller to a laptop with an FTDI cable and running this
software on the laptop, a port reconfigure during an ongoing serial
transaction - which the host of course doesn't really control - can and
sometimes will corrupt data.

The solution to this is to move timeout setting back to a transaction
timeframe, so that there are overall fewer timeout changes and thus
fewer port reconfigures and thus the problem doesn't occur.

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
