### PR TITLE
refactor(api): Add quick HC api repl

### DIFF
--- a/api/src/opentrons/hardware_control/scripts/__init__.py
+++ b/api/src/opentrons/hardware_control/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Scripts for the hardware controller."""

--- a/api/src/opentrons/hardware_control/scripts/repl.py
+++ b/api/src/opentrons/hardware_control/scripts/repl.py
@@ -1,0 +1,68 @@
+"""opentrons.hardware_control.scripts.repl - cli for hc api
+
+Running this script will create and spin up a hardware controller
+and expose it to a python commandline.
+"""
+
+import os
+
+os.environ["RUNNING_ON_PI"] = "1"
+if os.environ.get("OT2", None):
+    print(
+        '"OT2" env var detected, running with OT2 HC. '
+        "If you dont want this, remove the OT2 env var"
+    )
+    os.environ["OT_API_FF_enableOT3HardwareController"] = "false"
+else:
+    print("Running with OT3 HC. If you dont want this, set an " 'env var named "OT2".')
+    os.environ["OT_API_FF_enableOT3HardwareController"] = "true"
+
+from code import interact  # noqa: E402
+from subprocess import run  # noqa: E402
+from typing import Union, Type  # noqa: E402
+import logging  # noqa: E402
+
+from opentrons.types import Mount, Point  # noqa: E402
+from opentrons.hardware_control.types import Axis  # noqa: E402
+from opentrons.config.feature_flags import enable_ot3_hardware_controller  # noqa: E402
+
+if enable_ot3_hardware_controller():
+    from opentrons.hardware_control.ot3api import OT3API
+
+    HCApi: Union[Type[OT3API], Type["API"]] = OT3API
+else:
+    from opentrons.hardware_control.api import API
+
+    HCApi = API
+
+from opentrons.hardware_control.protocols import HardwareControlAPI  # noqa: E402
+from opentrons.hardware_control.thread_manager import ThreadManager  # noqa: E402
+
+logging.basicConfig(level=logging.INFO)
+
+
+def stop_server() -> None:
+    run(["systemctl", "stop", "opentrons-robot-server"])
+
+
+def build_api() -> ThreadManager[HardwareControlAPI]:
+    tm = ThreadManager(HCApi.build_hardware_controller)
+    tm.managed_thread_ready_blocking()
+    return tm
+
+
+def do_interact(api: ThreadManager[HardwareControlAPI]) -> None:
+    interact(
+        banner=(
+            "Hardware Control API REPL\nCall methods on api like "
+            "api.move_to(Mount.RIGHT, Point(400, 400, 500))"
+        ),
+        local={"api": api.sync, "Mount": Mount, "Point": Point, "Axis": Axis},
+    )
+
+
+if __name__ == "__main__":
+    stop_server()
+    api_tm = build_api()
+    do_interact(api_tm)
+    api_tm.clean_up()


### PR DESCRIPTION
You can run this either as a script or runnable module (so, python
/path/to/opentrons/hardware_control/scripts/repl.py or python -m
opentrons.hardware_control.scripts.repl) and it will set env vars and
feature flags properly to spin up a hardware controller and dump you
into a repl. Really only meant for actually controlling hardware,
probably running on a robot. Will stop the robot server.
