### PR TITLE
commented out call to run_store.has()

### DIFF
--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -80,10 +80,10 @@ async def get_current_run_engine_from_url(
         engine_store: Engine store to pull current run ProtocolEngine.
         run_store: Run data storage.
     """
-    if not run_store.has(runId):
-        raise RunNotFound(detail=f"Run {runId} not found.").as_error(
-            status.HTTP_404_NOT_FOUND
-        )
+    # if not run_store.has(runId):
+    #     raise RunNotFound(detail=f"Run {runId} not found.").as_error(
+    #         status.HTTP_404_NOT_FOUND
+    #     )
 
     if runId != engine_store.current_run_id:
         raise RunStopped(detail=f"Run {runId} is not the current run").as_error(

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -51,23 +51,23 @@ async def test_get_current_run_engine_from_url(
     assert result is mock_engine_store.engine
 
 
-async def test_get_current_run_engine_no_run(
-    decoy: Decoy,
-    mock_engine_store: EngineStore,
-    mock_run_store: RunStore,
-) -> None:
-    """It should 404 if the run is not in the store."""
-    decoy.when(mock_run_store.has("run-id")).then_return(False)
-
-    with pytest.raises(ApiError) as exc_info:
-        await get_current_run_engine_from_url(
-            runId="run-id",
-            engine_store=mock_engine_store,
-            run_store=mock_run_store,
-        )
-
-    assert exc_info.value.status_code == 404
-    assert exc_info.value.content["errors"][0]["id"] == "RunNotFound"
+# async def test_get_current_run_engine_no_run(
+#     decoy: Decoy,
+#     mock_engine_store: EngineStore,
+#     mock_run_store: RunStore,
+# ) -> None:
+#     """It should 404 if the run is not in the store."""
+#     decoy.when(mock_run_store.has("run-id")).then_return(False)
+#
+#     with pytest.raises(ApiError) as exc_info:
+#         await get_current_run_engine_from_url(
+#             runId="run-id",
+#             engine_store=mock_engine_store,
+#             run_store=mock_run_store,
+#         )
+#
+#     assert exc_info.value.status_code == 404
+#     assert exc_info.value.content["errors"][0]["id"] == "RunNotFound"
 
 
 async def test_get_current_run_engine_from_url_not_current(


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

commented out call to run_store.has(run_id). this causes a delay in the POST commands end point

Quick solution for #10333. 

# Changelog

- Commands router - commented out call to run_store.has()

# Risk assessment

Very low. This call is being done from a depends method that is only being used by the current end point 
