### PR TITLE
refactor(api): smoothie emulator is extracted from emulator app.

### DIFF
--- a/api/src/opentrons/hardware_control/emulation/app.py
+++ b/api/src/opentrons/hardware_control/emulation/app.py
@@ -2,11 +2,8 @@ import asyncio
 import logging
 
 from opentrons.hardware_control.emulation.module_server import ModuleStatusServer
-from opentrons.hardware_control.emulation.parser import Parser
 from opentrons.hardware_control.emulation.proxy import Proxy
-from opentrons.hardware_control.emulation.run_emulator import run_emulator_server
 from opentrons.hardware_control.emulation.settings import Settings
-from opentrons.hardware_control.emulation.smoothie import SmoothieEmulator
 from opentrons.hardware_control.emulation.types import ModuleType
 
 logger = logging.getLogger(__name__)
@@ -23,9 +20,6 @@ class Application:
         """
         self._settings = settings
         self._status_server = ModuleStatusServer(settings.module_server)
-        self._smoothie_emulator = SmoothieEmulator(
-            parser=Parser(), settings=settings.smoothie
-        )
         self._magdeck = Proxy(
             ModuleType.Magnetic, self._status_server, self._settings.magdeck_proxy
         )
@@ -49,11 +43,6 @@ class Application:
         """Run the application."""
         await asyncio.gather(
             self._status_server.run(),
-            run_emulator_server(
-                host=self._settings.smoothie.host,
-                port=self._settings.smoothie.port,
-                emulator=self._smoothie_emulator,
-            ),
             self._magdeck.run(),
             self._temperature.run(),
             self._thermocycler.run(),

--- a/api/src/opentrons/hardware_control/emulation/scripts/run_smoothie.py
+++ b/api/src/opentrons/hardware_control/emulation/scripts/run_smoothie.py
@@ -1,0 +1,37 @@
+"""Script for starting up a python smoothie emulator."""
+import logging
+import asyncio
+
+from opentrons.hardware_control.emulation.smoothie import SmoothieEmulator
+from opentrons.hardware_control.emulation.parser import Parser
+
+
+from opentrons.hardware_control.emulation.run_emulator import run_emulator_server
+from opentrons.hardware_control.emulation.settings import Settings
+
+
+async def run(settings: Settings) -> None:
+    """Run the smoothie emulator.
+
+    Args:
+        settings: emulator settings
+
+    Returns:
+        None
+    """
+    smoothie = SmoothieEmulator(parser=Parser(), settings=settings.smoothie)
+    await run_emulator_server(
+        host=settings.smoothie.host,
+        port=settings.smoothie.port,
+        emulator=smoothie,
+    )
+
+
+def main() -> None:
+    """Entry point."""
+    logging.basicConfig(format="%(asctime)s:%(message)s", level=logging.DEBUG)
+    asyncio.run(run(Settings()))
+
+
+if __name__ == "__main__":
+    main()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,16 @@ services:
       - '9003:9003'
       - '9004:9004'
       - '9995:9995'
-      - '9996:9996'
       - '9997:9997'
       - '9998:9998'
       - '9999:9999'
+    networks:
+      - container-network
+  smoothie:
+    build: .
+    command: python3 -m opentrons.hardware_control.emulation.scripts.run_smoothie
+    ports:
+      - '9996:9996'
     # Uncomment lines below to override the pipette(s) loaded by emulator
     #environment:
     #  OT_EMULATOR_smoothie: '{"right": {"model": "p300_multi"}, "left": {"model": "p20_single_v2.0"}}'
@@ -26,12 +32,13 @@ services:
       - '31950:31950'
     environment:
       OT_API_CONFIG_DIR: /config
-      OT_SMOOTHIE_EMULATOR_URI: socket://emulator:9996
+      OT_SMOOTHIE_EMULATOR_URI: socket://smoothie:9996
       OT_EMULATOR_module_server: '{"host": "emulator"}'
     networks:
       - container-network
     depends_on:
       - 'emulator'
+      - 'smoothie'
     volumes:
       - .opentrons_config:/config:rw
   tempdeck:

--- a/g-code-testing/g_code_parsing/g_code_engine.py
+++ b/g-code-testing/g_code_parsing/g_code_engine.py
@@ -71,9 +71,9 @@ class GCodeEngine:
             async def _async_entry():
                 await asyncio.gather(
                     run_smoothie.run(self._config),
-                    run_app.run(self._config,
-                                modules=[m.value for m in modules])
+                    run_app.run(self._config, modules=[m.value for m in modules]),
                 )
+
             asyncio.run(_async_entry())
 
         proc = Process(target=_run_app)

--- a/g-code-testing/g_code_parsing/g_code_engine.py
+++ b/g-code-testing/g_code_parsing/g_code_engine.py
@@ -17,7 +17,7 @@ from opentrons.hardware_control.emulation.module_server.helpers import (
     wait_emulators,
     ModuleStatusClient,
 )
-from opentrons.hardware_control.emulation.scripts import run_app
+from opentrons.hardware_control.emulation.scripts import run_app, run_smoothie
 from opentrons.hardware_control import API, ThreadManager
 from g_code_parsing.g_code_program.g_code_program import (
     GCodeProgram,
@@ -68,7 +68,13 @@ class GCodeEngine:
 
         # Entry point for the emulator app process
         def _run_app():
-            asyncio.run(run_app.run(self._config, modules=[m.value for m in modules]))
+            async def _async_entry():
+                await asyncio.gather(
+                    run_smoothie.run(self._config),
+                    run_app.run(self._config,
+                                modules=[m.value for m in modules])
+                )
+            asyncio.run(_async_entry())
 
         proc = Process(target=_run_app)
         proc.daemon = True


### PR DESCRIPTION
# Overview

So there's new thing called the OT3. It doesn't have a Smoothie. So like... we'll need to be able like run emulation differently for ot2 and ot3. like!

# Changelog

- Smoothie emulator is not started by the app that runs the proxies.
- Docker compose changes to start the smoothie emulator separtely.
- G-code testing and integration testing setup changes to support this change.

# Review requests

Is this what you meant @DerekMaggio ?

# Risk assessment

Low