### PR TITLE
fix(app): Updated See how to setup a new robot modal styling

### DIFF
--- a/app/src/pages/Devices/DevicesLanding/NewRobotSetupHelp.tsx
+++ b/app/src/pages/Devices/DevicesLanding/NewRobotSetupHelp.tsx
@@ -5,6 +5,9 @@ import {
   DIRECTION_COLUMN,
   Flex,
   Link,
+  TYPOGRAPHY,
+  TEXT_TRANSFORM_CAPITALIZE,
+  SPACING,
 } from '@opentrons/components'
 
 import { StyledText } from '../../../atoms/text'
@@ -24,7 +27,10 @@ export function NewRobotSetupHelp(): JSX.Element {
 
   return (
     <>
-      <Link onClick={() => setShowNewRobotHelpModal(true)}>
+      <Link
+        css={TYPOGRAPHY.labelSemiBold}
+        onClick={() => setShowNewRobotHelpModal(true)}
+      >
         {t('see_how_to_setup_new_robot')}
       </Link>
       <Portal>
@@ -34,13 +40,16 @@ export function NewRobotSetupHelp(): JSX.Element {
             onClose={() => setShowNewRobotHelpModal(false)}
           >
             <Flex flexDirection={DIRECTION_COLUMN}>
-              <StyledText as="p">{t('use_usb_cable_for_new_robot')}</StyledText>
+              <StyledText as="p" marginBottom={SPACING.spacing4}>
+                {t('use_usb_cable_for_new_robot')}
+              </StyledText>
               <ExternalLink href={NEW_ROBOT_SETUP_SUPPORT_ARTICLE_HREF}>
                 {t('learn_more_about_new_robot_setup')}
               </ExternalLink>
               <PrimaryButton
                 onClick={() => setShowNewRobotHelpModal(false)}
                 alignSelf={ALIGN_FLEX_END}
+                textTransform={TEXT_TRANSFORM_CAPITALIZE}
               >
                 {t('shared:close')}
               </PrimaryButton>


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Fixes #10085 

![Screen Shot 2022-04-26 at 2 31 19 PM](https://user-images.githubusercontent.com/474225/165368950-abfec0a3-38f6-4c3a-89ea-b63de7d3ae4b.png)

![Screen Shot 2022-04-26 at 2 30 25 PM](https://user-images.githubusercontent.com/474225/165368965-83eb6af3-5bbf-4751-a942-0ee8478adacb.png)


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- Add css(TYPOGRAPHY) to Link
- Capitalize modal close button's first letter
- Add stying to Modal child

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

- link: font size 11pt
- modal: capitalize close
- modal: 16px space between body copy and link

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
