### PR TITLE
refactor(api): Implement `MagneticModule.load_labware()` in APIv3

### DIFF
--- a/api/src/opentrons/protocol_api_experimental/constants.py
+++ b/api/src/opentrons/protocol_api_experimental/constants.py
@@ -1,0 +1,6 @@
+"""Data constants shared inside Python Protocol API v3.
+
+For Opentrons internal use only.
+"""
+
+DEFAULT_LABWARE_NAMESPACE = "opentrons"

--- a/api/src/opentrons/protocol_api_experimental/constants.py
+++ b/api/src/opentrons/protocol_api_experimental/constants.py
@@ -3,4 +3,7 @@
 For Opentrons internal use only.
 """
 
-DEFAULT_LABWARE_NAMESPACE = "opentrons"
+from opentrons.protocols.api_support.constants import OPENTRONS_NAMESPACE
+
+
+DEFAULT_LABWARE_NAMESPACE = OPENTRONS_NAMESPACE

--- a/api/src/opentrons/protocol_api_experimental/protocol_context.py
+++ b/api/src/opentrons/protocol_api_experimental/protocol_context.py
@@ -26,6 +26,7 @@ from .types import (
 )
 
 from . import errors
+from .constants import DEFAULT_LABWARE_NAMESPACE
 
 
 class ProtocolContext:
@@ -104,7 +105,7 @@ class ProtocolContext:
             location=DeckSlotLocation(slotName=DeckSlotName.from_primitive(location)),
             # TODO(mc, 2021-04-22): make sure this default is compatible with using
             # namespace=None to load custom labware in PAPIv3
-            namespace=namespace or "opentrons",
+            namespace=namespace if namespace is not None else DEFAULT_LABWARE_NAMESPACE,
             version=version or 1,
         )
 
@@ -203,7 +204,9 @@ class ProtocolContext:
         )
 
         if result.definition.moduleType == ModuleType.MAGNETIC:
-            return MagneticModuleContext(module_id=result.moduleId)
+            return MagneticModuleContext(
+                engine_client=self._engine_client, module_id=result.moduleId
+            )
         elif result.definition.moduleType == ModuleType.TEMPERATURE:
             return TemperatureModuleContext(module_id=result.moduleId)
         elif result.definition.moduleType == ModuleType.THERMOCYCLER:

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -5,7 +5,13 @@ from opentrons.types import MountType
 
 from .. import commands
 from ..state import StateView
-from ..types import DeckSlotLocation, ModuleModel, PipetteName, WellLocation
+from ..types import (
+    DeckSlotLocation,
+    LabwareLocation,
+    ModuleModel,
+    PipetteName,
+    WellLocation,
+)
 from .transports import AbstractSyncTransport
 
 
@@ -23,7 +29,7 @@ class SyncClient:
 
     def load_labware(
         self,
-        location: DeckSlotLocation,
+        location: LabwareLocation,
         load_name: str,
         namespace: str,
         version: int,

--- a/api/tests/opentrons/protocol_api_experimental/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/test_protocol_context.py
@@ -300,7 +300,10 @@ def test_load_magnetic_module(
     )
 
     result = subject.load_module(module_name=module_name, location="3")
-    assert result == module_contexts.MagneticModuleContext(module_id="abc123")
+    assert result == module_contexts.MagneticModuleContext(
+        engine_client=engine_client,
+        module_id="abc123",
+    )
 
 
 @pytest.mark.parametrize(

--- a/api/tests/opentrons/protocol_api_experimental/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/test_protocol_context.py
@@ -174,8 +174,8 @@ def test_load_labware_explicit_namespace_and_version(
     decoy.when(
         engine_client.load_labware(
             location=DeckSlotLocation(slotName=DeckSlotName.SLOT_5),
-            load_name="some_explicit_namespace",
-            namespace="opentrons",
+            load_name="some_labware",
+            namespace="some_explicit_namespace",
             version=9001,
         )
     ).then_return(

--- a/api/tests/opentrons/protocol_api_experimental/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/test_protocol_context.py
@@ -164,7 +164,7 @@ def test_load_pipette_with_replace(subject: ProtocolContext) -> None:
     subject.load_pipette(pipette_name="p300_single", mount="left", replace=True)
 
 
-def test_load_labware(
+def test_load_labware_explicit_namespace_and_version(
     decoy: Decoy,
     minimal_labware_def: labware_dict_types.LabwareDefinition,
     engine_client: SyncClient,
@@ -174,9 +174,9 @@ def test_load_labware(
     decoy.when(
         engine_client.load_labware(
             location=DeckSlotLocation(slotName=DeckSlotName.SLOT_5),
-            load_name="some_labware",
+            load_name="some_explicit_namespace",
             namespace="opentrons",
-            version=1,
+            version=9001,
         )
     ).then_return(
         pe_commands.LoadLabwareResult(
@@ -189,8 +189,8 @@ def test_load_labware(
     result = subject.load_labware(
         load_name="some_labware",
         location=5,
-        namespace="opentrons",
-        version=1,
+        namespace="some_explicit_namespace",
+        version=9001,
     )
 
     assert result == Labware(labware_id="abc123", engine_client=engine_client)


### PR DESCRIPTION
# Overview

This implements `magnetic_module.load_labware()` in Python Protocol API v3.

# Review requests

See my GitHub comment below.

# Risk assessment

None. Changes are to Python Protocol API v3 only, which is not used in production.