### PR TITLE
refactor(api): ot3: tolerate unimplemented axes

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -495,7 +495,11 @@ class OT3Controller:
         self._present_nodes = present
 
     def _axis_is_present(self, axis: OT3Axis) -> bool:
-        return axis_to_node(axis) in self._present_nodes
+        try:
+            return axis_to_node(axis) in self._present_nodes
+        except KeyError:
+            # Currently unhandled axis
+            return False
 
     def _axis_map_to_present_nodes(
         self, to_xform: OT3AxisMap[MapPayload]

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -271,13 +271,13 @@ class OT3Controller:
             A map of mount to pipette name.
         """
         if (
-            expected.get(OT3Mount.LEFT)
-            and expected.get(OT3Mount.LEFT) != _FIXED_PIPETTE_NAME
+            expected.get(OT3Mount.RIGHT)
+            and expected.get(OT3Mount.RIGHT) != _FIXED_PIPETTE_NAME
         ):
             raise RuntimeError(f"only support {_FIXED_PIPETTE_NAME}  right now")
 
         return {
-            OT3Mount.LEFT: {
+            OT3Mount.RIGHT: {
                 "config": pipette_config.load(_FIXED_PIPETTE_MODEL, _FIXED_PIPETTE_ID),
                 "id": _FIXED_PIPETTE_ID,
             }

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -239,11 +239,13 @@ class OT3Controller:
         runner = MoveGroupRunner(move_groups=[group])
         await runner.run(can_messenger=self._messenger)
 
-        for ax in checked_axes:
-            self._position[axis_to_node(ax)] = 0
-        axis_positions = {ax: 0.0 for ax in checked_axes}
+        axis_positions = {
+            axis_to_node(ax): self._get_home_position()[axis_to_node(ax)]
+            for ax in checked_axes
+        }
+        self._position.update(axis_positions)
 
-        return axis_positions
+        return axis_convert(self._position, 0.0)
 
     async def fast_home(
         self, axes: Sequence[OT3Axis], margin: float

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -94,7 +94,7 @@ async def test_home(
 
 async def test_home_only_present_nodes(controller: OT3Controller, mock_move_group_run):
     controller._present_nodes = set((NodeId.gantry_x, NodeId.gantry_y))
-    await controller.home([OT3Axis.X, OT3Axis.Z_L])
+    await controller.home([OT3Axis.X, OT3Axis.Z_L, OT3Axis.Q])
     home_move = (mock_move_group_run.call_args_list[0][0][0]._move_groups)[0][0]
     assert list(home_move.keys()) == [NodeId.gantry_x]
 

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -121,7 +121,7 @@ async def test_probing(controller: OT3Controller) -> None:
                 NodeId.gantry_x,
                 NodeId.gantry_y,
                 NodeId.head,
-                NodeId.pipette_left,
+                NodeId.pipette_right,
             )
         )
     assert controller._present_nodes == set(


### PR DESCRIPTION
Handle a couple edge cases in the current OT3 support:
- Some OT3 axes are not yet implemented but we still want to carve out space; handle commands that specify them
- Return full position dumps after home

This PR used to have a lot of other stuff that got sent to different PRs:

- ~use ot3 simulator on ot3~ #9723 
- ~Filter more commands to only send messages to attached node ids~ #9728
- ~Correct the home positions for gen3 pipettes~ #9727 
- ~Correctly set currents during e.g. pick up tip and drop tip~ #9726 
- ~Fix a message field ordering problem that broke motion~ #9724 
- mostly do-nothing pr to change hardcoded pipette assignments
- ~some motion settings updates~ #9729 
