### PR TITLE
feat(ot3): add pipette tip handling CAN messages

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -121,8 +121,8 @@ class MessageId(int, Enum):
     limit_sw_request = 0x08
     limit_sw_response = 0x09
 
-    pick_up_tip_request = 0x501
-    pick_up_tip_response = 0x502
+    do_self_contained_pickup_request = 0x501
+    do_self_contained_pickup_response = 0x502
     drop_tip_request = 0x503
     drop_tip_response = 0x504
 

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -121,6 +121,11 @@ class MessageId(int, Enum):
     limit_sw_request = 0x08
     limit_sw_response = 0x09
 
+    pick_up_tip_request = 0x501
+    pick_up_tip_response = 0x502
+    drop_tip_request = 0x503
+    drop_tip_response = 0x504
+
     read_sensor_request = 0x82
     write_sensor_request = 0x83
     baseline_sensor_request = 0x84

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -121,10 +121,8 @@ class MessageId(int, Enum):
     limit_sw_request = 0x08
     limit_sw_response = 0x09
 
-    do_self_contained_pickup_request = 0x501
-    do_self_contained_pickup_response = 0x502
-    drop_tip_request = 0x503
-    drop_tip_response = 0x504
+    do_self_contained_tip_action_request = 0x501
+    do_self_contained_tip_action_response = 0x502
 
     read_sensor_request = 0x82
     write_sensor_request = 0x83

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -489,14 +489,18 @@ class GripperInfoResponse:  # noqa: D101
 class PickUpTipRequest:  # noqa: D101
     payload: payloads.PickUpTipRequestPayload
     payload_type: Type[BinarySerializable] = payloads.PickUpTipRequestPayload
-    message_id: Literal[MessageId.pick_up_tip_request] = MessageId.pick_up_tip_request
+    message_id: Literal[
+        MessageId.do_self_contained_pickup_request
+    ] = MessageId.do_self_contained_pickup_request
 
 
 @dataclass
 class PickUpTipResponse:  # noqa: D101
     payload: payloads.PickUpTipResponsePayload
     payload_type: Type[BinarySerializable] = payloads.PickUpTipResponsePayload
-    message_id: Literal[MessageId.pick_up_tip_response] = MessageId.pick_up_tip_response
+    message_id: Literal[
+        MessageId.do_self_contained_pickup_response
+    ] = MessageId.do_self_contained_pickup_response
 
 
 @dataclass

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -472,7 +472,6 @@ class BindSensorOutputResponse:  # noqa: D101
 
 
 @dataclass
-<<<<<<< HEAD
 class GripperInfoRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.gripper_info_request] = MessageId.gripper_info_request
 
@@ -484,7 +483,8 @@ class GripperInfoResponse:  # noqa: D101
     message_id: Literal[
         MessageId.gripper_info_response
     ] = MessageId.gripper_info_response
-=======
+
+
 class PickUpTipRequest:  # noqa: D101
     payload: payloads.PickUpTipRequestPayload
     payload_type: Type[BinarySerializable] = payloads.PickUpTipRequestPayload
@@ -510,4 +510,3 @@ class DropTipResponse:  # noqa: D101
     payload: payloads.DropTipResponsePayload
     payload_type: Type[BinarySerializable] = payloads.DropTipResponsePayload
     message_id: Literal[MessageId.drop_tip_response] = MessageId.drop_tip_response
->>>>>>> feat(ot3): add pipette tip handling CAN messages

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -485,6 +485,7 @@ class GripperInfoResponse:  # noqa: D101
     ] = MessageId.gripper_info_response
 
 
+@dataclass
 class PickUpTipRequest:  # noqa: D101
     payload: payloads.PickUpTipRequestPayload
     payload_type: Type[BinarySerializable] = payloads.PickUpTipRequestPayload

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -486,32 +486,18 @@ class GripperInfoResponse:  # noqa: D101
 
 
 @dataclass
-class PickUpTipRequest:  # noqa: D101
-    payload: payloads.PickUpTipRequestPayload
-    payload_type: Type[BinarySerializable] = payloads.PickUpTipRequestPayload
+class TipActionRequest:  # noqa: D101
+    payload: payloads.TipActionRequestPayload
+    payload_type: Type[BinarySerializable] = payloads.TipActionRequestPayload
     message_id: Literal[
-        MessageId.do_self_contained_pickup_request
-    ] = MessageId.do_self_contained_pickup_request
+        MessageId.do_self_contained_tip_action_request
+    ] = MessageId.do_self_contained_tip_action_request
 
 
 @dataclass
-class PickUpTipResponse:  # noqa: D101
-    payload: payloads.PickUpTipResponsePayload
-    payload_type: Type[BinarySerializable] = payloads.PickUpTipResponsePayload
+class TipActionResponse:  # noqa: D101
+    payload: payloads.TipActionResponsePayload
+    payload_type: Type[BinarySerializable] = payloads.TipActionResponsePayload
     message_id: Literal[
-        MessageId.do_self_contained_pickup_response
-    ] = MessageId.do_self_contained_pickup_response
-
-
-@dataclass
-class DropTipRequest:  # noqa: D101
-    payload: payloads.DropTipRequestPayload
-    payload_type: Type[BinarySerializable] = payloads.DropTipRequestPayload
-    message_id: Literal[MessageId.drop_tip_request] = MessageId.drop_tip_request
-
-
-@dataclass
-class DropTipResponse:  # noqa: D101
-    payload: payloads.DropTipResponsePayload
-    payload_type: Type[BinarySerializable] = payloads.DropTipResponsePayload
-    message_id: Literal[MessageId.drop_tip_response] = MessageId.drop_tip_response
+        MessageId.do_self_contained_tip_action_response
+    ] = MessageId.do_self_contained_tip_action_response

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -472,6 +472,7 @@ class BindSensorOutputResponse:  # noqa: D101
 
 
 @dataclass
+<<<<<<< HEAD
 class GripperInfoRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.gripper_info_request] = MessageId.gripper_info_request
 
@@ -483,3 +484,30 @@ class GripperInfoResponse:  # noqa: D101
     message_id: Literal[
         MessageId.gripper_info_response
     ] = MessageId.gripper_info_response
+=======
+class PickUpTipRequest:  # noqa: D101
+    payload: payloads.PickUpTipRequestPayload
+    payload_type: Type[BinarySerializable] = payloads.PickUpTipRequestPayload
+    message_id: Literal[MessageId.pick_up_tip_request] = MessageId.pick_up_tip_request
+
+
+@dataclass
+class PickUpTipResponse:  # noqa: D101
+    payload: payloads.PickUpTipResponsePayload
+    payload_type: Type[BinarySerializable] = payloads.PickUpTipResponsePayload
+    message_id: Literal[MessageId.pick_up_tip_response] = MessageId.pick_up_tip_response
+
+
+@dataclass
+class DropTipRequest:  # noqa: D101
+    payload: payloads.DropTipRequestPayload
+    payload_type: Type[BinarySerializable] = payloads.DropTipRequestPayload
+    message_id: Literal[MessageId.drop_tip_request] = MessageId.drop_tip_request
+
+
+@dataclass
+class DropTipResponse:  # noqa: D101
+    payload: payloads.DropTipResponsePayload
+    payload_type: Type[BinarySerializable] = payloads.DropTipResponsePayload
+    message_id: Literal[MessageId.drop_tip_response] = MessageId.drop_tip_response
+>>>>>>> feat(ot3): add pipette tip handling CAN messages

--- a/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
@@ -71,10 +71,8 @@ MessageDefinition = Union[
     defs.GripperInfoRequest,
     defs.GripperInfoResponse,
     defs.BindSensorOutputRequest,
-    defs.PickUpTipRequest,
-    defs.PickUpTipResponse,
-    defs.DropTipRequest,
-    defs.DropTipResponse,
+    defs.TipActionRequest,
+    defs.TipActionResponse,
 ]
 
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
@@ -71,6 +71,10 @@ MessageDefinition = Union[
     defs.GripperInfoRequest,
     defs.GripperInfoResponse,
     defs.BindSensorOutputRequest,
+    defs.PickUpTipRequest,
+    defs.PickUpTipResponse,
+    defs.DropTipRequest,
+    defs.DropTipResponse,
 ]
 
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -397,8 +397,8 @@ class GripperInfoResponsePayload(utils.BinarySerializable):
 
     gripper_model: utils.UInt16Field
     gripper_serial: GripperSerialField
-    
-    
+
+
 class PickUpTipRequestPayload(AddToMoveGroupRequestPayload):
     """A request to pick up a tip."""
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -397,3 +397,30 @@ class GripperInfoResponsePayload(utils.BinarySerializable):
 
     gripper_model: utils.UInt16Field
     gripper_serial: GripperSerialField
+    
+    
+class PickUpTipRequestPayload(AddToMoveGroupRequestPayload):
+    """A request to pick up a tip."""
+
+    velocity: utils.Int32Field
+
+
+@dataclass
+class PickUpTipResponsePayload(MoveGroupResponsePayload):
+    """A response that sends back whether pick up tip was successful."""
+
+    success: utils.UInt8Field
+
+
+@dataclass
+class DropTipRequestPayload(AddToMoveGroupRequestPayload):
+    """A request to drop a tip."""
+
+    velocity: utils.Int32Field
+
+
+@dataclass
+class DropTipResponsePayload(MoveGroupResponsePayload):
+    """A response that sends back whether drop tip was successful."""
+
+    success: utils.UInt8Field

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -399,28 +399,14 @@ class GripperInfoResponsePayload(utils.BinarySerializable):
     gripper_serial: GripperSerialField
 
 
-class PickUpTipRequestPayload(AddToMoveGroupRequestPayload):
-    """A request to pick up a tip."""
+class TipActionRequestPayload(AddToMoveGroupRequestPayload):
+    """A request to perform a tip action."""
 
     velocity: utils.Int32Field
 
 
 @dataclass
-class PickUpTipResponsePayload(MoveGroupResponsePayload):
-    """A response that sends back whether pick up tip was successful."""
-
-    success: utils.UInt8Field
-
-
-@dataclass
-class DropTipRequestPayload(AddToMoveGroupRequestPayload):
-    """A request to drop a tip."""
-
-    velocity: utils.Int32Field
-
-
-@dataclass
-class DropTipResponsePayload(MoveGroupResponsePayload):
-    """A response that sends back whether drop tip was successful."""
+class TipActionResponsePayload(MoveGroupResponsePayload):
+    """A response that sends back whether tip action was successful."""
 
     success: utils.UInt8Field


### PR DESCRIPTION
# Overview

For now, these messages will be used only to perform 96/384 channel pick up and drop tip commands. In the future, we would like to investigate potentially saving pipette configurations on the microcontroller itself so that we can use this CAN command for all pipette types.

# Changelog

- Added pickup and drop tip request/response messages.

# Risk assessment

None. Not being used currently.
