### PR TITLE
test(robot-server): scripts for testing against a live robot

### DIFF
--- a/robot-server/tests/integration/http_api/live/HS_LABWARE.md
+++ b/robot-server/tests/integration/http_api/live/HS_LABWARE.md
@@ -15,16 +15,18 @@
    1. `cd opentrons`
 7. clone the repository
    1. `git clone https://github.com/Opentrons/opentrons.git`
-8. move to the branch
-   1. `git pull origin`
-   2. `git switch 10313-hs-labware-script-2`
-9.  move to the robot-server directory
-   3. `cd .\opentrons\robot-server`
-10. install this package
-   4.  `pipenv install -d`
-11. call the help text on the tool
+8. move into the repository that you just cloned, (this looks a little funny as the path is opentrons/opentrons but actually reflects the structure of organization on github) 
+   1. `cd opentrons`
+9.  move to the branch
+   2. `git pull origin`
+   3. `git switch 10313-hs-labware-script-2`
+10. move to the robot-server directory
+   4. `cd .\opentrons\robot-server`
+11. install this package
+   5.  `pipenv install -d`
+12. call the help text on the tool
     1.  `pipenv run python .\tests\integration\http_api\live\hs_labware.py -h`
-12. follow the instructions
+13. follow the instructions
     1.  change the constants (ALL_CAPS_VARIABLES) at the top of `robot-server/tests/integration/http_api/live/hs_labware.py` file per your robot setup.
-13. run the script replacing the robot ip with your robot ip
+14. run the script replacing the robot ip with your robot ip
     1.  `pipenv run python .\tests\integration\http_api\live\hs_labware.py --robot_ip 192.168.50.89 --labware_key opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flatpipenv run python .\tests\integration\http_api\live\hs_labware.py`

--- a/robot-server/tests/integration/http_api/live/HS_LABWARE.md
+++ b/robot-server/tests/integration/http_api/live/HS_LABWARE.md
@@ -1,6 +1,6 @@
 # Script for measurement of the Heater Shaker
 
-> Commands below are for a windows machine
+> Paths below are for a windows machine
 
 1. Open command line
 2. Have git installed
@@ -13,15 +13,18 @@
    1. `mkdir opentrons`
 6. go into that directory
    1. `cd opentrons`
-7. clone in the code
+7. clone the repository
    1. `git clone https://github.com/Opentrons/opentrons.git`
-8. move to the robot-server directory
-   1. `cd opentrons/robot-server`
-9. install this package
-   1.  `pipenv install -d`
-10. call the help text on the tool
-    1.  `pipenv run python tests/integration/http_api/live/hs_labware.py -h`
-11. follow the instructions
+8. move to the branch
+   1. `git pull origin`
+   2. `git switch 10313-hs-labware-script-2`
+9.  move to the robot-server directory
+   3. `cd .\opentrons\robot-server`
+10. install this package
+   4.  `pipenv install -d`
+11. call the help text on the tool
+    1.  `pipenv run python .\tests\integration\http_api\live\hs_labware.py -h`
+12. follow the instructions
     1.  change the constants (ALL_CAPS_VARIABLES) at the top of `robot-server/tests/integration/http_api/live/hs_labware.py` file per your robot setup.
-12. run the script
-    1.  `pipenv run python tests/integration/http_api/live/hs_labware.py --robot_ip 192.168.50.89 --labware_key opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat`
+13. run the script replacing the robot ip with your robot ip
+    1.  `pipenv run python .\tests\integration\http_api\live\hs_labware.py --robot_ip 192.168.50.89 --labware_key opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flatpipenv run python .\tests\integration\http_api\live\hs_labware.py`

--- a/robot-server/tests/integration/http_api/live/HS_LABWARE.md
+++ b/robot-server/tests/integration/http_api/live/HS_LABWARE.md
@@ -15,18 +15,18 @@
    1. `cd opentrons`
 7. clone the repository
    1. `git clone https://github.com/Opentrons/opentrons.git`
-8. move into the repository that you just cloned, (this looks a little funny as the path is opentrons/opentrons but actually reflects the structure of organization on github) 
+8. move into the repository that you just cloned, (this looks a little funny as the path is opentrons/opentrons but actually reflects the structure of organization on github)
    1. `cd opentrons`
-9.  move to the branch
-   2. `git pull origin`
-   3. `git switch 10313-hs-labware-script-2`
+9. move to the branch
+   1. `git pull origin`
+   2. `git switch 10313-hs-labware-script-2`
 10. move to the robot-server directory
-   4. `cd .\opentrons\robot-server`
+    1. `cd .\robot-server`
 11. install this package
-   5.  `pipenv install -d`
+    1. `pipenv install -d`
 12. call the help text on the tool
-    1.  `pipenv run python .\tests\integration\http_api\live\hs_labware.py -h`
+    1. `pipenv run python .\tests\integration\http_api\live\hs_labware.py -h`
 13. follow the instructions
-    1.  change the constants (ALL_CAPS_VARIABLES) at the top of `robot-server/tests/integration/http_api/live/hs_labware.py` file per your robot setup.
+    1. change the constants (ALL_CAPS_VARIABLES) at the top of `robot-server/tests/integration/http_api/live/hs_labware.py` file per your robot setup.
 14. run the script replacing the robot ip with your robot ip
-    1.  `pipenv run python .\tests\integration\http_api\live\hs_labware.py --robot_ip 192.168.50.89 --labware_key opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flatpipenv run python .\tests\integration\http_api\live\hs_labware.py`
+    1. `pipenv run python .\tests\integration\http_api\live\hs_labware.py --robot_ip 192.168.50.89 --labware_key opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flatpipenv run python .\tests\integration\http_api\live\hs_labware.py`

--- a/robot-server/tests/integration/http_api/live/HS_LABWARE.md
+++ b/robot-server/tests/integration/http_api/live/HS_LABWARE.md
@@ -1,0 +1,27 @@
+# Script for measurement of the Heater Shaker
+
+> Commands below are for a windows machine
+
+1. Open command line
+2. Have git installed
+   1. `git --version`
+3. Have python 3.7 installed
+   1. `python --version`
+4. Install pipenv globally
+   1. `pip install --global -U pipenv`
+5. make a directory where the code will live
+   1. `mkdir opentrons`
+6. go into that directory
+   1. `cd opentrons`
+7. clone in the code
+   1. `git clone https://github.com/Opentrons/opentrons.git`
+8. move to the robot-server directory
+   1. `cd opentrons/robot-server`
+9. install this package
+   1.  `pipenv install -d`
+10. call the help text on the tool
+    1.  `pipenv run python tests/integration/http_api/live/hs_labware.py -h`
+11. follow the instructions
+    1.  change the constants (ALL_CAPS_VARIABLES) at the top of `robot-server/tests/integration/http_api/live/hs_labware.py` file per your robot setup.
+12. run the script
+    1.  `pipenv run python tests/integration/http_api/live/hs_labware.py --robot_ip 192.168.50.89 --labware_key opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat`

--- a/robot-server/tests/integration/http_api/live/base_cli.py
+++ b/robot-server/tests/integration/http_api/live/base_cli.py
@@ -6,6 +6,7 @@ class Formatter(argparse.RawTextHelpFormatter, argparse.RawDescriptionHelpFormat
 
 
 class BaseCli:
+    """A base cli for inheriting global flags."""
     def __init__(self) -> None:
         self.parser: argparse.ArgumentParser = argparse.ArgumentParser(
             formatter_class=Formatter,

--- a/robot-server/tests/integration/http_api/live/base_cli.py
+++ b/robot-server/tests/integration/http_api/live/base_cli.py
@@ -1,0 +1,15 @@
+import argparse
+
+
+class Formatter(argparse.RawTextHelpFormatter, argparse.RawDescriptionHelpFormatter):
+    pass
+
+
+class BaseCli:
+    def __init__(self) -> None:
+        self.parser: argparse.ArgumentParser = argparse.ArgumentParser(
+            formatter_class=Formatter,
+        )
+        self.parser.add_argument(
+            "--robot_ip", type=str, help="Your robot ip address like: 192.168.50.89"
+        )

--- a/robot-server/tests/integration/http_api/live/base_cli.py
+++ b/robot-server/tests/integration/http_api/live/base_cli.py
@@ -7,10 +7,19 @@ class Formatter(argparse.RawTextHelpFormatter, argparse.RawDescriptionHelpFormat
 
 class BaseCli:
     """A base cli for inheriting global flags."""
+
     def __init__(self) -> None:
         self.parser: argparse.ArgumentParser = argparse.ArgumentParser(
             formatter_class=Formatter,
         )
         self.parser.add_argument(
             "--robot_ip", type=str, help="Your robot ip address like: 192.168.50.89"
+        )
+
+        self.parser.add_argument(
+            "--robot_port",
+            type=str,
+            help="Your robot port like: 31950",
+            nargs="?",
+            default="31950",
         )

--- a/robot-server/tests/integration/http_api/live/freeze.py
+++ b/robot-server/tests/integration/http_api/live/freeze.py
@@ -70,11 +70,13 @@ async def freeze(robot_ip: str, robot_port: str) -> None:
                     }
                 }
                 async with create_task_group() as tg:
+                    # I am not sure if this is doing what I want.
+                    # I want synchronous traffic alongside the execute command call.
+                    tg.start_soon(robot_client.get_run, run_id)
+                    tg.start_soon(robot_interactions.query_random_runs)
                     tg.start_soon(
                         robot_interactions.execute_command, run_id, move_to_well_command
                     )
-                    tg.start_soon(robot_client.get_run, run_id)
-                    tg.start_soon(robot_interactions.query_random_runs)
 
         home_command = {
             "data": {
@@ -89,10 +91,10 @@ async def freeze(robot_ip: str, robot_port: str) -> None:
 if __name__ == "__main__":
 
     cli = BaseCli()
-    cli.parser.description = """
-1. Attach p20_single_gen2 pipette on the right.
+    cli.parser.description = f"""
+1. Attach {PIPETTE} pipette on the {PIPETTE_MOUNT}.
 2. Have an empty deck.
-3. Or place nest_96_wellplate_100ul_pcr_full_skirt in slot 2.
+3. Or place {LABWARE} in slot {LABWARE_SLOT}.
 5. Run this without -h
 """
     args = cli.parser.parse_args()

--- a/robot-server/tests/integration/http_api/live/freeze.py
+++ b/robot-server/tests/integration/http_api/live/freeze.py
@@ -1,9 +1,9 @@
 import asyncio
-from anyio import create_task_group
 
+from anyio import create_task_group
+from tests.integration.http_api.live.base_cli import BaseCli
 from tests.integration.http_api.live.robot_interactions import RobotInteractions
 from tests.integration.http_api.live.util import log_response
-from tests.integration.http_api.live.base_cli import BaseCli
 from tests.integration.robot_client import RobotClient
 
 LABWARE = "nest_96_wellplate_100ul_pcr_full_skirt"

--- a/robot-server/tests/integration/http_api/live/freeze.py
+++ b/robot-server/tests/integration/http_api/live/freeze.py
@@ -6,6 +6,12 @@ from tests.integration.http_api.live.util import log_response
 from tests.integration.http_api.live.base_cli import BaseCli
 from tests.integration.robot_client import RobotClient
 
+LABWARE = "nest_96_wellplate_100ul_pcr_full_skirt"
+LABWARE_SLOT = "2"
+LABWARE_DESTINATION_WELLS = ["A1", "A12", "H1", "H12", "D6"]
+PIPETTE = "p20_single_gen2"
+PIPETTE_MOUNT = "right"
+
 
 async def freeze(robot_ip: str, robot_port: str) -> None:
     """Run the series of commands to repetitively move a pipette to various wells
@@ -26,8 +32,8 @@ async def freeze(robot_ip: str, robot_port: str) -> None:
                 "data": {
                     "commandType": "loadLabware",
                     "params": {
-                        "location": {"slotName": "2"},
-                        "loadName": "nest_96_wellplate_100ul_pcr_full_skirt",
+                        "location": {"slotName": LABWARE_SLOT},
+                        "loadName": LABWARE,
                         "namespace": "opentrons",
                         "version": 1,
                         "labwareId": "destination",
@@ -42,9 +48,9 @@ async def freeze(robot_ip: str, robot_port: str) -> None:
                 "data": {
                     "commandType": "loadPipette",
                     "params": {
-                        "pipetteName": "p20_single_gen2",
-                        "mount": "right",
-                        "pipetteId": "20ul_pipette",
+                        "pipetteName": PIPETTE,
+                        "mount": PIPETTE_MOUNT,
+                        "pipetteId": "pipette",
                     },
                 }
             }
@@ -52,13 +58,12 @@ async def freeze(robot_ip: str, robot_port: str) -> None:
                 run_id=run_id, req_body=load_pipette_command
             )
 
-            wells_on_hs = ["A1", "A12", "H1", "H12", "D6"]
-            for well in wells_on_hs:
+            for well in LABWARE_DESTINATION_WELLS:
                 move_to_well_command = {
                     "data": {
                         "commandType": "moveToWell",
                         "params": {
-                            "pipetteId": "20ul_pipette",
+                            "pipetteId": "pipette",
                             "labwareId": "destination",
                             "wellName": well,
                         },

--- a/robot-server/tests/integration/http_api/live/freeze.py
+++ b/robot-server/tests/integration/http_api/live/freeze.py
@@ -1,0 +1,100 @@
+import asyncio
+
+from tests.integration.http_api.live import util
+from tests.integration.http_api.live.base_cli import BaseCli
+from tests.integration.robot_client import RobotClient
+
+
+async def freeze(robot_ip: str) -> None:
+    """Run the series of commands to move a pipette to various wells
+    on a plate repetitively. This exposed a freezing issue"""
+    async with RobotClient.make(
+        host=f"http://{robot_ip}", port=31950, version="*"
+    ) as robot_client:
+        await robot_client.wait_until_alive()
+        for _ in range(3):
+            run = await robot_client.post_run(req_body={"data": {}})
+            await util.log_response(run)
+            run_id = run.json()["data"]["id"]
+
+            load_plate_command = {
+                "data": {
+                    "commandType": "loadLabware",
+                    "params": {
+                        "location": {"slotName": "2"},
+                        "loadName": "nest_96_wellplate_100ul_pcr_full_skirt",
+                        "namespace": "opentrons",
+                        "version": 1,
+                        "labwareId": "destination",
+                    },
+                }
+            }
+            await util.execute_command(
+                robot_client=robot_client, run_id=run_id, req_body=load_plate_command
+            )
+
+            load_pipette_command = {
+                "data": {
+                    "commandType": "loadPipette",
+                    "params": {
+                        "pipetteName": "p20_single_gen2",
+                        "mount": "right",
+                        "pipetteId": "20ul_pipette",
+                    },
+                }
+            }
+            await util.execute_command(
+                robot_client=robot_client, run_id=run_id, req_body=load_pipette_command
+            )
+
+            wells_on_hs = ["A1", "A12", "H1", "H12", "D6"]
+            for well in wells_on_hs:
+                move_to_well_command = {
+                    "data": {
+                        "commandType": "moveToWell",
+                        "params": {
+                            "pipetteId": "20ul_pipette",
+                            "labwareId": "destination",
+                            "wellName": well,
+                        },
+                    }
+                }
+                command_task = asyncio.create_task(
+                    util.execute_command(
+                        robot_client=robot_client,
+                        run_id=run_id,
+                        req_body=move_to_well_command,
+                    )
+                )
+                try:
+                    # this is a new run we just created and should have busted the cache
+                    await robot_client.get_run(run_id=run_id)
+                    # more queries of the run table for load
+                    await util.query_random_runs(robot_client=robot_client)
+                finally:
+                    await command_task
+
+        home_command = {
+            "data": {
+                "commandType": "home",
+                "params": {},
+            }
+        }
+        print("Homing.")
+        await util.execute_command(
+            robot_client=robot_client, run_id=run_id, req_body=home_command
+        )
+
+
+if __name__ == "__main__":
+
+    cli = BaseCli()
+    cli.parser.description = """
+1. Attach p20_single_gen2 pipette on the right.
+2. Place opentrons_96_tiprack_20ul tip rack in slot 8.
+3. Place nest_96_wellplate_100ul_pcr_full_skirt in slot 2.
+4. Complete Pipette offset and tip length calibrations.
+5. Run this without -h
+"""
+    args = cli.parser.parse_args()
+    asyncio.run(freeze(robot_ip=args.robot_ip))

--- a/robot-server/tests/integration/http_api/live/freeze.py
+++ b/robot-server/tests/integration/http_api/live/freeze.py
@@ -6,8 +6,8 @@ from tests.integration.robot_client import RobotClient
 
 
 async def freeze(robot_ip: str) -> None:
-    """Run the series of commands to move a pipette to various wells
-    on a plate repetitively. This exposed a freezing issue"""
+    """Run the series of commands to repetitively move a pipette to various wells
+    on a plate. This exposed a freezing issue."""
     async with RobotClient.make(
         host=f"http://{robot_ip}", port=31950, version="*"
     ) as robot_client:
@@ -91,9 +91,8 @@ if __name__ == "__main__":
     cli = BaseCli()
     cli.parser.description = """
 1. Attach p20_single_gen2 pipette on the right.
-2. Place opentrons_96_tiprack_20ul tip rack in slot 8.
-3. Place nest_96_wellplate_100ul_pcr_full_skirt in slot 2.
-4. Complete Pipette offset and tip length calibrations.
+2. Have an empty deck.
+3. Or place nest_96_wellplate_100ul_pcr_full_skirt in slot 2.
 5. Run this without -h
 """
     args = cli.parser.parse_args()

--- a/robot-server/tests/integration/http_api/live/hs_commands.py
+++ b/robot-server/tests/integration/http_api/live/hs_commands.py
@@ -1,0 +1,411 @@
+import asyncio
+
+from tests.integration.http_api.live import util
+from tests.integration.http_api.live.base_cli import BaseCli
+from tests.integration.robot_client import RobotClient
+
+
+async def hs_commands(robot_ip: str) -> None:
+    """Run the series of commands necessary to evaluate tip height against labware on the Heater Shaker."""  # noqa: E501
+    async with RobotClient.make(
+        host=f"http://{robot_ip}", port=31950, version="*"
+    ) as robot_client:
+        await robot_client.wait_until_alive()
+        hs_id = await util.get_module_id(
+            robot_client=robot_client, module_model="heaterShakerModuleV1"
+        )
+        run = await robot_client.post_run(req_body={"data": {}})
+        await util.log_response(run)
+        run_id = run.json()["data"]["id"]
+        load_module_command = {
+            "data": {
+                "commandType": "loadModule",
+                "params": {
+                    "model": "heaterShakerModuleV1",
+                    "location": {"slotName": "2"},
+                    "moduleId": hs_id,
+                },
+            }
+        }
+        await util.execute_command(
+            robot_client=robot_client, run_id=run_id, req_body=load_module_command
+        )
+
+        close_latch_command = {
+            "data": {
+                "commandType": "heaterShakerModule/closeLatch",
+                "params": {
+                    "moduleId": hs_id,
+                },
+            }
+        }
+        await util.execute_command(
+            robot_client=robot_client, run_id=run_id, req_body=close_latch_command
+        )
+
+        open_latch_command = {
+            "data": {
+                "commandType": "heaterShakerModule/openLatch",
+                "params": {
+                    "moduleId": hs_id,
+                },
+            }
+        }
+        await util.execute_command(
+            robot_client=robot_client, run_id=run_id, req_body=open_latch_command
+        )
+
+
+if __name__ == "__main__":
+
+    cli = BaseCli()
+    cli.parser.description = """
+Check HS Commands Live
+1. Have a heater shaker connected via USB and powered on.
+2. The code puts the HS is slot 2 but a pipette is not interacting with it.
+3. from the robot-server directory 
+4. pipenv run python tests/integration/http_api/live/hs_commands.py --robot_ip ROBOT_IP
+5. look at robot-server/responses.log
+"""
+
+    args = cli.parser.parse_args()
+    asyncio.run(hs_commands(robot_ip=args.robot_ip))
+
+
+"""
+This is in robot logs
+May 25 16:49:12 kansas opentrons-api[229]: Polling exception
+                                           Traceback (most recent call last):
+                                             File "usr/lib/python3.7/site-packages/opentrons/drivers/utils.py", line 95, in parse_labware_latch_status_response
+                                           KeyError: 'STATUS'
+
+                                           During handling of the above exception, another exception occurred:
+
+                                           Traceback (most recent call last):
+                                             File "usr/lib/python3.7/site-packages/opentrons/hardware_control/poller.py", line 142, in _poller
+                                             File "usr/lib/python3.7/site-packages/opentrons/hardware_control/modules/heater_shaker.py", line 449, in read
+                                             File "usr/lib/python3.7/site-packages/opentrons/drivers/heater_shaker/driver.py", line 155, in get_labware_latch_status
+                                             File "usr/lib/python3.7/site-packages/opentrons/drivers/utils.py", line 99, in parse_labware_latch_status_response
+                                           opentrons.drivers.utils.ParseError: ParseError(error_message=Unexpected argument to parse_labware_latch_status_response, parse_source=M241 STATE:IDLE_OPEN)
+"""
+
+"""
+status_code = 200
+GET http://192.168.50.89:31950/modules0.051337{
+    "data": [
+        {
+            "id": "cf9e174e9f858b835b518a7ced84dda05172ab12",
+            "serialNumber": "MDV20P20210819B12",
+            "firmwareVersion": "2.0.0",
+            "hardwareRevision": "mag_deck_v20",
+            "hasAvailableUpdate": false,
+            "moduleType": "magneticModuleType",
+            "moduleModel": "magneticModuleV2",
+            "data": {
+                "status": "engaged",
+                "engaged": true,
+                "height": 10.5
+            },
+            "usbPort": {
+                "port": 1,
+                "hub": 1,
+                "path": "1.0/tty/ttyACM0/dev"
+            }
+        },
+        {
+            "id": "a83c65e79b3713c851b133533757b10ec8cb2d95",
+            "serialNumber": "HSDVT22041138",
+            "firmwareVersion": "v0.4.3-59aaf12",
+            "hardwareRevision": "Opentrons",
+            "hasAvailableUpdate": false,
+            "moduleType": "heaterShakerModuleType",
+            "moduleModel": "heaterShakerModuleV1",
+            "data": {
+                "status": "idle",
+                "labwareLatchStatus": "idle_unknown",
+                "speedStatus": "idle",
+                "currentSpeed": 0,
+                "temperatureStatus": "idle",
+                "currentTemperature": 25.0
+            },
+            "usbPort": {
+                "port": 2,
+                "hub": 1,
+                "path": "1.0/tty/ttyACM3/dev"
+            }
+        },
+        {
+            "id": "4b611c0b8651a0fe30d4cfef9d6d915baac55381",
+            "serialNumber": "TDV21P20211130D06",
+            "firmwareVersion": "v2.1.0",
+            "hardwareRevision": "temp_deck_v21",
+            "hasAvailableUpdate": false,
+            "moduleType": "temperatureModuleType",
+            "moduleModel": "temperatureModuleV2",
+            "data": {
+                "status": "idle",
+                "currentTemperature": 24.0
+            },
+            "usbPort": {
+                "port": 4,
+                "hub": 1,
+                "path": "1.0/tty/ttyACM2/dev"
+            }
+        },
+        {
+            "id": "4a0bd51e1ee3eb2cd17850b83e6b7c250f25fae0",
+            "serialNumber": "TCV0220211102A02",
+            "firmwareVersion": "v1.1.0",
+            "hardwareRevision": "v02",
+            "hasAvailableUpdate": false,
+            "moduleType": "thermocyclerModuleType",
+            "moduleModel": "thermocyclerModuleV1",
+            "data": {
+                "status": "idle",
+                "currentTemperature": 24.57,
+                "lidStatus": "open",
+                "lidTemperature": 23.75
+            },
+            "usbPort": {
+                "port": 2,
+                "path": "1.0/tty/ttyACM1/dev"
+            }
+        }
+    ],
+    "meta": {
+        "cursor": 0,
+        "totalLength": 4
+    }
+}
+status_code = 201
+POST http://192.168.50.89:31950/runs4.559605 *LONG*{
+    "data": {
+        "id": "0c5fd44b-371b-4d1f-8c52-d42fd2355bfa",
+        "createdAt": "2022-05-25T16:52:24.415019+00:00",
+        "status": "idle",
+        "current": true,
+        "actions": [],
+        "errors": [],
+        "pipettes": [],
+        "labware": [
+            {
+                "id": "fixedTrash",
+                "loadName": "opentrons_1_trash_1100ml_fixed",
+                "definitionUri": "opentrons/opentrons_1_trash_1100ml_fixed/1",
+                "location": {
+                    "slotName": "12"
+                }
+            }
+        ],
+        "labwareOffsets": []
+    }
+}
+status_code = 201
+POST http://192.168.50.89:31950/runs/0c5fd44b-371b-4d1f-8c52-d42fd2355bfa/commands?waitUntilComplete=true0.077322{
+    "data": {
+        "id": "65bbcd43-2443-4806-ab39-7f7dab044509",
+        "createdAt": "2022-05-25T16:52:28.973642+00:00",
+        "commandType": "loadModule",
+        "key": "65bbcd43-2443-4806-ab39-7f7dab044509",
+        "status": "succeeded",
+        "params": {
+            "model": "heaterShakerModuleV1",
+            "location": {
+                "slotName": "2"
+            },
+            "moduleId": "a83c65e79b3713c851b133533757b10ec8cb2d95"
+        },
+        "result": {
+            "moduleId": "a83c65e79b3713c851b133533757b10ec8cb2d95",
+            "definition": {
+                "otSharedSchema": "module/schemas/2",
+                "moduleType": "heaterShakerModuleType",
+                "model": "heaterShakerModuleV1",
+                "labwareOffset": {
+                    "x": -0.125,
+                    "y": 1.125,
+                    "z": 68.275
+                },
+                "dimensions": {
+                    "bareOverallHeight": 82.0,
+                    "overLabwareHeight": 0.0
+                },
+                "calibrationPoint": {
+                    "x": 12.0,
+                    "y": 8.75,
+                    "z": 68.275
+                },
+                "displayName": "Heater-Shaker Module GEN1",
+                "quirks": [],
+                "slotTransforms": {
+                    "ot2_standard": {
+                        "3": {
+                            "labwareOffset": [
+                                [
+                                    -1,
+                                    0,
+                                    0
+                                ],
+                                [
+                                    0,
+                                    -1,
+                                    0
+                                ],
+                                [
+                                    0,
+                                    0,
+                                    1
+                                ]
+                            ]
+                        },
+                        "6": {
+                            "labwareOffset": [
+                                [
+                                    -1,
+                                    0,
+                                    0
+                                ],
+                                [
+                                    0,
+                                    -1,
+                                    0
+                                ],
+                                [
+                                    0,
+                                    0,
+                                    1
+                                ]
+                            ]
+                        },
+                        "9": {
+                            "labwareOffset": [
+                                [
+                                    -1,
+                                    0,
+                                    0
+                                ],
+                                [
+                                    0,
+                                    -1,
+                                    0
+                                ],
+                                [
+                                    0,
+                                    0,
+                                    1
+                                ]
+                            ]
+                        }
+                    },
+                    "ot2_short_trash": {
+                        "3": {
+                            "labwareOffset": [
+                                [
+                                    -1,
+                                    0,
+                                    0
+                                ],
+                                [
+                                    0,
+                                    -1,
+                                    0
+                                ],
+                                [
+                                    0,
+                                    0,
+                                    1
+                                ]
+                            ]
+                        },
+                        "6": {
+                            "labwareOffset": [
+                                [
+                                    -1,
+                                    0,
+                                    0
+                                ],
+                                [
+                                    0,
+                                    -1,
+                                    0
+                                ],
+                                [
+                                    0,
+                                    0,
+                                    1
+                                ]
+                            ]
+                        },
+                        "9": {
+                            "labwareOffset": [
+                                [
+                                    -1,
+                                    0,
+                                    0
+                                ],
+                                [
+                                    0,
+                                    -1,
+                                    0
+                                ],
+                                [
+                                    0,
+                                    0,
+                                    1
+                                ]
+                            ]
+                        }
+                    }
+                },
+                "compatibleWith": []
+            },
+            "model": "heaterShakerModuleV1",
+            "serialNumber": "HSDVT22041138"
+        },
+        "startedAt": "2022-05-25T16:52:28.975734+00:00",
+        "completedAt": "2022-05-25T16:52:28.999307+00:00"
+    }
+}
+status_code = 201
+POST http://192.168.50.89:31950/runs/0c5fd44b-371b-4d1f-8c52-d42fd2355bfa/commands?waitUntilComplete=true2.305496 *LONG*{
+    "data": {
+        "id": "ea7ccf66-67e4-4444-b805-6d3f9685189e",
+        "createdAt": "2022-05-25T16:52:29.056941+00:00",
+        "commandType": "heaterShakerModule/closeLatch",
+        "key": "ea7ccf66-67e4-4444-b805-6d3f9685189e",
+        "status": "failed",
+        "params": {
+            "moduleId": "a83c65e79b3713c851b133533757b10ec8cb2d95"
+        },
+        "error": {
+            "id": "4e300206-2c2a-48b4-ba0b-fbc525012c40",
+            "errorType": "UnexpectedProtocolError",
+            "createdAt": "2022-05-25T16:52:31.309976+00:00",
+            "detail": "ParseError(error_message=Unexpected argument to parse_labware_latch_status_response, parse_source=M241 STATE:IDLE_CLOSED)"
+        },
+        "startedAt": "2022-05-25T16:52:29.059099+00:00",
+        "completedAt": "2022-05-25T16:52:31.309976+00:00"
+    }
+}
+status_code = 201
+POST http://192.168.50.89:31950/runs/0c5fd44b-371b-4d1f-8c52-d42fd2355bfa/commands?waitUntilComplete=true2.725859 *LONG*{
+    "data": {
+        "id": "be04bcd7-f9a5-4467-9137-95c48232bec0",
+        "createdAt": "2022-05-25T16:52:31.381805+00:00",
+        "commandType": "heaterShakerModule/openLatch",
+        "key": "be04bcd7-f9a5-4467-9137-95c48232bec0",
+        "status": "failed",
+        "params": {
+            "moduleId": "a83c65e79b3713c851b133533757b10ec8cb2d95"
+        },
+        "error": {
+            "id": "db21f470-d9d1-477b-9eb9-5d0b5b06cfd5",
+            "errorType": "UnexpectedProtocolError",
+            "createdAt": "2022-05-25T16:52:34.040908+00:00",
+            "detail": "ParseError(error_message=Unexpected argument to parse_labware_latch_status_response, parse_source=M241 STATE:IDLE_OPEN)"
+        },
+        "startedAt": "2022-05-25T16:52:31.383576+00:00",
+        "completedAt": "2022-05-25T16:52:34.040908+00:00"
+    }
+}
+"""

--- a/robot-server/tests/integration/http_api/live/hs_commands.py
+++ b/robot-server/tests/integration/http_api/live/hs_commands.py
@@ -65,10 +65,10 @@ async def hs_commands(robot_ip: str, robot_port: str) -> None:
 if __name__ == "__main__":
 
     cli = BaseCli()
-    cli.parser.description = """
+    cli.parser.description = f"""
 Check HS Commands Live
 1. Have a heater shaker connected via USB and powered on.
-2. The code puts the HS is slot 2 but a pipette is not interacting with it.
+2. The code puts the HS is slot {HS_SLOT} but a pipette is not interacting with it.
 3. from the robot-server directory
 4. pipenv run python tests/integration/http_api/live/hs_commands.py --robot_ip ROBOT_IP
 5. look at robot-server/responses.log

--- a/robot-server/tests/integration/http_api/live/hs_commands.py
+++ b/robot-server/tests/integration/http_api/live/hs_commands.py
@@ -2,17 +2,23 @@ import asyncio
 
 from tests.integration.http_api.live import util
 from tests.integration.http_api.live.base_cli import BaseCli
+from tests.integration.http_api.live.robot_interactions import RobotInteractions
 from tests.integration.robot_client import RobotClient
 
+HS_SLOT = "2"
 
-async def hs_commands(robot_ip: str) -> None:
+
+async def hs_commands(robot_ip: str, robot_port: str) -> None:
     """Run the series of commands necessary to evaluate tip height against labware on the Heater Shaker."""  # noqa: E501
     async with RobotClient.make(
-        host=f"http://{robot_ip}", port=31950, version="*"
+        host=f"http://{robot_ip}", port=robot_port, version="*"
     ) as robot_client:
         await robot_client.wait_until_alive()
-        hs_id = await util.get_module_id(
-            robot_client=robot_client, module_model="heaterShakerModuleV1"
+        robot_interactions: RobotInteractions = RobotInteractions(
+            robot_client=robot_client
+        )
+        hs_id = await robot_interactions.get_module_id(
+            module_model="heaterShakerModuleV1"
         )
         run = await robot_client.post_run(req_body={"data": {}})
         await util.log_response(run)
@@ -22,13 +28,13 @@ async def hs_commands(robot_ip: str) -> None:
                 "commandType": "loadModule",
                 "params": {
                     "model": "heaterShakerModuleV1",
-                    "location": {"slotName": "2"},
+                    "location": {"slotName": HS_SLOT},
                     "moduleId": hs_id,
                 },
             }
         }
-        await util.execute_command(
-            robot_client=robot_client, run_id=run_id, req_body=load_module_command
+        await robot_interactions.execute_command(
+            run_id=run_id, req_body=load_module_command
         )
 
         close_latch_command = {
@@ -39,8 +45,8 @@ async def hs_commands(robot_ip: str) -> None:
                 },
             }
         }
-        await util.execute_command(
-            robot_client=robot_client, run_id=run_id, req_body=close_latch_command
+        await robot_interactions.execute_command(
+            run_id=run_id, req_body=close_latch_command
         )
 
         open_latch_command = {
@@ -51,8 +57,8 @@ async def hs_commands(robot_ip: str) -> None:
                 },
             }
         }
-        await util.execute_command(
-            robot_client=robot_client, run_id=run_id, req_body=open_latch_command
+        await robot_interactions.execute_command(
+            run_id=run_id, req_body=open_latch_command
         )
 
 
@@ -63,349 +69,11 @@ if __name__ == "__main__":
 Check HS Commands Live
 1. Have a heater shaker connected via USB and powered on.
 2. The code puts the HS is slot 2 but a pipette is not interacting with it.
-3. from the robot-server directory 
+3. from the robot-server directory
 4. pipenv run python tests/integration/http_api/live/hs_commands.py --robot_ip ROBOT_IP
 5. look at robot-server/responses.log
+6. look at the logs on the robot
 """
 
     args = cli.parser.parse_args()
-    asyncio.run(hs_commands(robot_ip=args.robot_ip))
-
-
-"""
-This is in robot logs
-May 25 16:49:12 kansas opentrons-api[229]: Polling exception
-                                           Traceback (most recent call last):
-                                             File "usr/lib/python3.7/site-packages/opentrons/drivers/utils.py", line 95, in parse_labware_latch_status_response
-                                           KeyError: 'STATUS'
-
-                                           During handling of the above exception, another exception occurred:
-
-                                           Traceback (most recent call last):
-                                             File "usr/lib/python3.7/site-packages/opentrons/hardware_control/poller.py", line 142, in _poller
-                                             File "usr/lib/python3.7/site-packages/opentrons/hardware_control/modules/heater_shaker.py", line 449, in read
-                                             File "usr/lib/python3.7/site-packages/opentrons/drivers/heater_shaker/driver.py", line 155, in get_labware_latch_status
-                                             File "usr/lib/python3.7/site-packages/opentrons/drivers/utils.py", line 99, in parse_labware_latch_status_response
-                                           opentrons.drivers.utils.ParseError: ParseError(error_message=Unexpected argument to parse_labware_latch_status_response, parse_source=M241 STATE:IDLE_OPEN)
-"""
-
-"""
-status_code = 200
-GET http://192.168.50.89:31950/modules0.051337{
-    "data": [
-        {
-            "id": "cf9e174e9f858b835b518a7ced84dda05172ab12",
-            "serialNumber": "MDV20P20210819B12",
-            "firmwareVersion": "2.0.0",
-            "hardwareRevision": "mag_deck_v20",
-            "hasAvailableUpdate": false,
-            "moduleType": "magneticModuleType",
-            "moduleModel": "magneticModuleV2",
-            "data": {
-                "status": "engaged",
-                "engaged": true,
-                "height": 10.5
-            },
-            "usbPort": {
-                "port": 1,
-                "hub": 1,
-                "path": "1.0/tty/ttyACM0/dev"
-            }
-        },
-        {
-            "id": "a83c65e79b3713c851b133533757b10ec8cb2d95",
-            "serialNumber": "HSDVT22041138",
-            "firmwareVersion": "v0.4.3-59aaf12",
-            "hardwareRevision": "Opentrons",
-            "hasAvailableUpdate": false,
-            "moduleType": "heaterShakerModuleType",
-            "moduleModel": "heaterShakerModuleV1",
-            "data": {
-                "status": "idle",
-                "labwareLatchStatus": "idle_unknown",
-                "speedStatus": "idle",
-                "currentSpeed": 0,
-                "temperatureStatus": "idle",
-                "currentTemperature": 25.0
-            },
-            "usbPort": {
-                "port": 2,
-                "hub": 1,
-                "path": "1.0/tty/ttyACM3/dev"
-            }
-        },
-        {
-            "id": "4b611c0b8651a0fe30d4cfef9d6d915baac55381",
-            "serialNumber": "TDV21P20211130D06",
-            "firmwareVersion": "v2.1.0",
-            "hardwareRevision": "temp_deck_v21",
-            "hasAvailableUpdate": false,
-            "moduleType": "temperatureModuleType",
-            "moduleModel": "temperatureModuleV2",
-            "data": {
-                "status": "idle",
-                "currentTemperature": 24.0
-            },
-            "usbPort": {
-                "port": 4,
-                "hub": 1,
-                "path": "1.0/tty/ttyACM2/dev"
-            }
-        },
-        {
-            "id": "4a0bd51e1ee3eb2cd17850b83e6b7c250f25fae0",
-            "serialNumber": "TCV0220211102A02",
-            "firmwareVersion": "v1.1.0",
-            "hardwareRevision": "v02",
-            "hasAvailableUpdate": false,
-            "moduleType": "thermocyclerModuleType",
-            "moduleModel": "thermocyclerModuleV1",
-            "data": {
-                "status": "idle",
-                "currentTemperature": 24.57,
-                "lidStatus": "open",
-                "lidTemperature": 23.75
-            },
-            "usbPort": {
-                "port": 2,
-                "path": "1.0/tty/ttyACM1/dev"
-            }
-        }
-    ],
-    "meta": {
-        "cursor": 0,
-        "totalLength": 4
-    }
-}
-status_code = 201
-POST http://192.168.50.89:31950/runs4.559605 *LONG*{
-    "data": {
-        "id": "0c5fd44b-371b-4d1f-8c52-d42fd2355bfa",
-        "createdAt": "2022-05-25T16:52:24.415019+00:00",
-        "status": "idle",
-        "current": true,
-        "actions": [],
-        "errors": [],
-        "pipettes": [],
-        "labware": [
-            {
-                "id": "fixedTrash",
-                "loadName": "opentrons_1_trash_1100ml_fixed",
-                "definitionUri": "opentrons/opentrons_1_trash_1100ml_fixed/1",
-                "location": {
-                    "slotName": "12"
-                }
-            }
-        ],
-        "labwareOffsets": []
-    }
-}
-status_code = 201
-POST http://192.168.50.89:31950/runs/0c5fd44b-371b-4d1f-8c52-d42fd2355bfa/commands?waitUntilComplete=true0.077322{
-    "data": {
-        "id": "65bbcd43-2443-4806-ab39-7f7dab044509",
-        "createdAt": "2022-05-25T16:52:28.973642+00:00",
-        "commandType": "loadModule",
-        "key": "65bbcd43-2443-4806-ab39-7f7dab044509",
-        "status": "succeeded",
-        "params": {
-            "model": "heaterShakerModuleV1",
-            "location": {
-                "slotName": "2"
-            },
-            "moduleId": "a83c65e79b3713c851b133533757b10ec8cb2d95"
-        },
-        "result": {
-            "moduleId": "a83c65e79b3713c851b133533757b10ec8cb2d95",
-            "definition": {
-                "otSharedSchema": "module/schemas/2",
-                "moduleType": "heaterShakerModuleType",
-                "model": "heaterShakerModuleV1",
-                "labwareOffset": {
-                    "x": -0.125,
-                    "y": 1.125,
-                    "z": 68.275
-                },
-                "dimensions": {
-                    "bareOverallHeight": 82.0,
-                    "overLabwareHeight": 0.0
-                },
-                "calibrationPoint": {
-                    "x": 12.0,
-                    "y": 8.75,
-                    "z": 68.275
-                },
-                "displayName": "Heater-Shaker Module GEN1",
-                "quirks": [],
-                "slotTransforms": {
-                    "ot2_standard": {
-                        "3": {
-                            "labwareOffset": [
-                                [
-                                    -1,
-                                    0,
-                                    0
-                                ],
-                                [
-                                    0,
-                                    -1,
-                                    0
-                                ],
-                                [
-                                    0,
-                                    0,
-                                    1
-                                ]
-                            ]
-                        },
-                        "6": {
-                            "labwareOffset": [
-                                [
-                                    -1,
-                                    0,
-                                    0
-                                ],
-                                [
-                                    0,
-                                    -1,
-                                    0
-                                ],
-                                [
-                                    0,
-                                    0,
-                                    1
-                                ]
-                            ]
-                        },
-                        "9": {
-                            "labwareOffset": [
-                                [
-                                    -1,
-                                    0,
-                                    0
-                                ],
-                                [
-                                    0,
-                                    -1,
-                                    0
-                                ],
-                                [
-                                    0,
-                                    0,
-                                    1
-                                ]
-                            ]
-                        }
-                    },
-                    "ot2_short_trash": {
-                        "3": {
-                            "labwareOffset": [
-                                [
-                                    -1,
-                                    0,
-                                    0
-                                ],
-                                [
-                                    0,
-                                    -1,
-                                    0
-                                ],
-                                [
-                                    0,
-                                    0,
-                                    1
-                                ]
-                            ]
-                        },
-                        "6": {
-                            "labwareOffset": [
-                                [
-                                    -1,
-                                    0,
-                                    0
-                                ],
-                                [
-                                    0,
-                                    -1,
-                                    0
-                                ],
-                                [
-                                    0,
-                                    0,
-                                    1
-                                ]
-                            ]
-                        },
-                        "9": {
-                            "labwareOffset": [
-                                [
-                                    -1,
-                                    0,
-                                    0
-                                ],
-                                [
-                                    0,
-                                    -1,
-                                    0
-                                ],
-                                [
-                                    0,
-                                    0,
-                                    1
-                                ]
-                            ]
-                        }
-                    }
-                },
-                "compatibleWith": []
-            },
-            "model": "heaterShakerModuleV1",
-            "serialNumber": "HSDVT22041138"
-        },
-        "startedAt": "2022-05-25T16:52:28.975734+00:00",
-        "completedAt": "2022-05-25T16:52:28.999307+00:00"
-    }
-}
-status_code = 201
-POST http://192.168.50.89:31950/runs/0c5fd44b-371b-4d1f-8c52-d42fd2355bfa/commands?waitUntilComplete=true2.305496 *LONG*{
-    "data": {
-        "id": "ea7ccf66-67e4-4444-b805-6d3f9685189e",
-        "createdAt": "2022-05-25T16:52:29.056941+00:00",
-        "commandType": "heaterShakerModule/closeLatch",
-        "key": "ea7ccf66-67e4-4444-b805-6d3f9685189e",
-        "status": "failed",
-        "params": {
-            "moduleId": "a83c65e79b3713c851b133533757b10ec8cb2d95"
-        },
-        "error": {
-            "id": "4e300206-2c2a-48b4-ba0b-fbc525012c40",
-            "errorType": "UnexpectedProtocolError",
-            "createdAt": "2022-05-25T16:52:31.309976+00:00",
-            "detail": "ParseError(error_message=Unexpected argument to parse_labware_latch_status_response, parse_source=M241 STATE:IDLE_CLOSED)"
-        },
-        "startedAt": "2022-05-25T16:52:29.059099+00:00",
-        "completedAt": "2022-05-25T16:52:31.309976+00:00"
-    }
-}
-status_code = 201
-POST http://192.168.50.89:31950/runs/0c5fd44b-371b-4d1f-8c52-d42fd2355bfa/commands?waitUntilComplete=true2.725859 *LONG*{
-    "data": {
-        "id": "be04bcd7-f9a5-4467-9137-95c48232bec0",
-        "createdAt": "2022-05-25T16:52:31.381805+00:00",
-        "commandType": "heaterShakerModule/openLatch",
-        "key": "be04bcd7-f9a5-4467-9137-95c48232bec0",
-        "status": "failed",
-        "params": {
-            "moduleId": "a83c65e79b3713c851b133533757b10ec8cb2d95"
-        },
-        "error": {
-            "id": "db21f470-d9d1-477b-9eb9-5d0b5b06cfd5",
-            "errorType": "UnexpectedProtocolError",
-            "createdAt": "2022-05-25T16:52:34.040908+00:00",
-            "detail": "ParseError(error_message=Unexpected argument to parse_labware_latch_status_response, parse_source=M241 STATE:IDLE_OPEN)"
-        },
-        "startedAt": "2022-05-25T16:52:31.383576+00:00",
-        "completedAt": "2022-05-25T16:52:34.040908+00:00"
-    }
-}
-"""
+    asyncio.run(hs_commands(robot_ip=args.robot_ip, robot_port=args.robot_port))

--- a/robot-server/tests/integration/http_api/live/hs_commands.py
+++ b/robot-server/tests/integration/http_api/live/hs_commands.py
@@ -1,4 +1,5 @@
 import asyncio
+import pprint
 
 from tests.integration.http_api.live import util
 from tests.integration.http_api.live.base_cli import BaseCli
@@ -60,6 +61,66 @@ async def hs_commands(robot_ip: str, robot_port: str) -> None:
         await robot_interactions.execute_command(
             run_id=run_id, req_body=open_latch_command
         )
+
+        hs_module_data = await robot_interactions.get_module_data_by_id(hs_id)
+        pp = pprint.PrettyPrinter(indent=4)
+        pp.pprint(hs_module_data)
+
+        set_target_shake_speed_command = {
+            "data": {
+                "commandType": "heaterShakerModule/setTargetShakeSpeed",
+                "params": {
+                    "moduleId": hs_id,
+                    "rpm": 200,
+                },
+            }
+        }
+
+        stop_shake_command = {
+            "data": {
+                "commandType": "heaterShakerModule/stopShake",
+                "params": {
+                    "moduleId": hs_id,
+                },
+            }
+        }
+
+        set_target_temp_command = {
+            "data": {
+                "commandType": "heaterShakerModule/startSetTargetTemperature",
+                "params": {
+                    "moduleId": hs_id,
+                    "temperature": 25,
+                },
+            }
+        }
+
+        await_target_temp_command = {
+            "data": {
+                "commandType": "heaterShakerModule/awaitTemperature",
+                "params": {
+                    "moduleId": hs_id,
+                },
+            }
+        }
+
+        deactivate_heater_command = {
+            "data": {
+                "commandType": "heaterShakerModule/deactivateHeater",
+                "params": {
+                    "moduleId": hs_id,
+                },
+            }
+        }
+
+        for command in [
+            set_target_shake_speed_command,
+            stop_shake_command,
+            set_target_temp_command,
+            await_target_temp_command,
+            deactivate_heater_command,
+        ]:
+            await robot_interactions.execute_command(run_id=run_id, req_body=command)
 
 
 if __name__ == "__main__":

--- a/robot-server/tests/integration/http_api/live/hs_labware.py
+++ b/robot-server/tests/integration/http_api/live/hs_labware.py
@@ -1,0 +1,163 @@
+import asyncio
+
+from tests.integration.http_api.live import util
+from tests.integration.http_api.live.base_cli import BaseCli
+from tests.integration.robot_client import RobotClient
+
+
+async def hs_measure(robot_ip: str, labware: str) -> None:
+    """Run the series of commands necessary to evaluate tip height against labware on the Heater Shaker."""  # noqa: E501
+    async with RobotClient.make(
+        host=f"http://{robot_ip}", port=31950, version="*"
+    ) as robot_client:
+        await robot_client.wait_until_alive()
+        hs_id = await util.get_module_id(
+            robot_client=robot_client, module_model="heaterShakerModuleV1"
+        )
+        run = await robot_client.post_run(req_body={"data": {}})
+        await util.log_response(run)
+        run_id = run.json()["data"]["id"]
+        load_module_command = {
+            "data": {
+                "commandType": "loadModule",
+                "params": {
+                    "model": "heaterShakerModuleV1",
+                    "location": {"slotName": "2"},
+                    "moduleId": hs_id,
+                },
+            }
+        }
+        await util.execute_command(
+            robot_client=robot_client, run_id=run_id, req_body=load_module_command
+        )
+
+        load_labware_command = {
+            "data": {
+                "commandType": "loadLabware",
+                "params": {
+                    "location": {"moduleId": hs_id},
+                    "loadName": labware,
+                    "namespace": "opentrons",
+                    "version": 1,
+                    "labwareId": "target",
+                },
+            }
+        }
+        await util.execute_command(
+            robot_client=robot_client, run_id=run_id, req_body=load_labware_command
+        )
+
+        load_tiprack_command = {
+            "data": {
+                "commandType": "loadLabware",
+                "params": {
+                    "location": {"slotName": "8"},
+                    "loadName": "opentrons_96_tiprack_20ul",
+                    "namespace": "opentrons",
+                    "version": 1,
+                    "labwareId": "20ul_tips",
+                },
+            }
+        }
+        await util.execute_command(
+            robot_client=robot_client, run_id=run_id, req_body=load_tiprack_command
+        )
+
+        load_pipette_command = {
+            "data": {
+                "commandType": "loadPipette",
+                "params": {
+                    "pipetteName": "p20_single_gen2",
+                    "mount": "right",
+                    "pipetteId": "20ul_pipette",
+                },
+            }
+        }
+        await util.execute_command(
+            robot_client=robot_client, run_id=run_id, req_body=load_pipette_command
+        )
+
+        pickup_tip_command = {
+            "data": {
+                "commandType": "pickUpTip",
+                "params": {
+                    "pipetteId": "20ul_pipette",
+                    "labwareId": "20ul_tips",
+                    "wellName": "A1",
+                },
+            }
+        }
+        print("Picking up tip.")
+        await util.execute_command(
+            robot_client=robot_client, run_id=run_id, req_body=pickup_tip_command
+        )
+
+        wells_on_hs = ["A1", "A12", "H1", "H12", "D6"]
+        for well in wells_on_hs:
+            move_to_well_command = {
+                "data": {
+                    "commandType": "moveToWell",
+                    "params": {
+                        "pipetteId": "20ul_pipette",
+                        "labwareId": "target",
+                        "wellName": well,
+                    },
+                }
+            }
+            await util.execute_command(
+                robot_client=robot_client, run_id=run_id, req_body=move_to_well_command
+            )
+            await util.ainput(f"At well {well} press Enter to move to the next well.")
+
+        drop_tip_command = {
+            "data": {
+                "commandType": "dropTip",
+                "params": {
+                    "pipetteId": "20ul_pipette",
+                    "labwareId": "20ul_tips",
+                    "wellName": "A1",
+                },
+            }
+        }
+        print("Dropping tip.")
+        await util.execute_command(
+            robot_client=robot_client, run_id=run_id, req_body=drop_tip_command
+        )
+
+        home_command = {
+            "data": {
+                "commandType": "home",
+                "params": {},
+            }
+        }
+        print("Homing.")
+        await util.execute_command(
+            robot_client=robot_client, run_id=run_id, req_body=home_command
+        )
+
+
+if __name__ == "__main__":
+
+    cli = BaseCli()
+    cli.parser.description = """
+Check HS Labware
+1. Attach p20_single_gen2 pipette on the right.
+2. Place opentrons_96_tiprack_20ul tip rack in slot 8.
+3. Complete pipette offset and tip length calibrations
+4. Place the Heater Shaker in slot 2
+5. Place the labware to test on top of the Heater Shaker.
+"""
+
+    hs_labware = [
+        "opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat",
+        "opentrons_96_pcr_plate_adapter_nest_wellplate_100ul_pcr_full_skirt",
+        "opentrons_96_deepwell_adapter_nest_wellplate_2ml_deep",
+        "opentrons_flat_plate_adapter_corning_384_wellplate_112ul_flat",
+    ]
+
+    help = "One of \n"
+    for lw in hs_labware:
+        help = help + lw + "\n"
+    cli.parser.add_argument("--labware_key", type=str, help=help)
+    args = cli.parser.parse_args()
+    asyncio.run(hs_measure(robot_ip=args.robot_ip, labware=args.labware_key))

--- a/robot-server/tests/integration/http_api/live/hs_labware.py
+++ b/robot-server/tests/integration/http_api/live/hs_labware.py
@@ -9,7 +9,7 @@ from tests.integration.robot_client import RobotClient
 # Change the value for these constants to swap out
 # location/pipette/tiprack
 
-HS_SLOT = "1" # 1, 3, 6, 4 only
+HS_SLOT = "1"  # 1, 3, 6, 4 only
 TIPRACK = "opentrons_96_tiprack_20ul"
 TIPRACK_SLOT = "8"
 PIPETTE = "p20_single_gen2"

--- a/robot-server/tests/integration/http_api/live/hs_labware.py
+++ b/robot-server/tests/integration/http_api/live/hs_labware.py
@@ -111,9 +111,27 @@ async def hs_measure(robot_ip: str, robot_port: str, labware: str) -> None:
                 "H12",
                 "D6",
             ],
-            "opentrons_96_pcr_plate_adapter_nest_wellplate_100ul_pcr_full_skirt": [],
-            "opentrons_96_deepwell_adapter_nest_wellplate_2ml_deep": [],
-            "opentrons_flat_plate_adapter_corning_384_wellplate_112ul_flat": [],
+            "opentrons_96_pcr_plate_adapter_nest_wellplate_100ul_pcr_full_skirt": [
+                "A1",
+                "A12",
+                "H1",
+                "H12",
+                "D6",
+            ],
+            "opentrons_96_deepwell_adapter_nest_wellplate_2ml_deep": [
+                "A1",
+                "A12",
+                "H1",
+                "H12",
+                "D6",
+            ],
+            "opentrons_flat_plate_adapter_corning_384_wellplate_112ul_flat": [
+                "A1",
+                "A24",
+                "P1",
+                "P24",
+                "H12",
+            ],
         }
         wells_on_hs = mapping[labware]
         for well in wells_on_hs:

--- a/robot-server/tests/integration/http_api/live/hs_labware.py
+++ b/robot-server/tests/integration/http_api/live/hs_labware.py
@@ -6,7 +6,10 @@ from tests.integration.http_api.live.base_cli import BaseCli
 from tests.integration.http_api.live.robot_interactions import RobotInteractions
 from tests.integration.robot_client import RobotClient
 
-HS_SLOT = "2"
+# Change the value for these constants to swap out
+# location/pipette/tiprack
+
+HS_SLOT = "1" # 1, 3, 6, 4 only
 TIPRACK = "opentrons_96_tiprack_20ul"
 TIPRACK_SLOT = "8"
 PIPETTE = "p20_single_gen2"

--- a/robot-server/tests/integration/http_api/live/hs_labware.py
+++ b/robot-server/tests/integration/http_api/live/hs_labware.py
@@ -1,9 +1,10 @@
 import asyncio
+from typing import Dict, List
 
 from tests.integration.http_api.live import util
 from tests.integration.http_api.live.base_cli import BaseCli
-from tests.integration.robot_client import RobotClient
 from tests.integration.http_api.live.robot_interactions import RobotInteractions
+from tests.integration.robot_client import RobotClient
 
 HS_SLOT = "2"
 TIPRACK = "opentrons_96_tiprack_20ul"
@@ -102,7 +103,19 @@ async def hs_measure(robot_ip: str, robot_port: str, labware: str) -> None:
             run_id=run_id, req_body=pickup_tip_command
         )
 
-        wells_on_hs = ["A1", "A12", "H1", "H12", "D6"]
+        mapping: Dict[str, List[str]] = {
+            "opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat": [
+                "A1",
+                "A12",
+                "H1",
+                "H12",
+                "D6",
+            ],
+            "opentrons_96_pcr_plate_adapter_nest_wellplate_100ul_pcr_full_skirt": [],
+            "opentrons_96_deepwell_adapter_nest_wellplate_2ml_deep": [],
+            "opentrons_flat_plate_adapter_corning_384_wellplate_112ul_flat": [],
+        }
+        wells_on_hs = mapping[labware]
         for well in wells_on_hs:
             move_to_well_command = {
                 "data": {
@@ -149,7 +162,7 @@ if __name__ == "__main__":
     cli = BaseCli()
     cli.parser.description = f"""
 Check HS Labware
-1. Change the constants to exchange in location, pipette, and/or tiprack.
+1. Change the constants to alter location, pipette, and/or tiprack.
 2. Attach {PIPETTE} pipette on the {PIPETTE_MOUNT}.
 3. Place {TIPRACK} tip rack in slot {TIPRACK_SLOT}.
 4. Complete pipette offset and tip length calibrations

--- a/robot-server/tests/integration/http_api/live/robot_interactions.py
+++ b/robot-server/tests/integration/http_api/live/robot_interactions.py
@@ -1,0 +1,55 @@
+import random
+from typing import Any, Dict, List
+
+from anyio import create_task_group
+from tests.integration.http_api.live.util import log_response
+from tests.integration.robot_client import RobotClient
+
+
+class RobotInteractions:
+    """Reusable amalgamations of API calls to the robot."""
+
+    def __init__(self, robot_client: RobotClient) -> None:
+        self.robot_client = robot_client
+
+    async def execute_command(
+        self, run_id: str, req_body: Dict[str, Any], timeout_sec: float = 60.0
+    ) -> None:
+        """Post a command to a run waiting until complete then log the response."""
+        params = {"waitUntilComplete": True}
+        command = await self.robot_client.post_run_command(
+            run_id=run_id, req_body=req_body, params=params, timeout_sec=timeout_sec
+        )
+        await log_response(command)
+
+    async def get_module_id(self, module_model: str) -> str:
+        """Given a moduleModel get the id of that module."""
+        modules = await self.robot_client.get_modules()
+        await log_response(modules)
+        ids: List[str] = [
+            module["id"]
+            for module in modules.json()["data"]
+            if module["moduleModel"] == module_model
+        ]
+        if len(ids) > 1:
+            raise ValueError(
+                f"You have multiples of a module {module_model} attached and that is not supported."  # noqa: E501
+            )
+        elif len(ids) == 0:
+            raise ValueError(
+                f"No module attached to the robot has moduleModel of {module_model}"
+            )
+        return ids[0]
+
+    async def query_random_runs(self) -> None:
+        runs = await self.robot_client.get_runs()
+        run_ids = [run["id"] for run in runs.json()["data"]]
+        random_runs = random.choices(run_ids, k=4)
+
+        async def _get_and_log_run(run_id: str) -> None:
+            response = await self.robot_client.get_run(run_id)
+            log_response(response, True)
+
+        async with create_task_group() as tg:
+            for run_id in random_runs:
+                tg.start_soon(_get_and_log_run, run_id)

--- a/robot-server/tests/integration/http_api/live/robot_interactions.py
+++ b/robot-server/tests/integration/http_api/live/robot_interactions.py
@@ -53,3 +53,14 @@ class RobotInteractions:
         async with create_task_group() as tg:
             for run_id in random_runs:
                 tg.start_soon(_get_and_log_run, run_id)
+
+    async def get_module_data_by_id(self, module_id: str) -> Any:
+        """Given a moduleModel get the id of that module."""
+        modules = await self.robot_client.get_modules()
+        await log_response(modules)
+        data = [
+            module for module in modules.json()["data"] if module["id"] == module_id
+        ]
+        if len(data) == 0:
+            raise ValueError(f"No module attached to the robot has id of {module_id}")
+        return data[0]

--- a/robot-server/tests/integration/http_api/live/util.py
+++ b/robot-server/tests/integration/http_api/live/util.py
@@ -1,0 +1,74 @@
+import asyncio
+import json
+import random
+import sys
+from typing import Any, Dict, List
+
+from httpx import Response
+from tests.integration.robot_client import RobotClient
+
+
+async def ainput(string: str) -> str:
+    """async wait for input."""
+    await asyncio.get_event_loop().run_in_executor(None, lambda s=string: print(s))
+    return await asyncio.get_event_loop().run_in_executor(None, sys.stdin.readline)
+
+
+async def log_response(response: Response, print_timing: bool = False) -> None:
+    """Log the response status, url, timing, and json response."""
+    endpoint = f"\nstatus_code = {response.status_code}\n{response.request.method} {response.url}"  # noqa: E501
+    formatted_response_body = json.dumps(response.json(), indent=4)
+    elapsed = response.elapsed.total_seconds()
+    elapsed_output = str(elapsed)
+    if elapsed > 1:
+        elapsed_output = f"{str(elapsed)} *LONG*"
+    if print_timing:
+        print(endpoint)
+        print(elapsed_output)
+    # print(formatted_response_body) # too big to do in console usefully
+    with open("responses.log", "a") as log:
+        log.write(endpoint)
+        log.write(elapsed_output)
+        log.write(formatted_response_body)
+
+
+async def execute_command(
+    robot_client: RobotClient, run_id: str, req_body: Dict[str, Any]
+) -> None:
+    """Post a command to a run waiting until complete then log the response."""
+    params = {"waitUntilComplete": True}
+    command = await robot_client.post_run_command(
+        run_id=run_id, req_body=req_body, params=params, timeout_sec=60.0
+    )
+    await log_response(command)
+
+
+async def get_module_id(robot_client: RobotClient, module_model: str) -> str:
+    """Given a moduleModel get the id of that module."""
+    modules = await robot_client.get_modules()
+    await log_response(modules)
+    ids: List[str] = [
+        module["id"]
+        for module in modules.json()["data"]
+        if module["moduleModel"] == module_model
+    ]
+    if len(ids) > 1:
+        raise ValueError(
+            f"You have multiples of a module {module_model} attached and that is not supported."  # noqa: E501
+        )
+    elif len(ids) == 0:
+        raise ValueError(
+            f"No module attached to the robot has moduleModel of {module_model}"
+        )
+    return ids[0]
+
+
+async def query_random_runs(robot_client: RobotClient) -> None:
+    """Synchronously retrieve 4 random existing run details."""
+    runs = await robot_client.get_runs()
+    run_ids = [run["id"] for run in runs.json()["data"]]
+    random_runs = random.choices(run_ids, k=4)
+    tasks = [robot_client.get_run(run_id) for run_id in random_runs]
+    responses = asyncio.gather(*tasks)
+    for response in await responses:
+        await log_response(response, True)

--- a/robot-server/tests/integration/http_api/live/util.py
+++ b/robot-server/tests/integration/http_api/live/util.py
@@ -1,17 +1,16 @@
-import asyncio
 import json
-import random
 import sys
-from typing import Any, Dict, List
 
+from anyio import to_thread
 from httpx import Response
-from tests.integration.robot_client import RobotClient
 
 
-async def ainput(string: str) -> str:
-    """async wait for input."""
-    await asyncio.get_event_loop().run_in_executor(None, lambda s=string: print(s))
-    return await asyncio.get_event_loop().run_in_executor(None, sys.stdin.readline)
+async def prompt(message: str) -> str:
+    def _prompt() -> str:
+        print(message)
+        return sys.stdin.readline()
+
+    return await to_thread.run_sync(_prompt)
 
 
 async def log_response(response: Response, print_timing: bool = False) -> None:
@@ -24,51 +23,11 @@ async def log_response(response: Response, print_timing: bool = False) -> None:
         elapsed_output = f"{str(elapsed)} *LONG*"
     if print_timing:
         print(endpoint)
+        print("\n")
         print(elapsed_output)
     # print(formatted_response_body) # too big to do in console usefully
     with open("responses.log", "a") as log:
         log.write(endpoint)
+        log.write("\n")
         log.write(elapsed_output)
         log.write(formatted_response_body)
-
-
-async def execute_command(
-    robot_client: RobotClient, run_id: str, req_body: Dict[str, Any]
-) -> None:
-    """Post a command to a run waiting until complete then log the response."""
-    params = {"waitUntilComplete": True}
-    command = await robot_client.post_run_command(
-        run_id=run_id, req_body=req_body, params=params, timeout_sec=60.0
-    )
-    await log_response(command)
-
-
-async def get_module_id(robot_client: RobotClient, module_model: str) -> str:
-    """Given a moduleModel get the id of that module."""
-    modules = await robot_client.get_modules()
-    await log_response(modules)
-    ids: List[str] = [
-        module["id"]
-        for module in modules.json()["data"]
-        if module["moduleModel"] == module_model
-    ]
-    if len(ids) > 1:
-        raise ValueError(
-            f"You have multiples of a module {module_model} attached and that is not supported."  # noqa: E501
-        )
-    elif len(ids) == 0:
-        raise ValueError(
-            f"No module attached to the robot has moduleModel of {module_model}"
-        )
-    return ids[0]
-
-
-async def query_random_runs(robot_client: RobotClient) -> None:
-    """Synchronously retrieve 4 random existing run details."""
-    runs = await robot_client.get_runs()
-    run_ids = [run["id"] for run in runs.json()["data"]]
-    random_runs = random.choices(run_ids, k=4)
-    tasks = [robot_client.get_run(run_id) for run_id in random_runs]
-    responses = asyncio.gather(*tasks)
-    for response in await responses:
-        await log_response(response, True)

--- a/robot-server/tests/integration/robot_client.py
+++ b/robot-server/tests/integration/robot_client.py
@@ -176,12 +176,14 @@ class RobotClient:
         run_id: str,
         req_body: Dict[str, object],
         params: Dict[str, Any],
+        timeout_sec: float = 30.0,
     ) -> Response:
         """POST /runs/:run_id/commands."""
         response = await self.httpx_client.post(
             url=f"{self.base_url}/runs/{run_id}/commands",
             json=req_body,
             params=params,
+            timeout=timeout_sec,
         )
         response.raise_for_status()
         return response
@@ -251,5 +253,11 @@ class RobotClient:
             url=f"{self.base_url}/settings/reset",
             json=req_body,
         )
+        response.raise_for_status()
+        return response
+
+    async def get_modules(self) -> Response:
+        """GET /modules."""
+        response = await self.httpx_client.get(url=f"{self.base_url}/modules")
         response.raise_for_status()
         return response


### PR DESCRIPTION
closes #10313

# Overview

- Give testers the ability to position a tip over a labware for measurement.
- Specifically give QC the ability to measure the new Heater Shaker labware definitions.
- Execute the freeze test #10345
- This pattern will evolve to allow more live testing of robots using API commands.

## How to use

- Have monorepo [python dev environment set up](https://github.com/Opentrons/opentrons/blob/0d419626704d11e7c2a0303d726e77d3e01b8d95/DEV_SETUP.md#L1)
- Navigate to the robot-server folder
  - `cd robot-server`
### Heater Shaker Labware Tests
- See the instructions
  - `pipenv run python tests/integration/http_api/live/hs_labware.py -h`
```shell
🧶🐍💜🐍🧶 
~/github/opentrons/opentrons/robot-server on  10313-hs-labware-script-2! ⌚ 14:37:04
$ pipenv run python tests/integration/http_api/live/hs_labware.py -h
usage: hs_labware.py [-h] [--robot_ip ROBOT_IP] [--labware_key LABWARE_KEY]

Check HS Labware
1. Attach p20_single_gen2 pipette on the right.
2. Place opentrons_96_tiprack_20ul tip rack in slot 8.
3. Complete pipette offset and tip length calibrations
4. Place the Heater Shaker in slot 2
5. Place the labware to test on top of the Heater Shaker.

optional arguments:
  -h, --help            show this help message and exit
  --robot_ip ROBOT_IP   Your robot ip address like: 192.168.50.89
  --labware_key LABWARE_KEY
                        One of 
                        opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat
                        opentrons_96_pcr_plate_adapter_nest_wellplate_100ul_pcr_full_skirt
                        opentrons_96_deepwell_adapter_nest_wellplate_2ml_deep
                        opentrons_flat_plate_adapter_corning_384_wellplate_112ul_flat
```
- Follow the steps to setup your robot 
- Construct the command like below
  - `pipenv run python tests/integration/http_api/live/hs_labware.py --labware_key opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat --robot_ip 192.168.50.89`
- Follow the on screen prompts

### Freeze Test
- See the instructions
  - `pipenv run python tests/integration/http_api/live/freeze.py -h`
```shell
🧶🐍💜🐍🧶 
~/github/opentrons/opentrons/robot-server on  10313-hs-labware-script-2! ⌚ 14:37:08
$ pipenv run python tests/integration/http_api/live/freeze.py -h    
usage: freeze.py [-h] [--robot_ip ROBOT_IP]

1. Attach p20_single_gen2 pipette on the right.
2. Have an empty deck.
3. Or place nest_96_wellplate_100ul_pcr_full_skirt in slot 2.
5. Run this without -h

optional arguments:
  -h, --help           show this help message and exit
  --robot_ip ROBOT_IP  Your robot ip address like: 192.168.50.89
```
- Follow the steps to setup your robot 
- Construct the command like below
  - `pipenv run python tests/integration/http_api/live/freeze.py --robot_ip 192.168.50.89`
- Follow the on screen prompts

### The log

> A log of all the API calls is created at `robot-server/responses.log`

## Risk assessment
None test only.
