### PR TITLE
chore(robot-server): Allow omitting __init__() docstrings

### DIFF
--- a/robot-server/.flake8
+++ b/robot-server/.flake8
@@ -13,6 +13,8 @@ extend-ignore =
     # do not require type annotations for self nor cls
     ANN101,
     ANN102
+    # do not require docstring for __init__, put them on the class
+    D107,
 
 # configure flake8-docstrings
 # https://pypi.org/project/flake8-docstrings/


### PR DESCRIPTION
# Changelog

This PR makes it so that in robot server, instead of doing this:

```python
class MyClass:
    """MyClass is the best class ever because I made it.

    I like it a lot and I hope you will too.
    """

    def __init__(self) -> None:
        """Initialize the MyClass."""
        self.foo = "bar"

    ...
```

We can just do this:

```python
class MyClass:
    """MyClass is the best class ever because I made it.

    I like it a lot and I hope you will too.
    """

    def __init__(self) -> None:
        self.foo = "bar"

    ...
```

# Rationale

First, [`api` already does this](https://github.com/Opentrons/opentrons/blob/91645237f20c532ff9a7bd36da1b07ed46a42eeb/api/.flake8#L16-L17).

But the idea is, for simple classes, the `__init__()` docstring is often either meaningless or redundant with the class docstring. Sphinx, for example, has long had [an option](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autoclass_content) to use either one as the source of the class's documentation.

In cases where `__init__()` is meaningful to describe on its own—because it has parameters that need documenting, for example—you can of course still have docstrings on both. It's just not mandatory anymore.