### PR TITLE
refactor(protocol-engine): Add skeleton for `magneticModule/disengageMagnet`

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -137,6 +137,7 @@ Command = Union[
     heater_shaker.StopShake,
     heater_shaker.OpenLatch,
     heater_shaker.CloseLatch,
+    magnetic_module.Disengage,
     magnetic_module.Engage,
     SetRailLights,
 ]
@@ -162,6 +163,7 @@ CommandParams = Union[
     heater_shaker.StopShakeParams,
     heater_shaker.OpenLatchParams,
     heater_shaker.CloseLatchParams,
+    magnetic_module.DisengageParams,
     magnetic_module.EngageParams,
     SetRailLightsParams,
 ]
@@ -187,6 +189,7 @@ CommandType = Union[
     heater_shaker.StopShakeCommandType,
     heater_shaker.OpenLatchCommandType,
     heater_shaker.CloseLatchCommandType,
+    magnetic_module.DisengageCommandType,
     magnetic_module.EngageCommandType,
     SetRailLightsCommandType,
 ]
@@ -211,6 +214,7 @@ CommandCreate = Union[
     heater_shaker.StopShakeCreate,
     heater_shaker.OpenLatchCreate,
     heater_shaker.CloseLatchCreate,
+    magnetic_module.DisengageCreate,
     magnetic_module.EngageCreate,
     SetRailLightsCreate,
 ]
@@ -236,6 +240,7 @@ CommandResult = Union[
     heater_shaker.StopShakeResult,
     heater_shaker.OpenLatchResult,
     heater_shaker.CloseLatchResult,
+    magnetic_module.DisengageResult,
     magnetic_module.EngageResult,
     SetRailLightsResult,
 ]

--- a/api/src/opentrons/protocol_engine/commands/magnetic_module/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/magnetic_module/__init__.py
@@ -1,5 +1,12 @@
 """Magnetic Module protocol commands."""
 
+from .disengage import (
+    Disengage,
+    DisengageCreate,
+    DisengageParams,
+    DisengageResult,
+    DisengageCommandType,
+)
 from .engage import (
     Engage,
     EngageCreate,
@@ -8,25 +15,18 @@ from .engage import (
     EngageCommandType,
 )
 
-from .disengage import (
-    Disengage,
-    DisengageCreate,
-    DisengageParams,
-    DisengageResult,
-    DisengageCommandType,
-)
 
 __all__ = [
-    # magneticModule/engageMagnet
-    "Engage",
-    "EngageCreate",
-    "EngageParams",
-    "EngageResult",
-    "EngageCommandType",
     # magneticModule/disengageMagnet
     "Disengage",
     "DisengageCreate",
     "DisengageParams",
     "DisengageResult",
     "DisengageCommandType",
+    # magneticModule/engageMagnet
+    "Engage",
+    "EngageCreate",
+    "EngageParams",
+    "EngageResult",
+    "EngageCommandType",
 ]

--- a/api/src/opentrons/protocol_engine/commands/magnetic_module/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/magnetic_module/__init__.py
@@ -8,6 +8,14 @@ from .engage import (
     EngageCommandType,
 )
 
+from .disengage import (
+    Disengage,
+    DisengageCreate,
+    DisengageParams,
+    DisengageResult,
+    DisengageCommandType,
+)
+
 __all__ = [
     # magneticModule/engageMagnet
     "Engage",
@@ -15,4 +23,10 @@ __all__ = [
     "EngageParams",
     "EngageResult",
     "EngageCommandType",
+    # magneticModule/disengageMagnet
+    "Disengage",
+    "DisengageCreate",
+    "DisengageParams",
+    "DisengageResult",
+    "DisengageCommandType",
 ]

--- a/api/src/opentrons/protocol_engine/commands/magnetic_module/disengage.py
+++ b/api/src/opentrons/protocol_engine/commands/magnetic_module/disengage.py
@@ -1,0 +1,60 @@
+"""Magnetic Module disengage command request, result, and implementation models."""
+
+
+from __future__ import annotations
+
+from typing import Optional
+from typing_extensions import Literal, Type
+
+from pydantic import BaseModel, Field
+
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+
+DisengageCommandType = Literal["magneticModule/disengageMagnet"]
+
+
+class DisengageParams(BaseModel):
+    """Input data to disengage a Magnetic Module's magnets."""
+
+    moduleId: str = Field(
+        ...,
+        description=(
+            "The ID of the Magnetic Module whose magnets you want to disengage,"
+            " from a prior `loadModule` command."
+        ),
+    )
+
+
+class DisengageResult(BaseModel):
+    """The result of a Magnetic Module disengage command."""
+
+    pass
+
+
+class DisengageImplementation(AbstractCommandImpl[DisengageParams, DisengageResult]):
+    """The implementation of a Magnetic Module disengage command."""
+
+    async def execute(self, params: DisengageParams) -> DisengageResult:
+        """Execute a Magnetic Module disengage command."""
+        raise NotImplementedError()
+        return DisengageResult()
+
+
+class Disengage(BaseCommand[DisengageParams, DisengageResult]):
+    """A command to disengage a Magnetic Module's magnets."""
+
+    commandType: DisengageCommandType = "magneticModule/disengageMagnet"
+    params: DisengageParams
+    result: Optional[DisengageResult]
+
+    _ImplementationCls: Type[DisengageImplementation] = DisengageImplementation
+
+
+class DisengageCreate(BaseCommandCreate[DisengageParams]):
+    """A request to create a Magnetic Module disengage command."""
+
+    commandType: DisengageCommandType = "magneticModule/disengageMagnet"
+    params: DisengageParams
+
+    _CommandCls: Type[Disengage] = Disengage


### PR DESCRIPTION
# Changelog

* Add Python models for the Protocol Engine `magneticModule/disengageMagnet` command, matching the same command from our JSON protocol v6 schema.
* Leave `.execute()` as an untested no-op. It will be filled in in another PR.

# Review requests

* Do the new models exactly match [the JSON protocol v6 schema](https://github.com/Opentrons/opentrons/blob/edge/shared-data/protocol/schemas/6.json)?
* Have I made any silly copy-paste errors, for example in class names or docstrings?

# Risk assessment

No risk, assuming CI passes.
