### PR TITLE
chore(robot-server): Add sqlalchemy2-stubs

### DIFF
--- a/robot-server/Pipfile
+++ b/robot-server/Pipfile
@@ -1,13 +1,24 @@
 [[source]]
+
 url = "https://pypi.python.org/simple"
 verify_ssl = true
 name = "pypi"
 
+
 [requires]
+
 python_version = "3.7"
 
+
 [dev-packages]
+
 robot-server = {editable = true, path = "."}
+
+# pytest dependencies on windows, spec'd here to force lockfile inclusion
+# https://github.com/pypa/pipenv/issues/4408#issuecomment-668324177
+atomicwrites = {version="==1.4.0", sys_platform="== 'win32'"}
+colorama = {version="==0.4.4", sys_platform="== 'win32'"}
+
 pytest = "~=6.1"
 pytest-aiohttp = "==0.3.0"
 pytest-cov = "==2.10.1"
@@ -24,14 +35,13 @@ flake8-noqa = "~=1.1.0"
 decoy = "~=1.10.0"
 httpx = "==0.18.*"
 black = "==22.1.0"
-# pytest dependencies on windows, spec'd here to force lockfile inclusion
-# https://github.com/pypa/pipenv/issues/4408#issuecomment-668324177
-atomicwrites = {version="==1.4.0", sys_platform="== 'win32'"}
-colorama = {version="==0.4.4", sys_platform="== 'win32'"}
 types-requests = "==2.25.6"
 types-mock = "==4.0.1"
+sqlalchemy2-stubs = "==0.0.2a21"
+
 
 [packages]
+
 opentrons = {editable = true, path = "../api"}
 opentrons-shared-data = {editable = true, path = "../shared-data/python"}
 notify-server = {editable = true, path = "../notify-server"}

--- a/robot-server/Pipfile.lock
+++ b/robot-server/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bc6767a9061c14a3a23800547131935752e4bfdd779ea4e0e3cbaef6749bc8a4"
+            "sha256": "5d4eacd8b3a5568f3e4e09ef6e2fea283685276d52d4e24880e08c277675f783"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1375,6 +1375,14 @@
             ],
             "version": "==2.2.0"
         },
+        "sqlalchemy2-stubs": {
+            "hashes": [
+                "sha256:207e3d8a36fc032d325f4eec89e0c6760efe81d07e978513d8c9b14f108dcd0c",
+                "sha256:bd4a3d5ca7ff9d01b2245e1b26304d6b2ec4daf43a01faf40db9e09245679433"
+            ],
+            "index": "pypi",
+            "version": "==0.0.2a21"
+        },
         "starlette": {
             "hashes": [
                 "sha256:3c8e48e52736b3161e34c9f0e8153b4f32ec5d8995a3ee1d59410d92f75162ed",
@@ -1480,7 +1488,7 @@
                 "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14",
                 "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_full_version < '4.0.0'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==1.26.9"
         },
         "uvicorn": {

--- a/robot-server/mypy.ini
+++ b/robot-server/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-plugins = pydantic.mypy, decoy.mypy
+plugins = pydantic.mypy, decoy.mypy, sqlalchemy.ext.mypy.plugin
 show_error_codes = True
 strict = True
 # TODO(mc, 2021-09-12): remove these exclusions


### PR DESCRIPTION
# Overview

This PR adds the [`sqlalchemy2-stubs`](https://github.com/sqlalchemy/sqlalchemy2-stubs) package as a robot-server dev dependency.

# Background

The SQLAlchemy type-checking situation seems pretty bad:

* SQLAlchemy 2 promises to do it right, but there's no scheduled release date for it.
* SQLAlchemy 1.4 appears to require at least standalone stubs, plus maybe also a mypy plugin.

  `sqlalchemy2-stubs` [is the official solution](https://docs.sqlalchemy.org/en/14/orm/extensions/mypy.html), despite being proclaimed in various places to be unstable. (It "should now be considered as legacy, even though it is still necessary for full Mypy support when using SQLAlchemy 1.4." 🙃)

* There's also [`sqlalchemy-stubs`](https://github.com/sqlalchemy/sqlalchemy-stubs) (without the `2`), a more mature set of stubs published by DropBox. However, its support for SQLAlchemy 1.4 [seems](https://github.com/dropbox/sqlalchemy-stubs/issues/224) [spotty](https://github.com/dropbox/sqlalchemy-stubs/issues/222).

# Review requests

* Do we agree that `sqlalchemy2-stubs` is the least bad option, for now?

# Risk assessment

No risk to production code. This just adds a dev dependency.