### PR TITLE
fix(api): lowercase filename before checking extension in ProtocolReader

### DIFF
--- a/api/src/opentrons/protocol_reader/config_analyzer.py
+++ b/api/src/opentrons/protocol_reader/config_analyzer.py
@@ -41,7 +41,7 @@ class ConfigAnalyzer:
 
 # todo(mm, 2021-09-13): Deduplicate with opentrons.protocols.parse.
 def _analyze_python(main_file: RoleAnalysisFile) -> ConfigAnalysis:  # noqa: C901
-    assert main_file.name.endswith(".py"), "Expected main_file to be Python"
+    assert main_file.name.lower().endswith(".py"), "Expected main_file to be Python"
 
     try:
         # todo(mm, 2021-09-13): Investigate whether it's really appropriate to leave

--- a/api/src/opentrons/protocol_reader/file_reader_writer.py
+++ b/api/src/opentrons/protocol_reader/file_reader_writer.py
@@ -47,7 +47,7 @@ class FileReaderWriter:
                 contents = await f.read()
                 data: Optional[BufferedJsonFileData] = None
 
-                if input_file.filename.endswith(".json"):
+                if input_file.filename.lower().endswith(".json"):
                     try:
                         data = parse_raw_as(BufferedJsonFileData, contents)  # type: ignore[arg-type]  # noqa: E501
 

--- a/api/src/opentrons/protocol_reader/role_analyzer.py
+++ b/api/src/opentrons/protocol_reader/role_analyzer.py
@@ -58,7 +58,7 @@ class RoleAnalyzer:
         labware_files = []
 
         for f in files:
-            if f.name.endswith(".py") or isinstance(f.data, JsonProtocol):
+            if f.name.lower().endswith(".py") or isinstance(f.data, JsonProtocol):
                 data = f.data if isinstance(f.data, JsonProtocol) else None
                 main_file_candidates.append(
                     MainFile(name=f.name, contents=f.contents, data=data)

--- a/api/tests/opentrons/protocol_reader/test_config_analyzer.py
+++ b/api/tests/opentrons/protocol_reader/test_config_analyzer.py
@@ -117,6 +117,25 @@ CONFIG_ANALYZER_SPECS: List[ConfigAnalyzerSpec] = [
             config=JsonProtocolConfig(schema_version=3),
         ),
     ),
+    ConfigAnalyzerSpec(
+        main_file=RoleAnalysisFile(
+            name="protocol.PY",
+            data=None,
+            role=ProtocolFileRole.MAIN,
+            contents=textwrap.dedent(
+                """
+                metadata = {
+                    "author": "Dr. Sy. N. Tist",
+                    "apiLevel": "123.456",
+                }
+                """
+            ).encode(),
+        ),
+        expected=ConfigAnalysis(
+            metadata={"author": "Dr. Sy. N. Tist", "apiLevel": "123.456"},
+            config=PythonProtocolConfig(api_version=APIVersion(123, 456)),
+        ),
+    ),
 ]
 
 

--- a/api/tests/opentrons/protocol_reader/test_file_reader_writer.py
+++ b/api/tests/opentrons/protocol_reader/test_file_reader_writer.py
@@ -35,7 +35,7 @@ async def test_read() -> None:
 async def test_read_opentrons_json() -> None:
     """It should read and parse Opentrons JSON protocol/labware file-likes."""
     file_1 = InputFile(filename="hello.json", file=io.BytesIO(SIMPLE_V5_JSON_PROTOCOL))
-    file_2 = InputFile(filename="world.json", file=io.BytesIO(SIMPLE_LABWARE_DEF))
+    file_2 = InputFile(filename="world.JSON", file=io.BytesIO(SIMPLE_LABWARE_DEF))
 
     subject = FileReaderWriter()
     result = await subject.read([file_1, file_2])
@@ -47,7 +47,7 @@ async def test_read_opentrons_json() -> None:
             data=matchers.Anything(),
         ),
         BufferedFile(
-            name="world.json",
+            name="world.JSON",
             contents=SIMPLE_LABWARE_DEF,
             data=matchers.Anything(),
         ),

--- a/api/tests/opentrons/protocol_reader/test_role_analyzer.py
+++ b/api/tests/opentrons/protocol_reader/test_role_analyzer.py
@@ -122,6 +122,16 @@ ROLE_ANALYZER_SPECS: List[RoleAnalyzerSpec] = [
             ],
         ),
     ),
+    RoleAnalyzerSpec(
+        files=[
+            BufferedFile(name="PROTOCOL.PY", contents=b"", data=None),
+        ],
+        expected=RoleAnalysis(
+            main_file=MainFile(name="PROTOCOL.PY", contents=b""),
+            labware_files=[],
+            labware_definitions=[],
+        ),
+    ),
 ]
 
 


### PR DESCRIPTION
## Overview

Fix for a bug @nusrat813 found during release testing. The `ProtocolReader` interface was not accounting for uppercase file extensions 🤦 

## Changelog

- fix(api): lowercase filename before checking extension in ProtocolReader

## Review requests

- [ ] Can upload file with uppercase `.py` extension
- [ ] Can upload files with uppercase `.json` extension

## Risk assessment

Very low. Adding/adjusting unit tests to cover this functionality was trivial