### PR TITLE
refactor(app): create getter for getting H-S adapter name

### DIFF
--- a/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
@@ -64,7 +64,7 @@ export const HeaterShakerWizard = (
             labwareDefinition={labwareDef}
             thermalAdapterName={
               labwareDef != null
-                ? getAdapterName(labwareDef?.parameters.loadName)
+                ? getAdapterName(labwareDef.parameters.loadName)
                 : null
             }
           />

--- a/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
+import { getAdapterName } from '@opentrons/shared-data'
 import { Portal } from '../../../App/portal'
 import { Interstitial } from '../../../atoms/Interstitial/Interstitial'
 import { HEATERSHAKER_MODULE_TYPE } from '../../../redux/modules'
@@ -23,8 +24,7 @@ import {
 
 import type { NavRouteParams } from '../../../App/types'
 import type { HeaterShakerModule } from '../../../redux/modules/types'
-import type { ProtocolModuleInfo } from '../../Devices/ProtocolRun/utils/getProtocolModulesInfo'
-import type { ThermalAdapterName } from '@opentrons/shared-data'
+import type { ProtocolModuleInfo } from '../ProtocolRun/utils/getProtocolModulesInfo'
 
 interface HeaterShakerWizardProps {
   onCloseClick: () => unknown
@@ -54,22 +54,6 @@ export const HeaterShakerWizard = (
   const labwareDef =
     moduleFromProtocol != null ? moduleFromProtocol.nestedLabwareDef : null
 
-  let adapterName: ThermalAdapterName | null = null
-  if (
-    labwareDef != null &&
-    labwareDef.parameters.loadName.includes('adapter')
-  ) {
-    if (labwareDef.parameters.loadName.includes('pcr')) {
-      adapterName = 'PCR Adapter'
-    } else if (labwareDef.parameters.loadName.includes('deepwell')) {
-      adapterName = 'Deep Well Adapter'
-    } else if (labwareDef.parameters.loadName.includes('96flatbottom')) {
-      adapterName = '96 Flat Bottom Adapter'
-    }
-  } else if (labwareDef != null) {
-    adapterName = 'Universal Flat Adapter'
-  }
-
   let buttonContent = null
   const getWizardDisplayPage = (): JSX.Element | null => {
     switch (currentPage) {
@@ -78,7 +62,11 @@ export const HeaterShakerWizard = (
         return (
           <Introduction
             labwareDefinition={labwareDef}
-            thermalAdapterName={adapterName}
+            thermalAdapterName={
+              labwareDef != null
+                ? getAdapterName(labwareDef?.parameters.loadName)
+                : null
+            }
           />
         )
       case 1:

--- a/shared-data/js/helpers/__tests__/getAdapterName.test.ts
+++ b/shared-data/js/helpers/__tests__/getAdapterName.test.ts
@@ -1,0 +1,31 @@
+import { getAdapterName } from '../index'
+
+describe('getAdapterName', () => {
+  it(`should return the PCR adapter name`, () => {
+    expect(
+      getAdapterName(
+        'opentrons_96_pcr_plate_adapter_nest_wellplate_100ul_pcr_full_skirt'
+      )
+    ).toEqual('PCR Adapter')
+  })
+  it(`should return the Deep well adapter name`, () => {
+    expect(
+      getAdapterName('opentrons_96_deepwell_adapter_nest_wellplate_2ml_deep')
+    ).toEqual('Deep Well Adapter')
+  })
+  it(`should return the 96 flat bottom adapter name`, () => {
+    expect(
+      getAdapterName(
+        'opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat'
+      )
+    ).toEqual('96 Flat Bottom Adapter')
+  })
+  it(`should return universal flat adapter name when loadname is not 1 of the 3 specified loadnames`, () => {
+    expect(
+      getAdapterName(
+        'opentrons_flat_plate_adapter_corning_384_wellplate_112ul_flat'
+      )
+    ).toEqual('Universal Flat Adapter')
+    expect(getAdapterName('random labware')).toEqual('Universal Flat Adapter')
+  })
+})

--- a/shared-data/js/helpers/index.ts
+++ b/shared-data/js/helpers/index.ts
@@ -3,7 +3,7 @@ import uniq from 'lodash/uniq'
 
 import { OPENTRONS_LABWARE_NAMESPACE } from '../constants'
 import type { DeckDefinition, LabwareDefinition2 } from '../types'
-import type { LabwareParameters, ThermalAdapterName } from '..'
+import type { ThermalAdapterName } from '..'
 
 export { getWellNamePerMultiTip } from './getWellNamePerMultiTip'
 export { getWellTotalVolume } from './getWellTotalVolume'

--- a/shared-data/js/helpers/index.ts
+++ b/shared-data/js/helpers/index.ts
@@ -186,16 +186,22 @@ export const getSlotHasMatingSurfaceUnitVector = (
   return Boolean(matingSurfaceUnitVector)
 }
 
-export const getAdapterName = (
-  labwareLoadname: LabwareParameters['loadName']
-): ThermalAdapterName => {
+export const getAdapterName = (labwareLoadname: string): ThermalAdapterName => {
   let adapterName: ThermalAdapterName = 'Universal Flat Adapter'
 
-  if (labwareLoadname.includes('pcr')) {
+  if (
+    labwareLoadname ===
+    'opentrons_96_pcr_plate_adapter_nest_wellplate_100ul_pcr_full_skirt'
+  ) {
     adapterName = 'PCR Adapter'
-  } else if (labwareLoadname.includes('deepwell')) {
+  } else if (
+    labwareLoadname === 'opentrons_96_deepwell_adapter_nest_wellplate_2ml_deep'
+  ) {
     adapterName = 'Deep Well Adapter'
-  } else if (labwareLoadname.includes('flatbottom')) {
+  } else if (
+    labwareLoadname ===
+    'opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat'
+  ) {
     adapterName = '96 Flat Bottom Adapter'
   }
 

--- a/shared-data/js/helpers/index.ts
+++ b/shared-data/js/helpers/index.ts
@@ -3,6 +3,7 @@ import uniq from 'lodash/uniq'
 
 import { OPENTRONS_LABWARE_NAMESPACE } from '../constants'
 import type { DeckDefinition, LabwareDefinition2 } from '../types'
+import type { LabwareParameters, ThermalAdapterName } from '..'
 
 export { getWellNamePerMultiTip } from './getWellNamePerMultiTip'
 export { getWellTotalVolume } from './getWellTotalVolume'
@@ -183,4 +184,22 @@ export const getSlotHasMatingSurfaceUnitVector = (
   )?.matingSurfaceUnitVector
 
   return Boolean(matingSurfaceUnitVector)
+}
+
+export const getAdapterName = (
+  labwareLoadname: LabwareParameters['loadName']
+): ThermalAdapterName => {
+  let adapterName: ThermalAdapterName
+
+  if (labwareLoadname.includes('pcr')) {
+    adapterName = 'PCR Adapter'
+  } else if (labwareLoadname.includes('deepwell')) {
+    adapterName = 'Deep Well Adapter'
+  } else if (labwareLoadname.includes('flatbottom')) {
+    adapterName = '96 Flat Bottom Adapter'
+  } else {
+    adapterName = 'Universal Flat Adapter'
+  }
+
+  return adapterName
 }

--- a/shared-data/js/helpers/index.ts
+++ b/shared-data/js/helpers/index.ts
@@ -189,7 +189,7 @@ export const getSlotHasMatingSurfaceUnitVector = (
 export const getAdapterName = (
   labwareLoadname: LabwareParameters['loadName']
 ): ThermalAdapterName => {
-  let adapterName: ThermalAdapterName
+  let adapterName: ThermalAdapterName = 'Universal Flat Adapter'
 
   if (labwareLoadname.includes('pcr')) {
     adapterName = 'PCR Adapter'
@@ -197,8 +197,6 @@ export const getAdapterName = (
     adapterName = 'Deep Well Adapter'
   } else if (labwareLoadname.includes('flatbottom')) {
     adapterName = '96 Flat Bottom Adapter'
-  } else {
-    adapterName = 'Universal Flat Adapter'
   }
 
   return adapterName


### PR DESCRIPTION
closes #9963

# Overview

This creates a getter in shared-data that takes in the labware name and spits out the adapter name, used in the introduction page of the heater-shaker wizard

# Changelog

-moved adapter name logic from `heaterShakerWizard` to a getter called `getAdapterName`

# Review requests

- is logic sound? 

# Risk assessment

low, behind ff and hs
