### PR TITLE
app - Selectors for the Labware Offset 

### DIFF
--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/LabwareInfoOverlay.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/LabwareInfoOverlay.tsx
@@ -91,9 +91,13 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
       borderRadius={`0 0 0.4rem 0.4rem`}
       fontSize={FONT_SIZE_CAPTION}
       color={C_WHITE}
-      id='LabwareInfoOverlay_offset_box'
+      id="LabwareInfoOverlay_offset_box"
     >
-      <Text margin={SPACING_1} css={labwareDisplayNameStyle} id='LabwareInfoOverlay_displayName'>
+      <Text
+        margin={SPACING_1}
+        css={labwareDisplayNameStyle}
+        id="LabwareInfoOverlay_displayName"
+      >
         {displayName}
       </Text>
       {vector != null && (
@@ -111,7 +115,7 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
               as={'span'}
               fontWeight={FONT_WEIGHT_SEMIBOLD}
               marginRight={'0.15rem'}
-              id='LabwareInfoOverlay_X'
+              id="LabwareInfoOverlay_X"
             >
               X
             </Text>
@@ -119,7 +123,7 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
               as={'span'}
               fontWeight={FONT_WEIGHT_REGULAR}
               marginRight={'0.35rem'}
-              id='LabwareInfoOverlay_X_value'
+              id="LabwareInfoOverlay_X_value"
             >
               {vector.x.toFixed(1)}
             </Text>
@@ -127,7 +131,7 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
               as={'span'}
               fontWeight={FONT_WEIGHT_SEMIBOLD}
               marginRight={'0.15rem'}
-              id='LabwareInfoOverlay_Y'
+              id="LabwareInfoOverlay_Y"
             >
               Y
             </Text>
@@ -135,7 +139,7 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
               as={'span'}
               fontWeight={FONT_WEIGHT_REGULAR}
               marginRight={'0.35rem'}
-              id='LabwareInfoOverlay_Y_value'
+              id="LabwareInfoOverlay_Y_value"
             >
               {vector.y.toFixed(1)}
             </Text>
@@ -143,7 +147,7 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
               as={'span'}
               fontWeight={FONT_WEIGHT_SEMIBOLD}
               marginRight={'0.15rem'}
-              id='LabwareInfoOverlay_Z'
+              id="LabwareInfoOverlay_Z"
             >
               Z
             </Text>
@@ -151,7 +155,7 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
               as={'span'}
               fontWeight={FONT_WEIGHT_REGULAR}
               marginRight={'0.35rem'}
-              id='LabwareInfoOverlay_Z_value'
+              id="LabwareInfoOverlay_Z_value"
             >
               {vector.z.toFixed(1)}
             </Text>

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/LabwareInfoOverlay.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/LabwareInfoOverlay.tsx
@@ -91,7 +91,7 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
       borderRadius={`0 0 0.4rem 0.4rem`}
       fontSize={FONT_SIZE_CAPTION}
       color={C_WHITE}
-      id="LabwareInfoOverlay_offset_box"
+      id="LabwareInfoOverlay_offsetBox"
     >
       <Text
         margin={SPACING_1}
@@ -115,7 +115,7 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
               as={'span'}
               fontWeight={FONT_WEIGHT_SEMIBOLD}
               marginRight={'0.15rem'}
-              id="LabwareInfoOverlay_X"
+              id="LabwareInfoOverlay_x"
             >
               X
             </Text>
@@ -123,7 +123,7 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
               as={'span'}
               fontWeight={FONT_WEIGHT_REGULAR}
               marginRight={'0.35rem'}
-              id="LabwareInfoOverlay_X_value"
+              id="LabwareInfoOverlay_xValue"
             >
               {vector.x.toFixed(1)}
             </Text>
@@ -131,7 +131,7 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
               as={'span'}
               fontWeight={FONT_WEIGHT_SEMIBOLD}
               marginRight={'0.15rem'}
-              id="LabwareInfoOverlay_Y"
+              id="LabwareInfoOverlay_y"
             >
               Y
             </Text>
@@ -139,7 +139,7 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
               as={'span'}
               fontWeight={FONT_WEIGHT_REGULAR}
               marginRight={'0.35rem'}
-              id="LabwareInfoOverlay_Y_value"
+              id="LabwareInfoOverlay_yValue"
             >
               {vector.y.toFixed(1)}
             </Text>
@@ -147,7 +147,7 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
               as={'span'}
               fontWeight={FONT_WEIGHT_SEMIBOLD}
               marginRight={'0.15rem'}
-              id="LabwareInfoOverlay_Z"
+              id="LabwareInfoOverlay_z"
             >
               Z
             </Text>
@@ -155,7 +155,7 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
               as={'span'}
               fontWeight={FONT_WEIGHT_REGULAR}
               marginRight={'0.35rem'}
-              id="LabwareInfoOverlay_Z_value"
+              id="LabwareInfoOverlay_zValue"
             >
               {vector.z.toFixed(1)}
             </Text>

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/LabwareInfoOverlay.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/LabwareInfoOverlay.tsx
@@ -91,8 +91,9 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
       borderRadius={`0 0 0.4rem 0.4rem`}
       fontSize={FONT_SIZE_CAPTION}
       color={C_WHITE}
+      id='LabwareInfoOverlay_offset_box'
     >
-      <Text margin={SPACING_1} css={labwareDisplayNameStyle}>
+      <Text margin={SPACING_1} css={labwareDisplayNameStyle} id='LabwareInfoOverlay_displayName'>
         {displayName}
       </Text>
       {vector != null && (
@@ -110,6 +111,7 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
               as={'span'}
               fontWeight={FONT_WEIGHT_SEMIBOLD}
               marginRight={'0.15rem'}
+              id='LabwareInfoOverlay_X'
             >
               X
             </Text>
@@ -117,6 +119,7 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
               as={'span'}
               fontWeight={FONT_WEIGHT_REGULAR}
               marginRight={'0.35rem'}
+              id='LabwareInfoOverlay_X_value'
             >
               {vector.x.toFixed(1)}
             </Text>
@@ -124,6 +127,7 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
               as={'span'}
               fontWeight={FONT_WEIGHT_SEMIBOLD}
               marginRight={'0.15rem'}
+              id='LabwareInfoOverlay_Y'
             >
               Y
             </Text>
@@ -131,6 +135,7 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
               as={'span'}
               fontWeight={FONT_WEIGHT_REGULAR}
               marginRight={'0.35rem'}
+              id='LabwareInfoOverlay_Y_value'
             >
               {vector.y.toFixed(1)}
             </Text>
@@ -138,6 +143,7 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
               as={'span'}
               fontWeight={FONT_WEIGHT_SEMIBOLD}
               marginRight={'0.15rem'}
+              id='LabwareInfoOverlay_Z'
             >
               Z
             </Text>
@@ -145,6 +151,7 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
               as={'span'}
               fontWeight={FONT_WEIGHT_REGULAR}
               marginRight={'0.35rem'}
+              id='LabwareInfoOverlay_Z_value'
             >
               {vector.z.toFixed(1)}
             </Text>


### PR DESCRIPTION
I am adding ID selectors to LabwareInfoOverlay.tsx for the offset box, displayName and X,Y,Z offset values itself

- 'LabwareInfoOverlay_offset_box'
- 'LabwareInfoOverlay_displayName'
- 'LabwareInfoOverlay_X'
- 'LabwareInfoOverlay_Y'
- 'LabwareInfoOverlay_Z'
- 'LabwareInfoOverlay_X_value'
- 'LabwareInfoOverlay_Y_value'
- 'LabwareInfoOverlay_Z_value'
