### PR TITLE
build(app-shell): ensure bundled python includes all dependencies

### DIFF
--- a/app-shell/scripts/before-build.js
+++ b/app-shell/scripts/before-build.js
@@ -73,6 +73,8 @@ module.exports = function beforeBuild(context) {
     .then(() => {
       console.log('Standalone Python extracted, installing `opentrons` package')
 
+      // TODO(mc, 2022-05-16): explore virtualenvs for a more reliable
+      // implementation of this install
       return execa(
         HOST_PYTHON,
         [
@@ -81,6 +83,7 @@ module.exports = function beforeBuild(context) {
           'install',
           '--user',
           '--use-feature=in-tree-build',
+          '--force-reinstall',
           path.join(__dirname, '../../shared-data/python'),
           path.join(__dirname, '../../api'),
         ],
@@ -91,8 +94,9 @@ module.exports = function beforeBuild(context) {
         }
       )
     })
-    .then(() => {
+    .then(({ stdout }) => {
       console.log("`opentrons` package installed to app's Python environment")
+      console.debug('pip output:', stdout)
       // must return a truthy value, or else electron-builder will
       // skip installing project dependencies into the package
       return true


### PR DESCRIPTION
## Overview

This PR fixes (I hope) a build issue that was leading to weird in-app analysis failures due to missing Python packages.

Upon investigation, it seems like `pip` was incorrectly identifying packages installed in other locations as satisfying the dependency requirements for the copies of `opentrons` and `opentrons_shared_data` installed in the app's bundled Python location.

## Changelog

- Call `pip` with `--force-reinstall`, which should ensure all dependencies get added to the bundled Python location

## Review requests

- [ ] Ensure previously observed analysis failures are no longer present on the app builds of this branch

## Risk assessment

Low
