### PR TITLE
refactor(engine): force command impls to explicitly spec dependencies

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/aspirate.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate.py
@@ -1,11 +1,14 @@
 """Aspirate command request, result, and implementation models."""
 from __future__ import annotations
-from typing import Optional, Type
+from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
-
 
 from .pipetting_common import BaseLiquidHandlingParams, BaseLiquidHandlingResult
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+if TYPE_CHECKING:
+    from ..execution import PipettingHandler
+
 
 AspirateCommandType = Literal["aspirate"]
 
@@ -24,6 +27,9 @@ class AspirateResult(BaseLiquidHandlingResult):
 
 class AspirateImplementation(AbstractCommandImpl[AspirateParams, AspirateResult]):
     """Aspirate command implementation."""
+
+    def __init__(self, pipetting: PipettingHandler, **kwargs: object) -> None:
+        self._pipetting = pipetting
 
     async def execute(self, params: AspirateParams) -> AspirateResult:
         """Move to and aspirate from the requested well."""

--- a/api/src/opentrons/protocol_engine/commands/command.py
+++ b/api/src/opentrons/protocol_engine/commands/command.py
@@ -112,10 +112,7 @@ class AbstractCommandImpl(
         run_control: execution.RunControlHandler,
     ) -> None:
         """Initialize the command implementation with execution handlers."""
-        self._equipment = equipment
-        self._movement = movement
-        self._pipetting = pipetting
-        self._run_control = run_control
+        pass
 
     @abstractmethod
     async def execute(self, params: CommandParamsT) -> CommandResultT:

--- a/api/src/opentrons/protocol_engine/commands/dispense.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense.py
@@ -1,10 +1,13 @@
 """Dispense command request, result, and implementation models."""
 from __future__ import annotations
-from typing import Optional, Type
+from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
 from .pipetting_common import BaseLiquidHandlingParams, BaseLiquidHandlingResult
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+if TYPE_CHECKING:
+    from ..execution import PipettingHandler
 
 
 DispenseCommandType = Literal["dispense"]
@@ -24,6 +27,9 @@ class DispenseResult(BaseLiquidHandlingResult):
 
 class DispenseImplementation(AbstractCommandImpl[DispenseParams, DispenseResult]):
     """Dispense command implementation."""
+
+    def __init__(self, pipetting: PipettingHandler, **kwargs: object) -> None:
+        self._pipetting = pipetting
 
     async def execute(self, params: DispenseParams) -> DispenseResult:
         """Move to and dispense to the requested well."""

--- a/api/src/opentrons/protocol_engine/commands/drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip.py
@@ -1,11 +1,15 @@
 """Drop tip command request, result, and implementation models."""
 from __future__ import annotations
 from pydantic import BaseModel
-from typing import Optional, Type
+from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
 from .pipetting_common import BasePipettingParams
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+if TYPE_CHECKING:
+    from ..execution import PipettingHandler
+
 
 DropTipCommandType = Literal["dropTip"]
 
@@ -24,6 +28,9 @@ class DropTipResult(BaseModel):
 
 class DropTipImplementation(AbstractCommandImpl[DropTipParams, DropTipResult]):
     """Drop tip command implementation."""
+
+    def __init__(self, pipetting: PipettingHandler, **kwargs: object) -> None:
+        self._pipetting = pipetting
 
     async def execute(self, params: DropTipParams) -> DropTipResult:
         """Move to and drop a tip using the requested pipette."""

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/await_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/await_temperature.py
@@ -25,6 +25,9 @@ class AwaitTemperatureImpl(
 ):
     """Execution implementation of a Heater-Shaker's await temperature command."""
 
+    def __init__(self, **kwargs: object) -> None:
+        pass
+
     async def execute(self, params: AwaitTemperatureParams) -> AwaitTemperatureResult:
         """Wait for a Heater-Shaker's target temperature to be reached."""
         raise NotImplementedError(

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/close_latch.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/close_latch.py
@@ -23,6 +23,9 @@ class CloseLatchResult(BaseModel):
 class CloseLatchImpl(AbstractCommandImpl[CloseLatchParams, CloseLatchResult]):
     """Execution implementation of a Heater-Shaker's close latch command."""
 
+    def __init__(self, **kwargs: object) -> None:
+        pass
+
     async def execute(self, params: CloseLatchParams) -> CloseLatchResult:
         """Close a Heater-Shaker's latch."""
         raise NotImplementedError("Heater-Shaker close latch not yet implemented.")

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_heater.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_heater.py
@@ -25,6 +25,9 @@ class DeactivateHeaterImpl(
 ):
     """Execution implementation of a Heater-Shaker's deactivate heater command."""
 
+    def __init__(self, **kwargs: object) -> None:
+        pass
+
     async def execute(self, params: DeactivateHeaterParams) -> DeactivateHeaterResult:
         """Unset a Heater-Shaker's target temperature."""
         raise NotImplementedError(

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/open_latch.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/open_latch.py
@@ -23,6 +23,9 @@ class OpenLatchResult(BaseModel):
 class OpenLatchImpl(AbstractCommandImpl[OpenLatchParams, OpenLatchResult]):
     """Execution implementation of a Heater-Shaker's open latch command."""
 
+    def __init__(self, **kwargs: object) -> None:
+        pass
+
     async def execute(self, params: OpenLatchParams) -> OpenLatchResult:
         """Open a Heater-Shaker's latch."""
         raise NotImplementedError("Heater-Shaker open latch not yet implemented.")

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_shake_speed.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_shake_speed.py
@@ -28,6 +28,9 @@ class SetTargetShakeSpeedImpl(
 ):
     """Execution implementation of a Heater-Shaker's shake command."""
 
+    def __init__(self, **kwargs: object) -> None:
+        pass
+
     async def execute(
         self,
         params: SetTargetShakeSpeedParams,

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/start_set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/start_set_target_temperature.py
@@ -30,6 +30,9 @@ class StartSetTargetTemperatureImpl(
 ):
     """Execution implementation of a Heater-Shaker's set temperature command."""
 
+    def __init__(self, **kwargs: object) -> None:
+        pass
+
     async def execute(
         self,
         params: StartSetTargetTemperatureParams,

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/stop_shake.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/stop_shake.py
@@ -23,6 +23,9 @@ class StopShakeResult(BaseModel):
 class StopShakeImpl(AbstractCommandImpl[StopShakeParams, StopShakeResult]):
     """Execution implementation of a Heater-Shaker's stop shake command."""
 
+    def __init__(self, **kwargs: object) -> None:
+        pass
+
     async def execute(self, params: StopShakeParams) -> StopShakeResult:
         """Stop a Heater-Shaker's shake."""
         raise NotImplementedError("Heater-Shaker stop shake not yet implemented.")

--- a/api/src/opentrons/protocol_engine/commands/home.py
+++ b/api/src/opentrons/protocol_engine/commands/home.py
@@ -1,11 +1,14 @@
 """Home command payload, result, and implementation models."""
 from __future__ import annotations
 from pydantic import BaseModel, Field
-from typing import Optional, Sequence, Type
+from typing import TYPE_CHECKING, Optional, Sequence, Type
 from typing_extensions import Literal
 
 from ..types import MotorAxis
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+if TYPE_CHECKING:
+    from ..execution import MovementHandler
 
 
 HomeCommandType = Literal["home"]
@@ -30,6 +33,9 @@ class HomeResult(BaseModel):
 
 class HomeImplementation(AbstractCommandImpl[HomeParams, HomeResult]):
     """Home command implementation."""
+
+    def __init__(self, movement: MovementHandler, **kwargs: object) -> None:
+        self._movement = movement
 
     async def execute(self, params: HomeParams) -> HomeResult:
         """Home some or all motors to establish positional accuracy."""

--- a/api/src/opentrons/protocol_engine/commands/load_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/load_labware.py
@@ -1,13 +1,17 @@
 """Load labware command request, result, and implementation models."""
 from __future__ import annotations
 from pydantic import BaseModel, Field
-from typing import Optional, Type
+from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
 from opentrons.protocols.models import LabwareDefinition
 
 from ..types import LabwareLocation
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+if TYPE_CHECKING:
+    from ..execution import EquipmentHandler
+
 
 LoadLabwareCommandType = Literal["loadLabware"]
 
@@ -64,6 +68,9 @@ class LoadLabwareImplementation(
     AbstractCommandImpl[LoadLabwareParams, LoadLabwareResult]
 ):
     """Load labware command implementation."""
+
+    def __init__(self, equipment: EquipmentHandler, **kwargs: object) -> None:
+        self._equipment = equipment
 
     async def execute(self, params: LoadLabwareParams) -> LoadLabwareResult:
         """Load definition and calibration data necessary for a labware."""

--- a/api/src/opentrons/protocol_engine/commands/load_module.py
+++ b/api/src/opentrons/protocol_engine/commands/load_module.py
@@ -1,11 +1,14 @@
 """Implementation, request models, and response models for the load module command."""
-
-from typing import Optional, Type
+from __future__ import annotations
+from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 from pydantic import BaseModel, Field
 
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 from ..types import DeckSlotLocation, ModuleModel, ModuleDefinition
+
+if TYPE_CHECKING:
+    from ..execution import EquipmentHandler
 
 
 LoadModuleCommandType = Literal["loadModule"]
@@ -77,6 +80,9 @@ class LoadModuleResult(BaseModel):
 
 class LoadModuleImplementation(AbstractCommandImpl[LoadModuleParams, LoadModuleResult]):
     """The implementation of the load module command."""
+
+    def __init__(self, equipment: EquipmentHandler, **kwargs: object) -> None:
+        self._equipment = equipment
 
     async def execute(self, params: LoadModuleParams) -> LoadModuleResult:
         """Check that the requested module is attached and assign its identifier."""

--- a/api/src/opentrons/protocol_engine/commands/load_pipette.py
+++ b/api/src/opentrons/protocol_engine/commands/load_pipette.py
@@ -1,13 +1,17 @@
 """Load pipette command request, result, and implementation models."""
 from __future__ import annotations
 from pydantic import BaseModel, Field
-from typing import Optional, Type
+from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
 from opentrons.types import MountType
 
 from ..types import PipetteName
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+if TYPE_CHECKING:
+    from ..execution import EquipmentHandler
+
 
 LoadPipetteCommandType = Literal["loadPipette"]
 
@@ -43,6 +47,9 @@ class LoadPipetteImplementation(
     AbstractCommandImpl[LoadPipetteParams, LoadPipetteResult]
 ):
     """Load pipette command implementation."""
+
+    def __init__(self, equipment: EquipmentHandler, **kwargs: object) -> None:
+        self._equipment = equipment
 
     async def execute(self, params: LoadPipetteParams) -> LoadPipetteResult:
         """Check that requested pipette is attached and assign its identifier."""

--- a/api/src/opentrons/protocol_engine/commands/move_relative.py
+++ b/api/src/opentrons/protocol_engine/commands/move_relative.py
@@ -1,11 +1,14 @@
 """Move relative (jog) command payload, result, and implementation models."""
 from __future__ import annotations
 from pydantic import BaseModel, Field
-from typing import Optional, Type
+from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
 from ..types import MovementAxis
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+if TYPE_CHECKING:
+    from ..execution import MovementHandler
 
 
 MoveRelativeCommandType = Literal["moveRelative"]
@@ -33,6 +36,9 @@ class MoveRelativeImplementation(
     AbstractCommandImpl[MoveRelativeParams, MoveRelativeResult]
 ):
     """Move relative command implementation."""
+
+    def __init__(self, movement: MovementHandler, **kwargs: object) -> None:
+        self._movement = movement
 
     async def execute(self, params: MoveRelativeParams) -> MoveRelativeResult:
         """Move (jog) a given pipette a relative distance."""

--- a/api/src/opentrons/protocol_engine/commands/move_to_well.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_well.py
@@ -1,12 +1,14 @@
 """Move to well command request, result, and implementation models."""
 from __future__ import annotations
 from pydantic import BaseModel
-from typing import Optional, Type
+from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
 from .pipetting_common import BasePipettingParams
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
+if TYPE_CHECKING:
+    from ..execution import MovementHandler
 
 MoveToWellCommandType = Literal["moveToWell"]
 
@@ -25,6 +27,9 @@ class MoveToWellResult(BaseModel):
 
 class MoveToWellImplementation(AbstractCommandImpl[MoveToWellParams, MoveToWellResult]):
     """Move to well command implementation."""
+
+    def __init__(self, movement: MovementHandler, **kwargs: object) -> None:
+        self._movement = movement
 
     async def execute(self, params: MoveToWellParams) -> MoveToWellResult:
         """Move the requested pipette to the requested well."""

--- a/api/src/opentrons/protocol_engine/commands/pause.py
+++ b/api/src/opentrons/protocol_engine/commands/pause.py
@@ -1,10 +1,13 @@
 """Pause protocol command request, result, and implementation models."""
 from __future__ import annotations
 from pydantic import BaseModel, Field
-from typing import Optional, Type
+from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+if TYPE_CHECKING:
+    from ..execution import RunControlHandler
 
 
 PauseCommandType = Literal["pause"]
@@ -27,6 +30,9 @@ class PauseResult(BaseModel):
 
 class PauseImplementation(AbstractCommandImpl[PauseParams, PauseResult]):
     """Pause command implementation."""
+
+    def __init__(self, run_control: RunControlHandler, **kwargs: object) -> None:
+        self._run_control = run_control
 
     async def execute(self, params: PauseParams) -> PauseResult:
         """Dispatch a PauseAction to the store to pause the protocol."""

--- a/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
@@ -1,11 +1,14 @@
 """Pick up tip command request, result, and implementation models."""
 from __future__ import annotations
 from pydantic import BaseModel
-from typing import Optional, Type
+from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
 from .pipetting_common import BasePipettingParams
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+if TYPE_CHECKING:
+    from ..execution import PipettingHandler
 
 
 PickUpTipCommandType = Literal["pickUpTip"]
@@ -25,6 +28,9 @@ class PickUpTipResult(BaseModel):
 
 class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, PickUpTipResult]):
     """Pick up tip command implementation."""
+
+    def __init__(self, pipetting: PipettingHandler, **kwargs: object) -> None:
+        self._pipetting = pipetting
 
     async def execute(self, params: PickUpTipParams) -> PickUpTipResult:
         """Move to and pick up a tip using the requested pipette."""

--- a/api/src/opentrons/protocol_engine/commands/save_position.py
+++ b/api/src/opentrons/protocol_engine/commands/save_position.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 from pydantic import BaseModel, Field
-from typing import Optional, Type
+from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
 from ..types import DeckPoint
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+if TYPE_CHECKING:
+    from ..execution import MovementHandler
 
 SavePositionCommandType = Literal["savePosition"]
 
@@ -41,6 +44,9 @@ class SavePositionImplementation(
     AbstractCommandImpl[SavePositionParams, SavePositionResult]
 ):
     """Save position command implementation."""
+
+    def __init__(self, movement: MovementHandler, **kwargs: object) -> None:
+        self._movement = movement
 
     async def execute(self, params: SavePositionParams) -> SavePositionResult:
         """Check the requested pipette's current position."""

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_await_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_await_temperature.py
@@ -2,7 +2,6 @@
 import pytest
 from decoy import Decoy
 
-from opentrons.protocol_engine import execution
 from opentrons.protocol_engine.commands import heater_shaker
 from opentrons.protocol_engine.commands.heater_shaker.await_temperature import (
     AwaitTemperatureImpl,
@@ -10,19 +9,9 @@ from opentrons.protocol_engine.commands.heater_shaker.await_temperature import (
 
 
 @pytest.fixture()
-def subject(
-    equipment: execution.EquipmentHandler,
-    movement: execution.MovementHandler,
-    pipetting: execution.PipettingHandler,
-    run_control: execution.RunControlHandler,
-) -> AwaitTemperatureImpl:
+def subject() -> AwaitTemperatureImpl:
     """Get the command implementation with mocked out dependencies."""
-    return AwaitTemperatureImpl(
-        equipment=equipment,
-        movement=movement,
-        pipetting=pipetting,
-        run_control=run_control,
-    )
+    return AwaitTemperatureImpl()
 
 
 # TODO(mc, 2022-02-25): verify hardware interaction

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_close_latch.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_close_latch.py
@@ -2,7 +2,6 @@
 import pytest
 from decoy import Decoy
 
-from opentrons.protocol_engine import execution
 from opentrons.protocol_engine.commands import heater_shaker
 from opentrons.protocol_engine.commands.heater_shaker.close_latch import (
     CloseLatchImpl,
@@ -10,19 +9,9 @@ from opentrons.protocol_engine.commands.heater_shaker.close_latch import (
 
 
 @pytest.fixture()
-def subject(
-    equipment: execution.EquipmentHandler,
-    movement: execution.MovementHandler,
-    pipetting: execution.PipettingHandler,
-    run_control: execution.RunControlHandler,
-) -> CloseLatchImpl:
+def subject() -> CloseLatchImpl:
     """Get the command implementation with mocked out dependencies."""
-    return CloseLatchImpl(
-        equipment=equipment,
-        movement=movement,
-        pipetting=pipetting,
-        run_control=run_control,
-    )
+    return CloseLatchImpl()
 
 
 # TODO(mc, 2022-02-25): verify hardware interaction

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_deactivate_heater.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_deactivate_heater.py
@@ -2,7 +2,6 @@
 import pytest
 from decoy import Decoy
 
-from opentrons.protocol_engine import execution
 from opentrons.protocol_engine.commands import heater_shaker
 from opentrons.protocol_engine.commands.heater_shaker.deactivate_heater import (
     DeactivateHeaterImpl,
@@ -10,19 +9,9 @@ from opentrons.protocol_engine.commands.heater_shaker.deactivate_heater import (
 
 
 @pytest.fixture()
-def subject(
-    equipment: execution.EquipmentHandler,
-    movement: execution.MovementHandler,
-    pipetting: execution.PipettingHandler,
-    run_control: execution.RunControlHandler,
-) -> DeactivateHeaterImpl:
+def subject() -> DeactivateHeaterImpl:
     """Get the command implementation with mocked out dependencies."""
-    return DeactivateHeaterImpl(
-        equipment=equipment,
-        movement=movement,
-        pipetting=pipetting,
-        run_control=run_control,
-    )
+    return DeactivateHeaterImpl()
 
 
 # TODO(mc, 2022-02-25): verify hardware interaction

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_open_latch.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_open_latch.py
@@ -2,7 +2,6 @@
 import pytest
 from decoy import Decoy
 
-from opentrons.protocol_engine import execution
 from opentrons.protocol_engine.commands import heater_shaker
 from opentrons.protocol_engine.commands.heater_shaker.open_latch import (
     OpenLatchImpl,
@@ -10,19 +9,9 @@ from opentrons.protocol_engine.commands.heater_shaker.open_latch import (
 
 
 @pytest.fixture()
-def subject(
-    equipment: execution.EquipmentHandler,
-    movement: execution.MovementHandler,
-    pipetting: execution.PipettingHandler,
-    run_control: execution.RunControlHandler,
-) -> OpenLatchImpl:
+def subject() -> OpenLatchImpl:
     """Get the command implementation with mocked out dependencies."""
-    return OpenLatchImpl(
-        equipment=equipment,
-        movement=movement,
-        pipetting=pipetting,
-        run_control=run_control,
-    )
+    return OpenLatchImpl()
 
 
 # TODO(mc, 2022-02-25): verify hardware interaction

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_set_target_shake_speed.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_set_target_shake_speed.py
@@ -2,7 +2,6 @@
 import pytest
 from decoy import Decoy
 
-from opentrons.protocol_engine import execution
 from opentrons.protocol_engine.commands import heater_shaker
 from opentrons.protocol_engine.commands.heater_shaker.set_target_shake_speed import (
     SetTargetShakeSpeedImpl,
@@ -10,19 +9,9 @@ from opentrons.protocol_engine.commands.heater_shaker.set_target_shake_speed imp
 
 
 @pytest.fixture()
-def subject(
-    equipment: execution.EquipmentHandler,
-    movement: execution.MovementHandler,
-    pipetting: execution.PipettingHandler,
-    run_control: execution.RunControlHandler,
-) -> SetTargetShakeSpeedImpl:
+def subject() -> SetTargetShakeSpeedImpl:
     """Get the command implementation with mocked out dependencies."""
-    return SetTargetShakeSpeedImpl(
-        equipment=equipment,
-        movement=movement,
-        pipetting=pipetting,
-        run_control=run_control,
-    )
+    return SetTargetShakeSpeedImpl()
 
 
 # TODO(mc, 2022-02-25): verify hardware interaction

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_start_set_target_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_start_set_target_temperature.py
@@ -2,7 +2,6 @@
 import pytest
 from decoy import Decoy
 
-from opentrons.protocol_engine import execution
 from opentrons.protocol_engine.commands import heater_shaker
 from opentrons.protocol_engine.commands.heater_shaker.start_set_target_temperature import (  # noqa: E501
     StartSetTargetTemperatureImpl,
@@ -10,19 +9,9 @@ from opentrons.protocol_engine.commands.heater_shaker.start_set_target_temperatu
 
 
 @pytest.fixture()
-def subject(
-    equipment: execution.EquipmentHandler,
-    movement: execution.MovementHandler,
-    pipetting: execution.PipettingHandler,
-    run_control: execution.RunControlHandler,
-) -> StartSetTargetTemperatureImpl:
+def subject() -> StartSetTargetTemperatureImpl:
     """Get the command implementation with mocked out dependencies."""
-    return StartSetTargetTemperatureImpl(
-        equipment=equipment,
-        movement=movement,
-        pipetting=pipetting,
-        run_control=run_control,
-    )
+    return StartSetTargetTemperatureImpl()
 
 
 # TODO(mc, 2022-02-25): verify hardware interaction

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_stop_shake.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_stop_shake.py
@@ -2,7 +2,6 @@
 import pytest
 from decoy import Decoy
 
-from opentrons.protocol_engine import execution
 from opentrons.protocol_engine.commands import heater_shaker
 from opentrons.protocol_engine.commands.heater_shaker.stop_shake import (
     StopShakeImpl,
@@ -10,19 +9,9 @@ from opentrons.protocol_engine.commands.heater_shaker.stop_shake import (
 
 
 @pytest.fixture()
-def subject(
-    equipment: execution.EquipmentHandler,
-    movement: execution.MovementHandler,
-    pipetting: execution.PipettingHandler,
-    run_control: execution.RunControlHandler,
-) -> StopShakeImpl:
+def subject() -> StopShakeImpl:
     """Get the command implementation with mocked out dependencies."""
-    return StopShakeImpl(
-        equipment=equipment,
-        movement=movement,
-        pipetting=pipetting,
-        run_control=run_control,
-    )
+    return StopShakeImpl()
 
 
 # TODO(mc, 2022-02-25): verify hardware interaction

--- a/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
@@ -2,12 +2,7 @@
 from decoy import Decoy
 
 from opentrons.protocol_engine import WellLocation, WellOrigin, WellOffset
-from opentrons.protocol_engine.execution import (
-    EquipmentHandler,
-    MovementHandler,
-    PipettingHandler,
-    RunControlHandler,
-)
+from opentrons.protocol_engine.execution import PipettingHandler
 
 from opentrons.protocol_engine.commands.aspirate import (
     AspirateParams,
@@ -18,18 +13,10 @@ from opentrons.protocol_engine.commands.aspirate import (
 
 async def test_aspirate_implementation(
     decoy: Decoy,
-    equipment: EquipmentHandler,
-    movement: MovementHandler,
     pipetting: PipettingHandler,
-    run_control: RunControlHandler,
 ) -> None:
     """An Aspirate should have an execution implementation."""
-    subject = AspirateImplementation(
-        equipment=equipment,
-        movement=movement,
-        pipetting=pipetting,
-        run_control=run_control,
-    )
+    subject = AspirateImplementation(pipetting=pipetting)
 
     location = WellLocation(origin=WellOrigin.BOTTOM, offset=WellOffset(x=0, y=0, z=1))
 

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense.py
@@ -2,13 +2,7 @@
 from decoy import Decoy
 
 from opentrons.protocol_engine import WellLocation, WellOrigin, WellOffset
-from opentrons.protocol_engine.execution import (
-    EquipmentHandler,
-    MovementHandler,
-    PipettingHandler,
-    RunControlHandler,
-)
-
+from opentrons.protocol_engine.execution import PipettingHandler
 
 from opentrons.protocol_engine.commands.dispense import (
     DispenseParams,
@@ -19,18 +13,10 @@ from opentrons.protocol_engine.commands.dispense import (
 
 async def test_dispense_implementation(
     decoy: Decoy,
-    equipment: EquipmentHandler,
-    movement: MovementHandler,
     pipetting: PipettingHandler,
-    run_control: RunControlHandler,
 ) -> None:
     """A PickUpTipCreate should have an execution implementation."""
-    subject = DispenseImplementation(
-        equipment=equipment,
-        movement=movement,
-        pipetting=pipetting,
-        run_control=run_control,
-    )
+    subject = DispenseImplementation(pipetting=pipetting)
 
     location = WellLocation(origin=WellOrigin.BOTTOM, offset=WellOffset(x=0, y=0, z=1))
 

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
@@ -2,12 +2,7 @@
 from decoy import Decoy
 
 from opentrons.protocol_engine import WellLocation, WellOffset
-from opentrons.protocol_engine.execution import (
-    EquipmentHandler,
-    MovementHandler,
-    PipettingHandler,
-    RunControlHandler,
-)
+from opentrons.protocol_engine.execution import PipettingHandler
 
 from opentrons.protocol_engine.commands.drop_tip import (
     DropTipParams,
@@ -18,18 +13,10 @@ from opentrons.protocol_engine.commands.drop_tip import (
 
 async def test_drop_tip_implementation(
     decoy: Decoy,
-    equipment: EquipmentHandler,
-    movement: MovementHandler,
     pipetting: PipettingHandler,
-    run_control: RunControlHandler,
 ) -> None:
     """A DropTip command should have an execution implementation."""
-    subject = DropTipImplementation(
-        equipment=equipment,
-        movement=movement,
-        pipetting=pipetting,
-        run_control=run_control,
-    )
+    subject = DropTipImplementation(pipetting=pipetting)
 
     data = DropTipParams(
         pipetteId="abc",

--- a/api/tests/opentrons/protocol_engine/commands/test_home.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_home.py
@@ -2,13 +2,7 @@
 from decoy import Decoy
 
 from opentrons.protocol_engine.types import MotorAxis
-
-from opentrons.protocol_engine.execution import (
-    EquipmentHandler,
-    MovementHandler,
-    PipettingHandler,
-    RunControlHandler,
-)
+from opentrons.protocol_engine.execution import MovementHandler
 
 from opentrons.protocol_engine.commands.home import (
     HomeParams,
@@ -17,20 +11,9 @@ from opentrons.protocol_engine.commands.home import (
 )
 
 
-async def test_home_implementation(
-    decoy: Decoy,
-    equipment: EquipmentHandler,
-    movement: MovementHandler,
-    pipetting: PipettingHandler,
-    run_control: RunControlHandler,
-) -> None:
+async def test_home_implementation(decoy: Decoy, movement: MovementHandler) -> None:
     """A Home command should have an execution implementation."""
-    subject = HomeImplementation(
-        equipment=equipment,
-        movement=movement,
-        pipetting=pipetting,
-        run_control=run_control,
-    )
+    subject = HomeImplementation(movement=movement)
 
     data = HomeParams(axes=[MotorAxis.X, MotorAxis.Y])
 
@@ -40,20 +23,9 @@ async def test_home_implementation(
     decoy.verify(await movement.home(axes=[MotorAxis.X, MotorAxis.Y]))
 
 
-async def test_home_all_implementation(
-    decoy: Decoy,
-    equipment: EquipmentHandler,
-    movement: MovementHandler,
-    pipetting: PipettingHandler,
-    run_control: RunControlHandler,
-) -> None:
+async def test_home_all_implementation(decoy: Decoy, movement: MovementHandler) -> None:
     """It should pass axes=None along to the movement handler."""
-    subject = HomeImplementation(
-        equipment=equipment,
-        movement=movement,
-        pipetting=pipetting,
-        run_control=run_control,
-    )
+    subject = HomeImplementation(movement=movement)
 
     data = HomeParams()
 

--- a/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
@@ -4,13 +4,8 @@ from decoy import Decoy
 from opentrons.types import DeckSlotName
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.protocol_engine.types import DeckSlotLocation
-from opentrons.protocol_engine.execution import (
-    LoadedLabwareData,
-    EquipmentHandler,
-    MovementHandler,
-    PipettingHandler,
-    RunControlHandler,
-)
+from opentrons.protocol_engine.execution import LoadedLabwareData, EquipmentHandler
+
 from opentrons.protocol_engine.commands.load_labware import (
     LoadLabwareParams,
     LoadLabwareResult,
@@ -22,17 +17,9 @@ async def test_load_labware_implementation(
     decoy: Decoy,
     well_plate_def: LabwareDefinition,
     equipment: EquipmentHandler,
-    movement: MovementHandler,
-    pipetting: PipettingHandler,
-    run_control: RunControlHandler,
 ) -> None:
     """A LoadLabware command should have an execution implementation."""
-    subject = LoadLabwareImplementation(
-        equipment=equipment,
-        movement=movement,
-        pipetting=pipetting,
-        run_control=run_control,
-    )
+    subject = LoadLabwareImplementation(equipment=equipment)
 
     data = LoadLabwareParams(
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),

--- a/api/tests/opentrons/protocol_engine/commands/test_load_module.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_module.py
@@ -7,13 +7,7 @@ from opentrons.protocol_engine.types import (
     ModuleModel,
     ModuleDefinition,
 )
-from opentrons.protocol_engine.execution import (
-    EquipmentHandler,
-    MovementHandler,
-    PipettingHandler,
-    RunControlHandler,
-    LoadedModuleData,
-)
+from opentrons.protocol_engine.execution import EquipmentHandler, LoadedModuleData
 
 from opentrons.protocol_engine.commands.load_module import (
     LoadModuleParams,
@@ -25,18 +19,10 @@ from opentrons.protocol_engine.commands.load_module import (
 async def test_load_module_implementation(
     decoy: Decoy,
     equipment: EquipmentHandler,
-    movement: MovementHandler,
-    pipetting: PipettingHandler,
-    run_control: RunControlHandler,
     tempdeck_v2_def: ModuleDefinition,
 ) -> None:
     """A loadModule command should have an execution implementation."""
-    subject = LoadModuleImplementation(
-        equipment=equipment,
-        movement=movement,
-        pipetting=pipetting,
-        run_control=run_control,
-    )
+    subject = LoadModuleImplementation(equipment=equipment)
 
     data = LoadModuleParams(
         model=ModuleModel.TEMPERATURE_MODULE_V1,

--- a/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
@@ -3,14 +3,8 @@ from decoy import Decoy
 
 from opentrons.types import MountType
 from opentrons.protocol_engine.types import PipetteName
+from opentrons.protocol_engine.execution import LoadedPipetteData, EquipmentHandler
 
-from opentrons.protocol_engine.execution import (
-    LoadedPipetteData,
-    EquipmentHandler,
-    MovementHandler,
-    PipettingHandler,
-    RunControlHandler,
-)
 from opentrons.protocol_engine.commands.load_pipette import (
     LoadPipetteParams,
     LoadPipetteResult,
@@ -21,17 +15,9 @@ from opentrons.protocol_engine.commands.load_pipette import (
 async def test_load_pipette_implementation(
     decoy: Decoy,
     equipment: EquipmentHandler,
-    movement: MovementHandler,
-    pipetting: PipettingHandler,
-    run_control: RunControlHandler,
 ) -> None:
     """A LoadPipette command should have an execution implementation."""
-    subject = LoadPipetteImplementation(
-        equipment=equipment,
-        movement=movement,
-        pipetting=pipetting,
-        run_control=run_control,
-    )
+    subject = LoadPipetteImplementation(equipment=equipment)
 
     data = LoadPipetteParams(
         pipetteName=PipetteName.P300_SINGLE,

--- a/api/tests/opentrons/protocol_engine/commands/test_move_relative.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_relative.py
@@ -2,13 +2,7 @@
 from decoy import Decoy
 
 from opentrons.protocol_engine.types import MovementAxis
-
-from opentrons.protocol_engine.execution import (
-    EquipmentHandler,
-    MovementHandler,
-    PipettingHandler,
-    RunControlHandler,
-)
+from opentrons.protocol_engine.execution import MovementHandler
 
 from opentrons.protocol_engine.commands.move_relative import (
     MoveRelativeParams,
@@ -19,18 +13,10 @@ from opentrons.protocol_engine.commands.move_relative import (
 
 async def test_move_relative_implementation(
     decoy: Decoy,
-    equipment: EquipmentHandler,
     movement: MovementHandler,
-    pipetting: PipettingHandler,
-    run_control: RunControlHandler,
 ) -> None:
     """A MoveRelative command should have an execution implementation."""
-    subject = MoveRelativeImplementation(
-        equipment=equipment,
-        movement=movement,
-        pipetting=pipetting,
-        run_control=run_control,
-    )
+    subject = MoveRelativeImplementation(movement=movement)
 
     data = MoveRelativeParams(
         pipetteId="pipette-id",

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_well.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_well.py
@@ -2,12 +2,7 @@
 from decoy import Decoy
 
 from opentrons.protocol_engine import WellLocation, WellOffset
-from opentrons.protocol_engine.execution import (
-    EquipmentHandler,
-    MovementHandler,
-    PipettingHandler,
-    RunControlHandler,
-)
+from opentrons.protocol_engine.execution import MovementHandler
 
 from opentrons.protocol_engine.commands.move_to_well import (
     MoveToWellParams,
@@ -18,18 +13,10 @@ from opentrons.protocol_engine.commands.move_to_well import (
 
 async def test_move_to_well_implementation(
     decoy: Decoy,
-    equipment: EquipmentHandler,
     movement: MovementHandler,
-    pipetting: PipettingHandler,
-    run_control: RunControlHandler,
 ) -> None:
     """A MoveToWell command should have an execution implementation."""
-    subject = MoveToWellImplementation(
-        equipment=equipment,
-        movement=movement,
-        pipetting=pipetting,
-        run_control=run_control,
-    )
+    subject = MoveToWellImplementation(movement=movement)
 
     data = MoveToWellParams(
         pipetteId="abc",

--- a/api/tests/opentrons/protocol_engine/commands/test_pause.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_pause.py
@@ -1,12 +1,7 @@
 """Test pause command."""
 from decoy import Decoy
 
-from opentrons.protocol_engine.execution import (
-    EquipmentHandler,
-    MovementHandler,
-    PipettingHandler,
-    RunControlHandler,
-)
+from opentrons.protocol_engine.execution import RunControlHandler
 
 from opentrons.protocol_engine.commands.pause import (
     PauseParams,
@@ -16,19 +11,10 @@ from opentrons.protocol_engine.commands.pause import (
 
 
 async def test_pause_implementation(
-    decoy: Decoy,
-    equipment: EquipmentHandler,
-    movement: MovementHandler,
-    pipetting: PipettingHandler,
-    run_control: RunControlHandler,
+    decoy: Decoy, run_control: RunControlHandler
 ) -> None:
     """It should dispatch a PauseAction to the store and await resume."""
-    subject = PauseImplementation(
-        equipment=equipment,
-        movement=movement,
-        pipetting=pipetting,
-        run_control=run_control,
-    )
+    subject = PauseImplementation(run_control=run_control)
 
     data = PauseParams(message="hello world")
 

--- a/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
@@ -2,12 +2,7 @@
 from decoy import Decoy
 
 from opentrons.protocol_engine import WellLocation, WellOffset
-from opentrons.protocol_engine.execution import (
-    EquipmentHandler,
-    MovementHandler,
-    PipettingHandler,
-    RunControlHandler,
-)
+from opentrons.protocol_engine.execution import PipettingHandler
 
 from opentrons.protocol_engine.commands.pick_up_tip import (
     PickUpTipParams,
@@ -18,18 +13,10 @@ from opentrons.protocol_engine.commands.pick_up_tip import (
 
 async def test_pick_up_tip_implementation(
     decoy: Decoy,
-    equipment: EquipmentHandler,
-    movement: MovementHandler,
     pipetting: PipettingHandler,
-    run_control: RunControlHandler,
 ) -> None:
     """A PickUpTip command should have an execution implementation."""
-    subject = PickUpTipImplementation(
-        equipment=equipment,
-        movement=movement,
-        pipetting=pipetting,
-        run_control=run_control,
-    )
+    subject = PickUpTipImplementation(pipetting=pipetting)
 
     data = PickUpTipParams(
         pipetteId="abc",

--- a/api/tests/opentrons/protocol_engine/commands/test_save_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_save_position.py
@@ -2,13 +2,7 @@
 from decoy import Decoy
 
 from opentrons.protocol_engine.types import DeckPoint
-from opentrons.protocol_engine.execution import (
-    EquipmentHandler,
-    MovementHandler,
-    PipettingHandler,
-    RunControlHandler,
-    SavedPositionData,
-)
+from opentrons.protocol_engine.execution import MovementHandler, SavedPositionData
 
 from opentrons.protocol_engine.commands.save_position import (
     SavePositionParams,
@@ -19,18 +13,10 @@ from opentrons.protocol_engine.commands.save_position import (
 
 async def test_save_position_implementation(
     decoy: Decoy,
-    equipment: EquipmentHandler,
     movement: MovementHandler,
-    pipetting: PipettingHandler,
-    run_control: RunControlHandler,
 ) -> None:
     """A SavePosition command should have an execution implementation."""
-    subject = SavePositionImplementation(
-        equipment=equipment,
-        movement=movement,
-        pipetting=pipetting,
-        run_control=run_control,
-    )
+    subject = SavePositionImplementation(movement=movement)
     params = SavePositionParams(
         pipetteId="abc",
         positionId="123",


### PR DESCRIPTION
## Overview

Coming out of pairing and review on #9569 and #9572, it's become obvious that our command implementations are a little difficult to work with in tests.

I tried out a few things, and came up with this PR to make everything more explicit and more minimal at the same time. I sort of like where this ended up! Keeping as a draft to avoid interfering with in-flight PRs noted above until we all take a look at this.

## Changelog

- Do not implicitly feed `self._equipment`, `self._pipetting`, etc. into command implementations automagically
    - Instead, define implementations with their dependencies explicitly spec'd
- Remove unnecessary mocks from tests of impls that don't use those mocks


## Review requests

- [ ] What do you think of this?

I think the main "wart" of this is forcing all the command implementations' `__init__` method to have a catchall `**kwargs`, but the typechecker will catch it if you mess up any explicitly named args, which is cool.

## Risk assessment

Low