### PR TITLE
feat(app): add protocol labware details

### DIFF
--- a/app/src/assets/localization/en/protocol_details.json
+++ b/app/src/assets/localization/en/protocol_details.json
@@ -25,5 +25,8 @@
   "unavailable_or_busy_robot_not_listed": "{{count}} unavailable or busy robot is not listed",
   "unavailable_or_busy_robot_not_listed_plural": "{{count}} unavailable or busy robots are not listed",
   "view_all_robots": "View all robots on the Devices page",
-  "view_run_details": "View run details"
+  "view_run_details": "View run details",
+  "labware_name": "Labware Name",
+  "quantity": "Quantity",
+  "go_to_labware_definition": "Go to labware definition"
 }

--- a/app/src/organisms/Labware/LabwareCard.tsx
+++ b/app/src/organisms/Labware/LabwareCard.tsx
@@ -33,7 +33,7 @@ export function LabwareCard(props: LabwareCardProps): JSX.Element {
   const apiName = definition.parameters.loadName
   const displayName = definition?.metadata.displayName
   const displayCategory = startCase(definition.metadata.displayCategory)
-  const isCustomDefinition = modified != null
+  const isCustomDefinition = definition.namespace !== 'opentrons'
 
   return (
     <Box

--- a/app/src/organisms/Labware/LabwareDetails/index.tsx
+++ b/app/src/organisms/Labware/LabwareDetails/index.tsx
@@ -48,7 +48,7 @@ export function LabwareDetails(props: LabwareDetailsProps): JSX.Element {
   const insertCategory = insert?.metadata.displayCategory
   const irregular = wellGroups.length > 1
   const isMultiRow = ordering.some(row => row.length > 1)
-  const isCustomDefinition = modified != null
+  const isCustomDefinition = definition.namespace !== 'opentrons'
 
   const slideoutHeader = (
     <Flex

--- a/app/src/organisms/Labware/__tests__/LabwareCard.test.tsx
+++ b/app/src/organisms/Labware/__tests__/LabwareCard.test.tsx
@@ -37,6 +37,7 @@ describe('LabwareCard', () => {
   })
 
   it('renders correct info for opentrons labware card', () => {
+    props.labware.definition.namespace = 'opentrons'
     const [{ getByText, getByRole }] = render(props)
     getByText('mock RobotWorkSpace')
     getByText('Well Plate')
@@ -49,6 +50,7 @@ describe('LabwareCard', () => {
   it('renders additional info for custom labware card', () => {
     props.labware.modified = 123
     props.labware.filename = 'mock/filename'
+    props.labware.definition.namespace = 'custom'
     const [{ getByText }] = render(props)
     getByText('Custom Definition')
     getByText(nestedTextMatcher('Date added'))

--- a/app/src/organisms/ProtocolDetails/OverflowMenu.tsx
+++ b/app/src/organisms/ProtocolDetails/OverflowMenu.tsx
@@ -10,7 +10,9 @@ import {
   POSITION_RELATIVE,
   ALIGN_FLEX_END,
   SIZE_4,
+  Overlay,
 } from '@opentrons/components'
+import { Portal } from '../../App/portal'
 import { OverflowBtn } from '../../atoms/MenuList/OverflowBtn'
 import { MenuItem } from '../../atoms/MenuList/MenuItem'
 import {
@@ -44,6 +46,11 @@ export function OverflowMenu(props: OverflowMenuProps): JSX.Element {
     e.preventDefault()
     setShowOverflowMenu(!showOverflowMenu)
   }
+
+  const handleClickOutside: React.MouseEventHandler<HTMLDivElement> = e => {
+    e.preventDefault()
+    setShowOverflowMenu(false)
+  }
   return (
     <Flex flexDirection={DIRECTION_COLUMN} position={POSITION_RELATIVE}>
       <OverflowBtn alignSelf={ALIGN_FLEX_END} onClick={handleOverflowClick} />
@@ -65,6 +72,14 @@ export function OverflowMenu(props: OverflowMenuProps): JSX.Element {
           <MenuItem onClick={handleClickReanalyze}>{t('reanalyze')}</MenuItem>
         </Flex>
       ) : null}
+      <Portal level="top">
+        {showOverflowMenu ? (
+          <Overlay
+            onClick={handleClickOutside}
+            backgroundColor={COLORS.transparent}
+          />
+        ) : null}
+      </Portal>
     </Flex>
   )
 }

--- a/app/src/organisms/ProtocolDetails/ProtocolLabwareDetails.tsx
+++ b/app/src/organisms/ProtocolDetails/ProtocolLabwareDetails.tsx
@@ -13,9 +13,9 @@ import {
   POSITION_RELATIVE,
   SIZE_5,
   SPACING,
-  TEXT_TRANSFORM_CAPITALIZE,
   TYPOGRAPHY,
 } from '@opentrons/components'
+import { getLabwareDefURI } from '@opentrons/shared-data'
 import { StyledText } from '../../atoms/text'
 import { Divider } from '../../atoms/structure'
 import { OverflowBtn } from '../../atoms/MenuList/OverflowBtn'
@@ -41,12 +41,12 @@ export const ProtocolLabwareDetails = (
       ? [
           ...requiredLabwareDetails
             .reduce((obj, labware) => {
-              if (!obj.has(labware.result.definition.parameters.loadName))
-                obj.set(labware.result.definition.parameters.loadName, {
+              if (!obj.has(getLabwareDefURI(labware.result.definition)))
+                obj.set(getLabwareDefURI(labware.result.definition), {
                   ...labware,
                   quantity: 0,
                 })
-              obj.get(labware.result.definition.parameters.loadName).quantity++
+              obj.get(getLabwareDefURI(labware.result.definition)).quantity++
               return obj
             }, new Map())
             .values(),
@@ -60,7 +60,6 @@ export const ProtocolLabwareDetails = (
           as="label"
           fontWeight={TYPOGRAPHY.fontWeightSemiBold}
           color={COLORS.darkBlack}
-          textTransform={TEXT_TRANSFORM_CAPITALIZE}
           data-testid={'ProtocolLabwareDetails_labware_name'}
         >
           {t('labware_name')}
@@ -69,7 +68,6 @@ export const ProtocolLabwareDetails = (
           as="label"
           fontWeight={TYPOGRAPHY.fontWeightSemiBold}
           color={COLORS.darkBlack}
-          textTransform={TEXT_TRANSFORM_CAPITALIZE}
           marginLeft={SIZE_5}
           data-testid={'ProtocolLabwareDetails_quantity'}
         >

--- a/app/src/organisms/ProtocolDetails/ProtocolLabwareDetails.tsx
+++ b/app/src/organisms/ProtocolDetails/ProtocolLabwareDetails.tsx
@@ -116,27 +116,17 @@ export const ProtocolLabwareDetailItem = (
             <Icon
               color={COLORS.blue}
               name="check-decagram"
-              height=".7rem"
+              height=".75rem"
               marginRight={SPACING.spacing3}
             />
           ) : (
             <Flex marginLeft={SPACING.spacingM} />
           )}
-          <StyledText
-            as="p"
-            fontWeight={TYPOGRAPHY.fontWeightRegular}
-            color={COLORS.darkBlack}
-            width={SIZE_5}
-          >
+          <StyledText as="p" color={COLORS.darkBlack} width={SIZE_5}>
             {displayName}
           </StyledText>
         </Flex>
-        <StyledText
-          as="p"
-          fontWeight={TYPOGRAPHY.fontWeightRegular}
-          color={COLORS.darkBlack}
-          marginLeft={'5rem'}
-        >
+        <StyledText as="p" color={COLORS.darkBlack} marginLeft={'5rem'}>
           {quantity}
         </StyledText>
         <LabwareDetailOverflowMenu labware={labware} />

--- a/app/src/organisms/ProtocolDetails/ProtocolLabwareDetails.tsx
+++ b/app/src/organisms/ProtocolDetails/ProtocolLabwareDetails.tsx
@@ -11,8 +11,7 @@ import {
   Overlay,
   POSITION_ABSOLUTE,
   POSITION_RELATIVE,
-  SIZE_3,
-  SIZE_4,
+  SIZE_5,
   SPACING,
   TEXT_TRANSFORM_CAPITALIZE,
   TYPOGRAPHY,
@@ -56,25 +55,23 @@ export const ProtocolLabwareDetails = (
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN}>
-      <Flex
-        flexDirection={DIRECTION_ROW}
-        justifyContent={JUSTIFY_SPACE_BETWEEN}
-      >
+      <Flex flexDirection={DIRECTION_ROW}>
         <StyledText
           as="label"
           fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-          marginRight={SPACING.spacing4}
           color={COLORS.darkBlack}
           textTransform={TEXT_TRANSFORM_CAPITALIZE}
+          data-testid={'ProtocolLabwareDetails_labware_name'}
         >
           {t('labware_name')}
         </StyledText>
         <StyledText
           as="label"
           fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-          marginRight={SIZE_4}
           color={COLORS.darkBlack}
           textTransform={TEXT_TRANSFORM_CAPITALIZE}
+          marginLeft={SIZE_5}
+          data-testid={'ProtocolLabwareDetails_quantity'}
         >
           {t('quantity')}
         </StyledText>
@@ -87,6 +84,7 @@ export const ProtocolLabwareDetails = (
               displayName={labware.result.definition.metadata.displayName}
               quantity={labware.quantity}
               labware={{ definition: labware.result.definition }}
+              data-testid={`ProtocolLabwareDetails_item_${index}`}
             />
           </React.Fragment>
         )
@@ -124,13 +122,13 @@ export const ProtocolLabwareDetailItem = (
               marginRight={SPACING.spacing3}
             />
           ) : (
-            <Flex marginLeft={'1.25rem'}></Flex>
+            <Flex marginLeft={SPACING.spacingM} />
           )}
           <StyledText
             as="p"
             fontWeight={TYPOGRAPHY.fontWeightRegular}
             color={COLORS.darkBlack}
-            width={'15rem'}
+            width={SIZE_5}
           >
             {displayName}
           </StyledText>
@@ -139,7 +137,7 @@ export const ProtocolLabwareDetailItem = (
           as="p"
           fontWeight={TYPOGRAPHY.fontWeightRegular}
           color={COLORS.darkBlack}
-          marginLeft={SIZE_3}
+          marginLeft={'5rem'}
         >
           {quantity}
         </StyledText>
@@ -184,8 +182,11 @@ export const LabwareDetailOverflowMenu = (
       flexDirection={DIRECTION_COLUMN}
       position={POSITION_RELATIVE}
       marginRight={SPACING.spacing3}
+      marginLeft={'auto'}
     >
-      <OverflowBtn onClick={handleOverflowClick} />
+      <Flex>
+        <OverflowBtn onClick={handleOverflowClick} />
+      </Flex>
       {showOverflowMenu ? (
         <Flex
           width={'11rem'}

--- a/app/src/organisms/ProtocolDetails/ProtocolLabwareDetails.tsx
+++ b/app/src/organisms/ProtocolDetails/ProtocolLabwareDetails.tsx
@@ -1,0 +1,222 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  ALIGN_CENTER,
+  COLORS,
+  DIRECTION_COLUMN,
+  DIRECTION_ROW,
+  Flex,
+  Icon,
+  JUSTIFY_SPACE_BETWEEN,
+  Overlay,
+  POSITION_ABSOLUTE,
+  POSITION_RELATIVE,
+  SIZE_3,
+  SIZE_4,
+  SPACING,
+  TEXT_TRANSFORM_CAPITALIZE,
+  TYPOGRAPHY,
+} from '@opentrons/components'
+import { StyledText } from '../../atoms/text'
+import { Divider } from '../../atoms/structure'
+import { OverflowBtn } from '../../atoms/MenuList/OverflowBtn'
+import { MenuItem } from '../../atoms/MenuList/MenuItem'
+import { Portal } from '../../App/portal'
+import { LabwareDetails } from '../Labware/LabwareDetails'
+
+import type { LoadLabwareRunTimeCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
+import type { LabwareDefAndDate } from '../Labware/hooks'
+
+interface ProtocolLabwareDetailsProps {
+  requiredLabwareDetails: LoadLabwareRunTimeCommand[] | null
+}
+
+export const ProtocolLabwareDetails = (
+  props: ProtocolLabwareDetailsProps
+): JSX.Element => {
+  const { requiredLabwareDetails } = props
+  const { t } = useTranslation('protocol_details')
+
+  const labwareDetails =
+    requiredLabwareDetails != null
+      ? [
+          ...requiredLabwareDetails
+            .reduce((obj, labware) => {
+              if (!obj.has(labware.result.definition.parameters.loadName))
+                obj.set(labware.result.definition.parameters.loadName, {
+                  ...labware,
+                  quantity: 0,
+                })
+              obj.get(labware.result.definition.parameters.loadName).quantity++
+              return obj
+            }, new Map())
+            .values(),
+        ]
+      : []
+
+  return (
+    <Flex flexDirection={DIRECTION_COLUMN}>
+      <Flex
+        flexDirection={DIRECTION_ROW}
+        justifyContent={JUSTIFY_SPACE_BETWEEN}
+      >
+        <StyledText
+          as="label"
+          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+          marginRight={SPACING.spacing4}
+          color={COLORS.darkBlack}
+          textTransform={TEXT_TRANSFORM_CAPITALIZE}
+        >
+          {t('labware_name')}
+        </StyledText>
+        <StyledText
+          as="label"
+          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+          marginRight={SIZE_4}
+          color={COLORS.darkBlack}
+          textTransform={TEXT_TRANSFORM_CAPITALIZE}
+        >
+          {t('quantity')}
+        </StyledText>
+      </Flex>
+      {labwareDetails?.map((labware, index) => {
+        return (
+          <React.Fragment key={index}>
+            <ProtocolLabwareDetailItem
+              namespace={labware.params.namespace}
+              displayName={labware.result.definition.metadata.displayName}
+              quantity={labware.quantity}
+              labware={{ definition: labware.result.definition }}
+            />
+          </React.Fragment>
+        )
+      })}
+    </Flex>
+  )
+}
+
+interface ProtocolLabwareDetailItemProps {
+  namespace: string
+  displayName: string
+  quantity: string
+  labware: LabwareDefAndDate
+}
+
+export const ProtocolLabwareDetailItem = (
+  props: ProtocolLabwareDetailItemProps
+): JSX.Element => {
+  const { namespace, displayName, quantity, labware } = props
+  return (
+    <>
+      <Divider width="100%" />
+      <Flex
+        flexDirection={DIRECTION_ROW}
+        marginY={SPACING.spacing3}
+        alignItems={ALIGN_CENTER}
+        justifyContent={JUSTIFY_SPACE_BETWEEN}
+      >
+        <Flex flexDirection={DIRECTION_ROW} alignItems={ALIGN_CENTER}>
+          {namespace === 'opentrons' ? (
+            <Icon
+              color={COLORS.blue}
+              name="check-decagram"
+              height=".7rem"
+              marginRight={SPACING.spacing3}
+            />
+          ) : (
+            <Flex marginLeft={'1.25rem'}></Flex>
+          )}
+          <StyledText
+            as="p"
+            fontWeight={TYPOGRAPHY.fontWeightRegular}
+            color={COLORS.darkBlack}
+            width={'15rem'}
+          >
+            {displayName}
+          </StyledText>
+        </Flex>
+        <StyledText
+          as="p"
+          fontWeight={TYPOGRAPHY.fontWeightRegular}
+          color={COLORS.darkBlack}
+          marginLeft={SIZE_3}
+        >
+          {quantity}
+        </StyledText>
+        <LabwareDetailOverflowMenu labware={labware} />
+      </Flex>
+    </>
+  )
+}
+
+interface LabwareDetailOverflowMenuProps {
+  labware: LabwareDefAndDate
+}
+
+export const LabwareDetailOverflowMenu = (
+  props: LabwareDetailOverflowMenuProps
+): JSX.Element => {
+  const { labware } = props
+  const { t } = useTranslation('protocol_details')
+  const [showOverflowMenu, setShowOverflowMenu] = React.useState<boolean>(false)
+  const [
+    showLabwareDetailSlideout,
+    setShowLabwareDetailSlideout,
+  ] = React.useState<boolean>(false)
+
+  const handleOverflowClick: React.MouseEventHandler<HTMLButtonElement> = e => {
+    e.preventDefault()
+    setShowOverflowMenu(!showOverflowMenu)
+  }
+
+  const handleClickOutside: React.MouseEventHandler<HTMLDivElement> = e => {
+    e.preventDefault()
+    setShowOverflowMenu(false)
+  }
+
+  const handleClickMenuItem: React.MouseEventHandler<HTMLButtonElement> = e => {
+    e.preventDefault()
+    setShowOverflowMenu(false)
+    setShowLabwareDetailSlideout(true)
+  }
+  return (
+    <Flex
+      flexDirection={DIRECTION_COLUMN}
+      position={POSITION_RELATIVE}
+      marginRight={SPACING.spacing3}
+    >
+      <OverflowBtn onClick={handleOverflowClick} />
+      {showOverflowMenu ? (
+        <Flex
+          width={'11rem'}
+          zIndex={10}
+          borderRadius={'4px 4px 0px 0px'}
+          boxShadow={'0px 1px 3px rgba(0, 0, 0, 0.2)'}
+          position={POSITION_ABSOLUTE}
+          backgroundColor={COLORS.white}
+          top="3rem"
+          right={0}
+          flexDirection={DIRECTION_COLUMN}
+        >
+          <MenuItem onClick={handleClickMenuItem}>
+            {t('go_to_labware_definition')}
+          </MenuItem>
+        </Flex>
+      ) : null}
+      <Portal level="top">
+        {showOverflowMenu ? (
+          <Overlay
+            onClick={handleClickOutside}
+            backgroundColor={COLORS.transparent}
+          />
+        ) : null}
+        {showLabwareDetailSlideout ? (
+          <LabwareDetails
+            labware={labware}
+            onClose={() => setShowLabwareDetailSlideout(false)}
+          />
+        ) : null}
+      </Portal>
+    </Flex>
+  )
+}

--- a/app/src/organisms/ProtocolDetails/__tests__/ProtocolLabwareDetails.test.tsx
+++ b/app/src/organisms/ProtocolDetails/__tests__/ProtocolLabwareDetails.test.tsx
@@ -1,0 +1,137 @@
+import * as React from 'react'
+import { renderWithProviders } from '@opentrons/components'
+import { i18n } from '../../../i18n'
+import { ProtocolLabwareDetails } from '../ProtocolLabwareDetails'
+
+import type { LoadLabwareRunTimeCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
+
+const mockRequiredLabwareDetails = [
+  {
+    id: '568fd127-5554-4e19-b303-a8aeb6d8547d',
+    createdAt: '2022-04-18T19:16:57.398480+00:00',
+    commandType: 'loadLabware',
+    key: '568fd127-5554-4e19-b303-a8aeb6d8547d',
+    status: 'succeeded',
+    params: {
+      location: {
+        moduleId: '3e012450-3412-11eb-ad93-ed232a2337cf:magneticModuleType',
+      },
+      loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
+      namespace: 'opentrons',
+      version: 1,
+      labwareId:
+        'aac5d680-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+      displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
+    },
+    result: {
+      labwareId:
+        'aac5d680-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+      definition: {
+        version: 1,
+        schemaVersion: 2,
+        namespace: 'opentrons',
+        metadata: {
+          displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
+          displayCategory: 'wellPlate',
+          displayVolumeUnits: 'mL',
+        },
+        dimensions: { xDimension: 0, yDimension: 0, zDimension: 0 },
+        cornerOffsetFromSlot: { x: 0, y: 0, z: 0 },
+        parameters: {
+          loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
+          format: 'mock',
+          isTiprack: false,
+          isMagneticModuleCompatible: false,
+        },
+        brand: { brand: 'Opentrons' },
+        ordering: [],
+        wells: {},
+        groups: [],
+      },
+      offset: { x: 0, y: 0, z: 0 },
+    },
+    error: null,
+    startedAt: '2022-04-18T19:16:57.403135+00:00',
+    completedAt: '2022-04-18T19:16:57.403198+00:00',
+  } as LoadLabwareRunTimeCommand,
+]
+
+const render = (props: React.ComponentProps<typeof ProtocolLabwareDetails>) => {
+  return renderWithProviders(<ProtocolLabwareDetails {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+describe('ProtocolLabwareDetails', () => {
+  let props: React.ComponentProps<typeof ProtocolLabwareDetails>
+  beforeEach(() => {
+    props = {
+      requiredLabwareDetails: mockRequiredLabwareDetails,
+    }
+  })
+
+  it('should render an opentrons labware', () => {
+    const { getByText } = render(props)
+    getByText('Labware Name')
+    getByText('NEST 96 Well Plate 100 µL PCR Full Skirt')
+    getByText('Quantity')
+    getByText('1')
+  })
+
+  it('should render two quantites of the same opentrons labware', () => {
+    mockRequiredLabwareDetails.push({
+      id: '568fd127-5554-4e19-b303-a8aeb6d8547d',
+      createdAt: '2022-04-18T19:16:57.398480+00:00',
+      commandType: 'loadLabware',
+      key: '568fd127-5554-4e19-b303-a8aeb6d8547d',
+      status: 'succeeded',
+      params: {
+        location: {
+          moduleId: '3e012450-3412-11eb-ad93-ed232a2337cf:magneticModuleType',
+        },
+        loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
+        namespace: 'opentrons',
+        version: 1,
+        labwareId:
+          'aac5d680-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+        displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
+      },
+      result: {
+        labwareId:
+          'aac5d680-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+        definition: {
+          version: 1,
+          schemaVersion: 2,
+          namespace: 'opentrons',
+          metadata: {
+            displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
+            displayCategory: 'wellPlate',
+            displayVolumeUnits: 'mL',
+          },
+          dimensions: { xDimension: 0, yDimension: 0, zDimension: 0 },
+          cornerOffsetFromSlot: { x: 0, y: 0, z: 0 },
+          parameters: {
+            loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
+            format: 'mock',
+            isTiprack: false,
+            isMagneticModuleCompatible: false,
+          },
+          brand: { brand: 'Opentrons' },
+          ordering: [],
+          wells: {},
+          groups: [],
+        },
+        offset: { x: 0, y: 0, z: 0 },
+      },
+      error: null,
+      startedAt: '2022-04-18T19:16:57.403135+00:00',
+      completedAt: '2022-04-18T19:16:57.403198+00:00',
+    } as LoadLabwareRunTimeCommand)
+
+    const { getByText } = render(props)
+    getByText('Labware Name')
+    getByText('NEST 96 Well Plate 100 µL PCR Full Skirt')
+    getByText('Quantity')
+    getByText('2')
+  })
+})

--- a/app/src/organisms/ProtocolDetails/index.tsx
+++ b/app/src/organisms/ProtocolDetails/index.tsx
@@ -27,6 +27,8 @@ import {
 import {
   parseInitialPipetteNamesByMount,
   parseInitialLoadedModulesBySlot,
+  parseInitialLoadedLabwareBySlot,
+  parseInitialLoadedLabwareByModuleId,
 } from '@opentrons/api-client'
 
 import { getIsProtocolAnalysisInProgress } from '../../redux/protocol-storage'
@@ -37,6 +39,8 @@ import { PrimaryButton } from '../../atoms/Buttons'
 import { Divider } from '../../atoms/structure'
 import { ChooseRobotSlideout } from '../ChooseRobotSlideout'
 import { OverflowMenu } from './OverflowMenu'
+import { RobotConfigurationDetails } from './RobotConfigurationDetails'
+import { ProtocolLabwareDetails } from './ProtocolLabwareDetails'
 import {
   getAnalysisStatus,
   getProtocolDisplayName,
@@ -44,7 +48,6 @@ import {
 
 import type { State } from '../../redux/types'
 import type { StoredProtocolData } from '../../redux/protocol-storage'
-import { RobotConfigurationDetails } from './RobotConfigurationDetails'
 
 const defaultTabStyle = css`
   ${TYPOGRAPHY.pSemiBold}
@@ -129,6 +132,15 @@ export function ProtocolDetails(
     )
   )
 
+  const requiredLabwareDetails = map({
+    ...parseInitialLoadedLabwareByModuleId(
+      mostRecentAnalysis.commands != null ? mostRecentAnalysis.commands : []
+    ),
+    ...parseInitialLoadedLabwareBySlot(
+      mostRecentAnalysis.commands != null ? mostRecentAnalysis.commands : []
+    ),
+  }).filter(labware => labware.result.definition.parameters.format !== 'trash')
+
   const protocolDisplayName = getProtocolDisplayName(
     protocolKey,
     srcFileNames,
@@ -143,7 +155,7 @@ export function ProtocolDetails(
 
   const getTabContents = (): JSX.Element =>
     currentTab === 'labware' ? (
-      <Box>TODO: labware tab contents</Box>
+      <ProtocolLabwareDetails requiredLabwareDetails={requiredLabwareDetails} />
     ) : (
       <RobotConfigurationDetails
         leftMountPipetteName={leftMountPipetteName}


### PR DESCRIPTION

# Overview

This PR adds the protocol labware details and labware slideout to the protocol details page.

closes #8825, closes #9676

![image](https://user-images.githubusercontent.com/14794021/165334922-07b99326-4a03-464f-97f2-cf45939ce999.png)


# Changelog

- Added `ProtocolLabwareDetails`

Note: tests are being written and will be added soon

# Review requests

- Upload any protocol with labware and visit the protocol details page for that protocol. Then click the Labware tab. You should see all the labware listed. If it is an opentrons labware definition it should have an icon. Clicking the `Go to labware definition` in the overflow menu for each labware should open the slideout with the correct labware information.

# Risk assessment

low
