### PR TITLE
refactor(robot-server): fix cross endpoint dependency with run commands

### DIFF
--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -16,7 +16,7 @@ from robot_server.service.json_api import (
 from ..run_models import Run, RunCommandSummary
 from ..engine_store import EngineStore
 from ..dependencies import get_engine_store
-from .base_router import RunNotFound, RunStopped, get_run
+from .base_router import RunNotFound, RunStopped, get_run_data_from_url
 
 commands_router = APIRouter()
 
@@ -46,7 +46,7 @@ class CommandNotFound(ErrorDetails):
 async def create_run_command(
     request_body: RequestModel[pe_commands.CommandCreate],
     engine_store: EngineStore = Depends(get_engine_store),
-    run: SimpleBody[Run] = Depends(get_run),
+    run: Run = Depends(get_run_data_from_url),
 ) -> PydanticResponse[SimpleBody[pe_commands.Command]]:
     """Enqueue a protocol command.
 
@@ -59,8 +59,8 @@ async def create_run_command(
             `GET /runs/{runId}`. Present to ensure 404 if run
             not found.
     """
-    if not run.data.current:
-        raise RunStopped(detail=f"Run {run.data.id} is not the current run").as_error(
+    if not run.current:
+        raise RunStopped(detail=f"Run {run.id} is not the current run").as_error(
             status.HTTP_400_BAD_REQUEST
         )
 
@@ -87,7 +87,7 @@ async def create_run_command(
     },
 )
 async def get_run_commands(
-    run: SimpleBody[Run] = Depends(get_run),
+    run: Run = Depends(get_run_data_from_url),
 ) -> PydanticResponse[SimpleMultiBody[RunCommandSummary]]:
     """Get a summary of all commands in a run.
 
@@ -96,7 +96,7 @@ async def get_run_commands(
             `GET /runs/{runId}`
     """
     return PydanticResponse(
-        content=SimpleMultiBody.construct(data=run.data.commands),
+        content=SimpleMultiBody.construct(data=run.commands),
         status_code=status.HTTP_200_OK,
     )
 
@@ -118,7 +118,7 @@ async def get_run_commands(
 async def get_run_command(
     commandId: str,
     engine_store: EngineStore = Depends(get_engine_store),
-    run: SimpleBody[Run] = Depends(get_run),
+    run: Run = Depends(get_run_data_from_url),
 ) -> PydanticResponse[SimpleBody[pe_commands.Command]]:
     """Get a specific command from a run.
 
@@ -129,7 +129,7 @@ async def get_run_command(
             `GET /run/{runId}`. Present to ensure 404 if run
             not found.
     """
-    engine_state = engine_store.get_state(run.data.id)
+    engine_state = engine_store.get_state(run.id)
     try:
         command = engine_state.commands.get(commandId)
     except pe_errors.CommandDoesNotExistError as e:

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -13,7 +13,7 @@ from opentrons.protocol_engine import (
 )
 
 from robot_server.errors import ApiError
-from robot_server.service.json_api import RequestModel, SimpleBody
+from robot_server.service.json_api import RequestModel
 from robot_server.runs.run_models import Run, RunCommandSummary
 from robot_server.runs.engine_store import EngineStore
 from robot_server.runs.router.commands_router import (
@@ -59,7 +59,7 @@ async def test_create_run_command(decoy: Decoy, engine_store: EngineStore) -> No
     result = await create_run_command(
         request_body=RequestModel(data=command_request),
         engine_store=engine_store,
-        run=SimpleBody(data=run),
+        run=run,
     )
 
     assert result.content.data == output_command
@@ -93,7 +93,7 @@ async def test_create_run_command_not_current(
         await create_run_command(
             request_body=RequestModel(data=command_request),
             engine_store=engine_store,
-            run=SimpleBody(data=run),
+            run=run,
         )
 
     assert exc_info.value.status_code == 400
@@ -122,7 +122,7 @@ async def test_get_run_commands() -> None:
         labwareOffsets=[],
     )
 
-    result = await get_run_commands(run=SimpleBody(data=run))
+    result = await get_run_commands(run=run)
 
     assert result.content.data == [command_summary]
     assert result.status_code == 200
@@ -169,7 +169,7 @@ async def test_get_run_command_by_id(
     result = await get_run_command(
         commandId="command-id",
         engine_store=engine_store,
-        run=SimpleBody(data=run),
+        run=run,
     )
 
     assert result.content.data == command
@@ -205,7 +205,7 @@ async def test_get_run_command_missing_command(
         await get_run_command(
             commandId="command-id",
             engine_store=engine_store,
-            run=SimpleBody(data=run),
+            run=run,
         )
 
     assert exc_info.value.status_code == 404


### PR DESCRIPTION
## Overview

Fixes the /runs/:run_id/commands endpoints after #9188 broke them.

## Changelog

See PR title

## Review requests

- LPC works again

## Risk assessment

Low
