### PR TITLE
refactor(robot-server): Log SQLAlchemy usage

### DIFF
--- a/robot-server/robot_server/service/logging.py
+++ b/robot-server/robot_server/service/logging.py
@@ -62,8 +62,8 @@ def _robot_log_config(log_level: int) -> Dict[str, Any]:
                 # to see things below WARN.
                 # docs.sqlalchemy.org/en/14/core/engines.html#configuring-logging
                 "level": log_level,
-                "propagate": False
-            }
+                "propagate": False,
+            },
         },
     }
 
@@ -104,7 +104,7 @@ def _dev_log_config(log_level: int) -> Dict[str, Any]:
                 # to see things below WARN.
                 # docs.sqlalchemy.org/en/14/core/engines.html#configuring-logging
                 "level": log_level,
-                "propagate": False
-            }
+                "propagate": False,
+            },
         },
     }

--- a/robot-server/robot_server/service/logging.py
+++ b/robot-server/robot_server/service/logging.py
@@ -54,6 +54,16 @@ def _robot_log_config(log_level: int) -> Dict[str, Any]:
                 "level": log_level,
                 "propagate": False,
             },
+            "sqlalchemy": {
+                "handlers": ["robot_server"],
+                # SQLAlchemy's logging is slightly unusual:
+                # they set up their logger with a default level of WARN by itself,
+                # so even if we enabled propagation, we'd have to override the level
+                # to see things below WARN.
+                # docs.sqlalchemy.org/en/14/core/engines.html#configuring-logging
+                "level": log_level,
+                "propagate": False
+            }
         },
     }
 
@@ -86,5 +96,15 @@ def _dev_log_config(log_level: int) -> Dict[str, Any]:
                 "level": log_level,
                 "propagate": False,
             },
+            "sqlalchemy": {
+                "handlers": ["robot_server"],
+                # SQLAlchemy's logging is slightly unusual:
+                # they set up their logger with a default level of WARN by itself,
+                # so even if we enabled propagation, we'd have to override the level
+                # to see things below WARN.
+                # docs.sqlalchemy.org/en/14/core/engines.html#configuring-logging
+                "level": log_level,
+                "propagate": False
+            }
         },
     }


### PR DESCRIPTION
# Overview

This PR turns on developer logs for `robot-server`'s usage of SQLAlchemy.

# Changelog

For both the dev server and production server:

* Set the SQLAlchemy logger's level to whatever we're using for everything else. [By default, it throws away everything below `WARN`](https://docs.sqlalchemy.org/en/14/core/engines.html#configuring-logging).
* Set the handler to the same handler we're using for everything else.
* Do not propagate to the root logger, because our root logger is unconfigured, and we set the set a handler on the `sqlalchemy` logger anyway. This just extends the pattern in the rest of our logging configuration; I don't understand why we do things this way instead of giving the root logger a handler and letting everything propagate up to it.


# Testing

* With `make dev`: ensure your `~/.opentrons/robot_settings.json` has a `log_level` of `"DEBUG"` or `"INFO"`. Then, run `make dev`, upload a protocol to `localhost`, and ensure you see SQL-related messages in the logs.
* On a robot: SSH in, do `journalctl --follow`, upload a protocol, and ensure you see SQL-related messages.

# Review requests

None in particular.

# Risk assessment

Low.
