### PR TITLE
refactor(protocol-engine): Revise `wait_for()` docstring

### DIFF
--- a/api/src/opentrons/protocol_engine/state/state.py
+++ b/api/src/opentrons/protocol_engine/state/state.py
@@ -146,17 +146,41 @@ class StateStore(StateView, ActionHandler):
     ) -> ReturnT:
         """Wait for a condition to become true, checking whenever state changes.
 
+        If the condition is already true, return immediately.
+
         !!! Warning:
-            In general, callers should not trigger a state change via
-            `handle_action` directly after a `wait_for`, as it may interfere
-            with other subscribers. If you _must_ trigger a state change, ensure
-            the change cannot affect the `condition`'s of other `wait_for`'s.
+            This will only return when `condition` is true right now.
+            If you're not careful, this can cause you to miss updates,
+            and potentially wait forever.
+
+            For example, suppose:
+
+            1. Things start out in state A.
+            2. You start waiting specifically for state B.
+            3. State transitions A -> B.
+               Your task could theoretically run now,
+               but the event loop decides not to do that.
+            4. State transitions B -> C.
+            5. The event loop decides to run your task now.
+               But this method will only return when the state is B,
+               which it isn't now, so your task will stay waiting indefinitely.
+
+            To fix this, design your `condition` to look for something that,
+            after it first becomes true, remains true forever. For example,
+            suppose you want to wait for the engine to reach a specific command.
+            Don't use a `condition` that checks if that command is running now.
+            Instead, use a `condition` that checks if it ever has been running.
+
+            If this isn't possible, then you need other means to ensure that
+            no other task can transition the state out of the condition that you
+            care about until after you've had a chance to operate on the state
+            while it's in that condition.
 
         Arguments:
             condition: A function that returns a truthy value when the `await`
-                should resolve
-            *args: Positional arguments to pass to `condition`
-            **kwargs: Named arguments to pass to `condition`
+                should resolve.
+            *args: Positional arguments to pass to `condition`.
+            **kwargs: Named arguments to pass to `condition`.
 
         Returns:
             The truthy value returned by the `condition` function.

--- a/api/src/opentrons/protocol_engine/state/state.py
+++ b/api/src/opentrons/protocol_engine/state/state.py
@@ -184,6 +184,9 @@ class StateStore(StateView, ActionHandler):
 
         Returns:
             The truthy value returned by the `condition` function.
+
+        Raises:
+            The exception raised by the `condition` function, if any.
         """
         predicate = partial(condition, *args, **kwargs)
         is_done = predicate()


### PR DESCRIPTION
# Overview

This PR revises how we describe the concurrency caveats around `wait_for()`, and changes our recommendations for using it safely.

# My thinking

The original docstring says:

> In general, callers should not trigger a state change via `handle_action` directly after a `wait_for`, as it may interfere with other subscribers. If you _must_ trigger a state change, ensure the change cannot affect the `condition`'s of other `wait_for`'s.

I think there are two problems with this strategy:

1. It only looks at tasks that trigger a state change directly after a `wait_for()`. I don't think this is sufficient. We need to consider *any* task that triggers a state change, even if it has never touched a `wait_for()`. [Here's a demo](https://gist.github.com/SyntaxColoring/2102472235dd82dc95cf872eb870ec78) where all tasks obey the rules as written in the original docstring, but there's still has a concurrency bug.
2. If we have to consider every state-changing task, it's unrealistic to put the burden on all of them to avoid interfering with `wait_for()`s. Every time you write something that changes state, you'd have to know how every single waiter works.

So the new idea is to shift the burden onto the task doing the `wait_for()`.

If you're writing a task that does `wait_for()`, one thing you can do is choose a good `condition`. Some are more robust than others. Ideally, you take advantage of Protocol Engine state guarantees to make your `condition` interference-proof. (See the new docstring for details.)

If you can't do that, then you need some other way of making sure nothing can interfere with you. The new docstring briefly describes what condition you need to meet for this to be successful.

# Review requests

* Does this make sense to everyone? Can anything be phrased more clearly? Can anything be shortened?
* Is this the right place for these recommendations? Our `wait_for()` mirrors `asynycio.Condition.wait_for()`, which shares these caveats.