### PR TITLE
refactor(hardware): use enums values in payload display.

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
@@ -1,0 +1,87 @@
+"""Custom payload fields."""
+import enum
+
+from opentrons_hardware.firmware_bindings import utils, ErrorCode
+from opentrons_hardware.firmware_bindings.constants import ToolType, SensorType
+
+
+class FirmwareShortSHADataField(utils.BinaryFieldBase[bytes]):
+    """The short hash in a device info.
+
+    This is sized to hold the default size of an abbreviated Git hash,
+    what you get when you do git rev-parse --short HEAD. If we ever
+    need to increase the size of that abbreviated ID, we'll need to
+    increase this too.
+    """
+
+    NUM_BYTES = 7
+    FORMAT = f"{NUM_BYTES}s"
+
+
+class VersionFlags(enum.Enum):
+    """Flags in the version field."""
+
+    BUILD_IS_EXACT_COMMIT = 0x1
+    BUILD_IS_EXACT_VERSION = 0x2
+    BUILD_IS_FROM_CI = 0x4
+
+
+class VersionFlagsField(utils.UInt32Field):
+    """A field for version flags."""
+
+    def __repr__(self) -> str:
+        """Print version flags."""
+        flags_list = [
+            flag.name for flag in VersionFlags if bool(self.value & flag.value)
+        ]
+        return f"{self.__class__.__name__}(value={','.join(flags_list)})"
+
+
+class TaskNameDataField(utils.BinaryFieldBase[bytes]):
+    """The name field of TaskInfoResponsePayload."""
+
+    NUM_BYTES = 12
+    FORMAT = f"{NUM_BYTES}s"
+
+
+class ToolField(utils.UInt8Field):
+    """A tool field."""
+
+    def __repr__(self) -> str:
+        """Print out a tool string."""
+        try:
+            tool_val = ToolType(self.value).name
+        except ValueError:
+            tool_val = str(self.value)
+        return f"{self.__class__.__name__}(value={tool_val})"
+
+
+class FirmwareUpdateDataField(utils.BinaryFieldBase[bytes]):
+    """The data field of FirmwareUpdateData."""
+
+    NUM_BYTES = 56
+    FORMAT = f"{NUM_BYTES}s"
+
+
+class ErrorCodeField(utils.UInt16Field):
+    """Error code field."""
+
+    def __repr__(self) -> str:
+        """Print error code."""
+        try:
+            error = ErrorCode(self.value).name
+        except ValueError as e:
+            error = str(self.value)
+        return f"{self.__class__.__name__}(value={error})"
+
+
+class SensorTypeField(utils.UInt8Field):
+    """sensor type."""
+
+    def __repr__(self) -> str:
+        """Print sensor."""
+        try:
+            sensor_val = SensorType(self.value).name
+        except ValueError:
+            sensor_val = str(self.value)
+        return f"{self.__class__.__name__}(value={sensor_val})"

--- a/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
@@ -70,7 +70,7 @@ class ErrorCodeField(utils.UInt16Field):
         """Print error code."""
         try:
             error = ErrorCode(self.value).name
-        except ValueError as e:
+        except ValueError:
             error = str(self.value)
         return f"{self.__class__.__name__}(value={error})"
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -4,9 +4,15 @@
 #  from __future__ import annotations
 from dataclasses import dataclass
 
-from .fields import FirmwareShortSHADataField, VersionFlagsField, \
-    TaskNameDataField, ToolField, FirmwareUpdateDataField, ErrorCodeField, \
-    SensorTypeField
+from .fields import (
+    FirmwareShortSHADataField,
+    VersionFlagsField,
+    TaskNameDataField,
+    ToolField,
+    FirmwareUpdateDataField,
+    ErrorCodeField,
+    SensorTypeField,
+)
 from .. import utils
 
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -5,7 +5,8 @@
 from dataclasses import dataclass
 import enum
 
-from .. import utils
+from .. import utils, ErrorCode
+from ..constants import SensorType, ToolType
 
 
 @dataclass
@@ -224,14 +225,26 @@ class ReadPresenceSensingVoltageResponsePayload(utils.BinarySerializable):
     gripper: utils.UInt16Field
 
 
+class ToolField(utils.UInt8Field):
+    """A tool field."""
+
+    def __repr__(self) -> str:
+        """Print out a tool string."""
+        try:
+            tool_val = ToolType(self.value).name
+        except ValueError:
+            tool_val = str(self.value)
+        return f"{self.__class__.__name__}(value={tool_val})"
+
+
 @dataclass
 class ToolsDetectedNotificationPayload(utils.BinarySerializable):
     """Tool detection notification."""
 
     # Tools are mapped to an enum
-    z_motor: utils.UInt8Field
-    a_motor: utils.UInt8Field
-    gripper: utils.UInt8Field
+    z_motor: ToolField
+    a_motor: ToolField
+    gripper: ToolField
 
 
 @dataclass
@@ -282,11 +295,23 @@ class FirmwareUpdateData(FirmwareUpdateWithAddress):
         return obj
 
 
+class ErrorCodeField(utils.UInt16Field):
+    """Error code field."""
+
+    def __repr__(self) -> str:
+        """Print error code."""
+        try:
+            error = ErrorCode(self.value).name
+        except ValueError as e:
+            error = str(self.value)
+        return f"{self.__class__.__name__}(value={error})"
+
+
 @dataclass
 class FirmwareUpdateDataAcknowledge(FirmwareUpdateWithAddress):
     """A FW update data acknowledge payload."""
 
-    error_code: utils.UInt16Field
+    error_code: ErrorCodeField
 
 
 @dataclass
@@ -301,7 +326,7 @@ class FirmwareUpdateComplete(utils.BinarySerializable):
 class FirmwareUpdateAcknowledge(utils.BinarySerializable):
     """A response to a firmware update message with an error code."""
 
-    error_code: utils.UInt16Field
+    error_code: ErrorCodeField
 
 
 @dataclass
@@ -318,11 +343,23 @@ class GetLimitSwitchResponse(utils.BinarySerializable):
     switch_status: utils.UInt8Field
 
 
+class SensorTypeField(utils.UInt8Field):
+    """sensor type."""
+
+    def __repr__(self) -> str:
+        """Print sensor."""
+        try:
+            sensor_val = SensorType(self.value).name
+        except ValueError:
+            sensor_val = str(self.value)
+        return f"{self.__class__.__name__}(value={sensor_val})"
+
+
 @dataclass
 class ReadFromSensorRequestPayload(utils.BinarySerializable):
     """Take a single reading from a sensor request payload."""
 
-    sensor: utils.UInt8Field
+    sensor: SensorTypeField
     offset_reading: utils.UInt8Field
 
 
@@ -330,7 +367,7 @@ class ReadFromSensorRequestPayload(utils.BinarySerializable):
 class WriteToSensorRequestPayload(utils.BinarySerializable):
     """Write a piece of data to a sensor request payload."""
 
-    sensor: utils.UInt8Field
+    sensor: SensorTypeField
     data: utils.UInt32Field
 
 
@@ -338,7 +375,7 @@ class WriteToSensorRequestPayload(utils.BinarySerializable):
 class BaselineSensorRequestPayload(utils.BinarySerializable):
     """Take a specified amount of readings from a sensor request payload."""
 
-    sensor: utils.UInt8Field
+    sensor: SensorTypeField
     sample_rate: utils.UInt16Field
     offset_update: utils.UInt8Field
 
@@ -347,7 +384,7 @@ class BaselineSensorRequestPayload(utils.BinarySerializable):
 class ReadFromSensorResponsePayload(utils.BinarySerializable):
     """A response for either a single reading or an averaged reading of a sensor."""
 
-    sensor: utils.UInt8Field
+    sensor: SensorTypeField
     sensor_data: utils.UInt32Field
 
 
@@ -355,7 +392,7 @@ class ReadFromSensorResponsePayload(utils.BinarySerializable):
 class SetSensorThresholdRequestPayload(utils.BinarySerializable):
     """A request to set the threshold value of a sensor."""
 
-    sensor: utils.UInt8Field
+    sensor: SensorTypeField
     threshold: utils.UInt32Field
 
 
@@ -363,5 +400,5 @@ class SetSensorThresholdRequestPayload(utils.BinarySerializable):
 class SensorThresholdResponsePayload(utils.BinarySerializable):
     """A response that sends back the current threshold value of the sensor."""
 
-    sensor: utils.UInt8Field
+    sensor: SensorTypeField
     threshold: utils.UInt32Field

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -3,10 +3,11 @@
 #  dataclass fields interpretation.
 #  from __future__ import annotations
 from dataclasses import dataclass
-import enum
 
-from .. import utils, ErrorCode
-from ..constants import SensorType, ToolType
+from .fields import FirmwareShortSHADataField, VersionFlagsField, \
+    TaskNameDataField, ToolField, FirmwareUpdateDataField, ErrorCodeField, \
+    SensorTypeField
+from .. import utils
 
 
 @dataclass
@@ -16,38 +17,6 @@ class EmptyPayload(utils.BinarySerializable):
     pass
 
 
-class FirmwareShortSHADataField(utils.BinaryFieldBase[bytes]):
-    """The short hash in a device info.
-
-    This is sized to hold the default size of an abbreviated Git hash,
-    what you get when you do git rev-parse --short HEAD. If we ever
-    need to increase the size of that abbreviated ID, we'll need to
-    increase this too.
-    """
-
-    NUM_BYTES = 7
-    FORMAT = f"{NUM_BYTES}s"
-
-
-class VersionFlags(enum.Enum):
-    """Flags in the version field."""
-
-    BUILD_IS_EXACT_COMMIT = 0x1
-    BUILD_IS_EXACT_VERSION = 0x2
-    BUILD_IS_FROM_CI = 0x4
-
-
-class VersionFlagsField(utils.UInt32Field):
-    """A field for version flags."""
-
-    def __repr__(self) -> str:
-        """Print version flags."""
-        flags_list = [
-            flag.name for flag in VersionFlags if bool(self.value & flag.value)
-        ]
-        return f"{self.__class__.__name__}(value={','.join(flags_list)})"
-
-
 @dataclass
 class DeviceInfoResponsePayload(utils.BinarySerializable):
     """Device info response."""
@@ -55,13 +24,6 @@ class DeviceInfoResponsePayload(utils.BinarySerializable):
     version: utils.UInt32Field
     flags: VersionFlagsField
     shortsha: FirmwareShortSHADataField
-
-
-class TaskNameDataField(utils.BinaryFieldBase[bytes]):
-    """The name field of TaskInfoResponsePayload."""
-
-    NUM_BYTES = 12
-    FORMAT = f"{NUM_BYTES}s"
 
 
 @dataclass
@@ -225,18 +187,6 @@ class ReadPresenceSensingVoltageResponsePayload(utils.BinarySerializable):
     gripper: utils.UInt16Field
 
 
-class ToolField(utils.UInt8Field):
-    """A tool field."""
-
-    def __repr__(self) -> str:
-        """Print out a tool string."""
-        try:
-            tool_val = ToolType(self.value).name
-        except ValueError:
-            tool_val = str(self.value)
-        return f"{self.__class__.__name__}(value={tool_val})"
-
-
 @dataclass
 class ToolsDetectedNotificationPayload(utils.BinarySerializable):
     """Tool detection notification."""
@@ -252,13 +202,6 @@ class FirmwareUpdateWithAddress(utils.BinarySerializable):
     """A FW update payload with an address."""
 
     address: utils.UInt32Field
-
-
-class FirmwareUpdateDataField(utils.BinaryFieldBase[bytes]):
-    """The data field of FirmwareUpdateData."""
-
-    NUM_BYTES = 56
-    FORMAT = f"{NUM_BYTES}s"
 
 
 @dataclass
@@ -295,18 +238,6 @@ class FirmwareUpdateData(FirmwareUpdateWithAddress):
         return obj
 
 
-class ErrorCodeField(utils.UInt16Field):
-    """Error code field."""
-
-    def __repr__(self) -> str:
-        """Print error code."""
-        try:
-            error = ErrorCode(self.value).name
-        except ValueError as e:
-            error = str(self.value)
-        return f"{self.__class__.__name__}(value={error})"
-
-
 @dataclass
 class FirmwareUpdateDataAcknowledge(FirmwareUpdateWithAddress):
     """A FW update data acknowledge payload."""
@@ -341,18 +272,6 @@ class GetLimitSwitchResponse(utils.BinarySerializable):
     """A response to the Limit Switch Status request payload."""
 
     switch_status: utils.UInt8Field
-
-
-class SensorTypeField(utils.UInt8Field):
-    """sensor type."""
-
-    def __repr__(self) -> str:
-        """Print sensor."""
-        try:
-            sensor_val = SensorType(self.value).name
-        except ValueError:
-            sensor_val = str(self.value)
-        return f"{self.__class__.__name__}(value={sensor_val})"
 
 
 @dataclass

--- a/hardware/opentrons_hardware/firmware_update/downloader.py
+++ b/hardware/opentrons_hardware/firmware_update/downloader.py
@@ -3,7 +3,6 @@ import asyncio
 import binascii
 import logging
 
-import opentrons_hardware.firmware_bindings.messages.fields
 from opentrons_hardware.firmware_bindings import NodeId
 from opentrons_hardware.firmware_bindings.constants import ErrorCode
 from opentrons_hardware.firmware_bindings.utils import UInt32Field
@@ -14,8 +13,11 @@ from opentrons_hardware.drivers.can_bus.can_messenger import (
 )
 from opentrons_hardware.firmware_update.errors import ErrorResponse, TimeoutResponse
 from opentrons_hardware.firmware_update.hex_file import HexRecordProcessor
-from opentrons_hardware.firmware_bindings.messages import message_definitions, payloads
-
+from opentrons_hardware.firmware_bindings.messages import (
+    message_definitions,
+    payloads,
+    fields,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +49,7 @@ class FirmwareUpdateDownloader:
             num_messages = 0
             crc32 = 0
             for chunk in hex_processor.process(
-                opentrons_hardware.firmware_bindings.messages.fields.FirmwareUpdateDataField.NUM_BYTES
+                fields.FirmwareUpdateDataField.NUM_BYTES
             ):
                 logger.debug(
                     f"Sending chunk {num_messages} to address {chunk.address:x}."

--- a/hardware/opentrons_hardware/firmware_update/downloader.py
+++ b/hardware/opentrons_hardware/firmware_update/downloader.py
@@ -3,6 +3,7 @@ import asyncio
 import binascii
 import logging
 
+import opentrons_hardware.firmware_bindings.messages.fields
 from opentrons_hardware.firmware_bindings import NodeId
 from opentrons_hardware.firmware_bindings.constants import ErrorCode
 from opentrons_hardware.firmware_bindings.utils import UInt32Field
@@ -46,7 +47,7 @@ class FirmwareUpdateDownloader:
             num_messages = 0
             crc32 = 0
             for chunk in hex_processor.process(
-                payloads.FirmwareUpdateDataField.NUM_BYTES
+                opentrons_hardware.firmware_bindings.messages.fields.FirmwareUpdateDataField.NUM_BYTES
             ):
                 logger.debug(
                     f"Sending chunk {num_messages} to address {chunk.address:x}."

--- a/hardware/opentrons_hardware/sensors/scheduler.py
+++ b/hardware/opentrons_hardware/sensors/scheduler.py
@@ -23,8 +23,8 @@ from opentrons_hardware.firmware_bindings.messages.payloads import (
     SetSensorThresholdRequestPayload,
     WriteToSensorRequestPayload,
     BaselineSensorRequestPayload,
-    SensorTypeField,
 )
+from opentrons_hardware.firmware_bindings.messages.fields import SensorTypeField
 
 from opentrons_hardware.sensors.utils import (
     ReadSensorInformation,

--- a/hardware/opentrons_hardware/sensors/scheduler.py
+++ b/hardware/opentrons_hardware/sensors/scheduler.py
@@ -23,6 +23,7 @@ from opentrons_hardware.firmware_bindings.messages.payloads import (
     SetSensorThresholdRequestPayload,
     WriteToSensorRequestPayload,
     BaselineSensorRequestPayload,
+    SensorTypeField,
 )
 
 from opentrons_hardware.sensors.utils import (
@@ -54,7 +55,7 @@ class SensorScheduler:
                 node_id=sensor.node_id,
                 message=BaselineSensorRequest(
                     payload=BaselineSensorRequestPayload(
-                        sensor=UInt8Field(sensor.sensor_type),
+                        sensor=SensorTypeField(sensor.sensor_type),
                         sample_rate=UInt16Field(sensor.poll_for),
                         offset_update=UInt8Field(sensor.offset),
                     )
@@ -77,7 +78,7 @@ class SensorScheduler:
             node_id=sensor.node_id,
             message=WriteToSensorRequest(
                 payload=WriteToSensorRequestPayload(
-                    sensor=UInt8Field(sensor.sensor_type),
+                    sensor=SensorTypeField(sensor.sensor_type),
                     data=UInt32Field(sensor.data.to_int),
                 )
             ),
@@ -93,7 +94,7 @@ class SensorScheduler:
                 node_id=sensor.node_id,
                 message=ReadFromSensorRequest(
                     payload=ReadFromSensorRequestPayload(
-                        sensor=UInt8Field(sensor.sensor_type),
+                        sensor=SensorTypeField(sensor.sensor_type),
                         offset_reading=UInt8Field(sensor.offset),
                     )
                 ),
@@ -117,7 +118,7 @@ class SensorScheduler:
                 node_id=sensor.node_id,
                 message=SetSensorThresholdRequest(
                     payload=SetSensorThresholdRequestPayload(
-                        sensor=UInt8Field(sensor.sensor_type),
+                        sensor=SensorTypeField(sensor.sensor_type),
                         threshold=UInt32Field(sensor.data.to_int),
                     )
                 ),

--- a/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_payloads.py
+++ b/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_payloads.py
@@ -1,6 +1,7 @@
 """Payloads tests."""
 import pytest
 
+import opentrons_hardware.firmware_bindings.messages.fields
 from opentrons_hardware.firmware_bindings.messages import payloads
 from opentrons_hardware.firmware_bindings import utils
 
@@ -23,6 +24,6 @@ def test_create_firmware_updata_data(
         address=utils.UInt32Field(address),
         num_bytes=utils.UInt8Field(len(data)),
         reserved=utils.UInt8Field(0),
-        data=payloads.FirmwareUpdateDataField(data),
+        data=opentrons_hardware.firmware_bindings.messages.fields.FirmwareUpdateDataField(data),
         checksum=utils.UInt16Field(expected_checksum),
     )

--- a/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_payloads.py
+++ b/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_payloads.py
@@ -1,8 +1,7 @@
 """Payloads tests."""
 import pytest
 
-import opentrons_hardware.firmware_bindings.messages.fields
-from opentrons_hardware.firmware_bindings.messages import payloads
+from opentrons_hardware.firmware_bindings.messages import payloads, fields
 from opentrons_hardware.firmware_bindings import utils
 
 
@@ -24,6 +23,6 @@ def test_create_firmware_updata_data(
         address=utils.UInt32Field(address),
         num_bytes=utils.UInt8Field(len(data)),
         reserved=utils.UInt8Field(0),
-        data=opentrons_hardware.firmware_bindings.messages.fields.FirmwareUpdateDataField(data),
+        data=fields.FirmwareUpdateDataField(data),
         checksum=utils.UInt16Field(expected_checksum),
     )

--- a/hardware/tests/opentrons_hardware/firmware_update/test_downloader.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_downloader.py
@@ -19,7 +19,7 @@ from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     FirmwareUpdateCompleteAcknowledge,
 )
 from opentrons_hardware.firmware_bindings.messages import payloads
-from opentrons_hardware.firmware_bindings.messages.payloads import ErrorCodeField
+from opentrons_hardware.firmware_bindings.messages.fields import ErrorCodeField
 
 from opentrons_hardware.firmware_update import downloader
 from opentrons_hardware.firmware_update.errors import ErrorResponse, TimeoutResponse

--- a/hardware/tests/opentrons_hardware/firmware_update/test_downloader.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_downloader.py
@@ -19,6 +19,7 @@ from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     FirmwareUpdateCompleteAcknowledge,
 )
 from opentrons_hardware.firmware_bindings.messages import payloads
+from opentrons_hardware.firmware_bindings.messages.payloads import ErrorCodeField
 
 from opentrons_hardware.firmware_update import downloader
 from opentrons_hardware.firmware_update.errors import ErrorResponse, TimeoutResponse
@@ -74,7 +75,7 @@ async def test_messaging(
                 FirmwareUpdateDataAcknowledge(
                     payload=payloads.FirmwareUpdateDataAcknowledge(
                         address=message.payload.address,
-                        error_code=utils.UInt16Field(ErrorCode.ok),
+                        error_code=ErrorCodeField(ErrorCode.ok),
                     )
                 ),
                 ArbitrationId(
@@ -90,7 +91,7 @@ async def test_messaging(
             can_message_notifier.notify(
                 FirmwareUpdateCompleteAcknowledge(
                     payload=payloads.FirmwareUpdateAcknowledge(
-                        error_code=utils.UInt16Field(ErrorCode.ok)
+                        error_code=ErrorCodeField(ErrorCode.ok)
                     )
                 ),
                 ArbitrationId(
@@ -151,7 +152,7 @@ async def test_messaging_data_error_response(
                 FirmwareUpdateDataAcknowledge(
                     payload=payloads.FirmwareUpdateDataAcknowledge(
                         address=message.payload.address,
-                        error_code=utils.UInt16Field(ErrorCode.bad_checksum),
+                        error_code=ErrorCodeField(ErrorCode.bad_checksum),
                     )
                 ),
                 ArbitrationId(
@@ -188,7 +189,7 @@ async def test_messaging_complete_error_response(
                 FirmwareUpdateDataAcknowledge(
                     payload=payloads.FirmwareUpdateDataAcknowledge(
                         address=message.payload.address,
-                        error_code=utils.UInt16Field(ErrorCode.ok),
+                        error_code=ErrorCodeField(ErrorCode.ok),
                     )
                 ),
                 ArbitrationId(
@@ -204,7 +205,7 @@ async def test_messaging_complete_error_response(
             can_message_notifier.notify(
                 FirmwareUpdateCompleteAcknowledge(
                     payload=payloads.FirmwareUpdateAcknowledge(
-                        error_code=utils.UInt16Field(ErrorCode.invalid_size)
+                        error_code=ErrorCodeField(ErrorCode.invalid_size)
                     )
                 ),
                 ArbitrationId(
@@ -255,7 +256,7 @@ async def test_messaging_complete_no_response(
                 FirmwareUpdateDataAcknowledge(
                     payload=payloads.FirmwareUpdateDataAcknowledge(
                         address=message.payload.address,
-                        error_code=utils.UInt16Field(ErrorCode.ok),
+                        error_code=ErrorCodeField(ErrorCode.ok),
                     )
                 ),
                 ArbitrationId(

--- a/hardware/tests/opentrons_hardware/firmware_update/test_eraser.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_eraser.py
@@ -13,6 +13,7 @@ from opentrons_hardware.firmware_bindings.messages import (
     message_definitions,
     payloads,
 )
+from opentrons_hardware.firmware_bindings.messages.payloads import ErrorCodeField
 from opentrons_hardware.firmware_bindings.utils import UInt16Field
 from opentrons_hardware.firmware_update import FirmwareUpdateEraser
 from opentrons_hardware.firmware_update.errors import ErrorResponse, TimeoutResponse
@@ -37,7 +38,7 @@ async def test_messaging(
         if isinstance(message, message_definitions.FirmwareUpdateEraseAppRequest):
             response = message_definitions.FirmwareUpdateEraseAppResponse(
                 payload=payloads.FirmwareUpdateAcknowledge(
-                    error_code=UInt16Field(ErrorCode.ok)
+                    error_code=ErrorCodeField(ErrorCode.ok)
                 )
             )
             can_message_notifier.notify(
@@ -76,7 +77,7 @@ async def test_error_message(
         if isinstance(message, message_definitions.FirmwareUpdateEraseAppRequest):
             response = message_definitions.FirmwareUpdateEraseAppResponse(
                 payload=payloads.FirmwareUpdateAcknowledge(
-                    error_code=UInt16Field(ErrorCode.hardware)
+                    error_code=ErrorCodeField(ErrorCode.hardware)
                 )
             )
             can_message_notifier.notify(

--- a/hardware/tests/opentrons_hardware/firmware_update/test_eraser.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_eraser.py
@@ -13,7 +13,7 @@ from opentrons_hardware.firmware_bindings.messages import (
     message_definitions,
     payloads,
 )
-from opentrons_hardware.firmware_bindings.messages.payloads import ErrorCodeField
+from opentrons_hardware.firmware_bindings.messages.fields import ErrorCodeField
 from opentrons_hardware.firmware_bindings.utils import UInt16Field
 from opentrons_hardware.firmware_update import FirmwareUpdateEraser
 from opentrons_hardware.firmware_update.errors import ErrorResponse, TimeoutResponse

--- a/hardware/tests/opentrons_hardware/firmware_update/test_eraser.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_eraser.py
@@ -14,7 +14,6 @@ from opentrons_hardware.firmware_bindings.messages import (
     payloads,
 )
 from opentrons_hardware.firmware_bindings.messages.fields import ErrorCodeField
-from opentrons_hardware.firmware_bindings.utils import UInt16Field
 from opentrons_hardware.firmware_update import FirmwareUpdateEraser
 from opentrons_hardware.firmware_update.errors import ErrorResponse, TimeoutResponse
 from tests.conftest import MockCanMessageNotifier

--- a/hardware/tests/opentrons_hardware/firmware_update/test_initiater.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_initiater.py
@@ -2,13 +2,12 @@
 import pytest
 from mock import AsyncMock, call
 
-import opentrons_hardware.firmware_bindings.messages.fields
 from opentrons_hardware.firmware_bindings import (
     NodeId,
     ArbitrationId,
     ArbitrationIdParts,
 )
-from opentrons_hardware.firmware_bindings.messages import MessageDefinition
+from opentrons_hardware.firmware_bindings.messages import MessageDefinition, fields
 from opentrons_hardware.firmware_bindings.messages import message_definitions, payloads
 from opentrons_hardware.firmware_bindings.utils import UInt32Field
 
@@ -36,8 +35,8 @@ async def test_messaging(
             response = message_definitions.DeviceInfoResponse(
                 payload=payloads.DeviceInfoResponsePayload(
                     version=UInt32Field(0),
-                    flags=opentrons_hardware.firmware_bindings.messages.fields.VersionFlagsField(0),
-                    shortsha=opentrons_hardware.firmware_bindings.messages.fields.FirmwareShortSHADataField(b"abcdef0"),
+                    flags=fields.VersionFlagsField(0),
+                    shortsha=fields.FirmwareShortSHADataField(b"abcdef0"),
                 )
             )
             can_message_notifier.notify(
@@ -84,8 +83,8 @@ async def test_retry(
         message_definitions.DeviceInfoResponse(
             payload=payloads.DeviceInfoResponsePayload(
                 version=UInt32Field(0),
-                flags=opentrons_hardware.firmware_bindings.messages.fields.VersionFlagsField(0),
-                shortsha=opentrons_hardware.firmware_bindings.messages.fields.FirmwareShortSHADataField(b"abcdef0"),
+                flags=fields.VersionFlagsField(0),
+                shortsha=fields.FirmwareShortSHADataField(b"abcdef0"),
             )
         ),
         None,

--- a/hardware/tests/opentrons_hardware/firmware_update/test_initiater.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_initiater.py
@@ -1,6 +1,8 @@
 """Tests for FirmwareUpdateInitiator."""
 import pytest
 from mock import AsyncMock, call
+
+import opentrons_hardware.firmware_bindings.messages.fields
 from opentrons_hardware.firmware_bindings import (
     NodeId,
     ArbitrationId,
@@ -34,8 +36,8 @@ async def test_messaging(
             response = message_definitions.DeviceInfoResponse(
                 payload=payloads.DeviceInfoResponsePayload(
                     version=UInt32Field(0),
-                    flags=payloads.VersionFlagsField(0),
-                    shortsha=payloads.FirmwareShortSHADataField(b"abcdef0"),
+                    flags=opentrons_hardware.firmware_bindings.messages.fields.VersionFlagsField(0),
+                    shortsha=opentrons_hardware.firmware_bindings.messages.fields.FirmwareShortSHADataField(b"abcdef0"),
                 )
             )
             can_message_notifier.notify(
@@ -82,8 +84,8 @@ async def test_retry(
         message_definitions.DeviceInfoResponse(
             payload=payloads.DeviceInfoResponsePayload(
                 version=UInt32Field(0),
-                flags=payloads.VersionFlagsField(0),
-                shortsha=payloads.FirmwareShortSHADataField(b"abcdef0"),
+                flags=opentrons_hardware.firmware_bindings.messages.fields.VersionFlagsField(0),
+                shortsha=opentrons_hardware.firmware_bindings.messages.fields.FirmwareShortSHADataField(b"abcdef0"),
             )
         ),
         None,

--- a/hardware/tests/opentrons_hardware/hardware_control/test_network.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_network.py
@@ -4,6 +4,8 @@ import asyncio
 import datetime
 from typing import List, Callable
 from mock import AsyncMock
+
+import opentrons_hardware.firmware_bindings.messages.fields
 from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
 from opentrons_hardware.firmware_bindings import (
     ArbitrationId,
@@ -53,8 +55,8 @@ class MockStatusResponder:
                 response = message_definitions.DeviceInfoResponse(
                     payload=payloads.DeviceInfoResponsePayload(
                         version=utils.UInt32Field(0),
-                        flags=payloads.VersionFlagsField(0),
-                        shortsha=payloads.FirmwareShortSHADataField(b"abcdef0"),
+                        flags=opentrons_hardware.firmware_bindings.messages.fields.VersionFlagsField(0),
+                        shortsha=opentrons_hardware.firmware_bindings.messages.fields.FirmwareShortSHADataField(b"abcdef0"),
                     )
                 )
                 asyncio.get_running_loop().call_soon(

--- a/hardware/tests/opentrons_hardware/hardware_control/test_network.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_network.py
@@ -5,7 +5,6 @@ import datetime
 from typing import List, Callable
 from mock import AsyncMock
 
-import opentrons_hardware.firmware_bindings.messages.fields
 from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
 from opentrons_hardware.firmware_bindings import (
     ArbitrationId,
@@ -16,6 +15,7 @@ from opentrons_hardware.firmware_bindings.messages import (
     MessageDefinition,
     message_definitions,
     payloads,
+    fields,
 )
 from opentrons_hardware.firmware_bindings.constants import NodeId
 
@@ -55,8 +55,8 @@ class MockStatusResponder:
                 response = message_definitions.DeviceInfoResponse(
                     payload=payloads.DeviceInfoResponsePayload(
                         version=utils.UInt32Field(0),
-                        flags=opentrons_hardware.firmware_bindings.messages.fields.VersionFlagsField(0),
-                        shortsha=opentrons_hardware.firmware_bindings.messages.fields.FirmwareShortSHADataField(b"abcdef0"),
+                        flags=fields.VersionFlagsField(0),
+                        shortsha=fields.FirmwareShortSHADataField(b"abcdef0"),
                     )
                 )
                 asyncio.get_running_loop().call_soon(
@@ -80,7 +80,7 @@ async def test_timeout_fires(mock_can_messenger: AsyncMock) -> None:
     # if it didn't work, so wrap it in a wait_for of our own with a bigger timeout
     # that will raise if it fails
     nodes = await asyncio.wait_for(
-        probe(mock_can_messenger, set((NodeId.gantry_x, NodeId.gantry_y)), 0.5), 1.0
+        probe(mock_can_messenger, {NodeId.gantry_x, NodeId.gantry_y}, 0.5), 1.0
     )
     now = datetime.datetime.utcnow()
     # we should have taken the full time allotted
@@ -109,9 +109,9 @@ async def test_completes_exact_equality(mock_can_messenger: AsyncMock) -> None:
     # doesn't raise, so wrap it in a smaller timeout so it will raise (it should
     # complete basically instantly)
     probed = await asyncio.wait_for(
-        probe(mock_can_messenger, set((NodeId.gantry_x,)), None), 2.0
+        probe(mock_can_messenger, {NodeId.gantry_x}, None), 2.0
     )
-    assert probed == set((NodeId.gantry_x,))
+    assert probed == {NodeId.gantry_x}
 
 
 async def test_completes_more_than_expected(mock_can_messenger: AsyncMock) -> None:
@@ -121,10 +121,10 @@ async def test_completes_more_than_expected(mock_can_messenger: AsyncMock) -> No
     )
     # same deal with the timeout
     probed = await asyncio.wait_for(
-        probe(mock_can_messenger, set((NodeId.gantry_x,)), None), 2.0
+        probe(mock_can_messenger, {NodeId.gantry_x}, None), 2.0
     )
     # we should get everything we prepped the network with
-    assert probed == set((NodeId.gantry_x, NodeId.gantry_y))
+    assert probed == {NodeId.gantry_x, NodeId.gantry_y}
 
 
 async def test_handles_bad_node_ids(mock_can_messenger: AsyncMock) -> None:
@@ -132,7 +132,7 @@ async def test_handles_bad_node_ids(mock_can_messenger: AsyncMock) -> None:
     _ = MockStatusResponder(mock_can_messenger, [0x01, NodeId.gantry_x.value])
     # same deal with the timeout
     probed = await asyncio.wait_for(
-        probe(mock_can_messenger, set((NodeId.gantry_x,)), None), 2.0
+        probe(mock_can_messenger, {NodeId.gantry_x}, None), 2.0
     )
     # we should get everything we prepped the network with and ignore the bad values
-    assert probed == set((NodeId.gantry_x,))
+    assert probed == {NodeId.gantry_x}

--- a/hardware/tests/opentrons_hardware/hardware_control/tools/test_detector.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/tools/test_detector.py
@@ -8,7 +8,6 @@ from mock import AsyncMock, call
 
 from opentrons_hardware.firmware_bindings.messages.fields import ToolField
 from opentrons_hardware.hardware_control.tools import detector
-from opentrons_hardware.firmware_bindings.utils import UInt8Field
 from opentrons_hardware.firmware_bindings.messages import message_definitions, payloads
 from opentrons_hardware.firmware_bindings import (
     NodeId,

--- a/hardware/tests/opentrons_hardware/hardware_control/tools/test_detector.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/tools/test_detector.py
@@ -5,6 +5,8 @@ from opentrons_hardware.firmware_bindings.messages import (
 )
 import pytest
 from mock import AsyncMock, call
+
+from opentrons_hardware.firmware_bindings.messages.payloads import ToolField
 from opentrons_hardware.hardware_control.tools import detector
 from opentrons_hardware.firmware_bindings.utils import UInt8Field
 from opentrons_hardware.firmware_bindings.messages import message_definitions, payloads
@@ -30,7 +32,7 @@ def subject(
     argvalues=[
         [
             payloads.ToolsDetectedNotificationPayload(
-                z_motor=UInt8Field(1), a_motor=UInt8Field(2), gripper=UInt8Field(5)
+                z_motor=ToolField(1), a_motor=ToolField(2), gripper=ToolField(5)
             ),
             ToolDetectionResult(
                 left=ToolType.pipette_96_chan,
@@ -40,7 +42,7 @@ def subject(
         ],
         [
             payloads.ToolsDetectedNotificationPayload(
-                z_motor=UInt8Field(221), a_motor=UInt8Field(2), gripper=UInt8Field(5)
+                z_motor=ToolField(221), a_motor=ToolField(2), gripper=ToolField(5)
             ),
             ToolDetectionResult(
                 left=ToolType.undefined_tool,

--- a/hardware/tests/opentrons_hardware/hardware_control/tools/test_detector.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/tools/test_detector.py
@@ -6,7 +6,7 @@ from opentrons_hardware.firmware_bindings.messages import (
 import pytest
 from mock import AsyncMock, call
 
-from opentrons_hardware.firmware_bindings.messages.payloads import ToolField
+from opentrons_hardware.firmware_bindings.messages.fields import ToolField
 from opentrons_hardware.hardware_control.tools import detector
 from opentrons_hardware.firmware_bindings.utils import UInt8Field
 from opentrons_hardware.firmware_bindings.messages import message_definitions, payloads

--- a/hardware/tests/opentrons_hardware/sensors/test_sensor_drivers.py
+++ b/hardware/tests/opentrons_hardware/sensors/test_sensor_drivers.py
@@ -30,6 +30,7 @@ from opentrons_hardware.firmware_bindings.messages.payloads import (
     WriteToSensorRequestPayload,
     ReadFromSensorResponsePayload,
     SensorThresholdResponsePayload,
+    SensorTypeField,
 )
 from opentrons_hardware.sensors.utils import SensorDataType
 
@@ -66,7 +67,7 @@ def humidity_sensor() -> hdc2080.EnvironmentSensor:
             NodeId.pipette_left,
             BaselineSensorRequest(
                 payload=BaselineSensorRequestPayload(
-                    sensor=UInt8Field(SensorType.pressure),
+                    sensor=SensorTypeField(SensorType.pressure),
                     sample_rate=UInt16Field(10),
                     offset_update=UInt8Field(False),
                 )
@@ -77,7 +78,7 @@ def humidity_sensor() -> hdc2080.EnvironmentSensor:
             NodeId.pipette_left,
             BaselineSensorRequest(
                 payload=BaselineSensorRequestPayload(
-                    sensor=UInt8Field(SensorType.capacitive),
+                    sensor=SensorTypeField(SensorType.capacitive),
                     sample_rate=UInt16Field(10),
                     offset_update=UInt8Field(False),
                 )
@@ -114,7 +115,7 @@ async def test_receive_data_polling(
             ReadFromSensorResponse(
                 payload=ReadFromSensorResponsePayload(
                     sensor_data=UInt32Field(0x100),
-                    sensor=UInt8Field(sensor._sensor_type),
+                    sensor=SensorTypeField(sensor._sensor_type),
                 )
             ),
             ArbitrationId(
@@ -140,7 +141,7 @@ async def test_receive_data_polling(
             NodeId.pipette_left,
             WriteToSensorRequest(
                 payload=WriteToSensorRequestPayload(
-                    sensor=UInt8Field(SensorType.pressure),
+                    sensor=SensorTypeField(SensorType.pressure),
                     data=UInt32Field(SensorDataType.build([0x2, 0x2, 0x0, 0x0]).to_int),
                 )
             ),
@@ -150,7 +151,7 @@ async def test_receive_data_polling(
             NodeId.pipette_left,
             WriteToSensorRequest(
                 payload=WriteToSensorRequestPayload(
-                    sensor=UInt8Field(SensorType.capacitive),
+                    sensor=SensorTypeField(SensorType.capacitive),
                     data=UInt32Field(SensorDataType.build([0x2, 0x2, 0x0, 0x0]).to_int),
                 )
             ),
@@ -160,7 +161,7 @@ async def test_receive_data_polling(
             NodeId.pipette_left,
             WriteToSensorRequest(
                 payload=WriteToSensorRequestPayload(
-                    sensor=UInt8Field(SensorType.temperature),
+                    sensor=SensorTypeField(SensorType.temperature),
                     data=UInt32Field(SensorDataType.build([0x2, 0x2, 0x0, 0x0]).to_int),
                 )
             ),
@@ -170,7 +171,7 @@ async def test_receive_data_polling(
             NodeId.pipette_left,
             WriteToSensorRequest(
                 payload=WriteToSensorRequestPayload(
-                    sensor=UInt8Field(SensorType.humidity),
+                    sensor=SensorTypeField(SensorType.humidity),
                     data=UInt32Field(SensorDataType.build([0x2, 0x2, 0x0, 0x0]).to_int),
                 )
             ),
@@ -195,7 +196,7 @@ async def test_write(
             NodeId.pipette_left,
             ReadFromSensorRequest(
                 payload=ReadFromSensorRequestPayload(
-                    sensor=UInt8Field(SensorType.pressure),
+                    sensor=SensorTypeField(SensorType.pressure),
                     offset_reading=UInt8Field(False),
                 )
             ),
@@ -205,7 +206,7 @@ async def test_write(
             NodeId.pipette_left,
             ReadFromSensorRequest(
                 payload=ReadFromSensorRequestPayload(
-                    sensor=UInt8Field(SensorType.capacitive),
+                    sensor=SensorTypeField(SensorType.capacitive),
                     offset_reading=UInt8Field(False),
                 )
             ),
@@ -215,7 +216,7 @@ async def test_write(
             NodeId.pipette_left,
             ReadFromSensorRequest(
                 payload=ReadFromSensorRequestPayload(
-                    sensor=UInt8Field(SensorType.temperature),
+                    sensor=SensorTypeField(SensorType.temperature),
                     offset_reading=UInt8Field(False),
                 )
             ),
@@ -225,7 +226,7 @@ async def test_write(
             NodeId.pipette_left,
             ReadFromSensorRequest(
                 payload=ReadFromSensorRequestPayload(
-                    sensor=UInt8Field(SensorType.humidity),
+                    sensor=SensorTypeField(SensorType.humidity),
                     offset_reading=UInt8Field(False),
                 )
             ),
@@ -263,7 +264,7 @@ async def test_receive_data_read(
             ReadFromSensorResponse(
                 payload=ReadFromSensorResponsePayload(
                     sensor_data=UInt32Field(0x100),
-                    sensor=UInt8Field(sensor._sensor_type),
+                    sensor=SensorTypeField(sensor._sensor_type),
                 )
             ),
             ArbitrationId(
@@ -297,7 +298,8 @@ async def test_threshold(
         can_message_notifier.notify(
             SensorThresholdResponse(
                 payload=SensorThresholdResponsePayload(
-                    threshold=UInt32Field(0x5), sensor=UInt8Field(sensor._sensor_type)
+                    threshold=UInt32Field(0x5),
+                    sensor=SensorTypeField(sensor._sensor_type),
                 )
             ),
             ArbitrationId(

--- a/hardware/tests/opentrons_hardware/sensors/test_sensor_drivers.py
+++ b/hardware/tests/opentrons_hardware/sensors/test_sensor_drivers.py
@@ -30,8 +30,8 @@ from opentrons_hardware.firmware_bindings.messages.payloads import (
     WriteToSensorRequestPayload,
     ReadFromSensorResponsePayload,
     SensorThresholdResponsePayload,
-    SensorTypeField,
 )
+from opentrons_hardware.firmware_bindings.messages.fields import SensorTypeField
 from opentrons_hardware.sensors.utils import SensorDataType
 
 


### PR DESCRIPTION
# Overview

Use classes with nice `__repr__` implementations for payload fields that wrap an enumeration.  Makes display in log and can_mon more readable.

# Changelog

Add new custom field classes.
Move custom fields out of `payloads.py` and into `fields.py`.

# Review requests

# Risk assessment

None