### PR TITLE
refactor(app): add cancel run button for clearing an unstarted protocol

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -272,21 +272,14 @@ export function ProtocolRunHeader({
     runStatus === RUN_STATUS_RUNNING ||
     runStatus === RUN_STATUS_PAUSED ||
     runStatus === RUN_STATUS_PAUSE_REQUESTED ||
-    runStatus === RUN_STATUS_BLOCKED_BY_OPEN_DOOR
+    runStatus === RUN_STATUS_BLOCKED_BY_OPEN_DOOR ||
+    runStatus === RUN_STATUS_IDLE
 
   const { closeCurrentRun, isClosingCurrentRun } = useCloseCurrentRun()
 
   const handleClearClick = (): void => {
     closeCurrentRun()
   }
-
-  const isClearButtonDisabled =
-    isClosingCurrentRun ||
-    runStatus === RUN_STATUS_RUNNING ||
-    runStatus === RUN_STATUS_PAUSED ||
-    runStatus === RUN_STATUS_FINISHING ||
-    runStatus === RUN_STATUS_PAUSE_REQUESTED ||
-    runStatus === RUN_STATUS_STOP_REQUESTED
 
   const clearProtocolLink = (
     <Btn
@@ -341,7 +334,7 @@ export function ProtocolRunHeader({
   }
 
   const ProtocolRunningContent = (): JSX.Element | null =>
-    runStatus != null && runStatus !== RUN_STATUS_IDLE ? (
+    runStatus != null ? (
       <Flex
         backgroundColor={COLORS.lightGrey}
         justifyContent={JUSTIFY_SPACE_BETWEEN}
@@ -387,8 +380,13 @@ export function ProtocolRunHeader({
           <SecondaryButton
             color={COLORS.errorText}
             padding={`${SPACING.spacingSM} ${SPACING.spacing4}`}
-            onClick={handleCancelClick}
+            onClick={
+              isCurrentRun && runStatus === RUN_STATUS_IDLE
+                ? handleClearClick
+                : handleCancelClick
+            }
             id="ProtocolRunHeader_cancelRunButton"
+            disabled={isClosingCurrentRun}
           >
             {t('cancel_run')}
           </SecondaryButton>
@@ -517,16 +515,6 @@ export function ProtocolRunHeader({
           gridGap={SPACING.spacingSM}
           width={SIZE_5}
         >
-          {isCurrentRun ? (
-            <SecondaryButton
-              padding={`${SPACING.spacingSM} ${SPACING.spacing4}`}
-              onClick={handleClearClick}
-              disabled={isClearButtonDisabled}
-              id="ProtocolRunHeader_closeRunButton"
-            >
-              {t('clear_protocol')}
-            </SecondaryButton>
-          ) : null}
           <PrimaryButton
             justifyContent={JUSTIFY_CENTER}
             alignItems={ALIGN_CENTER}

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -288,14 +288,14 @@ describe('ProtocolRunHeader', () => {
     )
   })
 
-  it('renders a start run button and clear protocol button when run is ready to start', () => {
+  it('renders a start run button and cancel run button when run is ready to start', () => {
     const [{ getByRole, queryByText }] = render()
 
     getByRole('button', { name: 'Start run' })
-    expect(queryByText(formatTimestamp(STARTED_AT))).toBeFalsy()
-    expect(queryByText('Protocol start')).toBeFalsy()
-    expect(queryByText('Protocol end')).toBeFalsy()
-    getByRole('button', { name: 'Clear protocol' }).click()
+    queryByText(formatTimestamp(STARTED_AT))
+    queryByText('Protocol start')
+    queryByText('Protocol end')
+    getByRole('button', { name: 'Cancel run' }).click()
     expect(mockCloseCurrentRun).toBeCalled()
   })
 
@@ -340,7 +340,6 @@ describe('ProtocolRunHeader', () => {
     getByText(formatTimestamp(STARTED_AT))
     getByText('Protocol start')
     getByText('Protocol end')
-    expect(getByRole('button', { name: 'Clear protocol' })).toBeDisabled()
   })
 
   it('renders a cancel run button when running and shows a confirm cancel modal when clicked', () => {
@@ -426,13 +425,11 @@ describe('ProtocolRunHeader', () => {
       completedAt: COMPLETED_AT,
     })
 
-    const [{ getByRole, getByText }] = render()
+    const [{ getByText }] = render()
 
     getByText('Run again')
     getByText('Canceled')
     getByText(formatTimestamp(COMPLETED_AT))
-    getByRole('button', { name: 'Clear protocol' }).click()
-    expect(mockCloseCurrentRun).toBeCalled()
   })
 
   it('renders a Run Again button and end time when run has failed', () => {
@@ -449,13 +446,11 @@ describe('ProtocolRunHeader', () => {
       completedAt: COMPLETED_AT,
     })
 
-    const [{ getByRole, getByText }] = render()
+    const [{ getByText }] = render()
 
     getByText('Run again')
     getByText('Completed')
     getByText(formatTimestamp(COMPLETED_AT))
-    getByRole('button', { name: 'Clear protocol' }).click()
-    expect(mockCloseCurrentRun).toBeCalled()
   })
 
   it('renders a Run Again button and end time when run has succeeded', () => {
@@ -474,13 +469,11 @@ describe('ProtocolRunHeader', () => {
       completedAt: COMPLETED_AT,
     })
 
-    const [{ getByRole, getByText }] = render()
+    const [{ getByText }] = render()
 
     getByText('Run again')
     getByText('Completed')
     getByText(formatTimestamp(COMPLETED_AT))
-    getByRole('button', { name: 'Clear protocol' }).click()
-    expect(mockCloseCurrentRun).toBeCalled()
   })
 
   it('disables the Run Again button with tooltip for a completed run if the robot is busy', () => {


### PR DESCRIPTION

# Overview

This PR refactors the cancel run button to clear the protocol when a run has not started. closes #10231

<img width="878" alt="image" src="https://user-images.githubusercontent.com/14794021/167696333-20fef802-ea6c-4b3d-b436-dac1ab23707d.png">

# Changelog

- Refactored `ProtocolRunHeader` and removed the `Clear protocol` button

# Review requests

- Check that the acceptance criteria are fulfilled for [10231](https://github.com/Opentrons/opentrons/issues/10231)
- Upload a protocol and click `Run a protocol` on the robot. Then click the `Cancel run` button while the status is `Not started`. This should clear the protocol.

# Risk assessment

low
