### PR TITLE
fix(hardware): plan motion script needs converter to handle int64 vals

### DIFF
--- a/hardware/opentrons_hardware/scripts/motion_params.json
+++ b/hardware/opentrons_hardware/scripts/motion_params.json
@@ -31,7 +31,7 @@
       "max_direction_change_speed_discont": 30
     }
   },
-  "origin": [0, 0, 0, 0, 0, 0],
+  "origin": [200, 200, 200, 0, 0, 0],
   "target_list": [
     {
       "coordinates": [100, 0, 0, 0, 0, 0],

--- a/hardware/opentrons_hardware/scripts/plan_motion.py
+++ b/hardware/opentrons_hardware/scripts/plan_motion.py
@@ -4,7 +4,7 @@ import json
 import logging
 from logging.config import dictConfig
 import argparse
-import numpy as np
+import numpy as np  # type: ignore[import]
 
 from opentrons_hardware.hardware_control.motion_planning import move_manager
 from opentrons_hardware.hardware_control.motion_planning.types import (
@@ -112,11 +112,12 @@ def main() -> None:
         "origin": list(vectorize(origin)),
     }
 
-    def myconverter(obj):
+    def myconverter(obj: Any) -> Any:
         if isinstance(obj, np.integer):
             return int(obj)
         elif isinstance(obj, np.floating):
             return float(obj)
+        return obj
 
     with open(args.output, "w") as f:
         json.dump(output, f, indent=2, default=myconverter)

--- a/hardware/opentrons_hardware/scripts/plan_motion.py
+++ b/hardware/opentrons_hardware/scripts/plan_motion.py
@@ -4,6 +4,7 @@ import json
 import logging
 from logging.config import dictConfig
 import argparse
+import numpy as np
 
 from opentrons_hardware.hardware_control.motion_planning import move_manager
 from opentrons_hardware.hardware_control.motion_planning.types import (
@@ -94,7 +95,7 @@ def main() -> None:
     origin: Coordinates[str, float] = dict(zip(AXIS_NAMES, origin_from_file))
     target_list = [
         MoveTarget.build(
-            dict(zip(AXIS_NAMES, *target["coordinates"])), target["max_speed"]
+            dict(zip(AXIS_NAMES, target["coordinates"])), target["max_speed"]
         )
         for target in params["target_list"]
     ]
@@ -111,8 +112,14 @@ def main() -> None:
         "origin": list(vectorize(origin)),
     }
 
+    def myconverter(obj):
+        if isinstance(obj, np.integer):
+            return int(obj)
+        elif isinstance(obj, np.floating):
+            return float(obj)
+
     with open(args.output, "w") as f:
-        json.dump(output, f, indent=2)
+        json.dump(output, f, indent=2, default=myconverter)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes 2 things:
1. Coordinates need to be a list
2. Adds a converter to convert `np.int` values to `int`