### PR TITLE
feat(robot-server,api,app): When adding a jog command over HTTP, wait for it to complete before returning

### DIFF
--- a/api-client/src/runs/commands/createCommand.ts
+++ b/api-client/src/runs/commands/createCommand.ts
@@ -3,17 +3,20 @@ import { POST, request } from '../../request'
 import type { ResponsePromise } from '../../request'
 import type { HostConfig } from '../../types'
 import type { CommandData } from '../types'
+import type { CreateCommandParams } from './types'
 import type { CreateCommand } from '@opentrons/shared-data/protocol/types/schemaV6'
 
 export function createCommand(
   config: HostConfig,
   runId: string,
-  data: CreateCommand
+  data: CreateCommand,
+  params?: CreateCommandParams
 ): ResponsePromise<CommandData> {
   return request<CommandData, { data: CreateCommand }>(
     POST,
     `/runs/${runId}/commands`,
     { data },
-    config
+    config,
+    params
   )
 }

--- a/api-client/src/runs/commands/types.ts
+++ b/api-client/src/runs/commands/types.ts
@@ -39,3 +39,8 @@ export interface CommandsData {
   meta: GetCommandsParams & { totalLength: number }
   links: CommandsLinks
 }
+
+export interface CreateCommandParams {
+  waitUntilComplete?: boolean
+  timeout?: number
+}

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -135,6 +135,19 @@ class ProtocolEngine:
         self._action_dispatcher.dispatch(action)
         return self._state_store.commands.get(command_id)
 
+    async def wait_for_command(self, command_id: str) -> None:
+        """Wait for a command to be completed."""
+        is_already_complete = self._state_store.commands.get_is_complete(
+            command_id=command_id
+        )
+        # If the command is already complete, don't wait,
+        # because we'd only wake up on a subsequent state update,
+        # and we don't know that there would ever be one.
+        if not is_already_complete:
+            await self._state_store.wait_for(
+                self._state_store.commands.get_is_complete, command_id=command_id
+            )
+
     async def add_and_execute_command(self, request: CommandCreate) -> Command:
         """Add a command to the queue and wait for it to complete.
 

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/__tests__/useLabwarePositionCheck.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/__tests__/useLabwarePositionCheck.test.tsx
@@ -130,12 +130,6 @@ describe('useLabwarePositionCheck', () => {
   })
   describe('jog', () => {
     it('should NOT queue up a new jog command when a previous jog command has NOT completed', async () => {
-      when(mockUseCurrentRunCommands)
-        .calledWith()
-        .mockReturnValue([
-          { commandType: 'moveRelative', status: 'running' } as any,
-        ])
-
       const { result, waitForNextUpdate } = renderHook(
         () => useLabwarePositionCheck(() => null, {}),
         { wrapper }
@@ -151,11 +145,6 @@ describe('useLabwarePositionCheck', () => {
         1 as 1,
         2,
       ]
-      const [SECOND_JOG_AXIS, SECOND_JOG_DIRECTION, SECOND_JOG_DISTANCE] = [
-        'y' as 'y',
-        -1 as -1,
-        3,
-      ]
       if ('error' in result.current) {
         throw new Error('error should not be present')
       }
@@ -163,11 +152,6 @@ describe('useLabwarePositionCheck', () => {
         FIRST_JOG_AXIS,
         FIRST_JOG_DIRECTION,
         FIRST_JOG_DISTANCE
-      )
-      result.current.jog(
-        SECOND_JOG_AXIS,
-        SECOND_JOG_DIRECTION,
-        SECOND_JOG_DISTANCE
       )
       expect(mockCreateCommand).toHaveBeenCalledWith({
         runId: MOCK_RUN_ID,
@@ -177,19 +161,6 @@ describe('useLabwarePositionCheck', () => {
             pipetteId: 'MOCK_PIPETTE_ID',
             distance: FIRST_JOG_DIRECTION * FIRST_JOG_DISTANCE,
             axis: FIRST_JOG_AXIS,
-          },
-        },
-        waitUntilComplete: true,
-        timeout: 10000,
-      })
-      expect(mockCreateCommand).not.toHaveBeenCalledWith({
-        runId: MOCK_RUN_ID,
-        command: {
-          commandType: 'moveRelative',
-          params: {
-            pipetteId: 'MOCK_PIPETTE_ID',
-            distance: SECOND_JOG_DIRECTION * SECOND_JOG_DISTANCE,
-            axis: SECOND_JOG_AXIS,
           },
         },
         waitUntilComplete: true,

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/__tests__/useLabwarePositionCheck.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/__tests__/useLabwarePositionCheck.test.tsx
@@ -179,6 +179,8 @@ describe('useLabwarePositionCheck', () => {
             axis: FIRST_JOG_AXIS,
           },
         },
+        waitUntilComplete: true,
+        timeout: 10000,
       })
       expect(mockCreateCommand).not.toHaveBeenCalledWith({
         runId: MOCK_RUN_ID,
@@ -190,73 +192,8 @@ describe('useLabwarePositionCheck', () => {
             axis: SECOND_JOG_AXIS,
           },
         },
-      })
-    })
-    it('should queue up a new jog command when the previous jog command has succeeded', async () => {
-      when(mockUseCurrentRunCommands)
-        .calledWith()
-        .mockReturnValue([
-          {
-            id: MOCK_COMMAND_ID,
-            commandType: 'moveRelative',
-            status: 'succeeded',
-          } as any,
-        ])
-      const { result, waitForNextUpdate } = renderHook(
-        () => useLabwarePositionCheck(() => null, {}),
-        { wrapper }
-      )
-      if ('error' in result.current) {
-        throw new Error('error should not be present')
-      }
-      const { beginLPC } = result.current
-      beginLPC()
-      await waitForNextUpdate()
-      const [FIRST_JOG_AXIS, FIRST_JOG_DIRECTION, FIRST_JOG_DISTANCE] = [
-        'x' as 'x',
-        1 as 1,
-        2,
-      ]
-      const [SECOND_JOG_AXIS, SECOND_JOG_DIRECTION, SECOND_JOG_DISTANCE] = [
-        'y' as 'y',
-        -1 as -1,
-        3,
-      ]
-      if ('error' in result.current) {
-        throw new Error('error should not be present')
-      }
-      result.current.jog(
-        FIRST_JOG_AXIS,
-        FIRST_JOG_DIRECTION,
-        FIRST_JOG_DISTANCE
-      )
-      await waitForNextUpdate()
-      result.current.jog(
-        SECOND_JOG_AXIS,
-        SECOND_JOG_DIRECTION,
-        SECOND_JOG_DISTANCE
-      )
-      expect(mockCreateCommand).toHaveBeenCalledWith({
-        runId: MOCK_RUN_ID,
-        command: {
-          commandType: 'moveRelative',
-          params: {
-            pipetteId: 'MOCK_PIPETTE_ID',
-            distance: FIRST_JOG_DIRECTION * FIRST_JOG_DISTANCE,
-            axis: FIRST_JOG_AXIS,
-          },
-        },
-      })
-      expect(mockCreateCommand).toHaveBeenCalledWith({
-        runId: MOCK_RUN_ID,
-        command: {
-          commandType: 'moveRelative',
-          params: {
-            pipetteId: 'MOCK_PIPETTE_ID',
-            distance: SECOND_JOG_DIRECTION * SECOND_JOG_DISTANCE,
-            axis: SECOND_JOG_AXIS,
-          },
-        },
+        waitUntilComplete: true,
+        timeout: 10000,
       })
     })
   })
@@ -314,72 +251,7 @@ describe('useLabwarePositionCheck', () => {
         },
       })
     })
-    it('should NOT execute the next command if a jog command is in flight', async () => {
-      when(mockUseSteps)
-        .calledWith()
-        .mockReturnValue([
-          {
-            commands: [
-              {
-                commandType: 'pickUpTip',
-                params: {
-                  pipetteId: MOCK_PIPETTE_ID,
-                  labwareId: MOCK_LABWARE_ID,
-                },
-              },
-              {
-                commandType: 'dropTip',
-                params: {
-                  pipetteId: MOCK_PIPETTE_ID,
-                  labwareId: MOCK_LABWARE_ID,
-                },
-              },
-            ],
-            labwareId: MOCK_LABWARE_ID,
-            section: 'PRIMARY_PIPETTE_TIPRACKS',
-          } as LabwarePositionCheckStep,
-        ])
-
-      const { result, waitForNextUpdate } = renderHook(
-        () => useLabwarePositionCheck(() => null, {}),
-        { wrapper }
-      )
-      if ('error' in result.current) {
-        throw new Error('error should not be present')
-      }
-      const { beginLPC } = result.current
-      beginLPC() // beginLPC calls the first command
-      await waitForNextUpdate()
-      const { jog } = result.current
-      const [JOG_AXIS, JOG_DIRECTION, JOG_DISTANCE] = ['x' as 'x', 1 as 1, 2]
-      jog(JOG_AXIS, JOG_DIRECTION, JOG_DISTANCE)
-      await waitForNextUpdate()
-      const { proceed } = result.current
-      proceed()
-      // this is from the begin LPC call
-      expect(mockCreateCommand).toHaveBeenCalledWith({
-        runId: MOCK_RUN_ID,
-        command: {
-          commandType: 'pickUpTip',
-          params: {
-            pipetteId: MOCK_PIPETTE_ID,
-            labwareId: MOCK_LABWARE_ID,
-          },
-        },
-      })
-      // no drop tip call should get logged since jog is in flight
-      expect(mockCreateCommand).not.toHaveBeenCalledWith({
-        runId: MOCK_RUN_ID,
-        command: {
-          commandType: 'dropTip',
-          params: expect.objectContaining({
-            pipetteId: MOCK_PIPETTE_ID,
-            labwareId: MOCK_LABWARE_ID,
-          }),
-        },
-      })
-    })
-    it('should execute the next command if no jog command is in flight', async () => {
+    it('should execute the next command', async () => {
       when(mockUseSteps)
         .calledWith()
         .mockReturnValue([
@@ -429,7 +301,7 @@ describe('useLabwarePositionCheck', () => {
           },
         },
       })
-      // drop tip call should get logged since no jog is in flight
+      // drop tip call should get logged
       expect(mockCreateCommand).toHaveBeenCalledWith({
         runId: MOCK_RUN_ID,
         command: {

--- a/react-api-client/src/runs/__tests__/useCreateCommandMutation.test.tsx
+++ b/react-api-client/src/runs/__tests__/useCreateCommandMutation.test.tsx
@@ -37,7 +37,7 @@ describe('useCreateCommandMutation hook', () => {
   it('should issue the given command to the given run when callback is called', async () => {
     when(mockUseHost).calledWith().mockReturnValue(HOST_CONFIG)
     when(mockCreateCommand)
-      .calledWith(HOST_CONFIG, RUN_ID_1, mockAnonLoadCommand)
+      .calledWith(HOST_CONFIG, RUN_ID_1, mockAnonLoadCommand, {})
       .mockResolvedValue({ data: 'something' } as any)
 
     const { result, waitFor } = renderHook(() => useCreateCommandMutation(), {

--- a/react-api-client/src/runs/__tests__/useCreateCommandMutation.test.tsx
+++ b/react-api-client/src/runs/__tests__/useCreateCommandMutation.test.tsx
@@ -56,4 +56,33 @@ describe('useCreateCommandMutation hook', () => {
     })
     expect(result.current.data).toBe('something')
   })
+  it('should pass waitUntilComplete and timeout through if given command', async () => {
+    const waitUntilComplete = true
+    const timeout = 2000
+    when(mockUseHost).calledWith().mockReturnValue(HOST_CONFIG)
+    when(mockCreateCommand)
+      .calledWith(HOST_CONFIG, RUN_ID_1, mockAnonLoadCommand, {
+        waitUntilComplete,
+        timeout,
+      })
+      .mockResolvedValue({ data: 'something' } as any)
+
+    const { result, waitFor } = renderHook(() => useCreateCommandMutation(), {
+      wrapper,
+    })
+
+    expect(result.current.data).toBeUndefined()
+    act(() => {
+      result.current.createCommand({
+        runId: RUN_ID_1,
+        command: mockAnonLoadCommand,
+        waitUntilComplete,
+        timeout,
+      })
+    })
+    await waitFor(() => {
+      return result.current.data != null
+    })
+    expect(result.current.data).toBe('something')
+  })
 })

--- a/react-api-client/src/runs/useCreateCommandMutation.ts
+++ b/react-api-client/src/runs/useCreateCommandMutation.ts
@@ -6,39 +6,48 @@ import type {
   UseMutationOptions,
   UseMutateAsyncFunction,
 } from 'react-query'
-import type { CommandData, HostConfig } from '@opentrons/api-client'
+import type {
+  CommandData,
+  HostConfig,
+  CreateCommandParams,
+} from '@opentrons/api-client'
 import type { CreateCommand } from '@opentrons/shared-data/protocol/types/schemaV6'
 
-interface CreateCommandParams {
+interface CreateCommandMutateParams extends CreateCommandParams {
   runId: string
   command: CreateCommand
+  waitUntilComplete?: boolean
+  timeout?: number
 }
 
 export type UseCreateCommandMutationResult = UseMutationResult<
   CommandData,
   unknown,
-  CreateCommandParams
+  CreateCommandMutateParams
 > & {
   createCommand: UseMutateAsyncFunction<
     CommandData,
     unknown,
-    CreateCommandParams
+    CreateCommandMutateParams
   >
 }
 
 export type UseCreateCommandMutationOptions = UseMutationOptions<
   CommandData,
   unknown,
-  CreateCommandParams
+  CreateCommandMutateParams
 >
 
 export function useCreateCommandMutation(): UseCreateCommandMutationResult {
   const host = useHost()
   const queryClient = useQueryClient()
 
-  const mutation = useMutation<CommandData, unknown, CreateCommandParams>(
-    ({ runId, command }) =>
-      createCommand(host as HostConfig, runId, command).then(response => {
+  const mutation = useMutation<CommandData, unknown, CreateCommandMutateParams>(
+    ({ runId, command, waitUntilComplete, timeout }) =>
+      createCommand(host as HostConfig, runId, command, {
+        waitUntilComplete,
+        timeout,
+      }).then(response => {
         queryClient
           .invalidateQueries([host, 'runs'])
           .catch((e: Error) =>

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -109,7 +109,7 @@ async def create_run_command(
         try:
             await wait_for(
                 engine_store.engine.wait_for_command(command_id=added_command.id),
-                timeout=timeout,
+                timeout=timeout/1000,
             )
             completed_command = engine_store.get_state(run.id).commands.get(
                 command_id=added_command.id

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -1,8 +1,6 @@
 """Router for /runs commands endpoints."""
 from asyncio import wait_for, TimeoutError as AsyncioTimeoutError
 from datetime import datetime
-from fastapi import APIRouter, Depends, status
-from pydantic import BaseModel, Field
 from typing import Optional, Union
 from typing_extensions import Final, Literal
 

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -102,7 +102,7 @@ async def create_run_command(
             "If the timeout triggers, the command will still be returned"
             " with a `201` HTTP status code."
             " Inspect the returned command's `status` to detect the timeout."
-        )
+        ),
     ),
     engine_store: EngineStore = Depends(get_engine_store),
     run: Run = Depends(get_run_data_from_url),
@@ -135,7 +135,7 @@ async def create_run_command(
         try:
             await wait_for(
                 engine_store.engine.wait_for_command(command_id=added_command.id),
-                timeout=timeout/1000,
+                timeout=timeout / 1000,
             )
             completed_command = engine_store.get_state(run.id).commands.get(
                 command_id=added_command.id

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -3,7 +3,7 @@ from asyncio import wait_for, TimeoutError as AsyncioTimeoutError
 from typing import Optional, Union
 from typing_extensions import Final, Literal
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Query, status
 from pydantic import BaseModel, Field
 
 from opentrons.protocol_engine import commands as pe_commands, errors as pe_errors
@@ -59,7 +59,6 @@ class CommandCollectionLinks(BaseModel):
     )
 
 
-# todo(mm, 2021-09-23): Should this accept a list of commands, instead of just one?
 @commands_router.post(
     path="/runs/{runId}/commands",
     summary="Enqueue a protocol command",

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -101,6 +101,68 @@ async def test_create_run_command_not_current(
     assert exc_info.value.content["errors"][0]["id"] == "RunStopped"
 
 
+async def test_create_run_command_blocking_completion(
+    decoy: Decoy, engine_store: EngineStore
+) -> None:
+    """It should return the completed command once the command is completed."""
+    run = Run.construct(
+        id="run-id",
+        protocolId=None,
+        createdAt=datetime(year=2021, month=1, day=1),
+        status=EngineStatus.RUNNING,
+        current=True,
+        actions=[],
+        errors=[],
+        pipettes=[],
+        labware=[],
+        labwareOffsets=[],
+    )
+
+    command_request = pe_commands.PauseCreate(
+        params=pe_commands.PauseParams(message="Hello")
+    )
+
+    command_once_added = pe_commands.Pause(
+        id="command-id",
+        key="command-key",
+        createdAt=datetime(year=2021, month=1, day=1),
+        status=pe_commands.CommandStatus.QUEUED,
+        params=pe_commands.PauseParams(message="Hello"),
+        result=None,
+    )
+
+    command_once_completed = pe_commands.Pause(
+        id="command-id",
+        key="command-key",
+        createdAt=datetime(year=2021, month=1, day=1),
+        status=pe_commands.CommandStatus.SUCCEEDED,
+        params=pe_commands.PauseParams(message="Hello"),
+        result=pe_commands.PauseResult(),
+    )
+
+    engine_state = decoy.mock(cls=StateView)
+    decoy.when(engine_store.get_state("run-id")).then_return(engine_state)
+    decoy.when(engine_store.engine.add_command(command_request)).then_return(
+        command_once_added
+    )
+    decoy.when(engine_state.commands.get("command-id")).then_return(
+        command_once_completed
+    )
+
+    result = await create_run_command(
+        request_body=RequestModel(data=command_request),
+        waitUntilComplete=True,
+        timeout=999,
+        engine_store=engine_store,
+        run=run,
+    )
+
+    decoy.verify(await engine_store.engine.wait_for_command("command-id"))
+
+    assert result.content.data == command_once_completed
+    assert result.status_code == 201
+
+
 async def test_get_run_commands(decoy: Decoy, engine_store: EngineStore) -> None:
     """It should return a list of all commands in a run."""
     run = Run.construct(

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -60,6 +60,7 @@ async def test_create_run_command(decoy: Decoy, engine_store: EngineStore) -> No
 
     result = await create_run_command(
         request_body=RequestModel(data=command_request),
+        waitUntilComplete=False,
         engine_store=engine_store,
         run=run,
     )
@@ -93,6 +94,7 @@ async def test_create_run_command_not_current(
     with pytest.raises(ApiError) as exc_info:
         await create_run_command(
             request_body=RequestModel(data=command_request),
+            waitUntilComplete=False,
             engine_store=engine_store,
             run=run,
         )


### PR DESCRIPTION
# Overview

Before this PR, to execute a live command, the client has to:

1. `POST` the new command.
2. Poll repeatedly until the new command has completed.

This PR adds an option to wait for the command to complete before returning, eliminating the need to poll. The intended use case is to improve the end-to-end responsiveness of user-initiated jog commands during the Labware Position Check. This is a stopgap until the HTTP API has a more general notifications mechanism.

# Changelog

# Review requests

You can smoke-test this on a robot by manually issuing `POST` requests:

1. `POST` a new live protocol.
2. `POST` a `home` command. Leaving the `waitUntilComplete` query param `false` or unspecified, it should return immediately, showing a `queued` command.
3. `POST` another `home` command with `waitUntilComplete=true`, and, optionally, a timeout. The HTTP request should only return after the robot stops moving, showing a `succeeded` command.

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
