### PR TITLE
refactor(app): Added test for useUpdateRobotNameMutation

### DIFF
--- a/react-api-client/src/server/__tests__/useUpdateRobotNameMutation.test.tsx
+++ b/react-api-client/src/server/__tests__/useUpdateRobotNameMutation.test.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react'
+import { when, resetAllWhenMocks } from 'jest-when'
+import { QueryClient, QueryClientProvider } from 'react-query'
+import { act, renderHook } from '@testing-library/react-hooks'
+import { updateRobotName } from '@opentrons/api-client'
+import { useHost } from '../../api'
+import { useUpdateRobotNameMutation } from '..'
+
+import type {
+  HostConfig,
+  Response,
+  UpdatedRobotName,
+} from '@opentrons/api-client'
+
+jest.mock('@opentrons/api-client')
+jest.mock('../../api/useHost')
+
+// const contents = JSON.stringify({ name: 'mockRobotName' })
+
+const newRobotName = 'mockRobotName'
+
+const mockUpdateRobotName = updateRobotName as jest.MockedFunction<
+  typeof updateRobotName
+>
+const mockUseHost = useHost as jest.MockedFunction<typeof useHost>
+
+const HOST_CONFIG: HostConfig = { hostname: 'localhost' }
+
+const UPDATEROBOTNAME_RESPONSE = {
+  name: 'mockRobotName',
+}
+
+describe('useUpdatedRobotNameMutation, hook', () => {
+  let wrapper: React.FunctionComponent<{}>
+
+  beforeEach(() => {
+    const queryClient = new QueryClient()
+    const clientProvider: React.FunctionComponent<{}> = ({ children }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+    wrapper = clientProvider
+  })
+  afterEach(() => {
+    resetAllWhenMocks()
+  })
+
+  it('should return no data when calling updateRobotName if the request fails', async () => {
+    when(mockUseHost).calledWith().mockReturnValue(HOST_CONFIG)
+    when(mockUpdateRobotName)
+      .calledWith(HOST_CONFIG, newRobotName)
+      .mockRejectedValue('error')
+
+    const { result, waitFor } = renderHook(() => useUpdateRobotNameMutation(), {
+      wrapper,
+    })
+
+    expect(result.current.data).toBeUndefined()
+    result.current.updateRobotName(newRobotName)
+    await waitFor(() => {
+      console.log(result.current.status)
+      return result.current.status !== 'loading'
+    })
+  })
+
+  it('should update a robot name when calling the useRobotName callback', async () => {
+    when(mockUseHost).calledWith().mockReturnValue(HOST_CONFIG)
+    when(mockUpdateRobotName)
+      .calledWith(HOST_CONFIG, newRobotName)
+      .mockResolvedValue({
+        data: UPDATEROBOTNAME_RESPONSE,
+      } as Response<UpdatedRobotName>)
+
+    const { result, waitFor } = renderHook(() => useUpdateRobotNameMutation(), {
+      wrapper,
+    })
+    act(() => result.current.updateRobotName(newRobotName))
+
+    await waitFor(() => result.current.data != null)
+
+    expect(result.current.data).toEqual(UPDATEROBOTNAME_RESPONSE)
+  })
+})

--- a/react-api-client/src/server/__tests__/useUpdateRobotNameMutation.test.tsx
+++ b/react-api-client/src/server/__tests__/useUpdateRobotNameMutation.test.tsx
@@ -15,10 +15,7 @@ import type {
 jest.mock('@opentrons/api-client')
 jest.mock('../../api/useHost')
 
-// const contents = JSON.stringify({ name: 'mockRobotName' })
-
 const newRobotName = 'mockRobotName'
-
 const mockUpdateRobotName = updateRobotName as jest.MockedFunction<
   typeof updateRobotName
 >
@@ -26,7 +23,7 @@ const mockUseHost = useHost as jest.MockedFunction<typeof useHost>
 
 const HOST_CONFIG: HostConfig = { hostname: 'localhost' }
 
-const UPDATEROBOTNAME_RESPONSE = {
+const UPDATE_ROBOT_NAME_RESPONSE = {
   name: 'mockRobotName',
 }
 
@@ -57,7 +54,6 @@ describe('useUpdatedRobotNameMutation, hook', () => {
     expect(result.current.data).toBeUndefined()
     result.current.updateRobotName(newRobotName)
     await waitFor(() => {
-      console.log(result.current.status)
       return result.current.status !== 'loading'
     })
   })
@@ -67,7 +63,7 @@ describe('useUpdatedRobotNameMutation, hook', () => {
     when(mockUpdateRobotName)
       .calledWith(HOST_CONFIG, newRobotName)
       .mockResolvedValue({
-        data: UPDATEROBOTNAME_RESPONSE,
+        data: UPDATE_ROBOT_NAME_RESPONSE,
       } as Response<UpdatedRobotName>)
 
     const { result, waitFor } = renderHook(() => useUpdateRobotNameMutation(), {
@@ -77,6 +73,6 @@ describe('useUpdatedRobotNameMutation, hook', () => {
 
     await waitFor(() => result.current.data != null)
 
-    expect(result.current.data).toEqual(UPDATEROBOTNAME_RESPONSE)
+    expect(result.current.data).toEqual(UPDATE_ROBOT_NAME_RESPONSE)
   })
 })


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Added useUpdateRobotNameMutation that is for renaming a robot function.
This will fix #10078
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- Added test for useUpdateRobotNameMutation
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
useUpdateRobotNameMutation uses useUpdateRobotName function (api-client/server) to send a POST request to `server/name`

data format: `{name: string}`

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
