### PR TITLE
refactor(protocol-engine): Group Magnetic Module commands in a subpackage

### DIFF
--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -162,12 +162,12 @@ class SyncClient:
 
     def magnetic_module_engage(
         self, module_id: str, engage_height: float
-    ) -> commands.MagneticModuleEngageResult:
+    ) -> commands.magnetic_module.EngageResult:
         """Execute a ``MagneticModuleEngage`` command and return the result."""
-        request = commands.MagneticModuleEngageCreate(
-            params=commands.MagneticModuleEngageParams(
+        request = commands.magnetic_module.EngageCreate(
+            params=commands.magnetic_module.EngageParams(
                 moduleId=module_id, engageHeight=engage_height
             )
         )
         result = self._transport.execute_command(request=request)
-        return cast(commands.MagneticModuleEngageResult, result)
+        return cast(commands.magnetic_module.EngageResult, result)

--- a/api/src/opentrons/protocol_engine/commands/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/__init__.py
@@ -14,6 +14,7 @@ and/or schema generation.
 """
 
 from . import heater_shaker
+from . import magnetic_module
 
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, CommandStatus
 
@@ -86,14 +87,6 @@ from .load_pipette import (
     LoadPipetteCreate,
     LoadPipetteResult,
     LoadPipetteCommandType,
-)
-
-from .magnetic_module_engage import (
-    MagneticModuleEngage,
-    MagneticModuleEngageParams,
-    MagneticModuleEngageCreate,
-    MagneticModuleEngageResult,
-    MagneticModuleEngageCommandType,
 )
 
 from .move_relative import (
@@ -234,4 +227,5 @@ __all__ = [
     "SavePositionCommandType",
     # module command bundles
     "heater_shaker",
+    "magnetic_module",
 ]

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -3,6 +3,7 @@
 from typing import Union
 
 from . import heater_shaker
+from . import magnetic_module
 
 from .aspirate import (
     Aspirate,
@@ -67,14 +68,6 @@ from .load_pipette import (
     LoadPipetteCommandType,
 )
 
-from .magnetic_module_engage import (
-    MagneticModuleEngage,
-    MagneticModuleEngageParams,
-    MagneticModuleEngageCreate,
-    MagneticModuleEngageResult,
-    MagneticModuleEngageCommandType,
-)
-
 from .move_relative import (
     MoveRelative,
     MoveRelativeParams,
@@ -124,7 +117,6 @@ Command = Union[
     LoadLabware,
     LoadModule,
     LoadPipette,
-    MagneticModuleEngage,
     MoveRelative,
     MoveToWell,
     Pause,
@@ -137,6 +129,7 @@ Command = Union[
     heater_shaker.StopShake,
     heater_shaker.OpenLatch,
     heater_shaker.CloseLatch,
+    magnetic_module.Engage,
 ]
 
 CommandParams = Union[
@@ -148,7 +141,6 @@ CommandParams = Union[
     LoadLabwareParams,
     LoadModuleParams,
     LoadPipetteParams,
-    MagneticModuleEngageParams,
     MoveRelativeParams,
     MoveToWellParams,
     PauseParams,
@@ -161,6 +153,7 @@ CommandParams = Union[
     heater_shaker.StopShakeParams,
     heater_shaker.OpenLatchParams,
     heater_shaker.CloseLatchParams,
+    magnetic_module.EngageParams,
 ]
 
 CommandType = Union[
@@ -172,7 +165,6 @@ CommandType = Union[
     LoadLabwareCommandType,
     LoadModuleCommandType,
     LoadPipetteCommandType,
-    MagneticModuleEngageCommandType,
     MoveRelativeCommandType,
     MoveToWellCommandType,
     PauseCommandType,
@@ -185,6 +177,7 @@ CommandType = Union[
     heater_shaker.StopShakeCommandType,
     heater_shaker.OpenLatchCommandType,
     heater_shaker.CloseLatchCommandType,
+    magnetic_module.EngageCommandType,
 ]
 
 CommandCreate = Union[
@@ -195,7 +188,6 @@ CommandCreate = Union[
     LoadLabwareCreate,
     LoadModuleCreate,
     LoadPipetteCreate,
-    MagneticModuleEngageCreate,
     MoveRelativeCreate,
     MoveToWellCreate,
     PauseCreate,
@@ -208,6 +200,7 @@ CommandCreate = Union[
     heater_shaker.StopShakeCreate,
     heater_shaker.OpenLatchCreate,
     heater_shaker.CloseLatchCreate,
+    magnetic_module.EngageCreate,
 ]
 
 CommandResult = Union[
@@ -219,7 +212,6 @@ CommandResult = Union[
     LoadLabwareResult,
     LoadModuleResult,
     LoadPipetteResult,
-    MagneticModuleEngageResult,
     MoveRelativeResult,
     MoveToWellResult,
     PauseResult,
@@ -232,4 +224,5 @@ CommandResult = Union[
     heater_shaker.StopShakeResult,
     heater_shaker.OpenLatchResult,
     heater_shaker.CloseLatchResult,
+    magnetic_module.EngageResult,
 ]

--- a/api/src/opentrons/protocol_engine/commands/magnetic_module/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/magnetic_module/__init__.py
@@ -1,0 +1,18 @@
+"""Magnetic Module protocol commands."""
+
+from .engage import (
+    Engage,
+    EngageCreate,
+    EngageParams,
+    EngageResult,
+    EngageCommandType,
+)
+
+__all__ = [
+    # magneticModule/engageMagnet
+    "Engage",
+    "EngageCreate",
+    "EngageParams",
+    "EngageResult",
+    "EngageCommandType",
+]

--- a/api/src/opentrons/protocol_engine/commands/magnetic_module/engage.py
+++ b/api/src/opentrons/protocol_engine/commands/magnetic_module/engage.py
@@ -6,13 +6,13 @@ from typing_extensions import Literal, Type
 
 from pydantic import BaseModel, Field
 
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 
-MagneticModuleEngageCommandType = Literal["magneticModule/engageMagnet"]
+EngageCommandType = Literal["magneticModule/engageMagnet"]
 
 
-class MagneticModuleEngageParams(BaseModel):
+class EngageParams(BaseModel):
     """Input data to engage a Magnetic Module."""
 
     moduleId: str = Field(
@@ -42,44 +42,36 @@ class MagneticModuleEngageParams(BaseModel):
     )
 
 
-class MagneticModuleEngageResult(BaseModel):
+class EngageResult(BaseModel):
     """The result of a Magnetic Module engage command."""
 
     pass
 
 
-class MagneticModuleEngageImplementation(
-    AbstractCommandImpl[MagneticModuleEngageParams, MagneticModuleEngageResult]
-):
+class EngageImplementation(AbstractCommandImpl[EngageParams, EngageResult]):
     """The implementation of a Magnetic Module engage command."""
 
-    async def execute(
-        self, params: MagneticModuleEngageParams
-    ) -> MagneticModuleEngageResult:
+    async def execute(self, params: EngageParams) -> EngageResult:
         """Execute a Magnetic Module engage command."""
         raise NotImplementedError(
             "Protocol Engine does not yet support engaging magnets."
         )
 
 
-class MagneticModuleEngage(
-    BaseCommand[MagneticModuleEngageParams, MagneticModuleEngageResult]
-):
+class Engage(BaseCommand[EngageParams, EngageResult]):
     """A command to engage a Magnetic Module's magnets."""
 
-    commandType: MagneticModuleEngageCommandType = "magneticModule/engageMagnet"
-    params: MagneticModuleEngageParams
-    result: Optional[MagneticModuleEngageResult]
+    commandType: EngageCommandType = "magneticModule/engageMagnet"
+    params: EngageParams
+    result: Optional[EngageResult]
 
-    _ImplementationCls: Type[
-        MagneticModuleEngageImplementation
-    ] = MagneticModuleEngageImplementation
+    _ImplementationCls: Type[EngageImplementation] = EngageImplementation
 
 
-class MagneticModuleEngageCreate(BaseCommandCreate[MagneticModuleEngageParams]):
+class EngageCreate(BaseCommandCreate[EngageParams]):
     """A request to create a Magnetic Module engage command."""
 
-    commandType: MagneticModuleEngageCommandType = "magneticModule/engageMagnet"
-    params: MagneticModuleEngageParams
+    commandType: EngageCommandType = "magneticModule/engageMagnet"
+    params: EngageParams
 
-    _CommandCls: Type[MagneticModuleEngage] = MagneticModuleEngage
+    _CommandCls: Type[Engage] = Engage

--- a/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
@@ -269,12 +269,12 @@ def test_magnetic_module_engage(
     subject: SyncClient,
 ) -> None:
     """It should execute a Magnetic Module engage command."""
-    request = commands.MagneticModuleEngageCreate(
-        params=commands.MagneticModuleEngageParams(
+    request = commands.magnetic_module.EngageCreate(
+        params=commands.magnetic_module.EngageParams(
             moduleId="module-id", engageHeight=12.34
         )
     )
-    response = commands.MagneticModuleEngageResult()
+    response = commands.magnetic_module.EngageResult()
 
     decoy.when(transport.execute_command(request=request)).then_return(response)
 

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/__init__.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/__init__.py
@@ -1,1 +1,1 @@
-"""Tests for Heater Shaker Module commands."""
+"""Tests for Heater-Shaker Module commands."""

--- a/api/tests/opentrons/protocol_engine/commands/magnetic_module/__init__.py
+++ b/api/tests/opentrons/protocol_engine/commands/magnetic_module/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Magnetic Module commands."""

--- a/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_engage.py
+++ b/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_engage.py
@@ -9,9 +9,9 @@ from opentrons.protocol_engine.execution import (
     PipettingHandler,
     RunControlHandler,
 )
-from opentrons.protocol_engine.commands.magnetic_module_engage import (
-    MagneticModuleEngageParams,
-    MagneticModuleEngageImplementation,
+from opentrons.protocol_engine.commands.magnetic_module import EngageParams
+from opentrons.protocol_engine.commands.magnetic_module.engage import (
+    EngageImplementation,
 )
 
 
@@ -24,13 +24,13 @@ async def test_magnetic_module_engage_implementation(
     run_control: RunControlHandler,
 ) -> None:
     """It should engage the magnets."""
-    subject = MagneticModuleEngageImplementation(
+    subject = EngageImplementation(
         equipment=equipment,
         movement=movement,
         pipetting=pipetting,
         run_control=run_control,
     )
-    params = MagneticModuleEngageParams(
+    params = EngageParams(
         moduleId="module-id",
         engageHeight=3.14159,
     )


### PR DESCRIPTION
# Overview

This PR does the thing I said I was going to do in https://github.com/Opentrons/opentrons/pull/9572#discussion_r814974890.

# Changelog

* Move the Magnetic Module engage command to a `commands.magnetic_module` subpackage, for neatness and consistency with `commands.heater_shaker`.
* Rename those classes to not be so verbose and redundant, now that they can rely on their package name for context.

# Review requests

* None in particular. I guess skim the diff and make sure I didn't miss adding an entry to a `Union` or anything?

# Risk assessment

* None as long as CI passes.