### PR TITLE
fix(app): add top level poll for modules and pipettes to run and device details pages

### DIFF
--- a/app/src/pages/Devices/DeviceDetails/index.tsx
+++ b/app/src/pages/Devices/DeviceDetails/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { useParams } from 'react-router-dom'
+import { useDispatch } from 'react-redux'
 
 import {
   Box,
@@ -11,6 +12,7 @@ import {
   OVERFLOW_SCROLL,
   SIZE_6,
   SPACING_3,
+  useInterval,
 } from '@opentrons/components'
 import { ApiHostProvider } from '@opentrons/react-api-client'
 
@@ -18,13 +20,29 @@ import { useRobot } from '../../../organisms/Devices/hooks'
 import { PipettesAndModules } from '../../../organisms/Devices/PipettesAndModules'
 import { RecentProtocolRuns } from '../../../organisms/Devices/RecentProtocolRuns'
 import { RobotOverview } from '../../../organisms/Devices/RobotOverview'
+import { fetchModules } from '../../../redux/modules'
+import { fetchPipettes } from '../../../redux/pipettes'
 
 import type { NavRouteParams } from '../../../App/types'
+import type { Dispatch } from '../../../redux/types'
 
 export function DeviceDetails(): JSX.Element | null {
   const { robotName } = useParams<NavRouteParams>()
 
   const robot = useRobot(robotName)
+  const dispatch = useDispatch<Dispatch>()
+
+  // TODO(BC, 2022-05-23): replace this with an interval query once pipettes and modules have been added to the react-api-client
+  useInterval(
+    () => {
+      if (robotName != null) {
+        dispatch(fetchModules(robotName))
+        dispatch(fetchPipettes(robotName))
+      }
+    },
+    5000,
+    true
+  )
 
   return robot != null ? (
     <ApiHostProvider key={robot.name} hostname={robot.ip ?? null}>

--- a/app/src/pages/Devices/ProtocolRunDetails/index.tsx
+++ b/app/src/pages/Devices/ProtocolRunDetails/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { isEmpty } from 'lodash'
 import { useTranslation } from 'react-i18next'
+import { useDispatch } from 'react-redux'
 import { NavLink, Redirect, useParams } from 'react-router-dom'
 import styled, { css } from 'styled-components'
 
@@ -19,6 +20,7 @@ import {
   COLORS,
   SPACING,
   TYPOGRAPHY,
+  useInterval,
 } from '@opentrons/components'
 import { ApiHostProvider } from '@opentrons/react-api-client'
 
@@ -33,8 +35,11 @@ import { RunLog } from '../../../organisms/Devices/ProtocolRun/RunLog'
 import { ProtocolRunSetup } from '../../../organisms/Devices/ProtocolRun/ProtocolRunSetup'
 import { ProtocolRunModuleControls } from '../../../organisms/Devices/ProtocolRun/ProtocolRunModuleControls'
 import { useCurrentRunId } from '../../../organisms/ProtocolUpload/hooks'
+import { fetchModules } from '../../../redux/modules'
+import { fetchPipettes } from '../../../redux/pipettes'
 
 import type { NavRouteParams, ProtocolRunDetailsTab } from '../../../App/types'
+import type { Dispatch } from '../../../redux/types'
 
 const baseRoundTabStyling = css`
   ${TYPOGRAPHY.pSemiBold}
@@ -113,6 +118,18 @@ export function ProtocolRunDetails(): JSX.Element | null {
   const protocolRunHeaderRef = React.useRef<HTMLDivElement>(null)
 
   const robot = useRobot(robotName)
+  const dispatch = useDispatch<Dispatch>()
+  // TODO(BC, 2022-05-23): replace this with an interval query once pipettes and modules have been added to the react-api-client
+  useInterval(
+    () => {
+      if (robotName != null) {
+        dispatch(fetchModules(robotName))
+        dispatch(fetchPipettes(robotName))
+      }
+    },
+    5000,
+    true
+  )
 
   interface ProtocolRunDetailsTabProps {
     protocolRunHeaderRef: React.RefObject<HTMLDivElement> | null


### PR DESCRIPTION
# Overview

Ensure that both the Run Detail and Device Detail pages have up-to-date pipettes and modules from the robot via a 5 second poll.  

Note: This is a stepping stone to the final solution which will take advantage of queries that will be added to the react-api-client in another ticket.

# Review requests

- connect/turn on a module while already on the device details or run details page, the newly connected module should appear within ~5 seconds of attachment 

# Risk assessment
low