### PR TITLE
refactor(app): devices landing page design feedback

### DIFF
--- a/app/src/molecules/CollapsibleSection/index.tsx
+++ b/app/src/molecules/CollapsibleSection/index.tsx
@@ -4,7 +4,6 @@ import {
   Flex,
   Btn,
   Icon,
-  SIZE_1,
   JUSTIFY_SPACE_BETWEEN,
   SPACING,
   StyleProps,
@@ -28,7 +27,7 @@ export function CollapsibleSection(
           {title}
         </StyledText>
         <Btn onClick={() => setIsExpanded(!isExpanded)}>
-          <Icon size={SIZE_1} name={isExpanded ? 'minus' : 'plus'} />
+          <Icon size={'1.5rem'} name={isExpanded ? 'minus' : 'plus'} />
         </Btn>
       </Flex>
       {isExpanded ? children : null}

--- a/app/src/organisms/Devices/DevicesEmptyState.tsx
+++ b/app/src/organisms/Devices/DevicesEmptyState.tsx
@@ -7,22 +7,19 @@ import {
   Flex,
   Icon,
   Link,
-  NewPrimaryBtn,
-  Text,
   ALIGN_CENTER,
-  C_BLUE,
   DIRECTION_COLUMN,
-  FONT_SIZE_BODY_1,
   FONT_WEIGHT_REGULAR,
-  FONT_WEIGHT_SEMIBOLD,
-  JUSTIFY_CENTER,
-  SPACING_1,
-  SPACING_2,
-  SPACING_3,
   SPACING_5,
+  JUSTIFY_SPACE_BETWEEN,
+  COLORS,
+  TYPOGRAPHY,
+  SPACING,
 } from '@opentrons/components'
 
 import { startDiscovery } from '../../redux/discovery'
+import { PrimaryButton } from '../../atoms/buttons'
+import { StyledText } from '../../atoms/text'
 
 export const OT2_GET_STARTED_URL =
   'https://support.opentrons.com/s/ot2-get-started'
@@ -38,54 +35,69 @@ export function DevicesEmptyState(): JSX.Element {
   }
   return (
     <Flex
-      alignItems={ALIGN_CENTER}
       flexDirection={DIRECTION_COLUMN}
-      justifyContent={JUSTIFY_CENTER}
-      padding={`${SPACING_5} 0`}
+      paddingTop={SPACING_5}
+      justifyContent={JUSTIFY_SPACE_BETWEEN}
     >
-      <Text
-        as="h3"
-        fontWeight={FONT_WEIGHT_REGULAR}
-        paddingBottom={SPACING_2}
-        id="DevicesEmptyState_noRobotsFound"
-      >
-        {t('no_robots_found')}
-      </Text>
-      <Box paddingBottom={SPACING_3}>
-        <NewPrimaryBtn
-          onClick={handleRefresh}
-          id="DevicesEmptyState_refreshButton"
+      <Flex flexDirection={DIRECTION_COLUMN} alignItems={ALIGN_CENTER}>
+        <StyledText
+          as="h1"
+          fontWeight={FONT_WEIGHT_REGULAR}
+          paddingBottom={SPACING.spacing4}
+          id="DevicesEmptyState_noRobotsFound"
+          marginTop="20vh"
         >
-          {t('refresh')}
-        </NewPrimaryBtn>
-      </Box>
-      <Link
-        external
-        href={OT2_GET_STARTED_URL}
-        display="flex"
+          {t('no_robots_found')}
+        </StyledText>
+        <Box paddingBottom={SPACING.spacing4}>
+          <PrimaryButton
+            onClick={handleRefresh}
+            id="DevicesEmptyState_refreshButton"
+            fontWeight={TYPOGRAPHY.fontWeightRegular}
+          >
+            {t('refresh')}
+          </PrimaryButton>
+        </Box>
+      </Flex>
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
         alignItems={ALIGN_CENTER}
-        color={C_BLUE}
-        fontSize={FONT_SIZE_BODY_1}
-        fontWeight={FONT_WEIGHT_SEMIBOLD}
-        paddingBottom={SPACING_2}
-        id="DevicesEmptyState_settingUpNewRobot"
+        marginBottom={'2rem'}
       >
-        {t('setting_up_new_robot')}{' '}
-        <Icon name="open-in-new" size="0.675rem" marginLeft={SPACING_1} />
-      </Link>
-      <Link
-        external
-        href={TROUBLESHOOTING_CONNECTION_PROBLEMS_URL}
-        display="flex"
-        alignItems={ALIGN_CENTER}
-        color={C_BLUE}
-        fontSize={FONT_SIZE_BODY_1}
-        fontWeight={FONT_WEIGHT_SEMIBOLD}
-        id="DevicesEmptyState_troubleshootingConnectionProblems"
-      >
-        {t('troubleshooting_connection_problems')}
-        <Icon name="open-in-new" size="0.675rem" marginLeft={SPACING_1} />
-      </Link>
+        {/* <Link
+          external
+          href={OT2_GET_STARTED_URL}
+          display="flex"
+          alignItems={ALIGN_CENTER}
+          color={COLORS.darkBlack}
+          fontSize={TYPOGRAPHY.fontSizeLabel}
+          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+          opacity={'70%'}
+          paddingBottom={SPACING_2}
+          id="DevicesEmptyState_settingUpNewRobot"
+        >
+          {t('setting_up_new_robot')}{' '}
+          <Icon name="open-in-new" size="0.5rem" marginLeft={SPACING_1} />
+        </Link> */}
+        <Link
+          external
+          href={TROUBLESHOOTING_CONNECTION_PROBLEMS_URL}
+          display="flex"
+          alignItems={ALIGN_CENTER}
+          color={COLORS.darkBlack}
+          fontSize={TYPOGRAPHY.fontSizeLabel}
+          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+          opacity={'70%'}
+          id="DevicesEmptyState_troubleshootingConnectionProblems"
+        >
+          {t('troubleshooting_connection_problems')}
+          <Icon
+            name="open-in-new"
+            size="0.5rem"
+            marginLeft={SPACING.spacing2}
+          />
+        </Link>
+      </Flex>
     </Flex>
   )
 }

--- a/app/src/organisms/Devices/DevicesEmptyState.tsx
+++ b/app/src/organisms/Devices/DevicesEmptyState.tsx
@@ -16,6 +16,7 @@ import {
   TYPOGRAPHY,
   SPACING,
 } from '@opentrons/components'
+import { css } from 'styled-components'
 
 import { startDiscovery } from '../../redux/discovery'
 import { PrimaryButton } from '../../atoms/buttons'
@@ -24,6 +25,13 @@ import { StyledText } from '../../atoms/text'
 export const TROUBLESHOOTING_CONNECTION_PROBLEMS_URL =
   'https://support.opentrons.com/s/article/Troubleshooting-connection-problems'
 
+const LINK_STYLES = css`
+  opacity: 70%;
+
+  &:hover {
+    opacity: 100%;
+  }
+`
 export function DevicesEmptyState(): JSX.Element {
   const { t } = useTranslation('devices_landing')
   const dispatch = useDispatch()
@@ -60,9 +68,10 @@ export function DevicesEmptyState(): JSX.Element {
       <Flex
         flexDirection={DIRECTION_COLUMN}
         alignItems={ALIGN_CENTER}
-        marginBottom={'2rem'}
+        marginBottom={SPACING.spacing6}
       >
         <Link
+          css={LINK_STYLES}
           external
           href={TROUBLESHOOTING_CONNECTION_PROBLEMS_URL}
           display="flex"
@@ -70,7 +79,6 @@ export function DevicesEmptyState(): JSX.Element {
           color={COLORS.darkBlack}
           fontSize={TYPOGRAPHY.fontSizeLabel}
           fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-          opacity={'70%'}
           id="DevicesEmptyState_troubleshootingConnectionProblems"
         >
           {t('troubleshooting_connection_problems')}

--- a/app/src/organisms/Devices/DevicesEmptyState.tsx
+++ b/app/src/organisms/Devices/DevicesEmptyState.tsx
@@ -21,8 +21,6 @@ import { startDiscovery } from '../../redux/discovery'
 import { PrimaryButton } from '../../atoms/buttons'
 import { StyledText } from '../../atoms/text'
 
-export const OT2_GET_STARTED_URL =
-  'https://support.opentrons.com/s/ot2-get-started'
 export const TROUBLESHOOTING_CONNECTION_PROBLEMS_URL =
   'https://support.opentrons.com/s/article/Troubleshooting-connection-problems'
 
@@ -64,21 +62,6 @@ export function DevicesEmptyState(): JSX.Element {
         alignItems={ALIGN_CENTER}
         marginBottom={'2rem'}
       >
-        {/* <Link
-          external
-          href={OT2_GET_STARTED_URL}
-          display="flex"
-          alignItems={ALIGN_CENTER}
-          color={COLORS.darkBlack}
-          fontSize={TYPOGRAPHY.fontSizeLabel}
-          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-          opacity={'70%'}
-          paddingBottom={SPACING_2}
-          id="DevicesEmptyState_settingUpNewRobot"
-        >
-          {t('setting_up_new_robot')}{' '}
-          <Icon name="open-in-new" size="0.5rem" marginLeft={SPACING_1} />
-        </Link> */}
         <Link
           external
           href={TROUBLESHOOTING_CONNECTION_PROBLEMS_URL}

--- a/app/src/organisms/Devices/RobotCard.tsx
+++ b/app/src/organisms/Devices/RobotCard.tsx
@@ -7,7 +7,6 @@ import {
   Flex,
   ALIGN_CENTER,
   ALIGN_START,
-  C_MED_LIGHT_GRAY,
   DIRECTION_COLUMN,
   DIRECTION_ROW,
   SPACING,
@@ -21,12 +20,12 @@ import OT2_PNG from '../../assets/images/OT2-R_HERO.png'
 import { StyledText } from '../../atoms/text'
 import { UNREACHABLE } from '../../redux/discovery'
 import { ModuleIcon } from '../../molecules/ModuleIcon'
+import { UpdateRobotBanner } from '../UpdateRobotBanner'
 import { useAttachedModules, useAttachedPipettes } from './hooks'
 import { RobotStatusBanner } from './RobotStatusBanner'
 import { RobotOverflowMenu } from './RobotOverflowMenu'
 
 import type { DiscoveredRobot } from '../../redux/discovery/types'
-import { UpdateRobotBanner } from '../UpdateRobotBanner'
 
 interface RobotCardProps {
   robot: DiscoveredRobot
@@ -44,7 +43,7 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
     <Flex
       alignItems={ALIGN_CENTER}
       backgroundColor={COLORS.white}
-      border={`1px solid ${C_MED_LIGHT_GRAY}`}
+      border={`1px solid ${COLORS.medGrey}`}
       borderRadius={BORDERS.radiusSoftCorners}
       flexDirection={DIRECTION_ROW}
       marginBottom={SPACING.spacing3}

--- a/app/src/organisms/Devices/RobotCard.tsx
+++ b/app/src/organisms/Devices/RobotCard.tsx
@@ -8,10 +8,10 @@ import {
   ALIGN_CENTER,
   ALIGN_START,
   C_MED_LIGHT_GRAY,
-  C_WHITE,
   DIRECTION_COLUMN,
   DIRECTION_ROW,
   SPACING,
+  COLORS,
   TEXT_TRANSFORM_UPPERCASE,
   BORDERS,
 } from '@opentrons/components'
@@ -43,12 +43,12 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
   return name != null ? (
     <Flex
       alignItems={ALIGN_CENTER}
-      backgroundColor={C_WHITE}
+      backgroundColor={COLORS.white}
       border={`1px solid ${C_MED_LIGHT_GRAY}`}
       borderRadius={BORDERS.radiusSoftCorners}
       flexDirection={DIRECTION_ROW}
       marginBottom={SPACING.spacing3}
-      padding={SPACING.spacing3}
+      padding={`${SPACING.spacing3} ${SPACING.spacing2} ${SPACING.spacing3} ${SPACING.spacing3}`}
       width="100%"
       onClick={() => history.push(`/devices/${name}`)}
     >
@@ -67,7 +67,11 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
             flexDirection={DIRECTION_COLUMN}
             paddingRight={SPACING.spacing4}
           >
-            <StyledText as="h6" textTransform={TEXT_TRANSFORM_UPPERCASE}>
+            <StyledText
+              as="h6"
+              textTransform={TEXT_TRANSFORM_UPPERCASE}
+              color={COLORS.darkGreyEnabled}
+            >
               {t('left_mount')}
             </StyledText>
             <StyledText as="p" id={`RobotCard_${name}_leftMountPipette`}>
@@ -78,7 +82,11 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
             flexDirection={DIRECTION_COLUMN}
             paddingRight={SPACING.spacing4}
           >
-            <StyledText as="h6" textTransform={TEXT_TRANSFORM_UPPERCASE}>
+            <StyledText
+              as="h6"
+              textTransform={TEXT_TRANSFORM_UPPERCASE}
+              color={COLORS.darkGreyEnabled}
+            >
               {t('right_mount')}
             </StyledText>
             <StyledText as="p" id={`RobotCard_${name}_rightMountPipette`}>
@@ -89,21 +97,28 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
             flexDirection={DIRECTION_COLUMN}
             paddingRight={SPACING.spacing4}
           >
-            <StyledText as="h6" textTransform={TEXT_TRANSFORM_UPPERCASE}>
+            <StyledText
+              as="h6"
+              textTransform={TEXT_TRANSFORM_UPPERCASE}
+              color={COLORS.darkGreyEnabled}
+              marginBottom={SPACING.spacing1}
+            >
               {t('modules')}
             </StyledText>
             <Flex>
               {attachedModules.map((module, i) => (
-                <ModuleIcon
-                  key={`${module.moduleModel}_${i}_${name}`}
-                  tooltipText={t(
-                    'this_robot_has_connected_and_power_on_module',
-                    {
-                      moduleName: getModuleDisplayName(module.moduleModel),
-                    }
-                  )}
-                  module={module}
-                />
+                <Flex marginRight={SPACING.spacing1} key={i}>
+                  <ModuleIcon
+                    key={`${module.moduleModel}_${i}_${name}`}
+                    tooltipText={t(
+                      'this_robot_has_connected_and_power_on_module',
+                      {
+                        moduleName: getModuleDisplayName(module.moduleModel),
+                      }
+                    )}
+                    module={module}
+                  />
+                </Flex>
               ))}
             </Flex>
           </Flex>

--- a/app/src/organisms/Devices/RobotStatusBanner.tsx
+++ b/app/src/organisms/Devices/RobotStatusBanner.tsx
@@ -10,6 +10,7 @@ import {
   SIZE_1,
   JUSTIFY_SPACE_BETWEEN,
   SPACING,
+  COLORS,
 } from '@opentrons/components'
 
 import { TertiaryButton } from '../../atoms/buttons'
@@ -52,6 +53,7 @@ export function RobotStatusBanner(props: RobotStatusBannerProps): JSX.Element {
       <Flex flexDirection={DIRECTION_COLUMN}>
         <StyledText
           as="h6"
+          color={COLORS.darkGreyEnabled}
           paddingBottom={SPACING.spacing1}
           id={`RobotStatusBanner_${name}_robotModel`}
         >
@@ -61,7 +63,7 @@ export function RobotStatusBanner(props: RobotStatusBannerProps): JSX.Element {
           <Flex alignItems={ALIGN_CENTER}>
             <StyledText
               as="h3"
-              marginRight={SPACING.spacing4}
+              marginRight={SPACING.spacing3}
               id={`RobotStatusBanner_${name}_robotName`}
             >
               {name}

--- a/app/src/organisms/Devices/__tests__/DevicesEmptyState.test.tsx
+++ b/app/src/organisms/Devices/__tests__/DevicesEmptyState.test.tsx
@@ -5,7 +5,6 @@ import { i18n } from '../../../i18n'
 import { startDiscovery } from '../../../redux/discovery'
 import {
   DevicesEmptyState,
-  OT2_GET_STARTED_URL,
   TROUBLESHOOTING_CONNECTION_PROBLEMS_URL,
 } from '../DevicesEmptyState'
 
@@ -38,13 +37,8 @@ describe('DevicesEmptyState', () => {
     expect(mockStartDiscovery).toBeCalled()
   })
 
-  it('links to support documents', () => {
+  it('link to support documents', () => {
     const [{ getByRole }] = render()
-
-    const settingUpLink = getByRole('link', {
-      name: 'Learn about setting up a new robot',
-    })
-    expect(settingUpLink.getAttribute('href')).toBe(OT2_GET_STARTED_URL)
 
     const troubleshootingLink = getByRole('link', {
       name: 'Learn more about troubleshooting connection problems',

--- a/app/src/pages/Devices/DevicesLanding/NewRobotSetupHelp.tsx
+++ b/app/src/pages/Devices/DevicesLanding/NewRobotSetupHelp.tsx
@@ -30,6 +30,7 @@ export function NewRobotSetupHelp(): JSX.Element {
       <Link
         css={TYPOGRAPHY.labelSemiBold}
         onClick={() => setShowNewRobotHelpModal(true)}
+        opacity={'70%'}
       >
         {t('see_how_to_setup_new_robot')}
       </Link>

--- a/app/src/pages/Devices/DevicesLanding/index.tsx
+++ b/app/src/pages/Devices/DevicesLanding/index.tsx
@@ -55,7 +55,7 @@ export function DevicesLanding(): JSX.Element {
       {availableDevices.length > 0 ? (
         <>
           <CollapsibleSection
-            marginY={SPACING.spacing4}
+            marginTop={'2.1rem'}
             title={t('available', { count: availableDevices.length })}
           >
             {availableDevices.map(robot => (
@@ -64,7 +64,7 @@ export function DevicesLanding(): JSX.Element {
               </ApiHostProvider>
             ))}
           </CollapsibleSection>
-          {unavailableDevices.length > 0 ? <Divider /> : null}
+          <Divider />
         </>
       ) : null}
       {unavailableDevices.length > 0 ? (

--- a/app/src/pages/Devices/DevicesLanding/index.tsx
+++ b/app/src/pages/Devices/DevicesLanding/index.tsx
@@ -3,8 +3,10 @@ import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
 import {
+  ALIGN_CENTER,
   Box,
   Flex,
+  JUSTIFY_CENTER,
   JUSTIFY_SPACE_BETWEEN,
   SIZE_6,
   SPACING,
@@ -33,15 +35,21 @@ export function DevicesLanding(): JSX.Element {
 
   return (
     <Box minWidth={SIZE_6} padding={`${SPACING.spacing3} ${SPACING.spacing4}`}>
-      <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
-        <StyledText as="h3" id="DevicesLanding_title">
+      <Flex
+        justifyContent={JUSTIFY_SPACE_BETWEEN}
+        alignItems={ALIGN_CENTER}
+        marginTop={SPACING.spacing3}
+      >
+        <StyledText as="h1" id="DevicesLanding_title">
           {t('devices')}
         </StyledText>
         <NewRobotSetupHelp />
       </Flex>
       {!isScanning &&
       [...availableDevices, ...unavailableDevices].length === 0 ? (
-        <DevicesEmptyState />
+        <Flex height="93vh" justifyContent={JUSTIFY_CENTER}>
+          <DevicesEmptyState />
+        </Flex>
       ) : null}
 
       {availableDevices.length > 0 ? (


### PR DESCRIPTION
closes #10243 

# Overview

This PR makes design changes to Devices landing page and the Robot card. 

<img width="613" alt="Screen Shot 2022-05-25 at 11 51 24 AM" src="https://user-images.githubusercontent.com/66035149/170304613-0e418ec2-c626-43d0-8401-40faf67a514e.png">

<img width="614" alt="Screen Shot 2022-05-25 at 11 52 11 AM" src="https://user-images.githubusercontent.com/66035149/170304775-3587f989-8c54-42a7-9418-5a149a907505.png">


# Changelog

- touched a handful of components in the devices landing folder and updated the UI to match figma/AC on ticket

# Review requests

- examine the different pages found in Devices landing (no robot found, searching for robot, and robot available/unavailable) does it match figma?

# Risk assessment

low