### PR TITLE
ci(protocol-designer): remove pd mac os e2e test from matrix

### DIFF
--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -75,7 +75,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        os: ['ubuntu-18.04', 'macos-latest']
+        os: ['ubuntu-18.04']
     runs-on: '${{ matrix.os }}'
     steps:
       - uses: 'actions/checkout@v2'


### PR DESCRIPTION
# Overview

PD mac os e2e tests are insanely flakey right now. Until we have the resources to figure out why, Ubuntu will suffice.

# Changelog

- Remove pd mac os e2e tests from ci


# Risk assessment
Low