### PR TITLE
feat(hardware): can monitor script

### DIFF
--- a/hardware/README.md
+++ b/hardware/README.md
@@ -50,7 +50,6 @@ Example: `opentrons_sim_can_bus --port 12345`
 
 The `opentrons-hardware` package includes some utility scripts.
 
-
 ### opentrons_can_comm
 
 This is a tool for sending messages to firmware (or simulator) over CAN bus. The CAN bus can either be a [python-can](https://python-can.readthedocs.io/en/master/interfaces.html) defined interface or `opentrons`.

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -50,6 +50,7 @@ Example: `opentrons_sim_can_bus --port 12345`
 
 The `opentrons-hardware` package includes some utility scripts.
 
+
 ### opentrons_can_comm
 
 This is a tool for sending messages to firmware (or simulator) over CAN bus. The CAN bus can either be a [python-can](https://python-can.readthedocs.io/en/master/interfaces.html) defined interface or `opentrons`.
@@ -68,6 +69,14 @@ On Linux using socketcan: `opentrons_can_comm --interface socketcan --channel vc
 On Mac using pcan: `opentrons_can_comm --interface pcan --channel PCAN_USBBUS1 --bitrate 250000`
 
 Example using opentrons' CAN over socket: `opentrons_can_comm --interface opentrons_sock`
+
+### opentrons_can_mon
+
+A monitor on the CAN bus. It prints out the contents of messages received on the CAN bus.
+
+#### Usage
+
+The usage is the same as `opentrons_can_comm`.
 
 ### opentrons_update_fw
 

--- a/hardware/opentrons_hardware/scripts/can_comm.py
+++ b/hardware/opentrons_hardware/scripts/can_comm.py
@@ -1,4 +1,4 @@
-"""A script for sending and monitoring CAN messages."""
+"""A script for sending CAN messages."""
 import asyncio
 import dataclasses
 import logging
@@ -38,29 +38,6 @@ class InvalidInput(Exception):
     """Invalid input exception."""
 
     pass
-
-
-async def listen_task(can_driver: AbstractCanDriver) -> None:
-    """A task that listens for can messages.
-
-    Args:
-        can_driver: Driver
-
-    Returns: Nothing.
-
-    """
-    async for message in can_driver:
-        message_definition = get_definition(
-            MessageId(message.arbitration_id.parts.message_id)
-        )
-        if message_definition:
-            try:
-                build = message_definition.payload_type.build(message.data)
-                log.info(f"Received <-- \n\traw: {message}, " f"\n\tparsed: {build}")
-            except BinarySerializableException:
-                log.exception(f"Failed to build from {message}")
-        else:
-            log.info(f"Received <-- \traw: {message}")
 
 
 def create_choices(enum_type: Type[Enum]) -> Sequence[str]:
@@ -189,9 +166,7 @@ async def run(args: argparse.Namespace) -> None:
     driver = await build_driver(build_settings(args))
 
     loop = asyncio.get_event_loop()
-    fut = asyncio.gather(
-        loop.create_task(listen_task(driver)), loop.create_task(ui_task(driver))
-    )
+    fut = loop.create_task(ui_task(driver))
     try:
         await fut
     except KeyboardInterrupt:

--- a/hardware/opentrons_hardware/scripts/can_mon.py
+++ b/hardware/opentrons_hardware/scripts/can_mon.py
@@ -1,0 +1,107 @@
+"""A script for monitoring CAN bus."""
+import asyncio
+import dataclasses
+import logging
+import argparse
+from datetime import datetime
+from logging.config import dictConfig
+
+from opentrons_hardware.drivers.can_bus.can_messenger import (
+    CanMessenger,
+    WaitableCallback,
+)
+from opentrons_hardware.firmware_bindings.constants import (
+    MessageId,
+    NodeId,
+)
+
+from opentrons_hardware.drivers.can_bus.build import build_driver
+from opentrons_hardware.scripts.can_args import add_can_args, build_settings
+
+log = logging.getLogger(__name__)
+
+
+async def task(messenger: CanMessenger) -> None:
+    """A task that listens for can messages.
+
+    Args:
+        messenger: Messenger
+
+    Returns: Nothing.
+    """
+    label_style = "\033[0;37;40m"
+    header_style = "\033[0;36;40m"
+    data_style = "\033[1;36;40m"
+    with WaitableCallback(messenger) as cb:
+        async for message, arbitration_id in cb:
+            try:
+                msg_name = MessageId(arbitration_id.parts.message_id).name
+                from_node = NodeId(arbitration_id.parts.originating_node_id).name
+                to_node = NodeId(arbitration_id.parts.node_id).name
+                arb_id_str = f"{data_style}{msg_name} ({from_node}->{to_node})"
+            except ValueError:
+                arb_id_str = f"{data_style}0x{arbitration_id.id:x}"
+            print(f"{header_style}{datetime.now()} {arb_id_str}")
+            for name, value in dataclasses.asdict(message.payload).items():
+                print(f"\t{label_style}{name}: {data_style}{value}")
+
+
+async def run(args: argparse.Namespace) -> None:
+    """Entry point for script."""
+    driver = await build_driver(build_settings(args))
+
+    messenger = CanMessenger(driver)
+    messenger.start()
+
+    loop = asyncio.get_event_loop()
+    fut = loop.create_task(task(messenger))
+    try:
+        await fut
+    except KeyboardInterrupt:
+        fut.cancel()
+    except asyncio.CancelledError:
+        pass
+    finally:
+        await messenger.stop()
+        driver.shutdown()
+
+
+LOG_CONFIG = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "basic": {"format": "%(asctime)s %(name)s %(levelname)s %(message)s"}
+    },
+    "handlers": {
+        "file_handler": {
+            "class": "logging.handlers.RotatingFileHandler",
+            "formatter": "basic",
+            "filename": "can_mon.log",
+            "maxBytes": 5000000,
+            "level": logging.INFO,
+            "backupCount": 3,
+        },
+    },
+    "loggers": {
+        "": {
+            "handlers": ["file_handler"],
+            "level": logging.INFO,
+        },
+    },
+}
+
+
+def main() -> None:
+    """Entry point."""
+    dictConfig(LOG_CONFIG)
+
+    parser = argparse.ArgumentParser(description="CAN bus monitoring.")
+    add_can_args(parser)
+
+    args = parser.parse_args()
+
+    asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/hardware/setup.py
+++ b/hardware/setup.py
@@ -83,6 +83,7 @@ if __name__ == "__main__":
             "console_scripts": [
                 "opentrons_update_fw = opentrons_hardware.scripts.update_fw:main",
                 "opentrons_can_comm = opentrons_hardware.scripts.can_comm:main",
+                "opentrons_can_mon = opentrons_hardware.scripts.can_mon:main",
                 "opentrons_sim_can_bus = opentrons_hardware.scripts.sim_socket_can:main",  # noqa: E501
             ]
         },


### PR DESCRIPTION
# Overview

Rather than relying on the logging produced by `can_comm`, this adds `can_mon` which will monitor the can bus and prettily print out messages.

# Changelog

`can_comm` no longer reads messages. It just send em.
Added `can_mon` to read messages and print em out.

# Review requests

Example Output:

```
2022-03-02 11:27:44.617625 device_info_request (host->broadcast)
2022-03-02 11:27:44.618151 device_info_response (head->host)
	version: UInt32Field(value=0)
2022-03-02 11:27:53.829933 fw_update_status_request (host->broadcast)
2022-03-02 11:27:53.830493 fw_update_status_response (head->host)
	flags: UInt32Field(value=0)
```


# Risk assessment

None
