### PR TITLE
docs(api): Fix typo in mix command example

### DIFF
--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -357,7 +357,7 @@ The ``mix`` command takes up to three arguments: ``mix(repetitions, volume, loca
 .. code-block:: python
 
     # mix 4 times, 100uL, in plate:A2
-    pipette.mix(4, 100, plate.['A2'])
+    pipette.mix(4, 100, plate['A2'])
     # mix 3 times, 50uL, in current location
     pipette.mix(3, 50)
     # mix 2 times, pipette's max volume, in current location


### PR DESCRIPTION
Fixed a typo in the Mix command example code. Changed line 360 from     `pipette.mix(4, 100, plate.['A2'])` to     `pipette.mix(4, 100, plate['A2'])`. Removed the period.

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
