### PR TITLE
refactor(app): add protocol run setup loading state

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -111,5 +111,6 @@
   "thermocycler_extra_attention": "Labware must be secured with the module’s latch. Thermocycler lid must be open when robot moves to the slots it occupies. Opentrons will automatically open the lid to move to these slots during Labware Position Check.",
   "calibration_data_not_available": "Calibration data not available once run has started",
   "connection_info_not_available": "Connection info not available once run has started",
-  "setup_is_view_only": "Setup is view-only once run has started"
+  "setup_is_view_only": "Setup is view-only once run has started",
+  "loading_data": "Loading data..."
 }

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunSetup.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunSetup.tsx
@@ -1,10 +1,17 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { Flex, DIRECTION_COLUMN, SPACING } from '@opentrons/components'
+import {
+  Flex,
+  ALIGN_CENTER,
+  COLORS,
+  DIRECTION_COLUMN,
+  SPACING,
+} from '@opentrons/components'
 import { protocolHasModules } from '@opentrons/shared-data'
 
 import { Line } from '../../../atoms/structure'
+import { StyledText } from '../../../atoms/text'
 import { InfoMessage } from '../../../molecules/InfoMessage'
 import {
   useDeckCalibrationData,
@@ -122,32 +129,42 @@ export function ProtocolRunSetup({
       gridGap={SPACING.spacing4}
       margin={SPACING.spacing4}
     >
-      {runHasStarted ? <InfoMessage title={t('setup_is_view_only')} /> : null}
-      {stepsKeysInOrder.map((stepKey, index) => (
-        <Flex flexDirection={DIRECTION_COLUMN} key={stepKey}>
-          <SetupStep
-            expanded={stepKey === expandedStepKey}
-            label={t('step', { index: index + 1 })}
-            title={t(`${stepKey}_title`)}
-            description={StepDetailMap[stepKey].description}
-            toggleExpanded={() =>
-              stepKey === expandedStepKey
-                ? setExpandedStepKey(null)
-                : setExpandedStepKey(stepKey)
-            }
-            calibrationStatusComplete={
-              stepKey === ROBOT_CALIBRATION_STEP_KEY && !runHasStarted
-                ? calibrationStatus.complete && isDeckCalibrated
-                : null
-            }
-          >
-            {StepDetailMap[stepKey].stepInternals}
-          </SetupStep>
-          {index !== stepsKeysInOrder.length - 1 ? (
-            <Line marginTop={SPACING.spacing5} />
+      {protocolData != null ? (
+        <>
+          {runHasStarted ? (
+            <InfoMessage title={t('setup_is_view_only')} />
           ) : null}
-        </Flex>
-      ))}
+          {stepsKeysInOrder.map((stepKey, index) => (
+            <Flex flexDirection={DIRECTION_COLUMN} key={stepKey}>
+              <SetupStep
+                expanded={stepKey === expandedStepKey}
+                label={t('step', { index: index + 1 })}
+                title={t(`${stepKey}_title`)}
+                description={StepDetailMap[stepKey].description}
+                toggleExpanded={() =>
+                  stepKey === expandedStepKey
+                    ? setExpandedStepKey(null)
+                    : setExpandedStepKey(stepKey)
+                }
+                calibrationStatusComplete={
+                  stepKey === ROBOT_CALIBRATION_STEP_KEY && !runHasStarted
+                    ? calibrationStatus.complete && isDeckCalibrated
+                    : null
+                }
+              >
+                {StepDetailMap[stepKey].stepInternals}
+              </SetupStep>
+              {index !== stepsKeysInOrder.length - 1 ? (
+                <Line marginTop={SPACING.spacing5} />
+              ) : null}
+            </Flex>
+          ))}
+        </>
+      ) : (
+        <StyledText alignSelf={ALIGN_CENTER} color={COLORS.darkGreyEnabled}>
+          {t('loading_data')}
+        </StyledText>
+      )}
     </Flex>
   )
 }

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunSetup.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunSetup.test.tsx
@@ -119,6 +119,16 @@ describe('ProtocolRunSetup', () => {
     expect(container.firstChild).toBeNull()
   })
 
+  it('renders loading data message if robot-analyzed protocol data is null', () => {
+    when(mockUseProtocolDetailsForRun).calledWith(RUN_ID).mockReturnValue({
+      protocolData: null,
+      displayName: null,
+      protocolKey: null,
+    })
+    const { getByText } = render()
+    getByText('Loading data...')
+  })
+
   it('renders calibration ready when robot calibration complete', () => {
     const { getByText } = render()
     getByText('Calibration ready')


### PR DESCRIPTION
# Overview

when robot-side analysis is not yet complete (protocol data is null), we want to show a loading state. protocol setup info
renders once analysis is complete. as per discussion with @emilywools and @mmencarelli, we also need to inactivate the run log tab during the loading state: https://www.figma.com/file/bVtCogdwiXj3ndpk4AWXCx?node-id=12587:283630#198360658

closes #10358

# Changelog

 - Adds protocol run setup loading state

# Review requests

 - confirm loading state exists on initial load and is replaced by protocol setup info

# Risk assessment

low-medium, to the extent this change affects rendering and tab routing on the protocol run details page