### PR TITLE
refactor(robot-server): ensure persisted datetimes are extracted as UTC

### DIFF
--- a/robot-server/robot_server/persistence.py
+++ b/robot-server/robot_server/persistence.py
@@ -38,7 +38,7 @@ protocol_table = sqlalchemy.Table(
     # To ensure proper functionality, all inserted datetimes must be UTC.
     sqlalchemy.Column(
         "created_at",
-        sqlalchemy.DateTime(),
+        sqlalchemy.DateTime,
         nullable=False,
     ),
     sqlalchemy.Column("protocol_key", sqlalchemy.String, nullable=True),
@@ -55,7 +55,7 @@ run_table = sqlalchemy.Table(
     # NOTE: See above note about naive datetimes
     sqlalchemy.Column(
         "created_at",
-        sqlalchemy.DateTime(),
+        sqlalchemy.DateTime,
         nullable=False,
     ),
     sqlalchemy.Column(
@@ -77,7 +77,7 @@ action_table = sqlalchemy.Table(
         primary_key=True,
     ),
     # NOTE: See above note about naive datetimes
-    sqlalchemy.Column("created_at", sqlalchemy.DateTime(), nullable=False),
+    sqlalchemy.Column("created_at", sqlalchemy.DateTime, nullable=False),
     sqlalchemy.Column("action_type", sqlalchemy.String, nullable=False),
     sqlalchemy.Column(
         "run_id",

--- a/robot-server/robot_server/protocols/protocol_store.py
+++ b/robot-server/robot_server/protocols/protocol_store.py
@@ -11,7 +11,7 @@ from anyio import Path as AsyncPath, create_task_group
 import sqlalchemy
 
 from opentrons.protocol_reader import ProtocolReader, ProtocolSource
-from robot_server.persistence import protocol_table, ensure_datetime
+from robot_server.persistence import protocol_table, ensure_utc_datetime
 
 
 _log = getLogger(__name__)
@@ -342,7 +342,7 @@ def _convert_sql_row_to_dataclass(
 ) -> _DBProtocolResource:
     protocol_id = sql_row.id
     protocol_key = sql_row.protocol_key
-    created_at = ensure_datetime(sql_row.created_at)
+    created_at = ensure_utc_datetime(sql_row.created_at)
 
     assert isinstance(protocol_id, str), f"Protocol ID {protocol_id} not a string"
     assert protocol_key is None or isinstance(
@@ -361,6 +361,6 @@ def _convert_dataclass_to_sql_values(
 ) -> Dict[str, object]:
     return {
         "id": resource.protocol_id,
-        "created_at": resource.created_at,
+        "created_at": ensure_utc_datetime(resource.created_at),
         "protocol_key": resource.protocol_key,
     }

--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional
 
 import sqlalchemy
 
-from robot_server.persistence import action_table, ensure_datetime, run_table
+from robot_server.persistence import action_table, ensure_utc_datetime, run_table
 
 from .action_models import RunAction, RunActionType
 
@@ -205,7 +205,7 @@ def _convert_sql_row_to_run(
 ) -> RunResource:
     run_id = sql_row.id
     protocol_id = sql_row.protocol_id
-    created_at = ensure_datetime(sql_row.created_at)
+    created_at = ensure_utc_datetime(sql_row.created_at)
 
     assert isinstance(run_id, str), f"Run ID {run_id} is not a string"
     assert protocol_id is None or isinstance(
@@ -226,7 +226,7 @@ def _convert_sql_row_to_run(
 def _convert_run_to_sql_values(run: RunResource) -> Dict[str, object]:
     return {
         "id": run.run_id,
-        "created_at": run.created_at,
+        "created_at": ensure_utc_datetime(run.created_at),
         "protocol_id": run.protocol_id,
     }
 
@@ -235,7 +235,7 @@ def _convert_sql_row_to_action(sql_row: sqlalchemy.engine.Row) -> RunAction:
     # rely on Pydantic and Enum to raise if data shapes are wrong
     return RunAction(
         id=sql_row.id,
-        createdAt=ensure_datetime(sql_row.created_at),
+        createdAt=ensure_utc_datetime(sql_row.created_at),
         actionType=RunActionType(sql_row.action_type),
     )
 
@@ -243,7 +243,7 @@ def _convert_sql_row_to_action(sql_row: sqlalchemy.engine.Row) -> RunAction:
 def _convert_action_to_sql_values(action: RunAction, run_id: str) -> Dict[str, object]:
     return {
         "id": action.id,
-        "created_at": action.createdAt,
+        "created_at": ensure_utc_datetime(action.createdAt),
         "action_type": action.actionType.value,
         "run_id": run_id,
     }

--- a/robot-server/tests/protocols/test_protocol_store.py
+++ b/robot-server/tests/protocols/test_protocol_store.py
@@ -1,6 +1,6 @@
 """Tests for the ProtocolStore interface."""
 import pytest
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Generator
 
@@ -55,7 +55,7 @@ async def test_insert_and_get_protocol(
     """It should store a single protocol."""
     protocol_resource = ProtocolResource(
         protocol_id="protocol-id",
-        created_at=datetime(year=2021, month=1, day=1),
+        created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
         source=ProtocolSource(
             directory=protocol_file_directory,
             main_file=(protocol_file_directory / "abc.json"),
@@ -79,7 +79,7 @@ async def test_insert_with_duplicate_key_raises(
     """It should raise an error when the given protocol ID is not unique."""
     protocol_resource_1 = ProtocolResource(
         protocol_id="protocol-id",
-        created_at=datetime(year=2021, month=1, day=1),
+        created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
         source=ProtocolSource(
             directory=protocol_file_directory,
             main_file=(protocol_file_directory / "abc.json"),
@@ -92,7 +92,7 @@ async def test_insert_with_duplicate_key_raises(
     )
     protocol_resource_2 = ProtocolResource(
         protocol_id="protocol-id",
-        created_at=datetime(year=2022, month=2, day=2),
+        created_at=datetime(year=2022, month=2, day=2, tzinfo=timezone.utc),
         source=ProtocolSource(
             directory=protocol_file_directory,
             main_file=(protocol_file_directory / "def.json"),
@@ -123,8 +123,8 @@ async def test_get_all_protocols(
     protocol_file_directory: Path, subject: ProtocolStore
 ) -> None:
     """It should get all protocols existing in the store."""
-    created_at_1 = datetime.now()
-    created_at_2 = datetime.now()
+    created_at_1 = datetime(year=2021, month=1, day=1, tzinfo=timezone.utc)
+    created_at_2 = datetime(year=2022, month=2, day=2, tzinfo=timezone.utc)
 
     resource_1 = ProtocolResource(
         protocol_id="abc",
@@ -173,7 +173,7 @@ async def test_remove_protocol(
 
     protocol_resource = ProtocolResource(
         protocol_id="protocol-id",
-        created_at=datetime(year=2021, month=1, day=1),
+        created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
         source=ProtocolSource(
             directory=directory,
             main_file=main_file,

--- a/robot-server/tests/runs/test_run_store.py
+++ b/robot-server/tests/runs/test_run_store.py
@@ -1,6 +1,6 @@
 """Tests for robot_server.runs.run_store."""
 import pytest
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Generator
 
 from sqlalchemy.engine import Engine as SQLEngine
@@ -34,7 +34,7 @@ def test_add_run(subject: RunStore) -> None:
     run = RunResource(
         run_id="run-id",
         protocol_id=None,
-        created_at=datetime.now(),
+        created_at=datetime.now(tz=timezone.utc),
         actions=[],
         is_current=True,
     )
@@ -47,7 +47,7 @@ def test_insert_actions_missing_run_id(subject: RunStore) -> None:
     """Should not be able to insert an action with a run id that does not exist."""
     action = RunAction(
         actionType=RunActionType.PLAY,
-        createdAt=datetime(year=2022, month=2, day=2),
+        createdAt=datetime(year=2022, month=2, day=2, tzinfo=timezone.utc),
         id="action-id",
     )
 
@@ -60,14 +60,14 @@ def test_update_active_run(subject: RunStore) -> None:
     run = RunResource(
         run_id="identical-run-id",
         protocol_id=None,
-        created_at=datetime(year=2021, month=1, day=1, hour=1, minute=1, second=1),
+        created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
         actions=[],
         is_current=False,
     )
     updated_run = RunResource(
         run_id="identical-run-id",
         protocol_id=None,
-        created_at=datetime(year=2021, month=1, day=1, hour=1, minute=1, second=1),
+        created_at=datetime(year=2022, month=2, day=2, tzinfo=timezone.utc),
         actions=[],
         is_current=True,
     )
@@ -75,7 +75,8 @@ def test_update_active_run(subject: RunStore) -> None:
     subject.insert(run)
 
     result = subject.update_active_run(
-        run_id=run.run_id, is_current=updated_run.is_current
+        run_id=run.run_id,
+        is_current=updated_run.is_current,
     )
     assert result.is_current == updated_run.is_current
 
@@ -91,7 +92,7 @@ def test_get_run_no_actions(subject: RunStore) -> None:
     run = RunResource(
         run_id="run-id",
         protocol_id=None,
-        created_at=datetime.now(),
+        created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
         actions=[],
         is_current=False,
     )
@@ -105,20 +106,20 @@ def test_get_run(subject: RunStore) -> None:
     """It can get a previously stored run entry."""
     action = RunAction(
         actionType=RunActionType.PLAY,
-        createdAt=datetime(year=2022, month=2, day=2),
+        createdAt=datetime(year=2022, month=2, day=2, tzinfo=timezone.utc),
         id="action-id",
     )
     run = RunResource(
         run_id="run-id",
         protocol_id=None,
-        created_at=datetime(year=2021, month=1, day=1, hour=1, minute=1, second=1),
+        created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
         actions=[],
         is_current=False,
     )
     update_run = RunResource(
         run_id="run-id",
         protocol_id=None,
-        created_at=datetime(year=2021, month=1, day=1, hour=1, minute=1, second=1),
+        created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
         actions=[action],
         is_current=False,
     )
@@ -141,14 +142,14 @@ def test_get_all_runs(subject: RunStore) -> None:
     run_1 = RunResource(
         run_id="run-id-1",
         protocol_id=None,
-        created_at=datetime.now(),
+        created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
         actions=[],
         is_current=False,
     )
     run_2 = RunResource(
         run_id="run-id-2",
         protocol_id=None,
-        created_at=datetime.now(),
+        created_at=datetime(year=2022, month=2, day=2, tzinfo=timezone.utc),
         actions=[],
         is_current=True,
     )
@@ -165,13 +166,13 @@ def test_remove_run(subject: RunStore) -> None:
     """It can remove and return a previously stored run entry."""
     action = RunAction(
         actionType=RunActionType.PLAY,
-        createdAt=datetime(year=2022, month=2, day=2),
+        createdAt=datetime(year=2022, month=2, day=2, tzinfo=timezone.utc),
         id="action-id",
     )
     run = RunResource(
         run_id="run-id",
         protocol_id=None,
-        created_at=datetime.now(),
+        created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
         actions=[action],
         is_current=True,
     )
@@ -194,21 +195,20 @@ def test_add_run_current_run_deactivates(subject: RunStore) -> None:
     """Adding a current run should mark all others as not current."""
     actions = RunAction(
         actionType=RunActionType.PLAY,
-        createdAt=datetime(year=2022, month=2, day=2),
+        createdAt=datetime(year=2023, month=3, day=3, tzinfo=timezone.utc),
         id="action-id",
     )
     run_1 = RunResource(
         run_id="run-id-1",
         protocol_id=None,
-        created_at=datetime.now(),
+        created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
         actions=[actions],
         is_current=True,
     )
-
     run_2 = RunResource(
         run_id="run-id-2",
         protocol_id=None,
-        created_at=datetime.now(),
+        created_at=datetime(year=2022, month=2, day=2, tzinfo=timezone.utc),
         actions=[],
         is_current=True,
     )
@@ -224,20 +224,20 @@ def test_update_active_run_deactivates(subject: RunStore) -> None:
     """Updating active run should deactivate other runs."""
     actions = RunAction(
         actionType=RunActionType.PLAY,
-        createdAt=datetime(year=2022, month=2, day=2),
+        createdAt=datetime(year=2023, month=3, day=3),
         id="action-id",
     )
     run_1 = RunResource(
         run_id="run-id-1",
         protocol_id=None,
-        created_at=datetime.now(),
+        created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
         actions=[actions],
         is_current=True,
     )
     run_2 = RunResource(
         run_id="run-id-2",
         protocol_id=None,
-        created_at=datetime.now(),
+        created_at=datetime(year=2022, month=2, day=2, tzinfo=timezone.utc),
         actions=[],
         is_current=True,
     )
@@ -251,10 +251,10 @@ def test_update_active_run_deactivates(subject: RunStore) -> None:
 
 
 def test_insert_actions_no_run(subject: RunStore) -> None:
-    """Insert actions with a run that dosent exist should raise an exception."""
+    """Insert actions with a run that doesn't exist should raise an exception."""
     action = RunAction(
         actionType=RunActionType.PLAY,
-        createdAt=datetime(year=2022, month=2, day=2),
+        createdAt=datetime(year=2023, month=3, day=3, tzinfo=timezone.utc),
         id="action-id-1",
     )
 


### PR DESCRIPTION
## Overview

SQLAlchemy when used with SQLite is unable to preserve timezone information when inserting datetimes into the database. Instead, they are stored as "naive" (timezone-less) datetimes.

Since I couldn't find any way to configure timezones to be stored, this PR adds on UTC to any naive datetime extracted from the DB.

## Changelog

- refactor(robot-server): ensure persisted datetimes are extracted as UTC

## Review requests

- [ ] Observed client bugs due to timezone problems are no longer observed

## Risk assessment

Low. We are very good about ensuring we always attach UTC to created datetimes, _and_ the robot has its timezone set to UTC, so even if any locale-based datetimes sneak in, they'd still be UTC in production.