### PR TITLE
refactor(protocol-engine): add heater-shaker support to various HW types

### DIFF
--- a/api/src/opentrons/hardware_control/modules/types.py
+++ b/api/src/opentrons/hardware_control/modules/types.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from enum import Enum
 from dataclasses import dataclass
 from typing import (
@@ -5,8 +6,6 @@ from typing import (
     NamedTuple,
     Callable,
     Any,
-    Type,
-    TypeVar,
     Tuple,
     Awaitable,
     Mapping,
@@ -22,6 +21,7 @@ if TYPE_CHECKING:
         ThermocyclerModuleType,
         MagneticModuleType,
         TemperatureModuleType,
+        HeaterShakerModuleType,
     )
 
 ThermocyclerStep = Dict[str, float]
@@ -31,44 +31,29 @@ UploadFunction = Callable[[str, str, Dict[str, Any]], Awaitable[Tuple[bool, str]
 LiveData = Mapping[str, Union[str, Mapping[str, Union[float, str, None]]]]
 
 
-E = TypeVar("E", bound="_ProvideLookup")
+class ModuleType(str, Enum):
+    THERMOCYCLER: ThermocyclerModuleType = "thermocyclerModuleType"
+    TEMPERATURE: TemperatureModuleType = "temperatureModuleType"
+    MAGNETIC: MagneticModuleType = "magneticModuleType"
+    HEATER_SHAKER: HeaterShakerModuleType = "heaterShakerModuleType"
 
 
-# TODO(mc, 2022-01-18): this mixin is unnecessary; Python enums can
-# use parenthetical notation to access by value
-class _ProvideLookup(Enum):
-    @classmethod
-    def from_str(cls: Type[E], typename: str) -> "E":
-        for m in cls.__members__.values():
-            if m.value == typename:
-                return m
-        raise AttributeError(f"No such type {typename}")
-
-
-class ModuleType(_ProvideLookup):
-    THERMOCYCLER: "ThermocyclerModuleType" = "thermocyclerModuleType"
-    TEMPERATURE: "TemperatureModuleType" = "temperatureModuleType"
-    MAGNETIC: "MagneticModuleType" = "magneticModuleType"
-
-
-class MagneticModuleModel(_ProvideLookup):
+class MagneticModuleModel(str, Enum):
     MAGNETIC_V1: str = "magneticModuleV1"
     MAGNETIC_V2: str = "magneticModuleV2"
 
 
-class TemperatureModuleModel(_ProvideLookup):
+class TemperatureModuleModel(str, Enum):
     TEMPERATURE_V1: str = "temperatureModuleV1"
     TEMPERATURE_V2: str = "temperatureModuleV2"
 
 
-class ThermocyclerModuleModel(_ProvideLookup):
-    @classmethod
-    def from_str(
-        cls: Type["ThermocyclerModuleModel"], typename: str
-    ) -> "ThermocyclerModuleModel":
-        return super().from_str(typename)
-
+class ThermocyclerModuleModel(str, Enum):
     THERMOCYCLER_V1: str = "thermocyclerModuleV1"
+
+
+class HeaterShakerModuleModel(str, Enum):
+    HEATER_SHAKER_V1: str = "heaterShakerModuleV1"
 
 
 @dataclass

--- a/api/src/opentrons/protocol_engine/resources/module_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/module_data_provider.py
@@ -13,5 +13,5 @@ class ModuleDataProvider:
     def get_definition(model: ModuleModel) -> ModuleDefinition:
         """Get the module definition."""
         model_name = cast(ModuleModelStr, model.value)
-        data = load_definition(model_or_loadname=model_name, version="2")
+        data = load_definition(model_or_loadname=model_name, version="3")
         return ModuleDefinition.parse_obj(data)

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -135,7 +135,9 @@ class MotorAxis(str, Enum):
     RIGHT_PLUNGER = "rightPlunger"
 
 
-# TODO(mc, 2022-01-18): move enum to hardware control module
+# TODO(mc, 2022-01-18): use opentrons_shared_data.module.dev_types.ModuleModel
+
+
 class ModuleModel(str, Enum):
     """All available modules' models."""
 
@@ -144,6 +146,7 @@ class ModuleModel(str, Enum):
     MAGNETIC_MODULE_V1 = "magneticModuleV1"
     MAGNETIC_MODULE_V2 = "magneticModuleV2"
     THERMOCYCLER_MODULE_V1 = "thermocyclerModuleV1"
+    HEATER_SHAKER_MODULE_V1 = "heaterShakerModuleV1"
 
     def as_type(self) -> ModuleType:
         """Get the ModuleType of this model."""
@@ -156,6 +159,8 @@ class ModuleModel(str, Enum):
             return ModuleType.MAGNETIC
         elif self == ModuleModel.THERMOCYCLER_MODULE_V1:
             return ModuleType.THERMOCYCLER
+        elif self == ModuleModel.HEATER_SHAKER_MODULE_V1:
+            return ModuleType.HEATER_SHAKER
 
         assert False, f"Invalid ModuleModel {self}"
 

--- a/api/src/opentrons/protocols/geometry/module_geometry.py
+++ b/api/src/opentrons/protocols/geometry/module_geometry.py
@@ -23,6 +23,7 @@ from opentrons.hardware_control.modules.types import (
     MagneticModuleModel,
     TemperatureModuleModel,
     ThermocyclerModuleModel,
+    HeaterShakerModuleModel,
 )
 from opentrons.types import Location, Point, LocationLabware
 from opentrons.protocols.api_support.types import APIVersion
@@ -47,10 +48,11 @@ def module_model_from_string(model_string: str) -> ModuleModel:
         MagneticModuleModel,
         TemperatureModuleModel,
         ThermocyclerModuleModel,
+        HeaterShakerModuleModel,
     }:
         try:
-            return model_enum.from_str(model_string)  # type: ignore
-        except AttributeError:
+            return model_enum(model_string)
+        except ValueError:
             pass
     raise AttributeError(f"No such module model {model_string}")
 
@@ -426,7 +428,7 @@ def _load_from_v2(
             overall_height=definition["dimensions"]["bareOverallHeight"],
             height_over_labware=definition["dimensions"]["overLabwareHeight"],
             model=module_model_from_string(definition["model"]),
-            module_type=ModuleType.from_str(definition["moduleType"]),
+            module_type=ModuleType(definition["moduleType"]),
             display_name=definition["displayName"],
         )
     elif definition["moduleType"] == ModuleType.THERMOCYCLER.value:
@@ -437,7 +439,7 @@ def _load_from_v2(
             overall_height=definition["dimensions"]["bareOverallHeight"],
             height_over_labware=definition["dimensions"]["overLabwareHeight"],
             model=module_model_from_string(definition["model"]),
-            module_type=ModuleType.from_str(definition["moduleType"]),
+            module_type=ModuleType(definition["moduleType"]),
             display_name=definition["displayName"],
             lid_height=definition["dimensions"]["lidHeight"],
             configuration=configuration,
@@ -633,7 +635,7 @@ def resolve_module_model(module_model_or_load_name: str) -> ModuleModel:
 
 
 def resolve_module_type(module_model: ModuleModel) -> ModuleType:
-    return ModuleType.from_str(_load_v2_module_def(module_model)["moduleType"])
+    return ModuleType(_load_v2_module_def(module_model)["moduleType"])
 
 
 def models_compatible(model_a: ModuleModel, model_b: ModuleModel) -> bool:

--- a/api/tests/opentrons/protocol_api_experimental/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/test_protocol_context.py
@@ -32,35 +32,35 @@ from opentrons.protocol_api_experimental import (
 @pytest.fixture(scope="session")
 def magdeck_v1_def() -> ModuleDefinition:
     """Get the definition of a V1 magdeck."""
-    definition = load_shared_data("module/definitions/2/magneticModuleV1.json")
+    definition = load_shared_data("module/definitions/3/magneticModuleV1.json")
     return ModuleDefinition.parse_raw(definition)
 
 
 @pytest.fixture(scope="session")
 def magdeck_v2_def() -> ModuleDefinition:
-    """Get the definition of a V1 magdeck."""
-    definition = load_shared_data("module/definitions/2/magneticModuleV2.json")
+    """Get the definition of a V2 magdeck."""
+    definition = load_shared_data("module/definitions/3/magneticModuleV2.json")
     return ModuleDefinition.parse_raw(definition)
 
 
 @pytest.fixture(scope="session")
 def tempdeck_v2_def() -> ModuleDefinition:
-    """Get the definition of a V1 tempdeck."""
-    definition = load_shared_data("module/definitions/2/temperatureModuleV2.json")
+    """Get the definition of a V2 tempdeck."""
+    definition = load_shared_data("module/definitions/3/temperatureModuleV2.json")
     return ModuleDefinition.parse_raw(definition)
 
 
 @pytest.fixture(scope="session")
 def tempdeck_v1_def() -> ModuleDefinition:
     """Get the definition of a V1 tempdeck."""
-    definition = load_shared_data("module/definitions/2/temperatureModuleV1.json")
+    definition = load_shared_data("module/definitions/3/temperatureModuleV1.json")
     return ModuleDefinition.parse_raw(definition)
 
 
 @pytest.fixture(scope="session")
 def thermocycler_v1_def() -> ModuleDefinition:
-    """Get the definition of a V2 thermocycler."""
-    definition = load_shared_data("module/definitions/2/thermocyclerModuleV1.json")
+    """Get the definition of a V1 thermocycler."""
+    definition = load_shared_data("module/definitions/3/thermocyclerModuleV1.json")
     return ModuleDefinition.parse_raw(definition)
 
 

--- a/robot-server/tests/integration/conftest.py
+++ b/robot-server/tests/integration/conftest.py
@@ -1,4 +1,7 @@
+import json
 from typing import Any, Dict
+
+from requests import Response
 
 
 def pytest_tavern_beta_before_every_test_run(
@@ -10,3 +13,8 @@ def pytest_tavern_beta_before_every_test_run(
         headers = stage["request"].get("headers", {})
         headers.setdefault("Opentrons-Version", "*")
         stage["request"].update({"headers": headers})
+
+
+def pytest_tavern_beta_after_every_response(expected: Any, response: Response) -> None:
+    print(response.url)
+    print(json.dumps(response.json(), indent=4))

--- a/robot-server/tests/integration/http_api/commands/test_load_module_failure.tavern.yaml
+++ b/robot-server/tests/integration/http_api/commands/test_load_module_failure.tavern.yaml
@@ -9,12 +9,6 @@ marks:
         - magneticModuleV2
 
 stages:
-  - name: Get modules
-    request:
-      url: '{host:s}:{port:d}/modules'
-      method: GET
-    response:
-      status_code: 200
   - name: Create Empty Run
     request:
       url: '{host:s}:{port:d}/runs'
@@ -33,7 +27,7 @@ stages:
       save:
         json:
           run_id: data.id
-  - name: Create loadModule Magnetic Module Command
+  - name: Create loadModule Command
     request:
       url: '{host:s}:{port:d}/runs/{run_id}/commands'
       method: POST

--- a/robot-server/tests/integration/http_api/commands/test_load_module_failure.tavern.yaml
+++ b/robot-server/tests/integration/http_api/commands/test_load_module_failure.tavern.yaml
@@ -1,0 +1,56 @@
+test_name: loadModule command failure
+
+marks:
+  - usefixtures:
+      - run_server
+  - parametrize:
+      key: model
+      vals:
+        - magneticModuleV2
+
+stages:
+  - name: Get modules
+    request:
+      url: '{host:s}:{port:d}/modules'
+      method: GET
+    response:
+      status_code: 200
+  - name: Create Empty Run
+    request:
+      url: '{host:s}:{port:d}/runs'
+      json:
+        data: {}
+      method: POST
+    response:
+      strict:
+        - json:off
+      status_code: 201
+      json:
+        data:
+          id: !anystr
+          status: idle
+          current: true
+      save:
+        json:
+          run_id: data.id
+  - name: Create loadModule Magnetic Module Command
+    request:
+      url: '{host:s}:{port:d}/runs/{run_id}/commands'
+      method: POST
+      params:
+        waitUntilComplete: true
+      json:
+        data:
+          commandType: loadModule
+          params:
+            model: '{model}'
+            location:
+              slotName: '10'
+    response:
+      strict:
+        - json:off
+      status_code: 201
+      json:
+        data:
+          status: failed
+    # TODO(jm, 2022-03-18): validate the error in the command and in the run

--- a/robot-server/tests/integration/http_api/commands/test_load_module_success.tavern.yaml
+++ b/robot-server/tests/integration/http_api/commands/test_load_module_success.tavern.yaml
@@ -30,23 +30,12 @@ stages:
       json:
         data:
           id: !anystr
-          createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
           status: idle
           current: true
-          actions: []
-          errors: []
-          pipettes: []
-          labware:
-            - id: fixedTrash
-              loadName: opentrons_1_trash_1100ml_fixed
-              definitionUri: opentrons/opentrons_1_trash_1100ml_fixed/1
-              location:
-                slotName: '12'
-          labwareOffsets: []
       save:
         json:
           run_id: data.id
-  - name: Create loadModule Magnetic Module Command
+  - name: Create loadModule Command
     request:
       url: '{host:s}:{port:d}/runs/{run_id}/commands'
       method: POST

--- a/robot-server/tests/integration/http_api/commands/test_load_module_success.tavern.yaml
+++ b/robot-server/tests/integration/http_api/commands/test_load_module_success.tavern.yaml
@@ -1,0 +1,69 @@
+test_name: loadModule command success
+
+marks:
+  - usefixtures:
+      - run_server
+  - parametrize:
+      key: model
+      vals:
+        - magneticModuleV1
+        - thermocyclerModuleV1
+        - temperatureModuleV1
+        - temperatureModuleV2 # can map to attached temperatureModuleV1
+        - heaterShakerModuleV1
+
+stages:
+  - name: Get modules
+    request:
+      url: '{host:s}:{port:d}/modules'
+      method: GET
+    response:
+      status_code: 200
+  - name: Create Empty Run
+    request:
+      url: '{host:s}:{port:d}/runs'
+      json:
+        data: {}
+      method: POST
+    response:
+      status_code: 201
+      json:
+        data:
+          id: !anystr
+          createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          status: idle
+          current: true
+          actions: []
+          errors: []
+          pipettes: []
+          labware:
+            - id: fixedTrash
+              loadName: opentrons_1_trash_1100ml_fixed
+              definitionUri: opentrons/opentrons_1_trash_1100ml_fixed/1
+              location:
+                slotName: '12'
+          labwareOffsets: []
+      save:
+        json:
+          run_id: data.id
+  - name: Create loadModule Magnetic Module Command
+    request:
+      url: '{host:s}:{port:d}/runs/{run_id}/commands'
+      method: POST
+      params:
+        waitUntilComplete: true
+      json:
+        data:
+          commandType: loadModule
+          params:
+            model: "{model}"
+            location:
+              slotName: '10'
+    response:
+      strict:
+        - json:off
+      status_code: 201
+      json:
+        data:
+          status: succeeded
+

--- a/robot-server/tests/integration/http_api/commands/test_load_module_success.tavern.yaml
+++ b/robot-server/tests/integration/http_api/commands/test_load_module_success.tavern.yaml
@@ -26,6 +26,8 @@ stages:
         data: {}
       method: POST
     response:
+      strict:
+        - json:off
       status_code: 201
       json:
         data:
@@ -45,7 +47,7 @@ stages:
         data:
           commandType: loadModule
           params:
-            model: "{model}"
+            model: '{model}'
             location:
               slotName: '10'
     response:
@@ -55,4 +57,3 @@ stages:
       json:
         data:
           status: succeeded
-

--- a/shared-data/python/opentrons_shared_data/module/__init__.py
+++ b/shared-data/python/opentrons_shared_data/module/__init__.py
@@ -9,8 +9,10 @@ from .dev_types import (
     ModuleSchema,
     SchemaV1,
     SchemaV2,
+    SchemaV3,
     ModuleDefinitionV1,
     ModuleDefinitionV2,
+    ModuleDefinitionV3,
     ModuleModel,
 )
 
@@ -51,10 +53,17 @@ def load_definition(
     ...
 
 
+@overload
 def load_definition(
-    version: Union[SchemaV1, SchemaV2],
+    version: SchemaV3, model_or_loadname: ModuleModel
+) -> ModuleDefinitionV3:
+    ...
+
+
+def load_definition(
+    version: SchemaVersions,
     model_or_loadname: Union[str, ModuleModel],
-) -> Union[ModuleDefinitionV1, ModuleDefinitionV2]:
+) -> Union[ModuleDefinitionV1, ModuleDefinitionV2, ModuleDefinitionV3]:
     if version == "1":
         path = Path("module") / "definitions" / "1.json"
         data = json.loads(load_shared_data(path))
@@ -63,7 +72,7 @@ def load_definition(
         except KeyError:
             raise ModuleNotFoundError("1", model_or_loadname)
     else:
-        path = Path(f"module/definitions/2/{model_or_loadname}.json")
+        path = Path(f"module/definitions/{version}/{model_or_loadname}.json")
         try:
             data = load_shared_data(path)
         except FileNotFoundError:

--- a/shared-data/python/opentrons_shared_data/module/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/module/dev_types.py
@@ -8,23 +8,33 @@ from typing_extensions import Literal, TypedDict
 
 SchemaV1 = Literal["1"]
 SchemaV2 = Literal["2"]
-SchemaVersions = Union[SchemaV1, SchemaV2]
+SchemaV3 = Literal["3"]
+SchemaVersions = Union[SchemaV1, SchemaV2, SchemaV3]
 
 ModuleSchema = Dict[str, Any]
 
 MagneticModuleType = Literal["magneticModuleType"]
 TemperatureModuleType = Literal["temperatureModuleType"]
 ThermocyclerModuleType = Literal["thermocyclerModuleType"]
+HeaterShakerModuleType = Literal["heaterShakerModuleType"]
 
-ModuleType = Union[MagneticModuleType, TemperatureModuleType, ThermocyclerModuleType]
-
-MagneticModuleModel = Union[Literal["magneticModuleV1"], Literal["magneticModuleV2"]]
-TemperatureModuleModel = Union[
-    Literal["temperatureModuleV1"], Literal["temperatureModuleV2"]
+ModuleType = Union[
+    MagneticModuleType,
+    TemperatureModuleType,
+    ThermocyclerModuleType,
+    HeaterShakerModuleType,
 ]
-ThermocyclerModuleModel = Union[Literal["thermocyclerModuleModel"]]
+
+MagneticModuleModel = Literal["magneticModuleV1", "magneticModuleV2"]
+TemperatureModuleModel = Literal["temperatureModuleV1", "temperatureModuleV2"]
+ThermocyclerModuleModel = Literal["thermocyclerModuleV1"]
+HeaterShakerModuleModel = Literal["heaterShakerModuleV1"]
+
 ModuleModel = Union[
-    MagneticModuleModel, TemperatureModuleModel, ThermocyclerModuleModel
+    MagneticModuleModel,
+    TemperatureModuleModel,
+    ThermocyclerModuleModel,
+    HeaterShakerModuleModel,
 ]
 
 ModuleSlotTransform = TypedDict(
@@ -70,3 +80,7 @@ ModuleDefinitionV1 = TypedDict(
         "quirks": List[str],
     },
 )
+
+# TODO(mc, 2022-03-18): flesh this out; also potentially move
+# from typed-dict to Pydantic
+ModuleDefinitionV3 = ModuleDefinitionV2


### PR DESCRIPTION
## Overview

This PR fixes an issue @y3rsh found during acceptance testing: `loadModule` commands are failing due to conflicts resulting from heater shaker not being known to various enums and types in the HW control layer.

This PR adds those properties, following existing patterns.

## Changelog

- refactor(protocol-engine): add heater-shaker support to various HW APIs

## Review requests

- [x] PE loadModule commands work

## Risk assessment

Low, bug fix
