### PR TITLE
refactor(api): move noqa comments to correct lines according to flake8

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -149,8 +149,8 @@ class API(
     def _reset_last_mount(self) -> None:
         self._last_moved_mount = None
 
-    @classmethod  # noqa: C901
-    async def build_hardware_controller(
+    @classmethod
+    async def build_hardware_controller(  # noqa: C901
         cls,
         config: Union[RobotConfig, OT3Config, None] = None,
         port: Optional[str] = None,

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -128,8 +128,8 @@ class InstrumentContext(CommandPublisher):
     def default_speed(self, speed: float) -> None:
         self._implementation.set_default_speed(speed)
 
-    @requires_version(2, 0)  # noqa: C901
-    def aspirate(
+    @requires_version(2, 0)
+    def aspirate(  # noqa: C901
         self,
         volume: Optional[float] = None,
         location: Optional[Union[types.Location, Well]] = None,
@@ -946,9 +946,9 @@ class InstrumentContext(CommandPublisher):
 
         return self.transfer(volume, source, dest, **kwargs)
 
-    @publish(command=cmds.transfer)  # noqa: C901
+    @publish(command=cmds.transfer)
     @requires_version(2, 0)
-    def transfer(
+    def transfer(  # noqa: C901
         self,
         volume: Union[float, Sequence[float]],
         source: AdvancedLiquidHandling,


### PR DESCRIPTION
# Overview

Something in one of the previous PRs exposed a linter error in api caused by `noqa` tags being added to a function decorator instead of the function itself. This started causing flake8 errors. This PR fixes those flake8 errors.

# Review requests

- I don't know if something (like a flake8 setting) accidentally changed in edge recently because these files don't seem to have changed. If so, do we want to keep that accidental change? Just want to make sure I'm not just patching a bug caused by some other underlying problem. 
- Also, not sure how CI has been passing all this time when I've been getting linter errors on my computer (@SyntaxColoring is also seeing this error)

# Risk assessment

None if CI passes?
