### PR TITLE
feat(hardware): integration tests for bootloader and more

### DIFF
--- a/hardware/tests/firmware_integration/test_update_fw.py
+++ b/hardware/tests/firmware_integration/test_update_fw.py
@@ -39,6 +39,7 @@ def hex_file_path() -> Path:
     return path / Path("bootloader-head.hex")
 
 
+@pytest.mark.requires_emulator
 async def test_download(
     downloader_subject: firmware_update.FirmwareUpdateDownloader,
     hex_file_path: Path,


### PR DESCRIPTION
# Overview

Not ready to be merged until we can run FW simulators in CI. 

Added an integration test for our bootloader. It uses a HEX file generated from our build (it's actually the bootloader's hex file). 

Some more fixes and clean ups surrounding integration tests and sim_socket simulator.

# Changelog

The sim_can script uses `SocketDriver` to handle each connection.
FW update integration test that downloads a hex file to the bootloader simulator


# Review requests

Is putting a `55215` (!?!?!) HEX file in our repo too luxurious? 

# Risk assessment

None