### PR TITLE
fix(app): add fileName to title bar if protocolName is undefined

### DIFF
--- a/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
+++ b/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
@@ -33,6 +33,7 @@ import { mockCalibrationStatus } from '../../../redux/calibration/__fixtures__'
 import { useRunStatus, useRunControls } from '../../RunTimeControl/hooks'
 import { useCurrentProtocolRun } from '../hooks/useCurrentProtocolRun'
 import { useCloseCurrentRun } from '../hooks/useCloseCurrentRun'
+import _uncastedSimpleV6Protocol from '@opentrons/shared-data/protocol/fixtures/6/simpleV6.json'
 import { UploadInput } from '../UploadInput'
 import { ProtocolUpload, ProtocolLoader } from '..'
 
@@ -94,6 +95,7 @@ const mockGetValidCustomLabwareFiles = customLabwareSelectors.getValidCustomLabw
 const mockUseTrackEvent = useTrackEvent as jest.MockedFunction<
   typeof useTrackEvent
 >
+
 const queryClient = new QueryClient()
 
 const render = () => {
@@ -141,7 +143,6 @@ describe('ProtocolUpload', () => {
       .mockReturnValue({ pause: jest.fn() } as any)
     mockTrackEvent = jest.fn()
     when(mockUseTrackEvent).calledWith().mockReturnValue(mockTrackEvent)
-
     when(mockUploadInput).mockReturnValue(<div></div>)
   })
   afterEach(() => {
@@ -171,7 +172,7 @@ describe('ProtocolUpload', () => {
       .calledWith()
       .mockReturnValue({
         protocolRecord: {
-          data: { analyses: [], metadata: { protocolName: 'protocolName' } },
+          data: { analyses: [] },
         },
         runRecord: {},
         createProtocolRun: jest.fn(),
@@ -187,9 +188,7 @@ describe('ProtocolUpload', () => {
     when(mockUseCurrentProtocolRun)
       .calledWith()
       .mockReturnValue({
-        protocolRecord: {
-          data: { analyses: [], metadata: { protocolName: 'protocolName' } },
-        },
+        protocolRecord: {},
         runRecord: {},
         createProtocolRun: jest.fn(),
       } as any)
@@ -204,9 +203,7 @@ describe('ProtocolUpload', () => {
     when(mockUseCurrentProtocolRun)
       .calledWith()
       .mockReturnValue({
-        protocolRecord: {
-          data: { analyses: [], metadata: { protocolName: 'protocolName' } },
-        },
+        protocolRecord: {},
         runRecord: {},
         createProtocolRun: jest.fn(),
       } as any)
@@ -248,9 +245,7 @@ describe('ProtocolUpload', () => {
     when(mockUseCurrentProtocolRun)
       .calledWith()
       .mockReturnValue({
-        protocolRecord: {
-          data: { analyses: [], metadata: { protocolName: 'protocolName' } },
-        },
+        protocolRecord: { data: { analyses: [] } },
         runRecord: {},
         createProtocolRun: jest.fn(),
       } as any)
@@ -268,9 +263,7 @@ describe('ProtocolUpload', () => {
     when(mockUseCurrentProtocolRun)
       .calledWith()
       .mockReturnValue({
-        protocolRecord: {
-          data: { analyses: [], metadata: { protocolName: 'protocolName' } },
-        },
+        protocolRecord: { data: { analyses: [] } },
         runRecord: {},
         createProtocolRun: jest.fn(),
       } as any)
@@ -288,9 +281,7 @@ describe('ProtocolUpload', () => {
     when(mockUseCurrentProtocolRun)
       .calledWith()
       .mockReturnValue({
-        protocolRecord: {
-          data: { analyses: [], metadata: { protocolName: 'protocolName' } },
-        },
+        protocolRecord: { data: { analyses: [] } },
         runRecord: {},
         createProtocolRun: jest.fn(),
       } as any)
@@ -308,9 +299,7 @@ describe('ProtocolUpload', () => {
     when(mockUseCurrentProtocolRun)
       .calledWith()
       .mockReturnValue({
-        protocolRecord: {
-          data: { analyses: [], metadata: { protocolName: 'protocolName' } },
-        },
+        protocolRecord: { data: { analyses: [] } },
         runRecord: {},
         createProtocolRun: jest.fn(),
       } as any)
@@ -330,9 +319,7 @@ describe('ProtocolUpload', () => {
     when(mockUseCurrentProtocolRun)
       .calledWith()
       .mockReturnValue({
-        protocolRecord: {
-          data: { analyses: [], metadata: { protocolName: 'protocolName' } },
-        },
+        protocolRecord: { data: { analyses: [] } },
         runRecord: {},
         createProtocolRun: jest.fn(),
       } as any)
@@ -345,14 +332,26 @@ describe('ProtocolUpload', () => {
     fireEvent.click(button)
     expect(screen.queryByText('mock confirm cancel modal')).not.toBeNull()
   })
-
-  it('renders only the protocol title with no button when run status is stop requested', () => {
+  it('renders protocol title', () => {
     when(mockUseCurrentProtocolRun)
       .calledWith()
       .mockReturnValue({
-        protocolRecord: {
-          data: { analyses: [], metadata: { protocolName: 'protocolName' } },
-        },
+        protocolRecord: { withModulesProtocol },
+        runRecord: {},
+        createProtocolRun: jest.fn(),
+      } as any)
+    mockUseProtocolDetails.mockReturnValue({
+      displayName: 'mock protocol name',
+    } as any)
+    const [{ getByText }] = render()
+    getByText('Protocol - mock protocol name')
+  })
+
+  it('renders only the protocol with no button when run status is stop requested', () => {
+    when(mockUseCurrentProtocolRun)
+      .calledWith()
+      .mockReturnValue({
+        protocolRecord: { data: { analyses: [] } },
         runRecord: {},
         createProtocolRun: jest.fn(),
       } as any)
@@ -363,7 +362,7 @@ describe('ProtocolUpload', () => {
       <div>mock confirm cancel modal</div>
     )
     const [{ getByText }] = render()
-    getByText('Protocol - protocolName')
+    getByText('Protocol -')
     expect(screen.queryByText('mock confirm cancel modal')).toBeNull()
     expect(screen.queryByText('Cancel Run')).toBeNull()
   })
@@ -385,7 +384,6 @@ describe('ProtocolUpload', () => {
                 ],
               },
             ],
-            metadata: { protocolName: 'protocolName' },
           },
         },
         runRecord: {},
@@ -404,9 +402,7 @@ describe('ProtocolUpload', () => {
     when(mockUseCurrentProtocolRun)
       .calledWith()
       .mockReturnValue({
-        protocolRecord: {
-          data: { analyses: [], metadata: { protocolName: 'protocolName' } },
-        },
+        protocolRecord: {},
         runRecord: {},
         createProtocolRun: jest.fn(),
         protocolCreationError: 'invalid protocol!',

--- a/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
+++ b/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
@@ -33,7 +33,6 @@ import { mockCalibrationStatus } from '../../../redux/calibration/__fixtures__'
 import { useRunStatus, useRunControls } from '../../RunTimeControl/hooks'
 import { useCurrentProtocolRun } from '../hooks/useCurrentProtocolRun'
 import { useCloseCurrentRun } from '../hooks/useCloseCurrentRun'
-import _uncastedSimpleV6Protocol from '@opentrons/shared-data/protocol/fixtures/6/simpleV6.json'
 import { UploadInput } from '../UploadInput'
 import { ProtocolUpload, ProtocolLoader } from '..'
 
@@ -245,7 +244,7 @@ describe('ProtocolUpload', () => {
     when(mockUseCurrentProtocolRun)
       .calledWith()
       .mockReturnValue({
-        protocolRecord: { data: { analyses: [] } },
+        protocolRecord: {},
         runRecord: {},
         createProtocolRun: jest.fn(),
       } as any)
@@ -347,7 +346,7 @@ describe('ProtocolUpload', () => {
     getByText('Protocol - mock protocol name')
   })
 
-  it('renders only the protocol with no button when run status is stop requested', () => {
+  it('renders only the protocol title with no button when run status is stop requested', () => {
     when(mockUseCurrentProtocolRun)
       .calledWith()
       .mockReturnValue({
@@ -361,8 +360,6 @@ describe('ProtocolUpload', () => {
     when(mockConfirmCancelModal).mockReturnValue(
       <div>mock confirm cancel modal</div>
     )
-    const [{ getByText }] = render()
-    getByText('Protocol -')
     expect(screen.queryByText('mock confirm cancel modal')).toBeNull()
     expect(screen.queryByText('Cancel Run')).toBeNull()
   })

--- a/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
+++ b/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { resetAllWhenMocks, when } from 'jest-when'
 import { QueryClient, QueryClientProvider } from 'react-query'
-import { BrowserRouter } from 'react-router-dom'
 import { fireEvent, screen } from '@testing-library/react'
 import {
   RUN_STATUS_FINISHING,
@@ -18,7 +17,6 @@ import {
 import withModulesProtocol from '@opentrons/shared-data/protocol/fixtures/4/testModulesProtocol.json'
 
 import { i18n } from '../../../i18n'
-import { useTrackEvent } from '../../../redux/analytics'
 import { mockConnectedRobot } from '../../../redux/discovery/__fixtures__'
 import * as RobotSelectors from '../../../redux/robot/selectors'
 import * as calibrationSelectors from '../../../redux/calibration/selectors'
@@ -33,10 +31,10 @@ import { mockCalibrationStatus } from '../../../redux/calibration/__fixtures__'
 import { useRunStatus, useRunControls } from '../../RunTimeControl/hooks'
 import { useCurrentProtocolRun } from '../hooks/useCurrentProtocolRun'
 import { useCloseCurrentRun } from '../hooks/useCloseCurrentRun'
+import { UploadInput } from '../UploadInput'
 import { ProtocolUpload, ProtocolLoader } from '..'
 
 jest.mock('../../../redux/protocol/selectors')
-jest.mock('../../../redux/analytics')
 jest.mock('../../../redux/protocol/utils')
 jest.mock('../../../redux/discovery/selectors')
 jest.mock('../../../redux/calibration/selectors')
@@ -48,6 +46,7 @@ jest.mock('../ConfirmExitProtocolUploadModal')
 jest.mock('../../../redux/robot/selectors')
 jest.mock('../../RunTimeControl/hooks')
 jest.mock('../../RunDetails/ConfirmCancelModal')
+jest.mock('../UploadInput')
 
 const getProtocolFile = protocolSelectors.getProtocolFile as jest.MockedFunction<
   typeof protocolSelectors.getProtocolFile
@@ -82,29 +81,25 @@ const mockUseProtocolDetails = useProtocolDetails as jest.MockedFunction<
 const mockConfirmCancelModal = ConfirmCancelModal as jest.MockedFunction<
   typeof ConfirmCancelModal
 >
+const mockUploadInput = UploadInput as jest.MockedFunction<typeof UploadInput>
 const mockGetConnectedRobotName = RobotSelectors.getConnectedRobotName as jest.MockedFunction<
   typeof RobotSelectors.getConnectedRobotName
 >
 const mockGetValidCustomLabwareFiles = customLabwareSelectors.getValidCustomLabwareFiles as jest.MockedFunction<
   typeof customLabwareSelectors.getValidCustomLabwareFiles
 >
-const mockUseTrackEvent = useTrackEvent as jest.MockedFunction<
-  typeof useTrackEvent
->
 const queryClient = new QueryClient()
 
 const render = () => {
   return renderWithProviders(
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <ProtocolUpload />
-      </BrowserRouter>
+      <ProtocolUpload />
     </QueryClientProvider>,
     { i18nInstance: i18n }
   )
 }
 
-let mockTrackEvent: jest.Mock
+const mockLoadingText = 'mockLoadingText'
 
 describe('ProtocolUpload', () => {
   beforeEach(() => {
@@ -135,8 +130,8 @@ describe('ProtocolUpload', () => {
     when(mockUseRunControls)
       .calledWith()
       .mockReturnValue({ pause: jest.fn() } as any)
-    mockTrackEvent = jest.fn()
-    when(mockUseTrackEvent).calledWith().mockReturnValue(mockTrackEvent)
+
+    when(mockUploadInput).mockReturnValue(<div></div>)
   })
   afterEach(() => {
     resetAllWhenMocks()
@@ -164,10 +159,13 @@ describe('ProtocolUpload', () => {
     when(mockUseCurrentProtocolRun)
       .calledWith()
       .mockReturnValue({
-        protocolRecord: { data: { analyses: [] } },
+        protocolRecord: {
+          data: { analyses: [], metadata: { protocolName: 'protocolName' } },
+        },
         runRecord: {},
         createProtocolRun: jest.fn(),
       } as any)
+
     const { queryByRole, getByText } = render()[0]
     expect(queryByRole('button', { name: 'Choose File...' })).toBeNull()
     expect(getByText('Organization/Author')).toBeTruthy()
@@ -178,7 +176,9 @@ describe('ProtocolUpload', () => {
     when(mockUseCurrentProtocolRun)
       .calledWith()
       .mockReturnValue({
-        protocolRecord: {},
+        protocolRecord: {
+          data: { analyses: [], metadata: { protocolName: 'protocolName' } },
+        },
         runRecord: {},
         createProtocolRun: jest.fn(),
       } as any)
@@ -193,7 +193,9 @@ describe('ProtocolUpload', () => {
     when(mockUseCurrentProtocolRun)
       .calledWith()
       .mockReturnValue({
-        protocolRecord: {},
+        protocolRecord: {
+          data: { analyses: [], metadata: { protocolName: 'protocolName' } },
+        },
         runRecord: {},
         createProtocolRun: jest.fn(),
       } as any)
@@ -235,7 +237,9 @@ describe('ProtocolUpload', () => {
     when(mockUseCurrentProtocolRun)
       .calledWith()
       .mockReturnValue({
-        protocolRecord: {},
+        protocolRecord: {
+          data: { analyses: [], metadata: { protocolName: 'protocolName' } },
+        },
         runRecord: {},
         createProtocolRun: jest.fn(),
       } as any)
@@ -253,7 +257,9 @@ describe('ProtocolUpload', () => {
     when(mockUseCurrentProtocolRun)
       .calledWith()
       .mockReturnValue({
-        protocolRecord: { data: { analyses: [] } },
+        protocolRecord: {
+          data: { analyses: [], metadata: { protocolName: 'protocolName' } },
+        },
         runRecord: {},
         createProtocolRun: jest.fn(),
       } as any)
@@ -271,7 +277,9 @@ describe('ProtocolUpload', () => {
     when(mockUseCurrentProtocolRun)
       .calledWith()
       .mockReturnValue({
-        protocolRecord: { data: { analyses: [] } },
+        protocolRecord: {
+          data: { analyses: [], metadata: { protocolName: 'protocolName' } },
+        },
         runRecord: {},
         createProtocolRun: jest.fn(),
       } as any)
@@ -289,7 +297,9 @@ describe('ProtocolUpload', () => {
     when(mockUseCurrentProtocolRun)
       .calledWith()
       .mockReturnValue({
-        protocolRecord: { data: { analyses: [] } },
+        protocolRecord: {
+          data: { analyses: [], metadata: { protocolName: 'protocolName' } },
+        },
         runRecord: {},
         createProtocolRun: jest.fn(),
       } as any)
@@ -309,7 +319,9 @@ describe('ProtocolUpload', () => {
     when(mockUseCurrentProtocolRun)
       .calledWith()
       .mockReturnValue({
-        protocolRecord: { data: { analyses: [] } },
+        protocolRecord: {
+          data: { analyses: [], metadata: { protocolName: 'protocolName' } },
+        },
         runRecord: {},
         createProtocolRun: jest.fn(),
       } as any)
@@ -327,7 +339,9 @@ describe('ProtocolUpload', () => {
     when(mockUseCurrentProtocolRun)
       .calledWith()
       .mockReturnValue({
-        protocolRecord: { data: { analyses: [] } },
+        protocolRecord: {
+          data: { analyses: [], metadata: { protocolName: 'protocolName' } },
+        },
         runRecord: {},
         createProtocolRun: jest.fn(),
       } as any)
@@ -337,6 +351,8 @@ describe('ProtocolUpload', () => {
     when(mockConfirmCancelModal).mockReturnValue(
       <div>mock confirm cancel modal</div>
     )
+    const [{ getByText }] = render()
+    getByText('Protocol - protocolName')
     expect(screen.queryByText('mock confirm cancel modal')).toBeNull()
     expect(screen.queryByText('Cancel Run')).toBeNull()
   })
@@ -358,6 +374,7 @@ describe('ProtocolUpload', () => {
                 ],
               },
             ],
+            metadata: { protocolName: 'protocolName' },
           },
         },
         runRecord: {},
@@ -376,7 +393,9 @@ describe('ProtocolUpload', () => {
     when(mockUseCurrentProtocolRun)
       .calledWith()
       .mockReturnValue({
-        protocolRecord: {},
+        protocolRecord: {
+          data: { analyses: [], metadata: { protocolName: 'protocolName' } },
+        },
         runRecord: {},
         createProtocolRun: jest.fn(),
         protocolCreationError: 'invalid protocol!',
@@ -396,7 +415,7 @@ const renderProtocolLoader = (
 describe('ProtocolLoader', () => {
   let props: React.ComponentProps<typeof ProtocolLoader>
   beforeEach(() => {
-    props = { loadingText: 'mockLoadingText' }
+    props = { loadingText: mockLoadingText }
   })
 
   it('should render ProtocolLoader text with spinner', () => {

--- a/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
+++ b/app/src/organisms/ProtocolUpload/__tests__/ProtocolUpload.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { resetAllWhenMocks, when } from 'jest-when'
 import { QueryClient, QueryClientProvider } from 'react-query'
+import { BrowserRouter } from 'react-router-dom'
 import { fireEvent, screen } from '@testing-library/react'
 import {
   RUN_STATUS_FINISHING,
@@ -17,6 +18,7 @@ import {
 import withModulesProtocol from '@opentrons/shared-data/protocol/fixtures/4/testModulesProtocol.json'
 
 import { i18n } from '../../../i18n'
+import { useTrackEvent } from '../../../redux/analytics'
 import { mockConnectedRobot } from '../../../redux/discovery/__fixtures__'
 import * as RobotSelectors from '../../../redux/robot/selectors'
 import * as calibrationSelectors from '../../../redux/calibration/selectors'
@@ -35,6 +37,7 @@ import { UploadInput } from '../UploadInput'
 import { ProtocolUpload, ProtocolLoader } from '..'
 
 jest.mock('../../../redux/protocol/selectors')
+jest.mock('../../../redux/analytics')
 jest.mock('../../../redux/protocol/utils')
 jest.mock('../../../redux/discovery/selectors')
 jest.mock('../../../redux/calibration/selectors')
@@ -88,18 +91,24 @@ const mockGetConnectedRobotName = RobotSelectors.getConnectedRobotName as jest.M
 const mockGetValidCustomLabwareFiles = customLabwareSelectors.getValidCustomLabwareFiles as jest.MockedFunction<
   typeof customLabwareSelectors.getValidCustomLabwareFiles
 >
+const mockUseTrackEvent = useTrackEvent as jest.MockedFunction<
+  typeof useTrackEvent
+>
 const queryClient = new QueryClient()
 
 const render = () => {
   return renderWithProviders(
     <QueryClientProvider client={queryClient}>
-      <ProtocolUpload />
+      <BrowserRouter>
+        <ProtocolUpload />
+      </BrowserRouter>
     </QueryClientProvider>,
     { i18nInstance: i18n }
   )
 }
 
 const mockLoadingText = 'mockLoadingText'
+let mockTrackEvent: jest.Mock
 
 describe('ProtocolUpload', () => {
   beforeEach(() => {
@@ -130,6 +139,8 @@ describe('ProtocolUpload', () => {
     when(mockUseRunControls)
       .calledWith()
       .mockReturnValue({ pause: jest.fn() } as any)
+    mockTrackEvent = jest.fn()
+    when(mockUseTrackEvent).calledWith().mockReturnValue(mockTrackEvent)
 
     when(mockUploadInput).mockReturnValue(<div></div>)
   })

--- a/app/src/organisms/ProtocolUpload/index.tsx
+++ b/app/src/organisms/ProtocolUpload/index.tsx
@@ -72,6 +72,7 @@ export function ProtocolUpload(): JSX.Element {
   const customLabwareFiles = useSelector((state: State) =>
     getValidCustomLabwareFiles(state)
   )
+
   const logger = useLogger(__filename)
   const [uploadError, setUploadError] = React.useState<
     [string, ErrorObject[] | string | null | undefined] | null
@@ -160,7 +161,10 @@ export function ProtocolUpload(): JSX.Element {
     runStatus === RUN_STATUS_PAUSE_REQUESTED ||
     runStatus === RUN_STATUS_FINISHING
 
-  const protocolName = protocolRecord?.data?.metadata?.protocolName ?? ''
+  const protocolName =
+    protocolRecord?.data?.metadata?.protocolName === undefined
+      ? protocolRecord?.data.files[0].name
+      : protocolRecord?.data.metadata.protocolName
 
   let titleBarProps
   if (

--- a/app/src/organisms/ProtocolUpload/index.tsx
+++ b/app/src/organisms/ProtocolUpload/index.tsx
@@ -41,6 +41,7 @@ import { getConnectedRobotName } from '../../redux/robot/selectors'
 import { getValidCustomLabwareFiles } from '../../redux/custom-labware/selectors'
 import { ConfirmCancelModal } from '../RunDetails/ConfirmCancelModal'
 import { useRunStatus, useRunControls } from '../RunTimeControl/hooks'
+import { useProtocolDetails } from '../RunDetails/hooks'
 
 import { ConfirmExitProtocolUploadModal } from './ConfirmExitProtocolUploadModal'
 
@@ -67,6 +68,7 @@ export function ProtocolUpload(): JSX.Element {
     protocolCreationError,
   } = useCurrentProtocolRun()
   const runStatus = useRunStatus()
+  const { displayName } = useProtocolDetails()
   const { closeCurrentRun, isProtocolRunLoaded } = useCloseCurrentRun()
   const robotName = useSelector((state: State) => getConnectedRobotName(state))
   const customLabwareFiles = useSelector((state: State) =>
@@ -161,11 +163,6 @@ export function ProtocolUpload(): JSX.Element {
     runStatus === RUN_STATUS_PAUSE_REQUESTED ||
     runStatus === RUN_STATUS_FINISHING
 
-  const protocolName =
-    protocolRecord?.data?.metadata?.protocolName === undefined
-      ? protocolRecord?.data.files[0].name
-      : protocolRecord?.data.metadata.protocolName
-
   let titleBarProps
   if (
     isProtocolRunLoaded &&
@@ -174,7 +171,7 @@ export function ProtocolUpload(): JSX.Element {
   ) {
     titleBarProps = {
       title: t('protocol_title', {
-        protocol_name: protocolName,
+        protocol_name: displayName,
       }),
       back: {
         onClick: confirmExit,
@@ -188,13 +185,13 @@ export function ProtocolUpload(): JSX.Element {
   } else if (runStatus === RUN_STATUS_STOP_REQUESTED) {
     titleBarProps = {
       title: t('protocol_title', {
-        protocol_name: protocolName,
+        protocol_name: displayName,
       }),
     }
   } else if (isRunInMotion) {
     titleBarProps = {
       title: t('protocol_title', {
-        protocol_name: protocolName,
+        protocol_name: displayName,
       }),
       rightNode: cancelRunButton,
     }

--- a/app/src/organisms/RunDetails/hooks.ts
+++ b/app/src/organisms/RunDetails/hooks.ts
@@ -5,7 +5,7 @@ import { useCurrentProtocolRun } from '../ProtocolUpload/hooks'
 import { formatInterval } from '../RunTimeControl/utils'
 import type { ProtocolFile } from '@opentrons/shared-data'
 interface ProtocolDetails {
-  displayName: string | null
+  displayName: string | undefined
   protocolData: ProtocolFile<{}> | null
 }
 
@@ -52,7 +52,10 @@ export function useProtocolDetails(): ProtocolDetails {
       protocolData = schemaV6Adapter(lastProtocolAnalysis)
     }
   }
-  const displayName = protocolRecord?.data.metadata.protocolName ?? null
+  const displayName =
+    protocolRecord?.data.metadata.protocolName === undefined
+      ? protocolRecord?.data.files[0].name
+      : protocolRecord?.data.metadata.protocolName
   return { displayName, protocolData }
 }
 

--- a/app/src/organisms/RunDetails/hooks.ts
+++ b/app/src/organisms/RunDetails/hooks.ts
@@ -53,9 +53,8 @@ export function useProtocolDetails(): ProtocolDetails {
     }
   }
   const displayName =
-    protocolRecord?.data.metadata.protocolName === undefined
-      ? protocolRecord?.data.files[0].name
-      : protocolRecord?.data.metadata.protocolName
+    protocolRecord?.data.metadata.protocolName ??
+    protocolRecord?.data.files[0].name
   return { displayName, protocolData }
 }
 

--- a/app/src/organisms/RunDetails/hooks.ts
+++ b/app/src/organisms/RunDetails/hooks.ts
@@ -5,7 +5,7 @@ import { useCurrentProtocolRun } from '../ProtocolUpload/hooks'
 import { formatInterval } from '../RunTimeControl/utils'
 import type { ProtocolFile } from '@opentrons/shared-data'
 interface ProtocolDetails {
-  displayName: string | undefined
+  displayName: string | null
   protocolData: ProtocolFile<{}> | null
 }
 
@@ -55,7 +55,7 @@ export function useProtocolDetails(): ProtocolDetails {
   const displayName =
     protocolRecord?.data.metadata.protocolName ??
     protocolRecord?.data.files[0].name
-  return { displayName, protocolData }
+  return { displayName: displayName ?? null, protocolData }
 }
 
 export function useTimeElapsedSincePause(): string | null {


### PR DESCRIPTION
closes #9163

# Overview

Currently, if you have a protocol with no name, the title bar at the top of the `RunDetails` and `ProtocolUpload` page doesn't include any protocol name. Now, if you upload a protocol with no name, it will include the `fileName` in the title bar.

Here is how it looks from `protocolUpload` page:
<img width="1020" alt="Screen Shot 2022-01-24 at 22 00 43" src="https://user-images.githubusercontent.com/66035149/150903144-0949cbd5-a88e-42d3-9163-1bab223fccf9.png">

And from the `runDetails` page
<img width="1023" alt="Screen Shot 2022-01-24 at 22 00 33" src="https://user-images.githubusercontent.com/66035149/150903168-7a4df2d3-c7ca-46c3-bcd9-5f40a0b5ba6f.png">

# Changelog

- both `runDetails` and `protocolUpload` grab the `fileName` from protocol resource

# Review requests

- test on your robot, you should now see the file name on an un named protocol

# Risk assessment

low