### PR TITLE
fix(hardware): Update can bitrate

### DIFF
--- a/hardware/opentrons_hardware/drivers/can_bus/settings.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/settings.py
@@ -4,7 +4,7 @@ from pydantic import BaseSettings, Field
 
 DEFAULT_INTERFACE: Final = "socketcan"
 
-DEFAULT_BITRATE: Final = 250000
+DEFAULT_BITRATE: Final = 500000
 
 DEFAULT_CHANNEL: Final = "can0"
 


### PR DESCRIPTION
The bitrate of the canbus has changed in the systemd configuration and the microcontroller settings, but it also needs to be changed in the python setup.