### PR TITLE
docs(robot-server): Fix wrong title for deleting pipette offset calibrations

### DIFF
--- a/robot-server/robot_server/service/pipette_offset/router.py
+++ b/robot-server/robot_server/service/pipette_offset/router.py
@@ -39,8 +39,8 @@ def _format_calibration(
 
 @router.get(
     "/calibration/pipette_offset",
+    summary="Get all pipette offset calibrations",
     description="Fetch all saved pipette offset calibrations from the robot",
-    summary="Search the robot for any saved pipette offsets",
     response_model=pip_models.MultipleCalibrationsResponse,
 )
 async def get_all_pipette_offset_calibrations(
@@ -69,11 +69,14 @@ async def get_all_pipette_offset_calibrations(
 
 @router.delete(
     "/calibration/pipette_offset",
-    description="Delete one specific pipette calibration "
-    "by pipette serial and mount",
+    summary="Delete a pipette offset calibration",
+    description=(
+        "Delete one specific pipette calibration"
+        " by pipette serial and mount."
+    ),
     responses={status.HTTP_404_NOT_FOUND: {"model": ErrorBody}},
 )
-async def get_specific_pipette_offset_calibration(
+async def delete_specific_pipette_offset_calibration(
     pipette_id: str, mount: pip_models.MountType
 ):
     try:

--- a/robot-server/robot_server/service/pipette_offset/router.py
+++ b/robot-server/robot_server/service/pipette_offset/router.py
@@ -70,10 +70,7 @@ async def get_all_pipette_offset_calibrations(
 @router.delete(
     "/calibration/pipette_offset",
     summary="Delete a pipette offset calibration",
-    description=(
-        "Delete one specific pipette calibration"
-        " by pipette serial and mount."
-    ),
+    description="Delete one specific pipette calibration by pipette serial and mount.",
     responses={status.HTTP_404_NOT_FOUND: {"model": ErrorBody}},
 )
 async def delete_specific_pipette_offset_calibration(


### PR DESCRIPTION
# Overview

In our OpenAPI-based documentation, the `DELETE /calibration/pipette_offset` HTTP endpoint was being incorrectly listed as:

>  Get Specific Pipette Offset Calibration

 This PR fixes it so that it says:

> Delete a pipette offset calibration

# Technical changelog

* Fix the Python method name wrongly saying `get` instead of `delete`. FastAPI was deriving the title in the documentation from this wrong method name.
* Manually supply FastAPI a `summary` string instead of letting FastAPI infer it from the method name. I think this is good practice, in general.

# Risk assessment

Very low. The only changes are to the documentation.