### PR TITLE
refactor(app): fix heater shaker is shaking modal white screen

### DIFF
--- a/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
@@ -39,9 +39,11 @@ export const HeaterShakerWizard = (
   const attachedModules = useAttachedModules(robotName)
   const [targetProps, tooltipProps] = useHoverTooltip()
 
-  const heaterShaker = (attachedModules.find(
-    module => module.type === HEATERSHAKER_MODULE_TYPE
-  ) as unknown) as HeaterShakerModule
+  const heaterShaker =
+    attachedModules.find(
+      (module): module is HeaterShakerModule =>
+        module.type === HEATERSHAKER_MODULE_TYPE
+    ) ?? null
   let isPrimaryCTAEnabled: boolean = true
 
   if (currentPage === 4) {
@@ -74,11 +76,14 @@ export const HeaterShakerWizard = (
       case 5:
         buttonContent = t('complete')
         return (
-          <TestShake
-            module={heaterShaker}
-            setCurrentPage={setCurrentPage}
-            hasProtocol={hasProtocol}
-          />
+          // heaterShaker should never be null because isPrimaryCTAEnabled would be disabled otherwise
+          heaterShaker != null ? (
+            <TestShake
+              module={heaterShaker}
+              setCurrentPage={setCurrentPage}
+              hasProtocol={hasProtocol}
+            />
+          ) : null
         )
       default:
         return null

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -162,9 +162,10 @@ export function ProtocolRunHeader({
     false
   )
   const attachedModules = useAttachedModules(robotName)
-  const heaterShaker = (attachedModules.find(
-    module => module.type === HEATERSHAKER_MODULE_TYPE
-  ) as unknown) as HeaterShakerModule
+  const heaterShaker = attachedModules.find(
+    (module): module is HeaterShakerModule =>
+      module.type === HEATERSHAKER_MODULE_TYPE
+  )
   const isShaking = heaterShaker?.data?.speedStatus !== 'idle'
 
   const handleProceedToRunClick = (): void => {
@@ -447,7 +448,7 @@ export function ProtocolRunHeader({
               completedAt={completedAt}
             />
           </Box>
-          {showIsShakingModal && (
+          {showIsShakingModal && heaterShaker != null && (
             <HeaterShakerIsRunningModal
               closeModal={() => setShowIsShakingModal(false)}
               module={heaterShaker}


### PR DESCRIPTION
# Overview

This PR fixes the white screen we were seeing in the run page when we try to run a protocol without a heater shaker

# Review requests
Run a protocol without a heater shaker with the hierarchy reorg flag on, you should no longer see white screen caused by the heater shaker is shaking modal.

# Risk assessment
Low
