### PR TITLE
fix(app): redirect to run page when run is cloned

### DIFF
--- a/app/src/assets/localization/en/run_details.json
+++ b/app/src/assets/localization/en/run_details.json
@@ -56,5 +56,7 @@
   "protocol_run_failed": "Protocol run failed",
   "protocol_run_canceled": "Protocol run canceled",
   "protocol_run_complete": "Protocol run complete",
-  "run_cta_disabled": "Complete required steps on Protocol tab before starting the run"
+  "run_cta_disabled": "Complete required steps on Protocol tab before starting the run",
+  "loading_protocol": "Loading Protocol",
+  "closing_protocol": "Closing Protocol"
 }

--- a/app/src/organisms/ProtocolUpload/UploadInput.tsx
+++ b/app/src/organisms/ProtocolUpload/UploadInput.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { format, parseISO } from 'date-fns'
 import { useSelector } from 'react-redux'
+import { useHistory } from 'react-router-dom'
 import { css } from 'styled-components'
 import { Trans, useTranslation } from 'react-i18next'
 import {
@@ -78,6 +79,7 @@ export interface UploadInputProps {
 
 export function UploadInput(props: UploadInputProps): JSX.Element | null {
   const { t } = useTranslation('protocol_info')
+  const history = useHistory()
   const mostRecentRunId = useMostRecentRunId()
   const runQuery = useRunQuery(mostRecentRunId)
   const mostRecentRun = runQuery.data?.data
@@ -148,6 +150,11 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
     : DROP_ZONE_STYLES
 
   const labwareOffsetCount = getLatestLabwareOffsetCount(labwareOffsets ?? [])
+
+  const handleCloneRun = (): void => {
+    cloneRun()
+    history.push('/run')
+  }
 
   return (
     <Flex
@@ -304,7 +311,7 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
             </Flex>
             <Flex>
               <NewSecondaryBtn
-                onClick={cloneRun}
+                onClick={handleCloneRun}
                 id={'UploadInput_runAgainButton'}
               >
                 {t('run_again')}

--- a/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
+++ b/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { resetAllWhenMocks, when } from 'jest-when'
 import { QueryClient, QueryClientProvider } from 'react-query'
+import { BrowserRouter } from 'react-router-dom'
 import { fireEvent, screen } from '@testing-library/react'
 import {
   RUN_STATUS_FINISHING,
@@ -90,7 +91,9 @@ const queryClient = new QueryClient()
 const render = () => {
   return renderWithProviders(
     <QueryClientProvider client={queryClient}>
-      <ProtocolUpload />
+      <BrowserRouter>
+        <ProtocolUpload />
+      </BrowserRouter>
     </QueryClientProvider>,
     { i18nInstance: i18n }
   )

--- a/app/src/organisms/ProtocolUpload/__tests__/UploadInput.test.tsx
+++ b/app/src/organisms/ProtocolUpload/__tests__/UploadInput.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { when, resetAllWhenMocks } from 'jest-when'
 import '@testing-library/jest-dom'
 import { fireEvent, screen } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
 import {
   componentPropsMatcher,
   nestedTextMatcher,
@@ -54,9 +55,14 @@ const mockGetLatestLabwareOffsetCount = getLatestLabwareOffsetCount as jest.Mock
 const simpleV6Protocol = (_uncastedSimpleV6Protocol as unknown) as ProtocolFile<{}>
 
 const render = (props: React.ComponentProps<typeof UploadInput>) => {
-  return renderWithProviders(<UploadInput onUpload={props.onUpload} />, {
-    i18nInstance: i18n,
-  })[0]
+  return renderWithProviders(
+    <BrowserRouter>
+      <UploadInput onUpload={props.onUpload} />
+    </BrowserRouter>,
+    {
+      i18nInstance: i18n,
+    }
+  )[0]
 }
 
 describe('UploadInput', () => {

--- a/app/src/organisms/RunDetails/__tests__/RunDetails.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/RunDetails.test.tsx
@@ -20,6 +20,7 @@ import { CommandList } from '../CommandList'
 import { useProtocolDetails } from '../hooks'
 import { useRunStatus, useRunControls } from '../../RunTimeControl/hooks'
 import { useCloseCurrentRun } from '../../ProtocolUpload/hooks/useCloseCurrentRun'
+import { ProtocolLoader } from '../../ProtocolUpload'
 import _uncastedSimpleV6Protocol from '@opentrons/shared-data/protocol/fixtures/6/simpleV6.json'
 import type { ProtocolFile } from '@opentrons/shared-data'
 
@@ -189,14 +190,25 @@ describe('RunDetails', () => {
     expect(button).not.toBeInTheDocument()
   })
 
-  it('renders null if protocol run is not loaded', () => {
+  const renderProtocolLoader = (
+    props: React.ComponentProps<typeof ProtocolLoader>
+  ) => {
+    return renderWithProviders(<ProtocolLoader {...props} />)[0]
+  }
+
+  let props: React.ComponentProps<typeof ProtocolLoader>
+  beforeEach(() => {
+    props = { loadingText: 'Loading Protocol' }
+  })
+
+  it('renders a loader if protocol run is not loaded', () => {
     when(mockUseCloseCurrentRun)
       .calledWith()
       .mockReturnValue({
         isProtocolRunLoaded: false,
         closeCurrentRun: jest.fn(),
       } as any)
-    const { container } = render()
-    expect(container.firstChild).toBeNull()
+    const { getByText } = renderProtocolLoader(props)
+    getByText('Loading Protocol')
   })
 })

--- a/app/src/organisms/RunDetails/index.tsx
+++ b/app/src/organisms/RunDetails/index.tsx
@@ -9,6 +9,7 @@ import {
   RUN_STATUS_PAUSE_REQUESTED,
   RUN_STATUS_FINISHING,
   RUN_STATUS_STOP_REQUESTED,
+  RUN_STATUS_STOPPED,
 } from '@opentrons/api-client'
 import {
   SPACING_2,
@@ -30,6 +31,7 @@ import { CommandList } from './CommandList'
 import { ConfirmCancelModal } from './ConfirmCancelModal'
 
 import styles from '../ProtocolUpload/styles.css'
+import { ProtocolLoader } from '../ProtocolUpload'
 
 export function RunDetails(): JSX.Element | null {
   const { t } = useTranslation(['run_details', 'shared'])
@@ -66,7 +68,14 @@ export function RunDetails(): JSX.Element | null {
   } = useConditionalConfirm(handleCloseProtocol, true)
 
   if (!isProtocolRunLoaded) {
-    return null
+    let text = t('loading_protocol')
+    if (
+      adjustedRunStatus === RUN_STATUS_FINISHING ||
+      adjustedRunStatus === RUN_STATUS_STOPPED
+    ) {
+      text = t('closing_protocol')
+    }
+    return <ProtocolLoader loadingText={text} />
   }
 
   const cancelRunButton = (


### PR DESCRIPTION
# Overview

This PR fixes the issue where cloned runs would be redirected to the Protocols page. They are now
redirected to the Runs page with a loading state. closes #9106

# Changelog

- Redirect to run page when a run is cloned from the `UploadInput` component.
- Render spinner instead of returning null on the Run page when a protocol is loading or a protocol is being closed.
- Updated and added tests

# Review requests

- Clone a run by clicking `Run Again` on a previously uploaded protocol in the `Protocol` page. This should redirect you to the `Run` tab while rendering a spinner when the protocol is still loading.
- After completing a protocol run, if you click the `Run Again` button in the `Run` page controls, it should stay on the `Run` page.
- If you close a protocol from the `Run` page it should render a spinner while it is closing.

# Risk assessment

low
