### PR TITLE
fix(api): working volume is not set in fast simulation

### DIFF
--- a/api/src/opentrons/protocols/context/simulator/instrument_context.py
+++ b/api/src/opentrons/protocols/context/simulator/instrument_context.py
@@ -76,9 +76,11 @@ class InstrumentContextSimulation(AbstractInstrument):
         presses: typing.Optional[int],
         increment: typing.Optional[float],
     ) -> None:
+        geometry = well.get_geometry()
         self._raise_if_tip("pick up tip")
         self._pipette_dict["has_tip"] = True
         self._pipette_dict["current_volume"] = 0
+        self._pipette_dict["working_volume"] = geometry.max_volume
 
     def drop_tip(self, home_after: bool) -> None:
         self._raise_if_no_tip(HardwareAction.DROPTIP.name)

--- a/api/src/opentrons/protocols/context/simulator/instrument_context.py
+++ b/api/src/opentrons/protocols/context/simulator/instrument_context.py
@@ -196,16 +196,6 @@ class InstrumentContextSimulation(AbstractInstrument):
         )
         self._update_flow_rate()
 
-    def _update_flow_rate(self):
-        p = self._protocol_interface.get_hardware().get_attached_instrument(
-            self.get_mount())
-        self._pipette_dict["aspirate_flow_rate"] = p["aspirate_flow_rate"]
-        self._pipette_dict["dispense_flow_rate"] = p["dispense_flow_rate"]
-        self._pipette_dict["blow_out_flow_rate"] = p["blow_out_flow_rate"]
-        self._pipette_dict["aspirate_speed"] = p["aspirate_speed"]
-        self._pipette_dict["dispense_speed"] = p["dispense_speed"]
-        self._pipette_dict["blow_out_speed"] = p["blow_out_speed"]
-
     def set_pipette_speed(
         self,
         aspirate: typing.Optional[float] = None,
@@ -219,6 +209,18 @@ class InstrumentContextSimulation(AbstractInstrument):
             blow_out=blow_out,
         )
         self._update_flow_rate()
+
+    def _update_flow_rate(self) -> None:
+        """Update cached speed and flow rates from hardware controller pipette."""
+        p = self._protocol_interface.get_hardware().get_attached_instrument(
+            self.get_mount()
+        )
+        self._pipette_dict["aspirate_flow_rate"] = p["aspirate_flow_rate"]
+        self._pipette_dict["dispense_flow_rate"] = p["dispense_flow_rate"]
+        self._pipette_dict["blow_out_flow_rate"] = p["blow_out_flow_rate"]
+        self._pipette_dict["aspirate_speed"] = p["aspirate_speed"]
+        self._pipette_dict["dispense_speed"] = p["dispense_speed"]
+        self._pipette_dict["blow_out_speed"] = p["blow_out_speed"]
 
     def _raise_if_no_tip(self, action: str) -> None:
         """Raise NoTipAttachedError if no tip."""

--- a/api/src/opentrons/protocols/context/simulator/instrument_context.py
+++ b/api/src/opentrons/protocols/context/simulator/instrument_context.py
@@ -97,6 +97,7 @@ class InstrumentContextSimulation(AbstractInstrument):
         self._raise_if_no_tip(HardwareAction.DROPTIP.name)
         self._pipette_dict["has_tip"] = False
         self._pipette_dict["tip_length"] = 0.0
+        self._update_volume(0)
 
     def home(self) -> None:
         self._protocol_interface.set_last_location(None)

--- a/api/src/opentrons/protocols/context/simulator/instrument_context.py
+++ b/api/src/opentrons/protocols/context/simulator/instrument_context.py
@@ -188,12 +188,23 @@ class InstrumentContextSimulation(AbstractInstrument):
         dispense: typing.Optional[float] = None,
         blow_out: typing.Optional[float] = None,
     ) -> None:
-        if aspirate is not None:
-            self._pipette_dict["aspirate_flow_rate"] = aspirate
-        if dispense is not None:
-            self._pipette_dict["dispense_flow_rate"] = dispense
-        if blow_out is not None:
-            self._pipette_dict["blow_out_flow_rate"] = blow_out
+        self._protocol_interface.get_hardware().set_flow_rate(
+            mount=self._mount,
+            aspirate=aspirate,
+            dispense=dispense,
+            blow_out=blow_out,
+        )
+        self._update_flow_rate()
+
+    def _update_flow_rate(self):
+        p = self._protocol_interface.get_hardware().get_attached_instrument(
+            self.get_mount())
+        self._pipette_dict["aspirate_flow_rate"] = p["aspirate_flow_rate"]
+        self._pipette_dict["dispense_flow_rate"] = p["dispense_flow_rate"]
+        self._pipette_dict["blow_out_flow_rate"] = p["blow_out_flow_rate"]
+        self._pipette_dict["aspirate_speed"] = p["aspirate_speed"]
+        self._pipette_dict["dispense_speed"] = p["dispense_speed"]
+        self._pipette_dict["blow_out_speed"] = p["blow_out_speed"]
 
     def set_pipette_speed(
         self,
@@ -201,12 +212,13 @@ class InstrumentContextSimulation(AbstractInstrument):
         dispense: typing.Optional[float] = None,
         blow_out: typing.Optional[float] = None,
     ) -> None:
-        if aspirate is not None:
-            self._pipette_dict["aspirate_speed"] = aspirate
-        if dispense is not None:
-            self._pipette_dict["dispense_speed"] = dispense
-        if blow_out is not None:
-            self._pipette_dict["blow_out_speed"] = blow_out
+        self._protocol_interface.get_hardware().set_pipette_speed(
+            mount=self._mount,
+            aspirate=aspirate,
+            dispense=dispense,
+            blow_out=blow_out,
+        )
+        self._update_flow_rate()
 
     def _raise_if_no_tip(self, action: str) -> None:
         """Raise NoTipAttachedError if no tip."""

--- a/api/src/opentrons/protocols/context/simulator/instrument_context.py
+++ b/api/src/opentrons/protocols/context/simulator/instrument_context.py
@@ -86,6 +86,7 @@ class InstrumentContextSimulation(AbstractInstrument):
         geometry = well.get_geometry()
         self._raise_if_tip("pick up tip")
         self._pipette_dict["has_tip"] = True
+        self._pipette_dict["tip_length"] = tip_length
         self._pipette_dict["current_volume"] = 0
         self._pipette_dict["working_volume"] = min(
             geometry.max_volume, self.get_max_volume()
@@ -95,6 +96,7 @@ class InstrumentContextSimulation(AbstractInstrument):
     def drop_tip(self, home_after: bool) -> None:
         self._raise_if_no_tip(HardwareAction.DROPTIP.name)
         self._pipette_dict["has_tip"] = False
+        self._pipette_dict["tip_length"] = 0.0
 
     def home(self) -> None:
         self._protocol_interface.set_last_location(None)

--- a/api/src/opentrons/protocols/context/simulator/instrument_context.py
+++ b/api/src/opentrons/protocols/context/simulator/instrument_context.py
@@ -140,7 +140,7 @@ class InstrumentContextSimulation(AbstractInstrument):
         return self._pipette_dict["current_volume"]
 
     def get_available_volume(self) -> float:
-        return self._pipette_dict["available_volume"]
+        return self._pipette_dict["working_volume"] - self.get_current_volume()
 
     def get_pipette(self) -> PipetteDict:
         return self._pipette_dict

--- a/api/tests/opentrons/protocols/context/simulator/test_instrument_context.py
+++ b/api/tests/opentrons/protocols/context/simulator/test_instrument_context.py
@@ -1,4 +1,6 @@
 """Test instrument context simulation."""
+from typing import Callable
+
 import pytest
 from pytest_lazyfixture import lazy_fixture
 
@@ -85,3 +87,96 @@ def test_aspirate_too_much(
         AssertionError, match="Cannot aspirate more than pipette max volume"
     ):
         subject.aspirate(subject.get_max_volume() + 1, rate=1)
+
+
+def test_working_volume(subject: AbstractInstrument, labware: AbstractLabware) -> None:
+    """It should have the correct working volume."""
+    subject.home()
+    assert subject.get_pipette()["working_volume"] == 300
+    subject.pick_up_tip(
+        well=labware.get_wells()[0], tip_length=1, presses=None, increment=None
+    )
+    assert subject.get_pipette()["working_volume"] == 100
+
+
+@pytest.mark.parametrize(
+    argnames=["side_effector"],
+    argvalues=[
+        [lambda i: None],
+        [lambda i: i.set_flow_rate(aspirate=212, dispense=44, blow_out=22)],
+        [lambda i: i.set_pipette_speed(aspirate=212, dispense=44, blow_out=22)],
+    ],
+)
+def test_pipette_dict(
+    side_effector: Callable[[AbstractInstrument], None],
+    instrument_context: AbstractInstrument,
+    simulating_instrument_context: AbstractInstrument,
+) -> None:
+    """It should be the same."""
+    side_effector(instrument_context)
+    side_effector(simulating_instrument_context)
+    assert (
+        instrument_context.get_pipette() == simulating_instrument_context.get_pipette()
+    )
+
+
+def _aspirate(i: AbstractInstrument) -> None:
+    """pipette dict with tip fixture."""
+    i.prepare_for_aspirate()
+    i.aspirate(12, 10)
+
+
+def _aspirate_dispense(i: AbstractInstrument) -> None:
+    """pipette dict with tip fixture."""
+    i.prepare_for_aspirate()
+    i.aspirate(12, 10)
+    i.dispense(2, 2)
+
+
+def _aspirate_blowout(i: AbstractInstrument) -> None:
+    """pipette dict with tip fixture."""
+    i.prepare_for_aspirate()
+    i.aspirate(112, 13)
+    i.blow_out()
+
+
+@pytest.mark.parametrize(
+    argnames=["side_effector"],
+    argvalues=[
+        [lambda i: None],
+        [_aspirate],
+        [_aspirate_dispense],
+        [_aspirate_blowout],
+    ],
+)
+def test_pipette_dict_with_tip(
+    side_effector: Callable[[AbstractInstrument], None],
+    instrument_context: AbstractInstrument,
+    simulating_instrument_context: AbstractInstrument,
+    labware: AbstractLabware,
+) -> None:
+    """It should be the same."""
+    # Home first
+    instrument_context.home()
+    simulating_instrument_context.home()
+    # Pickup tip
+    instrument_context.pick_up_tip(
+        well=labware.get_wells()[0], tip_length=2, presses=3, increment=4
+    )
+    simulating_instrument_context.pick_up_tip(
+        well=labware.get_wells()[0], tip_length=2, presses=3, increment=4
+    )
+
+    side_effector(instrument_context)
+    side_effector(simulating_instrument_context)
+    assert (
+        instrument_context.get_pipette() == simulating_instrument_context.get_pipette()
+    )
+
+    # Drop tip and compare again
+    instrument_context.drop_tip(home_after=False)
+    simulating_instrument_context.drop_tip(home_after=False)
+
+    assert (
+        instrument_context.get_pipette() == simulating_instrument_context.get_pipette()
+    )

--- a/api/tests/opentrons/protocols/context/simulator/test_instrument_context.py
+++ b/api/tests/opentrons/protocols/context/simulator/test_instrument_context.py
@@ -136,7 +136,7 @@ def _aspirate_dispense(i: AbstractInstrument) -> None:
 def _aspirate_blowout(i: AbstractInstrument) -> None:
     """pipette dict with tip fixture."""
     i.prepare_for_aspirate()
-    i.aspirate(112, 13)
+    i.aspirate(11, 13)
     i.blow_out()
 
 


### PR DESCRIPTION
# Overview

Our fast simulation was never setting the `working_volume` when picking up a tip. This led to bad transfer planning.

closes #9503 

# Changelog

- Added unit test to highlight the error
- Fix the error

# Review requests

I tested using the protocol provided in the bug description

# Risk assessment

Moderate?