### PR TITLE
build(shared-data): fix shared-data wheel build

### DIFF
--- a/shared-data/python/setup.py
+++ b/shared-data/python/setup.py
@@ -83,7 +83,7 @@ class BuildWithData(build_py.build_py):
         # should be something ending in opentrons_shared_data
         build_base = os.path.commonpath([f[2] for f in files])
         # We want a list of paths to only files relative to ../shared-data
-        to_include = get_shared_data_files()
+        to_include = [str(f.relative_to(DATA_ROOT)) for f in get_shared_data_files()]
         destination = os.path.join(build_base, "opentrons_shared_data", DEST_BASE_PATH)
         # And finally, tell the system about our files, including package.json
         files.extend(


### PR DESCRIPTION
## Overview

I completely broke `make -C shared-data/python wheel` in #9822. This PR fixes the wheel build. I don't know where this leaves #9845 

## Changelog

- build(shared-data): fix shared-data wheel build

## Review requests

- [ ] Wheel builds
- [ ] Shared data installed via wheel has everything (except fixtures) in its right place

## Risk assessment

Lower than #9822, I hope...