### PR TITLE
refactor(api): ot3 movement settings update

### DIFF
--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -180,23 +180,23 @@ DEFAULT_RUN_CURRENT: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoa
         OT3AxisKind.P: 1.4,
     },
     high_throughput={
-        OT3AxisKind.X: 1.4,
-        OT3AxisKind.Y: 1.4,
-        OT3AxisKind.Z: 1.4,
-        OT3AxisKind.P: 1.4,
+        OT3AxisKind.X: 1.0,
+        OT3AxisKind.Y: 1.0,
+        OT3AxisKind.Z: 1.0,
+        OT3AxisKind.P: 1.0,
     },
     low_throughput={
-        OT3AxisKind.X: 1.4,
-        OT3AxisKind.Y: 1.4,
-        OT3AxisKind.Z: 1.4,
-        OT3AxisKind.P: 1.4,
+        OT3AxisKind.X: 1.0,
+        OT3AxisKind.Y: 1.0,
+        OT3AxisKind.Z: 1.0,
+        OT3AxisKind.P: 1.0,
     },
     two_low_throughput={
-        OT3AxisKind.X: 1.4,
-        OT3AxisKind.Y: 1.4,
+        OT3AxisKind.X: 1.0,
+        OT3AxisKind.Y: 1.0,
     },
     gripper={
-        OT3AxisKind.Z: 1.4,
+        OT3AxisKind.Z: 1.0,
     },
 )
 

--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -30,26 +30,26 @@ DEFAULT_Z_RETRACT_DISTANCE: Final = 2
 
 DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad(
     none={
-        OT3AxisKind.X: 100,
-        OT3AxisKind.Y: 100,
-        OT3AxisKind.Z: 100,
+        OT3AxisKind.X: 40,
+        OT3AxisKind.Y: 40,
+        OT3AxisKind.Z: 20,
         OT3AxisKind.P: 100,
     },
     high_throughput={
-        OT3AxisKind.X: 100,
-        OT3AxisKind.Y: 100,
-        OT3AxisKind.Z: 100,
+        OT3AxisKind.X: 40,
+        OT3AxisKind.Y: 40,
+        OT3AxisKind.Z: 20,
         OT3AxisKind.P: 100,
     },
     low_throughput={
-        OT3AxisKind.X: 100,
-        OT3AxisKind.Y: 100,
-        OT3AxisKind.Z: 100,
+        OT3AxisKind.X: 40,
+        OT3AxisKind.Y: 40,
+        OT3AxisKind.Z: 20,
         OT3AxisKind.P: 100,
     },
     two_low_throughput={
-        OT3AxisKind.X: 100,
-        OT3AxisKind.Y: 100,
+        OT3AxisKind.X: 40,
+        OT3AxisKind.Y: 40,
     },
     gripper={
         OT3AxisKind.Z: 100,


### PR DESCRIPTION
- Drop some motion parameters to more reasonable levels for issue-free motion before further testing completes
- Drop the current used in most axes to prevent driver overheating