### PR TITLE
refactor(engine): allow module loads to be analyzed in PAPIv3

### DIFF
--- a/api/src/opentrons/protocol_engine/__init__.py
+++ b/api/src/opentrons/protocol_engine/__init__.py
@@ -9,7 +9,7 @@ from .create_protocol_engine import create_protocol_engine
 from .protocol_engine import ProtocolEngine
 from .errors import ProtocolEngineError, ErrorOccurrence
 from .commands import Command, CommandParams, CommandCreate, CommandStatus, CommandType
-from .state import State, StateView, CommandSlice
+from .state import State, StateView, CommandSlice, EngineConfigs
 from .plugins import AbstractPlugin
 
 from .types import (
@@ -23,6 +23,7 @@ from .types import (
     EngineStatus,
     LabwareLocation,
     LoadedLabware,
+    LoadedModule,
     LoadedPipette,
     PipetteName,
     WellLocation,
@@ -36,6 +37,7 @@ __all__ = [
     # main factory and interface exports
     "create_protocol_engine",
     "ProtocolEngine",
+    "EngineConfigs",
     # error types
     "ProtocolEngineError",
     "ErrorOccurrence",
@@ -60,6 +62,7 @@ __all__ = [
     "EngineStatus",
     "LabwareLocation",
     "LoadedLabware",
+    "LoadedModule",
     "LoadedPipette",
     "PipetteName",
     "WellLocation",

--- a/api/src/opentrons/protocol_engine/commands/load_module.py
+++ b/api/src/opentrons/protocol_engine/commands/load_module.py
@@ -85,6 +85,7 @@ class LoadModuleImplementation(AbstractCommandImpl[LoadModuleParams, LoadModuleR
             location=params.location,
             module_id=params.moduleId,
         )
+
         return LoadModuleResult(
             moduleId=loaded_module.module_id,
             serialNumber=loaded_module.serial_number,

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -195,22 +195,32 @@ class EquipmentHandler:
                 assigned to the requested location.
         """
         # TODO(mc, 2022-02-09): validate module location given deck definition
+        use_virtual_modules = self._state_store.get_configs().use_virtual_modules
 
-        attached_modules = [
-            HardwareModule(
-                serial_number=hw_mod.device_info["serial"],
-                definition=self._module_data_provider.get_definition(
-                    ModuleModel(hw_mod.model())
-                ),
+        if not use_virtual_modules:
+            attached_modules = [
+                HardwareModule(
+                    serial_number=hw_mod.device_info["serial"],
+                    definition=self._module_data_provider.get_definition(
+                        ModuleModel(hw_mod.model())
+                    ),
+                )
+                for hw_mod in self._hardware_api.attached_modules
+            ]
+
+            attached_module = self._state_store.modules.find_attached_module(
+                model=model,
+                location=location,
+                attached_modules=attached_modules,
             )
-            for hw_mod in self._hardware_api.attached_modules
-        ]
 
-        attached_module = self._state_store.modules.find_attached_module(
-            model=model,
-            location=location,
-            attached_modules=attached_modules,
-        )
+        else:
+            attached_module = HardwareModule(
+                # TODO(mc, 2022-02-14): use something a little more obvious
+                # than an opaque UUID for the virtual serial number
+                serial_number=self._model_utils.generate_id(),
+                definition=self._module_data_provider.get_definition(model),
+            )
 
         return LoadedModuleData(
             module_id=self._model_utils.ensure_id(module_id),

--- a/api/src/opentrons/protocol_engine/state/configs.py
+++ b/api/src/opentrons/protocol_engine/state/configs.py
@@ -7,3 +7,4 @@ class EngineConfigs:
     """Configurations for Protocol Engine."""
 
     ignore_pause: bool = False
+    use_virtual_modules: bool = False

--- a/api/src/opentrons/protocol_runner/create_simulating_runner.py
+++ b/api/src/opentrons/protocol_runner/create_simulating_runner.py
@@ -2,8 +2,7 @@
 
 from opentrons.config import feature_flags
 from opentrons.hardware_control import API as HardwareAPI, SynchronousAdapter
-from opentrons.protocol_engine import create_protocol_engine
-from opentrons.protocol_engine.state import EngineConfigs
+from opentrons.protocol_engine import EngineConfigs, create_protocol_engine
 
 from .legacy_wrappers import LegacySimulatingContextCreator
 from .legacy_labware_offset_provider import LegacyLabwareOffsetProvider
@@ -40,7 +39,10 @@ async def create_simulating_runner() -> ProtocolRunner:
 
     protocol_engine = await create_protocol_engine(
         hardware_api=simulating_hardware_api,
-        configs=EngineConfigs(ignore_pause=True),
+        configs=EngineConfigs(
+            ignore_pause=True,
+            use_virtual_modules=True,
+        ),
     )
 
     offset_provider = LegacyLabwareOffsetProvider(

--- a/api/src/opentrons/protocol_runner/protocol_runner.py
+++ b/api/src/opentrons/protocol_runner/protocol_runner.py
@@ -13,6 +13,7 @@ from opentrons.protocol_engine import (
     Command,
     ErrorOccurrence,
     LoadedLabware,
+    LoadedModule,
     LoadedPipette,
 )
 
@@ -41,6 +42,7 @@ class ProtocolRunData:
     errors: List[ErrorOccurrence]
     labware: List[LoadedLabware]
     pipettes: List[LoadedPipette]
+    modules: List[LoadedModule]
 
 
 # TODO(mc, 2022-01-11): this class has become bloated. Split into an abstract
@@ -167,6 +169,7 @@ class ProtocolRunner:
             errors=self._protocol_engine.state_view.commands.get_all_errors(),
             labware=self._protocol_engine.state_view.labware.get_all(),
             pipettes=self._protocol_engine.state_view.pipettes.get_all(),
+            modules=self._protocol_engine.state_view.modules.get_all(),
         )
 
     def _load_json(self, protocol_source: ProtocolSource) -> None:

--- a/api/tests/opentrons/protocol_runner/smoke_tests/conftest.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/conftest.py
@@ -9,14 +9,23 @@ import json
 import textwrap
 from pathlib import Path
 
+from opentrons_shared_data import load_shared_data
 from opentrons_shared_data.labware import load_definition
 from opentrons.protocol_reader import ProtocolReader, InputFile
+from opentrons.protocol_engine import ModuleDefinition
 
 
 @pytest.fixture
 def protocol_reader(tmp_path: Path) -> ProtocolReader:
     """Get a ProtocolReader configured to write to a temporary directory."""
     return ProtocolReader(directory=tmp_path)
+
+
+@pytest.fixture(scope="session")
+def tempdeck_v1_def() -> ModuleDefinition:
+    """Get the definition of a V1 tempdeck."""
+    definition = load_shared_data("module/definitions/2/temperatureModuleV1.json")
+    return ModuleDefinition.parse_raw(definition)
 
 
 # TODO(mc, 2021-09-13): update to schema v6
@@ -80,6 +89,10 @@ def python_protocol_file() -> InputFile:
                 tip_rack = ctx.load_labware(
                     load_name="opentrons_96_tiprack_300ul",
                     location="1",
+                )
+                temp_module = ctx.load_module(
+                    module_name="temperature module",
+                    location="3"
                 )
                 pipette.pick_up_tip(
                     location=tip_rack.wells_by_name()["A1"],

--- a/api/tests/opentrons/protocol_runner/smoke_tests/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/test_protocol_runner.py
@@ -17,7 +17,10 @@ from opentrons.types import MountType, DeckSlotName
 from opentrons.protocol_engine import (
     DeckSlotLocation,
     LoadedLabware,
+    LoadedModule,
     LoadedPipette,
+    ModuleDefinition,
+    ModuleModel,
     PipetteName,
     commands,
 )
@@ -32,6 +35,7 @@ from opentrons.protocol_runner import create_simulating_runner
 async def test_runner_with_python(
     protocol_reader: ProtocolReader,
     python_protocol_file: InputFile,
+    tempdeck_v1_def: ModuleDefinition,
 ) -> None:
     """It should run a Python protocol on the ProtocolRunner."""
     protocol_source = await protocol_reader.read(
@@ -44,6 +48,7 @@ async def test_runner_with_python(
     commands_result = result.commands
     pipettes_result = result.pipettes
     labware_result = result.labware
+    modules_result = result.modules
 
     pipette_id_captor = matchers.Captor()
     labware_id_captor = matchers.Captor()
@@ -65,8 +70,17 @@ async def test_runner_with_python(
         offsetId=None,
     )
 
+    expected_module = LoadedModule.construct(
+        id=matchers.IsA(str),
+        model=ModuleModel.TEMPERATURE_MODULE_V1,
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
+        definition=tempdeck_v1_def,
+        serialNumber=matchers.IsA(str),
+    )
+
     assert expected_pipette in pipettes_result
     assert expected_labware in labware_result
+    assert expected_module in modules_result
 
     expected_command = commands.PickUpTip.construct(
         id=matchers.IsA(str),

--- a/robot-server/tests/protocols/test_protocol_analyzer.py
+++ b/robot-server/tests/protocols/test_protocol_analyzer.py
@@ -97,6 +97,8 @@ async def test_analyze(
             errors=[analysis_error],
             labware=[analysis_labware],
             pipettes=[analysis_pipette],
+            # TODO(mc, 2022-02-14): evaluate usage of modules in the analysis resp.
+            modules=[],
         )
     )
 


### PR DESCRIPTION
## Overview

This PR implements module load analysis in PAPIv3. Closes #9416.

## Changelog

- Add a `use_virtual_modules` config to the `ProtocolEngine`
- Set `use_virtual_modules=True` in `create_simulating_runner`
- Return a fake load result from `EquipmentHandler.load_module` if `use_virtual_modules` is set

## Review requests

- [ ] Code and tests, including smoke test, make sense
- [ ] Module loads come back from `POST /protocols` with PAPIv3 protocols

## Risk assessment

Very low