### PR TITLE
feat(app-shell, app): change window width, height; add minWidth

### DIFF
--- a/app-shell/README.md
+++ b/app-shell/README.md
@@ -155,7 +155,16 @@ Sets the `webPreferences.webSecurity` option of the Electron [BrowserWindow][ele
 - CLI argument: `--ui.width`
 - Environment variable: `OT_APP_UI__WIDTH`
 - JSON path: `ui.width`
-- Default: `1024`
+- Default: `800`
+
+[BrowserWindow][electron-docs-browser-window] width at launch.
+
+##### ui.minWidth
+
+- CLI argument: `--ui.minWidth`
+- Environment variable: `OT_APP_UI__MIN_WIDTH`
+- JSON path: `ui.minWidth`
+- Default: `600`
 
 [BrowserWindow][electron-docs-browser-window] width at launch.
 
@@ -164,7 +173,7 @@ Sets the `webPreferences.webSecurity` option of the Electron [BrowserWindow][ele
 - CLI argument: `--ui.height`
 - Environment variable: `OT_APP_UI__HEIGHT`
 - JSON path: `ui.height`
-- Default: `768`
+- Default: `760`
 
 [BrowserWindow][electron-docs-browser-window] height at launch.
 

--- a/app-shell/README.md
+++ b/app-shell/README.md
@@ -166,7 +166,7 @@ Sets the `webPreferences.webSecurity` option of the Electron [BrowserWindow][ele
 - JSON path: `ui.minWidth`
 - Default: `600`
 
-[BrowserWindow][electron-docs-browser-window] width at launch.
+[BrowserWindow][electron-docs-browser-window] minWidth at launch.
 
 ##### ui.height
 

--- a/app-shell/src/config/__fixtures__/index.ts
+++ b/app-shell/src/config/__fixtures__/index.ts
@@ -118,12 +118,6 @@ export const MOCK_CONFIG_V6: ConfigV6 = {
       isAttached: false,
     },
   },
-  ui: {
-    ...MOCK_CONFIG_V5.ui,
-    width: 800,
-    minWidth: 600,
-    height: 760,
-  },
 }
 
 export const MOCK_CONFIG_V7: ConfigV7 = {

--- a/app-shell/src/config/__fixtures__/index.ts
+++ b/app-shell/src/config/__fixtures__/index.ts
@@ -6,6 +6,7 @@ import type {
   ConfigV4,
   ConfigV5,
   ConfigV6,
+  ConfigV7,
 } from '@opentrons/app/src/redux/config/types'
 
 export const MOCK_CONFIG_V0: ConfigV0 = {
@@ -119,6 +120,17 @@ export const MOCK_CONFIG_V6: ConfigV6 = {
   },
   ui: {
     ...MOCK_CONFIG_V5.ui,
+    width: 800,
+    minWidth: 600,
+    height: 760,
+  },
+}
+
+export const MOCK_CONFIG_V7: ConfigV7 = {
+  ...MOCK_CONFIG_V6,
+  version: 7,
+  ui: {
+    ...MOCK_CONFIG_V6.ui,
     width: 800,
     minWidth: 600,
     height: 760,

--- a/app-shell/src/config/__fixtures__/index.ts
+++ b/app-shell/src/config/__fixtures__/index.ts
@@ -117,4 +117,10 @@ export const MOCK_CONFIG_V6: ConfigV6 = {
       isAttached: false,
     },
   },
+  ui: {
+    ...MOCK_CONFIG_V5.ui,
+    width: 800,
+    minWidth: 600,
+    height: 760,
+  },
 }

--- a/app-shell/src/config/__tests__/migrate.test.ts
+++ b/app-shell/src/config/__tests__/migrate.test.ts
@@ -7,6 +7,7 @@ import {
   MOCK_CONFIG_V4,
   MOCK_CONFIG_V5,
   MOCK_CONFIG_V6,
+  MOCK_CONFIG_V7,
 } from '../__fixtures__'
 import { migrate } from '../migrate'
 
@@ -15,55 +16,63 @@ describe('config migration', () => {
     const v0Config = MOCK_CONFIG_V0
     const result = migrate(v0Config)
 
-    expect(result.version).toBe(6)
-    expect(result).toEqual(MOCK_CONFIG_V6)
+    expect(result.version).toBe(7)
+    expect(result).toEqual(MOCK_CONFIG_V7)
   })
 
   it('should migrate version 1 to latest', () => {
     const v1Config = MOCK_CONFIG_V1
     const result = migrate(v1Config)
 
-    expect(result.version).toBe(6)
-    expect(result).toEqual(MOCK_CONFIG_V6)
+    expect(result.version).toBe(7)
+    expect(result).toEqual(MOCK_CONFIG_V7)
   })
 
   it('should migrate version 2 to latest', () => {
     const v2Config = MOCK_CONFIG_V2
     const result = migrate(v2Config)
 
-    expect(result.version).toBe(6)
-    expect(result).toEqual(MOCK_CONFIG_V6)
+    expect(result.version).toBe(7)
+    expect(result).toEqual(MOCK_CONFIG_V7)
   })
 
   it('should migrate version 3 to latest', () => {
     const v3Config = MOCK_CONFIG_V3
     const result = migrate(v3Config)
 
-    expect(result.version).toBe(6)
-    expect(result).toEqual(MOCK_CONFIG_V6)
+    expect(result.version).toBe(7)
+    expect(result).toEqual(MOCK_CONFIG_V7)
   })
 
   it('should migrate version 4 to latest', () => {
     const v4Config = MOCK_CONFIG_V4
     const result = migrate(v4Config)
 
-    expect(result.version).toBe(6)
-    expect(result).toEqual(MOCK_CONFIG_V6)
+    expect(result.version).toBe(7)
+    expect(result).toEqual(MOCK_CONFIG_V7)
   })
 
   it('should migrate version 5 to latest', () => {
     const v5Config = MOCK_CONFIG_V5
     const result = migrate(v5Config)
 
-    expect(result.version).toBe(6)
-    expect(result).toEqual(MOCK_CONFIG_V6)
+    expect(result.version).toBe(7)
+    expect(result).toEqual(MOCK_CONFIG_V7)
   })
 
-  it('should keep version 6', () => {
+  it('should migrate version 6 to latest', () => {
     const v6Config = MOCK_CONFIG_V6
     const result = migrate(v6Config)
 
-    expect(result.version).toBe(6)
-    expect(result).toEqual(v6Config)
+    expect(result.version).toBe(7)
+    expect(result).toEqual(MOCK_CONFIG_V7)
+  })
+
+  it('should keep version 7', () => {
+    const v7Config = MOCK_CONFIG_V7
+    const result = migrate(v7Config)
+
+    expect(result.version).toBe(7)
+    expect(result).toEqual(v7Config)
   })
 })

--- a/app-shell/src/config/migrate.ts
+++ b/app-shell/src/config/migrate.ts
@@ -165,6 +165,12 @@ const toVersion6 = (prevConfig: ConfigV5): ConfigV6 => {
     modules: {
       heaterShaker: { isAttached: false },
     },
+    ui: {
+      ...prevConfig.ui,
+      width: 800,
+      minWidth: 600,
+      height: 760,
+    },
   }
 
   return nextConfig

--- a/app-shell/src/config/migrate.ts
+++ b/app-shell/src/config/migrate.ts
@@ -12,6 +12,7 @@ import type {
   ConfigV4,
   ConfigV5,
   ConfigV6,
+  ConfigV7,
 } from '@opentrons/app/src/redux/config/types'
 
 // base config v0 defaults
@@ -165,6 +166,16 @@ const toVersion6 = (prevConfig: ConfigV5): ConfigV6 => {
     modules: {
       heaterShaker: { isAttached: false },
     },
+  }
+
+  return nextConfig
+}
+
+// config version 7 migration and defaults
+const toVersion7 = (prevConfig: ConfigV6): ConfigV7 => {
+  const nextConfig = {
+    ...prevConfig,
+    version: 7 as const,
     ui: {
       ...prevConfig.ui,
       width: 800,
@@ -182,8 +193,17 @@ const MIGRATIONS: [
   (prevConfig: ConfigV2) => ConfigV3,
   (prevConfig: ConfigV3) => ConfigV4,
   (prevConfig: ConfigV4) => ConfigV5,
-  (prevConfig: ConfigV5) => ConfigV6
-] = [toVersion1, toVersion2, toVersion3, toVersion4, toVersion5, toVersion6]
+  (prevConfig: ConfigV5) => ConfigV6,
+  (prevConfig: ConfigV6) => ConfigV7
+] = [
+  toVersion1,
+  toVersion2,
+  toVersion3,
+  toVersion4,
+  toVersion5,
+  toVersion6,
+  toVersion7,
+]
 
 export const DEFAULTS: Config = migrate(DEFAULTS_V0)
 
@@ -196,6 +216,7 @@ export function migrate(
     | ConfigV4
     | ConfigV5
     | ConfigV6
+    | ConfigV7
 ): Config {
   const prevVersion = prevConfig.version
   let result = prevConfig

--- a/app-shell/src/ui.ts
+++ b/app-shell/src/ui.ts
@@ -19,6 +19,7 @@ const WINDOW_OPTS = {
   useContentSize: true,
   width: config.width,
   height: config.height,
+  minWidth: config.minWidth,
   // allow webPreferences to be set at launchtime from config
   webPreferences: Object.assign(
     {

--- a/app-shell/src/ui.ts
+++ b/app-shell/src/ui.ts
@@ -18,8 +18,8 @@ const WINDOW_OPTS = {
   show: false,
   useContentSize: true,
   width: config.width,
-  height: config.height,
   minWidth: config.minWidth,
+  height: config.height,
   // allow webPreferences to be set at launchtime from config
   webPreferences: Object.assign(
     {

--- a/app/src/redux/config/schema-types.ts
+++ b/app/src/redux/config/schema-types.ts
@@ -126,9 +126,13 @@ export interface ConfigV6 extends Omit<ConfigV5, 'version'> {
   modules: {
     heaterShaker: { isAttached: boolean }
   }
+}
+
+export interface ConfigV7 extends Omit<ConfigV6, 'version'> {
+  version: 7
   ui: ConfigV5['ui'] & {
     minWidth: number
   }
 }
 
-export type Config = ConfigV6
+export type Config = ConfigV7

--- a/app/src/redux/config/schema-types.ts
+++ b/app/src/redux/config/schema-types.ts
@@ -130,7 +130,7 @@ export interface ConfigV6 extends Omit<ConfigV5, 'version'> {
 
 export interface ConfigV7 extends Omit<ConfigV6, 'version'> {
   version: 7
-  ui: ConfigV5['ui'] & {
+  ui: ConfigV6['ui'] & {
     minWidth: number
   }
 }

--- a/app/src/redux/config/schema-types.ts
+++ b/app/src/redux/config/schema-types.ts
@@ -126,6 +126,9 @@ export interface ConfigV6 extends Omit<ConfigV5, 'version'> {
   modules: {
     heaterShaker: { isAttached: boolean }
   }
+  ui: ConfigV5['ui'] & {
+    minWidth: number
+  }
 }
 
 export type Config = ConfigV6


### PR DESCRIPTION
# Overview
This will change the default app window size to 800x760 and add a default `minWidth` of 600.
Closes #10289, #9651

# Changelog
- Edited default app window width and height in V6 config migration
- Added minWidth default to V6 config migration

# Review requests
Run the app to confirm new default size and minimum width. I had to remove my config.json file for this change to take effect, is this the typical way of resetting config?
Run with the `OT_APP_UI__MIN_WIDTH` set to confirm `minWidth` default is overrideable.

# Risk assessment
Low
