### PR TITLE
feat(app): add tooltip to disabled update software button

### DIFF
--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -138,5 +138,6 @@
   "software_update_modal_issue_tracker_link": "View Opentrons issue tracker",
   "software_update_modal_release_notes_link": "View full Opentrons release notes",
   "software_update_modal_remind_me_later_button": "Remind me later",
-  "software_update_modal_update_button": "Update robot now"
+  "software_update_modal_update_button": "Update robot now",
+  "software_update_modal_unable_to_update_with_run": "This robot cannot be updated while a protocol is running on it."
 }

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/SoftwareUpdateModal.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/SoftwareUpdateModal.tsx
@@ -7,6 +7,7 @@ import {
   JUSTIFY_FLEX_END,
   TYPOGRAPHY,
   SPACING,
+  useHoverTooltip,
 } from '@opentrons/components'
 import { getShellUpdateState } from '../../../../redux/shell'
 import { useCurrentRunId } from '../../../../organisms/ProtocolUpload/hooks'
@@ -21,6 +22,7 @@ import { Modal } from '../../../../atoms/Modal'
 import { Divider } from '../../../../atoms/structure'
 import { useRobot } from '../../hooks'
 import { CONNECTABLE, REACHABLE } from '../../../../redux/discovery'
+import { Tooltip } from '../../../../atoms/Tooltip'
 
 const TECHNICAL_CHANGE_LOG_URL =
   'https://github.com/Opentrons/opentrons/blob/edge/CHANGELOG.md'
@@ -48,6 +50,7 @@ export function SoftwareUpdateModal({
   //   const releaseNotes = updateInfo?.releaseNotes
   const [showUpdateModal, setShowUpdateModal] = React.useState<boolean>(false)
   const robot = useRobot(robotName)
+  const [targetProps, tooltipProps] = useHoverTooltip()
 
   const handleCloseModal = (): void => {
     setShowUpdateModal(false)
@@ -124,9 +127,15 @@ export function SoftwareUpdateModal({
           <PrimaryButton
             onClick={handleLaunchUpdateModal}
             disabled={currentRunId != null}
+            {...targetProps}
           >
             {t('software_update_modal_update_button')}
           </PrimaryButton>
+          {currentRunId != null ? (
+            <Tooltip tooltipProps={tooltipProps}>
+              {t('software_update_modal_unable_to_update_with_run')}
+            </Tooltip>
+          ) : null}
         </Flex>
       </Flex>
     </Modal>


### PR DESCRIPTION

# Overview

This PR adds a tooltip to the disabled update robot now button in the update software modal when a
run is present. closes #10311

![image](https://user-images.githubusercontent.com/14794021/169918166-ceba5846-59ef-4a64-a89e-3c37facd949b.png)

# Changelog

- Adds tooltip to secondary button in `SoftwareUpdateModal`

# Review requests

- Upload a protocol to a robot. Try to view the software update modal, check that the `update robot now` button is disabled and has a tooltip. **Note: this requires robot software on 5.0.2**

# Risk assessment

low
