### PR TITLE
fix(robot-server): clean up modules in fixtures.

### DIFF
--- a/robot-server/tests/service/legacy/routers/test_modules.py
+++ b/robot-server/tests/service/legacy/routers/test_modules.py
@@ -36,6 +36,8 @@ def magdeck():
 
     yield m
 
+    m.cleanup()
+
 
 @pytest.fixture
 def tempdeck():
@@ -59,6 +61,8 @@ def tempdeck():
     TempDeck.target = PropertyMock(return_value=321.0)
 
     yield t
+
+    t.cleanup()
 
 
 @pytest.fixture
@@ -90,7 +94,10 @@ def thermocycler():
     Thermocycler.total_cycle_count = PropertyMock(return_value=3)
     Thermocycler.current_step_index = PropertyMock(return_value=5)
     Thermocycler.total_step_count = PropertyMock(return_value=2)
-    return t
+    yield t
+
+    t.cleanup()
+
 
 
 @pytest.fixture
@@ -127,7 +134,8 @@ def heater_shaker():
             },
         }
     )
-    return heatershaker
+    yield heatershaker
+    heatershaker.cleanup()
 
 
 def test_get_modules_magdeck(api_client, hardware, magdeck):

--- a/robot-server/tests/service/legacy/routers/test_modules.py
+++ b/robot-server/tests/service/legacy/routers/test_modules.py
@@ -99,7 +99,6 @@ def thermocycler():
     t.cleanup()
 
 
-
 @pytest.fixture
 def heater_shaker():
     """Get a mocked out heater-shaker hardware control object."""

--- a/robot-server/tests/service/legacy/routers/test_settings.py
+++ b/robot-server/tests/service/legacy/routers/test_settings.py
@@ -209,17 +209,14 @@ def test_available_resets(api_client):
     body = resp.json()
     options_list = body.get("options")
     assert resp.status_code == 200
-    assert (
-        sorted(
-            [
-                "deckCalibration",
-                "pipetteOffsetCalibrations",
-                "bootScripts",
-                "tipLengthCalibrations",
-            ]
-        )
-        == sorted([item["id"] for item in options_list])
-    )
+    assert sorted(
+        [
+            "deckCalibration",
+            "pipetteOffsetCalibrations",
+            "bootScripts",
+            "tipLengthCalibrations",
+        ]
+    ) == sorted([item["id"] for item in options_list])
 
 
 @pytest.fixture

--- a/robot-server/tests/service/legacy/routers/test_settings.py
+++ b/robot-server/tests/service/legacy/routers/test_settings.py
@@ -209,14 +209,17 @@ def test_available_resets(api_client):
     body = resp.json()
     options_list = body.get("options")
     assert resp.status_code == 200
-    assert sorted(
-        [
-            "deckCalibration",
-            "pipetteOffsetCalibrations",
-            "bootScripts",
-            "tipLengthCalibrations",
-        ]
-    ) == sorted([item["id"] for item in options_list])
+    assert (
+        sorted(
+            [
+                "deckCalibration",
+                "pipetteOffsetCalibrations",
+                "bootScripts",
+                "tipLengthCalibrations",
+            ]
+        )
+        == sorted([item["id"] for item in options_list])
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
# Overview

`test_create_subscriber` is failing occasionally in CI. Can't reproduce it on my machine, but looking at error report I see:
```
ERROR    opentrons.hardware_control.util:util.py:16 Caught exception:
 {'message': 'Task was destroyed but it is pending!', 'task': <Task pending coro=<Poller._poller() running at 
/home/runner/work/opentrons/opentrons/api/src/opentrons/hardware_control/poller.py:144> 
wait_for=<Future pending cb=[<TaskWakeupMethWrapper object at 0x7fccb8d5c150>()]>>}
```

Digging in I found that the module tests were not cleaning up the created modules. 

Whether this explains the sporadic failures of `test_create_subscriber` is yet to be seen. At the very least this was a bug.

# Changelog

Module fixtures call clean up.


# Review requests

# Risk assessment
None