### PR TITLE
fix(app): Add null check to avoid white screen

### DIFF
--- a/app/src/organisms/CalibrationPanels/ChooseTipRack.tsx
+++ b/app/src/organisms/CalibrationPanels/ChooseTipRack.tsx
@@ -29,6 +29,8 @@ import {
   SecondaryBtn,
   SIZE_5,
 } from '@opentrons/components'
+import { usePipettesQuery } from '@opentrons/react-api-client'
+
 import * as Sessions from '../../redux/sessions'
 import { NeedHelpLink } from './NeedHelpLink'
 import { ChosenTipRackRender } from './ChosenTipRackRender'
@@ -79,6 +81,8 @@ const introContentByType = (sessionType: SessionType): string => {
   }
 }
 
+const EQUIPMENT_POLL_MS = 5000
+
 function formatOptionsFromLabwareDef(lw: LabwareDefinition2): SelectOption {
   return {
     value: getLabwareDefURI(lw),
@@ -109,12 +113,9 @@ export function ChooseTipRack(props: ChooseTipRackProps): JSX.Element {
     defaultTipracks,
   } = props
 
-  const pipSerial = useSelector(
-    (state: State) =>
-      robotName != null &&
-      getAttachedPipettes(state, robotName)[mount] != null &&
-      getAttachedPipettes(state, robotName)[mount]?.id
-  )
+  const pipSerial = usePipettesQuery({
+    refetchInterval: EQUIPMENT_POLL_MS,
+  })?.data?.[mount].id
 
   const pipetteOffsetCal = useSelector((state: State) =>
     robotName && pipSerial

--- a/app/src/organisms/CalibrationPanels/ChooseTipRack.tsx
+++ b/app/src/organisms/CalibrationPanels/ChooseTipRack.tsx
@@ -111,8 +111,9 @@ export function ChooseTipRack(props: ChooseTipRackProps): JSX.Element {
 
   const pipSerial = useSelector(
     (state: State) =>
-      // @ts-expect-error(sa, 2021-05-26): possibly null, can optionally chain. leaving to avoid src code change
-      robotName && getAttachedPipettes(state, robotName)[mount].id
+      robotName != null &&
+      getAttachedPipettes(state, robotName)[mount] != null &&
+      getAttachedPipettes(state, robotName)[mount]?.id
   )
 
   const pipetteOffsetCal = useSelector((state: State) =>

--- a/app/src/organisms/CalibrationPanels/ChooseTipRack.tsx
+++ b/app/src/organisms/CalibrationPanels/ChooseTipRack.tsx
@@ -35,7 +35,6 @@ import * as Sessions from '../../redux/sessions'
 import { NeedHelpLink } from './NeedHelpLink'
 import { ChosenTipRackRender } from './ChosenTipRackRender'
 import { getCustomTipRackDefinitions } from '../../redux/custom-labware'
-import { getAttachedPipettes } from '../../redux/pipettes'
 import {
   getCalibrationForPipette,
   getTipLengthCalibrations,

--- a/app/src/organisms/CalibrationPanels/__tests__/ChooseTipRack.test.tsx
+++ b/app/src/organisms/CalibrationPanels/__tests__/ChooseTipRack.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { mountWithStore } from '@opentrons/components'
+import { usePipettesQuery } from '@opentrons/react-api-client'
 
 import { mockAttachedPipette } from '../../../redux/pipettes/__fixtures__'
 import { mockDeckCalTipRack } from '../../../redux/sessions/__fixtures__'
@@ -12,13 +13,13 @@ import {
   getTipLengthCalibrations,
 } from '../../../redux/calibration'
 import { getCustomTipRackDefinitions } from '../../../redux/custom-labware'
-import { getAttachedPipettes } from '../../../redux/pipettes'
 
 import { ChooseTipRack } from '../ChooseTipRack'
 import type { AttachedPipettesByMount } from '../../../redux/pipettes/types'
 import type { ReactWrapper } from 'enzyme'
 import type { WrapperWithStore } from '@opentrons/components'
 
+jest.mock('@opentrons/react-api-client')
 jest.mock('../../../redux/pipettes/selectors')
 jest.mock('../../../redux/calibration/')
 jest.mock('../../../redux/custom-labware/selectors')
@@ -40,8 +41,8 @@ const mockGetTipLengthCalibrations = getTipLengthCalibrations as jest.MockedFunc
   typeof getTipLengthCalibrations
 >
 
-const mockGetAttachedPipettes = getAttachedPipettes as jest.MockedFunction<
-  typeof getAttachedPipettes
+const mockUsePipettesQuery = usePipettesQuery as jest.MockedFunction<
+  typeof usePipettesQuery
 >
 
 const mockGetCustomTipRackDefinitions = getCustomTipRackDefinitions as jest.MockedFunction<
@@ -61,7 +62,9 @@ describe('ChooseTipRack', () => {
     mockGetCalibrationForPipette.mockReturnValue(null)
     mockGetTipLengthForPipetteAndTiprack.mockReturnValue(null)
     mockGetTipLengthCalibrations.mockReturnValue([])
-    mockGetAttachedPipettes.mockReturnValue(mockAttachedPipettes)
+    mockUsePipettesQuery.mockReturnValue({
+      data: mockAttachedPipettes,
+    } as any)
     mockGetCustomTipRackDefinitions.mockReturnValue([
       mockTipRackDefinition,
       mockDeckCalTipRack.definition,


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This will close #10490 
The white screen has been caused by getting an id from a null object. 

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- Use `usePipettesQuery` to get `pipSerial` (id-serialNumber) instead of `getAttachedPipettes`

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
