### PR TITLE
refactor(app): address Pipette Settings slideout design feedback

### DIFF
--- a/app/src/atoms/Slideout/index.tsx
+++ b/app/src/atoms/Slideout/index.tsx
@@ -13,6 +13,7 @@ import {
   COLORS,
   Overlay,
   POSITION_FIXED,
+  TYPOGRAPHY,
 } from '@opentrons/components'
 
 import { Divider } from '../structure'

--- a/app/src/atoms/Slideout/index.tsx
+++ b/app/src/atoms/Slideout/index.tsx
@@ -11,7 +11,6 @@ import {
   JUSTIFY_SPACE_BETWEEN,
   ALIGN_CENTER,
   COLORS,
-  TYPOGRAPHY,
   Overlay,
   POSITION_FIXED,
 } from '@opentrons/components'
@@ -119,7 +118,7 @@ export const Slideout = (props: Props): JSX.Element | null => {
               </StyledText>
               <Flex alignItems={ALIGN_CENTER}>
                 <Btn
-                  size={TYPOGRAPHY.lineHeight24}
+                  size={'1.25rem'}
                   onClick={onCloseClick}
                   aria-label="exit"
                   data-testid={`Slideout_icon_close_${

--- a/app/src/atoms/buttons/index.tsx
+++ b/app/src/atoms/buttons/index.tsx
@@ -58,10 +58,29 @@ export const PrimaryButton = styled(NewPrimaryBtn)`
   background-color: ${COLORS.blue};
   border-radius: ${BORDERS.radiusSoftCorners};
   padding: ${SPACING.spacing3} ${SPACING.spacing4};
+  line-height: ${TYPOGRAPHY.lineHeight20};
   text-transform: ${TYPOGRAPHY.textTransformNone};
   ${TYPOGRAPHY.pSemiBold}
 
   ${styleProps}
+
+  &:focus {
+    box-shadow: 0 0 0 3px ${COLORS.warning};
+  }
+
+  &:hover {
+    background-color: ${COLORS.blueHover};
+    box-shadow: 0 0 0;
+  }
+
+  &:active {
+    background-color: ${COLORS.bluePressed};
+  }
+
+  &:disabled {
+    background-color: ${COLORS.greyDisabled};
+    color: ${COLORS.disabled};
+  }
 `
 
 export const SecondaryButton = styled(NewSecondaryBtn)`
@@ -72,6 +91,19 @@ export const SecondaryButton = styled(NewSecondaryBtn)`
   ${TYPOGRAPHY.pSemiBold}
 
   ${styleProps}
+
+  &:hover {
+    opacity: 80%;
+    box-shadow: 0 0 0;
+  }
+
+  &:focus {
+    box-shadow: 0 0 0 3px ${COLORS.warning};
+  }
+
+  &:disabled {
+    opacity: 40%;
+  }
 `
 
 export const ToggleButton = (props: ToggleBtnProps): JSX.Element => {

--- a/app/src/atoms/buttons/index.tsx
+++ b/app/src/atoms/buttons/index.tsx
@@ -93,7 +93,7 @@ export const SecondaryButton = styled(NewSecondaryBtn)`
   ${styleProps}
 
   &:hover {
-    opacity: 80%;
+    opacity: 70%;
     box-shadow: 0 0 0;
   }
 
@@ -102,7 +102,7 @@ export const SecondaryButton = styled(NewSecondaryBtn)`
   }
 
   &:disabled {
-    opacity: 40%;
+    opacity: 50%;
   }
 `
 

--- a/app/src/organisms/ConfigurePipette/ConfigForm.tsx
+++ b/app/src/organisms/ConfigurePipette/ConfigForm.tsx
@@ -9,6 +9,7 @@ import pick from 'lodash/pick'
 import omit from 'lodash/omit'
 import set from 'lodash/set'
 import isEmpty from 'lodash/isEmpty'
+import { Box } from '@opentrons/components'
 import { ConfigFormResetButton } from './ConfigFormResetButton'
 import { ConfigFormSubmitButton } from './ConfigFormSubmitButton'
 import {
@@ -218,39 +219,43 @@ export class ConfigForm extends React.Component<ConfigFormProps> {
           }
           //  TODO(jr, 4/19/22): add groupLabels to i18n
           return (
-            <Form>
+            <>
               <ConfigFormResetButton
                 onClick={handleReset}
                 disabled={updateInProgress}
               />
-              <FormColumn>
-                <ConfigFormGroup
-                  groupLabel="Plunger Positions"
-                  groupError={errors.plungerError}
-                  formFields={plungerFields}
-                />
-                <ConfigFormGroup
-                  groupLabel="Tip Pickup / Drop"
-                  formFields={tipFields}
-                />
-                {quirksPresent && <ConfigQuirkGroup quirks={quirkFields} />}
-                {this.props.__showHiddenFields && (
-                  <ConfigFormGroup
-                    groupLabel="For Dev Use Only"
-                    formFields={devFields}
-                  />
-                )}
-              </FormColumn>
-              <FormColumn>
-                <ConfigFormGroup
-                  groupLabel="Power / Force"
-                  formFields={powerFields}
-                />
-              </FormColumn>
+              <Form>
+                <Box overflowY="scroll" height="54vh">
+                  <FormColumn>
+                    <ConfigFormGroup
+                      groupLabel="Plunger Positions"
+                      groupError={errors.plungerError}
+                      formFields={plungerFields}
+                    />
+                    <ConfigFormGroup
+                      groupLabel="Tip Pickup / Drop"
+                      formFields={tipFields}
+                    />
+                    {quirksPresent && <ConfigQuirkGroup quirks={quirkFields} />}
+                    {this.props.__showHiddenFields && (
+                      <ConfigFormGroup
+                        groupLabel="For Dev Use Only"
+                        formFields={devFields}
+                      />
+                    )}
+                  </FormColumn>
+                  <FormColumn>
+                    <ConfigFormGroup
+                      groupLabel="Power / Force"
+                      formFields={powerFields}
+                    />
+                  </FormColumn>
+                </Box>
+              </Form>
               <ConfigFormSubmitButton
                 disabled={disableSubmit || updateInProgress}
               />
-            </Form>
+            </>
           )
         }}
       </Formik>

--- a/app/src/organisms/ConfigurePipette/ConfigForm.tsx
+++ b/app/src/organisms/ConfigurePipette/ConfigForm.tsx
@@ -220,12 +220,13 @@ export class ConfigForm extends React.Component<ConfigFormProps> {
           //  TODO(jr, 4/19/22): add groupLabels to i18n
           return (
             <>
-              <ConfigFormResetButton
-                onClick={handleReset}
-                disabled={updateInProgress}
-              />
               <Form>
-                <Box overflowY="scroll" height="54vh">
+                <Box overflowY="scroll" height="81vh">
+                  {/* 81vh is approximate height to leave 1rem margin below the submit button */}
+                  <ConfigFormResetButton
+                    onClick={handleReset}
+                    disabled={updateInProgress}
+                  />
                   <FormColumn>
                     <ConfigFormGroup
                       groupLabel="Plunger Positions"

--- a/app/src/organisms/ConfigurePipette/ConfigFormGroup.tsx
+++ b/app/src/organisms/ConfigurePipette/ConfigFormGroup.tsx
@@ -5,7 +5,6 @@ import {
   CheckboxField,
   Flex,
   DIRECTION_COLUMN,
-  COLORS,
   SPACING,
   TYPOGRAPHY,
 } from '@opentrons/components'
@@ -76,7 +75,6 @@ export function ConfigFormRow(props: ConfigFormRowProps): JSX.Element {
         as="label"
         id={props.labelFor}
         paddingBottom={SPACING.spacing3}
-        color={COLORS.darkBlack}
         fontWeight={TYPOGRAPHY.fontWeightSemiBold}
       >
         {props.label}

--- a/app/src/organisms/ConfigurePipette/ConfigFormGroup.tsx
+++ b/app/src/organisms/ConfigurePipette/ConfigFormGroup.tsx
@@ -36,8 +36,6 @@ export interface ConfigFormGroupProps {
 
 export function ConfigFormGroup(props: ConfigFormGroupProps): JSX.Element {
   const { groupLabel, groupError, formFields } = props
-  console.log(groupLabel)
-
   const formattedError =
     groupError &&
     groupError.split('\n').map(function (item, key) {

--- a/app/src/organisms/ConfigurePipette/ConfigFormGroup.tsx
+++ b/app/src/organisms/ConfigurePipette/ConfigFormGroup.tsx
@@ -46,7 +46,11 @@ export function ConfigFormGroup(props: ConfigFormGroupProps): JSX.Element {
       )
     })
   return (
-    <FormGroup label={groupLabel} className={styles.form_group}>
+    <FormGroup
+      label={groupLabel}
+      className={styles.form_group}
+      isPipetteSettingsSlideout={true}
+    >
       {groupError && <p className={styles.group_error}>{formattedError}</p>}
       {formFields.map((field, index) => {
         return <ConfigInput field={field} key={index} />

--- a/app/src/organisms/ConfigurePipette/ConfigFormGroup.tsx
+++ b/app/src/organisms/ConfigurePipette/ConfigFormGroup.tsx
@@ -5,7 +5,9 @@ import {
   CheckboxField,
   Flex,
   DIRECTION_COLUMN,
+  COLORS,
   SPACING,
+  TYPOGRAPHY,
 } from '@opentrons/components'
 import { InputField } from '../../atoms/InputField'
 import { StyledText } from '../../atoms/text'
@@ -34,6 +36,8 @@ export interface ConfigFormGroupProps {
 
 export function ConfigFormGroup(props: ConfigFormGroupProps): JSX.Element {
   const { groupLabel, groupError, formFields } = props
+  console.log(groupLabel)
+
   const formattedError =
     groupError &&
     groupError.split('\n').map(function (item, key) {
@@ -74,6 +78,8 @@ export function ConfigFormRow(props: ConfigFormRowProps): JSX.Element {
         as="label"
         id={props.labelFor}
         paddingBottom={SPACING.spacing3}
+        color={COLORS.darkBlack}
+        fontWeight={TYPOGRAPHY.fontWeightSemiBold}
       >
         {props.label}
       </StyledText>
@@ -84,11 +90,10 @@ export function ConfigFormRow(props: ConfigFormRowProps): JSX.Element {
 
 export interface ConfigInputProps {
   field: DisplayFieldProps
-  className?: string
 }
 
 export function ConfigInput(props: ConfigInputProps): JSX.Element {
-  const { field, className } = props
+  const { field } = props
   const { name, units, displayName } = field
   const id = makeId(field.name)
   const _default = field.default.toString()
@@ -106,7 +111,6 @@ export function ConfigInput(props: ConfigInputProps): JSX.Element {
             error={fieldProps.form.errors[name]}
             {...{
               units,
-              className,
             }}
           />
         )}

--- a/app/src/organisms/ConfigurePipette/ConfigFormResetButton.tsx
+++ b/app/src/organisms/ConfigurePipette/ConfigFormResetButton.tsx
@@ -25,13 +25,13 @@ export function ConfigFormResetButton(props: ButtonProps): JSX.Element {
     >
       <SecondaryButton
         marginTop={SPACING.spacingSM}
-        marginBottom={SPACING.spacingSM}
+        marginBottom={SPACING.spacing4}
         onClick={onClick}
         disabled={disabled}
       >
         {t('reset_all')}
       </SecondaryButton>
-      <Divider />
+      <Divider marginY={0} />
     </Flex>
   )
 }

--- a/app/src/organisms/ConfigurePipette/ConfigFormResetButton.tsx
+++ b/app/src/organisms/ConfigurePipette/ConfigFormResetButton.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import {
   DIRECTION_COLUMN,
   Flex,
   SPACING,
-  TEXT_TRANSFORM_UPPERCASE,
+  TYPOGRAPHY,
 } from '@opentrons/components'
 import { SecondaryButton } from '../../atoms/buttons'
 import { Divider } from '../../atoms/structure'
+import { StyledText } from '../../atoms/text'
 
 export interface ButtonProps {
   onClick?: () => unknown
@@ -16,13 +17,22 @@ export interface ButtonProps {
 
 export function ConfigFormResetButton(props: ButtonProps): JSX.Element {
   const { onClick, disabled } = props
-  const { t } = useTranslation('shared')
+  const { t } = useTranslation(['shared', 'device_details'])
 
   return (
-    <Flex
-      flexDirection={DIRECTION_COLUMN}
-      textTransform={TEXT_TRANSFORM_UPPERCASE}
-    >
+    <Flex flexDirection={DIRECTION_COLUMN}>
+      <Trans
+        t={t}
+        i18nKey={'device_details:these_are_advanced_settings'}
+        components={{
+          block: (
+            <StyledText
+              fontSize={TYPOGRAPHY.fontSizeP}
+              paddingBottom={SPACING.spacingXS}
+            />
+          ),
+        }}
+      />
       <SecondaryButton
         marginTop={SPACING.spacingSM}
         marginBottom={SPACING.spacing4}

--- a/app/src/organisms/ConfigurePipette/ConfigFormSubmitButton.tsx
+++ b/app/src/organisms/ConfigurePipette/ConfigFormSubmitButton.tsx
@@ -8,7 +8,6 @@ import {
   TEXT_TRANSFORM_UPPERCASE,
 } from '@opentrons/components'
 import { PrimaryButton } from '../../atoms/buttons'
-
 export interface ConfigFormSubmitButtonProps {
   disabled: boolean
 }

--- a/app/src/organisms/ConfigurePipette/ConfigFormSubmitButton.tsx
+++ b/app/src/organisms/ConfigurePipette/ConfigFormSubmitButton.tsx
@@ -4,6 +4,7 @@ import {
   DIRECTION_COLUMN,
   Flex,
   JUSTIFY_CENTER,
+  SPACING,
   TEXT_TRANSFORM_UPPERCASE,
 } from '@opentrons/components'
 import { PrimaryButton } from '../../atoms/buttons'
@@ -23,6 +24,8 @@ export function ConfigFormSubmitButton(
       justifyContent={JUSTIFY_CENTER}
       flexDirection={DIRECTION_COLUMN}
       textTransform={TEXT_TRANSFORM_UPPERCASE}
+      marginTop={SPACING.spacing4}
+      boxShadow={'0px -4px 12px rgba(0, 0, 0, 0.15)'}
     >
       <PrimaryButton type={'submit'} disabled={disabled}>
         {t('confirm')}

--- a/app/src/organisms/ConfigurePipette/ConfigFormSubmitButton.tsx
+++ b/app/src/organisms/ConfigurePipette/ConfigFormSubmitButton.tsx
@@ -6,6 +6,7 @@ import {
   JUSTIFY_CENTER,
   SPACING,
   TEXT_TRANSFORM_UPPERCASE,
+  Box,
 } from '@opentrons/components'
 import { PrimaryButton } from '../../atoms/buttons'
 export interface ConfigFormSubmitButtonProps {
@@ -19,16 +20,17 @@ export function ConfigFormSubmitButton(
   const { t } = useTranslation('shared')
 
   return (
-    <Flex
-      justifyContent={JUSTIFY_CENTER}
-      flexDirection={DIRECTION_COLUMN}
-      textTransform={TEXT_TRANSFORM_UPPERCASE}
-      marginTop={SPACING.spacing4}
-      boxShadow={'0px -4px 12px rgba(0, 0, 0, 0.15)'}
-    >
-      <PrimaryButton type={'submit'} disabled={disabled}>
-        {t('confirm')}
-      </PrimaryButton>
-    </Flex>
+    <Box boxShadow={'0px -4px 12px rgba(0, 0, 0, 0.15)'}>
+      <Flex
+        justifyContent={JUSTIFY_CENTER}
+        flexDirection={DIRECTION_COLUMN}
+        textTransform={TEXT_TRANSFORM_UPPERCASE}
+        marginTop={SPACING.spacing4}
+      >
+        <PrimaryButton type={'submit'} disabled={disabled}>
+          {t('confirm')}
+        </PrimaryButton>
+      </Flex>
+    </Box>
   )
 }

--- a/app/src/organisms/ConfigurePipette/__tests__/ConfigFormResetButton.test.tsx
+++ b/app/src/organisms/ConfigurePipette/__tests__/ConfigFormResetButton.test.tsx
@@ -22,9 +22,15 @@ describe('ConfigFormResetButton', () => {
     jest.resetAllMocks()
   })
 
-  it('renders button text and not disabled', () => {
-    const { getByRole } = render(props)
+  it('renders text and not disabled', () => {
+    const { getByRole, getByText } = render(props)
     const button = getByRole('button', { name: 'Reset all' })
+    getByText(
+      'These are advanced settings. Please do not attempt to adjust without assistance from Opentrons Support. Changing these settings may affect the lifespan of your pipette.'
+    )
+    getByText(
+      'These settings do not override any pipette settings defined in protocols.'
+    )
     fireEvent.click(button)
     expect(props.onClick).toHaveBeenCalled()
   })

--- a/app/src/organisms/Devices/PipetteCard/PipetteSettingsSlideout.tsx
+++ b/app/src/organisms/Devices/PipetteCard/PipetteSettingsSlideout.tsx
@@ -1,18 +1,11 @@
 import * as React from 'react'
-import { Trans, useTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 import { useDispatch } from 'react-redux'
-import {
-  Flex,
-  DIRECTION_COLUMN,
-  TYPOGRAPHY,
-  SPACING,
-  useInterval,
-} from '@opentrons/components'
+import { Flex, DIRECTION_COLUMN, useInterval } from '@opentrons/components'
 import { PipetteModelSpecs } from '@opentrons/shared-data'
 import { fetchPipetteSettings } from '../../../redux/pipettes'
-import { StyledText } from '../../../atoms/text'
-import { ConfigurePipette } from '../../ConfigurePipette'
 import { Slideout } from '../../../atoms/Slideout'
+import { ConfigurePipette } from '../../ConfigurePipette'
 
 import type { Mount } from '../../../redux/pipettes/types'
 import type { Dispatch } from '../../../redux/types'
@@ -52,18 +45,6 @@ export const PipetteSettingsSlideout = (
         flexDirection={DIRECTION_COLUMN}
         data-testid={`PipetteSettingsSlideout_${robotName}_${mount}`}
       >
-        <Trans
-          t={t}
-          i18nKey={'these_are_advanced_settings'}
-          components={{
-            block: (
-              <StyledText
-                fontSize={TYPOGRAPHY.fontSizeP}
-                paddingBottom={SPACING.spacingXS}
-              />
-            ),
-          }}
-        />
         <ConfigurePipette
           robotName={robotName}
           mount={mount}

--- a/app/src/organisms/Devices/PipetteCard/PipetteSettingsSlideout.tsx
+++ b/app/src/organisms/Devices/PipetteCard/PipetteSettingsSlideout.tsx
@@ -4,13 +4,13 @@ import { useDispatch } from 'react-redux'
 import {
   Flex,
   DIRECTION_COLUMN,
-  Text,
   TYPOGRAPHY,
   SPACING,
   useInterval,
 } from '@opentrons/components'
 import { PipetteModelSpecs } from '@opentrons/shared-data'
 import { fetchPipetteSettings } from '../../../redux/pipettes'
+import { StyledText } from '../../../atoms/text'
 import { ConfigurePipette } from '../../ConfigurePipette'
 import { Slideout } from '../../../atoms/Slideout'
 
@@ -57,7 +57,7 @@ export const PipetteSettingsSlideout = (
           i18nKey={'these_are_advanced_settings'}
           components={{
             block: (
-              <Text
+              <StyledText
                 fontSize={TYPOGRAPHY.fontSizeP}
                 paddingBottom={SPACING.spacingXS}
               />

--- a/app/src/organisms/Devices/PipetteCard/PipetteSettingsSlideout.tsx
+++ b/app/src/organisms/Devices/PipetteCard/PipetteSettingsSlideout.tsx
@@ -58,7 +58,7 @@ export const PipetteSettingsSlideout = (
           components={{
             block: (
               <Text
-                fontSize={TYPOGRAPHY.fontSizeLabel}
+                fontSize={TYPOGRAPHY.fontSizeP}
                 paddingBottom={SPACING.spacingXS}
               />
             ),

--- a/app/src/organisms/Devices/PipetteCard/__tests__/PipetteSettingsSlideout.test.tsx
+++ b/app/src/organisms/Devices/PipetteCard/__tests__/PipetteSettingsSlideout.test.tsx
@@ -43,12 +43,6 @@ describe('PipetteSettingsSlideout', () => {
     const { getByText, getByRole } = render(props)
 
     getByText('Left Pipette Settings')
-    getByText(
-      'These are advanced settings. Please do not attempt to adjust without assistance from Opentrons Support. Changing these settings may affect the lifespan of your pipette.'
-    )
-    getByText(
-      'These settings do not override any pipette settings defined in protocols.'
-    )
     getByText('mock configure pipette')
     const button = getByRole('button', { name: /exit/i })
     fireEvent.click(button)

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -195,10 +195,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
                 </Banner>
               </Flex>
             ) : null}
-            {isDeckCalibrated &&
-            pipetteOffsetCalibration == null &&
-            badCalibration &&
-            showBanner ? (
+            {isDeckCalibrated && badCalibration && showBanner ? (
               <Flex paddingBottom={SPACING.spacing2}>
                 <Banner
                   type="warning"

--- a/components/src/forms/FormGroup.tsx
+++ b/components/src/forms/FormGroup.tsx
@@ -17,6 +17,8 @@ export interface FormGroupProps {
   disabled?: boolean | null | undefined
   /** handlers for HoverTooltipComponent */
   hoverTooltipHandlers?: HoverTooltipHandlers | null | undefined
+  /** boolean indicating formGroup used in pipette Settings slideout */
+  isPipetteSettingsSlideout?: boolean
 }
 
 export function FormGroup(props: FormGroupProps): JSX.Element {
@@ -31,7 +33,11 @@ export function FormGroup(props: FormGroupProps): JSX.Element {
       {props.label && (
         <div
           {...props.hoverTooltipHandlers}
-          className={styles.form_group_label}
+          className={
+            props.isPipetteSettingsSlideout
+              ? styles.form_group_label_pipette_settings_slideout
+              : styles.form_group_label
+          }
         >
           {error && (
             <div className={styles.error_icon}>

--- a/components/src/forms/forms.css
+++ b/components/src/forms/forms.css
@@ -32,8 +32,21 @@
   @apply --font-form-default;
 
   font-weight: var(--fw-semibold);
+  margin-bottom: 0.15rem;
+  text-transform: capitalize;
+
+  &::after {
+    content: ':';
+  }
+}
+
+.form_group_label_pipette_settings_slideout {
+  @apply --font-form-default;
+
+  font-weight: var(--fw-semibold);
   margin-bottom: 0.5rem;
   text-transform: capitalize;
+  font-size: 13px;
 }
 
 .checkbox_icon {

--- a/components/src/forms/forms.css
+++ b/components/src/forms/forms.css
@@ -32,12 +32,8 @@
   @apply --font-form-default;
 
   font-weight: var(--fw-semibold);
-  margin-bottom: 0.15rem;
+  margin-bottom: 0.5rem;
   text-transform: capitalize;
-
-  &::after {
-    content: ':';
-  }
 }
 
 .checkbox_icon {


### PR DESCRIPTION
closes #10228

# Overview

This PR addresses the pipette settings slideout design QA feedback and fixes a quick bug regarding the "recalibrate pipette" banner on the pipette cards. 

<img width="317" alt="Screen Shot 2022-05-19 at 11 44 26 AM" src="https://user-images.githubusercontent.com/66035149/169341407-38bc9479-3bbf-4848-a5dc-1188153ca2bc.png">

# Changelog

- some design tweaks through `ConfigurePipette` folder
- quick fix to pipette card banner bug

# Review requests

- click on pipette settings slideout - the form field should be scroll able - does it match designs?

# Risk assessment

low, behind ff