### PR TITLE
refactor(protocol-engine): add skeleton H/S commands

### DIFF
--- a/api/.coveragerc
+++ b/api/.coveragerc
@@ -1,3 +1,4 @@
 [report]
 exclude_lines =
     @overload
+    if TYPE_CHECKING:

--- a/api/src/opentrons/protocol_engine/commands/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/__init__.py
@@ -13,6 +13,8 @@ they are part of the public input / output of the engine, and need validation
 and/or schema generation.
 """
 
+from . import heater_shaker
+
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, CommandStatus
 
 from .command_unions import (
@@ -230,4 +232,6 @@ __all__ = [
     "SavePositionCreate",
     "SavePositionResult",
     "SavePositionCommandType",
+    # module command bundles
+    "heater_shaker",
 ]

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -2,6 +2,8 @@
 
 from typing import Union
 
+from . import heater_shaker
+
 from .aspirate import (
     Aspirate,
     AspirateParams,
@@ -33,7 +35,13 @@ from .drop_tip import (
     DropTipCommandType,
 )
 
-from .home import Home, HomeParams, HomeCreate, HomeResult, HomeCommandType
+from .home import (
+    Home,
+    HomeParams,
+    HomeCreate,
+    HomeResult,
+    HomeCommandType,
+)
 
 from .load_labware import (
     LoadLabware,
@@ -122,6 +130,13 @@ Command = Union[
     Pause,
     PickUpTip,
     SavePosition,
+    heater_shaker.AwaitTemperature,
+    heater_shaker.StartSetTargetTemperature,
+    heater_shaker.DeactivateHeater,
+    heater_shaker.SetTargetShakeSpeed,
+    heater_shaker.StopShake,
+    heater_shaker.OpenLatch,
+    heater_shaker.CloseLatch,
 ]
 
 CommandParams = Union[
@@ -139,6 +154,13 @@ CommandParams = Union[
     PauseParams,
     PickUpTipParams,
     SavePositionParams,
+    heater_shaker.AwaitTemperatureParams,
+    heater_shaker.StartSetTargetTemperatureParams,
+    heater_shaker.DeactivateHeaterParams,
+    heater_shaker.SetTargetShakeSpeedParams,
+    heater_shaker.StopShakeParams,
+    heater_shaker.OpenLatchParams,
+    heater_shaker.CloseLatchParams,
 ]
 
 CommandType = Union[
@@ -156,6 +178,13 @@ CommandType = Union[
     PauseCommandType,
     PickUpTipCommandType,
     SavePositionCommandType,
+    heater_shaker.AwaitTemperatureCommandType,
+    heater_shaker.StartSetTargetTemperatureCommandType,
+    heater_shaker.DeactivateHeaterCommandType,
+    heater_shaker.SetTargetShakeSpeedCommandType,
+    heater_shaker.StopShakeCommandType,
+    heater_shaker.OpenLatchCommandType,
+    heater_shaker.CloseLatchCommandType,
 ]
 
 CommandCreate = Union[
@@ -172,6 +201,13 @@ CommandCreate = Union[
     PauseCreate,
     PickUpTipCreate,
     SavePositionCreate,
+    heater_shaker.AwaitTemperatureCreate,
+    heater_shaker.StartSetTargetTemperatureCreate,
+    heater_shaker.DeactivateHeaterCreate,
+    heater_shaker.SetTargetShakeSpeedCreate,
+    heater_shaker.StopShakeCreate,
+    heater_shaker.OpenLatchCreate,
+    heater_shaker.CloseLatchCreate,
 ]
 
 CommandResult = Union[
@@ -189,4 +225,11 @@ CommandResult = Union[
     PauseResult,
     PickUpTipResult,
     SavePositionResult,
+    heater_shaker.AwaitTemperatureResult,
+    heater_shaker.StartSetTargetTemperatureResult,
+    heater_shaker.DeactivateHeaterResult,
+    heater_shaker.SetTargetShakeSpeedResult,
+    heater_shaker.StopShakeResult,
+    heater_shaker.OpenLatchResult,
+    heater_shaker.CloseLatchResult,
 ]

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/__init__.py
@@ -1,4 +1,4 @@
-"""Heater Shaker Module protocol commands."""
+"""Heater-Shaker Module protocol commands."""
 
 from .await_temperature import (
     AwaitTemperature,

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/__init__.py
@@ -1,0 +1,102 @@
+"""Heater Shaker Module protocol commands."""
+
+from .await_temperature import (
+    AwaitTemperature,
+    AwaitTemperatureCreate,
+    AwaitTemperatureParams,
+    AwaitTemperatureResult,
+    AwaitTemperatureCommandType,
+)
+
+from .start_set_target_temperature import (
+    StartSetTargetTemperature,
+    StartSetTargetTemperatureCreate,
+    StartSetTargetTemperatureParams,
+    StartSetTargetTemperatureResult,
+    StartSetTargetTemperatureCommandType,
+)
+
+from .deactivate_heater import (
+    DeactivateHeater,
+    DeactivateHeaterCreate,
+    DeactivateHeaterParams,
+    DeactivateHeaterResult,
+    DeactivateHeaterCommandType,
+)
+
+from .set_target_shake_speed import (
+    SetTargetShakeSpeed,
+    SetTargetShakeSpeedCreate,
+    SetTargetShakeSpeedParams,
+    SetTargetShakeSpeedResult,
+    SetTargetShakeSpeedCommandType,
+)
+
+from .stop_shake import (
+    StopShake,
+    StopShakeCreate,
+    StopShakeParams,
+    StopShakeResult,
+    StopShakeCommandType,
+)
+
+from .open_latch import (
+    OpenLatch,
+    OpenLatchCreate,
+    OpenLatchParams,
+    OpenLatchResult,
+    OpenLatchCommandType,
+)
+
+from .close_latch import (
+    CloseLatch,
+    CloseLatchCreate,
+    CloseLatchParams,
+    CloseLatchResult,
+    CloseLatchCommandType,
+)
+
+__all__ = [
+    # heaterShakerModule/awaitTemperature
+    "AwaitTemperature",
+    "AwaitTemperatureCreate",
+    "AwaitTemperatureParams",
+    "AwaitTemperatureResult",
+    "AwaitTemperatureCommandType",
+    # heaterShakerModule/startSetTargetTemperature
+    "StartSetTargetTemperature",
+    "StartSetTargetTemperatureCreate",
+    "StartSetTargetTemperatureParams",
+    "StartSetTargetTemperatureResult",
+    "StartSetTargetTemperatureCommandType",
+    # heaterShakerModule/deactivateHeater
+    "DeactivateHeater",
+    "DeactivateHeaterCreate",
+    "DeactivateHeaterParams",
+    "DeactivateHeaterResult",
+    "DeactivateHeaterCommandType",
+    # heaterShakerModule/setTargetShakeSpeed
+    "SetTargetShakeSpeed",
+    "SetTargetShakeSpeedCreate",
+    "SetTargetShakeSpeedParams",
+    "SetTargetShakeSpeedResult",
+    "SetTargetShakeSpeedCommandType",
+    # heaterShakerModule/stopShake
+    "StopShake",
+    "StopShakeCreate",
+    "StopShakeParams",
+    "StopShakeResult",
+    "StopShakeCommandType",
+    # heaterShakerModule/openLatch
+    "OpenLatch",
+    "OpenLatchCreate",
+    "OpenLatchParams",
+    "OpenLatchResult",
+    "OpenLatchCommandType",
+    # heaterShakerModule/closeLatch
+    "CloseLatch",
+    "CloseLatchCreate",
+    "CloseLatchParams",
+    "CloseLatchResult",
+    "CloseLatchCommandType",
+]

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/await_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/await_temperature.py
@@ -1,0 +1,51 @@
+"""Command models to await a Heater Shaker Module's target temperature."""
+from typing import Optional
+from typing_extensions import Literal, Type
+
+from pydantic import BaseModel, Field
+
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+
+AwaitTemperatureCommandType = Literal["heaterShakerModule/awaitTemperature"]
+
+
+class AwaitTemperatureParams(BaseModel):
+    """Input parameters to await a Heater Shaker's target temperature."""
+
+    moduleId: str = Field(..., description="Unique ID of the Heater Shaker Module.")
+
+
+class AwaitTemperatureResult(BaseModel):
+    """Result data from awaiting a Heater Shaker's target temperature."""
+
+
+class AwaitTemperatureImpl(
+    AbstractCommandImpl[AwaitTemperatureParams, AwaitTemperatureResult]
+):
+    """Execution implementation of a Heater Shaker's await temperature command."""
+
+    async def execute(self, params: AwaitTemperatureParams) -> AwaitTemperatureResult:
+        """Wait for a Heater Shaker's target temperature to be reached."""
+        raise NotImplementedError(
+            "Heater Shaker await temperature not yet implemented."
+        )
+
+
+class AwaitTemperature(BaseCommand[AwaitTemperatureParams, AwaitTemperatureResult]):
+    """A command to wait for a Heater Shaker's target temperature to be reached."""
+
+    commandType: AwaitTemperatureCommandType = "heaterShakerModule/awaitTemperature"
+    params: AwaitTemperatureParams
+    result: Optional[AwaitTemperatureResult]
+
+    _ImplementationCls: Type[AwaitTemperatureImpl] = AwaitTemperatureImpl
+
+
+class AwaitTemperatureCreate(BaseCommandCreate[AwaitTemperatureParams]):
+    """A request to create a Heater Shaker's await temperature command."""
+
+    commandType: AwaitTemperatureCommandType
+    params: AwaitTemperatureParams
+
+    _CommandCls: Type[AwaitTemperature] = AwaitTemperature

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/await_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/await_temperature.py
@@ -1,4 +1,4 @@
-"""Command models to await a Heater Shaker Module's target temperature."""
+"""Command models to await a Heater-Shaker Module's target temperature."""
 from typing import Optional
 from typing_extensions import Literal, Type
 
@@ -11,29 +11,29 @@ AwaitTemperatureCommandType = Literal["heaterShakerModule/awaitTemperature"]
 
 
 class AwaitTemperatureParams(BaseModel):
-    """Input parameters to await a Heater Shaker's target temperature."""
+    """Input parameters to await a Heater-Shaker's target temperature."""
 
-    moduleId: str = Field(..., description="Unique ID of the Heater Shaker Module.")
+    moduleId: str = Field(..., description="Unique ID of the Heater-Shaker Module.")
 
 
 class AwaitTemperatureResult(BaseModel):
-    """Result data from awaiting a Heater Shaker's target temperature."""
+    """Result data from awaiting a Heater-Shaker's target temperature."""
 
 
 class AwaitTemperatureImpl(
     AbstractCommandImpl[AwaitTemperatureParams, AwaitTemperatureResult]
 ):
-    """Execution implementation of a Heater Shaker's await temperature command."""
+    """Execution implementation of a Heater-Shaker's await temperature command."""
 
     async def execute(self, params: AwaitTemperatureParams) -> AwaitTemperatureResult:
-        """Wait for a Heater Shaker's target temperature to be reached."""
+        """Wait for a Heater-Shaker's target temperature to be reached."""
         raise NotImplementedError(
-            "Heater Shaker await temperature not yet implemented."
+            "Heater-Shaker await temperature not yet implemented."
         )
 
 
 class AwaitTemperature(BaseCommand[AwaitTemperatureParams, AwaitTemperatureResult]):
-    """A command to wait for a Heater Shaker's target temperature to be reached."""
+    """A command to wait for a Heater-Shaker's target temperature to be reached."""
 
     commandType: AwaitTemperatureCommandType = "heaterShakerModule/awaitTemperature"
     params: AwaitTemperatureParams
@@ -43,7 +43,7 @@ class AwaitTemperature(BaseCommand[AwaitTemperatureParams, AwaitTemperatureResul
 
 
 class AwaitTemperatureCreate(BaseCommandCreate[AwaitTemperatureParams]):
-    """A request to create a Heater Shaker's await temperature command."""
+    """A request to create a Heater-Shaker's await temperature command."""
 
     commandType: AwaitTemperatureCommandType
     params: AwaitTemperatureParams

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/close_latch.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/close_latch.py
@@ -1,4 +1,4 @@
-"""Command models to close the Heater Shaker Module's latch."""
+"""Command models to close the Heater-Shaker Module's latch."""
 from typing import Optional
 from typing_extensions import Literal, Type
 
@@ -11,25 +11,25 @@ CloseLatchCommandType = Literal["heaterShakerModule/closeLatch"]
 
 
 class CloseLatchParams(BaseModel):
-    """Input parameters to close a Heater Shaker Module's latch."""
+    """Input parameters to close a Heater-Shaker Module's latch."""
 
-    moduleId: str = Field(..., description="Unique ID of the Heater Shaker Module.")
+    moduleId: str = Field(..., description="Unique ID of the Heater-Shaker Module.")
 
 
 class CloseLatchResult(BaseModel):
-    """Result data from closing a Heater Shaker's latch."""
+    """Result data from closing a Heater-Shaker's latch."""
 
 
 class CloseLatchImpl(AbstractCommandImpl[CloseLatchParams, CloseLatchResult]):
-    """Execution implementation of a Heater Shaker's close latch command."""
+    """Execution implementation of a Heater-Shaker's close latch command."""
 
     async def execute(self, params: CloseLatchParams) -> CloseLatchResult:
-        """Close a Heater Shaker's latch."""
-        raise NotImplementedError("Heater Shaker close latch not yet implemented.")
+        """Close a Heater-Shaker's latch."""
+        raise NotImplementedError("Heater-Shaker close latch not yet implemented.")
 
 
 class CloseLatch(BaseCommand[CloseLatchParams, CloseLatchResult]):
-    """A command to close a Heater Shaker's latch."""
+    """A command to close a Heater-Shaker's latch."""
 
     commandType: CloseLatchCommandType = "heaterShakerModule/closeLatch"
     params: CloseLatchParams
@@ -39,7 +39,7 @@ class CloseLatch(BaseCommand[CloseLatchParams, CloseLatchResult]):
 
 
 class CloseLatchCreate(BaseCommandCreate[CloseLatchParams]):
-    """A request to create a Heater Shaker's close latch command."""
+    """A request to create a Heater-Shaker's close latch command."""
 
     commandType: CloseLatchCommandType
     params: CloseLatchParams

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/close_latch.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/close_latch.py
@@ -17,7 +17,7 @@ class CloseLatchParams(BaseModel):
 
 
 class CloseLatchResult(BaseModel):
-    """Result data from closeing a Heater Shaker's latch."""
+    """Result data from closing a Heater Shaker's latch."""
 
 
 class CloseLatchImpl(AbstractCommandImpl[CloseLatchParams, CloseLatchResult]):

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/close_latch.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/close_latch.py
@@ -1,0 +1,47 @@
+"""Command models to close the Heater Shaker Module's latch."""
+from typing import Optional
+from typing_extensions import Literal, Type
+
+from pydantic import BaseModel, Field
+
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+
+CloseLatchCommandType = Literal["heaterShakerModule/closeLatch"]
+
+
+class CloseLatchParams(BaseModel):
+    """Input parameters to close a Heater Shaker Module's latch."""
+
+    moduleId: str = Field(..., description="Unique ID of the Heater Shaker Module.")
+
+
+class CloseLatchResult(BaseModel):
+    """Result data from closeing a Heater Shaker's latch."""
+
+
+class CloseLatchImpl(AbstractCommandImpl[CloseLatchParams, CloseLatchResult]):
+    """Execution implementation of a Heater Shaker's close latch command."""
+
+    async def execute(self, params: CloseLatchParams) -> CloseLatchResult:
+        """Close a Heater Shaker's latch."""
+        raise NotImplementedError("Heater Shaker close latch not yet implemented.")
+
+
+class CloseLatch(BaseCommand[CloseLatchParams, CloseLatchResult]):
+    """A command to close a Heater Shaker's latch."""
+
+    commandType: CloseLatchCommandType = "heaterShakerModule/closeLatch"
+    params: CloseLatchParams
+    result: Optional[CloseLatchResult]
+
+    _ImplementationCls: Type[CloseLatchImpl] = CloseLatchImpl
+
+
+class CloseLatchCreate(BaseCommandCreate[CloseLatchParams]):
+    """A request to create a Heater Shaker's close latch command."""
+
+    commandType: CloseLatchCommandType
+    params: CloseLatchParams
+
+    _CommandCls: Type[CloseLatch] = CloseLatch

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_heater.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_heater.py
@@ -1,0 +1,51 @@
+"""Command models to stop heating Heater Shaker Module."""
+from typing import Optional
+from typing_extensions import Literal, Type
+
+from pydantic import BaseModel, Field
+
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+
+DeactivateHeaterCommandType = Literal["heaterShakerModule/deactivateHeater"]
+
+
+class DeactivateHeaterParams(BaseModel):
+    """Input parameters to unset a Heater Shaker's target temperature."""
+
+    moduleId: str = Field(..., description="Unique ID of the Heater Shaker Module.")
+
+
+class DeactivateHeaterResult(BaseModel):
+    """Result data from unsetting a Heater Shaker's target temperature."""
+
+
+class DeactivateHeaterImpl(
+    AbstractCommandImpl[DeactivateHeaterParams, DeactivateHeaterResult]
+):
+    """Execution implementation of a Heater Shaker's deactivate heater command."""
+
+    async def execute(self, params: DeactivateHeaterParams) -> DeactivateHeaterResult:
+        """Unset a Heater Shaker's target temperature."""
+        raise NotImplementedError(
+            "Heater Shaker deactivate heater not yet implemented."
+        )
+
+
+class DeactivateHeater(BaseCommand[DeactivateHeaterParams, DeactivateHeaterResult]):
+    """A command to set a Heater Shaker's target temperature."""
+
+    commandType: DeactivateHeaterCommandType = "heaterShakerModule/deactivateHeater"
+    params: DeactivateHeaterParams
+    result: Optional[DeactivateHeaterResult]
+
+    _ImplementationCls: Type[DeactivateHeaterImpl] = DeactivateHeaterImpl
+
+
+class DeactivateHeaterCreate(BaseCommandCreate[DeactivateHeaterParams]):
+    """A request to create a Heater Shaker's deactivate heater command."""
+
+    commandType: DeactivateHeaterCommandType
+    params: DeactivateHeaterParams
+
+    _CommandCls: Type[DeactivateHeater] = DeactivateHeater

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_heater.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_heater.py
@@ -33,7 +33,7 @@ class DeactivateHeaterImpl(
 
 
 class DeactivateHeater(BaseCommand[DeactivateHeaterParams, DeactivateHeaterResult]):
-    """A command to set a Heater Shaker's target temperature."""
+    """A command to unset a Heater Shaker's target temperature."""
 
     commandType: DeactivateHeaterCommandType = "heaterShakerModule/deactivateHeater"
     params: DeactivateHeaterParams

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_heater.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_heater.py
@@ -1,4 +1,4 @@
-"""Command models to stop heating Heater Shaker Module."""
+"""Command models to stop heating Heater-Shaker Module."""
 from typing import Optional
 from typing_extensions import Literal, Type
 
@@ -11,29 +11,29 @@ DeactivateHeaterCommandType = Literal["heaterShakerModule/deactivateHeater"]
 
 
 class DeactivateHeaterParams(BaseModel):
-    """Input parameters to unset a Heater Shaker's target temperature."""
+    """Input parameters to unset a Heater-Shaker's target temperature."""
 
-    moduleId: str = Field(..., description="Unique ID of the Heater Shaker Module.")
+    moduleId: str = Field(..., description="Unique ID of the Heater-Shaker Module.")
 
 
 class DeactivateHeaterResult(BaseModel):
-    """Result data from unsetting a Heater Shaker's target temperature."""
+    """Result data from unsetting a Heater-Shaker's target temperature."""
 
 
 class DeactivateHeaterImpl(
     AbstractCommandImpl[DeactivateHeaterParams, DeactivateHeaterResult]
 ):
-    """Execution implementation of a Heater Shaker's deactivate heater command."""
+    """Execution implementation of a Heater-Shaker's deactivate heater command."""
 
     async def execute(self, params: DeactivateHeaterParams) -> DeactivateHeaterResult:
-        """Unset a Heater Shaker's target temperature."""
+        """Unset a Heater-Shaker's target temperature."""
         raise NotImplementedError(
-            "Heater Shaker deactivate heater not yet implemented."
+            "Heater-Shaker deactivate heater not yet implemented."
         )
 
 
 class DeactivateHeater(BaseCommand[DeactivateHeaterParams, DeactivateHeaterResult]):
-    """A command to unset a Heater Shaker's target temperature."""
+    """A command to unset a Heater-Shaker's target temperature."""
 
     commandType: DeactivateHeaterCommandType = "heaterShakerModule/deactivateHeater"
     params: DeactivateHeaterParams
@@ -43,7 +43,7 @@ class DeactivateHeater(BaseCommand[DeactivateHeaterParams, DeactivateHeaterResul
 
 
 class DeactivateHeaterCreate(BaseCommandCreate[DeactivateHeaterParams]):
-    """A request to create a Heater Shaker's deactivate heater command."""
+    """A request to create a Heater-Shaker's deactivate heater command."""
 
     commandType: DeactivateHeaterCommandType
     params: DeactivateHeaterParams

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/open_latch.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/open_latch.py
@@ -1,4 +1,4 @@
-"""Command models to open the Heater Shaker Module's latch."""
+"""Command models to open the Heater-Shaker Module's latch."""
 from typing import Optional
 from typing_extensions import Literal, Type
 
@@ -11,25 +11,25 @@ OpenLatchCommandType = Literal["heaterShakerModule/openLatch"]
 
 
 class OpenLatchParams(BaseModel):
-    """Input parameters to open a Heater Shaker Module's latch."""
+    """Input parameters to open a Heater-Shaker Module's latch."""
 
-    moduleId: str = Field(..., description="Unique ID of the Heater Shaker Module.")
+    moduleId: str = Field(..., description="Unique ID of the Heater-Shaker Module.")
 
 
 class OpenLatchResult(BaseModel):
-    """Result data from opening a Heater Shaker's latch."""
+    """Result data from opening a Heater-Shaker's latch."""
 
 
 class OpenLatchImpl(AbstractCommandImpl[OpenLatchParams, OpenLatchResult]):
-    """Execution implementation of a Heater Shaker's open latch command."""
+    """Execution implementation of a Heater-Shaker's open latch command."""
 
     async def execute(self, params: OpenLatchParams) -> OpenLatchResult:
-        """Open a Heater Shaker's latch."""
-        raise NotImplementedError("Heater Shaker open latch not yet implemented.")
+        """Open a Heater-Shaker's latch."""
+        raise NotImplementedError("Heater-Shaker open latch not yet implemented.")
 
 
 class OpenLatch(BaseCommand[OpenLatchParams, OpenLatchResult]):
-    """A command to open a Heater Shaker's latch."""
+    """A command to open a Heater-Shaker's latch."""
 
     commandType: OpenLatchCommandType = "heaterShakerModule/openLatch"
     params: OpenLatchParams
@@ -39,7 +39,7 @@ class OpenLatch(BaseCommand[OpenLatchParams, OpenLatchResult]):
 
 
 class OpenLatchCreate(BaseCommandCreate[OpenLatchParams]):
-    """A request to create a Heater Shaker's open latch command."""
+    """A request to create a Heater-Shaker's open latch command."""
 
     commandType: OpenLatchCommandType
     params: OpenLatchParams

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/open_latch.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/open_latch.py
@@ -1,0 +1,47 @@
+"""Command models to open the Heater Shaker Module's latch."""
+from typing import Optional
+from typing_extensions import Literal, Type
+
+from pydantic import BaseModel, Field
+
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+
+OpenLatchCommandType = Literal["heaterShakerModule/openLatch"]
+
+
+class OpenLatchParams(BaseModel):
+    """Input parameters to open a Heater Shaker Module's latch."""
+
+    moduleId: str = Field(..., description="Unique ID of the Heater Shaker Module.")
+
+
+class OpenLatchResult(BaseModel):
+    """Result data from opening a Heater Shaker's latch."""
+
+
+class OpenLatchImpl(AbstractCommandImpl[OpenLatchParams, OpenLatchResult]):
+    """Execution implementation of a Heater Shaker's open latch command."""
+
+    async def execute(self, params: OpenLatchParams) -> OpenLatchResult:
+        """Open a Heater Shaker's latch."""
+        raise NotImplementedError("Heater Shaker open latch not yet implemented.")
+
+
+class OpenLatch(BaseCommand[OpenLatchParams, OpenLatchResult]):
+    """A command to open a Heater Shaker's latch."""
+
+    commandType: OpenLatchCommandType = "heaterShakerModule/openLatch"
+    params: OpenLatchParams
+    result: Optional[OpenLatchResult]
+
+    _ImplementationCls: Type[OpenLatchImpl] = OpenLatchImpl
+
+
+class OpenLatchCreate(BaseCommandCreate[OpenLatchParams]):
+    """A request to create a Heater Shaker's open latch command."""
+
+    commandType: OpenLatchCommandType
+    params: OpenLatchParams
+
+    _CommandCls: Type[OpenLatch] = OpenLatch

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_shake_speed.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_shake_speed.py
@@ -1,4 +1,4 @@
-"""Command models to shake the Heater Shaker Module."""
+"""Command models to shake the Heater-Shaker Module."""
 from typing import Optional
 from typing_extensions import Literal, Type
 
@@ -11,35 +11,35 @@ SetTargetShakeSpeedCommandType = Literal["heaterShakerModule/setTargetShakeSpeed
 
 
 class SetTargetShakeSpeedParams(BaseModel):
-    """Input parameters to start shaking a Heater Shaker Module."""
+    """Input parameters to start shaking a Heater-Shaker Module."""
 
-    moduleId: str = Field(..., description="Unique ID of the Heater Shaker Module.")
+    moduleId: str = Field(..., description="Unique ID of the Heater-Shaker Module.")
     # TODO(mc, 2022-02-24): for set temperature we use `temperature` (not `celsius`)
     # but for shake we use `rpm` (not `speed`). This is inconsistent
-    rpm: int = Field(..., description="Target speed in rotations per minute.")
+    rpm: float = Field(..., description="Target speed in rotations per minute.")
 
 
 class SetTargetShakeSpeedResult(BaseModel):
-    """Result data from setting a Heater Shaker's shake speed."""
+    """Result data from setting a Heater-Shaker's shake speed."""
 
 
 class SetTargetShakeSpeedImpl(
     AbstractCommandImpl[SetTargetShakeSpeedParams, SetTargetShakeSpeedResult]
 ):
-    """Execution implementation of a Heater Shaker's shake command."""
+    """Execution implementation of a Heater-Shaker's shake command."""
 
     async def execute(
         self,
         params: SetTargetShakeSpeedParams,
     ) -> SetTargetShakeSpeedResult:
-        """Set a Heater Shaker's target shake speed."""
-        raise NotImplementedError("Heater Shaker set shake speed not yet implemented.")
+        """Set a Heater-Shaker's target shake speed."""
+        raise NotImplementedError("Heater-Shaker set shake speed not yet implemented.")
 
 
 class SetTargetShakeSpeed(
     BaseCommand[SetTargetShakeSpeedParams, SetTargetShakeSpeedResult]
 ):
-    """A command to set a Heater Shaker's shake speed."""
+    """A command to set a Heater-Shaker's shake speed."""
 
     commandType: SetTargetShakeSpeedCommandType = (
         "heaterShakerModule/setTargetShakeSpeed"
@@ -51,7 +51,7 @@ class SetTargetShakeSpeed(
 
 
 class SetTargetShakeSpeedCreate(BaseCommandCreate[SetTargetShakeSpeedParams]):
-    """A request to create a Heater Shaker's set shake speed command."""
+    """A request to create a Heater-Shaker's set shake speed command."""
 
     commandType: SetTargetShakeSpeedCommandType
     params: SetTargetShakeSpeedParams

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_shake_speed.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_shake_speed.py
@@ -1,0 +1,59 @@
+"""Command models to shake the Heater Shaker Module."""
+from typing import Optional
+from typing_extensions import Literal, Type
+
+from pydantic import BaseModel, Field
+
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+
+SetTargetShakeSpeedCommandType = Literal["heaterShakerModule/setTargetShakeSpeed"]
+
+
+class SetTargetShakeSpeedParams(BaseModel):
+    """Input parameters to start shaking a Heater Shaker Module."""
+
+    moduleId: str = Field(..., description="Unique ID of the Heater Shaker Module.")
+    # TODO(mc, 2022-02-24): for set temperature we use `temperature` (not `celsius`)
+    # but for shake we use `rpm` (not `speed`). This is inconsistent
+    rpm: int = Field(..., description="Target speed in rotations per minute.")
+
+
+class SetTargetShakeSpeedResult(BaseModel):
+    """Result data from setting a Heater Shaker's shake speed."""
+
+
+class SetTargetShakeSpeedImpl(
+    AbstractCommandImpl[SetTargetShakeSpeedParams, SetTargetShakeSpeedResult]
+):
+    """Execution implementation of a Heater Shaker's shake command."""
+
+    async def execute(
+        self,
+        params: SetTargetShakeSpeedParams,
+    ) -> SetTargetShakeSpeedResult:
+        """Set a Heater Shaker's target shake speed."""
+        raise NotImplementedError("Heater Shaker set shake speed not yet implemented.")
+
+
+class SetTargetShakeSpeed(
+    BaseCommand[SetTargetShakeSpeedParams, SetTargetShakeSpeedResult]
+):
+    """A command to set a Heater Shaker's shake speed."""
+
+    commandType: SetTargetShakeSpeedCommandType = (
+        "heaterShakerModule/setTargetShakeSpeed"
+    )
+    params: SetTargetShakeSpeedParams
+    result: Optional[SetTargetShakeSpeedResult]
+
+    _ImplementationCls: Type[SetTargetShakeSpeedImpl] = SetTargetShakeSpeedImpl
+
+
+class SetTargetShakeSpeedCreate(BaseCommandCreate[SetTargetShakeSpeedParams]):
+    """A request to create a Heater Shaker's set shake speed command."""
+
+    commandType: SetTargetShakeSpeedCommandType
+    params: SetTargetShakeSpeedParams
+
+    _CommandCls: Type[SetTargetShakeSpeed] = SetTargetShakeSpeed

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/start_set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/start_set_target_temperature.py
@@ -1,0 +1,67 @@
+"""Command models to start heating a Heater Shaker Module."""
+from typing import Optional
+from typing_extensions import Literal, Type
+
+from pydantic import BaseModel, Field
+
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+
+StartSetTargetTemperatureCommandType = Literal[
+    "heaterShakerModule/startSetTargetTemperature"
+]
+
+
+class StartSetTargetTemperatureParams(BaseModel):
+    """Input parameters to set a Heater Shaker's target temperature."""
+
+    moduleId: str = Field(..., description="Unique ID of the Heater Shaker Module.")
+    temperature: float = Field(..., description="Target temperature in °C.")
+
+
+class StartSetTargetTemperatureResult(BaseModel):
+    """Result data from setting a Heater Shaker's target temperature."""
+
+
+class StartSetTargetTemperatureImpl(
+    AbstractCommandImpl[
+        StartSetTargetTemperatureParams, StartSetTargetTemperatureResult
+    ]
+):
+    """Execution implementation of a Heater Shaker's set temperature command."""
+
+    async def execute(
+        self,
+        params: StartSetTargetTemperatureParams,
+    ) -> StartSetTargetTemperatureResult:
+        """Set a Heater Shaker's target temperature."""
+        raise NotImplementedError(
+            "Heater Shaker start set target temperature not yet implemented."
+        )
+
+
+class StartSetTargetTemperature(
+    BaseCommand[StartSetTargetTemperatureParams, StartSetTargetTemperatureResult]
+):
+    """A command to set a Heater Shaker's target temperature."""
+
+    commandType: StartSetTargetTemperatureCommandType = (
+        "heaterShakerModule/startSetTargetTemperature"
+    )
+    params: StartSetTargetTemperatureParams
+    result: Optional[StartSetTargetTemperatureResult]
+
+    _ImplementationCls: Type[
+        StartSetTargetTemperatureImpl
+    ] = StartSetTargetTemperatureImpl
+
+
+class StartSetTargetTemperatureCreate(
+    BaseCommandCreate[StartSetTargetTemperatureParams]
+):
+    """A request to create a Heater Shaker's set temperature command."""
+
+    commandType: StartSetTargetTemperatureCommandType
+    params: StartSetTargetTemperatureParams
+
+    _CommandCls: Type[StartSetTargetTemperature] = StartSetTargetTemperature

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/start_set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/start_set_target_temperature.py
@@ -1,4 +1,4 @@
-"""Command models to start heating a Heater Shaker Module."""
+"""Command models to start heating a Heater-Shaker Module."""
 from typing import Optional
 from typing_extensions import Literal, Type
 
@@ -13,14 +13,14 @@ StartSetTargetTemperatureCommandType = Literal[
 
 
 class StartSetTargetTemperatureParams(BaseModel):
-    """Input parameters to set a Heater Shaker's target temperature."""
+    """Input parameters to set a Heater-Shaker's target temperature."""
 
-    moduleId: str = Field(..., description="Unique ID of the Heater Shaker Module.")
+    moduleId: str = Field(..., description="Unique ID of the Heater-Shaker Module.")
     temperature: float = Field(..., description="Target temperature in °C.")
 
 
 class StartSetTargetTemperatureResult(BaseModel):
-    """Result data from setting a Heater Shaker's target temperature."""
+    """Result data from setting a Heater-Shaker's target temperature."""
 
 
 class StartSetTargetTemperatureImpl(
@@ -28,22 +28,22 @@ class StartSetTargetTemperatureImpl(
         StartSetTargetTemperatureParams, StartSetTargetTemperatureResult
     ]
 ):
-    """Execution implementation of a Heater Shaker's set temperature command."""
+    """Execution implementation of a Heater-Shaker's set temperature command."""
 
     async def execute(
         self,
         params: StartSetTargetTemperatureParams,
     ) -> StartSetTargetTemperatureResult:
-        """Set a Heater Shaker's target temperature."""
+        """Set a Heater-Shaker's target temperature."""
         raise NotImplementedError(
-            "Heater Shaker start set target temperature not yet implemented."
+            "Heater-Shaker start set target temperature not yet implemented."
         )
 
 
 class StartSetTargetTemperature(
     BaseCommand[StartSetTargetTemperatureParams, StartSetTargetTemperatureResult]
 ):
-    """A command to set a Heater Shaker's target temperature."""
+    """A command to set a Heater-Shaker's target temperature."""
 
     commandType: StartSetTargetTemperatureCommandType = (
         "heaterShakerModule/startSetTargetTemperature"
@@ -59,7 +59,7 @@ class StartSetTargetTemperature(
 class StartSetTargetTemperatureCreate(
     BaseCommandCreate[StartSetTargetTemperatureParams]
 ):
-    """A request to create a Heater Shaker's set temperature command."""
+    """A request to create a Heater-Shaker's set temperature command."""
 
     commandType: StartSetTargetTemperatureCommandType
     params: StartSetTargetTemperatureParams

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/stop_shake.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/stop_shake.py
@@ -1,4 +1,4 @@
-"""Command models to stop shaking the Heater Shaker Module."""
+"""Command models to stop shaking the Heater-Shaker Module."""
 from typing import Optional
 from typing_extensions import Literal, Type
 
@@ -11,25 +11,25 @@ StopShakeCommandType = Literal["heaterShakerModule/stopShake"]
 
 
 class StopShakeParams(BaseModel):
-    """Input parameters to stop shaking a Heater Shaker Module."""
+    """Input parameters to stop shaking a Heater-Shaker Module."""
 
-    moduleId: str = Field(..., description="Unique ID of the Heater Shaker Module.")
+    moduleId: str = Field(..., description="Unique ID of the Heater-Shaker Module.")
 
 
 class StopShakeResult(BaseModel):
-    """Result data from stopping a Heater Shaker's shake."""
+    """Result data from stopping a Heater-Shaker's shake."""
 
 
 class StopShakeImpl(AbstractCommandImpl[StopShakeParams, StopShakeResult]):
-    """Execution implementation of a Heater Shaker's stop shake command."""
+    """Execution implementation of a Heater-Shaker's stop shake command."""
 
     async def execute(self, params: StopShakeParams) -> StopShakeResult:
-        """Stop a Heater Shaker's shake."""
-        raise NotImplementedError("Heater Shaker stop shake not yet implemented.")
+        """Stop a Heater-Shaker's shake."""
+        raise NotImplementedError("Heater-Shaker stop shake not yet implemented.")
 
 
 class StopShake(BaseCommand[StopShakeParams, StopShakeResult]):
-    """A command to stop a Heater Shaker's shake."""
+    """A command to stop a Heater-Shaker's shake."""
 
     commandType: StopShakeCommandType = "heaterShakerModule/stopShake"
     params: StopShakeParams
@@ -39,7 +39,7 @@ class StopShake(BaseCommand[StopShakeParams, StopShakeResult]):
 
 
 class StopShakeCreate(BaseCommandCreate[StopShakeParams]):
-    """A request to create a Heater Shaker's stop shake command."""
+    """A request to create a Heater-Shaker's stop shake command."""
 
     commandType: StopShakeCommandType
     params: StopShakeParams

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/stop_shake.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/stop_shake.py
@@ -1,0 +1,47 @@
+"""Command models to stop shaking the Heater Shaker Module."""
+from typing import Optional
+from typing_extensions import Literal, Type
+
+from pydantic import BaseModel, Field
+
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+
+StopShakeCommandType = Literal["heaterShakerModule/stopShake"]
+
+
+class StopShakeParams(BaseModel):
+    """Input parameters to stop shaking a Heater Shaker Module."""
+
+    moduleId: str = Field(..., description="Unique ID of the Heater Shaker Module.")
+
+
+class StopShakeResult(BaseModel):
+    """Result data from stopping a Heater Shaker's shake."""
+
+
+class StopShakeImpl(AbstractCommandImpl[StopShakeParams, StopShakeResult]):
+    """Execution implementation of a Heater Shaker's stop shake command."""
+
+    async def execute(self, params: StopShakeParams) -> StopShakeResult:
+        """Stop a Heater Shaker's shake."""
+        raise NotImplementedError("Heater Shaker stop shake not yet implemented.")
+
+
+class StopShake(BaseCommand[StopShakeParams, StopShakeResult]):
+    """A command to stop a Heater Shaker's shake."""
+
+    commandType: StopShakeCommandType = "heaterShakerModule/stopShake"
+    params: StopShakeParams
+    result: Optional[StopShakeResult]
+
+    _ImplementationCls: Type[StopShakeImpl] = StopShakeImpl
+
+
+class StopShakeCreate(BaseCommandCreate[StopShakeParams]):
+    """A request to create a Heater Shaker's stop shake command."""
+
+    commandType: StopShakeCommandType
+    params: StopShakeParams
+
+    _CommandCls: Type[StopShake] = StopShake

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/__init__.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Heater Shaker Module commands."""

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_await_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_await_temperature.py
@@ -1,0 +1,36 @@
+"""Test Heater Shaker await temperature command implementation."""
+import pytest
+from decoy import Decoy
+
+from opentrons.protocol_engine import execution
+from opentrons.protocol_engine.commands import heater_shaker
+from opentrons.protocol_engine.commands.heater_shaker.await_temperature import (
+    AwaitTemperatureImpl,
+)
+
+
+@pytest.fixture()
+def subject(
+    equipment: execution.EquipmentHandler,
+    movement: execution.MovementHandler,
+    pipetting: execution.PipettingHandler,
+    run_control: execution.RunControlHandler,
+) -> AwaitTemperatureImpl:
+    """Get the command implementation with mocked out dependencies."""
+    return AwaitTemperatureImpl(
+        equipment=equipment,
+        movement=movement,
+        pipetting=pipetting,
+        run_control=run_control,
+    )
+
+
+# TODO(mc, 2022-02-25): verify hardware interaction
+@pytest.mark.xfail(raises=NotImplementedError, strict=True)
+async def test_await_temperature(decoy: Decoy, subject: AwaitTemperatureImpl) -> None:
+    """It should be able to wait for the module's target temperature."""
+    data = heater_shaker.AwaitTemperatureParams(moduleId="heater-shaker-id")
+
+    result = await subject.execute(data)
+
+    assert result == heater_shaker.AwaitTemperatureResult()

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_close_latch.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_close_latch.py
@@ -1,0 +1,36 @@
+"""Test Heater Shaker close latch command implementation."""
+import pytest
+from decoy import Decoy
+
+from opentrons.protocol_engine import execution
+from opentrons.protocol_engine.commands import heater_shaker
+from opentrons.protocol_engine.commands.heater_shaker.close_latch import (
+    CloseLatchImpl,
+)
+
+
+@pytest.fixture()
+def subject(
+    equipment: execution.EquipmentHandler,
+    movement: execution.MovementHandler,
+    pipetting: execution.PipettingHandler,
+    run_control: execution.RunControlHandler,
+) -> CloseLatchImpl:
+    """Get the command implementation with mocked out dependencies."""
+    return CloseLatchImpl(
+        equipment=equipment,
+        movement=movement,
+        pipetting=pipetting,
+        run_control=run_control,
+    )
+
+
+# TODO(mc, 2022-02-25): verify hardware interaction
+@pytest.mark.xfail(raises=NotImplementedError, strict=True)
+async def test_close_latch(decoy: Decoy, subject: CloseLatchImpl) -> None:
+    """It should be able to close the module's labware latch."""
+    data = heater_shaker.CloseLatchParams(moduleId="heater-shaker-id")
+
+    result = await subject.execute(data)
+
+    assert result == heater_shaker.CloseLatchResult()

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_deactivate_heater.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_deactivate_heater.py
@@ -1,0 +1,36 @@
+"""Test Heater Shaker deactivate heater command implementation."""
+import pytest
+from decoy import Decoy
+
+from opentrons.protocol_engine import execution
+from opentrons.protocol_engine.commands import heater_shaker
+from opentrons.protocol_engine.commands.heater_shaker.deactivate_heater import (
+    DeactivateHeaterImpl,
+)
+
+
+@pytest.fixture()
+def subject(
+    equipment: execution.EquipmentHandler,
+    movement: execution.MovementHandler,
+    pipetting: execution.PipettingHandler,
+    run_control: execution.RunControlHandler,
+) -> DeactivateHeaterImpl:
+    """Get the command implementation with mocked out dependencies."""
+    return DeactivateHeaterImpl(
+        equipment=equipment,
+        movement=movement,
+        pipetting=pipetting,
+        run_control=run_control,
+    )
+
+
+# TODO(mc, 2022-02-25): verify hardware interaction
+@pytest.mark.xfail(raises=NotImplementedError, strict=True)
+async def test_deactivate_heater(decoy: Decoy, subject: DeactivateHeaterImpl) -> None:
+    """It should be able to deactivate the module's heater."""
+    data = heater_shaker.DeactivateHeaterParams(moduleId="heater-shaker-id")
+
+    result = await subject.execute(data)
+
+    assert result == heater_shaker.DeactivateHeaterResult()

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_open_latch.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_open_latch.py
@@ -1,0 +1,36 @@
+"""Test Heater Shaker open latch command implementation."""
+import pytest
+from decoy import Decoy
+
+from opentrons.protocol_engine import execution
+from opentrons.protocol_engine.commands import heater_shaker
+from opentrons.protocol_engine.commands.heater_shaker.open_latch import (
+    OpenLatchImpl,
+)
+
+
+@pytest.fixture()
+def subject(
+    equipment: execution.EquipmentHandler,
+    movement: execution.MovementHandler,
+    pipetting: execution.PipettingHandler,
+    run_control: execution.RunControlHandler,
+) -> OpenLatchImpl:
+    """Get the command implementation with mocked out dependencies."""
+    return OpenLatchImpl(
+        equipment=equipment,
+        movement=movement,
+        pipetting=pipetting,
+        run_control=run_control,
+    )
+
+
+# TODO(mc, 2022-02-25): verify hardware interaction
+@pytest.mark.xfail(raises=NotImplementedError, strict=True)
+async def test_open_latch(decoy: Decoy, subject: OpenLatchImpl) -> None:
+    """It should be able to open the module's labware latch."""
+    data = heater_shaker.OpenLatchParams(moduleId="heater-shaker-id")
+
+    result = await subject.execute(data)
+
+    assert result == heater_shaker.OpenLatchResult()

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_set_target_shake_speed.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_set_target_shake_speed.py
@@ -1,0 +1,39 @@
+"""Test Heater Shaker set shake speed command implementation."""
+import pytest
+from decoy import Decoy
+
+from opentrons.protocol_engine import execution
+from opentrons.protocol_engine.commands import heater_shaker
+from opentrons.protocol_engine.commands.heater_shaker.set_target_shake_speed import (
+    SetTargetShakeSpeedImpl,
+)
+
+
+@pytest.fixture()
+def subject(
+    equipment: execution.EquipmentHandler,
+    movement: execution.MovementHandler,
+    pipetting: execution.PipettingHandler,
+    run_control: execution.RunControlHandler,
+) -> SetTargetShakeSpeedImpl:
+    """Get the command implementation with mocked out dependencies."""
+    return SetTargetShakeSpeedImpl(
+        equipment=equipment,
+        movement=movement,
+        pipetting=pipetting,
+        run_control=run_control,
+    )
+
+
+# TODO(mc, 2022-02-25): verify hardware interaction
+@pytest.mark.xfail(raises=NotImplementedError, strict=True)
+async def test_set_target_shake_speed(
+    decoy: Decoy,
+    subject: SetTargetShakeSpeedImpl,
+) -> None:
+    """It should be able to set the module's shake speed."""
+    data = heater_shaker.SetTargetShakeSpeedParams(moduleId="shake-shaker-id", rpm=1234)
+
+    result = await subject.execute(data)
+
+    assert result == heater_shaker.SetTargetShakeSpeedResult()

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_start_set_target_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_start_set_target_temperature.py
@@ -1,0 +1,42 @@
+"""Test Heater Shaker start set temperature command implementation."""
+import pytest
+from decoy import Decoy
+
+from opentrons.protocol_engine import execution
+from opentrons.protocol_engine.commands import heater_shaker
+from opentrons.protocol_engine.commands.heater_shaker.start_set_target_temperature import (  # noqa: E501
+    StartSetTargetTemperatureImpl,
+)
+
+
+@pytest.fixture()
+def subject(
+    equipment: execution.EquipmentHandler,
+    movement: execution.MovementHandler,
+    pipetting: execution.PipettingHandler,
+    run_control: execution.RunControlHandler,
+) -> StartSetTargetTemperatureImpl:
+    """Get the command implementation with mocked out dependencies."""
+    return StartSetTargetTemperatureImpl(
+        equipment=equipment,
+        movement=movement,
+        pipetting=pipetting,
+        run_control=run_control,
+    )
+
+
+# TODO(mc, 2022-02-25): verify hardware interaction
+@pytest.mark.xfail(raises=NotImplementedError, strict=True)
+async def test_set_target_shake_speed(
+    decoy: Decoy,
+    subject: StartSetTargetTemperatureImpl,
+) -> None:
+    """It should be able to set the module's target temperature."""
+    data = heater_shaker.StartSetTargetTemperatureParams(
+        moduleId="shake-shaker-id",
+        temperature=42,
+    )
+
+    result = await subject.execute(data)
+
+    assert result == heater_shaker.StartSetTargetTemperatureResult()

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_start_set_target_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_start_set_target_temperature.py
@@ -27,7 +27,7 @@ def subject(
 
 # TODO(mc, 2022-02-25): verify hardware interaction
 @pytest.mark.xfail(raises=NotImplementedError, strict=True)
-async def test_set_target_shake_speed(
+async def test_start_set_target_temperature(
     decoy: Decoy,
     subject: StartSetTargetTemperatureImpl,
 ) -> None:

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_stop_shake.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_stop_shake.py
@@ -1,0 +1,36 @@
+"""Test Heater Shaker stop shake command implementation."""
+import pytest
+from decoy import Decoy
+
+from opentrons.protocol_engine import execution
+from opentrons.protocol_engine.commands import heater_shaker
+from opentrons.protocol_engine.commands.heater_shaker.stop_shake import (
+    StopShakeImpl,
+)
+
+
+@pytest.fixture()
+def subject(
+    equipment: execution.EquipmentHandler,
+    movement: execution.MovementHandler,
+    pipetting: execution.PipettingHandler,
+    run_control: execution.RunControlHandler,
+) -> StopShakeImpl:
+    """Get the command implementation with mocked out dependencies."""
+    return StopShakeImpl(
+        equipment=equipment,
+        movement=movement,
+        pipetting=pipetting,
+        run_control=run_control,
+    )
+
+
+# TODO(mc, 2022-02-25): verify hardware interaction
+@pytest.mark.xfail(raises=NotImplementedError, strict=True)
+async def test_stop_shake(decoy: Decoy, subject: StopShakeImpl) -> None:
+    """It should be able to stop the module's shake."""
+    data = heater_shaker.StopShakeParams(moduleId="shake-shaker-id")
+
+    result = await subject.execute(data)
+
+    assert result == heater_shaker.StopShakeResult()

--- a/robot-server/.coveragerc
+++ b/robot-server/.coveragerc
@@ -1,3 +1,8 @@
 [paths]
 source =
     robot_server
+
+[report]
+exclude_lines =
+    @overload
+    if TYPE_CHECKING:

--- a/shared-data/python/.coveragerc
+++ b/shared-data/python/.coveragerc
@@ -1,3 +1,4 @@
 [report]
 exclude_lines =
     @overload
+    if TYPE_CHECKING:


### PR DESCRIPTION
## Overview

This PR adds a series of skeleton / not implemented to ensure all heater-shaker commands spec'd in JSON Protocol Schema v6 are present in the protocol engine.

This PR helps move #9020 along.

## Changelog

Added commands:

- `StartSetTargetTemperature`
- `AwaitTemperature`
- `StopHeater`
- `SetTargetShakeSpeed`
- `StopShake`
- `OpenLatch`
- `CloseLatch`

## Review requests

- [ ] Models match JSON schema
- [ ] TODOs look correct
- [ ] No copy-paste typos

## Risk assessment

Very low, does not implement functionality