### PR TITLE
refactor(api,hardware): ot3: probe any axis

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -654,4 +654,4 @@ class OT3Controller:
             log_sensor_values=True,
         )
 
-        self._position[axis_to_node(OT3Axis.by_mount(mount))] = pos
+        self._position[axis_to_node(moving)] = pos

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -639,11 +639,16 @@ class OT3Controller:
         return {k: v for k, v in by_node.items() if k in self._present_nodes}
 
     async def capacitive_probe(
-        self, mount: OT3Mount, distance_mm: float, speed_mm_per_s: float
+        self,
+        mount: OT3Mount,
+        moving: OT3Axis,
+        distance_mm: float,
+        speed_mm_per_s: float,
     ) -> None:
         pos = await capacitive_probe(
             self._messenger,
             sensor_node_for_mount(mount),
+            axis_to_node(moving),
             distance_mm,
             speed_mm_per_s,
             log_sensor_values=True,

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -409,6 +409,10 @@ class OT3Simulator:
         self._present_nodes = nodes
 
     async def capacitive_probe(
-        self, mount: OT3Mount, distance_mm: float, speed_mm_per_s: float
+        self,
+        mount: OT3Mount,
+        moving: OT3Axis,
+        distance_mm: float,
+        speed_mm_per_s: float,
     ) -> None:
-        self._position[axis_to_node(OT3Axis.by_mount(mount))] += distance_mm
+        self._position[axis_to_node(moving)] += distance_mm

--- a/api/src/opentrons/hardware_control/motion_utilities.py
+++ b/api/src/opentrons/hardware_control/motion_utilities.py
@@ -381,3 +381,10 @@ def deck_from_machine(  # type: ignore[no-untyped-def]
     }
     deck_pos.update(plunger_axes)
     return deck_pos
+
+
+def machine_vector_from_deck_vector(
+    machine_vector: Point, attitude: AttitudeMatrix
+) -> Point:
+    """Take a vector and pass it through the attitude matrix."""
+    return machine_point_from_deck_point(machine_vector, attitude, Point(0, 0, 0))

--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -38,7 +38,7 @@ async def find_deck_position(hcapi: OT3API, mount: OT3Mount) -> float:
     await hcapi.move_to(mount, above_point)
     LOG.info("probing")
     deck_z = await hcapi.capacitive_probe(
-        mount, z_prep_point.z, z_offset_settings.pass_settings
+        mount, OT3Axis.by_mount(mount), z_prep_point.z, z_offset_settings.pass_settings
     )
     LOG.info(f"autocalibration: found deck at {deck_z}")
     await hcapi.move_to(mount, z_prep_point + Point(0, 0, CAL_TRANSIT_HEIGHT))
@@ -118,7 +118,10 @@ async def find_edge(
         check_prep = checking_pos._replace(z=CAL_TRANSIT_HEIGHT)
         await hcapi.move_to(mount, check_prep)
         interaction_pos = await hcapi.capacitive_probe(
-            mount, slot_edge_nominal.z, edge_settings.pass_settings
+            mount,
+            OT3Axis.by_mount(mount),
+            slot_edge_nominal.z,
+            edge_settings.pass_settings,
         )
         await hcapi.move_to(mount, check_prep)
         if (

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1268,7 +1268,7 @@ class OT3API(
             )
         here = await self.gantry_position(mount)
         self._log.info(f"probe start: at {here}")
-        target = moving_axis.offset_point(
+        target = moving_axis.set_in_point(
             here, target_pos + pass_settings.prep_distance_mm
         )
         self._log.info(f"moving to {target}")

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -236,13 +236,13 @@ class OT3Axis(enum.Enum):
         else:
             raise KeyError(self)
 
-    def offset_point(self, point: top_types.Point, offset: float) -> top_types.Point:
+    def set_in_point(self, point: top_types.Point, position: float) -> top_types.Point:
         if OT3Axis.to_kind(self) == OT3AxisKind.Z:
-            return point + top_types.Point(0, 0, offset)
+            return point._replace(z=position)
         elif self == OT3Axis.X:
-            return point + top_types.Point(offset, 0, 0)
+            return point._replace(x=position)
         elif self == OT3Axis.Y:
-            return point + top_types.Point(0, offset, 0)
+            return point._replace(y=position)
         else:
             raise KeyError(self)
 

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -226,6 +226,26 @@ class OT3Axis(enum.Enum):
     def __str__(self) -> str:
         return self.name
 
+    def of_point(self, point: top_types.Point) -> float:
+        if OT3Axis.to_kind(self) == OT3AxisKind.Z:
+            return point.z
+        elif self == OT3Axis.X:
+            return point.x
+        elif self == OT3Axis.Y:
+            return point.y
+        else:
+            raise KeyError(self)
+
+    def offset_point(self, point: top_types.Point, offset: float) -> top_types.Point:
+        if OT3Axis.to_kind(self) == OT3AxisKind.Z:
+            return point + top_types.Point(0, 0, offset)
+        elif self == OT3Axis.X:
+            return point + top_types.Point(offset, 0, 0)
+        elif self == OT3Axis.Y:
+            return point + top_types.Point(0, offset, 0)
+        else:
+            raise KeyError(self)
+
 
 class OT3SubSystem(enum.Enum):
     """An enumeration of ot3 components.

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -112,11 +112,11 @@ async def test_capacitive_probe(
     # previous position is always 0. This is a test of ot3api though and checking
     # that the mock got called correctly and the resulting output was handled
     # correctly, by asking for backend._position afterwards, is good enough.
-    assert res == pytest.approx(4.5)
+    assert res == pytest.approx(1.5)
 
     # This is a negative probe because the current position is the home position
     # which is very large.
-    mock_backend_capacitive_probe.assert_called_once_with(mount, moving, -3, 4)
+    mock_backend_capacitive_probe.assert_called_once_with(mount, moving, 3, 4)
 
     original = moving.set_in_point(here, 0)
     for call in mock_move_to.call_args_list:
@@ -134,26 +134,27 @@ Direction = Union[Literal[0.0], Literal[1.0], Literal[-1.0]]
         # in the fake_settings fixture.
         # The origin is to the left of the target, exactly on
         # the prep point. Prep should not move, and the probe
-        # should be left-to-right (positive)
-        (1, Point(0, 0, 0), 0.0, 1.0),
+        # should be left-to-right (positive in deck coords,
+        # negative in machine coords)
+        (1, Point(0, 0, 0), 0.0, -1.0),
         # The origin is to the left of the target and the left
         # of the prep point. Prep should move left-to-right
-        # (positive), and so should probe.
-        (2, Point(0, 0, 0), 1.0, 1.0),
+        # and so should probe
+        (2, Point(0, 0, 0), 1.0, -1.0),
         # The origin is to the left of the target and the right
         # of the prep point. Prep should move right-to-left
         # (negative) and probe should move left-to-right
-        # (positive)
-        (0.5, Point(0, 0, 0), -1.0, 1.0),
+        (0.5, Point(0, 0, 0), -1.0, -1.0),
         # Origin to the right of target, on prep point. No prep,
-        # negative probe
-        (0, Point(1, 0, 0), 0.0, -1.0),
+        # probe is right-to-left (negative in deck coords,
+        # positive in machine coords)
+        (0, Point(1, 0, 0), 0.0, 1.0),
         # Origin to the right of target and prep point. Negative
-        # prep, negative probe.
-        (-1, Point(1, 0, 0), -1.0, -1.0),
+        # prep, right-to-left probe
+        (-1, Point(1, 0, 0), -1.0, 1.0),
         # Origin to the right of target and the left of prep.
-        # Positive prep, negative probe.
-        (0.5, Point(1, 0, 0), 1.0, -1.0),
+        # Positive prep, right-to-left probe
+        (0.5, Point(1, 0, 0), 1.0, 1.0),
     ],
 )
 async def test_probe_direction(

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -1,6 +1,8 @@
 """ Tests for behaviors specific to the OT3 hardware controller.
 """
-from typing import cast, Iterator
+from typing import cast, Iterator, Union
+from typing_extensions import Literal
+from math import copysign
 import pytest
 from mock import AsyncMock, patch
 from opentrons.config.types import GantryLoad, CapacitivePassSettings
@@ -9,6 +11,17 @@ from opentrons.hardware_control.types import OT3Mount, OT3Axis
 from opentrons.hardware_control.ot3api import OT3API
 from opentrons.hardware_control import ThreadManager
 from opentrons.hardware_control.backends.ot3utils import axis_to_node
+from opentrons.types import Point
+
+
+@pytest.fixture
+def fake_settings() -> CapacitivePassSettings:
+    return CapacitivePassSettings(
+        prep_distance_mm=1,
+        max_overrun_distance_mm=2,
+        speed_mm_per_s=4,
+        sensor_threshold_pf=1.0,
+    )
 
 
 @pytest.fixture
@@ -22,6 +35,19 @@ def mock_move_to(ot3_hardware: ThreadManager[OT3API]) -> Iterator[AsyncMock]:
         ),
     ) as mock_move:
         yield mock_move
+
+
+@pytest.fixture
+def mock_gantry_position(ot3_hardware: ThreadManager[OT3API]) -> Iterator[AsyncMock]:
+    with patch.object(
+        ot3_hardware.managed_obj,
+        "gantry_position",
+        AsyncMock(
+            spec=ot3_hardware.managed_obj.gantry_position,
+            wraps=ot3_hardware.managed_obj.gantry_position,
+        ),
+    ) as mock_gantry_pos:
+        yield mock_gantry_pos
 
 
 @pytest.mark.parametrize(
@@ -76,33 +102,84 @@ async def test_capacitive_probe(
     mock_backend_capacitive_probe: AsyncMock,
     mount: OT3Mount,
     moving: OT3Axis,
+    fake_settings: CapacitivePassSettings,
 ) -> None:
     await ot3_hardware.home()
     here = await ot3_hardware.gantry_position(mount)
-    fake_settings = CapacitivePassSettings(
-        prep_distance_mm=1,
-        max_overrun_distance_mm=2,
-        speed_mm_per_s=4,
-        sensor_threshold_pf=1.0,
-    )
     res = await ot3_hardware.capacitive_probe(mount, moving, 2, fake_settings)
     # in reality, this value would be the previous position + the value
     # updated in ot3controller.capacitive_probe, and it kind of is here, but that
     # previous position is always 0. This is a test of ot3api though and checking
     # that the mock got called correctly and the resulting output was handled
     # correctly, by asking for backend._position afterwards, is good enough.
-    assert res == pytest.approx(1.5)
-    mock_backend_capacitive_probe.assert_called_once_with(mount, moving, 3, 4)
+    assert res == pytest.approx(4.5)
+
+    # This is a negative probe because the current position is the home position
+    # which is very large.
+    mock_backend_capacitive_probe.assert_called_once_with(mount, moving, -3, 4)
+
+    original = moving.set_in_point(here, 0)
     for call in mock_move_to.call_args_list:
-        if moving in [OT3Axis.Z_R, OT3Axis.Z_L]:
-            assert call[0][1].x == here.x
-            assert call[0][1].y == here.y
-        elif moving == OT3Axis.X:
-            assert call[0][1].y == here.y
-            assert call[0][1].z == here.z
-        else:
-            assert call[0][1].x == here.x
-            assert call[0][1].z == here.z
+        this_point = moving.set_in_point(call[0][1], 0)
+        assert this_point == original
+
+
+Direction = Union[Literal[0.0], Literal[1.0], Literal[-1.0]]
+
+
+@pytest.mark.parametrize(
+    "target,origin,prep_direction,probe_direction",
+    [
+        # Positions here depend on the prep point which is set
+        # in the fake_settings fixture.
+        # The origin is to the left of the target, exactly on
+        # the prep point. Prep should not move, and the probe
+        # should be left-to-right (positive)
+        (1, Point(0, 0, 0), 0.0, 1.0),
+        # The origin is to the left of the target and the left
+        # of the prep point. Prep should move left-to-right
+        # (positive), and so should probe.
+        (2, Point(0, 0, 0), 1.0, 1.0),
+        # The origin is to the left of the target and the right
+        # of the prep point. Prep should move right-to-left
+        # (negative) and probe should move left-to-right
+        # (positive)
+        (0.5, Point(0, 0, 0), -1.0, 1.0),
+        # Origin to the right of target, on prep point. No prep,
+        # negative probe
+        (0, Point(1, 0, 0), 0.0, -1.0),
+        # Origin to the right of target and prep point. Negative
+        # prep, negative probe.
+        (-1, Point(1, 0, 0), -1.0, -1.0),
+        # Origin to the right of target and the left of prep.
+        # Positive prep, negative probe.
+        (0.5, Point(1, 0, 0), 1.0, -1.0),
+    ],
+)
+async def test_probe_direction(
+    ot3_hardware: ThreadManager[OT3API],
+    mock_move_to: AsyncMock,
+    mock_backend_capacitive_probe: AsyncMock,
+    mock_gantry_position: AsyncMock,
+    fake_settings: CapacitivePassSettings,
+    target: float,
+    origin: Point,
+    prep_direction: Direction,
+    probe_direction: Direction,
+) -> None:
+    mock_gantry_position.return_value = origin
+    await ot3_hardware.capacitive_probe(
+        OT3Mount.RIGHT, OT3Axis.X, target, fake_settings
+    )
+    prep_move = mock_move_to.call_args_list[0]
+    if prep_direction == 0.0:
+        assert prep_move[0][1].x == origin.x
+    elif prep_direction == -1.0:
+        assert prep_move[0][1].x < origin.x
+    elif prep_direction == 1.0:
+        assert prep_move[0][1].x > origin.x
+    probe_distance = mock_backend_capacitive_probe.call_args_list[0][0][2]
+    assert copysign(1.0, probe_distance) == probe_direction
 
 
 @pytest.mark.parametrize(
@@ -122,13 +199,8 @@ async def test_capacitive_probe_invalid_axes(
     mock_backend_capacitive_probe: AsyncMock,
     mount: OT3Mount,
     moving: OT3Axis,
+    fake_settings: CapacitivePassSettings,
 ) -> None:
-    fake_settings = CapacitivePassSettings(
-        prep_distance_mm=1,
-        max_overrun_distance_mm=2,
-        speed_mm_per_s=4,
-        sensor_threshold_pf=1.0,
-    )
     with pytest.raises(RuntimeError, match=r"Probing must be done with.*"):
         await ot3_hardware.capacitive_probe(mount, moving, 2, fake_settings)
     mock_move_to.assert_not_called()

--- a/hardware/opentrons_hardware/hardware_control/tool_sensors.py
+++ b/hardware/opentrons_hardware/hardware_control/tool_sensors.py
@@ -57,7 +57,7 @@ async def capacitive_probe(
         distance={mover: float64(abs(distance))},
         velocity={mover: float64(speed * copysign(1.0, distance))},
         acceleration={},
-        duration=float64(distance / speed),
+        duration=float64(abs(distance / speed)),
         present_nodes=[mover],
         stop_condition=MoveStopCondition.cap_sensor,
     )

--- a/hardware/opentrons_hardware/hardware_control/tool_sensors.py
+++ b/hardware/opentrons_hardware/hardware_control/tool_sensors.py
@@ -1,5 +1,5 @@
 """Functions for commanding motion limited by tool sensors."""
-from typing import Union, Dict
+from typing import Union
 from logging import getLogger
 from numpy import float64
 from typing_extensions import Literal
@@ -21,16 +21,11 @@ from opentrons_hardware.hardware_control.move_group_runner import MoveGroupRunne
 LOG = getLogger(__name__)
 ProbeTarget = Union[Literal[NodeId.pipette_left, NodeId.pipette_right, NodeId.gripper]]
 
-_Z_FOR_TARGET: Dict[ProbeTarget, NodeId] = {
-    NodeId.pipette_left: NodeId.head_l,
-    NodeId.pipette_right: NodeId.head_r,
-    NodeId.gripper: NodeId.gripper_z,
-}
-
 
 async def capacitive_probe(
     messenger: CanMessenger,
     tool: ProbeTarget,
+    mover: NodeId,
     distance: float,
     speed: float,
     relative_threshold_pf: float = 1.0,
@@ -41,7 +36,6 @@ async def capacitive_probe(
     Moves down by the specified distance at the specified speed until the
     capacitive sensor triggers and returns the position afterward.
     """
-    z_node = _Z_FOR_TARGET[tool]
     sensor_scheduler = SensorScheduler()
     threshold = await sensor_scheduler.send_threshold(
         SensorThresholdInformation(
@@ -56,11 +50,11 @@ async def capacitive_probe(
         raise RuntimeError("Could not set threshold for probe")
     LOG.info(f"starting capacitive probe with threshold {threshold.to_float()}")
     pass_group = create_step(
-        distance={z_node: float64(distance)},
-        velocity={z_node: float64(speed)},
+        distance={mover: float64(distance)},
+        velocity={mover: float64(speed)},
         acceleration={},
         duration=float64(distance / speed),
-        present_nodes=[z_node],
+        present_nodes=[mover],
         stop_condition=MoveStopCondition.cap_sensor,
     )
     runner = MoveGroupRunner(move_groups=[[pass_group]])
@@ -70,4 +64,4 @@ async def capacitive_probe(
         log=log_sensor_values,
     ):
         position = await runner.run(can_messenger=messenger)
-        return position[z_node]
+        return position[mover]

--- a/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
@@ -96,6 +96,7 @@ async def test_capacitive_probe(
     def move_responder(
         node_id: NodeId, message: MessageDefinition
     ) -> List[Tuple[NodeId, MessageDefinition, NodeId]]:
+        message.payload.serialize()
         if isinstance(message, ExecuteMoveGroupRequest):
             return [
                 (

--- a/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
@@ -113,7 +113,7 @@ async def test_capacitive_probe(
 
     message_send_loopback.add_responder(move_responder)
 
-    result = await capacitive_probe(mock_messenger, target_node, 10, 10)
+    result = await capacitive_probe(mock_messenger, target_node, motor_node, 10, 10)
     assert result == 10  # this comes from the current_position_um above
     # this mock assert is annoying because something's __eq__ doesn't work
     assert mock_sensor_threshold.call_args_list[0][0][0] == SensorThresholdInformation(

--- a/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
@@ -70,11 +70,13 @@ def mock_bind_sync() -> Iterator[AsyncMock]:
 
 
 @pytest.mark.parametrize(
-    "target_node,motor_node",
+    "target_node,motor_node,distance,speed,",
     [
-        (NodeId.pipette_left, NodeId.head_l),
-        (NodeId.pipette_right, NodeId.head_r),
-        (NodeId.gripper, NodeId.gripper_z),
+        (NodeId.pipette_left, NodeId.head_l, 10, 10),
+        (NodeId.pipette_right, NodeId.head_r, 10, -10),
+        (NodeId.gripper, NodeId.gripper_z, -10, 10),
+        (NodeId.pipette_left, NodeId.gantry_x, -10, -10),
+        (NodeId.gripper, NodeId.gantry_y, 10, 10),
     ],
 )
 async def test_capacitive_probe(
@@ -85,6 +87,8 @@ async def test_capacitive_probe(
     target_node: ProbeTarget,
     motor_node: NodeId,
     caplog: Any,
+    distance: float,
+    speed: float,
 ) -> None:
     """Test that capacitive_probe targets the right nodes."""
     caplog.set_level(logging.INFO)
@@ -113,7 +117,9 @@ async def test_capacitive_probe(
 
     message_send_loopback.add_responder(move_responder)
 
-    result = await capacitive_probe(mock_messenger, target_node, motor_node, 10, 10)
+    result = await capacitive_probe(
+        mock_messenger, target_node, motor_node, distance, speed
+    )
     assert result == 10  # this comes from the current_position_um above
     # this mock assert is annoying because something's __eq__ doesn't work
     assert mock_sensor_threshold.call_args_list[0][0][0] == SensorThresholdInformation(


### PR DESCRIPTION
Capacitive probing can actually happen on X, Y, and the appropriate Z axis for whatever's running the capacitive sensor. We now allow that to be specified, and happily remove a small layering violation in hardware as a bonus.

It also needs to handle any direction of movement, which added some complexity and required a new function to map vectors through deck calibration.