### PR TITLE
refactor(app): add loading state to protocol run details start run button

### DIFF
--- a/app/src/assets/localization/en/run_details.json
+++ b/app/src/assets/localization/en/run_details.json
@@ -97,5 +97,6 @@
   "no_offsets_available": "No Labware Offset data available",
   "data_out_of_date": "This data is likely out of date",
   "robot_was_recalibrated": "This robot was recalibrated after this Labware Offset data was stored.",
-  "not_available_for_a_completed_run": "not available for a completed run"
+  "not_available_for_a_completed_run": "not available for a completed run",
+  "analyzing_on_robot": "Analyzing on robot"
 }

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -121,7 +121,10 @@ export function ProtocolRunHeader({
   const isHeaterShakerInProtocol = useIsHeaterShakerInProtocol()
   const configHasHeaterShakerAttached = useSelector(getIsHeaterShakerAttached)
   const createdAtTimestamp = useRunCreatedAtTimestamp(runId)
-  const { displayName, protocolKey } = useProtocolDetailsForRun(runId)
+  const { protocolData, displayName, protocolKey } = useProtocolDetailsForRun(
+    runId
+  )
+  const isProtocolAnalyzing = protocolData == null
   const runStatus = useRunStatus(runId)
 
   const { startedAt, stoppedAt, completedAt } = useRunTimestamps(runId)
@@ -198,6 +201,7 @@ export function ProtocolRunHeader({
     !isSetupComplete ||
     isMutationLoading ||
     isRobotBusy ||
+    isProtocolAnalyzing ||
     runStatus === RUN_STATUS_FINISHING ||
     runStatus === RUN_STATUS_PAUSE_REQUESTED ||
     runStatus === RUN_STATUS_STOP_REQUESTED ||
@@ -237,6 +241,11 @@ export function ProtocolRunHeader({
       break
   }
 
+  if (isProtocolAnalyzing) {
+    buttonIconName = 'ot-spinner'
+    buttonText = t('analyzing_on_robot')
+  }
+
   let disableReason = null
   if (!isSetupComplete) {
     disableReason = t('setup_incomplete')
@@ -250,6 +259,7 @@ export function ProtocolRunHeader({
         name={buttonIconName}
         size={SIZE_1}
         marginRight={SPACING.spacing3}
+        spin={isProtocolAnalyzing}
       />
     ) : null
 

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -282,6 +282,19 @@ describe('ProtocolRunHeader', () => {
     expect(queryByRole('link', { name: 'A Protocol for Otie' })).toBeNull()
   })
 
+  it('renders a disabled "Analyzing on robot" button if robot-side analysis is not complete', () => {
+    when(mockUseProtocolDetailsForRun).calledWith(RUN_ID).mockReturnValue({
+      displayName: null,
+      protocolData: null,
+      protocolKey: null,
+    })
+
+    const [{ getByRole }] = render()
+
+    const button = getByRole('button', { name: 'Analyzing on robot' })
+    expect(button).toBeDisabled()
+  })
+
   it('renders a start run button and cancel run button when run is ready to start', () => {
     const [{ getByRole, queryByText, getByText }] = render()
 


### PR DESCRIPTION
# Overview

when the robot is analyzing a protocol, the start run button within the protocol run details page header is disabled with "Analyzing on robot" message

closes #10356

# Changelog

 -  Adds loading state to protocol run details start run button

# Review requests

confirm loading state of button on analysis, and active button after analysis is complete (if setup is complete, etc)

# Risk assessment

low
