### PR TITLE
docs(protocol-engine): Update loadModule docs to reflect new compatibility semantics

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/load_module.py
+++ b/api/src/opentrons/protocol_engine/commands/load_module.py
@@ -17,12 +17,10 @@ class LoadModuleParams(BaseModel):
     model: ModuleModel = Field(
         ...,
         description=(
-            "The exact model name of the module to load."
+            "The model name of the module to load."
             "\n\n"
-            "In the future,"
-            " this command may change so that the load will succeed"
-            " if the physically attached module is merely compatible"
-            " with the version you requested."
+            "Protocol Engine will look for a connected module that either"
+            " exactly matches this one, or is compatible."
         ),
     )
 


### PR DESCRIPTION
PR #9273 changed the `loadModule` Protocol Engine command in a way that made it behave opposite to how its docstring specified (deliberately). This PR updates the docstring to match the new behavior.