### PR TITLE
refactor(api, hardware): ot3: Handle move position response

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -236,32 +236,32 @@ class OT3Controller:
 
         distances_gantry = {
             ax: -1 * self.axis_bounds[ax][1] - self.axis_bounds[ax][0]
-            for ax in axes
+            for ax in checked_axes
             if ax in OT3Axis.gantry_axes() and ax not in OT3Axis.mount_axes()
         }
         velocities_gantry = {
             ax: -1 * speed_settings[OT3Axis.to_kind(ax)]
-            for ax in axes
+            for ax in checked_axes
             if ax in OT3Axis.gantry_axes() and ax not in OT3Axis.mount_axes()
         }
         distances_z = {
             ax: -1 * self.axis_bounds[ax][1] - self.axis_bounds[ax][0]
-            for ax in axes
+            for ax in checked_axes
             if ax in OT3Axis.mount_axes()
         }
         velocities_z = {
             ax: -1 * speed_settings[OT3Axis.to_kind(ax)]
-            for ax in axes
+            for ax in checked_axes
             if ax in OT3Axis.mount_axes()
         }
         distances_pipette = {
             ax: -1 * self.axis_bounds[ax][1] - self.axis_bounds[ax][0]
-            for ax in axes
+            for ax in checked_axes
             if ax in OT3Axis.pipette_axes()
         }
         velocities_pipette = {
             ax: -1 * speed_settings[OT3Axis.to_kind(ax)]
-            for ax in axes
+            for ax in checked_axes
             if ax in OT3Axis.pipette_axes()
         }
         move_group_gantry_z = []

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -213,10 +213,10 @@ class OT3Controller:
             None
         """
         group = create_move_group(origin, moves, self._present_nodes, stop_condition)
-        move_group, final_positions = group
+        move_group, _ = group
         runner = MoveGroupRunner(move_groups=[move_group])
-        await runner.run(can_messenger=self._messenger)
-        self._position.update(final_positions)
+        positions = await runner.run(can_messenger=self._messenger)
+        self._position.update(positions)
 
     async def home(self, axes: Sequence[OT3Axis]) -> OT3AxisMap[float]:
         """Home each axis passed in, and reset the positions to 0.
@@ -290,13 +290,9 @@ class OT3Controller:
             coros.append(runner_gantry_z.run(can_messenger=self._messenger))
         if move_group_pipette:
             coros.append(runner_pipette.run(can_messenger=self._messenger))
-        await asyncio.gather(*coros)
-
-        axis_positions = {
-            axis_to_node(ax): self._get_home_position()[axis_to_node(ax)]
-            for ax in checked_axes
-        }
-        self._position.update(axis_positions)
+        positions = await asyncio.gather(*coros)
+        for position in positions:
+            self._position.update(position)
 
         return axis_convert(self._position, 0.0)
 

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -53,7 +53,7 @@ def mock_move_group_run():
         "opentrons.hardware_control.backends.ot3controller.MoveGroupRunner.run",
         autospec=True,
     ) as mock_mgr_run:
-
+        mock_mgr_run.return_value = {}
         yield mock_mgr_run
 
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -140,7 +140,7 @@ class MoveCompletedPayload(MoveGroupResponsePayload):
     """Notification of a completed move group."""
 
     seq_id: utils.UInt8Field
-    current_position: utils.UInt32Field
+    current_position_um: utils.UInt32Field
     ack_id: utils.UInt8Field
 
 

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -1,7 +1,8 @@
 """Class that schedules motion on can bus."""
 import asyncio
+from collections import defaultdict
 import logging
-from typing import List, Set, Tuple
+from typing import List, Set, Tuple, Iterator
 
 from opentrons_hardware.firmware_bindings import ArbitrationId
 from opentrons_hardware.firmware_bindings.constants import NodeId
@@ -34,8 +35,12 @@ from opentrons_hardware.hardware_control.motion import MoveStopCondition
 from opentrons_hardware.hardware_control.motion_planning.move_utils import (
     MoveConditionNotMet,
 )
+from .types import NodeMap
 
 log = logging.getLogger(__name__)
+
+_CompletionPacket = Tuple[ArbitrationId, MoveCompleted]
+_Completions = List[_CompletionPacket]
 
 
 class MoveGroupRunner:
@@ -51,19 +56,48 @@ class MoveGroupRunner:
         self._move_groups = move_groups
         self._start_at_index = start_at_index
 
-    async def run(self, can_messenger: CanMessenger) -> None:
+    async def run(self, can_messenger: CanMessenger) -> NodeMap[float]:
         """Run the move group.
 
         Args:
             can_messenger: a can messenger
+
+        Returns:
+            The current position after the move for all the axes that
+            acknowledged completing moves.
         """
         if not self._move_groups:
             log.debug("No moves. Nothing to do.")
-            return
+            return {}
 
         await self._clear_groups(can_messenger)
         await self._send_groups(can_messenger)
-        await self._move(can_messenger)
+        move_completion_data = await self._move(can_messenger)
+        return self._accumulate_move_completions(move_completion_data)
+
+    @staticmethod
+    def _accumulate_move_completions(completions: _Completions) -> NodeMap[float]:
+        position: NodeMap[List[Tuple[Tuple[int, int], float]]] = defaultdict(list)
+        for arbid, completion in completions:
+            position[NodeId(arbid.parts.originating_node_id)].append(
+                (
+                    (
+                        completion.payload.group_id.value,
+                        completion.payload.seq_id.value,
+                    ),
+                    float(completion.payload.current_position_um.value) / 1000.0,
+                )
+            )
+        # for each node, pull the position from the completion with the largest
+        # combination of group id and sequence id
+        return {
+            node: next(
+                reversed(
+                    sorted(poslist, key=lambda position_element: position_element[0])
+                )
+            )[1]
+            for node, poslist in position.items()
+        }
 
     async def _clear_groups(self, can_messenger: CanMessenger) -> None:
         """Send commands to clear the message groups.
@@ -128,14 +162,15 @@ class MoveGroupRunner:
             )
             return AddLinearMoveRequest(payload=linear_payload)
 
-    async def _move(self, can_messenger: CanMessenger) -> None:
+    async def _move(self, can_messenger: CanMessenger) -> _Completions:
         """Run all the move groups."""
         scheduler = MoveScheduler(self._move_groups)
         try:
             can_messenger.add_listener(scheduler)
-            await scheduler.run(can_messenger)
+            completions = await scheduler.run(can_messenger)
         finally:
             can_messenger.remove_listener(scheduler)
+        return completions
 
 
 class MoveScheduler:
@@ -159,7 +194,7 @@ class MoveScheduler:
             self._moves.append(move_set)
             self._durations.append(duration)
         log.info(f"Move scheduler running for groups {move_groups}")
-
+        self._completion_queue: asyncio.Queue[_CompletionPacket] = asyncio.Queue()
         self._event = asyncio.Event()
 
     def __call__(
@@ -178,6 +213,7 @@ class MoveScheduler:
                 " in group"
             )
             self._moves[group_id].remove((node_id, seq_id))
+            self._completion_queue.put_nowait((arbitration_id, message))
             if not self._moves[group_id]:
                 log.info(f"Move group {group_id} has completed.")
                 self._event.set()
@@ -189,7 +225,7 @@ class MoveScheduler:
                     log.warning(f"Homing failed. Condition: {condition}")
                     raise MoveConditionNotMet()
 
-    async def run(self, can_messenger: CanMessenger) -> None:
+    async def run(self, can_messenger: CanMessenger) -> _Completions:
         """Start each move group after the prior has completed."""
         for group_id in range(len(self._moves)):
             self._event.clear()
@@ -214,3 +250,9 @@ class MoveScheduler:
                 )
             except asyncio.TimeoutError:
                 log.warning("Move set timed out")
+
+        def _reify_queue_iter() -> Iterator[_CompletionPacket]:
+            while not self._completion_queue.empty():
+                yield self._completion_queue.get_nowait()
+
+        return list(_reify_queue_iter())

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -35,7 +35,7 @@ from opentrons_hardware.hardware_control.motion import MoveStopCondition
 from opentrons_hardware.hardware_control.motion_planning.move_utils import (
     MoveConditionNotMet,
 )
-from .types import NodeMap
+from .types import NodeDict
 
 log = logging.getLogger(__name__)
 
@@ -56,7 +56,7 @@ class MoveGroupRunner:
         self._move_groups = move_groups
         self._start_at_index = start_at_index
 
-    async def run(self, can_messenger: CanMessenger) -> NodeMap[float]:
+    async def run(self, can_messenger: CanMessenger) -> NodeDict[float]:
         """Run the move group.
 
         Args:
@@ -76,8 +76,8 @@ class MoveGroupRunner:
         return self._accumulate_move_completions(move_completion_data)
 
     @staticmethod
-    def _accumulate_move_completions(completions: _Completions) -> NodeMap[float]:
-        position: NodeMap[List[Tuple[Tuple[int, int], float]]] = defaultdict(list)
+    def _accumulate_move_completions(completions: _Completions) -> NodeDict[float]:
+        position: NodeDict[List[Tuple[Tuple[int, int], float]]] = defaultdict(list)
         for arbid, completion in completions:
             position[NodeId(arbid.parts.originating_node_id)].append(
                 (

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -56,6 +56,14 @@ class MoveGroupRunner:
         self._move_groups = move_groups
         self._start_at_index = start_at_index
 
+    @staticmethod
+    def _has_moves(move_groups: MoveGroups) -> bool:
+        for move_group in move_groups:
+            for move in move_group:
+                for node, step in move.items():
+                    return True
+        return False
+
     async def run(self, can_messenger: CanMessenger) -> NodeDict[float]:
         """Run the move group.
 
@@ -66,7 +74,7 @@ class MoveGroupRunner:
             The current position after the move for all the axes that
             acknowledged completing moves.
         """
-        if not self._move_groups:
+        if not self._has_moves(self._move_groups):
             log.debug("No moves. Nothing to do.")
             return {}
 

--- a/hardware/opentrons_hardware/hardware_control/types.py
+++ b/hardware/opentrons_hardware/hardware_control/types.py
@@ -1,8 +1,10 @@
 """Types and definitions for hardware bindings."""
-from typing import Mapping, TypeVar
+from typing import Mapping, TypeVar, Dict
 
 from opentrons_hardware.firmware_bindings.constants import NodeId
 
 MapPayload = TypeVar("MapPayload")
 
 NodeMap = Mapping[NodeId, MapPayload]
+
+NodeDict = Dict[NodeId, MapPayload]

--- a/hardware/tests/firmware_integration/conftest.py
+++ b/hardware/tests/firmware_integration/conftest.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 import pytest
 import asyncio
-from typing import AsyncGenerator, Iterator, AsyncIterator
+from typing import AsyncGenerator, Iterator, AsyncIterator, List
 
 from _pytest.fixtures import FixtureRequest
 
@@ -65,16 +65,24 @@ def subsystem_node_id(request: FixtureRequest) -> Iterator[constants.NodeId]:
     yield request.param  # type: ignore[attr-defined]
 
 
+_motor_nodes = [
+    constants.NodeId.head_l,
+    constants.NodeId.head_r,
+    constants.NodeId.pipette_left,
+    constants.NodeId.gantry_x,
+    constants.NodeId.gantry_y,
+]
+
+
 @pytest.fixture(
     scope="session",
-    params=[
-        constants.NodeId.head_l,
-        constants.NodeId.head_r,
-        constants.NodeId.pipette_left,
-        constants.NodeId.gantry_x,
-        constants.NodeId.gantry_y,
-    ],
+    params=_motor_nodes,
 )
 def motor_node_id(request: FixtureRequest) -> Iterator[constants.NodeId]:
     """Each motor's node id as a fixture."""
     yield request.param  # type: ignore[attr-defined]
+
+
+@pytest.fixture(scope="session")
+def all_motor_nodes() -> List[constants.NodeId]:
+    return _motor_nodes

--- a/hardware/tests/firmware_integration/conftest.py
+++ b/hardware/tests/firmware_integration/conftest.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 import pytest
 import asyncio
-from typing import AsyncGenerator, Iterator, AsyncIterator, List
+from typing import AsyncGenerator, Iterator, AsyncIterator, List, Dict
 
 from _pytest.fixtures import FixtureRequest
 
@@ -73,6 +73,21 @@ _motor_nodes = [
     constants.NodeId.gantry_y,
 ]
 
+# These unfortunately need to be manually kept up to date with the c++
+# configurations
+_motor_node_step_sizes = {
+    # for lead screw pitch 12, microstepping 16
+    constants.NodeId.head_l: 0.00375,
+    constants.NodeId.head_r: 0.00375,
+    # for pulley diameter 12, microstepping 32
+    constants.NodeId.gantry_x: 0.006234098,
+    # for pulley diameter 12.7254, microstepping 32
+    constants.NodeId.gantry_y: 0.006246566,
+    # for lead screw pitch 3.03, microstepping 32
+    constants.NodeId.pipette_left: 0.000473437,
+    constants.NodeId.pipette_right: 0.000473437,
+}
+
 
 @pytest.fixture(
     scope="session",
@@ -85,4 +100,11 @@ def motor_node_id(request: FixtureRequest) -> Iterator[constants.NodeId]:
 
 @pytest.fixture(scope="session")
 def all_motor_nodes() -> List[constants.NodeId]:
+    """The full list of configured motor nodes."""
     return _motor_nodes
+
+
+@pytest.fixture(scope="session")
+def all_motor_node_step_sizes() -> Dict[constants.NodeId, float]:
+    """Step sizes for all configured motor nodes."""
+    return _motor_node_step_sizes

--- a/hardware/tests/firmware_integration/test_move_groups.py
+++ b/hardware/tests/firmware_integration/test_move_groups.py
@@ -1,6 +1,7 @@
 """Tests for move groups."""
 import asyncio
-from typing import Iterator
+import numpy as np  # type: ignore
+from typing import Iterator, List
 
 import pytest
 from _pytest.fixtures import FixtureRequest
@@ -21,6 +22,8 @@ from opentrons_hardware.firmware_bindings.utils import (
 )
 
 from opentrons_hardware.drivers.can_bus import CanMessenger, WaitableCallback
+from opentrons_hardware.hardware_control.move_group_runner import MoveGroupRunner
+from opentrons_hardware.hardware_control.motion import create_step, create_home_step
 
 
 @pytest.fixture(
@@ -80,3 +83,71 @@ async def test_add_moves(
     assert isinstance(response, GetMoveGroupResponse)
     assert response.payload.num_moves.value == len(durations)
     assert response.payload.total_duration.value == sum(durations)
+
+
+@pytest.mark.requires_emulator
+async def test_move_integration(
+    loop: asyncio.BaseEventLoop,
+    can_messenger: CanMessenger,
+    can_messenger_queue: WaitableCallback,
+    all_motor_nodes: List[NodeId],
+) -> None:
+    """Test that moving returns correct positions."""
+
+    # First, we should test homing. We have to home because the emulator stack is long-lived
+    # beyond each test, so we might as well make sure we're homing from a non-zero position
+    prep_move = [create_step(
+            distance={motor_node: motor_node.value for motor_node in all_motor_nodes},
+            velocity={
+                motor_node: motor_node.value / 10 for motor_node in all_motor_nodes
+            },
+            acceleration={motor_node: 0 for motor_node in all_motor_nodes},
+            duration=np.float64(1),
+            present_nodes=all_motor_nodes,
+        )]
+    prep_runner = MoveGroupRunner([prep_move])
+    # throw away this position - it may change depending on previous state of simulators
+    await prep_runner.run(can_messenger)
+
+    home_move = [create_home_step(
+        distance={motor_node: 10 for motor_node in all_motor_nodes},
+        velocity={motor_node: 40 for motor_node in all_motor_nodes})]
+    home_runner = MoveGroupRunner([home_move])
+    position = await home_runner.run(can_messenger)
+    assert position == {motor_node: 0 for motor_node in all_motor_nodes}
+    moves = [
+        create_step(
+            distance={motor_node: motor_node.value for motor_node in all_motor_nodes},
+            velocity={
+                motor_node: motor_node.value for motor_node in all_motor_nodes
+            },
+            acceleration={motor_node: 0 for motor_node in all_motor_nodes},
+            duration=np.float64(1),
+            present_nodes=all_motor_nodes,
+        ),
+        create_step(
+            distance={motor_node: motor_node.value for motor_node in all_motor_nodes},
+            velocity={
+                motor_node: motor_node.value for motor_node in all_motor_nodes
+            },
+            acceleration={motor_node: 0 for motor_node in all_motor_nodes},
+            duration=np.float64(1),
+            present_nodes=all_motor_nodes,
+        ),
+        create_step(
+            distance={motor_node: -motor_node.value for motor_node in all_motor_nodes},
+            velocity={
+                motor_node: -motor_node.value for motor_node in all_motor_nodes
+            },
+            acceleration={motor_node: 0 for motor_node in all_motor_nodes},
+            duration=np.float64(1),
+            present_nodes=all_motor_nodes,
+        ),
+    ]
+    runner = MoveGroupRunner([moves])
+    await runner.run(can_messenger)
+
+    position = await runner.run(can_messenger)
+    assert position == {
+        motor_node: pytest.approx(motor_node.value) for motor_node in all_motor_nodes
+    }

--- a/hardware/tests/firmware_integration/test_move_groups.py
+++ b/hardware/tests/firmware_integration/test_move_groups.py
@@ -1,7 +1,7 @@
 """Tests for move groups."""
 import asyncio
 import numpy as np  # type: ignore
-from typing import Iterator, List
+from typing import Iterator, List, Dict
 
 import pytest
 from _pytest.fixtures import FixtureRequest
@@ -91,12 +91,14 @@ async def test_move_integration(
     can_messenger: CanMessenger,
     can_messenger_queue: WaitableCallback,
     all_motor_nodes: List[NodeId],
+    all_motor_node_step_sizes: Dict[NodeId, float],
 ) -> None:
     """Test that moving returns correct positions."""
-
-    # First, we should test homing. We have to home because the emulator stack is long-lived
-    # beyond each test, so we might as well make sure we're homing from a non-zero position
-    prep_move = [create_step(
+    # First, we should test homing. We have to home because the emulator stack is
+    # long-lived beyond each test, so we might as well make sure we're homing
+    # from a non-zero position
+    prep_move = [
+        create_step(
             distance={motor_node: motor_node.value for motor_node in all_motor_nodes},
             velocity={
                 motor_node: motor_node.value / 10 for motor_node in all_motor_nodes
@@ -104,50 +106,78 @@ async def test_move_integration(
             acceleration={motor_node: 0 for motor_node in all_motor_nodes},
             duration=np.float64(1),
             present_nodes=all_motor_nodes,
-        )]
+        )
+    ]
     prep_runner = MoveGroupRunner([prep_move])
-    # throw away this position - it may change depending on previous state of simulators
+    # throw away this position - it may change depending on previous state of
+    # simulators
     await prep_runner.run(can_messenger)
 
-    home_move = [create_home_step(
-        distance={motor_node: 10 for motor_node in all_motor_nodes},
-        velocity={motor_node: 40 for motor_node in all_motor_nodes})]
+    home_move = [
+        create_home_step(
+            distance={motor_node: 10 for motor_node in all_motor_nodes},
+            velocity={motor_node: 40 for motor_node in all_motor_nodes},
+        )
+    ]
     home_runner = MoveGroupRunner([home_move])
     position = await home_runner.run(can_messenger)
     assert position == {motor_node: 0 for motor_node in all_motor_nodes}
+    # these moves test position accumulation to reasonably realistic values
+    # and have to do it over a kind of long time so that the velocities are low
+    # enough that the pipettes, with their extremely high steps/mm values,
+    # can handle it. The exact time this takes will be dependent on the speed of
+    # the computer.
     moves = [
         create_step(
-            distance={motor_node: motor_node.value for motor_node in all_motor_nodes},
+            distance={
+                motor_node: motor_node.value / 4 for motor_node in all_motor_nodes
+            },
             velocity={
-                motor_node: motor_node.value for motor_node in all_motor_nodes
+                motor_node: motor_node.value / 4 for motor_node in all_motor_nodes
             },
             acceleration={motor_node: 0 for motor_node in all_motor_nodes},
-            duration=np.float64(1),
+            duration=np.float64(4),
             present_nodes=all_motor_nodes,
         ),
         create_step(
-            distance={motor_node: motor_node.value for motor_node in all_motor_nodes},
+            distance={
+                motor_node: motor_node.value / 4 for motor_node in all_motor_nodes
+            },
             velocity={
-                motor_node: motor_node.value for motor_node in all_motor_nodes
+                motor_node: motor_node.value / 4 for motor_node in all_motor_nodes
             },
             acceleration={motor_node: 0 for motor_node in all_motor_nodes},
-            duration=np.float64(1),
+            duration=np.float64(4),
             present_nodes=all_motor_nodes,
         ),
         create_step(
-            distance={motor_node: -motor_node.value for motor_node in all_motor_nodes},
+            distance={
+                motor_node: -motor_node.value / 4 for motor_node in all_motor_nodes
+            },
             velocity={
-                motor_node: -motor_node.value for motor_node in all_motor_nodes
+                motor_node: -motor_node.value / 4 for motor_node in all_motor_nodes
             },
             acceleration={motor_node: 0 for motor_node in all_motor_nodes},
-            duration=np.float64(1),
+            duration=np.float64(4),
             present_nodes=all_motor_nodes,
         ),
     ]
     runner = MoveGroupRunner([moves])
-    await runner.run(can_messenger)
-
     position = await runner.run(can_messenger)
-    assert position == {
-        motor_node: pytest.approx(motor_node.value) for motor_node in all_motor_nodes
+    # The numerical comparisons here are complicated because there are several unit
+    # conversions that involve losing precision:
+    # - velocities specified above in float mm/s are converted to fixed point sq0.31
+    #   mm/tick, a discretizing operation to (2**-31)*10e6 mm/s
+    # - in the firmware, that velocity is converted to steps/tick, which is a
+    #   discretizing operation to 2**-31 step
+    # - in the firmware, after velocity is accumulated to position, that position
+    #   is converted to micrometers which is a different discretizing conversion to
+    #   10e-3 mm
+    #  All of this lines up to mean you have to give some wiggle room for positions.
+    #  Also mypy doesn't like pytest.approx so we have to type ignore it
+    assert position == {  # type: ignore[comparison-overlap]
+        motor_node: pytest.approx(
+            motor_node.value, abs=all_motor_node_step_sizes[motor_node] * 3
+        )
+        for motor_node in all_motor_nodes
     }

--- a/hardware/tests/opentrons_hardware/drivers/can_bus/test_can_messenger.py
+++ b/hardware/tests/opentrons_hardware/drivers/can_bus/test_can_messenger.py
@@ -65,7 +65,7 @@ def subject(mock_driver: AsyncMock) -> CanMessenger:
                 payload=MoveCompletedPayload(
                     group_id=UInt8Field(1),
                     seq_id=UInt8Field(2),
-                    current_position=UInt32Field(3),
+                    current_position_um=UInt32Field(3),
                     ack_id=UInt8Field(4),
                 )
             ),

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -1,6 +1,6 @@
 """Tests for the move scheduler."""
 import pytest
-from typing import List, Tuple
+from typing import List, Tuple, Any
 from mock import AsyncMock, call, MagicMock
 from opentrons_hardware.firmware_bindings import ArbitrationId, ArbitrationIdParts
 
@@ -635,3 +635,13 @@ def test_accumulate_move_completions(
 ) -> None:
     """Build correct move results."""
     assert MoveGroupRunner._accumulate_move_completions(completions) == position_map
+
+
+@pytest.mark.parametrize("empty_group", [[], [[]], [[{}]]])
+async def test_empty_groups(
+    mock_can_messenger: AsyncMock, empty_group: List[Any]
+) -> None:
+    """Test that various kinds of empty groups result in no calls."""
+    mg = MoveGroupRunner(empty_group)
+    await mg.run(mock_can_messenger)
+    mock_can_messenger.send.assert_not_called()

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -1,5 +1,6 @@
 """Tests for the move scheduler."""
 import pytest
+from typing import List, Tuple
 from mock import AsyncMock, call, MagicMock
 from opentrons_hardware.firmware_bindings import ArbitrationId, ArbitrationIdParts
 
@@ -8,6 +9,7 @@ from opentrons_hardware.drivers.can_bus.can_messenger import MessageListenerCall
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     AddLinearMoveRequest,
     HomeRequest,
+    MoveCompleted,
 )
 from opentrons_hardware.firmware_bindings.messages.payloads import (
     AddLinearMoveRequestPayload,
@@ -28,6 +30,7 @@ from opentrons_hardware.hardware_control.move_group_runner import (
     MoveGroupRunner,
     MoveScheduler,
 )
+from opentrons_hardware.hardware_control.types import NodeMap
 from opentrons_hardware.firmware_bindings.messages import (
     message_definitions as md,
     MessageDefinition,
@@ -52,7 +55,7 @@ def move_group_single() -> MoveGroups:
         [
             {
                 NodeId.head: MoveGroupSingleAxisStep(
-                    distance_mm=0, velocity_mm_sec=2, duration_sec=123
+                    distance_mm=246, velocity_mm_sec=2, duration_sec=123
                 )
             }
         ]
@@ -87,7 +90,7 @@ def move_group_multiple() -> MoveGroups:
         [
             {
                 NodeId.head: MoveGroupSingleAxisStep(
-                    distance_mm=0,
+                    distance_mm=229,
                     velocity_mm_sec=235,
                     duration_sec=2142,
                     acceleration_mm_sec_sq=1000,
@@ -98,13 +101,13 @@ def move_group_multiple() -> MoveGroups:
         [
             {
                 NodeId.gantry_x: MoveGroupSingleAxisStep(
-                    distance_mm=0,
+                    distance_mm=522,
                     velocity_mm_sec=22,
                     duration_sec=1,
                     acceleration_mm_sec_sq=1000,
                 ),
                 NodeId.gantry_y: MoveGroupSingleAxisStep(
-                    distance_mm=0,
+                    distance_mm=25,
                     velocity_mm_sec=23,
                     duration_sec=0,
                     acceleration_mm_sec_sq=1000,
@@ -136,8 +139,9 @@ def move_group_multiple() -> MoveGroups:
 async def test_no_groups_do_nothing(mock_can_messenger: AsyncMock) -> None:
     """It should not send any commands if there are no moves."""
     subject = MoveGroupRunner(move_groups=[])
-    await subject.run(mock_can_messenger)
+    position = await subject.run(mock_can_messenger)
     mock_can_messenger.send.assert_not_called()
+    assert position == {}
 
 
 async def test_single_group_clear(
@@ -443,11 +447,11 @@ class MockSendMoveCompleter:
             for seq_id, moves in enumerate(
                 self._move_groups[message.payload.group_id.value]
             ):
-                for node in moves.keys():
+                for node, move in moves.items():
                     payload = MoveCompletedPayload(
                         group_id=message.payload.group_id,
                         seq_id=UInt8Field(seq_id),
-                        current_position=UInt32Field(0),
+                        current_position_um=UInt32Field(int(move.distance_mm * 1000)),
                         ack_id=UInt8Field(1),
                     )
                     arbitration_id = ArbitrationId(
@@ -463,7 +467,7 @@ async def test_single_move(
     subject = MoveScheduler(move_groups=move_group_single)
     mock_sender = MockSendMoveCompleter(move_group_single, subject)
     mock_can_messenger.send.side_effect = mock_sender.mock_send
-    await subject.run(can_messenger=mock_can_messenger)
+    position = await subject.run(can_messenger=mock_can_messenger)
 
     mock_can_messenger.send.assert_has_calls(
         calls=[
@@ -479,6 +483,8 @@ async def test_single_move(
             )
         ]
     )
+    assert len(position) == 1
+    assert position[0][1].payload.current_position_um.value == 246000
 
 
 async def test_multi_group_move(
@@ -488,7 +494,7 @@ async def test_multi_group_move(
     subject = MoveScheduler(move_groups=move_group_multiple)
     mock_sender = MockSendMoveCompleter(move_group_multiple, subject)
     mock_can_messenger.send.side_effect = mock_sender.mock_send
-    await subject.run(can_messenger=mock_can_messenger)
+    position = await subject.run(can_messenger=mock_can_messenger)
 
     mock_can_messenger.send.assert_has_calls(
         calls=[
@@ -524,3 +530,108 @@ async def test_multi_group_move(
             ),
         ]
     )
+    assert len(position) == 5
+    assert position[0][1].payload.current_position_um.value == 229000
+    assert position[1][1].payload.current_position_um.value == 522000
+    assert position[2][1].payload.current_position_um.value == 25000
+    assert position[3][1].payload.current_position_um.value == 12000
+    assert position[4][1].payload.current_position_um.value == 12000
+
+
+def _build_arb(from_node: NodeId) -> ArbitrationId:
+    return ArbitrationId(ArbitrationIdParts(originating_node_id=from_node))
+
+
+@pytest.mark.parametrize(
+    "completions,position_map",
+    [
+        (
+            # one axis, completions reversed compared to execution order
+            [
+                (
+                    _build_arb(NodeId.gantry_x),
+                    MoveCompleted(
+                        payload=MoveCompletedPayload(
+                            ack_id=UInt8Field(0),
+                            group_id=UInt8Field(2),
+                            seq_id=UInt8Field(2),
+                            current_position_um=UInt32Field(10000),
+                        )
+                    ),
+                ),
+                (
+                    _build_arb(NodeId.gantry_x),
+                    MoveCompleted(
+                        payload=MoveCompletedPayload(
+                            ack_id=UInt8Field(0),
+                            group_id=UInt8Field(2),
+                            seq_id=UInt8Field(1),
+                            current_position_um=UInt32Field(20000),
+                        )
+                    ),
+                ),
+                (
+                    _build_arb(NodeId.gantry_x),
+                    MoveCompleted(
+                        payload=MoveCompletedPayload(
+                            ack_id=UInt8Field(0),
+                            group_id=UInt8Field(1),
+                            seq_id=UInt8Field(2),
+                            current_position_um=UInt32Field(30000),
+                        )
+                    ),
+                ),
+            ],
+            {NodeId.gantry_x: 10},
+        ),
+        (
+            # multiple axes with different numbers of completions
+            [
+                (
+                    _build_arb(NodeId.gantry_x),
+                    MoveCompleted(
+                        payload=MoveCompletedPayload(
+                            ack_id=UInt8Field(0),
+                            group_id=UInt8Field(2),
+                            seq_id=UInt8Field(2),
+                            current_position_um=UInt32Field(10000),
+                        )
+                    ),
+                ),
+                (
+                    _build_arb(NodeId.gantry_x),
+                    MoveCompleted(
+                        payload=MoveCompletedPayload(
+                            ack_id=UInt8Field(0),
+                            group_id=UInt8Field(2),
+                            seq_id=UInt8Field(1),
+                            current_position_um=UInt32Field(20000),
+                        )
+                    ),
+                ),
+                (
+                    _build_arb(NodeId.gantry_y),
+                    MoveCompleted(
+                        payload=MoveCompletedPayload(
+                            ack_id=UInt8Field(0),
+                            group_id=UInt8Field(1),
+                            seq_id=UInt8Field(2),
+                            current_position_um=UInt32Field(30000),
+                        )
+                    ),
+                ),
+            ],
+            {NodeId.gantry_x: 10, NodeId.gantry_y: 30},
+        ),
+        (
+            # empty base case
+            [],
+            {},
+        ),
+    ],
+)
+def test_accumulate_move_completions(
+    completions: List[Tuple[ArbitrationId, MoveCompleted]], position_map: NodeMap[float]
+) -> None:
+    """Build correct move results."""
+    assert MoveGroupRunner._accumulate_move_completions(completions) == position_map


### PR DESCRIPTION
After https://github.com/Opentrons/ot3-firmware/pull/304 , the firmware will return the current value of the position tracker in micrometers rather than steps, which means we can use its value to estimate the current position of the system. Add handling for the position value in MoveCompleted messages from Canbus and bubble it up to the position tracker in the controller.