### PR TITLE
feat(ot3-hardware): support tip action requests in the move group runner

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -203,7 +203,7 @@ class SensorThresholdMode(int, Enum):
 
 @unique
 class PipetteTipActionType(int, Enum):
-    """Links sensor threshold triggers to pins."""
+    """Tip action types."""
 
     pick_up = 0x0
     drop = 0x01

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -199,3 +199,11 @@ class SensorThresholdMode(int, Enum):
 
     absolute = 0x0
     auto_baseline = 0x1
+
+
+@unique
+class PipetteTipActionType(int, Enum):
+    """Links sensor threshold triggers to pins."""
+
+    pick_up = 0x0
+    drop = 0x01

--- a/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
@@ -13,6 +13,7 @@ from opentrons_hardware.firmware_bindings.constants import (
     PipetteName,
     SensorOutputBinding,
     SensorThresholdMode,
+    PipetteTipActionType,
 )
 
 
@@ -182,3 +183,15 @@ class EepromDataField(utils.BinaryFieldBase[bytes]):
     def from_string(cls, t: str) -> EepromDataField:
         """Create from a string."""
         return cls(binascii.unhexlify(t)[: cls.NUM_BYTES])
+
+
+class PipetteTipActionTypeField(utils.UInt8Field):
+    """pipette tip action type."""
+
+    def __repr__(self) -> str:
+        """Print tip action."""
+        try:
+            action_type = PipetteTipActionType(self.value).name
+        except ValueError:
+            action_type = str(self.value)
+        return f"{self.__class__.__name__}(value={action_type})"

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -418,6 +418,7 @@ class TipActionRequestPayload(AddToMoveGroupRequestPayload):
 
     velocity: utils.Int32Field
     action: PipetteTipActionTypeField
+    request_stop_condition: utils.UInt8Field
 
 
 @dataclass

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -419,7 +419,7 @@ class TipActionRequestPayload(AddToMoveGroupRequestPayload):
 
 
 @dataclass
-class TipActionResponsePayload(MoveGroupResponsePayload):
+class TipActionResponsePayload(MoveCompletedPayload):
     """A response that sends back whether tip action was successful."""
 
     success: utils.UInt8Field

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -17,6 +17,7 @@ from .fields import (
     EepromDataField,
     SerialField,
     SensorThresholdModeField,
+    PipetteTipActionTypeField,
 )
 from .. import utils
 
@@ -416,12 +417,14 @@ class TipActionRequestPayload(AddToMoveGroupRequestPayload):
     """A request to perform a tip action."""
 
     velocity: utils.Int32Field
+    action: PipetteTipActionTypeField
 
 
 @dataclass
 class TipActionResponsePayload(MoveCompletedPayload):
     """A response that sends back whether tip action was successful."""
 
+    action: PipetteTipActionTypeField
     success: utils.UInt8Field
 
 

--- a/hardware/opentrons_hardware/hardware_control/motion.py
+++ b/hardware/opentrons_hardware/hardware_control/motion.py
@@ -53,10 +53,13 @@ class MoveGroupSingleAxisStep:
 
 
 @dataclass(frozen=True)
-class MoveGroupTipActionStep(MoveGroupSingleAxisStep):
+class MoveGroupTipActionStep:
     """A single tip handling action that requires movement in a move group."""
 
-    action: PipetteTipActionType = PipetteTipActionType.drop
+    velocity_mm_sec: np.float64
+    duration_sec: np.float64
+    action: PipetteTipActionType
+    stop_condition: MoveStopCondition
 
 
 @dataclass(frozen=True)
@@ -143,7 +146,6 @@ def create_home_step(
 
 
 def create_tip_action_step(
-    distance: Dict[NodeId, np.float64],
     velocity: Dict[NodeId, np.float64],
     duration: np.float64,
     present_nodes: Iterable[NodeId],
@@ -154,17 +156,14 @@ def create_tip_action_step(
     step: MoveGroupStep = {}
     stop_condition = (
         MoveStopCondition.limit_switch
-        if action == PipetteTipActionType.pick_up
+        if action == PipetteTipActionType.drop
         else MoveStopCondition.none
     )
     for axis_node in ordered_nodes:
         step[axis_node] = MoveGroupTipActionStep(
-            distance_mm=distance.get(axis_node, np.float64(0)),
-            acceleration_mm_sec_sq=np.float64(0),
             velocity_mm_sec=velocity.get(axis_node, np.float64(0)),
             duration_sec=duration,
             stop_condition=stop_condition,
-            move_type=MoveType.get_move_type(stop_condition),
             action=action,
         )
     return step

--- a/hardware/opentrons_hardware/hardware_control/motion.py
+++ b/hardware/opentrons_hardware/hardware_control/motion.py
@@ -28,6 +28,7 @@ class MoveType(int, Enum):
     linear = 0x0
     home = 0x1
     calibration = 0x2
+    tip_action = 0x3
 
     @classmethod
     def get_move_type(cls, condition: MoveStopCondition) -> "MoveType":

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -227,6 +227,7 @@ class MoveGroupRunner:
             duration=UInt32Field(int(step.duration_sec * interrupts_per_sec)),
             velocity=self._convert_velocity(step.velocity_mm_sec, interrupts_per_sec),
             action=PipetteTipActionTypeField(step.action),
+            request_stop_condition=UInt8Field(step.stop_condition),
         )
         return TipActionRequest(payload=tip_action_payload)
 

--- a/hardware/opentrons_hardware/scripts/high_throughput_tip_handling.py
+++ b/hardware/opentrons_hardware/scripts/high_throughput_tip_handling.py
@@ -51,11 +51,6 @@ def prompt_int_input(prompt_name: str) -> int:
         raise InvalidInput(e)
 
 
-def in_green(s: str) -> str:
-    """Return string formatted in red."""
-    return f"\033[92m{str(s)}\033[0m"
-
-
 def output_details(i: int, total_i: int) -> None:
     """Print out test details."""
     print(f"\n\033[95mRound {i}/{total_i}:\033[0m")

--- a/hardware/opentrons_hardware/scripts/high_throughput_tip_handling.py
+++ b/hardware/opentrons_hardware/scripts/high_throughput_tip_handling.py
@@ -1,0 +1,164 @@
+"""A script for sending and receiving data from sensors on the OT3."""
+import os
+import logging
+import asyncio
+import argparse
+from numpy import float64
+
+from typing import Callable
+from logging.config import dictConfig
+
+from opentrons_hardware.firmware_bindings.messages.message_definitions import (
+    SetupRequest,
+    EnableMotorRequest,
+)
+from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
+from opentrons_hardware.firmware_bindings.constants import NodeId
+from opentrons_hardware.scripts.can_args import add_can_args, build_settings
+from opentrons_hardware.hardware_control.motion import (
+    MoveGroupSingleAxisStep,
+    MoveType,
+    MoveGroups,
+)
+from opentrons_hardware.hardware_control.move_group_runner import MoveGroupRunner
+
+from opentrons_hardware.drivers.can_bus.build import build_driver
+
+
+GetInputFunc = Callable[[str], str]
+OutputFunc = Callable[[str], None]
+
+
+class InvalidInput(Exception):
+    """Invalid input exception."""
+
+    pass
+
+
+def prompt_int_input(prompt_name: str) -> int:
+    """Prompt to choose a member of the enum.
+
+    Args:
+        output_func: Function to output text to user.
+        get_user_input: Function to get user input.
+        enum_type: an enum type
+
+    Returns:
+        The choice.
+
+    """
+    try:
+        return int(input(f"{prompt_name}: "))
+    except (ValueError, IndexError) as e:
+        raise InvalidInput(e)
+
+
+def in_green(s: str) -> str:
+    """Return string formatted in red."""
+    return f"\033[92m{str(s)}\033[0m"
+
+
+def output_details(i: int, total_i: int) -> None:
+    """Print out test details."""
+    print(f"\n\033[95mRound {i}/{total_i}:\033[0m")
+
+
+async def run(args: argparse.Namespace) -> None:
+    """Entry point for script."""
+    os.system("cls")
+    os.system("clear")
+
+    print("Test tip pick up for the 96 channel\n")
+    reps = prompt_int_input("Number of repetitions for pick up and drop tip")
+    delay = prompt_int_input("Delay in seconds between pick up and drop tip")
+    pipette_type = input("Please list pipette mount (right or left)")
+
+    if pipette_type == "right":
+        pipette_node = NodeId.pipette_right
+    elif pipette_type == "left":
+        pipette_node = NodeId.pipette_left
+    else:
+        raise ValueError("Unsupported pipette type")
+
+    driver = await build_driver(build_settings(args))
+
+    messenger = CanMessenger(driver=driver)
+    messenger.start()
+    await messenger.send(node_id=pipette_node, message=SetupRequest())
+    await messenger.send(node_id=pipette_node, message=EnableMotorRequest())
+
+    move_groups: MoveGroups = []
+    move_groups.append(
+        [
+            {
+                pipette_node: MoveGroupSingleAxisStep(
+                    distance_mm=float64(0),
+                    velocity_mm_sec=float64(20.5),
+                    duration_sec=float64(3),
+                    move_type=MoveType.tip_action,
+                )
+            }
+        ]
+    )
+
+    pick_up_tip_runner = MoveGroupRunner(move_groups=move_groups)
+    drop_tip_runner = MoveGroupRunner(move_groups=move_groups)
+    try:
+        for i in range(reps):
+            output_details(i, reps)
+            log.info(f"*********** Now executing round {i} / {reps}")
+            await pick_up_tip_runner.run(can_messenger=messenger)
+            await asyncio.sleep(delay)
+            await drop_tip_runner.run(can_messenger=messenger)
+            await asyncio.sleep(delay)
+    except asyncio.CancelledError:
+        pass
+    finally:
+        print("\nTesting finishes...\n")
+        await messenger.stop()
+        driver.shutdown()
+
+
+log = logging.getLogger(__name__)
+
+LOG_CONFIG = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "basic": {"format": "%(asctime)s %(name)s %(levelname)s %(message)s"}
+    },
+    "handlers": {
+        "file_handler": {
+            "class": "logging.handlers.RotatingFileHandler",
+            "formatter": "basic",
+            "filename": "96channel.log",
+            "maxBytes": 5000000,
+            "level": logging.INFO,
+            "backupCount": 3,
+        },
+    },
+    "loggers": {
+        "": {
+            "handlers": ["file_handler"],
+            "level": logging.INFO,
+        },
+    },
+}
+
+
+def main() -> None:
+    """Entry point."""
+    dictConfig(LOG_CONFIG)
+
+    parser = argparse.ArgumentParser(
+        description="96 channel tip handling testing script."
+    )
+    add_can_args(parser)
+
+    args = parser.parse_args()
+
+    asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/hardware/opentrons_hardware/scripts/high_throughput_tip_handling.py
+++ b/hardware/opentrons_hardware/scripts/high_throughput_tip_handling.py
@@ -81,9 +81,9 @@ async def run(args: argparse.Namespace) -> None:
             [
                 {
                     pipette_node: MoveGroupTipActionStep(
-                        distance_mm=float64(0),
                         velocity_mm_sec=float64(20.5),
                         duration_sec=float64(3),
+                        stop_condition=MoveStopCondition.none,
                         action=PipetteTipActionType.pick_up,
                     )
                 }
@@ -95,7 +95,6 @@ async def run(args: argparse.Namespace) -> None:
             [
                 {
                     pipette_node: MoveGroupTipActionStep(
-                        distance_mm=float64(0),
                         velocity_mm_sec=float64(-20.5),
                         duration_sec=float64(3),
                         stop_condition=MoveStopCondition.limit_switch,

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -1,6 +1,6 @@
 """Tests for the move scheduler."""
 import pytest
-from typing import List, Tuple, Any
+from typing import List, Any
 from numpy import float64
 from mock import AsyncMock, call, MagicMock
 from opentrons_hardware.firmware_bindings import ArbitrationId, ArbitrationIdParts
@@ -30,6 +30,7 @@ from opentrons_hardware.hardware_control.motion import (
 from opentrons_hardware.hardware_control.move_group_runner import (
     MoveGroupRunner,
     MoveScheduler,
+    _CompletionPacket,
 )
 from opentrons_hardware.hardware_control.types import NodeMap
 from opentrons_hardware.firmware_bindings.messages import (
@@ -549,7 +550,7 @@ def _build_arb(from_node: NodeId) -> ArbitrationId:
     ],
 )
 def test_accumulate_move_completions(
-    completions: List[Tuple[ArbitrationId, MoveCompleted]], position_map: NodeMap[float]
+    completions: List[_CompletionPacket], position_map: NodeMap[float]
 ) -> None:
     """Build correct move results."""
     assert MoveGroupRunner._accumulate_move_completions(completions) == position_map


### PR DESCRIPTION
# Overview

Related to #RET-916 and #RET-918.

Adds in TipActionRequest and TipActionResponse to the move group
runner as well as a script to test pick up and drop tip behavior on the 96 channel. For now, holding
off on adding this to the hardware controller until behavior is finalized around using the tip sense
detection.

# Changelog

- Handle tip action request and response in the move group runner
- Add a script for testing pick up and drop tip

# Review requests

- How do we feel about using the tip sense as a a method for detecting whether a move was successful or not? Should that be a higher level error, or is it fine as it is?

# Risk assessment

Low. 
