### PR TITLE
refactor(api, g-code-testing): rename plate_lock to labware_latch

### DIFF
--- a/api/src/opentrons/drivers/heater_shaker/abstract.py
+++ b/api/src/opentrons/drivers/heater_shaker/abstract.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Dict
 
-from opentrons.drivers.types import Temperature, RPM, HeaterShakerPlateLockStatus
+from opentrons.drivers.types import Temperature, RPM, HeaterShakerLabwareLatchStatus
 
 
 class AbstractHeaterShakerDriver(ABC):
@@ -21,13 +21,13 @@ class AbstractHeaterShakerDriver(ABC):
         ...
 
     @abstractmethod
-    async def open_plate_lock(self) -> None:
-        """Send open-plate-lock command"""
+    async def open_labware_latch(self) -> None:
+        """Send open-labware-latch command"""
         ...
 
     @abstractmethod
-    async def close_plate_lock(self) -> None:
-        """Send close-plate-lock command"""
+    async def close_labware_latch(self) -> None:
+        """Send close-labware-latch command"""
         ...
 
     @abstractmethod
@@ -51,8 +51,8 @@ class AbstractHeaterShakerDriver(ABC):
         ...
 
     @abstractmethod
-    async def get_plate_lock_status(self) -> HeaterShakerPlateLockStatus:
-        """Send get-plate-lock-status command"""
+    async def get_labware_latch_status(self) -> HeaterShakerLabwareLatchStatus:
+        """Send get-labware-latch-status command"""
         ...
 
     @abstractmethod

--- a/api/src/opentrons/drivers/heater_shaker/driver.py
+++ b/api/src/opentrons/drivers/heater_shaker/driver.py
@@ -78,14 +78,20 @@ class HeaterShakerDriver(AbstractHeaterShakerDriver):
         return await self._connection.is_open()
 
     async def open_labware_latch(self) -> None:
-        """Send open-plate-lock command"""
+        """Send open-plate-lock command.
+
+        Note: Labware latch is referred to as 'plate lock' in firmware.
+        """
         c = CommandBuilder(terminator=HS_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.OPEN_LABWARE_LATCH
         )
         await self._connection.send_command(command=c, retries=DEFAULT_COMMAND_RETRIES)
 
     async def close_labware_latch(self) -> None:
-        """Send close-plate-lock command"""
+        """Send close-plate-lock command.
+
+        Note: Labware latch is referred to as 'plate lock' in firmware.
+        """
         c = CommandBuilder(terminator=HS_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.CLOSE_LABWARE_LATCH
         )
@@ -137,7 +143,10 @@ class HeaterShakerDriver(AbstractHeaterShakerDriver):
         return utils.parse_rpm_response(rpm_string=response)
 
     async def get_labware_latch_status(self) -> HeaterShakerLabwareLatchStatus:
-        """Send get-labware-latch-status command"""
+        """Send get-labware-latch-status command.
+
+        Note: Labware latch is referred to as 'plate lock' in firmware.
+        """
         c = CommandBuilder(terminator=HS_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.GET_LABWARE_LATCH_STATE
         )

--- a/api/src/opentrons/drivers/heater_shaker/driver.py
+++ b/api/src/opentrons/drivers/heater_shaker/driver.py
@@ -8,7 +8,7 @@ from opentrons.drivers import utils
 from opentrons.drivers.command_builder import CommandBuilder
 from opentrons.drivers.asyncio.communication import SerialConnection
 from opentrons.drivers.heater_shaker.abstract import AbstractHeaterShakerDriver
-from opentrons.drivers.types import Temperature, RPM, HeaterShakerPlateLockStatus
+from opentrons.drivers.types import Temperature, RPM, HeaterShakerLabwareLatchStatus
 
 
 class GCODE(str, Enum):
@@ -19,9 +19,9 @@ class GCODE(str, Enum):
     HOME = "G28"
     ENTER_BOOTLOADER = "dfu"
     GET_VERSION = "M115"
-    OPEN_PLATE_LOCK = "M242"
-    CLOSE_PLATE_LOCK = "M243"
-    GET_PLATE_LOCK_STATE = "M241"
+    OPEN_LABWARE_LATCH = "M242"
+    CLOSE_LABWARE_LATCH = "M243"
+    GET_LABWARE_LATCH_STATE = "M241"
 
 
 HS_BAUDRATE = 115200
@@ -77,17 +77,17 @@ class HeaterShakerDriver(AbstractHeaterShakerDriver):
         """Check connection"""
         return await self._connection.is_open()
 
-    async def open_plate_lock(self) -> None:
+    async def open_labware_latch(self) -> None:
         """Send open-plate-lock command"""
         c = CommandBuilder(terminator=HS_COMMAND_TERMINATOR).add_gcode(
-            gcode=GCODE.OPEN_PLATE_LOCK
+            gcode=GCODE.OPEN_LABWARE_LATCH
         )
         await self._connection.send_command(command=c, retries=DEFAULT_COMMAND_RETRIES)
 
-    async def close_plate_lock(self) -> None:
+    async def close_labware_latch(self) -> None:
         """Send close-plate-lock command"""
         c = CommandBuilder(terminator=HS_COMMAND_TERMINATOR).add_gcode(
-            gcode=GCODE.CLOSE_PLATE_LOCK
+            gcode=GCODE.CLOSE_LABWARE_LATCH
         )
         await self._connection.send_command(command=c, retries=DEFAULT_COMMAND_RETRIES)
 
@@ -136,15 +136,15 @@ class HeaterShakerDriver(AbstractHeaterShakerDriver):
         )
         return utils.parse_rpm_response(rpm_string=response)
 
-    async def get_plate_lock_status(self) -> HeaterShakerPlateLockStatus:
-        """Send get-plate-lock-status command"""
+    async def get_labware_latch_status(self) -> HeaterShakerLabwareLatchStatus:
+        """Send get-labware-latch-status command"""
         c = CommandBuilder(terminator=HS_COMMAND_TERMINATOR).add_gcode(
-            gcode=GCODE.GET_PLATE_LOCK_STATE
+            gcode=GCODE.GET_LABWARE_LATCH_STATE
         )
         response = await self._connection.send_command(
             command=c, retries=DEFAULT_COMMAND_RETRIES
         )
-        return utils.parse_plate_lock_status_response(status_string=response)
+        return utils.parse_labware_latch_status_response(status_string=response)
 
     async def home(self) -> None:
         """Send home command"""

--- a/api/src/opentrons/drivers/heater_shaker/simulator.py
+++ b/api/src/opentrons/drivers/heater_shaker/simulator.py
@@ -1,13 +1,13 @@
 from typing import Dict
 from opentrons.drivers.heater_shaker.abstract import AbstractHeaterShakerDriver
-from opentrons.drivers.types import Temperature, RPM, HeaterShakerPlateLockStatus
+from opentrons.drivers.types import Temperature, RPM, HeaterShakerLabwareLatchStatus
 
 
 class SimulatingDriver(AbstractHeaterShakerDriver):
     DEFAULT_TEMP = 23
 
     def __init__(self) -> None:
-        self._plate_lock_state = HeaterShakerPlateLockStatus.IDLE_UNKNOWN
+        self._labware_latch_state = HeaterShakerLabwareLatchStatus.IDLE_UNKNOWN
         self._current_temperature = self.DEFAULT_TEMP
         self._temperature = Temperature(current=self.DEFAULT_TEMP, target=None)
         self._rpm = RPM(current=0, target=None)
@@ -22,14 +22,14 @@ class SimulatingDriver(AbstractHeaterShakerDriver):
     async def is_connected(self) -> bool:
         return True
 
-    async def open_plate_lock(self) -> None:
-        self._plate_lock_state = HeaterShakerPlateLockStatus.IDLE_OPEN
+    async def open_labware_latch(self) -> None:
+        self._labware_latch_state = HeaterShakerLabwareLatchStatus.IDLE_OPEN
 
-    async def close_plate_lock(self) -> None:
-        self._plate_lock_state = HeaterShakerPlateLockStatus.IDLE_CLOSED
+    async def close_labware_latch(self) -> None:
+        self._labware_latch_state = HeaterShakerLabwareLatchStatus.IDLE_CLOSED
 
-    async def get_plate_lock_status(self) -> HeaterShakerPlateLockStatus:
-        return self._plate_lock_state
+    async def get_labware_latch_status(self) -> HeaterShakerLabwareLatchStatus:
+        return self._labware_latch_state
 
     async def set_temperature(self, temperature: float) -> None:
         self._temperature.current = temperature

--- a/api/src/opentrons/drivers/types.py
+++ b/api/src/opentrons/drivers/types.py
@@ -32,8 +32,8 @@ class RPM:
     target: Optional[int]
 
 
-class HeaterShakerPlateLockStatus(str, Enum):
-    """Heater-shaker plate lock status"""
+class HeaterShakerLabwareLatchStatus(str, Enum):
+    """Heater-shaker labware latch status"""
 
     OPENING = "OPENING"
     IDLE_OPEN = "IDLE_OPEN"

--- a/api/src/opentrons/drivers/utils.py
+++ b/api/src/opentrons/drivers/utils.py
@@ -8,7 +8,7 @@ from opentrons.drivers.types import (
     Temperature,
     PlateTemperature,
     RPM,
-    HeaterShakerPlateLockStatus,
+    HeaterShakerLabwareLatchStatus,
 )
 
 log = logging.getLogger(__name__)
@@ -95,14 +95,16 @@ def parse_rpm_response(rpm_string: str) -> RPM:
         )
 
 
-def parse_plate_lock_status_response(status_string: str) -> HeaterShakerPlateLockStatus:
+def parse_labware_latch_status_response(
+    status_string: str,
+) -> HeaterShakerLabwareLatchStatus:
     """Example format: STATUS:IDLE_OPEN"""
     status_vals = parse_key_values(status_string)
     try:
-        return HeaterShakerPlateLockStatus[status_vals["STATUS"]]
+        return HeaterShakerLabwareLatchStatus[status_vals["STATUS"]]
     except KeyError:
         raise ParseError(
-            error_message="Unexpected argument to parse_plate_lock_status_response",
+            error_message="Unexpected argument to parse_labware_latch_status_response",
             parse_source=status_string,
         )
 

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -10,7 +10,7 @@ from opentrons.hardware_control.modules import mod_abc, types, update
 from opentrons.drivers.heater_shaker.driver import HeaterShakerDriver
 from opentrons.drivers.heater_shaker.abstract import AbstractHeaterShakerDriver
 from opentrons.drivers.heater_shaker.simulator import SimulatingDriver
-from opentrons.drivers.types import Temperature, RPM, HeaterShakerPlateLockStatus
+from opentrons.drivers.types import Temperature, RPM, HeaterShakerLabwareLatchStatus
 
 log = logging.getLogger(__name__)
 
@@ -354,10 +354,10 @@ class HeaterShaker(mod_abc.AbstractModule):
             self.await_speed(speed), self.await_temperature(temperature)
         )
 
-    async def _wait_for_plate_lock(self, status: HeaterShakerPlateLockStatus):
-        current_status = await self._driver.get_plate_lock_status()
+    async def _wait_for_labware_latch(self, status: HeaterShakerLabwareLatchStatus):
+        current_status = await self._driver.get_labware_latch_status()
         while status != current_status:
-            current_status = await self._driver.get_plate_lock_status()
+            current_status = await self._driver.get_labware_latch_status()
 
     async def deactivate(self):
         """Stop heating/cooling; stop shaking and home the plate"""
@@ -365,15 +365,15 @@ class HeaterShaker(mod_abc.AbstractModule):
         await self._driver.set_temperature(0)
         await self._driver.home()
 
-    async def open_plate_lock(self):
+    async def open_labware_latch(self):
         await self.wait_for_is_running()
-        await self._driver.open_plate_lock()
-        await self._wait_for_plate_lock(HeaterShakerPlateLockStatus.IDLE_OPEN)
+        await self._driver.open_labware_latch()
+        await self._wait_for_labware_latch(HeaterShakerLabwareLatchStatus.IDLE_OPEN)
 
-    async def close_plate_lock(self):
+    async def close_labware_latch(self):
         await self.wait_for_is_running()
-        await self._driver.close_plate_lock()
-        await self._wait_for_plate_lock(HeaterShakerPlateLockStatus.IDLE_CLOSED)
+        await self._driver.close_labware_latch()
+        await self._wait_for_labware_latch(HeaterShakerLabwareLatchStatus.IDLE_CLOSED)
 
     async def prep_for_update(self) -> str:
         return "no"

--- a/api/tests/opentrons/drivers/heater_shaker/test_driver.py
+++ b/api/tests/opentrons/drivers/heater_shaker/test_driver.py
@@ -3,7 +3,7 @@ from mock import AsyncMock
 from opentrons.drivers.asyncio.communication.serial_connection import SerialConnection
 from opentrons.drivers.heater_shaker import driver
 from opentrons.drivers.command_builder import CommandBuilder
-from opentrons.drivers.types import Temperature, RPM, HeaterShakerPlateLockStatus
+from opentrons.drivers.types import Temperature, RPM, HeaterShakerLabwareLatchStatus
 
 
 @pytest.fixture
@@ -22,7 +22,7 @@ async def test_open_lock(
 ) -> None:
     """It should send an open plate lock command"""
     connection.send_command.return_value = "M242 ok\n"
-    await subject.open_plate_lock()
+    await subject.open_labware_latch()
     expected = CommandBuilder(terminator=driver.HS_COMMAND_TERMINATOR).add_gcode(
         gcode="M242"
     )
@@ -34,7 +34,7 @@ async def test_close_lock(
 ) -> None:
     """It should send a close plate lock command"""
     connection.send_command.return_value = "M243 ok\n"
-    await subject.close_plate_lock()
+    await subject.close_labware_latch()
     expected = CommandBuilder(terminator=driver.HS_COMMAND_TERMINATOR).add_gcode(
         gcode="M243"
     )
@@ -47,14 +47,14 @@ async def test_get_lock_status(
     """It should send a get plate lock status command and parse response."""
     connection.send_command.return_value = "M241 STATUS:IDLE_UNKNOWN ok\n"
 
-    response = await subject.get_plate_lock_status()
+    response = await subject.get_labware_latch_status()
 
     expected = CommandBuilder(terminator=driver.HS_COMMAND_TERMINATOR).add_gcode(
         gcode="M241"
     )
 
     connection.send_command.assert_called_once_with(command=expected, retries=0)
-    assert response == HeaterShakerPlateLockStatus.IDLE_UNKNOWN
+    assert response == HeaterShakerLabwareLatchStatus.IDLE_UNKNOWN
 
 
 async def test_set_temperature(

--- a/api/tests/opentrons/drivers/test_utils.py
+++ b/api/tests/opentrons/drivers/test_utils.py
@@ -5,7 +5,7 @@ from opentrons.drivers.types import (
     Temperature,
     PlateTemperature,
     RPM,
-    HeaterShakerPlateLockStatus,
+    HeaterShakerLabwareLatchStatus,
 )
 
 
@@ -162,15 +162,15 @@ def test_parse_rpm_response_failure(input_str: str) -> None:
 @pytest.mark.parametrize(
     argnames=["input_str", "expected_result"],
     argvalues=[
-        ["STATUS:IDLE_OPEN", HeaterShakerPlateLockStatus.IDLE_OPEN],
-        ["STATUS:IDLE_CLOSED", HeaterShakerPlateLockStatus.IDLE_CLOSED],
-        ["a:safa STATUS:IDLE_UNKNOWN", HeaterShakerPlateLockStatus.IDLE_UNKNOWN],
+        ["STATUS:IDLE_OPEN", HeaterShakerLabwareLatchStatus.IDLE_OPEN],
+        ["STATUS:IDLE_CLOSED", HeaterShakerLabwareLatchStatus.IDLE_CLOSED],
+        ["a:safa STATUS:IDLE_UNKNOWN", HeaterShakerLabwareLatchStatus.IDLE_UNKNOWN],
     ],
 )
-def test_parse_plate_lock_status_response_success(
-    input_str: str, expected_result: HeaterShakerPlateLockStatus
+def test_parse_labware_latch_status_response_success(
+    input_str: str, expected_result: HeaterShakerLabwareLatchStatus
 ):
-    assert utils.parse_plate_lock_status_response(input_str) == expected_result
+    assert utils.parse_labware_latch_status_response(input_str) == expected_result
 
 
 @pytest.mark.parametrize(
@@ -184,9 +184,9 @@ def test_parse_plate_lock_status_response_success(
         [":"],
     ],
 )
-def test_parse_plate_lock_status_response_failure(input_str):
+def test_parse_labware_latch_status_response_failure(input_str):
     with pytest.raises(utils.ParseError):
-        utils.parse_plate_lock_status_response(input_str)
+        utils.parse_labware_latch_status_response(input_str)
 
 
 @pytest.mark.parametrize(

--- a/api/tests/opentrons/hardware_control/modules/test_hc_heatershaker.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_heatershaker.py
@@ -1,7 +1,7 @@
 import pytest
 from opentrons.hardware_control import modules, ExecutionManager
 from opentrons.drivers.rpi_drivers.types import USBPort
-from opentrons.drivers.types import HeaterShakerPlateLockStatus
+from opentrons.drivers.types import HeaterShakerLabwareLatchStatus
 
 
 @pytest.fixture
@@ -101,14 +101,14 @@ async def test_await_both(simulating_module):
     assert simulating_module.speed_status == "holding at target"
 
 
-async def test_plate_lock(simulating_module):
-    await simulating_module.open_plate_lock()
+async def test_labware_latch(simulating_module):
+    await simulating_module.open_labware_latch()
     assert (
-        await simulating_module._driver.get_plate_lock_status()
-        == HeaterShakerPlateLockStatus.IDLE_OPEN
+        await simulating_module._driver.get_labware_latch_status()
+        == HeaterShakerLabwareLatchStatus.IDLE_OPEN
     )
-    await simulating_module.close_plate_lock()
+    await simulating_module.close_labware_latch()
     assert (
-        await simulating_module._driver.get_plate_lock_status()
-        == HeaterShakerPlateLockStatus.IDLE_CLOSED
+        await simulating_module._driver.get_labware_latch_status()
+        == HeaterShakerLabwareLatchStatus.IDLE_CLOSED
     )

--- a/g-code-testing/g_code_parsing/g_code.py
+++ b/g-code-testing/g_code_parsing/g_code.py
@@ -103,9 +103,9 @@ class GCode:
         HEATER_SHAKER_G_CODE.GET_TEMPERATURE.name: heater_shaker.GetTempGCodeFunctionalityDef,  # noqa: E501
         HEATER_SHAKER_G_CODE.HOME.name: heater_shaker.HomeGCodeFunctionalityDef,
         HEATER_SHAKER_G_CODE.GET_VERSION.name: heater_shaker.GetVersionGCodeFunctionalityDef,  # noqa: E501
-        HEATER_SHAKER_G_CODE.OPEN_PLATE_LOCK.name: heater_shaker.OpenPlateLockGCodeFunctionalityDef,  # noqa: E501
-        HEATER_SHAKER_G_CODE.CLOSE_PLATE_LOCK.name: heater_shaker.ClosePlateLockGCodeFunctionalityDef,  # noqa: E501
-        HEATER_SHAKER_G_CODE.GET_PLATE_LOCK_STATE.name: heater_shaker.GetPlateLockStateGCodeFunctionalityDef,  # noqa: E501
+        HEATER_SHAKER_G_CODE.OPEN_LABWARE_LATCH.name: heater_shaker.OpenLabwareLatchGCodeFunctionalityDef,  # noqa: E501
+        HEATER_SHAKER_G_CODE.CLOSE_LABWARE_LATCH.name: heater_shaker.CloseLabwareLatchGCodeFunctionalityDef,  # noqa: E501
+        HEATER_SHAKER_G_CODE.GET_LABWARE_LATCH_STATE.name: heater_shaker.GetLabwareLatchStateGCodeFunctionalityDef,  # noqa: E501
     }
 
     # Smoothie G-Code Parsing Characters

--- a/g-code-testing/g_code_parsing/g_code_functionality_defs/heater_shaker/__init__.py
+++ b/g-code-testing/g_code_parsing/g_code_functionality_defs/heater_shaker/__init__.py
@@ -1,23 +1,25 @@
-from .close_plate_lock_functionality_def import ClosePlateLockGCodeFunctionalityDef
-from .get_plate_lock_state_functionality_def import (
-    GetPlateLockStateGCodeFunctionalityDef,
+from .close_labware_latch_functionality_def import (
+    CloseLabwareLatchGCodeFunctionalityDef,
+)
+from .get_labware_latch_state_functionality_def import (
+    GetLabwareLatchStateGCodeFunctionalityDef,
 )
 from .get_rpm_functionality_def import GetRPMGCodeFunctionalityDef
 from .get_temperature_functionality_def import GetTempGCodeFunctionalityDef
 from .get_version_functionality_def import GetVersionGCodeFunctionalityDef
 from .home_functionality_def import HomeGCodeFunctionalityDef
-from .open_plate_lock_functionality_def import OpenPlateLockGCodeFunctionalityDef
+from .open_labware_latch_functionality_def import OpenLabwareLatchGCodeFunctionalityDef
 from .set_rpm_functionality_def import SetRPMGCodeFunctionalityDef
 from .set_temperature_functionality_def import SetTempGCodeFunctionalityDef
 
 __all__ = [
-    "ClosePlateLockGCodeFunctionalityDef",
-    "GetPlateLockStateGCodeFunctionalityDef",
+    "CloseLabwareLatchGCodeFunctionalityDef",
+    "GetLabwareLatchStateGCodeFunctionalityDef",
     "GetRPMGCodeFunctionalityDef",
     "GetTempGCodeFunctionalityDef",
     "GetVersionGCodeFunctionalityDef",
     "HomeGCodeFunctionalityDef",
-    "OpenPlateLockGCodeFunctionalityDef",
+    "OpenLabwareLatchGCodeFunctionalityDef",
     "SetRPMGCodeFunctionalityDef",
     "SetTempGCodeFunctionalityDef",
 ]

--- a/g-code-testing/g_code_parsing/g_code_functionality_defs/heater_shaker/close_labware_latch_functionality_def.py
+++ b/g-code-testing/g_code_parsing/g_code_functionality_defs/heater_shaker/close_labware_latch_functionality_def.py
@@ -4,7 +4,7 @@ from g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base impo
 )
 
 
-class OpenPlateLockGCodeFunctionalityDef(GCodeFunctionalityDefBase):
+class CloseLabwareLatchGCodeFunctionalityDef(GCodeFunctionalityDefBase):
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return "Opening heater-shaker plate lock"
+        return "Closing heater-shaker labware latch"

--- a/g-code-testing/g_code_parsing/g_code_functionality_defs/heater_shaker/get_labware_latch_state_functionality_def.py
+++ b/g-code-testing/g_code_parsing/g_code_functionality_defs/heater_shaker/get_labware_latch_state_functionality_def.py
@@ -5,12 +5,12 @@ from g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base impo
 )
 
 
-class GetPlateLockStateGCodeFunctionalityDef(GCodeFunctionalityDefBase):
+class GetLabwareLatchStateGCodeFunctionalityDef(GCodeFunctionalityDefBase):
     RESPONSE_RE = re.compile(r"M241 STATE:([A-Z_]*)")
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return "Getting heater-shaker plate lock state"
+        return "Getting heater-shaker labware latch state"
 
     @classmethod
     def _generate_response_explanation(cls, response: str) -> str:
@@ -18,6 +18,6 @@ class GetPlateLockStateGCodeFunctionalityDef(GCodeFunctionalityDefBase):
         message = ""
 
         if match is not None:
-            message = f"Plate Lock State: {match.group(1)}"
+            message = f"Labware Latch State: {match.group(1)}"
 
         return message

--- a/g-code-testing/g_code_parsing/g_code_functionality_defs/heater_shaker/open_labware_latch_functionality_def.py
+++ b/g-code-testing/g_code_parsing/g_code_functionality_defs/heater_shaker/open_labware_latch_functionality_def.py
@@ -4,7 +4,7 @@ from g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base impo
 )
 
 
-class ClosePlateLockGCodeFunctionalityDef(GCodeFunctionalityDefBase):
+class OpenLabwareLatchGCodeFunctionalityDef(GCodeFunctionalityDefBase):
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return "Closing heater-shaker plate lock"
+        return "Opening heater-shaker labware latch"

--- a/g-code-testing/tests/g_code_parsing/test_g_code.py
+++ b/g-code-testing/tests/g_code_parsing/test_g_code.py
@@ -291,19 +291,19 @@ def heater_shaker_g_codes() -> List[GCode]:
             "M115 FW:v0.1.0-12-gba8ae71-ba8ae71 HW:Opentrons Heater-Shaker "
             "SerialNo:EMPTYSN OK",
         ],
-        # Test 81 - Open Plate Lock
+        # Test 81 - Open Labware Latch
         ["M242", "M242 OK"],
-        # Test 82 - Close Plate Lock
+        # Test 82 - Close Labware Latch
         ["M243", "M243 OK"],
-        # Test 83 - Get Plate Lock State (Opening)
+        # Test 83 - Get Labware Latch State (Opening)
         ["M241", "M241 STATE:OPENING OK"],
-        # Test 84 - Get Plate Lock State (Closing)
+        # Test 84 - Get Labware Latch State (Closing)
         ["M241", "M241 STATE:CLOSING OK"],
-        # Test 85 - Get Plate Lock State (Unknown)
+        # Test 85 - Get Labware Latch State (Unknown)
         ["M241", "M241 STATE:IDLE_UNKNOWN OK"],
-        # Test 86 - Get Plate Lock State (Open)
+        # Test 86 - Get Labware Latch State (Open)
         ["M241", "M241 STATE:IDLE_OPEN OK"],
-        # Test 87 - Get Plate Lock State (Closed)
+        # Test 87 - Get Labware Latch State (Closed)
         ["M241", "M241 STATE:IDLE_CLOSED OK"],
     ]
     g_code_list = [
@@ -420,13 +420,13 @@ def expected_function_name_values() -> List[str]:
         "GET_TEMPERATURE",  # Test 78 - Get Temperature
         "HOME",  # Test 79 - Home
         "GET_VERSION",  # Test 80 - Get Version
-        "OPEN_PLATE_LOCK",  # Test 81 - Open Plate Lock
-        "CLOSE_PLATE_LOCK",  # Test 82 - Close Plate Lock
-        "GET_PLATE_LOCK_STATE",  # Test 83 - Get Plate Lock State (Opening)
-        "GET_PLATE_LOCK_STATE",  # Test 84 - Get Plate Lock State (Closing)
-        "GET_PLATE_LOCK_STATE",  # Test 85 - Get Plate Lock State (Unknown)
-        "GET_PLATE_LOCK_STATE",  # Test 86 - Get Plate Lock State (Open)
-        "GET_PLATE_LOCK_STATE",  # Test 87 - Get Plate Lock State (Closed)
+        "OPEN_LABWARE_LATCH",  # Test 81 - Open Labware Latch
+        "CLOSE_LABWARE_LATCH",  # Test 82 - Close Labware Latch
+        "GET_LABWARE_LATCH_STATE",  # Test 83 - Get Labware Latch State (Opening)
+        "GET_LABWARE_LATCH_STATE",  # Test 84 - Get Labware Latch State (Closing)
+        "GET_LABWARE_LATCH_STATE",  # Test 85 - Get Labware Latch State (Unknown)
+        "GET_LABWARE_LATCH_STATE",  # Test 86 - Get Labware Latch State (Open)
+        "GET_LABWARE_LATCH_STATE",  # Test 87 - Get Labware Latch State (Closed)
     ]
 
 
@@ -610,19 +610,19 @@ def expected_arg_values() -> List[Dict[str, Union[int, float, str, None]]]:
         {},
         # Test 80 - Get Version
         {},
-        # Test 81 - Open Plate Lock
+        # Test 81 - Open Labware Latch
         {},
-        # Test 82 - Close Plate Lock
+        # Test 82 - Close Labware Latch
         {},
-        # Test 83 - Get Plate Lock State (Opening)
+        # Test 83 - Get Labware Latch State (Opening)
         {},
-        # Test 84 - Get Plate Lock State (Closing)
+        # Test 84 - Get Labware Latch State (Closing)
         {},
-        # Test 85 - Get Plate Lock State (Unknown)
+        # Test 85 - Get Labware Latch State (Unknown)
         {},
-        # Test 86 - Get Plate Lock State (Open)
+        # Test 86 - Get Labware Latch State (Open)
         {},
-        # Test 87 - Get Plate Lock State (Closed)
+        # Test 87 - Get Labware Latch State (Closed)
         {},
     ]
 
@@ -1396,58 +1396,58 @@ def explanations() -> List[Explanation]:
         # Test 81
         Explanation(
             code="M242",
-            command_name="OPEN_PLATE_LOCK",
+            command_name="OPEN_LABWARE_LATCH",
             response="",
             provided_args={},
-            command_explanation="Opening heater-shaker plate lock",
+            command_explanation="Opening heater-shaker labware latch",
         ),
         # Test 82
         Explanation(
             code="M243",
-            command_name="CLOSE_PLATE_LOCK",
+            command_name="CLOSE_LABWARE_LATCH",
             response="",
             provided_args={},
-            command_explanation="Closing heater-shaker plate lock",
+            command_explanation="Closing heater-shaker labware latch",
         ),
         # Test 83
         Explanation(
             code="M241",
-            command_name="GET_PLATE_LOCK_STATE",
-            response="Plate Lock State: OPENING",
+            command_name="GET_LABWARE_LATCH_STATE",
+            response="Labware Latch State: OPENING",
             provided_args={},
-            command_explanation="Getting heater-shaker plate lock state",
+            command_explanation="Getting heater-shaker labware latch state",
         ),
         # Test 84
         Explanation(
             code="M241",
-            command_name="GET_PLATE_LOCK_STATE",
-            response="Plate Lock State: CLOSING",
+            command_name="GET_LABWARE_LATCH_STATE",
+            response="Labware Latch State: CLOSING",
             provided_args={},
-            command_explanation="Getting heater-shaker plate lock state",
+            command_explanation="Getting heater-shaker labware latch state",
         ),
         # Test 85
         Explanation(
             code="M241",
-            command_name="GET_PLATE_LOCK_STATE",
-            response="Plate Lock State: IDLE_UNKNOWN",
+            command_name="GET_LABWARE_LATCH_STATE",
+            response="Labware Latch State: IDLE_UNKNOWN",
             provided_args={},
-            command_explanation="Getting heater-shaker plate lock state",
+            command_explanation="Getting heater-shaker labware latch state",
         ),
         # Test 86
         Explanation(
             code="M241",
-            command_name="GET_PLATE_LOCK_STATE",
-            response="Plate Lock State: IDLE_OPEN",
+            command_name="GET_LABWARE_LATCH_STATE",
+            response="Labware Latch State: IDLE_OPEN",
             provided_args={},
-            command_explanation="Getting heater-shaker plate lock state",
+            command_explanation="Getting heater-shaker labware latch state",
         ),
         # Test 87
         Explanation(
             code="M241",
-            command_name="GET_PLATE_LOCK_STATE",
-            response="Plate Lock State: IDLE_CLOSED",
+            command_name="GET_LABWARE_LATCH_STATE",
+            response="Labware Latch State: IDLE_CLOSED",
             provided_args={},
-            command_explanation="Getting heater-shaker plate lock state",
+            command_explanation="Getting heater-shaker labware latch state",
         ),
     ]
 


### PR DESCRIPTION
# Overview

The 'plate lock' in the api refers to the latch that locks the labware onto the heater shaker plate. To not confuse this lock with the plate homing solenoid lock, this PR renames references of 'plate lock' to 'labware latch' in the api and g-code-testing directories. 

# Review requests

- Spoke to @pmoegenburg to make sure the wording change isn't a bad idea. Still, let me know if I should take a different approach with this. 
- Make sure I haven't missed any instances.
- I think we'll need to make similar changes in firmware to be consistent?

# Risk assessment

None if all tests pass. Just a refactor.
