### PR TITLE
feat(robot-server): add heater-shaker to simulator file

### DIFF
--- a/robot-server/simulators/test.json
+++ b/robot-server/simulators/test.json
@@ -36,6 +36,7 @@
         }
       }
     ],
+    "heatershaker": [],
     "tempdeck": [
       {
         "function_name": "set_temperature",

--- a/robot-server/tests/integration/test_modules.tavern.yaml
+++ b/robot-server/tests/integration/test_modules.tavern.yaml
@@ -35,6 +35,26 @@ stages:
               totalCycleCount: Null
               currentStepIndex: Null
               totalStepCount: Null
+          - name: heatershaker
+            displayName: heatershaker
+            moduleModel: heaterShakerV1
+            port: !anystr
+            usbPort: !anydict
+            serial: !anystr
+            model: !anystr
+            revision: !anystr
+            fwVersion: !anystr
+            hasAvailableUpdate: !anybool
+            status: !anystr
+            data:
+              labwareLatchStatus: !anystr
+              speedStatus: !anystr
+              temperatureStatus: !anystr
+              currentSpeed: !anyint
+              currentTemp: !anyfloat
+              targetSpeed: Null
+              targetTemp: Null
+              errorDetails: Null
           - name: tempdeck
             displayName: tempdeck
             moduleModel: temperatureModuleV1


### PR DESCRIPTION


# Overview

Adds heater-shaker module to the simulated modules used by the dev server and updates tavern test for modules.


# Review requests

- Spin up the dev server and see that `GET /modules` includes a heater shaker with the expected live data.

# Risk assessment

None if tests pass.
