### PR TITLE
fix(app): fix loading and disabling of run cta button to avoid infinite spinner

### DIFF
--- a/app/src/organisms/RunTimeControl/Timer.tsx
+++ b/app/src/organisms/RunTimeControl/Timer.tsx
@@ -10,24 +10,20 @@ import {
   SPACING_3,
 } from '@opentrons/components'
 import { RUN_STATUS_STOP_REQUESTED } from '@opentrons/api-client'
+import { useRunCompleteTime, useRunPauseTime, useRunStopTime } from './hooks'
 import { formatInterval } from './utils'
 
 interface TimerProps {
   startTime: string
-  pausedAt: string | null
-  stoppedAt: string | null
-  completedAt: string | null
   runStatus?: string
 }
 
-export function Timer({
-  startTime,
-  pausedAt,
-  stoppedAt,
-  completedAt,
-  runStatus,
-}: TimerProps): JSX.Element {
+export function Timer({ startTime, runStatus }: TimerProps): JSX.Element {
   const { t } = useTranslation('run_details')
+
+  const pausedAt = useRunPauseTime()
+  const stoppedAt = useRunStopTime()
+  const completedAt = useRunCompleteTime()
 
   const [now, setNow] = React.useState(Date())
   useInterval(() => setNow(Date()), 500, true)

--- a/app/src/organisms/RunTimeControl/__tests__/Timer.test.tsx
+++ b/app/src/organisms/RunTimeControl/__tests__/Timer.test.tsx
@@ -3,71 +3,54 @@ import { renderWithProviders } from '@opentrons/components'
 
 import { i18n } from '../../../i18n'
 import { Timer } from '../Timer'
-import { RUN_STATUS_STOP_REQUESTED } from '@opentrons/api-client'
+import { useRunCompleteTime, useRunPauseTime, useRunStopTime } from '../hooks'
+import {
+  RUN_STATUS_RUNNING,
+  RUN_STATUS_STOP_REQUESTED,
+} from '@opentrons/api-client'
+
+jest.mock('../hooks')
 
 const START_TIME = '2021-10-07T18:44:49.366581+00:00'
 const PAUSED_TIME = '2021-10-07T18:47:55.366581+00:00'
 const COMPLETED_TIME = '2021-10-07T18:58:59.366581+00:00'
 const STOPPED_TIME = '2021-10-07T18:45:49.366581+00:00'
 
-const render = () => {
-  return renderWithProviders(
-    <Timer
-      startTime={START_TIME}
-      pausedAt={null}
-      stoppedAt={null}
-      completedAt={null}
-    />,
-    {
-      i18nInstance: i18n,
-    }
-  )
-}
-
-const renderPaused = () => {
-  return renderWithProviders(
-    <Timer
-      startTime={START_TIME}
-      pausedAt={PAUSED_TIME}
-      stoppedAt={null}
-      completedAt={null}
-    />,
-    {
-      i18nInstance: i18n,
-    }
-  )
-}
-
-const renderCompleted = () => {
-  return renderWithProviders(
-    <Timer
-      startTime={START_TIME}
-      pausedAt={null}
-      stoppedAt={null}
-      completedAt={COMPLETED_TIME}
-    />,
-    {
-      i18nInstance: i18n,
-    }
-  )
-}
-
-const renderStopped = () => {
-  return renderWithProviders(
-    <Timer
-      startTime={START_TIME}
-      pausedAt={null}
-      stoppedAt={STOPPED_TIME}
-      completedAt={null}
-      runStatus={RUN_STATUS_STOP_REQUESTED}
-    />,
-    {
-      i18nInstance: i18n,
-    }
-  )
-}
+const mockUseRunCompleteTime = useRunCompleteTime as jest.MockedFunction<
+  typeof useRunCompleteTime
+>
+const mockUseRunStopTime = useRunStopTime as jest.MockedFunction<
+  typeof useRunStopTime
+>
+const mockUseRunPauseTime = useRunPauseTime as jest.MockedFunction<
+  typeof useRunPauseTime
+>
 
 describe('Timer', () => {
+  let render: (
+    props?: React.ComponentProps<typeof Timer>
+  ) => ReturnType<typeof renderWithProviders>
+
+  beforeEach(() => {
+    mockUseRunCompleteTime.mockReturnValue(null)
+    mockUseRunPauseTime.mockReturnValue(null)
+    mockUseRunStopTime.mockReturnValue(null)
+    render = (
+      props = {
+        startTime: START_TIME,
+        runStatus: RUN_STATUS_RUNNING,
+      }
+    ) => {
+      return renderWithProviders(<Timer {...props} />, {
+        i18nInstance: i18n,
+      })
+    }
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
   it('renders a start time', () => {
     const [{ getByText }] = render()
 
@@ -86,7 +69,8 @@ describe('Timer', () => {
   })
 
   it('renders a paused time and a run time when paused', () => {
-    const [{ getAllByText, getByText }] = renderPaused()
+    mockUseRunPauseTime.mockReturnValue(PAUSED_TIME)
+    const [{ getAllByText, getByText }] = render()
 
     expect(getByText('Run Time:')).toBeTruthy()
     expect(getByText('Paused For:')).toBeTruthy()
@@ -94,14 +78,19 @@ describe('Timer', () => {
   })
 
   it('renders a completed time when completed', async () => {
-    const [{ getByText }] = renderCompleted()
+    mockUseRunCompleteTime.mockReturnValue(COMPLETED_TIME)
+    const [{ getByText }] = render()
 
     expect(getByText('Run Time:')).toBeTruthy()
     expect(getByText('00:14:10')).toBeTruthy()
   })
 
   it('renders a stopped time when run is canceled', () => {
-    const [{ getByText }] = renderStopped()
+    mockUseRunStopTime.mockReturnValue(STOPPED_TIME)
+    const [{ getByText }] = render({
+      startTime: START_TIME,
+      runStatus: RUN_STATUS_STOP_REQUESTED,
+    })
 
     expect(getByText('Run Time:')).toBeTruthy()
     expect(getByText('00:01:00')).toBeTruthy()


### PR DESCRIPTION
# Overview

This refactors and simplifies the run time controls components disable and loading states to be a
purer function of run status and action loading states

# Changelog

- simplify props required for `Timer` component
- remove duplicate loading state tracking from within `RunTimeControl`
- clarify and dedupe disabled button and loading state logic in `RunTimeControl` 
 
# Review requests
 
- With the "pause when robot door open" advanced robot setting on, start a protocol with the door open.  It should immediately transition to a disabled button with a warning prompt to close the door. After closing the door, the button should update to read "resume" and it should not be disabled.

# Risk assessment
low
