### PR TITLE
refactor(app): add support for mapping protocol engine drop tip commands

### DIFF
--- a/app/src/assets/localization/en/run_details.json
+++ b/app/src/assets/localization/en/run_details.json
@@ -47,6 +47,7 @@
   "load_labware_info_protocol_setup": "Load {{labware_loadname}} v{{labware_version}} in {{module_name}} in Slot {{slot_number}}",
   "load_labware_info_protocol_setup_plural": "Load {{labware_loadname}} v{{labware_version}} in {{module_name}}",
   "pickup_tip": "Picking up tip from {{well_name}} of {{labware}} in {{labware_location}}",
+  "drop_tip": "Dropping tip in {{well_name}} of {{labware}} in {{labware_location}}",
   "end_of_protocol": "End of protocol",
   "comment": "Comment",
   "anticipated": "Anticipated steps",

--- a/app/src/organisms/ProtocolSetup/utils/getLabwareLocation.ts
+++ b/app/src/organisms/ProtocolSetup/utils/getLabwareLocation.ts
@@ -4,10 +4,15 @@ import type {
   LabwareLocation,
 } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
 
+const TRASH_ID = 'fixedTrash'
+
 export const getLabwareLocation = (
   labwareId: string,
   commands: Command[]
 ): LabwareLocation => {
+  if (labwareId === TRASH_ID) {
+    return { slotName: '12' }
+  }
   const labwareLocation = commands.find(
     (command: Command): command is LoadLabwareCommand =>
       command.commandType === 'loadLabware' &&

--- a/app/src/organisms/RunDetails/CommandText.tsx
+++ b/app/src/organisms/RunDetails/CommandText.tsx
@@ -15,6 +15,8 @@ import { useProtocolDetails } from './hooks'
 import { getLabwareLocation } from '../ProtocolSetup/utils/getLabwareLocation'
 import { useLabwareRenderInfoById } from '../ProtocolSetup/hooks'
 
+const TRASH_ID = 'fixedTrash'
+
 interface Props {
   commandDetailsOrSummary: Command | RunCommandSummary
 }
@@ -43,6 +45,35 @@ export function CommandText(props: Props): JSX.Element | null {
               ? commandDetailsOrSummary.result
               : null}
           </>
+        )
+        break
+      }
+      case 'dropTip': {
+        // protocolData should never be null as we don't render the `RunDetails` unless we have an analysis
+        // but we're experiencing a zombie children issue, see https://github.com/Opentrons/opentrons/pull/9091
+        if (protocolData == null) {
+          return null
+        }
+        const { wellName, labwareId } = commandDetailsOrSummary.params
+        const labwareLocation = getLabwareLocation(
+          labwareId,
+          protocolData.commands
+        )
+        if (!('slotName' in labwareLocation)) {
+          throw new Error('expected tip rack to be in a slot')
+        }
+        messageNode = (
+          <Trans
+            t={t}
+            i18nKey={'drop_tip'}
+            values={{
+              well_name: wellName,
+              labware: labwareId === TRASH_ID ? 'Opentrons Fixed Trash' : getLabwareDisplayName(
+                labwareRenderInfoById[labwareId].labwareDef
+              ),
+              labware_location: labwareLocation.slotName,
+            }}
+          />
         )
         break
       }

--- a/app/src/organisms/RunDetails/CommandText.tsx
+++ b/app/src/organisms/RunDetails/CommandText.tsx
@@ -68,9 +68,12 @@ export function CommandText(props: Props): JSX.Element | null {
             i18nKey={'drop_tip'}
             values={{
               well_name: wellName,
-              labware: labwareId === TRASH_ID ? 'Opentrons Fixed Trash' : getLabwareDisplayName(
-                labwareRenderInfoById[labwareId].labwareDef
-              ),
+              labware:
+                labwareId === TRASH_ID
+                  ? 'Opentrons Fixed Trash'
+                  : getLabwareDisplayName(
+                      labwareRenderInfoById[labwareId].labwareDef
+                    ),
               labware_location: labwareLocation.slotName,
             }}
           />


### PR DESCRIPTION
# Overview

Now that the Protocol Engine understands drop tip commands, let's map them to data-based run log entries

# Review requests

- [ ] Run a protocol that involves dropping tips and ensure that the run log appears as expected

# Risk assessment

low