### PR TITLE
feat(heater-shaker): add deactivate_heater method

### DIFF
--- a/api/src/opentrons/drivers/heater_shaker/abstract.py
+++ b/api/src/opentrons/drivers/heater_shaker/abstract.py
@@ -59,7 +59,7 @@ class AbstractHeaterShakerDriver(ABC):
     async def home(self) -> None:
         """Send deactivate shaker command"""
         ...
-        
+
     @abstractmethod
     async def deactivate_heater(self) -> None:
         """Send deactivate heater command"""

--- a/api/src/opentrons/drivers/heater_shaker/abstract.py
+++ b/api/src/opentrons/drivers/heater_shaker/abstract.py
@@ -59,6 +59,11 @@ class AbstractHeaterShakerDriver(ABC):
     async def home(self) -> None:
         """Send deactivate shaker command"""
         ...
+        
+    @abstractmethod
+    async def deactivate_heater(self) -> None:
+        """Send deactivate heater command"""
+        ...
 
     @abstractmethod
     async def get_device_info(self) -> Dict[str, str]:

--- a/api/src/opentrons/drivers/heater_shaker/driver.py
+++ b/api/src/opentrons/drivers/heater_shaker/driver.py
@@ -22,6 +22,7 @@ class GCODE(str, Enum):
     OPEN_LABWARE_LATCH = "M242"
     CLOSE_LABWARE_LATCH = "M243"
     GET_LABWARE_LATCH_STATE = "M241"
+    DEACTIVATE_HEATER = "M106"
 
 
 HS_BAUDRATE = 115200
@@ -156,7 +157,10 @@ class HeaterShakerDriver(AbstractHeaterShakerDriver):
         return utils.parse_labware_latch_status_response(status_string=response)
 
     async def home(self) -> None:
-        """Send home command"""
+        """Send home command.
+        
+        Note: Homing also stops the shaking motion if applicable.
+        """
         c = CommandBuilder(terminator=HS_COMMAND_TERMINATOR).add_gcode(gcode=GCODE.HOME)
         await self._connection.send_command(command=c, retries=DEFAULT_COMMAND_RETRIES)
 
@@ -176,3 +180,8 @@ class HeaterShakerDriver(AbstractHeaterShakerDriver):
         )
         await self._connection.send_command(command=c, retries=DEFAULT_COMMAND_RETRIES)
         await self._connection.close()
+
+    async def deactivate_heater(self) -> None:
+        """Send deactivate-heater command"""
+        c = CommandBuilder(terminator=HS_COMMAND_TERMINATOR).add_gcode(gcode=GCODE.DEACTIVATE_HEATER)
+        await self._connection.send_command(command=c, retries=DEFAULT_COMMAND_RETRIES)

--- a/api/src/opentrons/drivers/heater_shaker/driver.py
+++ b/api/src/opentrons/drivers/heater_shaker/driver.py
@@ -120,8 +120,7 @@ class HeaterShakerDriver(AbstractHeaterShakerDriver):
         )
         return utils.parse_temperature_response(
             temperature_string=response,
-            rounding_val=utils.HS_GCODE_ROUNDING_PRECISION,
-            zero_target_is_unset=False,
+            rounding_val=utils.HS_GCODE_ROUNDING_PRECISION
         )
 
     async def set_rpm(self, rpm: int) -> None:

--- a/api/src/opentrons/drivers/heater_shaker/driver.py
+++ b/api/src/opentrons/drivers/heater_shaker/driver.py
@@ -119,8 +119,7 @@ class HeaterShakerDriver(AbstractHeaterShakerDriver):
             command=c, retries=DEFAULT_COMMAND_RETRIES
         )
         return utils.parse_temperature_response(
-            temperature_string=response,
-            rounding_val=utils.HS_GCODE_ROUNDING_PRECISION
+            temperature_string=response, rounding_val=utils.HS_GCODE_ROUNDING_PRECISION
         )
 
     async def set_rpm(self, rpm: int) -> None:

--- a/api/src/opentrons/drivers/heater_shaker/driver.py
+++ b/api/src/opentrons/drivers/heater_shaker/driver.py
@@ -158,7 +158,7 @@ class HeaterShakerDriver(AbstractHeaterShakerDriver):
 
     async def home(self) -> None:
         """Send home command.
-        
+
         Note: Homing also stops the shaking motion if applicable.
         """
         c = CommandBuilder(terminator=HS_COMMAND_TERMINATOR).add_gcode(gcode=GCODE.HOME)
@@ -183,5 +183,7 @@ class HeaterShakerDriver(AbstractHeaterShakerDriver):
 
     async def deactivate_heater(self) -> None:
         """Send deactivate-heater command"""
-        c = CommandBuilder(terminator=HS_COMMAND_TERMINATOR).add_gcode(gcode=GCODE.DEACTIVATE_HEATER)
+        c = CommandBuilder(terminator=HS_COMMAND_TERMINATOR).add_gcode(
+            gcode=GCODE.DEACTIVATE_HEATER
+        )
         await self._connection.send_command(command=c, retries=DEFAULT_COMMAND_RETRIES)

--- a/api/src/opentrons/drivers/heater_shaker/driver.py
+++ b/api/src/opentrons/drivers/heater_shaker/driver.py
@@ -121,7 +121,7 @@ class HeaterShakerDriver(AbstractHeaterShakerDriver):
         return utils.parse_temperature_response(
             temperature_string=response,
             rounding_val=utils.HS_GCODE_ROUNDING_PRECISION,
-            zero_target_is_unset=True,
+            zero_target_is_unset=False,
         )
 
     async def set_rpm(self, rpm: int) -> None:

--- a/api/src/opentrons/drivers/heater_shaker/simulator.py
+++ b/api/src/opentrons/drivers/heater_shaker/simulator.py
@@ -53,6 +53,17 @@ class SimulatingDriver(AbstractHeaterShakerDriver):
 
     async def deactivate_heater(self) -> None:
         self._temperature.target = None
+        self._temperature.current = 23
+
+    async def deactivate_shaker(self) -> None:
+        self._rpm.target = 0
+        self._rpm.current = 0
+
+    async def deactivate(self) -> None:
+        self._temperature.target = None
+        self._temperature.current = 23
+        self._rpm.target = 0
+        self._rpm.current = 0
 
     async def get_device_info(self) -> Dict[str, str]:
         return {

--- a/api/src/opentrons/drivers/heater_shaker/simulator.py
+++ b/api/src/opentrons/drivers/heater_shaker/simulator.py
@@ -51,6 +51,9 @@ class SimulatingDriver(AbstractHeaterShakerDriver):
         self._rpm.current = 0
         self._homing_status = True
 
+    async def deactivate_heater(self) -> None:
+        self._temperature.target = None
+
     async def get_device_info(self) -> Dict[str, str]:
         return {
             "serial": "dummySerialHS",

--- a/api/src/opentrons/drivers/utils.py
+++ b/api/src/opentrons/drivers/utils.py
@@ -61,7 +61,8 @@ def parse_temperature_response(
     does not currently have a target temperature set and is not regulating
     (as the heater/shaker does - it has a resistive heater rather than a
     thermoelectric cooler, and therefore cannot regulate on a temperature below
-    ambient).
+    ambient). Heater/shaker firmware has been updated to return a target of None
+    if heater is deactivated or in error state.
 
     Example input: "T:none C:25"""
     data = parse_key_values(temperature_string)

--- a/api/src/opentrons/drivers/utils.py
+++ b/api/src/opentrons/drivers/utils.py
@@ -49,27 +49,17 @@ def parse_string_value_from_substring(substring: str) -> str:
 
 
 def parse_temperature_response(
-    temperature_string: str, rounding_val: int, zero_target_is_unset: bool = False
+    temperature_string: str, rounding_val: int
 ) -> Temperature:
     """Parse a standard temperature response from a module
 
     temperature_string: The string from the module after decoding
     rounding_val: A value to round to
-    zero_target_is_unset: Whether or not to treat a 0 target temperature
-    as indicating that the module is regulating around the target temperature
-    0C (which the tempdeck and thermocycler are capable of) or that the module
-    does not currently have a target temperature set and is not regulating
-    (as the heater/shaker does - it has a resistive heater rather than a
-    thermoelectric cooler, and therefore cannot regulate on a temperature below
-    ambient). Heater/shaker firmware has been updated to return a target of None
-    if heater is deactivated or in error state.
 
     Example input: "T:none C:25"""
     data = parse_key_values(temperature_string)
     try:
         target = parse_optional_number(data["T"], rounding_val)
-        if zero_target_is_unset and target == 0.0:
-            target = None
         return Temperature(current=parse_number(data["C"], rounding_val), target=target)
     except KeyError:
         raise ParseError(

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -126,7 +126,7 @@ class HeaterShaker(mod_abc.AbstractModule):
         """
         DELTA: Final = 0.7
         status = TemperatureStatus.IDLE
-        if (temperature.target is not None) and (temperature.target != 0):
+        if temperature.target is not None:
             diff = temperature.target - temperature.current
             if abs(diff) < DELTA:  # To avoid status fluctuation near target
                 status = TemperatureStatus.HOLDING

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -126,7 +126,7 @@ class HeaterShaker(mod_abc.AbstractModule):
         """
         DELTA: Final = 0.7
         status = TemperatureStatus.IDLE
-        if temperature.target is not None:
+        if (temperature.target is not None) and (temperature.target != 0):
             diff = temperature.target - temperature.current
             if abs(diff) < DELTA:  # To avoid status fluctuation near target
                 status = TemperatureStatus.HOLDING
@@ -397,19 +397,20 @@ class HeaterShaker(mod_abc.AbstractModule):
         """Stop heating/cooling; stop shaking and home the plate"""
         await self.wait_for_is_running()
         await self._driver.deactivate_heater()
-        self._listener.state.temperature.target = None
         await self._driver.home()
+        await self.wait_next_poll()
 
     async def deactivate_heater(self) -> None:
         """Stop heating/cooling"""
         await self.wait_for_is_running()
         await self._driver.deactivate_heater()
-        self._listener.state.temperature.target = None
+        await self.wait_next_poll()
 
     async def deactivate_shaker(self) -> None:
         """Stop shaking and home the plate"""
         await self.wait_for_is_running()
         await self._driver.home()
+        await self.wait_next_poll()
 
     async def open_labware_latch(self) -> None:
         await self.wait_for_is_running()

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -149,7 +149,7 @@ class HeaterShaker(mod_abc.AbstractModule):
         """
         DELTA: Final = 100
         status = SpeedStatus.IDLE
-        if (speed.target is not None) and (speed.target != 0):
+        if speed.target is not None:
             diff = speed.target - speed.current
             if abs(diff) < DELTA:  # To avoid status fluctuation near target
                 status = SpeedStatus.HOLDING

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 from anyio import create_task_group
 from dataclasses import dataclass
-from types import NoneType
 from typing import Optional, Mapping, Callable
 from typing_extensions import Final
 from opentrons.drivers.rpi_drivers.types import USBPort

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -149,7 +149,7 @@ class HeaterShaker(mod_abc.AbstractModule):
         """
         DELTA: Final = 100
         status = SpeedStatus.IDLE
-        if speed.target is not None:
+        if (speed.target is not None) and (speed.target != 0):
             diff = speed.target - speed.current
             if abs(diff) < DELTA:  # To avoid status fluctuation near target
                 status = SpeedStatus.HOLDING

--- a/api/tests/opentrons/drivers/heater_shaker/test_driver.py
+++ b/api/tests/opentrons/drivers/heater_shaker/test_driver.py
@@ -116,6 +116,14 @@ async def test_home(subject: driver.HeaterShakerDriver, connection: AsyncMock) -
     connection.send_command.assert_called_once_with(command=expected, retries=0)
 
 
+async def test_deactivate_heater(subject: driver.HeaterShakerDriver, connection: AsyncMock) -> None:
+    """It should send a deactivate-heater command"""
+    connection.send_command.return_value = "M106 ok\n"
+    await subject.deactivate_heater()
+    expected = CommandBuilder(terminator=driver.HS_COMMAND_TERMINATOR).add_gcode("M106")
+    connection.send_command.assert_called_once_with(command=expected, retries=0)
+
+
 async def test_get_device_info(
     subject: driver.HeaterShakerDriver, connection: AsyncMock
 ) -> None:

--- a/api/tests/opentrons/drivers/heater_shaker/test_driver.py
+++ b/api/tests/opentrons/drivers/heater_shaker/test_driver.py
@@ -116,7 +116,9 @@ async def test_home(subject: driver.HeaterShakerDriver, connection: AsyncMock) -
     connection.send_command.assert_called_once_with(command=expected, retries=0)
 
 
-async def test_deactivate_heater(subject: driver.HeaterShakerDriver, connection: AsyncMock) -> None:
+async def test_deactivate_heater(
+    subject: driver.HeaterShakerDriver, connection: AsyncMock
+) -> None:
     """It should send a deactivate-heater command"""
     connection.send_command.return_value = "M106 ok\n"
     await subject.deactivate_heater()

--- a/api/tests/opentrons/drivers/test_utils.py
+++ b/api/tests/opentrons/drivers/test_utils.py
@@ -101,7 +101,7 @@ def test_parse_hs_device_information_failure(input_str: str) -> None:
         ["T:-123.566 C:-123.446", Temperature(target=-123.57, current=-123.45)],
         ["a:3 T:2. C:3 H:0 G:1", Temperature(target=2, current=3)],
         ["T:0 C:124", Temperature(target=0, current=124)],
-        ["T:None C:124", Temperature(target=None, current=124)],
+        ["T:none C:124", Temperature(target=None, current=124)],
     ],
 )
 def test_parse_temperature_response_success(

--- a/api/tests/opentrons/drivers/test_utils.py
+++ b/api/tests/opentrons/drivers/test_utils.py
@@ -94,26 +94,21 @@ def test_parse_hs_device_information_failure(input_str: str) -> None:
 
 
 @pytest.mark.parametrize(
-    argnames=["input_str", "expected_result", "zero_is_none"],
+    argnames=["input_str", "expected_result"],
     argvalues=[
-        ["T:none C:123.4", Temperature(target=None, current=123.4), False],
-        ["T:123.566 C:123.446", Temperature(target=123.57, current=123.45), False],
-        ["T:-123.566 C:-123.446", Temperature(target=-123.57, current=-123.45), False],
-        ["a:3 T:2. C:3 H:0 G:1", Temperature(target=2, current=3), False],
-        ["T:0 C:124", Temperature(target=0, current=124), False],
-        ["T:0 C:124", Temperature(target=None, current=124), True],
+        ["T:none C:123.4", Temperature(target=None, current=123.4)],
+        ["T:123.566 C:123.446", Temperature(target=123.57, current=123.45)],
+        ["T:-123.566 C:-123.446", Temperature(target=-123.57, current=-123.45)],
+        ["a:3 T:2. C:3 H:0 G:1", Temperature(target=2, current=3)],
+        ["T:0 C:124", Temperature(target=0, current=124)],
+        ["T:None C:124", Temperature(target=None, current=124)],
     ],
 )
 def test_parse_temperature_response_success(
-    input_str: str, expected_result: Temperature, zero_is_none: bool
+    input_str: str, expected_result: Temperature
 ) -> None:
     """It should parse temperature response."""
-    assert (
-        utils.parse_temperature_response(
-            input_str, 2, zero_target_is_unset=zero_is_none
-        )
-        == expected_result
-    )
+    assert utils.parse_temperature_response(input_str, 2) == expected_result
 
 
 @pytest.mark.parametrize(

--- a/api/tests/opentrons/hardware_control/modules/test_hc_heatershaker.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_heatershaker.py
@@ -67,7 +67,7 @@ async def test_sim_update(simulating_module):
 
     await simulating_module.deactivate()
     await simulating_module.wait_next_poll()
-    assert simulating_module.temperature == 0
+    assert simulating_module.temperature == 23
     assert simulating_module.speed == 0
     assert simulating_module.target_temperature is None
     assert simulating_module.target_speed is None
@@ -165,5 +165,5 @@ async def test_deactivated_updated_live_data(simulating_module):
             "targetTemp": None,
             "errorDetails": None,
         },
-        "status": "running",
+        "status": "idle",
     }

--- a/api/tests/opentrons/hardware_control/modules/test_hc_heatershaker.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_heatershaker.py
@@ -132,3 +132,22 @@ async def test_updated_live_data(simulating_module):
         },
         "status": "running",
     }
+
+async def test_deactivated_updated_live_data(simulating_module):
+    """Should update live data after module commands."""
+    await simulating_module.close_labware_latch()
+    await simulating_module.deactivate()
+    await simulating_module.wait_next_poll()
+    assert simulating_module.live_data == {
+        "data": {
+            "labwareLatchStatus": "idle_closed",
+            "speedStatus": "idle",
+            "temperatureStatus": "idle",
+            "currentSpeed": 0,
+            "currentTemp": 0,
+            "targetSpeed": None,
+            "targetTemp": None,
+            "errorDetails": None,
+        },
+        "status": "running",
+    }

--- a/api/tests/opentrons/hardware_control/modules/test_hc_heatershaker.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_heatershaker.py
@@ -144,7 +144,7 @@ async def test_deactivated_updated_live_data(simulating_module):
             "speedStatus": "idle",
             "temperatureStatus": "idle",
             "currentSpeed": 0,
-            "currentTemp": 0,
+            "currentTemp": 23,
             "targetSpeed": None,
             "targetTemp": None,
             "errorDetails": None,

--- a/api/tests/opentrons/hardware_control/modules/test_hc_heatershaker.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_heatershaker.py
@@ -135,9 +135,18 @@ async def test_updated_live_data(simulating_module):
 
 async def test_deactivated_updated_live_data(simulating_module):
     """Should update live data after module commands."""
-    await simulating_module.close_labware_latch()
+    assert simulating_module.live_data == {
+        "data": {
+            "labwareLatchStatus": "idle_closed",
+            "speedStatus": not "idle",
+            "temperatureStatus": not "idle",
+            "targetSpeed": not None,
+            "targetTemp": not None,
+            "errorDetails": None,
+        },
+        "status": "running",
+    }
     await simulating_module.deactivate()
-    await simulating_module.wait_next_poll()
     assert simulating_module.live_data == {
         "data": {
             "labwareLatchStatus": "idle_closed",

--- a/api/tests/opentrons/hardware_control/modules/test_hc_heatershaker.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_heatershaker.py
@@ -133,6 +133,7 @@ async def test_updated_live_data(simulating_module):
         "status": "running",
     }
 
+
 async def test_deactivated_updated_live_data(simulating_module):
     """Should update live data after module commands."""
     await simulating_module.close_labware_latch()

--- a/api/tests/opentrons/hardware_control/modules/test_hc_heatershaker.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_heatershaker.py
@@ -135,13 +135,19 @@ async def test_updated_live_data(simulating_module):
 
 async def test_deactivated_updated_live_data(simulating_module):
     """Should update live data after module commands."""
+    await simulating_module.close_labware_latch()
+    await simulating_module.start_set_temperature(50)
+    await simulating_module.start_set_speed(100)
+    await simulating_module.wait_next_poll()
     assert simulating_module.live_data == {
         "data": {
             "labwareLatchStatus": "idle_closed",
-            "speedStatus": not "idle",
-            "temperatureStatus": not "idle",
-            "targetSpeed": not None,
-            "targetTemp": not None,
+            "speedStatus": "holding at target",
+            "temperatureStatus": "holding at target",
+            "currentSpeed": 100,
+            "currentTemp": 50,
+            "targetSpeed": 100,
+            "targetTemp": 50,
             "errorDetails": None,
         },
         "status": "running",


### PR DESCRIPTION
Currently, we only have a `deactivate` hardware controller class method. This PR adds `deactivate_heater` and `deactivate_shaker` methods for more granular control. To deactivate the heater, the `deactivate_heater` gcode is now used instead of `set_temperature(0)`, which disables heatpad power output instead of setting the temperature setpoint to 0. To properly update temperature status, the target temperature is set to None after heater is deactivated. The target temperature is also set to None if heater is in error state.