### PR TITLE
refactor(can): Hardware socket script

### DIFF
--- a/hardware/README.md
+++ b/hardware/README.md
@@ -14,29 +14,29 @@ your network.
 
 The `opentrons-hardware` package includes some utility scripts.
 
-### Header Generator
+### Simulated CAN bus
 
-This will generate a C++ header file defining constants shared between firmware and the `opentrons-hardware` package.
+Runs a simulated CAN network using a socket server. This supports the `opentrons` interface.
 
 #### Usage
 
 ```
-opentrons_generate_header --target TARGET
+opentrons_sim_can_bus [-h] [--port PORT]
 ```
 
-Example: `opentrons_generate_header --target some_file.h`
+Example: `opentrons_sim_can_bus --port 12345`
 
 ### CAN Communication
 
 This is a tool for sending messages to firmware (or simulator) over CAN bus. The CAN bus can either be a [python-can](https://python-can.readthedocs.io/en/master/interfaces.html) defined interface or `opentrons`.
 
-**SocketCan's vcan (virtual can network) only works on Linux.** Firmware simulations on non-Linux computers require `opentrons` as it uses a plain old socket CAN network simulation.
+**SocketCan's vcan (virtual can network) only works on Linux.** Firmware simulations on non-Linux computers require `opentrons` as it uses a plain old socket CAN network simulation. [Simulated CAN bus](#simulated-can-bus) must be started to use the `opentrons` interface.
 
 #### Usage
 
 ```
 opentrons_can_comm [-h] --interface INTERFACE [--bitrate BITRATE]
-                   [--channel CHANNEL] [--port PORT]
+                   [--channel CHANNEL] [--port PORT] [--host HOST]
 ```
 
 Example using socketcan: `opentrons_can_comm --interface socketcan --channel vcan0`

--- a/hardware/opentrons_hardware/scripts/can_args.py
+++ b/hardware/opentrons_hardware/scripts/can_args.py
@@ -33,6 +33,13 @@ def add_can_args(parser: ArgumentParser) -> ArgumentParser:
         required=False,
         help="port to use for opentrons interface",
     )
+    parser.add_argument(
+        "--host",
+        type=str,
+        default="localhost",
+        required=False,
+        help="host to connect to for opentrons interface",
+    )
     return parser
 
 
@@ -46,7 +53,7 @@ async def build_driver(args: Namespace) -> AbstractCanDriver:
         A driver.
     """
     if args.interface == "opentrons":
-        return await SocketDriver.build(port=args.port)
+        return await SocketDriver.build(port=args.port, host=args.host)
     else:
         return await CanDriver.build(
             interface=args.interface, bitrate=args.bitrate, channel=args.channel

--- a/hardware/opentrons_hardware/scripts/sim_socket_can.py
+++ b/hardware/opentrons_hardware/scripts/sim_socket_can.py
@@ -16,7 +16,7 @@ class ConnectionHandler:
 
     _writers: List[asyncio.StreamWriter]
 
-    BYTES_TO_READ = 64 + 4 + 4   # Max data size + arbitration id + total size
+    BYTES_TO_READ = 64 + 4 + 4  # Max data size + arbitration id + total size
 
     def __init__(self) -> None:
         """Constructor."""

--- a/hardware/opentrons_hardware/scripts/sim_socket_can.py
+++ b/hardware/opentrons_hardware/scripts/sim_socket_can.py
@@ -1,0 +1,96 @@
+"""A driver that emulates CAN over socket."""
+from __future__ import annotations
+
+import argparse
+import logging
+import asyncio
+from logging.config import dictConfig
+from typing import List
+
+
+log = logging.getLogger(__name__)
+
+
+class ConnectionHandler:
+    """The class that manages client connections."""
+
+    _writers: List[asyncio.StreamWriter]
+
+    BYTES_TO_READ = 64 + 4 + 4   # Max data size + arbitration id + total size
+
+    def __init__(self) -> None:
+        """Constructor."""
+        self._writers = []
+
+    async def __call__(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        """Server accept connection callback."""
+        log.info("Handling new connection")
+
+        self._writers.append(writer)
+
+        while True:
+            data = await reader.read(self.BYTES_TO_READ)
+            if not data:
+                log.warning("client disconnected.")
+                break
+
+            for w in self._writers:
+                if w != writer:
+                    w.write(data)
+
+        self._writers.remove(writer)
+        writer.close()
+
+
+async def run(port: int) -> None:
+    """Run the application."""
+    connection_handler = ConnectionHandler()
+    server = await asyncio.start_server(connection_handler, port=port)
+    await server.serve_forever()
+
+
+LOG_CONFIG = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "basic": {"format": "%(asctime)s %(name)s %(levelname)s %(message)s"}
+    },
+    "handlers": {
+        "stream_handler": {
+            "class": "logging.StreamHandler",
+            "formatter": "basic",
+            "level": logging.DEBUG,
+        },
+    },
+    "loggers": {
+        "": {
+            "handlers": ["stream_handler"],
+            "level": logging.DEBUG,
+        },
+    },
+}
+
+
+def main() -> None:
+    """Entry point."""
+    dictConfig(LOG_CONFIG)
+
+    parser = argparse.ArgumentParser(description="Sim CAN over socket.")
+
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=9898,
+        required=False,
+        help="port to listen on",
+    )
+
+    args = parser.parse_args()
+
+    asyncio.run(run(args.port))
+
+
+if __name__ == "__main__":
+    main()

--- a/hardware/opentrons_hardware/scripts/sim_socket_can.py
+++ b/hardware/opentrons_hardware/scripts/sim_socket_can.py
@@ -36,6 +36,8 @@ class ConnectionHandler:
                 log.warning("client disconnected.")
                 break
 
+            log.info("Read %d bytes", len(data))
+
             for w in self._writers:
                 if w != writer:
                     w.write(data)
@@ -46,6 +48,7 @@ class ConnectionHandler:
 
 async def run(port: int) -> None:
     """Run the application."""
+    log.info("Starting simulated CAN bus on port %d", port)
     connection_handler = ConnectionHandler()
     server = await asyncio.start_server(connection_handler, port=port)
     await server.serve_forever()

--- a/hardware/setup.py
+++ b/hardware/setup.py
@@ -79,6 +79,7 @@ if __name__ == "__main__":
         entry_points={
             "console_scripts": [
                 "opentrons_can_comm = opentrons_hardware.scripts.can_comm:main",
+                "opentrons_sim_can_bus = opentrons_hardware.scripts.sim_socket_can:main",
             ]
         },
     )

--- a/hardware/setup.py
+++ b/hardware/setup.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
         entry_points={
             "console_scripts": [
                 "opentrons_can_comm = opentrons_hardware.scripts.can_comm:main",
-                "opentrons_sim_can_bus = opentrons_hardware.scripts.sim_socket_can:main",
+                "opentrons_sim_can_bus = opentrons_hardware.scripts.sim_socket_can:main",  # noqa: E501
             ]
         },
     )


### PR DESCRIPTION
# Overview

A slight refactor to make the plain old socket CAN driver more usable. 

`SocketDriver` had been a server which required that the `SocketDriver` be started before the FW simulators. A limitation.

This PR will bring us one step towards being able to run integration tests on Macs.

# Changelog

- `SocketDriver` becomes a client.
- The server is moved into its own script `opentrons_sim_can_bus`. 
- docs updated

# Review requests

Should `opentrons_sim_can_bus` be in the ot3_firmware repo? I'm somewhat ambivalent which likely means it should stay here.

# Risk assessment

None
