### PR TITLE
refactor(robot-server): remove deprecated protocols endpoints and FF

### DIFF
--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -23,11 +23,7 @@ from uuid import uuid4
 from opentrons.types import Mount as MountType
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
-from opentrons.api.util import (
-    RobotBusy,
-    robot_is_busy,
-    requires_http_protocols_disabled,
-)
+from opentrons.api.util import RobotBusy, robot_is_busy
 from opentrons.drivers.smoothie_drivers.errors import SmoothieAlarm
 from opentrons.broker import Broker
 from opentrons.config import feature_flags as ff
@@ -93,7 +89,6 @@ class SessionManager:
         self._broker.set_logger(self._command_logger)
         self._motion_lock = lock or ThreadedAsyncLock()
 
-    @requires_http_protocols_disabled
     def create(self, name: str, contents: str, is_binary: bool = False) -> Session:
         """Create a protocol session from either
 
@@ -147,7 +142,6 @@ class SessionManager:
         finally:
             self._session_lock = False
 
-    @requires_http_protocols_disabled
     def create_from_bundle(self, name: str, contents: str) -> Session:
         """Create a protocol session from a base64'd zip file.
 
@@ -184,7 +178,6 @@ class SessionManager:
         finally:
             self._session_lock = False
 
-    @requires_http_protocols_disabled
     def create_with_extra_labware(
         self, name: str, contents: str, extra_labware: List[LabwareDefinition]
     ) -> Session:

--- a/api/src/opentrons/api/util.py
+++ b/api/src/opentrons/api/util.py
@@ -2,7 +2,6 @@ import functools
 from abc import ABC, abstractmethod
 from typing import Any, cast, Callable, TypeVar
 
-from opentrons.config.feature_flags import enable_http_protocol_sessions
 from opentrons.hardware_control import ThreadedAsyncLock
 
 
@@ -33,25 +32,5 @@ def robot_is_busy(func: Func) -> Func:
                 return func(*args, **kwargs)
         else:
             return func(*args, **kwargs)
-
-    return cast(Func, decorated)
-
-
-def requires_http_protocols_disabled(func: Func) -> Func:
-    """Decorator that makes sure the enableHttpProtocolSessions is disabled
-    before proceeding.
-
-    :raises RuntimeError: if enableHttpProtocolSessions is enabled
-    """
-
-    @functools.wraps(func)
-    def decorated(*args: Any, **kwargs: Any) -> Any:
-        if enable_http_protocol_sessions():
-            raise RuntimeError(
-                "Please disable the 'Enable Experimental HTTP Protocol "
-                "Sessions' advanced setting for this robot if you'd like to "
-                "upload protocols from the Opentrons App"
-            )
-        return func(*args, **kwargs)
 
     return cast(Func, decorated)

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -158,16 +158,6 @@ settings = [
         restart_required=False,
     ),
     SettingDefinition(
-        _id="enableHttpProtocolSessions",
-        title="Enable deprecated experimental HTTP protocol upload",
-        description=(
-            "This setting is deprecated and exists only for backwards compatibility."
-            " If you have been using this setting, we recommend you disable it and"
-            " transition to using the standard HTTP API added in version 5."
-        ),
-        restart_required=True,
-    ),
-    SettingDefinition(
         _id="enableOT3HardwareController",
         title="Enable experimental OT3 hardware controller",
         description=(
@@ -428,6 +418,16 @@ def _migrate12to13(previous: SettingsMap) -> SettingsMap:
     return newmap
 
 
+def _migrate13to14(previous: SettingsMap) -> SettingsMap:
+    """Migrate to version 14 of the feature flags file.
+
+    - Removes deprecated enableHttpProtocolSessions option
+    """
+    removals = ["enableHttpProtocolSessions"]
+    newmap = {k: v for k, v in previous.items() if k not in removals}
+    return newmap
+
+
 _MIGRATIONS = [
     _migrate0to1,
     _migrate1to2,
@@ -442,6 +442,7 @@ _MIGRATIONS = [
     _migrate10to11,
     _migrate11to12,
     _migrate12to13,
+    _migrate13to14,
 ]
 """
 List of all migrations to apply, indexed by (version - 1). See _migrate below

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -21,10 +21,6 @@ def enable_door_safety_switch() -> bool:
     return advs.get_setting_with_env_overload("enableDoorSafetySwitch")
 
 
-def enable_http_protocol_sessions() -> bool:
-    return advs.get_setting_with_env_overload("enableHttpProtocolSessions")
-
-
 def disable_fast_protocol_upload() -> bool:
     return advs.get_setting_with_env_overload("disableFastProtocolUpload")
 

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -1,10 +1,8 @@
-from unittest.mock import patch
 import itertools
 import copy
 import pytest
 import base64
 
-from opentrons.api import session
 from opentrons.api.session import _accumulate, _dedupe
 from opentrons.hardware_control import ThreadedAsyncForbidden
 
@@ -320,51 +318,3 @@ def run(ctx):
 
             for future in as_completed(tasks):
                 future.result()
-
-
-@pytest.mark.parametrize(
-    argnames="create_func,extra_kwargs",
-    argvalues=[
-        [session.SessionManager.create, {}],
-        [session.SessionManager.create_from_bundle, {}],
-        [session.SessionManager.create_with_extra_labware, {"extra_labware": {}}],
-    ],
-)
-def test_http_protocol_sessions_disabled(
-    session_manager, protocol, create_func, extra_kwargs
-):
-    """Test that we can create a session if enableHttpProtocolSessions is
-    disabled."""
-    with patch.object(session.Session, "build_and_prep") as mock_build:
-        with patch("opentrons.api.util.enable_http_protocol_sessions") as m:
-            m.return_value = False
-            create_func(
-                session_manager, name="<blank>", contents=protocol.text, **extra_kwargs
-            )
-            mock_build.assert_called_once()
-
-
-@pytest.mark.parametrize(
-    argnames="create_func,extra_kwargs",
-    argvalues=[
-        [session.SessionManager.create, {}],
-        [session.SessionManager.create_from_bundle, {}],
-        [session.SessionManager.create_with_extra_labware, {"extra_labware": {}}],
-    ],
-)
-async def test_http_protocol_sessions_enabled(
-    session_manager, protocol, create_func, extra_kwargs
-):
-    """Test that we cannot create a session if enableHttpProtocolSessions is
-    enabled."""
-    with patch.object(session.Session, "build_and_prep"):
-        with patch("opentrons.api.util.enable_http_protocol_sessions") as m:
-            m.return_value = True
-            with pytest.raises(
-                RuntimeError,
-                match="Please disable the 'Enable Experimental HTTP "
-                "Protocol Sessions' advanced setting for this robot "
-                "if you'd like to upload protocols from the "
-                "Opentrons App",
-            ):
-                session_manager.create(name="<blank>", contents=protocol.text)

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -7,7 +7,7 @@ from opentrons.config.advanced_settings import _migrate, _ensure
 
 @pytest.fixture
 def migrated_file_version() -> int:
-    return 13
+    return 14
 
 
 @pytest.fixture
@@ -19,7 +19,6 @@ def default_file_settings() -> Dict[str, Optional[bool]]:
         "useOldAspirationFunctions": None,
         "disableLogAggregation": None,
         "enableDoorSafetySwitch": None,
-        "enableHttpProtocolSessions": None,
         "disableFastProtocolUpload": None,
         "enableOT3HardwareController": None,
     }
@@ -185,6 +184,14 @@ def v13_config(v12_config):
     return r
 
 
+@pytest.fixture
+def v14_config(v13_config):
+    r = v13_config.copy()
+    r.pop("enableHttpProtocolSessions")
+    r.update({"_version": 14})
+    return r
+
+
 @pytest.fixture(
     scope="session",
     params=[
@@ -203,6 +210,7 @@ def v13_config(v12_config):
         lazy_fixture("v11_config"),
         lazy_fixture("v12_config"),
         lazy_fixture("v13_config"),
+        lazy_fixture("v14_config"),
     ],
 )
 def old_settings(request):
@@ -271,7 +279,6 @@ def test_ensures_config():
         "useOldAspirationFunctions": None,
         "disableLogAggregation": True,
         "enableDoorSafetySwitch": None,
-        "enableHttpProtocolSessions": None,
         "disableFastProtocolUpload": None,
         "enableOT3HardwareController": None,
     }

--- a/robot-server/robot_server/router.py
+++ b/robot-server/robot_server/router.py
@@ -1,10 +1,6 @@
 """Application routes."""
 from fastapi import APIRouter, Depends, status
 
-from opentrons.config.feature_flags import (
-    enable_http_protocol_sessions as enable_deprecated_protocol_uploads,
-)
-
 from .constants import V1_TAG
 from .errors import LegacyErrorResponse
 from .health import health_router
@@ -16,7 +12,6 @@ from .service.legacy.routers import legacy_routes
 from .service.session.router import router as deprecated_session_router
 from .service.pipette_offset.router import router as pip_os_router
 from .service.labware.router import router as labware_router
-from .service.protocol.router import router as deprecated_protocol_router
 from .service.tip_length.router import router as tl_router
 from .service.notifications.router import router as notifications_router
 
@@ -50,18 +45,11 @@ router.include_router(
     dependencies=[Depends(check_version_header)],
 )
 
-if enable_deprecated_protocol_uploads():
-    router.include_router(
-        router=deprecated_protocol_router,
-        tags=["Protocol Management"],
-        dependencies=[Depends(check_version_header)],
-    )
-else:
-    router.include_router(
-        router=protocols_router,
-        tags=["Protocol Management"],
-        dependencies=[Depends(check_version_header)],
-    )
+router.include_router(
+    router=protocols_router,
+    tags=["Protocol Management"],
+    dependencies=[Depends(check_version_header)],
+)
 
 router.include_router(
     router=deprecated_session_router,

--- a/robot-server/robot_server/service/session/session_types/protocol/session.py
+++ b/robot-server/robot_server/service/session/session_types/protocol/session.py
@@ -1,12 +1,7 @@
 import logging
 from typing import cast
 
-from opentrons.config.feature_flags import enable_http_protocol_sessions
-
-from robot_server.service.session.errors import (
-    UnsupportedFeature,
-    SessionCreationException,
-)
+from robot_server.service.session.errors import UnsupportedFeature
 from robot_server.service.session.models.session import (
     SessionType,
     ProtocolResponseAttributes,
@@ -45,9 +40,6 @@ class ProtocolSession(BaseSession):
         cls, configuration: SessionConfiguration, instance_meta: SessionMetaData
     ) -> "BaseSession":
         """Try to create the protocol session"""
-        if not enable_http_protocol_sessions():
-            raise SessionCreationException("HTTP Protocol Session feature is disabled")
-
         protocol = configuration.protocol_manager.get(
             cast(ProtocolCreateParams, instance_meta.create_params).protocolId
         )

--- a/robot-server/tests/integration/test_settings.tavern.yaml
+++ b/robot-server/tests/integration/test_settings.tavern.yaml
@@ -48,12 +48,6 @@ stages:
             description: !re_search 'Use an older, slower method of analyzing uploaded protocols'
             restart_required: false
             value: !anything
-          - id: enableHttpProtocolSessions
-            old_id: Null
-            title: Enable deprecated experimental HTTP protocol upload
-            description: !re_search 'This setting is deprecated'
-            restart_required: true
-            value: !anything
           - id: enableOT3HardwareController
             old_id: Null
             title: Enable experimental OT3 hardware controller
@@ -77,7 +71,6 @@ marks:
         - useOldAspirationFunctions
         - enableDoorSafetySwitch
         - disableFastProtocolUpload
-        - enableHttpProtocolSessions
   - parametrize:
       key: value
       vals:
@@ -114,7 +107,6 @@ marks:
         - useOldAspirationFunctions
         - enableDoorSafetySwitch
         - disableFastProtocolUpload
-        - enableHttpProtocolSessions
 stages:
   - name: Set each setting to acceptable values
     request:


### PR DESCRIPTION
## Overview

This PR removes the experimental endpoints used by the [v4 HTTP API Beta](https://github.com/Opentrons/http-api-beta) now that production endpoints will be available in the v5 release.

See Opentrons/http-api-beta#8 for related information.

## Changelog

- Remove `enable_http_protocol_sessions` feature flag and associated logic

### Unchanged log

For safety reasons, this PR leaves a lot of "dead" code in place. We should remove this code after the 5.0.0 release branch has been cut just in case removing it breaks something unexpected.

## Review requests

- [ ] Nothing in production breaks

## Risk assessment

Low. Removal of non-production code
