### PR TITLE
fix(protocol-designer): delay when offset length is falsey

### DIFF
--- a/protocol-designer/fixtures/protocol/5/multipleLiquids.json
+++ b/protocol-designer/fixtures/protocol/5/multipleLiquids.json
@@ -4,16 +4,16 @@
     "author": "",
     "description": "",
     "created": 1649435471567,
-    "lastModified": 1649435581085,
+    "lastModified": 1650402453755,
     "category": null,
     "subcategory": null,
     "tags": []
   },
   "designerApplication": {
     "name": "opentrons/protocol-designer",
-    "version": "5.2.6",
+    "version": "6.0.0",
     "data": {
-      "_internalAppBuildDate": "Mon, 26 Apr 2021 18:42:28 GMT",
+      "_internalAppBuildDate": "Tue, 19 Apr 2022 14:26:07 GMT",
       "defaultValues": {
         "aspirate_mmFromBottom": 1,
         "dispense_mmFromBottom": 0.5,
@@ -172,8 +172,6 @@
       },
       "savedStepForms": {
         "__INITIAL_DECK_SETUP_STEP__": {
-          "stepType": "manualIntervention",
-          "id": "__INITIAL_DECK_SETUP_STEP__",
           "labwareLocationUpdate": {
             "trashId": "12",
             "4d253860-b759-11ec-81e8-7fa12dc3e861:opentrons/opentrons_96_filtertiprack_20ul/1": "1",
@@ -183,40 +181,88 @@
           "pipetteLocationUpdate": {
             "4d23ffe0-b759-11ec-81e8-7fa12dc3e861": "left"
           },
-          "moduleLocationUpdate": {}
+          "moduleLocationUpdate": {},
+          "stepType": "manualIntervention",
+          "id": "__INITIAL_DECK_SETUP_STEP__"
+        },
+        "b98d3ec0-c024-11ec-aabf-8ff28455296a": {
+          "id": "b98d3ec0-c024-11ec-aabf-8ff28455296a",
+          "stepType": "moveLiquid",
+          "stepName": "transfer",
+          "stepDetails": "",
+          "pipette": "4d23ffe0-b759-11ec-81e8-7fa12dc3e861",
+          "volume": "22",
+          "changeTip": "always",
+          "path": "single",
+          "aspirate_wells_grouped": false,
+          "aspirate_flowRate": null,
+          "aspirate_labware": "6114d3d0-b759-11ec-81e8-7fa12dc3e861:opentrons/opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap/1",
+          "aspirate_wells": ["A1"],
+          "aspirate_wellOrder_first": "t2b",
+          "aspirate_wellOrder_second": "l2r",
+          "aspirate_mix_checkbox": false,
+          "aspirate_mix_times": null,
+          "aspirate_mix_volume": null,
+          "aspirate_mmFromBottom": null,
+          "aspirate_touchTip_checkbox": false,
+          "aspirate_touchTip_mmFromBottom": null,
+          "dispense_flowRate": null,
+          "dispense_labware": "64c66a20-b759-11ec-81e8-7fa12dc3e861:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+          "dispense_wells": ["A12"],
+          "dispense_wellOrder_first": "t2b",
+          "dispense_wellOrder_second": "l2r",
+          "dispense_mix_checkbox": false,
+          "dispense_mix_times": null,
+          "dispense_mix_volume": null,
+          "dispense_mmFromBottom": null,
+          "dispense_touchTip_checkbox": false,
+          "dispense_touchTip_mmFromBottom": null,
+          "disposalVolume_checkbox": true,
+          "disposalVolume_volume": "20",
+          "blowout_checkbox": false,
+          "blowout_location": "trashId",
+          "preWetTip": false,
+          "aspirate_airGap_checkbox": false,
+          "aspirate_airGap_volume": "0",
+          "aspirate_delay_checkbox": true,
+          "aspirate_delay_mmFromBottom": 0,
+          "aspirate_delay_seconds": "1",
+          "dispense_airGap_checkbox": false,
+          "dispense_airGap_volume": "20",
+          "dispense_delay_checkbox": true,
+          "dispense_delay_seconds": "1",
+          "dispense_delay_mmFromBottom": 0
         }
       },
-      "orderedStepIds": []
+      "orderedStepIds": ["b98d3ec0-c024-11ec-aabf-8ff28455296a"]
     }
   },
-  "robot": { "model": "OT-2 Standard" },
+  "robot": { "model": "OT-2 Standard", "deckId": "ot2_standard" },
   "pipettes": {
-    "4d23ffe0-b759-11ec-81e8-7fa12dc3e861": {
-      "mount": "left",
-      "name": "p300_single_gen2"
-    }
+    "4d23ffe0-b759-11ec-81e8-7fa12dc3e861": { "name": "p300_single_gen2" }
   },
   "labware": {
     "trashId": {
-      "slot": "12",
       "displayName": "Trash",
       "definitionId": "opentrons/opentrons_1_trash_1100ml_fixed/1"
     },
     "4d253860-b759-11ec-81e8-7fa12dc3e861:opentrons/opentrons_96_filtertiprack_20ul/1": {
-      "slot": "1",
       "displayName": "Opentrons 96 Filter Tip Rack 20 µL",
       "definitionId": "opentrons/opentrons_96_filtertiprack_20ul/1"
     },
     "6114d3d0-b759-11ec-81e8-7fa12dc3e861:opentrons/opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap/1": {
-      "slot": "10",
       "displayName": "Opentrons 24 Tube Rack with Eppendorf 1.5 mL Safe-Lock Snapcap",
       "definitionId": "opentrons/opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap/1"
     },
     "64c66a20-b759-11ec-81e8-7fa12dc3e861:opentrons/usascientific_96_wellplate_2.4ml_deep/1": {
-      "slot": "8",
       "displayName": "USA Scientific 96 Deep Well Plate 2.4 mL",
       "definitionId": "opentrons/usascientific_96_wellplate_2.4ml_deep/1"
     }
+  },
+  "liquids": {
+    "0": { "displayName": "water", "description": "water" },
+    "1": { "displayName": "plasma", "description": "plasma" },
+    "2": { "displayName": "vinegar", "description": "vinegar" }
   },
   "labwareDefinitions": {
     "opentrons/opentrons_96_filtertiprack_20ul/1": {
@@ -2690,6 +2736,297 @@
       "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
     }
   },
-  "schemaVersion": 3,
-  "commands": []
+  "$otSharedSchema": "#/protocol/schemas/6",
+  "schemaVersion": 6,
+  "modules": {},
+  "commands": [
+    {
+      "key": "bb6e0cb0-c024-11ec-aabf-8ff28455296a",
+      "commandType": "loadPipette",
+      "params": {
+        "pipetteId": "4d23ffe0-b759-11ec-81e8-7fa12dc3e861",
+        "mount": "left"
+      }
+    },
+    {
+      "key": "bb6e0cb1-c024-11ec-aabf-8ff28455296a",
+      "commandType": "loadLabware",
+      "params": {
+        "labwareId": "4d253860-b759-11ec-81e8-7fa12dc3e861:opentrons/opentrons_96_filtertiprack_20ul/1",
+        "location": { "slotName": "1" }
+      }
+    },
+    {
+      "key": "bb6e0cb2-c024-11ec-aabf-8ff28455296a",
+      "commandType": "loadLabware",
+      "params": {
+        "labwareId": "6114d3d0-b759-11ec-81e8-7fa12dc3e861:opentrons/opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap/1",
+        "location": { "slotName": "10" }
+      }
+    },
+    {
+      "key": "bb6e0cb3-c024-11ec-aabf-8ff28455296a",
+      "commandType": "loadLabware",
+      "params": {
+        "labwareId": "64c66a20-b759-11ec-81e8-7fa12dc3e861:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "location": { "slotName": "8" }
+      }
+    },
+    {
+      "commandType": "loadLiquid",
+      "key": "bb6e33c3-c024-11ec-aabf-8ff28455296a",
+      "params": {
+        "liquidId": "2",
+        "labwareId": "6114d3d0-b759-11ec-81e8-7fa12dc3e861:opentrons/opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap/1",
+        "volumeByWell": {
+          "A5": 444,
+          "B5": 444,
+          "C5": 444,
+          "D5": 444,
+          "A6": 444,
+          "B6": 444,
+          "C6": 444,
+          "D6": 444
+        }
+      }
+    },
+    {
+      "commandType": "loadLiquid",
+      "key": "bb6e5ad0-c024-11ec-aabf-8ff28455296a",
+      "params": {
+        "liquidId": "2",
+        "labwareId": "64c66a20-b759-11ec-81e8-7fa12dc3e861:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "volumeByWell": {
+          "A7": 777,
+          "B7": 777,
+          "C7": 777,
+          "D7": 777,
+          "E7": 777,
+          "F7": 777,
+          "G7": 777,
+          "H7": 777,
+          "A8": 777,
+          "B8": 777,
+          "C8": 777,
+          "D8": 777,
+          "E8": 777,
+          "F8": 777,
+          "G8": 777,
+          "H8": 777,
+          "A9": 777,
+          "B9": 777,
+          "C9": 777,
+          "D9": 777,
+          "E9": 777,
+          "F9": 777,
+          "G9": 777,
+          "H9": 777,
+          "A10": 777,
+          "B10": 777,
+          "C10": 777,
+          "D10": 777,
+          "E10": 777,
+          "F10": 777,
+          "G10": 777,
+          "H10": 777,
+          "A11": 777,
+          "B11": 777,
+          "C11": 777,
+          "D11": 777,
+          "E11": 777,
+          "F11": 777,
+          "G11": 777,
+          "H11": 777,
+          "A12": 777,
+          "B12": 777,
+          "C12": 777,
+          "D12": 777,
+          "E12": 777,
+          "F12": 777,
+          "G12": 777,
+          "H12": 777
+        }
+      }
+    },
+    {
+      "commandType": "loadLiquid",
+      "key": "bb6e33c1-c024-11ec-aabf-8ff28455296a",
+      "params": {
+        "liquidId": "1",
+        "labwareId": "6114d3d0-b759-11ec-81e8-7fa12dc3e861:opentrons/opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap/1",
+        "volumeByWell": {
+          "A3": 333,
+          "B3": 333,
+          "C3": 333,
+          "D3": 333,
+          "A4": 333,
+          "B4": 333,
+          "C4": 333,
+          "D4": 333
+        }
+      }
+    },
+    {
+      "commandType": "loadLiquid",
+      "key": "bb6e33c2-c024-11ec-aabf-8ff28455296a",
+      "params": {
+        "liquidId": "1",
+        "labwareId": "64c66a20-b759-11ec-81e8-7fa12dc3e861:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "volumeByWell": {
+          "A4": 666,
+          "B4": 666,
+          "C4": 666,
+          "D4": 666,
+          "E4": 666,
+          "F4": 666,
+          "G4": 666,
+          "H4": 666,
+          "A5": 666,
+          "B5": 666,
+          "C5": 666,
+          "D5": 666,
+          "E5": 666,
+          "F5": 666,
+          "G5": 666,
+          "H5": 666,
+          "A6": 666,
+          "B6": 666,
+          "C6": 666,
+          "D6": 666,
+          "E6": 666,
+          "F6": 666,
+          "G6": 666,
+          "H6": 666
+        }
+      }
+    },
+    {
+      "commandType": "loadLiquid",
+      "key": "bb6e0cb4-c024-11ec-aabf-8ff28455296a",
+      "params": {
+        "liquidId": "0",
+        "labwareId": "6114d3d0-b759-11ec-81e8-7fa12dc3e861:opentrons/opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap/1",
+        "volumeByWell": {
+          "A1": 222,
+          "B1": 222,
+          "C1": 222,
+          "D1": 222,
+          "A2": 222,
+          "B2": 222,
+          "C2": 222,
+          "D2": 222
+        }
+      }
+    },
+    {
+      "commandType": "loadLiquid",
+      "key": "bb6e33c0-c024-11ec-aabf-8ff28455296a",
+      "params": {
+        "liquidId": "0",
+        "labwareId": "64c66a20-b759-11ec-81e8-7fa12dc3e861:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "volumeByWell": {
+          "A1": 555,
+          "B1": 555,
+          "C1": 555,
+          "D1": 555,
+          "E1": 555,
+          "F1": 555,
+          "G1": 555,
+          "H1": 555,
+          "A2": 555,
+          "B2": 555,
+          "C2": 555,
+          "D2": 555,
+          "E2": 555,
+          "F2": 555,
+          "G2": 555,
+          "H2": 555,
+          "A3": 555,
+          "B3": 555,
+          "C3": 555,
+          "D3": 555,
+          "E3": 555,
+          "F3": 555,
+          "G3": 555,
+          "H3": 555
+        }
+      }
+    },
+    {
+      "commandType": "pickUpTip",
+      "params": {
+        "pipetteId": "4d23ffe0-b759-11ec-81e8-7fa12dc3e861",
+        "labwareId": "4d253860-b759-11ec-81e8-7fa12dc3e861:opentrons/opentrons_96_filtertiprack_20ul/1",
+        "wellName": "A1"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "params": {
+        "pipetteId": "4d23ffe0-b759-11ec-81e8-7fa12dc3e861",
+        "volume": 11,
+        "labwareId": "6114d3d0-b759-11ec-81e8-7fa12dc3e861:opentrons/opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap/1",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 46.43
+      }
+    },
+    {
+      "commandType": "dispense",
+      "params": {
+        "pipetteId": "4d23ffe0-b759-11ec-81e8-7fa12dc3e861",
+        "volume": 11,
+        "labwareId": "64c66a20-b759-11ec-81e8-7fa12dc3e861:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A12",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+        "flowRate": 46.43
+      }
+    },
+    {
+      "commandType": "dropTip",
+      "params": {
+        "pipetteId": "4d23ffe0-b759-11ec-81e8-7fa12dc3e861",
+        "labwareId": "trashId",
+        "wellName": "A1"
+      }
+    },
+    {
+      "commandType": "pickUpTip",
+      "params": {
+        "pipetteId": "4d23ffe0-b759-11ec-81e8-7fa12dc3e861",
+        "labwareId": "4d253860-b759-11ec-81e8-7fa12dc3e861:opentrons/opentrons_96_filtertiprack_20ul/1",
+        "wellName": "B1"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "params": {
+        "pipetteId": "4d23ffe0-b759-11ec-81e8-7fa12dc3e861",
+        "volume": 11,
+        "labwareId": "6114d3d0-b759-11ec-81e8-7fa12dc3e861:opentrons/opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap/1",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 46.43
+      }
+    },
+    {
+      "commandType": "dispense",
+      "params": {
+        "pipetteId": "4d23ffe0-b759-11ec-81e8-7fa12dc3e861",
+        "volume": 11,
+        "labwareId": "64c66a20-b759-11ec-81e8-7fa12dc3e861:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A12",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+        "flowRate": 46.43
+      }
+    },
+    {
+      "commandType": "dropTip",
+      "params": {
+        "pipetteId": "4d23ffe0-b759-11ec-81e8-7fa12dc3e861",
+        "labwareId": "trashId",
+        "wellName": "A1"
+      }
+    }
+  ]
 }

--- a/protocol-designer/fixtures/protocol/5/multipleLiquids.json
+++ b/protocol-designer/fixtures/protocol/5/multipleLiquids.json
@@ -4,16 +4,16 @@
     "author": "",
     "description": "",
     "created": 1649435471567,
-    "lastModified": 1650402453755,
+    "lastModified": 1649435581085,
     "category": null,
     "subcategory": null,
     "tags": []
   },
   "designerApplication": {
     "name": "opentrons/protocol-designer",
-    "version": "6.0.0",
+    "version": "5.2.6",
     "data": {
-      "_internalAppBuildDate": "Tue, 19 Apr 2022 14:26:07 GMT",
+      "_internalAppBuildDate": "Mon, 26 Apr 2021 18:42:28 GMT",
       "defaultValues": {
         "aspirate_mmFromBottom": 1,
         "dispense_mmFromBottom": 0.5,
@@ -172,6 +172,8 @@
       },
       "savedStepForms": {
         "__INITIAL_DECK_SETUP_STEP__": {
+          "stepType": "manualIntervention",
+          "id": "__INITIAL_DECK_SETUP_STEP__",
           "labwareLocationUpdate": {
             "trashId": "12",
             "4d253860-b759-11ec-81e8-7fa12dc3e861:opentrons/opentrons_96_filtertiprack_20ul/1": "1",
@@ -181,9 +183,7 @@
           "pipetteLocationUpdate": {
             "4d23ffe0-b759-11ec-81e8-7fa12dc3e861": "left"
           },
-          "moduleLocationUpdate": {},
-          "stepType": "manualIntervention",
-          "id": "__INITIAL_DECK_SETUP_STEP__"
+          "moduleLocationUpdate": {}
         },
         "b98d3ec0-c024-11ec-aabf-8ff28455296a": {
           "id": "b98d3ec0-c024-11ec-aabf-8ff28455296a",
@@ -237,32 +237,34 @@
       "orderedStepIds": ["b98d3ec0-c024-11ec-aabf-8ff28455296a"]
     }
   },
-  "robot": { "model": "OT-2 Standard", "deckId": "ot2_standard" },
+  "robot": { "model": "OT-2 Standard" },
   "pipettes": {
-    "4d23ffe0-b759-11ec-81e8-7fa12dc3e861": { "name": "p300_single_gen2" }
+    "4d23ffe0-b759-11ec-81e8-7fa12dc3e861": {
+      "mount": "left",
+      "name": "p300_single_gen2"
+    }
   },
   "labware": {
     "trashId": {
+      "slot": "12",
       "displayName": "Trash",
       "definitionId": "opentrons/opentrons_1_trash_1100ml_fixed/1"
     },
     "4d253860-b759-11ec-81e8-7fa12dc3e861:opentrons/opentrons_96_filtertiprack_20ul/1": {
+      "slot": "1",
       "displayName": "Opentrons 96 Filter Tip Rack 20 µL",
       "definitionId": "opentrons/opentrons_96_filtertiprack_20ul/1"
     },
     "6114d3d0-b759-11ec-81e8-7fa12dc3e861:opentrons/opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap/1": {
+      "slot": "10",
       "displayName": "Opentrons 24 Tube Rack with Eppendorf 1.5 mL Safe-Lock Snapcap",
       "definitionId": "opentrons/opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap/1"
     },
     "64c66a20-b759-11ec-81e8-7fa12dc3e861:opentrons/usascientific_96_wellplate_2.4ml_deep/1": {
+      "slot": "8",
       "displayName": "USA Scientific 96 Deep Well Plate 2.4 mL",
       "definitionId": "opentrons/usascientific_96_wellplate_2.4ml_deep/1"
     }
-  },
-  "liquids": {
-    "0": { "displayName": "water", "description": "water" },
-    "1": { "displayName": "plasma", "description": "plasma" },
-    "2": { "displayName": "vinegar", "description": "vinegar" }
   },
   "labwareDefinitions": {
     "opentrons/opentrons_96_filtertiprack_20ul/1": {
@@ -2736,297 +2738,6 @@
       "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
     }
   },
-  "$otSharedSchema": "#/protocol/schemas/6",
-  "schemaVersion": 6,
-  "modules": {},
-  "commands": [
-    {
-      "key": "bb6e0cb0-c024-11ec-aabf-8ff28455296a",
-      "commandType": "loadPipette",
-      "params": {
-        "pipetteId": "4d23ffe0-b759-11ec-81e8-7fa12dc3e861",
-        "mount": "left"
-      }
-    },
-    {
-      "key": "bb6e0cb1-c024-11ec-aabf-8ff28455296a",
-      "commandType": "loadLabware",
-      "params": {
-        "labwareId": "4d253860-b759-11ec-81e8-7fa12dc3e861:opentrons/opentrons_96_filtertiprack_20ul/1",
-        "location": { "slotName": "1" }
-      }
-    },
-    {
-      "key": "bb6e0cb2-c024-11ec-aabf-8ff28455296a",
-      "commandType": "loadLabware",
-      "params": {
-        "labwareId": "6114d3d0-b759-11ec-81e8-7fa12dc3e861:opentrons/opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap/1",
-        "location": { "slotName": "10" }
-      }
-    },
-    {
-      "key": "bb6e0cb3-c024-11ec-aabf-8ff28455296a",
-      "commandType": "loadLabware",
-      "params": {
-        "labwareId": "64c66a20-b759-11ec-81e8-7fa12dc3e861:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "location": { "slotName": "8" }
-      }
-    },
-    {
-      "commandType": "loadLiquid",
-      "key": "bb6e33c3-c024-11ec-aabf-8ff28455296a",
-      "params": {
-        "liquidId": "2",
-        "labwareId": "6114d3d0-b759-11ec-81e8-7fa12dc3e861:opentrons/opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap/1",
-        "volumeByWell": {
-          "A5": 444,
-          "B5": 444,
-          "C5": 444,
-          "D5": 444,
-          "A6": 444,
-          "B6": 444,
-          "C6": 444,
-          "D6": 444
-        }
-      }
-    },
-    {
-      "commandType": "loadLiquid",
-      "key": "bb6e5ad0-c024-11ec-aabf-8ff28455296a",
-      "params": {
-        "liquidId": "2",
-        "labwareId": "64c66a20-b759-11ec-81e8-7fa12dc3e861:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "volumeByWell": {
-          "A7": 777,
-          "B7": 777,
-          "C7": 777,
-          "D7": 777,
-          "E7": 777,
-          "F7": 777,
-          "G7": 777,
-          "H7": 777,
-          "A8": 777,
-          "B8": 777,
-          "C8": 777,
-          "D8": 777,
-          "E8": 777,
-          "F8": 777,
-          "G8": 777,
-          "H8": 777,
-          "A9": 777,
-          "B9": 777,
-          "C9": 777,
-          "D9": 777,
-          "E9": 777,
-          "F9": 777,
-          "G9": 777,
-          "H9": 777,
-          "A10": 777,
-          "B10": 777,
-          "C10": 777,
-          "D10": 777,
-          "E10": 777,
-          "F10": 777,
-          "G10": 777,
-          "H10": 777,
-          "A11": 777,
-          "B11": 777,
-          "C11": 777,
-          "D11": 777,
-          "E11": 777,
-          "F11": 777,
-          "G11": 777,
-          "H11": 777,
-          "A12": 777,
-          "B12": 777,
-          "C12": 777,
-          "D12": 777,
-          "E12": 777,
-          "F12": 777,
-          "G12": 777,
-          "H12": 777
-        }
-      }
-    },
-    {
-      "commandType": "loadLiquid",
-      "key": "bb6e33c1-c024-11ec-aabf-8ff28455296a",
-      "params": {
-        "liquidId": "1",
-        "labwareId": "6114d3d0-b759-11ec-81e8-7fa12dc3e861:opentrons/opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap/1",
-        "volumeByWell": {
-          "A3": 333,
-          "B3": 333,
-          "C3": 333,
-          "D3": 333,
-          "A4": 333,
-          "B4": 333,
-          "C4": 333,
-          "D4": 333
-        }
-      }
-    },
-    {
-      "commandType": "loadLiquid",
-      "key": "bb6e33c2-c024-11ec-aabf-8ff28455296a",
-      "params": {
-        "liquidId": "1",
-        "labwareId": "64c66a20-b759-11ec-81e8-7fa12dc3e861:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "volumeByWell": {
-          "A4": 666,
-          "B4": 666,
-          "C4": 666,
-          "D4": 666,
-          "E4": 666,
-          "F4": 666,
-          "G4": 666,
-          "H4": 666,
-          "A5": 666,
-          "B5": 666,
-          "C5": 666,
-          "D5": 666,
-          "E5": 666,
-          "F5": 666,
-          "G5": 666,
-          "H5": 666,
-          "A6": 666,
-          "B6": 666,
-          "C6": 666,
-          "D6": 666,
-          "E6": 666,
-          "F6": 666,
-          "G6": 666,
-          "H6": 666
-        }
-      }
-    },
-    {
-      "commandType": "loadLiquid",
-      "key": "bb6e0cb4-c024-11ec-aabf-8ff28455296a",
-      "params": {
-        "liquidId": "0",
-        "labwareId": "6114d3d0-b759-11ec-81e8-7fa12dc3e861:opentrons/opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap/1",
-        "volumeByWell": {
-          "A1": 222,
-          "B1": 222,
-          "C1": 222,
-          "D1": 222,
-          "A2": 222,
-          "B2": 222,
-          "C2": 222,
-          "D2": 222
-        }
-      }
-    },
-    {
-      "commandType": "loadLiquid",
-      "key": "bb6e33c0-c024-11ec-aabf-8ff28455296a",
-      "params": {
-        "liquidId": "0",
-        "labwareId": "64c66a20-b759-11ec-81e8-7fa12dc3e861:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "volumeByWell": {
-          "A1": 555,
-          "B1": 555,
-          "C1": 555,
-          "D1": 555,
-          "E1": 555,
-          "F1": 555,
-          "G1": 555,
-          "H1": 555,
-          "A2": 555,
-          "B2": 555,
-          "C2": 555,
-          "D2": 555,
-          "E2": 555,
-          "F2": 555,
-          "G2": 555,
-          "H2": 555,
-          "A3": 555,
-          "B3": 555,
-          "C3": 555,
-          "D3": 555,
-          "E3": 555,
-          "F3": 555,
-          "G3": 555,
-          "H3": 555
-        }
-      }
-    },
-    {
-      "commandType": "pickUpTip",
-      "params": {
-        "pipetteId": "4d23ffe0-b759-11ec-81e8-7fa12dc3e861",
-        "labwareId": "4d253860-b759-11ec-81e8-7fa12dc3e861:opentrons/opentrons_96_filtertiprack_20ul/1",
-        "wellName": "A1"
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "params": {
-        "pipetteId": "4d23ffe0-b759-11ec-81e8-7fa12dc3e861",
-        "volume": 11,
-        "labwareId": "6114d3d0-b759-11ec-81e8-7fa12dc3e861:opentrons/opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap/1",
-        "wellName": "A1",
-        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-        "flowRate": 46.43
-      }
-    },
-    {
-      "commandType": "dispense",
-      "params": {
-        "pipetteId": "4d23ffe0-b759-11ec-81e8-7fa12dc3e861",
-        "volume": 11,
-        "labwareId": "64c66a20-b759-11ec-81e8-7fa12dc3e861:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A12",
-        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 46.43
-      }
-    },
-    {
-      "commandType": "dropTip",
-      "params": {
-        "pipetteId": "4d23ffe0-b759-11ec-81e8-7fa12dc3e861",
-        "labwareId": "trashId",
-        "wellName": "A1"
-      }
-    },
-    {
-      "commandType": "pickUpTip",
-      "params": {
-        "pipetteId": "4d23ffe0-b759-11ec-81e8-7fa12dc3e861",
-        "labwareId": "4d253860-b759-11ec-81e8-7fa12dc3e861:opentrons/opentrons_96_filtertiprack_20ul/1",
-        "wellName": "B1"
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "params": {
-        "pipetteId": "4d23ffe0-b759-11ec-81e8-7fa12dc3e861",
-        "volume": 11,
-        "labwareId": "6114d3d0-b759-11ec-81e8-7fa12dc3e861:opentrons/opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap/1",
-        "wellName": "A1",
-        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-        "flowRate": 46.43
-      }
-    },
-    {
-      "commandType": "dispense",
-      "params": {
-        "pipetteId": "4d23ffe0-b759-11ec-81e8-7fa12dc3e861",
-        "volume": 11,
-        "labwareId": "64c66a20-b759-11ec-81e8-7fa12dc3e861:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A12",
-        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 46.43
-      }
-    },
-    {
-      "commandType": "dropTip",
-      "params": {
-        "pipetteId": "4d23ffe0-b759-11ec-81e8-7fa12dc3e861",
-        "labwareId": "trashId",
-        "wellName": "A1"
-      }
-    }
-  ]
+  "schemaVersion": 3,
+  "commands": []
 }

--- a/protocol-designer/src/load-file/migration/6_0_0.ts
+++ b/protocol-designer/src/load-file/migration/6_0_0.ts
@@ -30,8 +30,7 @@ const SCHEMA_VERSION = 6
 export const migrateSavedStepForms = (
   savedStepForms?: Record<string, any>
 ): Record<string, any> => {
-  // uncheck asp + disp delay checkbox if the offset is 0 or null as before they were not getting registered because of a bug
-  // because of a bug. see https://github.com/Opentrons/opentrons/issues/8153
+  // uncheck asp + disp delay checkbox if the offset is 0 or null, see https://github.com/Opentrons/opentrons/issues/8153
   return mapValues(savedStepForms, stepForm => {
     if (stepForm.stepType === 'moveLiquid') {
       let migratedStepForm = { ...stepForm }

--- a/protocol-designer/src/load-file/migration/6_0_0.ts
+++ b/protocol-designer/src/load-file/migration/6_0_0.ts
@@ -27,6 +27,39 @@ import type { DesignerApplicationData } from './utils/getLoadLiquidCommands'
 const PD_VERSION = '6.0.0'
 const SCHEMA_VERSION = 6
 
+export const migrateSavedStepForms = (
+  savedStepForms?: Record<string, any>
+): Record<string, any> => {
+  // uncheck asp + disp delay checkbox if the offset is 0 or null as before they were not getting registered because of a bug
+  // because of a bug. see https://github.com/Opentrons/opentrons/issues/8153
+  return mapValues(savedStepForms, stepForm => {
+    if (stepForm.stepType === 'moveLiquid') {
+      let migratedStepForm = { ...stepForm }
+      if (
+        stepForm.aspirate_delay_checkbox === true &&
+        (stepForm.aspirate_delay_mmFromBottom === null || stepForm.aspirate_delay_mmFromBottom === 0)
+      ) {
+
+        migratedStepForm = {
+          ...migratedStepForm,
+          aspirate_delay_checkbox: false,
+        }
+      }
+      if (
+        stepForm.dispense_delay_checkbox === true &&
+        (stepForm.dispense_delay_mmFromBottom === null || stepForm.dispense_delay_mmFromBottom === 0)
+      ) {
+        migratedStepForm = {
+          ...migratedStepForm,
+          dispense_delay_checkbox: false,
+        }
+      }
+      return migratedStepForm
+    }
+    return stepForm
+  })
+}
+
 const migratePipettes = (appData: Record<string, any>): Record<string, any> =>
   mapValues(appData, pipettes => omit(pipettes, 'mount'))
 
@@ -143,13 +176,18 @@ export const migrateFile = (
           {}
         )
       : // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        ({} as ProtocolFile['liquids'])
-
+      ({} as ProtocolFile['liquids'])
   return {
     ...appData,
     designerApplication: {
       ...appData.designerApplication,
       version: PD_VERSION,
+      data: {
+        ...appData.designerApplication?.data,
+        savedStepForms: migrateSavedStepForms(
+          appData.designerApplication?.data?.savedStepForms
+        ),
+      },
     },
     schemaVersion: SCHEMA_VERSION,
     $otSharedSchema: '#/protocol/schemas/6',

--- a/protocol-designer/src/load-file/migration/6_0_0.ts
+++ b/protocol-designer/src/load-file/migration/6_0_0.ts
@@ -164,20 +164,20 @@ export const migrateFile = (
   const liquids: ProtocolFile['liquids'] =
     appData.designerApplication?.data?.ingredients != null
       ? reduce(
-        appData.designerApplication?.data?.ingredients,
-        (acc, liquidData, liquidId) => {
-          return {
-            ...acc,
-            [liquidId]: {
-              displayName: liquidData.name,
-              description: liquidData.description ?? '',
-            },
-          }
-        },
-        {}
-      )
+          appData.designerApplication?.data?.ingredients,
+          (acc, liquidData, liquidId) => {
+            return {
+              ...acc,
+              [liquidId]: {
+                displayName: liquidData.name,
+                description: liquidData.description ?? '',
+              },
+            }
+          },
+          {}
+        )
       : // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      ({} as ProtocolFile['liquids'])
+        ({} as ProtocolFile['liquids'])
   return {
     ...appData,
     designerApplication: {

--- a/protocol-designer/src/load-file/migration/6_0_0.ts
+++ b/protocol-designer/src/load-file/migration/6_0_0.ts
@@ -37,9 +37,9 @@ export const migrateSavedStepForms = (
       let migratedStepForm = { ...stepForm }
       if (
         stepForm.aspirate_delay_checkbox === true &&
-        (stepForm.aspirate_delay_mmFromBottom === null || stepForm.aspirate_delay_mmFromBottom === 0)
+        (stepForm.aspirate_delay_mmFromBottom === null ||
+          stepForm.aspirate_delay_mmFromBottom === 0)
       ) {
-
         migratedStepForm = {
           ...migratedStepForm,
           aspirate_delay_checkbox: false,
@@ -47,7 +47,8 @@ export const migrateSavedStepForms = (
       }
       if (
         stepForm.dispense_delay_checkbox === true &&
-        (stepForm.dispense_delay_mmFromBottom === null || stepForm.dispense_delay_mmFromBottom === 0)
+        (stepForm.dispense_delay_mmFromBottom === null ||
+          stepForm.dispense_delay_mmFromBottom === 0)
       ) {
         migratedStepForm = {
           ...migratedStepForm,
@@ -163,18 +164,18 @@ export const migrateFile = (
   const liquids: ProtocolFile['liquids'] =
     appData.designerApplication?.data?.ingredients != null
       ? reduce(
-          appData.designerApplication?.data?.ingredients,
-          (acc, liquidData, liquidId) => {
-            return {
-              ...acc,
-              [liquidId]: {
-                displayName: liquidData.name,
-                description: liquidData.description ?? '',
-              },
-            }
-          },
-          {}
-        )
+        appData.designerApplication?.data?.ingredients,
+        (acc, liquidData, liquidId) => {
+          return {
+            ...acc,
+            [liquidId]: {
+              displayName: liquidData.name,
+              description: liquidData.description ?? '',
+            },
+          }
+        },
+        {}
+      )
       : // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       ({} as ProtocolFile['liquids'])
   return {

--- a/protocol-designer/src/load-file/migration/__tests__/6_0_0.test.ts
+++ b/protocol-designer/src/load-file/migration/__tests__/6_0_0.test.ts
@@ -204,8 +204,15 @@ describe('v6 migration', () => {
   it('unchecks aspirate delay and dispense delay when no offset was applied', () => {
     const migratedFile = migrateFile(oldMultipleLiquidsProtocol)
     const TRANSFER_STEP_ID = 'b98d3ec0-c024-11ec-aabf-8ff28455296a' // this is just taken from the fixture
-    expect((migratedFile as any).designerApplication.data.savedStepForms[TRANSFER_STEP_ID].aspirate_delay_checkbox).toBe(false)
-    expect((migratedFile as any).designerApplication.data.savedStepForms[TRANSFER_STEP_ID].dispense_delay_checkbox).toBe(false)
-
+    expect(
+      (migratedFile as any).designerApplication.data.savedStepForms[
+        TRANSFER_STEP_ID
+      ].aspirate_delay_checkbox
+    ).toBe(false)
+    expect(
+      (migratedFile as any).designerApplication.data.savedStepForms[
+        TRANSFER_STEP_ID
+      ].dispense_delay_checkbox
+    ).toBe(false)
   })
 })

--- a/protocol-designer/src/load-file/migration/__tests__/6_0_0.test.ts
+++ b/protocol-designer/src/load-file/migration/__tests__/6_0_0.test.ts
@@ -65,7 +65,7 @@ describe('v6 migration', () => {
     })
   })
   it('adds a liquids key', () => {
-    const migratedFile = migrateFile(oldProtocol)
+    const migratedFile = migrateFile(oldDoItAllProtocol)
     const expectedLiquids = { '0': { displayName: 'Water', description: '' } }
     expect(migratedFile.liquids).toEqual(expectedLiquids)
   })

--- a/protocol-designer/src/load-file/migration/utils/getLoadLiquidCommands.ts
+++ b/protocol-designer/src/load-file/migration/utils/getLoadLiquidCommands.ts
@@ -16,6 +16,7 @@ export interface DesignerApplicationData {
       [wellName: string]: { [liquidId: string]: { volume: number } }
     }
   }
+  savedStepForms: Record<string, any>
 }
 
 export const getLoadLiquidCommands = (

--- a/protocol-designer/src/steplist/fieldLevel/index.ts
+++ b/protocol-designer/src/steplist/fieldLevel/index.ts
@@ -11,6 +11,7 @@ import {
 import {
   maskToInteger,
   maskToFloat,
+  numberOrNull,
   onlyPositiveNumbers,
   defaultTo,
   composeMaskers,
@@ -142,14 +143,14 @@ const stepFieldHelperMap: Record<StepFieldName, StepFieldHelpers> = {
     castValue: Number,
   },
   aspirate_delay_mmFromBottom: {
-    castValue: Number,
+    castValue: numberOrNull,
   },
   dispense_delay_seconds: {
     maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers, defaultTo(1)),
     castValue: Number,
   },
   dispense_delay_mmFromBottom: {
-    castValue: Number,
+    castValue: numberOrNull,
   },
   pauseHour: {
     maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),

--- a/protocol-designer/src/steplist/fieldLevel/processing.ts
+++ b/protocol-designer/src/steplist/fieldLevel/processing.ts
@@ -23,7 +23,14 @@ export const trimDecimals = (
   const trimRegex = new RegExp(`(\\d*[.]{1}\\d{${decimals}})(\\d*)`)
   return String(rawValue).replace(trimRegex, (match, group1) => group1)
 }
-
+// if it's null, keep it null. Otherwise, try to cast to number
+export const numberOrNull = (rawValue: unknown): number | null => {
+  if (rawValue === null) {
+    return null
+  } else {
+    return Number(rawValue)
+  }
+}
 /*********************
  **  Value Limiters  **
  **********************/

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/getDelayData.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/getDelayData.ts
@@ -1,4 +1,5 @@
 import { InnerDelayArgs } from '@opentrons/step-generation'
+import { getDefaultMmFromBottom } from '../../../components/StepEditForm/fields/TipPositionField/utils'
 import {
   DelayCheckboxFields,
   DelaySecondFields,
@@ -15,14 +16,22 @@ export function getMoveLiquidDelayData(
 ): InnerDelayArgs | null {
   const checkbox = hydratedFormData[checkboxField]
   const seconds = hydratedFormData[secondsField]
-  const mmFromBottom = hydratedFormData[mmFromBottomField]
-
+  let mmFromBottom: number | undefined
+  const mmFromBottomFormValue = hydratedFormData[mmFromBottomField]
+  if (typeof mmFromBottomFormValue === 'number') {
+    mmFromBottom = mmFromBottomFormValue
+  } else if (mmFromBottomFormValue === null) {
+    mmFromBottom = getDefaultMmFromBottom({
+      name: mmFromBottomField,
+      wellDepthMm: NaN /* NOTE: `wellDepthMm` should not be used for delay offsets */,
+    })
+  }
   if (
     checkbox &&
     typeof seconds === 'number' &&
     seconds > 0 &&
     typeof mmFromBottom === 'number' &&
-    mmFromBottom > 0
+    mmFromBottom >= 0
   ) {
     return {
       seconds,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/getDelayData.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/getDelayData.ts
@@ -23,7 +23,7 @@ export function getMoveLiquidDelayData(
   } else if (mmFromBottomFormValue === null) {
     mmFromBottom = getDefaultMmFromBottom({
       name: mmFromBottomField,
-      wellDepthMm: NaN /* NOTE: `wellDepthMm` should not be used for delay offsets */,
+      wellDepthMm: 0 /* NOTE: `wellDepthMm` should not be used for delay offsets */,
     })
   }
   if (

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
@@ -135,6 +135,7 @@ export const moveLiquidFormToArgs = (
     'dispense_delay_seconds',
     'dispense_delay_mmFromBottom'
   )
+
   const blowoutLocation =
     (fields.blowout_checkbox && fields.blowout_location) || null
   const blowoutOffsetFromTopMm = DEFAULT_MM_BLOWOUT_OFFSET_FROM_TOP

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
@@ -135,7 +135,6 @@ export const moveLiquidFormToArgs = (
     'dispense_delay_seconds',
     'dispense_delay_mmFromBottom'
   )
-
   const blowoutLocation =
     (fields.blowout_checkbox && fields.blowout_location) || null
   const blowoutOffsetFromTopMm = DEFAULT_MM_BLOWOUT_OFFSET_FROM_TOP

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/getDelayData.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/getDelayData.test.ts
@@ -2,96 +2,130 @@ import { getMoveLiquidDelayData, getMixDelayData } from '../getDelayData'
 
 describe('getMoveLiquidDelayData', () => {
   it('should return null if checkbox field is false', () => {
+    const fields: any = {
+      aspirate_delay_checkbox: false,
+      aspirate_delay_seconds: 3,
+      aspirate_delay_mmFromBottom: 2,
+    }
     expect(
       getMoveLiquidDelayData(
-        // @ts-expect-error(sa, 2021-6-15): these are not valid properties on the fields key of HydratedMoveLiquidFormData
-        { checkboxField: false, secondsField: 3, offsetField: 2 },
-        'checkboxField',
-        'secondsField',
-        'offsetField'
+        fields,
+        'aspirate_delay_checkbox',
+        'aspirate_delay_seconds',
+        'aspirate_delay_mmFromBottom'
       )
     ).toBe(null)
   })
 
-  it('should return null if either number fields <= 0 / null', () => {
+  it('should return null if either seconds field is <= 0 or null, or if offset field is negative', () => {
     const cases = [
       [0, 5],
       [null, 5],
-      [10, 0],
-      [10, null],
       [-1, 2],
       [2, -1],
     ]
 
     cases.forEach(testCase => {
       const [secondsValue, offsetValue] = testCase
+      const fields: any = {
+        aspirate_delay_checkbox: true,
+        aspirate_delay_seconds: secondsValue,
+        aspirate_delay_mmFromBottom: offsetValue,
+      }
       expect(
         getMoveLiquidDelayData(
-          {
-            // @ts-expect-error(sa, 2021-6-15): these are not valid properties on the fields key of HydratedMoveLiquidFormData
-            checkboxField: true,
-            secondsField: secondsValue,
-            offsetField: offsetValue,
-          },
-          'checkboxField',
-          'secondsField',
-          'offsetField'
+          fields,
+          'aspirate_delay_checkbox',
+          'aspirate_delay_seconds',
+          'aspirate_delay_mmFromBottom'
         )
       ).toBe(null)
     })
   })
 
   it('should return seconds & mmFromBottom if checkbox is checked', () => {
+    const fields: any = {
+      aspirate_delay_checkbox: true,
+      aspirate_delay_seconds: 30,
+      aspirate_delay_mmFromBottom: 2,
+    }
     expect(
       getMoveLiquidDelayData(
-        // @ts-expect-error(sa, 2021-6-15): these are not valid properties on the fields key of HydratedMoveLiquidFormData
-        { checkboxField: true, secondsField: 30, offsetField: 2 },
-        'checkboxField',
-        'secondsField',
-        'offsetField'
+        fields,
+        'aspirate_delay_checkbox',
+        'aspirate_delay_seconds',
+        'aspirate_delay_mmFromBottom'
       )
     ).toEqual({ seconds: 30, mmFromBottom: 2 })
+  })
+
+  it('should allow mmFromBottom to be zero', () => {
+    const fields: any = {
+      aspirate_delay_checkbox: true,
+      aspirate_delay_seconds: 30,
+      aspirate_delay_mmFromBottom: 0,
+    }
+    expect(
+      getMoveLiquidDelayData(
+        fields,
+        'aspirate_delay_checkbox',
+        'aspirate_delay_seconds',
+        'aspirate_delay_mmFromBottom'
+      )
+    ).toEqual({ seconds: 30, mmFromBottom: 0 })
   })
 })
 
 describe('getMixDelayData', () => {
   it('should return null if the checkbox field is false', () => {
+    const fields: any = {
+      aspirate_delay_checkbox: false,
+      aspirate_delay_seconds: 3,
+    }
     expect(
       getMixDelayData(
-        // @ts-expect-error(sa, 2021-6-15): these are not valid properties on the fields key of HydratedMoveLiquidFormData
-        { checkboxField: false, secondsField: 3 },
-        'checkboxField',
-        'secondsField'
+        fields,
+        'aspirate_delay_checkbox',
+        'aspirate_delay_seconds'
       )
     ).toBe(null)
   })
   it('should return null if the seconds field is 0', () => {
+    const fields: any = {
+      aspirate_delay_checkbox: true,
+      aspirate_delay_seconds: 0,
+    }
     expect(
       getMixDelayData(
-        // @ts-expect-error(sa, 2021-6-15): these are not valid properties on the fields key of HydratedMoveLiquidFormData
-        { checkboxField: true, secondsField: 0 },
-        'checkboxField',
-        'secondsField'
+        fields,
+        'aspirate_delay_checkbox',
+        'aspirate_delay_seconds'
       )
     ).toBe(null)
   })
   it('should return null if the seconds field is less than 0', () => {
+    const fields: any = {
+      aspirate_delay_checkbox: true,
+      aspirate_delay_seconds: -1,
+    }
     expect(
       getMixDelayData(
-        // @ts-expect-error(sa, 2021-6-15): these are not valid properties on the fields key of HydratedMoveLiquidFormData
-        { checkboxField: true, secondsField: -1 },
-        'checkboxField',
-        'secondsField'
+        fields,
+        'aspirate_delay_checkbox',
+        'aspirate_delay_seconds'
       )
     ).toBe(null)
   })
   it('should return the seconds field if checckbox is checked and the seconds field is > 0', () => {
+    const fields: any = {
+      aspirate_delay_checkbox: true,
+      aspirate_delay_seconds: 10,
+    }
     expect(
       getMixDelayData(
-        // @ts-expect-error(sa, 2021-6-15): these are not valid properties on the fields key of HydratedMoveLiquidFormData
-        { checkboxField: true, secondsField: 10 },
-        'checkboxField',
-        'secondsField'
+        fields,
+        'aspirate_delay_checkbox',
+        'aspirate_delay_seconds'
       )
     ).toEqual(10)
   })

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/moveLiquidFormToArgs.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/moveLiquidFormToArgs.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../moveLiquidFormToArgs'
 import { getOrderedWells } from '../../../utils'
 import { HydratedMoveLiquidFormData, PathOption } from '../../../../form-types'
+import { DEFAULT_MM_FROM_BOTTOM_ASPIRATE } from '../../../../constants'
 
 jest.mock('../../../utils')
 jest.mock('assert')
@@ -191,10 +192,15 @@ describe('move liquid step form -> command creator args', () => {
       checkboxField: 'aspirate_delay_checkbox',
       formFields: {
         aspirate_delay_seconds: 11,
-        aspirate_delay_mmFromBottom: 12,
+        aspirate_delay_mmFromBottom: null, // use default
       },
       expectedArgsUnchecked: { aspirateDelay: null },
-      expectedArgsChecked: { aspirateDelay: { seconds: 11, mmFromBottom: 12 } },
+      expectedArgsChecked: {
+        aspirateDelay: {
+          seconds: 11,
+          mmFromBottom: DEFAULT_MM_FROM_BOTTOM_ASPIRATE,
+        },
+      },
     },
     {
       checkboxField: 'dispense_delay_checkbox',


### PR DESCRIPTION
# Overview

This PR fixes the bug where PD transfer step forms with delays were not registering when the mm offset field was `null` or `0`.

closes #8153

# Changelog
- Delay when offset length is falsey


# Review requests

- Upload the protocol in the ticket, export it, you should now see delay commands get generated
- Make a protocol with aspirate + dispense delays and enter `0` for the mm offset field. When you export the protocol, `delay` commands should now get generated. 

# Risk assessment

Med, behavior change but it is minor and contained. 