### PR TITLE
refactor(app): display upload error when protocol is invalid

### DIFF
--- a/api-client/src/index.ts
+++ b/api-client/src/index.ts
@@ -1,5 +1,5 @@
 // api client entry point
-export type { HostConfig, EmptyResponse } from './types'
+export * from './types'
 export * from './request'
 export * from './health'
 export * from './sessions'

--- a/api-client/src/protocols/types.ts
+++ b/api-client/src/protocols/types.ts
@@ -1,5 +1,5 @@
 import type { ProtocolResource } from '@opentrons/shared-data'
-import type { ResourceLinks, ErrorDetails } from '../types'
+import type { ResourceLinks } from '../types'
 
 export interface ProtocolMetadata {
   protocolName?: string
@@ -21,14 +21,4 @@ export interface Protocol {
 export interface Protocols {
   links?: ResourceLinks
   data: ProtocolResource[]
-}
-
-export interface ProtocolFileInvalid extends ErrorDetails {
-  id: 'ProtocolFileInvalid'
-  meta: ProtocolMetadata
-}
-
-export interface ProtocolNotFound extends ErrorDetails {
-  id: 'ProtocolNotFound'
-  meta: ProtocolMetadata
 }

--- a/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
+++ b/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
@@ -274,4 +274,17 @@ describe('ProtocolUpload', () => {
     const [{ getByText }] = render()
     getByText('FAKE ERROR')
   })
+  it('renders an error if the protocol is invalid', () => {
+    when(mockUseCurrentProtocolRun)
+      .calledWith()
+      .mockReturnValue({
+        protocolRecord: {},
+        runRecord: {},
+        createProtocolRun: jest.fn(),
+        protocolCreationError: 'invalid protocol!',
+      } as any)
+    const [{ getByText }] = render()
+    getByText('Protocol upload failed. Fix the error and try again')
+    getByText('invalid protocol!')
+  })
 })

--- a/app/src/organisms/ProtocolUpload/hooks/useCurrentProtocolRun.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useCurrentProtocolRun.ts
@@ -20,6 +20,7 @@ export interface UseCurrentProtocolRun {
   protocolRecord?: Protocol | null
   runRecord?: Run | null
   isCreatingProtocolRun?: boolean
+  protocolCreationError: string | null
 }
 
 export function useCurrentProtocolRun(): UseCurrentProtocolRun {
@@ -30,6 +31,9 @@ export function useCurrentProtocolRun(): UseCurrentProtocolRun {
     refetchInterval: REFETCH_INTERVAL,
   })
   const [isInitializing, setIsInitializing] = React.useState(false)
+  const [protocolCreationError, setProtocolCreationError] = React.useState<
+    string | null
+  >(null)
   const enableProtocolPolling = React.useRef<boolean>(
     runRecord?.data.protocolId != null
   )
@@ -77,6 +81,9 @@ export function useCurrentProtocolRun(): UseCurrentProtocolRun {
     onSuccess: data => {
       createRun({ protocolId: data.data.id })
     },
+    onError: error => {
+      setProtocolCreationError(error.response?.data.errors[0].detail ?? null)
+    },
   })
 
   return {
@@ -85,5 +92,6 @@ export function useCurrentProtocolRun(): UseCurrentProtocolRun {
     runRecord,
     isCreatingProtocolRun:
       isCreatingProtocol || isCreatingRun || isInitializing,
+    protocolCreationError,
   }
 }

--- a/app/src/organisms/ProtocolUpload/index.tsx
+++ b/app/src/organisms/ProtocolUpload/index.tsx
@@ -52,6 +52,7 @@ import styles from './styles.css'
 const VALIDATION_ERROR_T_MAP: { [errorKey: string]: string } = {
   INVALID_FILE_TYPE: 'invalid_file_type',
   INVALID_JSON_FILE: 'invalid_json_file',
+  INVALID_PROTOCOL: 'invalid_protocol',
   ANALYSIS_ERROR: 'analysis_error',
 }
 
@@ -62,6 +63,7 @@ export function ProtocolUpload(): JSX.Element {
     createProtocolRun,
     protocolRecord,
     isCreatingProtocolRun,
+    protocolCreationError,
   } = useCurrentProtocolRun()
   const runStatus = useRunStatus()
   const { closeCurrentRun, isProtocolRunLoaded } = useCloseCurrentRun()
@@ -89,8 +91,13 @@ export function ProtocolUpload(): JSX.Element {
         VALIDATION_ERROR_T_MAP.ANALYSIS_ERROR,
         protocolRecord?.data.analyses[0].errors[0].detail as string,
       ])
+    } else if (protocolCreationError != null) {
+      setUploadError([
+        VALIDATION_ERROR_T_MAP.INVALID_PROTOCOL,
+        protocolCreationError,
+      ])
     }
-  }, [protocolRecord])
+  }, [protocolRecord, protocolCreationError])
 
   React.useEffect(() => {
     if (uploadError != null) {

--- a/react-api-client/src/protocols/useCreateProtocolMutation.ts
+++ b/react-api-client/src/protocols/useCreateProtocolMutation.ts
@@ -7,19 +7,20 @@ import {
 } from 'react-query'
 import { createProtocol } from '@opentrons/api-client'
 import { useHost } from '../api'
-import type { HostConfig, Protocol } from '@opentrons/api-client'
+import type { AxiosError } from 'axios'
+import type { ErrorResponse, HostConfig, Protocol } from '@opentrons/api-client'
 
 export type UseCreateProtocolMutationResult = UseMutationResult<
   Protocol,
-  unknown,
+  AxiosError<ErrorResponse>,
   File[]
 > & {
-  createProtocol: UseMutateFunction<Protocol, unknown, File[]>
+  createProtocol: UseMutateFunction<Protocol, AxiosError<ErrorResponse>, File[]>
 }
 
 export type UseCreateProtocolMutationOptions = UseMutationOptions<
   Protocol,
-  unknown,
+  AxiosError<ErrorResponse>,
   File[]
 >
 
@@ -29,7 +30,7 @@ export function useCreateProtocolMutation(
   const host = useHost()
   const queryClient = useQueryClient()
 
-  const mutation = useMutation<Protocol, unknown, File[]>(
+  const mutation = useMutation<Protocol, AxiosError<ErrorResponse>, File[]>(
     [host, 'protocols'],
     (protocolFiles: File[]) =>
       createProtocol(host as HostConfig, protocolFiles).then(response => {


### PR DESCRIPTION
# Overview
This PR shows a user facing error when a user attempts to upload a protocol that is invalid (this is different from the case where an upload succeeds (returns 2XX) but its analysis completes with a not-ok result.)

closes #9077

# Changelog

- Display upload error when protocol is invalid

# Review requests
Follow repro steps in the ticket, you should now see an upload error with the error response from the server

# Risk assessment
Low
