### PR TITLE
fix(hardware): can bus shutdown in driver

### DIFF
--- a/hardware/opentrons_hardware/drivers/can_bus/build.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/build.py
@@ -33,7 +33,7 @@ async def build_driver(driver_settings: settings.DriverSettings) -> AbstractCanD
 async def driver(
     driver_settings: settings.DriverSettings,
 ) -> AsyncIterator[AbstractCanDriver]:
-    """Context manager creating a can driver"""
+    """Context manager creating a can driver."""
     d = await build_driver(driver_settings)
     try:
         yield d

--- a/hardware/opentrons_hardware/drivers/can_bus/build.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/build.py
@@ -1,6 +1,8 @@
-"""Factory for building a driver."""
+"""Factory for building drivers and messengers."""
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
 
-from . import settings
+from . import settings, CanMessenger
 from .abstract_driver import AbstractCanDriver
 from .socket_driver import SocketDriver
 from .driver import CanDriver
@@ -25,3 +27,25 @@ async def build_driver(driver_settings: settings.DriverSettings) -> AbstractCanD
             bitrate=driver_settings.bit_rate,
             channel=driver_settings.channel,
         )
+
+
+@asynccontextmanager
+async def driver(
+    driver_settings: settings.DriverSettings,
+) -> AsyncIterator[AbstractCanDriver]:
+    """Context manager creating a can driver"""
+    d = await build_driver(driver_settings)
+    try:
+        yield d
+    finally:
+        d.shutdown()
+
+
+@asynccontextmanager
+async def can_messenger(
+    driver_settings: settings.DriverSettings,
+) -> AsyncIterator[CanMessenger]:
+    """Context manager creating a can driver and messenger."""
+    async with driver(driver_settings) as d:
+        async with CanMessenger(d) as m:
+            yield m

--- a/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
@@ -72,14 +72,14 @@ class CanMessenger:
         )
 
     async def __aenter__(self) -> CanMessenger:
-        """Start messenger"""
+        """Start messenger."""
         self.start()
         return self
 
     async def __aexit__(
         self, exc_type: type, exc_val: BaseException, exc_tb: Traceback
     ) -> None:
-        """stop messenger"""
+        """Stop messenger."""
         await self.stop()
 
     def start(self) -> None:

--- a/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
@@ -71,6 +71,17 @@ class CanMessenger:
             message=CanMessage(arbitration_id=arbitration_id, data=data)
         )
 
+    async def __aenter__(self) -> CanMessenger:
+        """Start messenger"""
+        self.start()
+        return self
+
+    async def __aexit__(
+        self, exc_type: type, exc_val: BaseException, exc_tb: Traceback
+    ) -> None:
+        """stop messenger"""
+        await self.stop()
+
     def start(self) -> None:
         """Start the reader task."""
         if self._task:

--- a/hardware/opentrons_hardware/drivers/can_bus/driver.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/driver.py
@@ -92,6 +92,7 @@ class CanDriver(AbstractCanDriver):
     def shutdown(self) -> None:
         """Stop the driver."""
         self._notifier.stop()
+        self._bus.shutdown()
 
     async def send(self, message: CanMessage) -> None:
         """Send a can message.

--- a/hardware/tests/opentrons_hardware/drivers/can_bus/test_build.py
+++ b/hardware/tests/opentrons_hardware/drivers/can_bus/test_build.py
@@ -1,3 +1,4 @@
+"""Tests for build module."""
 from opentrons_hardware.drivers.can_bus import DriverSettings, build
 import pytest
 from mock import patch, AsyncMock, Mock
@@ -7,7 +8,7 @@ from opentrons_hardware.drivers.can_bus.abstract_driver import AbstractCanDriver
 
 @pytest.fixture
 def driver_settings() -> DriverSettings:
-    """Driver settings fixture"""
+    """Driver settings fixture."""
     return DriverSettings(interface="virtual")
 
 
@@ -30,7 +31,7 @@ async def test_can_messenger(
     """It should create and destroy messenger and driver."""
     mock_driver = Mock()
     patch_build.return_value = mock_driver
-    async with build.can_messenger(driver_settings) as messenger:
+    async with build.can_messenger(driver_settings):
         pass
 
     patch_build.assert_called_once_with(driver_settings)

--- a/hardware/tests/opentrons_hardware/drivers/can_bus/test_build.py
+++ b/hardware/tests/opentrons_hardware/drivers/can_bus/test_build.py
@@ -1,0 +1,37 @@
+from opentrons_hardware.drivers.can_bus import DriverSettings, build
+import pytest
+from mock import patch, AsyncMock, Mock
+
+from opentrons_hardware.drivers.can_bus.abstract_driver import AbstractCanDriver
+
+
+@pytest.fixture
+def driver_settings() -> DriverSettings:
+    """Driver settings fixture"""
+    return DriverSettings(interface="virtual")
+
+
+@patch.object(build, "build_driver")
+async def test_driver(patch_build: AsyncMock, driver_settings: DriverSettings) -> None:
+    """It should create and destroy driver."""
+    mock_driver = Mock(spec=AbstractCanDriver)
+    patch_build.return_value = mock_driver
+    async with build.driver(driver_settings):
+        pass
+
+    patch_build.assert_called_once_with(driver_settings)
+    mock_driver.shutdown.assert_called_once()
+
+
+@patch.object(build, "build_driver")
+async def test_can_messenger(
+    patch_build: AsyncMock, driver_settings: DriverSettings
+) -> None:
+    """It should create and destroy messenger and driver."""
+    mock_driver = Mock()
+    patch_build.return_value = mock_driver
+    async with build.can_messenger(driver_settings) as messenger:
+        pass
+
+    patch_build.assert_called_once_with(driver_settings)
+    mock_driver.shutdown.assert_called_once()

--- a/hardware/tests/opentrons_hardware/drivers/can_bus/test_can_messenger.py
+++ b/hardware/tests/opentrons_hardware/drivers/can_bus/test_can_messenger.py
@@ -55,6 +55,14 @@ def subject(mock_driver: AsyncMock) -> CanMessenger:
     return CanMessenger(driver=mock_driver)
 
 
+async def test_context(mock_driver: AsyncMock) -> None:
+    """It should start and stop."""
+    async with CanMessenger(mock_driver) as m:
+        assert m._task
+        assert not m._task.done()
+    assert m._task.done()
+
+
 @pytest.mark.parametrize(
     "node_id,message",
     [


### PR DESCRIPTION
# Overview

A fix and quality of life refactors.

# Changelog

- Most importantly, we call python-can's `BusABC.shutdown` in `CanDriver.shutdown`. We hadn't been before.
- `CanMessenger` becomes a context manager. It starts on enter and stops on exit.
- added `can_bus.build.driver` context manager which creates a driver from `DriverSettings`. Driver is shutdown on exit.
- added `can_bus.build.can_messenger` context manager which creates a driver from `DriverSettings` then a `CanMessenger` using that driver. The CanMessnger and driver are shutdown on exit.

# Review requests


# Risk assessment

None