### PR TITLE
fix(app): add overflow prop for long name

### DIFF
--- a/app/src/organisms/Devices/HistoricalProtocolRun.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRun.tsx
@@ -74,6 +74,8 @@ export function HistoricalProtocolRun(
         <StyledText
           as="p"
           width="35%"
+          css={{ 'overflow-wrap': 'anywhere' }}
+          paddingRight={SPACING.spacing3}
           data-testid={`RecentProtocolRuns_Protocol_${props.key}`}
         >
           {protocolName}

--- a/app/src/organisms/Devices/RobotStatusBanner.tsx
+++ b/app/src/organisms/Devices/RobotStatusBanner.tsx
@@ -34,7 +34,11 @@ export function RobotStatusBanner(props: RobotStatusBannerProps): JSX.Element {
   const RunningProtocolBanner = (): JSX.Element | null =>
     currentRunId != null ? (
       <Flex alignItems={ALIGN_CENTER}>
-        <StyledText as="label" paddingRight={SPACING.spacing3}>
+        <StyledText
+          as="label"
+          paddingRight={SPACING.spacing3}
+          css={{ 'overflow-wrap': 'anywhere' }}
+        >
           {`${displayName}; ${t(`run_details:status_${currentRunStatus}`)}`}
         </StyledText>
         <Link
@@ -65,6 +69,7 @@ export function RobotStatusBanner(props: RobotStatusBannerProps): JSX.Element {
               as="h3"
               marginRight={SPACING.spacing3}
               id={`RobotStatusBanner_${name}_robotName`}
+              css={{ 'overflow-wrap': 'anywhere' }}
             >
               {name}
             </StyledText>


### PR DESCRIPTION


<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Add overflow prop to display robot name and protocol name without breaking ui
fix #10505 #10481

![Screen Shot 2022-05-27 at 6 50 36 PM](https://user-images.githubusercontent.com/474225/170799134-ef435813-6212-4f7e-9965-60aa386b6637.png)

![Screen Shot 2022-05-27 at 6 50 45 PM](https://user-images.githubusercontent.com/474225/170799135-af8d0395-663b-4782-9883-c8be31d667a1.png)

![Screen Shot 2022-05-27 at 7 03 35 PM](https://user-images.githubusercontent.com/474225/170799163-425388b8-df29-4a61-a540-b87848a183cc.png)


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
