### PR TITLE
feat(app): add module icon tooltips to robot card

### DIFF
--- a/app/src/assets/localization/en/devices_landing.json
+++ b/app/src/assets/localization/en/devices_landing.json
@@ -36,5 +36,6 @@
   "update_robot_software": "Update robot software",
   "disconnect_from_network": "Disconnect from network",
   "connect_to_network": "Connect to network",
-  "home_gantry": "Home gantry"
+  "home_gantry": "Home gantry",
+  "this_robot_has_connected_and_power_on_module": "This robot has a connected and powered on {{moduleName}}"
 }

--- a/app/src/atoms/Tooltip/index.tsx
+++ b/app/src/atoms/Tooltip/index.tsx
@@ -2,9 +2,9 @@ import * as React from 'react'
 import {
   COLORS,
   TYPOGRAPHY,
-  UseTooltipResultTooltipProps,
+  Tooltip as SharedTooltip,
 } from '@opentrons/components'
-import { Tooltip as SharedTooltip } from '@opentrons/components/src/tooltips/Tooltip'
+import type { UseTooltipResultTooltipProps } from '@opentrons/components'
 
 export interface TooltipProps {
   key: string

--- a/app/src/molecules/ModuleIcon/index.tsx
+++ b/app/src/molecules/ModuleIcon/index.tsx
@@ -12,20 +12,18 @@ import type { AttachedModule } from '../../redux/modules/types'
 
 interface ModuleIconProps {
   module: AttachedModule
-  robotName: string
   index: number
   tooltipText: string
 }
 
 export function ModuleIcon(props: ModuleIconProps): JSX.Element {
-  const { module, index, robotName, tooltipText } = props
+  const { module, index, tooltipText } = props
   const [targetProps, tooltipProps] = useHoverTooltip()
 
   return (
     <>
       <Flex {...targetProps}>
         <SharedModuleIcon
-          key={`${module.moduleModel}_${index}_${robotName}`}
           moduleType={module.moduleType}
           size={SPACING.spacing4}
         />

--- a/app/src/molecules/ModuleIcon/index.tsx
+++ b/app/src/molecules/ModuleIcon/index.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react'
+import {
+  Flex,
+  ModuleIcon as SharedModuleIcon,
+  POSITION_RELATIVE,
+  SPACING,
+  useHoverTooltip,
+} from '@opentrons/components'
+import { Tooltip } from '../../atoms/Tooltip'
+
+import type { AttachedModule } from '../../redux/modules/types'
+
+interface ModuleIconProps {
+  module: AttachedModule
+  robotName: string
+  index: number
+  tooltipText: string
+}
+
+export function ModuleIcon(props: ModuleIconProps): JSX.Element {
+  const { module, index, robotName, tooltipText } = props
+  const [targetProps, tooltipProps] = useHoverTooltip()
+
+  return (
+    <>
+      <Flex {...targetProps}>
+        <SharedModuleIcon
+          key={`${module.moduleModel}_${index}_${robotName}`}
+          moduleType={module.moduleType}
+          size={SPACING.spacing4}
+        />
+      </Flex>
+
+      <Flex position={POSITION_RELATIVE} marginTop={SPACING.spacingM}>
+        <Tooltip
+          tooltipProps={tooltipProps}
+          key={`ModuleIcon_tooltip_${index}`}
+        >
+          {tooltipText}
+        </Tooltip>
+      </Flex>
+    </>
+  )
+}

--- a/app/src/organisms/Devices/RobotCard.tsx
+++ b/app/src/organisms/Devices/RobotCard.tsx
@@ -14,7 +14,9 @@ import {
   SPACING,
   TEXT_TRANSFORM_UPPERCASE,
   ModuleIcon,
+  BORDERS,
 } from '@opentrons/components'
+import { getModuleDisplayName } from '@opentrons/shared-data'
 
 import OT2_PNG from '../../assets/images/OT2-R_HERO.png'
 import { StyledText } from '../../atoms/text'
@@ -34,7 +36,6 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
   const { robot } = props
   const { name = null, local } = robot
   const { t } = useTranslation('devices_landing')
-
   const attachedModules = useAttachedModules(name)
   const attachedPipettes = useAttachedPipettes(name)
 
@@ -44,7 +45,7 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
         alignItems={ALIGN_CENTER}
         backgroundColor={C_WHITE}
         border={`1px solid ${C_MED_LIGHT_GRAY}`}
-        borderRadius="4px"
+        borderRadius={BORDERS.radiusSoftCorners}
         flexDirection={DIRECTION_ROW}
         marginBottom={SPACING.spacing3}
         padding={SPACING.spacing3}
@@ -96,6 +97,11 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
                     key={`${name}_${module.moduleModel}_${i}`}
                     moduleType={module.moduleType}
                     size={SPACING.spacing4}
+                    moduleModel={module.model}
+                    tooltipText={t(
+                      'this_robot_has_connected_and_power_on_module',
+                      { moduleName: getModuleDisplayName(module.model) }
+                    )}
                   />
                 ))}
               </Flex>

--- a/app/src/organisms/Devices/RobotCard.tsx
+++ b/app/src/organisms/Devices/RobotCard.tsx
@@ -15,10 +15,12 @@ import {
   TEXT_TRANSFORM_UPPERCASE,
   BORDERS,
   ModuleIcon,
+  useHoverTooltip,
 } from '@opentrons/components'
 import { getModuleDisplayName } from '@opentrons/shared-data'
 
 import OT2_PNG from '../../assets/images/OT2-R_HERO.png'
+import { Tooltip } from '../../atoms/Tooltip'
 import { StyledText } from '../../atoms/text'
 import { useAttachedModules, useAttachedPipettes } from './hooks'
 import { RobotStatusBanner } from './RobotStatusBanner'
@@ -37,6 +39,7 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
   const { name = null, local } = robot
   const { t } = useTranslation('devices_landing')
   const attachedModules = useAttachedModules(name)
+  const [targetProps, tooltipProps] = useHoverTooltip()
   const attachedPipettes = useAttachedPipettes(name)
 
   return name != null ? (
@@ -97,11 +100,19 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
                     key={`${name}_${module.moduleModel}_${i}`}
                     moduleType={module.moduleType}
                     size={SPACING.spacing4}
-                    moduleModel={module.model}
-                    tooltipText={t(
-                      'this_robot_has_connected_and_power_on_module',
-                      { moduleName: getModuleDisplayName(module.model) }
-                    )}
+                    iconTargetProps={targetProps}
+                    moduleIconTooltip={
+                      <Flex position="relative" marginTop={SPACING.spacingM}>
+                        <Tooltip
+                          tooltipProps={tooltipProps}
+                          key={`ModuleIcon_tooltip_${i}`}
+                        >
+                          {t('this_robot_has_connected_and_power_on_module', {
+                            moduleName: getModuleDisplayName(module.model),
+                          })}
+                        </Tooltip>
+                      </Flex>
+                    }
                   />
                 ))}
               </Flex>

--- a/app/src/organisms/Devices/RobotCard.tsx
+++ b/app/src/organisms/Devices/RobotCard.tsx
@@ -13,8 +13,8 @@ import {
   DIRECTION_ROW,
   SPACING,
   TEXT_TRANSFORM_UPPERCASE,
-  ModuleIcon,
   BORDERS,
+  ModuleIcon,
 } from '@opentrons/components'
 import { getModuleDisplayName } from '@opentrons/shared-data'
 

--- a/app/src/organisms/Devices/RobotCard.tsx
+++ b/app/src/organisms/Devices/RobotCard.tsx
@@ -14,20 +14,18 @@ import {
   SPACING,
   TEXT_TRANSFORM_UPPERCASE,
   BORDERS,
-  ModuleIcon,
-  useHoverTooltip,
 } from '@opentrons/components'
 import { getModuleDisplayName } from '@opentrons/shared-data'
 
 import OT2_PNG from '../../assets/images/OT2-R_HERO.png'
-import { Tooltip } from '../../atoms/Tooltip'
 import { StyledText } from '../../atoms/text'
+import { UNREACHABLE } from '../../redux/discovery'
+import { ModuleIcon } from '../../molecules/ModuleIcon'
 import { useAttachedModules, useAttachedPipettes } from './hooks'
 import { RobotStatusBanner } from './RobotStatusBanner'
 import { RobotOverflowMenu } from './RobotOverflowMenu'
 
 import type { DiscoveredRobot } from '../../redux/discovery/types'
-import { UNREACHABLE } from '../../redux/discovery'
 // import { UpdateRobotBanner } from '../UpdateRobotBanner'
 
 interface RobotCardProps {
@@ -39,7 +37,6 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
   const { name = null, local } = robot
   const { t } = useTranslation('devices_landing')
   const attachedModules = useAttachedModules(name)
-  const [targetProps, tooltipProps] = useHoverTooltip()
   const attachedPipettes = useAttachedPipettes(name)
 
   return name != null ? (
@@ -97,22 +94,15 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
               <Flex>
                 {attachedModules.map((module, i) => (
                   <ModuleIcon
-                    key={`${name}_${module.moduleModel}_${i}`}
-                    moduleType={module.moduleType}
-                    size={SPACING.spacing4}
-                    iconTargetProps={targetProps}
-                    moduleIconTooltip={
-                      <Flex position="relative" marginTop={SPACING.spacingM}>
-                        <Tooltip
-                          tooltipProps={tooltipProps}
-                          key={`ModuleIcon_tooltip_${i}`}
-                        >
-                          {t('this_robot_has_connected_and_power_on_module', {
-                            moduleName: getModuleDisplayName(module.model),
-                          })}
-                        </Tooltip>
-                      </Flex>
-                    }
+                    tooltipText={t(
+                      'this_robot_has_connected_and_power_on_module',
+                      {
+                        moduleName: getModuleDisplayName(module.moduleModel),
+                      }
+                    )}
+                    robotName={name}
+                    index={i}
+                    module={module}
                   />
                 ))}
               </Flex>

--- a/app/src/organisms/Devices/RobotCard.tsx
+++ b/app/src/organisms/Devices/RobotCard.tsx
@@ -94,13 +94,13 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
               <Flex>
                 {attachedModules.map((module, i) => (
                   <ModuleIcon
+                    key={`${module.moduleModel}_${i}_${name}`}
                     tooltipText={t(
                       'this_robot_has_connected_and_power_on_module',
                       {
                         moduleName: getModuleDisplayName(module.moduleModel),
                       }
                     )}
-                    robotName={name}
                     index={i}
                     module={module}
                   />

--- a/components/src/icons/ModuleIcon.tsx
+++ b/components/src/icons/ModuleIcon.tsx
@@ -6,7 +6,6 @@ import {
   MAGNETIC_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
-import { UseHoverTooltipTargetProps } from '..'
 
 import type { ModuleType } from '@opentrons/shared-data'
 import type { StyleProps } from '../primitives/types'
@@ -20,28 +19,17 @@ const MODULE_ICON_NAME_BY_TYPE: { [type in ModuleType]: IconName } = {
 
 interface ModuleIconProps extends StyleProps {
   moduleType: ModuleType
-  moduleIconTooltip?: React.ReactNode
-  iconTargetProps?: UseHoverTooltipTargetProps
 }
 
 export function ModuleIcon(props: ModuleIconProps): JSX.Element {
-  const {
-    moduleType,
-    moduleIconTooltip,
-    iconTargetProps,
-    ...styleProps
-  } = props
+  const { moduleType, ...styleProps } = props
   const iconName = MODULE_ICON_NAME_BY_TYPE[moduleType]
 
   return (
-    <>
-      <Icon
-        name={iconName}
-        {...styleProps}
-        data-testid={`ModuleIcon_${iconName}`}
-        {...iconTargetProps}
-      />
-      {moduleIconTooltip}
-    </>
+    <Icon
+      name={iconName}
+      {...styleProps}
+      data-testid={`ModuleIcon_${iconName}`}
+    />
   )
 }

--- a/components/src/icons/ModuleIcon.tsx
+++ b/components/src/icons/ModuleIcon.tsx
@@ -6,11 +6,9 @@ import {
   MAGNETIC_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
-import { Tooltip } from '@opentrons/app/src/atoms/Tooltip/index'
-import { Flex, TOOLTIP_BOTTOM, useHoverTooltip } from '..'
-import { SPACING } from '../ui-style-constants'
+import { UseHoverTooltipTargetProps } from '..'
 
-import type { ModuleType, ModuleModel } from '@opentrons/shared-data'
+import type { ModuleType } from '@opentrons/shared-data'
 import type { StyleProps } from '../primitives/types'
 
 const MODULE_ICON_NAME_BY_TYPE: { [type in ModuleType]: IconName } = {
@@ -22,15 +20,17 @@ const MODULE_ICON_NAME_BY_TYPE: { [type in ModuleType]: IconName } = {
 
 interface ModuleIconProps extends StyleProps {
   moduleType: ModuleType
-  moduleModel?: ModuleModel
-  tooltipText?: string
+  moduleIconTooltip?: React.ReactNode
+  iconTargetProps?: UseHoverTooltipTargetProps
 }
 
 export function ModuleIcon(props: ModuleIconProps): JSX.Element {
-  const { moduleType, moduleModel, tooltipText, ...styleProps } = props
-  const [targetProps, tooltipProps] = useHoverTooltip({
-    placement: TOOLTIP_BOTTOM,
-  })
+  const {
+    moduleType,
+    moduleIconTooltip,
+    iconTargetProps,
+    ...styleProps
+  } = props
   const iconName = MODULE_ICON_NAME_BY_TYPE[moduleType]
 
   return (
@@ -39,18 +39,9 @@ export function ModuleIcon(props: ModuleIconProps): JSX.Element {
         name={iconName}
         {...styleProps}
         data-testid={`ModuleIcon_${iconName}`}
-        {...targetProps}
+        {...iconTargetProps}
       />
-      {moduleModel != null && (
-        <Flex position="relative" marginTop={SPACING.spacingM}>
-          <Tooltip
-            tooltipProps={tooltipProps}
-            key={`ModuleIcon_tooltip_${moduleType}`}
-          >
-            {tooltipText}
-          </Tooltip>
-        </Flex>
-      )}
+      {moduleIconTooltip}
     </>
   )
 }

--- a/components/src/icons/ModuleIcon.tsx
+++ b/components/src/icons/ModuleIcon.tsx
@@ -6,8 +6,11 @@ import {
   MAGNETIC_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
+import { Tooltip } from '@opentrons/app/src/atoms/Tooltip/index'
+import { Flex, TOOLTIP_BOTTOM, useHoverTooltip } from '..'
+import { SPACING } from '../ui-style-constants'
 
-import type { ModuleType } from '@opentrons/shared-data'
+import type { ModuleType, ModuleModel } from '@opentrons/shared-data'
 import type { StyleProps } from '../primitives/types'
 
 const MODULE_ICON_NAME_BY_TYPE: { [type in ModuleType]: IconName } = {
@@ -19,17 +22,35 @@ const MODULE_ICON_NAME_BY_TYPE: { [type in ModuleType]: IconName } = {
 
 interface ModuleIconProps extends StyleProps {
   moduleType: ModuleType
+  moduleModel?: ModuleModel
+  tooltipText?: string
 }
 
 export function ModuleIcon(props: ModuleIconProps): JSX.Element {
-  const { moduleType, ...styleProps } = props
+  const { moduleType, moduleModel, tooltipText, ...styleProps } = props
+  const [targetProps, tooltipProps] = useHoverTooltip({
+    placement: TOOLTIP_BOTTOM,
+  })
   const iconName = MODULE_ICON_NAME_BY_TYPE[moduleType]
 
   return (
-    <Icon
-      name={iconName}
-      {...styleProps}
-      data-testid={`ModuleIcon_${iconName}`}
-    />
+    <>
+      <Icon
+        name={iconName}
+        {...styleProps}
+        data-testid={`ModuleIcon_${iconName}`}
+        {...targetProps}
+      />
+      {moduleModel != null && (
+        <Flex position="relative" marginTop={SPACING.spacingM}>
+          <Tooltip
+            tooltipProps={tooltipProps}
+            key={`ModuleIcon_tooltip_${moduleType}`}
+          >
+            {tooltipText}
+          </Tooltip>
+        </Flex>
+      )}
+    </>
   )
 }


### PR DESCRIPTION
closes #8672

# Overview

This PR adds tooltips to the module icons on the RobotCard, the tooltips describe what module each icon represents.

# Changelog

- extends optional props in `moduleIcon` and adds props to `moduleIcon` in `robotCard`

# Review requests

- Because `toolTip` is in the app folder since we want a tooltip for the app and a tooltip in components, I added a few tooltip props to `moduleIcon` is that okay?
- Does it match designs?

# Risk assessment

low
