### PR TITLE
fix(api): Less magical async tests fix

### DIFF
--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -170,6 +170,8 @@ async def _build_ot2_hw() -> AsyncIterator[ThreadManager[HardwareControlAPI]]:
         yield hw_sim
     finally:
         config.robot_configs.clear()
+        for m in hw_sim.attached_modules:
+            await m.cleanup()
         hw_sim.set_config(old_config)
         hw_sim.clean_up()
 
@@ -189,8 +191,11 @@ async def _build_ot3_hw() -> AsyncIterator[ThreadManager[HardwareControlAPI]]:
         yield hw_sim
     finally:
         config.robot_configs.clear()
+        for m in hw_sim.attached_modules:
+            await m.cleanup()
         hw_sim.set_config(old_config)
         hw_sim.clean_up()
+
 
 
 @pytest.fixture
@@ -234,10 +239,14 @@ async def hardware(request, virtual_smoothie_env):
 # so this fixture needs to run in an event loop.
 @pytest.fixture
 async def ctx(hardware) -> ProtocolContext:
-    return ProtocolContext(
+    c = ProtocolContext(
         implementation=ProtocolContextImplementation(sync_hardware=hardware.sync),
         loop=asyncio.get_running_loop(),
     )
+    yield c
+    # Manually clean up all the modules.
+    for m in c.loaded_modules.items():
+        m[1]._module.cleanup()
 
 
 @pytest.fixture

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -197,7 +197,6 @@ async def _build_ot3_hw() -> AsyncIterator[ThreadManager[HardwareControlAPI]]:
         hw_sim.clean_up()
 
 
-
 @pytest.fixture
 async def ot3_hardware(request, enable_ot3_hardware_controller):
     # this is from the command line parameters added in root conftest
@@ -238,7 +237,7 @@ async def hardware(request, virtual_smoothie_env):
 # Async because ProtocolContext.__init__() needs an event loop,
 # so this fixture needs to run in an event loop.
 @pytest.fixture
-async def ctx(hardware) -> ProtocolContext:
+async def ctx(hardware) -> AsyncIterator[ProtocolContext]:
     c = ProtocolContext(
         implementation=ProtocolContextImplementation(sync_hardware=hardware.sync),
         loop=asyncio.get_running_loop(),

--- a/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
@@ -50,7 +50,6 @@ async def test_sim_state(subject: modules.AbstractModule):
     # return v1 if sim_model is not passed
     assert status["model"] == "temp_deck_v1.1"
     assert status["version"] == "dummyVersionTD"
-    await subject.cleanup()
 
 
 async def test_sim_update(subject: modules.AbstractModule):
@@ -76,7 +75,7 @@ async def test_revision_model_parsing(subject: modules.AbstractModule):
     assert subject.model() == "temperatureModuleV1"
 
 
-async def test_poll_error(usb_port) -> None:
+async def test_poll_error(usb_port: USBPort) -> None:
     mock_driver = AsyncMock(spec=AbstractTempDeckDriver)
     mock_driver.get_temperature.side_effect = ValueError("hello!")
 

--- a/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
@@ -18,7 +18,9 @@ def usb_port():
     )
 
 
-async def test_sim_initialization(usb_port):
+@pytest.fixture
+async def subject(usb_port: USBPort) -> modules.AbstractModule:
+    """Test subject"""
     temp = await modules.build(
         port="/dev/ot_module_sim_tempdeck0",
         usb_port=usb_port,
@@ -27,78 +29,58 @@ async def test_sim_initialization(usb_port):
         loop=asyncio.get_running_loop(),
         execution_manager=ExecutionManager(),
     )
-    assert isinstance(temp, modules.AbstractModule)
+    yield temp
+    await temp.cleanup()
 
 
-async def test_sim_state(usb_port):
-    temp = await modules.TempDeck.build(
-        port="/dev/ot_module_sim_tempdeck0",
-        usb_port=usb_port,
-        simulating=True,
-        interrupt_callback=lambda x: None,
-        loop=asyncio.get_running_loop(),
-        execution_manager=ExecutionManager(),
-    )
-    await temp.wait_next_poll()
-    assert temp.temperature == 0
-    assert temp.target is None
-    assert temp.status == "idle"
-    assert temp.live_data["status"] == temp.status
-    assert temp.live_data["data"]["currentTemp"] == temp.temperature
-    assert temp.live_data["data"]["targetTemp"] == temp.target
-    status = temp.device_info
+async def test_sim_initialization(subject: modules.AbstractModule):
+    assert isinstance(subject, modules.AbstractModule)
+
+
+async def test_sim_state(subject: modules.AbstractModule):
+    await subject.wait_next_poll()
+    assert subject.temperature == 0
+    assert subject.target is None
+    assert subject.status == "idle"
+    assert subject.live_data["status"] == subject.status
+    assert subject.live_data["data"]["currentTemp"] == subject.temperature
+    assert subject.live_data["data"]["targetTemp"] == subject.target
+    status = subject.device_info
     assert status["serial"] == "dummySerialTD"
     # return v1 if sim_model is not passed
     assert status["model"] == "temp_deck_v1.1"
     assert status["version"] == "dummyVersionTD"
+    await subject.cleanup()
 
 
-async def test_sim_update(usb_port):
-    temp = await modules.TempDeck.build(
-        port="/dev/ot_module_sim_tempdeck0",
-        usb_port=usb_port,
-        simulating=True,
-        interrupt_callback=lambda x: None,
-        loop=asyncio.get_running_loop(),
-        execution_manager=ExecutionManager(),
-        polling_frequency=0,
-    )
-    await temp.set_temperature(10)
-    assert temp.temperature == 10
-    assert temp.target == 10
-    assert temp.status == "holding at target"
-    await temp.deactivate()
-    await temp.wait_next_poll()
-    assert temp.temperature == 23
-    assert temp.target is None
-    assert temp.status == "idle"
+async def test_sim_update(subject: modules.AbstractModule):
+    await subject.set_temperature(10)
+    assert subject.temperature == 10
+    assert subject.target == 10
+    assert subject.status == "holding at target"
+    await subject.deactivate()
+    await subject.wait_next_poll()
+    assert subject.temperature == 23
+    assert subject.target is None
+    assert subject.status == "idle"
 
 
-async def test_revision_model_parsing(usb_port):
-    mag = await modules.TempDeck.build(
-        port="",
-        simulating=True,
-        usb_port=usb_port,
-        interrupt_callback=lambda x: None,
-        loop=asyncio.get_running_loop(),
-        execution_manager=ExecutionManager(),
-        polling_frequency=0,
-    )
-    mag._device_info["model"] = "temp_deck_v20"
-    assert mag.model() == "temperatureModuleV2"
-    mag._device_info["model"] = "temp_deck_v4.0"
-    assert mag.model() == "temperatureModuleV1"
-    del mag._device_info["model"]
-    assert mag.model() == "temperatureModuleV1"
-    mag._device_info["model"] = "temp_deck_v1.1"
-    assert mag.model() == "temperatureModuleV1"
+async def test_revision_model_parsing(subject: modules.AbstractModule):
+    subject._device_info["model"] = "temp_deck_v20"
+    assert subject.model() == "temperatureModuleV2"
+    subject._device_info["model"] = "temp_deck_v4.0"
+    assert subject.model() == "temperatureModuleV1"
+    del subject._device_info["model"]
+    assert subject.model() == "temperatureModuleV1"
+    subject._device_info["model"] = "temp_deck_v1.1"
+    assert subject.model() == "temperatureModuleV1"
 
 
 async def test_poll_error(usb_port) -> None:
     mock_driver = AsyncMock(spec=AbstractTempDeckDriver)
     mock_driver.get_temperature.side_effect = ValueError("hello!")
 
-    magdeck = modules.TempDeck(
+    tempdeck = modules.TempDeck(
         port="",
         usb_port=usb_port,
         execution_manager=AsyncMock(spec=ExecutionManager),
@@ -108,4 +90,6 @@ async def test_poll_error(usb_port) -> None:
         polling_frequency=1,
     )
     with pytest.raises(ValueError, match="hello!"):
-        await magdeck.wait_next_poll()
+        await tempdeck.wait_next_poll()
+
+    await tempdeck.cleanup()

--- a/api/tests/opentrons/hardware_control/test_execution_manager.py
+++ b/api/tests/opentrons/hardware_control/test_execution_manager.py
@@ -74,5 +74,4 @@ async def test_cancel_tasks():
     assert other_task in all_tasks
     assert cancellable_task not in all_tasks
 
-    cancellable_task.cancel()
     other_task.cancel()

--- a/api/tests/opentrons/hardware_control/test_execution_manager.py
+++ b/api/tests/opentrons/hardware_control/test_execution_manager.py
@@ -73,3 +73,6 @@ async def test_cancel_tasks():
     assert len(all_tasks) == 2  # current and other
     assert other_task in all_tasks
     assert cancellable_task not in all_tasks
+
+    cancellable_task.cancel()
+    other_task.cancel()

--- a/api/tests/opentrons/hardware_control/test_modules.py
+++ b/api/tests/opentrons/hardware_control/test_modules.py
@@ -261,6 +261,8 @@ async def test_get_bundled_fw(monkeypatch, tmpdir):
     assert api.attached_modules[2].bundled_fw == BundledFirmware(
         version="0.1.2", path=dummy_tc_file
     )
+    for m in api.attached_modules:
+        await m.cleanup()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Overview

An attempt to fix hanging tests. Lots of errors generated by `test_modules` that tasks are destroyed yet are pending. In the past I could correlate this to hanging tests.

# Changelog

- Clean up modules in tests.

# Review requests

The hardware controller doesn't clean up its owned modules. Rather than rocking the boat, I went with the ugly solution that only affects tests.

# Risk assessment

None