### PR TITLE
feat(protocol-designer): add feature flag for heater shaker in PD

### DIFF
--- a/protocol-designer/src/feature-flags/reducers.ts
+++ b/protocol-designer/src/feature-flags/reducers.ts
@@ -19,6 +19,8 @@ const initialFlags: Flags = {
   PRERELEASE_MODE: process.env.OT_PD_PRERELEASE_MODE === '1' || false,
   OT_PD_DISABLE_MODULE_RESTRICTIONS:
     process.env.OT_PD_DISABLE_MODULE_RESTRICTIONS === '1' || false,
+  OT_PD_ENABLE_HEATER_SHAKER:
+    process.env.OT_PD_ENABLE_HEATER_SHAKER === '1' || false,
 }
 // @ts-expect-error(sa, 2021-6-10): cannot use string literals as action type
 // TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081

--- a/protocol-designer/src/feature-flags/selectors.ts
+++ b/protocol-designer/src/feature-flags/selectors.ts
@@ -15,3 +15,8 @@ export const getDisableModuleRestrictions: Selector<
   getFeatureFlagData,
   flags => flags.OT_PD_DISABLE_MODULE_RESTRICTIONS
 )
+
+export const getEnabledHeaterShaker: Selector<boolean> = createSelector(
+  getFeatureFlagData,
+  flags => flags.OT_PD_ENABLE_HEATER_SHAKER ?? false
+)

--- a/protocol-designer/src/feature-flags/types.ts
+++ b/protocol-designer/src/feature-flags/types.ts
@@ -17,7 +17,10 @@ export const DEPRECATED_FLAGS = [
   'OT_PD_ENABLE_BATCH_EDIT_MIX',
 ]
 // union of feature flag string constant IDs
-export type FlagTypes = 'PRERELEASE_MODE' | 'OT_PD_DISABLE_MODULE_RESTRICTIONS'
+export type FlagTypes =
+  | 'PRERELEASE_MODE'
+  | 'OT_PD_DISABLE_MODULE_RESTRICTIONS'
+  | 'OT_PD_ENABLE_HEATER_SHAKER'
 // flags that are not in this list only show in prerelease mode
 export const userFacingFlags: FlagTypes[] = [
   'OT_PD_DISABLE_MODULE_RESTRICTIONS',

--- a/protocol-designer/src/localization/en/feature_flags.json
+++ b/protocol-designer/src/localization/en/feature_flags.json
@@ -11,5 +11,9 @@
   "OT_PD_ENABLE_BATCH_EDIT_MIX": {
     "title": "Enable mix batch edit",
     "description": "Allow users to batch edit mix forms"
+  },
+  "OT_PD_ENABLE_HEATER_SHAKER": {
+    "title": "Enable heater shaker module",
+    "description": "Allow adding heater shaker module and steps to protocols"
   }
 }


### PR DESCRIPTION
# Overview

This PR adds a feature flag in protocol designer for the heater shaker module. 

# Changelog

- Add heater shaker feature flag in PD

# Review requests

- Start your dev server (`make -C protocol-designer dev`)
- Go to the settings tab
- You should NOT see a heater shaker FF toggle at the bottom of the screen
- Open up your dev console. enter `enablePrereleaseMode()`
- You should now see a heater shaker FF toggle at the bottom of the screen
- Open up redux dev tools
- Toggle the FF
- You should see `OT_PD_ENABLE_HEATER_SHAKER` update from `false` to `true`

# Risk assessment
Low