### PR TITLE
chore(hardware): nicer arbitration id logging

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/arbitration_id.py
+++ b/hardware/opentrons_hardware/firmware_bindings/arbitration_id.py
@@ -6,7 +6,8 @@ library.
 """
 from __future__ import annotations
 import ctypes
-from typing import TYPE_CHECKING
+from enum import Enum
+from typing import TYPE_CHECKING, Type
 
 from opentrons_hardware.firmware_bindings.constants import (
     FunctionCode,
@@ -46,11 +47,19 @@ class ArbitrationIdParts(ctypes.Structure):
 
     def __repr__(self) -> str:
         """Return string representation of class."""
+
+        def _safe_to_str(enum_type: Type[Enum], val: int) -> str:
+            """Safely convert enum to string."""
+            try:
+                return enum_type(val).name
+            except ValueError:
+                return f"0x{val:x}"
+
         return (
-            f"function_code: {FunctionCode(self.function_code).name}, "
-            f"node_id: {NodeId(self.node_id).name}, "
-            f"originating_node_id: {NodeId(self.originating_node_id).name}, "
-            f"message_id: {MessageId(self.message_id).name}"
+            f"function_code: {_safe_to_str(FunctionCode, self.function_code)}, "
+            f"node_id: {_safe_to_str(NodeId, self.node_id)}, "
+            f"originating_node_id: {_safe_to_str(NodeId, self.originating_node_id)}, "
+            f"message_id: {_safe_to_str(MessageId, self.message_id)}"
         )
 
 

--- a/hardware/opentrons_hardware/firmware_bindings/arbitration_id.py
+++ b/hardware/opentrons_hardware/firmware_bindings/arbitration_id.py
@@ -8,6 +8,12 @@ from __future__ import annotations
 import ctypes
 from typing import TYPE_CHECKING
 
+from opentrons_hardware.firmware_bindings.constants import (
+    FunctionCode,
+    NodeId,
+    MessageId,
+)
+
 if TYPE_CHECKING:
     from typing_extensions import Final
 
@@ -41,10 +47,10 @@ class ArbitrationIdParts(ctypes.Structure):
     def __repr__(self) -> str:
         """Return string representation of class."""
         return (
-            f"function_code: 0x{self.function_code:x}, "
-            f"node_id: 0x{self.node_id:x}, "
-            f"originating_node_id: 0x{self.originating_node_id:x}, "
-            f"message_id: 0x{self.message_id:x}"
+            f"function_code: {FunctionCode(self.function_code).name}, "
+            f"node_id: {NodeId(self.node_id).name}, "
+            f"originating_node_id: {NodeId(self.originating_node_id).name}, "
+            f"message_id: {MessageId(self.message_id).name}"
         )
 
 

--- a/hardware/tests/opentrons_hardware/firmware_bindings/test_arbitration_id.py
+++ b/hardware/tests/opentrons_hardware/firmware_bindings/test_arbitration_id.py
@@ -67,3 +67,15 @@ def test_arbitration_id_integer(expected: int, parts: ArbitrationIdParts) -> Non
     """It should convert parts to an arbitration id."""
     c = ArbitrationId(parts=parts)
     assert c.id == expected
+
+
+def test_arbitration_id_parts_repr_invalid() -> None:
+    """It should tolerate invalid ids."""
+    # These are not valid enum values. They should display as hex numbers.
+    c = ArbitrationIdParts(
+        function_code=1, node_id=2, originating_node_id=3, message_id=1000
+    )
+    assert (
+        str(c) == "function_code: sync, node_id: 0x2,"
+        " originating_node_id: 0x3, message_id: 0x3e8"
+    )


### PR DESCRIPTION
# Overview

Use names instead of hex values in arbitration id parts `__repr__`.

# Changelog


# Review requests

```
2022-03-01 13:22:53,382 __main__ INFO Sending --> 
	raw: CanMessage(arbitration_id=id: 0xc088000, parts: function_code: network_management, node_id: broadcast, originating_node_id: host, message_id: device_info_request, data=b'')
2022-03-01 13:22:53,386 __main__ INFO Received <-- 
	raw: CanMessage(arbitration_id=id: 0xc0e8100, parts: function_code: network_management, node_id: host, originating_node_id: head, message_id: device_info_response, data=bytearray(b'\x00\x00\x00\x00')), 
	parsed: DeviceInfoResponsePayload(version=UInt32Field(value=0))
```

instead of 
```
2022-02-22 11:31:16,544 __main__ INFO Sending --> 
	raw: CanMessage(arbitration_id=id: 0xc088000, parts: function_code: 0x0, node_id: 0x0, originating_node_id: 0x10, message_id: 0x302, data=b'')
2022-02-22 11:31:16,549 __main__ INFO Received <-- 
	raw: CanMessage(arbitration_id=id: 0xc0e7900, parts: function_code: 0x0, node_id: 0x10, originating_node_id: 0x4f, message_id: 0x303, data=bytearray(b'\x00\x00\x00\x00')), 
	parsed: DeviceInfoResponsePayload(version=UInt32Field(value=0))

```

# Risk assessment

Low