### PR TITLE
fix(app): Added size prop to ModuleIcon

### DIFF
--- a/app/src/organisms/Devices/RobotCard.tsx
+++ b/app/src/organisms/Devices/RobotCard.tsx
@@ -90,6 +90,7 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
                   <ModuleIcon
                     key={`${name}_${module.model}_${i}`}
                     moduleType={module.type}
+                    size={SPACING.spacing4}
                   />
                 ))}
               </Flex>


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
If a robot has only one module, the module icon size is different from the design.
![Screen Shot 2022-04-14 at 3 14 19 PM](https://user-images.githubusercontent.com/474225/163467954-ceeaee16-c3cd-48f1-b701-8a4b8660c62f.png)

![Screen Shot 2022-04-14 at 4 10 48 PM](https://user-images.githubusercontent.com/474225/163468011-8fda3f07-aaff-44ad-a67a-7651a1dadced.png)


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- Added size prop to RobotCard ModuleIcon
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- An icon size is the same if a robot has one module or multiple modules.
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
