### PR TITLE
refactor(hardware): move fw upgrade out of script

### DIFF
--- a/hardware/opentrons_hardware/firmware_update/__init__.py
+++ b/hardware/opentrons_hardware/firmware_update/__init__.py
@@ -7,11 +7,13 @@ from .initiator import (
     gantry_x,
     pipette_left,
     pipette_right,
+    gripper,
     Target,
 )
 from .downloader import FirmwareUpdateDownloader
 from .hex_file import from_hex_file_path, from_hex_contents, HexRecordProcessor
 from .eraser import FirmwareUpdateEraser
+from .run import run_update
 
 __all__ = [
     "FirmwareUpdateDownloader",
@@ -22,8 +24,10 @@ __all__ = [
     "gantry_x",
     "pipette_left",
     "pipette_right",
+    "gripper",
     "from_hex_file_path",
     "from_hex_contents",
     "HexRecordProcessor",
     "Target",
+    "run_update",
 ]

--- a/hardware/opentrons_hardware/firmware_update/hex_file.py
+++ b/hardware/opentrons_hardware/firmware_update/hex_file.py
@@ -152,6 +152,11 @@ class HexRecordProcessor:
         """Construct from file."""
         return HexRecordProcessor(from_hex_file_path(file_path))
 
+    @classmethod
+    def from_content(cls, file_path: Path) -> HexRecordProcessor:
+        """Construct from file."""
+        return HexRecordProcessor(from_hex_file_path(file_path))
+
     @property
     def start_address(self) -> int:
         """Get the start address.

--- a/hardware/opentrons_hardware/firmware_update/initiator.py
+++ b/hardware/opentrons_hardware/firmware_update/initiator.py
@@ -36,6 +36,9 @@ gantry_x: Final = Target(
 gantry_y: Final = Target(
     system_node=NodeId.gantry_y, bootloader_node=NodeId.gantry_y_bootloader
 )
+gripper: Final = Target(
+    system_node=NodeId.gripper, bootloader_node=NodeId.gripper_bootloader
+)
 
 
 class FirmwareUpdateInitiator:

--- a/hardware/opentrons_hardware/firmware_update/run.py
+++ b/hardware/opentrons_hardware/firmware_update/run.py
@@ -1,0 +1,66 @@
+"""Complete FW updater."""
+import logging
+from typing import Optional
+
+from opentrons_hardware.drivers.can_bus import CanMessenger
+from opentrons_hardware.firmware_bindings.messages.message_definitions import \
+    FirmwareUpdateStartApp
+from opentrons_hardware.firmware_update import FirmwareUpdateInitiator, \
+    FirmwareUpdateDownloader, FirmwareUpdateEraser, HexRecordProcessor, Target
+
+
+logger = logging.getLogger(__name__)
+
+
+async def run_update(
+        messenger: CanMessenger,
+        target: Target,
+        hex_processor: HexRecordProcessor,
+        retry_count: int,
+        timeout_seconds: float,
+        erase: Optional[bool] = True) -> None:
+    """Perform a firmware update on a node target.
+
+    Args:
+        messenger: The can messenger to use
+        target: The node being updated
+        hex_processor: The producer of
+        retry_count: Number of times to retry.
+        timeout_seconds: How much to wait for responses.
+        erase: Whether to erase flash before updating.
+
+    Returns:
+        None
+    """
+    initiator = FirmwareUpdateInitiator(messenger)
+    downloader = FirmwareUpdateDownloader(messenger)
+
+    logger.info(f"Initiating FW Update on {target}.")
+
+    await initiator.run(
+        target=target,
+        retry_count=retry_count,
+        ready_wait_time_sec=timeout_seconds,
+    )
+    if erase:
+        eraser = FirmwareUpdateEraser(messenger)
+        logger.info(f"Erasing existing FW Update on {target}.")
+        await eraser.run(
+            node_id=target.bootloader_node,
+            timeout_sec=timeout_seconds,
+        )
+    else:
+        logger.info("Skipping erase step.")
+
+    logger.info(f"Downloading FW to {target.bootloader_node}.")
+    await downloader.run(
+        node_id=target.bootloader_node,
+        hex_processor=hex_processor,
+        ack_wait_seconds=timeout_seconds,
+    )
+
+    logger.info(f"Restarting FW on {target.system_node}.")
+    await messenger.send(
+        node_id=target.bootloader_node,
+        message=FirmwareUpdateStartApp(),
+    )

--- a/hardware/opentrons_hardware/firmware_update/run.py
+++ b/hardware/opentrons_hardware/firmware_update/run.py
@@ -3,22 +3,29 @@ import logging
 from typing import Optional
 
 from opentrons_hardware.drivers.can_bus import CanMessenger
-from opentrons_hardware.firmware_bindings.messages.message_definitions import \
-    FirmwareUpdateStartApp
-from opentrons_hardware.firmware_update import FirmwareUpdateInitiator, \
-    FirmwareUpdateDownloader, FirmwareUpdateEraser, HexRecordProcessor, Target
+from opentrons_hardware.firmware_bindings.messages.message_definitions import (
+    FirmwareUpdateStartApp,
+)
+from opentrons_hardware.firmware_update import (
+    FirmwareUpdateInitiator,
+    FirmwareUpdateDownloader,
+    FirmwareUpdateEraser,
+    HexRecordProcessor,
+    Target,
+)
 
 
 logger = logging.getLogger(__name__)
 
 
 async def run_update(
-        messenger: CanMessenger,
-        target: Target,
-        hex_processor: HexRecordProcessor,
-        retry_count: int,
-        timeout_seconds: float,
-        erase: Optional[bool] = True) -> None:
+    messenger: CanMessenger,
+    target: Target,
+    hex_processor: HexRecordProcessor,
+    retry_count: int,
+    timeout_seconds: float,
+    erase: Optional[bool] = True,
+) -> None:
     """Perform a firmware update on a node target.
 
     Args:

--- a/hardware/opentrons_hardware/scripts/update_fw.py
+++ b/hardware/opentrons_hardware/scripts/update_fw.py
@@ -68,8 +68,14 @@ async def run(args: argparse.Namespace) -> None:
     messenger = CanMessenger(driver)
     messenger.start()
 
-    await run_update(messenger=messenger, target=target, hex_processor=hex_processor,
-                     retry_count=retry_count, timeout_seconds=timeout_seconds, erase=erase)
+    await run_update(
+        messenger=messenger,
+        target=target,
+        hex_processor=hex_processor,
+        retry_count=retry_count,
+        timeout_seconds=timeout_seconds,
+        erase=erase,
+    )
 
     await messenger.stop()
 

--- a/hardware/tests/firmware_integration/test_update_fw.py
+++ b/hardware/tests/firmware_integration/test_update_fw.py
@@ -5,7 +5,12 @@ from pathlib import Path
 import pytest
 
 from opentrons_hardware.drivers.can_bus import CanMessenger
-from opentrons_hardware.firmware_update import HexRecordProcessor, run_update, pipette_left, Target
+from opentrons_hardware.firmware_update import (
+    HexRecordProcessor,
+    run_update,
+    pipette_left,
+    Target,
+)
 
 
 @pytest.fixture
@@ -24,8 +29,7 @@ def hex_file_path() -> Path:
 
 @pytest.mark.requires_emulator
 async def test_update(
-    can_messenger: CanMessenger, target: Target,
-    hex_file_path: Path
+    can_messenger: CanMessenger, target: Target, hex_file_path: Path
 ) -> None:
     """It should complete the download."""
     await run_update(
@@ -34,5 +38,5 @@ async def test_update(
         hex_processor=HexRecordProcessor.from_file(hex_file_path),
         retry_count=3,
         timeout_seconds=60,
-        erase=True
+        erase=True,
     )

--- a/hardware/tests/opentrons_hardware/firmware_update/test_run.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_run.py
@@ -1,40 +1,50 @@
+"""Tests for run module."""
+from typing import Iterator
+
 import mock
 import pytest
 from mock import AsyncMock, MagicMock
 
-from opentrons_hardware.firmware_bindings.messages.message_definitions import \
-    FirmwareUpdateStartApp
-from opentrons_hardware.firmware_update import FirmwareUpdateInitiator, \
-    FirmwareUpdateDownloader, FirmwareUpdateEraser, run_update, head
+from opentrons_hardware.firmware_bindings.messages.message_definitions import (
+    FirmwareUpdateStartApp,
+)
+from opentrons_hardware.firmware_update import (
+    FirmwareUpdateInitiator,
+    FirmwareUpdateDownloader,
+    FirmwareUpdateEraser,
+    run_update,
+    head,
+)
 
 
 @pytest.fixture
-def mock_initiator_run() -> AsyncMock:
-    """FirmwareInitiator run function."""
+def mock_initiator_run() -> Iterator[AsyncMock]:
+    """Mock run function."""
     with mock.patch.object(FirmwareUpdateInitiator, "run") as p:
         yield p
 
 
 @pytest.fixture
-def mock_downloader_run() -> AsyncMock:
-    """FirmwareUpdateDownloader run function."""
+def mock_downloader_run() -> Iterator[AsyncMock]:
+    """Mock run function."""
     with mock.patch.object(FirmwareUpdateDownloader, "run") as p:
         yield p
 
 
 @pytest.fixture
-def mock_eraser_run() -> AsyncMock:
-    """FirmwareUpdateEraser run function."""
+def mock_eraser_run() -> Iterator[AsyncMock]:
+    """Mock run function."""
     with mock.patch.object(FirmwareUpdateEraser, "run") as p:
         yield p
 
 
-@pytest.mark.parametrize(
-    argnames=["should_erase"],
-    argvalues=[[True], [False]])
+@pytest.mark.parametrize(argnames=["should_erase"], argvalues=[[True], [False]])
 async def test_run_update(
-        mock_initiator_run: AsyncMock, mock_downloader_run: AsyncMock,
-        mock_eraser_run: AsyncMock, should_erase: bool) -> None:
+    mock_initiator_run: AsyncMock,
+    mock_downloader_run: AsyncMock,
+    mock_eraser_run: AsyncMock,
+    should_erase: bool,
+) -> None:
     """It should call all the functions."""
     mock_messenger = AsyncMock()
     mock_hex = MagicMock()
@@ -45,12 +55,20 @@ async def test_run_update(
         hex_processor=mock_hex,
         retry_count=12,
         timeout_seconds=11,
-        erase=should_erase
+        erase=should_erase,
     )
-    mock_initiator_run.assert_called_once_with(target=target, retry_count=12, ready_wait_time_sec=11)
+    mock_initiator_run.assert_called_once_with(
+        target=target, retry_count=12, ready_wait_time_sec=11
+    )
     if should_erase:
-        mock_eraser_run.assert_called_once_with(node_id=target.bootloader_node, timeout_sec=11)
+        mock_eraser_run.assert_called_once_with(
+            node_id=target.bootloader_node, timeout_sec=11
+        )
     else:
         mock_eraser_run.assert_not_called()
-    mock_downloader_run.assert_called_once_with(node_id=target.bootloader_node, hex_processor=mock_hex, ack_wait_seconds=11)
-    mock_messenger.send.assert_called_once_with(node_id=head.bootloader_node, message=FirmwareUpdateStartApp())
+    mock_downloader_run.assert_called_once_with(
+        node_id=target.bootloader_node, hex_processor=mock_hex, ack_wait_seconds=11
+    )
+    mock_messenger.send.assert_called_once_with(
+        node_id=head.bootloader_node, message=FirmwareUpdateStartApp()
+    )

--- a/hardware/tests/opentrons_hardware/firmware_update/test_run.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_run.py
@@ -1,0 +1,56 @@
+import mock
+import pytest
+from mock import AsyncMock, MagicMock
+
+from opentrons_hardware.firmware_bindings.messages.message_definitions import \
+    FirmwareUpdateStartApp
+from opentrons_hardware.firmware_update import FirmwareUpdateInitiator, \
+    FirmwareUpdateDownloader, FirmwareUpdateEraser, run_update, head
+
+
+@pytest.fixture
+def mock_initiator_run() -> AsyncMock:
+    """FirmwareInitiator run function."""
+    with mock.patch.object(FirmwareUpdateInitiator, "run") as p:
+        yield p
+
+
+@pytest.fixture
+def mock_downloader_run() -> AsyncMock:
+    """FirmwareUpdateDownloader run function."""
+    with mock.patch.object(FirmwareUpdateDownloader, "run") as p:
+        yield p
+
+
+@pytest.fixture
+def mock_eraser_run() -> AsyncMock:
+    """FirmwareUpdateEraser run function."""
+    with mock.patch.object(FirmwareUpdateEraser, "run") as p:
+        yield p
+
+
+@pytest.mark.parametrize(
+    argnames=["should_erase"],
+    argvalues=[[True], [False]])
+async def test_run_update(
+        mock_initiator_run: AsyncMock, mock_downloader_run: AsyncMock,
+        mock_eraser_run: AsyncMock, should_erase: bool) -> None:
+    """It should call all the functions."""
+    mock_messenger = AsyncMock()
+    mock_hex = MagicMock()
+    target = head
+    await run_update(
+        messenger=mock_messenger,
+        target=target,
+        hex_processor=mock_hex,
+        retry_count=12,
+        timeout_seconds=11,
+        erase=should_erase
+    )
+    mock_initiator_run.assert_called_once_with(target=target, retry_count=12, ready_wait_time_sec=11)
+    if should_erase:
+        mock_eraser_run.assert_called_once_with(node_id=target.bootloader_node, timeout_sec=11)
+    else:
+        mock_eraser_run.assert_not_called()
+    mock_downloader_run.assert_called_once_with(node_id=target.bootloader_node, hex_processor=mock_hex, ack_wait_seconds=11)
+    mock_messenger.send.assert_called_once_with(node_id=head.bootloader_node, message=FirmwareUpdateStartApp())


### PR DESCRIPTION
# Overview

The `update_fw` script was doing too much. Extracted most of its logic into a function.

# Changelog

- Create `run_update` function to perform complete fw update
- Use `run_update` in integration test.

# Review requests

# Risk assessment

None