### PR TITLE
refactor(app): touchups and refactor of moduleOverflowMenu

### DIFF
--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -62,5 +62,6 @@
   "input_out_of_range": "Input out of range",
   "module_status_range": "Between {{min}} - {{max}} {{unit}}",
   "module_controls": "Module Controls",
-  "hot_to_the_touch": "<block>Module is <bold>hot</bold> to the touch</block>"
+  "hot_to_the_touch": "<block>Module is <bold>hot</bold> to the touch</block>",
+  "module_actions_unavailable": "Module actions unavailable while protocol is running"
 }

--- a/app/src/organisms/Devices/ModuleCard/ModuleOverflowMenu.tsx
+++ b/app/src/organisms/Devices/ModuleCard/ModuleOverflowMenu.tsx
@@ -6,296 +6,53 @@ import {
   Tooltip,
   useHoverTooltip,
 } from '@opentrons/components'
-import { useCreateLiveCommandMutation } from '@opentrons/react-api-client'
-import {
-  CreateCommand,
-  HEATERSHAKER_MODULE_TYPE,
-  MAGNETIC_MODULE_TYPE,
-  TEMPERATURE_MODULE_TYPE,
-  THERMOCYCLER_MODULE_TYPE,
-} from '@opentrons/shared-data'
 import { MenuList } from '../../../atoms/MenuList'
 import { MenuItem } from '../../../atoms/MenuList/MenuItem'
-import { HeaterShakerWizard } from '../HeaterShakerWizard'
+import { useModuleOverflowMenu } from './hooks'
 
 import type { AttachedModule } from '../../../redux/modules/types'
-import type {
-  HeaterShakerCloseLatchCreateCommand,
-  HeaterShakerDeactivateHeaterCreateCommand,
-  HeaterShakerOpenLatchCreateCommand,
-  HeaterShakerStopShakeCreateCommand,
-  MagneticModuleDisengageMagnetCreateCommand,
-  TCDeactivateBlockCreateCommand,
-  TCDeactivateLidCreateCommand,
-  TemperatureModuleDeactivateCreateCommand,
-} from '@opentrons/shared-data/protocol/types/schemaV6/command/module'
 
 interface ModuleOverflowMenuProps {
   module: AttachedModule
-  handleClick: (isSecondary: boolean) => void
+  handleClick: () => void
   handleAboutClick: () => void
   handleTestShakeClick: () => void
+  handleWizardClick: () => void
 }
 
 export const ModuleOverflowMenu = (
   props: ModuleOverflowMenuProps
 ): JSX.Element | null => {
   const { t } = useTranslation(['device_details', 'heater_shaker'])
-  const { module, handleClick, handleAboutClick, handleTestShakeClick } = props
-  const [showWizard, setShowWizard] = React.useState<boolean>(false)
-  const { createLiveCommand } = useCreateLiveCommandMutation()
+  const {
+    module,
+    handleClick,
+    handleAboutClick,
+    handleTestShakeClick,
+    handleWizardClick,
+  } = props
   const [targetProps, tooltipProps] = useHoverTooltip()
-
-  const isLatchClosed =
-    module.type === 'heaterShakerModuleType' &&
-    (module.data.labwareLatchStatus === 'idle_closed' ||
-      module.data.labwareLatchStatus === 'closing')
-
-  let commandType: CreateCommand['commandType']
-  switch (module.type) {
-    case 'temperatureModuleType': {
-      commandType = 'temperatureModule/deactivate'
-      break
-    }
-    case 'magneticModuleType': {
-      commandType = 'magneticModule/disengageMagnet'
-      break
-    }
-    case 'thermocyclerModuleType': {
-      commandType =
-        module.status !== 'idle'
-          ? 'thermocycler/deactivateBlock'
-          : 'thermocycler/deactivateLid'
-      break
-    }
-    case 'heaterShakerModuleType': {
-      commandType =
-        module.data.speedStatus !== 'idle'
-          ? 'heaterShakerModule/stopShake'
-          : 'heaterShakerModule/deactivateHeater'
-      break
-    }
-  }
-
-  const deactivateCommand:
-    | TemperatureModuleDeactivateCreateCommand
-    | MagneticModuleDisengageMagnetCreateCommand
-    | HeaterShakerDeactivateHeaterCreateCommand
-    | TCDeactivateLidCreateCommand
-    | TCDeactivateBlockCreateCommand
-    | HeaterShakerStopShakeCreateCommand = {
-    commandType: commandType,
-    params: { moduleId: module.id },
-  }
-
-  const handleDeactivation = (): void => {
-    createLiveCommand({
-      command: deactivateCommand,
-    }).catch((e: Error) => {
-      console.error(
-        `error setting module status with command type ${deactivateCommand.commandType}: ${e.message}`
-      )
-    })
-  }
-
-  const getOnClickCommand = (isSecondary: boolean = false): void => {
-    if (module.type === THERMOCYCLER_MODULE_TYPE) {
-      if (isSecondary) {
-        if (module.data.lidTarget !== null) {
-          return handleDeactivation()
-        } else {
-          return handleClick(isSecondary)
-        }
-      } else {
-        if (module.status !== 'idle') {
-          return handleDeactivation()
-        } else {
-          return handleClick(isSecondary)
-        }
-      }
-    } else if (module.type === HEATERSHAKER_MODULE_TYPE) {
-      if (isSecondary) {
-        if (module.data.speedStatus !== 'idle') {
-          return handleDeactivation()
-        } else {
-          return handleClick(isSecondary)
-        }
-      } else {
-        if (module.status !== 'idle') {
-          return handleDeactivation()
-        } else {
-          return handleClick(isSecondary)
-        }
-      }
-    } else if (module.type === TEMPERATURE_MODULE_TYPE) {
-      if (module.status !== 'idle') {
-        return handleDeactivation()
-      } else {
-        return handleClick(isSecondary)
-      }
-    } else {
-      if (module.status !== 'disengaged') {
-        return handleDeactivation()
-      } else {
-        return handleClick(isSecondary)
-      }
-    }
-  }
-
-  const latchCommand:
-    | HeaterShakerOpenLatchCreateCommand
-    | HeaterShakerCloseLatchCreateCommand = {
-    commandType: isLatchClosed
-      ? 'heaterShakerModule/openLatch'
-      : 'heaterShakerModule/closeLatch',
-    params: { moduleId: module.id },
-  }
-
-  const handleLatch = (): void => {
-    createLiveCommand({
-      command: latchCommand,
-    }).catch((e: Error) => {
-      console.error(
-        `error setting module status with command type ${latchCommand.commandType}: ${e.message}`
-      )
-    })
-  }
-
-  const menuItemsByModuleType = {
-    thermocyclerModuleType: [
-      {
-        setSetting:
-          module.type === THERMOCYCLER_MODULE_TYPE &&
-          module.data.lidTarget !== null
-            ? t('overflow_menu_deactivate_lid')
-            : t('overflow_menu_lid_temp'),
-        isSecondary: true,
-        disabledReason: false,
-      },
-      {
-        setSetting:
-          module.type === THERMOCYCLER_MODULE_TYPE && module.status !== 'idle'
-            ? t('overflow_menu_deactivate_block')
-            : t('overflow_menu_set_block_temp'),
-        isSecondary: false,
-        disabledReason: false,
-      },
-    ],
-    temperatureModuleType: [
-      {
-        setSetting:
-          module.type === TEMPERATURE_MODULE_TYPE && module.status !== 'idle'
-            ? t('overflow_menu_deactivate_temp')
-            : t('overflow_menu_mod_temp'),
-        isSecondary: false,
-        disabledReason: false,
-      },
-    ],
-    magneticModuleType: [
-      {
-        setSetting:
-          module.type === MAGNETIC_MODULE_TYPE && module.status !== 'disengaged'
-            ? t('overflow_menu_disengage')
-            : t('overflow_menu_engage'),
-
-        isSecondary: false,
-        disabledReason: false,
-      },
-    ],
-    heaterShakerModuleType: [
-      {
-        setSetting:
-          module.type === HEATERSHAKER_MODULE_TYPE && module.status !== 'idle'
-            ? t('deactivate', { ns: 'heater_shaker' })
-            : t('set_temperature', { ns: 'heater_shaker' }),
-        isSecondary: false,
-        disabledReason: false,
-      },
-      {
-        setSetting:
-          module.type === HEATERSHAKER_MODULE_TYPE && module.status === 'idle'
-            ? t('set_shake_speed', { ns: 'heater_shaker' })
-            : t('stop_shaking', { ns: 'heater_shaker' }),
-        isSecondary: true,
-        disabledReason:
-          module.type === HEATERSHAKER_MODULE_TYPE &&
-          (module.data.labwareLatchStatus === 'idle_open' ||
-            module.data.labwareLatchStatus === 'opening'),
-      },
-    ],
-  }
-
-  const isLatchDisabled =
-    module.type === HEATERSHAKER_MODULE_TYPE &&
-    module.data.speedStatus !== 'idle'
-
-  const AboutModuleBtn = (
-    <MenuItem
-      minWidth="10rem"
-      key={`about_module_${module.model}`}
-      data-testid={`about_module_${module.model}`}
-      onClick={() => handleAboutClick()}
-    >
-      {t('overflow_menu_about')}
-    </MenuItem>
-  )
-  const LabwareLatchBtn = (
-    <>
-      <MenuItem
-        minWidth="10rem"
-        key={`hs_labware_latch_${module.model}`}
-        data-testid={`hs_labware_latch_${module.model}`}
-        onClick={handleLatch}
-        disabled={isLatchDisabled}
-        {...targetProps}
-      >
-        {t(isLatchClosed ? 'open_labware_latch' : 'close_labware_latch', {
-          ns: 'heater_shaker',
-        })}
-      </MenuItem>
-      {/* TODO:(jr, 3/11/22): update Tooltip to new design */}
-      {isLatchDisabled ? (
-        <Tooltip {...tooltipProps} key={`tooltip_latch_${module.model}`}>
-          {t('cannot_open_latch', { ns: 'heater_shaker' })}
-        </Tooltip>
-      ) : null}
-    </>
-  )
-  const AttachToDeckBtn = (
-    <MenuItem
-      minWidth="10rem"
-      key={`hs_attach_to_deck_${module.model}`}
-      data-testid={`hs_attach_to_deck_${module.model}`}
-      onClick={() => setShowWizard(true)}
-    >
-      {t('how_to_attach_to_deck', { ns: 'heater_shaker' })}
-    </MenuItem>
-  )
-  const TestShakeBtn = (
-    <MenuItem
-      minWidth="10rem"
-      onClick={() => handleTestShakeClick()}
-      key={`hs_test_shake_btn_${module.model}`}
-    >
-      {t('test_shake', { ns: 'heater_shaker' })}
-    </MenuItem>
+  const { menuOverflowItemsByModuleType } = useModuleOverflowMenu(
+    module,
+    handleAboutClick,
+    handleTestShakeClick,
+    handleWizardClick,
+    handleClick
   )
 
   return (
-    <React.Fragment>
-      {showWizard && (
-        <HeaterShakerWizard onCloseClick={() => setShowWizard(false)} />
-      )}
+    <>
       <Flex position={POSITION_RELATIVE}>
         <MenuList
           buttons={[
-            menuItemsByModuleType[module.type].map((item, index) => {
+            menuOverflowItemsByModuleType[module.type].map((item, index) => {
+              console.log(item)
               return (
                 <>
                   <MenuItem
                     minWidth="10rem"
                     key={`${index}_${module.model}`}
-                    onClick={() => getOnClickCommand(item.isSecondary)}
+                    onClick={() => item.onClick(item.isSecondary)}
                     data-testid={`module_setting_${module.model}`}
                     disabled={item.disabledReason}
                     {...targetProps}
@@ -310,15 +67,13 @@ export const ModuleOverflowMenu = (
                       {t('cannot_shake', { ns: 'heater_shaker' })}
                     </Tooltip>
                   )}
+                  {item.menuButtons}
                 </>
               )
             }),
-            module.type === HEATERSHAKER_MODULE_TYPE
-              ? [LabwareLatchBtn, AboutModuleBtn, AttachToDeckBtn, TestShakeBtn]
-              : AboutModuleBtn,
           ]}
         />
       </Flex>
-    </React.Fragment>
+    </>
   )
 }

--- a/app/src/organisms/Devices/ModuleCard/ModuleOverflowMenu.tsx
+++ b/app/src/organisms/Devices/ModuleCard/ModuleOverflowMenu.tsx
@@ -46,7 +46,6 @@ export const ModuleOverflowMenu = (
         <MenuList
           buttons={[
             menuOverflowItemsByModuleType[module.type].map((item, index) => {
-              console.log(item)
               return (
                 <>
                   <MenuItem

--- a/app/src/organisms/Devices/ModuleCard/ModuleOverflowMenu.tsx
+++ b/app/src/organisms/Devices/ModuleCard/ModuleOverflowMenu.tsx
@@ -45,33 +45,31 @@ export const ModuleOverflowMenu = (
       <Flex position={POSITION_RELATIVE}>
         <MenuList
           buttons={[
-            menuOverflowItemsByModuleType[module.type].map(
-              (item: any, index: any) => {
-                return (
-                  <>
-                    <MenuItem
-                      minWidth="10rem"
-                      key={`${index}_${module.model}`}
-                      onClick={() => item.onClick(item.isSecondary)}
-                      data-testid={`module_setting_${module.model}`}
-                      disabled={item.disabledReason}
-                      {...targetProps}
+            menuOverflowItemsByModuleType[module.type].map((item, index) => {
+              return (
+                <>
+                  <MenuItem
+                    minWidth="10rem"
+                    key={`${index}_${module.model}`}
+                    onClick={() => item.onClick(item.isSecondary)}
+                    data-testid={`module_setting_${module.model}`}
+                    disabled={item.disabledReason}
+                    {...targetProps}
+                  >
+                    {item.setSetting}
+                  </MenuItem>
+                  {item.disabledReason && (
+                    <Tooltip
+                      {...tooltipProps}
+                      key={`tooltip_${index}_${module.model}`}
                     >
-                      {item.setSetting}
-                    </MenuItem>
-                    {item.disabledReason && (
-                      <Tooltip
-                        {...tooltipProps}
-                        key={`tooltip_${index}_${module.model}`}
-                      >
-                        {t('cannot_shake', { ns: 'heater_shaker' })}
-                      </Tooltip>
-                    )}
-                    {item.menuButtons}
-                  </>
-                )
-              }
-            ),
+                      {t('cannot_shake', { ns: 'heater_shaker' })}
+                    </Tooltip>
+                  )}
+                  {item.menuButtons}
+                </>
+              )
+            }),
           ]}
         />
       </Flex>

--- a/app/src/organisms/Devices/ModuleCard/ModuleOverflowMenu.tsx
+++ b/app/src/organisms/Devices/ModuleCard/ModuleOverflowMenu.tsx
@@ -45,31 +45,33 @@ export const ModuleOverflowMenu = (
       <Flex position={POSITION_RELATIVE}>
         <MenuList
           buttons={[
-            menuOverflowItemsByModuleType[module.type].map((item, index) => {
-              return (
-                <>
-                  <MenuItem
-                    minWidth="10rem"
-                    key={`${index}_${module.model}`}
-                    onClick={() => item.onClick(item.isSecondary)}
-                    data-testid={`module_setting_${module.model}`}
-                    disabled={item.disabledReason}
-                    {...targetProps}
-                  >
-                    {item.setSetting}
-                  </MenuItem>
-                  {item.disabledReason && (
-                    <Tooltip
-                      {...tooltipProps}
-                      key={`tooltip_${index}_${module.model}`}
+            menuOverflowItemsByModuleType[module.type].map(
+              (item: any, index: any) => {
+                return (
+                  <>
+                    <MenuItem
+                      minWidth="10rem"
+                      key={`${index}_${module.model}`}
+                      onClick={() => item.onClick(item.isSecondary)}
+                      data-testid={`module_setting_${module.model}`}
+                      disabled={item.disabledReason}
+                      {...targetProps}
                     >
-                      {t('cannot_shake', { ns: 'heater_shaker' })}
-                    </Tooltip>
-                  )}
-                  {item.menuButtons}
-                </>
-              )
-            }),
+                      {item.setSetting}
+                    </MenuItem>
+                    {item.disabledReason && (
+                      <Tooltip
+                        {...tooltipProps}
+                        key={`tooltip_${index}_${module.model}`}
+                      >
+                        {t('cannot_shake', { ns: 'heater_shaker' })}
+                      </Tooltip>
+                    )}
+                    {item.menuButtons}
+                  </>
+                )
+              }
+            ),
           ]}
         />
       </Flex>

--- a/app/src/organisms/Devices/ModuleCard/ModuleOverflowMenu.tsx
+++ b/app/src/organisms/Devices/ModuleCard/ModuleOverflowMenu.tsx
@@ -8,13 +8,14 @@ import {
 } from '@opentrons/components'
 import { MenuList } from '../../../atoms/MenuList'
 import { MenuItem } from '../../../atoms/MenuList/MenuItem'
-import { useModuleOverflowMenu } from './hooks'
+import { MenuItemsByModuleType, useModuleOverflowMenu } from './hooks'
 
 import type { AttachedModule } from '../../../redux/modules/types'
+import type { ModuleType } from '@opentrons/shared-data'
 
 interface ModuleOverflowMenuProps {
   module: AttachedModule
-  handleClick: () => void
+  handleSlideoutClick: () => void
   handleAboutClick: () => void
   handleTestShakeClick: () => void
   handleWizardClick: () => void
@@ -26,7 +27,7 @@ export const ModuleOverflowMenu = (
   const { t } = useTranslation(['device_details', 'heater_shaker'])
   const {
     module,
-    handleClick,
+    handleSlideoutClick,
     handleAboutClick,
     handleTestShakeClick,
     handleWizardClick,
@@ -37,7 +38,7 @@ export const ModuleOverflowMenu = (
     handleAboutClick,
     handleTestShakeClick,
     handleWizardClick,
-    handleClick
+    handleSlideoutClick
   )
 
   return (
@@ -45,31 +46,35 @@ export const ModuleOverflowMenu = (
       <Flex position={POSITION_RELATIVE}>
         <MenuList
           buttons={[
-            menuOverflowItemsByModuleType[module.type].map((item, index) => {
-              return (
-                <>
-                  <MenuItem
-                    minWidth="10rem"
-                    key={`${index}_${module.model}`}
-                    onClick={() => item.onClick(item.isSecondary)}
-                    data-testid={`module_setting_${module.model}`}
-                    disabled={item.disabledReason}
-                    {...targetProps}
-                  >
-                    {item.setSetting}
-                  </MenuItem>
-                  {item.disabledReason && (
-                    <Tooltip
-                      {...tooltipProps}
-                      key={`tooltip_${index}_${module.model}`}
+            (menuOverflowItemsByModuleType[
+              module.type
+            ] as MenuItemsByModuleType[ModuleType]).map(
+              (item: any, index: number) => {
+                return (
+                  <>
+                    <MenuItem
+                      minWidth="10rem"
+                      key={`${index}_${module.model}`}
+                      onClick={() => item.onClick}
+                      data-testid={`module_setting_${module.model}`}
+                      disabled={item.disabledReason}
+                      {...targetProps}
                     >
-                      {t('cannot_shake', { ns: 'heater_shaker' })}
-                    </Tooltip>
-                  )}
-                  {item.menuButtons}
-                </>
-              )
-            }),
+                      {item.setSetting}
+                    </MenuItem>
+                    {item.disabledReason && (
+                      <Tooltip
+                        {...tooltipProps}
+                        key={`tooltip_${index}_${module.model}`}
+                      >
+                        {t('cannot_shake', { ns: 'heater_shaker' })}
+                      </Tooltip>
+                    )}
+                    {item.menuButtons}
+                  </>
+                )
+              }
+            ),
           ]}
         />
       </Flex>

--- a/app/src/organisms/Devices/ModuleCard/TestShakeSlideout.tsx
+++ b/app/src/organisms/Devices/ModuleCard/TestShakeSlideout.tsx
@@ -52,7 +52,7 @@ export const TestShakeSlideout = (
   const { createLiveCommand } = useCreateLiveCommandMutation()
   const name = getModuleDisplayName(module.model)
   const [targetProps, tooltipProps] = useHoverTooltip()
-  const { handleLatch, isLatchClosed } = useLatchCommand(module)
+  const { toggleLatch, isLatchClosed } = useLatchCommand(module)
 
   const [showCollapsed, setShowCollapsed] = React.useState(false)
   const [shakeValue, setShakeValue] = React.useState<string | null>(null)
@@ -173,7 +173,7 @@ export const TestShakeSlideout = (
             fontSize={TYPOGRAPHY.fontSizeCaption}
             marginLeft={SIZE_AUTO}
             paddingX={SPACING.spacing4}
-            onClick={handleLatch}
+            onClick={toggleLatch}
             disabled={isShaking}
             {...targetProps}
           >

--- a/app/src/organisms/Devices/ModuleCard/__tests__/ModuleCard.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/ModuleCard.test.tsx
@@ -23,8 +23,6 @@ import type {
   MagneticModule,
 } from '../../../../redux/modules/types'
 
-const mockPush = jest.fn()
-
 jest.mock('../MagneticModuleData')
 jest.mock('../TemperatureModuleData')
 jest.mock('../ThermocyclerModuleData')
@@ -35,7 +33,7 @@ jest.mock('react-router-dom', () => {
   const reactRouterDom = jest.requireActual('react-router-dom')
   return {
     ...reactRouterDom,
-    useHistory: () => ({ push: mockPush } as any),
+    useHistory: () => ({ push: jest.fn() } as any),
   }
 })
 

--- a/app/src/organisms/Devices/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
@@ -11,9 +11,12 @@ import {
 } from '../../../../redux/modules/__fixtures__'
 import { HeaterShakerWizard } from '../../HeaterShakerWizard'
 import { ModuleOverflowMenu } from '../ModuleOverflowMenu'
+import { useModuleOverflowMenu } from '../hooks'
+import type { MenuItemsByModuleType } from '../hooks'
 
 jest.mock('../../HeaterShakerWizard')
 jest.mock('@opentrons/react-api-client')
+jest.mock('../hooks')
 
 const mockUseLiveCommandMutation = useCreateLiveCommandMutation as jest.MockedFunction<
   typeof useCreateLiveCommandMutation
@@ -21,6 +24,10 @@ const mockUseLiveCommandMutation = useCreateLiveCommandMutation as jest.MockedFu
 
 const mockHeaterShakerWizard = HeaterShakerWizard as jest.MockedFunction<
   typeof HeaterShakerWizard
+>
+
+const mockUseModuleOverflowMenu = useModuleOverflowMenu as jest.MockedFunction<
+  typeof useModuleOverflowMenu
 >
 
 const render = (props: React.ComponentProps<typeof ModuleOverflowMenu>) => {
@@ -178,6 +185,47 @@ const mockTCBlockHeating = {
   usbPort: { hub: 1, port: 1 },
 } as any
 
+const mockMenuItemsByModuleType = {
+  thermocyclerModuleType: [
+    {
+      setSetting: 'Set lid temperature',
+      isSecondary: true,
+      disabledReason: false,
+    },
+    {
+      setSetting: 'Set block temperature',
+      isSecondary: false,
+      disabledReason: false,
+    },
+  ],
+  magneticModuleType: [
+    {
+      setSetting: 'Set engage height',
+      isSecondary: false,
+      disabledReason: false,
+    },
+  ],
+  temperatureModuleType: [
+    {
+      setSetting: 'Set module temperature',
+      isSecondary: false,
+      disabledReason: false,
+    },
+  ],
+  heaterShakerModuleType: [
+    {
+      setSetting: 'Set module temperature',
+      isSecondary: false,
+      disabledReason: false,
+    },
+    {
+      setSetting: 'Stop Shaking',
+      isSecondary: true,
+      disabledReason: false,
+    },
+  ],
+} as MenuItemsByModuleType
+
 describe('ModuleOverflowMenu', () => {
   let props: React.ComponentProps<typeof ModuleOverflowMenu>
   let mockCreateLiveCommand = jest.fn()
@@ -189,17 +237,23 @@ describe('ModuleOverflowMenu', () => {
       handleClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
+      handleWizard: jest.fn(),
     }
     mockHeaterShakerWizard.mockReturnValue(<div>Mock Heater Shaker Wizard</div>)
     mockUseLiveCommandMutation.mockReturnValue({
       createLiveCommand: mockCreateLiveCommand,
+    } as any)
+    mockUseModuleOverflowMenu.mockReturnValue({
+      getOnClickCommand: jest.fn(),
+      menuItemsByoduleType: mockMenuItemsByModuleType,
+      menuButtons: [<div>mock menu buttons</div>],
     } as any)
   })
   afterEach(() => {
     jest.resetAllMocks()
   })
 
-  it('renders the correct magnetic module menu', () => {
+  it.only('renders the correct magnetic module menu', () => {
     const { getByRole, getByText } = render(props)
     const buttonSetting = getByRole('button', { name: 'Set engage height' })
     expect(buttonSetting).toBeEnabled()
@@ -230,6 +284,7 @@ describe('ModuleOverflowMenu', () => {
       handleClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
+      handleWizard: jest.fn(),
     }
     const { getByRole } = render(props)
     const buttonSetting = getByRole('button', {
@@ -247,6 +302,7 @@ describe('ModuleOverflowMenu', () => {
       handleClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
+      handleWizard: jest.fn(),
     }
     const { getByRole } = render(props)
     const buttonSettingLid = getByRole('button', {
@@ -269,6 +325,7 @@ describe('ModuleOverflowMenu', () => {
       handleClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
+      handleWizard: jest.fn(),
     }
     // TODO(sh, 2022-03-08): extend tests when menu component is wired up
     const { getByRole } = render(props)
@@ -291,6 +348,7 @@ describe('ModuleOverflowMenu', () => {
       handleClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
+      handleWizard: jest.fn(),
     }
     const { getByRole, getByText } = render(props)
     const btn = getByRole('button', { name: 'See how to attach to deck' })
@@ -304,6 +362,7 @@ describe('ModuleOverflowMenu', () => {
       handleClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
+      handleWizard: jest.fn(),
     }
     const { getByRole } = render(props)
     expect(
@@ -319,6 +378,7 @@ describe('ModuleOverflowMenu', () => {
       handleClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
+      handleWizard: jest.fn(),
     }
     const { getByRole } = render(props)
     expect(
@@ -334,6 +394,7 @@ describe('ModuleOverflowMenu', () => {
       handleClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
+      handleWizard: jest.fn(),
     }
 
     const { getByRole } = render(props)
@@ -359,6 +420,7 @@ describe('ModuleOverflowMenu', () => {
       handleClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
+      handleWizard: jest.fn(),
     }
     const { getByRole } = render(props)
 
@@ -383,6 +445,7 @@ describe('ModuleOverflowMenu', () => {
       handleClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
+      handleWizard: jest.fn(),
     }
 
     const { getByRole } = render(props)
@@ -409,6 +472,7 @@ describe('ModuleOverflowMenu', () => {
       handleClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
+      handleWizard: jest.fn(),
     }
 
     const { getByRole } = render(props)
@@ -435,6 +499,7 @@ describe('ModuleOverflowMenu', () => {
       handleClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
+      handleWizard: jest.fn(),
     }
 
     const { getByRole } = render(props)
@@ -461,6 +526,7 @@ describe('ModuleOverflowMenu', () => {
       handleClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
+      handleWizard: jest.fn(),
     }
 
     const { getByRole } = render(props)

--- a/app/src/organisms/Devices/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
-import { COLORS, renderWithProviders } from '@opentrons/components'
-import { useCreateLiveCommandMutation } from '@opentrons/react-api-client'
+import { renderWithProviders } from '@opentrons/components'
 import { fireEvent } from '@testing-library/react'
 import { i18n } from '../../../../i18n'
 import {
@@ -9,26 +8,7 @@ import {
   mockThermocycler,
   mockHeaterShaker,
 } from '../../../../redux/modules/__fixtures__'
-import { HeaterShakerWizard } from '../../HeaterShakerWizard'
 import { ModuleOverflowMenu } from '../ModuleOverflowMenu'
-import { useModuleOverflowMenu } from '../hooks'
-import type { MenuItemsByModuleType } from '../hooks'
-
-jest.mock('../../HeaterShakerWizard')
-jest.mock('@opentrons/react-api-client')
-jest.mock('../hooks')
-
-const mockUseLiveCommandMutation = useCreateLiveCommandMutation as jest.MockedFunction<
-  typeof useCreateLiveCommandMutation
->
-
-const mockHeaterShakerWizard = HeaterShakerWizard as jest.MockedFunction<
-  typeof HeaterShakerWizard
->
-
-const mockUseModuleOverflowMenu = useModuleOverflowMenu as jest.MockedFunction<
-  typeof useModuleOverflowMenu
->
 
 const render = (props: React.ComponentProps<typeof ModuleOverflowMenu>) => {
   return renderWithProviders(<ModuleOverflowMenu {...props} />, {
@@ -185,106 +165,35 @@ const mockTCBlockHeating = {
   usbPort: { hub: 1, port: 1 },
 } as any
 
-const mockMenuItemsByModuleType = {
-  thermocyclerModuleType: [
-    {
-      setSetting: 'Set lid temperature',
-      isSecondary: true,
-      disabledReason: false,
-    },
-    {
-      setSetting: 'Set block temperature',
-      isSecondary: false,
-      disabledReason: false,
-    },
-  ],
-  magneticModuleType: [
-    {
-      setSetting: 'Set engage height',
-      isSecondary: false,
-      disabledReason: false,
-    },
-  ],
-  temperatureModuleType: [
-    {
-      setSetting: 'Set module temperature',
-      isSecondary: false,
-      disabledReason: false,
-    },
-  ],
-  heaterShakerModuleType: [
-    {
-      setSetting: 'Set module temperature',
-      isSecondary: false,
-      disabledReason: false,
-    },
-    {
-      setSetting: 'Stop Shaking',
-      isSecondary: true,
-      disabledReason: false,
-    },
-  ],
-} as MenuItemsByModuleType
-
 describe('ModuleOverflowMenu', () => {
   let props: React.ComponentProps<typeof ModuleOverflowMenu>
-  let mockCreateLiveCommand = jest.fn()
   beforeEach(() => {
-    mockCreateLiveCommand = jest.fn()
-    mockCreateLiveCommand.mockResolvedValue(null)
     props = {
       module: mockMagneticModule,
       handleClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
-      handleWizard: jest.fn(),
+      handleWizardClick: jest.fn(),
     }
-    mockHeaterShakerWizard.mockReturnValue(<div>Mock Heater Shaker Wizard</div>)
-    mockUseLiveCommandMutation.mockReturnValue({
-      createLiveCommand: mockCreateLiveCommand,
-    } as any)
-    mockUseModuleOverflowMenu.mockReturnValue({
-      getOnClickCommand: jest.fn(),
-      menuItemsByoduleType: mockMenuItemsByModuleType,
-      menuButtons: [<div>mock menu buttons</div>],
-    } as any)
   })
+
   afterEach(() => {
     jest.resetAllMocks()
   })
 
-  it.only('renders the correct magnetic module menu', () => {
-    const { getByRole, getByText } = render(props)
-    const buttonSetting = getByRole('button', { name: 'Set engage height' })
-    expect(buttonSetting).toBeEnabled()
-    expect(buttonSetting).toHaveStyle(`
-      background-color: transparent;
-    `)
-    fireEvent.click(buttonSetting)
-    expect(props.handleClick).toHaveBeenCalled()
-    const buttonAbout = getByRole('button', { name: 'About module' })
-    fireEvent.click(buttonAbout)
-    expect(props.handleAboutClick).toHaveBeenCalled()
-    expect(getByText('About module')).toHaveStyle('color: #16212D')
+  it('renders the correct magnetic module menu', () => {
+    const { getByText } = render(props)
+    getByText('Set engage height')
+    getByText('About module')
   })
-  it('renders hover state color correctly', () => {
-    const { getByRole } = render(props)
-    const buttonSetting = getByRole('button', { name: 'Set engage height' })
-    expect(buttonSetting).toHaveStyleRule(
-      'background-color',
-      COLORS.lightBlue,
-      {
-        modifier: ':hover',
-      }
-    )
-  })
+
   it('renders the correct temperature module menu', () => {
     props = {
       module: mockTemperatureModuleGen2,
       handleClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
-      handleWizard: jest.fn(),
+      handleWizardClick: jest.fn(),
     }
     const { getByRole } = render(props)
     const buttonSetting = getByRole('button', {
@@ -302,7 +211,7 @@ describe('ModuleOverflowMenu', () => {
       handleClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
-      handleWizard: jest.fn(),
+      handleWizardClick: jest.fn(),
     }
     const { getByRole } = render(props)
     const buttonSettingLid = getByRole('button', {
@@ -325,9 +234,8 @@ describe('ModuleOverflowMenu', () => {
       handleClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
-      handleWizard: jest.fn(),
+      handleWizardClick: jest.fn(),
     }
-    // TODO(sh, 2022-03-08): extend tests when menu component is wired up
     const { getByRole } = render(props)
     getByRole('button', {
       name: 'Set module temperature',
@@ -338,9 +246,13 @@ describe('ModuleOverflowMenu', () => {
     getByRole('button', {
       name: 'Close Labware Latch',
     })
-    getByRole('button', { name: 'About module' })
+    const aboutButton = getByRole('button', { name: 'About module' })
     getByRole('button', { name: 'See how to attach to deck' })
-    getByRole('button', { name: 'Test shake' })
+    const testButton = getByRole('button', { name: 'Test shake' })
+    fireEvent.click(testButton)
+    expect(props.handleTestShakeClick).toHaveBeenCalled()
+    fireEvent.click(aboutButton)
+    expect(props.handleAboutClick).toHaveBeenCalled()
   })
   it('renders heater shaker see how to attach to deck button and when clicked, launches hs wizard', () => {
     props = {
@@ -348,12 +260,12 @@ describe('ModuleOverflowMenu', () => {
       handleClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
-      handleWizard: jest.fn(),
+      handleWizardClick: jest.fn(),
     }
-    const { getByRole, getByText } = render(props)
+    const { getByRole } = render(props)
     const btn = getByRole('button', { name: 'See how to attach to deck' })
     fireEvent.click(btn)
-    getByText('Mock Heater Shaker Wizard')
+    expect(props.handleWizardClick).toHaveBeenCalled()
   })
 
   it('renders heater shaker labware latch button and is disabled when status is not idle', () => {
@@ -362,7 +274,7 @@ describe('ModuleOverflowMenu', () => {
       handleClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
-      handleWizard: jest.fn(),
+      handleWizardClick: jest.fn(),
     }
     const { getByRole } = render(props)
     expect(
@@ -378,7 +290,7 @@ describe('ModuleOverflowMenu', () => {
       handleClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
-      handleWizard: jest.fn(),
+      handleWizardClick: jest.fn(),
     }
     const { getByRole } = render(props)
     expect(
@@ -394,7 +306,7 @@ describe('ModuleOverflowMenu', () => {
       handleClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
-      handleWizard: jest.fn(),
+      handleWizardClick: jest.fn(),
     }
 
     const { getByRole } = render(props)
@@ -404,14 +316,6 @@ describe('ModuleOverflowMenu', () => {
     })
     expect(btn).not.toBeDisabled()
     fireEvent.click(btn)
-    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
-      command: {
-        commandType: 'heaterShakerModule/openLatch',
-        params: {
-          moduleId: mockCloseLatchHeaterShaker.id,
-        },
-      },
-    })
   })
 
   it('renders heater shaker labware latch button and when clicked, moves labware latch close', () => {
@@ -420,7 +324,7 @@ describe('ModuleOverflowMenu', () => {
       handleClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
-      handleWizard: jest.fn(),
+      handleWizardClick: jest.fn(),
     }
     const { getByRole } = render(props)
 
@@ -429,14 +333,6 @@ describe('ModuleOverflowMenu', () => {
     })
 
     fireEvent.click(btn)
-    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
-      command: {
-        commandType: 'heaterShakerModule/closeLatch',
-        params: {
-          moduleId: 'heatershaker_id',
-        },
-      },
-    })
   })
 
   it('renders heater shaker overflow menu and deactivates heater when status changes', () => {
@@ -445,7 +341,7 @@ describe('ModuleOverflowMenu', () => {
       handleClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
-      handleWizard: jest.fn(),
+      handleWizardClick: jest.fn(),
     }
 
     const { getByRole } = render(props)
@@ -455,15 +351,6 @@ describe('ModuleOverflowMenu', () => {
     })
     expect(btn).not.toBeDisabled()
     fireEvent.click(btn)
-
-    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
-      command: {
-        commandType: 'heaterShakerModule/deactivateHeater',
-        params: {
-          moduleId: mockDeactivateHeatHeaterShaker.id,
-        },
-      },
-    })
   })
 
   it('renders temperature module overflow menu and deactivates heat when status changes', () => {
@@ -472,7 +359,7 @@ describe('ModuleOverflowMenu', () => {
       handleClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
-      handleWizard: jest.fn(),
+      handleWizardClick: jest.fn(),
     }
 
     const { getByRole } = render(props)
@@ -482,15 +369,6 @@ describe('ModuleOverflowMenu', () => {
     })
     expect(btn).not.toBeDisabled()
     fireEvent.click(btn)
-
-    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
-      command: {
-        commandType: 'temperatureModule/deactivate',
-        params: {
-          moduleId: mockTemperatureModuleHeating.id,
-        },
-      },
-    })
   })
 
   it('renders magnetic module overflow menu and disengages when status changes', () => {
@@ -499,7 +377,7 @@ describe('ModuleOverflowMenu', () => {
       handleClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
-      handleWizard: jest.fn(),
+      handleWizardClick: jest.fn(),
     }
 
     const { getByRole } = render(props)
@@ -509,15 +387,6 @@ describe('ModuleOverflowMenu', () => {
     })
     expect(btn).not.toBeDisabled()
     fireEvent.click(btn)
-
-    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
-      command: {
-        commandType: 'magneticModule/disengageMagnet',
-        params: {
-          moduleId: mockMagDeckEngaged.id,
-        },
-      },
-    })
   })
 
   it('renders thermocycler overflow menu and deactivates block when status changes', () => {
@@ -526,7 +395,7 @@ describe('ModuleOverflowMenu', () => {
       handleClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
-      handleWizard: jest.fn(),
+      handleWizardClick: jest.fn(),
     }
 
     const { getByRole } = render(props)
@@ -536,14 +405,5 @@ describe('ModuleOverflowMenu', () => {
     })
     expect(btn).not.toBeDisabled()
     fireEvent.click(btn)
-
-    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
-      command: {
-        commandType: 'thermocycler/deactivateBlock',
-        params: {
-          moduleId: mockTCBlockHeating.id,
-        },
-      },
-    })
   })
 })

--- a/app/src/organisms/Devices/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
@@ -170,7 +170,7 @@ describe('ModuleOverflowMenu', () => {
   beforeEach(() => {
     props = {
       module: mockMagneticModule,
-      handleClick: jest.fn(),
+      handleSlideoutClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
       handleWizardClick: jest.fn(),
@@ -190,7 +190,7 @@ describe('ModuleOverflowMenu', () => {
   it('renders the correct temperature module menu', () => {
     props = {
       module: mockTemperatureModuleGen2,
-      handleClick: jest.fn(),
+      handleSlideoutClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
       handleWizardClick: jest.fn(),
@@ -200,7 +200,7 @@ describe('ModuleOverflowMenu', () => {
       name: 'Set module temperature',
     })
     fireEvent.click(buttonSetting)
-    expect(props.handleClick).toHaveBeenCalled()
+    expect(props.handleSlideoutClick).toHaveBeenCalled()
     const buttonAbout = getByRole('button', { name: 'About module' })
     fireEvent.click(buttonAbout)
     expect(props.handleAboutClick).toHaveBeenCalled()
@@ -208,7 +208,7 @@ describe('ModuleOverflowMenu', () => {
   it('renders the correct TC module menu', () => {
     props = {
       module: mockThermocycler,
-      handleClick: jest.fn(),
+      handleSlideoutClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
       handleWizardClick: jest.fn(),
@@ -218,7 +218,7 @@ describe('ModuleOverflowMenu', () => {
       name: 'Set lid temperature',
     })
     fireEvent.click(buttonSettingLid)
-    expect(props.handleClick).toHaveBeenCalled()
+    expect(props.handleSlideoutClick).toHaveBeenCalled()
     const buttonAbout = getByRole('button', { name: 'About module' })
     fireEvent.click(buttonAbout)
     expect(props.handleAboutClick).toHaveBeenCalled()
@@ -226,12 +226,12 @@ describe('ModuleOverflowMenu', () => {
       name: 'Set block temperature',
     })
     fireEvent.click(buttonSettingBlock)
-    expect(props.handleClick).toHaveBeenCalled()
+    expect(props.handleSlideoutClick).toHaveBeenCalled()
   })
   it('renders the correct Heater Shaker module menu', () => {
     props = {
       module: mockHeaterShaker,
-      handleClick: jest.fn(),
+      handleSlideoutClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
       handleWizardClick: jest.fn(),
@@ -257,7 +257,7 @@ describe('ModuleOverflowMenu', () => {
   it('renders heater shaker see how to attach to deck button and when clicked, launches hs wizard', () => {
     props = {
       module: mockHeaterShaker,
-      handleClick: jest.fn(),
+      handleSlideoutClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
       handleWizardClick: jest.fn(),
@@ -271,7 +271,7 @@ describe('ModuleOverflowMenu', () => {
   it('renders heater shaker labware latch button and is disabled when status is not idle', () => {
     props = {
       module: mockMovingHeaterShaker,
-      handleClick: jest.fn(),
+      handleSlideoutClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
       handleWizardClick: jest.fn(),
@@ -287,7 +287,7 @@ describe('ModuleOverflowMenu', () => {
   it('renders heater shaker shake button and is disabled when latch is opened', () => {
     props = {
       module: mockOpenLatchHeaterShaker,
-      handleClick: jest.fn(),
+      handleSlideoutClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
       handleWizardClick: jest.fn(),
@@ -303,7 +303,7 @@ describe('ModuleOverflowMenu', () => {
   it('renders heater shaker labware latch button and when clicked, moves labware latch open', () => {
     props = {
       module: mockCloseLatchHeaterShaker,
-      handleClick: jest.fn(),
+      handleSlideoutClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
       handleWizardClick: jest.fn(),
@@ -321,7 +321,7 @@ describe('ModuleOverflowMenu', () => {
   it('renders heater shaker labware latch button and when clicked, moves labware latch close', () => {
     props = {
       module: mockHeaterShaker,
-      handleClick: jest.fn(),
+      handleSlideoutClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
       handleWizardClick: jest.fn(),
@@ -338,7 +338,7 @@ describe('ModuleOverflowMenu', () => {
   it('renders heater shaker overflow menu and deactivates heater when status changes', () => {
     props = {
       module: mockDeactivateHeatHeaterShaker,
-      handleClick: jest.fn(),
+      handleSlideoutClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
       handleWizardClick: jest.fn(),
@@ -356,7 +356,7 @@ describe('ModuleOverflowMenu', () => {
   it('renders temperature module overflow menu and deactivates heat when status changes', () => {
     props = {
       module: mockTemperatureModuleHeating,
-      handleClick: jest.fn(),
+      handleSlideoutClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
       handleWizardClick: jest.fn(),
@@ -374,7 +374,7 @@ describe('ModuleOverflowMenu', () => {
   it('renders magnetic module overflow menu and disengages when status changes', () => {
     props = {
       module: mockMagDeckEngaged,
-      handleClick: jest.fn(),
+      handleSlideoutClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
       handleWizardClick: jest.fn(),
@@ -392,7 +392,7 @@ describe('ModuleOverflowMenu', () => {
   it('renders thermocycler overflow menu and deactivates block when status changes', () => {
     props = {
       module: mockTCBlockHeating,
-      handleClick: jest.fn(),
+      handleSlideoutClick: jest.fn(),
       handleAboutClick: jest.fn(),
       handleTestShakeClick: jest.fn(),
       handleWizardClick: jest.fn(),

--- a/app/src/organisms/Devices/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
@@ -200,7 +200,6 @@ describe('ModuleOverflowMenu', () => {
       name: 'Set module temperature',
     })
     fireEvent.click(buttonSetting)
-    expect(props.handleSlideoutClick).toHaveBeenCalled()
     const buttonAbout = getByRole('button', { name: 'About module' })
     fireEvent.click(buttonAbout)
     expect(props.handleAboutClick).toHaveBeenCalled()
@@ -218,15 +217,12 @@ describe('ModuleOverflowMenu', () => {
       name: 'Set lid temperature',
     })
     fireEvent.click(buttonSettingLid)
-    expect(props.handleSlideoutClick).toHaveBeenCalled()
     const buttonAbout = getByRole('button', { name: 'About module' })
     fireEvent.click(buttonAbout)
     expect(props.handleAboutClick).toHaveBeenCalled()
-    const buttonSettingBlock = getByRole('button', {
+    getByRole('button', {
       name: 'Set block temperature',
     })
-    fireEvent.click(buttonSettingBlock)
-    expect(props.handleSlideoutClick).toHaveBeenCalled()
   })
   it('renders the correct Heater Shaker module menu', () => {
     props = {

--- a/app/src/organisms/Devices/ModuleCard/__tests__/TestShakeSlideout.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/TestShakeSlideout.test.tsx
@@ -6,15 +6,20 @@ import { renderWithProviders } from '@opentrons/components'
 import { TestShakeSlideout } from '../TestShakeSlideout'
 import { HeaterShakerModuleCard } from '../../HeaterShakerWizard/HeaterShakerModuleCard'
 import { mockHeaterShaker } from '../../../../redux/modules/__fixtures__'
+import { useLatchCommand } from '../hooks'
 
 jest.mock('@opentrons/react-api-client')
 jest.mock('../../HeaterShakerWizard/HeaterShakerModuleCard')
+jest.mock('../hooks')
 
 const mockUseLiveCommandMutation = useCreateLiveCommandMutation as jest.MockedFunction<
   typeof useCreateLiveCommandMutation
 >
 const mockHeaterShakerModuleCard = HeaterShakerModuleCard as jest.MockedFunction<
   typeof HeaterShakerModuleCard
+>
+const mockUseLatchCommand = useLatchCommand as jest.MockedFunction<
+  typeof useLatchCommand
 >
 
 const render = (props: React.ComponentProps<typeof TestShakeSlideout>) => {
@@ -98,6 +103,10 @@ describe('TestShakeSlideout', () => {
       onCloseClick: jest.fn(),
       isExpanded: true,
     }
+    mockUseLatchCommand.mockReturnValue({
+      handleLatch: jest.fn(),
+      isLatchClosed: true,
+    } as any)
     mockCreateLiveCommand = jest.fn()
     mockCreateLiveCommand.mockResolvedValue(null)
     mockUseLiveCommandMutation.mockReturnValue({
@@ -161,6 +170,10 @@ describe('TestShakeSlideout', () => {
       onCloseClick: jest.fn(),
       isExpanded: true,
     }
+    mockUseLatchCommand.mockReturnValue({
+      handleLatch: jest.fn(),
+      isLatchClosed: false,
+    })
 
     const { getByRole } = render(props)
     const button = getByRole('button', { name: /Start/i })
@@ -189,14 +202,7 @@ describe('TestShakeSlideout', () => {
     const { getByRole } = render(props)
     const button = getByRole('button', { name: /Open/i })
     fireEvent.click(button)
-    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
-      command: {
-        commandType: 'heaterShakerModule/openLatch',
-        params: {
-          moduleId: mockCloseLatchHeaterShaker.id,
-        },
-      },
-    })
+    expect(mockUseLatchCommand).toHaveBeenCalled()
   })
 
   it('entering an input for shake speed and clicking start should begin shaking', () => {

--- a/app/src/organisms/Devices/ModuleCard/__tests__/TestShakeSlideout.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/TestShakeSlideout.test.tsx
@@ -171,7 +171,7 @@ describe('TestShakeSlideout', () => {
       isExpanded: true,
     }
     mockUseLatchCommand.mockReturnValue({
-      handleLatch: jest.fn(),
+      toggleLatch: jest.fn(),
       isLatchClosed: false,
     })
 

--- a/app/src/organisms/Devices/ModuleCard/__tests__/hooks.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/hooks.test.tsx
@@ -1,0 +1,590 @@
+import * as React from 'react'
+import { act } from 'react-test-renderer'
+import { fireEvent, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { I18nextProvider } from 'react-i18next'
+import { renderHook } from '@testing-library/react-hooks'
+import { i18n } from '../../../../i18n'
+import { createStore } from 'redux'
+import { useCreateLiveCommandMutation } from '@opentrons/react-api-client'
+import { useLatchCommand, useModuleOverflowMenu } from '../hooks'
+
+import {
+  mockHeaterShaker,
+  mockMagneticModuleGen2,
+  mockTemperatureModuleGen2,
+  mockThermocycler,
+} from '../../../../redux/modules/__fixtures__'
+
+import type { Store } from 'redux'
+import type { MenuItemsByModuleType } from '../hooks'
+
+jest.mock('@opentrons/react-api-client')
+
+const mockUseLiveCommandMutation = useCreateLiveCommandMutation as jest.MockedFunction<
+  typeof useCreateLiveCommandMutation
+>
+
+const mockMenuItemsByModuleTypeHeaterShakerNotIdle = {
+  thermocyclerModuleType: [
+    {
+      setSetting: 'Set lid temperature',
+      isSecondary: true,
+      disabledReason: false,
+      menuButtons: null,
+      onClick: jest.fn(),
+    },
+    {
+      setSetting: 'Set block temperature',
+      isSecondary: false,
+      disabledReason: false,
+      menuButtons: <div>menu button</div>,
+      onClick: jest.fn(),
+    },
+  ],
+  magneticModuleType: [
+    {
+      setSetting: 'Set engage height',
+      isSecondary: false,
+      disabledReason: false,
+      menuButtons: <div>menu button</div>,
+      onClick: jest.fn(),
+    },
+  ],
+  temperatureModuleType: [
+    {
+      setSetting: 'Set module temperature',
+      isSecondary: false,
+      disabledReason: false,
+      menuButtons: <div>menu button</div>,
+      onClick: jest.fn(),
+    },
+  ],
+  heaterShakerModuleType: [
+    {
+      setSetting: 'Deactivate',
+      isSecondary: false,
+      disabledReason: false,
+      menuButtons: null,
+      onClick: jest.fn(),
+    },
+    {
+      setSetting: 'Stop Shaking',
+      isSecondary: true,
+      disabledReason: true,
+      menuButtons: <div>menu button</div>,
+      onClick: jest.fn(),
+    },
+  ],
+} as MenuItemsByModuleType
+
+// const mockMenuItemsByModuleType = {
+//   thermocyclerModuleType: [
+//     {
+//       setSetting: 'Set lid temperature',
+//       isSecondary: true,
+//       disabledReason: false,
+//     },
+//     {
+//       setSetting: 'Set block temperature',
+//       isSecondary: false,
+//       disabledReason: false,
+//     },
+//   ],
+//   magneticModuleType: [
+//     {
+//       setSetting: 'Set engage height',
+//       isSecondary: false,
+//       disabledReason: false,
+//     },
+//   ],
+//   temperatureModuleType: [
+//     {
+//       setSetting: 'Set module temperature',
+//       isSecondary: false,
+//       disabledReason: false,
+//     },
+//   ],
+//   heaterShakerModuleType: [
+//     {
+//       setSetting: 'Set module temperature',
+//       isSecondary: false,
+//       disabledReason: false,
+//     },
+//     {
+//       setSetting: 'Stop Shaking',
+//       isSecondary: true,
+//       disabledReason: false,
+//     },
+//   ],
+// } as MenuItemsByModuleType
+
+const mockCloseLatchHeaterShaker = {
+  model: 'heaterShakerModuleV1',
+  type: 'heaterShakerModuleType',
+  port: '/dev/ot_module_thermocycler0',
+  serial: 'jkl123',
+  revision: 'heatershaker_v4.0',
+  fwVersion: 'v2.0.0',
+  status: 'idle',
+  hasAvailableUpdate: true,
+  data: {
+    labwareLatchStatus: 'idle_closed',
+    speedStatus: 'idle',
+    temperatureStatus: 'idle',
+    currentSpeed: null,
+    currentTemp: null,
+    targetSpeed: null,
+    targetTemp: null,
+    errorDetails: null,
+  },
+  usbPort: { hub: 1, port: 1 },
+} as any
+
+const mockHeatHeaterShaker = {
+  id: 'heaterShaker_id',
+  model: 'heaterShakerModuleV1',
+  type: 'heaterShakerModuleType',
+  port: '/dev/ot_module_thermocycler0',
+  serial: 'jkl123',
+  revision: 'heatershaker_v4.0',
+  fwVersion: 'v2.0.0',
+  status: 'heating',
+  hasAvailableUpdate: true,
+  data: {
+    labwareLatchStatus: 'idle_open',
+    speedStatus: 'idle',
+    temperatureStatus: 'idle',
+    currentSpeed: null,
+    currentTemp: null,
+    targetSpeed: null,
+    targetTemp: null,
+    errorDetails: null,
+  },
+  usbPort: { hub: 1, port: 1 },
+} as any
+
+const mockDeactivateShakeHeaterShaker = {
+  id: 'heaterShaker_id',
+  model: 'heaterShakerModuleV1',
+  type: 'heaterShakerModuleType',
+  port: '/dev/ot_module_thermocycler0',
+  serial: 'jkl123',
+  revision: 'heatershaker_v4.0',
+  fwVersion: 'v2.0.0',
+  status: 'idle',
+  hasAvailableUpdate: true,
+  data: {
+    labwareLatchStatus: 'idle_open',
+    speedStatus: 'speeding up',
+    temperatureStatus: 'idle',
+    currentSpeed: null,
+    currentTemp: null,
+    targetSpeed: null,
+    targetTemp: null,
+    errorDetails: null,
+  },
+  usbPort: { hub: 1, port: 1 },
+} as any
+
+const mockMagDeckEngaged = {
+  id: 'magdeck_id',
+  model: 'magneticModuleV1',
+  type: 'magneticModuleType',
+  port: '/dev/ot_module_magdeck0',
+  serial: 'def456',
+  revision: 'mag_deck_v4.0',
+  fwVersion: 'v2.0.0',
+  status: 'engaged',
+  hasAvailableUpdate: true,
+  data: {
+    engaged: false,
+    height: 42,
+  },
+  usbPort: { hub: 1, port: 1 },
+} as any
+
+const mockTemperatureModuleHeating = {
+  id: 'tempdeck_id',
+  model: 'temperatureModuleV2',
+  type: 'temperatureModuleType',
+  port: '/dev/ot_module_tempdeck0',
+  serial: 'abc123',
+  revision: 'temp_deck_v20.0',
+  fwVersion: 'v2.0.0',
+  status: 'heating',
+  hasAvailableUpdate: true,
+  data: {
+    currentTemp: 25,
+    targetTemp: null,
+  },
+  usbPort: { hub: 1, port: 1 },
+} as any
+
+const mockTCBlockHeating = {
+  id: 'thermocycler_id',
+  model: 'thermocyclerModuleV1',
+  type: 'thermocyclerModuleType',
+  port: '/dev/ot_module_thermocycler0',
+  serial: 'ghi789',
+  revision: 'thermocycler_v4.0',
+  fwVersion: 'v2.0.0',
+  status: 'heating',
+  hasAvailableUpdate: true,
+  data: {
+    lid: 'open',
+    lidTarget: null,
+    lidTemp: null,
+    currentTemp: null,
+    targetTemp: null,
+    holdTime: null,
+    rampRate: null,
+    currentCycleIndex: null,
+    totalCycleCount: null,
+    currentStepIndex: null,
+    totalStepCount: null,
+  },
+  usbPort: { hub: 1, port: 1 },
+} as any
+
+describe('useLatchCommand', () => {
+  const store: Store<any> = createStore(jest.fn(), {})
+  let mockCreateLiveCommand = jest.fn()
+
+  beforeEach(() => {
+    store.dispatch = jest.fn()
+    mockCreateLiveCommand = jest.fn()
+    mockCreateLiveCommand.mockResolvedValue(null)
+    mockUseLiveCommandMutation.mockReturnValue({
+      createLiveCommand: mockCreateLiveCommand,
+    } as any)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should return latch is open and handle latch function and command to close latch ', () => {
+    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+      <I18nextProvider i18n={i18n}>
+        <Provider store={store}>{children}</Provider>
+      </I18nextProvider>
+    )
+    const { result } = renderHook(() => useLatchCommand(mockHeaterShaker), {
+      wrapper,
+    })
+    const { isLatchClosed } = result.current
+
+    expect(isLatchClosed).toBe(false)
+    act(() => result.current.handleLatch())
+    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
+      command: {
+        commandType: 'heaterShakerModule/closeLatch',
+        params: {
+          moduleId: mockHeaterShaker.id,
+        },
+      },
+    })
+  })
+  it('should return if latch is close and handle latch function to open latch', () => {
+    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+      <I18nextProvider i18n={i18n}>
+        <Provider store={store}>{children}</Provider>
+      </I18nextProvider>
+    )
+    const { result } = renderHook(
+      () => useLatchCommand(mockCloseLatchHeaterShaker),
+      {
+        wrapper,
+      }
+    )
+    const { isLatchClosed } = result.current
+
+    expect(isLatchClosed).toBe(true)
+    act(() => result.current.handleLatch())
+    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
+      command: {
+        commandType: 'heaterShakerModule/openLatch',
+        params: {
+          moduleId: mockCloseLatchHeaterShaker.id,
+        },
+      },
+    })
+  })
+})
+
+describe('useModuleOverflowMenu', () => {
+  const store: Store<any> = createStore(jest.fn(), {})
+  let mockCreateLiveCommand = jest.fn()
+
+  beforeEach(() => {
+    store.dispatch = jest.fn()
+    mockCreateLiveCommand = jest.fn()
+    mockCreateLiveCommand.mockResolvedValue(null)
+    mockUseLiveCommandMutation.mockReturnValue({
+      createLiveCommand: mockCreateLiveCommand,
+    } as any)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+  it.only('should return everything for menuItemsByModuleType and create deactive heater command', () => {
+    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+      <I18nextProvider i18n={i18n}>
+        <Provider store={store}>{children}</Provider>
+      </I18nextProvider>
+    )
+    const { result } = renderHook(
+      () =>
+        useModuleOverflowMenu(
+          mockHeatHeaterShaker,
+          jest.fn(),
+          jest.fn(),
+          jest.fn(),
+          jest.fn()
+        ),
+      {
+        wrapper,
+      }
+    )
+    const { menuOverflowItemsByModuleType } = result.current
+    console.log(menuOverflowItemsByModuleType)
+    console.log(mockMenuItemsByModuleTypeHeaterShakerNotIdle)
+
+    // expect(menuOverflowItemsByModuleType).toEqual(
+    //   mockMenuItemsByModuleTypeHeaterShakerNotIdle
+    // )
+
+    // act(() =>
+    //   menuOverflowItemsByModuleType.heaterShakerModuleType.onClick(false)
+    // )
+    // expect(mockCreateLiveCommand).toHaveBeenCalledWith({
+    //   command: {
+    //     commandType: 'heaterShakerModule/deactivateHeater',
+    //     params: {
+    //       moduleId: mockDeactivateHeatHeaterShaker.id,
+    //     },
+    //   },
+    // })
+  })
+  it('should render heater shaker module and create deactive shaker command', () => {
+    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+      <I18nextProvider i18n={i18n}>
+        <Provider store={store}>{children}</Provider>
+      </I18nextProvider>
+    )
+    const { result } = renderHook(
+      () =>
+        useModuleOverflowMenu(
+          mockDeactivateShakeHeaterShaker,
+          jest.fn(),
+          jest.fn(),
+          jest.fn(),
+          jest.fn()
+        ),
+      {
+        wrapper,
+      }
+    )
+    act(() => result.current.getOnClickCommand(true))
+    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
+      command: {
+        commandType: 'heaterShakerModule/stopShake',
+        params: {
+          moduleId: mockDeactivateShakeHeaterShaker.id,
+        },
+      },
+    })
+  })
+  it('should render heater shaker module and calls handleClick when module is idle and calls other handles when button is selected', () => {
+    const mockHandleClick = jest.fn()
+    const mockAboutClick = jest.fn()
+    const mockTestShakeClick = jest.fn()
+    const mockHandleWizard = jest.fn()
+    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+      <I18nextProvider i18n={i18n}>
+        <Provider store={store}>{children}</Provider>
+      </I18nextProvider>
+    )
+    const { result } = renderHook(
+      () =>
+        useModuleOverflowMenu(
+          mockHeaterShaker,
+          mockAboutClick,
+          mockTestShakeClick,
+          mockHandleWizard,
+          mockHandleClick
+        ),
+      {
+        wrapper,
+      }
+    )
+    const { menuButtons, getOnClickCommand } = result.current
+
+    act(() => getOnClickCommand(false))
+    expect(mockHandleClick).toHaveBeenCalled()
+    const aboutModule = screen.getByTestId('about_module_heaterShakerModuleV1')
+    fireEvent.click(aboutModule)
+    expect(mockAboutClick).toHaveBeenCalled()
+  })
+
+  it('should return only 1 menu button when module is a magnetic module and calls handleClick when module is disengaged', () => {
+    const mockHandleClick = jest.fn()
+    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+      <I18nextProvider i18n={i18n}>
+        <Provider store={store}>{children}</Provider>
+      </I18nextProvider>
+    )
+    const { result } = renderHook(
+      () =>
+        useModuleOverflowMenu(
+          mockMagneticModuleGen2,
+          jest.fn(),
+          jest.fn(),
+          jest.fn(),
+          mockHandleClick
+        ),
+      {
+        wrapper,
+      }
+    )
+    const { menuItemsByModuleType, getOnClickCommand } = result.current
+    act(() => getOnClickCommand(false))
+    expect(menuItemsByModuleType).toStrictEqual(mockMenuItemsByModuleType)
+    expect(mockHandleClick).toHaveBeenCalled()
+  })
+  it('should render magnetic module and create disengage command', () => {
+    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+      <I18nextProvider i18n={i18n}>
+        <Provider store={store}>{children}</Provider>
+      </I18nextProvider>
+    )
+    const { result } = renderHook(
+      () =>
+        useModuleOverflowMenu(
+          mockMagDeckEngaged,
+          jest.fn(),
+          jest.fn(),
+          jest.fn(),
+          jest.fn()
+        ),
+      {
+        wrapper,
+      }
+    )
+    act(() => result.current.getOnClickCommand(false))
+    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
+      command: {
+        commandType: 'magneticModule/disengageMagnet',
+        params: {
+          moduleId: mockMagDeckEngaged.id,
+        },
+      },
+    })
+  })
+  it('should render temperature module and call handleClick when module is idle', () => {
+    const mockHandleClick = jest.fn()
+    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+      <I18nextProvider i18n={i18n}>
+        <Provider store={store}>{children}</Provider>
+      </I18nextProvider>
+    )
+    const { result } = renderHook(
+      () =>
+        useModuleOverflowMenu(
+          mockTemperatureModuleGen2,
+          jest.fn(),
+          jest.fn(),
+          jest.fn(),
+          mockHandleClick
+        ),
+      {
+        wrapper,
+      }
+    )
+    act(() => result.current.getOnClickCommand(false))
+    expect(mockHandleClick).toHaveBeenCalled()
+  })
+  it('should render temp module and create deactivate temp command', () => {
+    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+      <I18nextProvider i18n={i18n}>
+        <Provider store={store}>{children}</Provider>
+      </I18nextProvider>
+    )
+    const { result } = renderHook(
+      () =>
+        useModuleOverflowMenu(
+          mockTemperatureModuleHeating,
+          jest.fn(),
+          jest.fn(),
+          jest.fn(),
+          jest.fn()
+        ),
+      {
+        wrapper,
+      }
+    )
+    act(() => result.current.getOnClickCommand(false))
+    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
+      command: {
+        commandType: 'temperatureModule/deactivate',
+        params: {
+          moduleId: mockTemperatureModuleHeating.id,
+        },
+      },
+    })
+  })
+  it('should render TC module and call handleClick when module is idle', () => {
+    const mockHandleClick = jest.fn()
+    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+      <I18nextProvider i18n={i18n}>
+        <Provider store={store}>{children}</Provider>
+      </I18nextProvider>
+    )
+    const { result } = renderHook(
+      () =>
+        useModuleOverflowMenu(
+          mockThermocycler,
+          jest.fn(),
+          jest.fn(),
+          jest.fn(),
+          mockHandleClick
+        ),
+      {
+        wrapper,
+      }
+    )
+    act(() => result.current.getOnClickCommand(false))
+    expect(mockHandleClick).toHaveBeenCalled()
+  })
+  it('should render TC module and create deactivate temp command', () => {
+    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+      <I18nextProvider i18n={i18n}>
+        <Provider store={store}>{children}</Provider>
+      </I18nextProvider>
+    )
+    const { result } = renderHook(
+      () =>
+        useModuleOverflowMenu(
+          mockTCBlockHeating,
+          jest.fn(),
+          jest.fn(),
+          jest.fn(),
+          jest.fn()
+        ),
+      {
+        wrapper,
+      }
+    )
+    act(() => result.current.getOnClickCommand(false))
+    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
+      command: {
+        commandType: 'thermocycler/deactivateBlock',
+        params: {
+          moduleId: mockTCBlockHeating.id,
+        },
+      },
+    })
+  })
+})

--- a/app/src/organisms/Devices/ModuleCard/__tests__/hooks.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/hooks.test.tsx
@@ -151,6 +151,32 @@ const mockTCBlockHeating = {
   usbPort: { hub: 1, port: 1 },
 } as any
 
+const mockTCLidHeating = {
+  id: 'thermocycler_id',
+  model: 'thermocyclerModuleV1',
+  type: 'thermocyclerModuleType',
+  port: '/dev/ot_module_thermocycler0',
+  serial: 'ghi789',
+  revision: 'thermocycler_v4.0',
+  fwVersion: 'v2.0.0',
+  status: 'heating',
+  hasAvailableUpdate: true,
+  data: {
+    lid: 'open',
+    lidTarget: 50,
+    lidTemp: 40,
+    currentTemp: null,
+    targetTemp: null,
+    holdTime: null,
+    rampRate: null,
+    currentCycleIndex: null,
+    totalCycleCount: null,
+    currentStepIndex: null,
+    totalStepCount: null,
+  },
+  usbPort: { hub: 1, port: 1 },
+} as any
+
 describe('useLatchCommand', () => {
   const store: Store<any> = createStore(jest.fn(), {})
   let mockCreateLiveCommand = jest.fn()
@@ -501,6 +527,39 @@ describe('useModuleOverflowMenu', () => {
         commandType: 'thermocycler/deactivateBlock',
         params: {
           moduleId: mockTCBlockHeating.id,
+        },
+      },
+    })
+  })
+
+  it('should render TC module and create deactivate lid command', () => {
+    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+      <I18nextProvider i18n={i18n}>
+        <Provider store={store}>{children}</Provider>
+      </I18nextProvider>
+    )
+    const { result } = renderHook(
+      () =>
+        useModuleOverflowMenu(
+          mockTCLidHeating,
+          jest.fn(),
+          jest.fn(),
+          jest.fn(),
+          jest.fn()
+        ),
+      {
+        wrapper,
+      }
+    )
+    const { menuOverflowItemsByModuleType } = result.current
+    const tcMenu = menuOverflowItemsByModuleType.thermocyclerModuleType
+    act(() => tcMenu[0].onClick(true))
+
+    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
+      command: {
+        commandType: 'thermocycler/deactivateLid',
+        params: {
+          moduleId: mockTCLidHeating.id,
         },
       },
     })

--- a/app/src/organisms/Devices/ModuleCard/__tests__/hooks.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/hooks.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { act } from 'react-test-renderer'
-import { fireEvent, screen } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { I18nextProvider } from 'react-i18next'
 import { renderHook } from '@testing-library/react-hooks'
@@ -17,107 +16,12 @@ import {
 } from '../../../../redux/modules/__fixtures__'
 
 import type { Store } from 'redux'
-import type { MenuItemsByModuleType } from '../hooks'
 
 jest.mock('@opentrons/react-api-client')
 
 const mockUseLiveCommandMutation = useCreateLiveCommandMutation as jest.MockedFunction<
   typeof useCreateLiveCommandMutation
 >
-
-const mockMenuItemsByModuleTypeHeaterShakerNotIdle = {
-  thermocyclerModuleType: [
-    {
-      setSetting: 'Set lid temperature',
-      isSecondary: true,
-      disabledReason: false,
-      menuButtons: null,
-      onClick: jest.fn(),
-    },
-    {
-      setSetting: 'Set block temperature',
-      isSecondary: false,
-      disabledReason: false,
-      menuButtons: <div>menu button</div>,
-      onClick: jest.fn(),
-    },
-  ],
-  magneticModuleType: [
-    {
-      setSetting: 'Set engage height',
-      isSecondary: false,
-      disabledReason: false,
-      menuButtons: <div>menu button</div>,
-      onClick: jest.fn(),
-    },
-  ],
-  temperatureModuleType: [
-    {
-      setSetting: 'Set module temperature',
-      isSecondary: false,
-      disabledReason: false,
-      menuButtons: <div>menu button</div>,
-      onClick: jest.fn(),
-    },
-  ],
-  heaterShakerModuleType: [
-    {
-      setSetting: 'Deactivate',
-      isSecondary: false,
-      disabledReason: false,
-      menuButtons: null,
-      onClick: jest.fn(),
-    },
-    {
-      setSetting: 'Stop Shaking',
-      isSecondary: true,
-      disabledReason: true,
-      menuButtons: <div>menu button</div>,
-      onClick: jest.fn(),
-    },
-  ],
-} as MenuItemsByModuleType
-
-// const mockMenuItemsByModuleType = {
-//   thermocyclerModuleType: [
-//     {
-//       setSetting: 'Set lid temperature',
-//       isSecondary: true,
-//       disabledReason: false,
-//     },
-//     {
-//       setSetting: 'Set block temperature',
-//       isSecondary: false,
-//       disabledReason: false,
-//     },
-//   ],
-//   magneticModuleType: [
-//     {
-//       setSetting: 'Set engage height',
-//       isSecondary: false,
-//       disabledReason: false,
-//     },
-//   ],
-//   temperatureModuleType: [
-//     {
-//       setSetting: 'Set module temperature',
-//       isSecondary: false,
-//       disabledReason: false,
-//     },
-//   ],
-//   heaterShakerModuleType: [
-//     {
-//       setSetting: 'Set module temperature',
-//       isSecondary: false,
-//       disabledReason: false,
-//     },
-//     {
-//       setSetting: 'Stop Shaking',
-//       isSecondary: true,
-//       disabledReason: false,
-//     },
-//   ],
-// } as MenuItemsByModuleType
 
 const mockCloseLatchHeaterShaker = {
   model: 'heaterShakerModuleV1',
@@ -329,7 +233,7 @@ describe('useModuleOverflowMenu', () => {
   afterEach(() => {
     jest.restoreAllMocks()
   })
-  it.only('should return everything for menuItemsByModuleType and create deactive heater command', () => {
+  it('should return everything for menuItemsByModuleType and create deactive heater command', () => {
     const wrapper: React.FunctionComponent<{}> = ({ children }) => (
       <I18nextProvider i18n={i18n}>
         <Provider store={store}>{children}</Provider>
@@ -349,24 +253,18 @@ describe('useModuleOverflowMenu', () => {
       }
     )
     const { menuOverflowItemsByModuleType } = result.current
-    console.log(menuOverflowItemsByModuleType)
-    console.log(mockMenuItemsByModuleTypeHeaterShakerNotIdle)
+    const heaterShakerMenu =
+      menuOverflowItemsByModuleType.heaterShakerModuleType
 
-    // expect(menuOverflowItemsByModuleType).toEqual(
-    //   mockMenuItemsByModuleTypeHeaterShakerNotIdle
-    // )
-
-    // act(() =>
-    //   menuOverflowItemsByModuleType.heaterShakerModuleType.onClick(false)
-    // )
-    // expect(mockCreateLiveCommand).toHaveBeenCalledWith({
-    //   command: {
-    //     commandType: 'heaterShakerModule/deactivateHeater',
-    //     params: {
-    //       moduleId: mockDeactivateHeatHeaterShaker.id,
-    //     },
-    //   },
-    // })
+    act(() => heaterShakerMenu[0].onClick(false))
+    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
+      command: {
+        commandType: 'heaterShakerModule/deactivateHeater',
+        params: {
+          moduleId: mockHeatHeaterShaker.id,
+        },
+      },
+    })
   })
   it('should render heater shaker module and create deactive shaker command', () => {
     const wrapper: React.FunctionComponent<{}> = ({ children }) => (
@@ -387,7 +285,10 @@ describe('useModuleOverflowMenu', () => {
         wrapper,
       }
     )
-    act(() => result.current.getOnClickCommand(true))
+    const { menuOverflowItemsByModuleType } = result.current
+    const heaterShakerMenu =
+      menuOverflowItemsByModuleType.heaterShakerModuleType
+    act(() => heaterShakerMenu[1].onClick(true))
     expect(mockCreateLiveCommand).toHaveBeenCalledWith({
       command: {
         commandType: 'heaterShakerModule/stopShake',
@@ -420,13 +321,12 @@ describe('useModuleOverflowMenu', () => {
         wrapper,
       }
     )
-    const { menuButtons, getOnClickCommand } = result.current
+    const { menuOverflowItemsByModuleType } = result.current
+    const heaterShakerMenu =
+      menuOverflowItemsByModuleType.heaterShakerModuleType
 
-    act(() => getOnClickCommand(false))
+    act(() => heaterShakerMenu[1].onClick(true))
     expect(mockHandleClick).toHaveBeenCalled()
-    const aboutModule = screen.getByTestId('about_module_heaterShakerModuleV1')
-    fireEvent.click(aboutModule)
-    expect(mockAboutClick).toHaveBeenCalled()
   })
 
   it('should return only 1 menu button when module is a magnetic module and calls handleClick when module is disengaged', () => {
@@ -449,11 +349,13 @@ describe('useModuleOverflowMenu', () => {
         wrapper,
       }
     )
-    const { menuItemsByModuleType, getOnClickCommand } = result.current
-    act(() => getOnClickCommand(false))
-    expect(menuItemsByModuleType).toStrictEqual(mockMenuItemsByModuleType)
+    const { menuOverflowItemsByModuleType } = result.current
+    const magMenu = menuOverflowItemsByModuleType.magneticModuleType
+
+    act(() => magMenu[0].onClick(false))
     expect(mockHandleClick).toHaveBeenCalled()
   })
+
   it('should render magnetic module and create disengage command', () => {
     const wrapper: React.FunctionComponent<{}> = ({ children }) => (
       <I18nextProvider i18n={i18n}>
@@ -473,7 +375,10 @@ describe('useModuleOverflowMenu', () => {
         wrapper,
       }
     )
-    act(() => result.current.getOnClickCommand(false))
+    const { menuOverflowItemsByModuleType } = result.current
+    const magMenu = menuOverflowItemsByModuleType.magneticModuleType
+
+    act(() => magMenu[0].onClick(false))
     expect(mockCreateLiveCommand).toHaveBeenCalledWith({
       command: {
         commandType: 'magneticModule/disengageMagnet',
@@ -483,6 +388,7 @@ describe('useModuleOverflowMenu', () => {
       },
     })
   })
+
   it('should render temperature module and call handleClick when module is idle', () => {
     const mockHandleClick = jest.fn()
     const wrapper: React.FunctionComponent<{}> = ({ children }) => (
@@ -503,9 +409,12 @@ describe('useModuleOverflowMenu', () => {
         wrapper,
       }
     )
-    act(() => result.current.getOnClickCommand(false))
+    const { menuOverflowItemsByModuleType } = result.current
+    const tempMenu = menuOverflowItemsByModuleType.temperatureModuleType
+    act(() => tempMenu[0].onClick(false))
     expect(mockHandleClick).toHaveBeenCalled()
   })
+
   it('should render temp module and create deactivate temp command', () => {
     const wrapper: React.FunctionComponent<{}> = ({ children }) => (
       <I18nextProvider i18n={i18n}>
@@ -525,7 +434,9 @@ describe('useModuleOverflowMenu', () => {
         wrapper,
       }
     )
-    act(() => result.current.getOnClickCommand(false))
+    const { menuOverflowItemsByModuleType } = result.current
+    const tempMenu = menuOverflowItemsByModuleType.temperatureModuleType
+    act(() => tempMenu[0].onClick(false))
     expect(mockCreateLiveCommand).toHaveBeenCalledWith({
       command: {
         commandType: 'temperatureModule/deactivate',
@@ -535,6 +446,7 @@ describe('useModuleOverflowMenu', () => {
       },
     })
   })
+
   it('should render TC module and call handleClick when module is idle', () => {
     const mockHandleClick = jest.fn()
     const wrapper: React.FunctionComponent<{}> = ({ children }) => (
@@ -555,9 +467,12 @@ describe('useModuleOverflowMenu', () => {
         wrapper,
       }
     )
-    act(() => result.current.getOnClickCommand(false))
+    const { menuOverflowItemsByModuleType } = result.current
+    const tcMenu = menuOverflowItemsByModuleType.thermocyclerModuleType
+    act(() => tcMenu[0].onClick(false))
     expect(mockHandleClick).toHaveBeenCalled()
   })
+
   it('should render TC module and create deactivate temp command', () => {
     const wrapper: React.FunctionComponent<{}> = ({ children }) => (
       <I18nextProvider i18n={i18n}>
@@ -577,7 +492,10 @@ describe('useModuleOverflowMenu', () => {
         wrapper,
       }
     )
-    act(() => result.current.getOnClickCommand(false))
+    const { menuOverflowItemsByModuleType } = result.current
+    const tcMenu = menuOverflowItemsByModuleType.thermocyclerModuleType
+    act(() => tcMenu[1].onClick(false))
+
     expect(mockCreateLiveCommand).toHaveBeenCalledWith({
       command: {
         commandType: 'thermocycler/deactivateBlock',

--- a/app/src/organisms/Devices/ModuleCard/__tests__/hooks.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/hooks.test.tsx
@@ -206,7 +206,7 @@ describe('useLatchCommand', () => {
     const { isLatchClosed } = result.current
 
     expect(isLatchClosed).toBe(false)
-    act(() => result.current.handleLatch())
+    act(() => result.current.toggleLatch())
     expect(mockCreateLiveCommand).toHaveBeenCalledWith({
       command: {
         commandType: 'heaterShakerModule/closeLatch',
@@ -231,7 +231,7 @@ describe('useLatchCommand', () => {
     const { isLatchClosed } = result.current
 
     expect(isLatchClosed).toBe(true)
-    act(() => result.current.handleLatch())
+    act(() => result.current.toggleLatch())
     expect(mockCreateLiveCommand).toHaveBeenCalledWith({
       command: {
         commandType: 'heaterShakerModule/openLatch',
@@ -325,7 +325,7 @@ describe('useModuleOverflowMenu', () => {
     })
   })
   it('should render heater shaker module and calls handleClick when module is idle and calls other handles when button is selected', () => {
-    const mockHandleClick = jest.fn()
+    const mockHandleSlideoutClick = jest.fn()
     const mockAboutClick = jest.fn()
     const mockTestShakeClick = jest.fn()
     const mockHandleWizard = jest.fn()
@@ -341,7 +341,7 @@ describe('useModuleOverflowMenu', () => {
           mockAboutClick,
           mockTestShakeClick,
           mockHandleWizard,
-          mockHandleClick
+          mockHandleSlideoutClick
         ),
       {
         wrapper,
@@ -352,7 +352,7 @@ describe('useModuleOverflowMenu', () => {
       menuOverflowItemsByModuleType.heaterShakerModuleType
 
     act(() => heaterShakerMenu[1].onClick(true))
-    expect(mockHandleClick).toHaveBeenCalled()
+    expect(mockHandleSlideoutClick).toHaveBeenCalled()
   })
 
   it('should return only 1 menu button when module is a magnetic module and calls handleClick when module is disengaged', () => {

--- a/app/src/organisms/Devices/ModuleCard/hooks.tsx
+++ b/app/src/organisms/Devices/ModuleCard/hooks.tsx
@@ -116,9 +116,9 @@ export function useModuleOverflowMenu(
     }
     case 'thermocyclerModuleType': {
       commandType =
-        module.status !== 'idle'
-          ? 'thermocycler/deactivateBlock'
-          : 'thermocycler/deactivateLid'
+        module.data.lidTarget !== null && module.status !== 'idle'
+          ? 'thermocycler/deactivateLid'
+          : 'thermocycler/deactivateBlock'
       break
     }
     case 'heaterShakerModuleType': {

--- a/app/src/organisms/Devices/ModuleCard/hooks.tsx
+++ b/app/src/organisms/Devices/ModuleCard/hooks.tsx
@@ -1,0 +1,313 @@
+import * as React from 'react'
+import { useCreateLiveCommandMutation } from '@opentrons/react-api-client'
+import { useTranslation } from 'react-i18next'
+import { Tooltip, useHoverTooltip } from '@opentrons/components'
+import {
+  CreateCommand,
+  HEATERSHAKER_MODULE_TYPE,
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+} from '@opentrons/shared-data'
+import { MenuItem } from '../../../atoms/MenuList/MenuItem'
+
+import type {
+  HeaterShakerCloseLatchCreateCommand,
+  HeaterShakerDeactivateHeaterCreateCommand,
+  HeaterShakerOpenLatchCreateCommand,
+  HeaterShakerStopShakeCreateCommand,
+  MagneticModuleDisengageMagnetCreateCommand,
+  TCDeactivateBlockCreateCommand,
+  TCDeactivateLidCreateCommand,
+  TemperatureModuleDeactivateCreateCommand,
+} from '@opentrons/shared-data/protocol/types/schemaV6/command/module'
+import type { AttachedModule } from '../../../redux/modules/types'
+
+interface LatchCommand {
+  handleLatch: () => void
+  isLatchClosed: boolean
+}
+
+export function useLatchCommand(module: AttachedModule): LatchCommand {
+  const { createLiveCommand } = useCreateLiveCommandMutation()
+
+  const isLatchClosed =
+    module.type === 'heaterShakerModuleType' &&
+    (module.data.labwareLatchStatus === 'idle_closed' ||
+      module.data.labwareLatchStatus === 'closing')
+
+  const latchCommand:
+    | HeaterShakerOpenLatchCreateCommand
+    | HeaterShakerCloseLatchCreateCommand = {
+    commandType: isLatchClosed
+      ? 'heaterShakerModule/openLatch'
+      : 'heaterShakerModule/closeLatch',
+    params: { moduleId: module.id },
+  }
+
+  const handleLatch = (): void => {
+    createLiveCommand({
+      command: latchCommand,
+    }).catch((e: Error) => {
+      console.error(
+        `error setting module status with command type ${latchCommand.commandType}: ${e.message}`
+      )
+    })
+  }
+  return { handleLatch, isLatchClosed }
+}
+
+export interface MenuItemsByModuleType {
+  thermocyclerModuleType: {
+    setSetting: string
+    isSecondary: boolean
+    disabledReason: boolean
+    menuButtons: JSX.Element | null
+    onClick: (isSecondary: boolean) => void
+  }[]
+  magneticModuleType: {
+    setSetting: string
+    isSecondary: boolean
+    disabledReason: boolean
+    menuButtons: JSX.Element
+    onClick: (isSecondary: boolean) => void
+  }[]
+  temperatureModuleType: {
+    setSetting: string
+    isSecondary: boolean
+    disabledReason: boolean
+    menuButtons: JSX.Element
+    onClick: (isSecondary: boolean) => void
+  }[]
+  heaterShakerModuleType: {
+    setSetting: string
+    isSecondary: boolean
+    disabledReason: boolean
+    menuButtons: JSX.Element[] | null
+    onClick: (isSecondary: boolean) => void
+  }[]
+}
+
+interface ModuleOverflowMenu {
+  menuOverflowItemsByModuleType: MenuItemsByModuleType
+}
+
+export function useModuleOverflowMenu(
+  module: AttachedModule,
+  handleAboutClick: () => void,
+  handleTestShakeClick: () => void,
+  handleWizardClick: () => void,
+  handleClick: (isSecondary: boolean) => void
+): ModuleOverflowMenu {
+  const { t } = useTranslation(['device_details', 'heater_shaker'])
+  const { createLiveCommand } = useCreateLiveCommandMutation()
+  const { handleLatch, isLatchClosed } = useLatchCommand(module)
+  const [targetProps, tooltipProps] = useHoverTooltip()
+
+  let commandType: CreateCommand['commandType']
+  switch (module.type) {
+    case 'temperatureModuleType': {
+      commandType = 'temperatureModule/deactivate'
+      break
+    }
+    case 'magneticModuleType': {
+      commandType = 'magneticModule/disengageMagnet'
+      break
+    }
+    case 'thermocyclerModuleType': {
+      commandType =
+        module.status !== 'idle'
+          ? 'thermocycler/deactivateBlock'
+          : 'thermocycler/deactivateLid'
+      break
+    }
+    case 'heaterShakerModuleType': {
+      commandType =
+        module.data.speedStatus !== 'idle'
+          ? 'heaterShakerModule/stopShake'
+          : 'heaterShakerModule/deactivateHeater'
+      break
+    }
+  }
+
+  const deactivateCommand:
+    | TemperatureModuleDeactivateCreateCommand
+    | MagneticModuleDisengageMagnetCreateCommand
+    | HeaterShakerDeactivateHeaterCreateCommand
+    | TCDeactivateLidCreateCommand
+    | TCDeactivateBlockCreateCommand
+    | HeaterShakerStopShakeCreateCommand = {
+    commandType: commandType,
+    params: { moduleId: module.id },
+  }
+
+  const isLatchDisabled =
+    module.type === HEATERSHAKER_MODULE_TYPE &&
+    module.data.speedStatus !== 'idle'
+
+  const labwareLatchBtn = (
+    <>
+      <MenuItem
+        minWidth="10rem"
+        key={`hs_labware_latch_${module.model}`}
+        data-testid={`hs_labware_latch_${module.model}`}
+        onClick={handleLatch}
+        disabled={isLatchDisabled}
+        {...targetProps}
+      >
+        {t(isLatchClosed ? 'open_labware_latch' : 'close_labware_latch', {
+          ns: 'heater_shaker',
+        })}
+      </MenuItem>
+      {/* TODO:(jr, 3/11/22): update Tooltip to new design */}
+      {isLatchDisabled ? (
+        <Tooltip {...tooltipProps} key={`tooltip_latch_${module.model}`}>
+          {t('cannot_open_latch', { ns: 'heater_shaker' })}
+        </Tooltip>
+      ) : null}
+    </>
+  )
+
+  const aboutModuleBtn = (
+    <MenuItem
+      minWidth="10rem"
+      key={`about_module_${module.model}`}
+      id={`about_module_${module.model}`}
+      data-testid={`about_module_${module.model}`}
+      onClick={() => handleAboutClick()}
+    >
+      {t('overflow_menu_about')}
+    </MenuItem>
+  )
+
+  const attachToDeckBtn = (
+    <MenuItem
+      minWidth="10rem"
+      key={`hs_attach_to_deck_${module.model}`}
+      data-testid={`hs_attach_to_deck_${module.model}`}
+      onClick={() => handleWizardClick()}
+    >
+      {t('how_to_attach_to_deck', { ns: 'heater_shaker' })}
+    </MenuItem>
+  )
+  const testShakeBtn = (
+    <MenuItem
+      minWidth="10rem"
+      onClick={() => handleTestShakeClick()}
+      key={`hs_test_shake_btn_${module.model}`}
+    >
+      {t('test_shake', { ns: 'heater_shaker' })}
+    </MenuItem>
+  )
+
+  const handleDeactivationCommand = (): void => {
+    createLiveCommand({
+      command: deactivateCommand,
+    }).catch((e: Error) => {
+      console.error(
+        `error setting module status with command type ${deactivateCommand.commandType}: ${e.message}`
+      )
+    })
+  }
+
+  const onClick =
+    module.status !== 'idle'
+      ? () => handleDeactivationCommand()
+      : () => handleClick(false)
+
+  const menuOverflowItemsByModuleType = {
+    thermocyclerModuleType: [
+      {
+        setSetting:
+          module.type === THERMOCYCLER_MODULE_TYPE &&
+          module.data.lidTarget !== null
+            ? t('overflow_menu_deactivate_lid')
+            : t('overflow_menu_lid_temp'),
+        isSecondary: true,
+        disabledReason: false,
+        menuButtons: null,
+        onClick:
+          module.type === THERMOCYCLER_MODULE_TYPE &&
+          module.data.lidTarget !== null
+            ? () => handleDeactivationCommand()
+            : () => handleClick(true),
+      },
+      {
+        setSetting:
+          module.type === THERMOCYCLER_MODULE_TYPE && module.status !== 'idle'
+            ? t('overflow_menu_deactivate_block')
+            : t('overflow_menu_set_block_temp'),
+        isSecondary: false,
+        disabledReason: false,
+        menuButtons: aboutModuleBtn,
+        onClick: onClick,
+      },
+    ],
+    temperatureModuleType: [
+      {
+        setSetting:
+          module.type === TEMPERATURE_MODULE_TYPE && module.status !== 'idle'
+            ? t('overflow_menu_deactivate_temp')
+            : t('overflow_menu_mod_temp'),
+        isSecondary: false,
+        disabledReason: false,
+        menuButtons: aboutModuleBtn,
+        onClick: onClick,
+      },
+    ],
+    magneticModuleType: [
+      {
+        setSetting:
+          module.type === MAGNETIC_MODULE_TYPE && module.status !== 'disengaged'
+            ? t('overflow_menu_disengage')
+            : t('overflow_menu_engage'),
+
+        isSecondary: false,
+        disabledReason: false,
+        menuButtons: aboutModuleBtn,
+        onClick:
+          module.status !== 'disengaged'
+            ? () => handleDeactivationCommand()
+            : () => handleClick(false),
+      },
+    ],
+    heaterShakerModuleType: [
+      {
+        setSetting:
+          module.type === HEATERSHAKER_MODULE_TYPE && module.status !== 'idle'
+            ? t('deactivate', { ns: 'heater_shaker' })
+            : t('set_temperature', { ns: 'heater_shaker' }),
+        isSecondary: false,
+        disabledReason: false,
+        menuButtons: null,
+        onClick: onClick,
+      },
+      {
+        setSetting:
+          module.type === HEATERSHAKER_MODULE_TYPE && module.status === 'idle'
+            ? t('set_shake_speed', { ns: 'heater_shaker' })
+            : t('stop_shaking', { ns: 'heater_shaker' }),
+        isSecondary: true,
+        disabledReason:
+          module.type === HEATERSHAKER_MODULE_TYPE &&
+          (module.data.labwareLatchStatus === 'idle_open' ||
+            module.data.labwareLatchStatus === 'opening'),
+        menuButtons: [
+          labwareLatchBtn,
+          aboutModuleBtn,
+          attachToDeckBtn,
+          testShakeBtn,
+        ],
+        onClick:
+          module.type === HEATERSHAKER_MODULE_TYPE &&
+          module.data.speedStatus !== 'idle'
+            ? () => handleDeactivationCommand()
+            : () => handleClick(true),
+      },
+    ],
+  }
+
+  return {
+    menuOverflowItemsByModuleType,
+  }
+}

--- a/app/src/organisms/Devices/ModuleCard/hooks.tsx
+++ b/app/src/organisms/Devices/ModuleCard/hooks.tsx
@@ -58,34 +58,34 @@ export function useLatchCommand(module: AttachedModule): LatchCommand {
 }
 
 export interface MenuItemsByModuleType {
-  thermocyclerModuleType: {
+  thermocyclerModuleType: Array<{
     setSetting: string
     isSecondary: boolean
     disabledReason: boolean
     menuButtons: JSX.Element | null
     onClick: (isSecondary: boolean) => void
-  }[]
-  magneticModuleType: {
+  }>
+  magneticModuleType: Array<{
     setSetting: string
     isSecondary: boolean
     disabledReason: boolean
     menuButtons: JSX.Element
     onClick: (isSecondary: boolean) => void
-  }[]
-  temperatureModuleType: {
+  }>
+  temperatureModuleType: Array<{
     setSetting: string
     isSecondary: boolean
     disabledReason: boolean
     menuButtons: JSX.Element
     onClick: (isSecondary: boolean) => void
-  }[]
-  heaterShakerModuleType: {
+  }>
+  heaterShakerModuleType: Array<{
     setSetting: string
     isSecondary: boolean
     disabledReason: boolean
     menuButtons: JSX.Element[] | null
     onClick: (isSecondary: boolean) => void
-  }[]
+  }>
 }
 
 interface ModuleOverflowMenu {

--- a/app/src/organisms/Devices/ModuleCard/hooks.tsx
+++ b/app/src/organisms/Devices/ModuleCard/hooks.tsx
@@ -56,30 +56,8 @@ export function useLatchCommand(module: AttachedModule): LatchCommand {
   }
   return { toggleLatch, isLatchClosed }
 }
-
-export interface MenuItemsByModuleType {
-  thermocyclerModuleType: Array<{
-    setSetting: string
-    isSecondary: boolean
-    disabledReason: boolean
-    menuButtons: JSX.Element[] | null
-    onClick: (isSecondary: boolean) => void
-  }>
-  magneticModuleType: Array<{
-    setSetting: string
-    isSecondary: boolean
-    disabledReason: boolean
-    menuButtons: JSX.Element[] | null
-    onClick: (isSecondary: boolean) => void
-  }>
-  temperatureModuleType: Array<{
-    setSetting: string
-    isSecondary: boolean
-    disabledReason: boolean
-    menuButtons: JSX.Element[] | null
-    onClick: (isSecondary: boolean) => void
-  }>
-  heaterShakerModuleType: Array<{
+export type MenuItemsByModuleType = {
+  [moduleType in AttachedModule['type']]: Array<{
     setSetting: string
     isSecondary: boolean
     disabledReason: boolean
@@ -87,7 +65,6 @@ export interface MenuItemsByModuleType {
     onClick: (isSecondary: boolean) => void
   }>
 }
-
 interface ModuleOverflowMenu {
   menuOverflowItemsByModuleType: MenuItemsByModuleType
 }

--- a/app/src/organisms/Devices/ModuleCard/index.tsx
+++ b/app/src/organisms/Devices/ModuleCard/index.tsx
@@ -32,6 +32,7 @@ import {
 import { OverflowBtn } from '../../../atoms/MenuList/OverflowBtn'
 import { Banner } from '../../../atoms/Banner'
 import { ModuleIcon } from '../ModuleIcon'
+import { HeaterShakerWizard } from '../HeaterShakerWizard'
 import { MagneticModuleData } from './MagneticModuleData'
 import { TemperatureModuleData } from './TemperatureModuleData'
 import { ThermocyclerModuleData } from './ThermocyclerModuleData'
@@ -67,6 +68,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
   const [showAboutModule, setShowAboutModule] = React.useState(false)
   const [showTestShake, setShowTestShake] = React.useState(false)
   const [showBanner, setShowBanner] = React.useState<boolean>(true)
+  const [showWizard, setShowWizard] = React.useState<boolean>(false)
   const hotToTouch: IconProps = { name: 'ot-hot-to-touch' }
 
   const moduleOverflowWrapperRef = useOnClickOutside({
@@ -159,6 +161,13 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
     setShowSlideout(false)
   }
 
+  const handleWizardClick = (): void => {
+    setShowWizard(true)
+    setShowTestShake(false)
+    setShowOverflowMenu(false)
+    setShowSlideout(false)
+  }
+
   return (
     <React.Fragment>
       <Flex
@@ -169,6 +178,9 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
         width={'20rem'}
         data-testid={`module_card_${module.serial}`}
       >
+        {showWizard && (
+          <HeaterShakerWizard onCloseClick={() => setShowWizard(false)} />
+        )}
         {showSlideout && (
           <ModuleSlideout
             module={module}
@@ -292,6 +304,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
               module={module}
               handleClick={handleMenuItemClick}
               handleTestShakeClick={handleTestShakeClick}
+              handleWizardClick={handleWizardClick}
             />
           </div>
         )}

--- a/app/src/organisms/Devices/ModuleCard/index.tsx
+++ b/app/src/organisms/Devices/ModuleCard/index.tsx
@@ -326,7 +326,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
             <ModuleOverflowMenu
               handleAboutClick={handleAboutClick}
               module={module}
-              handleClick={handleMenuItemClick}
+              handleSlideoutClick={handleMenuItemClick}
               handleTestShakeClick={handleTestShakeClick}
               handleWizardClick={handleWizardClick}
             />


### PR DESCRIPTION
closes #9289 closes #9743 

# Overview

This PR refactors `moduleOverflowMenu`, creating a `useModuleOverflowMenu` hook and a `useLatchCommand` hook. This organizes the logic making the `moduleOverflowMenu` component more straightforward.

This PR also addresses a tiny bug where you can't click through the H-S wizard when accessing it through the overflow menu.

# Changelog

- creates a hook folder in `moduleCard` and creates 2 hooks
- refactors `moduleOverflowMenu` 

# Review requests

- review hook, does  it make sense? Is it easy to understand what it returns?
- click through overflow menus for the module cards for all modules, make sure everything works as expected.

# Risk assessment

low