### PR TITLE
 feat(protocol-designer): H-S pause until modal

### DIFF
--- a/protocol-designer/src/components/StepEditForm/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/index.tsx
@@ -125,6 +125,12 @@ const StepEditFormManager = (
     handleChangeFormInput
   )
 
+  let displayTemp: string | null = null
+  if (formData?.stepType === 'temperature') {
+    displayTemp = formData?.targetTemperature
+  } else if (formData?.stepType === 'heaterShaker') {
+    displayTemp = formData?.targetHeaterShakerTemperature
+  }
   return (
     <>
       {showConfirmDeleteModal && (
@@ -145,7 +151,7 @@ const StepEditFormManager = (
       )}
       {showAddPauseUntilTempStepModal && (
         <AutoAddPauseUntilTempStepModal
-          displayTemperature={formData?.targetTemperature ?? '?'}
+          displayTemperature={displayTemp ?? '?'}
           handleCancelClick={saveStepForm}
           handleContinueClick={confirmAddPauseUntilTempStep}
         />

--- a/protocol-designer/src/components/StepEditForm/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/index.tsx
@@ -7,6 +7,7 @@ import { resetScrollElements } from '../../ui/steps/utils'
 import { selectors as stepFormSelectors } from '../../step-forms'
 import { maskField } from '../../steplist/fieldLevel'
 import { AutoAddPauseUntilTempStepModal } from '../modals/AutoAddPauseUntilTempStepModal'
+import { AutoAddPauseUntilHeaterShakerTempStepModal } from '../modals/AutoAddPauseUntilHeaterShakerTempStepModal'
 import {
   ConfirmDeleteModal,
   DELETE_STEP_FORM,
@@ -136,10 +137,7 @@ const StepEditFormManager = (
     formData,
     handleChangeFormInput
   )
-  console.log(formData)
-  console.log(formData?.targetHeaterShakerTemperature)
-  console.log(showAddPauseUntilHeaterShakerTempStepModal)
-  console.log(isPristineSetHeaterShakerTempForm)
+
   return (
     <>
       {showConfirmDeleteModal && (
@@ -158,15 +156,15 @@ const StepEditFormManager = (
           onContinueClick={confirmClose}
         />
       )}
-      {/* {showAddPauseUntilTempStepModal && (
+      {showAddPauseUntilTempStepModal && (
         <AutoAddPauseUntilTempStepModal
           displayTemperature={formData?.targetTemperature ?? '?'}
           handleCancelClick={saveStepForm}
           handleContinueClick={confirmAddPauseUntilTempStep}
         />
-      )} */}
+      )}
       {showAddPauseUntilHeaterShakerTempStepModal && (
-        <AutoAddPauseUntilTempStepModal
+        <AutoAddPauseUntilHeaterShakerTempStepModal
           displayTemperature={formData?.targetHeaterShakerTemperature ?? '?'}
           handleCancelClick={saveStepForm}
           handleContinueClick={confirmAddPauseUntilHeaterShakerTempStep}
@@ -181,11 +179,12 @@ const StepEditFormManager = (
           formData,
           handleClose: confirmClose,
           handleDelete: confirmDelete,
-          handleSave: isPristineSetTempForm
-            ? confirmAddPauseUntilTempStep
-            : isPristineSetHeaterShakerTempForm
-            ? confirmAddPauseUntilHeaterShakerTempStep
-            : saveStepForm,
+          handleSave:
+            isPristineSetTempForm === true
+              ? confirmAddPauseUntilTempStep
+              : isPristineSetHeaterShakerTempForm === true
+              ? confirmAddPauseUntilHeaterShakerTempStep
+              : saveStepForm,
           propsForFields,
           showMoreOptionsModal,
           toggleMoreOptionsModal,

--- a/protocol-designer/src/components/StepEditForm/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/index.tsx
@@ -25,11 +25,13 @@ interface SP {
   formHasChanges: boolean
   isNewStep: boolean
   isPristineSetTempForm: boolean
+  isPristineSetHeaterShakerTempForm: boolean
 }
 interface DP {
   deleteStep: (stepId: string) => unknown
   handleClose: () => unknown
   saveSetTempFormWithAddedPauseUntilTemp: () => unknown
+  saveSetTempFormWithAddedPauseUntilHeaterShakerTemp: () => unknown
   saveStepForm: () => unknown
   handleChangeFormInput: (name: string, value: unknown) => void
 }
@@ -47,7 +49,9 @@ const StepEditFormManager = (
     handleClose,
     isNewStep,
     isPristineSetTempForm,
+    isPristineSetHeaterShakerTempForm,
     saveSetTempFormWithAddedPauseUntilTemp,
+    saveSetTempFormWithAddedPauseUntilHeaterShakerTemp,
     saveStepForm,
   } = props
 
@@ -107,6 +111,14 @@ const StepEditFormManager = (
     isPristineSetTempForm
   )
 
+  const {
+    confirm: confirmAddPauseUntilHeaterShakerTempStep,
+    showConfirmation: showAddPauseUntilHeaterShakerTempStepModal,
+  } = useConditionalConfirm(
+    saveSetTempFormWithAddedPauseUntilHeaterShakerTemp,
+    isPristineSetHeaterShakerTempForm
+  )
+
   // no form selected
   if (formData == null) {
     return null
@@ -124,13 +136,10 @@ const StepEditFormManager = (
     formData,
     handleChangeFormInput
   )
-
-  let displayTemp: string | null = null
-  if (formData?.stepType === 'temperature') {
-    displayTemp = formData?.targetTemperature
-  } else if (formData?.stepType === 'heaterShaker') {
-    displayTemp = formData?.targetHeaterShakerTemperature
-  }
+  console.log(formData)
+  console.log(formData?.targetHeaterShakerTemperature)
+  console.log(showAddPauseUntilHeaterShakerTempStepModal)
+  console.log(isPristineSetHeaterShakerTempForm)
   return (
     <>
       {showConfirmDeleteModal && (
@@ -149,11 +158,18 @@ const StepEditFormManager = (
           onContinueClick={confirmClose}
         />
       )}
-      {showAddPauseUntilTempStepModal && (
+      {/* {showAddPauseUntilTempStepModal && (
         <AutoAddPauseUntilTempStepModal
-          displayTemperature={displayTemp ?? '?'}
+          displayTemperature={formData?.targetTemperature ?? '?'}
           handleCancelClick={saveStepForm}
           handleContinueClick={confirmAddPauseUntilTempStep}
+        />
+      )} */}
+      {showAddPauseUntilHeaterShakerTempStepModal && (
+        <AutoAddPauseUntilTempStepModal
+          displayTemperature={formData?.targetHeaterShakerTemperature ?? '?'}
+          handleCancelClick={saveStepForm}
+          handleContinueClick={confirmAddPauseUntilHeaterShakerTempStep}
         />
       )}
       <StepEditFormComponent
@@ -167,6 +183,8 @@ const StepEditFormManager = (
           handleDelete: confirmDelete,
           handleSave: isPristineSetTempForm
             ? confirmAddPauseUntilTempStep
+            : isPristineSetHeaterShakerTempForm
+            ? confirmAddPauseUntilHeaterShakerTempStep
             : saveStepForm,
           propsForFields,
           showMoreOptionsModal,
@@ -183,6 +201,9 @@ const mapStateToProps = (state: BaseState): SP => {
     formData: stepFormSelectors.getUnsavedForm(state),
     formHasChanges: stepFormSelectors.getCurrentFormHasUnsavedChanges(state),
     isNewStep: stepFormSelectors.getCurrentFormIsPresaved(state),
+    isPristineSetHeaterShakerTempForm: stepFormSelectors.getUnsavedFormIsPrestineSetHeaterShakerTempForm(
+      state
+    ),
     isPristineSetTempForm: stepFormSelectors.getUnsavedFormIsPristineSetTempForm(
       state
     ),
@@ -193,6 +214,8 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<any>): DP => {
   const deleteStep = (stepId: StepIdType): void =>
     dispatch(actions.deleteStep(stepId))
   const handleClose = (): void => dispatch(actions.cancelStepForm())
+  const saveSetTempFormWithAddedPauseUntilHeaterShakerTemp = (): void =>
+    dispatch(stepsActions.saveSetTempFormWithAddedPauseUntilHeaterShakerTemp())
   const saveSetTempFormWithAddedPauseUntilTemp = (): void =>
     dispatch(stepsActions.saveSetTempFormWithAddedPauseUntilTemp())
   const saveStepForm = (): void => dispatch(stepsActions.saveStepForm())
@@ -208,6 +231,7 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<any>): DP => {
     handleClose,
     saveSetTempFormWithAddedPauseUntilTemp,
     saveStepForm,
+    saveSetTempFormWithAddedPauseUntilHeaterShakerTemp,
   }
 }
 

--- a/protocol-designer/src/components/StepEditForm/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/index.tsx
@@ -32,7 +32,7 @@ interface DP {
   deleteStep: (stepId: string) => unknown
   handleClose: () => unknown
   saveSetTempFormWithAddedPauseUntilTemp: () => unknown
-  saveSetTempFormWithAddedPauseUntilHeaterShakerTemp: () => unknown
+  saveHeaterShakerFormWithAddedPauseUntilTemp: () => unknown
   saveStepForm: () => unknown
   handleChangeFormInput: (name: string, value: unknown) => void
 }
@@ -52,7 +52,7 @@ const StepEditFormManager = (
     isPristineSetTempForm,
     isPristineSetHeaterShakerTempForm,
     saveSetTempFormWithAddedPauseUntilTemp,
-    saveSetTempFormWithAddedPauseUntilHeaterShakerTemp,
+    saveHeaterShakerFormWithAddedPauseUntilTemp,
     saveStepForm,
   } = props
 
@@ -116,7 +116,7 @@ const StepEditFormManager = (
     confirm: confirmAddPauseUntilHeaterShakerTempStep,
     showConfirmation: showAddPauseUntilHeaterShakerTempStepModal,
   } = useConditionalConfirm(
-    saveSetTempFormWithAddedPauseUntilHeaterShakerTemp,
+    saveHeaterShakerFormWithAddedPauseUntilTemp,
     isPristineSetHeaterShakerTempForm
   )
 
@@ -137,6 +137,12 @@ const StepEditFormManager = (
     formData,
     handleChangeFormInput
   )
+  let handleSave
+  if (isPristineSetTempForm === true) {
+    handleSave = confirmAddPauseUntilTempStep
+  } else if (isPristineSetHeaterShakerTempForm === true) {
+    handleSave = confirmAddPauseUntilHeaterShakerTempStep
+  } else handleSave = saveStepForm
 
   return (
     <>
@@ -179,12 +185,7 @@ const StepEditFormManager = (
           formData,
           handleClose: confirmClose,
           handleDelete: confirmDelete,
-          handleSave:
-            isPristineSetTempForm === true
-              ? confirmAddPauseUntilTempStep
-              : isPristineSetHeaterShakerTempForm === true
-              ? confirmAddPauseUntilHeaterShakerTempStep
-              : saveStepForm,
+          handleSave: handleSave,
           propsForFields,
           showMoreOptionsModal,
           toggleMoreOptionsModal,
@@ -200,7 +201,7 @@ const mapStateToProps = (state: BaseState): SP => {
     formData: stepFormSelectors.getUnsavedForm(state),
     formHasChanges: stepFormSelectors.getCurrentFormHasUnsavedChanges(state),
     isNewStep: stepFormSelectors.getCurrentFormIsPresaved(state),
-    isPristineSetHeaterShakerTempForm: stepFormSelectors.getUnsavedFormIsPrestineSetHeaterShakerTempForm(
+    isPristineSetHeaterShakerTempForm: stepFormSelectors.getUnsavedFormIsPristineHeaterShakerForm(
       state
     ),
     isPristineSetTempForm: stepFormSelectors.getUnsavedFormIsPristineSetTempForm(
@@ -213,8 +214,8 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<any>): DP => {
   const deleteStep = (stepId: StepIdType): void =>
     dispatch(actions.deleteStep(stepId))
   const handleClose = (): void => dispatch(actions.cancelStepForm())
-  const saveSetTempFormWithAddedPauseUntilHeaterShakerTemp = (): void =>
-    dispatch(stepsActions.saveSetTempFormWithAddedPauseUntilHeaterShakerTemp())
+  const saveHeaterShakerFormWithAddedPauseUntilTemp = (): void =>
+    dispatch(stepsActions.saveHeaterShakerFormWithAddedPauseUntilTemp())
   const saveSetTempFormWithAddedPauseUntilTemp = (): void =>
     dispatch(stepsActions.saveSetTempFormWithAddedPauseUntilTemp())
   const saveStepForm = (): void => dispatch(stepsActions.saveStepForm())
@@ -230,7 +231,7 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<any>): DP => {
     handleClose,
     saveSetTempFormWithAddedPauseUntilTemp,
     saveStepForm,
-    saveSetTempFormWithAddedPauseUntilHeaterShakerTemp,
+    saveHeaterShakerFormWithAddedPauseUntilTemp,
   }
 }
 

--- a/protocol-designer/src/components/modals/AutoAddPauseUntilHeaterShakerTempStepModal.tsx
+++ b/protocol-designer/src/components/modals/AutoAddPauseUntilHeaterShakerTempStepModal.tsx
@@ -29,7 +29,7 @@ export const AutoAddPauseUntilHeaterShakerTempStepModal = (
       })}
     </p>
     <p className={styles.body}>
-      {i18n.t('modal.auto_add_pause_until_temp_step.body2', {
+      {i18n.t('modal.auto_add_pause_until_temp_step.heater_shaker_body2', {
         temperature: props.displayTemperature,
       })}
     </p>

--- a/protocol-designer/src/components/modals/AutoAddPauseUntilHeaterShakerTempStepModal.tsx
+++ b/protocol-designer/src/components/modals/AutoAddPauseUntilHeaterShakerTempStepModal.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react'
+import { AlertModal, OutlineButton, PrimaryButton } from '@opentrons/components'
+import { i18n } from '../../localization'
+import modalStyles from './modal.css'
+import styles from './AutoAddPauseUntilTempStepModal.css'
+
+interface Props {
+  displayTemperature: string
+  handleCancelClick: () => unknown
+  handleContinueClick: () => unknown
+}
+
+export const AutoAddPauseUntilHeaterShakerTempStepModal = (
+  props: Props
+): JSX.Element => (
+  <AlertModal
+    alertOverlay
+    className={modalStyles.modal}
+    contentsClassName={modalStyles.modal_contents}
+  >
+    <div className={styles.header}>
+      {i18n.t('modal.auto_add_pause_until_temp_step.heater_shaker_title', {
+        temperature: props.displayTemperature,
+      })}
+    </div>
+    <p className={styles.body}>
+      {i18n.t('modal.auto_add_pause_until_temp_step.body1', {
+        temperature: props.displayTemperature,
+      })}
+    </p>
+    <p className={styles.body}>
+      {i18n.t('modal.auto_add_pause_until_temp_step.body2', {
+        temperature: props.displayTemperature,
+      })}
+    </p>
+    <div className={modalStyles.button_row}>
+      <OutlineButton
+        className={styles.later_button}
+        onClick={props.handleCancelClick}
+      >
+        {i18n.t('modal.auto_add_pause_until_temp_step.later_button')}
+      </OutlineButton>
+      <PrimaryButton
+        className={styles.now_button}
+        onClick={props.handleContinueClick}
+      >
+        {i18n.t('modal.auto_add_pause_until_temp_step.now_button')}
+      </PrimaryButton>
+    </div>
+  </AlertModal>
+)

--- a/protocol-designer/src/components/modals/__tests__/AutoAddPauseUntilHeaterShakerTempStepModal.test.tsx
+++ b/protocol-designer/src/components/modals/__tests__/AutoAddPauseUntilHeaterShakerTempStepModal.test.tsx
@@ -29,12 +29,12 @@ describe('AutoAddPauseUntilHeaterShakerTempStepModal ', () => {
 
   it('should render the correct text with 10 C temp and buttons are clickable', () => {
     const { getByText, getByRole } = render(props)
-    getByText('Pause protocol until heater shaker module is at 10°C?')
+    getByText('Pause protocol until Heater-Shaker module is at 10°C?')
     getByText(
       'Pause protocol now to wait until module reaches 10°C before continuing on to the next step.'
     )
     getByText(
-      'Build a pause later if you want your protocol to proceed to the next steps while the temperature module ramps up to 10°C.'
+      'Build a pause later if you want your protocol to proceed to the next steps while the Heater-Shaker module ramps up to 10°C.'
     )
     const cancelBtn = getByRole('button', {
       name: 'I will build a pause later',

--- a/protocol-designer/src/components/modals/__tests__/AutoAddPauseUntilHeaterShakerTempStepModal.test.tsx
+++ b/protocol-designer/src/components/modals/__tests__/AutoAddPauseUntilHeaterShakerTempStepModal.test.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react'
+import i18next from 'i18next'
+import { fireEvent } from '@testing-library/react'
+import { renderWithProviders } from '@opentrons/components'
+import { AutoAddPauseUntilHeaterShakerTempStepModal } from '../AutoAddPauseUntilHeaterShakerTempStepModal'
+
+const render = (
+  props: React.ComponentProps<typeof AutoAddPauseUntilHeaterShakerTempStepModal>
+) => {
+  return renderWithProviders(
+    <AutoAddPauseUntilHeaterShakerTempStepModal {...props} />,
+    {
+      i18nInstance: i18next,
+    }
+  )[0]
+}
+
+describe('AutoAddPauseUntilHeaterShakerTempStepModal ', () => {
+  let props: React.ComponentProps<
+    typeof AutoAddPauseUntilHeaterShakerTempStepModal
+  >
+  beforeEach(() => {
+    props = {
+      displayTemperature: '10',
+      handleCancelClick: jest.fn(),
+      handleContinueClick: jest.fn(),
+    }
+  })
+
+  it('should render the correct text with 10 C temp and buttons are clickable', () => {
+    const { getByText, getByRole } = render(props)
+    getByText('Pause protocol until heater shaker module is at 10°C?')
+    getByText(
+      'Pause protocol now to wait until module reaches 10°C before continuing on to the next step.'
+    )
+    getByText(
+      'Build a pause later if you want your protocol to proceed to the next steps while the temperature module ramps up to 10°C.'
+    )
+    const cancelBtn = getByRole('button', {
+      name: 'I will build a pause later',
+    })
+    const contBtn = getByRole('button', { name: 'Pause protocol now' })
+    fireEvent.click(cancelBtn)
+    expect(props.handleCancelClick).toHaveBeenCalled()
+    fireEvent.click(contBtn)
+    expect(props.handleContinueClick).toHaveBeenCalled()
+  })
+})

--- a/protocol-designer/src/components/modals/__tests__/AutoAddPauseUntilTempStepModal.test.tsx
+++ b/protocol-designer/src/components/modals/__tests__/AutoAddPauseUntilTempStepModal.test.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react'
+import i18next from 'i18next'
+import { fireEvent } from '@testing-library/react'
+import { renderWithProviders } from '@opentrons/components'
+import { AutoAddPauseUntilTempStepModal } from '../AutoAddPauseUntilTempStepModal'
+
+const render = (
+  props: React.ComponentProps<typeof AutoAddPauseUntilTempStepModal>
+) => {
+  return renderWithProviders(<AutoAddPauseUntilTempStepModal {...props} />, {
+    i18nInstance: i18next,
+  })[0]
+}
+
+describe('AutoAddPauseUntilTempStepModal ', () => {
+  let props: React.ComponentProps<typeof AutoAddPauseUntilTempStepModal>
+  beforeEach(() => {
+    props = {
+      displayTemperature: '10',
+      handleCancelClick: jest.fn(),
+      handleContinueClick: jest.fn(),
+    }
+  })
+
+  it('should render the correct text with 10 C temp and buttons are clickable', () => {
+    const { getByText, getByRole } = render(props)
+    getByText('Pause protocol until temperature module is at 10°C?')
+    getByText(
+      'Pause protocol now to wait until module reaches 10°C before continuing on to the next step.'
+    )
+    getByText(
+      'Build a pause later if you want your protocol to proceed to the next steps while the temperature module ramps up to 10°C.'
+    )
+    const cancelBtn = getByRole('button', {
+      name: 'I will build a pause later',
+    })
+    const contBtn = getByRole('button', { name: 'Pause protocol now' })
+    fireEvent.click(cancelBtn)
+    expect(props.handleCancelClick).toHaveBeenCalled()
+    fireEvent.click(contBtn)
+    expect(props.handleContinueClick).toHaveBeenCalled()
+  })
+})

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -155,9 +155,10 @@
   },
   "auto_add_pause_until_temp_step": {
     "title": "Pause protocol until temperature module is at {{temperature}}°C?",
-    "heater_shaker_title": "Pause protocol until heater shaker module is at {{temperature}}°C?",
+    "heater_shaker_title": "Pause protocol until Heater-Shaker module is at {{temperature}}°C?",
     "body1": "Pause protocol now to wait until module reaches {{temperature}}°C before continuing on to the next step.",
     "body2": "Build a pause later if you want your protocol to proceed to the next steps while the temperature module ramps up to {{temperature}}°C.",
+    "heater_shaker_body2": "Build a pause later if you want your protocol to proceed to the next steps while the Heater-Shaker module ramps up to {{temperature}}°C.",
     "now_button": "Pause protocol now",
     "later_button": "I will build a pause later"
   },

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -155,6 +155,7 @@
   },
   "auto_add_pause_until_temp_step": {
     "title": "Pause protocol until temperature module is at {{temperature}}°C?",
+    "heater_shaker_title": "Pause protocol until heater shaker module is at {{temperature}}°C?",
     "body1": "Pause protocol now to wait until module reaches {{temperature}}°C before continuing on to the next step.",
     "body2": "Build a pause later if you want your protocol to proceed to the next steps while the temperature module ramps up to {{temperature}}°C.",
     "now_button": "Pause protocol now",

--- a/protocol-designer/src/step-forms/selectors/index.ts
+++ b/protocol-designer/src/step-forms/selectors/index.ts
@@ -638,8 +638,10 @@ export const getUnsavedFormIsPristineSetTempForm: Selector<
   getCurrentFormIsPresaved,
   (unsavedForm, isPresaved) => {
     const isSetTempForm =
-      unsavedForm?.stepType === 'temperature' &&
-      unsavedForm?.setTemperature === 'true'
+      (unsavedForm?.stepType === 'temperature' &&
+        unsavedForm?.setTemperature === 'true') ||
+      (unsavedForm?.stepType === 'heaterShaker' &&
+        unsavedForm?.setTemperature === 'true')
     return isPresaved && isSetTempForm
   }
 )

--- a/protocol-designer/src/step-forms/selectors/index.ts
+++ b/protocol-designer/src/step-forms/selectors/index.ts
@@ -638,11 +638,25 @@ export const getUnsavedFormIsPristineSetTempForm: Selector<
   getCurrentFormIsPresaved,
   (unsavedForm, isPresaved) => {
     const isSetTempForm =
-      (unsavedForm?.stepType === 'temperature' &&
-        unsavedForm?.setTemperature === 'true') ||
-      (unsavedForm?.stepType === 'heaterShaker' &&
-        unsavedForm?.setTemperature === 'true')
+      unsavedForm?.stepType === 'temperature' &&
+      unsavedForm?.setTemperature === 'true'
+
     return isPresaved && isSetTempForm
+  }
+)
+
+export const getUnsavedFormIsPrestineSetHeaterShakerTempForm: Selector<
+  BaseState,
+  boolean
+> = createSelector(
+  getUnsavedForm,
+  getCurrentFormIsPresaved,
+  (unsavedForm, isPresaved) => {
+    const isSetHsTempForm =
+      unsavedForm?.stepType === 'heaterShaker' &&
+      unsavedForm?.setTemperature === 'true'
+
+    return isPresaved && isSetHsTempForm
   }
 )
 export const getFormLevelWarningsForUnsavedForm: Selector<

--- a/protocol-designer/src/step-forms/selectors/index.ts
+++ b/protocol-designer/src/step-forms/selectors/index.ts
@@ -645,7 +645,7 @@ export const getUnsavedFormIsPristineSetTempForm: Selector<
   }
 )
 
-export const getUnsavedFormIsPrestineSetHeaterShakerTempForm: Selector<
+export const getUnsavedFormIsPristineHeaterShakerForm: Selector<
   BaseState,
   boolean
 > = createSelector(

--- a/protocol-designer/src/step-forms/selectors/index.ts
+++ b/protocol-designer/src/step-forms/selectors/index.ts
@@ -654,7 +654,7 @@ export const getUnsavedFormIsPrestineSetHeaterShakerTempForm: Selector<
   (unsavedForm, isPresaved) => {
     const isSetHsTempForm =
       unsavedForm?.stepType === 'heaterShaker' &&
-      unsavedForm?.setTemperature === 'true'
+      unsavedForm?.targetHeaterShakerTemperature !== null
 
     return isPresaved && isSetHsTempForm
   }

--- a/protocol-designer/src/step-forms/test/selectors.test.ts
+++ b/protocol-designer/src/step-forms/test/selectors.test.ts
@@ -2,6 +2,8 @@ import {
   _hasFieldLevelErrors,
   getEquippedPipetteOptions,
   getBatchEditFormHasUnsavedChanges,
+  getUnsavedFormIsPristineHeaterShakerForm,
+  getUnsavedFormIsPristineSetTempForm,
 } from '../selectors'
 import { getFieldErrors } from '../../steplist/fieldLevel'
 import { getProfileItemsHaveErrors } from '../utils/getProfileItemsHaveErrors'
@@ -152,5 +154,69 @@ describe('getBatchEditFormHasUnsavedChanges', () => {
   it('should return false if there are no unsaved changes ', () => {
     // @ts-expect-error(sa, 2021-6-14): resultFunc (from reselect) is weirdly not part of their Selector interface
     expect(getBatchEditFormHasUnsavedChanges.resultFunc({})).toBe(false)
+  })
+})
+
+describe('getUnsavedFormIsPristineSetTempForm', () => {
+  const mockIsPresaved = true
+  it('should return true if temperature mod set temp is true formData ', () => {
+    // @ts-expect-error(jr, 4/8/22): missing module id
+    const formData: FormData = {
+      stepType: 'temperature',
+      setTemperature: 'true',
+    }
+    const expected = true
+    // @ts-expect-error(jr, 4/8/22): resultFunc (from reselect) is not part of their Selector interface
+    const result = getUnsavedFormIsPristineSetTempForm.resultFunc(
+      formData,
+      mockIsPresaved
+    )
+    expect(result).toEqual(expected)
+  })
+  it('should return false if temperature mod is false in formData ', () => {
+    // @ts-expect-error(jr, 4/8/22): missing module id
+    const formData: FormData = {
+      stepType: 'temperature',
+      setTemperature: null,
+    }
+    const expected = false
+    // @ts-expect-error(jr, 4/8/22): resultFunc (from reselect) is not part of their Selector interface
+    const result = getUnsavedFormIsPristineSetTempForm.resultFunc(
+      formData,
+      mockIsPresaved
+    )
+    expect(result).toEqual(expected)
+  })
+})
+
+describe('getUnsavedFormIsPrestineSetHeaterShakerTempForm', () => {
+  const mockIsPresaved = true
+  it('should return true if heater shaker temperature is true in formData ', () => {
+    // @ts-expect-error(jr, 4/8/22): missing module id
+    const formData: FormData = {
+      stepType: 'heaterShaker',
+      targetHeaterShakerTemperature: '10',
+    }
+    const expected = true
+    // @ts-expect-error(jr, 4/8/22): resultFunc (from reselect) is not part of their Selector interface
+    const result = getUnsavedFormIsPristineHeaterShakerForm.resultFunc(
+      formData,
+      mockIsPresaved
+    )
+    expect(result).toEqual(expected)
+  })
+  it('should return false if heater shaker temperature is false in formData ', () => {
+    // @ts-expect-error(jr, 4/8/22): missing module id
+    const formData: FormData = {
+      stepType: 'heaterShaker',
+      targetHeaterShakerTemperature: null,
+    }
+    const expected = false
+    // @ts-expect-error(jr, 4/8/22): resultFunc (from reselect) is not part of their Selector interface
+    const result = getUnsavedFormIsPristineHeaterShakerForm.resultFunc(
+      formData,
+      mockIsPresaved
+    )
+    expect(result).toEqual(expected)
   })
 })

--- a/protocol-designer/src/ui/steps/actions/__tests__/actions.test.ts
+++ b/protocol-designer/src/ui/steps/actions/__tests__/actions.test.ts
@@ -4,11 +4,19 @@ import thunk from 'redux-thunk'
 import { when, resetAllWhenMocks } from 'jest-when'
 import * as utils from '../../../../utils'
 import * as stepFormSelectors from '../../../../step-forms/selectors'
+import { getRobotStateTimeline } from '../../../../file-data/selectors'
 import { getMultiSelectLastSelected } from '../../selectors'
 import { selectStep, selectAllSteps, deselectAllSteps } from '../actions'
-import { duplicateStep, duplicateMultipleSteps } from '../thunks'
+import {
+  duplicateStep,
+  duplicateMultipleSteps,
+  saveHeaterShakerFormWithAddedPauseUntilTemp,
+} from '../thunks'
+
 jest.mock('../../../../step-forms/selectors')
 jest.mock('../../selectors')
+jest.mock('../../../../file-data/selectors')
+
 const mockStore = configureMockStore([thunk])
 const mockGetSavedStepForms = stepFormSelectors.getSavedStepForms as jest.MockedFunction<
   typeof stepFormSelectors.getSavedStepForms
@@ -18,6 +26,16 @@ const mockGetOrderedStepIds = stepFormSelectors.getOrderedStepIds as jest.Mocked
 >
 const mockGetMultiSelectLastSelected = getMultiSelectLastSelected as jest.MockedFunction<
   typeof getMultiSelectLastSelected
+>
+
+const mockGetUnsavedForm = stepFormSelectors.getUnsavedForm as jest.MockedFunction<
+  typeof stepFormSelectors.getUnsavedForm
+>
+const mockGetUnsavedFormIsPristineHeaterShakerForm = stepFormSelectors.getUnsavedFormIsPristineHeaterShakerForm as jest.MockedFunction<
+  typeof stepFormSelectors.getUnsavedFormIsPristineHeaterShakerForm
+>
+const mockGetRobotStateTimeline = getRobotStateTimeline as jest.MockedFunction<
+  typeof getRobotStateTimeline
 >
 describe('steps actions', () => {
   describe('selectStep', () => {
@@ -254,6 +272,82 @@ describe('steps actions', () => {
         duplicateStepsAction,
         selectMultipleStepsAction,
       ])
+    })
+  })
+  describe('saveHeaterShakerFormWithAddedPauseUntilTemp', () => {
+    const mockRobotStateTimeline = {
+      commands: {
+        commandType: 'heaterShakerModule/awaitTemperature',
+      },
+    } as any
+
+    beforeEach(() => {
+      when(mockGetUnsavedForm)
+        .calledWith(expect.anything())
+        .mockReturnValue({
+          stepType: 'heaterShaker',
+          targetHeaterShakerTemperature: '10',
+        } as any)
+      mockGetUnsavedFormIsPristineHeaterShakerForm.mockReturnValue(true)
+      mockGetRobotStateTimeline.mockReturnValue(mockRobotStateTimeline)
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('should save heater shaker step with a pause until temp is reached', () => {
+      const HsStepWithPause = [
+        {
+          payload: {
+            stepType: 'heaterShaker',
+            targetHeaterShakerTemperature: '10',
+          },
+          type: 'SAVE_STEP_FORM',
+        },
+        {
+          meta: {
+            robotStateTimeline: {
+              commands: {
+                commandType: 'heaterShakerModule/awaitTemperature',
+              },
+            },
+          },
+          payload: {
+            id: '__presaved_step__',
+            stepType: 'pause',
+          },
+          type: 'ADD_STEP',
+        },
+        {
+          payload: {
+            update: {
+              pauseAction: 'untilTemperature',
+            },
+          },
+          type: 'CHANGE_FORM_INPUT',
+        },
+        {
+          payload: {
+            update: {
+              pauseTemperature: '10',
+            },
+          },
+          type: 'CHANGE_FORM_INPUT',
+        },
+        {
+          payload: {
+            stepType: 'heaterShaker',
+            targetHeaterShakerTemperature: '10',
+          },
+          type: 'SAVE_STEP_FORM',
+        },
+      ]
+
+      const store: any = mockStore()
+      store.dispatch(saveHeaterShakerFormWithAddedPauseUntilTemp())
+
+      expect(store.getActions()).toEqual(HsStepWithPause)
     })
   })
 })

--- a/protocol-designer/src/ui/steps/actions/thunks/index.ts
+++ b/protocol-designer/src/ui/steps/actions/thunks/index.ts
@@ -3,7 +3,7 @@ import last from 'lodash/last'
 import {
   getUnsavedForm,
   getUnsavedFormIsPristineSetTempForm,
-  getUnsavedFormIsPrestineSetHeaterShakerTempForm,
+  getUnsavedFormIsPristineHeaterShakerForm,
   getOrderedStepIds,
 } from '../../../../step-forms/selectors'
 import { changeFormInput } from '../../../../steplist/actions/actions'
@@ -260,13 +260,13 @@ export const saveSetTempFormWithAddedPauseUntilTemp: () => ThunkAction<any> = ()
   }
 }
 
-export const saveSetTempFormWithAddedPauseUntilHeaterShakerTemp: () => ThunkAction<any> = () => (
+export const saveHeaterShakerFormWithAddedPauseUntilTemp: () => ThunkAction<any> = () => (
   dispatch,
   getState
 ) => {
   const initialState = getState()
   const unsavedSetHeaterShakerTemperatureForm = getUnsavedForm(initialState)
-  const isPristineSetHeaterShakerTempForm = getUnsavedFormIsPrestineSetHeaterShakerTempForm(
+  const isPristineSetHeaterShakerTempForm = getUnsavedFormIsPristineHeaterShakerForm(
     initialState
   )
 

--- a/protocol-designer/src/ui/steps/actions/thunks/index.ts
+++ b/protocol-designer/src/ui/steps/actions/thunks/index.ts
@@ -3,6 +3,7 @@ import last from 'lodash/last'
 import {
   getUnsavedForm,
   getUnsavedFormIsPristineSetTempForm,
+  getUnsavedFormIsPrestineSetHeaterShakerTempForm,
   getOrderedStepIds,
 } from '../../../../step-forms/selectors'
 import { changeFormInput } from '../../../../steplist/actions/actions'
@@ -218,6 +219,7 @@ export const saveSetTempFormWithAddedPauseUntilTemp: () => ThunkAction<any> = ()
   }
 
   const temperature = unsavedSetTemperatureForm?.targetTemperature
+
   assert(
     temperature != null && temperature !== '',
     `tried to auto-add a pause until temp, but targetTemperature is missing: ${temperature}`
@@ -251,6 +253,71 @@ export const saveSetTempFormWithAddedPauseUntilTemp: () => ThunkAction<any> = ()
   const unsavedPauseForm = getUnsavedForm(getState())
 
   // this conditional is for Flow, the unsaved form should always exist
+  if (unsavedPauseForm != null) {
+    dispatch(_saveStepForm(unsavedPauseForm))
+  } else {
+    assert(false, 'could not auto-save pause form, getUnsavedForm returned')
+  }
+}
+
+export const saveSetTempFormWithAddedPauseUntilHeaterShakerTemp: () => ThunkAction<any> = () => (
+  dispatch,
+  getState
+) => {
+  const initialState = getState()
+  const unsavedSetHeaterShakerTemperatureForm = getUnsavedForm(initialState)
+  const isPristineSetHeaterShakerTempForm = getUnsavedFormIsPrestineSetHeaterShakerTempForm(
+    initialState
+  )
+
+  if (!unsavedSetHeaterShakerTemperatureForm) {
+    assert(
+      false,
+      'Tried to saveSetHeaterShakerTempFormWithAddedPauseUntilTemp with falsey unsavedForm. This should never be able to happen.'
+    )
+    return
+  }
+
+  const { id } = unsavedSetHeaterShakerTemperatureForm
+
+  if (!isPristineSetHeaterShakerTempForm) {
+    assert(
+      false,
+      `tried to saveSetHeaterShakerTempFormWithAddedPauseUntilTemp but form ${id} is not a pristine set heater shaker temp form`
+    )
+    return
+  }
+
+  const temperature =
+    unsavedSetHeaterShakerTemperatureForm?.targetHeaterShakerTemperature
+
+  assert(
+    temperature != null && temperature !== '',
+    `tried to auto-add a pause until temp, but targetHeaterShakerTemperature is missing: ${temperature}`
+  )
+  dispatch(_saveStepForm(unsavedSetHeaterShakerTemperatureForm))
+  dispatch(
+    addStep({
+      stepType: 'pause',
+      robotStateTimeline: fileDataSelectors.getRobotStateTimeline(getState()),
+    })
+  )
+  dispatch(
+    changeFormInput({
+      update: {
+        pauseAction: PAUSE_UNTIL_TEMP,
+      },
+    })
+  )
+  dispatch(
+    changeFormInput({
+      update: {
+        pauseTemperature: temperature,
+      },
+    })
+  )
+  const unsavedPauseForm = getUnsavedForm(getState())
+
   if (unsavedPauseForm != null) {
     dispatch(_saveStepForm(unsavedPauseForm))
   } else {


### PR DESCRIPTION
closes #9735 

# Overview

This PR creates the `pause until` modal for the heater shaker when it is added to the timeline with no timing for how long the temperature should last.

<img width="630" alt="Screen Shot 2022-04-08 at 9 00 08 AM" src="https://user-images.githubusercontent.com/66035149/162440651-e7505720-5362-4f31-ae8c-a314eb23861f.png">

# Changelog

- created its own thunk, selector, and modal to keep it separate from temperature module in case one of them changes in the future it would be easier to implement 

# Review requests

- check on PD, does it work as expected?

# Risk assessment

low behind ff