### PR TITLE
refactor(hardware): simplify messages with empty payloads.

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -18,14 +18,14 @@ class HeartbeatRequest:  # noqa: D101
 
 @dataclass
 class HeartbeatResponse:  # noqa: D101
-    payload: payloads.EmptyPayload
+    payload: payloads.EmptyPayload = payloads.EmptyPayload()
     payload_type: Type[BinarySerializable] = payloads.EmptyPayload
     message_id: Literal[MessageId.heartbeat_response] = MessageId.heartbeat_response
 
 
 @dataclass
 class DeviceInfoRequest:  # noqa: D101
-    payload: payloads.EmptyPayload
+    payload: payloads.EmptyPayload = payloads.EmptyPayload()
     payload_type: Type[BinarySerializable] = payloads.EmptyPayload
     message_id: Literal[MessageId.device_info_request] = MessageId.device_info_request
 
@@ -39,7 +39,7 @@ class DeviceInfoResponse:  # noqa: D101
 
 @dataclass
 class TaskInfoRequest:  # noqa: D101
-    payload: payloads.EmptyPayload
+    payload: payloads.EmptyPayload = payloads.EmptyPayload()
     payload_type: Type[BinarySerializable] = payloads.EmptyPayload
     message_id: Literal[MessageId.task_info_request] = MessageId.task_info_request
 
@@ -53,28 +53,28 @@ class TaskInfoResponse:  # noqa: D101
 
 @dataclass
 class StopRequest:  # noqa: D101
-    payload: payloads.EmptyPayload
+    payload: payloads.EmptyPayload = payloads.EmptyPayload()
     payload_type: Type[BinarySerializable] = payloads.EmptyPayload
     message_id: Literal[MessageId.stop_request] = MessageId.stop_request
 
 
 @dataclass
 class GetStatusRequest:  # noqa: D101
-    payload: payloads.EmptyPayload
+    payload: payloads.EmptyPayload = payloads.EmptyPayload()
     payload_type: Type[BinarySerializable] = payloads.EmptyPayload
     message_id: Literal[MessageId.get_status_request] = MessageId.get_status_request
 
 
 @dataclass
 class EnableMotorRequest:  # noqa: D101
-    payload: payloads.EmptyPayload
+    payload: payloads.EmptyPayload = payloads.EmptyPayload()
     payload_type: Type[BinarySerializable] = payloads.EmptyPayload
     message_id: Literal[MessageId.enable_motor_request] = MessageId.enable_motor_request
 
 
 @dataclass
 class DisableMotorRequest:  # noqa: D101
-    payload: payloads.EmptyPayload
+    payload: payloads.EmptyPayload = payloads.EmptyPayload()
     payload_type: Type[BinarySerializable] = payloads.EmptyPayload
     message_id: Literal[
         MessageId.disable_motor_request
@@ -97,7 +97,7 @@ class MoveRequest:  # noqa: D101
 
 @dataclass
 class SetupRequest:  # noqa: D101
-    payload: payloads.EmptyPayload
+    payload: payloads.EmptyPayload = payloads.EmptyPayload()
     payload_type: Type[BinarySerializable] = payloads.EmptyPayload
     message_id: Literal[MessageId.setup_request] = MessageId.setup_request
 
@@ -111,7 +111,7 @@ class WriteToEEPromRequest:  # noqa: D101
 
 @dataclass
 class ReadFromEEPromRequest:  # noqa: D101
-    payload: payloads.EmptyPayload
+    payload: payloads.EmptyPayload = payloads.EmptyPayload()
     payload_type: Type[BinarySerializable] = payloads.EmptyPayload
     message_id: Literal[MessageId.read_eeprom_request] = MessageId.read_eeprom_request
 
@@ -159,7 +159,7 @@ class ExecuteMoveGroupRequest:  # noqa: D101
 
 @dataclass
 class ClearAllMoveGroupsRequest:  # noqa: D101
-    payload: payloads.EmptyPayload
+    payload: payloads.EmptyPayload = payloads.EmptyPayload()
     payload_type: Type[BinarySerializable] = payloads.EmptyPayload
     message_id: Literal[
         MessageId.clear_all_move_groups_request
@@ -184,7 +184,7 @@ class SetMotionConstraints:  # noqa: D101
 
 @dataclass
 class GetMotionConstraintsRequest:  # noqa: D101
-    payload: payloads.EmptyPayload
+    payload: payloads.EmptyPayload = payloads.EmptyPayload()
     payload_type: Type[BinarySerializable] = payloads.EmptyPayload
     message_id: Literal[
         MessageId.get_motion_constraints_request
@@ -231,7 +231,7 @@ class ReadMotorDriverResponse:  # noqa: D101
 
 @dataclass
 class ReadPresenceSensingVoltageRequest:  # noqa: D101
-    payload: payloads.EmptyPayload
+    payload: payloads.EmptyPayload = payloads.EmptyPayload()
     payload_type: Type[BinarySerializable] = payloads.EmptyPayload
     message_id: Literal[
         MessageId.read_presence_sensing_voltage_request
@@ -260,7 +260,7 @@ class PushToolsDetectedNotification:  # noqa: D101
 
 @dataclass
 class AttachedToolsRequest:  # noqa: D101
-    payload: payloads.EmptyPayload
+    payload: payloads.EmptyPayload = payloads.EmptyPayload()
     payload_type: Type[BinarySerializable] = payloads.EmptyPayload
     message_id: Literal[
         MessageId.attached_tools_request
@@ -269,7 +269,7 @@ class AttachedToolsRequest:  # noqa: D101
 
 @dataclass
 class FirmwareUpdateInitiate:  # noqa: D101
-    payload: payloads.EmptyPayload
+    payload: payloads.EmptyPayload = payloads.EmptyPayload()
     payload_type: Type[BinarySerializable] = payloads.EmptyPayload
     message_id: Literal[MessageId.fw_update_initiate] = MessageId.fw_update_initiate
 
@@ -306,7 +306,7 @@ class FirmwareUpdateCompleteAcknowledge:  # noqa: D101
 
 @dataclass
 class FirmwareUpdateStatusRequest:  # noqa: D101
-    payload: payloads.EmptyPayload
+    payload: payloads.EmptyPayload = payloads.EmptyPayload()
     payload_type: Type[BinarySerializable] = payloads.EmptyPayload
     message_id: Literal[
         MessageId.fw_update_status_request
@@ -347,14 +347,14 @@ class HomeRequest:  # noqa: D101
 
 @dataclass
 class FirmwareUpdateStartApp:  # noqa: D101
-    payload: payloads.EmptyPayload
+    payload: payloads.EmptyPayload = payloads.EmptyPayload()
     payload_type: Type[BinarySerializable] = payloads.EmptyPayload
     message_id: Literal[MessageId.fw_update_start_app] = MessageId.fw_update_start_app
 
 
 @dataclass
 class ReadLimitSwitchRequest:  # noqa: D101
-    payload: payloads.EmptyPayload
+    payload: payloads.EmptyPayload = payloads.EmptyPayload()
     payload_type: Type[BinarySerializable] = payloads.EmptyPayload
     message_id: Literal[MessageId.limit_sw_request] = MessageId.limit_sw_request
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -10,23 +10,25 @@ from . import payloads
 
 
 @dataclass
-class HeartbeatRequest:  # noqa: D101
+class EmptyPayloadMessage:
+    """Base class of a message that has an empty payload."""
+
     payload: payloads.EmptyPayload = payloads.EmptyPayload()
     payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+
+
+@dataclass
+class HeartbeatRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.heartbeat_request] = MessageId.heartbeat_request
 
 
 @dataclass
-class HeartbeatResponse:  # noqa: D101
-    payload: payloads.EmptyPayload = payloads.EmptyPayload()
-    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+class HeartbeatResponse(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.heartbeat_response] = MessageId.heartbeat_response
 
 
 @dataclass
-class DeviceInfoRequest:  # noqa: D101
-    payload: payloads.EmptyPayload = payloads.EmptyPayload()
-    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+class DeviceInfoRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.device_info_request] = MessageId.device_info_request
 
 
@@ -38,9 +40,7 @@ class DeviceInfoResponse:  # noqa: D101
 
 
 @dataclass
-class TaskInfoRequest:  # noqa: D101
-    payload: payloads.EmptyPayload = payloads.EmptyPayload()
-    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+class TaskInfoRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.task_info_request] = MessageId.task_info_request
 
 
@@ -52,30 +52,22 @@ class TaskInfoResponse:  # noqa: D101
 
 
 @dataclass
-class StopRequest:  # noqa: D101
-    payload: payloads.EmptyPayload = payloads.EmptyPayload()
-    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+class StopRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.stop_request] = MessageId.stop_request
 
 
 @dataclass
-class GetStatusRequest:  # noqa: D101
-    payload: payloads.EmptyPayload = payloads.EmptyPayload()
-    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+class GetStatusRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.get_status_request] = MessageId.get_status_request
 
 
 @dataclass
-class EnableMotorRequest:  # noqa: D101
-    payload: payloads.EmptyPayload = payloads.EmptyPayload()
-    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+class EnableMotorRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.enable_motor_request] = MessageId.enable_motor_request
 
 
 @dataclass
-class DisableMotorRequest:  # noqa: D101
-    payload: payloads.EmptyPayload = payloads.EmptyPayload()
-    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+class DisableMotorRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[
         MessageId.disable_motor_request
     ] = MessageId.disable_motor_request
@@ -96,9 +88,7 @@ class MoveRequest:  # noqa: D101
 
 
 @dataclass
-class SetupRequest:  # noqa: D101
-    payload: payloads.EmptyPayload = payloads.EmptyPayload()
-    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+class SetupRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.setup_request] = MessageId.setup_request
 
 
@@ -110,9 +100,7 @@ class WriteToEEPromRequest:  # noqa: D101
 
 
 @dataclass
-class ReadFromEEPromRequest:  # noqa: D101
-    payload: payloads.EmptyPayload = payloads.EmptyPayload()
-    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+class ReadFromEEPromRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.read_eeprom_request] = MessageId.read_eeprom_request
 
 
@@ -158,9 +146,7 @@ class ExecuteMoveGroupRequest:  # noqa: D101
 
 
 @dataclass
-class ClearAllMoveGroupsRequest:  # noqa: D101
-    payload: payloads.EmptyPayload = payloads.EmptyPayload()
-    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+class ClearAllMoveGroupsRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[
         MessageId.clear_all_move_groups_request
     ] = MessageId.clear_all_move_groups_request
@@ -183,9 +169,7 @@ class SetMotionConstraints:  # noqa: D101
 
 
 @dataclass
-class GetMotionConstraintsRequest:  # noqa: D101
-    payload: payloads.EmptyPayload = payloads.EmptyPayload()
-    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+class GetMotionConstraintsRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[
         MessageId.get_motion_constraints_request
     ] = MessageId.get_motion_constraints_request
@@ -230,9 +214,7 @@ class ReadMotorDriverResponse:  # noqa: D101
 
 
 @dataclass
-class ReadPresenceSensingVoltageRequest:  # noqa: D101
-    payload: payloads.EmptyPayload = payloads.EmptyPayload()
-    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+class ReadPresenceSensingVoltageRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[
         MessageId.read_presence_sensing_voltage_request
     ] = MessageId.read_presence_sensing_voltage_request
@@ -259,18 +241,14 @@ class PushToolsDetectedNotification:  # noqa: D101
 
 
 @dataclass
-class AttachedToolsRequest:  # noqa: D101
-    payload: payloads.EmptyPayload = payloads.EmptyPayload()
-    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+class AttachedToolsRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[
         MessageId.attached_tools_request
     ] = MessageId.attached_tools_request
 
 
 @dataclass
-class FirmwareUpdateInitiate:  # noqa: D101
-    payload: payloads.EmptyPayload = payloads.EmptyPayload()
-    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+class FirmwareUpdateInitiate(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.fw_update_initiate] = MessageId.fw_update_initiate
 
 
@@ -305,9 +283,7 @@ class FirmwareUpdateCompleteAcknowledge:  # noqa: D101
 
 
 @dataclass
-class FirmwareUpdateStatusRequest:  # noqa: D101
-    payload: payloads.EmptyPayload = payloads.EmptyPayload()
-    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+class FirmwareUpdateStatusRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[
         MessageId.fw_update_status_request
     ] = MessageId.fw_update_status_request
@@ -323,9 +299,7 @@ class FirmwareUpdateStatusResponse:  # noqa: D101
 
 
 @dataclass
-class FirmwareUpdateEraseAppRequest:  # noqa: D101
-    payload: payloads.EmptyPayload = payloads.EmptyPayload()
-    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+class FirmwareUpdateEraseAppRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.fw_update_erase_app] = MessageId.fw_update_erase_app
 
 
@@ -346,16 +320,12 @@ class HomeRequest:  # noqa: D101
 
 
 @dataclass
-class FirmwareUpdateStartApp:  # noqa: D101
-    payload: payloads.EmptyPayload = payloads.EmptyPayload()
-    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+class FirmwareUpdateStartApp(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.fw_update_start_app] = MessageId.fw_update_start_app
 
 
 @dataclass
-class ReadLimitSwitchRequest:  # noqa: D101
-    payload: payloads.EmptyPayload = payloads.EmptyPayload()
-    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+class ReadLimitSwitchRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.limit_sw_request] = MessageId.limit_sw_request
 
 

--- a/hardware/opentrons_hardware/firmware_update/initiator.py
+++ b/hardware/opentrons_hardware/firmware_update/initiator.py
@@ -6,7 +6,7 @@ from typing_extensions import Final
 from dataclasses import dataclass
 
 from opentrons_hardware.firmware_bindings import NodeId
-from opentrons_hardware.firmware_bindings.messages import message_definitions, payloads
+from opentrons_hardware.firmware_bindings.messages import message_definitions
 
 from opentrons_hardware.drivers.can_bus import CanMessenger
 from opentrons_hardware.drivers.can_bus.can_messenger import WaitableCallback

--- a/hardware/opentrons_hardware/firmware_update/initiator.py
+++ b/hardware/opentrons_hardware/firmware_update/initiator.py
@@ -60,9 +60,7 @@ class FirmwareUpdateInitiator:
         """
         with WaitableCallback(self._messenger) as reader:
             # Create initiate message
-            initiate_message = message_definitions.FirmwareUpdateInitiate(
-                payload=payloads.EmptyPayload()
-            )
+            initiate_message = message_definitions.FirmwareUpdateInitiate()
             # Send it to system node
             await self._messenger.send(
                 node_id=target.system_node, message=initiate_message
@@ -92,9 +90,7 @@ class FirmwareUpdateInitiator:
     async def _wait_bootloader(self, reader: WaitableCallback, target: Target) -> None:
         """Wait for bootloader to be ready."""
         # Send device info request
-        device_info_request_message = message_definitions.DeviceInfoRequest(
-            payload=payloads.EmptyPayload()
-        )
+        device_info_request_message = message_definitions.DeviceInfoRequest()
         await self._messenger.send(
             node_id=target.bootloader_node, message=device_info_request_message
         )

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -16,7 +16,6 @@ from opentrons_hardware.firmware_bindings.messages.message_definitions import (
 from opentrons_hardware.firmware_bindings.messages.payloads import (
     AddLinearMoveRequestPayload,
     ExecuteMoveGroupRequestPayload,
-    EmptyPayload,
 )
 from .constants import interrupts_per_sec
 from opentrons_hardware.hardware_control.motion import MoveGroups

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -59,7 +59,7 @@ class MoveGroupRunner:
         """Send commands to clear the message groups."""
         await can_messenger.send(
             node_id=NodeId.broadcast,
-            message=ClearAllMoveGroupsRequest(payload=EmptyPayload()),
+            message=ClearAllMoveGroupsRequest(),
         )
 
     async def _send_groups(self, can_messenger: CanMessenger) -> None:

--- a/hardware/opentrons_hardware/hardware_control/network.py
+++ b/hardware/opentrons_hardware/hardware_control/network.py
@@ -5,7 +5,7 @@ from typing import Set, Optional
 from opentrons_hardware.firmware_bindings import ArbitrationId
 from opentrons_hardware.firmware_bindings.constants import NodeId
 from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
-from opentrons_hardware.firmware_bindings.messages import payloads, MessageDefinition
+from opentrons_hardware.firmware_bindings.messages import MessageDefinition
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     DeviceInfoRequest,
 )

--- a/hardware/opentrons_hardware/hardware_control/network.py
+++ b/hardware/opentrons_hardware/hardware_control/network.py
@@ -49,7 +49,7 @@ async def probe(
     can_messenger.add_listener(listener)
     await can_messenger.send(
         node_id=NodeId.broadcast,
-        message=DeviceInfoRequest(payload=payloads.EmptyPayload()),
+        message=DeviceInfoRequest(),
     )
     try:
         await asyncio.wait_for(event.wait(), timeout)

--- a/hardware/opentrons_hardware/scripts/load.py
+++ b/hardware/opentrons_hardware/scripts/load.py
@@ -18,7 +18,6 @@ from opentrons_hardware.firmware_bindings.messages.message_definitions import (
 )
 from opentrons_hardware.firmware_bindings.arbitration_id import ArbitrationId
 from opentrons_hardware.firmware_bindings.messages import MessageDefinition
-from opentrons_hardware.firmware_bindings.messages.payloads import EmptyPayload
 from opentrons_hardware.scripts.can_args import add_can_args
 
 

--- a/hardware/opentrons_hardware/scripts/load.py
+++ b/hardware/opentrons_hardware/scripts/load.py
@@ -82,9 +82,7 @@ class BusProber:
 
     async def _stimulate(self, messenger: CanMessenger) -> None:
         self._done.clear()
-        await messenger.send(
-            node_id=NodeId.broadcast, message=DeviceInfoRequest(payload=EmptyPayload())
-        )
+        await messenger.send(node_id=NodeId.broadcast, message=DeviceInfoRequest())
         await self._done.wait()
 
     def __call__(
@@ -171,9 +169,7 @@ class BusLoader:
         then = time.time()
         while True:
             for node in self._targets:
-                await self._messenger.send(
-                    node_id=node, message=DeviceInfoRequest(payload=EmptyPayload())
-                )
+                await self._messenger.send(node_id=node, message=DeviceInfoRequest())
                 self._stats.messages_sent[node] += 1
             now = time.time()
             if now - then > self._period:

--- a/hardware/opentrons_hardware/scripts/move.py
+++ b/hardware/opentrons_hardware/scripts/move.py
@@ -52,12 +52,8 @@ async def run(interface: str, bitrate: int, channel: Optional[str] = None) -> No
     messenger = CanMessenger(driver=driver)
     messenger.start()
 
-    await messenger.send(
-        node_id=NodeId.broadcast, message=SetupRequest(payload=EmptyPayload())
-    )
-    await messenger.send(
-        node_id=NodeId.broadcast, message=EnableMotorRequest(payload=EmptyPayload())
-    )
+    await messenger.send(node_id=NodeId.broadcast, message=SetupRequest())
+    await messenger.send(node_id=NodeId.broadcast, message=EnableMotorRequest())
 
     # TODO (al, 2021-11-11): Allow creating groups from command line or config file.
     move_groups = [

--- a/hardware/opentrons_hardware/scripts/move.py
+++ b/hardware/opentrons_hardware/scripts/move.py
@@ -13,7 +13,6 @@ from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     SetupRequest,
     EnableMotorRequest,
 )
-from opentrons_hardware.firmware_bindings.messages.payloads import EmptyPayload
 from opentrons_hardware.hardware_control.motion import MoveGroupSingleAxisStep
 from opentrons_hardware.hardware_control.move_group_runner import MoveGroupRunner
 from opentrons_hardware.scripts.can_args import add_can_args

--- a/hardware/opentrons_hardware/scripts/update_fw.py
+++ b/hardware/opentrons_hardware/scripts/update_fw.py
@@ -99,7 +99,7 @@ async def run(args: argparse.Namespace) -> None:
     logger.info(f"Restarting FW on {target.system_node}.")
     await messenger.send(
         node_id=target.bootloader_node,
-        message=FirmwareUpdateStartApp(payload=EmptyPayload()),
+        message=FirmwareUpdateStartApp(),
     )
 
     await messenger.stop()

--- a/hardware/opentrons_hardware/scripts/update_fw.py
+++ b/hardware/opentrons_hardware/scripts/update_fw.py
@@ -12,7 +12,6 @@ from opentrons_hardware.drivers.can_bus.build import build_driver
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     FirmwareUpdateStartApp,
 )
-from opentrons_hardware.firmware_bindings.messages.payloads import EmptyPayload
 from .can_args import add_can_args, build_settings
 from opentrons_hardware.firmware_update import (
     FirmwareUpdateDownloader,

--- a/hardware/tests/opentrons_hardware/drivers/can_bus/test_can_messenger.py
+++ b/hardware/tests/opentrons_hardware/drivers/can_bus/test_can_messenger.py
@@ -28,7 +28,6 @@ from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     GetMoveGroupRequest,
 )
 from opentrons_hardware.firmware_bindings.messages.payloads import (
-    EmptyPayload,
     MoveCompletedPayload,
     MoveGroupRequestPayload,
 )

--- a/hardware/tests/opentrons_hardware/drivers/can_bus/test_can_messenger.py
+++ b/hardware/tests/opentrons_hardware/drivers/can_bus/test_can_messenger.py
@@ -59,7 +59,7 @@ def subject(mock_driver: AsyncMock) -> CanMessenger:
 @pytest.mark.parametrize(
     "node_id,message",
     [
-        [NodeId.head, HeartbeatRequest(payload=EmptyPayload())],
+        [NodeId.head, HeartbeatRequest()],
         [
             NodeId.gantry_x,
             MoveCompleted(

--- a/hardware/tests/opentrons_hardware/firmware_update/test_eraser.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_eraser.py
@@ -60,9 +60,7 @@ async def test_messaging(
 
     mock_messenger.send.assert_called_once_with(
         node_id=target_id,
-        message=message_definitions.FirmwareUpdateEraseAppRequest(
-            payload=payloads.EmptyPayload()
-        ),
+        message=message_definitions.FirmwareUpdateEraseAppRequest(),
     )
 
 

--- a/hardware/tests/opentrons_hardware/firmware_update/test_initiater.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_initiater.py
@@ -154,9 +154,7 @@ async def test_bootloader_not_ready(
         + [
             call(
                 node_id=target.bootloader_node,
-                message=message_definitions.DeviceInfoRequest(
-                    payload=payloads.EmptyPayload()
-                ),
+                message=message_definitions.DeviceInfoRequest(),
             ),
         ]
         * retry_count

--- a/hardware/tests/opentrons_hardware/firmware_update/test_initiater.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_initiater.py
@@ -55,21 +55,15 @@ async def test_messaging(
     assert mock_messenger.send.mock_calls == [
         call(
             node_id=target.system_node,
-            message=message_definitions.FirmwareUpdateInitiate(
-                payload=payloads.EmptyPayload()
-            ),
+            message=message_definitions.FirmwareUpdateInitiate(),
         ),
         call(
             node_id=target.bootloader_node,
-            message=message_definitions.FirmwareUpdateInitiate(
-                payload=payloads.EmptyPayload()
-            ),
+            message=message_definitions.FirmwareUpdateInitiate(),
         ),
         call(
             node_id=target.bootloader_node,
-            message=message_definitions.DeviceInfoRequest(
-                payload=payloads.EmptyPayload()
-            ),
+            message=message_definitions.DeviceInfoRequest(),
         ),
     ]
 
@@ -117,23 +111,17 @@ async def test_retry(
         == [
             call(
                 node_id=target.system_node,
-                message=message_definitions.FirmwareUpdateInitiate(
-                    payload=payloads.EmptyPayload()
-                ),
+                message=message_definitions.FirmwareUpdateInitiate(),
             ),
             call(
                 node_id=target.bootloader_node,
-                message=message_definitions.FirmwareUpdateInitiate(
-                    payload=payloads.EmptyPayload()
-                ),
+                message=message_definitions.FirmwareUpdateInitiate(),
             ),
         ]
         + [
             call(
                 node_id=target.bootloader_node,
-                message=message_definitions.DeviceInfoRequest(
-                    payload=payloads.EmptyPayload()
-                ),
+                message=message_definitions.DeviceInfoRequest(),
             ),
         ]
         * retry_count
@@ -156,15 +144,11 @@ async def test_bootloader_not_ready(
         == [
             call(
                 node_id=target.system_node,
-                message=message_definitions.FirmwareUpdateInitiate(
-                    payload=payloads.EmptyPayload()
-                ),
+                message=message_definitions.FirmwareUpdateInitiate(),
             ),
             call(
                 node_id=target.bootloader_node,
-                message=message_definitions.FirmwareUpdateInitiate(
-                    payload=payloads.EmptyPayload()
-                ),
+                message=message_definitions.FirmwareUpdateInitiate(),
             ),
         ]
         + [

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -125,7 +125,7 @@ async def test_single_group_clear(
     await subject._clear_groups(can_messenger=mock_can_messenger)
     mock_can_messenger.send.assert_called_once_with(
         node_id=NodeId.broadcast,
-        message=md.ClearAllMoveGroupsRequest(payload=EmptyPayload()),
+        message=md.ClearAllMoveGroupsRequest(),
     )
 
 
@@ -137,7 +137,7 @@ async def test_multi_group_clear(
     await subject._clear_groups(can_messenger=mock_can_messenger)
     mock_can_messenger.send.assert_called_once_with(
         node_id=NodeId.broadcast,
-        message=md.ClearAllMoveGroupsRequest(payload=EmptyPayload()),
+        message=md.ClearAllMoveGroupsRequest(),
     )
 
 

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -11,7 +11,6 @@ from opentrons_hardware.firmware_bindings.messages.message_definitions import (
 from opentrons_hardware.firmware_bindings.messages.payloads import (
     AddLinearMoveRequestPayload,
     MoveCompletedPayload,
-    EmptyPayload,
     ExecuteMoveGroupRequestPayload,
 )
 from opentrons_hardware.hardware_control.constants import (

--- a/hardware/tests/opentrons_hardware/hardware_control/test_network.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_network.py
@@ -87,7 +87,7 @@ async def test_timeout_fires(mock_can_messenger: AsyncMock) -> None:
     # We should have sent a request
     mock_can_messenger.send.assert_called_once_with(
         node_id=NodeId.broadcast,
-        message=message_definitions.DeviceInfoRequest(payload=payloads.EmptyPayload()),
+        message=message_definitions.DeviceInfoRequest(),
     )
     # we should have added a listener
     mock_can_messenger.add_listener.assert_called_once()


### PR DESCRIPTION
# Overview

A convenience PR. 

# Changelog

Add base class for all messages that have an empty data payload.
`EmptyPayload` is default constructed so message creators don't need to.

# Review requests


# Risk assessment

None