### PR TITLE
feat(protocol-designer): add heater shaker step to dropdown

### DIFF
--- a/protocol-designer/src/components/StepCreationButton.tsx
+++ b/protocol-designer/src/components/StepCreationButton.tsx
@@ -10,6 +10,7 @@ import {
   TOOLTIP_FIXED,
 } from '@opentrons/components'
 import {
+  HEATERSHAKER_MODULE_TYPE,
   MAGNETIC_MODULE_TYPE,
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
@@ -38,7 +39,7 @@ interface StepButtonComponentProps {
 // TODO: Ian 2019-01-17 move out to centralized step info file - see #2926
 const getSupportedSteps = (): Array<
   Exclude<StepType, 'manualIntervention'>
-> => ['moveLiquid', 'mix', 'pause', 'magnet', 'temperature', 'thermocycler']
+> => ['moveLiquid', 'mix', 'pause', 'magnet', 'temperature', 'thermocycler', 'heaterShaker']
 
 export const StepCreationButtonComponent = (
   props: StepButtonComponentProps
@@ -123,6 +124,7 @@ export const StepCreationButton = (): JSX.Element => {
     magnet: getIsModuleOnDeck(modules, MAGNETIC_MODULE_TYPE),
     temperature: getIsModuleOnDeck(modules, TEMPERATURE_MODULE_TYPE),
     thermocycler: getIsModuleOnDeck(modules, THERMOCYCLER_MODULE_TYPE),
+    heaterShaker: getIsModuleOnDeck(modules, HEATERSHAKER_MODULE_TYPE)
   }
 
   const [expanded, setExpanded] = React.useState<boolean>(false)

--- a/protocol-designer/src/components/StepCreationButton.tsx
+++ b/protocol-designer/src/components/StepCreationButton.tsx
@@ -27,6 +27,7 @@ import {
 } from './modals/ConfirmDeleteModal'
 import { Portal } from './portals/MainPageModalPortal'
 import { stepIconsByType, StepType } from '../form-types'
+import { selectors as featureFlagSelectors } from '../feature-flags'
 import styles from './listButtons.css'
 
 interface StepButtonComponentProps {
@@ -147,22 +148,45 @@ export const StepCreationButton = (): JSX.Element => {
   ): ReturnType<typeof stepsActions.addAndSelectStepWithHints> =>
     dispatch(stepsActions.addAndSelectStepWithHints({ stepType }))
 
-  const items = getSupportedSteps().map(stepType => (
-    <StepButtonItem
-      key={stepType}
-      stepType={stepType}
-      disabled={!isStepTypeEnabled[stepType]}
-      onClick={() => {
-        setExpanded(false)
+  const enableHeaterShaker = useSelector(
+    featureFlagSelectors.getEnabledHeaterShaker
+  )
 
-        if (currentFormIsPresaved || formHasChanges) {
-          setEnqueuedStepType(stepType)
-        } else {
-          addStep(stepType)
-        }
-      }}
-    />
-  ))
+  const items = enableHeaterShaker
+    ? getSupportedSteps().map(stepType => (
+        <StepButtonItem
+          key={stepType}
+          stepType={stepType}
+          disabled={!isStepTypeEnabled[stepType]}
+          onClick={() => {
+            setExpanded(false)
+
+            if (currentFormIsPresaved || formHasChanges) {
+              setEnqueuedStepType(stepType)
+            } else {
+              addStep(stepType)
+            }
+          }}
+        />
+      ))
+    : getSupportedSteps().map(stepType =>
+        stepType === 'heaterShaker' ? null : (
+          <StepButtonItem
+            key={stepType}
+            stepType={stepType}
+            disabled={!isStepTypeEnabled[stepType]}
+            onClick={() => {
+              setExpanded(false)
+
+              if (currentFormIsPresaved || formHasChanges) {
+                setEnqueuedStepType(stepType)
+              } else {
+                addStep(stepType)
+              }
+            }}
+          />
+        )
+      )
 
   return (
     <>

--- a/protocol-designer/src/components/StepCreationButton.tsx
+++ b/protocol-designer/src/components/StepCreationButton.tsx
@@ -39,7 +39,15 @@ interface StepButtonComponentProps {
 // TODO: Ian 2019-01-17 move out to centralized step info file - see #2926
 const getSupportedSteps = (): Array<
   Exclude<StepType, 'manualIntervention'>
-> => ['moveLiquid', 'mix', 'pause', 'magnet', 'temperature', 'thermocycler', 'heaterShaker']
+> => [
+  'moveLiquid',
+  'mix',
+  'pause',
+  'magnet',
+  'temperature',
+  'thermocycler',
+  'heaterShaker',
+]
 
 export const StepCreationButtonComponent = (
   props: StepButtonComponentProps
@@ -124,7 +132,7 @@ export const StepCreationButton = (): JSX.Element => {
     magnet: getIsModuleOnDeck(modules, MAGNETIC_MODULE_TYPE),
     temperature: getIsModuleOnDeck(modules, TEMPERATURE_MODULE_TYPE),
     thermocycler: getIsModuleOnDeck(modules, THERMOCYCLER_MODULE_TYPE),
-    heaterShaker: getIsModuleOnDeck(modules, HEATERSHAKER_MODULE_TYPE)
+    heaterShaker: getIsModuleOnDeck(modules, HEATERSHAKER_MODULE_TYPE),
   }
 
   const [expanded, setExpanded] = React.useState<boolean>(false)

--- a/protocol-designer/src/components/StepCreationButton.tsx
+++ b/protocol-designer/src/components/StepCreationButton.tsx
@@ -38,17 +38,6 @@ interface StepButtonComponentProps {
 }
 
 // TODO: Ian 2019-01-17 move out to centralized step info file - see #2926
-const getSupportedSteps = (): Array<
-  Exclude<StepType, 'manualIntervention'>
-> => [
-  'moveLiquid',
-  'mix',
-  'pause',
-  'magnet',
-  'temperature',
-  'thermocycler',
-  'heaterShaker',
-]
 
 export const StepCreationButtonComponent = (
   props: StepButtonComponentProps
@@ -115,6 +104,34 @@ export function StepButtonItem(props: StepButtonItemProps): JSX.Element {
 }
 
 export const StepCreationButton = (): JSX.Element => {
+  const enableHeaterShaker = useSelector(
+    featureFlagSelectors.getEnabledHeaterShaker
+  )
+
+  const getSupportedSteps = (): Array<
+    Exclude<StepType, 'manualIntervention'>
+  > => {
+    if (enableHeaterShaker) {
+      return [
+        'moveLiquid',
+        'mix',
+        'pause',
+        'magnet',
+        'temperature',
+        'thermocycler',
+        'heaterShaker',
+      ]
+    } else {
+      return [
+        'moveLiquid',
+        'mix',
+        'pause',
+        'magnet',
+        'temperature',
+        'thermocycler',
+      ]
+    }
+  }
   const currentFormIsPresaved = useSelector(
     stepFormSelectors.getCurrentFormIsPresaved
   )
@@ -148,45 +165,22 @@ export const StepCreationButton = (): JSX.Element => {
   ): ReturnType<typeof stepsActions.addAndSelectStepWithHints> =>
     dispatch(stepsActions.addAndSelectStepWithHints({ stepType }))
 
-  const enableHeaterShaker = useSelector(
-    featureFlagSelectors.getEnabledHeaterShaker
-  )
+  const items = getSupportedSteps().map(stepType => (
+    <StepButtonItem
+      key={stepType}
+      stepType={stepType}
+      disabled={!isStepTypeEnabled[stepType]}
+      onClick={() => {
+        setExpanded(false)
 
-  const items = enableHeaterShaker
-    ? getSupportedSteps().map(stepType => (
-        <StepButtonItem
-          key={stepType}
-          stepType={stepType}
-          disabled={!isStepTypeEnabled[stepType]}
-          onClick={() => {
-            setExpanded(false)
-
-            if (currentFormIsPresaved || formHasChanges) {
-              setEnqueuedStepType(stepType)
-            } else {
-              addStep(stepType)
-            }
-          }}
-        />
-      ))
-    : getSupportedSteps().map(stepType =>
-        stepType === 'heaterShaker' ? null : (
-          <StepButtonItem
-            key={stepType}
-            stepType={stepType}
-            disabled={!isStepTypeEnabled[stepType]}
-            onClick={() => {
-              setExpanded(false)
-
-              if (currentFormIsPresaved || formHasChanges) {
-                setEnqueuedStepType(stepType)
-              } else {
-                addStep(stepType)
-              }
-            }}
-          />
-        )
-      )
+        if (currentFormIsPresaved || formHasChanges) {
+          setEnqueuedStepType(stepType)
+        } else {
+          addStep(stepType)
+        }
+      }}
+    />
+  ))
 
   return (
     <>

--- a/protocol-designer/src/components/__tests__/StepCreationButton.test.tsx
+++ b/protocol-designer/src/components/__tests__/StepCreationButton.test.tsx
@@ -13,6 +13,7 @@ import {
 
 import * as stepFormSelectors from '../../step-forms/selectors'
 import { actions as stepsActions, getIsMultiSelectMode } from '../../ui/steps'
+import { selectors } from '../../feature-flags'
 
 import { PrimaryButton, Tooltip } from '@opentrons/components'
 import {
@@ -23,6 +24,7 @@ import {
 
 jest.mock('../../step-forms/selectors')
 jest.mock('../../ui/steps/selectors')
+jest.mock('../../feature-flags')
 
 const middlewares = [thunk]
 const mockStore = configureMockStore(middlewares)
@@ -31,12 +33,17 @@ const getCurrentFormHasUnsavedChangesMock =
   stepFormSelectors.getCurrentFormHasUnsavedChanges
 const getInitialDeckSetupMock = stepFormSelectors.getInitialDeckSetup
 const getIsMultiSelectModeMock = getIsMultiSelectMode
+const getEnabledHeaterShaker = selectors.getEnabledHeaterShaker
 
 describe('StepCreationButton', () => {
   let store: any
 
   beforeEach(() => {
     store = mockStore()
+
+    when(getEnabledHeaterShaker)
+      .calledWith(expect.anything())
+      .mockReturnValue(true)
 
     when(getCurrentFormIsPresavedMock)
       .calledWith(expect.anything())
@@ -120,10 +127,10 @@ describe('StepCreationButton', () => {
       const updatedAddStepButton = wrapper.find(StepCreationButtonComponent)
       // all 6 step button items render as children
       const stepButtonItems = updatedAddStepButton.find(StepButtonItem)
-      expect(stepButtonItems).toHaveLength(6)
+      expect(stepButtonItems).toHaveLength(7)
       // modules are disabled since there are no modules on deck
       const disabledModuleSteps = stepButtonItems.find({ disabled: true })
-      expect(disabledModuleSteps).toHaveLength(3)
+      expect(disabledModuleSteps).toHaveLength(4)
       // enabled button tooltip
       const mixTooltip = stepButtonItems.at(1).find(Tooltip)
       expect(mixTooltip.prop('children')).toBe('Mix contents of wells/tubes.')
@@ -161,7 +168,7 @@ describe('StepCreationButton', () => {
 
       // temperature step enabled since it is on the deck
       const disabledModuleSteps = stepButtonItems.find({ disabled: true })
-      expect(disabledModuleSteps).toHaveLength(2)
+      expect(disabledModuleSteps).toHaveLength(3)
       // enabled temperature module step tooltip
       const enabledButtonTooltip = stepButtonItems.at(4).find(Tooltip)
       expect(enabledButtonTooltip.prop('children')).toBe(

--- a/protocol-designer/src/form-types.ts
+++ b/protocol-designer/src/form-types.ts
@@ -80,6 +80,7 @@ export type StepType =
   | 'magnet'
   | 'temperature'
   | 'thermocycler'
+  | 'heaterShaker'
 export const stepIconsByType: Record<StepType, IconName> = {
   moveLiquid: 'ot-transfer',
   mix: 'ot-mix',
@@ -89,6 +90,7 @@ export const stepIconsByType: Record<StepType, IconName> = {
   magnet: 'ot-magnet',
   temperature: 'ot-temperature',
   thermocycler: 'ot-thermocycler',
+  heaterShaker: 'ot-heater-shaker'
 }
 // ===== Unprocessed form types =====
 export interface AnnotationFields {

--- a/protocol-designer/src/form-types.ts
+++ b/protocol-designer/src/form-types.ts
@@ -90,7 +90,7 @@ export const stepIconsByType: Record<StepType, IconName> = {
   magnet: 'ot-magnet',
   temperature: 'ot-temperature',
   thermocycler: 'ot-thermocycler',
-  heaterShaker: 'ot-heater-shaker'
+  heaterShaker: 'ot-heater-shaker',
 }
 // ===== Unprocessed form types =====
 export interface AnnotationFields {

--- a/protocol-designer/src/localization/en/application.json
+++ b/protocol-designer/src/localization/en/application.json
@@ -5,6 +5,7 @@
     "pause": "pause",
     "magnet": "magnet",
     "temperature": "temperature",
+    "heaterShaker": "heater-shaker",
     "thermocycler": "thermocycler",
     "profile_settings": "profile settings",
     "profile_steps": "profile steps",

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -10,7 +10,8 @@
     "moveLiquid": "Move liquid to and from wells/tubes.",
     "magnet": "Engage or disengage the Magnetic module.",
     "temperature": "Set temperature command for Temperature module.",
-    "thermocycler": "Change Thermocycler state or program a profile."
+    "thermocycler": "Change Thermocycler state or program a profile.",
+    "heaterShaker": "Set heat, shake, or labware latch commands for the Heater Shaker module"
   },
 
   "disabled_module_step": "Add a relevant module to use this step",


### PR DESCRIPTION
closes #9562

paired with @shlokamin  and @sakibh 

# Overview

this PR adds the `HeaterShaker` to `Add Step` in the Design tab in PD

<img width="357" alt="Screen Shot 2022-03-07 at 4 04 15 PM" src="https://user-images.githubusercontent.com/66035149/157117542-e9840f3f-0cef-43c3-a678-08696529579e.png">

# Changelog

- added heater shaker as a supported step and added the icon and tooltips

# Review requests

- turn the h/s feature flag on when running PD locally and add the heater shaker to the protocol. Then in the Design tab, in the `add step` section, you should see heater shaker

# Risk assessment

low