### PR TITLE
fix(app): Fix the section order (Deck Calibration)

### DIFF
--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
@@ -416,6 +416,42 @@ export function RobotSettingsCalibration({
         </Flex>
       </Box>
       <Line />
+      {deckCalibrationButtonText === t('deck_calibration_calibrate_button') && (
+        <Banner type="error">
+          <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} width="100%">
+            <StyledText as="p">{t('deck_calibration_missing')}</StyledText>
+            <Link
+              role="button"
+              color={COLORS.darkBlack}
+              css={TYPOGRAPHY.pRegular}
+              textDecoration={TEXT_DECORATION_UNDERLINE}
+              onClick={() => confirmStart()}
+            >
+              {t('calibrate_now')}
+            </Link>
+          </Flex>
+        </Banner>
+      )}
+      <Box paddingTop={SPACING.spacing5} paddingBottom={SPACING.spacing5}>
+        <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>
+          <Box marginRight={SPACING.spacing6}>
+            <Box css={TYPOGRAPHY.h3SemiBold} marginBottom={SPACING.spacing3}>
+              {t('deck_calibration_title')}
+            </Box>
+            <StyledText as="p" marginBottom={SPACING.spacing3}>
+              {t('deck_calibration_description')}
+            </StyledText>
+            <StyledText as="label">{deckLastModified()}</StyledText>
+          </Box>
+          <TertiaryButton
+            onClick={() => confirmStart()}
+            disabled={disabledOrBusyReason !== null}
+          >
+            {deckCalibrationButtonText}
+          </TertiaryButton>
+        </Flex>
+      </Box>
+      <Line />
       {showPipetteOffsetCalibrationBanner && (
         <Banner
           type={pipetteOffsetCalBannerType === 'error' ? 'error' : 'warning'}
@@ -466,41 +502,6 @@ export function RobotSettingsCalibration({
               <StyledText as="label">{t('not_calibrated')}</StyledText>
             )}
           </Box>
-        </Flex>
-      </Box>
-      {deckCalibrationButtonText === t('deck_calibration_calibrate_button') && (
-        <Banner type="error">
-          <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} width="100%">
-            <StyledText as="p">{t('deck_calibration_missing')}</StyledText>
-            <Link
-              role="button"
-              color={COLORS.darkBlack}
-              css={TYPOGRAPHY.pRegular}
-              textDecoration={TEXT_DECORATION_UNDERLINE}
-              onClick={() => confirmStart()}
-            >
-              {t('calibrate_now')}
-            </Link>
-          </Flex>
-        </Banner>
-      )}
-      <Box paddingTop={SPACING.spacing5} paddingBottom={SPACING.spacing5}>
-        <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>
-          <Box marginRight={SPACING.spacing6}>
-            <Box css={TYPOGRAPHY.h3SemiBold} marginBottom={SPACING.spacing3}>
-              {t('deck_calibration_title')}
-            </Box>
-            <StyledText as="p" marginBottom={SPACING.spacing3}>
-              {t('deck_calibration_description')}
-            </StyledText>
-            <StyledText as="label">{deckLastModified()}</StyledText>
-          </Box>
-          <TertiaryButton
-            onClick={() => confirmStart()}
-            disabled={disabledOrBusyReason !== null}
-          >
-            {deckCalibrationButtonText}
-          </TertiaryButton>
         </Flex>
       </Box>
       <Line />


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This will fix #10392

![Screen Shot 2022-05-23 at 9 53 13 AM](https://user-images.githubusercontent.com/474225/169835038-6804bf09-f9dc-4e5a-82a5-768e1cdbe670.png)


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- Fixed the section order 
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- Deck Calibration section is under Calibration data download section
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
