### PR TITLE
refactor(app): spin or block run controls when finishing or stop requested

### DIFF
--- a/app/src/organisms/RunDetails/__tests__/RunDetails.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/RunDetails.test.tsx
@@ -7,6 +7,10 @@ import {
   RUN_STATUS_SUCCEEDED,
   RUN_STATUS_FAILED,
   RUN_STATUS_STOPPED,
+  RUN_STATUS_FINISHING,
+  RUN_STATUS_PAUSED,
+  RUN_STATUS_PAUSE_REQUESTED,
+  RUN_STATUS_STOP_REQUESTED,
 } from '@opentrons/api-client'
 import { renderWithProviders } from '@opentrons/components'
 import { resetAllWhenMocks, when } from 'jest-when'
@@ -101,6 +105,29 @@ describe('RunDetails', () => {
     expect(getByText('yes, cancel run')).toBeTruthy()
   })
 
+  it('renders a cancel run button when the status is finishing', () => {
+    when(mockUseRunStatus).calledWith().mockReturnValue(RUN_STATUS_FINISHING)
+    const { getByRole } = render()
+    const button = getByRole('button', { name: 'Cancel Run' })
+    expect(button).toBeEnabled()
+  })
+
+  it('renders a cancel run button when the status is paused', () => {
+    when(mockUseRunStatus).calledWith().mockReturnValue(RUN_STATUS_PAUSED)
+    const { getByRole } = render()
+    const button = getByRole('button', { name: 'Cancel Run' })
+    expect(button).toBeEnabled()
+  })
+
+  it('renders a cancel run button when the status is pause requested', () => {
+    when(mockUseRunStatus)
+      .calledWith()
+      .mockReturnValue(RUN_STATUS_PAUSE_REQUESTED)
+    const { getByRole } = render()
+    const button = getByRole('button', { name: 'Cancel Run' })
+    expect(button).toBeEnabled()
+  })
+
   it('renders the protocol close button, button is clickable, and confirm close protocol modal is rendered when status is succeeded', () => {
     when(mockUseRunStatus).calledWith().mockReturnValue(RUN_STATUS_SUCCEEDED)
     const { getByRole, getByText } = render()
@@ -138,6 +165,15 @@ describe('RunDetails', () => {
     ).toBeTruthy()
     expect(getByText('No, go back')).toBeTruthy()
     expect(getByText('Yes, close now')).toBeTruthy()
+  })
+
+  it('renders no button in the titlebar when the run status is stop requested', () => {
+    when(mockUseRunStatus)
+      .calledWith()
+      .mockReturnValue(RUN_STATUS_STOP_REQUESTED)
+    const { queryByRole } = render()
+    const button = queryByRole('button', { name: 'close' })
+    expect(button).not.toBeInTheDocument()
   })
 
   it('redirects to /upload if protocol run is not loaded', () => {

--- a/app/src/organisms/RunDetails/index.tsx
+++ b/app/src/organisms/RunDetails/index.tsx
@@ -7,6 +7,8 @@ import {
   RUN_STATUS_RUNNING,
   RUN_STATUS_PAUSED,
   RUN_STATUS_PAUSE_REQUESTED,
+  RUN_STATUS_FINISHING,
+  RUN_STATUS_STOP_REQUESTED,
 } from '@opentrons/api-client'
 import {
   SPACING_2,
@@ -81,11 +83,16 @@ export function RunDetails(): JSX.Element | null {
   if (
     adjustedRunStatus === RUN_STATUS_RUNNING ||
     adjustedRunStatus === RUN_STATUS_PAUSED ||
-    adjustedRunStatus === RUN_STATUS_PAUSE_REQUESTED
+    adjustedRunStatus === RUN_STATUS_PAUSE_REQUESTED ||
+    adjustedRunStatus === RUN_STATUS_FINISHING
   ) {
     titleBarProps = {
       title: t('protocol_title', { protocol_name: displayName }),
       rightNode: cancelRunButton,
+    }
+  } else if (adjustedRunStatus === RUN_STATUS_STOP_REQUESTED) {
+    titleBarProps = {
+      title: t('protocol_title', { protocol_name: displayName }),
     }
   } else {
     titleBarProps = {


### PR DESCRIPTION
# Overview

This PR adds a spinner to the Run Again button or blocks the cancel/close buttons for the finishing
and stop requested statuses. closes #9216

# Changelog

- Show cancel button when run is Finishing
- Hide titlebar buttons when run status is stop requested

# Review requests

- Check that when the status is Finishing the cancel button is showing
- Check that there are no buttons when the run status is stop requested
- Check that the Run Again button is blocked and spinning when the status is either Finishing or Stop Requested (this was addressed in #9229, but double check to make sure it is still working)

# Risk assessment

low
