### PR TITLE
refactor(api): add heater shaker module context with basic methods

### DIFF
--- a/api/src/opentrons/protocol_api_experimental/__init__.py
+++ b/api/src/opentrons/protocol_api_experimental/__init__.py
@@ -24,6 +24,7 @@ from .module_contexts import (
     MagneticModuleContext,
     TemperatureModuleContext,
     ThermocyclerModuleContext,
+    HeaterShakerModuleContext,
 )
 from .labware import Labware
 from .well import Well
@@ -51,6 +52,7 @@ __all__ = [
     "MagneticModuleStatus",
     "TemperatureModuleContext",
     "ThermocyclerModuleContext",
+    "HeaterShakerModuleContext",
     "Labware",
     "Well",
     # Protocol API errors

--- a/api/src/opentrons/protocol_api_experimental/errors.py
+++ b/api/src/opentrons/protocol_api_experimental/errors.py
@@ -40,6 +40,18 @@ class InvalidMagnetEngageHeightError(ValueError):
     """Error raised if a Magnetic Module engage height is invalid."""
 
 
+class InvalidTargetTemperatureError(ValueError):
+    """Error raised if a module with heating abilities gets an invalid target temp."""
+
+
+class NoTargetTemperatureError(ValueError):
+    """Error raised if awaiting temperature without setting a target temperature."""
+
+
+class InvalidTargetSpeedError(ValueError):
+    """Error raised if a heater-shaker target speed is invalid."""
+
+
 __all__ = [
     # re-exports from opentrons.protocol_engine
     "LabwareIsNotTipRackError",
@@ -48,4 +60,6 @@ __all__ = [
     "InvalidMountError",
     "InvalidModuleLocationError",
     "InvalidMagnetEngageHeightError",
+    "InvalidTargetTemperatureError",
+    "InvalidTargetSpeedError",
 ]

--- a/api/src/opentrons/protocol_api_experimental/module_contexts/__init__.py
+++ b/api/src/opentrons/protocol_api_experimental/module_contexts/__init__.py
@@ -3,10 +3,12 @@
 from .magnetic_module_context import MagneticModuleContext, MagneticModuleStatus
 from .temperature_module_context import TemperatureModuleContext
 from .thermocycler_module_context import ThermocyclerModuleContext
+from .heater_shaker_module_context import HeaterShakerModuleContext
 
 __all__ = [
     "MagneticModuleContext",
     "MagneticModuleStatus",
     "TemperatureModuleContext",
     "ThermocyclerModuleContext",
+    "HeaterShakerModuleContext",
 ]

--- a/api/src/opentrons/protocol_api_experimental/module_contexts/heater_shaker_module_context.py
+++ b/api/src/opentrons/protocol_api_experimental/module_contexts/heater_shaker_module_context.py
@@ -1,0 +1,80 @@
+"""Protocol API interface for Heater-Shaker Modules."""
+
+from ..errors import (
+    InvalidTargetTemperatureError,
+    InvalidTargetSpeedError,
+)
+
+TEMPERATURE_LOWER_LIMIT = 37
+TEMPERATURE_UPPER_LIMIT = 95
+SPEED_LOWER_LIMIT = 200
+SPEED_UPPER_LIMIT = 3000
+
+
+class HeaterShakerModuleContext:
+    # TODO(spp, 2022-02-15): Revise this when writing other module contexts' docstrings.
+    """Object representing a connected Heater-Shaker Module.
+
+    It should not be instantiated directly; instead, it should be created through
+    :py:meth:`.ProtocolContext.load_module`.
+    """
+
+    def __init__(self, module_id: str) -> None:
+        self._module_id = module_id
+
+    def start_set_temperature(self, temperature: float) -> None:
+        """Set the target temperature of heater-shaker and return immediately.
+
+        This method takes a target temperature between 37C & 95C and tells
+        the heater-shaker to start heating to the target temperature without waiting
+        for the heater-shaker to reach the target.
+        Use :py:meth:`await_temperature` to wait for the temperature set here.
+
+        raises: `InvalidTargetTemperatureError` if temperature out of limits
+        """
+        if not TEMPERATURE_LOWER_LIMIT <= temperature <= TEMPERATURE_UPPER_LIMIT:
+            raise InvalidTargetTemperatureError(
+                f"Temperature should be in range {TEMPERATURE_LOWER_LIMIT} to "
+                f"{TEMPERATURE_UPPER_LIMIT} degree celsius."
+            )
+        raise NotImplementedError()
+
+    def await_temperature(self) -> None:
+        """Wait for the heater-shaker to reach its target temperature.
+
+        Use :py:meth:`start_set_temperature` to set the target temperature first.
+
+        raises: `NoTargetTemperatureError` if heater-shaker has no target temperature.
+        """
+        raise NotImplementedError()
+
+    def stop_heating(self) -> None:
+        """Stop heating."""
+        raise NotImplementedError()
+
+    def set_shake(self, speed: int) -> None:
+        """Set shake speed in RPM and start shaking.
+
+        Latches the labware, starts shaking the plate and returns once the target
+        shake speed has reached.
+        Acceptable shake speed: 200 - 3000 RPM
+
+        raises: `InvalidTargetSpeedError` if target speed out of limits.
+        """
+        if not SPEED_LOWER_LIMIT <= speed <= SPEED_UPPER_LIMIT:
+            raise InvalidTargetSpeedError(
+                f"Speed should be in range {SPEED_LOWER_LIMIT} - {SPEED_UPPER_LIMIT}"
+                f"RPM."
+            )
+        raise NotImplementedError()
+
+    def stop_shake(self) -> None:
+        """Stop shaking."""
+        raise NotImplementedError()
+
+    def __eq__(self, other: object) -> bool:
+        """Compare for object equality using identifier string."""
+        return (
+            isinstance(other, HeaterShakerModuleContext)
+            and self._module_id == other._module_id
+        )

--- a/api/src/opentrons/protocol_api_experimental/module_contexts/heater_shaker_module_context.py
+++ b/api/src/opentrons/protocol_api_experimental/module_contexts/heater_shaker_module_context.py
@@ -61,7 +61,8 @@ class HeaterShakerModuleContext:
         shake speed has reached.
         Acceptable shake speed: 200 - 3000 RPM
 
-        raises: `InvalidTargetSpeedError` if target speed out of limits.
+        Raises:
+            InvalidTargetSpeedError: if target speed out of limits.
         """
         if not SPEED_LOWER_LIMIT <= speed <= SPEED_UPPER_LIMIT:
             raise InvalidTargetSpeedError(

--- a/api/src/opentrons/protocol_api_experimental/module_contexts/heater_shaker_module_context.py
+++ b/api/src/opentrons/protocol_api_experimental/module_contexts/heater_shaker_module_context.py
@@ -8,6 +8,8 @@ from ..errors import (
 TEMPERATURE_LOWER_LIMIT = 37
 TEMPERATURE_UPPER_LIMIT = 95
 SPEED_LOWER_LIMIT = 200
+# TODO (spp, 2022-2-22): User requirements doc states 2000rpm as limit but
+#  the module is capable of going up to 3000rpm. Do we limit the API to 2000rpm?
 SPEED_UPPER_LIMIT = 3000
 
 
@@ -22,7 +24,27 @@ class HeaterShakerModuleContext:
     def __init__(self, module_id: str) -> None:
         self._module_id = module_id
 
-    def start_set_temperature(self, temperature: float) -> None:
+    @property
+    def max_shake_speed(self) -> int:
+        """Maximum allowed shake speed of the module."""
+        return SPEED_UPPER_LIMIT
+
+    @property
+    def min_shake_speed(self) -> int:
+        """Minimum allowed shake speed of the module."""
+        return SPEED_LOWER_LIMIT
+
+    @property
+    def max_temperature(self) -> float:
+        """Maximum allowed temperature of the module."""
+        return TEMPERATURE_UPPER_LIMIT
+
+    @property
+    def min_temperature(self) -> float:
+        """Minimum allowed temperature of the module."""
+        return TEMPERATURE_LOWER_LIMIT
+
+    def start_set_temperature(self, celsius: float) -> None:
         """Set the target temperature of heater-shaker and return immediately.
 
         This method takes a target temperature between 37C & 95C and tells
@@ -33,7 +55,7 @@ class HeaterShakerModuleContext:
         Raises:
             InvalidTargetTemperatureError: target temperature out of limits.
         """
-        if not TEMPERATURE_LOWER_LIMIT <= temperature <= TEMPERATURE_UPPER_LIMIT:
+        if not TEMPERATURE_LOWER_LIMIT <= celsius <= TEMPERATURE_UPPER_LIMIT:
             raise InvalidTargetTemperatureError(
                 f"Temperature should be in range {TEMPERATURE_LOWER_LIMIT} to "
                 f"{TEMPERATURE_UPPER_LIMIT} degree celsius."
@@ -44,6 +66,9 @@ class HeaterShakerModuleContext:
         """Wait for the heater-shaker to reach its target temperature.
 
         Use :py:meth:`start_set_temperature` to set the target temperature first.
+        Note that since the heater-shaker does not have active cooling, waiting for
+        a temperature that is lower than the current temperature will take some time
+        and the protocol will be blocked during all that time.
 
         Raises:
             NoTargetTemperatureError: If heater-shaker has no target temperature.
@@ -54,7 +79,7 @@ class HeaterShakerModuleContext:
         """Stop heating."""
         raise NotImplementedError()
 
-    def set_shake(self, speed: int) -> None:
+    def set_shake_speed(self, rpm: int) -> None:
         f"""Set shake speed in RPM and start shaking.
 
         Latches the labware, starts shaking the plate and returns once the target
@@ -64,7 +89,7 @@ class HeaterShakerModuleContext:
         Raises:
             InvalidTargetSpeedError: if target speed out of limits.
         """
-        if not SPEED_LOWER_LIMIT <= speed <= SPEED_UPPER_LIMIT:
+        if not SPEED_LOWER_LIMIT <= rpm <= SPEED_UPPER_LIMIT:
             raise InvalidTargetSpeedError(
                 f"Speed should be in range {SPEED_LOWER_LIMIT} - {SPEED_UPPER_LIMIT}"
                 f"RPM."

--- a/api/src/opentrons/protocol_api_experimental/module_contexts/heater_shaker_module_context.py
+++ b/api/src/opentrons/protocol_api_experimental/module_contexts/heater_shaker_module_context.py
@@ -45,7 +45,8 @@ class HeaterShakerModuleContext:
 
         Use :py:meth:`start_set_temperature` to set the target temperature first.
 
-        raises: `NoTargetTemperatureError` if heater-shaker has no target temperature.
+        Raises:
+            NoTargetTemperatureError: If heater-shaker has no target temperature.
         """
         raise NotImplementedError()
 

--- a/api/src/opentrons/protocol_api_experimental/module_contexts/heater_shaker_module_context.py
+++ b/api/src/opentrons/protocol_api_experimental/module_contexts/heater_shaker_module_context.py
@@ -55,11 +55,11 @@ class HeaterShakerModuleContext:
         raise NotImplementedError()
 
     def set_shake(self, speed: int) -> None:
-        """Set shake speed in RPM and start shaking.
+        f"""Set shake speed in RPM and start shaking.
 
         Latches the labware, starts shaking the plate and returns once the target
         shake speed has reached.
-        Acceptable shake speed: 200 - 3000 RPM
+        Acceptable shake speed: {SPEED_LOWER_LIMIT} - {SPEED_UPPER_LIMIT} RPM
 
         Raises:
             InvalidTargetSpeedError: if target speed out of limits.

--- a/api/src/opentrons/protocol_api_experimental/module_contexts/heater_shaker_module_context.py
+++ b/api/src/opentrons/protocol_api_experimental/module_contexts/heater_shaker_module_context.py
@@ -30,7 +30,8 @@ class HeaterShakerModuleContext:
         for the heater-shaker to reach the target.
         Use :py:meth:`await_temperature` to wait for the temperature set here.
 
-        raises: `InvalidTargetTemperatureError` if temperature out of limits
+        Raises:
+            InvalidTargetTemperatureError: target temperature out of limits.
         """
         if not TEMPERATURE_LOWER_LIMIT <= temperature <= TEMPERATURE_UPPER_LIMIT:
             raise InvalidTargetTemperatureError(

--- a/api/src/opentrons/protocol_api_experimental/module_contexts/heater_shaker_module_context.py
+++ b/api/src/opentrons/protocol_api_experimental/module_contexts/heater_shaker_module_context.py
@@ -5,12 +5,12 @@ from ..errors import (
     InvalidTargetSpeedError,
 )
 
-TEMPERATURE_LOWER_LIMIT = 37
-TEMPERATURE_UPPER_LIMIT = 95
-SPEED_LOWER_LIMIT = 200
+MIN_ALLOWED_TEMPERATURE = 37
+MAX_ALLOWED_TEMPERATURE = 95
+MIN_ALLOWED_SPEED: int = 200
 # TODO (spp, 2022-2-22): User requirements doc states 2000rpm as limit but
-#  the module is capable of going up to 3000rpm. Do we limit the API to 2000rpm?
-SPEED_UPPER_LIMIT = 3000
+#  the module is capable of going up to 3000rpm. Which one to use for limit?
+MAX_ALLOWED_SPEED: int = 2000
 
 
 class HeaterShakerModuleContext:
@@ -27,22 +27,22 @@ class HeaterShakerModuleContext:
     @property
     def max_shake_speed(self) -> int:
         """Maximum allowed shake speed of the module."""
-        return SPEED_UPPER_LIMIT
+        return MAX_ALLOWED_SPEED
 
     @property
     def min_shake_speed(self) -> int:
         """Minimum allowed shake speed of the module."""
-        return SPEED_LOWER_LIMIT
+        return MIN_ALLOWED_SPEED
 
     @property
     def max_temperature(self) -> float:
         """Maximum allowed temperature of the module."""
-        return TEMPERATURE_UPPER_LIMIT
+        return MAX_ALLOWED_TEMPERATURE
 
     @property
     def min_temperature(self) -> float:
         """Minimum allowed temperature of the module."""
-        return TEMPERATURE_LOWER_LIMIT
+        return MIN_ALLOWED_TEMPERATURE
 
     def start_set_temperature(self, celsius: float) -> None:
         """Set the target temperature of heater-shaker and return immediately.
@@ -55,10 +55,10 @@ class HeaterShakerModuleContext:
         Raises:
             InvalidTargetTemperatureError: target temperature out of limits.
         """
-        if not TEMPERATURE_LOWER_LIMIT <= celsius <= TEMPERATURE_UPPER_LIMIT:
+        if not MIN_ALLOWED_TEMPERATURE <= celsius <= MAX_ALLOWED_TEMPERATURE:
             raise InvalidTargetTemperatureError(
-                f"Temperature should be in range {TEMPERATURE_LOWER_LIMIT} to "
-                f"{TEMPERATURE_UPPER_LIMIT} degree celsius."
+                f"Temperature should be in range {MIN_ALLOWED_TEMPERATURE} to "
+                f"{MAX_ALLOWED_TEMPERATURE} degree celsius."
             )
         raise NotImplementedError()
 
@@ -80,18 +80,18 @@ class HeaterShakerModuleContext:
         raise NotImplementedError()
 
     def set_shake_speed(self, rpm: int) -> None:
-        f"""Set shake speed in RPM and start shaking.
+        """Set shake speed in RPM and start shaking.
 
         Latches the labware, starts shaking the plate and returns once the target
         shake speed has reached.
-        Acceptable shake speed: {SPEED_LOWER_LIMIT} - {SPEED_UPPER_LIMIT} RPM
+        Acceptable shake speed: 200 - 2000 RPM
 
         Raises:
             InvalidTargetSpeedError: if target speed out of limits.
         """
-        if not SPEED_LOWER_LIMIT <= rpm <= SPEED_UPPER_LIMIT:
+        if not MIN_ALLOWED_SPEED <= rpm <= MAX_ALLOWED_SPEED:
             raise InvalidTargetSpeedError(
-                f"Speed should be in range {SPEED_LOWER_LIMIT} - {SPEED_UPPER_LIMIT}"
+                f"Speed should be in range {MIN_ALLOWED_SPEED} - {MAX_ALLOWED_SPEED}"
                 f"RPM."
             )
         raise NotImplementedError()

--- a/api/src/opentrons/protocol_api_experimental/module_contexts/heater_shaker_module_context.py
+++ b/api/src/opentrons/protocol_api_experimental/module_contexts/heater_shaker_module_context.py
@@ -96,7 +96,7 @@ class HeaterShakerModuleContext:
             )
         raise NotImplementedError()
 
-    def stop_shake(self) -> None:
+    def stop_shaking(self) -> None:
         """Stop shaking."""
         raise NotImplementedError()
 

--- a/api/tests/opentrons/protocol_api_experimental/module_contexts/test_heater_shaker_module_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/module_contexts/test_heater_shaker_module_context.py
@@ -60,3 +60,11 @@ def test_set_invalid_speed(subject: HeaterShakerModuleContext) -> None:
 def test_stop_shake(subject: HeaterShakerModuleContext) -> None:
     """It should stop shake."""
     subject.stop_shake()
+
+
+def test_max_and_min_properties(subject: HeaterShakerModuleContext) -> None:
+    """It should respond with correct max & min temperature & speed values."""
+    assert subject.max_shake_speed == 2000
+    assert subject.min_shake_speed == 200
+    assert subject.max_temperature == 95
+    assert subject.min_temperature == 37

--- a/api/tests/opentrons/protocol_api_experimental/module_contexts/test_heater_shaker_module_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/module_contexts/test_heater_shaker_module_context.py
@@ -43,7 +43,7 @@ def test_stop_heating(subject: HeaterShakerModuleContext) -> None:
 
 
 @pytest.mark.xfail(strict=True, raises=NotImplementedError)
-def test_set_speed(subject: HeaterShakerModuleContext) -> None:
+def test_set_shake_speed(subject: HeaterShakerModuleContext) -> None:
     """It should set heater shaker speed."""
     subject.set_shake_speed(500)
 
@@ -57,9 +57,9 @@ def test_set_invalid_speed(subject: HeaterShakerModuleContext) -> None:
 
 
 @pytest.mark.xfail(strict=True, raises=NotImplementedError)
-def test_stop_shake(subject: HeaterShakerModuleContext) -> None:
+def test_stop_shaking(subject: HeaterShakerModuleContext) -> None:
     """It should stop shake."""
-    subject.stop_shake()
+    subject.stop_shaking()
 
 
 def test_max_and_min_properties(subject: HeaterShakerModuleContext) -> None:

--- a/api/tests/opentrons/protocol_api_experimental/module_contexts/test_heater_shaker_module_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/module_contexts/test_heater_shaker_module_context.py
@@ -45,15 +45,15 @@ def test_stop_heating(subject: HeaterShakerModuleContext) -> None:
 @pytest.mark.xfail(strict=True, raises=NotImplementedError)
 def test_set_speed(subject: HeaterShakerModuleContext) -> None:
     """It should set heater shaker speed."""
-    subject.set_shake(500)
+    subject.set_shake_speed(500)
 
 
 def test_set_invalid_speed(subject: HeaterShakerModuleContext) -> None:
     """It should raise error when given invalid speed."""
     with pytest.raises(InvalidTargetSpeedError):
-        subject.set_shake(10)
+        subject.set_shake_speed(10)
     with pytest.raises(InvalidTargetSpeedError):
-        subject.set_shake(10000)
+        subject.set_shake_speed(10000)
 
 
 @pytest.mark.xfail(strict=True, raises=NotImplementedError)

--- a/api/tests/opentrons/protocol_api_experimental/module_contexts/test_heater_shaker_module_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/module_contexts/test_heater_shaker_module_context.py
@@ -1,0 +1,62 @@
+"""Tests for HeaterShakerModuleContext."""
+
+import pytest
+
+from opentrons.protocol_api_experimental import HeaterShakerModuleContext
+from opentrons.protocol_api_experimental.errors import (
+    InvalidTargetTemperatureError,
+    InvalidTargetSpeedError,
+)
+
+
+@pytest.fixture
+def subject() -> HeaterShakerModuleContext:
+    """Get a HeaterShakerModuleContext test subject."""
+    return HeaterShakerModuleContext(module_id="heater-shaker-id")
+
+
+@pytest.mark.xfail(strict=True, raises=NotImplementedError)
+def test_start_set_temperature(subject: HeaterShakerModuleContext) -> None:
+    """It should set the temperature and return immediately."""
+    subject.start_set_temperature(40.8)
+
+
+def test_start_set_invalid_temperature(subject: HeaterShakerModuleContext) -> None:
+    """It should raise if target temperature is invalid."""
+    with pytest.raises(InvalidTargetTemperatureError):
+        subject.start_set_temperature(20)
+    with pytest.raises(InvalidTargetTemperatureError):
+        subject.start_set_temperature(1000)
+
+
+@pytest.mark.xfail(strict=True, raises=NotImplementedError)
+def test_await_temperature(subject: HeaterShakerModuleContext) -> None:
+    """It should await the target temperature."""
+    subject.start_set_temperature(40)
+    subject.await_temperature()
+
+
+@pytest.mark.xfail(strict=True, raises=NotImplementedError)
+def test_stop_heating(subject: HeaterShakerModuleContext) -> None:
+    """It should stop heater shaker heating."""
+    subject.stop_heating()
+
+
+@pytest.mark.xfail(strict=True, raises=NotImplementedError)
+def test_set_speed(subject: HeaterShakerModuleContext) -> None:
+    """It should set heater shaker speed."""
+    subject.set_shake(500)
+
+
+def test_set_invalid_speed(subject: HeaterShakerModuleContext) -> None:
+    """It should raise error when given invalid speed."""
+    with pytest.raises(InvalidTargetSpeedError):
+        subject.set_shake(10)
+    with pytest.raises(InvalidTargetSpeedError):
+        subject.set_shake(10000)
+
+
+@pytest.mark.xfail(strict=True, raises=NotImplementedError)
+def test_stop_shake(subject: HeaterShakerModuleContext) -> None:
+    """It should stop shake."""
+    subject.stop_shake()


### PR DESCRIPTION
# Overview

Closes #9341 

Adds python method stubs for 'building block commands'. Specs are from [this](https://opentrons.atlassian.net/wiki/spaces/RPDO/pages/3157983283/Python+API+design) document.

I have deviated from our usual pattern of allowing out of limit inputs from users and relying on the firmware to do the checking. So these methods will raise an error if an out of bounds temperature or speed value is provided. This makes analyzing a protocol much easier and I think it's better to have such checks on the top layer of the stack rather than the bottom. We can loosen these checks later if required.

Will add the status properties in the next PR depending on client work requirements.

# Changelog

Added the following methods to `HeaterShakerModuleContext`:
- `start_set_temperature`
- `await_temperature`
- `stop_heating`
- ~`set_shake`~ `set_shake_speed`
- ~`stop_shake`~ `stop_shaking`

# Review requests

- Does the naming make sense?
- Do the errors make sense?
- Code looks good?

# Risk assessment

None. API not used yet
