### PR TITLE
refactor(hardware): ot3: fix incorrect field order in move

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -105,9 +105,9 @@ class AddToMoveGroupRequestPayload(MoveGroupRequestPayload):
 class AddLinearMoveRequestPayload(AddToMoveGroupRequestPayload):
     """Add a linear move request to a message group."""
 
-    request_stop_condition: utils.UInt8Field
     acceleration: utils.Int32Field
     velocity: utils.Int32Field
+    request_stop_condition: utils.UInt8Field
 
 
 @dataclass


### PR DESCRIPTION
The field order of this move did not match the order of the fields on the firmware side, leading to off-by-one-byte deserialization that caused massive problems.

This needs to be integration tested; before that can happen, however, we need a way for the simulator to express the moves it has executed or loaded in a way that integration tests can read.

We should also do the integration tests in a separate PR because this is a critical bugfix.