### PR TITLE
refactor(robot-server): Enforce SQLite foreign key constraint

### DIFF
--- a/robot-server/robot_server/persistence.py
+++ b/robot-server/robot_server/persistence.py
@@ -92,8 +92,11 @@ action_table = sqlalchemy.Table(
 
 # Enable foreign key support in sqlite
 # https://docs.sqlalchemy.org/en/14/dialects/sqlite.html#foreign-key-support
-@event.listens_for(SQLEngine, "connect")
-def _set_sqlite_pragma(dbapi_connection: sqlalchemy.engine.Connection, connection_record: sqlalchemy.engine.CursorResult) -> None:
+@event.listens_for(SQLEngine, "connect")  # type: ignore
+def _set_sqlite_pragma(
+    dbapi_connection: sqlalchemy.engine.CursorResult,
+    connection_record: sqlalchemy.engine.CursorResult,
+) -> None:
     cursor = dbapi_connection.cursor()
     cursor.execute("PRAGMA foreign_keys=ON;")
     cursor.close()
@@ -109,7 +112,7 @@ def open_db_no_cleanup(db_file_path: Path) -> SQLEngine:
 
 
 async def get_persistence_directory(
-        app_state: AppState = Depends(get_app_state),
+    app_state: AppState = Depends(get_app_state),
 ) -> Path:
     """Return the root persistence directory, creating it if necessary."""
     persistence_dir = _persistence_directory.get_from(app_state)
@@ -145,8 +148,8 @@ def add_tables_to_db(sql_engine: sqlalchemy.engine.Engine) -> None:
 
 
 def get_sql_engine(
-        app_state: AppState = Depends(get_app_state),
-        persistence_directory: Path = Depends(get_persistence_directory),
+    app_state: AppState = Depends(get_app_state),
+    persistence_directory: Path = Depends(get_persistence_directory),
 ) -> SQLEngine:
     """Return a singleton SQL engine referring to a ready-to-use database."""
     sql_engine = _sql_engine.get_from(app_state)

--- a/robot-server/robot_server/persistence.py
+++ b/robot-server/robot_server/persistence.py
@@ -3,6 +3,8 @@ import sqlalchemy
 from sqlalchemy.engine import Engine as SQLEngine
 from sqlalchemy import create_engine
 from fastapi import Depends
+from sqlalchemy import event
+from sqlite3 import Connection as SQLite3Connection
 
 import logging
 
@@ -92,6 +94,14 @@ action_table = sqlalchemy.Table(
         nullable=False,
     ),
 )
+
+
+@event.listens_for(SQLEngine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    if isinstance(dbapi_connection, SQLite3Connection):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON;")
+        cursor.close()
 
 
 def open_db_no_cleanup(db_file_path: Path) -> SQLEngine:

--- a/robot-server/robot_server/persistence.py
+++ b/robot-server/robot_server/persistence.py
@@ -92,6 +92,8 @@ action_table = sqlalchemy.Table(
 
 # Enable foreign key support in sqlite
 # https://docs.sqlalchemy.org/en/14/dialects/sqlite.html#foreign-key-support
+# mypy is expecting the decorator to return a function.
+# sqlalchemy listens_for() decorator does not return a function.
 @event.listens_for(SQLEngine, "connect")  # type: ignore
 def _set_sqlite_pragma(
     dbapi_connection: sqlalchemy.engine.CursorResult,

--- a/robot-server/robot_server/persistence.py
+++ b/robot-server/robot_server/persistence.py
@@ -68,8 +68,6 @@ run_table = sqlalchemy.Table(
     sqlalchemy.Column(
         "protocol_id",
         sqlalchemy.String,
-        # TODO (tz 4/8/22): SQLite does not support FK by default. Need to add support
-        # https://docs.sqlalchemy.org/en/14/dialects/sqlite.html#foreign-key-support
         sqlalchemy.ForeignKey("protocol.id"),
     ),
 )
@@ -88,8 +86,6 @@ action_table = sqlalchemy.Table(
     sqlalchemy.Column(
         "run_id",
         sqlalchemy.String,
-        # TODO (tz 4/8/22): SQLite does not support FK by default. Need to add support
-        # https://docs.sqlalchemy.org/en/14/dialects/sqlite.html#foreign-key-support
         sqlalchemy.ForeignKey("run.id"),
         nullable=False,
     ),

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -114,7 +114,7 @@ async def get_run_data_from_url(
     )
 
 
-@base_router.post(
+@base_router.post(  # noqa: C901
     path="/runs",
     summary="Create a run",
     description="Create a new run to track robot interaction.",
@@ -173,8 +173,11 @@ async def create_run(
         is_current=True,
         actions=[],
     )
+    try:
+        run_store.insert(run=run)
+    except ProtocolNotFoundError as e:
+        raise ProtocolNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
 
-    run_store.insert(run=run)
     log.info(f'Created protocol run "{run_id}" from protocol "{protocol_id}".')
 
     data = Run.construct(

--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -51,7 +51,7 @@ class RunStore:
         with self._sql_engine.begin() as transaction:
             try:
                 _insert_action_no_transaction(run_id, action, transaction)
-            except sqlalchemy.exc.IntegrityError as e:
+            except sqlalchemy.exc.IntegrityError:
                 raise RunNotFoundError(run_id=run_id)
 
     def update_active_run(self, run_id: str, is_current: bool) -> RunResource:
@@ -86,7 +86,8 @@ class RunStore:
         with self._sql_engine.begin() as transaction:
             try:
                 transaction.execute(statement)
-            except sqlalchemy.exc.IntegrityError as e:
+            except sqlalchemy.exc.IntegrityError:
+                assert run.protocol_id is not None
                 raise ProtocolNotFoundError(protocol_id=run.protocol_id)
 
         self.update_active_run(run_id=run.run_id, is_current=run.is_current)

--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -182,15 +182,6 @@ def _get_actions_no_transaction(
 def _insert_action_no_transaction(
     run_id: str, action: RunAction, transaction: sqlalchemy.engine.Connection
 ) -> None:
-    # TODO (tz): selecting to raise an error if a run does not exist.
-    # SQLite does not support FK by default. Need to add support
-    # https://docs.sqlalchemy.org/en/14/dialects/sqlite.html#foreign-key-support
-    # try:
-    #     transaction.execute(
-    #         sqlalchemy.select(run_table).where(run_table.c.id == run_id)
-    #     ).one()
-    # except sqlalchemy.exc.NoResultFound as e:
-    #     raise RunNotFoundError(run_id) from e
     transaction.execute(
         sqlalchemy.insert(action_table),
         _convert_action_to_sql_values(run_id=run_id, action=action),

--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -185,12 +185,12 @@ def _insert_action_no_transaction(
     # TODO (tz): selecting to raise an error if a run does not exist.
     # SQLite does not support FK by default. Need to add support
     # https://docs.sqlalchemy.org/en/14/dialects/sqlite.html#foreign-key-support
-    try:
-        transaction.execute(
-            sqlalchemy.select(run_table).where(run_table.c.id == run_id)
-        ).one()
-    except sqlalchemy.exc.NoResultFound as e:
-        raise RunNotFoundError(run_id) from e
+    # try:
+    #     transaction.execute(
+    #         sqlalchemy.select(run_table).where(run_table.c.id == run_id)
+    #     ).one()
+    # except sqlalchemy.exc.NoResultFound as e:
+    #     raise RunNotFoundError(run_id) from e
     transaction.execute(
         sqlalchemy.insert(action_table),
         _convert_action_to_sql_values(run_id=run_id, action=action),

--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -87,7 +87,9 @@ class RunStore:
             try:
                 transaction.execute(statement)
             except sqlalchemy.exc.IntegrityError:
-                assert run.protocol_id is not None
+                assert (
+                    run.protocol_id is not None
+                ), "Insert run failed due to unexpected IntegrityError"
                 raise ProtocolNotFoundError(protocol_id=run.protocol_id)
 
         self.update_active_run(run_id=run.run_id, is_current=run.is_current)

--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -7,7 +7,7 @@ import sqlalchemy
 from .action_models import RunAction, RunActionType
 
 from robot_server.persistence import run_table, action_table
-from robot_server.protocols.protocol_store import ProtocolNotFoundError
+from robot_server.protocols import ProtocolNotFoundError
 
 
 @dataclass(frozen=True)

--- a/robot-server/tests/runs/test_run_store.py
+++ b/robot-server/tests/runs/test_run_store.py
@@ -56,6 +56,20 @@ def test_insert_actions_missing_run_id(subject: RunStore) -> None:
         subject.insert_action(run_id="missing-run-id", action=action)
 
 
+def test_insert_run_missing_protocol_id(subject: RunStore) -> None:
+    """Should not be able to insert an action with a run id that does not exist."""
+    run = RunResource(
+        run_id="run-id",
+        protocol_id="missing-protocol-id",
+        created_at=datetime.now(),
+        actions=[],
+        is_current=True,
+    )
+
+    with pytest.raises(sqlalchemy.exc.IntegrityError, match="missing-protocol-id"):
+        subject.insert(run)
+
+
 def test_update_active_run(subject: RunStore) -> None:
     """It should be able to update a run in the store."""
     run = RunResource(

--- a/robot-server/tests/runs/test_run_store.py
+++ b/robot-server/tests/runs/test_run_store.py
@@ -3,6 +3,7 @@ import pytest
 from datetime import datetime
 from typing import Generator
 
+import sqlalchemy
 from sqlalchemy.engine import Engine as SQLEngine
 from pathlib import Path
 
@@ -51,7 +52,7 @@ def test_insert_actions_missing_run_id(subject: RunStore) -> None:
         id="action-id",
     )
 
-    with pytest.raises(RunNotFoundError, match="missing-run-id"):
+    with pytest.raises(sqlalchemy.exc.IntegrityError, match="missing-run-id"):
         subject.insert_action(run_id="missing-run-id", action=action)
 
 

--- a/robot-server/tests/runs/test_run_store.py
+++ b/robot-server/tests/runs/test_run_store.py
@@ -7,6 +7,7 @@ import sqlalchemy
 from sqlalchemy.engine import Engine as SQLEngine
 from pathlib import Path
 
+from robot_server.protocols.protocol_store import ProtocolNotFoundError
 from robot_server.runs.run_store import RunStore, RunResource, RunNotFoundError
 from robot_server.runs.action_models import RunAction, RunActionType
 from robot_server.persistence import open_db_no_cleanup, add_tables_to_db
@@ -52,7 +53,7 @@ def test_insert_actions_missing_run_id(subject: RunStore) -> None:
         id="action-id",
     )
 
-    with pytest.raises(sqlalchemy.exc.IntegrityError, match="missing-run-id"):
+    with pytest.raises(RunNotFoundError, match="missing-run-id"):
         subject.insert_action(run_id="missing-run-id", action=action)
 
 
@@ -66,7 +67,7 @@ def test_insert_run_missing_protocol_id(subject: RunStore) -> None:
         is_current=True,
     )
 
-    with pytest.raises(sqlalchemy.exc.IntegrityError, match="missing-protocol-id"):
+    with pytest.raises(ProtocolNotFoundError, match="missing-protocol-id"):
         subject.insert(run)
 
 

--- a/robot-server/tests/runs/test_run_store.py
+++ b/robot-server/tests/runs/test_run_store.py
@@ -3,7 +3,6 @@ import pytest
 from datetime import datetime
 from typing import Generator
 
-import sqlalchemy
 from sqlalchemy.engine import Engine as SQLEngine
 from pathlib import Path
 


### PR DESCRIPTION
# Overview

Override default SqlAlchemy settings and force sqlite FK constraint. 

# Changelog

- override _set_sqlite_pragma to force support for foreign keys
- Removed redundant select statements to raise KF exceptions 
- Added tests to check for FK constraints 

# Review requests
- Changes look good

# Risk assessment
- Low. FK constraint. Will raise and error when inserting run actions with unknown run id or a run with unknown protocol id.