### PR TITLE
fix(api):  Fix simulator home and is_homed

### DIFF
--- a/api/src/opentrons/drivers/smoothie_drivers/simulator.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/simulator.py
@@ -20,7 +20,7 @@ class SimulatingDriver:
 
     async def home(self, axis: str = AXES, disabled: str = DISABLE_AXES) -> None:
         for ax in axis:
-            self._homed_flags[axis] = True
+            self._homed_flags[ax] = True
 
     async def _smoothie_reset(self) -> None:
         self._homed_flags.clear()

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -193,11 +193,12 @@ class Simulator:
 
     async def home(self, axes: List[str] = None) -> Dict[str, float]:
         # driver_3_0-> HOMED_POSITION
-        checked_axes = axes or "XYZABC"
+        checked_axes = ''.join(axes) if axes else "XYZABC"
         self._position.update(
             {ax: self._smoothie_driver.homed_position[ax] for ax in checked_axes}
         )
         self._engaged_axes.update({ax: True for ax in checked_axes})
+        await self._smoothie_driver.home(axis=checked_axes)
         return self._position
 
     async def fast_home(self, axis: Sequence[str], margin: float) -> Dict[str, float]:

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -193,7 +193,7 @@ class Simulator:
 
     async def home(self, axes: List[str] = None) -> Dict[str, float]:
         # driver_3_0-> HOMED_POSITION
-        checked_axes = ''.join(axes) if axes else "XYZABC"
+        checked_axes = "".join(axes) if axes else "XYZABC"
         self._position.update(
             {ax: self._smoothie_driver.homed_position[ax] for ax in checked_axes}
         )


### PR DESCRIPTION
# Overview

Labware position check was not able to run using `make dev`. This fixes that.

closes #8969 

# Changelog

Fix some minor bugs in how we were homing and checking if homed in the simulator.

# Review requests

I tested by running App and Robot Server using make dev. I loaded a proto and initiated LPC. This change enabled me to proceed with the check.

# Risk assessment

Just simulation.