### PR TITLE
fix(app-shell): ensure Windows build can analyze protocols

### DIFF
--- a/api/src/opentrons/protocol_runner/legacy_wrappers.py
+++ b/api/src/opentrons/protocol_runner/legacy_wrappers.py
@@ -70,7 +70,7 @@ class LegacyFileReader:
     def read(protocol_source: ProtocolSource) -> LegacyProtocol:
         """Read a PAPIv2 protocol into a datastructure."""
         protocol_file_path = protocol_source.main_file
-        protocol_contents = protocol_file_path.read_text()
+        protocol_contents = protocol_file_path.read_text(encoding="utf-8")
 
         return parse(
             protocol_file=protocol_contents,
@@ -129,7 +129,7 @@ class LegacyContextCreator:
 
 
 class LegacySimulatingContextCreator(LegacyContextCreator):
-    """Interface to construct PAPIv2 contexts using simlulating implementations.
+    """Interface to construct PAPIv2 contexts using simulating implementations.
 
     Avoids some calls to the hardware API for performance.
     See `opentrons.protocols.context.simulator`.

--- a/app-shell/scripts/before-build.js
+++ b/app-shell/scripts/before-build.js
@@ -37,7 +37,10 @@ const PYTHON_BY_PLATFORM = {
 }
 
 const PYTHON_DESTINATION = path.join(__dirname, '..')
-const PYTHON_POST_EXTRACT_LOCATION = path.join(PYTHON_DESTINATION, 'python')
+const PYTHON_PACKAGE_INSTALL_TARGET = path.join(
+  PYTHON_DESTINATION,
+  'python/lib/python3.10/site-packages'
+)
 
 module.exports = function beforeBuild(context) {
   const { platform, arch } = context
@@ -75,24 +78,14 @@ module.exports = function beforeBuild(context) {
 
       // TODO(mc, 2022-05-16): explore virtualenvs for a more reliable
       // implementation of this install
-      return execa(
-        HOST_PYTHON,
-        [
-          '-m',
-          'pip',
-          'install',
-          '--user',
-          '--use-feature=in-tree-build',
-          '--force-reinstall',
-          path.join(__dirname, '../../shared-data/python'),
-          path.join(__dirname, '../../api'),
-        ],
-        {
-          env: {
-            PYTHONUSERBASE: PYTHON_POST_EXTRACT_LOCATION,
-          },
-        }
-      )
+      return execa(HOST_PYTHON, [
+        '-m',
+        'pip',
+        'install',
+        `--target=${PYTHON_PACKAGE_INSTALL_TARGET}`,
+        path.join(__dirname, '../../shared-data/python'),
+        path.join(__dirname, '../../api'),
+      ])
     })
     .then(({ stdout }) => {
       console.log("`opentrons` package installed to app's Python environment")

--- a/app-shell/scripts/before-build.js
+++ b/app-shell/scripts/before-build.js
@@ -29,9 +29,9 @@ const PYTHON_BY_PLATFORM = {
   win32: {
     x64: {
       url:
-        'https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3+20220318-x86_64-pc-windows-msvc-static-install_only.tar.gz',
+        'https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3+20220318-x86_64-pc-windows-msvc-shared-install_only.tar.gz',
       sha256:
-        '3c3e6212fc983640bbe85b9cc60514f80d885892e072d43017b73e1b50a7ad02',
+        'ba593370742ed8a7bc70ce563dd6a53e30ece1f6881e3888d334c1b485b0d9d0',
     },
   },
 }

--- a/app-shell/scripts/before-build.js
+++ b/app-shell/scripts/before-build.js
@@ -37,7 +37,8 @@ const PYTHON_BY_PLATFORM = {
 }
 
 const PYTHON_DESTINATION = path.join(__dirname, '..')
-const PYTHON_POST_EXTRACT_LOCATION = path.join(PYTHON_DESTINATION, 'python')
+const PYTHON_SITE_PACKAGES_TARGET_POSIX = 'python/lib/python3.10/site-packages'
+const PYTHON_SITE_PACKAGES_TARGET_WINDOWS = 'python/Lib/site-packages'
 
 module.exports = function beforeBuild(context) {
   const { platform, arch } = context
@@ -73,25 +74,21 @@ module.exports = function beforeBuild(context) {
     .then(() => {
       console.log('Standalone Python extracted, installing `opentrons` package')
 
+      const sitePackages =
+        platformName === 'win32'
+          ? PYTHON_SITE_PACKAGES_TARGET_WINDOWS
+          : PYTHON_SITE_PACKAGES_TARGET_POSIX
+
       // TODO(mc, 2022-05-16): explore virtualenvs for a more reliable
       // implementation of this install
-      return execa(
-        HOST_PYTHON,
-        [
-          '-m',
-          'pip',
-          'install',
-          '--user',
-          '--ignore-installed',
-          path.join(__dirname, '../../shared-data/python'),
-          path.join(__dirname, '../../api'),
-        ],
-        {
-          env: {
-            PYTHONUSERBASE: PYTHON_POST_EXTRACT_LOCATION,
-          },
-        }
-      )
+      return execa(HOST_PYTHON, [
+        '-m',
+        'pip',
+        'install',
+        `--target=${path.join(PYTHON_DESTINATION, sitePackages)}`,
+        path.join(__dirname, '../../shared-data/python'),
+        path.join(__dirname, '../../api'),
+      ])
     })
     .then(({ stdout }) => {
       console.log("`opentrons` package installed to app's Python environment")

--- a/app-shell/scripts/before-build.js
+++ b/app-shell/scripts/before-build.js
@@ -37,10 +37,8 @@ const PYTHON_BY_PLATFORM = {
 }
 
 const PYTHON_DESTINATION = path.join(__dirname, '..')
-const PYTHON_PACKAGE_INSTALL_TARGET = path.join(
-  PYTHON_DESTINATION,
-  'python/lib/python3.10/site-packages'
-)
+const PYTHON_SITE_PACKAGES_TARGET_POSIX = 'python/lib/python3.10/site-packages'
+const PYTHON_SITE_PACKAGES_TARGET_WINDOWS = 'python/Lib/site-packages'
 
 module.exports = function beforeBuild(context) {
   const { platform, arch } = context
@@ -76,13 +74,18 @@ module.exports = function beforeBuild(context) {
     .then(() => {
       console.log('Standalone Python extracted, installing `opentrons` package')
 
+      const sitePackages =
+        platformName === 'win32'
+          ? PYTHON_SITE_PACKAGES_TARGET_WINDOWS
+          : PYTHON_SITE_PACKAGES_TARGET_POSIX
+
       // TODO(mc, 2022-05-16): explore virtualenvs for a more reliable
       // implementation of this install
       return execa(HOST_PYTHON, [
         '-m',
         'pip',
         'install',
-        `--target=${PYTHON_PACKAGE_INSTALL_TARGET}`,
+        `--target=${path.join(PYTHON_DESTINATION, sitePackages)}`,
         path.join(__dirname, '../../shared-data/python'),
         path.join(__dirname, '../../api'),
       ])

--- a/app-shell/src/protocol-analysis/getPythonPath.ts
+++ b/app-shell/src/protocol-analysis/getPythonPath.ts
@@ -9,8 +9,8 @@ let pythonPath: string | null = null
 export function selectPythonPath(pythonOverride: string | null): void {
   // default candidates for posix and windows
   let candidates = [
-    path.join(process.resourcesPath ?? './', 'python', 'bin', 'python3'),
-    path.join(process.resourcesPath ?? './', 'python'),
+    path.join(process.resourcesPath ?? './', 'python/bin/python3'),
+    path.join(process.resourcesPath ?? './', 'python/python.exe'),
   ]
 
   // add override path, posix path, and windows path at front of candidates
@@ -18,7 +18,7 @@ export function selectPythonPath(pythonOverride: string | null): void {
     candidates = [
       pythonOverride,
       path.join(pythonOverride, 'bin/python3'),
-      path.join(pythonOverride, 'python'),
+      path.join(pythonOverride, 'python.exe'),
       ...candidates,
     ]
   }

--- a/shared-data/python/setup.py
+++ b/shared-data/python/setup.py
@@ -39,8 +39,11 @@ def get_shared_data_files() -> List[Path]:
 
 
 def _minimize_and_write_json(data_file: Path, target_file: Path) -> None:
-    contents = json.dumps(json.loads(data_file.read_text()), separators=(",", ":"))
-    target_file.write_text(contents)
+    contents = json.dumps(
+        json.loads(data_file.read_text(encoding="utf-8")),
+        separators=(",", ":"),
+    )
+    target_file.write_text(contents, encoding="utf-8")
 
 
 class SDistWithData(sdist.sdist):


### PR DESCRIPTION
## Overview

The app-shell's build + Python selection logic was incorrect, meaning that the Windows build of the app was unable to perform app-side protocol analysis. This PR corrects the build and application code.

Fixes #10378.

## Changelog

- Use the `shared` Windows standalone build rather than `static`
    - Upon reading the `python-build-standalone` docs more closely, `shared` is what they recommend
    - Numpy does not work in the `static` build
- Replaced `--user` install of `opentrons` package into the app's environment with `--target`
    - Turns out the `--user` install wasn't actually working in Windows
    - `--target` is the better option for all OS's, anyway; `--user` was a hack 
- Added Windows' `Python.exe` to Python candidates in the app-shell's Python environment selection logic
- Fixed a character encoding issue in the `shared-data` Python package that was causing spurious validation failures

## Review requests

Same as #9949 and #10303:

- [ ] Production macOS app is able to analyze protocols locally without issue
- [ ] Production Windows app ...
- [ ] ~Production Ubuntu app ...~ Moved to https://github.com/Opentrons/opentrons/issues/10396

### Test plan

1. Download production build of the Windows app from this branch
    - [Production build](https://s3.amazonaws.com/opentrons-app/builds/Opentrons-v5.1.0-beta.0-win-b17979-app-shell_remove-in-tree-build.exe) of commit [642c630](https://github.com/Opentrons/opentrons/pull/10347/commits/642c630a77232a8ef42d1a4ba5f1fa991da6178a)
2. Install and launch it on a Windows machine
    - Keep an eye out for any anti-virus or code-signing warnings
4. Open a protocol and **ensure it analyzes**
    - No errors/warnings in the protocol info page
    - Equipment shows up properly
    - Deck map shows up properly

Try to get a variety of protocols tested, if you can:

- [ ] Python v2 protocol
- [ ] Python v2 protocol with modules
- [ ] JSON v5 protocol
- [ ] JSON v5 protocol with modules

## Risk assessment

Low, if built assets are working. There is some risk this breaks local app builds if your local version of pip is older. Upgrading `pip` locally should be enough to fix the issue
