### PR TITLE
refactor(app): implement download run log, with toast

### DIFF
--- a/app/src/assets/localization/en/run_details.json
+++ b/app/src/assets/localization/en/run_details.json
@@ -82,6 +82,7 @@
   "clear_protocol": "Clear protocol",
   "clear_protocol_to_make_available": "Clear protocol from robot to make it available.",
   "download_run_log": "Download run log",
+  "downloading_run_log": "Downloading run log",
   "jump_to_current_step": "Jump to current step",
   "run_has_diverged_from_predicted": "Run has diverged from predicted state. Cannot anticipate new steps.",
   "unable_to_determine_steps": "Unable to determine steps",

--- a/app/src/atoms/Toast/index.tsx
+++ b/app/src/atoms/Toast/index.tsx
@@ -65,7 +65,7 @@ const toastStyleByType: {
   },
   info: {
     iconName: 'information',
-    color: COLORS.darkBlack,
+    color: COLORS.darkGreyEnabled,
     backgroundColor: COLORS.greyDisabled,
   },
 }

--- a/app/src/atoms/Toast/index.tsx
+++ b/app/src/atoms/Toast/index.tsx
@@ -15,9 +15,11 @@ import {
 import type { IconProps } from '@opentrons/components'
 import { StyledText } from '../text'
 
+type ToastType = 'success' | 'warning' | 'error' | 'info'
+
 export interface ToastProps {
   message: string | JSX.Element
-  type?: 'success' | 'warning' | 'error' | 'info'
+  type: ToastType
   icon?: IconProps
   closeButton?: boolean
   onClose: () => void
@@ -38,24 +40,38 @@ const EXPANDED_STYLE = css`
     }
   }
 `
+
+const toastStyleByType: {
+  [k in ToastType]: {
+    iconName: IconName
+    color: string
+    backgroundColor: string
+  }
+} = {
+  error: {
+    iconName: 'alert-circle',
+    color: COLORS.error,
+    backgroundColor: COLORS.errorBg,
+  },
+  warning: {
+    iconName: 'alert-circle',
+    color: COLORS.warning,
+    backgroundColor: COLORS.warningBg,
+  },
+  success: {
+    iconName: 'check-circle',
+    color: COLORS.success,
+    backgroundColor: COLORS.successBg,
+  },
+  info: {
+    iconName: 'information',
+    color: COLORS.darkBlack,
+    backgroundColor: COLORS.greyDisabled,
+  },
+}
+
 export function Toast(props: ToastProps): JSX.Element {
   const { message, type, icon, closeButton, onClose, requiredTimeout } = props
-  let iconName: IconName = 'alert-circle'
-  let color = COLORS.error
-  let backgroundColor = COLORS.errorBg
-
-  if (type === 'warning') {
-    color = COLORS.warning
-    backgroundColor = COLORS.warningBg
-  } else if (type === 'success') {
-    iconName = 'check-circle'
-    color = COLORS.success
-    backgroundColor = COLORS.successBg
-  } else {
-    iconName = icon?.name != null ? icon.name : 'information'
-    color = COLORS.darkBlack
-    backgroundColor = COLORS.greyDisabled
-  }
 
   if (!(requiredTimeout ?? false)) {
     setTimeout(() => {
@@ -69,10 +85,10 @@ export function Toast(props: ToastProps): JSX.Element {
       justifyContent={JUSTIFY_SPACE_BETWEEN}
       alignItems={ALIGN_CENTER}
       borderRadius={BORDERS.radiusSoftCorners}
-      borderColor={color}
+      borderColor={toastStyleByType[type].color}
       borderWidth={SPACING.spacingXXS}
       border={BORDER_STYLE_SOLID}
-      backgroundColor={backgroundColor}
+      backgroundColor={toastStyleByType[type].backgroundColor}
       paddingX={SPACING.spacing3}
       paddingY={SPACING.spacing2}
       right={SPACING.spacing4}
@@ -82,8 +98,8 @@ export function Toast(props: ToastProps): JSX.Element {
     >
       <Flex flexDirection="row">
         <Icon
-          name={iconName}
-          color={color}
+          name={icon?.name ?? toastStyleByType[type].iconName}
+          color={toastStyleByType[type].color}
           width={SPACING.spacing4}
           marginRight={SPACING.spacing3}
           spin={icon?.spin != null ? icon.spin : false}

--- a/app/src/organisms/Devices/DownloadRunLogToast.tsx
+++ b/app/src/organisms/Devices/DownloadRunLogToast.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { IconProps } from '@opentrons/components'
+import { useAllCommandsQuery, useRunQuery } from '@opentrons/react-api-client'
+
+import { Toast } from '../../atoms/Toast'
+import { useProtocolDetailsForRun } from './hooks'
+import { downloadFile } from './utils'
+
+interface DownloadRunLogToastProps {
+  robotName: string
+  runId: string
+  onClose: () => unknown
+  pageLength: number
+}
+
+export function DownloadRunLogToast({
+  robotName,
+  runId,
+  pageLength,
+  onClose,
+}: DownloadRunLogToastProps): JSX.Element {
+  const { t } = useTranslation('run_details')
+
+  const {
+    data: allCommandsQueryData,
+    error: allCommandsQueryError,
+    isError: isAllCommandsQueryError,
+  } = useAllCommandsQuery(
+    runId,
+    {
+      cursor: 0,
+      pageLength,
+    },
+    { staleTime: Infinity }
+  )
+  const commands = allCommandsQueryData?.data
+
+  const {
+    data: runQueryData,
+    error: runQueryError,
+    isError: isRunQueryError,
+  } = useRunQuery(runId, { staleTime: Infinity })
+  const run = runQueryData?.data
+
+  const isError = isAllCommandsQueryError || isRunQueryError
+  // prioritize display of commands error
+  const errorMessage =
+    allCommandsQueryError?.message ?? runQueryError?.message ?? ''
+
+  const { displayName } = useProtocolDetailsForRun(runId)
+  const protocolName = displayName ?? run?.protocolId ?? ''
+
+  const toastIcon: IconProps = { name: 'ot-spinner', spin: true }
+
+  React.useEffect(() => {
+    if (commands != null && run != null) {
+      const runDetails = {
+        ...run,
+        commands,
+      }
+      const createdAt = new Date(run.createdAt).toISOString()
+      const fileName = `${robotName}_${protocolName}_${createdAt}.json`
+      downloadFile(runDetails, fileName)
+      onClose()
+    }
+  }, [commands, protocolName, robotName, run, onClose])
+
+  return (
+    <Toast
+      message={isError ? errorMessage : t('downloading_run_log')}
+      type={isError ? 'error' : 'info'}
+      icon={isError ? undefined : toastIcon}
+      closeButton={isError}
+      onClose={onClose}
+      requiredTimeout={true}
+    />
+  )
+}

--- a/app/src/organisms/Devices/DownloadRunLogToast.tsx
+++ b/app/src/organisms/Devices/DownloadRunLogToast.tsx
@@ -11,7 +11,7 @@ import { downloadFile } from './utils'
 interface DownloadRunLogToastProps {
   robotName: string
   runId: string
-  onClose: () => unknown
+  onClose: () => void
   pageLength: number
 }
 

--- a/app/src/organisms/Devices/HistoricalProtocolRun.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRun.tsx
@@ -103,8 +103,7 @@ export function HistoricalProtocolRun(
           {duration}
         </StyledText>
         <OverflowMenu
-          run={run}
-          protocolName={protocolName}
+          runId={run.id}
           robotName={robotName}
           robotIsBusy={robotIsBusy}
           data-testid={`RecentProtocolRuns_OverflowButton_${props.key}`}

--- a/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
@@ -18,12 +18,11 @@ import { Divider } from '../../atoms/structure'
 import { OverflowBtn } from '../../atoms/MenuList/OverflowBtn'
 import { MenuItem } from '../../atoms/MenuList/MenuItem'
 import { useRunControls } from '../RunTimeControl/hooks'
-import { downloadFile } from './utils'
-import type { Run, RunData } from '@opentrons/api-client'
+import { DownloadRunLogToast } from './DownloadRunLogToast'
+import type { Run } from '@opentrons/api-client'
 
 export interface HistoricalProtocolRunOverflowMenuProps {
-  run: RunData
-  protocolName: string
+  runId: string
   robotName: string
   robotIsBusy: boolean
 }
@@ -31,32 +30,62 @@ export interface HistoricalProtocolRunOverflowMenuProps {
 export function HistoricalProtocolRunOverflowMenu(
   props: HistoricalProtocolRunOverflowMenuProps
 ): JSX.Element {
+  const { runId, robotName } = props
   const [showOverflowMenu, setShowOverflowMenu] = React.useState<boolean>(false)
+  const [
+    showDownloadRunLogToast,
+    setShowDownloadRunLogToast,
+  ] = React.useState<boolean>(false)
   const handleOverflowClick: React.MouseEventHandler<HTMLButtonElement> = e => {
     e.preventDefault()
     e.stopPropagation()
     setShowOverflowMenu(!showOverflowMenu)
   }
+
+  const commands = useAllCommandsQuery(
+    runId,
+    { cursor: 0, pageLength: 1 },
+    { staleTime: Infinity }
+  )
+  const runTotalCommandCount = commands?.data?.meta?.totalLength
+
   return (
     <Flex flexDirection={DIRECTION_COLUMN} position={POSITION_RELATIVE}>
       <OverflowBtn alignSelf={ALIGN_FLEX_END} onClick={handleOverflowClick} />
       {showOverflowMenu && (
-        <MenuDropdown {...props} closeOverflowMenu={handleOverflowClick} />
+        <MenuDropdown
+          {...props}
+          closeOverflowMenu={handleOverflowClick}
+          setShowDownloadRunLogToast={setShowDownloadRunLogToast}
+        />
       )}
+      {runTotalCommandCount != null && showDownloadRunLogToast ? (
+        <DownloadRunLogToast
+          robotName={robotName}
+          runId={runId}
+          pageLength={runTotalCommandCount}
+          onClose={() => setShowDownloadRunLogToast(false)}
+        />
+      ) : null}
     </Flex>
   )
 }
 
 interface MenuDropdownProps extends HistoricalProtocolRunOverflowMenuProps {
   closeOverflowMenu: React.MouseEventHandler<HTMLButtonElement>
+  setShowDownloadRunLogToast: (showDownloadRunLogToastValue: boolean) => void
 }
 function MenuDropdown(props: MenuDropdownProps): JSX.Element {
   const { t } = useTranslation('device_details')
   const history = useHistory()
 
-  const { run, robotName, protocolName, robotIsBusy, closeOverflowMenu } = props
-  const runId = run.id
-  const commands = useAllCommandsQuery(runId)
+  const {
+    runId,
+    robotName,
+    robotIsBusy,
+    closeOverflowMenu,
+    setShowDownloadRunLogToast,
+  } = props
 
   const onResetSuccess = (createRunResponse: Run): void =>
     history.push(
@@ -65,13 +94,7 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
   const onDownloadClick: React.MouseEventHandler<HTMLButtonElement> = e => {
     e.preventDefault()
     e.stopPropagation()
-    const runDetails = {
-      ...run,
-      commands: commands,
-    }
-    const createdAt = new Date(run.createdAt).toISOString()
-    const fileName = `${robotName}_${protocolName}_${createdAt}.json`
-    downloadFile(runDetails, fileName)
+    setShowDownloadRunLogToast(true)
     closeOverflowMenu(e)
   }
   const { reset } = useRunControls(runId, onResetSuccess)

--- a/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
@@ -18,6 +18,7 @@ import { Divider } from '../../atoms/structure'
 import { OverflowBtn } from '../../atoms/MenuList/OverflowBtn'
 import { MenuItem } from '../../atoms/MenuList/MenuItem'
 import { useRunControls } from '../RunTimeControl/hooks'
+import { RUN_LOG_WINDOW_SIZE } from './constants'
 import { DownloadRunLogToast } from './DownloadRunLogToast'
 import type { Run } from '@opentrons/api-client'
 
@@ -44,7 +45,7 @@ export function HistoricalProtocolRunOverflowMenu(
 
   const commands = useAllCommandsQuery(
     runId,
-    { cursor: 0, pageLength: 1 },
+    { cursor: 0, pageLength: RUN_LOG_WINDOW_SIZE },
     { staleTime: Infinity }
   )
   const runTotalCommandCount = commands?.data?.meta?.totalLength

--- a/app/src/organisms/Devices/ProtocolRun/RunLog.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/RunLog.tsx
@@ -40,6 +40,7 @@ import {
   useRunTimestamps,
 } from '../../../organisms/RunTimeControl/hooks'
 import { useProtocolDetailsForRun } from '../hooks'
+import { DownloadRunLogToast } from '../DownloadRunLogToast'
 import { RunLogProtocolSetupInfo } from './RunLogProtocolSetupInfo'
 import { StepItem } from './StepItem'
 
@@ -78,6 +79,10 @@ export function RunLog({ robotName, runId }: RunLogProps): JSX.Element | null {
   const firstPostInitialPlayRunCommandIndex = React.useRef<number | null>(null)
   const [isDeterministic, setIsDeterministic] = React.useState<boolean>(true)
   const [windowIndex, setWindowIndex] = React.useState<number>(0)
+  const [
+    showDownloadRunLogToast,
+    setShowDownloadRunLogToast,
+  ] = React.useState<boolean>(false)
 
   const windowFirstCommandIndex = (WINDOW_SIZE - WINDOW_OVERLAP) * windowIndex
   const prePlayCommandCount =
@@ -312,7 +317,7 @@ export function RunLog({ robotName, runId }: RunLogProps): JSX.Element | null {
   }
 
   const onClickDownloadRunLog = (): void => {
-    console.log('TODO: download run log')
+    setShowDownloadRunLogToast(true)
   }
 
   const isRunStarted = currentItemRef.current != null
@@ -356,6 +361,14 @@ export function RunLog({ robotName, runId }: RunLogProps): JSX.Element | null {
       width="100%"
       overflowY="hidden"
     >
+      {runTotalCommandCount != null && showDownloadRunLogToast ? (
+        <DownloadRunLogToast
+          robotName={robotName}
+          runId={runId}
+          pageLength={runTotalCommandCount}
+          onClose={() => setShowDownloadRunLogToast(false)}
+        />
+      ) : null}
       {jumpToCurrentStepButton}
       {isFirstWindow ? (
         <>

--- a/app/src/organisms/Devices/ProtocolRun/RunLog.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/RunLog.tsx
@@ -39,6 +39,7 @@ import {
   useRunStatus,
   useRunTimestamps,
 } from '../../../organisms/RunTimeControl/hooks'
+import { RUN_LOG_WINDOW_SIZE } from '../constants'
 import { useProtocolDetailsForRun } from '../hooks'
 import { DownloadRunLogToast } from '../DownloadRunLogToast'
 import { RunLogProtocolSetupInfo } from './RunLogProtocolSetupInfo'
@@ -48,12 +49,11 @@ import type { RunCommandSummary } from '@opentrons/api-client'
 import type { RunTimeCommand, CommandStatus } from '@opentrons/shared-data'
 
 const AVERAGE_ITEM_HEIGHT_PX = 52 // average px height of a command item
-const WINDOW_SIZE = 60 // number of command items rendered at a time
 const WINDOW_OVERLAP = 40 // number of command items that fall within two adjacent windows
 const NUM_EAGER_ITEMS = 5 // number of command items away from the end of the current window that will trigger a window transition if scrolled into view
 const COMMANDS_REFETCH_INTERVAL = 3000
 const AVERAGE_WINDOW_HEIGHT_PX =
-  (WINDOW_SIZE - WINDOW_OVERLAP) * AVERAGE_ITEM_HEIGHT_PX
+  (RUN_LOG_WINDOW_SIZE - WINDOW_OVERLAP) * AVERAGE_ITEM_HEIGHT_PX
 interface CommandRuntimeInfo {
   analysisCommand: RunTimeCommand | null // analysisCommand will only be null if protocol is nondeterministic
   runCommandSummary: RunCommandSummary | null
@@ -84,7 +84,8 @@ export function RunLog({ robotName, runId }: RunLogProps): JSX.Element | null {
     setShowDownloadRunLogToast,
   ] = React.useState<boolean>(false)
 
-  const windowFirstCommandIndex = (WINDOW_SIZE - WINDOW_OVERLAP) * windowIndex
+  const windowFirstCommandIndex =
+    (RUN_LOG_WINDOW_SIZE - WINDOW_OVERLAP) * windowIndex
   const prePlayCommandCount =
     firstPostInitialPlayRunCommandIndex.current != null
       ? firstPostInitialPlayRunCommandIndex.current
@@ -93,7 +94,7 @@ export function RunLog({ robotName, runId }: RunLogProps): JSX.Element | null {
     runId,
     {
       cursor: windowFirstCommandIndex + prePlayCommandCount,
-      pageLength: WINDOW_SIZE,
+      pageLength: RUN_LOG_WINDOW_SIZE,
     },
     {
       refetchInterval: COMMANDS_REFETCH_INTERVAL,
@@ -178,11 +179,11 @@ export function RunLog({ robotName, runId }: RunLogProps): JSX.Element | null {
 
   const commandWindow = currentCommandList.slice(
     windowFirstCommandIndex,
-    windowFirstCommandIndex + WINDOW_SIZE
+    windowFirstCommandIndex + RUN_LOG_WINDOW_SIZE
   )
   const isFirstWindow = windowIndex === 0
   const isFinalWindow =
-    currentCommandList.length <= windowFirstCommandIndex + WINDOW_SIZE
+    currentCommandList.length <= windowFirstCommandIndex + RUN_LOG_WINDOW_SIZE
 
   const currentCommandIndex = currentCommandList.findIndex(
     command => command?.analysisCommand?.key === currentCommandKey
@@ -233,14 +234,18 @@ export function RunLog({ robotName, runId }: RunLogProps): JSX.Element | null {
   // actually want the first window that contains the current command, in order to show as many
   // commands as possible and avoid an extra small final window
   const isCurrentCommandInFinalWindow =
-    currentCommandList.length - 1 - currentCommandIndex <= WINDOW_SIZE
+    currentCommandList.length - 1 - currentCommandIndex <= RUN_LOG_WINDOW_SIZE
 
   const indexOfFirstWindowContainingCurrentCommand = Math.ceil(
-    (currentCommandIndex + 1 - WINDOW_SIZE) / (WINDOW_SIZE - WINDOW_OVERLAP)
+    (currentCommandIndex + 1 - RUN_LOG_WINDOW_SIZE) /
+      (RUN_LOG_WINDOW_SIZE - WINDOW_OVERLAP)
   )
   const indexOfLastWindowContainingCurrentCommand = Math.floor(
-    Math.max(currentCommandIndex + 1 - (WINDOW_SIZE - WINDOW_OVERLAP), 0) /
-      (WINDOW_SIZE - WINDOW_OVERLAP)
+    Math.max(
+      currentCommandIndex + 1 - (RUN_LOG_WINDOW_SIZE - WINDOW_OVERLAP),
+      0
+    ) /
+      (RUN_LOG_WINDOW_SIZE - WINDOW_OVERLAP)
   )
 
   // when we initially mount, if the current item is not in view, jump to it
@@ -277,22 +282,24 @@ export function RunLog({ robotName, runId }: RunLogProps): JSX.Element | null {
 
   const topBufferHeightPx = windowFirstCommandIndex * AVERAGE_ITEM_HEIGHT_PX
   const bottomBufferHeightPx =
-    (currentCommandList.length - (windowFirstCommandIndex + WINDOW_SIZE)) *
+    (currentCommandList.length -
+      (windowFirstCommandIndex + RUN_LOG_WINDOW_SIZE)) *
     AVERAGE_ITEM_HEIGHT_PX
 
   const onScroll = (): void => {
     if (listInnerRef.current) {
       const { scrollTop, clientHeight } = listInnerRef.current
       const potentialNextWindowFirstIndex =
-        windowFirstCommandIndex + (WINDOW_SIZE - WINDOW_OVERLAP)
+        windowFirstCommandIndex + (RUN_LOG_WINDOW_SIZE - WINDOW_OVERLAP)
       const potentialPrevWindowFirstIndex =
-        windowFirstCommandIndex - (WINDOW_SIZE - WINDOW_OVERLAP)
+        windowFirstCommandIndex - (RUN_LOG_WINDOW_SIZE - WINDOW_OVERLAP)
 
       const prevWindowBoundary =
         topBufferHeightPx + NUM_EAGER_ITEMS * AVERAGE_ITEM_HEIGHT_PX
       const nextWindowBoundary =
         topBufferHeightPx +
-        Math.max(WINDOW_SIZE - NUM_EAGER_ITEMS, 0) * AVERAGE_ITEM_HEIGHT_PX -
+        Math.max(RUN_LOG_WINDOW_SIZE - NUM_EAGER_ITEMS, 0) *
+          AVERAGE_ITEM_HEIGHT_PX -
         clientHeight
       if (
         !isFinalWindow &&

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/RunLog.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/RunLog.test.tsx
@@ -14,6 +14,7 @@ import {
   useRunStatus,
   useRunTimestamps,
 } from '../../../../organisms/RunTimeControl/hooks'
+import { DownloadRunLogToast } from '../../DownloadRunLogToast'
 import { useProtocolDetailsForRun } from '../../hooks'
 import { RunLogProtocolSetupInfo } from '../RunLogProtocolSetupInfo'
 import { StepItemComponent as StepItem } from '../StepItem'
@@ -26,6 +27,7 @@ import type { RunTimestamps } from '../../../../organisms/RunTimeControl/hooks'
 jest.mock('@opentrons/react-api-client')
 jest.mock('../../../../organisms/Labware/helpers/getAllDefs')
 jest.mock('../../../../organisms/RunTimeControl/hooks')
+jest.mock('../../DownloadRunLogToast')
 jest.mock('../../hooks')
 jest.mock('../RunLogProtocolSetupInfo')
 jest.mock('../StepItem')
@@ -49,6 +51,9 @@ const mockRunLogProtocolSetupInfo = RunLogProtocolSetupInfo as jest.MockedFuncti
   typeof RunLogProtocolSetupInfo
 >
 const mockStepItem = StepItem as jest.MockedFunction<typeof StepItem>
+const mockDownloadRunLogToast = DownloadRunLogToast as jest.MockedFunction<
+  typeof DownloadRunLogToast
+>
 
 const _fixtureAnalysis = (fixtureAnalysis as unknown) as ProtocolAnalysisFile
 
@@ -69,7 +74,7 @@ describe('RunLog', () => {
       protocolKey: 'fakeProtocolKey',
     })
     when(mockUseAllCommandsQuery).mockReturnValue(({
-      data: { data: runRecord.data.commands },
+      data: { data: runRecord.data.commands, meta: { totalLength: 14 } },
     } as unknown) as UseQueryResult<CommandsData>)
     when(mockUseRunErrors).calledWith(RUN_ID).mockReturnValue([])
     when(mockUseRunStatus).calledWith(RUN_ID).mockReturnValue('idle')
@@ -79,6 +84,9 @@ describe('RunLog', () => {
 
     when(mockStepItem).mockReturnValue(
       <div>Picking up tip from A1 of Opentrons 96 Tip Rack 300 µL on 1</div>
+    )
+    when(mockDownloadRunLogToast).mockReturnValue(
+      <div>Mock DownloadRunLogToast</div>
     )
     when(mockUseRunTimestamps)
       .calledWith(RUN_ID)
@@ -157,5 +165,12 @@ describe('RunLog', () => {
 
     queryByText(`${fixtureErrors[0].errorType}: ${fixtureErrors[0].detail}`)
     queryByText(`${fixtureErrors[1].errorType}: ${fixtureErrors[1].detail}`)
+  })
+  it('renders the download run log toast when download run log clicked', () => {
+    const { getByText, queryByText } = render()
+
+    expect(queryByText('Mock DownloadRunLogToast')).toBeNull()
+    getByText('Download run log').click()
+    getByText('Mock DownloadRunLogToast')
   })
 })

--- a/app/src/organisms/Devices/__tests__/DownloadRunLogToast.test.tsx
+++ b/app/src/organisms/Devices/__tests__/DownloadRunLogToast.test.tsx
@@ -1,0 +1,122 @@
+import * as React from 'react'
+import { when, resetAllWhenMocks } from 'jest-when'
+import { UseQueryResult } from 'react-query'
+
+import { renderWithProviders } from '@opentrons/components'
+import { useAllCommandsQuery, useRunQuery } from '@opentrons/react-api-client'
+
+import { i18n } from '../../../i18n'
+import fixtureAnalysis from '../../../organisms/RunDetails/__fixtures__/analysis.json'
+import runRecord from '../../../organisms/RunDetails/__fixtures__/runRecord.json'
+import { useProtocolDetailsForRun } from '../hooks'
+import { downloadFile } from '../utils'
+import { DownloadRunLogToast } from '../DownloadRunLogToast'
+
+import type { CommandsData, Run } from '@opentrons/api-client'
+import type { ProtocolAnalysisFile } from '@opentrons/shared-data'
+
+jest.mock('@opentrons/react-api-client')
+jest.mock('../hooks')
+jest.mock('../utils')
+
+const mockUseProtocolDetailsForRun = useProtocolDetailsForRun as jest.MockedFunction<
+  typeof useProtocolDetailsForRun
+>
+const mockUseAllCommandsQuery = useAllCommandsQuery as jest.MockedFunction<
+  typeof useAllCommandsQuery
+>
+const mockUseRunQuery = useRunQuery as jest.MockedFunction<typeof useRunQuery>
+const mockDownloadFile = downloadFile as jest.MockedFunction<
+  typeof downloadFile
+>
+
+const _fixtureAnalysis = (fixtureAnalysis as unknown) as ProtocolAnalysisFile
+
+const ROBOT_NAME = 'otie'
+const RUN_ID = '1'
+const PAGE_LENGTH = 101
+
+const render = (props: React.ComponentProps<typeof DownloadRunLogToast>) => {
+  return renderWithProviders(<DownloadRunLogToast {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+let mockOnClose: jest.Mock
+
+describe('DownloadRunLogToast', () => {
+  let props: React.ComponentProps<typeof DownloadRunLogToast>
+
+  beforeEach(() => {
+    mockOnClose = jest.fn()
+    props = {
+      robotName: ROBOT_NAME,
+      runId: RUN_ID,
+      onClose: mockOnClose,
+      pageLength: PAGE_LENGTH,
+    }
+    when(mockUseProtocolDetailsForRun).calledWith(RUN_ID).mockReturnValue({
+      protocolData: _fixtureAnalysis,
+      displayName: 'mock display name',
+      protocolKey: 'fakeProtocolKey',
+    })
+    when(mockUseAllCommandsQuery)
+      .calledWith(
+        RUN_ID,
+        {
+          cursor: 0,
+          pageLength: PAGE_LENGTH,
+        },
+        { staleTime: Infinity }
+      )
+      .mockReturnValue(({
+        data: { data: runRecord.data.commands, meta: { totalLength: 14 } },
+      } as unknown) as UseQueryResult<CommandsData>)
+    when(mockUseRunQuery)
+      .calledWith(RUN_ID, { staleTime: Infinity })
+      .mockReturnValue(({
+        data: runRecord,
+      } as unknown) as UseQueryResult<Run>)
+  })
+  afterEach(() => {
+    resetAllWhenMocks()
+    jest.resetAllMocks()
+  })
+
+  it('calls download file and closes when command and run data is present', () => {
+    render(props)
+    expect(mockDownloadFile).toBeCalled()
+    expect(mockOnClose).toBeCalled()
+  })
+  it('renders info toast if command data not present', () => {
+    when(mockUseAllCommandsQuery)
+      .calledWith(
+        RUN_ID,
+        {
+          cursor: 0,
+          pageLength: PAGE_LENGTH,
+        },
+        { staleTime: Infinity }
+      )
+      .mockReturnValue({} as UseQueryResult<CommandsData>)
+    const { getByText } = render(props)
+    getByText('Downloading run log')
+  })
+  it('renders an error toast if command query errors', () => {
+    when(mockUseAllCommandsQuery)
+      .calledWith(
+        RUN_ID,
+        {
+          cursor: 0,
+          pageLength: PAGE_LENGTH,
+        },
+        { staleTime: Infinity }
+      )
+      .mockReturnValue({
+        isError: true,
+        error: { message: 'it errored' },
+      } as UseQueryResult<CommandsData>)
+    const { getByText } = render(props)
+    getByText('it errored')
+  })
+})

--- a/app/src/organisms/Devices/constants.ts
+++ b/app/src/organisms/Devices/constants.ts
@@ -1,0 +1,1 @@
+export const RUN_LOG_WINDOW_SIZE = 60 // number of command items rendered at a time

--- a/app/src/organisms/RunDetails/__fixtures__/runRecord.json
+++ b/app/src/organisms/RunDetails/__fixtures__/runRecord.json
@@ -72,6 +72,7 @@
         "status": "anticipated"
       }
     ],
-    "actions": []
+    "actions": [],
+    "createdAt": "2022-05-18T16:17:42.157321+00:00"
   }
 }

--- a/react-api-client/src/runs/useAllCommandsQuery.ts
+++ b/react-api-client/src/runs/useAllCommandsQuery.ts
@@ -14,18 +14,18 @@ export const DEFAULT_PARAMS: GetCommandsParams = {
   pageLength: DEFAULT_PAGE_LENGTH,
 }
 
-export function useAllCommandsQuery(
+export function useAllCommandsQuery<TError = Error>(
   runId: string | null,
   params: GetCommandsParams = DEFAULT_PARAMS,
-  options: UseQueryOptions<CommandsData> = {}
-): UseQueryResult<CommandsData> {
+  options: UseQueryOptions<CommandsData, TError> = {}
+): UseQueryResult<CommandsData, TError> {
   const host = useHost()
-  const allOptions: UseQueryOptions<CommandsData> = {
+  const allOptions: UseQueryOptions<CommandsData, TError> = {
     ...options,
     enabled: host !== null && runId != null && options.enabled !== false,
   }
   const { cursor, pageLength } = params
-  const query = useQuery<CommandsData>(
+  const query = useQuery<CommandsData, TError>(
     [host, 'runs', runId, 'commands', cursor, pageLength],
     () => {
       return getCommands(host as HostConfig, runId as string, params).then(

--- a/react-api-client/src/runs/useRunQuery.ts
+++ b/react-api-client/src/runs/useRunQuery.ts
@@ -4,12 +4,12 @@ import { useHost } from '../api'
 
 import type { UseQueryResult, UseQueryOptions } from 'react-query'
 
-export function useRunQuery(
+export function useRunQuery<TError = Error>(
   runId: string | null,
-  options: UseQueryOptions<Run> = {}
-): UseQueryResult<Run> {
+  options: UseQueryOptions<Run, TError> = {}
+): UseQueryResult<Run, TError> {
   const host = useHost()
-  const query = useQuery<Run>(
+  const query = useQuery<Run, TError>(
     [host, 'runs', runId, 'details'],
     () =>
       getRun(host as HostConfig, runId as string).then(


### PR DESCRIPTION
# Overview

implements download run log functionality within a toast component, shared between the run detail run log and historical run log list.

refactors the toast component a bit because the error type styling was falling through the control flow, and adds Error type to two useQuery types to strengthen our query typing a bit

re #8753

![Screen Shot 2022-05-19 at 11 10 40 AM](https://user-images.githubusercontent.com/29845468/169336533-a95d54b3-71c9-4004-9c42-35c7fc995208.png)
![Screen Shot 2022-05-19 at 11 10 26 AM](https://user-images.githubusercontent.com/29845468/169336545-5bd51171-6f6e-48db-bf09-3ccfedf718f5.png)

# Changelog

 - Implements download run log

# Review requests

check the toast and downloaded json file

# Risk assessment

low
