### PR TITLE
feat(app): AppSettings Enable labware offset download link

### DIFF
--- a/app/src/assets/localization/en/app_settings.json
+++ b/app/src/assets/localization/en/app_settings.json
@@ -47,6 +47,8 @@
   "prompt": "Always show the prompt to choose calibration block or trash bin",
   "display_unavail_robots": "Display Unavailable Robots",
   "display_unavail_robots_description": "Disabling this may improve overall networking performance in environments with many robots, but it may be slower to find robots when opening the app.",
+  "show_link_labware_data": "Show link to get Labware Offset data",
+  "show_link_labware_data_description": "If you need to access Labware Offset data outside of the Opentrons App, enabling this setting will display a link to get Offset Data in the Recent Runs overflow menu and in the Labware Setup section of the Protocol page.",
   "clear_unavail_robots": "Clear Unavailable Robots",
   "clear_robots_description": "Clear the list of unavailable robots on the Devices page. This action cannot be undone.",
   "clear_robots_button": "Clear unavailable robots list",

--- a/app/src/organisms/AppSettings/AdvancedSettings.tsx
+++ b/app/src/organisms/AppSettings/AdvancedSettings.tsx
@@ -238,7 +238,6 @@ export function AdvancedSettings(): JSX.Element {
           <ToggleButton
             label="show_link_to_get_labware_offset_data"
             toggledOn={isLabwareOffsetCodeSnippetsOn}
-            // onClick={() => toggleLabwareOffsetData}
             onClick={toggleLabwareOffsetData}
             id="AdvancedSettings_showLinkToggleButton"
           />

--- a/app/src/organisms/AppSettings/AdvancedSettings.tsx
+++ b/app/src/organisms/AppSettings/AdvancedSettings.tsx
@@ -46,6 +46,9 @@ export function AdvancedSettings(): JSX.Element {
     Config.getUpdateChannelOptions
   )
   const labwarePath = useSelector(CustomLabware.getCustomLabwareDirectory)
+  const isLabwareOffsetCodeSnippetOn = useSelector(
+    Config.getIsLabwareOffsetCodeSnippetsOn
+  )
   const dispatch = useDispatch<Dispatch>()
 
   const handleUseTrashSelection = (selection: BlockSelection): void => {
@@ -61,6 +64,13 @@ export function AdvancedSettings(): JSX.Element {
         break
     }
   }
+  const toggleLabwareOffsetData = (): unknown =>
+    dispatch(
+      Config.updateConfigValue(
+        'labwareOffsetCodeSnippets',
+        !isLabwareOffsetCodeSnippetOn
+      )
+    )
   const toggleDevtools = (): unknown => dispatch(Config.toggleDevtools())
   const handleChannel: React.ChangeEventHandler<HTMLSelectElement> = event =>
     dispatch(Config.updateConfigValue('update.channel', event.target.value))
@@ -227,10 +237,8 @@ export function AdvancedSettings(): JSX.Element {
           </Box>
           <ToggleButton
             label="display_unavailable_robots"
-            toggledOn={!displayUnavailRobots}
-            onClick={() =>
-              dispatch(Config.toggleConfigValue('discovery.disableCache'))
-            }
+            toggledOn={isLabwareOffsetCodeSnippetOn}
+            onClick={toggleLabwareOffsetData}
             id="AdvancedSettings_showLinkToggleButton"
           />
         </Flex>

--- a/app/src/organisms/AppSettings/AdvancedSettings.tsx
+++ b/app/src/organisms/AppSettings/AdvancedSettings.tsx
@@ -217,6 +217,29 @@ export function AdvancedSettings(): JSX.Element {
             <Text
               css={TYPOGRAPHY.h3SemiBold}
               paddingBottom={SPACING.spacing3}
+              id="AdvancedSettings_showLink"
+            >
+              {t('show_link_labware_data')}
+            </Text>
+            <Text css={TYPOGRAPHY.pRegular}>
+              {t('show_link_labware_data_description')}
+            </Text>
+          </Box>
+          <ToggleButton
+            label="display_unavailable_robots"
+            toggledOn={!displayUnavailRobots}
+            onClick={() =>
+              dispatch(Config.toggleConfigValue('discovery.disableCache'))
+            }
+            id="AdvancedSettings_showLinkToggleButton"
+          />
+        </Flex>
+        <Divider marginY={SPACING.spacing5} />
+        <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>
+          <Box width="70%">
+            <Text
+              css={TYPOGRAPHY.h3SemiBold}
+              paddingBottom={SPACING.spacing3}
               id="AdvancedSettings_clearRobots"
             >
               {t('clear_unavail_robots')}

--- a/app/src/organisms/AppSettings/AdvancedSettings.tsx
+++ b/app/src/organisms/AppSettings/AdvancedSettings.tsx
@@ -22,6 +22,7 @@ import * as CustomLabware from '../../redux/custom-labware'
 import { clearDiscoveryCache } from '../../redux/discovery'
 import { Divider } from '../../atoms/structure'
 import { TertiaryButton, ToggleButton } from '../../atoms/Buttons'
+import { StyledText } from '../../atoms/text'
 
 import type { Dispatch, State } from '../../redux/types'
 import type { DropdownOption } from '@opentrons/components'
@@ -224,16 +225,17 @@ export function AdvancedSettings(): JSX.Element {
         <Divider marginY={SPACING.spacing5} />
         <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>
           <Box width="70%">
-            <StyledText as="h3" css={TYPOGRAPHY.fontWeightSemiBold}
+            <StyledText
+              as="h3"
               css={TYPOGRAPHY.h3SemiBold}
               paddingBottom={SPACING.spacing3}
               id="AdvancedSettings_showLink"
             >
               {t('show_link_labware_data')}
-            </Text>
-            <Text css={TYPOGRAPHY.pRegular}>
+            </StyledText>
+            <StyledText as="p">
               {t('show_link_labware_data_description')}
-            </Text>
+            </StyledText>
           </Box>
           <ToggleButton
             label="show_link_to_get_labware_offset_data"

--- a/app/src/organisms/AppSettings/AdvancedSettings.tsx
+++ b/app/src/organisms/AppSettings/AdvancedSettings.tsx
@@ -224,7 +224,7 @@ export function AdvancedSettings(): JSX.Element {
         <Divider marginY={SPACING.spacing5} />
         <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>
           <Box width="70%">
-            <Text
+            <StyledText as="h3" css={TYPOGRAPHY.fontWeightSemiBold}
               css={TYPOGRAPHY.h3SemiBold}
               paddingBottom={SPACING.spacing3}
               id="AdvancedSettings_showLink"

--- a/app/src/organisms/AppSettings/AdvancedSettings.tsx
+++ b/app/src/organisms/AppSettings/AdvancedSettings.tsx
@@ -46,7 +46,7 @@ export function AdvancedSettings(): JSX.Element {
     Config.getUpdateChannelOptions
   )
   const labwarePath = useSelector(CustomLabware.getCustomLabwareDirectory)
-  const isLabwareOffsetCodeSnippetOn = useSelector(
+  const isLabwareOffsetCodeSnippetsOn = useSelector(
     Config.getIsLabwareOffsetCodeSnippetsOn
   )
   const dispatch = useDispatch<Dispatch>()
@@ -67,8 +67,8 @@ export function AdvancedSettings(): JSX.Element {
   const toggleLabwareOffsetData = (): unknown =>
     dispatch(
       Config.updateConfigValue(
-        'labwareOffsetCodeSnippets',
-        !isLabwareOffsetCodeSnippetOn
+        'labware.showLabwareOffsetCodeSnippets',
+        Boolean(!isLabwareOffsetCodeSnippetsOn)
       )
     )
   const toggleDevtools = (): unknown => dispatch(Config.toggleDevtools())
@@ -236,8 +236,9 @@ export function AdvancedSettings(): JSX.Element {
             </Text>
           </Box>
           <ToggleButton
-            label="display_unavailable_robots"
-            toggledOn={isLabwareOffsetCodeSnippetOn}
+            label="show_link_to_get_labware_offset_data"
+            toggledOn={isLabwareOffsetCodeSnippetsOn}
+            // onClick={() => toggleLabwareOffsetData}
             onClick={toggleLabwareOffsetData}
             id="AdvancedSettings_showLinkToggleButton"
           />

--- a/app/src/organisms/AppSettings/__tests__/AdvancedSettings.test.tsx
+++ b/app/src/organisms/AppSettings/__tests__/AdvancedSettings.test.tsx
@@ -31,6 +31,10 @@ const getChannelOptions = Config.getUpdateChannelOptions as jest.MockedFunction<
   typeof Config.getUpdateChannelOptions
 >
 
+const mockGetIsLabwareOffsetCodeSnippetsOn = Config.getIsLabwareOffsetCodeSnippetsOn as jest.MockedFunction<
+  typeof Config.getIsLabwareOffsetCodeSnippetsOn
+>
+
 describe('AdvancedSettings', () => {
   beforeEach(() => {
     getCustomLabwarePath.mockReturnValue('')
@@ -102,6 +106,15 @@ describe('AdvancedSettings', () => {
       'If you need to access Labware Offset data outside of the Opentrons App, enabling this setting will display a link to get Offset Data in the Recent Runs overflow menu and in the Labware Setup section of the Protocol page.'
     )
     getByRole('switch', { name: 'show_link_to_get_labware_offset_data' })
+  })
+
+  it('renders the toggle button on when show link to labware offset data setting is true', () => {
+    mockGetIsLabwareOffsetCodeSnippetsOn.mockReturnValue(true)
+    const [{ getByRole }] = render()
+    const toggleButton = getByRole('switch', {
+      name: 'show_link_to_get_labware_offset_data',
+    })
+    expect(toggleButton.getAttribute('aria-checked')).toBe('true')
   })
 
   it('renders the clear unavailable robots section', () => {

--- a/app/src/organisms/AppSettings/__tests__/AdvancedSettings.test.tsx
+++ b/app/src/organisms/AppSettings/__tests__/AdvancedSettings.test.tsx
@@ -95,6 +95,15 @@ describe('AdvancedSettings', () => {
     getByRole('switch', { name: 'display_unavailable_robots' })
   })
 
+  it('renders the display show link to get labware offset data section', () => {
+    const [{ getByText, getByRole }] = render()
+    getByText('Show link to get Labware Offset data')
+    getByText(
+      'If you need to access Labware Offset data outside of the Opentrons App, enabling this setting will display a link to get Offset Data in the Recent Runs overflow menu and in the Labware Setup section of the Protocol page.'
+    )
+    getByRole('switch', { name: 'show_link_to_get_labware_offset_data' })
+  })
+
   it('renders the clear unavailable robots section', () => {
     const [{ getByText, getByRole }] = render()
     getByText(


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Added `Show link to get Labware Offset data` section to AppSettings Advanced Settings page.
This is part of #9793

![toggle](https://user-images.githubusercontent.com/474225/160674195-8a810a50-4609-4a2a-9925-b55ffe4007c3.gif)



<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- Updated  app/src/organisms/AppSettings/AdvancedSettings.tsx
- Updated  app/src/organisms/AppSettings/__tests__/AdvancedSettings.test.tsx
- Added items to  app/src/assets/localization/en/app_settings.json
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Related designs live here:
https://www.figma.com/file/bVtCogdwiXj3ndpk4AWXCx/Milestone-1%3A-Read-and-Execute?node-id=7381%3A235816


<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
