### PR TITLE
refactor(update-server): Type update-server more strictly

### DIFF
--- a/update-server/Makefile
+++ b/update-server/Makefile
@@ -54,8 +54,8 @@ test:
 .PHONY: lint
 lint:
 	$(python) -m black --check ./otupdate ./tests
-	$(python) -m flake8 otupdate tests
 	$(python) -m mypy otupdate
+	$(python) -m flake8 otupdate tests
 
 .PHONY: format
 format:

--- a/update-server/Makefile
+++ b/update-server/Makefile
@@ -53,8 +53,8 @@ test:
 
 .PHONY: lint
 lint:
-	$(python) -m black --check ./otupdate ./tests
 	$(python) -m mypy otupdate
+	$(python) -m black --check ./otupdate ./tests
 	$(python) -m flake8 otupdate tests
 
 .PHONY: format

--- a/update-server/Pipfile
+++ b/update-server/Pipfile
@@ -22,7 +22,7 @@ coverage = "==5.1"
 # https://github.com/pypa/pipenv/issues/4408#issuecomment-668324177
 atomicwrites = {version="==1.4.0", sys_platform="== 'win32'"}
 colorama = {version="==0.4.4", sys_platform="== 'win32'"}
-mypy = "==0.910"
+mypy = "==0.940"
 black = "==22.3.0"
 
 [requires]

--- a/update-server/Pipfile.lock
+++ b/update-server/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9c7a2b2172e7027b242009d419726dce9f35400b112c159803ed9f23fad46610"
+            "sha256": "c1f36f5bd77121139aa590708ed72923fd199df3b0c32569a9870e0d8c8162ca"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -277,11 +277,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:24e1a4a9ec5bf6299411369b208c1df2188d9eb8d916302fe6bf03faed227f1e",
-                "sha256:479707fe14d9ec9a0757618b7a100a0ae4c4e236fac5b7f80ca68028141a1a72"
+                "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e",
+                "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==8.1.2"
+            "version": "==8.1.3"
         },
         "colorama": {
             "hashes": [
@@ -375,11 +375,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:1208431ca90a8cca1a6b8af391bb53c1a2db74e5d1cef6ddced95d4b2062edc6",
-                "sha256:ea4c597ebf37142f827b8f39299579e31685c31d3a438b59f469406afd0f2539"
+                "sha256:5d26852efe48c0a32b0509ffbc583fda1a2266545a78d104a6f4aff3db17d700",
+                "sha256:c58c8eb8a762858f49e18436ff552e83914778e50e9d2f1660535ffb364552ec"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==4.11.3"
+            "version": "==4.11.4"
         },
         "iniconfig": {
             "hashes": [
@@ -420,32 +420,32 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:088cd9c7904b4ad80bec811053272986611b84221835e079be5bcad029e79dd9",
-                "sha256:0aadfb2d3935988ec3815952e44058a3100499f5be5b28c34ac9d79f002a4a9a",
-                "sha256:119bed3832d961f3a880787bf621634ba042cb8dc850a7429f643508eeac97b9",
-                "sha256:1a85e280d4d217150ce8cb1a6dddffd14e753a4e0c3cf90baabb32cefa41b59e",
-                "sha256:3c4b8ca36877fc75339253721f69603a9c7fdb5d4d5a95a1a1b899d8b86a4de2",
-                "sha256:3e382b29f8e0ccf19a2df2b29a167591245df90c0b5a2542249873b5c1d78212",
-                "sha256:42c266ced41b65ed40a282c575705325fa7991af370036d3f134518336636f5b",
-                "sha256:53fd2eb27a8ee2892614370896956af2ff61254c275aaee4c230ae771cadd885",
-                "sha256:704098302473cb31a218f1775a873b376b30b4c18229421e9e9dc8916fd16150",
-                "sha256:7df1ead20c81371ccd6091fa3e2878559b5c4d4caadaf1a484cf88d93ca06703",
-                "sha256:866c41f28cee548475f146aa4d39a51cf3b6a84246969f3759cb3e9c742fc072",
-                "sha256:a155d80ea6cee511a3694b108c4494a39f42de11ee4e61e72bc424c490e46457",
-                "sha256:adaeee09bfde366d2c13fe6093a7df5df83c9a2ba98638c7d76b010694db760e",
-                "sha256:b6fb13123aeef4a3abbcfd7e71773ff3ff1526a7d3dc538f3929a49b42be03f0",
-                "sha256:b94e4b785e304a04ea0828759172a15add27088520dc7e49ceade7834275bedb",
-                "sha256:c0df2d30ed496a08de5daed2a9ea807d07c21ae0ab23acf541ab88c24b26ab97",
-                "sha256:c6c2602dffb74867498f86e6129fd52a2770c48b7cd3ece77ada4fa38f94eba8",
-                "sha256:ceb6e0a6e27fb364fb3853389607cf7eb3a126ad335790fa1e14ed02fba50811",
-                "sha256:d9dd839eb0dc1bbe866a288ba3c1afc33a202015d2ad83b31e875b5905a079b6",
-                "sha256:e4dab234478e3bd3ce83bac4193b2ecd9cf94e720ddd95ce69840273bf44f6de",
-                "sha256:ec4e0cd079db280b6bdabdc807047ff3e199f334050db5cbb91ba3e959a67504",
-                "sha256:ecd2c3fe726758037234c93df7e98deb257fd15c24c9180dacf1ef829da5f921",
-                "sha256:ef565033fa5a958e62796867b1df10c40263ea9ded87164d67572834e57a174d"
+                "sha256:0b52778a018559a256c819ee31b2e21e10b31ddca8705624317253d6d08dbc35",
+                "sha256:0fdc9191a49c77ab5fa0439915d405e80a1118b163ab03cd2a530f346b12566a",
+                "sha256:13677cb8b050f03b5bb2e8bf7b2668cd918b001d56c2435082bbfc9d5f730f42",
+                "sha256:1903c92ff8642d521b4627e51a67e49f5be5aedb1fb03465b3aae4c3338ec491",
+                "sha256:1f66f2309cdbb07e95e60e83fb4a8272095bd4ea6ee58bf9a70d5fb304ec3e3f",
+                "sha256:2dba92f58610d116f68ec1221fb2de2a346d081d17b24a784624389b17a4b3f9",
+                "sha256:2efd76893fb8327eca7e942e21b373e6f3c5c083ff860fb1e82ddd0462d662bd",
+                "sha256:3ac14949677ae9cb1adc498c423b194ad4d25b13322f6fe889fb72b664c79121",
+                "sha256:471af97c35a32061883b0f8a3305ac17947fd42ce962ca9e2b0639eb9141492f",
+                "sha256:51be997c1922e2b7be514a5215d1e1799a40832c0a0dee325ba8794f2c48818f",
+                "sha256:628f5513268ebbc563750af672ccba5eef7f92d2d90154233edd498dfb98ca4e",
+                "sha256:68038d514ae59d5b2f326be502a359160158d886bd153fc2489dbf7a03c44c96",
+                "sha256:6eab2bcc2b9489b7df87d7c20743b66d13254ad4d6430e1dfe1a655d51f0933d",
+                "sha256:712affcc456de637e774448c73e21c84dfa5a70bcda34e9b0be4fb898a9e8e07",
+                "sha256:71bec3d2782d0b1fecef7b1c436253544d81c1c0e9ca58190aed9befd8f081c5",
+                "sha256:83f66190e3c32603217105913fbfe0a3ef154ab6bbc7ef2c989f5b2957b55840",
+                "sha256:8aaf18d0f8bc3ffba56d32a85971dfbd371a5be5036da41ac16aefec440eff17",
+                "sha256:a0e5657ccaedeb5fdfda59918cc98fc6d8a8e83041bc0cec347a2ab6915f9998",
+                "sha256:a168da06eccf51875fdff5f305a47f021f23f300e2b89768abdac24538b1f8ec",
+                "sha256:b1a116c451b41e35afc09618f454b5c2704ba7a4e36f9ff65014fef26bb6075b",
+                "sha256:b2fa5f2d597478ccfe1f274f8da2f50ea1e63da5a7ae2342c5b3b2f3e57ec340",
+                "sha256:d9d7647505bf427bc7931e8baf6cacf9be97e78a397724511f20ddec2a850752",
+                "sha256:f8fe1bfab792e4300f80013edaf9949b34e4c056a7b2531b5ef3a0fb9d598ae2"
             ],
             "index": "pypi",
-            "version": "==0.910"
+            "version": "==0.940"
         },
         "mypy-extensions": {
             "hashes": [
@@ -523,11 +523,11 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:7bf433498c016c4314268d95df76c81b842a4cb2b276fa3312cfb1e1d85f6954",
-                "sha256:ef7b523f6356f763771559412c0d7134753f037822dad1b16945b7b846f7ad06"
+                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
+                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
             ],
             "markers": "python_full_version >= '3.6.8'",
-            "version": "==3.0.8"
+            "version": "==3.0.9"
         },
         "pytest": {
             "hashes": [
@@ -585,39 +585,33 @@
         },
         "typed-ast": {
             "hashes": [
-                "sha256:01ae5f73431d21eead5015997ab41afa53aa1fbe252f9da060be5dad2c730ace",
-                "sha256:067a74454df670dcaa4e59349a2e5c81e567d8d65458d480a5b3dfecec08c5ff",
-                "sha256:0fb71b8c643187d7492c1f8352f2c15b4c4af3f6338f21681d3681b3dc31a266",
-                "sha256:1b3ead4a96c9101bef08f9f7d1217c096f31667617b58de957f690c92378b528",
-                "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6",
-                "sha256:209596a4ec71d990d71d5e0d312ac935d86930e6eecff6ccc7007fe54d703808",
-                "sha256:2c726c276d09fc5c414693a2de063f521052d9ea7c240ce553316f70656c84d4",
-                "sha256:398e44cd480f4d2b7ee8d98385ca104e35c81525dd98c519acff1b79bdaac363",
-                "sha256:52b1eb8c83f178ab787f3a4283f68258525f8d70f778a2f6dd54d3b5e5fb4341",
-                "sha256:5feca99c17af94057417d744607b82dd0a664fd5e4ca98061480fd8b14b18d04",
-                "sha256:7538e495704e2ccda9b234b82423a4038f324f3a10c43bc088a1636180f11a41",
-                "sha256:760ad187b1041a154f0e4d0f6aae3e40fdb51d6de16e5c99aedadd9246450e9e",
-                "sha256:777a26c84bea6cd934422ac2e3b78863a37017618b6e5c08f92ef69853e765d3",
-                "sha256:95431a26309a21874005845c21118c83991c63ea800dd44843e42a916aec5899",
-                "sha256:9ad2c92ec681e02baf81fdfa056fe0d818645efa9af1f1cd5fd6f1bd2bdfd805",
-                "sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c",
-                "sha256:aee0c1256be6c07bd3e1263ff920c325b59849dc95392a05f258bb9b259cf39c",
-                "sha256:af3d4a73793725138d6b334d9d247ce7e5f084d96284ed23f22ee626a7b88e39",
-                "sha256:b36b4f3920103a25e1d5d024d155c504080959582b928e91cb608a65c3a49e1a",
-                "sha256:b9574c6f03f685070d859e75c7f9eeca02d6933273b5e69572e5ff9d5e3931c3",
-                "sha256:bff6ad71c81b3bba8fa35f0f1921fb24ff4476235a6e94a26ada2e54370e6da7",
-                "sha256:c190f0899e9f9f8b6b7863debfb739abcb21a5c054f911ca3596d12b8a4c4c7f",
-                "sha256:c907f561b1e83e93fad565bac5ba9c22d96a54e7ea0267c708bffe863cbe4075",
-                "sha256:cae53c389825d3b46fb37538441f75d6aecc4174f615d048321b716df2757fb0",
-                "sha256:dd4a21253f42b8d2b48410cb31fe501d32f8b9fbeb1f55063ad102fe9c425e40",
-                "sha256:dde816ca9dac1d9c01dd504ea5967821606f02e510438120091b84e852367428",
-                "sha256:f2362f3cb0f3172c42938946dbc5b7843c2a28aec307c49100c8b38764eb6927",
-                "sha256:f328adcfebed9f11301eaedfa48e15bdece9b519fb27e6a8c01aa52a17ec31b3",
-                "sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f",
-                "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"
+                "sha256:0261195c2062caf107831e92a76764c81227dae162c4f75192c0d489faf751a2",
+                "sha256:0fdbcf2fef0ca421a3f5912555804296f0b0960f0418c440f5d6d3abb549f3e1",
+                "sha256:183afdf0ec5b1b211724dfef3d2cad2d767cbefac291f24d69b00546c1837fb6",
+                "sha256:211260621ab1cd7324e0798d6be953d00b74e0428382991adfddb352252f1d62",
+                "sha256:267e3f78697a6c00c689c03db4876dd1efdfea2f251a5ad6555e82a26847b4ac",
+                "sha256:2efae9db7a8c05ad5547d522e7dbe62c83d838d3906a3716d1478b6c1d61388d",
+                "sha256:370788a63915e82fd6f212865a596a0fefcbb7d408bbbb13dea723d971ed8bdc",
+                "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2",
+                "sha256:3e123d878ba170397916557d31c8f589951e353cc95fb7f24f6bb69adc1a8a97",
+                "sha256:4879da6c9b73443f97e731b617184a596ac1235fe91f98d279a7af36c796da35",
+                "sha256:4e964b4ff86550a7a7d56345c7864b18f403f5bd7380edf44a3c1fb4ee7ac6c6",
+                "sha256:639c5f0b21776605dd6c9dbe592d5228f021404dafd377e2b7ac046b0349b1a1",
+                "sha256:669dd0c4167f6f2cd9f57041e03c3c2ebf9063d0757dc89f79ba1daa2bfca9d4",
+                "sha256:6778e1b2f81dfc7bc58e4b259363b83d2e509a65198e85d5700dfae4c6c8ff1c",
+                "sha256:683407d92dc953c8a7347119596f0b0e6c55eb98ebebd9b23437501b28dcbb8e",
+                "sha256:79b1e0869db7c830ba6a981d58711c88b6677506e648496b1f64ac7d15633aec",
+                "sha256:7d5d014b7daa8b0bf2eaef684295acae12b036d79f54178b92a2b6a56f92278f",
+                "sha256:98f80dee3c03455e92796b58b98ff6ca0b2a6f652120c263efdba4d6c5e58f72",
+                "sha256:a94d55d142c9265f4ea46fab70977a1944ecae359ae867397757d836ea5a3f47",
+                "sha256:a9916d2bb8865f973824fb47436fa45e1ebf2efd920f2b9f99342cb7fab93f72",
+                "sha256:c542eeda69212fa10a7ada75e668876fdec5f856cd3d06829e6aa64ad17c8dfe",
+                "sha256:cf4afcfac006ece570e32d6fa90ab74a17245b83dfd6655a6f68568098345ff6",
+                "sha256:ebd9d7f80ccf7a82ac5f88c521115cc55d84e35bf8b446fcd7836eb6b98929a3",
+                "sha256:ed855bbe3eb3715fca349c80174cfcfd699c2f9de574d40527b8429acae23a66"
             ],
             "markers": "python_version < '3.8' and implementation_name == 'cpython'",
-            "version": "==1.4.3"
+            "version": "==1.5.4"
         },
         "typing-extensions": {
             "hashes": [
@@ -630,33 +624,34 @@
         },
         "watchdog": {
             "hashes": [
-                "sha256:03b43d583df0f18782a0431b6e9e9965c5b3f7cf8ec36a00b930def67942c385",
-                "sha256:0908bb50f6f7de54d5d31ec3da1654cb7287c6b87bce371954561e6de379d690",
-                "sha256:0b4a1fe6201c6e5a1926f5767b8664b45f0fcb429b62564a41f490ff1ce1dc7a",
-                "sha256:177bae28ca723bc00846466016d34f8c1d6a621383b6caca86745918d55c7383",
-                "sha256:19b36d436578eb437e029c6b838e732ed08054956366f6dd11875434a62d2b99",
-                "sha256:1d1cf7dfd747dec519486a98ef16097e6c480934ef115b16f18adb341df747a4",
-                "sha256:1e877c70245424b06c41ac258023ea4bd0c8e4ff15d7c1368f17cd0ae6e351dd",
-                "sha256:340b875aecf4b0e6672076a6f05cfce6686935559bb6d34cebedee04126a9566",
-                "sha256:351e09b6d9374d5bcb947e6ac47a608ec25b9d70583e9db00b2fcdb97b00b572",
-                "sha256:3fd47815353be9c44eebc94cc28fe26b2b0c5bd889dafc4a5a7cbdf924143480",
-                "sha256:49639865e3db4be032a96695c98ac09eed39bbb43fe876bb217da8f8101689a6",
-                "sha256:4d0e98ac2e8dd803a56f4e10438b33a2d40390a72750cff4939b4b274e7906fa",
-                "sha256:6e6ae29b72977f2e1ee3d0b760d7ee47896cb53e831cbeede3e64485e5633cc8",
-                "sha256:7f14ce6adea2af1bba495acdde0e510aecaeb13b33f7bd2f6324e551b26688ca",
-                "sha256:81982c7884aac75017a6ecc72f1a4fedbae04181a8665a34afce9539fc1b3fab",
-                "sha256:81a5861d0158a7e55fe149335fb2bbfa6f48cbcbd149b52dbe2cd9a544034bbd",
-                "sha256:ae934e34c11aa8296c18f70bf66ed60e9870fcdb4cc19129a04ca83ab23e7055",
-                "sha256:b26e13e8008dcaea6a909e91d39b629a39635d1a8a7239dd35327c74f4388601",
-                "sha256:b3750ee5399e6e9c69eae8b125092b871ee9e2fcbd657a92747aea28f9056a5c",
-                "sha256:b61acffaf5cd5d664af555c0850f9747cc5f2baf71e54bbac164c58398d6ca7b",
-                "sha256:b9777664848160449e5b4260e0b7bc1ae0f6f4992a8b285db4ec1ef119ffa0e2",
-                "sha256:bdcbf75580bf4b960fb659bbccd00123d83119619195f42d721e002c1621602f",
-                "sha256:d802d65262a560278cf1a65ef7cae4e2bc7ecfe19e5451349e4c67e23c9dc420",
-                "sha256:ed6d9aad09a2a948572224663ab00f8975fae242aa540509737bb4507133fa2d"
+                "sha256:036ed15f7cd656351bf4e17244447be0a09a61aaa92014332d50719fc5973bc0",
+                "sha256:0c520009b8cce79099237d810aaa19bc920941c268578436b62013b2f0102320",
+                "sha256:0fb60c7d31474b21acba54079ce9ff0136411183e9a591369417cddb1d7d00d7",
+                "sha256:156ec3a94695ea68cfb83454b98754af6e276031ba1ae7ae724dc6bf8973b92a",
+                "sha256:1ae17b6be788fb8e4d8753d8d599de948f0275a232416e16436363c682c6f850",
+                "sha256:1e5d0fdfaa265c29dc12621913a76ae99656cf7587d03950dfeb3595e5a26102",
+                "sha256:24dedcc3ce75e150f2a1d704661f6879764461a481ba15a57dc80543de46021c",
+                "sha256:2962628a8777650703e8f6f2593065884c602df7bae95759b2df267bd89b2ef5",
+                "sha256:47598fe6713fc1fee86b1ca85c9cbe77e9b72d002d6adeab9c3b608f8a5ead10",
+                "sha256:4978db33fc0934c92013ee163a9db158ec216099b69fce5aec790aba704da412",
+                "sha256:5e2e51c53666850c3ecffe9d265fc5d7351db644de17b15e9c685dd3cdcd6f97",
+                "sha256:676263bee67b165f16b05abc52acc7a94feac5b5ab2449b491f1a97638a79277",
+                "sha256:68dbe75e0fa1ba4d73ab3f8e67b21770fbed0651d32ce515cd38919a26873266",
+                "sha256:6d03149126864abd32715d4e9267d2754cede25a69052901399356ad3bc5ecff",
+                "sha256:6ddf67bc9f413791072e3afb466e46cc72c6799ba73dea18439b412e8f2e3257",
+                "sha256:746e4c197ec1083581bb1f64d07d1136accf03437badb5ff8fcb862565c193b2",
+                "sha256:7721ac736170b191c50806f43357407138c6748e4eb3e69b071397f7f7aaeedd",
+                "sha256:88ef3e8640ef0a64b7ad7394b0f23384f58ac19dd759da7eaa9bc04b2898943f",
+                "sha256:aa68d2d9a89d686fae99d28a6edf3b18595e78f5adf4f5c18fbfda549ac0f20c",
+                "sha256:b962de4d7d92ff78fb2dbc6a0cb292a679dea879a0eb5568911484d56545b153",
+                "sha256:ce7376aed3da5fd777483fe5ebc8475a440c6d18f23998024f832134b2938e7b",
+                "sha256:ddde157dc1447d8130cb5b8df102fad845916fe4335e3d3c3f44c16565becbb7",
+                "sha256:efcc8cbc1b43902571b3dce7ef53003f5b97fe4f275fe0489565fc6e2ebe3314",
+                "sha256:f9ee4c6bf3a1b2ed6be90a2d78f3f4bbd8105b6390c04a86eb48ed67bbfa0b0b",
+                "sha256:fed4de6e45a4f16e4046ea00917b4fe1700b97244e5d114f594b4a1b9de6bed8"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.1.7"
+            "version": "==2.1.8"
         },
         "yarl": {
             "hashes": [

--- a/update-server/mypy.ini
+++ b/update-server/mypy.ini
@@ -3,13 +3,16 @@ strict = True
 show_error_codes = True
 
 
-# The dbus and systemd packages will not be installed in non-Linux dev environments,
-# so we expect mypy to find it missing wherever we try importing it.
+# The dbus and systemd packages will not be installed in non-Linux dev environments.
+# Permit mypy to find them missing wherever we try importing them.
 [mypy-dbus.*]
 ignore_missing_imports=True
 [mypy-systemd.*]
 ignore_missing_imports=True
 
+
+# TODO(mm, 2022-05-25): Resolve the typing errors in these files
+# and remove these overrides when able.
 
 # ~6 errors
 [mypy-otupdate.common.control]
@@ -17,32 +20,35 @@ disallow_untyped_defs= False
 disallow_untyped_calls = False
 warn_return_any = False
 
+# ~8 errors
 [mypy-otupdate.common.session]
 disallow_untyped_defs= False
 disallow_untyped_calls = False
 warn_return_any = False
 
+# ~28 errors
 [mypy-otupdate.common.update]
 disallow_untyped_defs= False
 disallow_untyped_calls = False
 warn_return_any = False
 
+# ~ 17 errors
 [mypy-otupdate.buildroot]
 disallow_untyped_defs= False
 disallow_untyped_calls = False
 warn_return_any = False
 
+# ~5 errors
 [mypy-otupdate.buildroot.update_actions]
 disallow_untyped_defs= False
 disallow_untyped_calls = False
-warn_return_any = False
 
+# ~16 errors
 [mypy-otupdate.openembedded]
 disallow_untyped_defs= False
 disallow_untyped_calls = False
-warn_return_any = False
 
+# ~5 errors
 [mypy-otupdate.openembedded.updater]
 disallow_untyped_defs= False
 disallow_untyped_calls = False
-warn_return_any = False

--- a/update-server/mypy.ini
+++ b/update-server/mypy.ini
@@ -1,3 +1,4 @@
 [mypy]
+strict = True
 ignore_missing_imports = True
 show_error_codes = True

--- a/update-server/mypy.ini
+++ b/update-server/mypy.ini
@@ -1,4 +1,48 @@
 [mypy]
 strict = True
-ignore_missing_imports = True
 show_error_codes = True
+
+
+# The dbus and systemd packages will not be installed in non-Linux dev environments,
+# so we expect mypy to find it missing wherever we try importing it.
+[mypy-dbus.*]
+ignore_missing_imports=True
+[mypy-systemd.*]
+ignore_missing_imports=True
+
+
+# ~6 errors
+[mypy-otupdate.common.control]
+disallow_untyped_defs= False
+disallow_untyped_calls = False
+warn_return_any = False
+
+[mypy-otupdate.common.session]
+disallow_untyped_defs= False
+disallow_untyped_calls = False
+warn_return_any = False
+
+[mypy-otupdate.common.update]
+disallow_untyped_defs= False
+disallow_untyped_calls = False
+warn_return_any = False
+
+[mypy-otupdate.buildroot]
+disallow_untyped_defs= False
+disallow_untyped_calls = False
+warn_return_any = False
+
+[mypy-otupdate.buildroot.update_actions]
+disallow_untyped_defs= False
+disallow_untyped_calls = False
+warn_return_any = False
+
+[mypy-otupdate.openembedded]
+disallow_untyped_defs= False
+disallow_untyped_calls = False
+warn_return_any = False
+
+[mypy-otupdate.openembedded.updater]
+disallow_untyped_defs= False
+disallow_untyped_calls = False
+warn_return_any = False

--- a/update-server/otupdate/buildroot/__init__.py
+++ b/update-server/otupdate/buildroot/__init__.py
@@ -2,7 +2,7 @@
 import asyncio
 import logging
 import json
-from typing import Mapping, Any
+from typing import Any, Mapping, Optional
 from aiohttp import web
 
 from otupdate.common import (
@@ -38,11 +38,11 @@ def get_version(version_file: str) -> Mapping[str, str]:
 
 
 def get_app(
-    system_version_file: str = None,
-    config_file_override: str = None,
-    name_override: str = None,
-    boot_id_override: str = None,
-    loop: asyncio.AbstractEventLoop = None,
+    system_version_file: Optional[str] = None,
+    config_file_override: Optional[str] = None,
+    name_override: Optional[str] = None,
+    boot_id_override: Optional[str] = None,
+    loop: Optional[asyncio.AbstractEventLoop] = None,
 ) -> web.Application:
     """Build and return the aiohttp.web.Application that runs the server
 

--- a/update-server/otupdate/buildroot/__main__.py
+++ b/update-server/otupdate/buildroot/__main__.py
@@ -40,7 +40,7 @@ def main() -> None:
     systemd.notify_up()
 
     LOG.info(f"Starting buildroot update server on http://{args.host}:{args.port}")
-    web.run_app(app, host=args.host, port=args.port)
+    web.run_app(app, host=args.host, port=args.port)  # type: ignore[no-untyped-call]
 
 
 if __name__ == "__main__":

--- a/update-server/otupdate/buildroot/update_actions.py
+++ b/update-server/otupdate/buildroot/update_actions.py
@@ -95,7 +95,7 @@ class OT2UpdateActions(UpdateActionsInterface):
         rootfs_filepath: str,
         progress_callback: Callable[[float], None],
         chunk_size: int = 1024,
-        file_size: int = None,
+        file_size: Optional[int] = None,
     ) -> Partition:
         """
         Write the new rootfs to the next root partition

--- a/update-server/otupdate/buildroot/update_actions.py
+++ b/update-server/otupdate/buildroot/update_actions.py
@@ -12,7 +12,7 @@ import os
 import re
 import subprocess
 import tempfile
-from typing import Callable, Optional
+from typing import Callable, Optional, Iterator
 
 from otupdate.common.file_actions import (
     unzip_update,
@@ -121,7 +121,7 @@ class OT2UpdateActions(UpdateActionsInterface):
         return unused.value
 
     @contextlib.contextmanager
-    def mount_update(self):
+    def mount_update(self) -> Iterator[str]:
         """Mount the freshly-written partition r/w (to update machine-id).
 
         Should be used as a context manager, and the yielded value is the path

--- a/update-server/otupdate/buildroot/update_actions.py
+++ b/update-server/otupdate/buildroot/update_actions.py
@@ -12,7 +12,7 @@ import os
 import re
 import subprocess
 import tempfile
-from typing import Callable, Optional, Iterator
+from typing import Callable, Generator, Optional
 
 from otupdate.common.file_actions import (
     unzip_update,
@@ -121,7 +121,7 @@ class OT2UpdateActions(UpdateActionsInterface):
         return unused.value
 
     @contextlib.contextmanager
-    def mount_update(self) -> Iterator[str]:
+    def mount_update(self) -> Generator[str, None, None]:
         """Mount the freshly-written partition r/w (to update machine-id).
 
         Should be used as a context manager, and the yielded value is the path

--- a/update-server/otupdate/buildroot/update_actions.py
+++ b/update-server/otupdate/buildroot/update_actions.py
@@ -150,7 +150,7 @@ class OT2UpdateActions(UpdateActionsInterface):
         else:
             LOG.info(f"commit_update: committed to booting {new}")
 
-    def write_machine_id(self, current_root: str, new_root: str):
+    def write_machine_id(self, current_root: str, new_root: str) -> None:
         """Update the machine id in target rootfs"""
         mid = open(os.path.join(current_root, "etc", "machine-id")).read()
         with open(os.path.join(new_root, "etc", "machine-id"), "w") as new_mid:
@@ -169,8 +169,8 @@ def write_file(
     outfile: str,
     progress_callback: Callable[[float], None],
     chunk_size: int = 1024,
-    file_size: int = None,
-):
+    file_size: Optional[int] = None,
+) -> None:
     """Write a file to another file with progress callbacks.
 
     :param infile: The input filepath

--- a/update-server/otupdate/common/config.py
+++ b/update-server/otupdate/common/config.py
@@ -5,7 +5,7 @@ otupdate.common.config: Handlers for reading update server configuration
 import os
 import logging
 import json
-from typing import Any, Dict, Mapping, NamedTuple, Optional, Tuple
+from typing import Any, Dict, Mapping, NamedTuple, Optional, Tuple, cast
 
 from aiohttp.web import Request
 
@@ -38,7 +38,7 @@ class Config(NamedTuple):
 
 
 def config_from_request(req: Request) -> Config:
-    return req.app[CONFIG_VARNAME]
+    return cast(Config, req.app[CONFIG_VARNAME])
 
 
 def _ensure_load(path: str) -> Optional[Mapping[str, Any]]:
@@ -116,7 +116,7 @@ def _get_path(args_path: Optional[str]) -> str:
     return DEFAULT_PATH
 
 
-def load(args_path: str = None) -> Config:
+def load(args_path: Optional[str] = None) -> Config:
     """
     Load the config file, selecting the appropriate path from many sources
     """

--- a/update-server/otupdate/common/file_actions.py
+++ b/update-server/otupdate/common/file_actions.py
@@ -16,38 +16,38 @@ LOG = logging.getLogger(__name__)
 
 
 class FileMissing(ValueError):
-    def __init__(self, message):
+    def __init__(self, message: str) -> None:
         self.message = message
         self.short = "File Missing"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<{self.__class__.__name__}: {self.message}>"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.message
 
 
 class SignatureMismatch(ValueError):
-    def __init__(self, message):
+    def __init__(self, message: str) -> None:
         self.message = message
         self.short = "Signature Mismatch"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<{self.__class__.__name__}: {self.message}>"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.message
 
 
 class HashMismatch(ValueError):
-    def __init__(self, message):
+    def __init__(self, message: str) -> None:
         self.message = message
         self.short = "Hash Mismatch"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<{self.__class__.__name__}: {self.message}>"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.message
 
 
@@ -144,7 +144,7 @@ def hash_file(
     path: str,
     progress_callback: Callable[[float], None],
     chunk_size: int = 1024,
-    file_size: int = None,
+    file_size: Optional[int] = None,
     algo: str = "sha256",
 ) -> bytes:
     """

--- a/update-server/otupdate/common/handler_type.py
+++ b/update-server/otupdate/common/handler_type.py
@@ -1,0 +1,12 @@
+from typing_extensions import Protocol
+from aiohttp import web
+
+
+class HandlerType(Protocol):
+    """The type signature of an aiohttp request handler function.
+
+    Useful for typing function decorators that operate on aiohttp request handlers.
+    """
+
+    async def __call__(self, request: web.Request) -> web.Response:
+        ...

--- a/update-server/otupdate/common/handler_type.py
+++ b/update-server/otupdate/common/handler_type.py
@@ -2,7 +2,7 @@ from typing_extensions import Protocol
 from aiohttp import web
 
 
-class HandlerType(Protocol):
+class Handler(Protocol):
     """The type signature of an aiohttp request handler function.
 
     Useful for typing function decorators that operate on aiohttp request handlers.

--- a/update-server/otupdate/common/name_management.py
+++ b/update-server/otupdate/common/name_management.py
@@ -83,7 +83,7 @@ try:
 
     _BUS_STATE: Optional[DBusState] = None
 
-    def _set_avahi_service_name_sync(new_service_name: str):
+    def _set_avahi_service_name_sync(new_service_name: str) -> None:
         """The synchronous implementation of setting the Avahi service name.
 
         The dbus module doesn't natively support async/await.
@@ -136,7 +136,7 @@ try:
 except ImportError:
     LOG.exception("Couldn't import dbus, name setting will be nonfunctional")
 
-    def _set_avahi_service_name_sync(new_service_name: str):
+    def _set_avahi_service_name_sync(new_service_name: str) -> None:
         LOG.warning("Not setting name, dbus could not be imported")
 
 
@@ -249,7 +249,7 @@ async def set_up_static_hostname() -> str:
     return hostname
 
 
-def _rewrite_machine_info(new_pretty_hostname: str):
+def _rewrite_machine_info(new_pretty_hostname: str) -> None:
     """Write a new value for the pretty hostname.
 
     :raises OSError: If the new value could not be written.
@@ -287,7 +287,7 @@ def _rewrite_machine_info_str(
     return new_contents
 
 
-def get_pretty_hostname(default: str = "no name set"):
+def get_pretty_hostname(default: str = "no name set") -> str:
     """Get the currently-configured pretty hostname"""
     try:
         with open("/etc/machine-info") as emi:
@@ -356,7 +356,9 @@ async def set_name_endpoint(request: web.Request) -> web.Response:
     """
 
     def build_400(msg: str) -> web.Response:
-        return web.json_response(data={"message": msg}, status=400)
+        return web.json_response(  # type: ignore[no-untyped-call,no-any-return]
+            data={"message": msg}, status=400
+        )
 
     try:
         body = await request.json()
@@ -376,7 +378,9 @@ async def set_name_endpoint(request: web.Request) -> web.Response:
     new_name = await set_name(app=request.app, new_name=name_to_set)
 
     request.app[DEVICE_NAME_VARNAME] = new_name
-    return web.json_response(data={"name": new_name}, status=200)
+    return web.json_response(  # type: ignore[no-untyped-call,no-any-return]
+        data={"name": new_name}, status=200
+    )
 
 
 async def get_name_endpoint(request: web.Request) -> web.Response:
@@ -387,6 +391,6 @@ async def get_name_endpoint(request: web.Request) -> web.Response:
 
     GET /server/name -> 200 OK, {'name': robot name}
     """
-    return web.json_response(
+    return web.json_response(  # type: ignore[no-untyped-call,no-any-return]
         data={"name": request.app[DEVICE_NAME_VARNAME]}, status=200
     )

--- a/update-server/otupdate/common/session.py
+++ b/update-server/otupdate/common/session.py
@@ -47,23 +47,23 @@ class UpdateSession:
         self._rootfs_file: Optional[str] = None
         LOG.info(f"update session: created {self._token}")
 
-    def _setup_dl_area(self):
+    def _setup_dl_area(self) -> None:
         if os.path.exists(self._storage_path):
             shutil.rmtree(self._storage_path)
         os.makedirs(self._storage_path, mode=0o700, exist_ok=True)
 
-    def __del__(self):
+    def __del__(self) -> None:
         if hasattr(self, "_storage_path"):
             shutil.rmtree(self._storage_path)
         LOG.info(f"Update session: removed {getattr(self, '_token', '<unknown>')}")
 
-    def set_stage(self, stage: Stages):
+    def set_stage(self, stage: Stages) -> None:
         """Convenience method to set the stage and lookup message"""
         assert stage in Stages
         LOG.info(f"Update session: stage {self._stage.name}->{stage.name}")
         self._stage = stage
 
-    def set_error(self, error_shortmsg: str, error_longmsg: str):
+    def set_error(self, error_shortmsg: str, error_longmsg: str) -> None:
         """Set the stage to error and add a message"""
         LOG.error(
             f"Update session: error in stage {self._stage.name}: "

--- a/update-server/otupdate/common/ssh_key_management.py
+++ b/update-server/otupdate/common/ssh_key_management.py
@@ -7,7 +7,13 @@ import hashlib
 import ipaddress
 import logging
 import os
-from typing import List, Tuple
+from typing import (
+    Any,
+    Generator,
+    IO,
+    List,
+    Tuple,
+)
 
 from aiohttp import web
 
@@ -15,7 +21,14 @@ from aiohttp import web
 LOG = logging.getLogger(__name__)
 
 
-def require_linklocal(handler):
+class _HandlerT(Protocol):
+    """The type signature of an aiohttp request handler function."""
+
+    async def __call__(self, request: web.Request) -> web.Response:
+        ...
+
+
+def require_linklocal(handler: _HandlerT) -> _HandlerT:
     """Ensure the decorated is only called if the request is linklocal.
 
     The host ip address should be in the X-Host-IP header (provided by nginx)
@@ -35,7 +48,9 @@ def require_linklocal(handler):
             ),
         }
         if not ipaddr_str:
-            return web.json_response(data=invalid_req_data, status=403)
+            return web.json_response(  # type: ignore[no-untyped-call,no-any-return]
+                data=invalid_req_data, status=403
+            )
         try:
             addr = ipaddress.ip_address(ipaddr_str)
         except ValueError:
@@ -43,7 +58,9 @@ def require_linklocal(handler):
             raise
 
         if not addr.is_link_local:
-            return web.json_response(data=invalid_req_data, status=403)
+            return web.json_response(  # type: ignore[no-untyped-call,no-any-return]
+                data=invalid_req_data, status=403
+            )
 
         return await handler(request)
 
@@ -51,7 +68,7 @@ def require_linklocal(handler):
 
 
 @contextlib.contextmanager
-def authorized_keys(mode="r"):
+def authorized_keys(mode: str = "r") -> Generator[IO[Any], None, None]:
     """Open the authorized_keys file. Separate function for mocking.
 
     :param mode: As :py:meth:`open`
@@ -74,7 +91,7 @@ def get_keys() -> List[Tuple[str, str]]:
         ]
 
 
-def remove_by_hash(hashval: str):
+def remove_by_hash(hashval: str) -> None:
     """Remove the key whose md5 sum matches hashval.
 
     :raises: KeyError if the hashval wasn't found
@@ -106,7 +123,7 @@ async def list_keys(request: web.Request) -> web.Response:
 
     (or 403 if not from the link-local connection)
     """
-    return web.json_response(
+    return web.json_response(  # type: ignore[no-untyped-call,no-any-return]
         {
             "public_keys": [
                 {"key_md5": details[0], "key": details[1]} for details in get_keys()
@@ -127,7 +144,9 @@ async def add(request: web.Request) -> web.Response:
     """
 
     def key_error(error: str, message: str) -> web.Response:
-        return web.json_response(data={"error": error, "message": message}, status=400)
+        return web.json_response(  # type: ignore[no-untyped-call,no-any-return]
+            data={"error": error, "message": message}, status=400
+        )
 
     body = await request.json()
 
@@ -162,7 +181,7 @@ async def add(request: web.Request) -> web.Response:
         with authorized_keys("a") as ak:
             ak.write(f"{pubkey}\n")
 
-    return web.json_response(
+    return web.json_response(  # type: ignore[no-untyped-call,no-any-return]
         data={"message": f"Added key {hashval}", "key_md5": hashval}, status=201
     )
 
@@ -179,7 +198,7 @@ async def clear(request: web.Request) -> web.Response:
     with authorized_keys("w") as ak:
         ak.write("\n".join([]) + "\n")
 
-    return web.json_response(
+    return web.json_response(  # type: ignore[no-untyped-call,no-any-return]
         data={
             "message": "Keys cleared. " "Restart robot to take effect",
             "restart_url": "/server/restart",
@@ -206,7 +225,7 @@ async def remove(request: web.Request) -> web.Response:
             new_keys.append(key)
 
     if not found:
-        return web.json_response(
+        return web.json_response(  # type: ignore[no-untyped-call,no-any-return]
             data={
                 "error": "invalid-key-hash",
                 "message": f"No such key md5 {requested_hash}",
@@ -217,7 +236,7 @@ async def remove(request: web.Request) -> web.Response:
     with authorized_keys("w") as ak:
         ak.write("\n".join(new_keys) + "\n")
 
-    return web.json_response(
+    return web.json_response(  # type: ignore[no-untyped-call,no-any-return]
         data={
             "message": f"Key {requested_hash} deleted. " "Restart robot to take effect",
             "restart_url": "/server/restart",

--- a/update-server/otupdate/common/ssh_key_management.py
+++ b/update-server/otupdate/common/ssh_key_management.py
@@ -17,13 +17,13 @@ from typing import (
 
 from aiohttp import web
 
-from .handler_type import HandlerType
+from .handler_type import Handler
 
 
 LOG = logging.getLogger(__name__)
 
 
-def require_linklocal(handler: HandlerType) -> HandlerType:
+def require_linklocal(handler: Handler) -> Handler:
     """Ensure the decorated is only called if the request is linklocal.
 
     The host ip address should be in the X-Host-IP header (provided by nginx)

--- a/update-server/otupdate/common/ssh_key_management.py
+++ b/update-server/otupdate/common/ssh_key_management.py
@@ -17,18 +17,13 @@ from typing import (
 
 from aiohttp import web
 
+from .handler_type import HandlerType
+
 
 LOG = logging.getLogger(__name__)
 
 
-class _HandlerT(Protocol):
-    """The type signature of an aiohttp request handler function."""
-
-    async def __call__(self, request: web.Request) -> web.Response:
-        ...
-
-
-def require_linklocal(handler: _HandlerT) -> _HandlerT:
+def require_linklocal(handler: HandlerType) -> HandlerType:
     """Ensure the decorated is only called if the request is linklocal.
 
     The host ip address should be in the X-Host-IP header (provided by nginx)

--- a/update-server/otupdate/common/systemd.py
+++ b/update-server/otupdate/common/systemd.py
@@ -3,13 +3,14 @@ systemd bindings with fallbacks for test
 """
 
 import logging.config
+from typing import Dict, Union
 
 try:
     # systemd journal is available, we can use its handler
     import systemd.journal
     import systemd.daemon
 
-    def log_handler(topic_name: str, log_level: int):
+    def log_handler(topic_name: str, log_level: int) -> Dict[str, Union[int, str]]:
         return {
             "class": "systemd.journal.JournalHandler",
             "formatter": "message_only",
@@ -23,7 +24,7 @@ try:
     # dependent services until we actually say we're ready. By calling this
     # after we change the hostname, we make anything with an After= on us
     # be guaranteed to see the correct hostname
-    def notify_up():
+    def notify_up() -> None:
         systemd.daemon.notify("READY=1")
 
     SOURCE: str = "systemd"
@@ -31,20 +32,20 @@ try:
 except ImportError:
     # systemd journal isn't available, probably running tests
 
-    def log_handler(topic_name: str, log_level: int):
+    def log_handler(topic_name: str, log_level: int) -> Dict[str, Union[int, str]]:
         return {
             "class": "logging.StreamHandler",
             "formatter": "basic",
             "level": log_level,
         }
 
-    def notify_up():
+    def notify_up() -> None:
         pass
 
     SOURCE = "dummy"
 
 
-def configure_logging(level: int):
+def configure_logging(level: int) -> None:
     config = {
         "version": 1,
         "formatters": {

--- a/update-server/otupdate/common/update.py
+++ b/update-server/otupdate/common/update.py
@@ -91,7 +91,7 @@ async def status(request: web.Request, session: UpdateSession) -> web.Response:
     return web.json_response(data=session.state, status=200)
 
 
-async def _save_file(part: BodyPartReader, path: str):
+async def _save_file(part: BodyPartReader, path: str) -> None:
     # making sure directory exists first
     Path(path).mkdir(parents=True, exist_ok=True)
     with open(os.path.join(path, part.name), "wb") as write:
@@ -111,7 +111,7 @@ def _begin_write(
     loop: asyncio.AbstractEventLoop,
     rootfs_file_path: str,
     actions: update_actions.UpdateActionsInterface,
-):
+) -> None:
     """Start the write process."""
     session.set_progress(0)
     session.set_stage(Stages.WRITING)
@@ -140,7 +140,7 @@ def _begin_validation(
     loop: asyncio.AbstractEventLoop,
     downloaded_update_path: str,
     actions: update_actions.UpdateActionsInterface,
-) -> asyncio.futures.Future:
+) -> "asyncio.futures.Future[Optional[str]]":
     """Start the validation process."""
     session.set_stage(Stages.VALIDATING)
     cert_path = config.update_cert_path if config.signature_required else None

--- a/update-server/otupdate/common/update.py
+++ b/update-server/otupdate/common/update.py
@@ -18,7 +18,7 @@ from aiohttp import web, BodyPartReader
 
 from . import config, update_actions
 from .constants import APP_VARIABLE_PREFIX, RESTART_LOCK_NAME
-from .handler_type import HandlerType
+from .handler_type import Handler
 from .session import UpdateSession, Stages
 
 from otupdate.openembedded.updater import UPDATE_PKG
@@ -27,7 +27,7 @@ SESSION_VARNAME = APP_VARIABLE_PREFIX + "session"
 LOG = logging.getLogger(__name__)
 
 
-class _HandlerWithSessionType(Protocol):
+class _HandlerWithSession(Protocol):
     """The type signature of an aiohttp request handler that also has a session arg.
 
     See require_session().
@@ -43,7 +43,7 @@ def session_from_request(request: web.Request) -> Optional[UpdateSession]:
     return request.app.get(SESSION_VARNAME, None)
 
 
-def require_session(handler: _HandlerWithSessionType) -> HandlerType:
+def require_session(handler: _HandlerWithSession) -> Handler:
     """Decorator to ensure a session is properly in the request"""
 
     @functools.wraps(handler)

--- a/update-server/otupdate/common/update.py
+++ b/update-server/otupdate/common/update.py
@@ -12,11 +12,13 @@ from pathlib import Path
 from subprocess import CalledProcessError
 
 from typing import Optional
+from typing_extensions import Protocol
 
 from aiohttp import web, BodyPartReader
 
-from .constants import APP_VARIABLE_PREFIX, RESTART_LOCK_NAME
 from . import config, update_actions
+from .constants import APP_VARIABLE_PREFIX, RESTART_LOCK_NAME
+from .handler_type import HandlerType
 from .session import UpdateSession, Stages
 
 from otupdate.openembedded.updater import UPDATE_PKG
@@ -25,11 +27,23 @@ SESSION_VARNAME = APP_VARIABLE_PREFIX + "session"
 LOG = logging.getLogger(__name__)
 
 
+class _HandlerWithSessionType(Protocol):
+    """The type signature of an aiohttp request handler that also has a session arg.
+
+    See require_session().
+    """
+
+    async def __call__(
+        self, request: web.Request, session: UpdateSession
+    ) -> web.Response:
+        ...
+
+
 def session_from_request(request: web.Request) -> Optional[UpdateSession]:
     return request.app.get(SESSION_VARNAME, None)
 
 
-def require_session(handler):
+def require_session(handler: _HandlerWithSessionType) -> HandlerType:
     """Decorator to ensure a session is properly in the request"""
 
     @functools.wraps(handler)

--- a/update-server/otupdate/common/update_actions.py
+++ b/update-server/otupdate/common/update_actions.py
@@ -5,7 +5,7 @@ update actions
 
 import abc
 import contextlib
-from typing import NamedTuple, Optional, Callable, Iterator
+from typing import Callable, Iterator, NamedTuple, Optional, cast
 from aiohttp import web
 
 from .constants import APP_VARIABLE_PREFIX
@@ -29,10 +29,13 @@ class UpdateActionsInterface:
     @staticmethod
     def from_request(request: web.Request) -> Optional["UpdateActionsInterface"]:
         """Get the update object from the aiohttp app store"""
-        return request.app.get(FILE_ACTIONS_VARNAME, None)
+        try:
+            return cast("UpdateActionsInterface", request.app[FILE_ACTIONS_VARNAME])
+        except KeyError:
+            return None
 
     @classmethod
-    def build_and_insert(cls, app: web.Application):
+    def build_and_insert(cls, app: web.Application) -> None:
         """Build the object and put it in the app store"""
         app[FILE_ACTIONS_VARNAME] = cls()
 
@@ -74,7 +77,7 @@ class UpdateActionsInterface:
 
     @abc.abstractmethod
     @contextlib.contextmanager
-    def mount_update(self) -> Iterator:
+    def mount_update(self) -> Iterator[str]:
         """
         Mount the fs to overwrite with the update
         """

--- a/update-server/otupdate/common/update_actions.py
+++ b/update-server/otupdate/common/update_actions.py
@@ -3,9 +3,11 @@ otupdate.common.update_actions: abc and resources for system-specific
 update actions
 """
 
+from __future__ import annotations
+
 import abc
 import contextlib
-from typing import Callable, Iterator, NamedTuple, Optional, cast
+from typing import Callable, Generator, NamedTuple, Optional, cast
 from aiohttp import web
 
 from .constants import APP_VARIABLE_PREFIX
@@ -27,10 +29,10 @@ class Partition(NamedTuple):
 
 class UpdateActionsInterface:
     @staticmethod
-    def from_request(request: web.Request) -> Optional["UpdateActionsInterface"]:
+    def from_request(request: web.Request) -> Optional[UpdateActionsInterface]:
         """Get the update object from the aiohttp app store"""
         try:
-            return cast("UpdateActionsInterface", request.app[FILE_ACTIONS_VARNAME])
+            return cast(UpdateActionsInterface, request.app[FILE_ACTIONS_VARNAME])
         except KeyError:
             return None
 
@@ -77,7 +79,7 @@ class UpdateActionsInterface:
 
     @abc.abstractmethod
     @contextlib.contextmanager
-    def mount_update(self) -> Iterator[str]:
+    def mount_update(self) -> Generator[str, None, None]:
         """
         Mount the fs to overwrite with the update
         """

--- a/update-server/otupdate/openembedded/__init__.py
+++ b/update-server/otupdate/openembedded/__init__.py
@@ -44,11 +44,11 @@ def get_version_dict(version_file: Optional[str]) -> Mapping[str, str]:
 
 
 def get_app(
-    system_version_file: str = None,
-    config_file_override: str = None,
-    name_override: str = None,
-    boot_id_override: str = None,
-    loop: asyncio.AbstractEventLoop = None,
+    system_version_file: Optional[str] = None,
+    config_file_override: Optional[str] = None,
+    name_override: Optional[str] = None,
+    boot_id_override: Optional[str] = None,
+    loop: Optional[asyncio.AbstractEventLoop] = None,
 ) -> web.Application:
     """Build and return the aiohttp.web.Application that runs the server"""
     if not system_version_file:

--- a/update-server/otupdate/openembedded/__main__.py
+++ b/update-server/otupdate/openembedded/__main__.py
@@ -11,7 +11,7 @@ from aiohttp import web
 LOG = logging.getLogger(__name__)
 
 
-def main():
+def main() -> None:
     parser = cli.build_root_parser()
     args = parser.parse_args()
     loop = asyncio.get_event_loop()
@@ -19,7 +19,7 @@ def main():
     systemd.configure_logging(getattr(logging, args.log_level.upper()))
 
     LOG.info("Setting hostname")
-    hostname = loop.run_until_complete(name_management.setup_hostname())
+    hostname = loop.run_until_complete(name_management.set_up_static_hostname())
     LOG.info(f"Set hostname to {hostname}")
 
     LOG.info("Building openembedded update server")
@@ -28,7 +28,7 @@ def main():
     systemd.notify_up()
 
     LOG.info(f"Starting openembedded update server on http://{args.host}:{args.port}")
-    web.run_app(app, host=args.host, port=args.port)
+    web.run_app(app, host=args.host, port=args.port)  # type: ignore[no-untyped-call]
 
 
 if __name__ == "__main__":

--- a/update-server/otupdate/openembedded/updater.py
+++ b/update-server/otupdate/openembedded/updater.py
@@ -233,7 +233,7 @@ class Updater(UpdateActionsInterface):
         rootfs_filepath: str,
         progress_callback: Callable[[float], None],
         chunk_size: int = 1024,
-        file_size: int = None,
+        file_size: Optional[int] = None,
     ) -> Partition:
         self.decomp_and_write(rootfs_filepath, progress_callback)
         unused_partition = self.part_mngr.find_unused_partition(


### PR DESCRIPTION
# Overview

This PR enhances static type-checking in `update-server`.

# Changelog

* Update mypy from 0.910 to 0.940. I needed to do this to resolve perplexing errors where mypy didn't think the `aiohttp.web.Request` class existed.
* Turn on mypy's [strict mode](https://mypy.readthedocs.io/en/stable/config_file.html?highlight=strict#confval-strict), like we do in the `api` and `robot-server` packages.
    * Resolve as many of the resultant typing errors as I could today.
    * Exclude the rest in `mypy.ini` and leave a `# TODO` comment for them. This follows the pattern set by `api` and `robot-server`.
* Solve one actual silly bug that the type-checker caught..

# Review requests

Go over the code and make sure that the changes are only to type annotations, unless I've noted otherwise.

I've tested this on a real OT-2 by making sure that it can still apply an update file and that it can still accept robot renames. I don't have an OT-3 environment to test on.

# Risk assessment

Low as long as I haven't accidentally affected the runtime behavior of anything.