### PR TITLE
refactor(app): Use RobotCoordsForeignObject for LPC check DeckMap

### DIFF
--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/DeckMap.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/DeckMap.tsx
@@ -8,6 +8,10 @@ import {
   C_SELECTED_DARK,
   Icon,
   COLOR_SUCCESS,
+  DISPLAY_FLEX,
+  ALIGN_CENTER,
+  JUSTIFY_CENTER,
+  C_WHITE,
 } from '@opentrons/components'
 import {
   THERMOCYCLER_MODULE_V1,
@@ -28,6 +32,12 @@ const DECK_LAYER_BLOCKLIST = [
   'screwHoles',
 ]
 
+const flexProps = {
+  display: DISPLAY_FLEX,
+  alignItems: ALIGN_CENTER,
+  justifyContent: JUSTIFY_CENTER,
+  flex: '1 1 100%',
+}
 interface DeckMapProps {
   labwareIdsToHighlight?: string[]
   completedLabwareIdSections?: string[]
@@ -89,16 +99,47 @@ export const DeckMap = (props: DeckMapProps): JSX.Element | null => {
                         completedLabwareIdSections?.includes(
                           nestedLabwareId
                         ) === true && (
-                          <g>
-                            <circle
-                              data-testid={`DeckMap_module_${nestedLabwareId}_whiteBackground`}
-                            />
-                            <Icon
-                              name="check-circle"
-                              color={COLOR_SUCCESS}
-                              data-testid={`DeckMap_module_${nestedLabwareId}_checkmark`}
-                            />
-                          </g>
+                          <>
+                            <RobotCoordsForeignObject
+                              x={x}
+                              y={y}
+                              height="100%"
+                              width="100%"
+                              flexProps={flexProps}
+                              foreignObjectProps={{
+                                width: nestedLabwareDef.dimensions.xDimension,
+                                height: nestedLabwareDef.dimensions.yDimension,
+                              }}
+                            >
+                              <svg height="36" width="36">
+                                <circle
+                                  cx="50%"
+                                  cy="50%"
+                                  r={16}
+                                  fill={C_WHITE}
+                                  data-testid={`DeckMap_${nestedLabwareId}_whiteBackground`}
+                                />
+                              </svg>
+                            </RobotCoordsForeignObject>
+                            <RobotCoordsForeignObject
+                              x={x}
+                              y={y}
+                              height="100%"
+                              width="100%"
+                              flexProps={flexProps}
+                              foreignObjectProps={{
+                                width: nestedLabwareDef.dimensions.xDimension,
+                                height: nestedLabwareDef.dimensions.yDimension,
+                              }}
+                            >
+                              <Icon
+                                name="check-circle"
+                                color={COLOR_SUCCESS}
+                                data-testid={`DeckMap_${nestedLabwareId}_checkmark`}
+                                width="2rem"
+                              />
+                            </RobotCoordsForeignObject>
+                          </>
                         )}
                     </React.Fragment>
                   ) : null}
@@ -125,19 +166,47 @@ export const DeckMap = (props: DeckMapProps): JSX.Element | null => {
                     )}
                   </g>
                   {completedLabwareIdSections?.includes(labwareId) === true && (
-                    <RobotCoordsForeignObject
-                      x={0}
-                      y={0}
-                      height="100%"
-                      width="100%"
-                      // flexProps={{ padding: SPACING_3 }}
-                    >
-                      <Icon
-                        name="check-circle"
-                        color={COLOR_SUCCESS}
-                        data-testid={`DeckMap_${labwareId}_checkmark`}
-                      />
-                    </RobotCoordsForeignObject>
+                    <>
+                      <RobotCoordsForeignObject
+                        x={x}
+                        y={y}
+                        height="100%"
+                        width="100%"
+                        flexProps={flexProps}
+                        foreignObjectProps={{
+                          width: labwareDef.dimensions.xDimension,
+                          height: labwareDef.dimensions.yDimension,
+                        }}
+                      >
+                        <svg height="36" width="36">
+                          <circle
+                            cx="50%"
+                            cy="50%"
+                            r={16}
+                            fill={C_WHITE}
+                            data-testid={`DeckMap_${labwareId}_whiteBackground`}
+                          />
+                        </svg>
+                      </RobotCoordsForeignObject>
+                      <RobotCoordsForeignObject
+                        x={x}
+                        y={y}
+                        height="100%"
+                        width="100%"
+                        flexProps={flexProps}
+                        foreignObjectProps={{
+                          width: labwareDef.dimensions.xDimension,
+                          height: labwareDef.dimensions.yDimension,
+                        }}
+                      >
+                        <Icon
+                          name="check-circle"
+                          color={COLOR_SUCCESS}
+                          data-testid={`DeckMap_${labwareId}_checkmark`}
+                          width="2rem"
+                        />
+                      </RobotCoordsForeignObject>
+                    </>
                   )}
                 </React.Fragment>
               )

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/DeckMap.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/DeckMap.tsx
@@ -84,8 +84,8 @@ export const DeckMap = (props: DeckMapProps): JSX.Element | null => {
                     {nestedLabwareId != null &&
                     completedLabwareIds?.includes(nestedLabwareId) ? (
                       <RobotCoordsCenteredCheck
-                        x={x}
-                        y={y}
+                        x={0}
+                        y={0}
                         boundingXDimension={
                           nestedLabwareDef.dimensions.xDimension
                         }

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/DeckMap.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/DeckMap.tsx
@@ -4,10 +4,10 @@ import {
   LabwareRender,
   Module,
   RobotWorkSpace,
+  RobotCoordsForeignObject,
   C_SELECTED_DARK,
   Icon,
   COLOR_SUCCESS,
-  C_WHITE,
 } from '@opentrons/components'
 import {
   THERMOCYCLER_MODULE_V1,
@@ -89,23 +89,8 @@ export const DeckMap = (props: DeckMapProps): JSX.Element | null => {
                         completedLabwareIdSections?.includes(
                           nestedLabwareId
                         ) === true && (
-                          <g
-                            transform={
-                              moduleDef.model !== THERMOCYCLER_MODULE_V1
-                                ? `translate(${x + 35},${
-                                    y + 70
-                                  }) scale(0.1, -0.1)`
-                                : `translate(${x + 35},${
-                                    y - 110
-                                  }) scale(0.1, -0.1)`
-                            }
-                          >
+                          <g>
                             <circle
-                              cx="0"
-                              cy="0"
-                              r={230}
-                              fill={C_WHITE}
-                              transform={`translate(273,235)`}
                               data-testid={`DeckMap_module_${nestedLabwareId}_whiteBackground`}
                             />
                             <Icon
@@ -140,25 +125,19 @@ export const DeckMap = (props: DeckMapProps): JSX.Element | null => {
                     )}
                   </g>
                   {completedLabwareIdSections?.includes(labwareId) === true && (
-                    <g
-                      transform={`
-                      translate(${x + 35},${y + 70}) scale(0.1, -0.1) 
-                      `}
+                    <RobotCoordsForeignObject
+                      x={0}
+                      y={0}
+                      height="100%"
+                      width="100%"
+                      // flexProps={{ padding: SPACING_3 }}
                     >
-                      <circle
-                        cx="0"
-                        cy="0"
-                        r={230}
-                        fill={C_WHITE}
-                        transform={`translate(273,235)`}
-                        data-testid={`DeckMap_${labwareId}_whiteBackground`}
-                      />
                       <Icon
                         name="check-circle"
                         color={COLOR_SUCCESS}
                         data-testid={`DeckMap_${labwareId}_checkmark`}
                       />
-                    </g>
+                    </RobotCoordsForeignObject>
                   )}
                 </React.Fragment>
               )

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/DeckMap.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/DeckMap.tsx
@@ -8,7 +8,6 @@ import {
   C_SELECTED_DARK,
   Icon,
   COLOR_SUCCESS,
-  DISPLAY_FLEX,
   ALIGN_CENTER,
   JUSTIFY_CENTER,
   C_WHITE,
@@ -32,19 +31,13 @@ const DECK_LAYER_BLOCKLIST = [
   'screwHoles',
 ]
 
-const flexProps = {
-  display: DISPLAY_FLEX,
-  alignItems: ALIGN_CENTER,
-  justifyContent: JUSTIFY_CENTER,
-  flex: '1 1 100%',
-}
 interface DeckMapProps {
   labwareIdsToHighlight?: string[]
-  completedLabwareIdSections?: string[]
+  completedLabwareIds?: string[]
 }
 
 export const DeckMap = (props: DeckMapProps): JSX.Element | null => {
-  const { labwareIdsToHighlight, completedLabwareIdSections } = props
+  const { labwareIdsToHighlight, completedLabwareIds } = props
   const moduleRenderInfoById = useModuleRenderInfoById()
   const labwareRenderInfoById = useLabwareRenderInfoById()
 
@@ -56,164 +49,122 @@ export const DeckMap = (props: DeckMapProps): JSX.Element | null => {
       deckLayerBlocklist={DECK_LAYER_BLOCKLIST}
       id={'LabwarePositionCheck_deckMap'}
     >
-      {() => {
-        return (
-          <React.Fragment>
-            {map(
-              moduleRenderInfoById,
-              ({ x, y, moduleDef, nestedLabwareDef, nestedLabwareId }) => (
-                <Module
-                  key={`LabwarePositionCheck_Module_${moduleDef.model}_${x}${y}`}
-                  x={x}
-                  y={y}
-                  orientation={inferModuleOrientationFromXCoordinate(x)}
-                  def={moduleDef}
-                  innerProps={
-                    moduleDef.model === THERMOCYCLER_MODULE_V1
-                      ? { lidMotorState: 'open' }
-                      : {}
-                  }
-                >
-                  {nestedLabwareDef != null ? (
-                    <React.Fragment
-                      key={`LabwarePositionCheck_Labware_${nestedLabwareDef.metadata.displayName}_${x}${y}`}
-                    >
-                      <g>
-                        <LabwareRender definition={nestedLabwareDef} />
-                        {nestedLabwareId != null &&
-                          labwareIdsToHighlight?.includes(nestedLabwareId) ===
-                            true && (
-                            <rect
-                              width={nestedLabwareDef.dimensions.xDimension - 2}
-                              height={
-                                nestedLabwareDef.dimensions.yDimension - 2
-                              }
-                              fill={'none'}
-                              stroke={C_SELECTED_DARK}
-                              strokeWidth={'3px'}
-                              data-testid={`DeckMap_module_${nestedLabwareId}_highlight`}
-                            />
-                          )}{' '}
-                      </g>
-                      {nestedLabwareId != null &&
-                        completedLabwareIdSections?.includes(
-                          nestedLabwareId
-                        ) === true && (
-                          <>
-                            <RobotCoordsForeignObject
-                              x={x}
-                              y={y}
-                              height="100%"
-                              width="100%"
-                              flexProps={flexProps}
-                              foreignObjectProps={{
-                                width: nestedLabwareDef.dimensions.xDimension,
-                                height: nestedLabwareDef.dimensions.yDimension,
-                              }}
-                            >
-                              <svg height="36" width="36">
-                                <circle
-                                  cx="50%"
-                                  cy="50%"
-                                  r={16}
-                                  fill={C_WHITE}
-                                  data-testid={`DeckMap_${nestedLabwareId}_whiteBackground`}
-                                />
-                              </svg>
-                            </RobotCoordsForeignObject>
-                            <RobotCoordsForeignObject
-                              x={x}
-                              y={y}
-                              height="100%"
-                              width="100%"
-                              flexProps={flexProps}
-                              foreignObjectProps={{
-                                width: nestedLabwareDef.dimensions.xDimension,
-                                height: nestedLabwareDef.dimensions.yDimension,
-                              }}
-                            >
-                              <Icon
-                                name="check-circle"
-                                color={COLOR_SUCCESS}
-                                data-testid={`DeckMap_${nestedLabwareId}_checkmark`}
-                                width="2rem"
-                              />
-                            </RobotCoordsForeignObject>
-                          </>
-                        )}
-                    </React.Fragment>
-                  ) : null}
-                </Module>
-              )
-            )}
-
-            {map(labwareRenderInfoById, ({ x, y, labwareDef }, labwareId) => {
-              return (
-                <React.Fragment
-                  key={`LabwarePositionCheck_Labware_${labwareDef.metadata.displayName}_${x}${y}`}
-                >
-                  <g transform={`translate(${x},${y})`}>
-                    <LabwareRender definition={labwareDef} />
-                    {labwareIdsToHighlight?.includes(labwareId) === true && (
+      {() => (
+        <>
+          {map(
+            moduleRenderInfoById,
+            ({ x, y, moduleDef, nestedLabwareDef, nestedLabwareId }) => (
+              <Module
+                key={`LabwarePositionCheck_Module_${moduleDef.model}_${x}${y}`}
+                x={x}
+                y={y}
+                orientation={inferModuleOrientationFromXCoordinate(x)}
+                def={moduleDef}
+                innerProps={
+                  moduleDef.model === THERMOCYCLER_MODULE_V1
+                    ? { lidMotorState: 'open' }
+                    : {}
+                }
+              >
+                {nestedLabwareDef != null ? (
+                  <>
+                    <LabwareRender definition={nestedLabwareDef} />
+                    {nestedLabwareId != null &&
+                    labwareIdsToHighlight?.includes(nestedLabwareId) ? (
                       <rect
-                        width={labwareDef.dimensions.xDimension - 2}
-                        height={labwareDef.dimensions.yDimension - 2}
+                        width={nestedLabwareDef.dimensions.xDimension - 2}
+                        height={nestedLabwareDef.dimensions.yDimension - 2}
                         fill={'none'}
                         stroke={C_SELECTED_DARK}
                         strokeWidth={'3px'}
-                        data-testid={`DeckMap_${labwareId}_highlight`}
+                        data-testid={`DeckMap_module_${nestedLabwareId}_highlight`}
                       />
-                    )}
-                  </g>
-                  {completedLabwareIdSections?.includes(labwareId) === true && (
-                    <>
-                      <RobotCoordsForeignObject
+                    ) : null}
+                    {nestedLabwareId != null &&
+                    completedLabwareIds?.includes(nestedLabwareId) ? (
+                      <RobotCoordsCenteredCheck
                         x={x}
                         y={y}
-                        height="100%"
-                        width="100%"
-                        flexProps={flexProps}
-                        foreignObjectProps={{
-                          width: labwareDef.dimensions.xDimension,
-                          height: labwareDef.dimensions.yDimension,
-                        }}
-                      >
-                        <svg height="36" width="36">
-                          <circle
-                            cx="50%"
-                            cy="50%"
-                            r={16}
-                            fill={C_WHITE}
-                            data-testid={`DeckMap_${labwareId}_whiteBackground`}
-                          />
-                        </svg>
-                      </RobotCoordsForeignObject>
-                      <RobotCoordsForeignObject
-                        x={x}
-                        y={y}
-                        height="100%"
-                        width="100%"
-                        flexProps={flexProps}
-                        foreignObjectProps={{
-                          width: labwareDef.dimensions.xDimension,
-                          height: labwareDef.dimensions.yDimension,
-                        }}
-                      >
-                        <Icon
-                          name="check-circle"
-                          color={COLOR_SUCCESS}
-                          data-testid={`DeckMap_${labwareId}_checkmark`}
-                          width="2rem"
-                        />
-                      </RobotCoordsForeignObject>
-                    </>
-                  )}
-                </React.Fragment>
-              )
-            })}
-          </React.Fragment>
-        )
-      }}
+                        boundingXDimension={
+                          nestedLabwareDef.dimensions.xDimension
+                        }
+                        boundingYDimension={
+                          nestedLabwareDef.dimensions.yDimension
+                        }
+                        data-testid={`DeckMap_${nestedLabwareId}_checkmark`}
+                      />
+                    ) : null}
+                  </>
+                ) : null}
+              </Module>
+            )
+          )}
+          {map(labwareRenderInfoById, ({ x, y, labwareDef }, labwareId) => (
+            <g transform={`translate(${x},${y})`}>
+              <LabwareRender definition={labwareDef} />
+              {labwareIdsToHighlight?.includes(labwareId) === true && (
+                <rect
+                  width={labwareDef.dimensions.xDimension - 2}
+                  height={labwareDef.dimensions.yDimension - 2}
+                  fill={'none'}
+                  stroke={C_SELECTED_DARK}
+                  strokeWidth={'3px'}
+                  data-testid={`DeckMap_${labwareId}_highlight`}
+                />
+              )}
+              {completedLabwareIds?.includes(labwareId) ? (
+                <RobotCoordsCenteredCheck
+                  x={0}
+                  y={0}
+                  boundingXDimension={labwareDef.dimensions.xDimension}
+                  boundingYDimension={labwareDef.dimensions.yDimension}
+                  data-testid={`DeckMap_${labwareId}_checkmark`}
+                />
+              ) : null}
+            </g>
+          ))}
+        </>
+      )}
     </RobotWorkSpace>
+  )
+}
+
+interface RobotCoordsCenteredCheckProps
+  extends Omit<
+    React.ComponentProps<typeof RobotCoordsForeignObject>,
+    'width' | 'height'
+  > {
+  x: number
+  y: number
+  boundingXDimension: number
+  boundingYDimension: number
+}
+function RobotCoordsCenteredCheck(props: RobotCoordsCenteredCheckProps): JSX.Element {
+  const {
+    x,
+    y,
+    boundingXDimension,
+    boundingYDimension,
+    ...wrapperProps
+  } = props
+  return (
+    <RobotCoordsForeignObject
+      {...wrapperProps}
+      x={x}
+      y={y}
+      width={boundingXDimension}
+      height={boundingYDimension}
+      foreignObjectProps={{
+        alignItems: ALIGN_CENTER,
+        justifyContent: JUSTIFY_CENTER,
+      }}
+    >
+      <Icon name="check-circle" color={COLOR_SUCCESS} width="2rem">
+        <path
+          fill={C_WHITE}
+          d="M9.6,18 L3.6,12 L5.292,10.296 L9.6,14.604 L18.708,5.496 L20.4,7.2 L9.6,18 Z"
+        />
+      </Icon>
+    </RobotCoordsForeignObject>
   )
 }

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/DeckMap.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/DeckMap.tsx
@@ -7,6 +7,7 @@ import {
   RobotCoordsForeignObject,
   C_SELECTED_DARK,
   Icon,
+  Flex,
   COLOR_SUCCESS,
   ALIGN_CENTER,
   JUSTIFY_CENTER,
@@ -91,7 +92,7 @@ export const DeckMap = (props: DeckMapProps): JSX.Element | null => {
                         boundingYDimension={
                           nestedLabwareDef.dimensions.yDimension
                         }
-                        data-testid={`DeckMap_${nestedLabwareId}_checkmark`}
+                        data-testid={`DeckMap_module_${nestedLabwareId}_checkmark`}
                       />
                     ) : null}
                   </>
@@ -100,7 +101,10 @@ export const DeckMap = (props: DeckMapProps): JSX.Element | null => {
             )
           )}
           {map(labwareRenderInfoById, ({ x, y, labwareDef }, labwareId) => (
-            <g transform={`translate(${x},${y})`}>
+            <g
+              key={`LabwarePositionCheck_Labware_${labwareId}_${x}${y}`}
+              transform={`translate(${x},${y})`}
+            >
               <LabwareRender definition={labwareDef} />
               {labwareIdsToHighlight?.includes(labwareId) === true && (
                 <rect
@@ -130,16 +134,15 @@ export const DeckMap = (props: DeckMapProps): JSX.Element | null => {
 }
 
 interface RobotCoordsCenteredCheckProps
-  extends Omit<
-    React.ComponentProps<typeof RobotCoordsForeignObject>,
-    'width' | 'height'
-  > {
+  extends React.ComponentProps<typeof Flex> {
   x: number
   y: number
   boundingXDimension: number
   boundingYDimension: number
 }
-function RobotCoordsCenteredCheck(props: RobotCoordsCenteredCheckProps): JSX.Element {
+function RobotCoordsCenteredCheck(
+  props: RobotCoordsCenteredCheckProps
+): JSX.Element {
   const {
     x,
     y,
@@ -149,7 +152,6 @@ function RobotCoordsCenteredCheck(props: RobotCoordsCenteredCheckProps): JSX.Ele
   } = props
   return (
     <RobotCoordsForeignObject
-      {...wrapperProps}
       x={x}
       y={y}
       width={boundingXDimension}
@@ -157,6 +159,7 @@ function RobotCoordsCenteredCheck(props: RobotCoordsCenteredCheckProps): JSX.Ele
       foreignObjectProps={{
         alignItems: ALIGN_CENTER,
         justifyContent: JUSTIFY_CENTER,
+        ...wrapperProps,
       }}
     >
       <Icon name="check-circle" color={COLOR_SUCCESS} width="2rem">

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/GenericStepScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/GenericStepScreen.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react'
+import uniq from 'lodash/uniq'
+import isEqual from 'lodash/isEqual'
 import {
   DIRECTION_COLUMN,
   Flex,
@@ -13,7 +15,7 @@ import {
 } from '@opentrons/components'
 import { LabwarePositionCheckStepDetail } from './LabwarePositionCheckStepDetail'
 import { SectionList } from './SectionList'
-import { useIntroInfo, useLabwareIdsBySection } from './hooks'
+import { useIntroInfo, useLabwareIdsBySection, useSteps } from './hooks'
 import { DeckMap } from './DeckMap'
 import type { Jog } from '../../../molecules/JogControls'
 import type { LabwarePositionCheckStep } from './types'
@@ -30,7 +32,7 @@ export const GenericStepScreen = (
 ): JSX.Element | null => {
   const introInfo = useIntroInfo()
   const labwareIdsBySection = useLabwareIdsBySection()
-  const [sectionIndex] = React.useState<number>(0)
+  const allSteps = useSteps()
   if (introInfo == null) return null
   const { sections, primaryPipetteMount, secondaryPipetteMount } = introInfo
   const labwareIdsToHighlight = labwareIdsBySection[props.selectedStep.section]
@@ -38,7 +40,18 @@ export const GenericStepScreen = (
     section => section === props.selectedStep.section
   )
   const completedSections = sections.slice(0, currentSectionIndex)
+  const selectedStepIndex = allSteps.findIndex(step =>
+    isEqual(step, props.selectedStep)
+  )
+  const completedSteps =
+    selectedStepIndex > 0 ? allSteps.slice(0, selectedStepIndex) : []
 
+  const completedLabwareIds = completedSteps.reduce<string[]>(
+    (acc, step) => uniq([...acc, step.labwareId]),
+    []
+  )
+
+  console.log(completedLabwareIds)
   return (
     <Flex margin={SPACING_3} flexDirection={DIRECTION_COLUMN}>
       <Text
@@ -64,9 +77,7 @@ export const GenericStepScreen = (
           <Flex justifyContent={JUSTIFY_CENTER} paddingTop={SPACING_3}>
             <DeckMap
               labwareIdsToHighlight={labwareIdsToHighlight}
-              completedLabwareIdSections={
-                labwareIdsBySection[sections[sectionIndex - 1]]
-              }
+              completedLabwareIds={completedLabwareIds}
             />
           </Flex>
         </Flex>

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
@@ -95,7 +95,7 @@ export const SummaryScreen = (props: {
             />
           </Flex>
           <Flex paddingTop={SPACING_2}>
-            <DeckMap completedLabwareIdSections={labwareIds} />
+            <DeckMap completedLabwareIds={labwareIds} />
           </Flex>
         </Flex>
         <Flex flex={'1 1 45%'}>

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/DeckMap.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/DeckMap.test.tsx
@@ -164,24 +164,20 @@ describe('LPC DeckMap', () => {
     const { getByTestId } = render(
       <DeckMap
         labwareIdsToHighlight={[ANOTHER_LABWARE_ID_TO_HIGHLIGHT]}
-        completedLabwareIdSections={[LABWARE_ID_TO_HIGHLIGHT]}
+        completedLabwareIds={[LABWARE_ID_TO_HIGHLIGHT]}
       />
     )
     getByTestId(`DeckMap_${LABWARE_ID_TO_HIGHLIGHT}_checkmark`)
-    getByTestId(`DeckMap_${LABWARE_ID_TO_HIGHLIGHT}_whiteBackground`)
     getByTestId(`DeckMap_module_${ANOTHER_LABWARE_ID_TO_HIGHLIGHT}_highlight`)
   })
   it('should render a deckmap with a blank circle and checkbox over completed module section', () => {
     const { getByTestId } = render(
       <DeckMap
         labwareIdsToHighlight={[LABWARE_ID_TO_HIGHLIGHT]}
-        completedLabwareIdSections={[ANOTHER_LABWARE_ID_TO_HIGHLIGHT]}
+        completedLabwareIds={[ANOTHER_LABWARE_ID_TO_HIGHLIGHT]}
       />
     )
     getByTestId(`DeckMap_${LABWARE_ID_TO_HIGHLIGHT}_highlight`)
     getByTestId(`DeckMap_module_${ANOTHER_LABWARE_ID_TO_HIGHLIGHT}_checkmark`)
-    getByTestId(
-      `DeckMap_module_${ANOTHER_LABWARE_ID_TO_HIGHLIGHT}_whiteBackground`
-    )
   })
 })

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/GenericStepScreen.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/GenericStepScreen.test.tsx
@@ -9,7 +9,7 @@ import { GenericStepScreen } from '../GenericStepScreen'
 import { LabwarePositionCheckStepDetail } from '../LabwarePositionCheckStepDetail'
 import { SectionList } from '../SectionList'
 import { DeckMap } from '../DeckMap'
-import { useIntroInfo, useLabwareIdsBySection } from '../hooks'
+import { useIntroInfo, useLabwareIdsBySection, useSteps } from '../hooks'
 import { Section } from '../types'
 
 jest.mock('../LabwarePositionCheckStepDetail')
@@ -24,6 +24,7 @@ const mockSectionList = SectionList as jest.MockedFunction<typeof SectionList>
 const mockUseIntroInfo = useIntroInfo as jest.MockedFunction<
   typeof useIntroInfo
 >
+const mockUseSteps = useSteps as jest.MockedFunction<typeof useSteps>
 const mockUseLabwareIdsBySection = useLabwareIdsBySection as jest.MockedFunction<
   typeof useLabwareIdsBySection
 >
@@ -73,6 +74,7 @@ describe('GenericStepScreen', () => {
     mockSectionList.mockReturnValue(<div>Mock SectionList </div>)
     mockDeckmap.mockReturnValue(<div>Mock DeckMap </div>)
     mockUseLabwareIdsBySection.mockReturnValue({})
+    mockUseSteps.mockReturnValue([])
 
     when(mockUseIntroInfo).calledWith().mockReturnValue({
       primaryPipetteMount: 'left',


### PR DESCRIPTION
Closes #9036 and #9270. Will open a follow up PR to add documentation for `RobotCoordsForeignObject` but best to get this in ASAP.

# Changelog

- refactor(app): Use RobotCoordsForeignObject for LPC check DeckMap
- fix non default module slot checkbox offset

# Review requests

run LPC
check deckmap on final summary screen
- [ ] checkboxes are centered with white bg
- [ ] checkboxes are centered with white bg (with modules in default slots)
- [ ] checkboxes are centered with white bg (with modules in non default slots)

# Risk assessment

low. small refactor in app
