### PR TITLE
refactor(protocol-engine): Implement `get_all_complete()`

### DIFF
--- a/api/src/opentrons/ordered_set.py
+++ b/api/src/opentrons/ordered_set.py
@@ -1,0 +1,68 @@
+"""A set that preserves the order in which elements are added."""
+
+
+from typing import Dict, Generic, Hashable, Iterable, Iterator, TypeVar
+from typing_extensions import Literal
+
+
+_SetElementT = TypeVar("_SetElementT", bound=Hashable)
+
+
+# Implemented as a standalone class for clarity.
+# If this proves insufficient, we can get many methods for free
+# by subclassing collections.abc.MutableSet.
+class OrderedSet(Generic[_SetElementT]):
+    """A set that preserves the order in which elements are added."""
+
+    def __init__(self, source_iterable: Iterable[_SetElementT] = tuple()) -> None:
+        """Inititalize the set.
+
+        Args:
+            source_iterable: An iterable with elements to initialize the set with,
+                in order.
+        """
+        self._elements: Dict[_SetElementT, Literal[True]] = {}
+        for element in source_iterable:
+            self.add(element)
+
+    def add(self, element: _SetElementT) -> None:
+        """Add ``element`` to the set.
+
+        If ``element`` is already in the set, it is not added again,
+        and its existing position in the set is retained.
+        """
+        self._elements[element] = True
+
+    def remove(self, element: _SetElementT) -> None:
+        """Remove ``element`` from the set.
+
+        Raises:
+            KeyError: If ``element`` is not in the set.
+        """
+        del self._elements[element]
+
+    def clear(self) -> None:
+        """Remove all elements from the set."""
+        self._elements.clear()
+
+    def __iter__(self) -> Iterator[_SetElementT]:
+        """Enable iteration over all elements in the set.
+
+        Elements are returned in the order they were added, oldest first.
+        """
+        return iter(self._elements)
+
+    def __len__(self) -> int:
+        """Return the number of unique elements added to the set."""
+        return len(self._elements)
+
+    def __eq__(self, other: object) -> bool:
+        """Return whether this set is equal to another object.
+
+        True if the other object is also an ordered set,
+        and it contains the same elements in the same order.
+        """
+        if isinstance(other, OrderedSet):
+            return list(self) == list(other)
+        else:
+            return False

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -181,7 +181,6 @@ class ProtocolEngine:
         self._queue_worker.cancel()
         await self._hardware_stopper.do_halt()
 
-    # TODO(mc, 2021-12-27): commands.get_all_complete not yet implemented
     async def wait_until_complete(self) -> None:
         """Wait until there are no more commands to execute.
 

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -89,34 +89,38 @@ class CommandEntry:
 
 @dataclass
 class CommandState:
-    """State of all protocol engine command resources.
+    """State of all protocol engine command resources."""
 
-    Attributes:
-        queue_status: Whether the engine is currently pulling new
-            commands off the queue to execute. A command may still be
-            executing, and the robot may still be in motion, even if INACTIVE.
-        is_hardware_stopped: Whether the engine's hardware has ceased
-            motion. Once set, this flag cannot be unset.
-        is_door_blocking: Whether the door is open when
-            enable_door_safety_switch feature flag is ON.
-        run_result: Whether the run is done and succeeded, failed, or stopped.
-            Once set, this status cannot be unset.
-        running_command_id: The ID of the currently running command, if any.
-        queued_command_ids: The IDs of queued commands in FIFO order.
-        commands_by_id: All command resources, in insertion order, mapped
-            by their unique IDs.
-        errors_by_id: All error occurrences, mapped by their unique IDs.
-    """
-
+    # All command IDs, in insertion order.
     all_command_ids: List[str]
-    commands_by_id: Dict[str, CommandEntry]
-    running_command_id: Optional[str]
+
+    # The IDs of queued commands, in FIFO order.
     queued_command_ids: OrderedSet[str]
 
+    # The ID of the currently running command, if any.
+    running_command_id: Optional[str]
+
+    # All command resources, in insertion order, mapped by their unique IDs.
+    commands_by_id: Dict[str, CommandEntry]
+
+    # Whether the engine is currently pulling new commands off the queue to execute.
+    # A command may still be executing, and the robot may still be in motion,
+    # even if INACTIVE.
     queue_status: QueueStatus
+
+    # Whether the engine's hardware has ceased motion.
+    # Once set, this flag cannot be unset.
     is_hardware_stopped: bool
+
+    # Whether the door is open when enable_door_safety_switch
+    # feature flag is ON.
     is_door_blocking: bool
+
+    # Whether the run is done and succeeded, failed, or stopped.
+    # Once set, this status cannot be unset.
     run_result: Optional[RunResult]
+
+    # All error occurrences, mapped by their unique IDs.
     errors_by_id: Dict[str, ErrorOccurrence]
 
 

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -438,17 +438,17 @@ class CommandView(HasState[CommandState]):
 
         return status == CommandStatus.SUCCEEDED or status == CommandStatus.FAILED
 
-    # TODO(mc, 2021-12-28): the method needs to be re-implemented prior to PAPIv3 prod
-    # Implementation should take care to remain O(1)
     def get_all_complete(self) -> bool:
-        """Get whether all commands have completed.
+        """Get whether all added commands have completed.
 
-        All commands have "completed" if one of the following is true:
-
-        - The hardware has been stopped
-        - There are no queued nor running commands
+        See `get_is_complete()` for what counts as "completed."
         """
-        raise NotImplementedError("CommandView.get_all_complete not yet implemented")
+        # Since every command is either queued, running, failed, or succeeded,
+        # "none running and none queued" == "all succeeded or failed".
+        return (
+            self._state.running_command_id is None
+            and len(self._state.queued_command_ids) == 0
+        )
 
     def get_stop_requested(self) -> bool:
         """Get whether an engine stop has been requested.

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -5,7 +5,8 @@ from enum import Enum
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, List, Mapping, Optional
-from typing_extensions import Literal
+
+from opentrons.ordered_set import OrderedSet
 
 from opentrons.hardware_control.types import DoorStateNotification, DoorState
 
@@ -102,20 +103,20 @@ class CommandState:
             Once set, this status cannot be unset.
         running_command_id: The ID of the currently running command, if any.
         queued_command_ids: The IDs of queued commands in FIFO order.
-            Implemented as an OrderedDict to behave like an ordered set.
         commands_by_id: All command resources, in insertion order, mapped
             by their unique IDs.
         errors_by_id: All error occurrences, mapped by their unique IDs.
     """
 
+    all_command_ids: List[str]
+    commands_by_id: Dict[str, CommandEntry]
+    running_command_id: Optional[str]
+    queued_command_ids: OrderedSet[str]
+
     queue_status: QueueStatus
     is_hardware_stopped: bool
     is_door_blocking: bool
     run_result: Optional[RunResult]
-    running_command_id: Optional[str]
-    all_command_ids: List[str]
-    queued_command_ids: OrderedDict[str, Literal[True]]
-    commands_by_id: Dict[str, CommandEntry]
     errors_by_id: Dict[str, ErrorOccurrence]
 
 
@@ -133,7 +134,7 @@ class CommandStore(HasState[CommandState], HandlesActions):
             run_result=None,
             running_command_id=None,
             all_command_ids=[],
-            queued_command_ids=OrderedDict(),
+            queued_command_ids=OrderedSet(),
             commands_by_id=OrderedDict(),
             errors_by_id={},
         )
@@ -159,7 +160,7 @@ class CommandStore(HasState[CommandState], HandlesActions):
 
             next_index = len(self._state.all_command_ids)
             self._state.all_command_ids.append(action.command_id)
-            self._state.queued_command_ids[queued_command.id] = True
+            self._state.queued_command_ids.add(queued_command.id)
             self._state.commands_by_id[queued_command.id] = CommandEntry(
                 index=next_index,
                 command=queued_command,
@@ -185,7 +186,10 @@ class CommandStore(HasState[CommandState], HandlesActions):
                     command=command,
                 )
 
-            self._state.queued_command_ids.pop(command.id, None)
+            try:
+                self._state.queued_command_ids.remove(command.id)
+            except KeyError:
+                pass
 
             if command.status == CommandStatus.RUNNING:
                 self._state.running_command_id = command.id
@@ -202,7 +206,7 @@ class CommandStore(HasState[CommandState], HandlesActions):
 
             command_ids_to_fail = [
                 action.command_id,
-                *[i for i in self._state.queued_command_ids.keys()],
+                *[i for i in self._state.queued_command_ids],
             ]
 
             for command_id in command_ids_to_fail:
@@ -390,7 +394,7 @@ class CommandView(HasState[CommandState]):
         if self._state.queue_status == QueueStatus.INACTIVE:
             return None
 
-        return next(iter(self._state.queued_command_ids.keys()), None)
+        return next(iter(self._state.queued_command_ids), None)
 
     def get_is_okay_to_clear(self) -> bool:
         """Get whether the engine is stopped or unplayed so it could be removed."""

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -91,37 +91,42 @@ class CommandEntry:
 class CommandState:
     """State of all protocol engine command resources."""
 
-    # All command IDs, in insertion order.
     all_command_ids: List[str]
+    """All command IDs, in insertion order."""
 
-    # The IDs of queued commands, in FIFO order.
     queued_command_ids: OrderedSet[str]
+    """The IDs of queued commands, in FIFO order"""
 
-    # The ID of the currently running command, if any.
     running_command_id: Optional[str]
+    """The ID of the currently running command, if any"""
 
-    # All command resources, in insertion order, mapped by their unique IDs.
     commands_by_id: Dict[str, CommandEntry]
+    """All command resources, in insertion order, mapped by their unique IDs."""
 
-    # Whether the engine is currently pulling new commands off the queue to execute.
-    # A command may still be executing, and the robot may still be in motion,
-    # even if INACTIVE.
     queue_status: QueueStatus
+    """Whether the engine is currently pulling new commands off the queue to execute.
 
-    # Whether the engine's hardware has ceased motion.
-    # Once set, this flag cannot be unset.
+    A command may still be executing, and the robot may still be in motion,
+    even if INACTIVE.
+    """
+
     is_hardware_stopped: bool
+    """Whether the engine's hardware has ceased motion.
 
-    # Whether the door is open when enable_door_safety_switch
-    # feature flag is ON.
+    Once set, this flag cannot be unset.
+    """
+
     is_door_blocking: bool
+    """Whether the door is open when enable_door_safety_switch feature flag is ON."""
 
-    # Whether the run is done and succeeded, failed, or stopped.
-    # Once set, this status cannot be unset.
     run_result: Optional[RunResult]
+    """Whether the run is done and succeeded, failed, or stopped.
 
-    # All error occurrences, mapped by their unique IDs.
+    Once set, this status cannot be unset.
+    """
+
     errors_by_id: Dict[str, ErrorOccurrence]
+    """All error occurrences, mapped by their unique IDs."""
 
 
 class CommandStore(HasState[CommandState], HandlesActions):

--- a/api/tests/opentrons/protocol_engine/state/test_command_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_store.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from datetime import datetime
 from typing import NamedTuple, Type
 
+from opentrons.ordered_set import OrderedSet
 from opentrons.types import MountType, DeckSlotName
 from opentrons.hardware_control.types import DoorStateNotification, DoorState
 
@@ -50,7 +51,7 @@ def test_initial_state() -> None:
         is_door_blocking=False,
         run_result=None,
         running_command_id=None,
-        queued_command_ids=OrderedDict(),
+        queued_command_ids=OrderedSet(),
         all_command_ids=[],
         commands_by_id=OrderedDict(),
         errors_by_id={},
@@ -181,7 +182,7 @@ def test_command_store_queues_commands(
         "command-id": CommandEntry(index=0, command=expected_command),
     }
     assert subject.state.all_command_ids == ["command-id"]
-    assert subject.state.queued_command_ids == OrderedDict({"command-id": True})
+    assert subject.state.queued_command_ids == OrderedSet(["command-id"])
 
 
 def test_command_queue_and_unqueue() -> None:
@@ -208,18 +209,18 @@ def test_command_queue_and_unqueue() -> None:
     subject = CommandStore()
 
     subject.handle_action(queue_1)
-    assert subject.state.queued_command_ids == OrderedDict([("command-id-1", True)])
+    assert subject.state.queued_command_ids == OrderedSet(["command-id-1"])
 
     subject.handle_action(queue_2)
-    assert subject.state.queued_command_ids == OrderedDict(
-        [("command-id-1", True), ("command-id-2", True)]
+    assert subject.state.queued_command_ids == OrderedSet(
+        ["command-id-1", "command-id-2"]
     )
 
     subject.handle_action(update_2)
-    assert subject.state.queued_command_ids == OrderedDict([("command-id-1", True)])
+    assert subject.state.queued_command_ids == OrderedSet(["command-id-1"])
 
     subject.handle_action(update_1)
-    assert subject.state.queued_command_ids == OrderedDict([])
+    assert subject.state.queued_command_ids == OrderedSet()
 
 
 def test_running_command_id() -> None:
@@ -328,7 +329,7 @@ def test_command_failure_clears_queue() -> None:
     subject.handle_action(fail_1)
 
     assert subject.state.running_command_id is None
-    assert subject.state.queued_command_ids == OrderedDict([])
+    assert subject.state.queued_command_ids == OrderedSet()
     assert subject.state.all_command_ids == ["command-id-1", "command-id-2"]
     assert subject.state.commands_by_id == {
         "command-id-1": CommandEntry(index=0, command=expected_failed_1),
@@ -379,7 +380,7 @@ def test_command_store_handles_pause_action(pause_source: PauseSource) -> None:
         is_door_blocking=False,
         running_command_id=None,
         all_command_ids=[],
-        queued_command_ids=OrderedDict(),
+        queued_command_ids=OrderedSet(),
         commands_by_id=OrderedDict(),
         errors_by_id={},
     )
@@ -399,7 +400,7 @@ def test_command_store_handles_play_action(pause_source: PauseSource) -> None:
         is_door_blocking=False,
         running_command_id=None,
         all_command_ids=[],
-        queued_command_ids=OrderedDict(),
+        queued_command_ids=OrderedSet(),
         commands_by_id=OrderedDict(),
         errors_by_id={},
     )
@@ -416,7 +417,7 @@ def test_command_store_handles_play_according_to_door_state() -> None:
         is_door_blocking=True,
         running_command_id=None,
         all_command_ids=[],
-        queued_command_ids=OrderedDict(),
+        queued_command_ids=OrderedSet(),
         commands_by_id=OrderedDict(),
         errors_by_id={},
     )
@@ -432,7 +433,7 @@ def test_command_store_handles_play_according_to_door_state() -> None:
         is_door_blocking=False,
         running_command_id=None,
         all_command_ids=[],
-        queued_command_ids=OrderedDict(),
+        queued_command_ids=OrderedSet(),
         commands_by_id=OrderedDict(),
         errors_by_id={},
     )
@@ -452,7 +453,7 @@ def test_command_store_handles_finish_action() -> None:
         is_door_blocking=False,
         running_command_id=None,
         all_command_ids=[],
-        queued_command_ids=OrderedDict(),
+        queued_command_ids=OrderedSet(),
         commands_by_id=OrderedDict(),
         errors_by_id={},
     )
@@ -472,7 +473,7 @@ def test_command_store_handles_stop_action() -> None:
         is_door_blocking=False,
         running_command_id=None,
         all_command_ids=[],
-        queued_command_ids=OrderedDict(),
+        queued_command_ids=OrderedSet(),
         commands_by_id=OrderedDict(),
         errors_by_id={},
     )
@@ -491,7 +492,7 @@ def test_command_store_cannot_restart_after_should_stop() -> None:
         is_door_blocking=False,
         running_command_id=None,
         all_command_ids=[],
-        queued_command_ids=OrderedDict(),
+        queued_command_ids=OrderedSet(),
         commands_by_id=OrderedDict(),
         errors_by_id={},
     )
@@ -515,7 +516,7 @@ def test_command_store_ignores_known_finish_error() -> None:
         is_door_blocking=False,
         running_command_id=None,
         all_command_ids=[],
-        queued_command_ids=OrderedDict(),
+        queued_command_ids=OrderedSet(),
         commands_by_id=OrderedDict(),
         errors_by_id={},
     )
@@ -539,7 +540,7 @@ def test_command_store_saves_unknown_finish_error() -> None:
         is_door_blocking=False,
         running_command_id=None,
         all_command_ids=[],
-        queued_command_ids=OrderedDict(),
+        queued_command_ids=OrderedSet(),
         commands_by_id=OrderedDict(),
         errors_by_id={
             "error-id": errors.ErrorOccurrence(
@@ -567,7 +568,7 @@ def test_command_store_ignores_stop_after_graceful_finish() -> None:
         is_door_blocking=False,
         running_command_id=None,
         all_command_ids=[],
-        queued_command_ids=OrderedDict(),
+        queued_command_ids=OrderedSet(),
         commands_by_id=OrderedDict(),
         errors_by_id={},
     )
@@ -588,7 +589,7 @@ def test_command_store_ignores_finish_after_non_graceful_stop() -> None:
         is_door_blocking=False,
         running_command_id=None,
         all_command_ids=[],
-        queued_command_ids=OrderedDict(),
+        queued_command_ids=OrderedSet(),
         commands_by_id=OrderedDict(),
         errors_by_id={},
     )
@@ -621,7 +622,7 @@ def test_command_store_handles_command_failed() -> None:
         is_door_blocking=False,
         running_command_id=None,
         all_command_ids=["command-id"],
-        queued_command_ids=OrderedDict(),
+        queued_command_ids=OrderedSet(),
         commands_by_id={
             "command-id": CommandEntry(index=0, command=expected_failed_command),
         },
@@ -648,7 +649,7 @@ def test_handles_hardware_stopped() -> None:
         is_door_blocking=False,
         running_command_id=None,
         all_command_ids=[],
-        queued_command_ids=OrderedDict(),
+        queued_command_ids=OrderedSet(),
         commands_by_id=OrderedDict(),
         errors_by_id={},
     )
@@ -671,7 +672,7 @@ def test_handles_door_open_and_close_event() -> None:
         is_door_blocking=True,
         running_command_id=None,
         all_command_ids=[],
-        queued_command_ids=OrderedDict(),
+        queued_command_ids=OrderedSet(),
         commands_by_id=OrderedDict(),
         errors_by_id={},
     )
@@ -686,7 +687,7 @@ def test_handles_door_open_and_close_event() -> None:
         is_door_blocking=False,
         running_command_id=None,
         all_command_ids=[],
-        queued_command_ids=OrderedDict(),
+        queued_command_ids=OrderedSet(),
         commands_by_id=OrderedDict(),
         errors_by_id={},
     )
@@ -707,7 +708,7 @@ def test_handles_door_event_during_idle_run() -> None:
         is_door_blocking=True,
         running_command_id=None,
         all_command_ids=[],
-        queued_command_ids=OrderedDict(),
+        queued_command_ids=OrderedSet(),
         commands_by_id=OrderedDict(),
         errors_by_id={},
     )
@@ -721,7 +722,7 @@ def test_handles_door_event_during_idle_run() -> None:
         is_door_blocking=False,
         running_command_id=None,
         all_command_ids=[],
-        queued_command_ids=OrderedDict(),
+        queued_command_ids=OrderedSet(),
         commands_by_id=OrderedDict(),
         errors_by_id={},
     )

--- a/api/tests/opentrons/protocol_engine/state/test_command_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view.py
@@ -1,9 +1,10 @@
 """Labware state store tests."""
 import pytest
-from collections import OrderedDict
 from contextlib import nullcontext as does_not_raise
 from datetime import datetime
 from typing import Dict, List, NamedTuple, Optional, Sequence, Type
+
+from opentrons.ordered_set import OrderedSet
 
 from opentrons.protocol_engine import EngineStatus, commands as cmd, errors
 
@@ -48,7 +49,7 @@ def get_command_view(
         is_door_blocking=is_door_blocking,
         run_result=run_result,
         running_command_id=running_command_id,
-        queued_command_ids=OrderedDict((i, True) for i in queued_command_ids),
+        queued_command_ids=OrderedSet(queued_command_ids),
         errors_by_id=errors_by_id or {},
         all_command_ids=all_command_ids,
         commands_by_id=commands_by_id,

--- a/api/tests/opentrons/protocol_engine/state/test_command_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view.py
@@ -158,26 +158,23 @@ def test_get_is_complete() -> None:
     assert subject.get_is_complete("command-id-4") is False
 
 
-@pytest.mark.xfail(strict=True, raises=NotImplementedError)
 def test_get_all_complete() -> None:
-    """It should return true if all commands completed or any failed."""
+    """It should return true if no commands queued or running."""
     running_command = create_running_command(command_id="command-id-2")
 
     subject = get_command_view(queued_command_ids=[])
     assert subject.get_all_complete() is True
 
-    subject = get_command_view(queued_command_ids=["command-id-1"])
+    subject = get_command_view(queued_command_ids=["queued-command-id"])
     assert subject.get_all_complete() is False
 
     subject = get_command_view(
-        queued_command_ids=[],
-        commands=[running_command],
+        queued_command_ids=[], running_command_id="running-command-id"
     )
     assert subject.get_all_complete() is False
 
     subject = get_command_view(
         queued_command_ids=[],
-        is_hardware_stopped=True,
         commands=[running_command],
     )
     assert subject.get_all_complete() is True

--- a/api/tests/opentrons/test_ordered_set.py
+++ b/api/tests/opentrons/test_ordered_set.py
@@ -26,6 +26,16 @@ def test_equality() -> None:
     subject_123_also.add(2)
     subject_123_also.add(3)
 
+    subject_123_float = OrderedSet[float]()
+    subject_123_float.add(1.0)
+    subject_123_float.add(2.0)
+    subject_123_float.add(3.0)
+
+    subject_123_str = OrderedSet[str]()
+    subject_123_str.add("1")
+    subject_123_str.add("2")
+    subject_123_str.add("3")
+
     subject_456 = OrderedSet[int]()
     subject_456.add(4)
     subject_456.add(5)
@@ -39,6 +49,8 @@ def test_equality() -> None:
     not_even_an_ordered_set = "💩"
 
     assert subject_123 == subject_123_also
+    assert subject_123 == subject_123_float
+    assert subject_123 != subject_123_str
     assert subject_123 != subject_456
     assert subject_123 != subject_321
     assert subject_123 != not_even_an_ordered_set

--- a/api/tests/opentrons/test_ordered_set.py
+++ b/api/tests/opentrons/test_ordered_set.py
@@ -1,0 +1,99 @@
+"""Tests for ordered_set."""
+
+
+import pytest
+from opentrons.ordered_set import OrderedSet
+
+
+def test_addition_and_iteration() -> None:
+    """Elements should be returned in the order they were added."""
+    subject = OrderedSet[int]()
+    expected = list(range(100))
+    for element in expected:
+        subject.add(element)
+    assert list(subject) == expected
+
+
+def test_equality() -> None:
+    """Sets should be equal only with the same elements in the same order."""
+    subject_123 = OrderedSet[int]()
+    subject_123.add(1)
+    subject_123.add(2)
+    subject_123.add(3)
+
+    subject_123_also = OrderedSet[int]()
+    subject_123_also.add(1)
+    subject_123_also.add(2)
+    subject_123_also.add(3)
+
+    subject_456 = OrderedSet[int]()
+    subject_456.add(4)
+    subject_456.add(5)
+    subject_456.add(6)
+
+    subject_321 = OrderedSet[int]()
+    subject_321.add(3)
+    subject_321.add(2)
+    subject_321.add(1)
+
+    not_even_an_ordered_set = "💩"
+
+    assert subject_123 == subject_123_also
+    assert subject_123 != subject_456
+    assert subject_123 != subject_321
+    assert subject_123 != not_even_an_ordered_set
+
+
+def test_deduplication() -> None:
+    """Added elements should be deduplicated."""
+    subject = OrderedSet[int]()
+    for i in [3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9]:
+        subject.add(i)
+    assert list(subject) == [3, 1, 4, 5, 9, 2, 6, 8, 7]
+
+
+def test_initialization_by_iterable() -> None:
+    """Initializing by iterable should be equivalent to adding one at a time."""
+    source_iterable = [3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9]
+    subject_1 = OrderedSet[int](source_iterable)
+    subject_2 = OrderedSet[int]()
+    for element in source_iterable:
+        subject_2.add(element)
+    assert subject_1 == subject_2
+
+
+def test_remove() -> None:
+    """It should remove the element from the set, or raise if it's not present."""
+    subject = OrderedSet([1, 2, 3, 4, 5])
+
+    subject.remove(2)
+    assert list(subject) == [1, 3, 4, 5]
+
+    with pytest.raises(KeyError):
+        subject.remove(2)
+    assert list(subject) == [1, 3, 4, 5]
+
+
+def test_length() -> None:
+    """The length should be the number of unique elements currently in the set."""
+    subject = OrderedSet[str]()
+    assert len(subject) == 0
+
+    subject.add("a")
+    assert len(subject) == 1
+
+    subject.add("a")  # Duplicate.
+    assert len(subject) == 1
+
+    subject.add("b")
+    assert len(subject) == 2
+
+    subject.remove("a")
+    assert len(subject) == 1
+
+
+def test_clear() -> None:
+    """It should clear all elements from the set."""
+    subject = OrderedSet([1, 2, 3, 4, 5])
+    subject.clear()
+    assert list(subject) == []


### PR DESCRIPTION
# Overview

This PR reimplements `CommandView.get_all_complete()`.

This function had been implemented before, but we wiped it out in #9170 because it was unused, and because it was written in a way that made it easy to accidentally cause performance problems, if it *were* used. We need it again now because it's involved in analyzing JSON protocol schema v6 protocols, which we're implementing now in other PRs.

# Changelog

* Change the specification of `get_all_complete()` so that it uses the same definition of "complete" as `get_is_complete()`. Formerly, the notion of "hardware stoppage" was involved, which I found confusing and unnecessary.
* Reimplement `CommandView.get_all_complete()`. It now has amortized O(1) time complexity.
* Refactor how `CommandState`'s caches queued commands. It was using a dict to implement a DIY ordered set. Now, it uses a custom ordered set class. This is mostly just for readability, at the moment.

# Review requests

I *believe* the new specification of `get_all_complete()` is behaviorally equivalent, but please check my thinking on this.

# Risk assessment

This can't possibly break anything that was already working, because it was unimplemented before.