### PR TITLE
perf(robot-server): Return some HTTP results slightly more efficiently

### DIFF
--- a/robot-server/robot_server/protocols/router.py
+++ b/robot-server/robot_server/protocols/router.py
@@ -135,7 +135,7 @@ async def create_protocol(
         f'Created protocol "{protocol_id}"' f' and started analysis "{analysis_id}".'
     )
 
-    return PydanticResponse(
+    return await PydanticResponse.create(
         content=SimpleBody.construct(data=data),
         status_code=status.HTTP_201_CREATED,
     )
@@ -211,7 +211,7 @@ async def get_protocol_by_id(
         files=[ProtocolFile(name=f.name, role=f.role) for f in resource.source.files],
     )
 
-    return PydanticResponse(
+    return await PydanticResponse.create(
         content=SimpleBody.construct(data=data),
         status_code=status.HTTP_200_OK,
     )
@@ -241,7 +241,7 @@ async def delete_protocol_by_id(
     except ProtocolNotFoundError as e:
         raise ProtocolNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
 
-    return PydanticResponse(
-        content=SimpleEmptyBody(),
+    return await PydanticResponse.create(
+        content=SimpleEmptyBody.construct(),
         status_code=status.HTTP_200_OK,
     )

--- a/robot-server/robot_server/runs/router/actions_router.py
+++ b/robot-server/robot_server/runs/router/actions_router.py
@@ -108,7 +108,7 @@ async def create_run_action(
 
     run_store.upsert(run=next_run)
 
-    return PydanticResponse(
+    return await PydanticResponse.create(
         content=SimpleBody.construct(data=action),
         status_code=status.HTTP_201_CREATED,
     )

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -308,8 +308,8 @@ async def remove_run(
     except RunNotFoundError as e:
         raise RunNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
 
-    return PydanticResponse(
-        content=SimpleEmptyBody(),
+    return await PydanticResponse.create(
+        content=SimpleEmptyBody.construct(),
         status_code=status.HTTP_200_OK,
     )
 

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -136,6 +136,6 @@ async def get_run_command(
         raise CommandNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
 
     return await PydanticResponse.create(
-        content=SimpleBody(data=command),
+        content=SimpleBody.construct(data=command),
         status_code=status.HTTP_200_OK,
     )


### PR DESCRIPTION
# Overview

This PR makes a few small fixups to our FastAPI endpoint functions for performance improvements when returning HTTP responses.

# Changelog

* Use `model.construct(...)` instead of `model(...)` to avoid runtime validation that we find unnecessary.
* Use `await PydanticResponse.create(...)` instead of `PydanticResponse(...)` to serialize in a worker thread instead of blocking the async event loop.

We were already mostly doing these things. It looks like we just accidentally missed a few places.

# Review requests

Code review should be sufficient. I've smoke-tested on a dev server.

# Risk assessment

Low because the changeset is small and this extends a pattern we're already doing elsewhere.