### PR TITLE
feat(app): add H-S to PD pause step

### DIFF
--- a/protocol-designer/src/components/StepEditForm/forms/PauseForm.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/PauseForm.tsx
@@ -23,13 +23,29 @@ import styles from '../StepEditForm.css'
 import { StepFormProps } from '../types'
 
 export const PauseForm = (props: StepFormProps): JSX.Element => {
-  const moduleLabwareOptions = useSelector(
+  const tempModuleLabwareOptions = useSelector(
     uiModuleSelectors.getTemperatureLabwareOptions
   )
+
+  const heaterShakerModuleLabwareOptions = useSelector(
+    uiModuleSelectors.getHeaterShakerLabwareOptions
+  )
+
+  const moduleLabwareOptions = [
+    ...tempModuleLabwareOptions,
+    ...heaterShakerModuleLabwareOptions,
+  ]
 
   const pauseUntilTempEnabled = useSelector(
     uiModuleSelectors.getTempModuleIsOnDeck
   )
+
+  const pauseUntilHeaterShakerEnabled = useSelector(
+    uiModuleSelectors.getHeaterShakerModuleIsOnDeck
+  )
+
+  const pauseUntilModuleEnabled =
+    pauseUntilTempEnabled || pauseUntilHeaterShakerEnabled
 
   const [targetProps, tooltipProps] = useHoverTooltip({
     placement: TOOLTIP_BOTTOM,
@@ -95,7 +111,7 @@ export const PauseForm = (props: StepFormProps): JSX.Element => {
             </div>
           )}
 
-          {pauseUntilTempEnabled ? null : (
+          {pauseUntilModuleEnabled ? null : (
             <Tooltip {...tooltipProps}>
               {getSingleSelectDisabledTooltip('wait_until_temp', 'pauseAction')}
             </Tooltip>
@@ -105,7 +121,7 @@ export const PauseForm = (props: StepFormProps): JSX.Element => {
               <RadioGroupField
                 {...propsForFields.pauseAction}
                 className={cx({
-                  [styles.disabled]: !pauseUntilTempEnabled,
+                  [styles.disabled]: !pauseUntilModuleEnabled,
                 })}
                 options={[
                   {

--- a/protocol-designer/src/components/steplist/StepItem.tsx
+++ b/protocol-designer/src/components/steplist/StepItem.tsx
@@ -469,7 +469,7 @@ export const StepItemContents = (
         message={substeps.message}
         action={i18n.t('modules.actions.await_temperature')}
         actionText={temperature}
-        moduleType={TEMPERATURE_MODULE_TYPE}
+        moduleType={substeps.moduleType}
         labwareNickname={substeps.labwareNickname}
       />
     )

--- a/protocol-designer/src/components/steplist/__tests__/StepItemContents.test.tsx
+++ b/protocol-designer/src/components/steplist/__tests__/StepItemContents.test.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { THERMOCYCLER_MODULE_TYPE } from '@opentrons/shared-data'
+import {
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+} from '@opentrons/shared-data'
 import { THERMOCYCLER_STATE } from '../../../constants'
 import { StepItemContents, StepItemContentsProps } from '../StepItem'
 import { ModuleStepItems } from '../ModuleStepItems'
@@ -144,6 +147,7 @@ describe('StepItemContents', () => {
         temperature: 45,
         labwareNickname: 'temperature nickname',
         message: 'message',
+        moduleType: TEMPERATURE_MODULE_TYPE,
       }
       // @ts-expect-error(sa, 2021-6-21): StepItemContents might return a list of JSX Elements
       const wrapper = shallow(<StepItemContents {...awaitTemperatureProps} />)

--- a/protocol-designer/src/steplist/generateSubstepItem.ts
+++ b/protocol-designer/src/steplist/generateSubstepItem.ts
@@ -401,11 +401,14 @@ export function generateSubstepItem(
   }
 
   if (stepArgs.commandCreatorFnName === 'awaitTemperature') {
+    const moduleId = stepArgs.module
+    const { type } = invariantContext.moduleEntities[moduleId]
     return {
       substepType: 'awaitTemperature',
       temperature: stepArgs.temperature,
       labwareNickname: labwareNames?.nickname,
       message: stepArgs.message,
+      moduleType: type,
     }
   }
 

--- a/protocol-designer/src/steplist/generateSubstepItem.ts
+++ b/protocol-designer/src/steplist/generateSubstepItem.ts
@@ -402,7 +402,7 @@ export function generateSubstepItem(
 
   if (stepArgs.commandCreatorFnName === 'awaitTemperature') {
     const moduleId = stepArgs.module
-    const { type } = invariantContext.moduleEntities[moduleId]
+    const { type } = invariantContext.moduleEntities[moduleId as string]
     return {
       substepType: 'awaitTemperature',
       temperature: stepArgs.temperature,

--- a/protocol-designer/src/steplist/types.ts
+++ b/protocol-designer/src/steplist/types.ts
@@ -4,6 +4,7 @@ import {
   PauseArgs,
   ThermocyclerProfileStepArgs,
 } from '@opentrons/step-generation'
+import { ModuleType } from '@opentrons/shared-data'
 import { StepIdType } from '../form-types'
 import { FormError } from './formLevel/errors'
 // timeline start and end
@@ -113,6 +114,7 @@ export interface AwaitTemperatureSubstepItem {
   substepType: 'awaitTemperature'
   temperature: number
   labwareNickname: string | null | undefined
+  moduleType: ModuleType
   message?: string
 }
 

--- a/protocol-designer/src/ui/modules/selectors.ts
+++ b/protocol-designer/src/ui/modules/selectors.ts
@@ -146,3 +146,14 @@ export const getTempModuleIsOnDeck: Selector<boolean> = createSelector(
     return Boolean(tempOnDeck)
   }
 )
+
+export const getHeaterShakerModuleIsOnDeck: Selector<boolean> = createSelector(
+  getInitialDeckSetup,
+  initialDeckSetup => {
+    const heaterShakerOnDeck = getModuleOnDeckByType(
+      initialDeckSetup,
+      HEATERSHAKER_MODULE_TYPE
+    )
+    return Boolean(heaterShakerOnDeck)
+  }
+)

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -285,7 +285,7 @@ export type PauseArgs = CommonArgs & {
 }
 
 export interface AwaitTemperatureArgs {
-  module: string
+  module: string | null
   commandCreatorFnName: 'awaitTemperature'
   temperature: number
   message?: string

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -285,7 +285,7 @@ export type PauseArgs = CommonArgs & {
 }
 
 export interface AwaitTemperatureArgs {
-  module: string | null
+  module: string
   commandCreatorFnName: 'awaitTemperature'
   temperature: number
   message?: string


### PR DESCRIPTION

# Overview

This PR adds the Heater-Shaker module to the PD pause step form.

closes #9736

![Screen Shot 2022-04-12 at 10 32 17 AM](https://user-images.githubusercontent.com/14794021/162994304-bbe96851-6e2c-451f-b1f1-5be580ea5754.png)

![Screen Shot 2022-04-12 at 10 32 35 AM](https://user-images.githubusercontent.com/14794021/162994319-4d175323-9592-4456-a5e9-a7dce22bcc83.png)

# Changelog

- Add H-S to Pause Form
- Updates types
  
# Review requests

- Check that when you add a H-S and you add a Pause step, you can pause until the H-S reaches a certain temperature.
- Check that when you add a H-S step it opens a modal and builds in a pause step which includes the H-S.

Note: will add `PauseForm` test shortly.

# Risk assessment
low