### PR TITLE
refactor(app): fix thermocycler and H-S module controls

### DIFF
--- a/app/src/organisms/Devices/ModuleCard/ConfirmAttachmentModal.tsx
+++ b/app/src/organisms/Devices/ModuleCard/ConfirmAttachmentModal.tsx
@@ -45,6 +45,7 @@ export const ConfirmAttachmentModal = (
       dispatch(setHeaterShakerAttached(isDismissed))
     }
     onConfirmClick()
+    onCloseClick()
   }
 
   return (

--- a/app/src/organisms/Devices/ModuleCard/ThermocyclerModuleData.tsx
+++ b/app/src/organisms/Devices/ModuleCard/ThermocyclerModuleData.tsx
@@ -97,7 +97,7 @@ export const ThermocyclerModuleData = (
           fontSize={FONT_SIZE_CAPTION}
           marginBottom={SPACING.spacing1}
         >
-          {t(lidTarget === null ? 'na_temp' : 'target_temp', {
+          {t(lidTarget == null ? 'na_temp' : 'target_temp', {
             temp: lidTarget,
           })}
         </Text>
@@ -124,7 +124,7 @@ export const ThermocyclerModuleData = (
           fontSize={FONT_SIZE_CAPTION}
           marginBottom={SPACING.spacing1}
         >
-          {t(targetTemp === null ? 'na_temp' : 'target_temp', {
+          {t(targetTemp == null ? 'na_temp' : 'target_temp', {
             temp: targetTemp,
           })}
         </Text>

--- a/app/src/organisms/Devices/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
@@ -93,11 +93,11 @@ const mockDeactivateHeatHeaterShaker = {
   data: {
     labwareLatchStatus: 'idle_open',
     speedStatus: 'idle',
-    temperatureStatus: 'idle',
+    temperatureStatus: 'holding at target',
     currentSpeed: null,
     currentTemperature: null,
     targetSpeed: null,
-    targetTemp: null,
+    targetTemp: 45,
     errorDetails: null,
     status: 'heating',
   },

--- a/app/src/organisms/Devices/ModuleCard/__tests__/hooks.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/hooks.test.tsx
@@ -86,7 +86,7 @@ const mockHeatHeaterShaker = {
   data: {
     labwareLatchStatus: 'idle_open',
     speedStatus: 'idle',
-    temperatureStatus: 'idle',
+    temperatureStatus: 'holding at target',
     currentSpeed: null,
     currentTemperature: null,
     targetSpeed: null,
@@ -164,7 +164,7 @@ const mockTCBlockHeating = {
     lidTargetTemperature: null,
     lidTemperature: null,
     currentTemperature: null,
-    targetTemperature: null,
+    targetTemperature: 45,
     holdTime: null,
     rampRate: null,
     currentCycleIndex: null,

--- a/app/src/organisms/Devices/ModuleCard/hooks.tsx
+++ b/app/src/organisms/Devices/ModuleCard/hooks.tsx
@@ -6,7 +6,6 @@ import {
 import { useTranslation } from 'react-i18next'
 import { useHoverTooltip } from '@opentrons/components'
 import {
-  CreateCommand,
   HEATERSHAKER_MODULE_TYPE,
   MAGNETIC_MODULE_TYPE,
   TEMPERATURE_MODULE_TYPE,
@@ -105,6 +104,14 @@ interface ModuleOverflowMenu {
   menuOverflowItemsByModuleType: MenuItemsByModuleType
 }
 
+type deactivateCommandTypes =
+  | 'thermocycler/deactivateLid'
+  | 'thermocycler/deactivateBlock'
+  | 'temperatureModule/deactivate'
+  | 'magneticModule/disengage'
+  | 'heaterShakerModule/stopShake'
+  | 'heaterShakerModule/deactivateHeater'
+
 export function useModuleOverflowMenu(
   module: AttachedModule,
   runId: string | null = null,
@@ -118,44 +125,6 @@ export function useModuleOverflowMenu(
   const { createCommand } = useCreateCommandMutation()
   const { toggleLatch, isLatchClosed } = useLatchControls(module, runId)
   const [targetProps, tooltipProps] = useHoverTooltip()
-
-  let deactivateModuleCommandType: CreateCommand['commandType']
-  switch (module.moduleType) {
-    case 'temperatureModuleType': {
-      deactivateModuleCommandType = 'temperatureModule/deactivate'
-      break
-    }
-    case 'magneticModuleType': {
-      deactivateModuleCommandType = 'magneticModule/disengage'
-      break
-    }
-    case 'thermocyclerModuleType': {
-      deactivateModuleCommandType =
-        module.data.lidTargetTemperature !== null &&
-        module.data.status !== 'idle'
-          ? 'thermocycler/deactivateLid'
-          : 'thermocycler/deactivateBlock'
-      break
-    }
-    case 'heaterShakerModuleType': {
-      deactivateModuleCommandType =
-        module.data.speedStatus !== 'idle'
-          ? 'heaterShakerModule/stopShake'
-          : 'heaterShakerModule/deactivateHeater'
-      break
-    }
-  }
-
-  const deactivateCommand:
-    | TemperatureModuleDeactivateCreateCommand
-    | MagneticModuleDisengageCreateCommand
-    | HeaterShakerDeactivateHeaterCreateCommand
-    | TCDeactivateLidCreateCommand
-    | TCDeactivateBlockCreateCommand
-    | HeaterShakerStopShakeCreateCommand = {
-    commandType: deactivateModuleCommandType,
-    params: { moduleId: module.id },
-  }
 
   const isLatchDisabled =
     module.moduleType === HEATERSHAKER_MODULE_TYPE &&
@@ -215,7 +184,19 @@ export function useModuleOverflowMenu(
     </MenuItem>
   )
 
-  const handleDeactivationCommand = (): void => {
+  const handleDeactivationCommand = (
+    deactivateModuleCommandType: deactivateCommandTypes
+  ): void => {
+    const deactivateCommand:
+      | TemperatureModuleDeactivateCreateCommand
+      | MagneticModuleDisengageCreateCommand
+      | HeaterShakerDeactivateHeaterCreateCommand
+      | TCDeactivateLidCreateCommand
+      | TCDeactivateBlockCreateCommand
+      | HeaterShakerStopShakeCreateCommand = {
+      commandType: deactivateModuleCommandType,
+      params: { moduleId: module.id },
+    }
     if (runId != null) {
       createCommand({
         runId: runId,
@@ -236,17 +217,12 @@ export function useModuleOverflowMenu(
     }
   }
 
-  const onClick =
-    module.data.status !== 'idle'
-      ? () => handleDeactivationCommand()
-      : () => handleSlideoutClick(false)
-
   const menuOverflowItemsByModuleType = {
     thermocyclerModuleType: [
       {
         setSetting:
           module.moduleType === THERMOCYCLER_MODULE_TYPE &&
-          module.data.lidTargetTemperature !== null
+          module.data.lidTargetTemperature != null
             ? t('overflow_menu_deactivate_lid')
             : t('overflow_menu_lid_temp'),
         isSecondary: true,
@@ -254,8 +230,8 @@ export function useModuleOverflowMenu(
         menuButtons: null,
         onClick:
           module.moduleType === THERMOCYCLER_MODULE_TYPE &&
-          module.data.lidTargetTemperature !== null
-            ? () => handleDeactivationCommand()
+          module.data.lidTargetTemperature != null
+            ? () => handleDeactivationCommand('thermocycler/deactivateLid')
             : () => handleSlideoutClick(true),
       },
       {
@@ -267,7 +243,11 @@ export function useModuleOverflowMenu(
         isSecondary: false,
         disabledReason: false,
         menuButtons: [aboutModuleBtn],
-        onClick: onClick,
+        onClick:
+          module.moduleType === THERMOCYCLER_MODULE_TYPE &&
+          module.data.targetTemperature != null
+            ? () => handleDeactivationCommand('thermocycler/deactivateBlock')
+            : () => handleSlideoutClick(false),
       },
     ],
     temperatureModuleType: [
@@ -280,7 +260,10 @@ export function useModuleOverflowMenu(
         isSecondary: false,
         disabledReason: false,
         menuButtons: [aboutModuleBtn],
-        onClick: onClick,
+        onClick:
+          module.data.status !== 'idle'
+            ? () => handleDeactivationCommand('temperatureModule/deactivate')
+            : () => handleSlideoutClick(false),
       },
     ],
     magneticModuleType: [
@@ -290,13 +273,12 @@ export function useModuleOverflowMenu(
           module.data.status !== 'disengaged'
             ? t('overflow_menu_disengage')
             : t('overflow_menu_engage'),
-
         isSecondary: false,
         disabledReason: false,
         menuButtons: [aboutModuleBtn],
         onClick:
           module.data.status !== 'disengaged'
-            ? () => handleDeactivationCommand()
+            ? () => handleDeactivationCommand('magneticModule/disengage')
             : () => handleSlideoutClick(false),
       },
     ],
@@ -304,20 +286,27 @@ export function useModuleOverflowMenu(
       {
         setSetting:
           module.moduleType === HEATERSHAKER_MODULE_TYPE &&
-          module.data.status !== 'idle'
+          module.data.temperatureStatus !== 'idle'
             ? t('deactivate', { ns: 'heater_shaker' })
             : t('set_temperature', { ns: 'heater_shaker' }),
         isSecondary: false,
         disabledReason: false,
         menuButtons: null,
-        onClick: onClick,
+        onClick:
+          module.moduleType === HEATERSHAKER_MODULE_TYPE &&
+          module.data.temperatureStatus !== 'idle' &&
+          module.data.status !== 'idle'
+            ? () =>
+                handleDeactivationCommand('heaterShakerModule/deactivateHeater')
+            : () => handleSlideoutClick(false),
       },
       {
         setSetting:
           module.moduleType === HEATERSHAKER_MODULE_TYPE &&
-          module.data.status === 'idle'
-            ? t('set_shake_speed', { ns: 'heater_shaker' })
-            : t('stop_shaking', { ns: 'heater_shaker' }),
+          module.data.speedStatus !== 'idle' &&
+          module.data.status !== 'idle'
+            ? t('stop_shaking', { ns: 'heater_shaker' })
+            : t('set_shake_speed', { ns: 'heater_shaker' }),
         isSecondary: true,
         disabledReason:
           module.moduleType === HEATERSHAKER_MODULE_TYPE &&
@@ -332,7 +321,7 @@ export function useModuleOverflowMenu(
         onClick:
           module.moduleType === HEATERSHAKER_MODULE_TYPE &&
           module.data.speedStatus !== 'idle'
-            ? () => handleDeactivationCommand()
+            ? () => handleDeactivationCommand('heaterShakerModule/stopShake')
             : () => handleSlideoutClick(true),
       },
     ],


### PR DESCRIPTION

# Overview

This PR fixes the bug where clicking `deactivate block` would actually send a request to deactivate the lid. It also fixes a similar issue with the heater shaker controls where when the heater is active the menu would also think the shaker was active too. 

closes #10021

# Changelog

- Refactored `useModuleOverflowMenu`

# Review requests

- Clicking `deactivate lid` should send a deactivate lid command.
- Clicking `deactivate block` should send a deactivate block command.
- Setting a temperature on the heater shaker only should change the menu button to deactivate and not change the `set shake speed button` to `stop shake`.

# Risk assessment

low