### PR TITLE
fix(hardware): Fix equal leg triangle move handling

### DIFF
--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -84,11 +84,13 @@ async def test_motion(ctx, hardware):
     old_pos = await hardware.current_position(instr._implementation.get_mount())
     instr.home()
     assert instr.move_to(Location(Point(0, 0, 0), None)) is instr
-    old_pos[Axis.X] = 0
-    old_pos[Axis.Y] = 0
-    old_pos[Axis.A] = 0
-    old_pos[Axis.C] = 2
-    assert await hardware.current_position(instr._implementation.get_mount()) == old_pos
+    old_pos[Axis.X] = 0.0
+    old_pos[Axis.Y] = 0.0
+    old_pos[Axis.A] = 0.0
+    old_pos[Axis.C] = 2.0
+    assert await hardware.current_position(
+        instr._implementation.get_mount()
+    ) == pytest.approx(old_pos)
 
 
 async def test_max_speeds(ctx, monkeypatch, hardware):

--- a/hardware/opentrons_hardware/drivers/can_bus/settings.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/settings.py
@@ -4,7 +4,7 @@ from pydantic import BaseSettings, Field
 
 DEFAULT_INTERFACE: Final = "socketcan"
 
-DEFAULT_BITRATE: Final = 250000
+DEFAULT_BITRATE: Final = 500000
 
 DEFAULT_CHANNEL: Final = "can0"
 

--- a/hardware/opentrons_hardware/hardware_control/motion_planning/move_utils.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/move_utils.py
@@ -348,7 +348,13 @@ def build_blocks(
         acceleration=-max_acceleration,
         distance=abs(max_speed_sq - final_speed_sq) / (2 * max_acceleration),
     )
-    if first.distance + final.distance > distance:
+    # the FLOAT_THRESHOLD here catches a numerical instability case where
+    # first.initial_speed and final.final_speed are almost exactly equal,
+    # and acceleration is low enough that this is a triangle move. in this
+    # case, sometimes numerical instability could cause the inequality
+    # to pass, and the code below subtracts the initial and final, and
+    # would come up with 0. Adding the threshold fixes the issue.
+    if first.distance + final.distance > (distance + FLOAT_THRESHOLD):
         # the math did not quite work out and we need to trim down our top speed.
         # This will be a suboptimal solution almost certainly, but it's better to
         # have a suboptimal solution that doesn't violate constraints than an
@@ -365,7 +371,7 @@ def build_blocks(
         final.initial_speed = first.final_speed
         final.distance = np.abs(max_speed_sq - final_speed_sq) / (2 * max_acceleration)
 
-    if first.distance + final.distance < distance:
+    if first.distance + final.distance < (distance - FLOAT_THRESHOLD):
         # we'll have a coast phase!
         coast = Block(
             initial_speed=final.initial_speed,


### PR DESCRIPTION
When you try and internally blend a move that has the same starting and
ending velocity and has certain numerically-coincidental constraint and
distance values, it will sometimes accidentally trigger a part of the
planning code that is supposed to handle very unequal triangle moves.

This code cannot handle the case where the overall initial and final speeds
are almost exactly equal. In that case, the accel/decel legs have their
distance set to 0, but not their speeds, accelerations, or distances,
and the coast phase takes the entire difference. That causes the move to
go twice as far as it should.

This is fixed pretty easily by using a sloppier comparison to catch
issues of numerical stability.
