### PR TITLE
feat(protocol-designer): pipette step validation for H-S shaking

### DIFF
--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -117,6 +117,10 @@
       "HEATER_SHAKER_LATCH_OPEN": {
         "title": "Heater-Shaker labware latch is open",
         "body": "Before a pipette can interact with labware on the Heater-Shaker module, the labware latch must be closed. To resolve this error, please add a Heater-Shaker step ahead of the current step, and set the labware latch status to \"closed\"."
+      },
+      "HEATER_SHAKER_IS_SHAKING": {
+        "title": "Heater-Shaker is shaking",
+        "body": "A pipette cannot interact with labware on the Heater-Shaker Module while it is shaking."
       }
     },
     "warning": {

--- a/step-generation/src/commandCreators/atomic/aspirate.ts
+++ b/step-generation/src/commandCreators/atomic/aspirate.ts
@@ -4,6 +4,7 @@ import {
   modulePipetteCollision,
   thermocyclerPipetteCollision,
   pipetteIntoHeaterShakerLatchOpen,
+  pipetteIntoHeaterShakerWhileShaking,
 } from '../../utils'
 import type { CreateCommand } from '@opentrons/shared-data'
 import type { AspirateParams } from '@opentrons/shared-data/protocol/types/schemaV3'
@@ -78,6 +79,16 @@ export const aspirate: CommandCreator<AspirateParams> = (
     )
   ) {
     errors.push(errorCreators.heaterShakerLatchOpen())
+  }
+
+  if (
+    pipetteIntoHeaterShakerWhileShaking(
+      prevRobotState.modules,
+      prevRobotState.labware,
+      labware
+    )
+  ) {
+    errors.push(errorCreators.heaterShakerIsShaking())
   }
 
   if (errors.length === 0 && pipetteSpec && pipetteSpec.maxVolume < volume) {

--- a/step-generation/src/commandCreators/atomic/dispense.ts
+++ b/step-generation/src/commandCreators/atomic/dispense.ts
@@ -3,6 +3,7 @@ import {
   modulePipetteCollision,
   thermocyclerPipetteCollision,
   pipetteIntoHeaterShakerLatchOpen,
+  pipetteIntoHeaterShakerWhileShaking,
 } from '../../utils'
 import type { CreateCommand } from '@opentrons/shared-data'
 import type { DispenseParams } from '@opentrons/shared-data/protocol/types/schemaV3'
@@ -67,6 +68,16 @@ export const dispense: CommandCreator<DispenseParams> = (
     )
   ) {
     errors.push(errorCreators.heaterShakerLatchOpen())
+  }
+
+  if (
+    pipetteIntoHeaterShakerWhileShaking(
+      prevRobotState.modules,
+      prevRobotState.labware,
+      labware
+    )
+  ) {
+    errors.push(errorCreators.heaterShakerIsShaking())
   }
 
   if (errors.length > 0) {

--- a/step-generation/src/commandCreators/atomic/moveToWell.ts
+++ b/step-generation/src/commandCreators/atomic/moveToWell.ts
@@ -3,6 +3,7 @@ import {
   modulePipetteCollision,
   thermocyclerPipetteCollision,
   pipetteIntoHeaterShakerLatchOpen,
+  pipetteIntoHeaterShakerWhileShaking,
 } from '../../utils'
 import type { CreateCommand } from '@opentrons/shared-data'
 import type { MoveToWellParams as v5MoveToWellParams } from '@opentrons/shared-data/protocol/types/schemaV5'
@@ -69,6 +70,16 @@ export const moveToWell: CommandCreator<v5MoveToWellParams> = (
     )
   ) {
     errors.push(errorCreators.heaterShakerLatchOpen())
+  }
+
+  if (
+    pipetteIntoHeaterShakerWhileShaking(
+      prevRobotState.modules,
+      prevRobotState.labware,
+      labware
+    )
+  ) {
+    errors.push(errorCreators.heaterShakerIsShaking())
   }
 
   if (errors.length > 0) {

--- a/step-generation/src/errorCreators.ts
+++ b/step-generation/src/errorCreators.ts
@@ -126,3 +126,10 @@ export const heaterShakerLatchOpen = (): CommandCreatorError => {
     message: 'Attempted to pipette into a heater-shaker with the latch open.',
   }
 }
+
+export const heaterShakerIsShaking = (): CommandCreatorError => {
+  return {
+    type: 'HEATER_SHAKER_IS_SHAKING',
+    message: 'Attempted to pipette into a heater-shaker when it is shaking.',
+  }
+}

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -474,7 +474,7 @@ export type ErrorType =
   | 'THERMOCYCLER_LID_CLOSED'
   | 'INVALID_SLOT'
   | 'HEATER_SHAKER_LATCH_OPEN'
-
+  | 'HEATER_SHAKER_IS_SHAKING'
 export interface CommandCreatorError {
   message: string
   type: ErrorType

--- a/step-generation/src/utils/index.ts
+++ b/step-generation/src/utils/index.ts
@@ -4,6 +4,7 @@ import { reduceCommandCreators } from './reduceCommandCreators'
 import { modulePipetteCollision } from './modulePipetteCollision'
 import { thermocyclerPipetteCollision } from './thermocyclerPipetteCollision'
 import { pipetteIntoHeaterShakerLatchOpen } from './pipetteIntoHeaterShakerLatchOpen'
+import { pipetteIntoHeaterShakerWhileShaking } from './pipetteIntoHeaterShakerWhileShaking'
 import { orderWells } from './orderWells'
 export {
   commandCreatorsTimeline,
@@ -13,6 +14,7 @@ export {
   modulePipetteCollision,
   thermocyclerPipetteCollision,
   pipetteIntoHeaterShakerLatchOpen,
+  pipetteIntoHeaterShakerWhileShaking,
 }
 export * from './commandCreatorArgsGetters'
 export * from './misc'

--- a/step-generation/src/utils/pipetteIntoHeaterShakerWhileShaking.ts
+++ b/step-generation/src/utils/pipetteIntoHeaterShakerWhileShaking.ts
@@ -15,7 +15,7 @@ export const pipetteIntoHeaterShakerWhileShaking = (
   const isShaking: boolean = Boolean(
     moduleState &&
       moduleState.type === HEATERSHAKER_MODULE_TYPE &&
-      (moduleState.targetSpeed !== null || moduleState.targetSpeed !== 0)
+      moduleState.targetSpeed !== null
   )
   return isShaking
 }

--- a/step-generation/src/utils/pipetteIntoHeaterShakerWhileShaking.ts
+++ b/step-generation/src/utils/pipetteIntoHeaterShakerWhileShaking.ts
@@ -1,0 +1,21 @@
+import { HEATERSHAKER_MODULE_TYPE } from '@opentrons/shared-data'
+import type { RobotState } from '../'
+export const pipetteIntoHeaterShakerWhileShaking = (
+  modules: RobotState['modules'],
+  labware: RobotState['labware'],
+  labwareId: string
+): boolean => {
+  const labwareSlot: string = labware[labwareId]?.slot
+  const moduleUnderLabware: string | null | undefined =
+    modules &&
+    labwareSlot &&
+    Object.keys(modules).find((moduleId: string) => moduleId === labwareSlot)
+  const moduleState =
+    moduleUnderLabware && modules[moduleUnderLabware].moduleState
+  const isShaking: boolean = Boolean(
+    moduleState &&
+      moduleState.type === HEATERSHAKER_MODULE_TYPE &&
+      (moduleState.targetSpeed !== null || moduleState.targetSpeed !== 0)
+  )
+  return isShaking
+}


### PR DESCRIPTION
closes #9752

# Overview

need to rebase after https://github.com/Opentrons/opentrons/pull/9928 merges!

This PR adds an error banner when you try to pipette into a H-S when it is shaking.

<img width="893" alt="Screen Shot 2022-04-11 at 1 12 24 PM" src="https://user-images.githubusercontent.com/66035149/162793845-c9c7ba66-7330-4699-b305-70b091e164b1.png">

# Changelog

- create `commandCreatorError` and impliment for `mixWell`, `aspirate`, and `dispense`

# Review requests

- makes sure logic is sound, it matches design, and it works as expected in PD 

# Risk assessment

low, behind ff