### PR TITLE
refactor(app): fix LPC loading text

### DIFF
--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
@@ -130,6 +130,7 @@ export const useTitleText = (
           .slotName
 
   if (loading) {
+    console.log(command.commandType)
     switch (command.commandType) {
       case 'moveToWell': {
         return t('moving_to_slot_title', {
@@ -340,6 +341,7 @@ export function useLabwarePositionCheck(
   // (sa 11-18-2021): refactor this function after beta release
   const proceed = (): void => {
     setIsLoading(true)
+    setCurrentCommandIndex(currentCommandIndex + 1)
     setShowPickUpTipConfirmationModal(false)
     // before executing the next movement command, save the current position
     const savePositionCommand: Command = {
@@ -491,7 +493,6 @@ export function useLabwarePositionCheck(
             setError(e)
           })
         }
-        setCurrentCommandIndex(currentCommandIndex + 1)
       })
       .catch((e: Error) => {
         console.error(`error issuing command to robot: ${e.message}`)

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
@@ -130,7 +130,6 @@ export const useTitleText = (
           .slotName
 
   if (loading) {
-    console.log(command.commandType)
     switch (command.commandType) {
       case 'moveToWell': {
         return t('moving_to_slot_title', {


### PR DESCRIPTION
closes #9047

# Overview

This PR fixes the delay on the loading command text. Now, instead of the command text being delayed by a few seconds once the robot starts executing the command, the text will be displayed immediately when the robot starts executing the command.

This also means that we don't need to combine the command texts like the ticket states. This is because a user will always have to manually press the CTA to go to `pickUpTip` and `returnTip`, so we will never run into both a `moveToWell` and `pickUpTip` commands or a `moveToWell` and `dropTip` commands that occur within the same `loading` span. 

# Changelog

- moves `setCurrentCommandIndex(currentCommandIndex + 1)` to occur right after `setIsLoading(true)`

# Review requests

- review code and run LPC on your robot or dev bot - the command text should display immediately rather than being slightly delayed

# Risk assessment

low