### PR TITLE
refactor(app): stop run timer when protocol is canceled

### DIFF
--- a/app/src/organisms/RunTimeControl/Timer.tsx
+++ b/app/src/organisms/RunTimeControl/Timer.tsx
@@ -47,21 +47,14 @@ export function Timer({
           </Text>
         </>
       ) : null}
-      {runStatus === RUN_STATUS_STOP_REQUESTED && stoppedAt != null ? (
-        <>
-          <Text css={FONT_BODY_1_DARK_SEMIBOLD}>{`${t('run_time')}:`}</Text>
-          <Text css={FONT_HUGE_DARK_SEMIBOLD} marginBottom={SPACING_3}>
-            {formatInterval(stoppedAt, startTime)}
-          </Text>
-        </>
-      ) : (
-        <>
-          <Text css={FONT_BODY_1_DARK_SEMIBOLD}>{`${t('run_time')}:`}</Text>
-          <Text css={FONT_HUGE_DARK_SEMIBOLD} marginBottom={SPACING_3}>
-            {formatInterval(startTime, endTime)}
-          </Text>
-        </>
-      )}
+      <>
+        <Text css={FONT_BODY_1_DARK_SEMIBOLD}>{`${t('run_time')}:`}</Text>
+        <Text css={FONT_HUGE_DARK_SEMIBOLD} marginBottom={SPACING_3}>
+          {runStatus === RUN_STATUS_STOP_REQUESTED && stoppedAt != null
+            ? formatInterval(stoppedAt, startTime)
+            : formatInterval(startTime, endTime)}
+        </Text>
+      </>
     </>
   )
 }

--- a/app/src/organisms/RunTimeControl/Timer.tsx
+++ b/app/src/organisms/RunTimeControl/Timer.tsx
@@ -9,19 +9,23 @@ import {
   FONT_HUGE_DARK_SEMIBOLD,
   SPACING_3,
 } from '@opentrons/components'
-
+import { RUN_STATUS_STOP_REQUESTED } from '@opentrons/api-client'
 import { formatInterval } from './utils'
 
 interface TimerProps {
   startTime: string
   pausedAt: string | null
+  stoppedAt: string | null
   completedAt: string | null
+  runStatus?: string
 }
 
 export function Timer({
   startTime,
   pausedAt,
+  stoppedAt,
   completedAt,
+  runStatus,
 }: TimerProps): JSX.Element {
   const { t } = useTranslation('run_details')
 
@@ -43,10 +47,21 @@ export function Timer({
           </Text>
         </>
       ) : null}
-      <Text css={FONT_BODY_1_DARK_SEMIBOLD}>{`${t('run_time')}:`}</Text>
-      <Text css={FONT_HUGE_DARK_SEMIBOLD} marginBottom={SPACING_3}>
-        {formatInterval(startTime, endTime)}
-      </Text>
+      {runStatus === RUN_STATUS_STOP_REQUESTED && stoppedAt != null ? (
+        <>
+          <Text css={FONT_BODY_1_DARK_SEMIBOLD}>{`${t('run_time')}:`}</Text>
+          <Text css={FONT_HUGE_DARK_SEMIBOLD} marginBottom={SPACING_3}>
+            {formatInterval(stoppedAt, startTime)}
+          </Text>
+        </>
+      ) : (
+        <>
+          <Text css={FONT_BODY_1_DARK_SEMIBOLD}>{`${t('run_time')}:`}</Text>
+          <Text css={FONT_HUGE_DARK_SEMIBOLD} marginBottom={SPACING_3}>
+            {formatInterval(startTime, endTime)}
+          </Text>
+        </>
+      )}
     </>
   )
 }

--- a/app/src/organisms/RunTimeControl/__tests__/Timer.test.tsx
+++ b/app/src/organisms/RunTimeControl/__tests__/Timer.test.tsx
@@ -3,14 +3,21 @@ import { renderWithProviders } from '@opentrons/components'
 
 import { i18n } from '../../../i18n'
 import { Timer } from '../Timer'
+import { RUN_STATUS_STOP_REQUESTED } from '@opentrons/api-client'
 
 const START_TIME = '2021-10-07T18:44:49.366581+00:00'
 const PAUSED_TIME = '2021-10-07T18:47:55.366581+00:00'
 const COMPLETED_TIME = '2021-10-07T18:58:59.366581+00:00'
+const STOPPED_TIME = '2021-10-07T18:45:49.366581+00:00'
 
 const render = () => {
   return renderWithProviders(
-    <Timer startTime={START_TIME} pausedAt={null} completedAt={null} />,
+    <Timer
+      startTime={START_TIME}
+      pausedAt={null}
+      stoppedAt={null}
+      completedAt={null}
+    />,
     {
       i18nInstance: i18n,
     }
@@ -19,7 +26,12 @@ const render = () => {
 
 const renderPaused = () => {
   return renderWithProviders(
-    <Timer startTime={START_TIME} pausedAt={PAUSED_TIME} completedAt={null} />,
+    <Timer
+      startTime={START_TIME}
+      pausedAt={PAUSED_TIME}
+      stoppedAt={null}
+      completedAt={null}
+    />,
     {
       i18nInstance: i18n,
     }
@@ -31,7 +43,23 @@ const renderCompleted = () => {
     <Timer
       startTime={START_TIME}
       pausedAt={null}
+      stoppedAt={null}
       completedAt={COMPLETED_TIME}
+    />,
+    {
+      i18nInstance: i18n,
+    }
+  )
+}
+
+const renderStopped = () => {
+  return renderWithProviders(
+    <Timer
+      startTime={START_TIME}
+      pausedAt={null}
+      stoppedAt={STOPPED_TIME}
+      completedAt={null}
+      runStatus={RUN_STATUS_STOP_REQUESTED}
     />,
     {
       i18nInstance: i18n,
@@ -70,5 +98,12 @@ describe('Timer', () => {
 
     expect(getByText('Run Time:')).toBeTruthy()
     expect(getByText('00:14:10')).toBeTruthy()
+  })
+
+  it('renders a stopped time when run is canceled', () => {
+    const [{ getByText }] = renderStopped()
+
+    expect(getByText('Run Time:')).toBeTruthy()
+    expect(getByText('00:01:00')).toBeTruthy()
   })
 })

--- a/app/src/organisms/RunTimeControl/__tests__/hooks.test.tsx
+++ b/app/src/organisms/RunTimeControl/__tests__/hooks.test.tsx
@@ -31,6 +31,7 @@ import {
   useRunCompleteTime,
   useRunControls,
   useRunPauseTime,
+  useRunStopTime,
   useRunStatus,
   useRunStartTime,
 } from '../hooks'
@@ -410,6 +411,44 @@ describe('useRunPauseTime hook', () => {
 
     const { result } = renderHook(useRunPauseTime)
     expect(result.current).toBe('2021-10-25T13:23:31.366581+00:00')
+  })
+})
+
+describe('useRunStopTime hook', () => {
+  afterEach(() => {
+    resetAllWhenMocks()
+  })
+
+  it('returns null when stop is not the last action', async () => {
+    when(mockUseCurrentProtocolRun)
+      .calledWith()
+      .mockReturnValue({
+        runRecord: { data: mockRunningRun },
+      } as UseCurrentProtocolRun)
+    when(mockUseRunQuery)
+      .calledWith(RUN_ID_2)
+      .mockReturnValue(({
+        data: { data: mockRunningRun },
+      } as unknown) as UseQueryResult<Run>)
+
+    const { result } = renderHook(useRunStopTime)
+    expect(result.current).toBe(null)
+  })
+
+  it('returns the stop time of the current run when stop is the last action', async () => {
+    when(mockUseCurrentProtocolRun)
+      .calledWith()
+      .mockReturnValue({
+        runRecord: { data: mockStoppedRun },
+      } as UseCurrentProtocolRun)
+    when(mockUseRunQuery)
+      .calledWith(RUN_ID_2)
+      .mockReturnValue(({
+        data: { data: mockStoppedRun },
+      } as unknown) as UseQueryResult<Run>)
+
+    const { result } = renderHook(useRunStopTime)
+    expect(result.current).toBe('2021-10-25T13:58:22.366581+00:00')
   })
 })
 

--- a/app/src/organisms/RunTimeControl/hooks.ts
+++ b/app/src/organisms/RunTimeControl/hooks.ts
@@ -11,6 +11,7 @@ import {
   RUN_STATUS_STOPPED,
   RUN_STATUS_FAILED,
   RUN_STATUS_SUCCEEDED,
+  RUN_ACTION_TYPE_STOP,
 } from '@opentrons/api-client'
 import {
   useCommandQuery,
@@ -123,6 +124,21 @@ export function useRunPauseTime(): string | null {
   const lastAction = last(actions)
 
   return lastAction?.actionType === RUN_ACTION_TYPE_PAUSE
+    ? lastAction.createdAt
+    : null
+}
+
+export function useRunStopTime(): string | null {
+  const { runRecord } = useCurrentProtocolRun()
+
+  const currentRunId = runRecord?.data?.id
+
+  const { data } = useRunQuery(currentRunId as string)
+
+  const actions = data?.data.actions as RunAction[]
+  const lastAction = last(actions)
+
+  return lastAction?.actionType === RUN_ACTION_TYPE_STOP
     ? lastAction.createdAt
     : null
 }

--- a/app/src/organisms/RunTimeControl/hooks.ts
+++ b/app/src/organisms/RunTimeControl/hooks.ts
@@ -48,7 +48,7 @@ export function useRunControls(): RunControls {
   } = useRunActionMutations(currentRunId as string)
 
   const { cloneRun, isLoading: isResetRunLoading } = useCloneRun(
-    currentRunId as string
+    currentRunId ?? null
   )
 
   return {
@@ -68,7 +68,7 @@ export function useRunStatus(): RunStatus | null {
 
   const currentRunId = runRecord?.data?.id
 
-  const { data } = useRunQuery(currentRunId as string, {
+  const { data } = useRunQuery(currentRunId ?? null, {
     refetchInterval: 1000,
   })
 
@@ -102,7 +102,7 @@ export function useRunStartTime(): string | undefined {
 
   const currentRunId = runRecord?.data?.id
 
-  const { data } = useRunQuery(currentRunId as string)
+  const { data } = useRunQuery(currentRunId ?? null)
 
   const actions = data?.data?.actions as RunAction[]
   const firstPlay = actions?.find(
@@ -118,7 +118,7 @@ export function useRunPauseTime(): string | null {
 
   const currentRunId = runRecord?.data?.id
 
-  const { data } = useRunQuery(currentRunId as string)
+  const { data } = useRunQuery(currentRunId ?? null)
 
   const actions = data?.data.actions as RunAction[]
   const lastAction = last(actions)
@@ -133,7 +133,7 @@ export function useRunStopTime(): string | null {
 
   const currentRunId = runRecord?.data?.id
 
-  const { data } = useRunQuery(currentRunId as string)
+  const { data } = useRunQuery(currentRunId ?? null)
 
   const actions = data?.data.actions as RunAction[]
   const lastAction = last(actions)
@@ -152,7 +152,7 @@ export function useRunCompleteTime(): string | null {
 
   const lastCommandId = last(runData?.commands)?.id
 
-  const { data: commandData } = useCommandQuery(runId, lastCommandId as string)
+  const { data: commandData } = useCommandQuery(runId, lastCommandId ?? null)
 
   const lastActionAt = last(runData?.actions)?.createdAt
   const lastErrorAt = last(runData?.errors)?.createdAt

--- a/app/src/organisms/RunTimeControl/index.tsx
+++ b/app/src/organisms/RunTimeControl/index.tsx
@@ -42,6 +42,7 @@ import {
   useRunPauseTime,
   useRunStartTime,
   useRunStatus,
+  useRunStopTime,
 } from './hooks'
 import { Timer } from './Timer'
 
@@ -54,6 +55,7 @@ export function RunTimeControl(): JSX.Element | null {
   const runStatus = useRunStatus()
   const startTime = useRunStartTime()
   const pausedAt = useRunPauseTime()
+  const stoppedAt = useRunStopTime()
   const completedAt = useRunCompleteTime()
 
   const {
@@ -176,7 +178,9 @@ export function RunTimeControl(): JSX.Element | null {
         <Timer
           startTime={startTime}
           pausedAt={pausedAt}
+          stoppedAt={stoppedAt}
           completedAt={completedAt}
+          runStatus={runStatus}
         />
       ) : null}
       <NewPrimaryBtn


### PR DESCRIPTION


# Overview

This PR stops the run timer when the protocol is canceled by utilizing the stop time from the run
record. closes #9264

# Changelog

- Added hook to retrieve the stop time
- Added conditional to render the stop time when run status is canceled (stop requested)

# Review requests

- Start a run, then cancel the run and ensure that the run timer has stopped and does not continue.

# Risk assessment

low
