### PR TITLE
feat(app): add selectors to Module Cards

### DIFF
--- a/app/src/atoms/StatusLabel/index.tsx
+++ b/app/src/atoms/StatusLabel/index.tsx
@@ -30,6 +30,7 @@ export const StatusLabel = (props: StatusLabelProps): JSX.Element | null => {
         alignItems={ALIGN_CENTER}
         marginTop={SPACING_1}
         marginBottom={SPACING_1}
+        data-testid={`status_label+${status}`}
       >
         <Icon
           name="circle"

--- a/app/src/organisms/Devices/ModuleCard/HeaterShakerModuleData.tsx
+++ b/app/src/organisms/Devices/ModuleCard/HeaterShakerModuleData.tsx
@@ -72,7 +72,11 @@ export const HeaterShakerModuleData = (
     <>
       <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
         {showTemperatureData && (
-          <Flex flexDirection={DIRECTION_COLUMN} marginRight={SPACING.spacing6}>
+          <Flex
+            flexDirection={DIRECTION_COLUMN}
+            marginRight={SPACING.spacing6}
+            data-testid={`heater_shaker_module_data_temp`}
+          >
             <Text
               textTransform={TEXT_TRANSFORM_UPPERCASE}
               color={COLORS.darkGreyEnabled}
@@ -100,7 +104,10 @@ export const HeaterShakerModuleData = (
             </Text>
           </Flex>
         )}
-        <Flex flexDirection={DIRECTION_COLUMN}>
+        <Flex
+          flexDirection={DIRECTION_COLUMN}
+          data-testid={`heater_shaker_module_data_shaker`}
+        >
           <Text
             textTransform={TEXT_TRANSFORM_UPPERCASE}
             color={COLORS.darkGreyEnabled}
@@ -128,7 +135,10 @@ export const HeaterShakerModuleData = (
           </Text>
         </Flex>
       </Flex>
-      <Flex flexDirection={DIRECTION_ROW}>
+      <Flex
+        flexDirection={DIRECTION_ROW}
+        data-testid={`heater_shaker_module_data_latch`}
+      >
         <Flex flexDirection={DIRECTION_COLUMN}>
           <Text
             textTransform={TEXT_TRANSFORM_UPPERCASE}

--- a/app/src/organisms/Devices/ModuleCard/MagneticModuleData.tsx
+++ b/app/src/organisms/Devices/ModuleCard/MagneticModuleData.tsx
@@ -33,7 +33,7 @@ export const MagneticModuleData = (
         iconColor={C_BLUE}
         pulse={moduleStatus === 'engaged'}
       />
-      <Text fontSize={FONT_SIZE_CAPTION}>
+      <Text fontSize={FONT_SIZE_CAPTION} data-testid={`mag_module_data`}>
         {t(
           moduleModel === MAGNETIC_MODULE_V2
             ? 'magdeck_gen2_height'

--- a/app/src/organisms/Devices/ModuleCard/TemperatureModuleData.tsx
+++ b/app/src/organisms/Devices/ModuleCard/TemperatureModuleData.tsx
@@ -60,7 +60,11 @@ export const TemperatureModuleData = (
         textColor={textColor}
         pulse={pulse}
       />
-      <Flex fontSize={FONT_SIZE_CAPTION} flexDirection={DIRECTION_COLUMN}>
+      <Flex
+        fontSize={FONT_SIZE_CAPTION}
+        flexDirection={DIRECTION_COLUMN}
+        data-testid={`temp_module_data`}
+      >
         <Text marginBottom={SPACING.spacing1}>
           {t(targetTemp === null ? 'na_temp' : 'target_temp', {
             temp: targetTemp,

--- a/app/src/organisms/Devices/ModuleCard/ThermocyclerModuleData.tsx
+++ b/app/src/organisms/Devices/ModuleCard/ThermocyclerModuleData.tsx
@@ -77,7 +77,10 @@ export const ThermocyclerModuleData = (
 
   return (
     <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
-      <Flex flexDirection={DIRECTION_COLUMN}>
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        data-testid={`thermocycler_module_data_lid`}
+      >
         <Text
           textTransform={TEXT_TRANSFORM_UPPERCASE}
           color={C_HARBOR_GRAY}
@@ -101,7 +104,11 @@ export const ThermocyclerModuleData = (
           {t('current_temp', { temp: lidTemp })}
         </Text>
       </Flex>
-      <Flex flexDirection={DIRECTION_COLUMN} marginLeft={SPACING_4}>
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        marginLeft={SPACING_4}
+        data-testid={`thermocycler_module_data_block`}
+      >
         <Text
           textTransform={TEXT_TRANSFORM_UPPERCASE}
           color={C_HARBOR_GRAY}

--- a/app/src/organisms/Devices/ModuleCard/index.tsx
+++ b/app/src/organisms/Devices/ModuleCard/index.tsx
@@ -125,6 +125,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
         marginBottom={SPACING_2}
         marginLeft={SPACING_2}
         width={'20rem'}
+        data-testid={`module_card_${module.serial}`}
       >
         {showSlideout && (
           <ModuleSlideout
@@ -154,12 +155,16 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
                 fontWeight={FONT_WEIGHT_REGULAR}
                 fontSize={FONT_SIZE_CAPTION}
                 paddingBottom={SPACING.spacing2}
+                data-testid={`module_card_usb_port_${module.serial}`}
               >
                 {t(module.usbPort.port === null ? 'usb_hub' : 'usb_port', {
                   port: module.usbPort.hub ?? module.usbPort.port,
                 })}
               </Text>
-              <Flex paddingBottom={SPACING.spacing2}>
+              <Flex
+                paddingBottom={SPACING.spacing2}
+                data-testid={`module_card_display_name_${module.serial}`}
+              >
                 <ModuleIcon moduleType={module.type} />
                 <Text fontSize={TYPOGRAPHY.fontSizeP}>
                   {getModuleDisplayName(module.model)}
@@ -170,7 +175,11 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
           </Flex>
         </Box>
 
-        <Box alignSelf={ALIGN_START} padding={SPACING.spacing2}>
+        <Box
+          alignSelf={ALIGN_START}
+          padding={SPACING.spacing2}
+          data-testid={`module_card_overflow_btn_${module.serial}`}
+        >
           <OverflowBtn
             aria-label="overflow"
             onClick={() => {
@@ -179,7 +188,10 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
           />
         </Box>
         {showOverflowMenu && (
-          <div ref={moduleOverflowWrapperRef}>
+          <div
+            ref={moduleOverflowWrapperRef}
+            data-testid={`module_card_overflow_menu_${module.serial}`}
+          >
             <ModuleOverflowMenu
               handleAboutClick={handleAboutClick}
               module={module}


### PR DESCRIPTION
closes #9359

# Overview

This PR goes back and adds selectors to module card work since it was previously skipped since multiple people were working on different parts of it simultaneously.

# Changelog

- addes selectors to `moduleCard`, each of the module data components, and the `statusLabel`

# Review requests

make sure adding selectors didn't do anything weird

# Risk assessment

low