### PR TITLE
fix(app): update labware for drop_tip case to prevent white screen

### DIFF
--- a/app/src/organisms/RunDetails/CommandText.tsx
+++ b/app/src/organisms/RunDetails/CommandText.tsx
@@ -82,7 +82,9 @@ export function CommandText(props: Props): JSX.Element | null {
               labwareId === TRASH_ID
                 ? 'Opentrons Fixed Trash'
                 : getLabwareDisplayName(
-                    labwareRenderInfoById[labwareId].labwareDef
+                    protocolData.labwareDefinitions[
+                      protocolData.labware[labwareId].definitionId
+                    ]
                   ),
             labware_location: labwareLocation.slotName,
           }}


### PR DESCRIPTION
# Overview

This PR addresses the white screen behavior in the Run tab when uploading a PD protocol that contains a drop_tip
command.

credits to @b-cooper 

# Changelog

- Update labware in `drop_tip` case in `CommandText`

# Review requests

- Upload a PD/JSON protocol that contains a `dropTip` command and ensure there is no white screen when visiting the Run tab.

# Risk assessment
low