### PR TITLE
feat(app): change H-S set shake speed button disabled reason

### DIFF
--- a/app/src/organisms/Devices/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
@@ -60,6 +60,28 @@ const mockOpenLatchHeaterShaker = {
   usbPort: { path: '/dev/ot_module_heatershaker0', port: 1 },
 } as any
 
+const mockUnknownLatchHeaterShaker = {
+  id: 'heatershaker_id',
+  moduleModel: 'heaterShakerModuleV1',
+  moduleType: 'heaterShakerModuleType',
+  serialNumber: 'jkl123',
+  hardwareRevision: 'heatershaker_v4.0',
+  firmwareVersion: 'v2.0.0',
+  hasAvailableUpdate: true,
+  data: {
+    labwareLatchStatus: 'idle_unknown',
+    speedStatus: 'idle',
+    temperatureStatus: 'idle',
+    currentSpeed: null,
+    currentTemperature: null,
+    targetSpeed: null,
+    targetTemp: null,
+    errorDetails: null,
+    status: 'idle',
+  },
+  usbPort: { path: '/dev/ot_module_heatershaker0', port: 1 },
+} as any
+
 const mockCloseLatchHeaterShaker = {
   id: 'heatershaker_id',
   moduleModel: 'heaterShakerModuleV1',
@@ -329,6 +351,22 @@ describe('ModuleOverflowMenu', () => {
     })
 
     fireEvent.click(btn)
+  })
+
+  it('renders heater shaker set shake speed button disabled when labware latch status is unknown', () => {
+    props = {
+      module: mockUnknownLatchHeaterShaker,
+      handleSlideoutClick: jest.fn(),
+      handleAboutClick: jest.fn(),
+      handleTestShakeClick: jest.fn(),
+      handleWizardClick: jest.fn(),
+    }
+    const { getByRole } = render(props)
+    expect(
+      getByRole('button', {
+        name: 'Set shake speed',
+      })
+    ).toBeDisabled()
   })
 
   it('renders heater shaker overflow menu and deactivates heater when status changes', () => {

--- a/app/src/organisms/Devices/ModuleCard/hooks.tsx
+++ b/app/src/organisms/Devices/ModuleCard/hooks.tsx
@@ -311,7 +311,8 @@ export function useModuleOverflowMenu(
         disabledReason:
           module.moduleType === HEATERSHAKER_MODULE_TYPE &&
           (module.data.labwareLatchStatus === 'idle_open' ||
-            module.data.labwareLatchStatus === 'opening'),
+            module.data.labwareLatchStatus === 'opening' ||
+            module.data.labwareLatchStatus === 'idle_unknown'),
         menuButtons: [
           labwareLatchBtn,
           aboutModuleBtn,

--- a/app/src/organisms/Devices/PipettesAndModules.tsx
+++ b/app/src/organisms/Devices/PipettesAndModules.tsx
@@ -94,7 +94,7 @@ export function PipettesAndModules({
               justifyContent={JUSTIFY_START}
               flexDirection={DIRECTION_COLUMN}
               flexWrap={WRAP}
-              maxHeight="25rem"
+              maxHeight="27rem"
             >
               {attachedModules.map((module, index) => {
                 return (


### PR DESCRIPTION
closes #10418

# Overview

This PR changes the disabled reason for the Set Shake Speed button in the H-S overflow menu. Now, when you first launch the app and the labware latch is `idle_unknown`, the button is disabled until you close the latch.

Also increased the height of the module cards in the `Pipettes and Modules section` so when the H-S "too hot to touch" banner is enabled, the cards don't overflow into a 3rd column

# Changelog

- height modification in `pipettesAndModules`
- tweaked module overflow menu hook to change the disabled reason
- increased test coverage on the `ModuleOverflowMenu`

# Review requests

- when you first open the app, if the H-S latch status is `opened`, the `Set shake speed` button should always be disabled. When hovering over the button, there should be a tooltip.

# Risk assessment

low, hs