### PR TITLE
fix(app): only render historical run overflow menu when menu is open

### DIFF
--- a/app/src/organisms/Devices/HistoricalProtocolRun.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRun.tsx
@@ -11,7 +11,6 @@ import {
   BORDERS,
 } from '@opentrons/components'
 import { StyledText } from '../../atoms/text'
-import { useRunStatus } from '../RunTimeControl/hooks'
 import { formatInterval } from '../RunTimeControl/utils'
 import { formatTimestamp } from './utils'
 import { HistoricalProtocolRunOverflowMenu as OverflowMenu } from './HistoricalProtocolRunOverflowMenu'
@@ -34,7 +33,7 @@ export function HistoricalProtocolRun(
   const { t } = useTranslation('run_details')
   const { run, protocolName, robotIsBusy, robotName } = props
   const [offsetDrawerOpen, setOffsetDrawerOpen] = React.useState(false)
-  const runStatus = useRunStatus(run.id)
+  const runStatus = run.status
   const runDisplayName = formatTimestamp(run.createdAt)
   let duration = EMPTY_TIMESTAMP
   if (runStatus !== 'idle') {

--- a/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
@@ -31,18 +31,33 @@ export interface HistoricalProtocolRunOverflowMenuProps {
 export function HistoricalProtocolRunOverflowMenu(
   props: HistoricalProtocolRunOverflowMenuProps
 ): JSX.Element {
-  const { t } = useTranslation('device_details')
-  const history = useHistory()
-
-  const { run, robotName, protocolName, robotIsBusy } = props
-  const runId = run.id
-  const commands = useAllCommandsQuery(runId)
   const [showOverflowMenu, setShowOverflowMenu] = React.useState<boolean>(false)
   const handleOverflowClick: React.MouseEventHandler<HTMLButtonElement> = e => {
     e.preventDefault()
     e.stopPropagation()
     setShowOverflowMenu(!showOverflowMenu)
   }
+  return (
+    <Flex flexDirection={DIRECTION_COLUMN} position={POSITION_RELATIVE}>
+      <OverflowBtn alignSelf={ALIGN_FLEX_END} onClick={handleOverflowClick} />
+      {showOverflowMenu && (
+        <MenuDropdown {...props} closeOverflowMenu={handleOverflowClick} />
+      )}
+    </Flex>
+  )
+}
+
+interface MenuDropdownProps extends HistoricalProtocolRunOverflowMenuProps {
+  closeOverflowMenu: React.MouseEventHandler<HTMLButtonElement>
+}
+function MenuDropdown(props: MenuDropdownProps): JSX.Element {
+  const { t } = useTranslation('device_details')
+  const history = useHistory()
+
+  const { run, robotName, protocolName, robotIsBusy, closeOverflowMenu } = props
+  const runId = run.id
+  const commands = useAllCommandsQuery(runId)
+
   const onResetSuccess = (createRunResponse: Run): void =>
     history.push(
       `/devices/${robotName}/protocol-runs/${createRunResponse.data.id}/run-log`
@@ -57,55 +72,47 @@ export function HistoricalProtocolRunOverflowMenu(
     const createdAt = new Date(run.createdAt).toISOString()
     const fileName = `${robotName}_${protocolName}_${createdAt}.json`
     downloadFile(runDetails, fileName)
-    setShowOverflowMenu(!showOverflowMenu)
+    closeOverflowMenu(e)
   }
   const { reset } = useRunControls(runId, onResetSuccess)
   const { deleteRun } = useDeleteRunMutation()
-
   return (
-    <Flex flexDirection={DIRECTION_COLUMN} position={POSITION_RELATIVE}>
-      <OverflowBtn alignSelf={ALIGN_FLEX_END} onClick={handleOverflowClick} />
-      {showOverflowMenu && (
-        <Flex
-          width="11.625rem"
-          zIndex={10}
-          borderRadius={'4px 4px 0px 0px'}
-          boxShadow={'0px 1px 3px rgba(0, 0, 0, 0.2)'}
-          position={POSITION_ABSOLUTE}
-          backgroundColor={COLORS.white}
-          top={SPACING.spacing6}
-          right={0}
-          flexDirection={DIRECTION_COLUMN}
-        >
-          <NavLink to={`/devices/${robotName}/protocol-runs/${runId}/run-log`}>
-            <MenuItem
-              dataTest-id={`RecentProtocolRun_OverflowMenu_viewRunRecord`}
-            >
-              {t('view_run_record')}
-            </MenuItem>
-          </NavLink>
-          <MenuItem
-            onClick={reset}
-            disabled={robotIsBusy}
-            dataTest-id={`RecentProtocolRun_OverflowMenu_rerunNow`}
-          >
-            {t('rerun_now')}
-          </MenuItem>
-          <MenuItem
-            dataTest-id={`RecentProtocolRun_OverflowMenu_downloadRunLog`}
-            onClick={onDownloadClick}
-          >
-            {t('download_run_log')}
-          </MenuItem>
-          <Divider />
-          <MenuItem
-            onClick={() => deleteRun(runId)}
-            dataTest-id={`RecentProtocolRun_OverflowMenu_deleteRun`}
-          >
-            {t('delete_run')}
-          </MenuItem>
-        </Flex>
-      )}
+    <Flex
+      width="11.625rem"
+      zIndex={10}
+      borderRadius={'4px 4px 0px 0px'}
+      boxShadow={'0px 1px 3px rgba(0, 0, 0, 0.2)'}
+      position={POSITION_ABSOLUTE}
+      backgroundColor={COLORS.white}
+      top={SPACING.spacing6}
+      right={0}
+      flexDirection={DIRECTION_COLUMN}
+    >
+      <NavLink to={`/devices/${robotName}/protocol-runs/${runId}/run-log`}>
+        <MenuItem dataTest-id={`RecentProtocolRun_OverflowMenu_viewRunRecord`}>
+          {t('view_run_record')}
+        </MenuItem>
+      </NavLink>
+      <MenuItem
+        onClick={reset}
+        disabled={robotIsBusy}
+        dataTest-id={`RecentProtocolRun_OverflowMenu_rerunNow`}
+      >
+        {t('rerun_now')}
+      </MenuItem>
+      <MenuItem
+        dataTest-id={`RecentProtocolRun_OverflowMenu_downloadRunLog`}
+        onClick={onDownloadClick}
+      >
+        {t('download_run_log')}
+      </MenuItem>
+      <Divider />
+      <MenuItem
+        onClick={() => deleteRun(runId)}
+        dataTest-id={`RecentProtocolRun_OverflowMenu_deleteRun`}
+      >
+        {t('delete_run')}
+      </MenuItem>
     </Flex>
   )
 }


### PR DESCRIPTION
# Overview

Small fix for unintended behavior in #10287, identified by @brenthagen .  All historical runs in the device details listing where rendering their overflow menu's which make HTTP calls for more details. This was leading to a polling cascade of unused spam GET requests.  

This PR separates out the Overflow Menu's logic so that it doesn't mount any of the detail fetching hooks when it's not open

# Review requests

Go to the detail page of a robot with multiple historical runs.  There should be initial fetches to the /runs and /protocols collection endpoints when the component mounts, but none more specific routes unless an overflow menu is opened for a particular row.

# Risk assessment
low
