### PR TITLE
refactor(hardware): eeprom address field is 16-bits

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -74,7 +74,7 @@ class GetSpeedResponsePayload(utils.BinarySerializable):
 class EEPromReadPayload(utils.BinarySerializable):
     """Eeprom read request payload ."""
 
-    address: utils.UInt8Field
+    address: utils.UInt16Field
     data_length: utils.UInt8Field
 
 

--- a/hardware/tests/firmware_integration/test_eeprom.py
+++ b/hardware/tests/firmware_integration/test_eeprom.py
@@ -16,7 +16,7 @@ from opentrons_hardware.firmware_bindings.messages.payloads import (
     EEPromDataPayload,
     EEPromReadPayload,
 )
-from opentrons_hardware.firmware_bindings.utils import UInt8Field
+from opentrons_hardware.firmware_bindings.utils import UInt8Field, UInt16Field
 
 from opentrons_hardware.drivers.can_bus import CanMessenger, WaitableCallback
 
@@ -63,7 +63,7 @@ async def test_read_write(
         node_id=eeprom_node_id,
         message=WriteToEEPromRequest(
             payload=EEPromDataPayload(
-                address=UInt8Field(address),
+                address=UInt16Field(address),
                 data_length=UInt8Field(len(data)),
                 data=EepromDataField(data),
             )
@@ -72,7 +72,7 @@ async def test_read_write(
 
     read_message = ReadFromEEPromRequest(
         payload=EEPromReadPayload(
-            address=UInt8Field(address), data_length=UInt8Field(len(data))
+            address=UInt16Field(address), data_length=UInt8Field(len(data))
         )
     )
     await can_messenger.send(node_id=eeprom_node_id, message=read_message)


### PR DESCRIPTION
# Overview

New board revisions will have 16-bit address space for eeprom.

# Changelog

Use 16-bit address instead of 8-bit.

# Review requests



# Risk assessment

None