### PR TITLE
chore(app-shell, app): remove dev override of localhost for discovery candidates

### DIFF
--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -40,8 +40,7 @@ electron := electron . \
 	--log.level.console="debug" \
 	--disable_ui.webPreferences.webSecurity \
 	--ui.url.protocol="http:" \
-	--ui.url.path="localhost:$(PORT)" \
-	--discovery.candidates=localhost
+	--ui.url.path="localhost:$(PORT)"
 
 # standard targets
 #####################################################################

--- a/app/README.md
+++ b/app/README.md
@@ -23,6 +23,8 @@ make setup
 make -C app dev
 ```
 
+NOTE: if you would like to interact with a virtual robot-server being served at `localhost`, you will need to manually add `localhost` to the discovery candidates list. This can be done through the app's GUI settings for "Connect to a robot via IP address / Add Manual IP Address"
+
 At this point, the Electron app will be running with [HMR][] and various Chrome devtools enabled. The app and dev server look for the following environment variables (defaults set in Makefile):
 
 | variable             | default      | description                                   |


### PR DESCRIPTION
## Overview

While kicking off work on @koji 's first ticket #8883 , we discovered that the discovery candidates config values were locked by an override in dev mode. In order to make further development on this area of the app's code smooth, we have removed this roadblock.

In order to make development smoother while contributing to code regarding discovery candidates on
the app, remove the app-shell default override which prevented any new values from being appended to
the manual ip list.

# Changelog

- remove `localhost` default cli variable `discovery.candidates` in the app-shell's Makefile
- update the App's README.md to note that `localhost` must be manually added from now on.  

# Review requests

- launch a dev server for the app, navigate to the "Manually add ip address" section of the settings page, and attempt to add multiple hostnames/ip address.  They should all append to the displayed values below/and persist between app sessions.

# Risk assessment
low, only effects dev environment