### PR TITLE
refactor(app): close module card menu on click

### DIFF
--- a/app/src/organisms/Devices/ModuleCard/ModuleOverflowMenu.tsx
+++ b/app/src/organisms/Devices/ModuleCard/ModuleOverflowMenu.tsx
@@ -1,59 +1,21 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { Flex, POSITION_RELATIVE } from '@opentrons/components'
-import {
-  THERMOCYCLER_MODULE_TYPE,
-  MAGNETIC_MODULE_TYPE,
-} from '@opentrons/shared-data'
 import { MenuList } from '../../../atoms/MenuList'
 import { MenuItem } from '../../../atoms/MenuList/MenuItem'
-import { MagneticModuleSlideout } from './MagneticModuleSlideout'
-import { TemperatureModuleSlideout } from './TemperatureModuleSlideout'
-import { ThermocyclerModuleSlideout } from './ThermocyclerModuleSlideout'
 
 import type { AttachedModule } from '../../../redux/modules/types'
 
 interface ModuleOverflowMenuProps {
   module: AttachedModule
+  handleClick: (isSecondary: boolean) => void
 }
 
 export const ModuleOverflowMenu = (
   props: ModuleOverflowMenuProps
 ): JSX.Element | null => {
   const { t } = useTranslation('device_details')
-  const { module } = props
-  const [showSlideout, setShowSlideout] = React.useState(false)
-  const [hasSecondary, setHasSecondary] = React.useState(false)
-
-  const renderSlideOut = (isSecondary: boolean = false): JSX.Element => {
-    if (module.type === THERMOCYCLER_MODULE_TYPE) {
-      return (
-        <ThermocyclerModuleSlideout
-          module={module}
-          onCloseClick={() => setShowSlideout(false)}
-          isExpanded={showSlideout}
-          isSecondaryTemp={isSecondary}
-        />
-      )
-    } else if (module.type === MAGNETIC_MODULE_TYPE) {
-      return (
-        <MagneticModuleSlideout
-          module={module}
-          onCloseClick={() => setShowSlideout(false)}
-          isExpanded={showSlideout}
-        />
-      )
-    } else {
-      return (
-        <TemperatureModuleSlideout
-          model={module.model}
-          serial={module.serial}
-          onCloseClick={() => setShowSlideout(false)}
-          isExpanded={showSlideout}
-        />
-      )
-    }
-  }
+  const { module, handleClick } = props
 
   const menuItems = {
     thermocyclerModuleType: [
@@ -84,13 +46,6 @@ export const ModuleOverflowMenu = (
     ],
   }
 
-  const handleClick = (isSecondary: boolean = false): void => {
-    if (isSecondary) {
-      setHasSecondary(true)
-    }
-    setShowSlideout(true)
-  }
-
   const AboutModuleBtn = (
     <MenuItem
       data-testid={`about_module_${module.model}`}
@@ -103,7 +58,6 @@ export const ModuleOverflowMenu = (
 
   return (
     <React.Fragment>
-      {showSlideout && renderSlideOut(hasSecondary)}
       <Flex position={POSITION_RELATIVE}>
         <MenuList
           buttons={[

--- a/app/src/organisms/Devices/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
@@ -8,24 +8,6 @@ import {
   mockThermocycler,
 } from '../../../../redux/modules/__fixtures__'
 import { ModuleOverflowMenu } from '../ModuleOverflowMenu'
-import { MagneticModuleSlideout } from '../MagneticModuleSlideout'
-import { TemperatureModuleSlideout } from '../TemperatureModuleSlideout'
-import { ThermocyclerModuleSlideout } from '../ThermocyclerModuleSlideout'
-
-jest.mock('../MagneticModuleSlideout')
-jest.mock('../TemperatureModuleSlideout')
-jest.mock('../ThermocyclerModuleSlideout')
-
-const mockMagneticModuleSlideout = MagneticModuleSlideout as jest.MockedFunction<
-  typeof MagneticModuleSlideout
->
-const mockTemperatureModuleSlideout = TemperatureModuleSlideout as jest.MockedFunction<
-  typeof TemperatureModuleSlideout
->
-
-const mockThermocyclerModuleSlideout = ThermocyclerModuleSlideout as jest.MockedFunction<
-  typeof ThermocyclerModuleSlideout
->
 
 const render = (props: React.ComponentProps<typeof ModuleOverflowMenu>) => {
   return renderWithProviders(<ModuleOverflowMenu {...props} />, {
@@ -38,16 +20,8 @@ describe('ModuleOverflowMenu', () => {
   beforeEach(() => {
     props = {
       module: mockMagneticModule,
+      handleClick: jest.fn(),
     }
-    mockMagneticModuleSlideout.mockReturnValue(
-      <div>Mock mag module slideout</div>
-    )
-    mockTemperatureModuleSlideout.mockReturnValue(
-      <div>Mock temperature module slideout</div>
-    )
-    mockThermocyclerModuleSlideout.mockReturnValue(
-      <div>Mock thermocycler module slideout</div>
-    )
   })
   afterEach(() => {
     jest.resetAllMocks()
@@ -61,7 +35,6 @@ describe('ModuleOverflowMenu', () => {
       background-color: transparent;
     `)
     fireEvent.click(buttonSetting)
-    getByText('Mock mag module slideout')
     const buttonAbout = getByRole('button', { name: 'About module' })
     fireEvent.click(buttonAbout)
     expect(buttonAbout).toBeEnabled()
@@ -82,13 +55,13 @@ describe('ModuleOverflowMenu', () => {
   it('renders the correct temperature module menu', () => {
     props = {
       module: mockTemperatureModuleGen2,
+      handleClick: jest.fn(),
     }
-    const { getByRole, getByText } = render(props)
+    const { getByRole } = render(props)
     const buttonSetting = getByRole('button', {
       name: 'Set module temperature',
     })
     fireEvent.click(buttonSetting)
-    getByText('Mock temperature module slideout')
     const buttonAbout = getByRole('button', { name: 'About module' })
     fireEvent.click(buttonAbout)
     expect(buttonAbout).toBeEnabled()
@@ -97,6 +70,7 @@ describe('ModuleOverflowMenu', () => {
   it('renders the correct TC module menu', () => {
     props = {
       module: mockThermocycler,
+      handleClick: jest.fn(),
     }
     const { getByRole } = render(props)
     const buttonSettingLid = getByRole('button', {

--- a/app/src/organisms/Devices/ModuleCard/index.tsx
+++ b/app/src/organisms/Devices/ModuleCard/index.tsx
@@ -30,15 +30,15 @@ import { MagneticModuleData } from './MagneticModuleData'
 import { TemperatureModuleData } from './TemperatureModuleData'
 import { ThermocyclerModuleData } from './ThermocyclerModuleData'
 import { ModuleOverflowMenu } from './ModuleOverflowMenu'
+import { ThermocyclerModuleSlideout } from './ThermocyclerModuleSlideout'
+import { MagneticModuleSlideout } from './MagneticModuleSlideout'
+import { TemperatureModuleSlideout } from './TemperatureModuleSlideout'
 
 import magneticModule from '../../../assets/images/magnetic_module_gen_2_transparent.svg'
 import temperatureModule from '../../../assets/images/temp_deck_gen_2_transparent.svg'
 import thermoModule from '../../../assets/images/thermocycler_open_transparent.svg'
 
 import type { AttachedModule } from '../../../redux/modules/types'
-import { ThermocyclerModuleSlideout } from './ThermocyclerModuleSlideout'
-import { MagneticModuleSlideout } from './MagneticModuleSlideout'
-import { TemperatureModuleSlideout } from './TemperatureModuleSlideout'
 
 interface ModuleCardProps {
   module: AttachedModule
@@ -51,7 +51,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
   const [showSlideout, setShowSlideout] = React.useState(false)
   const [hasSecondary, setHasSecondary] = React.useState(false)
 
-  const node = useOnClickOutside({
+  const moduleOverflowWrapperRef = useOnClickOutside({
     onClickOutside: () => setShowOverflowMenu(false),
   }) as React.RefObject<HTMLDivElement>
 
@@ -97,39 +97,11 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
     }
   }
 
-  const renderSlideOut = (isSecondary: boolean = false): JSX.Element => {
-    if (module.type === THERMOCYCLER_MODULE_TYPE) {
-      return (
-        <ThermocyclerModuleSlideout
-          module={module}
-          onCloseClick={() => setShowSlideout(false)}
-          isExpanded={showSlideout}
-          isSecondaryTemp={isSecondary}
-        />
-      )
-    } else if (module.type === MAGNETIC_MODULE_TYPE) {
-      return (
-        <MagneticModuleSlideout
-          module={module}
-          onCloseClick={() => setShowSlideout(false)}
-          isExpanded={showSlideout}
-        />
-      )
-    } else {
-      return (
-        <TemperatureModuleSlideout
-          model={module.model}
-          serial={module.serial}
-          onCloseClick={() => setShowSlideout(false)}
-          isExpanded={showSlideout}
-        />
-      )
-    }
-  }
-
   const handleMenuItemClick = (isSecondary: boolean = false): void => {
     if (isSecondary) {
       setHasSecondary(true)
+    } else {
+      setHasSecondary(false)
     }
     setShowSlideout(true)
     setShowOverflowMenu(false)
@@ -144,7 +116,14 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
         marginLeft={SPACING_2}
         width={'20rem'}
       >
-        {showSlideout && renderSlideOut(hasSecondary)}
+        {showSlideout && (
+          <ModuleSlideout
+            module={module}
+            isSecondary={hasSecondary}
+            showSlideout={showSlideout}
+            onCloseClick={() => setShowSlideout(false)}
+          />
+        )}
         <Box
           padding={`${SPACING_3} ${SPACING_2} ${SPACING_3} ${SPACING_2}`}
           width="100%"
@@ -183,7 +162,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
           />
         </Box>
         {showOverflowMenu && (
-          <div ref={node}>
+          <div ref={moduleOverflowWrapperRef}>
             <ModuleOverflowMenu
               module={module}
               handleClick={handleMenuItemClick}
@@ -193,4 +172,42 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
       </Flex>
     </React.Fragment>
   )
+}
+
+interface ModuleSlideoutProps {
+  module: AttachedModule
+  isSecondary: boolean
+  showSlideout: boolean
+  onCloseClick: () => unknown
+}
+
+const ModuleSlideout = (props: ModuleSlideoutProps): JSX.Element => {
+  const { module, isSecondary, showSlideout, onCloseClick } = props
+  if (module.type === THERMOCYCLER_MODULE_TYPE) {
+    return (
+      <ThermocyclerModuleSlideout
+        module={module}
+        onCloseClick={onCloseClick}
+        isExpanded={showSlideout}
+        isSecondaryTemp={isSecondary}
+      />
+    )
+  } else if (module.type === MAGNETIC_MODULE_TYPE) {
+    return (
+      <MagneticModuleSlideout
+        module={module}
+        onCloseClick={onCloseClick}
+        isExpanded={showSlideout}
+      />
+    )
+  } else {
+    return (
+      <TemperatureModuleSlideout
+        model={module.model}
+        serial={module.serial}
+        onCloseClick={onCloseClick}
+        isExpanded={showSlideout}
+      />
+    )
+  }
 }

--- a/app/src/organisms/Devices/ModuleCard/index.tsx
+++ b/app/src/organisms/Devices/ModuleCard/index.tsx
@@ -17,8 +17,13 @@ import {
   FONT_WEIGHT_REGULAR,
   FONT_SIZE_CAPTION,
   TYPOGRAPHY,
+  useOnClickOutside,
 } from '@opentrons/components'
-import { getModuleDisplayName } from '@opentrons/shared-data'
+import {
+  getModuleDisplayName,
+  MAGNETIC_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+} from '@opentrons/shared-data'
 import { OverflowBtn } from '../../../atoms/MenuList/OverflowBtn'
 import { ModuleIcon } from '../ModuleIcon'
 import { MagneticModuleData } from './MagneticModuleData'
@@ -31,6 +36,9 @@ import temperatureModule from '../../../assets/images/temp_deck_gen_2_transparen
 import thermoModule from '../../../assets/images/thermocycler_open_transparent.svg'
 
 import type { AttachedModule } from '../../../redux/modules/types'
+import { ThermocyclerModuleSlideout } from './ThermocyclerModuleSlideout'
+import { MagneticModuleSlideout } from './MagneticModuleSlideout'
+import { TemperatureModuleSlideout } from './TemperatureModuleSlideout'
 
 interface ModuleCardProps {
   module: AttachedModule
@@ -40,6 +48,12 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
   const { t } = useTranslation('device_details')
   const { module } = props
   const [showOverflowMenu, setShowOverflowMenu] = React.useState(false)
+  const [showSlideout, setShowSlideout] = React.useState(false)
+  const [hasSecondary, setHasSecondary] = React.useState(false)
+
+  const node = useOnClickOutside({
+    onClickOutside: () => setShowOverflowMenu(false),
+  }) as React.RefObject<HTMLDivElement>
 
   let image = ''
   let moduleData: JSX.Element = <div></div>
@@ -83,6 +97,44 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
     }
   }
 
+  const renderSlideOut = (isSecondary: boolean = false): JSX.Element => {
+    if (module.type === THERMOCYCLER_MODULE_TYPE) {
+      return (
+        <ThermocyclerModuleSlideout
+          module={module}
+          onCloseClick={() => setShowSlideout(false)}
+          isExpanded={showSlideout}
+          isSecondaryTemp={isSecondary}
+        />
+      )
+    } else if (module.type === MAGNETIC_MODULE_TYPE) {
+      return (
+        <MagneticModuleSlideout
+          module={module}
+          onCloseClick={() => setShowSlideout(false)}
+          isExpanded={showSlideout}
+        />
+      )
+    } else {
+      return (
+        <TemperatureModuleSlideout
+          model={module.model}
+          serial={module.serial}
+          onCloseClick={() => setShowSlideout(false)}
+          isExpanded={showSlideout}
+        />
+      )
+    }
+  }
+
+  const handleMenuItemClick = (isSecondary: boolean = false): void => {
+    if (isSecondary) {
+      setHasSecondary(true)
+    }
+    setShowSlideout(true)
+    setShowOverflowMenu(false)
+  }
+
   return (
     <React.Fragment>
       <Flex
@@ -92,6 +144,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
         marginLeft={SPACING_2}
         width={'20rem'}
       >
+        {showSlideout && renderSlideOut(hasSecondary)}
         <Box
           padding={`${SPACING_3} ${SPACING_2} ${SPACING_3} ${SPACING_2}`}
           width="100%"
@@ -129,7 +182,14 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
             }}
           />
         </Box>
-        {showOverflowMenu && <ModuleOverflowMenu module={module} />}
+        {showOverflowMenu && (
+          <div ref={node}>
+            <ModuleOverflowMenu
+              module={module}
+              handleClick={handleMenuItemClick}
+            />
+          </div>
+        )}
       </Flex>
     </React.Fragment>
   )


### PR DESCRIPTION
# Overview

This PR closes the module card menu when a menu item is clicked and also when the document is
clicked. closes #9413

https://user-images.githubusercontent.com/14794021/154391287-3efce43f-2daa-432e-b849-ac9b831af997.mov

# Changelog

- Utilized `useOnClickOutside` to listen for clicks and hide the menu when any DOM node is clicked.
- Moved module slideout components to the parent component (keeping this in the child would close the slideout and not allow the menu to close when an item is clicked).

# Review requests

- Click the overflow menu then click anywhere on the page to close it.
- Click the overflow menu and then click a button in the menu, it should close the menu and open the slideout.
- Assess potential performance concerns

# Risk assessment
low
