### PR TITLE
refactor(shared-data): add additional heater shaker commands to schema v6

### DIFF
--- a/shared-data/protocol/fixtures/6/heaterShakerCommands.json
+++ b/shared-data/protocol/fixtures/6/heaterShakerCommands.json
@@ -1388,8 +1388,7 @@
       "commandType": "heaterShakerModule/awaitTemperature",
       "id": "15abc123",
       "params": {
-        "moduleId": "heaterShakerId",
-        "temperature": 80
+        "moduleId": "heaterShakerId"
       }
     },
     {

--- a/shared-data/protocol/fixtures/6/heaterShakerCommands.json
+++ b/shared-data/protocol/fixtures/6/heaterShakerCommands.json
@@ -1361,14 +1361,6 @@
       }
     },
     {
-      "commandType": "heaterShakerModule/setTargetTemperature",
-      "id": "12abc123",
-      "params": {
-        "moduleId": "heaterShakerId",
-        "temperature": 80
-      }
-    },
-    {
       "commandType": "heaterShakerModule/setTargetShakeSpeed",
       "id": "13abc123",
       "params": {

--- a/shared-data/protocol/fixtures/6/heaterShakerCommands.json
+++ b/shared-data/protocol/fixtures/6/heaterShakerCommands.json
@@ -1377,14 +1377,6 @@
       }
     },
     {
-      "commandType": "heaterShakerModule/awaitShakeSpeed",
-      "id": "14abc123",
-      "params": {
-        "moduleId": "heaterShakerId",
-        "rpm": 2000
-      }
-    },
-    {
       "commandType": "heaterShakerModule/awaitTemperature",
       "id": "15abc123",
       "params": {

--- a/shared-data/protocol/schemas/6.json
+++ b/shared-data/protocol/schemas/6.json
@@ -911,29 +911,6 @@
           },
 
           {
-            "description": "Heater Shaker Module Await Speed: Delay protocol execution until the specified target shake speed is reached.",
-            "type": "object",
-            "required": ["id", "commandType", "params"],
-            "properties": {
-              "id": { "type": "string" },
-              "commandType": { "enum": ["heaterShakerModule/awaitShakeSpeed"] },
-              "params": {
-                "required": ["moduleId", "rpm"],
-                "properties": {
-                  "moduleId": {
-                    "type": "string",
-                    "description": "Unique identifier of Heater Shaker Module to target. Must be a key from the top level 'modules' object"
-                  },
-                  "rpm": {
-                    "type": "number",
-                    "description": "target rotations per minute to await"
-                  }
-                }
-              }
-            }
-          },
-
-          {
             "description": "Heater Shaker Module Deactivate Heater: Module will stop actively heating and drift to ambient temperature.",
             "type": "object",
             "required": ["id", "commandType", "params"],

--- a/shared-data/protocol/schemas/6.json
+++ b/shared-data/protocol/schemas/6.json
@@ -896,7 +896,7 @@
           },
 
           {
-            "description": "Heater Shaker Module Await Temperature: Delay protocol execution until the previously supplied startSetTemperature command's temperature parameter has been reached. Errors if no previous startSetTemperatureCommand has been executed",
+            "description": "Heater Shaker Module Await Temperature: Delay protocol execution until the previously supplied startSetTargetTemperature command's temperature parameter has been reached. Errors if no target temperature was set previously.",
             "type": "object",
             "required": ["id", "commandType", "params"],
             "properties": {
@@ -941,7 +941,7 @@
           },
 
           {
-            "description": "Heater Shaker Module Open Latch.",
+            "description": "Heater Shaker Module Open Latch: Open the module's labware latch.",
             "type": "object",
             "required": ["id", "commandType", "params"],
             "properties": {
@@ -956,7 +956,7 @@
           },
 
           {
-            "description": "Heater Shaker Module Close Latch.",
+            "description": "Heater Shaker Module Close Latch: Close the module's labware latch.",
             "type": "object",
             "required": ["id", "commandType", "params"],
             "properties": {

--- a/shared-data/protocol/schemas/6.json
+++ b/shared-data/protocol/schemas/6.json
@@ -846,7 +846,7 @@
           },
 
           {
-            "description": "Heater Shaker Module Set Target Shake Speed: Module will delay protocol execution until the target shake speed is reached. This command is blocking, it delays protocol execution while approaching the target shake speed.",
+            "description": "Heater Shaker Module Set Target Shake Speed: Start the module's shake procedure. The protocol will proceed once the target shake speed is reached.",
             "type": "object",
             "required": ["id", "commandType", "params"],
             "properties": {

--- a/shared-data/protocol/schemas/6.json
+++ b/shared-data/protocol/schemas/6.json
@@ -905,13 +905,7 @@
                 "enum": ["heaterShakerModule/awaitTemperature"]
               },
               "params": {
-                "required": ["moduleId"],
-                "properties": {
-                  "moduleId": {
-                    "type": "string",
-                    "description": "Unique identifier of Heater Shaker Module to target. Must be a key from the top level 'modules' object"
-                  }
-                }
+                "$ref": "#/definitions/moduleOnlyParams"
               }
             }
           },

--- a/shared-data/protocol/schemas/6.json
+++ b/shared-data/protocol/schemas/6.json
@@ -629,7 +629,7 @@
           },
 
           {
-            "description": "Thermocycler Set Target Block Temperature: Well block will begin moving to the target temperature. This command is non-blocking, it does not delay protocol execution while approaching the target temperature.",
+            "description": "Thermocycler Set Target Block Temperature: Well block will begin moving to the target temperature. This command is blocking, it delays protocol execution while approaching the target temperature.",
             "type": "object",
             "required": ["id", "commandType", "params"],
             "properties": {
@@ -821,7 +821,32 @@
           },
 
           {
-            "description": "Heater Shaker Module Set Target Temperature: Module will begin moving to the target temperature. This command is non-blocking, it does not delay protocol execution while approaching the target temperature.",
+            "description": "Heater Shaker Module Start Set Target Temperature: Module will begin moving to the target temperature. This command is non-blocking, it does not delay protocol execution while approaching the target temperature.",
+            "type": "object",
+            "required": ["id", "commandType", "params"],
+            "properties": {
+              "id": { "type": "string" },
+              "commandType": {
+                "enum": ["heaterShakerModule/startSetTargetTemperature"]
+              },
+              "params": {
+                "required": ["moduleId", "temperature"],
+                "properties": {
+                  "moduleId": {
+                    "type": "string",
+                    "description": "Unique identifier of Heater Shaker Module to target. Must be a key from the top level 'modules' object"
+                  },
+                  "temperature": {
+                    "type": "number",
+                    "description": "target temperature to heat to in °C"
+                  }
+                }
+              }
+            }
+          },
+
+          {
+            "description": "Heater Shaker Module Set Target Temperature: Module will delay protocol execution until the target specified target temperature is reached. This command is locking, it delays protocol execution while approaching the target temperature.",
             "type": "object",
             "required": ["id", "commandType", "params"],
             "properties": {
@@ -846,7 +871,32 @@
           },
 
           {
-            "description": "Heater Shaker Module Set Target Shake Speed: Module will begin accelerating to the target shake speed. This command is non-blocking, it does not delay protocol execution while approaching the target shake speed.",
+            "description": "Heater Shaker Module Start Set Target Shake Speed: Module will begin accelerating to the target shake speed. This command is non-blocking, it does not delay protocol execution while approaching the target shake speed.",
+            "type": "object",
+            "required": ["id", "commandType", "params"],
+            "properties": {
+              "id": { "type": "string" },
+              "commandType": {
+                "enum": ["heaterShakerModule/startSetTargetShakeSpeed"]
+              },
+              "params": {
+                "required": ["moduleId", "rpm"],
+                "properties": {
+                  "moduleId": {
+                    "type": "string",
+                    "description": "Unique identifier of Heater Shaker Module to target. Must be a key from the top level 'modules' object"
+                  },
+                  "rpm": {
+                    "type": "number",
+                    "description": "target orbital rotations per minute"
+                  }
+                }
+              }
+            }
+          },
+
+          {
+            "description": "Heater Shaker Module Set Target Shake Speed: Module will delay protocol execution until the target shake speed is reached. This command is blocking, it delays protocol execution while approaching the target shake speed.",
             "type": "object",
             "required": ["id", "commandType", "params"],
             "properties": {
@@ -926,6 +976,36 @@
               "id": { "type": "string" },
               "commandType": {
                 "enum": ["heaterShakerModule/deactivateHeater"]
+              },
+              "params": {
+                "$ref": "#/definitions/moduleOnlyParams"
+              }
+            }
+          },
+
+          {
+            "description": "Heater Shaker Module Open Latch.",
+            "type": "object",
+            "required": ["id", "commandType", "params"],
+            "properties": {
+              "id": { "type": "string" },
+              "commandType": {
+                "enum": ["heaterShakerModule/openLatch"]
+              },
+              "params": {
+                "$ref": "#/definitions/moduleOnlyParams"
+              }
+            }
+          },
+
+          {
+            "description": "Heater Shaker Module Close Latch.",
+            "type": "object",
+            "required": ["id", "commandType", "params"],
+            "properties": {
+              "id": { "type": "string" },
+              "commandType": {
+                "enum": ["heaterShakerModule/closeLatch"]
               },
               "params": {
                 "$ref": "#/definitions/moduleOnlyParams"

--- a/shared-data/protocol/schemas/6.json
+++ b/shared-data/protocol/schemas/6.json
@@ -871,31 +871,6 @@
           },
 
           {
-            "description": "Heater Shaker Module Start Set Target Shake Speed: Module will begin accelerating to the target shake speed. This command is non-blocking, it does not delay protocol execution while approaching the target shake speed.",
-            "type": "object",
-            "required": ["id", "commandType", "params"],
-            "properties": {
-              "id": { "type": "string" },
-              "commandType": {
-                "enum": ["heaterShakerModule/startSetTargetShakeSpeed"]
-              },
-              "params": {
-                "required": ["moduleId", "rpm"],
-                "properties": {
-                  "moduleId": {
-                    "type": "string",
-                    "description": "Unique identifier of Heater Shaker Module to target. Must be a key from the top level 'modules' object"
-                  },
-                  "rpm": {
-                    "type": "number",
-                    "description": "target orbital rotations per minute"
-                  }
-                }
-              }
-            }
-          },
-
-          {
             "description": "Heater Shaker Module Set Target Shake Speed: Module will delay protocol execution until the target shake speed is reached. This command is blocking, it delays protocol execution while approaching the target shake speed.",
             "type": "object",
             "required": ["id", "commandType", "params"],
@@ -921,7 +896,7 @@
           },
 
           {
-            "description": "Heater Shaker Module Await Temperature: Delay protocol execution until the specified target temperature is reached.",
+            "description": "Heater Shaker Module Await Temperature: Delay protocol execution until the previously supplied startSetTemperature command's temperature parameter has been reached. Errors if no previous startSetTemperatureCommand has been executed",
             "type": "object",
             "required": ["id", "commandType", "params"],
             "properties": {
@@ -930,15 +905,11 @@
                 "enum": ["heaterShakerModule/awaitTemperature"]
               },
               "params": {
-                "required": ["moduleId", "temperature"],
+                "required": ["moduleId"],
                 "properties": {
                   "moduleId": {
                     "type": "string",
                     "description": "Unique identifier of Heater Shaker Module to target. Must be a key from the top level 'modules' object"
-                  },
-                  "temperature": {
-                    "type": "number",
-                    "description": "temperature in °C to await"
                   }
                 }
               }
@@ -976,6 +947,21 @@
               "id": { "type": "string" },
               "commandType": {
                 "enum": ["heaterShakerModule/deactivateHeater"]
+              },
+              "params": {
+                "$ref": "#/definitions/moduleOnlyParams"
+              }
+            }
+          },
+
+          {
+            "description": "Heater Shaker Module Stop Shake: Module will stop actively shaking and ramp down to a still state",
+            "type": "object",
+            "required": ["id", "commandType", "params"],
+            "properties": {
+              "id": { "type": "string" },
+              "commandType": {
+                "enum": ["heaterShakerModule/stopShake"]
               },
               "params": {
                 "$ref": "#/definitions/moduleOnlyParams"

--- a/shared-data/protocol/schemas/6.json
+++ b/shared-data/protocol/schemas/6.json
@@ -846,31 +846,6 @@
           },
 
           {
-            "description": "Heater Shaker Module Set Target Temperature: Module will delay protocol execution until the target specified target temperature is reached. This command is locking, it delays protocol execution while approaching the target temperature.",
-            "type": "object",
-            "required": ["id", "commandType", "params"],
-            "properties": {
-              "id": { "type": "string" },
-              "commandType": {
-                "enum": ["heaterShakerModule/setTargetTemperature"]
-              },
-              "params": {
-                "required": ["moduleId", "temperature"],
-                "properties": {
-                  "moduleId": {
-                    "type": "string",
-                    "description": "Unique identifier of Heater Shaker Module to target. Must be a key from the top level 'modules' object"
-                  },
-                  "temperature": {
-                    "type": "number",
-                    "description": "target temperature to heat to in °C"
-                  }
-                }
-              }
-            }
-          },
-
-          {
             "description": "Heater Shaker Module Set Target Shake Speed: Module will delay protocol execution until the target shake speed is reached. This command is blocking, it delays protocol execution while approaching the target shake speed.",
             "type": "object",
             "required": ["id", "commandType", "params"],

--- a/shared-data/protocol/types/schemaV6/command/module.ts
+++ b/shared-data/protocol/types/schemaV6/command/module.ts
@@ -17,9 +17,13 @@ export type ModuleRunTimeCommand =
   | TCRunProfileRunTimeCommand
   | TCAwaitProfileCompleteRunTimeCommand
   | HeaterShakerSetTargetTemperatureRunTimeCommand
+  | HeaterShakerStartSetTargetTemperatureRunTimeCommand
   | HeaterShakerAwaitTemperatureRunTimeCommand
   | HeaterShakerSetTargetShakeSpeedRunTimeCommand
+  | HeaterShakerStartSetTargetShakeSpeedRunTimeCommand
   | HeaterShakerAwaitShakeSpeedRunTimeCommand
+  | HeaterShakerOpenLatchRunTimeCommand
+  | HeaterShakerCloseLatchRunTimeCommand
   | HeaterShakerDeactivateHeaterRunTimeCommand
 
 export type ModuleCreateCommand =
@@ -42,6 +46,8 @@ export type ModuleCreateCommand =
   | HeaterShakerAwaitTemperatureCreateCommand
   | HeaterShakerSetTargetShakeSpeedCreateCommand
   | HeaterShakerAwaitShakeSpeedCreateCommand
+  | HeaterShakerOpenLatchCreateCommand
+  | HeaterShakerCloseLatchCreateCommand
   | HeaterShakerDeactivateHeaterCreateCommand
 
 export interface MagneticModuleEngageMagnetCreateCommand {
@@ -188,6 +194,15 @@ export interface HeaterShakerSetTargetTemperatureRunTimeCommand
     HeaterShakerSetTargetTemperatureCreateCommand {
   result: any
 }
+export interface HeaterShakerStartSetTargetTemperatureCreateCommand {
+  commandType: 'heaterShaker/startSetTargetTemperature'
+  params: TemperatureParams
+}
+export interface HeaterShakerStartSetTargetTemperatureRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    HeaterShakerStartSetTargetTemperatureCreateCommand {
+  result: any
+}
 export interface HeaterShakerAwaitTemperatureCreateCommand {
   commandType: 'heaterShaker/awaitTemperature'
   params: TemperatureParams
@@ -206,6 +221,15 @@ export interface HeaterShakerSetTargetShakeSpeedRunTimeCommand
     HeaterShakerSetTargetShakeSpeedCreateCommand {
   result: any
 }
+export interface HeaterShakerStartSetTargetShakeSpeedCreateCommand {
+  commandType: 'heaterShaker/startSetTargetShakeSpeed'
+  params: ShakeSpeedParams
+}
+export interface HeaterShakerStartSetTargetShakeSpeedRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    HeaterShakerStartSetTargetShakeSpeedCreateCommand {
+  result: any
+}
 export interface HeaterShakerAwaitShakeSpeedCreateCommand {
   commandType: 'heaterShaker/awaitShakeSpeed'
   params: ShakeSpeedParams
@@ -222,6 +246,24 @@ export interface HeaterShakerDeactivateHeaterCreateCommand {
 export interface HeaterShakerDeactivateHeaterRunTimeCommand
   extends CommonCommandRunTimeInfo,
     HeaterShakerDeactivateHeaterCreateCommand {
+  result: any
+}
+export interface HeaterShakerOpenLatchCreateCommand {
+  commandType: 'heaterShaker/openLatch'
+  params: ModuleOnlyParams
+}
+export interface HeaterShakerOpenLatchRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    HeaterShakerOpenLatchCreateCommand {
+  result: any
+}
+export interface HeaterShakerCloseLatchCreateCommand {
+  commandType: 'heaterShaker/closeLatch'
+  params: ModuleOnlyParams
+}
+export interface HeaterShakerCloseLatchRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    HeaterShakerCloseLatchCreateCommand {
   result: any
 }
 

--- a/shared-data/protocol/types/schemaV6/command/module.ts
+++ b/shared-data/protocol/types/schemaV6/command/module.ts
@@ -20,7 +20,6 @@ export type ModuleRunTimeCommand =
   | HeaterShakerStartSetTargetTemperatureRunTimeCommand
   | HeaterShakerAwaitTemperatureRunTimeCommand
   | HeaterShakerSetTargetShakeSpeedRunTimeCommand
-  | HeaterShakerStartSetTargetShakeSpeedRunTimeCommand
   | HeaterShakerAwaitShakeSpeedRunTimeCommand
   | HeaterShakerOpenLatchRunTimeCommand
   | HeaterShakerCloseLatchRunTimeCommand
@@ -205,7 +204,7 @@ export interface HeaterShakerStartSetTargetTemperatureRunTimeCommand
 }
 export interface HeaterShakerAwaitTemperatureCreateCommand {
   commandType: 'heaterShaker/awaitTemperature'
-  params: TemperatureParams
+  params: ModuleOnlyParams
 }
 export interface HeaterShakerAwaitTemperatureRunTimeCommand
   extends CommonCommandRunTimeInfo,
@@ -219,15 +218,6 @@ export interface HeaterShakerSetTargetShakeSpeedCreateCommand {
 export interface HeaterShakerSetTargetShakeSpeedRunTimeCommand
   extends CommonCommandRunTimeInfo,
     HeaterShakerSetTargetShakeSpeedCreateCommand {
-  result: any
-}
-export interface HeaterShakerStartSetTargetShakeSpeedCreateCommand {
-  commandType: 'heaterShaker/startSetTargetShakeSpeed'
-  params: ShakeSpeedParams
-}
-export interface HeaterShakerStartSetTargetShakeSpeedRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    HeaterShakerStartSetTargetShakeSpeedCreateCommand {
   result: any
 }
 export interface HeaterShakerAwaitShakeSpeedCreateCommand {
@@ -264,6 +254,15 @@ export interface HeaterShakerCloseLatchCreateCommand {
 export interface HeaterShakerCloseLatchRunTimeCommand
   extends CommonCommandRunTimeInfo,
     HeaterShakerCloseLatchCreateCommand {
+  result: any
+}
+export interface HeaterShakerStopShakeCreateCommand {
+  commandType: 'heaterShaker/stopShake'
+  params: ModuleOnlyParams
+}
+export interface HeaterShakerStopShakeRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    HeaterShakerStopShakeCreateCommand {
   result: any
 }
 

--- a/shared-data/protocol/types/schemaV6/command/module.ts
+++ b/shared-data/protocol/types/schemaV6/command/module.ts
@@ -16,7 +16,6 @@ export type ModuleRunTimeCommand =
   | TCDeactivateLidRunTimeCommand
   | TCRunProfileRunTimeCommand
   | TCAwaitProfileCompleteRunTimeCommand
-  | HeaterShakerSetTargetTemperatureRunTimeCommand
   | HeaterShakerStartSetTargetTemperatureRunTimeCommand
   | HeaterShakerAwaitTemperatureRunTimeCommand
   | HeaterShakerSetTargetShakeSpeedRunTimeCommand
@@ -40,7 +39,6 @@ export type ModuleCreateCommand =
   | TCDeactivateLidCreateCommand
   | TCRunProfileCreateCommand
   | TCAwaitProfileCompleteCreateCommand
-  | HeaterShakerSetTargetTemperatureCreateCommand
   | HeaterShakerAwaitTemperatureCreateCommand
   | HeaterShakerSetTargetShakeSpeedCreateCommand
   | HeaterShakerOpenLatchCreateCommand
@@ -182,17 +180,8 @@ export interface TCAwaitProfileCompleteRunTimeCommand
     TCAwaitProfileCompleteCreateCommand {
   result: any
 }
-export interface HeaterShakerSetTargetTemperatureCreateCommand {
-  commandType: 'heaterShaker/setTargetTemperature'
-  params: TemperatureParams
-}
-export interface HeaterShakerSetTargetTemperatureRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    HeaterShakerSetTargetTemperatureCreateCommand {
-  result: any
-}
 export interface HeaterShakerStartSetTargetTemperatureCreateCommand {
-  commandType: 'heaterShaker/startSetTargetTemperature'
+  commandType: 'heaterShakerModule/startSetTargetTemperature'
   params: TemperatureParams
 }
 export interface HeaterShakerStartSetTargetTemperatureRunTimeCommand
@@ -201,7 +190,7 @@ export interface HeaterShakerStartSetTargetTemperatureRunTimeCommand
   result: any
 }
 export interface HeaterShakerAwaitTemperatureCreateCommand {
-  commandType: 'heaterShaker/awaitTemperature'
+  commandType: 'heaterShakerModule/awaitTemperature'
   params: ModuleOnlyParams
 }
 export interface HeaterShakerAwaitTemperatureRunTimeCommand
@@ -210,7 +199,7 @@ export interface HeaterShakerAwaitTemperatureRunTimeCommand
   result: any
 }
 export interface HeaterShakerSetTargetShakeSpeedCreateCommand {
-  commandType: 'heaterShaker/setTargetShakeSpeed'
+  commandType: 'heaterShakerModule/setTargetShakeSpeed'
   params: ShakeSpeedParams
 }
 export interface HeaterShakerSetTargetShakeSpeedRunTimeCommand
@@ -219,7 +208,7 @@ export interface HeaterShakerSetTargetShakeSpeedRunTimeCommand
   result: any
 }
 export interface HeaterShakerDeactivateHeaterCreateCommand {
-  commandType: 'heaterShaker/deactivateHeater'
+  commandType: 'heaterShakerModule/deactivateHeater'
   params: ModuleOnlyParams
 }
 export interface HeaterShakerDeactivateHeaterRunTimeCommand
@@ -228,7 +217,7 @@ export interface HeaterShakerDeactivateHeaterRunTimeCommand
   result: any
 }
 export interface HeaterShakerOpenLatchCreateCommand {
-  commandType: 'heaterShaker/openLatch'
+  commandType: 'heaterShakerModule/openLatch'
   params: ModuleOnlyParams
 }
 export interface HeaterShakerOpenLatchRunTimeCommand
@@ -237,7 +226,7 @@ export interface HeaterShakerOpenLatchRunTimeCommand
   result: any
 }
 export interface HeaterShakerCloseLatchCreateCommand {
-  commandType: 'heaterShaker/closeLatch'
+  commandType: 'heaterShakerModule/closeLatch'
   params: ModuleOnlyParams
 }
 export interface HeaterShakerCloseLatchRunTimeCommand
@@ -246,7 +235,7 @@ export interface HeaterShakerCloseLatchRunTimeCommand
   result: any
 }
 export interface HeaterShakerStopShakeCreateCommand {
-  commandType: 'heaterShaker/stopShake'
+  commandType: 'heaterShakerModule/stopShake'
   params: ModuleOnlyParams
 }
 export interface HeaterShakerStopShakeRunTimeCommand

--- a/shared-data/protocol/types/schemaV6/command/module.ts
+++ b/shared-data/protocol/types/schemaV6/command/module.ts
@@ -20,7 +20,6 @@ export type ModuleRunTimeCommand =
   | HeaterShakerStartSetTargetTemperatureRunTimeCommand
   | HeaterShakerAwaitTemperatureRunTimeCommand
   | HeaterShakerSetTargetShakeSpeedRunTimeCommand
-  | HeaterShakerAwaitShakeSpeedRunTimeCommand
   | HeaterShakerOpenLatchRunTimeCommand
   | HeaterShakerCloseLatchRunTimeCommand
   | HeaterShakerDeactivateHeaterRunTimeCommand
@@ -44,7 +43,6 @@ export type ModuleCreateCommand =
   | HeaterShakerSetTargetTemperatureCreateCommand
   | HeaterShakerAwaitTemperatureCreateCommand
   | HeaterShakerSetTargetShakeSpeedCreateCommand
-  | HeaterShakerAwaitShakeSpeedCreateCommand
   | HeaterShakerOpenLatchCreateCommand
   | HeaterShakerCloseLatchCreateCommand
   | HeaterShakerDeactivateHeaterCreateCommand
@@ -218,15 +216,6 @@ export interface HeaterShakerSetTargetShakeSpeedCreateCommand {
 export interface HeaterShakerSetTargetShakeSpeedRunTimeCommand
   extends CommonCommandRunTimeInfo,
     HeaterShakerSetTargetShakeSpeedCreateCommand {
-  result: any
-}
-export interface HeaterShakerAwaitShakeSpeedCreateCommand {
-  commandType: 'heaterShaker/awaitShakeSpeed'
-  params: ShakeSpeedParams
-}
-export interface HeaterShakerAwaitShakeSpeedRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    HeaterShakerAwaitShakeSpeedCreateCommand {
   result: any
 }
 export interface HeaterShakerDeactivateHeaterCreateCommand {


### PR DESCRIPTION
# Overview
This PR adds the following additional heater shaker commands to schema v6:

- Blocking set target block temperature
- Blocking set target shake speed
- Open latch
- Close latch
- Stop Shake

It modifies the following commands:
- AwaitTemperature — this command no longer accepts a temperature. Instead, it awaits the temp of the previously supplied `startSetTargetTemperature` command's temperature parameter

It removes the following: 
- StartSetTargetShakeSpeed — we decided we don't need this and will instead rely on the blocking command since setting the target shake speed happens quickly enough that users wouldn't need to be pipetting while the module is ramping.
- AwaitTargetShakeSpeed — unnecessary now that set shake speed is blocking
# Changelog

- Add additional heater shaker commands to schema v6

# Review requests
Seem reasonable?

# Risk assessment
Low
