### PR TITLE
feat(protocol-designer): pipette step validation for H-S latch open

### DIFF
--- a/protocol-designer/src/components/StepEditForm/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/index.tsx
@@ -137,7 +137,7 @@ const StepEditFormManager = (
     formData,
     handleChangeFormInput
   )
-  let handleSave
+  let handleSave = saveStepForm
   if (isPristineSetTempForm === true) {
     handleSave = confirmAddPauseUntilTempStep
   } else if (isPristineSetHeaterShakerTempForm === true) {

--- a/protocol-designer/src/components/StepEditForm/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/index.tsx
@@ -142,7 +142,7 @@ const StepEditFormManager = (
     handleSave = confirmAddPauseUntilTempStep
   } else if (isPristineSetHeaterShakerTempForm === true) {
     handleSave = confirmAddPauseUntilHeaterShakerTempStep
-  } else handleSave = saveStepForm
+  }
 
   return (
     <>

--- a/protocol-designer/src/components/modals/AutoAddPauseUntilHeaterShakerTempStepModal.tsx
+++ b/protocol-designer/src/components/modals/AutoAddPauseUntilHeaterShakerTempStepModal.tsx
@@ -29,9 +29,12 @@ export const AutoAddPauseUntilHeaterShakerTempStepModal = (
       })}
     </p>
     <p className={styles.body}>
-      {i18n.t('modal.auto_add_pause_until_temp_step.heater_shaker_body2', {
-        temperature: props.displayTemperature,
-      })}
+      {i18n.t(
+        'modal.auto_add_pause_until_temp_step.heater_shaker_pause_later',
+        {
+          temperature: props.displayTemperature,
+        }
+      )}
     </p>
     <div className={modalStyles.button_row}>
       <OutlineButton

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -113,6 +113,10 @@
       "THERMOCYCLER_LID_CLOSED": {
         "title": "Thermocycler lid is closed",
         "body": "Before a pipette can interact with labware in the Thermocycler, the lid must be open. To resolve this error, please add a thermocycler step ahead of the current step, and set the lid status to \"open\"."
+      },
+      "HEATER_SHAKER_LATCH_OPEN": {
+        "title": "Heater-Shaker labware latch is open",
+        "body": "Before a pipette can interact with labware on the Heater-Shaker module, the labware latch must be closed. To resolve this error, please add a Heater-Shaker step ahead of the current step, and set the labware latch status to \"closed\"."
       }
     },
     "warning": {

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -158,7 +158,7 @@
     "heater_shaker_title": "Pause protocol until Heater-Shaker module is at {{temperature}}°C?",
     "body1": "Pause protocol now to wait until module reaches {{temperature}}°C before continuing on to the next step.",
     "body2": "Build a pause later if you want your protocol to proceed to the next steps while the temperature module ramps up to {{temperature}}°C.",
-    "heater_shaker_body2": "Build a pause later if you want your protocol to proceed to the next steps while the Heater-Shaker module ramps up to {{temperature}}°C.",
+    "heater_shaker_pause_later": "Build a pause later if you want your protocol to proceed to the next steps while the Heater-Shaker module ramps up to {{temperature}}°C.",
     "now_button": "Pause protocol now",
     "later_button": "I will build a pause later"
   },

--- a/protocol-designer/src/step-forms/selectors/index.ts
+++ b/protocol-designer/src/step-forms/selectors/index.ts
@@ -640,7 +640,6 @@ export const getUnsavedFormIsPristineSetTempForm: Selector<
     const isSetTempForm =
       unsavedForm?.stepType === 'temperature' &&
       unsavedForm?.setTemperature === 'true'
-
     return isPresaved && isSetTempForm
   }
 )

--- a/protocol-designer/src/ui/steps/actions/__tests__/actions.test.ts
+++ b/protocol-designer/src/ui/steps/actions/__tests__/actions.test.ts
@@ -13,6 +13,7 @@ import {
   saveHeaterShakerFormWithAddedPauseUntilTemp,
   saveSetTempFormWithAddedPauseUntilTemp,
 } from '../thunks'
+import type { Timeline, RobotState } from '@opentrons/step-generation/src/types'
 
 jest.mock('../../../../step-forms/selectors')
 jest.mock('../../selectors')
@@ -41,6 +42,34 @@ const mockGetUnsavedFormIsPristineSetTempForm = stepFormSelectors.getUnsavedForm
 const mockGetRobotStateTimeline = getRobotStateTimeline as jest.MockedFunction<
   typeof getRobotStateTimeline
 >
+
+const initialRobotState: RobotState = {
+  labware: {
+    trashId: {
+      slot: '12',
+    },
+    tiprackId: {
+      slot: '1',
+    },
+    plateId: {
+      slot: '7',
+    },
+  },
+  modules: {},
+  pipettes: {
+    pipetteId: {
+      mount: 'left',
+    },
+  },
+  liquidState: {
+    pipettes: {},
+    labware: {},
+  },
+  tipState: {
+    pipettes: {},
+    tipracks: {},
+  },
+}
 
 describe('steps actions', () => {
   describe('selectStep', () => {
@@ -279,12 +308,26 @@ describe('steps actions', () => {
       ])
     })
   })
+
   describe('saveHeaterShakerFormWithAddedPauseUntilTemp', () => {
-    const mockRobotStateTimeline = {
-      commands: {
-        commandType: 'heaterShakerModule/awaitTemperature',
-      },
-    } as any
+    const mockRobotStateTimeline: Timeline = {
+      timeline: [
+        {
+          commands: [
+            {
+              commandType: 'heaterShakerModule/awaitTemperature',
+
+              params: {
+                moduleId: 'heaterShakerId',
+              },
+            },
+          ],
+          robotState: initialRobotState,
+          warnings: [],
+        },
+      ],
+      errors: null,
+    }
 
     beforeEach(() => {
       when(mockGetUnsavedForm)
@@ -310,12 +353,51 @@ describe('steps actions', () => {
           },
           type: 'SAVE_STEP_FORM',
         },
+
         {
           meta: {
             robotStateTimeline: {
-              commands: {
-                commandType: 'heaterShakerModule/awaitTemperature',
-              },
+              errors: null,
+              timeline: [
+                {
+                  commands: [
+                    {
+                      commandType: 'heaterShakerModule/awaitTemperature',
+                      params: {
+                        moduleId: 'heaterShakerId',
+                      },
+                    },
+                  ],
+                  robotState: {
+                    labware: {
+                      plateId: {
+                        slot: '7',
+                      },
+                      tiprackId: {
+                        slot: '1',
+                      },
+                      trashId: {
+                        slot: '12',
+                      },
+                    },
+                    liquidState: {
+                      labware: {},
+                      pipettes: {},
+                    },
+                    modules: {},
+                    pipettes: {
+                      pipetteId: {
+                        mount: 'left',
+                      },
+                    },
+                    tipState: {
+                      pipettes: {},
+                      tipracks: {},
+                    },
+                  },
+                  warnings: [],
+                },
+              ],
             },
           },
           payload: {
@@ -328,6 +410,14 @@ describe('steps actions', () => {
           payload: {
             update: {
               pauseAction: 'untilTemperature',
+            },
+          },
+          type: 'CHANGE_FORM_INPUT',
+        },
+        {
+          payload: {
+            update: {
+              moduleId: undefined,
             },
           },
           type: 'CHANGE_FORM_INPUT',
@@ -357,11 +447,25 @@ describe('steps actions', () => {
   })
 
   describe('saveSetTempFormWithAddedPauseUntilTemp', () => {
-    const mockRobotStateTimeline = {
-      commands: {
-        commandType: 'temperatureModule/setTargetTemperature',
-      },
-    } as any
+    const mockRobotStateTimeline: Timeline = {
+      timeline: [
+        {
+          commands: [
+            {
+              commandType: 'temperatureModule/setTargetTemperature',
+
+              params: {
+                moduleId: 'temperatureId',
+                temperature: 25,
+              },
+            },
+          ],
+          robotState: initialRobotState,
+          warnings: [],
+        },
+      ],
+      errors: null,
+    }
 
     beforeEach(() => {
       when(mockGetUnsavedForm)
@@ -383,18 +487,58 @@ describe('steps actions', () => {
       const temperatureStepWithPause = [
         {
           payload: {
-            stepType: 'temperature',
             setTemperature: 'true',
+            stepType: 'temperature',
             targetTemperature: 10,
           },
           type: 'SAVE_STEP_FORM',
         },
+
         {
           meta: {
             robotStateTimeline: {
-              commands: {
-                commandType: 'temperatureModule/setTargetTemperature',
-              },
+              errors: null,
+              timeline: [
+                {
+                  commands: [
+                    {
+                      commandType: 'temperatureModule/setTargetTemperature',
+                      params: {
+                        moduleId: 'temperatureId',
+                        temperature: 25,
+                      },
+                    },
+                  ],
+                  robotState: {
+                    labware: {
+                      plateId: {
+                        slot: '7',
+                      },
+                      tiprackId: {
+                        slot: '1',
+                      },
+                      trashId: {
+                        slot: '12',
+                      },
+                    },
+                    liquidState: {
+                      labware: {},
+                      pipettes: {},
+                    },
+                    modules: {},
+                    pipettes: {
+                      pipetteId: {
+                        mount: 'left',
+                      },
+                    },
+                    tipState: {
+                      pipettes: {},
+                      tipracks: {},
+                    },
+                  },
+                  warnings: [],
+                },
+              ],
             },
           },
           payload: {

--- a/protocol-designer/src/ui/steps/actions/thunks/index.ts
+++ b/protocol-designer/src/ui/steps/actions/thunks/index.ts
@@ -265,12 +265,12 @@ export const saveHeaterShakerFormWithAddedPauseUntilTemp: () => ThunkAction<any>
   getState
 ) => {
   const initialState = getState()
-  const unsavedSetHeaterShakerForm = getUnsavedForm(initialState)
+  const unsavedHeaterShakerForm = getUnsavedForm(initialState)
   const isPristineSetHeaterShakerTempForm = getUnsavedFormIsPristineHeaterShakerForm(
     initialState
   )
 
-  if (!unsavedSetHeaterShakerForm) {
+  if (!unsavedHeaterShakerForm) {
     assert(
       false,
       'Tried to saveSetHeaterShakerTempFormWithAddedPauseUntilTemp with falsey unsavedForm. This should never be able to happen.'
@@ -278,7 +278,7 @@ export const saveHeaterShakerFormWithAddedPauseUntilTemp: () => ThunkAction<any>
     return
   }
 
-  const { id } = unsavedSetHeaterShakerForm
+  const { id } = unsavedHeaterShakerForm
 
   if (!isPristineSetHeaterShakerTempForm) {
     assert(
@@ -288,13 +288,13 @@ export const saveHeaterShakerFormWithAddedPauseUntilTemp: () => ThunkAction<any>
     return
   }
 
-  const temperature = unsavedSetHeaterShakerForm?.targetHeaterShakerTemperature
+  const temperature = unsavedHeaterShakerForm?.targetHeaterShakerTemperature
 
   assert(
     temperature != null && temperature !== '',
     `tried to auto-add a pause until temp, but targetHeaterShakerTemperature is missing: ${temperature}`
   )
-  dispatch(_saveStepForm(unsavedSetHeaterShakerForm))
+  dispatch(_saveStepForm(unsavedHeaterShakerForm))
   dispatch(
     addStep({
       stepType: 'pause',
@@ -308,7 +308,7 @@ export const saveHeaterShakerFormWithAddedPauseUntilTemp: () => ThunkAction<any>
       },
     })
   )
-  const heaterShakerModuleId = unsavedSetHeaterShakerForm.moduleId
+  const heaterShakerModuleId = unsavedHeaterShakerForm.moduleId
   dispatch(
     changeFormInput({
       update: {

--- a/protocol-designer/src/ui/steps/actions/thunks/index.ts
+++ b/protocol-designer/src/ui/steps/actions/thunks/index.ts
@@ -265,12 +265,12 @@ export const saveHeaterShakerFormWithAddedPauseUntilTemp: () => ThunkAction<any>
   getState
 ) => {
   const initialState = getState()
-  const unsavedSetHeaterShakerTemperatureForm = getUnsavedForm(initialState)
+  const unsavedSetHeaterShakerForm = getUnsavedForm(initialState)
   const isPristineSetHeaterShakerTempForm = getUnsavedFormIsPristineHeaterShakerForm(
     initialState
   )
 
-  if (!unsavedSetHeaterShakerTemperatureForm) {
+  if (!unsavedSetHeaterShakerForm) {
     assert(
       false,
       'Tried to saveSetHeaterShakerTempFormWithAddedPauseUntilTemp with falsey unsavedForm. This should never be able to happen.'
@@ -278,7 +278,7 @@ export const saveHeaterShakerFormWithAddedPauseUntilTemp: () => ThunkAction<any>
     return
   }
 
-  const { id } = unsavedSetHeaterShakerTemperatureForm
+  const { id } = unsavedSetHeaterShakerForm
 
   if (!isPristineSetHeaterShakerTempForm) {
     assert(
@@ -288,14 +288,13 @@ export const saveHeaterShakerFormWithAddedPauseUntilTemp: () => ThunkAction<any>
     return
   }
 
-  const temperature =
-    unsavedSetHeaterShakerTemperatureForm?.targetHeaterShakerTemperature
+  const temperature = unsavedSetHeaterShakerForm?.targetHeaterShakerTemperature
 
   assert(
     temperature != null && temperature !== '',
     `tried to auto-add a pause until temp, but targetHeaterShakerTemperature is missing: ${temperature}`
   )
-  dispatch(_saveStepForm(unsavedSetHeaterShakerTemperatureForm))
+  dispatch(_saveStepForm(unsavedSetHeaterShakerForm))
   dispatch(
     addStep({
       stepType: 'pause',
@@ -309,6 +308,15 @@ export const saveHeaterShakerFormWithAddedPauseUntilTemp: () => ThunkAction<any>
       },
     })
   )
+  const heaterShakerModuleId = unsavedSetHeaterShakerForm.moduleId
+  dispatch(
+    changeFormInput({
+      update: {
+        moduleId: heaterShakerModuleId,
+      },
+    })
+  )
+
   dispatch(
     changeFormInput({
       update: {

--- a/step-generation/src/__tests__/moveToWell.test.ts
+++ b/step-generation/src/__tests__/moveToWell.test.ts
@@ -1,6 +1,9 @@
 import { expectTimelineError } from '../__utils__/testMatchers'
 import { moveToWell } from '../commandCreators/atomic/moveToWell'
-import { thermocyclerPipetteCollision } from '../utils'
+import {
+  thermocyclerPipetteCollision,
+  pipetteIntoHeaterShakerLatchOpen,
+} from '../utils'
 import {
   getRobotStateWithTipStandard,
   makeContext,
@@ -12,8 +15,12 @@ import {
 import type { InvariantContext, RobotState } from '../types'
 
 jest.mock('../utils/thermocyclerPipetteCollision')
+jest.mock('../utils/pipetteIntoHeaterShakerLatchOpen')
 const mockThermocyclerPipetteCollision = thermocyclerPipetteCollision as jest.MockedFunction<
   typeof thermocyclerPipetteCollision
+>
+const mockPipetteIntoHeaterShakerLatchOpen = pipetteIntoHeaterShakerLatchOpen as jest.MockedFunction<
+  typeof pipetteIntoHeaterShakerLatchOpen
 >
 describe('moveToWell', () => {
   let robotStateWithTip: RobotState
@@ -130,6 +137,61 @@ describe('moveToWell', () => {
     expect(getErrorResult(result).errors).toHaveLength(1)
     expect(getErrorResult(result).errors[0]).toMatchObject({
       type: 'THERMOCYCLER_LID_CLOSED',
+    })
+  })
+  it('should return an error when moving to well in a thermocycler with pipette collision', () => {
+    mockThermocyclerPipetteCollision.mockImplementationOnce(
+      (
+        modules: RobotState['modules'],
+        labware: RobotState['labware'],
+        labwareId: string
+      ) => {
+        expect(modules).toBe(robotStateWithTip.modules)
+        expect(labware).toBe(robotStateWithTip.labware)
+        expect(labwareId).toBe(SOURCE_LABWARE)
+        return true
+      }
+    )
+    const result = moveToWell(
+      {
+        pipette: DEFAULT_PIPETTE,
+        labware: SOURCE_LABWARE,
+        well: 'A1',
+      },
+      invariantContext,
+      robotStateWithTip
+    )
+    expect(getErrorResult(result).errors).toHaveLength(1)
+    expect(getErrorResult(result).errors[0]).toMatchObject({
+      type: 'THERMOCYCLER_LID_CLOSED',
+    })
+  })
+
+  it('should return an error when moving to well in a heater-shaker with latch opened', () => {
+    mockPipetteIntoHeaterShakerLatchOpen.mockImplementationOnce(
+      (
+        modules: RobotState['modules'],
+        labware: RobotState['labware'],
+        labwareId: string
+      ) => {
+        expect(modules).toBe(robotStateWithTip.modules)
+        expect(labware).toBe(robotStateWithTip.labware)
+        expect(labwareId).toBe(SOURCE_LABWARE)
+        return true
+      }
+    )
+    const result = moveToWell(
+      {
+        pipette: DEFAULT_PIPETTE,
+        labware: SOURCE_LABWARE,
+        well: 'A1',
+      },
+      invariantContext,
+      robotStateWithTip
+    )
+    expect(getErrorResult(result).errors).toHaveLength(1)
+    expect(getErrorResult(result).errors[0]).toMatchObject({
+      type: 'HEATER_SHAKER_LATCH_OPEN',
     })
   })
 })

--- a/step-generation/src/__tests__/moveToWell.test.ts
+++ b/step-generation/src/__tests__/moveToWell.test.ts
@@ -139,33 +139,6 @@ describe('moveToWell', () => {
       type: 'THERMOCYCLER_LID_CLOSED',
     })
   })
-  it('should return an error when moving to well in a thermocycler with pipette collision', () => {
-    mockThermocyclerPipetteCollision.mockImplementationOnce(
-      (
-        modules: RobotState['modules'],
-        labware: RobotState['labware'],
-        labwareId: string
-      ) => {
-        expect(modules).toBe(robotStateWithTip.modules)
-        expect(labware).toBe(robotStateWithTip.labware)
-        expect(labwareId).toBe(SOURCE_LABWARE)
-        return true
-      }
-    )
-    const result = moveToWell(
-      {
-        pipette: DEFAULT_PIPETTE,
-        labware: SOURCE_LABWARE,
-        well: 'A1',
-      },
-      invariantContext,
-      robotStateWithTip
-    )
-    expect(getErrorResult(result).errors).toHaveLength(1)
-    expect(getErrorResult(result).errors[0]).toMatchObject({
-      type: 'THERMOCYCLER_LID_CLOSED',
-    })
-  })
 
   it('should return an error when moving to well in a heater-shaker with latch opened', () => {
     mockPipetteIntoHeaterShakerLatchOpen.mockImplementationOnce(

--- a/step-generation/src/commandCreators/atomic/aspirate.ts
+++ b/step-generation/src/commandCreators/atomic/aspirate.ts
@@ -3,6 +3,7 @@ import { getPipetteWithTipMaxVol } from '../../robotStateSelectors'
 import {
   modulePipetteCollision,
   thermocyclerPipetteCollision,
+  pipetteIntoHeaterShakerLatchOpen,
 } from '../../utils'
 import type { CreateCommand } from '@opentrons/shared-data'
 import type { AspirateParams } from '@opentrons/shared-data/protocol/types/schemaV3'
@@ -67,6 +68,16 @@ export const aspirate: CommandCreator<AspirateParams> = (
     )
   ) {
     errors.push(errorCreators.thermocyclerLidClosed())
+  }
+
+  if (
+    pipetteIntoHeaterShakerLatchOpen(
+      prevRobotState.modules,
+      prevRobotState.labware,
+      labware
+    )
+  ) {
+    errors.push(errorCreators.heaterShakerLatchOpen())
   }
 
   if (errors.length === 0 && pipetteSpec && pipetteSpec.maxVolume < volume) {

--- a/step-generation/src/commandCreators/atomic/dispense.ts
+++ b/step-generation/src/commandCreators/atomic/dispense.ts
@@ -2,6 +2,7 @@ import * as errorCreators from '../../errorCreators'
 import {
   modulePipetteCollision,
   thermocyclerPipetteCollision,
+  pipetteIntoHeaterShakerLatchOpen,
 } from '../../utils'
 import type { CreateCommand } from '@opentrons/shared-data'
 import type { DispenseParams } from '@opentrons/shared-data/protocol/types/schemaV3'
@@ -56,6 +57,16 @@ export const dispense: CommandCreator<DispenseParams> = (
     )
   ) {
     errors.push(errorCreators.thermocyclerLidClosed())
+  }
+
+  if (
+    pipetteIntoHeaterShakerLatchOpen(
+      prevRobotState.modules,
+      prevRobotState.labware,
+      labware
+    )
+  ) {
+    errors.push(errorCreators.heaterShakerLatchOpen())
   }
 
   if (errors.length > 0) {

--- a/step-generation/src/commandCreators/atomic/moveToWell.ts
+++ b/step-generation/src/commandCreators/atomic/moveToWell.ts
@@ -2,6 +2,7 @@ import * as errorCreators from '../../errorCreators'
 import {
   modulePipetteCollision,
   thermocyclerPipetteCollision,
+  pipetteIntoHeaterShakerLatchOpen,
 } from '../../utils'
 import type { CreateCommand } from '@opentrons/shared-data'
 import type { MoveToWellParams as v5MoveToWellParams } from '@opentrons/shared-data/protocol/types/schemaV5'
@@ -58,6 +59,16 @@ export const moveToWell: CommandCreator<v5MoveToWellParams> = (
     )
   ) {
     errors.push(errorCreators.thermocyclerLidClosed())
+  }
+
+  if (
+    pipetteIntoHeaterShakerLatchOpen(
+      prevRobotState.modules,
+      prevRobotState.labware,
+      labware
+    )
+  ) {
+    errors.push(errorCreators.heaterShakerLatchOpen())
   }
 
   if (errors.length > 0) {

--- a/step-generation/src/commandCreators/compound/heaterShaker.ts
+++ b/step-generation/src/commandCreators/compound/heaterShaker.ts
@@ -33,7 +33,6 @@ export const heaterShaker: CommandCreator<HeaterShakerArgs> = (
   }
   const {
     latchOpen,
-    latchClosed,
     setTemperature,
     deactivateHeater,
     setShakeSpeed,
@@ -48,9 +47,7 @@ export const heaterShaker: CommandCreator<HeaterShakerArgs> = (
         moduleId: args.module,
       })
     )
-  }
-
-  if (latchClosed) {
+  } else {
     commandCreators.push(
       curryCommandCreator(heaterShakerCloseLatch, {
         moduleId: args.module,

--- a/step-generation/src/errorCreators.ts
+++ b/step-generation/src/errorCreators.ts
@@ -119,3 +119,10 @@ export const thermocyclerLidClosed = (): CommandCreatorError => {
     message: 'Attempted to pipette into a thermocycler with the lid closed.',
   }
 }
+
+export const heaterShakerLatchOpen = (): CommandCreatorError => {
+  return {
+    type: 'HEATER_SHAKER_LATCH_OPEN',
+    message: 'Attempted to pipette into a heater-shaker with the latch open.',
+  }
+}

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -473,6 +473,7 @@ export type ErrorType =
   | 'MISSING_TEMPERATURE_STEP'
   | 'THERMOCYCLER_LID_CLOSED'
   | 'INVALID_SLOT'
+  | 'HEATER_SHAKER_LATCH_OPEN'
 
 export interface CommandCreatorError {
   message: string

--- a/step-generation/src/utils/heaterShakerDiff.ts
+++ b/step-generation/src/utils/heaterShakerDiff.ts
@@ -2,7 +2,6 @@ import type { HeaterShakerModuleState, HeaterShakerArgs } from '../types'
 
 export interface Diff {
   latchOpen: boolean
-  latchClosed: boolean
   setTemperature: boolean
   deactivateHeater: boolean
   setShakeSpeed: boolean
@@ -11,48 +10,17 @@ export interface Diff {
 
 const getInitialDiff = (): Diff => ({
   latchOpen: false,
-  latchClosed: false,
   setTemperature: false,
   deactivateHeater: false,
   setShakeSpeed: false,
   stopShake: false,
 })
 
-const getLatchOpenDiff = (
-  prevHeaterShakerState: HeaterShakerModuleState,
-  args: HeaterShakerArgs
-): Partial<Diff> => {
-  if (!prevHeaterShakerState.latchOpen && args.latchOpen) {
-    return {
-      latchOpen: true,
-    }
-  }
-
-  return {}
-}
-
-const getLatchClosedDiff = (
-  prevHeaterShakerState: HeaterShakerModuleState,
-  args: HeaterShakerArgs
-): Partial<Diff> => {
-  if (
-    (prevHeaterShakerState.latchOpen && !args.latchOpen) ??
-    (prevHeaterShakerState.latchOpen === null && !args.latchOpen)
-  ) {
-    return {
-      latchOpen: true,
-    }
-  }
-
-  return {}
-}
-
 export const heaterShakerDiff = (
   prevHeaterShakerState: HeaterShakerModuleState,
   args: HeaterShakerArgs
 ): Diff => {
-  const latchOpenDiff = { ...getLatchOpenDiff(prevHeaterShakerState, args) }
-  const lidClosedDiff = { ...getLatchClosedDiff(prevHeaterShakerState, args) }
+  const latchOpen = args.latchOpen
   const tempChanged =
     prevHeaterShakerState.targetTemp !== args.targetTemperature
   const heaterDeactivated = tempChanged && args.targetTemperature === null
@@ -63,8 +31,7 @@ export const heaterShakerDiff = (
 
   return {
     ...getInitialDiff(),
-    ...latchOpenDiff,
-    ...lidClosedDiff,
+    latchOpen,
     setTemperature: heaterActivated,
     deactivateHeater: heaterDeactivated,
     setShakeSpeed: shakerActivated,

--- a/step-generation/src/utils/index.ts
+++ b/step-generation/src/utils/index.ts
@@ -3,6 +3,7 @@ import { curryCommandCreator } from './curryCommandCreator'
 import { reduceCommandCreators } from './reduceCommandCreators'
 import { modulePipetteCollision } from './modulePipetteCollision'
 import { thermocyclerPipetteCollision } from './thermocyclerPipetteCollision'
+import { pipetteIntoHeaterShakerLatchOpen } from './pipetteIntoHeaterShakerLatchOpen'
 import { orderWells } from './orderWells'
 export {
   commandCreatorsTimeline,
@@ -11,6 +12,7 @@ export {
   reduceCommandCreators,
   modulePipetteCollision,
   thermocyclerPipetteCollision,
+  pipetteIntoHeaterShakerLatchOpen,
 }
 export * from './commandCreatorArgsGetters'
 export * from './misc'

--- a/step-generation/src/utils/pipetteIntoHeaterShakerLatchOpen.ts
+++ b/step-generation/src/utils/pipetteIntoHeaterShakerLatchOpen.ts
@@ -1,0 +1,21 @@
+import { HEATERSHAKER_MODULE_TYPE } from '@opentrons/shared-data'
+import type { RobotState } from '../'
+export const pipetteIntoHeaterShakerLatchOpen = (
+  modules: RobotState['modules'],
+  labware: RobotState['labware'],
+  labwareId: string
+): boolean => {
+  const labwareSlot: string = labware[labwareId]?.slot
+  const moduleUnderLabware: string | null | undefined =
+    modules &&
+    labwareSlot &&
+    Object.keys(modules).find((moduleId: string) => moduleId === labwareSlot)
+  const moduleState =
+    moduleUnderLabware && modules[moduleUnderLabware].moduleState
+  const isHSLatchOpen: boolean = Boolean(
+    moduleState &&
+      moduleState.type === HEATERSHAKER_MODULE_TYPE &&
+      moduleState.latchOpen !== false
+  )
+  return isHSLatchOpen
+}


### PR DESCRIPTION
closes #9745 

# Overview

<img width="895" alt="Screen Shot 2022-04-08 at 5 31 56 PM" src="https://user-images.githubusercontent.com/66035149/162738815-86ecc3ad-ad7e-43a0-961f-88f9c86620b7.png">


This PR adds the pipette step validation for when the H-S's latch is open. So if you try to pipette into a H-S with the latch open (mixing, aspirating, dispense), there is an error banner that appears saying the latch is opened.

This also addresses some remaining PR comments in https://github.com/Opentrons/opentrons/pull/9916

# Changelog

- create a commandCreatorError for Heater-Shaker and implement it in `mixWell`, `aspirate`, and `dispense`. 
- address PR comments from other PR

# Review requests

- makes sure logic is sound, it matches design, and it works as expected in PD

# Risk assessment

low, behind ff