### PR TITLE
refactor(app): refactor heater shaker hook to account for MoaM

### DIFF
--- a/app/src/assets/localization/en/heater_shaker.json
+++ b/app/src/assets/localization/en/heater_shaker.json
@@ -86,7 +86,7 @@
   "keep_shaking_start_run": "Keep shaking and start run",
   "confirm_heater_shaker_modal_attachment": "Confirm Heater-Shaker Module attachment to deck",
   "module_should_have_anchors": "Module should have both anchors fully extended for a firm attachment to the deck.",
-  "module_anchors_extended": "Before the run begins, module should have both anchors fully extended for a firm attachment to Slot {{slot}}.",
+  "module_anchors_extended": "Before the run begins, module should have both anchors fully extended for a firm attachment to the deck.",
   "thermal_adapter_attached_to_module": "The thermal adapter should be attached to the module.",
   "proceed_to_run": "Proceed to run",
   "confirm_attachment": "Confirm attachment",

--- a/app/src/organisms/Devices/ModuleCard/ConfirmAttachmentModal.tsx
+++ b/app/src/organisms/Devices/ModuleCard/ConfirmAttachmentModal.tsx
@@ -18,7 +18,6 @@ import { Modal } from '../../../atoms/Modal'
 import { Dispatch } from '../../../redux/types'
 import { UpdateConfigValueAction } from '../../../redux/config/types'
 import { updateConfigValue } from '../../../redux/config'
-import { useHeaterShakerFromProtocol } from './hooks'
 
 export function setHeaterShakerAttached(
   heaterShakerAttached: boolean
@@ -39,8 +38,6 @@ export const ConfirmAttachmentModal = (
   const { isProceedToRunModal, onCloseClick, onConfirmClick } = props
   const { t } = useTranslation(['heater_shaker', 'shared'])
   const [isDismissed, setIsDismissed] = React.useState<boolean>(false)
-  const heaterShaker = useHeaterShakerFromProtocol()
-  const slotNumber = heaterShaker != null ? heaterShaker.slotName : null
   const dispatch = useDispatch<Dispatch>()
 
   const confirmAttached = (): void => {
@@ -66,8 +63,7 @@ export const ConfirmAttachmentModal = (
           {t(
             isProceedToRunModal
               ? 'module_anchors_extended'
-              : 'module_should_have_anchors',
-            { slot: slotNumber }
+              : 'module_should_have_anchors'
           )}
         </Text>
         <Text>{t('thermal_adapter_attached_to_module')}</Text>

--- a/app/src/organisms/Devices/ModuleCard/__tests__/ConfirmAttachmentModal.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/ConfirmAttachmentModal.test.tsx
@@ -2,19 +2,7 @@ import * as React from 'react'
 import { renderWithProviders } from '@opentrons/components'
 import { fireEvent } from '@testing-library/react'
 import { i18n } from '../../../../i18n'
-import heaterShakerCommands from '@opentrons/shared-data/protocol/fixtures/6/heaterShakerCommands.json'
-import { useHeaterShakerFromProtocol } from '../hooks'
 import { ConfirmAttachmentModal } from '../ConfirmAttachmentModal'
-
-import { mockHeaterShaker } from '../../../../redux/modules/__fixtures__'
-
-import type { ProtocolModuleInfo } from '../../../ProtocolSetup/utils/getProtocolModulesInfo'
-
-jest.mock('../hooks')
-
-const mockUseHeaterShakerFromProtocol = useHeaterShakerFromProtocol as jest.MockedFunction<
-  typeof useHeaterShakerFromProtocol
->
 
 const render = (props: React.ComponentProps<typeof ConfirmAttachmentModal>) => {
   return renderWithProviders(<ConfirmAttachmentModal {...props} />, {
@@ -22,18 +10,6 @@ const render = (props: React.ComponentProps<typeof ConfirmAttachmentModal>) => {
   })[0]
 }
 
-const HEATER_SHAKER_PROTOCOL_MODULE_INFO = {
-  moduleId: 'heater_shaker_id',
-  x: 0,
-  y: 0,
-  z: 0,
-  moduleDef: mockHeaterShaker as any,
-  nestedLabwareDef: heaterShakerCommands.labwareDefinitions['example/plate/1'],
-  nestedLabwareDisplayName: null,
-  nestedLabwareId: null,
-  protocolLoadOrder: 1,
-  slotName: '1',
-} as ProtocolModuleInfo
 
 describe('ConfirmAttachmentBanner', () => {
   let props: React.ComponentProps<typeof ConfirmAttachmentModal>
@@ -44,9 +20,6 @@ describe('ConfirmAttachmentBanner', () => {
       isProceedToRunModal: false,
       onCloseClick: jest.fn(),
     }
-    mockUseHeaterShakerFromProtocol.mockReturnValue(
-      HEATER_SHAKER_PROTOCOL_MODULE_INFO
-    )
   })
   afterEach(() => {
     jest.restoreAllMocks()
@@ -80,7 +53,7 @@ describe('ConfirmAttachmentBanner', () => {
     const { getByText, getByRole } = render(props)
 
     getByText(
-      'Before the run begins, module should have both anchors fully extended for a firm attachment to Slot 1.'
+      'Before the run begins, module should have both anchors fully extended for a firm attachment to the deck.'
     )
     getByText('The thermal adapter should be attached to the module.')
     const btn = getByRole('button', { name: 'Proceed to run' })

--- a/app/src/organisms/Devices/ModuleCard/__tests__/ConfirmAttachmentModal.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/ConfirmAttachmentModal.test.tsx
@@ -10,7 +10,6 @@ const render = (props: React.ComponentProps<typeof ConfirmAttachmentModal>) => {
   })[0]
 }
 
-
 describe('ConfirmAttachmentBanner', () => {
   let props: React.ComponentProps<typeof ConfirmAttachmentModal>
 

--- a/app/src/organisms/Devices/ModuleCard/__tests__/hooks.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/hooks.test.tsx
@@ -18,7 +18,7 @@ import { useProtocolDetailsForRun } from '../../hooks'
 import {
   useLatchControls,
   useModuleOverflowMenu,
-  useHeaterShakerFromProtocol,
+  useIsHeaterShakerInProtocol,
 } from '../hooks'
 
 import {
@@ -664,25 +664,25 @@ describe('useProtocolMetadata', () => {
     jest.restoreAllMocks()
   })
 
-  it('should return heater shaker slot number', () => {
+  it('should return true when a heater shaker is in the protocol', () => {
     const wrapper: React.FunctionComponent<{}> = ({ children }) => (
       <Provider store={store}>{children}</Provider>
     )
-    const { result } = renderHook(useHeaterShakerFromProtocol, { wrapper })
-    const heaterShaker = result.current
+    const { result } = renderHook(useIsHeaterShakerInProtocol, { wrapper })
+    const isHeaterShakerInProtocol = result.current
 
-    expect(heaterShaker?.slotName).toBe('1')
+    expect(isHeaterShakerInProtocol).toBe(true)
   })
 
-  it('should return undefined when heater shaker isnt in protocol', () => {
+  it('should return false when a heater shaker is NOT in the protocol', () => {
     mockGetProtocolModulesInfo.mockReturnValue([])
 
     const wrapper: React.FunctionComponent<{}> = ({ children }) => (
       <Provider store={store}>{children}</Provider>
     )
-    const { result } = renderHook(useHeaterShakerFromProtocol, { wrapper })
-    const heaterShaker = result.current
+    const { result } = renderHook(useIsHeaterShakerInProtocol, { wrapper })
+    const isHeaterShakerInProtocol = result.current
 
-    expect(heaterShaker?.slotName).toBe(undefined)
+    expect(isHeaterShakerInProtocol).toBe(false)
   })
 })

--- a/app/src/organisms/Devices/ModuleCard/hooks.tsx
+++ b/app/src/organisms/Devices/ModuleCard/hooks.tsx
@@ -31,21 +31,18 @@ import type {
 } from '@opentrons/shared-data/protocol/types/schemaV6/command/module'
 
 import type { AttachedModule } from '../../../redux/modules/types'
-import type { ProtocolModuleInfo } from '../../ProtocolSetup/utils/getProtocolModulesInfo'
 
-export function useHeaterShakerFromProtocol(): ProtocolModuleInfo | null {
+export function useIsHeaterShakerInProtocol(): boolean {
   const currentRunId = useCurrentRunId()
   const { protocolData } = useProtocolDetailsForRun(currentRunId)
-  if (protocolData == null) return null
+  if (protocolData == null) return false
   const protocolModulesInfo = getProtocolModulesInfo(
     protocolData,
     standardDeckDef as any
   )
-  const heaterShakerModule = protocolModulesInfo.find(
+  return protocolModulesInfo.some(
     module => module.moduleDef.model === 'heaterShakerModuleV1'
   )
-  if (heaterShakerModule == null) return null
-  return heaterShakerModule
 }
 interface LatchControls {
   toggleLatch: () => void

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -70,7 +70,7 @@ import {
   useUnmatchedModulesForProtocol,
 } from '../hooks'
 import { formatTimestamp } from '../utils'
-import { useHeaterShakerFromProtocol } from '../ModuleCard/hooks'
+import { useIsHeaterShakerInProtocol } from '../ModuleCard/hooks'
 import { ConfirmAttachmentModal } from '../ModuleCard/ConfirmAttachmentModal'
 
 import type { Run } from '@opentrons/api-client'
@@ -120,7 +120,7 @@ export function ProtocolRunHeader({
   const history = useHistory()
   const [targetProps, tooltipProps] = useHoverTooltip()
   const trackEvent = useTrackEvent()
-  const heaterShakerFromProtocol = useHeaterShakerFromProtocol()
+  const isHeaterShakerInProtocol = useIsHeaterShakerInProtocol()
   const configHasHeaterShakerAttached = useSelector(getIsHeaterShakerAttached)
   const runRecord = useRunQuery(runId)
   const createdAtTimestamp = useRunCreatedAtTimestamp(runId)
@@ -194,7 +194,7 @@ export function ProtocolRunHeader({
   const handlePlayButtonClick = (): void => {
     if (isShaking) {
       setShowIsShakingModal(true)
-    } else if (heaterShakerFromProtocol != null && !isShaking) {
+    } else if (isHeaterShakerInProtocol && !isShaking) {
       confirmAttachment()
     } else play()
   }

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -40,7 +40,6 @@ import {
   mockStopRequestedRun,
   mockSucceededRun,
 } from '../../../../organisms/RunTimeControl/__fixtures__'
-import heaterShakerCommands from '@opentrons/shared-data/protocol/fixtures/6/heaterShakerCommands.json'
 import { mockHeaterShaker } from '../../../../redux/modules/__fixtures__'
 import { useTrackEvent } from '../../../../redux/analytics'
 import { getIsHeaterShakerAttached } from '../../../../redux/config'
@@ -61,7 +60,6 @@ import { HeaterShakerIsRunningModal } from '../../HeaterShakerIsRunningModal'
 import type { UseQueryResult } from 'react-query'
 import type { Run } from '@opentrons/api-client'
 import type { ProtocolAnalysisFile } from '@opentrons/shared-data'
-import type { ProtocolModuleInfo } from '../../../ProtocolSetup/utils/getProtocolModulesInfo'
 
 const mockPush = jest.fn()
 

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -154,19 +154,6 @@ const PROTOCOL_DETAILS = {
   protocolData: simpleV6Protocol,
 }
 
-const HEATER_SHAKER_PROTOCOL_MODULE_INFO = {
-  moduleId: 'heater_shaker_id',
-  x: 0,
-  y: 0,
-  z: 0,
-  moduleDef: mockHeaterShaker as any,
-  nestedLabwareDef: heaterShakerCommands.labwareDefinitions['example/plate/1'],
-  nestedLabwareDisplayName: null,
-  nestedLabwareId: null,
-  protocolLoadOrder: 1,
-  slotName: '1',
-} as ProtocolModuleInfo
-
 const mockMovingHeaterShaker = {
   id: 'heatershaker_id',
   moduleModel: 'heaterShakerModuleV1',

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -52,7 +52,7 @@ import {
   useUnmatchedModulesForProtocol,
   useAttachedModules,
 } from '../../hooks'
-import { useHeaterShakerFromProtocol } from '../../ModuleCard/hooks'
+import { useIsHeaterShakerInProtocol } from '../../ModuleCard/hooks'
 import { ConfirmAttachmentModal } from '../../ModuleCard/ConfirmAttachmentModal'
 import { formatTimestamp } from '../../utils'
 import { ProtocolRunHeader } from '../ProtocolRunHeader'
@@ -130,8 +130,8 @@ const mockConfirmCancelModal = ConfirmCancelModal as jest.MockedFunction<
 const mockMockHeaterShakerIsRunningModal = HeaterShakerIsRunningModal as jest.MockedFunction<
   typeof HeaterShakerIsRunningModal
 >
-const mockUseHeaterShakerFromProtocol = useHeaterShakerFromProtocol as jest.MockedFunction<
-  typeof useHeaterShakerFromProtocol
+const mockUseIsHeaterShakerInProtocol = useIsHeaterShakerInProtocol as jest.MockedFunction<
+  typeof useIsHeaterShakerInProtocol
 >
 const mockConfirmAttachmentModal = ConfirmAttachmentModal as jest.MockedFunction<
   typeof ConfirmAttachmentModal
@@ -219,7 +219,7 @@ describe('ProtocolRunHeader', () => {
     mockConfirmAttachmentModal.mockReturnValue(
       <div>mock confirm attachment modal</div>
     )
-    mockUseHeaterShakerFromProtocol.mockReturnValue(null)
+    mockUseIsHeaterShakerInProtocol.mockReturnValue(false)
     when(mockUseCurrentRunId).calledWith().mockReturnValue(RUN_ID)
     when(mockUseCloseCurrentRun).calledWith().mockReturnValue({
       isClosingCurrentRun: false,
@@ -557,9 +557,7 @@ describe('ProtocolRunHeader', () => {
 
   it('renders the confirm attachment modal when there is a heater shaker in the protocol and the heater shaker is idle status', () => {
     mockUseAttachedModules.mockReturnValue([mockHeaterShaker])
-    mockUseHeaterShakerFromProtocol.mockReturnValue(
-      HEATER_SHAKER_PROTOCOL_MODULE_INFO
-    )
+    mockUseIsHeaterShakerInProtocol.mockReturnValue(true)
     const [{ getByText, getByRole }] = render()
 
     const button = getByRole('button', { name: 'Start run' })
@@ -567,12 +565,10 @@ describe('ProtocolRunHeader', () => {
     getByText('mock confirm attachment modal')
   })
 
-  it('does not render confirm attachment modal when there is a heater shaker in the protocol and the heater shaker is idle status', () => {
+  it('does NOT render confirm attachment modal when the user already confirmed the heater shaker is attached', () => {
     mockGetIsHeaterShakerAttached.mockReturnValue(true)
     mockUseAttachedModules.mockReturnValue([mockHeaterShaker])
-    mockUseHeaterShakerFromProtocol.mockReturnValue(
-      HEATER_SHAKER_PROTOCOL_MODULE_INFO
-    )
+    mockUseIsHeaterShakerInProtocol.mockReturnValue(true)
     const [{ getByRole }] = render()
     const button = getByRole('button', { name: 'Start run' })
     fireEvent.click(button)


### PR DESCRIPTION
# Overview

closes #10253

# Changelog

- Refactor heater shaker hook to account for MoaM 

# Review requests
Make sure the attachment modal no longer has any slot info about the heater shaker and make sure the heater shaker setup wizard can still be rendered when a heater shaker is in the protocol. 
# Risk assessment

Low