### PR TITLE
refactor(api): ot3: limit move command targets

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -13,6 +13,7 @@ from typing import (
     Sequence,
     Generator,
     cast,
+    Set,
 )
 
 from opentrons.config.types import OT3Config
@@ -127,6 +128,7 @@ class OT3Simulator:
         }
         self._module_controls: Optional[AttachedModulesControl] = None
         self._position = self._get_home_position()
+        self._present_nodes: Set[NodeId] = set()
 
     # TODO: These staticmethods exist to defer uses of NodeId to inside
     # method bodies, which won't be evaluated until called. This is needed
@@ -448,3 +450,11 @@ class OT3Simulator:
             NodeId.pipette_left: 0,
             NodeId.pipette_right: 0,
         }
+
+    async def probe_network(self) -> None:
+        nodes = set((NodeId.head_l, NodeId.head_r, NodeId.gantry_x, NodeId.gantry_y))
+        if self._attached_instruments[Mount.LEFT].get("model", None):
+            nodes.add(NodeId.pipette_left)
+        if self._attached_instruments[Mount.RIGHT].get("model", None):
+            nodes.add(NodeId.pipette_right)
+        self._present_nodes = nodes

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -374,7 +374,7 @@ class OT3API(
                 p, self._config, self._backend.board_revision
             )
             await self._backend.configure_mount(mount, hw_config)
-        self._log.info("Instruments found: {}".format(self._attached_instruments))
+        await self._backend.probe_network()
 
     # Global actions API
     def pause(self, pause_type: PauseType):

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -1,0 +1,83 @@
+import pytest
+from mock import AsyncMock, patch, ANY
+from opentrons.hardware_control.backends import OT3Controller
+from opentrons_hardware.drivers.can_bus import CanMessenger
+from opentrons.config.types import OT3Config
+from opentrons.config.robot_configs import build_config_ot3
+from opentrons_ot3_firmware.constants import NodeId
+from opentrons_hardware.drivers.can_bus.abstract_driver import AbstractCanDriver
+
+
+@pytest.fixture
+def mock_config() -> OT3Config:
+    return build_config_ot3({})
+
+
+@pytest.fixture
+def mock_messenger():
+    with patch(
+        "opentrons.hardware_control.backends.ot3controller.CanMessenger",
+        AsyncMock,
+        spec=CanMessenger,
+    ):
+        yield
+
+
+@pytest.fixture
+def mock_driver(mock_messenger) -> AbstractCanDriver:
+    return AsyncMock(spec=AbstractCanDriver)
+
+
+@pytest.fixture
+def controller(mock_config: OT3Config, mock_driver: AbstractCanDriver) -> OT3Controller:
+    return OT3Controller(mock_config, mock_driver)
+
+
+async def test_probing(controller: OT3Controller) -> None:
+    assert controller._present_nodes == set()
+    call_count = 0
+    fake_nodes = set((NodeId.gantry_x, NodeId.head_l))
+    passed_expected = None
+
+    async def fake_probe(can_messenger, expected, timeout):
+        nonlocal passed_expected
+        nonlocal call_count
+        nonlocal fake_nodes
+        passed_expected = expected
+        call_count += 1
+        return fake_nodes
+
+    with patch("opentrons.hardware_control.backends.ot3controller.probe", fake_probe):
+        await controller.probe_network(timeout=0.1)
+        assert call_count == 1
+        assert passed_expected == set(
+            (
+                NodeId.gantry_x,
+                NodeId.gantry_y,
+                NodeId.head_l,
+                NodeId.head_r,
+                NodeId.pipette_left,
+            )
+        )
+    assert controller._present_nodes == fake_nodes
+
+
+async def test_move_limiting(controller: OT3Controller) -> None:
+    controller._present_nodes = set((NodeId.gantry_x, NodeId.head_l))
+    with patch(
+        "opentrons.hardware_control.backends.ot3controller.MoveGroupRunner", AsyncMock
+    ) as mgr, patch(
+        "opentrons.hardware_control.backends.ot3controller.create"
+    ) as mock_create:
+
+        async def fake_run(*args, **kwargs):
+            return
+
+        mgr.runner = fake_run
+        await controller.move({"X": 0})
+        mock_create.assert_called_once_with(
+            origin=ANY,
+            target=ANY,
+            speed=ANY,
+            present_nodes=set((NodeId.gantry_x, NodeId.head_l)),
+        )

--- a/hardware/opentrons_hardware/hardware_control/motion.py
+++ b/hardware/opentrons_hardware/hardware_control/motion.py
@@ -1,5 +1,5 @@
 """A collection of motions that define a single move."""
-from typing import List, Dict
+from typing import List, Dict, Iterable, Optional
 from dataclasses import dataclass
 import numpy as np  # type: ignore[import]
 from logging import getLogger
@@ -38,7 +38,10 @@ MAX_SPEEDS = {
 
 
 def create(
-    origin: Dict[NodeId, float], target: Dict[NodeId, float], speed: float
+    origin: Dict[NodeId, float],
+    target: Dict[NodeId, float],
+    speed: float,
+    present_nodes: Optional[Iterable[NodeId]] = None,
 ) -> MoveGroups:
     """Create a move.
 
@@ -55,14 +58,19 @@ def create(
     # head (as opposed to head_l and head_r) is not an acceptable target for motion
     deltas.pop(NodeId.head, None)
 
-    ordered_nodes = [
-        NodeId.gantry_x,
-        NodeId.gantry_y,
-        NodeId.head_r,
-        NodeId.head_l,
-        NodeId.pipette_left,
-        NodeId.pipette_right,
-    ]
+    if not present_nodes:
+        checked_nodes: Iterable[NodeId] = [
+            NodeId.gantry_x,
+            NodeId.gantry_y,
+            NodeId.head_r,
+            NodeId.head_l,
+            NodeId.pipette_left,
+            NodeId.pipette_right,
+        ]
+    else:
+        checked_nodes = present_nodes
+
+    ordered_nodes = sorted(checked_nodes, key=lambda node: node.value)
     vec = np.array([deltas.get(node, 0) for node in ordered_nodes])
     if any(np.isnan(vec)):
         raise RuntimeError(vec)

--- a/hardware/opentrons_hardware/hardware_control/network.py
+++ b/hardware/opentrons_hardware/hardware_control/network.py
@@ -1,0 +1,66 @@
+"""Utilities for managing the CANbus network on the OT3."""
+import asyncio
+import logging
+from typing import Set, Optional
+from opentrons_ot3_firmware import ArbitrationId
+from opentrons_ot3_firmware.constants import NodeId
+from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
+from opentrons_ot3_firmware.messages import payloads, MessageDefinition
+from opentrons_ot3_firmware.messages.message_definitions import (
+    GetStatusRequest,
+)
+
+mod_log = logging.getLogger(__name__)
+
+
+async def probe(
+    can_messenger: CanMessenger,
+    expected: Optional[Set[NodeId]],
+    timeout: Optional[float],
+) -> Set[NodeId]:
+    """Probe the bus and discover connected devices.
+
+    Sends a status request to the broadcast address and waits for responses. Ends either
+    when all nodes in expected respond or when a timeout happens, whichever is first. A
+    None timeout is infinite and is not recommended, but could be useful if this is
+    wrapped in a task and cancelled externally.
+
+    The ideal call pattern is to build an expectation for nodes on the bus (i.e., fixed
+    nodes such as gantry controllers and head plus whatever tools the head indicates
+    are attached) and use this method to verify the assumption.
+    """
+    event = asyncio.Event()
+    nodes: Set[NodeId] = set()
+
+    def listener(message: MessageDefinition, arbitration_id: ArbitrationId) -> None:
+        try:
+            originator = NodeId(arbitration_id.parts.originating_node_id)
+        except ValueError:
+            mod_log.error(
+                "unknown node id on network: "
+                f"0x{arbitration_id.parts.originating_node_id:x}"
+            )
+            return
+        mod_log.debug(f"got response from {arbitration_id.parts.originating_node_id}")
+        nodes.add(originator)
+        if expected and expected.issubset(nodes):
+            event.set()
+
+    can_messenger.add_listener(listener)
+    await can_messenger.send(
+        node_id=NodeId.broadcast,
+        message=GetStatusRequest(payload=payloads.EmptyPayload()),
+    )
+    try:
+        await asyncio.wait_for(event.wait(), timeout)
+    except asyncio.TimeoutError:
+        if expected:
+            mod_log.warning(
+                "probe timed out before expected nodes found, missing "
+                f"{expected.difference(nodes)}"
+            )
+        else:
+            mod_log.debug("probe terminated (no expected set)")
+    finally:
+        can_messenger.remove_listener(listener)
+    return nodes

--- a/hardware/tests/opentrons_hardware/hardware_control/test_motion.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_motion.py
@@ -8,6 +8,36 @@ from opentrons_hardware.hardware_control.motion import (
 import math
 
 
+def test_only_specified_nodes() -> None:
+    """It should only add specified nodes, if specified."""
+    expected = [
+        [
+            {
+                NodeId.gantry_x: MoveGroupSingleAxisStep(
+                    distance_mm=0.0, velocity_mm_sec=0.0, duration_sec=8.0
+                ),
+                NodeId.gantry_y: MoveGroupSingleAxisStep(
+                    distance_mm=0.0, velocity_mm_sec=0.0, duration_sec=8.0
+                ),
+                NodeId.head_r: MoveGroupSingleAxisStep(
+                    distance_mm=0.0, velocity_mm_sec=0.0, duration_sec=8.0
+                ),
+                NodeId.head_l: MoveGroupSingleAxisStep(
+                    distance_mm=-2.0, velocity_mm_sec=-0.25, duration_sec=8.0
+                ),
+            },
+        ],
+    ]
+    assert expected == create(
+        origin={NodeId.head_l: 4, NodeId.pipette_right: 10},
+        target={NodeId.head_l: 2, NodeId.pipette_right: 20},
+        speed=0.25,
+        present_nodes=set(
+            (NodeId.gantry_x, NodeId.gantry_y, NodeId.head_r, NodeId.head_l)
+        ),
+    )
+
+
 def test_create_just_head() -> None:
     """It should create a move in head."""
     expected = [

--- a/hardware/tests/opentrons_hardware/hardware_control/test_network.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_network.py
@@ -1,0 +1,130 @@
+"""Test the network submodule."""
+import pytest
+import asyncio
+import datetime
+from typing import List, Callable
+from mock import AsyncMock
+from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
+from opentrons_ot3_firmware import ArbitrationId, ArbitrationIdParts, utils
+from opentrons_ot3_firmware.messages import (
+    MessageDefinition,
+    message_definitions,
+    payloads,
+)
+from opentrons_ot3_firmware.constants import NodeId
+
+from opentrons_hardware.hardware_control.network import probe
+
+
+@pytest.fixture
+def mock_can_messenger() -> AsyncMock:
+    """Mock communication."""
+    return AsyncMock(spec=CanMessenger)
+
+
+class MockStatusResponder:
+    """A harness that will automatically send status responses."""
+
+    def __init__(
+        self, mock_messenger: AsyncMock, respond_with_nodes: List[int]
+    ) -> None:
+        """Build the status responder."""
+        self._mock_messenger = mock_messenger
+        self._callbacks: List[Callable[[MessageDefinition, ArbitrationId], None]] = []
+        self._mock_messenger.add_listener.side_effect = self.add_callback
+        self._mock_messenger.send.side_effect = self.send
+        self._respond_with_nodes = respond_with_nodes
+
+    def add_callback(
+        self, callback: Callable[[MessageDefinition, ArbitrationId], None]
+    ) -> None:
+        """Wrap the add_callback mock method."""
+        self._callbacks.append(callback)
+
+    def send(self, node_id: NodeId, message: MessageDefinition) -> None:
+        """Wrap the send method to send predefined callbacks."""
+        assert self._callbacks
+        for callback in self._callbacks:
+            for node in self._respond_with_nodes:
+                response = message_definitions.GetStatusResponse(
+                    payload=payloads.GetStatusResponsePayload(
+                        status=utils.UInt8Field(0), data=utils.UInt32Field(0)
+                    )
+                )
+                asyncio.get_running_loop().call_soon(
+                    callback,
+                    response,
+                    ArbitrationId(
+                        parts=ArbitrationIdParts(
+                            function_code=0,
+                            node_id=NodeId.host.value,
+                            originating_node_id=node,
+                            message_id=response.message_id,
+                        )
+                    ),
+                )
+
+
+async def test_timeout_fires(mock_can_messenger: AsyncMock) -> None:
+    """Test that the timeout functionality works."""
+    then = datetime.datetime.utcnow()
+    # we expect a timeout, but a handled timeout, and we don't want to hang the tests
+    # if it didn't work, so wrap it in a wait_for of our own with a bigger timeout
+    # that will raise if it fails
+    nodes = await asyncio.wait_for(
+        probe(mock_can_messenger, set((NodeId.gantry_x, NodeId.gantry_y)), 0.5), 1.0
+    )
+    now = datetime.datetime.utcnow()
+    # we should have taken the full time allotted
+    assert (now - then).total_seconds() >= 0.5
+    # we should have no nodes
+    assert not nodes
+
+    # We should have sent a request
+    mock_can_messenger.send.assert_called_once_with(
+        node_id=NodeId.broadcast,
+        message=message_definitions.GetStatusRequest(payload=payloads.EmptyPayload()),
+    )
+    # we should have added a listener
+    mock_can_messenger.add_listener.assert_called_once()
+    # and we should have removed the same one
+    mock_can_messenger.remove_listener.assert_called_once_with(
+        # these accesses are 1) first call 2) positional args 3) first positional
+        mock_can_messenger.add_listener.call_args_list[0][0][0]
+    )
+
+
+async def test_completes_exact_equality(mock_can_messenger: AsyncMock) -> None:
+    """Test that if the exact specified nodes exist the probe works."""
+    _ = MockStatusResponder(mock_can_messenger, [NodeId.gantry_x.value])
+    # we should not get to the timeout, but if we did we wouldn't know because it
+    # doesn't raise, so wrap it in a smaller timeout so it will raise (it should
+    # complete basically instantly)
+    probed = await asyncio.wait_for(
+        probe(mock_can_messenger, set((NodeId.gantry_x,)), None), 2.0
+    )
+    assert probed == set((NodeId.gantry_x,))
+
+
+async def test_completes_more_than_expected(mock_can_messenger: AsyncMock) -> None:
+    """Test that if more than specified node exists, the probe works."""
+    _ = MockStatusResponder(
+        mock_can_messenger, [NodeId.gantry_y.value, NodeId.gantry_x.value]
+    )
+    # same deal with the timeout
+    probed = await asyncio.wait_for(
+        probe(mock_can_messenger, set((NodeId.gantry_x,)), None), 2.0
+    )
+    # we should get everything we prepped the network with
+    assert probed == set((NodeId.gantry_x, NodeId.gantry_y))
+
+
+async def test_handles_bad_node_ids(mock_can_messenger: AsyncMock) -> None:
+    """Test that invalid node ids are swalloed silently."""
+    _ = MockStatusResponder(mock_can_messenger, [0x01, NodeId.gantry_x.value])
+    # same deal with the timeout
+    probed = await asyncio.wait_for(
+        probe(mock_can_messenger, set((NodeId.gantry_x,)), None), 2.0
+    )
+    # we should get everything we prepped the network with and ignore the bad values
+    assert probed == set((NodeId.gantry_x,))


### PR DESCRIPTION
After splitting pipette node ids to handle having two pipettes at once, we were sending commands to all nodes and waiting for acknowledgements. That meant that if one or both pipettes wasn't connected (or if gantry stuff wasn't connected, though that's a little less important to handle in the grand scheme of things) then move commands would halt because they wouldn't get acknowledgements.

This adds a new hardware command to probe the network and uses it to find what's attached, then limits the generated commands down to the actual set of connected nodes.

The network is probed on boot and when `cache_instruments` is called. In the future, it needs to be integrated with the head's presence reporting, and should probably have some ongoing detection of missing nodes and health checks or something.