### PR TITLE
fix(api): Fix module ordering 

### DIFF
--- a/api/src/opentrons/algorithms/dfs.py
+++ b/api/src/opentrons/algorithms/dfs.py
@@ -34,17 +34,21 @@ class DFS(Generic[VertexName]):
         """
         return self._graph
 
-    def dfs(self) -> Set[VertexName]:
+    def dfs(self) -> List[VertexName]:
         """Depth first search.
 
         :returns: the set of visited vertices
         in depth first search order.
         """
+        visited_check: List[VertexName] = []
         visited_vertices: Set[VertexName] = set()
         for node in self.graph.graph:
             if node.name not in visited_vertices:
-                visited_vertices.add(node.name)
+                visited_check.append(node.name)
+            visited_vertices.add(node.name)
             for neighbor in node.neighbors:
                 if neighbor not in visited_vertices:
-                    visited_vertices.add(neighbor)
-        return visited_vertices
+                    visited_check.append(neighbor)
+                visited_vertices.add(neighbor)
+
+        return visited_check

--- a/api/src/opentrons/algorithms/graph.py
+++ b/api/src/opentrons/algorithms/graph.py
@@ -59,7 +59,6 @@ class Vertex(Generic[VertexName]):
         :param vertex_name: The name of the neighbor
         """
         self._neighbors.append(vertex_name)
-        self._neighbors.sort()
 
     def remove_neighbor(self, vertex_name: VertexName) -> None:
         """Remove a neighbor.
@@ -94,21 +93,20 @@ class Graph(Generic[VertexName]):
     # https://github.com/python/typing/issues/760
     def __init__(
         self,
-        sorted_graph: List[Vertex[VertexName]],
+        graph: List[Vertex[VertexName]],
         lookup_table: Dict[VertexName, Vertex[VertexName]],
         sort_by: Callable[[Vertex[VertexName]], VertexName],
     ) -> None:
         """Graph class initializer.
 
-        :param sorted_graph: The initial graph, sorted
-        and converted to vertex objects.
+        :param graph: The initial graph, converted to vertex objects.
         :param lookup_table: A lookup table keyed by vertex
         name and with a value of the vertex object
         :param sort_by: The callable function used to sort
         the graph nodes in priority order.
         """
         self._sort_by = sort_by
-        self._sorted_graph = sorted_graph
+        self._graph = graph
         self._lookup_table = lookup_table
 
     @classmethod
@@ -124,14 +122,13 @@ class Graph(Generic[VertexName]):
         in priority order.
         :returns: A graph class
         """
-        sorted_graph = []
+        built_graph = []
         lookup_table = {}
         for vertex in graph:
             vertex_obj = cls.build_vertex(vertex)
             lookup_table[vertex.name] = vertex_obj
-            sorted_graph.append(vertex_obj)
-        sorted_graph.sort(key=sort_by)
-        return cls(sorted_graph, lookup_table, sort_by)
+            built_graph.append(vertex_obj)
+        return cls(built_graph, lookup_table, sort_by)
 
     @property
     def graph(self) -> Sequence[Vertex[VertexName]]:
@@ -139,7 +136,7 @@ class Graph(Generic[VertexName]):
 
         :returns: A list of sorted vertex objects
         """
-        return self._sorted_graph
+        return self._graph
 
     @staticmethod
     def build_vertex(vertex: GenericNode[VertexName]) -> Vertex[VertexName]:
@@ -150,7 +147,6 @@ class Graph(Generic[VertexName]):
         :param vertex: A node dataclass
         :returns: vertex object
         """
-        vertex.sub_names.sort()
         return Vertex(vertex, vertex.sub_names)
 
     def add_vertex(self, vertex: GenericNode[VertexName]) -> None:
@@ -161,8 +157,7 @@ class Graph(Generic[VertexName]):
         new_vertex = self.build_vertex(vertex)
         if new_vertex not in self._lookup_table.values():
             self._lookup_table[new_vertex.name] = new_vertex
-            self._sorted_graph.append(new_vertex)
-        self._sorted_graph.sort(key=self._sort_by)
+            self._graph.append(new_vertex)
 
     def remove_vertex(self, vertex: GenericNode[VertexName]) -> None:
         """Remove a vertex.
@@ -172,7 +167,7 @@ class Graph(Generic[VertexName]):
         if vertex.name in self._lookup_table.keys():
             vertex_to_remove = self._lookup_table[vertex.name]
             del self._lookup_table[vertex.name]
-            self._sorted_graph.remove(vertex_to_remove)
+            self._graph.remove(vertex_to_remove)
 
     def get_vertex(self, vertex_name: VertexName) -> Vertex[VertexName]:
         """Get a vertex.

--- a/api/src/opentrons/drivers/rpi_drivers/interfaces.py
+++ b/api/src/opentrons/drivers/rpi_drivers/interfaces.py
@@ -1,4 +1,4 @@
-from typing import List, Set
+from typing import List
 from typing_extensions import Protocol
 
 from opentrons.hardware_control.modules.types import ModuleAtPort
@@ -29,11 +29,11 @@ class USBDriverInterface(Protocol):
         ...
 
     @property
-    def sorted_ports(self) -> Set[str]:
+    def sorted_ports(self) -> List[str]:
         ...
 
     @sorted_ports.setter
-    def sorted_ports(self, sorted: Set[str]) -> None:
+    def sorted_ports(self, ports: List[str]) -> None:
         ...
 
     def read_usb_bus(self) -> List[USBPort]:

--- a/api/src/opentrons/drivers/rpi_drivers/usb.py
+++ b/api/src/opentrons/drivers/rpi_drivers/usb.py
@@ -8,7 +8,7 @@ more readable format.
 import subprocess
 import re
 import os
-from typing import List, Set, cast
+from typing import List, cast
 
 from opentrons.algorithms.dfs import DFS
 from opentrons.algorithms.types import GenericNode
@@ -33,7 +33,7 @@ class USBBus(USBDriverInterface):
         self._board_revision = board_revision
         self._usb_dev = self.read_usb_bus()
         self._dfs: DFS[str] = DFS[str](cast(List[GenericNode[str]], self._usb_dev))
-        self._sorted = self._dfs.dfs()
+        self._searched = self._dfs.dfs()
 
     @staticmethod
     def read_bus() -> List[str]:
@@ -89,22 +89,22 @@ class USBBus(USBDriverInterface):
         self._usb_dev = ports
 
     @property
-    def sorted_ports(self) -> Set[str]:
+    def sorted_ports(self) -> List[str]:
         """
         USBBus property: sorted_ports.
 
         :returns: The set of sorted ports
         """
-        return self._sorted
+        return self._searched
 
     @sorted_ports.setter
-    def sorted_ports(self, sorted: Set[str]) -> None:
+    def sorted_ports(self, ports: List[str]) -> None:
         """
         USBBus setter: sorted_ports.
 
-        :param sorted: The updated set of usb ports.
+        :param ports: The updated set of usb ports.
         """
-        self._sorted = sorted
+        self._searched = ports
 
     def read_usb_bus(self) -> List[USBPort]:
         """

--- a/api/src/opentrons/drivers/rpi_drivers/usb_simulator.py
+++ b/api/src/opentrons/drivers/rpi_drivers/usb_simulator.py
@@ -4,7 +4,7 @@ USB Simulating Driver.
 A class to convert info from the usb bus into a
 more readable format.
 """
-from typing import List, Set
+from typing import List
 
 from opentrons.hardware_control.modules.types import ModuleAtPort
 from opentrons.hardware_control.types import BoardRevision
@@ -16,7 +16,7 @@ from .types import USBPort
 class USBBusSimulator(USBDriverInterface):
     def __init__(self, board_revision: BoardRevision):
         self._usb_dev: List[USBPort] = self.read_usb_bus()
-        self._sorted: Set[str] = set()
+        self._sorted: List[str] = []
         self._board_revision = board_revision
 
     @staticmethod
@@ -59,7 +59,7 @@ class USBBusSimulator(USBDriverInterface):
         self._usb_dev = ports
 
     @property
-    def sorted_ports(self) -> Set[str]:
+    def sorted_ports(self) -> List[str]:
         """
         USBBus property: sorted_ports.
 
@@ -68,13 +68,13 @@ class USBBusSimulator(USBDriverInterface):
         return self._sorted
 
     @sorted_ports.setter
-    def sorted_ports(self, sorted: Set[str]) -> None:
+    def sorted_ports(self, ports: List[str]) -> None:
         """
         USBBus setter: sorted_ports.
 
         :param sorted: The updated set of usb ports.
         """
-        self._sorted = sorted
+        self._sorted = ports
 
     def read_usb_bus(self) -> List[USBPort]:
         """

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -98,7 +98,7 @@ class AttachedModulesControl:
             )
             await removed_mod.cleanup()
         self._available_modules = sorted(
-            self._available_modules, key=modules.AbstractModule.sort_key
+            self._available_modules, key=modules.AbstractModule.sort_key, reverse=True
         )
 
     async def register_modules(
@@ -136,7 +136,7 @@ class AttachedModulesControl:
                 f" at port {mod.port}, new_instance: {new_instance}"
             )
         self._available_modules = sorted(
-            self._available_modules, key=modules.AbstractModule.sort_key
+            self._available_modules, key=modules.AbstractModule.sort_key, reverse=True
         )
 
     async def parse_modules(

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -97,6 +97,9 @@ class AttachedModulesControl:
                 f"Module {removed_mod.name()} detached" f" from port {removed_mod.port}"
             )
             await removed_mod.cleanup()
+        self._available_modules = sorted(
+            self._available_modules, key=modules.AbstractModule.sort_key
+        )
 
     async def register_modules(
         self,
@@ -132,6 +135,9 @@ class AttachedModulesControl:
                 f"Module {mod.name} discovered and attached"
                 f" at port {mod.port}, new_instance: {new_instance}"
             )
+        self._available_modules = sorted(
+            self._available_modules, key=modules.AbstractModule.sort_key
+        )
 
     async def parse_modules(
         self,

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -50,6 +50,10 @@ class AbstractModule(abc.ABC):
         self._execution_manager = execution_manager
         self._bundled_fw: Optional[BundledFirmware] = self.get_bundled_fw()
 
+    @staticmethod
+    def sort_key(inst: "AbstractModule") -> int:
+        return (inst.usb_port.port_number or 0) * 1000 + (inst.usb_port.hub or 0)
+
     @property
     def loop(self) -> asyncio.AbstractEventLoop:
         return self._loop

--- a/api/tests/opentrons/algorithms/test_dfs.py
+++ b/api/tests/opentrons/algorithms/test_dfs.py
@@ -58,10 +58,10 @@ def test_vertices(
     graph.add_vertex(additional_vertex)
     vertex_obj = graph.get_vertex(additional_vertex.name)
     assert additional_vertex.name in graph._lookup_table.keys()
-    assert vertex_obj in graph._sorted_graph
+    assert vertex_obj in graph._graph
     graph.remove_vertex(additional_vertex)
     assert additional_vertex.name not in graph._lookup_table.keys()
-    assert vertex_obj not in graph._sorted_graph
+    assert vertex_obj not in graph._graph
 
 
 def test_neighbors_int(str_named_graph: dfs.DFS[str]) -> None:
@@ -93,11 +93,11 @@ def test_neighbors_str(int_named_graph: dfs.DFS[int]) -> None:
     key = 1
     neighbor = 4
     og_neighbors = [2, 5]
-    sorted_neighbors = [2, 4, 5]
+    neighbors_by_add_order = [2, 5, 4]
     vertex = graph.get_vertex(key)
     assert vertex.neighbors == og_neighbors
     vertex.add_neighbor(neighbor)
-    assert vertex.neighbors == sorted_neighbors
+    assert vertex.neighbors == neighbors_by_add_order
     vertex.remove_neighbor(neighbor)
     assert vertex.neighbors == og_neighbors
 
@@ -109,7 +109,7 @@ def test_depth_first_search_str(str_named_graph: dfs.DFS[str]) -> None:
     before backtracking up to find unvisited nodes.
     """
     visited_vertices = str_named_graph.dfs()
-    sort = {"A", "B", "F", "G", "C", "J", "I", "H", "D", "E"}
+    sort = ["A", "B", "E", "F", "C", "G", "H", "I", "D", "J"]
     assert sort == visited_vertices
 
 
@@ -120,5 +120,5 @@ def test_depth_first_search_int(int_named_graph: dfs.DFS[int]) -> None:
     before backtracking up to find unvisited nodes.
     """
     visited_vertices = int_named_graph.dfs()
-    sort = {1, 2, 6, 7, 3, 10, 9, 8, 4, 5}
+    sort = [1, 2, 5, 6, 3, 7, 8, 9, 4, 10]
     assert sort == visited_vertices

--- a/api/tests/opentrons/drivers/rpi_drivers/test_usb.py
+++ b/api/tests/opentrons/drivers/rpi_drivers/test_usb.py
@@ -124,7 +124,7 @@ def test_unplug_device(usb_bus: USBBus) -> None:
 
 
 def test_sorted_usb_bus(usb_bus: USBBus) -> None:
-    expected_sorted = {"1-1.3", "1-1.5.1", "1-1.5.3", "1-1.5"}
+    expected_sorted = ["1-1.3", "1-1.5", "1-1.5.1", "1-1.5.3"]
     assert usb_bus.sorted_ports == expected_sorted
 
 


### PR DESCRIPTION
When we're using multiple modules, we need to decide which is which without forcing users to enter ports. This is done by guaranteeing a consistent retrieval order of hardware modules, so that multiple `load_module` calls get the same module each time the protocol is executed with the same physical hardware setup. The problem noted by #9309 is that this order, while consistent, does not match the way the app labels modules with usb ports in the deck map in the pre-protocol flow, and that I think is the bug - we didn't properly ensure that sort order was consistent.

This PR tries to sort the hardware modules by the same key that the app uses to display the module ports.

Note that module port labels printed on the robot aren't actually linked to the hardware in any way, but they should have a consistent ordering; so we should give this a try, and if it's not actually the same order we can just reverse the sort.

Also while I was at it I made the dfs algo preserve graph ordering in its output but I don't think that really matters here.

Fixes #9309 
Fixes #9253 