### PR TITLE
refactor(motion-planning): update motion planning script

### DIFF
--- a/hardware/opentrons_hardware/hardware_control/motion_planning/move_manager.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/move_manager.py
@@ -52,7 +52,7 @@ class MoveManager:
         self._clear_blend_log()
         to_blend = self._get_initial_moves_from_targets(origin, target_list)
         assert to_blend, "Check target list"
-
+        log.debug("Motion planning begins.")
         for i in range(iteration_limit):
             blend_log = []
             moveiter = iter(to_blend)

--- a/hardware/opentrons_hardware/hardware_control/motion_planning/move_utils.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/move_utils.py
@@ -313,6 +313,7 @@ def build_move(
     constraints: SystemConstraints,
 ) -> Move:
     """Build a move."""
+    log.debug(f"Build move: {move}")
     initial_speed = find_initial_speed(constraints, move, prev_move)
     final_speed = find_final_speed(constraints, move, next_move)
     final_speed = achievable_final(constraints, move, initial_speed, final_speed)

--- a/hardware/opentrons_hardware/hardware_control/motion_planning/types.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/types.py
@@ -1,5 +1,6 @@
 """Motion planning types."""
 from __future__ import annotations
+import logging
 import enum
 import dataclasses
 import numpy as np  # type: ignore[import]
@@ -14,6 +15,7 @@ from typing import (
     Union,
 )
 
+log = logging.getLogger(__name__)
 
 AcceptableType = Union[SupportsFloat, np.float64]
 

--- a/hardware/opentrons_hardware/hardware_control/motion_planning/types.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/types.py
@@ -6,6 +6,7 @@ import dataclasses
 import numpy as np  # type: ignore[import]
 from typing import (
     cast,
+    Any,
     SupportsFloat,
     Dict,
     Iterator,
@@ -196,6 +197,10 @@ class Move:
             max_speed=np.float64(max_speed),
             blocks=blocks,
         )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return Move a dict."""
+        return dataclasses.asdict(self)
 
 
 @dataclasses.dataclass(frozen=True)

--- a/hardware/opentrons_hardware/scripts/.gitignore
+++ b/hardware/opentrons_hardware/scripts/.gitignore
@@ -1,0 +1,4 @@
+# Ignore all simulator configurations
+*.json
+# ...unless specifically allowed.
+!motion_params.json

--- a/hardware/opentrons_hardware/scripts/motion_params.json
+++ b/hardware/opentrons_hardware/scripts/motion_params.json
@@ -33,12 +33,12 @@
     },
     {
       "coordinates": [400, 200, 0, 0],
-      "max_speed": 500
+      "max_speed": 30
     },
     {
       "coordinates": [300, 300, 150, 0],
-      "max_speed": 500
+      "max_speed": 20
     }
   ],
-  "iteration_limit": 10
+  "iteration_limit": 1
 }

--- a/hardware/opentrons_hardware/scripts/motion_params.json
+++ b/hardware/opentrons_hardware/scripts/motion_params.json
@@ -3,41 +3,42 @@
         "X": {
             "max_acceleration": 10000,
             "max_speed_discont": 40,
-            "max_direction_change_speed_discont": 20
+            "max_direction_change_speed_discont": 30
         },
         "Y": {
             "max_acceleration": 10000,
             "max_speed_discont": 40,
-            "max_direction_change_speed_discont": 20
+            "max_direction_change_speed_discont": 30
         },
         "Z": {
             "max_acceleration": 10000,
             "max_speed_discont": 40,
-            "max_direction_change_speed_discont": 20
+            "max_direction_change_speed_discont": 30
         },
         "A": {
-            "max_acceleration": 10000,
-            "max_speed_discont": 40,
-            "max_direction_change_speed_discont": 20
+            "max_acceleration": 1000,
+            "max_speed_discont": 100,
+            "max_direction_change_speed_discont": 30
         }
     },
     "origin": [0, 0, 0, 0],
     "target_list": [
         {
-            "coordinates": [100, 100, 0, 0],
-            "max_speed": 400
+            "coordinates": [100, 0, 0, 0],
+            "max_speed": 30
         },
         {
-            "coordinates": [200, 0, 0, 0],
-            "max_speed": 200
+            "coordinates": [200, 100, 0, 0],
+            "max_speed": 20
         },
         {
-            "coordinates": [300, 0, 0, 0],
-            "max_speed": 400
+            "coordinates": [400, 200, 0, 0],
+            "max_speed": 500
         },
         {
-            "coordinates": [200, 0, 0, 0],
-            "max_speed": 400
+            "coordinates": [300, 300, 150, 0],
+            "max_speed": 500
         }
-    ]
+    ],
+    "iteration_limit": 10
 }

--- a/hardware/opentrons_hardware/scripts/motion_params.json
+++ b/hardware/opentrons_hardware/scripts/motion_params.json
@@ -1,0 +1,43 @@
+{
+    "constraints": {
+        "X": {
+            "max_acceleration": 10000,
+            "max_speed_discont": 40,
+            "max_direction_change_speed_discont": 20
+        },
+        "Y": {
+            "max_acceleration": 10000,
+            "max_speed_discont": 40,
+            "max_direction_change_speed_discont": 20
+        },
+        "Z": {
+            "max_acceleration": 10000,
+            "max_speed_discont": 40,
+            "max_direction_change_speed_discont": 20
+        },
+        "A": {
+            "max_acceleration": 10000,
+            "max_speed_discont": 40,
+            "max_direction_change_speed_discont": 20
+        }
+    },
+    "origin": [0, 0, 0, 0],
+    "target_list": [
+        {
+            "coordinates": [100, 100, 0, 0],
+            "max_speed": 400
+        },
+        {
+            "coordinates": [200, 0, 0, 0],
+            "max_speed": 200
+        },
+        {
+            "coordinates": [300, 0, 0, 0],
+            "max_speed": 400
+        },
+        {
+            "coordinates": [200, 0, 0, 0],
+            "max_speed": 400
+        }
+    ]
+}

--- a/hardware/opentrons_hardware/scripts/motion_params.json
+++ b/hardware/opentrons_hardware/scripts/motion_params.json
@@ -1,44 +1,44 @@
 {
-    "constraints": {
-        "X": {
-            "max_acceleration": 10000,
-            "max_speed_discont": 40,
-            "max_direction_change_speed_discont": 30
-        },
-        "Y": {
-            "max_acceleration": 10000,
-            "max_speed_discont": 40,
-            "max_direction_change_speed_discont": 30
-        },
-        "Z": {
-            "max_acceleration": 10000,
-            "max_speed_discont": 40,
-            "max_direction_change_speed_discont": 30
-        },
-        "A": {
-            "max_acceleration": 1000,
-            "max_speed_discont": 100,
-            "max_direction_change_speed_discont": 30
-        }
+  "constraints": {
+    "X": {
+      "max_acceleration": 10000,
+      "max_speed_discont": 40,
+      "max_direction_change_speed_discont": 30
     },
-    "origin": [0, 0, 0, 0],
-    "target_list": [
-        {
-            "coordinates": [100, 0, 0, 0],
-            "max_speed": 30
-        },
-        {
-            "coordinates": [200, 100, 0, 0],
-            "max_speed": 20
-        },
-        {
-            "coordinates": [400, 200, 0, 0],
-            "max_speed": 500
-        },
-        {
-            "coordinates": [300, 300, 150, 0],
-            "max_speed": 500
-        }
-    ],
-    "iteration_limit": 10
+    "Y": {
+      "max_acceleration": 10000,
+      "max_speed_discont": 40,
+      "max_direction_change_speed_discont": 30
+    },
+    "Z": {
+      "max_acceleration": 10000,
+      "max_speed_discont": 40,
+      "max_direction_change_speed_discont": 30
+    },
+    "A": {
+      "max_acceleration": 1000,
+      "max_speed_discont": 100,
+      "max_direction_change_speed_discont": 30
+    }
+  },
+  "origin": [0, 0, 0, 0],
+  "target_list": [
+    {
+      "coordinates": [100, 0, 0, 0],
+      "max_speed": 30
+    },
+    {
+      "coordinates": [200, 100, 0, 0],
+      "max_speed": 20
+    },
+    {
+      "coordinates": [400, 200, 0, 0],
+      "max_speed": 500
+    },
+    {
+      "coordinates": [300, 300, 150, 0],
+      "max_speed": 500
+    }
+  ],
+  "iteration_limit": 10
 }

--- a/hardware/opentrons_hardware/scripts/plan_motion.py
+++ b/hardware/opentrons_hardware/scripts/plan_motion.py
@@ -42,9 +42,11 @@ LOG_CONFIG: Dict[str, Any] = {
 
 def main() -> None:
     """Entry point."""
+
     parser = argparse.ArgumentParser(description="Motion planning script.")
     parser.add_argument(
         "--params-file-path",
+        "-p",
         type=str,
         required=False,
         default=os.path.join(os.path.dirname(__file__) + "/motion_params.json"),
@@ -52,10 +54,19 @@ def main() -> None:
     )
     parser.add_argument(
         "--debug",
+        "-d",
         type=bool,
         required=False,
         default=False,
         help="set logging level to debug",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=str,
+        required=False,
+        default=os.path.join(os.path.dirname(__file__) + "/motion_output.json"),
+        help="the output file path",
     )
     args = parser.parse_args()
 
@@ -77,11 +88,18 @@ def main() -> None:
     ]
 
     manager = move_manager.MoveManager(constraints=constraints)
-    manager.plan_motion(
+    _, blend_log = manager.plan_motion(
         origin=origin,
         target_list=target_list,
         iteration_limit=params["iteration_limit"],
     )
+
+    output = {
+        index: [v.to_dict() for v in value] for index, value in enumerate(blend_log)
+    }
+
+    with open(args.output, "w") as f:
+        json.dump(output, f, indent=2)
 
 
 if __name__ == "__main__":

--- a/hardware/opentrons_hardware/scripts/plan_motion.py
+++ b/hardware/opentrons_hardware/scripts/plan_motion.py
@@ -13,11 +13,12 @@ from opentrons_hardware.hardware_control.motion_planning.types import (
     MoveTarget,
     Coordinates,
 )
+from typing import Dict, Any
 
 
 log = logging.getLogger(__name__)
 
-LOG_CONFIG = {
+LOG_CONFIG: Dict[str, Any] = {
     "version": 1,
     "disable_existing_loggers": False,
     "formatters": {
@@ -33,7 +34,7 @@ LOG_CONFIG = {
     "loggers": {
         "": {
             "handlers": ["stream_handler"],
-            "level": logging.INFO,
+            "level": logging.DEBUG,
         },
     },
 }
@@ -41,34 +42,47 @@ LOG_CONFIG = {
 
 def main() -> None:
     """Entry point."""
-    dictConfig(LOG_CONFIG)
 
     parser = argparse.ArgumentParser(description="Motion planning script.")
     parser.add_argument(
         "--params-file-path",
         type=str,
         required=False,
-        default=os.path.join(os.path.dirname(__file__) + '/motion_params.json'),
-        help="the parameter file path"
+        default=os.path.join(os.path.dirname(__file__) + "/motion_params.json"),
+        help="the parameter file path",
+    )
+    parser.add_argument(
+        "--debug",
+        type=bool,
+        required=False,
+        default=False,
+        help="set logging level to debug",
     )
     args = parser.parse_args()
+
+    if args.debug:
+        LOG_CONFIG["handlers"]["stream_handler"]["level"] = logging.DEBUG
+        LOG_CONFIG["loggers"][""]["level"] = logging.DEBUG
+    dictConfig(LOG_CONFIG)
 
     with open(args.params_file_path, "r") as f:
         params = json.load(f)
 
     constraints: SystemConstraints = {
-        axis: AxisConstraints.build(
-            **params['constraints'][axis.name]) for axis in Axis
+        axis: AxisConstraints.build(**params["constraints"][axis.name]) for axis in Axis
     }
-    origin = Coordinates(*params['origin'])
+    origin = Coordinates(*params["origin"])
     target_list = [
-        MoveTarget.build(
-            Coordinates(*target['coordinates']), target['max_speed'])
-            for target in params['target_list']
+        MoveTarget.build(Coordinates(*target["coordinates"]), target["max_speed"])
+        for target in params["target_list"]
     ]
 
     manager = move_manager.MoveManager(constraints=constraints)
-    manager.plan_motion(origin=origin, target_list=target_list)
+    manager.plan_motion(
+        origin=origin,
+        target_list=target_list,
+        iteration_limit=params["iteration_limit"],
+    )
 
 
 if __name__ == "__main__":

--- a/hardware/opentrons_hardware/scripts/plan_motion.py
+++ b/hardware/opentrons_hardware/scripts/plan_motion.py
@@ -42,7 +42,6 @@ LOG_CONFIG: Dict[str, Any] = {
 
 def main() -> None:
     """Entry point."""
-
     parser = argparse.ArgumentParser(description="Motion planning script.")
     parser.add_argument(
         "--params-file-path",


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR allows the motion planning script to be more interactive. You can now adjust the params in a json file `opentrons_hardware/scripts/motion_params.json` instead of editing the actual script.

Run the motion planning script by doing `pipenv run python -m opentrons_hardware.scripts.plan_motion`. To enable the debug log, add `--debug=True`. To specify a different config file, use `--params-config-path={JSON_PATH}`.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
