### PR TITLE
fix(app): show run errors in banner if run fails, hide errors if canceled

### DIFF
--- a/app/src/organisms/RunDetails/CommandList.tsx
+++ b/app/src/organisms/RunDetails/CommandList.tsx
@@ -325,7 +325,7 @@ export function CommandList(): JSX.Element | null {
                   }
                   title={alertItemTitle}
                 >
-                  {runErrors.length > 0
+                  {runStatus === RUN_STATUS_FAILED && runErrors.length > 0
                     ? runErrors.map(({ detail, errorType }, index) => (
                         <Text
                           key={index}
@@ -351,7 +351,7 @@ export function CommandList(): JSX.Element | null {
                 {t('total_step_count', { count: currentCommandList.length })}
               </Text>
             </Flex>
-            {currentCommandList[0]?.runCommandSummary != null &&
+            {currentCommandList[0]?.runCommandSummary == null &&
             isDeterministic ? (
               <Text fontSize={FONT_SIZE_CAPTION} marginY={SPACING_2}>
                 {t('anticipated')}

--- a/app/src/organisms/RunDetails/__tests__/CommandList.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/CommandList.test.tsx
@@ -141,14 +141,28 @@ describe('CommandList', () => {
     expect(errors).toContainHTML(fixtureErrors[0].errorType)
     expect(errors).toContainHTML(fixtureErrors[1].errorType)
   })
-  it('renders the protocol canceled banner when the status is stop-requested', () => {
+  it('renders the protocol canceled banner when the status is stop-requested, without errors shown', () => {
+    mockAlertItem.mockImplementation(({ children }) => (
+      <div>
+        Protocol Run Failed{' '}
+        <div data-testid="test_failed_errors">{children}</div>
+      </div>
+    ))
+    const fixtureError = {
+      id: 'ac02fd2a-9bd0-47e3-b739-ae562321e71d',
+      errorType: 'fakeErrorType',
+      createdAt: '2022-02-11T14:58:20.688699+00:00',
+      detail: 'fakeErrorDetail',
+    }
     mockUseRunStatus.mockReturnValue('stop-requested')
+    mockUseRunErrors.mockReturnValue([fixtureError])
     mockAlertItem.mockReturnValue(<div>Protocol Run Canceled</div>)
-    const { getByText } = render()
+    const { getByText, queryByTestId } = render()
     expect(getByText('Protocol Run Canceled')).toHaveStyle(
       'backgroundColor: Error_light'
     )
     expect(getByText('Protocol Run Canceled')).toHaveStyle('color: Error_dark')
+    expect(queryByTestId('test_failed_errors')).toBeNull()
   })
   it('renders the protocol canceled banner when the status is stopped', () => {
     mockUseRunStatus.mockReturnValue('stopped')


### PR DESCRIPTION
# Changelog

- do not show errors in red banner at the top of the run detail page if a run has been canceled (still shown when run failed)
- fixed a small bug that I noticed in the release notes demo, duplicate "anticipated steps" label

# Review requests

- Cancel a protocol and ensure that the banner at the top doesn't include any error details
- confirm that there is only one "anticipated steps" label visible after starting the run 

# Risk assessment
low, both changes are purely view layer changes