### PR TITLE
refactor(api): Formally deprecate `InstrumentContext.delay()`

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1146,14 +1146,29 @@ class InstrumentContext(CommandPublisher):
             getattr(self, cmd["method"])(*cmd["args"], **cmd["kwargs"])
 
     @requires_version(2, 0)
-    def delay(self) -> None:
+    def delay(self, *args, **kwargs) -> None:
         """
         .. deprecated:: 2.0
            Use :py:obj:`ProtocolContext.delay` instead.
            This method does nothing.
            It will be removed from a future version of the Python Protocol API.
         """
-        pass
+        if (args or kwargs):
+            # Former implementations of this method did not take any args, so users
+            # would get a TypeError if they tried to call it like delay(minutes=10).
+            # Without changing the ultimate behavior that such a call fails the
+            # protocol, we can provide a more descriptive message as a courtesy.
+            raise NotImplementedError(
+                "InstrumentContext.delay() is not supported in Python Protocol API v2."
+                " Use ProtocolContext.delay() instead."
+            )
+        else:
+            # Former implementations of this method, when called without any args,
+            # called ProtocolContext.delay() with a duration of 0, which was
+            # approximately a no-op.
+            # Preserve that allowed way to call this method for the very remote chance
+            # that a protocol out in the wild does it, for some reason.
+            pass
 
     @requires_version(2, 0)
     def move_to(

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1153,7 +1153,7 @@ class InstrumentContext(CommandPublisher):
            This method does nothing.
            It will be removed from a future version of the Python Protocol API.
         """
-        if (args or kwargs):
+        if args or kwargs:
             # Former implementations of this method did not take any args, so users
             # would get a TypeError if they tried to call it like delay(minutes=10).
             # Without changing the ultimate behavior that such a call fails the

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1147,7 +1147,13 @@ class InstrumentContext(CommandPublisher):
 
     @requires_version(2, 0)
     def delay(self) -> None:
-        return self._implementation.delay()
+        """
+        .. deprecated:: 2.0
+           Use :py:obj:`ProtocolContext.delay` instead.
+           This method does nothing.
+           It will be removed from a future version of the Python Protocol API.
+        """
+        pass
 
     @requires_version(2, 0)
     def move_to(

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1146,7 +1146,7 @@ class InstrumentContext(CommandPublisher):
             getattr(self, cmd["method"])(*cmd["args"], **cmd["kwargs"])
 
     @requires_version(2, 0)
-    def delay(self, *args, **kwargs) -> None:
+    def delay(self, *args: Any, **kwargs: Any) -> None:
         """
         .. deprecated:: 2.0
            Use :py:obj:`ProtocolContext.delay` instead.

--- a/api/src/opentrons/protocols/context/instrument.py
+++ b/api/src/opentrons/protocols/context/instrument.py
@@ -61,10 +61,6 @@ class AbstractInstrument(ABC):
         ...
 
     @abstractmethod
-    def delay(self) -> None:
-        ...
-
-    @abstractmethod
     def move_to(
         self,
         location: types.Location,

--- a/api/src/opentrons/protocols/context/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocols/context/protocol_api/instrument_context.py
@@ -128,10 +128,6 @@ class InstrumentContextImplementation(AbstractInstrument):
         """Home the plunger associated with this mount."""
         self._protocol_interface.get_hardware().home_plunger(self._mount)
 
-    def delay(self) -> None:
-        """Delay protocol execution."""
-        self._protocol_interface.delay(seconds=0, msg=None)
-
     def move_to(
         self,
         location: types.Location,

--- a/api/src/opentrons/protocols/context/simulator/instrument_context.py
+++ b/api/src/opentrons/protocols/context/simulator/instrument_context.py
@@ -90,9 +90,6 @@ class InstrumentContextSimulation(AbstractInstrument):
     def home_plunger(self) -> None:
         pass
 
-    def delay(self) -> None:
-        pass
-
     def move_to(
         self,
         location: types.Location,


### PR DESCRIPTION
# Overview

`pipette.delay()` is a holdover from APIv1; in APIv2, it's replaced by `protocol.delay()`. It looks like a stub implementation made it into APIv2 accidentally?

We've heard from @anuwrag that`pipette.delay()`'s quasi-presence in APIv2 is confusing. This PR tries to push users away from it and guide them towards `protocol.delay()`.

# Changelog

* In the public docs, tell people that they should use `protocol.delay()` instead of `pipette.delay`, that `pipette.delay()` does nothing, and that `pipette.delay()` will be removed.
* When `pipette.delay(...)` is called *with* arguments, instead of letting Python raise a `TypeError`, raise a `NotImplementedError` with a more helpful message.
* When `pipette.delay()` is called *without* any arguments, instead of doing the equivalent of `protocol.delay(seconds=0)`, simply `pass`.
    * **In a very strict technical sense, this is a breaking change.** The old behavior was a no-op, but I believe it gave the Opentrons App the opportunity to pause the protocol on that line. The new behavior is a no-op that doesn't have that opportunity. If you have an infinite loop of `pipette.delay()`s, it will now be uninterruptible. I'm going out on a limb and saying that nobody cares and that the code cleanup is worth this cost.

# Risk assessment

Low.
