### PR TITLE
test(robot-server): acceptance tests for temperatureModule commands

### DIFF
--- a/robot-server/tests/integration/http_api/commands/test_temp_commands.tavern.yaml
+++ b/robot-server/tests/integration/http_api/commands/test_temp_commands.tavern.yaml
@@ -1,0 +1,164 @@
+test_name: temperatureModuleV1 standalone commands
+
+marks:
+  - usefixtures:
+      - run_server
+
+stages:
+  - name: Delete all runs # Ensure there is no active run
+    request:
+      url: '{host:s}:{port:d}/runs'
+      method: GET
+    response:
+      status_code: 200
+      verify_response_with:
+        - function: 'tests.integration.fixtures:delete_all_runs'
+          extra_kwargs:
+            host: '{host:s}'
+            port: '{port:d}'
+  - name: Get tempModule id
+    request:
+      url: '{host:s}:{port:d}/modules'
+      method: GET
+    response:
+      status_code: 200
+      save:
+        $ext:
+          function: 'tests.integration.fixtures:get_module_id'
+          extra_kwargs:
+            module_model: temperatureModuleV1
+  - name: issue temperatureModule/setTargetTemperature Command
+    request:
+      url: '{host:s}:{port:d}/commands'
+      method: POST
+      params: # on simulations will return immediately
+        waitUntilComplete: true
+      json:
+        data:
+          commandType: 'temperatureModule/setTargetTemperature'
+          params:
+            moduleId: '{temperatureModuleV1_id}'
+            temperature: 28
+    response:
+      strict:
+        - json:off
+      status_code: 201
+      json:
+        data:
+          status: succeeded
+      save:
+        json:
+          command_id_set_temp: data.id
+  - name: issue temperatureModule/setTargetTemperature Command with error
+    request:
+      url: '{host:s}:{port:d}/commands'
+      method: POST
+      params:
+        waitUntilComplete: true
+      json:
+        data:
+          commandType: 'temperatureModule/setTargetTemperature'
+          params:
+            moduleId: '{temperatureModuleV1_id}'
+            temperature: 100
+    response:
+      strict:
+        - json:off
+      status_code: 201
+      json:
+        data:
+          commandType: temperatureModule/setTargetTemperature
+          status: failed
+          params:
+            moduleId: '{temperatureModuleV1_id}'
+            temperature: 100
+          error:
+            errorType: 'InvalidTargetTemperatureError'
+            detail: "Temperature module got an invalid temperature 100.0 \u00b0C. Valid range is TemperatureRange(min=-9, max=99)."
+      save:
+        json:
+          command_id_set_temp_error: data.id
+  - name: issue temperatureModule/deactivate Command
+    request:
+      url: '{host:s}:{port:d}/commands'
+      method: POST
+      params:
+        waitUntilComplete: true
+      json:
+        data:
+          commandType: 'temperatureModule/deactivate'
+          params:
+            moduleId: '{temperatureModuleV1_id}'
+    response:
+      strict:
+        - json:off
+      status_code: 201
+      json:
+        data:
+          status: succeeded
+      save:
+        json:
+          command_id_deactivate: data.id
+  - name: Get command by id
+    request:
+      url: '{host:s}:{port:d}/commands/{command_id_set_temp}'
+      method: GET
+    response:
+      strict:
+        - json:off
+      status_code: 200
+      json:
+        data:
+          id: '{command_id_set_temp}'
+          status: succeeded
+  - name: Get commands
+    request:
+      url: '{host:s}:{port:d}/commands'
+      method: GET
+    response:
+      strict:
+        - json:off
+      status_code: 200
+      json:
+        data: # order is enforced on this check!
+          - id: '{command_id_set_temp}'
+          - id: '{command_id_set_temp_error}'
+          - id: '{command_id_deactivate}'
+  - name: Create Empty Run
+    request:
+      url: '{host:s}:{port:d}/runs'
+      json:
+        data: {}
+      method: POST
+    response:
+      strict:
+        - json:off
+      status_code: 201
+      json:
+        data:
+          id: !anystr
+          status: idle
+          current: true
+      save:
+        json:
+          run_id: data.id
+  - name: issue temperatureModule/setTargetTemperature Command
+    request:
+      url: '{host:s}:{port:d}/commands'
+      method: POST
+      params:
+        waitUntilComplete: true
+      json:
+        data:
+          commandType: 'temperatureModule/setTargetTemperature'
+          params:
+            moduleId: '{temperatureModuleV1_id}'
+    response:
+      strict:
+        - json:off
+      status_code: 409
+      json:
+        errors:
+          - id: RunActive
+            title: Run Active
+            detail: There is an active run. Close the current run to issue commands via POST /commands.


### PR DESCRIPTION
# Overview

Acceptance integration test for /commands temperatureModule/* commands

# Changelog

- setTargetTemperature with valid temp
- setTargetTemperature with InvalidTargetTemperatureError 
- deactivate command
- get setTargetTemperature command by command id
- get /commands and verify all issued temperatureModule present in order
- active run present blocks temperatureModule command to /commands

# Risk assessment

None, test only