### PR TITLE
refactor(api): implement thermocycler SetTargetBlockTemperature command

### DIFF
--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -298,6 +298,18 @@ class Thermocycler(mod_abc.AbstractModule):
         await self.make_cancellable(task)
         await task
 
+    # TODO(mc, 2022-04-25): de-duplicate with `set_temperature`
+    async def set_target_block_temperature(self, celsius: float) -> None:
+        """Set the Thermocycler's target block temperature.
+
+        Does not wait for the target temperature to be reached.
+
+        Args:
+            celsius: The target block temperature, in degrees celsius.
+        """
+        await self.wait_for_is_running()
+        await self._driver.set_plate_temperature(temp=celsius)
+
     async def _wait_for_lid_temp(self) -> None:
         """
         This method only exits if lid target temperature has been reached.

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -299,7 +299,12 @@ class Thermocycler(mod_abc.AbstractModule):
         await task
 
     # TODO(mc, 2022-04-25): de-duplicate with `set_temperature`
-    async def set_target_block_temperature(self, celsius: float) -> None:
+    async def set_target_block_temperature(
+        self,
+        celsius: float,
+        hold_time_seconds: Optional[float] = None,
+        volume: Optional[float] = None,
+    ) -> None:
         """Set the Thermocycler's target block temperature.
 
         Does not wait for the target temperature to be reached.
@@ -308,7 +313,12 @@ class Thermocycler(mod_abc.AbstractModule):
             celsius: The target block temperature, in degrees celsius.
         """
         await self.wait_for_is_running()
-        await self._driver.set_plate_temperature(temp=celsius)
+        await self._driver.set_plate_temperature(
+            temp=celsius,
+            hold_time=hold_time_seconds,
+            volume=volume,
+        )
+        await self.wait_next_poll()
 
     async def _wait_for_lid_temp(self) -> None:
         """

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/set_target_block_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/set_target_block_temperature.py
@@ -49,7 +49,20 @@ class SetTargetBlockTemperatureImpl(
         params: SetTargetBlockTemperatureParams,
     ) -> SetTargetBlockTemperatureResult:
         """Set a Thermocycler's target block temperature."""
-        raise NotImplementedError()
+        thermocycler_state = self._state_view.modules.get_thermocycler_module_substate(
+            params.moduleId
+        )
+        target_temperature = thermocycler_state.validate_target_block_temperature(
+            params.temperature
+        )
+        thermocycler_hardware = self._equipment.get_module_hardware_api(
+            thermocycler_state.module_id
+        )
+
+        if thermocycler_hardware is not None:
+            await thermocycler_hardware.set_target_block_temperature(target_temperature)
+
+        return SetTargetBlockTemperatureResult()
 
 
 class SetTargetBlockTemperature(

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -11,11 +11,13 @@ from opentrons.hardware_control.modules import (
     MagDeck,
     HeaterShaker,
     TempDeck,
+    Thermocycler,
 )
 from opentrons.protocol_engine.state.module_substates import (
     MagneticModuleId,
     HeaterShakerModuleId,
     TemperatureModuleId,
+    ThermocyclerModuleId,
 )
 from ..errors import (
     FailedToLoadPipetteError,
@@ -262,6 +264,13 @@ class EquipmentHandler:
         self,
         module_id: TemperatureModuleId,
     ) -> Optional[TempDeck]:
+        ...
+
+    @overload
+    def get_module_hardware_api(
+        self,
+        module_id: ThermocyclerModuleId,
+    ) -> Optional[Thermocycler]:
         ...
 
     def get_module_hardware_api(self, module_id: str) -> Optional[AbstractModule]:

--- a/api/src/opentrons/protocol_engine/state/__init__.py
+++ b/api/src/opentrons/protocol_engine/state/__init__.py
@@ -10,6 +10,10 @@ from .module_substates import (
     MagneticModuleSubState,
     HeaterShakerModuleId,
     HeaterShakerModuleSubState,
+    TemperatureModuleId,
+    TemperatureModuleSubState,
+    ThermocyclerModuleId,
+    ThermocyclerModuleSubState,
     ModuleSubStateType,
 )
 from .geometry import GeometryView, TipGeometry
@@ -43,6 +47,10 @@ __all__ = [
     "MagneticModuleSubState",
     "HeaterShakerModuleId",
     "HeaterShakerModuleSubState",
+    "TemperatureModuleId",
+    "TemperatureModuleSubState",
+    "ThermocyclerModuleId",
+    "ThermocyclerModuleSubState",
     "ModuleSubStateType",
     # computed geometry state
     "GeometryView",

--- a/api/src/opentrons/protocol_engine/state/module_substates/__init__.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/__init__.py
@@ -7,11 +7,17 @@ from .heater_shaker_module_substate import (
     HeaterShakerModuleId,
 )
 from .temperature_module_substate import TemperatureModuleSubState, TemperatureModuleId
+from .thermocycler_module_substate import (
+    ThermocyclerModuleSubState,
+    ThermocyclerModuleId,
+)
+
 
 ModuleSubStateType = Union[
     HeaterShakerModuleSubState,
     MagneticModuleSubState,
     TemperatureModuleSubState,
+    ThermocyclerModuleSubState,
 ]
 
 __all__ = [
@@ -21,6 +27,8 @@ __all__ = [
     "HeaterShakerModuleId",
     "TemperatureModuleSubState",
     "TemperatureModuleId",
+    "ThermocyclerModuleSubState",
+    "ThermocyclerModuleId",
     # Union of all module substates
     "ModuleSubStateType",
 ]

--- a/api/src/opentrons/protocol_engine/state/module_substates/thermocycler_module_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/thermocycler_module_substate.py
@@ -1,0 +1,44 @@
+"""Thermocycler Module sub-state."""
+from dataclasses import dataclass
+from typing import NewType
+
+from opentrons.protocol_engine.errors import InvalidTargetTemperatureError
+
+# TODO(mc, 2022-04-25): move to module definition
+# https://github.com/Opentrons/opentrons/issues/9800
+from opentrons.drivers.thermocycler.driver import BLOCK_TARGET_MIN, BLOCK_TARGET_MAX
+
+ThermocyclerModuleId = NewType("ThermocyclerModuleId", str)
+
+
+@dataclass(frozen=True)
+class ThermocyclerModuleSubState:
+    """Thermocycler-specific state.
+
+    Provides calculations and read-only state access
+    for an individual loaded Thermocycler Module.
+    """
+
+    module_id: ThermocyclerModuleId
+
+    @staticmethod
+    def validate_target_block_temperature(celsius: float) -> float:
+        """Validate a given target block temperature.
+
+        Args:
+            celsius: The requested block temperature.
+
+        Raises:
+            InvalidTargetTemperatureError: The given temperature
+                is outside the thermocycler's operating range.
+
+        Returns:
+            The validated temperature in degrees Celsius.
+        """
+        if BLOCK_TARGET_MIN <= celsius <= BLOCK_TARGET_MAX:
+            return celsius
+
+        raise InvalidTargetTemperatureError(
+            "Thermocycler block temperature must be between"
+            f" {BLOCK_TARGET_MIN} and {BLOCK_TARGET_MAX}, but got {celsius}."
+        )

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -42,7 +42,7 @@ from .module_substates import (
     MagneticModuleId,
     HeaterShakerModuleId,
     TemperatureModuleId,
-    # ThermocyclerModuleId,
+    ThermocyclerModuleId,
     ModuleSubStateType,
 )
 
@@ -109,64 +109,21 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
             self._handle_command(action.command)
 
         elif isinstance(action, AddModuleAction):
-            self._state.slot_by_module_id[action.module_id] = None
-            self._state.hardware_by_module_id[action.module_id] = HardwareModule(
+            self._add_module_substate(
+                module_id=action.module_id,
                 serial_number=action.serial_number,
                 definition=action.definition,
             )
-            module_id = action.module_id
-            module_model = action.definition.model
-            if ModuleModel.is_magnetic_module_model(module_model):
-                self._state.substate_by_module_id[module_id] = MagneticModuleSubState(
-                    module_id=MagneticModuleId(module_id), model=module_model
-                )
-            elif ModuleModel.is_heater_shaker_module_model(module_model):
-                self._state.substate_by_module_id[
-                    module_id
-                ] = HeaterShakerModuleSubState(
-                    module_id=HeaterShakerModuleId(module_id),
-                    plate_target_temperature=None,
-                )
-            elif ModuleModel.is_temperature_module_model(module_model):
-                self._state.substate_by_module_id[
-                    module_id
-                ] = TemperatureModuleSubState(
-                    module_id=TemperatureModuleId(module_id),
-                    plate_target_temperature=None,
-                )
 
     def _handle_command(self, command: Command) -> None:
         if isinstance(command.result, LoadModuleResult):
-            module_id = command.result.moduleId
-            serial_number = command.result.serialNumber
-            definition = command.result.definition
-            slot_name = command.params.location.slotName
-
-            self._state.slot_by_module_id[module_id] = slot_name
-            self._state.hardware_by_module_id[module_id] = HardwareModule(
-                serial_number=serial_number,
-                definition=definition,
+            self._add_module_substate(
+                module_id=command.result.moduleId,
+                serial_number=command.result.serialNumber,
+                definition=command.result.definition,
+                slot_name=command.params.location.slotName,
             )
-            module_id = command.result.moduleId
-            module_model = command.result.definition.model
-            if ModuleModel.is_magnetic_module_model(module_model):
-                self._state.substate_by_module_id[module_id] = MagneticModuleSubState(
-                    module_id=MagneticModuleId(module_id), model=module_model
-                )
-            elif ModuleModel.is_heater_shaker_module_model(module_model):
-                self._state.substate_by_module_id[
-                    module_id
-                ] = HeaterShakerModuleSubState(
-                    module_id=HeaterShakerModuleId(module_id),
-                    plate_target_temperature=None,
-                )
-            elif ModuleModel.is_temperature_module_model(module_model):
-                self._state.substate_by_module_id[
-                    module_id
-                ] = TemperatureModuleSubState(
-                    module_id=TemperatureModuleId(module_id),
-                    plate_target_temperature=None,
-                )
+
         if isinstance(
             command.result,
             (
@@ -184,6 +141,41 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
             ),
         ):
             self._handle_temperature_module_commands(command)
+
+    def _add_module_substate(
+        self,
+        module_id: str,
+        serial_number: str,
+        definition: ModuleDefinition,
+        slot_name: Optional[DeckSlotName] = None,
+    ) -> None:
+        model = definition.model
+
+        self._state.slot_by_module_id[module_id] = slot_name
+        self._state.hardware_by_module_id[module_id] = HardwareModule(
+            serial_number=serial_number,
+            definition=definition,
+        )
+
+        if ModuleModel.is_magnetic_module_model(model):
+            self._state.substate_by_module_id[module_id] = MagneticModuleSubState(
+                module_id=MagneticModuleId(module_id),
+                model=model,
+            )
+        elif ModuleModel.is_heater_shaker_module_model(model):
+            self._state.substate_by_module_id[module_id] = HeaterShakerModuleSubState(
+                module_id=HeaterShakerModuleId(module_id),
+                plate_target_temperature=None,
+            )
+        elif ModuleModel.is_temperature_module_model(model):
+            self._state.substate_by_module_id[module_id] = TemperatureModuleSubState(
+                module_id=TemperatureModuleId(module_id),
+                plate_target_temperature=None,
+            )
+        elif ModuleModel.is_thermocycler_module_model(model):
+            self._state.substate_by_module_id[module_id] = ThermocyclerModuleSubState(
+                module_id=ThermocyclerModuleId(module_id),
+            )
 
     def _handle_heater_shaker_commands(
         self,

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -268,7 +268,7 @@ class ModuleView(HasState[ModuleState]):
     def _get_module_substate(
         self, module_id: str, expected_type: Type[ModuleSubStateT], expected_name: str
     ) -> ModuleSubStateT:
-        """Return a the specific sub-state of a given module ID.
+        """Return the specific sub-state of a given module ID.
 
         Args:
             module_id: The ID of the module.

--- a/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
@@ -1,5 +1,6 @@
 import asyncio
 import mock
+from typing import AsyncGenerator, cast
 
 import pytest
 
@@ -8,7 +9,7 @@ from opentrons.drivers.thermocycler import SimulatingDriver
 from opentrons.hardware_control import modules, ExecutionManager
 
 
-@pytest.fixture
+@pytest.fixture()
 def usb_port() -> USBPort:
     return USBPort(
         name="",
@@ -18,8 +19,8 @@ def usb_port() -> USBPort:
     )
 
 
-@pytest.fixture
-async def subject(usb_port: USBPort) -> modules.Thermocycler:
+@pytest.fixture()
+async def subject(usb_port: USBPort) -> AsyncGenerator[modules.Thermocycler, None]:
     """Test subject"""
     therm = await modules.build(
         port="/dev/ot_module_sim_thermocycler0",
@@ -29,15 +30,15 @@ async def subject(usb_port: USBPort) -> modules.Thermocycler:
         loop=asyncio.get_running_loop(),
         execution_manager=ExecutionManager(),
     )
-    yield therm
+    yield cast(modules.Thermocycler, therm)
     await therm.cleanup()
 
 
-async def test_sim_initialization(subject: modules.Thermocycler):
+async def test_sim_initialization(subject: modules.Thermocycler) -> None:
     assert isinstance(subject, modules.AbstractModule)
 
 
-async def test_lid(subject: modules.Thermocycler):
+async def test_lid(subject: modules.Thermocycler) -> None:
     await subject.open()
     await subject.wait_next_poll()
     assert subject.lid_status == "open"
@@ -55,7 +56,7 @@ async def test_lid(subject: modules.Thermocycler):
     assert subject.lid_status == "open"
 
 
-async def test_sim_state(subject: modules.Thermocycler):
+async def test_sim_state(subject: modules.Thermocycler) -> None:
     assert subject.temperature == 23
     assert subject.target is None
     assert subject.status == "idle"
@@ -68,7 +69,7 @@ async def test_sim_state(subject: modules.Thermocycler):
     assert status["version"] == "dummyVersionTC"
 
 
-async def test_sim_update(subject: modules.Thermocycler):
+async def test_sim_update(subject: modules.Thermocycler) -> None:
     await subject.set_temperature(
         temperature=10, hold_time_seconds=None, hold_time_minutes=None, volume=50
     )
@@ -106,30 +107,35 @@ async def test_sim_update(subject: modules.Thermocycler):
     assert subject.lid_temp == 23
     assert subject.lid_target is None
 
+    await subject.set_target_block_temperature(celsius=50.0)
+    assert subject.target == 50.0
+    await subject.deactivate_block()
+    assert subject.target is None
 
-@pytest.fixture
+
+@pytest.fixture()
 def simulator() -> SimulatingDriver:
     return SimulatingDriver()
 
 
-@pytest.fixture
+@pytest.fixture()
 def set_plate_temp_spy(simulator: SimulatingDriver) -> mock.AsyncMock:
     return mock.AsyncMock(wraps=simulator.set_plate_temperature)
 
 
-@pytest.fixture
+@pytest.fixture()
 def simulator_set_plate_spy(
     simulator: SimulatingDriver, set_plate_temp_spy: mock.AsyncMock
 ) -> SimulatingDriver:
     """Fixture that attaches spy to simulator."""
-    simulator.set_plate_temperature = set_plate_temp_spy
+    simulator.set_plate_temperature = set_plate_temp_spy  # type: ignore[assignment]
     return simulator
 
 
-@pytest.fixture
+@pytest.fixture()
 async def set_temperature_subject(
     usb_port: USBPort, simulator_set_plate_spy: SimulatingDriver
-) -> modules.Thermocycler:
+) -> AsyncGenerator[modules.Thermocycler, None]:
     """Fixture that spys on set_plate_temperature"""
     hw_tc = modules.Thermocycler(
         port="/dev/ot_module_sim_thermocycler0",
@@ -146,7 +152,7 @@ async def set_temperature_subject(
 
 async def test_set_temperature_with_volume(
     set_temperature_subject: modules.Thermocycler, set_plate_temp_spy: mock.AsyncMock
-):
+) -> None:
     """It should call set_plate_temperature with volume param"""
     await set_temperature_subject.set_temperature(30, volume=35)
     set_plate_temp_spy.assert_called_once_with(temp=30, hold_time=0, volume=35)
@@ -154,7 +160,7 @@ async def test_set_temperature_with_volume(
 
 async def test_set_temperature_mixed_hold(
     set_temperature_subject: modules.Thermocycler, set_plate_temp_spy: mock.AsyncMock
-):
+) -> None:
     """It should call set_plate_temperature with total second count computed from
     mix of seconds and minutes."""
     await set_temperature_subject.set_temperature(
@@ -165,7 +171,7 @@ async def test_set_temperature_mixed_hold(
 
 async def test_set_temperature_just_seconds_hold(
     set_temperature_subject: modules.Thermocycler, set_plate_temp_spy: mock.AsyncMock
-):
+) -> None:
     """ "It should call set_plate_temperature with total second count computed from
     just seconds."""
     await set_temperature_subject.set_temperature(20, hold_time_seconds=30)
@@ -174,7 +180,7 @@ async def test_set_temperature_just_seconds_hold(
 
 async def test_set_temperature_just_minutes_hold(
     set_temperature_subject: modules.Thermocycler, set_plate_temp_spy: mock.AsyncMock
-):
+) -> None:
     """ "It should call set_plate_temperature with total second count computed from
     just minutes."""
     await set_temperature_subject.set_temperature(40, hold_time_minutes=5.5)
@@ -183,13 +189,13 @@ async def test_set_temperature_just_minutes_hold(
 
 async def test_set_temperature_fuzzy(
     set_temperature_subject: modules.Thermocycler, set_plate_temp_spy: mock.AsyncMock
-):
+) -> None:
     """ "It should call set_plate_temperature with passed in hold time when under
     fuzzy seconds."""
     # Test hold_time < _hold_time_fuzzy_seconds. Here we know
     # that wait_for_hold will be called with the direct hold
     # time rather than increments of 0.1
-    set_temperature_subject._wait_for_hold = mock.AsyncMock()
+    set_temperature_subject._wait_for_hold = mock.AsyncMock()  # type: ignore[assignment]  # noqa: E501
     await set_temperature_subject.set_temperature(40, hold_time_seconds=2)
     set_temperature_subject._wait_for_hold.assert_called_once_with(2)
     set_plate_temp_spy.assert_called_once_with(temp=40, hold_time=2, volume=None)
@@ -197,7 +203,7 @@ async def test_set_temperature_fuzzy(
 
 async def test_cycle_temperature(
     set_temperature_subject: modules.Thermocycler, set_plate_temp_spy: mock.AsyncMock
-):
+) -> None:
     """It should send a series of set_plate_temperature commands from
     a configuration."""
     await set_temperature_subject.cycle_temperatures(

--- a/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
@@ -9,7 +9,7 @@ from opentrons.drivers.thermocycler import SimulatingDriver
 from opentrons.hardware_control import modules, ExecutionManager
 
 
-@pytest.fixture()
+@pytest.fixture
 def usb_port() -> USBPort:
     return USBPort(
         name="",
@@ -19,7 +19,7 @@ def usb_port() -> USBPort:
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 async def subject(usb_port: USBPort) -> AsyncGenerator[modules.Thermocycler, None]:
     """Test subject"""
     therm = await modules.build(
@@ -113,17 +113,17 @@ async def test_sim_update(subject: modules.Thermocycler) -> None:
     assert subject.target is None
 
 
-@pytest.fixture()
+@pytest.fixture
 def simulator() -> SimulatingDriver:
     return SimulatingDriver()
 
 
-@pytest.fixture()
+@pytest.fixture
 def set_plate_temp_spy(simulator: SimulatingDriver) -> mock.AsyncMock:
     return mock.AsyncMock(wraps=simulator.set_plate_temperature)
 
 
-@pytest.fixture()
+@pytest.fixture
 def simulator_set_plate_spy(
     simulator: SimulatingDriver, set_plate_temp_spy: mock.AsyncMock
 ) -> SimulatingDriver:
@@ -132,7 +132,7 @@ def simulator_set_plate_spy(
     return simulator
 
 
-@pytest.fixture()
+@pytest.fixture
 async def set_temperature_subject(
     usb_port: USBPort, simulator_set_plate_spy: SimulatingDriver
 ) -> AsyncGenerator[modules.Thermocycler, None]:

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_start_set_target_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_start_set_target_temperature.py
@@ -1,4 +1,4 @@
-"""Test Heater Shaker start set temperature command implementation."""
+"""Test Heater-Shaker start set temperature command implementation."""
 from decoy import Decoy
 
 from opentrons.hardware_control.modules import HeaterShaker

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/__init__.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Thermocycler commands."""

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_set_target_block_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_set_target_block_temperature.py
@@ -1,4 +1,4 @@
-"""Test Thermocucler set block temperature command implementation."""
+"""Test Thermocycler set block temperature command implementation."""
 from decoy import Decoy
 
 from opentrons.hardware_control.modules import Thermocycler

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_set_target_block_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_set_target_block_temperature.py
@@ -1,0 +1,56 @@
+"""Test Thermocucler set block temperature command implementation."""
+from decoy import Decoy
+
+from opentrons.hardware_control.modules import Thermocycler
+
+from opentrons.protocol_engine.state import StateView
+from opentrons.protocol_engine.state.module_substates import (
+    ThermocyclerModuleSubState,
+    ThermocyclerModuleId,
+)
+from opentrons.protocol_engine.execution import EquipmentHandler
+from opentrons.protocol_engine.commands import thermocycler as tc_commands
+from opentrons.protocol_engine.commands.thermocycler.set_target_block_temperature import (  # noqa: E501
+    SetTargetBlockTemperatureImpl,
+)
+
+
+async def test_set_target_block_temperature(
+    decoy: Decoy,
+    state_view: StateView,
+    equipment: EquipmentHandler,
+) -> None:
+    """It should be able to set the specified module's target temperature."""
+    subject = SetTargetBlockTemperatureImpl(state_view=state_view, equipment=equipment)
+
+    data = tc_commands.SetTargetBlockTemperatureParams(
+        moduleId="input-thermocycler-id",
+        temperature=12.3,
+    )
+    expected_result = tc_commands.SetTargetBlockTemperatureResult()
+
+    tc_module_substate = decoy.mock(cls=ThermocyclerModuleSubState)
+    tc_hardware = decoy.mock(cls=Thermocycler)
+
+    decoy.when(
+        state_view.modules.get_thermocycler_module_substate("input-thermocycler-id")
+    ).then_return(tc_module_substate)
+
+    decoy.when(tc_module_substate.module_id).then_return(
+        ThermocyclerModuleId("thermocycler-id")
+    )
+
+    # Stub temperature validation from hs module view
+    decoy.when(tc_module_substate.validate_target_block_temperature(12.3)).then_return(
+        45.6
+    )
+
+    # Get attached hardware modules
+    decoy.when(
+        equipment.get_module_hardware_api(ThermocyclerModuleId("thermocycler-id"))
+    ).then_return(tc_hardware)
+
+    result = await subject.execute(data)
+
+    decoy.verify(await tc_hardware.set_target_block_temperature(celsius=45.6), times=1)
+    assert result == expected_result

--- a/api/tests/opentrons/protocol_engine/state/test_module_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_store.py
@@ -27,6 +27,8 @@ from opentrons.protocol_engine.state.module_substates import (
     HeaterShakerModuleSubState,
     TemperatureModuleId,
     TemperatureModuleSubState,
+    ThermocyclerModuleId,
+    ThermocyclerModuleSubState,
     ModuleSubStateType,
 )
 
@@ -68,6 +70,11 @@ def test_initial_state() -> None:
                 module_id=TemperatureModuleId("module-id"),
                 plate_target_temperature=None,
             ),
+        ),
+        (
+            lazy_fixture("thermocycler_v1_def"),
+            ModuleModel.THERMOCYCLER_MODULE_V1,
+            ThermocyclerModuleSubState(module_id=ThermocyclerModuleId("module-id")),
         ),
     ],
 )
@@ -130,6 +137,10 @@ def test_load_module(
                 module_id=TemperatureModuleId("module-id"),
                 plate_target_temperature=None,
             ),
+        ),
+        (
+            lazy_fixture("thermocycler_v1_def"),
+            ThermocyclerModuleSubState(module_id=ThermocyclerModuleId("module-id")),
         ),
     ],
 )

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -1018,7 +1018,7 @@ def test_tempdeck_get_plate_target_temperature_no_target(
         subject.get_plate_target_temperature()
 
 
-@pytest.fixture()
+@pytest.fixture
 def module_view_with_thermocycler(thermocycler_v1_def: ModuleDefinition) -> ModuleView:
     """Get a module state view with a loaded thermocycler."""
     return make_module_view(

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -27,6 +27,8 @@ from opentrons.protocol_engine.state.module_substates import (
     MagneticModuleId,
     TemperatureModuleSubState,
     TemperatureModuleId,
+    ThermocyclerModuleSubState,
+    ThermocyclerModuleId,
     ModuleSubStateType,
 )
 
@@ -1014,3 +1016,50 @@ def test_tempdeck_get_plate_target_temperature_no_target(
 
     with pytest.raises(errors.NoTargetTemperatureSetError):
         subject.get_plate_target_temperature()
+
+
+@pytest.fixture()
+def module_view_with_thermocycler(thermocycler_v1_def: ModuleDefinition) -> ModuleView:
+    """Get a module state view with a loaded thermocycler."""
+    return make_module_view(
+        slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
+        hardware_by_module_id={
+            "module-id": HardwareModule(
+                serial_number="serial-number",
+                definition=thermocycler_v1_def,
+            )
+        },
+        substate_by_module_id={
+            "module-id": ThermocyclerModuleSubState(
+                module_id=ThermocyclerModuleId("module-id"),
+            )
+        },
+    )
+
+
+@pytest.mark.parametrize("input_temperature", [0, 0.0, 0.001, 98.999, 99, 99.0])
+def test_thermocycler_validate_target_block_temperature(
+    module_view_with_thermocycler: ModuleView,
+    input_temperature: float,
+) -> None:
+    """It should return a valid target block temperature."""
+    subject = module_view_with_thermocycler.get_thermocycler_module_substate(
+        "module-id"
+    )
+    result = subject.validate_target_block_temperature(input_temperature)
+
+    assert result == input_temperature
+
+
+@pytest.mark.parametrize("input_temperature", [-0.001, 99.001])
+def test_thermocycler_validate_target_block_temperature_raises(
+    module_view_with_thermocycler: ModuleView,
+    input_temperature: float,
+) -> None:
+    """It should raise on invalid target block temperature."""
+    subject = module_view_with_thermocycler.get_thermocycler_module_substate(
+        "module-id"
+    )
+
+    with pytest.raises(errors.InvalidTargetTemperatureError):
+        subject.validate_target_block_temperature(input_temperature)


### PR DESCRIPTION
## Overview

This PR implements the new, non-blocking `thermocycler/setTargetBlockTemperature` command in the Protocol Engine.

## Changelog

- refactor(api): implement thermocycler `SetTargetBlockTemperature` command

## Review requests

- **This PR touches the hardware control layer of the thermocycler**. Careful review of the changes is appreciated
- Test with real hardware, if you can

## Risk assessment

Medium. Hardware control changes need to be validated
