### PR TITLE
refactor(app): update not connected color to orange

### DIFF
--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/ModuleInfo.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/ModuleInfo.tsx
@@ -12,7 +12,7 @@ import {
   FONT_STYLE_ITALIC,
   FONT_SIZE_BODY_1,
   FONT_SIZE_CAPTION,
-  COLOR_ERROR,
+  COLOR_WARNING,
   COLOR_SUCCESS,
   ALIGN_CENTER,
   JUSTIFY_CENTER,
@@ -64,7 +64,7 @@ export const ModuleInfo = (props: ModuleInfoProps): JSX.Element => {
         <Flex flexDirection={DIRECTION_ROW} alignItems={ALIGN_CENTER}>
           <Icon
             name={isAttached ? 'check-circle' : 'alert-circle'}
-            color={isAttached ? COLOR_SUCCESS : COLOR_ERROR}
+            color={isAttached ? COLOR_SUCCESS : COLOR_WARNING}
             key="icon"
             size="10px"
             marginRight={SPACING_1}


### PR DESCRIPTION
# Overview

This PR changes the module not connected icon color from red to orange for consistency. closes #9136

![image](https://user-images.githubusercontent.com/14794021/148552655-8eff6bef-7e6a-40bf-994c-0dddb378f0ae.png)

# Changelog

- changed color from `COLOR_ERROR` to `COLOR_WARNING`.

# Review requests

- check that the "Not Connected" alert icon is orange.

# Risk assessment

low
