### PR TITLE
refactor(protocol-engine,shared-data): Change `engageMagnet` spec to use true mm

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/magnetic_module/engage.py
+++ b/api/src/opentrons/protocol_engine/commands/magnetic_module/engage.py
@@ -31,15 +31,16 @@ class EngageParams(BaseModel):
         ),
     )
 
-    # todo(mm, 2022-02-17): Using true millimeters differs from the current JSON
-    # protocol schema v6 draft. Ideally, change the v6 draft to match this.
     engageHeight: float = Field(
         ...,
         description=(
             "How high, in millimeters, to raise the magnets."
             "\n\n"
-            "Zero is level with the bottom of the labware."
-            " This will be a few millimeters above the magnets' hardware home position."
+            "Zero means the tops of the magnets are level with the ledge"
+            " that the labware rests on."
+            " This will be slightly above the magnets' minimum height,"
+            " the hardware home position."
+            " Negative values are allowed, to put the magnets below the ledge."
             "\n\n"
             "Units are always true millimeters."
             " This is unlike certain labware definitions,"

--- a/shared-data/protocol/schemas/6.json
+++ b/shared-data/protocol/schemas/6.json
@@ -545,7 +545,7 @@
                 "required": ["moduleId", "engageHeight"],
                 "properties": {
                   "engageHeight": {
-                    "description": "Height in mm(*) from bottom plane of labware (above if positive, below if negative). *NOTE: for magneticModuleV1 (aka GEN1), these are not true mm but an arbitrary unit equal to 0.5mm. So `engageHeight: 2` means 1mm above the labware plane if the command is for a GEN1 magnetic module, but would mean 2mm above the labware plane for GEN2 module",
+                    "description": "How high, in millimeters, to raise the magnets.\n\nZero means the tops of the magnets are level with the ledge that the labware rests on. This will be slightly above the magnets' minimum height, the hardware home position. Negative values are allowed, to put the magnets below the ledge.\n\nUnits are always true millimeters. This is unlike certain labware definitions, engage commands in the Python Protocol API, and engage commands in older versions of the JSON protocol schema. Take care to convert properly.",
                     "type": "number"
                   },
                   "moduleId": {


### PR DESCRIPTION
# Overview

In JSON v5 protocols, for historical reasons, Magnetic Module engage heights are specified in model-specific hardware units (true millimeters for Magnetic Modules GEN2, and half-millimeters for Magnetic Modules GEN1). This is confusing.

Following up on discussions with my CPX teammates and with @shlokamin and @b-cooper from App+UI, this changes the specification in JSON v6 protocols so that engage heights are always specified in true millimeters.

# Review requests

* Do we agree with this change?
* Is the new text is easy to understand, especially for people less familiar with these Magnetic Module nuances?
* The duplication between the JSON schema and our Python models is pretty troublesome. I don't think I can do anything about that in this PR, but we should recognize it.

# Risk assessment

None. The changes in this PR are to human-readable docs only.
