### PR TITLE
feat(robot-server): Add the `key` field to command HTTP summaries

### DIFF
--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -10,7 +10,7 @@ from typing_extensions import Literal
 from fastapi import APIRouter, Depends, status
 from pydantic import BaseModel, Field
 
-from opentrons.protocol_engine import LabwareOffsetCreate
+from opentrons.protocol_engine import Command, LabwareOffsetCreate
 
 from robot_server.errors import ErrorDetails, ErrorBody
 from robot_server.service.dependencies import get_current_time, get_unique_id
@@ -113,15 +113,7 @@ async def get_run_data_from_url(
         createdAt=run.created_at,
         current=run.is_current,
         actions=run.actions,
-        commands=[
-            RunCommandSummary.construct(
-                id=c.id,
-                commandType=c.commandType,
-                status=c.status,
-                errorId=c.errorId,
-            )
-            for c in engine_state.commands.get_all()
-        ],
+        commands=[_summarize_command(c) for c in engine_state.commands.get_all()],
         errors=engine_state.commands.get_all_errors(),
         pipettes=engine_state.pipettes.get_all(),
         labware=engine_state.labware.get_all(),
@@ -199,12 +191,7 @@ async def create_run(
         createdAt=run.created_at,
         current=run.is_current,
         actions=run.actions,
-        commands=[
-            RunCommandSummary.construct(
-                id=c.id, commandType=c.commandType, status=c.status
-            )
-            for c in engine_state.commands.get_all()
-        ],
+        commands=[_summarize_command(c) for c in engine_state.commands.get_all()],
         errors=[],
         pipettes=engine_state.pipettes.get_all(),
         labware=engine_state.labware.get_all(),
@@ -248,15 +235,7 @@ async def get_runs(
             createdAt=run.created_at,
             current=run.is_current,
             actions=run.actions,
-            commands=[
-                RunCommandSummary.construct(
-                    id=c.id,
-                    commandType=c.commandType,
-                    status=c.status,
-                    errorId=c.errorId,
-                )
-                for c in engine_state.commands.get_all()
-            ],
+            commands=[_summarize_command(c) for c in engine_state.commands.get_all()],
             errors=engine_state.commands.get_all_errors(),
             pipettes=engine_state.pipettes.get_all(),
             labware=engine_state.labware.get_all(),
@@ -386,15 +365,7 @@ async def add_labware_offset(
         createdAt=run.created_at,
         current=run.is_current,
         actions=run.actions,
-        commands=[
-            RunCommandSummary.construct(
-                id=c.id,
-                commandType=c.commandType,
-                status=c.status,
-                errorId=c.errorId,
-            )
-            for c in engine_state.commands.get_all()
-        ],
+        commands=[_summarize_command(c) for c in engine_state.commands.get_all()],
         errors=engine_state.commands.get_all_errors(),
         pipettes=engine_state.pipettes.get_all(),
         labware=engine_state.labware.get_all(),
@@ -464,15 +435,7 @@ async def update_run(
         createdAt=run.created_at,
         current=run.is_current,
         actions=run.actions,
-        commands=[
-            RunCommandSummary.construct(
-                id=c.id,
-                commandType=c.commandType,
-                status=c.status,
-                errorId=c.errorId,
-            )
-            for c in engine_state.commands.get_all()
-        ],
+        commands=[_summarize_command(c) for c in engine_state.commands.get_all()],
         errors=engine_state.commands.get_all_errors(),
         pipettes=engine_state.pipettes.get_all(),
         labware=engine_state.labware.get_all(),
@@ -483,4 +446,14 @@ async def update_run(
     return await PydanticResponse.create(
         content=SimpleBody.construct(data=data),
         status_code=status.HTTP_200_OK,
+    )
+
+
+def _summarize_command(full_command: Command) -> RunCommandSummary:
+    return RunCommandSummary.construct(
+        id=full_command.id,
+        key=full_command.key,
+        commandType=full_command.commandType,
+        status=full_command.status,
+        errorId=full_command.errorId,
     )

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -21,6 +21,10 @@ class RunCommandSummary(ResourceModel):
     """A stripped down model of a full Command for usage in a Run response."""
 
     id: str = Field(..., description="Unique command identifier.")
+    key: str = Field(
+        ...,
+        description="An identifier representing this command as a step in a protocol.",
+    )
     commandType: CommandType = Field(..., description="Specific type of command.")
     status: CommandStatus = Field(..., description="Execution status of the command.")
     errorId: Optional[str] = Field(

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -322,6 +322,7 @@ async def test_get_run_data_from_url(
         commands=[
             RunCommandSummary.construct(
                 id=command.id,
+                key=command.key,
                 commandType=command.commandType,
                 status=command.status,
             ),
@@ -404,6 +405,7 @@ async def test_get_run_with_errors(
         commands=[
             RunCommandSummary.construct(
                 id=command.id,
+                key=command.key,
                 commandType=command.commandType,
                 status=command.status,
                 errorId="error-1",

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -104,6 +104,7 @@ async def test_get_run_commands() -> None:
     """It should return a list of all commands in a run."""
     command_summary = RunCommandSummary.construct(
         id="command-id",
+        key="command-key",
         commandType="moveToWell",
         status=CommandStatus.RUNNING,
     )
@@ -135,6 +136,7 @@ async def test_get_run_command_by_id(
     """It should return full details about a command by ID."""
     command_summary = RunCommandSummary.construct(
         id="command-id",
+        key="command-key",
         commandType="moveToWell",
         status=CommandStatus.RUNNING,
     )

--- a/robot-server/tests/service/session/test_manager.py
+++ b/robot-server/tests/service/session/test_manager.py
@@ -88,6 +88,10 @@ def test_get_by_id_not_found(session_manager):
     assert session_manager.get_by_id(create_identifier()) is None
 
 
+# fixme(mm, 2022-01-14): This looks like a flaky test
+# because the session_manager.add() tasks will run and return
+# in a nondeterministic order.
+@pytest.mark.xfail(strict=False)
 async def test_get_by_type(session_manager):
     sessions = await asyncio.gather(
         *[


### PR DESCRIPTION
# Changelog

* Add the `key` field to command HTTP summaries. Closes #9251.
* Mark an unrelated test that's known to be flaky, and is about to be removed with RPC, so it doesn't fail the test suite.

# Review requests

Glancing over the code is probably good enough for this PR. I've smoke-tested on a dev server with a live session and confirmed that `key` shows up.

# Risk assessment

Low. 