### PR TITLE
fix(api): add missing format string to TC command message text

### DIFF
--- a/api/src/opentrons/commands/module_commands.py
+++ b/api/src/opentrons/commands/module_commands.py
@@ -92,7 +92,7 @@ def thermocycler_execute_profile(
 ) -> command_types.ThermocyclerExecuteProfileCommand:
     text = (
         f"Thermocycler starting {repetitions} repetitions"
-        " of cycle composed of the following steps: {steps}"
+        f" of cycle composed of the following steps: {steps}"
     )
     return {
         "name": command_types.THERMOCYCLER_EXECUTE_PROFILE,

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -272,7 +272,7 @@ class ProtocolContext(CommandPublisher):
                 return
 
             if message["$"] == "before":
-                self._commands.append(text.format(**payload))
+                self._commands.append(text)
 
         self._unsubscribe_commands = self.broker.subscribe(
             cmd_types.COMMAND, on_command


### PR DESCRIPTION
## Overview

Fixes #9380. The source of the issue was two-fold:

- The construction of the thermocycler command text was missing an `f`, so the literal `{steps}` was being inserted into the command log
- Inside `ProtocolContext`, and implicit call to `string.format` with the command's payload was happening, which is how the correct string ended up in the RPC runlog
    - As best I can tell, this TC command and potentially a paired pipette command were the only commands relying on this behavior

## Changelog

- fix(api): add missing format string to TC command message text

## Review requests

- [x] Thermocycler log entries show up correctly

### Future work

- Pull in something like https://github.com/MichaelKim0407/flake8-use-fstring
- Banish the usage of `"...".format(...)` in most places in our code
- Fully audit our Python code for this bug elsewhere
    - It exists in at least one place in the paired pipette command messages, but this will be resolved by #9399 
    - Also exists in an error message in `api/src/opentrons/protocols/geometry/deck.py`
 
## Risk assessment

Very low