### PR TITLE
refactor(protocol-designer): change selected path icon border

### DIFF
--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -156,7 +156,7 @@
   height: 1.55rem;
   margin-right: 0.25rem;
   border-radius: 2px;
-  border: 1px solid var(--c-med-gray);
+  border: 1.5px solid #000000;
   cursor: pointer;
 }
 

--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -155,13 +155,15 @@
   width: 2.275rem;
   height: 1.55rem;
   margin-right: 0.25rem;
-  border-radius: 2px;
-  border: 1.5px solid #000000;
   cursor: pointer;
+  border-radius: 2px;
+  border: 1px solid #c4c4c4;
 }
 
 .path_option.selected {
   background-color: var(--c-light-gray);
+  border-radius: 2px;
+  border: 1.5px solid #000000;
 }
 
 .path_option.disabled {

--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -163,7 +163,7 @@
 .path_option.selected {
   background-color: var(--c-light-gray);
   border-radius: 2px;
-  border: 1.5px solid #000000;
+  border: 1.5px solid #000;
 }
 
 .path_option.disabled {

--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -163,7 +163,7 @@
 .path_option.selected {
   background-color: var(--c-light-gray);
   border-radius: 2px;
-  border: 1.5px solid #000;
+  border: 1.5px solid var(--c-black);
 }
 
 .path_option.disabled {


### PR DESCRIPTION
closes #9658

# Overview

This is a quick change to update the path border in PD under transfer step to match the new designs

<img width="359" alt="Screen Shot 2022-03-09 at 9 44 42 AM" src="https://user-images.githubusercontent.com/66035149/157464755-1a74fab4-c9f2-4346-a0fd-678a6c47cad2.png">


# Changelog

- updates `path_option` in CSS style sheet
- updates `path_option.selected` in style sheet

# Review requests

- does it match figma? 

# Risk assessment

low