### PR TITLE
Update applied biosystems 384 well plate format key

### DIFF
--- a/shared-data/labware/definitions/2/appliedbiosystemsmicroamp_384_wellplate_40ul/1.json
+++ b/shared-data/labware/definitions/2/appliedbiosystemsmicroamp_384_wellplate_40ul/1.json
@@ -4303,7 +4303,7 @@
     }
   ],
   "parameters": {
-    "format": "irregular",
+    "format": "384Standard",
     "quirks": [],
     "isTiprack": false,
     "isMagneticModuleCompatible": false,

--- a/shared-data/labware/definitions/2/biorad_384_wellplate_50ul/1.json
+++ b/shared-data/labware/definitions/2/biorad_384_wellplate_50ul/1.json
@@ -4312,7 +4312,7 @@
     }
   ],
   "parameters": {
-    "format": "irregular",
+    "format": "384Standard",
     "quirks": [],
     "isTiprack": false,
     "isMagneticModuleCompatible": false,

--- a/shared-data/labware/definitions/2/thermoscientificnunc_96_wellplate_1300ul/1.json
+++ b/shared-data/labware/definitions/2/thermoscientificnunc_96_wellplate_1300ul/1.json
@@ -1001,10 +1001,10 @@
     }
   ],
   "parameters": {
-    "format": "irregular",
+    "format": "96Standard",
     "quirks": [],
     "isTiprack": false,
-    "isMagneticModuleCompatible": false,
+    "isMagneticModuleCompatible": true,
     "loadName": "thermoscientificnunc_96_wellplate_1300ul"
   },
   "namespace": "opentrons",

--- a/shared-data/labware/definitions/2/thermoscientificnunc_96_wellplate_2000ul/1.json
+++ b/shared-data/labware/definitions/2/thermoscientificnunc_96_wellplate_2000ul/1.json
@@ -1001,10 +1001,10 @@
     }
   ],
   "parameters": {
-    "format": "irregular",
+    "format": "96Standard",
     "quirks": [],
     "isTiprack": false,
-    "isMagneticModuleCompatible": false,
+    "isMagneticModuleCompatible": true,
     "loadName": "thermoscientificnunc_96_wellplate_2000ul"
   },
   "namespace": "opentrons",


### PR DESCRIPTION
Updating format key to "384Standard" to allow multichannel access in second row of the plate

Reference ticket #4678
