### PR TITLE
refactor(app): clear protocol creation error after new upload

### DIFF
--- a/app/src/organisms/ProtocolUpload/hooks/useCurrentProtocolRun.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useCurrentProtocolRun.ts
@@ -87,7 +87,10 @@ export function useCurrentProtocolRun(): UseCurrentProtocolRun {
   })
 
   return {
-    createProtocolRun,
+    createProtocolRun: (...args) => {
+      setProtocolCreationError(null)
+      createProtocolRun(...args)
+    },
     protocolRecord,
     runRecord,
     isCreatingProtocolRun:


### PR DESCRIPTION
# Overview

This PR clears the protocol creation error when uploading a new protocol

closes #9285

# Changelog
- Clear protocol creation error after new upload

# Review requests
Upload an invalid protocol like the one attached, and then upload a valid one. You should no longer see the error banner
[simple_transfer_proto.py 2.zip](https://github.com/Opentrons/opentrons/files/7908785/simple_transfer_proto.py.2.zip)


# Risk assessment
Low
