### PR TITLE
feat(app): heater shaker wizard power on page

### DIFF
--- a/app/src/assets/localization/en/heater_shaker.json
+++ b/app/src/assets/localization/en/heater_shaker.json
@@ -49,5 +49,6 @@
   "place_the_module_slot": "<block>Place the module in a Slot.</block>",
   "place_the_module_slot_number": "<block>Place the module in <bold>Slot {{slot}}</bold>.</block>",
   "attach_module_extend_anchors": "<block>Hold the module flat against the deck and turn screws <icon></icon> clockwise to <bold>extend the anchors</bold>.",
-  "attach_module_check_attachment": "Check attachment by gently pulling up and rocking the module."
+  "attach_module_check_attachment": "Check attachment by gently pulling up and rocking the module.",
+  "step_3_power_on": "<block><strong>Step 3 of 4: Power on the module</strong></block><block>Connect your module to the robot and and power it on.</block>"
 }

--- a/app/src/assets/localization/en/heater_shaker.json
+++ b/app/src/assets/localization/en/heater_shaker.json
@@ -50,5 +50,6 @@
   "place_the_module_slot_number": "<block>Place the module in <bold>Slot {{slot}}</bold>.</block>",
   "attach_module_extend_anchors": "<block>Hold the module flat against the deck and turn screws <icon></icon> clockwise to <bold>extend the anchors</bold>.",
   "attach_module_check_attachment": "Check attachment by gently pulling up and rocking the module.",
-  "step_3_power_on": "<block><strong>Step 3 of 4: Power on the module</strong></block><block>Connect your module to the robot and and power it on.</block>"
+  "step_3_power_on": "<block><strong>Step 3 of 4: Power on the module</strong></block><block>Connect your module to the robot and and power it on.</block>",
+  "module_is_not_connected": "Module is not connected"
 }

--- a/app/src/organisms/Devices/HeaterShakerWizard/PowerOn.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/PowerOn.tsx
@@ -1,9 +1,90 @@
 import React from 'react'
+import map from 'lodash/map'
+import { useDispatch } from 'react-redux'
+import { Trans, useTranslation } from 'react-i18next'
+import { inferModuleOrientationFromXCoordinate } from '@opentrons/shared-data'
+import {
+  COLORS,
+  DIRECTION_COLUMN,
+  Flex,
+  Module,
+  RobotWorkSpace,
+  SPACING,
+  Text,
+  useInterval,
+} from '@opentrons/components'
+import { fetchModules } from '../../../redux/modules'
+import { Dispatch } from '../../../redux/types'
+import { ModuleInfo } from '../../ProtocolSetup/RunSetupCard/ModuleSetup/ModuleInfo'
+import { useModuleRenderInfoById } from '../../ProtocolSetup/hooks'
+
+const POLL_MODULE_INTERVAL_MS = 5000
+const VIEW_BOX = '-150 -40 440 128'
 
 interface PowerOnProps {
-  status: string
+  robotName: string
 }
-
 export function PowerOn(props: PowerOnProps): JSX.Element {
-  return <div>PowerOn</div>
+  const { robotName } = props
+  const { t } = useTranslation('heater_shaker')
+  const dispatch = useDispatch<Dispatch>()
+  const moduleRenderInfoById = useModuleRenderInfoById()
+
+  useInterval(
+    () => dispatch(fetchModules(robotName)),
+    robotName === null ? POLL_MODULE_INTERVAL_MS : null,
+    true
+  )
+
+  return (
+    <React.Fragment>
+      <Flex
+        color={COLORS.darkBlack}
+        flexDirection={DIRECTION_COLUMN}
+        marginBottom="4rem"
+        data-testid={`heater_shaker_power_on_text`}
+      >
+        <Trans
+          t={t}
+          i18nKey="step_3_power_on"
+          components={{
+            strong: <Text fontWeight={700} paddingBottom={SPACING.spacingSM} />,
+            block: <Text fontSize="1rem" />,
+          }}
+        />
+      </Flex>
+      <RobotWorkSpace
+        viewBox={VIEW_BOX}
+        data-testid={`heater_shaker_svg_and_info`}
+      >
+        {() => (
+          <>
+            {map(moduleRenderInfoById, ({ moduleDef, attachedModuleMatch }) => {
+              const { model } = moduleDef
+              return (
+                <React.Fragment key={`Power_on_${model}`}>
+                  {/* TODO(jr, 2022-02-18): change this to heater shaker model when it exists */}
+                  {model === 'magneticModuleV2' && (
+                    <Module
+                      x={0}
+                      y={0}
+                      orientation={inferModuleOrientationFromXCoordinate(0)}
+                      def={moduleDef}
+                    >
+                      <ModuleInfo
+                        moduleModel={model}
+                        isAttached={attachedModuleMatch != null}
+                        usbPort={attachedModuleMatch?.usbPort.port ?? null}
+                        hubPort={attachedModuleMatch?.usbPort.hub ?? null}
+                      />
+                    </Module>
+                  )}
+                </React.Fragment>
+              )
+            })}
+          </>
+        )}
+      </RobotWorkSpace>
+    </React.Fragment>
+  )
 }

--- a/app/src/organisms/Devices/HeaterShakerWizard/PowerOn.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/PowerOn.tsx
@@ -19,7 +19,6 @@ import type { AttachedModule } from '../../../redux/modules/types'
 
 const VIEW_BOX = '-150 -40 440 128'
 interface PowerOnProps {
-  isAttached: boolean
   attachedModule: AttachedModule | null
 }
 
@@ -59,7 +58,7 @@ export function PowerOn(props: PowerOnProps): JSX.Element {
             >
               <ModuleInfo
                 moduleModel={moduleDef.model}
-                isAttached={props.isAttached}
+                isAttached={props.attachedModule !== null}
                 usbPort={props.attachedModule?.usbPort.port ?? null}
                 hubPort={props.attachedModule?.usbPort.hub ?? null}
               />

--- a/app/src/organisms/Devices/HeaterShakerWizard/PowerOn.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/PowerOn.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
-import map from 'lodash/map'
-import { useDispatch } from 'react-redux'
 import { Trans, useTranslation } from 'react-i18next'
-import { inferModuleOrientationFromXCoordinate } from '@opentrons/shared-data'
+import {
+  getModuleDef2,
+  inferModuleOrientationFromXCoordinate,
+} from '@opentrons/shared-data'
 import {
   COLORS,
   DIRECTION_COLUMN,
@@ -11,30 +12,21 @@ import {
   RobotWorkSpace,
   SPACING,
   Text,
-  useInterval,
 } from '@opentrons/components'
-import { fetchModules } from '../../../redux/modules'
-import { Dispatch } from '../../../redux/types'
 import { ModuleInfo } from '../../ProtocolSetup/RunSetupCard/ModuleSetup/ModuleInfo'
-import { useModuleRenderInfoById } from '../../ProtocolSetup/hooks'
 
-const POLL_MODULE_INTERVAL_MS = 5000
+import type { AttachedModule } from '../../../redux/modules/types'
+
 const VIEW_BOX = '-150 -40 440 128'
-
 interface PowerOnProps {
-  robotName: string
+  isAttached: boolean
+  attachedModule: AttachedModule | null
 }
-export function PowerOn(props: PowerOnProps): JSX.Element {
-  const { robotName } = props
-  const { t } = useTranslation('heater_shaker')
-  const dispatch = useDispatch<Dispatch>()
-  const moduleRenderInfoById = useModuleRenderInfoById()
 
-  useInterval(
-    () => dispatch(fetchModules(robotName)),
-    robotName === null ? POLL_MODULE_INTERVAL_MS : null,
-    true
-  )
+export function PowerOn(props: PowerOnProps): JSX.Element {
+  const { t } = useTranslation('heater_shaker')
+  //  TODO(jr, 2022-02-18): change this to heater shaker model when it exists
+  const moduleDef = getModuleDef2('magneticModuleV2')
 
   return (
     <React.Fragment>
@@ -58,31 +50,21 @@ export function PowerOn(props: PowerOnProps): JSX.Element {
         data-testid={`heater_shaker_svg_and_info`}
       >
         {() => (
-          <>
-            {map(moduleRenderInfoById, ({ moduleDef, attachedModuleMatch }) => {
-              const { model } = moduleDef
-              return (
-                <React.Fragment key={`Power_on_${model}`}>
-                  {/* TODO(jr, 2022-02-18): change this to heater shaker model when it exists */}
-                  {model === 'magneticModuleV2' && (
-                    <Module
-                      x={0}
-                      y={0}
-                      orientation={inferModuleOrientationFromXCoordinate(0)}
-                      def={moduleDef}
-                    >
-                      <ModuleInfo
-                        moduleModel={model}
-                        isAttached={attachedModuleMatch != null}
-                        usbPort={attachedModuleMatch?.usbPort.port ?? null}
-                        hubPort={attachedModuleMatch?.usbPort.hub ?? null}
-                      />
-                    </Module>
-                  )}
-                </React.Fragment>
-              )
-            })}
-          </>
+          <React.Fragment key={`Power_on_${moduleDef.model}`}>
+            <Module
+              x={0}
+              y={0}
+              orientation={inferModuleOrientationFromXCoordinate(0)}
+              def={moduleDef}
+            >
+              <ModuleInfo
+                moduleModel={moduleDef.model}
+                isAttached={props.isAttached}
+                usbPort={props.attachedModule?.usbPort.port ?? null}
+                hubPort={props.attachedModule?.usbPort.hub ?? null}
+              />
+            </Module>
+          </React.Fragment>
         )}
       </RobotWorkSpace>
     </React.Fragment>

--- a/app/src/organisms/Devices/HeaterShakerWizard/PowerOn.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/PowerOn.tsx
@@ -40,7 +40,7 @@ export function PowerOn(props: PowerOnProps): JSX.Element {
           i18nKey="step_3_power_on"
           components={{
             strong: <Text fontWeight={700} paddingBottom={SPACING.spacingSM} />,
-            block: <Text fontSize="1rem" />,
+            block: <span />,
           }}
         />
       </Flex>

--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/HeaterShakerWizard.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/HeaterShakerWizard.test.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react'
+import { when } from 'jest-when'
 import { fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../../i18n'
 import { getConnectedRobotName } from '../../../../redux/robot/selectors'
+import { getAttachedModules } from '../../../../redux/modules'
 import { HeaterShakerWizard } from '..'
 import { Introduction } from '../Introduction'
 import { KeyParts } from '../KeyParts'
@@ -11,6 +13,8 @@ import { AttachAdapter } from '../AttachAdapter'
 import { PowerOn } from '../PowerOn'
 import { TestShake } from '../TestShake'
 
+import { mockConnectedRobot } from '../../../../redux/discovery/__fixtures__'
+
 jest.mock('../../../../redux/robot/selectors')
 jest.mock('../Introduction')
 jest.mock('../KeyParts')
@@ -18,6 +22,7 @@ jest.mock('../AttachModule')
 jest.mock('../AttachAdapter')
 jest.mock('../PowerOn')
 jest.mock('../TestShake')
+jest.mock('../../../../redux/modules')
 
 const mockGetConnectedRobotName = getConnectedRobotName as jest.MockedFunction<
   typeof getConnectedRobotName
@@ -34,6 +39,9 @@ const mockAttachAdapter = AttachAdapter as jest.MockedFunction<
 >
 const mockPowerOn = PowerOn as jest.MockedFunction<typeof PowerOn>
 const mockTestShake = TestShake as jest.MockedFunction<typeof TestShake>
+const mockGetAttachedModules = getAttachedModules as jest.MockedFunction<
+  typeof getAttachedModules
+>
 
 const render = (props: React.ComponentProps<typeof HeaterShakerWizard>) => {
   return renderWithProviders(<HeaterShakerWizard {...props} />, {
@@ -53,6 +61,10 @@ describe('HeaterShakerWizard', () => {
     mockAttachAdapter.mockReturnValue(<div>Mock Attach Adapter</div>)
     mockPowerOn.mockReturnValue(<div>Mock Power On</div>)
     mockTestShake.mockReturnValue(<div>Mock Test Shake</div>)
+
+    when(mockGetAttachedModules)
+      .calledWith(undefined as any, mockConnectedRobot.name)
+      .mockReturnValue([])
   })
 
   it('renders the main modal component of the wizard', () => {
@@ -86,4 +98,6 @@ describe('HeaterShakerWizard', () => {
 
     getByRole('button', { name: 'Complete' })
   })
+  //  TODO(jr, 2022-02-18): get attached modules has an attached heater shaker
+  it.todo('renders power on component and the button is disabled')
 })

--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/HeaterShakerWizard.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/HeaterShakerWizard.test.tsx
@@ -60,7 +60,7 @@ describe('HeaterShakerWizard', () => {
     mockPowerOn.mockReturnValue(<div>Mock Power On</div>)
     mockTestShake.mockReturnValue(<div>Mock Test Shake</div>)
     mockGetAttachedModules
-      //  TODO(jr, 2022-02-18): fit get attached modules to have an attached heater shaker and can click through whole flow
+      //  TODO(jr, 2022-02-18): change to heater shaker when getAttachedModules supports it
       .mockReturnValue([mockMagneticModuleGen2])
   })
 

--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/HeaterShakerWizard.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/HeaterShakerWizard.test.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react'
-import { when } from 'jest-when'
 import { fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../../i18n'
-import { getConnectedRobotName } from '../../../../redux/robot/selectors'
 import { getAttachedModules } from '../../../../redux/modules'
+import { getConnectedRobotName } from '../../../../redux/robot/selectors'
+import { mockMagneticModuleGen2 } from '../../../../redux/modules/__fixtures__'
 import { HeaterShakerWizard } from '..'
 import { Introduction } from '../Introduction'
 import { KeyParts } from '../KeyParts'
@@ -12,8 +12,6 @@ import { AttachModule } from '../AttachModule'
 import { AttachAdapter } from '../AttachAdapter'
 import { PowerOn } from '../PowerOn'
 import { TestShake } from '../TestShake'
-
-import { mockConnectedRobot } from '../../../../redux/discovery/__fixtures__'
 
 jest.mock('../../../../redux/robot/selectors')
 jest.mock('../Introduction')
@@ -61,10 +59,9 @@ describe('HeaterShakerWizard', () => {
     mockAttachAdapter.mockReturnValue(<div>Mock Attach Adapter</div>)
     mockPowerOn.mockReturnValue(<div>Mock Power On</div>)
     mockTestShake.mockReturnValue(<div>Mock Test Shake</div>)
-
-    when(mockGetAttachedModules)
-      .calledWith(undefined as any, mockConnectedRobot.name)
-      .mockReturnValue([])
+    mockGetAttachedModules
+      //  TODO(jr, 2022-02-18): fit get attached modules to have an attached heater shaker and can click through whole flow
+      .mockReturnValue([mockMagneticModuleGen2])
   })
 
   it('renders the main modal component of the wizard', () => {
@@ -73,7 +70,7 @@ describe('HeaterShakerWizard', () => {
     getByText('Mock Introduction')
   })
 
-  it('renders wizard and returns the correct pages when the buttons are clicked', () => {
+  it('renders wizard and returns the correct pages when the buttons are clicked with test shake button disabled', () => {
     const { getByText, getByRole } = render(props)
 
     let button = getByRole('button', { name: 'Continue to attachment guide' })
@@ -98,6 +95,29 @@ describe('HeaterShakerWizard', () => {
 
     getByRole('button', { name: 'Complete' })
   })
-  //  TODO(jr, 2022-02-18): get attached modules has an attached heater shaker
-  it.todo('renders power on component and the button is disabled')
+
+  it('renders power on component and the test shake button is not disabled', () => {
+    mockGetAttachedModules.mockReturnValue([])
+
+    const { getByText, getByRole } = render(props)
+
+    let button = getByRole('button', { name: 'Continue to attachment guide' })
+    fireEvent.click(button)
+    getByText('Mock Key Parts')
+
+    button = getByRole('button', { name: 'Begin attachment' })
+    fireEvent.click(button)
+    getByText('Mock Attach Module')
+
+    button = getByRole('button', { name: 'Continue to attach thermal adapter' })
+    fireEvent.click(button)
+    getByText('Mock Attach Adapter')
+
+    button = getByRole('button', { name: 'Continue to power on module' })
+    fireEvent.click(button)
+    getByText('Mock Power On')
+
+    button = getByRole('button', { name: 'Continue to test shake' })
+    expect(button).toBeDisabled()
+  })
 })

--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/PowerOn.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/PowerOn.test.tsx
@@ -1,15 +1,8 @@
 import * as React from 'react'
-import { when } from 'jest-when'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../../i18n'
-import { useModuleRenderInfoById } from '../../../ProtocolSetup/hooks'
 import { PowerOn } from '../PowerOn'
-
-jest.mock('../../../ProtocolSetup/hooks')
-
-const mockUseModuleRenderInfoById = useModuleRenderInfoById as jest.MockedFunction<
-  typeof useModuleRenderInfoById
->
+import { mockMagneticModuleGen2 } from '../../../../redux/modules/__fixtures__'
 
 const render = (props: React.ComponentProps<typeof PowerOn>) => {
   return renderWithProviders(<PowerOn {...props} />, {
@@ -20,12 +13,12 @@ const render = (props: React.ComponentProps<typeof PowerOn>) => {
 describe('PowerOn', () => {
   let props: React.ComponentProps<typeof PowerOn>
 
+  // TODO(jr, 2022-02-18): fix module model to heater shaker when it exists
   beforeEach(() => {
     props = {
-      robotName: 'Name',
+      isAttached: true,
+      attachedModule: mockMagneticModuleGen2,
     }
-
-    when(mockUseModuleRenderInfoById).calledWith().mockReturnValue({})
   })
   afterEach(() => {
     jest.resetAllMocks()
@@ -38,8 +31,21 @@ describe('PowerOn', () => {
     getByText('Connect your module to the robot and and power it on.')
   })
 
-  // TODO(jr, 2022-02-18): add test when heaterShaker moduleDef and SVG exist
-  it.todo('renders heater shaker SVG with info with module not connected')
+  it('renders heater shaker SVG with info with module not connected', () => {
+    const { getByText } = render(props)
+    getByText('Connected')
+    getByText('Magnetic Module GEN2')
+    getByText('USB Port 1 via hub')
+  })
 
-  it.todo('renders heater shaker SVG with info with module connected')
+  it('renders heater shaker SVG with info with module not connected', () => {
+    props = {
+      isAttached: false,
+      attachedModule: null,
+    }
+    const { getByText } = render(props)
+    getByText('Not connected')
+    getByText('Magnetic Module GEN2')
+    getByText('No USB Port Yet')
+  })
 })

--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/PowerOn.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/PowerOn.test.tsx
@@ -31,7 +31,7 @@ describe('PowerOn', () => {
     getByText('Connect your module to the robot and and power it on.')
   })
 
-  it('renders heater shaker SVG with info with module not connected', () => {
+  it('renders heater shaker SVG with info with module connected', () => {
     const { getByText } = render(props)
     getByText('Connected')
     getByText('Magnetic Module GEN2')

--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/PowerOn.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/PowerOn.test.tsx
@@ -16,7 +16,6 @@ describe('PowerOn', () => {
   // TODO(jr, 2022-02-18): fix module model to heater shaker when it exists
   beforeEach(() => {
     props = {
-      isAttached: true,
       attachedModule: mockMagneticModuleGen2,
     }
   })
@@ -40,7 +39,6 @@ describe('PowerOn', () => {
 
   it('renders heater shaker SVG with info with module not connected', () => {
     props = {
-      isAttached: false,
       attachedModule: null,
     }
     const { getByText } = render(props)

--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/PowerOn.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/PowerOn.test.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react'
+import { when } from 'jest-when'
+import { renderWithProviders } from '@opentrons/components'
+import { i18n } from '../../../../i18n'
+import { useModuleRenderInfoById } from '../../../ProtocolSetup/hooks'
+import { PowerOn } from '../PowerOn'
+
+jest.mock('../../../ProtocolSetup/hooks')
+
+const mockUseModuleRenderInfoById = useModuleRenderInfoById as jest.MockedFunction<
+  typeof useModuleRenderInfoById
+>
+
+const render = (props: React.ComponentProps<typeof PowerOn>) => {
+  return renderWithProviders(<PowerOn {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+describe('PowerOn', () => {
+  let props: React.ComponentProps<typeof PowerOn>
+
+  beforeEach(() => {
+    props = {
+      robotName: 'Name',
+    }
+
+    when(mockUseModuleRenderInfoById).calledWith().mockReturnValue({})
+  })
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('renders correct title and body when protocol has not been uploaded', () => {
+    const { getByText } = render(props)
+
+    getByText('Step 3 of 4: Power on the module')
+    getByText('Connect your module to the robot and and power it on.')
+  })
+
+  // TODO(jr, 2022-02-18): add test when heaterShaker moduleDef and SVG exist
+  it.todo('renders heater shaker SVG with info with module not connected')
+
+  it.todo('renders heater shaker SVG with info with module connected')
+})

--- a/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
@@ -50,7 +50,7 @@ export const HeaterShakerWizard = (
   )
 
   let buttonContent = null
-  let isDisabled: boolean = false
+  let isPrimaryCTADisabled: boolean = false
   const getWizardDisplayPage = (): JSX.Element | null => {
     switch (currentPage) {
       case 0:
@@ -72,12 +72,14 @@ export const HeaterShakerWizard = (
         return <AttachAdapter />
       case 4:
         buttonContent = t('btn_test_shake')
-        isDisabled = heaterShakerAttachedIndex === -1
+        isPrimaryCTADisabled = heaterShakerAttachedIndex === -1
         return (
           <PowerOn
-            isAttached={!isDisabled}
+            isAttached={!isPrimaryCTADisabled}
             attachedModule={
-              !isDisabled ? attachedModules[heaterShakerAttachedIndex] : null
+              !isPrimaryCTADisabled
+                ? attachedModules[heaterShakerAttachedIndex]
+                : null
             }
           />
         )
@@ -123,7 +125,7 @@ export const HeaterShakerWizard = (
           {currentPage <= 5 ? (
             <PrimaryBtn
               alignItems={ALIGN_CENTER}
-              disabled={isDisabled}
+              disabled={isPrimaryCTADisabled}
               {...targetProps}
               backgroundColor={COLORS.blue}
               borderRadius={SPACING.spacingS}
@@ -136,7 +138,7 @@ export const HeaterShakerWizard = (
               }
             >
               {buttonContent}
-              {isDisabled !== false ? (
+              {isPrimaryCTADisabled !== false ? (
                 <Tooltip {...tooltipProps}>
                   {t('module_is_not_connected')}
                 </Tooltip>

--- a/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
@@ -44,13 +44,17 @@ export const HeaterShakerWizard = (
   )
   const [targetProps, tooltipProps] = useHoverTooltip()
 
-  const heaterShakerAttachedIndex = attachedModules.findIndex(
+  const heaterShaker = attachedModules.find(
     //  TODO(jr, 2022-02-18): get heaterShaker module when model exists
     module => module.model === 'magneticModuleV2'
   )
+  let isPrimaryCTAEnabled: boolean = true
+
+  if (currentPage === 4) {
+    isPrimaryCTAEnabled = Boolean(heaterShaker)
+  }
 
   let buttonContent = null
-  let isPrimaryCTADisabled: boolean = false
   const getWizardDisplayPage = (): JSX.Element | null => {
     switch (currentPage) {
       case 0:
@@ -72,17 +76,7 @@ export const HeaterShakerWizard = (
         return <AttachAdapter />
       case 4:
         buttonContent = t('btn_test_shake')
-        isPrimaryCTADisabled = heaterShakerAttachedIndex === -1
-        return (
-          <PowerOn
-            isAttached={!isPrimaryCTADisabled}
-            attachedModule={
-              !isPrimaryCTADisabled
-                ? attachedModules[heaterShakerAttachedIndex]
-                : null
-            }
-          />
-        )
+        return <PowerOn attachedModule={heaterShaker ?? null} />
       case 5:
         buttonContent = t('complete')
         return <TestShake />
@@ -125,7 +119,7 @@ export const HeaterShakerWizard = (
           {currentPage <= 5 ? (
             <PrimaryBtn
               alignItems={ALIGN_CENTER}
-              disabled={isPrimaryCTADisabled}
+              disabled={!isPrimaryCTAEnabled}
               {...targetProps}
               backgroundColor={COLORS.blue}
               borderRadius={SPACING.spacingS}
@@ -138,7 +132,7 @@ export const HeaterShakerWizard = (
               }
             >
               {buttonContent}
-              {isPrimaryCTADisabled !== false ? (
+              {!isPrimaryCTAEnabled ? (
                 <Tooltip {...tooltipProps}>
                   {t('module_is_not_connected')}
                 </Tooltip>

--- a/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
@@ -38,15 +38,15 @@ export const HeaterShakerWizard = (
   const [currentPage, setCurrentPage] = React.useState(0)
   const robotName = useSelector((state: State) => getConnectedRobotName(state))
   const attachedModules = useSelector((state: State) =>
-    getAttachedModules(state, robotName)
+    getAttachedModules(state, robotName === null ? null : robotName)
   )
 
-  if (robotName === null) return null
-
-  const heaterShakerAttached = attachedModules.findIndex(
-    //  TODO(jr, 2022-02-18): get heaterShaker module when model exists
-    module => module.model === 'magneticModuleV2'
-  )
+  const isHeaterShakerAttached =
+    attachedModules != null &&
+    attachedModules.some(
+      //  TODO(jr, 2022-02-18): get heaterShaker module when model exists
+      module => module.model === 'magneticModuleV2'
+    )
 
   let buttonContent = null
   let isDisabled: boolean = false
@@ -71,8 +71,8 @@ export const HeaterShakerWizard = (
         return <AttachAdapter />
       case 4:
         buttonContent = t('btn_test_shake')
-        isDisabled = heaterShakerAttached === -1
-        return <PowerOn robotName={robotName} />
+        isDisabled = !isHeaterShakerAttached
+        return <PowerOn robotName={robotName === null ? '' : robotName} />
       case 5:
         buttonContent = t('complete')
         return <TestShake />

--- a/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
@@ -22,6 +22,8 @@ import {
   SPACING,
   TEXT_TRANSFORM_NONE,
   JUSTIFY_FLEX_END,
+  Tooltip,
+  useHoverTooltip,
 } from '@opentrons/components'
 
 import type { State } from '../../../redux/types'
@@ -40,12 +42,13 @@ export const HeaterShakerWizard = (
   const attachedModules = useSelector((state: State) =>
     getAttachedModules(state, robotName === null ? null : robotName)
   )
+  const [targetProps, tooltipProps] = useHoverTooltip({})
 
   const isHeaterShakerAttached =
     attachedModules != null &&
     attachedModules.some(
       //  TODO(jr, 2022-02-18): get heaterShaker module when model exists
-      module => module.model === 'magneticModuleV2'
+      module => module.model === 'magneticModuleV1'
     )
 
   let buttonContent = null
@@ -116,6 +119,7 @@ export const HeaterShakerWizard = (
             <PrimaryBtn
               alignItems={ALIGN_CENTER}
               disabled={isDisabled}
+              {...targetProps}
               backgroundColor={COLORS.blue}
               borderRadius={SPACING.spacingS}
               textTransform={TEXT_TRANSFORM_NONE}
@@ -127,6 +131,11 @@ export const HeaterShakerWizard = (
               }
             >
               {buttonContent}
+              {isDisabled !== false ? (
+                <Tooltip {...tooltipProps}>
+                  {t('module_is_not_connected')}
+                </Tooltip>
+              ) : null}
             </PrimaryBtn>
           ) : null}
         </Flex>

--- a/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
@@ -44,12 +44,10 @@ export const HeaterShakerWizard = (
   )
   const [targetProps, tooltipProps] = useHoverTooltip()
 
-  const isHeaterShakerAttached =
-    attachedModules != null &&
-    attachedModules.some(
-      //  TODO(jr, 2022-02-18): get heaterShaker module when model exists
-      module => module.model === 'magneticModuleV2'
-    )
+  const heaterShakerAttachedIndex = attachedModules.findIndex(
+    //  TODO(jr, 2022-02-18): get heaterShaker module when model exists
+    module => module.model === 'magneticModuleV2'
+  )
 
   let buttonContent = null
   let isDisabled: boolean = false
@@ -74,8 +72,15 @@ export const HeaterShakerWizard = (
         return <AttachAdapter />
       case 4:
         buttonContent = t('btn_test_shake')
-        isDisabled = !isHeaterShakerAttached
-        return <PowerOn robotName={robotName === null ? '' : robotName} />
+        isDisabled = heaterShakerAttachedIndex === -1
+        return (
+          <PowerOn
+            isAttached={!isDisabled}
+            attachedModule={
+              !isDisabled ? attachedModules[heaterShakerAttachedIndex] : null
+            }
+          />
+        )
       case 5:
         buttonContent = t('complete')
         return <TestShake />

--- a/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
@@ -42,13 +42,13 @@ export const HeaterShakerWizard = (
   const attachedModules = useSelector((state: State) =>
     getAttachedModules(state, robotName === null ? null : robotName)
   )
-  const [targetProps, tooltipProps] = useHoverTooltip({})
+  const [targetProps, tooltipProps] = useHoverTooltip()
 
   const isHeaterShakerAttached =
     attachedModules != null &&
     attachedModules.some(
       //  TODO(jr, 2022-02-18): get heaterShaker module when model exists
-      module => module.model === 'magneticModuleV1'
+      module => module.model === 'magneticModuleV2'
     )
 
   let buttonContent = null

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/index.tsx
@@ -91,8 +91,7 @@ export function ModuleSetup(props: ModuleSetupProps): JSX.Element {
         const { model } = moduleDef
         return (
           <React.Fragment key={index}>
-            {/* @ts-expect-error: this is always false until heater shaker is added to model */}
-            {model === 'heatershakermoduleV1' && (
+            {model === 'magneticModuleV2' && (
               <Flex key="heater_shaker_banner">
                 <HeaterShakerBanner displayName={moduleDef.displayName} />
               </Flex>

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/index.tsx
@@ -91,7 +91,8 @@ export function ModuleSetup(props: ModuleSetupProps): JSX.Element {
         const { model } = moduleDef
         return (
           <React.Fragment key={index}>
-            {model === 'magneticModuleV2' && (
+            {/* @ts-expect-error: this is always false until heater shaker is added to model */}
+            {model === 'heatershakermoduleV1' && (
               <Flex key="heater_shaker_banner">
                 <HeaterShakerBanner displayName={moduleDef.displayName} />
               </Flex>


### PR DESCRIPTION
re #9283 

# Overview

This creates the `PowerOn` component in the heater shaker wizard setup flow. Currently, the heater shaker is stubbed in for a `magneticModuleGen2`

Module powered on and button enabled:
<img width="855" alt="Screen Shot 2022-02-22 at 1 39 08 PM" src="https://user-images.githubusercontent.com/66035149/155197750-661cb549-7682-417f-94af-7d4a17f30592.png">

Module powered off and button disabled:
<img width="854" alt="Screen Shot 2022-02-22 at 1 38 39 PM" src="https://user-images.githubusercontent.com/66035149/155197883-bd42508f-02ce-455b-93bd-9f2dfb21f325.png">

# Changelog

- added on to `PowerOn` component and increased button functionality and tooltip in `HeaterShakerWizard` component

# Review requests

- locally, go to `ModuleSetup` and change the model to equal a module that you have so you can see the setup wizard
- start the wizard and press the continue button until you reach the Power On page
- you should see a title, description, a MagneticModuleGEN2 image with the module info
- the proceed button should be disabled if the module is not activated and should have a tooltip
- the proceed button should not be disabled if the module is plugged in


Note: there are a few things stubbed out and are reminded in comments. A ticket #9519 has been created as a follow up to plug everything in

# Risk assessment

low
