### PR TITLE
refactor(app): home robot after LPC completes

### DIFF
--- a/app/src/assets/localization/en/labware_position_check.json
+++ b/app/src/assets/localization/en/labware_position_check.json
@@ -32,7 +32,7 @@
   "no_labware_offsets": "No Labware Offset",
   "confirm_position_and_move": "Confirm position, move to slot {{next_slot}}",
   "confirm_position_and_pick_up_tip": "Confirm position, pick up tip",
-  "confirm_position_and_return_tip": "Confirm position, return tip to Slot {{next_slot}}",
+  "confirm_position_and_return_tip": "Confirm position, return tip to Slot {{next_slot}} and home",
   "close_and_apply_offset_data": "Close and apply labware offset data",
   "error_modal_header": "Something went wrong",
   "error_modal_text": "There was an error processing your request on the robot",


### PR DESCRIPTION
# Overview
This PR homes the robot after LPC completes

closes #9153

# Changelog

- Home robot after LPC completes

# Review requests
Run through LPC, on the last LPC screen the CTA should be changed to indicate a home is about to happen, and when you hit the CTA, the robot should home after dropping tip

# Risk assessment
Low
