### PR TITLE
chore(*): python: run coverage only in CI

### DIFF
--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -97,7 +97,7 @@ jobs:
           OT_VIRTUALENV_VERSION: ${{ matrix.python }}
       - if: ${{ matrix.with-ot-hardware == 'true' }}
         name: Test with opentrons_hardware
-        run: make -C api test
+        run: make -C api test-cov
       - if: ${{ matrix.with-ot-hardware == 'true' }}
         uses: 'codecov/codecov-action@v2'
         with:

--- a/.github/workflows/hardware-lint-test.yaml
+++ b/.github/workflows/hardware-lint-test.yaml
@@ -67,7 +67,7 @@ jobs:
         run: make -C hardware lint
 
       - name: Test
-        run: make -C hardware test
+        run: make -C hardware test-cov
 # TODO(amit, 2022-03-08): Enable once ot3 emulation is ready
 #        env:
 #          CAN_CHANNEL: vcan0

--- a/.github/workflows/notify-server-lint-test.yaml
+++ b/.github/workflows/notify-server-lint-test.yaml
@@ -8,19 +8,19 @@ on:
   push:
     paths:
       - 'Makefile'
-      - 'notify-server/**'
+      - 'notify-server/**/*'
       - '.github/workflows/notify-server-lint-test.yaml'
-      - 'api/**'
-      - 'hardware/**'
-      - '.github/actions/python/**'
+      - 'api/**/*'
+      - 'hardware/**/*'
+      - '.github/actions/python/**/*'
     tags-ignore:
       - '*'
   pull_request:
     paths:
       - 'Makefile'
-      - 'notify-server/**'
-      - 'api/**'
-      - 'hardware/**'
+      - 'notify-server/**/*'
+      - 'api/**/*'
+      - 'hardware/**/*'
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/notify-server-lint-test.yaml
+++ b/.github/workflows/notify-server-lint-test.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Lint
         run: make -C notify-server lint
       - name: Test
-        run: make -C notify-server test
+        run: make -C notify-server test-cov
       - name: 'Upload coverage report'
         uses: 'codecov/codecov-action@v2'
         with:

--- a/.github/workflows/robot-server-lint-test.yaml
+++ b/.github/workflows/robot-server-lint-test.yaml
@@ -69,10 +69,10 @@ jobs:
         name: Test without opentrons_hardware
         run: |
           make -C robot-server setup-ot2
-          make -C robot-server test
+          make -C robot-server test-cov
       - if: ${{ matrix.with-ot-hardware == 'true' }}
         name: Test with opentrons_hardware
-        run: make -C robot-server test
+        run: make -C robot-server test-cov
       - if: ${{ matrix.with-ot-hardware == 'true' }}
         uses: 'codecov/codecov-action@v2'
         with:

--- a/api/Makefile
+++ b/api/Makefile
@@ -35,7 +35,7 @@ simfile ?=
 # make test tests=tests/opentrons/tools/test_pipette_memory.py would run only the
 # specified test
 tests ?= tests
-test_opts ?=  --cov=src/opentrons --cov-report term-missing:skip-covered --cov-report xml:coverage.xml
+test_opts ?= $(and $(CI),--cov=src/opentrons --cov-report term-missing:skip-covered --cov-report xml:coverage.xml)
 
 # These variables must be overridden when make deploy or make deploy-staging is run
 # to set the auth details for pypi

--- a/api/Makefile
+++ b/api/Makefile
@@ -35,7 +35,8 @@ simfile ?=
 # make test tests=tests/opentrons/tools/test_pipette_memory.py would run only the
 # specified test
 tests ?= tests
-test_opts ?= $(and $(CI),--cov=src/opentrons --cov-report term-missing:skip-covered --cov-report xml:coverage.xml)
+cov_opts ?= --cov=src/opentrons --cov-report term-missing:skip-covered --cov-report xml:coverage.xml
+test_opts ?=
 
 # These variables must be overridden when make deploy or make deploy-staging is run
 # to set the auth details for pypi
@@ -106,6 +107,10 @@ sdist: $(sdist_file)
 .PHONY: test
 test:
 	$(pytest) $(tests) $(test_opts)
+
+.PHONY: test-cov
+test-cov:
+	$(pytest) $(tests) $(test_opts) $(cov_opts)
 
 .PHONY: test-ot2
 test-ot2:

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -22,7 +22,7 @@ sdist_file = dist/$(call python_get_sdistname,hardware,opentrons_hardware)
 # make test tests=tests/opentrons/tools/test_pipette_memory.py would run only the
 # specified test
 tests ?= tests
-test_opts ?=  --cov=opentrons_hardware --cov-report term-missing:skip-covered --cov-report xml:coverage.xml
+test_opts ?=  $(and $(CI),--cov=opentrons_hardware --cov-report term-missing:skip-covered --cov-report xml:coverage.xml)
 
 # These variables must be overridden when make deploy or make deploy-staging is run
 # to set the auth details for pypi

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -22,7 +22,8 @@ sdist_file = dist/$(call python_get_sdistname,hardware,opentrons_hardware)
 # make test tests=tests/opentrons/tools/test_pipette_memory.py would run only the
 # specified test
 tests ?= tests
-test_opts ?=  $(and $(CI),--cov=opentrons_hardware --cov-report term-missing:skip-covered --cov-report xml:coverage.xml)
+cov_opts ?= --cov=opentrons_hardware --cov-report term-missing:skip-covered --cov-report xml:coverage.xml
+test_opts ?=
 
 # These variables must be overridden when make deploy or make deploy-staging is run
 # to set the auth details for pypi
@@ -80,6 +81,10 @@ sdist: $(sdist_file)
 .PHONY: test
 test:
 	$(pytest) -m 'not requires_emulator' $(tests) $(test_opts)
+
+.PHONY: test-cov
+test-cov:
+	$(pytest) -m 'not requires_emulator' $(tests) $(test_opts) $(cov_opts)
 
 .PHONY: test-with-emulator
 test-with-emulator:

--- a/notify-server/Makefile
+++ b/notify-server/Makefile
@@ -31,7 +31,8 @@ sdist_file = dist/$(call python_get_sdistname,notify-server,notify_server)
 # make test tests=tests/opentrons/tools/test_qc_scripts.py would run only the
 # specified test
 tests ?= tests
-test_opts ?= $(and $(CI),--cov=$(SRC_PATH) --cov-report term-missing:skip-covered --cov-report xml:coverage.xml)
+cov_opts ?= --cov=$(SRC_PATH) --cov-report term-missing:skip-covered --cov-report xml:coverage.xml
+test_opts ?=
 
 # Host key location for buildroot robot
 br_ssh_key ?= $(default_ssh_key)
@@ -92,6 +93,10 @@ sdist: $(sdist_file)
 .PHONY: test
 test:
 	$(pytest) $(tests) $(test_opts)
+
+.PHONY: test
+test:
+	$(pytest) $(tests) $(test_opts) $(cov_opts)
 
 .PHONY: lint
 lint: $(ot_py_sources)

--- a/notify-server/Makefile
+++ b/notify-server/Makefile
@@ -31,7 +31,7 @@ sdist_file = dist/$(call python_get_sdistname,notify-server,notify_server)
 # make test tests=tests/opentrons/tools/test_qc_scripts.py would run only the
 # specified test
 tests ?= tests
-test_opts ?=  --cov=$(SRC_PATH) --cov-report term-missing:skip-covered --cov-report xml:coverage.xml
+test_opts ?= $(and $(CI),--cov=$(SRC_PATH) --cov-report term-missing:skip-covered --cov-report xml:coverage.xml)
 
 # Host key location for buildroot robot
 br_ssh_key ?= $(default_ssh_key)

--- a/notify-server/Makefile
+++ b/notify-server/Makefile
@@ -94,8 +94,8 @@ sdist: $(sdist_file)
 test:
 	$(pytest) $(tests) $(test_opts)
 
-.PHONY: test
-test:
+.PHONY: test-cov
+test-cov:
 	$(pytest) $(tests) $(test_opts) $(cov_opts)
 
 .PHONY: lint

--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -23,7 +23,8 @@ sdist_file = dist/$(call python_get_sdistname,robot-server,robot_server)
 # make test tests=tests/opentrons/tools/test_qc_scripts.py would run only the
 # specified test
 tests ?= tests
-test_opts ?= $(and $(CI),--cov=$(SRC_PATH) --cov-report term-missing:skip-covered --cov-report xml:coverage.xml)
+cov_opts ?= --cov=$(SRC_PATH) --cov-report term-missing:skip-covered --cov-report xml:coverage.xml
+test_opts ?=
 
 # Host key location for buildroot robot
 br_ssh_key ?= $(default_ssh_key)
@@ -99,6 +100,10 @@ sdist: $(sdist_file)
 .PHONY: test
 test:
 	$(pytest) $(tests) $(test_opts)
+
+.PHONY: test-cov
+test-cov:
+	$(pytest) $(tests) $(test_opts) $(cov_opts)
 
 .PHONY: lint
 lint:

--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -23,7 +23,7 @@ sdist_file = dist/$(call python_get_sdistname,robot-server,robot_server)
 # make test tests=tests/opentrons/tools/test_qc_scripts.py would run only the
 # specified test
 tests ?= tests
-test_opts ?= --cov=$(SRC_PATH) --cov-report term-missing:skip-covered --cov-report xml:coverage.xml
+test_opts ?= $(and $(CI),--cov=$(SRC_PATH) --cov-report term-missing:skip-covered --cov-report xml:coverage.xml)
 
 # Host key location for buildroot robot
 br_ssh_key ?= $(default_ssh_key)


### PR DESCRIPTION
Python projects now only run coverage in CI, since in practice it's
unreadable as terminal output and just gets in the way of devs.
