### PR TITLE
docs: add missing close quote in deploy instructions

### DIFF
--- a/scripts/deploy/README.md
+++ b/scripts/deploy/README.md
@@ -20,17 +20,17 @@ Before running any of these scripts, the release in question must be tagged and 
 This process is still manual. Check out the commit you would like to release, and:
 
 ```shell
-git tag -a ${name}@${version} -m 'chore(release): ${name} ${version}'
+git tag -a ${name}@${version} -m "chore(release): ${name} ${version}"
 git push --tags
 ```
 
-- `name` - The name of the project in the monorepo
+- `name` - The name of the project in the monorepo. Make sure this matches the directory name exactly, as it determines what actions are triggered when the tag is pushed.
 - `version` - The version to bump to
 
 For example, to bump Protocol Designer to version 3.0.0:
 
 ```shell
-git tag -a protocol-designer@3.0.0 -m 'chore(release): protocol-designer 3.0.0'
+git tag -a protocol-designer@3.0.0 -m "chore(release): protocol-designer 3.0.0"
 git push --tags
 ```
 

--- a/scripts/deploy/README.md
+++ b/scripts/deploy/README.md
@@ -20,7 +20,7 @@ Before running any of these scripts, the release in question must be tagged and 
 This process is still manual. Check out the commit you would like to release, and:
 
 ```shell
-git tag -a ${name}@${version} -m 'chore(release): ${name} ${version}
+git tag -a ${name}@${version} -m 'chore(release): ${name} ${version}'
 git push --tags
 ```
 


### PR DESCRIPTION

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

Spotted this while doing a docs deploy.
Might also be good to add a line about `{name}` having to exactly match the directory name, that tripped me up.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

Added close quote.

# Review requests

<!--
Describe any requests for your reviewers here.
-->

Maybe add that clarification?

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

Readme only.