### PR TITLE
refactor(hardware): load git sha from device info

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -3,6 +3,7 @@
 #  dataclass fields interpretation.
 #  from __future__ import annotations
 from dataclasses import dataclass
+import enum
 
 from .. import utils
 
@@ -12,6 +13,7 @@ class EmptyPayload(utils.BinarySerializable):
     """An empty payload."""
 
     pass
+
 
 class FirmwareShortSHADataField(utils.BinaryFieldBase[bytes]):
     """The short hash in a device info.
@@ -25,11 +27,32 @@ class FirmwareShortSHADataField(utils.BinaryFieldBase[bytes]):
     NUM_BYTES = 7
     FORMAT = f"{NUM_BYTES}s"
 
+
+class VersionFlags(enum.Enum):
+    """Flags in the version field."""
+
+    BUILD_IS_EXACT_COMMIT = 0x1
+    BUILD_IS_EXACT_VERSION = 0x2
+    BUILD_IS_FROM_CI = 0x4
+
+
+class VersionFlagsField(utils.UInt32Field):
+    """A field for version flags."""
+
+    def __repr__(self) -> str:
+        """Print version flags."""
+        flags_list = [
+            flag.name for flag in VersionFlags if bool(self.value & flag.value)
+        ]
+        return f"{self.__class__.__name__}(value={','.join(flags_list)})"
+
+
 @dataclass
 class DeviceInfoResponsePayload(utils.BinarySerializable):
     """Device info response."""
 
     version: utils.UInt32Field
+    flags: VersionFlagsField
     shortsha: FirmwareShortSHADataField
 
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -13,12 +13,24 @@ class EmptyPayload(utils.BinarySerializable):
 
     pass
 
+class FirmwareShortSHADataField(utils.BinaryFieldBase[bytes]):
+    """The short hash in a device info.
+
+    This is sized to hold the default size of an abbreviated Git hash,
+    what you get when you do git rev-parse --short HEAD. If we ever
+    need to increase the size of that abbreviated ID, we'll need to
+    increase this too.
+    """
+
+    NUM_BYTES = 7
+    FORMAT = f"{NUM_BYTES}s"
 
 @dataclass
 class DeviceInfoResponsePayload(utils.BinarySerializable):
     """Device info response."""
 
     version: utils.UInt32Field
+    shortsha: FirmwareShortSHADataField
 
 
 class TaskNameDataField(utils.BinaryFieldBase[bytes]):

--- a/hardware/tests/opentrons_hardware/firmware_update/test_initiater.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_initiater.py
@@ -32,7 +32,11 @@ async def test_messaging(
         """Mock send method."""
         if isinstance(message, message_definitions.DeviceInfoRequest):
             response = message_definitions.DeviceInfoResponse(
-                payload=payloads.DeviceInfoResponsePayload(version=UInt32Field(0))
+                payload=payloads.DeviceInfoResponsePayload(
+                    version=UInt32Field(0),
+                    flags=payloads.VersionFlagsField(0),
+                    shortsha=payloads.FirmwareShortSHADataField(b"abcdef0"),
+                )
             )
             can_message_notifier.notify(
                 message=response,
@@ -76,7 +80,11 @@ async def test_retry(
     """It should retry device info request."""
     responses = [
         message_definitions.DeviceInfoResponse(
-            payload=payloads.DeviceInfoResponsePayload(version=UInt32Field(0))
+            payload=payloads.DeviceInfoResponsePayload(
+                version=UInt32Field(0),
+                flags=payloads.VersionFlagsField(0),
+                shortsha=payloads.FirmwareShortSHADataField(b"abcdef0"),
+            )
         ),
         None,
         None,

--- a/hardware/tests/opentrons_hardware/hardware_control/test_network.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_network.py
@@ -53,6 +53,8 @@ class MockStatusResponder:
                 response = message_definitions.DeviceInfoResponse(
                     payload=payloads.DeviceInfoResponsePayload(
                         version=utils.UInt32Field(0),
+                        flags=payloads.VersionFlagsField(0),
+                        shortsha=payloads.FirmwareShortSHADataField(b"abcdef0"),
                     )
                 )
                 asyncio.get_running_loop().call_soon(

--- a/hardware/tests/test_scripts/test_can_comm.py
+++ b/hardware/tests/test_scripts/test_can_comm.py
@@ -56,12 +56,13 @@ def test_prompt_message_with_payload(
     mock_get_input: MagicMock, mock_output: MagicMock
 ) -> None:
     """It should send a message with payload."""
-    message_id = MessageId.device_info_response
+    message_id = MessageId.write_motor_current_request
     node_id = NodeId.pipette_left
     mock_get_input.side_effect = [
         str(list(MessageId).index(message_id)),
         str(list(NodeId).index(node_id)),
         str(0xFF00FF00),
+        str(0xAA00BB00),
     ]
     r = can_comm.prompt_message(mock_get_input, mock_output)
     assert r == CanMessage(
@@ -70,7 +71,7 @@ def test_prompt_message_with_payload(
                 message_id=message_id, node_id=node_id, originating_node_id=NodeId.host
             )
         ),
-        data=b"\xff\x00\xff\x00",
+        data=b"\xff\x00\xff\x00\xAA\00\xBB\x00",
     )
 
 


### PR DESCRIPTION
The device info will now contain the git sha of the commit it was built from.

Works with https://github.com/Opentrons/ot3-firmware/pull/280