### PR TITLE
refactor(app): remove possibility of network calls from command item for timing information

### DIFF
--- a/app/src/organisms/RunDetails/CommandItem.tsx
+++ b/app/src/organisms/RunDetails/CommandItem.tsx
@@ -50,6 +50,7 @@ export interface CommandItemProps {
   runStatus: RunStatus
   currentRunId: string | null
   stepNumber: number
+  runStartedAt: string | null
 }
 
 const WRAPPER_STYLE_BY_STATUS: {
@@ -85,6 +86,7 @@ export function CommandItemComponent(
     runStatus,
     currentRunId,
     stepNumber,
+    runStartedAt,
   } = props
   const { t } = useTranslation('run_details')
   const [commandItemRef, isInView] = useInView({
@@ -203,9 +205,9 @@ export function CommandItemComponent(
         {['running', 'failed', 'succeeded'].includes(commandStatus) &&
         !isComment ? (
           <CommandTimer
-            commandStartedAt={commandDetails?.data.startedAt}
-            commandCompletedAt={commandDetails?.data.completedAt}
-            commandStatus={commandStatus}
+            commandStartedAt={commandDetails?.data.startedAt ?? null}
+            commandCompletedAt={commandDetails?.data.completedAt ?? null}
+            runStartedAt={runStartedAt}
           />
         ) : null}
       </Flex>

--- a/app/src/organisms/RunDetails/CommandList.tsx
+++ b/app/src/organisms/RunDetails/CommandList.tsx
@@ -316,6 +316,7 @@ export function CommandList(): JSX.Element | null {
                   runStatus={runStatus}
                   currentRunId={runRecord?.data.id ?? null}
                   stepNumber={overallIndex + 1}
+                  runStartedAt={firstPlayTimestamp ?? null}
                 />
                 {showAnticipatedStepsTitle && (
                   <Text

--- a/app/src/organisms/RunDetails/CommandTimer.tsx
+++ b/app/src/organisms/RunDetails/CommandTimer.tsx
@@ -9,19 +9,17 @@ import {
   SPACING_2,
   TEXT_TRANSFORM_UPPERCASE,
 } from '@opentrons/components'
-import { useFormatRunTimestamp, useTimeElapsedSincePause } from './hooks'
+import { formatInterval } from '../RunTimeControl/utils'
 
 const EMPTY_TIMESTAMP = '-- : -- : --'
 interface TimerProps {
-  commandStartedAt?: string | null
-  commandCompletedAt?: string | null
-  commandStatus: 'running' | 'failed' | 'succeeded' | 'queued'
+  commandStartedAt: string | null
+  commandCompletedAt: string | null
+  runStartedAt: string | null
 }
 export function CommandTimer(props: TimerProps): JSX.Element | null {
-  const { commandStartedAt, commandCompletedAt, commandStatus } = props
+  const { commandStartedAt, commandCompletedAt, runStartedAt } = props
   const { t } = useTranslation('run_details')
-  const timeElapsedSincePause = useTimeElapsedSincePause()
-  const formatRunTimestamp = useFormatRunTimestamp()
 
   return (
     <Flex
@@ -34,23 +32,16 @@ export function CommandTimer(props: TimerProps): JSX.Element | null {
       <Flex>
         <Flex marginRight={SPACING_1}>{t('start_step_time')}</Flex>
         <Flex>
-          {commandStartedAt != null
-            ? formatRunTimestamp(commandStartedAt)
+          {commandStartedAt != null && runStartedAt != null
+            ? formatInterval(runStartedAt, commandStartedAt)
             : EMPTY_TIMESTAMP}
         </Flex>
       </Flex>
-
-      {commandStatus === 'running' && timeElapsedSincePause != null ? (
-        <Flex>
-          <Flex marginRight={SPACING_1}>{t('current_step_pause_timer')}</Flex>
-          <Flex>{timeElapsedSincePause}</Flex>
-        </Flex>
-      ) : null}
       <Flex>
         <Flex marginRight={SPACING_1}>{t('end_step_time')}</Flex>
         <Flex marginLeft={SPACING_2}>
-          {commandCompletedAt
-            ? formatRunTimestamp(commandCompletedAt)
+          {commandCompletedAt && runStartedAt != null
+            ? formatInterval(runStartedAt, commandCompletedAt)
             : EMPTY_TIMESTAMP}
         </Flex>
       </Flex>

--- a/app/src/organisms/RunDetails/__tests__/CommandItem.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/CommandItem.test.tsx
@@ -102,6 +102,7 @@ describe('Run Details RunTimeCommand item', () => {
       runStatus: 'running',
       currentRunId: RUN_ID,
       stepNumber: 1,
+      runStartedAt: 'fake_timestamp',
     })
     expect(getByText('Step failed')).toHaveStyle(
       'backgroundColor: C_ERROR_LIGHT'
@@ -116,6 +117,7 @@ describe('Run Details RunTimeCommand item', () => {
       runStatus: 'succeeded',
       currentRunId: RUN_ID,
       stepNumber: 1,
+      runStartedAt: 'fake_timestamp',
     } as React.ComponentProps<typeof CommandItem>
     const { getByText } = render(props)
     expect(getByText('Mock RunTimeCommand Timer')).toHaveStyle(
@@ -130,6 +132,7 @@ describe('Run Details RunTimeCommand item', () => {
       runStatus: 'running',
       currentRunId: RUN_ID,
       stepNumber: 1,
+      runStartedAt: 'fake_timestamp',
     } as React.ComponentProps<typeof CommandItem>
     const { getByText } = render(props)
     expect(getByText('Current Step')).toHaveStyle(
@@ -146,6 +149,7 @@ describe('Run Details RunTimeCommand item', () => {
       runStatus: 'running',
       currentRunId: RUN_ID,
       stepNumber: 1,
+      runStartedAt: 'fake_timestamp',
     } as React.ComponentProps<typeof CommandItem>
     const { getByText } = render(props)
     expect(getByText('Mock RunTimeCommand Text')).toHaveStyle(
@@ -160,6 +164,7 @@ describe('Run Details RunTimeCommand item', () => {
       runStatus: 'paused',
       currentRunId: RUN_ID,
       stepNumber: 1,
+      runStartedAt: 'fake_timestamp',
     } as React.ComponentProps<typeof CommandItem>
     const { getByText } = render(props)
     expect(getByText('Current Step - Paused by User')).toHaveStyle(
@@ -209,6 +214,7 @@ describe('Run Details RunTimeCommand item', () => {
       runStatus: 'running',
       currentRunId: RUN_ID,
       stepNumber: 1,
+      runStartedAt: 'fake_timestamp',
     } as React.ComponentProps<typeof CommandItem>
     const { getByText } = render(props)
     expect(getByText('Comment')).toHaveStyle('backgroundColor: C_NEAR_WHITE')
@@ -248,6 +254,7 @@ describe('Run Details RunTimeCommand item', () => {
       runStatus: 'paused',
       currentRunId: RUN_ID,
       stepNumber: 1,
+      runStartedAt: 'fake_timestamp',
     } as React.ComponentProps<typeof CommandItem>
     const { getByText } = render(props)
     expect(getByText('Pause protocol')).toHaveStyle(

--- a/app/src/organisms/RunDetails/__tests__/CommandTimer.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/CommandTimer.test.tsx
@@ -2,16 +2,6 @@ import * as React from 'react'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../i18n'
 import { CommandTimer } from '../CommandTimer'
-import { useFormatRunTimestamp, useTimeElapsedSincePause } from '../hooks'
-
-jest.mock('../hooks')
-
-const mockUseFormatRunTimestamp = useFormatRunTimestamp as jest.MockedFunction<
-  typeof useFormatRunTimestamp
->
-const mockUseTimeElapsedSincePause = useTimeElapsedSincePause as jest.MockedFunction<
-  typeof useTimeElapsedSincePause
->
 
 const render = (props: React.ComponentProps<typeof CommandTimer>) => {
   return renderWithProviders(<CommandTimer {...props} />, {
@@ -19,34 +9,31 @@ const render = (props: React.ComponentProps<typeof CommandTimer>) => {
   })[0]
 }
 
-const MOCK_ELAPSED_TIME = '10 minutes'
+const MOCK_RUN_STARTED = '2020-10-09T13:30:10Z'
+const MOCK_COMMAND_STARTED = '2020-10-09T13:30:20Z'
+const MOCK_COMMAND_COMPLETED = '2020-10-09T13:30:35Z'
 
 describe('CommandTimer', () => {
   let props: React.ComponentProps<typeof CommandTimer>
 
-  beforeEach(() => {
-    mockUseFormatRunTimestamp.mockReturnValue(timestamp => timestamp)
-    mockUseTimeElapsedSincePause.mockReturnValue(MOCK_ELAPSED_TIME)
-  })
-  it('renders correct time when runStatus is paused', () => {
+  it('renders correct time when not complete', () => {
     props = {
-      commandStartedAt: '0',
-      commandCompletedAt: undefined,
-      commandStatus: 'running',
+      commandStartedAt: MOCK_COMMAND_STARTED,
+      commandCompletedAt: null,
+      runStartedAt: MOCK_RUN_STARTED,
     }
     const { getByText } = render(props)
-    getByText('0')
-    getByText('10 minutes')
+    getByText('00:00:10')
     getByText('-- : -- : --')
   })
-  it('renders correct time when runStatus is not paused', () => {
+  it('renders correct time when command complete', () => {
     props = {
-      commandStartedAt: '5',
-      commandCompletedAt: '10',
-      commandStatus: 'running',
+      commandStartedAt: MOCK_COMMAND_STARTED,
+      commandCompletedAt: MOCK_COMMAND_COMPLETED,
+      runStartedAt: MOCK_RUN_STARTED,
     }
     const { getByText } = render(props)
-    getByText('5')
-    getByText('10')
+    getByText('00:00:10')
+    getByText('00:00:25')
   })
 })

--- a/app/src/organisms/RunTimeControl/utils.ts
+++ b/app/src/organisms/RunTimeControl/utils.ts
@@ -30,6 +30,5 @@ export function formatInterval(start: string, end: string): string {
     start: new Date(start),
     end: new Date(end),
   })
-
   return formatDuration(duration)
 }


### PR DESCRIPTION
# Overview

With both performance and user experience in mind, remove the need for individual command items to
fetch from queries in order to render their own timestamp information.

# Changelog

- remove the redundant pause timer from within the current command item
- pass down the timestamp for the first play action so that is not recalculated or fetched unnecessarily

# Review requests

- check on the network performance of command items when actions are dispatched that would change the run's status

# Risk assessment
low