### PR TITLE
refactor(protocol-engine): Implement `magneticModule/disengageMagnet`

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/magnetic_module/disengage.py
+++ b/api/src/opentrons/protocol_engine/commands/magnetic_module/disengage.py
@@ -63,13 +63,15 @@ class DisengageImplementation(AbstractCommandImpl[DisengageParams, DisengageResu
         # Allow propagation of ModuleDoesNotExistError and WrongModuleTypeError.
         # Do this check even when using virtual modules,
         # to fully validate module IDs during analysis.
-        self._state_view.modules.assert_is_magnetic_module(module_id=params.moduleId)
+        magnetic_module_id = self._state_view.modules.assert_is_magnetic_module(
+            module_id=params.moduleId
+        )
 
         if not self._state_view.get_configs().use_virtual_modules:
             all_attached_modules = self._hardware_api.attached_modules
             # Allow propagation of ModuleNotAttachedError.
             target_module = self._state_view.modules.find_loaded_hardware_module(
-                module_id=params.moduleId,
+                module_id=magnetic_module_id,
                 attached_modules=all_attached_modules,
                 expected_type=MagDeck,
             )

--- a/api/src/opentrons/protocol_engine/commands/magnetic_module/disengage.py
+++ b/api/src/opentrons/protocol_engine/commands/magnetic_module/disengage.py
@@ -63,15 +63,13 @@ class DisengageImplementation(AbstractCommandImpl[DisengageParams, DisengageResu
         # Allow propagation of ModuleDoesNotExistError and WrongModuleTypeError.
         # Do this check even when using virtual modules,
         # to fully validate module IDs during analysis.
-        magnetic_module_id = self._state_view.modules.assert_is_magnetic_module(
-            module_id=params.moduleId
-        )
+        self._state_view.modules.assert_is_magnetic_module(module_id=params.moduleId)
 
         if not self._state_view.get_configs().use_virtual_modules:
             all_attached_modules = self._hardware_api.attached_modules
             # Allow propagation of ModuleNotAttachedError.
             target_module = self._state_view.modules.find_loaded_hardware_module(
-                module_id=magnetic_module_id,
+                module_id=params.moduleId,
                 attached_modules=all_attached_modules,
                 expected_type=MagDeck,
             )

--- a/api/src/opentrons/protocol_engine/commands/magnetic_module/disengage.py
+++ b/api/src/opentrons/protocol_engine/commands/magnetic_module/disengage.py
@@ -3,12 +3,18 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 from typing_extensions import Literal, Type
 
 from pydantic import BaseModel, Field
 
+from opentrons.hardware_control import HardwareControlAPI
+from opentrons.hardware_control.modules import MagDeck
+
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+if TYPE_CHECKING:
+    from opentrons.protocol_engine.state import StateView
 
 
 DisengageCommandType = Literal["magneticModule/disengageMagnet"]
@@ -35,9 +41,40 @@ class DisengageResult(BaseModel):
 class DisengageImplementation(AbstractCommandImpl[DisengageParams, DisengageResult]):
     """The implementation of a Magnetic Module disengage command."""
 
+    def __init__(
+        self,
+        state_view: StateView,
+        hardware_api: HardwareControlAPI,
+        **unused_dependencies: object,
+    ) -> None:
+        self._state_view = state_view
+        self._hardware_api = hardware_api
+
     async def execute(self, params: DisengageParams) -> DisengageResult:
-        """Execute a Magnetic Module disengage command."""
-        raise NotImplementedError()
+        """Execute a Magnetic Module disengage command.
+
+        Raises:
+            ModuleDoesNotExistError: If the given module ID has not been loaded.
+            WrongModuleTypeError: If the given module ID has been loaded,
+                but it's not a Magnetic Module.
+            ModuleNotAttachedError: If the given module ID points to a valid loaded
+                Magnetic Module, but that module's hardware wasn't found attached.
+        """
+        # Allow propagation of ModuleDoesNotExistError and WrongModuleTypeError.
+        # Do this check even when using virtual modules,
+        # to fully validate module IDs during analysis.
+        self._state_view.modules.assert_is_magnetic_module(module_id=params.moduleId)
+
+        if not self._state_view.get_configs().use_virtual_modules:
+            all_attached_modules = self._hardware_api.attached_modules
+            # Allow propagation of ModuleNotAttachedError.
+            target_module = self._state_view.modules.find_loaded_hardware_module(
+                module_id=params.moduleId,
+                attached_modules=all_attached_modules,
+                expected_type=MagDeck,
+            )
+            await target_module.deactivate()
+
         return DisengageResult()
 
 

--- a/api/src/opentrons/protocol_engine/commands/magnetic_module/disengage.py
+++ b/api/src/opentrons/protocol_engine/commands/magnetic_module/disengage.py
@@ -9,7 +9,6 @@ from typing_extensions import Literal, Type
 from pydantic import BaseModel, Field
 
 from opentrons.hardware_control import HardwareControlAPI
-from opentrons.hardware_control.modules import MagDeck
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 

--- a/api/src/opentrons/protocol_engine/commands/magnetic_module/engage.py
+++ b/api/src/opentrons/protocol_engine/commands/magnetic_module/engage.py
@@ -69,19 +69,7 @@ class EngageImplementation(AbstractCommandImpl[EngageParams, EngageResult]):
         self._hardware_api = hardware_api
 
     async def execute(self, params: EngageParams) -> EngageResult:
-        """Execute a Magnetic Module engage command."""
-        await self._engage_magnets(
-            magnetic_module_id=params.moduleId,
-            mm_from_base=params.engageHeight,
-        )
-        return EngageResult()
-
-    async def _engage_magnets(
-        self,
-        magnetic_module_id: str,
-        mm_from_base: float,
-    ) -> None:
-        """Engage a loaded Magnetic Module's magnets.
+        """Execute a Magnetic Module engage command.
 
         Raises:
             ModuleDoesNotExistError: If the given module ID doesn't point to a
@@ -92,23 +80,21 @@ class EngageImplementation(AbstractCommandImpl[EngageParams, EngageResult]):
                 Magnetic Module, but that module's hardware wasn't found attached.
             EngageHeightOutOfRangeError: If the given height is unreachable.
         """
-        # Allow propagation of ModuleDoesNotExistError.
-        model = self._state_view.modules.get_model(module_id=magnetic_module_id)
-
-        # Allow propagation of WrongModuleTypeError and EngageHeightOutOfRangeError.
-        hardware_height = self._state_view.modules.calculate_magnet_hardware_height(
-            magnetic_module_model=model,
-            mm_from_base=mm_from_base,
+        # Allow propagation of ModuleDoesNotExistError and WrongModuleTypeError.
+        magnetic_module_view = self._state_view.modules.get_magnetic_module_view(
+            module_id=params.moduleId,
         )
-
-        if not self._state_view.get_configs().use_virtual_modules:
-            # Allow propagation of ModuleNotAttachedError.
-            hardware_module = self._state_view.modules.find_loaded_hardware_module(
-                module_id=magnetic_module_id,
-                attached_modules=self._hardware_api.attached_modules,
-                expected_type=MagDeck,
-            )
+        # Allow propagation of EngageHeightOutOfRangeError.
+        hardware_height = magnetic_module_view.calculate_magnet_hardware_height(
+            mm_from_base=params.engageHeight,
+        )
+        # Allow propagation of ModuleNotAttachedError.
+        hardware_module = magnetic_module_view.find_hardware(
+            attached_modules=self._hardware_api.attached_modules,
+        )
+        if hardware_module is not None:  # Not virtualizing modules.
             await hardware_module.engage(height=hardware_height)
+        return EngageResult()
 
 
 class Engage(BaseCommand[EngageParams, EngageResult]):

--- a/api/src/opentrons/protocol_engine/commands/magnetic_module/engage.py
+++ b/api/src/opentrons/protocol_engine/commands/magnetic_module/engage.py
@@ -8,10 +8,10 @@ from typing_extensions import Literal, Type
 
 from pydantic import BaseModel, Field
 
-from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
-
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.modules import MagDeck
+
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView

--- a/api/src/opentrons/protocol_engine/commands/magnetic_module/engage.py
+++ b/api/src/opentrons/protocol_engine/commands/magnetic_module/engage.py
@@ -9,7 +9,6 @@ from typing_extensions import Literal, Type
 from pydantic import BaseModel, Field
 
 from opentrons.hardware_control import HardwareControlAPI
-from opentrons.hardware_control.modules import MagDeck
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 

--- a/api/src/opentrons/protocol_engine/state/__init__.py
+++ b/api/src/opentrons/protocol_engine/state/__init__.py
@@ -4,7 +4,7 @@ from .state import State, StateStore, StateView
 from .commands import CommandState, CommandView, CommandSlice, CurrentCommand
 from .labware import LabwareState, LabwareView
 from .pipettes import PipetteState, PipetteView, HardwarePipette, CurrentWell
-from .modules import ModuleState, ModuleView, HardwareModule
+from .modules import ModuleState, ModuleView, MagneticModuleView, HardwareModule
 from .geometry import GeometryView, TipGeometry
 from .motion import MotionView, PipetteLocationData
 from .configs import EngineConfigs
@@ -30,6 +30,7 @@ __all__ = [
     # module state and values
     "ModuleState",
     "ModuleView",
+    "MagneticModuleView",
     "HardwareModule",
     # computed geometry state
     "GeometryView",

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -100,9 +100,13 @@ class ModuleView(HasState[ModuleState]):
 
     _state: ModuleState
 
-    def __init__(self, state: ModuleState) -> None:
+    # TODO(mm, 2022-03-14): Fix this duplication between here and EngineConfigs.
+    _virtualize_modules: bool
+
+    def __init__(self, state: ModuleState, virtualize_modules: bool) -> None:
         """Initialize the view with its backing state value."""
         self._state = state
+        self._virtualize_modules = virtualize_modules
 
     def get(self, module_id: str) -> LoadedModule:
         """Get module data by the module's unique identifier."""
@@ -122,6 +126,10 @@ class ModuleView(HasState[ModuleState]):
             location=DeckSlotLocation(slotName=slot_name),
             definition=attached_module.definition,
         )
+
+    def is_virtualizing_modules(self) -> bool:
+        """Return whether this Protocol Engine is using virtual modules."""
+        return self._virtualize_modules
 
     def get_all(self) -> List[LoadedModule]:
         """Get a list of all module entries in state."""

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -1,9 +1,14 @@
 """Basic modules data state and store."""
+
+
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Dict, List, NamedTuple, Optional, Sequence, Type, TypeVar, overload
+from typing_extensions import Final
 from numpy import array, dot
 
-from opentrons.hardware_control.modules import AbstractModule
+from opentrons.hardware_control.modules import AbstractModule, MagDeck
 from opentrons.hardware_control.modules.magdeck import (
     engage_height_is_in_range,
     OFFSET_TO_LABWARE_BOTTOM as MAGNETIC_MODULE_OFFSET_TO_LABWARE_BOTTOM,
@@ -135,6 +140,25 @@ class ModuleView(HasState[ModuleState]):
         """Get a list of all module entries in state."""
         return [self.get(mod_id) for mod_id in self._state.slot_by_module_id.keys()]
 
+    def get_magnetic_module_view(self, module_id: str) -> MagneticModuleView:
+        """Return a `MagneticModuleView` for the given Magnetic Module.
+
+        Raises:
+            ModuleDoesNotExistError: If module_id has not been loaded.
+            WrongModuleTypeError: If module_id has been loaded,
+                but it's not a Magnetic Module.
+        """
+        model = self.get_model(module_id=module_id)  # Propagate ModuleDoesNotExistError
+        if model in [
+            ModuleModel.MAGNETIC_MODULE_V1,
+            ModuleModel.MAGNETIC_MODULE_V2,
+        ]:
+            return MagneticModuleView(parent_module_view=self, module_id=module_id)
+        else:
+            raise errors.WrongModuleTypeError(
+                f"{module_id} is a {model}, not a Magnetic Module."
+            )
+
     def get_location(self, module_id: str) -> DeckSlotLocation:
         """Get the slot location of the given module."""
         return self.get(module_id).location
@@ -207,24 +231,6 @@ class ModuleView(HasState[ModuleState]):
         else:
             raise errors.WrongModuleTypeError(
                 f"Cannot get lid height of {definition.moduleType}"
-            )
-
-    def assert_is_magnetic_module(self, module_id: str) -> None:
-        """Make sure the given module ID points to a Magnetic Module.
-
-        Raises:
-            ModuleDoesNotExistError: If module_id has not been loaded.
-            WrongModuleTypeError: If module_id has been loaded,
-                but it's not a Magnetic Module.
-        """
-        # Propagate ModuleDoesNotExistError.
-        model = self.get_model(module_id=module_id)
-        if model not in [
-            ModuleModel.MAGNETIC_MODULE_V1,
-            ModuleModel.MAGNETIC_MODULE_V2,
-        ]:
-            raise errors.WrongModuleTypeError(
-                f"{module_id} is a {model}, not a Magnetic Module."
             )
 
     @staticmethod
@@ -326,58 +332,6 @@ class ModuleView(HasState[ModuleState]):
             assert offset_from_labware_default is not None
             return labware_default_height + offset_from_labware_default
 
-    @staticmethod
-    def calculate_magnet_hardware_height(
-        magnetic_module_model: ModuleModel, mm_from_base: float
-    ) -> float:
-        """Convert a human-friendly magnet height to be hardware-friendly.
-
-        Args:
-            magnetic_module_model: The model of Magnetic Module to calculate
-                a height for.
-            mm_from_base: The height to convert. Measured in how far the tops
-                of the magnets are above the labware base plane.
-
-        Returns:
-            The same height, with its units and origin point converted
-            so that it's suitable to pass to `MagDeck.engage()`.
-
-        Raises:
-            WrongModuleTypeError: If the given model is not a Magnetic Module.
-            EngageHeightOutOfRangeError: If modules of the given model are
-                physically incapable of reaching the requested height.
-        """
-        if magnetic_module_model not in [
-            ModuleModel.MAGNETIC_MODULE_V1,
-            ModuleModel.MAGNETIC_MODULE_V2,
-        ]:
-            raise errors.WrongModuleTypeError(
-                f"{magnetic_module_model} is not a Magnetic Module."
-            )
-
-        hardware_units_from_base = (
-            mm_from_base * 2
-            if magnetic_module_model == ModuleModel.MAGNETIC_MODULE_V1
-            else mm_from_base
-        )
-        home_to_base_offset = MAGNETIC_MODULE_OFFSET_TO_LABWARE_BOTTOM[
-            magnetic_module_model
-        ]
-        hardware_units_from_home = home_to_base_offset + hardware_units_from_base
-        if not engage_height_is_in_range(
-            model=magnetic_module_model, height=hardware_units_from_home
-        ):
-            # TODO(mm, 2022-03-02): This error message probably will not match how
-            # the user specified the height. (Hardware units versus mm,
-            # home as origin versus labware base as origin.) This may be confusing
-            # depending on how it propagates up.
-            raise errors.EngageHeightOutOfRangeError(
-                f"Invalid engage height for"
-                f" {magnetic_module_model}: {hardware_units_from_home}. Must be"
-                f" 0 - {MAGNETIC_MODULE_MAX_ENGAGE_HEIGHT[magnetic_module_model]}."
-            )
-        return hardware_units_from_home
-
     def should_dodge_thermocycler(
         self,
         from_slot: DeckSlotName,
@@ -395,55 +349,6 @@ class ModuleView(HasState[ModuleState]):
             if transit in _THERMOCYCLER_SLOT_TRANSITS_TO_DODGE:
                 return True
         return False
-
-    _ModuleT = TypeVar("_ModuleT", bound=AbstractModule)
-
-    def find_loaded_hardware_module(
-        self,
-        module_id: str,
-        attached_modules: List[AbstractModule],
-        expected_type: Type[_ModuleT],
-    ) -> _ModuleT:
-        """Return the hardware module that corresponds to a Protocol Engine module ID.
-
-        Should not be called when the ``use_virtual_modules`` engine config is True,
-        since loaded modules will have no associated hardware modules.
-
-        Args:
-            module_id: The Protocol Engine ID of a loaded module to search for.
-            attached_modules: The list of currently attached hardware modules,
-                as returned by the hardware API.
-            expected_type: The Python type (class) that you expect the matching
-                hardware module to have.
-
-        Returns:
-            The element of ``attached_hardware_modules`` that corresponds to
-            the given ``module_id`.
-
-        Raises:
-            ModuleDoesNotExistError: If module_id has not been loaded.
-            ModuleNotAttachedError: If module_id has been loaded, but none of the
-                attached hardware modules match it.
-            WrongModuleTypeError: If a matching hardware module was found,
-                but it isn't an instance of ``expected_type``.
-        """
-        # May raise ModuleDoesNotExistError.
-        serial_number = self.get_serial_number(module_id=module_id)
-
-        for candidate in attached_modules:
-            if candidate.device_info["serial"] == serial_number:
-                if isinstance(candidate, expected_type):
-                    return candidate
-                else:
-                    raise errors.WrongModuleTypeError(
-                        f'Module with serial number "{serial_number}"'
-                        f' and Protocol Engine ID "{module_id}"'
-                        f' is type "{type(candidate)}", but expected "{expected_type}".'
-                    )
-        raise errors.ModuleNotAttachedError(
-            f'No module attached with serial number "{serial_number}'
-            f' for Protocol Engine module ID "{module_id}".'
-        )
 
     def select_hardware_module_to_load(
         self,
@@ -492,3 +397,103 @@ class ModuleView(HasState[ModuleState]):
                     return m
 
         raise errors.ModuleNotAttachedError(f"No available {model.value} found.")
+
+
+class MagneticModuleView:
+    """A Magnetic Module view.
+
+    Provides calculations and read-only state access
+    for an individual loaded Magnetic Module.
+    """
+
+    def __init__(self, parent_module_view: ModuleView, module_id: str) -> None:
+        """Initialize the `MagneticModuleView`.
+
+        Do not use this initializer directly, except in tests.
+        Use `ModuleView.get_magnetic_module_view()` instead.
+        """
+        self.parent_module_view: Final = parent_module_view
+        self.module_id: Final = module_id
+
+    def find_hardware(
+        self, attached_modules: List[AbstractModule]
+    ) -> Optional[MagDeck]:
+        """Find the matching attached hardware module.
+
+        Params:
+            attached_modules: The list of attached hardware modules,
+                from the `HardwareControlAPI`, to search.
+                If the Protocol Engine is using virtual modules,
+                there are no meaningful "attached hardware modules,"
+                so this list is ignored.
+
+        Returns:
+            If the Protocol Engine is using virtual modules, returns ``None``.
+            If not, returns the element of attached_modules that corresponds to
+            the same individual module as this `MagneticModuleView`.
+
+        Raises:
+            ModuleNotAttachedError: If no match was found in ``attached_modules``,
+                and the Protocol Engine is *not* using virtual modules.
+        """
+        if self.parent_module_view.is_virtualizing_modules():
+            return None
+        else:
+            serial_number = self.parent_module_view.get_serial_number(
+                module_id=self.module_id
+            )
+            for candidate in attached_modules:
+                if candidate.device_info["serial"] == serial_number and isinstance(
+                    candidate, MagDeck
+                ):
+                    return candidate
+            # This will report a mismatched module type as ModuleNotAttachedError
+            # instead of WrongModuleTypeError, but that's fine because that
+            # shouldn't be possible anyway. (It should be caught at module load.)
+            raise errors.ModuleNotAttachedError(
+                f'No module attached with serial number "{serial_number}'
+                f' for Protocol Engine module ID "{self.module_id}".'
+            )
+
+    def calculate_magnet_hardware_height(self, mm_from_base: float) -> float:
+        """Convert a human-friendly magnet height to be hardware-friendly.
+
+        Args:
+            mm_from_base: The height to convert. Measured in how far the tops
+                of the magnets are above the labware base plane.
+
+        Returns:
+            The same height, with its units and origin point converted
+            so that it's suitable to pass to `MagDeck.engage()`.
+
+        Raises:
+            WrongModuleTypeError: If the given model is not a Magnetic Module.
+            EngageHeightOutOfRangeError: If modules of the given model are
+                physically incapable of reaching the requested height.
+        """
+        model = self.parent_module_view.get_model(self.module_id)
+        if model not in [
+            ModuleModel.MAGNETIC_MODULE_V1,
+            ModuleModel.MAGNETIC_MODULE_V2,
+        ]:
+            # Shouldn't be possible; should have been caught during load time.
+            raise errors.WrongModuleTypeError(f"{model} is not a Magnetic Module.")
+
+        hardware_units_from_base = (
+            mm_from_base * 2
+            if model == ModuleModel.MAGNETIC_MODULE_V1
+            else mm_from_base
+        )
+        home_to_base_offset = MAGNETIC_MODULE_OFFSET_TO_LABWARE_BOTTOM[model]
+        hardware_units_from_home = home_to_base_offset + hardware_units_from_base
+        if not engage_height_is_in_range(model=model, height=hardware_units_from_home):
+            # TODO(mm, 2022-03-02): This error message probably will not match how
+            # the user specified the height. (Hardware units versus mm,
+            # home as origin versus labware base as origin.) This may be confusing
+            # depending on how it propagates up.
+            raise errors.EngageHeightOutOfRangeError(
+                f"Invalid engage height for {model}:"
+                f" {hardware_units_from_home}. Must be"
+                f" 0 - {MAGNETIC_MODULE_MAX_ENGAGE_HEIGHT[model]}."
+            )
+        return hardware_units_from_home

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -96,7 +96,7 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
 
 
 class ModuleView(HasState[ModuleState]):
-    """Read-only view of computet modules state."""
+    """Read-only view of computed module state."""
 
     _state: ModuleState
 

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -201,13 +201,16 @@ class ModuleView(HasState[ModuleState]):
                 f"Cannot get lid height of {definition.moduleType}"
             )
 
-    def assert_is_magnetic_module(self, module_id: str) -> None:
+    def assert_is_magnetic_module(self, module_id: str) -> str:
         """Make sure the given module ID points to a Magnetic Module.
 
         Raises:
-            ModuleDoesNotExistError: If module_id has not been loaded.
-            WrongModuleTypeError: If module_id has been loaded,
+            ModuleDoesNotExistError: If ``module_id`` has not been loaded.
+            WrongModuleTypeError: If ``module_id`` has been loaded,
                 but it's not a Magnetic Module.
+
+        Returns:
+            The same ``module_id`` passed in.
         """
         # Propagate ModuleDoesNotExistError.
         model = self.get_model(module_id=module_id)
@@ -218,6 +221,7 @@ class ModuleView(HasState[ModuleState]):
             raise errors.WrongModuleTypeError(
                 f"{module_id} is a {model}, not a Magnetic Module."
             )
+        return module_id
 
     @staticmethod
     def get_magnet_home_to_base_offset(module_model: ModuleModel) -> float:

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List, NamedTuple, Optional, Sequence, Type, TypeVar, overload
+from typing import Dict, List, NamedTuple, Optional, Sequence, overload
 from typing_extensions import Final
 from numpy import array, dot
 

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -210,9 +210,7 @@ class ModuleView(HasState[ModuleState]):
                 but it's not a Magnetic Module.
         """
         # Propagate ModuleDoesNotExistError.
-        model = self.get_model(
-            module_id=module_id
-        )
+        model = self.get_model(module_id=module_id)
         if model not in [
             ModuleModel.MAGNETIC_MODULE_V1,
             ModuleModel.MAGNETIC_MODULE_V2,

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -201,16 +201,13 @@ class ModuleView(HasState[ModuleState]):
                 f"Cannot get lid height of {definition.moduleType}"
             )
 
-    def assert_is_magnetic_module(self, module_id: str) -> str:
+    def assert_is_magnetic_module(self, module_id: str) -> None:
         """Make sure the given module ID points to a Magnetic Module.
 
         Raises:
-            ModuleDoesNotExistError: If ``module_id`` has not been loaded.
-            WrongModuleTypeError: If ``module_id`` has been loaded,
+            ModuleDoesNotExistError: If module_id has not been loaded.
+            WrongModuleTypeError: If module_id has been loaded,
                 but it's not a Magnetic Module.
-
-        Returns:
-            The same ``module_id`` passed in.
         """
         # Propagate ModuleDoesNotExistError.
         model = self.get_model(module_id=module_id)
@@ -221,7 +218,6 @@ class ModuleView(HasState[ModuleState]):
             raise errors.WrongModuleTypeError(
                 f"{module_id} is a {model}, not a Magnetic Module."
             )
-        return module_id
 
     @staticmethod
     def get_magnet_home_to_base_offset(module_model: ModuleModel) -> float:

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -201,6 +201,26 @@ class ModuleView(HasState[ModuleState]):
                 f"Cannot get lid height of {definition.moduleType}"
             )
 
+    def assert_is_magnetic_module(self, module_id: str) -> None:
+        """Make sure the given module ID points to a Magnetic Module.
+
+        Raises:
+            ModuleDoesNotExistError: If module_id has not been loaded.
+            WrongModuleTypeError: If module_id has been loaded,
+                but it's not a Magnetic Module.
+        """
+        # Propagate ModuleDoesNotExistError.
+        model = self.get_model(
+            module_id=module_id
+        )
+        if model not in [
+            ModuleModel.MAGNETIC_MODULE_V1,
+            ModuleModel.MAGNETIC_MODULE_V2,
+        ]:
+            raise errors.WrongModuleTypeError(
+                f"{module_id} is a {model}, not a Magnetic Module."
+            )
+
     @staticmethod
     def get_magnet_home_to_base_offset(module_model: ModuleModel) -> float:
         """Return a Magnetic Module's home offset.

--- a/api/src/opentrons/protocol_engine/state/state.py
+++ b/api/src/opentrons/protocol_engine/state/state.py
@@ -215,7 +215,9 @@ class StateStore(StateView, ActionHandler):
         self._commands = CommandView(state.commands)
         self._labware = LabwareView(state.labware)
         self._pipettes = PipetteView(state.pipettes)
-        self._modules = ModuleView(state.modules)
+        self._modules = ModuleView(
+            state.modules, virtualize_modules=self._configs.use_virtual_modules
+        )
 
         # Derived states
         self._geometry = GeometryView(

--- a/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_disengage.py
+++ b/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_disengage.py
@@ -29,10 +29,6 @@ async def test_magnetic_module_disengage_implementation(
         moduleId="module-id",
     )
 
-    decoy.when(
-        state_view.modules.assert_is_magnetic_module(module_id="module-id")
-    ).then_return("checked-module-id")
-
     decoy.when(state_view.get_configs()).then_return(
         EngineConfigs(
             ignore_pause=False,
@@ -48,14 +44,13 @@ async def test_magnetic_module_disengage_implementation(
 
     decoy.when(
         state_view.modules.find_loaded_hardware_module(
-            module_id="checked-module-id",
-            attached_modules=attached,
-            expected_type=MagDeck,
+            module_id="module-id", attached_modules=attached, expected_type=MagDeck
         )
     ).then_return(match)
 
     result = await subject.execute(params=params)
 
+    decoy.verify(state_view.modules.assert_is_magnetic_module(module_id="module-id"))
     decoy.verify(await match.deactivate(), times=(0 if use_virtual_modules else 1))
 
     assert result == DisengageResult()

--- a/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_disengage.py
+++ b/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_disengage.py
@@ -5,7 +5,7 @@ from decoy import Decoy
 
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.modules import AbstractModule, MagDeck
-from opentrons.protocol_engine.state import StateView, MagneticModuleView, EngineConfigs
+from opentrons.protocol_engine.state import StateView, MagneticModuleView
 from opentrons.protocol_engine.commands.magnetic_module import (
     DisengageParams,
     DisengageResult,

--- a/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_disengage.py
+++ b/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_disengage.py
@@ -1,6 +1,5 @@
 """Test magnetic module disengage commands."""
 
-import pytest
 from decoy import Decoy
 
 from opentrons.hardware_control import HardwareControlAPI
@@ -15,12 +14,10 @@ from opentrons.protocol_engine.commands.magnetic_module.disengage import (
 )
 
 
-@pytest.mark.parametrize("use_virtual_modules", [True, False])
 async def test_magnetic_module_disengage_implementation(
     decoy: Decoy,
     state_view: StateView,
     hardware_api: HardwareControlAPI,
-    use_virtual_modules: bool,
 ) -> None:
     """It should validate, find hardware module if not virtualized, and disengage."""
     subject = DisengageImplementation(state_view=state_view, hardware_api=hardware_api)
@@ -42,5 +39,5 @@ async def test_magnetic_module_disengage_implementation(
 
     result = await subject.execute(params=params)
 
-    decoy.verify(await match.deactivate(), times=(0 if use_virtual_modules else 1))
+    decoy.verify(await match.deactivate(), times=1)
     assert result == DisengageResult()

--- a/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_disengage.py
+++ b/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_disengage.py
@@ -5,7 +5,7 @@ from decoy import Decoy
 
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.modules import AbstractModule, MagDeck
-from opentrons.protocol_engine.state import StateView, EngineConfigs
+from opentrons.protocol_engine.state import StateView, MagneticModuleView, EngineConfigs
 from opentrons.protocol_engine.commands.magnetic_module import (
     DisengageParams,
     DisengageResult,
@@ -29,28 +29,18 @@ async def test_magnetic_module_disengage_implementation(
         moduleId="module-id",
     )
 
-    decoy.when(state_view.get_configs()).then_return(
-        EngineConfigs(
-            ignore_pause=False,
-            use_virtual_modules=use_virtual_modules,
-        )
-    )
+    magnetic_module_view = decoy.mock(cls=MagneticModuleView)
+    decoy.when(
+        state_view.modules.get_magnetic_module_view(module_id="module-id")
+    ).then_return(magnetic_module_view)
 
     attached = [decoy.mock(cls=AbstractModule), decoy.mock(cls=AbstractModule)]
+    match = decoy.mock(cls=MagDeck)
     # "type: ignore" to mock out what's normally a read-only property.
     hardware_api.attached_modules = attached  # type: ignore[misc]
-
-    match = decoy.mock(cls=MagDeck)
-
-    decoy.when(
-        state_view.modules.find_loaded_hardware_module(
-            module_id="module-id", attached_modules=attached, expected_type=MagDeck
-        )
-    ).then_return(match)
+    decoy.when(magnetic_module_view.find_hardware(attached)).then_return(match)
 
     result = await subject.execute(params=params)
 
-    decoy.verify(state_view.modules.assert_is_magnetic_module(module_id="module-id"))
     decoy.verify(await match.deactivate(), times=(0 if use_virtual_modules else 1))
-
     assert result == DisengageResult()

--- a/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_disengage.py
+++ b/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_disengage.py
@@ -1,0 +1,56 @@
+"""Test magnetic module disengage commands."""
+
+import pytest
+from decoy import Decoy
+
+from opentrons.hardware_control import HardwareControlAPI
+from opentrons.hardware_control.modules import AbstractModule, MagDeck
+from opentrons.protocol_engine.state import StateView, EngineConfigs
+from opentrons.protocol_engine.commands.magnetic_module import (
+    DisengageParams,
+    DisengageResult,
+)
+from opentrons.protocol_engine.commands.magnetic_module.disengage import (
+    DisengageImplementation,
+)
+
+
+@pytest.mark.parametrize("use_virtual_modules", [True, False])
+async def test_magnetic_module_disengage_implementation(
+    decoy: Decoy,
+    state_view: StateView,
+    hardware_api: HardwareControlAPI,
+    use_virtual_modules: bool,
+) -> None:
+    """It should validate, find hardware module if not virtualized, and disengage."""
+    subject = DisengageImplementation(state_view=state_view, hardware_api=hardware_api)
+
+    params = DisengageParams(
+        moduleId="module-id",
+    )
+
+    decoy.when(state_view.get_configs()).then_return(
+        EngineConfigs(
+            ignore_pause=False,
+            use_virtual_modules=use_virtual_modules,
+        )
+    )
+
+    attached = [decoy.mock(cls=AbstractModule), decoy.mock(cls=AbstractModule)]
+    # "type: ignore" to mock out what's normally a read-only property.
+    hardware_api.attached_modules = attached  # type: ignore[misc]
+
+    match = decoy.mock(cls=MagDeck)
+
+    decoy.when(
+        state_view.modules.find_loaded_hardware_module(
+            module_id="module-id", attached_modules=attached, expected_type=MagDeck
+        )
+    ).then_return(match)
+
+    result = await subject.execute(params=params)
+
+    decoy.verify(state_view.modules.assert_is_magnetic_module(module_id="module-id"))
+    decoy.verify(await match.deactivate(), times=(0 if use_virtual_modules else 1))
+
+    assert result == DisengageResult()

--- a/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_disengage.py
+++ b/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_disengage.py
@@ -29,6 +29,10 @@ async def test_magnetic_module_disengage_implementation(
         moduleId="module-id",
     )
 
+    decoy.when(
+        state_view.modules.assert_is_magnetic_module(module_id="module-id")
+    ).then_return("checked-module-id")
+
     decoy.when(state_view.get_configs()).then_return(
         EngineConfigs(
             ignore_pause=False,
@@ -44,13 +48,14 @@ async def test_magnetic_module_disengage_implementation(
 
     decoy.when(
         state_view.modules.find_loaded_hardware_module(
-            module_id="module-id", attached_modules=attached, expected_type=MagDeck
+            module_id="checked-module-id",
+            attached_modules=attached,
+            expected_type=MagDeck,
         )
     ).then_return(match)
 
     result = await subject.execute(params=params)
 
-    decoy.verify(state_view.modules.assert_is_magnetic_module(module_id="module-id"))
     decoy.verify(await match.deactivate(), times=(0 if use_virtual_modules else 1))
 
     assert result == DisengageResult()

--- a/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_engage.py
+++ b/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_engage.py
@@ -1,6 +1,5 @@
 """Test magnetic module engage commands."""
 
-import pytest
 from decoy import Decoy
 
 from opentrons.hardware_control import HardwareControlAPI
@@ -15,12 +14,10 @@ from opentrons.protocol_engine.commands.magnetic_module.engage import (
 )
 
 
-@pytest.mark.parametrize("use_virtual_modules", [True, False])
 async def test_magnetic_module_engage_implementation(
     decoy: Decoy,
     state_view: StateView,
     hardware_api: HardwareControlAPI,
-    use_virtual_modules: bool,
 ) -> None:
     """It should calculate the proper hardware height and engage."""
     subject = EngageImplementation(state_view=state_view, hardware_api=hardware_api)
@@ -47,5 +44,5 @@ async def test_magnetic_module_engage_implementation(
 
     result = await subject.execute(params=params)
 
-    decoy.verify(await match.engage(9001), times=(0 if use_virtual_modules else 1))
+    decoy.verify(await match.engage(9001), times=1)
     assert result == EngageResult()

--- a/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_engage.py
+++ b/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_engage.py
@@ -5,7 +5,7 @@ from decoy import Decoy
 
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.modules import AbstractModule, MagDeck
-from opentrons.protocol_engine.state import StateView, EngineConfigs
+from opentrons.protocol_engine.state import EngineConfigs, MagneticModuleView, StateView
 from opentrons.protocol_engine.types import ModuleModel
 from opentrons.protocol_engine.commands.magnetic_module import (
     EngageParams,
@@ -31,36 +31,22 @@ async def test_magnetic_module_engage_implementation(
         engageHeight=3.14159,
     )
 
-    decoy.when(state_view.modules.get_model(module_id="module-id")).then_return(
-        ModuleModel.MAGNETIC_MODULE_V1,
-    )
+    magnetic_module_view = decoy.mock(cls=MagneticModuleView)
     decoy.when(
-        state_view.modules.calculate_magnet_hardware_height(
-            magnetic_module_model=ModuleModel.MAGNETIC_MODULE_V1, mm_from_base=3.14159
-        )
+        state_view.modules.get_magnetic_module_view(module_id="module-id")
+    ).then_return(magnetic_module_view)
+
+    decoy.when(
+        magnetic_module_view.calculate_magnet_hardware_height(mm_from_base=3.14159)
     ).then_return(9001)
 
     attached = [decoy.mock(cls=AbstractModule), decoy.mock(cls=AbstractModule)]
+    match = decoy.mock(cls=MagDeck)
     # "type: ignore" to mock out what's normally a read-only property.
     hardware_api.attached_modules = attached  # type: ignore[misc]
-
-    match = decoy.mock(cls=MagDeck)
-
-    decoy.when(
-        state_view.modules.find_loaded_hardware_module(
-            module_id="module-id", attached_modules=attached, expected_type=MagDeck
-        )
-    ).then_return(match)
-
-    decoy.when(state_view.get_configs()).then_return(
-        EngineConfigs(
-            ignore_pause=False,
-            use_virtual_modules=use_virtual_modules,
-        )
-    )
+    decoy.when(magnetic_module_view.find_hardware(attached)).then_return(match)
 
     result = await subject.execute(params=params)
 
     decoy.verify(await match.engage(9001), times=(0 if use_virtual_modules else 1))
-
     assert result == EngageResult()

--- a/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_engage.py
+++ b/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_engage.py
@@ -5,8 +5,7 @@ from decoy import Decoy
 
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.modules import AbstractModule, MagDeck
-from opentrons.protocol_engine.state import EngineConfigs, MagneticModuleView, StateView
-from opentrons.protocol_engine.types import ModuleModel
+from opentrons.protocol_engine.state import MagneticModuleView, StateView
 from opentrons.protocol_engine.commands.magnetic_module import (
     EngageParams,
     EngageResult,

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -169,6 +169,45 @@ def test_get_properties_by_id(
     )
 
 
+def test_assert_is_magnetic_module(
+    magdeck_v1_def: ModuleDefinition,
+    magdeck_v2_def: ModuleDefinition,
+    tempdeck_v1_def: ModuleDefinition,
+) -> None:
+    """It should raise iff the given ID points to a non-Magnetic module."""
+    subject = make_module_view(
+        slot_by_module_id={
+            "id-module-1-magneticv1": DeckSlotName.SLOT_1,
+            "id-module-2-magneticv2": DeckSlotName.SLOT_2,
+            "id-module-3-temperaturev1": DeckSlotName.SLOT_3,
+        },
+        hardware_module_by_slot={
+            DeckSlotName.SLOT_1: HardwareModule(
+                serial_number="serial-module-1-magneticv1",
+                definition=magdeck_v1_def,
+            ),
+            DeckSlotName.SLOT_2: HardwareModule(
+                serial_number="serial-module-2-magneticv2",
+                definition=magdeck_v2_def,
+            ),
+            DeckSlotName.SLOT_3: HardwareModule(
+                serial_number="serial-module-3-temperaturev1",
+                definition=tempdeck_v1_def,
+            ),
+        },
+    )
+
+    # Should not raise:
+    subject.assert_is_magnetic_module(module_id="id-module-1-magneticv1")
+    subject.assert_is_magnetic_module(module_id="id-module-2-magneticv2")
+
+    with pytest.raises(errors.ModuleDoesNotExistError):
+        subject.assert_is_magnetic_module(module_id="nonexistent-module-id")
+
+    with pytest.raises(errors.WrongModuleTypeError):
+        subject.assert_is_magnetic_module(module_id="id-module-3-temperaturev1")
+
+
 def test_get_magnet_home_to_base_offset() -> None:
     """It should return the model-specific offset to bottom."""
     subject = make_module_view()

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -514,8 +514,30 @@ def test_magnetic_module_view_find_hardware(
     assert result == matching
 
 
-def test_magnetic_module_view_find_hardware_raises_if_match_not_attached(
-    decoy: Decoy, magdeck_v1_def: ModuleDefinition
+def test_magnetic_module_view_find_hardware_returns_none_if_virtualizing(
+    magdeck_v1_def: ModuleDefinition,
+) -> None:
+    parent = make_module_view(
+        hardware_module_by_slot={
+            DeckSlotName.SLOT_1: HardwareModule(
+                serial_number="serial-to-match",
+                definition=magdeck_v1_def,
+            ),
+        },
+        slot_by_module_id={
+            "id-to-match": DeckSlotName.SLOT_1,
+        },
+        virtualize_modules=True,
+    )
+    subject = parent.get_magnetic_module_view(module_id="id-to-match")
+
+    # Should return None,
+    # rather than raising because attached_modules contains no match.
+    assert subject.find_hardware(attached_modules=[]) is None
+
+
+def test_magnetic_module_view_find_hardware_raises_if_no_match_attached(
+    magdeck_v1_def: ModuleDefinition,
 ) -> None:
     """It should raise if nothing with a matching serial is in the attached list."""
     parent = make_module_view(

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -521,15 +521,15 @@ def test_magnetic_module_view_find_hardware_raises_if_match_not_attached(
     parent = make_module_view(
         hardware_module_by_slot={
             DeckSlotName.SLOT_1: HardwareModule(
-                serial_number="serial-matching",
+                serial_number="serial-to-match",
                 definition=magdeck_v1_def,
             ),
         },
         slot_by_module_id={
-            "id-matching": DeckSlotName.SLOT_1,
+            "id-to-match": DeckSlotName.SLOT_1,
         },
     )
-    subject = parent.get_magnetic_module_view(module_id="id-matching")
+    subject = parent.get_magnetic_module_view(module_id="id-to-match")
 
     with pytest.raises(errors.ModuleNotAttachedError):
         subject.find_hardware(
@@ -544,20 +544,20 @@ def test_magnetic_module_view_find_hardware_raises_if_match_is_wrong_type(
     matching = make_hardware_module(
         decoy=decoy,
         type=TempDeck,  # Not a Magnetic Module.
-        serial_number="serial-matching",
+        serial_number="serial-to-match",
     )
     parent = make_module_view(
         hardware_module_by_slot={
             DeckSlotName.SLOT_1: HardwareModule(
-                serial_number="serial-matching",
+                serial_number="serial-to-match",
                 definition=magdeck_v1_def,
             ),
         },
         slot_by_module_id={
-            "id-matching": DeckSlotName.SLOT_1,
+            "id-to-match": DeckSlotName.SLOT_1,
         },
     )
-    subject = parent.get_magnetic_module_view(module_id="id-matching")
+    subject = parent.get_magnetic_module_view(module_id="id-to-match")
     with pytest.raises(errors.ModuleNotAttachedError):
         subject.find_hardware(
             attached_modules=[matching],

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -198,14 +198,8 @@ def test_assert_is_magnetic_module(
     )
 
     # Should not raise:
-    assert (
-        subject.assert_is_magnetic_module(module_id="id-module-1-magneticv1")
-        == "id-module-1-magneticv1"
-    )
-    assert (
-        subject.assert_is_magnetic_module(module_id="id-module-2-magneticv2")
-        == "id-module-2-magneticv2"
-    )
+    subject.assert_is_magnetic_module(module_id="id-module-1-magneticv1")
+    subject.assert_is_magnetic_module(module_id="id-module-2-magneticv2")
 
     with pytest.raises(errors.ModuleDoesNotExistError):
         subject.assert_is_magnetic_module(module_id="nonexistent-module-id")

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -517,6 +517,10 @@ def test_magnetic_module_view_find_hardware(
 def test_magnetic_module_view_find_hardware_returns_none_if_virtualizing(
     magdeck_v1_def: ModuleDefinition,
 ) -> None:
+    """It should handle the case where the Protocol Engine is virtualizing modules.
+
+    This means ignoreing attached_modules and returning None.
+    """
     parent = make_module_view(
         hardware_module_by_slot={
             DeckSlotName.SLOT_1: HardwareModule(

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -25,6 +25,7 @@ from opentrons.protocol_engine.state.modules import (
 def make_module_view(
     slot_by_module_id: Optional[Dict[str, DeckSlotName]] = None,
     hardware_module_by_slot: Optional[Dict[DeckSlotName, HardwareModule]] = None,
+    virtualize_modules: bool = False,
 ) -> ModuleView:
     """Get a module view test subject with the specified state."""
     state = ModuleState(
@@ -32,7 +33,7 @@ def make_module_view(
         hardware_module_by_slot=hardware_module_by_slot or {},
     )
 
-    return ModuleView(state=state)
+    return ModuleView(state=state, virtualize_modules=virtualize_modules)
 
 
 HardwareModuleT = TypeVar("HardwareModuleT", bound=AbstractModule)

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -198,8 +198,14 @@ def test_assert_is_magnetic_module(
     )
 
     # Should not raise:
-    subject.assert_is_magnetic_module(module_id="id-module-1-magneticv1")
-    subject.assert_is_magnetic_module(module_id="id-module-2-magneticv2")
+    assert (
+        subject.assert_is_magnetic_module(module_id="id-module-1-magneticv1")
+        == "id-module-1-magneticv1"
+    )
+    assert (
+        subject.assert_is_magnetic_module(module_id="id-module-2-magneticv2")
+        == "id-module-2-magneticv2"
+    )
 
     with pytest.raises(errors.ModuleDoesNotExistError):
         subject.assert_is_magnetic_module(module_id="nonexistent-module-id")

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -17,7 +17,6 @@ from opentrons.protocol_engine.types import (
 )
 from opentrons.protocol_engine.state.modules import (
     ModuleView,
-    MagneticModuleView,
     ModuleState,
     HardwareModule,
 )
@@ -137,6 +136,7 @@ def test_get_magnetic_module_view(
     magdeck_v2_def: ModuleDefinition,
     tempdeck_v1_def: ModuleDefinition,
 ) -> None:
+    """It should return a view for the given Magnetic Module, if valid."""
     subject = make_module_view(
         slot_by_module_id={
             "magnetic-module-gen1-id": DeckSlotName.SLOT_1,

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -17,6 +17,7 @@ from opentrons.protocol_engine.types import (
 )
 from opentrons.protocol_engine.state.modules import (
     ModuleView,
+    MagneticModuleView,
     ModuleState,
     HardwareModule,
 )
@@ -131,6 +132,52 @@ def test_get_all_modules(
     ]
 
 
+def test_get_magnetic_module_view(
+    magdeck_v1_def: ModuleDefinition,
+    magdeck_v2_def: ModuleDefinition,
+    tempdeck_v1_def: ModuleDefinition,
+) -> None:
+    subject = make_module_view(
+        slot_by_module_id={
+            "magnetic-module-gen1-id": DeckSlotName.SLOT_1,
+            "magnetic-module-gen2-id": DeckSlotName.SLOT_2,
+            "temperature-module-id": DeckSlotName.SLOT_3,
+        },
+        hardware_module_by_slot={
+            DeckSlotName.SLOT_1: HardwareModule(
+                serial_number="magnetic-module-gen1-serial",
+                definition=magdeck_v1_def,
+            ),
+            DeckSlotName.SLOT_2: HardwareModule(
+                serial_number="magnetic-module-gen2-serial",
+                definition=magdeck_v2_def,
+            ),
+            DeckSlotName.SLOT_3: HardwareModule(
+                serial_number="temperature-module-serial",
+                definition=tempdeck_v1_def,
+            ),
+        },
+    )
+
+    module_1_view = subject.get_magnetic_module_view(
+        module_id="magnetic-module-gen1-id"
+    )
+    assert module_1_view.parent_module_view is subject
+    assert module_1_view.module_id == "magnetic-module-gen1-id"
+
+    module_2_view = subject.get_magnetic_module_view(
+        module_id="magnetic-module-gen2-id"
+    )
+    assert module_2_view.parent_module_view is subject
+    assert module_2_view.module_id == "magnetic-module-gen2-id"
+
+    with pytest.raises(errors.WrongModuleTypeError):
+        subject.get_magnetic_module_view(module_id="temperature-module-id")
+
+    with pytest.raises(errors.ModuleDoesNotExistError):
+        subject.get_magnetic_module_view(module_id="nonexistent-module-id")
+
+
 def test_get_properties_by_id(
     tempdeck_v1_def: ModuleDefinition,
     tempdeck_v2_def: ModuleDefinition,
@@ -168,45 +215,6 @@ def test_get_properties_by_id(
     assert subject.get_location("module-2") == DeckSlotLocation(
         slotName=DeckSlotName.SLOT_2
     )
-
-
-def test_assert_is_magnetic_module(
-    magdeck_v1_def: ModuleDefinition,
-    magdeck_v2_def: ModuleDefinition,
-    tempdeck_v1_def: ModuleDefinition,
-) -> None:
-    """It should raise iff the given ID points to a non-Magnetic module."""
-    subject = make_module_view(
-        slot_by_module_id={
-            "id-module-1-magneticv1": DeckSlotName.SLOT_1,
-            "id-module-2-magneticv2": DeckSlotName.SLOT_2,
-            "id-module-3-temperaturev1": DeckSlotName.SLOT_3,
-        },
-        hardware_module_by_slot={
-            DeckSlotName.SLOT_1: HardwareModule(
-                serial_number="serial-module-1-magneticv1",
-                definition=magdeck_v1_def,
-            ),
-            DeckSlotName.SLOT_2: HardwareModule(
-                serial_number="serial-module-2-magneticv2",
-                definition=magdeck_v2_def,
-            ),
-            DeckSlotName.SLOT_3: HardwareModule(
-                serial_number="serial-module-3-temperaturev1",
-                definition=tempdeck_v1_def,
-            ),
-        },
-    )
-
-    # Should not raise:
-    subject.assert_is_magnetic_module(module_id="id-module-1-magneticv1")
-    subject.assert_is_magnetic_module(module_id="id-module-2-magneticv2")
-
-    with pytest.raises(errors.ModuleDoesNotExistError):
-        subject.assert_is_magnetic_module(module_id="nonexistent-module-id")
-
-    with pytest.raises(errors.WrongModuleTypeError):
-        subject.assert_is_magnetic_module(module_id="id-module-3-temperaturev1")
 
 
 def test_get_magnet_home_to_base_offset() -> None:
@@ -267,117 +275,6 @@ def test_calculate_magnet_height(module_model: ModuleModel) -> None:
     )
 
 
-class _CalculateMagnetHardwareHeightTestParams(NamedTuple):
-    model: ModuleModel
-    mm_from_base: float
-    expected_result: Optional[float]
-    expected_exception_type: Union[Type[Exception], None]
-
-
-@pytest.mark.parametrize(
-    "model, mm_from_base, expected_result, expected_exception_type",
-    [
-        # Happy cases:
-        _CalculateMagnetHardwareHeightTestParams(
-            model=ModuleModel.MAGNETIC_MODULE_V1,
-            mm_from_base=10,
-            # TODO(mm, 2022-03-09): It's unclear if this expected result is correct.
-            # https://github.com/Opentrons/opentrons/issues/9585
-            expected_result=25,
-            expected_exception_type=None,
-        ),
-        _CalculateMagnetHardwareHeightTestParams(
-            model=ModuleModel.MAGNETIC_MODULE_V2,
-            mm_from_base=10,
-            expected_result=12.5,
-            expected_exception_type=None,
-        ),
-        # Boundary conditions:
-        #
-        # TODO(mm, 2022-03-09):
-        # In Python >=3.9, improve precision with math.nextafter().
-        # Also consider relying on shared constants instead of hard-coding bounds.
-        #
-        # TODO(mm, 2022-03-09): It's unclear if the bounds used for V1 modules
-        # are physically correct. https://github.com/Opentrons/opentrons/issues/9585
-        _CalculateMagnetHardwareHeightTestParams(  # V1 barely too low.
-            model=ModuleModel.MAGNETIC_MODULE_V1,
-            mm_from_base=-2.51,
-            expected_result=None,
-            expected_exception_type=errors.EngageHeightOutOfRangeError,
-        ),
-        _CalculateMagnetHardwareHeightTestParams(  # V1 lowest allowed.
-            model=ModuleModel.MAGNETIC_MODULE_V1,
-            mm_from_base=-2.5,
-            expected_result=0,
-            expected_exception_type=None,
-        ),
-        _CalculateMagnetHardwareHeightTestParams(  # V1 highest allowed.
-            model=ModuleModel.MAGNETIC_MODULE_V1,
-            mm_from_base=20,
-            expected_result=45,
-            expected_exception_type=None,
-        ),
-        _CalculateMagnetHardwareHeightTestParams(  # V1 barely too high.
-            model=ModuleModel.MAGNETIC_MODULE_V1,
-            mm_from_base=20.01,
-            expected_result=None,
-            expected_exception_type=errors.EngageHeightOutOfRangeError,
-        ),
-        _CalculateMagnetHardwareHeightTestParams(  # V2 barely too low.
-            model=ModuleModel.MAGNETIC_MODULE_V2,
-            mm_from_base=-2.51,
-            expected_result=None,
-            expected_exception_type=errors.EngageHeightOutOfRangeError,
-        ),
-        _CalculateMagnetHardwareHeightTestParams(  # V2 lowest allowed.
-            model=ModuleModel.MAGNETIC_MODULE_V2,
-            mm_from_base=-2.5,
-            expected_result=0,
-            expected_exception_type=None,
-        ),
-        _CalculateMagnetHardwareHeightTestParams(  # V2 highest allowed.
-            model=ModuleModel.MAGNETIC_MODULE_V2,
-            mm_from_base=22.5,
-            expected_result=25,
-            expected_exception_type=None,
-        ),
-        _CalculateMagnetHardwareHeightTestParams(  # V2 barely too high.
-            model=ModuleModel.MAGNETIC_MODULE_V2,
-            mm_from_base=22.51,
-            expected_result=None,
-            expected_exception_type=errors.EngageHeightOutOfRangeError,
-        ),
-        # Bad model:
-        _CalculateMagnetHardwareHeightTestParams(
-            model=ModuleModel.TEMPERATURE_MODULE_V1,
-            mm_from_base=0,
-            expected_result=None,
-            expected_exception_type=errors.WrongModuleTypeError,
-        ),
-    ],
-)
-def test_calculate_magnet_hardware_height(
-    model: ModuleModel,
-    mm_from_base: float,
-    expected_result: float,
-    expected_exception_type: Union[Type[Exception], None],
-) -> None:
-    """It should return the expected height or raise the expected exception."""
-    subject = make_module_view()
-    context: ContextManager[None] = (
-        # Not sure why mypy has trouble with this.
-        nullcontext()  # type: ignore[assignment]
-        if expected_exception_type is None
-        else pytest.raises(expected_exception_type)
-    )
-    with context:
-        result = subject.calculate_magnet_hardware_height(
-            magnetic_module_model=model, mm_from_base=mm_from_base
-        )
-        assert result == expected_result
-
-
 @pytest.mark.parametrize(
     argnames=["from_slot", "to_slot", "should_dodge"],
     argvalues=[
@@ -423,118 +320,6 @@ def test_thermocycler_dodging(
         subject.should_dodge_thermocycler(from_slot=from_slot, to_slot=to_slot)
         is should_dodge
     )
-
-
-def test_find_loaded_hardware_module(
-    decoy: Decoy, magdeck_v1_def: ModuleDefinition
-) -> None:
-    """It should return the matching hardware module."""
-    matching = make_hardware_module(
-        decoy=decoy, type=MagDeck, serial_number="serial-matching"
-    )
-    non_matching = make_hardware_module(
-        decoy=decoy, type=MagDeck, serial_number="serial-non-matching"
-    )
-    another_non_matching = make_hardware_module(
-        decoy=decoy, type=TempDeck, serial_number="serial-another-non-matching"
-    )
-
-    attached = [non_matching, matching, another_non_matching]
-
-    subject = make_module_view(
-        hardware_module_by_slot={
-            DeckSlotName.SLOT_1: HardwareModule(
-                serial_number="serial-non-matching",
-                definition=magdeck_v1_def,
-            ),
-            DeckSlotName.SLOT_2: HardwareModule(
-                serial_number="serial-matching",
-                definition=magdeck_v1_def,
-            ),
-            DeckSlotName.SLOT_3: HardwareModule(
-                serial_number="serial-another-non-matching",
-                definition=magdeck_v1_def,
-            ),
-        },
-        slot_by_module_id={
-            "id-non-matching": DeckSlotName.SLOT_1,
-            "id-matching": DeckSlotName.SLOT_2,
-            "id-another-non-matching": DeckSlotName.SLOT_3,
-        },
-    )
-
-    result = subject.find_loaded_hardware_module(
-        module_id="id-matching",
-        attached_modules=attached,
-        expected_type=MagDeck,
-    )
-
-    assert result == matching
-
-
-def test_find_loaded_hardware_module_raises_if_no_match_loaded(
-    decoy: Decoy,
-) -> None:
-    """It should raise if the ID doesn't point to a loaded module."""
-    subject = make_module_view(
-        hardware_module_by_slot={},
-        slot_by_module_id={},
-    )
-    with pytest.raises(errors.ModuleDoesNotExistError):
-        subject.find_loaded_hardware_module(
-            module_id="module-id",
-            attached_modules=[],
-            expected_type=MagDeck,
-        )
-
-
-def test_find_loaded_hardware_module_raises_if_match_not_attached(
-    decoy: Decoy, magdeck_v1_def: ModuleDefinition
-) -> None:
-    """It should raise if a match was loaded but is not found in the attached list."""
-    subject = make_module_view(
-        hardware_module_by_slot={
-            DeckSlotName.SLOT_1: HardwareModule(
-                serial_number="serial-matching",
-                definition=magdeck_v1_def,
-            ),
-        },
-        slot_by_module_id={
-            "id-matching": DeckSlotName.SLOT_1,
-        },
-    )
-    with pytest.raises(errors.ModuleNotAttachedError):
-        subject.find_loaded_hardware_module(
-            module_id="id-matching",
-            attached_modules=[],
-            expected_type=MagDeck,
-        )
-
-
-def test_find_loaded_hardware_module_raises_if_match_is_wrong_type(
-    decoy: Decoy, magdeck_v1_def: ModuleDefinition
-) -> None:
-    """It should raise if a match was found but is of an unexpected type."""
-    matching = make_hardware_module(
-        decoy=decoy, type=MagDeck, serial_number="serial-matching"
-    )
-    subject = make_module_view(
-        hardware_module_by_slot={
-            DeckSlotName.SLOT_1: HardwareModule(
-                serial_number="serial-matching",
-                definition=magdeck_v1_def,
-            ),
-        },
-        slot_by_module_id={
-            "id-matching": DeckSlotName.SLOT_1,
-        },
-    )
-    with pytest.raises(errors.WrongModuleTypeError):
-        subject.find_loaded_hardware_module(
-            module_id="id-matching",
-            attached_modules=[matching],
-            expected_type=TempDeck,  # Will definitely not match.
-        )
 
 
 def test_select_hardware_module_to_load_rejects_missing() -> None:
@@ -682,3 +467,209 @@ def test_select_hardware_module_to_load_rejects_location_reassignment(
             location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
             attached_modules=attached_modules,
         )
+
+
+def test_magnetic_module_view_find_hardware(
+    decoy: Decoy, magdeck_v1_def: ModuleDefinition
+) -> None:
+    """It should return the matching hardware module."""
+    matching = make_hardware_module(
+        decoy=decoy, type=MagDeck, serial_number="serial-matching"
+    )
+    non_matching = make_hardware_module(
+        decoy=decoy, type=MagDeck, serial_number="serial-non-matching"
+    )
+    another_non_matching = make_hardware_module(
+        decoy=decoy, type=TempDeck, serial_number="serial-another-non-matching"
+    )
+
+    attached = [non_matching, matching, another_non_matching]
+
+    parent = make_module_view(
+        hardware_module_by_slot={
+            DeckSlotName.SLOT_1: HardwareModule(
+                serial_number="serial-non-matching",
+                definition=magdeck_v1_def,
+            ),
+            DeckSlotName.SLOT_2: HardwareModule(
+                serial_number="serial-matching",
+                definition=magdeck_v1_def,
+            ),
+            DeckSlotName.SLOT_3: HardwareModule(
+                serial_number="serial-another-non-matching",
+                definition=magdeck_v1_def,
+            ),
+        },
+        slot_by_module_id={
+            "id-non-matching": DeckSlotName.SLOT_1,
+            "id-matching": DeckSlotName.SLOT_2,
+            "id-another-non-matching": DeckSlotName.SLOT_3,
+        },
+    )
+    subject = parent.get_magnetic_module_view(module_id="id-matching")
+
+    result = subject.find_hardware(
+        attached_modules=attached,
+    )
+    assert result == matching
+
+
+def test_magnetic_module_view_find_hardware_raises_if_match_not_attached(
+    decoy: Decoy, magdeck_v1_def: ModuleDefinition
+) -> None:
+    """It should raise if nothing with a matching serial is in the attached list."""
+    parent = make_module_view(
+        hardware_module_by_slot={
+            DeckSlotName.SLOT_1: HardwareModule(
+                serial_number="serial-matching",
+                definition=magdeck_v1_def,
+            ),
+        },
+        slot_by_module_id={
+            "id-matching": DeckSlotName.SLOT_1,
+        },
+    )
+    subject = parent.get_magnetic_module_view(module_id="id-matching")
+
+    with pytest.raises(errors.ModuleNotAttachedError):
+        subject.find_hardware(
+            attached_modules=[],
+        )
+
+
+def test_magnetic_module_view_find_hardware_raises_if_match_is_wrong_type(
+    decoy: Decoy, magdeck_v1_def: ModuleDefinition
+) -> None:
+    """It should raise if a match was found but is of an unexpected type."""
+    matching = make_hardware_module(
+        decoy=decoy,
+        type=TempDeck,  # Not a Magnetic Module.
+        serial_number="serial-matching",
+    )
+    parent = make_module_view(
+        hardware_module_by_slot={
+            DeckSlotName.SLOT_1: HardwareModule(
+                serial_number="serial-matching",
+                definition=magdeck_v1_def,
+            ),
+        },
+        slot_by_module_id={
+            "id-matching": DeckSlotName.SLOT_1,
+        },
+    )
+    subject = parent.get_magnetic_module_view(module_id="id-matching")
+    with pytest.raises(errors.ModuleNotAttachedError):
+        subject.find_hardware(
+            attached_modules=[matching],
+        )
+
+
+class _CalculateMagnetHardwareHeightTestParams(NamedTuple):
+    definition: ModuleDefinition
+    mm_from_base: float
+    expected_result: Optional[float]
+    expected_exception_type: Union[Type[Exception], None]
+
+
+@pytest.mark.parametrize(
+    "definition, mm_from_base, expected_result, expected_exception_type",
+    [
+        # Happy cases:
+        _CalculateMagnetHardwareHeightTestParams(
+            definition=lazy_fixture("magdeck_v1_def"),
+            mm_from_base=10,
+            # TODO(mm, 2022-03-09): It's unclear if this expected result is correct.
+            # https://github.com/Opentrons/opentrons/issues/9585
+            expected_result=25,
+            expected_exception_type=None,
+        ),
+        _CalculateMagnetHardwareHeightTestParams(
+            definition=lazy_fixture("magdeck_v2_def"),
+            mm_from_base=10,
+            expected_result=12.5,
+            expected_exception_type=None,
+        ),
+        # Boundary conditions:
+        #
+        # TODO(mm, 2022-03-09):
+        # In Python >=3.9, improve precision with math.nextafter().
+        # Also consider relying on shared constants instead of hard-coding bounds.
+        #
+        # TODO(mm, 2022-03-09): It's unclear if the bounds used for V1 modules
+        # are physically correct. https://github.com/Opentrons/opentrons/issues/9585
+        _CalculateMagnetHardwareHeightTestParams(  # V1 barely too low.
+            definition=lazy_fixture("magdeck_v1_def"),
+            mm_from_base=-2.51,
+            expected_result=None,
+            expected_exception_type=errors.EngageHeightOutOfRangeError,
+        ),
+        _CalculateMagnetHardwareHeightTestParams(  # V1 lowest allowed.
+            definition=lazy_fixture("magdeck_v1_def"),
+            mm_from_base=-2.5,
+            expected_result=0,
+            expected_exception_type=None,
+        ),
+        _CalculateMagnetHardwareHeightTestParams(  # V1 highest allowed.
+            definition=lazy_fixture("magdeck_v1_def"),
+            mm_from_base=20,
+            expected_result=45,
+            expected_exception_type=None,
+        ),
+        _CalculateMagnetHardwareHeightTestParams(  # V1 barely too high.
+            definition=lazy_fixture("magdeck_v1_def"),
+            mm_from_base=20.01,
+            expected_result=None,
+            expected_exception_type=errors.EngageHeightOutOfRangeError,
+        ),
+        _CalculateMagnetHardwareHeightTestParams(  # V2 barely too low.
+            definition=lazy_fixture("magdeck_v2_def"),
+            mm_from_base=-2.51,
+            expected_result=None,
+            expected_exception_type=errors.EngageHeightOutOfRangeError,
+        ),
+        _CalculateMagnetHardwareHeightTestParams(  # V2 lowest allowed.
+            definition=lazy_fixture("magdeck_v2_def"),
+            mm_from_base=-2.5,
+            expected_result=0,
+            expected_exception_type=None,
+        ),
+        _CalculateMagnetHardwareHeightTestParams(  # V2 highest allowed.
+            definition=lazy_fixture("magdeck_v2_def"),
+            mm_from_base=22.5,
+            expected_result=25,
+            expected_exception_type=None,
+        ),
+        _CalculateMagnetHardwareHeightTestParams(  # V2 barely too high.
+            definition=lazy_fixture("magdeck_v2_def"),
+            mm_from_base=22.51,
+            expected_result=None,
+            expected_exception_type=errors.EngageHeightOutOfRangeError,
+        ),
+    ],
+)
+def test_magnetic_module_view_calculate_magnet_hardware_height(
+    definition: ModuleDefinition,
+    mm_from_base: float,
+    expected_result: float,
+    expected_exception_type: Union[Type[Exception], None],
+) -> None:
+    """It should return the expected height or raise the expected exception."""
+    parent = make_module_view(
+        slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
+        hardware_module_by_slot={
+            DeckSlotName.SLOT_1: HardwareModule(
+                serial_number="serial-number",
+                definition=definition,
+            )
+        },
+    )
+    subject = parent.get_magnetic_module_view("module-id")
+    expected_raise: ContextManager[None] = (
+        # Not sure why mypy has trouble with this.
+        nullcontext()  # type: ignore[assignment]
+        if expected_exception_type is None
+        else pytest.raises(expected_exception_type)
+    )
+    with expected_raise:
+        result = subject.calculate_magnet_hardware_height(mm_from_base=mm_from_base)
+        assert result == expected_result


### PR DESCRIPTION
# Overview

This implements the `magneticModule/disengageMagnet` Protocol Engine command, whose skeleton was added in #9652. This closes part of #8243.

# Changelog

* Implement `magneticModule/disengageMagnet`.
* Refactor `ModuleView` and `magneticModule/engageMagnet` to simplify things that are common to both Magnetic Module commands: validating that the given ID points to a module, validating that the ID points to a *magnetic* module, and handling the case of virtualized modules.

# Manual test plan

1. Load a Magnetic Module or two with `loadModule` commands.
2. Issue `magneticModule/disengageMagnet` commands and confirm that they home the modules properly.
3. Try interleaving them with `magneticModule/engageMagnet` and confirm that the height tracking works properly.
4. Check to see that the command gives a helpful error when you supply a bogus `moduleId`.
5. Check to see that the command gives a helpful error when you supply a `moduleId` that points to a non-Magnetic module.
6. Check to see that the command gives a helpful error when you physically disconnect the module before running it (but after you've successfully loaded the module).

This can be combined with the manual test plan in #9599, which has copy-pastable request bodies.

# Risk assessment

Low. No production code uses this yet.