### PR TITLE
refactor(api): ot3: send only to present nodes

### DIFF
--- a/hardware/opentrons_hardware/hardware_control/current_settings.py
+++ b/hardware/opentrons_hardware/hardware_control/current_settings.py
@@ -1,17 +1,17 @@
 """Utilities for updating the current settings on the OT3."""
-from typing import Dict, Tuple
+from typing import Tuple
 
-from opentrons_hardware.firmware_bindings.constants import NodeId
 from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
 from opentrons_hardware.firmware_bindings.messages import payloads
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     WriteMotorCurrentRequest,
 )
 from opentrons_hardware.firmware_bindings.utils import UInt32Field
+from .types import NodeMap
 
 
-CompleteCurrentSettings = Dict[NodeId, Tuple[float, float]]
-PartialCurrentSettings = Dict[NodeId, float]
+CompleteCurrentSettings = NodeMap[Tuple[float, float]]
+PartialCurrentSettings = NodeMap[float]
 
 
 async def set_currents(

--- a/hardware/opentrons_hardware/hardware_control/types.py
+++ b/hardware/opentrons_hardware/hardware_control/types.py
@@ -1,0 +1,8 @@
+"""Types and definitions for hardware bindings."""
+from typing import Mapping, TypeVar
+
+from opentrons_hardware.firmware_bindings.constants import NodeId
+
+MapPayload = TypeVar("MapPayload")
+
+NodeMap = Mapping[NodeId, MapPayload]


### PR DESCRIPTION
We should extend the behavior that only sends commands to nodes that
have previously responded on the bus to things like homing and setting
currents, so we don't incorrectly wait a long time for non-existent
parts to respond.
