### PR TITLE
fix(app): titlebar cancel run button behavior and styling

### DIFF
--- a/app/src/organisms/ProtocolUpload/hooks/useCloseCurrentRun.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useCloseCurrentRun.ts
@@ -1,25 +1,8 @@
 import * as React from 'react'
-import {
-  useStopRunMutation,
-  useDismissCurrentRunMutation,
-} from '@opentrons/react-api-client'
+import { useDismissCurrentRunMutation } from '@opentrons/react-api-client'
 import { UseDismissCurrentRunMutationOptions } from '@opentrons/react-api-client/src/runs/useDismissCurrentRunMutation'
-import { useDeleteRunMutation } from '../../../../../react-api-client/src/runs'
 import { useCurrentProtocolRun } from './useCurrentProtocolRun'
 import { useCurrentRunId } from './useCurrentRunId'
-import type { RunStatus } from '@opentrons/api-client'
-
-const isStoppedState = (status: RunStatus): boolean => {
-  if (
-    status === 'stop-requested' ||
-    status === 'stopped' ||
-    status === 'failed' ||
-    status === 'succeeded'
-  ) {
-    return true
-  }
-  return false
-}
 
 type CloseCallback = (options?: UseDismissCurrentRunMutationOptions) => void
 
@@ -34,40 +17,16 @@ export function useCloseCurrentRun(): {
   } = useDismissCurrentRunMutation()
   const { protocolRecord, runRecord } = useCurrentProtocolRun()
 
-  const { stopRun } = useStopRunMutation()
-  const { deleteRun } = useDeleteRunMutation()
-
-  const closeCurrentRun = (
-    options: UseDismissCurrentRunMutationOptions = {}
-  ): void => {
+  const closeCurrentRun = (): void => {
     if (currentRunId != null) {
-      const status = runRecord?.data.status
-      if (isStoppedState(status as RunStatus)) {
-        dismissCurrentRun(currentRunId, {
-          // if we error when dismissing, delete the run
-          onError: () => deleteRun(currentRunId),
-        })
-      } else {
-        stopRun(currentRunId, {
-          onSuccess: _data => {
-            dismissCurrentRun(currentRunId, options)
-          },
-          // if we error when stopping, dismiss the run
-          onError: () => {
-            dismissCurrentRun(currentRunId, {
-              // if we error when dismissing, delete the run
-              onError: () => deleteRun(currentRunId),
-            })
-          },
-        })
-      }
+      dismissCurrentRun(currentRunId, {
+        onError: () => console.warn('failed to dismiss current'),
+      })
     }
   }
   const closeCurrentRunCallback = React.useCallback(closeCurrentRun, [
-    deleteRun,
     dismissCurrentRun,
     runRecord,
-    stopRun,
     currentRunId,
   ])
 

--- a/app/src/organisms/ProtocolUpload/index.tsx
+++ b/app/src/organisms/ProtocolUpload/index.tsx
@@ -162,6 +162,7 @@ export function ProtocolUpload(): JSX.Element {
         title: t('shared:close'),
         children: t('shared:close'),
         iconName: 'close' as const,
+        className: styles.close_button
       },
       className: styles.reverse_titlebar_items,
     }

--- a/app/src/organisms/ProtocolUpload/index.tsx
+++ b/app/src/organisms/ProtocolUpload/index.tsx
@@ -17,11 +17,9 @@ import {
   TEXT_TRANSFORM_UPPERCASE,
   FONT_SIZE_BIG,
   SPACING_8,
-  LINE_HEIGHT_SOLID,
   SPACING_3,
   SPACING_2,
-  NewSecondaryBtn,
-  C_ERROR_DARK,
+  NewAlertSecondaryBtn,
 } from '@opentrons/components'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
@@ -137,17 +135,16 @@ export function ProtocolUpload(): JSX.Element {
     cancel: cancelModalExit,
   } = useConditionalConfirm(cancelRunAndExit, true)
 
+  /** NOTE: the logic to determine the contents of this titlebar is
+  very close to the logic present on the RunDetails organism */
   const cancelRunButton = (
-    <NewSecondaryBtn
+    <NewAlertSecondaryBtn
       onClick={confirmCancelModalExit}
-      lineHeight={LINE_HEIGHT_SOLID}
       marginX={SPACING_3}
-      paddingRight={SPACING_2}
-      paddingLeft={SPACING_2}
-      color={C_ERROR_DARK}
+      paddingX={SPACING_2}
     >
       {t('cancel_run')}
-    </NewSecondaryBtn>
+    </NewAlertSecondaryBtn>
   )
   const isRunInMotion =
     runStatus === RUN_STATUS_RUNNING ||

--- a/app/src/organisms/ProtocolUpload/index.tsx
+++ b/app/src/organisms/ProtocolUpload/index.tsx
@@ -162,7 +162,7 @@ export function ProtocolUpload(): JSX.Element {
         title: t('shared:close'),
         children: t('shared:close'),
         iconName: 'close' as const,
-        className: styles.close_button
+        className: styles.close_button,
       },
       className: styles.reverse_titlebar_items,
     }

--- a/app/src/organisms/ProtocolUpload/styles.css
+++ b/app/src/organisms/ProtocolUpload/styles.css
@@ -13,3 +13,8 @@
   left: auto !important;
   right: var(--button-pad) !important;
 }
+
+.close_button {
+  margin-right: 0.5rem;
+  width: 7rem;
+}

--- a/app/src/organisms/RunDetails/index.tsx
+++ b/app/src/organisms/RunDetails/index.tsx
@@ -95,6 +95,7 @@ export function RunDetails(): JSX.Element | null {
         title: t('shared:close'),
         children: t('shared:close'),
         iconName: 'close' as const,
+        className: styles.close_button
       },
       className: styles.reverse_titlebar_items,
     }

--- a/app/src/organisms/RunDetails/index.tsx
+++ b/app/src/organisms/RunDetails/index.tsx
@@ -9,12 +9,10 @@ import {
   RUN_STATUS_PAUSE_REQUESTED,
 } from '@opentrons/api-client'
 import {
-  LINE_HEIGHT_SOLID,
   SPACING_2,
   SPACING_3,
-  C_ERROR_DARK,
   useConditionalConfirm,
-  NewSecondaryBtn,
+  NewAlertSecondaryBtn,
 } from '@opentrons/components'
 import { Page } from '../../atoms/Page'
 import { Portal } from '../../App/portal'
@@ -69,16 +67,13 @@ export function RunDetails(): JSX.Element | null {
   }
 
   const cancelRunButton = (
-    <NewSecondaryBtn
+    <NewAlertSecondaryBtn
       onClick={cancelRunAndExit}
-      lineHeight={LINE_HEIGHT_SOLID}
       marginX={SPACING_3}
-      paddingRight={SPACING_2}
-      paddingLeft={SPACING_2}
-      color={C_ERROR_DARK}
+      paddingX={SPACING_2}
     >
       {t('cancel_run')}
-    </NewSecondaryBtn>
+    </NewAlertSecondaryBtn>
   )
 
   let titleBarProps

--- a/app/src/organisms/RunDetails/index.tsx
+++ b/app/src/organisms/RunDetails/index.tsx
@@ -95,7 +95,7 @@ export function RunDetails(): JSX.Element | null {
         title: t('shared:close'),
         children: t('shared:close'),
         iconName: 'close' as const,
-        className: styles.close_button
+        className: styles.close_button,
       },
       className: styles.reverse_titlebar_items,
     }


### PR DESCRIPTION
# Overview

- Ensure button styling for the title bar cancel button on the Protocol and Run pages matches the design by using the `NewAlertSecondaryBtn`.  

- Make sure that closing a run via `useCloseCurrentRun` will never lead to a stop/cancel action. 

- Remove `useCloseCurrentRun`'s error handling ability to delete a run record.

Closes #9049

# Review requests

- [ ] Cancel a protocol run from the protocol and/or the run tab.  Make sure the active and hover state of the button is red.  
- [ ] ensure that closing a cancelled protocol doesn't send another cancel command (this would home the robot as well)

# Risk assessment

med, this removes the client's ability to unblock itself if the "uncurrent" run request fails.