### PR TITLE
fix(api): filter higher order commands out of legacy command response

### DIFF
--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -40,12 +40,20 @@ class LegacyContextCommandError(ProtocolEngineError):
     """An error returned when a PAPIv2 ProtocolContext command fails."""
 
 
-LEGACY_TO_PE_MODULE: Dict[LegacyModuleModel, pe_types.ModuleModel] = {
+_LEGACY_TO_PE_MODULE: Dict[LegacyModuleModel, pe_types.ModuleModel] = {
     LegacyMagneticModuleModel.MAGNETIC_V1: pe_types.ModuleModel.MAGNETIC_MODULE_V1,
     LegacyMagneticModuleModel.MAGNETIC_V2: pe_types.ModuleModel.MAGNETIC_MODULE_V2,
     LegacyTemperatureModuleModel.TEMPERATURE_V1: pe_types.ModuleModel.TEMPERATURE_MODULE_V1,  # noqa: E501
     LegacyTemperatureModuleModel.TEMPERATURE_V2: pe_types.ModuleModel.TEMPERATURE_MODULE_V2,  # noqa: E501
     LegacyThermocyclerModuleModel.THERMOCYCLER_V1: pe_types.ModuleModel.THERMOCYCLER_MODULE_V1,  # noqa: E501
+}
+
+_HIGHER_ORDER_COMMAND_TYPES = {
+    legacy_command_types.MIX,
+    legacy_command_types.CONSOLIDATE,
+    legacy_command_types.DISTRIBUTE,
+    legacy_command_types.TRANSFER,
+    legacy_command_types.RETURN_TIP,
 }
 
 
@@ -94,6 +102,10 @@ class LegacyCommandMapper:
         command's status in-place.
         """
         command_type = command["name"]
+
+        if command_type in _HIGHER_ORDER_COMMAND_TYPES:
+            return []
+
         command_error = command["error"]
         stage = command["$"]
         # TODO(mc, 2021-12-08): use message ID as command ID directly once
@@ -246,7 +258,7 @@ class LegacyCommandMapper:
         count = self._command_count["LOAD_MODULE"]
         command_id = f"commands.LOAD_MODULE-{count}"
         module_id = f"module-{count}"
-        module_model = LEGACY_TO_PE_MODULE[module_load_info.module_model]
+        module_model = _LEGACY_TO_PE_MODULE[module_load_info.module_model]
 
         # This will fetch a V2 definition only. PAPI < v2.3 use V1 definitions.
         # When running a < v2.3 protocol, there will be a mismatch of definitions used

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -2,8 +2,9 @@
 import pytest
 from decoy import matchers, Decoy
 from datetime import datetime
+from typing import cast
 
-from opentrons.commands.types import CommentMessage, PauseMessage
+from opentrons.commands.types import CommentMessage, PauseMessage, CommandMessage
 from opentrons.protocol_engine import (
     DeckSlotLocation,
     ModuleLocation,
@@ -415,3 +416,45 @@ def test_map_pause() -> None:
         ),
         pe_actions.PauseAction(source=pe_actions.PauseSource.PROTOCOL),
     ]
+
+
+@pytest.mark.parametrize(
+    "command_type",
+    [
+        "command.MIX",
+        "command.CONSOLIDATE",
+        "command.DISTRIBUTE",
+        "command.TRANSFER",
+        "command.RETURN_TIP",
+    ],
+)
+def test_filter_higher_order_commands(command_type: str) -> None:
+    """It should filter out higher order commands."""
+    legacy_command_start = cast(
+        CommandMessage,
+        {
+            "$": "before",
+            "id": "message-id",
+            "name": command_type,
+            "payload": {"text": "hello world"},
+            "error": None,
+        },
+    )
+    legacy_command_end = cast(
+        CommandMessage,
+        {
+            "$": "after",
+            "id": "message-id",
+            "name": command_type,
+            "payload": {"text": "hello world"},
+            "error": None,
+        },
+    )
+
+    subject = LegacyCommandMapper()
+    result = [
+        *subject.map_command(legacy_command_start),
+        *subject.map_command(legacy_command_end),
+    ]
+
+    assert result == []


### PR DESCRIPTION
## Overview

Closes #9102

## Changelog

- fix(api): filter higher order commands out of legacy command response

## Review requests

Verify the following no longer show up in the run log:

- Mix
- Consolidate
- Distribute
- Transfer
- Return tip

I chose to avoid filtering "air gap", even though its currently implemented as a compound command, where it publishes a child aspirate. A few options here for this PR:

- Continue to do nothing and leave air gap alone
- Filter air gap out
- Change implementation to avoid the child aspirate publish, "promoting" air gap to an atomic command

## Risk assessment

Low