### PR TITLE
refactor(protocol-engine): Make fake serial numbers more obvious

### DIFF
--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -216,7 +216,9 @@ class EquipmentHandler:
 
         else:
             attached_module = HardwareModule(
-                serial_number=self._model_utils.generate_fake_serial_number(),
+                serial_number=self._model_utils.generate_id(
+                    prefix="fake-serial-number-"
+                ),
                 definition=self._module_data_provider.get_definition(model),
             )
 

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -216,9 +216,7 @@ class EquipmentHandler:
 
         else:
             attached_module = HardwareModule(
-                # TODO(mc, 2022-02-14): use something a little more obvious
-                # than an opaque UUID for the virtual serial number
-                serial_number=self._model_utils.generate_id(),
+                serial_number=self._model_utils.generate_fake_serial_number(),
                 definition=self._module_data_provider.get_definition(model),
             )
 

--- a/api/src/opentrons/protocol_engine/resources/model_utils.py
+++ b/api/src/opentrons/protocol_engine/resources/model_utils.py
@@ -8,22 +8,15 @@ class ModelUtils:
     """Common resource model utilities provider."""
 
     @staticmethod
-    def generate_fake_serial_number() -> str:
-        """Generate a unique stand-in for a serial number.
-
-        This is meant to be used for protocol analysis (simulation),
-        where commands like module loads are supposed to report a serial number,
-        but there is no actual physical hardware to provide that serial number.
-        """
-        return f"fake-serial-number-{uuid4()}"
-
-    @staticmethod
-    def generate_id() -> str:
+    def generate_id(prefix: str = "") -> str:
         """Generate a unique identifier.
 
         Uses UUIDv4 for safety in a multiprocessing environment.
+
+        Params:
+            prefix: Prepended to the UUIDv4.
         """
-        return str(uuid4())
+        return prefix + str(uuid4())
 
     @staticmethod
     def ensure_id(maybe_id: Optional[str] = None) -> str:

--- a/api/src/opentrons/protocol_engine/resources/model_utils.py
+++ b/api/src/opentrons/protocol_engine/resources/model_utils.py
@@ -8,6 +8,16 @@ class ModelUtils:
     """Common resource model utilities provider."""
 
     @staticmethod
+    def generate_fake_serial_number() -> str:
+        """Generate a unique stand-in for a serial number.
+
+        This is meant to be used for protocol analysis (simulation),
+        where commands like module loads are supposed to report a serial number,
+        but there is no actual physical hardware to provide that serial number.
+        """
+        return f"fake-serial-number-{uuid4()}"
+
+    @staticmethod
     def generate_id() -> str:
         """Generate a unique identifier.
 

--- a/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
@@ -484,7 +484,9 @@ async def test_load_module_using_virtual(
     """It should load a virtual module."""
     decoy.when(model_utils.ensure_id("input-module-id")).then_return("module-id")
 
-    decoy.when(model_utils.generate_id()).then_return("fake-serial-number")
+    decoy.when(model_utils.generate_fake_serial_number()).then_return(
+        "fake-serial-number"
+    )
 
     decoy.when(
         module_data_provider.get_definition(ModuleModel.TEMPERATURE_MODULE_V1)

--- a/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
@@ -484,8 +484,8 @@ async def test_load_module_using_virtual(
     """It should load a virtual module."""
     decoy.when(model_utils.ensure_id("input-module-id")).then_return("module-id")
 
-    decoy.when(model_utils.generate_fake_serial_number()).then_return(
-        "fake-serial-number"
+    decoy.when(model_utils.generate_id(prefix="fake-serial-number-")).then_return(
+        "fake-serial-number-abc123"
     )
 
     decoy.when(
@@ -504,6 +504,6 @@ async def test_load_module_using_virtual(
 
     assert result == LoadedModuleData(
         module_id="module-id",
-        serial_number="fake-serial-number",
+        serial_number="fake-serial-number-abc123",
         definition=tempdeck_v1_def,
     )

--- a/api/tests/opentrons/protocol_engine/resources/test_model_utils.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_model_utils.py
@@ -2,28 +2,14 @@
 import re
 from opentrons.protocol_engine.resources import ModelUtils
 
+
 RE_UUID = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
     flags=re.IGNORECASE,
 )
 
 
-def test_model_utils_generates_fake_serial() -> None:
-    """It should generate a string that's visibly a fake serial number."""
-    result = ModelUtils().generate_fake_serial_number()
-    assert "fake-serial-number" in result
-    assert result != "fake-serial-number"
-
-
-def test_model_utils_generates_unique_fake_serial() -> None:
-    """Generated serial numbers should be unique."""
-    results = [ModelUtils().generate_id() for i in range(1000)]
-    unique_results = set(results)
-
-    assert len(results) == len(unique_results)
-
-
-def test_model_utils_generates_id() -> None:
+def test_model_utils_generates_uuid() -> None:
     """It should generate a string matching a UUID."""
     result = ModelUtils().generate_id()
 
@@ -36,6 +22,11 @@ def test_model_utils_generates_unique_id() -> None:
     unique_results = set(results)
 
     assert len(results) == len(unique_results)
+
+
+def test_model_utils_generates_id_with_prefix() -> None:
+    """It should return an ID with the given prefix."""
+    assert ModelUtils().generate_id(prefix="my-prefix-").startswith("my-prefix-")
 
 
 def test_model_utils_ensures_id() -> None:

--- a/api/tests/opentrons/protocol_engine/resources/test_model_utils.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_model_utils.py
@@ -8,15 +8,30 @@ RE_UUID = re.compile(
 )
 
 
-def test_model_utils_generates_uuid() -> None:
+def test_model_utils_generates_fake_serial() -> None:
+    """It should generate a string that's visibly a fake serial number."""
+    result = ModelUtils().generate_fake_serial_number()
+    assert "fake-serial-number" in result
+    assert result != "fake-serial-number"
+
+
+def test_model_utils_generates_unique_fake_serial() -> None:
+    """Generated serial numbers should be unique."""
+    results = [ModelUtils().generate_id() for i in range(1000)]
+    unique_results = set(results)
+
+    assert len(results) == len(unique_results)
+
+
+def test_model_utils_generates_id() -> None:
     """It should generate a string matching a UUID."""
     result = ModelUtils().generate_id()
 
     assert RE_UUID.match(result)
 
 
-def test_model_utils_generates_unique() -> None:
-    """It should generate unique IDs."""
+def test_model_utils_generates_unique_id() -> None:
+    """Generated IDs should be unique."""
     results = [ModelUtils().generate_id() for i in range(1000)]
     unique_results = set(results)
 


### PR DESCRIPTION
# Overview

This PR resolves a `# todo` comment in Protocol Engine's execution handler.

Various places in Protocol Engine, including the HTTP-client–facing command results, expect every "loaded module" to have a serial number. When the engine is merely simulating commands instead of actually controlling hardware, it needs to populate these fields with something fake.

Formerly, this was a raw UUID like `00112233-4455-6677-8899-aabbccddeeff`. Now, it looks like `fake-serial-number-00112233-4455-6677-8899-aabbccddeeff`.

# Review requests

* Code review should be sufficient.
* Do we like this format?

# Risk assessment

Low. This is not used in production because protocol analysis currently still goes through APIv2, not Protocol Engine.
