### PR TITLE
refactor(app): combine loading texts when multiple CommandTypes exist

### DIFF
--- a/app/src/assets/localization/en/labware_position_check.json
+++ b/app/src/assets/localization/en/labware_position_check.json
@@ -37,6 +37,8 @@
   "error_modal_header": "Something went wrong",
   "error_modal_text": "There was an error processing your request on the robot",
   "robot_in_motion": "Stand back, robot is in motion.",
+  "moving_and_returning_tip_title": "Moving to slot {{slot}} and returning tip",
+  "moving_and_picking_up_tip_title": "Moving to slot {{slot}} and picking up tip",
   "moving_to_slot_title": "Moving to slot {{slot}}",
   "picking_up_tip_title": "Picking up tip in slot {{slot}}",
   "returning_tip_title": "Returning tip in slot {{slot}}",

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/__tests__/useLoadingText.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/__tests__/useLoadingText.test.tsx
@@ -40,7 +40,19 @@ describe('useTitleText', () => {
       .mockReturnValue({ slotName: mockSlotNumber })
   })
   it('should return the loading text for a move to well command', () => {
-    const command: MoveToWellCommand = {
+    const previousCommand: MoveToWellCommand = {
+      id: '1',
+      commandType: 'moveToWell',
+      params: {
+        labwareId: mockLabwareId,
+        pipetteId: 'p300SingleId',
+        wellName: 'A1',
+        wellLocation: {
+          origin: 'top',
+        },
+      },
+    }
+    const currentCommand: MoveToWellCommand = {
       id: '1',
       commandType: 'moveToWell',
       params: {
@@ -53,13 +65,16 @@ describe('useTitleText', () => {
       },
     }
 
-    const { result } = renderHook(() => useTitleText(true, command), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () => useTitleText(true, previousCommand, currentCommand),
+      {
+        wrapper,
+      }
+    )
     expect(result.current).toBe(`Moving to slot ${mockSlotNumber}`)
   })
   it('should return the loading text for a move to well and pick up tip command', () => {
-    const firstCommand: MoveToWellCommand = {
+    const previousCommand: MoveToWellCommand = {
       id: '1',
       commandType: 'moveToWell',
       params: {
@@ -72,7 +87,7 @@ describe('useTitleText', () => {
       },
     }
 
-    const secondCommand: PickUpTipCommand = {
+    const currentCommand: PickUpTipCommand = {
       id: '2',
       commandType: 'pickUpTip',
       params: {
@@ -82,17 +97,18 @@ describe('useTitleText', () => {
       },
     }
 
-    const command = firstCommand && secondCommand
-
-    const { result } = renderHook(() => useTitleText(true, command), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () => useTitleText(true, previousCommand, currentCommand),
+      {
+        wrapper,
+      }
+    )
     expect(result.current).toBe(
       `Moving to slot ${mockSlotNumber} and picking up tip`
     )
   })
   it('should return the loading text for a move to well and returning a tip command', () => {
-    const firstCommand: MoveToWellCommand = {
+    const previousCommand: MoveToWellCommand = {
       id: '1',
       commandType: 'moveToWell',
       params: {
@@ -105,7 +121,7 @@ describe('useTitleText', () => {
       },
     }
 
-    const secondCommand: DropTipCommand = {
+    const currentCommand: DropTipCommand = {
       id: '1',
       commandType: 'dropTip',
       params: {
@@ -114,14 +130,76 @@ describe('useTitleText', () => {
         wellName: 'A1',
       },
     }
-
-    const command = firstCommand && secondCommand
-
-    const { result } = renderHook(() => useTitleText(true, command), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () => useTitleText(true, previousCommand, currentCommand),
+      {
+        wrapper,
+      }
+    )
     expect(result.current).toBe(
       `Moving to slot ${mockSlotNumber} and returning tip`
     )
+  })
+  it('should return the loading text for returning a tip command', () => {
+    const previousCommand: DropTipCommand = {
+      id: '1',
+      commandType: 'dropTip',
+      params: {
+        labwareId: mockLabwareId,
+        pipetteId: 'p300SingleId',
+        wellName: 'A1',
+      },
+    }
+    const currentCommand: MoveToWellCommand = {
+      id: '1',
+      commandType: 'moveToWell',
+      params: {
+        labwareId: mockLabwareId,
+        pipetteId: 'p300SingleId',
+        wellName: 'A1',
+        wellLocation: {
+          origin: 'top',
+        },
+      },
+    }
+
+    const { result } = renderHook(
+      () => useTitleText(true, previousCommand, currentCommand),
+      {
+        wrapper,
+      }
+    )
+    expect(result.current).toBe(`Returning tip in slot ${mockSlotNumber}`)
+  })
+  it('should return the loading text for pick up tip command', () => {
+    const previousCommand: PickUpTipCommand = {
+      id: '2',
+      commandType: 'pickUpTip',
+      params: {
+        labwareId: mockLabwareId,
+        pipetteId: 'p300SingleId',
+        wellName: 'A1',
+      },
+    }
+    const currentCommand: MoveToWellCommand = {
+      id: '1',
+      commandType: 'moveToWell',
+      params: {
+        labwareId: mockLabwareId,
+        pipetteId: 'p300SingleId',
+        wellName: 'A1',
+        wellLocation: {
+          origin: 'top',
+        },
+      },
+    }
+
+    const { result } = renderHook(
+      () => useTitleText(true, previousCommand, currentCommand),
+      {
+        wrapper,
+      }
+    )
+    expect(result.current).toBe(`Picking up tip in slot ${mockSlotNumber}`)
   })
 })

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/__tests__/useLoadingText.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/__tests__/useLoadingText.test.tsx
@@ -58,9 +58,22 @@ describe('useTitleText', () => {
     })
     expect(result.current).toBe(`Moving to slot ${mockSlotNumber}`)
   })
-  it('should return the loading text for a pick up tip command', () => {
-    const command: PickUpTipCommand = {
+  it('should return the loading text for a move to well and pick up tip command', () => {
+    const firstCommand: MoveToWellCommand = {
       id: '1',
+      commandType: 'moveToWell',
+      params: {
+        labwareId: mockLabwareId,
+        pipetteId: 'p300SingleId',
+        wellName: 'A1',
+        wellLocation: {
+          origin: 'top',
+        },
+      },
+    }
+
+    const secondCommand: PickUpTipCommand = {
+      id: '2',
       commandType: 'pickUpTip',
       params: {
         labwareId: mockLabwareId,
@@ -69,13 +82,30 @@ describe('useTitleText', () => {
       },
     }
 
+    const command = firstCommand && secondCommand
+
     const { result } = renderHook(() => useTitleText(true, command), {
       wrapper,
     })
-    expect(result.current).toBe(`Picking up tip in slot ${mockSlotNumber}`)
+    expect(result.current).toBe(
+      `Moving to slot ${mockSlotNumber} and picking up tip`
+    )
   })
-  it('should return the loading text for a drop tip command', () => {
-    const command: DropTipCommand = {
+  it('should return the loading text for a move to well and returning a tip command', () => {
+    const firstCommand: MoveToWellCommand = {
+      id: '1',
+      commandType: 'moveToWell',
+      params: {
+        labwareId: mockLabwareId,
+        pipetteId: 'p300SingleId',
+        wellName: 'A1',
+        wellLocation: {
+          origin: 'top',
+        },
+      },
+    }
+
+    const secondCommand: DropTipCommand = {
       id: '1',
       commandType: 'dropTip',
       params: {
@@ -85,9 +115,13 @@ describe('useTitleText', () => {
       },
     }
 
+    const command = firstCommand && secondCommand
+
     const { result } = renderHook(() => useTitleText(true, command), {
       wrapper,
     })
-    expect(result.current).toBe(`Returning tip in slot ${mockSlotNumber}`)
+    expect(result.current).toBe(
+      `Moving to slot ${mockSlotNumber} and returning tip`
+    )
   })
 })

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
@@ -131,6 +131,14 @@ export const useTitleText = (
 
   if (loading) {
     switch (command.commandType) {
+      case 'moveToWell' && 'pickUpTip': {
+        return t('moving_and_picking_up_tip_title', {
+          slot,
+        })
+      }
+      case 'moveToWell' && 'dropTip': {
+        return t('moving_and_returning_tip_title', { slot })
+      }
       case 'moveToWell': {
         return t('moving_to_slot_title', {
           slot,


### PR DESCRIPTION
closes #9047

# Overview

This PR combines the `Move to Slot` and `Pick up Tip` texts and the `Move to Slot'`and `Return Tip'` texts when the commands happen back to back. 

<img width="973" alt="Screen Shot 2022-01-11 at 15 42 19" src="https://user-images.githubusercontent.com/66035149/149019343-b5adeef8-ce95-4a18-a57c-cc156b0a585d.png">

<img width="1006" alt="Screen Shot 2022-01-11 at 15 41 37" src="https://user-images.githubusercontent.com/66035149/149019377-d845781b-ea1b-442b-9967-bc9c18101bb7.png">


# Changelog

- added onto the switch case to cover those conditions

# Review requests

- I tested on my robot but also test on your robot to make sure it works properly

# Risk assessment

low, behind ff
