### PR TITLE
chore(build): Use pull request triggers

### DIFF
--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -74,7 +74,7 @@ jobs:
           - os: 'macos-latest'
             with-ot-hardware: 'true'
           - os: 'macos-latest'
-            python: '3.7'
+            python: '3.10'
           - python: '3.10'
             with-ot-hardware: 'true'
     runs-on: '${{ matrix.os }}'

--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -6,7 +6,6 @@ name: 'API test/lint/deploy'
 on:
   # Most of the time, we run on pull requests, which lets us handle external PRs
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'api/**/*'
       - 'Makefile'
@@ -28,8 +27,7 @@ on:
       - '.github/workflows/utils.js'
     branches:
       - 'edge'
-      - '*release*'
-      - '*bump*'
+      - 'release'
       - '*hotfix*'
     tags:
       - 'v*'

--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -6,12 +6,16 @@ name: 'API test/lint/deploy'
 on:
   # Most of the time, we run on pull requests, which lets us handle external PRs
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'api/**/*'
       - 'Makefile'
       - 'shared-data/**/*'
       - '!shared-data/js/**'
       - 'hardware/**/*'
+      - '.github/workflows/api-test-lint-deploy.yaml'
+      - '.github/actions/python/**/*'
+      - '.github/workflows/utils.js'
   push:
     paths:
       - 'api/**'
@@ -23,10 +27,14 @@ on:
       - '.github/actions/python/**/*'
       - '.github/workflows/utils.js'
     branches:
-      - '*'
+      - 'edge'
+      - '*release*'
+      - '*bump*'
+      - '*hotfix*'
     tags:
       - 'v*'
   workflow_dispatch:
+
 
 defaults:
   run:
@@ -67,6 +75,8 @@ jobs:
             with-ot-hardware: 'true'
           - os: 'macos-latest'
             with-ot-hardware: 'true'
+          - os: 'macos-latest'
+            python: '3.7'
           - python: '3.10'
             with-ot-hardware: 'true'
     runs-on: '${{ matrix.os }}'

--- a/.github/workflows/hardware-lint-test.yaml
+++ b/.github/workflows/hardware-lint-test.yaml
@@ -11,12 +11,12 @@ on:
       - 'hardware/**'
       - '.github/workflows/hardware-lint-test.yaml'
       - '.github/actions/python/**'
-    branches:  # non-release only - release handled elsewhere
+    branches:
       - 'edge'
+      - 'release'
     tags-ignore:
       - '*'
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'Makefile'
       - 'hardware/**'

--- a/.github/workflows/hardware-lint-test.yaml
+++ b/.github/workflows/hardware-lint-test.yaml
@@ -11,15 +11,18 @@ on:
       - 'hardware/**'
       - '.github/workflows/hardware-lint-test.yaml'
       - '.github/actions/python/**'
-    branches-ignore: # ignore any release-related thing (handled elsewhere)
-      - 'release'
-      - 'chore_release-**'
+    branches:  # non-release only - release handled elsewhere
+      - 'edge'
     tags-ignore:
       - '*'
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'Makefile'
       - 'hardware/**'
+      - '.github/workflows/hardware-lint-test.yaml'
+      - '.github/actions/python/**'
+
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/notify-server-lint-test.yaml
+++ b/.github/workflows/notify-server-lint-test.yaml
@@ -15,13 +15,11 @@ on:
       - '.github/actions/python/**/*'
     branches:
       - 'edge'
-      - '*release*'
-      - '*bump*'
+      - 'release'
       - '*hotfix*'
     tags-ignore:
       - '*'
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'Makefile'
       - 'notify-server/**/*'

--- a/.github/workflows/notify-server-lint-test.yaml
+++ b/.github/workflows/notify-server-lint-test.yaml
@@ -13,9 +13,15 @@ on:
       - 'api/**/*'
       - 'hardware/**/*'
       - '.github/actions/python/**/*'
+    branches:
+      - 'edge'
+      - '*release*'
+      - '*bump*'
+      - '*hotfix*'
     tags-ignore:
       - '*'
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'Makefile'
       - 'notify-server/**/*'

--- a/.github/workflows/robot-server-lint-test.yaml
+++ b/.github/workflows/robot-server-lint-test.yaml
@@ -16,12 +16,12 @@ on:
       - 'notify-server/**/*'
       - '.github/workflows/robot-server-test-lint.yaml'
       - '.github/actions/python/**'
-    branches-ignore: # ignore any release-related thing (handled elsewhere)
-      - 'release'
-      - 'chore_release-**'
+    branches:  # non-release only - release handled elsewhere
+      - 'edge'
     tags-ignore:
       - '*'
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'api/**/*'
       - 'hardware/**/*'

--- a/.github/workflows/robot-server-lint-test.yaml
+++ b/.github/workflows/robot-server-lint-test.yaml
@@ -16,12 +16,13 @@ on:
       - 'notify-server/**/*'
       - '.github/workflows/robot-server-test-lint.yaml'
       - '.github/actions/python/**'
-    branches:  # non-release only - release handled elsewhere
+    branches:
       - 'edge'
+      - 'release'
+      - '*hotfix*'
     tags-ignore:
       - '*'
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'api/**/*'
       - 'hardware/**/*'

--- a/.github/workflows/shared-data-test-lint-deploy.yaml
+++ b/.github/workflows/shared-data-test-lint-deploy.yaml
@@ -13,13 +13,11 @@ on:
       - '.github/workflows/utils.js'
     branches:
       - 'edge'
-      - '*release*'
-      - '*bump*'
+      - 'release'
       - '*hotfix*'
     tags:
       - 'v*'
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'Makefile'
       - 'shared-data/*/**'

--- a/.github/workflows/shared-data-test-lint-deploy.yaml
+++ b/.github/workflows/shared-data-test-lint-deploy.yaml
@@ -12,13 +12,20 @@ on:
       - '.github/actions/python/**/*'
       - '.github/workflows/utils.js'
     branches:
-      - '*'
+      - 'edge'
+      - '*release*'
+      - '*bump*'
+      - '*hotfix*'
     tags:
       - 'v*'
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'Makefile'
       - 'shared-data/*/**'
+      - '.github/workflows/shared-data-test-lint-deploy.yaml'
+      - '.github/actions/python/**/*'
+      - '.github/workflows/utils.js'
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/shared-data-test-lint-deploy.yaml
+++ b/.github/workflows/shared-data-test-lint-deploy.yaml
@@ -60,6 +60,9 @@ jobs:
         # TODO(mc, 2022-02-24): expand this matrix to 3.8 and 3.9,
         # preferably in a nightly cronjob on edge or something
         python: ['3.7', '3.10']
+        exclude:
+          - os: 'macos-latest'
+            python: '3.10'
     runs-on: '${{ matrix.os }}'
     steps:
       - uses: 'actions/checkout@v2'

--- a/.github/workflows/update-server-lint-test.yaml
+++ b/.github/workflows/update-server-lint-test.yaml
@@ -10,20 +10,17 @@ on:
       - 'Makefile'
       - '.github/workflows/update-server-lint-test.yaml'
       - '.github/actions/python/**'
-    branches-ignore: # ignore any release-related thing (handled elsewhere)
-      - 'release'
-      - 'chore_release-*'
+    branches: # ignore any release-related thing (handled elsewhere)
+      - 'edge'
     tags-ignore:
       - '*'
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'update-server/**/*'
       - 'Makefile'
       - '.github/workflows/update-server-lint-test.yaml'
       - '.github/actions/python/**'
-    branches-ignore: # ignore any release-related thing (handled elsewhere)
-      - 'release'
-      - 'chore_release-*'
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
Use pull request triggers as the primary mechanism for testing pull
requests, rather than push triggers.

Github workflows have a characteristically very low limit on the number
of concurrent MacOS jobs, no matter the subscription level, and has a
limit of 50 non-macOS jobs. Combined with the number of jobs that we
run, this greatly limits the velocity of merging and checking code.

However, the number of jobs that we run often represents duplicate work
- our test/lint workflows run on both pull_request (targeting the
predicted merge branch that github automatically creates) and on
push (targeting whatever obj/ref was just pushed). By using pull_request
triggers and limiting push to release, we can greatly cut down on the
amount of work we do, while still testing the same code.

The hole that's left is running tests on branches that developers have
pushed but do not want to open a pull request for, or that has a merge
conflict that prevents pull request checks from automatically running.
In this case, we have workflow_dispatch triggers so that the checks can
be run through the web UI, and we should probably add magic-comment
triggers for a similar thing.
