### PR TITLE
feat(ot3): add diagnostic messages for sensors

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -118,6 +118,8 @@ class MessageId(int, Enum):
     read_sensor_response = 0x85
     set_sensor_threshold_request = 0x86
     set_sensor_threshold_response = 0x87
+    sensor_diagnostic_request = 0x88
+    sensor_diagnostic_response = 0x89
 
 
 @unique

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -394,6 +394,24 @@ class SensorThresholdResponse:  # noqa: D101
 
 
 @dataclass
+class SensorDiagnosticRequest:  # noqa: D101
+    payload: payloads.SensorDiagnosticRequestPayload
+    payload_type: Type[BinarySerializable] = payloads.SensorDiagnosticRequestPayload
+    message_id: Literal[
+        MessageId.sensor_diagnostic_request
+    ] = MessageId.sensor_diagnostic_request
+
+
+@dataclass
+class SensorDiagnosticResponse:  # noqa: D101
+    payload: payloads.SensorDiagnosticResponsePayload
+    payload_type: Type[BinarySerializable] = payloads.SensorDiagnosticResponsePayload
+    message_id: Literal[
+        MessageId.sensor_diagnostic_response
+    ] = MessageId.sensor_diagnostic_response
+
+
+@dataclass
 class PipetteInfoRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.pipette_info_request] = MessageId.pipette_info_request
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
@@ -59,6 +59,8 @@ MessageDefinition = Union[
     defs.SetSensorThresholdRequest,
     defs.ReadFromSensorResponse,
     defs.SensorThresholdResponse,
+    defs.SensorDiagnosticRequest,
+    defs.SensorDiagnosticResponse,
     defs.HomeRequest,
     defs.PipetteInfoRequest,
     defs.PipetteInfoResponse,

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -331,6 +331,23 @@ class SensorThresholdResponsePayload(utils.BinarySerializable):
 
 
 @dataclass
+class SensorDiagnosticRequestPayload(utils.BinarySerializable):
+    """A response that sends back the current threshold value of the sensor."""
+
+    sensor: SensorTypeField
+    reg_address: utils.UInt8Field
+
+
+@dataclass
+class SensorDiagnosticResponsePayload(utils.BinarySerializable):
+    """A response that sends back the current threshold value of the sensor."""
+
+    sensor: SensorTypeField
+    reg_address: utils.UInt8Field
+    data: utils.UInt32Field
+
+
+@dataclass
 class PipetteInfoResponsePayload(utils.BinarySerializable):
     """A response carrying data about an attached pipette."""
 


### PR DESCRIPTION
## Overview

There are certain sensor registers you may want to read from to get diagnostic information, so we
should make them available via some diagnostic CAN messages.

# Changelog

- Add CAN sensor diagnostic messages


# Risk assessment

Low. Just adding diagnostic messages. Will need to add this on the firmware side as well.
