### PR TITLE
chore(papiv3): add TODO comments for pipette tickets

### DIFF
--- a/api/src/opentrons/protocol_api_experimental/pipette_context.py
+++ b/api/src/opentrons/protocol_api_experimental/pipette_context.py
@@ -58,32 +58,36 @@ class PipetteContext:  # noqa: D101
         )
 
     def __repr__(self) -> str:  # noqa: D105
-        raise NotImplementedError()
-
-    def __str__(self) -> str:  # noqa: D105
+        # TODO: https://github.com/Opentrons/opentrons/issues/9510
         raise NotImplementedError()
 
     @property
     def api_version(self) -> APIVersion:  # noqa: D102
+        # TODO: https://github.com/Opentrons/opentrons/issues/9452
         raise NotImplementedError()
 
     @property
     def starting_tip(self) -> Optional[Well]:  # noqa: D102
+        # TODO: https://github.com/Opentrons/opentrons/issues/9463
         raise NotImplementedError()
 
     @starting_tip.setter
     def starting_tip(self, location: Optional[Well]) -> None:
+        # TODO: https://github.com/Opentrons/opentrons/issues/9463
         raise NotImplementedError()
 
     def reset_tipracks(self) -> None:  # noqa: D102
+        # TODO: https://github.com/Opentrons/opentrons/issues/9463
         raise NotImplementedError()
 
     @property
     def default_speed(self) -> float:  # noqa: D102
+        # TODO: https://github.com/Opentrons/opentrons/issues/9453
         raise NotImplementedError()
 
     @default_speed.setter
     def default_speed(self, speed: float) -> None:
+        # TODO: https://github.com/Opentrons/opentrons/issues/9453
         raise NotImplementedError()
 
     def aspirate(  # noqa: D102
@@ -94,10 +98,12 @@ class PipetteContext:  # noqa: D101
     ) -> PipetteContext:
 
         if volume is None or volume == 0:
-            # todo(mm, 2021-04-14): If None or 0, use highest volume possible.
+            # TODO(mm, 2021-04-14): If None or 0, use highest volume possible.
+            # https://github.com/Opentrons/opentrons/issues/9513
             raise NotImplementedError("volume must be specified.")
 
         if rate != 1:
+            # TODO: https://github.com/Opentrons/opentrons/issues/9465
             raise NotImplementedError(
                 "Protocol Engine does not yet support adjusting flow rates."
             )
@@ -109,17 +115,19 @@ class PipetteContext:  # noqa: D101
                 well_name=location.well_name,
                 well_location=WellLocation(
                     origin=WellOrigin.BOTTOM,
-                    # todo(mm, 2021-04-14): Get default offset in well via
+                    # TODO(mm, 2021-04-14): Get default offset in well via
                     # self.well_bottom_clearance.aspirate, instead of hard-coding.
+                    # https://github.com/Opentrons/opentrons/issues/9512
                     offset=WellOffset(x=0, y=0, z=1),
                 ),
                 volume=volume,
             )
         else:
-            # todo(mm, 2021-04-14):
+            # TODO(mm, 2021-04-14):
             #   * If location is None, use current location.
             #   * If location is a Location (possibly deck coords, or possibly
             #     something like well.top()), use that.
+            # https://github.com/Opentrons/opentrons/issues/9509
             raise NotImplementedError(
                 "locations other than Wells are currently unsupported."
             )
@@ -134,9 +142,11 @@ class PipetteContext:  # noqa: D101
     ) -> PipetteContext:
 
         if rate != 1:
+            # TODO: https://github.com/Opentrons/opentrons/issues/9465
             raise NotImplementedError("Flow rate adjustment not yet supported in PE.")
 
         if volume is None or volume == 0:
+            # TODO: https://github.com/Opentrons/opentrons/issues/9513
             raise NotImplementedError("Volume tracking not yet supported in PE.")
 
         # TODO (spp:
@@ -151,11 +161,13 @@ class PipetteContext:  # noqa: D101
                 well_name=location.well_name,
                 well_location=WellLocation(
                     origin=WellOrigin.BOTTOM,
+                    # https://github.com/Opentrons/opentrons/issues/9512
                     offset=WellOffset(x=0, y=0, z=1),
                 ),
                 volume=volume,
             )
         else:
+            # TODO: https://github.com/Opentrons/opentrons/issues/9509
             raise NotImplementedError(
                 "Dispensing to a non-well location not yet supported in PE."
             )
@@ -168,12 +180,14 @@ class PipetteContext:  # noqa: D101
         location: Optional[Union[types.Location, Well]] = None,
         rate: float = 1.0,
     ) -> PipetteContext:
+        # TODO: https://github.com/Opentrons/opentrons/issues/9466
         raise NotImplementedError()
 
     def blow_out(  # noqa: D102
         self,
         location: Optional[Union[types.Location, Well]] = None,
     ) -> PipetteContext:
+        # TODO: https://github.com/opentrons/opentrons/issues/9524
         raise NotImplementedError()
 
     def touch_tip(  # noqa: D102
@@ -183,6 +197,7 @@ class PipetteContext:  # noqa: D101
         v_offset: float = -1.0,
         speed: float = 60.0,
     ) -> PipetteContext:
+        # TODO: https://github.com/Opentrons/opentrons/issues/9526
         raise NotImplementedError()
 
     def air_gap(  # noqa: D102
@@ -190,9 +205,11 @@ class PipetteContext:  # noqa: D101
         volume: Optional[float] = None,
         height: Optional[float] = None,
     ) -> PipetteContext:
+        # TODO: https://github.com/Opentrons/opentrons/issues/9525
         raise NotImplementedError()
 
     def return_tip(self, home_after: bool = True) -> PipetteContext:  # noqa: D102
+        # TODO: https://github.com/Opentrons/opentrons/issues/9523
         raise NotImplementedError()
 
     def pick_up_tip(  # noqa: D102
@@ -202,10 +219,11 @@ class PipetteContext:  # noqa: D101
         increment: Optional[float] = None,
     ) -> PipetteContext:
         # TODO(al, 2021-04-12): What about presses and increment? They are not
-        #  supported by PE command. They are also not supported by PD protocols
-        #  either.
+        # supported by PE command. They are also not supported by PD protocols
+        # either. https://github.com/Opentrons/opentrons/issues/9523
         if presses is not None or increment is not None:
             raise NotImplementedError()
+
         if isinstance(location, Well):
             self._engine_client.pick_up_tip(
                 pipette_id=self._pipette_id,
@@ -215,6 +233,7 @@ class PipetteContext:  # noqa: D101
         else:
             # TODO(al, 2021-04-12): Support for picking up next tip in a labware
             #  and in tipracks associated with a pipette
+            # https://github.com/Opentrons/opentrons/issues/9461
             raise NotImplementedError()
 
         return self
@@ -225,8 +244,10 @@ class PipetteContext:  # noqa: D101
         home_after: bool = True,
     ) -> PipetteContext:
         # TODO(al, 2021-04-12): What about home_after?
+        # https://github.com/Opentrons/opentrons/issues/9470
         if not home_after:
             raise NotImplementedError()
+
         if isinstance(location, Well):
             self._engine_client.drop_tip(
                 pipette_id=self._pipette_id,
@@ -235,14 +256,17 @@ class PipetteContext:  # noqa: D101
             )
         else:
             # TODO(al, 2021-04-12): Support for dropping tip in trash.
+            # https://github.com/Opentrons/opentrons/issues/9521
             raise NotImplementedError()
 
         return self
 
     def home(self) -> PipetteContext:  # noqa: D102
+        # TODO: https://github.com/Opentrons/opentrons/issues/9470
         raise NotImplementedError()
 
     def home_plunger(self) -> PipetteContext:  # noqa: D102
+        # TODO: https://github.com/Opentrons/opentrons/issues/9470
         raise NotImplementedError()
 
     # TODO(mc, 2021-09-12): explicitely type kwargs, remove args
@@ -254,6 +278,7 @@ class PipetteContext:  # noqa: D101
         *args: Any,
         **kwargs: Any,
     ) -> PipetteContext:
+        # TODO: https://github.com/Opentrons/opentrons/issues/9522
         raise NotImplementedError()
 
     # TODO(mc, 2021-09-12): explicitely type kwargs, remove args
@@ -265,6 +290,7 @@ class PipetteContext:  # noqa: D101
         *args: Any,
         **kwargs: Any,
     ) -> PipetteContext:
+        # TODO: https://github.com/Opentrons/opentrons/issues/9522
         raise NotImplementedError()
 
     # TODO(mc, 2021-09-12): explicitely type kwargs
@@ -276,9 +302,7 @@ class PipetteContext:  # noqa: D101
         trash: bool = True,
         **kwargs: Any,
     ) -> PipetteContext:
-        raise NotImplementedError()
-
-    def delay(self) -> None:  # noqa: D102
+        # TODO: https://github.com/Opentrons/opentrons/issues/9522
         raise NotImplementedError()
 
     def move_to(  # noqa: D102
@@ -288,76 +312,97 @@ class PipetteContext:  # noqa: D101
         minimum_z_height: Optional[float] = None,
         speed: Optional[float] = None,
     ) -> PipetteContext:
+        # TODO: https://github.com/Opentrons/opentrons/issues/9514
         raise NotImplementedError()
 
     @property
     def mount(self) -> str:  # noqa: D102
+        # TODO: https://github.com/Opentrons/opentrons/issues/9516
         raise NotImplementedError()
 
     @property
     def speed(self) -> PlungerSpeeds:  # noqa: D102
+        # TODO(mc, 2022-02-18): Remove this unhelpful API
+        # see https://github.com/Opentrons/opentrons/issues/4837
         raise NotImplementedError()
 
     @property
     def flow_rate(self) -> FlowRates:  # noqa: D102
+        # TODO: https://github.com/Opentrons/opentrons/issues/9465
         raise NotImplementedError()
 
     @property
     def type(self) -> str:  # noqa: D102
+        # TODO(mc, 2022-02-18): remove as redundant and confusing?
         raise NotImplementedError()
 
     @property
     def tip_racks(self) -> List[Labware]:  # noqa: D102
+        # TODO: https://github.com/Opentrons/opentrons/issues/9461
         raise NotImplementedError()
 
     @tip_racks.setter
     def tip_racks(self, racks: List[Labware]) -> None:
+        # TODO: https://github.com/Opentrons/opentrons/issues/9461
         raise NotImplementedError()
 
     @property
     def trash_container(self) -> Labware:  # noqa: D102
+        # https://github.com/Opentrons/opentrons/issues/9521
         raise NotImplementedError()
 
     @trash_container.setter
     def trash_container(self, trash: Labware) -> None:
+        # https://github.com/Opentrons/opentrons/issues/9521
         raise NotImplementedError()
 
     @property
     def name(self) -> str:  # noqa: D102
+        # TODO: https://github.com/Opentrons/opentrons/issues/9516
         raise NotImplementedError()
 
     @property
     def model(self) -> str:  # noqa: D102
+        # TODO: https://github.com/Opentrons/opentrons/issues/9516
         raise NotImplementedError()
 
     @property
     def min_volume(self) -> float:  # noqa: D102
+        # TODO: https://github.com/Opentrons/opentrons/issues/9516
         raise NotImplementedError()
 
     @property
     def max_volume(self) -> float:  # noqa: D102
+        # TODO: https://github.com/Opentrons/opentrons/issues/9516
         raise NotImplementedError()
 
     @property
     def current_volume(self) -> float:  # noqa: D102
+        # TODO: https://github.com/Opentrons/opentrons/issues/9520
         raise NotImplementedError()
 
     @property
     def has_tip(self) -> bool:  # noqa: D102
+        # TODO: https://github.com/Opentrons/opentrons/issues/9520
         raise NotImplementedError()
 
     @property
     def hw_pipette(self) -> PipetteDict:  # noqa: D102
+        # TODO(mc, 2022-02-18): this may not be appropriate to carry forward
+        # investigate whether we want this for PAPIv3.
         raise NotImplementedError()
 
     @property
     def channels(self) -> int:  # noqa: D102
+        # TODO: https://github.com/Opentrons/opentrons/issues/9516
         raise NotImplementedError()
 
     @property
     def return_height(self) -> float:  # noqa: D102
+        # TODO: https://github.com/Opentrons/opentrons/issues/9516
         raise NotImplementedError()
 
     @property
     def well_bottom_clearance(self) -> Clearances:  # noqa: D102
+        # TODO: https://github.com/Opentrons/opentrons/issues/9512
         raise NotImplementedError()


### PR DESCRIPTION
## Overview

This PR adds a bunch of TODO comments linking tickets from #9394 to specific `NotImplementedError`s in PAPIv3's `PipetteContext`.

## Changelog

- refactor(papiv3): add TODO comments for pipette tickets
- Remove unused `PipetteContext.__str__` (in favor of repr)
- Remove unused `PipetteContext.delay` (was an accidental holdover from the PAPIv1 to v2 update)

## Review requests

Nothing specific

## Risk assessment

N/A
