### PR TITLE
ci(windows): pin to windows-2019

### DIFF
--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -57,7 +57,7 @@ jobs:
     needs: [lint]
     strategy:
       matrix:
-        os: ['windows-latest', 'ubuntu-18.04', 'macos-latest']
+        os: ['windows-2019', 'ubuntu-18.04', 'macos-latest']
     runs-on: '${{ matrix.os }}'
     steps:
       - uses: 'actions/checkout@v2'

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -89,7 +89,7 @@ jobs:
     # to run cross-platform just like builds, might as well do them in the same job
     strategy:
       matrix:
-        os: ['windows-latest', 'ubuntu-18.04', 'macos-latest']
+        os: ['windows-2019', 'ubuntu-18.04', 'macos-latest']
     name: 'opentrons app backend unit tests and build'
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/shared-data-test-lint-deploy.yaml
+++ b/.github/workflows/shared-data-test-lint-deploy.yaml
@@ -21,7 +21,6 @@ on:
       - 'shared-data/*/**'
   workflow_dispatch:
 
-
 defaults:
   run:
     shell: bash
@@ -45,14 +44,14 @@ jobs:
           project: 'shared-data/python'
       - name: Lint
         run: make -C shared-data/python lint
-  
+
   python-test:
     name: 'shared-data package python tests'
     timeout-minutes: 20
     needs: [python-lint]
     strategy:
       matrix:
-        os: ['windows-latest', 'ubuntu-18.04', 'macos-latest']
+        os: ['windows-2019', 'ubuntu-18.04', 'macos-latest']
     runs-on: '${{ matrix.os }}'
     steps:
       - uses: 'actions/checkout@v2'

--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -112,8 +112,8 @@ dist-ubuntu-latest: dist-linux
 .PHONY: dist-ubuntu-18.04
 dist-ubuntu-18.04: dist-linux
 
-.PHONY: dist-windows-latest
-dist-windows-latest: dist-win
+.PHONY: dist-windows-2019
+dist-windows-2019: dist-win
 
 # copy distributable artifacts to the publish directory
 # update files will not exist for all OSs, so noop if cp errors


### PR DESCRIPTION
## Overview

GitHub Actions recently updated the `windows-latest` target to [Windows 2022](https://github.blog/changelog/2022-01-11-github-actions-jobs-running-on-windows-latest-are-now-running-on-windows-server-2022/). This causes our builds to break.

This PR pins our Windows runners to the previous value of `windows-2019`. I've targetted this against the 5.0.1 branch to make sure that release goes out smoothly. We'll pick this up in `edge` in the sync-up PR following the release.

## Changelog

- ci(windows): pin to windows-2019

## Review requests

- [ ] CI is green

## Risk assessment

N/A
