### PR TITLE
refactor(robot-server): Log stop completions

### DIFF
--- a/robot-server/robot_server/runs/router/actions_router.py
+++ b/robot-server/robot_server/runs/router/actions_router.py
@@ -93,6 +93,7 @@ async def create_run_action(
             engine_store.runner.pause()
         elif action.actionType == RunActionType.STOP:
             log.info(f'Stopping run "{runId}".')
+
             # Grab engine_store.runner outside stop_and_log() in case it changes between
             # now and when task_runner runs stop_and_log().
             runner = engine_store.runner

--- a/robot-server/robot_server/runs/router/actions_router.py
+++ b/robot-server/robot_server/runs/router/actions_router.py
@@ -96,9 +96,11 @@ async def create_run_action(
             # Grab engine_store.runner outside stop_and_log() in case it changes between
             # now and when task_runner runs stop_and_log().
             runner = engine_store.runner
+
             async def stop_and_log() -> None:
                 await runner.stop()
                 log.info(f'Stopped run "{runId}".')
+
             task_runner.run(stop_and_log)
 
     except ProtocolEngineStoppedError as e:

--- a/robot-server/robot_server/runs/router/actions_router.py
+++ b/robot-server/robot_server/runs/router/actions_router.py
@@ -93,6 +93,8 @@ async def create_run_action(
             engine_store.runner.pause()
         elif action.actionType == RunActionType.STOP:
             log.info(f'Stopping run "{runId}".')
+            # Grab engine_store.runner outside stop_and_log() in case it changes between
+            # now and when task_runner runs stop_and_log().
             runner = engine_store.runner
             async def stop_and_log() -> None:
                 await runner.stop()

--- a/robot-server/robot_server/runs/router/actions_router.py
+++ b/robot-server/robot_server/runs/router/actions_router.py
@@ -93,7 +93,11 @@ async def create_run_action(
             engine_store.runner.pause()
         elif action.actionType == RunActionType.STOP:
             log.info(f'Stopping run "{runId}".')
-            task_runner.run(engine_store.runner.stop)
+            runner = engine_store.runner
+            async def stop_and_log() -> None:
+                await runner.stop()
+                log.info(f'Stopped run "{runId}".')
+            task_runner.run(stop_and_log)
 
     except ProtocolEngineStoppedError as e:
         raise RunActionNotAllowed(detail=str(e)).as_error(status.HTTP_409_CONFLICT)


### PR DESCRIPTION
Since #9169, stopping a protocol over HTTP involves background work that can take several seconds.

We already log when this background work begins. This PR adds logging for when it ends. This can help debug problems with concurrency and with the lifetime of a run.
