### PR TITLE
refactor(app): fix duplicate i18n key in device details

### DIFF
--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -89,5 +89,5 @@
   "pipette_offset_calibration_needed": "Pipette Offset calibration needed.",
   "calibrate_now": "Calibrate now",
   "deck_cal_missing": "Pipette Offset calibration missing. Calibrate deck first.",
-  "an_error_occurred_while_updating": "An error occurred while updating your pipette's settings. Please try again."
+  "an_error_occurred_while_updating_please_try_again": "An error occurred while updating your pipette's settings. Please try again."
 }

--- a/app/src/organisms/Devices/ModuleCard/FirmwareUpdateFailedModal.tsx
+++ b/app/src/organisms/Devices/ModuleCard/FirmwareUpdateFailedModal.tsx
@@ -49,7 +49,7 @@ export const FirmwareUpdateFailedModal = (
         data-testid={`FirmwareUpdateFailedModal_body_text_${module.serial}`}
       >
         <Text paddingBottom={SPACING.spacing2}>
-          {t('an_error_occurred_while_updating')}
+          {t('an_error_occurred_while_updating_please_try_again')}
         </Text>
         <Text>{errorMessage}</Text>
       </Flex>


### PR DESCRIPTION
# Overview

In edge, i noticed that there was a duplicate i18n key caused by a PR i merged this morning, i corrected it here.

# Changelog

- rename one of the `an_error_occurred_while_updating` key names 

# Risk assessment

low
