### PR TITLE
fix: send custom labware definitions to the server during LPC setup

### DIFF
--- a/api-client/src/runs/createLabwareDefinition.ts
+++ b/api-client/src/runs/createLabwareDefinition.ts
@@ -3,17 +3,18 @@ import { POST, request } from '../request'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { ResponsePromise } from '../request'
 import type { HostConfig } from '../types'
-import type { Run } from './types'
+
+export interface CreateLabwareDefinitionResponsePayload {
+  definitionUri: string
+}
 
 export function createLabwareDefinition(
   config: HostConfig,
   runId: string,
   data: LabwareDefinition2
-): ResponsePromise<Run> {
-  return request<Run, { data: LabwareDefinition2 }>(
-    POST,
-    `/runs/${runId}/labware_definitions`,
-    { data },
-    config
-  )
+): ResponsePromise<CreateLabwareDefinitionResponsePayload> {
+  return request<
+    CreateLabwareDefinitionResponsePayload,
+    { data: LabwareDefinition2 }
+  >(POST, `/runs/${runId}/labware_definitions`, { data }, config)
 }

--- a/api-client/src/runs/createLabwareDefinition.ts
+++ b/api-client/src/runs/createLabwareDefinition.ts
@@ -1,0 +1,19 @@
+import { POST, request } from '../request'
+
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { ResponsePromise } from '../request'
+import type { HostConfig } from '../types'
+import type { Run } from './types'
+
+export function createLabwareDefinition(
+  config: HostConfig,
+  runId: string,
+  data: LabwareDefinition2
+): ResponsePromise<Run> {
+  return request<Run, { data: LabwareDefinition2 }>(
+    POST,
+    `/runs/${runId}/labware_definitions`,
+    { data },
+    config
+  )
+}

--- a/api-client/src/runs/index.ts
+++ b/api-client/src/runs/index.ts
@@ -8,6 +8,7 @@ export { getCommand } from './commands/getCommand'
 export { getCommands } from './commands/getCommands'
 export { createRunAction } from './createRunAction'
 export * from './createLabwareOffset'
+export * from './createLabwareDefinition'
 
 export * from './types'
 export type { CreateRunData } from './createRun'

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -9,7 +9,7 @@ from .commands import (
     Command,
     CommandCreate,
 )
-from .types import LabwareOffset, LabwareOffsetCreate
+from .types import LabwareOffset, LabwareOffsetCreate, LabwareUri
 from .execution import (
     QueueWorker,
     create_queue_worker,
@@ -258,8 +258,9 @@ class ProtocolEngine:
             labware_offset_id=labware_offset_id
         )
 
-    def add_labware_definition(self, definition: LabwareDefinition) -> None:
+    def add_labware_definition(self, definition: LabwareDefinition) -> LabwareUri:
         """Add a labware definition to the state for subsequent labware loads."""
         self._action_dispatcher.dispatch(
             AddLabwareDefinitionAction(definition=definition)
         )
+        return self._state_store.labware.get_uri_from_definition(definition)

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -307,6 +307,17 @@ class LabwareView(HasState[LabwareState]):
         """Get a labware's definition URI."""
         return self.get(labware_id).definitionUri
 
+    def get_uri_from_definition(
+        self,
+        labware_definition: LabwareDefinition,
+    ) -> LabwareUri:
+        """Get a definition URI from a full labware definition."""
+        return uri_from_details(
+            load_name=labware_definition.parameters.loadName,
+            namespace=labware_definition.namespace,
+            version=labware_definition.version,
+        )
+
     def is_tiprack(self, labware_id: str) -> bool:
         """Get whether labware is a tiprack."""
         definition = self.get_definition(labware_id)

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -9,6 +9,11 @@ from typing import Optional, Union, List, Dict, Any
 from opentrons.types import MountType, DeckSlotName
 from opentrons.hardware_control.modules import ModuleType as ModuleType
 
+# convenience re-export of LabwareUri type
+from opentrons_shared_data.pipette.dev_types import (  # noqa: F401
+    LabwareUri as LabwareUri,
+)
+
 
 class EngineStatus(str, Enum):
     """Current execution status of a ProtocolEngine."""

--- a/api/src/opentrons/protocols/duration/estimator.py
+++ b/api/src/opentrons/protocols/duration/estimator.py
@@ -511,7 +511,7 @@ class DurationEstimator:
             # Inter slot movement defaults to half a second.
             deck_movement_time = 0.5
         else:
-            deck_distance = math.sqrt((x_difference ** 2) + (y_difference ** 2))
+            deck_distance = math.sqrt((x_difference**2) + (y_difference**2))
             deck_movement_time = deck_distance / gantry_speed
         return deck_movement_time
 

--- a/api/src/opentrons/protocols/duration/estimator.py
+++ b/api/src/opentrons/protocols/duration/estimator.py
@@ -511,7 +511,7 @@ class DurationEstimator:
             # Inter slot movement defaults to half a second.
             deck_movement_time = 0.5
         else:
-            deck_distance = math.sqrt((x_difference**2) + (y_difference**2))
+            deck_distance = math.sqrt((x_difference ** 2) + (y_difference ** 2))
             deck_movement_time = deck_distance / gantry_speed
         return deck_movement_time
 

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -59,7 +59,7 @@ class Point(NamedTuple):
         x_diff = self.x - other.x
         y_diff = self.y - other.y
         z_diff = self.z - other.z
-        return sqrt(x_diff ** 2 + y_diff ** 2 + z_diff ** 2)
+        return sqrt(x_diff**2 + y_diff**2 + z_diff**2)
 
 
 LocationLabware = Union["Labware", "Well", str, "ModuleGeometry", LabwareLike, None]

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -59,7 +59,7 @@ class Point(NamedTuple):
         x_diff = self.x - other.x
         y_diff = self.y - other.y
         z_diff = self.z - other.z
-        return sqrt(x_diff**2 + y_diff**2 + z_diff**2)
+        return sqrt(x_diff ** 2 + y_diff ** 2 + z_diff ** 2)
 
 
 LocationLabware = Union["Labware", "Well", str, "ModuleGeometry", LabwareLike, None]

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -302,6 +302,13 @@ def test_get_labware_uri_from_definition(tip_rack_def: LabwareDefinition) -> Non
     assert result == "some-tip-rack-uri"
 
 
+def test_get_labware_uri_from_full_definition(tip_rack_def: LabwareDefinition) -> None:
+    """It should be able to construct a URI given a full definition."""
+    subject = get_labware_view()
+    result = subject.get_uri_from_definition(tip_rack_def)
+    assert result == "opentrons/opentrons_96_tiprack_300ul/1"
+
+
 def test_is_tiprack(
     tip_rack_def: LabwareDefinition, reservoir_def: LabwareDefinition
 ) -> None:

--- a/api/tests/opentrons/protocols/duration/test_estimator.py
+++ b/api/tests/opentrons/protocols/duration/test_estimator.py
@@ -125,13 +125,13 @@ def mock_deck() -> MagicMock:
         # Same col sqrt(100**2) / 2
         ["1", "4", 2, 50],
         # Extremes
-        ["1", "12", 2, math.sqrt(20 ** 2 + 300 ** 2) / 2],
+        ["1", "12", 2, math.sqrt(20**2 + 300**2) / 2],
         # Same row sqrt(10**2) / 2
         ["3", "2", 2, 5],
         # Same col sqrt(100**2) / 2
         ["5", "2", 2, 50],
         # Extremes
-        ["12", "1", 2, math.sqrt(20 ** 2 + 300 ** 2) / 2],
+        ["12", "1", 2, math.sqrt(20**2 + 300**2) / 2],
     ],
 )
 def test_calc_deck_movement_time(

--- a/api/tests/opentrons/protocols/duration/test_estimator.py
+++ b/api/tests/opentrons/protocols/duration/test_estimator.py
@@ -125,13 +125,13 @@ def mock_deck() -> MagicMock:
         # Same col sqrt(100**2) / 2
         ["1", "4", 2, 50],
         # Extremes
-        ["1", "12", 2, math.sqrt(20**2 + 300**2) / 2],
+        ["1", "12", 2, math.sqrt(20 ** 2 + 300 ** 2) / 2],
         # Same row sqrt(10**2) / 2
         ["3", "2", 2, 5],
         # Same col sqrt(100**2) / 2
         ["5", "2", 2, 50],
         # Extremes
-        ["12", "1", 2, math.sqrt(20**2 + 300**2) / 2],
+        ["12", "1", 2, math.sqrt(20 ** 2 + 300 ** 2) / 2],
     ],
 )
 def test_calc_deck_movement_time(

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/__tests__/useLabwarePositionCheck.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/__tests__/useLabwarePositionCheck.test.tsx
@@ -7,6 +7,7 @@ import { renderHook } from '@testing-library/react-hooks'
 import {
   useCreateCommandMutation,
   useCreateLabwareOffsetMutation,
+  useCreateLabwareDefinitionMutation,
 } from '@opentrons/react-api-client'
 import { useTrackEvent } from '../../../../../redux/analytics'
 import { getConnectedRobotName } from '../../../../../redux/robot/selectors'
@@ -43,6 +44,9 @@ const mockUseSteps = useSteps as jest.MockedFunction<typeof useSteps>
 const mockUseCreateCommandMutation = useCreateCommandMutation as jest.MockedFunction<
   typeof useCreateCommandMutation
 >
+const mockUseCreateLabwareDefinitionMutation = useCreateLabwareDefinitionMutation as jest.MockedFunction<
+  typeof useCreateLabwareDefinitionMutation
+>
 const mockUseCreateLabwareOffsetMutation = useCreateLabwareOffsetMutation as jest.MockedFunction<
   typeof useCreateLabwareOffsetMutation
 >
@@ -67,6 +71,7 @@ describe('useLabwarePositionCheck', () => {
   const MOCK_SLOT = '1'
   let mockCreateCommand: jest.Mock
   let mockCreateLabwareOffset: jest.Mock
+  let mockCreateLabwareDefinition: jest.Mock
   beforeEach(() => {
     when(mockUseCurrentRunId).calledWith().mockReturnValue(MOCK_RUN_ID)
     when(mockUseCurrentRunCommands).calledWith().mockReturnValue([])
@@ -97,6 +102,10 @@ describe('useLabwarePositionCheck', () => {
     when(mockUseCreateLabwareOffsetMutation)
       .calledWith()
       .mockReturnValue({ createLabwareOffset: mockCreateLabwareOffset } as any)
+      mockCreateLabwareDefinition = jest.fn()
+    when(mockUseCreateLabwareDefinitionMutation)
+      .calledWith()
+      .mockReturnValue({ createLabwareOffset: mockCreateLabwareDefinition } as any)
     when(mockGetConnectedRobotName)
       .calledWith(expect.anything())
       .mockReturnValue('mock robot!')

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/__tests__/useLabwarePositionCheck.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/__tests__/useLabwarePositionCheck.test.tsx
@@ -102,10 +102,12 @@ describe('useLabwarePositionCheck', () => {
     when(mockUseCreateLabwareOffsetMutation)
       .calledWith()
       .mockReturnValue({ createLabwareOffset: mockCreateLabwareOffset } as any)
-      mockCreateLabwareDefinition = jest.fn()
+    mockCreateLabwareDefinition = jest.fn()
     when(mockUseCreateLabwareDefinitionMutation)
       .calledWith()
-      .mockReturnValue({ createLabwareOffset: mockCreateLabwareDefinition } as any)
+      .mockReturnValue({
+        createLabwareOffset: mockCreateLabwareDefinition,
+      } as any)
     when(mockGetConnectedRobotName)
       .calledWith(expect.anything())
       .mockReturnValue('mock robot!')

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
@@ -570,8 +570,9 @@ export function useLabwarePositionCheck(
       protocolType === 'python' && protocolData != null
         ? protocolData?.commands
             .filter(isLoadLabwareCommand)
-            .filter(loadLabwareCommand =>
-              getLabwareDefIsStandard(loadLabwareCommand.result.definition)
+            .filter(
+              loadLabwareCommand =>
+                !getLabwareDefIsStandard(loadLabwareCommand.result.definition)
             )
             .map(loadLabwareCommand => loadLabwareCommand.result.definition)
         : []

--- a/react-api-client/src/runs/__tests__/useCreateLabwareDefinitionMutation.test.tsx
+++ b/react-api-client/src/runs/__tests__/useCreateLabwareDefinitionMutation.test.tsx
@@ -2,30 +2,28 @@ import * as React from 'react'
 import { when, resetAllWhenMocks } from 'jest-when'
 import { QueryClient, QueryClientProvider } from 'react-query'
 import { act, renderHook } from '@testing-library/react-hooks'
-import { createLabwareOffset } from '@opentrons/api-client'
+import { createLabwareDefinition } from '@opentrons/api-client'
 import { useHost } from '../../api'
 
-import { useCreateLabwareOffsetMutation } from '../useCreateLabwareOffsetMutation'
-import type { HostConfig, LabwareOffsetCreateData } from '@opentrons/api-client'
+import { useCreateLabwareDefinitionMutation } from '../useCreateLabwareDefinitionMutation'
+import type { HostConfig } from '@opentrons/api-client'
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
 
 jest.mock('@opentrons/api-client')
 jest.mock('../../api/useHost')
 
 const mockUseHost = useHost as jest.MockedFunction<typeof useHost>
 
-const mockCreateLabwareOffset = createLabwareOffset as jest.MockedFunction<
-  typeof createLabwareOffset
+const mockCreateLabwareDefinition = createLabwareDefinition as jest.MockedFunction<
+  typeof createLabwareDefinition
 >
 
 const HOST_CONFIG: HostConfig = { hostname: 'localhost' }
 const RUN_ID = 'run_id'
-const DEFINITION_URI = 'definition_uri'
-const LABWARE_LOCATION = { slotName: '4' }
-const OFFSET = { x: 1, y: 2, z: 3 }
 
-describe('useCreateLabwareOffsetMutation hook', () => {
+describe('useCreateLabwareDefinitionMutation hook', () => {
   let wrapper: React.FunctionComponent<{}>
-  let labwareOffset: LabwareOffsetCreateData
+  let labwareDefinition: LabwareDefinition2
 
   beforeEach(() => {
     const queryClient = new QueryClient()
@@ -33,11 +31,7 @@ describe('useCreateLabwareOffsetMutation hook', () => {
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     )
     wrapper = clientProvider
-    labwareOffset = {
-      definitionUri: DEFINITION_URI,
-      location: LABWARE_LOCATION,
-      vector: OFFSET,
-    }
+    labwareDefinition = {} as any
   })
   afterEach(() => {
     resetAllWhenMocks()
@@ -45,24 +39,24 @@ describe('useCreateLabwareOffsetMutation hook', () => {
 
   it('should create labware offsets when callback is called', async () => {
     when(mockUseHost).calledWith().mockReturnValue(HOST_CONFIG)
-    when(mockCreateLabwareOffset)
-      .calledWith(HOST_CONFIG, RUN_ID, labwareOffset)
-      .mockResolvedValue({ data: 'created offsets!' } as any)
+    when(mockCreateLabwareDefinition)
+      .calledWith(HOST_CONFIG, RUN_ID, labwareDefinition)
+      .mockResolvedValue({ data: 'created labware definition!' } as any)
 
-    const { result, waitFor } = renderHook(useCreateLabwareOffsetMutation, {
+    const { result, waitFor } = renderHook(useCreateLabwareDefinitionMutation, {
       wrapper,
     })
 
     expect(result.current.data).toBeUndefined()
     act(() => {
-      result.current.createLabwareOffset({
+      result.current.createLabwareDefinition({
         runId: RUN_ID,
-        data: labwareOffset,
+        data: labwareDefinition,
       })
     })
     await waitFor(() => {
       return result.current.data != null
     })
-    expect(result.current.data).toBe('created offsets!')
+    expect(result.current.data).toBe('created labware definition!')
   })
 })

--- a/react-api-client/src/runs/index.ts
+++ b/react-api-client/src/runs/index.ts
@@ -11,6 +11,7 @@ export { useRunActionMutations } from './useRunActionMutations'
 export { useAllCommandsQuery } from './useAllCommandsQuery'
 export { useCommandQuery } from './useCommandQuery'
 export * from './useCreateLabwareOffsetMutation'
+export * from './useCreateLabwareDefinitionMutation'
 
 export type { UsePlayRunMutationResult } from './usePlayRunMutation'
 export type { UsePauseRunMutationResult } from './usePauseRunMutation'

--- a/react-api-client/src/runs/useCreateLabwareDefinitionMutation.ts
+++ b/react-api-client/src/runs/useCreateLabwareDefinitionMutation.ts
@@ -3,7 +3,10 @@ import { createLabwareDefinition } from '@opentrons/api-client'
 import { useHost } from '../api'
 import type { UseMutationResult, UseMutateAsyncFunction } from 'react-query'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
-import type { HostConfig, Run } from '@opentrons/api-client'
+import type {
+  HostConfig,
+  CreateLabwareDefinitionResponsePayload,
+} from '@opentrons/api-client'
 
 interface CreateLabwareDefinitionParams {
   runId: string
@@ -11,12 +14,12 @@ interface CreateLabwareDefinitionParams {
 }
 
 export type UseCreateLabwareDefinitionMutationResult = UseMutationResult<
-  Run,
+  CreateLabwareDefinitionResponsePayload,
   unknown,
   CreateLabwareDefinitionParams
 > & {
   createLabwareDefinition: UseMutateAsyncFunction<
-    Run,
+    CreateLabwareDefinitionResponsePayload,
     unknown,
     CreateLabwareDefinitionParams
   >
@@ -26,21 +29,24 @@ export function useCreateLabwareDefinitionMutation(): UseCreateLabwareDefinition
   const host = useHost()
   const queryClient = useQueryClient()
 
-  const mutation = useMutation<Run, unknown, CreateLabwareDefinitionParams>(
-    ({ runId, data }) =>
-      createLabwareDefinition(host as HostConfig, runId, data)
-        .then(response => {
-          queryClient
-            .invalidateQueries([host, 'runs'])
-            .catch((e: Error) =>
-              console.error(`error invalidating runs query: ${e.message}`)
-            )
-          return response.data
-        })
-        .catch((e: Error) => {
-          console.error(`error creating labware offsets: ${e.message}`)
-          throw e
-        })
+  const mutation = useMutation<
+    CreateLabwareDefinitionResponsePayload,
+    unknown,
+    CreateLabwareDefinitionParams
+  >(({ runId, data }) =>
+    createLabwareDefinition(host as HostConfig, runId, data)
+      .then(response => {
+        queryClient
+          .invalidateQueries([host, 'runs'])
+          .catch((e: Error) =>
+            console.error(`error invalidating runs query: ${e.message}`)
+          )
+        return response.data
+      })
+      .catch((e: Error) => {
+        console.error(`error creating labware offsets: ${e.message}`)
+        throw e
+      })
   )
 
   return {

--- a/react-api-client/src/runs/useCreateLabwareDefinitionMutation.ts
+++ b/react-api-client/src/runs/useCreateLabwareDefinitionMutation.ts
@@ -1,36 +1,34 @@
 import { useMutation, useQueryClient } from 'react-query'
-import {
-  createLabwareOffset,
-  LabwareOffsetCreateData,
-} from '@opentrons/api-client'
+import { createLabwareDefinition } from '@opentrons/api-client'
 import { useHost } from '../api'
-import type { HostConfig, Run } from '@opentrons/api-client'
 import type { UseMutationResult, UseMutateAsyncFunction } from 'react-query'
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { HostConfig, Run } from '@opentrons/api-client'
 
-interface CreateLabwareOffsetParams {
+interface CreateLabwareDefinitionParams {
   runId: string
-  data: LabwareOffsetCreateData
+  data: LabwareDefinition2
 }
 
-export type UseCreateLabwareOffsetMutationResult = UseMutationResult<
+export type UseCreateLabwareDefinitionMutationResult = UseMutationResult<
   Run,
   unknown,
-  CreateLabwareOffsetParams
+  CreateLabwareDefinitionParams
 > & {
-  createLabwareOffset: UseMutateAsyncFunction<
+  createLabwareDefinition: UseMutateAsyncFunction<
     Run,
     unknown,
-    CreateLabwareOffsetParams
+    CreateLabwareDefinitionParams
   >
 }
 
-export function useCreateLabwareOffsetMutation(): UseCreateLabwareOffsetMutationResult {
+export function useCreateLabwareDefinitionMutation(): UseCreateLabwareDefinitionMutationResult {
   const host = useHost()
   const queryClient = useQueryClient()
 
-  const mutation = useMutation<Run, unknown, CreateLabwareOffsetParams>(
+  const mutation = useMutation<Run, unknown, CreateLabwareDefinitionParams>(
     ({ runId, data }) =>
-      createLabwareOffset(host as HostConfig, runId, data)
+      createLabwareDefinition(host as HostConfig, runId, data)
         .then(response => {
           queryClient
             .invalidateQueries([host, 'runs'])
@@ -47,6 +45,6 @@ export function useCreateLabwareOffsetMutation(): UseCreateLabwareOffsetMutation
 
   return {
     ...mutation,
-    createLabwareOffset: mutation.mutateAsync,
+    createLabwareDefinition: mutation.mutateAsync,
   }
 }

--- a/robot-server/robot_server/runs/router/__init__.py
+++ b/robot-server/robot_server/runs/router/__init__.py
@@ -4,11 +4,13 @@ from fastapi import APIRouter
 from .base_router import base_router
 from .commands_router import commands_router
 from .actions_router import actions_router
+from .labware_router import labware_router
 
 runs_router = APIRouter()
 
 runs_router.include_router(base_router)
 runs_router.include_router(commands_router)
 runs_router.include_router(actions_router)
+runs_router.include_router(labware_router)
 
 __all__ = ["runs_router"]

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -10,8 +10,6 @@ from typing_extensions import Literal
 from fastapi import APIRouter, Depends, status
 from pydantic import BaseModel, Field
 
-from opentrons.protocol_engine import LabwareOffsetCreate
-
 from robot_server.errors import ErrorDetails, ErrorBody
 from robot_server.service.dependencies import get_current_time, get_unique_id
 from robot_server.service.task_runner import TaskRunner
@@ -301,70 +299,6 @@ async def remove_run(
     return await PydanticResponse.create(
         content=SimpleEmptyBody.construct(),
         status_code=status.HTTP_200_OK,
-    )
-
-
-@base_router.post(
-    path="/runs/{runId}/labware_offsets",
-    summary="Add a labware offset to a run",
-    description=(
-        "Add a labware offset to an existing run, returning the updated run."
-        "\n\n"
-        "There is no matching `GET /runs/{runId}/labware_offsets` endpoint."
-        " To read the list of labware offsets currently on the run,"
-        " see the run's `labwareOffsets` field."
-    ),
-    status_code=status.HTTP_201_CREATED,
-    responses={
-        status.HTTP_201_CREATED: {"model": SimpleBody[Run]},
-        status.HTTP_404_NOT_FOUND: {"model": ErrorBody[RunNotFound]},
-        status.HTTP_409_CONFLICT: {"model": ErrorBody[Union[RunStopped, RunNotIdle]]},
-    },
-)
-async def add_labware_offset(
-    runId: str,
-    request_body: RequestModel[LabwareOffsetCreate],
-    run_store: RunStore = Depends(get_run_store),
-    engine_store: EngineStore = Depends(get_engine_store),
-) -> PydanticResponse[SimpleBody[Run]]:
-    """Add a labware offset to a run.
-
-    Args:
-        runId: Run ID pulled from URL.
-        request_body: New labware offset request data from request body.
-        run_store: Run storage interface.
-        engine_store: Engine storage interface.
-    """
-    try:
-        run = run_store.get(run_id=runId)
-    except RunNotFoundError as e:
-        raise RunNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
-
-    if run.is_current is False:
-        raise RunStopped(detail=f"Run {runId} is not the current run").as_error(
-            status.HTTP_409_CONFLICT
-        )
-
-    added_offset = engine_store.engine.add_labware_offset(request_body.data)
-    log.info(f'Added labware offset "{added_offset.id}"' f' to run "{runId}".')
-
-    engine_state = engine_store.get_state(run.run_id)
-    data = Run.construct(
-        id=run.run_id,
-        protocolId=run.protocol_id,
-        createdAt=run.created_at,
-        current=run.is_current,
-        actions=run.actions,
-        errors=engine_state.commands.get_all_errors(),
-        pipettes=engine_state.pipettes.get_all(),
-        labware=engine_state.labware.get_all(),
-        labwareOffsets=engine_state.labware.get_labware_offsets(),
-        status=engine_state.commands.get_status(),
-    )
-
-    return await PydanticResponse.create(
-        content=SimpleBody.construct(data=data),
-        status_code=status.HTTP_201_CREATED,
     )
 
 

--- a/robot-server/robot_server/runs/router/labware_router.py
+++ b/robot-server/robot_server/runs/router/labware_router.py
@@ -1,0 +1,105 @@
+"""Router for /runs endpoints dealing with labware offsets and definitions."""
+import logging
+from typing import Union
+
+from fastapi import APIRouter, Depends, status
+
+from opentrons.protocol_engine import LabwareOffsetCreate, LabwareOffset
+from opentrons.protocols.models import LabwareDefinition
+
+from robot_server.errors import ErrorBody
+from robot_server.service.json_api import RequestModel, SimpleBody, PydanticResponse
+
+from ..run_models import Run, LabwareDefinitionSummary
+from ..engine_store import EngineStore
+from ..dependencies import get_engine_store
+from .base_router import RunNotFound, RunStopped, RunNotIdle, get_run_data_from_url
+
+log = logging.getLogger(__name__)
+labware_router = APIRouter()
+
+
+@labware_router.post(
+    path="/runs/{runId}/labware_offsets",
+    summary="Add a labware offset to a run",
+    description=(
+        "Add a labware offset to an existing run, returning the created offset."
+        "\n\n"
+        "There is no matching `GET /runs/{runId}/labware_offsets` endpoint."
+        " To read the list of labware offsets currently on the run,"
+        " see the run's `labwareOffsets` field."
+    ),
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        status.HTTP_201_CREATED: {"model": SimpleBody[Run]},
+        status.HTTP_404_NOT_FOUND: {"model": ErrorBody[RunNotFound]},
+        status.HTTP_409_CONFLICT: {"model": ErrorBody[Union[RunStopped, RunNotIdle]]},
+    },
+)
+async def add_labware_offset(
+    request_body: RequestModel[LabwareOffsetCreate],
+    engine_store: EngineStore = Depends(get_engine_store),
+    run: Run = Depends(get_run_data_from_url),
+) -> PydanticResponse[SimpleBody[LabwareOffset]]:
+    """Add a labware offset to a run.
+
+    Args:
+        request_body: New labware offset request data from request body.
+        engine_store: Engine storage interface.
+        run: Run response data by ID from URL; ensures 404 if run not found.
+    """
+    if run.current is False:
+        raise RunStopped(detail=f"Run {run.id} is not the current run").as_error(
+            status.HTTP_409_CONFLICT
+        )
+
+    added_offset = engine_store.engine.add_labware_offset(request_body.data)
+    log.info(f'Added labware offset "{added_offset.id}"' f' to run "{run.id}".')
+
+    return await PydanticResponse.create(
+        content=SimpleBody.construct(data=added_offset),
+        status_code=status.HTTP_201_CREATED,
+    )
+
+
+# TODO(mc, 2022-02-28): add complementary GET endpoint
+# https://github.com/Opentrons/opentrons/issues/9427
+@labware_router.post(
+    path="/runs/{runId}/labware_definitions",
+    summary="Add a labware definition to a run",
+    description=(
+        "Add a labware definition to a run, returning the added definition's URI."
+    ),
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        status.HTTP_201_CREATED: {"model": SimpleBody[Run]},
+        status.HTTP_404_NOT_FOUND: {"model": ErrorBody[RunNotFound]},
+        status.HTTP_409_CONFLICT: {"model": ErrorBody[Union[RunStopped, RunNotIdle]]},
+    },
+)
+async def add_labware_definition(
+    request_body: RequestModel[LabwareDefinition],
+    engine_store: EngineStore = Depends(get_engine_store),
+    run: Run = Depends(get_run_data_from_url),
+) -> PydanticResponse[SimpleBody[LabwareDefinitionSummary]]:
+    """Add a labware offset to a run.
+
+    Args:
+        request_body: New labware offset request data from request body.
+        engine_store: Engine storage interface.
+        run: Run response data by ID from URL; ensures 404 if run not found.
+    """
+    if run.current is False:
+        raise RunStopped(detail=f"Run {run.id} is not the current run").as_error(
+            status.HTTP_409_CONFLICT
+        )
+
+    uri = engine_store.engine.add_labware_definition(request_body.data)
+    log.info(f'Added labware definition "{uri}"' f' to run "{run.id}".')
+
+    return PydanticResponse(
+        content=SimpleBody.construct(
+            data=LabwareDefinitionSummary.construct(definitionUri=uri)
+        ),
+        status_code=status.HTTP_201_CREATED,
+    )

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -137,3 +137,12 @@ class RunUpdate(BaseModel):
             " Setting `current` to `false` will deactivate the run."
         ),
     )
+
+
+class LabwareDefinitionSummary(BaseModel):
+    """Summary of data about a created labware definition."""
+
+    definitionUri: str = Field(
+        ...,
+        description="The definition's unique resource identifier in the run.",
+    )

--- a/robot-server/tests/runs/router/conftest.py
+++ b/robot-server/tests/runs/router/conftest.py
@@ -1,87 +1,39 @@
 """Common test fixtures for runs route tests."""
 import pytest
-import asyncio
-from datetime import datetime
 from decoy import Decoy
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
-from httpx import AsyncClient
-from typing import AsyncIterator
 
-from robot_server.errors import exception_handlers
-from robot_server.service.dependencies import get_current_time, get_unique_id
 from robot_server.service.task_runner import TaskRunner
-from robot_server.protocols import ProtocolStore, get_protocol_store
+from robot_server.protocols import ProtocolStore
 from robot_server.runs.run_view import RunView
 from robot_server.runs.run_store import RunStore
 from robot_server.runs.engine_store import EngineStore
-from robot_server.runs.dependencies import get_run_store, get_engine_store
 
 
-@pytest.fixture
+@pytest.fixture()
 def task_runner(decoy: Decoy) -> TaskRunner:
     """Get a mock background TaskRunner."""
     return decoy.mock(cls=TaskRunner)
 
 
-@pytest.fixture
+@pytest.fixture()
 def protocol_store(decoy: Decoy) -> ProtocolStore:
     """Get a mock ProtocolStore interface."""
     return decoy.mock(cls=ProtocolStore)
 
 
-@pytest.fixture
+@pytest.fixture()
 def run_store(decoy: Decoy) -> RunStore:
     """Get a mock RunStore interface."""
     return decoy.mock(cls=RunStore)
 
 
-@pytest.fixture
+@pytest.fixture()
 def run_view(decoy: Decoy) -> RunView:
     """Get a mock RunView interface."""
     return decoy.mock(cls=RunView)
 
 
-@pytest.fixture
+@pytest.fixture()
 def engine_store(decoy: Decoy) -> EngineStore:
     """Get a mock EngineStore interface."""
     return decoy.mock(cls=EngineStore)
-
-
-@pytest.fixture
-def app(
-    task_runner: TaskRunner,
-    run_store: RunStore,
-    run_view: RunView,
-    engine_store: EngineStore,
-    protocol_store: ProtocolStore,
-    unique_id: str,
-    current_time: datetime,
-) -> FastAPI:
-    """Get a FastAPI app with mocked-out dependencies."""
-    app = FastAPI(exception_handlers=exception_handlers)
-    app.dependency_overrides[TaskRunner] = lambda: task_runner
-    app.dependency_overrides[RunView] = lambda: run_view
-    app.dependency_overrides[get_run_store] = lambda: run_store
-    app.dependency_overrides[get_engine_store] = lambda: engine_store
-    app.dependency_overrides[get_protocol_store] = lambda: protocol_store
-    app.dependency_overrides[get_unique_id] = lambda: unique_id
-    app.dependency_overrides[get_current_time] = lambda: current_time
-
-    return app
-
-
-@pytest.fixture
-def client(app: FastAPI) -> TestClient:
-    """Get an TestClient for /runs route testing."""
-    return TestClient(app)
-
-
-@pytest.fixture
-async def async_client(
-    loop: asyncio.AbstractEventLoop,
-    app: FastAPI,
-) -> AsyncIterator[AsyncClient]:
-    """Get an asynchronous client for /runs route testing."""
-    async with AsyncClient(app=app, base_url="http://test") as client:
-        yield client

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -18,7 +18,6 @@ from robot_server.service.json_api import (
     ResourceLink,
 )
 
-
 from robot_server.protocols import (
     ProtocolStore,
     ProtocolResource,
@@ -47,7 +46,6 @@ from robot_server.runs.router.base_router import (
     get_run,
     get_runs,
     remove_run,
-    add_labware_offset,
     update_run,
 )
 
@@ -295,7 +293,7 @@ async def test_get_run_data_from_url(
         mount=MountType.LEFT,
     )
 
-    expected_response = Run.construct(
+    expected_response = Run(
         id="run-id",
         protocolId=None,
         createdAt=created_at,
@@ -582,73 +580,6 @@ async def test_delete_active_run_no_engine(
         run_store=run_store,
         engine_store=engine_store,
     )
-
-
-async def test_add_labware_offset(
-    decoy: Decoy,
-    engine_store: EngineStore,
-    run_store: RunStore,
-) -> None:
-    """It should add the labware offset to the engine, assuming the run is current."""
-    labware_offset_request = LABWARE_OFFSET_REQUESTS[0]
-
-    run_resource = RunResource(
-        run_id="run-id",
-        protocol_id=None,
-        created_at=datetime(year=2021, month=1, day=1),
-        actions=[],
-        is_current=True,
-    )
-
-    expected_response = Run.construct(
-        id="run-id",
-        protocolId=None,
-        createdAt=datetime(year=2021, month=1, day=1),
-        status=pe_types.EngineStatus.SUCCEEDED,
-        current=True,
-        actions=[],
-        errors=[],
-        pipettes=[],
-        labware=[],
-        labwareOffsets=[],
-    )
-
-    decoy.when(run_store.get(run_id="run-id")).then_return(run_resource)
-
-    engine_state = decoy.mock(cls=StateView)
-    decoy.when(engine_store.get_state("run-id")).then_return(engine_state)
-
-    decoy.when(engine_state.commands.get_all()).then_return([])
-    decoy.when(engine_state.commands.get_all_errors()).then_return([])
-    decoy.when(engine_state.pipettes.get_all()).then_return([])
-    decoy.when(engine_state.labware.get_all()).then_return([])
-    decoy.when(
-        engine_store.engine.add_labware_offset(labware_offset_request)
-    ).then_return(
-        pe_types.LabwareOffset(
-            id="labware-offset-id",
-            createdAt=datetime(year=2021, month=1, day=1),
-            definitionUri="labware-definition-uri",
-            location=pe_types.LabwareOffsetLocation(slotName=DeckSlotName.SLOT_1),
-            vector=pe_types.LabwareOffsetVector(x=0, y=0, z=0),
-        )
-    )
-    # Tests for run POST and GET should already cover passing the engine's labware
-    # offsets to the client when .get_labware_offsets() returns a non-empty list.
-    decoy.when(engine_state.labware.get_labware_offsets()).then_return([])
-    decoy.when(engine_state.commands.get_status()).then_return(
-        pe_types.EngineStatus.SUCCEEDED
-    )
-
-    result = await add_labware_offset(
-        runId="run-id",
-        request_body=RequestModel(data=labware_offset_request),
-        engine_store=engine_store,
-        run_store=run_store,
-    )
-
-    assert result.content == SimpleBody(data=expected_response)
-    assert result.status_code == 201
 
 
 async def test_update_run_to_not_current(

--- a/robot-server/tests/runs/router/test_labware_router.py
+++ b/robot-server/tests/runs/router/test_labware_router.py
@@ -1,0 +1,144 @@
+"""Tests for /runs routes dealing with labware offsets and definitions."""
+import pytest
+from datetime import datetime
+from decoy import Decoy
+
+from opentrons_shared_data.labware.dev_types import LabwareDefinition as LabwareDefDict
+
+from opentrons.types import DeckSlotName
+from opentrons.protocol_engine import EngineStatus, types as pe_types
+from opentrons.protocols.models import LabwareDefinition
+
+from robot_server.errors import ApiError
+from robot_server.service.json_api import RequestModel, SimpleBody
+from robot_server.runs.run_models import Run, LabwareDefinitionSummary
+from robot_server.runs.engine_store import EngineStore
+from robot_server.runs.router.labware_router import (
+    add_labware_offset,
+    add_labware_definition,
+)
+
+
+@pytest.fixture()
+def run() -> Run:
+    """Get a fixture Run response data."""
+    return Run(
+        id="run-id",
+        createdAt=datetime(year=2021, month=1, day=1),
+        status=EngineStatus.IDLE,
+        current=True,
+        actions=[],
+        errors=[],
+        pipettes=[],
+        labware=[],
+        labwareOffsets=[],
+        protocolId=None,
+    )
+
+
+@pytest.fixture()
+def labware_definition(minimal_labware_def: LabwareDefDict) -> LabwareDefinition:
+    """Create a labware definition fixture."""
+    return LabwareDefinition.parse_obj(minimal_labware_def)
+
+
+async def test_add_labware_offset(
+    decoy: Decoy,
+    engine_store: EngineStore,
+    run: Run,
+) -> None:
+    """It should add the labware offset to the engine, assuming the run is current."""
+    labware_offset_request = pe_types.LabwareOffsetCreate(
+        definitionUri="namespace_1/load_name_1/123",
+        location=pe_types.LabwareOffsetLocation(slotName=DeckSlotName.SLOT_1),
+        vector=pe_types.LabwareOffsetVector(x=1, y=2, z=3),
+    )
+
+    labware_offset = pe_types.LabwareOffset(
+        id="labware-offset-id",
+        createdAt=datetime(year=2022, month=2, day=2),
+        definitionUri="labware-definition-uri",
+        location=pe_types.LabwareOffsetLocation(slotName=DeckSlotName.SLOT_1),
+        vector=pe_types.LabwareOffsetVector(x=0, y=0, z=0),
+    )
+
+    decoy.when(
+        engine_store.engine.add_labware_offset(labware_offset_request)
+    ).then_return(labware_offset)
+
+    result = await add_labware_offset(
+        request_body=RequestModel(data=labware_offset_request),
+        engine_store=engine_store,
+        run=run,
+    )
+
+    assert result.content == SimpleBody(data=labware_offset)
+    assert result.status_code == 201
+
+
+async def test_add_labware_offset_not_current(
+    decoy: Decoy,
+    engine_store: EngineStore,
+    run: Run,
+) -> None:
+    """It should 409 if the run is not current."""
+    not_current_run = run.copy(update={"current": False})
+
+    labware_offset_request = pe_types.LabwareOffsetCreate(
+        definitionUri="namespace_1/load_name_1/123",
+        location=pe_types.LabwareOffsetLocation(slotName=DeckSlotName.SLOT_1),
+        vector=pe_types.LabwareOffsetVector(x=1, y=2, z=3),
+    )
+
+    with pytest.raises(ApiError) as exc_info:
+        await add_labware_offset(
+            request_body=RequestModel(data=labware_offset_request),
+            engine_store=engine_store,
+            run=not_current_run,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.content["errors"][0]["id"] == "RunStopped"
+
+
+async def test_add_labware_definition(
+    decoy: Decoy,
+    engine_store: EngineStore,
+    run: Run,
+    labware_definition: LabwareDefinition,
+) -> None:
+    """It should be able to add a labware definition to the engine."""
+    uri = pe_types.LabwareUri("some/definition/uri")
+
+    decoy.when(
+        engine_store.engine.add_labware_definition(labware_definition)
+    ).then_return(uri)
+
+    result = await add_labware_definition(
+        engine_store=engine_store,
+        run=run,
+        request_body=RequestModel(data=labware_definition),
+    )
+
+    assert result.content.data == LabwareDefinitionSummary(definitionUri=uri)
+    assert result.status_code == 201
+
+
+async def test_add_labware_definition_not_current(
+    decoy: Decoy,
+    engine_store: EngineStore,
+    run: Run,
+    labware_definition: LabwareDefinition,
+) -> None:
+    """It should 409 if the run is not current."""
+    not_current_run = run.copy(update={"current": False})
+
+    with pytest.raises(ApiError) as exc_info:
+        await add_labware_definition(
+            engine_store=engine_store,
+            run=not_current_run,
+            request_body=RequestModel(data=labware_definition),
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.content["errors"][0]["id"] == "RunStopped"

--- a/robot-server/tests/service/legacy/routers/test_settings.py
+++ b/robot-server/tests/service/legacy/routers/test_settings.py
@@ -209,17 +209,14 @@ def test_available_resets(api_client):
     body = resp.json()
     options_list = body.get("options")
     assert resp.status_code == 200
-    assert (
-        sorted(
-            [
-                "deckCalibration",
-                "pipetteOffsetCalibrations",
-                "bootScripts",
-                "tipLengthCalibrations",
-            ]
-        )
-        == sorted([item["id"] for item in options_list])
-    )
+    assert sorted(
+        [
+            "deckCalibration",
+            "pipetteOffsetCalibrations",
+            "bootScripts",
+            "tipLengthCalibrations",
+        ]
+    ) == sorted([item["id"] for item in options_list])
 
 
 @pytest.fixture

--- a/robot-server/tests/service/legacy/routers/test_settings.py
+++ b/robot-server/tests/service/legacy/routers/test_settings.py
@@ -209,14 +209,17 @@ def test_available_resets(api_client):
     body = resp.json()
     options_list = body.get("options")
     assert resp.status_code == 200
-    assert sorted(
-        [
-            "deckCalibration",
-            "pipetteOffsetCalibrations",
-            "bootScripts",
-            "tipLengthCalibrations",
-        ]
-    ) == sorted([item["id"] for item in options_list])
+    assert (
+        sorted(
+            [
+                "deckCalibration",
+                "pipetteOffsetCalibrations",
+                "bootScripts",
+                "tipLengthCalibrations",
+            ]
+        )
+        == sorted([item["id"] for item in options_list])
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
## Overview

This PR fixes #9571 by allowing the app to explicitly add labware definitions to the `Run` as part of the LPC setup phase. This ensures that any custom labware loaded during the analysis run will be present for LPC load labware commands, even if those labware definitions were specified at runtime in the Python protocol via `load_labware_by_definition`.

## Changelog

- feat(api-client, react-api-client): add utils to create labware definitions
- feat(robot-server): add POST /runs/:id/labware_definitions endpoint
- feat(app): create labware definitions for custom labware before LPC kicks off

## Review requests

Smoke test procedure for this fix:

1. Upload the smoke test protocol below
2. Ensure LPC works
    - Verify that offsets are actually applied
    - You could do this by jogging to an obviously wrong offset
4. Ensure run works

### Bonus points

1. Modify the smoke test protocol to load the labware from definition onto a module
2. Ensure LPC works
5. Ensure run works

## Risk assessment

Low. If smoke tests prove LPC works, then we're good. None of the changes here affect actual PAPIv2 protocol runs.

## Smoke test protocol

```python
import json
from opentrons import types

metadata = {
    "protocolName": "Test inline custom labware",
    "apiLevel": "2.12",
}

# load_name: fixture_12_trough
# namespace: fixture
# version: 1
TROUGH_DEFINITION = """{"ordering":[["A1"],["A2"],["A3"],["A4"],["A5"],["A6"],["A7"],["A8"],["A9"],["A10"],["A11"],["A12"]],"schemaVersion":2,"version":1,"namespace":"fixture","metadata":{"displayName":"12 Channel Trough","displayVolumeUnits":"mL","displayCategory":"reservoir"},"dimensions":{"xDimension":127.76,"yDimension":85.8,"zDimension":44.45},"parameters":{"format":"trough","isTiprack":false,"isMagneticModuleCompatible":false,"loadName":"fixture_12_trough","quirks":["centerMultichannelOnWells","touchTipDisabled"]},"wells":{"A1":{"shape":"rectangular","depth":42.16,"xDimension":8.33,"yDimension":71.88,"totalLiquidVolume":22000,"x":13.94,"y":42.9,"z":2.29},"A2":{"shape":"rectangular","depth":42.16,"xDimension":8.33,"yDimension":71.88,"totalLiquidVolume":22000,"x":23.03,"y":42.9,"z":2.29},"A3":{"shape":"rectangular","depth":42.16,"xDimension":8.33,"yDimension":71.88,"totalLiquidVolume":22000,"x":32.12,"y":42.9,"z":2.29},"A4":{"shape":"rectangular","depth":42.16,"xDimension":8.33,"yDimension":71.88,"totalLiquidVolume":22000,"x":41.21,"y":42.9,"z":2.29},"A5":{"shape":"rectangular","depth":42.16,"xDimension":8.33,"yDimension":71.88,"totalLiquidVolume":22000,"x":50.3,"y":42.9,"z":2.29},"A6":{"shape":"rectangular","depth":42.16,"xDimension":8.33,"yDimension":71.88,"totalLiquidVolume":22000,"x":59.39,"y":42.9,"z":2.29},"A7":{"shape":"rectangular","depth":42.16,"xDimension":8.33,"yDimension":71.88,"totalLiquidVolume":22000,"x":68.48,"y":42.9,"z":2.29},"A8":{"shape":"rectangular","depth":42.16,"xDimension":8.33,"yDimension":71.88,"totalLiquidVolume":22000,"x":77.57,"y":42.9,"z":2.29},"A9":{"shape":"rectangular","depth":42.16,"xDimension":8.33,"yDimension":71.88,"totalLiquidVolume":22000,"x":86.66,"y":42.9,"z":2.29},"A10":{"shape":"rectangular","depth":42.16,"xDimension":8.33,"yDimension":71.88,"totalLiquidVolume":22000,"x":95.75,"y":42.9,"z":2.29},"A11":{"shape":"rectangular","depth":42.16,"xDimension":8.33,"yDimension":71.88,"totalLiquidVolume":22000,"x":104.84,"y":42.9,"z":2.29},"A12":{"shape":"rectangular","depth":42.16,"xDimension":8.33,"yDimension":71.88,"totalLiquidVolume":22000,"x":113.93,"y":42.9,"z":2.29}},"brand":{"brand":"USA Scientific","brandId":["1061-8150"]},"groups":[{"wells":["A1","A2","A3","A4","A5","A6","A7","A8","A9","A10","A11","A12"],"metadata":{"wellBottomShape":"v"}}],"cornerOffsetFromSlot":{"x":0,"y":0,"z":0}}"""  # noqa: E501


def run(ctx):
    tip_rack = ctx.load_labware("opentrons_96_tiprack_300ul", 1)
    pipette = ctx.load_instrument("p300_single", types.Mount.RIGHT, [tip_rack])
    trough = ctx.load_labware_from_definition(
        labware_def=json.loads(TROUGH_DEFINITION),
        location=2,
    )

    pipette.pick_up_tip()
    pipette.aspirate(10, trough.wells()[0].bottom())
    pipette.dispense(10, trough.wells()[1].bottom())
    pipette.return_tip()
```
