### PR TITLE
feat(protocol-designer): add tooltips to H-S stepform

### DIFF
--- a/components/src/tooltips/Tooltip.tsx
+++ b/components/src/tooltips/Tooltip.tsx
@@ -60,7 +60,7 @@ export const Tooltip = React.forwardRef(function TooltipComponent(
     arrowRef,
     arrowStyle,
     children,
-    width = '8.75rem',
+    width,
     backgroundColor = darkGrey,
     ...boxProps
   } = props

--- a/components/src/tooltips/Tooltip.tsx
+++ b/components/src/tooltips/Tooltip.tsx
@@ -41,7 +41,7 @@ export interface TooltipProps extends StyleProps {
   arrowRef: React.RefCallback<HTMLElement | null>
   /** Inline styles to apply to arrow element (provided by useTooltip) */
   arrowStyle: CSSProperties
-  /** Specify tooltip width when the default width isn't big enough see PD's PathField/Path for example*/
+  /** Specify tooltip width when the default width isn't big enough see PD's PathField/Path for example */
   width?: string
   /** Specify background color to COLORS.darkBlack when implementing a tooltip in the app */
   backgroundColor?: string
@@ -80,71 +80,71 @@ export const Tooltip = React.forwardRef(function TooltipComponent(
       {...boxProps}
     >
       {children}
-      <Arrow {...{ arrowRef, arrowStyle, placement }} />
+      <Arrow {...{ arrowRef, arrowStyle, placement, backgroundColor }} />
     </Box>
   ) : null
 })
-
-// shift arrows off the element
-const ARROW_ANCHOR_OFFSET = `-${ARROW_SIZE_PX}px;`
-
-// use borders to create arrows
-const ARROW_CSS_BASE = css`
-  position: absolute;
-  border-width: ${ARROW_SIZE_PX}px;
-  border-style: solid;
-  border-color: transparent;
-`
-
-// arrow pointing down from the top tooltip
-const ARROW_CSS_TOP = css`
-  ${ARROW_CSS_BASE}
-  bottom: ${ARROW_ANCHOR_OFFSET};
-  border-bottom-style: none;
-  border-top-color: ${darkGrey};
-`
-
-// arrow pointing left from the right tooltip
-const ARROW_CSS_RIGHT = css`
-  ${ARROW_CSS_BASE}
-  left: ${ARROW_ANCHOR_OFFSET};
-  border-left-style: none;
-  border-right-color: ${darkGrey};
-`
-
-// arrow pointing up from the bottom tooltip
-const ARROW_CSS_BOTTOM = css`
-  ${ARROW_CSS_BASE}
-  top: ${ARROW_ANCHOR_OFFSET};
-  border-top-style: none;
-  border-bottom-color: ${darkGrey};
-`
-
-// arrow pointing right from the left tooltip
-const ARROW_CSS_LEFT = css`
-  ${ARROW_CSS_BASE}
-  right: ${ARROW_ANCHOR_OFFSET};
-  border-right-style: none;
-  border-left-color: ${darkGrey};
-`
-
-const ARROW_CSS_BY_PLACEMENT_BASE: Record<
-  string,
-  FlattenSimpleInterpolation
-> = {
-  top: ARROW_CSS_TOP,
-  right: ARROW_CSS_RIGHT,
-  bottom: ARROW_CSS_BOTTOM,
-  left: ARROW_CSS_LEFT,
-}
 
 export interface ArrowProps {
   placement: Placement | null
   arrowRef: React.RefCallback<HTMLElement>
   arrowStyle: CSSProperties
+  backgroundColor: string
 }
 
 export function Arrow(props: ArrowProps): JSX.Element {
+  // shift arrows off the element
+  const ARROW_ANCHOR_OFFSET = `-${ARROW_SIZE_PX}px;`
+
+  // use borders to create arrows
+  const ARROW_CSS_BASE = css`
+    position: absolute;
+    border-width: ${ARROW_SIZE_PX}px;
+    border-style: solid;
+    border-color: transparent;
+  `
+
+  // arrow pointing down from the top tooltip
+  const ARROW_CSS_TOP = css`
+    ${ARROW_CSS_BASE}
+    bottom: ${ARROW_ANCHOR_OFFSET};
+    border-bottom-style: none;
+    border-top-color: ${props.backgroundColor};
+  `
+
+  // arrow pointing left from the right tooltip
+  const ARROW_CSS_RIGHT = css`
+    ${ARROW_CSS_BASE}
+    left: ${ARROW_ANCHOR_OFFSET};
+    border-left-style: none;
+    border-right-color: ${props.backgroundColor};
+  `
+
+  // arrow pointing up from the bottom tooltip
+  const ARROW_CSS_BOTTOM = css`
+    ${ARROW_CSS_BASE}
+    top: ${ARROW_ANCHOR_OFFSET};
+    border-top-style: none;
+    border-bottom-color: ${props.backgroundColor};
+  `
+
+  // arrow pointing right from the left tooltip
+  const ARROW_CSS_LEFT = css`
+    ${ARROW_CSS_BASE}
+    right: ${ARROW_ANCHOR_OFFSET};
+    border-right-style: none;
+    border-left-color: ${props.backgroundColor};
+  `
+
+  const ARROW_CSS_BY_PLACEMENT_BASE: Record<
+    string,
+    FlattenSimpleInterpolation
+  > = {
+    top: ARROW_CSS_TOP,
+    right: ARROW_CSS_RIGHT,
+    bottom: ARROW_CSS_BOTTOM,
+    left: ARROW_CSS_LEFT,
+  }
   const placement = props.placement ?? ''
   const placementBase = placement.split('-')[0]
   const arrowCss = ARROW_CSS_BY_PLACEMENT_BASE[placementBase]

--- a/components/src/tooltips/Tooltip.tsx
+++ b/components/src/tooltips/Tooltip.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { css } from 'styled-components'
 
 import { radiusSoftCorners } from '../ui-style-constants/borders'
-import { fontSizeLabel } from '../ui-style-constants/typography'
+import { fontSizeH4 } from '../ui-style-constants/typography'
 import { spacing3 } from '../ui-style-constants/spacing'
 import { white, darkGrey } from '../ui-style-constants/colors'
 import { ARROW_SIZE_PX } from './styles'
@@ -12,17 +12,6 @@ import type { CSSProperties } from 'react'
 import type { FlattenSimpleInterpolation } from 'styled-components'
 import type { Placement } from './types'
 import type { StyleProps } from '../primitives'
-
-const TOOLTIP_CSS = css`
-  position: absolute;
-  z-index: 9001;
-  padding: ${spacing3};
-  color: ${white};
-  filter: drop-shadow(0px 1px 3px rgba(0, 0, 0, 0.2));
-  cursor: pointer;
-  font-size: ${fontSizeLabel};
-  border-radius: ${radiusSoftCorners};
-`
 
 export interface TooltipProps extends StyleProps {
   /** Whether or not the tooltip should be rendered */
@@ -61,9 +50,21 @@ export const Tooltip = React.forwardRef(function TooltipComponent(
     arrowStyle,
     children,
     width,
+    fontSize = fontSizeH4,
     backgroundColor = darkGrey,
     ...boxProps
   } = props
+
+  const TOOLTIP_CSS = css`
+    position: absolute;
+    z-index: 9001;
+    padding: ${spacing3};
+    color: ${white};
+    filter: drop-shadow(0px 1px 3px rgba(0, 0, 0, 0.2));
+    cursor: pointer;
+    font-size: ${fontSize};
+    border-radius: ${radiusSoftCorners};
+  `
 
   return visible ? (
     <Box

--- a/components/src/tooltips/Tooltip.tsx
+++ b/components/src/tooltips/Tooltip.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react'
 import { css } from 'styled-components'
 
-import { FONT_BODY_1_LIGHT, C_DARK_GRAY } from '../styles'
+import { fontSizeLabel } from '../ui-style-constants/typography'
+import { spacing3, spacingS } from '../ui-style-constants/spacing'
+import { darkBlack, white } from '../ui-style-constants/colors'
 import { ARROW_SIZE_PX } from './styles'
 import { Box } from '../primitives'
 
@@ -13,11 +15,14 @@ import type { StyleProps } from '../primitives'
 const TOOLTIP_CSS = css`
   position: absolute;
   z-index: 9001;
-  padding: 0.5rem;
-  ${FONT_BODY_1_LIGHT}
-  background-color: ${C_DARK_GRAY};
-  box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.13), 0 3px 6px 0 rgba(0, 0, 0, 0.23);
+  padding: ${spacing3};
+  color: ${white};
+  background-color: ${darkBlack};
+  filter: drop-shadow(0px 1px 3px rgba(0, 0, 0, 0.2));
   cursor: pointer;
+  font-size: ${fontSizeLabel};
+  border-radius: ${spacingS};
+  width: 140px;
 `
 
 export interface TooltipProps extends StyleProps {
@@ -90,7 +95,7 @@ const ARROW_CSS_TOP = css`
   ${ARROW_CSS_BASE}
   bottom: ${ARROW_ANCHOR_OFFSET};
   border-bottom-style: none;
-  border-top-color: ${C_DARK_GRAY};
+  border-top-color: ${darkBlack};
 `
 
 // arrow pointing left from the right tooltip
@@ -98,7 +103,7 @@ const ARROW_CSS_RIGHT = css`
   ${ARROW_CSS_BASE}
   left: ${ARROW_ANCHOR_OFFSET};
   border-left-style: none;
-  border-right-color: ${C_DARK_GRAY};
+  border-right-color: ${darkBlack};
 `
 
 // arrow pointing up from the bottom tooltip
@@ -106,7 +111,7 @@ const ARROW_CSS_BOTTOM = css`
   ${ARROW_CSS_BASE}
   top: ${ARROW_ANCHOR_OFFSET};
   border-top-style: none;
-  border-bottom-color: ${C_DARK_GRAY};
+  border-bottom-color: ${darkBlack};
 `
 
 // arrow pointing right from the left tooltip
@@ -114,7 +119,7 @@ const ARROW_CSS_LEFT = css`
   ${ARROW_CSS_BASE}
   right: ${ARROW_ANCHOR_OFFSET};
   border-right-style: none;
-  border-left-color: ${C_DARK_GRAY};
+  border-left-color: ${darkBlack};
 `
 
 const ARROW_CSS_BY_PLACEMENT_BASE: Record<

--- a/components/src/tooltips/Tooltip.tsx
+++ b/components/src/tooltips/Tooltip.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react'
 import { css } from 'styled-components'
 
+import { radiusSoftCorners } from '../ui-style-constants/borders'
 import { fontSizeLabel } from '../ui-style-constants/typography'
-import { spacing3, spacingS } from '../ui-style-constants/spacing'
+import { spacing3 } from '../ui-style-constants/spacing'
 import { white, darkGrey } from '../ui-style-constants/colors'
 import { ARROW_SIZE_PX } from './styles'
 import { Box } from '../primitives'
@@ -20,7 +21,7 @@ const TOOLTIP_CSS = css`
   filter: drop-shadow(0px 1px 3px rgba(0, 0, 0, 0.2));
   cursor: pointer;
   font-size: ${fontSizeLabel};
-  border-radius: ${spacingS};
+  border-radius: ${radiusSoftCorners};
 `
 
 export interface TooltipProps extends StyleProps {
@@ -41,10 +42,6 @@ export interface TooltipProps extends StyleProps {
   arrowRef: React.RefCallback<HTMLElement | null>
   /** Inline styles to apply to arrow element (provided by useTooltip) */
   arrowStyle: CSSProperties
-  /** Specify tooltip width when the default width isn't big enough see PD's PathField/Path for example */
-  width?: string
-  /** Specify background color to COLORS.darkBlack when implementing a tooltip in the app */
-  backgroundColor?: string
 }
 
 /**

--- a/components/src/tooltips/Tooltip.tsx
+++ b/components/src/tooltips/Tooltip.tsx
@@ -22,7 +22,7 @@ const TOOLTIP_CSS = css`
   cursor: pointer;
   font-size: ${fontSizeLabel};
   border-radius: ${spacingS};
-  width: 140px;
+  width: 8.75rem;
 `
 
 export interface TooltipProps extends StyleProps {

--- a/components/src/tooltips/Tooltip.tsx
+++ b/components/src/tooltips/Tooltip.tsx
@@ -3,7 +3,7 @@ import { css } from 'styled-components'
 
 import { fontSizeLabel } from '../ui-style-constants/typography'
 import { spacing3, spacingS } from '../ui-style-constants/spacing'
-import { darkBlack, white } from '../ui-style-constants/colors'
+import { white, darkGrey } from '../ui-style-constants/colors'
 import { ARROW_SIZE_PX } from './styles'
 import { Box } from '../primitives'
 
@@ -17,12 +17,10 @@ const TOOLTIP_CSS = css`
   z-index: 9001;
   padding: ${spacing3};
   color: ${white};
-  background-color: ${darkBlack};
   filter: drop-shadow(0px 1px 3px rgba(0, 0, 0, 0.2));
   cursor: pointer;
   font-size: ${fontSizeLabel};
   border-radius: ${spacingS};
-  width: 8.75rem;
 `
 
 export interface TooltipProps extends StyleProps {
@@ -43,6 +41,10 @@ export interface TooltipProps extends StyleProps {
   arrowRef: React.RefCallback<HTMLElement | null>
   /** Inline styles to apply to arrow element (provided by useTooltip) */
   arrowStyle: CSSProperties
+  /** Specify tooltip width when the default width isn't big enough see PD's PathField/Path for example*/
+  width?: string
+  /** Specify background color to COLORS.darkBlack when implementing a tooltip in the app */
+  backgroundColor?: string
 }
 
 /**
@@ -61,6 +63,8 @@ export const Tooltip = React.forwardRef(function TooltipComponent(
     arrowRef,
     arrowStyle,
     children,
+    width = '8.75rem',
+    backgroundColor = darkGrey,
     ...boxProps
   } = props
 
@@ -71,6 +75,8 @@ export const Tooltip = React.forwardRef(function TooltipComponent(
       style={style}
       ref={ref}
       css={TOOLTIP_CSS}
+      width={width}
+      backgroundColor={backgroundColor}
       {...boxProps}
     >
       {children}
@@ -95,7 +101,7 @@ const ARROW_CSS_TOP = css`
   ${ARROW_CSS_BASE}
   bottom: ${ARROW_ANCHOR_OFFSET};
   border-bottom-style: none;
-  border-top-color: ${darkBlack};
+  border-top-color: ${darkGrey};
 `
 
 // arrow pointing left from the right tooltip
@@ -103,7 +109,7 @@ const ARROW_CSS_RIGHT = css`
   ${ARROW_CSS_BASE}
   left: ${ARROW_ANCHOR_OFFSET};
   border-left-style: none;
-  border-right-color: ${darkBlack};
+  border-right-color: ${darkGrey};
 `
 
 // arrow pointing up from the bottom tooltip
@@ -111,7 +117,7 @@ const ARROW_CSS_BOTTOM = css`
   ${ARROW_CSS_BASE}
   top: ${ARROW_ANCHOR_OFFSET};
   border-top-style: none;
-  border-bottom-color: ${darkBlack};
+  border-bottom-color: ${darkGrey};
 `
 
 // arrow pointing right from the left tooltip
@@ -119,7 +125,7 @@ const ARROW_CSS_LEFT = css`
   ${ARROW_CSS_BASE}
   right: ${ARROW_ANCHOR_OFFSET};
   border-right-style: none;
-  border-left-color: ${darkBlack};
+  border-left-color: ${darkGrey};
 `
 
 const ARROW_CSS_BY_PLACEMENT_BASE: Record<

--- a/components/src/tooltips/styles.ts
+++ b/components/src/tooltips/styles.ts
@@ -15,6 +15,6 @@ export const INITIAL_ARROW_STYLE = {
 
 export const TOOLTIP_OFFSET_PX = 8
 
-export const ARROW_OFFSET_PX = 2
+export const ARROW_OFFSET_PX = 4
 
 export const ARROW_SIZE_PX = TOOLTIP_OFFSET_PX - ARROW_OFFSET_PX

--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -298,7 +298,7 @@ and when that is implemented.
   margin: 0 0 1rem 1.75rem;
 }
 
-.toggle_form_group_no_bottom_margin {
+.set_plate_latch_form_group {
   min-width: 20%;
   margin: 0 0 0 1.75rem;
 }

--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -298,6 +298,11 @@ and when that is implemented.
   margin: 0 0 1rem 1.75rem;
 }
 
+.toggle_form_group_no_bottom_margin {
+  min-width: 20%;
+  margin: 0 0 0 1.75rem;
+}
+
 .toggle_row {
   display: flex;
   flex-direction: row;

--- a/protocol-designer/src/components/StepEditForm/fields/CheckboxRowField.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/CheckboxRowField.tsx
@@ -8,12 +8,14 @@ import {
 import cx from 'classnames'
 import styles from '../StepEditForm.css'
 import { FieldProps } from '../types'
+import type { Placement } from '@opentrons/components'
 
 type CheckboxRowProps = FieldProps & {
   children?: React.ReactNode
   className?: string
   label?: string
   tooltipContent?: React.ReactNode
+  tooltipPlacement?: Placement
 }
 
 export const CheckboxRowField = (props: CheckboxRowProps): JSX.Element => {
@@ -27,15 +29,16 @@ export const CheckboxRowField = (props: CheckboxRowProps): JSX.Element => {
     tooltipContent,
     updateValue,
     value,
+    tooltipPlacement = TOOLTIP_TOP,
   } = props
 
   const [targetProps, tooltipProps] = useHoverTooltip({
-    placement: TOOLTIP_TOP,
+    placement: tooltipPlacement,
   })
 
   return (
     <>
-      <Tooltip maxWidth="18rem" lineHeight="1.5" {...tooltipProps}>
+      <Tooltip lineHeight="1.5" {...tooltipProps}>
         {tooltipContent}
       </Tooltip>
       <div className={styles.checkbox_row}>

--- a/protocol-designer/src/components/StepEditForm/fields/PathField/Path.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/PathField/Path.tsx
@@ -59,7 +59,7 @@ const PathButton = (buttonProps: ButtonProps): JSX.Element => {
   const [targetProps, tooltipProps] = useHoverTooltip()
 
   const tooltip = (
-    <Tooltip width="33.5rem" {...tooltipProps}>
+    <Tooltip {...tooltipProps}>
       <div className={styles.path_tooltip_title}>
         {i18n.t(`form.step_edit_form.field.path.title.${path}`)}
       </div>

--- a/protocol-designer/src/components/StepEditForm/fields/PathField/Path.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/PathField/Path.tsx
@@ -59,7 +59,7 @@ const PathButton = (buttonProps: ButtonProps): JSX.Element => {
   const [targetProps, tooltipProps] = useHoverTooltip()
 
   const tooltip = (
-    <Tooltip {...tooltipProps}>
+    <Tooltip width="59.5%" {...tooltipProps}>
       <div className={styles.path_tooltip_title}>
         {i18n.t(`form.step_edit_form.field.path.title.${path}`)}
       </div>

--- a/protocol-designer/src/components/StepEditForm/fields/PathField/Path.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/PathField/Path.tsx
@@ -59,7 +59,7 @@ const PathButton = (buttonProps: ButtonProps): JSX.Element => {
   const [targetProps, tooltipProps] = useHoverTooltip()
 
   const tooltip = (
-    <Tooltip width="59.5%" {...tooltipProps}>
+    <Tooltip width="33.5rem" {...tooltipProps}>
       <div className={styles.path_tooltip_title}>
         {i18n.t(`form.step_edit_form.field.path.title.${path}`)}
       </div>

--- a/protocol-designer/src/components/StepEditForm/forms/HeaterShakerForm/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/HeaterShakerForm/index.tsx
@@ -11,14 +11,12 @@ import {
 } from '@opentrons/components'
 import { i18n } from '../../../../localization'
 import { getHeaterShakerLabwareOptions } from '../../../../ui/modules/selectors'
-import { getDisabledFields } from '../../../../steplist/formLevel'
 import {
   ToggleRowField,
   TextField,
   CheckboxRowField,
   StepFormDropdown,
 } from '../../fields'
-import { getSingleSelectDisabledTooltip } from '../../utils'
 import styles from '../../StepEditForm.css'
 
 import type { StepFormProps } from '../../types'

--- a/protocol-designer/src/components/StepEditForm/forms/HeaterShakerForm/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/HeaterShakerForm/index.tsx
@@ -11,6 +11,7 @@ import {
 } from '@opentrons/components'
 import { i18n } from '../../../../localization'
 import { getHeaterShakerLabwareOptions } from '../../../../ui/modules/selectors'
+import { getDisabledFields } from '../../../../steplist/formLevel'
 import {
   ToggleRowField,
   TextField,
@@ -27,8 +28,8 @@ export const HeaterShakerForm = (props: StepFormProps): JSX.Element | null => {
   const [targetLatchProps, tooltipLatchProps] = useHoverTooltip({
     placement: TOOLTIP_BOTTOM,
   })
-
   const { propsForFields, formData } = props
+
   return (
     <div>
       <span className={styles.section_header_text}>
@@ -111,7 +112,6 @@ export const HeaterShakerForm = (props: StepFormProps): JSX.Element | null => {
           >
             <ToggleRowField
               {...propsForFields.latchOpen}
-              disabled={formData.setShake === true}
               offLabel={i18n.t(
                 'form.step_edit_form.field.heaterShaker.latch.toggleOff'
               )}
@@ -122,7 +122,7 @@ export const HeaterShakerForm = (props: StepFormProps): JSX.Element | null => {
           </FormGroup>
         </Flex>
       </div>
-      <Flex paddingBottom={SPACING.spacing6}>
+      <Flex paddingBottom={'8.4rem'}>
         <Flex width={SPACING.spacingM}>
           <CheckboxRowField
             tooltipPlacement={TOOLTIP_BOTTOM}
@@ -144,9 +144,9 @@ export const HeaterShakerForm = (props: StepFormProps): JSX.Element | null => {
             />
           </CheckboxRowField>
         </Flex>
-        {formData.setShake === true && (
+        {propsForFields.latchOpen.disabled && (
           <Tooltip {...tooltipLatchProps}>
-            {getSingleSelectDisabledTooltip('latchOpen', 'heaterShaker')}
+            {propsForFields.latchOpen.tooltipContent}
           </Tooltip>
         )}
       </Flex>

--- a/protocol-designer/src/components/StepEditForm/forms/HeaterShakerForm/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/HeaterShakerForm/index.tsx
@@ -1,7 +1,14 @@
 import * as React from 'react'
 import cx from 'classnames'
 import { useSelector } from 'react-redux'
-import { FormGroup, Flex, SPACING } from '@opentrons/components'
+import {
+  FormGroup,
+  Flex,
+  SPACING,
+  useHoverTooltip,
+  Tooltip,
+  TOOLTIP_BOTTOM,
+} from '@opentrons/components'
 import { i18n } from '../../../../localization'
 import { getHeaterShakerLabwareOptions } from '../../../../ui/modules/selectors'
 import {
@@ -10,12 +17,17 @@ import {
   CheckboxRowField,
   StepFormDropdown,
 } from '../../fields'
+import { getSingleSelectDisabledTooltip } from '../../utils'
 import styles from '../../StepEditForm.css'
 
 import type { StepFormProps } from '../../types'
 
 export const HeaterShakerForm = (props: StepFormProps): JSX.Element | null => {
   const moduleLabwareOptions = useSelector(getHeaterShakerLabwareOptions)
+  const [targetLatchProps, tooltipLatchProps] = useHoverTooltip({
+    placement: TOOLTIP_BOTTOM,
+  })
+
   const { propsForFields, formData } = props
   return (
     <div>
@@ -90,43 +102,53 @@ export const HeaterShakerForm = (props: StepFormProps): JSX.Element | null => {
             )}
           </div>
         </FormGroup>
-
-        <FormGroup
-          label={i18n.t(
-            'form.step_edit_form.field.heaterShaker.latch.setLatch'
-          )}
-          className={styles.toggle_form_group}
-        >
-          <ToggleRowField
-            {...propsForFields.latchOpen}
-            offLabel={i18n.t(
-              'form.step_edit_form.field.heaterShaker.latch.toggleOff'
+        <Flex {...targetLatchProps}>
+          <FormGroup
+            label={i18n.t(
+              'form.step_edit_form.field.heaterShaker.latch.setLatch'
             )}
-            onLabel={i18n.t(
-              'form.step_edit_form.field.heaterShaker.latch.toggleOn'
-            )}
-          />
-        </FormGroup>
+            className={styles.toggle_form_group_no_bottom_margin}
+          >
+            <ToggleRowField
+              {...propsForFields.latchOpen}
+              disabled={formData.setShake === true}
+              offLabel={i18n.t(
+                'form.step_edit_form.field.heaterShaker.latch.toggleOff'
+              )}
+              onLabel={i18n.t(
+                'form.step_edit_form.field.heaterShaker.latch.toggleOn'
+              )}
+            />
+          </FormGroup>
+        </Flex>
       </div>
       <Flex paddingBottom={SPACING.spacing6}>
-        <CheckboxRowField
-          {...propsForFields.heaterShakerSetTimer}
-          label={i18n.t(
-            'form.step_edit_form.field.heaterShaker.timer.heaterShakerSetTimer'
-          )}
-          className={styles.small_field}
-        >
-          <TextField
-            {...propsForFields.heaterShakerTimerMinutes}
+        <Flex width={SPACING.spacingM}>
+          <CheckboxRowField
+            tooltipPlacement={TOOLTIP_BOTTOM}
+            {...propsForFields.heaterShakerSetTimer}
             className={styles.small_field}
-            units={i18n.t('application.units.minutes')}
-          />
-          <TextField
-            {...propsForFields.heaterShakerTimerSeconds}
-            className={styles.small_field}
-            units={i18n.t('application.units.seconds')}
-          />
-        </CheckboxRowField>
+            label={i18n.t(
+              'form.step_edit_form.field.heaterShaker.timer.heaterShakerSetTimer'
+            )}
+          >
+            <TextField
+              {...propsForFields.heaterShakerTimerMinutes}
+              className={styles.small_field}
+              units={i18n.t('application.units.minutes')}
+            />
+            <TextField
+              {...propsForFields.heaterShakerTimerSeconds}
+              className={styles.small_field}
+              units={i18n.t('application.units.seconds')}
+            />
+          </CheckboxRowField>
+        </Flex>
+        {formData.setShake === true && (
+          <Tooltip {...tooltipLatchProps}>
+            {getSingleSelectDisabledTooltip('latchOpen', 'heaterShaker')}
+          </Tooltip>
+        )}
       </Flex>
     </div>
   )

--- a/protocol-designer/src/components/StepEditForm/forms/HeaterShakerForm/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/HeaterShakerForm/index.tsx
@@ -106,7 +106,7 @@ export const HeaterShakerForm = (props: StepFormProps): JSX.Element | null => {
             label={i18n.t(
               'form.step_edit_form.field.heaterShaker.latch.setLatch'
             )}
-            className={styles.toggle_form_group_no_bottom_margin}
+            className={styles.set_plate_latch_form_group}
           >
             <ToggleRowField
               {...propsForFields.latchOpen}

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -11,7 +11,7 @@
     "magnet": "Engage or disengage the Magnetic module.",
     "temperature": "Set temperature command for Temperature module.",
     "thermocycler": "Change Thermocycler state or program a profile.",
-    "heaterShaker": "Set heat, shake, or labware latch commands for the Heater Shaker module"
+    "heaterShaker": "Set heat, shake, or labware latch commands for the Heater-Shaker module"
   },
 
   "disabled_module_step": "Add a relevant module to use this step",
@@ -46,7 +46,9 @@
       "dispense_touchTip_checkbox": "Touch tip to each side of well after dispensing",
       "mix_touchTip_checkbox": "Touch tip to each side of the well after mixing",
 
-      "volume": "Volume to dispense in each well"
+      "volume": "Volume to dispense in each well",
+
+      "heaterShakerSetTimer": "Once this counter has elapsed, the module will deactivate the heater and shaker"
     },
     "indeterminate": {
       "aspirate_airGap_checkbox": "Not all selected steps are using this setting",
@@ -82,6 +84,11 @@
     "pauseAction": {
       "disabled": {
         "wait_until_temp": "There is no temperature module on the deck"
+      }
+    },
+    "heaterShaker": {
+      "disabled": {
+        "latchOpen": "Labware Latch cannot be open while the module is shaking"
       }
     }
   },

--- a/protocol-designer/src/steplist/formLevel/getDisabledFields/getDisabledFieldsHeaterShaker.ts
+++ b/protocol-designer/src/steplist/formLevel/getDisabledFields/getDisabledFieldsHeaterShaker.ts
@@ -1,0 +1,10 @@
+import { FormData } from '../../../form-types'
+export function getDisabledFieldsHeaterShaker(rawForm: FormData): Set<string> {
+  const disabled: Set<string> = new Set()
+
+  if (rawForm.setShake === true) {
+    disabled.add('latchOpen')
+  }
+
+  return disabled
+}

--- a/protocol-designer/src/steplist/formLevel/getDisabledFields/index.ts
+++ b/protocol-designer/src/steplist/formLevel/getDisabledFields/index.ts
@@ -1,6 +1,7 @@
 import { defaultMemoize } from 'reselect'
 import { getDisabledFieldsMoveLiquidForm } from './getDisabledFieldsMoveLiquidForm'
 import { getDisabledFieldsMixForm } from './getDisabledFieldsMixForm'
+import { getDisabledFieldsHeaterShaker } from './getDisabledFieldsHeaterShaker'
 import { FormData } from '../../../form-types'
 
 function _getDisabledFields(rawForm: FormData): Set<string> {
@@ -10,6 +11,9 @@ function _getDisabledFields(rawForm: FormData): Set<string> {
 
     case 'mix':
       return getDisabledFieldsMixForm(rawForm)
+
+    case 'heaterShaker':
+      return getDisabledFieldsHeaterShaker(rawForm)
 
     case 'pause':
     case 'magnet':


### PR DESCRIPTION
closes #9733 and closes #9925

# Overview

This adds tooltips to H-S stepform and updates the `tooltip` component in shared components to reflect the new designs in UI overhaul. 

<img width="309" alt="Screen Shot 2022-04-12 at 2 02 46 PM" src="https://user-images.githubusercontent.com/66035149/163026755-1919caa9-984d-4cad-b684-dd2704833d5b.png">

<img width="168" alt="Screen Shot 2022-04-12 at 2 02 38 PM" src="https://user-images.githubusercontent.com/66035149/163026767-cc59ad65-437f-4d85-93f9-22944938b983.png">


# Changelog

- adds tooltips to `heaterShakerForm`
- changes designs of `tooltip`

# Review requests

- does it match designs? Do the tooltips appear when they are expected to?

# Risk assessment

low, behind ff