### PR TITLE
fix(api): Prioritize mc alarms over errors

### DIFF
--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -207,11 +207,12 @@ class SerialConnection:
         Raises: SerialException
         """
         lower = response.lower()
-        if self._error_keyword in lower:
-            raise ErrorResponse(port=self._port, response=response)
 
         if self._alarm_keyword in lower:
             raise AlarmResponse(port=self._port, response=response)
+
+        if self._error_keyword in lower:
+            raise ErrorResponse(port=self._port, response=response)
 
     async def on_retry(self) -> None:
         """

--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -810,6 +810,7 @@ class SmoothieDriver:
         # after it has entered an error state, so sleep for some milliseconds
         await asyncio.sleep(DEFAULT_STABILIZE_DELAY)
         log.debug("reset_from_error")
+        self._is_hard_halting.clear()
         await self._send_command(
             _command_builder().add_gcode(gcode=GCODE.RESET_FROM_ERROR)
         )

--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -1826,10 +1826,10 @@ class SmoothieDriver:
 
     async def hard_halt(self) -> None:
         log.debug(f"Halting Smoothie (simulating: {self.simulating}")
+        self._is_hard_halting.set()
         if self.simulating:
             pass
         else:
-            self._is_hard_halting.set()
             self._gpio_chardev.set_halt_pin(False)
             await asyncio.sleep(0.25)
             self._gpio_chardev.set_halt_pin(True)

--- a/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
+++ b/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
@@ -106,6 +106,7 @@ async def test_send_command_response(
         ["This is an Alarm", AlarmResponse],
         ["error:Alarm lock", AlarmResponse],
         ["alarm:error", AlarmResponse],
+        ["ALARM: Hard limit -X", AlarmResponse],
     ],
 )
 def test_raise_on_error(

--- a/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
+++ b/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
@@ -104,6 +104,8 @@ async def test_send_command_response(
         ["alarm", AlarmResponse],
         ["ALARM", AlarmResponse],
         ["This is an Alarm", AlarmResponse],
+        ["error:Alarm lock", AlarmResponse],
+        ["alarm:error", AlarmResponse],
     ],
 )
 def test_raise_on_error(


### PR DESCRIPTION
The error message returned by the motor controller after a hard halt is
"error:Alarm lock". This is meant to be sensed by logic that raises a
different kind of exception (SmoothieAlarm) from the kind raised by for
instance an unexpected limit switch actuation or malformed
response (SmoothieError). Unfortunately, the _way_ this is sensed is
that SmoothieAlarm looks for the keyword "alarm" and SmoothieError looks
for the keyword "error", and that message contains both, and the error
case is checked first.

The fix is to swap the order of the two. The fix could also be to
special case the message checking, but let's see if keeping it simple
works first.

## Testing
This is unit tested and will do what it says on the tin, but it's not clear to me if this is a safe thing to do in all circumstances on hardware. We should test this by running it on a robot and

- Cancel a running protocol (or do something else that causes a hard halt) and make sure the error recovery in case of a SmoothieAlarm actually, like, works, since it's probably never occurred before
- Run a protocol and tap a limit switch to cause a `HardLimitError` and make sure it's still a `SmoothieError`
- Hold down the switch during a jog or non-protocol-execution motion and check the same