### PR TITLE
refactor(api): Clarify Magnetic Module engage height and "short mm"

### DIFF
--- a/api/docs/v2/new_modules.rst
+++ b/api/docs/v2/new_modules.rst
@@ -292,9 +292,9 @@ The :py:meth:`.MagneticModuleContext.engage` function raises the magnets to indu
   .. versionadded:: 2.2
 
 .. note::
-    There is a +/- 1 mmm variance across magnetic module units, using ``height_from_base=0`` might not be able to get the magnets to completely flush with base of the labware. Please test before carrying out your experiment to ensure the desired engage height for your labware.
+    There is a +/- 1 mm variance across magnetic module units, using ``height_from_base=0`` might not be able to get the magnets to completely flush with base of the labware. Please test before carrying out your experiment to ensure the desired engage height for your labware.
 
-- You can also specify ``height``, which should be a distance in mm from the home position of the magnets.
+- You can also specify ``height``, which should be a distance from the home position of the magnets.
 
   .. code-block:: python
 

--- a/api/src/opentrons/drivers/mag_deck/driver.py
+++ b/api/src/opentrons/drivers/mag_deck/driver.py
@@ -139,17 +139,21 @@ class MagDeckDriver(AbstractMagDeckDriver):
         data = utils.parse_key_values(response)
         return utils.parse_number(str(data.get("Z")), GCODE_ROUNDING_PRECISION)
 
-    async def move(self, position_mm: float) -> None:
+    async def move(self, position: float) -> None:
         """
         Move the magnets along Z axis where the home position is 0.0;
-        position_mm-> a point along Z. Does not self-check if the position
+        position-> a point along Z. Does not self-check if the position
         is outside of the deck's linear range
+
+        The units of position depend on the module model.
+        For GEN1, it's half millimeters ("short millimeters").
+        For GEN2, it's millimeters.
         """
         c = (
             CommandBuilder(terminator=MAG_DECK_COMMAND_TERMINATOR)
             .add_gcode(gcode=GCODE.MOVE)
             .add_float(
-                prefix="Z", value=position_mm, precision=GCODE_ROUNDING_PRECISION
+                prefix="Z", value=position, precision=GCODE_ROUNDING_PRECISION
             )
         )
         await self._send_command(c)

--- a/api/src/opentrons/drivers/mag_deck/driver.py
+++ b/api/src/opentrons/drivers/mag_deck/driver.py
@@ -152,9 +152,7 @@ class MagDeckDriver(AbstractMagDeckDriver):
         c = (
             CommandBuilder(terminator=MAG_DECK_COMMAND_TERMINATOR)
             .add_gcode(gcode=GCODE.MOVE)
-            .add_float(
-                prefix="Z", value=position, precision=GCODE_ROUNDING_PRECISION
-            )
+            .add_float(prefix="Z", value=position, precision=GCODE_ROUNDING_PRECISION)
         )
         await self._send_command(c)
 

--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -93,12 +93,17 @@ class MagDeck(mod_abc.AbstractModule):
         # return if successful or not?
 
     async def engage(self, height: float) -> None:
-        """Move the magnet to a specific height, in mm from home position."""
+        """Move the magnet to a specific height, measured from home position.
+
+        The units of position depend on the module model.
+        For GEN1, it's half millimeters ("short millimeters").
+        For GEN2, it's millimeters.
+        """
         await self.wait_for_is_running()
         if height > MAX_ENGAGE_HEIGHT[self.model()] or height < 0:
             raise ValueError(
-                f"Invalid engage height for {self.model()}: {height} mm. "
-                f"Must be 0 - {MAX_ENGAGE_HEIGHT[self.model()]} mm"
+                f"Invalid engage height for {self.model()}: {height}. "
+                f"Must be 0 - {MAX_ENGAGE_HEIGHT[self.model()]}."
             )
         await self._driver.move(height)
         self._current_height = await self._driver.get_mag_position()

--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -13,10 +13,13 @@ from . import update, mod_abc, types
 log = logging.getLogger(__name__)
 
 MAX_ENGAGE_HEIGHT = {
-    # mm from home position
+    # Distance from home position.
+    # Measured in model-specific units (half-mm for GEN1, mm for GEN2).
     "magneticModuleV1": 45,
     "magneticModuleV2": 25,
 }
+
+# Measured in model-specific units (half-mm for GEN1, mm for GEN2).
 OFFSET_TO_LABWARE_BOTTOM = {"magneticModuleV1": 5, "magneticModuleV2": 2.5}
 
 

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -463,11 +463,11 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
 
         is_api_breakpoint = self._ctx._api_version >= APIVersion(2, 3)
         is_v1_module = self._module.model() == "magneticModuleV1"
-        engage_height_in_half_mm = self.labware.load_name in MAGDECK_HALF_MM_LABWARE
+        engage_height_is_in_half_mm = self.labware.load_name in MAGDECK_HALF_MM_LABWARE
 
-        if is_api_breakpoint and is_v1_module and not engage_height_in_half_mm:
+        if is_api_breakpoint and is_v1_module and not engage_height_is_in_half_mm:
             return engage_height * ENGAGE_HEIGHT_UNIT_CNV
-        elif is_api_breakpoint and not is_v1_module and engage_height_in_half_mm:
+        elif is_api_breakpoint and not is_v1_module and engage_height_is_in_half_mm:
             return engage_height / ENGAGE_HEIGHT_UNIT_CNV
         else:
             return engage_height

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -411,7 +411,7 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
         :param offset: An offset relative to the default height for the labware
                        in mm
 
-        .. versionadded:: 2.1
+        .. versionadded:: 2.2
             The *height_from_base* parameter.
         """
         if height is not None:

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -418,7 +418,8 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
         depend on which generation of Magnetic Module you're using:
 
            - For GEN1 Magnetic Modules, they're in *half-millimeters,*
-             for historical reasons.
+             for historical reasons. This will not be the case in future
+             releases of the Python Protocol API.
            - For GEN2 Magnetic Modules, they're in true millimeters.
 
         You may not specify more than one of

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -463,11 +463,11 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
 
         is_api_breakpoint = self._ctx._api_version >= APIVersion(2, 3)
         is_v1_module = self._module.model() == "magneticModuleV1"
-        is_standard_lw = self.labware.load_name in MAGDECK_HALF_MM_LABWARE
+        engage_height_in_half_mm = self.labware.load_name in MAGDECK_HALF_MM_LABWARE
 
-        if is_api_breakpoint and is_v1_module and not is_standard_lw:
+        if is_api_breakpoint and is_v1_module and not engage_height_in_half_mm:
             return engage_height * ENGAGE_HEIGHT_UNIT_CNV
-        elif is_api_breakpoint and not is_v1_module and is_standard_lw:
+        elif is_api_breakpoint and not is_v1_module and engage_height_in_half_mm:
             return engage_height / ENGAGE_HEIGHT_UNIT_CNV
         else:
             return engage_height

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -414,15 +414,15 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
              A positive number moves the magnets higher and
              a negative number moves the magnets lower.
 
-        The units of ``height``, ``offset``, and ``height_from_base``
+        The units of ``height_from_base``, ``height``, and ``offset``
         depend on which generation of Magnetic Module you're using:
 
            - For GEN1 Magnetic Modules, they're in *half-millimeters,*
              for historical reasons.
            - For GEN2 Magnetic Modules, they're in true millimeters.
 
-        You may not specify more than one of ``height``, ``offset``,
-        or ``height_from_base``.
+        You may not specify more than one of
+        ``height_from_base``, ``height``, and ``offset``.
 
         .. versionadded:: 2.2
             The *height_from_base* parameter.

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -25,7 +25,9 @@ if TYPE_CHECKING:
     from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 ENGAGE_HEIGHT_UNIT_CNV = 2
-STANDARD_MAGDECK_LABWARE = [
+MAGDECK_HALF_MM_LABWARE = [
+    # Load names of labware whose definitions accidentally specify an engage height
+    # in units of half-millimeters, instead of millimeters.
     "biorad_96_wellplate_200ul_pcr",
     "nest_96_wellplate_100ul_pcr_full_skirt",
     "usascientific_96_wellplate_2.4ml_deep",
@@ -461,7 +463,7 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
 
         is_api_breakpoint = self._ctx._api_version >= APIVersion(2, 3)
         is_v1_module = self._module.model() == "magneticModuleV1"
-        is_standard_lw = self.labware.load_name in STANDARD_MAGDECK_LABWARE
+        is_standard_lw = self.labware.load_name in MAGDECK_HALF_MM_LABWARE
 
         if is_api_breakpoint and is_v1_module and not is_standard_lw:
             return engage_height * ENGAGE_HEIGHT_UNIT_CNV

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -387,31 +387,42 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
     ) -> None:
         """Raise the Magnetic Module's magnets.
 
-        The destination of the magnets can be specified in several different
-        ways, based on internally stored default heights for labware:
+        You can specify how high the magnets should go in several different ways:
 
-           - If neither ``height``, ``height_from_base`` nor ``offset`` is
-             specified, the magnets will raise to a reasonable default height
-             based on the specified labware.
-           - The recommended way to adjust the height of the magnets is to
-             specify ``height_from_base``, which should be a distance in mm
-             relative to the base of the labware that is on the magnetic module
-           - If ``height`` is specified, it should be a distance in mm from the
-             home position of the magnets.
-           - If ``offset`` is specified, it should be an offset in mm from the
-             default position. A positive number moves the magnets higher and
+           - If you specify ``height_from_base``, it's measured relative to the bottom
+             of the labware.
+
+             This is the recommended way to adjust the magnets' height.
+
+           - If you specify ``height``, it's measured relative to the magnets'
+             home position.
+
+             You should normally use ``height_from_base`` instead.
+
+           - If you specify nothing,
+             the magnets will rise to a reasonable default height
+             based on what labware you've loaded on this Magnetic Module.
+
+             Only certain labware have a defined engage height.
+             If you've loaded a labware that doesn't,
+             or if you haven't loaded any labware, then you'll need to specify
+             a height yourself with ``height`` or ``height_from_base``.
+             Otherwise, an exception will be raised.
+
+           - If you specify ``offset``,
+             it's measured relative to the default height, as described above.
+             A positive number moves the magnets higher and
              a negative number moves the magnets lower.
 
-        Only certain labwares have defined engage heights for the Magnetic
-        Module. If a labware that does not have a defined engage height is
-        loaded on the Magnetic Module (or if no labware is loaded), then
-        ``height`` or ``height_from_labware`` must be specified.
+        The units of ``height``, ``offset``, and ``height_from_base``
+        depend on which generation of Magnetic Module you're using:
 
-        :param height_from_base: The height to raise the magnets to, in mm from
-                                 the base of the labware
-        :param height: The height to raise the magnets to, in mm from home.
-        :param offset: An offset relative to the default height for the labware
-                       in mm
+           - For GEN1 Magnetic Modules, they're in *half-millimeters,*
+             for historical reasons.
+           - For GEN2 Magnetic Modules, they're in true millimeters.
+
+        You may not specify more than one of ``height``, ``offset``,
+        or ``height_from_base``.
 
         .. versionadded:: 2.2
             The *height_from_base* parameter.

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -416,6 +416,12 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
         """
         if height is not None:
             dist = height
+
+        # This version check has a bug:
+        # if the caller sets height_from_base in an API version that's too low,
+        # we will silently ignore it instead of raising APIVersionError.
+        # Leaving this unfixed because we haven't thought through
+        # how to do backwards-compatible fixes to our version checking itself.
         elif height_from_base is not None and self._ctx._api_version >= APIVersion(
             2, 2
         ):
@@ -423,10 +429,12 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
                 height_from_base
                 + modules.magdeck.OFFSET_TO_LABWARE_BOTTOM[self._module.model()]
             )
+
         elif self.labware and self.labware.magdeck_engage_height is not None:
             dist = self._determine_lw_engage_height()
             if offset:
                 dist += offset
+
         else:
             raise ValueError(
                 "Currently loaded labware {} does not have a known engage "
@@ -434,6 +442,7 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
                     self.labware
                 )
             )
+
         self._module.engage(dist)
 
     def _determine_lw_engage_height(self) -> float:

--- a/shared-data/labware/schemas/2.json
+++ b/shared-data/labware/schemas/2.json
@@ -154,7 +154,7 @@
           "type": "boolean"
         },
         "magneticModuleEngageHeight": {
-          "description": "Distance to move magnetic module magnets to engage",
+          "description": "Millimeters above the labware base plane to move Magnetic Module magnets to engage, if the protocol does not specify a height. Beware: some Opentrons standard labware definitions accidentally specify this in units of half-millimeters (\"short mm\").",
           "$ref": "#/definitions/positiveNumber"
         }
       }

--- a/shared-data/labware/schemas/2.json
+++ b/shared-data/labware/schemas/2.json
@@ -154,7 +154,7 @@
           "type": "boolean"
         },
         "magneticModuleEngageHeight": {
-          "description": "Millimeters above the labware base plane to move Magnetic Module magnets to engage, if the protocol does not specify a height. Beware: some Opentrons standard labware definitions accidentally specify this in units of half-millimeters (\"short mm\").",
+          "description": "Distance to move magnetic module magnets to engage",
           "$ref": "#/definitions/positiveNumber"
         }
       }


### PR DESCRIPTION
# Overview

This PR makes a few scattered changes to clarify, to both Opentrons developers and Python protocol authors, what the units are when controlling a Magnetic Module.

The changes are mostly to comments and docstrings, with a couple of simple variable renames.

# Review requests

Please see the comments in the GitHub thread below. Make sure all the changes seem correct.

# Risk assessment

* No risk that the behavior of production code will change.
* A decent risk that this will confuse people and cause further bugs, if I got any of this wrong.

# Future work

A big thing that I didn't touch in this PR is how a default engage height is set in a labware definition:

https://github.com/Opentrons/opentrons/blob/9fadafce7cd575ae3db08aca7e5257dd6c186ddc/shared-data/labware/schemas/2.json#L156-L159

* Is this measured in true millimeters, or half-millimeters?
* Is this measured from the magnets' home position, or from the bottom of the labware?
* Does this depend on the module model?
* Does this depend on the labware?

I think bug #9529 is at least partially related to this confusion.
