### PR TITLE
fix(app): tweak copy on not avail modal

### DIFF
--- a/app/src/assets/localization/en/devices_landing.json
+++ b/app/src/assets/localization/en/devices_landing.json
@@ -3,7 +3,7 @@
   "available": "Available ({{count}})",
   "check_same_network": "Check that the computer and robot are on the same network",
   "connection_troubleshooting_intro": "If you're having trouble with the robot's connection, try these troubleshooting tasks. First, double check that the robot is powered on.",
-  "contact_support_for_connection_help": "If none of these work, contact Opentrons Support for help (via the chat link in this app, or by emailing {{support_email}}",
+  "contact_support_for_connection_help": "If none of these work, contact Opentrons Support for help (via the question mark link in this app, or by emailing {{support_email}}",
   "devices": "Devices",
   "empty": "Empty",
   "go_to_run": "Go to Run",


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This will close #10425

![Screen Shot 2022-05-24 at 2 35 46 PM](https://user-images.githubusercontent.com/474225/170108164-5b18206d-f09b-4d26-8fe3-097e00a819bf.png)


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- Update the text of `contact_support_for_connection_help`
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- The text is updated to `If none of these work, contact Opentrons Support for help (via the question mark link in this app, or by emailing support@opentrons.com)`
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
