### PR TITLE
fix(components): update labware render story to match new component interface

### DIFF
--- a/components/src/hardware-sim/Labware/LabwareRender.stories.tsx
+++ b/components/src/hardware-sim/Labware/LabwareRender.stories.tsx
@@ -68,7 +68,7 @@ Basic.argTypes = {
   },
 }
 Basic.args = {
-  showLabels: true,
+  wellLabelOption: 'SHOW_LABEL_INSIDE',
   highlightedWells: { A1: null, A2: null },
   wellFill: { A1: 'maroon', A2: 'lavender' },
 }
@@ -86,7 +86,7 @@ TipRack.argTypes = {
   },
 }
 TipRack.args = {
-  showLabels: true,
+  wellLabelOption: 'SHOW_LABEL_INSIDE',
   highlightedWells: { A1: null, A2: null },
   missingTips: { C3: null, D4: null },
 }


### PR DESCRIPTION
# Overview
The labware render story got broken after I updated the component interface for LPC, this just fixes the story!
# Changelog

- Update labware render story to match new component interface


# Review requests
Check the storybook component for the labware render, you should now be able to see well labels

# Risk assessment
Low
