### PR TITLE
refactor(app): remove flashing command text in run log

### DIFF
--- a/app/src/organisms/RunDetails/CommandItem.tsx
+++ b/app/src/organisms/RunDetails/CommandItem.tsx
@@ -112,6 +112,7 @@ export function CommandItem(props: CommandItemProps): JSX.Element | null {
     isComment = analysisCommand?.params.legacyCommandType === 'command.COMMENT'
   } else if (
     runCommandSummary != null &&
+    runCommandSummary.result != null &&
     'legacyCommandType' in runCommandSummary.result
   ) {
     isComment = runCommandSummary.result.legacyCommandType === 'command.COMMENT'

--- a/app/src/organisms/RunDetails/CommandText.tsx
+++ b/app/src/organisms/RunDetails/CommandText.tsx
@@ -6,103 +6,102 @@ import {
   SPACING_1,
   TEXT_TRANSFORM_UPPERCASE,
 } from '@opentrons/components'
-import type { RunCommandSummary } from '@opentrons/api-client'
-import { Command, getLabwareDisplayName } from '@opentrons/shared-data'
+import { getLabwareDisplayName } from '@opentrons/shared-data'
 import { ProtocolSetupInfo } from './ProtocolSetupInfo'
-
 import { useProtocolDetails } from './hooks'
-
 import { getLabwareLocation } from '../ProtocolSetup/utils/getLabwareLocation'
 import { useLabwareRenderInfoById } from '../ProtocolSetup/hooks'
 
+import type { Command } from '@opentrons/shared-data'
+
 interface Props {
-  commandDetailsOrSummary: Command | RunCommandSummary
+  analysisCommand: Command | null
+  runCommand: Command | null
 }
 export function CommandText(props: Props): JSX.Element | null {
-  const { commandDetailsOrSummary } = props
+  const { analysisCommand, runCommand } = props
   const { t } = useTranslation('run_details')
   const { protocolData } = useProtocolDetails()
   const labwareRenderInfoById = useLabwareRenderInfoById()
 
   let messageNode = null
-  if ('params' in commandDetailsOrSummary) {
-    // params will not exist on command summaries
-    switch (commandDetailsOrSummary.commandType) {
-      case 'delay': {
-        // TODO: IMMEDIATELY address displaying real comments
-        messageNode = (
-          <>
-            <Flex
-              textTransform={TEXT_TRANSFORM_UPPERCASE}
-              padding={SPACING_1}
-              id={`RunDetails_CommandList`}
-            >
-              {t('comment')}
-            </Flex>
-            {commandDetailsOrSummary != null
-              ? commandDetailsOrSummary.result
-              : null}
-          </>
-        )
-        break
-      }
-      case 'pickUpTip': {
-        // protocolData should never be null as we don't render the `RunDetails` unless we have an analysis
-        // but we're experiencing a zombie children issue, see https://github.com/Opentrons/opentrons/pull/9091
-        if (protocolData == null) {
-          return null
-        }
-        const { wellName, labwareId } = commandDetailsOrSummary.params
-        const labwareLocation = getLabwareLocation(
-          labwareId,
-          protocolData.commands
-        )
-        if (!('slotName' in labwareLocation)) {
-          throw new Error('expected tip rack to be in a slot')
-        }
-        messageNode = (
-          <Trans
-            t={t}
-            i18nKey={'pickup_tip'}
-            values={{
-              well_name: wellName,
-              labware: getLabwareDisplayName(
-                labwareRenderInfoById[labwareId].labwareDef
-              ),
-              labware_location: labwareLocation.slotName,
-            }}
-          />
-        )
-        break
-      }
-      case 'pause': {
-        messageNode =
-          commandDetailsOrSummary.params?.message ??
-          commandDetailsOrSummary.commandType
-        break
-      }
-      case 'loadLabware':
-      case 'loadPipette':
-      case 'loadModule': {
-        messageNode = (
-          <ProtocolSetupInfo setupCommand={commandDetailsOrSummary} />
-        )
-        break
-      }
-      case 'custom': {
-        messageNode =
-          commandDetailsOrSummary.params?.legacyCommandText ??
-          commandDetailsOrSummary.commandType
-        break
-      }
-      default: {
-        messageNode = commandDetailsOrSummary.commandType
-        break
-      }
+  const displayCommand =
+    analysisCommand !== null && runCommand === null
+      ? analysisCommand
+      : runCommand
+
+  if (displayCommand === null) {
+    console.warn(
+      'display command should never be null, command text could find no source'
+    )
+    return null
+  }
+  // params will not exist on command summaries
+  switch (displayCommand.commandType) {
+    case 'delay': {
+      // TODO: IMMEDIATELY address displaying real comments
+      messageNode = (
+        <>
+          <Flex
+            textTransform={TEXT_TRANSFORM_UPPERCASE}
+            padding={SPACING_1}
+            id={`RunDetails_CommandList`}
+          >
+            {t('comment')}
+          </Flex>
+          {displayCommand != null ? displayCommand.result : null}
+        </>
+      )
+      break
     }
-  } else {
-    // this must be a run command summary
-    messageNode = commandDetailsOrSummary.commandType
+    case 'pickUpTip': {
+      // protocolData should never be null as we don't render the `RunDetails` unless we have an analysis
+      // but we're experiencing a zombie children issue, see https://github.com/Opentrons/opentrons/pull/9091
+      if (protocolData == null) {
+        return null
+      }
+      const { wellName, labwareId } = displayCommand.params
+      const labwareLocation = getLabwareLocation(
+        labwareId,
+        protocolData.commands
+      )
+      if (!('slotName' in labwareLocation)) {
+        throw new Error('expected tip rack to be in a slot')
+      }
+      messageNode = (
+        <Trans
+          t={t}
+          i18nKey={'pickup_tip'}
+          values={{
+            well_name: wellName,
+            labware: getLabwareDisplayName(
+              labwareRenderInfoById[labwareId].labwareDef
+            ),
+            labware_location: labwareLocation.slotName,
+          }}
+        />
+      )
+      break
+    }
+    case 'pause': {
+      messageNode = displayCommand.params?.message ?? displayCommand.commandType
+      break
+    }
+    case 'loadLabware':
+    case 'loadPipette':
+    case 'loadModule': {
+      messageNode = <ProtocolSetupInfo setupCommand={displayCommand} />
+      break
+    }
+    case 'custom': {
+      messageNode =
+        displayCommand.params?.legacyCommandText ?? displayCommand.commandType
+      break
+    }
+    default: {
+      messageNode = displayCommand.commandType
+      break
+    }
   }
 
   return (

--- a/app/src/organisms/RunDetails/CommandText.tsx
+++ b/app/src/organisms/RunDetails/CommandText.tsx
@@ -39,7 +39,6 @@ export function CommandText(props: Props): JSX.Element | null {
   // params will not exist on command summaries
   switch (displayCommand.commandType) {
     case 'delay': {
-      // TODO: IMMEDIATELY address displaying real comments
       messageNode = (
         <>
           <Flex

--- a/app/src/organisms/RunDetails/__tests__/CommandText.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/CommandText.test.tsx
@@ -38,7 +38,13 @@ const render = (props: React.ComponentProps<typeof CommandText>) => {
   })[0]
 }
 
-const MOCK_COMMAND_DETAILS = {
+const MOCK_ANALYSIS_COMMAND: Command = {
+  id: 'some_id',
+  commandType: 'custom',
+  status: 'queued',
+  params: {},
+}
+const MOCK_COMMAND_DETAILS: Command = {
   id: '123',
   commandType: 'custom',
   params: {},
@@ -46,9 +52,9 @@ const MOCK_COMMAND_DETAILS = {
   result: {},
   startedAt: 'start timestamp',
   completedAt: 'end timestamp',
-} as Command
+}
 
-const MOCK_PAUSE_COMMAND = {
+const MOCK_PAUSE_COMMAND: Command = {
   id: '1234',
   commandType: 'pause',
   params: { message: 'THIS IS THE PAUSE MESSAGE' },
@@ -78,28 +84,25 @@ describe('CommandText', () => {
   })
   it('renders correct command text for custom legacy commands', () => {
     const { getByText } = render({
-      commandDetailsOrSummary: {
+      analysisCommand: MOCK_ANALYSIS_COMMAND,
+      runCommand: {
         ...MOCK_COMMAND_DETAILS,
-        params: {
-          legacyCommandText: 'legacy command text',
-        },
-      } as Command,
+        params: { legacyCommandText: 'legacy command text' },
+      },
     })
     getByText('legacy command text')
   })
   it('renders correct command text for pause commands', () => {
     const { getByText } = render({
-      commandDetailsOrSummary: {
-        ...MOCK_PAUSE_COMMAND,
-      } as Command,
+      analysisCommand: null,
+      runCommand: MOCK_PAUSE_COMMAND,
     })
     getByText('THIS IS THE PAUSE MESSAGE')
   })
   it('renders correct command text for load commands', () => {
     const { getByText } = render({
-      commandDetailsOrSummary: {
-        ...MOCK_LOAD_COMMAND,
-      } as Command,
+      analysisCommand: null,
+      runCommand: MOCK_LOAD_COMMAND as Command,
     })
     getByText('Mock Protocol Setup Step')
   })
@@ -119,7 +122,8 @@ describe('CommandText', () => {
       },
     } as any)
     const { getByText } = render({
-      commandDetailsOrSummary: {
+      analysisCommand: null,
+      runCommand: {
         ...MOCK_COMMAND_DETAILS,
         commandType: 'pickUpTip',
         params: {


### PR DESCRIPTION
# Overview

Pairing credit to @b-cooper!

This PR fixes the flashing that was happening in the run log log when a command becomes active. Previously the command text would flash from showing it's details to displaying it's command type. 

Closes #9157

# Changelog
- Fix flashing command text in run log

# Review requests
Run a protocol and watch the run log, flashing should not happen anymore
# Risk assessment
Low