### PR TITLE
feat(robot-server): add top-level stateless /commands endpoints

### DIFF
--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -151,8 +151,6 @@ class ProtocolEngine:
         Arguments:
             request: The command type and payload data used to construct
                 the command in state.
-            move_on_after: Maximum time in seconds to wait for the command to complete.
-                If None, will potentially wait forever.
 
         Returns:
             The completed command, whether it succeeded or failed.

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -137,16 +137,10 @@ class ProtocolEngine:
 
     async def wait_for_command(self, command_id: str) -> None:
         """Wait for a command to be completed."""
-        is_already_complete = self._state_store.commands.get_is_complete(
-            command_id=command_id
+        await self._state_store.wait_for(
+            self._state_store.commands.get_is_complete,
+            command_id=command_id,
         )
-        # If the command is already complete, don't wait,
-        # because we'd only wake up on a subsequent state update,
-        # and we don't know that there would ever be one.
-        if not is_already_complete:
-            await self._state_store.wait_for(
-                self._state_store.commands.get_is_complete, command_id=command_id
-            )
 
     async def add_and_execute_command(self, request: CommandCreate) -> Command:
         """Add a command to the queue and wait for it to complete.
@@ -157,15 +151,14 @@ class ProtocolEngine:
         Arguments:
             request: The command type and payload data used to construct
                 the command in state.
+            move_on_after: Maximum time in seconds to wait for the command to complete.
+                If None, will potentially wait forever.
 
         Returns:
             The completed command, whether it succeeded or failed.
         """
         command = self.add_command(request)
-        await self._state_store.wait_for(
-            condition=self._state_store.commands.get_is_complete,
-            command_id=command.id,
-        )
+        await self.wait_for_command(command.id)
         return self._state_store.commands.get(command.id)
 
     async def stop(self) -> None:

--- a/robot-server/robot_server/commands/__init__.py
+++ b/robot-server/robot_server/commands/__init__.py
@@ -1,0 +1,4 @@
+"""Module for /commands endpoints and models."""
+from .router import commands_router
+
+__all__ = ["commands_router"]

--- a/robot-server/robot_server/commands/router.py
+++ b/robot-server/robot_server/commands/router.py
@@ -1,0 +1,96 @@
+"""Router for top-level /commands endpoints."""
+from anyio import move_on_after
+from typing_extensions import Final, Literal
+
+from fastapi import APIRouter, Depends, Query, status
+
+from opentrons.protocol_engine import Command, CommandCreate
+
+from robot_server.errors import ErrorDetails, ErrorBody
+from robot_server.runs import EngineStore, EngineConflictError, get_engine_store
+from robot_server.service.json_api import RequestModel, SimpleBody, PydanticResponse
+
+_DEFAULT_COMMAND_WAIT_MS: Final = 30_000
+
+commands_router = APIRouter()
+
+
+class RunActive(ErrorDetails):
+    """An error returned if there is a run active.
+
+    If there is a run active, you cannot issue stateless commands.
+    """
+
+    id: Literal["RunActive"] = "RunActive"
+    title: str = "Run Active"
+    detail: str = (
+        "There is an active run. Close the current run"
+        " to issue commands via POST /commands."
+    )
+
+
+@commands_router.post(
+    path="/commands",
+    summary="Add a command to be executed.",
+    description=(
+        "Run a single command on the robot. This endpoint is meant for"
+        " simple, stateless control of the robot. For complex control,"
+        " create a run with ``POST /runs`` and issue commands on that run."
+    ),
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        status.HTTP_201_CREATED: {"model": SimpleBody[Command]},
+        status.HTTP_409_CONFLICT: {"model": ErrorBody[RunActive]},
+    },
+)
+async def create_command(
+    request_body: RequestModel[CommandCreate],
+    waitUntilComplete: bool = Query(
+        False,
+        description=(
+            "If `false`, return immediately, while the new command is still queued."
+            " If `true`, only return once the new command succeeds or fails,"
+            " or when the timeout is reached. See the `timeout` query parameter."
+        ),
+    ),
+    timeout: int = Query(
+        _DEFAULT_COMMAND_WAIT_MS,
+        gt=0,
+        description=(
+            "If `waitUntilComplete` is true, the maximum time in milliseconds to wait,"
+            " **starting from when the command is queued**, before returning."
+            " If the timeout elapses before the command succeeds or fails,"
+            " the command will be returned with its current status."
+        ),
+    ),
+    engine_store: EngineStore = Depends(get_engine_store),
+) -> PydanticResponse[SimpleBody[Command]]:
+    """Enqueue and execute a command.
+
+    Arguments:
+        request_body: The request containing the command that the client wants
+            to enqueue.
+        waitUntilComplete: If True, return only once the command is completed.
+            Else, return immediately. Comes from a query parameter in the URL.
+        timeout: The maximum time, in seconds, to wait before returning.
+            Comes from a query parameter in the URL.
+        engine_store: Used to retrieve the `ProtocolEngine` on which the new
+            command will be enqueued.
+    """
+    try:
+        engine = await engine_store.get_default_engine()
+    except EngineConflictError as e:
+        raise RunActive().as_error(status.HTTP_409_CONFLICT) from e
+
+    command = engine.add_command(request_body.data)
+
+    if waitUntilComplete:
+        with move_on_after(timeout / 1000.0):
+            await engine.wait_for_command(command.id)
+
+    response_data = engine.state_view.commands.get(command.id)
+
+    return await PydanticResponse.create(
+        content=SimpleBody.construct(data=response_data),
+        status_code=status.HTTP_201_CREATED,
+    )

--- a/robot-server/robot_server/commands/stateless_commands.py
+++ b/robot-server/robot_server/commands/stateless_commands.py
@@ -45,6 +45,3 @@ StatelessCommand = Union[
     commands.heater_shaker.OpenLatch,
     commands.heater_shaker.CloseLatch,
 ]
-
-
-StatelessCommand

--- a/robot-server/robot_server/commands/stateless_commands.py
+++ b/robot-server/robot_server/commands/stateless_commands.py
@@ -1,0 +1,50 @@
+"""Command requests and responses allowed to be used with /commands."""
+from typing import Union
+from opentrons.protocol_engine import commands
+
+StatelessCommandCreate = Union[
+    commands.HomeCreate,
+    commands.SetRailLightsCreate,
+    commands.magnetic_module.EngageCreate,
+    commands.magnetic_module.DisengageCreate,
+    # TODO(mc, 2022-03-18): implement these commands
+    # commands.temperature_module.SetTargetTemperatureCreate,
+    # commands.temperature_module.DeactivateCreate,
+    # commands.thermocycler.SetTargetBlockTemperatureCreate,
+    # commands.thermocycler.SetTargetLidTemperatureCreate,
+    # commands.thermocycler.DeactivateBlockCreate,
+    # commands.thermocycler.DeactivateLidCreate,
+    # commands.thermocycler.OpenLidCreate,
+    # commands.thermocycler.CloseLidCreate,
+    commands.heater_shaker.StartSetTargetTemperatureCreate,
+    commands.heater_shaker.SetTargetShakeSpeedCreate,
+    commands.heater_shaker.DeactivateHeaterCreate,
+    commands.heater_shaker.StopShakeCreate,
+    commands.heater_shaker.OpenLatchCreate,
+    commands.heater_shaker.CloseLatchCreate,
+]
+
+StatelessCommand = Union[
+    commands.Home,
+    commands.SetRailLights,
+    commands.magnetic_module.Engage,
+    commands.magnetic_module.Disengage,
+    # TODO(mc, 2022-03-18): implement these commands
+    # commands.temperature_module.SetTargetTemperature,
+    # commands.temperature_module.Deactivate,
+    # commands.thermocycler.SetTargetBlockTemperature,
+    # commands.thermocycler.SetTargetLidTemperature,
+    # commands.thermocycler.DeactivateBlock,
+    # commands.thermocycler.DeactivateLid,
+    # commands.thermocycler.OpenLid,
+    # commands.thermocycler.CloseLid,
+    commands.heater_shaker.StartSetTargetTemperature,
+    commands.heater_shaker.SetTargetShakeSpeed,
+    commands.heater_shaker.DeactivateHeater,
+    commands.heater_shaker.StopShake,
+    commands.heater_shaker.OpenLatch,
+    commands.heater_shaker.CloseLatch,
+]
+
+
+StatelessCommand

--- a/robot-server/robot_server/router.py
+++ b/robot-server/robot_server/router.py
@@ -6,6 +6,7 @@ from .errors import LegacyErrorResponse
 from .health import health_router
 from .protocols import protocols_router
 from .runs import runs_router
+from .commands import commands_router
 from .system import system_router
 from .versioning import check_version_header
 from .service.legacy.routers import legacy_routes
@@ -48,6 +49,12 @@ router.include_router(
 router.include_router(
     router=protocols_router,
     tags=["Protocol Management"],
+    dependencies=[Depends(check_version_header)],
+)
+
+router.include_router(
+    router=commands_router,
+    tags=["Simple Commands"],
     dependencies=[Depends(check_version_header)],
 )
 

--- a/robot-server/robot_server/runs/__init__.py
+++ b/robot-server/robot_server/runs/__init__.py
@@ -10,7 +10,14 @@ Examples of "runs" include:
   the frame lights on
 """
 from .router import runs_router
+from .engine_store import EngineStore, EngineConflictError
+from .dependencies import get_engine_store
 
 __all__ = [
+    # main export
     "runs_router",
+    # engine store
+    "EngineStore",
+    "EngineConflictError",
+    "get_engine_store",
 ]

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -40,6 +40,7 @@ class EngineStore:
                 construction.
         """
         self._hardware_api = hardware_api
+        self._default_engine: Optional[ProtocolEngine] = None
         self._runner_engine_pair: Optional[RunnerEnginePair] = None
         self._engines_by_run_id: Dict[str, ProtocolEngine] = {}
 
@@ -66,6 +67,18 @@ class EngineStore:
             raise EngineMissingError("Runner not yet created.")
 
         return self._runner_engine_pair.runner
+
+    async def get_default_engine(self) -> ProtocolEngine:
+        if self._runner_engine_pair is not None:
+            raise EngineConflictError("An engine for a run is currently active")
+
+        engine = self._default_engine
+
+        if engine is None:
+            engine = await create_protocol_engine(self._hardware_api)
+            self._default_engine = engine
+
+        return engine
 
     async def create(self, run_id: str) -> StateView:
         """Create and store a ProtocolRunner and ProtocolEngine for a given Run.

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -68,13 +68,21 @@ class EngineStore:
 
         return self._runner_engine_pair.runner
 
+    # TODO(mc, 2022-03-21): this resource locking is insufficient;
+    # come up with something more sophisticated without race condition holes.
     async def get_default_engine(self) -> ProtocolEngine:
+        """Get a "default" ProtocolEngine to use outside the context of a run.
+
+        Raises:
+            EngineConflictError: if a run-specific engine is active.
+        """
         if self._runner_engine_pair is not None:
             raise EngineConflictError("An engine for a run is currently active")
 
         engine = self._default_engine
 
         if engine is None:
+            # TODO(mc, 2022-03-21): potential race condition
             engine = await create_protocol_engine(self._hardware_api)
             self._default_engine = engine
 

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -1,5 +1,5 @@
 """Router for /runs commands endpoints."""
-from asyncio import wait_for, TimeoutError as AsyncioTimeoutError
+from anyio import move_on_after
 from datetime import datetime
 from typing import Optional, Union
 from typing_extensions import Final, Literal
@@ -26,6 +26,7 @@ from .base_router import RunNotFound, RunStopped, get_run_data_from_url
 
 _DEFAULT_COMMANDS_BEFORE: Final = 20
 _DEFAULT_COMMANDS_AFTER: Final = 30
+_DEFAULT_COMMAND_WAIT_MS: Final = 30_000
 
 commands_router = APIRouter()
 
@@ -92,7 +93,7 @@ async def create_run_command(
         ),
     ),
     timeout: int = Query(
-        default=30_000,
+        default=_DEFAULT_COMMAND_WAIT_MS,
         gt=0,
         description=(
             "If `waitUntilComplete` is `true`,"
@@ -134,30 +135,17 @@ async def create_run_command(
             status.HTTP_400_BAD_REQUEST
         )
 
-    added_command = engine_store.engine.add_command(request_body.data)
-
-    command_to_return: pe_commands.Command
+    engine = engine_store.engine
+    command = engine.add_command(request_body.data)
 
     if waitUntilComplete:
-        try:
-            await wait_for(
-                engine_store.engine.wait_for_command(command_id=added_command.id),
-                timeout=timeout / 1000,
-            )
-            completed_command = engine_store.get_state(run.id).commands.get(
-                command_id=added_command.id
-            )
-            command_to_return = completed_command
-        except AsyncioTimeoutError:
-            timed_out_command = engine_store.get_state(run.id).commands.get(
-                command_id=added_command.id
-            )
-            command_to_return = timed_out_command
-    else:
-        command_to_return = added_command
+        with move_on_after(timeout / 1000.0):
+            await engine.wait_for_command(command.id),
+
+    response_data = engine.state_view.commands.get(command.id)
 
     return await PydanticResponse.create(
-        content=SimpleBody.construct(data=command_to_return),
+        content=SimpleBody.construct(data=response_data),
         status_code=status.HTTP_201_CREATED,
     )
 

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -24,8 +24,7 @@ from ..dependencies import get_engine_store
 from .base_router import RunNotFound, RunStopped, get_run_data_from_url
 
 
-_DEFAULT_COMMANDS_BEFORE: Final = 20
-_DEFAULT_COMMANDS_AFTER: Final = 30
+_DEFAULT_COMMAND_LIST_LENGTH: Final = 20
 _DEFAULT_COMMAND_WAIT_MS: Final = 30_000
 
 commands_router = APIRouter()
@@ -169,8 +168,18 @@ async def create_run_command(
 async def get_run_commands(
     engine_store: EngineStore = Depends(get_engine_store),
     run: Run = Depends(get_run_data_from_url),
-    cursor: Optional[int] = None,
-    pageLength: int = _DEFAULT_COMMANDS_BEFORE,
+    cursor: Optional[int] = Query(
+        None,
+        description=(
+            "The starting index of the desired first command in the list."
+            " If unspecicifed, a cursor will be selected automatically"
+            " based on the next queued or more recently executed command."
+        ),
+    ),
+    pageLength: int = Query(
+        _DEFAULT_COMMAND_LIST_LENGTH,
+        description="The maximum number of commands in the list to return.",
+    ),
 ) -> PydanticResponse[MultiBody[RunCommandSummary, CommandCollectionLinks]]:
     """Get a summary of all commands in a run.
 

--- a/robot-server/tests/commands/__init__.py
+++ b/robot-server/tests/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for robot_server.commands."""

--- a/robot-server/tests/commands/test_router.py
+++ b/robot-server/tests/commands/test_router.py
@@ -1,0 +1,140 @@
+"""Tests for robot_server.commands.router."""
+import pytest
+from datetime import datetime
+from decoy import Decoy
+
+from opentrons.protocol_engine import ProtocolEngine, commands as pe_commands
+
+from robot_server.service.json_api import RequestModel
+from robot_server.errors import ApiError
+from robot_server.runs import EngineStore, EngineConflictError
+from robot_server.commands.router import create_command
+
+
+@pytest.fixture()
+def protocol_engine(decoy: Decoy) -> ProtocolEngine:
+    """Get a mocked out ProtocolEngine."""
+    return decoy.mock(cls=ProtocolEngine)
+
+
+@pytest.fixture()
+def engine_store(decoy: Decoy) -> EngineStore:
+    """Get a mocked out EngineStore."""
+    return decoy.mock(cls=EngineStore)
+
+
+async def test_create_command(
+    decoy: Decoy,
+    engine_store: EngineStore,
+    protocol_engine: ProtocolEngine,
+) -> None:
+    """It should be able to create a command."""
+    command_create = pe_commands.HomeCreate(params=pe_commands.HomeParams())
+    queued_command = pe_commands.Home(
+        id="abc123",
+        key="command-key",
+        createdAt=datetime(year=2021, month=1, day=1),
+        status=pe_commands.CommandStatus.QUEUED,
+        params=pe_commands.HomeParams(),
+        result=None,
+    )
+
+    def _stub_queued_command_state(*_a: object, **_k: object) -> pe_commands.Command:
+        decoy.when(protocol_engine.state_view.commands.get("abc123")).then_return(
+            queued_command
+        )
+        return queued_command
+
+    decoy.when(await engine_store.get_default_engine()).then_return(protocol_engine)
+
+    decoy.when(protocol_engine.add_command(command_create)).then_do(
+        _stub_queued_command_state
+    )
+
+    result = await create_command(
+        RequestModel(data=command_create),
+        waitUntilComplete=False,
+        timeout=42,
+        engine_store=engine_store,
+    )
+
+    assert result.content.data == queued_command
+    assert result.status_code == 201
+    decoy.verify(await protocol_engine.wait_for_command("abc123"), times=0)
+
+
+async def test_create_command_wait_for_complete(
+    decoy: Decoy,
+    engine_store: EngineStore,
+    protocol_engine: ProtocolEngine,
+) -> None:
+    """It should be able to create a command."""
+    command_create = pe_commands.HomeCreate(params=pe_commands.HomeParams())
+    queued_command = pe_commands.Home(
+        id="abc123",
+        key="command-key",
+        createdAt=datetime(year=2021, month=1, day=1),
+        status=pe_commands.CommandStatus.QUEUED,
+        params=pe_commands.HomeParams(),
+        result=None,
+    )
+    completed_command = pe_commands.Home(
+        id="abc123",
+        key="command-key",
+        createdAt=datetime(year=2021, month=1, day=1),
+        completedAt=datetime(year=2022, month=2, day=2),
+        status=pe_commands.CommandStatus.SUCCEEDED,
+        params=pe_commands.HomeParams(),
+        result=None,
+    )
+
+    def _stub_queued_command_state(*_a: object, **_k: object) -> pe_commands.Command:
+        decoy.when(protocol_engine.state_view.commands.get("abc123")).then_return(
+            queued_command
+        )
+        return queued_command
+
+    def _stub_completed_command_state(*_a: object, **_k: object) -> None:
+        decoy.when(protocol_engine.state_view.commands.get("abc123")).then_return(
+            completed_command
+        )
+
+    decoy.when(await engine_store.get_default_engine()).then_return(protocol_engine)
+
+    decoy.when(protocol_engine.add_command(command_create)).then_do(
+        _stub_queued_command_state
+    )
+
+    decoy.when(await protocol_engine.wait_for_command("abc123")).then_do(
+        _stub_completed_command_state
+    )
+
+    result = await create_command(
+        RequestModel(data=command_create),
+        waitUntilComplete=True,
+        timeout=42,
+        engine_store=engine_store,
+    )
+
+    assert result.content.data == completed_command
+    assert result.status_code == 201
+
+
+async def test_create_command_conflixt(decoy: Decoy, engine_store: EngineStore) -> None:
+    """It should raise a conflict if there is an active engine in place."""
+    home_create = pe_commands.HomeCreate(params=pe_commands.HomeParams())
+
+    decoy.when(await engine_store.get_default_engine()).then_raise(
+        EngineConflictError("oh no")
+    )
+
+    with pytest.raises(ApiError) as exc_info:
+        await create_command(
+            RequestModel(data=home_create),
+            waitUntilComplete=True,
+            timeout=42,
+            engine_store=engine_store,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.content["errors"][0]["id"] == "RunActive"

--- a/robot-server/tests/runs/test_engine_store.py
+++ b/robot-server/tests/runs/test_engine_store.py
@@ -86,7 +86,7 @@ async def test_clear_engine_not_stopped_or_idle(subject: EngineStore) -> None:
         await subject.clear()
 
 
-async def test_clear_idle_engine(decoy: Decoy, subject: EngineStore) -> None:
+async def test_clear_idle_engine(subject: EngineStore) -> None:
     """It should successfully clear engine if idle (not started)."""
     await subject.create(run_id="run-id")
     assert subject.engine is not None
@@ -99,3 +99,20 @@ async def test_clear_idle_engine(decoy: Decoy, subject: EngineStore) -> None:
         subject.engine
     with pytest.raises(EngineMissingError, match="Runner not yet created."):
         subject.runner
+
+
+async def test_get_default_engine(subject: EngineStore) -> None:
+    """It should create a retrieve a default ProtocolEngine."""
+    result = await subject.get_default_engine()
+    repeated_result = await subject.get_default_engine()
+
+    assert isinstance(result, ProtocolEngine)
+    assert repeated_result is result
+
+
+async def test_get_default_engine_conflict(subject: EngineStore) -> None:
+    """It should not allow a default engine if another engine is active."""
+    await subject.create(run_id="run-id")
+
+    with pytest.raises(EngineConflictError):
+        await subject.get_default_engine()

--- a/robot-server/tests/runs/test_engine_store.py
+++ b/robot-server/tests/runs/test_engine_store.py
@@ -102,7 +102,7 @@ async def test_clear_idle_engine(subject: EngineStore) -> None:
 
 
 async def test_get_default_engine(subject: EngineStore) -> None:
-    """It should create a retrieve a default ProtocolEngine."""
+    """It should create and retrieve a default ProtocolEngine."""
     result = await subject.get_default_engine()
     repeated_result = await subject.get_default_engine()
 


### PR DESCRIPTION
## Overview

This branch adds a top-level `/commands` endpoint for issuing stateless commands to the robot to take out a chunk of #9617. Will take one more PR to deal with module IDs to fully address the issue.

## Changelog

- Add `POST /commands`
- Add `GET /commands`
- Add `GET /commands/:id`

### Cleanup

After discussion with @SyntaxColoring, I took an approach for the "wait until complete" logic that is very similar to the exact logic that is currently implemented. It really just pulls in `anyio` instead of `asyncio` to reduce the code size.

Especially given our plans to beef up end-to-end acceptance testing of these API's, if we're satisfied with the in this PR as written, I'm satisfied to say this closes #9420. 

## Review requests

- [ ] Can create and get stateless commands on a robot or robot server

Easy commands for testing include `home` and `setRailLights`

## Risk assessment

Low, but introduces some tech debt around `EngineStore.get_default_engine` that we'll need to keep an eye on.
