### PR TITLE
chore(hardware): pipette sensor scripts

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
@@ -68,6 +68,7 @@ MessageDefinition = Union[
     defs.HomeRequest,
     defs.PipetteInfoRequest,
     defs.PipetteInfoResponse,
+    defs.BindSensorOutputRequest,
 ]
 
 

--- a/hardware/opentrons_hardware/scripts/monitor_sensors.py
+++ b/hardware/opentrons_hardware/scripts/monitor_sensors.py
@@ -1,0 +1,95 @@
+import asyncio
+import argparse
+import datetime
+
+
+from opentrons_hardware.drivers.can_bus.abstract_driver import AbstractCanDriver
+from opentrons_hardware.drivers.can_bus.can_messenger import (
+    CanMessenger,
+    WaitableCallback,
+)
+from opentrons_hardware.firmware_bindings import constants
+from opentrons_hardware.firmware_bindings.messages import (
+    message_definitions,
+    payloads,
+    fields,
+)
+from opentrons_hardware.sensors.utils import SensorDataType
+
+from opentrons_hardware.drivers.can_bus.build import build_driver
+from opentrons_hardware.scripts.can_args import add_can_args, build_settings
+
+
+async def do_run(
+    messenger: CanMessenger,
+    callback: WaitableCallback,
+    target_node: constants.NodeId,
+    target_sensor: constants.SensorType,
+) -> None:
+    stim_payload = payloads.BindSensorOutputRequestPayload(
+        sensor=fields.SensorTypeField(target_sensor.value),
+        binding=fields.SensorOutputBindingField(3),
+    )
+    stim_message = message_definitions.BindSensorOutputRequest(payload=stim_payload)
+    reset_payload = payloads.BindSensorOutputRequestPayload(
+        sensor=fields.SensorTypeField(target_sensor.value),
+        binding=fields.SensorOutputBindingField(0),
+    )
+    reset_message = message_definitions.BindSensorOutputRequest(payload=reset_payload)
+    print(f"Sending stimulus to {target_node.name} {target_sensor.name}")
+    await messenger.send(target_node, stim_message)
+    start = datetime.datetime.now()
+    try:
+        print("Monitoring")
+        async for message, _arbid in callback:
+            if isinstance(message, message_definitions.ReadFromSensorResponse):
+                ts = (datetime.datetime.now() - start).total_seconds()
+                s = constants.SensorType(message.payload.sensor.value).name
+                d = SensorDataType.build(message.payload.sensor_data)
+                print(f"{ts:.3f}: {s} {d.to_float():5.3f}")
+    finally:
+        print("cleaning up")
+        await messenger.send(target_node, reset_message)
+
+
+async def run(args: argparse.Namespace) -> None:
+    """Entry point for script."""
+    driver = await build_driver(build_settings(args))
+    target = constants.NodeId["pipette_" + args.mount]
+    sensor = constants.SensorType[args.sensor]
+
+    messenger = CanMessenger(driver)
+    messenger.start()
+    with WaitableCallback(messenger) as reader:
+        return await do_run(messenger, reader, target, sensor)
+
+
+def main() -> None:
+    """Entry point."""
+
+    parser = argparse.ArgumentParser(description="CAN bus testing.")
+    add_can_args(parser)
+    parser.add_argument(
+        "-m",
+        "--mount",
+        type=str,
+        choices=["left", "right"],
+        help="which mount",
+        default="right",
+    )
+    parser.add_argument(
+        "-s",
+        "--sensor",
+        type=str,
+        choices=["capacitive"],
+        help="which sensor",
+        default="capacitive",
+    )
+
+    args = parser.parse_args()
+
+    asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/hardware/opentrons_hardware/scripts/monitor_sensors.py
+++ b/hardware/opentrons_hardware/scripts/monitor_sensors.py
@@ -1,9 +1,8 @@
+"""Script to monitor sensor output."""
 import asyncio
 import argparse
 import datetime
 
-
-from opentrons_hardware.drivers.can_bus.abstract_driver import AbstractCanDriver
 from opentrons_hardware.drivers.can_bus.can_messenger import (
     CanMessenger,
     WaitableCallback,
@@ -28,6 +27,7 @@ async def do_run(
     target_sensor: constants.SensorType,
     threshold: float,
 ) -> None:
+    """Configure and start the monitoring."""
     threshold_payload = payloads.SetSensorThresholdRequestPayload(
         sensor=fields.SensorTypeField(constants.SensorType.capacitive),
         threshold=Int32Field(int(threshold * 2**15)),
@@ -76,7 +76,6 @@ async def run(args: argparse.Namespace) -> None:
 
 def main() -> None:
     """Entry point."""
-
     parser = argparse.ArgumentParser(description="CAN bus testing.")
     add_can_args(parser)
     parser.add_argument(

--- a/hardware/opentrons_hardware/scripts/sensor_pass.py
+++ b/hardware/opentrons_hardware/scripts/sensor_pass.py
@@ -4,23 +4,30 @@ import asyncio
 import logging
 from numpy import float64
 from logging.config import dictConfig
-from typing import Optional
+from typing import Optional, Iterator, List, Any, Dict
 
 from opentrons_hardware.drivers.can_bus import CanDriver
 from opentrons_hardware.drivers.can_bus.build import build_driver
 from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
 from opentrons_hardware.firmware_bindings.utils.binary_serializable import Int32Field
-from opentrons_hardware.firmware_bindings.constants import NodeId
+from opentrons_hardware.firmware_bindings.constants import NodeId, SensorType
 from opentrons_hardware.firmware_bindings.arbitration_id import ArbitrationId
 from opentrons_hardware.hardware_control.network import probe
 import opentrons_hardware.sensors.utils as sensor_utils
 
-from opentrons_hardware.firmware_bindings.messages import message_definitions, payloads
+from opentrons_hardware.firmware_bindings.messages import (
+    message_definitions,
+    payloads,
+    MessageDefinition,
+    fields,
+)
 
 from opentrons_hardware.hardware_control.motion import (
     MoveGroupSingleAxisStep,
     MoveType,
     MoveStopCondition,
+    create_home_step,
+    create_step,
 )
 from opentrons_hardware.hardware_control.move_group_runner import MoveGroupRunner
 from opentrons_hardware.scripts.can_args import add_can_args, build_settings
@@ -28,41 +35,54 @@ from opentrons_hardware.scripts.can_args import add_can_args, build_settings
 
 log = logging.getLogger(__name__)
 
-LOG_CONFIG = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "formatters": {
-        "basic": {"format": "%(asctime)s %(name)s %(levelname)s %(message)s"}
-    },
-    "handlers": {
-        "stream_handler": {
-            "class": "logging.StreamHandler",
-            "formatter": "basic",
-            "level": logging.DEBUG,
+
+def build_log_config(level: str) -> Dict[str, Any]:
+    return {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "basic": {"format": "%(asctime)s %(name)s %(levelname)s %(message)s"}
         },
-    },
-    "loggers": {
-        "": {
-            "handlers": ["stream_handler"],
-            "level": logging.DEBUG,
+        "handlers": {
+            "stream_handler": {
+                "class": "logging.StreamHandler",
+                "formatter": "basic",
+                "level": getattr(logging, level),
+            },
         },
-    },
-}
+        "loggers": {
+            "": {
+                "handlers": ["stream_handler"],
+                "level": getattr(logging, level),
+            },
+        },
+    }
 
 
 class Capturer:
     def __init__(self) -> None:
-        self.response_queue: asyncio.Queue[
-            message_definitions.ReadFromSensorResponse
-        ] = asyncio.Queue()
+        self.response_queue: asyncio.Queue[float] = asyncio.Queue()
+
+    def _do_get_all(self) -> Iterator[float]:
+        try:
+            yield self.response_queue.get_nowait()
+        except asyncio.QueueEmpty:
+            return
+
+    def get_all(self) -> List[float]:
+        return list(self._do_get_all())
 
     def __call__(
         self,
-        message: message_definitions.MessageDefinition,
+        message: MessageDefinition,
         arbitration_id: ArbitrationId,
     ) -> None:
         if isinstance(message, message_definitions.ReadFromSensorResponse):
-            self.response_queue.put_nowait(message)
+            self.response_queue.put_nowait(
+                sensor_utils.SensorDataType.build(
+                    message.payload.sensor_data
+                ).to_float()
+            )
 
 
 async def run(args: argparse.Namespace) -> None:
@@ -71,10 +91,10 @@ async def run(args: argparse.Namespace) -> None:
     messenger = CanMessenger(driver=driver)
     messenger.start()
 
-    target_z = NodeId["head_" + args.mount]
+    target_z = NodeId["head_" + args.mount[0]]
     target_pipette = NodeId["pipette_" + args.mount]
-    found = await probe(messenger, set((target_z, target_pipette)), 1)
-    if target_z not in found or target_pipette not in found:
+    found = await probe(messenger, set((NodeId.head, target_pipette)), 10)
+    if NodeId.head not in found or target_pipette not in found:
         raise RuntimeError(f"could not find targets for {args.mount} in {found}")
 
     await messenger.send(
@@ -89,49 +109,41 @@ async def run(args: argparse.Namespace) -> None:
 
     move_groups = [
         # Group 0 - home
-        [
-            {
-                target_z: MoveGroupSingleAxisStep(
-                    distance_mm=float64(0),
-                    velocity_mm_sec=float64(50),
-                    duration_sec=float64(1000),
-                    acceleration_mm_sec_sq=float64(0),
-                    stop_condition=MoveStopCondition.limit_switch,
-                    move_type=MoveType.home,
-                ),
-            },
-        ],
+        [create_home_step({target_z: float64(-1000)}, {target_z: float64(-50)})],
         # Group 1
         [
-            {
-                target_z: MoveGroupSingleAxisStep(
-                    distance_mm=float64(args.prep_distance),
-                    velocity_mm_sec=float64(args.prep_speed),
-                    duration_sec=float64(args.prep_distance / args.prep_speed),
-                ),
-            },
-            {
-                target_z: MoveGroupSingleAxisStep(
-                    distance_mm=float64(args.distance),
-                    velocity_mm_sec=float64(args.speed),
-                    duration_sec=float64(args.distance / args.speed),
-                    stop_condition=MoveStopCondition.cap_sensor,
-                    move_type=MoveType.calibration,
-                ),
-            },
+            create_step(
+                {target_z: float64(args.prep_distance)},
+                {target_z: float64(args.prep_speed)},
+                {},
+                float64(args.prep_distance / args.prep_speed),
+                [target_z],
+            ),
+            create_step(
+                {target_z: float64(args.distance)},
+                {target_z: float64(args.speed)},
+                {},
+                float64(args.distance / args.speed),
+                [target_z],
+                MoveStopCondition.cap_sensor,
+            ),
         ],
     ]
 
     threshold_payload = payloads.SetSensorThresholdRequestPayload(
         sensor=fields.SensorTypeField(SensorType.capacitive),
-        threshold=utils.Int32Field(int(args.threshold * 2**15)),
+        threshold=Int32Field(int(args.threshold * 2**15)),
     )
     threshold_message = message_definitions.SetSensorThresholdRequest(
         payload=threshold_payload
     )
+    if args.verbose_monitoring:
+        binding = 3
+    else:
+        binding = 1
     stim_payload = payloads.BindSensorOutputRequestPayload(
         sensor=fields.SensorTypeField(SensorType.capacitive),
-        binding=fields.SensorOutputBindingField(3),
+        binding=fields.SensorOutputBindingField(binding),
     )
     stim_message = message_definitions.BindSensorOutputRequest(payload=stim_payload)
     reset_payload = payloads.BindSensorOutputRequestPayload(
@@ -140,36 +152,46 @@ async def run(args: argparse.Namespace) -> None:
     )
     reset_message = message_definitions.BindSensorOutputRequest(payload=reset_payload)
     runner = MoveGroupRunner(move_groups=move_groups)
-    await can_messenger.send(target_pipette, threshold_message)
-    await can_messenger.send(target_pipette, stim_message)
-
-    try:
-        position = await runner.run(can_messenger=messenger)
-    except asyncio.CancelledError:
-        pass
-    finally:
-        await can_messenger.send(reset_message)
-        await messenger.stop()
-        driver.shutdown()
-        print(f"Position: {position[target_z]}")
+    await messenger.send(target_pipette, threshold_message)
+    await messenger.send(target_pipette, stim_message)
+    position = await runner.run(can_messenger=messenger)
+    if args.verbose_monitoring:
+        print(f"Sensor data: {sensor_cap.get_all()}")
+    print(f"Position: {position[target_z]}")
+    await messenger.send(target_pipette, reset_message)
+    await asyncio.get_running_loop().run_in_executor(
+        None, lambda: input("press enter to home")
+    )
+    runner = MoveGroupRunner(move_groups=[move_groups[0]])
+    await runner.run(can_messenger=messenger)
+    await messenger.send(NodeId.broadcast, message_definitions.DisableMotorRequest())
+    await messenger.stop()
+    driver.shutdown()
 
 
 def main() -> None:
     """Entry point."""
-    dictConfig(LOG_CONFIG)
 
     parser = argparse.ArgumentParser(description="CAN bus move.")
     add_can_args(parser)
     parser.add_argument(
-        "-m", "--mount", type="str", choices=["left", "right"], default="left"
+        "-m", "--mount", type=str, choices=["left", "right"], default="left"
     )
     parser.add_argument("-s", "--speed", type=float, default=5)
-    parser.add_argument("-d", "--distance", type=float, default=5)
-    parser.add_argument("-pd", "--prep-distance", type=float, default=50)
+    parser.add_argument("-d", "--distance", type=float, default=7)
+    parser.add_argument("-pd", "--prep-distance", type=float, default=12)
     parser.add_argument("-ps", "--prep-speed", type=float, default=50)
-    parser.add_argument("-t", "--threshold", type=float, default=30)
-
+    parser.add_argument("-t", "--threshold", type=float, default=17)
+    parser.add_argument("-v", "--verbose-monitoring", action="store_true")
+    parser.add_argument(
+        "-l",
+        "--log-level",
+        type=str,
+        choices=["INFO", "DEBUG", "WARNING", "ERROR"],
+        default="WARNING",
+    )
     args = parser.parse_args()
+    dictConfig(build_log_config(args.log_level))
 
     asyncio.run(run(args))
 

--- a/hardware/opentrons_hardware/scripts/sensor_pass.py
+++ b/hardware/opentrons_hardware/scripts/sensor_pass.py
@@ -1,0 +1,178 @@
+"""A very simple script to run a move group and wait for it to complete."""
+import argparse
+import asyncio
+import logging
+from numpy import float64
+from logging.config import dictConfig
+from typing import Optional
+
+from opentrons_hardware.drivers.can_bus import CanDriver
+from opentrons_hardware.drivers.can_bus.build import build_driver
+from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
+from opentrons_hardware.firmware_bindings.utils.binary_serializable import Int32Field
+from opentrons_hardware.firmware_bindings.constants import NodeId
+from opentrons_hardware.firmware_bindings.arbitration_id import ArbitrationId
+from opentrons_hardware.hardware_control.network import probe
+import opentrons_hardware.sensors.utils as sensor_utils
+
+from opentrons_hardware.firmware_bindings.messages import message_definitions, payloads
+
+from opentrons_hardware.hardware_control.motion import (
+    MoveGroupSingleAxisStep,
+    MoveType,
+    MoveStopCondition,
+)
+from opentrons_hardware.hardware_control.move_group_runner import MoveGroupRunner
+from opentrons_hardware.scripts.can_args import add_can_args, build_settings
+
+
+log = logging.getLogger(__name__)
+
+LOG_CONFIG = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "basic": {"format": "%(asctime)s %(name)s %(levelname)s %(message)s"}
+    },
+    "handlers": {
+        "stream_handler": {
+            "class": "logging.StreamHandler",
+            "formatter": "basic",
+            "level": logging.DEBUG,
+        },
+    },
+    "loggers": {
+        "": {
+            "handlers": ["stream_handler"],
+            "level": logging.DEBUG,
+        },
+    },
+}
+
+
+class Capturer:
+    def __init__(self) -> None:
+        self.response_queue: asyncio.Queue[
+            message_definitions.ReadFromSensorResponse
+        ] = asyncio.Queue()
+
+    def __call__(
+        self,
+        message: message_definitions.MessageDefinition,
+        arbitration_id: ArbitrationId,
+    ) -> None:
+        if isinstance(message, message_definitions.ReadFromSensorResponse):
+            self.response_queue.put_nowait(message)
+
+
+async def run(args: argparse.Namespace) -> None:
+    """Entry point for script."""
+    driver = await build_driver(build_settings(args))
+    messenger = CanMessenger(driver=driver)
+    messenger.start()
+
+    target_z = NodeId["head_" + args.mount]
+    target_pipette = NodeId["pipette_" + args.mount]
+    found = await probe(messenger, set((target_z, target_pipette)), 1)
+    if target_z not in found or target_pipette not in found:
+        raise RuntimeError(f"could not find targets for {args.mount} in {found}")
+
+    await messenger.send(
+        node_id=NodeId.broadcast, message=message_definitions.SetupRequest()
+    )
+    await messenger.send(
+        node_id=NodeId.broadcast, message=message_definitions.EnableMotorRequest()
+    )
+
+    sensor_cap = Capturer()
+    messenger.add_listener(sensor_cap, None)
+
+    move_groups = [
+        # Group 0 - home
+        [
+            {
+                target_z: MoveGroupSingleAxisStep(
+                    distance_mm=float64(0),
+                    velocity_mm_sec=float64(50),
+                    duration_sec=float64(1000),
+                    acceleration_mm_sec_sq=float64(0),
+                    stop_condition=MoveStopCondition.limit_switch,
+                    move_type=MoveType.home,
+                ),
+            },
+        ],
+        # Group 1
+        [
+            {
+                target_z: MoveGroupSingleAxisStep(
+                    distance_mm=float64(args.prep_distance),
+                    velocity_mm_sec=float64(args.prep_speed),
+                    duration_sec=float64(args.prep_distance / args.prep_speed),
+                ),
+            },
+            {
+                target_z: MoveGroupSingleAxisStep(
+                    distance_mm=float64(args.distance),
+                    velocity_mm_sec=float64(args.speed),
+                    duration_sec=float64(args.distance / args.speed),
+                    stop_condition=MoveStopCondition.cap_sensor,
+                    move_type=MoveType.calibration,
+                ),
+            },
+        ],
+    ]
+
+    threshold_payload = payloads.SetSensorThresholdRequestPayload(
+        sensor=fields.SensorTypeField(SensorType.capacitive),
+        threshold=utils.Int32Field(int(args.threshold * 2**15)),
+    )
+    threshold_message = message_definitions.SetSensorThresholdRequest(
+        payload=threshold_payload
+    )
+    stim_payload = payloads.BindSensorOutputRequestPayload(
+        sensor=fields.SensorTypeField(SensorType.capacitive),
+        binding=fields.SensorOutputBindingField(3),
+    )
+    stim_message = message_definitions.BindSensorOutputRequest(payload=stim_payload)
+    reset_payload = payloads.BindSensorOutputRequestPayload(
+        sensor=fields.SensorTypeField(SensorType.capacitive),
+        binding=fields.SensorOutputBindingField(0),
+    )
+    reset_message = message_definitions.BindSensorOutputRequest(payload=reset_payload)
+    runner = MoveGroupRunner(move_groups=move_groups)
+    await can_messenger.send(target_pipette, threshold_message)
+    await can_messenger.send(target_pipette, stim_message)
+
+    try:
+        position = await runner.run(can_messenger=messenger)
+    except asyncio.CancelledError:
+        pass
+    finally:
+        await can_messenger.send(reset_message)
+        await messenger.stop()
+        driver.shutdown()
+        print(f"Position: {position[target_z]}")
+
+
+def main() -> None:
+    """Entry point."""
+    dictConfig(LOG_CONFIG)
+
+    parser = argparse.ArgumentParser(description="CAN bus move.")
+    add_can_args(parser)
+    parser.add_argument(
+        "-m", "--mount", type="str", choices=["left", "right"], default="left"
+    )
+    parser.add_argument("-s", "--speed", type=float, default=5)
+    parser.add_argument("-d", "--distance", type=float, default=5)
+    parser.add_argument("-pd", "--prep-distance", type=float, default=50)
+    parser.add_argument("-ps", "--prep-speed", type=float, default=50)
+    parser.add_argument("-t", "--threshold", type=float, default=30)
+
+    args = parser.parse_args()
+
+    asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add message bindings and test scripts for pipette sensors.

- monitor_sensors.py will stream data from the selected sensors to test their reactivity to physical changes
- sensor_pass.py will configure the capacitive sensor (for now; later, selectable to pressure sensor) to trigger a sync line when it senses a change, and move down until the sync line is triggered.