### PR TITLE
refactor(api): hardware_control: strict types

### DIFF
--- a/api/mypy.ini
+++ b/api/mypy.ini
@@ -15,15 +15,6 @@ warn_untyped_fields = True
 # TODO(mc, 2021-09-08): fix and remove any / all of the
 # overrides below whenever able
 
-# ~390 errors
-[mypy-opentrons.hardware_control.*]
-disallow_any_generics = False
-disallow_untyped_defs = False
-disallow_untyped_calls = False
-disallow_incomplete_defs = False
-no_implicit_optional = False
-warn_return_any = False
-
 # ~240 errors
 [mypy-opentrons.protocols.*]
 disallow_any_generics = False

--- a/api/src/opentrons/hardware_control/__main__.py
+++ b/api/src/opentrons/hardware_control/__main__.py
@@ -11,6 +11,7 @@ _should_ only be run on an OT-2.
 import argparse
 import asyncio
 import logging
+from typing import Optional, Dict, Any
 
 from . import API
 from opentrons.config import robot_configs as rc
@@ -19,7 +20,7 @@ from opentrons.config.types import RobotConfig
 LOG = logging.getLogger("opentrons.hardware_control.__main__")
 
 
-def exception_handler(loop, context):
+def exception_handler(loop: asyncio.AbstractEventLoop, context: Dict[str, Any]) -> None:
     message = ""
     if "exception" in context:
         message += f'exception: {repr(context["exception"])}'
@@ -35,7 +36,9 @@ def exception_handler(loop, context):
     loop.default_exception_handler(context)
 
 
-async def arun(config: RobotConfig = None, port: str = None):
+async def arun(
+    config: Optional[RobotConfig] = None, port: Optional[str] = None
+) -> None:
     """Asynchronous entrypoint for the server
 
     :param config: Optional config override
@@ -45,7 +48,7 @@ async def arun(config: RobotConfig = None, port: str = None):
     hc = await API.build_hardware_controller(rconf, port)  # noqa: F841
 
 
-def run(config: RobotConfig = None, port: str = None):
+def run(config: Optional[RobotConfig] = None, port: Optional[str] = None) -> None:
     """Synchronous entrypoint for the server.
 
     Mostly builds a loop and calls arun.

--- a/api/src/opentrons/hardware_control/adapters.py
+++ b/api/src/opentrons/hardware_control/adapters.py
@@ -6,7 +6,7 @@ from typing import Generic, TypeVar, Callable, Sequence, Mapping, Any, cast
 from .protocols import AsyncioConfigurable
 
 
-WrappedObj = TypeVar("WrappedObj", bound=AsyncioConfigurable)
+WrappedObj = TypeVar("WrappedObj", bound=AsyncioConfigurable, covariant=True)
 WrappedReturn = TypeVar("WrappedReturn")
 WrappedFunc = TypeVar("WrappedFunc", bound=Callable[..., WrappedReturn])
 

--- a/api/src/opentrons/hardware_control/adapters.py
+++ b/api/src/opentrons/hardware_control/adapters.py
@@ -2,7 +2,7 @@
 """
 import asyncio
 import functools
-from typing import Generic, TypeVar, Callable, Sequence, Mapping, Any, cast
+from typing import Generic, TypeVar, Callable, Any, cast
 from .protocols import AsyncioConfigurable
 
 
@@ -55,8 +55,8 @@ class SynchronousAdapter(Generic[WrappedObj]):
     def call_coroutine_sync(
         loop: asyncio.AbstractEventLoop,
         to_call: WrappedFunc,
-        *args: Sequence[Any],
-        **kwargs: Mapping[str, Any]
+        *args: Any,
+        **kwargs: Any,
     ) -> WrappedReturn:
         fut = cast(
             "asyncio.Future[WrappedReturn]",

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -14,7 +14,6 @@ from typing import (
     Tuple,
     Sequence,
     Set,
-    Mapping,
     Any,
 )
 
@@ -832,7 +831,7 @@ class API(
         else:
             self._log.error("Cannot use an OT-3 config on an OT-2")
 
-    async def update_config(self, **kwargs: Mapping[str, Any]) -> None:
+    async def update_config(self, **kwargs: Any) -> None:
         """Update values of the robot's configuration.
 
         `kwargs` should contain keys of the robot's configuration. For

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -150,8 +150,8 @@ class OT3Controller:
 
     async def move(
         self,
-        origin: "Coordinates",
-        moves: List["Move"],
+        origin: Coordinates[OT3Axis, float],
+        moves: List[Move[OT3Axis]],
     ) -> None:
         """Move to a position.
 
@@ -237,7 +237,7 @@ class OT3Controller:
         yield
 
     @staticmethod
-    def _build_event_watcher():
+    def _build_event_watcher() -> aionotify.Watcher:
         watcher = aionotify.Watcher()
         watcher.watch(
             alias="modules",
@@ -246,7 +246,7 @@ class OT3Controller:
         )
         return watcher
 
-    async def _handle_watch_event(self):
+    async def _handle_watch_event(self) -> None:
         try:
             event = await self._event_watcher.get_event()
         except asyncio.IncompleteReadError:
@@ -259,7 +259,7 @@ class OT3Controller:
                 event_description = AionotifyEvent.build(event_name, flags)
                 await self.module_controls.handle_module_appearance(event_description)
 
-    async def watch(self, loop: asyncio.AbstractEventLoop):
+    async def watch(self, loop: asyncio.AbstractEventLoop) -> None:
         can_watch = aionotify is not None
         if can_watch:
             await self._event_watcher.setup(loop)

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -9,7 +9,6 @@ from typing import (
     List,
     Optional,
     Tuple,
-    TYPE_CHECKING,
     Sequence,
     Generator,
     cast,
@@ -40,14 +39,13 @@ from opentrons.hardware_control.types import (
     OT3AxisMap,
 )
 
-if TYPE_CHECKING:
-    from opentrons_shared_data.pipette.dev_types import PipetteName, PipetteModel
-    from opentrons.hardware_control.dev_types import (
-        InstrumentHardwareConfigs,
-        InstrumentSpec,
-        AttachedInstrument,
-    )
-    from opentrons.drivers.rpi_drivers.dev_types import GPIODriverLike
+from opentrons_shared_data.pipette.dev_types import PipetteName, PipetteModel
+from opentrons.hardware_control.dev_types import (
+    InstrumentHardwareConfigs,
+    InstrumentSpec,
+    AttachedInstrument,
+)
+from opentrons.drivers.rpi_drivers.dev_types import GPIODriverLike
 
 log = logging.getLogger(__name__)
 
@@ -112,7 +110,7 @@ class OT3Simulator:
         self._stubbed_attached_modules = attached_modules
 
         def _sanitize_attached_instrument(
-            passed_ai: Dict[str, Optional[str]] = None
+            passed_ai: Optional[Dict[str, Optional[str]]] = None
         ) -> InstrumentSpec:
             if not passed_ai or not passed_ai.get("model"):
                 return {"model": None, "id": None}
@@ -168,8 +166,8 @@ class OT3Simulator:
 
     async def move(
         self,
-        origin: "Coordinates",
-        moves: List[Move],
+        origin: Coordinates[OT3Axis, float],
+        moves: List[Move[OT3Axis]],
     ) -> None:
         """Move to a position.
 
@@ -293,7 +291,7 @@ class OT3Simulator:
         """Save the current."""
         yield
 
-    async def watch(self, loop: asyncio.AbstractEventLoop):
+    async def watch(self, loop: asyncio.AbstractEventLoop) -> None:
         new_mods_at_ports = [
             modules.ModuleAtPort(port=f"/dev/ot_module_sim_{mod}{str(idx)}", name=mod)
             for idx, mod in enumerate(self._stubbed_attached_modules)

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -11,6 +11,7 @@ from opentrons_hardware.hardware_control.motion_planning import (
     SystemConstraints,
     Coordinates,
     Move,
+    CoordinateValue,
 )
 from opentrons_hardware.hardware_control.motion_planning.move_utils import (
     unit_vector_multiplication,
@@ -101,20 +102,20 @@ def get_system_constraints(
 
 
 def _convert_to_node_id_dict(
-    axis_pos: "Coordinates[OT3Axis, np.float64]",
-) -> "NodeIdMotionValues":
+    axis_pos: Coordinates[OT3Axis, CoordinateValue],
+) -> NodeIdMotionValues:
     target: NodeIdMotionValues = {}
     for axis, pos in axis_pos.items():
         if axis_is_node(axis):
-            target[axis_to_node(axis)] = pos
+            target[axis_to_node(axis)] = np.float64(pos)
     return target
 
 
 def create_move_group(
-    origin: "Coordinates[OT3Axis, np.float64]",
-    moves: List["Move[OT3Axis]"],
-    present_nodes: Iterable["NodeId"],
-) -> Tuple["MoveGroup", Dict["NodeId", float]]:
+    origin: Coordinates[OT3Axis, CoordinateValue],
+    moves: List[Move[OT3Axis]],
+    present_nodes: Iterable[NodeId],
+) -> Tuple[MoveGroup, Dict[NodeId, float]]:
     pos = _convert_to_node_id_dict(origin)
     move_group: MoveGroup = []
     for move in moves:

--- a/api/src/opentrons/hardware_control/backends/simulator.py
+++ b/api/src/opentrons/hardware_control/backends/simulator.py
@@ -3,7 +3,7 @@ import asyncio
 import copy
 import logging
 from threading import Event
-from typing import Dict, Optional, List, Tuple, TYPE_CHECKING, Sequence
+from typing import Dict, Optional, List, Tuple, TYPE_CHECKING, Sequence, Iterator
 from contextlib import contextmanager
 
 from opentrons_shared_data.pipette import dummy_model_for_name
@@ -118,7 +118,7 @@ class Simulator:
         self._gpio_chardev = gpio_chardev
 
         def _sanitize_attached_instrument(
-            passed_ai: Dict[str, Optional[str]] = None
+            passed_ai: Optional[Dict[str, Optional[str]]] = None
         ) -> InstrumentSpec:
             if not passed_ai or not passed_ai.get("model"):
                 return {"model": None, "id": None}
@@ -169,7 +169,7 @@ class Simulator:
         return self._module_controls
 
     @module_controls.setter
-    def module_controls(self, module_controls: AttachedModulesControl):
+    def module_controls(self, module_controls: AttachedModulesControl) -> None:
         self._module_controls = module_controls
 
     async def update_position(self) -> Dict[str, float]:
@@ -185,13 +185,13 @@ class Simulator:
         self,
         target_position: Dict[str, float],
         home_flagged_axes: bool = True,
-        speed: float = None,
-        axis_max_speeds: Dict[str, float] = None,
-    ):
+        speed: Optional[float] = None,
+        axis_max_speeds: Optional[Dict[str, float]] = None,
+    ) -> None:
         self._position.update(target_position)
         self._engaged_axes.update({ax: True for ax in target_position})
 
-    async def home(self, axes: List[str] = None) -> Dict[str, float]:
+    async def home(self, axes: Optional[List[str]] = None) -> Dict[str, float]:
         # driver_3_0-> HOMED_POSITION
         checked_axes = "".join(axes) if axes else "XYZABC"
         self._position.update(
@@ -281,10 +281,10 @@ class Simulator:
             for mount in types.Mount
         }
 
-    def set_active_current(self, axis_currents: Dict[Axis, float]):
+    def set_active_current(self, axis_currents: Dict[Axis, float]) -> None:
         pass
 
-    async def watch(self):
+    async def watch(self) -> None:
         new_mods_at_ports = [
             modules.ModuleAtPort(port=f"/dev/ot_module_sim_{mod}{str(idx)}", name=mod)
             for idx, mod in enumerate(self._stubbed_attached_modules)
@@ -292,7 +292,7 @@ class Simulator:
         await self.module_controls.register_modules(new_mods_at_ports=new_mods_at_ports)
 
     @contextmanager
-    def save_current(self):
+    def save_current(self) -> Iterator[None]:
         yield
 
     @property
@@ -308,23 +308,25 @@ class Simulator:
     def fw_version(self) -> Optional[str]:
         return "Virtual Smoothie"
 
-    async def update_fw_version(self):
+    async def update_fw_version(self) -> None:
         pass
 
     @property
     def board_revision(self) -> BoardRevision:
         return self._board_revision
 
-    async def update_firmware(self, filename, loop, modeset) -> str:
+    async def update_firmware(
+        self, filename: str, loop: asyncio.AbstractEventLoop, modeset: bool
+    ) -> str:
         return "Did nothing (simulating)"
 
-    def engaged_axes(self):
+    def engaged_axes(self) -> Dict[str, bool]:
         return self._engaged_axes
 
-    async def disengage_axes(self, axes: List[str]):
+    async def disengage_axes(self, axes: List[str]) -> None:
         self._engaged_axes.update({ax: False for ax in axes})
 
-    def set_lights(self, button: Optional[bool], rails: Optional[bool]):
+    def set_lights(self, button: Optional[bool], rails: Optional[bool]) -> None:
         if button is not None:
             self._lights["button"] = button
         if rails is not None:
@@ -333,28 +335,28 @@ class Simulator:
     def get_lights(self) -> Dict[str, bool]:
         return self._lights
 
-    def pause(self):
+    def pause(self) -> None:
         self._run_flag.clear()
 
-    def resume(self):
+    def resume(self) -> None:
         self._run_flag.set()
 
-    async def halt(self):
+    async def halt(self) -> None:
         self._run_flag.set()
 
-    async def hard_halt(self):
+    async def hard_halt(self) -> None:
         self._run_flag.set()
 
     async def probe(self, axis: str, distance: float) -> Dict[str, float]:
         self._position[axis.upper()] = self._position[axis.upper()] + distance
         return self._position
 
-    async def clean_up(self):
+    async def clean_up(self) -> None:
         pass
 
     async def configure_mount(
         self, mount: types.Mount, config: InstrumentHardwareConfigs
-    ):
+    ) -> None:
         mount_axis = Axis.by_mount(mount)
         plunger_axis = Axis.of_plunger(mount)
 

--- a/api/src/opentrons/hardware_control/emulation/tempdeck.py
+++ b/api/src/opentrons/hardware_control/emulation/tempdeck.py
@@ -34,7 +34,7 @@ class TempDeckEmulator(AbstractEmulator):
         joined = " ".join(r for r in results if r)
         return None if not joined else joined
 
-    def reset(self):
+    def reset(self) -> None:
         self._temperature = Temperature(
             per_tick=self._settings.temperature.degrees_per_tick,
             current=self._settings.temperature.starting,

--- a/api/src/opentrons/hardware_control/emulation/thermocycler.py
+++ b/api/src/opentrons/hardware_control/emulation/thermocycler.py
@@ -37,7 +37,7 @@ class ThermocyclerEmulator(AbstractEmulator):
         joined = " ".join(r for r in results if r)
         return None if not joined else joined
 
-    def reset(self):
+    def reset(self) -> None:
         self._lid_temperature = Temperature(
             per_tick=self._settings.lid_temperature.degrees_per_tick,
             current=self._settings.lid_temperature.starting,

--- a/api/src/opentrons/hardware_control/emulation/util.py
+++ b/api/src/opentrons/hardware_control/emulation/util.py
@@ -1,4 +1,4 @@
-from typing import Optional, Generic, TypeVar, Any
+from typing import Optional, Generic, TypeVar
 
 TEMPERATURE_ROOM = 23
 
@@ -31,7 +31,7 @@ class OptionalValue(Generic[ValueType]):
     def __repr__(self) -> str:
         return "none" if self._value is None else str(self._value)
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, OptionalValue):
             return False
 

--- a/api/src/opentrons/hardware_control/emulation/util.py
+++ b/api/src/opentrons/hardware_control/emulation/util.py
@@ -1,4 +1,4 @@
-from typing import Optional, Generic, TypeVar
+from typing import Optional, Generic, TypeVar, Any
 
 TEMPERATURE_ROOM = 23
 
@@ -31,7 +31,7 @@ class OptionalValue(Generic[ValueType]):
     def __repr__(self) -> str:
         return "none" if self._value is None else str(self._value)
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: Any) -> bool:
         if not isinstance(other, OptionalValue):
             return False
 

--- a/api/src/opentrons/hardware_control/execution_manager.py
+++ b/api/src/opentrons/hardware_control/execution_manager.py
@@ -1,7 +1,10 @@
 import asyncio
 import functools
-from typing import Set, TypeVar, Type, cast, Callable
+from typing import Set, TypeVar, Type, cast, Callable, Any, Awaitable, overload
 from .types import ExecutionState, ExecutionCancelledError
+
+
+TaskContents = TypeVar("TaskContents")
 
 
 class ExecutionManager:
@@ -12,19 +15,22 @@ class ExecutionManager:
     It also handles loop clean up through its cancel method.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._state: ExecutionState = ExecutionState.RUNNING
         self._condition = asyncio.Condition()
-        self._cancellable_tasks: Set[asyncio.Task] = set()
+        # this Task would technically be parametrized with every different thing
+        # that you could possible call register_cancellable_task on unfortunately
+        # so it's not gonna get typechecked
+        self._cancellable_tasks: Set["asyncio.Task[Any]"] = set()
 
-    async def pause(self):
+    async def pause(self) -> None:
         async with self._condition:
             if self._state is ExecutionState.CANCELLED:
                 raise ExecutionCancelledError
             else:
                 self._state = ExecutionState.PAUSED
 
-    async def resume(self):
+    async def resume(self) -> None:
         async with self._condition:
             if self._state is ExecutionState.CANCELLED:
                 pass
@@ -32,7 +38,7 @@ class ExecutionManager:
                 self._state = ExecutionState.RUNNING
                 self._condition.notify_all()
 
-    async def cancel(self):
+    async def cancel(self) -> None:
         async with self._condition:
             self._state = ExecutionState.CANCELLED
             self._condition.notify_all()
@@ -41,7 +47,7 @@ class ExecutionManager:
                 if t is not running_task:
                     t.cancel()
 
-    async def reset(self):
+    async def reset(self) -> None:
         async with self._condition:
             self._state = ExecutionState.RUNNING
             self._condition.notify_all()
@@ -50,12 +56,14 @@ class ExecutionManager:
         async with self._condition:
             return self._state
 
-    async def register_cancellable_task(self, task: asyncio.Task):
+    async def register_cancellable_task(
+        self, task: "asyncio.Task[TaskContents]"
+    ) -> "asyncio.Task[TaskContents]":
         self._cancellable_tasks.add(task)
         task.add_done_callback(lambda t: self._cancellable_tasks.discard(t))
         return task
 
-    async def wait_for_is_running(self):
+    async def wait_for_is_running(self) -> None:
         async with self._condition:
             if self._state == ExecutionState.PAUSED:
                 await self._condition.wait()
@@ -67,7 +75,13 @@ class ExecutionManager:
                 pass
 
 
-DecoratedMethod = TypeVar("DecoratedMethod", bound=Callable)
+DecoratedReturn = TypeVar("DecoratedReturn")
+DecoratedMethodReturningValue = TypeVar(
+    "DecoratedMethodReturningValue", bound=Callable[..., Awaitable[DecoratedReturn]]
+)
+DecoratedMethodNoReturn = TypeVar(
+    "DecoratedMethodNoReturn", bound=Callable[..., Awaitable[None]]
+)
 SubclassInstance = TypeVar("SubclassInstance", bound="ExecutionManagerProvider")
 
 
@@ -86,22 +100,42 @@ class ExecutionManagerProvider:
     def execution_manager(self) -> ExecutionManager:
         return self._execution_manager
 
+    @overload
     @classmethod
     def wait_for_running(
-        cls: Type[SubclassInstance], decorated: DecoratedMethod
-    ) -> DecoratedMethod:
+        cls: Type[SubclassInstance], decorated: DecoratedMethodReturningValue
+    ) -> DecoratedMethodReturningValue:
+        ...
+
+    @overload
+    @classmethod
+    def wait_for_running(
+        cls: Type[SubclassInstance], decorated: DecoratedMethodNoReturn
+    ) -> DecoratedMethodNoReturn:
+        ...
+
+    # this type ignore and the overloads are because mypy requires that a function
+    # whose signature declares it returns None not have a return statement, whereas
+    # this function's implementation relies on python having None actually be the
+    # thing you return, and it's mad at that
+    @classmethod  # type: ignore
+    def wait_for_running(
+        cls: Type[SubclassInstance], decorated: DecoratedMethodReturningValue
+    ) -> DecoratedMethodReturningValue:
         @functools.wraps(decorated)
-        async def replace(inst: SubclassInstance, *args, **kwargs):
+        async def replace(
+            inst: SubclassInstance, *args: Any, **kwargs: Any
+        ) -> DecoratedReturn:
             if not inst._em_simulate:
                 await inst.execution_manager.wait_for_is_running()
             return await decorated(inst, *args, **kwargs)
 
-        return cast(DecoratedMethod, replace)
+        return cast(DecoratedMethodReturningValue, replace)
 
-    async def do_delay(self, duration_s: float):
+    async def do_delay(self, duration_s: float) -> None:
         if not self._em_simulate:
 
-            async def sleep_for_seconds(seconds: float):
+            async def sleep_for_seconds(seconds: float) -> None:
                 await asyncio.sleep(seconds)
 
             delay_task = asyncio.create_task(sleep_for_seconds(duration_s))

--- a/api/src/opentrons/hardware_control/instrument_handler.py
+++ b/api/src/opentrons/hardware_control/instrument_handler.py
@@ -102,7 +102,7 @@ class InstrumentHandlerProvider(Generic[MountType]):
         self._attached_instruments: InstrumentsByMount[MountType] = attached_instruments
         self._ihp_log = InstrumentHandlerProvider.IHP_LOG.getChild(str(id(self)))
 
-    def reset_instrument(self, mount: Optional[MountType] = None):
+    def reset_instrument(self, mount: Optional[MountType] = None) -> None:
         """
         Reset the internal state of a pipette by its mount, without doing
         any lower level reconfiguration. This is useful to make sure that no
@@ -112,7 +112,7 @@ class InstrumentHandlerProvider(Generic[MountType]):
                       reset both
         """
 
-        def _reset(m: MountType):
+        def _reset(m: MountType) -> None:
             self._ihp_log.info(f"Resetting configuration for {m}")
             p = self._attached_instruments[m]
             if not p:
@@ -220,7 +220,9 @@ class InstrumentHandlerProvider(Generic[MountType]):
         """Do not write new code that uses this."""
         return self._attached_instruments
 
-    def set_current_tiprack_diameter(self, mount: MountType, tiprack_diameter: float):
+    def set_current_tiprack_diameter(
+        self, mount: MountType, tiprack_diameter: float
+    ) -> None:
         instr = self.get_pipette(mount)
         self._ihp_log.info(
             "Updating tip rack diameter on pipette mount: "
@@ -260,7 +262,7 @@ class InstrumentHandlerProvider(Generic[MountType]):
         pipette
         """
         instr = self.get_pipette(mount)
-        pos_dict: Dict = {
+        pos_dict: Dict[str, float] = {
             "top": instr.config.top,
             "bottom": instr.config.bottom,
             "blow_out": instr.config.blow_out,
@@ -272,7 +274,7 @@ class InstrumentHandlerProvider(Generic[MountType]):
             pos_dict["bottom"] = bottom
         if blow_out is not None:
             pos_dict["blow_out"] = blow_out
-        if bottom is not None:
+        if drop_tip is not None:
             pos_dict["drop_tip"] = drop_tip
         for key in pos_dict.keys():
             instr.update_config_item(key, pos_dict[key])
@@ -361,7 +363,7 @@ class InstrumentHandlerProvider(Generic[MountType]):
             self._ihp_log.warning("detach tip called with no tip")
 
     def critical_point_for(
-        self, mount: MountType, cp_override: CriticalPoint = None
+        self, mount: MountType, cp_override: Optional[CriticalPoint] = None
     ) -> top_types.Point:
         """Return the current critical point of the specified mount.
 
@@ -380,7 +382,7 @@ class InstrumentHandlerProvider(Generic[MountType]):
             # configured such that the end of a p300 single gen1's tip is 0.
             return top_types.Point(0, 0, 30)
 
-    def ready_for_tip_action(self, target: Pipette, action: HardwareAction):
+    def ready_for_tip_action(self, target: Pipette, action: HardwareAction) -> None:
         if not target.has_tip:
             raise NoTipAttachedError(f"Cannot perform {action} without a tip attached")
         if (
@@ -422,7 +424,8 @@ class InstrumentHandlerProvider(Generic[MountType]):
     ) -> Optional[LiquidActionSpec[OT3Axis]]:
         ...
 
-    def plan_check_aspirate(
+    # note on this type ignore: see motion_utilities
+    def plan_check_aspirate(  # type: ignore
         self,
         mount,
         volume,
@@ -498,7 +501,7 @@ class InstrumentHandlerProvider(Generic[MountType]):
     ) -> Optional[LiquidActionSpec[OT3Axis]]:
         ...
 
-    def plan_check_dispense(
+    def plan_check_dispense(  # type: ignore
         self,
         mount,
         volume,
@@ -571,7 +574,7 @@ class InstrumentHandlerProvider(Generic[MountType]):
     def plan_check_blow_out(self, mount: OT3Mount) -> LiquidActionSpec[OT3Axis]:
         ...
 
-    def plan_check_blow_out(self, mount):
+    def plan_check_blow_out(self, mount):  # type: ignore
         """Check preconditions and calculate values for blowout."""
         instrument = self.get_pipette(mount)
         self.ready_for_tip_action(instrument, HardwareAction.BLOWOUT)
@@ -639,7 +642,7 @@ class InstrumentHandlerProvider(Generic[MountType]):
     ) -> Tuple[PickUpTipSpec[OT3Axis], Callable[[], None]]:
         ...
 
-    def plan_check_pick_up_tip(
+    def plan_check_pick_up_tip(  # type: ignore
         self,
         mount,
         tip_length,
@@ -802,7 +805,7 @@ class InstrumentHandlerProvider(Generic[MountType]):
     ) -> Tuple[DropTipSpec[OT3Axis], Callable[[], None]]:
         ...
 
-    def plan_check_drop_tip(
+    def plan_check_drop_tip(  # type: ignore
         self,
         mount,
         home_after,

--- a/api/src/opentrons/hardware_control/instrument_handler.py
+++ b/api/src/opentrons/hardware_control/instrument_handler.py
@@ -425,7 +425,7 @@ class InstrumentHandlerProvider(Generic[MountType]):
         ...
 
     # note on this type ignore: see motion_utilities
-    def plan_check_aspirate(  # type: ignore
+    def plan_check_aspirate(  # type: ignore[no-untyped-def]
         self,
         mount,
         volume,
@@ -501,7 +501,7 @@ class InstrumentHandlerProvider(Generic[MountType]):
     ) -> Optional[LiquidActionSpec[OT3Axis]]:
         ...
 
-    def plan_check_dispense(  # type: ignore
+    def plan_check_dispense(  # type: ignore[no-untyped-def]
         self,
         mount,
         volume,
@@ -574,7 +574,7 @@ class InstrumentHandlerProvider(Generic[MountType]):
     def plan_check_blow_out(self, mount: OT3Mount) -> LiquidActionSpec[OT3Axis]:
         ...
 
-    def plan_check_blow_out(self, mount):  # type: ignore
+    def plan_check_blow_out(self, mount):  # type: ignore[no-untyped-def]
         """Check preconditions and calculate values for blowout."""
         instrument = self.get_pipette(mount)
         self.ready_for_tip_action(instrument, HardwareAction.BLOWOUT)
@@ -642,7 +642,7 @@ class InstrumentHandlerProvider(Generic[MountType]):
     ) -> Tuple[PickUpTipSpec[OT3Axis], Callable[[], None]]:
         ...
 
-    def plan_check_pick_up_tip(  # type: ignore
+    def plan_check_pick_up_tip(  # type: ignore[no-untyped-def]
         self,
         mount,
         tip_length,
@@ -805,7 +805,7 @@ class InstrumentHandlerProvider(Generic[MountType]):
     ) -> Tuple[DropTipSpec[OT3Axis], Callable[[], None]]:
         ...
 
-    def plan_check_drop_tip(  # type: ignore
+    def plan_check_drop_tip(  # type: ignore[no-untyped-def]
         self,
         mount,
         home_after,

--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -30,11 +30,11 @@ class MagDeck(mod_abc.AbstractModule):
         port: str,
         usb_port: USBPort,
         execution_manager: ExecutionManager,
-        simulating=False,
-        loop: asyncio.AbstractEventLoop = None,
-        sim_model: str = None,
-        **kwargs,
-    ):
+        simulating: bool = False,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+        sim_model: Optional[str] = None,
+        **kwargs: float,
+    ) -> "MagDeck":
         """Factory function."""
         driver: AbstractMagDeckDriver
         if not simulating:
@@ -59,7 +59,7 @@ class MagDeck(mod_abc.AbstractModule):
         execution_manager: ExecutionManager,
         driver: AbstractMagDeckDriver,
         device_info: Mapping[str, str],
-        loop: asyncio.AbstractEventLoop = None,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
     ) -> None:
         """Constructor"""
         super().__init__(

--- a/api/src/opentrons/hardware_control/modules/plate_temp_status.py
+++ b/api/src/opentrons/hardware_control/modules/plate_temp_status.py
@@ -17,7 +17,9 @@ class PlateTemperatureStatus:
 
     def __init__(self) -> None:
         """Construct."""
-        self._temp_history: Deque = deque(maxlen=self.MIN_SAMPLES_UNDER_THRESHOLD)
+        self._temp_history: Deque[float] = deque(
+            maxlen=self.MIN_SAMPLES_UNDER_THRESHOLD
+        )
         self._status = TemperatureStatus.ERROR
 
     @property
@@ -44,7 +46,7 @@ class PlateTemperatureStatus:
         return self._status
 
     @staticmethod
-    def _is_holding_at_target(target: float, history: deque) -> bool:
+    def _is_holding_at_target(target: float, history: Deque[float]) -> bool:
         """
         Checks block temp history to determine if block temp has stabilized at
         the target temperature. Returns true only if all values in history are

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -35,10 +35,10 @@ class TempDeck(mod_abc.AbstractModule):
         usb_port: USBPort,
         execution_manager: ExecutionManager,
         simulating: bool = False,
-        loop: asyncio.AbstractEventLoop = None,
-        sim_model: str = None,
-        **kwargs,
-    ):
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+        sim_model: Optional[str] = None,
+        **kwargs: float,
+    ) -> "TempDeck":
         """
         Build a TempDeck
 
@@ -83,7 +83,7 @@ class TempDeck(mod_abc.AbstractModule):
         execution_manager: ExecutionManager,
         driver: AbstractTempDeckDriver,
         device_info: Mapping[str, str],
-        loop: asyncio.AbstractEventLoop = None,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
         polling_frequency: float = TEMP_POLL_INTERVAL_SECS,
     ) -> None:
         """Constructor"""
@@ -131,7 +131,7 @@ class TempDeck(mod_abc.AbstractModule):
         await self._driver.set_temperature(celsius=celsius)
         await self.wait_next_poll()
 
-        async def _wait():
+        async def _wait() -> None:
             # Wait until we reach the target temperature.
             while self.status != TemperatureStatus.HOLDING:
                 await self.wait_next_poll()
@@ -140,7 +140,7 @@ class TempDeck(mod_abc.AbstractModule):
         await self.make_cancellable(task)
         await task
 
-    async def start_set_temperature(self, celsius) -> None:
+    async def start_set_temperature(self, celsius: float) -> None:
         """
         Set temperature in degree Celsius
         Range: 4 to 95 degree Celsius (QA tested).
@@ -163,7 +163,7 @@ class TempDeck(mod_abc.AbstractModule):
         await self.wait_for_is_running()
         await self.wait_next_poll()
 
-        async def _await_temperature():
+        async def _await_temperature() -> None:
             if self.status == TemperatureStatus.HEATING:
                 while self.temperature < awaiting_temperature:
                     await self.wait_next_poll()

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -42,10 +42,10 @@ class Thermocycler(mod_abc.AbstractModule):
         usb_port: USBPort,
         execution_manager: ExecutionManager,
         simulating: bool = False,
-        loop: asyncio.AbstractEventLoop = None,
-        sim_model: str = None,
-        **kwargs,
-    ):
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+        sim_model: Optional[str] = None,
+        **kwargs: float,
+    ) -> "Thermocycler":
         """
         Build and connect to a Thermocycler
 
@@ -90,7 +90,7 @@ class Thermocycler(mod_abc.AbstractModule):
         execution_manager: ExecutionManager,
         driver: AbstractThermocyclerDriver,
         device_info: Dict[str, str],
-        loop: asyncio.AbstractEventLoop = None,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
         polling_interval_sec: float = POLLING_FREQUENCY_SEC,
     ) -> None:
         """
@@ -152,19 +152,19 @@ class Thermocycler(mod_abc.AbstractModule):
     async def deactivate_lid(self) -> None:
         """Deactivate the lid heating pad"""
         await self.wait_for_is_running()
-        return await self._driver.deactivate_lid()
+        await self._driver.deactivate_lid()
 
     async def deactivate_block(self) -> None:
         """Deactivate the block peltiers"""
         await self.wait_for_is_running()
         self._clear_cycle_counters()
-        return await self._driver.deactivate_block()
+        await self._driver.deactivate_block()
 
     async def deactivate(self) -> None:
         """Deactivate the block peltiers and lid heating pad"""
         await self.wait_for_is_running()
         self._clear_cycle_counters()
-        return await self._driver.deactivate_all()
+        await self._driver.deactivate_all()
 
     async def open(self) -> str:
         """Open the lid if it is closed"""
@@ -258,7 +258,7 @@ class Thermocycler(mod_abc.AbstractModule):
         self,
         steps: List[types.ThermocyclerStep],
         repetitions: int,
-        volume: float = None,
+        volume: Optional[float] = None,
     ) -> None:
         """
         Begin a set temperature cycle.
@@ -431,7 +431,7 @@ class Thermocycler(mod_abc.AbstractModule):
         return self._current_step_index
 
     @property
-    def live_data(self):
+    def live_data(self) -> types.LiveData:
         return {
             "status": self.status,
             "data": {
@@ -450,10 +450,10 @@ class Thermocycler(mod_abc.AbstractModule):
         }
 
     @property
-    def is_simulated(self):
+    def is_simulated(self) -> bool:
         return isinstance(self._driver, SimulatingDriver)
 
-    async def prep_for_update(self):
+    async def prep_for_update(self) -> str:
         await self._driver.enter_programming_mode()
 
         new_port = await update.find_bootloader_port()

--- a/api/src/opentrons/hardware_control/modules/update.py
+++ b/api/src/opentrons/hardware_control/modules/update.py
@@ -3,7 +3,7 @@ import logging
 import os
 from pathlib import Path
 from glob import glob
-from typing import Any, Dict, Tuple, Optional
+from typing import Any, Dict, Tuple, Optional, Union
 from .types import UpdateError
 from .mod_abc import AbstractModule
 
@@ -12,9 +12,9 @@ log = logging.getLogger(__name__)
 
 async def update_firmware(
     module: AbstractModule,
-    firmware_file: str,
+    firmware_file: Union[str, Path],
     loop: Optional[asyncio.AbstractEventLoop],
-):
+) -> None:
     """Apply update of given firmware file to given module.
 
     raises an UpdateError with the reason for the failure.
@@ -25,13 +25,13 @@ async def update_firmware(
         "stderr": asyncio.subprocess.PIPE,
         "loop": loop,
     }
-    successful, res = await module.bootloader()(flash_port, firmware_file, kwargs)
+    successful, res = await module.bootloader()(flash_port, str(firmware_file), kwargs)
     if not successful:
         log.info(f"Bootloader reponse: {res}")
         raise UpdateError(res)
 
 
-async def find_bootloader_port():
+async def find_bootloader_port() -> str:
     """
     Finds the port of an Opentrons Module that has entered its bootloader.
     The bootloader port shows up as 'ot_module_(avrdude|samba)_bootloader'

--- a/api/src/opentrons/hardware_control/modules/utils.py
+++ b/api/src/opentrons/hardware_control/modules/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from typing import Optional
 
 from opentrons.drivers.rpi_drivers.types import USBPort
 
@@ -23,7 +24,7 @@ async def build(
     usb_port: USBPort,
     loop: asyncio.AbstractEventLoop,
     execution_manager: ExecutionManager,
-    sim_model: str = None,
+    sim_model: Optional[str] = None,
 ) -> AbstractModule:
     return await MODULE_HW_BY_NAME[which].build(
         port,

--- a/api/src/opentrons/hardware_control/motion_utilities.py
+++ b/api/src/opentrons/hardware_control/motion_utilities.py
@@ -170,7 +170,7 @@ def target_position_from_absolute(
 # type signatures (see e.g. https://github.com/python/mypy/issues/9503).
 # And as discussed above, there's no way to write the type signature without
 # them. So, ignored.
-def target_position_from_absolute(  # type: ignore
+def target_position_from_absolute(  # type: ignore[no-untyped-def]
     mount,
     abs_position,
     get_critical_point,
@@ -204,7 +204,7 @@ def target_position_from_relative(
     ...
 
 
-def target_position_from_relative(  # type: ignore
+def target_position_from_relative(  # type: ignore[no-untyped-def]
     mount,
     delta,
     current_position,
@@ -237,7 +237,7 @@ def target_position_from_plunger(
     ...
 
 
-def target_position_from_plunger(  # type: ignore
+def target_position_from_plunger(  # type: ignore[no-untyped-def]
     mount,
     delta,
     current_position,
@@ -295,7 +295,7 @@ def machine_from_deck(
     ...
 
 
-def machine_from_deck(  # type: ignore
+def machine_from_deck(  # type: ignore[no-untyped-def]
     deck_pos,
     attitude,
     offset,
@@ -351,7 +351,7 @@ def deck_from_machine(
     ...
 
 
-def deck_from_machine(  # type: ignore
+def deck_from_machine(  # type: ignore[no-untyped-def]
     machine_pos,
     attitude,
     offset,

--- a/api/src/opentrons/hardware_control/motion_utilities.py
+++ b/api/src/opentrons/hardware_control/motion_utilities.py
@@ -34,7 +34,7 @@ def _x_for_mount(mount: OT3Mount) -> OT3Axis:
     ...
 
 
-def _x_for_mount(mount):
+def _x_for_mount(mount: Union[Mount, OT3Mount]) -> Union[Axis, OT3Axis]:
     if isinstance(mount, Mount):
         return Axis.X
     else:
@@ -51,7 +51,7 @@ def _y_for_mount(mount: OT3Mount) -> OT3Axis:
     ...
 
 
-def _y_for_mount(mount):
+def _y_for_mount(mount: Union[Mount, OT3Mount]) -> Union[Axis, OT3Axis]:
     if isinstance(mount, Mount):
         return Axis.Y
     else:
@@ -68,7 +68,7 @@ def _z_for_mount(mount: OT3Mount) -> OT3Axis:
     ...
 
 
-def _z_for_mount(mount):
+def _z_for_mount(mount: Union[Mount, OT3Mount]) -> Union[Axis, OT3Axis]:
     if isinstance(mount, Mount):
         return Axis.by_mount(mount)
     else:
@@ -85,7 +85,7 @@ def _plunger_for_mount(mount: OT3Mount) -> OT3Axis:
     ...
 
 
-def _plunger_for_mount(mount):
+def _plunger_for_mount(mount: Union[Mount, OT3Mount]) -> Union[Axis, OT3Axis]:
     if isinstance(mount, Mount):
         return Axis.of_plunger(mount)
     else:
@@ -102,7 +102,7 @@ def _axis_name(ax: OT3Axis) -> OT3Axis:
     ...
 
 
-def _axis_name(ax):
+def _axis_name(ax: Union[Axis, OT3Axis]) -> Union[str, OT3Axis]:
     if isinstance(ax, Axis):
         return ax.name
     else:
@@ -119,7 +119,7 @@ def _axis_enum(ax: OT3Axis) -> OT3Axis:
     ...
 
 
-def _axis_enum(ax):
+def _axis_enum(ax: Union[str, OT3Axis]) -> Union[Axis, OT3Axis]:
     if isinstance(ax, OT3Axis):
         return ax
     else:
@@ -148,7 +148,29 @@ def target_position_from_absolute(
     ...
 
 
-def target_position_from_absolute(
+# a note on the type ignoring of this and other overload implementation
+# functions: These functions are overloads in the first place because
+# that's the only way to create a semantic link between syntactically
+# unrelated types - the types of different arguments and return types
+# that can't really be related to each other in the type system. for
+# instance,
+# def do_something(a: Union[str, int], b: Union[str, int])
+# implies that all of the four cases of (a: int, b: str), (a: str, b: str),
+# (a: int, b: int, a: str, b: int) are semantically valid. typing
+# @overload
+# def do_something(a: int, b: int)
+# @overload
+# def do_something(a: str, b: str)
+# narrows that to 2.
+#
+# It's needed here because OT3Mount and OT3Axis can't really be
+# related, neither can Mount and Axis and str, etc.
+# The problem is that this is for _external callers_. When typechecking
+# the implementation of the overload, mypy doesn't consider the overload
+# type signatures (see e.g. https://github.com/python/mypy/issues/9503).
+# And as discussed above, there's no way to write the type signature without
+# them. So, ignored.
+def target_position_from_absolute(  # type: ignore
     mount,
     abs_position,
     get_critical_point,
@@ -182,7 +204,7 @@ def target_position_from_relative(
     ...
 
 
-def target_position_from_relative(
+def target_position_from_relative(  # type: ignore
     mount,
     delta,
     current_position,
@@ -215,7 +237,7 @@ def target_position_from_plunger(
     ...
 
 
-def target_position_from_plunger(
+def target_position_from_plunger(  # type: ignore
     mount,
     delta,
     current_position,
@@ -273,7 +295,7 @@ def machine_from_deck(
     ...
 
 
-def machine_from_deck(
+def machine_from_deck(  # type: ignore
     deck_pos,
     attitude,
     offset,
@@ -329,7 +351,12 @@ def deck_from_machine(
     ...
 
 
-def deck_from_machine(machine_pos, attitude, offset, axis_enum):
+def deck_from_machine(  # type: ignore
+    machine_pos,
+    attitude,
+    offset,
+    axis_enum,
+):
     """Build a deck-abs position store from the machine's position"""
     with_enum = {_axis_enum(k): v for k, v in machine_pos.items()}
     plunger_axes = {k: v for k, v in with_enum.items() if k not in k.gantry_axes()}

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -13,7 +13,6 @@ from typing import (
     Tuple,
     Sequence,
     Set,
-    Mapping,
     Any,
 )
 
@@ -830,7 +829,7 @@ class OT3API(
         else:
             self._log.error("Tried to specify an OT2 config object")
 
-    async def update_config(self, **kwargs: Mapping[str, Any]) -> None:
+    async def update_config(self, **kwargs: Any) -> None:
         """Update values of the robot's configuration."""
         self._config = replace(self._config, **kwargs)
 

--- a/api/src/opentrons/hardware_control/pause_manager.py
+++ b/api/src/opentrons/hardware_control/pause_manager.py
@@ -29,19 +29,19 @@ class PauseManager:
             return door_state is DoorState.OPEN
         return False
 
-    def set_door(self, door_state: DoorState):
+    def set_door(self, door_state: DoorState) -> None:
         self._blocked_by_door = self._evaluate_door_state(door_state)
 
-    def resume(self, pause_type: PauseType):
+    def resume(self, pause_type: PauseType) -> None:
         # door should be closed before a resume from the app can be received
         if self._blocked_by_door and pause_type is PauseType.PAUSE:
             raise PauseResumeError
         if pause_type in self.queue:
             self.queue.remove(pause_type)
 
-    def pause(self, pause_type: PauseType):
+    def pause(self, pause_type: PauseType) -> None:
         if pause_type not in self.queue:
             self.queue.append(pause_type)
 
-    def reset(self):
+    def reset(self) -> None:
         self.queue = []

--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -45,7 +45,7 @@ class Pipette:
         self,
         config: pipette_config.PipetteConfig,
         pipette_offset_cal: PipetteOffsetByPipetteMount,
-        pipette_id: str = None,
+        pipette_id: Optional[str] = None,
     ) -> None:
         self._config = config
         self._pipette_offset = pipette_offset_cal
@@ -78,7 +78,7 @@ class Pipette:
         # as_dict.
         self._config_as_dict = asdict(config)
 
-    def act_as(self, name: PipetteName):
+    def act_as(self, name: PipetteName) -> None:
         """Reconfigure to act as ``name``. ``name`` must be either the
         actual name of the pipette, or a name in its back-compatibility
         config.
@@ -99,7 +99,7 @@ class Pipette:
     def acting_as(self) -> PipetteName:
         return self._acting_as
 
-    def update_pipette_offset(self, offset_cal: PipetteOffsetByPipetteMount):
+    def update_pipette_offset(self, offset_cal: PipetteOffsetByPipetteMount) -> None:
         self._log.info("updating pipette offset to {}".format(offset_cal.offset))
         self._pipette_offset = offset_cal
 
@@ -111,7 +111,7 @@ class Pipette:
     def nozzle_offset(self) -> Tuple[float, float, float]:
         return self._nozzle_offset
 
-    def update_config_item(self, elem_name: str, elem_val: Any):
+    def update_config_item(self, elem_name: str, elem_val: Any) -> None:
         self._log.info("updated config: {}={}".format(elem_name, elem_val))
         self._config = replace(self._config, **{elem_name: elem_val})
         # Update the cached dict representation
@@ -129,7 +129,7 @@ class Pipette:
     def pipette_id(self) -> Optional[str]:
         return self._pipette_id
 
-    def critical_point(self, cp_override: CriticalPoint = None) -> Point:
+    def critical_point(self, cp_override: Optional[CriticalPoint] = None) -> Point:
         """
         The vector from the pipette's origin to its critical point. The
         critical point for a pipette is the end of the nozzle if no tip is
@@ -187,7 +187,7 @@ class Pipette:
         return self._current_tip_length
 
     @current_tip_length.setter
-    def current_tip_length(self, tip_length: float):
+    def current_tip_length(self, tip_length: float) -> None:
         self._current_tip_length = tip_length
 
     @property
@@ -196,7 +196,7 @@ class Pipette:
         return self._current_tiprack_diameter
 
     @current_tiprack_diameter.setter
-    def current_tiprack_diameter(self, diameter: float):
+    def current_tiprack_diameter(self, diameter: float) -> None:
         self._current_tiprack_diameter = diameter
 
     @property
@@ -205,7 +205,7 @@ class Pipette:
         return self._aspirate_flow_rate
 
     @aspirate_flow_rate.setter
-    def aspirate_flow_rate(self, new_flow_rate: float):
+    def aspirate_flow_rate(self, new_flow_rate: float) -> None:
         assert new_flow_rate > 0
         self._aspirate_flow_rate = new_flow_rate
 
@@ -215,7 +215,7 @@ class Pipette:
         return self._dispense_flow_rate
 
     @dispense_flow_rate.setter
-    def dispense_flow_rate(self, new_flow_rate: float):
+    def dispense_flow_rate(self, new_flow_rate: float) -> None:
         assert new_flow_rate > 0
         self._dispense_flow_rate = new_flow_rate
 
@@ -225,7 +225,7 @@ class Pipette:
         return self._blow_out_flow_rate
 
     @blow_out_flow_rate.setter
-    def blow_out_flow_rate(self, new_flow_rate: float):
+    def blow_out_flow_rate(self, new_flow_rate: float) -> None:
         assert new_flow_rate > 0
         self._blow_out_flow_rate = new_flow_rate
 
@@ -235,7 +235,7 @@ class Pipette:
         return self._working_volume
 
     @working_volume.setter
-    def working_volume(self, tip_volume: float):
+    def working_volume(self, tip_volume: float) -> None:
         """The working volume is the current tip max volume"""
         self._working_volume = min(self.config.max_volume, tip_volume)
 
@@ -244,16 +244,16 @@ class Pipette:
         """The amount of liquid possible to aspirate"""
         return self.working_volume - self.current_volume
 
-    def set_current_volume(self, new_volume: float):
+    def set_current_volume(self, new_volume: float) -> None:
         assert new_volume >= 0
         assert new_volume <= self.working_volume
         self._current_volume = new_volume
 
-    def add_current_volume(self, volume_incr: float):
+    def add_current_volume(self, volume_incr: float) -> None:
         assert self.ok_to_add_volume(volume_incr)
         self._current_volume += volume_incr
 
-    def remove_current_volume(self, volume_incr: float):
+    def remove_current_volume(self, volume_incr: float) -> None:
         assert self._current_volume >= volume_incr
         self._current_volume -= volume_incr
 

--- a/api/src/opentrons/hardware_control/poller.py
+++ b/api/src/opentrons/hardware_control/poller.py
@@ -62,7 +62,7 @@ class WaitableListener(Listener[DataT]):
     def __init__(self, loop: Optional[asyncio.AbstractEventLoop] = None) -> None:
         """Constructor."""
         self._loop = loop or asyncio.get_running_loop()
-        self._futures: Deque[asyncio.Future] = deque()
+        self._futures: Deque["asyncio.Future[DataT]"] = deque()
 
     async def wait_next_poll(self) -> DataT:
         """
@@ -70,7 +70,7 @@ class WaitableListener(Listener[DataT]):
 
         Returns: The next poll result.
         """
-        f = self._loop.create_future()
+        f: "asyncio.Future[DataT]" = self._loop.create_future()
         self._futures.append(f)
         return await f
 

--- a/api/src/opentrons/hardware_control/protocols/configurable.py
+++ b/api/src/opentrons/hardware_control/protocols/configurable.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Dict, Any
 from typing_extensions import Protocol
 
 from opentrons.config.types import RobotConfig, OT3Config
@@ -14,7 +14,7 @@ class Configurable(Protocol):
         """
         ...
 
-    def set_config(self, config: Union[RobotConfig, OT3Config]):
+    def set_config(self, config: Union[RobotConfig, OT3Config]) -> None:
         """Replace the currently-loaded config"""
         ...
 
@@ -26,7 +26,7 @@ class Configurable(Protocol):
     def config(self, config: Union[RobotConfig, OT3Config]) -> None:
         ...
 
-    async def update_config(self, **kwargs) -> None:
+    async def update_config(self, **kwargs: Dict[str, Any]) -> None:
         """Update values of the robot's configuration.
 
         `kwargs` should contain keys of the robot's configuration. For

--- a/api/src/opentrons/hardware_control/protocols/execution_controllable.py
+++ b/api/src/opentrons/hardware_control/protocols/execution_controllable.py
@@ -28,6 +28,6 @@ class ExecutionControllable(Protocol):
         """
         ...
 
-    async def delay(self, duration_s: float):
+    async def delay(self, duration_s: float) -> None:
         """Delay execution by pausing and sleeping."""
         ...

--- a/api/src/opentrons/hardware_control/protocols/instrument_configurer.py
+++ b/api/src/opentrons/hardware_control/protocols/instrument_configurer.py
@@ -82,7 +82,7 @@ class InstrumentConfigurer(Protocol):
         bottom: Optional[float] = None,
         blow_out: Optional[float] = None,
         drop_tip: Optional[float] = None,
-    ):
+    ) -> None:
         """
         Set calibration values for the pipette plunger.
         This can be called multiple times as the user sets each value,

--- a/api/src/opentrons/hardware_control/protocols/motion_controller.py
+++ b/api/src/opentrons/hardware_control/protocols/motion_controller.py
@@ -114,7 +114,7 @@ class MotionController(Protocol):
         speed: Optional[float] = None,
         critical_point: Optional[CriticalPoint] = None,
         max_speeds: Optional[Dict[Axis, float]] = None,
-    ):
+    ) -> None:
         """Move the critical point of the specified mount to a location
         relative to the deck, at the specified speed. 'speed' sets the speed
         of all robot axes to the given value. So, if multiple axes are to be
@@ -162,7 +162,7 @@ class MotionController(Protocol):
         max_speeds: Optional[Dict[Axis, float]] = None,
         check_bounds: MotionChecks = MotionChecks.NONE,
         fail_on_not_homed: bool = False,
-    ):
+    ) -> None:
         """Move the critical point of the specified mount by a specified
         displacement in a specified direction, at the specified speed.
         'speed' sets the speed of all axes to the given value. So, if multiple

--- a/api/src/opentrons/hardware_control/thread_manager.py
+++ b/api/src/opentrons/hardware_control/thread_manager.py
@@ -4,7 +4,17 @@ import logging
 import asyncio
 import functools
 import weakref
-from typing import Any, Awaitable, Callable, Generic, Optional, TypeVar, cast
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Generic,
+    Optional,
+    TypeVar,
+    cast,
+    Sequence,
+    Mapping,
+)
 from .adapters import SynchronousAdapter
 from .modules.mod_abc import AbstractModule
 from .protocols import (
@@ -18,10 +28,20 @@ class ThreadManagerException(Exception):
     pass
 
 
+WrappedReturn = TypeVar("WrappedReturn", contravariant=True)
+WrappedCoro = TypeVar("WrappedCoro", bound=Callable[..., Awaitable[WrappedReturn]])
+
+
 async def call_coroutine_threadsafe(
-    loop: asyncio.AbstractEventLoop, coro, *args, **kwargs
-) -> asyncio.Future:
-    fut = asyncio.run_coroutine_threadsafe(coro(*args, **kwargs), loop)
+    loop: asyncio.AbstractEventLoop,
+    coro: WrappedCoro,
+    *args: Sequence[Any],
+    **kwargs: Mapping[str, Any],
+) -> WrappedReturn:
+    fut = cast(
+        "asyncio.Future[WrappedReturn]",
+        asyncio.run_coroutine_threadsafe(coro(*args, **kwargs), loop),
+    )
     wrapped = asyncio.wrap_future(fut)
     return await wrapped
 
@@ -52,7 +72,9 @@ class CallBridger(Generic[WrappedObj]):
             # executed in managed thread to calling thread
 
             @functools.wraps(attr)
-            async def wrapper(*args, **kwargs):
+            async def wrapper(
+                *args: Sequence[Any], **kwargs: Mapping[str, Any]
+            ) -> WrappedReturn:
                 return await call_coroutine_threadsafe(loop, attr, *args, **kwargs)
 
             return wrapper
@@ -111,7 +133,7 @@ class ThreadManager(Generic[WrappedObj]):
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self.managed_obj: Optional[WrappedObj] = None
         self.bridged_obj: Optional[CallBridger[WrappedObj]] = None
-        self._sync_managed_obj: Optional[SynchronousAdapter] = None
+        self._sync_managed_obj: Optional[SynchronousAdapter[WrappedObj]] = None
         is_running = threading.Event()
         self._is_running = is_running
         self._cached_modules: weakref.WeakKeyDictionary[
@@ -139,7 +161,7 @@ class ThreadManager(Generic[WrappedObj]):
         if blocking:
             object.__getattribute__(self, "managed_thread_ready_blocking")()
 
-    def managed_thread_ready_blocking(self):
+    def managed_thread_ready_blocking(self) -> None:
         object.__getattribute__(self, "_is_running").wait()
         if not object.__getattribute__(self, "managed_obj"):
             raise ThreadManagerException("Failed to create Managed Object")
@@ -153,8 +175,11 @@ class ThreadManager(Generic[WrappedObj]):
             raise ThreadManagerException("Failed to create Managed Object")
 
     def _build_and_start_loop(
-        self, builder: Callable[..., Awaitable[WrappedObj]], *args, **kwargs
-    ):
+        self,
+        builder: Callable[..., Awaitable[WrappedObj]],
+        *args: Sequence[Any],
+        **kwargs: Mapping[str, Any],
+    ) -> None:
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         self._loop = loop
@@ -178,7 +203,7 @@ class ThreadManager(Generic[WrappedObj]):
         # All callers of this property assume it to be valid.
         return self._sync_managed_obj  # type: ignore
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<ThreadManager>"
 
     def clean_up(self) -> None:
@@ -208,9 +233,9 @@ class ThreadManager(Generic[WrappedObj]):
             )
             wrapper_cache.update({module: this_module_wrapper})
 
-        return this_module_wrapper
+        return this_module_wrapper  # type: ignore
 
-    def __getattribute__(self, attr_name):
+    def __getattribute__(self, attr_name: str) -> Any:
         # hardware_control.api.API.attached_modules is the only hardware
         # API method that returns something other than data. The module
         # objects it returns have associated methods that can be called.
@@ -236,12 +261,12 @@ class ThreadManager(Generic[WrappedObj]):
             )
             our_cleanup = object.__getattribute__(self, "clean_up")
 
-            def call_both():
+            def call_both() -> None:
                 # the wrapped cleanup wants to happen in the managed thread,
                 # started from the managed loop. our cleanup wants to happen
                 # in the current thread, _after_ the wrapped cleanup is done
                 # so cancelled tasks can have a chance to complete.
-                async def clean_and_notify():
+                async def clean_and_notify() -> None:
                     await wrapped_cleanup()
                     # this sleep allows the wrapped loop to spin a couple
                     # times to clean up the tasks we just cancelled. My kingdom

--- a/api/src/opentrons/hardware_control/threaded_async_lock.py
+++ b/api/src/opentrons/hardware_control/threaded_async_lock.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import threading
 import time
+from typing import Any
 
 
 log = logging.getLogger(__name__)
@@ -42,13 +43,14 @@ class ThreadedAsyncForbidden(Exception):
 
     def __init__(
         self,
-        msg="Robot is currently moving. Please wait and try " "this command again.",
-    ):
+        msg: str = "Robot is currently moving. Please wait and try "
+        "this command again.",
+    ) -> None:
         super().__init__(msg)
 
 
 class _Internal:
-    def __init__(self, lock: threading.Lock, forbid: bool):
+    def __init__(self, lock: threading.Lock, forbid: bool) -> None:
         """
         The private context manager that interacts with the lock. It can
         behave in normal locking mode or in `forbid` mode. When `forbid` is
@@ -62,7 +64,7 @@ class _Internal:
         self._thread_lock = lock
         self._forbid = forbid
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> None:
         pref = (
             f"[ThreadedAsyncLock tid {threading.get_ident()} "
             f"task {asyncio.current_task()}] "
@@ -77,19 +79,19 @@ class _Internal:
         now = time.perf_counter()
         log.debug(pref + f"acquired in {now-then}s")
 
-    async def __aexit__(self, exc_type, exc, tb):
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
         log.debug(
             f"[ThreadedAsyncLock tid {threading.get_ident()} "
             f"task {asyncio.current_task()}] will release"
         )
         self._thread_lock.release()
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         if not self._forbid:
             self._thread_lock.acquire()
         elif not self._thread_lock.acquire(blocking=False):
             # Lock is already acquired and blocking is forbidden
             raise ThreadedAsyncForbidden()
 
-    def __exit__(self, exc_type, exc, tb):
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
         self._thread_lock.release()

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -234,7 +234,7 @@ class DoorState(enum.Enum):
     OPEN = False
     CLOSED = True
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name.lower()
 
 
@@ -342,7 +342,7 @@ class ExecutionState(enum.Enum):
     PAUSED = enum.auto()
     CANCELLED = enum.auto()
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
 
@@ -353,7 +353,7 @@ class HardwareAction(enum.Enum):
     BLOWOUT = enum.auto()
     PREPARE_ASPIRATE = enum.auto()
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
 

--- a/api/src/opentrons/hardware_control/util.py
+++ b/api/src/opentrons/hardware_control/util.py
@@ -10,7 +10,9 @@ from opentrons.types import Point
 mod_log = logging.getLogger(__name__)
 
 
-def _handle_loop_exception(loop: asyncio.AbstractEventLoop, context: Dict[str, Any]):
+def _handle_loop_exception(
+    loop: asyncio.AbstractEventLoop, context: Dict[str, Any]
+) -> None:
     mod_log.error(f"Caught exception: {context}")
 
 
@@ -46,7 +48,7 @@ class DeckTransformState(Enum):
     BAD_CALIBRATION = "BAD_CALIBRATION"
     SINGULARITY = "SINGULARITY"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
 

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -19,7 +19,6 @@ from typing import (
     BinaryIO,
     Optional,
     Union,
-    cast,
 )
 
 import opentrons
@@ -27,10 +26,8 @@ from opentrons.hardware_control import (
     API as HardwareAPI,
     ThreadManager,
     SyncHardwareAPI,
-    HardwareControlAPI,
 )
 from opentrons.hardware_control.simulator_setup import load_simulator
-from opentrons.hardware_control.adapters import SynchronousAdapter
 from opentrons.protocol_api import MAX_SUPPORTED_VERSION
 from opentrons.protocols.duration import DurationEstimator
 from opentrons.protocols.execution import execute
@@ -196,13 +193,8 @@ def get_protocol_api(
     ):
         extra_labware = labware_from_paths([str(JUPYTER_NOTEBOOK_LABWARE_DIR)])
 
-    # it's unclear why we need the cast here. without it, we have a conflict between
-    # SynchronousAdapter[HardwareControlAPI] and SynchronousAdapter[API], which is weird
-    # because the protocol is fulfilled or at least it doesn't tell us why it's not. I
-    # suspect something weird around covariance.
-    checked_hardware = hardware_simulator or cast(
-        SynchronousAdapter[HardwareControlAPI],
-        ThreadManager(HardwareAPI.build_hardware_simulator).sync,
+    checked_hardware = (
+        hardware_simulator or ThreadManager(HardwareAPI.build_hardware_simulator).sync
     )
 
     return _build_protocol_context(

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -2,7 +2,7 @@
 
 import json
 from unittest import mock
-from typing import Any, Dict
+from typing import Any, Dict, cast
 
 from opentrons_shared_data import load_shared_data
 from opentrons_shared_data.pipette.dev_types import LabwareUri
@@ -17,6 +17,8 @@ from opentrons.types import Mount, Point, Location, TransferTipPolicy
 from opentrons.hardware_control import API, NoTipAttachedError
 from opentrons.hardware_control.pipette import Pipette
 from opentrons.hardware_control.types import Axis
+from opentrons.hardware_control.protocols import HardwareControlAPI
+from opentrons.hardware_control.adapters import SynchronousAdapter
 from opentrons.protocols.advanced_control import transfers as tf
 from opentrons.config.pipette_config import config_names
 from opentrons.protocols.api_support.types import APIVersion
@@ -266,7 +268,7 @@ def test_return_tip_old_version(loop, hardware, get_labware_def):
     ctx = papi.ProtocolContext(
         implementation=ProtocolContextImplementation(
             api_version=api_version,
-            sync_hardware=hardware.sync,
+            sync_hardware=cast(SynchronousAdapter[HardwareControlAPI], hardware.sync),
         ),
         loop=loop,
         api_version=api_version,
@@ -627,7 +629,7 @@ def test_touch_tip_default_args(loop, monkeypatch, hardware):
     ctx = papi.ProtocolContext(
         implementation=ProtocolContextImplementation(
             api_version=api_version,
-            sync_hardware=hardware.sync,
+            sync_hardware=cast(SynchronousAdapter[HardwareControlAPI], hardware.sync),
         ),
         loop=loop,
         api_version=api_version,
@@ -930,7 +932,7 @@ def test_order_of_module_load(loop):
     thread_manager = hardware_control.ThreadManager(
         hardware_control.API.build_hardware_simulator, attached_modules=mods
     )
-    fake_hardware = thread_manager.sync
+    fake_hardware = cast(SynchronousAdapter[HardwareControlAPI], thread_manager.sync)
 
     attached_modules = fake_hardware.attached_modules
     hw_temp1 = attached_modules[0]

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -2,7 +2,7 @@
 
 import json
 from unittest import mock
-from typing import Any, Dict, cast
+from typing import Any, Dict
 
 from opentrons_shared_data import load_shared_data
 from opentrons_shared_data.pipette.dev_types import LabwareUri
@@ -17,8 +17,6 @@ from opentrons.types import Mount, Point, Location, TransferTipPolicy
 from opentrons.hardware_control import API, NoTipAttachedError
 from opentrons.hardware_control.pipette import Pipette
 from opentrons.hardware_control.types import Axis
-from opentrons.hardware_control.protocols import HardwareControlAPI
-from opentrons.hardware_control.adapters import SynchronousAdapter
 from opentrons.protocols.advanced_control import transfers as tf
 from opentrons.config.pipette_config import config_names
 from opentrons.protocols.api_support.types import APIVersion
@@ -268,7 +266,7 @@ def test_return_tip_old_version(loop, hardware, get_labware_def):
     ctx = papi.ProtocolContext(
         implementation=ProtocolContextImplementation(
             api_version=api_version,
-            sync_hardware=cast(SynchronousAdapter[HardwareControlAPI], hardware.sync),
+            sync_hardware=hardware.sync,
         ),
         loop=loop,
         api_version=api_version,
@@ -629,7 +627,7 @@ def test_touch_tip_default_args(loop, monkeypatch, hardware):
     ctx = papi.ProtocolContext(
         implementation=ProtocolContextImplementation(
             api_version=api_version,
-            sync_hardware=cast(SynchronousAdapter[HardwareControlAPI], hardware.sync),
+            sync_hardware=hardware.sync,
         ),
         loop=loop,
         api_version=api_version,
@@ -932,7 +930,7 @@ def test_order_of_module_load(loop):
     thread_manager = hardware_control.ThreadManager(
         hardware_control.API.build_hardware_simulator, attached_modules=mods
     )
-    fake_hardware = cast(SynchronousAdapter[HardwareControlAPI], thread_manager.sync)
+    fake_hardware = thread_manager.sync
 
     attached_modules = fake_hardware.attached_modules
     hw_temp1 = attached_modules[0]

--- a/hardware/opentrons_hardware/hardware_control/motion_planning/__init__.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/__init__.py
@@ -9,6 +9,7 @@ from .types import (
     AxisConstraints,
     ZeroLengthMoveError,
     SystemConstraints,
+    CoordinateValue,
 )
 from .move_utils import unit_vector_multiplication
 
@@ -22,4 +23,5 @@ __all__ = [
     "SystemConstraints",
     "unit_vector_multiplication",
     "ZeroLengthMoveError",
+    "CoordinateValue",
 ]


### PR DESCRIPTION
Removes the mypy exceptions and fixes the resulting errors from the
hardware_control subpackage. There's a lot here! The weirder parts are
documented in comment blocks in the code itself.

This also fixes a bug in `calibrate_plunger` where the wrong thing was being null-checked - `bottom` was being None-checked but then `drop_tip` was being assigned. This would have caused unrelated errors farther down the line if you ever called `calibrate_plunger` and set `bottom` but not `drop_tip`. I don't think anybody's used this, though.
