### PR TITLE
fix(app): close LPC success toast if relaunched

### DIFF
--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
@@ -45,7 +45,7 @@ export const SummaryScreen = (props: {
     )
   const { createLabwareOffset } = useCreateLabwareOffsetMutation()
   const runId = useCurrentRunId()
-  const { setShowLPCSuccessToast } = useLPCSuccessToast()
+  const { setIsShowingLPCSuccessToast } = useLPCSuccessToast()
 
   if (runId == null || introInfo == null || protocolData == null) return null
   const labwareIds = Object.keys(protocolData.labware)
@@ -107,7 +107,7 @@ export const SummaryScreen = (props: {
           id={'Lpc_summaryScreen_applyOffsetButton'}
           onClick={() => {
             applyLabwareOffsets()
-            setShowLPCSuccessToast()
+            setIsShowingLPCSuccessToast(true)
             props.onCloseClick()
           }}
         >

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
@@ -120,11 +120,9 @@ describe('SummaryScreen', () => {
   })
   it('renders apply offset button and clicks it', () => {
     const mockSetIsShowingLPCSuccessToast = jest.fn()
-    when(mockUseLPCSuccessToast)
-      .calledWith()
-      .mockReturnValue({
-        setIsShowingLPCSuccessToast: mockSetIsShowingLPCSuccessToast,
-      })
+    when(mockUseLPCSuccessToast).calledWith().mockReturnValue({
+      setIsShowingLPCSuccessToast: mockSetIsShowingLPCSuccessToast,
+    })
     const { getByRole } = render(props)
     expect(props.onCloseClick).not.toHaveBeenCalled()
     expect(mockSetIsShowingLPCSuccessToast).not.toHaveBeenCalled()

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
@@ -105,7 +105,7 @@ describe('SummaryScreen', () => {
       } as any)
     when(mockUseLPCSuccessToast)
       .calledWith()
-      .mockReturnValue({ setShowLPCSuccessToast: () => null })
+      .mockReturnValue({ setIsShowingLPCSuccessToast: _isShowing => {} })
   })
   afterEach(() => {
     resetAllWhenMocks()
@@ -119,13 +119,15 @@ describe('SummaryScreen', () => {
     getByText('Labware Position Check Complete')
   })
   it('renders apply offset button and clicks it', () => {
-    const mockSetShowLPCSuccessToast = jest.fn()
+    const mockSetIsShowingLPCSuccessToast = jest.fn()
     when(mockUseLPCSuccessToast)
       .calledWith()
-      .mockReturnValue({ setShowLPCSuccessToast: mockSetShowLPCSuccessToast })
+      .mockReturnValue({
+        setIsShowingLPCSuccessToast: mockSetIsShowingLPCSuccessToast,
+      })
     const { getByRole } = render(props)
     expect(props.onCloseClick).not.toHaveBeenCalled()
-    expect(mockSetShowLPCSuccessToast).not.toHaveBeenCalled()
+    expect(mockSetIsShowingLPCSuccessToast).not.toHaveBeenCalled()
     const button = getByRole('button', {
       name: 'Close and apply labware offset data',
     })
@@ -133,6 +135,6 @@ describe('SummaryScreen', () => {
       fireEvent.click(button)
     })
     expect(props.onCloseClick).toHaveBeenCalled()
-    expect(mockSetShowLPCSuccessToast).toHaveBeenCalled()
+    expect(mockSetIsShowingLPCSuccessToast).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareSetup.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareSetup.test.tsx
@@ -9,7 +9,6 @@ import {
   LabwareRender,
   RobotWorkSpace,
   Module,
-  anyProps,
 } from '@opentrons/components'
 import {
   inferModuleOrientationFromXCoordinate,

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
@@ -40,10 +40,13 @@ import standardDeckDef from '@opentrons/shared-data/deck/definitions/2/ot2_stand
 import { useRunStatus } from '../../../RunTimeControl/hooks'
 import { LabwarePositionCheck } from '../../LabwarePositionCheck'
 import styles from '../../styles.css'
-import { useModuleRenderInfoById, useLabwareRenderInfoById } from '../../hooks'
 import { useProtocolDetails } from '../../../RunDetails/hooks'
 import { DownloadOffsetDataModal } from '../../../ProtocolUpload/DownloadOffsetDataModal'
-import { useLPCSuccessToast } from '../../hooks'
+import {
+  useModuleRenderInfoById,
+  useLabwareRenderInfoById,
+  useLPCSuccessToast,
+} from '../../hooks'
 import { useModuleMatchResults, useProtocolCalibrationStatus } from '../hooks'
 import { LabwareInfoOverlay } from './LabwareInfoOverlay'
 import { LabwareOffsetModal } from './LabwareOffsetModal'

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
@@ -43,6 +43,7 @@ import styles from '../../styles.css'
 import { useModuleRenderInfoById, useLabwareRenderInfoById } from '../../hooks'
 import { useProtocolDetails } from '../../../RunDetails/hooks'
 import { DownloadOffsetDataModal } from '../../../ProtocolUpload/DownloadOffsetDataModal'
+import { useLPCSuccessToast } from '../../hooks'
 import { useModuleMatchResults, useProtocolCalibrationStatus } from '../hooks'
 import { LabwareInfoOverlay } from './LabwareInfoOverlay'
 import { LabwareOffsetModal } from './LabwareOffsetModal'
@@ -107,6 +108,7 @@ export const LabwareSetup = (): JSX.Element | null => {
   const isLabwareOffsetCodeSnippetsOn = useSelector(
     Config.getIsLabwareOffsetCodeSnippetsOn
   )
+  const { setIsShowingLPCSuccessToast } = useLPCSuccessToast()
 
   let lpcDisabledReason: string | null = null
 
@@ -254,7 +256,10 @@ export const LabwareSetup = (): JSX.Element | null => {
             <Flex justifyContent={JUSTIFY_CENTER}>
               <NewSecondaryBtn
                 title={t('run_labware_position_check')}
-                onClick={() => setShowLabwarePositionCheckModal(true)}
+                onClick={() => {
+                  setShowLabwarePositionCheckModal(true)
+                  setIsShowingLPCSuccessToast(false)
+                }}
                 id={'LabwareSetup_checkLabwarePositionsButton'}
                 {...targetProps}
                 disabled={lpcDisabledReason !== null}

--- a/app/src/organisms/ProtocolSetup/hooks.ts
+++ b/app/src/organisms/ProtocolSetup/hooks.ts
@@ -109,12 +109,12 @@ export function usePipetteMount(
 
 // this context is used to trigger an LPC success toast render from an LPC component lower in the tree
 export const LPCSuccessToastContext = createContext<{
-  setShowLPCSuccessToast: () => void
-}>({ setShowLPCSuccessToast: () => null })
+  setIsShowingLPCSuccessToast: (isShowing: boolean) => void
+}>({ setIsShowingLPCSuccessToast: () => null })
 
 export function useLPCSuccessToast(): {
-  setShowLPCSuccessToast: () => void
+  setIsShowingLPCSuccessToast: (isShowing: boolean) => void
 } {
-  const { setShowLPCSuccessToast } = useContext(LPCSuccessToastContext)
-  return { setShowLPCSuccessToast }
+  const { setIsShowingLPCSuccessToast } = useContext(LPCSuccessToastContext)
+  return { setIsShowingLPCSuccessToast }
 }

--- a/app/src/organisms/ProtocolSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/index.tsx
@@ -35,7 +35,9 @@ const feedbackFormLink =
   'https://docs.google.com/forms/d/e/1FAIpQLSd6oSV82IfgzSi5t_FP6n_pB_Y8wPGmAgFHsiiFho9qhxr-UQ/viewform'
 
 export function ProtocolSetup(): JSX.Element {
-  const [showLPCSuccessToast, setShowLPCSuccessToast] = React.useState(false)
+  const [showLPCSuccessToast, setIsShowingLPCSuccessToast] = React.useState(
+    false
+  )
   const { t } = useTranslation(['protocol_setup'])
 
   const runStatus = useRunStatus()
@@ -82,12 +84,13 @@ export function ProtocolSetup(): JSX.Element {
       >
         <LPCSuccessToastContext.Provider
           value={{
-            setShowLPCSuccessToast: () => setShowLPCSuccessToast(true),
+            setIsShowingLPCSuccessToast: (isShowing: boolean) =>
+              setIsShowingLPCSuccessToast(isShowing),
           }}
         >
           {showLPCSuccessToast && (
             <LabwareOffsetSuccessToast
-              onCloseClick={() => setShowLPCSuccessToast(false)}
+              onCloseClick={() => setIsShowingLPCSuccessToast(false)}
             />
           )}
           <MetadataCard />


### PR DESCRIPTION
# Overview

Implicitly close the Labware Position Check success toast if the flow is launched again.

Closes #9377

# Changelog

- close  the labware position check success toast if it is relaunched

# Review requests

- confirm that the labware position check success toast appears as expected
- confirm that the labware position check success toast closes when the "X" on the right side of it is clicked
- confirm that the labware position check success toast closes when labware position check is relaunched

# Risk assessment
low
