### PR TITLE
fix(app): poll protocol analyses not record in useProtocolDetailsForRun

### DIFF
--- a/app/src/organisms/Devices/hooks/__tests__/useProtocolDetailsForRun.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useProtocolDetailsForRun.test.tsx
@@ -60,10 +60,10 @@ describe('useProtocolDetailsForRun hook', () => {
       .calledWith(null, { staleTime: Infinity })
       .mockReturnValue({} as UseQueryResult<Run>)
     when(mockUseProtocolQuery)
-      .calledWith(null, { staleTime: Infinity }, true)
+      .calledWith(null, { staleTime: Infinity })
       .mockReturnValue({} as UseQueryResult<Protocol>)
     when(mockUseProtocolAnalysesQuery)
-      .calledWith(null, { staleTime: Infinity })
+      .calledWith(null, { staleTime: Infinity }, true)
       .mockReturnValue({
         data: { data: [] } as any,
       } as UseQueryResult<ProtocolAnalyses>)
@@ -94,10 +94,10 @@ describe('useProtocolDetailsForRun hook', () => {
         data: { data: { protocolId: PROTOCOL_ID } } as any,
       } as UseQueryResult<Run>)
     when(mockUseProtocolQuery)
-      .calledWith(PROTOCOL_ID, { staleTime: Infinity }, expect.any(Boolean))
+      .calledWith(PROTOCOL_ID, { staleTime: Infinity })
       .mockReturnValue({ data: PROTOCOL_RESPONSE } as UseQueryResult<Protocol>)
     when(mockUseProtocolAnalysesQuery)
-      .calledWith(PROTOCOL_ID, { staleTime: Infinity })
+      .calledWith(PROTOCOL_ID, { staleTime: Infinity }, expect.any(Boolean))
       .mockReturnValue({
         data: { data: [PROTOCOL_ANALYSIS as any] },
       } as UseQueryResult<ProtocolAnalyses>)

--- a/app/src/organisms/Devices/hooks/useProtocolDetailsForRun.ts
+++ b/app/src/organisms/Devices/hooks/useProtocolDetailsForRun.ts
@@ -20,37 +20,36 @@ export function useProtocolDetailsForRun(
 ): ProtocolDetails {
   const { data: runRecord } = useRunQuery(runId, { staleTime: Infinity })
   const protocolId = runRecord?.data?.protocolId ?? null
-  const [isPollingProtocol, setIsPollingProtocol] = React.useState<boolean>(
-    true
-  )
+  const [
+    isPollingProtocolAnalyses,
+    setIsPollingProtocolAnalyses,
+  ] = React.useState<boolean>(true)
 
-  const { data: protocolRecord } = useProtocolQuery(
+  const { data: protocolRecord } = useProtocolQuery(protocolId, {
+    staleTime: Infinity,
+  })
+
+  const { data: protocolAnalyses } = useProtocolAnalysesQuery(
     protocolId,
     {
       staleTime: Infinity,
     },
-    isPollingProtocol
+    isPollingProtocolAnalyses
   )
 
-  const { data: protocolAnalyses } = useProtocolAnalysesQuery(protocolId, {
-    staleTime: Infinity,
-  })
-
-  const mostRecentAnalysisSummary =
-    last(protocolRecord?.data?.analysisSummaries ?? []) ?? null
+  const mostRecentAnalysis = last(protocolAnalyses?.data ?? []) ?? null
 
   React.useEffect(() => {
-    if (mostRecentAnalysisSummary?.status === 'completed') {
-      setIsPollingProtocol(false)
+    if (mostRecentAnalysis?.status === 'completed') {
+      setIsPollingProtocolAnalyses(false)
     } else {
-      setIsPollingProtocol(true)
+      setIsPollingProtocolAnalyses(true)
     }
-  }, [mostRecentAnalysisSummary?.status])
+  }, [mostRecentAnalysis?.status])
 
   const displayName =
     protocolRecord?.data.metadata.protocolName ??
     protocolRecord?.data.files[0].name
-  const mostRecentAnalysis = last(protocolAnalyses?.data ?? []) ?? null
 
   return {
     displayName: displayName ?? null,


### PR DESCRIPTION
# Overview

this fixes the bug where sections of the protocol run setup tab are missing due to protocol polling ending before robot-side protocol analysis is complete. 

the root cause (i believe) is a previously analyzed protocol marked as analysis "completed" in the analysis summary on the protocol record while the current robot-side analysis is still pending.

closes #10341

# Changelog

 - Polls protocol analyses not record in useProtocolDetailsForRun

# Review requests

confirm that the "Required Pipettes" and "Required Tip Length Calibrations" sections of the protocol run setup tab populate after a protocol run is started and robot-side analysis is complete. confirm for the first run of an uploaded protocol and subsequent runs of that protocol

# Risk assessment

low
