### PR TITLE
fix(shared-data): Update shop links for alumn block nest

### DIFF
--- a/shared-data/labware/definitions/2/opentrons_24_aluminumblock_nest_0.5ml_screwcap/1.json
+++ b/shared-data/labware/definitions/2/opentrons_24_aluminumblock_nest_0.5ml_screwcap/1.json
@@ -10,9 +10,7 @@
   "brand": {
     "brand": "Opentrons",
     "brandId": [],
-    "links": [
-      "https://shop.opentrons.com/collections/opentrons-tips/products/tube-rack-set-1"
-    ]
+    "links": ["https://shop.opentrons.com/aluminum-block-set/"]
   },
   "metadata": {
     "displayName": "Opentrons 24 Well Aluminum Block with NEST 0.5 mL Screwcap",

--- a/shared-data/labware/definitions/2/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1.json
+++ b/shared-data/labware/definitions/2/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1.json
@@ -10,9 +10,7 @@
   "brand": {
     "brand": "Opentrons",
     "brandId": [],
-    "links": [
-      "https://shop.opentrons.com/collections/opentrons-tips/products/tube-rack-set-1"
-    ]
+    "links": ["https://shop.opentrons.com/aluminum-block-set/"]
   },
   "metadata": {
     "displayName": "Opentrons 24 Well Aluminum Block with NEST 1.5 mL Screwcap",

--- a/shared-data/labware/definitions/2/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1.json
+++ b/shared-data/labware/definitions/2/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1.json
@@ -10,9 +10,7 @@
   "brand": {
     "brand": "Opentrons",
     "brandId": [],
-    "links": [
-      "https://shop.opentrons.com/collections/opentrons-tips/products/tube-rack-set-1"
-    ]
+    "links": ["https://shop.opentrons.com/aluminum-block-set/"]
   },
   "metadata": {
     "displayName": "Opentrons 24 Well Aluminum Block with NEST 1.5 mL Snapcap",

--- a/shared-data/labware/definitions/2/opentrons_24_aluminumblock_nest_2ml_screwcap/1.json
+++ b/shared-data/labware/definitions/2/opentrons_24_aluminumblock_nest_2ml_screwcap/1.json
@@ -10,9 +10,7 @@
   "brand": {
     "brand": "Opentrons",
     "brandId": [],
-    "links": [
-      "https://shop.opentrons.com/collections/opentrons-tips/products/tube-rack-set-1"
-    ]
+    "links": ["https://shop.opentrons.com/aluminum-block-set/"]
   },
   "metadata": {
     "displayName": "Opentrons 24 Well Aluminum Block with NEST 2 mL Screwcap",

--- a/shared-data/labware/definitions/2/opentrons_24_aluminumblock_nest_2ml_snapcap/1.json
+++ b/shared-data/labware/definitions/2/opentrons_24_aluminumblock_nest_2ml_snapcap/1.json
@@ -10,9 +10,7 @@
   "brand": {
     "brand": "Opentrons",
     "brandId": [],
-    "links": [
-      "https://shop.opentrons.com/collections/opentrons-tips/products/tube-rack-set-1"
-    ]
+    "links": ["https://shop.opentrons.com/aluminum-block-set/"]
   },
   "metadata": {
     "displayName": "Opentrons 24 Well Aluminum Block with NEST 2 mL Snapcap",


### PR DESCRIPTION
# Overview

closes #9375 by updating links for nest alumn block 24 nest labwares

# Changelog

- fix(shared-data): Update shop links for alumn block nest

# Review requests

check the nest 24 aluminum block links on this branch, should now link to aluminum block set in shop

# Risk assessment

low, fixing incorrect links for labware 