### PR TITLE
fix(app): update out of date support links

### DIFF
--- a/app/src/organisms/AppSettings/ConnectRobotSlideout.tsx
+++ b/app/src/organisms/AppSettings/ConnectRobotSlideout.tsx
@@ -25,7 +25,7 @@ import { getScanning, startDiscovery } from '../../redux/discovery'
 import type { Dispatch, State } from '../../redux/types'
 
 const SUPPORT_PAGE_LINK =
-  'https://support.opentrons.com/en/articles/2934336-manually-adding-a-robot-s-ip-address'
+  'https://support.opentrons.com/s/article/Manually-adding-a-robot-s-IP-address'
 
 export interface ConnectRobotSlideoutProps {
   isExpanded: boolean

--- a/app/src/organisms/AppSettings/GeneralSettings.tsx
+++ b/app/src/organisms/AppSettings/GeneralSettings.tsx
@@ -42,8 +42,7 @@ import { ConnectRobotSlideout } from './ConnectRobotSlideout'
 import type { Dispatch, State } from '../../redux/types'
 
 const SOFTWARE_SYNC_URL =
-  'https://support.opentrons.com/en/articles/1795303-get-started-update-your-ot-2#:~:text=It%E2%80%99s%20important%20to%20understand,that%20runs%20your%20protocols).'
-
+  'https://support.opentrons.com/s/article/Get-started-Update-your-OT-2'
 const GITHUB_LINK =
   'https://github.com/Opentrons/opentrons/blob/edge/app-shell/build/release-notes.md'
 

--- a/app/src/organisms/AppSettings/PreviousVersionModal.tsx
+++ b/app/src/organisms/AppSettings/PreviousVersionModal.tsx
@@ -8,8 +8,7 @@ import { PrimaryButton } from '../../atoms/buttons'
 import { StyledText } from '../../atoms/text'
 
 export const UNINSTALL_APP_URL =
-  'https://support.opentrons.com/en/articles/2393514-uninstall-the-opentrons-app'
-
+  'https://support.opentrons.com/s/article/Uninstall-the-Opentrons-App'
 export const PREVIOUS_RELEASES_URL =
   'https://github.com/Opentrons/opentrons/releases'
 

--- a/app/src/organisms/AppSettings/__tests__/ConnectRobotSlideout.test.tsx
+++ b/app/src/organisms/AppSettings/__tests__/ConnectRobotSlideout.test.tsx
@@ -95,7 +95,7 @@ describe('ConnectRobotSlideout', () => {
   it('renders the link and it has the correct href attribute', () => {
     const { getByText } = render(props)
     const targetLink =
-      'https://support.opentrons.com/en/articles/2934336-manually-adding-a-robot-s-ip-address'
+      'https://support.opentrons.com/s/article/Manually-adding-a-robot-s-IP-address'
     const link = getByText('Learn more about connecting a robot manually')
     expect(link.closest('a')).toHaveAttribute('href', targetLink)
   })

--- a/app/src/organisms/CalibrateTipLength/ConfirmRecalibrationModal.tsx
+++ b/app/src/organisms/CalibrateTipLength/ConfirmRecalibrationModal.tsx
@@ -29,8 +29,8 @@ const THIS_LINK = 'this link'
 const CONTINUE = 'continue to calibrate tip length'
 const CANCEL = 'cancel'
 
-// TODO: This link needs to be real(er)
-const CALIBRATION_URL = 'https://support.opentrons.com/en/articles/4523313'
+const CALIBRATION_URL =
+  'https://support.opentrons.com/s/article/Recalibrating-tip-length-before-running-a-protocol'
 
 interface Props {
   confirm: () => unknown

--- a/app/src/organisms/CalibrationPanels/NeedHelpLink.tsx
+++ b/app/src/organisms/CalibrationPanels/NeedHelpLink.tsx
@@ -2,9 +2,7 @@ import * as React from 'react'
 import { Flex, Link, C_BLUE, FONT_SIZE_BODY_1 } from '@opentrons/components'
 
 const NEED_HELP = 'Need Help?'
-const SUPPORT_PAGE =
-  'https://support.opentrons.com/en/collections/2426956-ot-2-calibration'
-
+const SUPPORT_PAGE = 'https://support.opentrons.com/s/ot2-calibration'
 type Props = React.ComponentProps<typeof Flex>
 
 export function NeedHelpLink(props: Props): JSX.Element {

--- a/app/src/organisms/Devices/ConnectionTroubleshootingModal.tsx
+++ b/app/src/organisms/Devices/ConnectionTroubleshootingModal.tsx
@@ -6,6 +6,7 @@ import {
   DIRECTION_COLUMN,
   Flex,
   Box,
+  Link,
   TYPOGRAPHY,
   SPACING,
   TEXT_TRANSFORM_CAPITALIZE,
@@ -13,11 +14,10 @@ import {
 
 import { StyledText } from '../../atoms/text'
 import { Modal } from '../../atoms/Modal'
-import { ExternalLink } from '../../atoms/Link/ExternalLink'
 import { PrimaryButton } from '../../atoms/buttons'
 
 const NEW_ROBOT_SETUP_SUPPORT_ARTICLE_HREF =
-  'https://support.opentrons.com/en/articles/2687601-troubleshooting-connection-problems'
+  'https://support.opentrons.com/s/article/Troubleshooting-connection-problems'
 const SUPPORT_EMAIL = 'support@opentrons.com'
 
 interface Props {
@@ -50,12 +50,15 @@ export function ConnectionTroubleshootingModal(props: Props): JSX.Element {
             support_email: SUPPORT_EMAIL,
           })}
         </StyledText>
-        <ExternalLink
+        <Link
+          external
+          css={TYPOGRAPHY.linkPSemiBold}
           href={NEW_ROBOT_SETUP_SUPPORT_ARTICLE_HREF}
           marginTop={SPACING.spacing4}
+          marginBottom={SPACING.spacing5}
         >
           {t('learn_more_about_troubleshooting_connection')}
-        </ExternalLink>
+        </Link>
         <PrimaryButton
           onClick={() => props.onClose()}
           alignSelf={ALIGN_FLEX_END}

--- a/app/src/organisms/Devices/DevicesEmptyState.tsx
+++ b/app/src/organisms/Devices/DevicesEmptyState.tsx
@@ -25,9 +25,9 @@ import {
 import { startDiscovery } from '../../redux/discovery'
 
 export const OT2_GET_STARTED_URL =
-  'https://support.opentrons.com/en/collections/1559720-ot-2-get-started'
+  'https://support.opentrons.com/s/ot2-get-started'
 export const TROUBLESHOOTING_CONNECTION_PROBLEMS_URL =
-  'https://support.opentrons.com/en/articles/2687601-troubleshooting-connection-problems'
+  'https://support.opentrons.com/s/article/Troubleshooting-connection-problems'
 
 export function DevicesEmptyState(): JSX.Element {
   const { t } = useTranslation('devices_landing')

--- a/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibrationItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibrationItem.tsx
@@ -33,8 +33,7 @@ import { SetupCalibrationItem } from './SetupCalibrationItem'
 import type { PipetteInfo } from '../hooks'
 
 const inexactPipetteSupportArticle =
-  'https://support.opentrons.com/en/articles/3450143-gen2-pipette-compatibility'
-
+  'https://support.opentrons.com/s/article/GEN2-pipette-compatibility'
 interface SetupPipetteCalibrationItemProps {
   pipetteInfo: PipetteInfo
   index: number

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsNetworking.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsNetworking.tsx
@@ -34,7 +34,7 @@ interface NetworkingProps {
 // ToDo modify ConnectModal to align with new design
 // This is temporary until we can get the new design details
 const HELP_CENTER_URL =
-  'https://support.opentrons.com/en/articles/2687586-get-started-connect-to-your-ot-2-over-usb'
+  'https://support.opentrons.com/s/article/Get-started-Connect-to-your-OT-2-over-USB'
 const STATUS_REFRESH_MS = 5000
 const LIST_REFRESH_MS = 10000
 

--- a/app/src/organisms/Devices/RobotSettings/__tests__/RobotSettingsNetworking.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/__tests__/RobotSettingsNetworking.test.tsx
@@ -192,7 +192,7 @@ describe('RobotSettingsNetworking', () => {
 
   it('should render the right links to external resouce and internal resource', () => {
     const usbExternalLink =
-      'https://support.opentrons.com/en/articles/2687586-get-started-connect-to-your-ot-2-over-usb'
+      'https://support.opentrons.com/s/article/Get-started-Connect-to-your-OT-2-over-USB'
     const usbInternalLink = '/app-settings/advanced'
     const [{ getByText }] = render()
     const externalLink = getByText('Learn about connecting to a robot via USB')

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/LabwareOffsetModal.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/LabwareOffsetModal.tsx
@@ -26,9 +26,9 @@ import { Portal } from '../../../../App/portal'
 import styles from '../../styles.css'
 
 const ROBOT_CAL_HELP_ARTICLE =
-  'https://support.opentrons.com/en/articles/3499692-how-positional-calibration-works-on-the-ot-2'
+  'https://support.opentrons.com/s/article/How-positional-calibration-works-on-the-OT-2'
 const OFFSET_DATA_HELP_ARTICLE =
-  'http://support.opentrons.com/en/articles/5742955-how-labware-offsets-work-on-the-ot-2'
+  'https://support.opentrons.com/s/article/How-Labware-Offsets-work-on-the-OT-2'
 interface LabwareOffsetModalProps {
   onCloseClick: () => unknown
 }

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareOffsetModal.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareOffsetModal.test.tsx
@@ -57,7 +57,7 @@ describe('LabwareOffsetModal', () => {
         name: 'Learn more about Robot Calibration',
       }).getAttribute('href')
     ).toBe(
-      'https://support.opentrons.com/en/articles/3499692-how-positional-calibration-works-on-the-ot-2'
+      'https://support.opentrons.com/s/article/How-positional-calibration-works-on-the-OT-2'
     )
   })
   it('should render a link to the learn more page', () => {
@@ -67,7 +67,7 @@ describe('LabwareOffsetModal', () => {
         name: 'Learn more about Labware Offset Data',
       }).getAttribute('href')
     ).toBe(
-      'http://support.opentrons.com/en/articles/5742955-how-labware-offsets-work-on-the-ot-2'
+      'https://support.opentrons.com/s/article/How-Labware-Offsets-work-on-the-OT-2'
     )
   })
   it('should call onCloseClick when the close button is pressed', () => {

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/MultipleModulesModal.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/MultipleModulesModal.tsx
@@ -28,7 +28,7 @@ import multipleModuleHelp from '../../../../assets/images/MoaM_modal_Image.svg'
 import styles from '../../styles.css'
 
 const HOW_TO_MULTIPLE_MODULES_HREF =
-  'https://support.opentrons.com/en/articles/5167312-using-modules-of-the-same-type-on-the-ot-2'
+  'https://support.opentrons.com/s/article/Using-modules-of-the-same-type-on-the-OT-2'
 
 interface MultipleModulesModalProps {
   onCloseClick: () => unknown

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/__tests__/MultipleModuleModal.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/__tests__/MultipleModuleModal.test.tsx
@@ -40,7 +40,7 @@ describe('MultipleModulesModal', () => {
         name: 'Learn more about using more than one module of the same type',
       }).getAttribute('href')
     ).toBe(
-      'https://support.opentrons.com/en/articles/5167312-using-modules-of-the-same-type-on-the-ot-2'
+      'https://support.opentrons.com/s/article/Using-modules-of-the-same-type-on-the-OT-2'
     )
   })
   it('should call onCloseClick when the close button is pressed', () => {

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/RobotCalibration/DeckCalibrationModal.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/RobotCalibration/DeckCalibrationModal.tsx
@@ -27,8 +27,7 @@ import RobotCalHelpImage from '../../../../assets/images/robot_calibration_help.
 import { Portal } from '../../../../App/portal'
 
 const robotCalHelpArticle =
-  'https://support.opentrons.com/en/articles/3499692-how-positional-calibration-works-on-the-ot-2'
-
+  'https://support.opentrons.com/s/article/How-positional-calibration-works-on-the-OT-2'
 interface DeckCalibrationModalProps {
   onCloseClick: () => unknown
 }

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/RobotCalibration/PipetteCalibration.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/RobotCalibration/PipetteCalibration.tsx
@@ -29,8 +29,7 @@ import { CalibrationItem } from './CalibrationItem'
 import type { PipetteInfo } from '../hooks/useCurrentRunPipetteInfoByMount'
 
 const inexactPipetteSupportArticle =
-  'https://support.opentrons.com/en/articles/3450143-gen2-pipette-compatibility'
-
+  'https://support.opentrons.com/s/article/GEN2-pipette-compatibility'
 interface Props {
   pipetteInfo: PipetteInfo
   index: number

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/RobotCalibration/__tests__/DeckCalibrationModal.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/RobotCalibration/__tests__/DeckCalibrationModal.test.tsx
@@ -54,7 +54,7 @@ describe('DeckCalibrationModal', () => {
         name: 'Learn more about robot calibration',
       }).getAttribute('href')
     ).toBe(
-      'https://support.opentrons.com/en/articles/3499692-how-positional-calibration-works-on-the-ot-2'
+      'https://support.opentrons.com/s/article/How-positional-calibration-works-on-the-OT-2'
     )
   })
   it('should call onCloseClick when the close button is pressed', () => {

--- a/app/src/organisms/ProtocolUpload/RerunningProtocolModal.tsx
+++ b/app/src/organisms/ProtocolUpload/RerunningProtocolModal.tsx
@@ -31,7 +31,7 @@ interface RerunningProtocolModalProps {
 }
 
 const UPLOAD_PROTOCOL_URL =
-  'http://support.opentrons.com/en/articles/5742955-how-labware-offsets-work-on-the-ot-2'
+  'https://support.opentrons.com/s/article/How-Labware-Offsets-work-on-the-OT-2'
 
 export const RerunningProtocolModal = (
   props: RerunningProtocolModalProps

--- a/app/src/organisms/ProtocolUpload/hooks/__tests__/RerunningProtocolModal.test.tsx
+++ b/app/src/organisms/ProtocolUpload/hooks/__tests__/RerunningProtocolModal.test.tsx
@@ -41,7 +41,7 @@ describe('RerunningProtocolModal', () => {
         name: 'Learn more about Labware Offset Data',
       }).getAttribute('href')
     ).toBe(
-      'http://support.opentrons.com/en/articles/5742955-how-labware-offsets-work-on-the-ot-2'
+      'https://support.opentrons.com/s/article/How-Labware-Offsets-work-on-the-OT-2'
     )
   })
   it('should call onCloseClick when the close button is pressed', () => {

--- a/app/src/pages/Devices/DevicesLanding/NewRobotSetupHelp.tsx
+++ b/app/src/pages/Devices/DevicesLanding/NewRobotSetupHelp.tsx
@@ -17,7 +17,7 @@ import { ExternalLink } from '../../../atoms/Link/ExternalLink'
 import { PrimaryButton } from '../../../atoms/buttons'
 
 const NEW_ROBOT_SETUP_SUPPORT_ARTICLE_HREF =
-  'https://support.opentrons.com/en/collections/1559720-ot-2-get-started'
+  'https://support.opentrons.com/s/ot2-get-started'
 
 export function NewRobotSetupHelp(): JSX.Element {
   const { t } = useTranslation(['devices_landing', 'shared'])

--- a/app/src/pages/Robots/RobotSettings/CalibrationCard.tsx
+++ b/app/src/pages/Robots/RobotSettings/CalibrationCard.tsx
@@ -49,8 +49,7 @@ interface Props {
 
 const DECK_CAL_STATUS_POLL_INTERVAL = 10000
 const CAL_ARTICLE_URL =
-  'https://support.opentrons.com/en/articles/3499692-how-calibration-works-on-the-ot-2'
-
+  'https://support.opentrons.com/s/article/How-positional-calibration-works-on-the-OT-2'
 const attachedPipetteCalPresent: (
   pipettes: AttachedPipettesByMount,
   pipetteCalibrations: PipetteCalibrationsByMount


### PR DESCRIPTION
fix #10204

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
Change support links to new salesforce links

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
Updated all links according to this spreadsheet https://docs.google.com/spreadsheets/d/14QmcI6KgWcUN2m4MjVjKeDEkX-548biQUmJsGXMMgnc/edit#gid=0
Updated some of the link styling from this comment https://github.com/Opentrons/opentrons/pull/10364#pullrequestreview-980052547

# Review requests

<!--
Describe any requests for your reviewers here.
-->
Verify all of the links are correct as detailed in the spreadsheet
# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Low