### PR TITLE
style(component color): update blue/enabled color

### DIFF
--- a/app/src/pages/Robots/RobotSettings/UpdateBuildroot/styles.css
+++ b/app/src/pages/Robots/RobotSettings/UpdateBuildroot/styles.css
@@ -58,7 +58,7 @@
   height: 100%;
   border: solid 2px var(--c-white);
   border-radius: 3px;
-  background-color: #006fff;
+  background-color: #006cfa;
   transition: width ease-in-out 0.5s;
 }
 
@@ -77,7 +77,7 @@
 
 .progress_spinner span {
   transition: all 500ms ease;
-  background: #006fff;
+  background: #006cfa;
   height: 0.5rem;
   width: 0.5rem;
   display: inline-block;

--- a/components/src/primitives/__tests__/Btn.test.tsx
+++ b/components/src/primitives/__tests__/Btn.test.tsx
@@ -144,7 +144,7 @@ describe('Btn primitive component', () => {
     it('should render an app primary button variant', () => {
       const wrapper = shallow(<NewPrimaryBtn />)
 
-      expect(wrapper).toHaveStyleRule('background-color', '#006fff')
+      expect(wrapper).toHaveStyleRule('background-color', '#006cfa')
       expect(wrapper).toHaveStyleRule('border-radius', '2px')
       expect(wrapper).toHaveStyleRule('color', '#ffffff')
       expect(wrapper).toHaveStyleRule('font-size', '0.875rem')
@@ -157,11 +157,11 @@ describe('Btn primitive component', () => {
       expect(wrapper).toHaveStyleRule('text-transform', 'uppercase')
 
       // focus
-      expect(wrapper).toHaveStyleRule('background-color', '#006fff', {
+      expect(wrapper).toHaveStyleRule('background-color', '#006cfa', {
         modifier: ':focus',
       })
       // hover
-      expect(wrapper).toHaveStyleRule('background-color', '#006fff', {
+      expect(wrapper).toHaveStyleRule('background-color', '#006cfa', {
         modifier: ':focus',
       })
 
@@ -179,7 +179,7 @@ describe('Btn primitive component', () => {
     it('should render an app secondary button variant', () => {
       const wrapper = shallow(<NewSecondaryBtn />)
 
-      expect(wrapper).toHaveStyleRule('color', '#006fff')
+      expect(wrapper).toHaveStyleRule('color', '#006cfa')
       expect(wrapper).toHaveStyleRule('border-radius', '2px')
       expect(wrapper).toHaveStyleRule('background-color', '#ffffff')
       expect(wrapper).toHaveStyleRule('font-size', '0.875rem')
@@ -192,12 +192,12 @@ describe('Btn primitive component', () => {
       expect(wrapper).toHaveStyleRule('text-transform', 'uppercase')
 
       // focus
-      expect(wrapper).toHaveStyleRule('color', '#006fff', {
+      expect(wrapper).toHaveStyleRule('color', '#006cfa', {
         modifier: ':focus',
       })
 
       // hover
-      expect(wrapper).toHaveStyleRule('color', '#006fff', {
+      expect(wrapper).toHaveStyleRule('color', '#006cfa', {
         modifier: ':focus',
       })
 

--- a/components/src/styles/colors.css
+++ b/components/src/styles/colors.css
@@ -1,7 +1,7 @@
 :root {
   /* ot brand */
   --c-mustard: #ffd252;
-  --c-blue: #006fff;
+  --c-blue: #006cfa;
   --c-light-blue: color-mod(var(--c-blue) lightness(85%));
 
   /*

--- a/components/src/styles/colors.ts
+++ b/components/src/styles/colors.ts
@@ -14,7 +14,7 @@ export const C_TRANSPARENT = 'transparent'
 export const C_DARK_BLACK = '#16212d'
 
 // brand colors
-export const C_BLUE = '#006fff'
+export const C_BLUE = '#006cfa'
 export const C_MINT = '#00bfa8'
 export const C_AQUAMARINE = '#eefff8'
 export const C_POWDER_BLUE = '#f1f8ff'

--- a/components/src/ui-style-constants/colors.ts
+++ b/components/src/ui-style-constants/colors.ts
@@ -7,7 +7,7 @@ export const black = '#000000'
 
 // colors with states
 export const blueFocus = '#deecff'
-export const blue = '#006fff'
+export const blue = '#006cfa'
 export const blueHover = '#0061e0'
 export const bluePressed = '#0050b8'
 


### PR DESCRIPTION
This PR is for #9719. 
Update blue/enabled colour. Updated blue/enabled color code from `#006fff` to
`#006cfa`.

fix #9719

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- Updated blue/enabled hex code from `#006fff` to `#006cfa`
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
The codes under `app` don't use `#006fff` for blue/enabled. They include `.tsx`, `css`.

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low 
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
