### PR TITLE
fix(api): Fix delays returning immediately

### DIFF
--- a/api/src/opentrons/hardware_control/execution_manager.py
+++ b/api/src/opentrons/hardware_control/execution_manager.py
@@ -56,7 +56,7 @@ class ExecutionManager:
         async with self._condition:
             return self._state
 
-    async def register_cancellable_task(
+    def register_cancellable_task(
         self, task: "asyncio.Task[TaskContents]"
     ) -> "asyncio.Task[TaskContents]":
         self._cancellable_tasks.add(task)

--- a/api/src/opentrons/hardware_control/execution_manager.py
+++ b/api/src/opentrons/hardware_control/execution_manager.py
@@ -56,12 +56,9 @@ class ExecutionManager:
         async with self._condition:
             return self._state
 
-    def register_cancellable_task(
-        self, task: "asyncio.Task[TaskContents]"
-    ) -> "asyncio.Task[TaskContents]":
+    def register_cancellable_task(self, task: "asyncio.Task[TaskContents]") -> None:
         self._cancellable_tasks.add(task)
         task.add_done_callback(lambda t: self._cancellable_tasks.discard(t))
-        return task
 
     async def wait_for_is_running(self) -> None:
         async with self._condition:
@@ -139,4 +136,5 @@ class ExecutionManagerProvider:
                 await asyncio.sleep(seconds)
 
             delay_task = asyncio.create_task(sleep_for_seconds(duration_s))
-            await self._execution_manager.register_cancellable_task(delay_task)
+            self._execution_manager.register_cancellable_task(delay_task)
+            await delay_task

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -264,7 +264,7 @@ class HeaterShaker(mod_abc.AbstractModule):
                 await self.wait_next_poll()
 
         task = self._loop.create_task(_wait())
-        await self.make_cancellable(task)
+        self.make_cancellable(task)
         await task
 
     async def start_set_temperature(self, celsius: float) -> None:
@@ -309,7 +309,7 @@ class HeaterShaker(mod_abc.AbstractModule):
                     await self.wait_next_poll()
 
         t = self._loop.create_task(_await_temperature())
-        await self.make_cancellable(t)
+        self.make_cancellable(t)
         await t
 
     async def set_speed(self, rpm: int) -> None:
@@ -333,7 +333,7 @@ class HeaterShaker(mod_abc.AbstractModule):
                 await self.wait_next_poll()
 
         task = self._loop.create_task(_wait())
-        await self.make_cancellable(task)
+        self.make_cancellable(task)
         await task
 
     async def start_set_speed(self, rpm: int) -> None:
@@ -372,7 +372,7 @@ class HeaterShaker(mod_abc.AbstractModule):
                     await self.wait_next_poll()
 
         t = self._loop.create_task(_await_speed())
-        await self.make_cancellable(t)
+        self.make_cancellable(t)
         await t
 
     async def await_speed_and_temperature(self, temperature: float, speed: int) -> None:

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -101,8 +101,8 @@ class AbstractModule(abc.ABC):
         if not self.is_simulated:
             await self._execution_manager.wait_for_is_running()
 
-    async def make_cancellable(self, task: "asyncio.Task[TaskPayload]") -> None:
-        await self._execution_manager.register_cancellable_task(task)
+    def make_cancellable(self, task: "asyncio.Task[TaskPayload]") -> None:
+        self._execution_manager.register_cancellable_task(task)
 
     @abc.abstractmethod
     async def deactivate(self) -> None:

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -137,7 +137,7 @@ class TempDeck(mod_abc.AbstractModule):
                 await self.wait_next_poll()
 
         task = self._loop.create_task(_wait())
-        await self.make_cancellable(task)
+        self.make_cancellable(task)
         await task
 
     async def start_set_temperature(self, celsius: float) -> None:
@@ -172,7 +172,7 @@ class TempDeck(mod_abc.AbstractModule):
                     await self.wait_next_poll()
 
         t = self._loop.create_task(_await_temperature())
-        await self.make_cancellable(t)
+        self.make_cancellable(t)
         await t
 
     async def deactivate(self) -> None:

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -251,7 +251,7 @@ class Thermocycler(mod_abc.AbstractModule):
             task = self._loop.create_task(self._wait_for_hold(hold_time))
         else:
             task = self._loop.create_task(self._wait_for_temp())
-        await self.make_cancellable(task)
+        self.make_cancellable(task)
         await task
 
     async def cycle_temperatures(
@@ -275,7 +275,7 @@ class Thermocycler(mod_abc.AbstractModule):
         self._total_step_count = len(steps)
 
         task = self._loop.create_task(self._execute_cycles(steps, repetitions, volume))
-        await self.make_cancellable(task)
+        self.make_cancellable(task)
         await task
 
     async def set_lid_temperature(self, temperature: float) -> None:
@@ -295,7 +295,7 @@ class Thermocycler(mod_abc.AbstractModule):
                     f"but status reads T={self.lid_target}"
                 )
         task = self._loop.create_task(self._wait_for_lid_temp())
-        await self.make_cancellable(task)
+        self.make_cancellable(task)
         await task
 
     # TODO(mc, 2022-04-25): de-duplicate with `set_temperature`

--- a/api/tests/opentrons/hardware_control/test_execution_manager.py
+++ b/api/tests/opentrons/hardware_control/test_execution_manager.py
@@ -58,7 +58,7 @@ async def test_cancel_tasks():
     loop = asyncio.get_running_loop()
 
     cancellable_task = loop.create_task(fake_task())
-    await exec_mgr.register_cancellable_task(cancellable_task)
+    exec_mgr.register_cancellable_task(cancellable_task)
 
     other_task = loop.create_task(fake_task())
 


### PR DESCRIPTION
# Overview

Fixes #10279.

# Explanation

This bug was a missing `await` that got hidden in a sneaky way.

Here, we have an async method that returns an async task:

https://github.com/Opentrons/opentrons/blob/b1fd19f6fa7cb2dc8cab2cac43e0015d07b561b1/api/src/opentrons/hardware_control/execution_manager.py#L53-L56

And here, we try to call that method and then wait for the returned task to finish:

https://github.com/Opentrons/opentrons/blob/b1fd19f6fa7cb2dc8cab2cac43e0015d07b561b1/api/src/opentrons/hardware_control/execution_manager.py#L108

But notice that we only have one `await`. We really need two: one to wait for `register_cancellable_task()` to return a task, and one to wait for the returned task to complete.

This PR fixes it by making `register_cancellable_task()` `def` instead of `async def`, so the call site only needs a single `await`. This is how things used to be; the `async` was unnecessary, and we apparently accidentally added it in #9368.

# Review requests

Try out the steps to reproduce in #10279 and confirm that the bug is fixed. You'll need a real robot for this, since the dev server always skips delays.

# Risk assessment

Low. This is a risky area of the code, but this particular change is small and easily auditable.