### PR TITLE
fix(robot-server): add current command metadata to /commands response

### DIFF
--- a/api-client/src/runs/commands/types.ts
+++ b/api-client/src/runs/commands/types.ts
@@ -30,7 +30,6 @@ export interface CommandsLinks {
       runId: string
       commandId: string
       index: number
-      key: string
     }
   }
 }

--- a/api-client/src/runs/commands/types.ts
+++ b/api-client/src/runs/commands/types.ts
@@ -30,6 +30,7 @@ export interface CommandsLinks {
       runId: string
       commandId: string
       index: number
+      key: string
     }
   }
 }

--- a/api/src/opentrons/protocol_engine/__init__.py
+++ b/api/src/opentrons/protocol_engine/__init__.py
@@ -9,7 +9,7 @@ from .create_protocol_engine import create_protocol_engine
 from .protocol_engine import ProtocolEngine
 from .errors import ProtocolEngineError, ErrorOccurrence
 from .commands import Command, CommandParams, CommandCreate, CommandStatus, CommandType
-from .state import State, StateView, CommandSlice
+from .state import State, StateView, CommandSlice, CurrentCommand
 from .plugins import AbstractPlugin
 
 from .types import (
@@ -49,6 +49,7 @@ __all__ = [
     "State",
     "StateView",
     "CommandSlice",
+    "CurrentCommand",
     # public value interfaces and models
     "LabwareOffset",
     "LabwareOffsetCreate",

--- a/api/src/opentrons/protocol_engine/state/__init__.py
+++ b/api/src/opentrons/protocol_engine/state/__init__.py
@@ -1,7 +1,7 @@
 """Protocol engine state module."""
 
 from .state import State, StateStore, StateView
-from .commands import CommandState, CommandView, CommandSlice
+from .commands import CommandState, CommandView, CommandSlice, CurrentCommand
 from .labware import LabwareState, LabwareView
 from .pipettes import PipetteState, PipetteView, HardwarePipette, CurrentWell
 from .modules import ModuleState, ModuleView, HardwareModule
@@ -18,6 +18,7 @@ __all__ = [
     "CommandState",
     "CommandView",
     "CommandSlice",
+    "CurrentCommand",
     # labware state and values
     "LabwareState",
     "LabwareView",

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -64,7 +64,6 @@ class CommandSlice:
 
     commands: List[Command]
     cursor: int
-    length: int
     total_length: int
 
 
@@ -330,14 +329,12 @@ class CommandView(HasState[CommandState]):
         # start is inclusive, stop is exclusive
         actual_cursor = max(0, min(cursor, total_length - 1))
         stop = min(total_length, actual_cursor + length)
-        actual_length = stop - actual_cursor
         command_ids = all_command_ids[actual_cursor:stop]
         commands = [commands_by_id[cid].command for cid in command_ids]
 
         return CommandSlice(
             commands=commands,
             cursor=actual_cursor,
-            length=actual_length,
             total_length=total_length,
         )
 

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections import OrderedDict
 from enum import Enum
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Dict, List, Mapping, Optional
 from typing_extensions import Literal
 
@@ -73,6 +74,7 @@ class CurrentCommand:
 
     command_id: str
     command_key: str
+    created_at: datetime
     index: int
 
 
@@ -354,6 +356,7 @@ class CommandView(HasState[CommandState]):
             return CurrentCommand(
                 command_id=entry.command.id,
                 command_key=entry.command.key,
+                created_at=entry.command.createdAt,
                 index=entry.index,
             )
 
@@ -365,6 +368,7 @@ class CommandView(HasState[CommandState]):
                 return CurrentCommand(
                     command_id=entry.command.id,
                     command_key=entry.command.key,
+                    created_at=entry.command.createdAt,
                     index=len(self._state.all_command_ids) - reverse_index - 1,
                 )
 

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -72,6 +72,7 @@ class CurrentCommand:
     """The "current" command's ID and index in the overall commands list."""
 
     command_id: str
+    command_key: str
     index: int
 
 
@@ -350,14 +351,20 @@ class CommandView(HasState[CommandState]):
         """
         if self._state.running_command_id:
             entry = self._state.commands_by_id[self._state.running_command_id]
-            return CurrentCommand(command_id=entry.command.id, index=entry.index)
+            return CurrentCommand(
+                command_id=entry.command.id,
+                command_key=entry.command.key,
+                index=entry.index,
+            )
 
         # TODO(mc, 2022-02-07): this is O(n) in the worst case for no good reason.
         # Resolve prior to JSONv6 support, where this will matter.
         for reverse_index, cid in enumerate(reversed(self._state.all_command_ids)):
             if self.get_is_complete(cid):
+                entry = self._state.commands_by_id[cid]
                 return CurrentCommand(
-                    command_id=cid,
+                    command_id=entry.command.id,
+                    command_key=entry.command.key,
                     index=len(self._state.all_command_ids) - reverse_index - 1,
                 )
 

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -1,6 +1,5 @@
 """Protocol engine commands sub-state."""
 from __future__ import annotations
-import itertools
 from collections import OrderedDict
 from enum import Enum
 from dataclasses import dataclass
@@ -69,6 +68,22 @@ class CommandSlice:
     total_length: int
 
 
+@dataclass(frozen=True)
+class CurrentCommand:
+    """The "current" command's ID and index in the overall commands list."""
+
+    command_id: str
+    index: int
+
+
+@dataclass(frozen=True)
+class CommandEntry:
+    """An command entry in state, including its index in the list."""
+
+    command: Command
+    index: int
+
+
 @dataclass
 class CommandState:
     """State of all protocol engine command resources.
@@ -96,8 +111,9 @@ class CommandState:
     is_door_blocking: bool
     run_result: Optional[RunResult]
     running_command_id: Optional[str]
+    all_command_ids: List[str]
     queued_command_ids: OrderedDict[str, Literal[True]]
-    commands_by_id: OrderedDict[str, Command]
+    commands_by_id: Dict[str, CommandEntry]
     errors_by_id: Dict[str, ErrorOccurrence]
 
 
@@ -114,6 +130,7 @@ class CommandStore(HasState[CommandState], HandlesActions):
             is_door_blocking=is_door_blocking,
             run_result=None,
             running_command_id=None,
+            all_command_ids=[],
             queued_command_ids=OrderedDict(),
             commands_by_id=OrderedDict(),
             errors_by_id={},
@@ -124,6 +141,8 @@ class CommandStore(HasState[CommandState], HandlesActions):
         errors_by_id: Mapping[str, ErrorOccurrence]
 
         if isinstance(action, QueueCommandAction):
+            assert action.command_id not in self._state.commands_by_id
+
             # TODO(mc, 2021-06-22): mypy has trouble with this automatic
             # request > command mapping, figure out how to type precisely
             # (or wait for a future mypy version that can figure it out).
@@ -136,16 +155,34 @@ class CommandStore(HasState[CommandState], HandlesActions):
                 status=CommandStatus.QUEUED,
             )
 
-            self._state.commands_by_id[queued_command.id] = queued_command
+            next_index = len(self._state.all_command_ids)
+            self._state.all_command_ids.append(action.command_id)
             self._state.queued_command_ids[queued_command.id] = True
+            self._state.commands_by_id[queued_command.id] = CommandEntry(
+                index=next_index,
+                command=queued_command,
+            )
 
         # TODO(mc, 2021-12-28): replace "UpdateCommandAction" with explicit
         # state change actions (e.g. RunCommandAction, SucceedCommandAction)
         # to make a command's queue transition logic easier to follow
         elif isinstance(action, UpdateCommandAction):
             command = action.command
+            prev_entry = self._state.commands_by_id.get(command.id)
 
-            self._state.commands_by_id[command.id] = command
+            if prev_entry is None:
+                index = len(self._state.all_command_ids)
+                self._state.all_command_ids.append(command.id)
+                self._state.commands_by_id[command.id] = CommandEntry(
+                    index=index,
+                    command=command,
+                )
+            else:
+                self._state.commands_by_id[command.id] = CommandEntry(
+                    index=prev_entry.index,
+                    command=command,
+                )
+
             self._state.queued_command_ids.pop(command.id, None)
 
             if command.status == CommandStatus.RUNNING:
@@ -167,13 +204,17 @@ class CommandStore(HasState[CommandState], HandlesActions):
             ]
 
             for command_id in command_ids_to_fail:
-                prev_command = self._state.commands_by_id[command_id]
-                self._state.commands_by_id[command_id] = prev_command.copy(
-                    update={
-                        "errorId": action.error_id,
-                        "completedAt": action.failed_at,
-                        "status": CommandStatus.FAILED,
-                    }
+                prev_entry = self._state.commands_by_id[command_id]
+
+                self._state.commands_by_id[command_id] = CommandEntry(
+                    index=prev_entry.index,
+                    command=prev_entry.command.copy(
+                        update={
+                            "errorId": action.error_id,
+                            "completedAt": action.failed_at,
+                            "status": CommandStatus.FAILED,
+                        }
+                    ),
                 )
 
             if self._state.running_command_id == action.command_id:
@@ -251,7 +292,7 @@ class CommandView(HasState[CommandState]):
     def get(self, command_id: str) -> Command:
         """Get a command by its unique identifier."""
         try:
-            return self._state.commands_by_id[command_id]
+            return self._state.commands_by_id[command_id].command
         except KeyError:
             raise CommandDoesNotExistError(f"Command {command_id} does not exist")
 
@@ -262,40 +303,36 @@ class CommandView(HasState[CommandState]):
         Replacing a command (to change its status, for example) keeps its place in the
         ordering.
         """
-        return list(self._state.commands_by_id.values())
+        return [
+            self._state.commands_by_id[cid].command
+            for cid in self._state.all_command_ids
+        ]
 
     def get_slice(
         self,
         cursor: Optional[int],
         length: int,
     ) -> CommandSlice:
-        """Get a subset of commands around a given cursor."""
+        """Get a subset of commands around a given cursor.
+
+        If the cursor is omitted, return the tail of `length` of the collection.
+        """
         # TODO(mc, 2022-01-31): this is not the most performant way to implement
         # this; if this becomes a problem, change or the underlying data structure
         # to something that isn't just an OrderedDict
+        all_command_ids = self._state.all_command_ids
         commands_by_id = self._state.commands_by_id
-        total_length = len(commands_by_id)
+        total_length = len(all_command_ids)
 
         if cursor is None:
-            current_id = self.get_current()
-
-            if current_id is not None:
-                # TODO(mc, 2022-01-31): this risks becoming a performance bottleneck
-                # when runnning JSONv6 protocols and will require data structure
-                # changes (see TODO above). `reversed` will usually prevent O(n)
-                # worst-case in practice for Python + PAPIv2 protocols
-                for index, command_id in enumerate(reversed(commands_by_id.keys())):
-                    if command_id == current_id:
-                        cursor = total_length - index - 1
-
-            if cursor is None:
-                cursor = total_length - length
+            cursor = total_length - length
 
         # start is inclusive, stop is exclusive
         actual_cursor = max(0, min(cursor, total_length - 1))
         stop = min(total_length, actual_cursor + length)
         actual_length = stop - actual_cursor
-        commands = list(itertools.islice(commands_by_id.values(), actual_cursor, stop))
+        command_ids = all_command_ids[actual_cursor:stop]
+        commands = [commands_by_id[cid].command for cid in command_ids]
 
         return CommandSlice(
             commands=commands,
@@ -308,12 +345,26 @@ class CommandView(HasState[CommandState]):
         """Get a list of all errors that have occurred."""
         return list(self._state.errors_by_id.values())
 
-    def get_current(self) -> Optional[str]:
-        """Return the command that is currently running, if any."""
-        if self._state.running_command_id:
-            return self._state.running_command_id
+    def get_current(self) -> Optional[CurrentCommand]:
+        """Return the "current" command, if any.
 
-        return next(iter(self._state.queued_command_ids.keys()), None)
+        The "current" command is the command that is currently executing,
+        or the most recent command to have completed.
+        """
+        if self._state.running_command_id:
+            entry = self._state.commands_by_id[self._state.running_command_id]
+            return CurrentCommand(command_id=entry.command.id, index=entry.index)
+
+        # TODO(mc, 2022-02-07): this is O(n) in the worst case for no good reason.
+        # Resolve prior to JSONv6 support, where this will matter.
+        for reverse_index, cid in enumerate(reversed(self._state.all_command_ids)):
+            if self.get_is_complete(cid):
+                return CurrentCommand(
+                    command_id=cid,
+                    index=len(self._state.all_command_ids) - reverse_index - 1,
+                )
+
+        return None
 
     def get_next_queued(self) -> Optional[str]:
         """Return the next command in line to be executed.

--- a/api/tests/opentrons/protocol_engine/state/command_fixtures.py
+++ b/api/tests/opentrons/protocol_engine/state/command_fixtures.py
@@ -37,6 +37,7 @@ def create_running_command(
     command_id: str = "command-id",
     command_key: str = "command-key",
     command_type: str = "command-type",
+    created_at: datetime = datetime(year=2021, month=1, day=1),
     params: Optional[BaseModel] = None,
 ) -> cmd.Command:
     """Given command data, build a running command model."""
@@ -45,7 +46,7 @@ def create_running_command(
         cmd.BaseCommand(
             id=command_id,
             key=command_key,
-            createdAt=datetime(year=2021, month=1, day=1),
+            createdAt=created_at,
             commandType=command_type,
             status=cmd.CommandStatus.RUNNING,
             params=params or BaseModel(),
@@ -82,6 +83,7 @@ def create_succeeded_command(
     command_id: str = "command-id",
     command_key: str = "command-key",
     command_type: str = "command-type",
+    created_at: datetime = datetime(year=2021, month=1, day=1),
     params: Optional[BaseModel] = None,
     result: Optional[BaseModel] = None,
 ) -> cmd.Command:
@@ -91,7 +93,7 @@ def create_succeeded_command(
         cmd.BaseCommand(
             id=command_id,
             key=command_key,
-            createdAt=datetime(year=2021, month=1, day=1),
+            createdAt=created_at,
             commandType=command_type,
             status=cmd.CommandStatus.SUCCEEDED,
             params=params or BaseModel(),

--- a/api/tests/opentrons/protocol_engine/state/test_command_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view.py
@@ -503,15 +503,9 @@ def test_get_current() -> None:
 def test_get_slice_empty() -> None:
     """It should return a slice from the tail if no current command."""
     subject = get_command_view(commands=[])
-
     result = subject.get_slice(cursor=None, length=2)
 
-    assert result == CommandSlice(
-        commands=[],
-        cursor=0,
-        length=0,
-        total_length=0,
-    )
+    assert result == CommandSlice(commands=[], cursor=0, total_length=0)
 
 
 def test_get_slice() -> None:
@@ -528,7 +522,6 @@ def test_get_slice() -> None:
     assert result == CommandSlice(
         commands=[command_2, command_3, command_4],
         cursor=1,
-        length=3,
         total_length=4,
     )
 
@@ -537,7 +530,6 @@ def test_get_slice() -> None:
     assert result == CommandSlice(
         commands=[command_1, command_2, command_3, command_4],
         cursor=0,
-        length=4,
         total_length=4,
     )
 
@@ -558,7 +550,6 @@ def test_get_slice_default_cursor() -> None:
     assert result == CommandSlice(
         commands=[command_3, command_4],
         cursor=2,
-        length=2,
         total_length=4,
     )
 
@@ -577,6 +568,5 @@ def test_get_slice_default_cursor_no_current() -> None:
     assert result == CommandSlice(
         commands=[command_2, command_3, command_4],
         cursor=1,
-        length=3,
         total_length=4,
     )

--- a/api/tests/opentrons/protocol_engine/state/test_command_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view.py
@@ -481,23 +481,35 @@ def test_get_current() -> None:
     )
     assert subject.get_current() is None
 
-    command = create_running_command("command-id")
+    command = create_running_command("command-id", command_key="command-key")
     subject = get_command_view(
         running_command_id="command-id",
         queued_command_ids=[],
         commands=[command],
     )
-    assert subject.get_current() == CurrentCommand(index=0, command_id="command-id")
+    assert subject.get_current() == CurrentCommand(
+        index=0,
+        command_id="command-id",
+        command_key="command-key",
+    )
 
-    command_1 = create_succeeded_command("command-id-1")
-    command_2 = create_succeeded_command("command-id-2")
+    command_1 = create_succeeded_command("command-id-1", command_key="key-1")
+    command_2 = create_succeeded_command("command-id-2", command_key="key-2")
     subject = get_command_view(commands=[command_1, command_2])
-    assert subject.get_current() == CurrentCommand(index=1, command_id="command-id-2")
+    assert subject.get_current() == CurrentCommand(
+        index=1,
+        command_id="command-id-2",
+        command_key="key-2",
+    )
 
-    command_1 = create_succeeded_command("command-id-1")
-    command_2 = create_failed_command("command-id-2")
+    command_1 = create_succeeded_command("command-id-1", command_key="key-1")
+    command_2 = create_failed_command("command-id-2", command_key="key-2")
     subject = get_command_view(commands=[command_1, command_2])
-    assert subject.get_current() == CurrentCommand(index=1, command_id="command-id-2")
+    assert subject.get_current() == CurrentCommand(
+        index=1,
+        command_id="command-id-2",
+        command_key="key-2",
+    )
 
 
 def test_get_slice_empty() -> None:

--- a/api/tests/opentrons/protocol_engine/state/test_command_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view.py
@@ -3,7 +3,7 @@ import pytest
 from collections import OrderedDict
 from contextlib import nullcontext as does_not_raise
 from datetime import datetime
-from typing import Dict, List, NamedTuple, Optional, Sequence, Tuple, Type
+from typing import Dict, List, NamedTuple, Optional, Sequence, Type
 
 from opentrons.protocol_engine import EngineStatus, commands as cmd, errors
 
@@ -11,6 +11,8 @@ from opentrons.protocol_engine.state.commands import (
     CommandState,
     CommandView,
     CommandSlice,
+    CommandEntry,
+    CurrentCommand,
     RunResult,
     QueueStatus,
 )
@@ -30,10 +32,16 @@ def get_command_view(
     run_result: Optional[RunResult] = None,
     running_command_id: Optional[str] = None,
     queued_command_ids: Sequence[str] = (),
-    commands_by_id: Sequence[Tuple[str, cmd.Command]] = (),
     errors_by_id: Optional[Dict[str, errors.ErrorOccurrence]] = None,
+    commands: Sequence[cmd.Command] = (),
 ) -> CommandView:
     """Get a command view test subject."""
+    all_command_ids = [command.id for command in commands]
+    commands_by_id = {
+        command.id: CommandEntry(index=index, command=command)
+        for index, command in enumerate(commands)
+    }
+
     state = CommandState(
         queue_status=queue_status,
         is_hardware_stopped=is_hardware_stopped,
@@ -41,8 +49,9 @@ def get_command_view(
         run_result=run_result,
         running_command_id=running_command_id,
         queued_command_ids=OrderedDict((i, True) for i in queued_command_ids),
-        commands_by_id=OrderedDict(commands_by_id),
         errors_by_id=errors_by_id or {},
+        all_command_ids=all_command_ids,
+        commands_by_id=commands_by_id,
     )
 
     return CommandView(state=state)
@@ -51,7 +60,7 @@ def get_command_view(
 def test_get_by_id() -> None:
     """It should get a command by ID from state."""
     command = create_succeeded_command(command_id="command-id")
-    subject = get_command_view(commands_by_id=[("command-id", command)])
+    subject = get_command_view(commands=[command])
 
     assert subject.get("command-id") == command
 
@@ -59,7 +68,7 @@ def test_get_by_id() -> None:
 def test_get_command_bad_id() -> None:
     """It should raise if a requested command ID isn't in state."""
     command = create_succeeded_command(command_id="command-id")
-    subject = get_command_view(commands_by_id=[("command-id", command)])
+    subject = get_command_view(commands=[command])
 
     with pytest.raises(errors.CommandDoesNotExistError):
         subject.get("asdfghjkl")
@@ -71,13 +80,7 @@ def test_get_all() -> None:
     command_2 = create_running_command(command_id="command-id-2")
     command_3 = create_queued_command(command_id="command-id-3")
 
-    subject = get_command_view(
-        commands_by_id=[
-            ("command-id-1", command_1),
-            ("command-id-2", command_2),
-            ("command-id-3", command_3),
-        ]
-    )
+    subject = get_command_view(commands=[command_1, command_2, command_3])
 
     assert subject.get_all() == [command_1, command_2, command_3]
 
@@ -145,12 +148,7 @@ def test_get_is_complete() -> None:
     pending_command = create_queued_command(command_id="command-id-4")
 
     subject = get_command_view(
-        commands_by_id=[
-            ("command-id-1", completed_command),
-            ("command-id-2", failed_command),
-            ("command-id-3", running_command),
-            ("command-id-4", pending_command),
-        ]
+        commands=[completed_command, failed_command, running_command, pending_command]
     )
 
     assert subject.get_is_complete("command-id-1") is True
@@ -172,14 +170,14 @@ def test_get_all_complete() -> None:
 
     subject = get_command_view(
         queued_command_ids=[],
-        commands_by_id=[("command-id-1", running_command)],
+        commands=[running_command],
     )
     assert subject.get_all_complete() is False
 
     subject = get_command_view(
         queued_command_ids=[],
         is_hardware_stopped=True,
-        commands_by_id=[("command-id-1", running_command)],
+        commands=[running_command],
     )
     assert subject.get_all_complete() is True
 
@@ -448,9 +446,7 @@ get_okay_to_clear_specs: List[GetOkayToClearSpec] = [
             queue_status=QueueStatus.IMPLICITLY_ACTIVE,
             running_command_id=None,
             queued_command_ids=["command-id"],
-            commands_by_id=[
-                ("command-id", create_queued_command(command_id="command-id"))
-            ],
+            commands=[create_queued_command(command_id="command-id")],
         ),
         expected_is_okay=False,
     ),
@@ -458,9 +454,7 @@ get_okay_to_clear_specs: List[GetOkayToClearSpec] = [
         subject=get_command_view(
             running_command_id=None,
             queued_command_ids=[],
-            commands_by_id=[
-                ("command-id", create_queued_command(command_id="command-id"))
-            ],
+            commands=[create_queued_command(command_id="command-id")],
         ),
         expected_is_okay=True,
     ),
@@ -487,22 +481,28 @@ def test_get_current() -> None:
     )
     assert subject.get_current() is None
 
+    command = create_running_command("command-id")
     subject = get_command_view(
         running_command_id="command-id",
         queued_command_ids=[],
+        commands=[command],
     )
-    assert subject.get_current() == "command-id"
+    assert subject.get_current() == CurrentCommand(index=0, command_id="command-id")
 
-    subject = get_command_view(
-        running_command_id=None,
-        queued_command_ids=["command-id", "next-command-id"],
-    )
-    assert subject.get_current() == "command-id"
+    command_1 = create_succeeded_command("command-id-1")
+    command_2 = create_succeeded_command("command-id-2")
+    subject = get_command_view(commands=[command_1, command_2])
+    assert subject.get_current() == CurrentCommand(index=1, command_id="command-id-2")
+
+    command_1 = create_succeeded_command("command-id-1")
+    command_2 = create_failed_command("command-id-2")
+    subject = get_command_view(commands=[command_1, command_2])
+    assert subject.get_current() == CurrentCommand(index=1, command_id="command-id-2")
 
 
 def test_get_slice_empty() -> None:
     """It should return a slice from the tail if no current command."""
-    subject = get_command_view(commands_by_id=[])
+    subject = get_command_view(commands=[])
 
     result = subject.get_slice(cursor=None, length=2)
 
@@ -521,14 +521,7 @@ def test_get_slice() -> None:
     command_3 = create_queued_command(command_id="command-id-3")
     command_4 = create_queued_command(command_id="command-id-4")
 
-    subject = get_command_view(
-        commands_by_id=[
-            ("command-id-1", command_1),
-            ("command-id-2", command_2),
-            ("command-id-3", command_3),
-            ("command-id-4", command_4),
-        ]
-    )
+    subject = get_command_view(commands=[command_1, command_2, command_3, command_4])
 
     result = subject.get_slice(cursor=1, length=3)
 
@@ -550,27 +543,21 @@ def test_get_slice() -> None:
 
 
 def test_get_slice_default_cursor() -> None:
-    """It should use the current command as the default cursor location."""
+    """It should use the tail as the default cursor location."""
     command_1 = create_succeeded_command(command_id="command-id-1")
     command_2 = create_succeeded_command(command_id="command-id-2")
     command_3 = create_running_command(command_id="command-id-3")
     command_4 = create_queued_command(command_id="command-id-4")
 
     subject = get_command_view(
-        running_command_id="command-id-2",
-        commands_by_id=[
-            ("command-id-1", command_1),
-            ("command-id-2", command_2),
-            ("command-id-3", command_3),
-            ("command-id-4", command_4),
-        ],
+        commands=[command_1, command_2, command_3, command_4],
     )
 
     result = subject.get_slice(cursor=None, length=2)
 
     assert result == CommandSlice(
-        commands=[command_2, command_3],
-        cursor=1,
+        commands=[command_3, command_4],
+        cursor=2,
         length=2,
         total_length=4,
     )
@@ -583,14 +570,7 @@ def test_get_slice_default_cursor_no_current() -> None:
     command_3 = create_succeeded_command(command_id="command-id-3")
     command_4 = create_succeeded_command(command_id="command-id-4")
 
-    subject = get_command_view(
-        commands_by_id=[
-            ("command-id-1", command_1),
-            ("command-id-2", command_2),
-            ("command-id-3", command_3),
-            ("command-id-4", command_4),
-        ],
-    )
+    subject = get_command_view(commands=[command_1, command_2, command_3, command_4])
 
     result = subject.get_slice(cursor=None, length=3)
 

--- a/api/tests/opentrons/protocol_engine/state/test_command_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view.py
@@ -481,7 +481,11 @@ def test_get_current() -> None:
     )
     assert subject.get_current() is None
 
-    command = create_running_command("command-id", command_key="command-key")
+    command = create_running_command(
+        "command-id",
+        command_key="command-key",
+        created_at=datetime(year=2021, month=1, day=1),
+    )
     subject = get_command_view(
         running_command_id="command-id",
         queued_command_ids=[],
@@ -491,24 +495,43 @@ def test_get_current() -> None:
         index=0,
         command_id="command-id",
         command_key="command-key",
+        created_at=datetime(year=2021, month=1, day=1),
     )
 
-    command_1 = create_succeeded_command("command-id-1", command_key="key-1")
-    command_2 = create_succeeded_command("command-id-2", command_key="key-2")
+    command_1 = create_succeeded_command(
+        "command-id-1",
+        command_key="key-1",
+        created_at=datetime(year=2021, month=1, day=1),
+    )
+    command_2 = create_succeeded_command(
+        "command-id-2",
+        command_key="key-2",
+        created_at=datetime(year=2022, month=2, day=2),
+    )
     subject = get_command_view(commands=[command_1, command_2])
     assert subject.get_current() == CurrentCommand(
         index=1,
         command_id="command-id-2",
         command_key="key-2",
+        created_at=datetime(year=2022, month=2, day=2),
     )
 
-    command_1 = create_succeeded_command("command-id-1", command_key="key-1")
-    command_2 = create_failed_command("command-id-2", command_key="key-2")
+    command_1 = create_succeeded_command(
+        "command-id-1",
+        command_key="key-1",
+        created_at=datetime(year=2021, month=1, day=1),
+    )
+    command_2 = create_failed_command(
+        "command-id-2",
+        command_key="key-2",
+        created_at=datetime(year=2022, month=2, day=2),
+    )
     subject = get_command_view(commands=[command_1, command_2])
     assert subject.get_current() == CurrentCommand(
         index=1,
         command_id="command-id-2",
         command_key="key-2",
+        created_at=datetime(year=2022, month=2, day=2),
     )
 
 

--- a/robot-server/robot_server/protocols/router.py
+++ b/robot-server/robot_server/protocols/router.py
@@ -169,7 +169,7 @@ async def get_protocols(
         )
         for r in protocol_resources
     ]
-    meta = MultiBodyMeta(cursor=0, pageLength=len(data), totalLength=len(data))
+    meta = MultiBodyMeta(cursor=0, totalLength=len(data))
 
     return await PydanticResponse.create(
         content=SimpleMultiBody.construct(data=data, meta=meta),

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -236,7 +236,7 @@ async def get_runs(
         if run.is_current:
             links.current = ResourceLink.construct(href=f"/runs/{run.run_id}")
 
-    meta = MultiBodyMeta(cursor=0, pageLength=len(data), totalLength=len(data))
+    meta = MultiBodyMeta(cursor=0, totalLength=len(data))
 
     return await PydanticResponse.create(
         content=MultiBody.construct(data=data, links=links, meta=meta),

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -40,6 +40,7 @@ class CommandLinkMeta(BaseModel):
     runId: str = Field(..., description="The ID of the command's run.")
     commandId: str = Field(..., description="The ID of the command.")
     index: int = Field(..., description="Index of the command in the overall list.")
+    key: str = Field(..., description="Value of the current command's `key` field.")
 
 
 class CommandLink(BaseModel):
@@ -165,6 +166,7 @@ async def get_run_commands(
                 runId=run.id,
                 commandId=current_command.command_id,
                 index=current_command.index,
+                key=current_command.command_key,
             ),
         )
 

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -153,7 +153,6 @@ async def get_run_commands(
 
     meta = MultiBodyMeta(
         cursor=command_slice.cursor,
-        pageLength=command_slice.length,
         totalLength=command_slice.total_length,
     )
 

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -39,6 +39,7 @@ class CommandLinkMeta(BaseModel):
 
     runId: str = Field(..., description="The ID of the command's run.")
     commandId: str = Field(..., description="The ID of the command.")
+    index: int = Field(..., description="Index of the command in the overall list.")
 
 
 class CommandLink(BaseModel):
@@ -132,7 +133,7 @@ async def get_run_commands(
         pageLength: Maximum number of items to return.
     """
     state = engine_store.get_state(run.id)
-    current_command_id = state.commands.get_current()
+    current_command = state.commands.get_current()
     command_slice = state.commands.get_slice(cursor=cursor, length=pageLength)
 
     data = [
@@ -158,10 +159,14 @@ async def get_run_commands(
 
     links = CommandCollectionLinks()
 
-    if current_command_id is not None:
+    if current_command is not None:
         links.current = CommandLink(
-            href=f"/runs/{run.id}/commands/{current_command_id}",
-            meta=CommandLinkMeta(runId=run.id, commandId=current_command_id),
+            href=f"/runs/{run.id}/commands/{current_command.command_id}",
+            meta=CommandLinkMeta(
+                runId=run.id,
+                commandId=current_command.command_id,
+                index=current_command.index,
+            ),
         )
 
     return await PydanticResponse.create(

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -1,4 +1,5 @@
 """Router for /runs commands endpoints."""
+from datetime import datetime
 from fastapi import APIRouter, Depends, status
 from pydantic import BaseModel, Field
 from typing import Optional, Union
@@ -41,6 +42,10 @@ class CommandLinkMeta(BaseModel):
     commandId: str = Field(..., description="The ID of the command.")
     index: int = Field(..., description="Index of the command in the overall list.")
     key: str = Field(..., description="Value of the current command's `key` field.")
+    createdAt: datetime = Field(
+        ...,
+        description="When the current command was created.",
+    )
 
 
 class CommandLink(BaseModel):
@@ -167,6 +172,7 @@ async def get_run_commands(
                 commandId=current_command.command_id,
                 index=current_command.index,
                 key=current_command.command_key,
+                createdAt=current_command.created_at,
             ),
         )
 

--- a/robot-server/robot_server/service/json_api/response.py
+++ b/robot-server/robot_server/service/json_api/response.py
@@ -71,10 +71,6 @@ class MultiBodyMeta(BaseModel):
             " the response represents."
         ),
     )
-    pageLength: int = Field(
-        ...,
-        description="Number of items included in the response.",
-    )
     totalLength: int = Field(
         ...,
         description="Total number of items in the overall collection.",

--- a/robot-server/tests/protocols/test_protocols_router.py
+++ b/robot-server/tests/protocols/test_protocols_router.py
@@ -84,7 +84,7 @@ async def test_get_protocols_no_protocols(
     result = await get_protocols(protocol_store=protocol_store)
 
     assert result.content.data == []
-    assert result.content.meta == MultiBodyMeta(cursor=0, pageLength=0, totalLength=0)
+    assert result.content.meta == MultiBodyMeta(cursor=0, totalLength=0)
     assert result.status_code == 200
 
 
@@ -152,7 +152,7 @@ async def test_get_protocols(
     )
 
     assert result.content.data == [expected_protocol_1, expected_protocol_2]
-    assert result.content.meta == MultiBodyMeta(cursor=0, pageLength=2, totalLength=2)
+    assert result.content.meta == MultiBodyMeta(cursor=0, totalLength=2)
     assert result.status_code == 200
 
 

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -437,7 +437,7 @@ async def test_get_runs_empty(decoy: Decoy, run_store: RunStore) -> None:
 
     assert result.content.data == []
     assert result.content.links == AllRunsLinks(current=None)
-    assert result.content.meta == MultiBodyMeta(cursor=0, pageLength=0, totalLength=0)
+    assert result.content.meta == MultiBodyMeta(cursor=0, totalLength=0)
     assert result.status_code == 200
 
 
@@ -504,7 +504,7 @@ async def test_get_runs_not_empty(
     assert result.content.links == AllRunsLinks(
         current=ResourceLink(href="/runs/unique-id-2")
     )
-    assert result.content.meta == MultiBodyMeta(cursor=0, pageLength=2, totalLength=2)
+    assert result.content.meta == MultiBodyMeta(cursor=0, totalLength=2)
     assert result.status_code == 200
 
 

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -8,6 +8,7 @@ from opentrons.protocol_engine import (
     EngineStatus,
     StateView,
     CommandSlice,
+    CurrentCommand,
     commands as pe_commands,
     errors as pe_errors,
 )
@@ -129,7 +130,9 @@ async def test_get_run_commands(decoy: Decoy, engine_store: EngineStore) -> None
 
     engine_state = decoy.mock(cls=StateView)
     decoy.when(engine_store.get_state("run-id")).then_return(engine_state)
-    decoy.when(engine_state.commands.get_current()).then_return("current-command-id")
+    decoy.when(engine_state.commands.get_current()).then_return(
+        CurrentCommand(command_id="current-command-id", index=101)
+    )
     decoy.when(engine_state.commands.get_slice(cursor=None, length=42)).then_return(
         CommandSlice(commands=[command], cursor=1, length=2, total_length=3)
     )
@@ -158,7 +161,11 @@ async def test_get_run_commands(decoy: Decoy, engine_store: EngineStore) -> None
     assert result.content.links == CommandCollectionLinks(
         current=CommandLink(
             href="/runs/run-id/commands/current-command-id",
-            meta=CommandLinkMeta(runId="run-id", commandId="current-command-id"),
+            meta=CommandLinkMeta(
+                runId="run-id",
+                commandId="current-command-id",
+                index=101,
+            ),
         )
     )
     assert result.status_code == 200

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -134,6 +134,7 @@ async def test_get_run_commands(decoy: Decoy, engine_store: EngineStore) -> None
         CurrentCommand(
             command_id="current-command-id",
             command_key="current-command-key",
+            created_at=datetime(year=2024, month=4, day=4),
             index=101,
         )
     )
@@ -169,6 +170,7 @@ async def test_get_run_commands(decoy: Decoy, engine_store: EngineStore) -> None
                 runId="run-id",
                 commandId="current-command-id",
                 key="current-command-key",
+                createdAt=datetime(year=2024, month=4, day=4),
                 index=101,
             ),
         )

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -131,7 +131,11 @@ async def test_get_run_commands(decoy: Decoy, engine_store: EngineStore) -> None
     engine_state = decoy.mock(cls=StateView)
     decoy.when(engine_store.get_state("run-id")).then_return(engine_state)
     decoy.when(engine_state.commands.get_current()).then_return(
-        CurrentCommand(command_id="current-command-id", index=101)
+        CurrentCommand(
+            command_id="current-command-id",
+            command_key="current-command-key",
+            index=101,
+        )
     )
     decoy.when(engine_state.commands.get_slice(cursor=None, length=42)).then_return(
         CommandSlice(commands=[command], cursor=1, total_length=3)
@@ -164,6 +168,7 @@ async def test_get_run_commands(decoy: Decoy, engine_store: EngineStore) -> None
             meta=CommandLinkMeta(
                 runId="run-id",
                 commandId="current-command-id",
+                key="current-command-key",
                 index=101,
             ),
         )

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -134,7 +134,7 @@ async def test_get_run_commands(decoy: Decoy, engine_store: EngineStore) -> None
         CurrentCommand(command_id="current-command-id", index=101)
     )
     decoy.when(engine_state.commands.get_slice(cursor=None, length=42)).then_return(
-        CommandSlice(commands=[command], cursor=1, length=2, total_length=3)
+        CommandSlice(commands=[command], cursor=1, total_length=3)
     )
 
     result = await get_run_commands(
@@ -157,7 +157,7 @@ async def test_get_run_commands(decoy: Decoy, engine_store: EngineStore) -> None
             errorId="error-id",
         )
     ]
-    assert result.content.meta == MultiBodyMeta(cursor=1, pageLength=2, totalLength=3)
+    assert result.content.meta == MultiBodyMeta(cursor=1, totalLength=3)
     assert result.content.links == CommandCollectionLinks(
         current=CommandLink(
             href="/runs/run-id/commands/current-command-id",
@@ -190,7 +190,7 @@ async def test_get_run_commands_empty(decoy: Decoy, engine_store: EngineStore) -
     decoy.when(engine_store.get_state("run-id")).then_return(engine_state)
     decoy.when(engine_state.commands.get_current()).then_return(None)
     decoy.when(engine_state.commands.get_slice(cursor=21, length=42)).then_return(
-        CommandSlice(commands=[], cursor=0, length=0, total_length=0)
+        CommandSlice(commands=[], cursor=0, total_length=0)
     )
 
     result = await get_run_commands(
@@ -201,7 +201,7 @@ async def test_get_run_commands_empty(decoy: Decoy, engine_store: EngineStore) -
     )
 
     assert result.content.data == []
-    assert result.content.meta == MultiBodyMeta(cursor=0, pageLength=0, totalLength=0)
+    assert result.content.meta == MultiBodyMeta(cursor=0, totalLength=0)
     assert result.content.links == CommandCollectionLinks(current=None)
     assert result.status_code == 200
 

--- a/robot-server/tests/service/json_api/test_response.py
+++ b/robot-server/tests/service/json_api/test_response.py
@@ -60,23 +60,23 @@ RESPONSE_SPECS = [
     ResponseSpec(
         subject=SimpleMultiBody(
             data=[_Resource(id="hello"), _Resource(id="goodbye")],
-            meta=MultiBodyMeta(cursor=1, pageLength=2, totalLength=3),
+            meta=MultiBodyMeta(cursor=1, totalLength=3),
         ),
         expected={
             "data": [{"id": "hello"}, {"id": "goodbye"}],
-            "meta": {"cursor": 1, "pageLength": 2, "totalLength": 3},
+            "meta": {"cursor": 1, "totalLength": 3},
         },
     ),
     ResponseSpec(
         subject=MultiBody(
             data=[_Resource(id="hello"), _Resource(id="goodbye")],
             links=_Links(sibling=ResourceLink(href="/bar")),
-            meta=MultiBodyMeta(cursor=1, pageLength=2, totalLength=3),
+            meta=MultiBodyMeta(cursor=1, totalLength=3),
         ),
         expected={
             "data": [{"id": "hello"}, {"id": "goodbye"}],
             "links": {"sibling": {"href": "/bar"}},
-            "meta": {"cursor": 1, "pageLength": 2, "totalLength": 3},
+            "meta": {"cursor": 1, "totalLength": 3},
         },
     ),
     ResponseSpec(


### PR DESCRIPTION
## Overview

This PR adds two meta fields to the `GET .../commands` response so the client can organize the run log UI properly

- `links.current.meta.index` - the index of the current command in the overall command collection
- `links.current.meta.key` - the value of the current command's `key` field, for matching with the analysis
- `links.current.meta.createdAt` - the value of the current command's `createdAt` field, to differentiate between LPC commands and commands resulting from a non-deterministic run


## Changelog

- fix(robot-server): add current command index and key to /commands response
- refactor: remove redundant `meta.pageLength` from collection responses

## Review requests

- [ ] `links.current.meta.index` is present in response and correct
- [ ] `links.current.meta.key` is present in response and correct
- [ ] `links.current.meta.createdAt` is present in response and correct
- [ ] nothing else breaks

## Risk assessment

Medium low.

- Needed to reorganize underlying ProtocolEngine `CommandState` shape to make the index of the current command accessible at at O(1) in most cases
- Added a little bit of tech debt that needs to be addressed prior to JSONv6 (see TODO comment)