### PR TITLE
fix(hardware): serial number field needs from_string to be updated from can_comm

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
@@ -118,6 +118,11 @@ class SerialField(utils.BinaryFieldBase[bytes]):
     NUM_BYTES = 12
     FORMAT = f"{NUM_BYTES}s"
 
+    @classmethod
+    def from_string(cls, t: str) -> SerialField:
+        """Create from a string."""
+        return cls(binascii.unhexlify(t)[: cls.NUM_BYTES])
+
 
 class SensorOutputBindingField(utils.UInt8Field):
     """sensor type."""


### PR DESCRIPTION
# Overview

Should put this from_string in a base class in the future

# Changelog


# Review requests


# Risk assessment

None