### PR TITLE
chore(shared-data): default shared-data mypy to strict and add overrides

### DIFF
--- a/shared-data/python/Makefile
+++ b/shared-data/python/Makefile
@@ -90,7 +90,7 @@ $(sdist_file): setup.py $(py_sources)
 
 .PHONY: lint
 lint: $(py_sources)
-	$(python) -m mypy opentrons_shared_data
+	$(python) -m mypy opentrons_shared_data tests
 	$(python) -m flake8 opentrons_shared_data tests setup.py
 
 .PHONY: push-no-restart

--- a/shared-data/python/mypy.ini
+++ b/shared-data/python/mypy.ini
@@ -1,0 +1,43 @@
+[mypy]
+show_error_codes = True
+warn_unused_configs = True
+strict = True
+
+# TODO(mc, 2022-01-20): fix and remove all of the overrides belo
+# overrides below whenever able
+
+[mypy-opentrons_shared_data.deck.*]
+disallow_untyped_defs = False
+warn_return_any = False
+
+[mypy-opentrons_shared_data.labware.*]
+warn_return_any = False
+
+[mypy-opentrons_shared_data.module.*]
+disallow_untyped_defs = False
+warn_return_any = False
+
+[mypy-opentrons_shared_data.pipette.*]
+no_implicit_optional = False
+warn_return_any = False
+
+[mypy-opentrons_shared_data.protocol.*]
+warn_return_any = False
+
+[mypy-tests.deck.*]
+disallow_untyped_defs = False
+
+[mypy-tests.labware.*]
+disallow_untyped_defs = False
+disallow_untyped_calls = False
+
+[mypy-tests.module.*]
+disallow_untyped_defs = False
+disallow_untyped_calls = False
+
+[mypy-tests.pipette.*]
+disallow_untyped_defs = False
+disallow_untyped_calls = False
+
+[mypy-tests.protocol.*]
+disallow_untyped_defs = False

--- a/shared-data/python/mypy.ini
+++ b/shared-data/python/mypy.ini
@@ -3,8 +3,7 @@ show_error_codes = True
 warn_unused_configs = True
 strict = True
 
-# TODO(mc, 2022-01-20): fix and remove all of the overrides belo
-# overrides below whenever able
+# TODO(mc, 2022-01-20): fix and remove all of the overrides below
 
 [mypy-opentrons_shared_data.deck.*]
 disallow_untyped_defs = False

--- a/shared-data/python/tests/module/test_load.py
+++ b/shared-data/python/tests/module/test_load.py
@@ -26,7 +26,7 @@ def test_bad_module_name_throws():
         load_definition('1', 'alsjdag')
 
     with pytest.raises(ModuleNotFoundError):
-        load_definition('2', 'asdasda')
+        load_definition('2', 'asdasda')  # type: ignore[call-overload]
 
 
 @pytest.mark.parametrize('schemaname', ['1', '2'])


### PR DESCRIPTION
## Overview

I found a [pretty silly typing bug](https://github.com/Opentrons/opentrons/pull/9273/commits/ae33645d14f32f11b2f87b4371e0fb6038ef2436) in shared-data while working on #9273. Strict-mode typechecking would've caught this, so this PR starts `shared-data/python` on the mypy strict mode journey by:

- Adding a `mypy.ini` file with `strict: True`
- Adding overrides to `mypy.ini` to silence current errors for fixing in future PRs

## Changelog

- chore(shared-data): default shared-data mypy to strict and add overrides

## Review requests

Nothing specific

## Risk assessment

N/A if CI stays green. Config changes only, no code changes
