### PR TITLE
refactor(app): update canceling run state CTA

### DIFF
--- a/app/src/assets/localization/en/run_details.json
+++ b/app/src/assets/localization/en/run_details.json
@@ -58,5 +58,6 @@
   "protocol_run_complete": "Protocol run complete",
   "run_cta_disabled": "Complete required steps on Protocol tab before starting the run",
   "loading_protocol": "Loading Protocol",
-  "closing_protocol": "Closing Protocol"
+  "closing_protocol": "Closing Protocol",
+  "canceling_run": "Canceling Run"
 }

--- a/app/src/organisms/RunTimeControl/__tests__/RunTimeControl.test.tsx
+++ b/app/src/organisms/RunTimeControl/__tests__/RunTimeControl.test.tsx
@@ -189,7 +189,7 @@ describe('RunTimeControl', () => {
       .calledWith()
       .mockReturnValue(RUN_STATUS_STOP_REQUESTED)
     const [{ getByRole }] = render()
-    const button = getByRole('button', { name: 'Run Again' })
+    const button = getByRole('button', { name: 'Canceling Run' })
     expect(button).toBeDisabled()
   })
 
@@ -275,7 +275,7 @@ describe('RunTimeControl', () => {
 
     expect(getByText('Status: Stop requested')).toBeTruthy()
     expect(queryByText('Mock Timer')).toBeTruthy()
-    expect(getByRole('button', { name: 'Run Again' })).toBeTruthy()
+    expect(getByRole('button', { name: 'Canceling Run' })).toBeTruthy()
   })
 
   it('renders a run status and timer if stopped', () => {

--- a/app/src/organisms/RunTimeControl/index.tsx
+++ b/app/src/organisms/RunTimeControl/index.tsx
@@ -142,8 +142,11 @@ export function RunTimeControl(): JSX.Element | null {
     buttonIconName = 'play'
     buttonText = t('resume_run')
     handleButtonClick = play
+  } else if (runStatus === RUN_STATUS_STOP_REQUESTED) {
+    buttonIconName = null
+    buttonText = t('canceling_run')
+    handleButtonClick = reset
   } else if (
-    runStatus === RUN_STATUS_STOP_REQUESTED ||
     runStatus === RUN_STATUS_STOPPED ||
     runStatus === RUN_STATUS_FINISHING ||
     runStatus === RUN_STATUS_FAILED ||


### PR DESCRIPTION


# Overview

This PR updates the main CTA text when a run is canceling. closes #8783

![Screen Shot 2022-01-25 at 2 21 50 PM](https://user-images.githubusercontent.com/14794021/151047429-f6072f22-102f-41f6-a9d8-82131298e27a.png)

# Changelog

- Change main CTA text when run is canceling (stop requested).

# Review requests

- When a run is canceling make sure no buttons render in the titlebar (addressed in a previous PR) and make sure the main CTA says "Canceling Run".

# Risk assessment

low
