### PR TITLE
fix(app): show labware def display name in lpc summary screen, fix nested lw render 

### DIFF
--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/StepDetailText.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/StepDetailText.tsx
@@ -30,8 +30,9 @@ export const StepDetailText = (
   ] = React.useState<boolean>(false)
   if (protocolData == null) return null
   const labwareDefId = protocolData.labware[labwareId].definitionId
-  const displayName =
-    protocolData.labwareDefinitions[labwareDefId].metadata.displayName
+  const labwareDef = protocolData.labwareDefinitions[labwareDefId]
+  const { displayName } = labwareDef.metadata
+  const { isTiprack } = labwareDef.parameters
 
   return (
     <React.Fragment>
@@ -48,7 +49,7 @@ export const StepDetailText = (
         <Trans
           t={t}
           i18nKey={
-            displayName.includes('Tip Rack')
+            isTiprack
               ? 'labware_step_detail_tiprack'
               : 'labware_step_detail_labware'
           }

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/SummaryScreen.tsx
@@ -41,7 +41,7 @@ export const SummaryScreen = (props: {
       labwareOffsets.length === 0 && setLabwareOffsets(offsets)
     })
     .catch((e: Error) =>
-      console.error(`error getting labware offsetsL ${e.message}`)
+      console.error(`error getting labware offsets: ${e.message}`)
     )
   const { createLabwareOffset } = useCreateLabwareOffsetMutation()
   const runId = useCurrentRunId()

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
@@ -88,7 +88,7 @@ describe('SummaryScreen', () => {
           labware: {
             '1d57fc10-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_96_filtertiprack_200ul/1': {
               slot: '1',
-              displayName: 'someDislpayName',
+              displayName: 'someDisplayName',
               definitionId: LABWARE_DEF_ID,
             },
           },

--- a/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/useLabwareOffsets.ts
+++ b/app/src/organisms/ProtocolSetup/LabwarePositionCheck/hooks/useLabwareOffsets.ts
@@ -2,6 +2,7 @@ import reduce from 'lodash/reduce'
 import { useTranslation, TFunction } from 'react-i18next'
 import {
   getModuleDisplayName,
+  getLabwareDisplayName,
   getModuleType,
   ProtocolFile,
   THERMOCYCLER_MODULE_TYPE,
@@ -79,7 +80,10 @@ export const useLabwareOffsets = (
         protocolData.labware,
         protocolData.labwareDefinitions
       )
-      const displayName = protocolData.labware[labwareId].displayName ?? ''
+      const { definitionId } = protocolData.labware[labwareId]
+      const displayName = getLabwareDisplayName(
+        protocolData.labwareDefinitions[definitionId]
+      )
       const vectorPromise = offsetDataByLabwareId.then(result => ({
         ...result[labwareId],
       }))

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
@@ -194,9 +194,7 @@ export const LabwareSetup = (): JSX.Element | null => {
                           : {}
                       }
                     >
-                      {nestedLabwareDef != null &&
-                      nestedLabwareId != null &&
-                      nestedLabwareDisplayName ? (
+                      {nestedLabwareDef != null && nestedLabwareId != null ? (
                         <React.Fragment
                           key={`LabwareSetup_Labware_${nestedLabwareDef.metadata.displayName}_${x}${y}`}
                         >


### PR DESCRIPTION
# Overview

- In the LPC summary screen, show labware definition display names in the offset table, instead of user defined nicknames (which are optional)
- remove buggy conditional that wasn't rendering nested labware on the Labware Setup if there was no user display name set
- use `isTiprack` boolean from definition parameters to switch on Step Detail Text

# Review requests

- upload a protocol with a module and a nested labware, that labware should render correctly on the labware setup step
- complete the Labware Position Check, the summary screen should correctly display labware definition display names in the labware column of the offset data table.

# Risk assessment
low