### PR TITLE
refactor(app): use correct icon name for heater shaker

### DIFF
--- a/app/src/organisms/Devices/HeaterShakerWizard/HeaterShakerModuleCard.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/HeaterShakerModuleCard.tsx
@@ -43,7 +43,7 @@ export const HeaterShakerModuleCard = (): JSX.Element | null => {
           </Text>
           <Flex paddingBottom={SPACING.spacing2}>
             <Icon
-              name={'heater-shaker'}
+              name={'ot-heater-shaker'}
               size={SIZE_1}
               marginRight={SPACING.spacing2}
               color={COLORS.darkGreyEnabled}


### PR DESCRIPTION
# Overview

Type checks are broken on edge because of a weird merge it looks like, this small PR updates an icon name prop to reflect it's actual name.


# Review requests

Type checks pass

# Risk assessment

Low
