### PR TITLE
feat(app): heater shaker banner

### DIFF
--- a/app/src/assets/localization/en/heater_shaker.json
+++ b/app/src/assets/localization/en/heater_shaker.json
@@ -1,0 +1,4 @@
+{
+    "banner_body": "Attach the module to the robot deck to prevent module from shaking out of a deck slot.",
+    "banner_wizard_link": "See how to attach module to deck"
+}

--- a/app/src/assets/localization/en/heater_shaker.json
+++ b/app/src/assets/localization/en/heater_shaker.json
@@ -1,4 +1,5 @@
 {
-  "banner_body": "Attach the module to the robot deck to prevent module from shaking out of a deck slot.",
-  "banner_wizard_link": "See how to attach module to deck"
+  "banner_title": "Attach {{name}} to deck before proceeding to run",
+  "banner_body": "Attachment prevents the module from shaking out of a deck slot.",
+  "banner_wizard_button": "See how to attach module to the deck"
 }

--- a/app/src/assets/localization/en/heater_shaker.json
+++ b/app/src/assets/localization/en/heater_shaker.json
@@ -1,4 +1,4 @@
 {
-    "banner_body": "Attach the module to the robot deck to prevent module from shaking out of a deck slot.",
-    "banner_wizard_link": "See how to attach module to deck"
+  "banner_body": "Attach the module to the robot deck to prevent module from shaking out of a deck slot.",
+  "banner_wizard_link": "See how to attach module to deck"
 }

--- a/app/src/assets/localization/en/index.ts
+++ b/app/src/assets/localization/en/index.ts
@@ -14,6 +14,7 @@ import robot_controls from './robot_controls.json'
 import robot_info from './robot_info.json'
 import run_details from './run_details.json'
 import top_navigation from './top_navigation.json'
+import heater_shaker from './heater_shaker.json'
 
 export const en = {
   shared,
@@ -32,4 +33,5 @@ export const en = {
   robot_info,
   run_details,
   top_navigation,
+  heater_shaker,
 }

--- a/app/src/atoms/Banner/Banner.tsx
+++ b/app/src/atoms/Banner/Banner.tsx
@@ -11,6 +11,7 @@ import {
   SPACING,
   Icon,
   PrimaryBtn,
+  TEXT_TRANSFORM_NONE,
 } from '@opentrons/components'
 
 interface BannerProps {
@@ -74,7 +75,7 @@ export function Banner(props: BannerProps): JSX.Element | null {
           marginTop={TYPOGRAPHY.bannerButtonTopMargin}
           backgroundColor={COLORS.blue}
           borderRadius={SPACING.spacingM}
-          textTransform="none"
+          textTransform={TEXT_TRANSFORM_NONE}
           css={TYPOGRAPHY.labelRegular}
           alignItems={ALIGN_CENTER}
           marginRight={SPACING.spacing3}

--- a/app/src/atoms/Banner/Banner.tsx
+++ b/app/src/atoms/Banner/Banner.tsx
@@ -35,9 +35,10 @@ export function Banner(props: BannerProps): JSX.Element | null {
         justifyContent={JUSTIFY_SPACE_BETWEEN}
       >
         <Flex flexDirection={DIRECTION_COLUMN}>
-          <Flex flexDirection={DIRECTION_ROW} color={COLORS.darkGrey}>
+          <Flex flexDirection={DIRECTION_ROW}>
             <Icon
               size={SPACING.spacing6}
+              color={COLORS.darkGreyEnabled}
               name="information"
               paddingRight={SPACING.spacing3}
               paddingBottom={TYPOGRAPHY.fontSizeCaption}
@@ -51,7 +52,7 @@ export function Banner(props: BannerProps): JSX.Element | null {
               {title}
             </Text>
           </Flex>
-          {subtitle !== null ? (
+          {subtitle !== null && (
             <Text
               fontSize={TYPOGRAPHY.fontSizeP}
               color={COLORS.darkBlack}
@@ -59,7 +60,7 @@ export function Banner(props: BannerProps): JSX.Element | null {
             >
               {subtitle}
             </Text>
-          ) : null}
+          )}
           <Text
             paddingTop={subtitle === null ? SPACING.spacingM : SPACING.spacing2}
             color={COLORS.darkGrey}

--- a/app/src/atoms/Banner/Banner.tsx
+++ b/app/src/atoms/Banner/Banner.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react'
+import {
+  COLORS,
+  Flex,
+  Text,
+  DIRECTION_COLUMN,
+  JUSTIFY_SPACE_BETWEEN,
+  DIRECTION_ROW,
+  ALIGN_CENTER,
+  TYPOGRAPHY,
+  SPACING,
+  Icon,
+  PrimaryBtn,
+} from '@opentrons/components'
+
+interface BannerProps {
+  title: string
+  subtitle?: string
+  body: string
+  btnText: string
+  onClick: () => void
+}
+
+export function Banner(props: BannerProps): JSX.Element | null {
+  const { title, subtitle, body, btnText, onClick } = props
+
+  return (
+    <React.Fragment>
+      <Flex
+        marginTop={TYPOGRAPHY.lineHeight16}
+        flexDirection={DIRECTION_ROW}
+        backgroundColor={COLORS.background}
+        padding={SPACING.spacing5}
+        justifyContent={JUSTIFY_SPACE_BETWEEN}
+      >
+        <Flex flexDirection={DIRECTION_COLUMN}>
+          <Flex flexDirection={DIRECTION_ROW} color={COLORS.darkGrey}>
+            <Icon
+              size={SPACING.spacing6}
+              name="information"
+              paddingRight={SPACING.spacing3}
+              paddingBottom={TYPOGRAPHY.fontSizeCaption}
+              aria-label="information_icon"
+            />
+            <Text
+              fontSize={TYPOGRAPHY.fontSizeH3}
+              data-testid={`banner_title_${title}`}
+              color={COLORS.darkBlack}
+            >
+              {title}
+            </Text>
+          </Flex>
+          {subtitle !== null ? (
+            <Text
+              fontSize={TYPOGRAPHY.fontSizeP}
+              color={COLORS.darkBlack}
+              paddingTop={SPACING.spacing4}
+            >
+              {subtitle}
+            </Text>
+          ) : null}
+          <Text
+            paddingTop={subtitle === null ? SPACING.spacingM : SPACING.spacing2}
+            color={COLORS.darkGrey}
+            fontSize={TYPOGRAPHY.fontSizeP}
+            data-testid={`banner_body_${title}`}
+          >
+            {body}
+          </Text>
+        </Flex>
+
+        {/* TODO immediately: use NewPrimaryBtn when sarah's pr is merged */}
+        <PrimaryBtn
+          marginTop={TYPOGRAPHY.bannerButtonTopMargin}
+          backgroundColor={COLORS.blue}
+          borderRadius={SPACING.spacingM}
+          textTransform="none"
+          css={TYPOGRAPHY.labelRegular}
+          alignItems={ALIGN_CENTER}
+          marginRight={SPACING.spacing3}
+          data-testid={`banner_open_wizard_btn`}
+          onClick={onClick}
+        >
+          {btnText}
+        </PrimaryBtn>
+      </Flex>
+    </React.Fragment>
+  )
+}

--- a/app/src/atoms/Banner/__tests__/Banner.test.tsx
+++ b/app/src/atoms/Banner/__tests__/Banner.test.tsx
@@ -19,12 +19,26 @@ describe('HeaterShakerBanner', () => {
     }
   })
 
-  it('should render correct text', () => {
-    const { getByText } = render(props)
+  it('should render correct text when subtitle is not null', () => {
+    const { getByText, getByLabelText } = render(props)
     getByText('TITLE')
     getByText('BODY')
     getByText('btnText')
     getByText('SUBTITLE')
+    getByLabelText('information_icon')
+  })
+
+  it('should render correct text when subtitle null', () => {
+    props = {
+      title: 'TITLE',
+      body: 'BODY',
+      btnText: 'btnText',
+      onClick: jest.fn(),
+    }
+    const { getByText } = render(props)
+    getByText('TITLE')
+    getByText('BODY')
+    getByText('btnText')
   })
 
   it('should render button and it is clickable', () => {

--- a/app/src/atoms/Banner/__tests__/Banner.test.tsx
+++ b/app/src/atoms/Banner/__tests__/Banner.test.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react'
+import { fireEvent } from '@testing-library/react'
+import { renderWithProviders } from '@opentrons/components'
+import { Banner } from '../Banner'
+
+const render = (props: React.ComponentProps<typeof Banner>) => {
+  return renderWithProviders(<Banner {...props} />)[0]
+}
+
+describe('HeaterShakerBanner', () => {
+  let props: React.ComponentProps<typeof Banner>
+  beforeEach(() => {
+    props = {
+      title: 'TITLE',
+      body: 'BODY',
+      btnText: 'btnText',
+      subtitle: 'SUBTITLE',
+      onClick: jest.fn(),
+    }
+  })
+
+  it('should render correct text', () => {
+    const { getByText } = render(props)
+    getByText('TITLE')
+    getByText('BODY')
+    getByText('btnText')
+    getByText('SUBTITLE')
+  })
+
+  it('should render button and it is clickable', () => {
+    const { getByRole } = render(props)
+    const button = getByRole('button', {
+      name: 'btnText',
+    })
+    fireEvent.click(button)
+    expect(button).toBeEnabled()
+  })
+})

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/HeaterShakerBanner.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/HeaterShakerBanner.tsx
@@ -1,77 +1,23 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import {
-  COLORS,
-  Flex,
-  Text,
-  TEXT_TRANSFORM_UPPERCASE,
-  DIRECTION_COLUMN,
-  JUSTIFY_SPACE_BETWEEN,
-  DIRECTION_ROW,
-  ALIGN_CENTER,
-  Btn,
-  TYPOGRAPHY,
-  SPACING,
-} from '@opentrons/components'
-import type { ModuleDefinition } from '@opentrons/shared-data'
+import { Banner } from '../../../../../atoms/Banner/Banner'
 
 interface HeaterShakerBannerProps {
-  moduleDef: ModuleDefinition
+  model: string
 }
 
 export function HeaterShakerBanner(
   props: HeaterShakerBannerProps
 ): JSX.Element | null {
-  const { moduleDef } = props
+  const { model } = props
   const { t } = useTranslation('heater_shaker')
 
   return (
-    <React.Fragment>
-      <Flex
-        marginTop={TYPOGRAPHY.lineHeight16}
-        flexDirection={DIRECTION_ROW}
-        backgroundColor={COLORS.background}
-        padding={SPACING.spacing3}
-        justifyContent={JUSTIFY_SPACE_BETWEEN}
-      >
-        <Flex flexDirection={DIRECTION_COLUMN}>
-          <Text
-            color={COLORS.darkGrey}
-            textTransform={TEXT_TRANSFORM_UPPERCASE}
-            fontSize={TYPOGRAPHY.fontSizeH6}
-            data-testid={`heater_shaker_banner_slot`}
-          >
-            {/* TODO immediately: add in slot number, its stubbed for now until we can access protocol context */}
-            {'Slot 1'}
-          </Text>
-          <Text
-            paddingTop={SPACING.spacing2}
-            color={COLORS.darkBlack}
-            fontSize={TYPOGRAPHY.fontSizeP}
-            data-testid={`heater_shaker_banner_${moduleDef.displayName}`}
-          >
-            {moduleDef.displayName}
-          </Text>
-          <Text
-            paddingTop={SPACING.spacing2}
-            color={COLORS.darkGrey}
-            fontSize={TYPOGRAPHY.fontSizeH6}
-            data-testid={`heater_shaker_banner_body`}
-          >
-            {t('banner_body')}
-          </Text>
-        </Flex>
-        <Btn
-          color={COLORS.blue}
-          fontSize={TYPOGRAPHY.fontSizeH6}
-          alignItems={ALIGN_CENTER}
-          paddingRight={SPACING.spacing3}
-          data-testid={`heater_shaker_banner_open_wizard`}
-          onClick={() => console.log('open wizard')}
-        >
-          {t('banner_wizard_link')}
-        </Btn>
-      </Flex>
-    </React.Fragment>
+    <Banner
+      title={t('banner_title', { name: model })}
+      body={t('banner_body')}
+      btnText={t('banner_wizard_button')}
+      onClick={() => console.log('proceed to wizard')}
+    />
   )
 }

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/HeaterShakerBanner.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/HeaterShakerBanner.tsx
@@ -39,6 +39,7 @@ export function HeaterShakerBanner(
             color={COLORS.darkGrey}
             textTransform={TEXT_TRANSFORM_UPPERCASE}
             fontSize={TYPOGRAPHY.fontSizeH6}
+            data-testid={`heater_shaker_banner_slot`}
           >
             {/* TODO immediately: add in slot number, its stubbed for now until we can access protocol context */}
             {'Slot 1'}
@@ -47,6 +48,7 @@ export function HeaterShakerBanner(
             paddingTop={SPACING.spacing2}
             color={COLORS.darkBlack}
             fontSize={TYPOGRAPHY.fontSizeP}
+            data-testid={`heater_shaker_banner_${moduleDef.displayName}`}
           >
             {moduleDef.displayName}
           </Text>
@@ -54,6 +56,7 @@ export function HeaterShakerBanner(
             paddingTop={SPACING.spacing2}
             color={COLORS.darkGrey}
             fontSize={TYPOGRAPHY.fontSizeH6}
+            data-testid={`heater_shaker_banner_body`}
           >
             {t('banner_body')}
           </Text>
@@ -63,6 +66,7 @@ export function HeaterShakerBanner(
           fontSize={TYPOGRAPHY.fontSizeH6}
           alignItems={ALIGN_CENTER}
           paddingRight={SPACING.spacing3}
+          data-testid={`heater_shaker_banner_open_wizard`}
           onClick={() => console.log('open wizard')}
         >
           {t('banner_wizard_link')}

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/HeaterShakerBanner.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/HeaterShakerBanner.tsx
@@ -3,18 +3,18 @@ import { useTranslation } from 'react-i18next'
 import { Banner } from '../../../../../atoms/Banner/Banner'
 
 interface HeaterShakerBannerProps {
-  model: string
+  displayName: string
 }
 
 export function HeaterShakerBanner(
   props: HeaterShakerBannerProps
 ): JSX.Element | null {
-  const { model } = props
+  const { displayName } = props
   const { t } = useTranslation('heater_shaker')
 
   return (
     <Banner
-      title={t('banner_title', { name: model })}
+      title={t('banner_title', { name: displayName })}
       body={t('banner_body')}
       btnText={t('banner_wizard_button')}
       onClick={() => console.log('proceed to wizard')}

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/HeaterShakerBanner.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/HeaterShakerBanner.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  COLORS,
+  Flex,
+  Text,
+  TEXT_TRANSFORM_UPPERCASE,
+  DIRECTION_COLUMN,
+  JUSTIFY_SPACE_BETWEEN,
+  DIRECTION_ROW,
+  ALIGN_CENTER,
+  Btn,
+  TYPOGRAPHY,
+  SPACING,
+} from '@opentrons/components'
+import type { ModuleDefinition } from '@opentrons/shared-data'
+
+interface HeaterShakerBannerProps {
+  moduleDef: ModuleDefinition
+}
+
+export function HeaterShakerBanner(
+  props: HeaterShakerBannerProps
+): JSX.Element | null {
+  const { moduleDef } = props
+  const { t } = useTranslation('heater_shaker')
+
+  return (
+    <React.Fragment>
+      <Flex
+        marginTop={TYPOGRAPHY.lineHeight16}
+        flexDirection={DIRECTION_ROW}
+        backgroundColor={COLORS.background}
+        padding={SPACING.spacing3}
+        justifyContent={JUSTIFY_SPACE_BETWEEN}
+      >
+        <Flex flexDirection={DIRECTION_COLUMN}>
+          <Text
+            color={COLORS.darkGrey}
+            textTransform={TEXT_TRANSFORM_UPPERCASE}
+            fontSize={TYPOGRAPHY.fontSizeH6}
+          >
+            {/* TODO immediately: add in slot number, its stubbed for now until we can access protocol context */}
+            {'Slot 1'}
+          </Text>
+          <Text
+            paddingTop={SPACING.spacing2}
+            color={COLORS.darkBlack}
+            fontSize={TYPOGRAPHY.fontSizeP}
+          >
+            {moduleDef.displayName}
+          </Text>
+          <Text
+            paddingTop={SPACING.spacing2}
+            color={COLORS.darkGrey}
+            fontSize={TYPOGRAPHY.fontSizeH6}
+          >
+            {t('banner_body')}
+          </Text>
+        </Flex>
+        <Btn
+          color={COLORS.blue}
+          fontSize={TYPOGRAPHY.fontSizeH6}
+          alignItems={ALIGN_CENTER}
+          paddingRight={SPACING.spacing3}
+          onClick={() => console.log('open wizard')}
+        >
+          {t('banner_wizard_link')}
+        </Btn>
+      </Flex>
+    </React.Fragment>
+  )
+}

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/__tests__/HeaterShakerBanner.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/__tests__/HeaterShakerBanner.test.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react'
-import { fireEvent } from '@testing-library/react'
 import { i18n } from '../../../../../../i18n'
 import { renderWithProviders } from '@opentrons/components'
+import { Banner } from '../../../../../../atoms/Banner/Banner'
 import { HeaterShakerBanner } from '../HeaterShakerBanner'
 
-import type { ModuleDefinition } from '@opentrons/shared-data'
+jest.mock('../../../../../../atoms/Banner/Banner')
+
+const mockBanner = Banner as jest.MockedFunction<typeof Banner>
 
 const render = (props: React.ComponentProps<typeof HeaterShakerBanner>) => {
   return renderWithProviders(<HeaterShakerBanner {...props} />, {
@@ -12,30 +14,17 @@ const render = (props: React.ComponentProps<typeof HeaterShakerBanner>) => {
   })[0]
 }
 
-const mockHeaterShakerStub = {
-  displayName: 'Heater Shaker Module GEN1',
-} as ModuleDefinition
 describe('HeaterShakerBanner', () => {
   let props: React.ComponentProps<typeof HeaterShakerBanner>
   beforeEach(() => {
-    props = { moduleDef: mockHeaterShakerStub }
-  })
-
-  it('should render the correct header and body', () => {
-    const { getByText } = render(props)
-    getByText('Slot 1')
-    getByText('Heater Shaker Module GEN1')
-    getByText(
-      'Attach the module to the robot deck to prevent module from shaking out of a deck slot.'
+    props = { model: 'HeaterShakerV1' }
+    mockBanner.mockReturnValue(
+      <div>Attach HeaterShakerV1 to deck before proceeding to run</div>
     )
   })
 
-  it('should render button and it is clickable', () => {
-    const { getByRole } = render(props)
-    const wizardButton = getByRole('button', {
-      name: 'See how to attach module to deck',
-    })
-    fireEvent.click(wizardButton)
-    expect(wizardButton).toBeEnabled()
+  it('should render banner component', () => {
+    const { getByText } = render(props)
+    getByText('Attach HeaterShakerV1 to deck before proceeding to run')
   })
 })

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/__tests__/HeaterShakerBanner.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/__tests__/HeaterShakerBanner.test.tsx
@@ -17,7 +17,7 @@ const render = (props: React.ComponentProps<typeof HeaterShakerBanner>) => {
 describe('HeaterShakerBanner', () => {
   let props: React.ComponentProps<typeof HeaterShakerBanner>
   beforeEach(() => {
-    props = { model: 'HeaterShakerV1' }
+    props = { displayName: 'HeaterShakerV1' }
     mockBanner.mockReturnValue(<div>mock banner</div>)
   })
 

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/__tests__/HeaterShakerBanner.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/__tests__/HeaterShakerBanner.test.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react'
+import { fireEvent } from '@testing-library/react'
+import { i18n } from '../../../../../../i18n'
+import { renderWithProviders } from '@opentrons/components'
+import { HeaterShakerBanner } from '../HeaterShakerBanner'
+
+import type { ModuleDefinition } from '@opentrons/shared-data'
+
+const render = (props: React.ComponentProps<typeof HeaterShakerBanner>) => {
+  return renderWithProviders(<HeaterShakerBanner {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+const mockHeaterShakerStub = {
+  displayName: 'Heater Shaker Module GEN1',
+} as ModuleDefinition
+describe('HeaterShakerBanner', () => {
+  let props: React.ComponentProps<typeof HeaterShakerBanner>
+  beforeEach(() => {
+    props = { moduleDef: mockHeaterShakerStub }
+  })
+
+  it('should render the correct header and body', () => {
+    const { getByText } = render(props)
+    getByText('Slot 1')
+    getByText('Heater Shaker Module GEN1')
+    getByText(
+      'Attach the module to the robot deck to prevent module from shaking out of a deck slot.'
+    )
+  })
+
+  it('should render button and it is clickable', () => {
+    const { getByRole } = render(props)
+    const wizardButton = getByRole('button', {
+      name: 'See how to attach module to deck',
+    })
+    fireEvent.click(wizardButton)
+    expect(wizardButton).toBeEnabled()
+  })
+})

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/__tests__/HeaterShakerBanner.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/__tests__/HeaterShakerBanner.test.tsx
@@ -18,13 +18,11 @@ describe('HeaterShakerBanner', () => {
   let props: React.ComponentProps<typeof HeaterShakerBanner>
   beforeEach(() => {
     props = { model: 'HeaterShakerV1' }
-    mockBanner.mockReturnValue(
-      <div>Attach HeaterShakerV1 to deck before proceeding to run</div>
-    )
+    mockBanner.mockReturnValue(<div>mock banner</div>)
   })
 
   it('should render banner component', () => {
     const { getByText } = render(props)
-    getByText('Attach HeaterShakerV1 to deck before proceeding to run')
+    getByText('mock banner')
   })
 })

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/__tests__/ModuleSetup.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/__tests__/ModuleSetup.test.tsx
@@ -28,6 +28,7 @@ import { MultipleModulesModal } from '../MultipleModulesModal'
 import { ModuleSetup } from '..'
 import { ModuleInfo } from '../ModuleInfo'
 import { UnMatchedModuleWarning } from '../UnMatchedModuleWarning'
+import { HeaterShakerBanner } from '../HeaterShakerSetupWizard/HeaterShakerBanner'
 
 jest.mock('../../../../../redux/modules')
 jest.mock('../ModuleInfo')
@@ -35,6 +36,7 @@ jest.mock('../../hooks')
 jest.mock('../../../hooks')
 jest.mock('../MultipleModulesModal')
 jest.mock('../UnMatchedModuleWarning')
+jest.mock('../HeaterShakerSetupWizard/HeaterShakerBanner')
 jest.mock('@opentrons/components', () => {
   const actualComponents = jest.requireActual('@opentrons/components')
   return {
@@ -70,6 +72,9 @@ const mockUseModuleRenderInfoById = useModuleRenderInfoById as jest.MockedFuncti
 >
 const mockUnMatchedModuleWarning = UnMatchedModuleWarning as jest.MockedFunction<
   typeof UnMatchedModuleWarning
+>
+const mockHeaterShakerBanner = HeaterShakerBanner as jest.MockedFunction<
+  typeof HeaterShakerBanner
 >
 
 const deckSlotsById = standardDeckDef.locations.orderedSlots.reduce(
@@ -168,6 +173,10 @@ describe('ModuleSetup', () => {
     when(mockGetAttachedModules)
       .calledWith(undefined as any, MOCK_ROBOT_NAME)
       .mockReturnValue([])
+
+    when(mockHeaterShakerBanner).mockReturnValue(
+      <div>mock Heater Shaker Banner</div>
+    )
   })
 
   afterEach(() => {
@@ -450,4 +459,5 @@ describe('ModuleSetup', () => {
     const button = getByRole('button', { name: 'Proceed to Labware Setup' })
     expect(button).not.toBeDisabled()
   })
+  it.todo('renders heater shaker banner correctly')
 })

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/index.tsx
@@ -93,7 +93,9 @@ export function ModuleSetup(props: ModuleSetupProps): JSX.Element {
           <>
             {/* @ts-expect-error: this is always false until heater shaker is added to model */}
             {model === 'heatershakermoduleV1' && (
-              <HeaterShakerBanner displayName={moduleDef.displayName} />
+              <Flex key="heater_shaker_banner">
+                <HeaterShakerBanner displayName={moduleDef.displayName} />
+              </Flex>
             )}
           </>
         )

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/index.tsx
@@ -29,6 +29,7 @@ import { useModuleRenderInfoById } from '../../hooks'
 import styles from '../../styles.css'
 
 import type { Dispatch } from '../../../../redux/types'
+import { HeaterShakerBanner } from './HeaterShakerSetupWizard/HeaterShakerBanner'
 
 const DECK_LAYER_BLOCKLIST = [
   'calibrationMarkings',
@@ -85,6 +86,19 @@ export function ModuleSetup(props: ModuleSetupProps): JSX.Element {
           onCloseClick={() => setShowMultipleModulesModal(false)}
         />
       )}
+
+      {map(moduleRenderInfoById, ({ moduleDef }) => {
+        const { model } = moduleDef
+        return (
+          <>
+            {/* @ts-expect-error this will say false always until heaterShakerV1 is added to the model */}
+            {model === 'heaterShakerV1' && (
+              <HeaterShakerBanner moduleDef={moduleDef} />
+            )}
+          </>
+        )
+      })}
+
       {hasADuplicateModule ? (
         <Btn
           as={Link}

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/index.tsx
@@ -21,15 +21,15 @@ import {
 import { inferModuleOrientationFromXCoordinate } from '@opentrons/shared-data'
 import standardDeckDef from '@opentrons/shared-data/deck/definitions/2/ot2_standard.json'
 import { useModuleMatchResults } from '../hooks'
+import { useModuleRenderInfoById } from '../../hooks'
 import { fetchModules } from '../../../../redux/modules'
 import { ModuleInfo } from './ModuleInfo'
 import { UnMatchedModuleWarning } from './UnMatchedModuleWarning'
 import { MultipleModulesModal } from './MultipleModulesModal'
-import { useModuleRenderInfoById } from '../../hooks'
+import { HeaterShakerBanner } from './HeaterShakerSetupWizard/HeaterShakerBanner'
 import styles from '../../styles.css'
 
 import type { Dispatch } from '../../../../redux/types'
-import { HeaterShakerBanner } from './HeaterShakerSetupWizard/HeaterShakerBanner'
 
 const DECK_LAYER_BLOCKLIST = [
   'calibrationMarkings',
@@ -91,9 +91,9 @@ export function ModuleSetup(props: ModuleSetupProps): JSX.Element {
         const { model } = moduleDef
         return (
           <>
-            {/* @ts-expect-error this will say false always until heaterShakerV1 is added to the model */}
-            {model === 'heaterShakerV1' && (
-              <HeaterShakerBanner moduleDef={moduleDef} />
+            {/* @ts-expect-error: this is always false until heater shaker is added to model */}
+            {model === 'heatershakermoduleV1' && (
+              <HeaterShakerBanner model={moduleDef.displayName} />
             )}
           </>
         )

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/index.tsx
@@ -91,7 +91,8 @@ export function ModuleSetup(props: ModuleSetupProps): JSX.Element {
         const { model } = moduleDef
         return (
           <>
-            {model === 'magneticModuleV2' && (
+            {/* @ts-expect-error: this is always false until heater shaker is added to model */}
+            {model === 'heatershakermoduleV1' && (
               <HeaterShakerBanner displayName={moduleDef.displayName} />
             )}
           </>

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/index.tsx
@@ -80,7 +80,7 @@ export function ModuleSetup(props: ModuleSetupProps): JSX.Element {
       : null
 
   return (
-    <Flex flex="1" maxHeight="80vh" flexDirection={DIRECTION_COLUMN}>
+    <Flex flex="1" maxHeight="100vh" flexDirection={DIRECTION_COLUMN}>
       {showMultipleModulesModal && (
         <MultipleModulesModal
           onCloseClick={() => setShowMultipleModulesModal(false)}
@@ -91,9 +91,8 @@ export function ModuleSetup(props: ModuleSetupProps): JSX.Element {
         const { model } = moduleDef
         return (
           <>
-            {/* @ts-expect-error: this is always false until heater shaker is added to model */}
-            {model === 'heatershakermoduleV1' && (
-              <HeaterShakerBanner model={moduleDef.displayName} />
+            {model === 'magneticModuleV2' && (
+              <HeaterShakerBanner displayName={moduleDef.displayName} />
             )}
           </>
         )

--- a/components/src/ui-style-constants/colors.ts
+++ b/components/src/ui-style-constants/colors.ts
@@ -19,6 +19,7 @@ export const darkBlackPressed = '#16212D'
 export const darkGrey = '#4a4a4a'
 export const darkGreyHover = '#787a7d'
 export const darkGreyPressed = '#646668'
+export const darkGreyEnabled = '#707075'
 // note: darkGreyDisabled = greyDisabled
 
 export const greyHover = '#acacaf'

--- a/components/src/ui-style-constants/colors.ts
+++ b/components/src/ui-style-constants/colors.ts
@@ -16,7 +16,7 @@ export const darkBlackHover = '#283d52'
 export const darkBlackPressed = '#16212D'
 // note: darkBlackDisabled = greyDisabled
 
-export const darkGrey = '#8a8c8e'
+export const darkGrey = '#4a4a4a'
 export const darkGreyHover = '#787a7d'
 export const darkGreyPressed = '#646668'
 // note: darkGreyDisabled = greyDisabled

--- a/components/src/ui-style-constants/spacing.ts
+++ b/components/src/ui-style-constants/spacing.ts
@@ -5,3 +5,4 @@ export const spacing3 = '0.5rem' // 8px
 export const spacing4 = '1rem' // 16px
 export const spacing5 = '1.5rem' // 24px
 export const spacing6 = '2rem' // 32px
+export const spacingM = '1.25rem' // 20px

--- a/components/src/ui-style-constants/typography.ts
+++ b/components/src/ui-style-constants/typography.ts
@@ -48,6 +48,9 @@ export const boxShadowM = '0px 3px 6px rgba(0, 0, 0, 0.23)'
 //  Overflow menu btn width
 export const overflowMenuWidth = '9.562rem'
 
+//  Banner component styling
+export const bannerButtonTopMargin = '2.75rem'
+
 // Default font styles, color agnositic for first pass
 export const h1Default = css`
   font-size: ${fontSizeH1};


### PR DESCRIPTION
closes #9243

# Overview

This PR creates the heater shaker banner with the slot number stubbed in (note: I used the magnetic module so  you can visually see how the banner looks)

<img width="934" alt="Screen Shot 2022-02-11 at 2 32 36 PM" src="https://user-images.githubusercontent.com/66035149/153657577-3a1a38a2-cdc0-4a5b-820c-6d37260e2980.png">

# Changelog

- created `HeaterShakerBanner` component and made a few new folders for Heater Shaker within the `ModuleSetup` folder
- created `heater_shaker.json`
- created a generic `Banner` shared component and placed it in Atoms

# Review requests

- examine organization of folders - does it look ok?
- examine the above photo: does styling match the figma? I stubbed in module name (magnetic module for now until we have the heater shaker module def), the banner body, and the link to start the setup wizard
- the link should console.log `proceed to wizard`
- examine selectors


Note: still using the old `primaryBtn` until Sarah's [PR](https://github.com/Opentrons/opentrons/pull/9426#pullrequestreview-880379049) is merged

# Risk assessment

low
