### PR TITLE
feat(app): add X icon to close out of exta attention warning labels

### DIFF
--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/ExtraAttentionWarning.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/ExtraAttentionWarning.tsx
@@ -16,6 +16,8 @@ import {
   COLOR_WARNING_LIGHT,
   C_DARK_GRAY,
   TEXT_DECORATION_UNDERLINE,
+  JUSTIFY_SPACE_BETWEEN,
+  DIRECTION_COLUMN,
 } from '@opentrons/components'
 import { getModuleName } from './utils/getModuleName'
 import { SecureLabwareModal } from './SecureLabwareModal'
@@ -69,13 +71,21 @@ const ModuleWarning = (props: {
 
 export const ExtraAttentionWarning = (
   props: ExtraAttentionWarningProps
-): JSX.Element => {
+): JSX.Element | null => {
   const { moduleTypes } = props
   const [
     secureLabwareModalType,
     setSecureLabwareModalType,
   ] = React.useState<ModuleTypesThatRequiresExtraAttention | null>(null)
   const { t } = useTranslation('protocol_setup')
+  const [
+    showExtraAttentionWarning,
+    setShowExtraAttentionWarning,
+  ] = React.useState(false)
+
+  const isVisible = !showExtraAttentionWarning && moduleTypes !== []
+  if (!isVisible) return null
+
   return (
     <React.Fragment>
       {secureLabwareModalType != null && (
@@ -90,18 +100,27 @@ export const ExtraAttentionWarning = (
         color={C_DARK_GRAY}
         id={'ExtraAttentionWarning'}
       >
-        <Box margin={SPACING_3}>
-          <Flex margin={SPACING_2}>
-            <Box size={SIZE_2} paddingY={SPACING_1} paddingRight={SPACING_2}>
-              <Icon name="alert-circle" color={COLOR_WARNING} />
-            </Box>
-            <Text
-              as="h4"
-              marginY={SPACING_2}
-              id={`ExtraAttentionWarning_title`}
+        <Flex flexDirection={DIRECTION_COLUMN} flex="auto" margin={SPACING_3}>
+          <Flex margin={SPACING_2} justifyContent={JUSTIFY_SPACE_BETWEEN}>
+            <Flex>
+              <Box size={SIZE_2} paddingY={SPACING_1} paddingRight={SPACING_2}>
+                <Icon name="alert-circle" color={COLOR_WARNING} />
+              </Box>
+              <Text
+                as="h4"
+                marginY={SPACING_2}
+                id={`ExtraAttentionWarning_title`}
+              >
+                {t('extra_attention_warning_title')}
+              </Text>
+            </Flex>
+            <Btn
+              size={SIZE_2}
+              onClick={() => setShowExtraAttentionWarning(true)}
+              aria-label="close"
             >
-              {t('extra_attention_warning_title')}
-            </Text>
+              <Icon name={'close'} color={COLOR_WARNING} />
+            </Btn>
           </Flex>
           {moduleTypes.map(moduleType => (
             <ModuleWarning
@@ -110,7 +129,7 @@ export const ExtraAttentionWarning = (
               onLinkClick={() => setSecureLabwareModalType(moduleType)}
             />
           ))}
-        </Box>
+        </Flex>
       </Box>
     </React.Fragment>
   )

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/ExtraAttentionWarning.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/ExtraAttentionWarning.tsx
@@ -81,10 +81,10 @@ export const ExtraAttentionWarning = (
   const { t } = useTranslation('protocol_setup')
   const [
     showExtraAttentionWarning,
-    setShowExtraAttentionWarning,
+    setHideExtraAttentionWarning,
   ] = React.useState(false)
 
-  const isVisible = !showExtraAttentionWarning && moduleTypes !== []
+  const isVisible = !showExtraAttentionWarning
   if (!isVisible) return null
 
   return (
@@ -101,7 +101,7 @@ export const ExtraAttentionWarning = (
         color={C_DARK_GRAY}
         id={'ExtraAttentionWarning'}
       >
-        <Flex flexDirection={DIRECTION_COLUMN} flex="auto" margin={SPACING_3}>
+        <Flex flexDirection={DIRECTION_COLUMN} margin={SPACING_3}>
           <Flex margin={SPACING_2} justifyContent={JUSTIFY_SPACE_BETWEEN}>
             <Flex>
               <Box size={SIZE_2} paddingY={SPACING_1} paddingRight={SPACING_2}>
@@ -118,7 +118,7 @@ export const ExtraAttentionWarning = (
             </Flex>
             <Btn
               size={SIZE_2}
-              onClick={() => setShowExtraAttentionWarning(true)}
+              onClick={() => setHideExtraAttentionWarning(true)}
               aria-label="close"
             >
               <Icon name={'close'} color={COLOR_WARNING} />

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/ExtraAttentionWarning.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/ExtraAttentionWarning.tsx
@@ -18,6 +18,7 @@ import {
   TEXT_DECORATION_UNDERLINE,
   JUSTIFY_SPACE_BETWEEN,
   DIRECTION_COLUMN,
+  COLOR_WARNING_DARK,
 } from '@opentrons/components'
 import { getModuleName } from './utils/getModuleName'
 import { SecureLabwareModal } from './SecureLabwareModal'
@@ -110,6 +111,7 @@ export const ExtraAttentionWarning = (
                 as="h4"
                 marginY={SPACING_2}
                 id={`ExtraAttentionWarning_title`}
+                color={COLOR_WARNING_DARK}
               >
                 {t('extra_attention_warning_title')}
               </Text>

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/ExtraAttentionWarning.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/ExtraAttentionWarning.tsx
@@ -80,11 +80,11 @@ export const ExtraAttentionWarning = (
   ] = React.useState<ModuleTypesThatRequiresExtraAttention | null>(null)
   const { t } = useTranslation('protocol_setup')
   const [
-    showExtraAttentionWarning,
+    hideExtraAttentionWarning,
     setHideExtraAttentionWarning,
   ] = React.useState(false)
 
-  const isVisible = !showExtraAttentionWarning
+  const isVisible = !hideExtraAttentionWarning
   if (!isVisible) return null
 
   return (

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/ExtraAttentionWarning.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/ExtraAttentionWarning.test.tsx
@@ -33,6 +33,21 @@ describe('ExtraAttentionWarning', () => {
       name: 'Secure labware and modules before proceeding to run',
     })
   })
+  it('should click on the X icon and close the warning label', () => {
+    const { queryByText, getByRole } = render(props)
+    const closeButton = getByRole('button', {
+      name: /close/i,
+    })
+    getByRole('heading', {
+      name: 'Secure labware and modules before proceeding to run',
+    })
+
+    fireEvent.click(closeButton)
+
+    expect(
+      queryByText('Secure labware and modules before proceeding to run')
+    ).toBeNull()
+  })
   it('should render the correct text for the mag mod', () => {
     props = {
       ...props,

--- a/components/src/styles/colors.ts
+++ b/components/src/styles/colors.ts
@@ -19,6 +19,7 @@ export const C_POWDER_BLUE = '#f1f8ff'
 // TODO(mc, 2020-10-08): s/COLOR_/C_
 export const COLOR_WARNING = '#e28200'
 export const COLOR_WARNING_LIGHT = '#ffd58f'
+export const COLOR_WARNING_DARK = '#9e5e00'
 export const COLOR_ERROR = '#d12929'
 export const COLOR_SUCCESS = '#60b120'
 export const C_DISABLED = '#9c9c9c'


### PR DESCRIPTION
closes #8487

# Overview

This PR adds an X icon to the top right corner of the extra attention warning so the user can dismiss the warning.

<img width="954" alt="Screen Shot 2022-01-14 at 15 10 38" src="https://user-images.githubusercontent.com/66035149/149578855-e0311633-f15f-40be-b0e1-9bd676e3b8e4.png">



# Changelog

- added button with `close` icon to `ExtraAttentionWarning`
- created `COLOR_WARNING_DARK` for title text

# Review requests

- test on robot and compare to design

# Risk assessment

low, behind ff