### PR TITLE
test(api): add required arguments to verify rehearsal

### DIFF
--- a/api/tests/opentrons/protocol_reader/test_protocol_reader.py
+++ b/api/tests/opentrons/protocol_reader/test_protocol_reader.py
@@ -2,7 +2,7 @@
 import pytest
 import io
 from dataclasses import dataclass
-from decoy import Decoy
+from decoy import Decoy, matchers
 from pathlib import Path
 from typing import IO, Optional
 
@@ -289,7 +289,9 @@ async def test_read_files_no_copy(
     )
 
     decoy.verify(
-        await file_reader_writer.write(),  # type: ignore[call-arg]
-        ignore_extra_args=True,
+        await file_reader_writer.write(
+            directory=matchers.Anything(),
+            files=matchers.Anything(),
+        ),
         times=0,
     )


### PR DESCRIPTION
## Overview

Continuing on the train of #9985, this PR fixes a warning I introduced into the `api` test suite.

A `verify` rehearsal in a test did not spec the correct arguments for a call, which Decoy [does not like](https://mike.cousins.io/decoy/usage/errors-and-warnings/#incorrectcallwarning). This PR adds those arguments.

## Changelog

- test(api): add required arguments to verify rehearsal

## Review requests

- [ ] Change makes sense

## Risk assessment

Very low, fixing a warning in the test suite
