### PR TITLE
refactor(robot-server): Rename `AppStateValue` to `AppStateAccessor`

### DIFF
--- a/robot-server/robot_server/app_state.py
+++ b/robot-server/robot_server/app_state.py
@@ -1,18 +1,54 @@
 """Global application state.
 
-Mostly, this serves as a place to store singletons as well as
-in-memory databases.
+We sometimes have singleton objects, like data stores and hardware controllers,
+that we need to share across HTTP requests. We store these singletons on the
+global application state object, which is provided to us by FastAPI and Starlette.
+
+https://www.starlette.io/applications/#storing-state-on-the-app-instance
+
+This module has helpers for working with the global application state object.
 """
+
+
 from fastapi import Request, WebSocket
-from starlette.datastructures import State as AppState
+from starlette.datastructures import State as AppState  # Re-exported.
 from typing import cast, Generic, Optional, TypeVar
 
 
-ValueT = TypeVar("ValueT")
+async def get_app_state(
+    # NOTE: both of these must be typed as non-optional to allow FastAPI's
+    # dependency injection magic to work, but must have default values of
+    # None in order to function at runtime, as only one will be present
+    request: Request = cast(Request, None),
+    websocket: WebSocket = cast(WebSocket, None),
+) -> AppState:
+    """Get the global application state object from the framework.
+
+    Must be used with FastAPI's dependency injection system via fastapi.Depends.
+
+    Arguments:
+        request: The request object, injected by FastAPI. Will be `None` if the
+            endpoint is a websocket endpoint.
+        websocket: The websocket object, injected by FastAPI. Will be `None` if
+            the endpoint is a regular HTTP endpoint.
+
+    Returns:
+        The global application state object.
+        This is a dictionary-like bag of arbitrary attributes.
+        See https://www.starlette.io/applications/#storing-state-on-the-app-instance.
+
+        You can store and retrieve stuff on it directly, like `app_state.foo = 123`.
+        But it's safer to do this through `AppStateAccessor`.
+    """
+    request_scope = request or websocket
+    return cast(AppState, request_scope.app.state)
 
 
-class AppStateValue(Generic[ValueT]):
-    """A helper to get and set values on `AppState` in a type-safe way.
+_ValueT = TypeVar("_ValueT")
+
+
+class AppStateAccessor(Generic[_ValueT]):
+    """A helper to store and retrieve values on an `AppState` in a type-safe way.
 
     Normally, `AppState` is a loosely-typed bag of attributes,
     which opens the door to silly mistakes:
@@ -26,15 +62,18 @@ class AppStateValue(Generic[ValueT]):
     With this class, this becomes:
 
     .. code-block::
-        my_field = AppStateValue[int]("my_field")
+        my_field = AppStateAccessor[int]("my_field")
         my_field.set_on(app_state, 123)
 
         x = my_fild.get_from(app_state)  # Type-checking error: misspelled variable.
         y: str = my_field.get_from(app_state)  # Type-checking error: not a str.
+
+    Every singleton object you want to store on the `AppState` should get its own
+    `AppStateAccessor`.
     """
 
     def __init__(self, key: str) -> None:
-        """Initialize the value wrapper with a key in state.
+        """Initialize the `AppStateAccessor`.
 
         Arguments:
             key: Unique key on which to store the value. Must be
@@ -42,43 +81,19 @@ class AppStateValue(Generic[ValueT]):
         """
         self._key = key
 
-    def get_from(self, app_state: AppState) -> Optional[ValueT]:
-        """Get the value from state, returning None if not present."""
+    def get_from(self, app_state: AppState) -> Optional[_ValueT]:
+        """Retrieve the value previously stored on `app_state`.
+
+        Return None if not present.
+        """
         return cast(
-            Optional[ValueT],
+            Optional[_ValueT],
             getattr(app_state, self._key, None),
         )
 
-    def set_on(self, app_state: AppState, value: Optional[ValueT]) -> None:
-        """Set the value on state."""
+    def set_on(self, app_state: AppState, value: Optional[_ValueT]) -> None:
+        """Store `value` on `app_state`."""
         setattr(app_state, self._key, value)
 
 
-async def get_app_state(
-    # NOTE: both of these must be typed as non-optional to allow FastAPI's
-    # dependency injection magic to work, but must have default values of
-    # None in order to function at runtime, as only one will be present
-    request: Request = cast(Request, None),
-    websocket: WebSocket = cast(WebSocket, None),
-) -> AppState:
-    """Get the global application's state from the framework.
-
-    Muse be used with FastAPI's dependency injection system via fastapi.Depends.
-
-    See https://www.starlette.io/applications/#storing-state-on-the-app-instance
-    for more details about the application state object.
-
-    Arguments:
-        request: The request object, injected by FastAPI. Will be `None` if the
-            endpoint is a websocket endpoint.
-        websocket: The websocket object, injected by FastAPI. Will be `None` if
-            the endpoint is a regular HTTP endpoint.
-
-    Returns:
-        A dictionary-like object containing global application state.
-    """
-    request_scope = request or websocket
-    return cast(AppState, request_scope.app.state)
-
-
-__all__ = ["AppState", "get_app_state"]
+__all__ = ["AppState", "get_app_state", "AppStateAccessor"]

--- a/robot-server/robot_server/persistence.py
+++ b/robot-server/robot_server/persistence.py
@@ -13,7 +13,7 @@ from robot_server.app_state import AppState, AppStateAccessor, get_app_state
 from robot_server.settings import get_settings
 
 
-_sql_engine_accessor = AppStateAccessor[SQLEngine]("sql_engine")
+_sql_engine_accessor = AppStateAccessor[sqlalchemy.engine.Engine]("sql_engine")
 _persistence_directory_accessor = AppStateAccessor[Path]("persistence_directory")
 _protocol_directory_accessor = AppStateAccessor[Path]("protocol_directory")
 

--- a/robot-server/robot_server/persistence.py
+++ b/robot-server/robot_server/persistence.py
@@ -9,12 +9,13 @@ from anyio import Path as AsyncPath
 from fastapi import Depends
 from typing_extensions import Final
 
-from robot_server.app_state import AppState, AppStateValue, get_app_state
+from robot_server.app_state import AppState, AppStateAccessor, get_app_state
 from robot_server.settings import get_settings
 
-_sql_engine = AppStateValue[sqlalchemy.engine.Engine]("sql_engine")
-_persistence_directory = AppStateValue[Path]("persistence_directory")
-_protocol_directory = AppStateValue[Path]("protocol_directory")
+
+_sql_engine_accessor = AppStateAccessor[SQLEngine]("sql_engine")
+_persistence_directory_accessor = AppStateAccessor[Path]("persistence_directory")
+_protocol_directory_accessor = AppStateAccessor[Path]("protocol_directory")
 
 _TEMP_PERSISTENCE_DIR_PREFIX: Final = "opentrons-robot-server-"
 _DATABASE_FILE: Final = "robot_server.db"
@@ -110,7 +111,7 @@ async def get_persistence_directory(
     app_state: AppState = Depends(get_app_state),
 ) -> Path:
     """Return the root persistence directory, creating it if necessary."""
-    persistence_dir = _persistence_directory.get_from(app_state)
+    persistence_dir = _persistence_directory_accessor.get_from(app_state)
 
     if persistence_dir is None:
         setting = get_settings().persistence_directory
@@ -128,7 +129,7 @@ async def get_persistence_directory(
             await AsyncPath(persistence_dir).mkdir(parents=True, exist_ok=True)
             _log.info(f"Using directory {persistence_dir} for persistence.")
 
-        _persistence_directory.set_on(app_state, persistence_dir)
+        _persistence_directory_accessor.set_on(app_state, persistence_dir)
 
     return persistence_dir
 
@@ -147,14 +148,14 @@ def get_sql_engine(
     persistence_directory: Path = Depends(get_persistence_directory),
 ) -> sqlalchemy.engine.Engine:
     """Return a singleton SQL engine referring to a ready-to-use database."""
-    sql_engine = _sql_engine.get_from(app_state)
+    sql_engine = _sql_engine_accessor.get_from(app_state)
 
     if sql_engine is None:
         sql_engine = open_db_no_cleanup(
             db_file_path=persistence_directory / _DATABASE_FILE
         )
         add_tables_to_db(sql_engine)
-        _sql_engine.set_on(app_state, sql_engine)
+        _sql_engine_accessor.set_on(app_state, sql_engine)
 
     return sql_engine
     # Rely on connections being cleaned up automatically when the process dies.

--- a/robot-server/robot_server/protocols/dependencies.py
+++ b/robot-server/robot_server/protocols/dependencies.py
@@ -12,7 +12,7 @@ from anyio import Path as AsyncPath
 from opentrons.protocol_reader import ProtocolReader
 from opentrons.protocol_runner import create_simulating_runner
 
-from robot_server.app_state import AppState, AppStateValue, get_app_state
+from robot_server.app_state import AppState, AppStateAccessor, get_app_state
 from robot_server.persistence import get_sql_engine, get_persistence_directory
 
 from .protocol_store import (
@@ -25,9 +25,9 @@ _log = logging.getLogger(__name__)
 
 _PROTOCOL_FILES_SUBDIRECTORY: Final = "protocols"
 
-_protocol_store = AppStateValue[ProtocolStore]("protocol_store")
-_analysis_store = AppStateValue[AnalysisStore]("analysis_store")
-_protocol_directory = AppStateValue[Path]("protocol_directory")
+_protocol_store_accessor = AppStateAccessor[ProtocolStore]("protocol_store")
+_analysis_store_accessor = AppStateAccessor[AnalysisStore]("analysis_store")
+_protocol_directory_accessor = AppStateAccessor[Path]("protocol_directory")
 
 
 def get_protocol_reader() -> ProtocolReader:
@@ -40,12 +40,12 @@ async def get_protocol_directory(
     persistence_directory: Path = Depends(get_persistence_directory),
 ) -> Path:
     """Get the directory to save protocol files, creating it if needed."""
-    protocol_directory = _protocol_directory.get_from(app_state)
+    protocol_directory = _protocol_directory_accessor.get_from(app_state)
 
     if protocol_directory is None:
         protocol_directory = persistence_directory / _PROTOCOL_FILES_SUBDIRECTORY
         await AsyncPath(protocol_directory).mkdir(exist_ok=True)
-        _protocol_directory.set_on(app_state, protocol_directory)
+        _protocol_directory_accessor.set_on(app_state, protocol_directory)
 
     return protocol_directory
 
@@ -57,7 +57,7 @@ async def get_protocol_store(
     protocol_reader: ProtocolReader = Depends(get_protocol_reader),
 ) -> ProtocolStore:
     """Get a singleton ProtocolStore to keep track of created protocols."""
-    protocol_store = _protocol_store.get_from(app_state)
+    protocol_store = _protocol_store_accessor.get_from(app_state)
 
     if protocol_store is None:
         protocol_store = await ProtocolStore.rehydrate(
@@ -65,18 +65,18 @@ async def get_protocol_store(
             protocols_directory=protocol_directory,
             protocol_reader=protocol_reader,
         )
-        _protocol_store.set_on(app_state, protocol_store)
+        _protocol_store_accessor.set_on(app_state, protocol_store)
 
     return protocol_store
 
 
 def get_analysis_store(app_state: AppState = Depends(get_app_state)) -> AnalysisStore:
     """Get a singleton AnalysisStore to keep track of created analyses."""
-    analysis_store = _analysis_store.get_from(app_state)
+    analysis_store = _analysis_store_accessor.get_from(app_state)
 
     if analysis_store is None:
         analysis_store = AnalysisStore()
-        _analysis_store.set_on(app_state, analysis_store)
+        _analysis_store_accessor.set_on(app_state, analysis_store)
 
     return analysis_store
 

--- a/robot-server/robot_server/runs/dependencies.py
+++ b/robot-server/robot_server/runs/dependencies.py
@@ -4,7 +4,7 @@ from sqlalchemy.engine import Engine as SQLEngine
 
 from opentrons.hardware_control import HardwareControlAPI
 
-from robot_server.app_state import AppState, AppStateValue, get_app_state
+from robot_server.app_state import AppState, AppStateAccessor, get_app_state
 from robot_server.hardware import get_hardware
 from robot_server.persistence import get_sql_engine
 
@@ -12,8 +12,8 @@ from .engine_store import EngineStore
 from .run_store import RunStore
 
 
-_run_store = AppStateValue[RunStore]("run_store")
-_engine_store = AppStateValue[EngineStore]("engine_store")
+_run_store_accessor = AppStateAccessor[RunStore]("run_store")
+_engine_store_accessor = AppStateAccessor[EngineStore]("engine_store")
 
 
 def get_run_store(
@@ -21,11 +21,11 @@ def get_run_store(
     sql_engine: SQLEngine = Depends(get_sql_engine),
 ) -> RunStore:
     """Get a singleton RunStore to keep track of created runs."""
-    run_store = _run_store.get_from(app_state)
+    run_store = _run_store_accessor.get_from(app_state)
 
     if run_store is None:
         run_store = RunStore(sql_engine=sql_engine)
-        _run_store.set_on(app_state, run_store)
+        _run_store_accessor.set_on(app_state, run_store)
 
     return run_store
 
@@ -35,10 +35,10 @@ def get_engine_store(
     hardware_api: HardwareControlAPI = Depends(get_hardware),
 ) -> EngineStore:
     """Get a singleton EngineStore to keep track of created engines / runners."""
-    engine_store = _engine_store.get_from(app_state)
+    engine_store = _engine_store_accessor.get_from(app_state)
 
     if engine_store is None:
         engine_store = EngineStore(hardware_api=hardware_api)
-        _engine_store.set_on(app_state, engine_store)
+        _engine_store_accessor.set_on(app_state, engine_store)
 
     return engine_store


### PR DESCRIPTION
# Overview

Following up on a brief discussion in a recent team call, this renames the `AppStateValue` class to `AppStateAccessor`. 

# Changelog

* Rename `AppStateValue` to `AppStateAccessor`.
    * Props to @mcous for the suggestion.
    * I think `AppStateValue` was misleading because an instance of it usually isn't the "value" that we care about. For example, suppose we have a database singleton, and we manage it with an `AppStateValue` instance. The `AppStateValue` instance *isn't* the actual singleton database object. It's merely a helper to store and retrieve that object from somewhere else.
* Shuffle things around in `app_setup.py` and reword some of the docstrings to, I hope, provide a gentler introduction to these concepts and their motivation.

# Review requests

* Does the name `AppStateAccessor` make more sense than `AppStateValue`?
* Do the docstrings make more sense than before?
* Did anything unintentional sneak into my find+replace?

# Risk assessment

Very low. There should be no behavioral code changes here.