### PR TITLE
refactor(engine): reorganize module state

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/await_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/await_temperature.py
@@ -41,9 +41,8 @@ class AwaitTemperatureImpl(
 
     async def execute(self, params: AwaitTemperatureParams) -> AwaitTemperatureResult:
         """Wait for a Heater-Shaker's target temperature to be reached."""
-        hs_module_view = self._state_view.modules.get_heater_shaker_module_view(
-            module_id=params.moduleId
-        )
+        hs_module_view = self._state_view.modules.get_heater_shaker_module_substate(
+            module_id=params.moduleId)
         target_temp = self._state_view.modules.get_plate_target_temperature(
             hs_module_view.module_id
         )

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/await_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/await_temperature.py
@@ -41,13 +41,14 @@ class AwaitTemperatureImpl(
 
     async def execute(self, params: AwaitTemperatureParams) -> AwaitTemperatureResult:
         """Wait for a Heater-Shaker's target temperature to be reached."""
-        hs_module_view = self._state_view.modules.get_heater_shaker_module_substate(
-            module_id=params.moduleId)
-        target_temp = self._state_view.modules.get_plate_target_temperature(
-            hs_module_view.module_id
+        hs_module_substate = self._state_view.modules.get_heater_shaker_module_substate(
+            module_id=params.moduleId
         )
+
+        # Raises error if no target temperature
+        target_temp = hs_module_substate.get_plate_target_temperature()
         hs_hardware_module = self._equipment.get_module_hardware_api(
-            hs_module_view.module_id
+            hs_module_substate.module_id
         )
 
         if hs_hardware_module is not None:

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/close_latch.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/close_latch.py
@@ -41,7 +41,8 @@ class CloseLatchImpl(AbstractCommandImpl[CloseLatchParams, CloseLatchResult]):
         """Close a Heater-Shaker's latch."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
         hs_module_view = self._state_view.modules.get_heater_shaker_module_substate(
-            module_id=params.moduleId)
+            module_id=params.moduleId
+        )
 
         # Allow propagation of ModuleNotAttachedError.
         hs_hardware_module = self._equipment.get_module_hardware_api(

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/close_latch.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/close_latch.py
@@ -40,9 +40,8 @@ class CloseLatchImpl(AbstractCommandImpl[CloseLatchParams, CloseLatchResult]):
     async def execute(self, params: CloseLatchParams) -> CloseLatchResult:
         """Close a Heater-Shaker's latch."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
-        hs_module_view = self._state_view.modules.get_heater_shaker_module_view(
-            module_id=params.moduleId
-        )
+        hs_module_view = self._state_view.modules.get_heater_shaker_module_substate(
+            module_id=params.moduleId)
 
         # Allow propagation of ModuleNotAttachedError.
         hs_hardware_module = self._equipment.get_module_hardware_api(

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/close_latch.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/close_latch.py
@@ -6,10 +6,11 @@ from typing_extensions import Literal, Type
 from pydantic import BaseModel, Field
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
-from opentrons.hardware_control import HardwareControlAPI
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
+    from opentrons.protocol_engine.execution import EquipmentHandler
+
 
 CloseLatchCommandType = Literal["heaterShakerModule/closeLatch"]
 
@@ -30,11 +31,11 @@ class CloseLatchImpl(AbstractCommandImpl[CloseLatchParams, CloseLatchResult]):
     def __init__(
         self,
         state_view: StateView,
-        hardware_api: HardwareControlAPI,
+        equipment: EquipmentHandler,
         **unused_dependencies: object,
     ) -> None:
         self._state_view = state_view
-        self._hardware_api = hardware_api
+        self._equipment = equipment
 
     async def execute(self, params: CloseLatchParams) -> CloseLatchResult:
         """Close a Heater-Shaker's latch."""
@@ -44,12 +45,13 @@ class CloseLatchImpl(AbstractCommandImpl[CloseLatchParams, CloseLatchResult]):
         )
 
         # Allow propagation of ModuleNotAttachedError.
-        hs_hardware_module = hs_module_view.find_hardware(
-            attached_modules=self._hardware_api.attached_modules
+        hs_hardware_module = self._equipment.get_module_hardware_api(
+            hs_module_view.module_id
         )
 
         if hs_hardware_module is not None:
             await hs_hardware_module.close_labware_latch()
+
         return CloseLatchResult()
 
 

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/close_latch.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/close_latch.py
@@ -40,13 +40,13 @@ class CloseLatchImpl(AbstractCommandImpl[CloseLatchParams, CloseLatchResult]):
     async def execute(self, params: CloseLatchParams) -> CloseLatchResult:
         """Close a Heater-Shaker's latch."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
-        hs_module_view = self._state_view.modules.get_heater_shaker_module_substate(
+        hs_module_substate = self._state_view.modules.get_heater_shaker_module_substate(
             module_id=params.moduleId
         )
 
         # Allow propagation of ModuleNotAttachedError.
         hs_hardware_module = self._equipment.get_module_hardware_api(
-            hs_module_view.module_id
+            hs_module_substate.module_id
         )
 
         if hs_hardware_module is not None:

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_heater.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_heater.py
@@ -42,7 +42,8 @@ class DeactivateHeaterImpl(
     async def execute(self, params: DeactivateHeaterParams) -> DeactivateHeaterResult:
         """Unset a Heater-Shaker's target temperature."""
         hs_module_view = self._state_view.modules.get_heater_shaker_module_substate(
-            module_id=params.moduleId)
+            module_id=params.moduleId
+        )
 
         # Allow propagation of ModuleNotAttachedError.
         hs_hardware_module = self._equipment.get_module_hardware_api(

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_heater.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_heater.py
@@ -5,11 +5,11 @@ from typing_extensions import Literal, Type
 
 from pydantic import BaseModel, Field
 
-from opentrons.hardware_control import HardwareControlAPI
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
+    from opentrons.protocol_engine.execution import EquipmentHandler
 
 
 DeactivateHeaterCommandType = Literal["heaterShakerModule/deactivateHeater"]
@@ -33,22 +33,26 @@ class DeactivateHeaterImpl(
     def __init__(
         self,
         state_view: StateView,
-        hardware_api: HardwareControlAPI,
+        equipment: EquipmentHandler,
         **unused_dependencies: object,
     ) -> None:
         self._state_view = state_view
-        self._hardware_api = hardware_api
+        self._equipment = equipment
 
     async def execute(self, params: DeactivateHeaterParams) -> DeactivateHeaterResult:
         """Unset a Heater-Shaker's target temperature."""
         hs_module_view = self._state_view.modules.get_heater_shaker_module_view(
             module_id=params.moduleId
         )
-        hs_hardware_module = hs_module_view.find_hardware(
-            attached_modules=self._hardware_api.attached_modules
+
+        # Allow propagation of ModuleNotAttachedError.
+        hs_hardware_module = self._equipment.get_module_hardware_api(
+            hs_module_view.module_id
         )
+
         if hs_hardware_module is not None:
             await hs_hardware_module.start_set_temperature(celsius=0)
+
         return DeactivateHeaterResult()
 
 

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_heater.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_heater.py
@@ -41,9 +41,8 @@ class DeactivateHeaterImpl(
 
     async def execute(self, params: DeactivateHeaterParams) -> DeactivateHeaterResult:
         """Unset a Heater-Shaker's target temperature."""
-        hs_module_view = self._state_view.modules.get_heater_shaker_module_view(
-            module_id=params.moduleId
-        )
+        hs_module_view = self._state_view.modules.get_heater_shaker_module_substate(
+            module_id=params.moduleId)
 
         # Allow propagation of ModuleNotAttachedError.
         hs_hardware_module = self._equipment.get_module_hardware_api(

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_heater.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_heater.py
@@ -41,13 +41,13 @@ class DeactivateHeaterImpl(
 
     async def execute(self, params: DeactivateHeaterParams) -> DeactivateHeaterResult:
         """Unset a Heater-Shaker's target temperature."""
-        hs_module_view = self._state_view.modules.get_heater_shaker_module_substate(
+        hs_module_substate = self._state_view.modules.get_heater_shaker_module_substate(
             module_id=params.moduleId
         )
 
         # Allow propagation of ModuleNotAttachedError.
         hs_hardware_module = self._equipment.get_module_hardware_api(
-            hs_module_view.module_id
+            hs_module_substate.module_id
         )
 
         if hs_hardware_module is not None:

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/open_latch.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/open_latch.py
@@ -40,7 +40,8 @@ class OpenLatchImpl(AbstractCommandImpl[OpenLatchParams, OpenLatchResult]):
         """Open a Heater-Shaker's latch."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
         hs_module_view = self._state_view.modules.get_heater_shaker_module_substate(
-            module_id=params.moduleId)
+            module_id=params.moduleId
+        )
 
         # Allow propagation of ModuleNotAttachedError.
         hs_hardware_module = self._equipment.get_module_hardware_api(

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/open_latch.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/open_latch.py
@@ -39,13 +39,13 @@ class OpenLatchImpl(AbstractCommandImpl[OpenLatchParams, OpenLatchResult]):
     async def execute(self, params: OpenLatchParams) -> OpenLatchResult:
         """Open a Heater-Shaker's latch."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
-        hs_module_view = self._state_view.modules.get_heater_shaker_module_substate(
+        hs_module_substate = self._state_view.modules.get_heater_shaker_module_substate(
             module_id=params.moduleId
         )
 
         # Allow propagation of ModuleNotAttachedError.
         hs_hardware_module = self._equipment.get_module_hardware_api(
-            hs_module_view.module_id
+            hs_module_substate.module_id
         )
 
         if hs_hardware_module is not None:

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/open_latch.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/open_latch.py
@@ -6,10 +6,10 @@ from typing_extensions import Literal, Type
 from pydantic import BaseModel, Field
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
-from opentrons.hardware_control import HardwareControlAPI
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
+    from opentrons.protocol_engine.execution import EquipmentHandler
 
 OpenLatchCommandType = Literal["heaterShakerModule/openLatch"]
 
@@ -30,11 +30,11 @@ class OpenLatchImpl(AbstractCommandImpl[OpenLatchParams, OpenLatchResult]):
     def __init__(
         self,
         state_view: StateView,
-        hardware_api: HardwareControlAPI,
+        equipment: EquipmentHandler,
         **unused_dependencies: object,
     ) -> None:
         self._state_view = state_view
-        self._hardware_api = hardware_api
+        self._equipment = equipment
 
     async def execute(self, params: OpenLatchParams) -> OpenLatchResult:
         """Open a Heater-Shaker's latch."""
@@ -44,12 +44,13 @@ class OpenLatchImpl(AbstractCommandImpl[OpenLatchParams, OpenLatchResult]):
         )
 
         # Allow propagation of ModuleNotAttachedError.
-        hs_hardware_module = hs_module_view.find_hardware(
-            attached_modules=self._hardware_api.attached_modules
+        hs_hardware_module = self._equipment.get_module_hardware_api(
+            hs_module_view.module_id
         )
 
         if hs_hardware_module is not None:
             await hs_hardware_module.open_labware_latch()
+
         return OpenLatchResult()
 
 

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/open_latch.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/open_latch.py
@@ -39,9 +39,8 @@ class OpenLatchImpl(AbstractCommandImpl[OpenLatchParams, OpenLatchResult]):
     async def execute(self, params: OpenLatchParams) -> OpenLatchResult:
         """Open a Heater-Shaker's latch."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
-        hs_module_view = self._state_view.modules.get_heater_shaker_module_view(
-            module_id=params.moduleId
-        )
+        hs_module_view = self._state_view.modules.get_heater_shaker_module_substate(
+            module_id=params.moduleId)
 
         # Allow propagation of ModuleNotAttachedError.
         hs_hardware_module = self._equipment.get_module_hardware_api(

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_shake_speed.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_shake_speed.py
@@ -48,7 +48,8 @@ class SetTargetShakeSpeedImpl(
         """Set a Heater-Shaker's target shake speed."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
         hs_module_view = self._state_view.modules.get_heater_shaker_module_substate(
-            module_id=params.moduleId)
+            module_id=params.moduleId
+        )
 
         # Verify speed from hs module view
         validated_speed = hs_module_view.validate_target_speed(params.rpm)

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_shake_speed.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_shake_speed.py
@@ -47,9 +47,8 @@ class SetTargetShakeSpeedImpl(
     ) -> SetTargetShakeSpeedResult:
         """Set a Heater-Shaker's target shake speed."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
-        hs_module_view = self._state_view.modules.get_heater_shaker_module_view(
-            module_id=params.moduleId
-        )
+        hs_module_view = self._state_view.modules.get_heater_shaker_module_substate(
+            module_id=params.moduleId)
 
         # Verify speed from hs module view
         validated_speed = hs_module_view.validate_target_speed(params.rpm)

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_shake_speed.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_shake_speed.py
@@ -47,16 +47,16 @@ class SetTargetShakeSpeedImpl(
     ) -> SetTargetShakeSpeedResult:
         """Set a Heater-Shaker's target shake speed."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
-        hs_module_view = self._state_view.modules.get_heater_shaker_module_substate(
+        hs_module_substate = self._state_view.modules.get_heater_shaker_module_substate(
             module_id=params.moduleId
         )
 
         # Verify speed from hs module view
-        validated_speed = hs_module_view.validate_target_speed(params.rpm)
+        validated_speed = hs_module_substate.validate_target_speed(params.rpm)
 
         # Allow propagation of ModuleNotAttachedError.
         hs_hardware_module = self._equipment.get_module_hardware_api(
-            hs_module_view.module_id
+            hs_module_substate.module_id
         )
 
         if hs_hardware_module is not None:

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/start_set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/start_set_target_temperature.py
@@ -51,7 +51,8 @@ class StartSetTargetTemperatureImpl(
         """Set a Heater-Shaker's target temperature."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
         hs_module_view = self._state_view.modules.get_heater_shaker_module_substate(
-            module_id=params.moduleId)
+            module_id=params.moduleId
+        )
 
         # Verify temperature from hs module view
         validated_temp = hs_module_view.validate_target_temperature(params.temperature)

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/start_set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/start_set_target_temperature.py
@@ -50,9 +50,8 @@ class StartSetTargetTemperatureImpl(
     ) -> StartSetTargetTemperatureResult:
         """Set a Heater-Shaker's target temperature."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
-        hs_module_view = self._state_view.modules.get_heater_shaker_module_view(
-            module_id=params.moduleId
-        )
+        hs_module_view = self._state_view.modules.get_heater_shaker_module_substate(
+            module_id=params.moduleId)
 
         # Verify temperature from hs module view
         validated_temp = hs_module_view.validate_target_temperature(params.temperature)

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/start_set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/start_set_target_temperature.py
@@ -50,16 +50,18 @@ class StartSetTargetTemperatureImpl(
     ) -> StartSetTargetTemperatureResult:
         """Set a Heater-Shaker's target temperature."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
-        hs_module_view = self._state_view.modules.get_heater_shaker_module_substate(
+        hs_module_substate = self._state_view.modules.get_heater_shaker_module_substate(
             module_id=params.moduleId
         )
 
         # Verify temperature from hs module view
-        validated_temp = hs_module_view.validate_target_temperature(params.temperature)
+        validated_temp = hs_module_substate.validate_target_temperature(
+            params.temperature
+        )
 
         # Allow propagation of ModuleNotAttachedError.
         hs_hardware_module = self._equipment.get_module_hardware_api(
-            hs_module_view.module_id
+            hs_module_substate.module_id
         )
 
         if hs_hardware_module is not None:

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/stop_shake.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/stop_shake.py
@@ -40,7 +40,8 @@ class StopShakeImpl(AbstractCommandImpl[StopShakeParams, StopShakeResult]):
         """Stop a Heater-Shaker's shake."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
         hs_module_view = self._state_view.modules.get_heater_shaker_module_substate(
-            module_id=params.moduleId)
+            module_id=params.moduleId
+        )
 
         # Allow propagation of ModuleNotAttachedError.
         hs_hardware_module = self._equipment.get_module_hardware_api(

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/stop_shake.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/stop_shake.py
@@ -39,13 +39,13 @@ class StopShakeImpl(AbstractCommandImpl[StopShakeParams, StopShakeResult]):
     async def execute(self, params: StopShakeParams) -> StopShakeResult:
         """Stop a Heater-Shaker's shake."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
-        hs_module_view = self._state_view.modules.get_heater_shaker_module_substate(
+        hs_module_substate = self._state_view.modules.get_heater_shaker_module_substate(
             module_id=params.moduleId
         )
 
         # Allow propagation of ModuleNotAttachedError.
         hs_hardware_module = self._equipment.get_module_hardware_api(
-            hs_module_view.module_id
+            hs_module_substate.module_id
         )
 
         if hs_hardware_module is not None:

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/stop_shake.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/stop_shake.py
@@ -6,10 +6,10 @@ from typing_extensions import Literal, Type
 from pydantic import BaseModel, Field
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
-from opentrons.hardware_control import HardwareControlAPI
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
+    from opentrons.protocol_engine.execution import EquipmentHandler
 
 StopShakeCommandType = Literal["heaterShakerModule/stopShake"]
 
@@ -30,11 +30,11 @@ class StopShakeImpl(AbstractCommandImpl[StopShakeParams, StopShakeResult]):
     def __init__(
         self,
         state_view: StateView,
-        hardware_api: HardwareControlAPI,
+        equipment: EquipmentHandler,
         **unused_dependencies: object,
     ) -> None:
         self._state_view = state_view
-        self._hardware_api = hardware_api
+        self._equipment = equipment
 
     async def execute(self, params: StopShakeParams) -> StopShakeResult:
         """Stop a Heater-Shaker's shake."""
@@ -44,12 +44,13 @@ class StopShakeImpl(AbstractCommandImpl[StopShakeParams, StopShakeResult]):
         )
 
         # Allow propagation of ModuleNotAttachedError.
-        hs_hardware_module = hs_module_view.find_hardware(
-            attached_modules=self._hardware_api.attached_modules
+        hs_hardware_module = self._equipment.get_module_hardware_api(
+            hs_module_view.module_id
         )
 
         if hs_hardware_module is not None:
             await hs_hardware_module.set_speed(rpm=0)
+
         return StopShakeResult()
 
 

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/stop_shake.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/stop_shake.py
@@ -39,9 +39,8 @@ class StopShakeImpl(AbstractCommandImpl[StopShakeParams, StopShakeResult]):
     async def execute(self, params: StopShakeParams) -> StopShakeResult:
         """Stop a Heater-Shaker's shake."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
-        hs_module_view = self._state_view.modules.get_heater_shaker_module_view(
-            module_id=params.moduleId
-        )
+        hs_module_view = self._state_view.modules.get_heater_shaker_module_substate(
+            module_id=params.moduleId)
 
         # Allow propagation of ModuleNotAttachedError.
         hs_hardware_module = self._equipment.get_module_hardware_api(

--- a/api/src/opentrons/protocol_engine/commands/magnetic_module/disengage.py
+++ b/api/src/opentrons/protocol_engine/commands/magnetic_module/disengage.py
@@ -60,7 +60,8 @@ class DisengageImplementation(AbstractCommandImpl[DisengageParams, DisengageResu
         """
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
         magnetic_module_view = self._state_view.modules.get_magnetic_module_substate(
-            module_id=params.moduleId)
+            module_id=params.moduleId
+        )
         # Allow propagation of ModuleNotAttachedError.
         hardware_module = self._equipment.get_module_hardware_api(
             magnetic_module_view.module_id

--- a/api/src/opentrons/protocol_engine/commands/magnetic_module/disengage.py
+++ b/api/src/opentrons/protocol_engine/commands/magnetic_module/disengage.py
@@ -59,9 +59,8 @@ class DisengageImplementation(AbstractCommandImpl[DisengageParams, DisengageResu
                 Magnetic Module, but that module's hardware wasn't found attached.
         """
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
-        magnetic_module_view = self._state_view.modules.get_magnetic_module_view(
-            module_id=params.moduleId
-        )
+        magnetic_module_view = self._state_view.modules.get_magnetic_module_substate(
+            module_id=params.moduleId)
         # Allow propagation of ModuleNotAttachedError.
         hardware_module = self._equipment.get_module_hardware_api(
             magnetic_module_view.module_id

--- a/api/src/opentrons/protocol_engine/commands/magnetic_module/disengage.py
+++ b/api/src/opentrons/protocol_engine/commands/magnetic_module/disengage.py
@@ -59,12 +59,12 @@ class DisengageImplementation(AbstractCommandImpl[DisengageParams, DisengageResu
                 Magnetic Module, but that module's hardware wasn't found attached.
         """
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
-        magnetic_module_view = self._state_view.modules.get_magnetic_module_substate(
+        mag_module_substate = self._state_view.modules.get_magnetic_module_substate(
             module_id=params.moduleId
         )
         # Allow propagation of ModuleNotAttachedError.
         hardware_module = self._equipment.get_module_hardware_api(
-            magnetic_module_view.module_id
+            mag_module_substate.module_id
         )
 
         if hardware_module is not None:  # Not virtualizing modules.

--- a/api/src/opentrons/protocol_engine/commands/magnetic_module/engage.py
+++ b/api/src/opentrons/protocol_engine/commands/magnetic_module/engage.py
@@ -77,9 +77,8 @@ class EngageImplementation(AbstractCommandImpl[EngageParams, EngageResult]):
             EngageHeightOutOfRangeError: If the given height is unreachable.
         """
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
-        magnetic_module_view = self._state_view.modules.get_magnetic_module_view(
-            module_id=params.moduleId,
-        )
+        magnetic_module_view = self._state_view.modules.get_magnetic_module_substate(
+            module_id=params.moduleId)
         # Allow propagation of EngageHeightOutOfRangeError.
         hardware_height = magnetic_module_view.calculate_magnet_hardware_height(
             mm_from_base=params.engageHeight,

--- a/api/src/opentrons/protocol_engine/commands/magnetic_module/engage.py
+++ b/api/src/opentrons/protocol_engine/commands/magnetic_module/engage.py
@@ -77,16 +77,16 @@ class EngageImplementation(AbstractCommandImpl[EngageParams, EngageResult]):
             EngageHeightOutOfRangeError: If the given height is unreachable.
         """
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
-        magnetic_module_view = self._state_view.modules.get_magnetic_module_substate(
+        mag_module_substate = self._state_view.modules.get_magnetic_module_substate(
             module_id=params.moduleId
         )
         # Allow propagation of EngageHeightOutOfRangeError.
-        hardware_height = magnetic_module_view.calculate_magnet_hardware_height(
+        hardware_height = mag_module_substate.calculate_magnet_hardware_height(
             mm_from_base=params.engageHeight,
         )
         # Allow propagation of ModuleNotAttachedError.
         hardware_module = self._equipment.get_module_hardware_api(
-            magnetic_module_view.module_id
+            mag_module_substate.module_id
         )
 
         if hardware_module is not None:  # Not virtualizing modules.

--- a/api/src/opentrons/protocol_engine/commands/magnetic_module/engage.py
+++ b/api/src/opentrons/protocol_engine/commands/magnetic_module/engage.py
@@ -78,7 +78,8 @@ class EngageImplementation(AbstractCommandImpl[EngageParams, EngageResult]):
         """
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
         magnetic_module_view = self._state_view.modules.get_magnetic_module_substate(
-            module_id=params.moduleId)
+            module_id=params.moduleId
+        )
         # Allow propagation of EngageHeightOutOfRangeError.
         hardware_height = magnetic_module_view.calculate_magnet_hardware_height(
             mm_from_base=params.engageHeight,

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -251,12 +251,11 @@ class EquipmentHandler:
     def get_module_hardware_api(self, module_id: str) -> Optional[AbstractModule]:
         """Get the hardware API for a given module."""
         use_virtual_modules = self._state_store.get_configs().use_virtual_modules
-        attached_modules = self._hardware_api.attached_modules
-        serial_number = self._state_store.modules.get_serial_number(module_id)
-
         if use_virtual_modules:
             return None
 
+        attached_modules = self._hardware_api.attached_modules
+        serial_number = self._state_store.modules.get_serial_number(module_id)
         for mod in attached_modules:
             if mod.device_info["serial"] == serial_number:
                 return mod

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -1,15 +1,20 @@
 """Equipment command side-effect logic."""
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, overload
 
 from opentrons.calibration_storage.helpers import uri_from_details
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.types import MountType
 from opentrons.hardware_control import HardwareControlAPI
+from opentrons.hardware_control.modules import AbstractModule, MagDeck, HeaterShaker
 
-from ..errors import FailedToLoadPipetteError, LabwareDefinitionDoesNotExistError
+from ..errors import (
+    FailedToLoadPipetteError,
+    LabwareDefinitionDoesNotExistError,
+    ModuleNotAttachedError,
+)
 from ..resources import LabwareDataProvider, ModuleDataProvider, ModelUtils
-from ..state import StateStore, HardwareModule
+from ..state import StateStore, HardwareModule, MagneticModuleId, HeaterShakerModuleId
 from ..types import (
     LabwareLocation,
     PipetteName,
@@ -227,4 +232,36 @@ class EquipmentHandler:
             module_id=self._model_utils.ensure_id(module_id),
             serial_number=attached_module.serial_number,
             definition=attached_module.definition,
+        )
+
+    @overload
+    def get_module_hardware_api(
+        self,
+        module_id: MagneticModuleId,
+    ) -> Optional[MagDeck]:
+        ...
+
+    @overload
+    def get_module_hardware_api(
+        self,
+        module_id: HeaterShakerModuleId,
+    ) -> Optional[HeaterShaker]:
+        ...
+
+    def get_module_hardware_api(self, module_id: str) -> Optional[AbstractModule]:
+        """Get the hardware API for a given module."""
+        use_virtual_modules = self._state_store.get_configs().use_virtual_modules
+        attached_modules = self._hardware_api.attached_modules
+        serial_number = self._state_store.modules.get_serial_number(module_id)
+
+        if use_virtual_modules:
+            return None
+
+        for mod in attached_modules:
+            if mod.device_info["serial"] == serial_number:
+                return mod
+
+        raise ModuleNotAttachedError(
+            f'No module attached with serial number "{serial_number}"'
+            f' for module ID "{module_id}".'
         )

--- a/api/src/opentrons/protocol_engine/state/__init__.py
+++ b/api/src/opentrons/protocol_engine/state/__init__.py
@@ -4,7 +4,14 @@ from .state import State, StateStore, StateView
 from .commands import CommandState, CommandView, CommandSlice, CurrentCommand
 from .labware import LabwareState, LabwareView
 from .pipettes import PipetteState, PipetteView, HardwarePipette, CurrentWell
-from .modules import ModuleState, ModuleView, MagneticModuleView, HardwareModule
+from .modules import (
+    ModuleState,
+    ModuleView,
+    MagneticModuleView,
+    HardwareModule,
+    MagneticModuleId,
+    HeaterShakerModuleId,
+)
 from .geometry import GeometryView, TipGeometry
 from .motion import MotionView, PipetteLocationData
 from .configs import EngineConfigs
@@ -32,6 +39,8 @@ __all__ = [
     "ModuleView",
     "MagneticModuleView",
     "HardwareModule",
+    "MagneticModuleId",
+    "HeaterShakerModuleId",
     # computed geometry state
     "GeometryView",
     "TipGeometry",

--- a/api/src/opentrons/protocol_engine/state/__init__.py
+++ b/api/src/opentrons/protocol_engine/state/__init__.py
@@ -4,17 +4,13 @@ from .state import State, StateStore, StateView
 from .commands import CommandState, CommandView, CommandSlice, CurrentCommand
 from .labware import LabwareState, LabwareView
 from .pipettes import PipetteState, PipetteView, HardwarePipette, CurrentWell
-from .modules import (
-    ModuleState,
-    ModuleView,
-    HardwareModule
-)
+from .modules import ModuleState, ModuleView, HardwareModule
 from .module_substates import (
     MagneticModuleId,
     MagneticModuleSubState,
     HeaterShakerModuleSubState,
     HeaterShakerModuleId,
-    ModuleViewTypes
+    ModuleViewTypes,
 )
 from .geometry import GeometryView, TipGeometry
 from .motion import MotionView, PipetteLocationData

--- a/api/src/opentrons/protocol_engine/state/__init__.py
+++ b/api/src/opentrons/protocol_engine/state/__init__.py
@@ -10,7 +10,7 @@ from .module_substates import (
     MagneticModuleSubState,
     HeaterShakerModuleId,
     HeaterShakerModuleSubState,
-    ModuleViewTypes,
+    ModuleSubStateType,
 )
 from .geometry import GeometryView, TipGeometry
 from .motion import MotionView, PipetteLocationData
@@ -43,7 +43,7 @@ __all__ = [
     "MagneticModuleSubState",
     "HeaterShakerModuleId",
     "HeaterShakerModuleSubState",
-    "ModuleViewTypes",
+    "ModuleSubStateType",
     # computed geometry state
     "GeometryView",
     "TipGeometry",

--- a/api/src/opentrons/protocol_engine/state/__init__.py
+++ b/api/src/opentrons/protocol_engine/state/__init__.py
@@ -7,14 +7,19 @@ from .pipettes import PipetteState, PipetteView, HardwarePipette, CurrentWell
 from .modules import (
     ModuleState,
     ModuleView,
-    MagneticModuleView,
-    HardwareModule,
+    HardwareModule
+)
+from .module_substates import (
     MagneticModuleId,
+    MagneticModuleSubState,
+    HeaterShakerModuleSubState,
     HeaterShakerModuleId,
+    ModuleViewTypes
 )
 from .geometry import GeometryView, TipGeometry
 from .motion import MotionView, PipetteLocationData
 from .configs import EngineConfigs
+
 
 __all__ = [
     # top level state value and interfaces
@@ -37,9 +42,11 @@ __all__ = [
     # module state and values
     "ModuleState",
     "ModuleView",
-    "MagneticModuleView",
+    "ModuleViewTypes",
+    "MagneticModuleSubState",
     "HardwareModule",
     "MagneticModuleId",
+    "HeaterShakerModuleSubState",
     "HeaterShakerModuleId",
     # computed geometry state
     "GeometryView",

--- a/api/src/opentrons/protocol_engine/state/__init__.py
+++ b/api/src/opentrons/protocol_engine/state/__init__.py
@@ -8,8 +8,8 @@ from .modules import ModuleState, ModuleView, HardwareModule
 from .module_substates import (
     MagneticModuleId,
     MagneticModuleSubState,
-    HeaterShakerModuleSubState,
     HeaterShakerModuleId,
+    HeaterShakerModuleSubState,
     ModuleViewTypes,
 )
 from .geometry import GeometryView, TipGeometry
@@ -38,12 +38,12 @@ __all__ = [
     # module state and values
     "ModuleState",
     "ModuleView",
-    "ModuleViewTypes",
-    "MagneticModuleSubState",
     "HardwareModule",
     "MagneticModuleId",
-    "HeaterShakerModuleSubState",
+    "MagneticModuleSubState",
     "HeaterShakerModuleId",
+    "HeaterShakerModuleSubState",
+    "ModuleViewTypes",
     # computed geometry state
     "GeometryView",
     "TipGeometry",

--- a/api/src/opentrons/protocol_engine/state/module_substates/__init__.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/__init__.py
@@ -7,12 +7,12 @@ from .heater_shaker_module_substate import (
     HeaterShakerModuleId,
 )
 
-ModuleViewTypes = Union[HeaterShakerModuleSubState, MagneticModuleSubState]
+ModuleSubStateType = Union[HeaterShakerModuleSubState, MagneticModuleSubState]
 
 __all__ = [
     "MagneticModuleSubState",
     "MagneticModuleId",
     "HeaterShakerModuleSubState",
     "HeaterShakerModuleId",
-    "ModuleViewTypes",
+    "ModuleSubStateType",
 ]

--- a/api/src/opentrons/protocol_engine/state/module_substates/__init__.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/__init__.py
@@ -1,0 +1,13 @@
+from typing import Union
+from .magnetic_module_substate import MagneticModuleSubState, MagneticModuleId
+from .heater_shaker_module_substate import HeaterShakerModuleSubState, HeaterShakerModuleId
+
+ModuleViewTypes = Union[HeaterShakerModuleSubState, MagneticModuleSubState]
+
+__all__ = [
+    "MagneticModuleSubState",
+    "MagneticModuleId",
+    "HeaterShakerModuleSubState",
+    "HeaterShakerModuleId",
+    "ModuleViewTypes",
+]

--- a/api/src/opentrons/protocol_engine/state/module_substates/__init__.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/__init__.py
@@ -1,6 +1,11 @@
+"""Hardware Modules' substates."""
+
 from typing import Union
 from .magnetic_module_substate import MagneticModuleSubState, MagneticModuleId
-from .heater_shaker_module_substate import HeaterShakerModuleSubState, HeaterShakerModuleId
+from .heater_shaker_module_substate import (
+    HeaterShakerModuleSubState,
+    HeaterShakerModuleId,
+)
 
 ModuleViewTypes = Union[HeaterShakerModuleSubState, MagneticModuleSubState]
 

--- a/api/src/opentrons/protocol_engine/state/module_substates/heater_shaker_module_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/heater_shaker_module_substate.py
@@ -12,14 +12,14 @@ HeaterShakerModuleId = NewType("HeaterShakerModuleId", str)
 
 
 class SpeedRange(NamedTuple):
-    """Class defining minimum and maximum allowed speeds for a shaking module."""
+    """Minimum and maximum allowed speeds for a shaking module."""
 
     min: int
     max: int
 
 
 class TemperatureRange(NamedTuple):
-    """Class defining minimum and maximum allowed temperatures for a heating module."""
+    """Minimum and maximum allowed temperatures for a heating module."""
 
     min: float
     max: float
@@ -63,7 +63,7 @@ class HeaterShakerModuleSubState:
         else:
             raise InvalidTargetTemperatureError(
                 f"Heater-Shaker got an invalid temperature {celsius} degree Celsius."
-                f"Valid range is {HEATER_SHAKER_TEMPERATURE_RANGE}."
+                f" Valid range is {HEATER_SHAKER_TEMPERATURE_RANGE}."
             )
 
     @staticmethod

--- a/api/src/opentrons/protocol_engine/state/module_substates/heater_shaker_module_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/heater_shaker_module_substate.py
@@ -1,0 +1,77 @@
+from dataclasses import dataclass
+from typing import NewType, NamedTuple, Optional
+
+from opentrons.protocol_engine.errors import (
+    InvalidTargetTemperatureError,
+    InvalidTargetSpeedError,
+    NoTargetTemperatureSetError,
+)
+
+HeaterShakerModuleId = NewType("HeaterShakerModuleId", str)
+
+
+class SpeedRange(NamedTuple):
+    """Class defining minimum and maximum allowed speeds for a shaking module."""
+
+    min: int
+    max: int
+
+
+class TemperatureRange(NamedTuple):
+    """Class defining minimum and maximum allowed temperatures for a heating module."""
+
+    min: float
+    max: float
+
+
+# TODO (spp, 2022-03-22): Move these values to heater-shaker module definition.
+HEATER_SHAKER_TEMPERATURE_RANGE = TemperatureRange(min=37, max=95)
+HEATER_SHAKER_SPEED_RANGE = SpeedRange(min=200, max=3000)
+
+
+@dataclass(frozen=True)
+class HeaterShakerModuleSubState:
+    """Heater-Shaker-specific state.
+
+    Provides calculations and read-only state access
+    for an individual loaded Heater-Shaker Module.
+    """
+    module_id: HeaterShakerModuleId
+    plate_target_temperature: Optional[float]
+
+    def get_plate_target_temperature(self) -> float:
+        """Get the module's target plate temperature."""
+        target = self.plate_target_temperature
+
+        if target is None:
+            raise NoTargetTemperatureSetError(
+                f"Module {self.module_id} does not have a target temperature set."
+            )
+        return target
+
+    @staticmethod
+    def validate_target_temperature(celsius: float) -> float:
+        """Verify that the target temperature being set is valid for heater-shaker."""
+        if (
+            HEATER_SHAKER_TEMPERATURE_RANGE.min
+            <= celsius
+            <= HEATER_SHAKER_TEMPERATURE_RANGE.max
+        ):
+            return celsius
+        else:
+            raise InvalidTargetTemperatureError(
+                f"Heater-Shaker got an invalid temperature {celsius} degree Celsius."
+                f"Valid range is {HEATER_SHAKER_TEMPERATURE_RANGE}."
+            )
+
+    @staticmethod
+    def validate_target_speed(rpm: float) -> int:
+        """Verify that the target speed is valid for heater-shaker & convert to int."""
+        rpm_int = int(round(rpm, 0))
+        if HEATER_SHAKER_SPEED_RANGE.min <= rpm <= HEATER_SHAKER_SPEED_RANGE.max:
+            return rpm_int
+        else:
+            raise InvalidTargetSpeedError(
+                f"Heater-Shaker got invalid speed of {rpm}RPM. Valid range is "
+                f"{HEATER_SHAKER_SPEED_RANGE}."
+            )

--- a/api/src/opentrons/protocol_engine/state/module_substates/heater_shaker_module_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/heater_shaker_module_substate.py
@@ -1,3 +1,4 @@
+"""Heater-Shaker Module sub-state."""
 from dataclasses import dataclass
 from typing import NewType, NamedTuple, Optional
 
@@ -36,6 +37,7 @@ class HeaterShakerModuleSubState:
     Provides calculations and read-only state access
     for an individual loaded Heater-Shaker Module.
     """
+
     module_id: HeaterShakerModuleId
     plate_target_temperature: Optional[float]
 

--- a/api/src/opentrons/protocol_engine/state/module_substates/magnetic_module_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/magnetic_module_substate.py
@@ -1,0 +1,65 @@
+"""Magnetic module state view."""
+
+from dataclasses import dataclass
+from typing import NewType
+
+from opentrons.protocol_engine.types import MagneticModuleModel, ModuleModel
+from opentrons.protocol_engine.errors import EngageHeightOutOfRangeError
+from opentrons.hardware_control.modules.magdeck import (
+    engage_height_is_in_range,
+    OFFSET_TO_LABWARE_BOTTOM as MAGNETIC_MODULE_OFFSET_TO_LABWARE_BOTTOM,
+    MAX_ENGAGE_HEIGHT as MAGNETIC_MODULE_MAX_ENGAGE_HEIGHT,
+)
+
+MagneticModuleId = NewType("MagneticModuleId", str)
+
+
+@dataclass(frozen=True)
+class MagneticModuleSubState:
+    """Magnetic Module specific state.
+
+    Provides calculations and read-only state access
+    for an individual loaded Magnetic Module.
+    """
+
+    module_id: MagneticModuleId
+    model: MagneticModuleModel
+
+    def calculate_magnet_hardware_height(self, mm_from_base: float) -> float:
+        """Convert a human-friendly magnet height to be hardware-friendly.
+
+        Args:
+            mm_from_base: The height to convert. Measured in how far the tops
+                of the magnets are above the labware base plane.
+
+        Returns:
+            The same height, with its units and origin point converted
+            so that it's suitable to pass to `MagDeck.engage()`.
+
+        Raises:
+            EngageHeightOutOfRangeError: If modules of the given model are
+                physically incapable of reaching the requested height.
+        """
+        hardware_units_from_base = (
+            mm_from_base * 2
+            if self.model == ModuleModel.MAGNETIC_MODULE_V1
+            else mm_from_base
+        )
+        home_to_base_offset = MAGNETIC_MODULE_OFFSET_TO_LABWARE_BOTTOM[self.model]
+        hardware_units_from_home = home_to_base_offset + hardware_units_from_base
+
+        if not engage_height_is_in_range(
+            model=self.model,
+            height=hardware_units_from_home,
+        ):
+            # TODO(mm, 2022-03-02): This error message probably will not match how
+            # the user specified the height. (Hardware units versus mm,
+            # home as origin versus labware base as origin.) This may be confusing
+            # depending on how it propagates up.
+            raise EngageHeightOutOfRangeError(
+                f"Invalid engage height for {self.model}:"
+                f" {hardware_units_from_home}. Must be"
+                f" 0 - {MAGNETIC_MODULE_MAX_ENGAGE_HEIGHT[self.model]}."
+            )
+
+        return hardware_units_from_home

--- a/api/src/opentrons/protocol_engine/state/module_substates/magnetic_module_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/magnetic_module_substate.py
@@ -1,4 +1,4 @@
-"""Magnetic module state view."""
+"""Magnetic module sub-state."""
 
 from dataclasses import dataclass
 from typing import NewType

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -218,9 +218,22 @@ class ModuleView(HasState[ModuleState]):
                 f"{module_id} is a {model}, not a Heater-Shaker Module."
             )
 
-    def get_plate_target_temperature(self, module_id: str) -> Optional[float]:
+    # TODO(mc, 2022-03-28): move to heater shaker view
+    def get_plate_target_temperature(self, module_id: str) -> float:
         """Get the module's target plate temperature."""
-        return self._state.hardware_by_module_id[module_id].plate_target_temperature
+        try:
+            target = self._state.hardware_by_module_id[
+                module_id
+            ].plate_target_temperature
+        except KeyError as e:
+            raise errors.ModuleNotLoadedError(f"Module {module_id} not found.") from e
+
+        if target is None:
+            raise errors.NoTargetTemperatureSetError(
+                f"Module {module_id} does not have a target temperature set."
+            )
+
+        return target
 
     def get_location(self, module_id: str) -> DeckSlotLocation:
         """Get the slot location of the given module."""

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -208,18 +208,17 @@ class ModuleView(HasState[ModuleState]):
             WrongModuleTypeError: If module_id has been loaded,
                 but it's not a Magnetic Module.
         """
-        model = self.get_model(module_id=module_id)  # Propagate ModuleNotLoadedError
-
-        if ModuleModel.is_magnetic_module_model(model):
+        try:
             substate = self._state.substate_by_module_id[module_id]
-            assert isinstance(
-                substate, MagneticModuleSubState
-            ), f"Expected MagneticModuleSubState but got {substate}."
-            return substate
+        except KeyError as e:
+            raise errors.ModuleNotLoadedError(f"Module {module_id} not found.") from e
         else:
-            raise errors.WrongModuleTypeError(
-                f"{module_id} is a {model}, not a Magnetic Module."
-            )
+            if isinstance(substate, MagneticModuleSubState):
+                return substate
+            else:
+                raise errors.WrongModuleTypeError(
+                    f"{module_id} is not a Magnetic Module."
+                )
 
     def get_heater_shaker_module_substate(
         self, module_id: str
@@ -231,17 +230,17 @@ class ModuleView(HasState[ModuleState]):
            WrongModuleTypeError: If module_id has been loaded,
                but it's not a Heater-Shaker Module.
         """
-        model = self.get_model(module_id=module_id)  # Propagate ModuleNotLoadedError
-        if ModuleModel.is_heater_shaker_module_model(model):
+        try:
             substate = self._state.substate_by_module_id[module_id]
-            assert isinstance(
-                substate, HeaterShakerModuleSubState
-            ), f"Expected HeaterShakerModuleSubState but got {substate}"
-            return substate
+        except KeyError as e:
+            raise errors.ModuleNotLoadedError(f"Module {module_id} not found.") from e
         else:
-            raise errors.WrongModuleTypeError(
-                f"{module_id} is a {model}, not a Heater-Shaker Module."
-            )
+            if isinstance(substate, HeaterShakerModuleSubState):
+                return substate
+            else:
+                raise errors.WrongModuleTypeError(
+                    f"{module_id} is not a Heater-Shaker Module."
+                )
 
     def get_location(self, module_id: str) -> DeckSlotLocation:
         """Get the slot location of the given module."""

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List, NamedTuple, Optional, Sequence, overload, Union
+from typing import Dict, List, NamedTuple, Optional, Sequence, overload
 from numpy import array, dot
 
 from opentrons.hardware_control.modules.magdeck import (
@@ -29,6 +29,7 @@ from .module_substates import (
     HeaterShakerModuleSubState,
     MagneticModuleId,
     HeaterShakerModuleId,
+    ModuleSubStateType,
 )
 
 
@@ -71,9 +72,7 @@ class ModuleState:
 
     slot_by_module_id: Dict[str, Optional[DeckSlotName]]
     hardware_by_module_id: Dict[str, HardwareModule]
-    substate_by_module_id: Dict[
-        str, Union[HeaterShakerModuleSubState, MagneticModuleSubState]
-    ]
+    substate_by_module_id: Dict[str, ModuleSubStateType]
 
 
 class ModuleStore(HasState[ModuleState], HandlesActions):

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -1,10 +1,11 @@
 """Public protocol engine value types and models."""
-
+from __future__ import annotations
 from datetime import datetime
 from enum import Enum
 from dataclasses import dataclass
 from pydantic import BaseModel, Field
 from typing import Optional, Union, List, Dict, Any
+from typing_extensions import Literal, TypeGuard
 
 from opentrons.types import MountType, DeckSlotName
 from opentrons.hardware_control.modules import ModuleType as ModuleType
@@ -136,8 +137,6 @@ class MotorAxis(str, Enum):
 
 
 # TODO(mc, 2022-01-18): use opentrons_shared_data.module.dev_types.ModuleModel
-
-
 class ModuleModel(str, Enum):
     """All available modules' models."""
 
@@ -150,19 +149,54 @@ class ModuleModel(str, Enum):
 
     def as_type(self) -> ModuleType:
         """Get the ModuleType of this model."""
-        if self in [
-            ModuleModel.TEMPERATURE_MODULE_V1,
-            ModuleModel.TEMPERATURE_MODULE_V2,
-        ]:
+        if ModuleModel.is_temperature_module_model(self):
             return ModuleType.TEMPERATURE
-        elif self in [ModuleModel.MAGNETIC_MODULE_V1, ModuleModel.MAGNETIC_MODULE_V2]:
+        elif ModuleModel.is_magnetic_module_model(self):
             return ModuleType.MAGNETIC
-        elif self == ModuleModel.THERMOCYCLER_MODULE_V1:
+        elif ModuleModel.is_thermocycler_module_model(self):
             return ModuleType.THERMOCYCLER
-        elif self == ModuleModel.HEATER_SHAKER_MODULE_V1:
+        elif ModuleModel.is_heater_shaker_module_model(self):
             return ModuleType.HEATER_SHAKER
 
         assert False, f"Invalid ModuleModel {self}"
+
+    @classmethod
+    def is_temperature_module_model(
+        cls, model: ModuleModel
+    ) -> TypeGuard[TemperatureModuleModel]:
+        """Whether a given model is a Temperature Module."""
+        return model in [cls.TEMPERATURE_MODULE_V1, cls.TEMPERATURE_MODULE_V2]
+
+    @classmethod
+    def is_magnetic_module_model(
+        cls, model: ModuleModel
+    ) -> TypeGuard[MagneticModuleModel]:
+        """Whether a given model is a Magnetic Module."""
+        return model in [cls.MAGNETIC_MODULE_V1, cls.MAGNETIC_MODULE_V2]
+
+    @classmethod
+    def is_thermocycler_module_model(
+        cls, model: ModuleModel
+    ) -> TypeGuard[ThermocyclerModuleModel]:
+        """Whether a given model is a Thermocyler Module."""
+        return model == cls.THERMOCYCLER_MODULE_V1
+
+    @classmethod
+    def is_heater_shaker_module_model(
+        cls, model: ModuleModel
+    ) -> TypeGuard[HeaterShakerModuleModel]:
+        """Whether a given model is a Heater-Shaker Module."""
+        return model == cls.HEATER_SHAKER_MODULE_V1
+
+
+TemperatureModuleModel = Literal[
+    ModuleModel.TEMPERATURE_MODULE_V1, ModuleModel.TEMPERATURE_MODULE_V2
+]
+MagneticModuleModel = Literal[
+    ModuleModel.MAGNETIC_MODULE_V1, ModuleModel.MAGNETIC_MODULE_V2
+]
+ThermocyclerModuleModel = Literal[ModuleModel.THERMOCYCLER_MODULE_V1]
+HeaterShakerModuleModel = Literal[ModuleModel.HEATER_SHAKER_MODULE_V1]
 
 
 class ModuleDimensions(BaseModel):

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_await_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_await_temperature.py
@@ -1,13 +1,14 @@
 """Test Heater Shaker await temperature command implementation."""
-import pytest
 from decoy import Decoy
 
-from opentrons.hardware_control import HardwareControlAPI
-from opentrons.hardware_control.modules import HeaterShaker, AbstractModule
+from opentrons.hardware_control.modules import HeaterShaker
 
-from opentrons.protocol_engine import errors
 from opentrons.protocol_engine.state import StateView
-from opentrons.protocol_engine.state.modules import HeaterShakerModuleView
+from opentrons.protocol_engine.state.modules import (
+    HeaterShakerModuleView,
+    HeaterShakerModuleId,
+)
+from opentrons.protocol_engine.execution import EquipmentHandler
 from opentrons.protocol_engine.commands import heater_shaker
 from opentrons.protocol_engine.commands.heater_shaker.await_temperature import (
     AwaitTemperatureImpl,
@@ -15,53 +16,42 @@ from opentrons.protocol_engine.commands.heater_shaker.await_temperature import (
 
 
 async def test_await_temperature(
-    decoy: Decoy, state_view: StateView, hardware_api: HardwareControlAPI
+    decoy: Decoy,
+    state_view: StateView,
+    equipment: EquipmentHandler,
 ) -> None:
     """It should be able to wait for the module's target temperature."""
-    subject = AwaitTemperatureImpl(state_view=state_view, hardware_api=hardware_api)
+    subject = AwaitTemperatureImpl(state_view=state_view, equipment=equipment)
 
-    data = heater_shaker.AwaitTemperatureParams(moduleId="heater-shaker-id")
+    data = heater_shaker.AwaitTemperatureParams(moduleId="input-heater-shaker-id")
 
     # Get module view
     hs_module_view = decoy.mock(cls=HeaterShakerModuleView)
+    hs_hardware = decoy.mock(cls=HeaterShaker)
 
     decoy.when(
-        state_view.modules.get_heater_shaker_module_view(module_id="heater-shaker-id")
+        state_view.modules.get_heater_shaker_module_view(
+            module_id="input-heater-shaker-id"
+        )
     ).then_return(hs_module_view)
 
+    decoy.when(hs_module_view.module_id).then_return(
+        HeaterShakerModuleId("heater-shaker-id")
+    )
+
     decoy.when(
-        hs_module_view.parent_module_view.get_plate_target_temperature(
-            module_id="heater-shaker-id"
+        state_view.modules.get_plate_target_temperature(
+            HeaterShakerModuleId("heater-shaker-id")
         )
     ).then_return(123.45)
 
-    # Get attached hardware modules
-    attached = [decoy.mock(cls=AbstractModule), decoy.mock(cls=AbstractModule)]
-    match = decoy.mock(cls=HeaterShaker)
-    decoy.when(hardware_api.attached_modules).then_return(attached)
-
     # Get stubbed hardware module from hs module view
-    decoy.when(hs_module_view.find_hardware(attached_modules=attached)).then_return(
-        match
-    )
+    decoy.when(
+        equipment.get_module_hardware_api(HeaterShakerModuleId("heater-shaker-id"))
+    ).then_return(hs_hardware)
 
     result = await subject.execute(data)
-    decoy.verify(await match.await_temperature(awaiting_temperature=123.45), times=1)
+    decoy.verify(
+        await hs_hardware.await_temperature(awaiting_temperature=123.45), times=1
+    )
     assert result == heater_shaker.AwaitTemperatureResult()
-
-
-async def test_raises_without_target_temp(
-    decoy: Decoy, state_view: StateView, hardware_api: HardwareControlAPI
-) -> None:
-    """It should raise an error when executing command without a target temperature."""
-    subject = AwaitTemperatureImpl(state_view=state_view, hardware_api=hardware_api)
-    data = heater_shaker.AwaitTemperatureParams(moduleId="heater-shaker-id")
-
-    # Get module view
-    hs_module_view = decoy.mock(cls=HeaterShakerModuleView)
-    decoy.when(
-        state_view.modules.get_heater_shaker_module_view(module_id="heater-shaker-id")
-    ).then_return(hs_module_view)
-
-    with pytest.raises(errors.NoTargetTemperatureSetError):
-        await subject.execute(data)

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_await_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_await_temperature.py
@@ -5,7 +5,7 @@ from opentrons.hardware_control.modules import HeaterShaker
 
 from opentrons.protocol_engine.state import StateView
 from opentrons.protocol_engine.state.modules import (
-    HeaterShakerModuleView,
+    HeaterShakerModuleSubState,
     HeaterShakerModuleId,
 )
 from opentrons.protocol_engine.execution import EquipmentHandler
@@ -26,13 +26,12 @@ async def test_await_temperature(
     data = heater_shaker.AwaitTemperatureParams(moduleId="input-heater-shaker-id")
 
     # Get module view
-    hs_module_view = decoy.mock(cls=HeaterShakerModuleView)
+    hs_module_view = decoy.mock(cls=HeaterShakerModuleSubState)
     hs_hardware = decoy.mock(cls=HeaterShaker)
 
     decoy.when(
-        state_view.modules.get_heater_shaker_module_view(
-            module_id="input-heater-shaker-id"
-        )
+        state_view.modules.get_heater_shaker_module_substate(
+            module_id="input-heater-shaker-id")
     ).then_return(hs_module_view)
 
     decoy.when(hs_module_view.module_id).then_return(

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_await_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_await_temperature.py
@@ -4,7 +4,7 @@ from decoy import Decoy
 from opentrons.hardware_control.modules import HeaterShaker
 
 from opentrons.protocol_engine.state import StateView
-from opentrons.protocol_engine.state.modules import (
+from opentrons.protocol_engine.state.module_substates import (
     HeaterShakerModuleSubState,
     HeaterShakerModuleId,
 )
@@ -23,26 +23,22 @@ async def test_await_temperature(
     """It should be able to wait for the module's target temperature."""
     subject = AwaitTemperatureImpl(state_view=state_view, equipment=equipment)
 
-    data = heater_shaker.AwaitTemperatureParams(moduleId="input-heater-shaker-id")
+    data = heater_shaker.AwaitTemperatureParams(moduleId="heater-shaker-id")
 
     # Get module view
-    hs_module_view = decoy.mock(cls=HeaterShakerModuleSubState)
+    hs_module_substate = decoy.mock(cls=HeaterShakerModuleSubState)
     hs_hardware = decoy.mock(cls=HeaterShaker)
 
     decoy.when(
         state_view.modules.get_heater_shaker_module_substate(
-            module_id="input-heater-shaker-id")
-    ).then_return(hs_module_view)
+            module_id="heater-shaker-id"
+        )
+    ).then_return(hs_module_substate)
 
-    decoy.when(hs_module_view.module_id).then_return(
+    decoy.when(hs_module_substate.get_plate_target_temperature()).then_return(123.45)
+    decoy.when(hs_module_substate.module_id).then_return(
         HeaterShakerModuleId("heater-shaker-id")
     )
-
-    decoy.when(
-        state_view.modules.get_plate_target_temperature(
-            HeaterShakerModuleId("heater-shaker-id")
-        )
-    ).then_return(123.45)
 
     # Get stubbed hardware module from hs module view
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_await_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_await_temperature.py
@@ -25,7 +25,6 @@ async def test_await_temperature(
 
     data = heater_shaker.AwaitTemperatureParams(moduleId="heater-shaker-id")
 
-    # Get module view
     hs_module_substate = decoy.mock(cls=HeaterShakerModuleSubState)
     hs_hardware = decoy.mock(cls=HeaterShaker)
 

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_close_latch.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_close_latch.py
@@ -4,7 +4,7 @@ from decoy import Decoy
 from opentrons.hardware_control.modules import HeaterShaker
 
 from opentrons.protocol_engine.state import StateView
-from opentrons.protocol_engine.state.modules import (
+from opentrons.protocol_engine.state.module_substates import (
     HeaterShakerModuleSubState,
     HeaterShakerModuleId,
 )
@@ -16,7 +16,9 @@ from opentrons.protocol_engine.commands.heater_shaker.close_latch import (
 
 
 async def test_close_latch(
-    decoy: Decoy, state_view: StateView, equipment: EquipmentHandler,
+    decoy: Decoy,
+    state_view: StateView,
+    equipment: EquipmentHandler,
 ) -> None:
     """It should be able to close the module's labware latch."""
     subject = CloseLatchImpl(state_view=state_view, equipment=equipment)
@@ -27,7 +29,8 @@ async def test_close_latch(
 
     decoy.when(
         state_view.modules.get_heater_shaker_module_substate(
-            module_id="input-heater-shaker-id")
+            module_id="input-heater-shaker-id"
+        )
     ).then_return(hs_module_view)
 
     decoy.when(hs_module_view.module_id).then_return(
@@ -44,7 +47,9 @@ async def test_close_latch(
 
 
 async def test_close_latch_virtual(
-    decoy: Decoy, state_view: StateView, equipment: EquipmentHandler,
+    decoy: Decoy,
+    state_view: StateView,
+    equipment: EquipmentHandler,
 ) -> None:
     """It should no-op for virtual modules."""
     subject = CloseLatchImpl(state_view=state_view, equipment=equipment)
@@ -54,7 +59,8 @@ async def test_close_latch_virtual(
 
     decoy.when(
         state_view.modules.get_heater_shaker_module_substate(
-            module_id="input-heater-shaker-id")
+            module_id="input-heater-shaker-id"
+        )
     ).then_return(hs_module_view)
 
     decoy.when(hs_module_view.module_id).then_return(

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_close_latch.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_close_latch.py
@@ -5,7 +5,7 @@ from opentrons.hardware_control.modules import HeaterShaker
 
 from opentrons.protocol_engine.state import StateView
 from opentrons.protocol_engine.state.modules import (
-    HeaterShakerModuleView,
+    HeaterShakerModuleSubState,
     HeaterShakerModuleId,
 )
 from opentrons.protocol_engine.execution import EquipmentHandler
@@ -22,13 +22,12 @@ async def test_close_latch(
     subject = CloseLatchImpl(state_view=state_view, equipment=equipment)
     data = heater_shaker.CloseLatchParams(moduleId="input-heater-shaker-id")
 
-    hs_module_view = decoy.mock(cls=HeaterShakerModuleView)
+    hs_module_view = decoy.mock(cls=HeaterShakerModuleSubState)
     heater_shaker_hardware = decoy.mock(cls=HeaterShaker)
 
     decoy.when(
-        state_view.modules.get_heater_shaker_module_view(
-            module_id="input-heater-shaker-id"
-        )
+        state_view.modules.get_heater_shaker_module_substate(
+            module_id="input-heater-shaker-id")
     ).then_return(hs_module_view)
 
     decoy.when(hs_module_view.module_id).then_return(
@@ -51,12 +50,11 @@ async def test_close_latch_virtual(
     subject = CloseLatchImpl(state_view=state_view, equipment=equipment)
     data = heater_shaker.CloseLatchParams(moduleId="input-heater-shaker-id")
 
-    hs_module_view = decoy.mock(cls=HeaterShakerModuleView)
+    hs_module_view = decoy.mock(cls=HeaterShakerModuleSubState)
 
     decoy.when(
-        state_view.modules.get_heater_shaker_module_view(
-            module_id="input-heater-shaker-id"
-        )
+        state_view.modules.get_heater_shaker_module_substate(
+            module_id="input-heater-shaker-id")
     ).then_return(hs_module_view)
 
     decoy.when(hs_module_view.module_id).then_return(

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_close_latch.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_close_latch.py
@@ -1,11 +1,14 @@
 """Test Heater Shaker close latch command implementation."""
 from decoy import Decoy
 
-from opentrons.hardware_control import HardwareControlAPI
-from opentrons.hardware_control.modules import AbstractModule, HeaterShaker
+from opentrons.hardware_control.modules import HeaterShaker
 
 from opentrons.protocol_engine.state import StateView
-from opentrons.protocol_engine.state.modules import HeaterShakerModuleView
+from opentrons.protocol_engine.state.modules import (
+    HeaterShakerModuleView,
+    HeaterShakerModuleId,
+)
+from opentrons.protocol_engine.execution import EquipmentHandler
 from opentrons.protocol_engine.commands import heater_shaker
 from opentrons.protocol_engine.commands.heater_shaker.close_latch import (
     CloseLatchImpl,
@@ -13,29 +16,57 @@ from opentrons.protocol_engine.commands.heater_shaker.close_latch import (
 
 
 async def test_close_latch(
-    decoy: Decoy, state_view: StateView, hardware_api: HardwareControlAPI
+    decoy: Decoy, state_view: StateView, equipment: EquipmentHandler
 ) -> None:
     """It should be able to close the module's labware latch."""
-    subject = CloseLatchImpl(state_view=state_view, hardware_api=hardware_api)
-    data = heater_shaker.CloseLatchParams(moduleId="heater-shaker-id")
+    subject = CloseLatchImpl(state_view=state_view, equipment=equipment)
+    data = heater_shaker.CloseLatchParams(moduleId="input-heater-shaker-id")
 
-    # Get module view
+    hs_module_view = decoy.mock(cls=HeaterShakerModuleView)
+    heater_shaker_hardware = decoy.mock(cls=HeaterShaker)
+
+    decoy.when(
+        state_view.modules.get_heater_shaker_module_view(
+            module_id="input-heater-shaker-id"
+        )
+    ).then_return(hs_module_view)
+
+    decoy.when(hs_module_view.module_id).then_return(
+        HeaterShakerModuleId("heater-shaker-id")
+    )
+
+    decoy.when(
+        equipment.get_module_hardware_api(HeaterShakerModuleId("heater-shaker-id"))
+    ).then_return(heater_shaker_hardware)
+
+    result = await subject.execute(data)
+    decoy.verify(await heater_shaker_hardware.close_labware_latch(), times=1)
+    assert result == heater_shaker.CloseLatchResult()
+
+
+async def test_close_latch_virtual(
+    decoy: Decoy, state_view: StateView, equipment: EquipmentHandler
+) -> None:
+    """It should no-op for virtual modules."""
+    subject = CloseLatchImpl(state_view=state_view, equipment=equipment)
+    data = heater_shaker.CloseLatchParams(moduleId="input-heater-shaker-id")
+
     hs_module_view = decoy.mock(cls=HeaterShakerModuleView)
 
     decoy.when(
-        state_view.modules.get_heater_shaker_module_view(module_id="heater-shaker-id")
+        state_view.modules.get_heater_shaker_module_view(
+            module_id="input-heater-shaker-id"
+        )
     ).then_return(hs_module_view)
 
-    # Get attached hardware modules
-    attached = [decoy.mock(cls=AbstractModule), decoy.mock(cls=AbstractModule)]
-    match = decoy.mock(cls=HeaterShaker)
-    decoy.when(hardware_api.attached_modules).then_return(attached)
-
-    # Get stubbed hardware module from hs module view
-    decoy.when(hs_module_view.find_hardware(attached_modules=attached)).then_return(
-        match
+    decoy.when(hs_module_view.module_id).then_return(
+        HeaterShakerModuleId("heater-shaker-id")
     )
 
+    decoy.when(
+        equipment.get_module_hardware_api(HeaterShakerModuleId("heater-shaker-id"))
+    ).then_return(None)
+
     result = await subject.execute(data)
-    decoy.verify(await match.close_labware_latch(), times=1)
+
     assert result == heater_shaker.CloseLatchResult()

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_close_latch.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_close_latch.py
@@ -16,7 +16,7 @@ from opentrons.protocol_engine.commands.heater_shaker.close_latch import (
 
 
 async def test_close_latch(
-    decoy: Decoy, state_view: StateView, equipment: EquipmentHandler
+    decoy: Decoy, state_view: StateView, equipment: EquipmentHandler,
 ) -> None:
     """It should be able to close the module's labware latch."""
     subject = CloseLatchImpl(state_view=state_view, equipment=equipment)
@@ -45,7 +45,7 @@ async def test_close_latch(
 
 
 async def test_close_latch_virtual(
-    decoy: Decoy, state_view: StateView, equipment: EquipmentHandler
+    decoy: Decoy, state_view: StateView, equipment: EquipmentHandler,
 ) -> None:
     """It should no-op for virtual modules."""
     subject = CloseLatchImpl(state_view=state_view, equipment=equipment)

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_close_latch.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_close_latch.py
@@ -24,16 +24,16 @@ async def test_close_latch(
     subject = CloseLatchImpl(state_view=state_view, equipment=equipment)
     data = heater_shaker.CloseLatchParams(moduleId="input-heater-shaker-id")
 
-    hs_module_view = decoy.mock(cls=HeaterShakerModuleSubState)
+    hs_module_substate = decoy.mock(cls=HeaterShakerModuleSubState)
     heater_shaker_hardware = decoy.mock(cls=HeaterShaker)
 
     decoy.when(
         state_view.modules.get_heater_shaker_module_substate(
             module_id="input-heater-shaker-id"
         )
-    ).then_return(hs_module_view)
+    ).then_return(hs_module_substate)
 
-    decoy.when(hs_module_view.module_id).then_return(
+    decoy.when(hs_module_substate.module_id).then_return(
         HeaterShakerModuleId("heater-shaker-id")
     )
 
@@ -55,15 +55,15 @@ async def test_close_latch_virtual(
     subject = CloseLatchImpl(state_view=state_view, equipment=equipment)
     data = heater_shaker.CloseLatchParams(moduleId="input-heater-shaker-id")
 
-    hs_module_view = decoy.mock(cls=HeaterShakerModuleSubState)
+    hs_module_substate = decoy.mock(cls=HeaterShakerModuleSubState)
 
     decoy.when(
         state_view.modules.get_heater_shaker_module_substate(
             module_id="input-heater-shaker-id"
         )
-    ).then_return(hs_module_view)
+    ).then_return(hs_module_substate)
 
-    decoy.when(hs_module_view.module_id).then_return(
+    decoy.when(hs_module_substate.module_id).then_return(
         HeaterShakerModuleId("heater-shaker-id")
     )
 

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_deactivate_heater.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_deactivate_heater.py
@@ -1,12 +1,14 @@
 """Test Heater Shaker deactivate heater command implementation."""
-
 from decoy import Decoy
 
-from opentrons.hardware_control import HardwareControlAPI
-from opentrons.hardware_control.modules import AbstractModule, HeaterShaker
+from opentrons.hardware_control.modules import HeaterShaker
 
 from opentrons.protocol_engine.state import StateView
-from opentrons.protocol_engine.state.modules import HeaterShakerModuleView
+from opentrons.protocol_engine.state.modules import (
+    HeaterShakerModuleView,
+    HeaterShakerModuleId,
+)
+from opentrons.protocol_engine.execution import EquipmentHandler
 from opentrons.protocol_engine.commands import heater_shaker
 from opentrons.protocol_engine.commands.heater_shaker.deactivate_heater import (
     DeactivateHeaterImpl,
@@ -14,29 +16,34 @@ from opentrons.protocol_engine.commands.heater_shaker.deactivate_heater import (
 
 
 async def test_deactivate_heater(
-    decoy: Decoy, state_view: StateView, hardware_api: HardwareControlAPI
+    decoy: Decoy,
+    state_view: StateView,
+    equipment: EquipmentHandler,
 ) -> None:
     """It should be able to deactivate the module's heater."""
-    subject = DeactivateHeaterImpl(state_view=state_view, hardware_api=hardware_api)
-
-    data = heater_shaker.DeactivateHeaterParams(moduleId="heater-shaker-id")
+    subject = DeactivateHeaterImpl(state_view=state_view, equipment=equipment)
+    data = heater_shaker.DeactivateHeaterParams(moduleId="input-heater-shaker-id")
 
     # Get module view
+    # Get module view
     hs_module_view = decoy.mock(cls=HeaterShakerModuleView)
+    hs_hardware = decoy.mock(cls=HeaterShaker)
+
     decoy.when(
-        state_view.modules.get_heater_shaker_module_view(module_id="heater-shaker-id")
+        state_view.modules.get_heater_shaker_module_view(
+            module_id="input-heater-shaker-id"
+        )
     ).then_return(hs_module_view)
 
-    # Get attached hardware modules
-    attached = [decoy.mock(cls=AbstractModule), decoy.mock(cls=AbstractModule)]
-    match = decoy.mock(cls=HeaterShaker)
-    decoy.when(hardware_api.attached_modules).then_return(attached)
-
-    # Get stubbed hardware module from hs module view
-    decoy.when(hs_module_view.find_hardware(attached_modules=attached)).then_return(
-        match
+    decoy.when(hs_module_view.module_id).then_return(
+        HeaterShakerModuleId("heater-shaker-id")
     )
 
+    # Get stubbed hardware module
+    decoy.when(
+        equipment.get_module_hardware_api(HeaterShakerModuleId("heater-shaker-id"))
+    ).then_return(hs_hardware)
+
     result = await subject.execute(data)
-    decoy.verify(await match.start_set_temperature(celsius=0), times=1)
+    decoy.verify(await hs_hardware.start_set_temperature(celsius=0), times=1)
     assert result == heater_shaker.DeactivateHeaterResult()

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_deactivate_heater.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_deactivate_heater.py
@@ -24,18 +24,16 @@ async def test_deactivate_heater(
     subject = DeactivateHeaterImpl(state_view=state_view, equipment=equipment)
     data = heater_shaker.DeactivateHeaterParams(moduleId="input-heater-shaker-id")
 
-    # Get module view
-    # Get module view
-    hs_module_view = decoy.mock(cls=HeaterShakerModuleSubState)
+    hs_module_substate = decoy.mock(cls=HeaterShakerModuleSubState)
     hs_hardware = decoy.mock(cls=HeaterShaker)
 
     decoy.when(
         state_view.modules.get_heater_shaker_module_substate(
             module_id="input-heater-shaker-id"
         )
-    ).then_return(hs_module_view)
+    ).then_return(hs_module_substate)
 
-    decoy.when(hs_module_view.module_id).then_return(
+    decoy.when(hs_module_substate.module_id).then_return(
         HeaterShakerModuleId("heater-shaker-id")
     )
 

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_deactivate_heater.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_deactivate_heater.py
@@ -4,7 +4,7 @@ from decoy import Decoy
 from opentrons.hardware_control.modules import HeaterShaker
 
 from opentrons.protocol_engine.state import StateView
-from opentrons.protocol_engine.state.modules import (
+from opentrons.protocol_engine.state.module_substates import (
     HeaterShakerModuleSubState,
     HeaterShakerModuleId,
 )
@@ -31,7 +31,8 @@ async def test_deactivate_heater(
 
     decoy.when(
         state_view.modules.get_heater_shaker_module_substate(
-            module_id="input-heater-shaker-id")
+            module_id="input-heater-shaker-id"
+        )
     ).then_return(hs_module_view)
 
     decoy.when(hs_module_view.module_id).then_return(

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_deactivate_heater.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_deactivate_heater.py
@@ -5,7 +5,7 @@ from opentrons.hardware_control.modules import HeaterShaker
 
 from opentrons.protocol_engine.state import StateView
 from opentrons.protocol_engine.state.modules import (
-    HeaterShakerModuleView,
+    HeaterShakerModuleSubState,
     HeaterShakerModuleId,
 )
 from opentrons.protocol_engine.execution import EquipmentHandler
@@ -26,13 +26,12 @@ async def test_deactivate_heater(
 
     # Get module view
     # Get module view
-    hs_module_view = decoy.mock(cls=HeaterShakerModuleView)
+    hs_module_view = decoy.mock(cls=HeaterShakerModuleSubState)
     hs_hardware = decoy.mock(cls=HeaterShaker)
 
     decoy.when(
-        state_view.modules.get_heater_shaker_module_view(
-            module_id="input-heater-shaker-id"
-        )
+        state_view.modules.get_heater_shaker_module_substate(
+            module_id="input-heater-shaker-id")
     ).then_return(hs_module_view)
 
     decoy.when(hs_module_view.module_id).then_return(

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_open_latch.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_open_latch.py
@@ -24,17 +24,16 @@ async def test_open_latch(
     subject = OpenLatchImpl(state_view=state_view, equipment=equipment)
     data = heater_shaker.OpenLatchParams(moduleId="input-heater-shaker-id")
 
-    # Get module view
-    hs_module_view = decoy.mock(cls=HeaterShakerModuleSubState)
+    hs_module_substate = decoy.mock(cls=HeaterShakerModuleSubState)
     hs_hardware = decoy.mock(cls=HeaterShaker)
 
     decoy.when(
         state_view.modules.get_heater_shaker_module_substate(
             module_id="input-heater-shaker-id"
         )
-    ).then_return(hs_module_view)
+    ).then_return(hs_module_substate)
 
-    decoy.when(hs_module_view.module_id).then_return(
+    decoy.when(hs_module_substate.module_id).then_return(
         HeaterShakerModuleId("heater-shaker-id")
     )
 

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_open_latch.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_open_latch.py
@@ -1,11 +1,14 @@
 """Test Heater Shaker open latch command implementation."""
 from decoy import Decoy
 
-from opentrons.hardware_control import HardwareControlAPI
-from opentrons.hardware_control.modules import AbstractModule, HeaterShaker
+from opentrons.hardware_control.modules import HeaterShaker
 
 from opentrons.protocol_engine.state import StateView
-from opentrons.protocol_engine.state.modules import HeaterShakerModuleView
+from opentrons.protocol_engine.state.modules import (
+    HeaterShakerModuleView,
+    HeaterShakerModuleId,
+)
+from opentrons.protocol_engine.execution import EquipmentHandler
 from opentrons.protocol_engine.commands import heater_shaker
 from opentrons.protocol_engine.commands.heater_shaker.open_latch import (
     OpenLatchImpl,
@@ -13,28 +16,33 @@ from opentrons.protocol_engine.commands.heater_shaker.open_latch import (
 
 
 async def test_open_latch(
-    decoy: Decoy, state_view: StateView, hardware_api: HardwareControlAPI
+    decoy: Decoy,
+    state_view: StateView,
+    equipment: EquipmentHandler,
 ) -> None:
     """It should be able to open the module's labware latch."""
-    subject = OpenLatchImpl(state_view=state_view, hardware_api=hardware_api)
-    data = heater_shaker.OpenLatchParams(moduleId="heater-shaker-id")
+    subject = OpenLatchImpl(state_view=state_view, equipment=equipment)
+    data = heater_shaker.OpenLatchParams(moduleId="input-heater-shaker-id")
 
     # Get module view
     hs_module_view = decoy.mock(cls=HeaterShakerModuleView)
+    hs_hardware = decoy.mock(cls=HeaterShaker)
+
     decoy.when(
-        state_view.modules.get_heater_shaker_module_view(module_id="heater-shaker-id")
+        state_view.modules.get_heater_shaker_module_view(
+            module_id="input-heater-shaker-id"
+        )
     ).then_return(hs_module_view)
 
-    # Get attached hardware modules
-    attached = [decoy.mock(cls=AbstractModule), decoy.mock(cls=AbstractModule)]
-    match = decoy.mock(cls=HeaterShaker)
-    decoy.when(hardware_api.attached_modules).then_return(attached)
-
-    # Get stubbed hardware module from hs module view
-    decoy.when(hs_module_view.find_hardware(attached_modules=attached)).then_return(
-        match
+    decoy.when(hs_module_view.module_id).then_return(
+        HeaterShakerModuleId("heater-shaker-id")
     )
 
+    # Get stubbed hardware module
+    decoy.when(
+        equipment.get_module_hardware_api(HeaterShakerModuleId("heater-shaker-id"))
+    ).then_return(hs_hardware)
+
     result = await subject.execute(data)
-    decoy.verify(await match.open_labware_latch(), times=1)
+    decoy.verify(await hs_hardware.open_labware_latch(), times=1)
     assert result == heater_shaker.OpenLatchResult()

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_open_latch.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_open_latch.py
@@ -5,7 +5,7 @@ from opentrons.hardware_control.modules import HeaterShaker
 
 from opentrons.protocol_engine.state import StateView
 from opentrons.protocol_engine.state.modules import (
-    HeaterShakerModuleView,
+    HeaterShakerModuleSubState,
     HeaterShakerModuleId,
 )
 from opentrons.protocol_engine.execution import EquipmentHandler
@@ -25,13 +25,12 @@ async def test_open_latch(
     data = heater_shaker.OpenLatchParams(moduleId="input-heater-shaker-id")
 
     # Get module view
-    hs_module_view = decoy.mock(cls=HeaterShakerModuleView)
+    hs_module_view = decoy.mock(cls=HeaterShakerModuleSubState)
     hs_hardware = decoy.mock(cls=HeaterShaker)
 
     decoy.when(
-        state_view.modules.get_heater_shaker_module_view(
-            module_id="input-heater-shaker-id"
-        )
+        state_view.modules.get_heater_shaker_module_substate(
+            module_id="input-heater-shaker-id")
     ).then_return(hs_module_view)
 
     decoy.when(hs_module_view.module_id).then_return(

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_open_latch.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_open_latch.py
@@ -4,7 +4,7 @@ from decoy import Decoy
 from opentrons.hardware_control.modules import HeaterShaker
 
 from opentrons.protocol_engine.state import StateView
-from opentrons.protocol_engine.state.modules import (
+from opentrons.protocol_engine.state.module_substates import (
     HeaterShakerModuleSubState,
     HeaterShakerModuleId,
 )
@@ -30,7 +30,8 @@ async def test_open_latch(
 
     decoy.when(
         state_view.modules.get_heater_shaker_module_substate(
-            module_id="input-heater-shaker-id")
+            module_id="input-heater-shaker-id"
+        )
     ).then_return(hs_module_view)
 
     decoy.when(hs_module_view.module_id).then_return(

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_set_target_shake_speed.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_set_target_shake_speed.py
@@ -4,7 +4,7 @@ from decoy import Decoy
 from opentrons.hardware_control.modules import HeaterShaker
 
 from opentrons.protocol_engine.state import StateView
-from opentrons.protocol_engine.state.modules import (
+from opentrons.protocol_engine.state.module_substates import (
     HeaterShakerModuleSubState,
     HeaterShakerModuleId,
 )
@@ -33,7 +33,8 @@ async def test_set_target_shake_speed(
 
     decoy.when(
         state_view.modules.get_heater_shaker_module_substate(
-            module_id="input-heater-shaker-id")
+            module_id="input-heater-shaker-id"
+        )
     ).then_return(hs_module_view)
 
     decoy.when(hs_module_view.module_id).then_return(

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_set_target_shake_speed.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_set_target_shake_speed.py
@@ -5,7 +5,7 @@ from opentrons.hardware_control.modules import HeaterShaker
 
 from opentrons.protocol_engine.state import StateView
 from opentrons.protocol_engine.state.modules import (
-    HeaterShakerModuleView,
+    HeaterShakerModuleSubState,
     HeaterShakerModuleId,
 )
 from opentrons.protocol_engine.execution import EquipmentHandler
@@ -28,13 +28,12 @@ async def test_set_target_shake_speed(
     )
 
     # Get module view
-    hs_module_view = decoy.mock(cls=HeaterShakerModuleView)
+    hs_module_view = decoy.mock(cls=HeaterShakerModuleSubState)
     hs_hardware = decoy.mock(cls=HeaterShaker)
 
     decoy.when(
-        state_view.modules.get_heater_shaker_module_view(
-            module_id="input-heater-shaker-id"
-        )
+        state_view.modules.get_heater_shaker_module_substate(
+            module_id="input-heater-shaker-id")
     ).then_return(hs_module_view)
 
     decoy.when(hs_module_view.module_id).then_return(

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_set_target_shake_speed.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_set_target_shake_speed.py
@@ -1,11 +1,14 @@
 """Test Heater Shaker set shake speed command implementation."""
 from decoy import Decoy
 
-from opentrons.hardware_control import HardwareControlAPI
-from opentrons.hardware_control.modules import AbstractModule, HeaterShaker
+from opentrons.hardware_control.modules import HeaterShaker
 
 from opentrons.protocol_engine.state import StateView
-from opentrons.protocol_engine.state.modules import HeaterShakerModuleView
+from opentrons.protocol_engine.state.modules import (
+    HeaterShakerModuleView,
+    HeaterShakerModuleId,
+)
+from opentrons.protocol_engine.execution import EquipmentHandler
 from opentrons.protocol_engine.commands import heater_shaker
 from opentrons.protocol_engine.commands.heater_shaker.set_target_shake_speed import (
     SetTargetShakeSpeedImpl,
@@ -15,33 +18,37 @@ from opentrons.protocol_engine.commands.heater_shaker.set_target_shake_speed imp
 async def test_set_target_shake_speed(
     decoy: Decoy,
     state_view: StateView,
-    hardware_api: HardwareControlAPI,
+    equipment: EquipmentHandler,
 ) -> None:
     """It should be able to set the module's shake speed."""
-    subject = SetTargetShakeSpeedImpl(state_view=state_view, hardware_api=hardware_api)
+    subject = SetTargetShakeSpeedImpl(state_view=state_view, equipment=equipment)
     data = heater_shaker.SetTargetShakeSpeedParams(
-        moduleId="shake-shaker-id", rpm=1234.56
+        moduleId="input-heater-shaker-id",
+        rpm=1234.56,
     )
 
     # Get module view
     hs_module_view = decoy.mock(cls=HeaterShakerModuleView)
+    hs_hardware = decoy.mock(cls=HeaterShaker)
+
     decoy.when(
-        state_view.modules.get_heater_shaker_module_view(module_id="shake-shaker-id")
+        state_view.modules.get_heater_shaker_module_view(
+            module_id="input-heater-shaker-id"
+        )
     ).then_return(hs_module_view)
+
+    decoy.when(hs_module_view.module_id).then_return(
+        HeaterShakerModuleId("heater-shaker-id")
+    )
 
     # Stub speed validation from hs module view
     decoy.when(hs_module_view.validate_target_speed(rpm=1234.56)).then_return(1234)
 
     # Get attached hardware modules
-    attached = [decoy.mock(cls=AbstractModule), decoy.mock(cls=AbstractModule)]
-    match = decoy.mock(cls=HeaterShaker)
-    decoy.when(hardware_api.attached_modules).then_return(attached)
-
-    # Get stubbed hardware module from hs module view
-    decoy.when(hs_module_view.find_hardware(attached_modules=attached)).then_return(
-        match
-    )
+    decoy.when(
+        equipment.get_module_hardware_api(HeaterShakerModuleId("heater-shaker-id"))
+    ).then_return(hs_hardware)
 
     result = await subject.execute(data)
-    decoy.verify(await match.set_speed(rpm=1234), times=1)
+    decoy.verify(await hs_hardware.set_speed(rpm=1234), times=1)
     assert result == heater_shaker.SetTargetShakeSpeedResult()

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_set_target_shake_speed.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_set_target_shake_speed.py
@@ -27,22 +27,21 @@ async def test_set_target_shake_speed(
         rpm=1234.56,
     )
 
-    # Get module view
-    hs_module_view = decoy.mock(cls=HeaterShakerModuleSubState)
+    hs_module_substate = decoy.mock(cls=HeaterShakerModuleSubState)
     hs_hardware = decoy.mock(cls=HeaterShaker)
 
     decoy.when(
         state_view.modules.get_heater_shaker_module_substate(
             module_id="input-heater-shaker-id"
         )
-    ).then_return(hs_module_view)
+    ).then_return(hs_module_substate)
 
-    decoy.when(hs_module_view.module_id).then_return(
+    decoy.when(hs_module_substate.module_id).then_return(
         HeaterShakerModuleId("heater-shaker-id")
     )
 
     # Stub speed validation from hs module view
-    decoy.when(hs_module_view.validate_target_speed(rpm=1234.56)).then_return(1234)
+    decoy.when(hs_module_substate.validate_target_speed(rpm=1234.56)).then_return(1234)
 
     # Get attached hardware modules
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_start_set_target_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_start_set_target_temperature.py
@@ -4,7 +4,7 @@ from decoy import Decoy
 from opentrons.hardware_control.modules import HeaterShaker
 
 from opentrons.protocol_engine.state import StateView
-from opentrons.protocol_engine.state.modules import (
+from opentrons.protocol_engine.state.module_substates import (
     HeaterShakerModuleSubState,
     HeaterShakerModuleId,
 )
@@ -34,7 +34,8 @@ async def test_start_set_target_temperature(
 
     decoy.when(
         state_view.modules.get_heater_shaker_module_substate(
-            module_id="input-heater-shaker-id")
+            module_id="input-heater-shaker-id"
+        )
     ).then_return(hs_module_view)
 
     decoy.when(hs_module_view.module_id).then_return(

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_start_set_target_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_start_set_target_temperature.py
@@ -28,24 +28,23 @@ async def test_start_set_target_temperature(
         temperature=12.3,
     )
 
-    # Get module view
-    hs_module_view = decoy.mock(cls=HeaterShakerModuleSubState)
+    hs_module_substate = decoy.mock(cls=HeaterShakerModuleSubState)
     hs_hardware = decoy.mock(cls=HeaterShaker)
 
     decoy.when(
         state_view.modules.get_heater_shaker_module_substate(
             module_id="input-heater-shaker-id"
         )
-    ).then_return(hs_module_view)
+    ).then_return(hs_module_substate)
 
-    decoy.when(hs_module_view.module_id).then_return(
+    decoy.when(hs_module_substate.module_id).then_return(
         HeaterShakerModuleId("heater-shaker-id")
     )
 
     # Stub temperature validation from hs module view
-    decoy.when(hs_module_view.validate_target_temperature(celsius=12.3)).then_return(
-        45.6
-    )
+    decoy.when(
+        hs_module_substate.validate_target_temperature(celsius=12.3)
+    ).then_return(45.6)
 
     # Get attached hardware modules
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_start_set_target_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_start_set_target_temperature.py
@@ -5,7 +5,7 @@ from opentrons.hardware_control.modules import HeaterShaker
 
 from opentrons.protocol_engine.state import StateView
 from opentrons.protocol_engine.state.modules import (
-    HeaterShakerModuleView,
+    HeaterShakerModuleSubState,
     HeaterShakerModuleId,
 )
 from opentrons.protocol_engine.execution import EquipmentHandler
@@ -29,13 +29,12 @@ async def test_start_set_target_temperature(
     )
 
     # Get module view
-    hs_module_view = decoy.mock(cls=HeaterShakerModuleView)
+    hs_module_view = decoy.mock(cls=HeaterShakerModuleSubState)
     hs_hardware = decoy.mock(cls=HeaterShaker)
 
     decoy.when(
-        state_view.modules.get_heater_shaker_module_view(
-            module_id="input-heater-shaker-id"
-        )
+        state_view.modules.get_heater_shaker_module_substate(
+            module_id="input-heater-shaker-id")
     ).then_return(hs_module_view)
 
     decoy.when(hs_module_view.module_id).then_return(

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_start_set_target_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_start_set_target_temperature.py
@@ -1,11 +1,14 @@
 """Test Heater Shaker start set temperature command implementation."""
 from decoy import Decoy
 
-from opentrons.hardware_control import HardwareControlAPI
-from opentrons.hardware_control.modules import AbstractModule, HeaterShaker
+from opentrons.hardware_control.modules import HeaterShaker
 
 from opentrons.protocol_engine.state import StateView
-from opentrons.protocol_engine.state.modules import HeaterShakerModuleView
+from opentrons.protocol_engine.state.modules import (
+    HeaterShakerModuleView,
+    HeaterShakerModuleId,
+)
+from opentrons.protocol_engine.execution import EquipmentHandler
 from opentrons.protocol_engine.commands import heater_shaker
 from opentrons.protocol_engine.commands.heater_shaker.start_set_target_temperature import (  # noqa: E501
     StartSetTargetTemperatureImpl,
@@ -15,40 +18,40 @@ from opentrons.protocol_engine.commands.heater_shaker.start_set_target_temperatu
 async def test_start_set_target_temperature(
     decoy: Decoy,
     state_view: StateView,
-    hardware_api: HardwareControlAPI,
+    equipment: EquipmentHandler,
 ) -> None:
     """It should be able to set the specified module's target temperature."""
-    subject = StartSetTargetTemperatureImpl(
-        state_view=state_view, hardware_api=hardware_api
-    )
+    subject = StartSetTargetTemperatureImpl(state_view=state_view, equipment=equipment)
 
     data = heater_shaker.StartSetTargetTemperatureParams(
-        moduleId="heater-shaker-id",
-        temperature=42.3,
+        moduleId="input-heater-shaker-id",
+        temperature=12.3,
     )
 
     # Get module view
     hs_module_view = decoy.mock(cls=HeaterShakerModuleView)
+    hs_hardware = decoy.mock(cls=HeaterShaker)
 
     decoy.when(
-        state_view.modules.get_heater_shaker_module_view(module_id="heater-shaker-id")
+        state_view.modules.get_heater_shaker_module_view(
+            module_id="input-heater-shaker-id"
+        )
     ).then_return(hs_module_view)
 
+    decoy.when(hs_module_view.module_id).then_return(
+        HeaterShakerModuleId("heater-shaker-id")
+    )
+
     # Stub temperature validation from hs module view
-    decoy.when(hs_module_view.validate_target_temperature(celsius=42.3)).then_return(
-        42.3
+    decoy.when(hs_module_view.validate_target_temperature(celsius=12.3)).then_return(
+        45.6
     )
 
     # Get attached hardware modules
-    attached = [decoy.mock(cls=AbstractModule), decoy.mock(cls=AbstractModule)]
-    match = decoy.mock(cls=HeaterShaker)
-    decoy.when(hardware_api.attached_modules).then_return(attached)
-
-    # Get stubbed hardware module from hs module view
-    decoy.when(hs_module_view.find_hardware(attached_modules=attached)).then_return(
-        match
-    )
+    decoy.when(
+        equipment.get_module_hardware_api(HeaterShakerModuleId("heater-shaker-id"))
+    ).then_return(hs_hardware)
 
     result = await subject.execute(data)
-    decoy.verify(await match.start_set_temperature(celsius=42.3), times=1)
+    decoy.verify(await hs_hardware.start_set_temperature(celsius=45.6), times=1)
     assert result == heater_shaker.StartSetTargetTemperatureResult()

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_stop_shake.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_stop_shake.py
@@ -24,17 +24,16 @@ async def test_stop_shake(
     subject = StopShakeImpl(state_view=state_view, equipment=equipment)
     data = heater_shaker.StopShakeParams(moduleId="input-heater-shaker-id")
 
-    # Get module view
-    hs_module_view = decoy.mock(cls=HeaterShakerModuleSubState)
+    hs_module_substate = decoy.mock(cls=HeaterShakerModuleSubState)
     hs_hardware = decoy.mock(cls=HeaterShaker)
 
     decoy.when(
         state_view.modules.get_heater_shaker_module_substate(
             module_id="input-heater-shaker-id"
         )
-    ).then_return(hs_module_view)
+    ).then_return(hs_module_substate)
 
-    decoy.when(hs_module_view.module_id).then_return(
+    decoy.when(hs_module_substate.module_id).then_return(
         HeaterShakerModuleId("heater-shaker-id")
     )
 
@@ -57,16 +56,15 @@ async def test_stop_shake_virtual(
     subject = StopShakeImpl(state_view=state_view, equipment=equipment)
     data = heater_shaker.StopShakeParams(moduleId="input-heater-shaker-id")
 
-    # Get module view
-    hs_module_view = decoy.mock(cls=HeaterShakerModuleSubState)
+    hs_module_substate = decoy.mock(cls=HeaterShakerModuleSubState)
 
     decoy.when(
         state_view.modules.get_heater_shaker_module_substate(
             module_id="input-heater-shaker-id"
         )
-    ).then_return(hs_module_view)
+    ).then_return(hs_module_substate)
 
-    decoy.when(hs_module_view.module_id).then_return(
+    decoy.when(hs_module_substate.module_id).then_return(
         HeaterShakerModuleId("heater-shaker-id")
     )
 

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_stop_shake.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_stop_shake.py
@@ -5,7 +5,7 @@ from opentrons.hardware_control.modules import HeaterShaker
 
 from opentrons.protocol_engine.state import StateView
 from opentrons.protocol_engine.state.modules import (
-    HeaterShakerModuleView,
+    HeaterShakerModuleSubState,
     HeaterShakerModuleId,
 )
 from opentrons.protocol_engine.execution import EquipmentHandler
@@ -25,13 +25,12 @@ async def test_stop_shake(
     data = heater_shaker.StopShakeParams(moduleId="input-heater-shaker-id")
 
     # Get module view
-    hs_module_view = decoy.mock(cls=HeaterShakerModuleView)
+    hs_module_view = decoy.mock(cls=HeaterShakerModuleSubState)
     hs_hardware = decoy.mock(cls=HeaterShaker)
 
     decoy.when(
-        state_view.modules.get_heater_shaker_module_view(
-            module_id="input-heater-shaker-id"
-        )
+        state_view.modules.get_heater_shaker_module_substate(
+            module_id="input-heater-shaker-id")
     ).then_return(hs_module_view)
 
     decoy.when(hs_module_view.module_id).then_return(
@@ -58,12 +57,11 @@ async def test_stop_shake_virtual(
     data = heater_shaker.StopShakeParams(moduleId="input-heater-shaker-id")
 
     # Get module view
-    hs_module_view = decoy.mock(cls=HeaterShakerModuleView)
+    hs_module_view = decoy.mock(cls=HeaterShakerModuleSubState)
 
     decoy.when(
-        state_view.modules.get_heater_shaker_module_view(
-            module_id="input-heater-shaker-id"
-        )
+        state_view.modules.get_heater_shaker_module_substate(
+            module_id="input-heater-shaker-id")
     ).then_return(hs_module_view)
 
     decoy.when(hs_module_view.module_id).then_return(

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_stop_shake.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_stop_shake.py
@@ -1,11 +1,14 @@
 """Test Heater Shaker stop shake command implementation."""
 from decoy import Decoy
 
-from opentrons.hardware_control import HardwareControlAPI
-from opentrons.hardware_control.modules import AbstractModule, HeaterShaker
+from opentrons.hardware_control.modules import HeaterShaker
 
 from opentrons.protocol_engine.state import StateView
-from opentrons.protocol_engine.state.modules import HeaterShakerModuleView
+from opentrons.protocol_engine.state.modules import (
+    HeaterShakerModuleView,
+    HeaterShakerModuleId,
+)
+from opentrons.protocol_engine.execution import EquipmentHandler
 from opentrons.protocol_engine.commands import heater_shaker
 from opentrons.protocol_engine.commands.heater_shaker.stop_shake import (
     StopShakeImpl,
@@ -13,28 +16,64 @@ from opentrons.protocol_engine.commands.heater_shaker.stop_shake import (
 
 
 async def test_stop_shake(
-    decoy: Decoy, state_view: StateView, hardware_api: HardwareControlAPI
+    decoy: Decoy,
+    state_view: StateView,
+    equipment: EquipmentHandler,
 ) -> None:
     """It should be able to stop the module's shake."""
-    subject = StopShakeImpl(state_view=state_view, hardware_api=hardware_api)
-    data = heater_shaker.StopShakeParams(moduleId="heater-shaker-id")
+    subject = StopShakeImpl(state_view=state_view, equipment=equipment)
+    data = heater_shaker.StopShakeParams(moduleId="input-heater-shaker-id")
 
     # Get module view
     hs_module_view = decoy.mock(cls=HeaterShakerModuleView)
+    hs_hardware = decoy.mock(cls=HeaterShaker)
+
     decoy.when(
-        state_view.modules.get_heater_shaker_module_view(module_id="heater-shaker-id")
+        state_view.modules.get_heater_shaker_module_view(
+            module_id="input-heater-shaker-id"
+        )
     ).then_return(hs_module_view)
 
-    # Get attached hardware modules
-    attached = [decoy.mock(cls=AbstractModule), decoy.mock(cls=AbstractModule)]
-    match = decoy.mock(cls=HeaterShaker)
-    decoy.when(hardware_api.attached_modules).then_return(attached)
-
-    # Get stubbed hardware module from hs module view
-    decoy.when(hs_module_view.find_hardware(attached_modules=attached)).then_return(
-        match
+    decoy.when(hs_module_view.module_id).then_return(
+        HeaterShakerModuleId("heater-shaker-id")
     )
 
+    # Get stubbed hardware module from hs module view
+    decoy.when(
+        equipment.get_module_hardware_api(HeaterShakerModuleId("heater-shaker-id"))
+    ).then_return(hs_hardware)
+
     result = await subject.execute(data)
-    decoy.verify(await match.set_speed(rpm=0), times=1)
+    decoy.verify(await hs_hardware.set_speed(rpm=0), times=1)
+    assert result == heater_shaker.StopShakeResult()
+
+
+async def test_stop_shake_virtual(
+    decoy: Decoy,
+    state_view: StateView,
+    equipment: EquipmentHandler,
+) -> None:
+    """It should be able to stop the module's shake."""
+    subject = StopShakeImpl(state_view=state_view, equipment=equipment)
+    data = heater_shaker.StopShakeParams(moduleId="input-heater-shaker-id")
+
+    # Get module view
+    hs_module_view = decoy.mock(cls=HeaterShakerModuleView)
+
+    decoy.when(
+        state_view.modules.get_heater_shaker_module_view(
+            module_id="input-heater-shaker-id"
+        )
+    ).then_return(hs_module_view)
+
+    decoy.when(hs_module_view.module_id).then_return(
+        HeaterShakerModuleId("heater-shaker-id")
+    )
+
+    # Get stubbed hardware module from hs module view
+    decoy.when(
+        equipment.get_module_hardware_api(HeaterShakerModuleId("heater-shaker-id"))
+    ).then_return(None)
+
+    result = await subject.execute(data)
     assert result == heater_shaker.StopShakeResult()

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_stop_shake.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_stop_shake.py
@@ -4,7 +4,7 @@ from decoy import Decoy
 from opentrons.hardware_control.modules import HeaterShaker
 
 from opentrons.protocol_engine.state import StateView
-from opentrons.protocol_engine.state.modules import (
+from opentrons.protocol_engine.state.module_substates import (
     HeaterShakerModuleSubState,
     HeaterShakerModuleId,
 )
@@ -30,7 +30,8 @@ async def test_stop_shake(
 
     decoy.when(
         state_view.modules.get_heater_shaker_module_substate(
-            module_id="input-heater-shaker-id")
+            module_id="input-heater-shaker-id"
+        )
     ).then_return(hs_module_view)
 
     decoy.when(hs_module_view.module_id).then_return(
@@ -61,7 +62,8 @@ async def test_stop_shake_virtual(
 
     decoy.when(
         state_view.modules.get_heater_shaker_module_substate(
-            module_id="input-heater-shaker-id")
+            module_id="input-heater-shaker-id"
+        )
     ).then_return(hs_module_view)
 
     decoy.when(hs_module_view.module_id).then_return(

--- a/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_disengage.py
+++ b/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_disengage.py
@@ -29,14 +29,14 @@ async def test_magnetic_module_disengage_implementation(
     params = DisengageParams(moduleId="unverified-module-id")
 
     verified_module_id = MagneticModuleId("module-id")
-    magnetic_module_view = decoy.mock(cls=MagneticModuleSubState)
+    magnetic_module_substate = decoy.mock(cls=MagneticModuleSubState)
     magnetic_module_hw = decoy.mock(cls=MagDeck)
 
     decoy.when(
         state_view.modules.get_magnetic_module_substate("unverified-module-id")
-    ).then_return(magnetic_module_view)
+    ).then_return(magnetic_module_substate)
 
-    decoy.when(magnetic_module_view.module_id).then_return(verified_module_id)
+    decoy.when(magnetic_module_substate.module_id).then_return(verified_module_id)
 
     decoy.when(equipment.get_module_hardware_api(verified_module_id)).then_return(
         magnetic_module_hw

--- a/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_disengage.py
+++ b/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_disengage.py
@@ -4,8 +4,8 @@ from decoy import Decoy
 from opentrons.hardware_control.modules import MagDeck
 
 from opentrons.protocol_engine.execution import EquipmentHandler
-from opentrons.protocol_engine.state import (
-    StateView,
+from opentrons.protocol_engine.state import StateView
+from opentrons.protocol_engine.state.module_substates import (
     MagneticModuleSubState,
     MagneticModuleId,
 )

--- a/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_disengage.py
+++ b/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_disengage.py
@@ -6,7 +6,7 @@ from opentrons.hardware_control.modules import MagDeck
 from opentrons.protocol_engine.execution import EquipmentHandler
 from opentrons.protocol_engine.state import (
     StateView,
-    MagneticModuleView,
+    MagneticModuleSubState,
     MagneticModuleId,
 )
 from opentrons.protocol_engine.commands.magnetic_module import (
@@ -29,11 +29,11 @@ async def test_magnetic_module_disengage_implementation(
     params = DisengageParams(moduleId="unverified-module-id")
 
     verified_module_id = MagneticModuleId("module-id")
-    magnetic_module_view = decoy.mock(cls=MagneticModuleView)
+    magnetic_module_view = decoy.mock(cls=MagneticModuleSubState)
     magnetic_module_hw = decoy.mock(cls=MagDeck)
 
     decoy.when(
-        state_view.modules.get_magnetic_module_view("unverified-module-id")
+        state_view.modules.get_magnetic_module_substate("unverified-module-id")
     ).then_return(magnetic_module_view)
 
     decoy.when(magnetic_module_view.module_id).then_return(verified_module_id)

--- a/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_engage.py
+++ b/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_engage.py
@@ -5,7 +5,7 @@ from decoy import Decoy
 from opentrons.hardware_control.modules import MagDeck
 from opentrons.protocol_engine.state import (
     MagneticModuleId,
-    MagneticModuleView,
+    MagneticModuleSubState,
     StateView,
 )
 from opentrons.protocol_engine.execution import EquipmentHandler
@@ -30,11 +30,11 @@ async def test_magnetic_module_engage_implementation(
     )
 
     verified_module_id = MagneticModuleId("module-id")
-    magnetic_module_view = decoy.mock(cls=MagneticModuleView)
+    magnetic_module_view = decoy.mock(cls=MagneticModuleSubState)
     magnetic_module_hw = decoy.mock(cls=MagDeck)
 
     decoy.when(
-        state_view.modules.get_magnetic_module_view("unverified-module-id")
+        state_view.modules.get_magnetic_module_substate("unverified-module-id")
     ).then_return(magnetic_module_view)
 
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_engage.py
+++ b/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_engage.py
@@ -30,18 +30,18 @@ async def test_magnetic_module_engage_implementation(
     )
 
     verified_module_id = MagneticModuleId("module-id")
-    magnetic_module_view = decoy.mock(cls=MagneticModuleSubState)
+    magnetic_module_substate = decoy.mock(cls=MagneticModuleSubState)
     magnetic_module_hw = decoy.mock(cls=MagDeck)
 
     decoy.when(
         state_view.modules.get_magnetic_module_substate("unverified-module-id")
-    ).then_return(magnetic_module_view)
+    ).then_return(magnetic_module_substate)
 
     decoy.when(
-        magnetic_module_view.calculate_magnet_hardware_height(mm_from_base=3.14159)
+        magnetic_module_substate.calculate_magnet_hardware_height(mm_from_base=3.14159)
     ).then_return(9001)
 
-    decoy.when(magnetic_module_view.module_id).then_return(verified_module_id)
+    decoy.when(magnetic_module_substate.module_id).then_return(verified_module_id)
 
     decoy.when(equipment.get_module_hardware_api(verified_module_id)).then_return(
         magnetic_module_hw

--- a/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_engage.py
+++ b/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_engage.py
@@ -3,10 +3,10 @@
 from decoy import Decoy
 
 from opentrons.hardware_control.modules import MagDeck
-from opentrons.protocol_engine.state import (
+from opentrons.protocol_engine.state import StateView
+from opentrons.protocol_engine.state.module_substates import (
     MagneticModuleId,
     MagneticModuleSubState,
-    StateView,
 )
 from opentrons.protocol_engine.execution import EquipmentHandler
 from opentrons.protocol_engine.commands.magnetic_module import (

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -730,6 +730,8 @@ def test_validate_target_temperature(
     if not expected_valid:
         with pytest.raises(errors.InvalidTargetTemperatureError):
             subject.validate_target_temperature(target_temp)
+    else:
+        assert subject.validate_target_temperature(target_temp) == target_temp
 
 
 @pytest.mark.parametrize(

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -24,7 +24,7 @@ from opentrons.protocol_engine.state.modules import (
 from opentrons.protocol_engine.state.module_substates import (
     HeaterShakerModuleSubState,
     MagneticModuleSubState,
-    ModuleViewTypes
+    ModuleViewTypes,
 )
 
 
@@ -52,24 +52,27 @@ def get_sample_parent_module_view(
     definition = load_shared_data("module/definitions/2/magneticModuleV1.json")
     magdeck_def = ModuleDefinition.parse_raw(definition)
 
-    return make_module_view(slot_by_module_id={
-        "id-non-matching": DeckSlotName.SLOT_1,
-        matching_module_id: DeckSlotName.SLOT_2,
-        "id-another-non-matching": DeckSlotName.SLOT_3,
-    }, hardware_by_module_id={
-        "id-non-matching": HardwareModule(
-            serial_number="serial-non-matching",
-            definition=magdeck_def,
-        ),
-        matching_module_id: HardwareModule(
-            serial_number="serial-matching",
-            definition=matching_module_def,
-        ),
-        "id-another-non-matching": HardwareModule(
-            serial_number="serial-another-non-matching",
-            definition=magdeck_def,
-        ),
-    })
+    return make_module_view(
+        slot_by_module_id={
+            "id-non-matching": DeckSlotName.SLOT_1,
+            matching_module_id: DeckSlotName.SLOT_2,
+            "id-another-non-matching": DeckSlotName.SLOT_3,
+        },
+        hardware_by_module_id={
+            "id-non-matching": HardwareModule(
+                serial_number="serial-non-matching",
+                definition=magdeck_def,
+            ),
+            matching_module_id: HardwareModule(
+                serial_number="serial-matching",
+                definition=matching_module_def,
+            ),
+            "id-another-non-matching": HardwareModule(
+                serial_number="serial-another-non-matching",
+                definition=magdeck_def,
+            ),
+        },
+    )
 
 
 def test_initial_module_data_by_id() -> None:
@@ -90,13 +93,15 @@ def test_get_missing_hardware() -> None:
 
 def test_get_module_data(tempdeck_v1_def: ModuleDefinition) -> None:
     """It should get module data from state by ID."""
-    subject = make_module_view(slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
-                               hardware_by_module_id={
-                                   "module-id": HardwareModule(
-                                       serial_number="serial-number",
-                                       definition=tempdeck_v1_def,
-                                   )
-                               })
+    subject = make_module_view(
+        slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
+        hardware_by_module_id={
+            "module-id": HardwareModule(
+                serial_number="serial-number",
+                definition=tempdeck_v1_def,
+            )
+        },
+    )
 
     assert subject.get("module-id") == LoadedModule(
         id="module-id",
@@ -109,19 +114,22 @@ def test_get_module_data(tempdeck_v1_def: ModuleDefinition) -> None:
 
 def test_get_location(tempdeck_v1_def: ModuleDefinition) -> None:
     """It should return the module's location or raise."""
-    subject = make_module_view(slot_by_module_id={
-        "module-1": DeckSlotName.SLOT_1,
-        "module-2": None,
-    }, hardware_by_module_id={
-        "module-1": HardwareModule(
-            serial_number="serial-1",
-            definition=tempdeck_v1_def,
-        ),
-        "module-2": HardwareModule(
-            serial_number="serial-2",
-            definition=tempdeck_v1_def,
-        ),
-    })
+    subject = make_module_view(
+        slot_by_module_id={
+            "module-1": DeckSlotName.SLOT_1,
+            "module-2": None,
+        },
+        hardware_by_module_id={
+            "module-1": HardwareModule(
+                serial_number="serial-1",
+                definition=tempdeck_v1_def,
+            ),
+            "module-2": HardwareModule(
+                serial_number="serial-2",
+                definition=tempdeck_v1_def,
+            ),
+        },
+    )
 
     assert subject.get_location("module-1") == DeckSlotLocation(
         slotName=DeckSlotName.SLOT_1
@@ -136,19 +144,22 @@ def test_get_all_modules(
     tempdeck_v2_def: ModuleDefinition,
 ) -> None:
     """It should return all modules in state."""
-    subject = make_module_view(slot_by_module_id={
-        "module-1": DeckSlotName.SLOT_1,
-        "module-2": DeckSlotName.SLOT_2,
-    }, hardware_by_module_id={
-        "module-1": HardwareModule(
-            serial_number="serial-1",
-            definition=tempdeck_v1_def,
-        ),
-        "module-2": HardwareModule(
-            serial_number="serial-2",
-            definition=tempdeck_v2_def,
-        ),
-    })
+    subject = make_module_view(
+        slot_by_module_id={
+            "module-1": DeckSlotName.SLOT_1,
+            "module-2": DeckSlotName.SLOT_2,
+        },
+        hardware_by_module_id={
+            "module-1": HardwareModule(
+                serial_number="serial-1",
+                definition=tempdeck_v1_def,
+            ),
+            "module-2": HardwareModule(
+                serial_number="serial-2",
+                definition=tempdeck_v2_def,
+            ),
+        },
+    )
 
     assert subject.get_all() == [
         LoadedModule(
@@ -174,41 +185,47 @@ def test_get_magnetic_module_view(
     tempdeck_v1_def: ModuleDefinition,
 ) -> None:
     """It should return a view for the given Magnetic Module, if valid."""
-    subject = make_module_view(slot_by_module_id={
-        "magnetic-module-gen1-id": DeckSlotName.SLOT_1,
-        "magnetic-module-gen2-id": DeckSlotName.SLOT_2,
-        "temperature-module-id": DeckSlotName.SLOT_3,
-    }, hardware_by_module_id={
-        "magnetic-module-gen1-id": HardwareModule(
-            serial_number="magnetic-module-gen1-serial",
-            definition=magdeck_v1_def,
-        ),
-        "magnetic-module-gen2-id": HardwareModule(
-            serial_number="magnetic-module-gen2-serial",
-            definition=magdeck_v2_def,
-        ),
-        "temperature-module-id": HardwareModule(
-            serial_number="temperature-module-serial",
-            definition=tempdeck_v1_def,
-        ),
-    }, substate_by_module_id={
-        "magnetic-module-gen1-id": MagneticModuleSubState(
-            module_id=MagneticModuleId("magnetic-module-gen1-id"),
-            model=ModuleModel.MAGNETIC_MODULE_V1,
-        ),
-        "magnetic-module-gen2-id": MagneticModuleSubState(
-            module_id=MagneticModuleId("magnetic-module-gen2-id"),
-            model=ModuleModel.MAGNETIC_MODULE_V2,
-        ),
-    })
+    subject = make_module_view(
+        slot_by_module_id={
+            "magnetic-module-gen1-id": DeckSlotName.SLOT_1,
+            "magnetic-module-gen2-id": DeckSlotName.SLOT_2,
+            "temperature-module-id": DeckSlotName.SLOT_3,
+        },
+        hardware_by_module_id={
+            "magnetic-module-gen1-id": HardwareModule(
+                serial_number="magnetic-module-gen1-serial",
+                definition=magdeck_v1_def,
+            ),
+            "magnetic-module-gen2-id": HardwareModule(
+                serial_number="magnetic-module-gen2-serial",
+                definition=magdeck_v2_def,
+            ),
+            "temperature-module-id": HardwareModule(
+                serial_number="temperature-module-serial",
+                definition=tempdeck_v1_def,
+            ),
+        },
+        substate_by_module_id={
+            "magnetic-module-gen1-id": MagneticModuleSubState(
+                module_id=MagneticModuleId("magnetic-module-gen1-id"),
+                model=ModuleModel.MAGNETIC_MODULE_V1,
+            ),
+            "magnetic-module-gen2-id": MagneticModuleSubState(
+                module_id=MagneticModuleId("magnetic-module-gen2-id"),
+                model=ModuleModel.MAGNETIC_MODULE_V2,
+            ),
+        },
+    )
 
     module_1_view = subject.get_magnetic_module_substate(
-        module_id="magnetic-module-gen1-id")
+        module_id="magnetic-module-gen1-id"
+    )
     assert module_1_view.module_id == "magnetic-module-gen1-id"
     assert module_1_view.model == ModuleModel.MAGNETIC_MODULE_V1
 
     module_2_view = subject.get_magnetic_module_substate(
-        module_id="magnetic-module-gen2-id")
+        module_id="magnetic-module-gen2-id"
+    )
     assert module_2_view.module_id == "magnetic-module-gen2-id"
     assert module_2_view.model == ModuleModel.MAGNETIC_MODULE_V2
 
@@ -224,19 +241,22 @@ def test_get_properties_by_id(
     tempdeck_v2_def: ModuleDefinition,
 ) -> None:
     """It should return a loaded module's properties by ID."""
-    subject = make_module_view(slot_by_module_id={
-        "module-1": DeckSlotName.SLOT_1,
-        "module-2": DeckSlotName.SLOT_2,
-    }, hardware_by_module_id={
-        "module-1": HardwareModule(
-            serial_number="serial-1",
-            definition=tempdeck_v1_def,
-        ),
-        "module-2": HardwareModule(
-            serial_number="serial-2",
-            definition=tempdeck_v2_def,
-        ),
-    })
+    subject = make_module_view(
+        slot_by_module_id={
+            "module-1": DeckSlotName.SLOT_1,
+            "module-2": DeckSlotName.SLOT_2,
+        },
+        hardware_by_module_id={
+            "module-1": HardwareModule(
+                serial_number="serial-1",
+                definition=tempdeck_v1_def,
+            ),
+            "module-2": HardwareModule(
+                serial_number="serial-2",
+                definition=tempdeck_v2_def,
+            ),
+        },
+    )
 
     assert subject.get_definition("module-1") == tempdeck_v1_def
     assert subject.get_dimensions("module-1") == tempdeck_v1_def.dimensions
@@ -257,18 +277,21 @@ def test_get_properties_by_id(
 
 def test_get_plate_target_temperature(heater_shaker_v1_def: ModuleDefinition) -> None:
     """It should return whether target temperature is set."""
-    module_view = make_module_view(slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
-                                   hardware_by_module_id={
-                                       "module-id": HardwareModule(
-                                           serial_number="serial-number",
-                                           definition=heater_shaker_v1_def,
-                                       )
-                                   }, substate_by_module_id={
+    module_view = make_module_view(
+        slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
+        hardware_by_module_id={
+            "module-id": HardwareModule(
+                serial_number="serial-number",
+                definition=heater_shaker_v1_def,
+            )
+        },
+        substate_by_module_id={
             "module-id": HeaterShakerModuleSubState(
                 module_id=HeaterShakerModuleId("module-id"),
-                plate_target_temperature=12.3
+                plate_target_temperature=12.3,
             )
-        })
+        },
+    )
     subject = module_view.get_heater_shaker_module_substate("module-id")
     assert subject.get_plate_target_temperature() == 12.3
 
@@ -277,18 +300,21 @@ def test_get_plate_target_temperature_no_target(
     heater_shaker_v1_def: ModuleDefinition,
 ) -> None:
     """It should raise if no target temperature is set."""
-    module_view = make_module_view(slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
-                                   hardware_by_module_id={
-                                       "module-id": HardwareModule(
-                                           serial_number="serial-number",
-                                           definition=heater_shaker_v1_def,
-                                       )
-                                   }, substate_by_module_id={
+    module_view = make_module_view(
+        slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
+        hardware_by_module_id={
+            "module-id": HardwareModule(
+                serial_number="serial-number",
+                definition=heater_shaker_v1_def,
+            )
+        },
+        substate_by_module_id={
             "module-id": HeaterShakerModuleSubState(
                 module_id=HeaterShakerModuleId("module-id"),
-                plate_target_temperature=None
+                plate_target_temperature=None,
             )
-        })
+        },
+    )
     subject = module_view.get_heater_shaker_module_substate("module-id")
 
     with pytest.raises(errors.NoTargetTemperatureSetError):
@@ -384,13 +410,15 @@ def test_thermocycler_dodging(
     It should return True if thermocycler exists and movement is between bad pairs of
     slot locations.
     """
-    subject = make_module_view(slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
-                               hardware_by_module_id={
-                                   "module-id": HardwareModule(
-                                       serial_number="serial-number",
-                                       definition=thermocycler_v1_def,
-                                   )
-                               })
+    subject = make_module_view(
+        slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
+        hardware_by_module_id={
+            "module-id": HardwareModule(
+                serial_number="serial-number",
+                definition=thermocycler_v1_def,
+            )
+        },
+    )
 
     assert (
         subject.should_dodge_thermocycler(from_slot=from_slot, to_slot=to_slot)
@@ -468,12 +496,14 @@ def test_select_hardware_module_to_load_skips_already_loaded(
     magdeck_v1_def: ModuleDefinition,
 ) -> None:
     """It should skip over already assigned modules."""
-    subject = make_module_view(hardware_by_module_id={
-        "module-1": HardwareModule(
-            serial_number="serial-1",
-            definition=magdeck_v1_def,
-        )
-    })
+    subject = make_module_view(
+        hardware_by_module_id={
+            "module-1": HardwareModule(
+                serial_number="serial-1",
+                definition=magdeck_v1_def,
+            )
+        }
+    )
 
     attached_modules = [
         HardwareModule(serial_number="serial-1", definition=magdeck_v1_def),
@@ -493,14 +523,17 @@ def test_select_hardware_module_to_load_reuses_already_loaded(
     magdeck_v1_def: ModuleDefinition,
 ) -> None:
     """It should reuse over already assigned modules in the same location."""
-    subject = make_module_view(slot_by_module_id={
-        "module-1": DeckSlotName.SLOT_1,
-    }, hardware_by_module_id={
-        "module-1": HardwareModule(
-            serial_number="serial-1",
-            definition=magdeck_v1_def,
-        )
-    })
+    subject = make_module_view(
+        slot_by_module_id={
+            "module-1": DeckSlotName.SLOT_1,
+        },
+        hardware_by_module_id={
+            "module-1": HardwareModule(
+                serial_number="serial-1",
+                definition=magdeck_v1_def,
+            )
+        },
+    )
 
     attached_modules = [
         HardwareModule(serial_number="serial-1", definition=magdeck_v1_def),
@@ -521,14 +554,17 @@ def test_select_hardware_module_to_load_rejects_location_reassignment(
     tempdeck_v1_def: ModuleDefinition,
 ) -> None:
     """It should raise if a non-matching module is already present in the slot."""
-    subject = make_module_view(slot_by_module_id={
-        "module-1": DeckSlotName.SLOT_1,
-    }, hardware_by_module_id={
-        "module-1": HardwareModule(
-            serial_number="serial-1",
-            definition=magdeck_v1_def,
-        )
-    })
+    subject = make_module_view(
+        slot_by_module_id={
+            "module-1": DeckSlotName.SLOT_1,
+        },
+        hardware_by_module_id={
+            "module-1": HardwareModule(
+                serial_number="serial-1",
+                definition=magdeck_v1_def,
+            )
+        },
+    )
 
     attached_modules = [
         HardwareModule(serial_number="serial-1", definition=magdeck_v1_def),
@@ -633,18 +669,21 @@ def test_magnetic_module_view_calculate_magnet_hardware_height(
     expected_exception_type: Union[Type[Exception], None],
 ) -> None:
     """It should return the expected height or raise the expected exception."""
-    module_view = make_module_view(slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
-                                   hardware_by_module_id={
-                                       "module-id": HardwareModule(
-                                           serial_number="serial-number",
-                                           definition=definition,
-                                       )
-                                   }, substate_by_module_id={
+    module_view = make_module_view(
+        slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
+        hardware_by_module_id={
+            "module-id": HardwareModule(
+                serial_number="serial-number",
+                definition=definition,
+            )
+        },
+        substate_by_module_id={
             "module-id": MagneticModuleSubState(
                 module_id=MagneticModuleId("module-id"),
-                model=definition.model,
+                model=definition.model,  # type: ignore [arg-type]
             )
-        })
+        },
+    )
     subject = module_view.get_magnetic_module_substate("module-id")
     expected_raise: ContextManager[None] = (
         # Not sure why mypy has trouble with this.
@@ -672,18 +711,21 @@ def test_validate_target_temperature(
     expected_valid: bool,
 ) -> None:
     """It should verify if a target temperature is valid for the specified module."""
-    module_view = make_module_view(slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
-                                   hardware_by_module_id={
-                                       "module-id": HardwareModule(
-                                           serial_number="serial-number",
-                                           definition=heater_shaker_v1_def,
-                                       )
-                                   }, substate_by_module_id={
+    module_view = make_module_view(
+        slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
+        hardware_by_module_id={
+            "module-id": HardwareModule(
+                serial_number="serial-number",
+                definition=heater_shaker_v1_def,
+            )
+        },
+        substate_by_module_id={
             "module-id": HeaterShakerModuleSubState(
-                module_id="module-id",
+                module_id=HeaterShakerModuleId("module-id"),
                 plate_target_temperature=None,
             )
-        })
+        },
+    )
     subject = module_view.get_heater_shaker_module_substate("module-id")
     if not expected_valid:
         with pytest.raises(errors.InvalidTargetTemperatureError):
@@ -698,18 +740,21 @@ def test_validate_heater_shaker_target_speed_converts_to_int(
     rpm_param: float, validated_param: bool, heater_shaker_v1_def: ModuleDefinition
 ) -> None:
     """It should validate heater-shaker target rpm."""
-    module_view = make_module_view(slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
-                                   hardware_by_module_id={
-                                       "module-id": HardwareModule(
-                                           serial_number="serial-number",
-                                           definition=heater_shaker_v1_def,
-                                       )
-                                   }, substate_by_module_id={
+    module_view = make_module_view(
+        slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
+        hardware_by_module_id={
+            "module-id": HardwareModule(
+                serial_number="serial-number",
+                definition=heater_shaker_v1_def,
+            )
+        },
+        substate_by_module_id={
             "module-id": HeaterShakerModuleSubState(
-                module_id="module-id",
+                module_id=HeaterShakerModuleId("module-id"),
                 plate_target_temperature=None,
             )
-        })
+        },
+    )
     subject = module_view.get_heater_shaker_module_substate("module-id")
     assert subject.validate_target_speed(rpm_param) == validated_param
 
@@ -722,18 +767,21 @@ def test_validate_heater_shaker_target_speed_raises_error(
     rpm_param: float, expected_valid: bool, heater_shaker_v1_def: ModuleDefinition
 ) -> None:
     """It should validate heater-shaker target rpm."""
-    module_view = make_module_view(slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
-                                   hardware_by_module_id={
-                                       "module-id": HardwareModule(
-                                           serial_number="serial-number",
-                                           definition=heater_shaker_v1_def,
-                                       )
-                                   }, substate_by_module_id={
+    module_view = make_module_view(
+        slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
+        hardware_by_module_id={
+            "module-id": HardwareModule(
+                serial_number="serial-number",
+                definition=heater_shaker_v1_def,
+            )
+        },
+        substate_by_module_id={
             "module-id": HeaterShakerModuleSubState(
-                module_id="module-id",
+                module_id=HeaterShakerModuleId("module-id"),
                 plate_target_temperature=None,
             )
-        })
+        },
+    )
     subject = module_view.get_heater_shaker_module_substate("module-id")
     if not expected_valid:
         with pytest.raises(errors.InvalidTargetSpeedError):

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -256,10 +256,7 @@ def test_get_properties_by_id(
     )
 
 
-@pytest.mark.parametrize("target", [123.45, None])
-def test_get_plate_target_temperature(
-    target: Optional[float], thermocycler_v1_def: ModuleDefinition
-) -> None:
+def test_get_plate_target_temperature(thermocycler_v1_def: ModuleDefinition) -> None:
     """It should return whether target temperature is set."""
     subject = make_module_view(
         slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
@@ -267,11 +264,40 @@ def test_get_plate_target_temperature(
             "module-id": HardwareModule(
                 serial_number="serial-number",
                 definition=thermocycler_v1_def,
-                plate_target_temperature=target,
+                plate_target_temperature=12.3,
             )
         },
     )
-    assert subject.get_plate_target_temperature("module-id") == target
+    assert subject.get_plate_target_temperature("module-id") == 12.3
+
+
+def test_get_plate_target_temperature_no_target(
+    thermocycler_v1_def: ModuleDefinition,
+) -> None:
+    """It should raise if no target temperature is set."""
+    subject = make_module_view(
+        slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
+        hardware_by_module_id={
+            "module-id": HardwareModule(
+                serial_number="serial-number",
+                definition=thermocycler_v1_def,
+                plate_target_temperature=None,
+            )
+        },
+    )
+
+    with pytest.raises(errors.NoTargetTemperatureSetError):
+        subject.get_plate_target_temperature("module-id")
+
+
+def test_get_plate_target_temperature_no_module(
+    thermocycler_v1_def: ModuleDefinition,
+) -> None:
+    """It should raise if no target temperature is set."""
+    subject = make_module_view()
+
+    with pytest.raises(errors.ModuleNotLoadedError):
+        subject.get_plate_target_temperature("module-id")
 
 
 def test_get_magnet_home_to_base_offset() -> None:

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -24,14 +24,14 @@ from opentrons.protocol_engine.state.modules import (
 from opentrons.protocol_engine.state.module_substates import (
     HeaterShakerModuleSubState,
     MagneticModuleSubState,
-    ModuleViewTypes,
+    ModuleSubStateType,
 )
 
 
 def make_module_view(
     slot_by_module_id: Optional[Dict[str, Optional[DeckSlotName]]] = None,
     hardware_by_module_id: Optional[Dict[str, HardwareModule]] = None,
-    substate_by_module_id: Optional[Dict[str, ModuleViewTypes]] = None,
+    substate_by_module_id: Optional[Dict[str, ModuleSubStateType]] = None,
     virtualize_modules: bool = False,
 ) -> ModuleView:
     """Get a module view test subject with the specified state."""

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -214,6 +214,7 @@ def test_get_magnetic_module_view(
                 module_id=MagneticModuleId("magnetic-module-gen2-id"),
                 model=ModuleModel.MAGNETIC_MODULE_V2,
             ),
+            # TODO (spp, 2022-04-01): Add tempdeck substate
         },
     )
 
@@ -229,8 +230,9 @@ def test_get_magnetic_module_view(
     assert module_2_view.module_id == "magnetic-module-gen2-id"
     assert module_2_view.model == ModuleModel.MAGNETIC_MODULE_V2
 
-    with pytest.raises(errors.WrongModuleTypeError):
-        subject.get_magnetic_module_substate(module_id="temperature-module-id")
+    # TODO (spp, 2022-04-01: Uncomment once temp module substate is added to store)
+    # with pytest.raises(errors.WrongModuleTypeError):
+    #     subject.get_magnetic_module_substate(module_id="temperature-module-id")
 
     with pytest.raises(errors.ModuleNotLoadedError):
         subject.get_magnetic_module_substate(module_id="nonexistent-module-id")

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -216,8 +216,8 @@ def test_get_magnetic_module_substate(
             ),
             "heatshake-module-id": HeaterShakerModuleSubState(
                 module_id=HeaterShakerModuleId("heatshake-module-id"),
-                plate_target_temperature=None
-            )
+                plate_target_temperature=None,
+            ),
         },
     )
 
@@ -267,8 +267,8 @@ def test_get_heater_shaker_module_substate(
             ),
             "heatshake-module-id": HeaterShakerModuleSubState(
                 module_id=HeaterShakerModuleId("heatshake-module-id"),
-                plate_target_temperature=432
-            )
+                plate_target_temperature=432,
+            ),
         },
     )
 
@@ -745,9 +745,7 @@ def test_magnetic_module_view_calculate_magnet_hardware_height(
         assert result == expected_result
 
 
-@pytest.mark.parametrize(
-    "target_temp", [36.8, 95.1]
-)
+@pytest.mark.parametrize("target_temp", [36.8, 95.1])
 def test_validate_target_temperature_raises(
     heater_shaker_v1_def: ModuleDefinition,
     target_temp: float,


### PR DESCRIPTION
# Overview

Closes #9801 
Paired with @mcous 

Reorganizes individual module states into manageable substates for a module type. 

# Changelog

- Moved modules' hardware api retreival into `execution.EquipmentHandler`
- Changed `MagneticModuleView` & `HeaterShakerModuleView` into frozen dataclasses that are now part of the module store & updated while handling appropriate actions.
- Updated magnetic & heater-shaker module command execution.

# Review requests

- Does the re-organization make sense? Any objections to calling the 'substates' so?
- Any missing name changes (mainly look for any references to 'module_view' that should be 'substate')
- Error handling ok?

@mcous and I talked briefly about moving the tests in `test_module_view`, that are restricted to the substate, into separate files while keeping the flow of tests the same (i.e. tests substates in context of module_view and not as a separate entity). I didn't make those changes in this PR in fear of blowing up the diff even further but could do so if it helps make this PR more readable due to better organization.

# Risk assessment

Low. Pretty well tested + new feature that shouldn't break existing released work.
