### PR TITLE
refactor(hardware-control): make repl script available in simulation

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -160,7 +160,7 @@ class OT3Simulator:
         """Set the module controls"""
         self._module_controls = module_controls
 
-    def update_to_default_current_settings(self, gantry_load: GantryLoad) -> None:
+    async def update_to_default_current_settings(self, gantry_load: GantryLoad) -> None:
         self._current_settings = get_current_settings(
             self._configuration.current_settings, gantry_load
         )

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -178,13 +178,12 @@ class OT3API(
     def gantry_load(self) -> GantryLoad:
         return self._gantry_load
 
-    @gantry_load.setter
-    def gantry_load(self, gantry_load: GantryLoad) -> None:
+    async def set_gantry_load(self, gantry_load: GantryLoad) -> None:
         self._gantry_load = gantry_load
         self._move_manager.update_constraints(
             get_system_constraints(self._config.motion_settings, gantry_load)
         )
-        self._backend.update_to_default_current_settings(gantry_load)
+        await self._backend.update_to_default_current_settings(gantry_load)
 
     def _update_door_state(self, door_state: DoorState) -> None:
         mod_log.info(f"Updating the window switch status: {door_state}")
@@ -404,7 +403,7 @@ class OT3API(
             await self._backend.configure_mount(mount, hw_config)
         await self._backend.probe_network()
         # TODO: (AA, 2022-02-09) Set correct pipette kind based on attached instr
-        self.gantry_load = GantryLoad.TWO_LOW_THROUGHPUT
+        await self.set_gantry_load(GantryLoad.TWO_LOW_THROUGHPUT)
 
     # Global actions API
     def pause(self, pause_type: PauseType) -> None:

--- a/api/src/opentrons/hardware_control/scripts/repl.py
+++ b/api/src/opentrons/hardware_control/scripts/repl.py
@@ -6,9 +6,10 @@ and expose it to a python commandline.
 
 import os
 
-if not os.environ.get("RUNNING_ON_PI") and not os.environ.get("RUNNING_ON_VERDIN"):
-    print("You should run this through the script alias: ot3repl")
-    exit()
+has_robot_server = True
+if os.environ.get("OPENTRONS_SIMULATION"):
+    print("Running with simulators")
+    has_robot_server = False
 if os.environ.get("OT2", None):
     print(
         '"OT2" env var detected, running with OT2 HC. '
@@ -64,7 +65,8 @@ def do_interact(api: ThreadManager[HardwareControlAPI]) -> None:
 
 
 if __name__ == "__main__":
-    stop_server()
+    if has_robot_server:
+        stop_server()
     api_tm = build_api()
     api_tm.sync.cache_instruments()
     do_interact(api_tm)

--- a/api/src/opentrons/hardware_control/scripts/repl.py
+++ b/api/src/opentrons/hardware_control/scripts/repl.py
@@ -20,14 +20,14 @@ else:
     print("Running with OT3 HC. If you dont want this, set an " 'env var named "OT2".')
     os.environ["OT_API_FF_enableOT3HardwareController"] = "true"
 
-from code import interact
-from subprocess import run
-from typing import Union, Type
-import logging
+from code import interact  # noqa: E402
+from subprocess import run  # noqa: E402
+from typing import Union, Type  # noqa: E402
+import logging  # noqa: E402
 
-from opentrons.types import Mount, Point
-from opentrons.hardware_control.types import Axis
-from opentrons.config.feature_flags import enable_ot3_hardware_controller
+from opentrons.types import Mount, Point  # noqa: E402
+from opentrons.hardware_control.types import Axis  # noqa: E402
+from opentrons.config.feature_flags import enable_ot3_hardware_controller  # noqa: E402
 
 if enable_ot3_hardware_controller():
     from opentrons.hardware_control.ot3api import OT3API
@@ -38,8 +38,8 @@ else:
 
     HCApi = API
 
-from opentrons.hardware_control.protocols import HardwareControlAPI
-from opentrons.hardware_control.thread_manager import ThreadManager
+from opentrons.hardware_control.protocols import HardwareControlAPI  # noqa: E402
+from opentrons.hardware_control.thread_manager import ThreadManager  # noqa: E402
 
 logging.basicConfig(level=logging.INFO)
 


### PR DESCRIPTION
# Overview

Now you can call the repl script locally on your computer if you have `opentrons_sock` open. Also
fixed some async problems that showed up due to simulation.

The call would look something like:
`OT3_CAN_DRIVER_INTERFACE=opentrons_sock OPENTRONS_SIMULATION=true pipenv run python -m opentrons.hardware_control.scripts.repl`

# Changelog
- Fixed some functions that weren't awaited
- Allow repl script to be run locally

# Review requests
Is there a readme this should be added to?


# Risk assessment

Low.