### PR TITLE
fix(docs): don't center text on API doc pages

### DIFF
--- a/api/docs/static/override_sphinx.css
+++ b/api/docs/static/override_sphinx.css
@@ -81,7 +81,6 @@ div.sphinxsidebar h3 a:hover,
     div.documentwrapper {
         float: none;
         background: #fff;
-        text-align: center;
     }
     div.sphinxsidebar {
         display: block;


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

Closes #9695.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

Found and eliminated the offending line of responsive CSS.

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

I don't think this CSS file applies to anything outside of docs, and even if it did I'm not sure we'd want the alignment shift at tablet breakpoint to happen there either.