### PR TITLE
fix(app): Appettings general tab remove duplicated text

### DIFF
--- a/app/src/organisms/AppSettings/GeneralSettings.tsx
+++ b/app/src/organisms/AppSettings/GeneralSettings.tsx
@@ -56,10 +56,12 @@ export function GeneralSettings(): JSX.Element {
   const [
     showPreviousVersionModal,
     setShowPreviousVersionModal,
-  ] = React.useState(false)
+  ] = React.useState<boolean>(false)
   const updateAvailable = Boolean(useSelector(getAvailableShellUpdate))
-  const [showUpdateModal, setShowUpdateModal] = React.useState(updateAvailable)
-  const [showUpdateBanner, setShowUpdateBanner] = React.useState(
+  const [showUpdateModal, setShowUpdateModal] = React.useState<boolean>(
+    updateAvailable
+  )
+  const [showUpdateBanner, setShowUpdateBanner] = React.useState<boolean>(
     updateAvailable
   )
   const [

--- a/app/src/organisms/AppSettings/GeneralSettings.tsx
+++ b/app/src/organisms/AppSettings/GeneralSettings.tsx
@@ -120,44 +120,69 @@ export function GeneralSettings(): JSX.Element {
             </Banner>
           </Box>
         )}
-        <Flex
-          flexDirection={DIRECTION_ROW}
-          alignItems={updateAvailable ? ALIGN_CENTER : ALIGN_START}
-          justifyContent={JUSTIFY_SPACE_BETWEEN}
-          gridGap={SPACING.spacing4}
-        >
-          {showConnectRobotSlideout && (
-            <ConnectRobotSlideout
-              isExpanded={showConnectRobotSlideout}
-              onCloseClick={() => setShowConnectRobotSlideout(false)}
-            />
-          )}
-          <Box width="65%">
-            <StyledText
-              css={TYPOGRAPHY.h3SemiBold}
-              paddingBottom={SPACING.spacing3}
-            >
-              {t('software_version')}
-            </StyledText>
-            <StyledText
-              as="p"
-              paddingBottom={SPACING.spacing3}
-              id="GeneralSettings_currentVersion"
-            >
-              {CURRENT_VERSION}
-            </StyledText>
-            <StyledText as="p">
-              {t('shared:view_latest_release_notes')}
-              <Link
-                external
-                href={GITHUB_LINK}
-                css={TYPOGRAPHY.linkPSemiBold}
-                id="AdvancedSettings_GitHubLink"
-              >{` ${t('shared:github')}`}</Link>
-            </StyledText>
+        <Box>
+          <Flex
+            flexDirection={DIRECTION_ROW}
+            alignItems={updateAvailable ? ALIGN_CENTER : ALIGN_START}
+            justifyContent={JUSTIFY_SPACE_BETWEEN}
+            gridGap={SPACING.spacing4}
+          >
+            {showConnectRobotSlideout && (
+              <ConnectRobotSlideout
+                isExpanded={showConnectRobotSlideout}
+                onCloseClick={() => setShowConnectRobotSlideout(false)}
+              />
+            )}
+            <Box width="65%">
+              <StyledText
+                css={TYPOGRAPHY.h3SemiBold}
+                paddingBottom={SPACING.spacing3}
+              >
+                {t('software_version')}
+              </StyledText>
+              <StyledText
+                as="p"
+                paddingBottom={SPACING.spacing3}
+                id="GeneralSettings_currentVersion"
+              >
+                {CURRENT_VERSION}
+              </StyledText>
+              <StyledText as="p">
+                {t('shared:view_latest_release_notes')}
+                <Link
+                  external
+                  href={GITHUB_LINK}
+                  css={TYPOGRAPHY.linkPSemiBold}
+                  id="GeneralSettings_GitHubLink"
+                >{` ${t('shared:github')}`}</Link>
+              </StyledText>
+            </Box>
+            {updateAvailable ? (
+              <TertiaryButton
+                disabled={!updateAvailable}
+                marginLeft={SPACING_AUTO}
+                onClick={() => setShowUpdateModal(true)}
+                id="GeneralSettings_softwareUpdate"
+              >
+                {t('view_software_update')}
+              </TertiaryButton>
+            ) : (
+              <StyledText
+                fontSize={TYPOGRAPHY.fontSizeLabel}
+                lineHeight={TYPOGRAPHY.lineHeight12}
+                color={COLORS.darkGreyEnabled}
+                paddingY={SPACING.spacing5}
+              >
+                {t('up_to_date')}
+              </StyledText>
+            )}
+          </Flex>
+          <Box width="70%">
             <StyledText as="p" paddingY={SPACING.spacing3}>
               {t('manage_versions')}
             </StyledText>
+          </Box>
+          <Box>
             <Link
               role="button"
               css={TYPOGRAPHY.linkPSemiBold}
@@ -166,9 +191,6 @@ export function GeneralSettings(): JSX.Element {
             >
               {t('restore_previous')}
             </Link>
-            <StyledText as="p" paddingY={SPACING.spacing3}>
-              {t('manage_versions')}
-            </StyledText>
             <ExternalLink
               href={SOFTWARE_SYNC_URL}
               id="GeneralSettings_appAndRobotSync"
@@ -176,26 +198,7 @@ export function GeneralSettings(): JSX.Element {
               {t('versions_sync')}
             </ExternalLink>
           </Box>
-          {updateAvailable ? (
-            <TertiaryButton
-              disabled={!updateAvailable}
-              marginLeft={SPACING_AUTO}
-              onClick={() => setShowUpdateModal(true)}
-              id="GeneralSettings_softwareUpdate"
-            >
-              {t('view_software_update')}
-            </TertiaryButton>
-          ) : (
-            <StyledText
-              fontSize={TYPOGRAPHY.fontSizeCaption}
-              lineHeight={TYPOGRAPHY.lineHeight12}
-              color={COLORS.darkGreyEnabled}
-              paddingY={SPACING.spacing5}
-            >
-              {t('up_to_date')}
-            </StyledText>
-          )}
-        </Flex>
+        </Box>
         <Divider marginY={SPACING.spacing5} />
         <StyledText
           css={TYPOGRAPHY.h3SemiBold}


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This will close #10500
Adjust the `view software update` button position

<img width="800" alt="Screen Shot 2022-05-28 at 11 19 54 PM" src="https://user-images.githubusercontent.com/474225/170850610-56762e81-43aa-4c9b-af03-fb7f04413b7d.png">


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- Remove duplicated text 
- Adjust the update button position

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
The text is remove 

![Screen Shot 2022-05-27 at 8 56 55 AM](https://user-images.githubusercontent.com/4339860/170703813-4c1cd098-cf08-4d63-8ca7-2c0980263481.png)

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
