### PR TITLE
fix(protocol-designer): change PD help link

### DIFF
--- a/protocol-designer/cypress/integration/sidebar.spec.js
+++ b/protocol-designer/cypress/integration/sidebar.spec.js
@@ -33,7 +33,7 @@ describe('Desktop Navigation', () => {
       .should('have.prop', 'href')
       .and(
         'equal',
-        'https://support.opentrons.com/en/collections/493886-protocol-designer'
+        'https://support.opentrons.com/s/protocol-designer'
       )
   })
 

--- a/protocol-designer/cypress/integration/sidebar.spec.js
+++ b/protocol-designer/cypress/integration/sidebar.spec.js
@@ -31,10 +31,7 @@ describe('Desktop Navigation', () => {
       .contains('HELP')
       .parent()
       .should('have.prop', 'href')
-      .and(
-        'equal',
-        'https://support.opentrons.com/s/protocol-designer'
-      )
+      .and('equal', 'https://support.opentrons.com/s/protocol-designer')
   })
 
   it('contains a settings button', () => {

--- a/protocol-designer/src/components/KnowledgeBaseLink/index.tsx
+++ b/protocol-designer/src/components/KnowledgeBaseLink/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 export const KNOWLEDGEBASE_ROOT_URL =
-  'https://support.opentrons.com/en/collections/493886-protocol-designer'
+  'https://support.opentrons.com/s/protocol-designer'
 
 export const links = {
   airGap: `https://support.opentrons.com/en/articles/4398106-air-gap`,


### PR DESCRIPTION
closes #10325

# Overview

Fixes the help icon link in PD to the new correct link

# Changelog

- update `knowledgeBaseLink`

# Review requests

- test in PD, clicking on the help link at the bottom left nav bar should direct you to the correct support page

# Risk assessment

low
