### PR TITLE
refactor(api): OT3 max instrument height is home

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -24,6 +24,7 @@ from .ot3utils import (
     axis_to_node,
     get_current_settings,
     create_home_group,
+    node_to_axis,
 )
 
 try:
@@ -441,6 +442,12 @@ class OT3Controller:
             NodeId.gantry_y: 0,
             NodeId.pipette_left: 0,
             NodeId.pipette_right: 0,
+        }
+
+    @staticmethod
+    def home_position() -> OT3AxisMap[float]:
+        return {
+            node_to_axis(k): v for k, v in OT3Controller._get_home_position().items()
         }
 
     async def probe_network(self, timeout: float = 5.0) -> None:

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -23,6 +23,7 @@ from .ot3utils import (
     axis_convert,
     create_move_group,
     get_current_settings,
+    node_to_axis,
 )
 
 from opentrons_hardware.firmware_bindings.constants import NodeId
@@ -391,6 +392,12 @@ class OT3Simulator:
             NodeId.gantry_y: 0,
             NodeId.pipette_left: 0,
             NodeId.pipette_right: 0,
+        }
+
+    @staticmethod
+    def home_position() -> OT3AxisMap[float]:
+        return {
+            node_to_axis(k): v for k, v in OT3Simulator._get_home_position().items()
         }
 
     async def probe_network(self) -> None:

--- a/api/src/opentrons/hardware_control/instrument_handler.py
+++ b/api/src/opentrons/hardware_control/instrument_handler.py
@@ -902,3 +902,12 @@ class OT3InstrumentHandler(InstrumentHandlerProvider[OT3Mount]):
         mm = ul / instr.ul_per_mm(ul, action)
         position = instr.config.bottom - mm
         return round(position, 6)
+
+    def critical_point_for(
+        self, mount: MountType, cp_override: Optional[CriticalPoint] = None
+    ) -> top_types.Point:
+        pip = self._attached_instruments[OT3Mount.from_mount(mount)]
+        if pip is not None and cp_override != CriticalPoint.MOUNT:
+            return pip.critical_point(cp_override)
+        else:
+            return top_types.Point(0, 0, 0)

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -533,16 +533,30 @@ class OT3API(
                     self._transforms.carriage_offset,
                     OT3Axis,
                 )
-            offset = offset_for_mount(
-                mount, self._config.left_mount_offset, self._config.right_mount_offset
+            ot3pos = self._effector_pos_from_carriage_pos(
+                OT3Mount.from_mount(mount), self._current_position, critical_point
             )
-            cp = self.critical_point_for(mount, critical_point)
-            return {
-                Axis.X: self._current_position[OT3Axis.X] + offset[0] + cp.x,
-                Axis.Y: self._current_position[OT3Axis.Y] + offset[1] + cp.y,
-                z_ax.to_axis(): self._current_position[z_ax] + offset[2] + cp.z,
-                plunger_ax.to_axis(): self._current_position[plunger_ax],
-            }
+            return {ot3ax.to_axis(): value for ot3ax, value in ot3pos.items()}
+
+    def _effector_pos_from_carriage_pos(
+        self,
+        mount: OT3Mount,
+        carriage_position: OT3AxisMap[float],
+        critical_point: Optional[CriticalPoint],
+    ) -> OT3AxisMap[float]:
+        offset = offset_for_mount(
+            mount, self._config.left_mount_offset, self._config.right_mount_offset
+        )
+        cp = self.critical_point_for(mount, critical_point)
+        z_ax = OT3Axis.by_mount(mount)
+        plunger_ax = OT3Axis.of_main_tool_actuator(mount)
+
+        return {
+            OT3Axis.X: carriage_position[OT3Axis.X] + offset[0] + cp.x,
+            OT3Axis.Y: carriage_position[OT3Axis.Y] + offset[1] + cp.y,
+            z_ax: carriage_position[z_ax] + offset[2] + cp.z,
+            plunger_ax: carriage_position[plunger_ax],
+        }
 
     async def gantry_position(
         self,
@@ -1066,15 +1080,6 @@ class OT3API(
         """Get the API ready to stop cleanly."""
         await self._backend.clean_up()
 
-    def get_instrument_max_height(
-        self,
-        mount: Union[top_types.Mount, OT3Mount],
-        critical_point: Optional[CriticalPoint] = None,
-    ) -> float:
-        return self._instrument_handler.instrument_max_height(
-            OT3Mount.from_mount(mount), self._config.z_retract_distance, critical_point
-        )
-
     def critical_point_for(
         self,
         mount: Union[top_types.Mount, OT3Mount],
@@ -1158,15 +1163,22 @@ class OT3API(
             OT3Mount.from_mount(mount), aspirate, dispense, blow_out
         )
 
-    def instrument_max_height(
+    def get_instrument_max_height(
         self,
         mount: Union[top_types.Mount, OT3Mount],
-        retract_distance: float,
-        critical_point: Optional[CriticalPoint],
+        critical_point: Optional[CriticalPoint] = None,
     ) -> float:
-        return self._instrument_handler.instrument_max_height(
-            OT3Mount.from_mount(mount), retract_distance, critical_point
+        carriage_pos = deck_from_machine(
+            self._backend.home_position(),
+            self._transforms.deck_calibration.attitude,
+            self._transforms.carriage_offset,
+            OT3Axis,
         )
+        pos_at_home = self._effector_pos_from_carriage_pos(
+            OT3Mount.from_mount(mount), carriage_pos, critical_point
+        )
+
+        return pos_at_home[OT3Axis.by_mount(mount)] - self._config.z_retract_distance
 
     async def add_tip(
         self, mount: Union[top_types.Mount, OT3Mount], tip_length: float

--- a/shared-data/pipette/definitions/pipetteNameSpecs.json
+++ b/shared-data/pipette/definitions/pipetteNameSpecs.json
@@ -491,7 +491,7 @@
     "channels": 1,
     "smoothieConfigs": {
       "stepsPerMM": 2133.33,
-      "homePosition": 220,
+      "homePosition": 230.15,
       "travelDistance": 80
     },
     "defaultTipracks": [
@@ -537,7 +537,7 @@
     "maxVolume": 300,
     "smoothieConfigs": {
       "stepsPerMM": 2133.33,
-      "homePosition": 220,
+      "homePosition": 230.15,
       "travelDistance": 80
     },
     "defaultTipracks": [
@@ -580,7 +580,7 @@
     "maxVolume": 1000,
     "smoothieConfigs": {
       "stepsPerMM": 2133.33,
-      "homePosition": 220,
+      "homePosition": 230.15,
       "travelDistance": 80
     },
     "defaultTipracks": [


### PR DESCRIPTION
The OT2 needed a bunch of annoying workarounds and config values to
determine the highest position the pipette could achieve, for checking
if it could clear a given piece of labware. On the OT3, this highest
position is just the home position of the effector, and doesn't require
extra config.
