### PR TITLE
refactor(app): only fetch run log command details when command is in view

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -42,6 +42,7 @@
     "react-dom": "17.0.1",
     "react-hot-loader": "4.13.0",
     "react-i18next": "^11.7.3",
+    "react-intersection-observer": "^8.33.1",
     "react-redux": "7.2.1",
     "react-router-dom": "5.1.1",
     "redux": "4.0.5",

--- a/app/src/organisms/RunDetails/CommandItem.tsx
+++ b/app/src/organisms/RunDetails/CommandItem.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
+import { useInView } from 'react-intersection-observer'
 import {
   DIRECTION_ROW,
   Flex,
@@ -67,10 +68,16 @@ const WRAPPER_STYLE_BY_STATUS: {
 const commandIsComplete = (status: RunCommandSummary['status']): boolean =>
   status === 'succeeded' || status === 'failed'
 
+// minimum delay in MS for observer notifications
+const OBSERVER_DELAY = 300
+
 export function CommandItem(props: CommandItemProps): JSX.Element | null {
   const { analysisCommand, runCommandSummary, runStatus } = props
   const { t } = useTranslation('run_details')
   const currentRunId = useCurrentRunId()
+  const [commandItemRef, isInView] = useInView({
+    delay: OBSERVER_DELAY,
+  })
   const [staleTime, setStaleTime] = React.useState<number>(0)
   const isAnticipatedCommand =
     analysisCommand !== null && runCommandSummary === null
@@ -78,7 +85,7 @@ export function CommandItem(props: CommandItemProps): JSX.Element | null {
     currentRunId,
     runCommandSummary?.id ?? null,
     {
-      enabled: !isAnticipatedCommand && runStatus !== 'idle',
+      enabled: !isAnticipatedCommand && runStatus !== 'idle' && isInView,
       staleTime,
     }
   )
@@ -137,7 +144,7 @@ export function CommandItem(props: CommandItemProps): JSX.Element | null {
     flex-direction: ${DIRECTION_COLUMN};
   `
   return (
-    <Flex css={WRAPPER_STYLE}>
+    <Flex css={WRAPPER_STYLE} ref={commandItemRef}>
       {commandStatus === 'running' ? (
         <CurrentCommandLabel runStatus={runStatus} />
       ) : null}

--- a/app/src/organisms/RunDetails/CommandItem.tsx
+++ b/app/src/organisms/RunDetails/CommandItem.tsx
@@ -69,7 +69,7 @@ const commandIsComplete = (status: RunCommandSummary['status']): boolean =>
   status === 'succeeded' || status === 'failed'
 
 // minimum delay in MS for observer notifications
-const OBSERVER_DELAY = 300
+export const OBSERVER_DELAY = 300
 
 export function CommandItem(props: CommandItemProps): JSX.Element | null {
   const { analysisCommand, runCommandSummary, runStatus } = props

--- a/app/src/organisms/RunDetails/CommandItem.tsx
+++ b/app/src/organisms/RunDetails/CommandItem.tsx
@@ -100,7 +100,8 @@ export function CommandItem(props: CommandItemProps): JSX.Element | null {
     }
     if (
       commandDetails?.data.startedAt != null &&
-      commandDetails?.data.completedAt == null
+      commandDetails?.data.completedAt == null &&
+      isInView
     ) {
       refetch()
     }

--- a/app/src/organisms/RunDetails/__tests__/CommandItem.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/CommandItem.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react'
 import { when } from 'jest-when'
+import { useInView } from 'react-intersection-observer'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../i18n'
-import { CommandItem } from '../CommandItem'
+import { CommandItem, OBSERVER_DELAY } from '../CommandItem'
 import { CommandText } from '../CommandText'
 import { CommandTimer } from '../CommandTimer'
 import {
@@ -13,6 +14,7 @@ import { useCurrentRunId } from '../../ProtocolUpload/hooks/useCurrentRunId'
 import type { Command } from '@opentrons/shared-data/protocol/types/schemaV6/command'
 import type { RunCommandSummary } from '@opentrons/api-client'
 
+jest.mock('react-intersection-observer')
 jest.mock('../CommandText')
 jest.mock('../CommandTimer')
 jest.mock('../../ProtocolUpload/hooks/useCurrentRunId')
@@ -31,6 +33,7 @@ const mockUseCommandQuery = useCommandQuery as jest.MockedFunction<
 const mockUseAllCommandsQuery = useAllCommandsQuery as jest.MockedFunction<
   typeof useAllCommandsQuery
 >
+const mockUseInView = useInView as jest.MockedFunction<typeof useInView>
 const render = (props: React.ComponentProps<typeof CommandItem>) => {
   return renderWithProviders(<CommandItem {...props} />, {
     i18nInstance: i18n,
@@ -83,6 +86,9 @@ describe('Run Details Command item', () => {
       .mockReturnValue({
         data: { data: [] },
       } as any)
+    when(mockUseInView)
+      .calledWith({ delay: OBSERVER_DELAY })
+      .mockReturnValue([() => null, true] as any)
   })
 
   it('renders the correct failed status', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17805,6 +17805,11 @@ react-inspector@^5.1.0:
     is-dom "^1.0.0"
     prop-types "^15.0.0"
 
+react-intersection-observer@^8.33.1:
+  version "8.33.1"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-8.33.1.tgz#8e6442cac7052ed63056e191b7539e423e7d5c64"
+  integrity sha512-3v+qaJvp3D1MlGHyM+KISVg/CMhPiOlO6FgPHcluqHkx4YFCLuyXNlQ/LE6UkbODXlQcLOppfX6UMxCEkUhDLw==
+
 react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
# Overview
Another performance follow up to https://github.com/Opentrons/opentrons/pull/9162

This PR makes it so that in the run log  network requests to a command's endpoint do not get triggered unless that specific command is in view

closes #9211
# Changelog

- Only fetch run log command details when command is in view

# Review requests

Upload a protocol and navigate to the run tab. Hit start, and inspect your dev tools — network requests should only be made to command's you can see in your viewport

# Risk assessment
Low (this adds a new dependency though)
