### PR TITLE
refactor(protocol-designer): fix load labware commands

### DIFF
--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -5,7 +5,11 @@ import mapValues from 'lodash/mapValues'
 import map from 'lodash/map'
 import reduce from 'lodash/reduce'
 import uniq from 'lodash/uniq'
-import { FIXED_TRASH_ID, OT2_STANDARD_DECKID, OT2_STANDARD_MODEL } from '@opentrons/shared-data'
+import {
+  FIXED_TRASH_ID,
+  OT2_STANDARD_DECKID,
+  OT2_STANDARD_MODEL,
+} from '@opentrons/shared-data'
 import { getFileMetadata } from './fileFields'
 import { getInitialRobotState, getRobotStateTimeline } from './commands'
 import { selectors as dismissSelectors } from '../../dismiss'
@@ -197,7 +201,10 @@ export const createFile: Selector<ProtocolFile> = createSelector(
       })
     )
 
-    const loadLabwareCommands = reduce<RobotState['labware'], LoadLabwareCreateCommand[]>(
+    const loadLabwareCommands = reduce<
+      RobotState['labware'],
+      LoadLabwareCreateCommand[]
+    >(
       initialRobotState.labware,
       (
         acc,
@@ -211,11 +218,14 @@ export const createFile: Selector<ProtocolFile> = createSelector(
           commandType: 'loadLabware' as const,
           params: {
             labwareId: labwareId,
-            location: isLabwareOnTopOfModule ? { moduleId: labware.slot } : { slotName: labware.slot },
+            location: isLabwareOnTopOfModule
+              ? { moduleId: labware.slot }
+              : { slotName: labware.slot },
           },
         }
         return [...acc, loadLabwareCommand]
-      }, []
+      },
+      []
     )
 
     const loadLiquidCommands = getLoadLiquidCommands(

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -264,8 +264,8 @@ export const createFile: Selector<ProtocolFile> = createSelector(
     )
     const loadCommands: CreateCommand[] = [
       ...loadPipetteCommands,
-      ...loadLabwareCommands,
       ...loadModuleCommands,
+      ...loadLabwareCommands,
       ...loadLiquidCommands,
     ]
 


### PR DESCRIPTION
# Overview

When labware is on top of a module, load labware commands were assigning the `location` parameter to the slot name, rather than the module id. load labware commands were also being generated for the trash. This PR addresses both of these issues.



# Review requests

Import a PD protocol with modules, export, and you should see that `loadLabware` commands for labware on top of modules have a `location` parameter of `{ moduleId: MODULE_ID }`
# Risk assessment

Low
