### PR TITLE
fix(hardware,api): can network_probe functionality

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -455,13 +455,14 @@ class OT3Controller:
         # see if we should expect instruments to be present, which should be removed
         # when that method actually does canbus stuff
         instrs = await self.get_attached_instruments({})
-        expected = set(self._get_home_position().keys())
-        if not instrs.get(Mount.LEFT, cast("AttachedInstrument", {})).get(
-            "config", None
-        ):
-            expected.remove(NodeId.pipette_left)
-        if not instrs.get(Mount.RIGHT, cast("AttachedInstrument", {})).get(
-            "config", None
-        ):
-            expected.remove(NodeId.pipette_right)
-        self._present_nodes = await probe(self._messenger, expected, timeout)
+        expected = set((NodeId.gantry_x, NodeId.gantry_y, NodeId.head))
+        if instrs.get(Mount.LEFT, cast("AttachedInstrument", {})).get("config", None):
+            expected.add(NodeId.pipette_left)
+        if instrs.get(Mount.RIGHT, cast("AttachedInstrument", {})).get("config", None):
+            expected.add(NodeId.pipette_right)
+        present = await probe(self._messenger, expected, timeout)
+        if NodeId.head in present:
+            present.remove(NodeId.head)
+            present.add(NodeId.head_r)
+            present.add(NodeId.head_l)
+        self._present_nodes = present

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -36,7 +36,7 @@ def controller(mock_config: OT3Config, mock_driver: AbstractCanDriver) -> OT3Con
 async def test_probing(controller: OT3Controller) -> None:
     assert controller._present_nodes == set()
     call_count = 0
-    fake_nodes = set((NodeId.gantry_x, NodeId.head_l))
+    fake_nodes = set((NodeId.gantry_x, NodeId.head))
     passed_expected = None
 
     async def fake_probe(can_messenger, expected, timeout):
@@ -54,12 +54,13 @@ async def test_probing(controller: OT3Controller) -> None:
             (
                 NodeId.gantry_x,
                 NodeId.gantry_y,
-                NodeId.head_l,
-                NodeId.head_r,
+                NodeId.head,
                 NodeId.pipette_left,
             )
         )
-    assert controller._present_nodes == fake_nodes
+    assert controller._present_nodes == set(
+        (NodeId.gantry_x, NodeId.head_l, NodeId.head_r)
+    )
 
 
 async def test_move_limiting(controller: OT3Controller) -> None:

--- a/hardware/opentrons_hardware/hardware_control/network.py
+++ b/hardware/opentrons_hardware/hardware_control/network.py
@@ -7,7 +7,7 @@ from opentrons_ot3_firmware.constants import NodeId
 from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
 from opentrons_ot3_firmware.messages import payloads, MessageDefinition
 from opentrons_ot3_firmware.messages.message_definitions import (
-    GetStatusRequest,
+    DeviceInfoRequest,
 )
 
 mod_log = logging.getLogger(__name__)
@@ -49,7 +49,7 @@ async def probe(
     can_messenger.add_listener(listener)
     await can_messenger.send(
         node_id=NodeId.broadcast,
-        message=GetStatusRequest(payload=payloads.EmptyPayload()),
+        message=DeviceInfoRequest(payload=payloads.EmptyPayload()),
     )
     try:
         await asyncio.wait_for(event.wait(), timeout)

--- a/hardware/tests/opentrons_hardware/hardware_control/test_network.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_network.py
@@ -48,7 +48,7 @@ class MockStatusResponder:
             for node in self._respond_with_nodes:
                 response = message_definitions.DeviceInfoResponse(
                     payload=payloads.DeviceInfoResponsePayload(
-                        version=0,
+                        version=utils.UInt32Field(0),
                     )
                 )
                 asyncio.get_running_loop().call_soon(

--- a/hardware/tests/opentrons_hardware/hardware_control/test_network.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_network.py
@@ -46,9 +46,9 @@ class MockStatusResponder:
         assert self._callbacks
         for callback in self._callbacks:
             for node in self._respond_with_nodes:
-                response = message_definitions.GetStatusResponse(
-                    payload=payloads.GetStatusResponsePayload(
-                        status=utils.UInt8Field(0), data=utils.UInt32Field(0)
+                response = message_definitions.DeviceInfoResponse(
+                    payload=payloads.DeviceInfoResponsePayload(
+                        version=0,
                     )
                 )
                 asyncio.get_running_loop().call_soon(
@@ -83,7 +83,7 @@ async def test_timeout_fires(mock_can_messenger: AsyncMock) -> None:
     # We should have sent a request
     mock_can_messenger.send.assert_called_once_with(
         node_id=NodeId.broadcast,
-        message=message_definitions.GetStatusRequest(payload=payloads.EmptyPayload()),
+        message=message_definitions.DeviceInfoRequest(payload=payloads.EmptyPayload()),
     )
     # we should have added a listener
     mock_can_messenger.add_listener.assert_called_once()


### PR DESCRIPTION
Network probe was using get_status_request, which nothing has
implemented, and therefore nothing responds to. That's bad. Use
GetDeviceInfo instead which I think was what I was searching for in my
mind's brain originally.

Additionally, head responds to GetDeviceInfo, not head_l or head_r, so
handle that in the controller backends.
