### PR TITLE
refactor(hardware): Exact types for payloads

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/messages/__init__.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/__init__.py
@@ -1,7 +1,4 @@
 """Can bus message definitions."""
 from .messages import MessageDefinition, get_definition
 
-__all__ = [
-    "MessageDefinition",
-    "get_definition",
-]
+__all__ = ["MessageDefinition", "get_definition"]

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -4,7 +4,6 @@ from typing import Type
 
 from typing_extensions import Literal
 
-from ..utils import BinarySerializable
 from ..constants import MessageId
 from . import payloads
 
@@ -14,7 +13,7 @@ class EmptyPayloadMessage:
     """Base class of a message that has an empty payload."""
 
     payload: payloads.EmptyPayload = payloads.EmptyPayload()
-    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+    payload_type: Type[payloads.EmptyPayload] = payloads.EmptyPayload
 
 
 @dataclass
@@ -35,7 +34,9 @@ class DeviceInfoRequest(EmptyPayloadMessage):  # noqa: D101
 @dataclass
 class DeviceInfoResponse:  # noqa: D101
     payload: payloads.DeviceInfoResponsePayload
-    payload_type: Type[BinarySerializable] = payloads.DeviceInfoResponsePayload
+    payload_type: Type[
+        payloads.DeviceInfoResponsePayload
+    ] = payloads.DeviceInfoResponsePayload
     message_id: Literal[MessageId.device_info_response] = MessageId.device_info_response
 
 
@@ -47,7 +48,9 @@ class TaskInfoRequest(EmptyPayloadMessage):  # noqa: D101
 @dataclass
 class TaskInfoResponse:  # noqa: D101
     payload: payloads.TaskInfoResponsePayload
-    payload_type: Type[BinarySerializable] = payloads.TaskInfoResponsePayload
+    payload_type: Type[
+        payloads.TaskInfoResponsePayload
+    ] = payloads.TaskInfoResponsePayload
     message_id: Literal[MessageId.task_info_response] = MessageId.task_info_response
 
 
@@ -76,14 +79,16 @@ class DisableMotorRequest(EmptyPayloadMessage):  # noqa: D101
 @dataclass
 class GetStatusResponse:  # noqa: D101
     payload: payloads.GetStatusResponsePayload
-    payload_type: Type[BinarySerializable] = payloads.GetStatusResponsePayload
+    payload_type: Type[
+        payloads.GetStatusResponsePayload
+    ] = payloads.GetStatusResponsePayload
     message_id: Literal[MessageId.get_status_response] = MessageId.get_status_response
 
 
 @dataclass
 class MoveRequest:  # noqa: D101
     payload: payloads.MoveRequestPayload
-    payload_type: Type[BinarySerializable] = payloads.MoveRequestPayload
+    payload_type: Type[payloads.MoveRequestPayload] = payloads.MoveRequestPayload
     message_id: Literal[MessageId.move_request] = MessageId.move_request
 
 
@@ -95,35 +100,39 @@ class SetupRequest(EmptyPayloadMessage):  # noqa: D101
 @dataclass
 class WriteToEEPromRequest:  # noqa: D101
     payload: payloads.EEPromDataPayload
-    payload_type: Type[BinarySerializable] = payloads.EEPromDataPayload
+    payload_type: Type[payloads.EEPromDataPayload] = payloads.EEPromDataPayload
     message_id: Literal[MessageId.write_eeprom] = MessageId.write_eeprom
 
 
 @dataclass
 class ReadFromEEPromRequest:  # noqa: D101
     payload: payloads.EEPromReadPayload
-    payload_type: Type[BinarySerializable] = payloads.EEPromReadPayload
+    payload_type: Type[payloads.EEPromReadPayload] = payloads.EEPromReadPayload
     message_id: Literal[MessageId.read_eeprom_request] = MessageId.read_eeprom_request
 
 
 @dataclass
 class ReadFromEEPromResponse:  # noqa: D101
     payload: payloads.EEPromDataPayload
-    payload_type: Type[BinarySerializable] = payloads.EEPromDataPayload
+    payload_type: Type[payloads.EEPromDataPayload] = payloads.EEPromDataPayload
     message_id: Literal[MessageId.read_eeprom_response] = MessageId.read_eeprom_response
 
 
 @dataclass
 class AddLinearMoveRequest:  # noqa: D101
     payload: payloads.AddLinearMoveRequestPayload
-    payload_type: Type[BinarySerializable] = payloads.AddLinearMoveRequestPayload
+    payload_type: Type[
+        payloads.AddLinearMoveRequestPayload
+    ] = payloads.AddLinearMoveRequestPayload
     message_id: Literal[MessageId.add_move_request] = MessageId.add_move_request
 
 
 @dataclass
 class GetMoveGroupRequest:  # noqa: D101
     payload: payloads.MoveGroupRequestPayload
-    payload_type: Type[BinarySerializable] = payloads.MoveGroupRequestPayload
+    payload_type: Type[
+        payloads.MoveGroupRequestPayload
+    ] = payloads.MoveGroupRequestPayload
     message_id: Literal[
         MessageId.get_move_group_request
     ] = MessageId.get_move_group_request
@@ -132,7 +141,9 @@ class GetMoveGroupRequest:  # noqa: D101
 @dataclass
 class GetMoveGroupResponse:  # noqa: D101
     payload: payloads.GetMoveGroupResponsePayload
-    payload_type: Type[BinarySerializable] = payloads.GetMoveGroupResponsePayload
+    payload_type: Type[
+        payloads.GetMoveGroupResponsePayload
+    ] = payloads.GetMoveGroupResponsePayload
     message_id: Literal[
         MessageId.get_move_group_response
     ] = MessageId.get_move_group_response
@@ -141,7 +152,9 @@ class GetMoveGroupResponse:  # noqa: D101
 @dataclass
 class ExecuteMoveGroupRequest:  # noqa: D101
     payload: payloads.ExecuteMoveGroupRequestPayload
-    payload_type: Type[BinarySerializable] = payloads.ExecuteMoveGroupRequestPayload
+    payload_type: Type[
+        payloads.ExecuteMoveGroupRequestPayload
+    ] = payloads.ExecuteMoveGroupRequestPayload
     message_id: Literal[
         MessageId.execute_move_group_request
     ] = MessageId.execute_move_group_request
@@ -157,14 +170,16 @@ class ClearAllMoveGroupsRequest(EmptyPayloadMessage):  # noqa: D101
 @dataclass
 class MoveCompleted:  # noqa: D101
     payload: payloads.MoveCompletedPayload
-    payload_type: Type[BinarySerializable] = payloads.MoveCompletedPayload
+    payload_type: Type[payloads.MoveCompletedPayload] = payloads.MoveCompletedPayload
     message_id: Literal[MessageId.move_completed] = MessageId.move_completed
 
 
 @dataclass
 class SetMotionConstraints:  # noqa: D101
     payload: payloads.MotionConstraintsPayload
-    payload_type: Type[BinarySerializable] = payloads.MotionConstraintsPayload
+    payload_type: Type[
+        payloads.MotionConstraintsPayload
+    ] = payloads.MotionConstraintsPayload
     message_id: Literal[
         MessageId.set_motion_constraints
     ] = MessageId.set_motion_constraints
@@ -180,7 +195,9 @@ class GetMotionConstraintsRequest(EmptyPayloadMessage):  # noqa: D101
 @dataclass
 class GetMotionConstraintsResponse:  # noqa: D101
     payload: payloads.MotionConstraintsPayload
-    payload_type: Type[BinarySerializable] = payloads.MotionConstraintsPayload
+    payload_type: Type[
+        payloads.MotionConstraintsPayload
+    ] = payloads.MotionConstraintsPayload
     message_id: Literal[
         MessageId.get_motion_constraints_response
     ] = MessageId.get_motion_constraints_response
@@ -189,7 +206,9 @@ class GetMotionConstraintsResponse:  # noqa: D101
 @dataclass
 class WriteMotorDriverRegister:  # noqa: D101
     payload: payloads.MotorDriverRegisterDataPayload
-    payload_type: Type[BinarySerializable] = payloads.MotorDriverRegisterDataPayload
+    payload_type: Type[
+        payloads.MotorDriverRegisterPayload
+    ] = payloads.MotorDriverRegisterDataPayload
     message_id: Literal[
         MessageId.write_motor_driver_register_request
     ] = MessageId.write_motor_driver_register_request
@@ -198,7 +217,9 @@ class WriteMotorDriverRegister:  # noqa: D101
 @dataclass
 class ReadMotorDriverRequest:  # noqa: D101
     payload: payloads.MotorDriverRegisterPayload
-    payload_type: Type[BinarySerializable] = payloads.MotorDriverRegisterPayload
+    payload_type: Type[
+        payloads.MotorDriverRegisterPayload
+    ] = payloads.MotorDriverRegisterPayload
     message_id: Literal[
         MessageId.read_motor_driver_register_request
     ] = MessageId.read_motor_driver_register_request
@@ -208,7 +229,7 @@ class ReadMotorDriverRequest:  # noqa: D101
 class ReadMotorDriverResponse:  # noqa: D101
     payload: payloads.ReadMotorDriverRegisterResponsePayload
     payload_type: Type[
-        BinarySerializable
+        payloads.ReadMotorDriverRegisterResponsePayload
     ] = payloads.ReadMotorDriverRegisterResponsePayload
     message_id: Literal[
         MessageId.read_motor_driver_register_response
@@ -218,7 +239,7 @@ class ReadMotorDriverResponse:  # noqa: D101
 @dataclass
 class WriteMotorCurrentRequest:  # noqa: D101
     payload: payloads.MotorCurrentPayload
-    payload_type: Type[BinarySerializable] = payloads.MotorCurrentPayload
+    payload_type: Type[payloads.MotorCurrentPayload] = payloads.MotorCurrentPayload
     message_id: Literal[
         MessageId.write_motor_current_request
     ] = MessageId.write_motor_current_request
@@ -235,7 +256,7 @@ class ReadPresenceSensingVoltageRequest(EmptyPayloadMessage):  # noqa: D101
 class ReadPresenceSensingVoltageResponse:  # noqa: D101
     payload: payloads.ReadPresenceSensingVoltageResponsePayload
     payload_type: Type[
-        BinarySerializable
+        payloads.ReadPresenceSensingVoltageResponsePayload
     ] = payloads.ReadPresenceSensingVoltageResponsePayload
     message_id: Literal[
         MessageId.read_presence_sensing_voltage_response
@@ -245,7 +266,9 @@ class ReadPresenceSensingVoltageResponse:  # noqa: D101
 @dataclass
 class PushToolsDetectedNotification:  # noqa: D101
     payload: payloads.ToolsDetectedNotificationPayload
-    payload_type: Type[BinarySerializable] = payloads.ToolsDetectedNotificationPayload
+    payload_type: Type[
+        payloads.ToolsDetectedNotificationPayload
+    ] = payloads.ToolsDetectedNotificationPayload
     message_id: Literal[
         MessageId.tools_detected_notification
     ] = MessageId.tools_detected_notification
@@ -266,28 +289,34 @@ class FirmwareUpdateInitiate(EmptyPayloadMessage):  # noqa: D101
 @dataclass
 class FirmwareUpdateData:  # noqa: D101
     payload: payloads.FirmwareUpdateData
-    payload_type: Type[BinarySerializable] = payloads.FirmwareUpdateData
+    payload_type: Type[payloads.FirmwareUpdateData] = payloads.FirmwareUpdateData
     message_id: Literal[MessageId.fw_update_data] = MessageId.fw_update_data
 
 
 @dataclass
 class FirmwareUpdateDataAcknowledge:  # noqa: D101
     payload: payloads.FirmwareUpdateDataAcknowledge
-    payload_type: Type[BinarySerializable] = payloads.FirmwareUpdateDataAcknowledge
+    payload_type: Type[
+        payloads.FirmwareUpdateDataAcknowledge
+    ] = payloads.FirmwareUpdateDataAcknowledge
     message_id: Literal[MessageId.fw_update_data_ack] = MessageId.fw_update_data_ack
 
 
 @dataclass
 class FirmwareUpdateComplete:  # noqa: D101
     payload: payloads.FirmwareUpdateComplete
-    payload_type: Type[BinarySerializable] = payloads.FirmwareUpdateComplete
+    payload_type: Type[
+        payloads.FirmwareUpdateComplete
+    ] = payloads.FirmwareUpdateComplete
     message_id: Literal[MessageId.fw_update_complete] = MessageId.fw_update_complete
 
 
 @dataclass
 class FirmwareUpdateCompleteAcknowledge:  # noqa: D101
     payload: payloads.FirmwareUpdateAcknowledge
-    payload_type: Type[BinarySerializable] = payloads.FirmwareUpdateAcknowledge
+    payload_type: Type[
+        payloads.FirmwareUpdateAcknowledge
+    ] = payloads.FirmwareUpdateAcknowledge
     message_id: Literal[
         MessageId.fw_update_complete_ack
     ] = MessageId.fw_update_complete_ack
@@ -303,7 +332,7 @@ class FirmwareUpdateStatusRequest(EmptyPayloadMessage):  # noqa: D101
 @dataclass
 class FirmwareUpdateStatusResponse:  # noqa: D101
     payload: payloads.FirmwareUpdateStatus
-    payload_type: Type[BinarySerializable] = payloads.FirmwareUpdateStatus
+    payload_type: Type[payloads.FirmwareUpdateStatus] = payloads.FirmwareUpdateStatus
     message_id: Literal[
         MessageId.fw_update_status_response
     ] = MessageId.fw_update_status_response
@@ -317,7 +346,9 @@ class FirmwareUpdateEraseAppRequest(EmptyPayloadMessage):  # noqa: D101
 @dataclass
 class FirmwareUpdateEraseAppResponse:  # noqa: D101
     payload: payloads.FirmwareUpdateAcknowledge
-    payload_type: Type[BinarySerializable] = payloads.FirmwareUpdateAcknowledge
+    payload_type: Type[
+        payloads.FirmwareUpdateAcknowledge
+    ] = payloads.FirmwareUpdateAcknowledge
     message_id: Literal[
         MessageId.fw_update_erase_app_ack
     ] = MessageId.fw_update_erase_app_ack
@@ -326,7 +357,7 @@ class FirmwareUpdateEraseAppResponse:  # noqa: D101
 @dataclass
 class HomeRequest:  # noqa: D101
     payload: payloads.HomeRequestPayload
-    payload_type: Type[BinarySerializable] = payloads.HomeRequestPayload
+    payload_type: Type[payloads.HomeRequestPayload] = payloads.HomeRequestPayload
     message_id: Literal[MessageId.home_request] = MessageId.home_request
 
 
@@ -343,28 +374,36 @@ class ReadLimitSwitchRequest(EmptyPayloadMessage):  # noqa: D101
 @dataclass
 class ReadLimitSwitchResponse:  # noqa: D101
     payload: payloads.GetLimitSwitchResponse
-    payload_type: Type[BinarySerializable] = payloads.GetLimitSwitchResponse
+    payload_type: Type[
+        payloads.GetLimitSwitchResponse
+    ] = payloads.GetLimitSwitchResponse
     message_id: Literal[MessageId.limit_sw_response] = MessageId.limit_sw_response
 
 
 @dataclass
 class ReadFromSensorRequest:  # noqa: D101
     payload: payloads.ReadFromSensorRequestPayload
-    payload_type: Type[BinarySerializable] = payloads.ReadFromSensorRequestPayload
+    payload_type: Type[
+        payloads.ReadFromSensorRequestPayload
+    ] = payloads.ReadFromSensorRequestPayload
     message_id: Literal[MessageId.read_sensor_request] = MessageId.read_sensor_request
 
 
 @dataclass
 class WriteToSensorRequest:  # noqa: D101
     payload: payloads.WriteToSensorRequestPayload
-    payload_type: Type[BinarySerializable] = payloads.WriteToSensorRequestPayload
+    payload_type: Type[
+        payloads.WriteToSensorRequestPayload
+    ] = payloads.WriteToSensorRequestPayload
     message_id: Literal[MessageId.write_sensor_request] = MessageId.write_sensor_request
 
 
 @dataclass
 class BaselineSensorRequest:  # noqa: D101
     payload: payloads.BaselineSensorRequestPayload
-    payload_type: Type[BinarySerializable] = payloads.BaselineSensorRequestPayload
+    payload_type: Type[
+        payloads.BaselineSensorRequestPayload
+    ] = payloads.BaselineSensorRequestPayload
     message_id: Literal[
         MessageId.baseline_sensor_request
     ] = MessageId.baseline_sensor_request
@@ -373,14 +412,18 @@ class BaselineSensorRequest:  # noqa: D101
 @dataclass
 class ReadFromSensorResponse:  # noqa: D101
     payload: payloads.ReadFromSensorResponsePayload
-    payload_type: Type[BinarySerializable] = payloads.ReadFromSensorResponsePayload
+    payload_type: Type[
+        payloads.ReadFromSensorResponsePayload
+    ] = payloads.ReadFromSensorResponsePayload
     message_id: Literal[MessageId.read_sensor_response] = MessageId.read_sensor_response
 
 
 @dataclass
 class SetSensorThresholdRequest:  # noqa: D101
     payload: payloads.SetSensorThresholdRequestPayload
-    payload_type: Type[BinarySerializable] = payloads.SetSensorThresholdRequestPayload
+    payload_type: Type[
+        payloads.SetSensorThresholdRequestPayload
+    ] = payloads.SetSensorThresholdRequestPayload
     message_id: Literal[
         MessageId.set_sensor_threshold_request
     ] = MessageId.set_sensor_threshold_request
@@ -389,7 +432,9 @@ class SetSensorThresholdRequest:  # noqa: D101
 @dataclass
 class SensorThresholdResponse:  # noqa: D101
     payload: payloads.SensorThresholdResponsePayload
-    payload_type: Type[BinarySerializable] = payloads.SensorThresholdResponsePayload
+    payload_type: Type[
+        payloads.SensorThresholdResponsePayload
+    ] = payloads.SensorThresholdResponsePayload
     message_id: Literal[
         MessageId.set_sensor_threshold_response
     ] = MessageId.set_sensor_threshold_response
@@ -398,7 +443,9 @@ class SensorThresholdResponse:  # noqa: D101
 @dataclass
 class SensorDiagnosticRequest:  # noqa: D101
     payload: payloads.SensorDiagnosticRequestPayload
-    payload_type: Type[BinarySerializable] = payloads.SensorDiagnosticRequestPayload
+    payload_type: Type[
+        payloads.SensorDiagnosticRequestPayload
+    ] = payloads.SensorDiagnosticRequestPayload
     message_id: Literal[
         MessageId.sensor_diagnostic_request
     ] = MessageId.sensor_diagnostic_request
@@ -407,7 +454,9 @@ class SensorDiagnosticRequest:  # noqa: D101
 @dataclass
 class SensorDiagnosticResponse:  # noqa: D101
     payload: payloads.SensorDiagnosticResponsePayload
-    payload_type: Type[BinarySerializable] = payloads.SensorDiagnosticResponsePayload
+    payload_type: Type[
+        payloads.SensorDiagnosticResponsePayload
+    ] = payloads.SensorDiagnosticResponsePayload
     message_id: Literal[
         MessageId.sensor_diagnostic_response
     ] = MessageId.sensor_diagnostic_response
@@ -421,7 +470,9 @@ class PipetteInfoRequest(EmptyPayloadMessage):  # noqa: D101
 @dataclass
 class PipetteInfoResponse:  # noqa: D101
     payload: payloads.PipetteInfoResponsePayload
-    payload_type: Type[BinarySerializable] = payloads.PipetteInfoResponsePayload
+    payload_type: Type[
+        payloads.PipetteInfoResponsePayload
+    ] = payloads.PipetteInfoResponsePayload
     message_id: Literal[
         MessageId.pipette_info_response
     ] = MessageId.pipette_info_response
@@ -430,7 +481,9 @@ class PipetteInfoResponse:  # noqa: D101
 @dataclass
 class SetBrushedMotorVrefRequest:  # noqa: D101
     payload: payloads.BrushedMotorVrefPayload
-    payload_type: Type[BinarySerializable] = payloads.BrushedMotorVrefPayload
+    payload_type: Type[
+        payloads.BrushedMotorVrefPayload
+    ] = payloads.BrushedMotorVrefPayload
     message_id: Literal[
         MessageId.set_brushed_motor_vref_request
     ] = MessageId.set_brushed_motor_vref_request
@@ -439,7 +492,9 @@ class SetBrushedMotorVrefRequest:  # noqa: D101
 @dataclass
 class SetBrushedMotorPwmRequest:  # noqa: D101
     payload: payloads.BrushedMotorPwmPayload
-    payload_type: Type[BinarySerializable] = payloads.BrushedMotorPwmPayload
+    payload_type: Type[
+        payloads.BrushedMotorPwmPayload
+    ] = payloads.BrushedMotorPwmPayload
     message_id: Literal[
         MessageId.set_brushed_motor_pwm_request
     ] = MessageId.set_brushed_motor_pwm_request
@@ -448,21 +503,27 @@ class SetBrushedMotorPwmRequest:  # noqa: D101
 @dataclass
 class GripperGripRequest:  # noqa: D101
     payload: payloads.GripperMoveRequestPayload
-    payload_type: Type[BinarySerializable] = payloads.GripperMoveRequestPayload
+    payload_type: Type[
+        payloads.GripperMoveRequestPayload
+    ] = payloads.GripperMoveRequestPayload
     message_id: Literal[MessageId.gripper_grip_request] = MessageId.gripper_grip_request
 
 
 @dataclass
 class GripperHomeRequest:  # noqa: D101
     payload: payloads.GripperMoveRequestPayload
-    payload_type: Type[BinarySerializable] = payloads.GripperMoveRequestPayload
+    payload_type: Type[
+        payloads.GripperMoveRequestPayload
+    ] = payloads.GripperMoveRequestPayload
     message_id: Literal[MessageId.gripper_home_request] = MessageId.gripper_home_request
 
 
 @dataclass
 class BindSensorOutputRequest:  # noqa: D101
     payload: payloads.BindSensorOutputRequestPayload
-    payload_type: Type[BinarySerializable] = payloads.BindSensorOutputRequestPayload
+    payload_type: Type[
+        payloads.BindSensorOutputRequestPayload
+    ] = payloads.BindSensorOutputRequestPayload
     message_id: Literal[
         MessageId.bind_sensor_output_request
     ] = MessageId.bind_sensor_output_request
@@ -471,7 +532,9 @@ class BindSensorOutputRequest:  # noqa: D101
 @dataclass
 class BindSensorOutputResponse:  # noqa: D101
     payload: payloads.BindSensorOutputResponsePayload
-    payload_type: Type[BinarySerializable] = payloads.BindSensorOutputResponsePayload
+    payload_type: Type[
+        payloads.BindSensorOutputResponsePayload
+    ] = payloads.BindSensorOutputResponsePayload
     message_id: Literal[
         MessageId.bind_sensor_output_response
     ] = MessageId.bind_sensor_output_response
@@ -485,7 +548,9 @@ class GripperInfoRequest(EmptyPayloadMessage):  # noqa: D101
 @dataclass
 class GripperInfoResponse:  # noqa: D101
     payload: payloads.GripperInfoResponsePayload
-    payload_type: Type[BinarySerializable] = payloads.GripperInfoResponsePayload
+    payload_type: Type[
+        payloads.GripperInfoResponsePayload
+    ] = payloads.GripperInfoResponsePayload
     message_id: Literal[
         MessageId.gripper_info_response
     ] = MessageId.gripper_info_response
@@ -494,7 +559,9 @@ class GripperInfoResponse:  # noqa: D101
 @dataclass
 class TipActionRequest:  # noqa: D101
     payload: payloads.TipActionRequestPayload
-    payload_type: Type[BinarySerializable] = payloads.TipActionRequestPayload
+    payload_type: Type[
+        payloads.TipActionRequestPayload
+    ] = payloads.TipActionRequestPayload
     message_id: Literal[
         MessageId.do_self_contained_tip_action_request
     ] = MessageId.do_self_contained_tip_action_request
@@ -503,7 +570,9 @@ class TipActionRequest:  # noqa: D101
 @dataclass
 class TipActionResponse:  # noqa: D101
     payload: payloads.TipActionResponsePayload
-    payload_type: Type[BinarySerializable] = payloads.TipActionResponsePayload
+    payload_type: Type[
+        payloads.TipActionResponsePayload
+    ] = payloads.TipActionResponsePayload
     message_id: Literal[
         MessageId.do_self_contained_tip_action_response
     ] = MessageId.do_self_contained_tip_action_response


### PR DESCRIPTION
Payloads had been specified in message dataclasses as their supertype,
which sort of discards a bunch of information. They should get hoisted
to their common supertype if you get a union of messages anyway, and
this way we can check any given message instantiation by the payload if
we want to - it certainly doesn't hurt anything.

It would be nice to have a typesafe way of getting the payload of a
message; in C++ this would be easy but mypy doesn't really have type
operations, so the only way to do it would be a giant explicit
overloaded function. That is not in this PR.

This is a typing annotations only change.