### PR TITLE
feat(hardware): binary_serializable.from_string

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
@@ -1,4 +1,7 @@
 """Custom payload fields."""
+from __future__ import annotations
+
+import binascii
 import enum
 
 from opentrons_hardware.firmware_bindings import utils, ErrorCode
@@ -144,3 +147,8 @@ class EepromDataField(utils.BinaryFieldBase[bytes]):
 
     NUM_BYTES = 8
     FORMAT = f"{NUM_BYTES}s"
+
+    @classmethod
+    def from_string(cls, t: str) -> EepromDataField:
+        """Create from a string."""
+        return cls(binascii.unhexlify(t[: cls.NUM_BYTES]))

--- a/hardware/opentrons_hardware/firmware_bindings/utils/binary_serializable.py
+++ b/hardware/opentrons_hardware/firmware_bindings/utils/binary_serializable.py
@@ -49,6 +49,18 @@ class BinaryFieldBase(Generic[T]):
         """
         return cls(t)
 
+    @classmethod
+    def from_string(cls, t: str) -> BinaryFieldBase[T]:
+        """Create from a string.
+
+        Args:
+            t: The value as a string.
+
+        Returns:
+            New instance.
+        """
+        ...
+
     @property
     def value(self) -> T:
         """The value."""
@@ -68,49 +80,58 @@ class BinaryFieldBase(Generic[T]):
         return f"{self.__class__.__name__}(value={repr(self.value)})"
 
 
-class UInt64Field(BinaryFieldBase[int]):
+class IntFieldBase(BinaryFieldBase[int]):
+    """Base class of integer fields."""
+
+    @classmethod
+    def from_string(cls, t: str) -> IntFieldBase:
+        """Create from string."""
+        return cls(int(t))
+
+
+class UInt64Field(IntFieldBase):
     """Unsigned 64-bit integer field."""
 
     FORMAT = "Q"
 
 
-class Int64Field(BinaryFieldBase[int]):
+class Int64Field(IntFieldBase):
     """Signed 64-bit integer field."""
 
     FORMAT = "q"
 
 
-class UInt32Field(BinaryFieldBase[int]):
+class UInt32Field(IntFieldBase):
     """Unsigned 32-bit integer field."""
 
     FORMAT = "L"
 
 
-class Int32Field(BinaryFieldBase[int]):
+class Int32Field(IntFieldBase):
     """Signed 32-bit integer field."""
 
     FORMAT = "l"
 
 
-class UInt16Field(BinaryFieldBase[int]):
+class UInt16Field(IntFieldBase):
     """Unsigned 16-bit integer field."""
 
     FORMAT = "H"
 
 
-class Int16Field(BinaryFieldBase[int]):
+class Int16Field(IntFieldBase):
     """Signed 16-bit integer field."""
 
     FORMAT = "h"
 
 
-class UInt8Field(BinaryFieldBase[int]):
+class UInt8Field(IntFieldBase):
     """Unsigned 8-bit integer field."""
 
     FORMAT = "B"
 
 
-class Int8Field(BinaryFieldBase[int]):
+class Int8Field(IntFieldBase):
     """Signed 8-bit integer field."""
 
     FORMAT = "b"

--- a/hardware/opentrons_hardware/scripts/can_comm.py
+++ b/hardware/opentrons_hardware/scripts/can_comm.py
@@ -144,12 +144,8 @@ def prompt_payload(
     payload_fields = dataclasses.fields(payload_type)
     i = {}
     for f in payload_fields:
-        # TODO (amit 2021-10-01): Conversion to int is not good here long term.
-        #  Should be handled by type coercion in utils.BinarySerializable.
-        #  All values are ints now, but may be bytes in the future (ie serial
-        #  numbers, fw upgrade blobs).
         try:
-            i[f.name] = f.type.build(int(get_user_input(f"enter {f.name}: ")))
+            i[f.name] = f.type.from_string(get_user_input(f"enter {f.name}: ").strip())
         except ValueError as e:
             raise InvalidInput(str(e))
     # Mypy is not liking constructing the derived types.


### PR DESCRIPTION
# Overview

In testing eeprom interaction I was limited by not being able to enter binary data using can_comm. This PR fixes that.

# Changelog

- added `from_string` class method to `BinaryFieldBase`. 
- can_comm uses `from_string` instead of `build`


# Review requests



# Risk assessment

None