### PR TITLE
test(robot-server): Pass along server subprocess's logs to pytest

### DIFF
--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -141,8 +141,10 @@ def run_server(
             "OT_ROBOT_SERVER_DOT_ENV_PATH": "dev.env",
             "OT_API_CONFIG_DIR": server_temp_directory,
         },
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        # The server will log to its stdout or stderr.
+        # Let it inherit our stdout and stderr so PyTest captures its logs.
+        stdout=None,
+        stderr=None,
     ) as proc:
         # Wait for a bit to get started by polling /health
         from requests.exceptions import ConnectionError

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -143,7 +143,7 @@ def run_server(
         },
         stdin=subprocess.DEVNULL,
         # The server will log to its stdout or stderr.
-        # Let it inherit our stdout and stderr so PyTest captures its logs.
+        # Let it inherit our stdout and stderr so pytest captures its logs.
         stdout=None,
         stderr=None,
     ) as proc:

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -141,6 +141,7 @@ def run_server(
             "OT_ROBOT_SERVER_DOT_ENV_PATH": "dev.env",
             "OT_API_CONFIG_DIR": server_temp_directory,
         },
+        stdin=subprocess.DEVNULL,
         # The server will log to its stdout or stderr.
         # Let it inherit our stdout and stderr so PyTest captures its logs.
         stdout=None,

--- a/robot-server/tests/integration/dev_server.py
+++ b/robot-server/tests/integration/dev_server.py
@@ -54,12 +54,13 @@ class DevServer:
                 "OT_API_CONFIG_DIR": self.server_temp_directory,
                 "OT_ROBOT_SERVER_persistence_directory": self.persistence_directory,
             },
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            # The server will log to its stdout or stderr.
+            # Let it inherit our stdout and stderr so PyTest captures its logs.
+            stdout=None,
+            stderr=None,
         )
 
     def stop(self) -> None:
         """Stop the robot server."""
         self.proc.send_signal(signal.SIGTERM)
-        # This calls proc.wait() and does cleanup on stdin, stdout and stderr.
-        self.proc.__exit__(None, None, None)
+        self.proc.wait()

--- a/robot-server/tests/integration/dev_server.py
+++ b/robot-server/tests/integration/dev_server.py
@@ -54,6 +54,7 @@ class DevServer:
                 "OT_API_CONFIG_DIR": self.server_temp_directory,
                 "OT_ROBOT_SERVER_persistence_directory": self.persistence_directory,
             },
+            stdin=subprocess.DEVNULL,
             # The server will log to its stdout or stderr.
             # Let it inherit our stdout and stderr so PyTest captures its logs.
             stdout=None,

--- a/robot-server/tests/integration/dev_server.py
+++ b/robot-server/tests/integration/dev_server.py
@@ -56,7 +56,7 @@ class DevServer:
             },
             stdin=subprocess.DEVNULL,
             # The server will log to its stdout or stderr.
-            # Let it inherit our stdout and stderr so PyTest captures its logs.
+            # Let it inherit our stdout and stderr so pytest captures its logs.
             stdout=None,
             stderr=None,
         )


### PR DESCRIPTION
# Overview

Small improvements to integration test debuggability and reliability.

# Changelog

* When the integration tests spin up a robot-server subprocess...
    * Instead of having it output to an anonymous pipe, have it output to the test process's stdout and stderr.
    
       This accomplishes two things. First, for debuggability, it lets PyTest display the server logs when an integration test fails. Second, it resolves what I believe is [a deadlock hazard related to the output buffers filling up when nothing is reading from them on the other end](https://docs.python.org/3.7/library/subprocess.html#:~:text=This%20will%20deadlock%20when%20using%20stdout%3DPIPE%20or%20stderr%3DPIPE).
     * Instead of having it inherit the test process's stdin, give it an empty stdin. This is not strictly required because [pytest will already close stdin for the tests that it runs](https://docs.pytest.org/en/6.2.x/capture.html#default-stdout-stderr-stdin-capturing-behaviour), but I think the explicitness is good in case these fixtures ever get copy-pasted somewhere. Theoretically, it can deadlock hazards if the subprocess is poorly behaved.
* Replace `proc.__exit__(None, None, None)` with `proc.wait()`. I might have been missing something here, but I don't *think* `__exit__()` is doing anything that we want, at this point. In particular, note that there is no stdin/stdout/stderr cleanup for it to do.

# Review requests

To see this in action, try something like:

```shell
pipenv run pytest -rA tests/integration/http_api/persistence/test_protocol_persistence.py
```

`-rA` makes pytest show captured output even though the test is passing.


# Risk assessment

None. Changes are only to tests.