### PR TITLE
feat(protocol-designer): hook up heater shaker command creator

### DIFF
--- a/protocol-designer/src/file-data/selectors/commands.ts
+++ b/protocol-designer/src/file-data/selectors/commands.ts
@@ -148,6 +148,11 @@ export const commandCreatorFromStepArgs = (
         StepGeneration.thermocyclerStateStep,
         args
       )
+    case 'heaterShaker':
+      return StepGeneration.curryCommandCreator(
+        StepGeneration.heaterShaker,
+        args
+      )
   }
   console.warn(`unhandled commandCreatorFnName: ${args.commandCreatorFnName}`)
   return null

--- a/protocol-designer/src/file-data/selectors/commands.ts
+++ b/protocol-designer/src/file-data/selectors/commands.ts
@@ -154,6 +154,8 @@ export const commandCreatorFromStepArgs = (
         args
       )
   }
+  // @ts-expect-error we've exhausted all command creators, but keeping this console warn
+  // for when we impelement the next command creator
   console.warn(`unhandled commandCreatorFnName: ${args.commandCreatorFnName}`)
   return null
 }

--- a/step-generation/src/index.ts
+++ b/step-generation/src/index.ts
@@ -18,6 +18,7 @@ export {
   thermocyclerStateStep,
   touchTip,
   transfer,
+  heaterShaker,
 } from './commandCreators'
 
 export * from './robotStateSelectors'


### PR DESCRIPTION
# Overview

This PR hooks up the heater shaker compound command creator that @sakibh implemented.

# Changelog
- Hook up heater shaker command creator

# Review requests

- Add a heater shaker step, inspect redux dev tools and look at the timeline data in `state.fileData.computedRobotStateTimeline.timeline`, command info should now be there 
- When you export a protocol with heater shaker steps they should also show up in the commands list of the JSON file

# Risk assessment

Low