### PR TITLE
fix(api): disallow thermocycler if item in conflicting slot

### DIFF
--- a/api/src/opentrons/protocols/geometry/deck.py
+++ b/api/src/opentrons/protocols/geometry/deck.py
@@ -2,7 +2,7 @@ import functools
 import logging
 from collections import UserDict
 from dataclasses import dataclass
-from typing import Optional, List, Dict, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, List, Dict, Set
 
 from opentrons import types
 from opentrons.protocol_api.labware import load as load_lw, Labware
@@ -112,26 +112,27 @@ class Deck(UserDict):
         slot_key_int = self._check_name(key)
         item = self.data.get(slot_key_int)
 
-        overlapping_items = self.get_collisions_for_item(slot_key_int, val)
+        overlapping_items = self._get_collisions_for_item(slot_key_int, val)
         if item is not None:
             if slot_key_int == 12:
                 if FIXED_TRASH_ID in item.parameters.get("quirks", []):
                     pass
                 else:
-                    raise ValueError(f"Deck location {key} " "is for fixed trash only")
+                    raise ValueError(f"Deck slot {key} is for fixed trash only")
             else:
                 raise ValueError(
-                    f"Deck location {key} already"
-                    f"  has an item: {self.data[slot_key_int]}"
+                    f"Deck slot {key} already"
+                    f" has an item: {self.data[slot_key_int].load_name}"
                 )
         elif overlapping_items:
             flattened_overlappers = [
-                repr(item) for sublist in overlapping_items.values() for item in sublist
+                f"{item.load_name} in slot {slot}"
+                for slot, sublist in overlapping_items.items()
+                for item in sublist
             ]
             raise ValueError(
-                f"Could not load {val} as deck location {key} "
-                "is obscured by "
-                f'{", ".join(flattened_overlappers)}'
+                f"Could not load {val} because slot {key}"
+                f" is obscured by {', '.join(flattened_overlappers)}"
             )
         self.data[slot_key_int] = val
         self._highest_z = max(val.highest_z, self._highest_z)
@@ -238,7 +239,7 @@ class Deck(UserDict):
                 return valid_slots[0]
             elif not valid_slots:
                 raise ValueError(
-                    "A {dn_from_type[module_type]} cannot be used with this " "deck"
+                    "A {dn_from_type[module_type]} cannot be used with this deck"
                 )
             else:
                 raise AssertionError(
@@ -286,28 +287,30 @@ class Deck(UserDict):
         }
         return [s for s in self.data.keys() if s not in fixture_slots]
 
-    def get_collisions_for_item(
+    def _get_collisions_for_item(
         self, slot_key: types.DeckLocation, item: DeckItem
     ) -> Dict[types.DeckLocation, List[DeckItem]]:
-        """Return the loaded deck items that collide
-        with the given item.
-        """
+        """Return the loaded deck items that collide with the given item."""
 
-        def get_item_covered_slot_keys(sk, i):
+        def get_item_covered_slot_keys(sk, i) -> Set[str]:
             if isinstance(i, ThermocyclerGeometry):
                 return i.covered_slots
             elif i is not None:
                 return set([sk])
             else:
-                return set([])
+                return set()
 
         item_slot_keys = get_item_covered_slot_keys(slot_key, item)
-
         colliding_items: Dict[types.DeckLocation, List[DeckItem]] = {}
-        for sk, i in self.data.items():
-            covered_sks = get_item_covered_slot_keys(sk, i)
-            if item_slot_keys.issubset(covered_sks):
-                colliding_items.setdefault(sk, []).append(i)
+
+        for slot_key, existing_item in self.data.items():
+            occupied_slot_keys = get_item_covered_slot_keys(slot_key, existing_item)
+            conflicting_slot_keys = occupied_slot_keys & item_slot_keys
+
+            if len(conflicting_slot_keys) > 0:
+                for conflict in conflicting_slot_keys:
+                    colliding_items.setdefault(conflict, []).append(existing_item)
+
         return colliding_items
 
     @property

--- a/api/src/opentrons/protocols/geometry/deck.py
+++ b/api/src/opentrons/protocols/geometry/deck.py
@@ -131,8 +131,8 @@ class Deck(UserDict):
                 for item in sublist
             ]
             raise ValueError(
-                f"Could not load {val} because slot {key}"
-                f" is obscured by {', '.join(flattened_overlappers)}"
+                f"Could not load {val} because it would"
+                f" interfere with {', '.join(flattened_overlappers)}"
             )
         self.data[slot_key_int] = val
         self._highest_z = max(val.highest_z, self._highest_z)

--- a/api/tests/opentrons/protocols/geometry/test_geometry.py
+++ b/api/tests/opentrons/protocols/geometry/test_geometry.py
@@ -10,6 +10,7 @@ from opentrons.protocols.geometry.deck import Deck
 from opentrons.protocol_api import labware
 from opentrons.protocols.geometry import module_geometry
 from opentrons.hardware_control.types import CriticalPoint
+from opentrons.hardware_control.modules.types import ThermocyclerModuleModel
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 
 tall_lw_name = "opentrons_96_tiprack_1000ul"
@@ -44,7 +45,7 @@ def test_slot_names():
         d["ahgoasia"] = "nope"
 
 
-def test_slot_collisions():
+def test_slot_collisions_module_first():
     d = Deck()
     mod_slot = "7"
     mod = module_geometry.load_module(
@@ -66,6 +67,18 @@ def test_slot_collisions():
     d[lw_slot] = lw
 
     assert lw_slot in d
+
+
+@pytest.mark.parametrize("labware_slot", ["7", "8", "10", "11"])
+def test_slot_collisions_labware_first(labware_slot: str):
+    deck = Deck()
+    deck[labware_slot] = labware.load(labware_name, deck.position_for(labware_slot))
+
+    with pytest.raises(ValueError):
+        deck["7"] = module_geometry.load_module(
+            ThermocyclerModuleModel.THERMOCYCLER_V1,
+            deck.position_for("7"),
+        )
 
 
 def test_highest_z():


### PR DESCRIPTION
## Overview

Fixes #9419

Slot conflict logic in the `Deck` class used by Protocol API v2 was configured to only check conflicts one way. If a thermocycler was on the deck in slot 7 (and therefore obscuring slots 7, 8, 9, and 10), a load in any of those slots would be disallowed. However, if something was loaded in slots 8, 9, or 10 and one attempted to load a thermocycler in slot 7, the load was not blocked.

This PR fixes the logic so that both conditions will trigger an error. The original ticket specified analysis, but I believe this bug is present in both analysis and run.

**I chose not to put this behind a protocol API version bump.** This is an unambiguous bug (potentially a regression somewhere, but I didn't try to find a point where this worked). I think guarding it would be a lot of work and provide no real value.

## Review requests

The following conditions should be smoke tested:

- [ ] Two items may not be loaded in the same exact slot
- [ ] An item cannot be loaded in slots 8, 9, or 10 if a thermocycler is present
- [ ] A thermocycler cannot be loaded if an item is present in slots 8, 9, or 10

If possible, try our both labware and other modules for "item" in the smoke tests above.

## Risk assessment

Medium. Test coverage of this logic is ok, but a little shaky around specifics. The module in question is also only partially type-checked, so it was a little hard to move around confidently. Error messages aren't really covered at all, so please play close attention to them.