### PR TITLE
refactor(hardware): Hardware can messenger filter

### DIFF
--- a/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 import asyncio
 from inspect import Traceback
-from typing import List, Optional, Callable, Tuple
+from typing import List, Optional, Callable, Tuple, Dict
 import logging
 
 from opentrons_hardware.drivers.can_bus.abstract_driver import AbstractCanDriver
@@ -26,6 +26,10 @@ MessageListenerCallback = Callable[[MessageDefinition, ArbitrationId], None]
 """Incoming message listener."""
 
 
+MessageListenerCallbackFilter = Callable[[ArbitrationId], bool]
+"""A function used to filter incoming messages. Returns true to accept message."""
+
+
 class CanMessenger:
     """High level can messaging class wrapping a CanDriver.
 
@@ -41,7 +45,7 @@ class CanMessenger:
             driver: The can bus driver to use.
         """
         self._drive = driver
-        self._listeners: List[MessageListenerCallback] = []
+        self._listeners: Dict[MessageListenerCallback, Tuple[MessageListenerCallback, MessageListenerCallbackFilter]] = {}
         self._task: Optional[asyncio.Task[None]] = None
 
     async def send(self, node_id: NodeId, message: MessageDefinition) -> None:
@@ -82,13 +86,13 @@ class CanMessenger:
         else:
             log.warning("task not running.")
 
-    def add_listener(self, listener: MessageListenerCallback) -> None:
+    def add_listener(self, listener: MessageListenerCallback, filter: Optional[MessageListenerCallbackFilter] = None) -> None:
         """Add a message listener."""
-        self._listeners.append(listener)
+        self._listeners[listener] = listener, filter
 
     def remove_listener(self, listener: MessageListenerCallback) -> None:
         """Remove a message listener."""
-        self._listeners.remove(listener)
+        del self._listeners[listener]
 
     async def _read_task_shield(self) -> None:
         try:
@@ -112,7 +116,9 @@ class CanMessenger:
                         f"Received <--\n\tarbitration_id: {message.arbitration_id},\n\t"
                         f"payload: {build}"
                     )
-                    for listener in self._listeners:
+                    for listener, filter in self._listeners.values():
+                        if filter and not filter(message.arbitration_id):
+                            continue
                         listener(message_definition(payload=build), message.arbitration_id)  # type: ignore[arg-type]  # noqa: E501
                 except BinarySerializableException:
                     log.exception(f"Failed to build from {message}")
@@ -123,13 +129,15 @@ class CanMessenger:
 class WaitableCallback:
     """MessageListenerCallback that can be awaited or iterated."""
 
-    def __init__(self, messenger: CanMessenger) -> None:
+    def __init__(self, messenger: CanMessenger, filter: Optional[MessageListenerCallbackFilter] = None) -> None:
         """Constructor.
 
         Args:
             messenger: Messenger to listen on.
+            filter: Optional message filtering function
         """
         self._messenger = messenger
+        self._filter = filter
         self._queue: asyncio.Queue[
             Tuple[MessageDefinition, ArbitrationId]
         ] = asyncio.Queue()
@@ -142,7 +150,7 @@ class WaitableCallback:
 
     def __enter__(self) -> WaitableCallback:
         """Enter context manager."""
-        self._messenger.add_listener(self)
+        self._messenger.add_listener(self, self._filter)
         return self
 
     def __exit__(

--- a/hardware/tests/conftest.py
+++ b/hardware/tests/conftest.py
@@ -1,5 +1,5 @@
 """Pytest shared fixtures."""
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 from typing_extensions import Protocol
 
 import pytest
@@ -9,7 +9,10 @@ from opentrons_hardware.firmware_bindings.messages import MessageDefinition
 from opentrons_hardware.firmware_bindings import NodeId
 
 from opentrons_hardware.drivers.can_bus import CanMessenger
-from opentrons_hardware.drivers.can_bus.can_messenger import MessageListenerCallback
+from opentrons_hardware.drivers.can_bus.can_messenger import (
+    MessageListenerCallback,
+    MessageListenerCallbackFilter,
+)
 
 
 class MockCanMessageNotifier:
@@ -19,7 +22,11 @@ class MockCanMessageNotifier:
         """Constructor."""
         self._listeners: List[MessageListenerCallback] = []
 
-    def add_listener(self, listener: MessageListenerCallback) -> None:
+    def add_listener(
+        self,
+        listener: MessageListenerCallback,
+        filter: Optional[MessageListenerCallbackFilter],
+    ) -> None:
         """Add listener."""
         self._listeners.append(listener)
 

--- a/hardware/tests/opentrons_hardware/drivers/can_bus/test_can_messenger.py
+++ b/hardware/tests/opentrons_hardware/drivers/can_bus/test_can_messenger.py
@@ -95,7 +95,6 @@ async def test_send(
     )
 
 
-
 async def test_listen_messages(
     subject: CanMessenger, incoming_messages: Queue[CanMessage]
 ) -> None:
@@ -166,7 +165,12 @@ async def test_filter_messages(
     # Set up a listener
     listener = Mock(spec=MessageListenerCallback)
     # Add a filter that rejects all but the message in there queue
-    subject.add_listener(listener, lambda arbitration_id: arbitration_id.parts.message_id != MessageId.get_move_group_request)
+    subject.add_listener(
+        listener,
+        lambda arbitration_id: bool(
+            arbitration_id.parts.message_id != MessageId.get_move_group_request
+        ),
+    )
 
     # Start the listener
     subject.start()
@@ -194,7 +198,10 @@ async def test_waitable_callback_context() -> None:
 async def test_waitable_callback_context_with_filter() -> None:
     """It should add itself and remove itself using context manager."""
     mock_messenger = Mock(spec=CanMessenger)
-    some_func = lambda x: True
+
+    def some_func(a: ArbitrationId) -> bool:
+        return False
+
     with WaitableCallback(mock_messenger, some_func) as callback:
         mock_messenger.add_listener.assert_called_once_with(callback, some_func)
     mock_messenger.remove_listener.assert_called_once_with(callback)

--- a/hardware/tests/opentrons_hardware/drivers/can_bus/test_can_messenger.py
+++ b/hardware/tests/opentrons_hardware/drivers/can_bus/test_can_messenger.py
@@ -95,6 +95,7 @@ async def test_send(
     )
 
 
+
 async def test_listen_messages(
     subject: CanMessenger, incoming_messages: Queue[CanMessage]
 ) -> None:
@@ -143,9 +144,57 @@ async def test_listen_messages(
     )
 
 
+async def test_filter_messages(
+    subject: CanMessenger, incoming_messages: Queue[CanMessage]
+) -> None:
+    """It should not call listener if matches filter."""
+    # Add a received message to the driver
+    incoming_messages.put_nowait(
+        CanMessage(
+            arbitration_id=ArbitrationId(
+                parts=ArbitrationIdParts(
+                    message_id=MessageId.get_move_group_request,
+                    node_id=0,
+                    function_code=0,
+                    originating_node_id=NodeId.gantry_x,
+                )
+            ),
+            data=b"\1",
+        )
+    )
+
+    # Set up a listener
+    listener = Mock(spec=MessageListenerCallback)
+    # Add a filter that rejects all but the message in there queue
+    subject.add_listener(listener, lambda arbitration_id: arbitration_id.parts.message_id != MessageId.get_move_group_request)
+
+    # Start the listener
+    subject.start()
+
+    # Wait for the incoming messages to be read
+    while not incoming_messages.empty():
+        await asyncio.sleep(0.01)
+
+    # Clean up
+    subject.remove_listener(listener)
+    await subject.stop()
+
+    # Listener should not be called
+    listener.assert_not_called()
+
+
 async def test_waitable_callback_context() -> None:
     """It should add itself and remove itself using context manager."""
     mock_messenger = Mock(spec=CanMessenger)
     with WaitableCallback(mock_messenger) as callback:
-        mock_messenger.add_listener.assert_called_once_with(callback)
+        mock_messenger.add_listener.assert_called_once_with(callback, None)
+    mock_messenger.remove_listener.assert_called_once_with(callback)
+
+
+async def test_waitable_callback_context_with_filter() -> None:
+    """It should add itself and remove itself using context manager."""
+    mock_messenger = Mock(spec=CanMessenger)
+    some_func = lambda x: True
+    with WaitableCallback(mock_messenger, some_func) as callback:
+        mock_messenger.add_listener.assert_called_once_with(callback, some_func)
     mock_messenger.remove_listener.assert_called_once_with(callback)

--- a/robot-server/emulator_ot3.env
+++ b/robot-server/emulator_ot3.env
@@ -1,4 +1,0 @@
-# Environment for use with OT2 and module emulators
-OT_ROBOT_SERVER_ws_domain_socket=
-# Set up URIs for emulator
-OT_SMOOTHIE_EMULATOR_URI=socket://127.0.0.1:9996

--- a/robot-server/emulator_ot3.env
+++ b/robot-server/emulator_ot3.env
@@ -1,0 +1,4 @@
+# Environment for use with OT2 and module emulators
+OT_ROBOT_SERVER_ws_domain_socket=
+# Set up URIs for emulator
+OT_SMOOTHIE_EMULATOR_URI=socket://127.0.0.1:9996


### PR DESCRIPTION
# Overview

`CanMessenger` supports adding an optional per listener filtering function. The filter accepts an arbitration id and should return `True` if it wants to receive a message. Passing `None` for the filter function means all messages will be sent to the listener.

# Changelog

- Tests
- Add definition of filtering function
- Add argument to add_listener
- Use the filter

# Review requests


# Risk assessment

None