### PR TITLE
refactor(ot3): add a register address to write to for the write sensor command

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -154,7 +154,7 @@ class SensorType(int, Enum):
     humidity = 0x02
     temperature = 0x03
     pressure = 0x04
-    preassure_temperature = 0x05
+    pressure_temperature = 0x05
 
 
 @unique

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -154,6 +154,7 @@ class SensorType(int, Enum):
     humidity = 0x02
     temperature = 0x03
     pressure = 0x04
+    preassure_temperature = 0x05
 
 
 @unique

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -296,6 +296,7 @@ class WriteToSensorRequestPayload(utils.BinarySerializable):
 
     sensor: SensorTypeField
     data: utils.UInt32Field
+    reg_address: utils.UInt8Field
 
 
 @dataclass

--- a/hardware/opentrons_hardware/sensors/scheduler.py
+++ b/hardware/opentrons_hardware/sensors/scheduler.py
@@ -80,6 +80,8 @@ class SensorScheduler:
                 payload=WriteToSensorRequestPayload(
                     sensor=SensorTypeField(sensor.sensor_type),
                     data=UInt32Field(sensor.data.to_int),
+                    # TODO(lc, 03-29-2022, actually pass in a register value)
+                    reg_address=UInt8Field(0x0),
                 )
             ),
         )

--- a/hardware/tests/opentrons_hardware/sensors/test_sensor_drivers.py
+++ b/hardware/tests/opentrons_hardware/sensors/test_sensor_drivers.py
@@ -143,6 +143,7 @@ async def test_receive_data_polling(
                 payload=WriteToSensorRequestPayload(
                     sensor=SensorTypeField(SensorType.pressure),
                     data=UInt32Field(SensorDataType.build([0x2, 0x2, 0x0, 0x0]).to_int),
+                    reg_address=UInt8Field(0x0),
                 )
             ),
         ],
@@ -153,6 +154,7 @@ async def test_receive_data_polling(
                 payload=WriteToSensorRequestPayload(
                     sensor=SensorTypeField(SensorType.capacitive),
                     data=UInt32Field(SensorDataType.build([0x2, 0x2, 0x0, 0x0]).to_int),
+                    reg_address=UInt8Field(0x0),
                 )
             ),
         ],
@@ -163,6 +165,7 @@ async def test_receive_data_polling(
                 payload=WriteToSensorRequestPayload(
                     sensor=SensorTypeField(SensorType.temperature),
                     data=UInt32Field(SensorDataType.build([0x2, 0x2, 0x0, 0x0]).to_int),
+                    reg_address=UInt8Field(0x0),
                 )
             ),
         ],
@@ -173,6 +176,7 @@ async def test_receive_data_polling(
                 payload=WriteToSensorRequestPayload(
                     sensor=SensorTypeField(SensorType.humidity),
                     data=UInt32Field(SensorDataType.build([0x2, 0x2, 0x0, 0x0]).to_int),
+                    reg_address=UInt8Field(0x0),
                 )
             ),
         ],


### PR DESCRIPTION
# Overview
Adding in a register address parameter to the write sensor command. I also added an additional
sensor type for the pressure sensor to get the temperature value from the pressure sensor.

# Changelog
- Added in an additional sensor "type" to filter which reading to take from the pressure sensor
- Modified the write sensor command to accept a register address

# Risk assessment

Low.