### PR TITLE
refactor(api): Add more stub methods to APIv3 `MagneticModuleContext`

### DIFF
--- a/api/src/opentrons/protocol_api_experimental/__init__.py
+++ b/api/src/opentrons/protocol_api_experimental/__init__.py
@@ -27,7 +27,12 @@ from .module_contexts import (
 )
 from .labware import Labware
 from .well import Well
-from .errors import InvalidPipetteNameError, InvalidMountError
+from .errors import (
+    InvalidPipetteNameError,
+    InvalidMountError,
+    InvalidModuleLocationError,
+    InvalidMagnetEngageHeightError,
+)
 from .types import (
     DeckSlotName,
     LabwareParameters,
@@ -43,6 +48,7 @@ __all__ = [
     "PipetteContext",
     "InstrumentContext",
     "MagneticModuleContext",
+    "MagneticModuleStatus",
     "TemperatureModuleContext",
     "ThermocyclerModuleContext",
     "Labware",
@@ -50,6 +56,8 @@ __all__ = [
     # Protocol API errors
     "InvalidPipetteNameError",
     "InvalidMountError",
+    "InvalidModuleLocationError",
+    "InvalidMagnetEngageHeightError",
     # Protocol API types and data classes
     "DeckSlotName",
     "LabwareParameters",

--- a/api/src/opentrons/protocol_api_experimental/__init__.py
+++ b/api/src/opentrons/protocol_api_experimental/__init__.py
@@ -20,6 +20,11 @@ This code is totally unsupported. To do science on a robot, use the stable
 from .protocol_context import ProtocolContext
 from .pipette_context import PipetteContext
 from .instrument_context import InstrumentContext
+from .module_contexts import (
+    MagneticModuleContext,
+    TemperatureModuleContext,
+    ThermocyclerModuleContext,
+)
 from .labware import Labware
 from .well import Well
 from .errors import InvalidPipetteNameError, InvalidMountError
@@ -37,6 +42,9 @@ __all__ = [
     "ProtocolContext",
     "PipetteContext",
     "InstrumentContext",
+    "MagneticModuleContext",
+    "TemperatureModuleContext",
+    "ThermocyclerModuleContext",
     "Labware",
     "Well",
     # Protocol API errors

--- a/api/src/opentrons/protocol_api_experimental/errors.py
+++ b/api/src/opentrons/protocol_api_experimental/errors.py
@@ -36,10 +36,16 @@ class InvalidModuleLocationError(ValueError):
         self.module_name = module_name
 
 
+class InvalidMagnetEngageHeightError(ValueError):
+    """Error raised if a Magnetic Module engage height is invalid."""
+
+
 __all__ = [
     # re-exports from opentrons.protocol_engine
     "LabwareIsNotTipRackError",
     # exports specific to the Protocol API layer
     "InvalidPipetteNameError",
     "InvalidMountError",
+    "InvalidModuleLocationError",
+    "InvalidMagnetEngageHeightError",
 ]

--- a/api/src/opentrons/protocol_api_experimental/module_contexts/__init__.py
+++ b/api/src/opentrons/protocol_api_experimental/module_contexts/__init__.py
@@ -1,11 +1,12 @@
 """Protocol API interfaces for module control."""
 
-from .magnetic_module_context import MagneticModuleContext
+from .magnetic_module_context import MagneticModuleContext, MagneticModuleStatus
 from .temperature_module_context import TemperatureModuleContext
 from .thermocycler_module_context import ThermocyclerModuleContext
 
 __all__ = [
     "MagneticModuleContext",
+    "MagneticModuleStatus",
     "TemperatureModuleContext",
     "ThermocyclerModuleContext",
 ]

--- a/api/src/opentrons/protocol_api_experimental/module_contexts/magnetic_module_context.py
+++ b/api/src/opentrons/protocol_api_experimental/module_contexts/magnetic_module_context.py
@@ -1,7 +1,7 @@
 """Protocol API interfaces for Magnetic Modules."""
 
 from enum import Enum
-from typing import Optional
+from typing import Optional, overload
 
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
@@ -53,6 +53,22 @@ class MagneticModuleContext:  # noqa: D101
     @property
     def labware(self) -> Optional[Labware]:  # noqa: D102
         raise NotImplementedError()
+
+    @overload
+    def engage(self) -> None:
+        ...
+
+    @overload
+    def engage(self, height: float) -> None:
+        ...
+
+    @overload
+    def engage(self, *, height_from_base: float) -> None:
+        ...
+
+    @overload
+    def engage(self, *, offset: float) -> None:
+        ...
 
     def engage(
         self,

--- a/api/src/opentrons/protocol_api_experimental/module_contexts/magnetic_module_context.py
+++ b/api/src/opentrons/protocol_api_experimental/module_contexts/magnetic_module_context.py
@@ -97,8 +97,13 @@ class MagneticModuleContext:  # noqa: D101
         """See APIv2 docstring."""
         raise NotImplementedError()
 
-    # todo(mm, 2021-02-15): Decide whether APIv3 will return the same module object
-    # every time the module is retrieved. If yes, we don't need this method.
+    def __hash__(self) -> int:
+        """Get hash.
+
+        Uses the module instance's unique identifier in protocol state.
+        """
+        return hash(self._module_id)
+
     def __eq__(self, other: object) -> bool:
         """Compare for object equality using identifier string."""
         return (

--- a/api/src/opentrons/protocol_api_experimental/module_contexts/magnetic_module_context.py
+++ b/api/src/opentrons/protocol_api_experimental/module_contexts/magnetic_module_context.py
@@ -47,12 +47,6 @@ class MagneticModuleContext:  # noqa: D101
         """See APIv2 docstring."""
         raise NotImplementedError()
 
-    # todo(mm, 2021-02-15): This looks like a vestigial internal APIv2 thing.
-    # Can we remove it from APIv3?
-    def load_labware_object(self, labware: Labware) -> Labware:
-        """See APIv2 docstring."""
-        raise NotImplementedError()
-
     @property
     def labware(self) -> Optional[Labware]:
         """See APIv2 docstring."""

--- a/api/src/opentrons/protocol_api_experimental/module_contexts/magnetic_module_context.py
+++ b/api/src/opentrons/protocol_api_experimental/module_contexts/magnetic_module_context.py
@@ -3,9 +3,11 @@
 from enum import Enum
 from typing import Optional
 
-from opentrons.protocols.api_support.types import APIVersion
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
+from opentrons.protocols.api_support.types import APIVersion
+
+from ..errors import InvalidMagnetEngageHeightError
 from ..labware import Labware
 
 
@@ -75,7 +77,7 @@ class MagneticModuleContext:  # noqa: D101
             arguments.
         """
         if len([a for a in [height, height_from_base, offset] if a is not None]) > 1:
-            raise ValueError(
+            raise InvalidMagnetEngageHeightError(
                 "You may only specify one of"
                 " `height`, `height_from_base`, and `offset`."
             )

--- a/api/src/opentrons/protocol_api_experimental/module_contexts/magnetic_module_context.py
+++ b/api/src/opentrons/protocol_api_experimental/module_contexts/magnetic_module_context.py
@@ -1,5 +1,13 @@
 """Protocol API interfaces for Magnetic Modules."""
 
+from typing import Optional
+from typing_extensions import Literal
+
+from opentrons.protocols.api_support.types import APIVersion
+from opentrons_shared_data.labware.dev_types import LabwareDefinition
+
+from ..labware import Labware
+
 
 class MagneticModuleContext:  # noqa: D101
     # TODO(mc, 2022-02-09): copy or rewrite docstring from
@@ -8,6 +16,82 @@ class MagneticModuleContext:  # noqa: D101
     def __init__(self, module_id: str) -> None:
         self._module_id = module_id
 
+    # todo(mm, 2022-02-15): This public method returns an internal, undocumented type.
+    @property
+    def api_version(self) -> APIVersion:
+        """See APIv2 docstring."""
+        raise NotImplementedError()
+
+    def load_labware(
+        self,
+        name: str,
+        label: Optional[str] = None,
+        namespace: Optional[str] = None,
+        version: int = 1,
+    ) -> Labware:
+        """See APIv2 docstring."""
+        raise NotImplementedError()
+
+    def load_labware_from_definition(
+        self, definition: LabwareDefinition, label: Optional[str] = None
+    ) -> Labware:
+        """See APIv2 docstring."""
+        raise NotImplementedError()
+
+    # todo(mm, 2021-02-15): This looks like a vestigial internal APIv2 thing.
+    # Can we remove it from APIv3?
+    def load_labware_object(self, labware: Labware) -> Labware:
+        """See APIv2 docstring."""
+        raise NotImplementedError()
+
+    @property
+    def labware(self) -> Optional[Labware]:
+        """See APIv2 docstring."""
+        raise NotImplementedError()
+
+    def engage(
+        self,
+        height: Optional[float] = None,
+        *,
+        height_from_base: Optional[float] = None,
+        offset: Optional[float] = None,
+    ) -> None:
+        """See APIv2 docstring.
+
+        .. versionchanged:: 3.0
+            An error is now raised if you provide more than one of
+            ``height``, ``height_from_base``, and ``offset``.
+            Formerly, the behavior was unspecified.
+
+        .. versionchanged:: 3.0
+            You must now specify ``height_from_base`` and ``offset`` as keyword
+            arguments.
+        """
+        if len([a for a in [height, height_from_base, offset] if a is not None]) > 1:
+            raise ValueError(
+                "You may only specify one of"
+                " `height`, `height_from_base`, and `offset`."
+            )
+
+        raise NotImplementedError()
+
+    def disengage(self) -> None:
+        """See APIv2 docstring."""
+        raise NotImplementedError()
+
+    @property
+    def status(self) -> Literal["engaged", "disengaged"]:
+        """See APIv2 docstring."""
+        raise NotImplementedError()
+
+    # todo(mm, 2021-02-15): Does anyone internal or external
+    # use calibrate() in APIv2? Can we remove it from APIv3?
+    def calibrate(self) -> None:
+        """See APIv2 docstring."""
+        raise NotImplementedError()
+
+    # todo(mm, 2021-02-15): Decide whether APIv3 will return the same module object
+    # every time the module is retrieved. If yes, we don't need this method.
     def __eq__(self, other: object) -> bool:
         """Compare for object equality using identifier string."""
         return (

--- a/api/src/opentrons/protocol_api_experimental/module_contexts/magnetic_module_context.py
+++ b/api/src/opentrons/protocol_api_experimental/module_contexts/magnetic_module_context.py
@@ -102,11 +102,6 @@ class MagneticModuleContext:  # noqa: D101
     def status(self) -> MagneticModuleStatus:  # noqa: D102
         raise NotImplementedError()
 
-    # todo(mm, 2021-02-15): Does anyone internal or external
-    # use calibrate() in APIv2? Can we remove it from APIv3?
-    def calibrate(self) -> None:  # noqa: D102
-        raise NotImplementedError()
-
     def __hash__(self) -> int:
         """Return a hash.
 

--- a/api/src/opentrons/protocol_api_experimental/module_contexts/magnetic_module_context.py
+++ b/api/src/opentrons/protocol_api_experimental/module_contexts/magnetic_module_context.py
@@ -12,7 +12,13 @@ from ..labware import Labware
 
 
 class MagneticModuleStatus(str, Enum):
-    """The status of a Temperature Module's magnets."""
+    """The status of a Temperature Module's magnets.
+
+    Returned by `MagneticModuleContext.status`.
+
+    .. versionadded:: 3.0
+        This enum is now returned instead of a simple string.
+    """
 
     ENGAGED = "engaged"
     DISENGAGED = "disengaged"

--- a/api/src/opentrons/protocol_api_experimental/module_contexts/magnetic_module_context.py
+++ b/api/src/opentrons/protocol_api_experimental/module_contexts/magnetic_module_context.py
@@ -1,12 +1,19 @@
 """Protocol API interfaces for Magnetic Modules."""
 
+from enum import Enum
 from typing import Optional
-from typing_extensions import Literal
 
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 from ..labware import Labware
+
+
+class MagneticModuleStatus(str, Enum):
+    """The status of a Temperature Module's magnets."""
+
+    ENGAGED = "engaged"
+    DISENGAGED = "disengaged"
 
 
 class MagneticModuleContext:  # noqa: D101
@@ -80,7 +87,7 @@ class MagneticModuleContext:  # noqa: D101
         raise NotImplementedError()
 
     @property
-    def status(self) -> Literal["engaged", "disengaged"]:
+    def status(self) -> MagneticModuleStatus:
         """See APIv2 docstring."""
         raise NotImplementedError()
 

--- a/api/src/opentrons/protocol_api_experimental/module_contexts/magnetic_module_context.py
+++ b/api/src/opentrons/protocol_api_experimental/module_contexts/magnetic_module_context.py
@@ -25,7 +25,7 @@ class MagneticModuleStatus(str, Enum):
 
 
 class MagneticModuleContext:  # noqa: D101
-    # TODO(mc, 2022-02-09): copy or rewrite docstring from
+    # TODO(mc, 2022-02-09): copy or rewrite docstrings from
     # src/opentrons/protocol_api/module_contexts.py
 
     def __init__(self, module_id: str) -> None:
@@ -33,29 +33,25 @@ class MagneticModuleContext:  # noqa: D101
 
     # todo(mm, 2022-02-15): This public method returns an internal, undocumented type.
     @property
-    def api_version(self) -> APIVersion:
-        """See APIv2 docstring."""
+    def api_version(self) -> APIVersion:  # noqa: D102
         raise NotImplementedError()
 
-    def load_labware(
+    def load_labware(  # noqa: D102
         self,
         name: str,
         label: Optional[str] = None,
         namespace: Optional[str] = None,
         version: int = 1,
     ) -> Labware:
-        """See APIv2 docstring."""
         raise NotImplementedError()
 
-    def load_labware_from_definition(
+    def load_labware_from_definition(  # noqa: D102
         self, definition: LabwareDefinition, label: Optional[str] = None
     ) -> Labware:
-        """See APIv2 docstring."""
         raise NotImplementedError()
 
     @property
-    def labware(self) -> Optional[Labware]:
-        """See APIv2 docstring."""
+    def labware(self) -> Optional[Labware]:  # noqa: D102
         raise NotImplementedError()
 
     def engage(
@@ -65,8 +61,7 @@ class MagneticModuleContext:  # noqa: D101
         height_from_base: Optional[float] = None,
         offset: Optional[float] = None,
     ) -> None:
-        """See APIv2 docstring.
-
+        """
         .. versionchanged:: 3.0
             An error is now raised if you provide more than one of
             ``height``, ``height_from_base``, and ``offset``.
@@ -75,7 +70,7 @@ class MagneticModuleContext:  # noqa: D101
         .. versionchanged:: 3.0
             You must now specify ``height_from_base`` and ``offset`` as keyword
             arguments.
-        """
+        """  # noqa: D205,D212,D415
         if len([a for a in [height, height_from_base, offset] if a is not None]) > 1:
             raise InvalidMagnetEngageHeightError(
                 "You may only specify one of"
@@ -84,23 +79,20 @@ class MagneticModuleContext:  # noqa: D101
 
         raise NotImplementedError()
 
-    def disengage(self) -> None:
-        """See APIv2 docstring."""
+    def disengage(self) -> None:  # noqa: D102
         raise NotImplementedError()
 
     @property
-    def status(self) -> MagneticModuleStatus:
-        """See APIv2 docstring."""
+    def status(self) -> MagneticModuleStatus:  # noqa: D102
         raise NotImplementedError()
 
     # todo(mm, 2021-02-15): Does anyone internal or external
     # use calibrate() in APIv2? Can we remove it from APIv3?
-    def calibrate(self) -> None:
-        """See APIv2 docstring."""
+    def calibrate(self) -> None:  # noqa: D102
         raise NotImplementedError()
 
     def __hash__(self) -> int:
-        """Get hash.
+        """Return a hash.
 
         Uses the module instance's unique identifier in protocol state.
         """

--- a/api/tests/opentrons/protocol_api_experimental/module_contexts/__init__.py
+++ b/api/tests/opentrons/protocol_api_experimental/module_contexts/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for `module_contexts`."""

--- a/api/tests/opentrons/protocol_api_experimental/module_contexts/test_magnetic_module_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/module_contexts/test_magnetic_module_context.py
@@ -1,0 +1,71 @@
+"""Tests for `magnetic_module_context`."""
+
+
+import pytest
+
+from opentrons.protocol_api_experimental.module_contexts import MagneticModuleContext
+
+
+@pytest.fixture
+def subject() -> MagneticModuleContext:
+    """Return a MagneticModuleContext to test."""
+    return MagneticModuleContext(module_id="module-id")
+
+
+@pytest.mark.xfail(strict=True, raises=NotImplementedError)
+def test_api_version(subject: MagneticModuleContext) -> None:  # noqa: D103
+    _ = subject.api_version
+
+
+@pytest.mark.xfail(strict=True, raises=NotImplementedError)
+def test_load_labware(subject: MagneticModuleContext) -> None:  # noqa: D103
+    subject.load_labware("my_load_name")
+
+
+@pytest.mark.xfail(strict=True, raises=NotImplementedError)
+def test_load_labware_from_definition(  # noqa: D103
+    subject: MagneticModuleContext,
+) -> None:
+    subject.load_labware_from_definition(definition={})  # type: ignore[typeddict-item]
+
+
+@pytest.mark.xfail(strict=True, raises=NotImplementedError)
+def test_load_labware_object(subject: MagneticModuleContext) -> None:  # noqa: D103
+    subject.load_labware_object(labware=None)  # type: ignore[arg-type]
+
+
+@pytest.mark.xfail(strict=True, raises=NotImplementedError)
+def test_labware_property(subject: MagneticModuleContext) -> None:  # noqa: D103
+    _ = subject.labware
+
+
+@pytest.mark.xfail(strict=True, raises=NotImplementedError)
+def test_engage(subject: MagneticModuleContext) -> None:  # noqa: D103
+    subject.engage(10)
+
+
+def test_engage_only_one_height_allowed(subject: MagneticModuleContext) -> None:
+    """It should raise if you provide conflicting height arguments."""
+    with pytest.raises(ValueError):
+        subject.engage(height=1, height_from_base=2, offset=3)
+    with pytest.raises(ValueError):
+        subject.engage(height=1, height_from_base=2)
+    with pytest.raises(ValueError):
+        subject.engage(height=1, offset=3)
+    with pytest.raises(ValueError):
+        subject.engage(height_from_base=2, offset=3)
+
+
+@pytest.mark.xfail(strict=True, raises=NotImplementedError)
+def test_disengage(subject: MagneticModuleContext) -> None:  # noqa: D103
+    subject.disengage()
+
+
+@pytest.mark.xfail(strict=True, raises=NotImplementedError)
+def test_status(subject: MagneticModuleContext) -> None:  # noqa: D103
+    _ = subject.status
+
+
+@pytest.mark.xfail(strict=True, raises=NotImplementedError)
+def test_calibrate(subject: MagneticModuleContext) -> None:  # noqa: D103
+    subject.calibrate()

--- a/api/tests/opentrons/protocol_api_experimental/module_contexts/test_magnetic_module_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/module_contexts/test_magnetic_module_context.py
@@ -3,7 +3,10 @@
 
 import pytest
 
-from opentrons.protocol_api_experimental.module_contexts import MagneticModuleContext
+from opentrons.protocol_api_experimental import (
+    MagneticModuleContext,
+    InvalidMagnetEngageHeightError,
+)
 
 
 @pytest.fixture
@@ -46,13 +49,13 @@ def test_engage(subject: MagneticModuleContext) -> None:  # noqa: D103
 
 def test_engage_only_one_height_allowed(subject: MagneticModuleContext) -> None:
     """It should raise if you provide conflicting height arguments."""
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidMagnetEngageHeightError):
         subject.engage(height=1, height_from_base=2, offset=3)
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidMagnetEngageHeightError):
         subject.engage(height=1, height_from_base=2)
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidMagnetEngageHeightError):
         subject.engage(height=1, offset=3)
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidMagnetEngageHeightError):
         subject.engage(height_from_base=2, offset=3)
 
 

--- a/api/tests/opentrons/protocol_api_experimental/module_contexts/test_magnetic_module_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/module_contexts/test_magnetic_module_context.py
@@ -40,18 +40,23 @@ def test_labware_property(subject: MagneticModuleContext) -> None:  # noqa: D103
 @pytest.mark.xfail(strict=True, raises=NotImplementedError)
 def test_engage(subject: MagneticModuleContext) -> None:  # noqa: D103
     subject.engage(10)
+    subject.engage(height=10)
+    subject.engage(height_from_base=10)
+    subject.engage(offset=10)
 
 
 def test_engage_only_one_height_allowed(subject: MagneticModuleContext) -> None:
     """It should raise if you provide conflicting height arguments."""
+    # The type-checker wants to stop us from miscalling this function, but
+    # we need to test that the function protects itself when there is no type-checker.
     with pytest.raises(InvalidMagnetEngageHeightError):
-        subject.engage(height=1, height_from_base=2, offset=3)
+        subject.engage(height=1, height_from_base=2, offset=3)  # type: ignore[call-overload]  # noqa: E501
     with pytest.raises(InvalidMagnetEngageHeightError):
-        subject.engage(height=1, height_from_base=2)
+        subject.engage(height=1, height_from_base=2)  # type: ignore[call-overload]
     with pytest.raises(InvalidMagnetEngageHeightError):
-        subject.engage(height=1, offset=3)
+        subject.engage(height=1, offset=3)  # type: ignore[call-overload]
     with pytest.raises(InvalidMagnetEngageHeightError):
-        subject.engage(height_from_base=2, offset=3)
+        subject.engage(height_from_base=2, offset=3)  # type: ignore[call-overload]
 
 
 @pytest.mark.xfail(strict=True, raises=NotImplementedError)

--- a/api/tests/opentrons/protocol_api_experimental/module_contexts/test_magnetic_module_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/module_contexts/test_magnetic_module_context.py
@@ -33,11 +33,6 @@ def test_load_labware_from_definition(  # noqa: D103
 
 
 @pytest.mark.xfail(strict=True, raises=NotImplementedError)
-def test_load_labware_object(subject: MagneticModuleContext) -> None:  # noqa: D103
-    subject.load_labware_object(labware=None)  # type: ignore[arg-type]
-
-
-@pytest.mark.xfail(strict=True, raises=NotImplementedError)
 def test_labware_property(subject: MagneticModuleContext) -> None:  # noqa: D103
     _ = subject.labware
 

--- a/api/tests/opentrons/protocol_api_experimental/module_contexts/test_magnetic_module_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/module_contexts/test_magnetic_module_context.py
@@ -67,8 +67,3 @@ def test_disengage(subject: MagneticModuleContext) -> None:  # noqa: D103
 @pytest.mark.xfail(strict=True, raises=NotImplementedError)
 def test_status(subject: MagneticModuleContext) -> None:  # noqa: D103
     _ = subject.status
-
-
-@pytest.mark.xfail(strict=True, raises=NotImplementedError)
-def test_calibrate(subject: MagneticModuleContext) -> None:  # noqa: D103
-    subject.calibrate()


### PR DESCRIPTION
# Overview

This is a step towards #9393. It sets the method signatures for Python Protocol API v3's version of `MagneticModuleContext`.

# Changelog

Things are almost entirely unchanged from APIv2. The differences are:

* Added strict parameter validation to `.engage()` to disallow, for example, setting `height` and `offset` simultaneously. In APIv2, this is permitted with the undocumented behavior that one is favored over the other.
* Removed the `.geometry` property, which seemed internal and not legitimately usable by protocol authors.
* Removed `.load_labware_object()`. This also seemed internal and not legitimately usable by protocol authors. And it doesn't make sense in a Protocol Engine world, anyway.
* Removed `.load_labware_by_name()`, which has long been deprecated in favor of `.load_labware()`. 
* Removed `.calibrate()`. According to @Laura-Danielle this for a scrapped feature. And according to @sanni-t (see the comments below), although it still works on its own as far as we know, it's not useful without other API changes.
* Made `.status` return a backwards-compatible `str` `Enum` instead of a literal plain `str`. This won't affect user code, but it will affect how this interface shows up in the docs later on.

I've also noted these in Confluence.

# Review requests

Do all method signatures look good so far? Do we agree with the changes?

Barring any implementation surprises, and setting aside the `# todo`s, I expect these to be final.

# Risk assessment

None. No one is using this code yet.
