### PR TITLE
chore(app): update labware definitions

### DIFF
--- a/shared-data/labware/definitions/2/thermoscientificnunc_96_wellplate_1300ul/1.json
+++ b/shared-data/labware/definitions/2/thermoscientificnunc_96_wellplate_1300ul/1.json
@@ -1005,6 +1005,7 @@
     "quirks": [],
     "isTiprack": false,
     "isMagneticModuleCompatible": true,
+    "magneticModuleEngageHeight": 5.5,
     "loadName": "thermoscientificnunc_96_wellplate_1300ul"
   },
   "namespace": "opentrons",

--- a/shared-data/labware/definitions/2/thermoscientificnunc_96_wellplate_2000ul/1.json
+++ b/shared-data/labware/definitions/2/thermoscientificnunc_96_wellplate_2000ul/1.json
@@ -1005,6 +1005,7 @@
     "quirks": [],
     "isTiprack": false,
     "isMagneticModuleCompatible": true,
+    "magneticModuleEngageHeight": 6,
     "loadName": "thermoscientificnunc_96_wellplate_2000ul"
   },
   "namespace": "opentrons",


### PR DESCRIPTION
This PR adds magnetic module engage heights to two labware library additions. This will allow these standard definitions to be used on our magnetic module. 

References this ticket: #9921

