### PR TITLE
refactor(app): add id field to attached module response

### DIFF
--- a/app/src/redux/modules/__fixtures__/index.ts
+++ b/app/src/redux/modules/__fixtures__/index.ts
@@ -23,7 +23,7 @@ export const mockApiTemperatureModuleLegacy: ApiTypes.ApiTemperatureModuleLegacy
 }
 
 export const mockApiTemperatureModule: ApiTypes.ApiTemperatureModule = {
-  id: 'tempdeck_id_1',
+  id: 'tempdeck_id',
   name: 'tempdeck',
   displayName: 'tempdeck',
   port: '/dev/ot_module_tempdeck0',
@@ -42,7 +42,7 @@ export const mockApiTemperatureModule: ApiTypes.ApiTemperatureModule = {
 }
 
 export const mockApiTemperatureModuleGen2: ApiTypes.ApiTemperatureModule = {
-  id: 'tempdeck_id_2',
+  id: 'tempdeck_id',
   name: 'tempdeck',
   displayName: 'tempdeck',
   model: 'temp_deck_v20',
@@ -61,7 +61,7 @@ export const mockApiTemperatureModuleGen2: ApiTypes.ApiTemperatureModule = {
 }
 
 export const mockTemperatureModule: Types.TemperatureModule = {
-  id: 'tempdeck_id_3',
+  id: 'tempdeck_id',
   model: 'temperatureModuleV1',
   type: 'temperatureModuleType',
   port: '/dev/ot_module_tempdeck0',
@@ -78,7 +78,7 @@ export const mockTemperatureModule: Types.TemperatureModule = {
 }
 
 export const mockTemperatureModuleGen2: Types.TemperatureModule = {
-  id: 'tempdeck_id_4',
+  id: 'tempdeck_id',
   model: 'temperatureModuleV2',
   type: 'temperatureModuleType',
   port: '/dev/ot_module_tempdeck0',
@@ -110,7 +110,7 @@ export const mockApiMagneticModuleLegacy: ApiTypes.ApiMagneticModuleLegacy = {
 }
 
 export const mockApiMagneticModule: ApiTypes.ApiMagneticModule = {
-  id: 'magdeck_id_5',
+  id: 'magdeck_id',
   name: 'magdeck',
   displayName: 'magdeck',
   model: 'mag_deck_v4.0',
@@ -129,7 +129,7 @@ export const mockApiMagneticModule: ApiTypes.ApiMagneticModule = {
 }
 
 export const mockApiMagneticModuleGen2: ApiTypes.ApiMagneticModule = {
-  id: 'magdeck_id_1',
+  id: 'magdeck_id',
   name: 'magdeck',
   displayName: 'magdeck',
   model: 'mag_deck_v20',
@@ -148,7 +148,7 @@ export const mockApiMagneticModuleGen2: ApiTypes.ApiMagneticModule = {
 }
 
 export const mockMagneticModule: Types.MagneticModule = {
-  id: 'magdeck_id_2',
+  id: 'magdeck_id',
   model: 'magneticModuleV1',
   type: 'magneticModuleType',
   port: '/dev/ot_module_magdeck0',
@@ -165,7 +165,7 @@ export const mockMagneticModule: Types.MagneticModule = {
 }
 
 export const mockMagneticModuleGen2: Types.MagneticModule = {
-  id: 'magdeck_id_3',
+  id: 'magdeck_id',
   model: 'magneticModuleV2',
   type: 'magneticModuleType',
   port: '/dev/ot_module_magdeck0',
@@ -206,7 +206,7 @@ export const mockApiThermocyclerLegacy: ApiTypes.ApiThermocyclerModuleLegacy = {
 }
 
 export const mockApiThermocycler: ApiTypes.ApiThermocyclerModule = {
-  id: 'thermocycler_id_1',
+  id: 'thermocycler_id',
   name: 'thermocycler',
   displayName: 'thermocycler',
   port: '/dev/ot_module_thermocycler0',
@@ -234,7 +234,7 @@ export const mockApiThermocycler: ApiTypes.ApiThermocyclerModule = {
 }
 
 export const mockThermocycler: Types.ThermocyclerModule = {
-  id: 'thermocycler_id_2',
+  id: 'thermocycler_id',
   model: 'thermocyclerModuleV1',
   type: 'thermocyclerModuleType',
   port: '/dev/ot_module_thermocycler0',
@@ -260,7 +260,7 @@ export const mockThermocycler: Types.ThermocyclerModule = {
 }
 
 export const mockApiHeaterShaker: ApiTypes.ApiHeaterShakerModule = {
-  id: 'heatershaker_id_1',
+  id: 'heatershaker_id',
   displayName: 'heatershaker',
   port: '/dev/ot_module_heatershaker0',
   serial: 'jkl123',
@@ -284,7 +284,7 @@ export const mockApiHeaterShaker: ApiTypes.ApiHeaterShakerModule = {
 }
 
 export const mockHeaterShaker: Types.HeaterShakerModule = {
-  id: 'heatershaker_id_2',
+  id: 'heatershaker_id',
   model: 'heaterShakerModuleV1',
   type: 'heaterShakerModuleType',
   port: '/dev/ot_module_thermocycler0',

--- a/app/src/redux/modules/__fixtures__/index.ts
+++ b/app/src/redux/modules/__fixtures__/index.ts
@@ -23,6 +23,7 @@ export const mockApiTemperatureModuleLegacy: ApiTypes.ApiTemperatureModuleLegacy
 }
 
 export const mockApiTemperatureModule: ApiTypes.ApiTemperatureModule = {
+  id: 'tempdeck_id_1',
   name: 'tempdeck',
   displayName: 'tempdeck',
   port: '/dev/ot_module_tempdeck0',
@@ -41,6 +42,7 @@ export const mockApiTemperatureModule: ApiTypes.ApiTemperatureModule = {
 }
 
 export const mockApiTemperatureModuleGen2: ApiTypes.ApiTemperatureModule = {
+  id: 'tempdeck_id_2',
   name: 'tempdeck',
   displayName: 'tempdeck',
   model: 'temp_deck_v20',
@@ -59,6 +61,7 @@ export const mockApiTemperatureModuleGen2: ApiTypes.ApiTemperatureModule = {
 }
 
 export const mockTemperatureModule: Types.TemperatureModule = {
+  id: 'tempdeck_id_3',
   model: 'temperatureModuleV1',
   type: 'temperatureModuleType',
   port: '/dev/ot_module_tempdeck0',
@@ -75,6 +78,7 @@ export const mockTemperatureModule: Types.TemperatureModule = {
 }
 
 export const mockTemperatureModuleGen2: Types.TemperatureModule = {
+  id: 'tempdeck_id_4',
   model: 'temperatureModuleV2',
   type: 'temperatureModuleType',
   port: '/dev/ot_module_tempdeck0',
@@ -106,6 +110,7 @@ export const mockApiMagneticModuleLegacy: ApiTypes.ApiMagneticModuleLegacy = {
 }
 
 export const mockApiMagneticModule: ApiTypes.ApiMagneticModule = {
+  id: 'magdeck_id_5',
   name: 'magdeck',
   displayName: 'magdeck',
   model: 'mag_deck_v4.0',
@@ -124,6 +129,7 @@ export const mockApiMagneticModule: ApiTypes.ApiMagneticModule = {
 }
 
 export const mockApiMagneticModuleGen2: ApiTypes.ApiMagneticModule = {
+  id: 'magdeck_id_1',
   name: 'magdeck',
   displayName: 'magdeck',
   model: 'mag_deck_v20',
@@ -142,6 +148,7 @@ export const mockApiMagneticModuleGen2: ApiTypes.ApiMagneticModule = {
 }
 
 export const mockMagneticModule: Types.MagneticModule = {
+  id: 'magdeck_id_2',
   model: 'magneticModuleV1',
   type: 'magneticModuleType',
   port: '/dev/ot_module_magdeck0',
@@ -158,6 +165,7 @@ export const mockMagneticModule: Types.MagneticModule = {
 }
 
 export const mockMagneticModuleGen2: Types.MagneticModule = {
+  id: 'magdeck_id_3',
   model: 'magneticModuleV2',
   type: 'magneticModuleType',
   port: '/dev/ot_module_magdeck0',
@@ -198,6 +206,7 @@ export const mockApiThermocyclerLegacy: ApiTypes.ApiThermocyclerModuleLegacy = {
 }
 
 export const mockApiThermocycler: ApiTypes.ApiThermocyclerModule = {
+  id: 'thermocycler_id_1',
   name: 'thermocycler',
   displayName: 'thermocycler',
   port: '/dev/ot_module_thermocycler0',
@@ -225,6 +234,7 @@ export const mockApiThermocycler: ApiTypes.ApiThermocyclerModule = {
 }
 
 export const mockThermocycler: Types.ThermocyclerModule = {
+  id: 'thermocycler_id_2',
   model: 'thermocyclerModuleV1',
   type: 'thermocyclerModuleType',
   port: '/dev/ot_module_thermocycler0',
@@ -250,6 +260,7 @@ export const mockThermocycler: Types.ThermocyclerModule = {
 }
 
 export const mockApiHeaterShaker: ApiTypes.ApiHeaterShakerModule = {
+  id: 'heatershaker_id_1',
   displayName: 'heatershaker',
   port: '/dev/ot_module_heatershaker0',
   serial: 'jkl123',
@@ -273,6 +284,7 @@ export const mockApiHeaterShaker: ApiTypes.ApiHeaterShakerModule = {
 }
 
 export const mockHeaterShaker: Types.HeaterShakerModule = {
+  id: 'heatershaker_id_2',
   model: 'heaterShakerModuleV1',
   type: 'heaterShakerModuleType',
   port: '/dev/ot_module_thermocycler0',

--- a/app/src/redux/modules/api-types.ts
+++ b/app/src/redux/modules/api-types.ts
@@ -14,6 +14,7 @@ interface PhysicalPort {
 }
 
 export interface ApiBaseModule {
+  id: string
   displayName: string
   serial: string
   revision: string

--- a/app/src/redux/modules/epic/__tests__/fetchModulesEpic.test.ts
+++ b/app/src/redux/modules/epic/__tests__/fetchModulesEpic.test.ts
@@ -98,41 +98,6 @@ describe('fetchModulesEpic', () => {
     })
   })
 
-  it('maps successful legacy response to FETCH_MODULES_SUCCESS', () => {
-    testScheduler.run(({ hot, cold, expectObservable, flush }) => {
-      mockFetchRobotApi.mockReturnValue(
-        cold<RobotApiResponse>('r', {
-          r: Fixtures.mockLegacyFetchModulesSuccess,
-        })
-      )
-
-      const action$ = hot<Action>('--a', { a: action })
-      const state$ = hot<State>('a-a', { a: {} } as any)
-      const output$ = modulesEpic(action$, state$)
-
-      expectObservable(output$).toBe('--a', {
-        a: Actions.fetchModulesSuccess(
-          mockRobot.name,
-          [
-            {
-              ...Fixtures.mockMagneticModule,
-              usbPort: { hub: null, port: null },
-            },
-            {
-              ...Fixtures.mockTemperatureModule,
-              usbPort: { hub: null, port: null },
-            },
-            {
-              ...Fixtures.mockThermocycler,
-              usbPort: { hub: null, port: null },
-            },
-          ],
-          { ...meta, response: Fixtures.mockFetchModulesSuccessMeta }
-        ),
-      })
-    })
-  })
-
   it('maps failed response to FETCH_MODULES_FAILURE', () => {
     testScheduler.run(({ hot, cold, expectObservable, flush }) => {
       mockFetchRobotApi.mockReturnValue(

--- a/app/src/redux/modules/epic/fetchModulesEpic.ts
+++ b/app/src/redux/modules/epic/fetchModulesEpic.ts
@@ -164,6 +164,7 @@ const normalizeModuleResponse = (
 ): AttachedModule => {
   return {
     ...normalizeModuleInfo(response),
+    id: response.id,
     revision: response.revision ? response.revision : response.model,
     port: response.port,
     serial: response.serial,


### PR DESCRIPTION
# Overview

as per https://github.com/Opentrons/opentrons/issues/9617  module resources from the`GET /modules` endpoint will have a new `id` field we will need to use in the `moduleId` payload fields in `POST /commands` endpoint.

This PR adds this id to the `ApiBaseModule` type and pulls out this new field in `fetchModulesEpic`

Note: backend has not been implemented yet so the id field doesn't actually come back yet. This is just so we can work off of valid TS types until the backend is complete. 


# Risk assessment

Low
