### PR TITLE
refactor(app): robot settings page and about calibration tab

### DIFF
--- a/app/src/App/NextGenApp.tsx
+++ b/app/src/App/NextGenApp.tsx
@@ -184,7 +184,7 @@ export const nextGenRoutes: RouteProps[] = [
     component: RobotSettings,
     exact: true,
     name: 'Robot Settings',
-    path: '/devices/:robotName/robot-settings/:robotSettingsTab',
+    path: '/devices/:robotName/robot-settings/:robotSettingsTab?',
   },
   {
     component: () => <div>protocol runs landing</div>,

--- a/app/src/App/NextGenApp.tsx
+++ b/app/src/App/NextGenApp.tsx
@@ -23,12 +23,15 @@ import * as Config from '../redux/config'
 import { Breadcrumbs } from '../molecules/Breadcrumbs'
 import { DeviceDetails } from '../pages/Devices/DeviceDetails'
 import { DevicesLanding } from '../pages/Devices/DevicesLanding'
+import { RobotSettings } from '../pages/Devices/RobotSettings'
 import { usePathCrumbs } from './hooks'
 import { ProtocolsLanding } from '../pages/Protocols/ProtocolsLanding'
 import { GeneralSettings } from '../organisms/AppSettings/GeneralSettings'
 import { PrivacySettings } from '../organisms/AppSettings/PrivacySettings'
 import { AdvancedSettings } from '../organisms/AppSettings/AdvancedSettings'
 import { FeatureFlags } from '../organisms/AppSettings/FeatureFlags'
+import { TopPortalRoot } from './portal'
+
 export interface RouteProps {
   /**
    * the component rendered by a route match
@@ -101,6 +104,8 @@ export function TempNavBar({ routes }: { routes: RouteProps[] }): JSX.Element {
   )
 }
 
+export type RobotSettingsTab = 'calibration' | 'networking' | 'advanced'
+
 /**
  * route params type definition for the next gen app
  */
@@ -108,7 +113,7 @@ export interface NextGenRouteParams {
   robotName: string
   protocolName: string
   labwareId: string
-  robotSettingsTab: string
+  robotSettingsTab: RobotSettingsTab
   runId: string
   runDetailsTab: string
 }
@@ -176,10 +181,9 @@ export const nextGenRoutes: RouteProps[] = [
     path: '/devices/:robotName',
   },
   {
-    component: () => <div>robot settings</div>,
+    component: RobotSettings,
     exact: true,
     name: 'Robot Settings',
-    // robot settings tabs params: 'calibration' | 'networking' | 'advanced'
     path: '/devices/:robotName/robot-settings/:robotSettingsTab',
   },
   {
@@ -234,6 +238,7 @@ export function NextGenApp(): JSX.Element {
 
   return (
     <>
+      <TopPortalRoot />
       <TempNavBar routes={nextGenRoutes} />
       <Box width="100%">
         <Breadcrumbs pathCrumbs={pathCrumbs} />

--- a/app/src/App/__tests__/NextGenApp.test.tsx
+++ b/app/src/App/__tests__/NextGenApp.test.tsx
@@ -8,6 +8,7 @@ import { renderWithProviders } from '@opentrons/components'
 import { Breadcrumbs } from '../../molecules/Breadcrumbs'
 import { DeviceDetails } from '../../pages/Devices/DeviceDetails'
 import { DevicesLanding } from '../../pages/Devices/DevicesLanding'
+import { RobotSettings } from '../../pages/Devices/RobotSettings'
 import { GeneralSettings } from '../../organisms/AppSettings/GeneralSettings'
 import { usePathCrumbs } from '../hooks'
 import { NextGenApp } from '../NextGenApp'
@@ -16,6 +17,7 @@ jest.mock('../../molecules/Breadcrumbs')
 jest.mock('../../organisms/Devices/hooks')
 jest.mock('../../pages/Devices/DeviceDetails')
 jest.mock('../../pages/Devices/DevicesLanding')
+jest.mock('../../pages/Devices/RobotSettings')
 jest.mock('../../organisms/AppSettings/GeneralSettings')
 jest.mock('../../redux/config')
 jest.mock('../hooks')
@@ -28,6 +30,10 @@ const mockDevicesLanding = DevicesLanding as jest.MockedFunction<
   typeof DevicesLanding
 >
 mockDevicesLanding.mockReturnValue(<div>Mock DevicesLanding</div>)
+const mockRobotSettings = RobotSettings as jest.MockedFunction<
+  typeof RobotSettings
+>
+mockRobotSettings.mockReturnValue(<div>Mock RobotSettings</div>)
 const mockAppSettings = GeneralSettings as jest.MockedFunction<
   typeof GeneralSettings
 >
@@ -72,5 +78,10 @@ describe('NextGenApp', () => {
   it('renders a DeviceDetails component from /robots/:robotName', () => {
     const [{ getByText }] = render('/devices/otie')
     getByText('Mock DeviceDetails')
+  })
+
+  it('renders a RobotSettings component from /robots/:robotName/robot-settings/:robotSettingsTab', () => {
+    const [{ getByText }] = render('/devices/otie/robot-settings/calibration')
+    getByText('Mock RobotSettings')
   })
 })

--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -1,0 +1,10 @@
+{
+  "about_calibration_description": "For the robot to move accurately and precisely, you need to calibrate it. Positional calibration happens in three parts: deck calibration, pipette offset calibration and tip length calibration.",
+  "about_calibration_title": "About Calibration",
+  "advanced": "Advanced",
+  "calibration": "Calibration",
+  "download_calibration_data": "Download calibration data",
+  "networking": "Networking",
+  "robot_settings": "Robot Settings",
+  "see_how_robot_calibration_works": "See how robot calibration works"
+}

--- a/app/src/assets/localization/en/index.ts
+++ b/app/src/assets/localization/en/index.ts
@@ -1,5 +1,6 @@
 import shared from './shared.json'
 import device_details from './device_details.json'
+import device_settings from './device_settings.json'
 import devices_landing from './devices_landing.json'
 import labware_position_check from './labware_position_check.json'
 import more_network_and_system from './more_network_and_system.json'
@@ -20,6 +21,7 @@ import app_settings from './app_settings.json'
 export const en = {
   shared,
   device_details,
+  device_settings,
   devices_landing,
   labware_position_check,
   more_network_and_system,

--- a/app/src/atoms/structure/Line.tsx
+++ b/app/src/atoms/structure/Line.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react'
+import { Box, BORDERS } from '@opentrons/components'
+
+type Props = React.ComponentProps<typeof Box>
+
+export function Line(props: Props): JSX.Element {
+  return <Box borderBottom={BORDERS.lineBorder} {...props} />
+}

--- a/app/src/atoms/structure/index.ts
+++ b/app/src/atoms/structure/index.ts
@@ -1,2 +1,3 @@
 export * from './LabeledValue'
 export * from './Divider'
+export * from './Line'

--- a/app/src/organisms/Devices/RobotOverview.tsx
+++ b/app/src/organisms/Devices/RobotOverview.tsx
@@ -95,7 +95,10 @@ export function RobotOverview({
         </Flex>
       </Box>
       <Box alignSelf={ALIGN_START}>
-        <Icon name="dots-vertical" color={C_MED_DARK_GRAY} size={SIZE_2} />
+        {/* temp link to robot settings until overflow menu implemented */}
+        <Link to={`/devices/${robotName}/robot-settings/calibration`}>
+          <Icon name="dots-vertical" color={C_MED_DARK_GRAY} size={SIZE_2} />
+        </Link>
       </Box>
     </Flex>
   ) : null

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
@@ -7,13 +7,13 @@ import {
   Flex,
   Link,
   ALIGN_CENTER,
-  BORDERS,
   COLORS,
   SPACING,
   TYPOGRAPHY,
 } from '@opentrons/components'
 
 import { TertiaryButton } from '../../../atoms/Buttons'
+import { Line } from '../../../atoms/structure'
 import { StyledText } from '../../../atoms/text'
 import { DeckCalibrationModal } from '../../../organisms/ProtocolSetup/RunSetupCard/RobotCalibration/DeckCalibrationModal'
 import { useTrackEvent } from '../../../redux/analytics'
@@ -66,43 +66,44 @@ export function RobotSettingsCalibration({
   }
 
   return (
-    <Box
-      paddingBottom={SPACING.spacing5}
-      borderBottom={`${SPACING.spacingXXS} ${BORDERS.styleSolid} ${COLORS.medGrey}`}
-    >
-      <Flex alignItems={ALIGN_CENTER}>
-        <Box marginRight={SPACING.spacing6}>
-          <Box css={TYPOGRAPHY.h3SemiBold} marginBottom={SPACING.spacing3}>
-            {t('about_calibration_title')}
+    <>
+      <Box paddingBottom={SPACING.spacing5}>
+        <Flex alignItems={ALIGN_CENTER}>
+          <Box marginRight={SPACING.spacing6}>
+            <Box css={TYPOGRAPHY.h3SemiBold} marginBottom={SPACING.spacing3}>
+              {t('about_calibration_title')}
+            </Box>
+            <StyledText as="p" marginBottom={SPACING.spacing3}>
+              {t('about_calibration_description')}
+            </StyledText>
+            {showDeckCalibrationModal ? (
+              <DeckCalibrationModal
+                onCloseClick={() => setShowDeckCalibrationModal(false)}
+              />
+            ) : null}
+            <Link
+              color={COLORS.blue}
+              css={TYPOGRAPHY.pRegular}
+              onClick={() => setShowDeckCalibrationModal(true)}
+            >
+              {t('see_how_robot_calibration_works')}
+            </Link>
           </Box>
-          <StyledText as="p" marginBottom={SPACING.spacing3}>
-            {t('about_calibration_description')}
-          </StyledText>
-          {showDeckCalibrationModal ? (
-            <DeckCalibrationModal
-              onCloseClick={() => setShowDeckCalibrationModal(false)}
-            />
-          ) : null}
-          <Link
-            color={COLORS.blue}
-            css={TYPOGRAPHY.pRegular}
-            onClick={() => setShowDeckCalibrationModal(true)}
+          <TertiaryButton
+            boxShadow="none"
+            color={COLORS.background}
+            css={TYPOGRAPHY.h6SemiBold}
+            padding="0.375rem 0.75rem"
+            textTransform={TYPOGRAPHY.textTransformNone}
+            whiteSpace="nowrap"
+            onClick={onClickSaveAs}
           >
-            {t('see_how_robot_calibration_works')}
-          </Link>
-        </Box>
-        <TertiaryButton
-          boxShadow="none"
-          color={COLORS.background}
-          css={TYPOGRAPHY.h6SemiBold}
-          padding="0.375rem 0.75rem"
-          textTransform={TYPOGRAPHY.textTransformNone}
-          whiteSpace="nowrap"
-          onClick={onClickSaveAs}
-        >
-          {t('download_calibration_data')}
-        </TertiaryButton>
-      </Flex>
-    </Box>
+            {t('download_calibration_data')}
+          </TertiaryButton>
+        </Flex>
+      </Box>
+      <Line />
+      {/* TODO: additional calibration content here */}
+    </>
   )
 }

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
@@ -1,0 +1,108 @@
+import * as React from 'react'
+import { saveAs } from 'file-saver'
+import { useTranslation } from 'react-i18next'
+
+import {
+  Box,
+  Flex,
+  Link,
+  ALIGN_CENTER,
+  BORDERS,
+  COLORS,
+  SPACING,
+  TYPOGRAPHY,
+} from '@opentrons/components'
+
+import { TertiaryButton } from '../../../atoms/Buttons'
+import { StyledText } from '../../../atoms/text'
+import { DeckCalibrationModal } from '../../../organisms/ProtocolSetup/RunSetupCard/RobotCalibration/DeckCalibrationModal'
+import { useTrackEvent } from '../../../redux/analytics'
+import { EVENT_CALIBRATION_DOWNLOADED } from '../../../redux/calibration'
+import {
+  useDeckCalibrationData,
+  usePipetteOffsetCalibrations,
+  useRobot,
+  useTipLengthCalibrations,
+} from '../hooks'
+
+interface CalibrationProps {
+  robotName: string
+}
+
+export function RobotSettingsCalibration({
+  robotName,
+}: CalibrationProps): JSX.Element {
+  const { t } = useTranslation('device_settings')
+  const doTrackEvent = useTrackEvent()
+
+  const [
+    showDeckCalibrationModal,
+    setShowDeckCalibrationModal,
+  ] = React.useState(false)
+
+  const robot = useRobot(robotName)
+
+  // wait for robot request to resolve instead of using name directly from params
+  const deckCalibrationData = useDeckCalibrationData(robot?.name)
+  const pipetteOffsetCalibrations = usePipetteOffsetCalibrations(robot?.name)
+  const tipLengthCalibrations = useTipLengthCalibrations(robot?.name)
+
+  const onClickSaveAs: React.MouseEventHandler = e => {
+    e.preventDefault()
+    doTrackEvent({
+      name: EVENT_CALIBRATION_DOWNLOADED,
+      properties: {},
+    })
+    saveAs(
+      new Blob([
+        JSON.stringify({
+          deck: deckCalibrationData,
+          pipetteOffset: pipetteOffsetCalibrations,
+          tipLength: tipLengthCalibrations,
+        }),
+      ]),
+      `opentrons-${robotName}-calibration.json`
+    )
+  }
+
+  return (
+    <Box
+      paddingBottom={SPACING.spacing5}
+      borderBottom={`${SPACING.spacingXXS} ${BORDERS.styleSolid} ${COLORS.medGrey}`}
+    >
+      <Flex alignItems={ALIGN_CENTER}>
+        <Box marginRight={SPACING.spacing6}>
+          <Box css={TYPOGRAPHY.h3SemiBold} marginBottom={SPACING.spacing3}>
+            {t('about_calibration_title')}
+          </Box>
+          <StyledText as="p" marginBottom={SPACING.spacing3}>
+            {t('about_calibration_description')}
+          </StyledText>
+          {showDeckCalibrationModal ? (
+            <DeckCalibrationModal
+              onCloseClick={() => setShowDeckCalibrationModal(false)}
+            />
+          ) : null}
+          <Link
+            color={COLORS.blue}
+            css={TYPOGRAPHY.pRegular}
+            onClick={() => setShowDeckCalibrationModal(true)}
+          >
+            {t('see_how_robot_calibration_works')}
+          </Link>
+        </Box>
+        <TertiaryButton
+          boxShadow="none"
+          color={COLORS.background}
+          css={TYPOGRAPHY.h6SemiBold}
+          padding="0.375rem 0.75rem"
+          textTransform={TYPOGRAPHY.textTransformNone}
+          whiteSpace="nowrap"
+          onClick={onClickSaveAs}
+        >
+          {t('download_calibration_data')}
+        </TertiaryButton>
+      </Flex>
+    </Box>
+  )
+}

--- a/app/src/organisms/Devices/RobotSettings/__tests__/RobotSettingsCalibration.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/__tests__/RobotSettingsCalibration.test.tsx
@@ -1,0 +1,131 @@
+import * as React from 'react'
+import { saveAs } from 'file-saver'
+import { MemoryRouter } from 'react-router-dom'
+
+import { renderWithProviders } from '@opentrons/components'
+
+import { i18n } from '../../../../i18n'
+import { DeckCalibrationModal } from '../../../../organisms/ProtocolSetup/RunSetupCard/RobotCalibration/DeckCalibrationModal'
+import { useTrackEvent } from '../../../../redux/analytics'
+import { mockDeckCalData } from '../../../../redux/calibration/__fixtures__'
+import {
+  mockPipetteOffsetCalibration1,
+  mockPipetteOffsetCalibration2,
+  mockPipetteOffsetCalibration3,
+} from '../../../../redux/calibration/pipette-offset/__fixtures__'
+import {
+  mockTipLengthCalibration1,
+  mockTipLengthCalibration2,
+  mockTipLengthCalibration3,
+} from '../../../../redux/calibration/tip-length/__fixtures__'
+import { mockConnectableRobot } from '../../../../redux/discovery/__fixtures__'
+import {
+  useDeckCalibrationData,
+  usePipetteOffsetCalibrations,
+  useRobot,
+  useTipLengthCalibrations,
+} from '../../hooks'
+import { RobotSettingsCalibration } from '../RobotSettingsCalibration'
+
+jest.mock('file-saver')
+
+jest.mock(
+  '../../../../organisms/ProtocolSetup/RunSetupCard/RobotCalibration/DeckCalibrationModal'
+)
+jest.mock('../../../../redux/analytics')
+jest.mock('../../hooks')
+
+const mockDeckCalibrationModal = DeckCalibrationModal as jest.MockedFunction<
+  typeof DeckCalibrationModal
+>
+const mockUseDeckCalibrationData = useDeckCalibrationData as jest.MockedFunction<
+  typeof useDeckCalibrationData
+>
+const mockUsePipetteOffsetCalibrations = usePipetteOffsetCalibrations as jest.MockedFunction<
+  typeof usePipetteOffsetCalibrations
+>
+const mockUseRobot = useRobot as jest.MockedFunction<typeof useRobot>
+const mockUseTipLengthCalibrations = useTipLengthCalibrations as jest.MockedFunction<
+  typeof useTipLengthCalibrations
+>
+const mockUseTrackEvent = useTrackEvent as jest.MockedFunction<
+  typeof useTrackEvent
+>
+
+let mockTrackEvent: jest.Mock
+
+const render = () => {
+  return renderWithProviders(
+    <MemoryRouter>
+      <RobotSettingsCalibration robotName="otie" />
+    </MemoryRouter>,
+    {
+      i18nInstance: i18n,
+    }
+  )
+}
+
+describe('RobotSettingsCalibration', () => {
+  const realBlob = global.Blob
+  beforeAll(() => {
+    // @ts-expect-error(sa, 2021-6-28): not a valid blob interface
+    global.Blob = function (content: any, options: any) {
+      return { content, options }
+    }
+  })
+
+  afterAll(() => {
+    global.Blob = realBlob
+  })
+
+  beforeEach(() => {
+    mockTrackEvent = jest.fn()
+    mockUseTrackEvent.mockReturnValue(mockTrackEvent)
+    mockDeckCalibrationModal.mockReturnValue(
+      <div>Mock DeckCalibrationModal</div>
+    )
+    mockUseDeckCalibrationData.mockReturnValue(mockDeckCalData)
+    mockUsePipetteOffsetCalibrations.mockReturnValue([
+      mockPipetteOffsetCalibration1,
+      mockPipetteOffsetCalibration2,
+      mockPipetteOffsetCalibration3,
+    ])
+    mockUseRobot.mockReturnValue(mockConnectableRobot)
+    mockUseTipLengthCalibrations.mockReturnValue([
+      mockTipLengthCalibration1,
+      mockTipLengthCalibration2,
+      mockTipLengthCalibration3,
+    ])
+  })
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('renders a title and description', () => {
+    const [{ getByText }] = render()
+    getByText('About Calibration')
+    getByText(
+      'For the robot to move accurately and precisely, you need to calibrate it. Positional calibration happens in three parts: deck calibration, pipette offset calibration and tip length calibration.'
+    )
+  })
+
+  it('renders a clickable link to the deck calibration modal', () => {
+    const [{ getByText, queryByText }] = render()
+    expect(queryByText('Mock DeckCalibrationModal')).toBeFalsy()
+    const modalLink = getByText('See how robot calibration works')
+    modalLink.click()
+    getByText('Mock DeckCalibrationModal')
+  })
+
+  it('renders a download calibration data button', () => {
+    const [{ getByText }] = render()
+
+    const downloadButton = getByText('Download calibration data')
+    downloadButton.click()
+    expect(saveAs).toHaveBeenCalled()
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      name: 'calibrationDataDownloaded',
+      properties: {},
+    })
+  })
+})

--- a/app/src/organisms/Devices/__tests__/hooks.test.tsx
+++ b/app/src/organisms/Devices/__tests__/hooks.test.tsx
@@ -7,6 +7,25 @@ import { QueryClient, QueryClientProvider } from 'react-query'
 
 import { RUN_STATUS_IDLE, RUN_STATUS_RUNNING } from '@opentrons/api-client'
 
+import {
+  fetchCalibrationStatus,
+  fetchPipetteOffsetCalibrations,
+  fetchTipLengthCalibrations,
+  getDeckCalibrationData,
+  getPipetteOffsetCalibrations,
+  getTipLengthCalibrations,
+} from '../../../redux/calibration'
+import { mockDeckCalData } from '../../../redux/calibration/__fixtures__'
+import {
+  mockPipetteOffsetCalibration1,
+  mockPipetteOffsetCalibration2,
+  mockPipetteOffsetCalibration3,
+} from '../../../redux/calibration/pipette-offset/__fixtures__'
+import {
+  mockTipLengthCalibration1,
+  mockTipLengthCalibration2,
+  mockTipLengthCalibration3,
+} from '../../../redux/calibration/tip-length/__fixtures__'
 import { getDiscoverableRobotByName } from '../../../redux/discovery'
 import {
   mockConnectableRobot,
@@ -33,19 +52,41 @@ import type { DispatchApiRequestType } from '../../../redux/robot-api'
 import {
   useAttachedModules,
   useAttachedPipettes,
+  useDeckCalibrationData,
   useIsProtocolRunning,
   useIsRobotViewable,
   useLights,
+  usePipetteOffsetCalibrations,
   useRobot,
+  useTipLengthCalibrations,
 } from '../hooks'
 
 jest.mock('../../../organisms/RunTimeControl/hooks')
+jest.mock('../../../redux/calibration')
 jest.mock('../../../redux/discovery')
 jest.mock('../../../redux/modules')
 jest.mock('../../../redux/pipettes')
 jest.mock('../../../redux/robot-api')
 jest.mock('../../../redux/robot-controls')
 
+const mockFetchCalibrationStatus = fetchCalibrationStatus as jest.MockedFunction<
+  typeof fetchCalibrationStatus
+>
+const mockFetchPipetteOffsetCalibrations = fetchPipetteOffsetCalibrations as jest.MockedFunction<
+  typeof fetchPipetteOffsetCalibrations
+>
+const mockFetchTipLengthCalibrations = fetchTipLengthCalibrations as jest.MockedFunction<
+  typeof fetchTipLengthCalibrations
+>
+const mockGetDeckCalibrationData = getDeckCalibrationData as jest.MockedFunction<
+  typeof getDeckCalibrationData
+>
+const mockGetPipetteOffsetCalibrations = getPipetteOffsetCalibrations as jest.MockedFunction<
+  typeof getPipetteOffsetCalibrations
+>
+const mockGetTipLengthCalibrations = getTipLengthCalibrations as jest.MockedFunction<
+  typeof getTipLengthCalibrations
+>
 const mockFetchLights = fetchLights as jest.MockedFunction<typeof fetchLights>
 const mockGetLightsOn = getLightsOn as jest.MockedFunction<typeof getLightsOn>
 const mockUpdateLights = updateLights as jest.MockedFunction<
@@ -353,5 +394,168 @@ describe('useIsRobotViewable hook', () => {
     })
 
     expect(result.current).toEqual(true)
+  })
+})
+
+describe('useDeckCalibrationData hook', () => {
+  let dispatchApiRequest: DispatchApiRequestType
+  let wrapper: React.FunctionComponent<{}>
+  beforeEach(() => {
+    dispatchApiRequest = jest.fn()
+    const queryClient = new QueryClient()
+    wrapper = ({ children }) => (
+      <Provider store={store}>
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      </Provider>
+    )
+    mockUseDispatchApiRequest.mockReturnValue([dispatchApiRequest, []])
+  })
+  afterEach(() => {
+    resetAllWhenMocks()
+    jest.resetAllMocks()
+  })
+
+  it('returns no deck calibration data when given a null robot name', () => {
+    when(mockGetDeckCalibrationData)
+      .calledWith(undefined as any, null)
+      .mockReturnValue(null)
+
+    const { result } = renderHook(() => useDeckCalibrationData(null), {
+      wrapper,
+    })
+
+    expect(result.current).toEqual(null)
+    expect(dispatchApiRequest).not.toBeCalled()
+  })
+
+  it('returns deck calibration data when given a robot name', () => {
+    when(mockGetDeckCalibrationData)
+      .calledWith(undefined as any, 'otie')
+      .mockReturnValue(mockDeckCalData)
+
+    const { result } = renderHook(() => useDeckCalibrationData('otie'), {
+      wrapper,
+    })
+
+    expect(result.current).toEqual(mockDeckCalData)
+    expect(dispatchApiRequest).toBeCalledWith(
+      mockFetchCalibrationStatus('otie')
+    )
+  })
+})
+
+describe('usePipetteOffsetCalibrations hook', () => {
+  let dispatchApiRequest: DispatchApiRequestType
+  let wrapper: React.FunctionComponent<{}>
+  beforeEach(() => {
+    dispatchApiRequest = jest.fn()
+    const queryClient = new QueryClient()
+    wrapper = ({ children }) => (
+      <Provider store={store}>
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      </Provider>
+    )
+    mockUseDispatchApiRequest.mockReturnValue([dispatchApiRequest, []])
+  })
+  afterEach(() => {
+    resetAllWhenMocks()
+    jest.resetAllMocks()
+  })
+
+  it('returns no pipette offset calibrations when given a null robot name', () => {
+    when(mockGetPipetteOffsetCalibrations)
+      .calledWith(undefined as any, null)
+      .mockReturnValue([])
+
+    const { result } = renderHook(() => usePipetteOffsetCalibrations(null), {
+      wrapper,
+    })
+
+    expect(result.current).toEqual([])
+    expect(dispatchApiRequest).not.toBeCalled()
+  })
+
+  it('returns pipette offset calibrations when given a robot name', () => {
+    when(mockGetPipetteOffsetCalibrations)
+      .calledWith(undefined as any, 'otie')
+      .mockReturnValue([
+        mockPipetteOffsetCalibration1,
+        mockPipetteOffsetCalibration2,
+        mockPipetteOffsetCalibration3,
+      ])
+
+    const { result } = renderHook(() => usePipetteOffsetCalibrations('otie'), {
+      wrapper,
+    })
+
+    expect(result.current).toEqual([
+      mockPipetteOffsetCalibration1,
+      mockPipetteOffsetCalibration2,
+      mockPipetteOffsetCalibration3,
+    ])
+    expect(dispatchApiRequest).toBeCalledWith(
+      mockFetchPipetteOffsetCalibrations('otie')
+    )
+  })
+})
+
+describe('useTipLengthCalibrations hook', () => {
+  let dispatchApiRequest: DispatchApiRequestType
+  let wrapper: React.FunctionComponent<{}>
+  beforeEach(() => {
+    dispatchApiRequest = jest.fn()
+    const queryClient = new QueryClient()
+    wrapper = ({ children }) => (
+      <Provider store={store}>
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      </Provider>
+    )
+    mockUseDispatchApiRequest.mockReturnValue([dispatchApiRequest, []])
+  })
+  afterEach(() => {
+    resetAllWhenMocks()
+    jest.resetAllMocks()
+  })
+
+  it('returns no tip length calibrations when given a null robot name', () => {
+    when(mockGetTipLengthCalibrations)
+      .calledWith(undefined as any, null)
+      .mockReturnValue([])
+
+    const { result } = renderHook(() => useTipLengthCalibrations(null), {
+      wrapper,
+    })
+
+    expect(result.current).toEqual([])
+    expect(dispatchApiRequest).not.toBeCalled()
+  })
+
+  it('returns tip length calibrations when given a robot name', () => {
+    when(mockGetTipLengthCalibrations)
+      .calledWith(undefined as any, 'otie')
+      .mockReturnValue([
+        mockTipLengthCalibration1,
+        mockTipLengthCalibration2,
+        mockTipLengthCalibration3,
+      ])
+
+    const { result } = renderHook(() => useTipLengthCalibrations('otie'), {
+      wrapper,
+    })
+
+    expect(result.current).toEqual([
+      mockTipLengthCalibration1,
+      mockTipLengthCalibration2,
+      mockTipLengthCalibration3,
+    ])
+    expect(dispatchApiRequest).toBeCalledWith(
+      mockFetchTipLengthCalibrations('otie')
+    )
   })
 })

--- a/app/src/organisms/Devices/hooks.ts
+++ b/app/src/organisms/Devices/hooks.ts
@@ -5,6 +5,14 @@ import { RUN_STATUS_IDLE } from '@opentrons/api-client'
 
 import { useRunStatus } from '../../organisms/RunTimeControl/hooks'
 import {
+  fetchCalibrationStatus,
+  fetchPipetteOffsetCalibrations,
+  fetchTipLengthCalibrations,
+  getDeckCalibrationData,
+  getPipetteOffsetCalibrations,
+  getTipLengthCalibrations,
+} from '../../redux/calibration'
+import {
   getDiscoverableRobotByName,
   CONNECTABLE,
   REACHABLE,
@@ -18,6 +26,11 @@ import {
   getLightsOn,
 } from '../../redux/robot-controls'
 
+import type {
+  DeckCalibrationData,
+  PipetteOffsetCalibration,
+  TipLengthCalibration,
+} from '../../redux/calibration/types'
 import type { DiscoveredRobot } from '../../redux/discovery/types'
 import type { AttachedModule } from '../../redux/modules/types'
 import type { AttachedPipettesByMount } from '../../redux/pipettes/types'
@@ -98,4 +111,58 @@ export function useIsRobotViewable(robotName: string): boolean {
   const robot = useRobot(robotName)
 
   return robot?.status === CONNECTABLE || robot?.status === REACHABLE
+}
+
+export function useDeckCalibrationData(
+  robotName: string | null = null
+): DeckCalibrationData | null {
+  const [dispatchRequest] = useDispatchApiRequest()
+
+  const deckCalibrationData = useSelector((state: State) =>
+    getDeckCalibrationData(state, robotName)
+  )
+
+  React.useEffect(() => {
+    if (robotName != null) {
+      dispatchRequest(fetchCalibrationStatus(robotName))
+    }
+  }, [dispatchRequest, robotName])
+
+  return deckCalibrationData
+}
+
+export function usePipetteOffsetCalibrations(
+  robotName: string | null = null
+): PipetteOffsetCalibration[] | null {
+  const [dispatchRequest] = useDispatchApiRequest()
+
+  const pipetteOffsetCalibrations = useSelector((state: State) =>
+    getPipetteOffsetCalibrations(state, robotName)
+  )
+
+  React.useEffect(() => {
+    if (robotName != null) {
+      dispatchRequest(fetchPipetteOffsetCalibrations(robotName))
+    }
+  }, [dispatchRequest, robotName])
+
+  return pipetteOffsetCalibrations
+}
+
+export function useTipLengthCalibrations(
+  robotName: string | null = null
+): TipLengthCalibration[] | null {
+  const [dispatchRequest] = useDispatchApiRequest()
+
+  const tipLengthCalibrations = useSelector((state: State) =>
+    getTipLengthCalibrations(state, robotName)
+  )
+
+  React.useEffect(() => {
+    if (robotName != null) {
+      dispatchRequest(fetchTipLengthCalibrations(robotName))
+    }
+  }, [dispatchRequest, robotName])
+
+  return tipLengthCalibrations
 }

--- a/app/src/pages/Devices/RobotSettings/__tests__/RobotSettings.test.tsx
+++ b/app/src/pages/Devices/RobotSettings/__tests__/RobotSettings.test.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react'
+import { Route } from 'react-router'
+import { MemoryRouter } from 'react-router-dom'
+import { renderWithProviders } from '@opentrons/components'
+
+import { i18n } from '../../../../i18n'
+import { RobotSettingsCalibration } from '../../../../organisms/Devices/RobotSettings/RobotSettingsCalibration'
+import { RobotSettings } from '..'
+
+jest.mock(
+  '../../../../organisms/Devices/RobotSettings/RobotSettingsCalibration'
+)
+
+const mockRobotSettingsCalibration = RobotSettingsCalibration as jest.MockedFunction<
+  typeof RobotSettingsCalibration
+>
+
+const render = (path = '/') => {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={[path]} initialIndex={0}>
+      <Route path="/devices/:robotName/robot-settings/:robotSettingsTab">
+        <RobotSettings />
+      </Route>
+    </MemoryRouter>,
+    {
+      i18nInstance: i18n,
+    }
+  )
+}
+
+describe('RobotSettings', () => {
+  beforeEach(() => {
+    mockRobotSettingsCalibration.mockReturnValue(
+      <div>Mock RobotSettingsCalibration</div>
+    )
+  })
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('renders a title and navigation tabs', () => {
+    const [{ getByText }] = render('/devices/otie/robot-settings/calibration')
+
+    getByText('Robot Settings')
+    getByText('Calibration')
+    getByText('Networking')
+    getByText('Advanced')
+  })
+
+  it('renders calibration content when the calibration tab is clicked', () => {
+    const [{ getByText, queryByText }] = render(
+      '/devices/otie/robot-settings/advanced'
+    )
+
+    const calibrationTab = getByText('Calibration')
+    expect(queryByText('Mock RobotSettingsCalibration')).toBeFalsy()
+    calibrationTab.click()
+    getByText('Mock RobotSettingsCalibration')
+  })
+})

--- a/app/src/pages/Devices/RobotSettings/__tests__/RobotSettings.test.tsx
+++ b/app/src/pages/Devices/RobotSettings/__tests__/RobotSettings.test.tsx
@@ -57,4 +57,12 @@ describe('RobotSettings', () => {
     calibrationTab.click()
     getByText('Mock RobotSettingsCalibration')
   })
+
+  it('defaults to calibration content when given an unspecified tab', () => {
+    const [{ getByText }] = render(
+      '/devices/otie/robot-settings/this-is-not-a-real-tab'
+    )
+
+    getByText('Mock RobotSettingsCalibration')
+  })
 })

--- a/app/src/pages/Devices/RobotSettings/index.tsx
+++ b/app/src/pages/Devices/RobotSettings/index.tsx
@@ -1,0 +1,114 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { NavLink, useParams } from 'react-router-dom'
+import styled from 'styled-components'
+
+import {
+  Box,
+  Flex,
+  DIRECTION_COLUMN,
+  OVERFLOW_SCROLL,
+  SIZE_6,
+  BORDERS,
+  COLORS,
+  SPACING,
+  TYPOGRAPHY,
+} from '@opentrons/components'
+
+import { RobotSettingsCalibration } from '../../../organisms/Devices/RobotSettings/RobotSettingsCalibration'
+
+import type {
+  NextGenRouteParams,
+  RobotSettingsTab,
+} from '../../../App/NextGenApp'
+
+export function RobotSettings(): JSX.Element | null {
+  const { t } = useTranslation('device_settings')
+  const { robotName, robotSettingsTab } = useParams<NextGenRouteParams>()
+
+  const robotSettingsContentByTab: {
+    [K in RobotSettingsTab]: () => JSX.Element
+  } = {
+    calibration: () => <RobotSettingsCalibration robotName={robotName} />,
+    // TODO: networking tab content
+    networking: () => <div>networking</div>,
+    // TODO: advanced tab content
+    advanced: () => <div>advanced</div>,
+  }
+
+  const RobotSettingsContent = robotSettingsContentByTab[robotSettingsTab]
+
+  interface NavTabProps {
+    to: string
+    tabName: string
+  }
+
+  const StyledNavLink = styled(NavLink)`
+    color: ${COLORS.darkGreyEnabled};
+    &.active {
+      color: ${COLORS.darkBlack};
+      ${BORDERS.tabBorder}
+    }
+  `
+
+  function NavTab({ to, tabName }: NavTabProps): JSX.Element {
+    return (
+      <StyledNavLink to={to} replace>
+        <Box
+          css={TYPOGRAPHY.h6SemiBold}
+          padding={`0 ${SPACING.spacing2} ${SPACING.spacing3} ${SPACING.spacing2}`}
+        >
+          {tabName}
+        </Box>
+      </StyledNavLink>
+    )
+  }
+
+  return (
+    <Box
+      minWidth={SIZE_6}
+      height="100%"
+      overflow={OVERFLOW_SCROLL}
+      padding={SPACING.spacing4}
+    >
+      <Flex
+        backgroundColor={COLORS.white}
+        border={`${SPACING.spacingXXS} ${BORDERS.styleSolid} ${COLORS.medGrey}`}
+        borderRadius={BORDERS.radiusSoftCorners}
+        flexDirection={DIRECTION_COLUMN}
+        marginBottom={SPACING.spacing4}
+        width="100%"
+      >
+        <Box
+          borderBottom={`${SPACING.spacingXXS} ${BORDERS.styleSolid} ${COLORS.medGrey}`}
+          padding={`0 ${SPACING.spacing4}`}
+        >
+          <Box
+            color={COLORS.black}
+            css={TYPOGRAPHY.h1Default}
+            padding={`${SPACING.spacing5} 0`}
+          >
+            {t('robot_settings')}
+          </Box>
+          <Flex gridGap={SPACING.spacing4}>
+            <NavTab
+              to={`/devices/${robotName}/robot-settings/calibration`}
+              tabName={t('calibration')}
+            />
+            <NavTab
+              to={`/devices/${robotName}/robot-settings/networking`}
+              tabName={t('networking')}
+            />
+            <NavTab
+              to={`/devices/${robotName}/robot-settings/advanced`}
+              tabName={t('advanced')}
+            />
+          </Flex>
+        </Box>
+        <Box padding={`${SPACING.spacing5} ${SPACING.spacing4}`}>
+          <RobotSettingsContent />
+        </Box>
+      </Flex>
+    </Box>
+  )
+}

--- a/app/src/pages/Devices/RobotSettings/index.tsx
+++ b/app/src/pages/Devices/RobotSettings/index.tsx
@@ -15,6 +15,7 @@ import {
   TYPOGRAPHY,
 } from '@opentrons/components'
 
+import { Line } from '../../../atoms/structure'
 import { RobotSettingsCalibration } from '../../../organisms/Devices/RobotSettings/RobotSettingsCalibration'
 
 import type {
@@ -76,16 +77,13 @@ export function RobotSettings(): JSX.Element | null {
     >
       <Flex
         backgroundColor={COLORS.white}
-        border={`${SPACING.spacingXXS} ${BORDERS.styleSolid} ${COLORS.medGrey}`}
+        border={BORDERS.lineBorder}
         borderRadius={BORDERS.radiusSoftCorners}
         flexDirection={DIRECTION_COLUMN}
         marginBottom={SPACING.spacing4}
         width="100%"
       >
-        <Box
-          borderBottom={`${SPACING.spacingXXS} ${BORDERS.styleSolid} ${COLORS.medGrey}`}
-          padding={`0 ${SPACING.spacing4}`}
-        >
+        <Box padding={`0 ${SPACING.spacing4}`}>
           <Box
             color={COLORS.black}
             css={TYPOGRAPHY.h1Default}
@@ -108,6 +106,7 @@ export function RobotSettings(): JSX.Element | null {
             />
           </Flex>
         </Box>
+        <Line />
         <Box padding={`${SPACING.spacing5} ${SPACING.spacing4}`}>
           <RobotSettingsContent />
         </Box>

--- a/app/src/pages/Devices/RobotSettings/index.tsx
+++ b/app/src/pages/Devices/RobotSettings/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { NavLink, useParams } from 'react-router-dom'
+import { NavLink, Redirect, useParams } from 'react-router-dom'
 import styled from 'styled-components'
 
 import {
@@ -36,7 +36,10 @@ export function RobotSettings(): JSX.Element | null {
     advanced: () => <div>advanced</div>,
   }
 
-  const RobotSettingsContent = robotSettingsContentByTab[robotSettingsTab]
+  const RobotSettingsContent =
+    robotSettingsContentByTab[robotSettingsTab] ??
+    // default to the calibration tab if no tab or nonexistent tab is passed as a param
+    (() => <Redirect to={`/devices/${robotName}/robot-settings/calibration`} />)
 
   interface NavTabProps {
     to: string

--- a/app/src/redux/calibration/__tests__/selectors.test.ts
+++ b/app/src/redux/calibration/__tests__/selectors.test.ts
@@ -79,6 +79,34 @@ describe('calibration selectors', () => {
     })
   })
 })
+
+describe('getDeckCalibrationData', () => {
+  it('should return null if given a null robot name', () => {
+    const state: State = { calibration: {} } as any
+    expect(Selectors.getDeckCalibrationData(state, null)).toBe(null)
+  })
+
+  it('should return null if no robot in state', () => {
+    const state: State = { calibration: {} } as any
+    expect(Selectors.getDeckCalibrationData(state, 'robotName')).toBe(null)
+  })
+
+  it('should return deck calibration data if in state', () => {
+    const state: State = {
+      calibration: {
+        robotName: {
+          calibrationStatus: Fixtures.mockCalibrationStatus,
+          pipetteOffsetCalibrations: null,
+          tipLengthCalibrations: null,
+        },
+      },
+    } as any
+    expect(Selectors.getDeckCalibrationData(state, 'robotName')).toEqual(
+      Fixtures.mockCalibrationStatus.deckCalibration.data
+    )
+  })
+})
+
 describe('getProtocolCalibrationComplete without bad deck calibration', () => {
   beforeEach(() => {
     mockGetProtocolPipetteTipRackCalInfo.mockReturnValue({

--- a/app/src/redux/calibration/selectors.ts
+++ b/app/src/redux/calibration/selectors.ts
@@ -26,9 +26,11 @@ export const getDeckCalibrationStatus = (
 
 export const getDeckCalibrationData = (
   state: State,
-  robotName: string
+  robotName: string | null
 ): DeckCalibrationData | null => {
-  return getCalibrationStatus(state, robotName)?.deckCalibration.data ?? null
+  return robotName != null
+    ? getCalibrationStatus(state, robotName)?.deckCalibration.data ?? null
+    : null
 }
 
 export const getProtocolCalibrationComplete: (

--- a/components/src/primitives/style-props.ts
+++ b/components/src/primitives/style-props.ts
@@ -77,6 +77,7 @@ const LAYOUT_PROPS = [
   'overflow',
   'overflowX',
   'overflowY',
+  'whiteSpace',
   'wordSpacing',
 ] as const
 

--- a/components/src/ui-style-constants/borders.ts
+++ b/components/src/ui-style-constants/borders.ts
@@ -1,6 +1,6 @@
 import { css } from 'styled-components'
-import { spacing1 } from './spacing'
-import { blue } from './colors'
+import { spacing1, spacingXXS } from './spacing'
+import { blue, medGrey } from './colors'
 
 export const radiusSoftCorners = '3px'
 export const radiusRoundEdge = '20px'
@@ -11,3 +11,5 @@ export const tabBorder = css`
   border-bottom-width: ${spacing1};
   border-bottom-color: ${blue};
 `
+
+export const lineBorder = `${spacingXXS} ${styleSolid} ${medGrey}`

--- a/components/src/ui-style-constants/typography.ts
+++ b/components/src/ui-style-constants/typography.ts
@@ -76,6 +76,12 @@ export const h6Default = css`
   line-height: ${lineHeight12};
 `
 
+export const h6SemiBold = css`
+  font-size: ${fontSizeH6};
+  font-weight: ${fontWeightSemiBold};
+  line-height: ${lineHeight12};
+`
+
 export const pRegular = css`
   font-size: ${fontSizeP};
   font-weight: ${fontWeightRegular};


### PR DESCRIPTION
# Overview

This adds the robot settings page and the 'about calibration' section of the calibration tab. There's a new approach to handling navigation tab params and a `NavTab` component that maybe should be split out for reuse elsewhere if we decide to consistently implement tabs this way.

<img width="1099" alt="Screen Shot 2022-02-23 at 11 14 01 AM" src="https://user-images.githubusercontent.com/29845468/155362537-d0a9183d-0eef-449d-9020-b1477e82f5b8.png">


closes #8757

# Changelog

 - Adds robot settings page and 'About Calibration' section of calibration tab

# Review requests

confirm functionality of the about calibration section, review code organization and tab params approach

# Risk assessment

low
