### PR TITLE
fix(engine): take calibrated tip length into account during tip pickup

### DIFF
--- a/api/src/opentrons/calibration_storage/get.py
+++ b/api/src/opentrons/calibration_storage/get.py
@@ -116,6 +116,7 @@ def _get_tip_length_data(
         )
 
 
+# TODO(mc, 2022-01-12): no longer used; remove
 def get_labware_calibration(
     lookup_path: local_types.StrPath,
     definition: "LabwareDefinition",

--- a/api/src/opentrons/calibration_storage/helpers.py
+++ b/api/src/opentrons/calibration_storage/helpers.py
@@ -56,6 +56,7 @@ def hash_labware_def(labware_def: "LabwareDefinition") -> str:
     blocklist = ["metadata", "brand", "groups"]
     def_no_metadata = {k: v for k, v in labware_def.items() if k not in blocklist}
     sorted_def_str = json.dumps(def_no_metadata, sort_keys=True, separators=(",", ":"))
+
     return sha256(sorted_def_str.encode("utf-8")).hexdigest()
 
 

--- a/api/src/opentrons/protocol_engine/resources/labware_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/labware_data_provider.py
@@ -1,20 +1,81 @@
-"""Labware data resource provider."""
+"""Labware data resource provider.
+
+This module is a wrapper around existing, but older, internal APIs to
+abstract away rough edges until we can improve those underlying interfaces.
+"""
+import logging
+from anyio import to_thread
+from typing import Optional, cast
+
+from opentrons_shared_data.labware.dev_types import LabwareDefinition as LabwareDefDict
 from opentrons.protocols.models import LabwareDefinition
-from opentrons.protocol_api.labware import get_labware_definition
+from opentrons.protocols.labware import get_labware_definition
+from opentrons.calibration_storage.get import load_tip_length_calibration
+from opentrons.calibration_storage.types import TipLengthCalNotFound
+
+
+log = logging.getLogger(__name__)
 
 
 class LabwareDataProvider:
     """Labware data provider."""
 
-    # NOTE(mc, 2020-10-18): async to allow file reading and parsing to be
-    # async on a worker thread in the future
     @staticmethod
     async def get_labware_definition(
         load_name: str,
         namespace: str,
         version: int,
     ) -> LabwareDefinition:
-        """Get a labware definition given the labware's identification."""
+        """Get a labware definition given the labware's identification.
+
+        Note: this method hits the filesystem, which will have performance
+        implications if it is called often.
+        """
+        return await to_thread.run_sync(
+            LabwareDataProvider._get_labware_definition_sync,
+            load_name,
+            namespace,
+            version,
+        )
+
+    @staticmethod
+    def _get_labware_definition_sync(
+        load_name: str, namespace: str, version: int
+    ) -> LabwareDefinition:
         return LabwareDefinition.parse_obj(
             get_labware_definition(load_name, namespace, version)
         )
+
+    @staticmethod
+    async def get_calibrated_tip_length(
+        pipette_serial: str,
+        labware_definition: LabwareDefinition,
+    ) -> Optional[float]:
+        """Get the calibrated tip length of a tip rack / pipette pair.
+
+        Note: this method hits the filesystem, which will have performance
+        implications if it is called often.
+        """
+        return await to_thread.run_sync(
+            LabwareDataProvider._get_calibrated_tip_length_sync,
+            pipette_serial,
+            labware_definition,
+        )
+
+    @staticmethod
+    def _get_calibrated_tip_length_sync(
+        pipette_serial: str,
+        labware_definition: LabwareDefinition,
+    ) -> Optional[float]:
+        try:
+            return load_tip_length_calibration(
+                pip_id=pipette_serial,
+                definition=cast(
+                    LabwareDefDict,
+                    labware_definition.dict(exclude_none=True),
+                ),
+            ).tip_length
+
+        except TipLengthCalNotFound as e:
+            log.warn("No calibrated tip length found", exc_info=e)
+            return None

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -246,10 +246,17 @@ class LabwareView(HasState[LabwareState]):
     def get_well_definition(
         self,
         labware_id: str,
-        well_name: str,
+        well_name: Optional[str] = None,
     ) -> WellDefinition:
-        """Get a well's definition by labware and well identifier."""
+        """Get a well's definition by labware and well name.
+
+        If `well_name` is omitted, the first well in the labware
+        will be used.
+        """
         definition = self.get_definition(labware_id)
+
+        if well_name is None:
+            well_name = definition.ordering[0][0]
 
         try:
             return definition.wells[well_name]

--- a/api/src/opentrons/protocols/models/labware_definition.py
+++ b/api/src/opentrons/protocols/models/labware_definition.py
@@ -37,7 +37,7 @@ _Number = Union[StrictInt, StrictFloat]
 
 For labware definition hashing, which is an older part of the codebase,
 this ensures that Pydantic won't change `"someFloatField: 0` to
-"someFloatField: 0.0, which
+`"someFloatField"`: 0.0, which would hash differently.
 """
 
 _NonNegativeNumber = Union[_StrictNonNegativeInt, _StrictNonNegativeFloat]

--- a/api/src/opentrons/protocols/models/labware_definition.py
+++ b/api/src/opentrons/protocols/models/labware_definition.py
@@ -37,7 +37,7 @@ _Number = Union[StrictInt, StrictFloat]
 
 For labware definition hashing, which is an older part of the codebase,
 this ensures that Pydantic won't change `"someFloatField: 0` to
-`"someFloatField"`: 0.0, which would hash differently.
+`"someFloatField": 0.0`, which would hash differently.
 """
 
 _NonNegativeNumber = Union[_StrictNonNegativeInt, _StrictNonNegativeFloat]

--- a/api/src/opentrons/protocols/models/labware_definition.py
+++ b/api/src/opentrons/protocols/models/labware_definition.py
@@ -8,12 +8,40 @@ TODO: 20210330 Amit - consider moving this to opentrons-shared-data.
 from __future__ import annotations
 
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
-from pydantic import BaseModel, Extra, Field
+from pydantic import (
+    BaseModel,
+    Extra,
+    Field,
+    conint,
+    confloat,
+    StrictInt,
+    StrictFloat,
+)
 from typing_extensions import Literal
 
 SAFE_STRING_REGEX = "^[a-z0-9._]+$"
+
+
+if TYPE_CHECKING:
+    _StrictNonNegativeInt = int
+    _StrictNonNegativeFloat = float
+else:
+    _StrictNonNegativeInt = conint(strict=True, ge=0)
+    _StrictNonNegativeFloat = confloat(strict=True, ge=0.0)
+
+
+_Number = Union[StrictInt, StrictFloat]
+"""JSON number type, written to preserve lack of decimal point.
+
+For labware definition hashing, which is an older part of the codebase,
+this ensures that Pydantic won't change `"someFloatField: 0` to
+"someFloatField: 0.0, which
+"""
+
+_NonNegativeNumber = Union[_StrictNonNegativeInt, _StrictNonNegativeFloat]
+"""Non-negative JSON number type, written to preserve lack of decimal point."""
 
 
 class CornerOffsetFromSlot(BaseModel):
@@ -23,9 +51,9 @@ class CornerOffsetFromSlot(BaseModel):
       labware that does not span multiple slots, x/y/z should all be zero.
     """
 
-    x: float
-    y: float
-    z: float
+    x: _Number
+    y: _Number
+    z: _Number
 
 
 class BrandData(BaseModel):
@@ -84,15 +112,13 @@ class Parameters(BaseModel):
     isTiprack: bool = Field(
         ..., description="Flag marking whether a labware is a tiprack or not"
     )
-    tipLength: Optional[float] = Field(
+    tipLength: Optional[_NonNegativeNumber] = Field(
         None,
-        ge=0.0,
         description="Required if labware is tiprack, specifies length of tip"
         " from drawing or as measured with calipers",
     )
-    tipOverlap: Optional[float] = Field(
+    tipOverlap: Optional[_NonNegativeNumber] = Field(
         None,
-        ge=0.0,
         description="Required if labware is tiprack, specifies the length of "
         "the area of the tip that overlaps the nozzle of the pipette",
     )
@@ -106,8 +132,8 @@ class Parameters(BaseModel):
         description="Flag marking whether a labware is compatible by default "
         "with the Magnetic Module",
     )
-    magneticModuleEngageHeight: Optional[float] = Field(
-        None, ge=0.0, description="Distance to move magnetic module magnets to engage"
+    magneticModuleEngageHeight: Optional[_NonNegativeNumber] = Field(
+        None, description="Distance to move magnetic module magnets to engage"
     )
 
 
@@ -116,45 +142,45 @@ class Dimensions(BaseModel):
     Outer dimensions of a labware
     """
 
-    yDimension: float = Field(..., ge=0.0)
-    zDimension: float = Field(..., ge=0.0)
-    xDimension: float = Field(..., ge=0.0)
+    yDimension: _NonNegativeNumber = Field(...)
+    zDimension: _NonNegativeNumber = Field(...)
+    xDimension: _NonNegativeNumber = Field(...)
 
 
 class WellDefinition(BaseModel):
     class Config:
         extra = Extra.allow
 
-    depth: float = Field(..., ge=0.0)
-    x: float = Field(
+    depth: _NonNegativeNumber = Field(...)
+    x: _NonNegativeNumber = Field(
         ...,
-        ge=0.0,
         description="x location of center-bottom of well in reference to "
         "left-front-bottom of labware",
     )
-    y: float = Field(
+    y: _NonNegativeNumber = Field(
         ...,
-        ge=0.0,
         description="y location of center-bottom of well in reference to "
         "left-front-bottom of labware",
     )
-    z: float = Field(
+    z: _NonNegativeNumber = Field(
         ...,
-        ge=0.0,
         description="z location of center-bottom of well in reference to "
         "left-front-bottom of labware",
     )
-    totalLiquidVolume: float = Field(
-        ..., ge=0.0, description="Total well, tube, or tip volume in microliters"
+    totalLiquidVolume: _NonNegativeNumber = Field(
+        ..., description="Total well, tube, or tip volume in microliters"
     )
-    xDimension: Optional[float] = Field(
-        None, ge=0.0, description="x dimension of rectangular wells"
+    xDimension: Optional[_NonNegativeNumber] = Field(
+        None,
+        description="x dimension of rectangular wells",
     )
-    yDimension: Optional[float] = Field(
-        None, ge=0.0, description="y dimension of rectangular wells"
+    yDimension: Optional[_NonNegativeNumber] = Field(
+        None,
+        description="y dimension of rectangular wells",
     )
-    diameter: Optional[float] = Field(
-        None, ge=0.0, description="diameter of circular wells"
+    diameter: Optional[_NonNegativeNumber] = Field(
+        None,
+        description="diameter of circular wells",
     )
     shape: Literal["rectangular", "circular"] = Field(
         ...,

--- a/api/tests/opentrons/protocol_engine/execution/mock_defs.py
+++ b/api/tests/opentrons/protocol_engine/execution/mock_defs.py
@@ -11,10 +11,14 @@ class MockPipettes:
     """Dummy pipette data to use in liquid handling collabortation tests."""
 
     left_config: PipetteDict = field(
-        default_factory=lambda: cast(PipetteDict, {"name": "p300_single"})
+        default_factory=lambda: cast(
+            PipetteDict, {"name": "p300_single", "pipette_id": "123"}
+        )
     )
     right_config: PipetteDict = field(
-        default_factory=lambda: cast(PipetteDict, {"name": "p300_multi"})
+        default_factory=lambda: cast(
+            PipetteDict, {"name": "p300_multi", "pipette_id": "abc"}
+        )
     )
 
     @property

--- a/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
@@ -1,4 +1,4 @@
-"""Pipetting command handler."""
+"""Pipetting execution handler."""
 import pytest
 from decoy import Decoy
 from typing import Tuple
@@ -7,6 +7,7 @@ from opentrons.types import Mount
 from opentrons.hardware_control import API as HardwareAPI
 from opentrons.hardware_control.dev_types import PipetteDict
 
+from opentrons.protocols.models import LabwareDefinition
 from opentrons.protocol_engine import WellLocation, WellOrigin, WellOffset
 from opentrons.protocol_engine.state import (
     StateStore,
@@ -16,6 +17,7 @@ from opentrons.protocol_engine.state import (
 )
 from opentrons.protocol_engine.execution.movement import MovementHandler
 from opentrons.protocol_engine.execution.pipetting import PipettingHandler
+from opentrons.protocol_engine.resources import LabwareDataProvider
 
 from .mock_defs import MockPipettes
 
@@ -36,6 +38,12 @@ def state_store(decoy: Decoy) -> StateStore:
 def movement_handler(decoy: Decoy) -> MovementHandler:
     """Get a mock in the shape of a MovementHandler."""
     return decoy.mock(cls=MovementHandler)
+
+
+@pytest.fixture
+def labware_data_provider(decoy: Decoy) -> LabwareDataProvider:
+    """Get a mock LabwareDataProvider."""
+    return decoy.mock(cls=LabwareDataProvider)
 
 
 @pytest.fixture
@@ -64,16 +72,18 @@ def mock_right_pipette_config(
 
 
 @pytest.fixture
-def handler(
+def subject(
     state_store: StateStore,
     hardware_api: HardwareAPI,
     movement_handler: MovementHandler,
+    labware_data_provider: LabwareDataProvider,
 ) -> PipettingHandler:
     """Create a PipettingHandler with its dependencies mocked out."""
     return PipettingHandler(
         state_store=state_store,
         hardware_api=hardware_api,
         movement_handler=movement_handler,
+        labware_data_provider=labware_data_provider,
     )
 
 
@@ -82,8 +92,10 @@ async def test_handle_pick_up_tip_request(
     state_store: StateStore,
     hardware_api: HardwareAPI,
     movement_handler: MovementHandler,
+    labware_data_provider: LabwareDataProvider,
     mock_hw_pipettes: MockPipettes,
-    handler: PipettingHandler,
+    tip_rack_def: LabwareDefinition,
+    subject: PipettingHandler,
 ) -> None:
     """It should handle a PickUpTipCreate properly."""
     decoy.when(
@@ -95,8 +107,12 @@ async def test_handle_pick_up_tip_request(
         HardwarePipette(mount=Mount.LEFT, config=mock_hw_pipettes.left_config)
     )
 
+    decoy.when(state_store.labware.get_definition("labware-id")).then_return(
+        tip_rack_def
+    )
+
     decoy.when(
-        state_store.geometry.get_tip_geometry(
+        state_store.geometry.get_nominal_tip_geometry(
             labware_id="labware-id",
             well_name="B2",
             pipette_config=mock_hw_pipettes.left_config,
@@ -109,7 +125,14 @@ async def test_handle_pick_up_tip_request(
         )
     )
 
-    await handler.pick_up_tip(
+    decoy.when(
+        await labware_data_provider.get_calibrated_tip_length(
+            pipette_serial=mock_hw_pipettes.left_config["pipette_id"],
+            labware_definition=tip_rack_def,
+        )
+    ).then_return(42)
+
+    await subject.pick_up_tip(
         pipette_id="pipette-id",
         labware_id="labware-id",
         well_name="B2",
@@ -125,12 +148,74 @@ async def test_handle_pick_up_tip_request(
         ),
         await hardware_api.pick_up_tip(
             mount=Mount.LEFT,
-            tip_length=50,
+            tip_length=42,
             presses=None,
             increment=None,
         ),
         hardware_api.set_current_tiprack_diameter(mount=Mount.LEFT, tiprack_diameter=5),
         hardware_api.set_working_volume(mount=Mount.LEFT, tip_volume=300),
+    )
+
+
+async def test_handle_pick_up_tip_request_tip_length_fallback(
+    decoy: Decoy,
+    state_store: StateStore,
+    hardware_api: HardwareAPI,
+    movement_handler: MovementHandler,
+    labware_data_provider: LabwareDataProvider,
+    mock_hw_pipettes: MockPipettes,
+    tip_rack_def: LabwareDefinition,
+    subject: PipettingHandler,
+) -> None:
+    """It should pick up a tip even if there's no calibrated tip length available."""
+    decoy.when(
+        state_store.pipettes.get_hardware_pipette(
+            pipette_id="pipette-id",
+            attached_pipettes=mock_hw_pipettes.by_mount,
+        )
+    ).then_return(
+        HardwarePipette(mount=Mount.LEFT, config=mock_hw_pipettes.left_config)
+    )
+
+    decoy.when(state_store.labware.get_definition("labware-id")).then_return(
+        tip_rack_def
+    )
+
+    decoy.when(
+        state_store.geometry.get_nominal_tip_geometry(
+            labware_id="labware-id",
+            well_name="B2",
+            pipette_config=mock_hw_pipettes.left_config,
+        )
+    ).then_return(
+        TipGeometry(
+            effective_length=50,
+            diameter=5,
+            volume=300,
+        )
+    )
+
+    decoy.when(
+        await labware_data_provider.get_calibrated_tip_length(
+            pipette_serial=mock_hw_pipettes.left_config["pipette_id"],
+            labware_definition=tip_rack_def,
+        )
+    ).then_return(None)
+
+    await subject.pick_up_tip(
+        pipette_id="pipette-id",
+        labware_id="labware-id",
+        well_name="B2",
+        well_location=WellLocation(offset=WellOffset(x=1, y=2, z=3)),
+    )
+
+    decoy.verify(
+        await hardware_api.pick_up_tip(
+            mount=Mount.LEFT,
+            tip_length=50,
+            presses=None,
+            increment=None,
+        ),
     )
 
 
@@ -140,7 +225,7 @@ async def test_handle_drop_up_tip_request(
     hardware_api: HardwareAPI,
     movement_handler: MovementHandler,
     mock_hw_pipettes: MockPipettes,
-    handler: PipettingHandler,
+    subject: PipettingHandler,
 ) -> None:
     """It should handle a DropTipCreate properly."""
     decoy.when(
@@ -163,7 +248,7 @@ async def test_handle_drop_up_tip_request(
         )
     ).then_return(WellLocation(offset=WellOffset(x=4, y=5, z=6)))
 
-    await handler.drop_tip(
+    await subject.drop_tip(
         pipette_id="pipette-id",
         labware_id="labware-id",
         well_name="A1",
@@ -187,7 +272,7 @@ async def test_handle_aspirate_request_without_prep(
     hardware_api: HardwareAPI,
     movement_handler: MovementHandler,
     mock_hw_pipettes: MockPipettes,
-    handler: PipettingHandler,
+    subject: PipettingHandler,
 ) -> None:
     """It should aspirate from a well if pipette is ready to aspirate."""
     well_location = WellLocation(
@@ -214,7 +299,7 @@ async def test_handle_aspirate_request_without_prep(
         )
     ).then_return(True)
 
-    volume = await handler.aspirate(
+    volume = await subject.aspirate(
         pipette_id="pipette-id",
         labware_id="labware-id",
         well_name="C6",
@@ -245,7 +330,7 @@ async def test_handle_aspirate_request_with_prep(
     hardware_api: HardwareAPI,
     movement_handler: MovementHandler,
     mock_hw_pipettes: MockPipettes,
-    handler: PipettingHandler,
+    subject: PipettingHandler,
 ) -> None:
     """It should aspirate from a well if pipette isn't ready to aspirate."""
     well_location = WellLocation(
@@ -272,7 +357,7 @@ async def test_handle_aspirate_request_with_prep(
         )
     ).then_return(False)
 
-    volume = await handler.aspirate(
+    volume = await subject.aspirate(
         pipette_id="pipette-id",
         labware_id="labware-id",
         well_name="C6",
@@ -311,7 +396,7 @@ async def test_handle_dispense_request(
     hardware_api: HardwareAPI,
     movement_handler: MovementHandler,
     mock_hw_pipettes: MockPipettes,
-    handler: PipettingHandler,
+    subject: PipettingHandler,
 ) -> None:
     """It should be able to dispense to a well."""
     well_location = WellLocation(
@@ -331,7 +416,7 @@ async def test_handle_dispense_request(
         )
     )
 
-    volume = await handler.dispense(
+    volume = await subject.dispense(
         pipette_id="pipette-id",
         labware_id="labware-id",
         well_name="C6",
@@ -349,4 +434,110 @@ async def test_handle_dispense_request(
             well_location=well_location,
         ),
         await hardware_api.dispense(mount=Mount.RIGHT, volume=25),
+    )
+
+
+async def test_handle_add_tip(
+    decoy: Decoy,
+    state_store: StateStore,
+    hardware_api: HardwareAPI,
+    labware_data_provider: LabwareDataProvider,
+    mock_hw_pipettes: MockPipettes,
+    tip_rack_def: LabwareDefinition,
+    subject: PipettingHandler,
+) -> None:
+    """It should add a tip manually to the hardware API."""
+    decoy.when(
+        state_store.pipettes.get_hardware_pipette(
+            pipette_id="pipette-id",
+            attached_pipettes=mock_hw_pipettes.by_mount,
+        )
+    ).then_return(
+        HardwarePipette(mount=Mount.LEFT, config=mock_hw_pipettes.left_config)
+    )
+
+    decoy.when(state_store.labware.get_definition("labware-id")).then_return(
+        tip_rack_def
+    )
+
+    decoy.when(
+        state_store.geometry.get_nominal_tip_geometry(
+            labware_id="labware-id",
+            pipette_config=mock_hw_pipettes.left_config,
+            well_name=None,
+        )
+    ).then_return(
+        TipGeometry(
+            effective_length=50,
+            diameter=5,
+            volume=300,
+        )
+    )
+
+    decoy.when(
+        await labware_data_provider.get_calibrated_tip_length(
+            pipette_serial=mock_hw_pipettes.left_config["pipette_id"],
+            labware_definition=tip_rack_def,
+        )
+    ).then_return(42)
+
+    await subject.add_tip(pipette_id="pipette-id", labware_id="labware-id")
+
+    decoy.verify(
+        await hardware_api.add_tip(mount=Mount.LEFT, tip_length=42),
+        hardware_api.set_current_tiprack_diameter(mount=Mount.LEFT, tiprack_diameter=5),
+        hardware_api.set_working_volume(mount=Mount.LEFT, tip_volume=300),
+    )
+
+
+async def test_handle_add_tip_length_fallback(
+    decoy: Decoy,
+    state_store: StateStore,
+    hardware_api: HardwareAPI,
+    labware_data_provider: LabwareDataProvider,
+    mock_hw_pipettes: MockPipettes,
+    tip_rack_def: LabwareDefinition,
+    subject: PipettingHandler,
+) -> None:
+    """It should add a tip to the HW API even if there's no calibrated length."""
+    decoy.when(
+        state_store.pipettes.get_hardware_pipette(
+            pipette_id="pipette-id",
+            attached_pipettes=mock_hw_pipettes.by_mount,
+        )
+    ).then_return(
+        HardwarePipette(mount=Mount.LEFT, config=mock_hw_pipettes.left_config)
+    )
+
+    decoy.when(state_store.labware.get_definition("labware-id")).then_return(
+        tip_rack_def
+    )
+
+    decoy.when(
+        state_store.geometry.get_nominal_tip_geometry(
+            labware_id="labware-id",
+            pipette_config=mock_hw_pipettes.left_config,
+            well_name=None,
+        )
+    ).then_return(
+        TipGeometry(
+            effective_length=50,
+            diameter=5,
+            volume=300,
+        )
+    )
+
+    decoy.when(
+        await labware_data_provider.get_calibrated_tip_length(
+            pipette_serial=mock_hw_pipettes.left_config["pipette_id"],
+            labware_definition=tip_rack_def,
+        )
+    ).then_return(None)
+
+    await subject.add_tip(pipette_id="pipette-id", labware_id="labware-id")
+
+    decoy.verify(
+        await hardware_api.add_tip(mount=Mount.LEFT, tip_length=50),
+        hardware_api.set_current_tiprack_diameter(mount=Mount.LEFT, tiprack_diameter=5),
+        hardware_api.set_working_volume(mount=Mount.LEFT, tip_volume=300),
     )

--- a/api/tests/opentrons/protocol_engine/resources/test_labware_data_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_labware_data_provider.py
@@ -1,4 +1,8 @@
-"""Functional tests for the LabwareData provider."""
+"""Functional tests for the LabwareDataProvider."""
+from typing import cast
+
+from opentrons_shared_data.labware.dev_types import LabwareDefinition as LabwareDefDict
+from opentrons.calibration_storage.helpers import hash_labware_def
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.protocol_api.labware import get_labware_definition
 
@@ -19,3 +23,22 @@ async def test_labware_data_gets_standard_definition() -> None:
     )
 
     assert result == LabwareDefinition.parse_obj(expected)
+
+
+async def test_labware_hash_match() -> None:
+    """Labware dict vs Pydantic model hashing should match.
+
+    This is a smoke test to ensure proper functioning of
+    LabwareDataProvider.get_calibrated_tip_length given its
+    internal implementation relies on this to work.
+    """
+    labware_dict = get_labware_definition(
+        load_name="opentrons_96_tiprack_300ul",
+        namespace="opentrons",
+        version=1,
+    )
+
+    labware_model = LabwareDefinition.parse_obj(labware_dict)
+    labware_model_dict = cast(LabwareDefDict, labware_model.dict(exclude_none=True))
+
+    assert hash_labware_def(labware_dict) == hash_labware_def(labware_model_dict)

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -479,7 +479,7 @@ def test_get_well_position_with_bottom_offset(
     )
 
 
-def test_get_effective_tip_length(
+def test_get_nominal_effective_tip_length(
     decoy: Decoy,
     labware_view: LabwareView,
     subject: GeometryView,
@@ -501,7 +501,7 @@ def test_get_effective_tip_length(
         "opentrons/opentrons_96_tiprack_300ul/1"
     )
 
-    length_eff = subject.get_effective_tip_length(
+    length_eff = subject.get_nominal_effective_tip_length(
         labware_id="tip-rack-id",
         pipette_config=pipette_config,
     )
@@ -512,7 +512,7 @@ def test_get_effective_tip_length(
         "opentrons/something_else/1"
     )
 
-    default_length_eff = subject.get_effective_tip_length(
+    default_length_eff = subject.get_nominal_effective_tip_length(
         labware_id="tip-rack-id",
         pipette_config=pipette_config,
     )
@@ -520,7 +520,7 @@ def test_get_effective_tip_length(
     assert default_length_eff == 40
 
 
-def test_get_tip_geometry(
+def test_get_nominal_tip_geometry(
     decoy: Decoy,
     tip_rack_def: LabwareDefinition,
     labware_view: LabwareView,
@@ -538,7 +538,7 @@ def test_get_tip_geometry(
         well_def
     )
 
-    tip_geometry = subject.get_tip_geometry(
+    tip_geometry = subject.get_nominal_tip_geometry(
         labware_id="tip-rack-id",
         well_name="B2",
         pipette_config=pipette_config,
@@ -549,7 +549,7 @@ def test_get_tip_geometry(
     assert tip_geometry.volume == well_def.totalLiquidVolume
 
 
-def test_get_tip_geometry_raises(
+def test_get_nominal_tip_geometry_raises(
     decoy: Decoy,
     tip_rack_def: LabwareDefinition,
     labware_view: LabwareView,
@@ -567,7 +567,7 @@ def test_get_tip_geometry_raises(
             well_def
         )
 
-        subject.get_tip_geometry(
+        subject.get_nominal_tip_geometry(
             labware_id="tip-rack-id", well_name="B2", pipette_config=pipette_config
         )
 

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -184,7 +184,7 @@ def test_quirks(
     assert reservoir_quirks == ["centerMultichannelOnWells", "touchTipDisabled"]
 
 
-def test_get_well_definition_bad_id(well_plate_def: LabwareDefinition) -> None:
+def test_get_well_definition_bad_name(well_plate_def: LabwareDefinition) -> None:
     """get_well_definition should raise if well name doesn't exist."""
     subject = get_labware_view(
         labware_by_id={"plate-id": plate},
@@ -196,7 +196,7 @@ def test_get_well_definition_bad_id(well_plate_def: LabwareDefinition) -> None:
 
 
 def test_get_well_definition(well_plate_def: LabwareDefinition) -> None:
-    """It should return a well definition by well ID."""
+    """It should return a well definition by well name."""
     subject = get_labware_view(
         labware_by_id={"plate-id": plate},
         definitions_by_uri={"some-plate-uri": well_plate_def},
@@ -204,6 +204,19 @@ def test_get_well_definition(well_plate_def: LabwareDefinition) -> None:
 
     expected_well_def = well_plate_def.wells["B2"]
     result = subject.get_well_definition(labware_id="plate-id", well_name="B2")
+
+    assert result == expected_well_def
+
+
+def test_get_well_definition_get_first(well_plate_def: LabwareDefinition) -> None:
+    """It should return the first well definition if no given well name."""
+    subject = get_labware_view(
+        labware_by_id={"plate-id": plate},
+        definitions_by_uri={"some-plate-uri": well_plate_def},
+    )
+
+    expected_well_def = well_plate_def.wells["A1"]
+    result = subject.get_well_definition(labware_id="plate-id", well_name=None)
 
     assert result == expected_well_def
 


### PR DESCRIPTION
## Overview

This PR based on the following overlooked, but highly important TODO:

https://github.com/Opentrons/opentrons/blob/81164a93d67e762421b5323e51c2e4b7bfc3d5cd/api/src/opentrons/protocol_engine/state/geometry.py#L140-L146

The `ProtocolEngine`'s tip pickup logic was written around the time of v4.0, when we first introduced the current tip length calibration procedure. This means that tip pickups during LPC in the 5.0 beta **have been using different tip length values than the actual protocol run**. I believe this explains offset discrepancies we've been seeing in the beta so far.

This PR implements "new" tip length calibration data in the ProtocolEngine. Closes #9220, based on test data (see below).

## Changelog

- take calibrated tip length into account during tip pickup
- take calibrated tip length into account during drop-tip-after-cancel

## Review requests

Besides normal code review, I think a smoke test to compare LPC values with v4.7 offset values is important to confirm this as a root cause of discrepancies we've been seeing. (That being said, this PR is still necessary even if it isn't the cause.)

### My smoke test results

Smoke testing on my robot, I found:

- The calculated Z offset differed between v4.7 and `edge` by the same amount as the difference between my tip rack's nominal tip length and calibrated tip length (~2 mm)
- X and Y offsets did not differ in a consistent amount nor by an amount outside our expected margins due to tip bending and inherent eyeball inaccuracy

#### Version 4.7 (non-LPC)

<img width="300" alt="Screen Shot 2022-01-12 at 17 36 19" src="https://user-images.githubusercontent.com/2963448/149242237-8f701fac-1117-4ffd-b0dc-f6724cccf937.png">

#### Current `edge` (beta LPC)

<img width="599" alt="Screen Shot 2022-01-12 at 17 49 03" src="https://user-images.githubusercontent.com/2963448/149242240-60c14eec-de6a-4223-938a-29dc9f99ff51.png">

#### This branch

<img width="572" alt="Screen Shot 2022-01-12 at 18 55 39" src="https://user-images.githubusercontent.com/2963448/149242261-82fdd8c3-ae95-43d3-a6a5-269b3a1d7ea6.png">


## Risk assessment

Low, bugfix. Changes affect LPC, but do not affect PAPIv2 protocols at run time.
