### PR TITLE
refactor(api): fix label mapping in `edge` after release sync

### DIFF
--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -303,6 +303,7 @@ class LegacyCommandMapper:
                 loadName=labware_load_info.labware_load_name,
                 namespace=labware_load_info.labware_namespace,
                 version=labware_load_info.labware_version,
+                displayName=labware_load_info.labware_display_name,
             ),
             result=pe_commands.LoadLabwareResult.construct(
                 labwareId=labware_id,


### PR DESCRIPTION
## Overview

I missed a line in resolving the merge conflict in #9623, resulting in `api` test failures for labware label mapping. This PR resolves the issue.

## Changelog

- Re-add missing `params.displayName` field

## Review requests

Nothing special, simple review

## Risk assessment

Very low, fixing a failing test. Yay tests
