### PR TITLE
fix(app): while closing a protocol run, place loading spinner over whole app

### DIFF
--- a/app/src/organisms/RunDetails/index.tsx
+++ b/app/src/organisms/RunDetails/index.tsx
@@ -17,6 +17,7 @@ import {
   SPACING_3,
   useConditionalConfirm,
   NewAlertSecondaryBtn,
+  SpinnerModal,
 } from '@opentrons/components'
 import { Page } from '../../atoms/Page'
 import { Portal } from '../../App/portal'
@@ -79,7 +80,11 @@ export function RunDetails(): JSX.Element | null {
     ) {
       text = t('closing_protocol')
     }
-    return <ProtocolLoader loadingText={text} />
+    return (
+    <Portal level="top">
+      <SpinnerModal message={text} />
+      </Portal>
+    )
   }
 
   const cancelRunButton = (

--- a/app/src/organisms/RunDetails/index.tsx
+++ b/app/src/organisms/RunDetails/index.tsx
@@ -80,8 +80,8 @@ export function RunDetails(): JSX.Element | null {
       text = t('closing_protocol')
     }
     return (
-    <Portal level="top">
-      <SpinnerModal message={text} />
+      <Portal level="top">
+        <SpinnerModal message={text} />
       </Portal>
     )
   }

--- a/app/src/organisms/RunDetails/index.tsx
+++ b/app/src/organisms/RunDetails/index.tsx
@@ -33,7 +33,6 @@ import { CommandList } from './CommandList'
 import { ConfirmCancelModal } from './ConfirmCancelModal'
 
 import styles from '../ProtocolUpload/styles.css'
-import { ProtocolLoader } from '../ProtocolUpload'
 import { useIsProtocolRunLoaded } from '../ProtocolUpload/hooks'
 
 export function RunDetails(): JSX.Element | null {


### PR DESCRIPTION
# Overview

Instead of only blocking the page portion, and leaving the side panel interactive, while the
protocol is loading or closing on the run detail page, place a spinner over the whole app.

# Changelog

make the loading spinner on the protocol page block the whole app instead of just the page

# Review requests

- confirm cloning and closing a run are a smooth experience without jumping between views

# Risk assessment
low