### PR TITLE
refactor(ot3): update sensor payloads to include offset parameter

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -378,7 +378,7 @@ class SetSensorThresholdRequest:  # noqa: D101
 @dataclass
 class SensorThresholdResponse:  # noqa: D101
     payload: payloads.SensorThresholdResponsePayload
-    payload_type: Type[BinarySerializable] = payloads.SetSensorThresholdRequestPayload
+    payload_type: Type[BinarySerializable] = payloads.SensorThresholdResponsePayload
     message_id: Literal[
         MessageId.set_sensor_threshold_response
     ] = MessageId.set_sensor_threshold_response

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -338,22 +338,22 @@ class ReadLimitSwitchResponse:  # noqa: D101
 
 @dataclass
 class ReadFromSensorRequest:  # noqa: D101
-    payload: payloads.ReadFromSensorRequest
-    payload_type: Type[BinarySerializable] = payloads.ReadFromSensorRequest
+    payload: payloads.ReadFromSensorRequestPayload
+    payload_type: Type[BinarySerializable] = payloads.ReadFromSensorRequestPayload
     message_id: Literal[MessageId.read_sensor_request] = MessageId.read_sensor_request
 
 
 @dataclass
 class WriteToSensorRequest:  # noqa: D101
-    payload: payloads.WriteToSensorRequest
-    payload_type: Type[BinarySerializable] = payloads.WriteToSensorRequest
+    payload: payloads.WriteToSensorRequestPayload
+    payload_type: Type[BinarySerializable] = payloads.WriteToSensorRequestPayload
     message_id: Literal[MessageId.write_sensor_request] = MessageId.write_sensor_request
 
 
 @dataclass
 class BaselineSensorRequest:  # noqa: D101
-    payload: payloads.BaselineSensorRequest
-    payload_type: Type[BinarySerializable] = payloads.BaselineSensorRequest
+    payload: payloads.BaselineSensorRequestPayload
+    payload_type: Type[BinarySerializable] = payloads.BaselineSensorRequestPayload
     message_id: Literal[
         MessageId.baseline_sensor_request
     ] = MessageId.baseline_sensor_request
@@ -361,15 +361,15 @@ class BaselineSensorRequest:  # noqa: D101
 
 @dataclass
 class ReadFromSensorResponse:  # noqa: D101
-    payload: payloads.ReadFromSensorResponse
-    payload_type: Type[BinarySerializable] = payloads.ReadFromSensorResponse
+    payload: payloads.ReadFromSensorResponsePayload
+    payload_type: Type[BinarySerializable] = payloads.ReadFromSensorResponsePayload
     message_id: Literal[MessageId.read_sensor_response] = MessageId.read_sensor_response
 
 
 @dataclass
 class SetSensorThresholdRequest:  # noqa: D101
-    payload: payloads.SetSensorThresholdRequest
-    payload_type: Type[BinarySerializable] = payloads.SetSensorThresholdRequest
+    payload: payloads.SetSensorThresholdRequestPayload
+    payload_type: Type[BinarySerializable] = payloads.SetSensorThresholdRequestPayload
     message_id: Literal[
         MessageId.set_sensor_threshold_request
     ] = MessageId.set_sensor_threshold_request
@@ -377,8 +377,8 @@ class SetSensorThresholdRequest:  # noqa: D101
 
 @dataclass
 class SensorThresholdResponse:  # noqa: D101
-    payload: payloads.SensorThresholdResponse
-    payload_type: Type[BinarySerializable] = payloads.SensorThresholdResponse
+    payload: payloads.SensorThresholdResponsePayload
+    payload_type: Type[BinarySerializable] = payloads.SetSensorThresholdRequestPayload
     message_id: Literal[
         MessageId.set_sensor_threshold_response
     ] = MessageId.set_sensor_threshold_response

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -256,14 +256,15 @@ class GetLimitSwitchResponse(utils.BinarySerializable):
 
 
 @dataclass
-class ReadFromSensorRequest(utils.BinarySerializable):
+class ReadFromSensorRequestPayload(utils.BinarySerializable):
     """Take a single reading from a sensor request payload."""
 
     sensor: utils.UInt8Field
+    offset_reading: utils.UInt8Field
 
 
 @dataclass
-class WriteToSensorRequest(utils.BinarySerializable):
+class WriteToSensorRequestPayload(utils.BinarySerializable):
     """Write a piece of data to a sensor request payload."""
 
     sensor: utils.UInt8Field
@@ -271,15 +272,16 @@ class WriteToSensorRequest(utils.BinarySerializable):
 
 
 @dataclass
-class BaselineSensorRequest(utils.BinarySerializable):
+class BaselineSensorRequestPayload(utils.BinarySerializable):
     """Take a specified amount of readings from a sensor request payload."""
 
     sensor: utils.UInt8Field
     sample_rate: utils.UInt8Field
+    offset_update: utils.UInt8Field
 
 
 @dataclass
-class ReadFromSensorResponse(utils.BinarySerializable):
+class ReadFromSensorResponsePayload(utils.BinarySerializable):
     """A response for either a single reading or an averaged reading of a sensor."""
 
     sensor: utils.UInt8Field
@@ -287,7 +289,7 @@ class ReadFromSensorResponse(utils.BinarySerializable):
 
 
 @dataclass
-class SetSensorThresholdRequest(utils.BinarySerializable):
+class SetSensorThresholdRequestPayload(utils.BinarySerializable):
     """A request to set the threshold value of a sensor."""
 
     sensor: utils.UInt8Field
@@ -295,7 +297,7 @@ class SetSensorThresholdRequest(utils.BinarySerializable):
 
 
 @dataclass
-class SensorThresholdResponse(utils.BinarySerializable):
+class SensorThresholdResponsePayload(utils.BinarySerializable):
     """A response that sends back the current threshold value of the sensor."""
 
     sensor: utils.UInt8Field


### PR DESCRIPTION
# Overview

Tiny PR in preparation for sensor drivers on the python side and the pressure/capacitance PRs on the firmware side.

## Changelog

- Add an offset parameter on the read sensor messages to determine whether we want to take baseline readings of the sensor offset, or regular data.
