### PR TITLE
refactor(hardware): Move can bindings to monorepo

### DIFF
--- a/api/Pipfile
+++ b/api/Pipfile
@@ -37,4 +37,3 @@ types-setuptools = "==57.0.2"
 opentrons-shared-data = {editable = true, path = "../shared-data/python"}
 opentrons = {editable = true, path = "."}
 opentrons-hardware = {editable = true, path = "./../hardware"}
-opentrons-ot3-firmware = {subdirectory = "python", git = "https://github.com/Opentrons/ot3-firmware.git", branch = "main"}

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -38,12 +38,12 @@ try:
     )
 
     from opentrons_hardware.hardware_control.network import probe
-    from opentrons_ot3_firmware.constants import NodeId
-    from opentrons_ot3_firmware.messages.message_definitions import (
+    from opentrons_hardware.firmware_bindings.constants import NodeId
+    from opentrons_hardware.firmware_bindings.messages.message_definitions import (
         SetupRequest,
         EnableMotorRequest,
     )
-    from opentrons_ot3_firmware.messages.payloads import EmptyPayload
+    from opentrons_hardware.firmware_bindings.messages.payloads import EmptyPayload
 except ModuleNotFoundError:
     pass
 

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -27,25 +27,22 @@ try:
 except (OSError, ModuleNotFoundError):
     aionotify = None
 
-try:
-    from opentrons_hardware.drivers.can_bus import CanMessenger, DriverSettings
-    from opentrons_hardware.drivers.can_bus.abstract_driver import AbstractCanDriver
-    from opentrons_hardware.drivers.can_bus.build import build_driver
-    from opentrons_hardware.hardware_control.move_group_runner import MoveGroupRunner
-    from opentrons_hardware.hardware_control.motion_planning import (
-        Move,
-        Coordinates,
-    )
+from opentrons_hardware.drivers.can_bus import CanMessenger, DriverSettings
+from opentrons_hardware.drivers.can_bus.abstract_driver import AbstractCanDriver
+from opentrons_hardware.drivers.can_bus.build import build_driver
+from opentrons_hardware.hardware_control.move_group_runner import MoveGroupRunner
+from opentrons_hardware.hardware_control.motion_planning import (
+    Move,
+    Coordinates,
+)
 
-    from opentrons_hardware.hardware_control.network import probe
-    from opentrons_hardware.firmware_bindings.constants import NodeId
-    from opentrons_hardware.firmware_bindings.messages.message_definitions import (
-        SetupRequest,
-        EnableMotorRequest,
-    )
-    from opentrons_hardware.firmware_bindings.messages.payloads import EmptyPayload
-except ModuleNotFoundError:
-    pass
+from opentrons_hardware.hardware_control.network import probe
+from opentrons_hardware.firmware_bindings.constants import NodeId
+from opentrons_hardware.firmware_bindings.messages.message_definitions import (
+    SetupRequest,
+    EnableMotorRequest,
+)
+from opentrons_hardware.firmware_bindings.messages.payloads import EmptyPayload
 
 from opentrons.hardware_control.module_control import AttachedModulesControl
 from opentrons.hardware_control.types import BoardRevision, Axis, AionotifyEvent

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -23,14 +23,11 @@ from opentrons.config import pipette_config
 from opentrons_shared_data.pipette import dummy_model_for_name
 from . import ot3utils
 
-try:
-    from opentrons_hardware.firmware_bindings.constants import NodeId
-    from opentrons_hardware.hardware_control.motion_planning import (
-        Move,
-        Coordinates,
-    )
-except ModuleNotFoundError:
-    pass
+from opentrons_hardware.firmware_bindings.constants import NodeId
+from opentrons_hardware.hardware_control.motion_planning import (
+    Move,
+    Coordinates,
+)
 
 from opentrons.hardware_control.module_control import AttachedModulesControl
 from opentrons.hardware_control import modules

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -24,7 +24,7 @@ from opentrons_shared_data.pipette import dummy_model_for_name
 from . import ot3utils
 
 try:
-    from opentrons_ot3_firmware.constants import NodeId
+    from opentrons_hardware.firmware_bindings.constants import NodeId
     from opentrons_hardware.hardware_control.motion_planning import (
         Move,
         Coordinates,

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -4,7 +4,7 @@ from typing_extensions import Literal
 from opentrons.config.types import OT3MotionSettings, GantryLoad
 
 try:
-    from opentrons_ot3_firmware.constants import NodeId
+    from opentrons_hardware.firmware_bindings.constants import NodeId
     from opentrons_hardware.hardware_control.motion_planning import (
         AxisConstraints,
         AxisNames,

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -3,25 +3,22 @@ from typing import Dict, Iterable, List, Tuple
 from typing_extensions import Literal
 from opentrons.config.types import OT3MotionSettings, GantryLoad
 
-try:
-    from opentrons_hardware.firmware_bindings.constants import NodeId
-    from opentrons_hardware.hardware_control.motion_planning import (
-        AxisConstraints,
-        AxisNames,
-        AXIS_NAMES,
-        Coordinates,
-        Move,
-    )
-    from opentrons_hardware.hardware_control.motion_planning.move_utils import (
-        unit_vector_multiplication,
-    )
-    from opentrons_hardware.hardware_control.motion import (
-        create_step,
-        NodeIdMotionValues,
-        MoveGroup,
-    )
-except ImportError:
-    pass
+from opentrons_hardware.firmware_bindings.constants import NodeId
+from opentrons_hardware.hardware_control.motion_planning import (
+    AxisConstraints,
+    AxisNames,
+    AXIS_NAMES,
+    Coordinates,
+    Move,
+)
+from opentrons_hardware.hardware_control.motion_planning.move_utils import (
+    unit_vector_multiplication,
+)
+from opentrons_hardware.hardware_control.motion import (
+    create_step,
+    NodeIdMotionValues,
+    MoveGroup,
+)
 
 
 # TODO: These methods exist to defer uses of NodeId to inside

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -4,7 +4,7 @@ from opentrons.hardware_control.backends import OT3Controller
 from opentrons_hardware.drivers.can_bus import CanMessenger
 from opentrons.config.types import OT3Config
 from opentrons.config.robot_configs import build_config_ot3
-from opentrons_ot3_firmware.constants import NodeId
+from opentrons_hardware.firmware_bindings.constants import NodeId
 from opentrons_hardware.drivers.can_bus.abstract_driver import AbstractCanDriver
 
 

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_utils.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_utils.py
@@ -1,6 +1,6 @@
 from opentrons_hardware.hardware_control.motion_planning import Coordinates, Move
 from opentrons.hardware_control.backends import ot3utils
-from opentrons_ot3_firmware.constants import NodeId
+from opentrons_hardware.firmware_bindings.constants import NodeId
 
 
 def test_create_step():

--- a/g-code-testing/Pipfile
+++ b/g-code-testing/Pipfile
@@ -8,6 +8,7 @@ opentrons = {editable = true, path = "./../api"}
 notify-server = {editable = true, path = "./../notify-server"}
 robot-server = {editable = true, path = "./../robot-server"}
 opentrons-shared-data = {editable = true, path = "../shared-data/python"}
+opentrons_hardware = {editable = true, path = "../hardware"}
 g-code-testing = {editable = true, path = "."}
 anyio = "==3.3.0"
 pydantic = "==1.8.2"

--- a/g-code-testing/Pipfile.lock
+++ b/g-code-testing/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "87f356eb845f1c2f0cb132a629cb017189e82d324248fd766bf78ca572dc65c2"
+            "sha256": "bb67ecef87e1d251e32d74941eecdc0d2aa6cfa78a0d4d01160e7924cdd10b71"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,14 @@
         ]
     },
     "default": {
+        "aenum": {
+            "hashes": [
+                "sha256:07ea89f43d78b3d5997b32b8d5b0ec3e5be17b3e05b7bac0154b8c484a4aeff5",
+                "sha256:859fe994719e6b5e39f15f73acd84e08b4e57dc642373b177a5fa6646798706a",
+                "sha256:8dbe15f446eb8264b788dfeca163fb0a043d408d212152397dc11377b851e4ae"
+            ],
+            "version": "==3.1.8"
+        },
         "aionotify": {
             "hashes": [
                 "sha256:385e1becfaac2d9f4326673033d53912ef9565b6febdedbec593ee966df392c6",
@@ -85,11 +93,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:899e2a40a8c4a1aec681feef45733de8a6c58f3f6a0dbed2eb6574b4387a77b6",
-                "sha256:951f0d8a5b7260e9db5e41d429285b5f451e928479f19d80818878527d36e95e"
+                "sha256:175f4ee440a0317f6e8d81b7f8d4869f93316170a65ad2b007d2929186c8052c",
+                "sha256:e0bc84ff355328a4adfc5240c4f211e0ab386f80aa640d1b11f0618a1d282094"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==4.10.1"
+            "version": "==4.11.1"
         },
         "jsonschema": {
             "hashes": [
@@ -141,6 +149,10 @@
         "opentrons": {
             "editable": true,
             "path": "./../api"
+        },
+        "opentrons-hardware": {
+            "editable": true,
+            "path": "./../hardware"
         },
         "opentrons-shared-data": {
             "editable": true,
@@ -207,6 +219,13 @@
                 "sha256:c4451db6ba391ca6ca299fb3ec7bae67a5c55dde170964c7a14ceefec02f2cf0"
             ],
             "version": "==3.5"
+        },
+        "python-can": {
+            "hashes": [
+                "sha256:2d3c223b7adc4dd46ce258d4a33b7e0dbb6c339e002faa40ee4a69d5fdce9449"
+            ],
+            "markers": "python_version >= '2.7'",
+            "version": "==3.3.4"
         },
         "python-dotenv": {
             "hashes": [
@@ -292,6 +311,7 @@
             "hashes": [
                 "sha256:fd0e44bf70eadae45aadc292cb0a7eb5b0b6372cd1b391228047d33895db83e7"
             ],
+            "index": "pypi",
             "markers": "sys_platform == 'linux'",
             "version": "==234"
         },
@@ -310,6 +330,63 @@
                 "sha256:45ad7dfaaa7d55cab4cd1e85e03f27e9d60bc067ddc59db52a2b0aeca8870292"
             ],
             "version": "==0.14.0"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:086218a72ec7d986a3eddb7707c8c4526d677c7b35e355875a0fe2918b059179",
+                "sha256:0877fe981fd76b183711d767500e6b3111378ed2043c145e21816ee589d91096",
+                "sha256:0a017a667d1f7411816e4bf214646d0ad5b1da2c1ea13dec6c162736ff25a374",
+                "sha256:0cb23d36ed03bf46b894cfec777eec754146d68429c30431c99ef28482b5c1df",
+                "sha256:1fea9cd438686e6682271d36f3481a9f3636195578bab9ca3382e2f5f01fc185",
+                "sha256:220a869982ea9023e163ba915077816ca439489de6d2c09089b219f4e11b6785",
+                "sha256:25b1b1d5df495d82be1c9d2fad408f7ce5ca8a38085e2da41bb63c914baadff7",
+                "sha256:2dded5496e8f1592ec27079b28b6ad2a1ef0b9296d270f77b8e4a3a796cf6909",
+                "sha256:2ebdde19cd3c8cdf8df3fc165bc7827334bc4e353465048b36f7deeae8ee0918",
+                "sha256:43e69ffe47e3609a6aec0fe723001c60c65305784d964f5007d5b4fb1bc6bf33",
+                "sha256:46f7f3af321a573fc0c3586612db4decb7eb37172af1bc6173d81f5b66c2e068",
+                "sha256:47f0a183743e7f71f29e4e21574ad3fa95676136f45b91afcf83f6a050914829",
+                "sha256:498e6217523111d07cd67e87a791f5e9ee769f9241fcf8a379696e25806965af",
+                "sha256:4b9c458732450ec42578b5642ac53e312092acf8c0bfce140ada5ca1ac556f79",
+                "sha256:51799ca950cfee9396a87f4a1240622ac38973b6df5ef7a41e7f0b98797099ce",
+                "sha256:5601f44a0f38fed36cc07db004f0eedeaadbdcec90e4e90509480e7e6060a5bc",
+                "sha256:5f223101f21cfd41deec8ce3889dc59f88a59b409db028c469c9b20cfeefbe36",
+                "sha256:610f5f83dd1e0ad40254c306f4764fcdc846641f120c3cf424ff57a19d5f7ade",
+                "sha256:6a03d9917aee887690aa3f1747ce634e610f6db6f6b332b35c2dd89412912bca",
+                "sha256:705e2af1f7be4707e49ced9153f8d72131090e52be9278b5dbb1498c749a1e32",
+                "sha256:766b32c762e07e26f50d8a3468e3b4228b3736c805018e4b0ec8cc01ecd88125",
+                "sha256:77416e6b17926d953b5c666a3cb718d5945df63ecf922af0ee576206d7033b5e",
+                "sha256:778fd096ee96890c10ce96187c76b3e99b2da44e08c9e24d5652f356873f6709",
+                "sha256:78dea98c81915bbf510eb6a3c9c24915e4660302937b9ae05a0947164248020f",
+                "sha256:7dd215e4e8514004c8d810a73e342c536547038fb130205ec4bba9f5de35d45b",
+                "sha256:7dde79d007cd6dfa65afe404766057c2409316135cb892be4b1c768e3f3a11cb",
+                "sha256:81bd7c90d28a4b2e1df135bfbd7c23aee3050078ca6441bead44c42483f9ebfb",
+                "sha256:85148f4225287b6a0665eef08a178c15097366d46b210574a658c1ff5b377489",
+                "sha256:865c0b50003616f05858b22174c40ffc27a38e67359fa1495605f96125f76640",
+                "sha256:87883690cae293541e08ba2da22cacaae0a092e0ed56bbba8d018cc486fbafbb",
+                "sha256:8aab36778fa9bba1a8f06a4919556f9f8c7b33102bd71b3ab307bb3fecb21851",
+                "sha256:8c73c1a2ec7c98d7eaded149f6d225a692caa1bd7b2401a14125446e9e90410d",
+                "sha256:936503cb0a6ed28dbfa87e8fcd0a56458822144e9d11a49ccee6d9a8adb2ac44",
+                "sha256:944b180f61f5e36c0634d3202ba8509b986b5fbaf57db3e94df11abee244ba13",
+                "sha256:96b81ae75591a795d8c90edc0bfaab44d3d41ffc1aae4d994c5aa21d9b8e19a2",
+                "sha256:981da26722bebb9247a0601e2922cedf8bb7a600e89c852d063313102de6f2cb",
+                "sha256:ae9de71eb60940e58207f8e71fe113c639da42adb02fb2bcbcaccc1ccecd092b",
+                "sha256:b73d4b78807bd299b38e4598b8e7bd34ed55d480160d2e7fdaabd9931afa65f9",
+                "sha256:d4a5f6146cfa5c7ba0134249665acd322a70d1ea61732723c7d3e8cc0fa80755",
+                "sha256:dd91006848eb55af2159375134d724032a2d1d13bcc6f81cd8d3ed9f2b8e846c",
+                "sha256:e05e60ff3b2b0342153be4d1b597bbcfd8330890056b9619f4ad6b8d5c96a81a",
+                "sha256:e6906d6f48437dfd80464f7d7af1740eadc572b9f7a4301e7dd3d65db285cacf",
+                "sha256:e92d0d4fa68ea0c02d39f1e2f9cb5bc4b4a71e8c442207433d8db47ee79d7aa3",
+                "sha256:e94b7d9deaa4cc7bac9198a58a7240aaf87fe56c6277ee25fa5b3aa1edebd229",
+                "sha256:ea3e746e29d4000cd98d572f3ee2a6050a4f784bb536f4ac1f035987fc1ed83e",
+                "sha256:ec7e20258ecc5174029a0f391e1b948bf2906cd64c198a9b8b281b811cbc04de",
+                "sha256:ec9465dd69d5657b5d2fa6133b3e1e989ae27d29471a672416fd729b429eb554",
+                "sha256:f122ccd12fdc69628786d0c947bdd9cb2733be8f800d88b5a37c57f1f1d73c10",
+                "sha256:f99c0489258086308aad4ae57da9e8ecf9e1f3f30fa35d5e170b4d4896554d80",
+                "sha256:f9c51d9af9abb899bd34ace878fbec8bf357b3194a10c4e8e0a25512826ef056",
+                "sha256:fd76c47f20984b43d93de9a82011bb6e5f8325df6c9ed4d8310029a55fa361ea"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.13.3"
         },
         "wsproto": {
             "hashes": [
@@ -486,11 +563,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:2842d8f5e82a1f6aa437380934d5e1cd4fcf2003b06fed6940769c164a480a45",
-                "sha256:98398a9d69ee80548c762ba991a4728bfc3836768ed226b3945908d1a688371c"
+                "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
+                "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==2.0.11"
+            "markers": "python_full_version >= '3.5.0'",
+            "version": "==2.0.12"
         },
         "click": {
             "hashes": [
@@ -677,11 +754,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:899e2a40a8c4a1aec681feef45733de8a6c58f3f6a0dbed2eb6574b4387a77b6",
-                "sha256:951f0d8a5b7260e9db5e41d429285b5f451e928479f19d80818878527d36e95e"
+                "sha256:175f4ee440a0317f6e8d81b7f8d4869f93316170a65ad2b007d2929186c8052c",
+                "sha256:e0bc84ff355328a4adfc5240c4f211e0ab386f80aa640d1b11f0618a1d282094"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==4.10.1"
+            "version": "==4.11.1"
         },
         "iniconfig": {
             "hashes": [
@@ -830,11 +907,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:1d7385c7db91728b83efd0ca99a5afb296cab9d0ed8313a45ed8ba17967ecfca",
-                "sha256:440633ddfebcc36264232365d7840a970e75e1018d15b4327d11f91909045fda"
+                "sha256:30671902352e97b1eafd74ade8e4a694782bd3471685e78c32d0fdfd3aa7e7bb",
+                "sha256:8ec11dfba28ecc0715eb5fb0147a87b1bf325f349f3da9aab2cd6b50b96b692b"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.4.1"
+            "version": "==2.5.0"
         },
         "pluggy": {
             "hashes": [
@@ -965,11 +1042,11 @@
         },
         "tomli": {
             "hashes": [
-                "sha256:b5bde28da1fed24b9bd1d4d2b8cba62300bfb4ec9a6187a957e8ddb9434c5224",
-                "sha256:c292c34f58502a1eb2bbb9f5bbc9a5ebc37bee10ffb8c2d6bbdfa8eb13cc14e1"
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.0.0"
+            "version": "==2.0.1"
         },
         "typed-ast": {
             "hashes": [

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -100,10 +100,6 @@ format:
 dev:
 	echo "Nothing here yet"
 
-.PHONY: opentrons_ot3_firmware_sdist
-opentrons_ot3_firmware_sdist: Pipfile.lock
-	mkdir -p dist
-	$(python) ../scripts/bundle_installed_package.py opentrons_ot3_firmware dist
 
 .PHONY: push-no-restart
 push-no-restart: wheel
@@ -114,10 +110,8 @@ push: push-no-restart
 	$(call restart-service,$(host),$(br_ssh_key),$(ssh_opts),"jupyter-notebook opentrons-robot-server")
 
 .PHONY: push-no-restart-ot3
-push-no-restart-ot3: sdist Pipfile.lock opentrons_ot3_firmware_sdist
-	echo $(sdist_file) $(wildcard dist/opentrons_ot3_firmware-*.tar.gz)
+push-no-restart-ot3: sdist Pipfile.lock
 	$(call push-python-sdist,$(host),,$(ssh_opts),$(sdist_file),/opt/opentrons-robot-server,"opentrons_hardware")
-	$(call push-python-sdist,$(host),,$(ssh_opts),$(wildcard dist/opentrons_ot3_firmware-*.tar.gz),/opt/opentrons-robot-server,"opentrons_ot3_firmware",,dist)
 
 .PHONY: push-ot3
 push-ot3: push-no-restart-ot3

--- a/hardware/Pipfile
+++ b/hardware/Pipfile
@@ -7,7 +7,6 @@ name = "pypi"
 python-can = "==3.3.4"
 pyserial = "==3.5"
 typing-extensions = "==3.10.0.0"
-opentrons-ot3-firmware = {subdirectory = "python", git = "https://github.com/Opentrons/ot3-firmware.git", ref = "main"}
 numpy = "==1.17.4"
 pydantic = "==1.8.2"
 

--- a/hardware/opentrons_hardware/drivers/can_bus/__init__.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/__init__.py
@@ -2,12 +2,16 @@
 
 from .driver import CanDriver
 from .can_messenger import CanMessenger
-from opentrons_ot3_firmware.message import CanMessage
-from opentrons_ot3_firmware.arbitration_id import (
+from opentrons_hardware.firmware_bindings.message import CanMessage
+from opentrons_hardware.firmware_bindings.arbitration_id import (
     ArbitrationId,
     ArbitrationIdParts,
 )
-from opentrons_ot3_firmware.constants import NodeId, FunctionCode, MessageId
+from opentrons_hardware.firmware_bindings.constants import (
+    NodeId,
+    FunctionCode,
+    MessageId,
+)
 from .settings import DriverSettings
 
 

--- a/hardware/opentrons_hardware/drivers/can_bus/abstract_driver.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/abstract_driver.py
@@ -1,7 +1,7 @@
 """The can bus transport."""
 from __future__ import annotations
 from abc import ABC, abstractmethod
-from opentrons_ot3_firmware import CanMessage
+from opentrons_hardware.firmware_bindings import CanMessage
 
 
 class AbstractCanDriver(ABC):

--- a/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
@@ -6,18 +6,18 @@ from typing import List, Optional, Callable, Tuple
 import logging
 
 from opentrons_hardware.drivers.can_bus.abstract_driver import AbstractCanDriver
-from opentrons_ot3_firmware.arbitration_id import (
+from opentrons_hardware.firmware_bindings.arbitration_id import (
     ArbitrationId,
     ArbitrationIdParts,
 )
-from opentrons_ot3_firmware.message import CanMessage
-from opentrons_ot3_firmware.constants import NodeId, MessageId
+from opentrons_hardware.firmware_bindings.message import CanMessage
+from opentrons_hardware.firmware_bindings.constants import NodeId, MessageId
 
-from opentrons_ot3_firmware.messages.messages import (
+from opentrons_hardware.firmware_bindings.messages.messages import (
     MessageDefinition,
     get_definition,
 )
-from opentrons_ot3_firmware.utils import BinarySerializableException
+from opentrons_hardware.firmware_bindings.utils import BinarySerializableException
 
 log = logging.getLogger(__name__)
 

--- a/hardware/opentrons_hardware/drivers/can_bus/driver.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/driver.py
@@ -7,8 +7,8 @@ from typing import Optional
 
 from can import Notifier, Bus, AsyncBufferedReader, Message
 
-from opentrons_ot3_firmware.arbitration_id import ArbitrationId
-from opentrons_ot3_firmware.message import CanMessage
+from opentrons_hardware.firmware_bindings.arbitration_id import ArbitrationId
+from opentrons_hardware.firmware_bindings.message import CanMessage
 from .errors import ErrorFrameCanError
 from .abstract_driver import AbstractCanDriver
 

--- a/hardware/opentrons_hardware/drivers/can_bus/socket_driver.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/socket_driver.py
@@ -6,7 +6,7 @@ import struct
 import asyncio
 
 from . import ArbitrationId
-from opentrons_ot3_firmware import CanMessage
+from opentrons_hardware.firmware_bindings import CanMessage
 from .abstract_driver import AbstractCanDriver
 
 

--- a/hardware/opentrons_hardware/firmware_bindings/__init__.py
+++ b/hardware/opentrons_hardware/firmware_bindings/__init__.py
@@ -1,0 +1,18 @@
+"""bindings and generation for ot3 firmware canbus messages."""
+
+from .message import CanMessage
+from .arbitration_id import (
+    ArbitrationId,
+    ArbitrationIdParts,
+)
+from .constants import NodeId, FunctionCode, MessageId, ErrorCode
+
+__all__ = [
+    "CanMessage",
+    "ArbitrationId",
+    "NodeId",
+    "FunctionCode",
+    "MessageId",
+    "ArbitrationIdParts",
+    "ErrorCode",
+]

--- a/hardware/opentrons_hardware/firmware_bindings/arbitration_id.py
+++ b/hardware/opentrons_hardware/firmware_bindings/arbitration_id.py
@@ -1,0 +1,67 @@
+"""Can bus arbitration id.
+
+This file is used as a source for code generation, which does not run in a venv by
+default. Please do not unconditionally import things outside the python standard
+library.
+"""
+from __future__ import annotations
+import ctypes
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing_extensions import Final
+
+NODE_ID_BITS: Final[int] = 7
+FUNCTION_CODE_BITS: Final[int] = 4
+MESSAGE_ID_BITS: Final[int] = 11
+
+
+class ArbitrationIdParts(ctypes.Structure):
+    """A bit field of the arbitration id parts."""
+
+    _fields_ = (
+        ("function_code", ctypes.c_uint, FUNCTION_CODE_BITS),
+        ("node_id", ctypes.c_uint, NODE_ID_BITS),
+        ("originating_node_id", ctypes.c_uint, NODE_ID_BITS),
+        ("message_id", ctypes.c_uint, MESSAGE_ID_BITS),
+        ("padding", ctypes.c_uint, 3),
+    )
+
+    def __eq__(self, other: object) -> bool:
+        """Check equality."""
+        if isinstance(other, ArbitrationIdParts):
+            return bool(
+                other.function_code == self.function_code
+                and other.node_id == self.node_id
+                and other.originating_node_id == self.originating_node_id
+                and other.message_id == self.message_id
+            )
+        return False
+
+    def __repr__(self) -> str:
+        """Return string representation of class."""
+        return (
+            f"function_code: 0x{self.function_code:x}, "
+            f"node_id: 0x{self.node_id:x}, "
+            f"originating_node_id: 0x{self.originating_node_id:x}, "
+            f"message_id: 0x{self.message_id:x}"
+        )
+
+
+class ArbitrationId(ctypes.Union):
+    """Arbitration id union."""
+
+    _fields_ = (
+        ("parts", ArbitrationIdParts),
+        ("id", ctypes.c_uint32),
+    )
+
+    def __eq__(self, other: object) -> bool:
+        """Check equality."""
+        if isinstance(other, ArbitrationId):
+            return bool(other.id == self.id)
+        return False
+
+    def __repr__(self) -> str:
+        """Return string representation of class."""
+        return f"id: 0x{self.id:x}, " f"parts: {self.parts}"

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -1,0 +1,140 @@
+"""Constants for can bus.
+
+This file is used as a source for code generation, which does not run in a venv
+by default. Please do not unconditionally import things outside the python standard
+library.
+"""
+from enum import Enum, unique
+
+
+@unique
+class NodeId(int, Enum):
+    """Can bus arbitration id node id."""
+
+    broadcast = 0x00
+    host = 0x10
+    pipette_left = 0x60
+    pipette_right = 0x70
+    gantry_x = 0x30
+    gantry_y = 0x40
+    head = 0x50
+    head_l = 0x51
+    head_r = 0x52
+    pipette_left_bootloader = pipette_left | 0xF
+    pipette_right_bootloader = pipette_right | 0xF
+    gantry_x_bootloader = gantry_x | 0xF
+    gantry_y_bootloader = gantry_y | 0xF
+    head_bootloader = head | 0xF
+
+
+@unique
+class FunctionCode(int, Enum):
+    """Can bus arbitration id function code."""
+
+    network_management = 0x0
+    sync = 0x1
+    error = 0x2
+    command = 0x3
+    status = 0x4
+    parameters = 0x5
+    bootloader = 0x6
+    heartbeat = 0x7
+
+
+@unique
+class MessageId(int, Enum):
+    """Can bus arbitration id message id."""
+
+    heartbeat_request = 0x3FF
+    heartbeat_response = 0x3FE
+
+    device_info_request = 0x302
+    device_info_response = 0x303
+
+    stop_request = 0x00
+
+    get_status_request = 0x01
+    get_status_response = 0x05
+
+    enable_motor_request = 0x06
+    disable_motor_request = 0x07
+
+    move_request = 0x10
+
+    setup_request = 0x02
+
+    write_eeprom = 0x201
+    read_eeprom_request = 0x202
+    read_eeprom_response = 0x203
+
+    add_move_request = 0x15
+    get_move_group_request = 0x16
+    get_move_group_response = 0x17
+    execute_move_group_request = 0x18
+    clear_all_move_groups_request = 0x19
+    move_completed = 0x13
+
+    set_motion_constraints = 0x101
+    get_motion_constraints_request = 0x102
+    get_motion_constraints_response = 0x103
+
+    write_motor_driver_register_request = 0x30
+    read_motor_driver_register_request = 0x31
+    read_motor_driver_register_response = 0x32
+
+    read_presence_sensing_voltage_request = 0x600
+    read_presence_sensing_voltage_response = 0x601
+
+    attached_tools_request = 0x700
+    tools_detected_notification = 0x701
+
+    fw_update_initiate = 0x60
+    fw_update_data = 0x61
+    fw_update_data_ack = 0x62
+    fw_update_complete = 0x63
+    fw_update_complete_ack = 0x64
+    fw_update_status_request = 0x65
+    fw_update_status_response = 0x66
+
+    limit_sw_request = 0x08
+    limit_sw_response = 0x09
+
+    read_sensor_request = 0x82
+    write_sensor_request = 0x83
+    baseline_sensor_request = 0x84
+    read_sensor_response = 0x85
+
+
+@unique
+class ErrorCode(int, Enum):
+    """Common error codes."""
+
+    ok = 0x00
+    invalid_size = 0x01
+    bad_checksum = 0x02
+    invalid_byte_count = 0x03
+    invalid_input = 0x04
+    hardware = 0x05
+
+
+@unique
+class ToolType(int, Enum):
+    """Tool types detected on Head."""
+
+    undefined_tool = 0x00
+    pipette_96_chan = 0x01
+    pipette_384_chan = 0x02
+    pipette_single_chan = 0x03
+    pipette_multi_chan = 0x04
+    gripper = 0x05
+    nothing_attached = 0x06
+
+
+@unique
+class SensorType(int, Enum):
+    """Sensor types available."""
+
+    tip = 0x00
+    capacitive = 0x01
+    humidity = 0x02
+    temperature = 0x03

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -103,6 +103,8 @@ class MessageId(int, Enum):
     write_sensor_request = 0x83
     baseline_sensor_request = 0x84
     read_sensor_response = 0x85
+    set_sensor_threshold_request = 0x86
+    set_sensor_threshold_response = 0x87
 
 
 @unique

--- a/hardware/opentrons_hardware/firmware_bindings/message.py
+++ b/hardware/opentrons_hardware/firmware_bindings/message.py
@@ -1,0 +1,13 @@
+"""Can message."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from .arbitration_id import ArbitrationId
+
+
+@dataclass(frozen=True)
+class CanMessage:
+    """A can message."""
+
+    arbitration_id: ArbitrationId
+    data: bytes

--- a/hardware/opentrons_hardware/firmware_bindings/messages/__init__.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/__init__.py
@@ -1,0 +1,7 @@
+"""Can bus message definitions."""
+from .messages import MessageDefinition, get_definition
+
+__all__ = [
+    "MessageDefinition",
+    "get_definition",
+]

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -1,0 +1,352 @@
+"""Definition of CAN messages."""
+from dataclasses import dataclass
+from typing import Type
+
+from typing_extensions import Literal
+
+from ..utils import BinarySerializable
+from ..constants import MessageId
+from . import payloads
+
+
+@dataclass
+class HeartbeatRequest:  # noqa: D101
+    payload: payloads.EmptyPayload
+    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+    message_id: Literal[MessageId.heartbeat_request] = MessageId.heartbeat_request
+
+
+@dataclass
+class HeartbeatResponse:  # noqa: D101
+    payload: payloads.EmptyPayload
+    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+    message_id: Literal[MessageId.heartbeat_response] = MessageId.heartbeat_response
+
+
+@dataclass
+class DeviceInfoRequest:  # noqa: D101
+    payload: payloads.EmptyPayload
+    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+    message_id: Literal[MessageId.device_info_request] = MessageId.device_info_request
+
+
+@dataclass
+class DeviceInfoResponse:  # noqa: D101
+    payload: payloads.DeviceInfoResponsePayload
+    payload_type: Type[BinarySerializable] = payloads.DeviceInfoResponsePayload
+    message_id: Literal[MessageId.device_info_response] = MessageId.device_info_response
+
+
+@dataclass
+class StopRequest:  # noqa: D101
+    payload: payloads.EmptyPayload
+    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+    message_id: Literal[MessageId.stop_request] = MessageId.stop_request
+
+
+@dataclass
+class GetStatusRequest:  # noqa: D101
+    payload: payloads.EmptyPayload
+    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+    message_id: Literal[MessageId.get_status_request] = MessageId.get_status_request
+
+
+@dataclass
+class EnableMotorRequest:  # noqa: D101
+    payload: payloads.EmptyPayload
+    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+    message_id: Literal[MessageId.enable_motor_request] = MessageId.enable_motor_request
+
+
+@dataclass
+class DisableMotorRequest:  # noqa: D101
+    payload: payloads.EmptyPayload
+    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+    message_id: Literal[
+        MessageId.disable_motor_request
+    ] = MessageId.disable_motor_request
+
+
+@dataclass
+class GetStatusResponse:  # noqa: D101
+    payload: payloads.GetStatusResponsePayload
+    payload_type: Type[BinarySerializable] = payloads.GetStatusResponsePayload
+    message_id: Literal[MessageId.get_status_response] = MessageId.get_status_response
+
+
+@dataclass
+class MoveRequest:  # noqa: D101
+    payload: payloads.MoveRequestPayload
+    payload_type: Type[BinarySerializable] = payloads.MoveRequestPayload
+    message_id: Literal[MessageId.move_request] = MessageId.move_request
+
+
+@dataclass
+class SetupRequest:  # noqa: D101
+    payload: payloads.EmptyPayload
+    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+    message_id: Literal[MessageId.setup_request] = MessageId.setup_request
+
+
+@dataclass
+class WriteToEEPromRequest:  # noqa: D101
+    payload: payloads.WriteToEEPromRequestPayload
+    payload_type: Type[BinarySerializable] = payloads.WriteToEEPromRequestPayload
+    message_id: Literal[MessageId.write_eeprom] = MessageId.write_eeprom
+
+
+@dataclass
+class ReadFromEEPromRequest:  # noqa: D101
+    payload: payloads.EmptyPayload
+    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+    message_id: Literal[MessageId.read_eeprom_request] = MessageId.read_eeprom_request
+
+
+@dataclass
+class ReadFromEEPromResponse:  # noqa: D101
+    payload: payloads.ReadFromEEPromResponsePayload
+    payload_type: Type[BinarySerializable] = payloads.ReadFromEEPromResponsePayload
+    message_id: Literal[MessageId.read_eeprom_response] = MessageId.read_eeprom_response
+
+
+@dataclass
+class AddLinearMoveRequest:  # noqa: D101
+    payload: payloads.AddLinearMoveRequestPayload
+    payload_type: Type[BinarySerializable] = payloads.AddLinearMoveRequestPayload
+    message_id: Literal[MessageId.add_move_request] = MessageId.add_move_request
+
+
+@dataclass
+class GetMoveGroupRequest:  # noqa: D101
+    payload: payloads.MoveGroupRequestPayload
+    payload_type: Type[BinarySerializable] = payloads.MoveGroupRequestPayload
+    message_id: Literal[
+        MessageId.get_move_group_request
+    ] = MessageId.get_move_group_request
+
+
+@dataclass
+class GetMoveGroupResponse:  # noqa: D101
+    payload: payloads.GetMoveGroupResponsePayload
+    payload_type: Type[BinarySerializable] = payloads.GetMoveGroupResponsePayload
+    message_id: Literal[
+        MessageId.get_move_group_response
+    ] = MessageId.get_move_group_response
+
+
+@dataclass
+class ExecuteMoveGroupRequest:  # noqa: D101
+    payload: payloads.ExecuteMoveGroupRequestPayload
+    payload_type: Type[BinarySerializable] = payloads.ExecuteMoveGroupRequestPayload
+    message_id: Literal[
+        MessageId.execute_move_group_request
+    ] = MessageId.execute_move_group_request
+
+
+@dataclass
+class ClearAllMoveGroupsRequest:  # noqa: D101
+    payload: payloads.EmptyPayload
+    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+    message_id: Literal[
+        MessageId.clear_all_move_groups_request
+    ] = MessageId.clear_all_move_groups_request
+
+
+@dataclass
+class MoveCompleted:  # noqa: D101
+    payload: payloads.MoveCompletedPayload
+    payload_type: Type[BinarySerializable] = payloads.MoveCompletedPayload
+    message_id: Literal[MessageId.move_completed] = MessageId.move_completed
+
+
+@dataclass
+class SetMotionConstraints:  # noqa: D101
+    payload: payloads.MotionConstraintsPayload
+    payload_type: Type[BinarySerializable] = payloads.MotionConstraintsPayload
+    message_id: Literal[
+        MessageId.set_motion_constraints
+    ] = MessageId.set_motion_constraints
+
+
+@dataclass
+class GetMotionConstraintsRequest:  # noqa: D101
+    payload: payloads.EmptyPayload
+    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+    message_id: Literal[
+        MessageId.get_motion_constraints_request
+    ] = MessageId.get_motion_constraints_request
+
+
+@dataclass
+class GetMotionConstraintsResponse:  # noqa: D101
+    payload: payloads.MotionConstraintsPayload
+    payload_type: Type[BinarySerializable] = payloads.MotionConstraintsPayload
+    message_id: Literal[
+        MessageId.get_motion_constraints_response
+    ] = MessageId.get_motion_constraints_response
+
+
+@dataclass
+class WriteMotorDriverRegister:  # noqa: D101
+    payload: payloads.MotorDriverRegisterDataPayload
+    payload_type: Type[BinarySerializable] = payloads.MotorDriverRegisterDataPayload
+    message_id: Literal[
+        MessageId.write_motor_driver_register_request
+    ] = MessageId.write_motor_driver_register_request
+
+
+@dataclass
+class ReadMotorDriverRequest:  # noqa: D101
+    payload: payloads.MotorDriverRegisterPayload
+    payload_type: Type[BinarySerializable] = payloads.MotorDriverRegisterPayload
+    message_id: Literal[
+        MessageId.read_motor_driver_register_request
+    ] = MessageId.read_motor_driver_register_request
+
+
+@dataclass
+class ReadMotorDriverResponse:  # noqa: D101
+    payload: payloads.ReadMotorDriverRegisterResponsePayload
+    payload_type: Type[
+        BinarySerializable
+    ] = payloads.ReadMotorDriverRegisterResponsePayload
+    message_id: Literal[
+        MessageId.read_motor_driver_register_response
+    ] = MessageId.read_motor_driver_register_response
+
+
+@dataclass
+class ReadPresenceSensingVoltageRequest:  # noqa: D101
+    payload: payloads.EmptyPayload
+    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+    message_id: Literal[
+        MessageId.read_presence_sensing_voltage_request
+    ] = MessageId.read_presence_sensing_voltage_request
+
+
+@dataclass
+class ReadPresenceSensingVoltageResponse:  # noqa: D101
+    payload: payloads.ReadPresenceSensingVoltageResponsePayload
+    payload_type: Type[
+        BinarySerializable
+    ] = payloads.ReadPresenceSensingVoltageResponsePayload
+    message_id: Literal[
+        MessageId.read_presence_sensing_voltage_response
+    ] = MessageId.read_presence_sensing_voltage_response
+
+
+@dataclass
+class PushToolsDetectedNotification:  # noqa: D101
+    payload: payloads.ToolsDetectedNotificationPayload
+    payload_type: Type[BinarySerializable] = payloads.ToolsDetectedNotificationPayload
+    message_id: Literal[
+        MessageId.tools_detected_notification
+    ] = MessageId.tools_detected_notification
+
+
+@dataclass
+class AttachedToolsRequest:  # noqa: D101
+    payload: payloads.EmptyPayload
+    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+    message_id: Literal[
+        MessageId.attached_tools_request
+    ] = MessageId.attached_tools_request
+
+
+@dataclass
+class FirmwareUpdateInitiate:  # noqa: D101
+    payload: payloads.EmptyPayload
+    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+    message_id: Literal[MessageId.fw_update_initiate] = MessageId.fw_update_initiate
+
+
+@dataclass
+class FirmwareUpdateData:  # noqa: D101
+    payload: payloads.FirmwareUpdateData
+    payload_type: Type[BinarySerializable] = payloads.FirmwareUpdateData
+    message_id: Literal[MessageId.fw_update_data] = MessageId.fw_update_data
+
+
+@dataclass
+class FirmwareUpdateDataAcknowledge:  # noqa: D101
+    payload: payloads.FirmwareUpdateDataAcknowledge
+    payload_type: Type[BinarySerializable] = payloads.FirmwareUpdateDataAcknowledge
+    message_id: Literal[MessageId.fw_update_data_ack] = MessageId.fw_update_data_ack
+
+
+@dataclass
+class FirmwareUpdateComplete:  # noqa: D101
+    payload: payloads.FirmwareUpdateComplete
+    payload_type: Type[BinarySerializable] = payloads.FirmwareUpdateComplete
+    message_id: Literal[MessageId.fw_update_complete] = MessageId.fw_update_complete
+
+
+@dataclass
+class FirmwareUpdateCompleteAcknowledge:  # noqa: D101
+    payload: payloads.FirmwareUpdateCompleteAcknowledge
+    payload_type: Type[BinarySerializable] = payloads.FirmwareUpdateCompleteAcknowledge
+    message_id: Literal[
+        MessageId.fw_update_complete_ack
+    ] = MessageId.fw_update_complete_ack
+
+
+@dataclass
+class FirmwareUpdateStatusRequest:  # noqa: D101
+    payload: payloads.EmptyPayload
+    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+    message_id: Literal[
+        MessageId.fw_update_status_request
+    ] = MessageId.fw_update_status_request
+
+
+@dataclass
+class FirmwareUpdateStatusResponse:  # noqa: D101
+    payload: payloads.FirmwareUpdateStatus
+    payload_type: Type[BinarySerializable] = payloads.FirmwareUpdateStatus
+    message_id: Literal[
+        MessageId.fw_update_status_response
+    ] = MessageId.fw_update_status_response
+
+
+@dataclass
+class ReadLimitSwitchRequest:  # noqa: D101
+    payload: payloads.EmptyPayload
+    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+    message_id: Literal[MessageId.limit_sw_request] = MessageId.limit_sw_request
+
+
+@dataclass
+class ReadLimitSwitchResponse:  # noqa: D101
+    payload: payloads.GetLimitSwitchResponse
+    payload_type: Type[BinarySerializable] = payloads.GetLimitSwitchResponse
+    message_id: Literal[MessageId.limit_sw_response] = MessageId.limit_sw_response
+
+
+@dataclass
+class ReadFromSensorRequest:  # noqa: D101
+    payload: payloads.ReadFromSensorRequest
+    payload_type: Type[BinarySerializable] = payloads.ReadFromSensorRequest
+    message_id: Literal[MessageId.read_sensor_request] = MessageId.read_sensor_request
+
+
+@dataclass
+class WriteToSensorRequest:  # noqa: D101
+    payload: payloads.WriteToSensorRequest
+    payload_type: Type[BinarySerializable] = payloads.WriteToSensorRequest
+    message_id: Literal[MessageId.write_sensor_request] = MessageId.write_sensor_request
+
+
+@dataclass
+class BaselineSensorRequest:  # noqa: D101
+    payload: payloads.BaselineSensorRequest
+    payload_type: Type[BinarySerializable] = payloads.BaselineSensorRequest
+    message_id: Literal[
+        MessageId.baseline_sensor_request
+    ] = MessageId.baseline_sensor_request
+
+
+@dataclass
+class ReadFromSensorResponse:  # noqa: D101
+    payload: payloads.ReadFromSensorResponse
+    payload_type: Type[BinarySerializable] = payloads.ReadFromSensorResponse
+    message_id: Literal[MessageId.read_sensor_response] = MessageId.read_sensor_response

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -350,3 +350,21 @@ class ReadFromSensorResponse:  # noqa: D101
     payload: payloads.ReadFromSensorResponse
     payload_type: Type[BinarySerializable] = payloads.ReadFromSensorResponse
     message_id: Literal[MessageId.read_sensor_response] = MessageId.read_sensor_response
+
+
+@dataclass
+class SetSensorThresholdRequest:  # noqa: D101
+    payload: payloads.SetSensorThresholdRequest
+    payload_type: Type[BinarySerializable] = payloads.SetSensorThresholdRequest
+    message_id: Literal[
+        MessageId.set_sensor_threshold_request
+    ] = MessageId.set_sensor_threshold_request
+
+
+@dataclass
+class SensorThresholdResponse:  # noqa: D101
+    payload: payloads.SensorThresholdResponse
+    payload_type: Type[BinarySerializable] = payloads.SensorThresholdResponse
+    message_id: Literal[
+        MessageId.set_sensor_threshold_response
+    ] = MessageId.set_sensor_threshold_response

--- a/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
@@ -1,0 +1,69 @@
+"""Message types."""
+from functools import lru_cache
+from typing import Union, Optional, Type
+
+from typing_extensions import get_args
+
+from . import message_definitions as defs
+from ..constants import MessageId
+
+MessageDefinition = Union[
+    defs.HeartbeatRequest,
+    defs.HeartbeatResponse,
+    defs.DeviceInfoRequest,
+    defs.DeviceInfoResponse,
+    defs.StopRequest,
+    defs.GetStatusRequest,
+    defs.GetStatusResponse,
+    defs.EnableMotorRequest,
+    defs.DisableMotorRequest,
+    defs.MoveRequest,
+    defs.SetupRequest,
+    defs.WriteToEEPromRequest,
+    defs.ReadFromEEPromRequest,
+    defs.ReadFromEEPromResponse,
+    defs.AddLinearMoveRequest,
+    defs.GetMoveGroupRequest,
+    defs.GetMoveGroupResponse,
+    defs.ExecuteMoveGroupRequest,
+    defs.ClearAllMoveGroupsRequest,
+    defs.MoveCompleted,
+    defs.SetMotionConstraints,
+    defs.GetMotionConstraintsRequest,
+    defs.GetMotionConstraintsResponse,
+    defs.WriteMotorDriverRegister,
+    defs.ReadMotorDriverRequest,
+    defs.ReadMotorDriverResponse,
+    defs.ReadPresenceSensingVoltageRequest,
+    defs.ReadPresenceSensingVoltageResponse,
+    defs.AttachedToolsRequest,
+    defs.PushToolsDetectedNotification,
+    defs.FirmwareUpdateInitiate,
+    defs.FirmwareUpdateData,
+    defs.FirmwareUpdateDataAcknowledge,
+    defs.FirmwareUpdateComplete,
+    defs.FirmwareUpdateCompleteAcknowledge,
+    defs.FirmwareUpdateStatusRequest,
+    defs.FirmwareUpdateStatusResponse,
+    defs.ReadLimitSwitchRequest,
+    defs.ReadLimitSwitchResponse,
+]
+
+
+@lru_cache(maxsize=None)
+def get_definition(message_id: MessageId) -> Optional[Type[MessageDefinition]]:
+    """Get the message type for a message id.
+
+    Args:
+        message_id: A message id
+
+    Returns: The message definition for a type
+
+    """
+    # Dumb linear search, but the result is memoized.
+    for i in get_args(MessageDefinition):
+        if i.message_id == message_id:
+            # get args returns Tuple[Any...]
+            return i  # type: ignore[no-any-return]
+
+    return None

--- a/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
@@ -47,6 +47,12 @@ MessageDefinition = Union[
     defs.FirmwareUpdateStatusResponse,
     defs.ReadLimitSwitchRequest,
     defs.ReadLimitSwitchResponse,
+    defs.ReadFromSensorRequest,
+    defs.WriteToSensorRequest,
+    defs.BaselineSensorRequest,
+    defs.SetSensorThresholdRequest,
+    defs.ReadFromSensorResponse,
+    defs.SensorThresholdResponse,
 ]
 
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -1,0 +1,280 @@
+"""Payloads of can bus messages."""
+# TODO (amit, 2022-01-26): Figure out why using annotations import ruins
+#  dataclass fields interpretation.
+#  from __future__ import annotations
+from dataclasses import dataclass
+
+from .. import utils
+from opentrons_hardware.firmware_bindings import constants
+
+
+@dataclass
+class EmptyPayload(utils.BinarySerializable):
+    """An empty payload."""
+
+    pass
+
+
+@dataclass
+class DeviceInfoResponsePayload(utils.BinarySerializable):
+    """Device info response."""
+
+    version: utils.UInt32Field
+
+
+@dataclass
+class GetStatusResponsePayload(utils.BinarySerializable):
+    """Get status response."""
+
+    status: utils.UInt8Field
+    data: utils.UInt32Field
+
+
+@dataclass
+class MoveRequestPayload(utils.BinarySerializable):
+    """Move request."""
+
+    steps: utils.UInt32Field
+
+
+@dataclass
+class GetSpeedResponsePayload(utils.BinarySerializable):
+    """Get speed response."""
+
+    mm_sec: utils.UInt32Field
+
+
+@dataclass
+class WriteToEEPromRequestPayload(utils.BinarySerializable):
+    """Write to eeprom request."""
+
+    serial_number: utils.UInt16Field
+
+
+@dataclass
+class ReadFromEEPromResponsePayload(utils.BinarySerializable):
+    """Read from ee prom response."""
+
+    serial_number: utils.UInt16Field
+
+
+@dataclass
+class MoveGroupRequestPayload(utils.BinarySerializable):
+    """A payload with a group id."""
+
+    group_id: utils.UInt8Field
+
+
+@dataclass
+class MoveGroupResponsePayload(utils.BinarySerializable):
+    """A response payload with a group id."""
+
+    group_id: utils.UInt8Field
+
+
+@dataclass
+class AddToMoveGroupRequestPayload(MoveGroupRequestPayload):
+    """Base of add to move group request to a message group."""
+
+    seq_id: utils.UInt8Field
+    duration: utils.UInt32Field
+
+
+@dataclass
+class AddLinearMoveRequestPayload(AddToMoveGroupRequestPayload):
+    """Add a linear move request to a message group."""
+
+    request_stop_condition: utils.UInt8Field
+    acceleration: utils.Int32Field
+    velocity: utils.Int32Field
+
+
+@dataclass
+class GetMoveGroupResponsePayload(MoveGroupResponsePayload):
+    """Response to request to get a move group."""
+
+    num_moves: utils.UInt8Field
+    total_duration: utils.UInt32Field
+
+
+@dataclass
+class ExecuteMoveGroupRequestPayload(MoveGroupRequestPayload):
+    """Start executing a move group."""
+
+    start_trigger: utils.UInt8Field
+    cancel_trigger: utils.UInt8Field
+
+
+@dataclass
+class MoveCompletedPayload(MoveGroupResponsePayload):
+    """Notification of a completed move group."""
+
+    seq_id: utils.UInt8Field
+    current_position: utils.UInt32Field
+    ack_id: utils.UInt8Field
+
+
+@dataclass
+class MotionConstraintsPayload(utils.BinarySerializable):
+    """The min and max velocity and acceleration of a motion system."""
+
+    min_velocity: utils.Int32Field
+    max_velocity: utils.Int32Field
+    min_acceleration: utils.Int32Field
+    max_acceleration: utils.Int32Field
+
+
+@dataclass
+class MotorDriverRegisterPayload(utils.BinarySerializable):
+    """Read motor driver register request payload."""
+
+    reg_addr: utils.UInt8Field
+
+
+@dataclass
+class MotorDriverRegisterDataPayload(MotorDriverRegisterPayload):
+    """Write motor driver register request payload."""
+
+    data: utils.UInt32Field
+
+
+@dataclass
+class ReadMotorDriverRegisterResponsePayload(utils.BinarySerializable):
+    """Read motor driver register response payload."""
+
+    reg_addr: utils.UInt8Field
+    data: utils.UInt32Field
+
+
+@dataclass
+class ReadPresenceSensingVoltageResponsePayload(utils.BinarySerializable):
+    """Read head presence sensing voltage response payload."""
+
+    # All values in millivolts
+    z_motor: utils.UInt16Field
+    a_motor: utils.UInt16Field
+    gripper: utils.UInt16Field
+
+
+@dataclass
+class ToolsDetectedNotificationPayload(utils.BinarySerializable):
+    """Tool detection notification."""
+
+    # Tools are mapped to an enum
+    z_motor: utils.UInt8Field
+    a_motor: utils.UInt8Field
+    gripper: utils.UInt8Field
+
+
+@dataclass
+class FirmwareUpdateWithAddress(utils.BinarySerializable):
+    """A FW update payload with an address."""
+
+    address: utils.UInt32Field
+
+
+class FirmwareUpdateDataField(utils.BinaryFieldBase[bytes]):
+    """The data field of FirmwareUpdateData."""
+
+    NUM_BYTES = 56
+    FORMAT = f"{NUM_BYTES}s"
+
+
+@dataclass
+class FirmwareUpdateData(FirmwareUpdateWithAddress):
+    """A FW update data payload."""
+
+    num_bytes: utils.UInt8Field
+    reserved: utils.UInt8Field
+    data: FirmwareUpdateDataField
+    checksum: utils.UInt16Field
+
+    def __post_init__(self) -> None:
+        """Post init processing."""
+        data_length = len(self.data.value)
+        if data_length > FirmwareUpdateDataField.NUM_BYTES:
+            raise ValueError(
+                f"Data cannot be more than"
+                f" {FirmwareUpdateDataField.NUM_BYTES} bytes."
+            )
+
+    @classmethod
+    def create(cls, address: int, data: bytes) -> "FirmwareUpdateData":
+        """Create a firmware update data payload."""
+        checksum = 0
+        obj = FirmwareUpdateData(
+            address=utils.UInt32Field(address),
+            num_bytes=utils.UInt8Field(len(data)),
+            reserved=utils.UInt8Field(0),
+            data=FirmwareUpdateDataField(data),
+            checksum=utils.UInt16Field(checksum),
+        )
+        checksum = (1 + ~sum(obj.serialize())) & 0xFFFF
+        obj.checksum.value = checksum
+        return obj
+
+
+@dataclass
+class FirmwareUpdateDataAcknowledge(FirmwareUpdateWithAddress):
+    """A FW update data acknowledge payload."""
+
+    error_code: utils.UInt16Field
+
+
+@dataclass
+class FirmwareUpdateComplete(utils.BinarySerializable):
+    """All data messages have been transmitted."""
+
+    num_messages: utils.UInt32Field
+
+
+@dataclass
+class FirmwareUpdateCompleteAcknowledge(utils.BinarySerializable):
+    """A response to the FirmwareUpdateComplete message."""
+
+    error_code: utils.UInt16Field
+
+
+@dataclass
+class FirmwareUpdateStatus(utils.BinarySerializable):
+    """A response to the FirmwareUpdateStatusRequest message."""
+
+    flags: utils.UInt32Field
+
+
+@dataclass
+class GetLimitSwitchResponse(utils.BinarySerializable):
+    """A response to the Limit Switch Status request payload."""
+
+    switch_status: utils.UInt8Field
+
+
+@dataclass
+class ReadFromSensorRequest(utils.BinarySerializable):
+    """Take a single reading from a sensor request payload."""
+
+    sensor: utils.UInt8Field
+
+
+@dataclass
+class WriteToSensorRequest(utils.BinarySerializable):
+    """Write a piece of data to a sensor request payload."""
+
+    sensor: utils.UInt8Field
+    data: utils.UInt16Field
+
+
+@dataclass
+class BaselineSensorRequest(utils.BinarySerializable):
+    """Take a specified amount of readings from a sensor request payload."""
+
+    sensor: utils.UInt8Field
+    sample_rate: utils.UInt8Field
+
+
+@dataclass
+class ReadFromSensorResponse(utils.BinarySerializable):
+    """A response for either a single reading or an averaged reading of a sensor."""
+
+    sensor: constants.SensorType
+    sensor_data: utils.UInt32Field

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -5,7 +5,6 @@
 from dataclasses import dataclass
 
 from .. import utils
-from opentrons_hardware.firmware_bindings import constants
 
 
 @dataclass
@@ -276,5 +275,21 @@ class BaselineSensorRequest(utils.BinarySerializable):
 class ReadFromSensorResponse(utils.BinarySerializable):
     """A response for either a single reading or an averaged reading of a sensor."""
 
-    sensor: constants.SensorType
+    sensor: utils.UInt8Field
     sensor_data: utils.UInt32Field
+
+
+@dataclass
+class SetSensorThresholdRequest(utils.BinarySerializable):
+    """A request to set the threshold value of a sensor."""
+
+    sensor: utils.UInt8Field
+    threshold: utils.UInt32Field
+
+
+@dataclass
+class SensorThresholdResponse(utils.BinarySerializable):
+    """A response that sends back the current threshold value of the sensor."""
+
+    sensor: utils.UInt8Field
+    threshold: utils.UInt32Field

--- a/hardware/opentrons_hardware/firmware_bindings/utils/__init__.py
+++ b/hardware/opentrons_hardware/firmware_bindings/utils/__init__.py
@@ -1,0 +1,33 @@
+"""Utils package."""
+
+from .binary_serializable import (
+    BinarySerializable,
+    LittleEndianBinarySerializable,
+    Int8Field,
+    Int16Field,
+    Int32Field,
+    Int64Field,
+    UInt8Field,
+    UInt16Field,
+    UInt32Field,
+    UInt64Field,
+    BinaryFieldBase,
+    BinarySerializableException,
+    InvalidFieldException,
+)
+
+__all__ = [
+    "BinarySerializable",
+    "LittleEndianBinarySerializable",
+    "Int8Field",
+    "Int16Field",
+    "Int32Field",
+    "Int64Field",
+    "UInt8Field",
+    "UInt16Field",
+    "UInt32Field",
+    "UInt64Field",
+    "BinaryFieldBase",
+    "BinarySerializableException",
+    "InvalidFieldException",
+]

--- a/hardware/opentrons_hardware/firmware_bindings/utils/binary_serializable.py
+++ b/hardware/opentrons_hardware/firmware_bindings/utils/binary_serializable.py
@@ -1,0 +1,206 @@
+"""BinarySerializable dataclass."""
+
+from __future__ import annotations
+import struct
+from dataclasses import dataclass, fields, astuple
+from typing import TypeVar, Generic
+
+
+class BinarySerializableException(BaseException):
+    """Exception."""
+
+    pass
+
+
+class InvalidFieldException(BinarySerializableException):
+    """Field is wrong type."""
+
+    pass
+
+
+class SerializationException(BinarySerializableException):
+    """Serialization error."""
+
+    pass
+
+
+T = TypeVar("T")
+
+
+class BinaryFieldBase(Generic[T]):
+    """Binary serializable field."""
+
+    FORMAT = ""
+    """The struct format string for this field."""
+
+    def __init__(self, t: T) -> None:
+        """Constructor."""
+        self._t = t
+
+    @classmethod
+    def build(cls, t: T) -> BinaryFieldBase[T]:
+        """Factory method.
+
+        Args:
+            t: The value.
+
+        Returns:
+            New instance.
+        """
+        return cls(t)
+
+    @property
+    def value(self) -> T:
+        """The value."""
+        return self._t
+
+    @value.setter
+    def value(self, val: T) -> None:
+        """Set the value."""
+        self._t = val
+
+    def __eq__(self, other: object) -> bool:
+        """Comparison."""
+        return isinstance(other, BinaryFieldBase) and other.value == self.value
+
+    def __repr__(self) -> str:
+        """Representation string."""
+        return f"{self.__class__.__name__}(value={repr(self.value)})"
+
+
+class UInt64Field(BinaryFieldBase[int]):
+    """Unsigned 64-bit integer field."""
+
+    FORMAT = "Q"
+
+
+class Int64Field(BinaryFieldBase[int]):
+    """Signed 64-bit integer field."""
+
+    FORMAT = "q"
+
+
+class UInt32Field(BinaryFieldBase[int]):
+    """Unsigned 32-bit integer field."""
+
+    FORMAT = "L"
+
+
+class Int32Field(BinaryFieldBase[int]):
+    """Signed 32-bit integer field."""
+
+    FORMAT = "l"
+
+
+class UInt16Field(BinaryFieldBase[int]):
+    """Unsigned 16-bit integer field."""
+
+    FORMAT = "H"
+
+
+class Int16Field(BinaryFieldBase[int]):
+    """Signed 16-bit integer field."""
+
+    FORMAT = "h"
+
+
+class UInt8Field(BinaryFieldBase[int]):
+    """Unsigned 8-bit integer field."""
+
+    FORMAT = "B"
+
+
+class Int8Field(BinaryFieldBase[int]):
+    """Signed 8-bit integer field."""
+
+    FORMAT = "b"
+
+
+@dataclass
+class BinarySerializable:
+    """Base class of a dataclass that can be serialized/deserialized into bytes.
+
+    Each field must have the FieldMetaData metadata value defining the format string
+    used by `struct` package to pack/unpack the field.
+
+    Data will be packed big endian.
+    """
+
+    ENDIAN = ">"
+    """The big endian format string"""
+
+    def serialize(self) -> bytes:
+        """Serialize into a byte buffer.
+
+        Returns:
+            Byte buffer
+        """
+        string = self._get_format_string()
+        vals = [x.value for x in astuple(self)]
+        try:
+            return struct.pack(string, *vals)
+        except struct.error as e:
+            raise SerializationException(str(e))
+
+    @classmethod
+    def build(cls, data: bytes) -> BinarySerializable:
+        """Create a BinarySerializable from a byte buffer.
+
+        The byte buffer must be at least enough bytes to satisfy all fields.
+
+        Extra bytes will be ignored. This is for two reasons:
+            - CANFD requires padding to round byte lengths to fixed sizes.
+            - To accommodate extracting multiple  BinarySerializable objects
+            from a stream of bytes.
+
+        Args:
+            data: Byte buffer
+
+        Returns:
+            cls
+        """
+        try:
+            format_string = cls._get_format_string()
+            size = cls.get_size()
+            # ignore bytes beyond the size of message.
+            b = struct.unpack(format_string, data[:size])
+            args = {v.name: v.type.build(b[i]) for i, v in enumerate(fields(cls))}
+            # Mypy is not liking constructing the derived types.
+            return cls(**args)  # type: ignore[call-arg]
+        except struct.error as e:
+            raise InvalidFieldException(str(e))
+
+    @classmethod
+    def _get_format_string(cls) -> str:
+        """Get the `struct` format string for this class.
+
+        Returns:
+            a string
+        """
+        dataclass_fields = fields(cls)
+        try:
+            format_string = (
+                f"{cls.ENDIAN}{''.join(v.type.FORMAT for v in dataclass_fields)}"
+            )
+        except AttributeError:
+            raise InvalidFieldException(f"All fields must be of type {BinaryFieldBase}")
+
+        return format_string
+
+    @classmethod
+    def get_size(cls) -> int:
+        """Get the size of the serializable in bytes."""
+        return struct.calcsize(cls._get_format_string())
+
+
+class LittleEndianMixIn:
+    """Mix in to use with BinarySerializable to use little endian packing."""
+
+    ENDIAN = "<"
+    """The little endian format string"""
+
+
+class LittleEndianBinarySerializable(LittleEndianMixIn, BinarySerializable):
+    """Little endian binary serializable."""
+
+    ...

--- a/hardware/opentrons_hardware/firmware_update/downloader.py
+++ b/hardware/opentrons_hardware/firmware_update/downloader.py
@@ -2,9 +2,9 @@
 import asyncio
 import logging
 
-from opentrons_ot3_firmware import NodeId
-from opentrons_ot3_firmware.constants import ErrorCode
-from opentrons_ot3_firmware.utils import UInt32Field
+from opentrons_hardware.firmware_bindings import NodeId
+from opentrons_hardware.firmware_bindings.constants import ErrorCode
+from opentrons_hardware.firmware_bindings.utils import UInt32Field
 
 from opentrons_hardware.drivers.can_bus.can_messenger import (
     CanMessenger,
@@ -12,7 +12,7 @@ from opentrons_hardware.drivers.can_bus.can_messenger import (
 )
 from opentrons_hardware.firmware_update.errors import ErrorResponse, TimeoutResponse
 from opentrons_hardware.firmware_update.hex_file import HexRecordProcessor
-from opentrons_ot3_firmware.messages import message_definitions, payloads
+from opentrons_hardware.firmware_bindings.messages import message_definitions, payloads
 
 
 logger = logging.getLogger(__name__)

--- a/hardware/opentrons_hardware/firmware_update/errors.py
+++ b/hardware/opentrons_hardware/firmware_update/errors.py
@@ -1,5 +1,5 @@
 """Firmware update exceptions."""
-from opentrons_ot3_firmware.messages import MessageDefinition
+from opentrons_hardware.firmware_bindings.messages import MessageDefinition
 
 
 class FirmwareUpdateException(Exception):

--- a/hardware/opentrons_hardware/firmware_update/initiator.py
+++ b/hardware/opentrons_hardware/firmware_update/initiator.py
@@ -5,8 +5,8 @@ import logging
 from typing_extensions import Final
 from dataclasses import dataclass
 
-from opentrons_ot3_firmware import NodeId
-from opentrons_ot3_firmware.messages import message_definitions, payloads
+from opentrons_hardware.firmware_bindings import NodeId
+from opentrons_hardware.firmware_bindings.messages import message_definitions, payloads
 
 from opentrons_hardware.drivers.can_bus import CanMessenger
 from opentrons_hardware.drivers.can_bus.can_messenger import WaitableCallback

--- a/hardware/opentrons_hardware/hardware_control/motion.py
+++ b/hardware/opentrons_hardware/hardware_control/motion.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 import numpy as np  # type: ignore[import]
 from logging import getLogger
 
-from opentrons_ot3_firmware.constants import NodeId
+from opentrons_hardware.firmware_bindings.constants import NodeId
 
 LOG = getLogger(__name__)
 

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -3,24 +3,28 @@ import asyncio
 import logging
 from typing import List, Set, Tuple
 
-from opentrons_ot3_firmware import ArbitrationId
-from opentrons_ot3_firmware.constants import NodeId
+from opentrons_hardware.firmware_bindings import ArbitrationId
+from opentrons_hardware.firmware_bindings.constants import NodeId
 from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
-from opentrons_ot3_firmware.messages import MessageDefinition
-from opentrons_ot3_firmware.messages.message_definitions import (
+from opentrons_hardware.firmware_bindings.messages import MessageDefinition
+from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     ClearAllMoveGroupsRequest,
     AddLinearMoveRequest,
     MoveCompleted,
     ExecuteMoveGroupRequest,
 )
-from opentrons_ot3_firmware.messages.payloads import (
+from opentrons_hardware.firmware_bindings.messages.payloads import (
     AddLinearMoveRequestPayload,
     ExecuteMoveGroupRequestPayload,
     EmptyPayload,
 )
 from .constants import interrupts_per_sec
 from opentrons_hardware.hardware_control.motion import MoveGroups
-from opentrons_ot3_firmware.utils import UInt8Field, UInt32Field, Int32Field
+from opentrons_hardware.firmware_bindings.utils import (
+    UInt8Field,
+    UInt32Field,
+    Int32Field,
+)
 
 
 log = logging.getLogger(__name__)
@@ -67,6 +71,7 @@ class MoveGroupRunner:
                         node_id=node,
                         message=AddLinearMoveRequest(
                             payload=AddLinearMoveRequestPayload(
+                                request_stop_condition=UInt8Field(0),
                                 group_id=UInt8Field(group_i),
                                 seq_id=UInt8Field(seq_i),
                                 duration=UInt32Field(

--- a/hardware/opentrons_hardware/hardware_control/network.py
+++ b/hardware/opentrons_hardware/hardware_control/network.py
@@ -2,11 +2,11 @@
 import asyncio
 import logging
 from typing import Set, Optional
-from opentrons_ot3_firmware import ArbitrationId
-from opentrons_ot3_firmware.constants import NodeId
+from opentrons_hardware.firmware_bindings import ArbitrationId
+from opentrons_hardware.firmware_bindings.constants import NodeId
 from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
-from opentrons_ot3_firmware.messages import payloads, MessageDefinition
-from opentrons_ot3_firmware.messages.message_definitions import (
+from opentrons_hardware.firmware_bindings.messages import payloads, MessageDefinition
+from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     DeviceInfoRequest,
 )
 

--- a/hardware/opentrons_hardware/opentrons_hardware.cmakefind
+++ b/hardware/opentrons_hardware/opentrons_hardware.cmakefind
@@ -1,0 +1,1 @@
+This is a dummy file used as a hook for CMake to be able to find this directory.

--- a/hardware/opentrons_hardware/scripts/can_comm.py
+++ b/hardware/opentrons_hardware/scripts/can_comm.py
@@ -7,22 +7,25 @@ from enum import Enum
 from logging.config import dictConfig
 from typing import Type, Sequence, Callable, cast
 
-from opentrons_ot3_firmware.constants import (
+from opentrons_hardware.firmware_bindings.constants import (
     MessageId,
     NodeId,
     FunctionCode,
 )
-from opentrons_ot3_firmware.message import CanMessage
-from opentrons_ot3_firmware.arbitration_id import (
+from opentrons_hardware.firmware_bindings.message import CanMessage
+from opentrons_hardware.firmware_bindings.arbitration_id import (
     ArbitrationId,
     ArbitrationIdParts,
 )
 from opentrons_hardware.drivers.can_bus.abstract_driver import AbstractCanDriver
-from opentrons_ot3_firmware.messages.messages import get_definition
+from opentrons_hardware.firmware_bindings.messages.messages import get_definition
 
 from opentrons_hardware.drivers.can_bus.build import build_driver
 from opentrons_hardware.scripts.can_args import add_can_args, build_settings
-from opentrons_ot3_firmware.utils import BinarySerializable, BinarySerializableException
+from opentrons_hardware.firmware_bindings.utils import (
+    BinarySerializable,
+    BinarySerializableException,
+)
 
 log = logging.getLogger(__name__)
 

--- a/hardware/opentrons_hardware/scripts/load.py
+++ b/hardware/opentrons_hardware/scripts/load.py
@@ -11,14 +11,14 @@ import time
 
 from opentrons_hardware.drivers.can_bus import CanDriver
 from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
-from opentrons_ot3_firmware.constants import NodeId
-from opentrons_ot3_firmware.messages.message_definitions import (
+from opentrons_hardware.firmware_bindings.constants import NodeId
+from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     DeviceInfoRequest,
     DeviceInfoResponse,
 )
-from opentrons_ot3_firmware.arbitration_id import ArbitrationId
-from opentrons_ot3_firmware.messages import MessageDefinition
-from opentrons_ot3_firmware.messages.payloads import EmptyPayload
+from opentrons_hardware.firmware_bindings.arbitration_id import ArbitrationId
+from opentrons_hardware.firmware_bindings.messages import MessageDefinition
+from opentrons_hardware.firmware_bindings.messages.payloads import EmptyPayload
 from opentrons_hardware.scripts.can_args import add_can_args
 
 

--- a/hardware/opentrons_hardware/scripts/move.py
+++ b/hardware/opentrons_hardware/scripts/move.py
@@ -7,13 +7,13 @@ from typing import Optional
 
 from opentrons_hardware.drivers.can_bus import CanDriver
 from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
-from opentrons_ot3_firmware.constants import NodeId
+from opentrons_hardware.firmware_bindings.constants import NodeId
 
-from opentrons_ot3_firmware.messages.message_definitions import (
+from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     SetupRequest,
     EnableMotorRequest,
 )
-from opentrons_ot3_firmware.messages.payloads import EmptyPayload
+from opentrons_hardware.firmware_bindings.messages.payloads import EmptyPayload
 from opentrons_hardware.hardware_control.motion import MoveGroupSingleAxisStep
 from opentrons_hardware.hardware_control.move_group_runner import MoveGroupRunner
 from opentrons_hardware.scripts.can_args import add_can_args

--- a/hardware/setup.py
+++ b/hardware/setup.py
@@ -76,7 +76,9 @@ if __name__ == "__main__":
         classifiers=CLASSIFIERS,
         install_requires=INSTALL_REQUIRES,
         include_package_data=True,
-        package_data={"opentrons_hardware": ["py.typed", "opentrons_hardware.cmakefind"]},
+        package_data={
+            "opentrons_hardware": ["py.typed", "opentrons_hardware.cmakefind"]
+        },
         entry_points={
             "console_scripts": [
                 "opentrons_update_fw = opentrons_hardware.scripts.update_fw:main",

--- a/hardware/setup.py
+++ b/hardware/setup.py
@@ -76,6 +76,7 @@ if __name__ == "__main__":
         classifiers=CLASSIFIERS,
         install_requires=INSTALL_REQUIRES,
         include_package_data=True,
+        package_data={"opentrons_hardware": ["py.typed", "opentrons_hardware.cmakefind"]},
         entry_points={
             "console_scripts": [
                 "opentrons_update_fw = opentrons_hardware.scripts.update_fw:main",

--- a/hardware/tests/conftest.py
+++ b/hardware/tests/conftest.py
@@ -3,8 +3,8 @@ from typing import List
 
 import pytest
 from mock.mock import AsyncMock
-from opentrons_ot3_firmware import ArbitrationId
-from opentrons_ot3_firmware.messages import MessageDefinition
+from opentrons_hardware.firmware_bindings import ArbitrationId
+from opentrons_hardware.firmware_bindings.messages import MessageDefinition
 
 from opentrons_hardware.drivers.can_bus import CanMessenger
 from opentrons_hardware.drivers.can_bus.can_messenger import MessageListenerCallback

--- a/hardware/tests/opentrons_hardware/drivers/can_bus/test_can_messenger.py
+++ b/hardware/tests/opentrons_hardware/drivers/can_bus/test_can_messenger.py
@@ -6,13 +6,13 @@ from asyncio import Queue
 import pytest
 from mock import AsyncMock, Mock
 
-from opentrons_ot3_firmware.constants import (
+from opentrons_hardware.firmware_bindings.constants import (
     NodeId,
     MessageId,
 )
 
-from opentrons_ot3_firmware.message import CanMessage
-from opentrons_ot3_firmware.arbitration_id import (
+from opentrons_hardware.firmware_bindings.message import CanMessage
+from opentrons_hardware.firmware_bindings.arbitration_id import (
     ArbitrationId,
     ArbitrationIdParts,
 )
@@ -21,18 +21,18 @@ from opentrons_hardware.drivers.can_bus.can_messenger import (
     MessageListenerCallback,
     WaitableCallback,
 )
-from opentrons_ot3_firmware.messages import MessageDefinition
-from opentrons_ot3_firmware.messages.message_definitions import (
+from opentrons_hardware.firmware_bindings.messages import MessageDefinition
+from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     HeartbeatRequest,
     MoveCompleted,
     GetMoveGroupRequest,
 )
-from opentrons_ot3_firmware.messages.payloads import (
+from opentrons_hardware.firmware_bindings.messages.payloads import (
     EmptyPayload,
     MoveCompletedPayload,
     MoveGroupRequestPayload,
 )
-from opentrons_ot3_firmware.utils import UInt8Field, UInt32Field
+from opentrons_hardware.firmware_bindings.utils import UInt8Field, UInt32Field
 
 
 @pytest.fixture

--- a/hardware/tests/opentrons_hardware/firmware_bindings/__init__.py
+++ b/hardware/tests/opentrons_hardware/firmware_bindings/__init__.py
@@ -1,0 +1,1 @@
+"""ot3 firmware driver tests."""

--- a/hardware/tests/opentrons_hardware/firmware_bindings/test_arbitration_id.py
+++ b/hardware/tests/opentrons_hardware/firmware_bindings/test_arbitration_id.py
@@ -1,0 +1,69 @@
+"""Arbitration id tests."""
+import pytest
+from opentrons_hardware.firmware_bindings import ArbitrationId, ArbitrationIdParts
+
+
+@pytest.mark.parametrize(
+    argnames=["arbitration_id", "expected"],
+    argvalues=[
+        [
+            0x0,
+            ArbitrationIdParts(
+                function_code=0x0, node_id=0x0, originating_node_id=0, message_id=0
+            ),
+        ],
+        [
+            0xFFFFFFFF,
+            ArbitrationIdParts(
+                function_code=0x7F,
+                node_id=0xFF,
+                originating_node_id=0xFF,
+                message_id=0x3FFF,
+            ),
+        ],
+        [
+            0x101821,
+            ArbitrationIdParts(
+                function_code=0x1, node_id=0x2, originating_node_id=0x3, message_id=0x4
+            ),
+        ],
+    ],
+)
+def test_arbitration_id_parts(
+    arbitration_id: int, expected: ArbitrationIdParts
+) -> None:
+    """It should convert arbitration id to its parts."""
+    c = ArbitrationId(id=arbitration_id)
+    assert c.parts == expected
+
+
+@pytest.mark.parametrize(
+    argnames=["expected", "parts"],
+    argvalues=[
+        [
+            0x0,
+            ArbitrationIdParts(
+                function_code=0x0, node_id=0x0, originating_node_id=0, message_id=0
+            ),
+        ],
+        [
+            0x1FFFFFFF,
+            ArbitrationIdParts(
+                function_code=0x7F,
+                node_id=0xFF,
+                originating_node_id=0xFF,
+                message_id=0x3FFF,
+            ),
+        ],
+        [
+            0x101821,
+            ArbitrationIdParts(
+                function_code=0x1, node_id=0x2, originating_node_id=0x3, message_id=0x4
+            ),
+        ],
+    ],
+)
+def test_arbitration_id_integer(expected: int, parts: ArbitrationIdParts) -> None:
+    """It should convert parts to an arbitration id."""
+    c = ArbitrationId(parts=parts)
+    assert c.id == expected

--- a/hardware/tests/opentrons_hardware/firmware_bindings/test_constants.py
+++ b/hardware/tests/opentrons_hardware/firmware_bindings/test_constants.py
@@ -1,0 +1,26 @@
+"""Test for constants module."""
+from typing import Iterable
+
+import pytest
+
+from opentrons_hardware.firmware_bindings import constants
+from opentrons_hardware.firmware_bindings.arbitration_id import (
+    NODE_ID_BITS,
+    MESSAGE_ID_BITS,
+    FUNCTION_CODE_BITS,
+)
+
+
+@pytest.mark.parametrize(
+    argnames=["subject", "bit_width"],
+    argvalues=[
+        [constants.NodeId, NODE_ID_BITS],
+        [constants.MessageId, MESSAGE_ID_BITS],
+        [constants.FunctionCode, FUNCTION_CODE_BITS],
+    ],
+)
+def test_range(subject: Iterable[int], bit_width: int) -> None:
+    """Each value must be in range."""
+    mask = (2**bit_width) - 1
+    for v in subject:
+        assert (v & ~mask) == 0, f"{v} must be between 0 and {mask}"

--- a/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/__init__.py
+++ b/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for messages package."""

--- a/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_message_definitions.py
+++ b/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_message_definitions.py
@@ -1,0 +1,25 @@
+"""Test for message definitions."""
+import pytest
+from typing_extensions import get_args
+from dataclasses import fields
+
+from opentrons_hardware.firmware_bindings.messages.messages import MessageDefinition
+
+
+@pytest.mark.parametrize("message_definition", get_args(MessageDefinition))
+def test_payload_types(message_definition: MessageDefinition) -> None:
+    """Its payload_type and payload typing should match."""
+    all_fields = fields(message_definition)
+    payload_type_type = None
+    payload_type = None
+    for f in all_fields:
+        if f.name == "payload_type":
+            payload_type_type = f.default
+        elif f.name == "payload":
+            payload_type = f.type
+        if payload_type and payload_type_type:
+            break
+
+    assert payload_type_type is not None
+    assert payload_type is not None
+    assert payload_type == payload_type_type

--- a/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_payloads.py
+++ b/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_payloads.py
@@ -1,0 +1,28 @@
+"""Payloads tests."""
+import pytest
+
+from opentrons_hardware.firmware_bindings.messages import payloads
+from opentrons_hardware.firmware_bindings import utils
+
+
+@pytest.mark.parametrize(
+    argnames=["address", "data", "expected_checksum"],
+    argvalues=[
+        [0xF0F0F0F0, bytes(range(56)), 0xF604],
+        [0x0, b"", 0x0],
+        [0x0, b"\x00", 0xFFFF],
+        [0x12345678, b"\x05\x06\x07", 0xFED7],
+    ],
+)
+def test_create_firmware_updata_data(
+    address: int, data: bytes, expected_checksum: int
+) -> None:
+    """It should create a complete firmware update data payload."""
+    obj = payloads.FirmwareUpdateData.create(address, data)
+    assert obj == payloads.FirmwareUpdateData(
+        address=utils.UInt32Field(address),
+        num_bytes=utils.UInt8Field(len(data)),
+        reserved=utils.UInt8Field(0),
+        data=payloads.FirmwareUpdateDataField(data),
+        checksum=utils.UInt16Field(expected_checksum),
+    )

--- a/hardware/tests/opentrons_hardware/firmware_update/test_downloader.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_downloader.py
@@ -3,16 +3,21 @@ from typing import List
 
 import pytest
 from mock import AsyncMock, MagicMock, call
-from opentrons_ot3_firmware import NodeId, utils, ArbitrationId, ArbitrationIdParts
-from opentrons_ot3_firmware.constants import ErrorCode
-from opentrons_ot3_firmware.messages import MessageDefinition
-from opentrons_ot3_firmware.messages.message_definitions import (
+from opentrons_hardware.firmware_bindings import (
+    NodeId,
+    utils,
+    ArbitrationId,
+    ArbitrationIdParts,
+)
+from opentrons_hardware.firmware_bindings.constants import ErrorCode
+from opentrons_hardware.firmware_bindings.messages import MessageDefinition
+from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     FirmwareUpdateData,
     FirmwareUpdateComplete,
     FirmwareUpdateDataAcknowledge,
     FirmwareUpdateCompleteAcknowledge,
 )
-from opentrons_ot3_firmware.messages import payloads
+from opentrons_hardware.firmware_bindings.messages import payloads
 
 from opentrons_hardware.firmware_update import downloader
 from opentrons_hardware.firmware_update.errors import ErrorResponse, TimeoutResponse

--- a/hardware/tests/opentrons_hardware/firmware_update/test_initiater.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_initiater.py
@@ -1,10 +1,14 @@
 """Tests for FirmwareUpdateInitiator."""
 import pytest
 from mock import AsyncMock, call
-from opentrons_ot3_firmware import NodeId, ArbitrationId, ArbitrationIdParts
-from opentrons_ot3_firmware.messages import MessageDefinition
-from opentrons_ot3_firmware.messages import message_definitions, payloads
-from opentrons_ot3_firmware.utils import UInt32Field
+from opentrons_hardware.firmware_bindings import (
+    NodeId,
+    ArbitrationId,
+    ArbitrationIdParts,
+)
+from opentrons_hardware.firmware_bindings.messages import MessageDefinition
+from opentrons_hardware.firmware_bindings.messages import message_definitions, payloads
+from opentrons_hardware.firmware_bindings.utils import UInt32Field
 
 from opentrons_hardware.firmware_update import initiator
 from opentrons_hardware.firmware_update.errors import BootloaderNotReady

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -1,14 +1,14 @@
 """Tests for the move scheduler."""
 import pytest
 from mock import AsyncMock, call, MagicMock
-from opentrons_ot3_firmware import ArbitrationId, ArbitrationIdParts
+from opentrons_hardware.firmware_bindings import ArbitrationId, ArbitrationIdParts
 
-from opentrons_ot3_firmware.constants import NodeId
+from opentrons_hardware.firmware_bindings.constants import NodeId
 from opentrons_hardware.drivers.can_bus.can_messenger import MessageListenerCallback
-from opentrons_ot3_firmware.messages.message_definitions import (
+from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     AddLinearMoveRequest,
 )
-from opentrons_ot3_firmware.messages.payloads import (
+from opentrons_hardware.firmware_bindings.messages.payloads import (
     AddLinearMoveRequestPayload,
     MoveCompletedPayload,
     EmptyPayload,
@@ -25,11 +25,15 @@ from opentrons_hardware.hardware_control.move_group_runner import (
     MoveGroupRunner,
     MoveScheduler,
 )
-from opentrons_ot3_firmware.messages import (
+from opentrons_hardware.firmware_bindings.messages import (
     message_definitions as md,
     MessageDefinition,
 )
-from opentrons_ot3_firmware.utils import UInt8Field, Int32Field, UInt32Field
+from opentrons_hardware.firmware_bindings.utils import (
+    UInt8Field,
+    Int32Field,
+    UInt32Field,
+)
 
 
 @pytest.fixture
@@ -149,6 +153,7 @@ async def test_single_send_setup_commands(
             payload=AddLinearMoveRequestPayload(
                 group_id=UInt8Field(0),
                 seq_id=UInt8Field(0),
+                request_stop_condition=UInt8Field(0),
                 velocity=Int32Field(
                     int(
                         move_group_single[0][0][NodeId.head].velocity_mm_sec
@@ -189,6 +194,7 @@ async def test_multi_send_setup_commands(
             payload=AddLinearMoveRequestPayload(
                 group_id=UInt8Field(0),
                 seq_id=UInt8Field(0),
+                request_stop_condition=UInt8Field(0),
                 velocity=Int32Field(
                     int(
                         move_group_multiple[0][0][NodeId.head].velocity_mm_sec
@@ -221,6 +227,7 @@ async def test_multi_send_setup_commands(
             payload=AddLinearMoveRequestPayload(
                 group_id=UInt8Field(1),
                 seq_id=UInt8Field(0),
+                request_stop_condition=UInt8Field(0),
                 velocity=Int32Field(
                     int(
                         move_group_multiple[1][0][NodeId.gantry_x].velocity_mm_sec
@@ -254,6 +261,7 @@ async def test_multi_send_setup_commands(
             payload=AddLinearMoveRequestPayload(
                 group_id=UInt8Field(1),
                 seq_id=UInt8Field(0),
+                request_stop_condition=UInt8Field(0),
                 velocity=Int32Field(
                     int(
                         move_group_multiple[1][0][NodeId.gantry_y].velocity_mm_sec
@@ -288,6 +296,7 @@ async def test_multi_send_setup_commands(
             payload=AddLinearMoveRequestPayload(
                 group_id=UInt8Field(2),
                 seq_id=UInt8Field(0),
+                request_stop_condition=UInt8Field(0),
                 velocity=Int32Field(
                     int(
                         move_group_multiple[2][0][NodeId.pipette_left].velocity_mm_sec
@@ -321,6 +330,7 @@ async def test_multi_send_setup_commands(
             payload=AddLinearMoveRequestPayload(
                 group_id=UInt8Field(2),
                 seq_id=UInt8Field(1),
+                request_stop_condition=UInt8Field(0),
                 velocity=Int32Field(
                     int(
                         move_group_multiple[2][1][NodeId.pipette_left].velocity_mm_sec

--- a/hardware/tests/opentrons_hardware/hardware_control/test_network.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_network.py
@@ -5,13 +5,17 @@ import datetime
 from typing import List, Callable
 from mock import AsyncMock
 from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
-from opentrons_ot3_firmware import ArbitrationId, ArbitrationIdParts, utils
-from opentrons_ot3_firmware.messages import (
+from opentrons_hardware.firmware_bindings import (
+    ArbitrationId,
+    ArbitrationIdParts,
+    utils,
+)
+from opentrons_hardware.firmware_bindings.messages import (
     MessageDefinition,
     message_definitions,
     payloads,
 )
-from opentrons_ot3_firmware.constants import NodeId
+from opentrons_hardware.firmware_bindings.constants import NodeId
 
 from opentrons_hardware.hardware_control.network import probe
 

--- a/hardware/tests/test_scripts/test_can_comm.py
+++ b/hardware/tests/test_scripts/test_can_comm.py
@@ -5,18 +5,18 @@ from mock import MagicMock
 
 import pytest
 
-from opentrons_ot3_firmware.message import (
+from opentrons_hardware.firmware_bindings.message import (
     CanMessage,
 )
-from opentrons_ot3_firmware.arbitration_id import (
+from opentrons_hardware.firmware_bindings.arbitration_id import (
     ArbitrationId,
     ArbitrationIdParts,
 )
-from opentrons_ot3_firmware.messages.payloads import (
+from opentrons_hardware.firmware_bindings.messages.payloads import (
     GetStatusResponsePayload,
 )
 from opentrons_hardware.scripts import can_comm
-from opentrons_ot3_firmware.constants import MessageId, NodeId
+from opentrons_hardware.firmware_bindings.constants import MessageId, NodeId
 
 
 @pytest.fixture


### PR DESCRIPTION
Take the canbus bindings from https://github.com/opentrons/ot3-firmware
python/ subdirectory and put them in opentrons_hardware.

We previously had a python package called opentrons_ot3_firmware that
was defined in a subdirectory of
https://github.com/opentrons/ot3-firmware. That repo contained basically
nothing but structures and enums that defined the structure and values
of canbus messages, so that they could be used from python and generated
to c and c++ from the same source. This was a pretty good idea! But it
fell down in the details of the monorepo package management solution
really not working well with things like poetry, or pyproject.toml, or
dealing with updates, which required elaborate workaround workflows
involving make teardown and make setup.

Instead, let's make the manual step more explicit and straightforward.
The python lives here, which means there's no manual upkeep in this
repository, and no weird workarounds in dependent packages for
optionally-present data. The workaround lives in ot3-firmware, where
when a developer wants to update canbus constant structures they now
make sure the monorepo with their changes is locally checked out and
then run a cmake command to generate the new header structure, which
they check in.
