### PR TITLE
feat(app): robot controls warning banner

### DIFF
--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -90,5 +90,6 @@
   "calibrate_now": "Calibrate now",
   "deck_cal_missing": "Pipette Offset calibration missing. Calibrate deck first.",
   "an_error_occurred_while_updating_please_try_again": "An error occurred while updating your pipette's settings. Please try again.",
-  "deck_slot": "deck slot {{slot}}"
+  "deck_slot": "deck slot {{slot}}",
+  "robot_control_not_available": "Some robot controls are not available when run is in progress"
 }

--- a/app/src/organisms/Devices/PipettesAndModules.tsx
+++ b/app/src/organisms/Devices/PipettesAndModules.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { LEFT, RIGHT } from '@opentrons/shared-data'
-import { RUN_STATUS_IDLE } from '@opentrons/api-client'
 import {
   Flex,
   ALIGN_CENTER,
@@ -19,7 +18,6 @@ import {
 import { StyledText } from '../../atoms/text'
 import { Banner } from '../../atoms/Banner'
 import { useCurrentRunId } from '../ProtocolUpload/hooks'
-import { useCurrentRunStatus } from '../RunTimeControl/hooks'
 import { ModuleCard } from './ModuleCard'
 import {
   useAttachedModules,
@@ -41,9 +39,6 @@ export function PipettesAndModules({
   const attachedPipettes = useAttachedPipettes(robotName)
   const isRobotViewable = useIsRobotViewable(robotName)
   const currentRunId = useCurrentRunId()
-  const runStatus = useCurrentRunStatus()
-  const isProtocolLoaded =
-    currentRunId != null || (runStatus != null && runStatus !== RUN_STATUS_IDLE)
 
   return (
     <Flex
@@ -68,7 +63,7 @@ export function PipettesAndModules({
         width="100%"
         flexDirection={DIRECTION_COLUMN}
       >
-        {isProtocolLoaded && (
+        {currentRunId != null && (
           <Flex
             paddingBottom={SPACING.spacing4}
             flexDirection={DIRECTION_COLUMN}

--- a/app/src/organisms/Devices/PipettesAndModules.tsx
+++ b/app/src/organisms/Devices/PipettesAndModules.tsx
@@ -42,7 +42,7 @@ export function PipettesAndModules({
   const isRobotViewable = useIsRobotViewable(robotName)
   const currentRunId = useCurrentRunId()
   const runStatus = useCurrentRunStatus()
-  const showWarningBanner =
+  const isProtocolLoaded =
     currentRunId != null || (runStatus != null && runStatus !== RUN_STATUS_IDLE)
 
   return (
@@ -68,11 +68,14 @@ export function PipettesAndModules({
         width="100%"
         flexDirection={DIRECTION_COLUMN}
       >
-        {showWarningBanner && (
-          <Flex paddingBottom={SPACING.spacing4}>
-            <Banner type="warning">
-              <Flex width="100%">{t('robot_control_not_available')}</Flex>
-            </Banner>
+        {isProtocolLoaded && (
+          <Flex
+            paddingBottom={SPACING.spacing4}
+            flexDirection={DIRECTION_COLUMN}
+            paddingX={SPACING.spacing2}
+            width="100%"
+          >
+            <Banner type="warning">{t('robot_control_not_available')}</Banner>
           </Flex>
         )}
         {/* TODO(jr, 4/15/22): This needs to be refactored to get a combined array of pipettes and modules so it can display with widths matching each column as the design shows */}

--- a/app/src/organisms/Devices/PipettesAndModules.tsx
+++ b/app/src/organisms/Devices/PipettesAndModules.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { LEFT, RIGHT } from '@opentrons/shared-data'
+import { RUN_STATUS_IDLE } from '@opentrons/api-client'
 import {
   Flex,
   ALIGN_CENTER,
@@ -16,6 +17,9 @@ import {
 } from '@opentrons/components'
 
 import { StyledText } from '../../atoms/text'
+import { Banner } from '../../atoms/Banner'
+import { useCurrentRunId } from '../ProtocolUpload/hooks'
+import { useCurrentRunStatus } from '../RunTimeControl/hooks'
 import { ModuleCard } from './ModuleCard'
 import {
   useAttachedModules,
@@ -36,6 +40,11 @@ export function PipettesAndModules({
   const attachedModules = useAttachedModules(robotName)
   const attachedPipettes = useAttachedPipettes(robotName)
   const isRobotViewable = useIsRobotViewable(robotName)
+  const currentRunId = useCurrentRunId()
+  const runStatus = useCurrentRunStatus()
+  const showWarningBanner =
+    currentRunId != null || (runStatus != null && runStatus !== RUN_STATUS_IDLE)
+
   return (
     <Flex
       alignItems={ALIGN_FLEX_START}
@@ -54,9 +63,18 @@ export function PipettesAndModules({
         alignItems={ALIGN_CENTER}
         justifyContent={JUSTIFY_CENTER}
         minHeight={SIZE_3}
-        padding={SPACING.spacing3}
+        paddingX={SPACING.spacing3}
+        paddingBottom={SPACING.spacing3}
         width="100%"
+        flexDirection={DIRECTION_COLUMN}
       >
+        {showWarningBanner && (
+          <Flex paddingBottom={SPACING.spacing4}>
+            <Banner type="warning">
+              <Flex width="100%">{t('robot_control_not_available')}</Flex>
+            </Banner>
+          </Flex>
+        )}
         {/* TODO(jr, 4/15/22): This needs to be refactored to get a combined array of pipettes and modules so it can display with widths matching each column as the design shows */}
         {isRobotViewable ? (
           <Flex flexDirection={DIRECTION_COLUMN} width="100%">

--- a/app/src/organisms/Devices/__tests__/PipettesAndModules.test.tsx
+++ b/app/src/organisms/Devices/__tests__/PipettesAndModules.test.tsx
@@ -4,7 +4,6 @@ import { i18n } from '../../../i18n'
 import { Banner } from '../../../atoms/Banner'
 import { mockMagneticModule } from '../../../redux/modules/__fixtures__'
 import { useCurrentRunId } from '../../ProtocolUpload/hooks'
-import { useCurrentRunStatus } from '../../RunTimeControl/hooks'
 import {
   useAttachedModules,
   useAttachedPipettes,
@@ -13,14 +12,12 @@ import {
 import { ModuleCard } from '../ModuleCard'
 import { PipettesAndModules } from '../PipettesAndModules'
 import { PipetteCard } from '../PipetteCard'
-import { RUN_STATUS_RUNNING } from '@opentrons/api-client'
 
 jest.mock('../hooks')
 jest.mock('../ModuleCard')
 jest.mock('../PipetteCard')
 jest.mock('../../ProtocolUpload/hooks')
 jest.mock('../../../atoms/Banner')
-jest.mock('../../RunTimeControl/hooks')
 
 const mockUseAttachedModules = useAttachedModules as jest.MockedFunction<
   typeof useAttachedModules
@@ -37,9 +34,6 @@ const mockBanner = Banner as jest.MockedFunction<typeof Banner>
 const mockUseCurrentRunId = useCurrentRunId as jest.MockedFunction<
   typeof useCurrentRunId
 >
-const mockUseCurrentRunStatus = useCurrentRunStatus as jest.MockedFunction<
-  typeof useCurrentRunStatus
->
 
 const render = () => {
   return renderWithProviders(<PipettesAndModules robotName="otie" />, {
@@ -50,7 +44,6 @@ const render = () => {
 describe('PipettesAndModules', () => {
   beforeEach(() => {
     mockUseCurrentRunId.mockReturnValue(null)
-    mockUseCurrentRunStatus.mockReturnValue(null)
   })
   afterEach(() => {
     jest.resetAllMocks()
@@ -90,13 +83,6 @@ describe('PipettesAndModules', () => {
   })
   it('renders the protocol loaded banner when protocol is loaded', () => {
     mockUseCurrentRunId.mockReturnValue('RUNID')
-    mockBanner.mockReturnValue(<div>mock Banner</div>)
-    const [{ getByText }] = render()
-
-    getByText('mock Banner')
-  })
-  it('renders the protocol loaded banner when run status is not idle', () => {
-    mockUseCurrentRunStatus.mockReturnValue(RUN_STATUS_RUNNING)
     mockBanner.mockReturnValue(<div>mock Banner</div>)
     const [{ getByText }] = render()
 

--- a/app/src/organisms/Devices/__tests__/PipettesAndModules.test.tsx
+++ b/app/src/organisms/Devices/__tests__/PipettesAndModules.test.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../i18n'
+import { Banner } from '../../../atoms/Banner'
 import { mockMagneticModule } from '../../../redux/modules/__fixtures__'
+import { useCurrentRunId } from '../../ProtocolUpload/hooks'
+import { useCurrentRunStatus } from '../../RunTimeControl/hooks'
 import {
   useAttachedModules,
   useAttachedPipettes,
@@ -10,10 +13,14 @@ import {
 import { ModuleCard } from '../ModuleCard'
 import { PipettesAndModules } from '../PipettesAndModules'
 import { PipetteCard } from '../PipetteCard'
+import { RUN_STATUS_RUNNING } from '@opentrons/api-client'
 
 jest.mock('../hooks')
 jest.mock('../ModuleCard')
 jest.mock('../PipetteCard')
+jest.mock('../../ProtocolUpload/hooks')
+jest.mock('../../../atoms/Banner')
+jest.mock('../../RunTimeControl/hooks')
 
 const mockUseAttachedModules = useAttachedModules as jest.MockedFunction<
   typeof useAttachedModules
@@ -26,6 +33,13 @@ const mockPipetteCard = PipetteCard as jest.MockedFunction<typeof PipetteCard>
 const mockUseAttachedPipettes = useAttachedPipettes as jest.MockedFunction<
   typeof useAttachedPipettes
 >
+const mockBanner = Banner as jest.MockedFunction<typeof Banner>
+const mockUseCurrentRunId = useCurrentRunId as jest.MockedFunction<
+  typeof useCurrentRunId
+>
+const mockUseCurrentRunStatus = useCurrentRunStatus as jest.MockedFunction<
+  typeof useCurrentRunStatus
+>
 
 const render = () => {
   return renderWithProviders(<PipettesAndModules robotName="otie" />, {
@@ -34,6 +48,10 @@ const render = () => {
 }
 
 describe('PipettesAndModules', () => {
+  beforeEach(() => {
+    mockUseCurrentRunId.mockReturnValue(null)
+    mockUseCurrentRunStatus.mockReturnValue(null)
+  })
   afterEach(() => {
     jest.resetAllMocks()
   })
@@ -69,5 +87,19 @@ describe('PipettesAndModules', () => {
     })
     const [{ getAllByText }] = render()
     getAllByText('Mock PipetteCard')
+  })
+  it('renders the protocol loaded banner when protocol is loaded', () => {
+    mockUseCurrentRunId.mockReturnValue('RUNID')
+    mockBanner.mockReturnValue(<div>mock Banner</div>)
+    const [{ getByText }] = render()
+
+    getByText('mock Banner')
+  })
+  it('renders the protocol loaded banner when run status is not idle', () => {
+    mockUseCurrentRunStatus.mockReturnValue(RUN_STATUS_RUNNING)
+    mockBanner.mockReturnValue(<div>mock Banner</div>)
+    const [{ getByText }] = render()
+
+    getByText('mock Banner')
   })
 })


### PR DESCRIPTION
# Overview

closes #10123 - creates warning banner when a runId exists or when run is not idle

<img width="927" alt="Screen Shot 2022-05-02 at 1 21 47 PM" src="https://user-images.githubusercontent.com/66035149/166294460-94f7a7a8-7c16-441d-b794-3a58dee84ae0.png">

# Changelog

- adds banner to `pipettesAndModules` 

# Review requests

- are the hooks I'm using up to date? Does it mach design? is logic correct?

# Risk assessment

low, behind ff