### PR TITLE
refactor(app): add functionality to Update robot software menu item

### DIFF
--- a/app/src/organisms/Devices/RobotOverviewOverflowMenu.tsx
+++ b/app/src/organisms/Devices/RobotOverviewOverflowMenu.tsx
@@ -15,6 +15,8 @@ import {
 import { RUN_STATUS_RUNNING } from '@opentrons/api-client'
 import { checkShellUpdate } from '../../redux/shell'
 import { restartRobot } from '../../redux/robot-admin'
+import { UpdateBuildroot } from '../../pages/Robots/RobotSettings/UpdateBuildroot'
+import { UNREACHABLE } from '../../redux/discovery'
 import { home, ROBOT } from '../../redux/robot-controls'
 import { MenuItem } from '../../atoms/MenuList/MenuItem'
 import { Portal } from '../../App/portal'
@@ -23,7 +25,6 @@ import { OverflowBtn } from '../../atoms/MenuList/OverflowBtn'
 import { Divider } from '../../atoms/structure'
 import { useCurrentRunStatus } from '../RunTimeControl/hooks'
 import { useMenuHandleClickOutside } from '../../atoms/MenuList/hooks'
-import { SoftwareUpdateModal } from './RobotSettings/AdvancedTab/SoftwareUpdateModal'
 
 import type { DiscoveredRobot } from '../../redux/discovery/types'
 import type { Dispatch, State } from '../../redux/types'
@@ -73,11 +74,12 @@ export const RobotOverviewOverflowMenu = (
 
   useInterval(checkAppUpdate, UPDATE_RECHECK_DELAY_MS)
 
-  const handleLaunchModal: React.MouseEventHandler = e => {
+  const handleClickUpdateBuildroot: React.MouseEventHandler = e => {
     e.preventDefault()
     e.stopPropagation()
     setShowSoftwareUpdateModal(true)
   }
+
   const { autoUpdateAction } = useSelector((state: State) => {
     return getBuildrootUpdateDisplayInfo(state, robot.name)
   })
@@ -90,11 +92,13 @@ export const RobotOverviewOverflowMenu = (
         e.preventDefault()
       }}
     >
-      {showSoftwareUpdateModal ? (
+      {showSoftwareUpdateModal &&
+      robot != null &&
+      robot.status !== UNREACHABLE ? (
         <Portal level="top">
-          <SoftwareUpdateModal
-            robotName={robot.name}
-            closeModal={() => setShowSoftwareUpdateModal(false)}
+          <UpdateBuildroot
+            robot={robot}
+            close={() => setShowSoftwareUpdateModal(false)}
           />
         </Portal>
       ) : null}
@@ -114,7 +118,7 @@ export const RobotOverviewOverflowMenu = (
           {autoUpdateAction === 'upgrade' ? (
             <MenuItem
               disabled={buttonDisabledReason}
-              onClick={handleLaunchModal}
+              onClick={handleClickUpdateBuildroot}
               data-testid={`RobotOverviewOverflowMenu_updateSoftware_${robot.name}`}
             >
               {t('update_robot_software')}

--- a/app/src/organisms/Devices/__tests__/RobotOverviewOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotOverviewOverflowMenu.test.tsx
@@ -6,18 +6,18 @@ import { renderWithProviders } from '@opentrons/components'
 import { RUN_STATUS_IDLE, RUN_STATUS_RUNNING } from '@opentrons/api-client'
 import { i18n } from '../../../i18n'
 import { home } from '../../../redux/robot-controls'
+import { UpdateBuildroot } from '../../../pages/Robots/RobotSettings/UpdateBuildroot'
 import * as Buildroot from '../../../redux/buildroot'
 import { restartRobot } from '../../../redux/robot-admin'
 import { mockConnectableRobot } from '../../../redux/discovery/__fixtures__'
 import { useCurrentRunStatus } from '../../RunTimeControl/hooks'
 import { RobotOverviewOverflowMenu } from '../RobotOverviewOverflowMenu'
-import { SoftwareUpdateModal } from '../RobotSettings/AdvancedTab/SoftwareUpdateModal'
 
 jest.mock('../../RunTimeControl/hooks')
 jest.mock('../../../redux/robot-controls')
 jest.mock('../../../redux/robot-admin')
 jest.mock('../../../redux/buildroot')
-jest.mock('../RobotSettings/AdvancedTab/SoftwareUpdateModal')
+jest.mock('../../../pages/Robots/RobotSettings/UpdateBuildroot')
 
 const mockUseCurrentRunStatus = useCurrentRunStatus as jest.MockedFunction<
   typeof useCurrentRunStatus
@@ -29,8 +29,8 @@ const mockHome = home as jest.MockedFunction<typeof home>
 const mockRestartRobot = restartRobot as jest.MockedFunction<
   typeof restartRobot
 >
-const mockSoftwareUpdateModal = SoftwareUpdateModal as jest.MockedFunction<
-  typeof SoftwareUpdateModal
+const mockUpdateBuildroot = UpdateBuildroot as jest.MockedFunction<
+  typeof UpdateBuildroot
 >
 
 const render = (
@@ -56,9 +56,7 @@ describe('RobotOverviewOverflowMenu', () => {
       updateFromFileDisabledReason: null,
     })
     when(mockUseCurrentRunStatus).calledWith().mockReturnValue(RUN_STATUS_IDLE)
-    when(mockSoftwareUpdateModal).mockReturnValue(
-      <div>mock software update modal</div>
-    )
+    when(mockUpdateBuildroot).mockReturnValue(<div>mock update buildroot</div>)
   })
   afterEach(() => {
     resetAllWhenMocks()
@@ -82,7 +80,7 @@ describe('RobotOverviewOverflowMenu', () => {
     expect(homeBtn).toBeEnabled()
     expect(settingsBtn).toBeEnabled()
     fireEvent.click(updateRobotSoftwareBtn)
-    getByText('mock software update modal')
+    getByText('mock update buildroot')
   })
 
   it('should render disabled buttons in the menu when the run status is running', () => {


### PR DESCRIPTION
closes #10479

# Overview

This PR adds functionality to the `Update robot software` button in the robot overview overflow menu. It appears only when an update is available.

# Changelog

- edit `robotOverviewOverflowMenu`

# Review requests

- if an update is available, you should be able to see the `Update robot software` button. Clicking on it will launch the Robot software update modal
- if an update is not available, the button menu item will not be there.

# Risk assessment

low