### PR TITLE
refactor(app): fix react warnings in module cards

### DIFF
--- a/app/src/atoms/MenuList/OverflowBtn.tsx
+++ b/app/src/atoms/MenuList/OverflowBtn.tsx
@@ -29,11 +29,9 @@ const overflowButtonStyles = css`
   }
 `
 
-export const OverflowBtn = (
-  props: React.ComponentProps<typeof Btn>
-): JSX.Element | null => {
-  return (
-    <Btn css={overflowButtonStyles} {...props}>
+export const OverflowBtn = React.forwardRef(
+  (props: React.ComponentProps<typeof Btn>, ref): JSX.Element | null => (
+    <Btn css={overflowButtonStyles} {...props} ref={ref}>
       <svg
         width="19"
         height="31"
@@ -48,4 +46,4 @@ export const OverflowBtn = (
       {props.children}
     </Btn>
   )
-}
+)


### PR DESCRIPTION
# Overview

This PR fixes two React errors where
-  a `div` was a child of a `p` element
- a `ref` was trying to be forwarded to a function component 
# Changelog

- fix warnings in module cards

# Review requests
Turn on the hierarchy reorg FF, go to the devices page, you should no longer see the two errors above
# Risk assessment
Low