### PR TITLE
refactor(protocol-engine): Stub out a command to engage a Magnetic Module's magnets

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/__init__.py
@@ -31,6 +31,13 @@ from .aspirate import (
     AspirateCommandType,
 )
 
+from .custom import (
+    Custom,
+    CustomParams,
+    CustomResult,
+    CustomCommandType,
+)
+
 from .dispense import (
     Dispense,
     DispenseParams,
@@ -47,20 +54,20 @@ from .drop_tip import (
     DropTipCommandType,
 )
 
+from .home import (
+    Home,
+    HomeParams,
+    HomeCreate,
+    HomeResult,
+    HomeCommandType,
+)
+
 from .load_labware import (
     LoadLabware,
     LoadLabwareParams,
     LoadLabwareCreate,
     LoadLabwareResult,
     LoadLabwareCommandType,
-)
-
-from .load_pipette import (
-    LoadPipette,
-    LoadPipetteParams,
-    LoadPipetteCreate,
-    LoadPipetteResult,
-    LoadPipetteCommandType,
 )
 
 from .load_module import (
@@ -71,12 +78,20 @@ from .load_module import (
     LoadModuleCommandType,
 )
 
-from .home import (
-    Home,
-    HomeParams,
-    HomeCreate,
-    HomeResult,
-    HomeCommandType,
+from .load_pipette import (
+    LoadPipette,
+    LoadPipetteParams,
+    LoadPipetteCreate,
+    LoadPipetteResult,
+    LoadPipetteCommandType,
+)
+
+from .magnetic_module_engage import (
+    MagneticModuleEngage,
+    MagneticModuleEngageParams,
+    MagneticModuleEngageCreate,
+    MagneticModuleEngageResult,
+    MagneticModuleEngageCommandType,
 )
 
 from .move_relative import (
@@ -86,20 +101,13 @@ from .move_relative import (
     MoveRelativeResult,
     MoveRelativeCommandType,
 )
+
 from .move_to_well import (
     MoveToWell,
     MoveToWellParams,
     MoveToWellCreate,
     MoveToWellResult,
     MoveToWellCommandType,
-)
-
-from .pick_up_tip import (
-    PickUpTip,
-    PickUpTipParams,
-    PickUpTipCreate,
-    PickUpTipResult,
-    PickUpTipCommandType,
 )
 
 from .pause import (
@@ -110,19 +118,20 @@ from .pause import (
     PauseCommandType,
 )
 
+from .pick_up_tip import (
+    PickUpTip,
+    PickUpTipParams,
+    PickUpTipCreate,
+    PickUpTipResult,
+    PickUpTipCommandType,
+)
+
 from .save_position import (
     SavePosition,
     SavePositionParams,
     SavePositionCreate,
     SavePositionResult,
     SavePositionCommandType,
-)
-
-from .custom import (
-    Custom,
-    CustomParams,
-    CustomResult,
-    CustomCommandType,
 )
 
 
@@ -138,30 +147,59 @@ __all__ = [
     "BaseCommand",
     "BaseCommandCreate",
     "CommandStatus",
-    # load labware command models
-    "LoadLabware",
-    "LoadLabwareCreate",
-    "LoadLabwareParams",
-    "LoadLabwareResult",
-    "LoadLabwareCommandType",
-    # load pipette command models
-    "LoadPipette",
-    "LoadPipetteCreate",
-    "LoadPipetteParams",
-    "LoadPipetteResult",
-    "LoadPipetteCommandType",
-    # load module command models
-    "LoadModule",
-    "LoadModuleCreate",
-    "LoadModuleParams",
-    "LoadModuleResult",
-    "LoadModuleCommandType",
+    # aspirate command models
+    "Aspirate",
+    "AspirateCreate",
+    "AspirateParams",
+    "AspirateResult",
+    "AspirateCommandType",
+    # custom command models
+    "Custom",
+    "CustomParams",
+    "CustomResult",
+    "CustomCommandType",
+    # dispense command models
+    "Dispense",
+    "DispenseCreate",
+    "DispenseParams",
+    "DispenseResult",
+    "DispenseCommandType",
+    # drop tip command models
+    "DropTip",
+    "DropTipCreate",
+    "DropTipParams",
+    "DropTipResult",
+    "DropTipCommandType",
     # home command models
     "Home",
     "HomeParams",
     "HomeCreate",
     "HomeResult",
     "HomeCommandType",
+    # load labware command models
+    "LoadLabware",
+    "LoadLabwareCreate",
+    "LoadLabwareParams",
+    "LoadLabwareResult",
+    "LoadLabwareCommandType",
+    # load module command models
+    "LoadModule",
+    "LoadModuleCreate",
+    "LoadModuleParams",
+    "LoadModuleResult",
+    "LoadModuleCommandType",
+    # load pipette command models
+    "LoadPipette",
+    "LoadPipetteCreate",
+    "LoadPipetteParams",
+    "LoadPipetteResult",
+    "LoadPipetteCommandType",
+    # magnetic module engage command models
+    "MagneticModuleEngage",
+    "MagneticModuleEngageCreate",
+    "MagneticModuleEngageParams",
+    "MagneticModuleEngageResult",
+    "MagneticModuleEngageCommandType",
     # move relative command models
     "MoveRelative",
     "MoveRelativeParams",
@@ -174,45 +212,22 @@ __all__ = [
     "MoveToWellParams",
     "MoveToWellResult",
     "MoveToWellCommandType",
-    # pick up tip command models
-    "PickUpTip",
-    "PickUpTipCreate",
-    "PickUpTipParams",
-    "PickUpTipResult",
-    "PickUpTipCommandType",
-    # drop tip command models
-    "DropTip",
-    "DropTipCreate",
-    "DropTipParams",
-    "DropTipResult",
-    "DropTipCommandType",
-    # aspirate command models
-    "Aspirate",
-    "AspirateCreate",
-    "AspirateParams",
-    "AspirateResult",
-    "AspirateCommandType",
-    # dispense command models
-    "Dispense",
-    "DispenseCreate",
-    "DispenseParams",
-    "DispenseResult",
-    "DispenseCommandType",
     # pause command models
     "Pause",
     "PauseParams",
     "PauseCreate",
     "PauseResult",
     "PauseCommandType",
+    # pick up tip command models
+    "PickUpTip",
+    "PickUpTipCreate",
+    "PickUpTipParams",
+    "PickUpTipResult",
+    "PickUpTipCommandType",
     # save position command models
     "SavePosition",
     "SavePositionParams",
     "SavePositionCreate",
     "SavePositionResult",
     "SavePositionCommandType",
-    # custom command models
-    "Custom",
-    "CustomParams",
-    "CustomResult",
-    "CustomCommandType",
 ]

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -10,6 +10,13 @@ from .aspirate import (
     AspirateCommandType,
 )
 
+from .custom import (
+    Custom,
+    CustomParams,
+    CustomResult,
+    CustomCommandType,
+)
+
 from .dispense import (
     Dispense,
     DispenseParams,
@@ -25,6 +32,8 @@ from .drop_tip import (
     DropTipResult,
     DropTipCommandType,
 )
+
+from .home import Home, HomeParams, HomeCreate, HomeResult, HomeCommandType
 
 from .load_labware import (
     LoadLabware,
@@ -50,7 +59,13 @@ from .load_pipette import (
     LoadPipetteCommandType,
 )
 
-from .home import Home, HomeParams, HomeCreate, HomeResult, HomeCommandType
+from .magnetic_module_engage import (
+    MagneticModuleEngage,
+    MagneticModuleEngageParams,
+    MagneticModuleEngageCreate,
+    MagneticModuleEngageResult,
+    MagneticModuleEngageCommandType,
+)
 
 from .move_relative import (
     MoveRelative,
@@ -68,20 +83,20 @@ from .move_to_well import (
     MoveToWellCommandType,
 )
 
-from .pick_up_tip import (
-    PickUpTip,
-    PickUpTipParams,
-    PickUpTipCreate,
-    PickUpTipResult,
-    PickUpTipCommandType,
-)
-
 from .pause import (
     Pause,
     PauseParams,
     PauseCreate,
     PauseResult,
     PauseCommandType,
+)
+
+from .pick_up_tip import (
+    PickUpTip,
+    PickUpTipParams,
+    PickUpTipCreate,
+    PickUpTipResult,
+    PickUpTipCommandType,
 )
 
 from .save_position import (
@@ -92,88 +107,86 @@ from .save_position import (
     SavePositionCommandType,
 )
 
-from .custom import (
-    Custom,
-    CustomParams,
-    CustomResult,
-    CustomCommandType,
-)
-
 Command = Union[
     Aspirate,
+    Custom,
     Dispense,
     DropTip,
+    Home,
     LoadLabware,
     LoadModule,
     LoadPipette,
-    Home,
+    MagneticModuleEngage,
     MoveRelative,
     MoveToWell,
-    PickUpTip,
     Pause,
+    PickUpTip,
     SavePosition,
-    Custom,
 ]
 
 CommandParams = Union[
     AspirateParams,
+    CustomParams,
     DispenseParams,
     DropTipParams,
+    HomeParams,
     LoadLabwareParams,
     LoadModuleParams,
     LoadPipetteParams,
-    HomeParams,
+    MagneticModuleEngageParams,
     MoveRelativeParams,
     MoveToWellParams,
-    PickUpTipParams,
     PauseParams,
+    PickUpTipParams,
     SavePositionParams,
-    CustomParams,
 ]
 
 CommandType = Union[
     AspirateCommandType,
+    CustomCommandType,
     DispenseCommandType,
     DropTipCommandType,
+    HomeCommandType,
     LoadLabwareCommandType,
     LoadModuleCommandType,
     LoadPipetteCommandType,
-    HomeCommandType,
+    MagneticModuleEngageCommandType,
     MoveRelativeCommandType,
     MoveToWellCommandType,
-    PickUpTipCommandType,
     PauseCommandType,
+    PickUpTipCommandType,
     SavePositionCommandType,
-    CustomCommandType,
 ]
 
 CommandCreate = Union[
     AspirateCreate,
     DispenseCreate,
     DropTipCreate,
+    HomeCreate,
     LoadLabwareCreate,
     LoadModuleCreate,
     LoadPipetteCreate,
-    HomeCreate,
+    MagneticModuleEngageCreate,
     MoveRelativeCreate,
     MoveToWellCreate,
-    PickUpTipCreate,
     PauseCreate,
+    PickUpTipCreate,
     SavePositionCreate,
 ]
 
 CommandResult = Union[
     AspirateResult,
+    CustomResult,
     DispenseResult,
     DropTipResult,
+    HomeResult,
     LoadLabwareResult,
     LoadModuleResult,
     LoadPipetteResult,
-    HomeResult,
+    MagneticModuleEngageResult,
     MoveRelativeResult,
     MoveToWellResult,
-    PickUpTipResult,
     PauseResult,
+    PickUpTipResult,
     SavePositionResult,
-    CustomResult,
 ]

--- a/api/src/opentrons/protocol_engine/commands/magnetic_module_engage.py
+++ b/api/src/opentrons/protocol_engine/commands/magnetic_module_engage.py
@@ -1,0 +1,85 @@
+"""Magnetic Module engage command request, result, and implementation models."""
+
+
+from typing import Optional
+from typing_extensions import Literal, Type
+
+from pydantic import BaseModel, Field
+
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+
+MagneticModuleEngageCommandType = Literal["magneticModule/engageMagnet"]
+
+
+class MagneticModuleEngageParams(BaseModel):
+    """Input data to engage a Magnetic Module."""
+
+    moduleId: str = Field(
+        ...,
+        description=(
+            "The ID of the Magnetic Module whose magnets you want to raise,"
+            " from a prior `loadModule` command."
+        ),
+    )
+
+    # todo(mm, 2022-02-17): Using true millimeters differs from the current JSON
+    # protocol schema v6 draft. Ideally, change the v6 draft to match this.
+    engageHeight: float = Field(
+        ...,
+        description=(
+            "How high, in millimeters, to raise the magnets."
+            "\n\n"
+            "Zero is level with the bottom of the labware."
+            " This will be a few millimeters above the magnets' hardware home position."
+            "\n\n"
+            "Units are always true millimeters."
+            " This is unlike certain labware definitions,"
+            " engage commands in the Python Protocol API,"
+            " and engage commands in older versions of the JSON protocol schema."
+            " Take care to convert properly."
+        ),
+    )
+
+
+class MagneticModuleEngageResult(BaseModel):
+    """The result of a Magnetic Module engage command."""
+
+    pass
+
+
+class MagneticModuleEngageImplementation(
+    AbstractCommandImpl[MagneticModuleEngageParams, MagneticModuleEngageResult]
+):
+    """The implementation of a Magnetic Module engage command."""
+
+    async def execute(
+        self, params: MagneticModuleEngageParams
+    ) -> MagneticModuleEngageResult:
+        """Execute a Magnetic Module engage command."""
+        raise NotImplementedError(
+            "Protocol Engine does not yet support engaging magnets."
+        )
+
+
+class MagneticModuleEngage(
+    BaseCommand[MagneticModuleEngageParams, MagneticModuleEngageResult]
+):
+    """A command to engage a Magnetic Module's magnets."""
+
+    commandType: MagneticModuleEngageCommandType = "magneticModule/engageMagnet"
+    params: MagneticModuleEngageParams
+    result: Optional[MagneticModuleEngageResult]
+
+    _ImplementationCls: Type[
+        MagneticModuleEngageImplementation
+    ] = MagneticModuleEngageImplementation
+
+
+class MagneticModuleEngageCreate(BaseCommandCreate[MagneticModuleEngageParams]):
+    """A request to create a Magnetic Module engage command."""
+
+    commandType: MagneticModuleEngageCommandType = "magneticModule/engageMagnet"
+    params: MagneticModuleEngageParams
+
+    _CommandCls: Type[MagneticModuleEngage] = MagneticModuleEngage

--- a/api/tests/opentrons/protocol_engine/commands/test_magnetic_module_engage.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_magnetic_module_engage.py
@@ -1,0 +1,37 @@
+"""Test magnetic module engage commands."""
+
+import pytest
+from decoy import Decoy
+
+from opentrons.protocol_engine.execution import (
+    EquipmentHandler,
+    MovementHandler,
+    PipettingHandler,
+    RunControlHandler,
+)
+from opentrons.protocol_engine.commands.magnetic_module_engage import (
+    MagneticModuleEngageParams,
+    MagneticModuleEngageImplementation,
+)
+
+
+@pytest.mark.xfail(strict=True, raises=NotImplementedError)
+async def test_magnetic_module_engage_implementation(
+    decoy: Decoy,
+    equipment: EquipmentHandler,
+    movement: MovementHandler,
+    pipetting: PipettingHandler,
+    run_control: RunControlHandler,
+) -> None:
+    """It should engage the magnets."""
+    subject = MagneticModuleEngageImplementation(
+        equipment=equipment,
+        movement=movement,
+        pipetting=pipetting,
+        run_control=run_control,
+    )
+    params = MagneticModuleEngageParams(
+        moduleId="module-id",
+        engageHeight=3.14159,
+    )
+    await subject.execute(params=params)


### PR DESCRIPTION
# Overview

This is incremental work towards #9393. It sets the shape of a new Protocol Engine command to engage a Magnetic Module's magnets, which will be our first module control command! 🎉  This will be used by the Python Protocol APIv3 internals, and by the HTTP API.

# Changelog

* Add a `MagneticModuleEngage` command to Protocol Engine, currently stubbed out with a `NotImplementedError`.
* Reorder a bunch of import statements to make them alphabetical. Before, I think we were sort of trying to organize them based on logical group, but as the list of commands gets longer, that gets hard to keep in sync across all these files.

# Review requests

In `magnetic_module_engage.py`:

* Do we like these Python class names?
* Do we like the `commandType` string `"magneticModule/engageMagnet"`? [It's copied directly from JSON protocol schema v6](https://github.com/Opentrons/opentrons/blob/21c939e94ec393193f0c048a2f12763f4b5e8f90/shared-data/protocol/schemas/6.json#L543), but it doesn't exactly match the names I've chosen for these Python classes, which are slightly shorter.
* Are we okay with the specified meaning of `engageHeight`?
    * Measuring from the labware base plane [matches the specification from JSON protocol schema v6](https://github.com/Opentrons/opentrons/blob/21c939e94ec393193f0c048a2f12763f4b5e8f90/shared-data/protocol/schemas/6.json#L549).
       
       This *may* differ from [`magneticModuleEngageHeight` in labware definitions](https://github.com/Opentrons/opentrons/blob/21c939e94ec393193f0c048a2f12763f4b5e8f90/shared-data/labware/schemas/2.json#L157) , which *may* measure from the hardware home point. I'm not sure yet. I have a thread in Slack about this. It looks messy.
    * Uniformly using true millimeters is something that we on CPX have discussed before, but it breaks JSON protocol schema tradition, and will need cooperation from App+UI. I spoke with @shlokamin about this in-person, and it sounds like they're open to it, but I need to do a due-diligence writeup that demonstrates that we can do this without any undue user-facing effects.

# Risk assessment

None. This is currently dead code.