### PR TITLE
test(robot-server): Fix a race condition in the persistence tests

### DIFF
--- a/robot-server/tests/integration/http_api/runs/test_persistence.py
+++ b/robot-server/tests/integration/http_api/runs/test_persistence.py
@@ -1,5 +1,7 @@
+import asyncio
 from typing import AsyncGenerator, NamedTuple
 
+import anyio
 import pytest
 
 from tests.integration.dev_server import DevServer
@@ -142,6 +144,13 @@ async def test_run_actions_labware_offsets_persist(
         run_id=run_id,
         req_body={"data": {"actionType": "stop"}},
     )
+
+    # wait for the action to take effect
+    with anyio.fail_after(10):
+        while (await client.get_run(run_id=run_id)).json()["data"][
+            "status"
+        ] != "stopped":
+            await asyncio.sleep(1)
 
     # persist the run by setting current: false
     archive_run_response = await client.patch_run(

--- a/robot-server/tests/integration/http_api/runs/test_persistence.py
+++ b/robot-server/tests/integration/http_api/runs/test_persistence.py
@@ -1,4 +1,3 @@
-import asyncio
 from typing import AsyncGenerator, NamedTuple
 
 import anyio
@@ -146,11 +145,11 @@ async def test_run_actions_labware_offsets_persist(
     )
 
     # wait for the action to take effect
-    with anyio.fail_after(10):
+    with anyio.fail_after(5):
         while (await client.get_run(run_id=run_id)).json()["data"][
             "status"
         ] != "stopped":
-            await asyncio.sleep(1)
+            await anyio.sleep(0.1)
 
     # persist the run by setting current: false
     archive_run_response = await client.patch_run(


### PR DESCRIPTION
# Overview

One of the persistence tests does this:

1. Make a run.
2. Request the run to be stopped.
3. Mark the run as not-current.

But it should do this:

1. Make a run.
2. Request the run to be stopped.
3. **Wait for the stop to take effect.**
4. Mark the run as not-current.

Because the stop action does not necessarily take effect by the time its HTTP response is returned to the client, and because marking the run as not-current is a 409 conflict if the run is still going.

# Review requests

Do any other race conditions pop out in this file?

# Risk assessment

No risk of changing production code behavior. Changes are just to tests.