### PR TITLE
fix(api): set finished live runs to stopped rather than succeeded/failed

### DIFF
--- a/api/src/opentrons/protocol_engine/actions/actions.py
+++ b/api/src/opentrons/protocol_engine/actions/actions.py
@@ -61,9 +61,11 @@ class FinishErrorDetails:
 class FinishAction:
     """Gracefully stop processing commands in the engine.
 
-    After a FinishAction, the engine status will be marked as succeeded or failed.
+    After a FinishAction, the engine status will be marked as `succeeded` or `failed`
+    if `set_run_status` is True. If False, status will be `stopped`.
     """
 
+    set_run_status: bool = True
     error_details: Optional[FinishErrorDetails] = None
 
 

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -189,6 +189,7 @@ class ProtocolEngine:
         self,
         error: Optional[Exception] = None,
         drop_tips_and_home: bool = True,
+        set_run_status: bool = True,
     ) -> None:
         """Gracefully finish using the ProtocolEngine, waiting for it to become idle.
 
@@ -203,6 +204,8 @@ class ProtocolEngine:
         Arguments:
             error: An error that caused the stop, if applicable.
             drop_tips_and_home: Whether to home and drop tips as part of cleanup.
+            set_run_status: Whether to calculate a `success` or `failure` run status.
+                If `False`, will set status to `stopped`.
         """
         if error:
             error_details: Optional[FinishErrorDetails] = FinishErrorDetails(
@@ -213,7 +216,9 @@ class ProtocolEngine:
         else:
             error_details = None
 
-        self._action_dispatcher.dispatch(FinishAction(error_details=error_details))
+        self._action_dispatcher.dispatch(
+            FinishAction(error_details=error_details, set_run_status=set_run_status)
+        )
 
         try:
             await self._queue_worker.join()

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -270,11 +270,14 @@ class CommandStore(HasState[CommandState], HandlesActions):
         elif isinstance(action, FinishAction):
             if not self._state.run_result:
                 self._state.queue_status = QueueStatus.INACTIVE
-                self._state.run_result = (
-                    RunResult.SUCCEEDED
-                    if not action.error_details
-                    else RunResult.FAILED
-                )
+                if action.set_run_status:
+                    self._state.run_result = (
+                        RunResult.SUCCEEDED
+                        if not action.error_details
+                        else RunResult.FAILED
+                    )
+                else:
+                    self._state.run_result = RunResult.STOPPED
 
                 # any `ProtocolEngineError`'s will be captured by `FailCommandAction`,
                 # so only capture unknown errors here

--- a/api/src/opentrons/protocol_runner/protocol_runner.py
+++ b/api/src/opentrons/protocol_runner/protocol_runner.py
@@ -148,7 +148,10 @@ class ProtocolRunner:
         if self._was_started:
             await self._protocol_engine.stop()
         else:
-            await self._protocol_engine.finish(drop_tips_and_home=False)
+            await self._protocol_engine.finish(
+                drop_tips_and_home=False,
+                set_run_status=False,
+            )
 
     async def run(
         self,

--- a/api/tests/opentrons/protocol_engine/state/test_command_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_store.py
@@ -464,6 +464,16 @@ def test_command_store_handles_finish_action() -> None:
     )
 
 
+def test_command_store_handles_finish_action_with_stopped() -> None:
+    """It should change to a stopped state if FinishAction has set_run_status=False."""
+    subject = CommandStore()
+
+    subject.handle_action(PlayAction())
+    subject.handle_action(FinishAction(set_run_status=False))
+
+    assert subject.state.run_result == RunResult.STOPPED
+
+
 def test_command_store_handles_stop_action() -> None:
     """It should mark the engine as non-gracefully stopped on StopAction."""
     subject = CommandStore()

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner.py
@@ -182,7 +182,10 @@ async def test_stop_never_started(
     """It should clean up rather than halt if the runner was never started."""
     await subject.stop()
 
-    decoy.verify(await protocol_engine.finish(drop_tips_and_home=False), times=1)
+    decoy.verify(
+        await protocol_engine.finish(drop_tips_and_home=False, set_run_status=False),
+        times=1,
+    )
 
 
 async def test_run(

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -134,7 +134,7 @@ class EngineStore:
         """
         if self._runner_engine_pair is not None:
             if self.engine.state_view.commands.get_is_okay_to_clear():
-                await self.engine.finish(drop_tips_and_home=False)
+                await self.engine.finish(drop_tips_and_home=False, set_run_status=False)
             else:
                 raise EngineConflictError("Current run is not idle or stopped.")
 

--- a/robot-server/tests/integration/http_api/runs/test_run_status.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_run_status.tavern.yaml
@@ -1,0 +1,142 @@
+test_name: Alter the value of run status and current
+
+marks:
+  - usefixtures:
+      - run_server
+
+stages:
+  - name: Create Empty Run 1
+    request:
+      url: '{host:s}:{port:d}/runs'
+      json:
+        data: {}
+      method: POST
+    response:
+      strict:
+        - json:off
+      status_code: 201
+      json:
+        data:
+          id: !anystr
+          status: idle
+          current: true
+      save:
+        json:
+          first_run_id: data.id
+  - name: Patch the Run
+    request:
+      url: '{host:s}:{port:d}/runs/{first_run_id}'
+      json:
+        data: { 'current': false }
+      method: PATCH
+    response:
+      strict:
+        - json:off
+      status_code: 200
+      json:
+        data:
+          id: !anystr
+          status: stopped
+          current: false
+  - name: Create Empty Run 2
+    request:
+      url: '{host:s}:{port:d}/runs'
+      json:
+        data: {}
+      method: POST
+    response:
+      strict:
+        - json:off
+      status_code: 201
+      json:
+        data:
+          id: !anystr
+          status: idle
+          current: true
+      save:
+        json:
+          second_run_id: data.id
+  - name: Create Empty Run 3
+    request:
+      url: '{host:s}:{port:d}/runs'
+      json:
+        data: {}
+      method: POST
+    response:
+      strict:
+        - json:off
+      status_code: 201
+      json:
+        data:
+          id: !anystr
+          status: idle
+          current: true
+      save:
+        json:
+          third_run_id: data.id
+  - name: Get run 2
+    request:
+      url: '{host:s}:{port:d}/runs/{second_run_id}'
+      method: GET
+    response:
+      strict:
+        - json:off
+      status_code: 200
+      json:
+        data:
+          id: !anystr
+          status: stopped
+          current: false
+  - name: Get run 3
+    request:
+      url: '{host:s}:{port:d}/runs/{third_run_id}'
+      method: GET
+    response:
+      strict:
+        - json:off
+      status_code: 200
+      json:
+        data:
+          id: !anystr
+          status: idle
+          current: true
+  - name: Create Empty Run 4
+    request:
+      url: '{host:s}:{port:d}/runs'
+      json:
+        data: {}
+      method: POST
+    response:
+      strict:
+        - json:off
+      status_code: 201
+      json:
+        data:
+          id: !anystr
+          status: idle
+          current: true
+      save:
+        json:
+          fourth_run_id: data.id
+  - name: Issue stop action to Run 4
+    request:
+      url: '{host:s}:{port:d}/runs/{fourth_run_id}/actions'
+      json:
+        data:
+          actionType: stop
+      method: POST
+    response:
+      status_code: 201
+  - name: Get run 4
+    request:
+      url: '{host:s}:{port:d}/runs/{fourth_run_id}'
+      method: GET
+    response:
+      strict:
+        - json:off
+      status_code: 200
+      json:
+        data:
+          id: !anystr
+          status: stopped
+          current: true


### PR DESCRIPTION
## Overview

Fixes #9277

## Changelog

- fix(api): set finished live runs to stopped rather than succeeded/failed

## Review requests

Acceptance tests:

1. Explicitly stopped run
    1. Create run
    2. Create 0 or more commands
    3. Create `stop` action
    4. Fetch fun
        - Run status should be `stopped`
2. Implictly stopped run
    1. Create run
    2. Create 0 or more commands
    3. "Uncurrent" the run
        - `PATCH /runs/:run_id { "data": { "current": false } }`, or
        - Create a new run
    4. Fetch run
        - Run status should be `stopped`

Note: Was unable to get good unit test coverage for case (2), so automated acceptance tests will be (extra) important here (CC @y3rsh)

## Risk assessment

Low