### PR TITLE
chore(docs): syntax fix in TemperatureModuleContext docstring

### DIFF
--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -230,7 +230,7 @@ class TemperatureModuleContext(ModuleContext[ModuleGeometry]):
 
     A minimal protocol with a Temperature module would look like this:
 
-    .. code block:: python
+    .. code-block:: python
 
         def run(ctx):
             slot_number = 10


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

1-byte change to fix broken syntax in the docstring for `TemperatureModuleContext`, which was causing an entire block to not render.

closes #10321 

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

`code block` -> `code-block`

# Review requests

<!--
Describe any requests for your reviewers here.
-->
Check the API reference in the docs sandbox to ensure this has the desired effect.

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Low, docstring change only.