### PR TITLE
refactor(api,hardware): ot3 fw update

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -480,6 +480,8 @@ class OT3Controller:
             messenger=self._messenger,
             node_id=target,
             hex_processor=firmware_update.HexRecordProcessor.from_file(Path(filename)),
+            # TODO (amit, 2022-04-05): Fill in retry_count and timeout_seconds from
+            #  config values.
             retry_count=3,
             timeout_seconds=20,
             erase=True,

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -69,7 +69,8 @@ from opentrons.hardware_control.types import (
     AionotifyEvent,
     OT3Mount,
     OT3AxisMap,
-    CurrentConfig, OT3SubSystem,
+    CurrentConfig,
+    OT3SubSystem,
 )
 from opentrons_hardware.hardware_control.motion import (
     MoveStopCondition,
@@ -580,8 +581,12 @@ class OT3Controller:
         current_set: Set[NodeId], probed_set: Set[NodeId]
     ) -> Set[NodeId]:
         probed_set = OT3Controller._replace_head_node(probed_set)
-        core_replaced: Set[NodeId] = {NodeId.gantry_x, NodeId.gantry_y,
-                                      NodeId.head_l, NodeId.head_r}
+        core_replaced: Set[NodeId] = {
+            NodeId.gantry_x,
+            NodeId.gantry_y,
+            NodeId.head_l,
+            NodeId.head_r,
+        }
         current_set -= core_replaced
         current_set |= probed_set
         return current_set

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -5,7 +5,6 @@ import asyncio
 from contextlib import asynccontextmanager
 import logging
 from copy import deepcopy
-from pathlib import Path
 from typing import (
     Dict,
     List,
@@ -478,16 +477,17 @@ class OT3Controller:
 
     async def update_firmware(self, filename: str, target: OT3SubSystem) -> None:
         """Update the firmware."""
-        await firmware_update.run_update(
-            messenger=self._messenger,
-            node_id=sub_system_to_node_id(target),
-            hex_processor=firmware_update.HexRecordProcessor.from_file(Path(filename)),
-            # TODO (amit, 2022-04-05): Fill in retry_count and timeout_seconds from
-            #  config values.
-            retry_count=3,
-            timeout_seconds=20,
-            erase=True,
-        )
+        with open(filename, "r") as f:
+            await firmware_update.run_update(
+                messenger=self._messenger,
+                node_id=sub_system_to_node_id(target),
+                hex_file=f,
+                # TODO (amit, 2022-04-05): Fill in retry_count and timeout_seconds from
+                #  config values.
+                retry_count=3,
+                timeout_seconds=20,
+                erase=True,
+            )
 
     def engaged_axes(self) -> OT3AxisMap[bool]:
         """Get engaged axes."""

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -474,9 +474,7 @@ class OT3Controller:
         """Get the firmware version."""
         return None
 
-    async def update_firmware(
-        self, filename: str, target: NodeId
-    ) -> None:
+    async def update_firmware(self, filename: str, target: NodeId) -> None:
         """Update the firmware."""
         await firmware_update.run_update(
             messenger=self._messenger,
@@ -484,7 +482,7 @@ class OT3Controller:
             hex_processor=firmware_update.HexRecordProcessor.from_file(Path(filename)),
             retry_count=3,
             timeout_seconds=20,
-            erase=True
+            erase=True,
         )
 
     def engaged_axes(self) -> OT3AxisMap[bool]:

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -39,7 +39,7 @@ from opentrons.hardware_control.types import (
     OT3Axis,
     OT3Mount,
     OT3AxisMap,
-    CurrentConfig,
+    CurrentConfig, OT3SubSystem,
 )
 from opentrons_hardware.hardware_control.motion import MoveStopCondition
 
@@ -331,7 +331,7 @@ class OT3Simulator:
         """Get the firmware version."""
         return None
 
-    async def update_firmware(self, filename: str, target: NodeId) -> None:
+    async def update_firmware(self, filename: str, target: OT3SubSystem) -> None:
         """Update the firmware."""
         pass
 

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -39,7 +39,8 @@ from opentrons.hardware_control.types import (
     OT3Axis,
     OT3Mount,
     OT3AxisMap,
-    CurrentConfig, OT3SubSystem,
+    CurrentConfig,
+    OT3SubSystem,
 )
 from opentrons_hardware.hardware_control.motion import MoveStopCondition
 

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -332,10 +332,10 @@ class OT3Simulator:
         return None
 
     async def update_firmware(
-        self, filename: str, loop: asyncio.AbstractEventLoop, modeset: bool
-    ) -> str:
+        self, filename: str, target: NodeId
+    ) -> None:
         """Update the firmware."""
-        return "Done"
+        pass
 
     def engaged_axes(self) -> OT3AxisMap[bool]:
         """Get engaged axes."""

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -331,9 +331,7 @@ class OT3Simulator:
         """Get the firmware version."""
         return None
 
-    async def update_firmware(
-        self, filename: str, target: NodeId
-    ) -> None:
+    async def update_firmware(self, filename: str, target: NodeId) -> None:
         """Update the firmware."""
         pass
 

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -5,7 +5,7 @@ from opentrons.hardware_control.types import (
     OT3Axis,
     OT3AxisKind,
     OT3AxisMap,
-    CurrentConfig,
+    CurrentConfig, OT3SubSystem,
 )
 import numpy as np
 
@@ -104,6 +104,19 @@ def axis_is_node(axis: OT3Axis) -> bool:
         return True
     except KeyError:
         return False
+
+
+def sub_system_to_node_id(sub_sys: OT3SubSystem) -> "NodeId":
+    """Convert a sub system to a NodeId."""
+    nam = {
+        OT3SubSystem.gantry_x: NodeId.gantry_x,
+        OT3SubSystem.gantry_y: NodeId.gantry_y,
+        OT3SubSystem.head: NodeId.head,
+        OT3SubSystem.pipette_left: NodeId.pipette_left,
+        OT3SubSystem.pipette_right: NodeId.pipette_right,
+        OT3SubSystem.gripper: NodeId.gripper,
+    }
+    return nam[sub_sys]
 
 
 def get_current_settings(

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -5,7 +5,8 @@ from opentrons.hardware_control.types import (
     OT3Axis,
     OT3AxisKind,
     OT3AxisMap,
-    CurrentConfig, OT3SubSystem,
+    CurrentConfig,
+    OT3SubSystem,
 )
 import numpy as np
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -358,9 +358,7 @@ class OT3API(
         target: NodeId,
     ) -> None:
         """Update the firmware on the hardware."""
-        await self._backend.update_firmware(
-            firmware_file, target
-        )
+        await self._backend.update_firmware(firmware_file, target)
 
     @staticmethod
     def _gantry_load_from_instruments(

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -54,7 +54,7 @@ from .types import (
     PauseType,
     OT3Axis,
     OT3Mount,
-    OT3AxisMap,
+    OT3AxisMap, OT3SubSystem,
 )
 from . import modules
 from .robot_calibration import (
@@ -355,7 +355,7 @@ class OT3API(
     async def update_firmware(
         self,
         firmware_file: str,
-        target: NodeId,
+        target: OT3SubSystem,
     ) -> None:
         """Update the firmware on the hardware."""
         await self._backend.update_firmware(firmware_file, target)

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -27,7 +27,6 @@ from opentrons_hardware.hardware_control.motion_planning import (
     MoveTarget,
     ZeroLengthMoveError,
 )
-from opentrons_hardware.firmware_bindings.constants import NodeId
 
 
 from .util import use_or_initialize_loop, check_motion_bounds
@@ -54,7 +53,8 @@ from .types import (
     PauseType,
     OT3Axis,
     OT3Mount,
-    OT3AxisMap, OT3SubSystem,
+    OT3AxisMap,
+    OT3SubSystem,
 )
 from . import modules
 from .robot_calibration import (

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -27,6 +27,7 @@ from opentrons_hardware.hardware_control.motion_planning import (
     MoveTarget,
     ZeroLengthMoveError,
 )
+from opentrons_hardware.firmware_bindings.constants import NodeId
 
 
 from .util import use_or_initialize_loop, check_motion_bounds
@@ -354,16 +355,11 @@ class OT3API(
     async def update_firmware(
         self,
         firmware_file: str,
-        loop: Optional[asyncio.AbstractEventLoop] = None,
-        explicit_modeset: bool = True,
-    ) -> str:
+        target: NodeId,
+    ) -> None:
         """Update the firmware on the hardware."""
-        if None is loop:
-            checked_loop = self._loop
-        else:
-            checked_loop = loop
-        return await self._backend.update_firmware(
-            firmware_file, checked_loop, explicit_modeset
+        await self._backend.update_firmware(
+            firmware_file, target
         )
 
     @staticmethod

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -116,7 +116,7 @@ class OT3Axis(enum.Enum):
     Z_G = 4  # gripper mount Z
     P_L = 5  # left pipette plunger
     P_R = 6  # right pipette plunger
-    Q = 7  # hi-thruput pipette tiprack grab
+    Q = 7  # hi-throughput pipette tiprack grab
     G = 8  # gripper grab
 
     @classmethod
@@ -227,6 +227,22 @@ class OT3Axis(enum.Enum):
         return self.name
 
 
+class OT3SubSystem(enum.Enum):
+    """An enumeration of ot3 components.
+
+    This is a complete list of unique firmware nodes in the ot3.
+    """
+    gantry_x = 0
+    gantry_y = 1
+    head = 2
+    pipette_left = 3
+    pipette_right = 4
+    gripper = 5
+
+    def __str__(self) -> str:
+        return self.name
+
+
 BCAxes = Union[Axis, OT3Axis]
 AxisMapValue = TypeVar("AxisMapValue")
 OT3AxisMap = Dict[OT3Axis, AxisMapValue]
@@ -238,7 +254,7 @@ class CurrentConfig:
     run_current: float
 
     def as_tuple(self) -> Tuple[float, float]:
-        return (self.hold_current, self.run_current)
+        return self.hold_current, self.run_current
 
 
 class DoorState(enum.Enum):

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -232,6 +232,7 @@ class OT3SubSystem(enum.Enum):
 
     This is a complete list of unique firmware nodes in the ot3.
     """
+
     gantry_x = 0
     gantry_y = 1
     head = 2

--- a/hardware/opentrons_hardware/firmware_update/__init__.py
+++ b/hardware/opentrons_hardware/firmware_update/__init__.py
@@ -2,13 +2,6 @@
 
 from .initiator import (
     FirmwareUpdateInitiator,
-    head,
-    gantry_y,
-    gantry_x,
-    pipette_left,
-    pipette_right,
-    gripper,
-    Target,
 )
 from .downloader import FirmwareUpdateDownloader
 from .hex_file import from_hex_file_path, from_hex_contents, HexRecordProcessor
@@ -19,15 +12,8 @@ __all__ = [
     "FirmwareUpdateDownloader",
     "FirmwareUpdateInitiator",
     "FirmwareUpdateEraser",
-    "head",
-    "gantry_y",
-    "gantry_x",
-    "pipette_left",
-    "pipette_right",
-    "gripper",
     "from_hex_file_path",
     "from_hex_contents",
     "HexRecordProcessor",
-    "Target",
     "run_update",
 ]

--- a/hardware/opentrons_hardware/firmware_update/__init__.py
+++ b/hardware/opentrons_hardware/firmware_update/__init__.py
@@ -4,7 +4,7 @@ from .initiator import (
     FirmwareUpdateInitiator,
 )
 from .downloader import FirmwareUpdateDownloader
-from .hex_file import from_hex_file_path, from_hex_contents, HexRecordProcessor
+from .hex_file import from_hex_file_path, from_hex_file, HexRecordProcessor
 from .eraser import FirmwareUpdateEraser
 from .run import run_update
 
@@ -13,7 +13,7 @@ __all__ = [
     "FirmwareUpdateInitiator",
     "FirmwareUpdateEraser",
     "from_hex_file_path",
-    "from_hex_contents",
+    "from_hex_file",
     "HexRecordProcessor",
     "run_update",
 ]

--- a/hardware/opentrons_hardware/firmware_update/hex_file.py
+++ b/hardware/opentrons_hardware/firmware_update/hex_file.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from dataclasses import dataclass
 from enum import Enum
-from typing import Iterable, List, Generator
+from typing import Iterable, List, Generator, TextIO
 import binascii
 import struct
 import logging
@@ -69,13 +69,12 @@ class BadChunkSizeException(HexFileException):
 def from_hex_file_path(file_path: Path) -> Iterable[HexRecord]:
     """A generator that processes a hex file at file_path."""
     with file_path.open() as hex_file:
-        for line in hex_file.readlines():
-            yield process_line(line)
+        return from_hex_file(hex_file)
 
 
-def from_hex_contents(data: str) -> Iterable[HexRecord]:
+def from_hex_file(hex_file: TextIO) -> Iterable[HexRecord]:
     """A generator that processes a hex file contents."""
-    for line in data.splitlines():
+    for line in hex_file.readlines():
         yield process_line(line)
 
 
@@ -148,14 +147,14 @@ class HexRecordProcessor:
         self._start_address: int = 0
 
     @classmethod
-    def from_file(cls, file_path: Path) -> HexRecordProcessor:
+    def from_file_path(cls, file_path: Path) -> HexRecordProcessor:
         """Construct from file."""
         return HexRecordProcessor(from_hex_file_path(file_path))
 
     @classmethod
-    def from_content(cls, file_path: Path) -> HexRecordProcessor:
+    def from_file(cls, hex_file: TextIO) -> HexRecordProcessor:
         """Construct from file."""
-        return HexRecordProcessor(from_hex_file_path(file_path))
+        return HexRecordProcessor(from_hex_file(hex_file))
 
     @property
     def start_address(self) -> int:

--- a/hardware/opentrons_hardware/firmware_update/initiator.py
+++ b/hardware/opentrons_hardware/firmware_update/initiator.py
@@ -2,43 +2,15 @@
 
 import asyncio
 import logging
-from typing_extensions import Final
-from dataclasses import dataclass
 
-from opentrons_hardware.firmware_bindings import NodeId
 from opentrons_hardware.firmware_bindings.messages import message_definitions
 
 from opentrons_hardware.drivers.can_bus import CanMessenger
 from opentrons_hardware.drivers.can_bus.can_messenger import WaitableCallback
+from opentrons_hardware.firmware_update.target import Target
 from opentrons_hardware.firmware_update.errors import BootloaderNotReady
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass(frozen=True)
-class Target:
-    """Pair of a sub-system's node id with its bootloader's node id."""
-
-    system_node: NodeId
-    bootloader_node: NodeId
-
-
-head: Final = Target(system_node=NodeId.head, bootloader_node=NodeId.head_bootloader)
-pipette_left: Final = Target(
-    system_node=NodeId.pipette_left, bootloader_node=NodeId.pipette_left_bootloader
-)
-pipette_right: Final = Target(
-    system_node=NodeId.pipette_right, bootloader_node=NodeId.pipette_right_bootloader
-)
-gantry_x: Final = Target(
-    system_node=NodeId.gantry_x, bootloader_node=NodeId.gantry_x_bootloader
-)
-gantry_y: Final = Target(
-    system_node=NodeId.gantry_y, bootloader_node=NodeId.gantry_y_bootloader
-)
-gripper: Final = Target(
-    system_node=NodeId.gripper, bootloader_node=NodeId.gripper_bootloader
-)
 
 
 class FirmwareUpdateInitiator:

--- a/hardware/opentrons_hardware/firmware_update/run.py
+++ b/hardware/opentrons_hardware/firmware_update/run.py
@@ -3,6 +3,7 @@ import logging
 from typing import Optional
 
 from opentrons_hardware.drivers.can_bus import CanMessenger
+from opentrons_hardware.firmware_bindings import NodeId
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     FirmwareUpdateStartApp,
 )
@@ -11,16 +12,15 @@ from opentrons_hardware.firmware_update import (
     FirmwareUpdateDownloader,
     FirmwareUpdateEraser,
     HexRecordProcessor,
-    Target,
 )
-
+from opentrons_hardware.firmware_update.target import Target
 
 logger = logging.getLogger(__name__)
 
 
 async def run_update(
     messenger: CanMessenger,
-    target: Target,
+    node_id: NodeId,
     hex_processor: HexRecordProcessor,
     retry_count: int,
     timeout_seconds: float,
@@ -30,7 +30,7 @@ async def run_update(
 
     Args:
         messenger: The can messenger to use
-        target: The node being updated
+        node_id: The node being updated
         hex_processor: The producer of
         retry_count: Number of times to retry.
         timeout_seconds: How much to wait for responses.
@@ -41,6 +41,8 @@ async def run_update(
     """
     initiator = FirmwareUpdateInitiator(messenger)
     downloader = FirmwareUpdateDownloader(messenger)
+
+    target = Target(system_node=node_id)
 
     logger.info(f"Initiating FW Update on {target}.")
 

--- a/hardware/opentrons_hardware/firmware_update/run.py
+++ b/hardware/opentrons_hardware/firmware_update/run.py
@@ -1,6 +1,6 @@
 """Complete FW updater."""
 import logging
-from typing import Optional
+from typing import Optional, TextIO
 
 from opentrons_hardware.drivers.can_bus import CanMessenger
 from opentrons_hardware.firmware_bindings import NodeId
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 async def run_update(
     messenger: CanMessenger,
     node_id: NodeId,
-    hex_processor: HexRecordProcessor,
+    hex_file: TextIO,
     retry_count: int,
     timeout_seconds: float,
     erase: Optional[bool] = True,
@@ -29,9 +29,9 @@ async def run_update(
     """Perform a firmware update on a node target.
 
     Args:
-        messenger: The can messenger to use
-        node_id: The node being updated
-        hex_processor: The producer of
+        messenger: The can messenger to use.
+        node_id: The node being updated.
+        hex_file: File containing firmware.
         retry_count: Number of times to retry.
         timeout_seconds: How much to wait for responses.
         erase: Whether to erase flash before updating.
@@ -39,6 +39,8 @@ async def run_update(
     Returns:
         None
     """
+    hex_processor = HexRecordProcessor.from_file(hex_file)
+
     initiator = FirmwareUpdateInitiator(messenger)
     downloader = FirmwareUpdateDownloader(messenger)
 

--- a/hardware/opentrons_hardware/firmware_update/target.py
+++ b/hardware/opentrons_hardware/firmware_update/target.py
@@ -1,0 +1,29 @@
+"""Firmware update target."""
+from dataclasses import dataclass, field
+from typing_extensions import Final
+
+from opentrons_hardware.firmware_bindings import NodeId
+
+
+BootloaderNodeIdMap: Final = {
+    NodeId.head: NodeId.head_bootloader,
+    NodeId.pipette_left: NodeId.pipette_left_bootloader,
+    NodeId.pipette_right: NodeId.pipette_right_bootloader,
+    NodeId.gantry_x: NodeId.gantry_x_bootloader,
+    NodeId.gantry_y: NodeId.gantry_y_bootloader,
+    NodeId.gripper: NodeId.gripper_bootloader
+}
+
+
+@dataclass
+class Target:
+    """Pair of a sub-system's node id with its bootloader's node id."""
+
+    system_node: NodeId
+    bootloader_node: NodeId = field(init=False)
+
+    def __post_init__(self) -> None:
+        """Assign computed values."""
+        bn = BootloaderNodeIdMap.get(self.system_node)
+        assert bn, f"'{self.system_node}' is not valid for firmware update."
+        self.bootloader_node = bn

--- a/hardware/opentrons_hardware/firmware_update/target.py
+++ b/hardware/opentrons_hardware/firmware_update/target.py
@@ -11,7 +11,7 @@ BootloaderNodeIdMap: Final = {
     NodeId.pipette_right: NodeId.pipette_right_bootloader,
     NodeId.gantry_x: NodeId.gantry_x_bootloader,
     NodeId.gantry_y: NodeId.gantry_y_bootloader,
-    NodeId.gripper: NodeId.gripper_bootloader
+    NodeId.gripper: NodeId.gripper_bootloader,
 }
 
 

--- a/hardware/opentrons_hardware/scripts/update_fw.py
+++ b/hardware/opentrons_hardware/scripts/update_fw.py
@@ -9,15 +9,10 @@ from typing_extensions import Final
 
 from opentrons_hardware.drivers.can_bus import CanMessenger
 from opentrons_hardware.drivers.can_bus.build import build_driver
+from opentrons_hardware.firmware_bindings import NodeId
 from opentrons_hardware.firmware_update.run import run_update
 from .can_args import add_can_args, build_settings
 from opentrons_hardware.firmware_update import (
-    head,
-    gantry_x,
-    gantry_y,
-    pipette_left,
-    pipette_right,
-    gripper,
     HexRecordProcessor,
 )
 
@@ -45,12 +40,12 @@ LOG_CONFIG = {
 }
 
 TARGETS: Final = {
-    "head": head,
-    "gantry-x": gantry_x,
-    "gantry-y": gantry_y,
-    "pipette-left": pipette_left,
-    "pipette-right": pipette_right,
-    "gripper": gripper,
+    "head": NodeId.head,
+    "gantry-x": NodeId.gantry_x,
+    "gantry-y": NodeId.gantry_y,
+    "pipette-left": NodeId.pipette_left,
+    "pipette-right": NodeId.pipette_right,
+    "gripper": NodeId.gripper,
 }
 
 
@@ -70,7 +65,7 @@ async def run(args: argparse.Namespace) -> None:
 
     await run_update(
         messenger=messenger,
-        target=target,
+        node_id=target,
         hex_processor=hex_processor,
         retry_count=retry_count,
         timeout_seconds=timeout_seconds,

--- a/hardware/tests/firmware_integration/test_update_fw.py
+++ b/hardware/tests/firmware_integration/test_update_fw.py
@@ -6,10 +6,7 @@ import pytest
 
 from opentrons_hardware.drivers.can_bus import CanMessenger
 from opentrons_hardware.firmware_bindings import NodeId
-from opentrons_hardware.firmware_update import (
-    HexRecordProcessor,
-    run_update,
-)
+from opentrons_hardware.firmware_update import run_update
 
 
 @pytest.fixture
@@ -31,11 +28,12 @@ async def test_update(
     can_messenger: CanMessenger, system_node_id: NodeId, hex_file_path: Path
 ) -> None:
     """It should complete the download."""
-    await run_update(
-        messenger=can_messenger,
-        node_id=system_node_id,
-        hex_processor=HexRecordProcessor.from_file(hex_file_path),
-        retry_count=3,
-        timeout_seconds=60,
-        erase=True,
-    )
+    with hex_file_path.open("r") as f:
+        await run_update(
+            messenger=can_messenger,
+            node_id=system_node_id,
+            hex_file=f,
+            retry_count=3,
+            timeout_seconds=60,
+            erase=True,
+        )

--- a/hardware/tests/firmware_integration/test_update_fw.py
+++ b/hardware/tests/firmware_integration/test_update_fw.py
@@ -5,18 +5,17 @@ from pathlib import Path
 import pytest
 
 from opentrons_hardware.drivers.can_bus import CanMessenger
+from opentrons_hardware.firmware_bindings import NodeId
 from opentrons_hardware.firmware_update import (
     HexRecordProcessor,
     run_update,
-    pipette_left,
-    Target,
 )
 
 
 @pytest.fixture
-def target() -> Target:
+def system_node_id() -> NodeId:
     """Target node."""
-    return pipette_left
+    return NodeId.pipette_left
 
 
 @pytest.fixture
@@ -29,12 +28,12 @@ def hex_file_path() -> Path:
 
 @pytest.mark.requires_emulator
 async def test_update(
-    can_messenger: CanMessenger, target: Target, hex_file_path: Path
+    can_messenger: CanMessenger, system_node_id: NodeId, hex_file_path: Path
 ) -> None:
     """It should complete the download."""
     await run_update(
         messenger=can_messenger,
-        target=target,
+        node_id=system_node_id,
         hex_processor=HexRecordProcessor.from_file(hex_file_path),
         retry_count=3,
         timeout_seconds=60,

--- a/hardware/tests/opentrons_hardware/firmware_update/test_initiater.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_initiater.py
@@ -13,6 +13,7 @@ from opentrons_hardware.firmware_bindings.utils import UInt32Field
 
 from opentrons_hardware.firmware_update import initiator
 from opentrons_hardware.firmware_update.errors import BootloaderNotReady
+from opentrons_hardware.firmware_update.target import Target
 from tests.conftest import MockCanMessageNotifier
 
 
@@ -51,7 +52,7 @@ async def test_messaging(
                 ),
             )
 
-    target = initiator.head
+    target = Target(system_node=NodeId.head)
 
     mock_messenger.send.side_effect = responder
 
@@ -109,7 +110,7 @@ async def test_retry(
                     ),
                 )
 
-    target = initiator.head
+    target = Target(system_node=NodeId.head)
 
     mock_messenger.send.side_effect = responder
 
@@ -142,7 +143,7 @@ async def test_bootloader_not_ready(
     mock_messenger: AsyncMock,
 ) -> None:
     """It should raise an error when bootloader never responds."""
-    target = initiator.head
+    target =  Target(system_node=NodeId.head)
 
     retry_count = 3
     with pytest.raises(BootloaderNotReady):

--- a/hardware/tests/opentrons_hardware/firmware_update/test_initiater.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_initiater.py
@@ -143,7 +143,7 @@ async def test_bootloader_not_ready(
     mock_messenger: AsyncMock,
 ) -> None:
     """It should raise an error when bootloader never responds."""
-    target =  Target(system_node=NodeId.head)
+    target = Target(system_node=NodeId.head)
 
     retry_count = 3
     with pytest.raises(BootloaderNotReady):

--- a/hardware/tests/opentrons_hardware/firmware_update/test_run.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_run.py
@@ -5,6 +5,7 @@ import mock
 import pytest
 from mock import AsyncMock, MagicMock
 
+from opentrons_hardware.firmware_bindings import NodeId
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     FirmwareUpdateStartApp,
 )
@@ -13,8 +14,8 @@ from opentrons_hardware.firmware_update import (
     FirmwareUpdateDownloader,
     FirmwareUpdateEraser,
     run_update,
-    head,
 )
+from opentrons_hardware.firmware_update.target import Target
 
 
 @pytest.fixture
@@ -48,10 +49,10 @@ async def test_run_update(
     """It should call all the functions."""
     mock_messenger = AsyncMock()
     mock_hex = MagicMock()
-    target = head
+    target = Target(system_node=NodeId.head)
     await run_update(
         messenger=mock_messenger,
-        target=target,
+        node_id=target.system_node,
         hex_processor=mock_hex,
         retry_count=12,
         timeout_seconds=11,
@@ -70,5 +71,5 @@ async def test_run_update(
         node_id=target.bootloader_node, hex_processor=mock_hex, ack_wait_seconds=11
     )
     mock_messenger.send.assert_called_once_with(
-        node_id=head.bootloader_node, message=FirmwareUpdateStartApp()
+        node_id=target.bootloader_node, message=FirmwareUpdateStartApp()
     )

--- a/hardware/tests/opentrons_hardware/firmware_update/test_target.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_target.py
@@ -9,23 +9,40 @@ from opentrons_hardware.firmware_update.target import Target
 @pytest.fixture(params=list(NodeId))
 def system_node_id(request: FixtureRequest) -> NodeId:
     """Each node id fixture."""
-    return request.param
+    return request.param  # type: ignore[attr-defined,no-any-return]
 
 
 def test_make_target(system_node_id: NodeId) -> None:
     """It should create the Target."""
     if system_node_id == NodeId.head:
-        assert Target(system_node=system_node_id).bootloader_node == NodeId.head_bootloader
+        assert (
+            Target(system_node=system_node_id).bootloader_node == NodeId.head_bootloader
+        )
     elif system_node_id == NodeId.pipette_left:
-        assert Target(system_node=system_node_id).bootloader_node == NodeId.pipette_left_bootloader
+        assert (
+            Target(system_node=system_node_id).bootloader_node
+            == NodeId.pipette_left_bootloader
+        )
     elif system_node_id == NodeId.pipette_right:
-        assert Target(system_node=system_node_id).bootloader_node == NodeId.pipette_right_bootloader
+        assert (
+            Target(system_node=system_node_id).bootloader_node
+            == NodeId.pipette_right_bootloader
+        )
     elif system_node_id == NodeId.gantry_x:
-        assert Target(system_node=system_node_id).bootloader_node == NodeId.gantry_x_bootloader
+        assert (
+            Target(system_node=system_node_id).bootloader_node
+            == NodeId.gantry_x_bootloader
+        )
     elif system_node_id == NodeId.gantry_y:
-        assert Target(system_node=system_node_id).bootloader_node == NodeId.gantry_y_bootloader
+        assert (
+            Target(system_node=system_node_id).bootloader_node
+            == NodeId.gantry_y_bootloader
+        )
     elif system_node_id == NodeId.gripper:
-        assert Target(system_node=system_node_id).bootloader_node == NodeId.gripper_bootloader
+        assert (
+            Target(system_node=system_node_id).bootloader_node
+            == NodeId.gripper_bootloader
+        )
     else:
         with pytest.raises(AssertionError):
             Target(system_node=system_node_id)

--- a/hardware/tests/opentrons_hardware/firmware_update/test_target.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_target.py
@@ -1,0 +1,31 @@
+"""Tests for Target class."""
+import pytest
+from _pytest.fixtures import FixtureRequest
+
+from opentrons_hardware.firmware_bindings import NodeId
+from opentrons_hardware.firmware_update.target import Target
+
+
+@pytest.fixture(params=list(NodeId))
+def system_node_id(request: FixtureRequest) -> NodeId:
+    """Each node id fixture."""
+    return request.param
+
+
+def test_make_target(system_node_id: NodeId) -> None:
+    """It should create the Target."""
+    if system_node_id == NodeId.head:
+        assert Target(system_node=system_node_id).bootloader_node == NodeId.head_bootloader
+    elif system_node_id == NodeId.pipette_left:
+        assert Target(system_node=system_node_id).bootloader_node == NodeId.pipette_left_bootloader
+    elif system_node_id == NodeId.pipette_right:
+        assert Target(system_node=system_node_id).bootloader_node == NodeId.pipette_right_bootloader
+    elif system_node_id == NodeId.gantry_x:
+        assert Target(system_node=system_node_id).bootloader_node == NodeId.gantry_x_bootloader
+    elif system_node_id == NodeId.gantry_y:
+        assert Target(system_node=system_node_id).bootloader_node == NodeId.gantry_y_bootloader
+    elif system_node_id == NodeId.gripper:
+        assert Target(system_node=system_node_id).bootloader_node == NodeId.gripper_bootloader
+    else:
+        with pytest.raises(AssertionError):
+            Target(system_node=system_node_id)

--- a/hardware/tests/opentrons_hardware/firmware_update/test_target.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_target.py
@@ -44,5 +44,6 @@ def test_make_target(system_node_id: NodeId) -> None:
             == NodeId.gripper_bootloader
         )
     else:
+        # Every other node id should raise an exception.
         with pytest.raises(AssertionError):
             Target(system_node=system_node_id)

--- a/hardware/tests/opentrons_hardware/hardware_control/tools/test_detector.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/tools/test_detector.py
@@ -90,8 +90,6 @@ async def test_messaging(
     assert mock_messenger.send.mock_calls == [
         call(
             node_id=NodeId.head,
-            message=message_definitions.AttachedToolsRequest(
-                payload=payloads.EmptyPayload()
-            ),
+            message=message_definitions.AttachedToolsRequest(),
         )
     ]

--- a/hardware/tests/opentrons_hardware/hardware_control/tools/test_oneshot.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/tools/test_oneshot.py
@@ -67,9 +67,7 @@ async def test_suppresses_undefined(
     # them
     assert await mock_messenger.send.called_once_with(
         node_id=NodeId.head,
-        message=message_definitions.AttachedToolsRequest(
-            payload=payloads.EmptyPayload()
-        ),
+        message=message_definitions.AttachedToolsRequest(),
     )
 
 
@@ -175,15 +173,11 @@ async def test_sends_only_required_followups(
     assert mock_messenger.send.mock_calls == [
         call(
             node_id=NodeId.head,
-            message=message_definitions.AttachedToolsRequest(
-                payload=payloads.EmptyPayload()
-            ),
+            message=message_definitions.AttachedToolsRequest(),
         ),
         call(
             node_id=NodeId.broadcast,
-            message=message_definitions.PipetteInfoRequest(
-                payload=payloads.EmptyPayload()
-            ),
+            message=message_definitions.PipetteInfoRequest(),
         ),
     ]
 
@@ -269,9 +263,7 @@ async def test_sends_all_required_followups(
         ),
         call(
             node_id=NodeId.broadcast,
-            message=message_definitions.PipetteInfoRequest(
-                payload=payloads.EmptyPayload()
-            ),
+            message=message_definitions.PipetteInfoRequest(),
         ),
     ]
 


### PR DESCRIPTION
# Overview

Integrate update with ot3 api.

# Changelog

- Refactor `Target` `dataclass` to be constructed from the system `NodeId`. The bootloader `NodeId` is populated in `__post_init__`.
- Fill in `update_firmware` in ot3api and ot3controller.

# Review requests



# Risk assessment

None