### PR TITLE
Update biorad 384 well plate format key

### DIFF
--- a/shared-data/labware/definitions/2/biorad_384_wellplate_50ul/1.json
+++ b/shared-data/labware/definitions/2/biorad_384_wellplate_50ul/1.json
@@ -4312,7 +4312,7 @@
     }
   ],
   "parameters": {
-    "format": "irregular",
+    "format": "384Standard",
     "quirks": [],
     "isTiprack": false,
     "isMagneticModuleCompatible": false,


### PR DESCRIPTION
Updating format key to "384Standard" to allow multichannel access to second row of plate

Reference ticket #9827 