### PR TITLE
feat(hardware): ot3: add pipette querying

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -16,6 +16,7 @@ from typing import (
     cast,
     Set,
     TypeVar,
+    Iterator,
 )
 from opentrons.config.types import OT3Config, GantryLoad
 from opentrons.drivers.rpi_drivers.gpio_simulator import SimulatingGPIOCharDev
@@ -49,7 +50,10 @@ from opentrons_hardware.hardware_control.current_settings import (
     set_hold_current,
     set_currents,
 )
-from opentrons_hardware.firmware_bindings.constants import NodeId
+from opentrons_hardware.firmware_bindings.constants import (
+    NodeId,
+    PipetteName as FirmwarePipetteName,
+)
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     SetupRequest,
     EnableMotorRequest,
@@ -67,6 +71,7 @@ from opentrons.hardware_control.types import (
 )
 from opentrons_hardware.hardware_control.motion import MoveStopCondition
 from opentrons_hardware.hardware_control.types import NodeMap
+from opentrons_hardware.hardware_control.tools import detector, types as ohc_tool_types
 
 if TYPE_CHECKING:
     from opentrons_shared_data.pipette.dev_types import PipetteName, PipetteModel
@@ -78,11 +83,6 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-_FIXED_PIPETTE_ID: str = "P1KSV3120211118A01"
-_FIXED_PIPETTE_NAME: PipetteName = "p1000_single_gen3"
-_FIXED_PIPETTE_MODEL: PipetteModel = cast("PipetteModel", "p1000_single_v3.0")
-
-
 MapPayload = TypeVar("MapPayload")
 
 
@@ -91,6 +91,7 @@ class OT3Controller:
 
     _messenger: CanMessenger
     _position: Dict[NodeId, float]
+    _tool_detector: detector.OneshotToolDetector
 
     @classmethod
     async def build(cls, config: OT3Config) -> OT3Controller:
@@ -117,6 +118,7 @@ class OT3Controller:
         self._module_controls: Optional[AttachedModulesControl] = None
         self._messenger = CanMessenger(driver=driver)
         self._messenger.start()
+        self._tool_detector = detector.OneshotToolDetector(self._messenger)
         self._position = self._get_home_position()
         try:
             self._event_watcher = self._build_event_watcher()
@@ -272,18 +274,42 @@ class OT3Controller:
         Returns:
             A map of mount to pipette name.
         """
-        if (
-            expected.get(OT3Mount.RIGHT)
-            and expected.get(OT3Mount.RIGHT) != _FIXED_PIPETTE_NAME
-        ):
-            raise RuntimeError(f"only support {_FIXED_PIPETTE_NAME}  right now")
+        await self._probe_core()
+        attached = await self._tool_detector.detect()
 
-        return {
-            OT3Mount.RIGHT: {
-                "config": pipette_config.load(_FIXED_PIPETTE_MODEL, _FIXED_PIPETTE_ID),
-                "id": _FIXED_PIPETTE_ID,
+        def _synthesize_model_name(
+            name: FirmwarePipetteName, model: int
+        ) -> "PipetteModel":
+            return cast("PipetteModel", name.name + "_v3." + str(model))
+
+        def _build_attached_instr(
+            attached: ohc_tool_types.PipetteInformation,
+        ) -> AttachedInstrument:
+            return {
+                "config": pipette_config.load(
+                    _synthesize_model_name(attached.name, attached.model)
+                ),
+                "id": attached.serial,
             }
-        }
+
+        def _generate_attached_instrs(
+            attached: ohc_tool_types.ToolSummary,
+        ) -> Iterator[Tuple[OT3Mount, AttachedInstrument]]:
+            if attached.left:
+                yield (OT3Mount.LEFT, _build_attached_instr(attached.left))
+            if attached.right:
+                yield (OT3Mount.RIGHT, _build_attached_instr(attached.right))
+
+        current_tools = dict(_generate_attached_instrs(attached))
+        self._present_nodes -= set(
+            (
+                axis_to_node(OT3Axis.of_main_tool_actuator(mount))
+                for mount in (OT3Mount.RIGHT, OT3Mount.LEFT)
+            )
+        )
+        for mount in current_tools.keys():
+            self._present_nodes.add(axis_to_node(OT3Axis.of_main_tool_actuator(mount)))
+        return current_tools
 
     async def set_default_currents(self) -> None:
         """Set both run and hold currents from robot config to each node."""
@@ -468,6 +494,26 @@ class OT3Controller:
         return {
             node_to_axis(k): v for k, v in OT3Controller._get_home_position().items()
         }
+
+    async def _probe_core(self, timeout: float = 5.0) -> None:
+        """Update the list of core nodes present on the network.
+
+        Unlike probe_network, this always waits for the nodes that must be present for
+        a working machine, and no more.
+        """
+        core_nodes = set([NodeId.gantry_x, NodeId.gantry_y, NodeId.head])
+        core_present = await probe(self._messenger, core_nodes, timeout)
+
+        if NodeId.head in core_present:
+            core_present.remove(NodeId.head)
+            core_present.add(NodeId.head_r)
+            core_present.add(NodeId.head_l)
+
+        core_replaced = set(
+            [NodeId.gantry_x, NodeId.gantry_y, NodeId.head_l, NodeId.head_r]
+        )
+        self._present_nodes -= core_replaced
+        self._present_nodes |= core_present
 
     async def probe_network(self, timeout: float = 5.0) -> None:
         """Update the list of nodes present on the network.

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -181,3 +181,21 @@ async def test_get_attached_instruments(
     assert list(detected.keys()) == [OT3Mount.LEFT]
     assert detected[OT3Mount.LEFT]["id"] == "hello"
     assert detected[OT3Mount.LEFT]["config"].name == "p1000_single_gen3"
+
+
+def test_nodeid_replace_head():
+    assert OT3Controller._replace_head_node(set([NodeId.head, NodeId.gantry_x])) == set(
+        [NodeId.head_l, NodeId.head_r, NodeId.gantry_x]
+    )
+    assert OT3Controller._replace_head_node(set([NodeId.gantry_x])) == set(
+        [NodeId.gantry_x]
+    )
+    assert OT3Controller._replace_head_node(set([NodeId.head_l])) == set(
+        [NodeId.head_l]
+    )
+
+
+def test_nodeid_filter_probed_core():
+    assert OT3Controller._filter_probed_core_nodes(
+        set([NodeId.gantry_x, NodeId.pipette_left]), set([NodeId.gantry_y])
+    ) == set([NodeId.gantry_y, NodeId.pipette_left])

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -5,12 +5,18 @@ from opentrons.hardware_control.backends.ot3utils import axis_to_node
 from opentrons_hardware.drivers.can_bus import CanMessenger
 from opentrons.config.types import OT3Config
 from opentrons.config.robot_configs import build_config_ot3
-from opentrons_hardware.firmware_bindings.constants import NodeId
+from opentrons_hardware.firmware_bindings.constants import NodeId, PipetteName, ToolType
 from opentrons_hardware.drivers.can_bus.abstract_driver import AbstractCanDriver
-from opentrons.hardware_control.types import OT3Axis
+from opentrons.hardware_control.types import OT3Axis, OT3Mount
+
 from opentrons_hardware.hardware_control.motion import (
     MoveType,
     MoveStopCondition,
+)
+from opentrons_hardware.hardware_control.tools.detector import OneshotToolDetector
+from opentrons_hardware.hardware_control.tools.types import (
+    ToolSummary,
+    PipetteInformation,
 )
 
 
@@ -68,6 +74,19 @@ def mock_present_nodes(controller: OT3Controller):
         controller._present_nodes = old_pn
 
 
+@pytest.fixture
+def mock_tool_detector(controller: OT3Controller):
+    with patch.object(
+        controller._tool_detector, "detect", spec=controller._tool_detector.detect
+    ) as md:
+
+        md.return_value = ToolSummary(
+            right=None, left=None, gripper=ToolType.nothing_attached
+        )
+
+        yield md
+
+
 @pytest.mark.parametrize(
     "axes",
     [
@@ -89,7 +108,7 @@ async def test_home(
     assert home_move.acceleration_mm_sec_sq == 0
     assert home_move.move_type == MoveType.home
     assert home_move.stop_condition == MoveStopCondition.limit_switch
-    mock_move_group_run.assert_called_once()
+    mock_move_group_run.assert_awaited_once()
 
 
 async def test_home_only_present_nodes(controller: OT3Controller, mock_move_group_run):
@@ -99,10 +118,13 @@ async def test_home_only_present_nodes(controller: OT3Controller, mock_move_grou
     assert list(home_move.keys()) == [NodeId.gantry_x]
 
 
-async def test_probing(controller: OT3Controller) -> None:
+async def test_probing(
+    controller: OT3Controller, mock_tool_detector: AsyncMock
+) -> None:
     assert controller._present_nodes == set()
+
     call_count = 0
-    fake_nodes = set((NodeId.gantry_x, NodeId.head))
+    fake_nodes = set((NodeId.gantry_x, NodeId.head, NodeId.pipette_left))
     passed_expected = None
 
     async def fake_probe(can_messenger, expected, timeout):
@@ -113,7 +135,12 @@ async def test_probing(controller: OT3Controller) -> None:
         call_count += 1
         return fake_nodes
 
-    with patch("opentrons.hardware_control.backends.ot3controller.probe", fake_probe):
+    async def fake_gai(expected):
+        return {OT3Mount.RIGHT: {"config": "whatever"}}
+
+    with patch(
+        "opentrons.hardware_control.backends.ot3controller.probe", fake_probe
+    ), patch.object(controller, "get_attached_instruments", fake_gai):
         await controller.probe_network(timeout=0.1)
         assert call_count == 1
         assert passed_expected == set(
@@ -125,5 +152,32 @@ async def test_probing(controller: OT3Controller) -> None:
             )
         )
     assert controller._present_nodes == set(
-        (NodeId.gantry_x, NodeId.head_l, NodeId.head_r)
+        (
+            NodeId.gantry_x,
+            NodeId.head_l,
+            NodeId.head_r,
+            NodeId.pipette_left,
+        )
     )
+
+
+async def test_get_attached_instruments(
+    controller: OT3Controller, mock_tool_detector: OneshotToolDetector
+):
+    async def fake_probe(can_messenger, expected, timeout):
+        return set((NodeId.gantry_x, NodeId.gantry_y, NodeId.head))
+
+    with patch("opentrons.hardware_control.backends.ot3controller.probe", fake_probe):
+        assert await controller.get_attached_instruments({}) == {}
+
+    mock_tool_detector.return_value = ToolSummary(
+        left=PipetteInformation(name=PipetteName.p1000_single, model=0, serial="hello"),
+        right=None,
+        gripper=ToolType.nothing_attached,
+    )
+
+    with patch("opentrons.hardware_control.backends.ot3controller.probe", fake_probe):
+        detected = await controller.get_attached_instruments({})
+    assert list(detected.keys()) == [OT3Mount.LEFT]
+    assert detected[OT3Mount.LEFT]["id"] == "hello"
+    assert detected[OT3Mount.LEFT]["config"].name == "p1000_single_gen3"

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -1,0 +1,25 @@
+""" Tests for behaviors specific to the OT3 hardware controller.
+"""
+from typing import cast
+import pytest
+from opentrons.config.types import GantryLoad
+from opentrons.hardware_control.dev_types import PipetteDict
+from opentrons.hardware_control.types import OT3Mount
+from opentrons.hardware_control.ot3api import OT3API
+
+
+@pytest.mark.parametrize(
+    "attached,load",
+    (
+        (
+            {OT3Mount.RIGHT: {"channels": 8}, OT3Mount.LEFT: {"channels": 1}},
+            GantryLoad.TWO_LOW_THROUGHPUT,
+        ),
+        ({}, GantryLoad.NONE),
+        ({OT3Mount.LEFT: {"channels": 1}}, GantryLoad.LOW_THROUGHPUT),
+        ({OT3Mount.RIGHT: {"channels": 8}}, GantryLoad.LOW_THROUGHPUT),
+        ({OT3Mount.RIGHT: {"channels": 96}}, GantryLoad.HIGH_THROUGHPUT),
+    ),
+)
+def test_gantry_load_transform(attached, load):
+    assert OT3API._gantry_load_from_instruments(cast(PipetteDict, attached)) == load

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -54,6 +54,8 @@ class MessageId(int, Enum):
     device_info_response = 0x303
     task_info_request = 0x304
     task_info_response = 0x305
+    pipette_info_request = 0x306
+    pipette_info_response = 0x307
 
     stop_request = 0x00
 
@@ -152,3 +154,11 @@ class SensorType(int, Enum):
     humidity = 0x02
     temperature = 0x03
     pressure = 0x04
+
+
+@unique
+class PipetteName(int, Enum):
+    """High-level type of pipette."""
+
+    p1000_single = 0x00
+    p1000_multi = 0x01

--- a/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
@@ -2,7 +2,11 @@
 import enum
 
 from opentrons_hardware.firmware_bindings import utils, ErrorCode
-from opentrons_hardware.firmware_bindings.constants import ToolType, SensorType
+from opentrons_hardware.firmware_bindings.constants import (
+    ToolType,
+    SensorType,
+    PipetteName,
+)
 
 
 class FirmwareShortSHADataField(utils.BinaryFieldBase[bytes]):
@@ -85,3 +89,27 @@ class SensorTypeField(utils.UInt8Field):
         except ValueError:
             sensor_val = str(self.value)
         return f"{self.__class__.__name__}(value={sensor_val})"
+
+
+class PipetteNameField(utils.UInt16Field):
+    """high-level pipette name field."""
+
+    def __repr__(self) -> str:
+        """Print pipette."""
+        try:
+            pipette_val = PipetteName(self.value).name
+        except ValueError:
+            pipette_val = str(self.value)
+        return f"{self.__class__.__name__}(value={pipette_val})"
+
+
+class PipetteSerialField(utils.BinaryFieldBase[bytes]):
+    """The serial number of a pipette.
+
+    This is sized to handle only the datecode part of the serial
+    number; the full field can be synthesized from this, the
+    model number, and the name.
+    """
+
+    NUM_BYTES = 12
+    FORMAT = f"{NUM_BYTES}s"

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -391,3 +391,17 @@ class SensorThresholdResponse:  # noqa: D101
     message_id: Literal[
         MessageId.set_sensor_threshold_response
     ] = MessageId.set_sensor_threshold_response
+
+
+@dataclass
+class PipetteInfoRequest(EmptyPayloadMessage):  # noqa: D101
+    message_id: Literal[MessageId.pipette_info_request] = MessageId.pipette_info_request
+
+
+@dataclass
+class PipetteInfoResponse:  # noqa: D101
+    payload: payloads.PipetteInfoResponsePayload
+    payload_type: Type[BinarySerializable] = payloads.PipetteInfoResponsePayload
+    message_id: Literal[
+        MessageId.pipette_info_response
+    ] = MessageId.pipette_info_response

--- a/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
@@ -60,6 +60,8 @@ MessageDefinition = Union[
     defs.ReadFromSensorResponse,
     defs.SensorThresholdResponse,
     defs.HomeRequest,
+    defs.PipetteInfoRequest,
+    defs.PipetteInfoResponse,
 ]
 
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -12,6 +12,8 @@ from .fields import (
     FirmwareUpdateDataField,
     ErrorCodeField,
     SensorTypeField,
+    PipetteNameField,
+    PipetteSerialField,
 )
 from .. import utils
 
@@ -326,3 +328,12 @@ class SensorThresholdResponsePayload(utils.BinarySerializable):
 
     sensor: SensorTypeField
     threshold: utils.Int32Field
+
+
+@dataclass
+class PipetteInfoResponsePayload(utils.BinarySerializable):
+    """A response carrying data about an attached pipette."""
+
+    pipette_name: PipetteNameField
+    pipette_model: utils.UInt16Field
+    pipette_serial: PipetteSerialField

--- a/hardware/opentrons_hardware/hardware_control/tools/detector.py
+++ b/hardware/opentrons_hardware/hardware_control/tools/detector.py
@@ -1,17 +1,43 @@
 """Head tool detector."""
 
 import logging
-from typing import AsyncIterator
+import asyncio
+from typing import AsyncIterator, Set, Dict
 
 from opentrons_hardware.drivers.can_bus.can_messenger import WaitableCallback
-from opentrons_hardware.firmware_bindings.constants import ToolType
+from opentrons_hardware.firmware_bindings.constants import ToolType, PipetteName
 from opentrons_hardware.firmware_bindings.messages import message_definitions
 from opentrons_hardware.firmware_bindings import NodeId
 from opentrons_hardware.drivers.can_bus import CanMessenger
+from .types import PipetteInformation, ToolSummary
 
 from opentrons_hardware.hardware_control.tools.types import ToolDetectionResult
 
 log = logging.getLogger(__name__)
+
+
+def _handle_detection_result(
+    response: message_definitions.PushToolsDetectedNotification,
+) -> ToolDetectionResult:
+    def _check_tool(i: int) -> ToolType:
+        """Either return a valid tool or "undefined" on error."""
+        try:
+            return ToolType(i)
+        except ValueError:
+            return ToolType.undefined_tool
+
+    return ToolDetectionResult(
+        left=_check_tool(response.payload.z_motor.value),
+        right=_check_tool(response.payload.a_motor.value),
+        gripper=_check_tool(response.payload.gripper.value),
+    )
+
+
+async def _await_one_result(callback: WaitableCallback) -> ToolDetectionResult:
+    async for response, _ in callback:
+        if isinstance(response, message_definitions.PushToolsDetectedNotification):
+            return _handle_detection_result(response)
+    raise RuntimeError("Messenger closed before a tool was found")
 
 
 class ToolDetector:
@@ -33,22 +59,79 @@ class ToolDetector:
             # send request message once, to establish initial state
             attached_tool_request_message = message_definitions.AttachedToolsRequest()
             await self._messenger.send(
-                node_id=NodeId.host, message=attached_tool_request_message
+                node_id=NodeId.head, message=attached_tool_request_message
             )
-            async for response, arbitration_id in wc:
-                if isinstance(
-                    response, message_definitions.PushToolsDetectedNotification
-                ):
+            yield await _await_one_result(wc)
 
-                    def _check_tool(i: int) -> ToolType:
-                        """Either return a valid tool or "undefined" on error."""
-                        try:
-                            return ToolType(i)
-                        except ValueError:
-                            return ToolType.undefined_tool
 
-                    yield ToolDetectionResult(
-                        left=_check_tool(response.payload.z_motor.value),
-                        right=_check_tool(response.payload.a_motor.value),
-                        gripper=_check_tool(response.payload.gripper.value),
+class OneshotToolDetector:
+    """Class that detects tools for one command."""
+
+    def __init__(self, messenger: CanMessenger) -> None:
+        """Build a oneshot detector.
+
+        Args:
+           messenger: An initialized and running can messenger
+        """
+        self._messenger = messenger
+
+    @staticmethod
+    async def _await_responses(
+        callback: WaitableCallback, for_nodes: Set[NodeId]
+    ) -> Dict[NodeId, PipetteInformation]:
+        to_ret: Dict[NodeId, PipetteInformation] = {}
+
+        def _decode_or_default(orig: bytes) -> str:
+            try:
+                return orig.decode()
+            except UnicodeDecodeError:
+                return repr(orig)
+
+        while not for_nodes.issubset(set(to_ret.keys())):
+            async for response, arbitration_id in callback:
+                if isinstance(response, message_definitions.PipetteInfoResponse):
+                    to_ret[
+                        NodeId(arbitration_id.parts.originating_node_id)
+                    ] = PipetteInformation(
+                        name=PipetteName(response.payload.pipette_name.value),
+                        model=response.payload.pipette_model.value,
+                        serial=_decode_or_default(
+                            response.payload.pipette_serial.value
+                        ),
                     )
+                    break
+        return to_ret
+
+    async def detect(self, timeout_sec: float = 1.0) -> ToolSummary:
+        """Run once and detect tools."""
+        with WaitableCallback(self._messenger) as wc:
+            attached_status_request = message_definitions.AttachedToolsRequest()
+            await self._messenger.send(
+                node_id=NodeId.head, message=attached_status_request
+            )
+            attached = await _await_one_result(wc)
+            should_respond: Set[NodeId] = set()
+
+            def _should_query(attach_response: ToolType) -> bool:
+                return attach_response not in (
+                    ToolType.undefined_tool,
+                    ToolType.nothing_attached,
+                )
+
+            if _should_query(attached.left):
+                should_respond.add(NodeId.pipette_left)
+            if _should_query(attached.right):
+                should_respond.add(NodeId.pipette_right)
+
+            await self._messenger.send(
+                node_id=NodeId.broadcast,
+                message=message_definitions.PipetteInfoRequest(),
+            )
+            all_responses = await asyncio.wait_for(
+                self._await_responses(wc, should_respond), timeout=timeout_sec
+            )
+        return ToolSummary(
+            left=all_responses.get(NodeId.pipette_left, None),
+            right=all_responses.get(NodeId.pipette_right, None),
+            gripper=attached.gripper,
+        )

--- a/hardware/opentrons_hardware/hardware_control/tools/types.py
+++ b/hardware/opentrons_hardware/hardware_control/tools/types.py
@@ -1,7 +1,8 @@
 """tool types."""
 
+from typing import Optional
 from dataclasses import dataclass
-from opentrons_hardware.firmware_bindings.constants import ToolType
+from opentrons_hardware.firmware_bindings.constants import ToolType, PipetteName
 
 
 @dataclass(frozen=True)
@@ -10,4 +11,22 @@ class ToolDetectionResult:
 
     left: ToolType
     right: ToolType
+    gripper: ToolType
+
+
+@dataclass(frozen=True)
+class PipetteInformation:
+    """Model the information you can retrieve from a pipette."""
+
+    name: PipetteName
+    model: int
+    serial: str
+
+
+@dataclass(frozen=True)
+class ToolSummary:
+    """Model a full tool detection pass."""
+
+    left: Optional[PipetteInformation]
+    right: Optional[PipetteInformation]
     gripper: ToolType

--- a/hardware/tests/conftest.py
+++ b/hardware/tests/conftest.py
@@ -1,10 +1,12 @@
 """Pytest shared fixtures."""
-from typing import List
+from typing import List, Tuple
+from typing_extensions import Protocol
 
 import pytest
 from mock.mock import AsyncMock
-from opentrons_hardware.firmware_bindings import ArbitrationId
+from opentrons_hardware.firmware_bindings import ArbitrationId, ArbitrationIdParts
 from opentrons_hardware.firmware_bindings.messages import MessageDefinition
+from opentrons_hardware.firmware_bindings import NodeId
 
 from opentrons_hardware.drivers.can_bus import CanMessenger
 from opentrons_hardware.drivers.can_bus.can_messenger import MessageListenerCallback
@@ -39,3 +41,75 @@ def mock_messenger(can_message_notifier: MockCanMessageNotifier) -> AsyncMock:
     mock = AsyncMock(spec=CanMessenger)
     mock.add_listener.side_effect = can_message_notifier.add_listener
     return mock
+
+
+class CanLoopback:
+    """A class for capturing a mocked canbus and providing responses to messages.
+
+    When built on a mocked CanMessenger, hooks the messenger's send mocked method
+    and inserts provided responders.
+    """
+
+    class LoopbackResponder(Protocol):
+        """The provided callback function. Returned values will be sent."""
+
+        def __call__(
+            self,
+            node_id: NodeId,
+            message: MessageDefinition,
+        ) -> List[Tuple[NodeId, MessageDefinition, NodeId]]:
+            """Main call method that will usually be a function.
+
+            Args:
+                node_id: Destination node id
+                message: Message
+
+            Return value:
+                A tuple of (destination, message, source).
+            """
+            ...
+
+    def __init__(
+        self, mock_messenger: AsyncMock, mock_notifier: MockCanMessageNotifier
+    ) -> None:
+        """Build the loopback.
+
+        Args:
+            mock_messenger: The messenger to wrap
+            mock_notifier: A notifier to wrap
+        """
+        self._mock_messenger = mock_messenger
+        self._mock_notifier = mock_notifier
+        self._responders: List[CanLoopback.LoopbackResponder] = []
+        self._mock_messenger.send.side_effect = self._listener
+
+    def _listener(self, node_id: NodeId, message: MessageDefinition) -> None:
+        for responder in self._responders:
+            for response in responder(node_id, message):
+                self._mock_notifier.notify(
+                    message=response[1],
+                    arbitration_id=ArbitrationId(
+                        parts=ArbitrationIdParts(
+                            message_id=response[1].message_id,
+                            originating_node_id=response[2],
+                            node_id=response[0],
+                            function_code=0,
+                        )
+                    ),
+                )
+
+    def add_responder(self, responder: "CanLoopback.LoopbackResponder") -> None:
+        """Add a responder."""
+        self._responders.append(responder)
+
+    def remove_responder(self, responder: "CanLoopback.LoopbackResponder") -> None:
+        """Remove a responder."""
+        self._responders.remove(responder)
+
+
+@pytest.fixture
+def message_send_loopback(
+    mock_messenger: AsyncMock, can_message_notifier: MockCanMessageNotifier
+) -> CanLoopback:
+    """Provide a loopback object for injecting responses."""
+    return CanLoopback(mock_messenger, can_message_notifier)

--- a/hardware/tests/opentrons_hardware/hardware_control/tools/test_oneshot.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/tools/test_oneshot.py
@@ -1,0 +1,366 @@
+"""Test one-shot tool detector."""
+import asyncio
+from opentrons_hardware.firmware_bindings.constants import ToolType, PipetteName
+from opentrons_hardware.firmware_bindings.messages import (
+    MessageDefinition,
+)
+import pytest
+from mock import AsyncMock, call
+
+from opentrons_hardware.firmware_bindings.messages.fields import (
+    ToolField,
+    PipetteNameField,
+    PipetteSerialField,
+)
+from opentrons_hardware.firmware_bindings.utils import UInt16Field
+from opentrons_hardware.hardware_control.tools import detector, types
+from opentrons_hardware.firmware_bindings.messages import message_definitions, payloads
+from opentrons_hardware.firmware_bindings import (
+    NodeId,
+)
+from tests.conftest import CanLoopback
+from typing import List, Tuple
+
+
+@pytest.fixture
+def subject(
+    mock_messenger: AsyncMock,
+) -> detector.OneshotToolDetector:
+    """The test subject."""
+    return detector.OneshotToolDetector(messenger=mock_messenger)
+
+
+async def test_suppresses_undefined(
+    subject: detector.OneshotToolDetector,
+    mock_messenger: AsyncMock,
+    message_send_loopback: CanLoopback,
+) -> None:
+    """It should not query tools that are undefined."""
+
+    def responder(
+        node_id: NodeId, message: MessageDefinition
+    ) -> List[Tuple[NodeId, MessageDefinition, NodeId]]:
+        """Replaces mock send method."""
+        if isinstance(message, message_definitions.AttachedToolsRequest):
+            return [
+                (
+                    NodeId.host,
+                    message_definitions.PushToolsDetectedNotification(
+                        payload=payloads.ToolsDetectedNotificationPayload(
+                            z_motor=ToolField(ToolType.undefined_tool.value),
+                            a_motor=ToolField(ToolType.undefined_tool.value),
+                            gripper=ToolField(ToolType.undefined_tool.value),
+                        )
+                    ),
+                    NodeId.head,
+                )
+            ]
+        return []
+
+    message_send_loopback.add_responder(responder)
+    tools = await subject.detect()
+
+    assert tools.left is None
+    assert tools.right is None
+    assert tools.gripper == ToolType.undefined_tool
+    # Only the tools request should be sent - no followups for mounts with nothing on
+    # them
+    assert await mock_messenger.send.called_once_with(
+        node_id=NodeId.head,
+        message=message_definitions.AttachedToolsRequest(
+            payload=payloads.EmptyPayload()
+        ),
+    )
+
+
+async def test_handles_not_attached(
+    subject: detector.OneshotToolDetector,
+    mock_messenger: AsyncMock,
+    message_send_loopback: CanLoopback,
+) -> None:
+    """It should not query tools that are undefined."""
+
+    def responder(
+        node_id: NodeId, message: MessageDefinition
+    ) -> List[Tuple[NodeId, MessageDefinition, NodeId]]:
+        """Replaces mock send method."""
+        if isinstance(message, message_definitions.AttachedToolsRequest):
+            return [
+                (
+                    NodeId.host,
+                    message_definitions.PushToolsDetectedNotification(
+                        payload=payloads.ToolsDetectedNotificationPayload(
+                            z_motor=ToolField(ToolType.nothing_attached.value),
+                            a_motor=ToolField(ToolType.nothing_attached.value),
+                            gripper=ToolField(ToolType.nothing_attached.value),
+                        )
+                    ),
+                    NodeId.head,
+                )
+            ]
+        return []
+
+    message_send_loopback.add_responder(responder)
+
+    tools = await subject.detect()
+
+    assert tools.left is None
+    assert tools.right is None
+    assert tools.gripper == ToolType.nothing_attached
+
+    # Only the tools request should be sent - no followups for mounts with nothing on
+    # them
+    assert await mock_messenger.send.called_once_with(
+        node_id=NodeId.head,
+        message=message_definitions.AttachedToolsRequest(
+            payload=payloads.EmptyPayload()
+        ),
+    )
+
+
+async def test_sends_only_required_followups(
+    subject: detector.OneshotToolDetector,
+    mock_messenger: AsyncMock,
+    message_send_loopback: CanLoopback,
+) -> None:
+    """It should send pipette info followups only for present tools."""
+
+    def attached_tool_responder(
+        node_id: NodeId, message: MessageDefinition
+    ) -> List[Tuple[NodeId, MessageDefinition, NodeId]]:
+        if isinstance(message, message_definitions.AttachedToolsRequest):
+            return [
+                (
+                    NodeId.host,
+                    message_definitions.PushToolsDetectedNotification(
+                        payload=payloads.ToolsDetectedNotificationPayload(
+                            z_motor=ToolField(ToolType.nothing_attached.value),
+                            a_motor=ToolField(ToolType.pipette_multi_chan.value),
+                            gripper=ToolField(ToolType.nothing_attached.value),
+                        )
+                    ),
+                    NodeId.head,
+                )
+            ]
+        return []
+
+    def pipette_info_responder(
+        node_id: NodeId, message: MessageDefinition
+    ) -> List[Tuple[NodeId, MessageDefinition, NodeId]]:
+        if isinstance(message, message_definitions.PipetteInfoRequest):
+            payload = payloads.PipetteInfoResponsePayload(
+                pipette_name=PipetteNameField(PipetteName.p1000_single.value),
+                pipette_model=UInt16Field(2),
+                pipette_serial=PipetteSerialField(b"20220809A022"),
+            )
+            return [
+                (
+                    NodeId.host,
+                    message_definitions.PipetteInfoResponse(payload=payload),
+                    NodeId.pipette_right,
+                )
+            ]
+        return []
+
+    message_send_loopback.add_responder(attached_tool_responder)
+    message_send_loopback.add_responder(pipette_info_responder)
+
+    tools = await subject.detect()
+
+    assert tools.left is None
+    assert tools.right == types.PipetteInformation(
+        name=PipetteName.p1000_single, model=2, serial="20220809A022"
+    )
+
+    assert mock_messenger.send.mock_calls == [
+        call(
+            node_id=NodeId.head,
+            message=message_definitions.AttachedToolsRequest(
+                payload=payloads.EmptyPayload()
+            ),
+        ),
+        call(
+            node_id=NodeId.broadcast,
+            message=message_definitions.PipetteInfoRequest(
+                payload=payloads.EmptyPayload()
+            ),
+        ),
+    ]
+
+
+async def test_sends_all_required_followups(
+    subject: detector.OneshotToolDetector,
+    mock_messenger: AsyncMock,
+    message_send_loopback: CanLoopback,
+) -> None:
+    """It should send pipette info followups only for present tools."""
+
+    def attached_tool_responder(
+        node_id: NodeId, message: MessageDefinition
+    ) -> List[Tuple[NodeId, MessageDefinition, NodeId]]:
+        if isinstance(message, message_definitions.AttachedToolsRequest):
+            return [
+                (
+                    NodeId.host,
+                    message_definitions.PushToolsDetectedNotification(
+                        payload=payloads.ToolsDetectedNotificationPayload(
+                            z_motor=ToolField(ToolType.pipette_single_chan.value),
+                            a_motor=ToolField(ToolType.pipette_multi_chan.value),
+                            gripper=ToolField(ToolType.nothing_attached.value),
+                        )
+                    ),
+                    NodeId.head,
+                )
+            ]
+        return []
+
+    def pipette_info_responder(
+        node_id: NodeId, message: MessageDefinition
+    ) -> List[Tuple[NodeId, MessageDefinition, NodeId]]:
+        if isinstance(message, message_definitions.PipetteInfoRequest):
+            return [
+                (
+                    NodeId.host,
+                    message_definitions.PipetteInfoResponse(
+                        payload=payloads.PipetteInfoResponsePayload(
+                            pipette_name=PipetteNameField(
+                                PipetteName.p1000_single.value
+                            ),
+                            pipette_model=UInt16Field(2),
+                            pipette_serial=PipetteSerialField(b"20220809A022"),
+                        )
+                    ),
+                    NodeId.pipette_left,
+                ),
+                (
+                    NodeId.host,
+                    message_definitions.PipetteInfoResponse(
+                        payload=payloads.PipetteInfoResponsePayload(
+                            pipette_name=PipetteNameField(
+                                PipetteName.p1000_multi.value
+                            ),
+                            pipette_model=UInt16Field(4),
+                            pipette_serial=PipetteSerialField(b"20231005A220"),
+                        )
+                    ),
+                    NodeId.pipette_right,
+                ),
+            ]
+        return []
+
+    message_send_loopback.add_responder(attached_tool_responder)
+    message_send_loopback.add_responder(pipette_info_responder)
+
+    tools = await subject.detect()
+
+    assert tools.left == types.PipetteInformation(
+        name=PipetteName.p1000_single, model=2, serial="20220809A022"
+    )
+    assert tools.right == types.PipetteInformation(
+        name=PipetteName.p1000_multi, model=4, serial="20231005A220"
+    )
+
+    assert mock_messenger.send.mock_calls == [
+        call(
+            node_id=NodeId.head,
+            message=message_definitions.AttachedToolsRequest(
+                payload=payloads.EmptyPayload()
+            ),
+        ),
+        call(
+            node_id=NodeId.broadcast,
+            message=message_definitions.PipetteInfoRequest(
+                payload=payloads.EmptyPayload()
+            ),
+        ),
+    ]
+
+
+async def test_handles_bad_serials(
+    subject: detector.OneshotToolDetector,
+    mock_messenger: AsyncMock,
+    message_send_loopback: CanLoopback,
+) -> None:
+    """It should accept serial values that cannot be decoded."""
+
+    def attached_tool_responder(
+        node_id: NodeId, message: MessageDefinition
+    ) -> List[Tuple[NodeId, MessageDefinition, NodeId]]:
+        if isinstance(message, message_definitions.AttachedToolsRequest):
+            return [
+                (
+                    NodeId.host,
+                    message_definitions.PushToolsDetectedNotification(
+                        payload=payloads.ToolsDetectedNotificationPayload(
+                            z_motor=ToolField(ToolType.pipette_single_chan.value),
+                            a_motor=ToolField(ToolType.nothing_attached.value),
+                            gripper=ToolField(ToolType.nothing_attached.value),
+                        )
+                    ),
+                    NodeId.head,
+                )
+            ]
+        return []
+
+    def pipette_info_responder(
+        node_id: NodeId, message: MessageDefinition
+    ) -> List[Tuple[NodeId, MessageDefinition, NodeId]]:
+        if isinstance(message, message_definitions.PipetteInfoRequest):
+            payload = payloads.PipetteInfoResponsePayload(
+                pipette_name=PipetteNameField(PipetteName.p1000_multi.value),
+                pipette_model=UInt16Field(4),
+                pipette_serial=PipetteSerialField(
+                    b"\x00\x01\x02\x03\x04\0x05\x06\x07\x08\x09\x0a\x0b"
+                ),
+            )
+            return [
+                (
+                    NodeId.host,
+                    message_definitions.PipetteInfoResponse(payload=payload),
+                    NodeId.pipette_left,
+                )
+            ]
+        return []
+
+    message_send_loopback.add_responder(attached_tool_responder)
+    message_send_loopback.add_responder(pipette_info_responder)
+
+    tools = await subject.detect()
+
+    assert tools.left == types.PipetteInformation(
+        name=PipetteName.p1000_multi,
+        model=4,
+        serial="\x00\x01\x02\x03\x04\0x05\x06\x07\x08\x09\x0a\x0b",
+    )
+
+
+async def test_timeout(
+    subject: detector.OneshotToolDetector,
+    mock_messenger: AsyncMock,
+    message_send_loopback: CanLoopback,
+) -> None:
+    """It should accept serial values that cannot be decoded."""
+
+    def attached_tool_responder(
+        node_id: NodeId, message: MessageDefinition
+    ) -> List[Tuple[NodeId, MessageDefinition, NodeId]]:
+        if isinstance(message, message_definitions.AttachedToolsRequest):
+            return [
+                (
+                    NodeId.host,
+                    message_definitions.PushToolsDetectedNotification(
+                        payload=payloads.ToolsDetectedNotificationPayload(
+                            z_motor=ToolField(ToolType.nothing_attached.value),
+                            a_motor=ToolField(ToolType.pipette_single_chan.value),
+                            gripper=ToolField(ToolType.nothing_attached.value),
+                        )
+                    ),
+                    NodeId.head,
+                )
+            ]
+        return []
+
+    message_send_loopback.add_responder(attached_tool_responder)
+
+    with pytest.raises(asyncio.TimeoutError):
+        await subject.detect(timeout_sec=0.1)


### PR DESCRIPTION
With a new GetPipetteInfo message that can send back the name, model, and serial (similar semantics as in shared data) we can now hook up the pipette identification machinery to work the same as in the OT-2.

