### PR TITLE
feat(engine): allow compatible module loads and reloads

### DIFF
--- a/api/src/opentrons/hardware_control/modules/__init__.py
+++ b/api/src/opentrons/hardware_control/modules/__init__.py
@@ -11,6 +11,8 @@ from .types import (
     BundledFirmware,
     UpdateError,
     ModuleAtPort,
+    ModuleType,
+    ModuleModel,
 )
 
 __all__ = [
@@ -27,4 +29,6 @@ __all__ = [
     "UpdateError",
     "ModuleAtPort",
     "HeaterShaker",
+    "ModuleType",
+    "ModuleModel",
 ]

--- a/api/src/opentrons/hardware_control/modules/types.py
+++ b/api/src/opentrons/hardware_control/modules/types.py
@@ -34,6 +34,8 @@ LiveData = Mapping[str, Union[str, Mapping[str, Union[float, str, None]]]]
 E = TypeVar("E", bound="_ProvideLookup")
 
 
+# TODO(mc, 2022-01-18): this mixin is unnecessary; Python enums can
+# use parenthetical notation to access by value
 class _ProvideLookup(Enum):
     @classmethod
     def from_str(cls: Type[E], typename: str) -> "E":
@@ -97,6 +99,7 @@ class ModuleInfo(NamedTuple):
     serial: str  # the serial number
 
 
+# TODO(mc, 2022-01-18): replace with enum
 ModuleModel = Union[
     MagneticModuleModel, TemperatureModuleModel, ThermocyclerModuleModel
 ]

--- a/api/src/opentrons/protocol_api/load_info.py
+++ b/api/src/opentrons/protocol_api/load_info.py
@@ -62,4 +62,4 @@ class ModuleLoadInfo:
     module_model: ModuleModel
     deck_slot: DeckSlotName
     configuration: Optional[str]
-    module_serial: Optional[str]
+    module_serial: str

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -604,9 +604,7 @@ class ProtocolContext(CommandPublisher):
         module_loc = module.geometry.parent
         assert isinstance(module_loc, (int, str)), "Unexpected labware object parent"
         deck_slot = types.DeckSlotName.from_primitive(module_loc)
-        module_serial = (
-            module.module.device_info.get("serial") if module.module else None
-        )
+        module_serial = module.module.device_info["serial"]
 
         self.module_load_broker.publish(
             ModuleLoadInfo(

--- a/api/src/opentrons/protocol_engine/commands/load_module.py
+++ b/api/src/opentrons/protocol_engine/commands/load_module.py
@@ -59,9 +59,17 @@ class LoadModuleResult(BaseModel):
     # TODO (spp, 2021-11-24): Evaluate if this needs to be in the result
     definition: ModuleDefinition = Field(description="The definition of this module.")
 
-    # TODO (spp, 2021-11-24): Remove optional
-    moduleSerial: Optional[str] = Field(
-        None, description="Hardware serial number of the module, if connected."
+    model: ModuleModel = Field(
+        ...,
+        description=(
+            "Hardware model of the connected module. May be different than"
+            " the requested model if the attached module is still compatible."
+        ),
+    )
+
+    serialNumber: str = Field(
+        ...,
+        description="Hardware serial number of the connected module.",
     )
 
 
@@ -77,7 +85,8 @@ class LoadModuleImplementation(AbstractCommandImpl[LoadModuleParams, LoadModuleR
         )
         return LoadModuleResult(
             moduleId=loaded_module.module_id,
-            moduleSerial=loaded_module.module_serial,
+            serialNumber=loaded_module.serial_number,
+            model=loaded_module.definition.model,
             definition=loaded_module.definition,
         )
 

--- a/api/src/opentrons/protocol_engine/errors/__init__.py
+++ b/api/src/opentrons/protocol_engine/errors/__init__.py
@@ -20,7 +20,7 @@ from .exceptions import (
     ProtocolEngineStoppedError,
     WellOriginNotAllowedError,
     ModuleNotAttachedError,
-    ModuleDefinitionDoesNotExistError,
+    ModuleAlreadyPresentError,
     ModuleIsNotThermocyclerError,
     ThermocyclerNotOpenError,
 )
@@ -48,7 +48,7 @@ __all__ = [
     "ProtocolEngineStoppedError",
     "WellOriginNotAllowedError",
     "ModuleNotAttachedError",
-    "ModuleDefinitionDoesNotExistError",
+    "ModuleAlreadyPresentError",
     "ModuleIsNotThermocyclerError",
     "ThermocyclerNotOpenError",
     # error occurrence models

--- a/api/src/opentrons/protocol_engine/errors/exceptions.py
+++ b/api/src/opentrons/protocol_engine/errors/exceptions.py
@@ -93,11 +93,11 @@ class WellOriginNotAllowedError(ProtocolEngineError):
 
 
 class ModuleNotAttachedError(ProtocolEngineError):
-    """An error raised when no simulating or real modules are found attached."""
+    """An error raised when a requested module is not attached."""
 
 
-class ModuleDefinitionDoesNotExistError(ProtocolEngineError):
-    """An error raised when referencing a module definition that does not exist."""
+class ModuleAlreadyPresentError(ProtocolEngineError):
+    """An error raised when a module is already present in a requested location."""
 
 
 class ModuleIsNotThermocyclerError(ProtocolEngineError):

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -186,7 +186,13 @@ class EquipmentHandler:
                        If None, an ID will be generated.
 
         Returns:
-            A LoadedModuleData object
+            A LoadedModuleData object.
+
+        Raises:
+            ModuleNotAttachedError: A not-yet-assigned module matching the requested
+                parameters could not be found in the attached modules list.
+            ModuleAlreadyPresentError: A module of a different type is already
+                assigned to the requested location.
         """
         attached_modules = [
             HardwareModule(

--- a/api/src/opentrons/protocol_engine/execution/thermocycler_movement_flagger.py
+++ b/api/src/opentrons/protocol_engine/execution/thermocycler_movement_flagger.py
@@ -113,7 +113,9 @@ class ThermocyclerMovementFlagger:
         if module_model != PEModuleModel.THERMOCYCLER_MODULE_V1:
             return None  # Labware on a module, but not a Thermocycler.
 
-        thermocycler_serial = self._state_store.modules.get_serial(module_id=module_id)
+        thermocycler_serial = self._state_store.modules.get_serial_number(
+            module_id=module_id
+        )
         thermocycler = await self._find_thermocycler_by_serial(
             serial_number=thermocycler_serial
         )

--- a/api/src/opentrons/protocol_engine/resources/model_utils.py
+++ b/api/src/opentrons/protocol_engine/resources/model_utils.py
@@ -1,6 +1,7 @@
 """Unique ID generation provider."""
 from datetime import datetime, timezone
 from uuid import uuid4
+from typing import Optional
 
 
 class ModelUtils:
@@ -13,6 +14,14 @@ class ModelUtils:
         Uses UUIDv4 for safety in a multiprocessing environment.
         """
         return str(uuid4())
+
+    @staticmethod
+    def ensure_id(maybe_id: Optional[str] = None) -> str:
+        """Generate a unique identifier only if the given input is None.
+
+        Uses UUIDv4 for safety in a multiprocessing environment.
+        """
+        return maybe_id if maybe_id is not None else ModelUtils.generate_id()
 
     @staticmethod
     def get_timestamp() -> datetime:

--- a/api/src/opentrons/protocol_engine/resources/module_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/module_data_provider.py
@@ -1,8 +1,8 @@
 """Module data resource provider."""
-from opentrons.protocols.geometry.module_geometry import (
-    _load_v2_module_def,
-    module_model_from_string,
-)
+from typing import cast
+from opentrons_shared_data.module import load_definition
+from opentrons_shared_data.module.dev_types import ModuleModel as ModuleModelStr
+
 from ..types import ModuleModel, ModuleDefinition
 
 
@@ -10,9 +10,8 @@ class ModuleDataProvider:
     """Module data provider."""
 
     @staticmethod
-    def get_module_definition(model: ModuleModel) -> ModuleDefinition:
+    def get_definition(model: ModuleModel) -> ModuleDefinition:
         """Get the module definition."""
-        legacy_model = module_model_from_string(model.value)
-        return ModuleDefinition.parse_obj(
-            _load_v2_module_def(module_model=legacy_model)
-        )
+        model_name = cast(ModuleModelStr, model.value)
+        data = load_definition(model_or_loadname=model_name, version="2")
+        return ModuleDefinition.parse_obj(data)

--- a/api/src/opentrons/protocol_engine/state/__init__.py
+++ b/api/src/opentrons/protocol_engine/state/__init__.py
@@ -4,6 +4,7 @@ from .state import State, StateStore, StateView
 from .commands import CommandState, CommandView
 from .labware import LabwareState, LabwareView
 from .pipettes import PipetteState, PipetteView, HardwarePipette, CurrentWell
+from .modules import ModuleState, ModuleView, HardwareModule
 from .geometry import GeometryView, TipGeometry
 from .motion import MotionView, PipetteLocationData
 from .configs import EngineConfigs
@@ -16,14 +17,18 @@ __all__ = [
     # command state
     "CommandState",
     "CommandView",
-    # labware state
+    # labware state and values
     "LabwareState",
     "LabwareView",
-    # pipette state
+    # pipette state and values
     "PipetteState",
     "PipetteView",
     "HardwarePipette",
     "CurrentWell",
+    # module state and values
+    "ModuleState",
+    "ModuleView",
+    "HardwareModule",
     # computed geometry state
     "GeometryView",
     "TipGeometry",

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -46,7 +46,7 @@ _THERMOCYCLER_SLOT_TRANSITS_TO_DODGE = [
 
 @dataclass(frozen=True)
 class HardwareModule:
-    """Data describing from an actually connected module."""
+    """Data describing an actually connected module."""
 
     serial_number: str
     definition: ModuleDefinition

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -60,8 +60,6 @@ class ModuleState:
     hardware_module_by_slot: Dict[DeckSlotName, HardwareModule]
 
 
-# TODO(mc, 2021-12-28): ModuleStore is entirely untested. See
-# https://github.com/Opentrons/opentrons/issues/8914
 class ModuleStore(HasState[ModuleState], HandlesActions):
     """Module state container."""
 

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -1,12 +1,13 @@
 """Basic modules data state and store."""
 from dataclasses import dataclass
-from typing import Dict, List, Optional, NamedTuple
+from typing import Dict, List, NamedTuple, Sequence
 from numpy import array, dot
 
 from opentrons.types import DeckSlotName
 from ..types import (
     LoadedModule,
     ModuleModel,
+    ModuleType,
     ModuleDefinition,
     DeckSlotLocation,
     ModuleDimensions,
@@ -25,7 +26,7 @@ class SlotTransit(NamedTuple):
     end: DeckSlotName
 
 
-THERMOCYCLER_SLOT_TRANSITS_TO_DODGE = [
+_THERMOCYCLER_SLOT_TRANSITS_TO_DODGE = [
     SlotTransit(start=DeckSlotName.SLOT_1, end=DeckSlotName.FIXED_TRASH),
     SlotTransit(start=DeckSlotName.FIXED_TRASH, end=DeckSlotName.SLOT_1),
     SlotTransit(start=DeckSlotName.SLOT_4, end=DeckSlotName.FIXED_TRASH),
@@ -43,15 +44,20 @@ THERMOCYCLER_SLOT_TRANSITS_TO_DODGE = [
 ]
 
 
+@dataclass(frozen=True)
+class HardwareModule:
+    """Data describing from an actually connected module."""
+
+    serial_number: str
+    definition: ModuleDefinition
+
+
 @dataclass
 class ModuleState:
     """Basic module data state and getter methods."""
 
-    modules_by_id: Dict[str, LoadedModule]
-
-    # TODO (spp, 2021-11-24): remove definition_by_model and
-    #  unconditionally fetch definitions from ModuleDataProvider
-    definition_by_model: Dict[ModuleModel, ModuleDefinition]
+    slot_by_module_id: Dict[str, DeckSlotName]
+    hardware_module_by_slot: Dict[DeckSlotName, HardwareModule]
 
 
 # TODO(mc, 2021-12-28): ModuleStore is entirely untested. See
@@ -63,7 +69,7 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
 
     def __init__(self) -> None:
         """Initialize a ModuleStore and its state."""
-        self._state = ModuleState(modules_by_id={}, definition_by_model={})
+        self._state = ModuleState(slot_by_module_id={}, hardware_module_by_slot={})
 
     def handle_action(self, action: Action) -> None:
         """Modify state in reaction to an action."""
@@ -73,18 +79,15 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
     def _handle_command(self, command: Command) -> None:
         if isinstance(command.result, LoadModuleResult):
             module_id = command.result.moduleId
+            serial_number = command.result.serialNumber
+            definition = command.result.definition
+            slot_name = command.params.location.slotName
 
-            self._state.modules_by_id[module_id] = LoadedModule(
-                id=module_id,
-                model=command.params.model,
-                location=command.params.location,
-                serial=command.result.moduleSerial,
-                definition=command.result.definition,
+            self._state.slot_by_module_id[module_id] = slot_name
+            self._state.hardware_module_by_slot[slot_name] = HardwareModule(
+                serial_number=serial_number,
+                definition=definition,
             )
-
-            self._state.definition_by_model[
-                command.params.model
-            ] = command.result.definition
 
 
 class ModuleView(HasState[ModuleState]):
@@ -99,64 +102,52 @@ class ModuleView(HasState[ModuleState]):
     def get(self, module_id: str) -> LoadedModule:
         """Get module data by the module's unique identifier."""
         try:
-            return self._state.modules_by_id[module_id]
+            slot_name = self._state.slot_by_module_id[module_id]
+            attached_module = self._state.hardware_module_by_slot[slot_name]
+
         except KeyError:
             raise errors.ModuleDoesNotExistError(f"Module {module_id} not found.")
 
+        return LoadedModule.construct(
+            id=module_id,
+            model=attached_module.definition.model,
+            serialNumber=attached_module.serial_number,
+            location=DeckSlotLocation(slotName=slot_name),
+            definition=attached_module.definition,
+        )
+
     def get_all(self) -> List[LoadedModule]:
         """Get a list of all module entries in state."""
-        mod_list = []
-        for mod in self._state.modules_by_id.values():
-            mod_list.append(mod)
-        return mod_list
+        return [self.get(mod_id) for mod_id in self._state.slot_by_module_id.keys()]
 
     def get_location(self, module_id: str) -> DeckSlotLocation:
         """Get the slot location of the given module."""
-        return self.get(module_id=module_id).location
+        return self.get(module_id).location
 
     def get_model(self, module_id: str) -> ModuleModel:
         """Get the model name of the given module."""
-        return self.get(module_id=module_id).model
+        return self.get(module_id).model
 
-    def get_serial(self, module_id: str) -> str:
+    def get_serial_number(self, module_id: str) -> str:
         """Get the hardware serial number of the given module.
 
         If the underlying hardware API is simulating, this will be a dummy value
         provided by the hardware API.
         """
-        loaded_module = self.get(module_id=module_id)
-        # As far as we know, None can never actually happen. See todo in
-        # protocol_engine.types.LoadedModule.
-        assert loaded_module.serial is not None
-        return loaded_module.serial
+        return self.get(module_id).serialNumber
 
-    def get_definition_by_id(self, module_id: str) -> ModuleDefinition:
+    def get_definition(self, module_id: str) -> ModuleDefinition:
         """Module definition by ID."""
         return self.get(module_id).definition
-
-    def get_definition_by_model(self, model: ModuleModel) -> ModuleDefinition:
-        """Return module definition by model."""
-        try:
-            return self._state.definition_by_model[model]
-        except KeyError as e:
-            raise errors.ModuleDefinitionDoesNotExistError(
-                f"Module definition for matching {model} not found."
-            ) from e
-
-    def get_by_serial(self, serial: str) -> Optional[LoadedModule]:
-        """Get a loaded module by its serial number."""
-        for mod in self.get_all():
-            if mod.serial == serial:
-                return mod
-        return None
 
     def get_dimensions(self, module_id: str) -> ModuleDimensions:
         """Get the specified module's dimensions."""
         return self.get(module_id).definition.dimensions
 
+    # TODO(mc, 2022-01-19): this method is missing unit test coverage
     def get_module_offset(self, module_id: str) -> LabwareOffsetVector:
         """Get the module's offset vector computed with slot transform."""
-        definition = self.get_definition_by_id(module_id)
+        definition = self.get_definition(module_id)
         slot = self.get_location(module_id).slotName.value
         pre_transform = array(
             (definition.labwareOffset.x, definition.labwareOffset.y, 1)
@@ -170,23 +161,30 @@ class ModuleView(HasState[ModuleState]):
         xform = array(xforms_ser)
         xformed = dot(xform, pre_transform)  # type: ignore[no-untyped-call]
         return LabwareOffsetVector(
-            x=xformed[0], y=xformed[1], z=definition.labwareOffset.z
+            x=xformed[0],
+            y=xformed[1],
+            z=definition.labwareOffset.z,
         )
 
+    # TODO(mc, 2022-01-19): this method is missing unit test coverage and
+    # is also unused. Remove or add tests.
     def get_overall_height(self, module_id: str) -> float:
         """Get the height of the module."""
-        return self.get_definition_by_id(module_id).dimensions.bareOverallHeight
+        return self.get_dimensions(module_id).bareOverallHeight
 
+    # TODO(mc, 2022-01-19): this method is missing unit test coverage
     def get_height_over_labware(self, module_id: str) -> float:
         """Get the height of module parts above module labware base."""
-        return self.get_definition_by_id(module_id).dimensions.overLabwareHeight
+        return self.get_dimensions(module_id).overLabwareHeight
 
+    # TODO(mc, 2022-01-19): this method is missing unit test coverage and
+    # is also unused. Remove or add tests.
     def get_lid_height(self, module_id: str) -> float:
         """Get lid height if module is thermocycler."""
-        definition = self.get_definition_by_id(module_id)
+        definition = self.get_definition(module_id)
 
         if (
-            definition.moduleType == "thermocyclerModuleType"
+            definition.moduleType == ModuleType.THERMOCYCLER
             and hasattr(definition.dimensions, "lidHeight")
             and definition.dimensions.lidHeight is not None
         ):
@@ -196,17 +194,10 @@ class ModuleView(HasState[ModuleState]):
                 f"Cannot get lid height of {definition.moduleType}"
             )
 
-    def get_module_by_location(
-        self, deck_location: DeckSlotLocation
-    ) -> Optional[LoadedModule]:
-        """Get the module loaded in the given slot."""
-        for mod in self.get_all():
-            if mod.location == deck_location:
-                return mod
-        return None
-
     def should_dodge_thermocycler(
-        self, from_slot: DeckSlotName, to_slot: DeckSlotName
+        self,
+        from_slot: DeckSlotName,
+        to_slot: DeckSlotName,
     ) -> bool:
         """Decide if the requested path would cross the thermocycler, if installed.
 
@@ -217,6 +208,54 @@ class ModuleView(HasState[ModuleState]):
             mod.model for mod in all_mods
         ]:
             transit = (from_slot, to_slot)
-            if transit in THERMOCYCLER_SLOT_TRANSITS_TO_DODGE:
+            if transit in _THERMOCYCLER_SLOT_TRANSITS_TO_DODGE:
                 return True
         return False
+
+    def find_attached_module(
+        self,
+        model: ModuleModel,
+        location: DeckSlotLocation,
+        attached_modules: Sequence[HardwareModule],
+    ) -> HardwareModule:
+        """Get the next matching hardware module for the given model and location.
+
+        If a "matching" model is found already loaded in state at the requested
+        location, that hardware module will be "reused" and selected. This behavior
+        allows multiple load module commands to be issued while always preserving
+        module hardware instance to deck slot mapping, which is required for
+        multiples-of-a-module functionality.
+
+        Args:
+            model: The requested module model. The selected module may have a
+                different model if the definition lists the model as compatible.
+            location: The location the module will be assigned to.
+            attached_modules: All attached modules as reported by the HardwareAPI,
+                in the order in which they should be used.
+
+        Raises:
+            ModuleNotAttachedError: A not-yet-assigned module matching the requested
+                parameters could not be found in the attached modules list.
+            ModuleAlreadyPresentError: A module of a different type is already
+                assigned to the requested location.
+        """
+        existing_mod = self._state.hardware_module_by_slot.get(location.slotName)
+
+        if existing_mod:
+            existing_def = existing_mod.definition
+
+            if existing_def.model == model or model in existing_def.compatibleWith:
+                return existing_mod
+
+            else:
+                raise errors.ModuleAlreadyPresentError(
+                    f"A {existing_def.model.value} is already"
+                    f" present in {location.slotName.value}"
+                )
+
+        for m in attached_modules:
+            if m not in self._state.hardware_module_by_slot.values():
+                if model == m.definition.model or model in m.definition.compatibleWith:
+                    return m
+
+        raise errors.ModuleNotAttachedError(f"No available {model.value} found.")

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 from typing import Optional, Union, List, Dict, Any
 
 from opentrons.types import MountType, DeckSlotName
+from opentrons.hardware_control.modules import ModuleType as ModuleType
 
 
 class EngineStatus(str, Enum):
@@ -164,24 +165,29 @@ class ModuleDefinition(BaseModel):
     """Module definition class."""
 
     otSharedSchema: str = Field("module/schemas/2", description="The current schema.")
-    moduleType: str = Field(
-        ..., description="Module type (Temperature/ Magnetic/ Thermocycler)"
+    moduleType: ModuleType = Field(
+        ...,
+        description="Module type (Temperature/Magnetic/Thermocycler)",
     )
-    model: str = Field(..., description="Model name of the module")
+    model: ModuleModel = Field(..., description="Model name of the module")
     labwareOffset: LabwareOffsetVector = Field(
-        ..., description="Labware offset in x, y, z."
+        ...,
+        description="Labware offset in x, y, z.",
     )
     dimensions: ModuleDimensions = Field(..., description="Module dimension")
     calibrationPoint: ModuleCalibrationPoint = Field(
-        ..., description="Calibration point of module."
+        ...,
+        description="Calibration point of module.",
     )
     displayName: str = Field(..., description="Display name.")
     quirks: List[str] = Field(..., description="Module quirks")
     slotTransforms: Dict[str, Any] = Field(
-        ..., description="Dictionary of transforms for each slot."
+        ...,
+        description="Dictionary of transforms for each slot.",
     )
-    compatibleWith: List[str] = Field(
-        ..., description="List of module models this model is compatible with."
+    compatibleWith: List[ModuleModel] = Field(
+        ...,
+        description="List of module models this model is compatible with.",
     )
 
 
@@ -192,9 +198,7 @@ class LoadedModule(BaseModel):
     model: ModuleModel
     location: DeckSlotLocation
     definition: ModuleDefinition
-    # TODO(mc, 2021-11-24): make serial non-optional, here and in internal state.
-    # Our hardware backend always provides a module serial, even when it's simulated.
-    serial: Optional[str]
+    serialNumber: str
 
 
 class LabwareOffsetLocation(BaseModel):

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -126,6 +126,7 @@ class MotorAxis(str, Enum):
     RIGHT_PLUNGER = "rightPlunger"
 
 
+# TODO(mc, 2022-01-18): move enum to hardware control module
 class ModuleModel(str, Enum):
     """All available modules' models."""
 

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -255,7 +255,7 @@ class LegacyCommandMapper:
         # have similar info, with V2 having additional info fields.
         definition = self._module_definition_by_model.get(
             module_model
-        ) or self._module_data_provider.get_module_definition(module_model)
+        ) or self._module_data_provider.get_definition(module_model)
 
         load_module_command = pe_commands.LoadModule.construct(
             id=command_id,
@@ -273,8 +273,9 @@ class LegacyCommandMapper:
             ),
             result=pe_commands.LoadModuleResult.construct(
                 moduleId=module_id,
-                moduleSerial=module_load_info.module_serial,
+                serialNumber=module_load_info.module_serial,
                 definition=definition,
+                model=definition.model,
             ),
         )
         self._command_count["LOAD_MODULE"] = count + 1

--- a/api/tests/opentrons/protocol_engine/commands/test_load_module.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_module.py
@@ -28,7 +28,7 @@ async def test_load_module_implementation(
     movement: MovementHandler,
     pipetting: PipettingHandler,
     run_control: RunControlHandler,
-    tempdeck_v1_def: ModuleDefinition,
+    tempdeck_v2_def: ModuleDefinition,
 ) -> None:
     """A loadModule command should have an execution implementation."""
     subject = LoadModuleImplementation(
@@ -53,12 +53,15 @@ async def test_load_module_implementation(
     ).then_return(
         LoadedModuleData(
             module_id="module-id",
-            module_serial="mod-serial",
-            definition=tempdeck_v1_def,
+            serial_number="mod-serial",
+            definition=tempdeck_v2_def,
         )
     )
 
     result = await subject.execute(data)
     assert result == LoadModuleResult(
-        moduleId="module-id", moduleSerial="mod-serial", definition=tempdeck_v1_def
+        moduleId="module-id",
+        serialNumber="mod-serial",
+        model=ModuleModel.TEMPERATURE_MODULE_V2,
+        definition=tempdeck_v2_def,
     )

--- a/api/tests/opentrons/protocol_engine/conftest.py
+++ b/api/tests/opentrons/protocol_engine/conftest.py
@@ -3,10 +3,10 @@ import pytest
 from typing import AsyncGenerator
 
 from opentrons import config
+from opentrons_shared_data import load_shared_data
 from opentrons_shared_data.deck import load as load_deck
 from opentrons_shared_data.deck.dev_types import DeckDefinitionV2
 from opentrons_shared_data.labware import load_definition
-from opentrons_shared_data.module.dev_types import ModuleDefinitionV2
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.protocols.api_support.constants import (
     STANDARD_OT2_DECK,
@@ -79,7 +79,15 @@ def falcon_tuberack_def() -> LabwareDefinition:
     )
 
 
-@pytest.fixture
-def tempdeck_v1_def(minimal_module_def: ModuleDefinitionV2) -> ModuleDefinition:
+@pytest.fixture(scope="session")
+def tempdeck_v1_def() -> ModuleDefinition:
     """Get the definition of a V1 tempdeck."""
-    return ModuleDefinition.parse_obj(minimal_module_def)
+    definition = load_shared_data("module/definitions/2/temperatureModuleV1.json")
+    return ModuleDefinition.parse_raw(definition)
+
+
+@pytest.fixture(scope="session")
+def tempdeck_v2_def() -> ModuleDefinition:
+    """Get the definition of a V2 tempdeck."""
+    definition = load_shared_data("module/definitions/2/temperatureModuleV2.json")
+    return ModuleDefinition.parse_raw(definition)

--- a/api/tests/opentrons/protocol_engine/conftest.py
+++ b/api/tests/opentrons/protocol_engine/conftest.py
@@ -91,3 +91,24 @@ def tempdeck_v2_def() -> ModuleDefinition:
     """Get the definition of a V2 tempdeck."""
     definition = load_shared_data("module/definitions/2/temperatureModuleV2.json")
     return ModuleDefinition.parse_raw(definition)
+
+
+@pytest.fixture(scope="session")
+def magdeck_v1_def() -> ModuleDefinition:
+    """Get the definition of a V1 magdeck."""
+    definition = load_shared_data("module/definitions/2/magneticModuleV1.json")
+    return ModuleDefinition.parse_raw(definition)
+
+
+@pytest.fixture(scope="session")
+def magdeck_v2_def() -> ModuleDefinition:
+    """Get the definition of a V2 magdeck."""
+    definition = load_shared_data("module/definitions/2/magneticModuleV2.json")
+    return ModuleDefinition.parse_raw(definition)
+
+
+@pytest.fixture(scope="session")
+def thermocycler_v1_def() -> ModuleDefinition:
+    """Get the definition of a V2 thermocycler."""
+    definition = load_shared_data("module/definitions/2/thermocyclerModuleV1.json")
+    return ModuleDefinition.parse_raw(definition)

--- a/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
@@ -6,16 +6,10 @@ from opentrons.calibration_storage.helpers import uri_from_details
 
 from opentrons.types import Mount as HwMount, MountType, DeckSlotName
 from opentrons.hardware_control import API as HardwareAPI
-from opentrons.hardware_control.modules.types import TemperatureModuleModel, ModuleType
-from opentrons.hardware_control.modules import TempDeck
-from opentrons.drivers.rpi_drivers.types import USBPort
+from opentrons.hardware_control.modules import TempDeck, AbstractModule, ModuleType
 from opentrons.protocols.models import LabwareDefinition
 
 from opentrons.protocol_engine import errors
-from opentrons.protocol_engine.errors import (
-    LabwareDefinitionDoesNotExistError,
-    ModuleDefinitionDoesNotExistError,
-)
 from opentrons.protocol_engine.types import (
     DeckSlotLocation,
     ModuleLocation,
@@ -74,18 +68,13 @@ def module_data_provider(decoy: Decoy) -> ModuleDataProvider:
 
 
 @pytest.fixture
-async def simulating_module_fixture(hardware_api: HardwareAPI) -> TempDeck:
+async def temp_module_v1(decoy: Decoy) -> TempDeck:
     """Get a mocked out module fixture."""
-    mod = await TempDeck.build(
-        port="",
-        usb_port=USBPort(sub_names=[], name=""),
-        simulating=True,
-        execution_manager=hardware_api._execution_manager,
-        sim_model="temperatureModuleV1",
-    )
-    mod._device_info = {"serial": "abc123"}
-    mod._poller = None
-    return mod  # type: ignore[no-any-return]
+    temp_mod = decoy.mock(cls=TempDeck)
+    temp_mod.device_info = {"serial": "abc123"}  # type: ignore[misc]
+    decoy.when(temp_mod.model()).then_return("temperatureModuleV1")
+
+    return temp_mod
 
 
 @pytest.fixture
@@ -118,7 +107,7 @@ async def test_load_labware(
     decoy.when(model_utils.generate_id()).then_return("unique-id")
 
     decoy.when(state_store.labware.get_definition_by_uri(matchers.IsA(str))).then_raise(
-        LabwareDefinitionDoesNotExistError("oh no")
+        errors.LabwareDefinitionDoesNotExistError("oh no")
     )
 
     decoy.when(
@@ -169,7 +158,7 @@ async def test_load_labware_uses_provided_id(
 ) -> None:
     """It should use the provided ID rather than generating an ID for the labware."""
     decoy.when(state_store.labware.get_definition_by_uri(matchers.IsA(str))).then_raise(
-        LabwareDefinitionDoesNotExistError("oh no")
+        errors.LabwareDefinitionDoesNotExistError("oh no")
     )
 
     decoy.when(
@@ -413,64 +402,64 @@ async def test_load_pipette_raises_if_pipette_not_attached(
         )
 
 
-# TODO (spp, 2021-11-24): So many mocks or the possible need to mock out
-#  an internal method of subject is code smell.
 async def test_load_module(
     decoy: Decoy,
     model_utils: ModelUtils,
     state_store: StateStore,
-    module_data_provider: ModuleDataProvider,
-    tempdeck_v1_def: ModuleDefinition,
-    subject: EquipmentHandler,
     hardware_api: HardwareAPI,
-    simulating_module_fixture: TempDeck,
+    tempdeck_v1_def: ModuleDefinition,
+    temp_module_v1: AbstractModule,
+    subject: EquipmentHandler,
 ) -> None:
     """It should load a module, returning its ID, serial & definition in result."""
-    decoy.when(model_utils.generate_id()).then_return("unique-id")
     decoy.when(
         state_store.modules.get_definition_by_model(ModuleModel.TEMPERATURE_MODULE_V1)
-    ).then_raise(ModuleDefinitionDoesNotExistError("oh no"))
-
-    decoy.when(
-        module_data_provider.get_module_definition(ModuleModel.TEMPERATURE_MODULE_V1)
     ).then_return(tempdeck_v1_def)
 
     decoy.when(
         await hardware_api.find_modules(
-            by_model=TemperatureModuleModel.TEMPERATURE_V1,
+            by_model=ModuleModel.TEMPERATURE_MODULE_V1,  # type: ignore[arg-type]
             resolved_type=ModuleType.TEMPERATURE,
         )
-    ).then_return(([], simulating_module_fixture))
+    ).then_return(([temp_module_v1], None))
 
     expected_output = LoadedModuleData(
-        module_id="unique-id",
-        module_serial=simulating_module_fixture.device_info["serial"],
+        module_id="module-id",
+        module_serial="abc123",
         definition=tempdeck_v1_def,
     )
     result = await subject.load_module(
         model=ModuleModel.TEMPERATURE_MODULE_V1,
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
-        module_id=None,
+        module_id="module-id",
     )
     assert result == expected_output
 
 
-# TODO (spp, 2021-11-23): Add tests for fetching a match from available modules
-async def test_get_hardware_module(
+async def test_load_module_not_attached(
     decoy: Decoy,
-    subject: EquipmentHandler,
+    model_utils: ModelUtils,
+    state_store: StateStore,
     hardware_api: HardwareAPI,
-    simulating_module_fixture: TempDeck,
+    tempdeck_v2_def: ModuleDefinition,
+    temp_module_v1: AbstractModule,
+    subject: EquipmentHandler,
 ) -> None:
-    """It should fetch the matching module instance from attached modules."""
+    """It should raise if the right module isn't attached."""
+    decoy.when(
+        state_store.modules.get_definition_by_model(ModuleModel.TEMPERATURE_MODULE_V2)
+    ).then_return(tempdeck_v2_def)
+
     decoy.when(
         await hardware_api.find_modules(
-            by_model=TemperatureModuleModel.TEMPERATURE_V1,
+            by_model=ModuleModel.TEMPERATURE_MODULE_V2,  # type: ignore[arg-type]
             resolved_type=ModuleType.TEMPERATURE,
         )
-    ).then_return(([], simulating_module_fixture))
+    ).then_return(([temp_module_v1], None))
 
-    assert (
-        await subject._get_hardware_module(ModuleModel.TEMPERATURE_MODULE_V1)
-        == simulating_module_fixture
-    )
+    with pytest.raises(errors.ModuleNotAttachedError):
+        await subject.load_module(
+            model=ModuleModel.TEMPERATURE_MODULE_V2,
+            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+            module_id="module-id",
+        )

--- a/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
@@ -463,32 +463,3 @@ async def test_load_module(
         serial_number="serial-1",
         definition=tempdeck_v1_def,
     )
-
-
-# async def test_load_module_not_attached(
-#     decoy: Decoy,
-#     model_utils: ModelUtils,
-#     state_store: StateStore,
-#     hardware_api: HardwareAPI,
-#     tempdeck_v2_def: ModuleDefinition,
-#     temp_module_v1: AbstractModule,
-#     subject: EquipmentHandler,
-# ) -> None:
-#     """It should raise if the right module isn't attached."""
-#     decoy.when(
-#         state_store.modules.get_definition_by_model(ModuleModel.TEMPERATURE_MODULE_V2)
-#     ).then_return(tempdeck_v2_def)
-
-#     decoy.when(
-#         await hardware_api.find_modules(
-#             by_model=ModuleModel.TEMPERATURE_MODULE_V2,  # type: ignore[arg-type]
-#             resolved_type=ModuleType.TEMPERATURE,
-#         )
-#     ).then_return(([temp_module_v1], None))
-
-#     with pytest.raises(errors.ModuleNotAttachedError):
-#         await subject.load_module(
-#             model=ModuleModel.TEMPERATURE_MODULE_V2,
-#             location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
-#             module_id="module-id",
-#         )

--- a/api/tests/opentrons/protocol_engine/execution/test_thermocycler_movement_flagger.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_thermocycler_movement_flagger.py
@@ -103,9 +103,9 @@ async def test_raises_depending_on_thermocycler_lid_status(
     decoy.when(state_store.modules.get_model(module_id="module-id")).then_return(
         PEModuleModel.THERMOCYCLER_MODULE_V1,
     )
-    decoy.when(state_store.modules.get_serial(module_id="module-id")).then_return(
-        "module-serial"
-    )
+    decoy.when(
+        state_store.modules.get_serial_number(module_id="module-id")
+    ).then_return("module-serial")
 
     # These "type: ignore[misc]" comments let us assign to read-only properties,
     # necessary to work around Decoy not being able to stub properties.
@@ -139,9 +139,9 @@ async def test_raises_if_hardware_module_has_gone_missing(
     decoy.when(state_store.modules.get_model(module_id="module-id")).then_return(
         PEModuleModel.THERMOCYCLER_MODULE_V1,
     )
-    decoy.when(state_store.modules.get_serial(module_id="module-id")).then_return(
-        "module-serial"
-    )
+    decoy.when(
+        state_store.modules.get_serial_number(module_id="module-id")
+    ).then_return("module-serial")
 
     decoy.when(
         await hardware_api.find_modules(

--- a/api/tests/opentrons/protocol_engine/resources/test_model_utils.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_model_utils.py
@@ -21,3 +21,11 @@ def test_model_utils_generates_unique() -> None:
     unique_results = set(results)
 
     assert len(results) == len(unique_results)
+
+
+def test_model_utils_ensures_id() -> None:
+    """It should generate unique IDs only when needed."""
+    subject = ModelUtils()
+    assert subject.ensure_id("hello world") == "hello world"
+    assert RE_UUID.match(subject.ensure_id())
+    assert RE_UUID.match(subject.ensure_id(None))

--- a/api/tests/opentrons/protocol_engine/state/test_module_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_store.py
@@ -1,0 +1,56 @@
+"""Module state store tests."""
+from opentrons.types import DeckSlotName
+from opentrons.protocol_engine import commands, actions
+
+from opentrons.protocol_engine.types import (
+    DeckSlotLocation,
+    ModuleDefinition,
+    ModuleModel,
+)
+
+from opentrons.protocol_engine.state.modules import (
+    ModuleStore,
+    ModuleState,
+    HardwareModule,
+)
+
+
+def test_initial_state() -> None:
+    """It should initialize the module state."""
+    subject = ModuleStore()
+
+    assert subject.state == ModuleState(
+        slot_by_module_id={},
+        hardware_module_by_slot={},
+    )
+
+
+def test_load_module(tempdeck_v2_def: ModuleDefinition) -> None:
+    """It should handle a successful LoadModule command."""
+    action = actions.UpdateCommandAction(
+        command=commands.LoadModule.construct(  # type: ignore[call-arg]
+            params=commands.LoadModuleParams(
+                model=ModuleModel.TEMPERATURE_MODULE_V1,
+                location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+            ),
+            result=commands.LoadModuleResult(
+                moduleId="module-id",
+                model=ModuleModel.TEMPERATURE_MODULE_V2,
+                serialNumber="serial-number",
+                definition=tempdeck_v2_def,
+            ),
+        )
+    )
+
+    subject = ModuleStore()
+    subject.handle_action(action)
+
+    assert subject.state == ModuleState(
+        slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
+        hardware_module_by_slot={
+            DeckSlotName.SLOT_1: HardwareModule(
+                serial_number="serial-number",
+                definition=tempdeck_v2_def,
+            )
+        },
+    )

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -1,5 +1,6 @@
 """Tests for module state accessors in the protocol engine state store."""
 import pytest
+from pytest_lazyfixture import lazy_fixture  # type: ignore[import]
 from typing import Optional, Dict
 
 from opentrons.types import DeckSlotName
@@ -13,18 +14,20 @@ from opentrons.protocol_engine.types import (
 from opentrons.protocol_engine.state.modules import (
     ModuleView,
     ModuleState,
-    THERMOCYCLER_SLOT_TRANSITS_TO_DODGE as DODGE_SLOTS,
+    HardwareModule,
 )
 
 
 def get_module_view(
-    modules_by_id: Optional[Dict[str, LoadedModule]] = None,
-    definition_by_model: Optional[Dict[ModuleModel, ModuleDefinition]] = None,
+    slot_by_module_id: Optional[Dict[str, DeckSlotName]] = None,
+    hardware_module_by_slot: Optional[Dict[DeckSlotName, HardwareModule]] = None,
 ) -> ModuleView:
     """Get a module view test subject with the specified state."""
     state = ModuleState(
-        modules_by_id=modules_by_id or {}, definition_by_model=definition_by_model or {}
+        slot_by_module_id=slot_by_module_id or {},
+        hardware_module_by_slot=hardware_module_by_slot or {},
     )
+
     return ModuleView(state=state)
 
 
@@ -36,162 +39,136 @@ def test_initial_module_data_by_id() -> None:
         subject.get("helloWorld")
 
 
+def test_get_missing_hardware() -> None:
+    """It should raise if no loaded hardware."""
+    subject = get_module_view(slot_by_module_id={"module-id": DeckSlotName.SLOT_1})
+
+    with pytest.raises(errors.ModuleDoesNotExistError):
+        subject.get("module-id")
+
+
 def test_get_module_data(tempdeck_v1_def: ModuleDefinition) -> None:
     """It should get module data from state by ID."""
-    module_data = LoadedModule(
-        id="module-id",
-        model=ModuleModel.THERMOCYCLER_MODULE_V1,
-        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
-        serial="module-serial",
-        definition=tempdeck_v1_def,
+    subject = get_module_view(
+        slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
+        hardware_module_by_slot={
+            DeckSlotName.SLOT_1: HardwareModule(
+                serial_number="serial-number",
+                definition=tempdeck_v1_def,
+            )
+        },
     )
 
-    subject = get_module_view(modules_by_id={"module-id": module_data})
-    assert subject.get("module-id") == module_data
-
-
-def test_get_all_modules(tempdeck_v1_def: ModuleDefinition) -> None:
-    """It should return all modules in state."""
-    module1 = LoadedModule(
-        id="module-1",
+    assert subject.get("module-id") == LoadedModule(
+        id="module-id",
         model=ModuleModel.TEMPERATURE_MODULE_V1,
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
-        serial="serial-1",
+        serialNumber="serial-number",
         definition=tempdeck_v1_def,
     )
-    module2 = LoadedModule(
-        id="module-2",
-        model=ModuleModel.MAGNETIC_MODULE_V1,
-        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2),
-        serial="serial-2",
-        definition=tempdeck_v1_def,
-    )
-    subject = get_module_view(modules_by_id={"module-1": module1, "module-2": module2})
-    assert subject.get_all() == [module1, module2]
 
 
-def test_get_definition_by_id(tempdeck_v1_def: ModuleDefinition) -> None:
-    """It should return a loaded module's definition by ID."""
-    module_data = LoadedModule(
-        id="module-id",
-        model=ModuleModel.TEMPERATURE_MODULE_V2,
-        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
-        serial="module-serial",
-        definition=tempdeck_v1_def,
-    )
-    subject = get_module_view(modules_by_id={"module-id": module_data})
-    assert subject.get_definition_by_id("module-id") == tempdeck_v1_def
-
-
-def test_get_definition_by_model(tempdeck_v1_def: ModuleDefinition) -> None:
-    """It should return the cached definition of a specific module model."""
+def test_get_all_modules(
+    tempdeck_v1_def: ModuleDefinition,
+    tempdeck_v2_def: ModuleDefinition,
+) -> None:
+    """It should return all modules in state."""
     subject = get_module_view(
-        definition_by_model={ModuleModel.TEMPERATURE_MODULE_V1: tempdeck_v1_def}
-    )
-    assert (
-        subject.get_definition_by_model(ModuleModel.TEMPERATURE_MODULE_V1)
-        == tempdeck_v1_def
+        slot_by_module_id={
+            "module-1": DeckSlotName.SLOT_1,
+            "module-2": DeckSlotName.SLOT_2,
+        },
+        hardware_module_by_slot={
+            DeckSlotName.SLOT_1: HardwareModule(
+                serial_number="serial-1",
+                definition=tempdeck_v1_def,
+            ),
+            DeckSlotName.SLOT_2: HardwareModule(
+                serial_number="serial-2",
+                definition=tempdeck_v2_def,
+            ),
+        },
     )
 
+    assert subject.get_all() == [
+        LoadedModule(
+            id="module-1",
+            serialNumber="serial-1",
+            model=ModuleModel.TEMPERATURE_MODULE_V1,
+            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+            definition=tempdeck_v1_def,
+        ),
+        LoadedModule(
+            id="module-2",
+            serialNumber="serial-2",
+            model=ModuleModel.TEMPERATURE_MODULE_V2,
+            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2),
+            definition=tempdeck_v2_def,
+        ),
+    ]
 
-def test_raise_error_if_no_definition(tempdeck_v1_def: ModuleDefinition) -> None:
-    """It should raise if definition for given model not found."""
+
+def test_get_properties_by_id(
+    tempdeck_v1_def: ModuleDefinition,
+    tempdeck_v2_def: ModuleDefinition,
+) -> None:
+    """It should return a loaded module's properties by ID."""
     subject = get_module_view(
-        definition_by_model={ModuleModel.TEMPERATURE_MODULE_V1: tempdeck_v1_def}
+        slot_by_module_id={
+            "module-1": DeckSlotName.SLOT_1,
+            "module-2": DeckSlotName.SLOT_2,
+        },
+        hardware_module_by_slot={
+            DeckSlotName.SLOT_1: HardwareModule(
+                serial_number="serial-1",
+                definition=tempdeck_v1_def,
+            ),
+            DeckSlotName.SLOT_2: HardwareModule(
+                serial_number="serial-2",
+                definition=tempdeck_v2_def,
+            ),
+        },
     )
-    with pytest.raises(errors.ModuleDefinitionDoesNotExistError):
-        subject.get_definition_by_model(ModuleModel.MAGNETIC_MODULE_V2)
 
-
-def test_get_module_by_serial(tempdeck_v1_def: ModuleDefinition) -> None:
-    """It should get a particular loaded module for a given module serial number."""
-    module1 = LoadedModule(
-        id="module-1",
-        model=ModuleModel.TEMPERATURE_MODULE_V2,
-        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
-        serial="serial-1",
-        definition=tempdeck_v1_def,
+    assert subject.get_definition("module-1") == tempdeck_v1_def
+    assert subject.get_dimensions("module-1") == tempdeck_v1_def.dimensions
+    assert subject.get_model("module-1") == ModuleModel.TEMPERATURE_MODULE_V1
+    assert subject.get_serial_number("module-1") == "serial-1"
+    assert subject.get_location("module-1") == DeckSlotLocation(
+        slotName=DeckSlotName.SLOT_1
     )
-    module2 = LoadedModule(
-        id="module-2",
-        model=ModuleModel.MAGNETIC_MODULE_V2,
-        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2),
-        serial="serial-2",
-        definition=tempdeck_v1_def,
-    )
-    subject = get_module_view(modules_by_id={"module-1": module1, "module-2": module2})
-    assert subject.get_by_serial("serial-2") == module2
 
-
-def test_get_location(tempdeck_v1_def: ModuleDefinition) -> None:
-    """It should return the deck slot location of the module."""
-    module_id = "unique-id"
-    module = LoadedModule(
-        id=module_id,
-        model=ModuleModel.MAGNETIC_MODULE_V2,
-        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2),
-        serial="serial-1",
-        definition=tempdeck_v1_def,
-    )
-    subject = get_module_view(modules_by_id={module_id: module})
-    assert subject.get_location(module_id=module_id) == DeckSlotLocation(
+    assert subject.get_definition("module-2") == tempdeck_v2_def
+    assert subject.get_dimensions("module-2") == tempdeck_v2_def.dimensions
+    assert subject.get_model("module-2") == ModuleModel.TEMPERATURE_MODULE_V2
+    assert subject.get_serial_number("module-2") == "serial-2"
+    assert subject.get_location("module-2") == DeckSlotLocation(
         slotName=DeckSlotName.SLOT_2
     )
 
 
-def test_get_model(tempdeck_v1_def: ModuleDefinition) -> None:
-    """It should return the model of the loaded module."""
-    module_id = "unique-id"
-    module = LoadedModule(
-        id=module_id,
-        model=ModuleModel.MAGNETIC_MODULE_V2,
-        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2),
-        serial="serial-1",
-        definition=tempdeck_v1_def,
-    )
-    subject = get_module_view(modules_by_id={module_id: module})
-    assert subject.get_model(module_id=module_id) == ModuleModel.MAGNETIC_MODULE_V2
-
-
-def test_get_serial(tempdeck_v1_def: ModuleDefinition) -> None:
-    """It should return the serial number of the loaded module."""
-    module_id = "unique-id"
-    module = LoadedModule(
-        id=module_id,
-        model=ModuleModel.MAGNETIC_MODULE_V2,
-        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2),
-        serial="serial-1",
-        definition=tempdeck_v1_def,
-    )
-    subject = get_module_view(modules_by_id={module_id: module})
-    assert subject.get_serial(module_id=module_id) == "serial-1"
-
-
-def test_get_dimensions(tempdeck_v1_def: ModuleDefinition) -> None:
-    """It should return the dimensions of the specified module."""
-    module_id = "unique-id"
-    module = LoadedModule(
-        id=module_id,
-        model=ModuleModel.MAGNETIC_MODULE_V2,
-        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2),
-        serial="serial-1",
-        definition=tempdeck_v1_def,
-    )
-    subject = get_module_view(modules_by_id={module_id: module})
-    assert subject.get_dimensions(module_id=module_id) == tempdeck_v1_def.dimensions
-
-
 @pytest.mark.parametrize(
-    argnames="from_slot, to_slot, should_dodge",
+    argnames=["from_slot", "to_slot", "should_dodge"],
     argvalues=[
-        [DODGE_SLOTS[0].start, DODGE_SLOTS[0].end, True],
-        [DODGE_SLOTS[2].start, DODGE_SLOTS[2].end, True],
-        [DODGE_SLOTS[5].start, DODGE_SLOTS[5].end, True],
-        [DeckSlotName.SLOT_2, DeckSlotName.SLOT_4, False],
+        (DeckSlotName.SLOT_1, DeckSlotName.FIXED_TRASH, True),
+        (DeckSlotName.FIXED_TRASH, DeckSlotName.SLOT_1, True),
+        (DeckSlotName.SLOT_4, DeckSlotName.FIXED_TRASH, True),
+        (DeckSlotName.FIXED_TRASH, DeckSlotName.SLOT_4, True),
+        (DeckSlotName.SLOT_4, DeckSlotName.SLOT_9, True),
+        (DeckSlotName.SLOT_9, DeckSlotName.SLOT_4, True),
+        (DeckSlotName.SLOT_4, DeckSlotName.SLOT_8, True),
+        (DeckSlotName.SLOT_8, DeckSlotName.SLOT_4, True),
+        (DeckSlotName.SLOT_1, DeckSlotName.SLOT_8, True),
+        (DeckSlotName.SLOT_8, DeckSlotName.SLOT_1, True),
+        (DeckSlotName.SLOT_4, DeckSlotName.SLOT_11, True),
+        (DeckSlotName.SLOT_11, DeckSlotName.SLOT_4, True),
+        (DeckSlotName.SLOT_1, DeckSlotName.SLOT_11, True),
+        (DeckSlotName.SLOT_11, DeckSlotName.SLOT_1, True),
+        (DeckSlotName.SLOT_2, DeckSlotName.SLOT_4, False),
     ],
 )
 def test_thermocycler_dodging(
-    tempdeck_v1_def: ModuleDefinition,
+    thermocycler_v1_def: ModuleDefinition,
     from_slot: DeckSlotName,
     to_slot: DeckSlotName,
     should_dodge: bool,
@@ -201,16 +178,164 @@ def test_thermocycler_dodging(
     It should return True if thermocycler exists and movement is between bad pairs of
     slot locations.
     """
-    module_data = LoadedModule(
-        id="module-id",
-        model=ModuleModel.THERMOCYCLER_MODULE_V1,
-        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
-        serial="module-serial",
-        definition=tempdeck_v1_def,
+    subject = get_module_view(
+        slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
+        hardware_module_by_slot={
+            DeckSlotName.SLOT_1: HardwareModule(
+                serial_number="serial-number",
+                definition=thermocycler_v1_def,
+            )
+        },
     )
 
-    subject = get_module_view(modules_by_id={"module-id": module_data})
     assert (
         subject.should_dodge_thermocycler(from_slot=from_slot, to_slot=to_slot)
         is should_dodge
     )
+
+
+def test_find_attached_module_rejects_missing() -> None:
+    """It should raise if the correct module isn't attached."""
+    subject = get_module_view()
+
+    with pytest.raises(errors.ModuleNotAttachedError):
+        subject.find_attached_module(
+            model=ModuleModel.TEMPERATURE_MODULE_V1,
+            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+            attached_modules=[],
+        )
+
+
+@pytest.mark.parametrize(
+    argnames=["requested_model", "attached_definition"],
+    argvalues=[
+        (ModuleModel.TEMPERATURE_MODULE_V1, lazy_fixture("tempdeck_v1_def")),
+        (ModuleModel.TEMPERATURE_MODULE_V2, lazy_fixture("tempdeck_v2_def")),
+        (ModuleModel.TEMPERATURE_MODULE_V1, lazy_fixture("tempdeck_v2_def")),
+        (ModuleModel.TEMPERATURE_MODULE_V2, lazy_fixture("tempdeck_v1_def")),
+        (ModuleModel.MAGNETIC_MODULE_V1, lazy_fixture("magdeck_v1_def")),
+        (ModuleModel.MAGNETIC_MODULE_V2, lazy_fixture("magdeck_v2_def")),
+        (ModuleModel.THERMOCYCLER_MODULE_V1, lazy_fixture("thermocycler_v1_def")),
+    ],
+)
+def test_find_attached_module(
+    requested_model: ModuleModel,
+    attached_definition: ModuleDefinition,
+) -> None:
+    """It should return the first attached module that matches."""
+    subject = get_module_view()
+
+    attached_modules = [
+        HardwareModule(serial_number="serial-1", definition=attached_definition),
+        HardwareModule(serial_number="serial-2", definition=attached_definition),
+    ]
+
+    result = subject.find_attached_module(
+        model=requested_model,
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+        attached_modules=attached_modules,
+    )
+
+    assert result == attached_modules[0]
+
+
+def test_find_attached_module_skips_non_matching(
+    magdeck_v1_def: ModuleDefinition,
+    magdeck_v2_def: ModuleDefinition,
+) -> None:
+    """It should skip over non-matching modules."""
+    subject = get_module_view()
+
+    attached_modules = [
+        HardwareModule(serial_number="serial-1", definition=magdeck_v1_def),
+        HardwareModule(serial_number="serial-2", definition=magdeck_v2_def),
+    ]
+
+    result = subject.find_attached_module(
+        model=ModuleModel.MAGNETIC_MODULE_V2,
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+        attached_modules=attached_modules,
+    )
+
+    assert result == attached_modules[1]
+
+
+def test_find_attached_module_skips_already_loaded(
+    magdeck_v1_def: ModuleDefinition,
+) -> None:
+    """It should skip over already assigned modules."""
+    subject = get_module_view(
+        hardware_module_by_slot={
+            DeckSlotName.SLOT_1: HardwareModule(
+                serial_number="serial-1",
+                definition=magdeck_v1_def,
+            )
+        }
+    )
+
+    attached_modules = [
+        HardwareModule(serial_number="serial-1", definition=magdeck_v1_def),
+        HardwareModule(serial_number="serial-2", definition=magdeck_v1_def),
+    ]
+
+    result = subject.find_attached_module(
+        model=ModuleModel.MAGNETIC_MODULE_V1,
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
+        attached_modules=attached_modules,
+    )
+
+    assert result == attached_modules[1]
+
+
+def test_find_attached_module_reuses_already_loaded(
+    magdeck_v1_def: ModuleDefinition,
+) -> None:
+    """It should reuse over already assigned modules in the same location."""
+    subject = get_module_view(
+        hardware_module_by_slot={
+            DeckSlotName.SLOT_1: HardwareModule(
+                serial_number="serial-1",
+                definition=magdeck_v1_def,
+            )
+        }
+    )
+
+    attached_modules = [
+        HardwareModule(serial_number="serial-1", definition=magdeck_v1_def),
+        HardwareModule(serial_number="serial-2", definition=magdeck_v1_def),
+    ]
+
+    result = subject.find_attached_module(
+        model=ModuleModel.MAGNETIC_MODULE_V1,
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+        attached_modules=attached_modules,
+    )
+
+    assert result == attached_modules[0]
+
+
+def test_find_attached_module_rejects_location_reassignment(
+    magdeck_v1_def: ModuleDefinition,
+    tempdeck_v1_def: ModuleDefinition,
+) -> None:
+    """It should raise if a non-matching module is already present in the slot."""
+    subject = get_module_view(
+        hardware_module_by_slot={
+            DeckSlotName.SLOT_1: HardwareModule(
+                serial_number="serial-1",
+                definition=magdeck_v1_def,
+            )
+        }
+    )
+
+    attached_modules = [
+        HardwareModule(serial_number="serial-1", definition=magdeck_v1_def),
+        HardwareModule(serial_number="serial-2", definition=tempdeck_v1_def),
+    ]
+
+    with pytest.raises(errors.ModuleAlreadyPresentError):
+        subject.find_attached_module(
+            model=ModuleModel.TEMPERATURE_MODULE_V1,
+            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+            attached_modules=attached_modules,
+        )

--- a/api/tests/opentrons/protocol_engine/state/test_state_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_state_store.py
@@ -18,8 +18,7 @@ def change_notifier(decoy: Decoy) -> ChangeNotifier:
 
 @pytest.fixture
 def subject(
-    change_notifier: ChangeNotifier,
-    standard_deck_def: DeckDefinitionV2,
+    change_notifier: ChangeNotifier, standard_deck_def: DeckDefinitionV2
 ) -> StateStore:
     """Get a StateStore test subject."""
     return StateStore(

--- a/api/tests/opentrons/protocol_engine/state/test_state_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_state_store.py
@@ -18,7 +18,8 @@ def change_notifier(decoy: Decoy) -> ChangeNotifier:
 
 @pytest.fixture
 def subject(
-    change_notifier: ChangeNotifier, standard_deck_def: DeckDefinitionV2
+    change_notifier: ChangeNotifier,
+    standard_deck_def: DeckDefinitionV2,
 ) -> StateStore:
     """Get a StateStore test subject."""
     return StateStore(

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -304,8 +304,9 @@ def test_map_module_load(
         module_serial="module-serial",
     )
     decoy.when(
-        module_data_provider.get_module_definition(ModuleModel.MAGNETIC_MODULE_V2)
+        module_data_provider.get_definition(ModuleModel.MAGNETIC_MODULE_V2)
     ).then_return(test_definition)
+
     expected_output = pe_commands.LoadModule.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
@@ -320,8 +321,9 @@ def test_map_module_load(
         ),
         result=pe_commands.LoadModuleResult.construct(
             moduleId=matchers.IsA(str),
-            moduleSerial="module-serial",
+            serialNumber="module-serial",
             definition=test_definition,
+            model=test_definition.model,
         ),
     )
     output = LegacyCommandMapper(

--- a/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
@@ -301,7 +301,7 @@ async def test_module_load_broker_messages(
         module_model=LegacyMagneticModuleModel.MAGNETIC_V2,
         deck_slot=DeckSlotName.SLOT_1,
         configuration=None,
-        module_serial=None,
+        module_serial="serial-number",
     )
     engine_command = pe_commands.Custom(
         id="command-id",

--- a/shared-data/python/mypy.ini
+++ b/shared-data/python/mypy.ini
@@ -12,10 +12,6 @@ warn_return_any = False
 [mypy-opentrons_shared_data.labware.*]
 warn_return_any = False
 
-[mypy-opentrons_shared_data.module.*]
-disallow_untyped_defs = False
-warn_return_any = False
-
 [mypy-opentrons_shared_data.pipette.*]
 no_implicit_optional = False
 warn_return_any = False

--- a/shared-data/python/opentrons_shared_data/module/__init__.py
+++ b/shared-data/python/opentrons_shared_data/module/__init__.py
@@ -1,16 +1,13 @@
 """ opentrons_shared_data.module: functions and types for module defs """
-
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING, Union, overload
+from typing import Union, cast, overload
 
 from ..load import load_shared_data
-
-if TYPE_CHECKING:
-    from .dev_types import (
-        SchemaVersions, ModuleSchema, SchemaV1, SchemaV2,
-        ModuleDefinitionV1, ModuleDefinitionV2, ModuleModel
-    )
+from .dev_types import (
+    SchemaVersions, ModuleSchema, SchemaV1, SchemaV2,
+    ModuleDefinitionV1, ModuleDefinitionV2, ModuleModel
+)
 
 
 class ModuleNotFoundError(KeyError):
@@ -28,33 +25,33 @@ class ModuleNotFoundError(KeyError):
             f'at version {self.requested_version}'
 
 
-def load_schema(version: 'SchemaVersions') -> 'ModuleSchema':
+def load_schema(version: SchemaVersions) -> ModuleSchema:
     path = Path('module') / 'schemas' / f'{version}.json'
-    return json.loads(load_shared_data(path))
+    return cast(ModuleSchema, json.loads(load_shared_data(path)))
 
 
 @overload
 def load_definition(
-        version: 'SchemaV1', model_or_loadname: str) -> 'ModuleDefinitionV1':
+        version: SchemaV1, model_or_loadname: str) -> ModuleDefinitionV1:
     ...
 
 
 @overload
 def load_definition(
-        version: 'SchemaV2',
-        model_or_loadname: 'ModuleModel') -> 'ModuleDefinitionV2':
+        version: SchemaV2,
+        model_or_loadname: ModuleModel) -> ModuleDefinitionV2:
     ...
 
 
 def load_definition(
-    version: Union['SchemaV1', 'SchemaV2'],
-    model_or_loadname: Union[str, 'ModuleModel'],
-) -> Union['ModuleDefinitionV1', 'ModuleDefinitionV2']:
+    version: Union[SchemaV1, SchemaV2],
+    model_or_loadname: Union[str, ModuleModel],
+) -> Union[ModuleDefinitionV1, ModuleDefinitionV2]:
     if version == '1':
         path = Path('module') / 'definitions' / '1.json'
         data = json.loads(load_shared_data(path))
         try:
-            return data[model_or_loadname]
+            return cast(ModuleDefinitionV1, data[model_or_loadname])
         except KeyError:
             raise ModuleNotFoundError('1', model_or_loadname)
     else:
@@ -63,4 +60,4 @@ def load_definition(
             data = load_shared_data(path)
         except FileNotFoundError:
             raise ModuleNotFoundError('2', model_or_loadname)
-        return json.loads(data)
+        return cast(ModuleDefinitionV2, json.loads(data))

--- a/shared-data/python/opentrons_shared_data/module/__init__.py
+++ b/shared-data/python/opentrons_shared_data/module/__init__.py
@@ -2,7 +2,7 @@
 
 import json
 from pathlib import Path
-from typing import overload, TYPE_CHECKING
+from typing import TYPE_CHECKING, Union, overload
 
 from ..load import load_shared_data
 
@@ -46,18 +46,21 @@ def load_definition(
     ...
 
 
-def load_definition(version, model_or_definition):
+def load_definition(
+    version: Union['SchemaV1', 'SchemaV2'],
+    model_or_loadname: Union[str, 'ModuleModel'],
+) -> Union['ModuleDefinitionV1', 'ModuleDefinitionV2']:
     if version == '1':
         path = Path('module') / 'definitions' / '1.json'
         data = json.loads(load_shared_data(path))
         try:
-            return data[model_or_definition]
+            return data[model_or_loadname]
         except KeyError:
-            raise ModuleNotFoundError('1', model_or_definition)
+            raise ModuleNotFoundError('1', model_or_loadname)
     else:
-        path = Path(f'module/definitions/2/{model_or_definition}.json')
+        path = Path(f'module/definitions/2/{model_or_loadname}.json')
         try:
             data = load_shared_data(path)
         except FileNotFoundError:
-            raise ModuleNotFoundError('2', model_or_definition)
+            raise ModuleNotFoundError('2', model_or_loadname)
         return json.loads(data)


### PR DESCRIPTION
## Overview

This PR makes the following two changes to ProtocolEngine's load module logic:

- Add support for the module definitions' `compatibleWith` field when selecting modules to load (Closes #8914)
- Treat module hardware (via serial number) linking to deck location (via slot name) as idempotent, allowing multiple load labware commands referencing the same slot/module combo to succeed (Closes #8994)

Along the way, it adds a lot of missing unit tests and addresses various TODO comments from the original load module implementation pass.

## Client-side follow ups

- The shape of `LoadModuleResult` has changed:
    - The `moduleSerial` field has been renamed to `serialNumber`
    - A `model` field has been added to reflect **actual** attached model, which may be different from the requested model in `LoadModuleParams`

## Review requests

Smoke test against a real robot, the emulator, and probably the dev server. Things to look out / check for :

- Weird `KeyError`s popping up when they didn't used to
- Problems with protocol analysis
- Problems with mapping PAPIv2 run results to the HTTP API
- Multiple LPC runs with a module protocol should work
- MoaM should continue to function without issue

## Risk assessment

Medium. I think this PR does a good job of moving some of the weirder parts of this logic to places where it can be heavily covered with opaque unit tests, but the parts of the HardwareAPI that deal with modules are not very geared to protocol engine usage.
