### PR TITLE
fix(api): opentrons_simulate run log error

### DIFF
--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -395,10 +395,7 @@ def format_runlog(runlog: List[Mapping[str, Any]]) -> str:
     """
     to_ret = []
     for command in runlog:
-        to_ret.append(
-            "\t" * command["level"]
-            + command["payload"].get("text", "").format(**command["payload"])
-        )
+        to_ret.append("\t" * command["level"] + command["payload"].get("text", ""))
         if command["logs"]:
             to_ret.append("\t" * command["level"] + "Logs from this command:")
             to_ret.extend(


### PR DESCRIPTION
# Overview

The `text` field in protocol commands is no longer a format string. `opentrons_simulate` didn't know this and would raise exception on thermocycler commands.

# Changelog

Remove format call. Don't treat `text` field as a format string.

# Review requests



# Risk assessment

Low