### PR TITLE
fix(app): shore up edge cases of current command tracking, use new commands endpoint link metadata

### DIFF
--- a/api-client/src/runs/commands/createCommand.ts
+++ b/api-client/src/runs/commands/createCommand.ts
@@ -3,17 +3,20 @@ import { POST, request } from '../../request'
 import type { ResponsePromise } from '../../request'
 import type { HostConfig } from '../../types'
 import type { CommandData } from '../types'
+import type { CreateCommandParams } from './types'
 import type { CreateCommand } from '@opentrons/shared-data/protocol/types/schemaV6'
 
 export function createCommand(
   config: HostConfig,
   runId: string,
-  data: CreateCommand
+  data: CreateCommand,
+  params?: CreateCommandParams
 ): ResponsePromise<CommandData> {
   return request<CommandData, { data: CreateCommand }>(
     POST,
     `/runs/${runId}/commands`,
     { data },
-    config
+    config,
+    params
   )
 }

--- a/api-client/src/runs/commands/types.ts
+++ b/api-client/src/runs/commands/types.ts
@@ -30,6 +30,7 @@ export interface CommandsLinks {
       runId: string
       commandId: string
       key: string
+      createdAt: string
       index: number
     }
   }

--- a/api-client/src/runs/commands/types.ts
+++ b/api-client/src/runs/commands/types.ts
@@ -29,6 +29,7 @@ export interface CommandsLinks {
     meta: {
       runId: string
       commandId: string
+      key: string
       index: number
     }
   }

--- a/api-client/src/runs/commands/types.ts
+++ b/api-client/src/runs/commands/types.ts
@@ -39,3 +39,8 @@ export interface CommandsData {
   meta: GetCommandsParams & { totalLength: number }
   links: CommandsLinks
 }
+
+export interface CreateCommandParams {
+  waitUntilComplete?: boolean
+  timeout?: number
+}

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -135,6 +135,19 @@ class ProtocolEngine:
         self._action_dispatcher.dispatch(action)
         return self._state_store.commands.get(command_id)
 
+    async def wait_for_command(self, command_id: str) -> None:
+        """Wait for a command to be completed."""
+        is_already_complete = self._state_store.commands.get_is_complete(
+            command_id=command_id
+        )
+        # If the command is already complete, don't wait,
+        # because we'd only wake up on a subsequent state update,
+        # and we don't know that there would ever be one.
+        if not is_already_complete:
+            await self._state_store.wait_for(
+                self._state_store.commands.get_is_complete, command_id=command_id
+            )
+
     async def add_and_execute_command(self, request: CommandCreate) -> Command:
         """Add a command to the queue and wait for it to complete.
 

--- a/app/src/assets/localization/en/protocol_info.json
+++ b/app/src/assets/localization/en/protocol_info.json
@@ -53,6 +53,6 @@
   "labware_positon_check_complete_toast_with_offsets": "Labware Position Check complete. {{count}} Labware Offset created.",
   "labware_positon_check_complete_toast_with_offsets_plural": "Labware Position Check complete. {{count}} Labware Offsets created.",
   "protocol_loading": "Opening Protocol On {{robot_name}}",
-  "protocol_finishing": "Closing Protocol On {{robot_name}}",
+  "protocol_finishing": "Finishing Protocol On {{robot_name}}",
   "cancel_run": "Cancel Run"
 }

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/__tests__/useLabwarePositionCheck.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/__tests__/useLabwarePositionCheck.test.tsx
@@ -130,12 +130,6 @@ describe('useLabwarePositionCheck', () => {
   })
   describe('jog', () => {
     it('should NOT queue up a new jog command when a previous jog command has NOT completed', async () => {
-      when(mockUseCurrentRunCommands)
-        .calledWith()
-        .mockReturnValue([
-          { commandType: 'moveRelative', status: 'running' } as any,
-        ])
-
       const { result, waitForNextUpdate } = renderHook(
         () => useLabwarePositionCheck(() => null, {}),
         { wrapper }
@@ -151,11 +145,6 @@ describe('useLabwarePositionCheck', () => {
         1 as 1,
         2,
       ]
-      const [SECOND_JOG_AXIS, SECOND_JOG_DIRECTION, SECOND_JOG_DISTANCE] = [
-        'y' as 'y',
-        -1 as -1,
-        3,
-      ]
       if ('error' in result.current) {
         throw new Error('error should not be present')
       }
@@ -163,11 +152,6 @@ describe('useLabwarePositionCheck', () => {
         FIRST_JOG_AXIS,
         FIRST_JOG_DIRECTION,
         FIRST_JOG_DISTANCE
-      )
-      result.current.jog(
-        SECOND_JOG_AXIS,
-        SECOND_JOG_DIRECTION,
-        SECOND_JOG_DISTANCE
       )
       expect(mockCreateCommand).toHaveBeenCalledWith({
         runId: MOCK_RUN_ID,
@@ -179,84 +163,8 @@ describe('useLabwarePositionCheck', () => {
             axis: FIRST_JOG_AXIS,
           },
         },
-      })
-      expect(mockCreateCommand).not.toHaveBeenCalledWith({
-        runId: MOCK_RUN_ID,
-        command: {
-          commandType: 'moveRelative',
-          params: {
-            pipetteId: 'MOCK_PIPETTE_ID',
-            distance: SECOND_JOG_DIRECTION * SECOND_JOG_DISTANCE,
-            axis: SECOND_JOG_AXIS,
-          },
-        },
-      })
-    })
-    it('should queue up a new jog command when the previous jog command has succeeded', async () => {
-      when(mockUseCurrentRunCommands)
-        .calledWith()
-        .mockReturnValue([
-          {
-            id: MOCK_COMMAND_ID,
-            commandType: 'moveRelative',
-            status: 'succeeded',
-          } as any,
-        ])
-      const { result, waitForNextUpdate } = renderHook(
-        () => useLabwarePositionCheck(() => null, {}),
-        { wrapper }
-      )
-      if ('error' in result.current) {
-        throw new Error('error should not be present')
-      }
-      const { beginLPC } = result.current
-      beginLPC()
-      await waitForNextUpdate()
-      const [FIRST_JOG_AXIS, FIRST_JOG_DIRECTION, FIRST_JOG_DISTANCE] = [
-        'x' as 'x',
-        1 as 1,
-        2,
-      ]
-      const [SECOND_JOG_AXIS, SECOND_JOG_DIRECTION, SECOND_JOG_DISTANCE] = [
-        'y' as 'y',
-        -1 as -1,
-        3,
-      ]
-      if ('error' in result.current) {
-        throw new Error('error should not be present')
-      }
-      result.current.jog(
-        FIRST_JOG_AXIS,
-        FIRST_JOG_DIRECTION,
-        FIRST_JOG_DISTANCE
-      )
-      await waitForNextUpdate()
-      result.current.jog(
-        SECOND_JOG_AXIS,
-        SECOND_JOG_DIRECTION,
-        SECOND_JOG_DISTANCE
-      )
-      expect(mockCreateCommand).toHaveBeenCalledWith({
-        runId: MOCK_RUN_ID,
-        command: {
-          commandType: 'moveRelative',
-          params: {
-            pipetteId: 'MOCK_PIPETTE_ID',
-            distance: FIRST_JOG_DIRECTION * FIRST_JOG_DISTANCE,
-            axis: FIRST_JOG_AXIS,
-          },
-        },
-      })
-      expect(mockCreateCommand).toHaveBeenCalledWith({
-        runId: MOCK_RUN_ID,
-        command: {
-          commandType: 'moveRelative',
-          params: {
-            pipetteId: 'MOCK_PIPETTE_ID',
-            distance: SECOND_JOG_DIRECTION * SECOND_JOG_DISTANCE,
-            axis: SECOND_JOG_AXIS,
-          },
-        },
+        waitUntilComplete: true,
+        timeout: 10000,
       })
     })
   })
@@ -314,72 +222,7 @@ describe('useLabwarePositionCheck', () => {
         },
       })
     })
-    it('should NOT execute the next command if a jog command is in flight', async () => {
-      when(mockUseSteps)
-        .calledWith()
-        .mockReturnValue([
-          {
-            commands: [
-              {
-                commandType: 'pickUpTip',
-                params: {
-                  pipetteId: MOCK_PIPETTE_ID,
-                  labwareId: MOCK_LABWARE_ID,
-                },
-              },
-              {
-                commandType: 'dropTip',
-                params: {
-                  pipetteId: MOCK_PIPETTE_ID,
-                  labwareId: MOCK_LABWARE_ID,
-                },
-              },
-            ],
-            labwareId: MOCK_LABWARE_ID,
-            section: 'PRIMARY_PIPETTE_TIPRACKS',
-          } as LabwarePositionCheckStep,
-        ])
-
-      const { result, waitForNextUpdate } = renderHook(
-        () => useLabwarePositionCheck(() => null, {}),
-        { wrapper }
-      )
-      if ('error' in result.current) {
-        throw new Error('error should not be present')
-      }
-      const { beginLPC } = result.current
-      beginLPC() // beginLPC calls the first command
-      await waitForNextUpdate()
-      const { jog } = result.current
-      const [JOG_AXIS, JOG_DIRECTION, JOG_DISTANCE] = ['x' as 'x', 1 as 1, 2]
-      jog(JOG_AXIS, JOG_DIRECTION, JOG_DISTANCE)
-      await waitForNextUpdate()
-      const { proceed } = result.current
-      proceed()
-      // this is from the begin LPC call
-      expect(mockCreateCommand).toHaveBeenCalledWith({
-        runId: MOCK_RUN_ID,
-        command: {
-          commandType: 'pickUpTip',
-          params: {
-            pipetteId: MOCK_PIPETTE_ID,
-            labwareId: MOCK_LABWARE_ID,
-          },
-        },
-      })
-      // no drop tip call should get logged since jog is in flight
-      expect(mockCreateCommand).not.toHaveBeenCalledWith({
-        runId: MOCK_RUN_ID,
-        command: {
-          commandType: 'dropTip',
-          params: expect.objectContaining({
-            pipetteId: MOCK_PIPETTE_ID,
-            labwareId: MOCK_LABWARE_ID,
-          }),
-        },
-      })
-    })
-    it('should execute the next command if no jog command is in flight', async () => {
+    it('should execute the next command', async () => {
       when(mockUseSteps)
         .calledWith()
         .mockReturnValue([
@@ -429,7 +272,7 @@ describe('useLabwarePositionCheck', () => {
           },
         },
       })
-      // drop tip call should get logged since no jog is in flight
+      // drop tip call should get logged
       expect(mockCreateCommand).toHaveBeenCalledWith({
         runId: MOCK_RUN_ID,
         command: {

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/hooks/__tests__/useModuleMatchResults.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/hooks/__tests__/useModuleMatchResults.test.tsx
@@ -47,7 +47,7 @@ describe('useModuleMatchResults', () => {
   beforeEach(() => {
     store.dispatch = jest.fn()
 
-    when(mockGetConnectedRobot).mockReturnValue(mockConnectedRobot)
+    mockGetConnectedRobot.mockReturnValue(mockConnectedRobot)
 
     when(mockUseModuleRenderInfoById).calledWith().mockReturnValue({})
 

--- a/app/src/organisms/RunDetails/CommandItem.tsx
+++ b/app/src/organisms/RunDetails/CommandItem.tsx
@@ -89,7 +89,7 @@ export function CommandItemComponent(
   ) {
     commandStatus = runCommandSummary.status
   }
-  if (isMostRecentCommand && commandStatus === 'queued') {
+  if (isMostRecentCommand && (commandStatus === 'queued' || commandStatus === 'succeeded')) {
     commandStatus = 'running' as const
   }
 
@@ -194,6 +194,7 @@ export const CommandItem = React.memo(
     const shouldRerender =
       !isEqual(prevProps.analysisCommand, nextProps.analysisCommand) ||
       !isEqual(prevProps.runCommandSummary, nextProps.runCommandSummary) ||
+      !isEqual(prevProps.isMostRecentCommand, nextProps.isMostRecentCommand) ||
       ((([
         RUN_STATUS_PAUSED,
         RUN_STATUS_PAUSE_REQUESTED,

--- a/app/src/organisms/RunDetails/CommandItem.tsx
+++ b/app/src/organisms/RunDetails/CommandItem.tsx
@@ -83,13 +83,13 @@ export function CommandItemComponent(
   const { t } = useTranslation('run_details')
 
   let commandStatus: RunCommandSummary['status'] = 'queued' as const
-  if (
-    runStatus !== RUN_STATUS_IDLE &&
-    runCommandSummary?.status != null
-  ) {
+  if (runStatus !== RUN_STATUS_IDLE && runCommandSummary?.status != null) {
     commandStatus = runCommandSummary.status
   }
-  if (isMostRecentCommand && (commandStatus === 'queued' || commandStatus === 'succeeded')) {
+  if (
+    isMostRecentCommand &&
+    (commandStatus === 'queued' || commandStatus === 'succeeded')
+  ) {
     commandStatus = 'running' as const
   }
 

--- a/app/src/organisms/RunDetails/CommandItem.tsx
+++ b/app/src/organisms/RunDetails/CommandItem.tsx
@@ -83,13 +83,14 @@ export function CommandItemComponent(
   const { t } = useTranslation('run_details')
 
   let commandStatus: RunCommandSummary['status'] = 'queued' as const
-  if (isMostRecentCommand) {
-    commandStatus = 'running' as const
-  } else if (
+  if (
     runStatus !== RUN_STATUS_IDLE &&
     runCommandSummary?.status != null
   ) {
     commandStatus = runCommandSummary.status
+  }
+  if (isMostRecentCommand && commandStatus === 'queued') {
+    commandStatus = 'running' as const
   }
 
   let isComment = false

--- a/app/src/organisms/RunDetails/CommandItem.tsx
+++ b/app/src/organisms/RunDetails/CommandItem.tsx
@@ -111,14 +111,10 @@ export function CommandItemComponent(
   const isPause =
     analysisCommand?.commandType === 'pause' ||
     runCommandSummary?.commandType === 'pause'
-  const backgroundColor =
-    commandStatus === 'queued' && isMostRecentCommand
-      ? C_AQUAMARINE
-      : WRAPPER_STYLE_BY_STATUS[commandStatus].backgroundColor
 
   const WRAPPER_STYLE = css`
     font-size: ${FONT_SIZE_BODY_1};
-    background-color: ${backgroundColor};
+    background-color: ${WRAPPER_STYLE_BY_STATUS[commandStatus].backgroundColor};
     border: ${WRAPPER_STYLE_BY_STATUS[commandStatus].border};
     padding: ${SPACING_2};
     color: ${C_DARK_GRAY};

--- a/app/src/organisms/RunDetails/CommandItem.tsx
+++ b/app/src/organisms/RunDetails/CommandItem.tsx
@@ -111,13 +111,6 @@ export function CommandItemComponent(
   const isPause =
     analysisCommand?.commandType === 'pause' ||
     runCommandSummary?.commandType === 'pause'
-<<<<<<< HEAD
-=======
-  const backgroundColor =
-    commandStatus === 'queued' && isMostRecentCommand
-      ? C_AQUAMARINE
-      : WRAPPER_STYLE_BY_STATUS[commandStatus].backgroundColor
->>>>>>> cd877cefe7e11c8c0592667e0d1fd095292bc1bb
 
   const WRAPPER_STYLE = css`
     font-size: ${FONT_SIZE_BODY_1};

--- a/app/src/organisms/RunDetails/CommandItem.tsx
+++ b/app/src/organisms/RunDetails/CommandItem.tsx
@@ -48,7 +48,7 @@ export interface CommandItemProps {
   runStatus: RunStatus
   stepNumber: number
   runStartedAt: string | null
-  isFetchingRunCommands: boolean
+  isMostRecentCommand: boolean
 }
 
 const WRAPPER_STYLE_BY_STATUS: {
@@ -78,14 +78,19 @@ export function CommandItemComponent(
     runStatus,
     stepNumber,
     runStartedAt,
-    isFetchingRunCommands
+    isMostRecentCommand,
   } = props
   const { t } = useTranslation('run_details')
 
-  const commandStatus =
-    runStatus !== RUN_STATUS_IDLE && runCommandSummary?.status != null
-      ? runCommandSummary.status
-      : 'queued'
+  let commandStatus: RunCommandSummary['status'] = 'queued' as const
+  if (isMostRecentCommand) {
+    commandStatus = 'running' as const
+  } else if (
+    runStatus !== RUN_STATUS_IDLE &&
+    runCommandSummary?.status != null
+  ) {
+    commandStatus = runCommandSummary.status
+  }
 
   let isComment = false
   if (
@@ -106,7 +111,7 @@ export function CommandItemComponent(
     analysisCommand?.commandType === 'pause' ||
     runCommandSummary?.commandType === 'pause'
   const backgroundColor =
-    commandStatus === 'queued' && runCommandSummary != null && isFetchingRunCommands
+    commandStatus === 'queued' && isMostRecentCommand
       ? C_AQUAMARINE
       : WRAPPER_STYLE_BY_STATUS[commandStatus].backgroundColor
 

--- a/app/src/organisms/RunDetails/CommandItem.tsx
+++ b/app/src/organisms/RunDetails/CommandItem.tsx
@@ -48,6 +48,7 @@ export interface CommandItemProps {
   runStatus: RunStatus
   stepNumber: number
   runStartedAt: string | null
+  isFetchingRunCommands: boolean
 }
 
 const WRAPPER_STYLE_BY_STATUS: {
@@ -77,6 +78,7 @@ export function CommandItemComponent(
     runStatus,
     stepNumber,
     runStartedAt,
+    isFetchingRunCommands
   } = props
   const { t } = useTranslation('run_details')
 
@@ -104,7 +106,7 @@ export function CommandItemComponent(
     analysisCommand?.commandType === 'pause' ||
     runCommandSummary?.commandType === 'pause'
   const backgroundColor =
-    commandStatus === 'queued' && runCommandSummary != null
+    commandStatus === 'queued' && runCommandSummary != null && isFetchingRunCommands
       ? C_AQUAMARINE
       : WRAPPER_STYLE_BY_STATUS[commandStatus].backgroundColor
 

--- a/app/src/organisms/RunDetails/CommandItem.tsx
+++ b/app/src/organisms/RunDetails/CommandItem.tsx
@@ -46,7 +46,6 @@ export interface CommandItemProps {
   analysisCommand: RunTimeCommand | null
   runCommandSummary: RunCommandSummary | null
   runStatus: RunStatus
-  hasBeenRun: boolean
   stepNumber: number
   runStartedAt: string | null
 }
@@ -76,7 +75,6 @@ export function CommandItemComponent(
     analysisCommand,
     runCommandSummary,
     runStatus,
-    hasBeenRun,
     stepNumber,
     runStartedAt,
   } = props
@@ -106,7 +104,7 @@ export function CommandItemComponent(
     analysisCommand?.commandType === 'pause' ||
     runCommandSummary?.commandType === 'pause'
   const backgroundColor =
-    commandStatus === 'queued' && hasBeenRun
+    commandStatus === 'queued' && runCommandSummary != null
       ? C_AQUAMARINE
       : WRAPPER_STYLE_BY_STATUS[commandStatus].backgroundColor
 

--- a/app/src/organisms/RunDetails/CommandList.tsx
+++ b/app/src/organisms/RunDetails/CommandList.tsx
@@ -107,11 +107,6 @@ export function CommandList(): JSX.Element | null {
     firstNonSetupIndex
   )
 
-  // console.log('allProtocolCommands', allProtocolCommands.length)
-  // console.log('runCommands', runCommands.length)
-  // console.log('firstRunCommandIndexAfterInitialPlay', firstRunCommandIndexAfterInitialPlay)
-  // console.log('postInitialPlayRunCommandCount', postInitialPlayRunCommandCount)
-
   const runStartDateTime = runStartTime != null ? new Date(runStartTime) : null
   const postInitialPlayRunCommands = runStartDateTime != null ? dropWhile(runCommands, runCommandSummary => (
     new Date(runCommandSummary.createdAt) <= runStartDateTime
@@ -121,9 +116,6 @@ export function CommandList(): JSX.Element | null {
       runCommandSummary.commandType !== 'loadPipette' &&
       runCommandSummary.commandType !== 'loadModule'
   ))
-  // console.log('postSetupRunCommands', postSetupRunCommands)
-  // const currentCommandIndex = postSetupRunCommands.length - 1
-  // console.log('currentCommandIndex', currentCommandIndex)
 
   let currentCommandList: CommandRuntimeInfo[] = postSetupAnticipatedCommands.map(
     postSetupAnticaptedCommand => ({

--- a/app/src/organisms/RunDetails/CommandList.tsx
+++ b/app/src/organisms/RunDetails/CommandList.tsx
@@ -76,7 +76,7 @@ export function CommandList(): JSX.Element | null {
   )
   const totalRunCommandCount = commandsData?.meta.totalLength ?? 0
   const runCommands = commandsData?.data ?? []
-  const currentRunCommandIndex = commandsData?.links?.current?.meta?.index ?? 0
+  const currentCommandKey = commandsData?.links?.current?.meta?.key ?? null
 
   const [
     isInitiallyJumpingToCurrent,
@@ -148,16 +148,19 @@ export function CommandList(): JSX.Element | null {
   const isFinalWindow =
     currentCommandList.length - 1 <= windowFirstCommandIndex + WINDOW_SIZE
 
-  console.table({currentRunCommandIndex, totalRunCommandCount, rC: postSetupRunCommands.length})
-
-  // run 50 commands total
-  // made up of 10 LPC, 5 setup commands, and 35 actual run commands
-  // commandsList has 100 commands, 35 of which have corresponding run commands
-
-  // knowns setup commands
-  //
-  const currentCommandIndex = Math.max(currentRunCommandIndex - (totalRunCommandCount - postSetupRunCommands.length), 0)
-  console.log(currentCommandIndex)
+  const currentCommandIndex = currentCommandList.findIndex(command => (
+    command?.analysisCommand?.key === currentCommandKey
+  ))
+  if (currentCommandIndex < 0) {
+    const isRunningSetupCommand = protocolSetupCommandList.find(command => command.key === currentCommandKey) != null
+    if (runStartTime !== null && !isRunningSetupCommand) {
+      // protocol is non-deterministic
+      console.log('NON DET')
+    } else {
+      // all run commands are from LPC
+      console.log('UNSTARTED WITH LPC or Setup')
+    }
+  }
   const indexOfWindowContainingCurrentItem = Math.floor(
     Math.max(currentCommandIndex - (WINDOW_SIZE - WINDOW_OVERLAP), 0) /
       (WINDOW_SIZE - WINDOW_OVERLAP)

--- a/app/src/organisms/RunDetails/CommandList.tsx
+++ b/app/src/organisms/RunDetails/CommandList.tsx
@@ -121,7 +121,7 @@ export function CommandList(): JSX.Element | null {
       runCommandSummary.commandType !== 'loadPipette' &&
       runCommandSummary.commandType !== 'loadModule'
   ))
-  console.log('postSetupRunCommands', postSetupRunCommands)
+  // console.log('postSetupRunCommands', postSetupRunCommands)
   // const currentCommandIndex = postSetupRunCommands.length - 1
   // console.log('currentCommandIndex', currentCommandIndex)
 
@@ -133,21 +133,12 @@ export function CommandList(): JSX.Element | null {
   )
   if (postInitialPlayRunCommands != null && postInitialPlayRunCommands.length > 0 && runStartTime != null) {
     const allCommands = allProtocolCommands.map((anticipatedCommand, index) => {
-      const isAnticipated = index + 1 > postInitialPlayRunCommands.length
-      // console.log('index + 1', index+1, '>' , 'postInitialPlayRunCommandCount', postInitialPlayRunCommands.length)
       const matchedRunCommand = postInitialPlayRunCommands.find(
         runCommandSummary => runCommandSummary.key === anticipatedCommand.key
       )
-      if (!isAnticipated && matchedRunCommand != null) {
-        return {
-          analysisCommand: anticipatedCommand,
-          runCommandSummary: matchedRunCommand,
-        }
-      } else {
-        return {
-          analysisCommand: anticipatedCommand,
-          runCommandSummary: null,
-        }
+      return {
+        analysisCommand: anticipatedCommand,
+        runCommandSummary: matchedRunCommand ?? null,
       }
     })
 
@@ -325,7 +316,7 @@ export function CommandList(): JSX.Element | null {
                 <CommandItem
                   analysisCommand={command.analysisCommand}
                   runCommandSummary={command.runCommandSummary}
-                  isFetchingRunCommands={isFetchingRunCommands}
+                  isMostRecentCommand={isCurrentCommand}
                   runStatus={runStatus}
                   stepNumber={overallIndex + 1}
                   runStartedAt={runStartTime}

--- a/app/src/organisms/RunDetails/CommandList.tsx
+++ b/app/src/organisms/RunDetails/CommandList.tsx
@@ -42,6 +42,7 @@ import type {
   RunTimeCommand,
   CommandStatus,
 } from '@opentrons/shared-data'
+import { isYesterday } from 'date-fns'
 
 const AVERAGE_ITEM_HEIGHT_PX = 52 // average px height of a command item
 const WINDOW_SIZE = 60 // number of command items rendered at a time
@@ -171,17 +172,19 @@ export function CommandList(): JSX.Element | null {
   )
 
   // if the run's current command key doesn't exist in the analysis commands
-  if (runCommands.length > 0 && currentCommandIndex < 0) {
+  if (runCommands.length > 0 && currentCommandIndex < 0 && isDeterministic) {
     const isRunningSetupCommand =
       protocolSetupCommandList.find(
         command => command.key === currentCommandKey
       ) != null
     // AND the run has been started and the current step is NOT an initial setup step
     if (runStartDateTime !== null && !isRunningSetupCommand) {
+      console.log('\n\nASECOND IF DET\n\n', currentCommandCreatedAt, runStartDateTime, new Date(currentCommandCreatedAt) > runStartDateTime)
       // AND the current command was created after the run was started
       if (new Date(currentCommandCreatedAt) > runStartDateTime) {
         // then we know that the run has diverged from the analysis expectation and
         // that this protocol is non-deterministic
+        console.log('\n\nset is NON DET\n\n')
         setIsDeterministic(false)
       }
     }
@@ -198,7 +201,7 @@ export function CommandList(): JSX.Element | null {
   // when we initially mount, if the current item is not in view, jump to it
   React.useEffect(() => {
     if (indexOfWindowContainingCurrentItem !== windowIndex) {
-      setWindowIndex(indexOfWindowContainingCurrentItem)
+      setWindowIndex(Math.max(indexOfWindowContainingCurrentItem, 0))
     }
     setIsInitiallyJumpingToCurrent(true)
   }, [])
@@ -254,11 +257,12 @@ export function CommandList(): JSX.Element | null {
         topBufferHeightPx +
         Math.max(nextWindowSize - 5, 0) * AVERAGE_ITEM_HEIGHT_PX -
         clientHeight
-      console.log('isFinalWindow', isFinalWindow)
-      console.log('windowFirstCommandIndex', windowFirstCommandIndex)
-      console.log('potentialNextWindowFirstIndex', potentialNextWindowFirstIndex)
-      console.log('scrollTop', scrollTop)
-      console.log('nextWindowBoundary', nextWindowBoundary)
+      // console.log('isFinalWindow', isFinalWindow)
+      // console.log('windowFirstCommandIndex', windowFirstCommandIndex)
+      // console.log('potentialNextWindowFirstIndex', potentialNextWindowFirstIndex)
+      // console.log('scrollTop', scrollTop)
+      // console.log('nextWindowBoundary', nextWindowBoundary)
+      // console.log('isDeterministic', isDeterministic)
       if (
         !isFinalWindow &&
         potentialNextWindowFirstIndex < currentCommandList.length &&

--- a/app/src/organisms/RunDetails/CommandList.tsx
+++ b/app/src/organisms/RunDetails/CommandList.tsx
@@ -78,7 +78,6 @@ export function CommandList(): JSX.Element | null {
       keepPreviousData: true,
     }
   )
-  const totalRunCommandCount = commandsData?.meta.totalLength ?? 0
   const runCommands = commandsData?.data ?? []
   const currentCommandKey = commandsData?.links?.current?.meta?.key ?? null
   const currentCommandCreatedAt =
@@ -173,7 +172,10 @@ export function CommandList(): JSX.Element | null {
     // AND the run has been started and the current step is NOT an initial setup step
     if (runStartDateTime !== null && !isRunningSetupCommand) {
       // AND the current command was created after the run was started
-      if (new Date(currentCommandCreatedAt) > runStartDateTime) {
+      if (
+        currentCommandCreatedAt != null &&
+        new Date(currentCommandCreatedAt) > runStartDateTime
+      ) {
         // then we know that the run has diverged from the analysis expectation and
         // that this protocol is non-deterministic
         setIsDeterministic(false)

--- a/app/src/organisms/RunDetails/__tests__/CommandItem.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/CommandItem.test.tsx
@@ -99,7 +99,7 @@ describe('Run Details CommandItem', () => {
       analysisCommand: MOCK_ANALYSIS_COMMAND,
       runStatus: 'running',
       stepNumber: 1,
-      hasBeenRun: true,
+      isMostRecentCommand: true,
       runStartedAt: 'fake_timestamp',
     })
     expect(getByText('Step failed')).toHaveStyle(
@@ -108,14 +108,14 @@ describe('Run Details CommandItem', () => {
     getByText('Mock RunTimeCommand Text')
     getByText('Mock RunTimeCommand Timer')
   })
-  it('renders the green background if has been run but runCommandSummary not loaded', () => {
+  it('renders the green background if is most recent command but runCommandSummary not loaded', () => {
     const props = {
       runCommandSummary: null,
       analysisCommand: MOCK_ANALYSIS_COMMAND,
       runStatus: 'succeeded',
       stepNumber: 1,
-      hasBeenRun: true,
       runStartedAt: 'fake_timestamp',
+      isMostRecentCommand: true,
     } as React.ComponentProps<typeof CommandItem>
     const { getByText } = render(props)
     expect(getByText('Mock RunTimeCommand Text')).toHaveStyle(
@@ -127,7 +127,7 @@ describe('Run Details CommandItem', () => {
       runCommandSummary: { ...MOCK_COMMAND_SUMMARY, status: 'succeeded' },
       analysisCommand: MOCK_ANALYSIS_COMMAND,
       runStatus: 'succeeded',
-      hasBeenRun: true,
+      isMostRecentCommand: true,
       stepNumber: 1,
       runStartedAt: 'fake_timestamp',
     } as React.ComponentProps<typeof CommandItem>
@@ -143,7 +143,7 @@ describe('Run Details CommandItem', () => {
       analysisCommand: MOCK_ANALYSIS_COMMAND,
       runStatus: 'running',
       stepNumber: 1,
-      hasBeenRun: true,
+      isMostRecentCommand: true,
       runStartedAt: 'fake_timestamp',
     } as React.ComponentProps<typeof CommandItem>
     const { getByText } = render(props)
@@ -159,7 +159,7 @@ describe('Run Details CommandItem', () => {
       runCommandSummary: { ...MOCK_COMMAND_SUMMARY, status: 'queued' },
       analysisCommand: MOCK_ANALYSIS_COMMAND,
       runStatus: 'running',
-      hasBeenRun: false,
+      isMostRecentCommand: false,
       stepNumber: 1,
       runStartedAt: 'fake_timestamp',
     } as React.ComponentProps<typeof CommandItem>
@@ -174,7 +174,7 @@ describe('Run Details CommandItem', () => {
       runCommandSummary: { ...MOCK_COMMAND_SUMMARY, status: 'running' },
       analysisCommand: MOCK_ANALYSIS_COMMAND,
       runStatus: 'paused',
-      hasBeenRun: true,
+      isMostRecentCommand: true,
       stepNumber: 1,
       runStartedAt: 'fake_timestamp',
     } as React.ComponentProps<typeof CommandItem>
@@ -191,7 +191,7 @@ describe('Run Details CommandItem', () => {
       runCommandSummary: { ...MOCK_COMMAND_SUMMARY, status: 'running' },
       analysisCommand: MOCK_ANALYSIS_COMMAND,
       runStatus: 'blocked-by-open-door',
-      hasBeenRun: true,
+      isMostRecentCommand: true,
       stepNumber: 1,
       runStartedAt: 'fake_timestamp',
     } as React.ComponentProps<typeof CommandItem>
@@ -227,7 +227,7 @@ describe('Run Details CommandItem', () => {
       analysisCommand: MOCK_COMMENT_COMMAND,
       runStatus: 'running',
       stepNumber: 1,
-      hasBeenRun: true,
+      isMostRecentCommand: true,
       runStartedAt: 'fake_timestamp',
     } as React.ComponentProps<typeof CommandItem>
     const { getByText } = render(props)
@@ -266,7 +266,7 @@ describe('Run Details CommandItem', () => {
       runCommandSummary: MOCK_PAUSE_COMMAND_SUMMARY,
       analysisCommand: MOCK_PAUSE_COMMAND,
       runStatus: 'paused',
-      hasBeenRun: true,
+      isMostRecentCommand: true,
       stepNumber: 1,
       runStartedAt: 'fake_timestamp',
     } as React.ComponentProps<typeof CommandItem>

--- a/app/src/organisms/RunDetails/__tests__/CommandList.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/CommandList.test.tsx
@@ -80,7 +80,6 @@ describe('CommandList', () => {
     fireEvent.click(getByText('Protocol Setup'))
     getAllByText('Mock ProtocolSetup Info')
     getByText('End of protocol')
-    getByText('Anticipated steps')
   })
   it('renders the first non ProtocolSetup command', () => {
     const { getAllByText } = render()

--- a/app/src/organisms/RunDetails/__tests__/RunDetails.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/RunDetails.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import '@testing-library/jest-dom'
 import { fireEvent } from '@testing-library/dom'
-import { Route, BrowserRouter, useHistory } from 'react-router-dom'
+import { Route, BrowserRouter } from 'react-router-dom'
 import { resetAllWhenMocks, when } from 'jest-when'
 import {
   RUN_STATUS_RUNNING,
@@ -29,7 +29,6 @@ import {
 } from '../../ProtocolUpload/hooks'
 import type { ProtocolFile } from '@opentrons/shared-data'
 
-
 const mockPush = jest.fn()
 
 jest.mock('../hooks')
@@ -39,7 +38,7 @@ jest.mock('react-router-dom', () => {
   const reactRouterDom = jest.requireActual('react-router-dom')
   return {
     ...reactRouterDom,
-    useHistory: () => ({push: mockPush } as any)
+    useHistory: () => ({ push: mockPush } as any),
   }
 })
 jest.mock('../../RunTimeControl/hooks')

--- a/app/src/organisms/RunDetails/index.tsx
+++ b/app/src/organisms/RunDetails/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 import { useHistory } from 'react-router-dom'
 import {
@@ -34,9 +35,12 @@ import { ConfirmCancelModal } from './ConfirmCancelModal'
 
 import styles from '../ProtocolUpload/styles.css'
 import { useIsProtocolRunLoaded } from '../ProtocolUpload/hooks'
+import { getConnectedRobotName } from '../../redux/robot/selectors'
+import type { State } from '../../redux/types'
 
 export function RunDetails(): JSX.Element | null {
   const { t } = useTranslation(['run_details', 'shared'])
+  const robotName = useSelector<State>(getConnectedRobotName)
   const { displayName } = useProtocolDetails()
   const history = useHistory()
   const runStatus = useRunStatus({
@@ -44,7 +48,7 @@ export function RunDetails(): JSX.Element | null {
       if (data == null) {
         history.push('/upload')
       }
-    },
+    }
   })
   const startTime = useRunStartTime()
   const isProtocolRunLoaded = useIsProtocolRunLoaded()
@@ -75,6 +79,7 @@ export function RunDetails(): JSX.Element | null {
     confirm: confirmCloseExit,
     cancel: cancelCloseExit,
   } = useConditionalConfirm(handleCloseProtocol, true)
+  if(robotName == null) history.push('/robots')
 
   if (!isProtocolRunLoaded || isClosingCurrentRun) {
     let text = t('loading_protocol')

--- a/app/src/organisms/RunDetails/index.tsx
+++ b/app/src/organisms/RunDetails/index.tsx
@@ -48,7 +48,7 @@ export function RunDetails(): JSX.Element | null {
       if (data == null) {
         history.push('/upload')
       }
-    }
+    },
   })
   const startTime = useRunStartTime()
   const isProtocolRunLoaded = useIsProtocolRunLoaded()
@@ -79,7 +79,7 @@ export function RunDetails(): JSX.Element | null {
     confirm: confirmCloseExit,
     cancel: cancelCloseExit,
   } = useConditionalConfirm(handleCloseProtocol, true)
-  if(robotName == null) history.push('/robots')
+  if (robotName == null) history.push('/robots')
 
   if (!isProtocolRunLoaded || isClosingCurrentRun) {
     let text = t('loading_protocol')

--- a/react-api-client/src/runs/__fixtures__/runCommands.ts
+++ b/react-api-client/src/runs/__fixtures__/runCommands.ts
@@ -62,6 +62,8 @@ export const mockCommandsResponse: CommandsData = {
       meta: {
         runId: 'fake_run_id',
         commandId: 'fake_command_id',
+        key: 'fake_command_key',
+        createdAt: 'fake_command_created_at',
         index: 10,
       },
     },

--- a/react-api-client/src/runs/__tests__/useCreateCommandMutation.test.tsx
+++ b/react-api-client/src/runs/__tests__/useCreateCommandMutation.test.tsx
@@ -37,7 +37,7 @@ describe('useCreateCommandMutation hook', () => {
   it('should issue the given command to the given run when callback is called', async () => {
     when(mockUseHost).calledWith().mockReturnValue(HOST_CONFIG)
     when(mockCreateCommand)
-      .calledWith(HOST_CONFIG, RUN_ID_1, mockAnonLoadCommand)
+      .calledWith(HOST_CONFIG, RUN_ID_1, mockAnonLoadCommand, {})
       .mockResolvedValue({ data: 'something' } as any)
 
     const { result, waitFor } = renderHook(() => useCreateCommandMutation(), {
@@ -49,6 +49,35 @@ describe('useCreateCommandMutation hook', () => {
       result.current.createCommand({
         runId: RUN_ID_1,
         command: mockAnonLoadCommand,
+      })
+    })
+    await waitFor(() => {
+      return result.current.data != null
+    })
+    expect(result.current.data).toBe('something')
+  })
+  it('should pass waitUntilComplete and timeout through if given command', async () => {
+    const waitUntilComplete = true
+    const timeout = 2000
+    when(mockUseHost).calledWith().mockReturnValue(HOST_CONFIG)
+    when(mockCreateCommand)
+      .calledWith(HOST_CONFIG, RUN_ID_1, mockAnonLoadCommand, {
+        waitUntilComplete,
+        timeout,
+      })
+      .mockResolvedValue({ data: 'something' } as any)
+
+    const { result, waitFor } = renderHook(() => useCreateCommandMutation(), {
+      wrapper,
+    })
+
+    expect(result.current.data).toBeUndefined()
+    act(() => {
+      result.current.createCommand({
+        runId: RUN_ID_1,
+        command: mockAnonLoadCommand,
+        waitUntilComplete,
+        timeout,
       })
     })
     await waitFor(() => {

--- a/react-api-client/src/runs/useCreateCommandMutation.ts
+++ b/react-api-client/src/runs/useCreateCommandMutation.ts
@@ -6,39 +6,48 @@ import type {
   UseMutationOptions,
   UseMutateAsyncFunction,
 } from 'react-query'
-import type { CommandData, HostConfig } from '@opentrons/api-client'
+import type {
+  CommandData,
+  HostConfig,
+  CreateCommandParams,
+} from '@opentrons/api-client'
 import type { CreateCommand } from '@opentrons/shared-data/protocol/types/schemaV6'
 
-interface CreateCommandParams {
+interface CreateCommandMutateParams extends CreateCommandParams {
   runId: string
   command: CreateCommand
+  waitUntilComplete?: boolean
+  timeout?: number
 }
 
 export type UseCreateCommandMutationResult = UseMutationResult<
   CommandData,
   unknown,
-  CreateCommandParams
+  CreateCommandMutateParams
 > & {
   createCommand: UseMutateAsyncFunction<
     CommandData,
     unknown,
-    CreateCommandParams
+    CreateCommandMutateParams
   >
 }
 
 export type UseCreateCommandMutationOptions = UseMutationOptions<
   CommandData,
   unknown,
-  CreateCommandParams
+  CreateCommandMutateParams
 >
 
 export function useCreateCommandMutation(): UseCreateCommandMutationResult {
   const host = useHost()
   const queryClient = useQueryClient()
 
-  const mutation = useMutation<CommandData, unknown, CreateCommandParams>(
-    ({ runId, command }) =>
-      createCommand(host as HostConfig, runId, command).then(response => {
+  const mutation = useMutation<CommandData, unknown, CreateCommandMutateParams>(
+    ({ runId, command, waitUntilComplete, timeout }) =>
+      createCommand(host as HostConfig, runId, command, {
+        waitUntilComplete,
+        timeout,
+      }).then(response => {
         queryClient
           .invalidateQueries([host, 'runs'])
           .catch((e: Error) =>

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -1,9 +1,11 @@
 """Router for /runs commands endpoints."""
+from asyncio import wait_for, TimeoutError as AsyncioTimeoutError
 from datetime import datetime
-from fastapi import APIRouter, Depends, status
-from pydantic import BaseModel, Field
 from typing import Optional, Union
 from typing_extensions import Final, Literal
+
+from fastapi import APIRouter, Depends, Query, status
+from pydantic import BaseModel, Field
 
 from opentrons.protocol_engine import commands as pe_commands, errors as pe_errors
 
@@ -64,7 +66,6 @@ class CommandCollectionLinks(BaseModel):
     )
 
 
-# todo(mm, 2021-09-23): Should this accept a list of commands, instead of just one?
 @commands_router.post(
     path="/runs/{runId}/commands",
     summary="Enqueue a protocol command",
@@ -81,6 +82,35 @@ class CommandCollectionLinks(BaseModel):
 )
 async def create_run_command(
     request_body: RequestModel[pe_commands.CommandCreate],
+    waitUntilComplete: bool = Query(
+        default=False,
+        description=(
+            "If `false`, return immediately, while the new command is still queued."
+            "\n\n"
+            "If `true`, only return once the new command succeeds or fails,"
+            " or when the timeout is reached. See the `timeout` query parameter."
+        ),
+    ),
+    timeout: int = Query(
+        default=30_000,
+        gt=0,
+        description=(
+            "If `waitUntilComplete` is `true`,"
+            " the maximum number of milliseconds to wait before returning."
+            "\n\n"
+            "Ignored if `waitUntilComplete` is `false`."
+            "\n\n"
+            "The timer starts when the new command is enqueued,"
+            " *not* when it starts running."
+            " So if a different command runs before the new command,"
+            " it may exhaust the timeout even if the new command on its own"
+            " would have completed in time."
+            "\n\n"
+            "If the timeout triggers, the command will still be returned"
+            " with a `201` HTTP status code."
+            " Inspect the returned command's `status` to detect the timeout."
+        ),
+    ),
     engine_store: EngineStore = Depends(get_engine_store),
     run: Run = Depends(get_run_data_from_url),
 ) -> PydanticResponse[SimpleBody[pe_commands.Command]]:
@@ -89,6 +119,10 @@ async def create_run_command(
     Arguments:
         request_body: The request containing the command that the client wants
             to enqueue.
+        waitUntilComplete: If True, return only once the command is completed.
+            Else, return immediately. Comes from a query parameter in the URL.
+        timeout: The maximum time, in seconds, to wait before returning.
+            Comes from a query parameter in the URL.
         engine_store: Used to retrieve the `ProtocolEngine` on which the new
             command will be enqueued.
         run: Run response model, provided by the route handler for
@@ -100,10 +134,30 @@ async def create_run_command(
             status.HTTP_400_BAD_REQUEST
         )
 
-    command = engine_store.engine.add_command(request_body.data)
+    added_command = engine_store.engine.add_command(request_body.data)
+
+    command_to_return: pe_commands.Command
+
+    if waitUntilComplete:
+        try:
+            await wait_for(
+                engine_store.engine.wait_for_command(command_id=added_command.id),
+                timeout=timeout / 1000,
+            )
+            completed_command = engine_store.get_state(run.id).commands.get(
+                command_id=added_command.id
+            )
+            command_to_return = completed_command
+        except AsyncioTimeoutError:
+            timed_out_command = engine_store.get_state(run.id).commands.get(
+                command_id=added_command.id
+            )
+            command_to_return = timed_out_command
+    else:
+        command_to_return = added_command
 
     return await PydanticResponse.create(
-        content=SimpleBody.construct(data=command),
+        content=SimpleBody.construct(data=command_to_return),
         status_code=status.HTTP_201_CREATED,
     )
 


### PR DESCRIPTION
# Overview

Fixes a bug where the current command item disappears periodically and miscalculates when LPC has
been run prior to starting the protocol. Also handles fast scrolling that spans multiple windows.

Note: in order to test this protocol the backend changes in #9400 will need to be on your robot.

Closes https://github.com/Opentrons/opentrons/issues/9379

# Changelog

# Review requests

- play around with the run log after running LPC. Make sure that the current command highlights as expected and the scroll behavior is consistent.

# Risk assessment

