### PR TITLE
refactor(hardware): ot3 integration test resilence

### DIFF
--- a/hardware/pytest.ini
+++ b/hardware/pytest.ini
@@ -3,3 +3,4 @@ addopts = --color=yes
 markers =
 	slow: mark test as slow
 	requires_emulator: mark test as requiring emulator
+	can_filter_func: can message filtering function

--- a/hardware/tests/firmware_integration/conftest.py
+++ b/hardware/tests/firmware_integration/conftest.py
@@ -37,7 +37,7 @@ async def can_messenger(
 
 @pytest.fixture
 def can_messenger_queue(
-    request,
+    request: FixtureRequest,
     can_messenger: CanMessenger,
 ) -> Iterator[WaitableCallback]:
     """Create WaitableCallback for the CAN Messenger."""

--- a/hardware/tests/firmware_integration/conftest.py
+++ b/hardware/tests/firmware_integration/conftest.py
@@ -37,10 +37,17 @@ async def can_messenger(
 
 @pytest.fixture
 def can_messenger_queue(
+    request,
     can_messenger: CanMessenger,
 ) -> Iterator[WaitableCallback]:
     """Create WaitableCallback for the CAN Messenger."""
-    with WaitableCallback(can_messenger) as wc:
+    # Get optional filtering function.
+    mark = request.node.get_closest_marker("can_filter_func")
+    if not mark:
+        filter_func = None
+    else:
+        filter_func = mark.args[0]
+    with WaitableCallback(messenger=can_messenger, filter=filter_func) as wc:
         yield wc
 
 

--- a/hardware/tests/firmware_integration/test_attached_tools.py
+++ b/hardware/tests/firmware_integration/test_attached_tools.py
@@ -16,6 +16,7 @@ from opentrons_hardware.firmware_bindings.messages.payloads import (
 
 
 def filter_func(arb: ArbitrationId) -> bool:
+    """Message filtering function."""
     return bool(arb.parts.message_id == PushToolsDetectedNotification.message_id)
 
 

--- a/hardware/tests/firmware_integration/test_attached_tools.py
+++ b/hardware/tests/firmware_integration/test_attached_tools.py
@@ -3,7 +3,7 @@ import asyncio
 import pytest
 
 from opentrons_hardware.drivers.can_bus import CanMessenger, WaitableCallback
-from opentrons_hardware.firmware_bindings import NodeId
+from opentrons_hardware.firmware_bindings import NodeId, ArbitrationId
 from opentrons_hardware.firmware_bindings.constants import ToolType
 from opentrons_hardware.firmware_bindings.messages.fields import ToolField
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
@@ -15,7 +15,12 @@ from opentrons_hardware.firmware_bindings.messages.payloads import (
 )
 
 
+def filter_func(arb: ArbitrationId) -> bool:
+    return bool(arb.parts.message_id == PushToolsDetectedNotification.message_id)
+
+
 @pytest.mark.requires_emulator
+@pytest.mark.can_filter_func.with_args(filter_func)
 async def test_attached_tools_request(
     loop: asyncio.BaseEventLoop,
     can_messenger: CanMessenger,

--- a/hardware/tests/firmware_integration/test_device_info.py
+++ b/hardware/tests/firmware_integration/test_device_info.py
@@ -5,7 +5,8 @@ import pytest
 
 from opentrons_hardware.firmware_bindings import ArbitrationId
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
-    DeviceInfoRequest, DeviceInfoResponse,
+    DeviceInfoRequest,
+    DeviceInfoResponse,
 )
 from opentrons_hardware.drivers.can_bus import CanMessenger, WaitableCallback
 from opentrons_hardware.firmware_bindings.constants import NodeId, MessageId
@@ -13,7 +14,10 @@ from opentrons_hardware.firmware_bindings.constants import NodeId, MessageId
 
 def filter_func(arb: ArbitrationId) -> bool:
     """Filtering function for device info tests."""
-    return bool(arb.parts.message_id == MessageId.device_info_response and arb.parts.node_id == NodeId.host)
+    return bool(
+        arb.parts.message_id == MessageId.device_info_response
+        and arb.parts.node_id == NodeId.host
+    )
 
 
 @pytest.mark.requires_emulator

--- a/hardware/tests/firmware_integration/test_eeprom.py
+++ b/hardware/tests/firmware_integration/test_eeprom.py
@@ -2,7 +2,7 @@
 import asyncio
 
 import pytest
-from opentrons_hardware.firmware_bindings import NodeId
+from opentrons_hardware.firmware_bindings import NodeId, ArbitrationId
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     ReadFromEEPromRequest,
     ReadFromEEPromResponse,
@@ -16,8 +16,13 @@ from opentrons_hardware.firmware_bindings.utils import UInt16Field
 from opentrons_hardware.drivers.can_bus import CanMessenger, WaitableCallback
 
 
+def filter_func(arb: ArbitrationId) -> bool:
+    return bool(arb.parts.message_id == ReadFromEEPromResponse.message_id)
+
+
 @pytest.mark.skip("eeprom simulator is broken")
 @pytest.mark.requires_emulator
+@pytest.mark.can_filter_func.with_args(filter_func)
 async def test_read_write(
     loop: asyncio.BaseEventLoop,
     can_messenger: CanMessenger,

--- a/hardware/tests/firmware_integration/test_eeprom.py
+++ b/hardware/tests/firmware_integration/test_eeprom.py
@@ -17,6 +17,7 @@ from opentrons_hardware.drivers.can_bus import CanMessenger, WaitableCallback
 
 
 def filter_func(arb: ArbitrationId) -> bool:
+    """Message filtering function."""
     return bool(arb.parts.message_id == ReadFromEEPromResponse.message_id)
 
 

--- a/hardware/tests/firmware_integration/test_motion_constraints.py
+++ b/hardware/tests/firmware_integration/test_motion_constraints.py
@@ -17,6 +17,7 @@ from opentrons_hardware.drivers.can_bus import CanMessenger, WaitableCallback
 
 
 def filter_func(arb: ArbitrationId) -> bool:
+    """Message filtering function."""
     return bool(arb.parts.message_id == GetMotionConstraintsResponse.message_id)
 
 

--- a/hardware/tests/firmware_integration/test_motion_constraints.py
+++ b/hardware/tests/firmware_integration/test_motion_constraints.py
@@ -7,7 +7,7 @@ from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     GetMotionConstraintsResponse,
 )
 
-from opentrons_hardware.firmware_bindings import NodeId
+from opentrons_hardware.firmware_bindings import NodeId, ArbitrationId
 from opentrons_hardware.firmware_bindings.messages.payloads import (
     MotionConstraintsPayload,
 )
@@ -16,7 +16,12 @@ from opentrons_hardware.firmware_bindings.utils import Int32Field
 from opentrons_hardware.drivers.can_bus import CanMessenger, WaitableCallback
 
 
+def filter_func(arb: ArbitrationId) -> bool:
+    return bool(arb.parts.message_id == GetMotionConstraintsResponse.message_id)
+
+
 @pytest.mark.requires_emulator
+@pytest.mark.can_filter_func.with_args(filter_func)
 async def test_each_node(
     loop: asyncio.BaseEventLoop,
     can_messenger: CanMessenger,

--- a/hardware/tests/firmware_integration/test_motor_driver.py
+++ b/hardware/tests/firmware_integration/test_motor_driver.py
@@ -18,7 +18,8 @@ from opentrons_hardware.drivers.can_bus import CanMessenger, WaitableCallback
 
 
 def filter_func(arb: ArbitrationId) -> bool:
-    return arb.parts.message_id == ReadMotorDriverResponse.message_id
+    """Message filtering function."""
+    return bool(arb.parts.message_id == ReadMotorDriverResponse.message_id)
 
 
 @pytest.mark.requires_emulator

--- a/hardware/tests/firmware_integration/test_motor_driver.py
+++ b/hardware/tests/firmware_integration/test_motor_driver.py
@@ -2,7 +2,7 @@
 import asyncio
 
 import pytest
-from opentrons_hardware.firmware_bindings import NodeId
+from opentrons_hardware.firmware_bindings import NodeId, ArbitrationId
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     ReadMotorDriverRequest,
     ReadMotorDriverResponse,
@@ -17,7 +17,12 @@ from opentrons_hardware.firmware_bindings.utils import UInt8Field, UInt32Field
 from opentrons_hardware.drivers.can_bus import CanMessenger, WaitableCallback
 
 
+def filter_func(arb: ArbitrationId) -> bool:
+    return arb.parts.message_id == ReadMotorDriverResponse.message_id
+
+
 @pytest.mark.requires_emulator
+@pytest.mark.can_filter_func.with_args(filter_func)
 async def test_read_write(
     loop: asyncio.BaseEventLoop,
     can_messenger: CanMessenger,

--- a/hardware/tests/firmware_integration/test_move_groups.py
+++ b/hardware/tests/firmware_integration/test_move_groups.py
@@ -4,7 +4,7 @@ from typing import Iterator
 
 import pytest
 from _pytest.fixtures import FixtureRequest
-from opentrons_hardware.firmware_bindings import NodeId
+from opentrons_hardware.firmware_bindings import NodeId, ArbitrationId
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     AddLinearMoveRequest,
     GetMoveGroupRequest,
@@ -32,7 +32,12 @@ def group_id(request: FixtureRequest) -> Iterator[int]:
     yield request.param  # type: ignore[attr-defined]
 
 
+def filter_func(arb: ArbitrationId) -> bool:
+    return bool(arb.parts.message_id == GetMoveGroupResponse.message_id)
+
+
 @pytest.mark.requires_emulator
+@pytest.mark.can_filter_func.with_args(filter_func)
 async def test_add_moves(
     loop: asyncio.BaseEventLoop,
     can_messenger: CanMessenger,

--- a/hardware/tests/firmware_integration/test_move_groups.py
+++ b/hardware/tests/firmware_integration/test_move_groups.py
@@ -33,6 +33,7 @@ def group_id(request: FixtureRequest) -> Iterator[int]:
 
 
 def filter_func(arb: ArbitrationId) -> bool:
+    """Message filtering function."""
     return bool(arb.parts.message_id == GetMoveGroupResponse.message_id)
 
 

--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -125,6 +125,13 @@ dev-with-emulator: export OT_ROBOT_SERVER_DOT_ENV_PATH ?= emulator.env
 dev-with-emulator:
 	$(pipenv) run $(run_dev)
 
+
+.PHONY: dev-with-ot3-emulator
+dev-with-ot3-emulator: export OT_ROBOT_SERVER_DOT_ENV_PATH ?= emulator_ot3.env
+dev-with-ot3-emulator:
+	$(pipenv) run $(run_dev)
+
+
 .PHONY: local-shell
 local-shell:
 	$(pipenv) shell

--- a/robot-server/emulator.env
+++ b/robot-server/emulator.env
@@ -2,6 +2,3 @@
 OT_ROBOT_SERVER_ws_domain_socket=
 # Set up URIs for emulator
 OT_SMOOTHIE_EMULATOR_URI=socket://127.0.0.1:9996
-OT_THERMOCYCLER_EMULATOR_URI=socket://localhost:9997
-OT_TEMPERATURE_EMULATOR_URI=socket://localhost:9998
-OT_MAGNETIC_EMULATOR_URI=socket://localhost:9999

--- a/robot-server/emulator.env
+++ b/robot-server/emulator.env
@@ -1,4 +1,4 @@
-# Environment for use with OT2 and module emulators
+# Environment for use with OT2
 OT_ROBOT_SERVER_ws_domain_socket=
 # Set up URIs for emulator
 OT_SMOOTHIE_EMULATOR_URI=socket://127.0.0.1:9996

--- a/robot-server/emulator_ot3.env
+++ b/robot-server/emulator_ot3.env
@@ -1,5 +1,4 @@
-# Environment for use with OT3 and module emulators
+# Environment for use with OT3
 OT_ROBOT_SERVER_ws_domain_socket=
-# Set up URIs for emulator
 OT_API_FF_enableOT3HardwareController=true
 OT3_CAN_DRIVER_interface=opentrons_sock

--- a/robot-server/emulator_ot3.env
+++ b/robot-server/emulator_ot3.env
@@ -1,0 +1,5 @@
+# Environment for use with OT3 and module emulators
+OT_ROBOT_SERVER_ws_domain_socket=
+# Set up URIs for emulator
+OT_API_FF_enableOT3HardwareController=true
+OT3_CAN_DRIVER_interface=opentrons_sock


### PR DESCRIPTION
# Overview

Integration tests use message filtering to not simply wait for the next can message but the exact one we're expecting. 

# Changelog

- Create new custom marker `can_filter_fun` to provide method for waitable callback fixture.
- Use `can_filter_fun` in all tests that wait for response.
- Add `robot-server` env file to run with local ot3 emulator.

# Review requests


# Risk assessment

None