### PR TITLE
refactor(api): ot3: settable cal thresholds

### DIFF
--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -22,7 +22,10 @@ DEFAULT_CALIBRATION_SETTINGS: Final[OT3CalibrationSettings] = OT3CalibrationSett
     z_offset=ZSenseSettings(
         point=(209, 170, 0),
         pass_settings=CapacitivePassSettings(
-            prep_distance_mm=3, max_overrun_distance_mm=3, speed_mm_per_s=1
+            prep_distance_mm=3,
+            max_overrun_distance_mm=3,
+            speed_mm_per_s=1,
+            sensor_threshold_pf=1.0,
         ),
     ),
     edge_sense=EdgeSenseSettings(
@@ -33,7 +36,10 @@ DEFAULT_CALIBRATION_SETTINGS: Final[OT3CalibrationSettings] = OT3CalibrationSett
         overrun_tolerance_mm=0.5,
         early_sense_tolerance_mm=0.2,
         pass_settings=CapacitivePassSettings(
-            prep_distance_mm=1, max_overrun_distance_mm=1, speed_mm_per_s=1
+            prep_distance_mm=1,
+            max_overrun_distance_mm=1,
+            speed_mm_per_s=1,
+            sensor_threshold_pf=1.0,
         ),
         search_initial_tolerance_mm=5.0,
         search_iteration_limit=10,
@@ -306,6 +312,9 @@ def _build_default_cap_pass(
             "max_overrun_distance_mm", default.max_overrun_distance_mm
         ),
         speed_mm_per_s=from_conf.get("speed_mm_per_s", default.speed_mm_per_s),
+        sensor_threshold_pf=from_conf.get(
+            "sensor_threshold_pf", default.sensor_threshold_pf
+        ),
     )
 
 

--- a/api/src/opentrons/config/types.py
+++ b/api/src/opentrons/config/types.py
@@ -126,6 +126,7 @@ class CapacitivePassSettings:
     prep_distance_mm: float
     max_overrun_distance_mm: float
     speed_mm_per_s: float
+    sensor_threshold_pf: float
 
 
 @dataclass(frozen=True)

--- a/api/tests/opentrons/config/ot3_settings.py
+++ b/api/tests/opentrons/config/ot3_settings.py
@@ -179,6 +179,7 @@ ot3_dummy_settings = {
                 "prep_distance_mm": 1,
                 "max_overrun_distance_mm": 2,
                 "speed_mm_per_s": 3,
+                "sensor_threshold_pf": 4,
             },
         },
         "edge_sense": {
@@ -192,6 +193,7 @@ ot3_dummy_settings = {
                 "prep_distance_mm": 4,
                 "max_overrun_distance_mm": 5,
                 "speed_mm_per_s": 6,
+                "sensor_threshold_pf": 7,
             },
             "search_initial_tolerance_mm": 18,
             "search_iteration_limit": 3,

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -61,7 +61,10 @@ async def test_capacitive_probe(
     await ot3_hardware.home()
     here = await ot3_hardware.gantry_position(OT3Mount.RIGHT)
     fake_settings = CapacitivePassSettings(
-        prep_distance_mm=1, max_overrun_distance_mm=2, speed_mm_per_s=4
+        prep_distance_mm=1,
+        max_overrun_distance_mm=2,
+        speed_mm_per_s=4,
+        sensor_threshold_pf=1.0,
     )
 
     res = await ot3_hardware.capacitive_probe(OT3Mount.RIGHT, 2, fake_settings)

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -191,10 +191,11 @@ class SensorOutputBinding(int, Enum):
     none = 0x0
     sync = 0x01
     report = 0x02
+
+
 @unique
 class SensorThresholdMode(int, Enum):
     """How a sensor's threshold should be interpreted."""
 
     absolute = 0x0
     auto_baseline = 0x1
-

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -191,3 +191,10 @@ class SensorOutputBinding(int, Enum):
     none = 0x0
     sync = 0x01
     report = 0x02
+@unique
+class SensorThresholdMode(int, Enum):
+    """How a sensor's threshold should be interpreted."""
+
+    absolute = 0x0
+    auto_baseline = 0x1
+

--- a/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
@@ -12,6 +12,7 @@ from opentrons_hardware.firmware_bindings.constants import (
     SensorType,
     PipetteName,
     SensorOutputBinding,
+    SensorThresholdMode,
 )
 
 
@@ -124,6 +125,18 @@ class SerialField(utils.BinaryFieldBase[bytes]):
     def from_string(cls, t: str) -> SerialField:
         """Create from a string."""
         return cls(binascii.unhexlify(t)[: cls.NUM_BYTES])
+
+
+class SensorThresholdModeField(utils.UInt8Field):
+    """sensor threshold mode."""
+
+    def __repr__(self) -> str:
+        """Print sensor."""
+        try:
+            sensor_val = SensorThresholdMode(self.value).name
+        except ValueError:
+            sensor_val = str(self.value)
+        return f"{self.__class__.__name__}(value={sensor_val})"
 
 
 class SensorOutputBindingField(utils.UInt8Field):

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -16,6 +16,7 @@ from .fields import (
     SensorOutputBindingField,
     EepromDataField,
     SerialField,
+    SensorThresholdModeField,
 )
 from .. import utils
 
@@ -325,6 +326,7 @@ class SetSensorThresholdRequestPayload(utils.BinarySerializable):
 
     sensor: SensorTypeField
     threshold: utils.Int32Field
+    mode: SensorThresholdModeField
 
 
 @dataclass
@@ -333,6 +335,7 @@ class SensorThresholdResponsePayload(utils.BinarySerializable):
 
     sensor: SensorTypeField
     threshold: utils.Int32Field
+    mode: SensorThresholdModeField
 
 
 @dataclass

--- a/hardware/opentrons_hardware/hardware_control/tool_sensors.py
+++ b/hardware/opentrons_hardware/hardware_control/tool_sensors.py
@@ -3,11 +3,16 @@ from typing import Union, Dict
 from logging import getLogger
 from numpy import float64
 from typing_extensions import Literal
-from opentrons_hardware.firmware_bindings.constants import NodeId, SensorType
+from opentrons_hardware.firmware_bindings.constants import (
+    NodeId,
+    SensorType,
+    SensorThresholdMode,
+)
 from opentrons_hardware.sensors.scheduler import SensorScheduler
 from opentrons_hardware.sensors.utils import (
     SensorInformation,
     SensorThresholdInformation,
+    SensorDataType,
 )
 from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
 from opentrons_hardware.hardware_control.motion import MoveStopCondition, create_step
@@ -28,6 +33,7 @@ async def capacitive_probe(
     tool: ProbeTarget,
     distance: float,
     speed: float,
+    relative_threshold_pf: float = 1.0,
     log_sensor_values: bool = False,
 ) -> float:
     """Move the specified tool down until its capacitive sensor triggers.
@@ -39,7 +45,10 @@ async def capacitive_probe(
     sensor_scheduler = SensorScheduler()
     threshold = await sensor_scheduler.send_threshold(
         SensorThresholdInformation(
-            sensor_type=SensorType.capacitive, node_id=tool, data="auto"
+            sensor_type=SensorType.capacitive,
+            node_id=tool,
+            data=SensorDataType.build(relative_threshold_pf),
+            mode=SensorThresholdMode.auto_baseline,
         ),
         messenger,
     )

--- a/hardware/opentrons_hardware/scripts/monitor_sensors.py
+++ b/hardware/opentrons_hardware/scripts/monitor_sensors.py
@@ -34,6 +34,7 @@ async def do_run(
     threshold_payload = payloads.SetSensorThresholdRequestPayload(
         sensor=fields.SensorTypeField(constants.SensorType.capacitive),
         threshold=Int32Field(int(threshold * sensor_fixed_point_conversion)),
+        mode=fields.SensorThresholdModeField(constants.SensorThresholdMode.absolute),
     )
     threshold_message = message_definitions.SetSensorThresholdRequest(
         payload=threshold_payload

--- a/hardware/opentrons_hardware/scripts/sensor_pass.py
+++ b/hardware/opentrons_hardware/scripts/sensor_pass.py
@@ -8,7 +8,11 @@ from typing import Iterator, List, Any, Dict
 
 from opentrons_hardware.drivers.can_bus import build, CanMessenger
 from opentrons_hardware.firmware_bindings.utils.binary_serializable import Int32Field
-from opentrons_hardware.firmware_bindings.constants import NodeId, SensorType
+from opentrons_hardware.firmware_bindings.constants import (
+    NodeId,
+    SensorType,
+    SensorThresholdMode,
+)
 from opentrons_hardware.firmware_bindings.arbitration_id import ArbitrationId
 from opentrons_hardware.hardware_control.network import probe
 import opentrons_hardware.sensors.utils as sensor_utils
@@ -134,6 +138,7 @@ async def run_test(messenger: CanMessenger, args: argparse.Namespace) -> None:
         threshold=Int32Field(
             int(args.threshold * sensor_utils.sensor_fixed_point_conversion)
         ),
+        mode=fields.SensorThresholdModeField(SensorThresholdMode.auto_baseline),
     )
     threshold_message = message_definitions.SetSensorThresholdRequest(
         payload=threshold_payload

--- a/hardware/opentrons_hardware/sensors/fdc1004.py
+++ b/hardware/opentrons_hardware/sensors/fdc1004.py
@@ -6,7 +6,10 @@ from contextlib import asynccontextmanager
 from opentrons_hardware.drivers.can_bus.can_messenger import (
     CanMessenger,
 )
-from opentrons_hardware.firmware_bindings.constants import SensorOutputBinding
+from opentrons_hardware.firmware_bindings.constants import (
+    SensorOutputBinding,
+    SensorThresholdMode,
+)
 from opentrons_hardware.firmware_bindings.constants import SensorType, NodeId
 from opentrons_hardware.sensors.utils import (
     ReadSensorInformation,
@@ -91,7 +94,9 @@ class CapacitiveSensor(AbstractAdvancedSensor):
         timeout: int = 1,
     ) -> Optional[SensorDataType]:
         """Send the zero threshold which the offset value is compared to."""
-        write = SensorThresholdInformation(self._sensor_type, node_id, threshold)
+        write = SensorThresholdInformation(
+            self._sensor_type, node_id, threshold, SensorThresholdMode.absolute
+        )
         threshold_data = await self._scheduler.send_threshold(
             write, can_messenger, timeout
         )

--- a/hardware/opentrons_hardware/sensors/mmr920C04.py
+++ b/hardware/opentrons_hardware/sensors/mmr920C04.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 from opentrons_hardware.firmware_bindings.constants import (
     SensorType,
     NodeId,
+    SensorThresholdMode,
 )
 from opentrons_hardware.firmware_bindings.constants import SensorOutputBinding
 from opentrons_hardware.sensors.utils import (
@@ -119,7 +120,9 @@ class PressureSensor(AbstractAdvancedSensor):
         timeout: int = 1,
     ) -> Optional[SensorDataType]:
         """Send the zero threshold which the offset value is compared to."""
-        write = SensorThresholdInformation(self._sensor_type, node_id, threshold)
+        write = SensorThresholdInformation(
+            self._sensor_type, node_id, threshold, SensorThresholdMode.absolute
+        )
         threshold_data = await self._scheduler.send_threshold(
             write, can_messenger, timeout
         )

--- a/hardware/opentrons_hardware/sensors/scheduler.py
+++ b/hardware/opentrons_hardware/sensors/scheduler.py
@@ -284,6 +284,7 @@ class SensorScheduler:
                 payload=BindSensorOutputRequestPayload(
                     sensor=SensorTypeField(target_sensor.sensor_type),
                     binding=SensorOutputBindingField.from_flags(flags),
+                    mode=UInt8Field(0)
                 )
             ),
         )

--- a/hardware/opentrons_hardware/sensors/scheduler.py
+++ b/hardware/opentrons_hardware/sensors/scheduler.py
@@ -40,6 +40,7 @@ from opentrons_hardware.firmware_bindings.messages.payloads import (
 from opentrons_hardware.firmware_bindings.messages.fields import (
     SensorTypeField,
     SensorOutputBindingField,
+    SensorThresholdModeField,
 )
 
 from opentrons_hardware.sensors.utils import (
@@ -54,7 +55,6 @@ from opentrons_hardware.firmware_bindings.utils import (
     UInt8Field,
     UInt16Field,
     UInt32Field,
-    Int32Field,
 )
 
 log = logging.getLogger(__name__)
@@ -181,9 +181,8 @@ class SensorScheduler:
                 message=SetSensorThresholdRequest(
                     payload=SetSensorThresholdRequestPayload(
                         sensor=SensorTypeField(sensor.sensor_type),
-                        threshold=Int32Field(
-                            0 if sensor.data == "auto" else sensor.data.to_int
-                        ),
+                        threshold=sensor.data.backing,
+                        mode=SensorThresholdModeField(sensor.mode.value),
                     )
                 ),
             )
@@ -284,7 +283,6 @@ class SensorScheduler:
                 payload=BindSensorOutputRequestPayload(
                     sensor=SensorTypeField(target_sensor.sensor_type),
                     binding=SensorOutputBindingField.from_flags(flags),
-                    mode=UInt8Field(0)
                 )
             ),
         )

--- a/hardware/opentrons_hardware/sensors/utils.py
+++ b/hardware/opentrons_hardware/sensors/utils.py
@@ -1,9 +1,13 @@
 """Sensor helper classes."""
 from dataclasses import dataclass
-from typing import List, overload, Union
-from typing_extensions import Final, Literal
+from typing import List, overload
+from typing_extensions import Final
 
-from opentrons_hardware.firmware_bindings.constants import NodeId, SensorType
+from opentrons_hardware.firmware_bindings.constants import (
+    NodeId,
+    SensorType,
+    SensorThresholdMode,
+)
 
 from opentrons_hardware.firmware_bindings.utils.binary_serializable import (
     Int32Field,
@@ -26,6 +30,11 @@ class SensorDataType:
 
     @overload
     @classmethod
+    def build(cls, data: float) -> "SensorDataType":
+        ...
+
+    @overload
+    @classmethod
     def build(cls, data: Int32Field) -> "SensorDataType":
         ...
 
@@ -41,6 +50,8 @@ class SensorDataType:
             backing = Int32Field(cls._convert_to_int(data))
         elif isinstance(data, Int32Field):
             backing = data
+        elif isinstance(data, float):
+            backing = Int32Field(int(data * sensor_fixed_point_conversion))
         else:
             backing = Int32Field(data)
         as_int = int(backing.value)
@@ -80,7 +91,8 @@ class WriteSensorInformation(SensorInformation):
 class SensorThresholdInformation(SensorInformation):
     """Set a sensor threshold or request an autoset."""
 
-    data: Union[SensorDataType, Literal["auto"]]
+    data: SensorDataType
+    mode: SensorThresholdMode
 
 
 @dataclass

--- a/hardware/tests/firmware_integration/test_sensors.py
+++ b/hardware/tests/firmware_integration/test_sensors.py
@@ -2,7 +2,11 @@
 import asyncio
 
 import pytest
-from opentrons_hardware.firmware_bindings.constants import NodeId, SensorType
+from opentrons_hardware.firmware_bindings.constants import (
+    NodeId,
+    SensorType,
+    SensorThresholdMode,
+)
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     BaselineSensorRequest,
     ReadFromSensorRequest,
@@ -17,7 +21,10 @@ from opentrons_hardware.firmware_bindings.messages.payloads import (
     SetSensorThresholdRequestPayload,
     WriteToSensorRequestPayload,
 )
-from opentrons_hardware.firmware_bindings.messages.fields import SensorTypeField
+from opentrons_hardware.firmware_bindings.messages.fields import (
+    SensorTypeField,
+    SensorThresholdModeField,
+)
 from opentrons_hardware.firmware_bindings.utils import (
     UInt8Field,
     UInt16Field,
@@ -146,7 +153,9 @@ async def test_set_threshold_sensors(
     """We should be able to set thresholds for the pressure and capacitive sensor."""
     set_threshold = SetSensorThresholdRequest(
         payload=SetSensorThresholdRequestPayload(
-            sensor=SensorTypeField(sensor_type), threshold=Int32Field(0x1)
+            sensor=SensorTypeField(sensor_type),
+            threshold=Int32Field(0x1),
+            mode=SensorThresholdModeField(SensorThresholdMode.absolute.value),
         )
     )
     await can_messenger.send(node_id=NodeId.pipette_left, message=set_threshold)

--- a/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
@@ -20,7 +20,11 @@ from opentrons_hardware.hardware_control.tool_sensors import (
     capacitive_probe,
     ProbeTarget,
 )
-from opentrons_hardware.firmware_bindings.constants import NodeId, SensorType
+from opentrons_hardware.firmware_bindings.constants import (
+    NodeId,
+    SensorType,
+    SensorThresholdMode,
+)
 from opentrons_hardware.sensors.scheduler import SensorScheduler
 from opentrons_hardware.sensors.utils import (
     SensorThresholdInformation,
@@ -40,7 +44,7 @@ def mock_sensor_threshold() -> Iterator[AsyncMock]:
         async def echo_value(
             info: SensorThresholdInformation, messenger: CanMessenger
         ) -> SensorDataType:
-            if info.data == "auto":
+            if info.mode == SensorThresholdMode.auto_baseline:
                 return SensorDataType.build(11)
             return info.data
 
@@ -113,7 +117,10 @@ async def test_capacitive_probe(
     assert result == 10  # this comes from the current_position_um above
     # this mock assert is annoying because something's __eq__ doesn't work
     assert mock_sensor_threshold.call_args_list[0][0][0] == SensorThresholdInformation(
-        sensor_type=SensorType.capacitive, node_id=target_node, data="auto"
+        sensor_type=SensorType.capacitive,
+        node_id=target_node,
+        data=SensorDataType.build(1.0),
+        mode=SensorThresholdMode.auto_baseline,
     )
     # this mock assert is annoying because, see below
     mock_bind_sync.assert_called_once_with(

--- a/hardware/tests/opentrons_hardware/sensors/test_sensor_drivers.py
+++ b/hardware/tests/opentrons_hardware/sensors/test_sensor_drivers.py
@@ -318,6 +318,7 @@ async def test_threshold(
                     payload=SensorThresholdResponsePayload(
                         threshold=message.payload.threshold,
                         sensor=SensorTypeField(sensor._sensor_type),
+                        mode=message.payload.mode,
                     )
                 ),
                 ArbitrationId(


### PR DESCRIPTION
Add the ability to set the threshold used by capacitive sensors during calibration (and other sensors during other behavior) by autobaseline+offset, instead of autobaseline alone with a builtin offset.

This allows for tighter tuning of behavior, useful at the very least for behavior testing.