### PR TITLE
perf(app): memoize command items to reduce rerender on run poll

### DIFF
--- a/app/src/organisms/RunDetails/CommandItem.tsx
+++ b/app/src/organisms/RunDetails/CommandItem.tsx
@@ -73,7 +73,7 @@ const commandIsComplete = (status: RunCommandSummary['status']): boolean =>
 export const OBSERVER_DELAY = 300
 
 function CommandItemComponent(props: CommandItemProps): JSX.Element | null {
-  const {analysisCommand, runCommandSummary, runStatus, currentRunId} = props
+  const { analysisCommand, runCommandSummary, runStatus, currentRunId } = props
   const { t } = useTranslation('run_details')
   const [commandItemRef, isInView] = useInView({
     delay: OBSERVER_DELAY,
@@ -198,14 +198,19 @@ function CommandItemComponent(props: CommandItemProps): JSX.Element | null {
 export const CommandItem = React.memo(
   CommandItemComponent,
   (prevProps, nextProps) => {
-    const shouldRerender = !isEqual(prevProps.analysisCommand, nextProps.analysisCommand)
-      || !isEqual(prevProps.runCommandSummary, nextProps.runCommandSummary)
-      || (
-        (([RUN_STATUS_PAUSED, RUN_STATUS_PAUSE_REQUESTED] as RunStatus[]).includes(nextProps.runStatus)
-        || ([RUN_STATUS_PAUSED, RUN_STATUS_PAUSE_REQUESTED] as RunStatus[]).includes(prevProps.runStatus)) &&
-        (prevProps.runCommandSummary?.status === 'running'
-        || nextProps.runCommandSummary?.status === 'running')
-      )
+    const shouldRerender =
+      !isEqual(prevProps.analysisCommand, nextProps.analysisCommand) ||
+      !isEqual(prevProps.runCommandSummary, nextProps.runCommandSummary) ||
+      ((([
+        RUN_STATUS_PAUSED,
+        RUN_STATUS_PAUSE_REQUESTED,
+      ] as RunStatus[]).includes(nextProps.runStatus) ||
+        ([
+          RUN_STATUS_PAUSED,
+          RUN_STATUS_PAUSE_REQUESTED,
+        ] as RunStatus[]).includes(prevProps.runStatus)) &&
+        (prevProps.runCommandSummary?.status === 'running' ||
+          nextProps.runCommandSummary?.status === 'running'))
     return !shouldRerender
   }
 )

--- a/app/src/organisms/RunDetails/CommandItem.tsx
+++ b/app/src/organisms/RunDetails/CommandItem.tsx
@@ -72,7 +72,7 @@ const commandIsComplete = (status: RunCommandSummary['status']): boolean =>
 // minimum delay in MS for observer notifications
 export const OBSERVER_DELAY = 300
 
-function CommandItemComponent(props: CommandItemProps): JSX.Element | null {
+export function CommandItemComponent(props: CommandItemProps): JSX.Element | null {
   const { analysisCommand, runCommandSummary, runStatus, currentRunId } = props
   const { t } = useTranslation('run_details')
   const [commandItemRef, isInView] = useInView({

--- a/app/src/organisms/RunDetails/CommandItem.tsx
+++ b/app/src/organisms/RunDetails/CommandItem.tsx
@@ -72,7 +72,9 @@ const commandIsComplete = (status: RunCommandSummary['status']): boolean =>
 // minimum delay in MS for observer notifications
 export const OBSERVER_DELAY = 300
 
-export function CommandItemComponent(props: CommandItemProps): JSX.Element | null {
+export function CommandItemComponent(
+  props: CommandItemProps
+): JSX.Element | null {
   const { analysisCommand, runCommandSummary, runStatus, currentRunId } = props
   const { t } = useTranslation('run_details')
   const [commandItemRef, isInView] = useInView({

--- a/app/src/organisms/RunDetails/CommandList.tsx
+++ b/app/src/organisms/RunDetails/CommandList.tsx
@@ -283,6 +283,7 @@ export function CommandList(): JSX.Element | null {
                       analysisCommand={command.analysisCommand}
                       runCommandSummary={command.runCommandSummary}
                       runStatus={runStatus}
+                      currentRunId={runRecord?.data.id ?? null}
                     />
                   </Flex>
                 </Flex>

--- a/app/src/organisms/RunDetails/__tests__/CommandItem.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/CommandItem.test.tsx
@@ -95,6 +95,8 @@ describe('Run Details Command item', () => {
     const { getByText } = render({
       runCommandSummary: { ...MOCK_COMMAND_SUMMARY, status: 'failed' },
       analysisCommand: { ...MOCK_ANALYSIS_COMMAND },
+      runStatus: 'running',
+      currentRunId: RUN_ID,
     })
     expect(getByText('Step failed')).toHaveStyle(
       'backgroundColor: C_ERROR_LIGHT'
@@ -107,6 +109,7 @@ describe('Run Details Command item', () => {
       runCommandSummary: { ...MOCK_COMMAND_SUMMARY, status: 'succeeded' },
       analysisCommand: { ...MOCK_ANALYSIS_COMMAND },
       runStatus: 'succeeded',
+      currentRunId: RUN_ID,
     } as React.ComponentProps<typeof CommandItem>
     const { getByText } = render(props)
     expect(getByText('Mock Command Timer')).toHaveStyle(
@@ -119,6 +122,7 @@ describe('Run Details Command item', () => {
       runCommandSummary: { ...MOCK_COMMAND_SUMMARY, status: 'running' },
       analysisCommand: { ...MOCK_ANALYSIS_COMMAND },
       runStatus: 'running',
+      currentRunId: RUN_ID,
     } as React.ComponentProps<typeof CommandItem>
     const { getByText } = render(props)
     expect(getByText('Current Step')).toHaveStyle(
@@ -133,6 +137,7 @@ describe('Run Details Command item', () => {
       runCommandSummary: { ...MOCK_COMMAND_SUMMARY, status: 'queued' },
       analysisCommand: { ...MOCK_ANALYSIS_COMMAND },
       runStatus: 'running',
+      currentRunId: RUN_ID,
     } as React.ComponentProps<typeof CommandItem>
     const { getByText } = render(props)
     expect(getByText('Mock Command Text')).toHaveStyle(
@@ -145,6 +150,7 @@ describe('Run Details Command item', () => {
       runCommandSummary: { ...MOCK_COMMAND_SUMMARY, status: 'running' },
       analysisCommand: { ...MOCK_ANALYSIS_COMMAND },
       runStatus: 'paused',
+      currentRunId: RUN_ID,
     } as React.ComponentProps<typeof CommandItem>
     const { getByText } = render(props)
     expect(getByText('Current Step - Paused by User')).toHaveStyle(
@@ -177,6 +183,7 @@ describe('Run Details Command item', () => {
       runCommandSummary: MOCK_COMMENT_COMMAND_SUMMARY,
       analysisCommand: MOCK_COMMENT_COMMAND,
       runStatus: 'running',
+      currentRunId: RUN_ID,
     } as React.ComponentProps<typeof CommandItem>
     const { getByText } = render(props)
     expect(getByText('Comment')).toHaveStyle('backgroundColor: C_NEAR_WHITE')
@@ -214,6 +221,7 @@ describe('Run Details Command item', () => {
       runCommandSummary: MOCK_PAUSE_COMMAND_SUMMARY,
       analysisCommand: MOCK_PAUSE_COMMAND,
       runStatus: 'paused',
+      currentRunId: RUN_ID,
     } as React.ComponentProps<typeof CommandItem>
     const { getByText } = render(props)
     expect(getByText('Pause protocol')).toHaveStyle(

--- a/app/src/organisms/RunDetails/__tests__/CommandList.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/CommandList.test.tsx
@@ -11,7 +11,7 @@ import { ProtocolSetupInfo } from '../ProtocolSetupInfo'
 import { CommandList } from '../CommandList'
 import fixtureAnalysis from '@opentrons/app/src/organisms/RunDetails/Fixture_analysis.json'
 import fixtureCommandSummary from '@opentrons/app/src/organisms/RunDetails/Fixture_commandSummary.json'
-import { CommandItem } from '../CommandItem'
+import { CommandItemComponent as CommandItem } from '../CommandItem'
 import type { ProtocolFile } from '@opentrons/shared-data'
 
 jest.mock('../hooks')


### PR DESCRIPTION
# Overview

Memoize renders of the `CommandItem` component within the run details page to reduce stress on the DOM during long protocols (with many commands). 

This is a helpful first step to making the run detail page more performant for long protocols.  We will likely follow this up with more improvements.

# Changelog

- memoize the `CommandItem` component to only re-render when necessary
- pass down the current run id to the `CommandItem` to remove dependencies and rerendering when 'runs' query key is invalidated

# Review requests

Upload a protocol and make sure it runs as expected

# Risk assessment

low