### PR TITLE
refactor(app): remove .zip from invalid file type alertItem

### DIFF
--- a/app/src/assets/localization/en/protocol_info.json
+++ b/app/src/assets/localization/en/protocol_info.json
@@ -12,7 +12,7 @@
   "instrument_not_attached": "Not attached",
   "instrument_cal_data_title": "Calibration data",
   "instruments_title": "Required Pipettes",
-  "invalid_file_type": "Invalid file type. Protocols must be '.py', '.json', or '.zip'.",
+  "invalid_file_type": "Invalid file type. Protocols must be '.py' or '.json'.",
   "invalid_json_file": "Invalid JSON file.",
   "labware_title": "Required Labware",
   "labware_legacy_definition": "N/A",


### PR DESCRIPTION
closes #9232 

# Overview

thie PR removes .zip files from the upload error banner text as something that is uploadable. 


<img width="1025" alt="Screen Shot 2022-01-14 at 13 10 45" src="https://user-images.githubusercontent.com/66035149/149569505-1fdede9e-e6b3-4a2a-8e9b-584377f47e45.png">

# Changelog

- edit `.json` file to remove zip mentioned from the banner text

# Review requests

- review above image and/or check on robot

# Risk assessment

low, behind ff
