### PR TITLE
ci(python): ensure wheel/sdist builds are tested in CI

### DIFF
--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -33,7 +33,6 @@ on:
       - 'v*'
   workflow_dispatch:
 
-
 defaults:
   run:
     shell: bash
@@ -97,16 +96,19 @@ jobs:
           project: 'api'
           python-version: ${{ matrix.python }}
       - if: ${{ matrix.with-ot-hardware == 'false' }}
-        name: Test without opentrons_hardware
-        run: |
-          make -C api setup-ot2
-          make -C api test-ot2
+        name: Remove OT-3 hardware package
+        run: make -C api setup-ot2
         env:
           OT_VIRTUALENV_VERSION: ${{ matrix.python }}
+      - if: ${{ matrix.with-ot-hardware == 'false' }}
+        name: Test without opentrons_hardware
+        run: make -C api test-ot2
       - if: ${{ matrix.with-ot-hardware == 'true' }}
         name: Test with opentrons_hardware
         run: make -C api test-cov
-      - if: ${{ matrix.with-ot-hardware == 'true' }}
+      - name: Ensure assets build
+        run: make -C api sdist wheel
+      - name: Upload coverage report
         uses: 'codecov/codecov-action@v2'
         with:
           files: ./api/coverage.xml

--- a/.github/workflows/robot-server-lint-test.yaml
+++ b/.github/workflows/robot-server-lint-test.yaml
@@ -58,23 +58,15 @@ jobs:
         with:
           project: 'robot-server'
       - if: ${{ matrix.with-ot-hardware == 'false' }}
-        name: Lint without opentrons_hardware
-        run: |
-          make -C robot-server setup-ot2
-          make -C robot-server lint
-      - if: ${{ matrix.with-ot-hardware == 'true' }}
-        name: Lint with opentrons_hardware
-        run: |
-          make -C robot-server lint
-      - if: ${{ matrix.with-ot-hardware == 'false' }}
-        name: Test without opentrons_hardware
-        run: |
-          make -C robot-server setup-ot2
-          make -C robot-server test-cov
-      - if: ${{ matrix.with-ot-hardware == 'true' }}
-        name: Test with opentrons_hardware
+        name: Remove OT-3 hardware package
+        run: make -C robot-server setup-ot2
+      - name: Lint
+        run: make -C robot-server lint
+      - name: Test
         run: make -C robot-server test-cov
-      - if: ${{ matrix.with-ot-hardware == 'true' }}
+      - name: Ensure assets build
+        run: make -C robot-server sdist wheel
+      - name: Upload coverage report
         uses: 'codecov/codecov-action@v2'
         with:
           files: ./robot-server/coverage.xml

--- a/.github/workflows/shared-data-test-lint-deploy.yaml
+++ b/.github/workflows/shared-data-test-lint-deploy.yaml
@@ -87,6 +87,8 @@ jobs:
             buildComplexEnvVars(core, context)
       - name: Test
         run: make -C shared-data/python test
+      - name: Ensure assets build
+        run: make -C shared-data/python sdist wheel
       - name: 'Upload coverage report'
         uses: codecov/codecov-action@v2
         with:

--- a/api/Makefile
+++ b/api/Makefile
@@ -67,7 +67,7 @@ clean_cmd = $(SHX) rm -rf build dist .coverage coverage.xml '*.egg-info' '**/__p
 plot_type ?=
 
 .PHONY: all
-all: clean wheel
+all: clean sdist wheel
 
 .PHONY: setup
 setup:

--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -60,7 +60,7 @@ clean_cmd = $(SHX) rm -rf build dist .coverage coverage.xml '*.egg-info' '**/__p
 run_dev ?= uvicorn "robot_server:app" --host localhost --port 31950 --ws wsproto --lifespan on --reload
 
 .PHONY: all
-all: clean wheel
+all: clean sdist wheel
 
 .PHONY: setup
 setup:

--- a/shared-data/Makefile
+++ b/shared-data/Makefile
@@ -42,7 +42,7 @@ setup-py:
 
 .PHONY: dist-py
 dist-py:
-	$(MAKE) -C python wheel
+	$(MAKE) -C python sdist wheel
 
 .PHONY: clean-py
 clean-py:

--- a/shared-data/python/Makefile
+++ b/shared-data/python/Makefile
@@ -47,6 +47,9 @@ twine_repository_url ?= $(pypi_test_upload_url)
 
 clean_cmd = $(SHX) rm -rf build $(BUILD_DIR) .coverage coverage.xml '*.egg-info' ' **/__pycache__' '**/*.pyc' 'opentrons_shared_data/**/.mypy_cache'
 
+.PHONY: all
+all: clean sdist wheel
+
 .PHONY: setup
 setup: setup-py
 


### PR DESCRIPTION
## Overview

After I so rudely broke the `opentrons_shared_data` build with #9822, I figured it'd be smart to add wheel/sdist builds to regular CI for `api` + `robot-server` + `shared-data` to save us from ourselves in the future.

## Changelog

- ci(python): ensure wheel/sdist builds are tested in CI

## Review requests

Check out the CI config file changes and inspect the CI runs of:

- `API test/lint/deploy`
- `Robot server lint/test`
- `shared-data test/lint/deploy`

## Risk assessment

Hopefully low! More CI checks for more safety in the future, especially when messing with `setup.py` et. al.
