### PR TITLE
feat(protocol-designer): add module placement restriction when editing position of H-S

### DIFF
--- a/protocol-designer/src/components/modals/EditModulesModal/index.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.tsx
@@ -67,6 +67,7 @@ export interface EditModulesFormValues {
   selectedSlot: string
 }
 
+// this util only works for outter slots (where we can safely place modules in PD)
 const getSlotNextTo = (slot: string): string | null => {
   const SLOT_ADJACENT_MAP: Record<string, string> = {
     '1': '2',

--- a/protocol-designer/src/components/modals/EditModulesModal/index.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.tsx
@@ -11,11 +11,14 @@ import {
   useHoverTooltip,
 } from '@opentrons/components'
 import {
+  getIsLabwareAboveHeight,
   THERMOCYCLER_MODULE_TYPE,
   MAGNETIC_MODULE_TYPE,
+  HEATERSHAKER_MODULE_V1,
   THERMOCYCLER_MODULE_V1,
   ModuleType,
   ModuleModel,
+  MAX_LABWARE_HEIGHT_EAST_WEST_HEATER_SHAKER_MM,
 } from '@opentrons/shared-data'
 import { i18n } from '../../../localization'
 import {
@@ -62,6 +65,20 @@ type EditModulesModalComponentProps = EditModulesModalProps & {
 export interface EditModulesFormValues {
   selectedModel: ModuleModel | null
   selectedSlot: string
+}
+
+const getSlotNextTo = (slot: string): string | null => {
+  const SLOT_ADJACENT_MAP: Record<string, string> = {
+    '1': '2',
+    '3': '2',
+    '4': '5',
+    '6': '5',
+    '7': '8',
+    '9': '8',
+    '10': '11',
+  }
+
+  return SLOT_ADJACENT_MAP[slot] ?? null
 }
 
 export const EditModulesModal = (props: EditModulesModalProps): JSX.Element => {
@@ -114,6 +131,26 @@ export const EditModulesModal = (props: EditModulesModalProps): JSX.Element => {
     const errors: Record<string, any> = {}
     if (!selectedModel) {
       errors.selectedModel = i18n.t('alert.field.required')
+    }
+
+    if (selectedModel === HEATERSHAKER_MODULE_V1) {
+      // heater shaker can only go in slot 1, so check labware in slot 2
+      const labwareNextToHeaterShaker = getLabwareOnSlot(
+        initialDeckSetup,
+        getSlotNextTo(selectedSlot) ?? ''
+      )
+      if (
+        labwareNextToHeaterShaker &&
+        getIsLabwareAboveHeight(
+          labwareNextToHeaterShaker.def,
+          MAX_LABWARE_HEIGHT_EAST_WEST_HEATER_SHAKER_MM
+        )
+      ) {
+        errors.selectedSlot = i18n.t(
+          'alert.module_placement.HEATER_SHAKER_ADJACENT_LABWARE_TOO_TALL.body',
+          { selectedSlot }
+        )
+      }
     }
 
     if (hasSlotIssue(selectedSlot)) {

--- a/protocol-designer/src/components/modals/EditModulesModal/index.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.tsx
@@ -135,7 +135,6 @@ export const EditModulesModal = (props: EditModulesModalProps): JSX.Element => {
     }
 
     if (selectedModel === HEATERSHAKER_MODULE_V1) {
-      // heater shaker can only go in slot 1, so check labware in slot 2
       const labwareNextToHeaterShaker = getLabwareOnSlot(
         initialDeckSetup,
         getSlotNextTo(selectedSlot) ?? ''

--- a/protocol-designer/src/components/modals/FilePipettesModal/ModuleFields.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/ModuleFields.tsx
@@ -80,7 +80,10 @@ export function ModuleFields(props: ModuleFieldsProps): JSX.Element {
     onFieldChange(e)
 
     // only clear model dropdown if not TC
-    if (targetToClear !== 'modulesByType.thermocyclerModuleType.model') {
+    if (
+      targetToClear !== 'modulesByType.thermocyclerModuleType.model' &&
+      targetToClear !== 'modulesByType.heaterShakerModuleType.model'
+    ) {
       onSetFieldValue(targetToClear, null)
     }
     onSetFieldTouched(targetToClear, false)

--- a/protocol-designer/src/components/modals/FilePipettesModal/__tests__/index.test.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/__tests__/index.test.tsx
@@ -188,7 +188,7 @@ describe('FilePipettesModal', () => {
         [HEATERSHAKER_MODULE_TYPE]: {
           ...initialModuleValues[HEATERSHAKER_MODULE_TYPE],
           slot: '1',
-          onDeck: true
+          onDeck: true,
         },
       }
 

--- a/protocol-designer/src/components/modals/FilePipettesModal/__tests__/index.test.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/__tests__/index.test.tsx
@@ -8,6 +8,7 @@ import {
   HEATERSHAKER_MODULE_TYPE,
   MAGNETIC_MODULE_V1,
   MAGNETIC_MODULE_V2,
+  HEATERSHAKER_MODULE_V1,
 } from '@opentrons/shared-data'
 import { Modal, InputField, OutlineButton } from '@opentrons/components'
 import { i18n } from '../../../../localization'
@@ -55,7 +56,7 @@ describe('FilePipettesModal', () => {
       [HEATERSHAKER_MODULE_TYPE]: {
         onDeck: false,
         slot: '',
-        model: null,
+        model: HEATERSHAKER_MODULE_V1,
       },
     }
 
@@ -167,6 +168,51 @@ describe('FilePipettesModal', () => {
             type: MAGNETIC_MODULE_TYPE,
             model: MAGNETIC_MODULE_V1,
             slot: initialModuleValues[MAGNETIC_MODULE_TYPE].slot,
+          },
+        ],
+        newProtocolFields: { name: '' },
+        pipettes: [
+          {
+            mount: 'left',
+            name: initialPipetteValues.left.pipetteName,
+            tiprackDefURI: initialPipetteValues.left.tiprackDefURI,
+          },
+        ],
+      })
+    })
+
+    it('updates the location of mag mod to slot 9 when a heater shaker is present', async () => {
+      props.initialPipetteValues = initialPipetteValues
+      props.initialModuleValues = {
+        ...initialModuleValues,
+        [HEATERSHAKER_MODULE_TYPE]: {
+          ...initialModuleValues[HEATERSHAKER_MODULE_TYPE],
+          slot: '1',
+          onDeck: true
+        },
+      }
+
+      const wrapper = renderFormComponent(props)
+      const saveButton = wrapper
+        .find(OutlineButton)
+        .filterWhere(n => n.render().text() === 'save')
+      saveButton.simulate('click')
+      // issue #823 in enzyme where simulate events are sync so we cannot test
+      // the btn click -> component handleSubmit properly here since formik submit is async
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      // expect(moduleFields.prop('values')).toEqual({})
+      expect(props.onSave).toHaveBeenCalledWith({
+        modules: [
+          {
+            type: MAGNETIC_MODULE_TYPE,
+            model: MAGNETIC_MODULE_V1,
+            slot: '9',
+          },
+          {
+            type: HEATERSHAKER_MODULE_TYPE,
+            model: HEATERSHAKER_MODULE_V1,
+            slot: '1',
           },
         ],
         newProtocolFields: { name: '' },

--- a/protocol-designer/src/components/modals/FilePipettesModal/index.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/index.tsx
@@ -18,6 +18,7 @@ import {
   OutlineButton,
 } from '@opentrons/components'
 import {
+  HEATERSHAKER_MODULE_V1,
   MAGNETIC_MODULE_TYPE,
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
@@ -98,8 +99,8 @@ const initialFormState: FormState = {
     },
     [HEATERSHAKER_MODULE_TYPE]: {
       onDeck: false,
-      model: null,
-      slot: '6',
+      model: HEATERSHAKER_MODULE_V1,
+      slot: '1',
     },
   },
 }
@@ -225,6 +226,16 @@ export class FilePipettesModal extends React.Component<Props, State> {
           ]
         : acc
     }, [])
+    const heaterShakerIndex = modules.findIndex(
+      hwModule => hwModule.type === HEATERSHAKER_MODULE_TYPE
+    )
+    const magModIndex = modules.findIndex(
+      hwModule => hwModule.type === MAGNETIC_MODULE_TYPE
+    )
+    if (heaterShakerIndex > -1 && magModIndex > -1) {
+      // if both are present, move the Mag mod to slot 9, since both can't be in slot 1
+      modules[magModIndex].slot = '9'
+    }
     this.props.onSave({ modules, newProtocolFields, pipettes })
   }
 

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -144,6 +144,10 @@
     "SLOT_OCCUPIED": {
       "title": "Cannot place module",
       "body": "Slot {{selectedSlot}} is occupied by another module or by labware incompatible with this module. Remove module or labware from the slot in order to continue."
+    },
+    "HEATER_SHAKER_ADJACENT_LABWARE_TOO_TALL": {
+      "title": "Cannot place module",
+      "body": "Slot {{selectedSlot}} is occupied by labware over 53mm tall. The Heater-Shaker's labware latch risks collision with this labware."
     }
   },
   "export_warnings": {

--- a/protocol-designer/src/step-forms/utils/index.ts
+++ b/protocol-designer/src/step-forms/utils/index.ts
@@ -132,9 +132,10 @@ export const getSlotIsEmpty = (
 export const getLabwareOnSlot = (
   initialDeckSetup: InitialDeckSetup,
   slot: string
-): LabwareOnDeckType => {
-  // @ts-expect-error(sa, 2021-6-10): find could return undefined, need to null check
-  return find(initialDeckSetup.labware, labware => labware.slot === slot)
+): LabwareOnDeckType | null => {
+  return (
+    find(initialDeckSetup.labware, labware => labware.slot === slot) ?? null
+  )
 }
 export const getIsCrashablePipetteSelected = (
   pipettesByMount: FormPipettesByMount

--- a/shared-data/js/helpers/index.ts
+++ b/shared-data/js/helpers/index.ts
@@ -2,7 +2,7 @@ import assert from 'assert'
 import uniq from 'lodash/uniq'
 
 import { OPENTRONS_LABWARE_NAMESPACE } from '../constants'
-import standardDeckDef from '../../deck/definitions/2/ot2_standard.json'
+import standardDeckDef from '../../deck/definitions/3/ot2_standard.json'
 import type { DeckDefinition, LabwareDefinition2 } from '../types'
 import type { ThermalAdapterName } from '..'
 


### PR DESCRIPTION
# Overview
This PR disables users from editing the location of the heater shaker into slots next to labware that is > 53 mm

closes #10454

# Changelog

- Add module placement restriction when editing position of H-S

# Review requests

review AC in [the ticket](https://github.com/Opentrons/opentrons/issues/10454)

# Risk assessment
Low
