### PR TITLE
refactor(hardware): add can_control script and fix styling

### DIFF
--- a/hardware/README.md
+++ b/hardware/README.md
@@ -92,3 +92,11 @@ opentrons_update_fw [-h] --interface INTERFACE [--bitrate BITRATE]
 ```
 
 The FILE argument is a `.hex` file built by our ot3-firmware repo.
+
+### opentrons_can_control
+
+A fusion of opentrons_can_mon's colorized prettyprint output monitoring and opentronscan_comm's command generation capability.
+
+#### Usage
+
+The usage is the same as `opentrons_can_comm`.

--- a/hardware/opentrons_hardware/scripts/can_args.py
+++ b/hardware/opentrons_hardware/scripts/can_args.py
@@ -16,7 +16,8 @@ def add_can_args(parser: ArgumentParser) -> ArgumentParser:
     parser.add_argument(
         "--interface",
         type=str,
-        required=True,
+        required=False,
+        default=settings.DEFAULT_INTERFACE,
         help=f"the interface to use (ie: {settings.OPENTRONS_INTERFACE}, "
         f"virtual, pcan, socketcan)",
     )

--- a/hardware/opentrons_hardware/scripts/can_comm.py
+++ b/hardware/opentrons_hardware/scripts/can_comm.py
@@ -109,9 +109,13 @@ def prompt_enum(  # noqa: C901
 
     if not brief_prompt:
         write_choices()
-    user = ''
+    user = ""
     while True:
-        user = get_user_input(f"choose {enum_type.__name__} (? for list): ").lower().strip()
+        user = (
+            get_user_input(f"choose {enum_type.__name__} (? for list): ")
+            .lower()
+            .strip()
+        )
         if not user:
             continue
         if "?" in user:
@@ -120,7 +124,8 @@ def prompt_enum(  # noqa: C901
         try:
             return parse_input(user)
         except InvalidInput as e:
-            output_func(str(e)+'\n')
+            output_func(str(e) + "\n")
+
 
 def prompt_payload(
     payload_type: Type[BinarySerializable], get_user_input: GetInputFunc

--- a/hardware/opentrons_hardware/scripts/can_comm.py
+++ b/hardware/opentrons_hardware/scripts/can_comm.py
@@ -105,7 +105,9 @@ def prompt_enum(
             raise InvalidInput(str(e))
 
     if only_prompt_on_request:
-        user = get_user_input(f"choose {enum_type.__name__} (? for list): ")
+        user = ''
+        while user in ('\n', ''):
+            user = get_user_input(f"choose {enum_type.__name__} (? for list): ")
         if "?" in user:
             write_choices()
             return parse_input(get_user_input("enter choice: "))

--- a/hardware/opentrons_hardware/scripts/can_comm.py
+++ b/hardware/opentrons_hardware/scripts/can_comm.py
@@ -5,7 +5,7 @@ import logging
 import argparse
 from enum import Enum
 from logging.config import dictConfig
-from typing import Type, Sequence, Callable, cast
+from typing import Type, Sequence, Callable, TypeVar
 
 from opentrons_hardware.firmware_bindings.constants import (
     MessageId,
@@ -75,12 +75,15 @@ def create_choices(enum_type: Type[Enum]) -> Sequence[str]:
     return [f"{i}: {v.name}" for (i, v) in enumerate(enum_type)]  # type: ignore[var-annotated]  # noqa: E501
 
 
-def prompt_enum(
-    enum_type: Type[Enum],
+PromptedEnum = TypeVar("PromptedEnum", bound=Enum, covariant=True)
+
+
+def prompt_enum(  # noqa: C901
+    enum_type: Type[PromptedEnum],
     get_user_input: GetInputFunc,
     output_func: OutputFunc,
     brief_prompt: bool = False,
-) -> Type[Enum]:
+) -> PromptedEnum:
     """Prompt to choose a member of the enum.
 
     Args:
@@ -98,7 +101,7 @@ def prompt_enum(
         for row in create_choices(enum_type):
             output_func(f"\t{row}")
 
-    def parse_input(userstr: str) -> Type[Enum]:
+    def parse_input(userstr: str) -> PromptedEnum:
         try:
             return list(enum_type)[int(userstr)]
         except (ValueError, IndexError) as e:
@@ -161,13 +164,11 @@ def prompt_message(
 
     Returns: a CanMessage
     """
-    message_id = prompt_enum(
-        MessageId, get_user_input, output_func, brief_prompt
-    )
+    message_id = prompt_enum(MessageId, get_user_input, output_func, brief_prompt)
     node_id = prompt_enum(NodeId, get_user_input, output_func, brief_prompt)
     # TODO (amit, 2021-10-01): Get function code when the time comes.
     function_code = FunctionCode.network_management
-    message_def = get_definition(cast(MessageId, message_id))
+    message_def = get_definition(message_id)
     if message_def is None:
         raise InvalidInput(f"No message definition found for {message_id}")
     payload = prompt_payload(message_def.payload_type, get_user_input)

--- a/hardware/opentrons_hardware/scripts/can_control.py
+++ b/hardware/opentrons_hardware/scripts/can_control.py
@@ -40,22 +40,28 @@ async def input_task(
 
     def prompt_with_io(promptstr: str) -> str:
         output_file.write(promptstr)
-        return input_file.readline()
+        userinput =  input_file.readline()
+        if userinput.lower().strip() in ['exit', 'quit']:
+            raise SystemExit()
+        return userinput
+
+    def write_with_newline(outstr: str) -> None:
+        output_file.write(outstr + "\n")
 
     async with output_lock:
         can_message = await asyncio.get_event_loop().run_in_executor(
-            None, prompt_message, prompt_with_io, output_file.write
+            None, prompt_message, prompt_with_io, write_with_newline
         )
     await can_driver.send(can_message)
     while True:
         try:
             # Run sync prompt message in threadpool executor.
             can_message = await asyncio.get_event_loop().run_in_executor(
-                None, prompt_message, prompt_with_io, output_file.write
+                None, prompt_message, prompt_with_io, write_with_newline, True
             )
             await can_driver.send(can_message)
         except InvalidInput as e:
-            output_file.write(str(e))
+            output_file.write(str(e) + '\n')
 
 
 async def run(args: argparse.Namespace) -> None:

--- a/hardware/opentrons_hardware/scripts/can_control.py
+++ b/hardware/opentrons_hardware/scripts/can_control.py
@@ -65,15 +65,13 @@ async def run(args: argparse.Namespace) -> None:
     messenger = CanMessenger(driver)
     messenger.start()
     write_lock = asyncio.Lock()
-    loop = asyncio.get_event_loop()
 
     try:
-        all_fut = loop.create_task(
-            asyncio.gather(
+        all_fut = asyncio.gather(
                 monitor_task(messenger, args.output, write_lock),
                 input_task(driver, args.input, args.output, write_lock),
             )
-        )
+        await all_fut
     except KeyboardInterrupt:
         all_fut.cancel()
     except asyncio.CancelledError:

--- a/hardware/opentrons_hardware/scripts/can_control.py
+++ b/hardware/opentrons_hardware/scripts/can_control.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Fused read and write for canbus messages.
+
+Uses the styled output of can_mon while allowing message prompts as can_comm.
+
+Enter ? to get the can_comm prompts.
+"""
+import asyncio
+import logging
+import argparse
+from logging.config import dictConfig
+from typing import TextIO
+
+from opentrons_hardware.drivers.can_bus.abstract_driver import AbstractCanDriver
+from opentrons_hardware.drivers.can_bus.can_messenger import (
+    CanMessenger,
+)
+
+from opentrons_hardware.drivers.can_bus.build import build_driver
+from opentrons_hardware.scripts.can_args import add_can_args, build_settings
+
+from .can_mon import task as monitor_task
+from .can_comm import prompt_message, InvalidInput
+
+
+async def input_task(
+    can_driver: AbstractCanDriver,
+    input_file: TextIO,
+    output_file: TextIO,
+    output_lock: asyncio.Lock,
+) -> None:
+    """UI task to create and send messages.
+
+    Args:
+        can_driver: Can driver
+        input_file: IO buf to read from
+        output_file: IO buf to write to
+        output_lock: Async lock for exclusive writes
+    """
+
+    def prompt_with_io(promptstr: str) -> str:
+        output_file.write(promptstr)
+        return input_file.readline()
+
+    async with output_lock:
+        can_message = await asyncio.get_event_loop().run_in_executor(
+            None, prompt_message, prompt_with_io, output_file.write
+        )
+    await can_driver.send(can_message)
+    while True:
+        try:
+            # Run sync prompt message in threadpool executor.
+            can_message = await asyncio.get_event_loop().run_in_executor(
+                None, prompt_message, prompt_with_io, output_file.write
+            )
+            await can_driver.send(can_message)
+        except InvalidInput as e:
+            output_file.write(str(e))
+
+
+async def run(args: argparse.Namespace) -> None:
+    """Entry point for script."""
+    driver = await build_driver(build_settings(args))
+
+    messenger = CanMessenger(driver)
+    messenger.start()
+    write_lock = asyncio.Lock()
+    loop = asyncio.get_event_loop()
+
+    try:
+        all_fut = loop.create_task(
+            asyncio.gather(
+                monitor_task(messenger, args.output, write_lock),
+                input_task(driver, args.input, args.output, write_lock),
+            )
+        )
+    except KeyboardInterrupt:
+        all_fut.cancel()
+    except asyncio.CancelledError:
+        pass
+    finally:
+        await messenger.stop()
+        driver.shutdown()
+
+
+LOG_CONFIG = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "basic": {"format": "%(asctime)s %(name)s %(levelname)s %(message)s"}
+    },
+    "handlers": {
+        "file_handler": {
+            "class": "logging.handlers.RotatingFileHandler",
+            "formatter": "basic",
+            "filename": "can_mon.log",
+            "maxBytes": 5000000,
+            "level": logging.WARNING,
+            "backupCount": 3,
+        },
+    },
+    "loggers": {
+        "": {
+            "handlers": ["file_handler"],
+            "level": logging.WARNING,
+        },
+    },
+}
+
+
+def main() -> None:
+    """Entry point."""
+    dictConfig(LOG_CONFIG)
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Where to write monitored canbus output to",
+        type=argparse.FileType("w"),
+        default="-",
+    )
+    parser.add_argument(
+        "-i",
+        "--input",
+        help="Where to listen for canbus input",
+        type=argparse.FileType("r"),
+        default="-",
+    )
+    add_can_args(parser)
+
+    args = parser.parse_args()
+
+    asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/hardware/opentrons_hardware/scripts/can_control.py
+++ b/hardware/opentrons_hardware/scripts/can_control.py
@@ -23,17 +23,20 @@ from opentrons_hardware.scripts.can_args import add_can_args, build_settings
 from .can_mon import task as monitor_task
 from .can_comm import prompt_message, InvalidInput
 
+
 async def get_input(
-        input_file: TextIO,
-        output_file: TextIO,
-        output_lock: asyncio.Lock,
-        brief_prompt: bool = True
+    input_file: TextIO,
+    output_file: TextIO,
+    output_lock: asyncio.Lock,
+    brief_prompt: bool = True,
 ) -> Optional[CanMessage]:
+    """Get user input with proper locking and buffering."""
+
     def prompt_with_io(promptstr: str) -> str:
         output_file.write(promptstr)
         output_file.flush()
         userinput = input_file.readline()
-        if userinput.lower().strip() in ['exit', 'quit']:
+        if userinput.lower().strip() in ["exit", "quit"]:
             raise SystemExit()
         return userinput
 
@@ -65,7 +68,6 @@ async def input_task(
         output_file: IO buf to write to
         output_lock: Async lock for exclusive writes
     """
-
     can_message = await get_input(input_file, output_file, output_lock, False)
     if can_message:
         await can_driver.send(can_message)
@@ -85,9 +87,9 @@ async def run(args: argparse.Namespace) -> None:
 
     try:
         all_fut = asyncio.gather(
-                monitor_task(messenger, args.output, write_lock),
-                input_task(driver, args.input, args.output, write_lock),
-            )
+            monitor_task(messenger, args.output, write_lock),
+            input_task(driver, args.input, args.output, write_lock),
+        )
         await all_fut
     except KeyboardInterrupt:
         all_fut.cancel()
@@ -149,7 +151,7 @@ def main() -> None:
     try:
         asyncio.run(run(args))
     except KeyboardInterrupt:
-        args.output.write('Quitting...\n')
+        args.output.write("Quitting...\n")
         args.output.flush()
 
 

--- a/hardware/opentrons_hardware/scripts/can_mon.py
+++ b/hardware/opentrons_hardware/scripts/can_mon.py
@@ -3,8 +3,12 @@ import asyncio
 import dataclasses
 import logging
 import argparse
+import atexit
+import sys
 from datetime import datetime
 from logging.config import dictConfig
+from typing import List, Optional, TextIO
+
 
 from opentrons_hardware.drivers.can_bus.can_messenger import (
     CanMessenger,
@@ -21,29 +25,94 @@ from opentrons_hardware.scripts.can_args import add_can_args, build_settings
 log = logging.getLogger(__name__)
 
 
-async def task(messenger: CanMessenger) -> None:
+@dataclasses.dataclass
+class StyledOutput:
+    """Dataclass bundling style and content for terminal output."""
+
+    style: str
+    content: str
+
+
+class Writer:
+    """Class that knows where to write and how to safely style output."""
+
+    RESET_STYLE = "\033[0m"
+
+    def __init__(self, destination: TextIO) -> None:
+        """Build a writer with a destination.
+
+        Args:
+            destination: A TextIO to write to. If this is a canonical output
+                         fd (e.g. stdout, stderr) styled output will be used;
+                         otherwise (for instance, if destination is a pipe)
+                         there will be no output styling.
+        """
+        self._dest = destination
+        self._do_style = self._dest in (sys.stdout, sys.stderr)
+        if self._do_style:
+            atexit.register(self._reset_shell_style)
+
+    def write(self, output: List[StyledOutput]) -> None:
+        """Write styled output to the destination.
+
+        Elements are joined with spaces and the styling is reset after all prints.
+        """
+        for elem in output:
+            if self._do_style:
+                self._dest.write(elem.style)
+            self._dest.write(elem.content)
+            if self._do_style:
+                self._dest.write(self.RESET_STYLE)
+            self._dest.write(" ")
+
+    def _reset_shell_style(self) -> None:
+        self._dest.write(self.RESET_STYLE)
+
+
+async def task(
+    messenger: CanMessenger,
+    write_to: TextIO,
+    write_lock: Optional[asyncio.Lock] = None,
+) -> None:
     """A task that listens for can messages.
 
     Args:
         messenger: Messenger
+        write_to: Destination to write to
+        write_lock: Optionally, a lock for exclusive writes.
 
     Returns: Nothing.
     """
+    writer = Writer(write_to)
     label_style = "\033[0;37;40m"
     header_style = "\033[0;36;40m"
     data_style = "\033[1;36;40m"
+
+    checked_write_lock = write_lock or asyncio.Lock()
+
     with WaitableCallback(messenger) as cb:
         async for message, arbitration_id in cb:
             try:
                 msg_name = MessageId(arbitration_id.parts.message_id).name
                 from_node = NodeId(arbitration_id.parts.originating_node_id).name
                 to_node = NodeId(arbitration_id.parts.node_id).name
-                arb_id_str = f"{data_style}{msg_name} ({from_node}->{to_node})"
+                arb_id_str = f"{msg_name} ({from_node}->{to_node})"
             except ValueError:
-                arb_id_str = f"{data_style}0x{arbitration_id.id:x}"
-            print(f"{header_style}{datetime.now()} {arb_id_str}")
-            for name, value in dataclasses.asdict(message.payload).items():
-                print(f"\t{label_style}{name}: {data_style}{value}")
+                arb_id_str = f"0x{arbitration_id.id:x}"
+            async with checked_write_lock:
+                writer.write(
+                    [
+                        StyledOutput(style=header_style, content=str(datetime.now())),
+                        StyledOutput(style=data_style, content=arb_id_str + "\n"),
+                    ]
+                )
+                for name, value in dataclasses.asdict(message.payload).items():
+                    writer.write(
+                        [
+                            StyledOutput(style=label_style, content=f"\t{name}:"),
+                            StyledOutput(style=data_style, content=str(value)),
+                        ]
+                    )
 
 
 async def run(args: argparse.Namespace) -> None:
@@ -54,7 +123,7 @@ async def run(args: argparse.Namespace) -> None:
     messenger.start()
 
     loop = asyncio.get_event_loop()
-    fut = loop.create_task(task(messenger))
+    fut = loop.create_task(task(messenger, args.output))
     try:
         await fut
     except KeyboardInterrupt:
@@ -78,14 +147,14 @@ LOG_CONFIG = {
             "formatter": "basic",
             "filename": "can_mon.log",
             "maxBytes": 5000000,
-            "level": logging.INFO,
+            "level": logging.WARNING,
             "backupCount": 3,
         },
     },
     "loggers": {
         "": {
             "handlers": ["file_handler"],
-            "level": logging.INFO,
+            "level": logging.WARNING,
         },
     },
 }
@@ -96,6 +165,13 @@ def main() -> None:
     dictConfig(LOG_CONFIG)
 
     parser = argparse.ArgumentParser(description="CAN bus monitoring.")
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Where to write monitored canbus output to",
+        type=argparse.FileType("w"),
+        default="-",
+    )
     add_can_args(parser)
 
     args = parser.parse_args()

--- a/hardware/opentrons_hardware/scripts/can_mon.py
+++ b/hardware/opentrons_hardware/scripts/can_mon.py
@@ -64,9 +64,11 @@ class Writer:
             if self._do_style:
                 self._dest.write(self.RESET_STYLE)
             self._dest.write(" ")
+        self._dest.flush()
 
     def _reset_shell_style(self) -> None:
         self._dest.write(self.RESET_STYLE)
+        self._dest.flush()
 
 
 async def task(

--- a/hardware/opentrons_hardware/scripts/can_mon.py
+++ b/hardware/opentrons_hardware/scripts/can_mon.py
@@ -110,7 +110,7 @@ async def task(
                     writer.write(
                         [
                             StyledOutput(style=label_style, content=f"\t{name}:"),
-                            StyledOutput(style=data_style, content=str(value)),
+                            StyledOutput(style=data_style, content=str(value) + "\n"),
                         ]
                     )
 

--- a/hardware/setup.py
+++ b/hardware/setup.py
@@ -85,6 +85,7 @@ if __name__ == "__main__":
                 "opentrons_can_comm = opentrons_hardware.scripts.can_comm:main",
                 "opentrons_can_mon = opentrons_hardware.scripts.can_mon:main",
                 "opentrons_sim_can_bus = opentrons_hardware.scripts.sim_socket_can:main",  # noqa: E501
+                "opentrons_can_control = opentrons_hardware.scripts.can_control:main"
             ]
         },
     )

--- a/hardware/setup.py
+++ b/hardware/setup.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
                 "opentrons_can_comm = opentrons_hardware.scripts.can_comm:main",
                 "opentrons_can_mon = opentrons_hardware.scripts.can_mon:main",
                 "opentrons_sim_can_bus = opentrons_hardware.scripts.sim_socket_can:main",  # noqa: E501
-                "opentrons_can_control = opentrons_hardware.scripts.can_control:main"
+                "opentrons_can_control = opentrons_hardware.scripts.can_control:main",
             ]
         },
     )

--- a/hardware/tests/test_scripts/test_can_comm.py
+++ b/hardware/tests/test_scripts/test_can_comm.py
@@ -79,18 +79,19 @@ def test_prompt_message_with_payload(
     argnames=["user_input"],
     argvalues=[
         # Not a number
-        [["b"]],
+        [["b", "2"]],
         # Out of range
-        [["1000000000"]],
+        [["1000000000", "2"]],
     ],
 )
 def test_prompt_enum_bad_input(
     user_input: List[str], mock_get_input: MagicMock, mock_output: MagicMock
 ) -> None:
-    """It should raise on bad input."""
+    """It should not raise on bad input but wait until input is good."""
     mock_get_input.side_effect = user_input
-    with pytest.raises(can_comm.InvalidInput):
-        can_comm.prompt_enum(MessageId, mock_get_input, mock_output)
+    parsed_id = can_comm.prompt_enum(MessageId, mock_get_input, mock_output)
+    assert mock_get_input.call_count == 2
+    assert parsed_id == MessageId.device_info_request
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Some general refactors for can scripts, including
- Making can_mon a little less likely to leave all your terminal text blue forever
- Adding can_control which fuses can_mon and can_comm

## TODO
- [x] Test on a robot
- [x] Test on an emulator setup