### PR TITLE
fix(api): opentrons execute doesn't try to format run log command

### DIFF
--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -324,14 +324,7 @@ def make_runlog_cb() -> Callable[[command_types.CommandMessage], None]:
                 level -= 1
         last_dollar = command["$"]
         if command["$"] == "before":
-            print(
-                " ".join(
-                    [
-                        "\t" * level,
-                        command["payload"].get("text", "")
-                    ]
-                )
-            )
+            print(" ".join(["\t" * level, command["payload"].get("text", "")]))
 
     return _print_runlog
 

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -328,7 +328,7 @@ def make_runlog_cb() -> Callable[[command_types.CommandMessage], None]:
                 " ".join(
                     [
                         "\t" * level,
-                        command["payload"].get("text", "").format(**command["payload"]),
+                        command["payload"].get("text", "")
                     ]
                 )
             )


### PR DESCRIPTION

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

`text` field is not a format string anymore.

companion to #9799 
This is the `opentrons_execute` version of #9988 
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
