### PR TITLE
chore(hardware): upgrade numpy

### DIFF
--- a/hardware/Pipfile
+++ b/hardware/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 python-can = "==3.3.4"
 pyserial = "==3.5"
 typing-extensions = ">=4.0.0,<5"
-numpy = "==1.17.4"
+numpy = "==1.21.2"
 pydantic = "==1.8.2"
 
 [dev-packages]

--- a/hardware/Pipfile.lock
+++ b/hardware/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f61feed65423e37617dd817e331620a44a6cd66e6808f4f67a06013a427c4091"
+            "sha256": "39ee9a9caf1d4c19e9f1d047e11139933b1487ad7d16e349bec3b51fce71a9c1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,30 +26,39 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:0a7a1dd123aecc9f0076934288ceed7fd9a81ba3919f11a855a7887cbe82a02f",
-                "sha256:0c0763787133dfeec19904c22c7e358b231c87ba3206b211652f8cbe1241deb6",
-                "sha256:3d52298d0be333583739f1aec9026f3b09fdfe3ddf7c7028cb16d9d2af1cca7e",
-                "sha256:43bb4b70585f1c2d153e45323a886839f98af8bfa810f7014b20be714c37c447",
-                "sha256:475963c5b9e116c38ad7347e154e5651d05a2286d86455671f5b1eebba5feb76",
-                "sha256:64874913367f18eb3013b16123c9fed113962e75d809fca5b78ebfbb73ed93ba",
-                "sha256:683828e50c339fc9e68720396f2de14253992c495fdddef77a1e17de55f1decc",
-                "sha256:6ca4000c4a6f95a78c33c7dadbb9495c10880be9c89316aa536eac359ab820ae",
-                "sha256:75fd817b7061f6378e4659dd792c84c0b60533e867f83e0d1e52d5d8e53df88c",
-                "sha256:7d81d784bdbed30137aca242ab307f3e65c8d93f4c7b7d8f322110b2e90177f9",
-                "sha256:8d0af8d3664f142414fd5b15cabfd3b6cc3ef242a3c7a7493257025be5a6955f",
-                "sha256:9679831005fb16c6df3dd35d17aa31dc0d4d7573d84f0b44cc481490a65c7725",
-                "sha256:a8f67ebfae9f575d85fa859b54d3bdecaeece74e3274b0b5c5f804d7ca789fe1",
-                "sha256:acbf5c52db4adb366c064d0b7c7899e3e778d89db585feadd23b06b587d64761",
-                "sha256:ada4805ed51f5bcaa3a06d3dd94939351869c095e30a2b54264f5a5004b52170",
-                "sha256:c7354e8f0eca5c110b7e978034cd86ed98a7a5ffcf69ca97535445a595e07b8e",
-                "sha256:e2e9d8c87120ba2c591f60e32736b82b67f72c37ba88a4c23c81b5b8fa49c018",
-                "sha256:e467c57121fe1b78a8f68dd9255fbb3bb3f4f7547c6b9e109f31d14569f490c3",
-                "sha256:ede47b98de79565fcd7f2decb475e2dcc85ee4097743e551fe26cfc7eb3ff143",
-                "sha256:f58913e9227400f1395c7b800503ebfdb0772f1c33ff8cb4d6451c06cabdf316",
-                "sha256:fe39f5fd4103ec4ca3cb8600b19216cd1ff316b4990f4c0b6057ad982c0a34d5"
+                "sha256:09858463db6dd9f78b2a1a05c93f3b33d4f65975771e90d2cf7aadb7c2f66edf",
+                "sha256:209666ce9d4a817e8a4597cd475b71b4878a85fa4b8db41d79fdb4fdee01dde2",
+                "sha256:298156f4d3d46815eaf0fcf0a03f9625fc7631692bd1ad851517ab93c3168fc6",
+                "sha256:30fc68307c0155d2a75ad19844224be0f2c6f06572d958db4e2053f816b859ad",
+                "sha256:423216d8afc5923b15df86037c6053bf030d15cc9e3224206ef868c2d63dd6dc",
+                "sha256:426a00b68b0d21f2deb2ace3c6d677e611ad5a612d2c76494e24a562a930c254",
+                "sha256:466e682264b14982012887e90346d33435c984b7fead7b85e634903795c8fdb0",
+                "sha256:51a7b9db0a2941434cd930dacaafe0fc9da8f3d6157f9d12f761bbde93f46218",
+                "sha256:52a664323273c08f3b473548bf87c8145b7513afd63e4ebba8496ecd3853df13",
+                "sha256:550564024dc5ceee9421a86fc0fb378aa9d222d4d0f858f6669eff7410c89bef",
+                "sha256:5de64950137f3a50b76ce93556db392e8f1f954c2d8207f78a92d1f79aa9f737",
+                "sha256:640c1ccfd56724f2955c237b6ccce2e5b8607c3bc1cc51d3933b8c48d1da3723",
+                "sha256:7fdc7689daf3b845934d67cb221ba8d250fdca20ac0334fea32f7091b93f00d3",
+                "sha256:805459ad8baaf815883d0d6f86e45b3b0b67d823a8f3fa39b1ed9c45eaf5edf1",
+                "sha256:92a0ab128b07799dd5b9077a9af075a63467d03ebac6f8a93e6440abfea4120d",
+                "sha256:9f2dc79c093f6c5113718d3d90c283f11463d77daa4e83aeeac088ec6a0bda52",
+                "sha256:a5109345f5ce7ddb3840f5970de71c34a0ff7fceb133c9441283bb8250f532a3",
+                "sha256:a55e4d81c4260386f71d22294795c87609164e22b28ba0d435850fbdf82fc0c5",
+                "sha256:a9da45b748caad72ea4a4ed57e9cd382089f33c5ec330a804eb420a496fa760f",
+                "sha256:b160b9a99ecc6559d9e6d461b95c8eec21461b332f80267ad2c10394b9503496",
+                "sha256:b342064e647d099ca765f19672696ad50c953cac95b566af1492fd142283580f",
+                "sha256:b5e8590b9245803c849e09bae070a8e1ff444f45e3f0bed558dd722119eea724",
+                "sha256:bf75d5825ef47aa51d669b03ce635ecb84d69311e05eccea083f31c7570c9931",
+                "sha256:c01b59b33c7c3ba90744f2c695be571a3bd40ab2ba7f3d169ffa6db3cfba614f",
+                "sha256:d96a6a7d74af56feb11e9a443150216578ea07b7450f7c05df40eec90af7f4a7",
+                "sha256:dd0e3651d210068d13e18503d75aaa45656eef51ef0b261f891788589db2cc38",
+                "sha256:e167b9805de54367dcb2043519382be541117503ce99e3291cc9b41ca0a83557",
+                "sha256:e42029e184008a5fd3d819323345e25e2337b0ac7f5c135b7623308530209d57",
+                "sha256:f545c082eeb09ae678dd451a1b1dbf17babd8a0d7adea02897a76e639afca310",
+                "sha256:fde50062d67d805bc96f1a9ecc0d37bfc2a8f02b937d2c50824d186aa91f2419"
             ],
             "index": "pypi",
-            "version": "==1.17.4"
+            "version": "==1.21.2"
         },
         "pydantic": {
             "hashes": [
@@ -318,16 +327,16 @@
                 "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
                 "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
             ],
-            "markers": "python_full_version >= '3.5.0'",
+            "markers": "python_version >= '3.5'",
             "version": "==2.0.12"
         },
         "click": {
             "hashes": [
-                "sha256:19a4baa64da924c5e0cd889aba8e947f280309f1a2ce0947a3e3a7bcb7cc72d6",
-                "sha256:977c213473c7665d3aa092b41ff12063227751c41d7b17165013e10069cc5cd2"
+                "sha256:24e1a4a9ec5bf6299411369b208c1df2188d9eb8d916302fe6bf03faed227f1e",
+                "sha256:479707fe14d9ec9a0757618b7a100a0ae4c4e236fac5b7f80ca68028141a1a72"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==8.1.0"
+            "version": "==8.1.2"
         },
         "coverage": {
             "hashes": [
@@ -485,7 +494,7 @@
                 "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
                 "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
             ],
-            "markers": "python_full_version >= '3.5.0'",
+            "markers": "python_version >= '3.5'",
             "version": "==3.3"
         },
         "importlib-metadata": {
@@ -884,11 +893,11 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d",
-                "sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375"
+                "sha256:56bf8aadb83c24db6c4b577e13de374ccfb67da2078beba1d037c17980bf43ad",
+                "sha256:c4f6e5bbf48e74f7a38e7cc5b0480ff42b0ae5178957d564d18932525d5cf099"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.7.0"
+            "version": "==3.8.0"
         }
     }
 }

--- a/hardware/opentrons_hardware/hardware_control/motion.py
+++ b/hardware/opentrons_hardware/hardware_control/motion.py
@@ -1,7 +1,7 @@
 """A collection of motions that define a single move."""
 from typing import List, Dict, Iterable
 from dataclasses import dataclass
-import numpy as np  # type: ignore[import]
+import numpy as np
 from logging import getLogger
 from enum import Enum, unique
 from opentrons_hardware.firmware_bindings.constants import NodeId
@@ -44,10 +44,10 @@ class MoveType(int, Enum):
 class MoveGroupSingleAxisStep:
     """A single move in a move group."""
 
-    distance_mm: float
-    velocity_mm_sec: float
-    duration_sec: float
-    acceleration_mm_sec_sq: float = 0
+    distance_mm: np.float64
+    velocity_mm_sec: np.float64
+    duration_sec: np.float64
+    acceleration_mm_sec_sq: np.float64 = np.float64(0)
     stop_condition: MoveStopCondition = MoveStopCondition.none
     move_type: MoveType = MoveType.linear
 
@@ -93,9 +93,9 @@ def create_step(
     step: MoveGroupStep = {}
     for axis_node in ordered_nodes:
         step[axis_node] = MoveGroupSingleAxisStep(
-            distance_mm=distance.get(axis_node, 0),
-            acceleration_mm_sec_sq=acceleration.get(axis_node, 0),
-            velocity_mm_sec=velocity.get(axis_node, 0),
+            distance_mm=distance.get(axis_node, np.float64(0)),
+            acceleration_mm_sec_sq=acceleration.get(axis_node, np.float64(0)),
+            velocity_mm_sec=velocity.get(axis_node, np.float64(0)),
             duration_sec=duration,
             stop_condition=stop_condition,
             move_type=MoveType.get_move_type(stop_condition),
@@ -111,7 +111,7 @@ def create_home_step(
     for axis in distance.keys():
         step[axis] = MoveGroupSingleAxisStep(
             distance_mm=distance[axis],
-            acceleration_mm_sec_sq=0,
+            acceleration_mm_sec_sq=np.float64(0),
             velocity_mm_sec=velocity[axis],
             duration_sec=abs(distance[axis] / velocity[axis]),
             stop_condition=MoveStopCondition.limit_switch,

--- a/hardware/opentrons_hardware/hardware_control/motion_planning/types.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/types.py
@@ -2,7 +2,8 @@
 from __future__ import annotations
 import logging
 import dataclasses
-import numpy as np  # type: ignore[import]
+import numpy as np
+
 
 from typing import (
     cast,
@@ -15,7 +16,11 @@ from typing import (
     Iterable,
     Generator,
     Union,
+    TYPE_CHECKING,
 )
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
 
 log = logging.getLogger(__name__)
 
@@ -51,8 +56,11 @@ class Block:
 
         def _final_speed() -> np.float64:
             """Get final speed of the block."""
-            return np.sqrt(
-                self.initial_speed**2 + self.acceleration * self.distance * 2
+            return cast(
+                np.float64,
+                np.sqrt(
+                    self.initial_speed**2 + self.acceleration * self.distance * 2
+                ),
             )
 
         def _time() -> np.float64:
@@ -264,7 +272,7 @@ class ZeroLengthMoveError(ValueError, Generic[AxisKey, CoordinateValue]):
         return self._destination
 
 
-def vectorize(position: Coordinates[AxisKey, np.float64]) -> np.ndarray:
+def vectorize(position: Coordinates[AxisKey, np.float64]) -> "NDArray[np.float64]":
     """Turn a coordinates map into a vector for math."""
     return np.array(list(position.values()))
 
@@ -272,5 +280,5 @@ def vectorize(position: Coordinates[AxisKey, np.float64]) -> np.ndarray:
 def is_unit_vector(position: Coordinates[AxisKey, np.float64]) -> bool:
     """Check whether a coordinate vector has unit magnitude."""
     vectorized = vectorize(position)
-    magnitude = np.linalg.norm(vectorized)
+    magnitude = np.linalg.norm(vectorized)  # type: ignore[no-untyped-call]
     return cast(bool, np.isclose(magnitude, 1.0))

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -2,7 +2,8 @@
 import asyncio
 from collections import defaultdict
 import logging
-from typing import List, Set, Tuple, Iterator
+from typing import List, Set, Tuple, Iterator, Union
+import numpy as np
 
 from opentrons_hardware.firmware_bindings import ArbitrationId
 from opentrons_hardware.firmware_bindings.constants import NodeId
@@ -130,7 +131,9 @@ class MoveGroupRunner:
                         ),
                     )
 
-    def _convert_velocity(self, velocity: float, interrupts: int) -> Int32Field:
+    def _convert_velocity(
+        self, velocity: Union[float, np.float64], interrupts: int
+    ) -> Int32Field:
         return Int32Field(int((velocity / interrupts) * (2**31)))
 
     def _get_message_type(
@@ -195,7 +198,7 @@ class MoveScheduler:
             duration = 0.0
             for seq_id, move in enumerate(move_group):
                 move_set.update(set((k.value, seq_id) for k in move.keys()))
-                duration += list(move.values())[0].duration_sec
+                duration += float(list(move.values())[0].duration_sec)
                 for step in move_group[seq_id]:
                     self._stop_condition.append(move_group[seq_id][step].stop_condition)
 

--- a/hardware/opentrons_hardware/scripts/move.py
+++ b/hardware/opentrons_hardware/scripts/move.py
@@ -2,6 +2,7 @@
 import argparse
 import asyncio
 import logging
+from numpy import float64
 from logging.config import dictConfig
 from typing import Optional
 
@@ -60,12 +61,16 @@ async def run(interface: str, bitrate: int, channel: Optional[str] = None) -> No
         [
             {
                 NodeId.gantry_x: MoveGroupSingleAxisStep(
-                    distance_mm=0, velocity_mm_sec=5000.5, duration_sec=3
+                    distance_mm=float64(0),
+                    velocity_mm_sec=float64(5000.5),
+                    duration_sec=float64(3),
                 ),
             },
             {
                 NodeId.gantry_y: MoveGroupSingleAxisStep(
-                    distance_mm=0, velocity_mm_sec=5000.5, duration_sec=3
+                    distance_mm=float64(0),
+                    velocity_mm_sec=float64(5000.5),
+                    duration_sec=float64(3),
                 ),
             },
         ],
@@ -73,12 +78,16 @@ async def run(interface: str, bitrate: int, channel: Optional[str] = None) -> No
         [
             {
                 NodeId.gantry_x: MoveGroupSingleAxisStep(
-                    distance_mm=0, velocity_mm_sec=2000.25, duration_sec=3
+                    distance_mm=float64(0),
+                    velocity_mm_sec=float64(2000.25),
+                    duration_sec=float64(3),
                 ),
             },
             {
                 NodeId.gantry_y: MoveGroupSingleAxisStep(
-                    distance_mm=0, velocity_mm_sec=1000.5, duration_sec=3
+                    distance_mm=float64(0),
+                    velocity_mm_sec=float64(1000.5),
+                    duration_sec=float64(3),
                 ),
             },
         ],

--- a/hardware/opentrons_hardware/scripts/plan_motion.py
+++ b/hardware/opentrons_hardware/scripts/plan_motion.py
@@ -4,7 +4,7 @@ import json
 import logging
 from logging.config import dictConfig
 import argparse
-import numpy as np  # type: ignore[import]
+import numpy as np
 
 from opentrons_hardware.hardware_control.motion_planning import move_manager
 from opentrons_hardware.hardware_control.motion_planning.types import (
@@ -92,7 +92,9 @@ def main() -> None:
         for axis in AXIS_NAMES
     }
     origin_from_file: List[float] = cast(List[float], params["origin"])
-    origin: Coordinates[str, float] = dict(zip(AXIS_NAMES, origin_from_file))
+    origin: Coordinates[str, np.float64] = dict(
+        zip(AXIS_NAMES, (np.float64(c) for c in origin_from_file))
+    )
     target_list = [
         MoveTarget.build(
             dict(zip(AXIS_NAMES, target["coordinates"])), target["max_speed"]

--- a/hardware/tests/firmware_integration/test_move_groups.py
+++ b/hardware/tests/firmware_integration/test_move_groups.py
@@ -1,6 +1,6 @@
 """Tests for move groups."""
 import asyncio
-import numpy as np  # type: ignore
+import numpy as np
 from typing import Iterator, List, Dict
 
 import pytest
@@ -99,11 +99,15 @@ async def test_move_integration(
     # from a non-zero position
     prep_move = [
         create_step(
-            distance={motor_node: motor_node.value for motor_node in all_motor_nodes},
-            velocity={
-                motor_node: motor_node.value / 10 for motor_node in all_motor_nodes
+            distance={
+                motor_node: np.float64(motor_node.value)
+                for motor_node in all_motor_nodes
             },
-            acceleration={motor_node: 0 for motor_node in all_motor_nodes},
+            velocity={
+                motor_node: np.float64(motor_node.value / 10)
+                for motor_node in all_motor_nodes
+            },
+            acceleration={motor_node: np.float64(0) for motor_node in all_motor_nodes},
             duration=np.float64(1),
             present_nodes=all_motor_nodes,
         )
@@ -115,13 +119,13 @@ async def test_move_integration(
 
     home_move = [
         create_home_step(
-            distance={motor_node: 10 for motor_node in all_motor_nodes},
-            velocity={motor_node: 40 for motor_node in all_motor_nodes},
+            distance={motor_node: np.float64(10) for motor_node in all_motor_nodes},
+            velocity={motor_node: np.float64(40) for motor_node in all_motor_nodes},
         )
     ]
     home_runner = MoveGroupRunner([home_move])
     position = await home_runner.run(can_messenger)
-    assert position == {motor_node: 0 for motor_node in all_motor_nodes}
+    assert position == {motor_node: 0.0 for motor_node in all_motor_nodes}
     # these moves test position accumulation to reasonably realistic values
     # and have to do it over a kind of long time so that the velocities are low
     # enough that the pipettes, with their extremely high steps/mm values,
@@ -130,34 +134,40 @@ async def test_move_integration(
     moves = [
         create_step(
             distance={
-                motor_node: motor_node.value / 4 for motor_node in all_motor_nodes
+                motor_node: np.float64(motor_node.value / 4)
+                for motor_node in all_motor_nodes
             },
             velocity={
-                motor_node: motor_node.value / 4 for motor_node in all_motor_nodes
+                motor_node: np.float64(motor_node.value / 4)
+                for motor_node in all_motor_nodes
             },
-            acceleration={motor_node: 0 for motor_node in all_motor_nodes},
+            acceleration={motor_node: np.float64(0) for motor_node in all_motor_nodes},
             duration=np.float64(4),
             present_nodes=all_motor_nodes,
         ),
         create_step(
             distance={
-                motor_node: motor_node.value / 4 for motor_node in all_motor_nodes
+                motor_node: np.float64(motor_node.value / 4)
+                for motor_node in all_motor_nodes
             },
             velocity={
-                motor_node: motor_node.value / 4 for motor_node in all_motor_nodes
+                motor_node: np.float64(motor_node.value / 4)
+                for motor_node in all_motor_nodes
             },
-            acceleration={motor_node: 0 for motor_node in all_motor_nodes},
+            acceleration={motor_node: np.float64(0) for motor_node in all_motor_nodes},
             duration=np.float64(4),
             present_nodes=all_motor_nodes,
         ),
         create_step(
             distance={
-                motor_node: -motor_node.value / 4 for motor_node in all_motor_nodes
+                motor_node: np.float64(-motor_node.value / 4)
+                for motor_node in all_motor_nodes
             },
             velocity={
-                motor_node: -motor_node.value / 4 for motor_node in all_motor_nodes
+                motor_node: np.float64(-motor_node.value / 4)
+                for motor_node in all_motor_nodes
             },
-            acceleration={motor_node: 0 for motor_node in all_motor_nodes},
+            acceleration={motor_node: np.float64(0) for motor_node in all_motor_nodes},
             duration=np.float64(4),
             present_nodes=all_motor_nodes,
         ),

--- a/hardware/tests/opentrons_hardware/hardware_control/test_motion.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_motion.py
@@ -1,4 +1,5 @@
 """Tests for motion methods."""
+from numpy import float64
 from opentrons_hardware.drivers.can_bus import NodeId
 from opentrons_hardware.hardware_control.motion import (
     create_step,
@@ -14,35 +15,38 @@ def test_build_move() -> None:
     """
     expected = {
         NodeId.gantry_x: MoveGroupSingleAxisStep(
-            distance_mm=0.0,
-            velocity_mm_sec=0.0,
-            duration_sec=10,
-            acceleration_mm_sec_sq=0,
+            distance_mm=float64(0.0),
+            velocity_mm_sec=float64(0.0),
+            duration_sec=float64(10),
+            acceleration_mm_sec_sq=float64(0),
         ),
         NodeId.gantry_y: MoveGroupSingleAxisStep(
-            distance_mm=0.0,
-            velocity_mm_sec=0.0,
-            duration_sec=10,
-            acceleration_mm_sec_sq=0,
+            distance_mm=float64(0.0),
+            velocity_mm_sec=float64(0.0),
+            duration_sec=float64(10),
+            acceleration_mm_sec_sq=float64(0),
         ),
         NodeId.head_r: MoveGroupSingleAxisStep(
-            distance_mm=0.0,
-            velocity_mm_sec=0.0,
-            duration_sec=10,
-            acceleration_mm_sec_sq=0,
+            distance_mm=float64(0.0),
+            velocity_mm_sec=float64(0.0),
+            duration_sec=float64(10),
+            acceleration_mm_sec_sq=float64(0),
         ),
         NodeId.head_l: MoveGroupSingleAxisStep(
-            distance_mm=4,
-            velocity_mm_sec=0.25,
-            duration_sec=10,
-            acceleration_mm_sec_sq=1000,
+            distance_mm=float64(4),
+            velocity_mm_sec=float64(0.25),
+            duration_sec=float64(10),
+            acceleration_mm_sec_sq=float64(1000),
         ),
     }
     assert expected == create_step(
-        distance={NodeId.head_l: 4, NodeId.pipette_right: 10},
-        velocity={NodeId.head_l: 0.25, NodeId.pipette_right: 0.3},
-        acceleration={NodeId.head_l: 1000, NodeId.pipette_right: 1000},
-        duration=10,
+        distance={NodeId.head_l: float64(4), NodeId.pipette_right: float64(10)},
+        velocity={NodeId.head_l: float64(0.25), NodeId.pipette_right: float64(0.3)},
+        acceleration={
+            NodeId.head_l: float64(1000),
+            NodeId.pipette_right: float64(1000),
+        },
+        duration=float64(10),
         present_nodes=set(
             (NodeId.gantry_x, NodeId.gantry_y, NodeId.head_r, NodeId.head_l)
         ),

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -1,6 +1,7 @@
 """Tests for the move scheduler."""
 import pytest
 from typing import List, Tuple, Any
+from numpy import float64
 from mock import AsyncMock, call, MagicMock
 from opentrons_hardware.firmware_bindings import ArbitrationId, ArbitrationIdParts
 
@@ -55,7 +56,9 @@ def move_group_single() -> MoveGroups:
         [
             {
                 NodeId.head: MoveGroupSingleAxisStep(
-                    distance_mm=246, velocity_mm_sec=2, duration_sec=123
+                    distance_mm=float64(246),
+                    velocity_mm_sec=float64(2),
+                    duration_sec=float64(123),
                 )
             }
         ]
@@ -70,10 +73,10 @@ def move_group_home_single() -> MoveGroups:
         [
             {
                 NodeId.head: MoveGroupSingleAxisStep(
-                    distance_mm=0,
-                    velocity_mm_sec=235,
-                    duration_sec=2142,
-                    acceleration_mm_sec_sq=1000,
+                    distance_mm=float64(0),
+                    velocity_mm_sec=float64(235),
+                    duration_sec=float64(2142),
+                    acceleration_mm_sec_sq=float64(1000),
                     stop_condition=MoveStopCondition.limit_switch,
                     move_type=MoveType.home,
                 ),
@@ -90,10 +93,10 @@ def move_group_multiple() -> MoveGroups:
         [
             {
                 NodeId.head: MoveGroupSingleAxisStep(
-                    distance_mm=229,
-                    velocity_mm_sec=235,
-                    duration_sec=2142,
-                    acceleration_mm_sec_sq=1000,
+                    distance_mm=float64(229),
+                    velocity_mm_sec=float64(235),
+                    duration_sec=float64(2142),
+                    acceleration_mm_sec_sq=float64(1000),
                 ),
             }
         ],
@@ -101,16 +104,16 @@ def move_group_multiple() -> MoveGroups:
         [
             {
                 NodeId.gantry_x: MoveGroupSingleAxisStep(
-                    distance_mm=522,
-                    velocity_mm_sec=22,
-                    duration_sec=1,
-                    acceleration_mm_sec_sq=1000,
+                    distance_mm=float64(522),
+                    velocity_mm_sec=float64(22),
+                    duration_sec=float64(1),
+                    acceleration_mm_sec_sq=float64(1000),
                 ),
                 NodeId.gantry_y: MoveGroupSingleAxisStep(
-                    distance_mm=25,
-                    velocity_mm_sec=23,
-                    duration_sec=0,
-                    acceleration_mm_sec_sq=1000,
+                    distance_mm=float64(25),
+                    velocity_mm_sec=float64(23),
+                    duration_sec=float64(0),
+                    acceleration_mm_sec_sq=float64(1000),
                 ),
             }
         ],
@@ -118,18 +121,18 @@ def move_group_multiple() -> MoveGroups:
         [
             {
                 NodeId.pipette_left: MoveGroupSingleAxisStep(
-                    distance_mm=12,
-                    velocity_mm_sec=-23,
-                    duration_sec=1234,
-                    acceleration_mm_sec_sq=1000,
+                    distance_mm=float64(12),
+                    velocity_mm_sec=float64(-23),
+                    duration_sec=float64(1234),
+                    acceleration_mm_sec_sq=float64(1000),
                 ),
             },
             {
                 NodeId.pipette_left: MoveGroupSingleAxisStep(
-                    distance_mm=12,
-                    velocity_mm_sec=23,
-                    duration_sec=1234,
-                    acceleration_mm_sec_sq=1000,
+                    distance_mm=float64(12),
+                    velocity_mm_sec=float64(23),
+                    duration_sec=float64(1234),
+                    acceleration_mm_sec_sq=float64(1000),
                 ),
             },
         ],

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_utils.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_utils.py
@@ -1,6 +1,6 @@
 """Tests for move util functions."""
 import pytest
-import numpy as np  # type: ignore[import]
+import numpy as np
 from typing import Iterator, List
 from hypothesis import given, strategies as st, assume
 


### PR DESCRIPTION
Building on #9871 and other work by @mcous , bump the version of numpy used in hardware to 1.21.1 which matches what will be on the OT-2 and has some better typing.

Bumping numpy revealed some real issues with our code and also some real
issues with numpy's as-yet incomplete typing, such as
- many functions particularly in numpy.linalg aren't typed, like `norm`
- many arithmetic ops and functions behave quite strangely, often
returning a `np.Float[_64bit, Any]` instead of a float64 equivalent
- ndarray typing is still not quite there, but that's mostly because
some typing peps need to be merged first

This should be a low risk set of changes.
