### PR TITLE
refactor(protocol-engine): move command-specific errors into command model

### DIFF
--- a/api/src/opentrons/protocol_engine/clients/transports.py
+++ b/api/src/opentrons/protocol_engine/clients/transports.py
@@ -67,10 +67,9 @@ class ChildThreadTransport(AbstractSyncTransport):
             loop=self._loop,
         ).result()
 
-        if command.errorId is not None:
-            raise ProtocolEngineError(
-                f'Command "{command.id}" failed due to error "{command.errorId}"'
-            )
+        if command.error is not None:
+            error = command.error
+            raise ProtocolEngineError(f"{error.errorType}: {error.detail}")
 
         assert command.result is not None, f"Expected Command {command} to have result"
 

--- a/api/src/opentrons/protocol_engine/commands/command.py
+++ b/api/src/opentrons/protocol_engine/commands/command.py
@@ -13,10 +13,12 @@ from pydantic.generics import GenericModel
 
 from opentrons.hardware_control import HardwareControlAPI
 
+from ..errors import ErrorOccurrence
+
 # Work around type-only circular dependencies.
 if TYPE_CHECKING:
-    from opentrons.protocol_engine import execution
-    from opentrons.protocol_engine.state import StateView
+    from .. import execution
+    from ..state import StateView
 
 
 CommandParamsT = TypeVar("CommandParamsT", bound=BaseModel)
@@ -85,7 +87,7 @@ class BaseCommand(GenericModel, Generic[CommandParamsT, CommandResultT]):
         None,
         description="Command execution result data, if succeeded",
     )
-    errorId: Optional[str] = Field(
+    error: Optional[ErrorOccurrence] = Field(
         None,
         description="Reference to error occurrence, if execution failed",
     )

--- a/api/tests/opentrons/protocol_engine/state/command_fixtures.py
+++ b/api/tests/opentrons/protocol_engine/state/command_fixtures.py
@@ -5,7 +5,7 @@ from typing import Optional, cast
 
 from opentrons.types import MountType
 from opentrons.protocols.models import LabwareDefinition
-from opentrons.protocol_engine import commands as cmd
+from opentrons.protocol_engine import ErrorOccurrence, commands as cmd
 from opentrons.protocol_engine.types import (
     PipetteName,
     WellLocation,
@@ -58,10 +58,10 @@ def create_failed_command(
     command_id: str = "command-id",
     command_key: str = "command-key",
     command_type: str = "command-type",
-    error_id: str = "error-id",
     created_at: datetime = datetime(year=2021, month=1, day=1),
     completed_at: datetime = datetime(year=2022, month=2, day=2),
     params: Optional[BaseModel] = None,
+    error: Optional[ErrorOccurrence] = None,
 ) -> cmd.Command:
     """Given command data, build a failed command model."""
     return cast(
@@ -70,11 +70,11 @@ def create_failed_command(
             id=command_id,
             key=command_key,
             createdAt=created_at,
+            completedAt=completed_at,
             commandType=command_type,
             status=cmd.CommandStatus.FAILED,
             params=params or BaseModel(),
-            errorId=error_id,
-            completedAt=completed_at,
+            error=error,
         ),
     )
 

--- a/api/tests/opentrons/protocol_engine/state/test_command_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_store.py
@@ -303,7 +303,12 @@ def test_command_failure_clears_queue() -> None:
     expected_failed_1 = commands.Pause(
         id="command-id-1",
         key="command-key-1",
-        errorId="error-id",
+        error=errors.ErrorOccurrence(
+            id="error-id",
+            errorType="ProtocolEngineError",
+            detail="oh no",
+            createdAt=datetime(year=2023, month=3, day=3),
+        ),
         createdAt=datetime(year=2021, month=1, day=1),
         startedAt=datetime(year=2022, month=2, day=2),
         completedAt=datetime(year=2023, month=3, day=3),
@@ -313,7 +318,7 @@ def test_command_failure_clears_queue() -> None:
     expected_failed_2 = commands.Pause(
         id="command-id-2",
         key="command-key-2",
-        errorId="error-id",
+        error=None,
         createdAt=datetime(year=2021, month=1, day=1),
         completedAt=datetime(year=2023, month=3, day=3),
         params=commands.PauseParams(),
@@ -597,9 +602,17 @@ def test_command_store_ignores_finish_after_non_graceful_stop() -> None:
 def test_command_store_handles_command_failed() -> None:
     """It should store an error and mark the command if it fails."""
     command = create_running_command(command_id="command-id")
+
+    expected_error_occurrence = errors.ErrorOccurrence(
+        id="error-id",
+        errorType="ProtocolEngineError",
+        createdAt=datetime(year=2022, month=2, day=2),
+        detail="oh no",
+    )
+
     expected_failed_command = create_failed_command(
         command_id="command-id",
-        error_id="error-id",
+        error=expected_error_occurrence,
         completed_at=datetime(year=2022, month=2, day=2),
     )
 
@@ -625,14 +638,7 @@ def test_command_store_handles_command_failed() -> None:
         commands_by_id={
             "command-id": CommandEntry(index=0, command=expected_failed_command),
         },
-        errors_by_id={
-            "error-id": errors.ErrorOccurrence(
-                id="error-id",
-                errorType="ProtocolEngineError",
-                createdAt=datetime(year=2022, month=2, day=2),
-                detail="oh no",
-            )
-        },
+        errors_by_id={},
     )
 
 

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -206,7 +206,7 @@ async def get_run_commands(
             startedAt=c.startedAt,
             completedAt=c.completedAt,
             params=c.params,
-            errorId=c.errorId,
+            error=c.error,
         )
         for c in command_slice.commands
     ]

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -41,9 +41,9 @@ class RunCommandSummary(ResourceModel):
         description="Command execution completed timestamp, if completed",
     )
     status: CommandStatus = Field(..., description="Execution status of the command.")
-    errorId: Optional[str] = Field(
+    error: Optional[ErrorOccurrence] = Field(
         None,
-        description="Error occurrence identifier, if status is 'failed'",
+        description="Error occurrence, if status is 'failed'",
     )
     # TODO(mc, 2022-02-01): this does not allow the command summary object to
     # be narrowed based on `commandType`. Will be resolved by TODO above

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -189,7 +189,12 @@ async def test_get_run_commands(decoy: Decoy, engine_store: EngineStore) -> None
         startedAt=datetime(year=2022, month=2, day=2),
         completedAt=datetime(year=2023, month=3, day=3),
         params=pe_commands.PauseParams(message="hello world"),
-        errorId="error-id",
+        error=pe_errors.ErrorOccurrence(
+            id="error-id",
+            errorType="PrettyBadError",
+            createdAt=datetime(year=2024, month=4, day=4),
+            detail="Things are not looking good.",
+        ),
     )
 
     engine_state = decoy.mock(cls=StateView)
@@ -223,7 +228,12 @@ async def test_get_run_commands(decoy: Decoy, engine_store: EngineStore) -> None
             completedAt=datetime(year=2023, month=3, day=3),
             status=pe_commands.CommandStatus.FAILED,
             params=pe_commands.PauseParams(message="hello world"),
-            errorId="error-id",
+            error=pe_errors.ErrorOccurrence(
+                id="error-id",
+                errorType="PrettyBadError",
+                createdAt=datetime(year=2024, month=4, day=4),
+                detail="Things are not looking good.",
+            ),
         )
     ]
     assert result.content.meta == MultiBodyMeta(cursor=1, totalLength=3)


### PR DESCRIPTION
## Overview

While working on #9617, I realized that we had no good way to expose stateless command errors to the API user.

After chatting this through with @SyntaxColoring, this PR moves **command-specifc** commands into the command resources themselves, replacing the `errorId` field of a command with an `error` field, instead.

The top-level `errors` field of the ProtocolEngine state / run still exists, and still represents fatal errors for the run itself.

Unblocks #9617, and as a happy side effect, fixes #9436

## Changelog

- Do not place command-specific errors into `run.errors`
    - This does not affect run failure, since the errors still bubble up to the `ProtocolRunner`
    - The `ProtocolRunner` is then in charge of placing the `ExceptionInProtocol` error into run state
- Place command-specific errors into `run.commands[].error`

## Review requests

- [x] Smoke test a protocol run that fails due to command failure
    - e.g. two pickup tips in a row
- [x] Smoke test a protocol run that fails due to programmer error
    - e.g. `IndexError`
- [x] Client-side code does not need changes
    - I could not find any references to the old `errorId` field in client code, so I think we're ok here

## Risk assessment

Low, provided we are able to confirm that this doesn't mess with client expectations


## Response examples

```py
from opentrons import types

metadata = {
    "protocolName": "Tipception",
    "apiLevel": "2.12",
}


def run(ctx):
    tr = ctx.load_labware("opentrons_96_tiprack_300ul", 1)
    right = ctx.load_instrument("p300_single", types.Mount.RIGHT, [tr])

    right.pick_up_tip()
    right.pick_up_tip()
```


### Before (`edge`)

```js
// GET /runs/:run_id
{
    "data": {
        "id": "fae0ab16-9d83-4817-a52e-617d0d85188f",
        "createdAt": "2022-03-18T18:52:37.038251+00:00",
        "status": "failed",
        "current": true,
        "errors": [
            {
                "id": "fc530a13-bf1e-4786-9602-cf0c5149c168",
                "errorType": "LegacyContextCommandError",
                "createdAt": "2022-03-18T18:52:39.112172+00:00",
                "detail": "Cannot pick up tip with a tip attached"
            },
            {
                "id": "724d19d8-a668-4a8a-98e3-277c621cccbb",
                "errorType": "ExceptionInProtocolError",
                "createdAt": "2022-03-18T18:52:39.113973+00:00",
                "detail": "TipAttachedError [line 14]: Cannot pick up tip with a tip attached"
            }
        ],
        // ...
    }
}

// GET /runs/:run_id/commands
{
    "data": [
        // ...
        {
            "id": "command.PICK_UP_TIP-0",
            "key": "command.PICK_UP_TIP-0",
            "commandType": "pickUpTip",
            "status": "succeeded",
            "params": {
                // ...
            },
            // ...
        },
        {
            "id": "command.PICK_UP_TIP-1",
            "key": "command.PICK_UP_TIP-1",
            "commandType": "pickUpTip",
            "status": "failed",
            "errorId": "fc530a13-bf1e-4786-9602-cf0c5149c168",
            "params": {
                // ...
            },
            // ...
        }
    ],
    // ...
}
```

### After (`engine_errors-reorg`)

```js
// GET /runs/:run_id
{
    "data": {
        "id": "0a5a6b2c-95bc-448d-86ba-ae11c5016f7e",
        "createdAt": "2022-03-18T18:48:41.261702+00:00",
        "status": "failed",
        "current": true,
        "errors": [
            {
                "id": "b72840b0-299b-4b9d-8de7-faee74dbaec4",
                "errorType": "ExceptionInProtocolError",
                "createdAt": "2022-03-18T18:48:45.798144+00:00",
                "detail": "TipAttachedError [line 14]: Cannot pick up tip with a tip attached"
            }
        ],
        // ...
    }
}

// GET /runs/:run_id/commands
{
    "data": [
        // ...
        {
            "id": "command.PICK_UP_TIP-0",
            "key": "command.PICK_UP_TIP-0",
            "commandType": "pickUpTip",
            "status": "succeeded",
            "params": {
                // ...
            },
            // ...
        },
        {
            "id": "command.PICK_UP_TIP-1",
            "key": "command.PICK_UP_TIP-1",
            "commandType": "pickUpTip",
            "status": "failed",
            "error": {
                "id": "80490a0d-3268-4569-870e-78a042bcac4f",
                "errorType": "LegacyContextCommandError",
                "createdAt": "2022-03-18T18:48:45.796623+00:00",
                "detail": "Cannot pick up tip with a tip attached"
            },
            "params": {
                // ...
            },
            // ...
        }
    ],
    // ...
}
```