### PR TITLE
feat(app): Add protocol landing page empty state

### DIFF
--- a/app/src/App/NextGenApp.tsx
+++ b/app/src/App/NextGenApp.tsx
@@ -17,6 +17,7 @@ import {
 import { AppSettings } from '../pages/More/AppSettings'
 import { DeviceDetails } from '../pages/Devices/DeviceDetails'
 import { DevicesLanding } from '../pages/Devices/DevicesLanding'
+import { ProtocolsLanding } from '../pages/Protocols/ProtocolsLanding'
 
 interface RouteProps {
   /**
@@ -97,7 +98,7 @@ export function NextGenApp(): JSX.Element {
   // TODO(bh, 2021-12-10): i18n for route name once final nav/breadcrumbs implemented
   const nextGenRoutes: RouteProps[] = [
     {
-      component: () => <div>protocols landing</div>,
+      component: ProtocolsLanding,
       exact: true,
       name: 'Protocols',
       navLinkTo: '/protocols',

--- a/app/src/assets/localization/en/protocol_info.json
+++ b/app/src/assets/localization/en/protocol_info.json
@@ -1,6 +1,7 @@
 {
   "browse_protocol_library": "Launch Opentrons Protocol Library",
   "choose_file": "Choose File...",
+  "choose_protocol_file": "Choose File",
   "choose_snippet_type": "Choose the Labware Offset Data Python Snippet based on target execution environment.",
   "continue_proceed_to_calibrate": "Proceed to Calibrate",
   "continue_verify_calibrations": "Verify pipette and labware calibrations",
@@ -11,6 +12,7 @@
   "estimated_run_time": "Estimated Run Time",
   "error_message_no_steps": "This protocol has no steps in it - there's nothing for your robot to do! Your protocol needs at least one aspirate/dispense to import properly",
   "get_labware_offset_data": "Get Labware Offset Data",
+  "import_a_file": "Import a protocol to get started",
   "instrument_not_attached": "Not attached",
   "instrument_cal_data_title": "Calibration data",
   "instruments_title": "Required Pipettes",
@@ -24,6 +26,7 @@
   "modules_title": "Required Modules",
   "no_protocol_yet": "Don't have a protocol yet?",
   "open_a_protocol": "Open a protocol to get started",
+  "open_api_docs": "Open Python API Documentation",
   "organization_and_author": "Organization/Author",
   "protocol_title": "Protocol - {{protocol_name}}",
   "protocol_upload_failed": "Protocol upload failed. Fix the error and try again",
@@ -54,5 +57,6 @@
   "labware_positon_check_complete_toast_with_offsets_plural": "Labware Position Check complete. {{count}} Labware Offsets created.",
   "protocol_loading": "Opening Protocol On {{robot_name}}",
   "protocol_finishing": "Closing Protocol On {{robot_name}}",
-  "cancel_run": "Cancel Run"
+  "cancel_run": "Cancel Run",
+  "valid_file_types": "Valid file types: Python files (.py), Protocol Designer files (.json), or .zip files"
 }

--- a/app/src/organisms/Protocols/EmptyStateLinks.tsx
+++ b/app/src/organisms/Protocols/EmptyStateLinks.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react'
+
+import { useTranslation } from 'react-i18next'
+import {
+  Icon,
+  Text,
+  Flex,
+  FONT_SIZE_CAPTION,
+  SPACING_2,
+  SPACING_3,
+  C_MED_GRAY,
+  Link,
+  SPACING_1,
+  JUSTIFY_START,
+  DIRECTION_ROW,
+  DIRECTION_COLUMN,
+  ALIGN_CENTER,
+  POSITION_ABSOLUTE,
+} from '@opentrons/components'
+
+const PROTOCOL_LIBRARY_URL = 'https://protocols.opentrons.com'
+const PROTOCOL_DESIGNER_URL = 'https://designer.opentrons.com'
+const API_DOCS_URL = 'https://docs.opentrons.com/v2/'
+
+export function EmptyStateLinks(): JSX.Element | null {
+  const { t } = useTranslation('protocol_info')
+
+  return (
+    <Flex
+      width="100%"
+      flexDirection={DIRECTION_COLUMN}
+      alignItems={ALIGN_CENTER}
+      position={POSITION_ABSOLUTE}
+      bottom="0"
+      paddingBottom={SPACING_3}
+    >
+      <Text role="complementary" as="h5" marginBottom={SPACING_2}>
+        {t('no_protocol_yet')}
+      </Text>
+      <Flex justifyContent={JUSTIFY_START} flexDirection={DIRECTION_ROW}>
+        <Link
+          fontSize={FONT_SIZE_CAPTION}
+          color={C_MED_GRAY}
+          href={PROTOCOL_LIBRARY_URL}
+          id={'EmptyStateLinks_protocolLibraryButton'}
+          marginRight={SPACING_3}
+          external
+        >
+          {t('browse_protocol_library')}
+          <Icon name={'open-in-new'} marginLeft={SPACING_1} size="10px" />
+        </Link>
+        <Link
+          fontSize={FONT_SIZE_CAPTION}
+          color={C_MED_GRAY}
+          marginRight={SPACING_3}
+          href={PROTOCOL_DESIGNER_URL}
+          id={'EmptyStateLinks_protocolDesignerButton'}
+          external
+        >
+          {t('launch_protocol_designer')}
+          <Icon name={'open-in-new'} marginLeft={SPACING_1} size="10px" />
+        </Link>
+        <Link
+          fontSize={FONT_SIZE_CAPTION}
+          color={C_MED_GRAY}
+          href={API_DOCS_URL}
+          id={'EmptyStateLinks_apiDocsButton'}
+          external
+        >
+          {t('open_api_docs')}
+          <Icon name={'open-in-new'} marginLeft={SPACING_1} size="10px" />
+        </Link>
+      </Flex>
+    </Flex>
+  )
+}

--- a/app/src/organisms/Protocols/ProtocolsEmptyState.tsx
+++ b/app/src/organisms/Protocols/ProtocolsEmptyState.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Flex,
+  Text,
+  DIRECTION_COLUMN,
+  ALIGN_CENTER,
+  SPACING_6,
+} from '@opentrons/components'
+
+import { UploadInput } from './UploadInput'
+import { EmptyStateLinks } from './EmptyStateLinks'
+export function ProtocolsEmptyState(): JSX.Element | null {
+  const { t } = useTranslation('protocol_info')
+  return (
+    <Flex
+      flexDirection={DIRECTION_COLUMN}
+      alignItems={ALIGN_CENTER}
+      width="100%"
+      paddingTop={SPACING_6}
+    >
+      <Text role="complementary" as="h4">
+        {t('import_a_file')}
+      </Text>
+      <UploadInput
+        onUpload={() => {
+          console.log('todo')
+        }}
+      />
+      <EmptyStateLinks />
+    </Flex>
+  )
+}

--- a/app/src/organisms/Protocols/UploadInput.tsx
+++ b/app/src/organisms/Protocols/UploadInput.tsx
@@ -1,0 +1,147 @@
+import * as React from 'react'
+import { css } from 'styled-components'
+import { useTranslation } from 'react-i18next'
+import {
+  Icon,
+  Text,
+  Flex,
+  NewPrimaryBtn,
+  FONT_SIZE_BODY_1,
+  FONT_SIZE_BODY_2,
+  FONT_WEIGHT_REGULAR,
+  TEXT_TRANSFORM_CAPITALIZE,
+  SPACING_4,
+  SPACING_5,
+  C_MED_LIGHT_GRAY,
+  C_MED_GRAY,
+  SIZE_3,
+  DIRECTION_COLUMN,
+  ALIGN_CENTER,
+  C_WHITE,
+  JUSTIFY_CENTER,
+  C_BLUE,
+} from '@opentrons/components'
+
+const DROP_ZONE_STYLES = css`
+  display: flex;
+  flex-direction: ${DIRECTION_COLUMN};
+  align-items: ${ALIGN_CENTER};
+  width: 90%;
+  font-size: ${FONT_SIZE_BODY_2};
+  font-weight: ${FONT_WEIGHT_REGULAR};
+  padding: ${SPACING_5};
+  border: 2px dashed ${C_MED_LIGHT_GRAY};
+  border-radius: 6px;
+  color: ${C_MED_GRAY};
+  text-align: center;
+  margin-bottom: ${SPACING_4};
+  background-color: ${C_WHITE};
+`
+const DRAG_OVER_STYLES = css`
+  background-color: ${C_BLUE};
+  color: ${C_WHITE};
+`
+
+const INPUT_STYLES = css`
+  position: fixed;
+  clip: rect(1px 1px 1px 1px);
+`
+
+export interface UploadInputProps {
+  onUpload: (file: File) => unknown
+}
+
+export function UploadInput(props: UploadInputProps): JSX.Element | null {
+  const { t } = useTranslation('protocol_info')
+
+  const fileInput = React.useRef<HTMLInputElement>(null)
+  const [isFileOverDropZone, setIsFileOverDropZone] = React.useState<boolean>(
+    false
+  )
+  const handleDrop: React.DragEventHandler<HTMLLabelElement> = e => {
+    e.preventDefault()
+    e.stopPropagation()
+    const { files = [] } = 'dataTransfer' in e ? e.dataTransfer : {}
+    props.onUpload(files[0])
+    setIsFileOverDropZone(false)
+  }
+  const handleDragEnter: React.DragEventHandler<HTMLLabelElement> = e => {
+    e.preventDefault()
+    e.stopPropagation()
+  }
+  const handleDragLeave: React.DragEventHandler<HTMLLabelElement> = e => {
+    e.preventDefault()
+    e.stopPropagation()
+    setIsFileOverDropZone(false)
+  }
+  const handleDragOver: React.DragEventHandler<HTMLLabelElement> = e => {
+    e.preventDefault()
+    e.stopPropagation()
+    setIsFileOverDropZone(true)
+  }
+
+  const handleClick: React.MouseEventHandler<HTMLButtonElement> = _event => {
+    fileInput.current?.click()
+  }
+
+  const onChange: React.ChangeEventHandler<HTMLInputElement> = event => {
+    const { files = [] } = event.target ?? {}
+    files?.[0] && props.onUpload(files?.[0])
+    if ('value' in event.currentTarget) event.currentTarget.value = ''
+  }
+
+  const dropZoneStyles = isFileOverDropZone
+    ? css`
+        ${DROP_ZONE_STYLES} ${DRAG_OVER_STYLES}
+      `
+    : DROP_ZONE_STYLES
+
+  return (
+    <Flex
+      height="100%"
+      flexDirection={DIRECTION_COLUMN}
+      justifyContent={JUSTIFY_CENTER}
+      alignItems={ALIGN_CENTER}
+    >
+      <Text fontSize={FONT_SIZE_BODY_1} margin="1.5rem">
+        {t('valid_file_types')}
+      </Text>
+      <NewPrimaryBtn
+        onClick={handleClick}
+        marginBottom={SPACING_4}
+        textTransform={TEXT_TRANSFORM_CAPITALIZE}
+        id={'UploadInput_protocolUploadButton'}
+      >
+        {t('choose_protocol_file')}
+      </NewPrimaryBtn>
+
+      <label
+        data-testid="file_drop_zone"
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+        onDragEnter={handleDragEnter}
+        onDragLeave={handleDragLeave}
+        css={dropZoneStyles}
+      >
+        <Icon width={SIZE_3} name="upload" marginBottom={SPACING_4} />
+
+        <span
+          aria-controls="file_input"
+          role="button"
+          id={'UploadInput_fileUploadLabel'}
+        >
+          {t('drag_file_here')}
+        </span>
+
+        <input
+          id="file_input"
+          data-testid="file_input"
+          ref={fileInput}
+          css={INPUT_STYLES}
+          type="file"
+          onChange={onChange}
+        />
+      </label>
+    </Flex>
+  )
+}

--- a/app/src/organisms/Protocols/__tests__/EmptyStateLinks.test.tsx
+++ b/app/src/organisms/Protocols/__tests__/EmptyStateLinks.test.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react'
+import '@testing-library/jest-dom'
+import { BrowserRouter } from 'react-router-dom'
+import { renderWithProviders } from '@opentrons/components'
+import { i18n } from '../../../i18n'
+import { EmptyStateLinks } from '../EmptyStateLinks'
+
+describe('EmptyStateLinks', () => {
+  let render: () => ReturnType<typeof renderWithProviders>[0]
+
+  beforeEach(() => {
+    render = () => {
+      return renderWithProviders(
+        <BrowserRouter>
+          <EmptyStateLinks />
+        </BrowserRouter>,
+        {
+          i18nInstance: i18n,
+        }
+      )[0]
+    }
+  })
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('renders correct contents for empty state', () => {
+    const { getByRole } = render()
+    expect(getByRole('complementary')).toHaveTextContent(
+      /Don't have a protocol yet\?/i
+    )
+
+    expect(
+      getByRole('link', { name: 'Launch Opentrons Protocol Library' })
+    ).toBeTruthy()
+    expect(
+      getByRole('link', { name: 'Launch Opentrons Protocol Designer' })
+    ).toBeTruthy()
+    expect(
+      getByRole('link', { name: 'Open Python API Documentation' })
+    ).toBeTruthy()
+  })
+})

--- a/app/src/organisms/Protocols/__tests__/UploadInput.test.tsx
+++ b/app/src/organisms/Protocols/__tests__/UploadInput.test.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react'
+import '@testing-library/jest-dom'
+import { fireEvent } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
+import { renderWithProviders } from '@opentrons/components'
+import { i18n } from '../../../i18n'
+import { UploadInput } from '../UploadInput'
+
+describe('UploadInput', () => {
+  let onUpload: jest.MockedFunction<() => {}>
+  let render: () => ReturnType<typeof renderWithProviders>[0]
+
+  beforeEach(() => {
+    onUpload = jest.fn()
+    render = () => {
+      return renderWithProviders(
+        <BrowserRouter>
+          <UploadInput onUpload={onUpload} />
+        </BrowserRouter>,
+        {
+          i18nInstance: i18n,
+        }
+      )[0]
+    }
+  })
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('renders correct contents for empty state', () => {
+    const { getByRole } = render()
+
+    expect(getByRole('button', { name: 'Choose File' })).toBeTruthy()
+    expect(
+      getByRole('button', { name: 'Drag and drop protocol file here' })
+    ).toBeTruthy()
+  })
+
+  it('opens file select on button click', () => {
+    const { getByRole, getByTestId } = render()
+    const button = getByRole('button', { name: 'Choose File' })
+    const input = getByTestId('file_input')
+    input.click = jest.fn()
+    fireEvent.click(button)
+    expect(input.click).toHaveBeenCalled()
+  })
+  it('calls create session on choose file', () => {
+    const { getByTestId } = render()
+    const input = getByTestId('file_input')
+    fireEvent.change(input, { target: { files: ['dummyFile'] } })
+    expect(onUpload).toHaveBeenCalledWith('dummyFile')
+  })
+})

--- a/app/src/pages/Protocols/ProtocolsLanding/index.tsx
+++ b/app/src/pages/Protocols/ProtocolsLanding/index.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react'
+// import { useTranslation } from 'react-i18next'
+import { ProtocolsEmptyState } from '../../../organisms/Protocols/ProtocolsEmptyState'
+
+import { Box } from '@opentrons/components'
+
+export function ProtocolsLanding(): JSX.Element {
+  return (
+    <Box>
+      <ProtocolsEmptyState />
+    </Box>
+  )
+}


### PR DESCRIPTION
# Overview

closes #8814 by adding empty state for next gen protocols page. NOTE: uploading here will only` console.log('TODO')`

# Changelog

- feat(app): Add protocol landing page empty state

# Review requests

turn on the `Hierarchy Reorganization` FF
click the protocols link
- [ ] page matches design
- [ ] file upload results in a console.lof('TODO')
- [ ] tests make sense
- [ ] component breakdown makes sense (note: i broke out the UploadInput a little differently so that it can be reused in the slide out in future tickets)

# Risk assessment

Low. Presentation changes behind a FF