### PR TITLE
refactor(shared-data): update JSONv6 Python models for recent schema updates

### DIFF
--- a/api/tests/opentrons/protocol_runner/test_json_command_translator.py
+++ b/api/tests/opentrons/protocol_runner/test_json_command_translator.py
@@ -32,7 +32,6 @@ INVALID_TEST_PARAMS = [
     (
         protocol_schema_v6.Command(
             commandType="aspirate",
-            id="command-id-ddd-666",
             params=protocol_schema_v6.Params(
                 pipetteId="pipette-id-abc123",
                 labwareId="labware-id-def456",
@@ -60,7 +59,6 @@ INVALID_TEST_PARAMS = [
     ),
     (
         protocol_schema_v6.Command(
-            id="dispense-command-id-666",
             commandType="dispense",
             params=protocol_schema_v6.Params(
                 pipetteId="pipette-id-abc123",
@@ -86,7 +84,6 @@ INVALID_TEST_PARAMS = [
     ),
     (
         protocol_schema_v6.Command(
-            id="dropTip-command-id-666",
             commandType="dropTip",
             params=protocol_schema_v6.Params(
                 pipetteId="pipette-id-abc123",
@@ -109,7 +106,6 @@ INVALID_TEST_PARAMS = [
     ),
     (
         protocol_schema_v6.Command(
-            id="pickUpTip-command-id-666",
             commandType="pickUpTip",
             params=protocol_schema_v6.Params(
                 pipetteId="pipette-id-abc123",
@@ -132,7 +128,6 @@ INVALID_TEST_PARAMS = [
     ),
     (
         protocol_schema_v6.Command(
-            id="load-pipette-command-id-666",
             commandType="loadPipette",
             params=protocol_schema_v6.Params(pipetteId="pipetteId", mount="left"),
         ),
@@ -146,7 +141,6 @@ INVALID_TEST_PARAMS = [
     ),
     (
         protocol_schema_v6.Command(
-            id="load-module-command-id-666",
             commandType="loadModule",
             params=protocol_schema_v6.Params(
                 moduleId="magneticModuleId",
@@ -167,7 +161,6 @@ VALID_TEST_PARAMS = [
     (
         protocol_schema_v6.Command(
             commandType="aspirate",
-            id="command-id-ddd-666",
             params=protocol_schema_v6.Params(
                 pipetteId="pipette-id-abc123",
                 labwareId="labware-id-def456",
@@ -198,7 +191,6 @@ VALID_TEST_PARAMS = [
     ),
     (
         protocol_schema_v6.Command(
-            id="dispense-command-id-666",
             commandType="dispense",
             params=protocol_schema_v6.Params(
                 pipetteId="pipette-id-abc123",
@@ -227,7 +219,6 @@ VALID_TEST_PARAMS = [
     ),
     (
         protocol_schema_v6.Command(
-            id="dropTip-command-id-666",
             commandType="dropTip",
             params=protocol_schema_v6.Params(
                 pipetteId="pipette-id-abc123",
@@ -246,7 +237,6 @@ VALID_TEST_PARAMS = [
     ),
     (
         protocol_schema_v6.Command(
-            id="pickUpTip-command-id-666",
             commandType="pickUpTip",
             params=protocol_schema_v6.Params(
                 pipetteId="pipette-id-abc123",
@@ -265,7 +255,6 @@ VALID_TEST_PARAMS = [
     ),
     (
         protocol_schema_v6.Command(
-            id="delay-command-id-666",
             commandType="pause",
             params=protocol_schema_v6.Params(
                 wait=True,
@@ -276,7 +265,6 @@ VALID_TEST_PARAMS = [
     ),
     (
         protocol_schema_v6.Command(
-            id="load-pipette-command-id-666",
             commandType="loadPipette",
             params=protocol_schema_v6.Params(pipetteId="pipetteId", mount="left"),
         ),
@@ -290,7 +278,6 @@ VALID_TEST_PARAMS = [
     ),
     (
         protocol_schema_v6.Command(
-            id="load-module-command-id-666",
             commandType="loadModule",
             params=protocol_schema_v6.Params(
                 moduleId="magneticModuleId",
@@ -307,7 +294,6 @@ VALID_TEST_PARAMS = [
     ),
     (
         protocol_schema_v6.Command(
-            id="load-labware-command-id-666",
             commandType="loadLabware",
             params=protocol_schema_v6.Params(
                 labwareId="sourcePlateId",

--- a/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v6.py
+++ b/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v6.py
@@ -11,9 +11,9 @@ class CommandAnnotation(BaseModel):
 
 
 class OffsetVector(BaseModel):
-    x: float
-    y: float
-    z: float
+    x: Optional[float]
+    y: Optional[float]
+    z: Optional[float]
 
 
 class Location(BaseModel):
@@ -57,9 +57,9 @@ class Params(BaseModel):
 
 
 class Command(BaseModel):
-    id: str
     commandType: str
     params: Params
+    key: Optional[str]
 
 
 class Labware(BaseModel):

--- a/shared-data/python/tests/protocol/test_protocol_schema_v6.py
+++ b/shared-data/python/tests/protocol/test_protocol_schema_v6.py
@@ -29,7 +29,5 @@ def test_v6_types(defpath):
 # https://github.com/Opentrons/opentrons/issues/9701
 def delete_unexpected_results(protocol_fixture: Dict[str, Any]) -> None:
     for command_object_dict in protocol_fixture["commands"]:
-        try:
-            command_object_dict.pop("result")
-        except KeyError:
-            pass
+        command_object_dict.pop("result", None)
+        command_object_dict.pop("id", None)


### PR DESCRIPTION
## Overview

Two small tweaks to the JSONv6 Python model to account for schema changes in #9824

## Changelog

- Replace required, unused `id` field with optional `key` field
- Mark params of `WellLocation` as optional

## Review requests

- Changes match schema

## Risk assessment

Pretty low. Tested against protocols coming out of PD post-#9824
