### PR TITLE
refactor(robot-server): heavily cache reads from run and protocol stores

### DIFF
--- a/robot-server/robot_server/protocols/analysis_store.py
+++ b/robot-server/robot_server/protocols/analysis_store.py
@@ -63,6 +63,14 @@ class AnalysisNotFoundError(ValueError):
         super().__init__(f'Analysis "{analysis_id}" not found.')
 
 
+# TODO(mm, 2022-05-19): Unlike ProtocolStore and RunStore, this class doesn't
+# have an in-memory cache. This is because of implementation difficulties:
+# this class is currently the only one of the three to have any async methods,
+# which functools.lru_cache() doesn't support.
+#
+# We should have a consistent strategy across all stores.
+# Either figure out an in-memory cache that supports async methods,
+# or remove in-memory caching from all stores.
 class AnalysisStore:
     """Storage interface for protocol analyses.
 

--- a/robot-server/robot_server/protocols/protocol_store.py
+++ b/robot-server/robot_server/protocols/protocol_store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+from functools import lru_cache
 from logging import getLogger
 from pathlib import Path
 from typing import Dict, List, Optional, Set
@@ -18,6 +19,9 @@ from robot_server.persistence import (
     sqlite_rowid,
     ensure_utc_datetime,
 )
+
+
+_CACHE_ENTRIES = 32
 
 
 _log = getLogger(__name__)
@@ -157,7 +161,9 @@ class ProtocolStore:
             )
         )
         self._sources_by_id[resource.protocol_id] = resource.source
+        self._clear_caches()
 
+    @lru_cache(maxsize=_CACHE_ENTRIES)
     def get(self, protocol_id: str) -> ProtocolResource:
         """Get a single protocol by ID.
 
@@ -172,6 +178,7 @@ class ProtocolStore:
             source=self._sources_by_id[sql_resource.protocol_id],
         )
 
+    @lru_cache(maxsize=_CACHE_ENTRIES)
     def get_all(self) -> List[ProtocolResource]:
         """Get all protocols currently saved in this store."""
         all_sql_resources = self._sql_get_all()
@@ -185,6 +192,7 @@ class ProtocolStore:
             for r in all_sql_resources
         ]
 
+    @lru_cache(maxsize=_CACHE_ENTRIES)
     def has(self, protocol_id: str) -> bool:
         """Check for the presence of a protocol ID in the store."""
         statement = sqlalchemy.select(protocol_table).where(
@@ -219,6 +227,8 @@ class ProtocolStore:
         if protocol_dir:
             protocol_dir.rmdir()
 
+        self._clear_caches()
+
         return ProtocolResource(
             protocol_id=protocol_id,
             created_at=deleted_sql_resource.created_at,
@@ -226,6 +236,7 @@ class ProtocolStore:
             source=deleted_source,
         )
 
+    @lru_cache(maxsize=_CACHE_ENTRIES)
     def get_usage_info(self) -> List[ProtocolUsageInfo]:
         """Return information about which protocols are currently being used by runs.
 
@@ -324,6 +335,12 @@ class ProtocolStore:
 
         deleted_resource = _convert_sql_row_to_dataclass(sql_row=row_to_delete)
         return deleted_resource
+
+    def _clear_caches(self) -> None:
+        self.get.cache_clear()
+        self.get_all.cache_clear()
+        self.has.cache_clear()
+        self.get_usage_info.cache_clear()
 
 
 # TODO(mm, 2022-04-18):

--- a/robot-server/robot_server/protocols/protocol_store.py
+++ b/robot-server/robot_server/protocols/protocol_store.py
@@ -236,7 +236,9 @@ class ProtocolStore:
             source=deleted_source,
         )
 
-    @lru_cache(maxsize=_CACHE_ENTRIES)
+    # Note that this is NOT cached like the other getters because we would need
+    # to invalidate the cache whenever the runs table changes, which is not something
+    # that this class can easily monitor.
     def get_usage_info(self) -> List[ProtocolUsageInfo]:
         """Return information about which protocols are currently being used by runs.
 
@@ -340,7 +342,6 @@ class ProtocolStore:
         self.get.cache_clear()
         self.get_all.cache_clear()
         self.has.cache_clear()
-        self.get_usage_info.cache_clear()
 
 
 # TODO(mm, 2022-04-18):

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -80,6 +80,13 @@ async def get_current_run_engine_from_url(
         engine_store: Engine store to pull current run ProtocolEngine.
         run_store: Run data storage.
     """
+    # HACK(mm, 2022-05-19):
+    # This call to run_store.has() is commented out because it
+    # seems to stall the robot, for mysterious reasons.
+    # While it's commented, requests with bad run IDs will incorrectly return
+    # HTTP 409 instead of 404.
+    # https://github.com/Opentrons/opentrons/issues/10333
+
     # if not run_store.has(runId):
     #     raise RunNotFound(detail=f"Run {runId} not found.").as_error(
     #         status.HTTP_404_NOT_FOUND

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -137,8 +137,8 @@ class RunDataManager:
         Raises:
             RunNotFoundError: The given run identifier does not exist.
         """
-        run_resource = self._run_store.get(run_id)
-        state_summary = self._get_state_summary(run_id)
+        run_resource = self._run_store.get(run_id=run_id)
+        state_summary = self._get_state_summary(run_id=run_id)
         current = run_id == self._engine_store.current_run_id
 
         return _build_run(run_resource, state_summary, current)
@@ -172,7 +172,7 @@ class RunDataManager:
         if run_id == self._engine_store.current_run_id:
             await self._engine_store.clear()
         else:
-            self._run_store.remove(run_id)
+            self._run_store.remove(run_id=run_id)
 
     async def update(self, run_id: str, current: Optional[bool]) -> Run:
         """Get and potentially archive a run.
@@ -204,7 +204,7 @@ class RunDataManager:
             )
         else:
             state_summary = self._engine_store.engine.state_view.get_summary()
-            run_resource = self._run_store.get(run_id)
+            run_resource = self._run_store.get(run_id=run_id)
 
         return _build_run(
             run_resource=run_resource,
@@ -273,6 +273,6 @@ class RunDataManager:
         if run_id == self._engine_store.current_run_id:
             result = self._engine_store.engine.state_view.get_summary()
         else:
-            result = self._run_store.get_state_summary(run_id)
+            result = self._run_store.get_state_summary(run_id=run_id)
 
         return result

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -204,7 +204,7 @@ class RunDataManager:
             )
         else:
             state_summary = self._engine_store.engine.state_view.get_summary()
-            run_resource = self._run_store.get(run_id=run_id)
+            run_resource = self._run_store.get(run_id)
 
         return _build_run(
             run_resource=run_resource,

--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -18,6 +18,9 @@ from robot_server.protocols import ProtocolNotFoundError
 from .action_models import RunAction, RunActionType
 
 
+_CACHE_ENTRIES = 32
+
+
 @dataclass(frozen=True)
 class RunResource:
     """An entry in the run store, used to construct response models.
@@ -173,14 +176,14 @@ class RunStore:
         self._clear_caches()
         return run
 
-    @lru_cache(maxsize=32)
+    @lru_cache(maxsize=_CACHE_ENTRIES)
     def has(self, run_id: str) -> bool:
         """Whether a given run exists in the store."""
         statement = sqlalchemy.select(run_table.c.id).where(run_table.c.id == run_id)
         with self._sql_engine.begin() as transaction:
             return transaction.execute(statement).first() is not None
 
-    @lru_cache(maxsize=32)
+    @lru_cache(maxsize=_CACHE_ENTRIES)
     def get(self, run_id: str) -> RunResource:
         """Get a specific run entry by its identifier.
 
@@ -212,7 +215,7 @@ class RunStore:
 
         return _convert_row_to_run(run_row, action_rows)
 
-    @lru_cache(maxsize=32)
+    @lru_cache(maxsize=_CACHE_ENTRIES)
     def get_all(self) -> List[RunResource]:
         """Get all known run resources.
 
@@ -238,7 +241,7 @@ class RunStore:
             for run_row in runs
         ]
 
-    @lru_cache(maxsize=32)
+    @lru_cache(maxsize=_CACHE_ENTRIES)
     def get_state_summary(self, run_id: str) -> Optional[StateSummary]:
         """Get the archived run state summary.
 
@@ -259,7 +262,7 @@ class RunStore:
             else None
         )
 
-    @lru_cache(maxsize=32)
+    @lru_cache(maxsize=_CACHE_ENTRIES)
     def _get_all_unparsed_commands(self, run_id: str) -> List[Dict[str, Any]]:
         select_run_commands = sqlalchemy.select(run_table.c.commands).where(
             run_table.c.id == run_id
@@ -314,7 +317,7 @@ class RunStore:
             commands=sliced_commands,
         )
 
-    @lru_cache(maxsize=32)
+    @lru_cache(maxsize=_CACHE_ENTRIES)
     def get_command(self, run_id: str, command_id: str) -> Command:
         """Get run command by id.
 

--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -2,7 +2,8 @@
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Dict, List, Optional
+from functools import lru_cache
+from typing import Any, Dict, List, Optional, cast
 
 import sqlalchemy
 from pydantic import parse_obj_as
@@ -105,6 +106,7 @@ class RunStore:
 
             action_rows = transaction.execute(select_actions).all()
 
+        self._clear_caches()
         return _convert_row_to_run(row=run_row, action_rows=action_rows)
 
     def insert_action(self, run_id: str, action: RunAction) -> None:
@@ -126,6 +128,8 @@ class RunStore:
                 transaction.execute(insert)
             except sqlalchemy.exc.IntegrityError:
                 raise RunNotFoundError(run_id=run_id)
+
+        self._clear_caches()
 
     def insert(
         self,
@@ -166,14 +170,17 @@ class RunStore:
                 ), "Insert run failed due to unexpected IntegrityError"
                 raise ProtocolNotFoundError(protocol_id=run.protocol_id)
 
+        self._clear_caches()
         return run
 
+    @lru_cache(maxsize=32)
     def has(self, run_id: str) -> bool:
         """Whether a given run exists in the store."""
-        statement = sqlalchemy.select(run_table).where(run_table.c.id == run_id)
+        statement = sqlalchemy.select(run_table.c.id).where(run_table.c.id == run_id)
         with self._sql_engine.begin() as transaction:
             return transaction.execute(statement).first() is not None
 
+    @lru_cache(maxsize=32)
     def get(self, run_id: str) -> RunResource:
         """Get a specific run entry by its identifier.
 
@@ -205,6 +212,7 @@ class RunStore:
 
         return _convert_row_to_run(run_row, action_rows)
 
+    @lru_cache(maxsize=32)
     def get_all(self) -> List[RunResource]:
         """Get all known run resources.
 
@@ -230,6 +238,7 @@ class RunStore:
             for run_row in runs
         ]
 
+    @lru_cache(maxsize=32)
     def get_state_summary(self, run_id: str) -> Optional[StateSummary]:
         """Get the archived run state summary.
 
@@ -248,6 +257,22 @@ class RunStore:
             StateSummary.parse_obj(row.state_summary)
             if row.state_summary is not None
             else None
+        )
+
+    @lru_cache(maxsize=32)
+    def _get_all_unparsed_commands(self, run_id: str) -> List[Dict[str, Any]]:
+        select_run_commands = sqlalchemy.select(run_table.c.commands).where(
+            run_table.c.id == run_id
+        )
+
+        with self._sql_engine.begin() as transaction:
+            try:
+                row = transaction.execute(select_run_commands).one()
+            except sqlalchemy.exc.NoResultFound:
+                raise RunNotFoundError(run_id=run_id)
+
+        return (
+            cast(List[Dict[str, Any]], row.commands) if row.commands is not None else []
         )
 
     def get_commands_slice(
@@ -270,17 +295,7 @@ class RunStore:
         Raises:
             RunNotFoundError: The given run ID was not found.
         """
-        select_run_commands = sqlalchemy.select(run_table.c.commands).where(
-            run_table.c.id == run_id
-        )
-
-        with self._sql_engine.begin() as transaction:
-            try:
-                row = transaction.execute(select_run_commands).one()
-            except sqlalchemy.exc.NoResultFound:
-                raise RunNotFoundError(run_id=run_id)
-
-        command_source_dicts = row.commands if row.commands is not None else []
+        command_source_dicts = self._get_all_unparsed_commands(run_id)
         commands_length = len(command_source_dicts)
         if cursor is None:
             cursor = commands_length - length
@@ -299,6 +314,7 @@ class RunStore:
             commands=sliced_commands,
         )
 
+    @lru_cache(maxsize=32)
     def get_command(self, run_id: str, command_id: str) -> Command:
         """Get run command by id.
 
@@ -321,12 +337,13 @@ class RunStore:
                 row = transaction.execute(select_run_commands).one()
             except sqlalchemy.exc.NoResultFound as e:
                 raise RunNotFoundError(run_id=run_id) from e
-            try:
-                command = next(c for c in row.commands if c["id"] == command_id)
-            except StopIteration as e:
-                raise CommandNotFoundError(command_id=command_id) from e
 
-            return parse_obj_as(Command, command)  # type: ignore[arg-type]
+        try:
+            command = next(c for c in row.commands if c["id"] == command_id)
+        except StopIteration as e:
+            raise CommandNotFoundError(command_id=command_id) from e
+
+        return parse_obj_as(Command, command)  # type: ignore[arg-type]
 
     def remove(self, run_id: str) -> None:
         """Remove a run by its unique identifier.
@@ -345,8 +362,18 @@ class RunStore:
             transaction.execute(delete_actions)
             result = transaction.execute(delete_run)
 
-            if result.rowcount < 1:
-                raise RunNotFoundError(run_id)
+        if result.rowcount < 1:
+            raise RunNotFoundError(run_id)
+
+        self._clear_caches()
+
+    def _clear_caches(self) -> None:
+        self.has.cache_clear()
+        self.get.cache_clear()
+        self.get_all.cache_clear()
+        self.get_state_summary.cache_clear()
+        self.get_command.cache_clear()
+        self._get_all_unparsed_commands.cache_clear()
 
 
 def _convert_row_to_run(

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -136,7 +136,7 @@ async def test_create_protocol_run(
         status=pe_types.EngineStatus.IDLE,
     )
 
-    decoy.when(mock_protocol_store.get(protocol_id)).then_return(protocol_resource)
+    decoy.when(mock_protocol_store.get(protocol_id=protocol_id)).then_return(protocol_resource)
 
     decoy.when(
         await mock_run_data_manager.create(

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -136,7 +136,9 @@ async def test_create_protocol_run(
         status=pe_types.EngineStatus.IDLE,
     )
 
-    decoy.when(mock_protocol_store.get(protocol_id=protocol_id)).then_return(protocol_resource)
+    decoy.when(mock_protocol_store.get(protocol_id=protocol_id)).then_return(
+        protocol_resource
+    )
 
     decoy.when(
         await mock_run_data_manager.create(

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -51,23 +51,28 @@ async def test_get_current_run_engine_from_url(
     assert result is mock_engine_store.engine
 
 
-# async def test_get_current_run_engine_no_run(
-#     decoy: Decoy,
-#     mock_engine_store: EngineStore,
-#     mock_run_store: RunStore,
-# ) -> None:
-#     """It should 404 if the run is not in the store."""
-#     decoy.when(mock_run_store.has("run-id")).then_return(False)
-#
-#     with pytest.raises(ApiError) as exc_info:
-#         await get_current_run_engine_from_url(
-#             runId="run-id",
-#             engine_store=mock_engine_store,
-#             run_store=mock_run_store,
-#         )
-#
-#     assert exc_info.value.status_code == 404
-#     assert exc_info.value.content["errors"][0]["id"] == "RunNotFound"
+# TODO(mm, 2022-05-19): Remove this xfail when we resolve mysteries about
+# performance problems and are able to add the call to run_store.has()
+# back into get_current_run_engine_from_url() without causing stalls.
+# https://github.com/Opentrons/opentrons/issues/10333
+@pytest.mark.xfail(strict=True)
+async def test_get_current_run_engine_no_run(
+    decoy: Decoy,
+    mock_engine_store: EngineStore,
+    mock_run_store: RunStore,
+) -> None:
+    """It should 404 if the run is not in the store."""
+    decoy.when(mock_run_store.has("run-id")).then_return(False)
+
+    with pytest.raises(ApiError) as exc_info:
+        await get_current_run_engine_from_url(
+            runId="run-id",
+            engine_store=mock_engine_store,
+            run_store=mock_run_store,
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.content["errors"][0]["id"] == "RunNotFound"
 
 
 async def test_get_current_run_engine_from_url_not_current(

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -248,13 +248,13 @@ async def test_get_current_run(
     """It should get the current run from the engine."""
     run_id = "hello world"
 
-    decoy.when(mock_run_store.get(run_id)).then_return(run_resource)
+    decoy.when(mock_run_store.get(run_id=run_id)).then_return(run_resource)
     decoy.when(mock_engine_store.current_run_id).then_return(run_id)
     decoy.when(mock_engine_store.engine.state_view.get_summary()).then_return(
         engine_state_summary
     )
 
-    result = subject.get(run_id)
+    result = subject.get(run_id=run_id)
 
     assert result == Run(
         current=True,
@@ -282,13 +282,13 @@ async def test_get_historical_run(
     """It should get a historical run from the store."""
     run_id = "hello world"
 
-    decoy.when(mock_run_store.get(run_id)).then_return(run_resource)
-    decoy.when(mock_run_store.get_state_summary(run_id)).then_return(
+    decoy.when(mock_run_store.get(run_id=run_id)).then_return(run_resource)
+    decoy.when(mock_run_store.get_state_summary(run_id=run_id)).then_return(
         engine_state_summary
     )
     decoy.when(mock_engine_store.current_run_id).then_return("some other id")
 
-    result = subject.get(run_id)
+    result = subject.get(run_id=run_id)
 
     assert result == Run(
         current=False,
@@ -314,11 +314,11 @@ async def test_get_historical_run_no_data(
     """It should get a historical run from the store."""
     run_id = "hello world"
 
-    decoy.when(mock_run_store.get(run_id)).then_return(run_resource)
-    decoy.when(mock_run_store.get_state_summary(run_id)).then_return(None)
+    decoy.when(mock_run_store.get(run_id=run_id)).then_return(run_resource)
+    decoy.when(mock_run_store.get_state_summary(run_id=run_id)).then_return(None)
     decoy.when(mock_engine_store.current_run_id).then_return("some other id")
 
-    result = subject.get(run_id)
+    result = subject.get(run_id=run_id)
 
     assert result == Run(
         current=False,
@@ -424,10 +424,10 @@ async def test_delete_current_run(
     run_id = "hello world"
     decoy.when(mock_engine_store.current_run_id).then_return(run_id)
 
-    await subject.delete(run_id)
+    await subject.delete(run_id=run_id)
 
     decoy.verify(await mock_engine_store.clear(), times=1)
-    decoy.verify(mock_run_store.remove(run_id), times=0)
+    decoy.verify(mock_run_store.remove(run_id=run_id), times=0)
 
 
 async def test_delete_historical_run(
@@ -440,10 +440,10 @@ async def test_delete_historical_run(
     run_id = "hello world"
     decoy.when(mock_engine_store.current_run_id).then_return("some other id")
 
-    await subject.delete(run_id)
+    await subject.delete(run_id=run_id)
 
     decoy.verify(await mock_engine_store.clear(), times=0)
-    decoy.verify(mock_run_store.remove(run_id), times=1)
+    decoy.verify(mock_run_store.remove(run_id=run_id), times=1)
 
 
 async def test_update_current(
@@ -503,7 +503,7 @@ async def test_update_current_noop(
     decoy.when(mock_engine_store.engine.state_view.get_summary()).then_return(
         engine_state_summary
     )
-    decoy.when(mock_run_store.get(run_id)).then_return(run_resource)
+    decoy.when(mock_run_store.get(run_id=run_id)).then_return(run_resource)
 
     result = await subject.update(run_id=run_id, current=current)
 


### PR DESCRIPTION
[PR taken over by @SyntaxColoring]

## Overview

Experimental band-aid fix for #10345 and possibly also #10333.

The robot is sometimes mysteriously stalling. We think database access is sometimes unusually slow. This PR mitigates the problem by avoiding some database access.

## Changelog

- Cache most `RunStore.get*` and `ProtocolStore.get*` methods with `lru_cache`.
- Clear _all_ of the store's `lru_cache`'s in every method that modifies the store.

-----

Unfortunately, `lru_cache` interfere's with Decoy's ability to understand arguments passed to mocks.

This causes a bunch of warnings like:

```
IncorrectCallWarning: missing a required argument: 'self'
```

And forces us to call match the tests' mock calls more exactly to the calls in the production code. (`foo(bar)` is not necessarily recognized as equivalent to `foo(arg=bar)`.)

This is ticketed as https://github.com/mcous/decoy/issues/133.


## Review requests

* [ ] Every getter in `RunStore` and `ProtocolStore` should be marked with `@lru_cache`.
* [ ] Every setter in `RunStore` and `ProtocolStore` **must** contain a call to `self._clear_cache()`.
* [ ] `_clear_cache()` **must** clear the cache of every method that's marked with `@lru_cache`.
* [ ] We're okay with the Decoy warnings described above.
* [ ] We feel this is sufficiently documented and tested.
* [ ] Other than `get_usage_info()`, there are no other cases where changes made through one store should invalidate the data returned by a different store.

## Risk assessment

Medium-high?

* We don't understand the root cause yet.
* Caching is notoriously hard to get right.
* Our stores sometimes coordinate between multiple things (like a SQL database and a `protocols/` directory), so updates can theoretically be non-atomic, especially if there's an unexpected failure in between updating two different things. Adding a caching layer will make this worse: we'll have an inconsistent cache to deal with in addition to inconsistent backing data.
* Our stores sometimes reach into each other's tables, so there are hazards where changes made through one store should invalidate the data returned by a different store.
* It's easy to accidentally forget to clear a cache when we need to.

We should only merge this if:

* [x] We're confident it fixes the problem.
    * See @y3rsh's comment below: https://github.com/Opentrons/opentrons/pull/10344#issuecomment-1132950881
* [x] This code has been reviewed carefully, per the review requests above.
* [x] We have `# TODO`s or a ticket to investigate this further, determine the underlying cause of the mysterious stalls, and determine whether there’s anything else we can do to fix them.
    * See https://github.com/Opentrons/opentrons/issues/10353.
* [x] We have a way of reproducing the problem so that, in the future, we can be confident that we fixed it and that it’s okay to rip this band-aid out.
    * See https://github.com/Opentrons/opentrons/issues/10353.
