### PR TITLE
chore(api): Cherry-pick #9364 from release_5.0.0 to pass G-code tests

### DIFF
--- a/api/src/opentrons/protocol_api/load_info.py
+++ b/api/src/opentrons/protocol_api/load_info.py
@@ -59,7 +59,9 @@ class ModuleLoadInfo:
     :meta private:
     """
 
-    module_model: ModuleModel
+    requested_model: ModuleModel
+    loaded_model: ModuleModel
+
     deck_slot: DeckSlotName
     configuration: Optional[str]
     module_serial: str

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Generic, List, Optional, TYPE_CHECKING, TypeVar, Union, cast
+from typing import Generic, List, Optional, TYPE_CHECKING, TypeVar, cast
 
 from opentrons import types
 from opentrons.hardware_control import modules
+from opentrons.hardware_control.modules import ModuleModel
 from opentrons.hardware_control.types import Axis
 from opentrons.commands import module_commands as cmds
 from opentrons.commands.publisher import CommandPublisher, publish
@@ -22,11 +23,6 @@ from opentrons.protocols.api_support.util import requires_version
 if TYPE_CHECKING:
     from .protocol_context import ProtocolContext
     from opentrons_shared_data.labware.dev_types import LabwareDefinition
-
-
-ModuleTypes = Union[
-    "TemperatureModuleContext", "MagneticModuleContext", "ThermocyclerContext"
-]
 
 ENGAGE_HEIGHT_UNIT_CNV = 2
 STANDARD_MAGDECK_LABWARE = [
@@ -50,6 +46,7 @@ class ModuleContext(CommandPublisher, Generic[GeometryType]):
         self,
         ctx: ProtocolContext,
         geometry: GeometryType,
+        requested_as: ModuleModel,
         at_version: APIVersion,
     ) -> None:
         """Build the ModuleContext.
@@ -59,10 +56,12 @@ class ModuleContext(CommandPublisher, Generic[GeometryType]):
 
         :param ctx: The parent context for the module
         :param geometry: The :py:class:`.ModuleGeometry` for the module
+        :param requested_as: See :py:obj:`requested_as`.
         """
         super().__init__(ctx.broker)
         self._geometry = geometry
         self._ctx = ctx
+        self._requested_as = requested_as
         self._api_version = at_version
 
     @property  # type: ignore
@@ -90,7 +89,7 @@ class ModuleContext(CommandPublisher, Generic[GeometryType]):
 
         provided_offset = self._ctx._labware_offset_provider.find(
             labware_definition_uri=labware.uri,
-            module_model=self.geometry.model.value,
+            requested_module_model=self.requested_as,
             deck_slot=deck_slot,
         )
 
@@ -200,6 +199,19 @@ class ModuleContext(CommandPublisher, Generic[GeometryType]):
         """
         return self._geometry
 
+    @property
+    def requested_as(self) -> ModuleModel:
+        """How the protocol requested this module.
+
+        For example, a physical ``temperatureModuleV2`` might have been requested
+        either as ``temperatureModuleV2`` or ``temperatureModuleV1``.
+
+        For Opentrons internal use only.
+
+        :meta private:
+        """
+        return self._requested_as
+
     def __repr__(self):
         return "{} at {} lw {}".format(
             self.__class__.__name__, self._geometry, self.labware
@@ -243,12 +255,13 @@ class TemperatureModuleContext(ModuleContext[ModuleGeometry]):
         ctx: ProtocolContext,
         hw_module: modules.tempdeck.TempDeck,
         geometry: ModuleGeometry,
+        requested_as: ModuleModel,
         at_version: APIVersion,
         loop: asyncio.AbstractEventLoop,
     ) -> None:
         self._module = hw_module
         self._loop = loop
-        super().__init__(ctx, geometry, at_version)
+        super().__init__(ctx, geometry, requested_as, at_version)
 
     @publish(command=cmds.tempdeck_set_temp)
     @requires_version(2, 0)
@@ -327,12 +340,13 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
         ctx: ProtocolContext,
         hw_module: modules.magdeck.MagDeck,
         geometry: ModuleGeometry,
+        requested_as: ModuleModel,
         at_version: APIVersion,
         loop: asyncio.AbstractEventLoop,
     ) -> None:
         self._module = hw_module
         self._loop = loop
-        super().__init__(ctx, geometry, at_version)
+        super().__init__(ctx, geometry, requested_as, at_version)
 
     @publish(command=cmds.magdeck_calibrate)
     @requires_version(2, 0)
@@ -470,12 +484,13 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
         ctx: ProtocolContext,
         hw_module: modules.thermocycler.Thermocycler,
         geometry: ThermocyclerGeometry,
+        requested_as: ModuleModel,
         at_version: APIVersion,
         loop: asyncio.AbstractEventLoop,
     ) -> None:
         self._module = hw_module
         self._loop = loop
-        super().__init__(ctx, geometry, at_version)
+        super().__init__(ctx, geometry, requested_as, at_version)
 
     def _prepare_for_lid_move(self):
         loaded_instruments = [

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -30,7 +30,10 @@ from opentrons.protocols.api_support.util import (
 from opentrons.protocols.types import Protocol
 from opentrons.protocols.context.labware import AbstractLabware
 from opentrons.protocols.context.protocol import AbstractProtocol
-from opentrons.protocols.geometry.module_geometry import ModuleGeometry
+from opentrons.protocols.geometry.module_geometry import (
+    ModuleGeometry,
+    resolve_module_model,
+)
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 
@@ -54,7 +57,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 ModuleTypes = Union[
-    "TemperatureModuleContext", "MagneticModuleContext", "ThermocyclerContext"
+    TemperatureModuleContext, MagneticModuleContext, ThermocyclerContext
 ]
 
 
@@ -294,7 +297,7 @@ class ProtocolContext(CommandPublisher):
 
         provided_labware_offset = self._labware_offset_provider.find(
             labware_definition_uri=result.uri,
-            module_model=None,
+            requested_module_model=None,
             deck_slot=types.DeckSlotName.from_primitive(location),
         )
 
@@ -361,7 +364,7 @@ class ProtocolContext(CommandPublisher):
 
         provided_labware_offset = self._labware_offset_provider.find(
             labware_definition_uri=result.uri,
-            module_model=None,
+            requested_module_model=None,
             deck_slot=types.DeckSlotName.from_primitive(location),
         )
 
@@ -474,37 +477,41 @@ class ProtocolContext(CommandPublisher):
                 "using thermocycler parameters only available in 2.4"
             )
 
-        module = self._implementation.load_module(
-            module_name=module_name, location=location, configuration=configuration
+        requested_model = resolve_module_model(module_name)
+
+        load_result = self._implementation.load_module(
+            model=requested_model, location=location, configuration=configuration
         )
 
-        if not module:
+        if not load_result:
             raise RuntimeError(f"Could not find specified module: {module_name}")
 
         mod_class = {
             ModuleType.MAGNETIC: MagneticModuleContext,
             ModuleType.TEMPERATURE: TemperatureModuleContext,
             ModuleType.THERMOCYCLER: ThermocyclerContext,
-        }[module.type]
+        }[load_result.type]
 
         module_context = mod_class(
             ctx=self,
-            hw_module=module.module,
-            geometry=module.geometry,
+            hw_module=load_result.module,
+            geometry=load_result.geometry,
             at_version=self.api_version,
+            requested_as=requested_model,
             loop=self._loop,
         )
         self._modules.append(module_context)
 
         # ===== Protocol Engine stuff ====
-        module_loc = module.geometry.parent
+        module_loc = load_result.geometry.parent
         assert isinstance(module_loc, (int, str)), "Unexpected labware object parent"
         deck_slot = types.DeckSlotName.from_primitive(module_loc)
-        module_serial = module.module.device_info["serial"]
+        module_serial = load_result.module.device_info["serial"]
 
         self.equipment_broker.publish(
             ModuleLoadInfo(
-                module_model=module.geometry.model,
+                requested_model=requested_model,
+                loaded_model=load_result.geometry.model,
                 deck_slot=deck_slot,
                 configuration=configuration,
                 module_serial=module_serial,

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -221,14 +221,13 @@ class LabwareOffsetLocation(BaseModel):
             "The model of the module that the labware will be loaded onto,"
             " if applicable."
             "\n\n"
-            "For the offset to apply,"
-            " this must exactly match the model that the robot will find"
-            " *physically connected* during the protocol's execution."
-            " This means it's not enough to blindly use the model"
-            " reported by the protocol's analysis."
-            " The two models will differ"
-            " if the physically connected module is compatible, but not identical,"
-            " to the one that the protocol requested."
+            "Because of module compatibility, the model that the protocol requests"
+            " may not beexactly the same"
+            " as what it will find physically connected during execution."
+            " For this labware offset to apply,"
+            " this field must be the *requested* model, not the connected one."
+            " You can retrieve this from a `loadModule` command's `params.model`"
+            " in the protocol's analysis."
         ),
     )
 

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -362,16 +362,17 @@ class LegacyCommandMapper:
         count = self._command_count["LOAD_MODULE"]
         command_id = f"commands.LOAD_MODULE-{count}"
         module_id = f"module-{count}"
-        module_model = _LEGACY_TO_PE_MODULE[module_load_info.module_model]
+        requested_model = _LEGACY_TO_PE_MODULE[module_load_info.requested_model]
+        loaded_model = _LEGACY_TO_PE_MODULE[module_load_info.loaded_model]
 
         # This will fetch a V2 definition only. PAPI < v2.3 use V1 definitions.
         # When running a < v2.3 protocol, there will be a mismatch of definitions used
         # during analysis+LPC (V2) and protocol execution (V1).
         # But this shouldn't result in any problems since V2 and V1 definitions
         # have similar info, with V2 having additional info fields.
-        definition = self._module_definition_by_model.get(
-            module_model
-        ) or self._module_data_provider.get_definition(module_model)
+        loaded_definition = self._module_definition_by_model.get(
+            loaded_model
+        ) or self._module_data_provider.get_definition(loaded_model)
 
         load_module_command = pe_commands.LoadModule.construct(
             id=command_id,
@@ -381,7 +382,7 @@ class LegacyCommandMapper:
             startedAt=now,
             completedAt=now,
             params=pe_commands.LoadModuleParams.construct(
-                model=module_model,
+                model=requested_model,
                 location=pe_types.DeckSlotLocation(
                     slotName=module_load_info.deck_slot,
                 ),
@@ -390,11 +391,11 @@ class LegacyCommandMapper:
             result=pe_commands.LoadModuleResult.construct(
                 moduleId=module_id,
                 serialNumber=module_load_info.module_serial,
-                definition=definition,
-                model=definition.model,
+                definition=loaded_definition,
+                model=loaded_model,
             ),
         )
         self._command_count["LOAD_MODULE"] = count + 1
         self._module_id_by_slot[module_load_info.deck_slot] = module_id
-        self._module_definition_by_model[module_model] = definition
+        self._module_definition_by_model[loaded_model] = loaded_definition
         return load_module_command

--- a/api/src/opentrons/protocol_runner/legacy_labware_offset_provider.py
+++ b/api/src/opentrons/protocol_runner/legacy_labware_offset_provider.py
@@ -11,6 +11,8 @@ from opentrons.protocol_api.labware_offset_provider import (
 from opentrons.protocol_engine import LabwareOffsetLocation, ModuleModel
 from opentrons.protocol_engine.state import LabwareView
 
+from .legacy_wrappers import LegacyModuleModel
+
 
 class LegacyLabwareOffsetProvider(AbstractLegacyLabwareOffsetProvider):
     """Provides a `ProtocolEngine`'s labware offsets."""
@@ -22,7 +24,7 @@ class LegacyLabwareOffsetProvider(AbstractLegacyLabwareOffsetProvider):
     def find(
         self,
         labware_definition_uri: str,
-        module_model: Optional[str],
+        requested_module_model: Optional[LegacyModuleModel],
         deck_slot: DeckSlotName,
     ) -> LegacyProvidedLabwareOffset:
         """Look up an offset in ProtocolEngine state and return it, if one exists.
@@ -34,7 +36,9 @@ class LegacyLabwareOffsetProvider(AbstractLegacyLabwareOffsetProvider):
             location=LabwareOffsetLocation(
                 slotName=deck_slot,
                 moduleModel=(
-                    None if module_model is None else ModuleModel(module_model)
+                    None
+                    if requested_module_model is None
+                    else ModuleModel(requested_module_model.value)
                 ),
             ),
         )

--- a/api/src/opentrons/protocols/context/protocol.py
+++ b/api/src/opentrons/protocols/context/protocol.py
@@ -8,7 +8,7 @@ from typing import Dict, Optional
 
 from opentrons import types
 from opentrons.hardware_control import SyncHardwareAPI, SynchronousAdapter
-from opentrons.hardware_control.modules.types import ModuleType
+from opentrons.hardware_control.modules.types import ModuleModel, ModuleType
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.protocols.geometry.deck_item import DeckItem
 from opentrons.protocols.geometry.module_geometry import ModuleGeometry
@@ -79,7 +79,7 @@ class AbstractProtocol(ABC):
     @abstractmethod
     def load_module(
         self,
-        module_name: str,
+        model: ModuleModel,
         location: Optional[types.DeckLocation],
         configuration: Optional[str],
     ) -> Optional[LoadModuleResult]:

--- a/api/src/opentrons/protocols/context/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocols/context/protocol_api/protocol_context.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 from opentrons import types
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.hardware_control import SyncHardwareAPI, SynchronousAdapter
+from opentrons.hardware_control.modules import AbstractModule, ModuleModel
 from opentrons.hardware_control.types import DoorState, PauseType
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 from opentrons.protocols.geometry.deck import Deck
@@ -24,9 +25,6 @@ from opentrons.protocols.api_support.util import AxisMaxSpeeds
 from opentrons.protocols.labware import load_from_definition, get_labware_definition
 from opentrons.protocols.types import Protocol
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
-
-if TYPE_CHECKING:
-    from opentrons.hardware_control.modules import AbstractModule, ModuleModel
 
 
 logger = logging.getLogger(__name__)

--- a/api/src/opentrons/protocols/context/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocols/context/protocol_api/protocol_context.py
@@ -26,7 +26,7 @@ from opentrons.protocols.types import Protocol
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 if TYPE_CHECKING:
-    from opentrons.hardware_control.modules import AbstractModule
+    from opentrons.hardware_control.modules import AbstractModule, ModuleModel
 
 
 logger = logging.getLogger(__name__)

--- a/api/src/opentrons/protocols/context/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocols/context/protocol_api/protocol_context.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Dict, List, Optional, Set
+from typing import Dict, List, Optional, Set
 from collections import OrderedDict
 
 from opentrons import types

--- a/api/src/opentrons/protocols/context/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocols/context/protocol_api/protocol_context.py
@@ -148,34 +148,25 @@ class ProtocolContextImplementation(AbstractProtocol):
 
     def load_module(
         self,
-        module_name: str,
+        model: ModuleModel,
         location: Optional[types.DeckLocation],
         configuration: Optional[str],
     ) -> Optional[LoadModuleResult]:
         """Load a module."""
-        resolved_model = module_geometry.resolve_module_model(module_name)
-        resolved_type = module_geometry.resolve_module_type(resolved_model)
+        resolved_type = module_geometry.resolve_module_type(model)
         resolved_location = self._deck_layout.resolve_module_location(
             resolved_type, location
         )
 
-        # Load the geometry
-        geometry = module_geometry.load_module(
-            model=resolved_model,
-            parent=self._deck_layout.position_for(resolved_location),
-            api_level=self._api_version,
-            configuration=configuration,
-        )
-
         # Try to find in the hardware instance
         available_modules, simulating_module = self._sync_hardware.find_modules(
-            resolved_model, resolved_type
+            model, resolved_type
         )
 
         hc_mod_instance = None
         for mod in available_modules:
             compatible = module_geometry.models_compatible(
-                module_geometry.module_model_from_string(mod.model()), resolved_model
+                module_geometry.module_model_from_string(mod.model()), model
             )
             if compatible and mod not in self._loaded_modules:
                 self._loaded_modules.add(mod)
@@ -187,6 +178,14 @@ class ProtocolContextImplementation(AbstractProtocol):
 
         if not hc_mod_instance:
             return None
+
+        # Load geometry to match the hardware module that we found connected.
+        geometry = module_geometry.load_module(
+            model=module_geometry.module_model_from_string(hc_mod_instance.model()),
+            parent=self._deck_layout.position_for(resolved_location),
+            api_level=self._api_version,
+            configuration=configuration,
+        )
 
         result = LoadModuleResult(
             type=resolved_type, geometry=geometry, module=hc_mod_instance

--- a/api/src/opentrons/protocols/geometry/module_geometry.py
+++ b/api/src/opentrons/protocols/geometry/module_geometry.py
@@ -592,8 +592,8 @@ def load_module(
         return load_module_from_definition(defn, parent, api_level)
 
 
-def resolve_module_model(module_name: str) -> ModuleModel:
-    """Turn any of the supported load names into module model names"""
+def resolve_module_model(module_model_or_load_name: str) -> ModuleModel:
+    """Turn any of the supported APIv2 load names into module model names."""
 
     model_map: Mapping[str, ModuleModel] = {
         "magneticModuleV1": MagneticModuleModel.MAGNETIC_V1,
@@ -614,11 +614,13 @@ def resolve_module_model(module_name: str) -> ModuleModel:
         "thermocycler module": ThermocyclerModuleModel.THERMOCYCLER_V1,
     }
 
-    lower_name = module_name.lower()
-    resolved_name = model_map.get(module_name, None) or alias_map.get(lower_name, None)
+    lower_name = module_model_or_load_name.lower()
+    resolved_name = model_map.get(module_model_or_load_name, None) or alias_map.get(
+        lower_name, None
+    )
     if not resolved_name:
         raise ValueError(
-            f"{module_name} is not a valid module load name.\n"
+            f"{module_model_or_load_name} is not a valid module load name.\n"
             "Valid names (ignoring case): "
             '"'
             + '", "'.join(alias_map.keys())

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -24,7 +24,7 @@ from opentrons.protocol_runner.legacy_wrappers import (
     LegacyInstrumentLoadInfo,
     LegacyLabwareLoadInfo,
     LegacyModuleLoadInfo,
-    LegacyMagneticModuleModel,
+    LegacyTemperatureModuleModel,
 )
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 from opentrons_shared_data.module.dev_types import ModuleDefinitionV2
@@ -299,13 +299,14 @@ def test_map_module_load(
     """It should correctly map a module load."""
     test_definition = ModuleDefinition.parse_obj(minimal_module_def)
     input = LegacyModuleLoadInfo(
-        module_model=LegacyMagneticModuleModel.MAGNETIC_V2,
+        requested_model=LegacyTemperatureModuleModel.TEMPERATURE_V1,
+        loaded_model=LegacyTemperatureModuleModel.TEMPERATURE_V2,
         deck_slot=DeckSlotName.SLOT_1,
         configuration="conf",
         module_serial="module-serial",
     )
     decoy.when(
-        module_data_provider.get_definition(ModuleModel.MAGNETIC_MODULE_V2)
+        module_data_provider.get_definition(ModuleModel.TEMPERATURE_MODULE_V2)
     ).then_return(test_definition)
 
     expected_output = pe_commands.LoadModule.construct(
@@ -316,7 +317,7 @@ def test_map_module_load(
         startedAt=matchers.IsA(datetime),
         completedAt=matchers.IsA(datetime),
         params=pe_commands.LoadModuleParams.construct(
-            model=ModuleModel.MAGNETIC_MODULE_V2,
+            model=ModuleModel.TEMPERATURE_MODULE_V1,
             location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
             moduleId=matchers.IsA(str),
         ),
@@ -324,7 +325,7 @@ def test_map_module_load(
             moduleId=matchers.IsA(str),
             serialNumber="module-serial",
             definition=test_definition,
-            model=test_definition.model,
+            model=ModuleModel.TEMPERATURE_MODULE_V2,
         ),
     )
     output = LegacyCommandMapper(

--- a/api/tests/opentrons/protocol_runner/test_legacy_labware_offset_provider.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_labware_offset_provider.py
@@ -18,6 +18,7 @@ from opentrons.protocol_runner.legacy_labware_offset_provider import (
     LegacyLabwareOffsetProvider,
     LegacyProvidedLabwareOffset,
 )
+from opentrons.protocol_runner.legacy_wrappers import LegacyTemperatureModuleModel
 
 
 @pytest.fixture
@@ -58,7 +59,7 @@ def test_find_something(
 
     result = subject.find(
         labware_definition_uri="some_namespace/some_load_name/123",
-        module_model="temperatureModuleV1",
+        requested_module_model=LegacyTemperatureModuleModel.TEMPERATURE_V1,
         deck_slot=DeckSlotName.SLOT_1,
     )
 
@@ -84,7 +85,7 @@ def test_find_nothing(
 
     result = subject.find(
         labware_definition_uri="some_namespace/some_load_name/123",
-        module_model="temperatureModuleV1",
+        requested_module_model=LegacyTemperatureModuleModel.TEMPERATURE_V1,
         deck_slot=DeckSlotName.SLOT_1,
     )
 


### PR DESCRIPTION
# Overview

This cherry-picks commit 042907b3fa69cf30935dfa381eafa72b2b9f42fe (from PR #9364) from the `release_5.0.0` branch into the `edge` branch.

Our G-code snapshot tests have been updated to account for this commit in `release_5.0.0`. However, since the same golden file is used for all branches, getting tests to pass on `release_5.0.0` means breaking them on `edge`.

This PR brings into `edge` the commit that prompted those test changes, so the bug is fixed in `edge` too, and `edge` can continue to use our G-code snapshot testing.

There were a few merge conflicts, mostly around import statements ordering.

# Review requests

See #9364.