### PR TITLE
feat(app): add protocol card sorting

### DIFF
--- a/app/src/assets/localization/en/protocol_info.json
+++ b/app/src/assets/localization/en/protocol_info.json
@@ -63,5 +63,7 @@
   "protocols": "Protocols",
   "import": "Import",
   "all_protocols": "All Protocols",
-  "import_new_protocol": "Import a Protocol"
+  "import_new_protocol": "Import a Protocol",
+  "most_recent_updates": "Most recent updates",
+  "oldest_updates": "Oldest updates"
 }

--- a/app/src/organisms/ProtocolsLanding/ProtocolList.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolList.tsx
@@ -6,7 +6,16 @@ import {
   ALIGN_CENTER,
   JUSTIFY_SPACE_BETWEEN,
   SPACING,
+  DIRECTION_ROW,
+  Icon,
+  TYPOGRAPHY,
+  BORDERS,
+  POSITION_ABSOLUTE,
+  COLORS,
+  DIRECTION_COLUMN,
+  Overlay,
 } from '@opentrons/components'
+import { useSortedProtocols } from './hooks'
 import { StyledText } from '../../atoms/text'
 import { SecondaryButton } from '../../atoms/Buttons'
 import { Slideout } from '../../atoms/Slideout'
@@ -14,20 +23,32 @@ import { ChooseRobotSlideout } from '../ChooseRobotSlideout'
 import { UploadInput } from './UploadInput'
 import { ProtocolCard } from './ProtocolCard'
 import { EmptyStateLinks } from './EmptyStateLinks'
+import { MenuItem } from '../../atoms/MenuList/MenuItem'
 
 import type { StoredProtocolData } from '../../redux/protocol-storage'
+import type { ProtocolSort } from './hooks'
 
 interface ProtocolListProps {
   storedProtocols: StoredProtocolData[]
 }
 export function ProtocolList(props: ProtocolListProps): JSX.Element | null {
   const [showSlideout, setShowSlideout] = React.useState(false)
+  const [sortBy, setSortBy] = React.useState<ProtocolSort>('alphabetical')
+  const [showSortByMenu, setShowSortByMenu] = React.useState<boolean>(false)
+  const toggleSetShowSortByMenu = (): void => setShowSortByMenu(!showSortByMenu)
   const { t } = useTranslation('protocol_info')
   const { storedProtocols } = props
   const [
     selectedProtocol,
     setSelectedProtocol,
   ] = React.useState<StoredProtocolData | null>(null)
+
+  const sortedStoredProtocols = useSortedProtocols(sortBy, storedProtocols)
+
+  const handleClickOutside: React.MouseEventHandler<HTMLDivElement> = e => {
+    e.preventDefault()
+    setShowSortByMenu(false)
+  }
 
   return (
     <Box padding={SPACING.spacing4}>
@@ -45,15 +66,83 @@ export function ProtocolList(props: ProtocolListProps): JSX.Element | null {
       >
         <StyledText as="h1">{t('protocols')}</StyledText>
         {/* TODO - Add text filter dropdown overflow menu component */}
-        <SecondaryButton onClick={() => setShowSlideout(true)}>
-          {t('import')}
-        </SecondaryButton>
+        <Flex flexDirection={DIRECTION_ROW}>
+          <Flex
+            flexDirection={DIRECTION_ROW}
+            alignItems={ALIGN_CENTER}
+            marginRight={SPACING.spacing4}
+            onClick={toggleSetShowSortByMenu}
+          >
+            <StyledText css={TYPOGRAPHY.pSemiBold}>
+              {t('labware_landing:sort_by')}
+            </StyledText>
+            <Icon
+              height={TYPOGRAPHY.lineHeight16}
+              name={showSortByMenu ? 'chevron-up' : 'chevron-down'}
+            />
+          </Flex>
+          {showSortByMenu && (
+            <Flex
+              width="10rem"
+              zIndex={2}
+              borderRadius={BORDERS.radiusSoftCorners}
+              boxShadow={'0px 1px 3px rgba(0, 0, 0, 0.2)'}
+              position={POSITION_ABSOLUTE}
+              backgroundColor={COLORS.white}
+              top="3rem"
+              right={'7rem'}
+              flexDirection={DIRECTION_COLUMN}
+            >
+              <MenuItem
+                onClick={() => {
+                  setSortBy('alphabetical')
+                  setShowSortByMenu(false)
+                }}
+              >
+                {t('labware_landing:alphabetical')}
+              </MenuItem>
+              <MenuItem
+                onClick={() => {
+                  setSortBy('recent')
+                  setShowSortByMenu(false)
+                }}
+              >
+                {'Most recent updates'}
+              </MenuItem>
+              <MenuItem
+                onClick={() => {
+                  setSortBy('reverse')
+                  setShowSortByMenu(false)
+                }}
+              >
+                {t('labware_landing:reverse')}
+              </MenuItem>
+              <MenuItem
+                onClick={() => {
+                  setSortBy('oldest')
+                  setShowSortByMenu(false)
+                }}
+              >
+                {'Oldest updates'}
+              </MenuItem>
+            </Flex>
+          )}
+          {showSortByMenu ? (
+            <Overlay
+              onClick={handleClickOutside}
+              backgroundColor={COLORS.transparent}
+            />
+          ) : null}
+          <SecondaryButton onClick={() => setShowSlideout(true)}>
+            {t('import')}
+          </SecondaryButton>
+        </Flex>
       </Flex>
       <StyledText as="p" paddingBottom={SPACING.spacing4}>
         {t('all_protocols')}
       </StyledText>
       <Flex flexDirection="column">
-        {storedProtocols.map(storedProtocol => (
+        {sortedStoredProtocols.map(storedProtocol => (
           <ProtocolCard
             key={storedProtocol.protocolKey}
             handleRunProtocol={() => setSelectedProtocol(storedProtocol)}

--- a/app/src/organisms/ProtocolsLanding/ProtocolList.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolList.tsx
@@ -107,7 +107,7 @@ export function ProtocolList(props: ProtocolListProps): JSX.Element | null {
                   setShowSortByMenu(false)
                 }}
               >
-                {'Most recent updates'}
+                {t('most_recent_updates')}
               </MenuItem>
               <MenuItem
                 onClick={() => {
@@ -123,7 +123,7 @@ export function ProtocolList(props: ProtocolListProps): JSX.Element | null {
                   setShowSortByMenu(false)
                 }}
               >
-                {'Oldest updates'}
+                {t('oldest_updates')}
               </MenuItem>
             </Flex>
           )}

--- a/app/src/organisms/ProtocolsLanding/ProtocolList.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolList.tsx
@@ -65,7 +65,6 @@ export function ProtocolList(props: ProtocolListProps): JSX.Element | null {
         marginBottom={SPACING.spacing5}
       >
         <StyledText as="h1">{t('protocols')}</StyledText>
-        {/* TODO - Add text filter dropdown overflow menu component */}
         <Flex flexDirection={DIRECTION_ROW}>
           <Flex
             flexDirection={DIRECTION_ROW}

--- a/app/src/organisms/ProtocolsLanding/__tests__/hooks.test.tsx
+++ b/app/src/organisms/ProtocolsLanding/__tests__/hooks.test.tsx
@@ -1,0 +1,203 @@
+import * as React from 'react'
+import { Provider } from 'react-redux'
+import { createStore } from 'redux'
+import { renderHook } from '@testing-library/react-hooks'
+
+import { useSortedProtocols } from '../hooks'
+import { StoredProtocolData } from '../../../redux/protocol-storage'
+
+import type { Store } from 'redux'
+import type { State } from '../../../redux/types'
+import type { ProtocolAnalysisOutput } from '@opentrons/shared-data'
+
+const mockStoredProtocolData = [
+  {
+    protocolKey: '26ed5a82-502f-4074-8981-57cdda1d066d',
+    modified: 1651613783762.9993,
+    srcFileNames: ['secondProtocol.json'],
+    srcFiles: [],
+    mostRecentAnalysis: {
+      createdAt: '2022-05-03T21:36:12.494778+00:00',
+      files: [
+        {
+          name: 'secondProtocol.json',
+          role: 'main',
+        },
+      ],
+      config: {
+        protocolType: 'json',
+        schemaVersion: 6,
+      },
+      metadata: {
+        author: 'Otie',
+        description: 'another mock protocol',
+        created: 1606853851893,
+        lastModified: 1619792954015,
+        tags: [],
+      },
+      commands: [],
+      errors: [],
+    } as ProtocolAnalysisOutput,
+  },
+  {
+    protocolKey: '3dc99ffa-f85e-4c01-ab0a-edecff432dac',
+    modified: 1652339310312.1985,
+    srcFileNames: ['testProtocol.json'],
+    srcFiles: [],
+    mostRecentAnalysis: {
+      createdAt: '2022-05-10T17:04:43.132768+00:00',
+      files: [
+        {
+          name: 'testProtocol.json',
+          role: 'main',
+        },
+      ],
+      config: {
+        protocolType: 'json',
+        schemaVersion: 6,
+      },
+      metadata: {
+        protocolName: 'Third protocol',
+        author: 'engineering',
+        description: 'A short mock protocol',
+        created: 1223131231,
+        tags: ['unitTest'],
+      },
+      commands: [],
+      errors: [],
+    } as ProtocolAnalysisOutput,
+  },
+  {
+    protocolKey: 'f130337e-68ad-4b5d-a6d2-cbc20515b1f7',
+    modified: 1651688428961.8438,
+    srcFileNames: ['demo.py'],
+    srcFiles: [],
+    mostRecentAnalysis: {
+      createdAt: '2022-05-04T18:20:21.526508+00:00',
+      files: [
+        {
+          name: 'demo.py',
+          role: 'main',
+        },
+      ],
+      config: {
+        protocolType: 'python',
+        apiVersion: [2, 10],
+      },
+      metadata: {
+        protocolName: 'First protocol',
+        author: 'Otie',
+        source: 'Custom Protocol Request',
+        apiLevel: '2.10',
+      },
+      commands: [],
+      errors: [],
+    } as ProtocolAnalysisOutput,
+  },
+] as StoredProtocolData[]
+
+describe('useSortedProtocols', () => {
+  const store: Store<State> = createStore(jest.fn(), {})
+  beforeEach(() => {
+    store.dispatch = jest.fn()
+  })
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should return an object with protocols sorted alphabetically', () => {
+    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+      <Provider store={store}>{children}</Provider>
+    )
+
+    const { result } = renderHook(
+      () => useSortedProtocols('alphabetical', mockStoredProtocolData),
+      { wrapper }
+    )
+    const firstProtocol = result.current[0]
+    const secondProtocol = result.current[1]
+    const thirdProtocol = result.current[2]
+
+    expect(firstProtocol.protocolKey).toBe(
+      'f130337e-68ad-4b5d-a6d2-cbc20515b1f7'
+    )
+    expect(secondProtocol.protocolKey).toBe(
+      '26ed5a82-502f-4074-8981-57cdda1d066d'
+    )
+    expect(thirdProtocol.protocolKey).toBe(
+      '3dc99ffa-f85e-4c01-ab0a-edecff432dac'
+    )
+  })
+
+  it('should return an object with protocols sorted reverse alphabetically', () => {
+    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+      <Provider store={store}>{children}</Provider>
+    )
+
+    const { result } = renderHook(
+      () => useSortedProtocols('reverse', mockStoredProtocolData),
+      { wrapper }
+    )
+    const firstProtocol = result.current[0]
+    const secondProtocol = result.current[1]
+    const thirdProtocol = result.current[2]
+
+    expect(firstProtocol.protocolKey).toBe(
+      '3dc99ffa-f85e-4c01-ab0a-edecff432dac'
+    )
+    expect(secondProtocol.protocolKey).toBe(
+      '26ed5a82-502f-4074-8981-57cdda1d066d'
+    )
+    expect(thirdProtocol.protocolKey).toBe(
+      'f130337e-68ad-4b5d-a6d2-cbc20515b1f7'
+    )
+  })
+
+  it('should return an object with protocols sorted by most recent modified data', () => {
+    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+      <Provider store={store}>{children}</Provider>
+    )
+
+    const { result } = renderHook(
+      () => useSortedProtocols('recent', mockStoredProtocolData),
+      { wrapper }
+    )
+    const firstProtocol = result.current[0]
+    const secondProtocol = result.current[1]
+    const thirdProtocol = result.current[2]
+
+    expect(firstProtocol.protocolKey).toBe(
+      '3dc99ffa-f85e-4c01-ab0a-edecff432dac'
+    )
+    expect(secondProtocol.protocolKey).toBe(
+      'f130337e-68ad-4b5d-a6d2-cbc20515b1f7'
+    )
+    expect(thirdProtocol.protocolKey).toBe(
+      '26ed5a82-502f-4074-8981-57cdda1d066d'
+    )
+  })
+
+  it('should return an object with protocols sorted by oldest modified data', () => {
+    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+      <Provider store={store}>{children}</Provider>
+    )
+
+    const { result } = renderHook(
+      () => useSortedProtocols('oldest', mockStoredProtocolData),
+      { wrapper }
+    )
+    const firstProtocol = result.current[0]
+    const secondProtocol = result.current[1]
+    const thirdProtocol = result.current[2]
+
+    expect(firstProtocol.protocolKey).toBe(
+      '26ed5a82-502f-4074-8981-57cdda1d066d'
+    )
+    expect(secondProtocol.protocolKey).toBe(
+      'f130337e-68ad-4b5d-a6d2-cbc20515b1f7'
+    )
+    expect(thirdProtocol.protocolKey).toBe(
+      '3dc99ffa-f85e-4c01-ab0a-edecff432dac'
+    )
+  })
+})

--- a/app/src/organisms/ProtocolsLanding/hooks.tsx
+++ b/app/src/organisms/ProtocolsLanding/hooks.tsx
@@ -8,14 +8,17 @@ export function useSortedProtocols(
   protocolData: StoredProtocolData[]
 ): StoredProtocolData[] {
   protocolData.sort((a, b) => {
-    const protocolNameA =
-      a.mostRecentAnalysis.metadata.protocolName != null
-        ? a.mostRecentAnalysis.metadata.protocolName
-        : getProtocolDisplayName(a.protocolKey, a.srcFileNames)
-    const protocolNameB =
-      b.mostRecentAnalysis.metadata.protocolName != null
-        ? b.mostRecentAnalysis.metadata.protocolName
-        : getProtocolDisplayName(b.protocolKey, b.srcFileNames)
+    const protocolNameA = getProtocolDisplayName(
+      a.protocolKey,
+      a.srcFileNames,
+      a.mostRecentAnalysis
+    )
+    const protocolNameB = getProtocolDisplayName(
+      b.protocolKey,
+      b.srcFileNames,
+      b.mostRecentAnalysis
+    )
+
     if (sortBy === 'alphabetical') {
       return protocolNameA.toLowerCase() > protocolNameB.toLowerCase() ? 1 : -1
     } else if (sortBy === 'reverse') {

--- a/app/src/organisms/ProtocolsLanding/hooks.tsx
+++ b/app/src/organisms/ProtocolsLanding/hooks.tsx
@@ -1,0 +1,31 @@
+import { StoredProtocolData } from '../../redux/protocol-storage'
+import { getProtocolDisplayName } from './utils'
+
+export type ProtocolSort = 'alphabetical' | 'reverse' | 'recent' | 'oldest'
+
+export function useSortedProtocols(
+  sortBy: ProtocolSort,
+  protocolData: StoredProtocolData[]
+): StoredProtocolData[] {
+  protocolData.sort((a, b) => {
+    const protocolNameA =
+      a.mostRecentAnalysis.metadata.protocolName != null
+        ? a.mostRecentAnalysis.metadata.protocolName
+        : getProtocolDisplayName(a.protocolKey, a.srcFileNames)
+    const protocolNameB =
+      b.mostRecentAnalysis.metadata.protocolName != null
+        ? b.mostRecentAnalysis.metadata.protocolName
+        : getProtocolDisplayName(b.protocolKey, b.srcFileNames)
+    if (sortBy === 'alphabetical') {
+      return protocolNameA.toLowerCase() > protocolNameB.toLowerCase() ? 1 : -1
+    } else if (sortBy === 'reverse') {
+      return protocolNameA.toLowerCase() > protocolNameB.toLowerCase() ? -1 : 1
+    } else if (sortBy === 'recent') {
+      return b.modified - a.modified
+    } else if (sortBy === 'oldest') {
+      return a.modified - b.modified
+    }
+    return 0
+  })
+  return protocolData
+}


### PR DESCRIPTION
# Overview

This PR adds the menu and functionality to sort the protocol cards in different orders. closes #8817

![Screen Shot 2022-05-06 at 12 48 06 PM](https://user-images.githubusercontent.com/14794021/167177597-a575811c-7e6d-4919-a334-b4c93f427a0b.png)

# Changelog

- Added menu for protocol card sorting
- Added `useSortedProtocols` hook

# Review requests

- Upload a set of different protocols. Then use the `Sort by` menu to test the different orders of sorting. Check that the sorting is accurate.

# Risk assessment

low
