### PR TITLE
fix(api): make opentrons_hardware not required

### DIFF
--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -37,7 +37,9 @@ jobs:
     name: 'opentrons package linting'
     timeout-minutes: 10
     runs-on: 'ubuntu-18.04'
-    with-ot-hardware: ['true', 'false']
+    strategy:
+      matrix:
+        with-ot-hardware: ['true', 'false']
     steps:
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'

--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -62,19 +62,19 @@ jobs:
         # preferably in a nightly cronjob on edge or something
         python: ['3.7', '3.10']
         with-ot-hardware: ['true', 'false']
-      exclude:
-        - os: 'windows-2019'
-          with-ot-hardware: 'true'
-        - os: 'macos-latest'
-          with-ot-hardware: 'true'
-        - python: '3.10'
-          with-ot-hardware: 'true'
-        - python: '3.7'
-          with-ot-hardware: 'true'
-      include:
-        - os: 'ubuntu-18.04'
-          with-ot-hardware: 'true'
-          python: '3.8'
+        exclude:
+          - os: 'windows-2019'
+            with-ot-hardware: 'true'
+          - os: 'macos-latest'
+            with-ot-hardware: 'true'
+          - python: '3.10'
+            with-ot-hardware: 'true'
+          - python: '3.7'
+            with-ot-hardware: 'true'
+        include:
+          - os: 'ubuntu-18.04'
+            with-ot-hardware: 'true'
+            python: '3.8'
     runs-on: '${{ matrix.os }}'
     steps:
       - uses: 'actions/checkout@v2'

--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -37,9 +37,6 @@ jobs:
     name: 'opentrons package linting'
     timeout-minutes: 10
     runs-on: 'ubuntu-18.04'
-    strategy:
-      matrix:
-        with-ot-hardware: ['true', 'false']
     steps:
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'
@@ -52,13 +49,7 @@ jobs:
       - uses: './.github/actions/python/setup'
         with:
           project: 'api'
-      - if: ${{ matrix.with-ot-hardware == 'false' }}
-        name: Lint without opentrons_hardware
-        run: |
-          make -C api setup-ot2
-          make -C api lint
-      - if: ${{ matrix.with-ot-hardware == 'true' }}
-        name: Lint with opentrons_hardware
+      - name: Lint with opentrons_hardware
         run: make -C api lint
   test:
     name: 'opentrons package tests on ${{ matrix.os }}, python ${{ matrix.python }}'

--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -69,12 +69,6 @@ jobs:
             with-ot-hardware: 'true'
           - python: '3.10'
             with-ot-hardware: 'true'
-          - python: '3.7'
-            with-ot-hardware: 'true'
-        include:
-          - os: 'ubuntu-18.04'
-            with-ot-hardware: 'true'
-            python: '3.8'
     runs-on: '${{ matrix.os }}'
     steps:
       - uses: 'actions/checkout@v2'

--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -62,6 +62,19 @@ jobs:
         # preferably in a nightly cronjob on edge or something
         python: ['3.7', '3.10']
         with-ot-hardware: ['true', 'false']
+      exclude:
+        - os: 'windows-2019'
+          with-ot-hardware: 'true'
+        - os: 'macos-latest'
+          with-ot-hardware: 'true'
+        - python: '3.10'
+          with-ot-hardware: 'true'
+        - python: '3.7'
+          with-ot-hardware: 'true'
+      include:
+        - os: 'ubuntu-18.04'
+          with-ot-hardware: 'true'
+          python: '3.8'
     runs-on: '${{ matrix.os }}'
     steps:
       - uses: 'actions/checkout@v2'

--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -37,6 +37,7 @@ jobs:
     name: 'opentrons package linting'
     timeout-minutes: 10
     runs-on: 'ubuntu-18.04'
+    with-ot-hardware: ['true', 'false']
     steps:
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'
@@ -49,7 +50,13 @@ jobs:
       - uses: './.github/actions/python/setup'
         with:
           project: 'api'
-      - name: Lint
+      - if: ${{ matrix.with-ot-hardware == 'false' }}
+        name: Lint without opentrons_hardware
+        run: |
+          make -C api setup-ot2
+          make -C api lint
+      - if: ${{ matrix.with-ot-hardware == 'true' }}
+        name: Lint with opentrons_hardware
         run: make -C api lint
   test:
     name: 'opentrons package tests on ${{ matrix.os }}, python ${{ matrix.python }}'
@@ -61,6 +68,7 @@ jobs:
         # TODO(mc, 2022-02-24): expand this matrix to 3.8 and 3.9,
         # preferably in a nightly cronjob on edge or something
         python: ['3.7', '3.10']
+        with-ot-hardware: ['true', 'false']
     runs-on: '${{ matrix.os }}'
     steps:
       - uses: 'actions/checkout@v2'
@@ -79,9 +87,16 @@ jobs:
       - uses: './.github/actions/python/setup'
         with:
           project: 'api'
-      - name: Test
+      - if: ${{ matrix.with-ot-hardware == 'false' }}
+        name: Test without opentrons_hardware
+        run: |
+          make -C api setup-ot2
+          make -C api test-ot2
+      - if: ${{ matrix.with-ot-hardware == 'true' }}
+        name: Test with opentrons_hardware
         run: make -C api test
-      - uses: 'codecov/codecov-action@v2'
+      - if: ${{ matrix.with-ot-hardware == 'true' }}
+        uses: 'codecov/codecov-action@v2'
         with:
           files: ./api/coverage.xml
           flags: api

--- a/.github/workflows/robot-server-lint-test.yaml
+++ b/.github/workflows/robot-server-lint-test.yaml
@@ -41,6 +41,9 @@ jobs:
     name: 'robot server package linting and tests'
     timeout-minutes: 20
     runs-on: 'ubuntu-18.04'
+    strategy:
+      matrix:
+        with-ot-hardware: ['true', 'false']
     steps:
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'
@@ -53,11 +56,25 @@ jobs:
       - uses: './.github/actions/python/setup'
         with:
           project: 'robot-server'
-      - name: Lint
-        run: make -C robot-server lint
-      - name: Test
+      - if: ${{ matrix.with-ot-hardware == 'false' }}
+        name: Lint without opentrons_hardware
+        run: |
+          make -C robot-server setup-ot2
+          make -C robot-server lint
+      - if: ${{ matrix.with-ot-hardware == 'true' }}
+        name: Lint with opentrons_hardware
+        run: |
+          make -C robot-server lint
+      - if: ${{ matrix.with-ot-hardware == 'false' }}
+        name: Test without opentrons_hardware
+        run: |
+          make -C robot-server setup-ot2
+          make -C robot-server test
+      - if: ${{ matrix.with-ot-hardware == 'true' }}
+        name: Test with opentrons_hardware
         run: make -C robot-server test
-      - uses: 'codecov/codecov-action@v2'
+      - if: ${{ matrix.with-ot-hardware == 'true' }}
+        uses: 'codecov/codecov-action@v2'
         with:
           files: ./robot-server/coverage.xml
           flags: robot-server

--- a/api/Makefile
+++ b/api/Makefile
@@ -107,6 +107,10 @@ sdist: $(sdist_file)
 test:
 	$(pytest) $(tests) $(test_opts)
 
+.PHONY: test-ot2
+test-ot2:
+	$(pytest) $(tests) $(test_opts) --ot2-only --ignore-glob="**/*ot3*"
+
 .PHONY: lint
 lint:
 	$(python) -m mypy src tests

--- a/api/Makefile
+++ b/api/Makefile
@@ -73,6 +73,12 @@ setup:
 	$(pipenv) sync $(pipenv_opts)
 	$(pipenv) run pip freeze
 
+.PHONY: setup-ot2
+setup-ot2:
+	$(pipenv) sync $(pipenv_opts)
+	$(pipenv) run pip uninstall -y opentrons_hardware
+	$(pipenv) run pip freeze
+
 .PHONY: clean
 clean: docs-clean
 	$(clean_cmd)

--- a/api/README.rst
+++ b/api/README.rst
@@ -81,3 +81,8 @@ Configuration
 -------------
 
 The module has a lot of configuration, some of which is only relevant when running on an actual robot, but some of which could be useful during simulation. When the module is first imported, it will try and write configuration files in ``~/.opentrons/config.json`` (``C:\Users\%USERNAME%\.opentrons\config.json`` on Windows). This contains mostly paths to other configuration files and directories, most of which will be in that folder. The location can be changed by setting the environment variable ``OT_API_CONFIG_DIR`` to another path. Inividual settings in the config file can be overridden by setting environment variables named like ``OT_API_${UPPERCASED_VAR_NAME}`` (for instance, to override the ``serial_log_file`` config element you could set the environment variable ``OT_API_SERIAL_LOG_FILE`` to a different path).
+
+Dealing With Robot Versions
+---------------------------
+
+The OT2 does not use the ``hardware`` subdirectory or the ``opentrons_hardware`` package. This can be a problem to work around. Please keep imports of ``opentrons_hardware`` to limited places inside the hardware_control submodule and tests of that submodule, and ensure that anything outside these safe areas conditionally imports ``opentrons_hardware`` or imports it inside a non-file scope in a place used only outside an OT2. In tests, any test that uses the OT3 hardware controller will be skipped in the ``test-ot2`` Makefile recipe.

--- a/api/README.rst
+++ b/api/README.rst
@@ -30,7 +30,7 @@ The Opentrons library has two purposes:
 Setting Up For Development
 --------------------------
 
-First, read the `top-level contributing guide section on setup <https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#environment-and-repository>`_. As that document states, once you have installed the prerequisites you can simply run ``make setup`` in this subdirectory.
+First, read the `top-level contributing guide section on setup <https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#environment-and-repository>`_. As that document states, once you have installed the prerequisites you can simply run ``make setup`` in this subdirectory. If you want to make the environment as it will be on an OT-2 specifically, run ``make setup-ot2``
 
 The only additional prerequisite concerns building documentation. If you want to build the PDF version of the documentation, you will need an installation of `LaTeX <https://www.latex-project.org/get/>`_ that includes the ``pdflatex`` tool. Note that if you don’t install this, everything will still work - you just won’t get the PDF documentation.
 

--- a/api/conftest.py
+++ b/api/conftest.py
@@ -1,0 +1,12 @@
+"""rootfile conftest - settings that must be in root."""
+import pytest
+
+# Options must be added at the root level for pytest to properly
+# pick them up. Technically, the main conftest that we use in
+# tests/opentrons is not the root level.
+def pytest_addoption(parser):
+    parser.addoption(
+        "--ot2-only",
+        action="store_true",
+        help="only run OT2 based tests",
+    )

--- a/api/src/opentrons/hardware_control/backends/__init__.py
+++ b/api/src/opentrons/hardware_control/backends/__init__.py
@@ -1,6 +1,7 @@
 from .controller import Controller
 from .simulator import Simulator
-from .ot3controller import OT3Controller
-from .ot3simulator import OT3Simulator
 
-__all__ = ["Controller", "Simulator", "OT3Controller", "OT3Simulator", "ot3utils"]
+# only expose the ot2 interfaces in __init__ so everything works if opentrons_hardware
+# is not present
+
+__all__ = ["Controller", "Simulator"]

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -35,7 +35,8 @@ from .pipette import (
     generate_hardware_configs_ot3,
     load_from_config_and_check_skip,
 )
-from .backends import OT3Controller, OT3Simulator
+from .backends.ot3controller import OT3Controller
+from .backends.ot3simulator import OT3Simulator
 from .execution_manager import ExecutionManagerProvider
 from .pause_manager import PauseManager
 from .module_control import AttachedModulesControl

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -35,7 +35,6 @@ from opentrons_shared_data.module.dev_types import ModuleDefinitionV2
 
 Protocol = namedtuple("Protocol", ["text", "filename", "filelike"])
 
-
 @pytest.fixture(autouse=True)
 def asyncio_loop_exception_handler(loop):
     def exception_handler(loop, context):
@@ -111,7 +110,11 @@ async def enable_door_safety_switch():
 
 
 @pytest.fixture
-async def enable_ot3_hardware_controller():
+async def enable_ot3_hardware_controller(request):
+    # this is from the command line parameters added in root conftest
+    if request.config.getoption("--ot2-only"):
+        pytest.skip("testing only ot2")
+
     await config.advanced_settings.set_adv_setting("enableOT3HardwareController", True)
     yield
     await config.advanced_settings.set_adv_setting("enableOT3HardwareController", False)
@@ -150,9 +153,9 @@ def virtual_smoothie_env(monkeypatch):
     params=["ot2", "ot3"],
 )
 async def machine_variant_ffs(request, loop):
-    if request.node.get_closest_marker("ot2_only") and request.param == "ot2":
+    if request.node.get_closest_marker("ot3_only") and request.param == "ot2":
         pytest.skip()
-    if request.node.get_closest_marker("ot3_only") and request.param == "ot3":
+    if request.node.get_closest_marker("ot2_only") and request.param == "ot3":
         pytest.skip()
 
     old = config.advanced_settings.get_adv_setting("enableOT3HardwareController")
@@ -200,6 +203,9 @@ async def _build_ot3_hw() -> AsyncIterator[ThreadManager[HardwareControlAPI]]:
 
 @pytest.fixture
 async def ot3_hardware(request, loop, enable_ot3_hardware_controller):
+    # this is from the command line parameters added in root conftest
+    if request.config.getoption("--ot2-only"):
+        pytest.skip("testing only ot2")
     async for hw in _build_ot3_hw():
         yield hw
 
@@ -215,6 +221,8 @@ async def hardware(request, loop, virtual_smoothie_env):
         pytest.skip()
     if request.node.get_closest_marker("ot3_only") and request.param() == _build_ot2_hw:
         pytest.skip()
+    if request.param() == _build_ot3_hw and request.config.getoption("--ot2-only"):
+        pytest.skip("testing only ot2")
 
     # param() return a function we have to call
     async for hw in request.param()():

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -187,6 +187,7 @@ async def ot2_hardware(request, loop, virtual_smoothie_env):
 
 async def _build_ot3_hw() -> AsyncIterator[ThreadManager[HardwareControlAPI]]:
     from opentrons.hardware_control.ot3api import OT3API
+
     hw_sim = ThreadManager(OT3API.build_hardware_simulator)
     old_config = config.robot_configs.load()
     try:

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -26,7 +26,6 @@ import pytest
 from opentrons import config
 from opentrons import hardware_control as hc
 from opentrons.hardware_control import HardwareControlAPI, API, ThreadManager
-from opentrons.hardware_control.ot3api import OT3API
 from opentrons.protocol_api import ProtocolContext
 from opentrons.types import Location, Point
 
@@ -187,6 +186,7 @@ async def ot2_hardware(request, loop, virtual_smoothie_env):
 
 
 async def _build_ot3_hw() -> AsyncIterator[ThreadManager[HardwareControlAPI]]:
+    from opentrons.hardware_control.ot3api import OT3API
     hw_sim = ThreadManager(OT3API.build_hardware_simulator)
     old_config = config.robot_configs.load()
     try:

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -35,6 +35,7 @@ from opentrons_shared_data.module.dev_types import ModuleDefinitionV2
 
 Protocol = namedtuple("Protocol", ["text", "filename", "filelike"])
 
+
 @pytest.fixture(autouse=True)
 def asyncio_loop_exception_handler(loop):
     def exception_handler(loop, context):

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -1,6 +1,6 @@
 import pytest
 from mock import AsyncMock, patch
-from opentrons.hardware_control.backends import OT3Controller
+from opentrons.hardware_control.backends.ot3controller import OT3Controller
 from opentrons_hardware.drivers.can_bus import CanMessenger
 from opentrons.config.types import OT3Config
 from opentrons.config.robot_configs import build_config_ot3

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -8,8 +8,7 @@ except (OSError, ModuleNotFoundError):
 import typeguard
 from opentrons import types
 from opentrons.hardware_control import API
-from opentrons.hardware_control.ot3api import OT3API
-from opentrons.hardware_control.types import Axis, OT3Mount
+from opentrons.hardware_control.types import Axis
 from opentrons.hardware_control.dev_types import PipetteDict
 
 
@@ -17,51 +16,63 @@ LEFT_PIPETTE_PREFIX = "p10_single"
 LEFT_PIPETTE_MODEL = "{}_v1".format(LEFT_PIPETTE_PREFIX)
 LEFT_PIPETTE_ID = "testy"
 
-dummy_instruments_attached = {
-    types.Mount.LEFT: {
-        "model": LEFT_PIPETTE_MODEL,
-        "id": LEFT_PIPETTE_ID,
-        "name": LEFT_PIPETTE_PREFIX,
-    },
-    types.Mount.RIGHT: {
-        "model": None,
-        "id": None,
-        "name": None,
-    },
-}
+def dummy_instruments_attached():
+    return {
+        types.Mount.LEFT: {
+            "model": LEFT_PIPETTE_MODEL,
+            "id": LEFT_PIPETTE_ID,
+            "name": LEFT_PIPETTE_PREFIX,
+        },
+        types.Mount.RIGHT: {
+            "model": None,
+            "id": None,
+            "name": None,
+        },
+    }
 
 
 @pytest.fixture
 def dummy_instruments():
-    return dummy_instruments_attached
+    return dummy_instruments_attached()
 
 
-dummy_instruments_attached_ot3 = {
-    OT3Mount.LEFT: {
-        "model": "p1000_single_v3.0",
-        "id": "testy",
-        "name": "p1000_single_gen3",
-    },
-    OT3Mount.RIGHT: {"model": None, "id": None, "name": None},
-}
+def dummy_instruments_attached_ot3():
+    return {
+        types.Mount.LEFT: {
+            "model": "p1000_single_v3.0",
+            "id": "testy",
+            "name": "p1000_single_gen3",
+        },
+        types.Mount.RIGHT: {"model": None, "id": None, "name": None},
+    }
 
 
 @pytest.fixture
 def dummy_instruments_ot3():
-    return dummy_instruments_attached_ot3
+    return dummy_instruments_attached_ot3()
 
+def wrap_build_ot3_sim():
+    from opentrons.hardware_control.ot3api import OT3API
+    return OT3API.build_hardware_simulator
+
+@pytest.fixture
+def ot3_api_obj(request):
+    if request.config.getoption("--ot2-only"):
+        pytest.skip("testing ot2 only")
+    from opentrons.hardware_control.ot3api import OT3API
+    return OT3API.build_hardware_simulator
 
 @pytest.fixture(
     params=[
-        (API.build_hardware_simulator, dummy_instruments_attached),
-        (OT3API.build_hardware_simulator, dummy_instruments_attached_ot3),
+        (lambda: API.build_hardware_simulator, dummy_instruments_attached),
+        (wrap_build_ot3_sim, dummy_instruments_attached_ot3),
     ],
     ids=["ot2", "ot3"],
 )
 def sim_and_instr(request):
     if (
         request.node.get_closest_marker("ot2_only")
-        and request.param[0] == OT3API.build_hardware_simulator
+        and request.param[0] == wrap_build_ot3_sim
     ):
         pytest.skip()
     if (
@@ -69,8 +80,10 @@ def sim_and_instr(request):
         and request.param[0] == API.build_hardware_simulator
     ):
         pytest.skip()
+    if request.param[0] == wrap_build_ot3_sim and request.config.getoption("--ot2-only"):
+        pytest.skip("testing ot2 only")
 
-    yield request.param
+    yield (request.param[0](), request.param[1]())
 
 
 @pytest.fixture
@@ -326,8 +339,8 @@ async def test_aspirate_old(dummy_instruments, loop, old_aspiration):
     assert pos[Axis.B] == new_plunger_pos
 
 
-async def test_aspirate_ot3(dummy_instruments_ot3, loop):
-    hw_api = await OT3API.build_hardware_simulator(
+async def test_aspirate_ot3(dummy_instruments_ot3, ot3_api_obj, loop):
+    hw_api = await ot3_api_obj(
         attached_instruments=dummy_instruments_ot3, loop=loop
     )
     await hw_api.home()
@@ -371,8 +384,8 @@ async def test_dispense_ot2(dummy_instruments, loop):
     assert (await hw_api.current_position(mount))[Axis.B] == plunger_pos_2
 
 
-async def test_dispense_ot3(dummy_instruments_ot3, loop):
-    hw_api = await OT3API.build_hardware_simulator(
+async def test_dispense_ot3(dummy_instruments_ot3, ot3_api_obj, loop):
+    hw_api = await ot3_api_obj(
         attached_instruments=dummy_instruments_ot3, loop=loop
     )
     await hw_api.home()

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -16,6 +16,7 @@ LEFT_PIPETTE_PREFIX = "p10_single"
 LEFT_PIPETTE_MODEL = "{}_v1".format(LEFT_PIPETTE_PREFIX)
 LEFT_PIPETTE_ID = "testy"
 
+
 def dummy_instruments_attached():
     return {
         types.Mount.LEFT: {
@@ -51,16 +52,21 @@ def dummy_instruments_attached_ot3():
 def dummy_instruments_ot3():
     return dummy_instruments_attached_ot3()
 
+
 def wrap_build_ot3_sim():
     from opentrons.hardware_control.ot3api import OT3API
+
     return OT3API.build_hardware_simulator
+
 
 @pytest.fixture
 def ot3_api_obj(request):
     if request.config.getoption("--ot2-only"):
         pytest.skip("testing ot2 only")
     from opentrons.hardware_control.ot3api import OT3API
+
     return OT3API.build_hardware_simulator
+
 
 @pytest.fixture(
     params=[
@@ -80,7 +86,9 @@ def sim_and_instr(request):
         and request.param[0] == API.build_hardware_simulator
     ):
         pytest.skip()
-    if request.param[0] == wrap_build_ot3_sim and request.config.getoption("--ot2-only"):
+    if request.param[0] == wrap_build_ot3_sim and request.config.getoption(
+        "--ot2-only"
+    ):
         pytest.skip("testing ot2 only")
 
     yield (request.param[0](), request.param[1]())
@@ -340,9 +348,7 @@ async def test_aspirate_old(dummy_instruments, loop, old_aspiration):
 
 
 async def test_aspirate_ot3(dummy_instruments_ot3, ot3_api_obj, loop):
-    hw_api = await ot3_api_obj(
-        attached_instruments=dummy_instruments_ot3, loop=loop
-    )
+    hw_api = await ot3_api_obj(attached_instruments=dummy_instruments_ot3, loop=loop)
     await hw_api.home()
     await hw_api.cache_instruments()
 
@@ -385,9 +391,7 @@ async def test_dispense_ot2(dummy_instruments, loop):
 
 
 async def test_dispense_ot3(dummy_instruments_ot3, ot3_api_obj, loop):
-    hw_api = await ot3_api_obj(
-        attached_instruments=dummy_instruments_ot3, loop=loop
-    )
+    hw_api = await ot3_api_obj(attached_instruments=dummy_instruments_ot3, loop=loop)
     await hw_api.home()
 
     await hw_api.cache_instruments()

--- a/notify-server/Makefile
+++ b/notify-server/Makefile
@@ -57,6 +57,12 @@ setup:
 	$(pipenv) sync $(pipenv_opts)
 	$(pipenv) run pip freeze
 
+.PHONY: setup-ot2
+setup-ot2:
+	$(pipenv) sync $(pipenv_opts)
+	$(pipenv) run pip uninstall -y opentrons_hardware
+	$(pipenv) run pip freeze
+
 .PHONY: clean
 clean:
 	$(clean_cmd)

--- a/notify-server/README.rst
+++ b/notify-server/README.rst
@@ -11,6 +11,7 @@ Development Environment
 -----------------------------------
 - `pipenv <https://github.com/pypa/pipenv>`_ is the package manager.
 - ``make setup`` will setup the project.
+- ``make setup-ot2`` will setup the project as it is on the OT2.
 - ``make test`` will run the unit tests.
 - ``make lint`` will run type checking and linting.
 - ``make dev`` will run the server application locally in dev mode.

--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -66,6 +66,12 @@ setup:
 	$(pipenv) sync $(pipenv_opts)
 	$(pipenv) run pip freeze
 
+.PHONY: setup-ot2
+setup-ot2:
+	$(pipenv) sync $(pipenv_opts)
+	$(pipenv) run pip uninstall -y opentrons_hardware
+	$(pipenv) run pip freeze
+
 .PHONY: clean
 clean:
 	$(clean_cmd)

--- a/robot-server/README.rst
+++ b/robot-server/README.rst
@@ -17,7 +17,7 @@ This document is about the structure and purpose of the source code of the HTTP 
 Setting Up For Development
 --------------------------
 
-First, read the `top-level contributing guide section on setup <https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#environment-and-repository>`_. As that document states, once you have installed the prerequisites you can simply run ``make setup`` in this subdirectory.
+First, read the `top-level contributing guide section on setup <https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#environment-and-repository>`_. As that document states, once you have installed the prerequisites you can simply run ``make setup`` in this subdirectory. If you want to have only the dependencies used for the ot2, run ``make setup-ot2``.
 
 
 Configuration

--- a/robot-server/tests/service/notifications/test_handle_subscriber.py
+++ b/robot-server/tests/service/notifications/test_handle_subscriber.py
@@ -17,7 +17,9 @@ def mock_socket() -> MagicMock:
 async def test_create_subscriber(mock_socket: MagicMock) -> None:
     """Test that a subscriber is created correctly."""
     # Why two patch calls? `create` is the name of an arg to `patch.multiple`.
-    with patch('robot_server.service.notifications.handle_subscriber.create') as mock_create:
+    with patch(
+        "robot_server.service.notifications.handle_subscriber.create"
+    ) as mock_create:
         with patch.multiple(
             handle_subscriber, route_events=DEFAULT, receive=DEFAULT
         ) as values:

--- a/robot-server/tests/service/notifications/test_handle_subscriber.py
+++ b/robot-server/tests/service/notifications/test_handle_subscriber.py
@@ -17,7 +17,7 @@ def mock_socket() -> MagicMock:
 async def test_create_subscriber(mock_socket: MagicMock) -> None:
     """Test that a subscriber is created correctly."""
     # Why two patch calls? `create` is the name of an arg to `patch.multiple`.
-    with patch.object(handle_subscriber, "create") as mock_create:
+    with patch('robot_server.service.notifications.handle_subscriber.create') as mock_create:
         with patch.multiple(
             handle_subscriber, route_events=DEFAULT, receive=DEFAULT
         ) as values:


### PR DESCRIPTION
The OT2 doesn't have opentrons_hardware installed - that's only an OT3
thing. We have a responsibility to make that actually function. This
setup wasn't actually being tested.

This commit adds
- New makefile targets to "setup-ot2" in relevant python subprojects by
running a pipenv sync and then removing opentrons_hardware from the
virtualenv. This is not good, but absent being able to have separate
pipfiles it seems like the best fix available.
- Github workflow entries to lint and test under these conditions. This
is also not good because it will make these tests take longer, but same
thing about the conditions.

To be truly optional, it must be possible to import opentrons without
the ot3 feature flag set and not ever need opentrons_hardware. That was
mostly true, but there were some exceptions (default re-exports) that
needed to be updated.

To cut down on the absolute number of tests needed, since we don't ship `opentrons_hardware` to pypi, we now only test cross version and cross os without `opentrons_hardware`. With `opentrons_hardware`, we also just test python3.8, which is what's on the new machine.