### PR TITLE
fix(app): set run again button loading state for completed and stopped runs

### DIFF
--- a/app/src/organisms/RunTimeControl/__tests__/RunTimeControl.test.tsx
+++ b/app/src/organisms/RunTimeControl/__tests__/RunTimeControl.test.tsx
@@ -164,6 +164,59 @@ describe('RunTimeControl', () => {
     expect(button).toBeDisabled()
   })
 
+  it('should render a disabled Run Again button if run status is stop requested', () => {
+    when(mockUseRunControls)
+      .calledWith()
+      .mockReturnValue({
+        play: () => {},
+        pause: () => {},
+        reset: () => {},
+        isPlayRunActionLoading: true,
+        isPauseRunActionLoading: false,
+        isResetRunLoading: false,
+      })
+    when(mockUseRunStatus)
+      .calledWith()
+      .mockReturnValue(RUN_STATUS_STOP_REQUESTED)
+    const [{ getByRole }] = render()
+    const button = getByRole('button', { name: 'Run Again' })
+    expect(button).toBeDisabled()
+  })
+
+  it('should render an enabled Run Again button if run is completed', () => {
+    when(mockUseRunControls)
+      .calledWith()
+      .mockReturnValue({
+        play: () => {},
+        pause: () => {},
+        reset: () => {},
+        isPlayRunActionLoading: false,
+        isPauseRunActionLoading: false,
+        isResetRunLoading: false,
+      })
+    when(mockUseRunStatus).calledWith().mockReturnValue(RUN_STATUS_SUCCEEDED)
+    const [{ getByRole }] = render()
+    const button = getByRole('button', { name: 'Run Again' })
+    expect(button).toBeEnabled()
+  })
+
+  it('should render an enabled Run Again button if run is canceled', () => {
+    when(mockUseRunControls)
+      .calledWith()
+      .mockReturnValue({
+        play: () => {},
+        pause: () => {},
+        reset: () => {},
+        isPlayRunActionLoading: false,
+        isPauseRunActionLoading: false,
+        isResetRunLoading: false,
+      })
+    when(mockUseRunStatus).calledWith().mockReturnValue(RUN_STATUS_STOPPED)
+    const [{ getByRole }] = render()
+    const button = getByRole('button', { name: 'Run Again' })
+    expect(button).toBeEnabled()
+  })
+
   it('renders a run status and timer if running', () => {
     when(mockUseRunStatus).calledWith().mockReturnValue(RUN_STATUS_RUNNING)
     when(mockUseRunStartTime).calledWith().mockReturnValue('noon')

--- a/app/src/organisms/RunTimeControl/index.tsx
+++ b/app/src/organisms/RunTimeControl/index.tsx
@@ -99,6 +99,12 @@ export function RunTimeControl(): JSX.Element | null {
       if (lastRunAction === 'reset' && runStatus === RUN_STATUS_IDLE) {
         setIsRunActionLoading(false)
       }
+      if (
+        runStatus === RUN_STATUS_SUCCEEDED ||
+        runStatus === RUN_STATUS_STOPPED
+      ) {
+        setIsRunActionLoading(false)
+      }
     }
     if (isFinishing && runStatus !== 'finishing') {
       setIsFinishing(false)

--- a/app/src/organisms/RunTimeControl/index.tsx
+++ b/app/src/organisms/RunTimeControl/index.tsx
@@ -99,15 +99,20 @@ export function RunTimeControl(): JSX.Element | null {
       if (lastRunAction === 'reset' && runStatus === RUN_STATUS_IDLE) {
         setIsRunActionLoading(false)
       }
-      if (
-        runStatus === RUN_STATUS_SUCCEEDED ||
-        runStatus === RUN_STATUS_STOPPED
-      ) {
-        setIsRunActionLoading(false)
-      }
     }
     if (isFinishing && runStatus !== 'finishing') {
       setIsFinishing(false)
+    }
+    if (
+      (lastRunAction === 'play' || lastRunAction === 'pause') &&
+      runStatus === RUN_STATUS_STOP_REQUESTED
+    ) {
+      setIsRunActionLoading(true)
+    } else if (
+      (lastRunAction === 'play' || lastRunAction === 'pause') &&
+      (runStatus === RUN_STATUS_STOPPED || runStatus === RUN_STATUS_SUCCEEDED)
+    ) {
+      setIsRunActionLoading(false)
     }
   }, [
     isPlayRunActionLoading,


### PR DESCRIPTION


<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR fixes the run again button loading forever even when the run is completed or stopped.

closes #9161

# Changelog

- Set loading state to false when run is stopped or complete

# Review requests

- Test on a robot that the Run Again button does not load forever when a run is stopped or completed.

# Risk assessment

low
