### PR TITLE
feat(app): add heater shaker wizard scaffold

### DIFF
--- a/app/src/assets/localization/en/heater_shaker.json
+++ b/app/src/assets/localization/en/heater_shaker.json
@@ -1,5 +1,14 @@
 {
   "banner_title": "Attach {{name}} to deck before proceeding to run",
   "banner_body": "Attachment prevents the module from shaking out of a deck slot.",
-  "banner_wizard_button": "See how to attach module to the deck"
+  "banner_wizard_button": "See how to attach module to the deck",
+  "btn_continue_attachment_guide": "Continue to attachment guide",
+  "btn_begin_attachment": "Begin attachment",
+  "btn_thermal_adapter": "Continue to attach thermal adapter",
+  "btn_power_module": "Continue to power on module",
+  "btn_test_shake": "Continue to test shake",
+  "complete": "Complete",
+  "back": "Back",
+  "btn_exit": "Exit",
+  "modal_title": "{{name}} - Attach Heater Shaker Module"
 }

--- a/app/src/assets/localization/en/heater_shaker.json
+++ b/app/src/assets/localization/en/heater_shaker.json
@@ -9,6 +9,5 @@
   "btn_test_shake": "Continue to test shake",
   "complete": "Complete",
   "back": "Back",
-  "btn_exit": "Exit",
   "modal_title": "{{name}} - Attach Heater Shaker Module"
 }

--- a/app/src/organisms/Devices/HeaterShakerWizard/AttachAdapter.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/AttachAdapter.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export function AttachAdapter(): JSX.Element {
+  return <div>AttachAdapter</div>
+}

--- a/app/src/organisms/Devices/HeaterShakerWizard/AttachModule.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/AttachModule.tsx
@@ -1,5 +1,9 @@
 import React from 'react'
 
-export function AttachModule(): JSX.Element {
+interface AttachModuleProps {
+  slotName: string
+}
+
+export function AttachModule(props: AttachModuleProps): JSX.Element {
   return <div>AttachModule</div>
 }

--- a/app/src/organisms/Devices/HeaterShakerWizard/AttachModule.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/AttachModule.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export function AttachModule(): JSX.Element {
+  return <div>AttachModule</div>
+}

--- a/app/src/organisms/Devices/HeaterShakerWizard/Introduction.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/Introduction.tsx
@@ -1,5 +1,10 @@
 import React from 'react'
 
-export function Introduction(): JSX.Element {
+interface IntroductionProps {
+  labwareDefinition: string
+  thermalAdapterName: string
+}
+
+export function Introduction(props: IntroductionProps): JSX.Element {
   return <div>Introduction</div>
 }

--- a/app/src/organisms/Devices/HeaterShakerWizard/Introduction.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/Introduction.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export function Introduction(): JSX.Element {
+  return <div>Introduction</div>
+}

--- a/app/src/organisms/Devices/HeaterShakerWizard/KeyParts.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/KeyParts.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export function KeyParts(): JSX.Element {
+  return <div>KeyParts</div>
+}

--- a/app/src/organisms/Devices/HeaterShakerWizard/PowerOn.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/PowerOn.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export function PowerOn(): JSX.Element {
+  return <div>PowerOn</div>
+}

--- a/app/src/organisms/Devices/HeaterShakerWizard/PowerOn.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/PowerOn.tsx
@@ -1,5 +1,9 @@
 import React from 'react'
 
-export function PowerOn(): JSX.Element {
+interface PowerOnProps {
+  status: string
+}
+
+export function PowerOn(props: PowerOnProps): JSX.Element {
   return <div>PowerOn</div>
 }

--- a/app/src/organisms/Devices/HeaterShakerWizard/TestShake.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/TestShake.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export function TestShake(): JSX.Element {
+  return <div>TestShake</div>
+}

--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/HeaterShakerWizard.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/HeaterShakerWizard.test.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react'
+import { fireEvent } from '@testing-library/react'
+import { renderWithProviders } from '@opentrons/components'
+import { i18n } from '../../../../i18n'
+import { getConnectedRobotName } from '../../../../redux/robot/selectors'
+import { HeaterShakerWizard } from '..'
+import { Introduction } from '../Introduction'
+import { KeyParts } from '../KeyParts'
+import { AttachModule } from '../AttachModule'
+import { AttachAdapter } from '../AttachAdapter'
+import { PowerOn } from '../PowerOn'
+import { TestShake } from '../TestShake'
+
+jest.mock('../../../../redux/robot/selectors')
+jest.mock('../Introduction')
+jest.mock('../KeyParts')
+jest.mock('../AttachModule')
+jest.mock('../AttachAdapter')
+jest.mock('../PowerOn')
+jest.mock('../TestShake')
+
+const mockGetConnectedRobotName = getConnectedRobotName as jest.MockedFunction<
+  typeof getConnectedRobotName
+>
+const mockIntroduction = Introduction as jest.MockedFunction<
+  typeof Introduction
+>
+const mockKeyParts = KeyParts as jest.MockedFunction<typeof KeyParts>
+const mockAttachModule = AttachModule as jest.MockedFunction<
+  typeof AttachModule
+>
+const mockAttachAdapter = AttachAdapter as jest.MockedFunction<
+  typeof AttachAdapter
+>
+const mockPowerOn = PowerOn as jest.MockedFunction<typeof PowerOn>
+const mockTestShake = TestShake as jest.MockedFunction<typeof TestShake>
+
+const render = (props: React.ComponentProps<typeof HeaterShakerWizard>) => {
+  return renderWithProviders(<HeaterShakerWizard {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+describe('HeaterShakerWizard', () => {
+  const props: React.ComponentProps<typeof HeaterShakerWizard> = {
+    onCloseClick: jest.fn(),
+  }
+  beforeEach(() => {
+    mockGetConnectedRobotName.mockReturnValue('Mock Robot')
+    mockIntroduction.mockReturnValue(<div>Mock Introduction</div>)
+    mockKeyParts.mockReturnValue(<div>Mock Key Parts</div>)
+    mockAttachModule.mockReturnValue(<div>Mock Attach Module</div>)
+    mockAttachAdapter.mockReturnValue(<div>Mock Attach Adapter</div>)
+    mockPowerOn.mockReturnValue(<div>Mock Power On</div>)
+    mockTestShake.mockReturnValue(<div>Mock Test Shake</div>)
+  })
+
+  it('renders the main modal component of the wizard', () => {
+    const { getByText } = render(props)
+    getByText('Mock Robot - Attach Heater Shaker Module')
+    getByText('Mock Introduction')
+  })
+
+  it('renders wizard and returns the correct pages when the buttons are clicked', () => {
+    const { getByText, getByRole } = render(props)
+
+    let button = getByRole('button', { name: 'Continue to attachment guide' })
+    fireEvent.click(button)
+    getByText('Mock Key Parts')
+
+    button = getByRole('button', { name: 'Begin attachment' })
+    fireEvent.click(button)
+    getByText('Mock Attach Module')
+
+    button = getByRole('button', { name: 'Continue to attach thermal adapter' })
+    fireEvent.click(button)
+    getByText('Mock Attach Adapter')
+
+    button = getByRole('button', { name: 'Continue to power on module' })
+    fireEvent.click(button)
+    getByText('Mock Power On')
+
+    button = getByRole('button', { name: 'Continue to test shake' })
+    fireEvent.click(button)
+    getByText('Mock Test Shake')
+
+    getByRole('button', { name: 'Complete' })
+  })
+})

--- a/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react'
+import { useTranslation } from 'react-i18next'
 import { Portal } from '../../../App/portal'
+import { useSelector } from 'react-redux'
+import { getConnectedRobotName } from '../../../redux/robot/selectors'
 import { Introduction } from './Introduction'
 import { KeyParts } from './KeyParts'
 import { AttachModule } from './AttachModule'
@@ -15,7 +18,10 @@ import {
   ModalPage,
   PrimaryBtn,
   SecondaryBtn,
+  TEXT_TRANSFORM_NONE,
 } from '@opentrons/components'
+
+import type { State } from '../../../redux/types'
 
 interface HeaterShakerWizardProps {
   onCloseClick: () => unknown
@@ -25,27 +31,34 @@ export const HeaterShakerWizard = (
   props: HeaterShakerWizardProps
 ): JSX.Element => {
   const { onCloseClick } = props
+  const { t } = useTranslation(['heater_shaker', 'shared'])
   const [currentPage, setCurrentPage] = React.useState(0)
+  const robotName = useSelector((state: State) => getConnectedRobotName(state))
   let buttonContent = null
   const getWizardDisplayPage = (): JSX.Element | null => {
     switch (currentPage) {
       case 0:
-        buttonContent = 'Continue to attachment guide'
-        return <Introduction />
+        buttonContent = t('btn_continue_attachment_guide')
+        return (
+          <Introduction
+            labwareDefinition="plate"
+            thermalAdapterName="adapter"
+          />
+        )
       case 1:
-        buttonContent = 'Begin attachment'
+        buttonContent = t('btn_begin_attachment')
         return <KeyParts />
       case 2:
-        buttonContent = 'Continue to attach thermal adapter'
-        return <AttachModule />
+        buttonContent = t('btn_thermal_adapter')
+        return <AttachModule slotName={'1'} />
       case 3:
-        buttonContent = 'Continue to power on module'
+        buttonContent = t('btn_power_module')
         return <AttachAdapter />
       case 4:
-        buttonContent = 'Continue to test shake'
-        return <PowerOn />
+        buttonContent = t('btn_test_shake')
+        return <PowerOn status={'on'} />
       case 5:
-        buttonContent = 'Complete'
+        buttonContent = t('complete')
         return <TestShake />
       default:
         return null
@@ -56,11 +69,11 @@ export const HeaterShakerWizard = (
     <Portal level="top">
       <ModalPage
         titleBar={{
-          title: 'Robot Name - Attach Heater Shaker Module',
+          title: t('modal_title', { name: robotName }),
           back: {
             onClick: () => onCloseClick(),
-            title: 'Exit',
-            children: 'Exit',
+            title: t('shared:exit'),
+            children: t('shared:exit'),
           },
         }}
       >
@@ -71,20 +84,22 @@ export const HeaterShakerWizard = (
         >
           {currentPage > 0 ? (
             <SecondaryBtn
+              alignItems={ALIGN_CENTER}
               color={COLORS.blue}
               borderRadius={'3px'}
-              alignItems={ALIGN_CENTER}
+              textTransform={TEXT_TRANSFORM_NONE}
               data-testid={`wizard_back_btn`}
               onClick={() => setCurrentPage(currentPage => currentPage - 1)}
             >
-              Back
+              {t('back')}
             </SecondaryBtn>
           ) : null}
           {currentPage <= 5 ? (
             <PrimaryBtn
+              alignItems={ALIGN_CENTER}
               backgroundColor={COLORS.blue}
               borderRadius={'3px'}
-              alignItems={ALIGN_CENTER}
+              textTransform={TEXT_TRANSFORM_NONE}
               data-testid={`wizard_next_btn`}
               onClick={
                 currentPage === 5

--- a/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
@@ -1,0 +1,102 @@
+import * as React from 'react'
+import { Portal } from '../../../App/portal'
+import { Introduction } from './Introduction'
+import { KeyParts } from './KeyParts'
+import { AttachModule } from './AttachModule'
+import { AttachAdapter } from './AttachAdapter'
+import { PowerOn } from './PowerOn'
+import { TestShake } from './TestShake'
+import {
+  ALIGN_CENTER,
+  COLORS,
+  DIRECTION_ROW,
+  Flex,
+  JUSTIFY_SPACE_BETWEEN,
+  ModalPage,
+  PrimaryBtn,
+  SecondaryBtn,
+} from '@opentrons/components'
+
+interface HeaterShakerWizardProps {
+  onCloseClick: () => unknown
+}
+
+export const HeaterShakerWizard = (
+  props: HeaterShakerWizardProps
+): JSX.Element => {
+  const { onCloseClick } = props
+  const [currentPage, setCurrentPage] = React.useState(0)
+  let buttonContent = null
+  const getWizardDisplayPage = (): JSX.Element | null => {
+    switch (currentPage) {
+      case 0:
+        buttonContent = 'Continue to attachment guide'
+        return <Introduction />
+      case 1:
+        buttonContent = 'Begin attachment'
+        return <KeyParts />
+      case 2:
+        buttonContent = 'Continue to attach thermal adapter'
+        return <AttachModule />
+      case 3:
+        buttonContent = 'Continue to power on module'
+        return <AttachAdapter />
+      case 4:
+        buttonContent = 'Continue to test shake'
+        return <PowerOn />
+      case 5:
+        buttonContent = 'Complete'
+        return <TestShake />
+      default:
+        return null
+    }
+  }
+
+  return (
+    <Portal level="top">
+      <ModalPage
+        titleBar={{
+          title: 'Robot Name - Attach Heater Shaker Module',
+          back: {
+            onClick: () => onCloseClick(),
+            title: 'Exit',
+            children: 'Exit',
+          },
+        }}
+      >
+        {getWizardDisplayPage()}
+        <Flex
+          flexDirection={DIRECTION_ROW}
+          justifyContent={JUSTIFY_SPACE_BETWEEN}
+        >
+          {currentPage > 0 ? (
+            <SecondaryBtn
+              color={COLORS.blue}
+              borderRadius={'3px'}
+              alignItems={ALIGN_CENTER}
+              data-testid={`wizard_back_btn`}
+              onClick={() => setCurrentPage(currentPage => currentPage - 1)}
+            >
+              Back
+            </SecondaryBtn>
+          ) : null}
+          {currentPage <= 5 ? (
+            <PrimaryBtn
+              backgroundColor={COLORS.blue}
+              borderRadius={'3px'}
+              alignItems={ALIGN_CENTER}
+              data-testid={`wizard_next_btn`}
+              onClick={
+                currentPage === 5
+                  ? () => onCloseClick()
+                  : () => setCurrentPage(currentPage => currentPage + 1)
+              }
+            >
+              {buttonContent}
+            </PrimaryBtn>
+          ) : null}
+        </Flex>
+      </ModalPage>
+    </Portal>
+  )
+}

--- a/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
@@ -18,6 +18,7 @@ import {
   ModalPage,
   PrimaryBtn,
   SecondaryBtn,
+  SPACING,
   TEXT_TRANSFORM_NONE,
 } from '@opentrons/components'
 
@@ -86,7 +87,7 @@ export const HeaterShakerWizard = (
             <SecondaryBtn
               alignItems={ALIGN_CENTER}
               color={COLORS.blue}
-              borderRadius={'3px'}
+              borderRadius={SPACING.spacingS}
               textTransform={TEXT_TRANSFORM_NONE}
               data-testid={`wizard_back_btn`}
               onClick={() => setCurrentPage(currentPage => currentPage - 1)}
@@ -98,7 +99,7 @@ export const HeaterShakerWizard = (
             <PrimaryBtn
               alignItems={ALIGN_CENTER}
               backgroundColor={COLORS.blue}
-              borderRadius={'3px'}
+              borderRadius={SPACING.spacingS}
               textTransform={TEXT_TRANSFORM_NONE}
               data-testid={`wizard_next_btn`}
               onClick={

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/HeaterShakerBanner.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/HeaterShakerBanner.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { Banner } from '../../../../../atoms/Banner/Banner'
+import { HeaterShakerWizard } from '../../../../Devices/HeaterShakerWizard'
 
 interface HeaterShakerBannerProps {
   displayName: string
@@ -9,15 +10,21 @@ interface HeaterShakerBannerProps {
 export function HeaterShakerBanner(
   props: HeaterShakerBannerProps
 ): JSX.Element | null {
+  const [showWizard, setShowWizard] = React.useState(false)
   const { displayName } = props
   const { t } = useTranslation('heater_shaker')
 
   return (
-    <Banner
-      title={t('banner_title', { name: displayName })}
-      body={t('banner_body')}
-      btnText={t('banner_wizard_button')}
-      onClick={() => console.log('proceed to wizard')}
-    />
+    <>
+      {showWizard && (
+        <HeaterShakerWizard onCloseClick={() => setShowWizard(false)} />
+      )}
+      <Banner
+        title={t('banner_title', { name: displayName })}
+        body={t('banner_body')}
+        btnText={t('banner_wizard_button')}
+        onClick={() => setShowWizard(true)}
+      />
+    </>
   )
 }

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/index.tsx
@@ -92,7 +92,8 @@ export function ModuleSetup(props: ModuleSetupProps): JSX.Element {
         return (
           <>
             {/* @ts-expect-error: this is always false until heater shaker is added to model */}
-            {model === 'heatershakermoduleV1' && (
+            {(model === 'heatershakermoduleV1' ||
+              model === 'magneticModuleV2') && (
               <Flex key="heater_shaker_banner">
                 <HeaterShakerBanner displayName={moduleDef.displayName} />
               </Flex>

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/index.tsx
@@ -92,8 +92,7 @@ export function ModuleSetup(props: ModuleSetupProps): JSX.Element {
         return (
           <>
             {/* @ts-expect-error: this is always false until heater shaker is added to model */}
-            {(model === 'heatershakermoduleV1' ||
-              model === 'magneticModuleV2') && (
+            {model === 'heatershakermoduleV1' && (
               <Flex key="heater_shaker_banner">
                 <HeaterShakerBanner displayName={moduleDef.displayName} />
               </Flex>

--- a/components/src/ui-style-constants/spacing.ts
+++ b/components/src/ui-style-constants/spacing.ts
@@ -5,4 +5,5 @@ export const spacing3 = '0.5rem' // 8px
 export const spacing4 = '1rem' // 16px
 export const spacing5 = '1.5rem' // 24px
 export const spacing6 = '2rem' // 32px
+export const spacingS = '0.188' // 3px
 export const spacingM = '1.25rem' // 20px


### PR DESCRIPTION


# Overview

This PR adds the scaffolding layer of the heater shaker setup wizard.

<img width="705" alt="Screen Shot 2022-02-14 at 11 16 35 AM" src="https://user-images.githubusercontent.com/14794021/153905194-bed4b42e-441d-490e-8a6a-439ac5d3abba.png">

<img width="701" alt="Screen Shot 2022-02-14 at 11 16 40 AM" src="https://user-images.githubusercontent.com/14794021/153905175-8694f4dd-c04d-48a3-990e-cb42ed004355.png">


Paired/Planned with: @jerader @shlokamin 

# Changelog

- Added `HeaterShakerWizard` component
- Created blank subcomponents for the wizard
- Added test coverage

# Review requests

- In `ModuleSetup`, locally change `model === 'heatershakermoduleV1'` to any existing module and upload a protocol with that module. This will render the heater shaker banner and the CTA to open the wizard. Once the wizard is open check that it renders the sub-components correctly when the buttons are clicked.
- Note: The modal component will need stylistic upgrades (perhaps a new component altogether?)

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

low
