### PR TITLE
refactor(engine): add temperature module commands

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/__init__.py
@@ -197,12 +197,6 @@ __all__ = [
     "LoadPipetteParams",
     "LoadPipetteResult",
     "LoadPipetteCommandType",
-    # magnetic module engage command models
-    "MagneticModuleEngage",
-    "MagneticModuleEngageCreate",
-    "MagneticModuleEngageParams",
-    "MagneticModuleEngageResult",
-    "MagneticModuleEngageCommandType",
     # move relative command models
     "MoveRelative",
     "MoveRelativeParams",

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -141,6 +141,8 @@ Command = Union[
     magnetic_module.Disengage,
     magnetic_module.Engage,
     temperature_module.SetTargetTemperature,
+    temperature_module.AwaitTemperature,
+    temperature_module.DeactivateTemperature,
     SetRailLights,
 ]
 
@@ -168,6 +170,8 @@ CommandParams = Union[
     magnetic_module.DisengageParams,
     magnetic_module.EngageParams,
     temperature_module.SetTargetTemperatureParams,
+    temperature_module.AwaitTemperatureParams,
+    temperature_module.DeactivateTemperatureParams,
     SetRailLightsParams,
 ]
 
@@ -195,6 +199,8 @@ CommandType = Union[
     magnetic_module.DisengageCommandType,
     magnetic_module.EngageCommandType,
     temperature_module.SetTargetTemperatureCommandType,
+    temperature_module.AwaitTemperatureCommandType,
+    temperature_module.DeactivateTemperatureCommandType,
     SetRailLightsCommandType,
 ]
 
@@ -221,6 +227,8 @@ CommandCreate = Union[
     magnetic_module.DisengageCreate,
     magnetic_module.EngageCreate,
     temperature_module.SetTargetTemperatureCreate,
+    temperature_module.AwaitTemperatureCreate,
+    temperature_module.DeactivateTemperatureCreate,
     SetRailLightsCreate,
 ]
 
@@ -248,5 +256,7 @@ CommandResult = Union[
     magnetic_module.DisengageResult,
     magnetic_module.EngageResult,
     temperature_module.SetTargetTemperatureResult,
+    temperature_module.AwaitTemperatureResult,
+    temperature_module.DeactivateTemperatureResult,
     SetRailLightsResult,
 ]

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -4,6 +4,7 @@ from typing import Union
 
 from . import heater_shaker
 from . import magnetic_module
+from . import temperature_module
 
 from .set_rail_lights import (
     SetRailLights,
@@ -139,6 +140,7 @@ Command = Union[
     heater_shaker.CloseLatch,
     magnetic_module.Disengage,
     magnetic_module.Engage,
+    temperature_module.SetTargetTemperature,
     SetRailLights,
 ]
 
@@ -165,6 +167,7 @@ CommandParams = Union[
     heater_shaker.CloseLatchParams,
     magnetic_module.DisengageParams,
     magnetic_module.EngageParams,
+    temperature_module.SetTargetTemperatureParams,
     SetRailLightsParams,
 ]
 
@@ -191,6 +194,7 @@ CommandType = Union[
     heater_shaker.CloseLatchCommandType,
     magnetic_module.DisengageCommandType,
     magnetic_module.EngageCommandType,
+    temperature_module.SetTargetTemperatureCommandType,
     SetRailLightsCommandType,
 ]
 
@@ -216,6 +220,7 @@ CommandCreate = Union[
     heater_shaker.CloseLatchCreate,
     magnetic_module.DisengageCreate,
     magnetic_module.EngageCreate,
+    temperature_module.SetTargetTemperatureCreate,
     SetRailLightsCreate,
 ]
 
@@ -242,5 +247,6 @@ CommandResult = Union[
     heater_shaker.CloseLatchResult,
     magnetic_module.DisengageResult,
     magnetic_module.EngageResult,
+    temperature_module.SetTargetTemperatureResult,
     SetRailLightsResult,
 ]

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/__init__.py
@@ -5,7 +5,7 @@ from .set_target_temperature import (
     SetTargetTemperatureCreate,
     SetTargetTemperatureParams,
     SetTargetTemperatureResult,
-    SetTargetTemperatureCommandType
+    SetTargetTemperatureCommandType,
 )
 
 from .await_temperature import (
@@ -13,7 +13,7 @@ from .await_temperature import (
     AwaitTemperatureCreate,
     AwaitTemperatureParams,
     AwaitTemperatureResult,
-    AwaitTemperatureCommandType
+    AwaitTemperatureCommandType,
 )
 
 from .deactivate import (
@@ -21,7 +21,7 @@ from .deactivate import (
     DeactivateTemperatureCreate,
     DeactivateTemperatureParams,
     DeactivateTemperatureResult,
-    DeactivateTemperatureCommandType
+    DeactivateTemperatureCommandType,
 )
 
 __all__ = [

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/__init__.py
@@ -16,6 +16,14 @@ from .await_temperature import (
     AwaitTemperatureCommandType
 )
 
+from .deactivate import (
+    DeactivateTemperature,
+    DeactivateTemperatureCreate,
+    DeactivateTemperatureParams,
+    DeactivateTemperatureResult,
+    DeactivateTemperatureCommandType
+)
+
 __all__ = [
     # temperatureModule/setTargetTemperature
     "SetTargetTemperature",
@@ -29,4 +37,10 @@ __all__ = [
     "AwaitTemperatureParams",
     "AwaitTemperatureResult",
     "AwaitTemperatureCommandType",
+    # temperatureModule/deactivateTemperature
+    "DeactivateTemperature",
+    "DeactivateTemperatureCreate",
+    "DeactivateTemperatureParams",
+    "DeactivateTemperatureResult",
+    "DeactivateTemperatureCommandType",
 ]

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/__init__.py
@@ -1,0 +1,19 @@
+"""Temperature Module protocol commands."""
+
+from .set_target_temperature import (
+    SetTargetTemperature,
+    SetTargetTemperatureCreate,
+    SetTargetTemperatureParams,
+    SetTargetTemperatureResult,
+    SetTargetTemperatureCommandType
+)
+
+
+__all__ = [
+    # temperatureModule/setTargetTemperature
+    "SetTargetTemperature",
+    "SetTargetTemperatureCreate",
+    "SetTargetTemperatureParams",
+    "SetTargetTemperatureResult",
+    "SetTargetTemperatureCommandType",
+]

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/__init__.py
@@ -8,6 +8,13 @@ from .set_target_temperature import (
     SetTargetTemperatureCommandType
 )
 
+from .await_temperature import (
+    AwaitTemperature,
+    AwaitTemperatureCreate,
+    AwaitTemperatureParams,
+    AwaitTemperatureResult,
+    AwaitTemperatureCommandType
+)
 
 __all__ = [
     # temperatureModule/setTargetTemperature
@@ -16,4 +23,10 @@ __all__ = [
     "SetTargetTemperatureParams",
     "SetTargetTemperatureResult",
     "SetTargetTemperatureCommandType",
+    # temperatureModule/awaitTemperature
+    "AwaitTemperature",
+    "AwaitTemperatureCreate",
+    "AwaitTemperatureParams",
+    "AwaitTemperatureResult",
+    "AwaitTemperatureCommandType",
 ]

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/await_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/await_temperature.py
@@ -72,7 +72,7 @@ class AwaitTemperature(
     """A command to set a Temperature Module's target temperature."""
 
     commandType: AwaitTemperatureCommandType = (
-        "temperatureModule/AwaitTemperature"
+        "temperatureModule/awaitTemperature"
     )
     params: AwaitTemperatureParams
     result: Optional[AwaitTemperatureResult]

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/await_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/await_temperature.py
@@ -1,0 +1,91 @@
+"""Command models to wait for target temperature of a Temperature Module."""
+from __future__ import annotations
+from typing import Optional, TYPE_CHECKING
+from typing_extensions import Literal, Type
+
+from pydantic import BaseModel, Field
+
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+if TYPE_CHECKING:
+    from opentrons.protocol_engine.state import StateView
+    from opentrons.protocol_engine.execution import EquipmentHandler
+
+AwaitTemperatureCommandType = Literal[
+    "temperatureModule/awaitTemperature"
+]
+
+
+class AwaitTemperatureParams(BaseModel):
+    """Input parameters to wait for a Temperature Module's target temperature."""
+
+    moduleId: str = Field(..., description="Unique ID of the Temperature Module.")
+
+
+class AwaitTemperatureResult(BaseModel):
+    """Result data from waiting for a Temperature Module's target temperature."""
+
+
+class AwaitTemperatureImpl(
+    AbstractCommandImpl[
+        AwaitTemperatureParams, AwaitTemperatureResult
+    ]
+):
+    """Execution implementation of a Temperature Module's await temperature command."""
+
+    def __init__(
+        self,
+        state_view: StateView,
+        equipment: EquipmentHandler,
+        **unused_dependencies: object,
+    ) -> None:
+        self._state_view = state_view
+        self._equipment = equipment
+
+    async def execute(
+        self,
+        params: AwaitTemperatureParams
+    ) -> AwaitTemperatureResult:
+        """Wait for a Temperature Module's target temperature."""
+        # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
+        module_substate = self._state_view.modules.get_temperature_module_substate(
+            module_id=params.moduleId
+        )
+
+        # Raises error if no target temperature
+        target_temp = module_substate.get_plate_target_temperature()
+
+        # Allow propagation of ModuleNotAttachedError.
+        temp_hardware_module = self._equipment.get_module_hardware_api(
+            module_substate.module_id
+        )
+
+        if temp_hardware_module is not None:
+            await temp_hardware_module.await_temperature(
+                awaiting_temperature=target_temp)
+        return AwaitTemperatureResult()
+
+
+class AwaitTemperature(
+    BaseCommand[AwaitTemperatureParams, AwaitTemperatureResult]
+):
+    """A command to set a Temperature Module's target temperature."""
+
+    commandType: AwaitTemperatureCommandType = (
+        "temperatureModule/AwaitTemperature"
+    )
+    params: AwaitTemperatureParams
+    result: Optional[AwaitTemperatureResult]
+
+    _ImplementationCls: Type[AwaitTemperatureImpl] = AwaitTemperatureImpl
+
+
+class AwaitTemperatureCreate(
+    BaseCommandCreate[AwaitTemperatureParams]
+):
+    """A request to create a Temperature Module's set temperature command."""
+
+    commandType: AwaitTemperatureCommandType
+    params: AwaitTemperatureParams
+
+    _CommandCls: Type[AwaitTemperature] = AwaitTemperature

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/await_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/await_temperature.py
@@ -11,9 +11,7 @@ if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
     from opentrons.protocol_engine.execution import EquipmentHandler
 
-AwaitTemperatureCommandType = Literal[
-    "temperatureModule/awaitTemperature"
-]
+AwaitTemperatureCommandType = Literal["temperatureModule/awaitTemperature"]
 
 
 class AwaitTemperatureParams(BaseModel):
@@ -27,9 +25,7 @@ class AwaitTemperatureResult(BaseModel):
 
 
 class AwaitTemperatureImpl(
-    AbstractCommandImpl[
-        AwaitTemperatureParams, AwaitTemperatureResult
-    ]
+    AbstractCommandImpl[AwaitTemperatureParams, AwaitTemperatureResult]
 ):
     """Execution implementation of a Temperature Module's await temperature command."""
 
@@ -42,10 +38,7 @@ class AwaitTemperatureImpl(
         self._state_view = state_view
         self._equipment = equipment
 
-    async def execute(
-        self,
-        params: AwaitTemperatureParams
-    ) -> AwaitTemperatureResult:
+    async def execute(self, params: AwaitTemperatureParams) -> AwaitTemperatureResult:
         """Wait for a Temperature Module's target temperature."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
         module_substate = self._state_view.modules.get_temperature_module_substate(
@@ -62,27 +55,22 @@ class AwaitTemperatureImpl(
 
         if temp_hardware_module is not None:
             await temp_hardware_module.await_temperature(
-                awaiting_temperature=target_temp)
+                awaiting_temperature=target_temp
+            )
         return AwaitTemperatureResult()
 
 
-class AwaitTemperature(
-    BaseCommand[AwaitTemperatureParams, AwaitTemperatureResult]
-):
+class AwaitTemperature(BaseCommand[AwaitTemperatureParams, AwaitTemperatureResult]):
     """A command to set a Temperature Module's target temperature."""
 
-    commandType: AwaitTemperatureCommandType = (
-        "temperatureModule/awaitTemperature"
-    )
+    commandType: AwaitTemperatureCommandType = "temperatureModule/awaitTemperature"
     params: AwaitTemperatureParams
     result: Optional[AwaitTemperatureResult]
 
     _ImplementationCls: Type[AwaitTemperatureImpl] = AwaitTemperatureImpl
 
 
-class AwaitTemperatureCreate(
-    BaseCommandCreate[AwaitTemperatureParams]
-):
+class AwaitTemperatureCreate(BaseCommandCreate[AwaitTemperatureParams]):
     """A request to create a Temperature Module's set temperature command."""
 
     commandType: AwaitTemperatureCommandType

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/deactivate.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/deactivate.py
@@ -62,9 +62,8 @@ class DeactivateTemperature(
 ):
     """A command to deactivate a Temperature Module."""
 
-    commandType: DeactivateTemperatureCommandType = (
-        "temperatureModule/deactivateTemperature"
-    )
+    commandType: DeactivateTemperatureCommandType = "temperatureModule/deactivate"
+
     params: DeactivateTemperatureParams
     result: Optional[DeactivateTemperatureResult]
 

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/deactivate.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/deactivate.py
@@ -1,0 +1,87 @@
+"""Command models to deactivate a Temperature Module."""
+from __future__ import annotations
+from typing import Optional, TYPE_CHECKING
+from typing_extensions import Literal, Type
+
+from pydantic import BaseModel, Field
+
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+if TYPE_CHECKING:
+    from opentrons.protocol_engine.state import StateView
+    from opentrons.protocol_engine.execution import EquipmentHandler
+
+DeactivateTemperatureCommandType = Literal[
+    "temperatureModule/deactivateTemperature"
+]
+
+
+class DeactivateTemperatureParams(BaseModel):
+    """Input parameters to deactivate a Temperature Module."""
+
+    moduleId: str = Field(..., description="Unique ID of the Temperature Module.")
+
+
+class DeactivateTemperatureResult(BaseModel):
+    """Result data from deactivating a Temperature Module."""
+
+
+class DeactivateTemperatureImpl(
+    AbstractCommandImpl[
+        DeactivateTemperatureParams, DeactivateTemperatureResult
+    ]
+):
+    """Execution implementation of a Temperature Module's deactivate command."""
+
+    def __init__(
+        self,
+        state_view: StateView,
+        equipment: EquipmentHandler,
+        **unused_dependencies: object,
+    ) -> None:
+        self._state_view = state_view
+        self._equipment = equipment
+
+    async def execute(
+        self,
+        params: DeactivateTemperatureParams
+    ) -> DeactivateTemperatureResult:
+        """Deactivate a Temperature Module."""
+        # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
+        module_substate = self._state_view.modules.get_temperature_module_substate(
+            module_id=params.moduleId
+        )
+
+        # Allow propagation of ModuleNotAttachedError.
+        temp_hardware_module = self._equipment.get_module_hardware_api(
+            module_substate.module_id
+        )
+
+        if temp_hardware_module is not None:
+            await temp_hardware_module.deactivate()
+        return DeactivateTemperatureResult()
+
+
+class DeactivateTemperature(
+    BaseCommand[DeactivateTemperatureParams, DeactivateTemperatureResult]
+):
+    """A command to deactivate a Temperature Module."""
+
+    commandType: DeactivateTemperatureCommandType = (
+        "temperatureModule/deactivateTemperature"
+    )
+    params: DeactivateTemperatureParams
+    result: Optional[DeactivateTemperatureResult]
+
+    _ImplementationCls: Type[DeactivateTemperatureImpl] = DeactivateTemperatureImpl
+
+
+class DeactivateTemperatureCreate(
+    BaseCommandCreate[DeactivateTemperatureParams]
+):
+    """A request to deactivate a Temperature Module."""
+
+    commandType: DeactivateTemperatureCommandType
+    params: DeactivateTemperatureParams
+
+    _CommandCls: Type[DeactivateTemperature] = DeactivateTemperature

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/deactivate.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/deactivate.py
@@ -11,9 +11,7 @@ if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
     from opentrons.protocol_engine.execution import EquipmentHandler
 
-DeactivateTemperatureCommandType = Literal[
-    "temperatureModule/deactivateTemperature"
-]
+DeactivateTemperatureCommandType = Literal["temperatureModule/deactivateTemperature"]
 
 
 class DeactivateTemperatureParams(BaseModel):
@@ -27,9 +25,7 @@ class DeactivateTemperatureResult(BaseModel):
 
 
 class DeactivateTemperatureImpl(
-    AbstractCommandImpl[
-        DeactivateTemperatureParams, DeactivateTemperatureResult
-    ]
+    AbstractCommandImpl[DeactivateTemperatureParams, DeactivateTemperatureResult]
 ):
     """Execution implementation of a Temperature Module's deactivate command."""
 
@@ -43,8 +39,7 @@ class DeactivateTemperatureImpl(
         self._equipment = equipment
 
     async def execute(
-        self,
-        params: DeactivateTemperatureParams
+        self, params: DeactivateTemperatureParams
     ) -> DeactivateTemperatureResult:
         """Deactivate a Temperature Module."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
@@ -76,9 +71,7 @@ class DeactivateTemperature(
     _ImplementationCls: Type[DeactivateTemperatureImpl] = DeactivateTemperatureImpl
 
 
-class DeactivateTemperatureCreate(
-    BaseCommandCreate[DeactivateTemperatureParams]
-):
+class DeactivateTemperatureCreate(BaseCommandCreate[DeactivateTemperatureParams]):
     """A request to deactivate a Temperature Module."""
 
     commandType: DeactivateTemperatureCommandType

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/deactivate.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/deactivate.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
     from opentrons.protocol_engine.execution import EquipmentHandler
 
-DeactivateTemperatureCommandType = Literal["temperatureModule/deactivateTemperature"]
+DeactivateTemperatureCommandType = Literal["temperatureModule/deactivate"]
 
 
 class DeactivateTemperatureParams(BaseModel):

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/set_target_temperature.py
@@ -11,9 +11,7 @@ if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
     from opentrons.protocol_engine.execution import EquipmentHandler
 
-SetTargetTemperatureCommandType = Literal[
-    "temperatureModule/setTargetTemperature"
-]
+SetTargetTemperatureCommandType = Literal["temperatureModule/setTargetTemperature"]
 
 
 class SetTargetTemperatureParams(BaseModel):
@@ -28,9 +26,7 @@ class SetTargetTemperatureResult(BaseModel):
 
 
 class SetTargetTemperatureImpl(
-    AbstractCommandImpl[
-        SetTargetTemperatureParams, SetTargetTemperatureResult
-    ]
+    AbstractCommandImpl[SetTargetTemperatureParams, SetTargetTemperatureResult]
 ):
     """Execution implementation of a Temperature Module's set temperature command."""
 
@@ -44,8 +40,7 @@ class SetTargetTemperatureImpl(
         self._equipment = equipment
 
     async def execute(
-        self,
-        params: SetTargetTemperatureParams
+        self, params: SetTargetTemperatureParams
     ) -> SetTargetTemperatureResult:
         """Set a Temperature Module's target temperature."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
@@ -80,9 +75,7 @@ class SetTargetTemperature(
     _ImplementationCls: Type[SetTargetTemperatureImpl] = SetTargetTemperatureImpl
 
 
-class SetTargetTemperatureCreate(
-    BaseCommandCreate[SetTargetTemperatureParams]
-):
+class SetTargetTemperatureCreate(BaseCommandCreate[SetTargetTemperatureParams]):
     """A request to create a Temperature Module's set temperature command."""
 
     commandType: SetTargetTemperatureCommandType

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/set_target_temperature.py
@@ -24,6 +24,12 @@ class SetTargetTemperatureParams(BaseModel):
 class SetTargetTemperatureResult(BaseModel):
     """Result data from setting a Temperature Module's target temperature."""
 
+    targetTemperature: float = Field(
+        ...,
+        description="The target temperature that was set after validation "
+        "and type conversion (if any).",
+    )
+
 
 class SetTargetTemperatureImpl(
     AbstractCommandImpl[SetTargetTemperatureParams, SetTargetTemperatureResult]
@@ -58,7 +64,7 @@ class SetTargetTemperatureImpl(
 
         if temp_hardware_module is not None:
             await temp_hardware_module.start_set_temperature(celsius=validated_temp)
-        return SetTargetTemperatureResult()
+        return SetTargetTemperatureResult(targetTemperature=validated_temp)
 
 
 class SetTargetTemperature(

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/set_target_temperature.py
@@ -1,0 +1,91 @@
+"""Command models to start heating a Temperature Module."""
+from __future__ import annotations
+from typing import Optional, TYPE_CHECKING
+from typing_extensions import Literal, Type
+
+from pydantic import BaseModel, Field
+
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+if TYPE_CHECKING:
+    from opentrons.protocol_engine.state import StateView
+    from opentrons.protocol_engine.execution import EquipmentHandler
+
+SetTargetTemperatureCommandType = Literal[
+    "temperatureModule/setTargetTemperature"
+]
+
+
+class SetTargetTemperatureParams(BaseModel):
+    """Input parameters to set a Temperature Module's target temperature."""
+
+    moduleId: str = Field(..., description="Unique ID of the Temperature Module.")
+    temperature: float = Field(..., description="Target temperature in °C.")
+
+
+class SetTargetTemperatureResult(BaseModel):
+    """Result data from setting a Temperature Module's target temperature."""
+
+
+class SetTargetTemperatureImpl(
+    AbstractCommandImpl[
+        SetTargetTemperatureParams, SetTargetTemperatureResult
+    ]
+):
+    """Execution implementation of a Temperature Module's set temperature command."""
+
+    def __init__(
+        self,
+        state_view: StateView,
+        equipment: EquipmentHandler,
+        **unused_dependencies: object,
+    ) -> None:
+        self._state_view = state_view
+        self._equipment = equipment
+
+    async def execute(
+        self,
+        params: SetTargetTemperatureParams
+    ) -> SetTargetTemperatureResult:
+        """Set a Temperature Module's target temperature."""
+        # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
+        module_substate = self._state_view.modules.get_temperature_module_substate(
+            module_id=params.moduleId
+        )
+
+        # Verify temperature from temperature module view
+        validated_temp = module_substate.validate_target_temperature(params.temperature)
+
+        # Allow propagation of ModuleNotAttachedError.
+        temp_hardware_module = self._equipment.get_module_hardware_api(
+            module_substate.module_id
+        )
+
+        if temp_hardware_module is not None:
+            await temp_hardware_module.start_set_temperature(celsius=validated_temp)
+        return SetTargetTemperatureResult()
+
+
+class SetTargetTemperature(
+    BaseCommand[SetTargetTemperatureParams, SetTargetTemperatureResult]
+):
+    """A command to set a Temperature Module's target temperature."""
+
+    commandType: SetTargetTemperatureCommandType = (
+        "temperatureModule/setTargetTemperature"
+    )
+    params: SetTargetTemperatureParams
+    result: Optional[SetTargetTemperatureResult]
+
+    _ImplementationCls: Type[SetTargetTemperatureImpl] = SetTargetTemperatureImpl
+
+
+class SetTargetTemperatureCreate(
+    BaseCommandCreate[SetTargetTemperatureParams]
+):
+    """A request to create a Temperature Module's set temperature command."""
+
+    commandType: SetTargetTemperatureCommandType
+    params: SetTargetTemperatureParams
+
+    _CommandCls: Type[SetTargetTemperature] = SetTargetTemperature

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -6,15 +6,24 @@ from opentrons.calibration_storage.helpers import uri_from_details
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.types import MountType
 from opentrons.hardware_control import HardwareControlAPI
-from opentrons.hardware_control.modules import AbstractModule, MagDeck, HeaterShaker
-
+from opentrons.hardware_control.modules import (
+    AbstractModule,
+    MagDeck,
+    HeaterShaker,
+    TempDeck
+)
+from opentrons.protocol_engine.state.module_substates import (
+    MagneticModuleId,
+    HeaterShakerModuleId,
+    TemperatureModuleId,
+)
 from ..errors import (
     FailedToLoadPipetteError,
     LabwareDefinitionDoesNotExistError,
     ModuleNotAttachedError,
 )
 from ..resources import LabwareDataProvider, ModuleDataProvider, ModelUtils
-from ..state import StateStore, HardwareModule, MagneticModuleId, HeaterShakerModuleId
+from ..state import StateStore, HardwareModule
 from ..types import (
     LabwareLocation,
     PipetteName,
@@ -246,6 +255,13 @@ class EquipmentHandler:
         self,
         module_id: HeaterShakerModuleId,
     ) -> Optional[HeaterShaker]:
+        ...
+
+    @overload
+    def get_module_hardware_api(
+        self,
+        module_id: TemperatureModuleId,
+    ) -> Optional[TempDeck]:
         ...
 
     def get_module_hardware_api(self, module_id: str) -> Optional[AbstractModule]:

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -10,7 +10,7 @@ from opentrons.hardware_control.modules import (
     AbstractModule,
     MagDeck,
     HeaterShaker,
-    TempDeck
+    TempDeck,
 )
 from opentrons.protocol_engine.state.module_substates import (
     MagneticModuleId,

--- a/api/src/opentrons/protocol_engine/state/module_substates/__init__.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/__init__.py
@@ -6,13 +6,21 @@ from .heater_shaker_module_substate import (
     HeaterShakerModuleSubState,
     HeaterShakerModuleId,
 )
+from .temperature_module_substate import TemperatureModuleSubState, TemperatureModuleId
 
-ModuleSubStateType = Union[HeaterShakerModuleSubState, MagneticModuleSubState]
+ModuleSubStateType = Union[
+    HeaterShakerModuleSubState,
+    MagneticModuleSubState,
+    TemperatureModuleSubState,
+]
 
 __all__ = [
     "MagneticModuleSubState",
     "MagneticModuleId",
     "HeaterShakerModuleSubState",
     "HeaterShakerModuleId",
+    "TemperatureModuleSubState",
+    "TemperatureModuleId",
+    # Union of all module substates
     "ModuleSubStateType",
 ]

--- a/api/src/opentrons/protocol_engine/state/module_substates/heater_shaker_module_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/heater_shaker_module_substate.py
@@ -1,6 +1,6 @@
 """Heater-Shaker Module sub-state."""
 from dataclasses import dataclass
-from typing import NewType, NamedTuple, Optional
+from typing import NewType, Optional
 
 from opentrons.protocol_engine.types import TemperatureRange, SpeedRange
 from opentrons.protocol_engine.errors import (

--- a/api/src/opentrons/protocol_engine/state/module_substates/heater_shaker_module_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/heater_shaker_module_substate.py
@@ -2,6 +2,7 @@
 from dataclasses import dataclass
 from typing import NewType, NamedTuple, Optional
 
+from opentrons.protocol_engine.types import TemperatureRange, SpeedRange
 from opentrons.protocol_engine.errors import (
     InvalidTargetTemperatureError,
     InvalidTargetSpeedError,
@@ -9,20 +10,6 @@ from opentrons.protocol_engine.errors import (
 )
 
 HeaterShakerModuleId = NewType("HeaterShakerModuleId", str)
-
-
-class SpeedRange(NamedTuple):
-    """Minimum and maximum allowed speeds for a shaking module."""
-
-    min: int
-    max: int
-
-
-class TemperatureRange(NamedTuple):
-    """Minimum and maximum allowed temperatures for a heating module."""
-
-    min: float
-    max: float
 
 
 # TODO (spp, 2022-03-22): Move these values to heater-shaker module definition.

--- a/api/src/opentrons/protocol_engine/state/module_substates/temperature_module_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/temperature_module_substate.py
@@ -24,11 +24,12 @@ class TemperatureModuleSubState:
     """
 
     module_id: TemperatureModuleId
-    plate_target_temperature: Optional[int]
+    plate_target_temperature: Optional[float]
 
     @staticmethod
     def validate_target_temperature(celsius: float) -> int:
-        """Verify target temperature is within range and convert to int."""
+        """Verify target temperature is within range and of correct type."""
+        # Both Gen1 & 2 Temperature modules use 0 decimal precision.
         celsius_int = int(round(celsius, 0))
         if (
             TEMP_MODULE_TEMPERATURE_RANGE.min
@@ -42,7 +43,7 @@ class TemperatureModuleSubState:
                 f" Valid range is {TEMP_MODULE_TEMPERATURE_RANGE}."
             )
 
-    def get_plate_target_temperature(self) -> int:
+    def get_plate_target_temperature(self) -> float:
         """Get the module's target plate temperature."""
         target = self.plate_target_temperature
 

--- a/api/src/opentrons/protocol_engine/state/module_substates/temperature_module_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/temperature_module_substate.py
@@ -1,23 +1,15 @@
 """Temperature module sub-state."""
 
 from dataclasses import dataclass
-from typing import NewType, NamedTuple, Optional
+from typing import NewType, Optional
 
-from opentrons.protocol_engine.types import TemperatureModuleModel
+from opentrons.protocol_engine.types import TemperatureRange
 from opentrons.protocol_engine.errors import (
     InvalidTargetTemperatureError,
-    NoTargetTemperatureSetError
+    NoTargetTemperatureSetError,
 )
 
 TemperatureModuleId = NewType("TemperatureModuleId", str)
-
-
-class TemperatureRange(NamedTuple):
-    """Minimum and maximum allowed temperatures for a heating module."""
-
-    min: float
-    max: float
-
 
 # TODO (spp, 2022-03-22): Move these values to temperature module definition.
 TEMP_MODULE_TEMPERATURE_RANGE = TemperatureRange(min=-9, max=99)
@@ -38,9 +30,10 @@ class TemperatureModuleSubState:
     def validate_target_temperature(celsius: float) -> int:
         """Verify target temperature is within range and convert to int."""
         celsius_int = int(round(celsius, 0))
-        if (TEMP_MODULE_TEMPERATURE_RANGE.min
-                <= celsius_int
-                <= TEMP_MODULE_TEMPERATURE_RANGE.max
+        if (
+            TEMP_MODULE_TEMPERATURE_RANGE.min
+            <= celsius_int
+            <= TEMP_MODULE_TEMPERATURE_RANGE.max
         ):
             return celsius_int
         else:

--- a/api/src/opentrons/protocol_engine/state/module_substates/temperature_module_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/temperature_module_substate.py
@@ -1,10 +1,13 @@
 """Temperature module sub-state."""
 
 from dataclasses import dataclass
-from typing import NewType, NamedTuple
+from typing import NewType, NamedTuple, Optional
 
 from opentrons.protocol_engine.types import TemperatureModuleModel
-from opentrons.protocol_engine.errors import InvalidTargetTemperatureError
+from opentrons.protocol_engine.errors import (
+    InvalidTargetTemperatureError,
+    NoTargetTemperatureSetError
+)
 
 TemperatureModuleId = NewType("TemperatureModuleId", str)
 
@@ -29,6 +32,7 @@ class TemperatureModuleSubState:
     """
 
     module_id: TemperatureModuleId
+    plate_target_temperature: Optional[int]
 
     @staticmethod
     def validate_target_temperature(celsius: float) -> int:
@@ -44,3 +48,13 @@ class TemperatureModuleSubState:
                 f"Temperature module got an invalid temperature {celsius} °C."
                 f" Valid range is {TEMP_MODULE_TEMPERATURE_RANGE}."
             )
+
+    def get_plate_target_temperature(self) -> int:
+        """Get the module's target plate temperature."""
+        target = self.plate_target_temperature
+
+        if target is None:
+            raise NoTargetTemperatureSetError(
+                f"Module {self.module_id} does not have a target temperature set."
+            )
+        return target

--- a/api/src/opentrons/protocol_engine/state/module_substates/temperature_module_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/temperature_module_substate.py
@@ -1,0 +1,20 @@
+"""Temperature module sub-state."""
+
+from dataclasses import dataclass
+from typing import NewType
+
+from opentrons.protocol_engine.types import TemperatureModuleModel, ModuleModel
+
+TemperatureModuleId = NewType("TemperatureModuleId", str)
+
+
+@dataclass(frozen=True)
+class TemperatureModuleSubState:
+    """Temperature Module specific state.
+
+    Provides calculations and read-only state access
+    for an individual loaded Temperaute Module.
+    """
+
+    module_id: TemperatureModuleId
+    model: TemperatureModuleModel

--- a/api/src/opentrons/protocol_engine/state/module_substates/temperature_module_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/temperature_module_substate.py
@@ -1,11 +1,23 @@
 """Temperature module sub-state."""
 
 from dataclasses import dataclass
-from typing import NewType
+from typing import NewType, NamedTuple
 
-from opentrons.protocol_engine.types import TemperatureModuleModel, ModuleModel
+from opentrons.protocol_engine.types import TemperatureModuleModel
+from opentrons.protocol_engine.errors import InvalidTargetTemperatureError
 
 TemperatureModuleId = NewType("TemperatureModuleId", str)
+
+
+class TemperatureRange(NamedTuple):
+    """Minimum and maximum allowed temperatures for a heating module."""
+
+    min: float
+    max: float
+
+
+# TODO (spp, 2022-03-22): Move these values to temperature module definition.
+TEMP_MODULE_TEMPERATURE_RANGE = TemperatureRange(min=-9, max=99)
 
 
 @dataclass(frozen=True)
@@ -17,4 +29,18 @@ class TemperatureModuleSubState:
     """
 
     module_id: TemperatureModuleId
-    model: TemperatureModuleModel
+
+    @staticmethod
+    def validate_target_temperature(celsius: float) -> int:
+        """Verify target temperature is within range and convert to int."""
+        celsius_int = int(round(celsius, 0))
+        if (TEMP_MODULE_TEMPERATURE_RANGE.min
+                <= celsius_int
+                <= TEMP_MODULE_TEMPERATURE_RANGE.max
+        ):
+            return celsius_int
+        else:
+            raise InvalidTargetTemperatureError(
+                f"Temperature module got an invalid temperature {celsius} °C."
+                f" Valid range is {TEMP_MODULE_TEMPERATURE_RANGE}."
+            )

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -210,7 +210,7 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
                 # Not sure if a float conversion here is a good idea.
                 # But it won't be right to let target_temperature be a float
                 # since it might lead to problems with await command.
-                # Should we add the converted target to result?
+                # Should we add the converted target to SetTargetTemperatureResult?
                 plate_target_temperature=int(round(command.params.temperature, 0)),
             )
         elif isinstance(command.result, temperature_module.DeactivateTemperatureResult):

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -116,7 +116,7 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
                 self._state.substate_by_module_id[
                     module_id
                 ] = TemperatureModuleSubState(
-                    module_id=TemperatureModuleId(module_id), model=module_model
+                    module_id=TemperatureModuleId(module_id),
                 )
 
     def _handle_command(self, command: Command) -> None:
@@ -148,7 +148,7 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
                 self._state.substate_by_module_id[
                     module_id
                 ] = TemperatureModuleSubState(
-                    module_id=TemperatureModuleId(module_id), model=module_model
+                    module_id=TemperatureModuleId(module_id),
                 )
         if isinstance(
             command.result,

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -207,11 +207,7 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
         if isinstance(command.result, temperature_module.SetTargetTemperatureResult):
             self._state.substate_by_module_id[module_id] = TemperatureModuleSubState(
                 module_id=TemperatureModuleId(module_id),
-                # Not sure if a float conversion here is a good idea.
-                # But it won't be right to let target_temperature be a float
-                # since it might lead to problems with await command.
-                # Should we add the converted target to SetTargetTemperatureResult?
-                plate_target_temperature=int(round(command.params.temperature, 0)),
+                plate_target_temperature=command.result.targetTemperature,
             )
         elif isinstance(command.result, temperature_module.DeactivateTemperatureResult):
             self._state.substate_by_module_id[module_id] = TemperatureModuleSubState(

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -183,7 +183,8 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
         if isinstance(
             command.result,
                 (
-                    temperature_module.SetTargetTemperatureResult
+                    temperature_module.SetTargetTemperatureResult,
+                    temperature_module.DeactivateTemperatureResult,
                 )
         ):
             module_id = command.params.moduleId
@@ -198,7 +199,20 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
                     module_id
                 ] = TemperatureModuleSubState(
                     module_id=TemperatureModuleId(module_id),
+                    # Not sure if a float conversion here is a good idea.
+                    # But it won't be right to let target_temperature be a float
+                    # since it might lead to problems with await command.
+                    # Should we add the converted target to result?
                     plate_target_temperature=int(round(command.params.temperature, 0)),
+                )
+            elif isinstance(
+                command.result, temperature_module.DeactivateTemperatureResult
+            ):
+                self._state.substate_by_module_id[
+                    module_id
+                ] = TemperatureModuleSubState(
+                    module_id=TemperatureModuleId(module_id),
+                    plate_target_temperature=None
                 )
 
 

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from enum import Enum
 from dataclasses import dataclass
 from pydantic import BaseModel, Field
-from typing import Optional, Union, List, Dict, Any
+from typing import Optional, Union, List, Dict, Any, NamedTuple
 from typing_extensions import Literal, TypeGuard
 
 from opentrons.types import MountType, DeckSlotName
@@ -341,3 +341,17 @@ class LoadedLabware(BaseModel):
             " so the default of (0, 0, 0) will be used."
         ),
     )
+
+
+class SpeedRange(NamedTuple):
+    """Minimum and maximum allowed speeds for a shaking module."""
+
+    min: int
+    max: int
+
+
+class TemperatureRange(NamedTuple):
+    """Minimum and maximum allowed temperatures for a heating module."""
+
+    min: float
+    max: float

--- a/api/tests/opentrons/protocol_engine/commands/temperature_module/__init__.py
+++ b/api/tests/opentrons/protocol_engine/commands/temperature_module/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Temperature Module commands."""

--- a/api/tests/opentrons/protocol_engine/commands/temperature_module/test_await_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/temperature_module/test_await_temperature.py
@@ -1,0 +1,51 @@
+"""Test Temperature Module's await temperature command implementation."""
+from decoy import Decoy
+
+from opentrons.hardware_control.modules import TempDeck
+
+from opentrons.protocol_engine.state import StateView
+from opentrons.protocol_engine.state.module_substates import (
+    TemperatureModuleSubState,
+    TemperatureModuleId,
+)
+from opentrons.protocol_engine.execution import EquipmentHandler
+from opentrons.protocol_engine.commands import temperature_module
+from opentrons.protocol_engine.commands.temperature_module.await_temperature import (  # noqa: E501
+    AwaitTemperatureImpl
+)
+
+
+async def test_await_temperature(
+        decoy: Decoy,
+        state_view: StateView,
+        equipment: EquipmentHandler,
+) -> None:
+    """It should be able to wait for the module's target temperature."""
+    subject = AwaitTemperatureImpl(state_view=state_view, equipment=equipment)
+
+    data = temperature_module.AwaitTemperatureParams(moduleId="tempdeck-id")
+
+    module_substate = decoy.mock(cls=TemperatureModuleSubState)
+    tempdeck_hardware = decoy.mock(cls=TempDeck)
+
+    decoy.when(
+        state_view.modules.get_temperature_module_substate(
+            module_id="tempdeck-id"
+        )
+    ).then_return(module_substate)
+
+    decoy.when(module_substate.get_plate_target_temperature()).then_return(123)
+    decoy.when(module_substate.module_id).then_return(
+        TemperatureModuleId("tempdeck-id")
+    )
+
+    # Get stubbed hardware module from hs module view
+    decoy.when(
+        equipment.get_module_hardware_api(TemperatureModuleId("tempdeck-id"))
+    ).then_return(tempdeck_hardware)
+
+    result = await subject.execute(data)
+    decoy.verify(
+        await tempdeck_hardware.await_temperature(awaiting_temperature=123), times=1
+    )
+    assert result == temperature_module.AwaitTemperatureResult()

--- a/api/tests/opentrons/protocol_engine/commands/temperature_module/test_await_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/temperature_module/test_await_temperature.py
@@ -11,14 +11,14 @@ from opentrons.protocol_engine.state.module_substates import (
 from opentrons.protocol_engine.execution import EquipmentHandler
 from opentrons.protocol_engine.commands import temperature_module
 from opentrons.protocol_engine.commands.temperature_module.await_temperature import (  # noqa: E501
-    AwaitTemperatureImpl
+    AwaitTemperatureImpl,
 )
 
 
 async def test_await_temperature(
-        decoy: Decoy,
-        state_view: StateView,
-        equipment: EquipmentHandler,
+    decoy: Decoy,
+    state_view: StateView,
+    equipment: EquipmentHandler,
 ) -> None:
     """It should be able to wait for the module's target temperature."""
     subject = AwaitTemperatureImpl(state_view=state_view, equipment=equipment)
@@ -29,9 +29,7 @@ async def test_await_temperature(
     tempdeck_hardware = decoy.mock(cls=TempDeck)
 
     decoy.when(
-        state_view.modules.get_temperature_module_substate(
-            module_id="tempdeck-id"
-        )
+        state_view.modules.get_temperature_module_substate(module_id="tempdeck-id")
     ).then_return(module_substate)
 
     decoy.when(module_substate.get_plate_target_temperature()).then_return(123)

--- a/api/tests/opentrons/protocol_engine/commands/temperature_module/test_await_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/temperature_module/test_await_temperature.py
@@ -37,7 +37,7 @@ async def test_await_temperature(
         TemperatureModuleId("tempdeck-id")
     )
 
-    # Get stubbed hardware module from hs module view
+    # Get stubbed hardware module
     decoy.when(
         equipment.get_module_hardware_api(TemperatureModuleId("tempdeck-id"))
     ).then_return(tempdeck_hardware)

--- a/api/tests/opentrons/protocol_engine/commands/temperature_module/test_deactivate.py
+++ b/api/tests/opentrons/protocol_engine/commands/temperature_module/test_deactivate.py
@@ -1,0 +1,50 @@
+"""Test Temperature Module's await temperature command implementation."""
+from decoy import Decoy
+
+from opentrons.hardware_control.modules import TempDeck
+
+from opentrons.protocol_engine.state import StateView
+from opentrons.protocol_engine.state.module_substates import (
+    TemperatureModuleSubState,
+    TemperatureModuleId,
+)
+from opentrons.protocol_engine.execution import EquipmentHandler
+from opentrons.protocol_engine.commands import temperature_module
+from opentrons.protocol_engine.commands.temperature_module.deactivate import (  # noqa: E501
+    DeactivateTemperatureImpl
+)
+
+
+async def test_await_temperature(
+        decoy: Decoy,
+        state_view: StateView,
+        equipment: EquipmentHandler,
+) -> None:
+    """It should be able to wait for the module's target temperature."""
+    subject = DeactivateTemperatureImpl(state_view=state_view, equipment=equipment)
+
+    data = temperature_module.DeactivateTemperatureParams(moduleId="tempdeck-id")
+
+    module_substate = decoy.mock(cls=TemperatureModuleSubState)
+    tempdeck_hardware = decoy.mock(cls=TempDeck)
+
+    decoy.when(
+        state_view.modules.get_temperature_module_substate(
+            module_id="tempdeck-id"
+        )
+    ).then_return(module_substate)
+
+    decoy.when(module_substate.module_id).then_return(
+        TemperatureModuleId("tempdeck-id")
+    )
+
+    # Get stubbed hardware module from hs module view
+    decoy.when(
+        equipment.get_module_hardware_api(TemperatureModuleId("tempdeck-id"))
+    ).then_return(tempdeck_hardware)
+
+    result = await subject.execute(data)
+    decoy.verify(
+        await tempdeck_hardware.deactivate(), times=1
+    )
+    assert result == temperature_module.AwaitTemperatureResult()

--- a/api/tests/opentrons/protocol_engine/commands/temperature_module/test_deactivate.py
+++ b/api/tests/opentrons/protocol_engine/commands/temperature_module/test_deactivate.py
@@ -36,7 +36,7 @@ async def test_await_temperature(
         TemperatureModuleId("tempdeck-id")
     )
 
-    # Get stubbed hardware module from hs module view
+    # Get stubbed hardware module
     decoy.when(
         equipment.get_module_hardware_api(TemperatureModuleId("tempdeck-id"))
     ).then_return(tempdeck_hardware)

--- a/api/tests/opentrons/protocol_engine/commands/temperature_module/test_deactivate.py
+++ b/api/tests/opentrons/protocol_engine/commands/temperature_module/test_deactivate.py
@@ -11,14 +11,14 @@ from opentrons.protocol_engine.state.module_substates import (
 from opentrons.protocol_engine.execution import EquipmentHandler
 from opentrons.protocol_engine.commands import temperature_module
 from opentrons.protocol_engine.commands.temperature_module.deactivate import (  # noqa: E501
-    DeactivateTemperatureImpl
+    DeactivateTemperatureImpl,
 )
 
 
 async def test_await_temperature(
-        decoy: Decoy,
-        state_view: StateView,
-        equipment: EquipmentHandler,
+    decoy: Decoy,
+    state_view: StateView,
+    equipment: EquipmentHandler,
 ) -> None:
     """It should be able to wait for the module's target temperature."""
     subject = DeactivateTemperatureImpl(state_view=state_view, equipment=equipment)
@@ -29,9 +29,7 @@ async def test_await_temperature(
     tempdeck_hardware = decoy.mock(cls=TempDeck)
 
     decoy.when(
-        state_view.modules.get_temperature_module_substate(
-            module_id="tempdeck-id"
-        )
+        state_view.modules.get_temperature_module_substate(module_id="tempdeck-id")
     ).then_return(module_substate)
 
     decoy.when(module_substate.module_id).then_return(
@@ -44,7 +42,5 @@ async def test_await_temperature(
     ).then_return(tempdeck_hardware)
 
     result = await subject.execute(data)
-    decoy.verify(
-        await tempdeck_hardware.deactivate(), times=1
-    )
+    decoy.verify(await tempdeck_hardware.deactivate(), times=1)
     assert result == temperature_module.AwaitTemperatureResult()

--- a/api/tests/opentrons/protocol_engine/commands/temperature_module/test_set_target_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/temperature_module/test_set_target_temperature.py
@@ -11,7 +11,7 @@ from opentrons.protocol_engine.state.module_substates import (
 from opentrons.protocol_engine.execution import EquipmentHandler
 from opentrons.protocol_engine.commands import temperature_module
 from opentrons.protocol_engine.commands.temperature_module.set_target_temperature import (  # noqa: E501
-    SetTargetTemperatureImpl
+    SetTargetTemperatureImpl,
 )
 
 
@@ -32,9 +32,7 @@ async def test_set_target_temperature(
     tempdeck_hardware = decoy.mock(cls=TempDeck)
 
     decoy.when(
-        state_view.modules.get_temperature_module_substate(
-            module_id="tempdeck-id"
-        )
+        state_view.modules.get_temperature_module_substate(module_id="tempdeck-id")
     ).then_return(module_substate)
 
     decoy.when(module_substate.module_id).then_return(

--- a/api/tests/opentrons/protocol_engine/commands/temperature_module/test_set_target_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/temperature_module/test_set_target_temperature.py
@@ -1,0 +1,53 @@
+"""Test Temperature Module's set target temperature command implementation."""
+from decoy import Decoy
+
+from opentrons.hardware_control.modules import TempDeck
+
+from opentrons.protocol_engine.state import StateView
+from opentrons.protocol_engine.state.module_substates import (
+    TemperatureModuleSubState,
+    TemperatureModuleId,
+)
+from opentrons.protocol_engine.execution import EquipmentHandler
+from opentrons.protocol_engine.commands import temperature_module
+from opentrons.protocol_engine.commands.temperature_module.set_target_temperature import (  # noqa: E501
+    SetTargetTemperatureImpl
+)
+
+
+async def test_set_target_temperature(
+    decoy: Decoy,
+    state_view: StateView,
+    equipment: EquipmentHandler,
+) -> None:
+    """It should be able to set the specified module's target temperature."""
+    subject = SetTargetTemperatureImpl(state_view=state_view, equipment=equipment)
+
+    data = temperature_module.SetTargetTemperatureParams(
+        moduleId="tempdeck-id",
+        temperature=1.23,
+    )
+
+    module_substate = decoy.mock(cls=TemperatureModuleSubState)
+    tempdeck_hardware = decoy.mock(cls=TempDeck)
+
+    decoy.when(
+        state_view.modules.get_temperature_module_substate(
+            module_id="tempdeck-id"
+        )
+    ).then_return(module_substate)
+
+    decoy.when(module_substate.module_id).then_return(
+        TemperatureModuleId("tempdeck-id")
+    )
+
+    # Stub temperature validation
+    decoy.when(module_substate.validate_target_temperature(celsius=1.23)).then_return(1)
+    # Get attached hardware modules
+    decoy.when(
+        equipment.get_module_hardware_api(TemperatureModuleId("tempdeck-id"))
+    ).then_return(tempdeck_hardware)
+
+    result = await subject.execute(data)
+    decoy.verify(await tempdeck_hardware.start_set_temperature(celsius=1), times=1)
+    assert result == temperature_module.SetTargetTemperatureResult()

--- a/api/tests/opentrons/protocol_engine/commands/temperature_module/test_set_target_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/temperature_module/test_set_target_temperature.py
@@ -41,7 +41,8 @@ async def test_set_target_temperature(
 
     # Stub temperature validation
     decoy.when(module_substate.validate_target_temperature(celsius=1.23)).then_return(1)
-    # Get attached hardware modules
+
+    # Get stubbed hardware module
     decoy.when(
         equipment.get_module_hardware_api(TemperatureModuleId("tempdeck-id"))
     ).then_return(tempdeck_hardware)

--- a/api/tests/opentrons/protocol_engine/commands/temperature_module/test_set_target_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/temperature_module/test_set_target_temperature.py
@@ -49,4 +49,4 @@ async def test_set_target_temperature(
 
     result = await subject.execute(data)
     decoy.verify(await tempdeck_hardware.start_set_temperature(celsius=1), times=1)
-    assert result == temperature_module.SetTargetTemperatureResult()
+    assert result == temperature_module.SetTargetTemperatureResult(targetTemperature=1)

--- a/api/tests/opentrons/protocol_engine/state/test_module_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_store.py
@@ -218,9 +218,9 @@ def test_handle_tempdeck_temperature_commands(
     )
     set_temp_cmd = temp_commands.SetTargetTemperature.construct(  # type: ignore[call-arg]  # noqa: E501
         params=temp_commands.SetTargetTemperatureParams(
-            moduleId="module-id", temperature=42
+            moduleId="module-id", temperature=42.4
         ),
-        result=temp_commands.SetTargetTemperatureResult(),
+        result=temp_commands.SetTargetTemperatureResult(targetTemperature=42),
     )
     deactivate_cmd = temp_commands.DeactivateTemperature.construct(  # type: ignore[call-arg]  # noqa: E501
         params=temp_commands.DeactivateTemperatureParams(moduleId="module-id"),

--- a/api/tests/opentrons/protocol_engine/state/test_module_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_store.py
@@ -4,7 +4,10 @@ from pytest_lazyfixture import lazy_fixture  # type: ignore[import]
 
 from opentrons.types import DeckSlotName
 from opentrons.protocol_engine import commands, actions
-from opentrons.protocol_engine.commands import heater_shaker as hs_commands
+from opentrons.protocol_engine.commands import (
+    heater_shaker as hs_commands,
+    temperature_module as temp_commands
+)
 from opentrons.protocol_engine.types import (
     DeckSlotLocation,
     ModuleDefinition,
@@ -63,6 +66,7 @@ def test_initial_state() -> None:
             ModuleModel.TEMPERATURE_MODULE_V1,
             TemperatureModuleSubState(
                 module_id=TemperatureModuleId("module-id"),
+                plate_target_temperature=None
             ),
         )
     ],
@@ -124,6 +128,7 @@ def test_load_module(
             lazy_fixture("tempdeck_v2_def"),
             TemperatureModuleSubState(
                 module_id=TemperatureModuleId("module-id"),
+                plate_target_temperature=None
             )
         )
     ],
@@ -154,7 +159,7 @@ def test_add_module_action(
     )
 
 
-def test_handle_temperature_commands(heater_shaker_v1_def: ModuleDefinition) -> None:
+def test_handle_hs_temperature_commands(heater_shaker_v1_def: ModuleDefinition) -> None:
     """It should update `plate_target_temperature` correctly."""
     load_module_cmd = commands.LoadModule.construct(  # type: ignore[call-arg]
         params=commands.LoadModuleParams(
@@ -193,3 +198,46 @@ def test_handle_temperature_commands(heater_shaker_v1_def: ModuleDefinition) -> 
             module_id=HeaterShakerModuleId("module-id"), plate_target_temperature=None
         )
     }
+
+
+def test_handle_tempdeck_temperature_commands(
+        tempdeck_v2_def: ModuleDefinition
+) -> None:
+    """It should update Tempdeck's `plate_target_temperature` correctly."""
+    load_module_cmd = commands.LoadModule.construct(  # type: ignore[call-arg]
+        params=commands.LoadModuleParams(
+            model=ModuleModel.TEMPERATURE_MODULE_V2,
+            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+        ),
+        result=commands.LoadModuleResult(
+            moduleId="module-id",
+            model=ModuleModel.TEMPERATURE_MODULE_V2,
+            serialNumber="serial-number",
+            definition=tempdeck_v2_def,
+        ),
+    )
+    set_temp_cmd = temp_commands.SetTargetTemperature.construct(  # type: ignore[call-arg]  # noqa: E501
+        params=temp_commands.SetTargetTemperatureParams(
+            moduleId="module-id", temperature=42
+        ),
+        result=temp_commands.SetTargetTemperatureResult(),
+    )
+    # deactivate_cmd = hs_commands.DeactivateHeater.construct(  # type: ignore[call-arg]
+    #     params=hs_commands.DeactivateHeaterParams(moduleId="module-id"),
+    #     result=hs_commands.DeactivateHeaterResult(),
+    # )
+    subject = ModuleStore()
+
+    subject.handle_action(actions.UpdateCommandAction(command=load_module_cmd))
+    subject.handle_action(actions.UpdateCommandAction(command=set_temp_cmd))
+    assert subject.state.substate_by_module_id == {
+        "module-id": TemperatureModuleSubState(
+            module_id=TemperatureModuleId("module-id"), plate_target_temperature=42
+        )
+    }
+    # subject.handle_action(actions.UpdateCommandAction(command=deactivate_cmd))
+    # assert subject.state.substate_by_module_id == {
+    #     "module-id": HeaterShakerModuleSubState(
+    #         module_id=HeaterShakerModuleId("module-id"), plate_target_temperature=None
+    #     )
+    # }

--- a/api/tests/opentrons/protocol_engine/state/test_module_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_store.py
@@ -22,6 +22,8 @@ from opentrons.protocol_engine.state.module_substates import (
     MagneticModuleSubState,
     HeaterShakerModuleId,
     HeaterShakerModuleSubState,
+    TemperatureModuleId,
+    TemperatureModuleSubState,
     ModuleSubStateType,
 )
 
@@ -56,6 +58,14 @@ def test_initial_state() -> None:
                 plate_target_temperature=None,
             ),
         ),
+        (
+            lazy_fixture("tempdeck_v1_def"),
+            ModuleModel.TEMPERATURE_MODULE_V1,
+            TemperatureModuleSubState(
+                module_id=TemperatureModuleId("module-id"),
+                model=ModuleModel.TEMPERATURE_MODULE_V1,
+            ),
+        )
     ],
 )
 def test_load_module(
@@ -111,6 +121,13 @@ def test_load_module(
                 plate_target_temperature=None,
             ),
         ),
+        (
+            lazy_fixture("tempdeck_v2_def"),
+            TemperatureModuleSubState(
+                module_id=TemperatureModuleId("module-id"),
+                model=ModuleModel.TEMPERATURE_MODULE_V2
+            )
+        )
     ],
 )
 def test_add_module_action(

--- a/api/tests/opentrons/protocol_engine/state/test_module_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_store.py
@@ -6,7 +6,7 @@ from opentrons.types import DeckSlotName
 from opentrons.protocol_engine import commands, actions
 from opentrons.protocol_engine.commands import (
     heater_shaker as hs_commands,
-    temperature_module as temp_commands
+    temperature_module as temp_commands,
 )
 from opentrons.protocol_engine.types import (
     DeckSlotLocation,
@@ -66,9 +66,9 @@ def test_initial_state() -> None:
             ModuleModel.TEMPERATURE_MODULE_V1,
             TemperatureModuleSubState(
                 module_id=TemperatureModuleId("module-id"),
-                plate_target_temperature=None
+                plate_target_temperature=None,
             ),
-        )
+        ),
     ],
 )
 def test_load_module(
@@ -128,9 +128,9 @@ def test_load_module(
             lazy_fixture("tempdeck_v2_def"),
             TemperatureModuleSubState(
                 module_id=TemperatureModuleId("module-id"),
-                plate_target_temperature=None
-            )
-        )
+                plate_target_temperature=None,
+            ),
+        ),
     ],
 )
 def test_add_module_action(
@@ -201,7 +201,7 @@ def test_handle_hs_temperature_commands(heater_shaker_v1_def: ModuleDefinition) 
 
 
 def test_handle_tempdeck_temperature_commands(
-        tempdeck_v2_def: ModuleDefinition
+    tempdeck_v2_def: ModuleDefinition,
 ) -> None:
     """It should update Tempdeck's `plate_target_temperature` correctly."""
     load_module_cmd = commands.LoadModule.construct(  # type: ignore[call-arg]
@@ -222,7 +222,7 @@ def test_handle_tempdeck_temperature_commands(
         ),
         result=temp_commands.SetTargetTemperatureResult(),
     )
-    deactivate_cmd = temp_commands.DeactivateTemperature.construct(  # type: ignore[call-arg]
+    deactivate_cmd = temp_commands.DeactivateTemperature.construct(  # type: ignore[call-arg]  # noqa: E501
         params=temp_commands.DeactivateTemperatureParams(moduleId="module-id"),
         result=temp_commands.DeactivateTemperatureResult(),
     )

--- a/api/tests/opentrons/protocol_engine/state/test_module_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_store.py
@@ -63,7 +63,6 @@ def test_initial_state() -> None:
             ModuleModel.TEMPERATURE_MODULE_V1,
             TemperatureModuleSubState(
                 module_id=TemperatureModuleId("module-id"),
-                model=ModuleModel.TEMPERATURE_MODULE_V1,
             ),
         )
     ],
@@ -125,7 +124,6 @@ def test_load_module(
             lazy_fixture("tempdeck_v2_def"),
             TemperatureModuleSubState(
                 module_id=TemperatureModuleId("module-id"),
-                model=ModuleModel.TEMPERATURE_MODULE_V2
             )
         )
     ],

--- a/api/tests/opentrons/protocol_engine/state/test_module_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_store.py
@@ -222,10 +222,10 @@ def test_handle_tempdeck_temperature_commands(
         ),
         result=temp_commands.SetTargetTemperatureResult(),
     )
-    # deactivate_cmd = hs_commands.DeactivateHeater.construct(  # type: ignore[call-arg]
-    #     params=hs_commands.DeactivateHeaterParams(moduleId="module-id"),
-    #     result=hs_commands.DeactivateHeaterResult(),
-    # )
+    deactivate_cmd = temp_commands.DeactivateTemperature.construct(  # type: ignore[call-arg]
+        params=temp_commands.DeactivateTemperatureParams(moduleId="module-id"),
+        result=temp_commands.DeactivateTemperatureResult(),
+    )
     subject = ModuleStore()
 
     subject.handle_action(actions.UpdateCommandAction(command=load_module_cmd))
@@ -235,9 +235,9 @@ def test_handle_tempdeck_temperature_commands(
             module_id=TemperatureModuleId("module-id"), plate_target_temperature=42
         )
     }
-    # subject.handle_action(actions.UpdateCommandAction(command=deactivate_cmd))
-    # assert subject.state.substate_by_module_id == {
-    #     "module-id": HeaterShakerModuleSubState(
-    #         module_id=HeaterShakerModuleId("module-id"), plate_target_temperature=None
-    #     )
-    # }
+    subject.handle_action(actions.UpdateCommandAction(command=deactivate_cmd))
+    assert subject.state.substate_by_module_id == {
+        "module-id": TemperatureModuleSubState(
+            module_id=TemperatureModuleId("module-id"), plate_target_temperature=None
+        )
+    }

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -317,11 +317,11 @@ def test_get_temperature_module_substate(
         substate_by_module_id={
             "temp-module-gen1-id": TemperatureModuleSubState(
                 module_id=TemperatureModuleId("temp-module-gen1-id"),
-                plate_target_temperature=None
+                plate_target_temperature=None,
             ),
             "temp-module-gen2-id": TemperatureModuleSubState(
                 module_id=TemperatureModuleId("temp-module-gen2-id"),
-                plate_target_temperature=123
+                plate_target_temperature=123,
             ),
             "heatshake-module-id": HeaterShakerModuleSubState(
                 module_id=HeaterShakerModuleId("heatshake-module-id"),
@@ -877,7 +877,7 @@ def test_validate_temp_module_target_temperature_raises(
         substate_by_module_id={
             "module-id": TemperatureModuleSubState(
                 module_id=TemperatureModuleId("module-id"),
-                plate_target_temperature=None
+                plate_target_temperature=None,
             )
         },
     )
@@ -886,12 +886,11 @@ def test_validate_temp_module_target_temperature_raises(
         subject.validate_target_temperature(target_temp)
 
 
-@pytest.mark.parametrize(["target_temp", "validated_temp"],
-                         [(-9.431, -9), (0, 0), (99.1, 99)])
+@pytest.mark.parametrize(
+    ["target_temp", "validated_temp"], [(-9.431, -9), (0, 0), (99.1, 99)]
+)
 def test_validate_temp_module_target_temperature(
-    tempdeck_v2_def: ModuleDefinition,
-    target_temp: float,
-    validated_temp: int
+    tempdeck_v2_def: ModuleDefinition, target_temp: float, validated_temp: int
 ) -> None:
     """It should verify if a target temperature is valid for the specified module."""
     module_view = make_module_view(
@@ -905,7 +904,7 @@ def test_validate_temp_module_target_temperature(
         substate_by_module_id={
             "module-id": TemperatureModuleSubState(
                 module_id=TemperatureModuleId("module-id"),
-                plate_target_temperature=None
+                plate_target_temperature=None,
             )
         },
     )
@@ -970,7 +969,7 @@ def test_validate_heater_shaker_target_speed_raises_error(
 
 
 def test_tempdeck_get_plate_target_temperature(
-        tempdeck_v2_def: ModuleDefinition
+    tempdeck_v2_def: ModuleDefinition,
 ) -> None:
     """It should return whether target temperature is set."""
     module_view = make_module_view(

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -810,7 +810,7 @@ def test_magnetic_module_view_calculate_magnet_hardware_height(
 
 
 @pytest.mark.parametrize("target_temp", [36.8, 95.1])
-def test_validate_target_temperature_raises(
+def test_validate_heater_shaker_target_temperature_raises(
     heater_shaker_v1_def: ModuleDefinition,
     target_temp: float,
 ) -> None:
@@ -836,7 +836,7 @@ def test_validate_target_temperature_raises(
 
 
 @pytest.mark.parametrize("target_temp", [37, 94.8])
-def test_validate_target_temperature(
+def test_validate_heater_shaker_target_temperature(
     heater_shaker_v1_def: ModuleDefinition,
     target_temp: float,
 ) -> None:
@@ -858,6 +858,57 @@ def test_validate_target_temperature(
     )
     subject = module_view.get_heater_shaker_module_substate("module-id")
     assert subject.validate_target_temperature(target_temp) == target_temp
+
+
+@pytest.mark.parametrize("target_temp", [-10, 99.9])
+def test_validate_temp_module_target_temperature_raises(
+    tempdeck_v1_def: ModuleDefinition,
+    target_temp: float,
+) -> None:
+    """It should verify if a target temperature is valid for the specified module."""
+    module_view = make_module_view(
+        slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
+        hardware_by_module_id={
+            "module-id": HardwareModule(
+                serial_number="serial-number",
+                definition=tempdeck_v1_def,
+            )
+        },
+        substate_by_module_id={
+            "module-id": TemperatureModuleSubState(
+                module_id=TemperatureModuleId("module-id"),
+            )
+        },
+    )
+    subject = module_view.get_temperature_module_substate("module-id")
+    with pytest.raises(errors.InvalidTargetTemperatureError):
+        subject.validate_target_temperature(target_temp)
+
+
+@pytest.mark.parametrize(["target_temp", "validated_temp"],
+                         [(-9.431, -9), (0, 0), (99.1, 99)])
+def test_validate_temp_module_target_temperature(
+    tempdeck_v2_def: ModuleDefinition,
+    target_temp: float,
+    validated_temp: int
+) -> None:
+    """It should verify if a target temperature is valid for the specified module."""
+    module_view = make_module_view(
+        slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
+        hardware_by_module_id={
+            "module-id": HardwareModule(
+                serial_number="serial-number",
+                definition=tempdeck_v2_def,
+            )
+        },
+        substate_by_module_id={
+            "module-id": TemperatureModuleSubState(
+                module_id=TemperatureModuleId("module-id"),
+            )
+        },
+    )
+    subject = module_view.get_temperature_module_substate("module-id")
+    assert subject.validate_target_temperature(target_temp) == validated_temp
 
 
 @pytest.mark.parametrize(

--- a/robot-server/robot_server/commands/stateless_commands.py
+++ b/robot-server/robot_server/commands/stateless_commands.py
@@ -7,9 +7,9 @@ StatelessCommandCreate = Union[
     commands.SetRailLightsCreate,
     commands.magnetic_module.EngageCreate,
     commands.magnetic_module.DisengageCreate,
+    commands.temperature_module.SetTargetTemperatureCreate,
+    commands.temperature_module.DeactivateTemperatureCreate,
     # TODO(mc, 2022-03-18): implement these commands
-    # commands.temperature_module.SetTargetTemperatureCreate,
-    # commands.temperature_module.DeactivateCreate,
     # commands.thermocycler.SetTargetBlockTemperatureCreate,
     # commands.thermocycler.SetTargetLidTemperatureCreate,
     # commands.thermocycler.DeactivateBlockCreate,
@@ -29,9 +29,9 @@ StatelessCommand = Union[
     commands.SetRailLights,
     commands.magnetic_module.Engage,
     commands.magnetic_module.Disengage,
+    commands.temperature_module.SetTargetTemperature,
+    commands.temperature_module.DeactivateTemperature,
     # TODO(mc, 2022-03-18): implement these commands
-    # commands.temperature_module.SetTargetTemperature,
-    # commands.temperature_module.Deactivate,
     # commands.thermocycler.SetTargetBlockTemperature,
     # commands.thermocycler.SetTargetLidTemperature,
     # commands.thermocycler.DeactivateBlock,

--- a/shared-data/protocol/fixtures/6/heaterShakerCommands.json
+++ b/shared-data/protocol/fixtures/6/heaterShakerCommands.json
@@ -1244,7 +1244,7 @@
       "id": "0abc123",
       "params": {
         "pipetteId": "pipetteId",
-        "mount": "leftMount"
+        "mount": "left"
       }
     },
     {
@@ -1366,6 +1366,14 @@
       "params": {
         "moduleId": "heaterShakerId",
         "rpm": 2000
+      }
+    },
+    {
+      "commandType": "heaterShakerModule/startSetTargetTemperature",
+      "id": "14abc123",
+      "params": {
+        "moduleId": "heaterShakerId",
+        "temperature": 42
       }
     },
     {

--- a/shared-data/protocol/fixtures/6/tempAndMagModuleCommands.json
+++ b/shared-data/protocol/fixtures/6/tempAndMagModuleCommands.json
@@ -1241,7 +1241,7 @@
       "id": "0abc123",
       "params": {
         "pipetteId": "pipetteId",
-        "mount": "leftMount"
+        "mount": "left"
       }
     },
     {
@@ -1392,7 +1392,7 @@
       "commandType": "magneticModule/disengageMagnet",
       "id": "16abc123",
       "params": {
-        "moduleId": "temperatureModuleId"
+        "moduleId": "magneticModuleId"
       }
     }
   ],


### PR DESCRIPTION
# Overview

Closes #9554 

Adds commands to set, await and deactivate target temperature.

# Changelog

- added these commands to `/temperatureModule`:
  - `setTargetTemperature`
  - `awaitTemperature`
  - `deactivateTemperature`
- added `TemperatureModuleSubState` to module store
- updated command action handling for temp modules  

# Review requests

- Found a weirdness about the saved plate target temperature and have noted it in a comment. Any strong opinions on which route we should go? 
- Usual stuff: code & tests look good

# Risk assessment

Low. Only new addition
