### PR TITLE
refactor(robot-server) Refactor name setting for readability

### DIFF
--- a/update-server/otupdate/buildroot/__init__.py
+++ b/update-server/otupdate/buildroot/__init__.py
@@ -52,7 +52,7 @@ def get_app(
         system_version_file = BR_BUILTIN_VERSION_FILE
 
     version = get_version(system_version_file)
-    name = name_override or name_management.get_name()
+    name = name_override or name_management.get_pretty_hostname()
     boot_id = boot_id_override or control.get_boot_id()
     config_obj = config.load(config_file_override)
 
@@ -99,8 +99,8 @@ def get_app(
             web.post("/server/ssh_keys", ssh_key_management.add),
             web.delete("/server/ssh_keys", ssh_key_management.clear),
             web.delete("/server/ssh_keys/{key_md5}", ssh_key_management.remove),
-            web.post("/server/name", name_management.set_name_endpoint),
-            web.get("/server/name", name_management.get_name_endpoint),
+            web.post("/server/name", name_management.set_display_name_endpoint),
+            web.get("/server/name", name_management.get_display_name_endpoint),
         ]
     )
     return app

--- a/update-server/otupdate/buildroot/__main__.py
+++ b/update-server/otupdate/buildroot/__main__.py
@@ -12,7 +12,7 @@ from aiohttp import web
 LOG = logging.getLogger(__name__)
 
 
-def main():
+def main() -> None:
     parser = cli.build_root_parser()
     args = parser.parse_args()
     loop = asyncio.get_event_loop()
@@ -27,7 +27,7 @@ def main():
 
     name = app[constants.DEVICE_NAME_VARNAME]
     LOG.info(f"Setting advertised name to {name}")
-    loop.run_until_complete(name_management.set_name(name))
+    loop.run_until_complete(name_management.set_pretty_hostname(name))
 
     LOG.info(f"Notifying {systemd.SOURCE} that service is up")
     systemd.notify_up()

--- a/update-server/otupdate/buildroot/__main__.py
+++ b/update-server/otupdate/buildroot/__main__.py
@@ -19,7 +19,7 @@ def main():
     systemd.configure_logging(getattr(logging, args.log_level.upper()))
 
     LOG.info("Setting hostname")
-    hostname = loop.run_until_complete(name_management.setup_hostname())
+    hostname = loop.run_until_complete(name_management.set_up_static_hostname())
     LOG.info(f"Set hostname to {hostname}")
 
     LOG.info("Building buildroot update server")

--- a/update-server/otupdate/common/name_management.py
+++ b/update-server/otupdate/common/name_management.py
@@ -249,7 +249,7 @@ async def set_pretty_hostname(name: str) -> str:
     Writes the new name to /etc/machine-info so it persists across reboots,
     and so it can be picked up by Avahi on its next restart.
 
-    Also notifies the currently-running Avahi daemon the updated pretty hostname,
+    Also notifies the currently-running Avahi daemon of the updated pretty hostname,
     to apply it immediately.
 
     :param name: The name to set.

--- a/update-server/otupdate/common/name_management.py
+++ b/update-server/otupdate/common/name_management.py
@@ -3,17 +3,24 @@ otupdate.common.name_management: functions for managing machine names
 
 The robot has two names associated with it:
 
-- The hostname is the name by which the machine is advertised on mdns. This can
-  be used to ping, issue HTTP requests, ssh in, etc. It should be set when the
-  update server starts by :py:func:`setup_hostname`. During this call, avahi
-  will be restarted to pick up the new hostname.
-- The name (unqualified) is the name of the robot. The name is stored in
-  /etc/machine-info as the PRETTY_HOSTNAME. `opentrons-${name}` is used as the
-  name value in the health endpoints and as the avahi service name. This name
-  can be set with POST /server/name, but does not change the machine hostname.
-  This can be set with :py:func:`set_name`, which should be called at boot
-  and whenever the name changes; this function will write /etc/machine-info
-  and change the avahi service advertisement (without restarting avahi).
+- The static hostname:
+
+  This is the traditional computer networking hostname,
+  which has limits on length and allowed characters.
+  This is the name by which the machine is advertised on mDNS,
+  so it can be used to ping, issue HTTP requests, ssh in, etc.,
+  via <static_hostname>.local.
+
+  It should be set when the update server starts by :py:func:`set_up_static_hostname`.
+
+- The pretty hostname:
+
+  This is a human-readable Unicode string.
+  It's stored in /etc/machine-info as the PRETTY_HOSTNAME, as specified by systemd,
+  and is used in the Avahi service name.
+
+  We also expose the pretty hostname over HTTP as the robot's "display name"
+  or "name" (unqualified). This is what users normally see in the Opentrons App.
 """
 
 import asyncio
@@ -57,9 +64,9 @@ try:
 
     _BUS_STATE: Optional[DBusState] = None
 
-    def _set_name_future(name: str):
+    def _set_pretty_hostname_future(name: str):
         """
-        The implementation of the name setting, to be run in a concurrent
+        The implementation of the pretty hostname setting, to be run in a concurrent
         executor since the dbus module doesn't work with asyncio
         """
         global _BUS_STATE
@@ -93,25 +100,26 @@ try:
 except ImportError:
     LOG.exception("Couldn't import dbus, name setting will be nonfunctional")
 
-    def _set_name_future(name: str):
+    def _set_pretty_hostname_future(name: str):
         LOG.warning("Not setting name, dbus could not be imported")
 
 
 _BUS_LOCK = asyncio.Lock()
 
 
-def _get_hostname() -> str:
-    """Get a good value for the system hostname.
+def _choose_static_hostname() -> str:
+    """Get a good value for the system's static hostname.
 
-    The hostname is loaded from, in order of preference,
+    The static hostname is loaded from, in order of preference:
 
-    - url-encoding the contents of /var/serial-number, if it is present,
-      not empty, and not the default
-    - the systemd-generated machine-id, which changes at every boot.
+    1. url-encoding the contents of /var/serial-number, if it is present and not empty.
+    2. the systemd-generated machine-id.
     """
     if os.path.exists("/var/serial"):
         serial = open("/var/serial").read().strip()
         if serial:
+            # TODO(mm, 2022-04-27): This uses the serial number even if it hasn't
+            # been configured and is still the default, like "opentrons."
             LOG.info("Using serial for hostname")
             hn = "".join([c for c in urllib.parse.quote(serial, safe="") if c != "%"])
             if hn != serial:
@@ -123,22 +131,20 @@ def _get_hostname() -> str:
     else:
         LOG.info("Using machine-id for hostname: no /var/serial")
 
-    return open("/etc/machine-id").read().strip()[:6]
+    with open("/etc/machine-id") as f:
+        return f.read().strip()[:6]
 
 
-async def setup_hostname() -> str:
-    """
-    Intended to be run when the server starts. Sets the machine hostname.
+async def set_up_static_hostname() -> str:
+    """Automatically configure the machine's static hostname.
+
+    Intended to be run when the server starts.
 
     Once the hostname is set, we restart avahi.
 
-    This is a separate task from establishing and changing the opentrons
-    machine name, which is UTF-8 and stored in /etc/machine-info as the
-    PRETTY_HOSTNAME and used in the avahi service name.
-
-    :returns: the hostname
+    :returns: the static hostname
     """
-    hostname = _get_hostname()
+    hostname = _choose_static_hostname()
     with open("/etc/hostname", "w") as ehn:
         ehn.write(f"{hostname}\n")
 
@@ -181,7 +187,7 @@ async def setup_hostname() -> str:
     return hostname
 
 
-def _update_pretty_hostname(new_val: str):
+def _rewrite_machine_info(new_pretty_hostname: str):
     """Write a new value for the pretty hostname.
 
     :raises OSError: If the new value could not be written.
@@ -192,12 +198,14 @@ def _update_pretty_hostname(new_val: str):
     except OSError:
         LOG.exception("Couldn't read /etc/machine-info")
         contents = ""
-    new_contents = _rewrite_machine_info(contents, new_val)
+    new_contents = _rewrite_machine_info_str(
+        current_machine_info_contents=contents, new_pretty_hostname=new_pretty_hostname
+    )
     with open("/etc/machine-info", "w") as emi:
         emi.write(new_contents)
 
 
-def _rewrite_machine_info(
+def _rewrite_machine_info_str(
     current_machine_info_contents: str, new_pretty_hostname: str
 ) -> str:
     """
@@ -209,13 +217,16 @@ def _rewrite_machine_info(
     preserved_lines = [
         ln for ln in current_lines if not ln.startswith("PRETTY_HOSTNAME")
     ]
+    # FIXME(mm, 2022-04-27): This will not correctly store the pretty hostname
+    # if it contains newlines or certain other special characters.
+    # https://github.com/Opentrons/opentrons/issues/9960
     new_lines = preserved_lines + [f"PRETTY_HOSTNAME={new_pretty_hostname}"]
     new_contents = "\n".join(new_lines) + "\n"
     return new_contents
 
 
-def get_name(default: str = "no name set"):
-    """Get the currently-configured name of the machine"""
+def get_pretty_hostname(default: str = "no name set"):
+    """Get the currently-configured pretty hostname"""
     try:
         with open("/etc/machine-info") as emi:
             contents = emi.read()
@@ -224,52 +235,49 @@ def get_name(default: str = "no name set"):
         contents = ""
     for line in contents.split("\n"):
         if line.startswith("PRETTY_HOSTNAME="):
+            # FIXME(mm, 2022-04-27): This will not correctly read the pretty hostname
+            # if it contains newlines or certain other special characters.
+            # https://github.com/Opentrons/opentrons/issues/9960
             return "=".join(line.split("=")[1:])
     LOG.warning(f"No PRETTY_HOSTNAME in {contents}, defaulting to {default}")
-    try:
-        _update_pretty_hostname(default)
-    except OSError:
-        LOG.exception("Could not write new pretty hostname!")
     return default
 
 
-async def set_name(name: str = None) -> str:
-    """
-    Change the name by writing /etc/machine-info and then calling setup_name
+async def set_pretty_hostname(name: str) -> str:
+    """Change the robot's pretty hostname.
 
-    :param name: The name to set. If ``None``, read it from /etc/machine-info
-    :returns: The name that was set. This may be different from ``name``, if
-              ``name`` was none or if the pretty hostname could not be written
-    """
+    Writes the new name to /etc/machine-info so it persists across reboots,
+    and so it can be picked up by Avahi on its next restart.
 
-    if name:
+    Also notifies the currently-running Avahi daemon the updated pretty hostname,
+    to apply it immediately.
+
+    :param name: The name to set.
+    :returns: The name that was set. This may be different from ``name``,
+              if the pretty hostname could not be written.
+    """
+    try:
+        _rewrite_machine_info(new_pretty_hostname=name)
         checked_name = name
-        try:
-            _update_pretty_hostname(checked_name)
-        except OSError:
-            LOG.exception("Could not set pretty hostname")
-            checked_name = get_name()
-    else:
-        checked_name = get_name()
+    except OSError:
+        LOG.exception("Could not set pretty hostname")
+        checked_name = get_pretty_hostname()
 
     async with _BUS_LOCK:
         await asyncio.get_event_loop().run_in_executor(
-            None, _set_name_future, checked_name
+            None, _set_pretty_hostname_future, checked_name
         )
+
     return checked_name
 
 
-async def set_name_endpoint(request: web.Request) -> web.Response:
-    """Set the name of the robot.
+async def set_display_name_endpoint(request: web.Request) -> web.Response:
+    """Set the robot's display name.
 
     Request with POST /server/name {"name": new_name}
-    Responds with 200 OK {"hostname": new_name, "prettyname": pretty_name}
-    or 400 Bad Request
+    Responds with 200 OK {"name": "set_name"}
 
-    In general, the new pretty name will be the specified name. The true
-    hostname will be capped to 53 letters, and have any characters other than
-    ascii letters or dashes replaced with dashes to fit the requirements here
-    https://www.freedesktop.org/software/systemd/man/hostname.html#.
+    In general, the name that is set will be the same name that was requested.
     """
 
     def build_400(msg: str) -> web.Response:
@@ -279,14 +287,14 @@ async def set_name_endpoint(request: web.Request) -> web.Response:
     if "name" not in body or not isinstance(body["name"], str):
         return build_400('Body has no "name" key with a string')
 
-    new_name = await set_name(body["name"])
+    new_name = await set_pretty_hostname(body["name"])
     request.app[DEVICE_NAME_VARNAME] = new_name
 
     return web.json_response(data={"name": new_name}, status=200)
 
 
-async def get_name_endpoint(request: web.Request) -> web.Response:
-    """Get the name of the robot.
+async def get_display_name_endpoint(request: web.Request) -> web.Response:
+    """Get the robot's display name.
 
     This information is also accessible in /server/update/health, but this
     endpoint provides symmetry with POST /server/name.

--- a/update-server/otupdate/common/name_management.py
+++ b/update-server/otupdate/common/name_management.py
@@ -276,6 +276,7 @@ async def set_display_name_endpoint(request: web.Request) -> web.Response:
 
     Request with POST /server/name {"name": new_name}
     Responds with 200 OK {"name": "set_name"}
+    or 400 Bad Request
 
     In general, the name that is set will be the same name that was requested.
     """

--- a/update-server/tests/buildroot/test_name_endpoints.py
+++ b/update-server/tests/buildroot/test_name_endpoints.py
@@ -5,7 +5,7 @@ async def test_name_endpoint(test_cli, monkeypatch):
     async def fake_name(name):
         return name + name
 
-    monkeypatch.setattr(name_management, "set_name", fake_name)
+    monkeypatch.setattr(name_management, "set_pretty_hostname", fake_name)
 
     to_set = "check out this cool name"
     resp = await test_cli.post("/server/name", json={"name": to_set})

--- a/update-server/tests/common/test_name_management.py
+++ b/update-server/tests/common/test_name_management.py
@@ -12,8 +12,9 @@ machine_info_examples = [
 
 
 @pytest.mark.parametrize("initial_contents", machine_info_examples)
-def test_rewrite_machine_info_updates_pretty_hostname(initial_contents):
-    rewrite = name_management._rewrite_machine_info(
+def test_rewrite_machine_info_updates_pretty_hostname(initial_contents) -> None:
+    # TODO(mm, 2022-04-27): Rework so we don't have to test a private function.
+    rewrite = name_management._rewrite_machine_info_str(
         initial_contents, "new_pretty_hostname"
     )
     assert (
@@ -25,9 +26,10 @@ def test_rewrite_machine_info_updates_pretty_hostname(initial_contents):
 
 
 @pytest.mark.parametrize("initial_contents", machine_info_examples)
-def test_rewrite_machine_info_preserves_other_lines(initial_contents):
+def test_rewrite_machine_info_preserves_other_lines(initial_contents) -> None:
+    # TODO(mm, 2022-04-27): Rework so we don't have to test a private function.
     intitial_lines = Counter(initial_contents.splitlines())
-    rewrite_string = name_management._rewrite_machine_info(
+    rewrite_string = name_management._rewrite_machine_info_str(
         initial_contents, "new_pretty_hostname"
     )
     rewrite_lines = Counter(rewrite_string.splitlines())
@@ -38,12 +40,14 @@ def test_rewrite_machine_info_preserves_other_lines(initial_contents):
         assert line.startswith("PRETTY_HOSTNAME=") or line == ""
 
 
+# Covers this bug: https://github.com/Opentrons/opentrons/pull/4671
 @pytest.mark.parametrize("initial_contents", machine_info_examples)
-def test_rewrite_machine_info_is_idempotent(initial_contents):
-    first_rewrite = name_management._rewrite_machine_info(
+def test_rewrite_machine_info_is_idempotent(initial_contents) -> None:
+    # TODO(mm, 2022-04-27): Rework so we don't have to test a private function.
+    first_rewrite = name_management._rewrite_machine_info_str(
         initial_contents, "new_pretty_hostname"
     )
-    second_rewrite = name_management._rewrite_machine_info(
+    second_rewrite = name_management._rewrite_machine_info_str(
         first_rewrite, "new_pretty_hostname"
     )
     assert second_rewrite == first_rewrite


### PR DESCRIPTION
Ignore this for now. I think I'm getting a lot of these details wrong.


<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

* Does the documentation make sense?
* Except where I've explicitly noted, does this preserve the existing behavior?
* If you want, you can smoke-test this on a robot and make sure setting and getting the display name still works. Either go through the beta Opentrons App, or manually issue HTTP requests to `GET`/`POST` `/server/name {"name": "foo"}`.
    * I have tested this.

# Risk assessment

Low-medium.