### PR TITLE
feat(hardware): task info

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -50,6 +50,8 @@ class MessageId(int, Enum):
 
     device_info_request = 0x302
     device_info_response = 0x303
+    task_info_request = 0x304
+    task_info_response = 0x305
 
     stop_request = 0x00
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -38,6 +38,20 @@ class DeviceInfoResponse:  # noqa: D101
 
 
 @dataclass
+class TaskInfoRequest:  # noqa: D101
+    payload: payloads.EmptyPayload
+    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+    message_id: Literal[MessageId.task_info_request] = MessageId.task_info_request
+
+
+@dataclass
+class TaskInfoResponse:  # noqa: D101
+    payload: payloads.TaskInfoResponsePayload
+    payload_type: Type[BinarySerializable] = payloads.TaskInfoResponsePayload
+    message_id: Literal[MessageId.task_info_response] = MessageId.task_info_response
+
+
+@dataclass
 class StopRequest:  # noqa: D101
     payload: payloads.EmptyPayload
     payload_type: Type[BinarySerializable] = payloads.EmptyPayload

--- a/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
@@ -12,6 +12,8 @@ MessageDefinition = Union[
     defs.HeartbeatResponse,
     defs.DeviceInfoRequest,
     defs.DeviceInfoResponse,
+    defs.TaskInfoRequest,
+    defs.TaskInfoResponse,
     defs.StopRequest,
     defs.GetStatusRequest,
     defs.GetStatusResponse,

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -21,6 +21,24 @@ class DeviceInfoResponsePayload(utils.BinarySerializable):
     version: utils.UInt32Field
 
 
+class TaskNameDataField(utils.BinaryFieldBase[bytes]):
+    """The name field of TaskInfoResponsePayload."""
+
+    NUM_BYTES = 12
+    FORMAT = f"{NUM_BYTES}s"
+
+
+@dataclass
+class TaskInfoResponsePayload(utils.BinarySerializable):
+    """Task info response payload."""
+    name: TaskNameDataField
+    runtime_counter: utils.UInt32Field
+    stack_high_water_mark: utils.UInt32Field
+    state: utils.UInt16Field
+    priority: utils.UInt16Field
+
+
+
 @dataclass
 class GetStatusResponsePayload(utils.BinarySerializable):
     """Get status response."""

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -31,12 +31,12 @@ class TaskNameDataField(utils.BinaryFieldBase[bytes]):
 @dataclass
 class TaskInfoResponsePayload(utils.BinarySerializable):
     """Task info response payload."""
+
     name: TaskNameDataField
     runtime_counter: utils.UInt32Field
     stack_high_water_mark: utils.UInt32Field
     state: utils.UInt16Field
     priority: utils.UInt16Field
-
 
 
 @dataclass

--- a/hardware/opentrons_hardware/scripts/can_comm.py
+++ b/hardware/opentrons_hardware/scripts/can_comm.py
@@ -42,6 +42,7 @@ class InvalidInput(Exception):
 
 async def listen_task(can_driver: AbstractCanDriver) -> None:
     """A task that listens for can messages.
+
     Args:
         can_driver: Driver
     Returns: Nothing.


### PR DESCRIPTION
# Overview

Support task info request / response messages. A companion to https://github.com/Opentrons/ot3-firmware/pull/268

# Changelog

- Define schemas and ids for `TaskInfoRequest` and `TaskInfoResponse`.
- Also, return message reading task to can_comm. It was foolish to remove it when adding `can_mon`. The CAN analyzer cannot be opened by more than one device at a time. Duh.

# Review requests


# Risk assessment

None