### PR TITLE
refactor(app): do not proceed to next LPC step if jog is in flight

### DIFF
--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
@@ -339,6 +339,8 @@ export function useLabwarePositionCheck(
   }
   // (sa 11-18-2021): refactor this function after beta release
   const proceed = (): void => {
+    // if a jog command is in flight, ignore this call to proceed
+    if (isJogging.current) return
     setIsLoading(true)
     setShowPickUpTipConfirmationModal(false)
     // before executing the next movement command, save the current position


### PR DESCRIPTION
# Overview
This PR makes it so users cannot proceed to the next LPC step if a jog is in flight.

closes #9121
# Changelog

- Do not proceed to next LPC step if jog is in flight

# Review requests

Go through LPC, hit jog a bunch of times and then try to proceed to the next LPC step. It should not allow you to until all jogs are complete
# Risk assessment
Low
