### PR TITLE
feat(app): make protocol runs from history clickable

### DIFF
--- a/app/src/organisms/Devices/HistoricalProtocolRun.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRun.tsx
@@ -31,11 +31,11 @@ const CLICK_STYLE = css`
 
 interface HistoricalProtocolRunProps {
   run: RunData
-  protocolKey?: string
   protocolName: string
   robotName: string
   robotIsBusy: boolean
   key: number
+  protocolKey?: string
 }
 
 export function HistoricalProtocolRun(
@@ -58,10 +58,9 @@ export function HistoricalProtocolRun(
       duration = formatInterval(run.createdAt, new Date().toString())
     }
   }
-  const protocolKeys = storedProtocols.map(({ protocolKey }) => protocolKey)
-  const protocolKeyInStoredKeys = Object.values(protocolKeys).find(
-    key => key === protocolKey
-  )
+  const protocolKeyInStoredKeys = storedProtocols
+    .map(({ protocolKey }) => protocolKey)
+    .find(key => key === protocolKey)
 
   return (
     <>

--- a/app/src/organisms/Devices/HistoricalProtocolRun.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRun.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
+import { css } from 'styled-components'
+import { useHistory } from 'react-router-dom'
+import { useSelector } from 'react-redux'
 import {
   Flex,
   Box,
@@ -11,16 +14,24 @@ import {
   BORDERS,
 } from '@opentrons/components'
 import { StyledText } from '../../atoms/text'
+import { getStoredProtocols } from '../../redux/protocol-storage'
 import { formatInterval } from '../RunTimeControl/utils'
 import { formatTimestamp } from './utils'
 import { HistoricalProtocolRunOverflowMenu as OverflowMenu } from './HistoricalProtocolRunOverflowMenu'
 import { HistoricalProtocolRunOffsetDrawer as OffsetDrawer } from './HistoricalProtocolRunOffsetDrawer'
 import type { RunData } from '@opentrons/api-client'
+import type { State } from '../../redux/types'
 
 const EMPTY_TIMESTAMP = '--:--:--'
 
+const CLICK_STYLE = css`
+  cursor: pointer;
+  overflow-wrap: anywhere;
+`
+
 interface HistoricalProtocolRunProps {
   run: RunData
+  protocolKey?: string
   protocolName: string
   robotName: string
   robotIsBusy: boolean
@@ -31,8 +42,12 @@ export function HistoricalProtocolRun(
   props: HistoricalProtocolRunProps
 ): JSX.Element | null {
   const { t } = useTranslation('run_details')
-  const { run, protocolName, robotIsBusy, robotName } = props
+  const { run, protocolName, robotIsBusy, robotName, protocolKey, key } = props
+  const history = useHistory()
   const [offsetDrawerOpen, setOffsetDrawerOpen] = React.useState(false)
+  const storedProtocols = useSelector((state: State) =>
+    getStoredProtocols(state)
+  )
   const runStatus = run.status
   const runDisplayName = formatTimestamp(run.createdAt)
   let duration = EMPTY_TIMESTAMP
@@ -43,6 +58,11 @@ export function HistoricalProtocolRun(
       duration = formatInterval(run.createdAt, new Date().toString())
     }
   }
+  const protocolKeys = storedProtocols.map(({ protocolKey }) => protocolKey)
+  const protocolKeyInStoredKeys = Object.values(protocolKeys).find(
+    key => key === protocolKey
+  )
+
   return (
     <>
       <Flex
@@ -64,22 +84,50 @@ export function HistoricalProtocolRun(
             marginRight={SPACING.spacing3}
           />
         </Box>
-        <StyledText
-          as="p"
-          width="25%"
-          data-testid={`RecentProtocolRuns_Run_${props.key}`}
-        >
-          {runDisplayName}
-        </StyledText>
-        <StyledText
-          as="p"
-          width="35%"
-          css={{ 'overflow-wrap': 'anywhere' }}
-          paddingRight={SPACING.spacing3}
-          data-testid={`RecentProtocolRuns_Protocol_${props.key}`}
-        >
-          {protocolName}
-        </StyledText>
+        {protocolKeyInStoredKeys != null ? (
+          <>
+            <StyledText
+              as="p"
+              width="25%"
+              data-testid={`RecentProtocolRuns_Run_${key}`}
+              onClick={() =>
+                history.push(
+                  `${robotName}/protocol-runs/${run.id}/protocolRunDetailsTab?`
+                )
+              }
+              css={CLICK_STYLE}
+            >
+              {runDisplayName}
+            </StyledText>
+            <StyledText
+              as="p"
+              width="35%"
+              data-testid={`RecentProtocolRuns_Protocol_${props.key}`}
+              onClick={() => history.push(`/protocols/${protocolKey}`)}
+              css={CLICK_STYLE}
+            >
+              {protocolName}
+            </StyledText>
+          </>
+        ) : (
+          <>
+            <StyledText
+              as="p"
+              width="25%"
+              data-testid={`RecentProtocolRuns_Run_${key}`}
+            >
+              {runDisplayName}
+            </StyledText>
+            <StyledText
+              as="p"
+              width="35%"
+              data-testid={`RecentProtocolRuns_Protocol_${props.key}`}
+              css={{ 'overflow-wrap': 'anywhere' }}
+            >
+              {protocolName}
+            </StyledText>
+          </>
+        )}
         <StyledText
           as="p"
           width="20%"

--- a/app/src/organisms/Devices/HistoricalProtocolRun.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRun.tsx
@@ -58,9 +58,9 @@ export function HistoricalProtocolRun(
       duration = formatInterval(run.createdAt, new Date().toString())
     }
   }
-  const protocolKeyInStoredKeys = storedProtocols
-    .map(({ protocolKey }) => protocolKey)
-    .find(key => key === protocolKey)
+  const protocolKeyInStoredKeys = storedProtocols.find(
+    ({ protocolKey: key }) => protocolKey === key
+  )
 
   return (
     <>
@@ -83,49 +83,40 @@ export function HistoricalProtocolRun(
             marginRight={SPACING.spacing3}
           />
         </Box>
+        <StyledText
+          as="p"
+          width="25%"
+          data-testid={`RecentProtocolRuns_Run_${key}`}
+          onClick={() =>
+            history.push(
+              `${robotName}/protocol-runs/${run.id}/protocolRunDetailsTab?`
+            )
+          }
+          css={css`
+            cursor: pointer;
+          `}
+        >
+          {runDisplayName}
+        </StyledText>
         {protocolKeyInStoredKeys != null ? (
-          <>
-            <StyledText
-              as="p"
-              width="25%"
-              data-testid={`RecentProtocolRuns_Run_${key}`}
-              onClick={() =>
-                history.push(
-                  `${robotName}/protocol-runs/${run.id}/protocolRunDetailsTab?`
-                )
-              }
-              css={CLICK_STYLE}
-            >
-              {runDisplayName}
-            </StyledText>
-            <StyledText
-              as="p"
-              width="35%"
-              data-testid={`RecentProtocolRuns_Protocol_${props.key}`}
-              onClick={() => history.push(`/protocols/${protocolKey}`)}
-              css={CLICK_STYLE}
-            >
-              {protocolName}
-            </StyledText>
-          </>
+          <StyledText
+            as="p"
+            width="35%"
+            data-testid={`RecentProtocolRuns_Protocol_${props.key}`}
+            onClick={() => history.push(`/protocols/${protocolKey}`)}
+            css={CLICK_STYLE}
+          >
+            {protocolName}
+          </StyledText>
         ) : (
-          <>
-            <StyledText
-              as="p"
-              width="25%"
-              data-testid={`RecentProtocolRuns_Run_${key}`}
-            >
-              {runDisplayName}
-            </StyledText>
-            <StyledText
-              as="p"
-              width="35%"
-              data-testid={`RecentProtocolRuns_Protocol_${props.key}`}
-              css={{ 'overflow-wrap': 'anywhere' }}
-            >
-              {protocolName}
-            </StyledText>
-          </>
+          <StyledText
+            as="p"
+            width="35%"
+            data-testid={`RecentProtocolRuns_Protocol_${props.key}`}
+            css={{ 'overflow-wrap': 'anywhere' }}
+          >
+            {protocolName}
+          </StyledText>
         )}
         <StyledText
           as="p"

--- a/app/src/organisms/Devices/RecentProtocolRuns.tsx
+++ b/app/src/organisms/Devices/RecentProtocolRuns.tsx
@@ -71,6 +71,7 @@ export function RecentProtocolRuns({
               >
                 {t('run')}
               </StyledText>
+
               <StyledText
                 as="label"
                 width="35%"
@@ -79,6 +80,7 @@ export function RecentProtocolRuns({
               >
                 {t('protocol')}
               </StyledText>
+
               <StyledText
                 as="label"
                 width="20%"
@@ -117,6 +119,7 @@ export function RecentProtocolRuns({
                   <HistoricalProtocolRun
                     run={run}
                     protocolName={protocolName}
+                    protocolKey={protocol?.key}
                     robotName={robotName}
                     robotIsBusy={robotIsBusy}
                     key={index}

--- a/app/src/organisms/Devices/__tests__/HistoricalProtocolRun.test.tsx
+++ b/app/src/organisms/Devices/__tests__/HistoricalProtocolRun.test.tsx
@@ -72,13 +72,8 @@ describe('RecentProtocolRuns', () => {
     const protocolBtn = getByText('my protocol')
     getByText('Completed')
     getByText('mock HistoricalProtocolRunOverflowMenu')
-    const runBtn = getByText('05/04/2022 14:24:40')
     fireEvent.click(protocolBtn)
     expect(mockPush).toHaveBeenCalledWith('/protocols/protocolKeyStub')
-    fireEvent.click(runBtn)
-    expect(mockPush).toHaveBeenCalledWith(
-      'otie/protocol-runs/test_id/protocolRunDetailsTab?'
-    )
   })
   it('renders buttons that are not clickable when the protocol was deleted from the app directory', () => {
     mockGetStoredProtocols.mockReturnValue([storedProtocolDataFixture])
@@ -94,12 +89,7 @@ describe('RecentProtocolRuns', () => {
     const protocolBtn = getByText('my protocol')
     getByText('Completed')
     getByText('mock HistoricalProtocolRunOverflowMenu')
-    const runBtn = getByText('05/04/2022 14:24:40')
     fireEvent.click(protocolBtn)
     expect(mockPush).not.toHaveBeenCalledWith('/protocols/12345')
-    fireEvent.click(runBtn)
-    expect(mockPush).not.toHaveBeenCalledWith(
-      'otie/protocol-runs/test_id/protocolRunDetailsTab?'
-    )
   })
 })

--- a/app/src/organisms/Devices/__tests__/HistoricalProtocolRun.test.tsx
+++ b/app/src/organisms/Devices/__tests__/HistoricalProtocolRun.test.tsx
@@ -1,13 +1,26 @@
 import * as React from 'react'
+import { fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../i18n'
+import { getStoredProtocols } from '../../../redux/protocol-storage'
+import { storedProtocolData as storedProtocolDataFixture } from '../../../redux/protocol-storage/__fixtures__'
 import { useRunStatus } from '../../RunTimeControl/hooks'
 import { HistoricalProtocolRun } from '../HistoricalProtocolRun'
 import { HistoricalProtocolRunOverflowMenu } from '../HistoricalProtocolRunOverflowMenu'
 import type { RunStatus, RunData } from '@opentrons/api-client'
 
+const mockPush = jest.fn()
+
+jest.mock('../../../redux/protocol-storage')
 jest.mock('../../RunTimeControl/hooks')
 jest.mock('../HistoricalProtocolRunOverflowMenu')
+jest.mock('react-router-dom', () => {
+  const reactRouterDom = jest.requireActual('react-router-dom')
+  return {
+    ...reactRouterDom,
+    useHistory: () => ({ push: mockPush } as any),
+  }
+})
 
 const mockUseRunStatus = useRunStatus as jest.MockedFunction<
   typeof useRunStatus
@@ -15,6 +28,10 @@ const mockUseRunStatus = useRunStatus as jest.MockedFunction<
 const mockHistoricalProtocolRunOverflowMenu = HistoricalProtocolRunOverflowMenu as jest.MockedFunction<
   typeof HistoricalProtocolRunOverflowMenu
 >
+const mockGetStoredProtocols = getStoredProtocols as jest.MockedFunction<
+  typeof getStoredProtocols
+>
+
 const run = {
   createdAt: '2022-05-04T18:24:40.833862+00:00',
   current: false,
@@ -22,36 +39,67 @@ const run = {
   protocolId: 'test_protocol_id',
   status: 'succeeded' as RunStatus,
 } as RunData
-const render = () => {
-  return renderWithProviders(
-    <HistoricalProtocolRun
-      robotName="otie"
-      protocolName="my protocol"
-      robotIsBusy={false}
-      run={run}
-      key={1}
-    />,
-    {
-      i18nInstance: i18n,
-    }
-  )
+
+const render = (props: React.ComponentProps<typeof HistoricalProtocolRun>) => {
+  return renderWithProviders(<HistoricalProtocolRun {...props} />, {
+    i18nInstance: i18n,
+  })[0]
 }
 
 describe('RecentProtocolRuns', () => {
+  let props: React.ComponentProps<typeof HistoricalProtocolRun>
+
   beforeEach(() => {
+    props = {
+      robotName: 'otie',
+      protocolName: 'my protocol',
+      protocolKey: 'protocolKeyStub',
+      robotIsBusy: false,
+      run: run,
+      key: 1,
+    }
     mockHistoricalProtocolRunOverflowMenu.mockReturnValue(
       <div>mock HistoricalProtocolRunOverflowMenu</div>
     )
+    mockUseRunStatus.mockReturnValue('succeeded')
+    mockGetStoredProtocols.mockReturnValue([storedProtocolDataFixture])
   })
   afterEach(() => {
     jest.resetAllMocks()
   })
   it('renders the correct information derived from run and protocol', () => {
-    mockUseRunStatus.mockReturnValue('succeeded')
-    const [{ getByText }] = render()
-
-    getByText('my protocol')
+    const { getByText } = render(props)
+    const protocolBtn = getByText('my protocol')
     getByText('Completed')
     getByText('mock HistoricalProtocolRunOverflowMenu')
+    const runBtn = getByText('05/04/2022 14:24:40')
+    fireEvent.click(protocolBtn)
+    expect(mockPush).toHaveBeenCalledWith('/protocols/protocolKeyStub')
+    fireEvent.click(runBtn)
+    expect(mockPush).toHaveBeenCalledWith(
+      'otie/protocol-runs/test_id/protocolRunDetailsTab?'
+    )
+  })
+  it('renders buttons that are not clickable when the protocol was deleted from the app directory', () => {
+    mockGetStoredProtocols.mockReturnValue([storedProtocolDataFixture])
+    props = {
+      robotName: 'otie',
+      protocolName: 'my protocol',
+      protocolKey: '12345',
+      robotIsBusy: false,
+      run: run,
+      key: 1,
+    }
+    const { getByText } = render(props)
+    const protocolBtn = getByText('my protocol')
+    getByText('Completed')
+    getByText('mock HistoricalProtocolRunOverflowMenu')
+    const runBtn = getByText('05/04/2022 14:24:40')
+    fireEvent.click(protocolBtn)
+    expect(mockPush).not.toHaveBeenCalledWith('/protocols/12345')
+    fireEvent.click(runBtn)
+    expect(mockPush).not.toHaveBeenCalledWith(
+      'otie/protocol-runs/test_id/protocolRunDetailsTab?'
+    )
   })
 })


### PR DESCRIPTION
closes #10502

# Overview

This PR makes each run and protocol in the run history clickable. When clicking on run, it links to the run details page. When clicking on protocol Name, it links to the protocol details page.


# Changelog

- changes `HistoricalProtocolRun` to take in a protocol key prop and also gets stored protocols
- extends prop in `RecentProtocolRuns`

# Review requests

- click on a run in your robot's recent Protocol Runs, it should link you to the correct run details page.
- click on a protocol name in your robot's recent Protocol Runs, it should link you to the correct protocol details page.
- go into Protocol Cards and delete a protocol. When you return to the Protocol Runs, the run and protocol name for that deleted protocol should **not** be clickable.

# Risk assessment

low