### PR TITLE
refactor(robot-server): implement thermocycler/setTargetLidTemperature

### DIFF
--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -320,6 +320,19 @@ class Thermocycler(mod_abc.AbstractModule):
         )
         await self.wait_next_poll()
 
+    # TODO(mc, 2022-04-26): de-duplicate with `set_lid_temperature`
+    async def set_target_lid_temperature(self, celsius: float) -> None:
+        """Set the Thermocycler's target lid temperature.
+
+        Does not wait for the target temperature to be reached.
+
+        Args:
+            celsius: The target lid temperature, in degrees celsius.
+        """
+        await self.wait_for_is_running()
+        await self._driver.set_lid_temperature(temp=celsius)
+        await self.wait_next_poll()
+
     async def _wait_for_lid_temp(self) -> None:
         """
         This method only exits if lid target temperature has been reached.

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/set_target_lid_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/set_target_lid_temperature.py
@@ -46,7 +46,20 @@ class SetTargetLidTemperatureImpl(
         params: SetTargetLidTemperatureParams,
     ) -> SetTargetLidTemperatureResult:
         """Set a Thermocycler's target lid temperature."""
-        raise NotImplementedError()
+        thermocycler_state = self._state_view.modules.get_thermocycler_module_substate(
+            params.moduleId
+        )
+        target_temperature = thermocycler_state.validate_target_lid_temperature(
+            params.temperature
+        )
+        thermocycler_hardware = self._equipment.get_module_hardware_api(
+            thermocycler_state.module_id
+        )
+
+        if thermocycler_hardware is not None:
+            await thermocycler_hardware.set_target_lid_temperature(target_temperature)
+
+        return SetTargetLidTemperatureResult()
 
 
 class SetTargetLidTemperature(

--- a/api/src/opentrons/protocol_engine/state/module_substates/thermocycler_module_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/thermocycler_module_substate.py
@@ -6,7 +6,12 @@ from opentrons.protocol_engine.errors import InvalidTargetTemperatureError
 
 # TODO(mc, 2022-04-25): move to module definition
 # https://github.com/Opentrons/opentrons/issues/9800
-from opentrons.drivers.thermocycler.driver import BLOCK_TARGET_MIN, BLOCK_TARGET_MAX
+from opentrons.drivers.thermocycler.driver import (
+    BLOCK_TARGET_MIN,
+    BLOCK_TARGET_MAX,
+    LID_TARGET_MIN,
+    LID_TARGET_MAX,
+)
 
 ThermocyclerModuleId = NewType("ThermocyclerModuleId", str)
 
@@ -41,4 +46,26 @@ class ThermocyclerModuleSubState:
         raise InvalidTargetTemperatureError(
             "Thermocycler block temperature must be between"
             f" {BLOCK_TARGET_MIN} and {BLOCK_TARGET_MAX}, but got {celsius}."
+        )
+
+    @staticmethod
+    def validate_target_lid_temperature(celsius: float) -> float:
+        """Validate a given target lid temperature.
+
+        Args:
+            celsius: The requested lid temperature.
+
+        Raises:
+            InvalidTargetTemperatureError: The given temperature
+                is outside the thermocycler's operating range.
+
+        Returns:
+            The validated temperature in degrees Celsius.
+        """
+        if LID_TARGET_MIN <= celsius <= LID_TARGET_MAX:
+            return celsius
+
+        raise InvalidTargetTemperatureError(
+            "Thermocycler lid temperature must be between"
+            f" {LID_TARGET_MIN} and {LID_TARGET_MAX}, but got {celsius}."
         )

--- a/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
@@ -112,6 +112,11 @@ async def test_sim_update(subject: modules.Thermocycler) -> None:
     await subject.deactivate_block()
     assert subject.target is None
 
+    await subject.set_target_lid_temperature(celsius=50.0)
+    assert subject.lid_target == 50.0
+    await subject.deactivate_lid()
+    assert subject.lid_target is None
+
 
 @pytest.fixture
 def simulator() -> SimulatingDriver:

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_set_target_lid_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_set_target_lid_temperature.py
@@ -15,7 +15,7 @@ from opentrons.protocol_engine.commands.thermocycler.set_target_lid_temperature 
 )
 
 
-async def test_set_target_lif_temperature(
+async def test_set_target_lid_temperature(
     decoy: Decoy,
     state_view: StateView,
     equipment: EquipmentHandler,

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_set_target_lid_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_set_target_lid_temperature.py
@@ -1,0 +1,56 @@
+"""Test Thermocycler set lid temperature command implementation."""
+from decoy import Decoy
+
+from opentrons.hardware_control.modules import Thermocycler
+
+from opentrons.protocol_engine.state import StateView
+from opentrons.protocol_engine.state.module_substates import (
+    ThermocyclerModuleSubState,
+    ThermocyclerModuleId,
+)
+from opentrons.protocol_engine.execution import EquipmentHandler
+from opentrons.protocol_engine.commands import thermocycler as tc_commands
+from opentrons.protocol_engine.commands.thermocycler.set_target_lid_temperature import (  # noqa: E501
+    SetTargetLidTemperatureImpl,
+)
+
+
+async def test_set_target_lif_temperature(
+    decoy: Decoy,
+    state_view: StateView,
+    equipment: EquipmentHandler,
+) -> None:
+    """It should be able to set the specified module's target temperature."""
+    subject = SetTargetLidTemperatureImpl(state_view=state_view, equipment=equipment)
+
+    data = tc_commands.SetTargetLidTemperatureParams(
+        moduleId="input-thermocycler-id",
+        temperature=12.3,
+    )
+    expected_result = tc_commands.SetTargetLidTemperatureResult()
+
+    tc_module_substate = decoy.mock(cls=ThermocyclerModuleSubState)
+    tc_hardware = decoy.mock(cls=Thermocycler)
+
+    decoy.when(
+        state_view.modules.get_thermocycler_module_substate("input-thermocycler-id")
+    ).then_return(tc_module_substate)
+
+    decoy.when(tc_module_substate.module_id).then_return(
+        ThermocyclerModuleId("thermocycler-id")
+    )
+
+    # Stub temperature validation from hs module view
+    decoy.when(tc_module_substate.validate_target_lid_temperature(12.3)).then_return(
+        45.6
+    )
+
+    # Get attached hardware modules
+    decoy.when(
+        equipment.get_module_hardware_api(ThermocyclerModuleId("thermocycler-id"))
+    ).then_return(tc_hardware)
+
+    result = await subject.execute(data)
+
+    decoy.verify(await tc_hardware.set_target_lid_temperature(celsius=45.6), times=1)
+    assert result == expected_result

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -1063,3 +1063,31 @@ def test_thermocycler_validate_target_block_temperature_raises(
 
     with pytest.raises(errors.InvalidTargetTemperatureError):
         subject.validate_target_block_temperature(input_temperature)
+
+
+@pytest.mark.parametrize("input_temperature", [37, 37.0, 37.001, 109.999, 110, 110.0])
+def test_thermocycler_validate_target_lid_temperature(
+    module_view_with_thermocycler: ModuleView,
+    input_temperature: float,
+) -> None:
+    """It should return a valid target block temperature."""
+    subject = module_view_with_thermocycler.get_thermocycler_module_substate(
+        "module-id"
+    )
+    result = subject.validate_target_lid_temperature(input_temperature)
+
+    assert result == input_temperature
+
+
+@pytest.mark.parametrize("input_temperature", [36.999, 110.001])
+def test_thermocycler_validate_target_lid_temperature_raises(
+    module_view_with_thermocycler: ModuleView,
+    input_temperature: float,
+) -> None:
+    """It should raise on invalid target block temperature."""
+    subject = module_view_with_thermocycler.get_thermocycler_module_substate(
+        "module-id"
+    )
+
+    with pytest.raises(errors.InvalidTargetTemperatureError):
+        subject.validate_target_lid_temperature(input_temperature)


### PR DESCRIPTION
## Overview

This PR follows up #10068 by implementing the `thermocycler/setLidTargetTemperature` command in the same manner.

## Changelog

- refactor(robot-server): implement thermocycler/setTargetLidTemperature

## Review requests

I tested this in the office on an OT-2R with an attached thermocycler using `POST /commands`, but if you've got the hardware, more testing is good! Emulator testing is probably also worthwhile.

Otherwise, regular code review is great.

## Risk assessment

Like #10068, this touches the thermocycler's hardware control API a little. Since it adds a new method rather than touching existing ones, I think this presents a pretty low risk to other TC interactions.
