### PR TITLE
refactor(api): Separate OT3 robot config

### DIFF
--- a/api/src/opentrons/config/defaults_ot2.py
+++ b/api/src/opentrons/config/defaults_ot2.py
@@ -1,0 +1,214 @@
+from copy import deepcopy
+from dataclasses import asdict
+from typing import Dict, Any, List, cast, Union, Optional, TypeVar
+from typing_extensions import Final
+from .types import RobotConfig, CurrentDict, AxisDict
+
+ROBOT_CONFIG_VERSION: Final = 4
+PLUNGER_CURRENT_LOW = 0.05
+PLUNGER_CURRENT_HIGH = 0.05
+
+MOUNT_CURRENT_LOW = 0.1
+MOUNT_CURRENT_HIGH = 0.8
+
+X_CURRENT_LOW = 0.3
+X_CURRENT_HIGH = 1.25
+
+Y_CURRENT_LOW = 0.3
+Y_CURRENT_HIGH = 1.25
+
+XY_CURRENT_LOW_REFRESH = 0.7
+MOUNT_CURRENT_HIGH_REFRESH = 0.5
+
+Z_RETRACT_DISTANCE = 2
+
+HIGH_CURRENT: CurrentDict = {
+    "default": {
+        "X": X_CURRENT_HIGH,
+        "Y": Y_CURRENT_HIGH,
+        "Z": MOUNT_CURRENT_HIGH_REFRESH,
+        "A": MOUNT_CURRENT_HIGH_REFRESH,
+        "B": PLUNGER_CURRENT_HIGH,
+        "C": PLUNGER_CURRENT_HIGH,
+    },
+    "2.1": {
+        "X": X_CURRENT_HIGH,
+        "Y": Y_CURRENT_HIGH,
+        "Z": MOUNT_CURRENT_HIGH,
+        "A": MOUNT_CURRENT_HIGH,
+        "B": PLUNGER_CURRENT_HIGH,
+        "C": PLUNGER_CURRENT_HIGH,
+    },
+}
+
+LOW_CURRENT: CurrentDict = {
+    "default": {
+        "X": XY_CURRENT_LOW_REFRESH,
+        "Y": XY_CURRENT_LOW_REFRESH,
+        "Z": MOUNT_CURRENT_LOW,
+        "A": MOUNT_CURRENT_LOW,
+        "B": PLUNGER_CURRENT_LOW,
+        "C": PLUNGER_CURRENT_LOW,
+    },
+    "2.1": {
+        "X": X_CURRENT_LOW,
+        "Y": Y_CURRENT_LOW,
+        "Z": MOUNT_CURRENT_LOW,
+        "A": MOUNT_CURRENT_LOW,
+        "B": PLUNGER_CURRENT_LOW,
+        "C": PLUNGER_CURRENT_LOW,
+    },
+}
+
+DEFAULT_CURRENT: CurrentDict = {
+    "default": {
+        "X": HIGH_CURRENT["default"]["X"],
+        "Y": HIGH_CURRENT["default"]["Y"],
+        "Z": HIGH_CURRENT["default"]["Z"],
+        "A": HIGH_CURRENT["default"]["A"],
+        "B": LOW_CURRENT["default"]["B"],
+        "C": LOW_CURRENT["default"]["C"],
+    },
+    "2.1": {
+        "X": HIGH_CURRENT["2.1"]["X"],
+        "Y": HIGH_CURRENT["2.1"]["Y"],
+        "Z": HIGH_CURRENT["2.1"]["Z"],
+        "A": HIGH_CURRENT["2.1"]["A"],
+        "B": LOW_CURRENT["2.1"]["B"],
+        "C": LOW_CURRENT["2.1"]["C"],
+    },
+}
+
+X_MAX_SPEED = 600
+Y_MAX_SPEED = 400
+Z_MAX_SPEED = 125
+A_MAX_SPEED = 125
+B_MAX_SPEED = 40
+C_MAX_SPEED = 40
+
+DEFAULT_MAX_SPEEDS: AxisDict = {
+    "X": X_MAX_SPEED,
+    "Y": Y_MAX_SPEED,
+    "Z": Z_MAX_SPEED,
+    "A": A_MAX_SPEED,
+    "B": B_MAX_SPEED,
+    "C": C_MAX_SPEED,
+}
+
+DEFAULT_CURRENT_STRING = " ".join(
+    ["{}{}".format(key, value) for key, value in DEFAULT_CURRENT.items()]
+)
+
+DEFAULT_DECK_CALIBRATION_V2: List[List[float]] = [
+    [1.00, 0.00, 0.00],
+    [0.00, 1.00, 0.00],
+    [0.00, 0.00, 1.00],
+]
+
+DEFAULT_SIMULATION_CALIBRATION: List[List[float]] = [
+    [1.0, 0.0, 0.0, 0.0],
+    [0.0, 1.0, 0.0, 0.0],
+    [0.0, 0.0, 1.0, -25.0],
+    [0.0, 0.0, 0.0, 1.0],
+]
+
+X_ACCELERATION = 3000
+Y_ACCELERATION = 2000
+Z_ACCELERATION = 1500
+A_ACCELERATION = 1500
+B_ACCELERATION = 200
+C_ACCELERATION = 200
+
+DEFAULT_ACCELERATION: Dict[str, float] = {
+    "X": X_ACCELERATION,
+    "Y": Y_ACCELERATION,
+    "Z": Z_ACCELERATION,
+    "A": A_ACCELERATION,
+    "B": B_ACCELERATION,
+    "C": C_ACCELERATION,
+}
+
+DEFAULT_PIPETTE_CONFIGS: Dict[str, float] = {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "maxTravel": 30,
+}
+
+DEFAULT_GANTRY_STEPS_PER_MM: Dict[str, float] = {
+    "X": 80.00,
+    "Y": 80.00,
+    "Z": 400,
+    "A": 400,
+}
+
+
+DEFAULT_MOUNT_OFFSET = [-34, 0, 0]
+DEFAULT_PIPETTE_OFFSET = [0.0, 0.0, 0.0]
+SERIAL_SPEED = 115200
+DEFAULT_LOG_LEVEL = "INFO"
+
+DictType = TypeVar("DictType", bound=Dict)
+
+
+def _build_dict_with_default(
+    from_conf: Union[DictType, str, None], default: DictType
+) -> DictType:
+    if not isinstance(from_conf, dict):
+        return default
+    else:
+        return cast(DictType, from_conf)
+
+
+def _build_hw_versioned_current_dict(
+    from_conf: Optional[Dict[str, Any]], default: CurrentDict
+) -> CurrentDict:
+    if not from_conf or not isinstance(from_conf, dict):
+        return default
+    # special case: if this is a valid old (i.e. not model-specific) current
+    # setup, migrate it.
+    if "default" not in from_conf and not (set("XYZABC") - set(from_conf.keys())):
+        new_dct = deepcopy(default)
+        # Because there's no case in which a machine with a more recent revision
+        # than 2.1 should have a valid and edited robot config when updating
+        # to this code, we should default it to 2.1 to avoid breaking other
+        # robots
+        new_dct["2.1"] = cast(AxisDict, from_conf)
+        return new_dct
+    return cast(CurrentDict, from_conf)
+
+
+def build_with_defaults(robot_settings: Dict[str, Any]) -> RobotConfig:
+    return RobotConfig(
+        model="OT-2 Standard",
+        name=robot_settings.get("name", "Ada Lovelace"),
+        version=ROBOT_CONFIG_VERSION,
+        gantry_steps_per_mm=_build_dict_with_default(
+            robot_settings.get("steps_per_mm"), DEFAULT_GANTRY_STEPS_PER_MM
+        ),
+        acceleration=_build_dict_with_default(
+            robot_settings.get("acceleration"), DEFAULT_ACCELERATION
+        ),
+        serial_speed=robot_settings.get("serial_speed", SERIAL_SPEED),
+        default_current=_build_hw_versioned_current_dict(
+            robot_settings.get("default_current"), DEFAULT_CURRENT
+        ),
+        low_current=_build_hw_versioned_current_dict(
+            robot_settings.get("low_current"), LOW_CURRENT
+        ),
+        high_current=_build_hw_versioned_current_dict(
+            robot_settings.get("high_current"), HIGH_CURRENT
+        ),
+        default_max_speed=robot_settings.get("default_max_speed", DEFAULT_MAX_SPEEDS),
+        log_level=robot_settings.get("log_level", DEFAULT_LOG_LEVEL),
+        default_pipette_configs=robot_settings.get(
+            "default_pipette_configs", DEFAULT_PIPETTE_CONFIGS
+        ),
+        z_retract_distance=robot_settings.get("z_retract_distance", Z_RETRACT_DISTANCE),
+        left_mount_offset=robot_settings.get("left_mount_offset", DEFAULT_MOUNT_OFFSET),
+    )
+
+
+def serialize(config: RobotConfig) -> Dict[str, Any]:
+    config_dict = asdict(config)
+    config_dict.pop("model", None)
+    return config_dict

--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -1,8 +1,17 @@
-from typing import Any, Dict, cast
+from typing import Any, Dict, cast, List
 from typing_extensions import Final
 from dataclasses import asdict
 
 from .types import OT3Config, ByPipetteKind, GeneralizeableAxisDict
+
+DEFAULT_DECK_CALIBRATION: List[List[float]] = [
+    [-1.00, 0.00, 0.00],
+    [0.00, -1.00, 0.00],
+    [0.00, 0.00, 1.00],
+]
+
+DEFAULT_PIPETTE_OFFSET = [0.0, 0.0, 0.0]
+
 
 ROBOT_CONFIG_VERSION: Final = 1
 DEFAULT_LOG_LEVEL = "INFO"

--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -1,0 +1,249 @@
+from typing import Any, Dict, cast
+from typing_extensions import Final
+from dataclasses import asdict
+
+from .types import OT3Config, ByPipetteKind, GeneralizeableAxisDict
+
+ROBOT_CONFIG_VERSION: Final = 1
+DEFAULT_LOG_LEVEL = "INFO"
+DEFAULT_MOUNT_OFFSET = [50.0, 0.0, 0.0]
+DEFAULT_Z_RETRACT_DISTANCE = 2
+
+DEFAULT_MAX_SPEEDS: ByPipetteKind[GeneralizeableAxisDict] = ByPipetteKind(
+    none={
+        "X": 500,
+        "Y": 500,
+        "Z": 500,
+        "P": 500,
+    },
+    high_throughput={
+        "X": 500,
+        "Y": 500,
+        "Z": 500,
+        "P": 500,
+    },
+    low_throughput={
+        "X": 500,
+        "Y": 500,
+        "Z": 500,
+        "P": 500,
+    },
+    two_low_throughput={
+        "X": 500,
+        "Y": 500,
+    },
+    gripper={
+        "Z": 500,
+    },
+)
+
+DEFAULT_ACCELERATIONS: ByPipetteKind[GeneralizeableAxisDict] = ByPipetteKind(
+    none={
+        "X": 10000,
+        "Y": 10000,
+        "Z": 10000,
+        "P": 10000,
+    },
+    high_throughput={
+        "X": 10000,
+        "Y": 10000,
+        "Z": 10000,
+        "P": 10000,
+    },
+    low_throughput={
+        "X": 10000,
+        "Y": 10000,
+        "Z": 10000,
+        "P": 10000,
+    },
+    two_low_throughput={
+        "X": 10000,
+        "Y": 10000,
+    },
+    gripper={
+        "Z": 10000,
+    },
+)
+
+DEFAULT_MAX_SPEED_DISCONTINUITY: ByPipetteKind[GeneralizeableAxisDict] = ByPipetteKind(
+    none={
+        "X": 40,
+        "Y": 40,
+        "Z": 40,
+        "P": 40,
+    },
+    high_throughput={
+        "X": 40,
+        "Y": 40,
+        "Z": 40,
+        "P": 40,
+    },
+    low_throughput={
+        "X": 40,
+        "Y": 40,
+        "Z": 40,
+        "P": 40,
+    },
+    two_low_throughput={
+        "X": 40,
+        "Y": 40,
+    },
+    gripper={
+        "Z": 40,
+    },
+)
+
+DEFAULT_DIRECTION_CHANGE_SPEED_DISCONTINUITY: ByPipetteKind[
+    GeneralizeableAxisDict
+] = ByPipetteKind(
+    none={
+        "X": 20,
+        "Y": 20,
+        "Z": 20,
+        "P": 20,
+    },
+    high_throughput={
+        "X": 20,
+        "Y": 20,
+        "Z": 20,
+        "P": 20,
+    },
+    low_throughput={
+        "X": 20,
+        "Y": 20,
+        "Z": 20,
+        "P": 20,
+    },
+    two_low_throughput={
+        "X": 20,
+        "Y": 20,
+    },
+    gripper={
+        "Z": 20,
+    },
+)
+
+DEFAULT_HOLDING_CURRENT: ByPipetteKind[GeneralizeableAxisDict] = ByPipetteKind(
+    none={
+        "X": 0.1,
+        "Y": 0.1,
+        "Z": 0.1,
+        "P": 0.1,
+    },
+    high_throughput={
+        "X": 0.1,
+        "Y": 0.1,
+        "Z": 0.1,
+        "P": 0.1,
+    },
+    low_throughput={
+        "X": 0.1,
+        "Y": 0.1,
+        "Z": 0.1,
+        "P": 0.1,
+    },
+    two_low_throughput={
+        "X": 0.1,
+        "Y": 0.1,
+    },
+    gripper={
+        "Z": 0.1,
+    },
+)
+
+DEFAULT_NORMAL_MOTION_CURRENT: ByPipetteKind[GeneralizeableAxisDict] = ByPipetteKind(
+    none={
+        "X": 1.0,
+        "Y": 1.0,
+        "Z": 1.0,
+        "P": 1.0,
+    },
+    high_throughput={
+        "X": 1.0,
+        "Y": 1.0,
+        "Z": 1.0,
+        "P": 1.0,
+    },
+    low_throughput={
+        "X": 1.0,
+        "Y": 1.0,
+        "Z": 1.0,
+        "P": 1.0,
+    },
+    two_low_throughput={
+        "X": 1.0,
+        "Y": 1.0,
+    },
+    gripper={
+        "Z": 1.0,
+    },
+)
+
+
+def _build_dict_with_default(
+    from_conf: Any,
+    default: GeneralizeableAxisDict,
+) -> GeneralizeableAxisDict:
+    if not isinstance(from_conf, dict):
+        return default
+    else:
+        for k in default.keys():
+            if k not in from_conf:
+                from_conf[k] = default[k]  # type: ignore[misc]
+        return cast(GeneralizeableAxisDict, from_conf)
+
+
+def _build_default_bpk(
+    from_conf: Any, default: ByPipetteKind[GeneralizeableAxisDict]
+) -> ByPipetteKind[GeneralizeableAxisDict]:
+    return ByPipetteKind(
+        low_throughput=_build_dict_with_default(
+            from_conf.get("low_throughput", {}), default.low_throughput
+        ),
+        high_throughput=_build_dict_with_default(
+            from_conf.get("high_throughput", {}), default.high_throughput
+        ),
+        two_low_throughput=_build_dict_with_default(
+            from_conf.get("two_low_throughput", {}), default.two_low_throughput
+        ),
+        none=_build_dict_with_default(from_conf.get("none", {}), default.none),
+        gripper=_build_dict_with_default(from_conf.get("gripper", {}), default.gripper),
+    )
+
+
+def build_with_defaults(robot_settings: Dict[str, Any]) -> OT3Config:
+    return OT3Config(
+        model="OT-3 Standard",
+        version=ROBOT_CONFIG_VERSION,
+        name=robot_settings.get("name", "Grace Hopper"),
+        log_level=robot_settings.get("log_level", DEFAULT_LOG_LEVEL),
+        left_mount_offset=robot_settings.get("left_mount_offset", DEFAULT_MOUNT_OFFSET),
+        default_max_speed=_build_default_bpk(
+            robot_settings.get("default_max_speed", {}), DEFAULT_MAX_SPEEDS
+        ),
+        acceleration=_build_default_bpk(
+            robot_settings.get("acceleration", {}), DEFAULT_ACCELERATIONS
+        ),
+        max_speed_discontinuity=_build_default_bpk(
+            robot_settings.get("max_speed_discontinuity", {}),
+            DEFAULT_MAX_SPEED_DISCONTINUITY,
+        ),
+        direction_change_speed_discontinuity=_build_default_bpk(
+            robot_settings.get("direction_change_speed_discontinuity", {}),
+            DEFAULT_DIRECTION_CHANGE_SPEED_DISCONTINUITY,
+        ),
+        holding_current=_build_default_bpk(
+            robot_settings.get("holding_current", {}), DEFAULT_HOLDING_CURRENT
+        ),
+        normal_motion_current=_build_default_bpk(
+            robot_settings.get("normal_motion_current", {}),
+            DEFAULT_NORMAL_MOTION_CURRENT,
+        ),
+        z_retract_distance=robot_settings.get(
+            "z_retract_distance", DEFAULT_Z_RETRACT_DISTANCE
+        ),
+    )
+
+
+def serialize(config: OT3Config) -> Dict[str, Any]:
+    return asdict(config)

--- a/api/src/opentrons/config/robot_configs.py
+++ b/api/src/opentrons/config/robot_configs.py
@@ -1,191 +1,17 @@
-from copy import deepcopy
 import json
 import logging
 import os
-from dataclasses import asdict
 from pathlib import Path
 
-from typing import Any, Dict, List, Union, Optional, TypeVar, cast
+from typing import Any, Dict, List, Union, Optional
+from typing_extensions import Literal
 
-from opentrons.config import CONFIG
+from . import CONFIG, defaults_ot3, defaults_ot2
+from .feature_flags import enable_ot3_hardware_controller
 from opentrons.hardware_control.types import BoardRevision
-from .types import CurrentDict, RobotConfig, AxisDict
+from .types import CurrentDict, RobotConfig, AxisDict, OT3Config
 
 log = logging.getLogger(__name__)
-
-ROBOT_CONFIG_VERSION = 4
-
-PLUNGER_CURRENT_LOW = 0.05
-PLUNGER_CURRENT_HIGH = 0.05
-
-MOUNT_CURRENT_LOW = 0.1
-MOUNT_CURRENT_HIGH = 0.8
-
-X_CURRENT_LOW = 0.3
-X_CURRENT_HIGH = 1.25
-
-Y_CURRENT_LOW = 0.3
-Y_CURRENT_HIGH = 1.25
-
-XY_CURRENT_LOW_REFRESH = 0.7
-MOUNT_CURRENT_HIGH_REFRESH = 0.5
-
-Z_RETRACT_DISTANCE = 2
-
-HIGH_CURRENT: CurrentDict = {
-    "default": {
-        "X": X_CURRENT_HIGH,
-        "Y": Y_CURRENT_HIGH,
-        "Z": MOUNT_CURRENT_HIGH_REFRESH,
-        "A": MOUNT_CURRENT_HIGH_REFRESH,
-        "B": PLUNGER_CURRENT_HIGH,
-        "C": PLUNGER_CURRENT_HIGH,
-    },
-    "2.1": {
-        "X": X_CURRENT_HIGH,
-        "Y": Y_CURRENT_HIGH,
-        "Z": MOUNT_CURRENT_HIGH,
-        "A": MOUNT_CURRENT_HIGH,
-        "B": PLUNGER_CURRENT_HIGH,
-        "C": PLUNGER_CURRENT_HIGH,
-    },
-}
-
-LOW_CURRENT: CurrentDict = {
-    "default": {
-        "X": XY_CURRENT_LOW_REFRESH,
-        "Y": XY_CURRENT_LOW_REFRESH,
-        "Z": MOUNT_CURRENT_LOW,
-        "A": MOUNT_CURRENT_LOW,
-        "B": PLUNGER_CURRENT_LOW,
-        "C": PLUNGER_CURRENT_LOW,
-    },
-    "2.1": {
-        "X": X_CURRENT_LOW,
-        "Y": Y_CURRENT_LOW,
-        "Z": MOUNT_CURRENT_LOW,
-        "A": MOUNT_CURRENT_LOW,
-        "B": PLUNGER_CURRENT_LOW,
-        "C": PLUNGER_CURRENT_LOW,
-    },
-}
-
-DEFAULT_CURRENT: CurrentDict = {
-    "default": {
-        "X": HIGH_CURRENT["default"]["X"],
-        "Y": HIGH_CURRENT["default"]["Y"],
-        "Z": HIGH_CURRENT["default"]["Z"],
-        "A": HIGH_CURRENT["default"]["A"],
-        "B": LOW_CURRENT["default"]["B"],
-        "C": LOW_CURRENT["default"]["C"],
-    },
-    "2.1": {
-        "X": HIGH_CURRENT["2.1"]["X"],
-        "Y": HIGH_CURRENT["2.1"]["Y"],
-        "Z": HIGH_CURRENT["2.1"]["Z"],
-        "A": HIGH_CURRENT["2.1"]["A"],
-        "B": LOW_CURRENT["2.1"]["B"],
-        "C": LOW_CURRENT["2.1"]["C"],
-    },
-}
-
-X_MAX_SPEED = 600
-Y_MAX_SPEED = 400
-Z_MAX_SPEED = 125
-A_MAX_SPEED = 125
-B_MAX_SPEED = 40
-C_MAX_SPEED = 40
-
-DEFAULT_MAX_SPEEDS: AxisDict = {
-    "X": X_MAX_SPEED,
-    "Y": Y_MAX_SPEED,
-    "Z": Z_MAX_SPEED,
-    "A": A_MAX_SPEED,
-    "B": B_MAX_SPEED,
-    "C": C_MAX_SPEED,
-}
-
-DEFAULT_CURRENT_STRING = " ".join(
-    ["{}{}".format(key, value) for key, value in DEFAULT_CURRENT.items()]
-)
-
-DEFAULT_DECK_CALIBRATION_V2: List[List[float]] = [
-    [1.00, 0.00, 0.00],
-    [0.00, 1.00, 0.00],
-    [0.00, 0.00, 1.00],
-]
-
-DEFAULT_SIMULATION_CALIBRATION: List[List[float]] = [
-    [1.0, 0.0, 0.0, 0.0],
-    [0.0, 1.0, 0.0, 0.0],
-    [0.0, 0.0, 1.0, -25.0],
-    [0.0, 0.0, 0.0, 1.0],
-]
-
-X_ACCELERATION = 3000
-Y_ACCELERATION = 2000
-Z_ACCELERATION = 1500
-A_ACCELERATION = 1500
-B_ACCELERATION = 200
-C_ACCELERATION = 200
-
-DEFAULT_ACCELERATION: Dict[str, float] = {
-    "X": X_ACCELERATION,
-    "Y": Y_ACCELERATION,
-    "Z": Z_ACCELERATION,
-    "A": A_ACCELERATION,
-    "B": B_ACCELERATION,
-    "C": C_ACCELERATION,
-}
-
-DEFAULT_PIPETTE_CONFIGS: Dict[str, float] = {
-    "homePosition": 220,
-    "stepsPerMM": 768,
-    "maxTravel": 30,
-}
-
-DEFAULT_GANTRY_STEPS_PER_MM: Dict[str, float] = {
-    "X": 80.00,
-    "Y": 80.00,
-    "Z": 400,
-    "A": 400,
-}
-
-
-DEFAULT_MOUNT_OFFSET = [-34, 0, 0]
-DEFAULT_PIPETTE_OFFSET = [0.0, 0.0, 0.0]
-SERIAL_SPEED = 115200
-DEFAULT_LOG_LEVEL = "INFO"
-
-
-def _build_hw_versioned_current_dict(
-    from_conf: Optional[Dict[str, Any]], default: CurrentDict
-) -> CurrentDict:
-    if not from_conf or not isinstance(from_conf, dict):
-        return default
-    # special case: if this is a valid old (i.e. not model-specific) current
-    # setup, migrate it.
-    if "default" not in from_conf and not (set("XYZABC") - set(from_conf.keys())):
-        new_dct = deepcopy(default)
-        # Because there's no case in which a machine with a more recent revision
-        # than 2.1 should have a valid and edited robot config when updating
-        # to this code, we should default it to 2.1 to avoid breaking other
-        # robots
-        new_dct["2.1"] = cast(AxisDict, from_conf)
-        return new_dct
-    return cast(CurrentDict, from_conf)
-
-
-DictType = TypeVar("DictType", bound=Dict)
-
-
-def _build_dict_with_default(
-    from_conf: Union[DictType, str, None], default: DictType
-) -> DictType:
-    if not isinstance(from_conf, dict):
-        return default
-    else:
-        return cast(DictType, from_conf)
 
 
 def current_for_revision(
@@ -199,48 +25,53 @@ def current_for_revision(
         return current_dict["default"]
 
 
-def build_config(robot_settings: Dict[str, Any]) -> RobotConfig:
-    return RobotConfig(
-        name=robot_settings.get("name", "Ada Lovelace"),
-        version=ROBOT_CONFIG_VERSION,
-        gantry_steps_per_mm=_build_dict_with_default(
-            robot_settings.get("steps_per_mm"), DEFAULT_GANTRY_STEPS_PER_MM
-        ),
-        acceleration=_build_dict_with_default(
-            robot_settings.get("acceleration"), DEFAULT_ACCELERATION
-        ),
-        serial_speed=robot_settings.get("serial_speed", SERIAL_SPEED),
-        default_current=_build_hw_versioned_current_dict(
-            robot_settings.get("default_current"), DEFAULT_CURRENT
-        ),
-        low_current=_build_hw_versioned_current_dict(
-            robot_settings.get("low_current"), LOW_CURRENT
-        ),
-        high_current=_build_hw_versioned_current_dict(
-            robot_settings.get("high_current"), HIGH_CURRENT
-        ),
-        default_max_speed=robot_settings.get("default_max_speed", DEFAULT_MAX_SPEEDS),
-        log_level=robot_settings.get("log_level", DEFAULT_LOG_LEVEL),
-        default_pipette_configs=robot_settings.get(
-            "default_pipette_configs", DEFAULT_PIPETTE_CONFIGS
-        ),
-        z_retract_distance=robot_settings.get("z_retract_distance", Z_RETRACT_DISTANCE),
-        left_mount_offset=robot_settings.get("left_mount_offset", DEFAULT_MOUNT_OFFSET),
+def build_config(robot_settings: Dict[str, Any]) -> Union[RobotConfig, OT3Config]:
+    default_robot_model: Union[Literal["OT-3 Standard"], Literal["OT-2 Standard"]] = (
+        "OT-3 Standard" if enable_ot3_hardware_controller() else "OT-2 Standard"
     )
+    robot_model = robot_settings.get("model", default_robot_model)
+    if robot_model == "OT-3 Standard":
+        return build_config_ot3(robot_settings)
+    else:
+        return build_config_ot2(robot_settings)
 
 
-def config_to_save(config: RobotConfig) -> Dict[str, Any]:
-    return asdict(config)
+def build_config_ot2(robot_settings: Dict[str, Any]) -> RobotConfig:
+    return defaults_ot2.build_with_defaults(robot_settings)
 
 
-def load() -> RobotConfig:
+def build_config_ot3(robot_settings: Dict[str, Any]) -> OT3Config:
+    return defaults_ot3.build_with_defaults(robot_settings)
+
+
+def config_to_save(config: Union[RobotConfig, OT3Config]) -> Dict[str, Any]:
+    if config.model == "OT-2 Standard":
+        return defaults_ot2.serialize(config)
+    else:
+        return defaults_ot3.serialize(config)
+
+
+def _load_file() -> Dict[str, Any]:
     settings_file = CONFIG["robot_settings_file"]
     log.debug("Loading robot settings from {}".format(settings_file))
-    robot_settings = _load_json(settings_file) or {}
-    return build_config(robot_settings)
+    return _load_json(settings_file) or {}
 
 
-def save_robot_settings(config: RobotConfig, rs_filename: str = None, tag: str = None):
+def load() -> Union[RobotConfig, OT3Config]:
+    return build_config(_load_file())
+
+
+def load_ot2() -> RobotConfig:
+    return build_config_ot2(_load_file())
+
+
+def load_ot3() -> OT3Config:
+    return build_config_ot3(_load_file())
+
+
+def save_robot_settings(
+    config: Union[RobotConfig, OT3Config], rs_filename: str = None, tag: str = None
+):
     config_dict = config_to_save(config)
 
     # Save everything else in a different file
@@ -253,7 +84,9 @@ def save_robot_settings(config: RobotConfig, rs_filename: str = None, tag: str =
     return config_dict
 
 
-def backup_configuration(config: RobotConfig, tag: str = None) -> None:
+def backup_configuration(
+    config: Union[RobotConfig, OT3Config], tag: str = None
+) -> None:
     import time
 
     if not tag:

--- a/api/src/opentrons/config/robot_configs.py
+++ b/api/src/opentrons/config/robot_configs.py
@@ -141,3 +141,17 @@ def _save_json(data: Dict[str, Any], filename: Union[str, Path]) -> None:
             os.fsync(file.fileno())
     except OSError:
         log.exception("Write failed with exception:")
+
+
+def default_deck_calibration() -> List[List[float]]:
+    if enable_ot3_hardware_controller():
+        return defaults_ot3.DEFAULT_DECK_CALIBRATION
+    else:
+        return defaults_ot2.DEFAULT_DECK_CALIBRATION_V2
+
+
+def default_pipette_offset() -> List[float]:
+    if enable_ot3_hardware_controller():
+        return defaults_ot3.DEFAULT_PIPETTE_OFFSET
+    else:
+        return defaults_ot2.DEFAULT_PIPETTE_OFFSET

--- a/api/src/opentrons/config/types.py
+++ b/api/src/opentrons/config/types.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
-from typing import Dict, Tuple
-from typing_extensions import TypedDict
+from typing import Dict, Tuple, TypeVar, Generic
+from typing_extensions import TypedDict, Literal
 
 
 class AxisDict(TypedDict):
@@ -10,6 +10,28 @@ class AxisDict(TypedDict):
     A: float
     B: float
     C: float
+
+
+class GeneralizeableAxisDict(TypedDict, total=False):
+    X: float
+    Y: float
+    Z: float
+    P: float
+
+
+Vt = TypeVar("Vt")
+
+
+@dataclass
+class ByPipetteKind(Generic[Vt]):
+    high_throughput: Vt
+    low_throughput: Vt
+    two_low_throughput: Vt
+    none: Vt
+    gripper: Vt
+
+
+PerPipetteAxisSettings = ByPipetteKind[GeneralizeableAxisDict]
 
 
 class CurrentDictDefault(TypedDict):
@@ -29,6 +51,7 @@ class CurrentDict(CurrentDictDefault, CurrentDictModelEntries):
 
 @dataclass
 class RobotConfig:
+    model: Literal["OT-2 Standard"]
     name: str
     version: int
     gantry_steps_per_mm: Dict[str, float]
@@ -42,3 +65,19 @@ class RobotConfig:
     log_level: str
     z_retract_distance: float
     left_mount_offset: Tuple[float, float, float]
+
+
+@dataclass
+class OT3Config:
+    model: Literal["OT-3 Standard"]
+    name: str
+    version: int
+    log_level: str
+    left_mount_offset: Tuple[float, float, float]
+    default_max_speed: PerPipetteAxisSettings
+    acceleration: PerPipetteAxisSettings
+    max_speed_discontinuity: PerPipetteAxisSettings
+    direction_change_speed_discontinuity: PerPipetteAxisSettings
+    holding_current: PerPipetteAxisSettings
+    normal_motion_current: PerPipetteAxisSettings
+    z_retract_distance: float

--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -68,7 +68,7 @@ class Controller:
                 "environmental variable to 1."
             )
 
-        self.config = config or opentrons.config.robot_configs.load()
+        self.config = config or opentrons.config.robot_configs.load_ot2()
 
         self._gpio_chardev: Final = gpio
         self._board_revision: Final = self.gpio_chardev.board_rev

--- a/api/src/opentrons/hardware_control/ot3controller.py
+++ b/api/src/opentrons/hardware_control/ot3controller.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 import logging
 from typing import Dict, List, Optional, Tuple, TYPE_CHECKING, Sequence, Generator, cast
 
-from opentrons.config.types import RobotConfig
+from opentrons.config.types import OT3Config
 from opentrons.drivers.rpi_drivers.gpio_simulator import SimulatingGPIOCharDev
 from opentrons.types import Mount
 from opentrons.config import pipette_config
@@ -61,7 +61,7 @@ class OT3Controller:
     _position: Dict[NodeId, float]
 
     @classmethod
-    async def build(cls, config: RobotConfig) -> OT3Controller:
+    async def build(cls, config: OT3Config) -> OT3Controller:
         """Create the OT3Controller instance.
 
         Args:
@@ -73,7 +73,7 @@ class OT3Controller:
         driver = await build_driver(DriverSettings())
         return cls(config, driver=driver)
 
-    def __init__(self, config: RobotConfig, driver: AbstractCanDriver) -> None:
+    def __init__(self, config: OT3Config, driver: AbstractCanDriver) -> None:
         """Construct.
 
         Args:

--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -11,7 +11,7 @@ from opentrons_shared_data.pipette import name_config as pipette_name_config
 from opentrons.types import Point
 from opentrons.calibration_storage.types import PipetteOffsetByPipetteMount
 from opentrons.config import pipette_config, robot_configs
-from opentrons.config.types import RobotConfig
+from opentrons.config.types import RobotConfig, OT3Config
 from opentrons.drivers.types import MoveSplit
 from .types import CriticalPoint, BoardRevision
 
@@ -437,5 +437,30 @@ def generate_hardware_configs(
             "idle_current": robot_configs.current_for_revision(
                 robot_config.low_current, revision
             )["B"],
+            "splits": None,
+        }
+
+
+def generate_hardware_configs_ot3(
+    pipette: Optional[Pipette], robot_config: OT3Config, revision: BoardRevision
+) -> InstrumentHardwareConfigs:
+    """
+    Fuse robot and pipette configuration to generate commands to send to
+    the motor driver if required
+    """
+    if pipette:
+        return {
+            "steps_per_mm": 0,
+            "home_pos": 0,
+            "max_travel": pipette.config.max_travel,
+            "idle_current": pipette.config.idle_current,
+            "splits": _build_splits(pipette),
+        }
+    else:
+        return {
+            "steps_per_mm": 0,
+            "home_pos": 0,
+            "max_travel": 0,
+            "idle_current": robot_config.holding_current.none["P"],
             "splits": None,
         }

--- a/api/src/opentrons/hardware_control/protocols/configurable.py
+++ b/api/src/opentrons/hardware_control/protocols/configurable.py
@@ -1,28 +1,29 @@
+from typing import Union
 from typing_extensions import Protocol
 
-from opentrons.config.types import RobotConfig
+from opentrons.config.types import RobotConfig, OT3Config
 
 
 class Configurable(Protocol):
     """Protocol specifying hardware control configuration."""
 
-    def get_config(self) -> RobotConfig:
+    def get_config(self) -> Union[RobotConfig, OT3Config]:
         """Get the robot's configuration object.
 
         :returns .RobotConfig: The object.
         """
         ...
 
-    def set_config(self, config: RobotConfig):
+    def set_config(self, config: Union[RobotConfig, OT3Config]):
         """Replace the currently-loaded config"""
         ...
 
     @property
-    def config(self) -> RobotConfig:
+    def config(self) -> Union[RobotConfig, OT3Config]:
         ...
 
     @config.setter
-    def config(self, config: RobotConfig) -> None:
+    def config(self, config: Union[RobotConfig, OT3Config]) -> None:
         ...
 
     async def update_config(self, **kwargs) -> None:

--- a/api/src/opentrons/hardware_control/robot_calibration.py
+++ b/api/src/opentrons/hardware_control/robot_calibration.py
@@ -6,7 +6,11 @@ from typing import Optional, List
 
 from opentrons import config
 
-from opentrons.config.robot_configs import get_legacy_gantry_calibration
+from opentrons.config.robot_configs import (
+    get_legacy_gantry_calibration,
+    default_deck_calibration,
+    default_pipette_offset,
+)
 from opentrons.calibration_storage import modify, types, get
 from opentrons.types import Mount
 from opentrons.util import linal
@@ -28,7 +32,7 @@ def build_temporary_identity_calibration() -> RobotCalibration:
     """
     return RobotCalibration(
         deck_calibration=types.DeckCalibration(
-            attitude=linal.identity_deck_transform().tolist(),
+            attitude=default_deck_calibration(),
             source=types.SourceType.default,
             status=types.CalibrationStatus(),
         )
@@ -142,7 +146,7 @@ def load_attitude_matrix() -> types.DeckCalibration:
     else:
         # load default if deck calibration data do not exist
         return types.DeckCalibration(
-            attitude=config.robot_configs.defaults_ot2.DEFAULT_DECK_CALIBRATION_V2,
+            attitude=default_deck_calibration(),
             source=types.SourceType.default,
             status=types.CalibrationStatus(),
         )
@@ -153,7 +157,7 @@ def load_pipette_offset(
 ) -> types.PipetteOffsetByPipetteMount:
     # load default if pipette offset data do not exist
     pip_cal_obj = types.PipetteOffsetByPipetteMount(
-        offset=config.robot_configs.defaults_ot2.DEFAULT_PIPETTE_OFFSET,
+        offset=default_pipette_offset(),
         source=types.SourceType.default,
         status=types.CalibrationStatus(),
     )

--- a/api/src/opentrons/hardware_control/robot_calibration.py
+++ b/api/src/opentrons/hardware_control/robot_calibration.py
@@ -142,7 +142,7 @@ def load_attitude_matrix() -> types.DeckCalibration:
     else:
         # load default if deck calibration data do not exist
         return types.DeckCalibration(
-            attitude=config.robot_configs.DEFAULT_DECK_CALIBRATION_V2,
+            attitude=config.robot_configs.defaults_ot2.DEFAULT_DECK_CALIBRATION_V2,
             source=types.SourceType.default,
             status=types.CalibrationStatus(),
         )
@@ -153,7 +153,7 @@ def load_pipette_offset(
 ) -> types.PipetteOffsetByPipetteMount:
     # load default if pipette offset data do not exist
     pip_cal_obj = types.PipetteOffsetByPipetteMount(
-        offset=config.robot_configs.DEFAULT_PIPETTE_OFFSET,
+        offset=config.robot_configs.defaults_ot2.DEFAULT_PIPETTE_OFFSET,
         source=types.SourceType.default,
         status=types.CalibrationStatus(),
     )

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -3,14 +3,14 @@ import asyncio
 import copy
 import logging
 from threading import Event
-from typing import Dict, Optional, List, Tuple, TYPE_CHECKING, Sequence
+from typing import Dict, Optional, List, Tuple, TYPE_CHECKING, Sequence, Union
 from contextlib import contextmanager
 
 from opentrons_shared_data.pipette import dummy_model_for_name
 
 from opentrons import types
 from opentrons.config.pipette_config import config_models, config_names, configs, load
-from opentrons.config.types import RobotConfig
+from opentrons.config.types import RobotConfig, OT3Config
 from opentrons.drivers.smoothie_drivers import SimulatingDriver
 
 from opentrons.drivers.rpi_drivers.gpio_simulator import SimulatingGPIOCharDev
@@ -45,7 +45,7 @@ class Simulator:
         cls,
         attached_instruments: Dict[types.Mount, Dict[str, Optional[str]]],
         attached_modules: List[str],
-        config: RobotConfig,
+        config: Union[RobotConfig, OT3Config],
         loop: asyncio.AbstractEventLoop,
         strict_attached_instruments: bool = True,
     ) -> Simulator:
@@ -101,7 +101,7 @@ class Simulator:
         self,
         attached_instruments: Dict[types.Mount, Dict[str, Optional[str]]],
         attached_modules: List[str],
-        config: RobotConfig,
+        config: Union[RobotConfig, OT3Config],
         loop: asyncio.AbstractEventLoop,
         gpio_chardev: GPIODriverLike,
         strict_attached_instruments: bool = True,

--- a/api/tests/opentrons/drivers/smoothie_drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/smoothie_drivers/test_driver.py
@@ -34,7 +34,9 @@ def smoothie(mock_connection: AsyncMock, sim_gpio) -> driver_3_0.SmoothieDriver:
     from opentrons.config import robot_configs
 
     d = driver_3_0.SmoothieDriver(
-        connection=mock_connection, config=robot_configs.load(), gpio_chardev=sim_gpio
+        connection=mock_connection,
+        config=robot_configs.load_ot2(),
+        gpio_chardev=sim_gpio,
     )
     return d
 

--- a/api/tests/opentrons/hardware_control/integration/test_smoothie.py
+++ b/api/tests/opentrons/hardware_control/integration/test_smoothie.py
@@ -4,11 +4,11 @@ from mock import MagicMock
 from opentrons.drivers.types import MoveSplit
 from opentrons.hardware_control.emulation.settings import Settings
 
-from opentrons.config.robot_configs import (
+from opentrons.config.defaults_ot2 import (
     DEFAULT_GANTRY_STEPS_PER_MM,
     DEFAULT_PIPETTE_CONFIGS,
-    build_config,
 )
+from opentrons.config.robot_configs import build_config_ot2
 from opentrons.drivers.smoothie_drivers import SmoothieDriver
 
 
@@ -19,7 +19,7 @@ async def subject(
     """Smoothie driver connected to emulator."""
     d = await SmoothieDriver.build(
         port=f"socket://127.0.0.1:{emulator_settings.smoothie.port}",
-        config=build_config({}),
+        config=build_config_ot2({}),
     )
     yield d
     await d.disconnect()

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -395,8 +395,6 @@ async def test_pick_up_tip(dummy_instruments, loop, is_robot, sim_builder):
     await hw_api.cache_instruments()
     tip_position = types.Point(12.13, 9, 150)
     target_position = {
-        Axis.X: 46.13,  # Left mount offset
-        Axis.Y: 9,
         Axis.Z: 218,  # Z retracts after pick_up
         Axis.A: 218,
         Axis.B: 2,
@@ -411,7 +409,8 @@ async def test_pick_up_tip(dummy_instruments, loop, is_robot, sim_builder):
     await hw_api.pick_up_tip(mount, tip_length)
     assert hw_api._attached_instruments[mount].has_tip
     assert hw_api._attached_instruments[mount].current_volume == 0
-    assert hw_api._current_position == target_position
+    for k, v in target_position.items():
+        assert hw_api._current_position[k] == v, f"{k} position doesnt match"
 
 
 def assert_move_called(mock_move, speed, lock=None):

--- a/robot-server/tests/integration/test_settings_robot.tavern.yaml
+++ b/robot-server/tests/integration/test_settings_robot.tavern.yaml
@@ -12,6 +12,7 @@ stages:
       status_code: 200
       json:
         name: !anystr
+        model: !anystr
         version: !anyint
         gantry_steps_per_mm: !anydict
         acceleration: !anydict

--- a/robot-server/tests/robot/calibration/check/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/check/test_user_flow.py
@@ -25,7 +25,7 @@ from robot_server.robot.calibration.constants import (
 
 
 PIP_OFFSET = CSTypes.PipetteOffsetByPipetteMount(
-    offset=robot_configs.DEFAULT_PIPETTE_OFFSET,
+    offset=robot_configs.defaults_ot2.DEFAULT_PIPETTE_OFFSET,
     source=CSTypes.SourceType.user,
     status=CSTypes.CalibrationStatus(),
 )
@@ -177,7 +177,7 @@ def build_mock_deck_calibration(kind="normal"):
     elif kind == "identity":
         return MagicMock(
             return_value=CSTypes.DeckCalibration(
-                attitude=robot_configs.DEFAULT_DECK_CALIBRATION_V2,
+                attitude=robot_configs.defaults_ot2.DEFAULT_DECK_CALIBRATION_V2,
                 source=CSTypes.SourceType.user,
                 status=CSTypes.CalibrationStatus(markedBad=False),
             )

--- a/robot-server/tests/robot/calibration/deck/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/deck/test_user_flow.py
@@ -21,7 +21,7 @@ from robot_server.robot.calibration.deck.constants import (
 
 
 PIP_OFFSET = cal_types.PipetteOffsetByPipetteMount(
-    offset=robot_configs.DEFAULT_PIPETTE_OFFSET,
+    offset=robot_configs.defaults_ot2.DEFAULT_PIPETTE_OFFSET,
     source=cal_types.SourceType.user,
     status=cal_types.CalibrationStatus(),
 )


### PR DESCRIPTION
The OT3 has a very different set of required settings from the OT2.
Create a new dataclass and loading/saving functions to hold them and
propagate types around.

The extra settings here are meant for axis constraints for the motion
control system. They have a layered format. The "none" options apply
when nothing is connected, but as more mass is added to the head we will
need different configuration values. Values for the appropriate hardware
config should be overlaid, as in pipettes.py.

The Z axis is specified just once because it should apply equally to
both. The P axis stands for whichever plunger is active.
