### PR TITLE
fix: Put opentrons repo in it's own directory for E2E testing against em

### DIFF
--- a/.github/workflows/app-installed-test-linux.yaml
+++ b/.github/workflows/app-installed-test-linux.yaml
@@ -14,21 +14,32 @@ on:
 jobs:
   build:
     env:
-      PIPENV_VENV_IN_PROJECT: enabled  
+      PIPENV_VENV_IN_PROJECT: enabled
     runs-on: ubuntu-latest
     steps:
       - uses: 'actions/setup-python@v2'
         with:
           python-version: '3.10'
+
       - name: Install pipenv
         run: |
           pip install pipenv==2022.3.24
+
+      - name: Checkout opentrons-emulation
+        uses: actions/checkout@v3
+        with:
+          repository: "Opentrons/opentrons-emulation"
+
       - name: Check out repository code.
         uses: actions/checkout@v3
+        with:
+          path: opentrons
+
       - name: Install python dependencies
-        working-directory: ./app-testing
+        working-directory: ./opentrons/app-testing
         run: |
           pipenv install --skip-lock
+
       - name: Get Opentrons AppImage and set env.EXECUTABLE_PATH
         run: |
           wget ${{ github.event.inputs.appimage-url }}
@@ -36,33 +47,34 @@ jobs:
           chmod +x $filename
           filepath=$(pwd)/$filename
           echo "EXECUTABLE_PATH=$filepath" >> $GITHUB_ENV
+
       - name: Install Chromedriver on the path.
         run: |
-          chmod +x ./app-testing/ci-tools/linux_get_chromedriver.sh
-          ./app-testing/ci-tools/linux_get_chromedriver.sh ${{ github.event.inputs.electron-version }}
+          chmod +x ./opentrons/app-testing/ci-tools/linux_get_chromedriver.sh
+          ./opentrons/app-testing/ci-tools/linux_get_chromedriver.sh ${{ github.event.inputs.electron-version }}
           chromedriver --version
-      - name: Checkout opentrons-emulation
-        uses: actions/checkout@v3
-        with:
-          repository: "Opentrons/opentrons-emulation"
+
       - name: Setup opentrons-emulation project
         uses: Opentrons/opentrons-emulation@main
         with:
-          input-file: ${{ github.workspace }}/app-testing/ci-tools/ot2_with_all_modules.yaml
+          input-file: ${{ github.workspace }}/opentrons/app-testing/ci-tools/ot2_with_all_modules.yaml
           command: setup
+
       - name: Run emulated system
         uses: Opentrons/opentrons-emulation@main
         with:
-          input-file: ${{ github.workspace }}/app-testing/ci-tools/ot2_with_all_modules.yaml
+          input-file: ${{ github.workspace }}/opentrons/app-testing/ci-tools/ot2_with_all_modules.yaml
           command: run
+
       - name: Run Tests.
-        working-directory: ./app-testing
+        working-directory: ./opentrons/app-testing
         run: |
           export DISPLAY=:99
           sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
           export EXECUTABLE_PATH=${{ env.EXECUTABLE_PATH }}
           export ROBOT_BASE_URL="http://127.0.0.1:31950"
           make test
+
       - name: Upload results.
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/app-installed-test-linux.yaml
+++ b/.github/workflows/app-installed-test-linux.yaml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: "Opentrons/opentrons-emulation"
+          ref: v2.2.0
 
       - name: Check out repository code.
         uses: actions/checkout@v3
@@ -55,13 +56,13 @@ jobs:
           chromedriver --version
 
       - name: Setup opentrons-emulation project
-        uses: Opentrons/opentrons-emulation@main
+        uses: Opentrons/opentrons-emulation@v2.2.0
         with:
           input-file: ${{ github.workspace }}/opentrons/app-testing/ci-tools/ot2_with_all_modules.yaml
           command: setup
 
       - name: Run emulated system
-        uses: Opentrons/opentrons-emulation@main
+        uses: Opentrons/opentrons-emulation@v2.2.0
         with:
           input-file: ${{ github.workspace }}/opentrons/app-testing/ci-tools/ot2_with_all_modules.yaml
           command: run


### PR DESCRIPTION
# Overview

Previously we were checking out opentrons and then opentrons-emulation but we were putting them at the same path.
This caused opentrons-emulation to overwrite all of opentrons. 

Now checkout opentrons-emulation first the checkout opentrons into and opentrons directory. 

This puts opentrons inside of opentrons-emulation which is gross. But this is how it works for now

Eventually opentrons-emulation Github Actions will be fixed to be able to be ran without having to checkout opentron-emulation


See https://github.com/Opentrons/opentrons/actions/runs/2059954637