### PR TITLE
fix(app): Aligned link text with the design

### DIFF
--- a/app/src/assets/localization/en/protocol_info.json
+++ b/app/src/assets/localization/en/protocol_info.json
@@ -1,5 +1,5 @@
 {
-  "browse_protocol_library": "Launch Opentrons Protocol Library",
+  "browse_protocol_library": "Open Protocol Library",
   "choose_file": "Choose File...",
   "choose_protocol_file": "Choose File",
   "choose_snippet_type": "Choose the Labware Offset Data Python Snippet based on target execution environment.",
@@ -22,7 +22,7 @@
   "labware_legacy_definition": "N/A",
   "labware_cal_description": "Calibrated offset from labware origin point",
   "last_updated": "Last Updated",
-  "launch_protocol_designer": "Launch Opentrons Protocol Designer",
+  "launch_protocol_designer": "Open Protocol Designer",
   "modules_title": "Required Modules",
   "no_protocol_yet": "Don't have a protocol yet?",
   "create_or_download": "Create or download a new protocol",

--- a/app/src/organisms/ProtocolUpload/__tests__/UploadInput.test.tsx
+++ b/app/src/organisms/ProtocolUpload/__tests__/UploadInput.test.tsx
@@ -44,12 +44,8 @@ describe('UploadInput', () => {
       /Don't have a protocol yet\?/i
     )
     getByText('MOCK LAST RUN')
-    expect(
-      getByRole('link', { name: 'Launch Opentrons Protocol Library' })
-    ).toBeTruthy()
-    expect(
-      getByRole('link', { name: 'Launch Opentrons Protocol Designer' })
-    ).toBeTruthy()
+    expect(getByRole('link', { name: 'Open Protocol Library' })).toBeTruthy()
+    expect(getByRole('link', { name: 'Open Protocol Designer' })).toBeTruthy()
   })
 
   it('opens file select on button click', () => {

--- a/app/src/organisms/ProtocolUpload/__tests__/UploadInput.test.tsx
+++ b/app/src/organisms/ProtocolUpload/__tests__/UploadInput.test.tsx
@@ -44,8 +44,8 @@ describe('UploadInput', () => {
       /Don't have a protocol yet\?/i
     )
     getByText('MOCK LAST RUN')
-    expect(getByRole('link', { name: 'Open Protocol Library' })).toBeTruthy()
-    expect(getByRole('link', { name: 'Open Protocol Designer' })).toBeTruthy()
+    getByRole('link', { name: 'Open Protocol Library' })
+    getByRole('link', { name: 'Open Protocol Designer' })
   })
 
   it('opens file select on button click', () => {

--- a/app/src/organisms/ProtocolsLanding/__tests__/EmptyStateLinks.test.tsx
+++ b/app/src/organisms/ProtocolsLanding/__tests__/EmptyStateLinks.test.tsx
@@ -30,12 +30,8 @@ describe('EmptyStateLinks', () => {
       /Don't have a protocol yet\?/i
     )
 
-    expect(
-      getByRole('link', { name: 'Launch Opentrons Protocol Library' })
-    ).toBeTruthy()
-    expect(
-      getByRole('link', { name: 'Launch Opentrons Protocol Designer' })
-    ).toBeTruthy()
+    expect(getByRole('link', { name: 'Open Protocol Library' })).toBeTruthy()
+    expect(getByRole('link', { name: 'Open Protocol Designer' })).toBeTruthy()
     expect(
       getByRole('link', { name: 'Open Python API Documentation' })
     ).toBeTruthy()

--- a/app/src/organisms/ProtocolsLanding/__tests__/EmptyStateLinks.test.tsx
+++ b/app/src/organisms/ProtocolsLanding/__tests__/EmptyStateLinks.test.tsx
@@ -30,10 +30,8 @@ describe('EmptyStateLinks', () => {
       /Don't have a protocol yet\?/i
     )
 
-    expect(getByRole('link', { name: 'Open Protocol Library' })).toBeTruthy()
-    expect(getByRole('link', { name: 'Open Protocol Designer' })).toBeTruthy()
-    expect(
-      getByRole('link', { name: 'Open Python API Documentation' })
-    ).toBeTruthy()
+    getByRole('link', { name: 'Open Protocol Library' })
+    getByRole('link', { name: 'Open Protocol Designer' })
+    getByRole('link', { name: 'Open Python API Documentation' })
   })
 })


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
By chance, I noticed that the difference between the app and the design

- Launch Opentrons Protocol Library -> Open Protocol Library
- Launch Opentrons Protocol Designer -> Open Protocol Designer

### app
![Screen Shot 2022-04-21 at 10 27 12 AM](https://user-images.githubusercontent.com/474225/164480246-abb51902-775a-4cf4-91a8-aafe19c213af.png)

### design
![Screen Shot 2022-04-21 at 9 56 09 AM](https://user-images.githubusercontent.com/474225/164480279-cb5d6238-13e1-4028-b29c-45e32219c837.png)

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- Updated protocol_info.json
- Updated test cases

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- text is changed from `Launch` to `Open`
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
