### PR TITLE
feat(app): add protocol robot configuration details

### DIFF
--- a/app/src/organisms/ProtocolDetails/RobotConfigurationDetails.tsx
+++ b/app/src/organisms/ProtocolDetails/RobotConfigurationDetails.tsx
@@ -1,0 +1,135 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  ALIGN_CENTER,
+  COLORS,
+  DIRECTION_COLUMN,
+  DIRECTION_ROW,
+  Flex,
+  ModuleIcon,
+  POSITION_ABSOLUTE,
+  SPACING,
+  TEXT_TRANSFORM_CAPITALIZE,
+  TEXT_TRANSFORM_UPPERCASE,
+  TYPOGRAPHY,
+} from '@opentrons/components'
+import {
+  getModuleDisplayName,
+  getModuleType,
+  getPipetteNameSpecs,
+  PipetteName,
+  THERMOCYCLER_MODULE_TYPE,
+} from '@opentrons/shared-data'
+import { Divider } from '../../atoms/structure'
+import { StyledText } from '../../atoms/text'
+
+import type { LoadModuleRunTimeCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
+
+interface RobotConfigurationDetailsProps {
+  leftMountPipetteName: PipetteName | null
+  rightMountPipetteName: PipetteName | null
+  requiredModuleDetails: LoadModuleRunTimeCommand[] | null
+}
+
+export const RobotConfigurationDetails = (
+  props: RobotConfigurationDetailsProps
+): JSX.Element => {
+  const {
+    leftMountPipetteName,
+    rightMountPipetteName,
+    requiredModuleDetails,
+  } = props
+  const { t } = useTranslation(['protocol_details', 'shared'])
+
+  return (
+    <Flex flexDirection={DIRECTION_COLUMN}>
+      <Flex
+        flexDirection={DIRECTION_ROW}
+        alignItems={ALIGN_CENTER}
+        marginY={SPACING.spacing3}
+      >
+        <StyledText
+          as="h6"
+          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+          marginRight={SPACING.spacing4}
+          color={COLORS.darkGreyPressed}
+          textTransform={TEXT_TRANSFORM_UPPERCASE}
+        >
+          {t('left_mount')}
+        </StyledText>
+        <Flex marginX={'6rem'} position={POSITION_ABSOLUTE}>
+          <StyledText as="p" textTransform={TEXT_TRANSFORM_CAPITALIZE}>
+            {leftMountPipetteName != null
+              ? getPipetteNameSpecs(leftMountPipetteName)?.displayName
+              : t('shared:empty')}
+          </StyledText>
+        </Flex>
+      </Flex>
+      <Divider width="100%" />
+      <Flex
+        flexDirection={DIRECTION_ROW}
+        alignItems={ALIGN_CENTER}
+        marginY={SPACING.spacing3}
+      >
+        <StyledText
+          as="h6"
+          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+          marginRight={SPACING.spacing4}
+          color={COLORS.darkGreyPressed}
+          textTransform={TEXT_TRANSFORM_UPPERCASE}
+        >
+          {t('right_mount')}
+        </StyledText>
+        <Flex marginX={'6rem'} position={POSITION_ABSOLUTE}>
+          <StyledText as="p" textTransform={TEXT_TRANSFORM_CAPITALIZE}>
+            {rightMountPipetteName != null
+              ? getPipetteNameSpecs(rightMountPipetteName)?.displayName
+              : t('shared:empty')}
+          </StyledText>
+        </Flex>
+      </Flex>
+      {requiredModuleDetails != null
+        ? requiredModuleDetails.map((module, index) => {
+            return (
+              <React.Fragment key={index}>
+                <Divider width="100%" />
+                <Flex
+                  flexDirection={DIRECTION_ROW}
+                  alignItems={ALIGN_CENTER}
+                  marginY={SPACING.spacing3}
+                >
+                  <StyledText
+                    as="h6"
+                    fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+                    marginRight={SPACING.spacing4}
+                    color={COLORS.darkGreyPressed}
+                    textTransform={TEXT_TRANSFORM_UPPERCASE}
+                  >
+                    {t('run_details:module_slot_number', {
+                      slot_number:
+                        getModuleType(module.params.model) ===
+                        THERMOCYCLER_MODULE_TYPE
+                          ? '7/10'
+                          : module.params.location.slotName,
+                    })}
+                  </StyledText>
+                  <Flex marginX={'6rem'} position={POSITION_ABSOLUTE}>
+                    <ModuleIcon
+                      key={index}
+                      moduleType={getModuleType(module.params.model)}
+                      height="1rem"
+                      marginRight={SPACING.spacing3}
+                      alignSelf={ALIGN_CENTER}
+                    />
+                    <StyledText as="p">
+                      {getModuleDisplayName(module.params.model)}
+                    </StyledText>
+                  </Flex>
+                </Flex>
+              </React.Fragment>
+            )
+          })
+        : null}
+    </Flex>
+  )
+}

--- a/app/src/organisms/ProtocolDetails/RobotConfigurationDetails.tsx
+++ b/app/src/organisms/ProtocolDetails/RobotConfigurationDetails.tsx
@@ -58,7 +58,11 @@ export const RobotConfigurationDetails = (
           {t('left_mount')}
         </StyledText>
         <Flex marginX={'6rem'} position={POSITION_ABSOLUTE}>
-          <StyledText as="p" textTransform={TEXT_TRANSFORM_CAPITALIZE}>
+          <StyledText
+            as="p"
+            textTransform={TEXT_TRANSFORM_CAPITALIZE}
+            data-testid={'leftMountPipetteName'}
+          >
             {leftMountPipetteName != null
               ? getPipetteNameSpecs(leftMountPipetteName)?.displayName
               : t('shared:empty')}
@@ -81,7 +85,11 @@ export const RobotConfigurationDetails = (
           {t('right_mount')}
         </StyledText>
         <Flex marginX={'6rem'} position={POSITION_ABSOLUTE}>
-          <StyledText as="p" textTransform={TEXT_TRANSFORM_CAPITALIZE}>
+          <StyledText
+            as="p"
+            textTransform={TEXT_TRANSFORM_CAPITALIZE}
+            data-testid={'rightMountPipetteName'}
+          >
             {rightMountPipetteName != null
               ? getPipetteNameSpecs(rightMountPipetteName)?.displayName
               : t('shared:empty')}
@@ -97,6 +105,7 @@ export const RobotConfigurationDetails = (
                   flexDirection={DIRECTION_ROW}
                   alignItems={ALIGN_CENTER}
                   marginY={SPACING.spacing3}
+                  data-testid={`${module.params.model}_slot_${module.params.location.slotName}`}
                 >
                   <StyledText
                     as="h6"

--- a/app/src/organisms/ProtocolDetails/RobotConfigurationDetails.tsx
+++ b/app/src/organisms/ProtocolDetails/RobotConfigurationDetails.tsx
@@ -47,19 +47,16 @@ export const RobotConfigurationDetails = (
       <RobotConfigurationDetailsItem
         label={t('left_mount')}
         item={
-          leftMountPipetteName != null
-            ? (getPipetteNameSpecs(leftMountPipetteName)?.displayName as string)
-            : t('shared:empty')
+          getPipetteNameSpecs(leftMountPipetteName as PipetteName)
+            ?.displayName ?? t('shared:empty')
         }
       />
       <Divider width="100%" />
       <RobotConfigurationDetailsItem
         label={t('right_mount')}
         item={
-          rightMountPipetteName != null
-            ? (getPipetteNameSpecs(rightMountPipetteName)
-                ?.displayName as string)
-            : t('shared:empty')
+          getPipetteNameSpecs(rightMountPipetteName as PipetteName)
+            ?.displayName ?? t('shared:empty')
         }
       />
       {requiredModuleDetails != null

--- a/app/src/organisms/ProtocolDetails/RobotConfigurationDetails.tsx
+++ b/app/src/organisms/ProtocolDetails/RobotConfigurationDetails.tsx
@@ -8,6 +8,7 @@ import {
   Flex,
   ModuleIcon,
   POSITION_ABSOLUTE,
+  SIZE_1,
   SPACING,
   TEXT_TRANSFORM_CAPITALIZE,
   TEXT_TRANSFORM_UPPERCASE,
@@ -17,13 +18,13 @@ import {
   getModuleDisplayName,
   getModuleType,
   getPipetteNameSpecs,
-  PipetteName,
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import { Divider } from '../../atoms/structure'
 import { StyledText } from '../../atoms/text'
 
 import type { LoadModuleRunTimeCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
+import type { PipetteName } from '@opentrons/shared-data'
 
 interface RobotConfigurationDetailsProps {
   leftMountPipetteName: PipetteName | null
@@ -43,59 +44,24 @@ export const RobotConfigurationDetails = (
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN}>
-      <Flex
-        flexDirection={DIRECTION_ROW}
-        alignItems={ALIGN_CENTER}
-        marginY={SPACING.spacing3}
-      >
-        <StyledText
-          as="h6"
-          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-          marginRight={SPACING.spacing4}
-          color={COLORS.darkGreyPressed}
-          textTransform={TEXT_TRANSFORM_UPPERCASE}
-        >
-          {t('left_mount')}
-        </StyledText>
-        <Flex marginX={'6rem'} position={POSITION_ABSOLUTE}>
-          <StyledText
-            as="p"
-            textTransform={TEXT_TRANSFORM_CAPITALIZE}
-            data-testid={'leftMountPipetteName'}
-          >
-            {leftMountPipetteName != null
-              ? getPipetteNameSpecs(leftMountPipetteName)?.displayName
-              : t('shared:empty')}
-          </StyledText>
-        </Flex>
-      </Flex>
+      <RobotConfigurationDetailsItem
+        label={t('left_mount')}
+        item={
+          leftMountPipetteName != null
+            ? (getPipetteNameSpecs(leftMountPipetteName)?.displayName as string)
+            : t('shared:empty')
+        }
+      />
       <Divider width="100%" />
-      <Flex
-        flexDirection={DIRECTION_ROW}
-        alignItems={ALIGN_CENTER}
-        marginY={SPACING.spacing3}
-      >
-        <StyledText
-          as="h6"
-          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-          marginRight={SPACING.spacing4}
-          color={COLORS.darkGreyPressed}
-          textTransform={TEXT_TRANSFORM_UPPERCASE}
-        >
-          {t('right_mount')}
-        </StyledText>
-        <Flex marginX={'6rem'} position={POSITION_ABSOLUTE}>
-          <StyledText
-            as="p"
-            textTransform={TEXT_TRANSFORM_CAPITALIZE}
-            data-testid={'rightMountPipetteName'}
-          >
-            {rightMountPipetteName != null
-              ? getPipetteNameSpecs(rightMountPipetteName)?.displayName
-              : t('shared:empty')}
-          </StyledText>
-        </Flex>
-      </Flex>
+      <RobotConfigurationDetailsItem
+        label={t('right_mount')}
+        item={
+          rightMountPipetteName != null
+            ? (getPipetteNameSpecs(rightMountPipetteName)
+                ?.displayName as string)
+            : t('shared:empty')
+        }
+      />
       {requiredModuleDetails != null
         ? requiredModuleDetails.map((module, index) => {
             return (
@@ -105,7 +71,7 @@ export const RobotConfigurationDetails = (
                   flexDirection={DIRECTION_ROW}
                   alignItems={ALIGN_CENTER}
                   marginY={SPACING.spacing3}
-                  data-testid={`${module.params.model}_slot_${module.params.location.slotName}`}
+                  data-testid={`RobotConfigurationDetails__${module.params.model}_slot_${module.params.location.slotName}`}
                 >
                   <StyledText
                     as="h6"
@@ -126,7 +92,7 @@ export const RobotConfigurationDetails = (
                     <ModuleIcon
                       key={index}
                       moduleType={getModuleType(module.params.model)}
-                      height="1rem"
+                      height={SIZE_1}
                       marginRight={SPACING.spacing3}
                       alignSelf={ALIGN_CENTER}
                     />
@@ -139,6 +105,43 @@ export const RobotConfigurationDetails = (
             )
           })
         : null}
+    </Flex>
+  )
+}
+
+interface RobotConfigurationDetailsItemProps {
+  label: string
+  item: string
+}
+
+export const RobotConfigurationDetailsItem = (
+  props: RobotConfigurationDetailsItemProps
+): JSX.Element => {
+  const { label, item } = props
+  return (
+    <Flex
+      flexDirection={DIRECTION_ROW}
+      alignItems={ALIGN_CENTER}
+      marginY={SPACING.spacing3}
+    >
+      <StyledText
+        as="h6"
+        fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+        marginRight={SPACING.spacing4}
+        color={COLORS.darkGreyPressed}
+        textTransform={TEXT_TRANSFORM_UPPERCASE}
+      >
+        {label}
+      </StyledText>
+      <Flex marginX={'6rem'} position={POSITION_ABSOLUTE}>
+        <StyledText
+          as="p"
+          textTransform={TEXT_TRANSFORM_CAPITALIZE}
+          data-testid={`RobotConfigurationDetails_${label}`}
+        >
+          {item}
+        </StyledText>
+      </Flex>
     </Flex>
   )
 }

--- a/app/src/organisms/ProtocolDetails/__tests__/RobotConfigurationDetails.test.tsx
+++ b/app/src/organisms/ProtocolDetails/__tests__/RobotConfigurationDetails.test.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react'
+import { renderWithProviders } from '@opentrons/components'
+import { i18n } from '../../../i18n'
+import { RobotConfigurationDetails } from '../RobotConfigurationDetails'
+import { LoadModuleRunTimeCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
+
+const mockRequiredModuleDetails = [
+  {
+    id: 'someId',
+    createdAt: '2022-04-18T19:16:57.398363+00:00',
+    commandType: 'loadModule',
+    key: 'someKey',
+    status: 'succeeded',
+    params: {
+      model: 'magneticModuleV2',
+      location: {
+        slotName: '1',
+      },
+      moduleId: 'magneticModuleType',
+    },
+    result: {
+      moduleId: 'magneticModuleType',
+      definition: {
+        otSharedSchema: 'module/schemas/2',
+        moduleType: 'magneticModuleType',
+        model: 'magneticModuleV2',
+        labwareOffset: {
+          x: -1.175,
+          y: -0.125,
+          z: 82.25,
+        },
+        dimensions: {
+          bareOverallHeight: 110.152,
+          overLabwareHeight: 4.052,
+          lidHeight: null,
+        },
+        calibrationPoint: {
+          x: 124.875,
+          y: 2.75,
+        },
+        displayName: 'Magnetic Module GEN2',
+        quirks: [],
+        slotTransforms: {},
+        compatibleWith: [],
+      },
+      model: 'magneticModuleV2',
+      serialNumber: 'fake-serial-number',
+    },
+    error: null,
+    startedAt: '2022-04-18T19:16:57.401628+00:00',
+    completedAt: '2022-04-18T19:16:57.402112+00:00',
+  } as LoadModuleRunTimeCommand,
+]
+
+const render = (
+  props: React.ComponentProps<typeof RobotConfigurationDetails>
+) => {
+  return renderWithProviders(<RobotConfigurationDetails {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+describe('RobotConfigurationDetails', () => {
+  let props: React.ComponentProps<typeof RobotConfigurationDetails>
+  beforeEach(() => {})
+  it('renders left mount pipette when there is a pipette only in the left mount', () => {
+    props = {
+      leftMountPipetteName: 'p10_single',
+      rightMountPipetteName: null,
+      requiredModuleDetails: null,
+    }
+    const { getByText } = render(props)
+    getByText('left mount')
+    getByText('P10 Single-Channel GEN1')
+    getByText('right mount')
+    getByText('empty')
+  })
+
+  it('renders right mount pipette when there is a pipette only in the right mount', () => {
+    props = {
+      leftMountPipetteName: null,
+      rightMountPipetteName: 'p10_single',
+      requiredModuleDetails: null,
+    }
+    const { getByText } = render(props)
+    getByText('left mount')
+    getByText('P10 Single-Channel GEN1')
+    getByText('right mount')
+    getByText('empty')
+  })
+
+  it('renders the magnetic module when the protocol contains a magnetic module', () => {
+    props = {
+      leftMountPipetteName: null,
+      rightMountPipetteName: 'p10_single',
+      requiredModuleDetails: mockRequiredModuleDetails,
+    }
+
+    const { getByText } = render(props)
+    getByText('Slot 1')
+    getByText('Magnetic Module GEN2')
+  })
+})

--- a/app/src/organisms/ProtocolDetails/index.tsx
+++ b/app/src/organisms/ProtocolDetails/index.tsx
@@ -276,8 +276,13 @@ export function ProtocolDetails(
             }
           </Box>
         </Card>
-        <Box height="100%" width={SPACING.spacing4} />
-        <Card flex="1">
+
+        <Flex
+          width="100%"
+          height="100%"
+          flexDirection={DIRECTION_COLUMN}
+          marginLeft={SPACING.spacing4}
+        >
           <Flex>
             <RoundTab
               isCurrent={currentTab === 'robot_config'}
@@ -309,7 +314,7 @@ export function ProtocolDetails(
           >
             {getTabContents()}
           </Box>
-        </Card>
+        </Flex>
       </Flex>
     </Flex>
   )

--- a/app/src/organisms/ProtocolDetails/index.tsx
+++ b/app/src/organisms/ProtocolDetails/index.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
+import map from 'lodash/map'
 import { format } from 'date-fns'
 import { css } from 'styled-components'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
-import { getModuleType, getPipetteNameSpecs } from '@opentrons/shared-data'
 import {
   Box,
   Btn,
@@ -22,12 +22,11 @@ import {
   Card,
   JUSTIFY_SPACE_BETWEEN,
   TEXT_TRANSFORM_CAPITALIZE,
-  ModuleIcon,
-  ALIGN_CENTER,
+  Text,
 } from '@opentrons/components'
 import {
   parseInitialPipetteNamesByMount,
-  parseAllRequiredModuleModels,
+  parseInitialLoadedModulesBySlot,
 } from '@opentrons/api-client'
 
 import { getIsProtocolAnalysisInProgress } from '../../redux/protocol-storage'
@@ -45,6 +44,7 @@ import {
 
 import type { State } from '../../redux/types'
 import type { StoredProtocolData } from '../../redux/protocol-storage'
+import { RobotConfigurationDetails } from './RobotConfigurationDetails'
 
 const defaultTabStyle = css`
   ${TYPOGRAPHY.pSemiBold}
@@ -122,9 +122,12 @@ export function ProtocolDetails(
     mostRecentAnalysis != null
       ? parseInitialPipetteNamesByMount(mostRecentAnalysis.commands)
       : { left: null, right: null }
-  const requiredModuleTypes = parseAllRequiredModuleModels(
-    mostRecentAnalysis != null ? mostRecentAnalysis.commands : []
-  ).map(getModuleType)
+
+  const requiredModuleDetails = map(
+    parseInitialLoadedModulesBySlot(
+      mostRecentAnalysis.commands != null ? mostRecentAnalysis.commands : []
+    )
+  )
 
   const protocolDisplayName = getProtocolDisplayName(
     protocolKey,
@@ -142,73 +145,11 @@ export function ProtocolDetails(
     currentTab === 'labware' ? (
       <Box>TODO: labware tab contents</Box>
     ) : (
-      <Flex flexDirection={DIRECTION_COLUMN}>
-        <Flex
-          flexDirection={DIRECTION_ROW}
-          alignItems={ALIGN_CENTER}
-          marginY={SPACING.spacing3}
-        >
-          <StyledText
-            as="h6"
-            fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-            marginRight={SPACING.spacing4}
-          >
-            {t('left_mount')}
-          </StyledText>
-          <StyledText as="p">
-            {leftMountPipetteName != null
-              ? getPipetteNameSpecs(leftMountPipetteName)?.displayName
-              : t('shared:empty')}
-          </StyledText>
-        </Flex>
-        <Divider width="100%" />
-        <Flex
-          flexDirection={DIRECTION_ROW}
-          alignItems={ALIGN_CENTER}
-          marginY={SPACING.spacing3}
-        >
-          <StyledText
-            as="h6"
-            fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-            marginRight={SPACING.spacing4}
-          >
-            {t('right_mount')}
-          </StyledText>
-          <StyledText as="p">
-            {rightMountPipetteName != null
-              ? getPipetteNameSpecs(rightMountPipetteName)?.displayName
-              : t('shared:empty')}
-          </StyledText>
-        </Flex>
-        {requiredModuleTypes.map((moduleType, index) => (
-          <>
-            <Divider width="100%" />
-            <Flex
-              key={index}
-              flexDirection={DIRECTION_ROW}
-              alignItems={ALIGN_CENTER}
-              marginY={SPACING.spacing3}
-            >
-              <StyledText
-                as="h6"
-                fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-                marginRight={SPACING.spacing4}
-              >
-                TODO slot
-              </StyledText>
-              <Flex flexDirection={DIRECTION_ROW} alignItems={ALIGN_CENTER}>
-                <ModuleIcon
-                  key={index}
-                  moduleType={moduleType}
-                  height="1rem"
-                  marginRight={SPACING.spacing3}
-                />
-                <StyledText as="p">{moduleType}</StyledText>
-              </Flex>
-            </Flex>
-          </>
-        ))}
-      </Flex>
+      <RobotConfigurationDetails
+        leftMountPipetteName={leftMountPipetteName}
+        rightMountPipetteName={rightMountPipetteName}
+        requiredModuleDetails={requiredModuleDetails}
+      />
     )
 
   return (
@@ -310,7 +251,7 @@ export function ProtocolDetails(
         flexDirection={DIRECTION_ROW}
         justifyContent={JUSTIFY_SPACE_BETWEEN}
       >
-        <Card flex="0 0 20rem">
+        <Card flex="0 0 20rem" backgroundColor={COLORS.white}>
           <StyledText
             as="h3"
             fontWeight={TYPOGRAPHY.fontWeightSemiBold}
@@ -320,7 +261,7 @@ export function ProtocolDetails(
             {t('deck_setup')}
           </StyledText>
           <Divider />
-          <Box padding={SPACING.spacing4}>
+          <Box padding={SPACING.spacing4} backgroundColor={COLORS.white}>
             {
               {
                 missing: <Box size="15rem" backgroundColor={COLORS.medGrey} />,
@@ -342,13 +283,17 @@ export function ProtocolDetails(
               isCurrent={currentTab === 'robot_config'}
               onClick={() => setCurrentTab('robot_config')}
             >
-              {t('robot_configuration')}
+              <Text textTransform={TEXT_TRANSFORM_CAPITALIZE}>
+                {t('robot_configuration')}
+              </Text>
             </RoundTab>
             <RoundTab
               isCurrent={currentTab === 'labware'}
               onClick={() => setCurrentTab('labware')}
             >
-              {t('labware')}
+              <Text textTransform={TEXT_TRANSFORM_CAPITALIZE}>
+                {t('labware')}
+              </Text>
             </RoundTab>
           </Flex>
           <Box


### PR DESCRIPTION

# Overview

This PR adds the robot configuration details section in the Protocol Details page. closes #8824

![image](https://user-images.githubusercontent.com/14794021/164768983-dbc450bd-058b-41c4-9225-0e384158b79d.png)

# Changelog

- Added `RobotConfigurationDetails` component and corresponding tests

# Review requests

- Upload a protocol, click the protocol card and check to see if the correct robot configurations show up (pipettes/modules).

# Risk assessment

low
