### PR TITLE
refactor(api): add engine/PAPIv3 thermocycler deactivate lid/block

### DIFF
--- a/api/src/opentrons/protocol_api_experimental/module_contexts/thermocycler_module_context.py
+++ b/api/src/opentrons/protocol_api_experimental/module_contexts/thermocycler_module_context.py
@@ -1,11 +1,13 @@
 """Protocol API interfaces for Thermocycler Modules."""
+from opentrons.protocol_engine.clients import SyncClient as ProtocolEngineClient
 
 
 class ThermocyclerModuleContext:  # noqa: D101
     # TODO(mc, 2022-02-09): copy or rewrite docstring from
     # src/opentrons/protocol_api/module_contexts.py
 
-    def __init__(self, module_id: str) -> None:
+    def __init__(self, engine_client: ProtocolEngineClient, module_id: str) -> None:
+        self._engine_client = engine_client
         self._module_id = module_id
 
     def __eq__(self, other: object) -> bool:
@@ -14,3 +16,16 @@ class ThermocyclerModuleContext:  # noqa: D101
             isinstance(other, ThermocyclerModuleContext)
             and self._module_id == other._module_id
         )
+
+    def deactivate_lid(self) -> None:
+        """Turn off the lid heater."""
+        self._engine_client.thermocycler_deactivate_lid(self._module_id)
+
+    def deactivate_block(self) -> None:
+        """Turn off the well block heater."""
+        self._engine_client.thermocycler_deactivate_block(self._module_id)
+
+    def deactivate(self) -> None:
+        """Turn off all heaters."""
+        self.deactivate_lid()
+        self.deactivate_block()

--- a/api/src/opentrons/protocol_api_experimental/module_contexts/thermocycler_module_context.py
+++ b/api/src/opentrons/protocol_api_experimental/module_contexts/thermocycler_module_context.py
@@ -25,6 +25,9 @@ class ThermocyclerModuleContext:  # noqa: D101
         """Turn off the well block heater."""
         self._engine_client.thermocycler_deactivate_block(self._module_id)
 
+    # TODO(mc, 2022-04-29): if you go down to the driver level, there is a
+    # separate "deactivate all" g-code. Is this functionally different than
+    # deactivating the lid and block in sequence like this?
     def deactivate(self) -> None:
         """Turn off all heaters."""
         self.deactivate_lid()

--- a/api/src/opentrons/protocol_api_experimental/protocol_context.py
+++ b/api/src/opentrons/protocol_api_experimental/protocol_context.py
@@ -210,7 +210,9 @@ class ProtocolContext:
         elif result.definition.moduleType == ModuleType.TEMPERATURE:
             return TemperatureModuleContext(module_id=result.moduleId)
         elif result.definition.moduleType == ModuleType.THERMOCYCLER:
-            return ThermocyclerModuleContext(module_id=result.moduleId)
+            return ThermocyclerModuleContext(
+                engine_client=self._engine_client, module_id=result.moduleId
+            )
         else:
             assert False, "Unsupported module definition"
 

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -160,6 +160,14 @@ class SyncClient:
         result = self._transport.execute_command(request=request)
         return cast(commands.PauseResult, result)
 
+    def set_rail_lights(self, on: bool) -> commands.SetRailLightsResult:
+        """Execute a ``setRailLights`` command and return the result."""
+        request = commands.SetRailLightsCreate(
+            params=commands.SetRailLightsParams(on=on)
+        )
+        result = self._transport.execute_command(request=request)
+        return cast(commands.SetRailLightsResult, result)
+
     def magnetic_module_engage(
         self, module_id: str, engage_height: float
     ) -> commands.magnetic_module.EngageResult:
@@ -172,10 +180,22 @@ class SyncClient:
         result = self._transport.execute_command(request=request)
         return cast(commands.magnetic_module.EngageResult, result)
 
-    def set_rail_lights(self, on: bool) -> commands.SetRailLightsResult:
-        """Execute a ``setRailLights`` command and return the result."""
-        request = commands.SetRailLightsCreate(
-            params=commands.SetRailLightsParams(on=on)
+    def thermocycler_deactivate_block(
+        self, module_id: str
+    ) -> commands.thermocycler.DeactivateBlockResult:
+        """Execute a `thermocycler/deactivateBlock` command and return the result."""
+        request = commands.thermocycler.DeactivateBlockCreate(
+            params=commands.thermocycler.DeactivateBlockParams(moduleId=module_id)
         )
         result = self._transport.execute_command(request=request)
-        return cast(commands.SetRailLightsResult, result)
+        return cast(commands.thermocycler.DeactivateBlockResult, result)
+
+    def thermocycler_deactivate_lid(
+        self, module_id: str
+    ) -> commands.thermocycler.DeactivateLidResult:
+        """Execute a `thermocycler/deactivateLid` command and return the result."""
+        request = commands.thermocycler.DeactivateLidCreate(
+            params=commands.thermocycler.DeactivateLidParams(moduleId=module_id)
+        )
+        result = self._transport.execute_command(request=request)
+        return cast(commands.thermocycler.DeactivateLidResult, result)

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/deactivate_block.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/deactivate_block.py
@@ -67,7 +67,7 @@ class DeactivateBlock(BaseCommand[DeactivateBlockParams, DeactivateBlockResult])
 class DeactivateBlockCreate(BaseCommandCreate[DeactivateBlockParams]):
     """A request to create a Thermocycler's deactivate block command."""
 
-    commandType: DeactivateBlockCommandType
+    commandType: DeactivateBlockCommandType = "thermocycler/deactivateBlock"
     params: DeactivateBlockParams
 
     _CommandCls: Type[DeactivateBlock] = DeactivateBlock

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/deactivate_block.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/deactivate_block.py
@@ -41,7 +41,17 @@ class DeactivateBlockImpl(
 
     async def execute(self, params: DeactivateBlockParams) -> DeactivateBlockResult:
         """Unset a Thermocycler's target block temperature."""
-        raise NotImplementedError()
+        thermocycler_state = self._state_view.modules.get_thermocycler_module_substate(
+            params.moduleId
+        )
+        thermocycler_hardware = self._equipment.get_module_hardware_api(
+            thermocycler_state.module_id
+        )
+
+        if thermocycler_hardware is not None:
+            await thermocycler_hardware.deactivate_block()
+
+        return DeactivateBlockResult()
 
 
 class DeactivateBlock(BaseCommand[DeactivateBlockParams, DeactivateBlockResult]):

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/deactivate_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/deactivate_lid.py
@@ -39,7 +39,17 @@ class DeactivateLidImpl(AbstractCommandImpl[DeactivateLidParams, DeactivateLidRe
 
     async def execute(self, params: DeactivateLidParams) -> DeactivateLidResult:
         """Unset a Thermocycler's target lid temperature."""
-        raise NotImplementedError()
+        thermocycler_state = self._state_view.modules.get_thermocycler_module_substate(
+            params.moduleId
+        )
+        thermocycler_hardware = self._equipment.get_module_hardware_api(
+            thermocycler_state.module_id
+        )
+
+        if thermocycler_hardware is not None:
+            await thermocycler_hardware.deactivate_lid()
+
+        return DeactivateLidResult()
 
 
 class DeactivateLid(BaseCommand[DeactivateLidParams, DeactivateLidResult]):

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/deactivate_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/deactivate_lid.py
@@ -65,7 +65,7 @@ class DeactivateLid(BaseCommand[DeactivateLidParams, DeactivateLidResult]):
 class DeactivateLidCreate(BaseCommandCreate[DeactivateLidParams]):
     """A request to create a Thermocycler's deactivate lid command."""
 
-    commandType: DeactivateLidCommandType
+    commandType: DeactivateLidCommandType = "thermocycler/deactivateLid"
     params: DeactivateLidParams
 
     _CommandCls: Type[DeactivateLid] = DeactivateLid

--- a/api/tests/opentrons/protocol_api_experimental/module_contexts/test_thermocycler_module_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/module_contexts/test_thermocycler_module_context.py
@@ -1,0 +1,68 @@
+"""Tests for `thermocycler_module_context`."""
+import pytest
+from decoy import Decoy
+
+from opentrons.protocol_engine.clients import SyncClient
+from opentrons.protocol_api_experimental import ThermocyclerModuleContext
+
+
+@pytest.fixture
+def engine_client(decoy: Decoy) -> SyncClient:
+    """Return a mock in the shape of a Protocol Engine client."""
+    return decoy.mock(cls=SyncClient)
+
+
+@pytest.fixture
+def subject_module_id() -> str:
+    """Return the ProtocolEngine module ID of the subject."""
+    return "subject-module-id"
+
+
+@pytest.fixture
+def subject(
+    engine_client: SyncClient, subject_module_id: str
+) -> ThermocyclerModuleContext:
+    """Return a ThermocyclerModuleContext with mocked dependencies."""
+    return ThermocyclerModuleContext(
+        engine_client=engine_client,
+        module_id=subject_module_id,
+    )
+
+
+def test_deactivate_block(
+    decoy: Decoy,
+    engine_client: SyncClient,
+    subject_module_id: str,
+    subject: ThermocyclerModuleContext,
+) -> None:
+    """It should use the engine client to deactivate the block."""
+    subject.deactivate_block()
+    decoy.verify(
+        engine_client.thermocycler_deactivate_block(subject_module_id),
+        times=1,
+    )
+
+
+def test_deactivate_lid(
+    decoy: Decoy,
+    engine_client: SyncClient,
+    subject_module_id: str,
+    subject: ThermocyclerModuleContext,
+) -> None:
+    """It should use the engine client to deactivate the lid."""
+    subject.deactivate_lid()
+    decoy.verify(engine_client.thermocycler_deactivate_lid(subject_module_id), times=1)
+
+
+def test_deactivate(
+    decoy: Decoy,
+    engine_client: SyncClient,
+    subject_module_id: str,
+    subject: ThermocyclerModuleContext,
+) -> None:
+    """It should use the engine client to deactivate both the lid and block."""
+    subject.deactivate()
+    decoy.verify(
+        engine_client.thermocycler_deactivate_lid(subject_module_id),
+        engine_client.thermocycler_deactivate_block(subject_module_id),
+    )

--- a/api/tests/opentrons/protocol_api_experimental/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/test_protocol_context.py
@@ -394,10 +394,16 @@ def test_load_thermocycler(
     )
 
     result = subject.load_module(module_name=module_name)
-    assert result == module_contexts.ThermocyclerModuleContext(module_id="abc123")
+    assert result == module_contexts.ThermocyclerModuleContext(
+        module_id="abc123",
+        engine_client=engine_client,
+    )
 
     result = subject.load_module(module_name=module_name, location="7")
-    assert result == module_contexts.ThermocyclerModuleContext(module_id="abc123")
+    assert result == module_contexts.ThermocyclerModuleContext(
+        module_id="abc123",
+        engine_client=engine_client,
+    )
 
 
 @pytest.mark.parametrize(

--- a/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
@@ -320,7 +320,7 @@ def test_thermocycler_deactivate_lid(
     transport: AbstractSyncTransport,
     subject: SyncClient,
 ) -> None:
-    """It should execute a Thermocycler's deactivate block command."""
+    """It should execute a Thermocycler's deactivate lid command."""
     request = commands.thermocycler.DeactivateLidCreate(
         params=commands.thermocycler.DeactivateLidParams(moduleId="module-id")
     )

--- a/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
@@ -263,6 +263,22 @@ def test_pause(
     assert result == response
 
 
+def test_set_rail_lights(
+    decoy: Decoy,
+    transport: AbstractSyncTransport,
+    subject: SyncClient,
+) -> None:
+    """It should execute a setRailLights command."""
+    request = commands.SetRailLightsCreate(params=commands.SetRailLightsParams(on=True))
+    response = commands.SetRailLightsResult()
+
+    decoy.when(transport.execute_command(request=request)).then_return(response)
+
+    result = subject.set_rail_lights(on=True)
+
+    assert result == response
+
+
 def test_magnetic_module_engage(
     decoy: Decoy,
     transport: AbstractSyncTransport,
@@ -283,17 +299,33 @@ def test_magnetic_module_engage(
     assert result == response
 
 
-def test_set_rail_lights(
+def test_thermocycler_deactivate_block(
     decoy: Decoy,
     transport: AbstractSyncTransport,
     subject: SyncClient,
 ) -> None:
-    """It should execute a setRailLights command."""
-    request = commands.SetRailLightsCreate(params=commands.SetRailLightsParams(on=True))
-    response = commands.SetRailLightsResult()
-
+    """It should execute a Thermocycler's deactivate block command."""
+    request = commands.thermocycler.DeactivateBlockCreate(
+        params=commands.thermocycler.DeactivateBlockParams(moduleId="module-id")
+    )
+    response = commands.thermocycler.DeactivateBlockResult()
     decoy.when(transport.execute_command(request=request)).then_return(response)
+    result = subject.thermocycler_deactivate_block(module_id="module-id")
 
-    result = subject.set_rail_lights(on=True)
+    assert result == response
+
+
+def test_thermocycler_deactivate_lid(
+    decoy: Decoy,
+    transport: AbstractSyncTransport,
+    subject: SyncClient,
+) -> None:
+    """It should execute a Thermocycler's deactivate block command."""
+    request = commands.thermocycler.DeactivateLidCreate(
+        params=commands.thermocycler.DeactivateLidParams(moduleId="module-id")
+    )
+    response = commands.thermocycler.DeactivateLidResult()
+    decoy.when(transport.execute_command(request=request)).then_return(response)
+    result = subject.thermocycler_deactivate_lid(module_id="module-id")
 
     assert result == response

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_deactivate_block.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_deactivate_block.py
@@ -1,0 +1,47 @@
+"""Test Thermocycler deactivate block command implementation."""
+from decoy import Decoy
+
+from opentrons.hardware_control.modules import Thermocycler
+
+from opentrons.protocol_engine.state import StateView
+from opentrons.protocol_engine.state.module_substates import (
+    ThermocyclerModuleSubState,
+    ThermocyclerModuleId,
+)
+from opentrons.protocol_engine.execution import EquipmentHandler
+from opentrons.protocol_engine.commands import thermocycler as tc_commands
+from opentrons.protocol_engine.commands.thermocycler.deactivate_block import (
+    DeactivateBlockImpl,
+)
+
+
+async def test_deactivate_block(
+    decoy: Decoy,
+    state_view: StateView,
+    equipment: EquipmentHandler,
+) -> None:
+    """It should be able to deactivate the specified module's block."""
+    subject = DeactivateBlockImpl(state_view=state_view, equipment=equipment)
+
+    data = tc_commands.DeactivateBlockParams(moduleId="input-thermocycler-id")
+    expected_module_id = ThermocyclerModuleId("thermocycler-id")
+    expected_result = tc_commands.DeactivateBlockResult()
+
+    tc_module_substate = decoy.mock(cls=ThermocyclerModuleSubState)
+    tc_hardware = decoy.mock(cls=Thermocycler)
+
+    decoy.when(
+        state_view.modules.get_thermocycler_module_substate("input-thermocycler-id")
+    ).then_return(tc_module_substate)
+
+    decoy.when(tc_module_substate.module_id).then_return(expected_module_id)
+
+    # Get attached hardware modules
+    decoy.when(equipment.get_module_hardware_api(expected_module_id)).then_return(
+        tc_hardware
+    )
+
+    result = await subject.execute(data)
+
+    decoy.verify(await tc_hardware.deactivate_block(), times=1)
+    assert result == expected_result

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_deactivate_lid.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_deactivate_lid.py
@@ -1,0 +1,47 @@
+"""Test Thermocycler deactivate lid command implementation."""
+from decoy import Decoy
+
+from opentrons.hardware_control.modules import Thermocycler
+
+from opentrons.protocol_engine.state import StateView
+from opentrons.protocol_engine.state.module_substates import (
+    ThermocyclerModuleSubState,
+    ThermocyclerModuleId,
+)
+from opentrons.protocol_engine.execution import EquipmentHandler
+from opentrons.protocol_engine.commands import thermocycler as tc_commands
+from opentrons.protocol_engine.commands.thermocycler.deactivate_lid import (
+    DeactivateLidImpl,
+)
+
+
+async def test_deactivate_lid(
+    decoy: Decoy,
+    state_view: StateView,
+    equipment: EquipmentHandler,
+) -> None:
+    """It should be able to deactivate the specified module's lid."""
+    subject = DeactivateLidImpl(state_view=state_view, equipment=equipment)
+
+    data = tc_commands.DeactivateLidParams(moduleId="input-thermocycler-id")
+    expected_module_id = ThermocyclerModuleId("thermocycler-id")
+    expected_result = tc_commands.DeactivateLidResult()
+
+    tc_module_substate = decoy.mock(cls=ThermocyclerModuleSubState)
+    tc_hardware = decoy.mock(cls=Thermocycler)
+
+    decoy.when(
+        state_view.modules.get_thermocycler_module_substate("input-thermocycler-id")
+    ).then_return(tc_module_substate)
+
+    decoy.when(tc_module_substate.module_id).then_return(expected_module_id)
+
+    # Get attached hardware modules
+    decoy.when(equipment.get_module_hardware_api(expected_module_id)).then_return(
+        tc_hardware
+    )
+
+    result = await subject.execute(data)
+
+    decoy.verify(await tc_hardware.deactivate_lid(), times=1)
+    assert result == expected_result


### PR DESCRIPTION
## Overview

This PR closes https://github.com/Opentrons/opentrons/issues/9557. See ticket for more information and acceptance criteria.

## Changelog

- Add deactivate lid and block commands to the engine
- Add `deactivate`, `deactivate_block`, and `deactivate_lid` methods to the PAPIv3 TC context

## Review requests

For now, we mainly need to focus on the engine side of things. The PAPIv3 work in this ticket is mainly to stay proactive about pushing that forward.

To smoke test, you can use the live commands endpoint (`POST /commands`) to issue commands to set and then deactivate the heaters. For example, here are commands to set and deactivate the block.

```js
// POST /commands
{
  "data": {
    "commandType": "thermocycler/setTargetBlockTemperature",
    "params": {
        "moduleId": "module-id-from-get-modules",
        "temperature": 42
    }
  }
}

// POST /commands
{
  "data": {
    "commandType": "thermocycler/deactivateBlock",
    "params": {
        "moduleId": "module-id-from-get-modules"
    }
  }
}
```

After the `setTargetBlockTemperature`, `GET /modules` should report a target block temperature. After `deactivateBlock`, there should be no target block temperature in the `GET /modules` response.

**This smoke test will probably only work against real hardware or the emulator.** IIRC the simulating thermocycler in the regular `make dev` server will not react to these commands.

## Risk assessment

Low, these are really straightforward commands that hook into existing methods of the hardware API.