### PR TITLE
docs(api,robot-server): Flesh out how labware offsets on modules work

### DIFF
--- a/api/src/opentrons/protocol_api/labware_offset_provider.py
+++ b/api/src/opentrons/protocol_api/labware_offset_provider.py
@@ -40,9 +40,11 @@ class AbstractLabwareOffsetProvider(ABC):
         Args:
             labware_definition_uri: The labware's definition URI.
             module_model: If the labware is atop a module, the module's model string,
-                          like "temperatureModuleV1". During protocol execution, this
-                          should be the model that's actually physically connected,
-                          which may be upgraded from the one that the protocol requested
+                          like "temperatureModuleV1".
+                          During protocol execution,
+                          this should be the model of the module that's actually
+                          physically connected, which may be different from the model
+                          that the protocol requested
                           with `ProtocolContext.load_module()`.
             deck_slot: The deck slot that the labware occupies. Or, if the labware is
                        atop a module, the deck slot that the module occupies.

--- a/api/src/opentrons/protocol_engine/commands/load_module.py
+++ b/api/src/opentrons/protocol_engine/commands/load_module.py
@@ -60,8 +60,12 @@ class LoadModuleResult(BaseModel):
     model: ModuleModel = Field(
         ...,
         description=(
-            "Hardware model of the connected module. May be different than"
-            " the requested model if the attached module is still compatible."
+            "The hardware model of the connected module."
+            " May be different than the requested model"
+            " if the connected module is still compatible."
+            "\n\n"
+            "This field is only meaningful in the run's actual execution,"
+            " not in the protocol's analysis."
         ),
     )
 

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -363,8 +363,12 @@ class LabwareView(HasState[LabwareState]):
 
         Returns the *most recently* added matching offset,
         so later offsets can override earlier ones.
+        Or, ``None`` if no offsets match at all.
 
-        Returns ``None`` if no offsets match at all.
+        An offset "matches"
+        if its ``definition_uri`` and ``location`` *exactly* match what's provided.
+        This implies that if the location involves a module,
+        it will *not* match a module that's compatible but not identical.
         """
         for candidate in reversed(list(self._state.labware_offsets_by_id.values())):
             if (

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -211,7 +211,7 @@ class LabwareOffsetLocation(BaseModel):
             "The deck slot where the protocol will load the labware."
             " Or, if the protocol will load the labware on a module,"
             " the deck slot where the protocol will load that module."
-        )
+        ),
     )
     moduleModel: Optional[ModuleModel] = Field(
         None,
@@ -227,7 +227,7 @@ class LabwareOffsetLocation(BaseModel):
             " The two models will differ"
             " if the physically connected module is compatible, but not identical,"
             " to the one that the protocol requested."
-        )
+        ),
     )
 
 

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -207,11 +207,27 @@ class LabwareOffsetLocation(BaseModel):
 
     slotName: DeckSlotName = Field(
         ...,
-        description="The deck slot the offset applies to",
+        description=(
+            "The deck slot where the protocol will load the labware."
+            " Or, if the protocol will load the labware on a module,"
+            " the deck slot where the protocol will load that module."
+        )
     )
     moduleModel: Optional[ModuleModel] = Field(
         None,
-        description="The module model the labware will be loaded onto, if applicable",
+        description=(
+            "The model of the module that the labware will be loaded onto,"
+            " if applicable."
+            "\n\n"
+            "For the offset to apply,"
+            " this must exactly match the model that the robot will find"
+            " *physically connected* during the protocol's execution."
+            " This means it's not enough to blindly use the model"
+            " reported by the protocol's analysis."
+            " The two models will differ"
+            " if the physically connected module is compatible, but not identical,"
+            " to the one that the protocol requested."
+        )
     )
 
 

--- a/api/src/opentrons/protocol_runner/legacy_labware_offset_provider.py
+++ b/api/src/opentrons/protocol_runner/legacy_labware_offset_provider.py
@@ -25,7 +25,10 @@ class LegacyLabwareOffsetProvider(AbstractLegacyLabwareOffsetProvider):
         module_model: Optional[str],
         deck_slot: DeckSlotName,
     ) -> LegacyProvidedLabwareOffset:
-        """Look up an offset in ProtocolEngine state and return it, if one exists."""
+        """Look up an offset in ProtocolEngine state and return it, if one exists.
+
+        See the parent class for param details.
+        """
         offset = self._labware_view.find_applicable_labware_offset(
             definition_uri=labware_definition_uri,
             location=LabwareOffsetLocation(


### PR DESCRIPTION
# Overview

This PR updates our internal and client-facing documentation to reflect how labware offsets currently work when the labware is on a module.

This is ahead of #9299, which will propose revisions to this API.

# Risk assessment

None. Changes are to docstrings only.
