### PR TITLE
refactor(ot3): Hardware unit vector

### DIFF
--- a/hardware/opentrons_hardware/hardware_control/motion_planning/move_utils.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/move_utils.py
@@ -300,10 +300,10 @@ def build_blocks(
             acceleration=0,
             distance=distance - first.distance - final.distance,
         )
-        return (first, coast, final)
+        return first, coast, final
     else:
         # no coast phase for us
-        return (first, Block(0, 0, 0), final)
+        return first, Block(0, 0, 0), final
 
 
 def build_move(

--- a/hardware/opentrons_hardware/hardware_control/motion_planning/types.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/types.py
@@ -186,7 +186,7 @@ class Move:
         distance: AcceptableType,
         max_speed: AcceptableType,
         blocks: Tuple[Block, Block, Block],
-    ) -> "Move":
+    ) -> Move:
         """Build function for Move."""
         return cls(
             unit_vector=unit_vector,
@@ -223,7 +223,7 @@ class AxisConstraints:
         max_acceleration: AcceptableType,
         max_speed_discont: AcceptableType,
         max_direction_change_speed_discont: AcceptableType,
-    ) -> "AxisConstraints":
+    ) -> AxisConstraints:
         """Build AxisConstraints."""
         return cls(
             max_acceleration=np.float64(max_acceleration),


### PR DESCRIPTION
# Overview

Found that is_unit_vector was failing in comparing 0.99999999 to 1.0. .

# Changelog

- changed to use numpy's isclose vs comparing magnitude to 1.0
- Also moved _is_unit_vector to a public member of Coordinates. Seems to make more sense than a classmethod in `Move`.
- Remove quotes from type annotations and redundant parentheses.

# Review requests



# Risk assessment

None