### PR TITLE
fix(app): make sure pipette is being used during LPC flow

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -97,6 +97,7 @@
   "protocol_run_canceled": "Protocol run canceled.",
   "labware_position_check_not_available_empty_protocol": "Labware Position Check requires that the protocol loads labware and pipettes",
   "lpc_disabled_no_tipracks_loaded": "Labware Position Check requires that the protocol loads a tip rack",
+  "lpc_disabled_no_tipracks_used": "Labware Position Check requires that the protocol has at least one pipette that picks up a tip",
   "get_labware_offset_data": "Get Labware Offset Data",
   "module_mismatch_title": "This robot has connected modules that are not specified in this protocol",
   "module_mismatch_body": "If you’re having trouble connecting the modules specifed below, make sure the module’s generation (GEN1 vs GEN2) is correct."

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/getLabwarePositionCheckSteps.test.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/getLabwarePositionCheckSteps.test.ts
@@ -1,6 +1,7 @@
 import { when, resetAllWhenMocks } from 'jest-when'
 import _uncasted_protocolWithOnePipette from '@opentrons/shared-data/protocol/fixtures/4/simpleV4.json'
 import _uncasted_protocolWithTwoPipettes from '@opentrons/shared-data/protocol/fixtures/4/transferSettings.json'
+import _uncasted_v6ProtocolWithTwoPipettes from '@opentrons/shared-data/protocol/fixtures/6/multipleTipracks.json'
 import { getLabwarePositionCheckSteps } from '../getLabwarePositionCheckSteps'
 import { getPrimaryPipetteId } from '../utils/getPrimaryPipetteId'
 import { getPipetteWorkflow } from '../utils/getPipetteWorkflow'
@@ -12,6 +13,7 @@ import type { ProtocolFile } from '@opentrons/shared-data'
 // TODO: update these fixtures to be v6 protocols
 const protocolWithOnePipette = (_uncasted_protocolWithOnePipette as unknown) as ProtocolFile<any>
 const protocolWithTwoPipettes = (_uncasted_protocolWithTwoPipettes as unknown) as ProtocolFile<any>
+const v6ProtocolWithTwoPipettes = (_uncasted_v6ProtocolWithTwoPipettes as unknown) as ProtocolFile<any>
 
 jest.mock('../utils/getPrimaryPipetteId')
 jest.mock('../utils/getPipetteWorkflow')
@@ -35,7 +37,7 @@ describe('getLabwarePositionCheckSteps', () => {
   afterEach(() => {
     resetAllWhenMocks()
   })
-  it('should generate commands with the one pipette workflow', () => {
+  it('should generate commands with the one pipette workflow when there is only one pipette in the protocol', () => {
     const mockPipette = protocolWithOnePipette.pipettes.pipetteId
     when(mockGetPrimaryPipetteId)
       .calledWith(
@@ -62,6 +64,56 @@ describe('getLabwarePositionCheckSteps', () => {
       labwareDefinitions: protocolWithOnePipette.labwareDefinitions,
       modules: protocolWithOnePipette.modules,
       commands: protocolWithOnePipette.commands,
+    })
+  })
+  it('should generate commands with the one pipette workflow when there are two pipettes in the protocol but only one is used', () => {
+    const leftPipetteId = '50d23e00-0042-11ec-8258-f7ffdf5ad45a'
+    const rightPipetteId = 'c235a5a0-0042-11ec-8258-f7ffdf5ad45a'
+    const leftPipette = v6ProtocolWithTwoPipettes.pipettes[leftPipetteId]
+    const commandsWithoutLeftPipettePickupTipCommand = v6ProtocolWithTwoPipettes.commands.filter(
+      command =>
+        !(
+          command.commandType === 'pickUpTip' &&
+          command.params.pipetteId === leftPipetteId
+        )
+    )
+
+    const protocolWithTwoPipettesWithOnlyOneBeingUsed = {
+      ...v6ProtocolWithTwoPipettes,
+      commands: commandsWithoutLeftPipettePickupTipCommand,
+    }
+
+    const pipettesBeingUsedInProtocol: ProtocolFile<any>['pipettes'] = {
+      '50d23e00-0042-11ec-8258-f7ffdf5ad45a': { name: 'p300_single_gen2' },
+    }
+
+    when(mockGetPrimaryPipetteId)
+      .calledWith(
+        pipettesBeingUsedInProtocol,
+        protocolWithTwoPipettesWithOnlyOneBeingUsed.commands
+      )
+      .mockReturnValue(rightPipetteId)
+
+    when(mockGetPipetteWorkflow)
+      .calledWith({
+        pipetteNames: [leftPipette.name],
+        primaryPipetteId: rightPipetteId,
+        labware: protocolWithTwoPipettesWithOnlyOneBeingUsed.labware,
+        labwareDefinitions:
+          protocolWithTwoPipettesWithOnlyOneBeingUsed.labwareDefinitions,
+        commands: protocolWithTwoPipettesWithOnlyOneBeingUsed.commands,
+      })
+      .mockReturnValue(1)
+
+    getLabwarePositionCheckSteps(protocolWithTwoPipettesWithOnlyOneBeingUsed)
+
+    expect(mockgetOnePipettePositionCheckSteps).toHaveBeenCalledWith({
+      primaryPipetteId: rightPipetteId,
+      labware: protocolWithTwoPipettesWithOnlyOneBeingUsed.labware,
+      labwareDefinitions:
+        protocolWithTwoPipettesWithOnlyOneBeingUsed.labwareDefinitions,
+      modules: protocolWithTwoPipettesWithOnlyOneBeingUsed.modules,
+      commands: protocolWithTwoPipettesWithOnlyOneBeingUsed.commands,
     })
   })
   it('should generate commands with the two pipette workflow', () => {

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/getLabwarePositionCheckSteps.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/getLabwarePositionCheckSteps.ts
@@ -1,3 +1,4 @@
+import omitBy from 'lodash/omitBy'
 import values from 'lodash/values'
 import { getPrimaryPipetteId } from './utils/getPrimaryPipetteId'
 import { getPipetteWorkflow } from './utils/getPipetteWorkflow'
@@ -13,7 +14,16 @@ export const getLabwarePositionCheckSteps = (
   protocolData: ProtocolFile<{}>
 ): LabwarePositionCheckStep[] => {
   if (protocolData != null && 'pipettes' in protocolData) {
-    const pipettesById: ProtocolFile<{}>['pipettes'] = protocolData.pipettes
+    // filter out any pipettes that are not being used in the protocol
+    const pipettesById: ProtocolFile<{}>['pipettes'] = omitBy(
+      protocolData.pipettes,
+      (_pipette, id) =>
+        protocolData.commands.find(
+          command =>
+            command.commandType === 'pickUpTip' &&
+            command.params.pipetteId === id
+        )
+    )
     const pipettes = values(pipettesById)
     const pipetteNames = pipettes.map(({ name }) => name)
     const labware = protocolData.labware

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/getLabwarePositionCheckSteps.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/getLabwarePositionCheckSteps.ts
@@ -18,7 +18,7 @@ export const getLabwarePositionCheckSteps = (
     const pipettesById: ProtocolFile<{}>['pipettes'] = omitBy(
       protocolData.pipettes,
       (_pipette, id) =>
-        protocolData.commands.find(
+        !protocolData.commands.some(
           command =>
             command.commandType === 'pickUpTip' &&
             command.params.pipetteId === id

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/utils/getPrimaryPipetteId.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/utils/getPrimaryPipetteId.ts
@@ -1,3 +1,4 @@
+import { omitBy } from 'lodash'
 import { getPipetteNameSpecs } from '@opentrons/shared-data'
 import type {
   RunTimeCommand,
@@ -9,6 +10,12 @@ export const getPrimaryPipetteId = (
   pipettesById: ProtocolFile<{}>['pipettes'],
   commands: RunTimeCommand[]
 ): string => {
+  pipettesById = omitBy(pipettesById, (_pipette, id) =>
+    commands.find(
+      command =>
+        command.commandType === 'pickUpTip' && command.params.pipetteId === id
+    )
+  )
   if (Object.keys(pipettesById).length === 1) {
     return Object.keys(pipettesById)[0]
   }

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/utils/getPrimaryPipetteId.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/utils/getPrimaryPipetteId.ts
@@ -1,4 +1,3 @@
-import { omitBy } from 'lodash'
 import { getPipetteNameSpecs } from '@opentrons/shared-data'
 import type {
   RunTimeCommand,
@@ -10,12 +9,6 @@ export const getPrimaryPipetteId = (
   pipettesById: ProtocolFile<{}>['pipettes'],
   commands: RunTimeCommand[]
 ): string => {
-  pipettesById = omitBy(pipettesById, (_pipette, id) =>
-    commands.find(
-      command =>
-        command.commandType === 'pickUpTip' && command.params.pipetteId === id
-    )
-  )
   if (Object.keys(pipettesById).length === 1) {
     return Object.keys(pipettesById)[0]
   }

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareSetup.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareSetup.test.tsx
@@ -274,6 +274,12 @@ describe('LabwareSetup', () => {
               mount: 'left',
             },
           },
+          commands: [
+            {
+              commandType: 'pickUpTip',
+              params: { pipetteId: PRIMARY_PIPETTE_ID },
+            } as any,
+          ],
         },
       } as any)
     mockGetIsLabwareOffsetCodeSnippetsOn.mockReturnValue(false)
@@ -522,6 +528,36 @@ describe('LabwareSetup', () => {
         },
       },
     } as any)
+    const { getByRole } = render()
+    const button = getByRole('button', {
+      name: 'run labware position check',
+    })
+    expect(button).toBeDisabled()
+  })
+  it('should render a disabled button when a protocol does not include a pickUpTip', () => {
+    when(mockUseProtocolDetails)
+      .calledWith()
+      .mockReturnValue({
+        protocolData: {
+          labware: {
+            [mockLabwarePositionCheckStepTipRack.labwareId]: {
+              slot: '1',
+              displayName: 'someDisplayName',
+              definitionId: LABWARE_DEF_ID,
+            },
+          },
+          labwareDefinitions: {
+            [LABWARE_DEF_ID]: LABWARE_DEF,
+          },
+          pipettes: {
+            [PRIMARY_PIPETTE_ID]: {
+              name: PRIMARY_PIPETTE_NAME,
+              mount: 'left',
+            },
+          },
+          commands: [],
+        },
+      } as any)
     const { getByRole } = render()
     const button = getByRole('button', {
       name: 'run labware position check',

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
@@ -100,11 +100,6 @@ export const LabwareSetup = (): JSX.Element | null => {
   const moduleAndCalibrationIncomplete =
     missingModuleIds.length > 0 && !isEverythingCalibrated
 
-  const tipRackLoadedInProtocol: boolean = some(
-    protocolData?.labwareDefinitions,
-    def => def.parameters?.isTiprack
-  )
-
   const [downloadOffsetDataModal, showDownloadOffsetDataModal] = React.useState(
     false
   )
@@ -112,6 +107,16 @@ export const LabwareSetup = (): JSX.Element | null => {
     Config.getIsLabwareOffsetCodeSnippetsOn
   )
   const { setIsShowingLPCSuccessToast } = useLPCSuccessToast()
+
+  const tipRackLoadedInProtocol: boolean = some(
+    protocolData?.labwareDefinitions,
+    def => def.parameters?.isTiprack
+  )
+
+  const tipsArePickedUp: boolean = some(
+    protocolData?.commands,
+    command => command.commandType === 'pickUpTip'
+  )
 
   let lpcDisabledReason: string | null = null
 
@@ -130,6 +135,8 @@ export const LabwareSetup = (): JSX.Element | null => {
     lpcDisabledReason = t('labware_position_check_not_available_empty_protocol')
   } else if (!tipRackLoadedInProtocol) {
     lpcDisabledReason = t('lpc_disabled_no_tipracks_loaded')
+  } else if (!tipsArePickedUp) {
+    lpcDisabledReason = t('lpc_disabled_no_tipracks_used')
   }
 
   return (


### PR DESCRIPTION
# Overview

This addresses two edge cases surrounding Labware Position Check:

- The labware position check flow should not include pipettes that are loaded, but never used in the protocol
- a user should not be able to launch LPC if there are no `pickUpTips` in the protocol 

# Review requests

- [ ] load a protocol with two pipettes, and only use one, LPC should only use the pipette that performs a `pickUpTip` command
- [ ] load a protocol with no `pickUpTips`, the LPC CTA should be disabled with the text "Labware Position Check requires that the protocol has at least one pipette that picks up a tip"

# Risk assessment
low, these are two very contained edge cases
