### PR TITLE
perf(robot-server): move large response serialization to worker thread

### DIFF
--- a/robot-server/robot_server/protocols/router.py
+++ b/robot-server/robot_server/protocols/router.py
@@ -169,7 +169,7 @@ async def get_protocols(
         for r in protocol_resources
     ]
 
-    return PydanticResponse(
+    return await PydanticResponse.create(
         content=SimpleMultiBody.construct(data=data),
         status_code=status.HTTP_200_OK,
     )

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -174,7 +174,7 @@ async def create_run(
         status=engine_state.commands.get_status(),
     )
 
-    return PydanticResponse(
+    return await PydanticResponse.create(
         content=SimpleBody.construct(data=data),
         status_code=status.HTTP_201_CREATED,
     )
@@ -231,7 +231,7 @@ async def get_runs(
         if run.is_current:
             links.current = ResourceLink.construct(href=f"/runs/{run.run_id}")
 
-    return PydanticResponse(
+    return await PydanticResponse.create(
         content=MultiBody.construct(data=data, links=links),
         status_code=status.HTTP_200_OK,
     )
@@ -287,7 +287,7 @@ async def get_run(
         status=engine_state.commands.get_status(),
     )
 
-    return PydanticResponse(
+    return await PydanticResponse.create(
         content=SimpleBody.construct(data=data),
         status_code=status.HTTP_200_OK,
     )
@@ -397,7 +397,7 @@ async def add_labware_offset(
         status=engine_state.commands.get_status(),
     )
 
-    return PydanticResponse(
+    return await PydanticResponse.create(
         content=SimpleBody.construct(data=data),
         status_code=status.HTTP_201_CREATED,
     )
@@ -475,7 +475,7 @@ async def update_run(
         status=engine_state.commands.get_status(),
     )
 
-    return PydanticResponse(
+    return await PydanticResponse.create(
         content=SimpleBody.construct(data=data),
         status_code=status.HTTP_200_OK,
     )

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -66,7 +66,7 @@ async def create_run_command(
 
     command = engine_store.engine.add_command(request_body.data)
 
-    return PydanticResponse(
+    return await PydanticResponse.create(
         content=SimpleBody.construct(data=command),
         status_code=status.HTTP_201_CREATED,
     )
@@ -95,7 +95,7 @@ async def get_run_commands(
         run: Run response model, provided by the route handler for
             `GET /runs/{runId}`
     """
-    return PydanticResponse(
+    return await PydanticResponse.create(
         content=SimpleMultiBody.construct(data=run.data.commands),
         status_code=status.HTTP_200_OK,
     )
@@ -135,7 +135,7 @@ async def get_run_command(
     except pe_errors.CommandDoesNotExistError as e:
         raise CommandNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
 
-    return PydanticResponse(
+    return await PydanticResponse.create(
         content=SimpleBody(data=command),
         status_code=status.HTTP_200_OK,
     )


### PR DESCRIPTION
## Overview

This is a~n experimental~ PR that moves large response serialization to worker threads.

## Changelog

- perf(robot-server): move large response serialization to worker thread
    - Basically anything that returns one or more `Protocol`, `Run`, or `Command` resource models

## Review requests

- Does this impact run performance in 5.x?

## Risk assessment

Low
