### PR TITLE
refactor(api): axis and mounts for ot3

### DIFF
--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -2,10 +2,10 @@ from typing import Any, Dict, cast, List
 from typing_extensions import Final
 from dataclasses import asdict
 
+from opentrons.hardware_control.types import OT3AxisKind
 from .types import (
     OT3Config,
     ByGantryLoad,
-    GeneralizeableAxisDict,
     OT3MotionSettings,
     OT3Transform,
     Offset,
@@ -27,197 +27,215 @@ DEFAULT_RIGHT_MOUNT_OFFSET: Final[Offset] = (33, -63.05, 256.175)
 DEFAULT_GRIPPER_MOUNT_OFFSET: Final[Offset] = (-50.0, 0.0, 0.0)
 DEFAULT_Z_RETRACT_DISTANCE: Final = 2
 
-DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[GeneralizeableAxisDict]] = ByGantryLoad(
+DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad(
     none={
-        "X": 500,
-        "Y": 500,
-        "Z": 500,
-        "P": 500,
+        OT3AxisKind.X: 500,
+        OT3AxisKind.Y: 500,
+        OT3AxisKind.Z: 500,
+        OT3AxisKind.P: 500,
     },
     high_throughput={
-        "X": 500,
-        "Y": 500,
-        "Z": 500,
-        "P": 500,
+        OT3AxisKind.X: 500,
+        OT3AxisKind.Y: 500,
+        OT3AxisKind.Z: 500,
+        OT3AxisKind.P: 500,
     },
     low_throughput={
-        "X": 500,
-        "Y": 500,
-        "Z": 500,
-        "P": 500,
+        OT3AxisKind.X: 500,
+        OT3AxisKind.Y: 500,
+        OT3AxisKind.Z: 500,
+        OT3AxisKind.P: 500,
     },
     two_low_throughput={
-        "X": 500,
-        "Y": 500,
+        OT3AxisKind.X: 500,
+        OT3AxisKind.Y: 500,
     },
     gripper={
-        "Z": 500,
+        OT3AxisKind.Z: 500,
     },
 )
 
-DEFAULT_ACCELERATIONS: Final[ByGantryLoad[GeneralizeableAxisDict]] = ByGantryLoad(
+DEFAULT_ACCELERATIONS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad(
     none={
-        "X": 10000,
-        "Y": 10000,
-        "Z": 10000,
-        "P": 10000,
+        OT3AxisKind.X: 10000,
+        OT3AxisKind.Y: 10000,
+        OT3AxisKind.Z: 10000,
+        OT3AxisKind.P: 10000,
     },
     high_throughput={
-        "X": 10000,
-        "Y": 10000,
-        "Z": 10000,
-        "P": 10000,
+        OT3AxisKind.X: 10000,
+        OT3AxisKind.Y: 10000,
+        OT3AxisKind.Z: 10000,
+        OT3AxisKind.P: 10000,
     },
     low_throughput={
-        "X": 10000,
-        "Y": 10000,
-        "Z": 10000,
-        "P": 10000,
+        OT3AxisKind.X: 10000,
+        OT3AxisKind.Y: 10000,
+        OT3AxisKind.Z: 10000,
+        OT3AxisKind.P: 10000,
     },
     two_low_throughput={
-        "X": 10000,
-        "Y": 10000,
+        OT3AxisKind.X: 10000,
+        OT3AxisKind.Y: 10000,
     },
     gripper={
-        "Z": 10000,
+        OT3AxisKind.Z: 10000,
     },
 )
 
 DEFAULT_MAX_SPEED_DISCONTINUITY: Final[
-    ByGantryLoad[GeneralizeableAxisDict]
+    ByGantryLoad[Dict[OT3AxisKind, float]]
 ] = ByGantryLoad(
     none={
-        "X": 40,
-        "Y": 40,
-        "Z": 40,
-        "P": 40,
+        OT3AxisKind.X: 40,
+        OT3AxisKind.Y: 40,
+        OT3AxisKind.Z: 40,
+        OT3AxisKind.P: 40,
     },
     high_throughput={
-        "X": 40,
-        "Y": 40,
-        "Z": 40,
-        "P": 40,
+        OT3AxisKind.X: 40,
+        OT3AxisKind.Y: 40,
+        OT3AxisKind.Z: 40,
+        OT3AxisKind.P: 40,
     },
     low_throughput={
-        "X": 40,
-        "Y": 40,
-        "Z": 40,
-        "P": 40,
+        OT3AxisKind.X: 40,
+        OT3AxisKind.Y: 40,
+        OT3AxisKind.Z: 40,
+        OT3AxisKind.P: 40,
     },
     two_low_throughput={
-        "X": 40,
-        "Y": 40,
+        OT3AxisKind.X: 40,
+        OT3AxisKind.Y: 40,
     },
     gripper={
-        "Z": 40,
+        OT3AxisKind.Z: 40,
     },
 )
 
 DEFAULT_DIRECTION_CHANGE_SPEED_DISCONTINUITY: Final[
-    ByGantryLoad[GeneralizeableAxisDict]
+    ByGantryLoad[Dict[OT3AxisKind, float]]
 ] = ByGantryLoad(
     none={
-        "X": 20,
-        "Y": 20,
-        "Z": 20,
-        "P": 20,
+        OT3AxisKind.X: 20,
+        OT3AxisKind.Y: 20,
+        OT3AxisKind.Z: 20,
+        OT3AxisKind.P: 20,
     },
     high_throughput={
-        "X": 20,
-        "Y": 20,
-        "Z": 20,
-        "P": 20,
+        OT3AxisKind.X: 20,
+        OT3AxisKind.Y: 20,
+        OT3AxisKind.Z: 20,
+        OT3AxisKind.P: 20,
     },
     low_throughput={
-        "X": 20,
-        "Y": 20,
-        "Z": 20,
-        "P": 20,
+        OT3AxisKind.X: 20,
+        OT3AxisKind.Y: 20,
+        OT3AxisKind.Z: 20,
+        OT3AxisKind.P: 20,
     },
     two_low_throughput={
-        "X": 20,
-        "Y": 20,
+        OT3AxisKind.X: 20,
+        OT3AxisKind.Y: 20,
     },
     gripper={
-        "Z": 20,
+        OT3AxisKind.Z: 20,
     },
 )
 
-DEFAULT_HOLDING_CURRENT: Final[ByGantryLoad[GeneralizeableAxisDict]] = ByGantryLoad(
+DEFAULT_HOLDING_CURRENT: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad(
     none={
-        "X": 0.1,
-        "Y": 0.1,
-        "Z": 0.1,
-        "P": 0.1,
+        OT3AxisKind.X: 0.1,
+        OT3AxisKind.Y: 0.1,
+        OT3AxisKind.Z: 0.1,
+        OT3AxisKind.P: 0.1,
     },
     high_throughput={
-        "X": 0.1,
-        "Y": 0.1,
-        "Z": 0.1,
-        "P": 0.1,
+        OT3AxisKind.X: 0.1,
+        OT3AxisKind.Y: 0.1,
+        OT3AxisKind.Z: 0.1,
+        OT3AxisKind.P: 0.1,
     },
     low_throughput={
-        "X": 0.1,
-        "Y": 0.1,
-        "Z": 0.1,
-        "P": 0.1,
+        OT3AxisKind.X: 0.1,
+        OT3AxisKind.Y: 0.1,
+        OT3AxisKind.Z: 0.1,
+        OT3AxisKind.P: 0.1,
     },
     two_low_throughput={
-        "X": 0.1,
-        "Y": 0.1,
+        OT3AxisKind.X: 0.1,
+        OT3AxisKind.Y: 0.1,
     },
     gripper={
-        "Z": 0.1,
+        OT3AxisKind.Z: 0.1,
     },
 )
 
 DEFAULT_NORMAL_MOTION_CURRENT: Final[
-    ByGantryLoad[GeneralizeableAxisDict]
+    ByGantryLoad[Dict[OT3AxisKind, float]]
 ] = ByGantryLoad(
     none={
-        "X": 1.0,
-        "Y": 1.0,
-        "Z": 1.0,
-        "P": 1.0,
+        OT3AxisKind.X: 1.0,
+        OT3AxisKind.Y: 1.0,
+        OT3AxisKind.Z: 1.0,
+        OT3AxisKind.P: 1.0,
     },
     high_throughput={
-        "X": 1.0,
-        "Y": 1.0,
-        "Z": 1.0,
-        "P": 1.0,
+        OT3AxisKind.X: 1.0,
+        OT3AxisKind.Y: 1.0,
+        OT3AxisKind.Z: 1.0,
+        OT3AxisKind.P: 1.0,
     },
     low_throughput={
-        "X": 1.0,
-        "Y": 1.0,
-        "Z": 1.0,
-        "P": 1.0,
+        OT3AxisKind.X: 1.0,
+        OT3AxisKind.Y: 1.0,
+        OT3AxisKind.Z: 1.0,
+        OT3AxisKind.P: 1.0,
     },
     two_low_throughput={
-        "X": 1.0,
-        "Y": 1.0,
+        OT3AxisKind.X: 1.0,
+        OT3AxisKind.Y: 1.0,
     },
     gripper={
-        "Z": 1.0,
+        OT3AxisKind.Z: 1.0,
     },
 )
 
 
 def _build_dict_with_default(
     from_conf: Any,
-    default: GeneralizeableAxisDict,
-) -> GeneralizeableAxisDict:
+    default: Dict[OT3AxisKind, float],
+) -> Dict[OT3AxisKind, float]:
     if not isinstance(from_conf, dict):
-        return default
+        return {k: v for k, v in default.items()}
     else:
-        for k in default.keys():
-            if k not in from_conf:
-                from_conf[k] = default[k]  # type: ignore[misc]
-        return cast(GeneralizeableAxisDict, from_conf)
+        validated: Dict[OT3AxisKind, float] = {}
+        # Keep what is specified, handling it being
+        # either enum element name string or enum element directly
+        for k, v in from_conf.items():
+            if isinstance(k, OT3AxisKind):
+                validated[k] = v
+            else:
+                try:
+                    enumval = OT3AxisKind[k]
+                except KeyError:  # not an enum entry
+                    pass
+                else:
+                    validated[enumval] = v
+        # Add what's missing relative to the default
+        for k, default_v in default.items():
+            if k in from_conf:
+                validated[k] = from_conf[k]
+            elif k.name in from_conf:
+                validated[k] = from_conf[k.name]
+            else:
+                validated[k] = default_v
+        return validated
 
 
 def _build_default_bpk(
-    from_conf: Any, default: ByGantryLoad[GeneralizeableAxisDict]
-) -> ByGantryLoad[GeneralizeableAxisDict]:
+    from_conf: Any, default: ByGantryLoad[Dict[OT3AxisKind, float]]
+) -> ByGantryLoad[Dict[OT3AxisKind, float]]:
     return ByGantryLoad(
         low_throughput=_build_dict_with_default(
             from_conf.get("low_throughput", {}), default.low_throughput

--- a/api/src/opentrons/config/types.py
+++ b/api/src/opentrons/config/types.py
@@ -2,6 +2,7 @@ from enum import Enum
 from dataclasses import dataclass, asdict, fields
 from typing import Dict, Tuple, TypeVar, Generic, List
 from typing_extensions import TypedDict, Literal
+from opentrons.hardware_control.types import OT3AxisKind
 
 
 class AxisDict(TypedDict):
@@ -11,13 +12,6 @@ class AxisDict(TypedDict):
     A: float
     B: float
     C: float
-
-
-class GeneralizeableAxisDict(TypedDict, total=False):
-    X: float
-    Y: float
-    Z: float
-    P: float
 
 
 Vt = TypeVar("Vt")
@@ -43,7 +37,7 @@ class ByGantryLoad(Generic[Vt]):
         return asdict(self)[key.value]
 
 
-PerPipetteAxisSettings = ByGantryLoad[GeneralizeableAxisDict]
+PerPipetteAxisSettings = ByGantryLoad[Dict[OT3AxisKind, float]]
 
 
 class CurrentDictDefault(TypedDict):
@@ -94,7 +88,7 @@ class OT3MotionSettings:
 
     def by_gantry_load(
         self, gantry_load: GantryLoad
-    ) -> Dict[str, GeneralizeableAxisDict]:
+    ) -> Dict[str, Dict[OT3AxisKind, float]]:
         # create a shallow copy
         base = dict(
             (field.name, getattr(self, field.name)[GantryLoad.NONE])

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -59,7 +59,7 @@ mod_log = logging.getLogger(__name__)
 class API(
     ExecutionManagerProvider,
     RobotCalibrationProvider,
-    InstrumentHandlerProvider,
+    InstrumentHandlerProvider[top_types.Mount],
     # This MUST be kept last in the inheritance list so that it is
     # deprioritized in the method resolution order; otherwise, invocations
     # of methods that are present in the protocol will call the (empty,
@@ -116,7 +116,9 @@ class API(
         self._pause_manager = PauseManager(self._door_state)
         ExecutionManagerProvider.__init__(self, loop, isinstance(backend, Simulator))
         RobotCalibrationProvider.__init__(self)
-        InstrumentHandlerProvider.__init__(self)
+        InstrumentHandlerProvider.__init__(
+            self, {top_types.Mount.LEFT: None, top_types.Mount.RIGHT: None}
+        )
 
     @property
     def door_state(self) -> DoorState:

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -557,6 +557,7 @@ class API(
                     smoothie_pos,
                     self._robot_calibration.deck_calibration.attitude,
                     top_types.Point(0, 0, 0),
+                    Axis,
                 )
             for plunger in plungers:
                 await self._do_plunger_home(axis=plunger, acquire_lock=False)
@@ -593,6 +594,7 @@ class API(
                     await self._backend.update_position(),
                     self._robot_calibration.deck_calibration.attitude,
                     top_types.Point(0, 0, 0),
+                    Axis,
                 )
             if mount == top_types.Mount.RIGHT:
                 offset = top_types.Point(0, 0, 0)
@@ -789,6 +791,7 @@ class API(
                 smoothie_pos,
                 self._robot_calibration.deck_calibration.attitude,
                 top_types.Point(0, 0, 0),
+                Axis,
             )
 
     # Gantry/frame (i.e. not pipette) config API
@@ -1020,6 +1023,7 @@ class API(
                     smoothie_pos,
                     self._robot_calibration.deck_calibration.attitude,
                     top_types.Point(0, 0, 0),
+                    Axis,
                 )
 
         for shake in spec.shake_moves:

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -49,6 +49,7 @@ from opentrons.hardware_control.types import (
     OT3Axis,
     AionotifyEvent,
     OT3Mount,
+    OT3AxisMap,
 )
 
 if TYPE_CHECKING:
@@ -60,9 +61,6 @@ if TYPE_CHECKING:
     from opentrons.drivers.rpi_drivers.dev_types import GPIODriverLike
 
 log = logging.getLogger(__name__)
-
-
-AxisValueMap = Dict[OT3Axis, float]
 
 _FIXED_PIPETTE_ID: str = "P1KSV3120211118A01"
 _FIXED_PIPETTE_NAME: PipetteName = "p1000_single_gen3"
@@ -146,7 +144,7 @@ class OT3Controller:
     def is_homed(self, axes: Sequence[OT3Axis]) -> bool:
         return True
 
-    async def update_position(self) -> AxisValueMap:
+    async def update_position(self) -> OT3AxisMap[float]:
         """Get the current position."""
         return axis_convert(self._position, 0.0)
 
@@ -173,7 +171,7 @@ class OT3Controller:
         await runner.run(can_messenger=self._messenger)
         self._position.update(final_positions)
 
-    async def home(self, axes: Optional[List[OT3Axis]] = None) -> AxisValueMap:
+    async def home(self, axes: Optional[List[OT3Axis]] = None) -> OT3AxisMap[float]:
         """Home axes.
 
         Args:
@@ -184,7 +182,9 @@ class OT3Controller:
         """
         return axis_convert(self._position, 0.0)
 
-    async def fast_home(self, axes: Sequence[OT3Axis], margin: float) -> AxisValueMap:
+    async def fast_home(
+        self, axes: Sequence[OT3Axis], margin: float
+    ) -> OT3AxisMap[float]:
         """Fast home axes.
 
         Args:
@@ -220,7 +220,7 @@ class OT3Controller:
             }
         }
 
-    def set_active_current(self, axis_currents: Dict[OT3Axis, float]) -> None:
+    def set_active_current(self, axis_currents: OT3AxisMap[float]) -> None:
         """Set the active current.
 
         Args:
@@ -268,7 +268,7 @@ class OT3Controller:
             await self._handle_watch_event()
 
     @property
-    def axis_bounds(self) -> Dict[OT3Axis, Tuple[float, float]]:
+    def axis_bounds(self) -> OT3AxisMap[Tuple[float, float]]:
         """Get the axis bounds."""
         # TODO (AL, 2021-11-18): The bounds need to be defined
         phony_bounds = (0, 10000)
@@ -292,7 +292,7 @@ class OT3Controller:
         """Update the firmware."""
         return "Done"
 
-    def engaged_axes(self) -> Dict[OT3Axis, bool]:
+    def engaged_axes(self) -> OT3AxisMap[bool]:
         """Get engaged axes."""
         return {}
 
@@ -324,7 +324,7 @@ class OT3Controller:
         """Halt the motors."""
         return None
 
-    async def probe(self, axis: OT3Axis, distance: float) -> AxisValueMap:
+    async def probe(self, axis: OT3Axis, distance: float) -> OT3AxisMap[float]:
         """Probe."""
         return {}
 

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -33,7 +33,12 @@ from opentrons_hardware.hardware_control.motion_planning import (
 
 from opentrons.hardware_control.module_control import AttachedModulesControl
 from opentrons.hardware_control import modules
-from opentrons.hardware_control.types import BoardRevision, OT3Axis, OT3Mount
+from opentrons.hardware_control.types import (
+    BoardRevision,
+    OT3Axis,
+    OT3Mount,
+    OT3AxisMap,
+)
 
 if TYPE_CHECKING:
     from opentrons_shared_data.pipette.dev_types import PipetteName, PipetteModel
@@ -46,8 +51,6 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-
-AxisValueMap = Dict[OT3Axis, float]
 
 _FIXED_PIPETTE_ID: str = "P1KSV3120211118A01"
 _FIXED_PIPETTE_NAME: PipetteName = "p1000_single_gen3"
@@ -159,7 +162,7 @@ class OT3Simulator:
     def is_homed(self, axes: Sequence[OT3Axis]) -> bool:
         return True
 
-    async def update_position(self) -> AxisValueMap:
+    async def update_position(self) -> OT3AxisMap[float]:
         """Get the current position."""
         return axis_convert(self._position, 0.0)
 
@@ -182,7 +185,7 @@ class OT3Simulator:
         _, final_positions = create_move_group(origin, moves, self._present_nodes)
         self._position.update(final_positions)
 
-    async def home(self, axes: Optional[List[OT3Axis]] = None) -> AxisValueMap:
+    async def home(self, axes: Optional[List[OT3Axis]] = None) -> OT3AxisMap[float]:
         """Home axes.
 
         Args:
@@ -193,7 +196,9 @@ class OT3Simulator:
         """
         return axis_convert(self._position, 0.0)
 
-    async def fast_home(self, axes: Sequence[OT3Axis], margin: float) -> AxisValueMap:
+    async def fast_home(
+        self, axes: Sequence[OT3Axis], margin: float
+    ) -> OT3AxisMap[float]:
         """Fast home axes.
 
         Args:
@@ -272,7 +277,7 @@ class OT3Simulator:
             for mount in OT3Mount
         }
 
-    def set_active_current(self, axis_currents: Dict[OT3Axis, float]) -> None:
+    def set_active_current(self, axis_currents: OT3AxisMap[float]) -> None:
         """Set the active current.
 
         Args:
@@ -296,7 +301,7 @@ class OT3Simulator:
         await self.module_controls.register_modules(new_mods_at_ports=new_mods_at_ports)
 
     @property
-    def axis_bounds(self) -> Dict[OT3Axis, Tuple[float, float]]:
+    def axis_bounds(self) -> OT3AxisMap[Tuple[float, float]]:
         """Get the axis bounds."""
         # TODO (AL, 2021-11-18): The bounds need to be defined
         phony_bounds = (0, 10000)
@@ -320,7 +325,7 @@ class OT3Simulator:
         """Update the firmware."""
         return "Done"
 
-    def engaged_axes(self) -> Dict[OT3Axis, bool]:
+    def engaged_axes(self) -> OT3AxisMap[bool]:
         """Get engaged axes."""
         return {}
 
@@ -352,7 +357,7 @@ class OT3Simulator:
         """Halt the motors."""
         return None
 
-    async def probe(self, axis: OT3Axis, distance: float) -> AxisValueMap:
+    async def probe(self, axis: OT3Axis, distance: float) -> OT3AxisMap[float]:
         """Probe."""
         return {}
 

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -18,10 +18,12 @@ from typing import (
 
 from opentrons.config.types import OT3Config
 from opentrons.drivers.rpi_drivers.gpio_simulator import SimulatingGPIOCharDev
-from opentrons.types import Mount
 from opentrons.config import pipette_config
 from opentrons_shared_data.pipette import dummy_model_for_name
-from . import ot3utils
+from .ot3utils import (
+    axis_convert,
+    create_move_group,
+)
 
 from opentrons_hardware.firmware_bindings.constants import NodeId
 from opentrons_hardware.hardware_control.motion_planning import (
@@ -31,12 +33,11 @@ from opentrons_hardware.hardware_control.motion_planning import (
 
 from opentrons.hardware_control.module_control import AttachedModulesControl
 from opentrons.hardware_control import modules
-from opentrons.hardware_control.types import BoardRevision, Axis
+from opentrons.hardware_control.types import BoardRevision, OT3Axis, OT3Mount
 
 if TYPE_CHECKING:
     from opentrons_shared_data.pipette.dev_types import PipetteName, PipetteModel
     from opentrons.hardware_control.dev_types import (
-        AttachedInstruments,
         InstrumentHardwareConfigs,
         InstrumentSpec,
         AttachedInstrument,
@@ -46,7 +47,7 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
-AxisValueMap = Dict[str, float]
+AxisValueMap = Dict[OT3Axis, float]
 
 _FIXED_PIPETTE_ID: str = "P1KSV3120211118A01"
 _FIXED_PIPETTE_NAME: PipetteName = "p1000_single_gen3"
@@ -61,7 +62,7 @@ class OT3Simulator:
     @classmethod
     async def build(
         cls,
-        attached_instruments: Dict[Mount, Dict[str, Optional[str]]],
+        attached_instruments: Dict[OT3Mount, Dict[str, Optional[str]]],
         attached_modules: List[str],
         config: OT3Config,
         loop: asyncio.AbstractEventLoop,
@@ -88,7 +89,7 @@ class OT3Simulator:
 
     def __init__(
         self,
-        attached_instruments: Dict[Mount, Dict[str, Optional[str]]],
+        attached_instruments: Dict[OT3Mount, Dict[str, Optional[str]]],
         attached_modules: List[str],
         config: OT3Config,
         loop: asyncio.AbstractEventLoop,
@@ -126,63 +127,12 @@ class OT3Simulator:
             )
 
         self._attached_instruments = {
-            m: _sanitize_attached_instrument(attached_instruments.get(m)) for m in Mount
+            m: _sanitize_attached_instrument(attached_instruments.get(m))
+            for m in OT3Mount
         }
         self._module_controls: Optional[AttachedModulesControl] = None
         self._position = self._get_home_position()
         self._present_nodes: Set[NodeId] = set()
-
-    # TODO: These staticmethods exist to defer uses of NodeId to inside
-    # method bodies, which won't be evaluated until called. This is needed
-    # because the robot server doesn't have opentrons_ot3_firmware as a dep
-    # which is where they're defined, and therefore you can't have references
-    # to NodeId that are interpreted at import time because then the robot
-    # server tests fail when importing hardware controller. This is obviously
-    # terrible and needs to be fixed.
-
-    @staticmethod
-    def _node_axes() -> List[str]:
-        return ["X", "Y", "Z", "A", "B", "C"]
-
-    @staticmethod
-    def _axis_to_node(axis: str) -> "NodeId":
-        anm: Dict[str, "NodeId"] = {
-            "X": NodeId.gantry_x,
-            "Y": NodeId.gantry_y,
-            "Z": NodeId.head_l,
-            "A": NodeId.head_r,
-            "B": NodeId.pipette_left,
-            "C": NodeId.pipette_right,
-        }
-        return anm[axis]
-
-    @staticmethod
-    def _node_to_axis(node: "NodeId") -> str:
-        nam = {
-            NodeId.gantry_x: "X",
-            NodeId.gantry_y: "Y",
-            NodeId.head_l: "Z",
-            NodeId.head_r: "A",
-            NodeId.pipette_left: "B",
-            NodeId.pipette_right: "C",
-        }
-        return nam[node]
-
-    @staticmethod
-    def _node_is_axis(node: "NodeId") -> bool:
-        try:
-            OT3Simulator._node_to_axis(node)
-            return True
-        except KeyError:
-            return False
-
-    @staticmethod
-    def _axis_is_node(axis: str) -> bool:
-        try:
-            OT3Simulator._axis_to_node(axis)
-            return True
-        except KeyError:
-            return False
 
     @property
     def gpio_chardev(self) -> GPIODriverLike:
@@ -206,23 +156,12 @@ class OT3Simulator:
         """Set the module controls"""
         self._module_controls = module_controls
 
-    def is_homed(self, axes: Sequence[str]) -> bool:
+    def is_homed(self, axes: Sequence[OT3Axis]) -> bool:
         return True
 
     async def update_position(self) -> AxisValueMap:
         """Get the current position."""
-        return self._axis_convert(self._position)
-
-    @staticmethod
-    def _axis_convert(position: Dict[NodeId, float]) -> AxisValueMap:
-        ret: AxisValueMap = {"A": 0, "B": 0, "C": 0, "X": 0, "Y": 0, "Z": 0}
-        for node, pos in position.items():
-            # we need to make robot config apply to z or in some other way
-            # reflect the sense of the axis direction
-            if OT3Simulator._node_is_axis(node):
-                ret[OT3Simulator._node_to_axis(node)] = pos
-        log.info(f"update_position: {ret}")
-        return ret
+        return axis_convert(self._position, 0.0)
 
     async def move(
         self,
@@ -240,12 +179,10 @@ class OT3Simulator:
         Returns:
             None
         """
-        move_group, final_positions = ot3utils.create_move_group(
-            origin, moves, self._present_nodes
-        )
+        _, final_positions = create_move_group(origin, moves, self._present_nodes)
         self._position.update(final_positions)
 
-    async def home(self, axes: Optional[List[str]] = None) -> AxisValueMap:
+    async def home(self, axes: Optional[List[OT3Axis]] = None) -> AxisValueMap:
         """Home axes.
 
         Args:
@@ -254,9 +191,9 @@ class OT3Simulator:
         Returns:
             Homed position.
         """
-        return self._axis_convert(self._position)
+        return axis_convert(self._position, 0.0)
 
-    async def fast_home(self, axes: Sequence[str], margin: float) -> AxisValueMap:
+    async def fast_home(self, axes: Sequence[OT3Axis], margin: float) -> AxisValueMap:
         """Fast home axes.
 
         Args:
@@ -266,10 +203,10 @@ class OT3Simulator:
         Returns:
             New position.
         """
-        return self._axis_convert(self._position)
+        return axis_convert(self._position, 0.0)
 
     def _attached_to_mount(
-        self, mount: Mount, expected_instr: Optional[PipetteName]
+        self, mount: OT3Mount, expected_instr: Optional[PipetteName]
     ) -> AttachedInstrument:
         init_instr = self._attached_instruments.get(mount, {"model": None, "id": None})
         found_model = init_instr["model"]
@@ -320,8 +257,8 @@ class OT3Simulator:
             return {"config": None, "id": None}
 
     async def get_attached_instruments(
-        self, expected: Dict[Mount, PipetteName]
-    ) -> AttachedInstruments:
+        self, expected: Dict[OT3Mount, PipetteName]
+    ) -> Dict[OT3Mount, AttachedInstrument]:
         """Get attached instruments.
 
         Args:
@@ -332,10 +269,10 @@ class OT3Simulator:
         """
         return {
             mount: self._attached_to_mount(mount, expected.get(mount))
-            for mount in Mount
+            for mount in OT3Mount
         }
 
-    def set_active_current(self, axis_currents: Dict[Axis, float]) -> None:
+    def set_active_current(self, axis_currents: Dict[OT3Axis, float]) -> None:
         """Set the active current.
 
         Args:
@@ -359,17 +296,17 @@ class OT3Simulator:
         await self.module_controls.register_modules(new_mods_at_ports=new_mods_at_ports)
 
     @property
-    def axis_bounds(self) -> Dict[Axis, Tuple[float, float]]:
+    def axis_bounds(self) -> Dict[OT3Axis, Tuple[float, float]]:
         """Get the axis bounds."""
         # TODO (AL, 2021-11-18): The bounds need to be defined
         phony_bounds = (0, 10000)
         return {
-            Axis.A: phony_bounds,
-            Axis.B: phony_bounds,
-            Axis.C: phony_bounds,
-            Axis.X: phony_bounds,
-            Axis.Y: phony_bounds,
-            Axis.Z: phony_bounds,
+            OT3Axis.Z_R: phony_bounds,
+            OT3Axis.Z_L: phony_bounds,
+            OT3Axis.P_L: phony_bounds,
+            OT3Axis.P_R: phony_bounds,
+            OT3Axis.Y: phony_bounds,
+            OT3Axis.X: phony_bounds,
         }
 
     @property
@@ -383,11 +320,11 @@ class OT3Simulator:
         """Update the firmware."""
         return "Done"
 
-    def engaged_axes(self) -> Dict[str, bool]:
+    def engaged_axes(self) -> Dict[OT3Axis, bool]:
         """Get engaged axes."""
         return {}
 
-    async def disengage_axes(self, axes: List[str]) -> None:
+    async def disengage_axes(self, axes: List[OT3Axis]) -> None:
         """Disengage axes."""
         return None
 
@@ -415,7 +352,7 @@ class OT3Simulator:
         """Halt the motors."""
         return None
 
-    async def probe(self, axis: str, distance: float) -> AxisValueMap:
+    async def probe(self, axis: OT3Axis, distance: float) -> AxisValueMap:
         """Probe."""
         return {}
 
@@ -424,7 +361,7 @@ class OT3Simulator:
         pass
 
     async def configure_mount(
-        self, mount: Mount, config: InstrumentHardwareConfigs
+        self, mount: OT3Mount, config: InstrumentHardwareConfigs
     ) -> None:
         """Configure a mount."""
         return None
@@ -442,8 +379,8 @@ class OT3Simulator:
 
     async def probe_network(self) -> None:
         nodes = set((NodeId.head_l, NodeId.head_r, NodeId.gantry_x, NodeId.gantry_y))
-        if self._attached_instruments[Mount.LEFT].get("model", None):
+        if self._attached_instruments[OT3Mount.LEFT].get("model", None):
             nodes.add(NodeId.pipette_left)
-        if self._attached_instruments[Mount.RIGHT].get("model", None):
+        if self._attached_instruments[OT3Mount.RIGHT].get("model", None):
             nodes.add(NodeId.pipette_right)
         self._present_nodes = nodes

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -1,13 +1,14 @@
 """Shared utilities for ot3 hardware control."""
-from typing import Dict, Iterable, List, Tuple
-from typing_extensions import Literal
+from typing import Dict, Iterable, List, Tuple, TypeVar
 from opentrons.config.types import OT3MotionSettings, GantryLoad
+from opentrons.hardware_control.types import OT3Axis, OT3AxisKind
+import numpy as np
+
 
 from opentrons_hardware.firmware_bindings.constants import NodeId
 from opentrons_hardware.hardware_control.motion_planning import (
     AxisConstraints,
-    AxisNames,
-    AXIS_NAMES,
+    SystemConstraints,
     Coordinates,
     Move,
 )
@@ -39,30 +40,30 @@ def axis_nodes() -> List["NodeId"]:
     ]
 
 
-def node_axes() -> List[str]:
-    return ["X", "Y", "Z", "A", "B"]
+def node_axes() -> List[OT3Axis]:
+    return [OT3Axis.X, OT3Axis.Y, OT3Axis.Z_L, OT3Axis.Z_R, OT3Axis.P_L, OT3Axis.P_R]
 
 
-def axis_to_node(axis: str) -> "NodeId":
+def axis_to_node(axis: OT3Axis) -> "NodeId":
     anm = {
-        "X": NodeId.gantry_x,
-        "Y": NodeId.gantry_y,
-        "Z": NodeId.head_l,
-        "A": NodeId.head_r,
-        "B": NodeId.pipette_left,
-        "C": NodeId.pipette_right,
+        OT3Axis.X: NodeId.gantry_x,
+        OT3Axis.Y: NodeId.gantry_y,
+        OT3Axis.Z_L: NodeId.head_l,
+        OT3Axis.Z_R: NodeId.head_r,
+        OT3Axis.P_L: NodeId.pipette_left,
+        OT3Axis.P_R: NodeId.pipette_right,
     }
     return anm[axis]
 
 
-def node_to_axis(node: "NodeId") -> str:
+def node_to_axis(node: "NodeId") -> OT3Axis:
     nam = {
-        NodeId.gantry_x: "X",
-        NodeId.gantry_y: "Y",
-        NodeId.head_l: "Z",
-        NodeId.head_r: "A",
-        NodeId.pipette_left: "B",
-        NodeId.pipette_right: "C",
+        NodeId.gantry_x: OT3Axis.X,
+        NodeId.gantry_y: OT3Axis.Y,
+        NodeId.head_l: OT3Axis.Z_L,
+        NodeId.head_r: OT3Axis.Z_R,
+        NodeId.pipette_left: OT3Axis.P_L,
+        NodeId.pipette_right: OT3Axis.P_R,
     }
     return nam[node]
 
@@ -75,7 +76,7 @@ def node_is_axis(node: "NodeId") -> bool:
         return False
 
 
-def axis_is_node(axis: str) -> bool:
+def axis_is_node(axis: OT3Axis) -> bool:
     try:
         axis_to_node(axis)
         return True
@@ -83,44 +84,35 @@ def axis_is_node(axis: str) -> bool:
         return False
 
 
-def _constraint_name_from_axis(ax: "AxisNames") -> Literal["X", "Y", "Z", "P"]:
-    lookup: Dict[AxisNames, Literal["X", "Y", "Z", "P"]] = {
-        "X": "X",
-        "Y": "Y",
-        "Z": "Z",
-        "A": "Z",
-        "B": "P",
-        "C": "P",
-    }
-    return lookup[ax]
-
-
 def get_system_constraints(
-    config: OT3MotionSettings, gantry_load: GantryLoad
-) -> Dict["AxisNames", "AxisConstraints"]:
+    config: OT3MotionSettings,
+    gantry_load: GantryLoad,
+) -> "SystemConstraints[OT3Axis]":
     conf_by_pip = config.by_gantry_load(gantry_load)
     constraints = {}
-    for axis in AXIS_NAMES:
-        constraint_name = _constraint_name_from_axis(axis)
-        constraints[axis] = AxisConstraints.build(
-            conf_by_pip["acceleration"][constraint_name],
-            conf_by_pip["max_speed_discontinuity"][constraint_name],
-            conf_by_pip["direction_change_speed_discontinuity"][constraint_name],
-        )
+    for axis_kind in [OT3AxisKind.P, OT3AxisKind.X, OT3AxisKind.Y, OT3AxisKind.Z]:
+        for axis in OT3Axis.of_kind(axis_kind):
+            constraints[axis] = AxisConstraints.build(
+                conf_by_pip["acceleration"][axis_kind],
+                conf_by_pip["max_speed_discontinuity"][axis_kind],
+                conf_by_pip["direction_change_speed_discontinuity"][axis_kind],
+            )
     return constraints
 
 
-def _convert_to_node_id_dict(axis_pos: "Coordinates") -> "NodeIdMotionValues":
+def _convert_to_node_id_dict(
+    axis_pos: "Coordinates[OT3Axis, np.float64]",
+) -> "NodeIdMotionValues":
     target: NodeIdMotionValues = {}
-    for axis, pos in axis_pos.to_dict().items():
+    for axis, pos in axis_pos.items():
         if axis_is_node(axis):
             target[axis_to_node(axis)] = pos
     return target
 
 
 def create_move_group(
-    origin: "Coordinates",
-    moves: List["Move"],
+    origin: "Coordinates[OT3Axis, np.float64]",
+    moves: List["Move[OT3Axis]"],
     present_nodes: Iterable["NodeId"],
 ) -> Tuple["MoveGroup", Dict["NodeId", float]]:
     pos = _convert_to_node_id_dict(origin)
@@ -140,6 +132,19 @@ def create_move_group(
                 present_nodes=present_nodes,
             )
             for ax in pos.keys():
-                pos[ax] += node_id_distances[ax]
+                pos[ax] += node_id_distances.get(ax, 0)
             move_group.append(step)
     return move_group, {k: float(v) for k, v in pos.items()}
+
+
+AxisMapPayload = TypeVar("AxisMapPayload")
+
+
+def axis_convert(
+    axis_map: Dict["NodeId", AxisMapPayload], default_value: AxisMapPayload
+) -> Dict[OT3Axis, AxisMapPayload]:
+    ret: Dict[OT3Axis, AxisMapPayload] = {k: default_value for k in node_axes()}
+    for node, value in axis_map.items():
+        if node_is_axis(node):
+            ret[node_to_axis(node)] = value
+    return ret

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -1,7 +1,7 @@
 """Shared utilities for ot3 hardware control."""
 from typing import Dict, Iterable, List, Tuple, TypeVar
 from opentrons.config.types import OT3MotionSettings, GantryLoad
-from opentrons.hardware_control.types import OT3Axis, OT3AxisKind
+from opentrons.hardware_control.types import OT3Axis, OT3AxisKind, OT3AxisMap
 import numpy as np
 
 
@@ -142,8 +142,8 @@ AxisMapPayload = TypeVar("AxisMapPayload")
 
 def axis_convert(
     axis_map: Dict["NodeId", AxisMapPayload], default_value: AxisMapPayload
-) -> Dict[OT3Axis, AxisMapPayload]:
-    ret: Dict[OT3Axis, AxisMapPayload] = {k: default_value for k in node_axes()}
+) -> OT3AxisMap[AxisMapPayload]:
+    ret: OT3AxisMap[AxisMapPayload] = {k: default_value for k in node_axes()}
     for node, value in axis_map.items():
         if node_is_axis(node):
             ret[node_to_axis(node)] = value

--- a/api/src/opentrons/hardware_control/instrument_handler.py
+++ b/api/src/opentrons/hardware_control/instrument_handler.py
@@ -4,6 +4,7 @@ import logging
 from typing import (
     Callable,
     Dict,
+    Generic,
     Optional,
     Tuple,
     Any,
@@ -11,6 +12,8 @@ from typing import (
     List,
     Sequence,
     Iterator,
+    TypeVar,
+    overload,
 )
 
 from opentrons_shared_data.pipette.dev_types import UlPerMmAction
@@ -22,6 +25,8 @@ from .types import (
     TipAttachedError,
     NoTipAttachedError,
     Axis,
+    OT3Axis,
+    OT3Mount,
 )
 from .constants import (
     SHAKE_OFF_TIPS_SPEED,
@@ -34,23 +39,70 @@ from .robot_calibration import load_pipette_offset
 from .dev_types import PipetteDict
 from .pipette import Pipette
 
-InstrumentsByMount = Dict[top_types.Mount, Optional[Pipette]]
-PipetteHandlingData = Tuple[Pipette, top_types.Mount]
+
+MountType = TypeVar("MountType", top_types.Mount, OT3Mount)
+
+InstrumentsByMount = Dict[MountType, Optional[Pipette]]
+PipetteHandlingData = Tuple[Pipette, MountType]
 
 MOD_LOG = logging.getLogger(__name__)
 
+AxisType = TypeVar("AxisType", Axis, OT3Axis)
 
-class InstrumentHandlerProvider:
+
+@dataclass(frozen=True)
+class LiquidActionSpec(Generic[AxisType]):
+    axis: AxisType
+    volume: float
+    plunger_distance: float
+    speed: float
+    instr: Pipette
+    current: float
+
+
+@dataclass(frozen=True)
+class PickUpTipPressSpec(Generic[AxisType]):
+    relative_down: top_types.Point
+    relative_up: top_types.Point
+    current: Dict[AxisType, float]
+    speed: float
+
+
+@dataclass(frozen=True)
+class PickUpTipSpec(Generic[AxisType]):
+    plunger_prep_pos: float
+    plunger_currents: Dict[AxisType, float]
+    presses: List[PickUpTipPressSpec[AxisType]]
+    shake_off_list: List[Tuple[top_types.Point, Optional[float]]]
+    retract_target: float
+
+
+@dataclass(frozen=True)
+class DropTipMove(Generic[AxisType]):
+    target_position: float
+    current: Dict[AxisType, float]
+    speed: Optional[float]
+    home_after: bool = False
+    home_after_safety_margin: float = 0
+    home_axes: Sequence[AxisType] = tuple()
+
+
+@dataclass(frozen=True)
+class DropTipSpec(Generic[AxisType]):
+    drop_moves: List[DropTipMove[AxisType]]
+    shake_moves: List[Tuple[top_types.Point, Optional[float]]]
+    ending_current: Dict[AxisType, float]
+
+
+class InstrumentHandlerProvider(Generic[MountType]):
     IHP_LOG = MOD_LOG.getChild("InstrumentHandler")
 
-    def __init__(self):
-        self._attached_instruments: InstrumentsByMount = {
-            top_types.Mount.LEFT: None,
-            top_types.Mount.RIGHT: None,
-        }
+    def __init__(self, attached_instruments: InstrumentsByMount[MountType]):
+        assert attached_instruments
+        self._attached_instruments: InstrumentsByMount[MountType] = attached_instruments
         self._ihp_log = InstrumentHandlerProvider.IHP_LOG.getChild(str(id(self)))
 
-    def reset_instrument(self, mount: Optional[top_types.Mount] = None):
+    def reset_instrument(self, mount: Optional[MountType] = None):
         """
         Reset the internal state of a pipette by its mount, without doing
         any lower level reconfiguration. This is useful to make sure that no
@@ -60,7 +112,7 @@ class InstrumentHandlerProvider:
                       reset both
         """
 
-        def _reset(m: top_types.Mount):
+        def _reset(m: MountType):
             self._ihp_log.info(f"Resetting configuration for {m}")
             p = self._attached_instruments[m]
             if not p:
@@ -72,14 +124,14 @@ class InstrumentHandlerProvider:
             self._attached_instruments[m] = new_p
 
         if not mount:
-            for m in top_types.Mount:
+            for m in type(list(self._attached_instruments.keys())[0]):
                 _reset(m)
         else:
             _reset(mount)
 
     # TODO(mc, 2022-01-11): change returned map value type to `Optional[PipetteDict]`
     # instead of potentially returning an empty dict
-    def get_attached_instruments(self) -> Dict[top_types.Mount, PipetteDict]:
+    def get_attached_instruments(self) -> Dict[MountType, PipetteDict]:
         """Get the status dicts of the cached attached instruments.
 
         Also available as :py:meth:`get_attached_instruments`.
@@ -96,12 +148,12 @@ class InstrumentHandlerProvider:
         """
         return {
             m: self.get_attached_instrument(m)
-            for m in (top_types.Mount.LEFT, top_types.Mount.RIGHT)
+            for m in self._attached_instruments.keys()
         }
 
     # TODO(mc, 2022-01-11): change return type to `Optional[PipetteDict]` instead
     # of potentially returning an empty dict
-    def get_attached_instrument(self, mount: top_types.Mount) -> PipetteDict:
+    def get_attached_instrument(self, mount: MountType) -> PipetteDict:
         instr = self._attached_instruments[mount]
         result: Dict[str, Any] = {}
         if instr:
@@ -160,17 +212,15 @@ class InstrumentHandlerProvider:
         return cast(PipetteDict, result)
 
     @property
-    def attached_instruments(self) -> Dict[top_types.Mount, PipetteDict]:
+    def attached_instruments(self) -> Dict[MountType, PipetteDict]:
         return self.get_attached_instruments()
 
     @property
-    def hardware_instruments(self) -> InstrumentsByMount:
+    def hardware_instruments(self) -> InstrumentsByMount[MountType]:
         """Do not write new code that uses this."""
         return self._attached_instruments
 
-    def set_current_tiprack_diameter(
-        self, mount: top_types.Mount, tiprack_diameter: float
-    ):
+    def set_current_tiprack_diameter(self, mount: MountType, tiprack_diameter: float):
         instr = self.get_pipette(mount)
         self._ihp_log.info(
             "Updating tip rack diameter on pipette mount: "
@@ -178,7 +228,7 @@ class InstrumentHandlerProvider:
         )
         instr.current_tiprack_diameter = tiprack_diameter
 
-    def set_working_volume(self, mount: top_types.Mount, tip_volume: int):
+    def set_working_volume(self, mount: MountType, tip_volume: int) -> None:
         instr = self.get_pipette(mount)
         if not instr:
             raise top_types.PipetteNotAttachedError(
@@ -192,12 +242,12 @@ class InstrumentHandlerProvider:
 
     def calibrate_plunger(
         self,
-        mount: top_types.Mount,
+        mount: MountType,
         top: Optional[float] = None,
         bottom: Optional[float] = None,
         blow_out: Optional[float] = None,
         drop_tip: Optional[float] = None,
-    ):
+    ) -> None:
         """
         Set calibration values for the pipette plunger.
         This can be called multiple times as the user sets each value,
@@ -229,7 +279,7 @@ class InstrumentHandlerProvider:
 
     def set_flow_rate(
         self,
-        mount: top_types.Mount,
+        mount: MountType,
         aspirate: Optional[float] = None,
         dispense: Optional[float] = None,
         blow_out: Optional[float] = None,
@@ -244,7 +294,7 @@ class InstrumentHandlerProvider:
 
     def set_pipette_speed(
         self,
-        mount: top_types.Mount,
+        mount: MountType,
         aspirate: Optional[float] = None,
         dispense: Optional[float] = None,
         blow_out: Optional[float] = None,
@@ -265,7 +315,7 @@ class InstrumentHandlerProvider:
 
     def instrument_max_height(
         self,
-        mount: top_types.Mount,
+        mount: MountType,
         retract_distance: float,
         critical_point: Optional[CriticalPoint],
     ) -> float:
@@ -284,7 +334,7 @@ class InstrumentHandlerProvider:
             k: None for k in self._attached_instruments.keys()
         }
 
-    async def add_tip(self, mount: top_types.Mount, tip_length: float):
+    async def add_tip(self, mount: MountType, tip_length: float) -> None:
         instr = self._attached_instruments[mount]
         attached = self.attached_instruments
         instr_dict = attached[mount]
@@ -297,7 +347,7 @@ class InstrumentHandlerProvider:
         else:
             self._ihp_log.warning("attach tip called while tip already attached")
 
-    async def remove_tip(self, mount: top_types.Mount):
+    async def remove_tip(self, mount: MountType) -> None:
         instr = self._attached_instruments[mount]
         attached = self.attached_instruments
         instr_dict = attached[mount]
@@ -311,7 +361,7 @@ class InstrumentHandlerProvider:
             self._ihp_log.warning("detach tip called with no tip")
 
     def critical_point_for(
-        self, mount: top_types.Mount, cp_override: CriticalPoint = None
+        self, mount: MountType, cp_override: CriticalPoint = None
     ) -> top_types.Point:
         """Return the current critical point of the specified mount.
 
@@ -360,21 +410,24 @@ class InstrumentHandlerProvider:
         ul_per_s = mm_per_s * instr.ul_per_mm(instr.config.max_volume, action)
         return round(ul_per_s, 6)
 
-    @dataclass(frozen=True)
-    class LiquidActionSpec:
-        axis: Axis
-        volume: float
-        plunger_distance: float
-        speed: float
-        instr: Pipette
-        current: float
+    @overload
+    def plan_check_aspirate(
+        self, mount: top_types.Mount, volume: Optional[float], rate: float
+    ) -> Optional[LiquidActionSpec[Axis]]:
+        ...
+
+    @overload
+    def plan_check_aspirate(
+        self, mount: OT3Mount, volume: Optional[float], rate: float
+    ) -> Optional[LiquidActionSpec[OT3Axis]]:
+        ...
 
     def plan_check_aspirate(
         self,
-        mount: top_types.Mount,
-        volume: Optional[float],
-        rate: float,
-    ) -> Optional["InstrumentHandlerProvider.LiquidActionSpec"]:
+        mount,
+        volume,
+        rate,
+    ):
         """Check preconditions for aspirate, parse args, and calculate positions.
 
         While the mechanics of issuing an aspirate move itself are left to child
@@ -414,21 +467,43 @@ class InstrumentHandlerProvider:
         speed = self.plunger_speed(
             instrument, instrument.aspirate_flow_rate * rate, "aspirate"
         )
-        return self.LiquidActionSpec(
-            axis=Axis.of_plunger(mount),
-            volume=asp_vol,
-            plunger_distance=dist,
-            speed=speed,
-            instr=instrument,
-            current=instrument.config.plunger_current,
-        )
+        if isinstance(mount, OT3Mount):
+            return LiquidActionSpec(
+                axis=OT3Axis.of_main_tool_actuator(mount),
+                volume=asp_vol,
+                plunger_distance=dist,
+                speed=speed,
+                instr=instrument,
+                current=instrument.config.plunger_current,
+            )
+        else:
+            return LiquidActionSpec(
+                axis=Axis.of_plunger(mount),
+                volume=asp_vol,
+                plunger_distance=dist,
+                speed=speed,
+                instr=instrument,
+                current=instrument.config.plunger_current,
+            )
+
+    @overload
+    def plan_check_dispense(
+        self, mount: top_types.Mount, volume: Optional[float], rate: float
+    ) -> Optional[LiquidActionSpec[Axis]]:
+        ...
+
+    @overload
+    def plan_check_dispense(
+        self, mount: OT3Mount, volume: Optional[float], rate: float
+    ) -> Optional[LiquidActionSpec[OT3Axis]]:
+        ...
 
     def plan_check_dispense(
         self,
-        mount: top_types.Mount,
-        volume: Optional[float],
-        rate: float,
-    ) -> Optional["InstrumentHandlerProvider.LiquidActionSpec"]:
+        mount,
+        volume,
+        rate,
+    ):
         """Check preconditions for dispense, parse args, and calculate positions.
 
         While the mechanics of issuing a dispense move itself are left to child
@@ -469,47 +544,58 @@ class InstrumentHandlerProvider:
         speed = self.plunger_speed(
             instrument, instrument.dispense_flow_rate * rate, "dispense"
         )
-        return self.LiquidActionSpec(
-            axis=Axis.of_plunger(mount),
-            volume=disp_vol,
-            plunger_distance=dist,
-            speed=speed,
-            instr=instrument,
-            current=instrument.config.plunger_current,
-        )
+        if isinstance(mount, top_types.Mount):
+            return LiquidActionSpec(
+                axis=Axis.of_plunger(mount),
+                volume=disp_vol,
+                plunger_distance=dist,
+                speed=speed,
+                instr=instrument,
+                current=instrument.config.plunger_current,
+            )
+        else:
+            return LiquidActionSpec(
+                axis=OT3Axis.of_main_tool_actuator(mount),
+                volume=disp_vol,
+                plunger_distance=dist,
+                speed=speed,
+                instr=instrument,
+                current=instrument.config.plunger_current,
+            )
 
-    def plan_check_blow_out(
-        self, mount: top_types.Mount
-    ) -> "InstrumentHandlerProvider.LiquidActionSpec":
+    @overload
+    def plan_check_blow_out(self, mount: top_types.Mount) -> LiquidActionSpec[Axis]:
+        ...
+
+    @overload
+    def plan_check_blow_out(self, mount: OT3Mount) -> LiquidActionSpec[OT3Axis]:
+        ...
+
+    def plan_check_blow_out(self, mount):
         """Check preconditions and calculate values for blowout."""
         instrument = self.get_pipette(mount)
         self.ready_for_tip_action(instrument, HardwareAction.BLOWOUT)
         speed = self.plunger_speed(
             instrument, instrument.blow_out_flow_rate, "dispense"
         )
-        return self.LiquidActionSpec(
-            axis=Axis.of_plunger(mount),
-            volume=0,
-            plunger_distance=instrument.config.blow_out,
-            speed=speed,
-            instr=instrument,
-            current=instrument.config.plunger_current,
-        )
-
-    @dataclass(frozen=True)
-    class PickUpTipPressSpec:
-        relative_down: top_types.Point
-        relative_up: top_types.Point
-        current: Dict[Axis, float]
-        speed: float
-
-    @dataclass(frozen=True)
-    class PickUpTipSpec:
-        plunger_prep_pos: float
-        plunger_currents: Dict[Axis, float]
-        presses: List["InstrumentHandlerProvider.PickUpTipPressSpec"]
-        shake_off_list: List[Tuple[top_types.Point, Optional[float]]]
-        retract_target: float
+        if isinstance(mount, top_types.Mount):
+            return LiquidActionSpec(
+                axis=Axis.of_plunger(mount),
+                volume=0,
+                plunger_distance=instrument.config.blow_out,
+                speed=speed,
+                instr=instrument,
+                current=instrument.config.plunger_current,
+            )
+        else:
+            return LiquidActionSpec(
+                axis=OT3Axis.of_main_tool_actuator(mount),
+                volume=0,
+                plunger_distance=instrument.config.blow_out,
+                speed=speed,
+                instr=instrument,
+                current=instrument.config.plunger_current,
+            )
 
     @staticmethod
     def _build_pickup_shakes(
@@ -533,13 +619,33 @@ class InstrumentHandlerProvider:
         else:
             return []
 
+    @overload
     def plan_check_pick_up_tip(
         self,
         mount: top_types.Mount,
         tip_length: float,
         presses: Optional[int],
         increment: Optional[float],
-    ) -> Tuple["InstrumentHandlerProvider.PickUpTipSpec", Callable[[], None]]:
+    ) -> Tuple[PickUpTipSpec[Axis], Callable[[], None]]:
+        ...
+
+    @overload
+    def plan_check_pick_up_tip(
+        self,
+        mount: OT3Mount,
+        tip_length: float,
+        presses: Optional[int],
+        increment: Optional[float],
+    ) -> Tuple[PickUpTipSpec[OT3Axis], Callable[[], None]]:
+        ...
+
+    def plan_check_pick_up_tip(
+        self,
+        mount,
+        tip_length,
+        presses,
+        increment,
+    ):
 
         # Prechecks: ready for pickup tip and press/increment are valid
         instrument = self.get_pipette(mount)
@@ -557,7 +663,6 @@ class InstrumentHandlerProvider:
         else:
             check_incr = increment
 
-        z_axis_currents = {Axis.by_mount(mount): instrument.config.pick_up_current}
         pick_up_speed = instrument.config.pick_up_speed
 
         def build_presses() -> Iterator[Tuple[float, float]]:
@@ -576,43 +681,60 @@ class InstrumentHandlerProvider:
             instrument.add_tip(tip_length=tip_length)
             instrument.set_current_volume(0)
 
-        return (
-            InstrumentHandlerProvider.PickUpTipSpec(
-                plunger_prep_pos=instrument.config.bottom,
-                plunger_currents={
-                    Axis.of_plunger(mount): instrument.config.plunger_current
-                },
-                presses=[
-                    InstrumentHandlerProvider.PickUpTipPressSpec(
-                        current=z_axis_currents,
-                        speed=pick_up_speed,
-                        relative_down=top_types.Point(0, 0, press_dist),
-                        relative_up=top_types.Point(0, 0, backup_dist),
-                    )
-                    for press_dist, backup_dist in build_presses()
-                ],
-                shake_off_list=self._build_pickup_shakes(instrument),
-                retract_target=instrument.config.pick_up_distance
-                + check_incr * checked_presses
-                + 2,
-            ),
-            add_tip_to_instr,
-        )
-
-    @dataclass(frozen=True)
-    class DropTipMove:
-        target_position: float
-        current: Dict[Axis, float]
-        speed: Optional[float]
-        home_after: bool = False
-        home_after_safety_margin: float = 0
-        home_axes: Sequence[Axis] = tuple()
-
-    @dataclass(frozen=True)
-    class DropTipSpec:
-        drop_moves: List["InstrumentHandlerProvider.DropTipMove"]
-        shake_moves: List[Tuple[top_types.Point, Optional[float]]]
-        ending_current: Dict[Axis, float]
+        if isinstance(mount, top_types.Mount):
+            return (
+                PickUpTipSpec(
+                    plunger_prep_pos=instrument.config.bottom,
+                    plunger_currents={
+                        Axis.of_plunger(mount): instrument.config.plunger_current
+                    },
+                    presses=[
+                        PickUpTipPressSpec(
+                            current={
+                                Axis.by_mount(mount): instrument.config.pick_up_current
+                            },
+                            speed=pick_up_speed,
+                            relative_down=top_types.Point(0, 0, press_dist),
+                            relative_up=top_types.Point(0, 0, backup_dist),
+                        )
+                        for press_dist, backup_dist in build_presses()
+                    ],
+                    shake_off_list=self._build_pickup_shakes(instrument),
+                    retract_target=instrument.config.pick_up_distance
+                    + check_incr * checked_presses
+                    + 2,
+                ),
+                add_tip_to_instr,
+            )
+        else:
+            return (
+                PickUpTipSpec(
+                    plunger_prep_pos=instrument.config.bottom,
+                    plunger_currents={
+                        OT3Axis.of_main_tool_actuator(
+                            mount
+                        ): instrument.config.plunger_current
+                    },
+                    presses=[
+                        PickUpTipPressSpec(
+                            current={
+                                OT3Axis.by_mount(
+                                    mount
+                                ): instrument.config.pick_up_current
+                            },
+                            speed=pick_up_speed,
+                            relative_down=top_types.Point(0, 0, press_dist),
+                            relative_up=top_types.Point(0, 0, backup_dist),
+                        )
+                        for press_dist, backup_dist in build_presses()
+                    ],
+                    shake_off_list=self._build_pickup_shakes(instrument),
+                    retract_target=instrument.config.pick_up_distance
+                    + check_incr * checked_presses
+                    + 2,
+                ),
+                add_tip_to_instr,
+            )
 
     @staticmethod
     def _shake_off_tips_drop(
@@ -634,47 +756,63 @@ class InstrumentHandlerProvider:
             (top_types.Point(0, 0, DROP_TIP_RELEASE_DISTANCE), None),  # top
         ]
 
-    def plan_check_drop_tip(
+    def _droptip_sequence_builder(
         self,
-        mount: top_types.Mount,
+        bottom_pos: float,
+        droptip_pos: float,
+        plunger_currents: Dict[AxisType, float],
+        drop_tip_currents: Dict[AxisType, float],
+        speed: float,
         home_after: bool,
-    ) -> Tuple["InstrumentHandlerProvider.DropTipSpec", Callable[[], None]]:
-        instrument = self.get_pipette(mount)
-        self.ready_for_tip_action(instrument, HardwareAction.DROPTIP)
-        plunger_currents = {Axis.of_plunger(mount): instrument.config.plunger_current}
-        drop_tip_currents = {Axis.of_plunger(mount): instrument.config.drop_tip_current}
-        plunger_axes = (Axis.of_plunger(mount),)
-
-        bottom = instrument.config.bottom
-        droptip = instrument.config.drop_tip
-        speed = instrument.config.drop_tip_speed
-
-        def _build_single_sequence() -> List[InstrumentHandlerProvider.DropTipMove]:
+        home_axes: Sequence[AxisType],
+    ) -> Callable[[], List[DropTipMove[AxisType]]]:
+        def build() -> List[DropTipMove[AxisType]]:
             base = [
-                self.DropTipMove(
-                    target_position=bottom, current=plunger_currents, speed=None
+                DropTipMove(
+                    target_position=bottom_pos, current=plunger_currents, speed=None
                 ),
-                self.DropTipMove(
-                    target_position=droptip,
+                DropTipMove(
+                    target_position=droptip_pos,
                     current=drop_tip_currents,
                     speed=speed,
                     home_after=home_after,
-                    home_after_safety_margin=abs(bottom - droptip),
-                    home_axes=plunger_axes,
+                    home_after_safety_margin=abs(bottom_pos - droptip_pos),
+                    home_axes=home_axes,
                 ),
             ]
             if home_after:
                 base.append(
-                    self.DropTipMove(
-                        target_position=bottom, current=plunger_currents, speed=None
+                    DropTipMove(
+                        target_position=bottom_pos, current=plunger_currents, speed=None
                     )
                 )
             return base
 
-        seq = _build_single_sequence()
-        if "doubleDropTip" in instrument.config.quirks:
-            seq += seq
+        return build
 
+    @overload
+    def plan_check_drop_tip(
+        self, mount: top_types.Mount, home_after: bool
+    ) -> Tuple[DropTipSpec[Axis], Callable[[], None]]:
+        ...
+
+    @overload
+    def plan_check_drop_tip(
+        self, mount: OT3Mount, home_after: bool
+    ) -> Tuple[DropTipSpec[OT3Axis], Callable[[], None]]:
+        ...
+
+    def plan_check_drop_tip(
+        self,
+        mount,
+        home_after,
+    ):
+        instrument = self.get_pipette(mount)
+        self.ready_for_tip_action(instrument, HardwareAction.DROPTIP)
+
+        bottom = instrument.config.bottom
+        droptip = instrument.config.drop_tip
+        speed = instrument.config.drop_tip_speed
         shakes: List[Tuple[top_types.Point, Optional[float]]] = []
         if "dropTipShake" in instrument.config.quirks:
             diameter = instrument.current_tiprack_diameter
@@ -685,17 +823,79 @@ class InstrumentHandlerProvider:
             instrument.current_tiprack_diameter = 0.0
             instrument.remove_tip()
 
-        return (
-            self.DropTipSpec(
-                drop_moves=seq, shake_moves=shakes, ending_current=plunger_currents
-            ),
-            _remove_tips,
-        )
+        if isinstance(mount, top_types.Mount):
+            seq_builder_ot2 = self._droptip_sequence_builder(
+                bottom,
+                droptip,
+                {Axis.of_plunger(mount): instrument.config.plunger_current},
+                {Axis.of_plunger(mount): instrument.config.drop_tip_current},
+                speed,
+                home_after,
+                (Axis.of_plunger(mount),),
+            )
+            seq_ot2 = seq_builder_ot2()
+            if "doubleDropTip" in instrument.config.quirks:
+                seq_ot2 = seq_ot2 + seq_builder_ot2()
+            return (
+                DropTipSpec(
+                    drop_moves=seq_ot2,
+                    shake_moves=shakes,
+                    ending_current={
+                        Axis.of_plunger(mount): instrument.config.plunger_current
+                    },
+                ),
+                _remove_tips,
+            )
+        else:
+            seq_builder_ot3 = self._droptip_sequence_builder(
+                bottom,
+                droptip,
+                {
+                    OT3Axis.of_main_tool_actuator(
+                        mount
+                    ): instrument.config.plunger_current
+                },
+                {
+                    OT3Axis.of_main_tool_actuator(
+                        mount
+                    ): instrument.config.drop_tip_current
+                },
+                speed,
+                home_after,
+                (OT3Axis.of_main_tool_actuator(mount),),
+            )
 
-    def get_pipette(self, mount: top_types.Mount) -> Pipette:
+            seq_ot3 = seq_builder_ot3()
+            if "doubleDropTip" in instrument.config.quirks:
+                seq_ot3 = seq_ot3 + seq_builder_ot3()
+            return (
+                DropTipSpec(
+                    drop_moves=seq_ot3,
+                    shake_moves=shakes,
+                    ending_current={
+                        OT3Axis.of_main_tool_actuator(
+                            mount
+                        ): instrument.config.plunger_current
+                    },
+                ),
+                _remove_tips,
+            )
+
+    def get_pipette(self, mount: MountType) -> Pipette:
         pip = self._attached_instruments[mount]
         if not pip:
             raise top_types.PipetteNotAttachedError(
                 f"No pipette attached to {mount.name} mount"
             )
         return pip
+
+
+class OT3InstrumentHandler(InstrumentHandlerProvider[OT3Mount]):
+    """Override for correct plunger_position."""
+
+    def plunger_position(
+        self, instr: Pipette, ul: float, action: "UlPerMmAction"
+    ) -> float:
+        mm = ul / instr.ul_per_mm(ul, action)
+        position = instr.config.bottom - mm
+        return round(position, 6)

--- a/api/src/opentrons/hardware_control/motion_utilities.py
+++ b/api/src/opentrons/hardware_control/motion_utilities.py
@@ -1,22 +1,132 @@
 """Utilities for calculating motion correctly."""
 
-from typing import Callable, Dict
+from typing import Callable, Dict, Union, overload, Type
 from collections import OrderedDict
 from opentrons.types import Mount, Point
 from opentrons.calibration_storage.types import AttitudeMatrix
 from opentrons.util import linal
-from .types import Axis
+from .types import Axis, OT3Axis, OT3Mount
 from functools import lru_cache
 
 
-@lru_cache(2)
+@lru_cache(4)
 def offset_for_mount(
-    primary_mount: Mount, left_mount_offset: Point, right_mount_offset: Point
+    primary_mount: Union[Mount, OT3Mount],
+    left_mount_offset: Point,
+    right_mount_offset: Point,
 ) -> Point:
-    offsets = {Mount.LEFT: left_mount_offset, Mount.RIGHT: right_mount_offset}
+    offsets = {
+        Mount.LEFT: left_mount_offset,
+        Mount.RIGHT: right_mount_offset,
+        OT3Mount.LEFT: left_mount_offset,
+        OT3Mount.RIGHT: right_mount_offset,
+    }
     return offsets[primary_mount]
 
 
+@overload
+def _x_for_mount(mount: Mount) -> Axis:
+    ...
+
+
+@overload
+def _x_for_mount(mount: OT3Mount) -> OT3Axis:
+    ...
+
+
+def _x_for_mount(mount):
+    if isinstance(mount, Mount):
+        return Axis.X
+    else:
+        return OT3Axis.X
+
+
+@overload
+def _y_for_mount(mount: Mount) -> Axis:
+    ...
+
+
+@overload
+def _y_for_mount(mount: OT3Mount) -> OT3Axis:
+    ...
+
+
+def _y_for_mount(mount):
+    if isinstance(mount, Mount):
+        return Axis.Y
+    else:
+        return OT3Axis.Y
+
+
+@overload
+def _z_for_mount(mount: Mount) -> Axis:
+    ...
+
+
+@overload
+def _z_for_mount(mount: OT3Mount) -> OT3Axis:
+    ...
+
+
+def _z_for_mount(mount):
+    if isinstance(mount, Mount):
+        return Axis.by_mount(mount)
+    else:
+        return OT3Axis.by_mount(mount)
+
+
+@overload
+def _plunger_for_mount(mount: Mount) -> Axis:
+    ...
+
+
+@overload
+def _plunger_for_mount(mount: OT3Mount) -> OT3Axis:
+    ...
+
+
+def _plunger_for_mount(mount):
+    if isinstance(mount, Mount):
+        return Axis.of_plunger(mount)
+    else:
+        return OT3Axis.of_main_tool_actuator(mount)
+
+
+@overload
+def _axis_name(ax: Axis) -> str:
+    ...
+
+
+@overload
+def _axis_name(ax: OT3Axis) -> OT3Axis:
+    ...
+
+
+def _axis_name(ax):
+    if isinstance(ax, Axis):
+        return ax.name
+    else:
+        return ax
+
+
+@overload
+def _axis_enum(ax: str) -> Axis:
+    ...
+
+
+@overload
+def _axis_enum(ax: OT3Axis) -> OT3Axis:
+    ...
+
+
+def _axis_enum(ax):
+    if isinstance(ax, OT3Axis):
+        return ax
+    else:
+        return Axis[ax]
+
+
+@overload
 def target_position_from_absolute(
     mount: Mount,
     abs_position: Point,
@@ -24,56 +134,109 @@ def target_position_from_absolute(
     left_mount_offset: Point,
     right_mount_offset: Point,
 ) -> "OrderedDict[Axis, float]":
+    ...
+
+
+@overload
+def target_position_from_absolute(
+    mount: OT3Mount,
+    abs_position: Point,
+    get_critical_point: Callable[[OT3Mount], Point],
+    left_mount_offset: Point,
+    right_mount_offset: Point,
+) -> "OrderedDict[OT3Axis, float]":
+    ...
+
+
+def target_position_from_absolute(
+    mount,
+    abs_position,
+    get_critical_point,
+    left_mount_offset,
+    right_mount_offset,
+):
     offset = offset_for_mount(mount, left_mount_offset, right_mount_offset)
     primary_cp = get_critical_point(mount)
-    primary_z = Axis.by_mount(mount)
+    primary_z = _z_for_mount(mount)
     target_position = OrderedDict(
         (
-            (Axis.X, abs_position.x - offset.x - primary_cp.x),
-            (Axis.Y, abs_position.y - offset.y - primary_cp.y),
+            (_x_for_mount(mount), abs_position.x - offset.x - primary_cp.x),
+            (_y_for_mount(mount), abs_position.y - offset.y - primary_cp.y),
             (primary_z, abs_position.z - offset.z - primary_cp.z),
         )
     )
     return target_position
 
 
+@overload
 def target_position_from_relative(
-    mount: Mount,
-    delta: Point,
-    current_position: Dict[Axis, float],
+    mount: Mount, delta: Point, current_position: Dict[Axis, float]
 ) -> "OrderedDict[Axis, float]":
+    ...
+
+
+@overload
+def target_position_from_relative(
+    mount: OT3Mount, delta: Point, current_position: Dict[OT3Axis, float]
+) -> "OrderedDict[OT3Axis, float]":
+    ...
+
+
+def target_position_from_relative(
+    mount,
+    delta,
+    current_position,
+):
     """Create a target position for all specified machine axes."""
-    primary_z = Axis.by_mount(mount)
+    primary_z = _z_for_mount(mount)
+    x_ax = _x_for_mount(mount)
+    y_ax = _y_for_mount(mount)
     target_position = OrderedDict(
         (
-            (Axis.X, current_position[Axis.X] + delta[0]),
-            (Axis.Y, current_position[Axis.Y] + delta[1]),
+            (x_ax, current_position[x_ax] + delta[0]),
+            (y_ax, current_position[y_ax] + delta[1]),
             (primary_z, current_position[primary_z] + delta[2]),
         )
     )
     return target_position
 
 
+@overload
 def target_position_from_plunger(
-    mount: Mount,
-    delta: float,
-    current_position: Dict[Axis, float],
+    mount: Mount, delta: float, current_position: Dict[Axis, float]
 ) -> "OrderedDict[Axis, float]":
+    ...
+
+
+@overload
+def target_position_from_plunger(
+    mount: OT3Mount, delta: float, current_position: Dict[OT3Axis, float]
+) -> "OrderedDict[OT3Axis, float]":
+    ...
+
+
+def target_position_from_plunger(
+    mount,
+    delta,
+    current_position,
+):
     """Create a target position for machine axes including plungers.
 
     Axis positions other than the plunger are identical to current
     position.
     """
+    x_ax = _x_for_mount(mount)
+    y_ax = _y_for_mount(mount)
     all_axes_pos = OrderedDict(
         (
-            (Axis.X, current_position[Axis.X]),
-            (Axis.Y, current_position[Axis.Y]),
+            (x_ax, current_position[x_ax]),
+            (y_ax, current_position[y_ax]),
         )
     )
     plunger_pos = OrderedDict()
-    z = Axis.by_mount(mount)
-    plunger = Axis.of_plunger(mount)
-    all_axes_pos[z] = current_position[z]
+    z_ax = _z_for_mount(mount)
+    plunger = _plunger_for_mount(mount)
+    all_axes_pos[z_ax] = current_position[z_ax]
     plunger_pos[plunger] = delta
     all_axes_pos.update(plunger_pos)
     return all_axes_pos
@@ -96,20 +259,34 @@ def machine_point_from_deck_point(
     return Point(*linal.apply_transform(attitude, deck_point)) + offset
 
 
+@overload
 def machine_from_deck(
-    deck_pos: Dict[Axis, float],
-    attitude: AttitudeMatrix,
-    offset: Point,
+    deck_pos: Dict[Axis, float], attitude: AttitudeMatrix, offset: Point
 ) -> Dict[str, float]:
+    ...
+
+
+@overload
+def machine_from_deck(
+    deck_pos: Dict[OT3Axis, float], attitude: AttitudeMatrix, offset: Point
+) -> Dict[OT3Axis, float]:
+    ...
+
+
+def machine_from_deck(
+    deck_pos,
+    attitude,
+    offset,
+):
     """Build a machine-axis position from a deck position"""
-    to_transform = Point(
-        *(tp for ax, tp in deck_pos.items() if ax in Axis.gantry_axes())
-    )
+    to_transform = Point(*(tp for ax, tp in deck_pos.items() if ax in ax.gantry_axes()))
 
     # Pre-fill the dict we’ll send to the backend with the axes we don’t
     # need to transform
     machine_pos = {
-        ax.name: pos for ax, pos in deck_pos.items() if ax not in Axis.gantry_axes()
+        _axis_name(ax): pos
+        for ax, pos in deck_pos.items()
+        if ax not in ax.gantry_axes()
     }
     if len(to_transform) != 3:
         raise ValueError(
@@ -124,38 +301,56 @@ def machine_from_deck(
     transformed = machine_point_from_deck_point(to_transform, attitude, offset)
 
     to_check = {
-        ax.name: transformed[idx]
+        _axis_name(ax): transformed[idx]
         for idx, ax in enumerate(deck_pos.keys())
-        if ax in Axis.gantry_axes()
+        if ax in ax.gantry_axes()
     }
     machine_pos.update({ax: pos for ax, pos in to_check.items()})
     return machine_pos
 
 
+@overload
 def deck_from_machine(
-    machine_pos: Dict[str, float], attitude: AttitudeMatrix, offset: Point
+    machine_pos: Dict[str, float],
+    attitude: AttitudeMatrix,
+    offset: Point,
+    axis_enum: Type[Axis],
 ) -> Dict[Axis, float]:
+    ...
+
+
+@overload
+def deck_from_machine(
+    machine_pos: Dict[OT3Axis, float],
+    attitude: AttitudeMatrix,
+    offset: Point,
+    axis_enum: Type[OT3Axis],
+) -> Dict[OT3Axis, float]:
+    ...
+
+
+def deck_from_machine(machine_pos, attitude, offset, axis_enum):
     """Build a deck-abs position store from the machine's position"""
-    with_enum = {Axis[k]: v for k, v in machine_pos.items()}
-    plunger_axes = {k: v for k, v in with_enum.items() if k not in Axis.gantry_axes()}
+    with_enum = {_axis_enum(k): v for k, v in machine_pos.items()}
+    plunger_axes = {k: v for k, v in with_enum.items() if k not in k.gantry_axes()}
     right = Point(
-        with_enum[Axis.X],
-        with_enum[Axis.Y],
-        with_enum[Axis.by_mount(Mount.RIGHT)],
+        with_enum[axis_enum.X],
+        with_enum[axis_enum.Y],
+        with_enum[axis_enum.by_mount(Mount.RIGHT)],
     )
     left = Point(
-        with_enum[Axis.X],
-        with_enum[Axis.Y],
-        with_enum[Axis.by_mount(Mount.LEFT)],
+        with_enum[axis_enum.X],
+        with_enum[axis_enum.Y],
+        with_enum[axis_enum.by_mount(Mount.LEFT)],
     )
 
     right_deck = deck_point_from_machine_point(right, attitude, offset)
     left_deck = deck_point_from_machine_point(left, attitude, offset)
     deck_pos = {
-        Axis.X: right_deck[0],
-        Axis.Y: right_deck[1],
-        Axis.by_mount(Mount.RIGHT): right_deck[2],
-        Axis.by_mount(Mount.LEFT): left_deck[2],
+        axis_enum.X: right_deck[0],
+        axis_enum.Y: right_deck[1],
+        axis_enum.by_mount(Mount.RIGHT): right_deck[2],
+        axis_enum.by_mount(Mount.LEFT): left_deck[2],
     }
     deck_pos.update(plunger_axes)
     return deck_pos

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -54,6 +54,7 @@ from .types import (
     PauseType,
     OT3Axis,
     OT3Mount,
+    OT3AxisMap,
 )
 from . import modules
 from .robot_calibration import (
@@ -130,7 +131,7 @@ class OT3API(
 
         self._callbacks: Set[HardwareEventHandler] = set()
         # {'X': 0.0, 'Y': 0.0, 'Z': 0.0, 'A': 0.0, 'B': 0.0, 'C': 0.0}
-        self._current_position: Dict[OT3Axis, float] = {}
+        self._current_position: OT3AxisMap[float] = {}
 
         self._last_moved_mount: Optional[OT3Mount] = None
         # The motion lock synchronizes calls to long-running physical tasks
@@ -626,7 +627,7 @@ class OT3API(
         abs_position: top_types.Point,
         speed: Optional[float] = None,
         critical_point: Optional[CriticalPoint] = None,
-        max_speeds: Union[None, Dict[Axis, float], Dict[OT3Axis, float]] = None,
+        max_speeds: Union[None, Dict[Axis, float], OT3AxisMap[float]] = None,
     ):
         """Move the critical point of the specified mount to a location
         relative to the deck, at the specified speed."""
@@ -642,7 +643,7 @@ class OT3API(
             top_types.Point(*self._config.right_mount_offset),
         )
         if max_speeds:
-            checked_max: Optional[Dict[OT3Axis, float]] = {
+            checked_max: Optional[OT3AxisMap[float]] = {
                 OT3Axis.from_axis(k): v for k, v in max_speeds.items()
             }
         else:
@@ -656,7 +657,7 @@ class OT3API(
         mount: Union[top_types.Mount, OT3Mount],
         delta: top_types.Point,
         speed: Optional[float] = None,
-        max_speeds: Union[None, Dict[Axis, float], Dict[OT3Axis, float]] = None,
+        max_speeds: Union[None, Dict[Axis, float], OT3AxisMap[float]] = None,
         check_bounds: MotionChecks = MotionChecks.NONE,
         fail_on_not_homed: bool = False,
     ):
@@ -685,7 +686,7 @@ class OT3API(
         ):
             raise mhe
         if max_speeds:
-            checked_max: Optional[Dict[OT3Axis, float]] = {
+            checked_max: Optional[OT3AxisMap[float]] = {
                 OT3Axis.from_axis(k): v for k, v in max_speeds.items()
             }
         else:
@@ -716,7 +717,7 @@ class OT3API(
         target_position: "OrderedDict[OT3Axis, float]",
         speed: float = None,
         home_flagged_axes: bool = True,
-        max_speeds: Dict[OT3Axis, float] = None,
+        max_speeds: OT3AxisMap[float] = None,
         acquire_lock: bool = True,
         check_bounds: MotionChecks = MotionChecks.NONE,
     ):
@@ -775,7 +776,7 @@ class OT3API(
 
     async def _fast_home(
         self, axes: Sequence[OT3Axis], margin: float
-    ) -> Dict[OT3Axis, float]:
+    ) -> OT3AxisMap[float]:
         return await self._backend.fast_home(axes, margin)
 
     @ExecutionManagerProvider.wait_for_running

--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -13,7 +13,7 @@ from opentrons.calibration_storage.types import PipetteOffsetByPipetteMount
 from opentrons.config import pipette_config, robot_configs
 from opentrons.config.types import RobotConfig, OT3Config
 from opentrons.drivers.types import MoveSplit
-from .types import CriticalPoint, BoardRevision
+from .types import CriticalPoint, BoardRevision, OT3AxisKind
 
 
 if TYPE_CHECKING:
@@ -461,6 +461,6 @@ def generate_hardware_configs_ot3(
             "steps_per_mm": 0,
             "home_pos": 0,
             "max_travel": 0,
-            "idle_current": robot_config.holding_current.none["P"],
+            "idle_current": robot_config.holding_current.none[OT3AxisKind.P],
             "splits": None,
         }

--- a/api/src/opentrons/hardware_control/robot_calibration.py
+++ b/api/src/opentrons/hardware_control/robot_calibration.py
@@ -2,7 +2,7 @@ from functools import lru_cache
 import logging
 import numpy as np
 from dataclasses import dataclass
-from typing import Optional, List
+from typing import Optional, List, Union
 
 from opentrons import config
 
@@ -15,6 +15,7 @@ from opentrons.config.types import OT3Config
 from opentrons.calibration_storage import modify, types, get
 from opentrons.types import Mount, Point
 from opentrons.util import linal
+from .types import OT3Mount
 
 from .util import DeckTransformState
 
@@ -176,7 +177,7 @@ def load_attitude_matrix() -> types.DeckCalibration:
 
 
 def load_pipette_offset(
-    pip_id: Optional[str], mount: Mount
+    pip_id: Optional[str], mount: Union[Mount, OT3Mount]
 ) -> types.PipetteOffsetByPipetteMount:
     # load default if pipette offset data do not exist
     pip_cal_obj = types.PipetteOffsetByPipetteMount(
@@ -184,8 +185,12 @@ def load_pipette_offset(
         source=types.SourceType.default,
         status=types.CalibrationStatus(),
     )
+    if isinstance(mount, OT3Mount):
+        checked_mount = mount.to_mount()
+    else:
+        checked_mount = mount
     if pip_id:
-        pip_offset_data = get.get_pipette_offset(pip_id, mount)
+        pip_offset_data = get.get_pipette_offset(pip_id, checked_mount)
         if pip_offset_data:
             return pip_offset_data
     return pip_cal_obj

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -77,7 +77,7 @@ class OT3Mount(enum.Enum):
     GRIPPER = enum.auto()
 
     @classmethod
-    def from_mount(cls, mount: top_types.Mount) -> "OT3Mount":
+    def from_mount(cls, mount: Union[top_types.Mount, "OT3Mount"]) -> "OT3Mount":
         return cls[mount.name]
 
     def to_mount(self) -> top_types.Mount:
@@ -131,7 +131,7 @@ class OT3Axis(enum.Enum):
         return bm[mount]
 
     @classmethod
-    def from_axis(cls, axis: Axis) -> "OT3Axis":
+    def from_axis(cls, axis: Union[Axis, "OT3Axis"]) -> "OT3Axis":
         am = {
             Axis.X: cls.X,
             Axis.Y: cls.Y,
@@ -140,7 +140,10 @@ class OT3Axis(enum.Enum):
             Axis.B: cls.P_L,
             Axis.C: cls.P_R,
         }
-        return am[axis]
+        try:
+            return am[axis]  # type: ignore
+        except KeyError:
+            return axis  # type: ignore
 
     def to_axis(self) -> Axis:
         am = {

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -1,7 +1,7 @@
 import enum
 import logging
 from dataclasses import dataclass
-from typing import cast, Tuple, Union, List, Callable, Dict
+from typing import cast, Tuple, Union, List, Callable, Dict, TypeVar
 from typing_extensions import Literal
 from opentrons import types as top_types
 
@@ -226,6 +226,8 @@ class OT3Axis(enum.Enum):
 
 
 BCAxes = Union[Axis, OT3Axis]
+AxisMapValue = TypeVar("AxisMapValue")
+OT3AxisMap = Dict[OT3Axis, AxisMapValue]
 
 
 class DoorState(enum.Enum):

--- a/api/src/opentrons/hardware_control/util.py
+++ b/api/src/opentrons/hardware_control/util.py
@@ -2,9 +2,9 @@
 import asyncio
 import logging
 from enum import Enum
-from typing import Dict, Any, Optional, List, Mapping, Tuple
+from typing import Dict, Any, Optional, List, Mapping, Tuple, TypeVar
 
-from .types import CriticalPoint, MotionChecks, OutOfBoundsMove, Axis
+from .types import CriticalPoint, MotionChecks, OutOfBoundsMove
 from opentrons.types import Point
 
 mod_log = logging.getLogger(__name__)
@@ -50,12 +50,15 @@ class DeckTransformState(Enum):
         return self.name
 
 
+AxisType = TypeVar("AxisType")
+
+
 def check_motion_bounds(
-    target_smoothie: Mapping[Axis, float],
-    target_deck: Mapping[Axis, float],
-    bounds: Mapping[Axis, Tuple[float, float]],
+    target_smoothie: Mapping[AxisType, float],
+    target_deck: Mapping[AxisType, float],
+    bounds: Mapping[AxisType, Tuple[float, float]],
     checks: MotionChecks,
-):
+) -> None:
     """
     Log or raise an error (depending on checks) if a specified
     target position is outside the acceptable bounds of motion

--- a/api/tests/opentrons/config/test_pipette_config.py
+++ b/api/tests/opentrons/config/test_pipette_config.py
@@ -4,7 +4,6 @@ from numpy import isclose
 from typing import Any, Dict, Iterator
 
 import pytest
-from opentrons import types
 
 from opentrons.config import pipette_config, feature_flags as ff, CONFIG
 from opentrons_shared_data import load_shared_data
@@ -275,9 +274,10 @@ async def attached_pipettes(hardware, request):
     right_name = right_mod.split("_v")[0]
     left_id = marker_with_default("attach_left_id", "abc123")
     right_id = marker_with_default("attach_right_id", "abcd123")
+    mount_type = type(list(hardware._backend._attached_instruments.keys())[0])
     hardware._backend._attached_instruments = {
-        types.Mount.RIGHT: {"model": right_mod, "id": right_id, "name": right_name},
-        types.Mount.LEFT: {"model": left_mod, "id": left_id, "name": left_name},
+        mount_type.RIGHT: {"model": right_mod, "id": right_id, "name": right_name},
+        mount_type.LEFT: {"model": left_mod, "id": left_id, "name": left_name},
     }
     await hardware.cache_instruments()
     yield {

--- a/api/tests/opentrons/config/test_robots_config.py
+++ b/api/tests/opentrons/config/test_robots_config.py
@@ -6,7 +6,8 @@ import pytest
 
 from opentrons.config import CONFIG, robot_configs, defaults_ot2, defaults_ot3
 from opentrons.config.types import CurrentDict, GantryLoad, OT3Config
-from opentrons.hardware_control.types import BoardRevision
+from opentrons.hardware_control.types import BoardRevision, OT3AxisKind
+
 
 legacy_dummy_settings = {
     "name": "Rosalind Franklin",
@@ -96,78 +97,163 @@ ot3_dummy_settings = {
     "version": 1,
     "motion_settings": {
         "acceleration": {
-            "none": {"X": 3, "Y": 2, "Z": 15, "P": 2},
+            "none": {
+                OT3AxisKind.X: 3,
+                OT3AxisKind.Y: 2,
+                OT3AxisKind.Z: 15,
+                OT3AxisKind.P: 2,
+            },
             "low_throughput": {
-                "X": 3,
-                "Y": 2,
-                "Z": 15,
-                "P": 15,
+                OT3AxisKind.X: 3,
+                OT3AxisKind.Y: 2,
+                OT3AxisKind.Z: 15,
+                OT3AxisKind.P: 15,
             },
             "high_throughput": {
-                "X": 3,
-                "Y": 2,
-                "Z": 15,
-                "P": 15,
+                OT3AxisKind.X: 3,
+                OT3AxisKind.Y: 2,
+                OT3AxisKind.Z: 15,
+                OT3AxisKind.P: 15,
             },
-            "two_low_throughput": {"X": 1.1, "Y": 2.2},
+            "two_low_throughput": {OT3AxisKind.X: 1.1, OT3AxisKind.Y: 2.2},
             "gripper": {
-                "Z": 2.8,
+                OT3AxisKind.Z: 2.8,
             },
         },
         "default_max_speed": {
             "none": {
-                "X": 1,
-                "Y": 2,
-                "Z": 3,
-                "P": 4,
+                OT3AxisKind.X: 1,
+                OT3AxisKind.Y: 2,
+                OT3AxisKind.Z: 3,
+                OT3AxisKind.P: 4,
             },
             "low_throughput": {
-                "X": 1,
-                "Y": 2,
-                "Z": 3,
-                "P": 4,
+                OT3AxisKind.X: 1,
+                OT3AxisKind.Y: 2,
+                OT3AxisKind.Z: 3,
+                OT3AxisKind.P: 4,
             },
-            "high_throughput": {"X": 1, "Y": 2, "Z": 3, "P": 4},
-            "two_low_throughput": {"X": 4, "Y": 3, "Z": 2, "P": 1},
-            "gripper": {"Z": 2.8},
+            "high_throughput": {
+                OT3AxisKind.X: 1,
+                OT3AxisKind.Y: 2,
+                OT3AxisKind.Z: 3,
+                OT3AxisKind.P: 4,
+            },
+            "two_low_throughput": {
+                OT3AxisKind.X: 4,
+                OT3AxisKind.Y: 3,
+                OT3AxisKind.Z: 2,
+                OT3AxisKind.P: 1,
+            },
+            "gripper": {OT3AxisKind.Z: 2.8},
         },
         "max_speed_discontinuity": {
-            "none": {"X": 10, "Y": 20, "Z": 30, "P": 40},
-            "low_throughput": {"X": 1, "Y": 2, "Z": 3, "P": 6},
-            "high_throughput": {"X": 1, "Y": 2, "Z": 3, "P": 6},
-            "two_low_throughput": {"X": 1, "Y": 2, "Z": 3, "P": 6},
-            "gripper": {"Z": 2.8},
+            "none": {
+                OT3AxisKind.X: 10,
+                OT3AxisKind.Y: 20,
+                OT3AxisKind.Z: 30,
+                OT3AxisKind.P: 40,
+            },
+            "low_throughput": {
+                OT3AxisKind.X: 1,
+                OT3AxisKind.Y: 2,
+                OT3AxisKind.Z: 3,
+                OT3AxisKind.P: 6,
+            },
+            "high_throughput": {
+                OT3AxisKind.X: 1,
+                OT3AxisKind.Y: 2,
+                OT3AxisKind.Z: 3,
+                OT3AxisKind.P: 6,
+            },
+            "two_low_throughput": {
+                OT3AxisKind.X: 1,
+                OT3AxisKind.Y: 2,
+                OT3AxisKind.Z: 3,
+                OT3AxisKind.P: 6,
+            },
+            "gripper": {OT3AxisKind.Z: 2.8},
         },
         "direction_change_speed_discontinuity": {
-            "none": {"X": 5, "Y": 10, "Z": 15, "P": 20},
-            "low_throughput": {"X": 0.8, "Y": 1, "Z": 2, "P": 4},
-            "high_throughput": {"X": 1, "Y": 2, "Z": 3, "P": 6},
-            "two_low_throughput": {"X": 0.5, "Y": 1, "Z": 1.5, "P": 3},
-            "gripper": {"Z": 2.8},
+            "none": {
+                OT3AxisKind.X: 5,
+                OT3AxisKind.Y: 10,
+                OT3AxisKind.Z: 15,
+                OT3AxisKind.P: 20,
+            },
+            "low_throughput": {
+                OT3AxisKind.X: 0.8,
+                OT3AxisKind.Y: 1,
+                OT3AxisKind.Z: 2,
+                OT3AxisKind.P: 4,
+            },
+            "high_throughput": {
+                OT3AxisKind.X: 1,
+                OT3AxisKind.Y: 2,
+                OT3AxisKind.Z: 3,
+                OT3AxisKind.P: 6,
+            },
+            "two_low_throughput": {
+                OT3AxisKind.X: 0.5,
+                OT3AxisKind.Y: 1,
+                OT3AxisKind.Z: 1.5,
+                OT3AxisKind.P: 3,
+            },
+            "gripper": {OT3AxisKind.Z: 2.8},
         },
     },
     "holding_current": {
-        "none": {"X": 0.7, "Y": 0.7, "Z": 0.7, "P": 0.8},
-        "low_throughput": {"X": 0.7, "Y": 0.7, "Z": 0.7, "P": 0.8},
-        "high_throughput": {"X": 0.7, "Y": 0.7, "Z": 0.7, "P": 0.8},
+        "none": {
+            OT3AxisKind.X: 0.7,
+            OT3AxisKind.Y: 0.7,
+            OT3AxisKind.Z: 0.7,
+            OT3AxisKind.P: 0.8,
+        },
+        "low_throughput": {
+            OT3AxisKind.X: 0.7,
+            OT3AxisKind.Y: 0.7,
+            OT3AxisKind.Z: 0.7,
+            OT3AxisKind.P: 0.8,
+        },
+        "high_throughput": {
+            OT3AxisKind.X: 0.7,
+            OT3AxisKind.Y: 0.7,
+            OT3AxisKind.Z: 0.7,
+            OT3AxisKind.P: 0.8,
+        },
         "two_low_throughput": {
-            "X": 0.7,
-            "Y": 0.7,
+            OT3AxisKind.X: 0.7,
+            OT3AxisKind.Y: 0.7,
         },
         "gripper": {
-            "Z": 0.7,
+            OT3AxisKind.Z: 0.7,
         },
     },
     "normal_motion_current": {
-        "none": {"X": 7.0, "Y": 7.0, "Z": 7.0, "P": 5.0},
-        "low_throughput": {"X": 1, "Y": 2, "Z": 3, "P": 4.0},
-        "high_throughput": {"X": 0.2, "Y": 0.5, "Z": 0.4, "P": 2.0},
+        "none": {
+            OT3AxisKind.X: 7.0,
+            OT3AxisKind.Y: 7.0,
+            OT3AxisKind.Z: 7.0,
+            OT3AxisKind.P: 5.0,
+        },
+        "low_throughput": {
+            OT3AxisKind.X: 1,
+            OT3AxisKind.Y: 2,
+            OT3AxisKind.Z: 3,
+            OT3AxisKind.P: 4.0,
+        },
+        "high_throughput": {
+            OT3AxisKind.X: 0.2,
+            OT3AxisKind.Y: 0.5,
+            OT3AxisKind.Z: 0.4,
+            OT3AxisKind.P: 2.0,
+        },
         "two_low_throughput": {
-            "X": 9,
-            "Y": 0.1,
+            OT3AxisKind.X: 9,
+            OT3AxisKind.Y: 0.1,
         },
         "gripper": {
-            "Z": 10,
+            OT3AxisKind.Z: 10,
         },
     },
     "log_level": "NADA",
@@ -277,25 +363,29 @@ def test_load_per_pipette_vals():
         == defaults_ot3.DEFAULT_ACCELERATIONS.low_throughput
     )
 
-    # altered values aare preserved
-    mostly_right["motion_settings"]["acceleration"]["high_throughput"]["X"] -= 2
+    # altered values are preserved
+    mostly_right["motion_settings"]["acceleration"]["high_throughput"][
+        OT3AxisKind.X
+    ] -= 2
     assert (
         defaults_ot3._build_default_bpk(
             mostly_right["motion_settings"]["acceleration"],
             defaults_ot3.DEFAULT_ACCELERATIONS,
-        ).high_throughput["X"]
-        == defaults_ot3.DEFAULT_ACCELERATIONS.high_throughput["X"] - 2
+        ).high_throughput[OT3AxisKind.X]
+        == defaults_ot3.DEFAULT_ACCELERATIONS.high_throughput[OT3AxisKind.X] - 2
     )
 
     # added values are preserved
     altered_default = copy.deepcopy(defaults_ot3.DEFAULT_ACCELERATIONS)
-    altered_default.two_low_throughput.pop("X", None)
+    altered_default.two_low_throughput.pop(OT3AxisKind.X, None)
 
-    mostly_right["motion_settings"]["acceleration"]["two_low_throughput"]["X"] = -72
+    mostly_right["motion_settings"]["acceleration"]["two_low_throughput"][
+        OT3AxisKind.X
+    ] = -72
     assert (
         defaults_ot3._build_default_bpk(
             mostly_right["motion_settings"]["acceleration"], altered_default
-        ).two_low_throughput["X"]
+        ).two_low_throughput[OT3AxisKind.X]
         == -72
     )
 
@@ -380,49 +470,79 @@ def test_motion_settings_dataclass():
     motion_settings = built_config.motion_settings
 
     none_setting = motion_settings.by_gantry_load(GantryLoad.NONE)
-    assert none_setting["acceleration"] == {"X": 3, "Y": 2, "Z": 15, "P": 2}
-    assert none_setting["default_max_speed"] == {"X": 1, "Y": 2, "Z": 3, "P": 4}
+    assert none_setting["acceleration"] == {
+        OT3AxisKind.X: 3,
+        OT3AxisKind.Y: 2,
+        OT3AxisKind.Z: 15,
+        OT3AxisKind.P: 2,
+    }
+    assert none_setting["default_max_speed"] == {
+        OT3AxisKind.X: 1,
+        OT3AxisKind.Y: 2,
+        OT3AxisKind.Z: 3,
+        OT3AxisKind.P: 4,
+    }
     assert none_setting["max_speed_discontinuity"] == {
-        "X": 10,
-        "Y": 20,
-        "Z": 30,
-        "P": 40,
+        OT3AxisKind.X: 10,
+        OT3AxisKind.Y: 20,
+        OT3AxisKind.Z: 30,
+        OT3AxisKind.P: 40,
     }
     assert none_setting["direction_change_speed_discontinuity"] == {
-        "X": 5,
-        "Y": 10,
-        "Z": 15,
-        "P": 20,
+        OT3AxisKind.X: 5,
+        OT3AxisKind.Y: 10,
+        OT3AxisKind.Z: 15,
+        OT3AxisKind.P: 20,
     }
 
     gripper_setting = motion_settings.by_gantry_load(GantryLoad.GRIPPER)
-    assert gripper_setting["acceleration"] == {"X": 3, "Y": 2, "Z": 2.8, "P": 2}
-    assert gripper_setting["default_max_speed"] == {"X": 1, "Y": 2, "Z": 2.8, "P": 4}
+    assert gripper_setting["acceleration"] == {
+        OT3AxisKind.X: 3,
+        OT3AxisKind.Y: 2,
+        OT3AxisKind.Z: 2.8,
+        OT3AxisKind.P: 2,
+    }
+    assert gripper_setting["default_max_speed"] == {
+        OT3AxisKind.X: 1,
+        OT3AxisKind.Y: 2,
+        OT3AxisKind.Z: 2.8,
+        OT3AxisKind.P: 4,
+    }
     assert gripper_setting["max_speed_discontinuity"] == {
-        "X": 10,
-        "Y": 20,
-        "Z": 2.8,
-        "P": 40,
+        OT3AxisKind.X: 10,
+        OT3AxisKind.Y: 20,
+        OT3AxisKind.Z: 2.8,
+        OT3AxisKind.P: 40,
     }
     assert gripper_setting["direction_change_speed_discontinuity"] == {
-        "X": 5,
-        "Y": 10,
-        "Z": 2.8,
-        "P": 20,
+        OT3AxisKind.X: 5,
+        OT3AxisKind.Y: 10,
+        OT3AxisKind.Z: 2.8,
+        OT3AxisKind.P: 20,
     }
 
     two_low_setting = motion_settings.by_gantry_load(GantryLoad.TWO_LOW_THROUGHPUT)
-    assert two_low_setting["acceleration"] == {"X": 1.1, "Y": 2.2, "Z": 15, "P": 2}
-    assert two_low_setting["default_max_speed"] == {"X": 4, "Y": 3, "Z": 2, "P": 1}
+    assert two_low_setting["acceleration"] == {
+        OT3AxisKind.X: 1.1,
+        OT3AxisKind.Y: 2.2,
+        OT3AxisKind.Z: 15,
+        OT3AxisKind.P: 2,
+    }
+    assert two_low_setting["default_max_speed"] == {
+        OT3AxisKind.X: 4,
+        OT3AxisKind.Y: 3,
+        OT3AxisKind.Z: 2,
+        OT3AxisKind.P: 1,
+    }
     assert two_low_setting["max_speed_discontinuity"] == {
-        "X": 1,
-        "Y": 2,
-        "Z": 3,
-        "P": 6,
+        OT3AxisKind.X: 1,
+        OT3AxisKind.Y: 2,
+        OT3AxisKind.Z: 3,
+        OT3AxisKind.P: 6,
     }
     assert two_low_setting["direction_change_speed_discontinuity"] == {
-        "X": 0.5,
-        "Y": 1,
-        "Z": 1.5,
-        "P": 3,
+        OT3AxisKind.X: 0.5,
+        OT3AxisKind.Y: 1,
+        OT3AxisKind.Z: 1.5,
+        OT3AxisKind.P: 3,
     }

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_utils.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_utils.py
@@ -1,11 +1,21 @@
-from opentrons_hardware.hardware_control.motion_planning import Coordinates, Move
+from opentrons_hardware.hardware_control.motion_planning import Move
 from opentrons.hardware_control.backends import ot3utils
 from opentrons_hardware.firmware_bindings.constants import NodeId
+from opentrons.hardware_control.types import OT3Axis
 
 
 def test_create_step():
-    origin = Coordinates(0, 0, 0, 0, 0, 0)
-    moves = [Move.build_dummy_move()]
+    origin = {
+        OT3Axis.X: 0,
+        OT3Axis.Y: 0,
+        OT3Axis.Z_L: 0,
+        OT3Axis.Z_R: 0,
+        OT3Axis.P_L: 0,
+        OT3Axis.P_R: 0,
+    }
+    moves = [
+        Move.build_dummy([OT3Axis.X, OT3Axis.Y, OT3Axis.Z_L, OT3Axis.Z_R, OT3Axis.P_L])
+    ]
     present_nodes = [NodeId.gantry_x, NodeId.gantry_y, NodeId.head_l]
     move_group, final_pos = ot3utils.create_move_group(
         origin=origin,

--- a/api/tests/opentrons/hardware_control/test_ot3_transforms.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_transforms.py
@@ -53,7 +53,7 @@ async def test_transform_values(pipette_model):
         spec=sim._move_manager.plan_motion,
     ) as mock_move:
         await sim.move_to(types.Mount.RIGHT, target)
-        right_offset = sim._attached_instruments[types.Mount.RIGHT].critical_point()
+        right_offset = sim.hardware_instruments[types.Mount.RIGHT].critical_point()
         point = [
             (target.x - right_offset[0] - sim.config.right_mount_offset[0]) * -1
             + sim.config.carriage_offset[0],
@@ -75,7 +75,7 @@ async def test_transform_values(pipette_model):
         spec=sim._move_manager.plan_motion,
     ) as mock_move:
         await sim.move_to(types.Mount.LEFT, target)
-        left_offset = sim._attached_instruments[types.Mount.LEFT].critical_point()
+        left_offset = sim.hardware_instruments[types.Mount.LEFT].critical_point()
         point = [
             (target.x - left_offset[0] - sim.config.left_mount_offset[0]) * -1
             + sim.config.carriage_offset[0],

--- a/api/tests/opentrons/hardware_control/test_ot3_transforms.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_transforms.py
@@ -2,6 +2,7 @@ import pytest
 from unittest import mock
 from opentrons import types
 from opentrons.hardware_control import ot3api
+from opentrons.hardware_control.types import OT3Axis
 from opentrons_shared_data.pipette import name_for_model
 
 
@@ -61,9 +62,11 @@ async def test_transform_values(pipette_model):
             (target.z - right_offset[2] - sim.config.right_mount_offset[2]) * -1
             + sim.config.carriage_offset[2],
         ]
-        assert mock_move.call_args[1]["target_list"][0].position.X == point[0]
-        assert mock_move.call_args[1]["target_list"][0].position.Y == point[1]
-        assert mock_move.call_args[1]["target_list"][0].position.A == point[2]
+        assert mock_move.call_args[1]["target_list"][0].position[OT3Axis.X] == point[0]
+        assert mock_move.call_args[1]["target_list"][0].position[OT3Axis.Y] == point[1]
+        assert (
+            mock_move.call_args[1]["target_list"][0].position[OT3Axis.Z_R] == point[2]
+        )
 
     with mock.patch.object(
         sim._move_manager,
@@ -81,6 +84,8 @@ async def test_transform_values(pipette_model):
             (target.z - left_offset[2] - sim.config.left_mount_offset[2]) * -1
             + sim.config.carriage_offset[2],
         ]
-        assert mock_move.call_args[1]["target_list"][0].position.X == point[0]
-        assert mock_move.call_args[1]["target_list"][0].position.Y == point[1]
-        assert mock_move.call_args[1]["target_list"][0].position.Z == point[2]
+        assert mock_move.call_args[1]["target_list"][0].position[OT3Axis.X] == point[0]
+        assert mock_move.call_args[1]["target_list"][0].position[OT3Axis.Y] == point[1]
+        assert (
+            mock_move.call_args[1]["target_list"][0].position[OT3Axis.Z_L] == point[2]
+        )

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -242,7 +242,7 @@ def test_pick_up_and_drop_tip(ctx, get_labware_def):
 
     instr = ctx.load_instrument("p300_single", mount, tip_racks=[tiprack])
 
-    pipette: Pipette = ctx._implementation.get_hardware()._attached_instruments[mount]
+    pipette: Pipette = ctx._implementation.get_hardware().hardware_instruments[mount]
     nozzle_offset = Point(*pipette.config.nozzle_offset)
     assert pipette.critical_point() == nozzle_offset
     target_location = tiprack["A1"].top()
@@ -280,7 +280,7 @@ def test_return_tip_old_version(loop, hardware, get_labware_def):
     with pytest.raises(TypeError):
         instr.return_tip()
 
-    pipette: Pipette = ctx._implementation.get_hardware()._attached_instruments[mount]
+    pipette: Pipette = ctx._implementation.get_hardware().hardware_instruments[mount]
 
     target_location = tiprack["A1"].top()
     instr.pick_up_tip(target_location)
@@ -306,7 +306,7 @@ def test_return_tip(ctx, get_labware_def):
     with pytest.raises(TypeError):
         instr.return_tip()
 
-    pipette: Pipette = ctx._implementation.get_hardware()._attached_instruments[mount]
+    pipette: Pipette = ctx._implementation.get_hardware().hardware_instruments[mount]
 
     target_location = tiprack["A1"].top()
     instr.pick_up_tip(target_location)
@@ -330,7 +330,7 @@ def test_use_filter_tips(ctx, get_labware_def):
     mount = Mount.LEFT
 
     instr = ctx.load_instrument("p300_single", mount, tip_racks=[tiprack])
-    pipette: Pipette = ctx._implementation.get_hardware()._attached_instruments[mount]
+    pipette: Pipette = ctx._implementation.get_hardware().hardware_instruments[mount]
 
     assert pipette.available_volume == pipette.config.max_volume
 
@@ -356,7 +356,7 @@ def test_pick_up_tip_no_location(ctx, get_labware_def, pipette_model, tiprack_ki
 
     instr = ctx.load_instrument(pipette_model, mount, tip_racks=[tiprack1, tiprack2])
 
-    pipette: Pipette = ctx._implementation.get_hardware()._attached_instruments[mount]
+    pipette: Pipette = ctx._implementation.get_hardware().hardware_instruments[mount]
     nozzle_offset = Point(*pipette.config.nozzle_offset)
     assert pipette.critical_point() == nozzle_offset
 
@@ -453,7 +453,7 @@ def test_aspirate(ctx, get_labware_def):
         ctx._implementation.get_hardware()._obj_to_adapt, "aspirate"
     ) as fake_hw_aspirate:
         hardware = ctx._implementation.get_hardware()
-        hardware._obj_to_adapt._attached_instruments[Mount.RIGHT]._current_volume = 1
+        hardware._obj_to_adapt.hardware_instruments[Mount.RIGHT]._current_volume = 1
 
         instr.aspirate(2.0)
         fake_move.assert_not_called()

--- a/hardware/opentrons_hardware/hardware_control/motion_planning/__init__.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/__init__.py
@@ -7,10 +7,10 @@ from .types import (
     Move,
     MoveTarget,
     AxisConstraints,
-    AxisNames,
-    AXIS_NAMES,
     ZeroLengthMoveError,
+    SystemConstraints,
 )
+from .move_utils import unit_vector_multiplication
 
 __all__ = [
     "MoveManager",
@@ -21,7 +21,5 @@ __all__ = [
     "AxisConstraints",
     "SystemConstraints",
     "unit_vector_multiplication",
-    "AxisNames",
-    "AXIS_NAMES",
     "ZeroLengthMoveError",
 ]

--- a/hardware/opentrons_hardware/hardware_control/motion_planning/move_utils.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/move_utils.py
@@ -1,7 +1,7 @@
 """Utils for motion planning."""
 import numpy as np  # type: ignore[import]
 import logging
-from typing import Iterator, List, Tuple
+from typing import Iterator, List, Tuple, Set
 
 from opentrons_hardware.hardware_control.motion_planning.types import (
     Block,
@@ -9,9 +9,11 @@ from opentrons_hardware.hardware_control.motion_planning.types import (
     Move,
     MoveTarget,
     AxisConstraints,
+    CoordinateValue,
+    AxisKey,
     SystemConstraints,
-    AXIS_NAMES,
     ZeroLengthMoveError,
+    vectorize,
 )
 
 log = logging.getLogger(__name__)
@@ -31,23 +33,33 @@ def check_less_or_close(constraint: np.float64, input: np.float64) -> bool:
 
 
 def get_unit_vector(
-    initial: Coordinates, target: Coordinates
-) -> Tuple[Coordinates, np.float64]:
+    initial: Coordinates[AxisKey, CoordinateValue],
+    target: Coordinates[AxisKey, CoordinateValue],
+) -> Tuple[Coordinates[AxisKey, np.float64], np.float64]:
     """Get the unit vector and the distance the two coordinates."""
-    initial_vectorized = initial.vectorize()
-    target_vectorized = target.vectorize()
+    initial_vectorized = vectorize({k: np.float64(v) for k, v in initial.items()})
+    target_vectorized = vectorize({k: np.float64(v) for k, v in target.items()})
     displacement: np.ndarray = target_vectorized - initial_vectorized
     distance = np.linalg.norm(displacement)
     if not distance or np.array_equal(initial_vectorized, target_vectorized):
         raise ZeroLengthMoveError(initial, target)
-    unit_vector = Coordinates.from_iter(displacement / distance)
+    unit_vector_ndarray = displacement / distance
+    unit_vector = {k: v for k, v in zip(initial.keys(), unit_vector_ndarray)}
     return unit_vector, distance
 
 
-def targets_to_moves(initial: Coordinates, targets: List[MoveTarget]) -> Iterator[Move]:
+def targets_to_moves(
+    initial: Coordinates[AxisKey, CoordinateValue], targets: List[MoveTarget[AxisKey]]
+) -> Iterator[Move[AxisKey]]:
     """Transform a list of MoveTargets into a list of Moves."""
+    all_axes: Set[AxisKey] = set()
     for target in targets:
-        unit_vector, distance = get_unit_vector(initial, target.position)
+        all_axes.update(set(target.position.keys()))
+
+    initial_checked = {k: initial.get(k, 0) for k in all_axes}
+    for target in targets:
+        position = {k: target.position.get(k, 0) for k in all_axes}
+        unit_vector, distance = get_unit_vector(initial_checked, position)
         m = Move(
             unit_vector=unit_vector,
             distance=distance,
@@ -72,7 +84,7 @@ def targets_to_moves(initial: Coordinates, targets: List[MoveTarget]) -> Iterato
         )
         log.debug(f"Built move from {initial} to {target} as {m}")
         yield m
-        initial = target.position
+        initial_checked = position
 
 
 def initial_speed_limit_from_axis(
@@ -114,13 +126,15 @@ def initial_speed_limit_from_axis(
 
 
 def find_initial_speed(
-    constraints: SystemConstraints, move: Move, prev_move: Move
+    constraints: SystemConstraints[AxisKey],
+    move: Move[AxisKey],
+    prev_move: Move[AxisKey],
 ) -> np.float64:
     """Get a move's initial speed."""
     log = logging.getLogger("find_initial_speed")
     # Figure out how fast we can be going when we start
     initial_speed = move.initial_speed
-    for axis in AXIS_NAMES:
+    for axis in move.unit_vector.keys():
         axis_component = move.unit_vector[axis]
 
         if abs(axis_component * initial_speed) < FLOAT_THRESHOLD:
@@ -188,16 +202,16 @@ def final_speed_limit_from_axis(
 
 
 def find_final_speed(
-    constraints: SystemConstraints,
-    move: Move,
-    next_move: Move,
+    constraints: SystemConstraints[AxisKey],
+    move: Move[AxisKey],
+    next_move: Move[AxisKey],
 ) -> np.float64:
     """Get a move's final speed."""
     log = logging.getLogger("find_final_speed")
     # Figure out how fast we can be going when we stop
     final_speed: np.float64 = move.final_speed
 
-    for axis in AXIS_NAMES:
+    for axis in move.unit_vector.keys():
         axis_component = move.unit_vector[axis]
         if abs(axis_component * final_speed) < FLOAT_THRESHOLD:
             log.debug(f"Skip {axis} because it is not moving")
@@ -225,8 +239,8 @@ def find_final_speed(
 
 
 def achievable_final(
-    constraints: SystemConstraints,
-    move: Move,
+    constraints: SystemConstraints[AxisKey],
+    move: Move[AxisKey],
     initial_speed: np.float64,
     final_speed: np.float64,
 ) -> np.float64:
@@ -234,7 +248,7 @@ def achievable_final(
     log = logging.getLogger("achievable_final")
     # Figure out whether this final speed is in fact achievable from the initial speed
     # in the distance allowed
-    for axis in AXIS_NAMES:
+    for axis in move.unit_vector.keys():
         axis_component = move.unit_vector[axis]
         if axis_component:
             axis_max_acc = constraints[axis].max_acceleration
@@ -262,12 +276,12 @@ def achievable_final(
 
 
 def build_blocks(
-    unit_vector: Coordinates,
+    unit_vector: Coordinates[AxisKey, np.float64],
     initial_speed: np.float64,
     final_speed: np.float64,
     distance: np.float64,
     max_speed: np.float64,
-    constraints: SystemConstraints,
+    constraints: SystemConstraints[AxisKey],
 ) -> Tuple[Block, Block, Block]:
     """Build blocks for a move.
 
@@ -289,11 +303,11 @@ def build_blocks(
     max_acc = np.array(
         [
             constraints[axis].max_acceleration if unit_vector[axis] else 0.0
-            for axis in AXIS_NAMES
+            for axis in unit_vector.keys()
         ]
     )
     max_acc_magnitude = np.linalg.norm(max_acc)
-    acc_v = max_acc_magnitude * unit_vector.vectorize()
+    acc_v = max_acc_magnitude * vectorize(unit_vector)
 
     for a_i, max_acc_i in zip(acc_v, max_acc):
         if abs(a_i) > max_acc_i:
@@ -351,15 +365,15 @@ def build_blocks(
         return first, coast, final
     else:
         # no coast phase for us
-        return first, Block(0, 0, 0), final
+        return first, Block(np.float64(0), np.float64(0), np.float64(0)), final
 
 
 def build_move(
-    move: Move,
-    prev_move: Move,
-    next_move: Move,
-    constraints: SystemConstraints,
-) -> Move:
+    move: Move[AxisKey],
+    prev_move: Move[AxisKey],
+    next_move: Move[AxisKey],
+    constraints: SystemConstraints[AxisKey],
+) -> Move[AxisKey]:
     """Build a move."""
     log = logging.getLogger("build_move")
 
@@ -384,7 +398,9 @@ def build_move(
     return m
 
 
-def blended(constraints: SystemConstraints, first: Move, second: Move) -> bool:
+def blended(
+    constraints: SystemConstraints[AxisKey], first: Move[AxisKey], second: Move[AxisKey]
+) -> bool:
     """Check if the moves are blended."""
     log = logging.getLogger("blended")
     # have these actually had their blocks built?
@@ -408,7 +424,7 @@ def blended(constraints: SystemConstraints, first: Move, second: Move) -> bool:
         return False
 
     # do their junction velocities match constraints?
-    for axis in AXIS_NAMES:
+    for axis in first.unit_vector.keys():
         final_speed = first.blocks[-1].final_speed * first.unit_vector[axis]
         log.debug(f"{axis} final_speed: {final_speed}")
         initial_speed = second.blocks[0].initial_speed * second.unit_vector[axis]
@@ -444,7 +460,9 @@ def blended(constraints: SystemConstraints, first: Move, second: Move) -> bool:
     return True
 
 
-def all_blended(constraints: SystemConstraints, moves: List[Move]) -> bool:
+def all_blended(
+    constraints: SystemConstraints[AxisKey], moves: List[Move[AxisKey]]
+) -> bool:
     """Check if the moves in the list are all blended."""
     moveiter = iter(moves)
     prev = next(moveiter)
@@ -459,8 +477,8 @@ def all_blended(constraints: SystemConstraints, moves: List[Move]) -> bool:
 
 
 def unit_vector_multiplication(
-    unit_vector: Coordinates, value: np.float64
-) -> Coordinates:
+    unit_vector: Coordinates[AxisKey, np.float64], value: np.float64
+) -> Coordinates[AxisKey, np.float64]:
     """Multiply coordinates type by a float value."""
-    targets: np.ndarray = unit_vector.vectorize() * value
-    return Coordinates.from_iter(targets)
+    targets: np.ndarray = vectorize(unit_vector) * value
+    return {k: v for k, v in zip(unit_vector.keys(), targets)}

--- a/hardware/opentrons_hardware/scripts/plan_motion.py
+++ b/hardware/opentrons_hardware/scripts/plan_motion.py
@@ -10,11 +10,12 @@ from opentrons_hardware.hardware_control.motion_planning.types import (
     AxisConstraints,
     SystemConstraints,
     MoveTarget,
+    vectorize,
     Coordinates,
-    AXIS_NAMES,
 )
-from typing import Dict, Any
+from typing import Dict, Any, List, cast
 
+AXIS_NAMES = ["X", "Y", "Z", "A", "B", "C"]
 
 log = logging.getLogger(__name__)
 
@@ -85,13 +86,16 @@ def main() -> None:
     with open(args.params_file_path, "r") as f:
         params = json.load(f)
 
-    constraints: SystemConstraints = {
+    constraints: SystemConstraints[str] = {
         axis: AxisConstraints.build(**params["constraints"][axis])
         for axis in AXIS_NAMES
     }
-    origin = Coordinates(*params["origin"])
+    origin_from_file: List[float] = cast(List[float], params["origin"])
+    origin: Coordinates[str, float] = dict(zip(AXIS_NAMES, origin_from_file))
     target_list = [
-        MoveTarget.build(Coordinates(*target["coordinates"]), target["max_speed"])
+        MoveTarget.build(
+            dict(zip(AXIS_NAMES, *target["coordinates"])), target["max_speed"]
+        )
         for target in params["target_list"]
     ]
 
@@ -104,7 +108,7 @@ def main() -> None:
 
     output = {
         "moves": [v.to_dict() for v in blend_log[-1]],
-        "origin": list(origin.vectorize()),
+        "origin": list(vectorize(origin)),
     }
 
     with open(args.output, "w") as f:

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_utils.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_utils.py
@@ -16,126 +16,274 @@ from opentrons_hardware.hardware_control.motion_planning.move_utils import (
 from opentrons_hardware.hardware_control.motion_planning.types import (
     AxisConstraints,
     Block,
-    Coordinates,
     Move,
     MoveTarget,
-    AcceptableType,
     SystemConstraints,
+    is_unit_vector,
 )
 
+AXES = ["X", "Y", "Z", "A"]
+SIXAXES = ["X", "Y", "Z", "A", "B", "C"]
 
-CONSTRAINTS: SystemConstraints = {
+CONSTRAINTS: SystemConstraints[str] = {
     "X": AxisConstraints.build(
-        max_acceleration=10,
-        max_speed_discont=15,
-        max_direction_change_speed_discont=500,
+        max_acceleration=np.float64(10),
+        max_speed_discont=np.float64(15),
+        max_direction_change_speed_discont=np.float64(500),
     ),
     "Y": AxisConstraints.build(
-        max_acceleration=10,
-        max_speed_discont=15,
-        max_direction_change_speed_discont=500,
+        max_acceleration=np.float64(10),
+        max_speed_discont=np.float64(15),
+        max_direction_change_speed_discont=np.float64(500),
     ),
     "Z": AxisConstraints.build(
-        max_acceleration=100,
-        max_speed_discont=100,
-        max_direction_change_speed_discont=500,
+        max_acceleration=np.float64(100),
+        max_speed_discont=np.float64(100),
+        max_direction_change_speed_discont=np.float64(500),
     ),
     "A": AxisConstraints.build(
-        max_acceleration=100,
-        max_speed_discont=100,
-        max_direction_change_speed_discont=500,
+        max_acceleration=np.float64(100),
+        max_speed_discont=np.float64(100),
+        max_direction_change_speed_discont=np.float64(500),
     ),
     "B": AxisConstraints.build(
-        max_acceleration=100,
-        max_speed_discont=100,
-        max_direction_change_speed_discont=500,
+        max_acceleration=np.float64(100),
+        max_speed_discont=np.float64(100),
+        max_direction_change_speed_discont=np.float64(500),
     ),
     "C": AxisConstraints.build(
-        max_acceleration=100,
-        max_speed_discont=100,
-        max_direction_change_speed_discont=500,
+        max_acceleration=np.float64(100),
+        max_speed_discont=np.float64(100),
+        max_direction_change_speed_discont=np.float64(500),
     ),
 }
 
 
 SIMPLE_FORWARD_MOVE = Move.build(
-    unit_vector=Coordinates(1, 0, 0, 0),
-    distance=1,
-    max_speed=1,
+    unit_vector={
+        "X": np.float64(1),
+        "Y": np.float64(0),
+        "Z": np.float64(0),
+        "A": np.float64(0),
+    },
+    distance=np.float64(1),
+    max_speed=np.float64(1),
     blocks=(
-        Block(distance=10, initial_speed=1, acceleration=0),
-        Block(distance=10, initial_speed=1, acceleration=0),
-        Block(distance=10, initial_speed=1, acceleration=0),
+        Block(
+            distance=np.float64(10),
+            initial_speed=np.float64(1),
+            acceleration=np.float64(0),
+        ),
+        Block(
+            distance=np.float64(10),
+            initial_speed=np.float64(1),
+            acceleration=np.float64(0),
+        ),
+        Block(
+            distance=np.float64(10),
+            initial_speed=np.float64(1),
+            acceleration=np.float64(0),
+        ),
     ),
 )
 
 SIMPLE_BACKWARD_MOVE = Move.build(
-    unit_vector=Coordinates(-1, 0, 0, 0),
-    distance=1,
-    max_speed=1,
+    unit_vector={
+        "X": np.float64(-1),
+        "Y": np.float64(0),
+        "Z": np.float64(0),
+        "A": np.float64(0),
+    },
+    distance=np.float64(1),
+    max_speed=np.float64(1),
     blocks=(
-        Block(distance=10, initial_speed=1, acceleration=0),
-        Block(distance=10, initial_speed=1, acceleration=0),
-        Block(distance=10, initial_speed=1, acceleration=0),
+        Block(
+            distance=np.float64(10),
+            initial_speed=np.float64(1),
+            acceleration=np.float64(0),
+        ),
+        Block(
+            distance=np.float64(10),
+            initial_speed=np.float64(1),
+            acceleration=np.float64(0),
+        ),
+        Block(
+            distance=np.float64(10),
+            initial_speed=np.float64(1),
+            acceleration=np.float64(0),
+        ),
     ),
 )
 
-DUMMY_MOVE = Move.build_dummy_move()
+DUMMY_MOVE = Move.build_dummy(["X", "Y", "Z", "A"])
 
 
 def test_convert_targets_to_moves() -> None:
     """It should convert a list of move targets into a list of moves."""
     targets = [
-        MoveTarget.build(Coordinates(10, 0, 0, 0), 1),
-        MoveTarget.build(Coordinates(10, 20, 0, 0), 2),
-        MoveTarget.build(Coordinates(10, 20, 151, 0), 3),
-        MoveTarget.build(Coordinates(10, 20, 151, 1255), 4),
+        MoveTarget.build(
+            {
+                "X": np.float64(10),
+                "Y": np.float64(0),
+                "Z": np.float64(0),
+                "A": np.float64(0),
+            },
+            np.float64(1),
+        ),
+        MoveTarget.build(
+            {
+                "X": np.float64(10),
+                "Y": np.float64(20),
+                "Z": np.float64(0),
+                "A": np.float64(0),
+            },
+            np.float64(2),
+        ),
+        MoveTarget.build(
+            {
+                "X": np.float64(10),
+                "Y": np.float64(20),
+                "Z": np.float64(151),
+                "A": np.float64(0),
+            },
+            np.float64(3),
+        ),
+        MoveTarget.build(
+            {
+                "X": np.float64(10),
+                "Y": np.float64(20),
+                "Z": np.float64(151),
+                "A": np.float64(1255),
+            },
+            np.float64(4),
+        ),
     ]
 
     expected = [
         Move.build(
-            unit_vector=Coordinates(1.0, 0.0, 0.0, 0.0),
-            distance=10.0,
-            max_speed=1,
+            unit_vector={
+                "X": np.float64(1),
+                "Y": np.float64(0),
+                "Z": np.float64(0),
+                "A": np.float64(0),
+            },
+            distance=np.float64(10),
+            max_speed=np.float64(1),
             blocks=(
-                Block(distance=10 / 3, initial_speed=1, acceleration=0),
-                Block(distance=10 / 3, initial_speed=1, acceleration=0),
-                Block(distance=10 / 3, initial_speed=1, acceleration=0),
+                Block(
+                    distance=np.float64(10 / 3),
+                    initial_speed=np.float64(1),
+                    acceleration=np.float64(0),
+                ),
+                Block(
+                    distance=np.float64(10 / 3),
+                    initial_speed=np.float64(1),
+                    acceleration=np.float64(0),
+                ),
+                Block(
+                    distance=np.float64(10 / 3),
+                    initial_speed=np.float64(1),
+                    acceleration=np.float64(0),
+                ),
             ),
         ),
         Move.build(
-            unit_vector=Coordinates(0.0, 1.0, 0.0, 0.0),
-            distance=20.0,
-            max_speed=2,
+            unit_vector={
+                "X": np.float64(0),
+                "Y": np.float64(1),
+                "Z": np.float64(0),
+                "A": np.float64(0),
+            },
+            distance=np.float64(20),
+            max_speed=np.float64(2),
             blocks=(
-                Block(distance=20 / 3, initial_speed=2, acceleration=0),
-                Block(distance=20 / 3, initial_speed=2, acceleration=0),
-                Block(distance=20 / 3, initial_speed=2, acceleration=0),
+                Block(
+                    distance=np.float64(20 / 3),
+                    initial_speed=np.float64(2),
+                    acceleration=np.float64(0),
+                ),
+                Block(
+                    distance=np.float64(20 / 3),
+                    initial_speed=np.float64(2),
+                    acceleration=np.float64(0),
+                ),
+                Block(
+                    distance=np.float64(20 / 3),
+                    initial_speed=np.float64(2),
+                    acceleration=np.float64(0),
+                ),
             ),
         ),
         Move.build(
-            unit_vector=Coordinates(0.0, 0.0, 1.0, 0.0),
-            distance=151.0,
-            max_speed=3,
+            unit_vector={
+                "X": np.float64(0),
+                "Y": np.float64(0),
+                "Z": np.float64(1),
+                "A": np.float64(0),
+            },
+            distance=np.float64(151),
+            max_speed=np.float64(3),
             blocks=(
-                Block(distance=151 / 3, initial_speed=3, acceleration=0),
-                Block(distance=151 / 3, initial_speed=3, acceleration=0),
-                Block(distance=151 / 3, initial_speed=3, acceleration=0),
+                Block(
+                    distance=np.float64(151 / 3),
+                    initial_speed=np.float64(3),
+                    acceleration=np.float64(0),
+                ),
+                Block(
+                    distance=np.float64(151 / 3),
+                    initial_speed=np.float64(3),
+                    acceleration=np.float64(0),
+                ),
+                Block(
+                    distance=np.float64(151 / 3),
+                    initial_speed=np.float64(3),
+                    acceleration=np.float64(0),
+                ),
             ),
         ),
         Move.build(
-            unit_vector=Coordinates(0.0, 0.0, 0.0, 1.0),
-            distance=1255.0,
-            max_speed=4,
+            unit_vector={
+                "X": np.float64(0),
+                "Y": np.float64(0),
+                "Z": np.float64(0),
+                "A": np.float64(1),
+            },
+            distance=np.float64(1255),
+            max_speed=np.float64(4),
             blocks=(
-                Block(distance=1255 / 3, initial_speed=4, acceleration=0),
-                Block(distance=1255 / 3, initial_speed=4, acceleration=0),
-                Block(distance=1255 / 3, initial_speed=4, acceleration=0),
+                Block(
+                    distance=np.float64(1255 / 3),
+                    initial_speed=np.float64(4),
+                    acceleration=np.float64(0),
+                ),
+                Block(
+                    distance=np.float64(1255 / 3),
+                    initial_speed=np.float64(4),
+                    acceleration=np.float64(0),
+                ),
+                Block(
+                    distance=np.float64(1255 / 3),
+                    initial_speed=np.float64(4),
+                    acceleration=np.float64(0),
+                ),
             ),
         ),
     ]
 
-    assert list(targets_to_moves(Coordinates(0, 0, 0, 0), targets)) == expected
+    assert (
+        list(
+            targets_to_moves(
+                {
+                    "X": np.float64(0),
+                    "Y": np.float64(0),
+                    "Z": np.float64(0),
+                    "A": np.float64(0),
+                },
+                targets,
+            )
+        )
+        == expected
+    )
 
 
 @pytest.mark.parametrize(
@@ -166,20 +314,32 @@ def test_convert_targets_to_moves() -> None:
     ],
 )
 def test_initial_speed(
-    prev_move: Move,
-    unit_vector: Iterator[AcceptableType],
+    prev_move: Move[str],
+    unit_vector: Iterator[np.float64],
     max_speed: float,
     expected: float,
 ) -> None:
     """It should find the correct initial speed of the move."""
     move = Move.build(
-        unit_vector=Coordinates.from_iter(unit_vector),
-        distance=100,
-        max_speed=max_speed,
+        unit_vector={k: v for k, v in zip(AXES, unit_vector)},
+        distance=np.float64(100),
+        max_speed=np.float64(max_speed),
         blocks=(
-            Block(distance=100 / 3, initial_speed=max_speed, acceleration=0),
-            Block(distance=100 / 3, initial_speed=max_speed, acceleration=0),
-            Block(distance=100 / 3, initial_speed=max_speed, acceleration=0),
+            Block(
+                distance=np.float64(100 / 3),
+                initial_speed=np.float64(max_speed),
+                acceleration=np.float64(0),
+            ),
+            Block(
+                distance=np.float64(100 / 3),
+                initial_speed=np.float64(max_speed),
+                acceleration=np.float64(0),
+            ),
+            Block(
+                distance=np.float64(100 / 3),
+                initial_speed=np.float64(max_speed),
+                acceleration=np.float64(0),
+            ),
         ),
     )
     assert find_initial_speed(CONSTRAINTS, move, prev_move) == expected
@@ -208,20 +368,32 @@ def test_initial_speed(
     ],
 )
 def test_final_speed(
-    next_move: Move,
-    unit_vector: Iterator[AcceptableType],
+    next_move: Move[str],
+    unit_vector: Iterator[np.float64],
     max_speed: float,
     expected: float,
 ) -> None:
     """It should find the correct final speed of the move."""
     move = Move.build(
-        unit_vector=Coordinates.from_iter(unit_vector),
-        distance=100,
-        max_speed=max_speed,
+        unit_vector=dict(zip(AXES, unit_vector)),
+        distance=np.float64(100),
+        max_speed=np.float64(max_speed),
         blocks=(
-            Block(distance=100 / 3, initial_speed=max_speed, acceleration=0),
-            Block(distance=100 / 3, initial_speed=max_speed, acceleration=0),
-            Block(distance=100 / 3, initial_speed=max_speed, acceleration=0),
+            Block(
+                distance=np.float64(100 / 3),
+                initial_speed=np.float64(max_speed),
+                acceleration=np.float64(0),
+            ),
+            Block(
+                distance=np.float64(100 / 3),
+                initial_speed=np.float64(max_speed),
+                acceleration=np.float64(0),
+            ),
+            Block(
+                distance=np.float64(100 / 3),
+                initial_speed=np.float64(max_speed),
+                acceleration=np.float64(0),
+            ),
         ),
     )
     assert find_final_speed(CONSTRAINTS, move, next_move) == expected
@@ -230,11 +402,46 @@ def test_final_speed(
 def test_blend_motion() -> None:
     """Motion should blend."""
     manager = MoveManager(CONSTRAINTS)
-    origin = Coordinates(0, 0, 0, 0, 0, 0)
+
+    def all_zeros() -> Iterator[np.float64]:
+        while True:
+            yield np.float64(0)
+
+    origin = dict(zip(SIXAXES, all_zeros()))
     target_list = [
-        MoveTarget.build(position=Coordinates(10, 0, 0, 0, 0, 0), max_speed=30),
-        MoveTarget.build(position=Coordinates(10, 10, 0, 0, 0, 0), max_speed=20),
-        MoveTarget.build(position=Coordinates(10, 10, 15, 10, 0, 0), max_speed=10),
+        MoveTarget.build(
+            position={
+                "X": np.float64(10),
+                "Y": np.float64(0),
+                "Z": np.float64(0),
+                "A": np.float64(0),
+                "B": np.float64(0),
+                "C": np.float64(0),
+            },
+            max_speed=np.float64(30),
+        ),
+        MoveTarget.build(
+            position={
+                "X": np.float64(10),
+                "Y": np.float64(10),
+                "Z": np.float64(0),
+                "A": np.float64(0),
+                "B": np.float64(0),
+                "C": np.float64(0),
+            },
+            max_speed=np.float64(20),
+        ),
+        MoveTarget.build(
+            position={
+                "X": np.float64(10),
+                "Y": np.float64(10),
+                "Z": np.float64(15),
+                "A": np.float64(10),
+                "B": np.float64(0),
+                "C": np.float64(0),
+            },
+            max_speed=np.float64(10),
+        ),
     ]
     success, blend_log = manager.plan_motion(origin, target_list)
     assert success
@@ -249,7 +456,7 @@ def test_get_unit_vector(x: List[float], y: List[float]) -> None:
     """Get unit vector function should return a unit vector."""
     assume(x != y)
     assume(all(abs(j - i) > FLOAT_THRESHOLD for i, j in zip(x, y)))
-    coord_0 = Coordinates.from_iter(np.float64(i) for i in x)
-    coord_1 = Coordinates.from_iter(np.float64(i) for i in y)
+    coord_0 = dict(zip(AXES, (np.float64(i) for i in x)))
+    coord_1 = dict(zip(AXES, (np.float64(i) for i in y)))
     unit_v, _ = get_unit_vector(coord_1, coord_0)
-    assert unit_v.is_unit_vector()
+    assert is_unit_vector(unit_v)


### PR DESCRIPTION
The OT3 has a different hardware configuration than the OT2. It has a different number of axes that have different names, and a different number of mounts. It's pretty annoying (and insufficient) to map the current axis and mount types into the OT3, and adding the OT3 stuff to the already existing axis and mounts pollutes the global API even when not using the OT3, confusing users.

This is a different approach. It creates OT3Mount and OT3Axis types, inside hardware_control.types. It characteristically makes input values to OT3API methods take unions of the old and new - e.g. `Union[Mount, OT3Mount]`, which is safe because it includes the API mandated by the hardware control protocols, but also allows a window to new functionality. Internally, the OT3API and backends use these new mount and axis types everywhere.

This has some followon requirements that are almost, but not quite, pure type-level changes. The instrument handler and the motion utilities are now generic across axis and mount types; this is usually sufficient but sometimes they need explicit enum type value callouts, which have to be provided or derived (at runtime level, not type level) from some other inputs. It's kind of messy and kind of a lot of code, but it does remove all the string values from the API/backend interface and lets us callout the new axis names from the top down.

Open to feedback about better ways this can be done.