### PR TITLE
refactor(app): add run status for finishing to run time controls

### DIFF
--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -10,6 +10,7 @@ export const RUN_STATUS_PAUSED: 'paused' = 'paused'
 export const RUN_STATUS_STOP_REQUESTED: 'stop-requested' = 'stop-requested'
 export const RUN_STATUS_STOPPED: 'stopped' = 'stopped'
 export const RUN_STATUS_FAILED: 'failed' = 'failed'
+export const RUN_STATUS_FINISHING: 'finishing' = 'finishing'
 export const RUN_STATUS_SUCCEEDED: 'succeeded' = 'succeeded'
 
 export type RunStatus =
@@ -20,6 +21,7 @@ export type RunStatus =
   | typeof RUN_STATUS_STOP_REQUESTED
   | typeof RUN_STATUS_STOPPED
   | typeof RUN_STATUS_FAILED
+  | typeof RUN_STATUS_FINISHING
   | typeof RUN_STATUS_SUCCEEDED
 
 export interface RunData {

--- a/app/src/assets/localization/en/run_details.json
+++ b/app/src/assets/localization/en/run_details.json
@@ -16,6 +16,7 @@
   "status_pause-requested": "Pause requested",
   "status_paused": "Paused",
   "status_idle": "Not started",
+  "status_finishing": "Finishing",
   "status_running": "Running",
   "status_stop-requested": "Stop requested",
   "status_stopped": "Canceled",

--- a/app/src/organisms/RunTimeControl/index.tsx
+++ b/app/src/organisms/RunTimeControl/index.tsx
@@ -8,6 +8,7 @@ import {
   RUN_STATUS_STOP_REQUESTED,
   RUN_STATUS_STOPPED,
   RUN_STATUS_FAILED,
+  RUN_STATUS_FINISHING,
   RUN_STATUS_SUCCEEDED,
 } from '@opentrons/api-client'
 import {
@@ -65,6 +66,7 @@ export function RunTimeControl(): JSX.Element | null {
   } = useRunControls()
 
   const [isRunActionLoading, setIsRunActionLoading] = React.useState(false)
+  const [isFinishing, setIsFinishing] = React.useState(false)
   const [lastRunAction, setLastRunAction] = React.useState<
     'play' | 'pause' | 'reset' | null
   >(null)
@@ -79,6 +81,8 @@ export function RunTimeControl(): JSX.Element | null {
     } else if (isResetRunLoading) {
       setIsRunActionLoading(true)
       setLastRunAction('reset')
+    } else if (!isFinishing && runStatus === 'finishing') {
+      setIsFinishing(true)
     }
 
     if (isRunActionLoading) {
@@ -95,6 +99,9 @@ export function RunTimeControl(): JSX.Element | null {
       if (lastRunAction === 'reset' && runStatus === RUN_STATUS_IDLE) {
         setIsRunActionLoading(false)
       }
+    }
+    if (isFinishing && runStatus !== 'finishing') {
+      setIsFinishing(false)
     }
   }, [
     isPlayRunActionLoading,
@@ -127,6 +134,7 @@ export function RunTimeControl(): JSX.Element | null {
   } else if (
     runStatus === RUN_STATUS_STOP_REQUESTED ||
     runStatus === RUN_STATUS_STOPPED ||
+    runStatus === RUN_STATUS_FINISHING ||
     runStatus === RUN_STATUS_FAILED ||
     runStatus === RUN_STATUS_SUCCEEDED
   ) {
@@ -166,10 +174,10 @@ export function RunTimeControl(): JSX.Element | null {
         justifyContent={JUSTIFY_CENTER}
         alignItems={ALIGN_CENTER}
         display={DISPLAY_FLEX}
-        disabled={disableRunCta || isRunActionLoading}
+        disabled={disableRunCta || isRunActionLoading || isFinishing}
         {...targetProps}
       >
-        {isRunActionLoading ? (
+        {isRunActionLoading || isFinishing ? (
           <Icon name="ot-spinner" size={SIZE_1} marginRight={SPACING_2} spin />
         ) : (
           buttonIcon


### PR DESCRIPTION
# Overview

Add support for the new "finishing" run status to the Run Time Controls

# Review requests

Allow a protocol to finish naturally, the status should update to "finishing" and the run CTA should be disabled "Run Again" with a spinner.

# Risk assessment

low
