### PR TITLE
feat(protocol-designer): make liquid descriptions strings

### DIFF
--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -183,7 +183,7 @@ export const createFile: Selector<ProtocolFile> = createSelector(
           ...acc,
           [liquidId]: {
             displayName: liquidData.name,
-            description: liquidData.description,
+            description: liquidData.description ?? '',
           },
         }
       },

--- a/protocol-designer/src/load-file/migration/6_0_0.ts
+++ b/protocol-designer/src/load-file/migration/6_0_0.ts
@@ -136,7 +136,7 @@ export const migrateFile = (
               ...acc,
               [liquidId]: {
                 displayName: liquidData.name,
-                description: liquidData.description,
+                description: liquidData.description ?? '',
               },
             }
           },

--- a/protocol-designer/src/load-file/migration/__tests__/6_0_0.test.ts
+++ b/protocol-designer/src/load-file/migration/__tests__/6_0_0.test.ts
@@ -64,7 +64,7 @@ describe('v6 migration', () => {
   })
   it('adds a liquids key', () => {
     const migratedFile = migrateFile(oldProtocol)
-    const expectedLiquids = { '0': { displayName: 'Water', description: null } }
+    const expectedLiquids = { '0': { displayName: 'Water', description: '' } }
     expect(migratedFile.liquids).toEqual(expectedLiquids)
   })
   it('creates loadModule commands', () => {


### PR DESCRIPTION
# Overview

This PR makes liquid descriptions empty strings rather than null when a user does not provide them.

closes #10001

# Changelog
- Make liquid descriptions strings

# Review requests

Export a PD protocol with liquids, do not give liquids descriptions, they should be an empty string in the JSON file.

# Risk assessment
Low
