### PR TITLE
feat(app): wire up firmware update banner in Module Cards

### DIFF
--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -46,7 +46,7 @@
   "serial_number": "Serial Number",
   "link_firmware_update": "View Firmware Update",
   "firmware_update_available": "Firmware update available.",
-  "view_update": "View Update",
+  "update_now": "Update now",
   "heater": "Heater",
   "shaker": "Shaker",
   "target_speed": "Target: {{speed}} RPM",
@@ -74,5 +74,10 @@
   "detach_pipette": "Detach pipette",
   "view_pipette_setting": "View pipette settings",
   "left": "left",
-  "right": "right"
+  "right": "right",
+  "firmware_update_failed": "Failed to update module firmware",
+  "an_error_occurred_while_updating": "An error occurred while attempting to update your robot.",
+  "bundle_firmware_file_not_found": "Bundled fw file not found for module of type: {{module}}",
+  "firmware_update_installation_successful": "Installation successful",
+  "updating_firmware": "Updating firmware..."
 }

--- a/app/src/organisms/Devices/ModuleCard/AboutModuleSlideout.tsx
+++ b/app/src/organisms/Devices/ModuleCard/AboutModuleSlideout.tsx
@@ -70,7 +70,7 @@ export const AboutModuleSlideout = (
               textDecoration={TEXT_DECORATION_UNDERLINE}
               onClick={handleFirmwareUpdateClick}
             >
-              {t('view_update')}
+              {t('update_now')}
             </Btn>
           </Banner>
         </Flex>

--- a/app/src/organisms/Devices/ModuleCard/AboutModuleSlideout.tsx
+++ b/app/src/organisms/Devices/ModuleCard/AboutModuleSlideout.tsx
@@ -1,16 +1,12 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { useDispatch, useSelector } from 'react-redux'
 import { css } from 'styled-components'
 import { RUN_STATUS_RUNNING, RUN_STATUS_FINISHING } from '@opentrons/api-client'
 import {
   Flex,
   DIRECTION_COLUMN,
-  TEXT_TRANSFORM_UPPERCASE,
   TYPOGRAPHY,
   SPACING,
-  COLORS,
-  ALIGN_CENTER,
   JUSTIFY_SPACE_BETWEEN,
   TEXT_DECORATION_UNDERLINE,
   Btn,
@@ -18,20 +14,17 @@ import {
 } from '@opentrons/components'
 import { getModuleDisplayName } from '@opentrons/shared-data'
 import { StyledText } from '../../../atoms/text'
-import { SecondaryButton } from '../../../atoms/Buttons'
 import { Slideout } from '../../../atoms/Slideout'
 import { Banner } from '../../../atoms/Banner'
-import { updateModule } from '../../../redux/modules'
-import { getConnectedRobotName } from '../../../redux/robot/selectors'
 import { useCurrentRunStatus } from '../../RunTimeControl/hooks'
 
-import type { State, Dispatch } from '../../../redux/types'
 import type { AttachedModule } from '../../../redux/modules/types'
 
 interface AboutModuleSlideoutProps {
   module: AttachedModule
   onCloseClick: () => unknown
   isExpanded: boolean
+  firmwareUpdateClick: () => unknown
 }
 
 const ALERT_ITEM_STYLE = css`
@@ -42,18 +35,17 @@ const ALERT_ITEM_STYLE = css`
 export const AboutModuleSlideout = (
   props: AboutModuleSlideoutProps
 ): JSX.Element | null => {
-  const { module, isExpanded, onCloseClick } = props
+  const { module, isExpanded, onCloseClick, firmwareUpdateClick } = props
   const { t } = useTranslation('device_details')
   const moduleName = getModuleDisplayName(module.model)
-  const robotName = useSelector((state: State) => getConnectedRobotName(state))
   const runStatus = useCurrentRunStatus()
-  const dispatch = useDispatch<Dispatch>()
   const [showBanner, setShowBanner] = React.useState<boolean>(true)
   const isDisabled =
     runStatus === RUN_STATUS_RUNNING || runStatus === RUN_STATUS_FINISHING
 
-  const handleClick = (): void => {
-    robotName && dispatch(updateModule(robotName, module.serial))
+  const handleFirmwareUpdateClick = (): void => {
+    firmwareUpdateClick()
+    onCloseClick()
   }
 
   return (
@@ -62,7 +54,7 @@ export const AboutModuleSlideout = (
       onCloseClick={onCloseClick}
       isExpanded={isExpanded}
     >
-      {module.hasAvailableUpdate && showBanner ? (
+      {module.hasAvailableUpdate && !isDisabled && showBanner ? (
         <Flex paddingBottom={SPACING.spacing4}>
           <Banner
             data-testid={`alert_item_firmware_update_${module.model}`}
@@ -76,8 +68,7 @@ export const AboutModuleSlideout = (
               paddingLeft={SPACING.spacing2}
               fontSize={TYPOGRAPHY.fontSizeP}
               textDecoration={TEXT_DECORATION_UNDERLINE}
-              //  TODO(jr, 3/21/22): wire up the link
-              onClick={() => console.log('firmware update!')}
+              onClick={handleFirmwareUpdateClick}
             >
               {t('view_update')}
             </Btn>
@@ -95,18 +86,6 @@ export const AboutModuleSlideout = (
               {t('version', { version: module.fwVersion })}
             </StyledText>
           </Flex>
-          {module.hasAvailableUpdate && showBanner ? (
-            <SecondaryButton
-              data-testid={`firmware_update_btn_${module.model}`}
-              textTransform={TEXT_TRANSFORM_UPPERCASE}
-              alignItems={ALIGN_CENTER}
-              onClick={handleClick}
-              disabled={isDisabled}
-              color={COLORS.blue}
-            >
-              {t('link_firmware_update')}
-            </SecondaryButton>
-          ) : null}
         </Flex>
         <StyledText
           paddingTop={SPACING.spacing4}

--- a/app/src/organisms/Devices/ModuleCard/FirmwareUpdateFailedModal.tsx
+++ b/app/src/organisms/Devices/ModuleCard/FirmwareUpdateFailedModal.tsx
@@ -50,9 +50,6 @@ export const FirmwareUpdateFailedModal = (
         <Text paddingBottom={SPACING.spacing2}>
           {t('an_error_occurred_while_updating')}
         </Text>
-        <Text paddingBottom={SPACING.spacing2}>
-          {t('bundle_firmware_file_not_found', { module: module.type })}
-        </Text>
         <Text>{errorMessage}</Text>
       </Flex>
       <Flex

--- a/app/src/organisms/Devices/ModuleCard/FirmwareUpdateFailedModal.tsx
+++ b/app/src/organisms/Devices/ModuleCard/FirmwareUpdateFailedModal.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  DIRECTION_ROW,
+  Flex,
+  JUSTIFY_FLEX_END,
+  Text,
+  SPACING,
+  TYPOGRAPHY,
+  DIRECTION_COLUMN,
+  Icon,
+  COLORS,
+  TEXT_TRANSFORM_CAPITALIZE,
+} from '@opentrons/components'
+import { PrimaryButton } from '../../../atoms/Buttons'
+import { Modal } from '../../../atoms/Modal'
+
+import type { AttachedModule } from '../../../redux/modules/types'
+
+interface FirmwareUpdateFailedModalProps {
+  onCloseClick: () => void
+  module: AttachedModule
+  errorMessage?: string
+}
+export const FirmwareUpdateFailedModal = (
+  props: FirmwareUpdateFailedModalProps
+): JSX.Element => {
+  const { onCloseClick, module, errorMessage } = props
+  const { t } = useTranslation(['device_details', 'shared'])
+
+  const title = (
+    <Flex flexDirection={DIRECTION_ROW}>
+      <Icon
+        width={SPACING.spacingM}
+        color={COLORS.error}
+        name="information"
+        aria-label="information"
+      />
+      <Text marginLeft={SPACING.spacing3}>{t('firmware_update_failed')}</Text>
+    </Flex>
+  )
+
+  return (
+    <Modal title={title} onClose={onCloseClick}>
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        fontSize={TYPOGRAPHY.fontSizeP}
+        data-testid={`FirmwareUpdateFailedModal_body_text_${module.serial}`}
+      >
+        <Text paddingBottom={SPACING.spacing2}>
+          {t('an_error_occurred_while_updating')}
+        </Text>
+        <Text paddingBottom={SPACING.spacing2}>
+          {t('bundle_firmware_file_not_found', { module: module.type })}
+        </Text>
+        <Text>{errorMessage}</Text>
+      </Flex>
+      <Flex
+        flexDirection={DIRECTION_ROW}
+        paddingTop={SPACING.spacingXL}
+        justifyContent={JUSTIFY_FLEX_END}
+        data-testid={`FirmwareUpdateFailedModal_cancel_btn_${module.serial}`}
+      >
+        <Flex textTransform={TEXT_TRANSFORM_CAPITALIZE}>
+          <PrimaryButton onClick={onCloseClick}>
+            {t('shared:close')}
+          </PrimaryButton>
+        </Flex>
+      </Flex>
+    </Modal>
+  )
+}

--- a/app/src/organisms/Devices/ModuleCard/FirmwareUpdateFailedModal.tsx
+++ b/app/src/organisms/Devices/ModuleCard/FirmwareUpdateFailedModal.tsx
@@ -6,13 +6,13 @@ import {
   JUSTIFY_FLEX_END,
   Text,
   SPACING,
-  TYPOGRAPHY,
   DIRECTION_COLUMN,
   Icon,
   COLORS,
   TEXT_TRANSFORM_CAPITALIZE,
 } from '@opentrons/components'
 import { PrimaryButton } from '../../../atoms/Buttons'
+import { StyledText } from '../../../atoms/text'
 import { Modal } from '../../../atoms/Modal'
 
 import type { AttachedModule } from '../../../redux/modules/types'
@@ -36,7 +36,9 @@ export const FirmwareUpdateFailedModal = (
         name="information"
         aria-label="information"
       />
-      <Text marginLeft={SPACING.spacing3}>{t('firmware_update_failed')}</Text>
+      <StyledText marginLeft={SPACING.spacing3}>
+        {t('firmware_update_failed')}
+      </StyledText>
     </Flex>
   )
 
@@ -44,7 +46,6 @@ export const FirmwareUpdateFailedModal = (
     <Modal title={title} onClose={onCloseClick}>
       <Flex
         flexDirection={DIRECTION_COLUMN}
-        fontSize={TYPOGRAPHY.fontSizeP}
         data-testid={`FirmwareUpdateFailedModal_body_text_${module.serial}`}
       >
         <Text paddingBottom={SPACING.spacing2}>
@@ -58,11 +59,12 @@ export const FirmwareUpdateFailedModal = (
         justifyContent={JUSTIFY_FLEX_END}
         data-testid={`FirmwareUpdateFailedModal_cancel_btn_${module.serial}`}
       >
-        <Flex textTransform={TEXT_TRANSFORM_CAPITALIZE}>
-          <PrimaryButton onClick={onCloseClick}>
-            {t('shared:close')}
-          </PrimaryButton>
-        </Flex>
+        <PrimaryButton
+          onClick={onCloseClick}
+          textTransform={TEXT_TRANSFORM_CAPITALIZE}
+        >
+          {t('shared:close')}
+        </PrimaryButton>
       </Flex>
     </Modal>
   )

--- a/app/src/organisms/Devices/ModuleCard/__tests__/AboutModuleSlideout.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/AboutModuleSlideout.test.tsx
@@ -41,6 +41,7 @@ describe('AboutModuleSlideout', () => {
       module: mockMagneticModule,
       isExpanded: true,
       onCloseClick: jest.fn(),
+      firmwareUpdateClick: jest.fn(),
     }
     mockGetConnectedRobotName.mockReturnValue('Mock Robot Name')
     mockUseCurrentRunStatus.mockReturnValue(RUN_STATUS_IDLE)
@@ -62,18 +63,26 @@ describe('AboutModuleSlideout', () => {
     expect(props.onCloseClick).toHaveBeenCalled()
   })
 
-  it('renders firmware button disabled when run is running', () => {
+  it('renders no banner when run is running', () => {
     mockUseCurrentRunStatus.mockReturnValue(RUN_STATUS_RUNNING)
-    const { getByRole } = render(props)
-    const button = getByRole('button', { name: 'View Firmware Update' })
-    expect(button).toBeDisabled()
+    const { getByText } = render(props)
+
+    getByText('About Magnetic Module GEN1')
+    getByText('def456')
+    getByText('Serial Number')
+    getByText('Current Version')
+    getByText('Version v2.0.0')
   })
 
-  it('renders firmware button disabled when run is finishing', () => {
+  it('renders no banner when run is finishing', () => {
     mockUseCurrentRunStatus.mockReturnValue(RUN_STATUS_FINISHING)
-    const { getByRole } = render(props)
-    const button = getByRole('button', { name: 'View Firmware Update' })
-    expect(button).toBeDisabled()
+    const { getByText } = render(props)
+
+    getByText('About Magnetic Module GEN1')
+    getByText('def456')
+    getByText('Serial Number')
+    getByText('Current Version')
+    getByText('Version v2.0.0')
   })
 
   it('renders correct info when module is a magnetic module GEN2', () => {
@@ -81,6 +90,7 @@ describe('AboutModuleSlideout', () => {
       module: mockMagneticModuleGen2,
       isExpanded: true,
       onCloseClick: jest.fn(),
+      firmwareUpdateClick: jest.fn(),
     }
     const { getByText } = render(props)
 
@@ -96,6 +106,7 @@ describe('AboutModuleSlideout', () => {
       module: mockTemperatureModuleGen2,
       isExpanded: true,
       onCloseClick: jest.fn(),
+      firmwareUpdateClick: jest.fn(),
     }
     const { getByText } = render(props)
 
@@ -111,6 +122,7 @@ describe('AboutModuleSlideout', () => {
       module: mockTemperatureModule,
       isExpanded: true,
       onCloseClick: jest.fn(),
+      firmwareUpdateClick: jest.fn(),
     }
     const { getByText } = render(props)
 
@@ -126,6 +138,7 @@ describe('AboutModuleSlideout', () => {
       module: mockThermocycler,
       isExpanded: true,
       onCloseClick: jest.fn(),
+      firmwareUpdateClick: jest.fn(),
     }
     const { getByText, getByRole, getByLabelText } = render(props)
 
@@ -135,15 +148,13 @@ describe('AboutModuleSlideout', () => {
     getByText('Current Version')
     getByText('Version v2.0.0')
     getByText('Firmware update available.')
-    const button = getByRole('button', { name: 'View Firmware Update' })
-    fireEvent.click(button)
-    expect(button).toBeEnabled()
     const viewUpdate = getByRole('button', { name: 'Update now' })
     fireEvent.click(viewUpdate)
+    expect(props.firmwareUpdateClick).toHaveBeenCalled()
+    expect(props.onCloseClick).toHaveBeenCalled()
     expect(viewUpdate).toBeEnabled()
     const exit = getByLabelText('close_icon')
     fireEvent.click(exit)
     expect(exit).not.toBeVisible()
-    //  TODO(jr, 2/23/22): expect button to open a modal when this is properly wired up
   })
 })

--- a/app/src/organisms/Devices/ModuleCard/__tests__/AboutModuleSlideout.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/AboutModuleSlideout.test.tsx
@@ -138,7 +138,7 @@ describe('AboutModuleSlideout', () => {
     const button = getByRole('button', { name: 'View Firmware Update' })
     fireEvent.click(button)
     expect(button).toBeEnabled()
-    const viewUpdate = getByRole('button', { name: 'View Update' })
+    const viewUpdate = getByRole('button', { name: 'Update now' })
     fireEvent.click(viewUpdate)
     expect(viewUpdate).toBeEnabled()
     const exit = getByLabelText('close_icon')

--- a/app/src/organisms/Devices/ModuleCard/__tests__/FirmwareUpdateFailedModal.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/FirmwareUpdateFailedModal.test.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react'
+import { fireEvent } from '@testing-library/react'
+import { renderWithProviders } from '@opentrons/components'
+import { i18n } from '../../../../i18n'
+import { FirmwareUpdateFailedModal } from '../FirmwareUpdateFailedModal'
+import { mockTemperatureModule } from '../../../../redux/modules/__fixtures__'
+
+const render = (
+  props: React.ComponentProps<typeof FirmwareUpdateFailedModal>
+) => {
+  return renderWithProviders(<FirmwareUpdateFailedModal {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+describe('FirmwareUpdateFailedModal', () => {
+  let props: React.ComponentProps<typeof FirmwareUpdateFailedModal>
+  beforeEach(() => {
+    props = {
+      onCloseClick: jest.fn(),
+      module: mockTemperatureModule,
+      errorMessage: 'error message',
+    }
+  })
+
+  it('should render the correct header and body', () => {
+    const { getByText } = render(props)
+    getByText('Failed to update module firmware')
+    getByText('error message')
+    getByText(
+      'Bundled fw file not found for module of type: temperatureModuleType'
+    )
+  })
+  it('should call onCloseClick when the close button is pressed', () => {
+    const { getByRole, getByLabelText } = render(props)
+    expect(props.onCloseClick).not.toHaveBeenCalled()
+    const closeButton = getByRole('button', { name: 'close' })
+    fireEvent.click(closeButton)
+    expect(props.onCloseClick).toHaveBeenCalled()
+    const closeIcon = getByLabelText('information')
+    fireEvent.click(closeIcon)
+    expect(props.onCloseClick).toHaveBeenCalled()
+  })
+})

--- a/app/src/organisms/Devices/ModuleCard/__tests__/FirmwareUpdateFailedModal.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/FirmwareUpdateFailedModal.test.tsx
@@ -27,9 +27,6 @@ describe('FirmwareUpdateFailedModal', () => {
     const { getByText } = render(props)
     getByText('Failed to update module firmware')
     getByText('error message')
-    getByText(
-      'Bundled fw file not found for module of type: temperatureModuleType'
-    )
   })
   it('should call onCloseClick when the close button is pressed', () => {
     const { getByRole, getByLabelText } = render(props)

--- a/app/src/organisms/Devices/ModuleCard/__tests__/ModuleCard.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/ModuleCard.test.tsx
@@ -139,15 +139,7 @@ describe('ModuleCard', () => {
       <div>mock firmware update failed modal</div>
     )
     mockToast.mockReturnValue(<div>mock toast</div>)
-    mockGetRequestById.mockReturnValue({
-      status: RobotApi.SUCCESS,
-      response: {
-        method: 'POST',
-        ok: true,
-        path: '/',
-        status: 200,
-      },
-    })
+    mockGetRequestById.mockReturnValue(null)
     when(mockUseCurrentRunStatus)
       .calledWith(expect.any(Object))
       .mockReturnValue(RUN_STATUS_IDLE)
@@ -255,6 +247,22 @@ describe('ModuleCard', () => {
       robotName: mockRobot.name,
     })
     getByText(nestedTextMatcher('Module is hot to the touch'))
+  })
+  it('renders information success toast when update has completed', () => {
+    mockGetRequestById.mockReturnValue({
+      status: RobotApi.SUCCESS,
+      response: {
+        method: 'POST',
+        ok: true,
+        path: '/',
+        status: 200,
+      },
+    })
+    const { getByText } = render({
+      module: mockHotHeaterShaker,
+      robotName: mockRobot.name,
+    })
+    getByText('mock toast')
   })
   it('renders information for a magnetic module when an update is available so update banner renders', () => {
     const { getByText } = render({

--- a/app/src/organisms/Devices/ModuleCard/__tests__/ModuleCard.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/ModuleCard.test.tsx
@@ -256,7 +256,7 @@ describe('ModuleCard', () => {
     })
     getByText(nestedTextMatcher('Module is hot to the touch'))
   })
-  it('renders information for a magnetic module when an update is available so update banner renders then toast renders when successful', async () => {
+  it('renders information for a magnetic module when an update is available so update banner renders', () => {
     const { getByText } = render({
       module: mockMagneticModuleHub,
       robotName: mockRobot.name,
@@ -265,8 +265,6 @@ describe('ModuleCard', () => {
     const button = getByText('Update now')
     fireEvent.click(button)
     expect(mockGetRequestById).toHaveBeenCalled()
-    await new Promise(resolve => setTimeout(resolve, 5000))
-    expect(getByText('mock toast')).toBeVisible()
   })
   it('renders information for update available and it fails rendering the fail modal', () => {
     mockGetRequestById.mockReturnValue({

--- a/app/src/organisms/Devices/ModuleCard/__tests__/ModuleCard.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/ModuleCard.test.tsx
@@ -22,6 +22,7 @@ import type {
   HeaterShakerModule,
   MagneticModule,
 } from '../../../../redux/modules/types'
+import { mockRobot } from '../../../../redux/robot-api/__fixtures__'
 
 jest.mock('../MagneticModuleData')
 jest.mock('../TemperatureModuleData')
@@ -126,6 +127,7 @@ describe('ModuleCard', () => {
   it('renders information for a magnetic module with mocked status', () => {
     const { getByText, getByAltText } = render({
       module: mockMagneticModule,
+      robotName: mockRobot.name,
     })
 
     getByText('Magnetic Module GEN1')
@@ -136,6 +138,7 @@ describe('ModuleCard', () => {
   it('renders information if module is connected via hub', () => {
     const { getByText, getByAltText } = render({
       module: mockMagneticModuleHub,
+      robotName: mockRobot.name,
     })
     getByText('Magnetic Module GEN1')
     getByText('Mock Magnetic Module Data')
@@ -149,6 +152,7 @@ describe('ModuleCard', () => {
 
     const { getByText, getByAltText } = render({
       module: mockTemperatureModuleGen2,
+      robotName: mockRobot.name,
     })
     getByText('Temperature Module GEN2')
     getByText('Mock Temperature Module Data')
@@ -159,6 +163,7 @@ describe('ModuleCard', () => {
   it('renders information for a thermocycler module with mocked status', () => {
     const { getByText, getByAltText } = render({
       module: mockThermocycler,
+      robotName: mockRobot.name,
     })
 
     getByText('Thermocycler Module')
@@ -170,6 +175,7 @@ describe('ModuleCard', () => {
   it('renders information for a heater shaker module with mocked status', () => {
     const { getByText, getByAltText } = render({
       module: mockHeaterShaker,
+      robotName: mockRobot.name,
     })
 
     getByText('Heater Shaker Module GEN1')
@@ -181,6 +187,7 @@ describe('ModuleCard', () => {
   it('renders kebab icon and is clickable', () => {
     const { getByRole, getByText } = render({
       module: mockMagneticModule,
+      robotName: mockRobot.name,
     })
     const overflowButton = getByRole('button', {
       name: /overflow/i,
@@ -198,6 +205,7 @@ describe('ModuleCard', () => {
 
     const { getByRole, getByText } = render({
       module: mockMagneticModule,
+      robotName: mockRobot.name,
     })
     const overflowButton = getByRole('button', {
       name: /overflow/i,
@@ -209,12 +217,14 @@ describe('ModuleCard', () => {
   it('renders information for a heater shaker module when it is hot, showing the too hot banner', () => {
     const { getByText } = render({
       module: mockHotHeaterShaker,
+      robotName: mockRobot.name,
     })
     getByText(nestedTextMatcher('Module is hot to the touch'))
   })
   it('renders information for a magnetic module when an update is available so update banner renders', () => {
     const { getByText } = render({
       module: mockMagneticModuleHub,
+      robotName: mockRobot.name,
     })
     getByText('Firmware update available.')
     getByText('View Update')

--- a/app/src/organisms/Devices/ModuleCard/__tests__/ModuleCard.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/ModuleCard.test.tsx
@@ -15,6 +15,7 @@ import { TemperatureModuleData } from '../TemperatureModuleData'
 import { ThermocyclerModuleData } from '../ThermocyclerModuleData'
 import { HeaterShakerModuleData } from '../HeaterShakerModuleData'
 import { ModuleOverflowMenu } from '../ModuleOverflowMenu'
+import { FirmwareUpdateFailedModal } from '../FirmwareUpdateFailedModal'
 import { ModuleCard } from '..'
 import {
   mockMagneticModule,
@@ -35,6 +36,7 @@ jest.mock('../ThermocyclerModuleData')
 jest.mock('../HeaterShakerModuleData')
 jest.mock('../ModuleOverflowMenu')
 jest.mock('../../../RunTimeControl/hooks')
+jest.mock('../FirmwareUpdateFailedModal')
 jest.mock('../../../../redux/robot-api')
 jest.mock('react-router-dom', () => {
   const reactRouterDom = jest.requireActual('react-router-dom')
@@ -67,6 +69,9 @@ const mockUseDispatchApiRequest = useDispatchApiRequest as jest.MockedFunction<
 >
 const mockGetRequestById = RobotApi.getRequestById as jest.MockedFunction<
   typeof RobotApi.getRequestById
+>
+const mockFirmwareUpdateFailedModal = FirmwareUpdateFailedModal as jest.MockedFunction<
+  typeof FirmwareUpdateFailedModal
 >
 const mockMagneticModuleHub = {
   model: 'magneticModuleV1',
@@ -127,6 +132,9 @@ describe('ModuleCard', () => {
       <div>Mock Heater Shaker Module Data</div>
     )
     mockModuleOverflowMenu.mockReturnValue(<div>mock module overflow menu</div>)
+    mockFirmwareUpdateFailedModal.mockReturnValue(
+      <div>mock firmware update failed modal</div>
+    )
     mockGetRequestById.mockReturnValue({
       status: RobotApi.SUCCESS,
       response: {

--- a/app/src/organisms/Devices/ModuleCard/index.tsx
+++ b/app/src/organisms/Devices/ModuleCard/index.tsx
@@ -90,6 +90,9 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
   const [showTestShake, setShowTestShake] = React.useState(false)
   const [showBanner, setShowBanner] = React.useState<boolean>(true)
   const [showWizard, setShowWizard] = React.useState<boolean>(false)
+  const [currentFwVersion, setFwVersion] = React.useState<number>(
+    parseInt(module.fwVersion)
+  )
   const [targetProps, tooltipProps] = useHoverTooltip()
   const history = useHistory()
   const [dispatchApiRequest, requestIds] = useDispatchApiRequest()
@@ -100,7 +103,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
       }
     },
   })
-
+  const oldFwVersion = currentFwVersion
   const latestRequestId = last(requestIds)
   const latestRequest = useSelector<State, RequestState | null>(state =>
     latestRequestId ? getRequestById(state, latestRequestId) : null
@@ -112,9 +115,12 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
   }
   const handleUpdateClick = (): void => {
     robotName && dispatchApiRequest(updateModule(robotName, module.serial))
-    setTimeout(() => {
-      latestRequest?.status === SUCCESS && setShowSuccessToast(true)
-    }, 5000)
+    if (latestRequest?.status === SUCCESS) {
+      setFwVersion(parseInt(module.fwVersion))
+      if (currentFwVersion > oldFwVersion) {
+        setShowSuccessToast(true)
+      }
+    }
   }
   const isPending = latestRequest?.status === PENDING
   const hotToTouch: IconProps = { name: 'ot-hot-to-touch' }

--- a/app/src/organisms/Devices/ModuleCard/index.tsx
+++ b/app/src/organisms/Devices/ModuleCard/index.tsx
@@ -113,7 +113,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
   const handleUpdateClick = (): void => {
     robotName && dispatchApiRequest(updateModule(robotName, module.serial))
     setTimeout(() => {
-      latestRequest?.status === SUCCESS ? setShowSuccessToast(true) : null
+      latestRequest?.status === SUCCESS && setShowSuccessToast(true)
     }, 5000)
   }
   const isPending = latestRequest?.status === PENDING

--- a/app/src/organisms/Devices/ModuleCard/index.tsx
+++ b/app/src/organisms/Devices/ModuleCard/index.tsx
@@ -304,7 +304,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
                         textDecoration={TEXT_DECORATION_UNDERLINE}
                         onClick={() => handleUpdateClick()}
                       >
-                        {t('view_update')}
+                        {t('update_now')}
                       </Btn>
                     </Flex>
                   </Banner>

--- a/app/src/organisms/Devices/ModuleCard/index.tsx
+++ b/app/src/organisms/Devices/ModuleCard/index.tsx
@@ -90,9 +90,6 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
   const [showTestShake, setShowTestShake] = React.useState(false)
   const [showBanner, setShowBanner] = React.useState<boolean>(true)
   const [showWizard, setShowWizard] = React.useState<boolean>(false)
-  const [currentFwVersion, setFwVersion] = React.useState<number>(
-    parseInt(module.fwVersion)
-  )
   const [targetProps, tooltipProps] = useHoverTooltip()
   const history = useHistory()
   const [dispatchApiRequest, requestIds] = useDispatchApiRequest()
@@ -103,7 +100,6 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
       }
     },
   })
-  const oldFwVersion = currentFwVersion
   const latestRequestId = last(requestIds)
   const latestRequest = useSelector<State, RequestState | null>(state =>
     latestRequestId ? getRequestById(state, latestRequestId) : null
@@ -115,13 +111,16 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
   }
   const handleUpdateClick = (): void => {
     robotName && dispatchApiRequest(updateModule(robotName, module.serial))
-    if (latestRequest?.status === SUCCESS) {
-      setFwVersion(parseInt(module.fwVersion))
-      if (currentFwVersion > oldFwVersion) {
-        setShowSuccessToast(true)
-      }
-    }
   }
+  React.useEffect(() => {
+    if (
+      module.hasAvailableUpdate === false &&
+      latestRequest?.status === SUCCESS
+    ) {
+      setShowSuccessToast(true)
+    }
+  }, [module.hasAvailableUpdate, latestRequest?.status])
+
   const isPending = latestRequest?.status === PENDING
   const hotToTouch: IconProps = { name: 'ot-hot-to-touch' }
 

--- a/app/src/organisms/Devices/ModuleCard/index.tsx
+++ b/app/src/organisms/Devices/ModuleCard/index.tsx
@@ -99,6 +99,12 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
       }
     },
   })
+  const handleUpdateClick = (): void => {
+    robotName && dispatchApiRequest(updateModule(robotName, module.serial))
+    setTimeout(() => {
+      setShowSuccessToast(true)
+    }, 10000)
+  }
   const latestRequestId = last(requestIds)
   const latestRequest = useSelector<State, RequestState | null>(state =>
     latestRequestId ? getRequestById(state, latestRequestId) : null
@@ -211,13 +217,6 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
     setShowSlideout(false)
   }
 
-  const handleUpdateClick = (): void => {
-    robotName && dispatchApiRequest(updateModule(robotName, module.serial))
-    setTimeout(() => {
-      setShowSuccessToast(true)
-    }, 10000)
-  }
-
   return (
     <React.Fragment>
       <Flex
@@ -245,6 +244,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
             module={module}
             isExpanded={showAboutModule}
             onCloseClick={() => setShowAboutModule(false)}
+            firmwareUpdateClick={handleUpdateClick}
           />
         )}
         {showTestShake && (
@@ -278,14 +278,15 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
                 latestRequest.status === FAILURE && (
                   <FirmwareUpdateFailedModal
                     module={module}
-                    onCloseClick={() => handleCloseErrorModal()}
+                    onCloseClick={handleCloseErrorModal}
                     errorMessage={getErrorResponseMessage(latestRequest.error)}
                   />
                 )}
               {module.hasAvailableUpdate && showBanner && !isPending ? (
                 <Flex
                   paddingBottom={SPACING.spacing2}
-                  width="12.4rem"
+                  width="100%"
+                  flexDirection={DIRECTION_COLUMN}
                   data-testid={`ModuleCard_firmware_update_banner_${module.serial}`}
                 >
                   <Banner
@@ -308,7 +309,8 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
               ) : null}
               {isTooHot ? (
                 <Flex
-                  width="12.4rem"
+                  width="100%"
+                  flexDirection={DIRECTION_COLUMN}
                   paddingRight={SPACING.spacingM}
                   paddingBottom={SPACING.spacing3}
                   data-testid={`ModuleCard_too_hot_banner_${module.serial}`}
@@ -331,7 +333,12 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
                   fontSize={TYPOGRAPHY.fontSizeP}
                   data-testid={`ModuleCard_update_pending_${module.serial}`}
                 >
-                  <Icon width={SPACING.spacingSM} name="ot-spinner" spin />
+                  <Icon
+                    width={SPACING.spacingSM}
+                    name="ot-spinner"
+                    spin
+                    aria-label="ot-spinner"
+                  />
                   <Text marginLeft={SPACING.spacing3}>
                     {t('updating_firmware')}
                   </Text>

--- a/app/src/organisms/Devices/ModuleCard/index.tsx
+++ b/app/src/organisms/Devices/ModuleCard/index.tsx
@@ -262,10 +262,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
             onCloseClick={() => setShowTestShake(false)}
           />
         )}
-        <Box
-          padding={`${SPACING.spacing4} ${SPACING.spacing3} ${SPACING.spacing4} ${SPACING.spacing3}`}
-          width="100%"
-        >
+        <Box padding={`${SPACING.spacing4} ${SPACING.spacing3}`} width="100%">
           <Flex flexDirection={DIRECTION_ROW} paddingRight={SPACING.spacing3}>
             <Flex alignItems={ALIGN_START} opacity={isPending ? '50%' : '100%'}>
               <img width="60px" height="54px" src={image} alt={module.model} />

--- a/app/src/organisms/Devices/ModuleCard/index.tsx
+++ b/app/src/organisms/Devices/ModuleCard/index.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
+import { useDispatch, useSelector } from 'react-redux'
+import { last } from 'lodash'
 import {
   Box,
   Flex,
@@ -19,6 +21,7 @@ import {
   Tooltip,
   useHoverTooltip,
   COLORS,
+  Icon,
   ModuleIcon,
 } from '@opentrons/components'
 import {
@@ -31,7 +34,17 @@ import {
 import { RUN_STATUS_FINISHING, RUN_STATUS_RUNNING } from '@opentrons/api-client'
 import { useHistory } from 'react-router-dom'
 import { OverflowBtn } from '../../../atoms/MenuList/OverflowBtn'
+import { updateModule } from '../../../redux/modules'
+import {
+  useDispatchApiRequest,
+  getRequestById,
+  PENDING,
+  FAILURE,
+  getErrorResponseMessage,
+  dismissRequest,
+} from '../../../redux/robot-api'
 import { Banner } from '../../../atoms/Banner'
+import { Toast } from '../../../atoms/Toast'
 import { useCurrentRunStatus } from '../../RunTimeControl/hooks'
 import { HeaterShakerWizard } from '../HeaterShakerWizard'
 import { MagneticModuleData } from './MagneticModuleData'
@@ -45,6 +58,7 @@ import { AboutModuleSlideout } from './AboutModuleSlideout'
 import { HeaterShakerModuleData } from './HeaterShakerModuleData'
 import { HeaterShakerSlideout } from './HeaterShakerSlideout'
 import { TestShakeSlideout } from './TestShakeSlideout'
+import { FirmwareUpdateFailedModal } from './FirmwareUpdateFailedModal'
 
 import magneticModule from '../../../assets/images/magnetic_module_gen_2_transparent.svg'
 import temperatureModule from '../../../assets/images/temp_deck_gen_2_transparent.svg'
@@ -55,23 +69,29 @@ import type {
   AttachedModule,
   HeaterShakerModule,
 } from '../../../redux/modules/types'
+import type { State, Dispatch } from '../../../redux/types'
+import type { RequestState } from '../../../redux/robot-api/types'
 
 interface ModuleCardProps {
   module: AttachedModule
+  robotName: string
 }
 
 export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
   const { t } = useTranslation('device_details')
-  const { module } = props
+  const { module, robotName } = props
+  const dispatch = useDispatch<Dispatch>()
   const [showOverflowMenu, setShowOverflowMenu] = React.useState(false)
   const [showSlideout, setShowSlideout] = React.useState(false)
   const [hasSecondary, setHasSecondary] = React.useState(false)
+  const [showSuccessToast, setShowSuccessToast] = React.useState(false)
   const [showAboutModule, setShowAboutModule] = React.useState(false)
   const [showTestShake, setShowTestShake] = React.useState(false)
   const [showBanner, setShowBanner] = React.useState<boolean>(true)
   const [showWizard, setShowWizard] = React.useState<boolean>(false)
   const [targetProps, tooltipProps] = useHoverTooltip()
   const history = useHistory()
+  const [dispatchApiRequest, requestIds] = useDispatchApiRequest()
   const runStatus = useCurrentRunStatus({
     onSettled: data => {
       if (data == null) {
@@ -79,6 +99,16 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
       }
     },
   })
+  const latestRequestId = last(requestIds)
+  const latestRequest = useSelector<State, RequestState | null>(state =>
+    latestRequestId ? getRequestById(state, latestRequestId) : null
+  )
+  const handleCloseErrorModal = (): void => {
+    if (latestRequestId != null) {
+      dispatch(dismissRequest(latestRequestId))
+    }
+  }
+  const isPending = latestRequest?.status === PENDING
   const hotToTouch: IconProps = { name: 'ot-hot-to-touch' }
 
   const isOverflowBtnDisabled =
@@ -181,6 +211,13 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
     setShowSlideout(false)
   }
 
+  const handleUpdateClick = (): void => {
+    robotName && dispatchApiRequest(updateModule(robotName, module.serial))
+    setTimeout(() => {
+      setShowSuccessToast(true)
+    }, 10000)
+  }
+
   return (
     <React.Fragment>
       <Flex
@@ -190,7 +227,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
         marginLeft={SPACING.spacing2}
         marginRight={SPACING.spacing2}
         width={'100%'}
-        data-testid={`module_card_${module.serial}`}
+        data-testid={`ModuleCard_${module.serial}`}
       >
         {showWizard && (
           <HeaterShakerWizard onCloseClick={() => setShowWizard(false)} />
@@ -222,15 +259,35 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
           width="100%"
         >
           <Flex flexDirection={DIRECTION_ROW} paddingRight={SPACING.spacing3}>
-            <Flex alignItems={ALIGN_START}>
+            <Flex alignItems={ALIGN_START} opacity={isPending ? '50%' : '100%'}>
               <img width="60px" height="54px" src={image} alt={module.model} />
             </Flex>
             <Flex
               flexDirection={DIRECTION_COLUMN}
               paddingLeft={SPACING.spacing3}
             >
-              {module.hasAvailableUpdate && showBanner ? (
-                <Flex paddingBottom={SPACING.spacing2} width="12.4rem">
+              {showSuccessToast && (
+                <Toast
+                  message={t('firmware_update_installation_successful')}
+                  type="success"
+                  onClose={() => setShowSuccessToast(false)}
+                />
+              )}
+              {latestRequest != null &&
+                latestRequest &&
+                latestRequest.status === FAILURE && (
+                  <FirmwareUpdateFailedModal
+                    module={module}
+                    onCloseClick={() => handleCloseErrorModal()}
+                    errorMessage={getErrorResponseMessage(latestRequest.error)}
+                  />
+                )}
+              {module.hasAvailableUpdate && showBanner && !isPending ? (
+                <Flex
+                  paddingBottom={SPACING.spacing2}
+                  width="12.4rem"
+                  data-testid={`ModuleCard_firmware_update_banner_${module.serial}`}
+                >
                   <Banner
                     type="warning"
                     onCloseClick={() => setShowBanner(false)}
@@ -241,8 +298,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
                         textAlign={ALIGN_START}
                         fontSize={TYPOGRAPHY.fontSizeP}
                         textDecoration={TEXT_DECORATION_UNDERLINE}
-                        // TODO(jr, 3/21/22) wire up button when we know where this should link to
-                        onClick={() => console.log('firmware update!')}
+                        onClick={() => handleUpdateClick()}
                       >
                         {t('view_update')}
                       </Btn>
@@ -255,6 +311,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
                   width="12.4rem"
                   paddingRight={SPACING.spacingM}
                   paddingBottom={SPACING.spacing3}
+                  data-testid={`ModuleCard_too_hot_banner_${module.serial}`}
                 >
                   <Banner type="warning" icon={hotToTouch}>
                     <Trans
@@ -268,33 +325,52 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
                   </Banner>
                 </Flex>
               ) : null}
-              <Text
-                textTransform={TEXT_TRANSFORM_UPPERCASE}
-                color={COLORS.darkGrey}
-                fontWeight={FONT_WEIGHT_REGULAR}
-                fontSize={FONT_SIZE_CAPTION}
-                paddingBottom={SPACING.spacing2}
-                data-testid={`module_card_usb_port_${module.serial}`}
-              >
-                {t(module.usbPort.port === null ? 'usb_hub' : 'usb_port', {
-                  port: module.usbPort.hub ?? module.usbPort.port,
-                })}
-              </Text>
+              {isPending ? (
+                <Flex
+                  flexDirection={DIRECTION_ROW}
+                  fontSize={TYPOGRAPHY.fontSizeP}
+                  data-testid={`ModuleCard_update_pending_${module.serial}`}
+                >
+                  <Icon width={SPACING.spacingSM} name="ot-spinner" spin />
+                  <Text marginLeft={SPACING.spacing3}>
+                    {t('updating_firmware')}
+                  </Text>
+                </Flex>
+              ) : (
+                <>
+                  <Text
+                    textTransform={TEXT_TRANSFORM_UPPERCASE}
+                    color={COLORS.darkGrey}
+                    fontWeight={FONT_WEIGHT_REGULAR}
+                    fontSize={FONT_SIZE_CAPTION}
+                    paddingBottom={SPACING.spacing2}
+                    data-testid={`ModuleCard_usb_port_${module.serial}`}
+                  >
+                    {t(module.usbPort.port === null ? 'usb_hub' : 'usb_port', {
+                      port: module.usbPort.hub ?? module.usbPort.port,
+                    })}
+                  </Text>
+                  <Flex
+                    paddingBottom={SPACING.spacing2}
+                    data-testid={`ModuleCrd_display_name_${module.serial}`}
+                    fontSize={TYPOGRAPHY.fontSizeP}
+                  >
+                    <ModuleIcon
+                      moduleType={module.type}
+                      size="1rem"
+                      marginRight={SPACING.spacing1}
+                      color={COLORS.darkGreyEnabled}
+                    />
+                    <Text>{getModuleDisplayName(module.model)}</Text>
+                  </Flex>
+                </>
+              )}
               <Flex
-                paddingBottom={SPACING.spacing2}
-                data-testid={`module_card_display_name_${module.serial}`}
+                opacity={isPending ? '50%' : '100%'}
+                flexDirection={DIRECTION_COLUMN}
               >
-                <ModuleIcon
-                  moduleType={module.type}
-                  size="1rem"
-                  marginRight={SPACING.spacing1}
-                  color={COLORS.darkGreyEnabled}
-                />
-                <Text fontSize={TYPOGRAPHY.fontSizeP}>
-                  {getModuleDisplayName(module.model)}
-                </Text>
+                {moduleData}
               </Flex>
-              {moduleData}
             </Flex>
           </Flex>
         </Box>
@@ -302,7 +378,8 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
         <Box
           alignSelf={ALIGN_START}
           padding={SPACING.spacing2}
-          data-testid={`module_card_overflow_btn_${module.serial}`}
+          data-testid={`ModuleCard_overflow_btn_${module.serial}`}
+          opacity={isPending ? '50%' : '100%'}
         >
           <OverflowBtn
             aria-label="overflow"
@@ -321,7 +398,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
         {showOverflowMenu && (
           <div
             ref={moduleOverflowWrapperRef}
-            data-testid={`module_card_overflow_menu_${module.serial}`}
+            data-testid={`ModuleCard_overflow_menu_${module.serial}`}
           >
             <ModuleOverflowMenu
               handleAboutClick={handleAboutClick}

--- a/app/src/organisms/Devices/ModuleCard/index.tsx
+++ b/app/src/organisms/Devices/ModuleCard/index.tsx
@@ -42,6 +42,7 @@ import {
   FAILURE,
   getErrorResponseMessage,
   dismissRequest,
+  SUCCESS,
 } from '../../../redux/robot-api'
 import { Banner } from '../../../atoms/Banner'
 import { Toast } from '../../../atoms/Toast'
@@ -99,12 +100,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
       }
     },
   })
-  const handleUpdateClick = (): void => {
-    robotName && dispatchApiRequest(updateModule(robotName, module.serial))
-    setTimeout(() => {
-      setShowSuccessToast(true)
-    }, 10000)
-  }
+
   const latestRequestId = last(requestIds)
   const latestRequest = useSelector<State, RequestState | null>(state =>
     latestRequestId ? getRequestById(state, latestRequestId) : null
@@ -113,6 +109,12 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
     if (latestRequestId != null) {
       dispatch(dismissRequest(latestRequestId))
     }
+  }
+  const handleUpdateClick = (): void => {
+    robotName && dispatchApiRequest(updateModule(robotName, module.serial))
+    setTimeout(() => {
+      latestRequest?.status === SUCCESS ? setShowSuccessToast(true) : null
+    }, 5000)
   }
   const isPending = latestRequest?.status === PENDING
   const hotToTouch: IconProps = { name: 'ot-hot-to-touch' }
@@ -273,15 +275,13 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
                   onClose={() => setShowSuccessToast(false)}
                 />
               )}
-              {latestRequest != null &&
-                latestRequest &&
-                latestRequest.status === FAILURE && (
-                  <FirmwareUpdateFailedModal
-                    module={module}
-                    onCloseClick={handleCloseErrorModal}
-                    errorMessage={getErrorResponseMessage(latestRequest.error)}
-                  />
-                )}
+              {latestRequest != null && latestRequest.status === FAILURE && (
+                <FirmwareUpdateFailedModal
+                  module={module}
+                  onCloseClick={handleCloseErrorModal}
+                  errorMessage={getErrorResponseMessage(latestRequest.error)}
+                />
+              )}
               {module.hasAvailableUpdate && showBanner && !isPending ? (
                 <Flex
                   paddingBottom={SPACING.spacing2}

--- a/app/src/organisms/Devices/PipettesAndModules.tsx
+++ b/app/src/organisms/Devices/PipettesAndModules.tsx
@@ -88,7 +88,7 @@ export function PipettesAndModules({
                     maxWidth="50%"
                     key={`moduleCard_${module.type}_${index}`}
                   >
-                    <ModuleCard module={module} />
+                    <ModuleCard module={module} robotName={robotName} />
                   </Flex>
                 )
               })}


### PR DESCRIPTION
closes #9155

# Overview

This PR wires up the firmware update banner when an update is available on a module. It follows the [figma flow](https://www.figma.com/file/bVtCogdwiXj3ndpk4AWXCx/Milestone-1%3A-Read-and-Execute?node-id=1297%3A87906)

<img width="289" alt="Screen Shot 2022-04-13 at 1 08 57 PM" src="https://user-images.githubusercontent.com/66035149/163256329-e4755ae1-dac3-44fd-9f25-d2c8361f422e.png">

<img width="594" alt="Screen Shot 2022-04-13 at 1 09 43 PM" src="https://user-images.githubusercontent.com/66035149/163256374-a068a556-6474-4f15-8ade-f33537aff2f5.png">

# Changelog

- adds logic to `moduleCard` and creates a modal for when the firmware update fails.

# Review requests

- when a firmware update is available on the module card, click on `update now`. That should start the update immedately. And the module card should have 50% opacity and the port and module name should be replaced with a spinner icon and the text "updating now". When the update is complete, a success toast should render at the bottom right of the viewport.

# Risk assessment

low, behind ff
