### PR TITLE
fix(ot3): handle unbalanced triangle moves

### DIFF
--- a/hardware/opentrons_hardware/hardware_control/motion_planning/move_utils.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/move_utils.py
@@ -337,7 +337,6 @@ def build_blocks(
         # ratio between the acceleration and deceleration phases is quite imbalanced.
         # We can always fall back to having our target maximum speed be the larger
         # of the final and initial speeds.
-        print(f"relimited from {max_speed_sq} to {max(initial_speed_sq, final_speed_sq)}")
         max_speed_sq = max(initial_speed_sq, final_speed_sq)
         first.distance = abs(max_speed_sq - initial_speed_sq) / (2 * max_acceleration)
         final.initial_speed = first.final_speed

--- a/hardware/opentrons_hardware/hardware_control/motion_planning/move_utils.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/move_utils.py
@@ -287,7 +287,6 @@ def build_blocks(
         abs(final_speed), max_speed
     ), f"final speed {final_speed} exceeds max speed {max_speed}"
 
-    constraint_max_speed = max_speed
     max_acc = np.array(
         [
             constraints[axis].max_acceleration if unit_vector[axis] else 0.0
@@ -328,13 +327,24 @@ def build_blocks(
         acceleration=-max_acceleration,
         distance=abs(max_speed_sq - final_speed_sq) / (2 * max_acceleration),
     )
+    if first.distance + final.distance > distance:
+        # the math did not quite work out and we need to trim down our top speed.
+        # This will be a suboptimal solution almost certainly, but it's better to
+        # have a suboptimal solution that doesn't violate constraints than an
+        # optimal one that does.
+        # This happens when we have a triangle move (so, anticipating no coast phase)
+        # where we slightly overaccelerate and end up moving too far, when the
+        # ratio between the acceleration and deceleration phases is quite imbalanced.
+        # We can always fall back to having our target maximum speed be the larger
+        # of the final and initial speeds.
+        print(f"relimited from {max_speed_sq} to {max(initial_speed_sq, final_speed_sq)}")
+        max_speed_sq = max(initial_speed_sq, final_speed_sq)
+        first.distance = abs(max_speed_sq - initial_speed_sq) / (2 * max_acceleration)
+        final.initial_speed = first.final_speed
+        final.distance = abs(max_speed_sq - final_speed_sq) / (2 * max_acceleration)
 
-    if max_achievable_speed > constraint_max_speed:
+    if first.distance + final.distance < distance:
         # we'll have a coast phase!
-        assert distance - first.distance - final.distance > 0, (
-            f"bad coast phase detection: total {distance}, first {first.distance}, "
-            f"final {final.distance} "
-        )
         coast = Block(
             initial_speed=final.initial_speed,
             acceleration=0,

--- a/hardware/tests/opentrons_hardware/hardware_control/test_motion_plan.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_motion_plan.py
@@ -160,7 +160,7 @@ def test_close_move_plan(
     converged, blend_log = manager.plan_motion(
         origin=origin,
         target_list=targets,
-        iteration_limit=5,
+        iteration_limit=20,
     )
 
     assert converged

--- a/hardware/tests/opentrons_hardware/hardware_control/test_motion_plan.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_motion_plan.py
@@ -126,7 +126,7 @@ def test_move_plan(
     converged, blend_log = manager.plan_motion(
         origin=origin,
         target_list=targets,
-        iteration_limit=5,
+        iteration_limit=20,
     )
 
     assert converged

--- a/hardware/tests/opentrons_hardware/hardware_control/test_motion_plan.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_motion_plan.py
@@ -17,8 +17,8 @@ from opentrons_hardware.hardware_control.motion_planning.types import (
 def generate_axis_constraint(draw: st.DrawFn) -> AxisConstraints:
     """Create axis constraint using Hypothesis."""
     acc = draw(st.integers(min_value=500, max_value=5000))
-    speed_dist = draw(st.integers(min_value=100, max_value=500))
-    dir_change_dist = draw(st.integers(min_value=10, max_value=100))
+    speed_dist = draw(st.integers(min_value=10, max_value=50))
+    dir_change_dist = draw(st.integers(min_value=5, max_value=10))
     assume(speed_dist > dir_change_dist)
     return AxisConstraints.build(
         max_acceleration=acc,


### PR DESCRIPTION
Sometimes, when we get a very unbalanced triangle move, the math that determines the internal maximum speed of the move doesn't quite work and we emit a move that has more distance in it than it should. We can fix this by detecting the case and making the internal max speed the higher of the two endpoint speeds, which keeps the move internally consistent. This is almost always going to be suboptimal, but it will be safe.

We also need to raise the iteration limit for tests that have lower constraints, which the tests now do.