### PR TITLE
fix(app): do not include tipracks in Labware Position Check that are unused in protocol

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/__tests__/getLabwarePositionCheckSteps.test.ts
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/getLabwarePositionCheckSteps.test.ts
@@ -71,6 +71,52 @@ describe('getLabwarePositionCheckSteps', () => {
       commands: protocolWithOnePipette.commands,
     })
   })
+  it('should not include labware that are tip racks and are unused in protocol', () => {
+    const mockPipette =
+      protocolWithOnePipette.pipettes[
+        Object.keys(protocolWithOnePipette.pipettes)[0]
+      ]
+    when(mockGetPrimaryPipetteId)
+      .calledWith(
+        protocolWithOnePipette.pipettes,
+        protocolWithOnePipette.commands
+      )
+      .mockReturnValue('pipetteId')
+
+    const protocolWithUnusedTipRack = {
+      ...protocolWithOnePipette,
+      labware: {
+        ...protocolWithOnePipette.labware,
+        unusedTipRackId: {
+          definitionId: 'bogusDefinitionId',
+        },
+      },
+      labwareDefinitions: {
+        ...protocolWithOnePipette.labwareDefinitions,
+        bogusDefinitionId: { parameters: { isTiprack: true } } as any,
+      },
+    }
+
+    when(mockGetPipetteWorkflow)
+      .calledWith({
+        pipetteNames: [mockPipette.name],
+        primaryPipetteId: 'pipetteId',
+        labware: protocolWithOnePipette.labware,
+        labwareDefinitions: protocolWithOnePipette.labwareDefinitions,
+        commands: protocolWithOnePipette.commands,
+      })
+      .mockReturnValue(1)
+
+    getLabwarePositionCheckSteps(protocolWithUnusedTipRack)
+
+    expect(mockGetOnePipettePositionCheckSteps).toHaveBeenCalledWith({
+      primaryPipetteId: 'pipetteId',
+      labware: protocolWithOnePipette.labware,
+      labwareDefinitions: protocolWithOnePipette.labwareDefinitions,
+      modules: protocolWithOnePipette.modules,
+      commands: protocolWithOnePipette.commands,
+    })
+  })
   it('should generate commands with the one pipette workflow when there are two pipettes in the protocol but only one is used', () => {
     const leftPipetteId = '50d23e00-0042-11ec-8258-f7ffdf5ad45a'
     const rightPipetteId = 'c235a5a0-0042-11ec-8258-f7ffdf5ad45a'

--- a/app/src/organisms/LabwarePositionCheck/getLabwarePositionCheckSteps.ts
+++ b/app/src/organisms/LabwarePositionCheck/getLabwarePositionCheckSteps.ts
@@ -26,7 +26,17 @@ export const getLabwarePositionCheckSteps = (
     )
     const pipettes = values(pipettesById)
     const pipetteNames = pipettes.map(({ name }) => name)
-    const labware = protocolData.labware
+    const labware = omitBy(
+      protocolData.labware,
+      (labware, id) =>
+        protocolData.labwareDefinitions[labware.definitionId]?.parameters
+          .isTiprack &&
+        !protocolData.commands.some(
+          command =>
+            command.commandType === 'pickUpTip' &&
+            command.params.labwareId === id
+        )
+    )
     const modules: ProtocolAnalysisFile['modules'] = protocolData.modules
     const labwareDefinitions = protocolData.labwareDefinitions
     const commands: RunTimeCommand[] = protocolData.commands


### PR DESCRIPTION
# Overview

Filter out all tipracks that are loaded but unused when constructing the Labware Position Check
Steps. This avoids the possible edge cases where unused and incompatible tipracks are potentially
used by the primary pipette for tip pick in LPC.

Close #9691

# Review requests

Upload a protocol that loads, but doesn't use a tip rack. Run LPC, which should not include that tip rack.

# Risk assessment
low
