### PR TITLE
fix(app): app settings navigation active state

### DIFF
--- a/app/src/App/Navbar.tsx
+++ b/app/src/App/Navbar.tsx
@@ -119,10 +119,7 @@ export function Navbar({ routes }: { routes: RouteProps[] }): JSX.Element {
         alignSelf={ALIGN_STRETCH}
         justifyContent={JUSTIFY_SPACE_EVENLY}
       >
-        <NavIconLink
-          data-testid="Navbar_settingsLink"
-          to="/app-settings/general"
-        >
+        <NavIconLink data-testid="Navbar_settingsLink" to="/app-settings">
           <NavbarIcon name="gear" />
         </NavIconLink>
         <NavbarIcon data-testid="Navbar_helpLink" name="question-mark-circle" />


### PR DESCRIPTION


# Overview

This PR fixes the active state when the additional tabs other than General are clicked.

closes #10104

<img width="535" alt="image" src="https://user-images.githubusercontent.com/14794021/168678191-0a203b92-6a3f-4196-8039-eeb03f3e477d.png">

# Changelog

- updated route to include all sub-routes

# Review requests

- Check that when you click `Privacy`, `Advanced`, or `Feature Flags` tabs, the active state is visible for the settings nav button.

# Risk assessment

low
