### PR TITLE
feat(protocol-designer): wire up moduleState for H-S on the deckmap

### DIFF
--- a/protocol-designer/src/components/DeckSetup/ModuleTag.tsx
+++ b/protocol-designer/src/components/DeckSetup/ModuleTag.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { useSelector } from 'react-redux'
 import cx from 'classnames'
-import { Flex, RobotCoordsForeignDiv } from '@opentrons/components'
+import { RobotCoordsForeignDiv, Text } from '@opentrons/components'
 import {
   getModuleVizDims,
   MAGNETIC_MODULE_TYPE,
@@ -126,16 +126,16 @@ export const ModuleStatus = ({
       return (
         <>
           <div className={styles.module_status_line}>
-            <Flex paddingBottom="2px">{i18n.t('modules.heater_label')}:</Flex>
-            <Flex>{makeTemperatureText(moduleState.targetTemp)}</Flex>
+            <Text paddingBottom="2px">{i18n.t('modules.heater_label')}:</Text>
+            <Text>{makeTemperatureText(moduleState.targetTemp)}</Text>
           </div>
           <div className={styles.module_status_line}>
-            <Flex paddingBottom="2px">{i18n.t('modules.shaker_label')}:</Flex>
-            <Flex>{makeSpeedText(moduleState.targetSpeed)}</Flex>
+            <Text paddingBottom="2px">{i18n.t('modules.shaker_label')}:</Text>
+            <Text>{makeSpeedText(moduleState.targetSpeed)}</Text>
           </div>
           <div className={styles.module_status_line}>
-            <Flex paddingBottom="2px"> {i18n.t('modules.labware_latch')}:</Flex>
-            <Flex>{latchStatus}</Flex>
+            <Text paddingBottom="2px"> {i18n.t('modules.labware_latch')}:</Text>
+            <Text>{latchStatus}</Text>
           </div>
           <div />
         </>

--- a/protocol-designer/src/components/DeckSetup/ModuleTag.tsx
+++ b/protocol-designer/src/components/DeckSetup/ModuleTag.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { useSelector } from 'react-redux'
 import cx from 'classnames'
-import { RobotCoordsForeignDiv } from '@opentrons/components'
+import { Flex, RobotCoordsForeignDiv } from '@opentrons/components'
 import {
   getModuleVizDims,
   MAGNETIC_MODULE_TYPE,
@@ -24,7 +24,7 @@ import { selectors as stepFormSelectors } from '../../step-forms'
 import { STD_SLOT_X_DIM, STD_SLOT_Y_DIM } from '../../constants'
 import * as uiSelectors from '../../ui/steps'
 import { getLabwareOnModule } from '../../ui/modules/utils'
-import { makeTemperatureText } from '../../utils'
+import { makeSpeedText, makeTemperatureText } from '../../utils'
 import styles from './ModuleTag.css'
 
 export interface ModuleTagProps {
@@ -112,20 +112,30 @@ export const ModuleStatus = ({
         </>
       )
     case HEATERSHAKER_MODULE_TYPE:
+      let latchStatus = null
+      switch (moduleState.latchOpen) {
+        case true:
+          latchStatus = i18n.t('modules.lid_open')
+          break
+        case false:
+          latchStatus = i18n.t('modules.lid_closed')
+          break
+        default:
+          latchStatus = i18n.t('modules.lid_undefined')
+      }
       return (
-        // TODO(sh, 2022-03-07): wire up heater shaker status values in follow up
         <>
           <div className={styles.module_status_line}>
-            <div>{i18n.t('modules.latch_label')}:</div>
-            <div>Undefined</div>
+            <Flex paddingBottom="2px">{i18n.t('modules.heater_label')}:</Flex>
+            <Flex>{makeTemperatureText(moduleState.targetTemp)}</Flex>
           </div>
           <div className={styles.module_status_line}>
-            <div>{i18n.t('modules.heater_label')}:</div>
-            <div>Deactivated</div>
+            <Flex paddingBottom="2px">{i18n.t('modules.shaker_label')}:</Flex>
+            <Flex>{makeSpeedText(moduleState.targetSpeed)}</Flex>
           </div>
           <div className={styles.module_status_line}>
-            <div>{i18n.t('modules.shaker_label')}:</div>
-            <div>Deactivated</div>
+            <Flex paddingBottom="2px"> {i18n.t('modules.labware_latch')}:</Flex>
+            <Flex>{latchStatus}</Flex>
           </div>
           <div />
         </>
@@ -138,7 +148,6 @@ export const ModuleStatus = ({
       return null
   }
 }
-
 const ModuleTagComponent = (props: ModuleTagProps): JSX.Element | null => {
   const timelineFrame = useSelector(timelineFrameBeforeActiveItem)
   const moduleEntity = useSelector(stepFormSelectors.getModuleEntities)[

--- a/protocol-designer/src/components/DeckSetup/__tests__/ModuleTag.test.tsx
+++ b/protocol-designer/src/components/DeckSetup/__tests__/ModuleTag.test.tsx
@@ -75,7 +75,7 @@ describe('ModuleTag', () => {
         }
         const component = render(<ModuleStatus moduleState={moduleState} />)
         expect(component.text()).toBe(
-          'Heater:40 °CShaker:400 RPMLabware Latch:closed'
+          'Heater:40 °CShaker:400 RPM Labware Latch:closed'
         )
       })
       it('displays a speed, and latch status when module is at target', () => {
@@ -87,7 +87,7 @@ describe('ModuleTag', () => {
         }
         const component = render(<ModuleStatus moduleState={moduleState} />)
         expect(component.text()).toBe(
-          'Heater:deactivatedShaker:deactivatedLabware Latch:open'
+          'Heater:deactivatedShaker:deactivated Labware Latch:open'
         )
       })
     })

--- a/protocol-designer/src/components/DeckSetup/__tests__/ModuleTag.test.tsx
+++ b/protocol-designer/src/components/DeckSetup/__tests__/ModuleTag.test.tsx
@@ -1,4 +1,5 @@
 import {
+  HEATERSHAKER_MODULE_TYPE,
   LabwareDefinition2,
   MAGNETIC_MODULE_TYPE,
   TEMPERATURE_MODULE_TYPE,
@@ -62,6 +63,32 @@ describe('ModuleTag', () => {
         const component = render(<ModuleStatus moduleState={moduleState} />)
 
         expect(component.text()).toBe('disengaged')
+      })
+    })
+    describe('heaterShaker module', () => {
+      it('displays a temperature, speed, and latch status when module is at target', () => {
+        const moduleState = {
+          type: HEATERSHAKER_MODULE_TYPE,
+          latchOpen: false,
+          targetTemp: 40,
+          targetSpeed: 400,
+        }
+        const component = render(<ModuleStatus moduleState={moduleState} />)
+        expect(component.text()).toBe(
+          'Heater:40 °CShaker:400 RPMLabware Latch:closed'
+        )
+      })
+      it('displays a speed, and latch status when module is at target', () => {
+        const moduleState = {
+          type: HEATERSHAKER_MODULE_TYPE,
+          latchOpen: true,
+          targetTemp: null,
+          targetSpeed: null,
+        }
+        const component = render(<ModuleStatus moduleState={moduleState} />)
+        expect(component.text()).toBe(
+          'Heater:deactivatedShaker:deactivatedLabware Latch:open'
+        )
       })
     })
 

--- a/protocol-designer/src/file-data/selectors/commands.ts
+++ b/protocol-designer/src/file-data/selectors/commands.ts
@@ -148,7 +148,6 @@ export const commandCreatorFromStepArgs = (
         StepGeneration.thermocyclerStateStep,
         args
       )
-
     case 'heaterShaker':
       return StepGeneration.curryCommandCreator(
         StepGeneration.heaterShaker,
@@ -165,7 +164,6 @@ export const getTimelineIsBeingComputed: Selector<boolean> = state =>
 // exposes errors and last valid robotState
 export const getRobotStateTimeline: Selector<StepGeneration.Timeline> = state =>
   state.fileData.computedRobotStateTimeline
-
 export const getSubsteps: Selector<Substeps> = state =>
   state.fileData.computedSubsteps
 type WarningsPerStep = {

--- a/protocol-designer/src/file-data/selectors/commands.ts
+++ b/protocol-designer/src/file-data/selectors/commands.ts
@@ -148,6 +148,7 @@ export const commandCreatorFromStepArgs = (
         StepGeneration.thermocyclerStateStep,
         args
       )
+
     case 'heaterShaker':
       return StepGeneration.curryCommandCreator(
         StepGeneration.heaterShaker,
@@ -164,6 +165,7 @@ export const getTimelineIsBeingComputed: Selector<boolean> = state =>
 // exposes errors and last valid robotState
 export const getRobotStateTimeline: Selector<StepGeneration.Timeline> = state =>
   state.fileData.computedRobotStateTimeline
+
 export const getSubsteps: Selector<Substeps> = state =>
   state.fileData.computedSubsteps
 type WarningsPerStep = {

--- a/protocol-designer/src/localization/en/modules.json
+++ b/protocol-designer/src/localization/en/modules.json
@@ -3,7 +3,7 @@
     "temperatureModuleType": "Temperature",
     "magneticModuleType": "Magnetic",
     "thermocyclerModuleType": "Thermocycler",
-    "heaterShakerModuleType": "Heater Shaker"
+    "heaterShakerModuleType": "Heater-Shaker"
   },
   "module_long_names": {
     "temperatureModuleType": "Temperature module",


### PR DESCRIPTION
# Overview

Closes #9739 

Wires up `moduleTag` to reflect added H-S statues 

<img width="320" alt="Screen Shot 2022-04-06 at 4 30 52 PM" src="https://user-images.githubusercontent.com/66035149/162066165-11557216-8dde-4fbc-849e-0de79d891dee.png">

# Changelog

- plugged in correct info in `moduleTag` to get HS `moduleState`
- small design tweaks to match figma

# Review requests

- should reflect designs

# Risk assessment

low behind ff