### PR TITLE
refactor(api): ot3: better default motion settings

### DIFF
--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -33,19 +33,19 @@ DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad
         OT3AxisKind.X: 100,
         OT3AxisKind.Y: 100,
         OT3AxisKind.Z: 100,
-        OT3AxisKind.P: 100,
+        OT3AxisKind.P: 10,
     },
     high_throughput={
         OT3AxisKind.X: 100,
         OT3AxisKind.Y: 100,
         OT3AxisKind.Z: 100,
-        OT3AxisKind.P: 100,
+        OT3AxisKind.P: 10,
     },
     low_throughput={
         OT3AxisKind.X: 100,
         OT3AxisKind.Y: 100,
         OT3AxisKind.Z: 100,
-        OT3AxisKind.P: 100,
+        OT3AxisKind.P: 10,
     },
     two_low_throughput={
         OT3AxisKind.X: 100,
@@ -58,29 +58,29 @@ DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad
 
 DEFAULT_ACCELERATIONS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad(
     none={
-        OT3AxisKind.X: 100,
-        OT3AxisKind.Y: 100,
-        OT3AxisKind.Z: 100,
-        OT3AxisKind.P: 100,
+        OT3AxisKind.X: 1000,
+        OT3AxisKind.Y: 1000,
+        OT3AxisKind.Z: 1000,
+        OT3AxisKind.P: 10,
     },
     high_throughput={
-        OT3AxisKind.X: 100,
-        OT3AxisKind.Y: 100,
-        OT3AxisKind.Z: 100,
-        OT3AxisKind.P: 100,
+        OT3AxisKind.X: 1000,
+        OT3AxisKind.Y: 1000,
+        OT3AxisKind.Z: 1000,
+        OT3AxisKind.P: 10,
     },
     low_throughput={
-        OT3AxisKind.X: 100,
-        OT3AxisKind.Y: 100,
-        OT3AxisKind.Z: 100,
-        OT3AxisKind.P: 100,
+        OT3AxisKind.X: 1000,
+        OT3AxisKind.Y: 1000,
+        OT3AxisKind.Z: 1000,
+        OT3AxisKind.P: 10,
     },
     two_low_throughput={
-        OT3AxisKind.X: 100,
-        OT3AxisKind.Y: 100,
+        OT3AxisKind.X: 1000,
+        OT3AxisKind.Y: 1000,
     },
     gripper={
-        OT3AxisKind.Z: 100,
+        OT3AxisKind.Z: 1000,
     },
 )
 
@@ -91,19 +91,19 @@ DEFAULT_MAX_SPEED_DISCONTINUITY: Final[
         OT3AxisKind.X: 40,
         OT3AxisKind.Y: 40,
         OT3AxisKind.Z: 40,
-        OT3AxisKind.P: 10,
+        OT3AxisKind.P: 1,
     },
     high_throughput={
         OT3AxisKind.X: 40,
         OT3AxisKind.Y: 40,
         OT3AxisKind.Z: 40,
-        OT3AxisKind.P: 10,
+        OT3AxisKind.P: 1,
     },
     low_throughput={
         OT3AxisKind.X: 40,
         OT3AxisKind.Y: 40,
         OT3AxisKind.Z: 40,
-        OT3AxisKind.P: 10,
+        OT3AxisKind.P: 1,
     },
     two_low_throughput={
         OT3AxisKind.X: 40,
@@ -121,19 +121,19 @@ DEFAULT_DIRECTION_CHANGE_SPEED_DISCONTINUITY: Final[
         OT3AxisKind.X: 20,
         OT3AxisKind.Y: 20,
         OT3AxisKind.Z: 20,
-        OT3AxisKind.P: 20,
+        OT3AxisKind.P: 0.5,
     },
     high_throughput={
         OT3AxisKind.X: 20,
         OT3AxisKind.Y: 20,
         OT3AxisKind.Z: 20,
-        OT3AxisKind.P: 20,
+        OT3AxisKind.P: 0.5,
     },
     low_throughput={
         OT3AxisKind.X: 20,
         OT3AxisKind.Y: 20,
         OT3AxisKind.Z: 20,
-        OT3AxisKind.P: 20,
+        OT3AxisKind.P: 0.5,
     },
     two_low_throughput={
         OT3AxisKind.X: 20,


### PR DESCRIPTION
One pass of optimization to get the OT3 prototype to move around in a way that's both not awfully slow and still functions.