### PR TITLE
feat(components): Add design system constants to components library

### DIFF
--- a/app/src/atoms/text/StyledText.tsx
+++ b/app/src/atoms/text/StyledText.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react'
+import { Text, TYPOGRAPHY } from '@opentrons/components'
+
+export interface Props extends React.ComponentProps<typeof Text> {
+  children: React.ReactNode
+}
+
+// stylemap defaults to regular style, pass in fontWeight={variable} to override
+const styleMap = {
+  h1: TYPOGRAPHY.h1Default,
+  h2: TYPOGRAPHY.h2Regular,
+  h3: TYPOGRAPHY.h3Regular,
+  h6: TYPOGRAPHY.h6Default,
+  p: TYPOGRAPHY.pRegular,
+  label: TYPOGRAPHY.labelRegular,
+}
+
+export function StyledText(props: Props): JSX.Element {
+  // @ts-expect-error: props.as is coming in as a string but TS is expecting type any
+  const css = props.as ? styleMap[props.as] : null
+  return (
+    <Text css={css} {...props}>
+      {props.children}
+    </Text>
+  )
+}

--- a/app/src/atoms/text/index.ts
+++ b/app/src/atoms/text/index.ts
@@ -1,0 +1,1 @@
+export * from './StyledText'

--- a/components/src/index.ts
+++ b/components/src/index.ts
@@ -25,6 +25,8 @@ export * from './tooltips'
 
 // styles
 export * from './styles'
+// new ui-overhaul style vars
+export * from './ui-style-constants'
 
 // Pure Types
 export * from './robot-types'

--- a/components/src/ui-style-constants/colors.ts
+++ b/components/src/ui-style-constants/colors.ts
@@ -17,7 +17,7 @@ export const darkBlackPressed = '#16212D'
 // note: darkBlackDisabled = greyDisabled
 
 export const darkGrey = '#8a8c8e'
-export const darkGeyHover = '#787a7d'
+export const darkGreyHover = '#787a7d'
 export const darkGreyPressed = '#646668'
 // note: darkGreyDisabled = greyDisabled
 

--- a/components/src/ui-style-constants/colors.ts
+++ b/components/src/ui-style-constants/colors.ts
@@ -1,0 +1,43 @@
+// colors fundamentals
+export const background = '#f8f8f8'
+export const white = '#ffffff'
+export const lightBlue = '#f1f8ff'
+export const medGrey = '#e3e3e3'
+
+// colors with states
+export const blueFocus = '#deecff'
+export const blue = '#006fff'
+export const blueHover = '#0061e0'
+export const bluePressed = '#0050b8'
+export const disabled = '#a0a0a0'
+
+export const darkBlack = '#16212D'
+export const darkBlackHover = '#283d52'
+export const darkBlackPressed = '#16212D'
+// note: darkBlackDisabled = greyDisabled
+
+export const darkGrey = '#8a8c8e'
+export const darkGeyHover = '#787a7d'
+export const darkGreyPressed = '#646668'
+// note: darkGreyDisabled = greyDisabled
+
+export const greyHover = '#acacaf'
+export const greyPressed = '#8d8d91'
+export const greyDisabled = '#eaeaeb'
+
+export const yellow = '#f2b53c'
+export const yellowHover = '#eca20f'
+export const yellowPressed = '#eca20f'
+
+export const error = '#bf0000'
+export const errorHover = '#a30000'
+export const errorText = '#850000'
+export const errorBg = '#fff3f3'
+
+export const success = '#04aa65'
+export const successText = '#00854d'
+export const successBg = '#f3fffa'
+
+export const warning = '#f09d20'
+export const warningText = '#7b5b09'
+export const warningBg = '#fffcf5'

--- a/components/src/ui-style-constants/index.ts
+++ b/components/src/ui-style-constants/index.ts
@@ -1,0 +1,3 @@
+export * as COLORS from './colors'
+export * as SPACING from './spacing'
+export * as TYPOGRAPHY from './typography'

--- a/components/src/ui-style-constants/spacing.ts
+++ b/components/src/ui-style-constants/spacing.ts
@@ -1,0 +1,7 @@
+// spacing vars NOTE: this is still flagged to be revisited in Figma
+export const spacing1 = '0.125rem' // 2px
+export const spacing2 = '0.25rem' // 4px
+export const spacing3 = '0.5rem' // 8px
+export const spacing4 = '1rem' // 16px
+export const spacing5 = '1.5rem' // 24px
+export const spacing6 = '2rem' // 32px

--- a/components/src/ui-style-constants/typography.ts
+++ b/components/src/ui-style-constants/typography.ts
@@ -1,0 +1,99 @@
+import { css } from 'styled-components'
+// import type { FlattenSimpleInterpolation } from 'styled-components'
+
+// Font Sizes
+export const fontSizeH1 = '1.125rem' // 18px
+export const fontSizeH2 = '0.9375rem' // 15px
+export const fontSizeH3 = '0.875rem' // 14px
+export const fontSizeH6 = '0.625' // 10px
+export const fontSizeP = '0.6875' // 11px
+export const fontSizeLabel = '0.75rem' // 12px
+// this is redundant but we need this for captions and it makes more sense to call it caption rather than re-using fsh6
+export const fontSizeCaption = '0.625' // 10px
+
+// Font Weights
+export const fontWeightBold = 800
+export const fontWeightSemiBold = 600
+export const fontWeightRegular = 400
+export const fontWeightLight = 300
+
+// Line Heights
+export const lineHeight24 = '1.5rem' // 24px
+export const lineHeight20 = '1.25rem' // 20px
+export const lineHeight16 = '1rem' // 16px
+export const lineHeight12 = '.75rem' // 12px
+
+// font styles
+export const fontStyleNormal = 'normal'
+export const fontStyleItalic = 'italic'
+
+// text transforms
+export const textTransformNone = 'none'
+export const textTransformCapitalize = 'capitalize'
+export const textTransformUppercase = 'uppercase'
+export const textTransformLowercase = 'lowercase'
+
+export const textAlignLeft = 'left'
+export const textAlignRight = 'right'
+export const textAlignCenter = 'center'
+export const textAlignJustify = 'justify'
+
+// Default font styles, color agnositic for first pass
+export const h1Default = css`
+  font-size: ${fontSizeH1};
+  font-weight: ${fontWeightSemiBold};
+  line-height: ${lineHeight24};
+`
+
+export const h2Regular = css`
+  font-size: ${fontSizeH2};
+  font-weight: ${fontWeightRegular};
+  line-height: ${lineHeight20};
+`
+
+export const h2SemiBold = css`
+  font-size: ${fontSizeH2};
+  font-weight: ${fontWeightSemiBold};
+  line-height: ${lineHeight20};
+`
+export const h3Regular = css`
+  font-size: ${fontSizeH3};
+  font-weight: ${fontWeightRegular};
+  line-height: ${lineHeight20};
+`
+
+export const h3SemiBold = css`
+  font-size: ${fontSizeH3};
+  font-weight: ${fontWeightSemiBold};
+  line-height: ${lineHeight20};
+`
+
+export const h6Default = css`
+  font-size: ${fontSizeH6};
+  font-weight: ${fontWeightRegular};
+  line-height: ${lineHeight12};
+`
+
+export const pRegular = css`
+  font-size: ${fontSizeP};
+  font-weight: ${fontWeightRegular};
+  line-height: ${lineHeight12};
+`
+
+export const pSemiBold = css`
+  font-size: ${fontSizeP};
+  font-weight: ${fontWeightSemiBold};
+  line-height: ${lineHeight12};
+`
+
+export const labelRegular = css`
+  font-size: ${fontSizeLabel};
+  font-weight: ${fontWeightRegular};
+  line-height: ${lineHeight12};
+`
+
+export const labelSemiBold = css`
+  font-size: ${fontSizeLabel};
+  font-weight: ${fontWeightSemiBold};
+  line-height: ${lineHeight12};
+`


### PR DESCRIPTION
# Overview

closes #9389 by adding color, spacing, and typography constants to components library under `/ui-style-constants`. it also ads a `StyledText` component to `/atoms` in the app that will default styles based on the tag passed in by `as` prop.

# Changelog

-feat(components): Add design system constants to components library
- bonus(app): Add StyledText component to atoms

# Review requests
You can now import these variables like so
`import { COLORS } from '@opentrons/components'`
and use them like we would the old ones but with a slightly different approach
`<Text color={COLORS.success}> Foo </Text>`

I also lumped some more super constants together for fonts so we don't repeat the same 4 or 5 constants every time we use `Text`. On top of that we can just use the new StyledText moving forward to get the default styles by tag type.

- [ ] naming conventions seem sane?
- [ ] StyledText component seems reasonable?

PS let me know if theres any documentation you think we might need beyond my comments

# Risk assessment

low unused constants for now.
