### PR TITLE
refactor(papiv3): Start wiring up `MagneticModuleContext.engage()`

### DIFF
--- a/api/src/opentrons/protocol_api_experimental/module_contexts/magnetic_module_context.py
+++ b/api/src/opentrons/protocol_api_experimental/module_contexts/magnetic_module_context.py
@@ -115,18 +115,19 @@ class MagneticModuleContext:  # noqa: D101
             )
 
         state = self._engine_client.state
+        model = state.modules.get_model(module_id=self._module_id)
 
         true_mm_above_base: float
 
         if height is not None:
             true_mm_above_base = state.modules.calculate_magnet_true_mm_above_base(
-                module_id=self._module_id,  # TODO: Change to module model?
+                module_model=model,
                 hardware_units_above_home=height,
             )
 
         elif height_from_base is not None:
             true_mm_above_base = state.modules.calculate_magnet_true_mm_above_base(
-                module_id=self._module_id,
+                module_model=model,
                 hardware_units_above_base=height_from_base,
             )
 
@@ -153,7 +154,7 @@ class MagneticModuleContext:  # noqa: D101
                 )
 
             true_mm_above_base = state.modules.calculate_magnet_true_mm_above_base(
-                module_id=self._module_id,
+                module_model=model,
                 labware_default_true_mm_above_base=labware_default_true_mm_above_base,
                 hardware_units_above_labware_default=(0 if offset is None else offset),
             )

--- a/api/src/opentrons/protocol_api_experimental/module_contexts/magnetic_module_context.py
+++ b/api/src/opentrons/protocol_api_experimental/module_contexts/magnetic_module_context.py
@@ -104,7 +104,9 @@ class MagneticModuleContext:  # noqa: D101
             You must now specify ``height_from_base`` and ``offset`` as keyword
             arguments.
         """  # noqa: D205,D212,D415
-        if len([a for a in [height, height_from_base, offset] if a is not None]) > 1:
+        all_height_arguments = [height, height_from_base, offset]
+        num_height_arguments_provided = len([a for a in all_height_arguments if a is not None])
+        if num_height_arguments_provided > 1:
             raise InvalidMagnetEngageHeightError(
                 "You may only specify one of"
                 " `height`, `height_from_base`, and `offset`."

--- a/api/src/opentrons/protocol_api_experimental/module_contexts/magnetic_module_context.py
+++ b/api/src/opentrons/protocol_api_experimental/module_contexts/magnetic_module_context.py
@@ -120,7 +120,7 @@ class MagneticModuleContext:  # noqa: D101
 
         if height is not None:
             true_mm_above_base = state.modules.calculate_magnet_true_mm_above_base(
-                module_id=self._module_id,
+                module_id=self._module_id,  # TODO: Change to module model?
                 hardware_units_above_home=height,
             )
 
@@ -139,12 +139,12 @@ class MagneticModuleContext:  # noqa: D101
                     " with the `height` or `height_from_base` parameter."
                 )
 
-            default_height_above_base_true_mm = (
+            labware_default_true_mm_above_base = (
                 state.labware.get_magnet_engage_height_above_base_true_mm(
                     labware_id=labware_id
                 )
             )
-            if default_height_above_base_true_mm is None:
+            if labware_default_true_mm_above_base is None:
                 raise InvalidMagnetEngageHeightError(
                     "The labware loaded on this Magnetic Module"
                     " does not have a default engage height,"
@@ -152,13 +152,11 @@ class MagneticModuleContext:  # noqa: D101
                     " with the `height` or `height_from_base` parameter."
                 )
 
-            if offset is None:
-                true_mm_above_base = default_height_above_base_true_mm
-            else:
-                # FIXME(mm, 2022-02-22): In APIv2, GEN1 Magnetic Modules have their
-                # offset argument in units of half-millimeters,
-                # which makes this arithmetic wrong.
-                true_mm_above_base = default_height_above_base_true_mm + offset
+            true_mm_above_base = state.modules.calculate_magnet_true_mm_above_base(
+                module_id=self._module_id,
+                labware_default_true_mm_above_base=labware_default_true_mm_above_base,
+                hardware_units_above_labware_default=(0 if offset is None else offset),
+            )
 
         self._engine_client.magnetic_module_engage(
             module_id=self._module_id,

--- a/api/src/opentrons/protocol_api_experimental/module_contexts/magnetic_module_context.py
+++ b/api/src/opentrons/protocol_api_experimental/module_contexts/magnetic_module_context.py
@@ -110,7 +110,39 @@ class MagneticModuleContext:  # noqa: D101
                 " `height`, `height_from_base`, and `offset`."
             )
 
-        raise NotImplementedError()
+        height_above_base_true_mm: float
+
+        if height is not None:
+            module_state = self._engine_client.state.modules
+            offset_home_to_base = module_state.get_magnet_offset_to_labware_bottom(
+                module_id=self._module_id
+            )
+
+            # FIXME(mm, 2022-02-22): In APIv2, GEN1 Magnetic Modules have their
+            # height argument in units of half-millimeters,
+            # which makes this arithmetic wrong.
+            height_above_base_true_mm = height - offset_home_to_base
+
+        elif height_from_base is not None:
+            # FIXME(mm, 2022-02-22): In APIv2, GEN1 Magnetic Modules have their
+            # height_from_base argument in units of half-millimeters,
+            # which makes this wrong.
+            height_above_base_true_mm = height_from_base
+
+        else:
+            # TODO(mm, 2021-02-22): Get the default height from the loaded labware.
+            # Take care to account for labware-specific differences in units and origin.
+            raise NotImplementedError()
+
+            if offset is not None:
+                # TODO(mm, 2021-02-22): Add offset to the default height.
+                # Take care to account for model-specific differences in units.
+                raise NotImplementedError()
+
+        self._engine_client.magnetic_module_engage(
+            module_id=self._module_id,
+            engage_height=height_above_base_true_mm,
+        )
 
     def disengage(self) -> None:  # noqa: D102
         raise NotImplementedError()

--- a/api/src/opentrons/protocol_api_experimental/module_contexts/magnetic_module_context.py
+++ b/api/src/opentrons/protocol_api_experimental/module_contexts/magnetic_module_context.py
@@ -147,10 +147,8 @@ class MagneticModuleContext:  # noqa: D101
                     " with the `height` or `height_from_base` parameter."
                 )
 
-            default_height = (
-                state.labware.get_default_magnet_height(
-                    labware_id=labware_id
-                )
+            default_height = state.labware.get_default_magnet_height(
+                labware_id=labware_id
             )
             if default_height is None:
                 raise InvalidMagnetEngageHeightError(

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -159,3 +159,15 @@ class SyncClient:
         request = commands.PauseCreate(params=commands.PauseParams(message=message))
         result = self._transport.execute_command(request=request)
         return cast(commands.PauseResult, result)
+
+    def magnetic_module_engage(
+        self, module_id: str, engage_height: float
+    ) -> commands.MagneticModuleEngageResult:
+        """Execute a ``MagneticModuleEngage`` command and return the result."""
+        request = commands.MagneticModuleEngageCreate(
+            params=commands.MagneticModuleEngageParams(
+                moduleId=module_id, engageHeight=engage_height
+            )
+        )
+        result = self._transport.execute_command(request=request)
+        return cast(commands.MagneticModuleEngageResult, result)

--- a/api/src/opentrons/protocol_engine/errors/__init__.py
+++ b/api/src/opentrons/protocol_engine/errors/__init__.py
@@ -21,7 +21,7 @@ from .exceptions import (
     WellOriginNotAllowedError,
     ModuleNotAttachedError,
     ModuleAlreadyPresentError,
-    ModuleIsNotThermocyclerError,
+    WrongModuleTypeError,
     ThermocyclerNotOpenError,
     RobotDoorOpenError,
 )
@@ -50,7 +50,7 @@ __all__ = [
     "WellOriginNotAllowedError",
     "ModuleNotAttachedError",
     "ModuleAlreadyPresentError",
-    "ModuleIsNotThermocyclerError",
+    "WrongModuleTypeError",
     "ThermocyclerNotOpenError",
     "RobotDoorOpenError",
     # error occurrence models

--- a/api/src/opentrons/protocol_engine/errors/exceptions.py
+++ b/api/src/opentrons/protocol_engine/errors/exceptions.py
@@ -100,8 +100,8 @@ class ModuleAlreadyPresentError(ProtocolEngineError):
     """An error raised when a module is already present in a requested location."""
 
 
-class ModuleIsNotThermocyclerError(ProtocolEngineError):
-    """An error raised when performing thermocycler actions with a non-thermocycler."""
+class WrongModuleTypeError(ProtocolEngineError):
+    """An error raised when performing a module action on the wrong kind of module."""
 
 
 class ThermocyclerNotOpenError(ProtocolEngineError):

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -177,6 +177,9 @@ class LabwareView(HasState[LabwareState]):
                 f"Labware {labware_id} not found."
             ) from e
 
+    def get_id_by_module(self, module_id: str) -> str:
+        raise NotImplementedError()
+
     def get_definition(self, labware_id: str) -> LabwareDefinition:
         """Get labware definition by the labware's unique identifier."""
         return self.get_definition_by_uri(
@@ -327,6 +330,9 @@ class LabwareView(HasState[LabwareState]):
             y=dims.yDimension,
             z=dims.zDimension,
         )
+
+    def get_magnet_engage_height_above_base_true_mm(self, labware_id: str) -> float:
+        raise NotImplementedError()
 
     def get_labware_offset_vector(self, labware_id: str) -> LabwareOffsetVector:
         """Get the labware's calibration offset."""

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -177,7 +177,7 @@ class LabwareView(HasState[LabwareState]):
                 f"Labware {labware_id} not found."
             ) from e
 
-    def get_id_by_module(self, module_id: str) -> str:
+    def get_id_by_module(self, module_id: str) -> Optional[str]:
         raise NotImplementedError()
 
     def get_definition(self, labware_id: str) -> LabwareDefinition:
@@ -331,7 +331,9 @@ class LabwareView(HasState[LabwareState]):
             z=dims.zDimension,
         )
 
-    def get_magnet_engage_height_above_base_true_mm(self, labware_id: str) -> float:
+    def get_magnet_engage_height_above_base_true_mm(
+        self, labware_id: str
+    ) -> Optional[float]:
         raise NotImplementedError()
 
     def get_labware_offset_vector(self, labware_id: str) -> LabwareOffsetVector:

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -332,14 +332,12 @@ class LabwareView(HasState[LabwareState]):
             z=dims.zDimension,
         )
 
-    def get_magnet_engage_height_above_base_true_mm(
+    def get_default_magnet_height(
         self, labware_id: str
     ) -> Optional[float]:
         """Return a labware's default Magnetic Module engage height.
 
-        For historical reasons, certain labware that set this property
-        use different units or a different origin point.
-        This function normalizes it to true millimeters above the labware base plane.
+        The returned value is measured in millimeters above the labware base plane.
         """
         raise NotImplementedError()
 

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -178,6 +178,7 @@ class LabwareView(HasState[LabwareState]):
             ) from e
 
     def get_id_by_module(self, module_id: str) -> Optional[str]:
+        """Return the ID of the labware loaded on the given module."""
         raise NotImplementedError()
 
     def get_definition(self, labware_id: str) -> LabwareDefinition:
@@ -334,6 +335,12 @@ class LabwareView(HasState[LabwareState]):
     def get_magnet_engage_height_above_base_true_mm(
         self, labware_id: str
     ) -> Optional[float]:
+        """Return a labware's default Magnetic Module engage height.
+
+        For historical reasons, certain labware that set this property
+        use different units or a different origin point.
+        This function normalizes it to true millimeters above the labware base plane.
+        """
         raise NotImplementedError()
 
     def get_labware_offset_vector(self, labware_id: str) -> LabwareOffsetVector:

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -332,9 +332,7 @@ class LabwareView(HasState[LabwareState]):
             z=dims.zDimension,
         )
 
-    def get_default_magnet_height(
-        self, labware_id: str
-    ) -> Optional[float]:
+    def get_default_magnet_height(self, labware_id: str) -> Optional[float]:
         """Return a labware's default Magnetic Module engage height.
 
         The returned value is measured in millimeters above the labware base plane.

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -283,9 +283,7 @@ class ModuleView(HasState[ModuleState]):
             suitable as input to a Magnetic Module engage Protocol Engine command.
         """
         if height_from_home is not None:
-            home_to_base = cls.get_magnet_home_to_base_offset(
-                module_model=module_model
-            )
+            home_to_base = cls.get_magnet_home_to_base_offset(module_model=module_model)
             return height_from_home - home_to_base
 
         elif height_from_base is not None:

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -188,7 +188,7 @@ class ModuleView(HasState[ModuleState]):
         ):
             return definition.dimensions.lidHeight
         else:
-            raise errors.ModuleIsNotThermocyclerError(
+            raise errors.WrongModuleTypeError(
                 f"Cannot get lid height of {definition.moduleType}"
             )
 

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -235,12 +235,24 @@ class ModuleView(HasState[ModuleState]):
     ) -> float:
         pass
 
+    @overload
+    def calculate_magnet_true_mm_above_base(
+        self,
+        *,
+        module_id: str,
+        labware_default_true_mm_above_base: float,
+        hardware_units_above_labware_default: float,
+    ) -> float:
+        pass
+
     def calculate_magnet_true_mm_above_base(
         self,
         *,
         module_id: str,
         hardware_units_above_home: Optional[float] = None,
         hardware_units_above_base: Optional[float] = None,
+        labware_default_true_mm_above_base: Optional[float] = None,
+        hardware_units_above_labware_default: Optional[float] = None,
     ) -> float:
         """Normalize a Magnetic Module engage height to standard units.
 
@@ -262,12 +274,23 @@ class ModuleView(HasState[ModuleState]):
                 module_id=module_id
             )
             return hardware_units_above_home - true_mm_home_to_base
+
+        elif hardware_units_above_base is not None:
+            # FIXME(mm, 2022-02-24): This is wrong for GEN1 modules
+            # because hardware units are not true millimeters.
+            return hardware_units_above_base
+
         else:
             # Guaranteed statically by overload.
-            assert hardware_units_above_base is not None
-            # FIXME(mm, 2022-02-24): This is wrong for GEN1 modules
-            # because hardeware units are not true millimeters.
-            return hardware_units_above_base
+            assert labware_default_true_mm_above_base is not None
+            assert hardware_units_above_labware_default is not None
+
+            # FIXME(mm, 2022-02-24): This arithmetic is wrong for GEN1 modules
+            # because it mixes units.
+            return (
+                labware_default_true_mm_above_base
+                + hardware_units_above_labware_default
+            )
 
     def should_dodge_thermocycler(
         self,

--- a/api/tests/opentrons/protocol_api_experimental/module_contexts/test_magnetic_module_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/module_contexts/test_magnetic_module_context.py
@@ -1,8 +1,6 @@
 """Tests for `magnetic_module_context`."""
 
 
-from typing import cast
-
 from decoy import Decoy
 import pytest
 

--- a/api/tests/opentrons/protocol_api_experimental/module_contexts/test_magnetic_module_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/module_contexts/test_magnetic_module_context.py
@@ -23,10 +23,16 @@ def engine_client(decoy: Decoy) -> SyncClient:
 
 
 @pytest.fixture
-def subject(engine_client: SyncClient) -> MagneticModuleContext:
+def subject_module_id() -> str:
+    """Return the Protocol Engine module ID of the subject."""
+    return "subject-module-id"
+
+
+@pytest.fixture
+def subject(engine_client: SyncClient, subject_module_id: str) -> MagneticModuleContext:
     """Return a MagneticModuleContext with mocked dependencies."""
     return MagneticModuleContext(
-        engine_client=engine_client, module_id="subject-module-id"
+        engine_client=engine_client, module_id=subject_module_id
     )
 
 
@@ -39,12 +45,13 @@ def test_load_labware_default_namespace_and_version(
     decoy: Decoy,
     minimal_labware_def: LabwareDefinition,
     engine_client: SyncClient,
+    subject_module_id: str,
     subject: MagneticModuleContext,
 ) -> None:
     """It should default namespace to "opentrons" and version to 1."""
     decoy.when(
         engine_client.load_labware(
-            location=ModuleLocation(moduleId="subject-module-id"),
+            location=ModuleLocation(moduleId=subject_module_id),
             load_name="some_labware",
             namespace="opentrons",
             version=1,
@@ -65,12 +72,13 @@ def test_load_labware_explicit_namespace_and_version(
     decoy: Decoy,
     minimal_labware_def: LabwareDefinition,
     engine_client: SyncClient,
+    subject_module_id: str,
     subject: MagneticModuleContext,
 ) -> None:
     """It should pass along the namespace, version, and load name."""
     decoy.when(
         engine_client.load_labware(
-            location=ModuleLocation(moduleId="subject-module-id"),
+            location=ModuleLocation(moduleId=subject_module_id),
             load_name="some_labware",
             namespace="some_explicit_namespace",
             version=9001,

--- a/api/tests/opentrons/protocol_api_experimental/module_contexts/test_magnetic_module_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/module_contexts/test_magnetic_module_context.py
@@ -167,6 +167,10 @@ def test_engage_height_from_base(
         )
     )
 
+# To do before merge: Test error if no labware loaded and use offset or none
+# To do before merge: Test error if labware loaded does not have intrinsic heigh
+# Check error strings for specificity
+
 
 @pytest.mark.xfail(strict=True, raises=NotImplementedError)
 def test_engage_offset(subject: MagneticModuleContext) -> None:  # noqa: D103

--- a/api/tests/opentrons/protocol_api_experimental/module_contexts/test_magnetic_module_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/module_contexts/test_magnetic_module_context.py
@@ -155,9 +155,9 @@ def test_engage_with_height_from_home(
         engine_client.state.modules.get_model(module_id=subject_module_id)
     ).then_return(ModuleModel.MAGNETIC_MODULE_V1)
     decoy.when(
-        engine_client.state.modules.calculate_magnet_true_mm_above_base(
+        engine_client.state.modules.calculate_magnet_height(
             module_model=ModuleModel.MAGNETIC_MODULE_V1,
-            hardware_units_above_home=12.34,
+            height_from_home=12.34,
         )
     ).then_return(56.78)
     subject.engage(height=12.34)
@@ -179,9 +179,9 @@ def test_engage_with_height_from_base(
         engine_client.state.modules.get_model(module_id=subject_module_id)
     ).then_return(ModuleModel.MAGNETIC_MODULE_V1)
     decoy.when(
-        engine_client.state.modules.calculate_magnet_true_mm_above_base(
+        engine_client.state.modules.calculate_magnet_height(
             module_model=ModuleModel.MAGNETIC_MODULE_V1,
-            hardware_units_above_base=12.34,
+            height_from_base=12.34,
         )
     ).then_return(56.78)
     subject.engage(height_from_base=12.34)
@@ -206,15 +206,15 @@ def test_engage_with_offset(
         engine_client.state.labware.get_id_by_module(module_id=subject_module_id)
     ).then_return("labware-id")
     decoy.when(
-        engine_client.state.labware.get_magnet_engage_height_above_base_true_mm(
+        engine_client.state.labware.get_default_magnet_height(
             labware_id="labware-id"
         )
     ).then_return(1.23)
     decoy.when(
-        engine_client.state.modules.calculate_magnet_true_mm_above_base(
+        engine_client.state.modules.calculate_magnet_height(
             module_model=ModuleModel.MAGNETIC_MODULE_V1,
-            labware_default_true_mm_above_base=1.23,
-            hardware_units_above_labware_default=4.56,
+            labware_default_height=1.23,
+            offset_from_labware_default=4.56,
         )
     ).then_return(7.89)
     subject.engage(offset=4.56)
@@ -239,15 +239,15 @@ def test_engage_with_no_arguments(
         engine_client.state.labware.get_id_by_module(module_id=subject_module_id)
     ).then_return("labware-id")
     decoy.when(
-        engine_client.state.labware.get_magnet_engage_height_above_base_true_mm(
+        engine_client.state.labware.get_default_magnet_height(
             labware_id="labware-id"
         )
     ).then_return(1.23)
     decoy.when(
-        engine_client.state.modules.calculate_magnet_true_mm_above_base(
+        engine_client.state.modules.calculate_magnet_height(
             module_model=ModuleModel.MAGNETIC_MODULE_V1,
-            labware_default_true_mm_above_base=1.23,
-            hardware_units_above_labware_default=0,
+            labware_default_height=1.23,
+            offset_from_labware_default=0,
         )
     ).then_return(7.89)
     subject.engage()
@@ -288,7 +288,7 @@ def test_engage_based_on_labware_errors_when_labware_has_no_default_height(
         engine_client.state.labware.get_id_by_module(module_id=subject_module_id)
     ).then_return("labware-id")
     decoy.when(
-        engine_client.state.labware.get_magnet_engage_height_above_base_true_mm(
+        engine_client.state.labware.get_default_magnet_height(
             labware_id="labware-id"
         )
     ).then_return(None)

--- a/api/tests/opentrons/protocol_api_experimental/module_contexts/test_magnetic_module_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/module_contexts/test_magnetic_module_context.py
@@ -254,9 +254,12 @@ def test_engage_based_on_labware_errors_when_no_labware_loaded(
     decoy.when(
         engine_client.state.labware.get_id_by_module(module_id=subject_module_id)
     ).then_return(None)
-    with pytest.raises(InvalidMagnetEngageHeightError, match="no labware loaded"):
+    expected_exception_text = "no labware loaded"
+    with pytest.raises(InvalidMagnetEngageHeightError, match=expected_exception_text):
         subject.engage(offset=1.23)
-    with pytest.raises(InvalidMagnetEngageHeightError, match="no labware loaded"):
+    with pytest.raises(InvalidMagnetEngageHeightError, match=expected_exception_text):
+        subject.engage(offset=0)
+    with pytest.raises(InvalidMagnetEngageHeightError, match=expected_exception_text):
         subject.engage()
 
 
@@ -275,9 +278,12 @@ def test_engage_based_on_labware_errors_when_labware_has_no_default_height(
             labware_id="labware-id"
         )
     ).then_return(None)
-    with pytest.raises(InvalidMagnetEngageHeightError, match="does not have a default"):
+    expected_exception_text = "does not have a default"
+    with pytest.raises(InvalidMagnetEngageHeightError, match=expected_exception_text):
         subject.engage(offset=1.23)
-    with pytest.raises(InvalidMagnetEngageHeightError, match="does not have a default"):
+    with pytest.raises(InvalidMagnetEngageHeightError, match=expected_exception_text):
+        subject.engage(offset=0)
+    with pytest.raises(InvalidMagnetEngageHeightError, match=expected_exception_text):
         subject.engage()
 
 

--- a/api/tests/opentrons/protocol_api_experimental/module_contexts/test_magnetic_module_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/module_contexts/test_magnetic_module_context.py
@@ -141,14 +141,15 @@ def test_engage_height_from_home(
 ) -> None:
     """It should pass the correct height to the Protocol Engine command."""
     decoy.when(
-        engine_client.state.modules.get_magnet_offset_to_labware_bottom(
-            module_id=subject_module_id
+        engine_client.state.modules.calculate_magnet_true_mm_above_base(
+            module_id=subject_module_id,
+            hardware_units_above_home=12.34,
         )
-    ).then_return(1.1)
-    subject.engage(height=3.3)
+    ).then_return(56.78)
+    subject.engage(height=12.34)
     decoy.verify(
         engine_client.magnetic_module_engage(
-            module_id=subject_module_id, engage_height=cast(float, pytest.approx(2.2))
+            module_id=subject_module_id, engage_height=56.78
         ),
     )
 
@@ -160,12 +161,19 @@ def test_engage_height_from_base(
     subject: MagneticModuleContext,
 ) -> None:
     """It should pass the correct height to the Protocol Engine command."""
+    decoy.when(
+        engine_client.state.modules.calculate_magnet_true_mm_above_base(
+            module_id=subject_module_id,
+            hardware_units_above_base=12.34,
+        )
+    ).then_return(56.78)
     subject.engage(height_from_base=12.34)
     decoy.verify(
         engine_client.magnetic_module_engage(
-            module_id=subject_module_id, engage_height=12.34
+            module_id=subject_module_id, engage_height=56.78
         )
     )
+
 
 # To do before merge: Test error if no labware loaded and use offset or none
 # To do before merge: Test error if labware loaded does not have intrinsic heigh

--- a/api/tests/opentrons/protocol_api_experimental/module_contexts/test_magnetic_module_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/module_contexts/test_magnetic_module_context.py
@@ -206,9 +206,7 @@ def test_engage_with_offset(
         engine_client.state.labware.get_id_by_module(module_id=subject_module_id)
     ).then_return("labware-id")
     decoy.when(
-        engine_client.state.labware.get_default_magnet_height(
-            labware_id="labware-id"
-        )
+        engine_client.state.labware.get_default_magnet_height(labware_id="labware-id")
     ).then_return(1.23)
     decoy.when(
         engine_client.state.modules.calculate_magnet_height(
@@ -239,9 +237,7 @@ def test_engage_with_no_arguments(
         engine_client.state.labware.get_id_by_module(module_id=subject_module_id)
     ).then_return("labware-id")
     decoy.when(
-        engine_client.state.labware.get_default_magnet_height(
-            labware_id="labware-id"
-        )
+        engine_client.state.labware.get_default_magnet_height(labware_id="labware-id")
     ).then_return(1.23)
     decoy.when(
         engine_client.state.modules.calculate_magnet_height(
@@ -288,9 +284,7 @@ def test_engage_based_on_labware_errors_when_labware_has_no_default_height(
         engine_client.state.labware.get_id_by_module(module_id=subject_module_id)
     ).then_return("labware-id")
     decoy.when(
-        engine_client.state.labware.get_default_magnet_height(
-            labware_id="labware-id"
-        )
+        engine_client.state.labware.get_default_magnet_height(labware_id="labware-id")
     ).then_return(None)
     expected_exception_text = "does not have a default"
     with pytest.raises(InvalidMagnetEngageHeightError, match=expected_exception_text):

--- a/api/tests/opentrons/protocol_api_experimental/module_contexts/test_magnetic_module_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/module_contexts/test_magnetic_module_context.py
@@ -8,7 +8,11 @@ import pytest
 
 from opentrons.protocols.models import LabwareDefinition
 
-from opentrons.protocol_engine import ModuleLocation, commands as pe_commands
+from opentrons.protocol_engine import (
+    ModuleLocation,
+    ModuleModel,
+    commands as pe_commands,
+)
 from opentrons.protocol_engine.clients import SyncClient
 
 from opentrons.protocol_api_experimental import (
@@ -150,8 +154,11 @@ def test_engage_with_height_from_home(
 ) -> None:
     """It should pass the correct height to the Protocol Engine command."""
     decoy.when(
+        engine_client.state.modules.get_model(module_id=subject_module_id)
+    ).then_return(ModuleModel.MAGNETIC_MODULE_V1)
+    decoy.when(
         engine_client.state.modules.calculate_magnet_true_mm_above_base(
-            module_id=subject_module_id,
+            module_model=ModuleModel.MAGNETIC_MODULE_V1,
             hardware_units_above_home=12.34,
         )
     ).then_return(56.78)
@@ -171,8 +178,11 @@ def test_engage_with_height_from_base(
 ) -> None:
     """It should pass the correct height to the Protocol Engine command."""
     decoy.when(
+        engine_client.state.modules.get_model(module_id=subject_module_id)
+    ).then_return(ModuleModel.MAGNETIC_MODULE_V1)
+    decoy.when(
         engine_client.state.modules.calculate_magnet_true_mm_above_base(
-            module_id=subject_module_id,
+            module_model=ModuleModel.MAGNETIC_MODULE_V1,
             hardware_units_above_base=12.34,
         )
     ).then_return(56.78)
@@ -192,6 +202,9 @@ def test_engage_with_offset(
 ) -> None:
     """It should use the offset combined with the labware's default engage height."""
     decoy.when(
+        engine_client.state.modules.get_model(module_id=subject_module_id)
+    ).then_return(ModuleModel.MAGNETIC_MODULE_V1)
+    decoy.when(
         engine_client.state.labware.get_id_by_module(module_id=subject_module_id)
     ).then_return("labware-id")
     decoy.when(
@@ -201,7 +214,7 @@ def test_engage_with_offset(
     ).then_return(1.23)
     decoy.when(
         engine_client.state.modules.calculate_magnet_true_mm_above_base(
-            module_id=subject_module_id,
+            module_model=ModuleModel.MAGNETIC_MODULE_V1,
             labware_default_true_mm_above_base=1.23,
             hardware_units_above_labware_default=4.56,
         )
@@ -222,6 +235,9 @@ def test_engage_with_no_arguments(
 ) -> None:
     """It should use the default engage height from the labware."""
     decoy.when(
+        engine_client.state.modules.get_model(module_id=subject_module_id)
+    ).then_return(ModuleModel.MAGNETIC_MODULE_V1)
+    decoy.when(
         engine_client.state.labware.get_id_by_module(module_id=subject_module_id)
     ).then_return("labware-id")
     decoy.when(
@@ -231,7 +247,7 @@ def test_engage_with_no_arguments(
     ).then_return(1.23)
     decoy.when(
         engine_client.state.modules.calculate_magnet_true_mm_above_base(
-            module_id=subject_module_id,
+            module_model=ModuleModel.MAGNETIC_MODULE_V1,
             labware_default_true_mm_above_base=1.23,
             hardware_units_above_labware_default=0,
         )

--- a/api/tests/opentrons/protocol_api_experimental/module_contexts/test_magnetic_module_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/module_contexts/test_magnetic_module_context.py
@@ -121,8 +121,10 @@ def test_labware_property(subject: MagneticModuleContext) -> None:  # noqa: D103
 
 def test_engage_only_one_height_allowed(subject: MagneticModuleContext) -> None:
     """It should raise if you provide conflicting height arguments."""
-    # The type-checker wants to stop us from miscalling this function, but
+    # The type: ignore[call-overloads] are because
+    # the type-checker wants to stop us from miscalling this function, but
     # we need to test that the function protects itself when there is no type-checker.
+
     with pytest.raises(InvalidMagnetEngageHeightError):
         subject.engage(height=1, height_from_base=2, offset=3)  # type: ignore[call-overload]  # noqa: E501
     with pytest.raises(InvalidMagnetEngageHeightError):
@@ -131,6 +133,13 @@ def test_engage_only_one_height_allowed(subject: MagneticModuleContext) -> None:
         subject.engage(height=1, offset=3)  # type: ignore[call-overload]
     with pytest.raises(InvalidMagnetEngageHeightError):
         subject.engage(height_from_base=2, offset=3)  # type: ignore[call-overload]
+
+    # Explicitly providing an offset value of 0 is intuitively equivalent to not
+    # providing any offset, but it should still be mutually exclusive with other args.
+    with pytest.raises(InvalidMagnetEngageHeightError):
+        subject.engage(height=123, offset=0)  # type: ignore[call-overload]
+    with pytest.raises(InvalidMagnetEngageHeightError):
+        subject.engage(height_from_base=123, offset=0)  # type: ignore[call-overload]
 
 
 def test_engage_height_from_home(
@@ -173,6 +182,7 @@ def test_engage_height_from_base(
             module_id=subject_module_id, engage_height=56.78
         )
     )
+
 
 
 # To do before merge: Test error if no labware loaded and use offset or none

--- a/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
@@ -261,3 +261,23 @@ def test_pause(
     result = subject.pause(message="hello world")
 
     assert result == response
+
+
+def test_magnetic_module_engage(
+    decoy: Decoy,
+    transport: AbstractSyncTransport,
+    subject: SyncClient,
+) -> None:
+    """It should execute a Magnetic Module engage command."""
+    request = commands.MagneticModuleEngageCreate(
+        params=commands.MagneticModuleEngageParams(
+            moduleId="module-id", engageHeight=12.34
+        )
+    )
+    response = commands.MagneticModuleEngageResult()
+
+    decoy.when(transport.execute_command(request=request)).then_return(response)
+
+    result = subject.magnetic_module_engage(module_id="module-id", engage_height=12.34)
+
+    assert result == response

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -87,6 +87,12 @@ def test_get_labware_data_by_id() -> None:
     assert subject.get("plate-id") == plate
 
 
+@pytest.mark.xfail(strict=True, raises=NotImplementedError)
+def test_get_id_by_module() -> None:
+    subject = get_labware_view()
+    _ = subject.get_id_by_module(module_id="module-id")
+
+
 def test_get_labware_definition(well_plate_def: LabwareDefinition) -> None:
     """It should get a labware's definition from the state."""
     subject = get_labware_view(
@@ -347,6 +353,12 @@ def test_get_dimensions(well_plate_def: LabwareDefinition) -> None:
         y=well_plate_def.dimensions.yDimension,
         z=well_plate_def.dimensions.zDimension,
     )
+
+
+@pytest.mark.xfail(strict=True, raises=NotImplementedError)
+def test_get_default_magnet_height() -> None:
+    subject = get_labware_view()
+    _ = subject.get_default_magnet_height("labware-id")
 
 
 def test_get_deck_definition(standard_deck_def: DeckDefinitionV2) -> None:

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -88,7 +88,7 @@ def test_get_labware_data_by_id() -> None:
 
 
 @pytest.mark.xfail(strict=True, raises=NotImplementedError)
-def test_get_id_by_module() -> None:
+def test_get_id_by_module() -> None:  # noqa: D103
     subject = get_labware_view()
     _ = subject.get_id_by_module(module_id="module-id")
 
@@ -356,7 +356,7 @@ def test_get_dimensions(well_plate_def: LabwareDefinition) -> None:
 
 
 @pytest.mark.xfail(strict=True, raises=NotImplementedError)
-def test_get_default_magnet_height() -> None:
+def test_get_default_magnet_height() -> None:  # noqa: D103
     subject = get_labware_view()
     _ = subject.get_default_magnet_height("labware-id")
 

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -147,7 +147,7 @@ def test_get_properties_by_id(
     )
 
 
-def test_get_magnet_offset_to_labware_bottom(
+def test_get_magnet_true_mm_home_to_base(
     magdeck_v1_def: ModuleDefinition,
     magdeck_v2_def: ModuleDefinition,
 ) -> None:
@@ -169,8 +169,8 @@ def test_get_magnet_offset_to_labware_bottom(
         },
     )
 
-    assert subject.get_magnet_offset_to_labware_bottom(module_id="magdeck-v1-id") == 2.5
-    assert subject.get_magnet_offset_to_labware_bottom(module_id="magdeck-v2-id") == 2.5
+    assert subject.get_magnet_true_mm_home_to_base(module_id="magdeck-v1-id") == 2.5
+    assert subject.get_magnet_true_mm_home_to_base(module_id="magdeck-v2-id") == 2.5
 
 
 @pytest.mark.parametrize(

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -167,7 +167,7 @@ def test_get_magnet_home_to_base_offset() -> None:
 @pytest.mark.parametrize(
     "module_model", [ModuleModel.MAGNETIC_MODULE_V1, ModuleModel.MAGNETIC_MODULE_V2]
 )
-def test_calculate_magnet_height_gen2(module_model: ModuleModel) -> None:
+def test_calculate_magnet_height(module_model: ModuleModel) -> None:
     """It should use true millimeters as hardware units."""
     subject = make_module_view()
 

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -164,6 +164,53 @@ def test_get_magnet_true_mm_home_to_base() -> None:
     )
 
 
+@pytest.mark.xfail(strict=True)
+def test_calculate_magnet_true_mm_above_base_gen1() -> None:
+    """It should use half-millimeters as hardware units."""
+    subject = make_module_view()
+
+    assert (
+        subject.calculate_magnet_true_mm_above_base(
+            module_model=ModuleModel.MAGNETIC_MODULE_V1,
+            hardware_units_above_base=100,
+        )
+        == 50
+    )
+
+    # TODO: Test hardware_units_above_home, etc. when we better understand
+    # the APIv2 behavior that we need to preserve.
+
+
+def test_calculate_magnet_true_mm_above_base_gen2() -> None:
+    """It should use true millimeters as hardware units."""
+    subject = make_module_view()
+
+    assert (
+        subject.calculate_magnet_true_mm_above_base(
+            module_model=ModuleModel.MAGNETIC_MODULE_V2,
+            hardware_units_above_base=100,
+        )
+        == 100
+    )
+
+    assert (
+        subject.calculate_magnet_true_mm_above_base(
+            module_model=ModuleModel.MAGNETIC_MODULE_V2,
+            hardware_units_above_home=100,
+        )
+        == 97.5
+    )
+
+    assert (
+        subject.calculate_magnet_true_mm_above_base(
+            module_model=ModuleModel.MAGNETIC_MODULE_V2,
+            labware_default_true_mm_above_base=100,
+            hardware_units_above_labware_default=10.0,
+        )
+        == 110
+    )
+
+
 @pytest.mark.parametrize(
     argnames=["from_slot", "to_slot", "should_dodge"],
     argvalues=[

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -18,7 +18,7 @@ from opentrons.protocol_engine.state.modules import (
 )
 
 
-def get_module_view(
+def make_module_view(
     slot_by_module_id: Optional[Dict[str, DeckSlotName]] = None,
     hardware_module_by_slot: Optional[Dict[DeckSlotName, HardwareModule]] = None,
 ) -> ModuleView:
@@ -33,7 +33,7 @@ def get_module_view(
 
 def test_initial_module_data_by_id() -> None:
     """It should raise if module ID doesn't exist."""
-    subject = get_module_view()
+    subject = make_module_view()
 
     with pytest.raises(errors.ModuleDoesNotExistError):
         subject.get("helloWorld")
@@ -41,7 +41,7 @@ def test_initial_module_data_by_id() -> None:
 
 def test_get_missing_hardware() -> None:
     """It should raise if no loaded hardware."""
-    subject = get_module_view(slot_by_module_id={"module-id": DeckSlotName.SLOT_1})
+    subject = make_module_view(slot_by_module_id={"module-id": DeckSlotName.SLOT_1})
 
     with pytest.raises(errors.ModuleDoesNotExistError):
         subject.get("module-id")
@@ -49,7 +49,7 @@ def test_get_missing_hardware() -> None:
 
 def test_get_module_data(tempdeck_v1_def: ModuleDefinition) -> None:
     """It should get module data from state by ID."""
-    subject = get_module_view(
+    subject = make_module_view(
         slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
         hardware_module_by_slot={
             DeckSlotName.SLOT_1: HardwareModule(
@@ -73,7 +73,7 @@ def test_get_all_modules(
     tempdeck_v2_def: ModuleDefinition,
 ) -> None:
     """It should return all modules in state."""
-    subject = get_module_view(
+    subject = make_module_view(
         slot_by_module_id={
             "module-1": DeckSlotName.SLOT_1,
             "module-2": DeckSlotName.SLOT_2,
@@ -113,7 +113,7 @@ def test_get_properties_by_id(
     tempdeck_v2_def: ModuleDefinition,
 ) -> None:
     """It should return a loaded module's properties by ID."""
-    subject = get_module_view(
+    subject = make_module_view(
         slot_by_module_id={
             "module-1": DeckSlotName.SLOT_1,
             "module-2": DeckSlotName.SLOT_2,
@@ -178,7 +178,7 @@ def test_thermocycler_dodging(
     It should return True if thermocycler exists and movement is between bad pairs of
     slot locations.
     """
-    subject = get_module_view(
+    subject = make_module_view(
         slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
         hardware_module_by_slot={
             DeckSlotName.SLOT_1: HardwareModule(
@@ -196,7 +196,7 @@ def test_thermocycler_dodging(
 
 def test_find_attached_module_rejects_missing() -> None:
     """It should raise if the correct module isn't attached."""
-    subject = get_module_view()
+    subject = make_module_view()
 
     with pytest.raises(errors.ModuleNotAttachedError):
         subject.find_attached_module(
@@ -223,7 +223,7 @@ def test_find_attached_module(
     attached_definition: ModuleDefinition,
 ) -> None:
     """It should return the first attached module that matches."""
-    subject = get_module_view()
+    subject = make_module_view()
 
     attached_modules = [
         HardwareModule(serial_number="serial-1", definition=attached_definition),
@@ -244,7 +244,7 @@ def test_find_attached_module_skips_non_matching(
     magdeck_v2_def: ModuleDefinition,
 ) -> None:
     """It should skip over non-matching modules."""
-    subject = get_module_view()
+    subject = make_module_view()
 
     attached_modules = [
         HardwareModule(serial_number="serial-1", definition=magdeck_v1_def),
@@ -264,7 +264,7 @@ def test_find_attached_module_skips_already_loaded(
     magdeck_v1_def: ModuleDefinition,
 ) -> None:
     """It should skip over already assigned modules."""
-    subject = get_module_view(
+    subject = make_module_view(
         hardware_module_by_slot={
             DeckSlotName.SLOT_1: HardwareModule(
                 serial_number="serial-1",
@@ -291,7 +291,7 @@ def test_find_attached_module_reuses_already_loaded(
     magdeck_v1_def: ModuleDefinition,
 ) -> None:
     """It should reuse over already assigned modules in the same location."""
-    subject = get_module_view(
+    subject = make_module_view(
         hardware_module_by_slot={
             DeckSlotName.SLOT_1: HardwareModule(
                 serial_number="serial-1",
@@ -319,7 +319,7 @@ def test_find_attached_module_rejects_location_reassignment(
     tempdeck_v1_def: ModuleDefinition,
 ) -> None:
     """It should raise if a non-matching module is already present in the slot."""
-    subject = get_module_view(
+    subject = make_module_view(
         hardware_module_by_slot={
             DeckSlotName.SLOT_1: HardwareModule(
                 serial_number="serial-1",

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -165,8 +165,7 @@ def test_get_magnet_home_to_base_offset() -> None:
 
 
 @pytest.mark.parametrize(
-    "module_model",
-    [ModuleModel.MAGNETIC_MODULE_V1, ModuleModel.MAGNETIC_MODULE_V2]
+    "module_model", [ModuleModel.MAGNETIC_MODULE_V1, ModuleModel.MAGNETIC_MODULE_V2]
 )
 def test_calculate_magnet_height_gen2(module_model: ModuleModel) -> None:
     """It should use true millimeters as hardware units."""

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -147,6 +147,32 @@ def test_get_properties_by_id(
     )
 
 
+def test_get_magnet_offset_to_labware_bottom(
+    magdeck_v1_def: ModuleDefinition,
+    magdeck_v2_def: ModuleDefinition,
+) -> None:
+    """It should return the model-specific offset to bottom."""
+    subject = make_module_view(
+        slot_by_module_id={
+            "magdeck-v1-id": DeckSlotName.SLOT_1,
+            "magdeck-v2-id": DeckSlotName.SLOT_2,
+        },
+        hardware_module_by_slot={
+            DeckSlotName.SLOT_1: HardwareModule(
+                serial_number="magdeck-v1-serial",
+                definition=magdeck_v1_def,
+            ),
+            DeckSlotName.SLOT_2: HardwareModule(
+                serial_number="magdeck-v2-serial",
+                definition=magdeck_v2_def,
+            ),
+        },
+    )
+
+    assert subject.get_magnet_offset_to_labware_bottom(module_id="magdeck-v1-id") == 2.5
+    assert subject.get_magnet_offset_to_labware_bottom(module_id="magdeck-v2-id") == 2.5
+
+
 @pytest.mark.parametrize(
     argnames=["from_slot", "to_slot", "should_dodge"],
     argvalues=[

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -147,65 +147,59 @@ def test_get_properties_by_id(
     )
 
 
-def test_get_magnet_true_mm_home_to_base() -> None:
+def test_get_magnet_home_to_base_offset() -> None:
     """It should return the model-specific offset to bottom."""
     subject = make_module_view()
     assert (
-        subject.get_magnet_true_mm_home_to_base(
+        subject.get_magnet_home_to_base_offset(
             module_model=ModuleModel.MAGNETIC_MODULE_V1
         )
         == 2.5
     )
     assert (
-        subject.get_magnet_true_mm_home_to_base(
+        subject.get_magnet_home_to_base_offset(
             module_model=ModuleModel.MAGNETIC_MODULE_V2
         )
         == 2.5
     )
 
 
-@pytest.mark.xfail(strict=True)
-def test_calculate_magnet_true_mm_above_base_gen1() -> None:
-    """It should use half-millimeters as hardware units."""
-    subject = make_module_view()
-
-    assert (
-        subject.calculate_magnet_true_mm_above_base(
-            module_model=ModuleModel.MAGNETIC_MODULE_V1,
-            hardware_units_above_base=100,
-        )
-        == 50
-    )
-
-    # TODO: Test hardware_units_above_home, etc. when we better understand
-    # the APIv2 behavior that we need to preserve.
-
-
-def test_calculate_magnet_true_mm_above_base_gen2() -> None:
+@pytest.mark.parametrize(
+    "module_model",
+    [ModuleModel.MAGNETIC_MODULE_V1, ModuleModel.MAGNETIC_MODULE_V2]
+)
+def test_calculate_magnet_height_gen2(module_model: ModuleModel) -> None:
     """It should use true millimeters as hardware units."""
     subject = make_module_view()
 
     assert (
-        subject.calculate_magnet_true_mm_above_base(
-            module_model=ModuleModel.MAGNETIC_MODULE_V2,
-            hardware_units_above_base=100,
+        subject.calculate_magnet_height(
+            module_model=module_model,
+            height_from_base=100,
         )
         == 100
     )
 
+    # todo(mm, 2022-02-28):
+    # It's unclear whether this expected result should actually be the same
+    # between GEN1 and GEN2.
+    # The GEN1 homing backoff distance looks accidentally halved, for the same reason
+    # that its heights are halved. If the limit switch hardware is the same for both
+    # modules, we'd expect the backoff difference to cause a difference in the
+    # height_from_home test, even though we're measuring everything in true mm.
     assert (
-        subject.calculate_magnet_true_mm_above_base(
-            module_model=ModuleModel.MAGNETIC_MODULE_V2,
-            hardware_units_above_home=100,
+        subject.calculate_magnet_height(
+            module_model=module_model,
+            height_from_home=100,
         )
         == 97.5
     )
 
     assert (
-        subject.calculate_magnet_true_mm_above_base(
-            module_model=ModuleModel.MAGNETIC_MODULE_V2,
-            labware_default_true_mm_above_base=100,
-            hardware_units_above_labware_default=10.0,
+        subject.calculate_magnet_height(
+            module_model=module_model,
+            labware_default_height=100,
+            offset_from_labware_default=10.0,
         )
         == 110
     )

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -147,30 +147,21 @@ def test_get_properties_by_id(
     )
 
 
-def test_get_magnet_true_mm_home_to_base(
-    magdeck_v1_def: ModuleDefinition,
-    magdeck_v2_def: ModuleDefinition,
-) -> None:
+def test_get_magnet_true_mm_home_to_base() -> None:
     """It should return the model-specific offset to bottom."""
-    subject = make_module_view(
-        slot_by_module_id={
-            "magdeck-v1-id": DeckSlotName.SLOT_1,
-            "magdeck-v2-id": DeckSlotName.SLOT_2,
-        },
-        hardware_module_by_slot={
-            DeckSlotName.SLOT_1: HardwareModule(
-                serial_number="magdeck-v1-serial",
-                definition=magdeck_v1_def,
-            ),
-            DeckSlotName.SLOT_2: HardwareModule(
-                serial_number="magdeck-v2-serial",
-                definition=magdeck_v2_def,
-            ),
-        },
+    subject = make_module_view()
+    assert (
+        subject.get_magnet_true_mm_home_to_base(
+            module_model=ModuleModel.MAGNETIC_MODULE_V1
+        )
+        == 2.5
     )
-
-    assert subject.get_magnet_true_mm_home_to_base(module_id="magdeck-v1-id") == 2.5
-    assert subject.get_magnet_true_mm_home_to_base(module_id="magdeck-v2-id") == 2.5
+    assert (
+        subject.get_magnet_true_mm_home_to_base(
+            module_model=ModuleModel.MAGNETIC_MODULE_V2
+        )
+        == 2.5
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Overview

This is incremental work towards #8243.

# Changelog

* Wire `SyncClient` to the Protocol Engine `MagneticModuleEngage` command.
* Wire `protocol_api_experimental.MagneticModuleContext` to that new `SyncClient` method.
* Make a half-hearted attempt to account for GEN1 "short millimeter" vs. GEN2 "true millimeter" stuff. Completing this support is partially blocked by, uh, figuring out how things are supposed to work. See #9494 for some of that work.
* Some other minor renames and refactors.

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

No risk to production behavior. `protocol_api_experimental` is currently unused.