### PR TITLE
refactor(api): Allow setting `ProtocolSource.directory` when reading from FS

### DIFF
--- a/api/src/opentrons/cli/analyze.py
+++ b/api/src/opentrons/cli/analyze.py
@@ -55,7 +55,10 @@ def _get_input_files(files_and_dirs: Sequence[Path]) -> List[Path]:
 async def _analyze(files_and_dirs: Sequence[Path], json_mode: bool) -> None:
     input_files = _get_input_files(files_and_dirs)
 
-    protocol_source = await ProtocolReader().read(input_files)
+    protocol_source = await ProtocolReader().read_saved(
+        files=input_files,
+        directory=None,
+    )
     runner = await create_simulating_runner()
     analysis = await runner.run(protocol_source)
 

--- a/api/src/opentrons/protocol_reader/protocol_reader.py
+++ b/api/src/opentrons/protocol_reader/protocol_reader.py
@@ -1,6 +1,6 @@
 """Read relevant protocol information from a set of files."""
 from pathlib import Path
-from typing import List, Optional, Sequence, Union, overload
+from typing import List, Sequence, Union
 
 from .input_file import AbstractInputFile
 from .file_reader_writer import FileReaderWriter, FileReadError
@@ -34,36 +34,15 @@ class ProtocolReader:
         self._role_analyzer = role_analyzer or RoleAnalyzer()
         self._config_analyzer = config_analyzer or ConfigAnalyzer()
 
-    @overload
-    async def read(
-        self,
-        files: Sequence[AbstractInputFile],
-        directory: Path,
+    async def read_and_save(
+        self, files: Sequence[AbstractInputFile], directory: Path
     ) -> ProtocolSource:
-        """Read a set of files and save them to disk."""
-        ...
-
-    @overload
-    async def read(self, files: Sequence[Path]) -> ProtocolSource:
-        """Read a set of files already on disk."""
-        ...
-
-    async def read(
-        self,
-        files: Union[
-            Sequence[AbstractInputFile],
-            Sequence[Path],
-        ],
-        directory: Optional[Path] = None,
-    ) -> ProtocolSource:
-        """Read a set of file-like objects or paths, returning a ProtocolSource.
+        """Compute a `ProtocolSource` from file-like objects and save them as files.
 
         Arguments:
-            files: List of files or paths. Do not attempt to reuse and file-like
-                objects once they've been passed to the ProtocolReader.
+            files: List of files-like objects. Do not attempt to reuse any objects
+                objects in this list once they've been passed to the ProtocolReader.
             directory: Name of the directory to create and place files in.
-                Required if `files` is a list of `AbstractInputFile`s, unused
-                if `files` is a list of `Path`'s.
 
         Returns:
             A validated ProtocolSource.
@@ -72,11 +51,6 @@ class ProtocolReader:
             ProtocolFilesInvalidError: Input file list given to the reader
                 could not be validated as a protocol.
         """
-        # TODO(mc, 2022-04-01): this assert is a bit awkward,
-        # consider restructuring so it isn't needed
-        if directory is None:
-            assert all(isinstance(f, Path) for f in files), "Must provide a directory"
-
         try:
             buffered_files = await self._file_reader_writer.read(files)
             role_analysis = self._role_analyzer.analyze(buffered_files)
@@ -90,24 +64,62 @@ class ProtocolReader:
             *role_analysis.labware_files,
         ]
 
-        if directory is not None:
-            await self._file_reader_writer.write(directory=directory, files=all_files)
-            main_file = directory / role_analysis.main_file.name
-            output_files = [
-                ProtocolSourceFile(path=directory / f.name, role=f.role)
-                for f in all_files
-            ]
-        else:
-            # TODO(mc, 2022-04-01): these asserts are a bit awkward,
-            # consider restructuring so they're not needed
-            assert isinstance(role_analysis.main_file.path, Path)
-            assert all(isinstance(f.path, Path) for f in all_files)
+        await self._file_reader_writer.write(directory=directory, files=all_files)
+        main_file = directory / role_analysis.main_file.name
+        output_files = [
+            ProtocolSourceFile(path=directory / f.name, role=f.role) for f in all_files
+        ]
 
-            main_file = role_analysis.main_file.path
-            output_files = [
-                ProtocolSourceFile(path=f.path, role=f.role)  # type: ignore[arg-type]
-                for f in all_files
-            ]
+        return ProtocolSource(
+            directory=directory,
+            main_file=main_file,
+            files=output_files,
+            config=config_analysis.config,
+            metadata=config_analysis.metadata,
+            labware_definitions=role_analysis.labware_definitions,
+        )
+
+    async def read_saved(
+        self,
+        files: Sequence[Path],
+        directory: Optional[Path],
+    ) -> ProtocolSource:
+        """Compute a `ProtocolSource` from  `read_and_save()`, except don't
+
+        Arguments:
+            files: The files comprising the protocol.
+            directory: Passed through to `ProtocolSource.directory`. Otherwise unused.
+
+        Returns:
+            A validated ProtocolSource.
+
+        Raises:
+            ProtocolFilesInvalidError: Input file list given to the reader
+                could not be validated as a protocol.
+        """
+        try:
+            buffered_files = await self._file_reader_writer.read(files)
+            role_analysis = self._role_analyzer.analyze(buffered_files)
+            config_analysis = self._config_analyzer.analyze(role_analysis.main_file)
+        except (FileReadError, RoleAnalysisError, ConfigAnalysisError) as e:
+            raise ProtocolFilesInvalidError(str(e)) from e
+
+        # TODO(mc, 2021-12-07): add support for other files, like arbitrary data files
+        all_files: List[RoleAnalysisFile] = [
+            role_analysis.main_file,
+            *role_analysis.labware_files,
+        ]
+
+        # TODO(mc, 2022-04-01): these asserts are a bit awkward,
+        # consider restructuring so they're not needed
+        assert isinstance(role_analysis.main_file.path, Path)
+        assert all(isinstance(f.path, Path) for f in all_files)
+
+        main_file = role_analysis.main_file.path
+        output_files = [
+            ProtocolSourceFile(path=f.path, role=f.role)  # type: ignore[arg-type]
+            for f in all_files
+        ]
 
         return ProtocolSource(
             directory=directory,

--- a/api/src/opentrons/protocol_reader/protocol_reader.py
+++ b/api/src/opentrons/protocol_reader/protocol_reader.py
@@ -1,6 +1,6 @@
 """Read relevant protocol information from a set of files."""
 from pathlib import Path
-from typing import List, Sequence, Union
+from typing import List, Optional, Sequence
 
 from .input_file import AbstractInputFile
 from .file_reader_writer import FileReaderWriter, FileReadError
@@ -84,7 +84,7 @@ class ProtocolReader:
         files: Sequence[Path],
         directory: Optional[Path],
     ) -> ProtocolSource:
-        """Compute a `ProtocolSource` from  `read_and_save()`, except don't
+        """Compute a `ProtocolSource` from protocol source files on the filesystem.
 
         Arguments:
             files: The files comprising the protocol.

--- a/api/src/opentrons/protocol_reader/protocol_source.py
+++ b/api/src/opentrons/protocol_reader/protocol_source.py
@@ -97,8 +97,8 @@ class ProtocolSource:
     (Excluding information that would require in-depth simulation of the protocol.)
 
     Attributes:
-        directory: The directory of the protocol files, if a directory
-            was created by the ProtocolReader.
+        directory: The directory containing the protocol files
+            (and only the protocol files), or ``None`` if this is unknown.
         main_file: The location of the protocol's main file on disk.
         files: Descriptions of all files that make up the protocol.
         metadata: Arbitrary metadata specified by the protocols.

--- a/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_command_mapper.py
@@ -68,7 +68,10 @@ def pick_up_tip_protocol_file(tmp_path: Path) -> Path:
 async def test_legacy_pick_up_tip(pick_up_tip_protocol_file: Path) -> None:
     """It should map legacy pick up tip commands."""
     protocol_reader = ProtocolReader()
-    protocol_source = await protocol_reader.read([pick_up_tip_protocol_file])
+    protocol_source = await protocol_reader.read_saved(
+        files=[pick_up_tip_protocol_file],
+        directory=None,
+    )
 
     subject = await create_simulating_runner()
     result = await subject.run(protocol_source)

--- a/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_custom_labware.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_custom_labware.py
@@ -47,7 +47,10 @@ def custom_labware_protocol_files(tmp_path: Path) -> List[Path]:
 async def test_legacy_custom_labware(custom_labware_protocol_files: List[Path]) -> None:
     """It should map legacy pick up tip commands."""
     protocol_reader = ProtocolReader()
-    protocol_source = await protocol_reader.read(custom_labware_protocol_files)
+    protocol_source = await protocol_reader.read_saved(
+        files=custom_labware_protocol_files,
+        directory=None,
+    )
 
     subject = await create_simulating_runner()
     result = await subject.run(protocol_source)

--- a/api/tests/opentrons/protocol_runner/smoke_tests/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/test_protocol_runner.py
@@ -34,7 +34,10 @@ async def test_runner_with_python(
 ) -> None:
     """It should run a Python protocol on the ProtocolRunner."""
     protocol_reader = ProtocolReader()
-    protocol_source = await protocol_reader.read([python_protocol_file])
+    protocol_source = await protocol_reader.read_saved(
+        files=[python_protocol_file],
+        directory=None,
+    )
 
     subject = await create_simulating_runner()
     result = await subject.run(protocol_source)
@@ -96,7 +99,10 @@ async def test_runner_with_python(
 async def test_runner_with_json(json_protocol_file: Path) -> None:
     """It should run a JSON protocol on the ProtocolRunner."""
     protocol_reader = ProtocolReader()
-    protocol_source = await protocol_reader.read([json_protocol_file])
+    protocol_source = await protocol_reader.read_saved(
+        files=[json_protocol_file],
+        directory=None,
+    )
 
     subject = await create_simulating_runner()
     result = await subject.run(protocol_source)
@@ -145,7 +151,10 @@ async def test_runner_with_json(json_protocol_file: Path) -> None:
 async def test_runner_with_legacy_python(legacy_python_protocol_file: Path) -> None:
     """It should run a Python protocol on the ProtocolRunner."""
     protocol_reader = ProtocolReader()
-    protocol_source = await protocol_reader.read([legacy_python_protocol_file])
+    protocol_source = await protocol_reader.read_saved(
+        files=[legacy_python_protocol_file],
+        directory=None,
+    )
 
     subject = await create_simulating_runner()
     result = await subject.run(protocol_source)
@@ -197,7 +206,10 @@ async def test_runner_with_legacy_python(legacy_python_protocol_file: Path) -> N
 async def test_runner_with_legacy_json(legacy_json_protocol_file: Path) -> None:
     """It should run a Python protocol on the ProtocolRunner."""
     protocol_reader = ProtocolReader()
-    protocol_source = await protocol_reader.read([legacy_json_protocol_file])
+    protocol_source = await protocol_reader.read_saved(
+        files=[legacy_json_protocol_file],
+        directory=None,
+    )
 
     subject = await create_simulating_runner()
     result = await subject.run(protocol_source)

--- a/api/tests/opentrons/protocol_runner/smoke_tests/test_python_file_reader.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/test_python_file_reader.py
@@ -10,7 +10,10 @@ from opentrons.protocol_runner.python_file_reader import PythonFileReader
 async def test_read_gets_run_method(python_protocol_file: Path) -> None:
     """It should pull the run method out of the Python file."""
     protocol_reader = ProtocolReader()
-    protocol_source = await protocol_reader.read([python_protocol_file])
+    protocol_source = await protocol_reader.read_saved(
+        files=[python_protocol_file],
+        directory=None,
+    )
 
     subject = PythonFileReader()
     result = subject.read(protocol_source)

--- a/robot-server/robot_server/protocols/router.py
+++ b/robot-server/robot_server/protocols/router.py
@@ -104,7 +104,7 @@ async def create_protocol(
         created_at: Timestamp to attach to the new resource.
     """
     try:
-        source = await protocol_reader.read(
+        source = await protocol_reader.read_and_save(
             files=files,
             directory=protocol_directory / protocol_id,
         )

--- a/robot-server/tests/protocols/test_protocols_router.py
+++ b/robot-server/tests/protocols/test_protocols_router.py
@@ -262,7 +262,7 @@ async def test_create_protocol(
     analysis = PendingAnalysis(id="analysis-id")
 
     decoy.when(
-        await protocol_reader.read(
+        await protocol_reader.read_and_save(
             files=[protocol_file],
             directory=protocol_directory / "protocol-id",
         )
@@ -313,7 +313,7 @@ async def test_create_protocol_not_readable(
 ) -> None:
     """It should 400 if the protocol is rejected by the pre-analyzer."""
     decoy.when(
-        await protocol_reader.read(
+        await protocol_reader.read_and_save(
             directory=matchers.Anything(),
             files=matchers.Anything(),
         )


### PR DESCRIPTION
# Overview

This PR decouples the presence/absence of the `ProtocolSource.directory` field from how the `ProtocolSource` was computed. You can now read a protocol from files that already exist on the filesystem, *and at the same time* get a `ProtocolSource` back that has its `directory` field set. 

# Rationale

Currently, `ProtocolReader` has two modes of operation:

1. Compute a `ProtocolSource` from a bunch of file-like things, and then save those file-like things to real files on the actual filesystem.
2. Compute a `ProtocolSource` from things that are already real files on the filesystem.

In mode (1), the `directory` field is properly set on the resulting `ProtocolSource`. In mode (2), it's `None`.

The problem with this is that it's sometimes helpful for the returned `ProtocolSource` to have a `directory` *even if it was computed via mode (2).* In particular, `ProtocolStore` looks at `directory` (as well as `files`) to see what it needs to clean up when a protocol is removed. And `ProtocolStore` will be using mode (2) shortly.

In the longer term, instead of `ProtocolReader` being responsible for copying and `ProtocolStore` being responsible for deleting, we probably want a third unit that assumes both of those responsibilities. This PR doesn't do that, but I think it takes a tiny step in that direction.

# Review requests

* Please scrutinize the way I split up `ProtocolReader.read()`. I've split it into two methods that should be equivalent to the two overloads, but double-check my work.
* Can we see any worthwhile way to reduce the duplication between the two methods?

# Risk assessment

I think low, but I'm really leaning on integration tests here.
