### PR TITLE
fix(app): display runtime errors in run detail header

### DIFF
--- a/app/src/organisms/RunDetails/CommandList.tsx
+++ b/app/src/organisms/RunDetails/CommandList.tsx
@@ -31,7 +31,11 @@ import {
   RUN_STATUS_SUCCEEDED,
 } from '@opentrons/api-client'
 import { useAllCommandsQuery } from '@opentrons/react-api-client'
-import { useRunStatus, useRunStartTime } from '../RunTimeControl/hooks'
+import {
+  useRunStatus,
+  useRunStartTime,
+  useRunErrors,
+} from '../RunTimeControl/hooks'
 import { useProtocolDetails } from './hooks'
 import { useCurrentRunId } from '../ProtocolUpload/hooks'
 import { ProtocolSetupInfo } from './ProtocolSetupInfo'
@@ -60,6 +64,7 @@ export function CommandList(): JSX.Element | null {
     .protocolData
   const runStartTime = useRunStartTime()
   const runStatus = useRunStatus()
+  const runErrors = useRunErrors()
   const listInnerRef = React.useRef<HTMLDivElement>(null)
   const currentItemRef = React.useRef<HTMLDivElement>(null)
   const firstPostInitialPlayRunCommandIndex = React.useRef<number | null>(null)
@@ -319,7 +324,16 @@ export function CommandList(): JSX.Element | null {
                       : 'success'
                   }
                   title={alertItemTitle}
-                />
+                >
+                  {runErrors.length > 0
+                    ? runErrors.map(({ detail, errorType }, index) => (
+                        <Text
+                          key={index}
+                          marginBottom={SPACING_2}
+                        >{`${errorType}: ${detail}`}</Text>
+                      ))
+                    : null}
+                </AlertItem>
               </Box>
             ) : null}
             <Flex

--- a/app/src/organisms/RunTimeControl/hooks.ts
+++ b/app/src/organisms/RunTimeControl/hooks.ts
@@ -22,7 +22,7 @@ import {
   useCurrentRunCommands,
 } from '../ProtocolUpload/hooks'
 import { UseQueryOptions } from 'react-query'
-import type { RunAction, RunStatus, Run } from '@opentrons/api-client'
+import type { RunAction, RunStatus, Run, RunData } from '@opentrons/api-client'
 
 interface RunControls {
   play: () => void
@@ -184,4 +184,8 @@ export function useRunTimestamps(): RunTimestamps {
     stoppedAt,
     completedAt,
   }
+}
+
+export function useRunErrors(): RunData['errors'] {
+  return useCurrentRun()?.data?.errors ?? []
 }


### PR DESCRIPTION
# Overview

Present error type and details for run time errors if the run status is "failed" 


<img width="655" alt="Screen Shot 2022-02-11 at 12 58 53 PM" src="https://user-images.githubusercontent.com/4731953/153650018-cebdebf9-0824-4566-bdfb-d139ee8ca0f4.png">

# Review requests

- please test the run time experience of a protocol that fails,  all errors associated with the run record should display in the "Protocol Run Failed" banner at the top of the Run Detail page 

# Risk assessment
low