### PR TITLE
refactor(shared-data): mark well location as optional in schema v6

### DIFF
--- a/shared-data/protocol/fixtures/6/oneTiprack.json
+++ b/shared-data/protocol/fixtures/6/oneTiprack.json
@@ -1292,10 +1292,7 @@
         "wellName": "A1",
         "volume": 5,
         "flowRate": 3,
-        "offsetFromBottomMm": 2,
-        "wellLocation": {
-          "origin": "top"
-        }
+        "offsetFromBottomMm": 2
       }
     },
     {
@@ -1327,10 +1324,7 @@
         "pipetteId": "pipetteId",
         "labwareId": "destPlateId",
         "wellName": "B1",
-        "offsetFromBottomMm": 11,
-        "wellLocation": {
-          "origin": "top"
-        }
+        "offsetFromBottomMm": 11
       }
     },
     {

--- a/shared-data/protocol/schemas/6.json
+++ b/shared-data/protocol/schemas/6.json
@@ -77,7 +77,6 @@
     },
 
     "wellLocation": {
-      "required": ["origin"],
       "properties": {
         "origin": {
           "type": "string",


### PR DESCRIPTION
# Overview
This PR marks well location params as optional in schema v6

closes #8843

# Changelog
- Marked well location params as optional in schema v6

# Risk assessment
Low
