### PR TITLE
ci(cache): only hash top-level yarn.lock for cache resolution

### DIFF
--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -69,7 +69,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.npm-cache/_prebuild
             ${{ github.workspace }}/.yarn-cache
-          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
       - name: 'setup-js'
         run: |
           npm config set cache ${{ github.workspace }}/.npm-cache
@@ -117,7 +117,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.npm-cache/_prebuild
             ${{ github.workspace }}/.yarn-cache
-          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
       - name: setup-js
         run: |
           npm config set cache ${{ github.workspace }}/.npm-cache

--- a/.github/workflows/components-test-build-deploy.yaml
+++ b/.github/workflows/components-test-build-deploy.yaml
@@ -47,7 +47,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.yarn-cache
             ${{ github.workspace }}/.npm-cache
-          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-
       - name: 'setup-js'
@@ -82,7 +82,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.yarn-cache
             ${{ github.workspace }}/.npm-cache
-          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-
       - name: 'setup-js'

--- a/.github/workflows/js-check.yaml
+++ b/.github/workflows/js-check.yaml
@@ -57,7 +57,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.yarn-cache
             ${{ github.workspace }}/.npm-cache
-          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-
       - name: 'setup-js'

--- a/.github/workflows/ll-test-build-deploy.yaml
+++ b/.github/workflows/ll-test-build-deploy.yaml
@@ -50,7 +50,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.yarn-cache
             ${{ github.workspace }}/.npm-cache
-          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-
       - name: 'setup-js'
@@ -89,7 +89,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.yarn-cache
             ${{ github.workspace }}/.npm-cache
-          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-
       - name: 'setup-js'
@@ -120,7 +120,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.yarn-cache
             ${{ github.workspace }}/.npm-cache
-          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-
       - name: 'setup-js'

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -52,7 +52,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.yarn-cache
             ${{ github.workspace }}/.npm-cache
-          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-
       - name: 'setup-js'
@@ -91,7 +91,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.yarn-cache
             ${{ github.workspace }}/.npm-cache
-          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-
       - name: 'setup-js'
@@ -119,7 +119,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.yarn-cache
             ${{ github.workspace }}/.npm-cache
-          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-
       - name: 'setup-js'

--- a/.github/workflows/react-api-client-test.yaml
+++ b/.github/workflows/react-api-client-test.yaml
@@ -44,7 +44,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.yarn-cache
             ${{ github.workspace }}/.npm-cache
-          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-
       - name: 'setup-js'

--- a/.github/workflows/shared-data-test-lint-deploy.yaml
+++ b/.github/workflows/shared-data-test-lint-deploy.yaml
@@ -112,7 +112,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.yarn-cache
             ${{ github.workspace }}/.npm-cache
-          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-
       - name: 'setup-js'

--- a/.github/workflows/step-generation-test.yaml
+++ b/.github/workflows/step-generation-test.yaml
@@ -45,7 +45,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.yarn-cache
             ${{ github.workspace }}/.npm-cache
-          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-
       - name: 'setup-js'


### PR DESCRIPTION
## Overview

We've been seeing periodic flakiness in cache upload from CI with the following failure:

```
Error: .github/workflows/app-test-build-deploy.yaml (Line: 120, Col: 16):
Error: The template is not valid. .github/workflows/app-test-build-deploy.yaml (Line: 120, Col: 16): hashFiles('**/yarn.lock') couldn't finish within 120 seconds.
```

Upon inspection on my own machine, `**/yarn.lock` matches a bunch of files after `make setup-js` is run, most of which have nothing to do with our dev environment:

```
❯ ls **/yarn.lock
app-shell/node_modules/combined-stream/yarn.lock
app-shell/node_modules/react-input-autosize/yarn.lock
app-shell/node_modules/uri-js/yarn.lock
node_modules/@cypress/request/node_modules/form-data/yarn.lock
node_modules/better-opn/yarn.lock
node_modules/browserify-zlib/yarn.lock
node_modules/combined-stream/yarn.lock
node_modules/copy-to-clipboard/yarn.lock
node_modules/detective-postcss/yarn.lock
node_modules/file-exists-dazinatorfork/yarn.lock
node_modules/microevent.ts/yarn.lock
node_modules/minimalcss/yarn.lock
node_modules/postcss-discard-overridden/yarn.lock
node_modules/react-input-autosize/yarn.lock
node_modules/request/node_modules/form-data/yarn.lock
node_modules/socks-proxy-agent/yarn.lock
node_modules/sumchecker/yarn.lock
node_modules/tiny-emitter/yarn.lock
node_modules/uri-js/yarn.lock
node_modules/worker-rpc/yarn.lock
yarn.lock
```

Except for our own `yarn.lock`, all those other lock files seem to be stuff those `npm` packages have accidentally published. They're not used by yarn when resolving/installing _our_ development environment.

Unless [`hashFiles`](https://docs.github.com/en/actions/learn-github-actions/expressions#hashfiles) is smart enough to skip `node_modules`, we could be wasting CI time including calculating the hash of _all_ of these files. There's a good chance `node_modules` isn't in play when the cache key is calculated (though GitHub Actions seems to be re-hashing in the post-cache step). Even so, though, the globstar would cause some file tree traversal, which could be bad on macOS Ci runners that are known to occasionally have slow filesystem access.

This PR replaces `hashFiles('**/yarn.lock')` with `hashFiles('yarn.lock')`, which I hope could avoid hitting this 2 minute hash timeout.

### Updates after publishing the PR

Upon investigation of previous CI runs and those triggered by this PR, this is my working theory of the timeline of the failure:

1. Cache step runs
    1. Workflow YAML file is read, `hashFiles` is called
    2. `node_modules` is not yet present, so only top-level `yarn.lock` gets hashed, producing the correct hash key
    3. Cache restored
2. CI runs
3. Post-cache step runs
    1. Workflow YAML file is read **again** for some reason, `hashFiles` is called again
    2. Post-cache checks that the cache was hit in step (1), declines to upload new cache
    3. Newly computed cache key is thrown away because it wasn't actually needed

Evidence / example runs:

- The cache keys produced by this PR are identical to `edge`, indicating that the initial file hashing was only grabbing the single `yarn.lock`
- `edge` post-cache on macOS takes ~1 minute  simply to skip the upload due to cache hit
    - Since this job isn't doing anything, and the failure we've been seeing was due to `hashFiles` timeout, it _must_ be running `hashFiles` in the post-cache step, even though it isn't necessary
    - https://github.com/Opentrons/opentrons/runs/6103940404?check_suite_focus=true
- `ci_hash-top-yarn-lock` post-cache on macOS takes `0s` to do the same thing (skip cache upload due to cache hit)
    - https://github.com/Opentrons/opentrons/runs/6116965518?check_suite_focus=true

## Changelog

- ci(cache): only hash top-level yarn.lock for cache resolution

## Review requests

- [ ] CI is green
- [ ] My "facts" above are actually true

## Risk assessment

There are two failure modes that I can think of:

1. We bust the cache too infrequently, leading to builds pulling in state caches (more likely, given the change)
5. We bust the cache too much, resulting in longer CI times

(1) can result in some pretty pernicious stuff, so we should be extra sure that my assessment of the situation is correct.