### PR TITLE
test(robot-server): Clean up dependency overrides on fixture teardown

### DIFF
--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -67,7 +67,7 @@ def hardware() -> MagicMock:
 
 
 @pytest.fixture
-def override_hardware(hardware: MagicMock) -> None:
+def override_hardware(hardware: MagicMock) -> Iterator[None]:
     async def get_hardware_override() -> HardwareControlAPI:
         """Override for get_hardware dependency"""
         return hardware

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -73,6 +73,8 @@ def override_hardware(hardware: MagicMock) -> None:
         return hardware
 
     app.dependency_overrides[get_hardware] = get_hardware_override
+    yield
+    del app.dependency_overrides[get_hardware]
 
 
 @pytest.fixture

--- a/robot-server/tests/service/session/test_router.py
+++ b/robot-server/tests/service/session/test_router.py
@@ -50,7 +50,8 @@ def sessions_api_client(mock_session_manager, api_client):
         return mock_session_manager
 
     api_client.app.dependency_overrides[get_session_manager] = get
-    return api_client
+    yield api_client
+    del api_client.app.dependency_overrides[get_session_manager]
 
 
 def test_get_session(mock_session_manager):


### PR DESCRIPTION
We had a couple PyTest fixtures like this:

```python
@pytest.fixture
def override_hardware(hardware: MagicMock) -> None:
    async def get_hardware_override() -> HardwareControlAPI:
        """Override for get_hardware dependency"""
        return hardware

    app.dependency_overrides[get_hardware] = get_hardware_override
```

This is meant to [override FastAPI's dependency injection](https://fastapi.tiangolo.com/advanced/testing-dependencies/), making FastAPI inject a mock to the endpoint functions instead of the actual dependency.

A tricky thing, though, is that `app` here is a global variable. This means, even though the fixture is test-scoped, the effect of the `app.dependency_overrides[get_hardware] = get_hardware_override` assignment lasts for the whole test *session*—leaking into tests that didn't explicitly request it. Anecdotally, I believe I've seen this cause confusing test behavior where tests pass or fail depending on whether they're run individually or as part of the whole suite.

This PR fixes it by undoing the override on fixture teardown. (See [the PyTest docs on `yield` fixtures](https://docs.pytest.org/en/6.2.x/fixture.html#yield-fixtures-recommended).)