### PR TITLE
feat(app): add overFlow menu component and icon states

### DIFF
--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -23,5 +23,14 @@
   "gen2_num_slideout": "{{num}} mm",
   "set_engage_height_slideout_btn": "Set Engage Height",
   "tc_lid": "Lid",
-  "tc_block": "Block"
+  "tc_block": "Block",
+  "overflow_menu_engage": "Set engage height",
+  "overflow_menu_disengage": "Disengage module",
+  "overflow_menu_about": "About module",
+  "overflow_menu_lid_temp": "Set lid temperature",
+  "overflow_menu_set_block_temp": "Set block temperature",
+  "overflow_menu_deactivate_lid": "Deactivate lid",
+  "overflow_menu_deactivate_block": "Deactivate block",
+  "overflow_menu_mod_temp": "Set module temperature",
+  "overflow_menu_deactivate_temp": "Deactivate module"
 }

--- a/app/src/atoms/OverflowMenu/OverflowBtn.tsx
+++ b/app/src/atoms/OverflowMenu/OverflowBtn.tsx
@@ -43,7 +43,7 @@ export const OverflowBtn = (
         width="19"
         height="31"
         viewBox="0 0 19 31"
-        fill="#E3E3E3"
+        fill={COLORS.medGrey}
         xmlns="http://www.w3.org/2000/svg"
       >
         <circle
@@ -51,21 +51,21 @@ export const OverflowBtn = (
           cy="9.5"
           r="1.5"
           transform="rotate(90 9.5 9.5)"
-          fill="#8A8C8E"
+          fill={COLORS.darkGrey}
         />
         <circle
           cx="9.5"
           cy="15.5"
           r="1.5"
           transform="rotate(90 9.5 15.5)"
-          fill="#8A8C8E"
+          fill={COLORS.darkGrey}
         />
         <circle
           cx="9.5"
           cy="21.5"
           r="1.5"
           transform="rotate(90 9.5 21.5)"
-          fill="#8A8C8E"
+          fill={COLORS.darkGrey}
         />
       </svg>
       {props.children}

--- a/app/src/atoms/OverflowMenu/OverflowBtn.tsx
+++ b/app/src/atoms/OverflowMenu/OverflowBtn.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react'
+import styled from 'styled-components'
+import { Btn, COLORS, SPACING, PrimitiveComponent } from '@opentrons/components'
+
+export interface OverflowBtnProps {
+  onClick?: () => void
+  children?: React.ReactNode
+}
+
+type BtnComponent = PrimitiveComponent<'button'>
+const StyledOverflowIcon: BtnComponent = styled(Btn)`
+  border-radius: 4px;
+  max-height: ${SPACING.spacing6};
+
+  &:hover {
+    background-color: ${COLORS.medGrey};
+  }
+
+  &:active {
+    background-color: ${COLORS.lightBlue};
+  }
+
+  &:active circle {
+    fill: ${COLORS.blue};
+  }
+
+  &:disabled,
+  &.disabled {
+    fill-opacity: 0.5;
+  }
+`
+
+export const OverflowBtn = (props: OverflowBtnProps): JSX.Element | null => {
+  return (
+    <StyledOverflowIcon onClick={props.onClick}>
+      <svg
+        width="19"
+        height="31"
+        viewBox="0 0 19 31"
+        fill="#E3E3E3"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="9.5"
+          cy="9.5"
+          r="1.5"
+          transform="rotate(90 9.5 9.5)"
+          fill="#8A8C8E"
+        />
+        <circle
+          cx="9.5"
+          cy="15.5"
+          r="1.5"
+          transform="rotate(90 9.5 15.5)"
+          fill="#8A8C8E"
+        />
+        <circle
+          cx="9.5"
+          cy="21.5"
+          r="1.5"
+          transform="rotate(90 9.5 21.5)"
+          fill="#8A8C8E"
+        />
+      </svg>
+      {props.children}
+    </StyledOverflowIcon>
+  )
+}

--- a/app/src/atoms/OverflowMenu/OverflowBtn.tsx
+++ b/app/src/atoms/OverflowMenu/OverflowBtn.tsx
@@ -8,34 +8,28 @@ export interface OverflowBtnProps {
 
 type BtnComponent = PrimitiveComponent<'button'>
 const StyledOverflowIcon: BtnComponent = styled(Btn)`
-  padding: 3px;
-  border-radius: 4px;
+  border-radius: ${SPACING.spacing2};
   max-height: ${SPACING.spacing6};
 
   &:hover {
-    padding: 3px;
     background-color: ${COLORS.medGrey};
   }
 
   &:active {
-    padding: 3px;
     background-color: ${COLORS.lightBlue};
   }
 
   &:active circle {
-    padding: 3px;
     fill: ${COLORS.blue};
   }
 
   &:focus {
-    padding-top: 1px;
-    padding-right: 1px;
-    border: 3px solid ${COLORS.blueFocus};
+    outline: 3px solid ${COLORS.blueFocus};
+    outline-offset: -3px;
   }
 
   &:disabled,
   &.disabled {
-    padding: 3px;
     fill-opacity: 0.5;
   }
 `

--- a/app/src/atoms/OverflowMenu/OverflowBtn.tsx
+++ b/app/src/atoms/OverflowMenu/OverflowBtn.tsx
@@ -24,8 +24,7 @@ const StyledOverflowIcon: BtnComponent = styled(Btn)`
   }
 
   &:focus {
-    outline: 3px solid ${COLORS.blueFocus};
-    outline-offset: -3px;
+    box-shadow: 0 0 0 3px ${COLORS.blueFocus};
   }
 
   &:disabled,

--- a/app/src/atoms/OverflowMenu/OverflowBtn.tsx
+++ b/app/src/atoms/OverflowMenu/OverflowBtn.tsx
@@ -24,6 +24,10 @@ const StyledOverflowIcon: BtnComponent = styled(Btn)`
     fill: ${COLORS.blue};
   }
 
+  &:focus {
+    border: 3px solid ${COLORS.blueFocus};
+  }
+
   &:disabled,
   &.disabled {
     fill-opacity: 0.5;

--- a/app/src/atoms/OverflowMenu/OverflowBtn.tsx
+++ b/app/src/atoms/OverflowMenu/OverflowBtn.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components'
 import { Btn, COLORS, SPACING, PrimitiveComponent } from '@opentrons/components'
 
 export interface OverflowBtnProps {
-  onClick?: () => void
   children?: React.ReactNode
 }
 
@@ -34,9 +33,11 @@ const StyledOverflowIcon: BtnComponent = styled(Btn)`
   }
 `
 
-export const OverflowBtn = (props: OverflowBtnProps): JSX.Element | null => {
+export const OverflowBtn = (
+  props: React.ButtonHTMLAttributes<HTMLButtonElement> | OverflowBtnProps
+): JSX.Element | null => {
   return (
-    <StyledOverflowIcon onClick={props.onClick}>
+    <StyledOverflowIcon {...props}>
       <svg
         width="19"
         height="31"

--- a/app/src/atoms/OverflowMenu/OverflowBtn.tsx
+++ b/app/src/atoms/OverflowMenu/OverflowBtn.tsx
@@ -8,27 +8,34 @@ export interface OverflowBtnProps {
 
 type BtnComponent = PrimitiveComponent<'button'>
 const StyledOverflowIcon: BtnComponent = styled(Btn)`
+  padding: 3px;
   border-radius: 4px;
   max-height: ${SPACING.spacing6};
 
   &:hover {
+    padding: 3px;
     background-color: ${COLORS.medGrey};
   }
 
   &:active {
+    padding: 3px;
     background-color: ${COLORS.lightBlue};
   }
 
   &:active circle {
+    padding: 3px;
     fill: ${COLORS.blue};
   }
 
   &:focus {
+    padding-top: 1px;
+    padding-right: 1px;
     border: 3px solid ${COLORS.blueFocus};
   }
 
   &:disabled,
   &.disabled {
+    padding: 3px;
     fill-opacity: 0.5;
   }
 `

--- a/app/src/atoms/OverflowMenu/OverflowMenuBtn.tsx
+++ b/app/src/atoms/OverflowMenu/OverflowMenuBtn.tsx
@@ -12,7 +12,7 @@ import type { PrimitiveComponent } from '@opentrons/components'
 type BtnComponent = PrimitiveComponent<'button'>
 
 export const OverflowMenuBtn: BtnComponent = styled(Btn)`
-  width: 9.562rem;
+  width: ${TYPOGRAPHY.overflowMenuWidth};
   text-align: ${TEXT_ALIGN_LEFT};
   font-size: ${TYPOGRAPHY.fontSizeP};
   padding-bottom: ${TYPOGRAPHY.fontSizeH6};

--- a/app/src/atoms/OverflowMenu/OverflowMenuBtn.tsx
+++ b/app/src/atoms/OverflowMenu/OverflowMenuBtn.tsx
@@ -1,12 +1,18 @@
 import styled from 'styled-components'
-import { Btn, COLORS, TEXT_ALIGN_LEFT, TYPOGRAPHY } from '@opentrons/components'
+import {
+  SPACING,
+  Btn,
+  COLORS,
+  TEXT_ALIGN_LEFT,
+  TYPOGRAPHY,
+} from '@opentrons/components'
 
 import type { PrimitiveComponent } from '@opentrons/components'
 
 type BtnComponent = PrimitiveComponent<'button'>
 
 export const OverflowMenuBtn: BtnComponent = styled(Btn)`
-  width: 153px;
+  width: 9.562rem;
   text-align: ${TEXT_ALIGN_LEFT};
   font-size: ${TYPOGRAPHY.fontSizeP};
   padding-bottom: ${TYPOGRAPHY.fontSizeH6};
@@ -14,7 +20,7 @@ export const OverflowMenuBtn: BtnComponent = styled(Btn)`
   color: ${COLORS.darkBlack};
   padding-left: ${TYPOGRAPHY.fontSizeLabel};
   padding-right: ${TYPOGRAPHY.fontSizeLabel};
-  padding-top: 8px;
+  padding-top: ${SPACING.spacing3};
 
   &:hover {
     background-color: ${COLORS.lightBlue};
@@ -22,7 +28,7 @@ export const OverflowMenuBtn: BtnComponent = styled(Btn)`
 
   &:focus,
   &:active {
-    font-weight: 600;
+    font-weight: ${TYPOGRAPHY.fontWeightSemiBold};
   }
 
   &:disabled,

--- a/app/src/atoms/OverflowMenu/OverflowMenuBtn.tsx
+++ b/app/src/atoms/OverflowMenu/OverflowMenuBtn.tsx
@@ -1,0 +1,32 @@
+import styled from 'styled-components'
+import { Btn, COLORS, TEXT_ALIGN_LEFT, TYPOGRAPHY } from '@opentrons/components'
+
+import type { PrimitiveComponent } from '@opentrons/components'
+
+type BtnComponent = PrimitiveComponent<'button'>
+
+export const OverflowMenuBtn: BtnComponent = styled(Btn)`
+  width: 153px;
+  text-align: ${TEXT_ALIGN_LEFT};
+  font-size: ${TYPOGRAPHY.fontSizeP};
+  padding-bottom: ${TYPOGRAPHY.fontSizeH6};
+  background-color: transparent;
+  color: ${COLORS.darkBlack};
+  padding-left: ${TYPOGRAPHY.fontSizeLabel};
+  padding-right: ${TYPOGRAPHY.fontSizeLabel};
+  padding-top: 8px;
+
+  &:hover {
+    background-color: ${COLORS.lightBlue};
+  }
+
+  &:focus,
+  &:active {
+    font-weight: 600;
+  }
+
+  &:disabled,
+  &.disabled {
+    color: ${COLORS.greyDisabled};
+  }
+`

--- a/app/src/atoms/OverflowMenu/__tests__/OverflowBtn.test.tsx
+++ b/app/src/atoms/OverflowMenu/__tests__/OverflowBtn.test.tsx
@@ -54,8 +54,8 @@ describe('OverflowBtn', () => {
     })
 
     expect(getByRole('button')).toHaveStyleRule(
-      'outline',
-      '3px solid #deecff',
+      'box-shadow',
+      '0 0 0 3px #deecff',
       {
         modifier: ':focus',
       }

--- a/app/src/atoms/OverflowMenu/__tests__/OverflowBtn.test.tsx
+++ b/app/src/atoms/OverflowMenu/__tests__/OverflowBtn.test.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react'
+import { COLORS, renderWithProviders } from '@opentrons/components'
+import 'jest-styled-components'
+import { OverflowBtn } from '../OverflowBtn'
+import { fireEvent } from '@testing-library/react'
+
+const render = (props: React.ComponentProps<typeof OverflowBtn>) => {
+  return renderWithProviders(<OverflowBtn {...props} />)[0]
+}
+
+describe('OverflowBtn', () => {
+  it('renders a clickable button', () => {
+    const handleClick = jest.fn()
+    const { getByRole } = render({
+      onClick: handleClick,
+    })
+
+    const button = getByRole('button')
+    fireEvent.click(button)
+    expect(handleClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders a hover state', () => {
+    const { getByRole } = render({
+      onClick: jest.fn(),
+    })
+
+    expect(getByRole('button')).toHaveStyleRule(
+      'background-color',
+      COLORS.medGrey,
+      {
+        modifier: ':hover',
+      }
+    )
+  })
+
+  it('renders an active state', () => {
+    const { getByRole } = render({
+      onClick: jest.fn(),
+    })
+
+    expect(getByRole('button')).toHaveStyleRule(
+      'background-color',
+      COLORS.lightBlue,
+      {
+        modifier: ':active',
+      }
+    )
+  })
+
+  it('renders a focus state', () => {
+    const { getByRole } = render({
+      onClick: jest.fn(),
+    })
+
+    expect(getByRole('button')).toHaveStyleRule('border', '3px solid #deecff', {
+      modifier: ':focus',
+    })
+  })
+
+  it('renders a disabled state', () => {
+    const { getByRole } = render({
+      onClick: jest.fn(),
+    })
+
+    expect(getByRole('button')).toHaveStyleRule('fill-opacity', '0.5', {
+      modifier: ':disabled',
+    })
+  })
+})

--- a/app/src/atoms/OverflowMenu/__tests__/OverflowBtn.test.tsx
+++ b/app/src/atoms/OverflowMenu/__tests__/OverflowBtn.test.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
-import { COLORS, renderWithProviders } from '@opentrons/components'
-import 'jest-styled-components'
-import { OverflowBtn } from '../OverflowBtn'
 import { fireEvent } from '@testing-library/react'
+import 'jest-styled-components'
+import { COLORS, renderWithProviders } from '@opentrons/components'
+import { OverflowBtn } from '../OverflowBtn'
 
 const render = (props: React.ComponentProps<typeof OverflowBtn>) => {
   return renderWithProviders(<OverflowBtn {...props} />)[0]
@@ -53,9 +53,13 @@ describe('OverflowBtn', () => {
       onClick: jest.fn(),
     })
 
-    expect(getByRole('button')).toHaveStyleRule('border', '3px solid #deecff', {
-      modifier: ':focus',
-    })
+    expect(getByRole('button')).toHaveStyleRule(
+      'outline',
+      '3px solid #deecff',
+      {
+        modifier: ':focus',
+      }
+    )
   })
 
   it('renders a disabled state', () => {

--- a/app/src/atoms/OverflowMenu/__tests__/OverflowMenu.test.tsx
+++ b/app/src/atoms/OverflowMenu/__tests__/OverflowMenu.test.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+import { renderWithProviders } from '@opentrons/components'
+import { OverflowMenu } from '..'
+
+const render = (props: React.ComponentProps<typeof OverflowMenu>) => {
+  return renderWithProviders(<OverflowMenu {...props} />)[0]
+}
+
+describe('OverflowMenu', () => {
+  let props: React.ComponentProps<typeof OverflowMenu>
+  beforeEach(() => {
+    props = {
+      children: <div>child</div>,
+    }
+  })
+
+  it('renders a child', () => {
+    const { getByText } = render(props)
+    getByText('child')
+  })
+})

--- a/app/src/atoms/OverflowMenu/index.tsx
+++ b/app/src/atoms/OverflowMenu/index.tsx
@@ -4,6 +4,7 @@ import {
   COLORS,
   POSITION_ABSOLUTE,
   SPACING_1,
+  TYPOGRAPHY,
 } from '@opentrons/components'
 
 interface OverflowMenuProps {
@@ -13,8 +14,8 @@ interface OverflowMenuProps {
 export const OverflowMenu = (props: OverflowMenuProps): JSX.Element | null => {
   return (
     <Box
-      borderRadius="4px 4px 0px 0px"
-      boxShadow="0px 1px 3px rgba(0, 0, 0, 0.2)"
+      borderRadius={TYPOGRAPHY.borderRadiusS}
+      boxShadow={TYPOGRAPHY.boxShadowS}
       position={POSITION_ABSOLUTE}
       backgroundColor={COLORS.white}
       top="2.5rem"

--- a/app/src/atoms/OverflowMenu/index.tsx
+++ b/app/src/atoms/OverflowMenu/index.tsx
@@ -18,7 +18,7 @@ export const OverflowMenu = (props: OverflowMenuProps): JSX.Element | null => {
       boxShadow={TYPOGRAPHY.boxShadowS}
       position={POSITION_ABSOLUTE}
       backgroundColor={COLORS.white}
-      top="2.5rem"
+      top="2.6rem"
       right={`calc(50% + ${SPACING_1})`}
     >
       {props.children}

--- a/app/src/atoms/OverflowMenu/index.tsx
+++ b/app/src/atoms/OverflowMenu/index.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react'
-import { Box, COLORS } from '@opentrons/components'
+import {
+  Box,
+  COLORS,
+  POSITION_ABSOLUTE,
+  SPACING_1,
+} from '@opentrons/components'
 
 interface OverflowMenuProps {
   children: React.ReactNode
@@ -10,9 +15,10 @@ export const OverflowMenu = (props: OverflowMenuProps): JSX.Element | null => {
     <Box
       borderRadius="4px 4px 0px 0px"
       boxShadow="0px 1px 3px rgba(0, 0, 0, 0.2)"
-      z-index="top"
-      position="absolute"
+      position={POSITION_ABSOLUTE}
       backgroundColor={COLORS.white}
+      top="2.5rem"
+      right={`calc(50% + ${SPACING_1})`}
     >
       {props.children}
     </Box>

--- a/app/src/atoms/OverflowMenu/index.tsx
+++ b/app/src/atoms/OverflowMenu/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Box, COLORS} from '@opentrons/components'
+import { Box, COLORS } from '@opentrons/components'
 
 interface OverflowMenuProps {
   children: React.ReactNode

--- a/app/src/atoms/OverflowMenu/index.tsx
+++ b/app/src/atoms/OverflowMenu/index.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react'
+import { Box, COLORS} from '@opentrons/components'
+
+interface OverflowMenuProps {
+  children: React.ReactNode
+}
+
+export const OverflowMenu = (props: OverflowMenuProps): JSX.Element | null => {
+  return (
+    <Box
+      borderRadius="4px 4px 0px 0px"
+      boxShadow="0px 1px 3px rgba(0, 0, 0, 0.2)"
+      z-index="top"
+      position="absolute"
+      backgroundColor={COLORS.white}
+    >
+      {props.children}
+    </Box>
+  )
+}

--- a/app/src/atoms/Slideout/index.tsx
+++ b/app/src/atoms/Slideout/index.tsx
@@ -14,6 +14,8 @@ import {
   JUSTIFY_SPACE_BETWEEN,
   ALIGN_CENTER,
   COLORS,
+  POSITION_ABSOLUTE,
+  TYPOGRAPHY,
 } from '@opentrons/components'
 
 import { Divider } from '../structure'
@@ -70,12 +72,11 @@ export const Slideout = (props: Props): JSX.Element | null => {
     <>
       <Box
         css={props.isExpanded ? EXPANDED_STYLE : COLLAPSED_STYLE}
-        position="absolute"
+        position={POSITION_ABSOLUTE}
         right="0"
         top="0"
         backgroundColor={COLORS.white}
-        //  TODO Immediately: add this boxShadow to the new typography standards once it is made!
-        boxShadow="0px 3px 6px rgba(0, 0, 0, 0.23)"
+        boxShadow={TYPOGRAPHY.boxShadowM}
         borderRadius={SPACING_1}
       >
         <Flex padding={SPACING_3} flexDirection={DIRECTION_COLUMN}>
@@ -84,8 +85,7 @@ export const Slideout = (props: Props): JSX.Element | null => {
             justifyContent={JUSTIFY_SPACE_BETWEEN}
           >
             <Text
-              //  TODO immediately: add this fontSize to typography standard
-              fontSize="0.937rem"
+              fontSize={TYPOGRAPHY.fontSizeH2}
               fontWeight={FONT_WEIGHT_SEMIBOLD}
               data-testid={`Slideout_title_${props.title}`}
             >
@@ -93,7 +93,7 @@ export const Slideout = (props: Props): JSX.Element | null => {
             </Text>
             <Flex alignItems={ALIGN_CENTER}>
               <Btn
-                size={'1.5rem'}
+                size={TYPOGRAPHY.lineHeight24}
                 onClick={() => setHideSlideOut(true)}
                 aria-label="exit"
                 data-testid={`Slideout_icon_close_${props.title}`}
@@ -103,7 +103,7 @@ export const Slideout = (props: Props): JSX.Element | null => {
             </Flex>
           </Flex>
         </Flex>
-        <Divider margin={SPACING_1} color="#e3e3e3" />
+        <Divider margin={SPACING_1} color={COLORS.medGrey} />
         <Flex
           padding={SPACING_3}
           flexDirection={DIRECTION_COLUMN}

--- a/app/src/atoms/Slideout/index.tsx
+++ b/app/src/atoms/Slideout/index.tsx
@@ -13,9 +13,9 @@ import {
   SPACING_3,
   JUSTIFY_SPACE_BETWEEN,
   ALIGN_CENTER,
+  COLORS,
 } from '@opentrons/components'
 
-import { Portal } from '../../App/__mocks__/portal'
 import { Divider } from '../structure'
 
 interface Props {
@@ -27,7 +27,7 @@ interface Props {
 
 const EXPANDED_STYLE = css`
   animation-duration: 300ms;
-  animation-name: slidein;
+  animation-name: slidein;s
   overflow: hidden;
   max-width: 19.5rem;
 
@@ -68,48 +68,50 @@ export const Slideout = (props: Props): JSX.Element | null => {
 
   return (
     <>
-      <Portal>
-        <Box
-          css={props.isExpanded ? EXPANDED_STYLE : COLLAPSED_STYLE}
-          //  TODO Immediately: add this boxShadow to the new typography standards once it is made!
-          boxShadow="0px 3px 6px rgba(0, 0, 0, 0.23)"
-          borderRadius={SPACING_1}
-        >
-          <Flex padding={SPACING_3} flexDirection={DIRECTION_COLUMN}>
-            <Flex
-              flexDirection={DIRECTION_ROW}
-              justifyContent={JUSTIFY_SPACE_BETWEEN}
+      <Box
+        css={props.isExpanded ? EXPANDED_STYLE : COLLAPSED_STYLE}
+        position="absolute"
+        right="0"
+        top="0"
+        backgroundColor={COLORS.white}
+        //  TODO Immediately: add this boxShadow to the new typography standards once it is made!
+        boxShadow="0px 3px 6px rgba(0, 0, 0, 0.23)"
+        borderRadius={SPACING_1}
+      >
+        <Flex padding={SPACING_3} flexDirection={DIRECTION_COLUMN}>
+          <Flex
+            flexDirection={DIRECTION_ROW}
+            justifyContent={JUSTIFY_SPACE_BETWEEN}
+          >
+            <Text
+              //  TODO immediately: add this fontSize to typography standard
+              fontSize="0.937rem"
+              fontWeight={FONT_WEIGHT_SEMIBOLD}
+              data-testid={`Slideout_title_${props.title}`}
             >
-              <Text
-                //  TODO immediately: add this fontSize to typography standard
-                fontSize="0.937rem"
-                fontWeight={FONT_WEIGHT_SEMIBOLD}
-                data-testid={`Slideout_title_${props.title}`}
+              {props.title}
+            </Text>
+            <Flex alignItems={ALIGN_CENTER}>
+              <Btn
+                size={'1.5rem'}
+                onClick={() => setHideSlideOut(true)}
+                aria-label="exit"
+                data-testid={`Slideout_icon_close_${props.title}`}
               >
-                {props.title}
-              </Text>
-              <Flex alignItems={ALIGN_CENTER}>
-                <Btn
-                  size={'1.5rem'}
-                  onClick={() => setHideSlideOut(true)}
-                  aria-label="exit"
-                  data-testid={`Slideout_icon_close_${props.title}`}
-                >
-                  <Icon name={'close'} />
-                </Btn>
-              </Flex>
+                <Icon name={'close'} />
+              </Btn>
             </Flex>
           </Flex>
-          <Divider margin={SPACING_1} color="#e3e3e3" />
-          <Flex
-            padding={SPACING_3}
-            flexDirection={DIRECTION_COLUMN}
-            data-testid={`Slideout_body_${props.title}`}
-          >
-            {props.children}
-          </Flex>
-        </Box>
-      </Portal>
+        </Flex>
+        <Divider margin={SPACING_1} color="#e3e3e3" />
+        <Flex
+          padding={SPACING_3}
+          flexDirection={DIRECTION_COLUMN}
+          data-testid={`Slideout_body_${props.title}`}
+        >
+          {props.children}
+        </Flex>
+      </Box>
     </>
   )
 }

--- a/app/src/atoms/Slideout/index.tsx
+++ b/app/src/atoms/Slideout/index.tsx
@@ -27,7 +27,7 @@ interface Props {
 
 const EXPANDED_STYLE = css`
   animation-duration: 300ms;
-  animation-name: slidein;s
+  animation-name: slidein;
   overflow: hidden;
   max-width: 19.5rem;
 

--- a/app/src/organisms/Devices/ModuleCard/MagneticModuleSlideout.tsx
+++ b/app/src/organisms/Devices/ModuleCard/MagneticModuleSlideout.tsx
@@ -18,6 +18,8 @@ import {
   C_BLUE,
   TEXT_TRANSFORM_NONE,
   JUSTIFY_FLEX_END,
+  COLORS,
+  TYPOGRAPHY,
 } from '@opentrons/components'
 import {
   getModuleDisplayName,
@@ -113,7 +115,7 @@ export const MagneticModuleSlideout = (
       <React.Fragment>
         <Text
           fontWeight={FONT_WEIGHT_REGULAR}
-          fontSize="0.6875rem"
+          fontSize={TYPOGRAPHY.fontSizeP}
           paddingTop={SPACING_1}
           data-testid={`Mag_Slideout_body_text_${module.model}`}
         >
@@ -123,7 +125,7 @@ export const MagneticModuleSlideout = (
           })}
         </Text>
         <Text
-          fontSize={'10px'}
+          fontSize={TYPOGRAPHY.fontSizeH6}
           fontWeight={FONT_WEIGHT_SEMIBOLD}
           paddingTop={SPACING_3}
           textTransform={TEXT_TRANSFORM_UPPERCASE}
@@ -137,7 +139,7 @@ export const MagneticModuleSlideout = (
           flexDirection={DIRECTION_ROW}
           justifyContent={JUSTIFY_SPACE_BETWEEN}
           fontWeight={FONT_WEIGHT_REGULAR}
-          fontSize="0.6875rem"
+          fontSize={TYPOGRAPHY.fontSizeP}
           padding={SPACING_3}
         >
           <Flex
@@ -169,9 +171,9 @@ export const MagneticModuleSlideout = (
         >
           <Text
             fontWeight={FONT_WEIGHT_REGULAR}
-            fontSize={'10px'}
+            fontSize={TYPOGRAPHY.fontSizeH6}
             //  TODO immediately: change to typography standard color when its made
-            color="#8A8C8E"
+            color={COLORS.darkGrey}
           >
             {t('engage_height_slideout')}
           </Text>

--- a/app/src/organisms/Devices/ModuleCard/ModuleOverflowMenu.tsx
+++ b/app/src/organisms/Devices/ModuleCard/ModuleOverflowMenu.tsx
@@ -30,6 +30,7 @@ export const ModuleOverflowMenu = (
   switch (module.type) {
     case 'magneticModuleType': {
       setSetting = t('overflow_menu_engage')
+      //  TODO immediately: add functionality to turnOffSetting once slideouts are complete
       turnOffSetting = t('overflow_menu_disengage')
       slideout = (
         <MagneticModuleSlideout module={module} isExpanded={showSlideout} />

--- a/app/src/organisms/Devices/ModuleCard/ModuleOverflowMenu.tsx
+++ b/app/src/organisms/Devices/ModuleCard/ModuleOverflowMenu.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { Flex, DIRECTION_COLUMN } from '@opentrons/components'
+import { THERMOCYCLER_MODULE_TYPE } from '@opentrons/shared-data'
+import { OverflowMenu } from '../../../atoms/OverflowMenu'
+import { OverflowMenuBtn } from '../../../atoms/OverflowMenu/OverflowMenuBtn'
+import { MagneticModuleSlideout } from './MagneticModuleSlideout'
+
+import type { AttachedModule } from '../../../redux/modules/types'
+
+interface ModuleOverflowMenuProps {
+  module: AttachedModule
+}
+
+export const ModuleOverflowMenu = (
+  props: ModuleOverflowMenuProps
+): JSX.Element | null => {
+  const { t } = useTranslation('device_details')
+  const { module } = props
+  const [showSlideout, setShowSlideout] = React.useState(false)
+
+  let setSetting: string = ''
+  let turnOffSetting: string = ''
+  let slideout = <div></div>
+
+  switch (module.type) {
+    case 'magneticModuleType': {
+      setSetting = t('overflow_menu_engage')
+      turnOffSetting = t('overflow_menu_disengage')
+      slideout = (
+        <MagneticModuleSlideout module={module} isExpanded={showSlideout} />
+      )
+      break
+    }
+    case 'temperatureModuleType': {
+      setSetting = t('overflow_menu_mod_temp')
+      turnOffSetting = t('overflow_menu_deactivate_temp')
+      slideout = (
+        //  TODO immediately: attach actual slideout!
+        <div></div>
+      )
+      break
+    }
+    case 'thermocyclerModuleType': {
+      setSetting = t('overflow_menu_lid_temp')
+      turnOffSetting = t('overflow_menu_set_block_temp')
+      slideout = (
+        //  TODO immediately: attach actual slideout!
+        <div></div>
+      )
+      break
+    }
+  }
+  return (
+    <React.Fragment>
+      {showSlideout && slideout}
+      <OverflowMenu>
+        <Flex flexDirection={DIRECTION_COLUMN}>
+          <OverflowMenuBtn
+            onClick={() => setShowSlideout(true)}
+            data-testid={`module_setting_${module.model}`}
+          >
+            {setSetting ?? turnOffSetting}
+          </OverflowMenuBtn>
+          {module.type === THERMOCYCLER_MODULE_TYPE ? (
+            <OverflowMenuBtn
+              onClick={() => setShowSlideout(true)}
+              data-testid={`thermo_block_setting_${module.model}`}
+            >
+              {t('overflow_menu_set_block_temp')}
+            </OverflowMenuBtn>
+          ) : null}
+          <OverflowMenuBtn
+            data-testid={`about_module_${module.model}`}
+            //  TODO immediately - add actual module overflow menu
+            onClick={() => console.log('about module overflow menu')}
+          >
+            {t('overflow_menu_about')}
+          </OverflowMenuBtn>
+        </Flex>
+      </OverflowMenu>
+    </React.Fragment>
+  )
+}

--- a/app/src/organisms/Devices/ModuleCard/ModuleOverflowMenu.tsx
+++ b/app/src/organisms/Devices/ModuleCard/ModuleOverflowMenu.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Flex, DIRECTION_COLUMN } from '@opentrons/components'
+import {
+  Flex,
+  DIRECTION_COLUMN,
+  POSITION_RELATIVE,
+} from '@opentrons/components'
 import { THERMOCYCLER_MODULE_TYPE } from '@opentrons/shared-data'
 import { OverflowMenu } from '../../../atoms/OverflowMenu'
 import { OverflowMenuBtn } from '../../../atoms/OverflowMenu/OverflowMenuBtn'
@@ -54,31 +58,33 @@ export const ModuleOverflowMenu = (
   return (
     <React.Fragment>
       {showSlideout && slideout}
-      <OverflowMenu>
-        <Flex flexDirection={DIRECTION_COLUMN}>
-          <OverflowMenuBtn
-            onClick={() => setShowSlideout(true)}
-            data-testid={`module_setting_${module.model}`}
-          >
-            {setSetting ?? turnOffSetting}
-          </OverflowMenuBtn>
-          {module.type === THERMOCYCLER_MODULE_TYPE ? (
+      <Flex position={POSITION_RELATIVE}>
+        <OverflowMenu>
+          <Flex flexDirection={DIRECTION_COLUMN}>
             <OverflowMenuBtn
               onClick={() => setShowSlideout(true)}
-              data-testid={`thermo_block_setting_${module.model}`}
+              data-testid={`module_setting_${module.model}`}
             >
-              {t('overflow_menu_set_block_temp')}
+              {setSetting ?? turnOffSetting}
             </OverflowMenuBtn>
-          ) : null}
-          <OverflowMenuBtn
-            data-testid={`about_module_${module.model}`}
-            //  TODO immediately - add actual module overflow menu
-            onClick={() => console.log('about module overflow menu')}
-          >
-            {t('overflow_menu_about')}
-          </OverflowMenuBtn>
-        </Flex>
-      </OverflowMenu>
+            {module.type === THERMOCYCLER_MODULE_TYPE ? (
+              <OverflowMenuBtn
+                onClick={() => setShowSlideout(true)}
+                data-testid={`thermo_block_setting_${module.model}`}
+              >
+                {t('overflow_menu_set_block_temp')}
+              </OverflowMenuBtn>
+            ) : null}
+            <OverflowMenuBtn
+              data-testid={`about_module_${module.model}`}
+              //  TODO immediately - add actual module overflow menu
+              onClick={() => console.log('about module overflow menu')}
+            >
+              {t('overflow_menu_about')}
+            </OverflowMenuBtn>
+          </Flex>
+        </OverflowMenu>
+      </Flex>
     </React.Fragment>
   )
 }

--- a/app/src/organisms/Devices/ModuleCard/__tests__/ModuleCard.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/ModuleCard.test.tsx
@@ -121,7 +121,9 @@ describe('ModuleCard', () => {
     const { getByRole, getByText } = render({
       module: mockMagneticModule,
     })
-    const overflowButton = getByRole('button')
+    const overflowButton = getByRole('button', {
+      name: /overflow/i,
+    })
     getByText('Magnetic Module GEN1')
     fireEvent.click(overflowButton)
     expect(overflowButton).not.toBeDisabled()

--- a/app/src/organisms/Devices/ModuleCard/__tests__/ModuleCard.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/ModuleCard.test.tsx
@@ -121,9 +121,7 @@ describe('ModuleCard', () => {
     const { getByRole, getByText } = render({
       module: mockMagneticModule,
     })
-    const overflowButton = getByRole('button', {
-      name: /overflow/i,
-    })
+    const overflowButton = getByRole('button')
     getByText('Magnetic Module GEN1')
     fireEvent.click(overflowButton)
     expect(overflowButton).not.toBeDisabled()

--- a/app/src/organisms/Devices/ModuleCard/__tests__/ModuleCard.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/ModuleCard.test.tsx
@@ -6,6 +6,7 @@ import { i18n } from '../../../../i18n'
 import { MagneticModuleData } from '../MagneticModuleData'
 import { TemperatureModuleData } from '../TemperatureModuleData'
 import { ThermocyclerModuleData } from '../ThermocyclerModuleData'
+import { ModuleOverflowMenu } from '../ModuleOverflowMenu'
 import { ModuleCard } from '..'
 import {
   mockMagneticModule,
@@ -18,12 +19,16 @@ import type { MagneticModule } from '../../../../redux/modules/types'
 jest.mock('../MagneticModuleData')
 jest.mock('../TemperatureModuleData')
 jest.mock('../ThermocyclerModuleData')
+jest.mock('../ModuleOverflowMenu')
 
 const mockMagneticModuleData = MagneticModuleData as jest.MockedFunction<
   typeof MagneticModuleData
 >
 const mockTemperatureModuleData = TemperatureModuleData as jest.MockedFunction<
   typeof TemperatureModuleData
+>
+const mockModuleOverflowMenu = ModuleOverflowMenu as jest.MockedFunction<
+  typeof ModuleOverflowMenu
 >
 
 const mockThermocyclerModuleData = ThermocyclerModuleData as jest.MockedFunction<
@@ -58,6 +63,7 @@ describe('ModuleCard', () => {
     mockThermocyclerModuleData.mockReturnValue(
       <div>Mock Thermocycler Module Data</div>
     )
+    mockModuleOverflowMenu.mockReturnValue(<div>mock module overflow menu</div>)
   })
 
   afterEach(() => {
@@ -111,17 +117,16 @@ describe('ModuleCard', () => {
     getByAltText('thermocyclerModuleV1')
   })
 
-  //  TODO Immediately: add more details to this test when overflow button has more functionality
-  it('renders 3 dot button icon and is clickable', () => {
+  it('renders kebab icon and is clickable', () => {
     const { getByRole, getByText } = render({
       module: mockMagneticModule,
     })
-
     const overflowButton = getByRole('button', {
       name: /overflow/i,
     })
     getByText('Magnetic Module GEN1')
     fireEvent.click(overflowButton)
     expect(overflowButton).not.toBeDisabled()
+    getByText('mock module overflow menu')
   })
 })

--- a/app/src/organisms/Devices/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react'
+import { renderWithProviders } from '@opentrons/components'
+import { fireEvent } from '@testing-library/react'
+import { i18n } from '../../../../i18n'
+import {
+  mockMagneticModule,
+  mockTemperatureModuleGen2,
+  mockThermocycler,
+} from '../../../../redux/modules/__fixtures__'
+import { ModuleOverflowMenu } from '../ModuleOverflowMenu'
+import { MagneticModuleSlideout } from '../MagneticModuleSlideout'
+
+jest.mock('../MagneticModuleSlideout')
+
+const mockMagneticModuleSlideout = MagneticModuleSlideout as jest.MockedFunction<
+  typeof MagneticModuleSlideout
+>
+
+const render = (props: React.ComponentProps<typeof ModuleOverflowMenu>) => {
+  return renderWithProviders(<ModuleOverflowMenu {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+describe('ModuleOverflowMenu', () => {
+  let props: React.ComponentProps<typeof ModuleOverflowMenu>
+  beforeEach(() => {
+    props = {
+      module: mockMagneticModule,
+    }
+    mockMagneticModuleSlideout.mockReturnValue(
+      <div>Mock mag module slideout</div>
+    )
+  })
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('renders the correct magnetic module menu', () => {
+    const { getByRole, getByText } = render(props)
+    const buttonSetting = getByRole('button', { name: 'Set engage height' })
+    expect(buttonSetting).toBeEnabled()
+    expect(buttonSetting).toHaveStyle(`
+      background-color: transparent;
+    `)
+    fireEvent.click(buttonSetting)
+    getByText('Mock mag module slideout')
+    const buttonAbout = getByRole('button', { name: 'About module' })
+    fireEvent.click(buttonAbout)
+    expect(buttonAbout).toBeEnabled()
+    expect(getByText('About module')).toHaveStyle('color: #16212D')
+  })
+  //  todo imemdiately: add on to following 2 tests when their slideout component is made
+  it('renders the correct temperature module menu', () => {
+    props = {
+      module: mockTemperatureModuleGen2,
+    }
+    const { getByRole } = render(props)
+    const buttonSetting = getByRole('button', {
+      name: 'Set module temperature',
+    })
+    fireEvent.click(buttonSetting)
+    const buttonAbout = getByRole('button', { name: 'About module' })
+    fireEvent.click(buttonAbout)
+    expect(buttonAbout).toBeEnabled()
+    expect(buttonSetting).toBeEnabled()
+  })
+  it('renders the correct TC module menu', () => {
+    props = {
+      module: mockThermocycler,
+    }
+    const { getByRole } = render(props)
+    const buttonSetting1 = getByRole('button', { name: 'Set lid temperature' })
+    fireEvent.click(buttonSetting1)
+    const buttonAbout = getByRole('button', { name: 'About module' })
+    fireEvent.click(buttonAbout)
+    const buttonSetting2 = getByRole('button', {
+      name: 'Set block temperature',
+    })
+    fireEvent.click(buttonSetting2)
+    expect(buttonAbout).toBeEnabled()
+    expect(buttonSetting1).toBeEnabled()
+    expect(buttonSetting2).toBeEnabled()
+  })
+})

--- a/app/src/organisms/Devices/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { renderWithProviders } from '@opentrons/components'
+import { COLORS, renderWithProviders } from '@opentrons/components'
 import { fireEvent } from '@testing-library/react'
 import { i18n } from '../../../../i18n'
 import {
@@ -49,6 +49,17 @@ describe('ModuleOverflowMenu', () => {
     fireEvent.click(buttonAbout)
     expect(buttonAbout).toBeEnabled()
     expect(getByText('About module')).toHaveStyle('color: #16212D')
+  })
+  it('renders hover state color correctly', () => {
+    const { getByRole } = render(props)
+    const buttonSetting = getByRole('button', { name: 'Set engage height' })
+    expect(buttonSetting).toHaveStyleRule(
+      'background-color',
+      COLORS.lightBlue,
+      {
+        modifier: ':hover',
+      }
+    )
   })
   //  todo imemdiately: add on to following 2 tests when their slideout component is made
   it('renders the correct temperature module menu', () => {

--- a/app/src/organisms/Devices/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
@@ -70,16 +70,18 @@ describe('ModuleOverflowMenu', () => {
       module: mockThermocycler,
     }
     const { getByRole } = render(props)
-    const buttonSetting1 = getByRole('button', { name: 'Set lid temperature' })
-    fireEvent.click(buttonSetting1)
+    const buttonSettingLid = getByRole('button', {
+      name: 'Set lid temperature',
+    })
+    fireEvent.click(buttonSettingLid)
     const buttonAbout = getByRole('button', { name: 'About module' })
     fireEvent.click(buttonAbout)
-    const buttonSetting2 = getByRole('button', {
+    const buttonSettingBlock = getByRole('button', {
       name: 'Set block temperature',
     })
-    fireEvent.click(buttonSetting2)
+    fireEvent.click(buttonSettingBlock)
     expect(buttonAbout).toBeEnabled()
-    expect(buttonSetting1).toBeEnabled()
-    expect(buttonSetting2).toBeEnabled()
+    expect(buttonSettingLid).toBeEnabled()
+    expect(buttonSettingBlock).toBeEnabled()
   })
 })

--- a/app/src/organisms/Devices/ModuleCard/index.tsx
+++ b/app/src/organisms/Devices/ModuleCard/index.tsx
@@ -84,7 +84,6 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
 
   return (
     <React.Fragment>
-      {showOverflowMenu && <ModuleOverflowMenu module={module} />}
       <Flex
         backgroundColor={C_BRIGHT_GRAY}
         borderRadius={SPACING_1}
@@ -123,14 +122,15 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
 
         <Box alignSelf={ALIGN_START} padding={SPACING_1}>
           <OverflowBtn
+            aria-label="overflow"
             onClick={() => {
               showOverflowMenu
                 ? setShowOverflowMenu(false)
                 : setShowOverflowMenu(true)
             }}
-            aria-label="overflow"
           />
         </Box>
+        {showOverflowMenu && <ModuleOverflowMenu module={module} />}
       </Flex>
     </React.Fragment>
   )

--- a/app/src/organisms/Devices/ModuleCard/index.tsx
+++ b/app/src/organisms/Devices/ModuleCard/index.tsx
@@ -120,7 +120,9 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
           </Flex>
         </Box>
 
-        <Box alignSelf={ALIGN_START} padding={SPACING_1}>
+        {/* The padding is small to align with designs for background-color and border-radius for the different states */}
+
+        <Box alignSelf={ALIGN_START} padding="1px">
           <OverflowBtn
             aria-label="overflow"
             onClick={() => {

--- a/app/src/organisms/Devices/ModuleCard/index.tsx
+++ b/app/src/organisms/Devices/ModuleCard/index.tsx
@@ -23,6 +23,7 @@ import { ModuleIcon } from '../ModuleIcon'
 import { MagneticModuleData } from './MagneticModuleData'
 import { TemperatureModuleData } from './TemperatureModuleData'
 import { ThermocyclerModuleData } from './ThermocyclerModuleData'
+import { ModuleOverflowMenu } from './ModuleOverflowMenu'
 
 import magneticModule from '../../../assets/images/magnetic_module_gen_2_transparent.svg'
 import temperatureModule from '../../../assets/images/temp_deck_gen_2_transparent.svg'
@@ -38,6 +39,7 @@ interface ModuleCardProps {
 export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
   const { t } = useTranslation('device_details')
   const { module } = props
+  const [showOverflowMenu, setShowOverflowMenu] = React.useState(false)
 
   let image = ''
   let moduleData: JSX.Element = <div></div>
@@ -82,47 +84,57 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
   }
 
   return (
-    <Flex
-      backgroundColor={C_BRIGHT_GRAY}
-      borderRadius={SPACING_1}
-      marginBottom={SPACING_2}
-      marginLeft={SPACING_2}
-      width={'20rem'}
-    >
-      <Box
-        padding={`${SPACING_3} ${SPACING_2} ${SPACING_3} ${SPACING_2}`}
-        width="100%"
+    <React.Fragment>
+      {showOverflowMenu && <ModuleOverflowMenu module={module} />}
+      <Flex
+        backgroundColor={C_BRIGHT_GRAY}
+        borderRadius={SPACING_1}
+        marginBottom={SPACING_2}
+        marginLeft={SPACING_2}
+        width={'20rem'}
       >
-        <Flex flexDirection={DIRECTION_ROW} paddingRight={SPACING_2}>
-          <img src={image} alt={module.model} />
-          <Flex flexDirection={DIRECTION_COLUMN} paddingLeft={SPACING_2}>
-            <Text
-              textTransform={TEXT_TRANSFORM_UPPERCASE}
-              color={C_HARBOR_GRAY}
-              fontWeight={FONT_WEIGHT_REGULAR}
-              fontSize={FONT_SIZE_CAPTION}
-              paddingBottom={SPACING_1}
-            >
-              {t(module.usbPort.port === null ? 'usb_hub' : 'usb_port', {
-                port: module.usbPort.hub ?? module.usbPort.port,
-              })}
-            </Text>
-            <Flex paddingBottom={SPACING_1}>
-              <ModuleIcon moduleType={module.type} />
-              <Text fontSize={TYPOGRAPHY.fontSizeP}>
-                {getModuleDisplayName(module.model)}
+        <Box
+          padding={`${SPACING_3} ${SPACING_2} ${SPACING_3} ${SPACING_2}`}
+          width="100%"
+        >
+          <Flex flexDirection={DIRECTION_ROW} paddingRight={SPACING_2}>
+            <img src={image} alt={module.model} />
+            <Flex flexDirection={DIRECTION_COLUMN} paddingLeft={SPACING_2}>
+              <Text
+                textTransform={TEXT_TRANSFORM_UPPERCASE}
+                color={C_HARBOR_GRAY}
+                fontWeight={FONT_WEIGHT_REGULAR}
+                fontSize={FONT_SIZE_CAPTION}
+                paddingBottom={SPACING_1}
+              >
+                {t(module.usbPort.port === null ? 'usb_hub' : 'usb_port', {
+                  port: module.usbPort.hub ?? module.usbPort.port,
+                })}
               </Text>
+              <Flex paddingBottom={SPACING_1}>
+                <ModuleIcon moduleType={module.type} />
+                <Text fontSize={TYPOGRAPHY.fontSizeP}>
+                  {getModuleDisplayName(module.model)}
+                </Text>
+              </Flex>
+              {moduleData}
             </Flex>
-            {moduleData}
           </Flex>
-        </Flex>
-      </Box>
+        </Box>
 
-      <Box alignSelf={ALIGN_START} padding={SPACING_1}>
-        <Btn onClick={() => console.log('overflow')} aria-label="overflow">
-          <img src={overflowIcon} />
-        </Btn>
-      </Box>
-    </Flex>
+        <Box alignSelf={ALIGN_START} padding={SPACING_1}>
+          <Btn
+            onClick={() => {
+              showOverflowMenu
+                ? setShowOverflowMenu(false)
+                : setShowOverflowMenu(true)
+            }}
+            aria-label="overflow"
+          >
+            <img src={overflowIcon} />
+          </Btn>
+        </Box>
+      </Flex>
+    </React.Fragment>
   )
 }

--- a/app/src/organisms/Devices/ModuleCard/index.tsx
+++ b/app/src/organisms/Devices/ModuleCard/index.tsx
@@ -18,6 +18,7 @@ import {
   TYPOGRAPHY,
 } from '@opentrons/components'
 import { getModuleDisplayName } from '@opentrons/shared-data'
+import { OverflowBtn } from '../../../atoms/OverflowMenu/OverflowBtn'
 import { ModuleIcon } from '../ModuleIcon'
 import { MagneticModuleData } from './MagneticModuleData'
 import { TemperatureModuleData } from './TemperatureModuleData'
@@ -29,7 +30,6 @@ import temperatureModule from '../../../assets/images/temp_deck_gen_2_transparen
 import thermoModule from '../../../assets/images/thermocycler_open_transparent.svg'
 
 import type { AttachedModule } from '../../../redux/modules/types'
-import { OverflowBtn } from '../../../atoms/OverflowMenu/OverflowBtn'
 
 interface ModuleCardProps {
   module: AttachedModule
@@ -124,9 +124,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
           <OverflowBtn
             aria-label="overflow"
             onClick={() => {
-              showOverflowMenu
-                ? setShowOverflowMenu(false)
-                : setShowOverflowMenu(true)
+              setShowOverflowMenu(prevShowOverflowMenu => !prevShowOverflowMenu)
             }}
           />
         </Box>

--- a/app/src/organisms/Devices/ModuleCard/index.tsx
+++ b/app/src/organisms/Devices/ModuleCard/index.tsx
@@ -11,6 +11,7 @@ import {
   SPACING_3,
   TEXT_TRANSFORM_UPPERCASE,
   SPACING_1,
+  SPACING,
   C_BRIGHT_GRAY,
   C_HARBOR_GRAY,
   FONT_WEIGHT_REGULAR,
@@ -103,13 +104,13 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
                 color={C_HARBOR_GRAY}
                 fontWeight={FONT_WEIGHT_REGULAR}
                 fontSize={FONT_SIZE_CAPTION}
-                paddingBottom={SPACING_1}
+                paddingBottom={SPACING.spacing2}
               >
                 {t(module.usbPort.port === null ? 'usb_hub' : 'usb_port', {
                   port: module.usbPort.hub ?? module.usbPort.port,
                 })}
               </Text>
-              <Flex paddingBottom={SPACING_1}>
+              <Flex paddingBottom={SPACING.spacing2}>
                 <ModuleIcon moduleType={module.type} />
                 <Text fontSize={TYPOGRAPHY.fontSizeP}>
                   {getModuleDisplayName(module.model)}
@@ -120,9 +121,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
           </Flex>
         </Box>
 
-        {/* The padding is small to align with designs for background-color and border-radius for the different states */}
-
-        <Box alignSelf={ALIGN_START} padding="1px">
+        <Box alignSelf={ALIGN_START} padding={SPACING.spacing2}>
           <OverflowBtn
             aria-label="overflow"
             onClick={() => {

--- a/app/src/organisms/Devices/ModuleCard/index.tsx
+++ b/app/src/organisms/Devices/ModuleCard/index.tsx
@@ -13,7 +13,6 @@ import {
   SPACING_1,
   C_BRIGHT_GRAY,
   C_HARBOR_GRAY,
-  Btn,
   FONT_WEIGHT_REGULAR,
   FONT_SIZE_CAPTION,
   TYPOGRAPHY,
@@ -28,9 +27,9 @@ import { ModuleOverflowMenu } from './ModuleOverflowMenu'
 import magneticModule from '../../../assets/images/magnetic_module_gen_2_transparent.svg'
 import temperatureModule from '../../../assets/images/temp_deck_gen_2_transparent.svg'
 import thermoModule from '../../../assets/images/thermocycler_open_transparent.svg'
-import overflowIcon from '../../../assets/images/overflow_icon.svg'
 
 import type { AttachedModule } from '../../../redux/modules/types'
+import { OverflowBtn } from '../../../atoms/OverflowMenu/OverflowBtn'
 
 interface ModuleCardProps {
   module: AttachedModule
@@ -123,16 +122,14 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
         </Box>
 
         <Box alignSelf={ALIGN_START} padding={SPACING_1}>
-          <Btn
+          <OverflowBtn
             onClick={() => {
               showOverflowMenu
                 ? setShowOverflowMenu(false)
                 : setShowOverflowMenu(true)
             }}
             aria-label="overflow"
-          >
-            <img src={overflowIcon} />
-          </Btn>
+          />
         </Box>
       </Flex>
     </React.Fragment>

--- a/components/src/ui-style-constants/typography.ts
+++ b/components/src/ui-style-constants/typography.ts
@@ -38,6 +38,13 @@ export const textAlignRight = 'right'
 export const textAlignCenter = 'center'
 export const textAlignJustify = 'justify'
 
+//  Overflow menu constants
+export const borderRadiusS = '4px 4px 0px 0px'
+export const boxShadowS = '0px 1px 3px rgba(0, 0, 0, 0.2)'
+
+//  Slideout constants
+export const boxShadowM = '0px 3px 6px rgba(0, 0, 0, 0.23)'
+
 // Default font styles, color agnositic for first pass
 export const h1Default = css`
   font-size: ${fontSizeH1};
@@ -97,10 +104,3 @@ export const labelSemiBold = css`
   font-weight: ${fontWeightSemiBold};
   line-height: ${lineHeight12};
 `
-
-//  Overflow menu constants
-export const borderRadiusS = '4px 4px 0px 0px'
-export const boxShadowS = '0px 1px 3px rgba(0, 0, 0, 0.2)'
-
-//  Slideout constants
-export const boxShadowM = '0px 3px 6px rgba(0, 0, 0, 0.23)'

--- a/components/src/ui-style-constants/typography.ts
+++ b/components/src/ui-style-constants/typography.ts
@@ -97,3 +97,10 @@ export const labelSemiBold = css`
   font-weight: ${fontWeightSemiBold};
   line-height: ${lineHeight12};
 `
+
+//  Overflow menu constants
+export const borderRadiusS = '4px 4px 0px 0px'
+export const boxShadowS = '0px 1px 3px rgba(0, 0, 0, 0.2)'
+
+//  Slideout constants
+export const boxShadowM = '0px 3px 6px rgba(0, 0, 0, 0.23)'

--- a/components/src/ui-style-constants/typography.ts
+++ b/components/src/ui-style-constants/typography.ts
@@ -45,6 +45,9 @@ export const boxShadowS = '0px 1px 3px rgba(0, 0, 0, 0.2)'
 //  Slideout constants
 export const boxShadowM = '0px 3px 6px rgba(0, 0, 0, 0.23)'
 
+//  Overflow menu btn width
+export const overflowMenuWidth = '9.562rem'
+
 // Default font styles, color agnositic for first pass
 export const h1Default = css`
   font-size: ${fontSizeH1};


### PR DESCRIPTION
closes #9362 

Co-Authored with @sakibh 

# Overview

This PR creates the shared `overflowMenu` `overflowBtn` and `overflowIcon` components and includes all the different states.

This PR also includes the overflow menus for the modules. Note: the buttons are all clickable but only the magnetic module `engage height` menu is properly setup right now.

<img width="717" alt="Screen Shot 2022-02-08 at 5 41 00 PM" src="https://user-images.githubusercontent.com/66035149/153087795-31a85d81-f2ca-4705-95a8-c76edd45d393.png">

# Changelog

- created several shared components
- created a generic `ModuleOverflowMenu` component that is versatile enough to take in all module types

# Review requests

- examine the `overflowMenu` component, it should render in the top right corner directly underneath the overflow icon, and it renders when you click on the overflow icon.
- examine the `overflowBtn` and `overflowIcon`, it should render the multiple states correctly
- If you have a Magnetic module plugged in, it should render 2 options in the overflow menu, both clickable and with the "engage height" opening a slideout on the right
- If you have the TC plugged in, it should render 3 options in the overflow menu, all clickable but not doing anything yet
- if you have the temp deck plugged in, it should render 2 options in the overflow menu, both clickable but not doing anything yet
- the overflow menus should be closeable when clicking on the overflow icon again
- review selectors throughout the `ModuleOverflowMenu`

Note: all except for the magnetic module slideout is not complete yet! Those will be completed in follow up PRs

# Risk assessment

low
