### PR TITLE
refactor(app): fix slideout state

### DIFF
--- a/app/src/atoms/Slideout/__tests__/Slideout.test.tsx
+++ b/app/src/atoms/Slideout/__tests__/Slideout.test.tsx
@@ -12,11 +12,13 @@ const render = (props: React.ComponentProps<typeof Slideout>) => {
 
 describe('Slideout', () => {
   let props: React.ComponentProps<typeof Slideout>
+  const mockOnClick = jest.fn()
   beforeEach(() => {
     props = {
       title: 'Set Engage Height for Magnetic Module GEN1',
       children: <div>Mock Children</div>,
       isExpanded: true,
+      onCloseClick: mockOnClick,
     }
   })
   afterEach(() => {
@@ -35,6 +37,6 @@ describe('Slideout', () => {
     const button = getByRole('button', { name: /exit/i })
     expect(button).toBeEnabled()
     fireEvent.click(button)
-    expect(button).not.toBeInTheDocument()
+    expect(mockOnClick).toHaveBeenCalledTimes(1)
   })
 })

--- a/app/src/atoms/Slideout/index.tsx
+++ b/app/src/atoms/Slideout/index.tsx
@@ -23,6 +23,7 @@ import { Divider } from '../structure'
 interface Props {
   title: string
   children: React.ReactNode
+  onCloseClick: () => unknown
   //  isExpanded is for collapse and expand animation
   isExpanded?: boolean
 }
@@ -64,10 +65,6 @@ const COLLAPSED_STYLE = css`
 `
 
 export const Slideout = (props: Props): JSX.Element | null => {
-  const [hideSlideOut, setHideSlideOut] = React.useState(false)
-
-  if (hideSlideOut) return null
-
   return (
     <>
       <Box
@@ -94,7 +91,7 @@ export const Slideout = (props: Props): JSX.Element | null => {
             <Flex alignItems={ALIGN_CENTER}>
               <Btn
                 size={TYPOGRAPHY.lineHeight24}
-                onClick={() => setHideSlideOut(true)}
+                onClick={props.onCloseClick}
                 aria-label="exit"
                 data-testid={`Slideout_icon_close_${props.title}`}
               >

--- a/app/src/organisms/Devices/ModuleCard/MagneticModuleSlideout.tsx
+++ b/app/src/organisms/Devices/ModuleCard/MagneticModuleSlideout.tsx
@@ -68,13 +68,14 @@ const getInfoByModel = (model: ModuleModel): ModelContents => {
 
 interface MagneticModuleSlideoutProps {
   module: AttachedModule
+  onCloseClick: () => unknown
   isExpanded: boolean
 }
 
 export const MagneticModuleSlideout = (
   props: MagneticModuleSlideoutProps
 ): JSX.Element | null => {
-  const { module, isExpanded } = props
+  const { module, isExpanded, onCloseClick } = props
   const { t } = useTranslation('device_details')
   const sendModuleCommand = useSendModuleCommand()
   const [engageHeightValue, setEngageHeightValue] = React.useState<
@@ -110,6 +111,7 @@ export const MagneticModuleSlideout = (
   return (
     <Slideout
       title={t('set_engage_height_slideout', { name: moduleName })}
+      onCloseClick={onCloseClick}
       isExpanded={isExpanded}
     >
       <React.Fragment>

--- a/app/src/organisms/Devices/ModuleCard/ModuleOverflowMenu.tsx
+++ b/app/src/organisms/Devices/ModuleCard/ModuleOverflowMenu.tsx
@@ -34,19 +34,25 @@ export const ModuleOverflowMenu = (
       return (
         <ThermocyclerModuleSlideout
           module={module}
+          onCloseClick={() => setShowSlideout(false)}
           isExpanded={showSlideout}
           isSecondaryTemp={isSecondary}
         />
       )
     } else if (module.type === MAGNETIC_MODULE_TYPE) {
       return (
-        <MagneticModuleSlideout module={module} isExpanded={showSlideout} />
+        <MagneticModuleSlideout
+          module={module}
+          onCloseClick={() => setShowSlideout(false)}
+          isExpanded={showSlideout}
+        />
       )
     } else {
       return (
         <TemperatureModuleSlideout
           model={module.model}
           serial={module.serial}
+          onCloseClick={() => setShowSlideout(false)}
           isExpanded={showSlideout}
         />
       )

--- a/app/src/organisms/Devices/ModuleCard/TemperatureModuleSlideout.tsx
+++ b/app/src/organisms/Devices/ModuleCard/TemperatureModuleSlideout.tsx
@@ -25,13 +25,14 @@ import { Slideout } from '../../../atoms/Slideout'
 interface TemperatureModuleSlideoutProps {
   model: typeof TEMPERATURE_MODULE_V1 | typeof TEMPERATURE_MODULE_V2
   serial: string
+  onCloseClick: () => unknown
   isExpanded: boolean
 }
 
 export const TemperatureModuleSlideout = (
   props: TemperatureModuleSlideoutProps
 ): JSX.Element | null => {
-  const { model, isExpanded, serial } = props
+  const { model, onCloseClick, isExpanded, serial } = props
   const { t } = useTranslation('device_details')
   const sendModuleCommand = useSendModuleCommand()
   const name = getModuleDisplayName(model)
@@ -49,6 +50,7 @@ export const TemperatureModuleSlideout = (
   return (
     <Slideout
       title={t('tempdeck_slideout_title', { name: name })}
+      onCloseClick={onCloseClick}
       isExpanded={isExpanded}
     >
       <React.Fragment>

--- a/app/src/organisms/Devices/ModuleCard/ThermocyclerModuleSlideout.tsx
+++ b/app/src/organisms/Devices/ModuleCard/ThermocyclerModuleSlideout.tsx
@@ -23,6 +23,7 @@ import { getModuleDisplayName } from '@opentrons/shared-data'
 
 interface ThermocyclerModuleSlideoutProps {
   module: AttachedModule
+  onCloseClick: () => unknown
   isExpanded: boolean
   isSecondaryTemp?: boolean
 }
@@ -30,7 +31,7 @@ interface ThermocyclerModuleSlideoutProps {
 export const ThermocyclerModuleSlideout = (
   props: ThermocyclerModuleSlideoutProps
 ): JSX.Element | null => {
-  const { module, isExpanded, isSecondaryTemp } = props
+  const { module, onCloseClick, isExpanded, isSecondaryTemp } = props
   const { t } = useTranslation('device_details')
   const [tempValue, setTempValue] = React.useState<string | null>(null)
   const sendModuleCommand = useSendModuleCommand()
@@ -53,6 +54,7 @@ export const ThermocyclerModuleSlideout = (
   return (
     <Slideout
       title={t('tc_set_temperature', { part: modulePart, name: moduleName })}
+      onCloseClick={onCloseClick}
       isExpanded={isExpanded}
     >
       <React.Fragment>

--- a/app/src/organisms/Devices/ModuleCard/__tests__/MagneticModuleSlideout.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/MagneticModuleSlideout.test.tsx
@@ -30,6 +30,7 @@ describe('MagneticModuleSlideout', () => {
     props = {
       module: mockMagneticModule,
       isExpanded: true,
+      onCloseClick: jest.fn(),
     }
     mockInputField.mockReturnValue(<div></div>)
     mockUseSendModuleCommand.mockReturnValue(jest.fn())
@@ -60,6 +61,7 @@ describe('MagneticModuleSlideout', () => {
     props = {
       module: mockMagneticModuleGen2,
       isExpanded: true,
+      onCloseClick: jest.fn(),
     }
     const { getByText } = render(props)
 

--- a/app/src/organisms/Devices/ModuleCard/__tests__/TemperatureModuleSlideout.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/TemperatureModuleSlideout.test.tsx
@@ -34,6 +34,7 @@ describe('TemperatureModuleSlideout', () => {
       model: TEMPERATURE_MODULE_V1,
       isExpanded: true,
       serial: SERIAL,
+      onCloseClick: jest.fn(),
     }
     mockInputField.mockReturnValue(<div></div>)
     mockUseSendModuleCommand.mockReturnValue(jest.fn())
@@ -57,6 +58,7 @@ describe('TemperatureModuleSlideout', () => {
       model: TEMPERATURE_MODULE_V2,
       serial: SERIAL,
       isExpanded: true,
+      onCloseClick: jest.fn(),
     }
     const { getByText } = render(props)
 

--- a/app/src/organisms/Devices/ModuleCard/__tests__/ThermocyclerModuleSlideout.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/ThermocyclerModuleSlideout.test.tsx
@@ -39,6 +39,7 @@ describe('ThermocyclerModuleSlideout', () => {
       module: mockThermocycler,
       isSecondaryTemp: true,
       isExpanded: true,
+      onCloseClick: jest.fn(),
     }
     const { getByText } = render(props)
 
@@ -55,6 +56,7 @@ describe('ThermocyclerModuleSlideout', () => {
       module: mockThermocycler,
       isSecondaryTemp: false,
       isExpanded: true,
+      onCloseClick: jest.fn(),
     }
     const { getByText } = render(props)
 
@@ -71,6 +73,7 @@ describe('ThermocyclerModuleSlideout', () => {
       module: mockThermocycler,
       isSecondaryTemp: false,
       isExpanded: true,
+      onCloseClick: jest.fn(),
     }
     const { getByRole } = render(props)
     const button = getByRole('button', { name: 'Set Block Temperature' })
@@ -90,6 +93,7 @@ describe('ThermocyclerModuleSlideout', () => {
       module: mockThermocycler,
       isSecondaryTemp: true,
       isExpanded: true,
+      onCloseClick: jest.fn(),
     }
     const { getByRole } = render(props)
     const button = getByRole('button', { name: 'Set Lid Temperature' })


### PR DESCRIPTION


# Overview

This PR refactors how the slideout is rendered using state in the parent component. Paired with @Kadee80 

# Changelog

- Remove state from `Slideout`
- Add `onCloseClick` prop to `Slideout`
- Update tests

# Review requests

- Open a slideout, close it and open it again. You can use the module card overflow menu as an example. You should be able to open and close the slideouts without having to close the menu and reopening it.

# Risk assessment

low
