### PR TITLE
refactor(api): Split motion control and configuration implementations

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -1161,61 +1161,34 @@ class API(
         rate : [float] Set plunger speed for this dispense, where
             speed = rate * dispense_speed
         """
-        instruments = self.instruments_for(mount)
-        self.ready_for_tip_action(instruments, HardwareAction.DISPENSE)
 
-        plunger_currents = {
-            Axis.of_plunger(instr[1]): instr[0].config.plunger_current
-            for instr in instruments
-        }
-        if volume is None:
-            disp_vol = tuple(instr[0].current_volume for instr in instruments)
-            mod_log.debug(
-                "No dispense volume specified. Dispensing all "
-                "remaining liquid ({}uL) from pipette".format(disp_vol)
-            )
-        else:
-            disp_vol = tuple(volume for instr in instruments)
-
-        # Ensure we don't dispense more than the current volume
-        disp_vol = tuple(
-            min(instr[0].current_volume, vol)
-            for instr, vol in zip(instruments, disp_vol)
-        )
-
-        if all([vol == 0 for vol in disp_vol]):
+        dispense_spec = self.plan_check_dispense(mount, volume, rate)
+        if not dispense_spec:
             return
-        elif 0 in disp_vol:
-            raise PairedPipetteConfigValueError("Cannot only dispense from one pipette")
-
-        dist = tuple(
-            self.plunger_position(instr[0], instr[0].current_volume - vol, "dispense")
-            for instr, vol in zip(instruments, disp_vol)
-        )
-        speed = min(
-            self.plunger_speed(instr[0], instr[0].dispense_flow_rate * rate, "dispense")
-            for instr in instruments
+        target_pos, _, secondary_z = target_position_from_plunger(
+            mount,
+            [spec.plunger_distance for spec in dispense_spec],
+            self._current_position,
         )
 
         try:
-            self._backend.set_active_current(plunger_currents)
-            target_pos, _, secondary_z = target_position_from_plunger(
-                mount, dist, self._current_position
+            self._backend.set_active_current(
+                {spec.axis: spec.current for spec in dispense_spec}
             )
             await self._move(
                 target_pos,
-                speed=speed,
+                speed=dispense_spec[0].speed,
                 secondary_z=secondary_z,
                 home_flagged_axes=False,
             )
         except Exception:
             self._log.exception("Dispense failed")
-            for instr in instruments:
-                instr[0].set_current_volume(0)
+            for spec in dispense_spec:
+                spec.instr.set_current_volume(0)
             raise
         else:
-            for instr, vol in zip(instruments, disp_vol):
-                instr[0].remove_current_volume(vol)
+            for spec in dispense_spec:
+                spec.instr.remove_current_volume(spec.volume)
 
     async def blow_out(self, mount: Union[top_types.Mount, PipettePair]):
         """

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -65,7 +65,15 @@ mod_log = logging.getLogger(__name__)
 
 
 class API(
-    ExecutionManagerProvider, RobotCalibrationProvider, InstrumentHandlerProvider
+    ExecutionManagerProvider,
+    RobotCalibrationProvider,
+    InstrumentHandlerProvider,
+    # This MUST be kept last in the inheritance list so that it is
+    # deprioritized in the method resolution order; otherwise, invocations
+    # of methods that are present in the protocol will call the (empty,
+    # do-nothing) methods in the protocol. This will happily make all the
+    # tests fail.
+    HardwareControlAPI,
 ):
     """This API is the primary interface to the hardware controller.
 
@@ -117,22 +125,6 @@ class API(
         ExecutionManagerProvider.__init__(self, loop, isinstance(backend, Simulator))
         RobotCalibrationProvider.__init__(self)
         InstrumentHandlerProvider.__init__(self)
-        API._check_type(self)
-
-    @staticmethod
-    def _check_type(inst: HardwareControlAPI) -> None:
-        """Do-nothing to provide early warning if the protocol is not satisfied.
-
-        This class can't inherit from the HardwareControlAPI protocol if we're also
-        doing multiple inheritance, because it confuses MRO - it looks like it should
-        have all these functions, but they're defined to not do anything. That means
-        that we don't get the early warning when the class doesn't fulfill the
-        protocol.
-
-        What we can do instead is this, a bogus function that exists to make mypy
-        verify while parsing the class that it fulfilles the protocol.
-        """
-        pass
 
     @property
     def door_state(self) -> DoorState:

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 from dataclasses import replace
+from functools import partial
 import logging
 import pathlib
 from collections import OrderedDict
@@ -53,6 +54,11 @@ from . import modules
 from .robot_calibration import RobotCalibrationProvider, load_pipette_offset
 from .protocols import HardwareControlAPI
 from .instrument_handler import InstrumentHandlerProvider
+from .motion_utilities import (
+    target_position_from_absolute,
+    target_position_from_relative,
+    target_position_from_plunger,
+)
 
 
 mod_log = logging.getLogger(__name__)
@@ -568,8 +574,14 @@ class API(
                 # either we were passed False for our acquire_lock and we
                 # should pass it on, or we acquired the lock above and
                 # shouldn't do it again
-                await self._move_plunger(
-                    checked_mount, (instr.config.bottom,), acquire_lock=False
+                target_pos, _, secondary_z = target_position_from_plunger(
+                    checked_mount, (instr.config.bottom,), self._current_position
+                )
+                await self._move(
+                    target_pos,
+                    acquire_lock=False,
+                    home_flagged_axes=False,
+                    secondary_z=secondary_z,
                 )
 
     async def home_plunger(self, mount: top_types.Mount):
@@ -788,47 +800,12 @@ class API(
         if not self._current_position:
             await self.home()
 
-        mounts = self.mounts(mount)
-        primary_mount = mounts[0]
-        secondary_mount = None
-        # Even with overloads, mypy cannot accept a length check on
-        # a tuple to confirm whether there are one or two mounts
-        # see: https://github.com/python/mypy/issues/1178
-        if len(mounts) > 1:
-            secondary_mount = mounts[1]  # type: ignore
-
-        mount_offset = self._config.left_mount_offset
-        if primary_mount == top_types.Mount.LEFT:
-            primary_offset = top_types.Point(*mount_offset)
-            s_offset = top_types.Point(0, 0, 0)
-        else:
-            primary_offset = top_types.Point(0, 0, 0)
-            s_offset = top_types.Point(*mount_offset)
-
-        if secondary_mount:
-            primary_z = Axis.by_mount(primary_mount)
-            secondary_z = Axis.by_mount(secondary_mount)
-            primary_cp = self.critical_point_for(primary_mount, critical_point)
-            s_cp = self.critical_point_for(secondary_mount, critical_point)
-            target_position = OrderedDict(
-                (
-                    (Axis.X, abs_position.x - primary_offset.x - primary_cp.x),
-                    (Axis.Y, abs_position.y - primary_offset.y - primary_cp.y),
-                    (primary_z, abs_position.z - primary_offset.z - primary_cp.z),
-                    (secondary_z, abs_position.z - s_offset.z - s_cp.z),
-                )
-            )
-        else:
-            primary_cp = self.critical_point_for(primary_mount, critical_point)
-            primary_z = Axis.by_mount(primary_mount)
-            secondary_z = None
-            target_position = OrderedDict(
-                (
-                    (Axis.X, abs_position.x - primary_offset.x - primary_cp.x),
-                    (Axis.Y, abs_position.y - primary_offset.y - primary_cp.y),
-                    (primary_z, abs_position.z - primary_offset.z - primary_cp.z),
-                )
-            )
+        target_position, primary_mount, secondary_z = target_position_from_absolute(
+            mount,
+            abs_position,
+            partial(self.critical_point_for, cp_override=critical_point),
+            top_types.Point(*self._config.left_mount_offset),
+        )
 
         await self._cache_and_maybe_retract_mount(primary_mount)
         await self._move(
@@ -856,49 +833,23 @@ class API(
         # TODO: Remove the fail_on_not_homed and make this the behavior all the time.
         # Having the optional arg makes the bug stick around in existing code and we
         # really want to fix it when we're not gearing up for a release.
-        mounts = self.mounts(mount)
-        if fail_on_not_homed:
-            axes_moving = [Axis.X, Axis.Y] + [Axis.by_mount(m) for m in mounts]
-            if (
-                not self._backend.is_homed([axis.name for axis in axes_moving])
-                or not self._current_position
-            ):
-                raise MustHomeError(
-                    "Cannot make a relative move because absolute position is unknown"
-                )
-        elif not self._current_position:
-            await self.home()
+        mhe = MustHomeError(
+            "Cannot make a relative move because absolute position is unknown"
+        )
+        if not self._current_position:
+            if fail_on_not_homed:
+                raise mhe
+            else:
+                await self.home()
 
-        primary_mount = mounts[0]
-        secondary_mount = None
-        # Even with overloads, mypy cannot accept a length check on
-        # a tuple to confirm whether there are one or two mounts
-        # see: https://github.com/python/mypy/issues/1178
-        if len(mounts) > 1:
-            secondary_mount = mounts[1]  # type: ignore
-
-        if secondary_mount:
-            primary_z = Axis.by_mount(primary_mount)
-            secondary_z = Axis.by_mount(secondary_mount)
-            target_position = OrderedDict(
-                (
-                    (Axis.X, self._current_position[Axis.X] + delta.x),
-                    (Axis.Y, self._current_position[Axis.Y] + delta.y),
-                    (primary_z, self._current_position[primary_z] + delta.z),
-                    (secondary_z, self._current_position[secondary_z] + delta.z),
-                )
-            )
-        else:
-            z_axis = Axis.by_mount(primary_mount)
-            secondary_z = None
-            target_position = OrderedDict(
-                (
-                    (Axis.X, self._current_position[Axis.X] + delta.x),
-                    (Axis.Y, self._current_position[Axis.Y] + delta.y),
-                    (z_axis, self._current_position[z_axis] + delta.z),
-                )
-            )
-
+        target_position, primary_mount, secondary_z = target_position_from_relative(
+            mount, delta, self._current_position
+        )
+        axes_moving = [Axis.X, Axis.Y, Axis.by_mount(primary_mount), secondary_z]
+        if fail_on_not_homed and not self._backend.is_homed(
+            [axis.name for axis in axes_moving if axis is not None]
+        ):
+            raise mhe
         await self._cache_and_maybe_retract_mount(primary_mount)
         await self._move(
             target_position,
@@ -919,63 +870,6 @@ class API(
         if mount != self._last_moved_mount and self._last_moved_mount:
             await self.retract(self._last_moved_mount, 10)
         self._last_moved_mount = mount
-
-    async def _move_plunger(
-        self,
-        mount: Union[top_types.Mount, PipettePair],
-        dist: Sequence[float],
-        speed: float = None,
-        acquire_lock: bool = True,
-    ):
-        all_axes_pos = OrderedDict(
-            (
-                (Axis.X, self._current_position[Axis.X]),
-                (Axis.Y, self._current_position[Axis.Y]),
-            )
-        )
-        plunger_pos = OrderedDict()
-        mounts = self.mounts(mount)
-        secondary_z = None
-        for idx, m in enumerate(mounts):
-            z = Axis.by_mount(m)
-            plunger = Axis.of_plunger(m)
-            all_axes_pos[z] = self._current_position[z]
-            plunger_pos[plunger] = dist[idx]
-            if idx == 1:
-                secondary_z = z
-        all_axes_pos.update(plunger_pos)
-        await self._move(
-            all_axes_pos,
-            speed,
-            False,
-            acquire_lock=acquire_lock,
-            secondary_z=secondary_z,
-        )
-
-    async def _move_relative_n_axes(
-        self,
-        mount: Union[top_types.Mount, PipettePair],
-        target: Sequence[float],
-        speed: float = None,
-    ):
-        all_axes_pos = OrderedDict(
-            (
-                (Axis.X, self._current_position[Axis.X] + target[0]),
-                (Axis.Y, self._current_position[Axis.Y] + target[1]),
-            )
-        )
-        mounts = self.mounts(mount)
-        secondary_z = None
-        for (
-            idx,
-            m,
-        ) in enumerate(mounts):
-            z = Axis.by_mount(m)
-            t_index = idx + 2
-            all_axes_pos[z] = self._current_position[z] + target[t_index]
-            if idx == 1:
-                secondary_z = z
-        await self._move(all_axes_pos, speed=speed, secondary_z=secondary_z)
 
     def _get_transformed(
         self,
@@ -1190,7 +1084,15 @@ class API(
                 instr[0], instr[0].blow_out_flow_rate, "aspirate"
             )
             bottom = (instr[0].config.bottom,)
-            await self._move_plunger(instr[1], bottom, speed=(speed * rate))
+            target, _, secondary_z = target_position_from_plunger(
+                instr[1], bottom, self._current_position
+            )
+            await self._move(
+                target,
+                speed=(speed * rate),
+                secondary_z=secondary_z,
+                home_flagged_axes=False,
+            )
             instr[0].ready_to_aspirate = True
 
     async def aspirate(
@@ -1254,7 +1156,15 @@ class API(
         )
         try:
             self._backend.set_active_current(plunger_currents)
-            await self._move_plunger(mount, dist, speed=speed)
+            target_pos, _, secondary_z = target_position_from_plunger(
+                mount, dist, self._current_position
+            )
+            await self._move(
+                target_pos,
+                speed=speed,
+                secondary_z=secondary_z,
+                home_flagged_axes=False,
+            )
         except Exception:
             self._log.exception("Aspirate failed")
             for instr in instruments:
@@ -1318,7 +1228,15 @@ class API(
 
         try:
             self._backend.set_active_current(plunger_currents)
-            await self._move_plunger(mount, dist, speed=speed)
+            target_pos, _, secondary_z = target_position_from_plunger(
+                mount, dist, self._current_position
+            )
+            await self._move(
+                target_pos,
+                speed=speed,
+                secondary_z=secondary_z,
+                home_flagged_axes=False,
+            )
         except Exception:
             self._log.exception("Dispense failed")
             for instr in instruments:
@@ -1347,7 +1265,15 @@ class API(
             for instr in instruments
         )
         try:
-            await self._move_plunger(mount, blow_out, speed=speed)
+            target_pos, _, secondary_z = target_position_from_plunger(
+                mount, blow_out, self._current_position
+            )
+            await self._move(
+                target_pos,
+                speed=speed,
+                secondary_z=secondary_z,
+                home_flagged_axes=False,
+            )
         except Exception:
             self._log.exception("Blow out failed")
             raise
@@ -1393,7 +1319,14 @@ class API(
         self._backend.set_active_current(plunger_currents)
         # Initialize plunger to bottom position
         bottom_positions = tuple(instr[0].config.bottom for instr in instruments)
-        await self._move_plunger(mount, bottom_positions)
+        target_absolute, _, secondary_z = target_position_from_plunger(
+            mount, bottom_positions, self._current_position
+        )
+        await self._move(
+            target_absolute,
+            secondary_z=secondary_z,
+            home_flagged_axes=False,
+        )
 
         if not presses or presses < 0:
             all_presses = tuple(
@@ -1426,11 +1359,23 @@ class API(
                     for instr, incrt in zip(instruments, check_incr)
                 )
                 target_pos = (0, 0, *dist)
-                await self._move_relative_n_axes(mount, target_pos, pick_up_speed)
+                (
+                    target_absolute,
+                    primary_mount,
+                    secondary_z,
+                ) = target_position_from_relative(
+                    mount, target_pos, self._current_position
+                )
+                await self._move(
+                    target_absolute, speed=pick_up_speed, secondary_z=secondary_z
+                )
 
             # move nozzle back up
             backup_pos = (0, 0, *tuple(-d for d in dist))
-            await self._move_relative_n_axes(mount, backup_pos)
+            target_absolute, primary_mount, secondary_z = target_position_from_relative(
+                mount, backup_pos, self._current_position
+            )
+            await self._move(target_absolute, secondary_z=secondary_z)
         for instr in instruments:
             instr[0].add_tip(tip_length=tip_length)
             instr[0].set_current_volume(0)
@@ -1484,9 +1429,26 @@ class API(
 
         async def _drop_tip():
             self._backend.set_active_current(plunger_currents)
-            await self._move_plunger(mount, bottom)
+            target_pos, _, secondary_z = target_position_from_plunger(
+                mount, bottom, self._current_position
+            )
+            await self._move(
+                target_pos,
+                secondary_z=secondary_z,
+                home_flagged_axes=False,
+            )
             self._backend.set_active_current(drop_tip_currents)
-            await self._move_plunger(mount, droptip, speed=speed)
+            target_pos, _, secondary_z = target_position_from_plunger(
+                mount,
+                droptip,
+                self._current_position,
+            )
+            await self._move(
+                target_pos,
+                speed=speed,
+                secondary_z=secondary_z,
+                home_flagged_axes=False,
+            )
             if home_after:
                 safety_margin = abs(max(bottom) - max(droptip))
                 smoothie_pos = await self._backend.fast_home(
@@ -1494,7 +1456,14 @@ class API(
                 )
                 self._current_position = self._deck_from_smoothie(smoothie_pos)
                 self._backend.set_active_current(plunger_currents)
-                await self._move_plunger(mount, bottom)
+                target_pos, _, secondary_z = target_position_from_plunger(
+                    mount, bottom, self._current_position
+                )
+                await self._move(
+                    target_pos,
+                    secondary_z=secondary_z,
+                    home_flagged_axes=False,
+                )
 
         if any(["doubleDropTip" in instr[0].config.quirks for instr in instruments]):
             await _drop_tip()

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -5,28 +5,25 @@ import logging
 import pathlib
 from collections import OrderedDict
 from typing import (
-    Any,
     Callable,
     Dict,
     Union,
     List,
     Optional,
     Tuple,
-    TYPE_CHECKING,
-    cast,
-    overload,
     Sequence,
     Set,
 )
 
 from opentrons_shared_data.pipette import name_config
+from opentrons_shared_data.pipette.dev_types import PipetteName
 from opentrons import types as top_types
 from opentrons.util import linal
 from opentrons.config import robot_configs
 from opentrons.config.types import RobotConfig
 
 from .util import use_or_initialize_loop, check_motion_bounds
-from .pipette import Pipette, generate_hardware_configs, load_from_config_and_check_skip
+from .pipette import generate_hardware_configs, load_from_config_and_check_skip
 from .controller import Controller
 from .simulator import Simulator
 from .constants import (
@@ -42,13 +39,11 @@ from .types import (
     Axis,
     CriticalPoint,
     MustHomeError,
-    NoTipAttachedError,
     DoorState,
     DoorStateNotification,
     ErrorMessageNotification,
     HardwareEventHandler,
     PipettePair,
-    TipAttachedError,
     HardwareAction,
     PairedPipetteConfigValueError,
     MotionChecks,
@@ -57,20 +52,15 @@ from .types import (
 from . import modules
 from .robot_calibration import RobotCalibrationProvider, load_pipette_offset
 from .protocols import HardwareControlAPI
-
-if TYPE_CHECKING:
-    from opentrons_shared_data.pipette.dev_types import UlPerMmAction, PipetteName
-    from .dev_types import PipetteDict
+from .instrument_handler import InstrumentHandlerProvider
 
 
 mod_log = logging.getLogger(__name__)
 
 
-InstrumentsByMount = Dict[top_types.Mount, Optional[Pipette]]
-PipetteHandlingData = Tuple[Pipette, top_types.Mount]
-
-
-class API(ExecutionManagerProvider, RobotCalibrationProvider):
+class API(
+    ExecutionManagerProvider, RobotCalibrationProvider, InstrumentHandlerProvider
+):
     """This API is the primary interface to the hardware controller.
 
     Because the hardware manager controls access to the system's hardware
@@ -104,10 +94,6 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
         # {'X': 0.0, 'Y': 0.0, 'Z': 0.0, 'A': 0.0, 'B': 0.0, 'C': 0.0}
         self._current_position: Dict[Axis, float] = {}
 
-        self._attached_instruments: InstrumentsByMount = {
-            top_types.Mount.LEFT: None,
-            top_types.Mount.RIGHT: None,
-        }
         self._last_moved_mount: Optional[top_types.Mount] = None
         # The motion lock synchronizes calls to long-running physical tasks
         # involved in motion. This fixes issue where for instance a move()
@@ -119,6 +105,7 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
         self._pause_manager = PauseManager(self._door_state)
         ExecutionManagerProvider.__init__(self, loop, isinstance(backend, Simulator))
         RobotCalibrationProvider.__init__(self)
+        InstrumentHandlerProvider.__init__(self)
         API._check_type(self)
 
     @staticmethod
@@ -366,35 +353,36 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
         finally:
             self.resume(PauseType.DELAY)
 
-    def reset_instrument(self, mount: top_types.Mount = None):
+    @property
+    def attached_modules(self) -> List[modules.AbstractModule]:
+        return self._backend.module_controls.available_modules
+
+    async def update_firmware(
+        self,
+        firmware_file: str,
+        loop: asyncio.AbstractEventLoop = None,
+        explicit_modeset: bool = True,
+    ) -> str:
+        """Update the firmware on the Smoothie board.
+
+        :param firmware_file: The path to the firmware file.
+        :param explicit_modeset: `True` to force the smoothie into programming
+                                 mode; `False` to assume it is already in
+                                 programming mode.
+        :param loop: An asyncio event loop to use; if not specified, the one
+                     associated with this instance will be used.
+        :returns: The stdout of the tool used to update the smoothie
         """
-        Reset the internal state of a pipette by its mount, without doing
-        any lower level reconfiguration. This is useful to make sure that no
-        settings changes from a protocol persist.
-
-        :param mount: If specified, reset that mount. If not specified,
-                      reset both
-        """
-
-        def _reset(m: top_types.Mount):
-            self._log.info(f"Resetting configuration for {m}")
-            p = self._attached_instruments[m]
-            if not p:
-                return
-            new_p = Pipette(
-                p._config, load_pipette_offset(p.pipette_id, m), p.pipette_id
-            )
-            new_p.act_as(p.acting_as)
-            self._attached_instruments[m] = new_p
-
-        if not mount:
-            for m in top_types.Mount:
-                _reset(m)
+        if None is loop:
+            checked_loop = self._loop
         else:
-            _reset(mount)
+            checked_loop = loop
+        return await self._backend.update_firmware(
+            firmware_file, checked_loop, explicit_modeset
+        )
 
     async def cache_instruments(
-        self, require: Dict[top_types.Mount, "PipetteName"] = None
+        self, require: Dict[top_types.Mount, PipetteName] = None
     ):
         """
         Scan the attached instruments, take necessary configuration actions,
@@ -452,126 +440,7 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
                 p, self._config, self._backend.board_revision
             )
             await self._backend.configure_mount(mount, hw_config)
-        mod_log.info("Instruments found: {}".format(self._attached_instruments))
-
-    # TODO(mc, 2022-01-11): change returned map value type to `Optional[PipetteDict]`
-    # instead of potentially returning an empty dict
-    def get_attached_instruments(self) -> Dict[top_types.Mount, "PipetteDict"]:
-        """Get the status dicts of the cached attached instruments.
-
-        Also available as :py:meth:`get_attached_instruments`.
-
-        This returns a dictified version of the
-        :py:class:`hardware_control.pipette.Pipette` as a dict keyed by
-        the :py:class:`top_types.Mount` to which the pipette is attached.
-        If no pipette is attached on a given mount, the mount key will
-        still be present but will have the value ``None``.
-
-        Note that this is only a query of a cached value; to actively scan
-        for changes, use :py:meth:`cache_instruments`. This process deactivates
-        the motors and should be used sparingly.
-        """
-        return {
-            m: self.get_attached_instrument(m)
-            for m in (top_types.Mount.LEFT, top_types.Mount.RIGHT)
-        }
-
-    # TODO(mc, 2022-01-11): change return type to `Optional[PipetteDict]` instead
-    # of potentially returning an empty dict
-    def get_attached_instrument(self, mount: top_types.Mount) -> "PipetteDict":
-        instr = self._attached_instruments[mount]
-        result: Dict[str, Any] = {}
-        if instr:
-            configs = [
-                "name",
-                "min_volume",
-                "max_volume",
-                "channels",
-                "aspirate_flow_rate",
-                "dispense_flow_rate",
-                "pipette_id",
-                "current_volume",
-                "display_name",
-                "tip_length",
-                "model",
-                "blow_out_flow_rate",
-                "working_volume",
-                "tip_overlap",
-                "available_volume",
-                "return_tip_height",
-                "default_aspirate_flow_rates",
-                "default_blow_out_flow_rates",
-                "default_dispense_flow_rates",
-                "back_compat_names",
-            ]
-
-            instr_dict = instr.as_dict()
-            # TODO (spp, 2021-08-27): Revisit this logic. Why do we need to build
-            #  this dict newly every time? Any why only a few items are being updated?
-            for key in configs:
-                result[key] = instr_dict[key]
-            result["has_tip"] = instr.has_tip
-            result["tip_length"] = instr.current_tip_length
-            result["aspirate_speed"] = self._plunger_speed(
-                instr, instr.aspirate_flow_rate, "aspirate"
-            )
-            result["dispense_speed"] = self._plunger_speed(
-                instr, instr.dispense_flow_rate, "dispense"
-            )
-            result["blow_out_speed"] = self._plunger_speed(
-                instr, instr.blow_out_flow_rate, "dispense"
-            )
-            result["ready_to_aspirate"] = instr.ready_to_aspirate
-            result["default_blow_out_speeds"] = {
-                alvl: self._plunger_speed(instr, fr, "dispense")
-                for alvl, fr in instr.config.default_aspirate_flow_rates.items()
-            }
-            result["default_dispense_speeds"] = {
-                alvl: self._plunger_speed(instr, fr, "dispense")
-                for alvl, fr in instr.config.default_dispense_flow_rates.items()
-            }
-            result["default_aspirate_speeds"] = {
-                alvl: self._plunger_speed(instr, fr, "aspirate")
-                for alvl, fr in instr.config.default_aspirate_flow_rates.items()
-            }
-        return cast("PipetteDict", result)
-
-    @property
-    def attached_instruments(self) -> Dict[top_types.Mount, "PipetteDict"]:
-        return self.get_attached_instruments()
-
-    @property
-    def hardware_instruments(self) -> InstrumentsByMount:
-        """Do not write new code that uses this."""
-        return self._attached_instruments
-
-    @property
-    def attached_modules(self) -> List[modules.AbstractModule]:
-        return self._backend.module_controls.available_modules
-
-    async def update_firmware(
-        self,
-        firmware_file: str,
-        loop: asyncio.AbstractEventLoop = None,
-        explicit_modeset: bool = True,
-    ) -> str:
-        """Update the firmware on the Smoothie board.
-
-        :param firmware_file: The path to the firmware file.
-        :param explicit_modeset: `True` to force the smoothie into programming
-                                 mode; `False` to assume it is already in
-                                 programming mode.
-        :param loop: An asyncio event loop to use; if not specified, the one
-                     associated with this instance will be used.
-        :returns: The stdout of the tool used to update the smoothie
-        """
-        if None is loop:
-            checked_loop = self._loop
-        else:
-            checked_loop = loop
-        return await self._backend.update_firmware(
-            firmware_file, checked_loop, explicit_modeset
-        )
+        self._log.info("Instruments found: {}".format(self._attached_instruments))
 
     # Global actions API
     def pause(self, pause_type: PauseType):
@@ -647,6 +516,7 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
         await self._backend.halt()
         self._log.info("Recovering from halt")
         await self.reset()
+        await self.cache_instruments()
 
         if home_after:
             await self.home()
@@ -659,10 +529,7 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
         """
         self._pause_manager.reset()
         await self._execution_manager.reset()
-        self._attached_instruments = {
-            k: None for k in self._attached_instruments.keys()
-        }
-        await self.cache_instruments()
+        await InstrumentHandlerProvider.reset(self)
 
     # Gantry/frame (i.e. not pipette) action API
     async def home_z(self, mount: Optional[top_types.Mount] = None):
@@ -687,7 +554,7 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
         if mount:
             checked_mount = mount
             checked_axis = Axis.of_plunger(checked_mount)
-        instr = self._attached_instruments[checked_mount]
+        instr = self.hardware_instruments[checked_mount]
         if not instr:
             return
         async with contextlib.AsyncExitStack() as stack:
@@ -736,32 +603,6 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
                 self._current_position = self._deck_from_smoothie(smoothie_pos)
             for plunger in plungers:
                 await self._do_plunger_home(axis=plunger, acquire_lock=False)
-
-    async def add_tip(self, mount: top_types.Mount, tip_length: float):
-        instr = self._attached_instruments[mount]
-        attached = self.attached_instruments
-        instr_dict = attached[mount]
-        if instr and not instr.has_tip:
-            instr.add_tip(tip_length=tip_length)
-            # TODO (spp, 2021-08-27): These items are being updated in a local copy
-            #  of the PipetteDict, which gets thrown away. Fix this.
-            instr_dict["has_tip"] = True
-            instr_dict["tip_length"] = tip_length
-        else:
-            mod_log.warning("attach tip called while tip already attached")
-
-    async def remove_tip(self, mount: top_types.Mount):
-        instr = self._attached_instruments[mount]
-        attached = self.attached_instruments
-        instr_dict = attached[mount]
-        if instr and instr.has_tip:
-            instr.remove_tip()
-            # TODO (spp, 2021-08-27): These items are being updated in a local copy
-            #  of the PipetteDict, which gets thrown away. Fix this.
-            instr_dict["has_tip"] = False
-            instr_dict["tip_length"] = 0.0
-        else:
-            mod_log.warning("detach tip called with no tip")
 
     def _deck_from_smoothie(self, smoothie_pos: Dict[str, float]) -> Dict[Axis, float]:
         """Build a deck-abs position store from the smoothie's position
@@ -858,7 +699,7 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
             else:
                 offset = top_types.Point(*self._config.left_mount_offset)
 
-            cp = self._critical_point_for(mount, critical_point)
+            cp = self.critical_point_for(mount, critical_point)
             return {
                 Axis.X: self._current_position[Axis.X] + offset[0] + cp.x,
                 Axis.Y: self._current_position[Axis.Y] + offset[1] + cp.y,
@@ -898,19 +739,6 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
         return top_types.Point(
             x=cur_pos[Axis.X], y=cur_pos[Axis.Y], z=cur_pos[Axis.by_mount(mount)]
         )
-
-    @overload
-    def _mounts(self, z_axis: PipettePair) -> Tuple[top_types.Mount, top_types.Mount]:
-        ...
-
-    @overload
-    def _mounts(self, z_axis: top_types.Mount) -> Tuple[top_types.Mount]:
-        ...
-
-    def _mounts(self, z_axis):
-        if isinstance(z_axis, PipettePair):
-            return (z_axis.primary, z_axis.secondary)
-        return (z_axis,)
 
     async def move_to(
         self,
@@ -960,7 +788,7 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
         if not self._current_position:
             await self.home()
 
-        mounts = self._mounts(mount)
+        mounts = self.mounts(mount)
         primary_mount = mounts[0]
         secondary_mount = None
         # Even with overloads, mypy cannot accept a length check on
@@ -980,8 +808,8 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
         if secondary_mount:
             primary_z = Axis.by_mount(primary_mount)
             secondary_z = Axis.by_mount(secondary_mount)
-            primary_cp = self._critical_point_for(primary_mount, critical_point)
-            s_cp = self._critical_point_for(secondary_mount, critical_point)
+            primary_cp = self.critical_point_for(primary_mount, critical_point)
+            s_cp = self.critical_point_for(secondary_mount, critical_point)
             target_position = OrderedDict(
                 (
                     (Axis.X, abs_position.x - primary_offset.x - primary_cp.x),
@@ -991,7 +819,7 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
                 )
             )
         else:
-            primary_cp = self._critical_point_for(primary_mount, critical_point)
+            primary_cp = self.critical_point_for(primary_mount, critical_point)
             primary_z = Axis.by_mount(primary_mount)
             secondary_z = None
             target_position = OrderedDict(
@@ -1028,7 +856,7 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
         # TODO: Remove the fail_on_not_homed and make this the behavior all the time.
         # Having the optional arg makes the bug stick around in existing code and we
         # really want to fix it when we're not gearing up for a release.
-        mounts = self._mounts(mount)
+        mounts = self.mounts(mount)
         if fail_on_not_homed:
             axes_moving = [Axis.X, Axis.Y] + [Axis.by_mount(m) for m in mounts]
             if (
@@ -1106,7 +934,7 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
             )
         )
         plunger_pos = OrderedDict()
-        mounts = self._mounts(mount)
+        mounts = self.mounts(mount)
         secondary_z = None
         for idx, m in enumerate(mounts):
             z = Axis.by_mount(m)
@@ -1136,7 +964,7 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
                 (Axis.Y, self._current_position[Axis.Y] + target[1]),
             )
         )
-        mounts = self._mounts(mount)
+        mounts = self.mounts(mount)
         secondary_z = None
         for (
             idx,
@@ -1291,26 +1119,6 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
             smoothie_pos = await self._fast_home(smoothie_ax, margin)
             self._current_position = self._deck_from_smoothie(smoothie_pos)
 
-    def _critical_point_for(
-        self, mount: top_types.Mount, cp_override: CriticalPoint = None
-    ) -> top_types.Point:
-        """Return the current critical point of the specified mount.
-
-        The mount's critical point is the position of the mount itself, if no
-        pipette is attached, or the pipette's critical point (which depends on
-        tip status).
-
-        If `cp_override` is specified, and that critical point actually exists,
-        it will be used instead. Invalid `cp_override`s are ignored.
-        """
-        pip = self._attached_instruments[mount]
-        if pip is not None and cp_override != CriticalPoint.MOUNT:
-            return pip.critical_point(cp_override)
-        else:
-            # This offset is required because the motor driver coordinate system is
-            # configured such that the end of a p300 single gen1's tip is 0.
-            return top_types.Point(0, 0, 30)
-
     # Gantry/frame (i.e. not pipette) config API
     @property
     def config(self) -> RobotConfig:
@@ -1373,12 +1181,12 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
         aspiration. To make the problem more obvious, :py:meth:`aspirate` will
         raise an exception if this method has not previously been called.
         """
-        instruments = self._instruments_for(mount)
-        self._ready_for_tip_action(instruments, HardwareAction.PREPARE_ASPIRATE)
+        instruments = self.instruments_for(mount)
+        self.ready_for_tip_action(instruments, HardwareAction.PREPARE_ASPIRATE)
 
         with_zero = filter(lambda i: i[0].current_volume == 0, instruments)
         for instr in with_zero:
-            speed = self._plunger_speed(
+            speed = self.plunger_speed(
                 instr[0], instr[0].blow_out_flow_rate, "aspirate"
             )
             bottom = (instr[0].config.bottom,)
@@ -1410,8 +1218,8 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
         rate : [float] Set plunger speed for this aspirate, where
             speed = rate * aspirate_speed
         """
-        instruments = self._instruments_for(mount)
-        self._ready_for_tip_action(instruments, HardwareAction.ASPIRATE)
+        instruments = self.instruments_for(mount)
+        self.ready_for_tip_action(instruments, HardwareAction.ASPIRATE)
         plunger_currents = {
             Axis.of_plunger(instr[1]): instr[0].config.plunger_current
             for instr in instruments
@@ -1437,13 +1245,11 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
             ), "Cannot aspirate more than pipette max volume"
 
         dist = tuple(
-            self._plunger_position(instr[0], instr[0].current_volume + vol, "aspirate")
+            self.plunger_position(instr[0], instr[0].current_volume + vol, "aspirate")
             for instr, vol in zip(instruments, asp_vol)
         )
         speed = min(
-            self._plunger_speed(
-                instr[0], instr[0].aspirate_flow_rate * rate, "aspirate"
-            )
+            self.plunger_speed(instr[0], instr[0].aspirate_flow_rate * rate, "aspirate")
             for instr in instruments
         )
         try:
@@ -1474,8 +1280,8 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
         rate : [float] Set plunger speed for this dispense, where
             speed = rate * dispense_speed
         """
-        instruments = self._instruments_for(mount)
-        self._ready_for_tip_action(instruments, HardwareAction.DISPENSE)
+        instruments = self.instruments_for(mount)
+        self.ready_for_tip_action(instruments, HardwareAction.DISPENSE)
 
         plunger_currents = {
             Axis.of_plunger(instr[1]): instr[0].config.plunger_current
@@ -1502,13 +1308,11 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
             raise PairedPipetteConfigValueError("Cannot only dispense from one pipette")
 
         dist = tuple(
-            self._plunger_position(instr[0], instr[0].current_volume - vol, "dispense")
+            self.plunger_position(instr[0], instr[0].current_volume - vol, "dispense")
             for instr, vol in zip(instruments, disp_vol)
         )
         speed = min(
-            self._plunger_speed(
-                instr[0], instr[0].dispense_flow_rate * rate, "dispense"
-            )
+            self.plunger_speed(instr[0], instr[0].dispense_flow_rate * rate, "dispense")
             for instr in instruments
         )
 
@@ -1524,32 +1328,13 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
             for instr, vol in zip(instruments, disp_vol):
                 instr[0].remove_current_volume(vol)
 
-    def _plunger_position(
-        self, instr: Pipette, ul: float, action: "UlPerMmAction"
-    ) -> float:
-        mm = ul / instr.ul_per_mm(ul, action)
-        position = mm + instr.config.bottom
-        return round(position, 6)
-
-    def _plunger_speed(
-        self, instr: Pipette, ul_per_s: float, action: "UlPerMmAction"
-    ) -> float:
-        mm_per_s = ul_per_s / instr.ul_per_mm(instr.config.max_volume, action)
-        return round(mm_per_s, 6)
-
-    def _plunger_flowrate(
-        self, instr: Pipette, mm_per_s: float, action: "UlPerMmAction"
-    ) -> float:
-        ul_per_s = mm_per_s * instr.ul_per_mm(instr.config.max_volume, action)
-        return round(ul_per_s, 6)
-
     async def blow_out(self, mount: Union[top_types.Mount, PipettePair]):
         """
         Force any remaining liquid to dispense. The liquid will be dispensed at
         the current location of pipette
         """
-        instruments = self._instruments_for(mount)
-        self._ready_for_tip_action(instruments, HardwareAction.BLOWOUT)
+        instruments = self.instruments_for(mount)
+        self.ready_for_tip_action(instruments, HardwareAction.BLOWOUT)
         plunger_currents = {
             Axis.of_plunger(instr[1]): instr[0].config.plunger_current
             for instr in instruments
@@ -1558,7 +1343,7 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
 
         self._backend.set_active_current(plunger_currents)
         speed = max(
-            self._plunger_speed(instr[0], instr[0].blow_out_flow_rate, "dispense")
+            self.plunger_speed(instr[0], instr[0].blow_out_flow_rate, "dispense")
             for instr in instruments
         )
         try:
@@ -1570,58 +1355,6 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
             for instr in instruments:
                 instr[0].set_current_volume(0)
                 instr[0].ready_to_aspirate = False
-
-    @overload
-    def _instruments_for(self, mount: top_types.Mount) -> Tuple[PipetteHandlingData]:
-        ...
-
-    @overload
-    def _instruments_for(
-        self, mount: PipettePair
-    ) -> Tuple[PipetteHandlingData, PipetteHandlingData]:
-        ...
-
-    def _instruments_for(self, mount):
-        if isinstance(mount, PipettePair):
-            primary_mount = mount.primary
-            secondary_mount = mount.secondary
-            instr1 = self._attached_instruments[primary_mount]
-            instr2 = self._attached_instruments[secondary_mount]
-            return ((instr1, primary_mount), (instr2, secondary_mount))
-        else:
-            primary_mount = mount
-            instr1 = self._attached_instruments[primary_mount]
-            return ((instr1, primary_mount),)
-
-    def _ready_for_pick_up_tip(self, targets: Sequence[PipetteHandlingData]):
-        for pipettes in targets:
-            if not pipettes[0]:
-                raise top_types.PipetteNotAttachedError(
-                    f"No pipette attached to {pipettes[1].name} mount"
-                )
-            if pipettes[0].has_tip:
-                raise TipAttachedError("Cannot pick up tip with a tip attached")
-            self._log.debug(f"Picking up tip on {pipettes[0].name}")
-
-    def _ready_for_tip_action(
-        self, targets: Sequence[PipetteHandlingData], action: HardwareAction
-    ):
-        for pipettes in targets:
-            if not pipettes[0]:
-                raise top_types.PipetteNotAttachedError(
-                    f"No pipette attached to {pipettes[1].name} mount"
-                )
-            if not pipettes[0].has_tip:
-                raise NoTipAttachedError(
-                    f"Cannot perform {action} without a tip attached"
-                )
-            if (
-                action == HardwareAction.ASPIRATE
-                and pipettes[0].current_volume == 0
-                and not pipettes[0].ready_to_aspirate
-            ):
-                raise RuntimeError("Pipette not ready to aspirate")
-            self._log.debug(f"{action} on {pipettes[0].name}")
 
     async def pick_up_tip(
         self,
@@ -1646,8 +1379,8 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
         If ``presses`` or ``increment`` is not specified (or is ``None``),
         their value is taken from the pipette configuration.
         """
-        instruments = self._instruments_for(mount)
-        self._ready_for_pick_up_tip(instruments)
+        instruments = self.instruments_for(mount)
+        self.ready_for_pick_up_tip(instruments)
         plunger_currents = {
             Axis.of_plunger(instr[1]): instr[0].config.plunger_current
             for instr in instruments
@@ -1718,30 +1451,6 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
 
         await self.retract(mount, retract_target)
 
-    def set_current_tiprack_diameter(
-        self, mount: Union[top_types.Mount, PipettePair], tiprack_diameter: float
-    ):
-        instruments = self._instruments_for(mount)
-        for instr in instruments:
-            assert instr[0]
-            self._log.info(
-                "Updating tip rack diameter on pipette mount: "
-                f"{instr[1]}, tip diameter: {tiprack_diameter} mm"
-            )
-            instr[0].current_tiprack_diameter = tiprack_diameter
-
-    def set_working_volume(
-        self, mount: Union[top_types.Mount, PipettePair], tip_volume: int
-    ):
-        instruments = self._instruments_for(mount)
-        for instr in instruments:
-            assert instr[0]
-            self._log.info(
-                "Updating working volume on pipette mount:"
-                f"{instr[1]}, tip volume: {tip_volume} ul"
-            )
-            instr[0].working_volume = tip_volume
-
     async def drop_tip(
         self, mount: Union[top_types.Mount, PipettePair], home_after=True
     ):
@@ -1755,8 +1464,8 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
                                 the ejector shroud after a drop.
         """
 
-        instruments = self._instruments_for(mount)
-        self._ready_for_tip_action(instruments, HardwareAction.DROPTIP)
+        instruments = self.instruments_for(mount)
+        self.ready_for_tip_action(instruments, HardwareAction.DROPTIP)
         plunger_currents = {
             Axis.of_plunger(instr[1]): instr[0].config.plunger_current
             for instr in instruments
@@ -1853,94 +1562,12 @@ class API(ExecutionManagerProvider, RobotCalibrationProvider):
         )
         return modules_result
 
-    # Pipette config api
-    def calibrate_plunger(
-        self,
-        mount: top_types.Mount,
-        top: Optional[float] = None,
-        bottom: Optional[float] = None,
-        blow_out: Optional[float] = None,
-        drop_tip: Optional[float] = None,
-    ):
-        """
-        Set calibration values for the pipette plunger.
-        This can be called multiple times as the user sets each value,
-        or you can set them all at once.
-        :param top: Touching but not engaging the plunger.
-        :param bottom: Must be above the pipette's physical hard-stop, while
-        still leaving enough room for 'blow_out'
-        :param blow_out: Plunger is pushed down enough to expel all liquids.
-        :param drop_tip: Position that causes the tip to be released from the
-        pipette
-        """
-        instr = self._attached_instruments[mount]
-        if not instr:
-            raise top_types.PipetteNotAttachedError(
-                "No pipette attached to {} mount".format(mount.name)
-            )
-
-        pos_dict: Dict = {
-            "top": instr.config.top,
-            "bottom": instr.config.bottom,
-            "blow_out": instr.config.blow_out,
-            "drop_tip": instr.config.drop_tip,
-        }
-        if top is not None:
-            pos_dict["top"] = top
-        if bottom is not None:
-            pos_dict["bottom"] = bottom
-        if blow_out is not None:
-            pos_dict["blow_out"] = blow_out
-        if bottom is not None:
-            pos_dict["drop_tip"] = drop_tip
-        for key in pos_dict.keys():
-            instr.update_config_item(key, pos_dict[key])
-
-    def set_flow_rate(self, mount, aspirate=None, dispense=None, blow_out=None):
-        this_pipette = self._attached_instruments[mount]
-        if not this_pipette:
-            raise top_types.PipetteNotAttachedError(
-                "No pipette attached to {} mount".format(mount)
-            )
-        if aspirate:
-            this_pipette.aspirate_flow_rate = aspirate
-        if dispense:
-            this_pipette.dispense_flow_rate = dispense
-        if blow_out:
-            this_pipette.blow_out_flow_rate = blow_out
-
-    def set_pipette_speed(self, mount, aspirate=None, dispense=None, blow_out=None):
-        this_pipette = self._attached_instruments[mount]
-        if not this_pipette:
-            raise top_types.PipetteNotAttachedError(
-                "No pipette attached to {} mount".format(mount)
-            )
-        if aspirate:
-            this_pipette.aspirate_flow_rate = self._plunger_flowrate(
-                this_pipette, aspirate, "aspirate"
-            )
-        if dispense:
-            this_pipette.dispense_flow_rate = self._plunger_flowrate(
-                this_pipette, dispense, "dispense"
-            )
-        if blow_out:
-            this_pipette.blow_out_flow_rate = self._plunger_flowrate(
-                this_pipette, blow_out, "dispense"
-            )
-
     def get_instrument_max_height(
         self, mount: top_types.Mount, critical_point: Optional[CriticalPoint] = None
     ) -> float:
-        """Return max achievable height of the attached instrument
-        based on the current critical point
-        """
-        pip = self._attached_instruments[mount]
-        assert pip
-        cp = self._critical_point_for(mount, critical_point)
-
-        max_height = pip.config.home_position - self._config.z_retract_distance + cp.z
-
-        return max_height
+        return InstrumentHandlerProvider.instrument_max_height(
+            self, mount, self._config.z_retract_distance, critical_point
+        )
 
     def clean_up(self) -> None:
         """Get the API ready to stop cleanly."""

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -1195,26 +1195,20 @@ class API(
         Force any remaining liquid to dispense. The liquid will be dispensed at
         the current location of pipette
         """
-        instruments = self.instruments_for(mount)
-        self.ready_for_tip_action(instruments, HardwareAction.BLOWOUT)
-        plunger_currents = {
-            Axis.of_plunger(instr[1]): instr[0].config.plunger_current
-            for instr in instruments
-        }
-        blow_out = tuple(instr[0].config.blow_out for instr in instruments)
-
-        self._backend.set_active_current(plunger_currents)
-        speed = max(
-            self.plunger_speed(instr[0], instr[0].blow_out_flow_rate, "dispense")
-            for instr in instruments
+        blowout_spec = self.plan_check_blow_out(mount)
+        self._backend.set_active_current(
+            {spec.axis: spec.current for spec in blowout_spec}
         )
+        target_pos, _, secondary_z = target_position_from_plunger(
+            mount,
+            [spec.plunger_distance for spec in blowout_spec],
+            self._current_position,
+        )
+
         try:
-            target_pos, _, secondary_z = target_position_from_plunger(
-                mount, blow_out, self._current_position
-            )
             await self._move(
                 target_pos,
-                speed=speed,
+                speed=blowout_spec[0].speed,
                 secondary_z=secondary_z,
                 home_flagged_axes=False,
             )
@@ -1222,9 +1216,9 @@ class API(
             self._log.exception("Blow out failed")
             raise
         finally:
-            for instr in instruments:
-                instr[0].set_current_volume(0)
-                instr[0].ready_to_aspirate = False
+            for spec in blowout_spec:
+                spec.instr.set_current_volume(0)
+                spec.instr.ready_to_aspirate = False
 
     async def pick_up_tip(
         self,

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -321,7 +321,9 @@ class API(
 
     # Incidentals (i.e. not motion) API
 
-    async def set_lights(self, button: bool = None, rails: bool = None):
+    async def set_lights(
+        self, button: Optional[bool] = None, rails: Optional[bool] = None
+    ) -> None:
         """Control the robot lights."""
         self._backend.set_lights(button, rails)
 
@@ -382,8 +384,8 @@ class API(
         )
 
     async def cache_instruments(
-        self, require: Dict[top_types.Mount, PipetteName] = None
-    ):
+        self, require: Optional[Dict[top_types.Mount, PipetteName]] = None
+    ) -> None:
         """
         Scan the attached instruments, take necessary configuration actions,
         and set up hardware controller internal state if necessary.

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -75,6 +75,11 @@ class API(
     of external access to the hardware. Each method may be minimal - it may
     only delegate the call to another submodule of the hardware manager -
     but its purpose is to be gathered here to provide a single interface.
+
+    This implements the protocols in opentrons.hardware_control.protocols,
+    and longer method docstrings may be found there. Docstrings for the
+    methods in this class only note where their behavior is different or
+    extended from that described in the protocol.
     """
 
     CLS_LOG = mod_log.getChild("API")
@@ -295,7 +300,7 @@ class API(
 
     def get_fw_version(self) -> str:
         """
-        Return the firmware version of the connected hardware.
+        Return the firmware version of the connected motor control board.
 
         The version is a string retrieved directly from the attached hardware
         (or possibly simulator).
@@ -317,15 +322,7 @@ class API(
     # Incidentals (i.e. not motion) API
 
     async def set_lights(self, button: bool = None, rails: bool = None):
-        """Control the robot lights.
-
-        :param button: If specified, turn the button light on (`True`) or
-                       off (`False`). If not specified, do not change the
-                       button light.
-        :param rails: If specified, turn the rail lights on (`True`) or
-                      off (`False`). If not specified, do not change the
-                      rail lights.
-        """
+        """Control the robot lights."""
         self._backend.set_lights(button, rails)
 
     def get_lights(self) -> Dict[str, bool]:
@@ -336,10 +333,7 @@ class API(
         return self._backend.get_lights()
 
     async def identify(self, duration_s: int = 5):
-        """Blink the button light to identify the robot.
-
-        :param int duration_s: The duration to blink for, in seconds.
-        """
+        """Blink the button light to identify the robot."""
         count = duration_s * 4
         on = False
         for sec in range(count):
@@ -369,7 +363,7 @@ class API(
         loop: asyncio.AbstractEventLoop = None,
         explicit_modeset: bool = True,
     ) -> str:
-        """Update the firmware on the Smoothie board.
+        """Update the firmware on the motor controller board.
 
         :param firmware_file: The path to the firmware file.
         :param explicit_modeset: `True` to force the smoothie into programming
@@ -393,25 +387,6 @@ class API(
         """
         Scan the attached instruments, take necessary configuration actions,
         and set up hardware controller internal state if necessary.
-
-        :param require: If specified, the require should be a dict
-                        of mounts to instrument names describing
-                        the instruments expected to be present. This can
-                        save a subsequent of :py:attr:`attached_instruments`
-                        and also serves as the hook for the hardware
-                        simulator to decide what is attached.
-        :raises RuntimeError: If an instrument is expected but not found.
-
-        .. note::
-
-            This function will only change the things that need to be changed.
-            If the same pipette (by serial) or the same lack of pipette is
-            observed on a mount before and after the scan, no action will be
-            taken. That makes this function appropriate for setting up the
-            robot for operation, but not for making sure that any previous
-            settings changes have been reset. For the latter use case, use
-            :py:meth:`reset_instrument`.
-
         """
         self._log.info("Updating instrument model cache")
         checked_require = require or {}
@@ -452,14 +427,6 @@ class API(
     def pause(self, pause_type: PauseType):
         """
         Pause motion of the robot after a current motion concludes.
-
-        Individual calls to :py:meth:`move`
-        (which :py:meth:`aspirate` and :py:meth:`dispense` and other
-        calls may depend on) are considered atomic and will always complete if
-        they have been called prior to a call to this method. However,
-        subsequent calls to :py:meth:`move` that occur when the system
-        is paused will not proceed until the system is resumed with
-        :py:meth:`resume`.
         """
         self._pause_manager.pause(pause_type)
 
@@ -470,6 +437,7 @@ class API(
         asyncio.run_coroutine_threadsafe(_chained_calls(), self._loop)
 
     def pause_with_message(self, message: str):
+        """As pause, but providing a message to registered callbacks."""
         self._log.warning(f"Pause with message: {message}")
         notification = ErrorMessageNotification(message=message)
         for cb in self._callbacks:
@@ -477,9 +445,7 @@ class API(
         self.pause(PauseType.PAUSE)
 
     def resume(self, pause_type: PauseType):
-        """
-        Resume motion after a call to :py:meth:`pause`.
-        """
+        """Resume motion after a call to pause."""
         self._pause_manager.resume(pause_type)
 
         if self._pause_manager.should_pause:
@@ -499,12 +465,6 @@ class API(
     async def halt(self) -> None:
         """Immediately stop motion.
 
-        Calls to :py:meth:`stop` through the synch adapter while other calls
-        are ongoing will typically wait until those calls are done, since most
-        of the async calls here in fact block the loop while they talk to
-        smoothie. To provide actual immediate halting, call this method which
-        does not require use of the loop.
-
         After this call, the smoothie will be in a bad state until a call to
         :py:meth:`stop`.
         """
@@ -517,7 +477,7 @@ class API(
 
         This will cancel motion (after the current call to :py:meth:`move`;
         see :py:meth:`pause` for more detail), then home and reset the
-        robot.
+        robot. After this call, no further recovery is necessary.
         """
         await self._backend.halt()
         self._log.info("Recovering from halt")
@@ -528,11 +488,7 @@ class API(
             await self.home()
 
     async def reset(self) -> None:
-        """Reset the stored state of the system.
-
-        This will re-scan instruments and models, clearing any cached
-        information about their presence or state.
-        """
+        """Reset the stored state of the system."""
         self._pause_manager.reset()
         await self._execution_manager.reset()
         await InstrumentHandlerProvider.reset(self)
@@ -588,19 +544,13 @@ class API(
         """
         Home the plunger motor for a mount, and then return it to the 'bottom'
         position.
-
-        :param mount: the mount associated with the target plunger
-        :type mount: :py:class:`.top_types.Mount`
         """
         await self.current_position(mount=mount, refresh=True)
         await self._do_plunger_home(mount=mount, acquire_lock=True)
 
     @ExecutionManagerProvider.wait_for_running
     async def home(self, axes: Optional[List[Axis]] = None):
-        """Home the entire robot and initialize current position.
-        :param axes: A list of axes to home. Default is `None`, which will
-                     home everything.
-        """
+        """Home the entire robot and initialize current position."""
         self._reset_last_mount()
         # Initialize/update current_position
         checked_axes = axes or [ax for ax in Axis]
@@ -672,20 +622,6 @@ class API(
     ) -> Dict[Axis, float]:
         """Return the postion (in deck coords) of the critical point of the
         specified mount.
-
-        This returns cached position to avoid hitting the smoothie driver
-        unless ``refresh`` is ``True``.
-
-        If `critical_point` is specified, that critical point will be applied
-        instead of the default one. For instance, if
-        `critical_point=CriticalPoints.MOUNT` then the position of the mount
-        will be returned. If the critical point specified does not exist, then
-        the next one down is returned - for instance, if there is no tip on the
-        specified mount but `CriticalPoint.TIP` was specified, the position of
-        the nozzle will be returned.
-
-        If `fail_on_not_homed` is `True`, this method will raise a `MustHomeError`
-        if any of the relavent axes are not homed, regardless of `refresh`.
         """
         z_ax = Axis.by_mount(mount)
         plunger_ax = Axis.of_plunger(mount)
@@ -728,20 +664,7 @@ class API(
         # position reporting when motors are not homed
         fail_on_not_homed: bool = False,
     ) -> top_types.Point:
-        """Return the position of the critical point as pertains to the gantry
-
-        This ignores the plunger position and gives the Z-axis a predictable
-        name (as :py:attr:`.Point.z`).
-
-        `critical_point` specifies an override to the current critical point to
-        use (see :py:meth:`current_position`).
-
-        `refresh` if set to True, update the cached position using the
-        smoothie driver (see :py:meth:`current_position`).
-
-        If `fail_on_not_homed` is `True`, this method will raise a `MustHomeError`
-        if any of the relavent axes are not homed, regardless of `refresh`.
-        """
+        """Return the position of the critical point for only gantry axes."""
         cur_pos = await self.current_position(
             mount,
             critical_point,
@@ -760,42 +683,9 @@ class API(
         critical_point: Optional[CriticalPoint] = None,
         max_speeds: Optional[Dict[Axis, float]] = None,
     ):
-        """Move the critical point of the specified mount to a location
-        relative to the deck, at the specified speed. 'speed' sets the speed
-        of all robot axes to the given value. So, if multiple axes are to be
-        moved, they will do so at the same speed
-
-        The critical point of the mount depends on the current status of
-        the mount:
-        - If the mount does not have anything attached, its critical point is
-          the bottom of the mount attach bracket.
-        - If the mount has a pipette attached and it is not known to have a
-          pipette tip, the critical point is the end of the nozzle of a single
-          pipette or the end of the backmost nozzle of a multipipette
-        - If the mount has a pipette attached and it is known to have a
-          pipette tip, the critical point is the end of the pipette tip for
-          a single pipette or the end of the tip of the backmost nozzle of a
-          multipipette
-
-        :param mount: The mount to move
-        :param abs_position: The target absolute position in
-                             deck coordinates to move the
-                             critical point to
-        :param speed: An overall head speed to use during the move
-        :param critical_point: The critical point to move. In most situations
-                               this is not needed. If not specified, the
-                               current critical point will be moved. If
-                               specified, the critical point must be one that
-                               actually exists - that is, specifying
-                               :py:attr:`.CriticalPoint.NOZZLE` when no pipette
-                               is attached or :py:attr:`.CriticalPoint.TIP`
-                               when no tip is applied will result in an error.
-        :param max_speeds: An optional override for per-axis maximum speeds. If
-                           an axis is specified, it will not move faster than
-                           the given speed. Note that this does not make that
-                           axis move precisely at the given speed; it only
-                           it if it was going to go faster. Direct speed
-                           is still set by ``speed``.
+        """
+        Move the critical point of the specified mount to a location
+        relative to the deck, at the specified speed.
         """
         if not self._current_position:
             await self.home()
@@ -823,11 +713,6 @@ class API(
     ):
         """Move the critical point of the specified mount by a specified
         displacement in a specified direction, at the specified speed.
-        'speed' sets the speed of all axes to the given value. So, if multiple
-        axes are to be moved, they will do so at the same speed.
-
-        If fail_on_not_homed is True (default False), if an axis that is not
-        homed moves it will raise a MustHomeError. Otherwise, it will home the axis.
         """
 
         # TODO: Remove the fail_on_not_homed and make this the behavior all the time.
@@ -1060,20 +945,6 @@ class API(
     ):
         """
         Prepare the pipette for aspiration.
-
-        This must happen after every :py:meth:`blow_out` and should probably be
-        called before every :py:meth:`aspirate`, while the pipette tip is not
-        immersed in a well. It ensures that the plunger is at the 0-volume
-        position of the pipette if necessary (if not necessary, it does
-        nothing).
-
-        If :py:meth:`aspirate` is called immediately after :py:meth:`blow_out`,
-        the plunger is left at the ``blow_out`` position, below the ``bottom``
-        position, and moving the plunger up during :py:meth:`aspirate` is
-        expected to aspirate liquid - :py:meth:`aspirate` is called once the
-        pipette tip is already in the well. This will cause a subtle over
-        aspiration. To make the problem more obvious, :py:meth:`aspirate` will
-        raise an exception if this method has not previously been called.
         """
         instruments = self.instruments_for(mount)
         self.ready_for_tip_action(instruments, HardwareAction.PREPARE_ASPIRATE)
@@ -1102,23 +973,7 @@ class API(
         rate: float = 1.0,
     ):
         """
-        Aspirate a volume of liquid (in microliters/uL) using this pipette
-        from the *current location*. If no volume is passed, `aspirate` will
-        default to max available volume (after taking into account the volume
-        already present in the tip).
-
-        The function :py:meth:`prepare_for_aspirate` must be called prior to
-        calling this function, while the tip is above the well. This ensures
-        that the pipette tip is in the proper position at the bottom of the
-        pipette to begin aspiration, and prevents subtle over-aspiration if
-        an aspirate is done immediately after :py:meth:`blow_out`. If
-        :py:meth:`prepare_for_aspirate` has not been called since the last
-        call to :py:meth:`aspirate`, an exception will be raised.
-
-        mount : Mount.LEFT or Mount.RIGHT
-        volume : [float] The number of microliters to aspirate
-        rate : [float] Set plunger speed for this aspirate, where
-            speed = rate * aspirate_speed
+        Aspirate a volume of liquid (in microliters/uL) using this pipette.
         """
         aspirate_spec = self.plan_check_aspirate(mount, volume, rate)
         target_pos, _, secondary_z = target_position_from_plunger(
@@ -1152,14 +1007,7 @@ class API(
         rate: float = 1.0,
     ):
         """
-        Dispense a volume of liquid in microliters(uL) using this pipette
-        at the current location. If no volume is specified, `dispense` will
-        dispense all volume currently present in pipette
-
-        mount : Mount.LEFT or Mount.RIGHT
-        volume : [float] The number of microliters to dispense
-        rate : [float] Set plunger speed for this dispense, where
-            speed = rate * dispense_speed
+        Dispense a volume of liquid in microliters(uL) using this pipette.
         """
 
         dispense_spec = self.plan_check_dispense(mount, volume, rate)
@@ -1229,19 +1077,6 @@ class API(
     ):
         """
         Pick up tip from current location.
-
-        This is achieved by attempting to move the instrument down by its
-        `pick_up_distance`, in a series of presses. This distance is larger
-        than the space available in the tip, so the stepper motor will
-        eventually skip steps, which is resolved by homing afterwards. The
-        pick up operation is done at a current specified in the pipette config,
-        which is experimentally determined to skip steps at a level of force
-        sufficient to provide a good seal between the pipette nozzle and tip
-        while also avoiding attaching the tip so firmly that it can't be
-        dropped later.
-
-        If ``presses`` or ``increment`` is not specified (or is ``None``),
-        their value is taken from the pipette configuration.
         """
         instruments = self.instruments_for(mount)
         self.ready_for_pick_up_tip(instruments)
@@ -1337,15 +1172,7 @@ class API(
     async def drop_tip(
         self, mount: Union[top_types.Mount, PipettePair], home_after=True
     ):
-        """
-        Drop tip at the current location
-
-        :param Mount mount: The mount to drop a tip from
-        :param bool home_after: Home the plunger motor after dropping tip. This
-                                is used in case the plunger motor skipped while
-                                dropping the tip, and is also used to recover
-                                the ejector shroud after a drop.
-        """
+        """Drop tip at the current location."""
 
         instruments = self.instruments_for(mount)
         self.ready_for_tip_action(instruments, HardwareAction.DROPTIP)

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -27,11 +27,6 @@ from .util import use_or_initialize_loop, check_motion_bounds
 from .pipette import generate_hardware_configs, load_from_config_and_check_skip
 from .controller import Controller
 from .simulator import Simulator
-from .constants import (
-    SHAKE_OFF_TIPS_SPEED,
-    SHAKE_OFF_TIPS_DROP_DISTANCE,
-    DROP_TIP_RELEASE_DISTANCE,
-)
 from .execution_manager import ExecutionManagerProvider
 from .pause_manager import PauseManager
 from .module_control import AttachedModulesControl
@@ -1111,94 +1106,31 @@ class API(
     ):
         """Drop tip at the current location."""
 
-        instruments = self.instruments_for(mount)
-        self.ready_for_tip_action(instruments, HardwareAction.DROPTIP)
-        plunger_currents = {
-            Axis.of_plunger(instr[1]): instr[0].config.plunger_current
-            for instr in instruments
-        }
-        drop_tip_currents = {
-            Axis.of_plunger(instr[1]): instr[0].config.drop_tip_current
-            for instr in instruments
-        }
-        plunger_axes = tuple(
-            Axis.of_plunger(instr[1]).name.upper() for instr in instruments
-        )
+        spec, _remove = self.plan_check_drop_tip(mount, home_after)
 
-        bottom = tuple(instr[0].config.bottom for instr in instruments)
-        droptip = tuple(instr[0].config.drop_tip for instr in instruments)
-        speed = min(instr[0].config.drop_tip_speed for instr in instruments)
-
-        async def _drop_tip():
-            self._backend.set_active_current(plunger_currents)
+        for move in spec.drop_moves:
+            self._backend.set_active_current(move.current)
             target_pos, _, secondary_z = target_position_from_plunger(
-                mount, bottom, self._current_position
+                mount, move.target_position, self._current_position
             )
             await self._move(
                 target_pos,
+                speed=move.speed,
                 secondary_z=secondary_z,
                 home_flagged_axes=False,
             )
-            self._backend.set_active_current(drop_tip_currents)
-            target_pos, _, secondary_z = target_position_from_plunger(
-                mount,
-                droptip,
-                self._current_position,
-            )
-            await self._move(
-                target_pos,
-                speed=speed,
-                secondary_z=secondary_z,
-                home_flagged_axes=False,
-            )
-            if home_after:
-                safety_margin = abs(max(bottom) - max(droptip))
+            if move.home_after:
                 smoothie_pos = await self._backend.fast_home(
-                    plunger_axes, safety_margin
+                    [ax.name.upper() for ax in move.home_axes],
+                    move.home_after_safety_margin,
                 )
                 self._current_position = self._deck_from_smoothie(smoothie_pos)
-                self._backend.set_active_current(plunger_currents)
-                target_pos, _, secondary_z = target_position_from_plunger(
-                    mount, bottom, self._current_position
-                )
-                await self._move(
-                    target_pos,
-                    secondary_z=secondary_z,
-                    home_flagged_axes=False,
-                )
 
-        if any(["doubleDropTip" in instr[0].config.quirks for instr in instruments]):
-            await _drop_tip()
-        await _drop_tip()
+        for shake in spec.shake_moves:
+            await self.move_rel(mount, shake[0], speed=shake[1])
 
-        if any(["dropTipShake" in instr[0].config.quirks for instr in instruments]):
-            diameter = min(instr[0].current_tiprack_diameter for instr in instruments)
-            await self._shake_off_tips_drop(mount, diameter)
-        self._backend.set_active_current(plunger_currents)
-        for instr in instruments:
-            instr[0].set_current_volume(0)
-            instr[0].current_tiprack_diameter = 0.0
-            instr[0].remove_tip()
-
-    async def _shake_off_tips_drop(self, mount, tiprack_diameter):
-        # tips don't always fall off, especially if resting against
-        # tiprack or other tips below it. To ensure the tip has fallen
-        # first, shake the pipette to dislodge partially-sealed tips,
-        # then second, raise the pipette so loosened tips have room to fall
-        shake_off_dist = SHAKE_OFF_TIPS_DROP_DISTANCE
-        if tiprack_diameter > 0.0:
-            shake_off_dist = min(shake_off_dist, tiprack_diameter / 4)
-        shake_off_dist = max(shake_off_dist, 1.0)
-
-        shake_pos = top_types.Point(-shake_off_dist, 0, 0)  # move left
-        await self.move_rel(mount, shake_pos, speed=SHAKE_OFF_TIPS_SPEED)
-        shake_pos = top_types.Point(2 * shake_off_dist, 0, 0)  # move right
-        await self.move_rel(mount, shake_pos, speed=SHAKE_OFF_TIPS_SPEED)
-        shake_pos = top_types.Point(-shake_off_dist, 0, 0)  # original position
-        await self.move_rel(mount, shake_pos, speed=SHAKE_OFF_TIPS_SPEED)
-        # raise the pipette upwards so we are sure tip has fallen off
-        up_pos = top_types.Point(0, 0, DROP_TIP_RELEASE_DISTANCE)
-        await self.move_rel(mount, up_pos)
+        self._backend.set_active_current(spec.ending_current)
+        _remove()
 
     async def find_modules(
         self,

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -22,11 +22,10 @@ from typing import (
 from opentrons_shared_data.pipette import name_config
 from opentrons import types as top_types
 from opentrons.util import linal
-from functools import lru_cache
 from opentrons.config import robot_configs
 from opentrons.config.types import RobotConfig
 
-from .util import use_or_initialize_loop, DeckTransformState, check_motion_bounds
+from .util import use_or_initialize_loop, check_motion_bounds
 from .pipette import Pipette, generate_hardware_configs, load_from_config_and_check_skip
 from .controller import Controller
 from .simulator import Simulator
@@ -36,7 +35,7 @@ from .constants import (
     SHAKE_OFF_TIPS_PICKUP_DISTANCE,
     DROP_TIP_RELEASE_DISTANCE,
 )
-from .execution_manager import ExecutionManager
+from .execution_manager import ExecutionManagerProvider
 from .pause_manager import PauseManager
 from .module_control import AttachedModulesControl
 from .types import (
@@ -55,7 +54,8 @@ from .types import (
     MotionChecks,
     PauseType,
 )
-from . import modules, robot_calibration as rb_cal
+from . import modules
+from .robot_calibration import RobotCalibrationProvider, load_pipette_offset
 from .protocols import HardwareControlAPI
 
 if TYPE_CHECKING:
@@ -70,7 +70,7 @@ InstrumentsByMount = Dict[top_types.Mount, Optional[Pipette]]
 PipetteHandlingData = Tuple[Pipette, top_types.Mount]
 
 
-class API(HardwareControlAPI):
+class API(ExecutionManagerProvider, RobotCalibrationProvider):
     """This API is the primary interface to the hardware controller.
 
     Because the hardware manager controls access to the system's hardware
@@ -100,7 +100,6 @@ class API(HardwareControlAPI):
         self._backend = backend
         self._loop = loop
 
-        self._execution_manager = ExecutionManager(loop=loop)
         self._callbacks: Set[HardwareEventHandler] = set()
         # {'X': 0.0, 'Y': 0.0, 'Z': 0.0, 'A': 0.0, 'B': 0.0, 'C': 0.0}
         self._current_position: Dict[Axis, float] = {}
@@ -117,20 +116,25 @@ class API(HardwareControlAPI):
         # home() call succeeds or fails.
         self._motion_lock = asyncio.Lock(loop=self._loop)
         self._door_state = DoorState.CLOSED
-        self._robot_calibration = rb_cal.load()
         self._pause_manager = PauseManager(self._door_state)
+        ExecutionManagerProvider.__init__(self, loop, isinstance(backend, Simulator))
+        RobotCalibrationProvider.__init__(self)
+        API._check_type(self)
 
-    @property
-    def robot_calibration(self) -> rb_cal.RobotCalibration:
-        return self._robot_calibration
+    @staticmethod
+    def _check_type(inst: HardwareControlAPI) -> None:
+        """Do-nothing to provide early warning if the protocol is not satisfied.
 
-    def reset_robot_calibration(self):
-        self._calculate_valid_attitude.cache_clear()
-        self._robot_calibration = rb_cal.load()
+        This class can't inherit from the HardwareControlAPI protocol if we're also
+        doing multiple inheritance, because it confuses MRO - it looks like it should
+        have all these functions, but they're defined to not do anything. That means
+        that we don't get the early warning when the class doesn't fulfill the
+        protocol.
 
-    def set_robot_calibration(self, robot_calibration: rb_cal.RobotCalibration):
-        self._calculate_valid_attitude.cache_clear()
-        self._robot_calibration = robot_calibration
+        What we can do instead is this, a bogus function that exists to make mypy
+        verify while parsing the class that it fulfilles the protocol.
+        """
+        pass
 
     @property
     def door_state(self) -> DoorState:
@@ -285,22 +289,6 @@ class API(HardwareControlAPI):
         """`True` if this is a simulator; `False` otherwise."""
         return isinstance(self._backend, Simulator)
 
-    def validate_calibration(self) -> DeckTransformState:
-        """
-        The lru cache decorator is currently not supported by the
-        ThreadManager. To work around this, we need to wrap the
-        actual function around a dummy outer function.
-
-        Once decorators are more fully supported, we can remove this.
-        """
-        return self._calculate_valid_attitude()
-
-    @lru_cache(maxsize=1)
-    def _calculate_valid_attitude(self) -> DeckTransformState:
-        return rb_cal.validate_attitude_deck_calibration(
-            self._robot_calibration.deck_calibration
-        )
-
     def register_callback(self, cb: HardwareEventHandler) -> Callable[[], None]:
         """Allows the caller to register a callback, and returns a closure
         that can be used to unregister the provided callback
@@ -369,18 +357,12 @@ class API(HardwareControlAPI):
             await asyncio.sleep(max(0, 0.25 - (now - then)))
         await self.set_lights(button=True)
 
+    @ExecutionManagerProvider.wait_for_running
     async def delay(self, duration_s: float):
         """Delay execution by pausing and sleeping."""
-        await self._wait_for_is_running()
         self.pause(PauseType.DELAY)
         try:
-            if not self.is_simulator:
-
-                async def sleep_for_seconds(seconds: float):
-                    await asyncio.sleep(seconds)
-
-                delay_task = self._loop.create_task(sleep_for_seconds(duration_s))
-                await self._execution_manager.register_cancellable_task(delay_task)
+            await self.do_delay(duration_s)
         finally:
             self.resume(PauseType.DELAY)
 
@@ -400,7 +382,7 @@ class API(HardwareControlAPI):
             if not p:
                 return
             new_p = Pipette(
-                p._config, rb_cal.load_pipette_offset(p.pipette_id, m), p.pipette_id
+                p._config, load_pipette_offset(p.pipette_id, m), p.pipette_id
             )
             new_p.act_as(p.acting_as)
             self._attached_instruments[m] = new_p
@@ -449,7 +431,7 @@ class API(HardwareControlAPI):
             config = instrument_data.get("config")
             req_instr = checked_require.get(mount, None)
             pip_id = instrument_data.get("id")
-            pip_offset_cal = rb_cal.load_pipette_offset(pip_id, mount)
+            pip_offset_cal = load_pipette_offset(pip_id, mount)
             p, may_skip = load_from_config_and_check_skip(
                 config,
                 self._attached_instruments[mount],
@@ -669,10 +651,6 @@ class API(HardwareControlAPI):
         if home_after:
             await self.home()
 
-    async def _wait_for_is_running(self):
-        if not self.is_simulator:
-            await self._execution_manager.wait_for_is_running()
-
     async def reset(self) -> None:
         """Reset the stored state of the system.
 
@@ -738,12 +716,12 @@ class API(HardwareControlAPI):
         await self.current_position(mount=mount, refresh=True)
         await self._do_plunger_home(mount=mount, acquire_lock=True)
 
+    @ExecutionManagerProvider.wait_for_running
     async def home(self, axes: Optional[List[Axis]] = None):
         """Home the entire robot and initialize current position.
         :param axes: A list of axes to home. Default is `None`, which will
                      home everything.
         """
-        await self._wait_for_is_running()
         self._reset_last_mount()
         # Initialize/update current_position
         checked_axes = axes or [ax for ax in Axis]
@@ -1191,6 +1169,7 @@ class API(HardwareControlAPI):
         )
         return primary_transformed, secondary_transformed
 
+    @ExecutionManagerProvider.wait_for_running
     async def _move(
         self,
         target_position: "OrderedDict[Axis, float]",
@@ -1212,7 +1191,6 @@ class API(HardwareControlAPI):
         at most one of a ZA or BC components. The frame in which to move
         is identified by the presence of (ZA) or (BC).
         """
-        await self._wait_for_is_running()
         # Transform only the x, y, and (z or a) axes specified since this could
         # get the b or c axes as well
         to_transform_primary = tuple(
@@ -1294,6 +1272,7 @@ class API(HardwareControlAPI):
         converted_axes = "".join(axes)
         return await self._backend.fast_home(converted_axes, margin)
 
+    @ExecutionManagerProvider.wait_for_running
     async def retract(
         self, mount: Union[top_types.Mount, PipettePair], margin: float = 10
     ):
@@ -1301,7 +1280,6 @@ class API(HardwareControlAPI):
 
         Works regardless of critical point or home status.
         """
-        await self._wait_for_is_running()
         if isinstance(mount, PipettePair):
             primary_ax = Axis.by_mount(mount.primary).name.upper()
             secondary_ax = Axis.by_mount(mount.secondary).name.upper()

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -1120,59 +1120,30 @@ class API(
         rate : [float] Set plunger speed for this aspirate, where
             speed = rate * aspirate_speed
         """
-        instruments = self.instruments_for(mount)
-        self.ready_for_tip_action(instruments, HardwareAction.ASPIRATE)
-        plunger_currents = {
-            Axis.of_plunger(instr[1]): instr[0].config.plunger_current
-            for instr in instruments
-        }
-
-        if volume is None:
-            mod_log.debug(
-                "No aspirate volume defined. Aspirating up to "
-                "max_volume for the pipette"
-            )
-            asp_vol = tuple(instr[0].available_volume for instr in instruments)
-        else:
-            asp_vol = tuple(volume for instr in instruments)
-
-        if all([vol == 0 for vol in asp_vol]):
-            return
-        elif 0 in asp_vol:
-            raise PairedPipetteConfigValueError("Cannot only aspirate from one pipette")
-
-        for instr, vol in zip(instruments, asp_vol):
-            assert instr[0].ok_to_add_volume(
-                vol
-            ), "Cannot aspirate more than pipette max volume"
-
-        dist = tuple(
-            self.plunger_position(instr[0], instr[0].current_volume + vol, "aspirate")
-            for instr, vol in zip(instruments, asp_vol)
-        )
-        speed = min(
-            self.plunger_speed(instr[0], instr[0].aspirate_flow_rate * rate, "aspirate")
-            for instr in instruments
+        aspirate_spec = self.plan_check_aspirate(mount, volume, rate)
+        target_pos, _, secondary_z = target_position_from_plunger(
+            mount,
+            [spec.plunger_distance for spec in aspirate_spec],
+            self._current_position,
         )
         try:
-            self._backend.set_active_current(plunger_currents)
-            target_pos, _, secondary_z = target_position_from_plunger(
-                mount, dist, self._current_position
+            self._backend.set_active_current(
+                {spec.axis: spec.current for spec in aspirate_spec}
             )
             await self._move(
                 target_pos,
-                speed=speed,
+                speed=aspirate_spec[0].speed,
                 secondary_z=secondary_z,
                 home_flagged_axes=False,
             )
         except Exception:
             self._log.exception("Aspirate failed")
-            for instr in instruments:
-                instr[0].set_current_volume(0)
+            for spec in aspirate_spec:
+                spec.instr.set_current_volume(0)
             raise
         else:
-            for instr, vol in zip(instruments, asp_vol):
-                instr[0].add_current_volume(vol)
+            for spec in aspirate_spec:
+                spec.instr.add_current_volume(spec.volume)
 
     async def dispense(
         self,

--- a/api/src/opentrons/hardware_control/instrument_handler.py
+++ b/api/src/opentrons/hardware_control/instrument_handler.py
@@ -529,3 +529,25 @@ class InstrumentHandlerProvider:
             )
             for instr, this_dist, this_vol in zip(instruments, dist, disp_vol)
         ]
+
+    def plan_check_blow_out(
+        self, mount: Union[top_types.Mount, PipettePair]
+    ) -> Sequence["InstrumentHandlerProvider.LiquidActionSpec"]:
+        """Check preconditions and calculate values for blowout."""
+        instruments = self.instruments_for(mount)
+        self.ready_for_tip_action(instruments, HardwareAction.BLOWOUT)
+        speed = max(
+            self.plunger_speed(instr[0], instr[0].blow_out_flow_rate, "dispense")
+            for instr in instruments
+        )
+        return [
+            self.LiquidActionSpec(
+                axis=Axis.of_plunger(instr[1]),
+                volume=0,
+                plunger_distance=instr[0].config.blow_out,
+                speed=speed,
+                instr=instr[0],
+                current=instr[0].config.plunger_current,
+            )
+            for instr in instruments
+        ]

--- a/api/src/opentrons/hardware_control/instrument_handler.py
+++ b/api/src/opentrons/hardware_control/instrument_handler.py
@@ -1,0 +1,403 @@
+"""Shared code for managing pipette configuration and storage."""
+import logging
+from typing import Dict, Optional, Tuple, overload, Sequence, Any, cast, Union
+
+from opentrons_shared_data.pipette.dev_types import UlPerMmAction
+
+from opentrons import types as top_types
+from .types import (
+    CriticalPoint,
+    HardwareAction,
+    TipAttachedError,
+    NoTipAttachedError,
+    PipettePair,
+)
+from .robot_calibration import load_pipette_offset
+from .dev_types import PipetteDict
+from .pipette import Pipette
+
+InstrumentsByMount = Dict[top_types.Mount, Optional[Pipette]]
+PipetteHandlingData = Tuple[Pipette, top_types.Mount]
+
+MOD_LOG = logging.getLogger(__name__)
+
+
+class InstrumentHandlerProvider:
+    IHP_LOG = MOD_LOG.getChild("InstrumentHandler")
+
+    def __init__(self):
+        self._attached_instruments: InstrumentsByMount = {
+            top_types.Mount.LEFT: None,
+            top_types.Mount.RIGHT: None,
+        }
+        self._ihp_log = InstrumentHandlerProvider.IHP_LOG.getChild(str(id(self)))
+
+    def reset_instrument(self, mount: top_types.Mount = None):
+        """
+        Reset the internal state of a pipette by its mount, without doing
+        any lower level reconfiguration. This is useful to make sure that no
+        settings changes from a protocol persist.
+
+        :param mount: If specified, reset that mount. If not specified,
+                      reset both
+        """
+
+        def _reset(m: top_types.Mount):
+            self._ihp_log.info(f"Resetting configuration for {m}")
+            p = self._attached_instruments[m]
+            if not p:
+                return
+            new_p = Pipette(
+                p._config, load_pipette_offset(p.pipette_id, m), p.pipette_id
+            )
+            new_p.act_as(p.acting_as)
+            self._attached_instruments[m] = new_p
+
+        if not mount:
+            for m in top_types.Mount:
+                _reset(m)
+        else:
+            _reset(mount)
+
+    # TODO(mc, 2022-01-11): change returned map value type to `Optional[PipetteDict]`
+    # instead of potentially returning an empty dict
+    def get_attached_instruments(self) -> Dict[top_types.Mount, PipetteDict]:
+        """Get the status dicts of the cached attached instruments.
+
+        Also available as :py:meth:`get_attached_instruments`.
+
+        This returns a dictified version of the
+        :py:class:`hardware_control.pipette.Pipette` as a dict keyed by
+        the :py:class:`top_types.Mount` to which the pipette is attached.
+        If no pipette is attached on a given mount, the mount key will
+        still be present but will have the value ``None``.
+
+        Note that this is only a query of a cached value; to actively scan
+        for changes, use :py:meth:`cache_instruments`. This process deactivates
+        the motors and should be used sparingly.
+        """
+        return {
+            m: self.get_attached_instrument(m)
+            for m in (top_types.Mount.LEFT, top_types.Mount.RIGHT)
+        }
+
+    # TODO(mc, 2022-01-11): change return type to `Optional[PipetteDict]` instead
+    # of potentially returning an empty dict
+    def get_attached_instrument(self, mount: top_types.Mount) -> PipetteDict:
+        instr = self._attached_instruments[mount]
+        result: Dict[str, Any] = {}
+        if instr:
+            configs = [
+                "name",
+                "min_volume",
+                "max_volume",
+                "channels",
+                "aspirate_flow_rate",
+                "dispense_flow_rate",
+                "pipette_id",
+                "current_volume",
+                "display_name",
+                "tip_length",
+                "model",
+                "blow_out_flow_rate",
+                "working_volume",
+                "tip_overlap",
+                "available_volume",
+                "return_tip_height",
+                "default_aspirate_flow_rates",
+                "default_blow_out_flow_rates",
+                "default_dispense_flow_rates",
+                "back_compat_names",
+            ]
+
+            instr_dict = instr.as_dict()
+            # TODO (spp, 2021-08-27): Revisit this logic. Why do we need to build
+            #  this dict newly every time? Any why only a few items are being updated?
+            for key in configs:
+                result[key] = instr_dict[key]
+            result["has_tip"] = instr.has_tip
+            result["tip_length"] = instr.current_tip_length
+            result["aspirate_speed"] = self.plunger_speed(
+                instr, instr.aspirate_flow_rate, "aspirate"
+            )
+            result["dispense_speed"] = self.plunger_speed(
+                instr, instr.dispense_flow_rate, "dispense"
+            )
+            result["blow_out_speed"] = self.plunger_speed(
+                instr, instr.blow_out_flow_rate, "dispense"
+            )
+            result["ready_to_aspirate"] = instr.ready_to_aspirate
+            result["default_blow_out_speeds"] = {
+                alvl: self.plunger_speed(instr, fr, "dispense")
+                for alvl, fr in instr.config.default_aspirate_flow_rates.items()
+            }
+            result["default_dispense_speeds"] = {
+                alvl: self.plunger_speed(instr, fr, "dispense")
+                for alvl, fr in instr.config.default_dispense_flow_rates.items()
+            }
+            result["default_aspirate_speeds"] = {
+                alvl: self.plunger_speed(instr, fr, "aspirate")
+                for alvl, fr in instr.config.default_aspirate_flow_rates.items()
+            }
+        return cast(PipetteDict, result)
+
+    @property
+    def attached_instruments(self) -> Dict[top_types.Mount, PipetteDict]:
+        return self.get_attached_instruments()
+
+    @property
+    def hardware_instruments(self) -> InstrumentsByMount:
+        """Do not write new code that uses this."""
+        return self._attached_instruments
+
+    def set_current_tiprack_diameter(
+        self, mount: Union[top_types.Mount, PipettePair], tiprack_diameter: float
+    ):
+        instruments = self.instruments_for(mount)
+        for instr in instruments:
+            assert instr[0]
+            self._ihp_log.info(
+                "Updating tip rack diameter on pipette mount: "
+                f"{instr[1]}, tip diameter: {tiprack_diameter} mm"
+            )
+            instr[0].current_tiprack_diameter = tiprack_diameter
+
+    def set_working_volume(
+        self, mount: Union[top_types.Mount, PipettePair], tip_volume: int
+    ):
+        instruments = self.instruments_for(mount)
+        for instr in instruments:
+            assert instr[0]
+            self._ihp_log.info(
+                "Updating working volume on pipette mount:"
+                f"{instr[1]}, tip volume: {tip_volume} ul"
+            )
+            instr[0].working_volume = tip_volume
+
+        # Pipette config api
+
+    def calibrate_plunger(
+        self,
+        mount: top_types.Mount,
+        top: Optional[float] = None,
+        bottom: Optional[float] = None,
+        blow_out: Optional[float] = None,
+        drop_tip: Optional[float] = None,
+    ):
+        """
+        Set calibration values for the pipette plunger.
+        This can be called multiple times as the user sets each value,
+        or you can set them all at once.
+        :param top: Touching but not engaging the plunger.
+        :param bottom: Must be above the pipette's physical hard-stop, while
+        still leaving enough room for 'blow_out'
+        :param blow_out: Plunger is pushed down enough to expel all liquids.
+        :param drop_tip: Position that causes the tip to be released from the
+        pipette
+        """
+        instr = self._attached_instruments[mount]
+        if not instr:
+            raise top_types.PipetteNotAttachedError(
+                "No pipette attached to {} mount".format(mount.name)
+            )
+
+        pos_dict: Dict = {
+            "top": instr.config.top,
+            "bottom": instr.config.bottom,
+            "blow_out": instr.config.blow_out,
+            "drop_tip": instr.config.drop_tip,
+        }
+        if top is not None:
+            pos_dict["top"] = top
+        if bottom is not None:
+            pos_dict["bottom"] = bottom
+        if blow_out is not None:
+            pos_dict["blow_out"] = blow_out
+        if bottom is not None:
+            pos_dict["drop_tip"] = drop_tip
+        for key in pos_dict.keys():
+            instr.update_config_item(key, pos_dict[key])
+
+    def set_flow_rate(self, mount, aspirate=None, dispense=None, blow_out=None):
+        this_pipette = self._attached_instruments[mount]
+        if not this_pipette:
+            raise top_types.PipetteNotAttachedError(
+                "No pipette attached to {} mount".format(mount)
+            )
+        if aspirate:
+            this_pipette.aspirate_flow_rate = aspirate
+        if dispense:
+            this_pipette.dispense_flow_rate = dispense
+        if blow_out:
+            this_pipette.blow_out_flow_rate = blow_out
+
+    def set_pipette_speed(self, mount, aspirate=None, dispense=None, blow_out=None):
+        this_pipette = self._attached_instruments[mount]
+        if not this_pipette:
+            raise top_types.PipetteNotAttachedError(
+                "No pipette attached to {} mount".format(mount)
+            )
+        if aspirate:
+            this_pipette.aspirate_flow_rate = self.plunger_flowrate(
+                this_pipette, aspirate, "aspirate"
+            )
+        if dispense:
+            this_pipette.dispense_flow_rate = self.plunger_flowrate(
+                this_pipette, dispense, "dispense"
+            )
+        if blow_out:
+            this_pipette.blow_out_flow_rate = self.plunger_flowrate(
+                this_pipette, blow_out, "dispense"
+            )
+
+    def instrument_max_height(
+        self,
+        mount: top_types.Mount,
+        retract_distance: float,
+        critical_point: Optional[CriticalPoint],
+    ) -> float:
+        """Return max achievable height of the attached instrument
+        based on the current critical point
+        """
+        pip = self._attached_instruments[mount]
+        assert pip
+        cp = self.critical_point_for(mount, critical_point)
+
+        max_height = pip.config.home_position - retract_distance + cp.z
+
+        return max_height
+
+    async def reset(self) -> None:
+        self._attached_instruments = {
+            k: None for k in self._attached_instruments.keys()
+        }
+
+    async def add_tip(self, mount: top_types.Mount, tip_length: float):
+        instr = self._attached_instruments[mount]
+        attached = self.attached_instruments
+        instr_dict = attached[mount]
+        if instr and not instr.has_tip:
+            instr.add_tip(tip_length=tip_length)
+            # TODO (spp, 2021-08-27): These items are being updated in a local copy
+            #  of the PipetteDict, which gets thrown away. Fix this.
+            instr_dict["has_tip"] = True
+            instr_dict["tip_length"] = tip_length
+        else:
+            self._ihp_log.warning("attach tip called while tip already attached")
+
+    async def remove_tip(self, mount: top_types.Mount):
+        instr = self._attached_instruments[mount]
+        attached = self.attached_instruments
+        instr_dict = attached[mount]
+        if instr and instr.has_tip:
+            instr.remove_tip()
+            # TODO (spp, 2021-08-27): These items are being updated in a local copy
+            #  of the PipetteDict, which gets thrown away. Fix this.
+            instr_dict["has_tip"] = False
+            instr_dict["tip_length"] = 0.0
+        else:
+            self._ihp_log.warning("detach tip called with no tip")
+
+    def critical_point_for(
+        self, mount: top_types.Mount, cp_override: CriticalPoint = None
+    ) -> top_types.Point:
+        """Return the current critical point of the specified mount.
+
+        The mount's critical point is the position of the mount itself, if no
+        pipette is attached, or the pipette's critical point (which depends on
+        tip status).
+
+        If `cp_override` is specified, and that critical point actually exists,
+        it will be used instead. Invalid `cp_override`s are ignored.
+        """
+        pip = self._attached_instruments[mount]
+        if pip is not None and cp_override != CriticalPoint.MOUNT:
+            return pip.critical_point(cp_override)
+        else:
+            # This offset is required because the motor driver coordinate system is
+            # configured such that the end of a p300 single gen1's tip is 0.
+            return top_types.Point(0, 0, 30)
+
+    @overload
+    def instruments_for(self, mount: top_types.Mount) -> Tuple[PipetteHandlingData]:
+        ...
+
+    @overload
+    def instruments_for(
+        self, mount: PipettePair
+    ) -> Tuple[PipetteHandlingData, PipetteHandlingData]:
+        ...
+
+    def instruments_for(self, mount):
+        if isinstance(mount, PipettePair):
+            primary_mount = mount.primary
+            secondary_mount = mount.secondary
+            instr1 = self._attached_instruments[primary_mount]
+            instr2 = self._attached_instruments[secondary_mount]
+            return ((instr1, primary_mount), (instr2, secondary_mount))
+        else:
+            primary_mount = mount
+            instr1 = self._attached_instruments[primary_mount]
+            return ((instr1, primary_mount),)
+
+    def ready_for_pick_up_tip(self, targets: Sequence[PipetteHandlingData]):
+        for pipettes in targets:
+            if not pipettes[0]:
+                raise top_types.PipetteNotAttachedError(
+                    f"No pipette attached to {pipettes[1].name} mount"
+                )
+            if pipettes[0].has_tip:
+                raise TipAttachedError("Cannot pick up tip with a tip attached")
+            self._ihp_log.debug(f"Picking up tip on {pipettes[0].name}")
+
+    def ready_for_tip_action(
+        self, targets: Sequence[PipetteHandlingData], action: HardwareAction
+    ):
+        for pipettes in targets:
+            if not pipettes[0]:
+                raise top_types.PipetteNotAttachedError(
+                    f"No pipette attached to {pipettes[1].name} mount"
+                )
+            if not pipettes[0].has_tip:
+                raise NoTipAttachedError(
+                    f"Cannot perform {action} without a tip attached"
+                )
+            if (
+                action == HardwareAction.ASPIRATE
+                and pipettes[0].current_volume == 0
+                and not pipettes[0].ready_to_aspirate
+            ):
+                raise RuntimeError("Pipette not ready to aspirate")
+            self._ihp_log.debug(f"{action} on {pipettes[0].name}")
+
+    @overload
+    def mounts(self, z_axis: PipettePair) -> Tuple[top_types.Mount, top_types.Mount]:
+        ...
+
+    @overload
+    def mounts(self, z_axis: top_types.Mount) -> Tuple[top_types.Mount]:
+        ...
+
+    def mounts(self, z_axis):
+        if isinstance(z_axis, PipettePair):
+            return (z_axis.primary, z_axis.secondary)
+        return (z_axis,)
+
+    def plunger_position(
+        self, instr: Pipette, ul: float, action: "UlPerMmAction"
+    ) -> float:
+        mm = ul / instr.ul_per_mm(ul, action)
+        position = mm + instr.config.bottom
+        return round(position, 6)
+
+    def plunger_speed(
+        self, instr: Pipette, ul_per_s: float, action: "UlPerMmAction"
+    ) -> float:
+        mm_per_s = ul_per_s / instr.ul_per_mm(instr.config.max_volume, action)
+        return round(mm_per_s, 6)
+
+    def plunger_flowrate(
+        self, instr: Pipette, mm_per_s: float, action: "UlPerMmAction"
+    ) -> float:
+        ul_per_s = mm_per_s * instr.ul_per_mm(instr.config.max_volume, action)
+        return round(ul_per_s, 6)

--- a/api/src/opentrons/hardware_control/instrument_handler.py
+++ b/api/src/opentrons/hardware_control/instrument_handler.py
@@ -35,7 +35,7 @@ class InstrumentHandlerProvider:
         }
         self._ihp_log = InstrumentHandlerProvider.IHP_LOG.getChild(str(id(self)))
 
-    def reset_instrument(self, mount: top_types.Mount = None):
+    def reset_instrument(self, mount: Optional[top_types.Mount] = None):
         """
         Reset the internal state of a pipette by its mount, without doing
         any lower level reconfiguration. This is useful to make sure that no

--- a/api/src/opentrons/hardware_control/instrument_handler.py
+++ b/api/src/opentrons/hardware_control/instrument_handler.py
@@ -370,19 +370,6 @@ class InstrumentHandlerProvider:
                 raise RuntimeError("Pipette not ready to aspirate")
             self._ihp_log.debug(f"{action} on {pipettes[0].name}")
 
-    @overload
-    def mounts(self, z_axis: PipettePair) -> Tuple[top_types.Mount, top_types.Mount]:
-        ...
-
-    @overload
-    def mounts(self, z_axis: top_types.Mount) -> Tuple[top_types.Mount]:
-        ...
-
-    def mounts(self, z_axis):
-        if isinstance(z_axis, PipettePair):
-            return (z_axis.primary, z_axis.secondary)
-        return (z_axis,)
-
     def plunger_position(
         self, instr: Pipette, ul: float, action: "UlPerMmAction"
     ) -> float:

--- a/api/src/opentrons/hardware_control/motion_utilities.py
+++ b/api/src/opentrons/hardware_control/motion_utilities.py
@@ -1,0 +1,123 @@
+"""Utilities for calculating motion correctly."""
+
+from typing import Callable, Dict, Optional, Tuple, Union, Iterator, Sequence
+from collections import OrderedDict
+from opentrons.types import Mount, Point
+from .types import PipettePair, Axis
+
+
+def mounts(z_axis: Union[PipettePair, Mount]) -> Tuple[Mount, Optional[Mount]]:
+    if isinstance(z_axis, PipettePair):
+        return (z_axis.primary, z_axis.secondary)
+    else:
+        return (z_axis, None)
+
+
+def mounts_enumerable(z_axis: Union[PipettePair, Mount]) -> Iterator[Mount]:
+    mount_or_pair = mounts(z_axis)
+    for mount in mount_or_pair:
+        if mount:
+            yield mount
+
+
+def target_position_from_absolute(
+    mount: Union[Mount, PipettePair],
+    abs_position: Point,
+    get_critical_point: Callable[[Mount], Point],
+    left_mount_offset: Point,
+) -> "Tuple[OrderedDict[Axis, float], Mount, Optional[Axis]]":
+    primary_mount, secondary_mount = mounts(mount)
+
+    def offsets(primary: Mount, mount_offset: Point) -> Tuple[Point, Point]:
+        if primary == Mount.LEFT:
+            return (mount_offset, Point(0, 0, 0))
+        else:
+            return (Point(0, 0, 0), mount_offset)
+
+    primary_offset, secondary_offset = offsets(primary_mount, left_mount_offset)
+    primary_cp = get_critical_point(primary_mount)
+    primary_z = Axis.by_mount(primary_mount)
+    target_position = OrderedDict(
+        (
+            (Axis.X, abs_position.x - primary_offset.x - primary_cp.x),
+            (Axis.Y, abs_position.y - primary_offset.y - primary_cp.y),
+            (primary_z, abs_position.z - primary_offset.z - primary_cp.z),
+        )
+    )
+
+    if secondary_mount:
+        other_z = Axis.by_mount(secondary_mount)
+        secondary_cp = get_critical_point(secondary_mount)
+        target_position[other_z] = abs_position.z - secondary_offset.z - secondary_cp.z
+        secondary_z: Optional[Axis] = other_z
+    else:
+        secondary_z = None
+    return target_position, primary_mount, secondary_z
+
+
+def target_position_from_relative(
+    mount: Union[Mount, PipettePair],
+    delta: Union[Point, Sequence[float]],
+    current_position: Dict[Axis, float],
+) -> "Tuple[OrderedDict[Axis, float], Mount, Optional[Axis]]":
+    """Create a target position for all specified machine axes.
+
+    If mount is a pair, then delta can be either a Point or a length
+    3 or 4 sequence. If a 4-sequence, the last two elements are mapped
+    to (primary, secondary) in the pair. If a 3-sequence or Point,
+    the last element is used for both z positions.
+    """
+    assert len(delta) < 5
+    primary_mount, secondary_mount = mounts(mount)
+
+    primary_z = Axis.by_mount(primary_mount)
+    target_position = OrderedDict(
+        (
+            (Axis.X, current_position[Axis.X] + delta[0]),
+            (Axis.Y, current_position[Axis.Y] + delta[1]),
+            (primary_z, current_position[primary_z] + delta[2]),
+        )
+    )
+
+    if secondary_mount:
+        other_z = Axis.by_mount(secondary_mount)
+        secondary_z: Optional[Axis] = other_z
+        target_position[other_z] = current_position[other_z] + delta[-1]
+    else:
+        secondary_z = None
+
+    return target_position, primary_mount, secondary_z
+
+
+def target_position_from_plunger(
+    mount: Union[Mount, PipettePair],
+    delta: Sequence[float],
+    current_position: Dict[Axis, float],
+) -> "Tuple[OrderedDict[Axis, float], Mount, Optional[Axis]]":
+    """Create a target position for machine axes including plungers.
+
+    If mount is a pair, then delta can be a 1- or 2-sequence. If mount
+    If a 2-sequence, then the two plungers go to different positions.
+    If a 1-sequence, both plungers go to the same position.
+
+    Axis positions other than the plunger are identical to current
+    position.
+    """
+    assert len(delta) < 3
+    all_axes_pos = OrderedDict(
+        (
+            (Axis.X, current_position[Axis.X]),
+            (Axis.Y, current_position[Axis.Y]),
+        )
+    )
+    plunger_pos = OrderedDict()
+    secondary_z = None
+    for idx, m in enumerate(mounts_enumerable(mount)):
+        z = Axis.by_mount(m)
+        plunger = Axis.of_plunger(m)
+        all_axes_pos[z] = current_position[z]
+        plunger_pos[plunger] = delta[idx]
+        if idx == 1:
+            secondary_z = z
+    all_axes_pos.update(plunger_pos)
+    return all_axes_pos, mounts(mount)[0], secondary_z

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -256,7 +256,9 @@ class OT3API(
 
     # Incidentals (i.e. not motion) API
 
-    async def set_lights(self, button: bool = None, rails: bool = None):
+    async def set_lights(
+        self, button: Optional[bool] = None, rails: Optional[bool] = None
+    ) -> None:
         """Control the robot lights."""
         self._backend.set_lights(button, rails)
 
@@ -305,8 +307,8 @@ class OT3API(
         )
 
     async def cache_instruments(
-        self, require: Dict[top_types.Mount, PipetteName] = None
-    ):
+        self, require: Optional[Dict[top_types.Mount, PipetteName]] = None
+    ) -> None:
         """
         Scan the attached instruments, take necessary configuration actions,
         and set up hardware controller internal state if necessary.

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -4,16 +4,12 @@ from dataclasses import replace
 import logging
 from collections import OrderedDict
 from typing import (
-    Any,
     Callable,
     Dict,
     Union,
     List,
     Optional,
     Tuple,
-    TYPE_CHECKING,
-    cast,
-    overload,
     Sequence,
     Set,
 )
@@ -56,10 +52,9 @@ from .types import (
 from . import modules
 from .robot_calibration import RobotCalibrationProvider, load_pipette_offset
 from .protocols import HardwareControlAPI
+from .instrument_handler import InstrumentHandlerProvider
 
-if TYPE_CHECKING:
-    from opentrons_shared_data.pipette.dev_types import UlPerMmAction, PipetteName
-    from .dev_types import PipetteDict
+from opentrons_shared_data.pipette.dev_types import UlPerMmAction, PipetteName
 
 
 mod_log = logging.getLogger(__name__)
@@ -69,7 +64,9 @@ InstrumentsByMount = Dict[top_types.Mount, Optional[Pipette]]
 PipetteHandlingData = Tuple[Pipette, top_types.Mount]
 
 
-class OT3API(ExecutionManagerProvider, RobotCalibrationProvider):
+class OT3API(
+    ExecutionManagerProvider, RobotCalibrationProvider, InstrumentHandlerProvider
+):
     """This API is the primary interface to the hardware controller.
 
     Because the hardware manager controls access to the system's hardware
@@ -103,10 +100,6 @@ class OT3API(ExecutionManagerProvider, RobotCalibrationProvider):
         # {'X': 0.0, 'Y': 0.0, 'Z': 0.0, 'A': 0.0, 'B': 0.0, 'C': 0.0}
         self._current_position: Dict[Axis, float] = {}
 
-        self._attached_instruments: InstrumentsByMount = {
-            top_types.Mount.LEFT: None,
-            top_types.Mount.RIGHT: None,
-        }
         self._last_moved_mount: Optional[top_types.Mount] = None
         # The motion lock synchronizes calls to long-running physical tasks
         # involved in motion. This fixes issue where for instance a move()
@@ -117,8 +110,9 @@ class OT3API(ExecutionManagerProvider, RobotCalibrationProvider):
         self._door_state = DoorState.CLOSED
         self._pause_manager = PauseManager(self._door_state)
         ExecutionManagerProvider.__init__(self, loop, isinstance(backend, Simulator))
-        OT3API._check_type(self)
         RobotCalibrationProvider.__init__(self)
+        InstrumentHandlerProvider.__init__(self)
+        OT3API._check_type(self)
 
     @staticmethod
     def _check_type(inst: HardwareControlAPI) -> None:
@@ -297,35 +291,36 @@ class OT3API(ExecutionManagerProvider, RobotCalibrationProvider):
         finally:
             self.resume(PauseType.DELAY)
 
-    def reset_instrument(self, mount: top_types.Mount = None):
+    @property
+    def attached_modules(self) -> List[modules.AbstractModule]:
+        return self._backend.module_controls.available_modules
+
+    async def update_firmware(
+        self,
+        firmware_file: str,
+        loop: asyncio.AbstractEventLoop = None,
+        explicit_modeset: bool = True,
+    ) -> str:
+        """Update the firmware on the Smoothie board.
+
+        :param firmware_file: The path to the firmware file.
+        :param explicit_modeset: `True` to force the smoothie into programming
+                                 mode; `False` to assume it is already in
+                                 programming mode.
+        :param loop: An asyncio event loop to use; if not specified, the one
+                     associated with this instance will be used.
+        :returns: The stdout of the tool used to update the smoothie
         """
-        Reset the internal state of a pipette by its mount, without doing
-        any lower level reconfiguration. This is useful to make sure that no
-        settings changes from a protocol persist.
-
-        :param mount: If specified, reset that mount. If not specified,
-                      reset both
-        """
-
-        def _reset(m: top_types.Mount):
-            self._log.info(f"Resetting configuration for {m}")
-            p = self._attached_instruments[m]
-            if not p:
-                return
-            new_p = Pipette(
-                p._config, load_pipette_offset(p.pipette_id, m), p.pipette_id
-            )
-            new_p.act_as(p.acting_as)
-            self._attached_instruments[m] = new_p
-
-        if not mount:
-            for m in top_types.Mount:
-                _reset(m)
+        if None is loop:
+            checked_loop = self._loop
         else:
-            _reset(mount)
+            checked_loop = loop
+        return await self._backend.update_firmware(
+            firmware_file, checked_loop, explicit_modeset
+        )
 
     async def cache_instruments(
-        self, require: Dict[top_types.Mount, "PipetteName"] = None
+        self, require: Dict[top_types.Mount, PipetteName] = None
     ):
         """
         Scan the attached instruments, take necessary configuration actions,
@@ -383,122 +378,7 @@ class OT3API(ExecutionManagerProvider, RobotCalibrationProvider):
                 p, self._config, self._backend.board_revision
             )
             await self._backend.configure_mount(mount, hw_config)
-        mod_log.info("Instruments found: {}".format(self._attached_instruments))
-
-    def get_attached_instruments(self) -> Dict[top_types.Mount, "PipetteDict"]:
-        """Get the status dicts of the cached attached instruments.
-
-        Also available as :py:meth:`get_attached_instruments`.
-
-        This returns a dictified version of the
-        :py:class:`hardware_control.pipette.Pipette` as a dict keyed by
-        the :py:class:`top_types.Mount` to which the pipette is attached.
-        If no pipette is attached on a given mount, the mount key will
-        still be present but will have the value ``None``.
-
-        Note that this is only a query of a cached value; to actively scan
-        for changes, use :py:meth:`cache_instruments`. This process deactivates
-        the motors and should be used sparingly.
-        """
-        return {
-            m: self.get_attached_instrument(m)
-            for m in (top_types.Mount.LEFT, top_types.Mount.RIGHT)
-        }
-
-    def get_attached_instrument(self, mount: top_types.Mount) -> "PipetteDict":
-        instr = self._attached_instruments[mount]
-        result: Dict[str, Any] = {}
-        if instr:
-            configs = [
-                "name",
-                "min_volume",
-                "max_volume",
-                "channels",
-                "aspirate_flow_rate",
-                "dispense_flow_rate",
-                "pipette_id",
-                "current_volume",
-                "display_name",
-                "tip_length",
-                "model",
-                "blow_out_flow_rate",
-                "working_volume",
-                "tip_overlap",
-                "available_volume",
-                "return_tip_height",
-                "default_aspirate_flow_rates",
-                "default_blow_out_flow_rates",
-                "default_dispense_flow_rates",
-                "back_compat_names",
-            ]
-
-            instr_dict = instr.as_dict()
-            # TODO (spp, 2021-08-27): Revisit this logic. Why do we need to build
-            #  this dict newly every time? Any why only a few items are being updated?
-            for key in configs:
-                result[key] = instr_dict[key]
-            result["has_tip"] = instr.has_tip
-            result["tip_length"] = instr.current_tip_length
-            result["aspirate_speed"] = self._plunger_speed(
-                instr, instr.aspirate_flow_rate, "aspirate"
-            )
-            result["dispense_speed"] = self._plunger_speed(
-                instr, instr.dispense_flow_rate, "dispense"
-            )
-            result["blow_out_speed"] = self._plunger_speed(
-                instr, instr.blow_out_flow_rate, "dispense"
-            )
-            result["ready_to_aspirate"] = instr.ready_to_aspirate
-            result["default_blow_out_speeds"] = {
-                alvl: self._plunger_speed(instr, fr, "dispense")
-                for alvl, fr in instr.config.default_aspirate_flow_rates.items()
-            }
-            result["default_dispense_speeds"] = {
-                alvl: self._plunger_speed(instr, fr, "dispense")
-                for alvl, fr in instr.config.default_dispense_flow_rates.items()
-            }
-            result["default_aspirate_speeds"] = {
-                alvl: self._plunger_speed(instr, fr, "aspirate")
-                for alvl, fr in instr.config.default_aspirate_flow_rates.items()
-            }
-        return cast("PipetteDict", result)
-
-    @property
-    def attached_instruments(self) -> Dict[top_types.Mount, "PipetteDict"]:
-        return self.get_attached_instruments()
-
-    @property
-    def hardware_instruments(self) -> InstrumentsByMount:
-        """Do not write new code that uses this."""
-        return self._attached_instruments
-
-    @property
-    def attached_modules(self) -> List[modules.AbstractModule]:
-        return self._backend.module_controls.available_modules
-
-    async def update_firmware(
-        self,
-        firmware_file: str,
-        loop: asyncio.AbstractEventLoop = None,
-        explicit_modeset: bool = True,
-    ) -> str:
-        """Update the firmware on the Smoothie board.
-
-        :param firmware_file: The path to the firmware file.
-        :param explicit_modeset: `True` to force the smoothie into programming
-                                 mode; `False` to assume it is already in
-                                 programming mode.
-        :param loop: An asyncio event loop to use; if not specified, the one
-                     associated with this instance will be used.
-        :returns: The stdout of the tool used to update the smoothie
-        """
-        if None is loop:
-            checked_loop = self._loop
-        else:
-            checked_loop = loop
-        return await self._backend.update_firmware(
-            firmware_file, checked_loop, explicit_modeset
-        )
+        self._log.info("Instruments found: {}".format(self._attached_instruments))
 
     # Global actions API
     def pause(self, pause_type: PauseType):
@@ -586,9 +466,7 @@ class OT3API(ExecutionManagerProvider, RobotCalibrationProvider):
         """
         self._pause_manager.reset()
         await self._execution_manager.reset()
-        self._attached_instruments = {
-            k: None for k in self._attached_instruments.keys()
-        }
+        await InstrumentHandlerProvider.reset(self)
         await self.cache_instruments()
 
     # Gantry/frame (i.e. not pipette) action API
@@ -663,32 +541,6 @@ class OT3API(ExecutionManagerProvider, RobotCalibrationProvider):
                 self._current_position = self._deck_from_smoothie(smoothie_pos)
             for plunger in plungers:
                 await self._do_plunger_home(axis=plunger, acquire_lock=False)
-
-    async def add_tip(self, mount: top_types.Mount, tip_length: float):
-        instr = self._attached_instruments[mount]
-        attached = self.attached_instruments
-        instr_dict = attached[mount]
-        if instr and not instr.has_tip:
-            instr.add_tip(tip_length=tip_length)
-            # TODO (spp, 2021-08-27): These items are being updated in a local copy
-            #  of the PipetteDict, which gets thrown away. Fix this.
-            instr_dict["has_tip"] = True
-            instr_dict["tip_length"] = tip_length
-        else:
-            mod_log.warning("attach tip called while tip already attached")
-
-    async def remove_tip(self, mount: top_types.Mount):
-        instr = self._attached_instruments[mount]
-        attached = self.attached_instruments
-        instr_dict = attached[mount]
-        if instr and instr.has_tip:
-            instr.remove_tip()
-            # TODO (spp, 2021-08-27): These items are being updated in a local copy
-            #  of the PipetteDict, which gets thrown away. Fix this.
-            instr_dict["has_tip"] = False
-            instr_dict["tip_length"] = 0.0
-        else:
-            mod_log.warning("detach tip called with no tip")
 
     def _deck_from_smoothie(self, smoothie_pos: Dict[str, float]) -> Dict[Axis, float]:
         """Build a deck-abs position store from the smoothie's position
@@ -785,7 +637,7 @@ class OT3API(ExecutionManagerProvider, RobotCalibrationProvider):
             else:
                 offset = top_types.Point(*self._config.left_mount_offset)
 
-            cp = self._critical_point_for(mount, critical_point)
+            cp = self.critical_point_for(mount, critical_point)
             return {
                 Axis.X: self._current_position[Axis.X] + offset[0] + cp.x,
                 Axis.Y: self._current_position[Axis.Y] + offset[1] + cp.y,
@@ -825,19 +677,6 @@ class OT3API(ExecutionManagerProvider, RobotCalibrationProvider):
         return top_types.Point(
             x=cur_pos[Axis.X], y=cur_pos[Axis.Y], z=cur_pos[Axis.by_mount(mount)]
         )
-
-    @overload
-    def _mounts(self, z_axis: PipettePair) -> Tuple[top_types.Mount, top_types.Mount]:
-        ...
-
-    @overload
-    def _mounts(self, z_axis: top_types.Mount) -> Tuple[top_types.Mount]:
-        ...
-
-    def _mounts(self, z_axis):
-        if isinstance(z_axis, PipettePair):
-            return (z_axis.primary, z_axis.secondary)
-        return (z_axis,)
 
     async def move_to(
         self,
@@ -887,7 +726,7 @@ class OT3API(ExecutionManagerProvider, RobotCalibrationProvider):
         if not self._current_position:
             await self.home()
 
-        mounts = self._mounts(mount)
+        mounts = self.mounts(mount)
         primary_mount = mounts[0]
         secondary_mount = None
         # Even with overloads, mypy cannot accept a length check on
@@ -907,8 +746,8 @@ class OT3API(ExecutionManagerProvider, RobotCalibrationProvider):
         if secondary_mount:
             primary_z = Axis.by_mount(primary_mount)
             secondary_z = Axis.by_mount(secondary_mount)
-            primary_cp = self._critical_point_for(primary_mount, critical_point)
-            s_cp = self._critical_point_for(secondary_mount, critical_point)
+            primary_cp = self.critical_point_for(primary_mount, critical_point)
+            s_cp = self.critical_point_for(secondary_mount, critical_point)
             target_position = OrderedDict(
                 (
                     (Axis.X, abs_position.x - primary_offset.x - primary_cp.x),
@@ -918,7 +757,7 @@ class OT3API(ExecutionManagerProvider, RobotCalibrationProvider):
                 )
             )
         else:
-            primary_cp = self._critical_point_for(primary_mount, critical_point)
+            primary_cp = self.critical_point_for(primary_mount, critical_point)
             primary_z = Axis.by_mount(primary_mount)
             secondary_z = None
             target_position = OrderedDict(
@@ -955,7 +794,7 @@ class OT3API(ExecutionManagerProvider, RobotCalibrationProvider):
         # TODO: Remove the fail_on_not_homed and make this the behavior all the time.
         # Having the optional arg makes the bug stick around in existing code and we
         # really want to fix it when we're not gearing up for a release.
-        mounts = self._mounts(mount)
+        mounts = self.mounts(mount)
         if fail_on_not_homed:
             axes_moving = [Axis.X, Axis.Y] + [Axis.by_mount(m) for m in mounts]
             if (
@@ -1033,7 +872,7 @@ class OT3API(ExecutionManagerProvider, RobotCalibrationProvider):
             )
         )
         plunger_pos = OrderedDict()
-        mounts = self._mounts(mount)
+        mounts = self.mounts(mount)
         secondary_z = None
         for idx, m in enumerate(mounts):
             z = Axis.by_mount(m)
@@ -1063,7 +902,7 @@ class OT3API(ExecutionManagerProvider, RobotCalibrationProvider):
                 (Axis.Y, self._current_position[Axis.Y] + target[1]),
             )
         )
-        mounts = self._mounts(mount)
+        mounts = self.mounts(mount)
         secondary_z = None
         for (
             idx,
@@ -1218,26 +1057,6 @@ class OT3API(ExecutionManagerProvider, RobotCalibrationProvider):
             smoothie_pos = await self._fast_home(smoothie_ax, margin)
             self._current_position = self._deck_from_smoothie(smoothie_pos)
 
-    def _critical_point_for(
-        self, mount: top_types.Mount, cp_override: CriticalPoint = None
-    ) -> top_types.Point:
-        """Return the current critical point of the specified mount.
-
-        The mount's critical point is the position of the mount itself, if no
-        pipette is attached, or the pipette's critical point (which depends on
-        tip status).
-
-        If `cp_override` is specified, and that critical point actually exists,
-        it will be used instead. Invalid `cp_override`s are ignored.
-        """
-        pip = self._attached_instruments[mount]
-        if pip is not None and cp_override != CriticalPoint.MOUNT:
-            return pip.critical_point(cp_override)
-        else:
-            # This offset is required because the motor driver coordinate system is
-            # configured such that the end of a p300 single gen1's tip is 0.
-            return top_types.Point(0, 0, 30)
-
     # Gantry/frame (i.e. not pipette) config API
     @property
     def config(self) -> RobotConfig:
@@ -1300,12 +1119,12 @@ class OT3API(ExecutionManagerProvider, RobotCalibrationProvider):
         aspiration. To make the problem more obvious, :py:meth:`aspirate` will
         raise an exception if this method has not previously been called.
         """
-        instruments = self._instruments_for(mount)
+        instruments = self.instruments_for(mount)
         self._ready_for_tip_action(instruments, HardwareAction.PREPARE_ASPIRATE)
 
         with_zero = filter(lambda i: i[0].current_volume == 0, instruments)
         for instr in with_zero:
-            speed = self._plunger_speed(
+            speed = self.plunger_speed(
                 instr[0], instr[0].blow_out_flow_rate, "aspirate"
             )
             bottom = (instr[0].config.bottom,)
@@ -1364,13 +1183,11 @@ class OT3API(ExecutionManagerProvider, RobotCalibrationProvider):
             ), "Cannot aspirate more than pipette max volume"
 
         dist = tuple(
-            self._plunger_position(instr[0], instr[0].current_volume + vol, "aspirate")
+            self.plunger_position(instr[0], instr[0].current_volume + vol, "aspirate")
             for instr, vol in zip(instruments, asp_vol)
         )
         speed = min(
-            self._plunger_speed(
-                instr[0], instr[0].aspirate_flow_rate * rate, "aspirate"
-            )
+            self.plunger_speed(instr[0], instr[0].aspirate_flow_rate * rate, "aspirate")
             for instr in instruments
         )
         try:
@@ -1429,13 +1246,11 @@ class OT3API(ExecutionManagerProvider, RobotCalibrationProvider):
             raise PairedPipetteConfigValueError("Cannot only dispense from one pipette")
 
         dist = tuple(
-            self._plunger_position(instr[0], instr[0].current_volume - vol, "dispense")
+            self.plunger_position(instr[0], instr[0].current_volume - vol, "dispense")
             for instr, vol in zip(instruments, disp_vol)
         )
         speed = min(
-            self._plunger_speed(
-                instr[0], instr[0].dispense_flow_rate * rate, "dispense"
-            )
+            self.plunger_speed(instr[0], instr[0].dispense_flow_rate * rate, "dispense")
             for instr in instruments
         )
 
@@ -1450,25 +1265,6 @@ class OT3API(ExecutionManagerProvider, RobotCalibrationProvider):
         else:
             for instr, vol in zip(instruments, disp_vol):
                 instr[0].remove_current_volume(vol)
-
-    def _plunger_position(
-        self, instr: Pipette, ul: float, action: "UlPerMmAction"
-    ) -> float:
-        mm = ul / instr.ul_per_mm(ul, action)
-        position = instr.config.bottom - mm
-        return round(position, 6)
-
-    def _plunger_speed(
-        self, instr: Pipette, ul_per_s: float, action: "UlPerMmAction"
-    ) -> float:
-        mm_per_s = ul_per_s / instr.ul_per_mm(instr.config.max_volume, action)
-        return round(mm_per_s, 6)
-
-    def _plunger_flowrate(
-        self, instr: Pipette, mm_per_s: float, action: "UlPerMmAction"
-    ) -> float:
-        ul_per_s = mm_per_s * instr.ul_per_mm(instr.config.max_volume, action)
-        return round(ul_per_s, 6)
 
     async def blow_out(self, mount: Union[top_types.Mount, PipettePair]):
         """
@@ -1485,7 +1281,7 @@ class OT3API(ExecutionManagerProvider, RobotCalibrationProvider):
 
         self._backend.set_active_current(plunger_currents)
         speed = max(
-            self._plunger_speed(instr[0], instr[0].blow_out_flow_rate, "dispense")
+            self.plunger_speed(instr[0], instr[0].blow_out_flow_rate, "dispense")
             for instr in instruments
         )
         try:
@@ -1497,28 +1293,6 @@ class OT3API(ExecutionManagerProvider, RobotCalibrationProvider):
             for instr in instruments:
                 instr[0].set_current_volume(0)
                 instr[0].ready_to_aspirate = False
-
-    @overload
-    def _instruments_for(self, mount: top_types.Mount) -> Tuple[PipetteHandlingData]:
-        ...
-
-    @overload
-    def _instruments_for(
-        self, mount: PipettePair
-    ) -> Tuple[PipetteHandlingData, PipetteHandlingData]:
-        ...
-
-    def _instruments_for(self, mount):
-        if isinstance(mount, PipettePair):
-            primary_mount = mount.primary
-            secondary_mount = mount.secondary
-            instr1 = self._attached_instruments[primary_mount]
-            instr2 = self._attached_instruments[secondary_mount]
-            return ((instr1, primary_mount), (instr2, secondary_mount))
-        else:
-            primary_mount = mount
-            instr1 = self._attached_instruments[primary_mount]
-            return ((instr1, primary_mount),)
 
     def _ready_for_pick_up_tip(self, targets: Sequence[PipetteHandlingData]):
         for pipettes in targets:
@@ -1573,7 +1347,7 @@ class OT3API(ExecutionManagerProvider, RobotCalibrationProvider):
         If ``presses`` or ``increment`` is not specified (or is ``None``),
         their value is taken from the pipette configuration.
         """
-        instruments = self._instruments_for(mount)
+        instruments = self.instruments_for(mount)
         self._ready_for_pick_up_tip(instruments)
         plunger_currents = {
             Axis.of_plunger(instr[1]): instr[0].config.plunger_current
@@ -1648,7 +1422,7 @@ class OT3API(ExecutionManagerProvider, RobotCalibrationProvider):
     def set_current_tiprack_diameter(
         self, mount: Union[top_types.Mount, PipettePair], tiprack_diameter: float
     ):
-        instruments = self._instruments_for(mount)
+        instruments = self.instruments_for(mount)
         for instr in instruments:
             assert instr[0]
             self._log.info(
@@ -1660,7 +1434,7 @@ class OT3API(ExecutionManagerProvider, RobotCalibrationProvider):
     def set_working_volume(
         self, mount: Union[top_types.Mount, PipettePair], tip_volume: int
     ):
-        instruments = self._instruments_for(mount)
+        instruments = self.instruments_for(mount)
         for instr in instruments:
             assert instr[0]
             self._log.info(
@@ -1682,7 +1456,7 @@ class OT3API(ExecutionManagerProvider, RobotCalibrationProvider):
                                 the ejector shroud after a drop.
         """
 
-        instruments = self._instruments_for(mount)
+        instruments = self.instruments_for(mount)
         self._ready_for_tip_action(instruments, HardwareAction.DROPTIP)
         plunger_currents = {
             Axis.of_plunger(instr[1]): instr[0].config.plunger_current
@@ -1780,98 +1554,20 @@ class OT3API(ExecutionManagerProvider, RobotCalibrationProvider):
         )
         return modules_result
 
-    # Pipette config api
-    def calibrate_plunger(
-        self,
-        mount: top_types.Mount,
-        top: Optional[float] = None,
-        bottom: Optional[float] = None,
-        blow_out: Optional[float] = None,
-        drop_tip: Optional[float] = None,
-    ):
-        """
-        Set calibration values for the pipette plunger.
-        This can be called multiple times as the user sets each value,
-        or you can set them all at once.
-        :param top: Touching but not engaging the plunger.
-        :param bottom: Must be above the pipette's physical hard-stop, while
-        still leaving enough room for 'blow_out'
-        :param blow_out: Plunger is pushed down enough to expel all liquids.
-        :param drop_tip: Position that causes the tip to be released from the
-        pipette
-        """
-        instr = self._attached_instruments[mount]
-        if not instr:
-            raise top_types.PipetteNotAttachedError(
-                "No pipette attached to {} mount".format(mount.name)
-            )
+    def clean_up(self) -> None:
+        """Get the API ready to stop cleanly."""
+        self._backend.clean_up()
 
-        pos_dict: Dict = {
-            "top": instr.config.top,
-            "bottom": instr.config.bottom,
-            "blow_out": instr.config.blow_out,
-            "drop_tip": instr.config.drop_tip,
-        }
-        if top is not None:
-            pos_dict["top"] = top
-        if bottom is not None:
-            pos_dict["bottom"] = bottom
-        if blow_out is not None:
-            pos_dict["blow_out"] = blow_out
-        if bottom is not None:
-            pos_dict["drop_tip"] = drop_tip
-        for key in pos_dict.keys():
-            instr.update_config_item(key, pos_dict[key])
-
-    def set_flow_rate(self, mount, aspirate=None, dispense=None, blow_out=None):
-        this_pipette = self._attached_instruments[mount]
-        if not this_pipette:
-            raise top_types.PipetteNotAttachedError(
-                "No pipette attached to {} mount".format(mount)
-            )
-        if aspirate:
-            this_pipette.aspirate_flow_rate = aspirate
-        if dispense:
-            this_pipette.dispense_flow_rate = dispense
-        if blow_out:
-            this_pipette.blow_out_flow_rate = blow_out
-
-    def set_pipette_speed(self, mount, aspirate=None, dispense=None, blow_out=None):
-        this_pipette = self._attached_instruments[mount]
-        if not this_pipette:
-            raise top_types.PipetteNotAttachedError(
-                "No pipette attached to {} mount".format(mount)
-            )
-        if aspirate:
-            this_pipette.aspirate_flow_rate = self._plunger_flowrate(
-                this_pipette, aspirate, "aspirate"
-            )
-        if dispense:
-            this_pipette.dispense_flow_rate = self._plunger_flowrate(
-                this_pipette, dispense, "dispense"
-            )
-        if blow_out:
-            this_pipette.blow_out_flow_rate = self._plunger_flowrate(
-                this_pipette, blow_out, "dispense"
-            )
+    def plunger_position(
+        self, instr: Pipette, ul: float, action: "UlPerMmAction"
+    ) -> float:
+        mm = ul / instr.ul_per_mm(ul, action)
+        position = instr.config.bottom - mm
+        return round(position, 6)
 
     def get_instrument_max_height(
         self, mount: top_types.Mount, critical_point: Optional[CriticalPoint] = None
     ) -> float:
-        """Return max achievable height of the attached instrument
-        based on the current critical point
-        """
-        pip = self._attached_instruments[mount]
-        assert pip
-        cp = self._critical_point_for(mount, critical_point)
-
-        max_height = pip.config.home_position - self._config.z_retract_distance + cp.z
-        self._log.debug(
-            f"GIMH[{mount}]: pip {pip} home {pip.config.home_position} "
-            "- zrd {self._config.z_retract_distance} + cp.z {cp.z} = max {max_height}"
+        return InstrumentHandlerProvider.instrument_max_height(
+            self, mount, self._config.z_retract_distance, critical_point
         )
-        return max_height
-
-    def clean_up(self) -> None:
-        """Get the API ready to stop cleanly."""
-        self._backend.clean_up()

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -81,6 +81,11 @@ class OT3API(
     of external access to the hardware. Each method may be minimal - it may
     only delegate the call to another submodule of the hardware manager -
     but its purpose is to be gathered here to provide a single interface.
+
+    This implements the protocols in opentrons.hardware_control.protocols,
+    and longer method docstrings may be found there. Docstrings for the
+    methods in this class only note where their behavior is different or
+    extended from that described in the protocol.
     """
 
     CLS_LOG = mod_log.getChild("OT3API")
@@ -234,9 +239,6 @@ class OT3API(
     def get_fw_version(self) -> str:
         """
         Return the firmware version of the connected hardware.
-
-        The version is a string retrieved directly from the attached hardware
-        (or possibly simulator).
         """
         from_backend = self._backend.fw_version
         if from_backend is None:
@@ -255,29 +257,15 @@ class OT3API(
     # Incidentals (i.e. not motion) API
 
     async def set_lights(self, button: bool = None, rails: bool = None):
-        """Control the robot lights.
-
-        :param button: If specified, turn the button light on (`True`) or
-                       off (`False`). If not specified, do not change the
-                       button light.
-        :param rails: If specified, turn the rail lights on (`True`) or
-                      off (`False`). If not specified, do not change the
-                      rail lights.
-        """
+        """Control the robot lights."""
         self._backend.set_lights(button, rails)
 
     def get_lights(self) -> Dict[str, bool]:
-        """Return the current status of the robot lights.
-
-        :returns: A dict of the lights: `{'button': bool, 'rails': bool}`
-        """
+        """Return the current status of the robot lights."""
         return self._backend.get_lights()
 
     async def identify(self, duration_s: int = 5):
-        """Blink the button light to identify the robot.
-
-        :param int duration_s: The duration to blink for, in seconds.
-        """
+        """Blink the button light to identify the robot."""
         count = duration_s * 4
         on = False
         for sec in range(count):
@@ -307,16 +295,7 @@ class OT3API(
         loop: asyncio.AbstractEventLoop = None,
         explicit_modeset: bool = True,
     ) -> str:
-        """Update the firmware on the Smoothie board.
-
-        :param firmware_file: The path to the firmware file.
-        :param explicit_modeset: `True` to force the smoothie into programming
-                                 mode; `False` to assume it is already in
-                                 programming mode.
-        :param loop: An asyncio event loop to use; if not specified, the one
-                     associated with this instance will be used.
-        :returns: The stdout of the tool used to update the smoothie
-        """
+        """Update the firmware on the hardware."""
         if None is loop:
             checked_loop = self._loop
         else:
@@ -331,25 +310,6 @@ class OT3API(
         """
         Scan the attached instruments, take necessary configuration actions,
         and set up hardware controller internal state if necessary.
-
-        :param require: If specified, the require should be a dict
-                        of mounts to instrument names describing
-                        the instruments expected to be present. This can
-                        save a subsequent of :py:attr:`attached_instruments`
-                        and also serves as the hook for the hardware
-                        simulator to decide what is attached.
-        :raises RuntimeError: If an instrument is expected but not found.
-
-        .. note::
-
-            This function will only change the things that need to be changed.
-            If the same pipette (by serial) or the same lack of pipette is
-            observed on a mount before and after the scan, no action will be
-            taken. That makes this function appropriate for setting up the
-            robot for operation, but not for making sure that any previous
-            settings changes have been reset. For the latter use case, use
-            :py:meth:`reset_instrument`.
-
         """
         self._log.info("Updating instrument model cache")
         checked_require = require or {}
@@ -389,16 +349,7 @@ class OT3API(
     # Global actions API
     def pause(self, pause_type: PauseType):
         """
-        Pause motion of the robot after a current motion concludes.
-
-        Individual calls to :py:meth:`move`
-        (which :py:meth:`aspirate` and :py:meth:`dispense` and other
-        calls may depend on) are considered atomic and will always complete if
-        they have been called prior to a call to this method. However,
-        subsequent calls to :py:meth:`move` that occur when the system
-        is paused will not proceed until the system is resumed with
-        :py:meth:`resume`.
-        """
+        Pause motion of the robot after a current motion concludes."""
         self._pause_manager.pause(pause_type)
 
         async def _chained_calls():
@@ -435,28 +386,12 @@ class OT3API(
         asyncio.run_coroutine_threadsafe(_chained_calls(), self._loop)
 
     async def halt(self) -> None:
-        """Immediately stop motion.
-
-        Calls to :py:meth:`stop` through the synch adapter while other calls
-        are ongoing will typically wait until those calls are done, since most
-        of the async calls here in fact block the loop while they talk to
-        smoothie. To provide actual immediate halting, call this method which
-        does not require use of the loop.
-
-        After this call, the smoothie will be in a bad state until a call to
-        :py:meth:`stop`.
-        """
+        """Immediately stop motion."""
         await self._backend.hard_halt()
         asyncio.run_coroutine_threadsafe(self._execution_manager.cancel(), self._loop)
 
     async def stop(self, home_after: bool = True):
-        """
-        Stop motion as soon as possible, reset, and optionally home.
-
-        This will cancel motion (after the current call to :py:meth:`move`;
-        see :py:meth:`pause` for more detail), then home and reset the
-        robot.
-        """
+        """Stop motion as soon as possible, reset, and optionally home."""
         await self._backend.halt()
         self._log.info("Recovering from halt")
         await self.reset()
@@ -465,11 +400,7 @@ class OT3API(
             await self.home()
 
     async def reset(self):
-        """Reset the stored state of the system.
-
-        This will re-scan instruments and models, clearing any cached
-        information about their presence or state.
-        """
+        """Reset the stored state of the system."""
         self._pause_manager.reset()
         await self._execution_manager.reset()
         await InstrumentHandlerProvider.reset(self)
@@ -526,19 +457,13 @@ class OT3API(
         """
         Home the plunger motor for a mount, and then return it to the 'bottom'
         position.
-
-        :param mount: the mount associated with the target plunger
-        :type mount: :py:class:`.top_types.Mount`
         """
         await self.current_position(mount=mount, refresh=True)
         await self._do_plunger_home(mount=mount, acquire_lock=True)
 
     @ExecutionManagerProvider.wait_for_running
     async def home(self, axes: Optional[List[Axis]] = None):
-        """Home the entire robot and initialize current position.
-        :param axes: A list of axes to home. Default is `None`, which will
-                     home everything.
-        """
+        """Home the entire robot and initialize current position."""
         self._reset_last_mount()
         # Initialize/update current_position
         checked_axes = axes or [ax for ax in Axis]
@@ -555,23 +480,7 @@ class OT3API(
                 await self._do_plunger_home(axis=plunger, acquire_lock=False)
 
     def _deck_from_smoothie(self, smoothie_pos: Dict[str, float]) -> Dict[Axis, float]:
-        """Build a deck-abs position store from the smoothie's position
-
-        This should take the smoothie style position {'X': float, etc}
-        and turn it into the position dict used here {Axis.X: float} in
-        deck-absolute coordinates. It runs the reverse deck transformation
-        for the axes that require it.
-
-        One piece of complexity is that if the gantry transformation includes
-        a transition between non parallel planes, the z position of the left
-        mount would depend on its actual position in deck frame, so we have
-        to apply the mount offset.
-
-        TODO: Figure out which frame the mount offset is measured in, because
-              if it's measured in the deck frame (e.g. by touching off points
-              on the deck) it has to go through the reverse transform to be
-              added to the smoothie coordinates here.
-        """
+        """Build a deck-abs position store from the smoothie's position"""
         with_enum = {Axis[k]: v for k, v in smoothie_pos.items()}
         plunger_axes = {
             k: v for k, v in with_enum.items() if k not in Axis.gantry_axes()
@@ -610,20 +519,6 @@ class OT3API(
     ) -> Dict[Axis, float]:
         """Return the postion (in deck coords) of the critical point of the
         specified mount.
-
-        This returns cached position to avoid hitting the smoothie driver
-        unless ``refresh`` is ``True``.
-
-        If `critical_point` is specified, that critical point will be applied
-        instead of the default one. For instance, if
-        `critical_point=CriticalPoints.MOUNT` then the position of the mount
-        will be returned. If the critical point specified does not exist, then
-        the next one down is returned - for instance, if there is no tip on the
-        specified mount but `CriticalPoint.TIP` was specified, the position of
-        the nozzle will be returned.
-
-        If `fail_on_not_homed` is `True`, this method will raise a `MustHomeError`
-        if any of the relavent axes are not homed, regardless of `refresh`.
         """
         z_ax = Axis.by_mount(mount)
         plunger_ax = Axis.of_plunger(mount)
@@ -666,20 +561,7 @@ class OT3API(
         # position reporting when motors are not homed
         fail_on_not_homed: bool = False,
     ) -> top_types.Point:
-        """Return the position of the critical point as pertains to the gantry
-
-        This ignores the plunger position and gives the Z-axis a predictable
-        name (as :py:attr:`.Point.z`).
-
-        `critical_point` specifies an override to the current critical point to
-        use (see :py:meth:`current_position`).
-
-        `refresh` if set to True, update the cached position using the
-        smoothie driver (see :py:meth:`current_position`).
-
-        If `fail_on_not_homed` is `True`, this method will raise a `MustHomeError`
-        if any of the relavent axes are not homed, regardless of `refresh`.
-        """
+        """Return the position of the critical point as pertains to the gantry."""
         cur_pos = await self.current_position(
             mount,
             critical_point,
@@ -699,42 +581,7 @@ class OT3API(
         max_speeds: Optional[Dict[Axis, float]] = None,
     ):
         """Move the critical point of the specified mount to a location
-        relative to the deck, at the specified speed. 'speed' sets the speed
-        of all robot axes to the given value. So, if multiple axes are to be
-        moved, they will do so at the same speed
-
-        The critical point of the mount depends on the current status of
-        the mount:
-        - If the mount does not have anything attached, its critical point is
-          the bottom of the mount attach bracket.
-        - If the mount has a pipette attached and it is not known to have a
-          pipette tip, the critical point is the end of the nozzle of a single
-          pipette or the end of the backmost nozzle of a multipipette
-        - If the mount has a pipette attached and it is known to have a
-          pipette tip, the critical point is the end of the pipette tip for
-          a single pipette or the end of the tip of the backmost nozzle of a
-          multipipette
-
-        :param mount: The mount to move
-        :param abs_position: The target absolute position in
-                             deck coordinates to move the
-                             critical point to
-        :param speed: An overall head speed to use during the move
-        :param critical_point: The critical point to move. In most situations
-                               this is not needed. If not specified, the
-                               current critical point will be moved. If
-                               specified, the critical point must be one that
-                               actually exists - that is, specifying
-                               :py:attr:`.CriticalPoint.NOZZLE` when no pipette
-                               is attached or :py:attr:`.CriticalPoint.TIP`
-                               when no tip is applied will result in an error.
-        :param max_speeds: An optional override for per-axis maximum speeds. If
-                           an axis is specified, it will not move faster than
-                           the given speed. Note that this does not make that
-                           axis move precisely at the given speed; it only
-                           it if it was going to go faster. Direct speed
-                           is still set by ``speed``.
-        """
+        relative to the deck, at the specified speed."""
         if not self._current_position:
             await self.home()
 
@@ -760,13 +607,7 @@ class OT3API(
         fail_on_not_homed: bool = False,
     ):
         """Move the critical point of the specified mount by a specified
-        displacement in a specified direction, at the specified speed.
-        'speed' sets the speed of all axes to the given value. So, if multiple
-        axes are to be moved, they will do so at the same speed.
-
-        If fail_on_not_homed is True (default False), if an axis that is not
-        homed moves it will raise a MustHomeError. Otherwise, it will home the axis.
-        """
+        displacement in a specified direction, at the specified speed."""
 
         # TODO: Remove the fail_on_not_homed and make this the behavior all the time.
         # Having the optional arg makes the bug stick around in existing code and we
@@ -840,17 +681,7 @@ class OT3API(
         secondary_z: Axis = None,
         check_bounds: MotionChecks = MotionChecks.NONE,
     ):
-        """Worker function to apply robot motion.
-
-        Robot motion means the kind of motions that are relevant to the robot,
-        i.e. only one pipette plunger and mount move at the same time, and an
-        XYZ move in the coordinate frame of one of the pipettes.
-
-        ``target_position`` should be an ordered dict (ordered by XYZABC)
-        of deck calibrated values, containing any specified XY motion and
-        at most one of a ZA or BC components. The frame in which to move
-        is identified by the presence of (ZA) or (BC).
-        """
+        """Worker function to apply robot motion."""
         # Transform only the x, y, and (z or a) axes specified since this could
         # get the b or c axes as well
         to_transform_primary = tuple(
@@ -978,15 +809,7 @@ class OT3API(
         self.config = config
 
     async def update_config(self, **kwargs):
-        """Update values of the robot's configuration.
-
-        `kwargs` should contain keys of the robot's configuration. For
-        instance, `update_config(log_level='debug)` would change the API
-        server log level to :py:attr:`logging.DEBUG`.
-
-        Documentation on keys can be found in the documentation for
-        :py:class:`.RobotConfig`.
-        """
+        """Update values of the robot's configuration."""
         self._config = replace(self._config, **kwargs)
 
     async def update_deck_calibration(self, new_transform):
@@ -996,24 +819,9 @@ class OT3API(
     async def prepare_for_aspirate(
         self, mount: Union[top_types.Mount, PipettePair], rate: float = 1.0
     ):
-        """
-        Prepare the pipette for aspiration.
-
-        This must happen after every :py:meth:`blow_out` and should probably be
-        called before every :py:meth:`aspirate`, while the pipette tip is not
-        immersed in a well. It ensures that the plunger is at the 0-volume
-        position of the pipette if necessary (if not necessary, it does
-        nothing).
-
-        If :py:meth:`aspirate` is called immediately after :py:meth:`blow_out`,
-        the plunger is left at the ``blow_out`` position, below the ``bottom``
-        position, and moving the plunger up during :py:meth:`aspirate` is
-        expected to aspirate liquid - :py:meth:`aspirate` is called once the
-        pipette tip is already in the well. This will cause a subtle over
-        aspiration. To make the problem more obvious, :py:meth:`aspirate` will
-        raise an exception if this method has not previously been called.
-        """
+        """Prepare the pipette for aspiration."""
         instruments = self.instruments_for(mount)
+
         self._ready_for_tip_action(instruments, HardwareAction.PREPARE_ASPIRATE)
 
         with_zero = filter(lambda i: i[0].current_volume == 0, instruments)
@@ -1040,24 +848,7 @@ class OT3API(
         rate: float = 1.0,
     ):
         """
-        Aspirate a volume of liquid (in microliters/uL) using this pipette
-        from the *current location*. If no volume is passed, `aspirate` will
-        default to max available volume (after taking into account the volume
-        already present in the tip).
-
-        The function :py:meth:`prepare_for_aspirate` must be called prior to
-        calling this function, while the tip is above the well. This ensures
-        that the pipette tip is in the proper position at the bottom of the
-        pipette to begin aspiration, and prevents subtle over-aspiration if
-        an aspirate is done immediately after :py:meth:`blow_out`. If
-        :py:meth:`prepare_for_aspirate` has not been called since the last
-        call to :py:meth:`aspirate`, an exception will be raised.
-
-        mount : Mount.LEFT or Mount.RIGHT
-        volume : [float] The number of microliters to aspirate
-        rate : [float] Set plunger speed for this aspirate, where
-            speed = rate * aspirate_speed
-        """
+        Aspirate a volume of liquid (in microliters/uL) using this pipette."""
         aspirate_spec = self.plan_check_aspirate(mount, volume, rate)
         if not aspirate_spec:
             return
@@ -1094,15 +885,7 @@ class OT3API(
         rate: float = 1.0,
     ):
         """
-        Dispense a volume of liquid in microliters(uL) using this pipette
-        at the current location. If no volume is specified, `dispense` will
-        dispense all volume currently present in pipette
-
-        mount : Mount.LEFT or Mount.RIGHT
-        volume : [float] The number of microliters to dispense
-        rate : [float] Set plunger speed for this dispense, where
-            speed = rate * dispense_speed
-        """
+        Dispense a volume of liquid in microliters(uL) using this pipette."""
         dispense_spec = self.plan_check_dispense(mount, volume, rate)
         if not dispense_spec:
             return
@@ -1198,22 +981,7 @@ class OT3API(
         presses: Optional[int] = None,
         increment: Optional[float] = None,
     ):
-        """
-        Pick up tip from current location.
-
-        This is achieved by attempting to move the instrument down by its
-        `pick_up_distance`, in a series of presses. This distance is larger
-        than the space available in the tip, so the stepper motor will
-        eventually skip steps, which is resolved by homing afterwards. The
-        pick up operation is done at a current specified in the pipette config,
-        which is experimentally determined to skip steps at a level of force
-        sufficient to provide a good seal between the pipette nozzle and tip
-        while also avoiding attaching the tip so firmly that it can't be
-        dropped later.
-
-        If ``presses`` or ``increment`` is not specified (or is ``None``),
-        their value is taken from the pipette configuration.
-        """
+        """Pick up tip from current location."""
         instruments = self.instruments_for(mount)
         self._ready_for_pick_up_tip(instruments)
         plunger_currents = {
@@ -1334,15 +1102,7 @@ class OT3API(
     async def drop_tip(
         self, mount: Union[top_types.Mount, PipettePair], home_after=True
     ):
-        """
-        Drop tip at the current location
-
-        :param Mount mount: The mount to drop a tip from
-        :param bool home_after: Home the plunger motor after dropping tip. This
-                                is used in case the plunger motor skipped while
-                                dropping the tip, and is also used to recover
-                                the ejector shroud after a drop.
-        """
+        """Drop tip at the current location."""
 
         instruments = self.instruments_for(mount)
         self._ready_for_tip_action(instruments, HardwareAction.DROPTIP)

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -28,7 +28,6 @@ from .simulator import Simulator
 from .constants import (
     SHAKE_OFF_TIPS_SPEED,
     SHAKE_OFF_TIPS_DROP_DISTANCE,
-    SHAKE_OFF_TIPS_PICKUP_DISTANCE,
     DROP_TIP_RELEASE_DISTANCE,
 )
 from .execution_manager import ExecutionManagerProvider
@@ -46,7 +45,6 @@ from .types import (
     PipettePair,
     TipAttachedError,
     HardwareAction,
-    PairedPipetteConfigValueError,
     MotionChecks,
     PauseType,
 )
@@ -987,22 +985,13 @@ class OT3API(
         increment: Optional[float] = None,
     ):
         """Pick up tip from current location."""
-        instruments = self.instruments_for(mount)
-        self._ready_for_pick_up_tip(instruments)
-        plunger_currents = {
-            Axis.of_plunger(instr[1]): instr[0].config.plunger_current
-            for instr in instruments
-        }
-        z_axis_currents = {
-            Axis.by_mount(instr[1]): instr[0].config.pick_up_current
-            for instr in instruments
-        }
 
-        self._backend.set_active_current(plunger_currents)
-        # Initialize plunger to bottom position
-        bottom_positions = tuple(instr[0].config.bottom for instr in instruments)
+        spec, _add_tip_to_instrs = self.plan_check_pick_up_tip(
+            mount, tip_length, presses, increment
+        )
+        self._backend.set_active_current(spec.plunger_currents)
         target_absolute, _, secondary_z = target_position_from_plunger(
-            mount, bottom_positions, self._current_position
+            mount, spec.plunger_prep_pos, self._current_position
         )
         await self._move(
             target_absolute,
@@ -1010,75 +999,30 @@ class OT3API(
             home_flagged_axes=False,
         )
 
-        if not presses or presses < 0:
-            all_presses = tuple(
-                instr[0].config.pick_up_presses for instr in instruments
-            )
-            if len(all_presses) > 1 and all_presses[0] != all_presses[1]:
-                raise PairedPipetteConfigValueError(
-                    "Number of pipette pickups must match"
-                )
-            checked_presses = all_presses[0]
-        else:
-            checked_presses = presses
-
-        if not increment or increment < 0:
-            check_incr = tuple(
-                instr[0].config.pick_up_increment for instr in instruments
-            )
-        else:
-            check_incr = tuple(increment for instr in instruments)
-
-        pick_up_speed = min(instr[0].config.pick_up_speed for instr in instruments)
-        # Press the nozzle into the tip <presses> number of times,
-        # moving further by <increment> mm after each press
-        for i in range(checked_presses):
-            # move nozzle down into the tip
+        for press in spec.presses:
             with self._backend.save_current():
-                self._backend.set_active_current(z_axis_currents)
-                dist = tuple(
-                    -1.0 * instr[0].config.pick_up_distance + -1.0 * incrt * i
-                    for instr, incrt in zip(instruments, check_incr)
-                )
-                target_pos = (0, 0, *dist)
-                (
-                    target_absolute,
-                    primary_mount,
-                    secondary_z,
-                ) = target_position_from_relative(
-                    mount, target_pos, self._current_position
+                self._backend.set_active_current(press.current)
+                target_down, _, secondary_z = target_position_from_relative(
+                    mount, press.relative_down, self._current_position
                 )
                 await self._move(
-                    target_absolute, speed=pick_up_speed, secondary_z=secondary_z
+                    target_down, speed=press.speed, secondary_z=secondary_z
                 )
+                target_up, _, secondary_z = target_position_from_relative(
+                    mount, press.relative_up, self._current_position
+                )
+                await self._move(target_up, secondary_z=secondary_z)
 
-            # move nozzle back up
-            backup_pos = (0, 0, *tuple(-d for d in dist))
-            target_absolute, primary_mount, secondary_z = target_position_from_relative(
-                mount, backup_pos, self._current_position
-            )
-            await self._move(
-                target_absolute, speed=pick_up_speed, secondary_z=secondary_z
-            )
-        for instr in instruments:
-            instr[0].add_tip(tip_length=tip_length)
-            instr[0].set_current_volume(0)
+        _add_tip_to_instrs()
 
         # neighboring tips tend to get stuck in the space between
         # the volume chamber and the drop-tip sleeve on p1000.
         # This extra shake ensures those tips are removed
-        if any(["pickupTipShake" in instr[0].config.quirks for instr in instruments]):
-            await self._shake_off_tips_pick_up(mount)
-            await self._shake_off_tips_pick_up(mount)
-
+        for rel_point, speed in spec.shake_off_list:
+            await self.move_rel(mount, rel_point, speed=speed)
         # Here we add in the debounce distance for the switch as
         # a safety precaution
-        retract_target = max(
-            instr[0].config.pick_up_distance + incrt * checked_presses + 2
-            for instr, incrt in zip(instruments, check_incr)
-        )
-
-        await self.retract(mount, retract_target)
+        await self.retract(mount, spec.retract_target)
 
     def set_current_tiprack_diameter(
         self, mount: Union[top_types.Mount, PipettePair], tiprack_diameter: float
@@ -1191,29 +1135,6 @@ class OT3API(
         shake_pos = top_types.Point(2 * shake_off_dist, 0, 0)  # move right
         await self.move_rel(mount, shake_pos, speed=SHAKE_OFF_TIPS_SPEED)
         shake_pos = top_types.Point(-shake_off_dist, 0, 0)  # original position
-        await self.move_rel(mount, shake_pos, speed=SHAKE_OFF_TIPS_SPEED)
-        # raise the pipette upwards so we are sure tip has fallen off
-        up_pos = top_types.Point(0, 0, DROP_TIP_RELEASE_DISTANCE)
-        await self.move_rel(mount, up_pos)
-
-    async def _shake_off_tips_pick_up(self, mount: Union[top_types.Mount, PipettePair]):
-        # tips don't always fall off, especially if resting against
-        # tiprack or other tips below it. To ensure the tip has fallen
-        # first, shake the pipette to dislodge partially-sealed tips,
-        # then second, raise the pipette so loosened tips have room to fall
-        shake_off_dist = SHAKE_OFF_TIPS_PICKUP_DISTANCE
-
-        shake_pos = top_types.Point(-shake_off_dist, 0, 0)  # move left
-        await self.move_rel(mount, shake_pos, speed=SHAKE_OFF_TIPS_SPEED)
-        shake_pos = top_types.Point(2 * shake_off_dist, 0, 0)  # move right
-        await self.move_rel(mount, shake_pos, speed=SHAKE_OFF_TIPS_SPEED)
-        shake_pos = top_types.Point(-shake_off_dist, 0, 0)  # original position
-        await self.move_rel(mount, shake_pos, speed=SHAKE_OFF_TIPS_SPEED)
-        shake_pos = top_types.Point(0, -shake_off_dist, 0)  # move front
-        await self.move_rel(mount, shake_pos, speed=SHAKE_OFF_TIPS_SPEED)
-        shake_pos = top_types.Point(0, 2 * shake_off_dist, 0)  # move back
-        await self.move_rel(mount, shake_pos, speed=SHAKE_OFF_TIPS_SPEED)
-        shake_pos = top_types.Point(0, -shake_off_dist, 0)  # original position
         await self.move_rel(mount, shake_pos, speed=SHAKE_OFF_TIPS_SPEED)
         # raise the pipette upwards so we are sure tip has fallen off
         up_pos = top_types.Point(0, 0, DROP_TIP_RELEASE_DISTANCE)

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -71,7 +71,15 @@ PipetteHandlingData = Tuple[Pipette, top_types.Mount]
 
 
 class OT3API(
-    ExecutionManagerProvider, RobotCalibrationProvider, InstrumentHandlerProvider
+    ExecutionManagerProvider,
+    RobotCalibrationProvider,
+    InstrumentHandlerProvider,
+    # This MUST be kept last in the inheritance list so that it is
+    # deprioritized in the method resolution order; otherwise, invocations
+    # of methods that are present in the protocol will call the (empty,
+    # do-nothing) methods in the protocol. This will happily make all the
+    # tests fail.
+    HardwareControlAPI,
 ):
     """This API is the primary interface to the hardware controller.
 
@@ -123,11 +131,6 @@ class OT3API(
         ExecutionManagerProvider.__init__(self, loop, isinstance(backend, Simulator))
         RobotCalibrationProvider.__init__(self)
         InstrumentHandlerProvider.__init__(self)
-        OT3API._check_type(self)
-
-    @staticmethod
-    def _check_type(inst: HardwareControlAPI) -> None:
-        pass
 
     @property
     def door_state(self) -> DoorState:

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1058,59 +1058,34 @@ class OT3API(
         rate : [float] Set plunger speed for this aspirate, where
             speed = rate * aspirate_speed
         """
-        instruments = self._instruments_for(mount)
-        self._ready_for_tip_action(instruments, HardwareAction.ASPIRATE)
-        plunger_currents = {
-            Axis.of_plunger(instr[1]): instr[0].config.plunger_current
-            for instr in instruments
-        }
-
-        if volume is None:
-            mod_log.debug(
-                "No aspirate volume defined. Aspirating up to "
-                "max_volume for the pipette"
-            )
-            asp_vol = tuple(instr[0].available_volume for instr in instruments)
-        else:
-            asp_vol = tuple(volume for instr in instruments)
-
-        if all([vol == 0 for vol in asp_vol]):
+        aspirate_spec = self.plan_check_aspirate(mount, volume, rate)
+        if not aspirate_spec:
             return
-        elif 0 in asp_vol:
-            raise PairedPipetteConfigValueError("Cannot only aspirate from one pipette")
-
-        for instr, vol in zip(instruments, asp_vol):
-            assert instr[0].ok_to_add_volume(
-                vol
-            ), "Cannot aspirate more than pipette max volume"
-
-        dist = tuple(
-            self.plunger_position(instr[0], instr[0].current_volume + vol, "aspirate")
-            for instr, vol in zip(instruments, asp_vol)
+        target_pos, _, secondary_z = target_position_from_plunger(
+            mount,
+            [spec.plunger_distance for spec in aspirate_spec],
+            self._current_position,
         )
-        speed = min(
-            self.plunger_speed(instr[0], instr[0].aspirate_flow_rate * rate, "aspirate")
-            for instr in instruments
-        )
+
         try:
-            self._backend.set_active_current(plunger_currents)
-            target_pos, _, secondary_z = target_position_from_plunger(
-                mount, dist, self._current_position
+            self._backend.set_active_current(
+                {spec.axis: spec.current for spec in aspirate_spec}
             )
+
             await self._move(
                 target_pos,
-                speed=speed,
+                speed=aspirate_spec[0].speed,
                 secondary_z=secondary_z,
                 home_flagged_axes=False,
             )
         except Exception:
             self._log.exception("Aspirate failed")
-            for instr in instruments:
-                instr[0].set_current_volume(0)
+            for spec in aspirate_spec:
+                spec.instr.set_current_volume(0)
             raise
         else:
-            for instr, vol in zip(instruments, asp_vol):
-                instr[0].add_current_volume(vol)
+            for spec in aspirate_spec:
+                spec.instr.add_current_volume(spec.volume)
 
     async def dispense(
         self,

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1103,61 +1103,33 @@ class OT3API(
         rate : [float] Set plunger speed for this dispense, where
             speed = rate * dispense_speed
         """
-        instruments = self._instruments_for(mount)
-        self._ready_for_tip_action(instruments, HardwareAction.DISPENSE)
-
-        plunger_currents = {
-            Axis.of_plunger(instr[1]): instr[0].config.plunger_current
-            for instr in instruments
-        }
-        if volume is None:
-            disp_vol = tuple(instr[0].current_volume for instr in instruments)
-            mod_log.debug(
-                "No dispense volume specified. Dispensing all "
-                "remaining liquid ({}uL) from pipette".format(disp_vol)
-            )
-        else:
-            disp_vol = tuple(volume for instr in instruments)
-
-        # Ensure we don't dispense more than the current volume
-        disp_vol = tuple(
-            min(instr[0].current_volume, vol)
-            for instr, vol in zip(instruments, disp_vol)
-        )
-
-        if all([vol == 0 for vol in disp_vol]):
+        dispense_spec = self.plan_check_dispense(mount, volume, rate)
+        if not dispense_spec:
             return
-        elif 0 in disp_vol:
-            raise PairedPipetteConfigValueError("Cannot only dispense from one pipette")
-
-        dist = tuple(
-            self.plunger_position(instr[0], instr[0].current_volume - vol, "dispense")
-            for instr, vol in zip(instruments, disp_vol)
-        )
-        speed = min(
-            self.plunger_speed(instr[0], instr[0].dispense_flow_rate * rate, "dispense")
-            for instr in instruments
+        target_pos, _, secondary_z = target_position_from_plunger(
+            mount,
+            [spec.plunger_distance for spec in dispense_spec],
+            self._current_position,
         )
 
         try:
-            self._backend.set_active_current(plunger_currents)
-            target_pos, _, secondary_z = target_position_from_plunger(
-                mount, dist, self._current_position
+            self._backend.set_active_current(
+                {spec.axis: spec.current for spec in dispense_spec}
             )
             await self._move(
                 target_pos,
-                speed=speed,
+                speed=dispense_spec[0].speed,
                 secondary_z=secondary_z,
                 home_flagged_axes=False,
             )
         except Exception:
             self._log.exception("Dispense failed")
-            for instr in instruments:
-                instr[0].set_current_volume(0)
+            for spec in dispense_spec:
+                spec.instr.set_current_volume(0)
             raise
         else:
-            for instr, vol in zip(instruments, disp_vol):
-                instr[0].remove_current_volume(vol)
+            for spec in dispense_spec:
+                spec.instr.remove_current_volume(spec.volume)
 
     async def blow_out(self, mount: Union[top_types.Mount, PipettePair]):
         """

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+from functools import partial
 from dataclasses import replace
 import logging
 from collections import OrderedDict
@@ -53,6 +54,11 @@ from . import modules
 from .robot_calibration import RobotCalibrationProvider, load_pipette_offset
 from .protocols import HardwareControlAPI
 from .instrument_handler import InstrumentHandlerProvider
+from .motion_utilities import (
+    target_position_from_absolute,
+    target_position_from_relative,
+    target_position_from_plunger,
+)
 
 from opentrons_shared_data.pipette.dev_types import UlPerMmAction, PipetteName
 
@@ -506,8 +512,14 @@ class OT3API(
                 # either we were passed False for our acquire_lock and we
                 # should pass it on, or we acquired the lock above and
                 # shouldn't do it again
-                await self._move_plunger(
-                    checked_mount, (instr.config.bottom,), acquire_lock=False
+                target_pos, _, secondary_z = target_position_from_plunger(
+                    checked_mount, (instr.config.bottom,), self._current_position
+                )
+                await self._move(
+                    target_pos,
+                    acquire_lock=False,
+                    secondary_z=secondary_z,
+                    home_flagged_axes=False,
                 )
 
     async def home_plunger(self, mount: top_types.Mount):
@@ -726,47 +738,12 @@ class OT3API(
         if not self._current_position:
             await self.home()
 
-        mounts = self.mounts(mount)
-        primary_mount = mounts[0]
-        secondary_mount = None
-        # Even with overloads, mypy cannot accept a length check on
-        # a tuple to confirm whether there are one or two mounts
-        # see: https://github.com/python/mypy/issues/1178
-        if len(mounts) > 1:
-            secondary_mount = mounts[1]  # type: ignore
-
-        mount_offset = self._config.left_mount_offset
-        if primary_mount == top_types.Mount.LEFT:
-            primary_offset = top_types.Point(*mount_offset)
-            s_offset = top_types.Point(0, 0, 0)
-        else:
-            primary_offset = top_types.Point(0, 0, 0)
-            s_offset = top_types.Point(*mount_offset)
-
-        if secondary_mount:
-            primary_z = Axis.by_mount(primary_mount)
-            secondary_z = Axis.by_mount(secondary_mount)
-            primary_cp = self.critical_point_for(primary_mount, critical_point)
-            s_cp = self.critical_point_for(secondary_mount, critical_point)
-            target_position = OrderedDict(
-                (
-                    (Axis.X, abs_position.x - primary_offset.x - primary_cp.x),
-                    (Axis.Y, abs_position.y - primary_offset.y - primary_cp.y),
-                    (primary_z, abs_position.z - primary_offset.z - primary_cp.z),
-                    (secondary_z, abs_position.z - s_offset.z - s_cp.z),
-                )
-            )
-        else:
-            primary_cp = self.critical_point_for(primary_mount, critical_point)
-            primary_z = Axis.by_mount(primary_mount)
-            secondary_z = None
-            target_position = OrderedDict(
-                (
-                    (Axis.X, abs_position.x - primary_offset.x - primary_cp.x),
-                    (Axis.Y, abs_position.y - primary_offset.y - primary_cp.y),
-                    (primary_z, abs_position.z - primary_offset.z - primary_cp.z),
-                )
-            )
+        target_position, primary_mount, secondary_z = target_position_from_absolute(
+            mount,
+            abs_position,
+            partial(self.critical_point_for, cp_override=critical_point),
+            top_types.Point(*self._config.left_mount_offset),
+        )
 
         await self._cache_and_maybe_retract_mount(primary_mount)
         await self._move(
@@ -794,49 +771,23 @@ class OT3API(
         # TODO: Remove the fail_on_not_homed and make this the behavior all the time.
         # Having the optional arg makes the bug stick around in existing code and we
         # really want to fix it when we're not gearing up for a release.
-        mounts = self.mounts(mount)
-        if fail_on_not_homed:
-            axes_moving = [Axis.X, Axis.Y] + [Axis.by_mount(m) for m in mounts]
-            if (
-                not self._backend.is_homed([axis.name for axis in axes_moving])
-                or not self._current_position
-            ):
-                raise MustHomeError(
-                    "Cannot make a relative move because absolute position is unknown"
-                )
-        elif not self._current_position:
-            await self.home()
+        mhe = MustHomeError(
+            "Cannot make a relative move because absolute position is unknown"
+        )
+        if not self._current_position:
+            if fail_on_not_homed:
+                raise mhe
+            else:
+                await self.home()
 
-        primary_mount = mounts[0]
-        secondary_mount = None
-        # Even with overloads, mypy cannot accept a length check on
-        # a tuple to confirm whether there are one or two mounts
-        # see: https://github.com/python/mypy/issues/1178
-        if len(mounts) > 1:
-            secondary_mount = mounts[1]  # type: ignore
-
-        if secondary_mount:
-            primary_z = Axis.by_mount(primary_mount)
-            secondary_z = Axis.by_mount(secondary_mount)
-            target_position = OrderedDict(
-                (
-                    (Axis.X, self._current_position[Axis.X] + delta.x),
-                    (Axis.Y, self._current_position[Axis.Y] + delta.y),
-                    (primary_z, self._current_position[primary_z] + delta.z),
-                    (secondary_z, self._current_position[secondary_z] + delta.z),
-                )
-            )
-        else:
-            z_axis = Axis.by_mount(primary_mount)
-            secondary_z = None
-            target_position = OrderedDict(
-                (
-                    (Axis.X, self._current_position[Axis.X] + delta.x),
-                    (Axis.Y, self._current_position[Axis.Y] + delta.y),
-                    (z_axis, self._current_position[z_axis] + delta.z),
-                )
-            )
-
+        target_position, primary_mount, secondary_z = target_position_from_relative(
+            mount, delta, self._current_position
+        )
+        axes_moving = [Axis.X, Axis.Y, Axis.by_mount(primary_mount), secondary_z]
+        if fail_on_not_homed and not self._backend.is_homed(
+            [axis.name for axis in axes_moving if axis is not None]
+        ):
+            raise mhe
         await self._cache_and_maybe_retract_mount(primary_mount)
         await self._move(
             target_position,
@@ -857,63 +808,6 @@ class OT3API(
         if mount != self._last_moved_mount and self._last_moved_mount:
             await self.retract(self._last_moved_mount, 10)
         self._last_moved_mount = mount
-
-    async def _move_plunger(
-        self,
-        mount: Union[top_types.Mount, PipettePair],
-        dist: Sequence[float],
-        speed: float = None,
-        acquire_lock: bool = True,
-    ):
-        all_axes_pos = OrderedDict(
-            (
-                (Axis.X, self._current_position[Axis.X]),
-                (Axis.Y, self._current_position[Axis.Y]),
-            )
-        )
-        plunger_pos = OrderedDict()
-        mounts = self.mounts(mount)
-        secondary_z = None
-        for idx, m in enumerate(mounts):
-            z = Axis.by_mount(m)
-            plunger = Axis.of_plunger(m)
-            all_axes_pos[z] = self._current_position[z]
-            plunger_pos[plunger] = dist[idx]
-            if idx == 1:
-                secondary_z = z
-        all_axes_pos.update(plunger_pos)
-        await self._move(
-            all_axes_pos,
-            speed,
-            False,
-            acquire_lock=acquire_lock,
-            secondary_z=secondary_z,
-        )
-
-    async def _move_relative_n_axes(
-        self,
-        mount: Union[top_types.Mount, PipettePair],
-        target: Sequence[float],
-        speed: float = None,
-    ):
-        all_axes_pos = OrderedDict(
-            (
-                (Axis.X, self._current_position[Axis.X] + target[0]),
-                (Axis.Y, self._current_position[Axis.Y] + target[1]),
-            )
-        )
-        mounts = self.mounts(mount)
-        secondary_z = None
-        for (
-            idx,
-            m,
-        ) in enumerate(mounts):
-            z = Axis.by_mount(m)
-            t_index = idx + 2
-            all_axes_pos[z] = self._current_position[z] + target[t_index]
-            if idx == 1:
-                secondary_z = z
-        await self._move(all_axes_pos, speed=speed, secondary_z=secondary_z)
 
     def _get_transformed(
         self,
@@ -1128,7 +1022,15 @@ class OT3API(
                 instr[0], instr[0].blow_out_flow_rate, "aspirate"
             )
             bottom = (instr[0].config.bottom,)
-            await self._move_plunger(instr[1], bottom, speed=(speed * rate))
+            target_pos, _, secondary_z = target_position_from_plunger(
+                instr[1], bottom, self._current_position
+            )
+            await self._move(
+                target_pos,
+                speed=(speed * rate),
+                secondary_z=secondary_z,
+                home_flagged_axes=False,
+            )
             instr[0].ready_to_aspirate = True
 
     async def aspirate(
@@ -1192,7 +1094,15 @@ class OT3API(
         )
         try:
             self._backend.set_active_current(plunger_currents)
-            await self._move_plunger(mount, dist, speed=speed)
+            target_pos, _, secondary_z = target_position_from_plunger(
+                mount, dist, self._current_position
+            )
+            await self._move(
+                target_pos,
+                speed=speed,
+                secondary_z=secondary_z,
+                home_flagged_axes=False,
+            )
         except Exception:
             self._log.exception("Aspirate failed")
             for instr in instruments:
@@ -1256,7 +1166,15 @@ class OT3API(
 
         try:
             self._backend.set_active_current(plunger_currents)
-            await self._move_plunger(mount, dist, speed=speed)
+            target_pos, _, secondary_z = target_position_from_plunger(
+                mount, dist, self._current_position
+            )
+            await self._move(
+                target_pos,
+                speed=speed,
+                secondary_z=secondary_z,
+                home_flagged_axes=False,
+            )
         except Exception:
             self._log.exception("Dispense failed")
             for instr in instruments:
@@ -1285,7 +1203,15 @@ class OT3API(
             for instr in instruments
         )
         try:
-            await self._move_plunger(mount, blow_out, speed=speed)
+            target_pos, _, secondary_z = target_position_from_plunger(
+                mount, blow_out, self._current_position
+            )
+            await self._move(
+                target_pos,
+                speed=speed,
+                secondary_z=secondary_z,
+                home_flagged_axes=False,
+            )
         except Exception:
             self._log.exception("Blow out failed")
             raise
@@ -1361,7 +1287,14 @@ class OT3API(
         self._backend.set_active_current(plunger_currents)
         # Initialize plunger to bottom position
         bottom_positions = tuple(instr[0].config.bottom for instr in instruments)
-        await self._move_plunger(mount, bottom_positions)
+        target_absolute, _, secondary_z = target_position_from_plunger(
+            mount, bottom_positions, self._current_position
+        )
+        await self._move(
+            target_absolute,
+            secondary_z=secondary_z,
+            home_flagged_axes=False,
+        )
 
         if not presses or presses < 0:
             all_presses = tuple(
@@ -1394,11 +1327,25 @@ class OT3API(
                     for instr, incrt in zip(instruments, check_incr)
                 )
                 target_pos = (0, 0, *dist)
-                await self._move_relative_n_axes(mount, target_pos, pick_up_speed)
+                (
+                    target_absolute,
+                    primary_mount,
+                    secondary_z,
+                ) = target_position_from_relative(
+                    mount, target_pos, self._current_position
+                )
+                await self._move(
+                    target_absolute, speed=pick_up_speed, secondary_z=secondary_z
+                )
 
             # move nozzle back up
             backup_pos = (0, 0, *tuple(-d for d in dist))
-            await self._move_relative_n_axes(mount, backup_pos)
+            target_absolute, primary_mount, secondary_z = target_position_from_relative(
+                mount, backup_pos, self._current_position
+            )
+            await self._move(
+                target_absolute, speed=pick_up_speed, secondary_z=secondary_z
+            )
         for instr in instruments:
             instr[0].add_tip(tip_length=tip_length)
             instr[0].set_current_volume(0)
@@ -1476,9 +1423,24 @@ class OT3API(
 
         async def _drop_tip():
             self._backend.set_active_current(plunger_currents)
-            await self._move_plunger(mount, bottom)
+            target_pos, _, secondary_z = target_position_from_plunger(
+                mount, bottom, self._current_position
+            )
+            await self._move(
+                target_pos,
+                secondary_z=secondary_z,
+                home_flagged_axes=False,
+            )
             self._backend.set_active_current(drop_tip_currents)
-            await self._move_plunger(mount, droptip, speed=speed)
+            target_pos, _, secondary_z = target_position_from_plunger(
+                mount, droptip, self._current_position
+            )
+            await self._move(
+                target_pos,
+                speed=speed,
+                secondary_z=secondary_z,
+                home_flagged_axes=False,
+            )
             if home_after:
                 safety_margin = abs(max(bottom) - max(droptip))
                 smoothie_pos = await self._backend.fast_home(
@@ -1486,7 +1448,14 @@ class OT3API(
                 )
                 self._current_position = self._deck_from_smoothie(smoothie_pos)
                 self._backend.set_active_current(plunger_currents)
-                await self._move_plunger(mount, bottom)
+                target_pos, _, secondary_z = target_position_from_plunger(
+                    mount, bottom, self._current_position
+                )
+                await self._move(
+                    target_pos,
+                    secondary_z=secondary_z,
+                    home_flagged_axes=False,
+                )
 
         if any(["doubleDropTip" in instr[0].config.quirks for instr in instruments]):
             await _drop_tip()

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -37,7 +37,7 @@ class Axis(enum.Enum):
     C = 5
 
     @classmethod
-    def by_mount(cls, mount: top_types.Mount):
+    def by_mount(cls, mount: top_types.Mount) -> "Axis":
         bm = {top_types.Mount.LEFT: cls.Z, top_types.Mount.RIGHT: cls.A}
         return bm[mount]
 
@@ -49,12 +49,12 @@ class Axis(enum.Enum):
         return cls.X, cls.Y, cls.Z, cls.A
 
     @classmethod
-    def of_plunger(cls, mount: top_types.Mount):
+    def of_plunger(cls, mount: top_types.Mount) -> "Axis":
         pm = {top_types.Mount.LEFT: cls.B, top_types.Mount.RIGHT: cls.C}
         return pm[mount]
 
     @classmethod
-    def to_mount(cls, inst: "Axis"):
+    def to_mount(cls, inst: "Axis") -> top_types.Mount:
         return {
             cls.Z: top_types.Mount.LEFT,
             cls.A: top_types.Mount.RIGHT,
@@ -62,7 +62,7 @@ class Axis(enum.Enum):
             cls.C: top_types.Mount.RIGHT,
         }[inst]
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
 

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -189,7 +189,6 @@ async def _build_ot2_hw() -> AsyncGenerator[HardwareControlAPI, None]:
         hw_sim.clean_up()
 
 
-@pytest.mark.skipif(aionotify is None, reason="requires inotify (linux only)")
 @pytest.fixture
 async def ot2_hardware(request, loop, virtual_smoothie_env):
     async for hw in _build_ot2_hw():
@@ -207,14 +206,12 @@ async def _build_ot3_hw() -> AsyncGenerator[HardwareControlAPI, None]:
         hw_sim.clean_up()
 
 
-@pytest.mark.skipif(aionotify is None, reason="requires inotify (linux only)")
 @pytest.fixture
 async def ot3_hardware(request, loop, enable_ot3_hardware_controller):
     async for hw in _build_ot3_hw():
         yield hw
 
 
-@pytest.mark.skipif(aionotify is None, reason="requires inotify (linux only)")
 @pytest.fixture(
     # these have to be lambdas because pytest calls them when providing the param
     # value and we want to use the function's identity

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -414,14 +414,22 @@ async def test_pick_up_tip(dummy_instruments, loop, is_robot, sim_builder):
     assert hw_api._current_position == target_position
 
 
-def assert_move_called(mock_move, speed, lock=True):
-    mock_move.assert_called_with(
-        mock.ANY,
-        speed,
-        False,
-        acquire_lock=lock,
-        secondary_z=mock.ANY,
-    )
+def assert_move_called(mock_move, speed, lock=None):
+    if lock is not None:
+        mock_move.assert_called_with(
+            mock.ANY,
+            speed=speed,
+            home_flagged_axes=False,
+            acquire_lock=lock,
+            secondary_z=mock.ANY,
+        )
+    else:
+        mock_move.assert_called_with(
+            mock.ANY,
+            speed=speed,
+            home_flagged_axes=False,
+            secondary_z=mock.ANY,
+        )
 
 
 async def test_aspirate_flow_rate(dummy_instruments, loop, sim_builder):

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -437,16 +437,16 @@ async def test_aspirate_flow_rate(dummy_instruments, loop, monkeypatch, sim_buil
     await hw_api.aspirate(types.Mount.LEFT, 2)
     assert mock_move_plunger.called_with(
         mount,
-        hw_api._plunger_position(pip, 2, "aspirate"),
-        speed=hw_api._plunger_speed(pip, pip.config.aspirate_flow_rate, "aspirate"),
+        hw_api.plunger_position(pip, 2, "aspirate"),
+        speed=hw_api.plunger_speed(pip, pip.config.aspirate_flow_rate, "aspirate"),
     )
     mock_move_plunger.reset_mock()
     await hw_api.prepare_for_aspirate(types.Mount.LEFT)
     await hw_api.aspirate(types.Mount.LEFT, 2, rate=0.5)
     assert mock_move_plunger.called_with(
         mount,
-        hw_api._plunger_position(pip, 4, "aspirate"),
-        speed=hw_api._plunger_speed(
+        hw_api.plunger_position(pip, 4, "aspirate"),
+        speed=hw_api.plunger_speed(
             pip, pip.config.aspirate_flow_rate * 0.5, "aspirate"
         ),
     )
@@ -456,29 +456,29 @@ async def test_aspirate_flow_rate(dummy_instruments, loop, monkeypatch, sim_buil
     await hw_api.aspirate(types.Mount.LEFT, 2)
     assert mock_move_plunger.called_with(
         mount,
-        hw_api._plunger_position(pip, 6, "aspirate"),
-        speed=hw_api._plunger_speed(pip, 2, "aspirate"),
+        hw_api.plunger_position(pip, 6, "aspirate"),
+        speed=hw_api.plunger_speed(pip, 2, "aspirate"),
     )
     mock_move_plunger.reset_mock()
     await hw_api.prepare_for_aspirate(types.Mount.LEFT)
     await hw_api.aspirate(types.Mount.LEFT, 2, rate=0.5)
     assert mock_move_plunger.called_with(
         mount,
-        hw_api._plunger_position(pip, 8, "aspirate"),
-        speed=hw_api._plunger_speed(pip, 1, "aspirate"),
+        hw_api.plunger_position(pip, 8, "aspirate"),
+        speed=hw_api.plunger_speed(pip, 1, "aspirate"),
     )
     mock_move_plunger.reset_mock()
     hw_api.set_pipette_speed(mount, aspirate=10)
     await hw_api.prepare_for_aspirate(types.Mount.LEFT)
     await hw_api.aspirate(types.Mount.LEFT, 1)
     assert mock_move_plunger.called_with(
-        mount, hw_api._plunger_position(pip, 8, "aspirate"), speed=10
+        mount, hw_api.plunger_position(pip, 8, "aspirate"), speed=10
     )
     mock_move_plunger.reset_mock()
     await hw_api.prepare_for_aspirate(types.Mount.LEFT)
     await hw_api.aspirate(types.Mount.LEFT, 1, rate=0.5)
     assert mock_move_plunger.called_with(
-        mount, hw_api._plunger_position(pip, 8, "aspirate"), speed=5
+        mount, hw_api.plunger_position(pip, 8, "aspirate"), speed=5
     )
 
 
@@ -505,15 +505,15 @@ async def test_dispense_flow_rate(dummy_instruments, loop, monkeypatch, sim_buil
     await hw_api.dispense(types.Mount.LEFT, 2)
     assert mock_move_plunger.called_with(
         mount,
-        hw_api._plunger_position(pip, 8, "dispense"),
-        speed=hw_api._plunger_speed(pip, pip.config.dispense_flow_rate, "dispense"),
+        hw_api.plunger_position(pip, 8, "dispense"),
+        speed=hw_api.plunger_speed(pip, pip.config.dispense_flow_rate, "dispense"),
     )
     mock_move_plunger.reset_mock()
     await hw_api.dispense(types.Mount.LEFT, 2, rate=0.5)
     assert mock_move_plunger.called_with(
         mount,
-        hw_api._plunger_position(pip, 6, "dispense"),
-        speed=hw_api._plunger_speed(
+        hw_api.plunger_position(pip, 6, "dispense"),
+        speed=hw_api.plunger_speed(
             pip, pip.config.dispense_flow_rate * 0.5, "dispense"
         ),
     )
@@ -522,26 +522,26 @@ async def test_dispense_flow_rate(dummy_instruments, loop, monkeypatch, sim_buil
     await hw_api.dispense(types.Mount.LEFT, 2)
     assert mock_move_plunger.called_with(
         mount,
-        hw_api._plunger_position(pip, 4, "dispense"),
-        speed=hw_api._plunger_speed(pip, 3, "dispense"),
+        hw_api.plunger_position(pip, 4, "dispense"),
+        speed=hw_api.plunger_speed(pip, 3, "dispense"),
     )
     mock_move_plunger.reset_mock()
     await hw_api.dispense(types.Mount.LEFT, 2, rate=0.5)
     assert mock_move_plunger.called_with(
         mount,
-        hw_api._plunger_position(pip, 2, "dispense"),
-        speed=hw_api._plunger_speed(pip, 1.5, "dispense"),
+        hw_api.plunger_position(pip, 2, "dispense"),
+        speed=hw_api.plunger_speed(pip, 1.5, "dispense"),
     )
     mock_move_plunger.reset_mock()
     hw_api.set_pipette_speed(mount, dispense=10)
     await hw_api.dispense(types.Mount.LEFT, 1)
     assert mock_move_plunger.called_with(
-        mount, hw_api._plunger_position(pip, 1, "dispense"), speed=10
+        mount, hw_api.plunger_position(pip, 1, "dispense"), speed=10
     )
     mock_move_plunger.reset_mock()
     await hw_api.dispense(types.Mount.LEFT, 1, rate=0.5)
     assert mock_move_plunger.called_with(
-        mount, hw_api._plunger_position(pip, 0, "dispense"), speed=5
+        mount, hw_api.plunger_position(pip, 0, "dispense"), speed=5
     )
 
 
@@ -571,7 +571,7 @@ async def test_blowout_flow_rate(dummy_instruments, loop, sim_builder, monkeypat
     assert mock_move_plunger.called_with(
         mount,
         pip.config.blow_out,
-        speed=hw_api._plunger_speed(pip, pip.config.blow_out_flow_rate, "dispense"),
+        speed=hw_api.plunger_speed(pip, pip.config.blow_out_flow_rate, "dispense"),
     )
     mock_move_plunger.reset_mock()
 
@@ -581,7 +581,7 @@ async def test_blowout_flow_rate(dummy_instruments, loop, sim_builder, monkeypat
     mock_move_plunger.reset_mock()
     await hw_api.blow_out(types.Mount.LEFT)
     assert mock_move_plunger.called_with(
-        mount, pip.config.blow_out, speed=hw_api._plunger_speed(pip, 2, "dispense")
+        mount, pip.config.blow_out, speed=hw_api.plunger_speed(pip, 2, "dispense")
     )
     mock_move_plunger.reset_mock()
 

--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -346,14 +346,10 @@ async def test_shake_during_drop(hardware_api, monkeypatch):
     }
     await hardware_api.cache_instruments()
     await hardware_api.add_tip(types.Mount.RIGHT, 50.0)
-    hardware_api.set_current_tiprack_diameter(types.Mount.RIGHT, 30.0)
+    hardware_api.set_current_tiprack_diameter(types.Mount.RIGHT, 2.0 * 4)
 
     shake_tips_drop = mock.Mock(side_effect=hardware_api._shake_off_tips_drop)
     monkeypatch.setattr(hardware_api, "_shake_off_tips_drop", shake_tips_drop)
-
-    # Test single shake after drop tip
-    await hardware_api.drop_tip(types.Mount.RIGHT)
-    shake_tips_drop.assert_called_once_with(types.Mount.RIGHT, 30)
 
     move_rel = mock.Mock(side_effect=hardware_api.move_rel)
     monkeypatch.setattr(hardware_api, "move_rel", move_rel)
@@ -361,36 +357,43 @@ async def test_shake_during_drop(hardware_api, monkeypatch):
     # Test drop tip shake with 25% of tiprack well diameter
     # between upper (2.25 mm) and lower limit (1.0 mm)
     shake_tips_drop.reset_mock()
-    await shake_tips_drop(types.Mount.RIGHT, 2.0 * 4)
+    await hardware_api.drop_tip(types.Mount.RIGHT)
+    shake_tips_drop.assert_called_once()
     move_rel_calls = [
         mock.call(types.Mount.RIGHT, types.Point(-2, 0, 0), speed=50),
         mock.call(types.Mount.RIGHT, types.Point(4, 0, 0), speed=50),
         mock.call(types.Mount.RIGHT, types.Point(-2, 0, 0), speed=50),
-        mock.call(types.Mount.RIGHT, types.Point(0, 0, 20)),
+        mock.call(types.Mount.RIGHT, types.Point(0, 0, 20), speed=None),
     ]
     move_rel.assert_has_calls(move_rel_calls)
 
     # Test drop tip shake with 25% of tiprack well diameter
     # over upper (2.25 mm) limit
+    await hardware_api.add_tip(types.Mount.RIGHT, 20)
+    hardware_api.set_current_tiprack_diameter(types.Mount.RIGHT, 2.3 * 4)
     shake_tips_drop.reset_mock()
-    await shake_tips_drop(types.Mount.RIGHT, 2.3 * 4)
+    move_rel.reset_move()
+    await hardware_api.drop_tip(types.Mount.RIGHT)
     move_rel_calls = [
         mock.call(types.Mount.RIGHT, types.Point(-2.25, 0, 0), speed=50),
         mock.call(types.Mount.RIGHT, types.Point(4.5, 0, 0), speed=50),
         mock.call(types.Mount.RIGHT, types.Point(-2.25, 0, 0), speed=50),
-        mock.call(types.Mount.RIGHT, types.Point(0, 0, 20)),
+        mock.call(types.Mount.RIGHT, types.Point(0, 0, 20), speed=None),
     ]
     move_rel.assert_has_calls(move_rel_calls)
 
     # Test drop tip shake with 25% of tiprack well diameter
     # below lower (1.0 mm) limit
+    await hardware_api.add_tip(types.Mount.RIGHT, 50)
+    hardware_api.set_current_tiprack_diameter(types.Mount.RIGHT, 0.9 * 4)
     shake_tips_drop.reset_mock()
-    await shake_tips_drop(types.Mount.RIGHT, 0.9 * 4)
+    move_rel.reset_mock()
+    await hardware_api.drop_tip(types.Mount.RIGHT)
     move_rel_calls = [
         mock.call(types.Mount.RIGHT, types.Point(-1, 0, 0), speed=50),
         mock.call(types.Mount.RIGHT, types.Point(2, 0, 0), speed=50),
         mock.call(types.Mount.RIGHT, types.Point(-1, 0, 0), speed=50),
-        mock.call(types.Mount.RIGHT, types.Point(0, 0, 20)),
+        mock.call(types.Mount.RIGHT, types.Point(0, 0, 20), speed=None),
     ]
     move_rel.assert_has_calls(move_rel_calls)
 

--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -317,20 +317,15 @@ async def test_shake_during_pick_up(hardware_api, monkeypatch):
     }
     await hardware_api.cache_instruments()
 
-    shake_tips_pick_up = mock.Mock(side_effect=hardware_api._shake_off_tips_pick_up)
-    monkeypatch.setattr(hardware_api, "_shake_off_tips_pick_up", shake_tips_pick_up)
-
-    # Test double shake for after pick up tips
-    await hardware_api.pick_up_tip(types.Mount.RIGHT, 50)
-    shake_tip_calls = [mock.call(types.Mount.RIGHT), mock.call(types.Mount.RIGHT)]
-    shake_tips_pick_up.assert_has_calls(shake_tip_calls)
+    shake_tips_pick_up = mock.Mock(side_effect=hardware_api._build_pickup_shakes)
+    monkeypatch.setattr(hardware_api, "_build_pickup_shakes", shake_tips_pick_up)
 
     move_rel = mock.Mock(side_effect=hardware_api.move_rel)
     monkeypatch.setattr(hardware_api, "move_rel", move_rel)
 
-    # Test shakes in X and Y direction with 0.3 mm shake tip distance
-    shake_tips_pick_up.reset_mock()
-    await shake_tips_pick_up(types.Mount.RIGHT)
+    # Test double shake for after pick up tips
+    await hardware_api.pick_up_tip(types.Mount.RIGHT, 50)
+    shake_tips_pick_up.assert_called_once()
     move_rel_calls = [
         mock.call(types.Mount.RIGHT, types.Point(-0.3, 0, 0), speed=50),
         mock.call(types.Mount.RIGHT, types.Point(0.6, 0, 0), speed=50),
@@ -338,7 +333,7 @@ async def test_shake_during_pick_up(hardware_api, monkeypatch):
         mock.call(types.Mount.RIGHT, types.Point(0, -0.3, 0), speed=50),
         mock.call(types.Mount.RIGHT, types.Point(0, 0.6, 0), speed=50),
         mock.call(types.Mount.RIGHT, types.Point(0, -0.3, 0), speed=50),
-        mock.call(types.Mount.RIGHT, types.Point(0, 0, 20)),
+        mock.call(types.Mount.RIGHT, types.Point(0, 0, 20), speed=None),
     ]
     move_rel.assert_has_calls(move_rel_calls)
 


### PR DESCRIPTION
While there's a lot of irreconcilable differences between OT3 and OT2 hardware controllers (some of which have not been made), there's a surprising amount of similarity that before this PR was duplicated code. This PR hoists as much common functionality as it can into either shared parent classes or utility modules (depending on how much state they need from the controller).

The guiding concept here is that only the end child classes may access backends. Shared code in parent classes may do static checks of configuration or cached state that is entirely self-contained to the parent class, and may not explicitly rely on abstract methods that must be implemented by children (though some methods may be overridden by children). Data that comes from backends must be passed in to these inherited methods as an argument.

Where possible, calculation code that requires maybe one or two bits of state is split into pure functions in a helper utility.

All of this is backed up by extending the hardware control tests to automatically run on both OT3 and OT2 to prevent regressions.

This shouldn't be merged into `merge-gen3-pipettes`, that's just targeted to get a cleaner diff for reviewing; this should not be merged until
- [x] #9062 is merged