### PR TITLE
chore(robot-server): Add aiosqlite==0.17.0 dependency

### DIFF
--- a/robot-server/Pipfile
+++ b/robot-server/Pipfile
@@ -1,24 +1,17 @@
 [[source]]
-
 url = "https://pypi.python.org/simple"
 verify_ssl = true
 name = "pypi"
 
-
 [requires]
-
 python_version = "3.7"
 
-
 [dev-packages]
-
 robot-server = { editable = true, path = "." }
-
 # pytest dependencies on windows, spec'd here to force lockfile inclusion
 # https://github.com/pypa/pipenv/issues/4408#issuecomment-668324177
 atomicwrites = { version = "==1.4.0", sys_platform = "== 'win32'" }
 colorama = { version = "==0.4.4", sys_platform = "== 'win32'" }
-
 pytest = "~=6.1"
 pytest-aiohttp = "==0.3.0"
 pytest-cov = "==2.10.1"
@@ -41,7 +34,6 @@ sqlalchemy2-stubs = "==0.0.2a21"
 python-box = "==5.4.1"
 
 [packages]
-
 opentrons = { editable = true, path = "../api" }
 opentrons-shared-data = { editable = true, path = "../shared-data/python" }
 notify-server = { editable = true, path = "../notify-server" }
@@ -63,3 +55,4 @@ numpy = "==1.21.2"
 zipp = "==3.5.0"
 opentrons-hardware = { editable = true, path = "./../hardware" }
 sqlalchemy = "==1.4.32"
+aiosqlite = "==0.17.0"

--- a/robot-server/Pipfile.lock
+++ b/robot-server/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a454e821427ee95beb89d62f4409f22ad1112b9ac6fc1d3d3dd5a6dc9fa01fcd"
+            "sha256": "6df21c44e73f444420eb295818b4a3202af2c62d4e393972d2881d300798797e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -30,6 +30,14 @@
                 "sha256:64b702ad0eb115034533f9f62730a9253b79f5ff0fbf3d100c392124cdf12507"
             ],
             "version": "==0.2.0"
+        },
+        "aiosqlite": {
+            "hashes": [
+                "sha256:6c49dc6d3405929b1d08eeccc72306d3677503cc5e5e43771efc1e00232e8231",
+                "sha256:f0e6acc24bc4864149267ac82fb46dfb3be4455f99fe21df82609cc6e6baee51"
+            ],
+            "index": "pypi",
+            "version": "==0.17.0"
         },
         "anyio": {
             "hashes": [
@@ -129,7 +137,7 @@
                 "sha256:fa877ca7f6b48054f847b61d6fa7bed5cebb663ebc55e018fda12db09dcc664c",
                 "sha256:fdcec0b8399108577ec290f55551d926d9a1fa6cad45882093a7a07ac5ec147b"
             ],
-            "markers": "python_version >= '3' and platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==1.1.2"
         },
         "h11": {
@@ -946,7 +954,7 @@
                 "sha256:fa877ca7f6b48054f847b61d6fa7bed5cebb663ebc55e018fda12db09dcc664c",
                 "sha256:fdcec0b8399108577ec290f55551d926d9a1fa6cad45882093a7a07ac5ec147b"
             ],
-            "markers": "python_version >= '3' and platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==1.1.2"
         },
         "h11": {
@@ -1590,7 +1598,7 @@
                 "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14",
                 "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==1.26.9"
         },
         "uvicorn": {


### PR DESCRIPTION
This PR adds a `robot-server` dependency on [`aiosqlite`](https://github.com/omnilib/aiosqlite). This will let us access our database through an `async` interface, instead of the traditional blocking synchronous one.

Opentrons/buildroot#157 bundles this dependency into the robot's operating system.

I'm being lazy and not re-locking the things that depend on robot-server, like `g-code-testing`, because a single `pipenv lock` takes literally 25 minutes on my machine. :rage4: 
