### PR TITLE
fix(app): do not pass `directionControlButtonColor` into DOM

### DIFF
--- a/app/src/molecules/JogControls/index.tsx
+++ b/app/src/molecules/JogControls/index.tsx
@@ -34,10 +34,11 @@ export { HORIZONTAL_PLANE, VERTICAL_PLANE }
 
 export function JogControls(props: JogControlsProps): JSX.Element {
   const {
+    jog,
     isLPC,
+    directionControlButtonColor,
     stepSizes = DEFAULT_STEP_SIZES,
     planes = [HORIZONTAL_PLANE, VERTICAL_PLANE],
-    jog,
     auxiliaryControl = null,
     ...styleProps
   } = props
@@ -62,7 +63,7 @@ export function JogControls(props: JogControlsProps): JSX.Element {
           plane={plane}
           jog={jog}
           stepSize={currentStepSize}
-          buttonColor={props.directionControlButtonColor}
+          buttonColor={directionControlButtonColor}
         />
       ))}
       {auxiliaryControl}


### PR DESCRIPTION
## Overview

Tiny fix found during LPC testing. A component in the JogControls component was erroneously passing one of our custom props straight into the DOM, causing React to barf out a big error message.

## Changelog

- fix(app): do not pass `directionControlButtonColor` into DOM

## Review requests

I smoke tested this by checking:

- [ ] Jog buttons in LPC still worked
- [ ] No React errors in console when rendering jog controls

## Risk assessment

Very low
