### PR TITLE
feat(app): add H-S 2d render to Power On page in Wizard

### DIFF
--- a/app/src/organisms/Devices/HeaterShakerWizard/PowerOn.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/PowerOn.tsx
@@ -24,8 +24,7 @@ interface PowerOnProps {
 
 export function PowerOn(props: PowerOnProps): JSX.Element {
   const { t } = useTranslation('heater_shaker')
-  //  TODO(jr, 2022-02-18): change this to heater shaker model when it exists
-  const moduleDef = getModuleDef2('magneticModuleV2')
+  const moduleDef = getModuleDef2('heaterShakerModuleV1')
 
   return (
     <React.Fragment>

--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/PowerOn.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/PowerOn.test.tsx
@@ -13,7 +13,6 @@ const render = (props: React.ComponentProps<typeof PowerOn>) => {
 describe('PowerOn', () => {
   let props: React.ComponentProps<typeof PowerOn>
 
-  // TODO(jr, 2022-02-18): fix module model to heater shaker when it exists
   beforeEach(() => {
     props = {
       attachedModule: mockHeaterShaker,
@@ -33,7 +32,7 @@ describe('PowerOn', () => {
   it('renders heater shaker SVG with info with module connected', () => {
     const { getByText } = render(props)
     getByText('Connected')
-    getByText('Magnetic Module GEN2')
+    getByText('Heater Shaker Module GEN1')
     getByText('USB Port 1 via hub')
   })
 
@@ -43,7 +42,7 @@ describe('PowerOn', () => {
     }
     const { getByText } = render(props)
     getByText('Not connected')
-    getByText('Magnetic Module GEN2')
+    getByText('Heater Shaker Module GEN1')
     getByText('No USB Port Yet')
   })
 })

--- a/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
@@ -8,6 +8,7 @@ import {
   getAttachedModules,
   HEATERSHAKER_MODULE_TYPE,
 } from '../../../redux/modules'
+import { PrimaryButton, SecondaryButton } from '../../../atoms/Buttons'
 import { Introduction } from './Introduction'
 import { KeyParts } from './KeyParts'
 import { AttachModule } from './AttachModule'
@@ -15,15 +16,9 @@ import { AttachAdapter } from './AttachAdapter'
 import { PowerOn } from './PowerOn'
 import { TestShake } from './TestShake'
 import {
-  ALIGN_CENTER,
-  COLORS,
   DIRECTION_ROW,
   Flex,
   JUSTIFY_SPACE_BETWEEN,
-  PrimaryBtn,
-  SecondaryBtn,
-  SPACING,
-  TEXT_TRANSFORM_NONE,
   JUSTIFY_FLEX_END,
   Tooltip,
   useHoverTooltip,
@@ -110,25 +105,17 @@ export const HeaterShakerWizard = (
           }
         >
           {currentPage > 0 ? (
-            <SecondaryBtn
-              alignItems={ALIGN_CENTER}
-              color={COLORS.blue}
-              borderRadius={SPACING.spacingS}
-              textTransform={TEXT_TRANSFORM_NONE}
+            <SecondaryButton
               data-testid={`wizard_back_btn`}
               onClick={() => setCurrentPage(currentPage => currentPage - 1)}
             >
               {t('back')}
-            </SecondaryBtn>
+            </SecondaryButton>
           ) : null}
           {currentPage <= 5 ? (
-            <PrimaryBtn
-              alignItems={ALIGN_CENTER}
+            <PrimaryButton
               disabled={!isPrimaryCTAEnabled}
               {...targetProps}
-              backgroundColor={COLORS.blue}
-              borderRadius={SPACING.spacingS}
-              textTransform={TEXT_TRANSFORM_NONE}
               data-testid={`wizard_next_btn`}
               onClick={
                 currentPage === 5
@@ -142,7 +129,7 @@ export const HeaterShakerWizard = (
                   {t('module_is_not_connected')}
                 </Tooltip>
               ) : null}
-            </PrimaryBtn>
+            </PrimaryButton>
           ) : null}
         </Flex>
       </Interstitial>

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/index.tsx
@@ -91,8 +91,7 @@ export function ModuleSetup(props: ModuleSetupProps): JSX.Element {
         const { model } = moduleDef
         return (
           <React.Fragment key={index}>
-            {/* @ts-expect-error: this is always false until heater shaker is added to model */}
-            {model === 'heatershakermoduleV1' && (
+            {model === 'heaterShakerModuleV1' && (
               <Flex key="heater_shaker_banner">
                 <HeaterShakerBanner displayName={moduleDef.displayName} />
               </Flex>


### PR DESCRIPTION
closes #9519

# Overview

This PR adds the H-S 2d render to the `powerOn` page in the H-S setup wizard. This also updates the Heater shaker wizard setup buttons and changes `ModuleSetup` to look for a heater shaker model in order to render the wizard banner.

<img width="932" alt="Screen Shot 2022-03-22 at 4 24 05 PM" src="https://user-images.githubusercontent.com/66035149/159572750-e7c393e9-0af1-4725-8ca5-83091712a9d8.png">


# Changelog

- adds H-S 2d render

# Review requests

- make sure the page logic makes sense and it matches figma

# Risk assessment

low