### PR TITLE
fix(app): stop click outside modal redirect 

### DIFF
--- a/app/src/atoms/Banner/index.tsx
+++ b/app/src/atoms/Banner/index.tsx
@@ -31,7 +31,6 @@ export interface BannerProps extends StyleProps {
   onCloseClick?: (() => unknown) | React.MouseEventHandler<HTMLButtonElement>
   /** Override the default Alert Icon */
   icon?: IconProps
-  onClick?: () => unknown
 }
 
 const BANNER_PROPS_BY_TYPE: Record<

--- a/app/src/atoms/Banner/index.tsx
+++ b/app/src/atoms/Banner/index.tsx
@@ -31,6 +31,7 @@ export interface BannerProps extends StyleProps {
   onCloseClick?: () => unknown
   /** Override the default Alert Icon */
   icon?: IconProps
+  onClick?: () => unknown
 }
 
 const BANNER_PROPS_BY_TYPE: Record<

--- a/app/src/atoms/Banner/index.tsx
+++ b/app/src/atoms/Banner/index.tsx
@@ -87,6 +87,7 @@ export function Banner(props: BannerProps): JSX.Element {
       justifyContent={JUSTIFY_SPACE_BETWEEN}
       alignItems={ALIGN_CENTER}
       padding={SPACING.spacing3}
+      onClick={e => e.stopPropagation()}
       data-testid={`Banner_${type}`}
       {...styleProps}
     >

--- a/app/src/organisms/ProtocolAnalysisFailure/index.tsx
+++ b/app/src/organisms/ProtocolAnalysisFailure/index.tsx
@@ -36,14 +36,18 @@ export function ProtocolAnalysisFailure(
 
   const handleClickShowDetails: React.MouseEventHandler = e => {
     e.preventDefault()
+    e.stopPropagation()
     setShowErrorDetails(true)
   }
   const handleClickHideDetails: React.MouseEventHandler = e => {
     e.preventDefault()
+    console.log('testing')
+    e.stopPropagation()
     setShowErrorDetails(false)
   }
   const handleClickReanalyze: React.MouseEventHandler = e => {
     e.preventDefault()
+    e.stopPropagation()
     dispatch(analyzeProtocol(protocolKey))
   }
   return (

--- a/app/src/organisms/ProtocolAnalysisFailure/index.tsx
+++ b/app/src/organisms/ProtocolAnalysisFailure/index.tsx
@@ -41,7 +41,6 @@ export function ProtocolAnalysisFailure(
   }
   const handleClickHideDetails: React.MouseEventHandler = e => {
     e.preventDefault()
-    console.log('testing')
     e.stopPropagation()
     setShowErrorDetails(false)
   }

--- a/app/src/organisms/ProtocolDetails/index.tsx
+++ b/app/src/organisms/ProtocolDetails/index.tsx
@@ -228,7 +228,8 @@ export function ProtocolDetails(
       })
     } else {
       return t('python_api_version', {
-        version: config.apiVersion?.join('.'),
+        version:
+          config.apiVersion != null ? config.apiVersion?.join('.') : null,
       })
     }
   }

--- a/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
@@ -23,7 +23,7 @@ import {
   ModuleIcon,
   POSITION_ABSOLUTE,
 } from '@opentrons/components'
-import { Link } from 'react-router-dom'
+import { useHistory } from 'react-router-dom'
 import {
   parseInitialPipetteNamesByMount,
   parseAllRequiredModuleModels,
@@ -51,7 +51,7 @@ export function ProtocolCard(props: ProtocolCardProps): JSX.Element | null {
     mostRecentAnalysis,
     modified,
   } = props
-
+  const history = useHistory()
   const isAnalyzing = useSelector((state: State) =>
     getIsProtocolAnalysisInProgress(state, protocolKey)
   )
@@ -62,37 +62,36 @@ export function ProtocolCard(props: ProtocolCardProps): JSX.Element | null {
   )
 
   return (
-    <Link to={`/protocols/${protocolKey}`} style={{ color: 'inherit' }}>
-      <Flex
-        backgroundColor={COLORS.white}
-        border={`1px solid ${COLORS.medGrey}`}
-        borderRadius="4px"
-        flexDirection={DIRECTION_ROW}
-        marginBottom={SPACING.spacing3}
-        padding={SPACING.spacing4}
-        justifyContent={JUSTIFY_SPACE_BETWEEN}
-        width="100%"
-        position="relative"
+    <Flex
+      backgroundColor={COLORS.white}
+      border={`1px solid ${COLORS.medGrey}`}
+      borderRadius="4px"
+      flexDirection={DIRECTION_ROW}
+      marginBottom={SPACING.spacing3}
+      padding={SPACING.spacing4}
+      justifyContent={JUSTIFY_SPACE_BETWEEN}
+      width="100%"
+      position="relative"
+      onClick={() => history.push(`/protocols/${protocolKey}`)}
+    >
+      <AnalysisInfo
+        protocolKey={protocolKey}
+        mostRecentAnalysis={mostRecentAnalysis}
+        protocolDisplayName={protocolDisplayName}
+        isAnalyzing={isAnalyzing}
+        modified={modified}
+      />
+      <Box
+        position={POSITION_ABSOLUTE}
+        top={SPACING.spacing2}
+        right={SPACING.spacing2}
       >
-        <AnalysisInfo
+        <ProtocolOverflowMenu
           protocolKey={protocolKey}
-          mostRecentAnalysis={mostRecentAnalysis}
-          protocolDisplayName={protocolDisplayName}
-          isAnalyzing={isAnalyzing}
-          modified={modified}
+          handleRunProtocol={handleRunProtocol}
         />
-        <Box
-          position={POSITION_ABSOLUTE}
-          top={SPACING.spacing2}
-          right={SPACING.spacing2}
-        >
-          <ProtocolOverflowMenu
-            protocolKey={protocolKey}
-            handleRunProtocol={handleRunProtocol}
-          />
-        </Box>
-      </Flex>
-    </Link>
+      </Box>
+    </Flex>
   )
 }
 

--- a/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
@@ -52,7 +52,6 @@ export function ProtocolCard(props: ProtocolCardProps): JSX.Element | null {
     mostRecentAnalysis,
     modified,
   } = props
-  const history = useHistory()
   const isAnalyzing = useSelector((state: State) =>
     getIsProtocolAnalysisInProgress(state, protocolKey)
   )

--- a/app/src/organisms/ProtocolsLanding/ProtocolOverflowMenu.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolOverflowMenu.tsx
@@ -71,7 +71,11 @@ export function ProtocolOverflowMenu(
     setShowOverflowMenu(!showOverflowMenu)
   }
   return (
-    <Flex flexDirection={DIRECTION_COLUMN} position={POSITION_RELATIVE}>
+    <Flex
+      flexDirection={DIRECTION_COLUMN}
+      position={POSITION_RELATIVE}
+      onClick={e => e.stopPropagation()}
+    >
       <OverflowBtn
         alignSelf={ALIGN_FLEX_END}
         onClick={handleOverflowClick}


### PR DESCRIPTION
# Overview

This PR stops the redirect when clicking outside of the modal, particularly the failed protocol
analysis modal.

closes https://github.com/Opentrons/opentrons/issues/10277

# Changelog

- Add `stopPropogation` to the appropriate components/handlers

# Review requests

- Upload a protocol that fails analysis. Click the `error details` link in the banner which should open a modal. Then try clicking outside the modal and make sure that the app does NOT redirect to the protocol details page.

# Risk assessment

low