### PR TITLE
fix(protocol-engine): Preserve distinction between APIv2 protocols' requested vs. connected modules

### DIFF
--- a/api/src/opentrons/protocol_api/load_info.py
+++ b/api/src/opentrons/protocol_api/load_info.py
@@ -59,7 +59,9 @@ class ModuleLoadInfo:
     :meta private:
     """
 
-    module_model: ModuleModel
+    requested_model: ModuleModel
+    loaded_model: ModuleModel
+
     deck_slot: DeckSlotName
     configuration: Optional[str]
     module_serial: str

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Generic, List, Optional, TYPE_CHECKING, TypeVar, Union, cast
+from typing import Generic, List, Optional, TYPE_CHECKING, TypeVar, cast
 
 from opentrons import types
 from opentrons.hardware_control import modules
@@ -22,11 +22,6 @@ from opentrons.protocols.api_support.util import requires_version
 if TYPE_CHECKING:
     from .protocol_context import ProtocolContext
     from opentrons_shared_data.labware.dev_types import LabwareDefinition
-
-
-ModuleTypes = Union[
-    "TemperatureModuleContext", "MagneticModuleContext", "ThermocyclerContext"
-]
 
 ENGAGE_HEIGHT_UNIT_CNV = 2
 STANDARD_MAGDECK_LABWARE = [

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -89,8 +89,7 @@ class ModuleContext(CommandPublisher, Generic[GeometryType]):
 
         provided_offset = self._ctx._labware_offset_provider.find(
             labware_definition_uri=labware.uri,
-            # FIX BEFORE MERGE
-            module_model=self.geometry.model.value,
+            module_model=self.requested_as,
             deck_slot=deck_slot,
         )
 

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -89,7 +89,7 @@ class ModuleContext(CommandPublisher, Generic[GeometryType]):
 
         provided_offset = self._ctx._labware_offset_provider.find(
             labware_definition_uri=labware.uri,
-            module_model=self.requested_as,
+            requested_module_model=self.requested_as,
             deck_slot=deck_slot,
         )
 

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -32,7 +32,10 @@ from opentrons.protocols.types import Protocol
 from .labware import Labware
 from opentrons.protocols.context.labware import AbstractLabware
 from opentrons.protocols.context.protocol import AbstractProtocol
-from opentrons.protocols.geometry.module_geometry import ModuleGeometry
+from opentrons.protocols.geometry.module_geometry import (
+    ModuleGeometry,
+    resolve_module_model,
+)
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 from .instrument_context import InstrumentContext
@@ -578,8 +581,10 @@ class ProtocolContext(CommandPublisher):
                 "using thermocycler parameters only available in 2.4"
             )
 
+        requested_model = resolve_module_model(module_name)
+
         module = self._implementation.load_module(
-            module_name=module_name, location=location, configuration=configuration
+            model=requested_model, location=location, configuration=configuration
         )
 
         if not module:
@@ -608,7 +613,8 @@ class ProtocolContext(CommandPublisher):
 
         self.module_load_broker.publish(
             ModuleLoadInfo(
-                module_model=module.geometry.model,
+                requested_model=requested_model,
+                loaded_model=module.geometry.model,
                 deck_slot=deck_slot,
                 configuration=configuration,
                 module_serial=module_serial,

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -63,7 +63,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 ModuleTypes = Union[
-    "TemperatureModuleContext", "MagneticModuleContext", "ThermocyclerContext"
+    TemperatureModuleContext, MagneticModuleContext, ThermocyclerContext
 ]
 
 

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -401,7 +401,7 @@ class ProtocolContext(CommandPublisher):
 
         provided_labware_offset = self._labware_offset_provider.find(
             labware_definition_uri=result.uri,
-            module_model=None,
+            requested_module_model=None,
             deck_slot=types.DeckSlotName.from_primitive(location),
         )
 
@@ -468,7 +468,7 @@ class ProtocolContext(CommandPublisher):
 
         provided_labware_offset = self._labware_offset_provider.find(
             labware_definition_uri=result.uri,
-            module_model=None,
+            requested_module_model=None,
             deck_slot=types.DeckSlotName.from_primitive(location),
         )
 

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -34,7 +34,6 @@ from opentrons.protocols.context.labware import AbstractLabware
 from opentrons.protocols.context.protocol import AbstractProtocol
 from opentrons.protocols.geometry.module_geometry import (
     ModuleGeometry,
-    module_model_from_string,
     resolve_module_model,
 )
 from opentrons.protocols.geometry.deck import Deck
@@ -616,7 +615,7 @@ class ProtocolContext(CommandPublisher):
         self.module_load_broker.publish(
             ModuleLoadInfo(
                 requested_model=requested_model,
-                loaded_model=module_model_from_string(load_result.module.model()),
+                loaded_model=load_result.geometry.model,
                 deck_slot=deck_slot,
                 configuration=configuration,
                 module_serial=module_serial,

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -602,6 +602,7 @@ class ProtocolContext(CommandPublisher):
             hw_module=load_result.module,
             geometry=load_result.geometry,
             at_version=self.api_version,
+            requested_as=requested_model,
             loop=self._loop,
         )
         self._modules.append(module_context)

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -219,14 +219,13 @@ class LabwareOffsetLocation(BaseModel):
             "The model of the module that the labware will be loaded onto,"
             " if applicable."
             "\n\n"
-            "For the offset to apply,"
-            " this must exactly match the model that the robot will find"
-            " *physically connected* during the protocol's execution."
-            " This means it's not enough to blindly use the model"
-            " reported by the protocol's analysis."
-            " The two models will differ"
-            " if the physically connected module is compatible, but not identical,"
-            " to the one that the protocol requested."
+            "Because of module compatibility, the model that the protocol requests"
+            " may not beexactly the same"
+            " as what it will find physically connected during execution."
+            " For this labware offset to apply,"
+            " this field must be the *requested* model, not the connected one."
+            " You can retrieve this from a `loadModule` command's `params.model`"
+            " in the protocol's analysis."
         ),
     )
 

--- a/api/src/opentrons/protocol_runner/legacy_labware_offset_provider.py
+++ b/api/src/opentrons/protocol_runner/legacy_labware_offset_provider.py
@@ -11,6 +11,8 @@ from opentrons.protocol_api.labware_offset_provider import (
 from opentrons.protocol_engine import LabwareOffsetLocation, ModuleModel
 from opentrons.protocol_engine.state import LabwareView
 
+from .legacy_wrappers import LegacyModuleModel
+
 
 class LegacyLabwareOffsetProvider(AbstractLegacyLabwareOffsetProvider):
     """Provides a `ProtocolEngine`'s labware offsets."""
@@ -22,7 +24,7 @@ class LegacyLabwareOffsetProvider(AbstractLegacyLabwareOffsetProvider):
     def find(
         self,
         labware_definition_uri: str,
-        module_model: Optional[str],
+        requested_module_model: Optional[LegacyModuleModel],
         deck_slot: DeckSlotName,
     ) -> LegacyProvidedLabwareOffset:
         """Look up an offset in ProtocolEngine state and return it, if one exists.
@@ -34,7 +36,9 @@ class LegacyLabwareOffsetProvider(AbstractLegacyLabwareOffsetProvider):
             location=LabwareOffsetLocation(
                 slotName=deck_slot,
                 moduleModel=(
-                    None if module_model is None else ModuleModel(module_model)
+                    None
+                    if requested_module_model is None
+                    else ModuleModel(requested_module_model.value)
                 ),
             ),
         )

--- a/api/src/opentrons/protocols/context/protocol.py
+++ b/api/src/opentrons/protocols/context/protocol.py
@@ -8,7 +8,7 @@ from typing import Dict, Optional, Union
 
 from opentrons import types
 from opentrons.hardware_control import SynchronousAdapter, ThreadManager
-from opentrons.hardware_control.modules.types import ModuleType
+from opentrons.hardware_control.modules.types import ModuleModel, ModuleType
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.protocols.geometry.deck_item import DeckItem
 from opentrons.protocols.geometry.module_geometry import ModuleGeometry
@@ -91,7 +91,7 @@ class AbstractProtocol(ABC):
     @abstractmethod
     def load_module(
         self,
-        module_name: str,
+        model: ModuleModel,
         location: Optional[types.DeckLocation],
         configuration: Optional[str],
     ) -> Optional[LoadModuleResult]:

--- a/api/src/opentrons/protocols/context/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocols/context/protocol_api/protocol_context.py
@@ -186,7 +186,12 @@ class ProtocolContextImplementation(AbstractProtocol):
             resolved_type, location
         )
 
-        # Load the geometry
+        # Load the geometry.
+        #
+        # fixme(mm, 2022-02-03):
+        # This loads the geometry of the *requested* module.
+        # But because of module compatibility, ths won't necessarily match
+        # the hardware module that we will actually load.
         geometry = module_geometry.load_module(
             model=model,
             parent=self._deck_layout.position_for(resolved_location),

--- a/api/src/opentrons/protocols/context/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocols/context/protocol_api/protocol_context.py
@@ -186,19 +186,6 @@ class ProtocolContextImplementation(AbstractProtocol):
             resolved_type, location
         )
 
-        # Load the geometry.
-        #
-        # fixme(mm, 2022-02-03):
-        # This loads the geometry of the *requested* module.
-        # But because of module compatibility, ths won't necessarily match
-        # the hardware module that we will actually load.
-        geometry = module_geometry.load_module(
-            model=model,
-            parent=self._deck_layout.position_for(resolved_location),
-            api_level=self._api_version,
-            configuration=configuration,
-        )
-
         # Try to find in the hardware instance
         available_modules, simulating_module = self._hw_manager.hardware.find_modules(
             model, resolved_type
@@ -219,6 +206,14 @@ class ProtocolContextImplementation(AbstractProtocol):
 
         if not hc_mod_instance:
             return None
+
+        # Load geometry to match the hardware module that we found connected.
+        geometry = module_geometry.load_module(
+            model=module_geometry.module_model_from_string(hc_mod_instance.model()),
+            parent=self._deck_layout.position_for(resolved_location),
+            api_level=self._api_version,
+            configuration=configuration,
+        )
 
         result = LoadModuleResult(
             type=resolved_type, geometry=geometry, module=hc_mod_instance

--- a/api/src/opentrons/protocols/context/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocols/context/protocol_api/protocol_context.py
@@ -1,15 +1,21 @@
 import logging
-from typing import Dict, Optional, Set, List, Union, TYPE_CHECKING
+from typing import Dict, Optional, Set, List, Union
 from collections import OrderedDict
 
 from opentrons import types
-from opentrons.protocols.api_support.types import APIVersion
-from opentrons.hardware_control.types import DoorState, PauseType
+
 from opentrons.hardware_control import ThreadManager, SynchronousAdapter
+from opentrons.hardware_control.modules import AbstractModule, ModuleModel
+from opentrons.hardware_control.types import DoorState, PauseType
+
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
-from opentrons.protocols.geometry.deck import Deck
-from opentrons.protocols.geometry import module_geometry
-from opentrons.protocols.geometry.deck_item import DeckItem
+from opentrons.protocols.api_support.types import APIVersion
+from opentrons.protocols.api_support.util import (
+    AxisMaxSpeeds,
+    HardwareToManage,
+    HardwareManager,
+)
+
 from opentrons.protocols.context.protocol_api.instrument_context import (
     InstrumentContextImplementation,
 )
@@ -20,17 +26,16 @@ from opentrons.protocols.context.protocol import (
     InstrumentDict,
     LoadModuleResult,
 )
-from opentrons.protocols.api_support.util import (
-    AxisMaxSpeeds,
-    HardwareToManage,
-    HardwareManager,
-)
-from opentrons.protocols.labware import load_from_definition, get_labware_definition
-from opentrons.protocols.types import Protocol
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
-if TYPE_CHECKING:
-    from opentrons.hardware_control.modules import AbstractModule
+from opentrons.protocols.geometry import module_geometry
+from opentrons.protocols.geometry.deck import Deck
+from opentrons.protocols.geometry.deck_item import DeckItem
+
+from opentrons.protocols.labware import load_from_definition, get_labware_definition
+
+from opentrons.protocols.types import Protocol
+
+from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 
 logger = logging.getLogger(__name__)
@@ -171,20 +176,19 @@ class ProtocolContextImplementation(AbstractProtocol):
 
     def load_module(
         self,
-        module_name: str,
+        model: ModuleModel,
         location: Optional[types.DeckLocation],
         configuration: Optional[str],
     ) -> Optional[LoadModuleResult]:
         """Load a module."""
-        resolved_model = module_geometry.resolve_module_model(module_name)
-        resolved_type = module_geometry.resolve_module_type(resolved_model)
+        resolved_type = module_geometry.resolve_module_type(model)
         resolved_location = self._deck_layout.resolve_module_location(
             resolved_type, location
         )
 
         # Load the geometry
         geometry = module_geometry.load_module(
-            model=resolved_model,
+            model=model,
             parent=self._deck_layout.position_for(resolved_location),
             api_level=self._api_version,
             configuration=configuration,
@@ -192,13 +196,13 @@ class ProtocolContextImplementation(AbstractProtocol):
 
         # Try to find in the hardware instance
         available_modules, simulating_module = self._hw_manager.hardware.find_modules(
-            resolved_model, resolved_type
+            model, resolved_type
         )
 
         hc_mod_instance = None
         for mod in available_modules:
             compatible = module_geometry.models_compatible(
-                module_geometry.module_model_from_string(mod.model()), resolved_model
+                module_geometry.module_model_from_string(mod.model()), model
             )
             if compatible and mod not in self._loaded_modules:
                 self._loaded_modules.add(mod)

--- a/api/src/opentrons/protocols/geometry/module_geometry.py
+++ b/api/src/opentrons/protocols/geometry/module_geometry.py
@@ -592,8 +592,8 @@ def load_module(
         return load_module_from_definition(defn, parent, api_level)
 
 
-def resolve_module_model(module_name: str) -> ModuleModel:
-    """Turn any of the supported load names into module model names"""
+def resolve_module_model(module_model_or_load_name: str) -> ModuleModel:
+    """Turn any of the supported APIv2 load names into module model names."""
 
     model_map: Mapping[str, ModuleModel] = {
         "magneticModuleV1": MagneticModuleModel.MAGNETIC_V1,
@@ -614,11 +614,13 @@ def resolve_module_model(module_name: str) -> ModuleModel:
         "thermocycler module": ThermocyclerModuleModel.THERMOCYCLER_V1,
     }
 
-    lower_name = module_name.lower()
-    resolved_name = model_map.get(module_name, None) or alias_map.get(lower_name, None)
+    lower_name = module_model_or_load_name.lower()
+    resolved_name = model_map.get(module_model_or_load_name, None) or alias_map.get(
+        lower_name, None
+    )
     if not resolved_name:
         raise ValueError(
-            f"{module_name} is not a valid module load name.\n"
+            f"{module_model_or_load_name} is not a valid module load name.\n"
             "Valid names (ignoring case): "
             '"'
             + '", "'.join(alias_map.keys())

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -24,7 +24,7 @@ from opentrons.protocol_runner.legacy_wrappers import (
     LegacyInstrumentLoadInfo,
     LegacyLabwareLoadInfo,
     LegacyModuleLoadInfo,
-    LegacyMagneticModuleModel,
+    LegacyTemperatureModuleModel,
 )
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 from opentrons_shared_data.module.dev_types import ModuleDefinitionV2
@@ -299,13 +299,14 @@ def test_map_module_load(
     """It should correctly map a module load."""
     test_definition = ModuleDefinition.parse_obj(minimal_module_def)
     input = LegacyModuleLoadInfo(
-        module_model=LegacyMagneticModuleModel.MAGNETIC_V2,
+        requested_model=LegacyTemperatureModuleModel.TEMPERATURE_V1,
+        loaded_model=LegacyTemperatureModuleModel.TEMPERATURE_V2,
         deck_slot=DeckSlotName.SLOT_1,
         configuration="conf",
         module_serial="module-serial",
     )
     decoy.when(
-        module_data_provider.get_definition(ModuleModel.MAGNETIC_MODULE_V2)
+        module_data_provider.get_definition(ModuleModel.TEMPERATURE_MODULE_V2)
     ).then_return(test_definition)
 
     expected_output = pe_commands.LoadModule.construct(
@@ -316,7 +317,7 @@ def test_map_module_load(
         startedAt=matchers.IsA(datetime),
         completedAt=matchers.IsA(datetime),
         params=pe_commands.LoadModuleParams.construct(
-            model=ModuleModel.MAGNETIC_MODULE_V2,
+            model=ModuleModel.TEMPERATURE_MODULE_V1,
             location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
             moduleId=matchers.IsA(str),
         ),
@@ -324,7 +325,7 @@ def test_map_module_load(
             moduleId=matchers.IsA(str),
             serialNumber="module-serial",
             definition=test_definition,
-            model=test_definition.model,
+            model=ModuleModel.TEMPERATURE_MODULE_V2,
         ),
     )
     output = LegacyCommandMapper(

--- a/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
@@ -389,7 +389,8 @@ async def test_module_load_broker_messages(
     handler: Callable[[LegacyModuleLoadInfo], None] = module_handler_captor.value
 
     module_load_info = LegacyModuleLoadInfo(
-        module_model=LegacyMagneticModuleModel.MAGNETIC_V2,
+        requested_model=LegacyMagneticModuleModel.MAGNETIC_V2,
+        loaded_model=LegacyMagneticModuleModel.MAGNETIC_V2,
         deck_slot=DeckSlotName.SLOT_1,
         configuration=None,
         module_serial="serial-number",

--- a/api/tests/opentrons/protocol_runner/test_legacy_labware_offset_provider.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_labware_offset_provider.py
@@ -18,6 +18,7 @@ from opentrons.protocol_runner.legacy_labware_offset_provider import (
     LegacyLabwareOffsetProvider,
     LegacyProvidedLabwareOffset,
 )
+from opentrons.protocol_runner.legacy_wrappers import LegacyTemperatureModuleModel
 
 
 @pytest.fixture
@@ -58,7 +59,7 @@ def test_find_something(
 
     result = subject.find(
         labware_definition_uri="some_namespace/some_load_name/123",
-        module_model="temperatureModuleV1",
+        requested_module_model=LegacyTemperatureModuleModel.TEMPERATURE_V1,
         deck_slot=DeckSlotName.SLOT_1,
     )
 
@@ -84,7 +85,7 @@ def test_find_nothing(
 
     result = subject.find(
         labware_definition_uri="some_namespace/some_load_name/123",
-        module_model="temperatureModuleV1",
+        requested_module_model=LegacyTemperatureModuleModel.TEMPERATURE_V1,
         deck_slot=DeckSlotName.SLOT_1,
     )
 


### PR DESCRIPTION
# Overview

This PR addresses a few module loading bugs that are intertwined with each other.

# Changelog

This is a few different things that are intertwined:

1. Change the contract for `POST /runs/{run_id}/labware_offsets`.

   When the labware's location involves a module, the client must now provide the module that the protocol will *request,* not the module that the protocol will actually *find.*

   This is the exact opposite of what we had [previously specified](https://github.com/Opentrons/opentrons/pull/9351). However, because of symmetrical bugs on both the client and server, we had accidentally been implementing it this way, all along. 🙃
   
   We had been finding the previous contract confusing and painful, anyway. This new contract avoids some of that pain and confusion and lets us proceed towards a v5.0.0 release without coordinating further client-side changes. I think we're basically buying time until we do #9354.

2. Fix Python Protocol API v2 sometimes using the wrong module geometry.

   This closes #9365.

   This was an apparent motion bug. It may have been covered up by labware calibration, but internal changes in v5.0.0 would mean it wouldn't be covered up by the new Labware Position Check.

3. In `loadModule` commands that come from APIv2 protocols, preserve the distinction between requested and connected modules.

    The `loadModule` model already has two separate fields to report these two separate things, but limitations in our mapping code were causing them to be conflated.

      **Before this PR:**
   
   |                                | **`params.model`**           | **`result.model`**                                                                                          |
   |--------------------------------|------------------------------|-------------------------------------------------------------------------------------------------------------|
   | **APIv2 protocol's analysis**  | What the protocol requested. | Arbitrary—whatever the simulating hardware API happens to return. In practice, identical to `params.model`. |
   | **APIv2 protocol's execution** | What the protocol requested. | **What the protocol requested.**                                                                                |
   
   **After this PR:**
   
   |                                | **`params.model`**           | **`result.model`**                                                                                          |
   |--------------------------------|------------------------------|-------------------------------------------------------------------------------------------------------------|
   | **APIv2 protocol's analysis**  | What the protocol requested. | Arbitrary—whatever the simulating hardware API happens to return. In practice, identical to `params.model`. |
   | **APIv2 protocol's execution** | What the protocol requested. | **What the robot actually found connected.**                                                                    |


# Review requests

Manual testing is important for this PR. Things to look for

* Can you still load and control different modules?
* If you skip Labware Position Check, is the default positioning reasonable, for labware that's atop a module?
    * Especially for Temperature Modules, and especially if your protocol specifies a different generation of Temperature Module than you actually have connected.
* Does Labware Position Check continue to function as expected, and is it still able to apply offsets to labware atop modules? Are those offsets present in the protocol run?
    * Especially for Temperature Modules, and especially if your protocol specifies a different generation of Temperature Module than you actually have connected.
* If you manually inspect an HTTP response, do `loadModule.params.model` and `loadModule.result.model` make sense? See the table above. 

# Risk assessment

Medium-high. This is precarious for a few reasons:

* Bad type-checking within `ProtocolContext`.
* Apparent module model bugginess and confusion within the APIv2 internals.
* The general fragility of how labware offsets currently work when multiples-of-a-module and module compatibility are in the picture.