### PR TITLE
refactor(protocol-engine): Merge APIv2 equipment brokers

### DIFF
--- a/api/src/opentrons/protocol_api/load_info.py
+++ b/api/src/opentrons/protocol_api/load_info.py
@@ -6,7 +6,7 @@ It's only for internal Opentrons use.
 
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Union
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 from opentrons.hardware_control.modules.types import ModuleModel
@@ -63,3 +63,6 @@ class ModuleLoadInfo:
     deck_slot: DeckSlotName
     configuration: Optional[str]
     module_serial: str
+
+
+LoadInfo = Union[LabwareLoadInfo, InstrumentLoadInfo, ModuleLoadInfo]

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -97,7 +97,7 @@ class ModuleContext(CommandPublisher, Generic[GeometryType]):
         labware.set_calibration(provided_offset.delta)
         self._ctx._implementation.get_deck().recalculate_high_z()
 
-        self._ctx.labware_load_broker.publish(
+        self._ctx.equipment_broker.publish(
             LabwareLoadInfo(
                 labware_definition=labware._implementation.get_definition(),
                 labware_namespace=labware_namespace,

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -173,6 +173,7 @@ class LegacyCommandMapper:
         return results
 
     def map_equipment_load(self, load_info: LegacyLoadInfo) -> pe_commands.Command:
+        """Map a labware, instrument (pipette), or module load to a PE command."""
         if isinstance(load_info, LegacyLabwareLoadInfo):
             return self._map_labware_load(load_info)
         elif isinstance(load_info, LegacyInstrumentLoadInfo):

--- a/api/src/opentrons/protocol_runner/legacy_context_plugin.py
+++ b/api/src/opentrons/protocol_runner/legacy_context_plugin.py
@@ -14,13 +14,7 @@ from opentrons.hardware_control.types import (
 
 from opentrons.protocol_engine import AbstractPlugin, actions as pe_actions
 
-from .legacy_wrappers import (
-    LegacyProtocolContext,
-    LegacyLoadInfo,
-    LegacyInstrumentLoadInfo,
-    LegacyLabwareLoadInfo,
-    LegacyModuleLoadInfo,
-)
+from .legacy_wrappers import LegacyProtocolContext, LegacyLoadInfo
 from .legacy_command_mapper import LegacyCommandMapper
 from .thread_async_queue import ThreadAsyncQueue
 

--- a/api/src/opentrons/protocol_runner/legacy_wrappers.py
+++ b/api/src/opentrons/protocol_runner/legacy_wrappers.py
@@ -29,6 +29,7 @@ from opentrons.protocol_api import (
 )
 from opentrons.protocol_api.labware import Labware as LegacyLabware, Well as LegacyWell
 from opentrons.protocol_api.load_info import (
+    LoadInfo as LegacyLoadInfo,
     InstrumentLoadInfo as LegacyInstrumentLoadInfo,
     LabwareLoadInfo as LegacyLabwareLoadInfo,
     ModuleLoadInfo as LegacyModuleLoadInfo,
@@ -166,6 +167,7 @@ __all__ = [
     "LegacyProtocol",
     "LegacyJsonProtocol",
     "LegacyPythonProtocol",
+    "LegacyLoadInfo",
     "LegacyLabwareLoadInfo",
     "LegacyInstrumentLoadInfo",
     "LegacyModuleLoadInfo",

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -264,7 +264,7 @@ def test_map_labware_load(minimal_labware_def: LabwareDefinition) -> None:
             offsetId="labware-offset-id-123",
         ),
     )
-    output = LegacyCommandMapper().map_labware_load(input)
+    output = LegacyCommandMapper().map_equipment_load(input)
     assert output == expected_output
 
 
@@ -287,7 +287,7 @@ def test_map_instrument_load() -> None:
         result=pe_commands.LoadPipetteResult.construct(pipetteId=matchers.IsA(str)),
     )
 
-    output = LegacyCommandMapper().map_instrument_load(input)
+    output = LegacyCommandMapper().map_equipment_load(input)
     assert output == expected_output
 
 
@@ -329,7 +329,7 @@ def test_map_module_load(
     )
     output = LegacyCommandMapper(
         module_data_provider=module_data_provider
-    ).map_module_load(input)
+    ).map_equipment_load(input)
     assert output == expected_output
 
 
@@ -367,7 +367,7 @@ def test_map_module_labware_load(minimal_labware_def: LabwareDefinition) -> None
     )
     subject = LegacyCommandMapper()
     subject._module_id_by_slot = {DeckSlotName.SLOT_1: "module-123"}
-    output = subject.map_labware_load(load_input)
+    output = subject.map_equipment_load(load_input)
     assert output == expected_output
 
 

--- a/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
@@ -22,14 +22,10 @@ from opentrons.protocol_runner.legacy_command_mapper import LegacyCommandMapper
 from opentrons.protocol_runner.legacy_context_plugin import LegacyContextPlugin
 from opentrons.protocol_runner.legacy_wrappers import (
     LegacyProtocolContext,
-    LegacyLoadInfo,
     LegacyLabwareLoadInfo,
-    LegacyInstrumentLoadInfo,
-    LegacyModuleLoadInfo,
-    LegacyMagneticModuleModel,
 )
 
-from opentrons.types import DeckSlotName, Mount
+from opentrons.types import DeckSlotName
 
 from opentrons_shared_data.labware.dev_types import (
     LabwareDefinition as LabwareDefinitionDict,


### PR DESCRIPTION
# Overview

This refactors the way that APIv2 reports labware loads, pipette loads, and module loads to Protocol Engine.

Before this PR, these were reported through three separate message brokers that could be individually subscribed to and unsubscribed from. This flexibility was unnecessary, and it caused some bloat in the tests.

With this PR, these are all merged into a single `EquipmentBroker`, which brokers a single `LoadInfo` type—a union of `LabwareLoadInfo`, `InstrumentLoadInfo`, or `ModuleLoadInfo`. It's now `LegacyCommandMapper`'s job to unwrap these generic `LoadInfo`s. This matches how it unwraps generic messages from the command broker.

# Review requests

* Does the new code make sense?
* If you like, you can smoke test this by uploading a protocol to a dev server and making sure its analysis returns all the correct pipettes, modules, and labware.

# Risk assessment

Low. This refactor is pretty straightforward.