### PR TITLE
refactor(hardware): types: polymorphic field ctors

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
@@ -1,6 +1,8 @@
 """Custom payload fields."""
 from __future__ import annotations
 
+from typing import Iterable, List, Iterator
+
 import binascii
 import enum
 
@@ -126,6 +128,28 @@ class SerialField(utils.BinaryFieldBase[bytes]):
 
 class SensorOutputBindingField(utils.UInt8Field):
     """sensor type."""
+
+    @classmethod
+    def from_flags(
+        cls, flags: Iterable[SensorOutputBinding]
+    ) -> "SensorOutputBindingField":
+        """Build a binding with a set of flags."""
+        backing = 0
+        for flag in flags:
+            backing |= flag.value
+        return cls.build(backing)
+
+    def to_flags(self) -> List[SensorOutputBinding]:
+        """Get the list of flags in the binding."""
+
+        def _flags() -> Iterator[SensorOutputBinding]:
+            for flag in SensorOutputBinding:
+                if flag == SensorOutputBinding.none:
+                    continue
+                if bool(flag.value & self.value):
+                    yield flag
+
+        return list(_flags())
 
     def __repr__(self) -> str:
         """Print version flags."""

--- a/hardware/opentrons_hardware/firmware_bindings/utils/binary_serializable.py
+++ b/hardware/opentrons_hardware/firmware_bindings/utils/binary_serializable.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 import struct
 from dataclasses import dataclass, fields, astuple
-from typing import TypeVar, Generic
+from typing import TypeVar, Generic, Type
 
 
 class BinarySerializableException(BaseException):
@@ -30,6 +30,7 @@ T = TypeVar("T")
 class BinaryFieldBase(Generic[T]):
     """Binary serializable field."""
 
+    This = TypeVar("This", bound="BinaryFieldBase[T]")
     FORMAT = ""
     """The struct format string for this field."""
 
@@ -38,7 +39,7 @@ class BinaryFieldBase(Generic[T]):
         self._t = t
 
     @classmethod
-    def build(cls, t: T) -> BinaryFieldBase[T]:
+    def build(cls: Type[This], t: T) -> This:
         """Factory method.
 
         Args:
@@ -50,7 +51,7 @@ class BinaryFieldBase(Generic[T]):
         return cls(t)
 
     @classmethod
-    def from_string(cls, t: str) -> BinaryFieldBase[T]:
+    def from_string(cls: Type[This], t: str) -> This:
         """Create from a string.
 
         Args:


### PR DESCRIPTION
By making the class arg of BinaryFieldBase factory functions a typevar
with a bound of the base itself, when using the factories from child
classes of BinaryFieldBase (i.e. UInt8Field.build()) then the return
type will be the child class. This means, among other htings, that we
can use the base class factories in child class factories that are
explicitly noted to return instances of the child class.

An example is in this commit, where we can add some new factories
to the sensor flags type and use the BFB build functions easily.