### PR TITLE
feat(can): add messages for gripper control

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -92,6 +92,9 @@ class MessageId(int, Enum):
     read_motor_current_request = 0x34
     read_motor_current_response = 0x35
 
+    set_brushed_motor_vref_request = 0x40
+    set_brushed_motor_pwm_request = 0x41
+
     read_presence_sensing_voltage_request = 0x600
     read_presence_sensing_voltage_response = 0x601
 

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -94,6 +94,8 @@ class MessageId(int, Enum):
 
     set_brushed_motor_vref_request = 0x40
     set_brushed_motor_pwm_request = 0x41
+    gripper_grip_request = 0x42
+    gripper_home_request = 0x43
 
     read_presence_sensing_voltage_request = 0x600
     read_presence_sensing_voltage_response = 0x601

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -423,3 +423,21 @@ class SetBrushedMotorPwmRequest:  # noqa: D101
     message_id: Literal[
         MessageId.set_brushed_motor_pwm_request
     ] = MessageId.set_brushed_motor_pwm_request
+
+
+@dataclass
+class GripperGripRequest:  # noqa: D101
+    payload: payloads.EmptyPayload
+    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+    message_id: Literal[
+        MessageId.gripper_grip_request
+    ] = MessageId.gripper_grip_request
+
+
+@dataclass
+class GripperHomeRequest:  # noqa: D101
+    payload: payloads.EmptyPayload
+    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+    message_id: Literal[
+        MessageId.gripper_home_request
+    ] = MessageId.gripper_home_request

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -426,18 +426,10 @@ class SetBrushedMotorPwmRequest:  # noqa: D101
 
 
 @dataclass
-class GripperGripRequest:  # noqa: D101
-    payload: payloads.EmptyPayload
-    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
-    message_id: Literal[
-        MessageId.gripper_grip_request
-    ] = MessageId.gripper_grip_request
+class GripperGripRequest(EmptyPayloadMessage):  # noqa: D101
+    message_id: Literal[MessageId.gripper_grip_request] = MessageId.gripper_grip_request
 
 
 @dataclass
-class GripperHomeRequest:  # noqa: D101
-    payload: payloads.EmptyPayload
-    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
-    message_id: Literal[
-        MessageId.gripper_home_request
-    ] = MessageId.gripper_home_request
+class GripperHomeRequest(EmptyPayloadMessage):  # noqa: D101
+    message_id: Literal[MessageId.gripper_home_request] = MessageId.gripper_home_request

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -405,3 +405,21 @@ class PipetteInfoResponse:  # noqa: D101
     message_id: Literal[
         MessageId.pipette_info_response
     ] = MessageId.pipette_info_response
+
+
+@dataclass
+class SetBrushedMotorVrefRequest:  # noqa: D101
+    payload: payloads.BrushedMotorVrefPayload
+    payload_type: Type[BinarySerializable] = payloads.BrushedMotorVrefPayload
+    message_id: Literal[
+        MessageId.set_brushed_motor_vref_request
+    ] = MessageId.set_brushed_motor_vref_request
+
+
+@dataclass
+class SetBrushedMotorPwmRequest:  # noqa: D101
+    payload: payloads.BrushedMotorPwmPayload
+    payload_type: Type[BinarySerializable] = payloads.BrushedMotorPwmPayload
+    message_id: Literal[
+        MessageId.set_brushed_motor_pwm_request
+    ] = MessageId.set_brushed_motor_pwm_request

--- a/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
@@ -39,6 +39,8 @@ MessageDefinition = Union[
     defs.WriteMotorCurrentRequest,
     defs.SetBrushedMotorVrefRequest,
     defs.SetBrushedMotorPwmRequest,
+    defs.GripperGripRequest,
+    defs.GripperHomeRequest,
     defs.ReadPresenceSensingVoltageRequest,
     defs.ReadPresenceSensingVoltageResponse,
     defs.AttachedToolsRequest,

--- a/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
@@ -37,6 +37,8 @@ MessageDefinition = Union[
     defs.ReadMotorDriverRequest,
     defs.ReadMotorDriverResponse,
     defs.WriteMotorCurrentRequest,
+    defs.SetBrushedMotorVrefRequest,
+    defs.SetBrushedMotorPwmRequest,
     defs.ReadPresenceSensingVoltageRequest,
     defs.ReadPresenceSensingVoltageResponse,
     defs.AttachedToolsRequest,

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -2,6 +2,7 @@
 # TODO (amit, 2022-01-26): Figure out why using annotations import ruins
 #  dataclass fields interpretation.
 #  from __future__ import annotations
+from ctypes import util
 from dataclasses import dataclass
 
 from .fields import (
@@ -337,3 +338,18 @@ class PipetteInfoResponsePayload(utils.BinarySerializable):
     pipette_name: PipetteNameField
     pipette_model: utils.UInt16Field
     pipette_serial: PipetteSerialField
+
+
+@dataclass
+class BrushedMotorVrefPayload(utils.BinarySerializable):
+    """A request to set the reference voltage of a brushed motor."""
+
+    v_ref: utils.UInt32Field
+
+
+@dataclass
+class BrushedMotorPwmPayload(utils.BinarySerializable):
+    """A request to set the pwm of a brushed motor."""
+
+    freq: utils.UInt8Field
+    duty_cycle: utils.UInt8Field

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -2,7 +2,6 @@
 # TODO (amit, 2022-01-26): Figure out why using annotations import ruins
 #  dataclass fields interpretation.
 #  from __future__ import annotations
-from ctypes import util
 from dataclasses import dataclass
 
 from .fields import (

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -350,5 +350,5 @@ class BrushedMotorVrefPayload(utils.BinarySerializable):
 class BrushedMotorPwmPayload(utils.BinarySerializable):
     """A request to set the pwm of a brushed motor."""
 
-    freq: utils.UInt8Field
-    duty_cycle: utils.UInt8Field
+    freq: utils.UInt32Field
+    duty_cycle: utils.UInt32Field

--- a/hardware/opentrons_hardware/hardware_control/gripper_settings.py
+++ b/hardware/opentrons_hardware/hardware_control/gripper_settings.py
@@ -1,11 +1,11 @@
 """Utilities for updating the gripper settings."""
-from lib2to3.pytree import Node
-from re import M
-from hardware.opentrons_hardware.firmware_bindings.messages.message_definitions import GripperGripRequest, GripperHomeRequest, SetBrushedMotorPwmRequest
 from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
 from opentrons_hardware.firmware_bindings.messages import payloads
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     SetBrushedMotorVrefRequest,
+    SetBrushedMotorPwmRequest,
+    GripperGripRequest,
+    GripperHomeRequest,
 )
 from opentrons_hardware.firmware_bindings.utils import UInt32Field
 from opentrons_hardware.firmware_bindings.constants import NodeId
@@ -22,7 +22,7 @@ async def set_reference_voltage(
             payload=payloads.BrushedMotorVrefPayload(
                 v_ref=UInt32Field(int(v_ref * (2**16)))
             )
-        )
+        ),
     )
 
 
@@ -35,25 +35,18 @@ async def set_pwm_param(
     await can_messenger.send(
         node_id=NodeId.gripper,
         message=SetBrushedMotorPwmRequest(
-            payload=payloads.SetBrushedMotorPwmRequest(
-                freq=UInt32Field(freq),
-                duty_cycle=UInt32Field(duty_cycle)
+            payload=payloads.BrushedMotorPwmPayload(
+                freq=UInt32Field(freq), duty_cycle=UInt32Field(duty_cycle)
             )
-        )
+        ),
     )
 
 
 async def grip(can_messenger: CanMessenger) -> None:
     """Start grip motion."""
-    await can_messenger.send(
-        node_id=NodeId.gripper,
-        message=GripperGripRequest(payload=payloads.EmptyPayload)
-    )
+    await can_messenger.send(node_id=NodeId.gripper, message=GripperGripRequest())
 
 
 async def home(can_messenger: CanMessenger) -> None:
     """Start home motion."""
-    await can_messenger.send(
-        node_id=NodeId.gripper,
-        message=GripperHomeRequest(payload=payloads.EmptyPayload)
-    )
+    await can_messenger.send(node_id=NodeId.gripper, message=GripperHomeRequest())

--- a/hardware/opentrons_hardware/hardware_control/gripper_settings.py
+++ b/hardware/opentrons_hardware/hardware_control/gripper_settings.py
@@ -1,0 +1,38 @@
+"""Utilities for updating the gripper settings."""
+from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
+from opentrons_hardware.firmware_bindings.messages import payloads
+from opentrons_hardware.firmware_bindings.messages.message_definitions import (
+    SetBrushedMotorVrefRequest,
+)
+from opentrons_hardware.firmware_bindings.utils import UInt32Field
+from opentrons_hardware.firmware_bindings.constants import NodeId
+
+
+async def set_reference_voltage(
+    can_messenger: CanMessenger,
+    v_ref: float,
+) -> None:
+    """Set gripper brushed motor reference voltage."""
+    await can_messenger.send(
+        node_id=NodeId.gripper,
+        message=SetBrushedMotorVrefRequest(
+            payload=payloads.BrushedMotorVrefPayload(
+                v_ref=UInt32Field(int(v_ref * (2**16)))
+            )
+        )
+    )
+
+
+async def set_reference_voltage(
+    can_messenger: CanMessenger,
+    v_ref: float,
+) -> None:
+    """Set gripper brushed motor reference voltage."""
+    await can_messenger.send(
+        node_id=NodeId.gripper,
+        message=SetBrushedMotorVrefRequest(
+            payload=payloads.BrushedMotorVrefPayload(
+                v_ref=UInt32Field(int(v_ref * (2**16)))
+            )
+        )
+    )

--- a/hardware/opentrons_hardware/hardware_control/gripper_settings.py
+++ b/hardware/opentrons_hardware/hardware_control/gripper_settings.py
@@ -1,4 +1,7 @@
 """Utilities for updating the gripper settings."""
+from lib2to3.pytree import Node
+from re import M
+from hardware.opentrons_hardware.firmware_bindings.messages.message_definitions import GripperGripRequest, GripperHomeRequest, SetBrushedMotorPwmRequest
 from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
 from opentrons_hardware.firmware_bindings.messages import payloads
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
@@ -23,16 +26,34 @@ async def set_reference_voltage(
     )
 
 
-async def set_reference_voltage(
+async def set_pwm_param(
     can_messenger: CanMessenger,
-    v_ref: float,
+    freq: int,
+    duty_cycle: int,
 ) -> None:
     """Set gripper brushed motor reference voltage."""
     await can_messenger.send(
         node_id=NodeId.gripper,
-        message=SetBrushedMotorVrefRequest(
-            payload=payloads.BrushedMotorVrefPayload(
-                v_ref=UInt32Field(int(v_ref * (2**16)))
+        message=SetBrushedMotorPwmRequest(
+            payload=payloads.SetBrushedMotorPwmRequest(
+                freq=UInt32Field(freq),
+                duty_cycle=UInt32Field(duty_cycle)
             )
         )
+    )
+
+
+async def grip(can_messenger: CanMessenger) -> None:
+    """Start grip motion."""
+    await can_messenger.send(
+        node_id=NodeId.gripper,
+        message=GripperGripRequest(payload=payloads.EmptyPayload)
+    )
+
+
+async def home(can_messenger: CanMessenger) -> None:
+    """Start home motion."""
+    await can_messenger.send(
+        node_id=NodeId.gripper,
+        message=GripperHomeRequest(payload=payloads.EmptyPayload)
     )


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR adds the following CAN messages:
* `SetBrushedMotorVrefRequest`: update gripper brushed motor voltage reference
* `SetBrushedMotorPwmRequest`: update gripper brushed motor PWM frequency & duty cycle
* `GripperGripRequest`: initiate gripper grip motion  `# this is only used for testing and will be refactored into the move manager`
* `GripperHomeRequest`: initiate gripper home motion  `# this is only used for testing and will be refactored into the move manager`
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
