### PR TITLE
fix(api): ot3: fix saving config to json

### DIFF
--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, cast, List
+from typing import Any, Dict, cast, List, Iterable, Tuple
 from typing_extensions import Final
 from dataclasses import asdict
 
@@ -328,4 +328,20 @@ def build_with_defaults(robot_settings: Dict[str, Any]) -> OT3Config:
 
 
 def serialize(config: OT3Config) -> Dict[str, Any]:
-    return asdict(config)
+    def _build_dict(pairs: Iterable[Tuple[Any, Any]]) -> Dict[str, Any]:
+        def _normalize_key(key: Any) -> Any:
+            if isinstance(key, OT3AxisKind):
+                return key.name
+            return key
+
+        def _normalize_value(value: Any) -> Any:
+            if isinstance(value, dict):
+                return {
+                    _normalize_key(k): _normalize_value(v) for k, v in value.items()
+                }
+            else:
+                return value
+
+        return dict((_normalize_key(key), _normalize_value(val)) for key, val in pairs)
+
+    return asdict(config, dict_factory=_build_dict)

--- a/api/src/opentrons/config/robot_configs.py
+++ b/api/src/opentrons/config/robot_configs.py
@@ -17,6 +17,7 @@ log = logging.getLogger(__name__)
 def current_for_revision(
     current_dict: CurrentDict, revision: BoardRevision
 ) -> AxisDict:
+    """Pull the appropriate current value for the specified revision."""
     if revision == BoardRevision.UNKNOWN:
         return current_dict.get("2.1", current_dict["default"])
     elif revision.real_name() in current_dict:
@@ -26,6 +27,11 @@ def current_for_revision(
 
 
 def build_config(robot_settings: Dict[str, Any]) -> Union[RobotConfig, OT3Config]:
+    """Build the appropriate config object for the machine.
+
+    Which config object should be used will be detected from the specified config
+    object.
+    """
     default_robot_model: Union[Literal["OT-3 Standard"], Literal["OT-2 Standard"]] = (
         "OT-3 Standard" if enable_ot3_hardware_controller() else "OT-2 Standard"
     )
@@ -37,14 +43,17 @@ def build_config(robot_settings: Dict[str, Any]) -> Union[RobotConfig, OT3Config
 
 
 def build_config_ot2(robot_settings: Dict[str, Any]) -> RobotConfig:
+    """Build an OT2 config object with default values for unspecified elements."""
     return defaults_ot2.build_with_defaults(robot_settings)
 
 
 def build_config_ot3(robot_settings: Dict[str, Any]) -> OT3Config:
+    """Build an OT3 config object with default values for unspecified elements."""
     return defaults_ot3.build_with_defaults(robot_settings)
 
 
 def config_to_save(config: Union[RobotConfig, OT3Config]) -> Dict[str, Any]:
+    """Turn the config into a serializable dictionary."""
     if config.model == "OT-2 Standard":
         return defaults_ot2.serialize(config)
     else:
@@ -58,14 +67,17 @@ def _load_file() -> Dict[str, Any]:
 
 
 def load() -> Union[RobotConfig, OT3Config]:
+    """Load the appropriate config, if it exists, or build defaults."""
     return build_config(_load_file())
 
 
 def load_ot2() -> RobotConfig:
+    """Load an OT2 config, or build defaults."""
     return build_config_ot2(_load_file())
 
 
 def load_ot3() -> OT3Config:
+    """Load an OT3 config, or build defaults."""
     return build_config_ot3(_load_file())
 
 
@@ -74,21 +86,29 @@ def save_robot_settings(
     rs_filename: Optional[str] = None,
     tag: Optional[str] = None,
 ) -> Dict[str, Any]:
+    """Save the specified config to disk as a JSON file."""
     config_dict = config_to_save(config)
+    config_json = json_to_save(config_dict)
 
     # Save everything else in a different file
     filename = rs_filename or CONFIG["robot_settings_file"]
     if tag:
         root, ext = os.path.splitext(filename)
         filename = "{}-{}{}".format(root, tag, ext)
-    _save_json(config_dict, filename=filename)
+    _save_config_data(config_json, filename=filename)
 
     return config_dict
+
+
+def json_to_save(config: Dict[str, Any]) -> str:
+    """Build a JSON object of the config, ready to store on disk."""
+    return json.dumps(config, sort_keys=True, indent=4)
 
 
 def backup_configuration(
     config: Union[RobotConfig, OT3Config], tag: Optional[str] = None
 ) -> None:
+    """Save a backup, tagged by timestamp, of the config."""
     import time
 
     if not tag:
@@ -134,11 +154,11 @@ def _load_json(filename: Union[str, Path]) -> Dict[str, Any]:
     return cast(Dict[str, Any], res)
 
 
-def _save_json(data: Dict[str, Any], filename: Union[str, Path]) -> None:
+def _save_config_data(data: str, filename: Union[str, Path]) -> None:
     try:
         os.makedirs(os.path.dirname(filename), exist_ok=True)
         with open(filename, "w") as file:
-            json.dump(data, file, sort_keys=True, indent=4)
+            file.write(data)
             file.flush()
             os.fsync(file.fileno())
     except OSError:

--- a/api/tests/opentrons/config/test_robots_config.py
+++ b/api/tests/opentrons/config/test_robots_config.py
@@ -3,6 +3,7 @@ import json
 import os
 
 import pytest
+from typing import Dict, Any
 
 from opentrons.config import CONFIG, robot_configs, defaults_ot2, defaults_ot3
 from opentrons.config.types import CurrentDict, GantryLoad, OT3Config
@@ -292,6 +293,16 @@ def test_dictify_roundtrip(config_dict):
     built_config = robot_configs.build_config(config_dict)
     new_saved_config = robot_configs.config_to_save(built_config)
     assert new_saved_config == config_dict
+
+
+@pytest.mark.parametrize("config_dict", [new_dummy_settings, ot3_dummy_settings])
+def test_json_roundtrip(config_dict: Dict[str, Any]) -> None:
+    built_config = robot_configs.build_config(config_dict)
+    config_dict = robot_configs.config_to_save(built_config)
+    jsonstr = robot_configs.json_to_save(config_dict)
+    reloaded = json.loads(jsonstr)
+    rebuilt = robot_configs.build_config(reloaded)
+    assert built_config == rebuilt
 
 
 def test_load_legacy_gantry_cal():

--- a/api/tests/opentrons/config/test_robots_config.py
+++ b/api/tests/opentrons/config/test_robots_config.py
@@ -99,163 +99,163 @@ ot3_dummy_settings = {
     "motion_settings": {
         "acceleration": {
             "none": {
-                OT3AxisKind.X: 3,
-                OT3AxisKind.Y: 2,
-                OT3AxisKind.Z: 15,
-                OT3AxisKind.P: 2,
+                "X": 3,
+                "Y": 2,
+                "Z": 15,
+                "P": 2,
             },
             "low_throughput": {
-                OT3AxisKind.X: 3,
-                OT3AxisKind.Y: 2,
-                OT3AxisKind.Z: 15,
-                OT3AxisKind.P: 15,
+                "X": 3,
+                "Y": 2,
+                "Z": 15,
+                "P": 15,
             },
             "high_throughput": {
-                OT3AxisKind.X: 3,
-                OT3AxisKind.Y: 2,
-                OT3AxisKind.Z: 15,
-                OT3AxisKind.P: 15,
+                "X": 3,
+                "Y": 2,
+                "Z": 15,
+                "P": 15,
             },
-            "two_low_throughput": {OT3AxisKind.X: 1.1, OT3AxisKind.Y: 2.2},
+            "two_low_throughput": {"X": 1.1, "Y": 2.2},
             "gripper": {
-                OT3AxisKind.Z: 2.8,
+                "Z": 2.8,
             },
         },
         "default_max_speed": {
             "none": {
-                OT3AxisKind.X: 1,
-                OT3AxisKind.Y: 2,
-                OT3AxisKind.Z: 3,
-                OT3AxisKind.P: 4,
+                "X": 1,
+                "Y": 2,
+                "Z": 3,
+                "P": 4,
             },
             "low_throughput": {
-                OT3AxisKind.X: 1,
-                OT3AxisKind.Y: 2,
-                OT3AxisKind.Z: 3,
-                OT3AxisKind.P: 4,
+                "X": 1,
+                "Y": 2,
+                "Z": 3,
+                "P": 4,
             },
             "high_throughput": {
-                OT3AxisKind.X: 1,
-                OT3AxisKind.Y: 2,
-                OT3AxisKind.Z: 3,
-                OT3AxisKind.P: 4,
+                "X": 1,
+                "Y": 2,
+                "Z": 3,
+                "P": 4,
             },
             "two_low_throughput": {
-                OT3AxisKind.X: 4,
-                OT3AxisKind.Y: 3,
-                OT3AxisKind.Z: 2,
-                OT3AxisKind.P: 1,
+                "X": 4,
+                "Y": 3,
+                "Z": 2,
+                "P": 1,
             },
-            "gripper": {OT3AxisKind.Z: 2.8},
+            "gripper": {"Z": 2.8},
         },
         "max_speed_discontinuity": {
             "none": {
-                OT3AxisKind.X: 10,
-                OT3AxisKind.Y: 20,
-                OT3AxisKind.Z: 30,
-                OT3AxisKind.P: 40,
+                "X": 10,
+                "Y": 20,
+                "Z": 30,
+                "P": 40,
             },
             "low_throughput": {
-                OT3AxisKind.X: 1,
-                OT3AxisKind.Y: 2,
-                OT3AxisKind.Z: 3,
-                OT3AxisKind.P: 6,
+                "X": 1,
+                "Y": 2,
+                "Z": 3,
+                "P": 6,
             },
             "high_throughput": {
-                OT3AxisKind.X: 1,
-                OT3AxisKind.Y: 2,
-                OT3AxisKind.Z: 3,
-                OT3AxisKind.P: 6,
+                "X": 1,
+                "Y": 2,
+                "Z": 3,
+                "P": 6,
             },
             "two_low_throughput": {
-                OT3AxisKind.X: 1,
-                OT3AxisKind.Y: 2,
-                OT3AxisKind.Z: 3,
-                OT3AxisKind.P: 6,
+                "X": 1,
+                "Y": 2,
+                "Z": 3,
+                "P": 6,
             },
-            "gripper": {OT3AxisKind.Z: 2.8},
+            "gripper": {"Z": 2.8},
         },
         "direction_change_speed_discontinuity": {
             "none": {
-                OT3AxisKind.X: 5,
-                OT3AxisKind.Y: 10,
-                OT3AxisKind.Z: 15,
-                OT3AxisKind.P: 20,
+                "X": 5,
+                "Y": 10,
+                "Z": 15,
+                "P": 20,
             },
             "low_throughput": {
-                OT3AxisKind.X: 0.8,
-                OT3AxisKind.Y: 1,
-                OT3AxisKind.Z: 2,
-                OT3AxisKind.P: 4,
+                "X": 0.8,
+                "Y": 1,
+                "Z": 2,
+                "P": 4,
             },
             "high_throughput": {
-                OT3AxisKind.X: 1,
-                OT3AxisKind.Y: 2,
-                OT3AxisKind.Z: 3,
-                OT3AxisKind.P: 6,
+                "X": 1,
+                "Y": 2,
+                "Z": 3,
+                "P": 6,
             },
             "two_low_throughput": {
-                OT3AxisKind.X: 0.5,
-                OT3AxisKind.Y: 1,
-                OT3AxisKind.Z: 1.5,
-                OT3AxisKind.P: 3,
+                "X": 0.5,
+                "Y": 1,
+                "Z": 1.5,
+                "P": 3,
             },
-            "gripper": {OT3AxisKind.Z: 2.8},
+            "gripper": {"Z": 2.8},
         },
     },
     "current_settings": {
         "hold_current": {
             "none": {
-                OT3AxisKind.X: 0.7,
-                OT3AxisKind.Y: 0.7,
-                OT3AxisKind.Z: 0.7,
-                OT3AxisKind.P: 0.8,
+                "X": 0.7,
+                "Y": 0.7,
+                "Z": 0.7,
+                "P": 0.8,
             },
             "low_throughput": {
-                OT3AxisKind.X: 0.7,
-                OT3AxisKind.Y: 0.7,
-                OT3AxisKind.Z: 0.7,
-                OT3AxisKind.P: 0.8,
+                "X": 0.7,
+                "Y": 0.7,
+                "Z": 0.7,
+                "P": 0.8,
             },
             "high_throughput": {
-                OT3AxisKind.X: 0.7,
-                OT3AxisKind.Y: 0.7,
-                OT3AxisKind.Z: 0.7,
-                OT3AxisKind.P: 0.8,
+                "X": 0.7,
+                "Y": 0.7,
+                "Z": 0.7,
+                "P": 0.8,
             },
             "two_low_throughput": {
-                OT3AxisKind.X: 0.7,
-                OT3AxisKind.Y: 0.7,
+                "X": 0.7,
+                "Y": 0.7,
             },
             "gripper": {
-                OT3AxisKind.Z: 0.7,
+                "Z": 0.7,
             },
         },
         "run_current": {
             "none": {
-                OT3AxisKind.X: 7.0,
-                OT3AxisKind.Y: 7.0,
-                OT3AxisKind.Z: 7.0,
-                OT3AxisKind.P: 5.0,
+                "X": 7.0,
+                "Y": 7.0,
+                "Z": 7.0,
+                "P": 5.0,
             },
             "low_throughput": {
-                OT3AxisKind.X: 1,
-                OT3AxisKind.Y: 2,
-                OT3AxisKind.Z: 3,
-                OT3AxisKind.P: 4.0,
+                "X": 1,
+                "Y": 2,
+                "Z": 3,
+                "P": 4.0,
             },
             "high_throughput": {
-                OT3AxisKind.X: 0.2,
-                OT3AxisKind.Y: 0.5,
-                OT3AxisKind.Z: 0.4,
-                OT3AxisKind.P: 2.0,
+                "X": 0.2,
+                "Y": 0.5,
+                "Z": 0.4,
+                "P": 2.0,
             },
             "two_low_throughput": {
-                OT3AxisKind.X: 9,
-                OT3AxisKind.Y: 0.1,
+                "X": 9,
+                "Y": 0.1,
             },
             "gripper": {
-                OT3AxisKind.Z: 10,
+                "Z": 10,
             },
         },
     },
@@ -377,9 +377,7 @@ def test_load_per_pipette_vals():
     )
 
     # altered values are preserved
-    mostly_right["motion_settings"]["acceleration"]["high_throughput"][
-        OT3AxisKind.X
-    ] -= 2
+    mostly_right["motion_settings"]["acceleration"]["high_throughput"]["X"] -= 2
     assert (
         defaults_ot3._build_default_bpk(
             mostly_right["motion_settings"]["acceleration"],
@@ -392,9 +390,7 @@ def test_load_per_pipette_vals():
     altered_default = copy.deepcopy(defaults_ot3.DEFAULT_ACCELERATIONS)
     altered_default.two_low_throughput.pop(OT3AxisKind.X, None)
 
-    mostly_right["motion_settings"]["acceleration"]["two_low_throughput"][
-        OT3AxisKind.X
-    ] = -72
+    mostly_right["motion_settings"]["acceleration"]["two_low_throughput"]["X"] = -72
     assert (
         defaults_ot3._build_default_bpk(
             mostly_right["motion_settings"]["acceleration"], altered_default


### PR DESCRIPTION
Saving the OT3 robot config to json did not work because when the config dataclass was serialized, it would produce dictionaries with keys that were `OT3AxisKind` enums. By using a custom `dataclasses.asdict` `dict_factory`, we can convert those to their enum names. 