### PR TITLE
fix(robot-server): disallow pause action for non-active run

### DIFF
--- a/api/src/opentrons/protocol_engine/errors/__init__.py
+++ b/api/src/opentrons/protocol_engine/errors/__init__.py
@@ -30,6 +30,7 @@ from .exceptions import (
     InvalidTargetSpeedError,
     InvalidTargetTemperatureError,
     InvalidBlockVolumeError,
+    RunNotStartedError
 )
 
 from .error_occurrence import ErrorOccurrence
@@ -67,4 +68,5 @@ __all__ = [
     "InvalidBlockVolumeError",
     # error occurrence models
     "ErrorOccurrence",
+    "RunNotStartedError"
 ]

--- a/api/src/opentrons/protocol_engine/errors/__init__.py
+++ b/api/src/opentrons/protocol_engine/errors/__init__.py
@@ -66,7 +66,7 @@ __all__ = [
     "InvalidTargetTemperatureError",
     "InvalidTargetSpeedError",
     "InvalidBlockVolumeError",
+    "RunNotStartedError",
     # error occurrence models
     "ErrorOccurrence",
-    "RunNotStartedError",
 ]

--- a/api/src/opentrons/protocol_engine/errors/__init__.py
+++ b/api/src/opentrons/protocol_engine/errors/__init__.py
@@ -30,7 +30,7 @@ from .exceptions import (
     InvalidTargetSpeedError,
     InvalidTargetTemperatureError,
     InvalidBlockVolumeError,
-    RunNotStartedError
+    RunNotStartedError,
 )
 
 from .error_occurrence import ErrorOccurrence
@@ -68,5 +68,5 @@ __all__ = [
     "InvalidBlockVolumeError",
     # error occurrence models
     "ErrorOccurrence",
-    "RunNotStartedError"
+    "RunNotStartedError",
 ]

--- a/api/src/opentrons/protocol_engine/errors/exceptions.py
+++ b/api/src/opentrons/protocol_engine/errors/exceptions.py
@@ -135,3 +135,6 @@ class InvalidBlockVolumeError(ProtocolEngineError):
 
 class InvalidTargetSpeedError(ProtocolEngineError):
     """An error raised when attempting to set an invalid target speed."""
+
+class RunNotStartedError(ProtocolEngineError):
+    """An error raised when attempting to pause a run that is not started."""

--- a/api/src/opentrons/protocol_engine/errors/exceptions.py
+++ b/api/src/opentrons/protocol_engine/errors/exceptions.py
@@ -136,5 +136,6 @@ class InvalidBlockVolumeError(ProtocolEngineError):
 class InvalidTargetSpeedError(ProtocolEngineError):
     """An error raised when attempting to set an invalid target speed."""
 
+
 class RunNotStartedError(ProtocolEngineError):
     """An error raised when attempting to pause a run that is not started."""

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -114,6 +114,7 @@ class ProtocolEngine:
     def pause(self) -> None:
         """Pause executing commands in the queue."""
         action = PauseAction(source=PauseSource.CLIENT)
+        self._state_store.commands.raise_if_not_started()
         self._state_store.commands.raise_if_stop_requested()
         self._action_dispatcher.dispatch(action)
 

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -114,8 +114,7 @@ class ProtocolEngine:
     def pause(self) -> None:
         """Pause executing commands in the queue."""
         action = PauseAction(source=PauseSource.CLIENT)
-        self._state_store.commands.raise_if_not_started()
-        self._state_store.commands.raise_if_stop_requested()
+        self._state_store.commands.raise_if_pause_not_allowed()
         self._action_dispatcher.dispatch(action)
 
     def add_command(self, request: CommandCreate) -> Command:

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -487,6 +487,7 @@ class CommandView(HasState[CommandState]):
         """Get whether an engine stop has completed."""
         return self._state.is_hardware_stopped
 
+    # TODO (tz, 5-31-22): change to is_running? after mc PR is merged
     def raise_if_not_started(self) -> None:
         """Raise if a run has not started.
 

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -447,7 +447,7 @@ class CommandView(HasState[CommandState]):
     def get_is_active(self) -> bool:
         """Get whether the engine is active and queued commands should be executed."""
         queue_status = self._state.queue_status
-        return (queue_status == QueueStatus.ACTIVE)
+        return queue_status == QueueStatus.ACTIVE
 
     def get_is_complete(self, command_id: str) -> bool:
         """Get whether a given command is completed.

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -444,6 +444,11 @@ class CommandView(HasState[CommandState]):
             or queue_status == QueueStatus.ACTIVE
         )
 
+    def get_is_active(self) -> bool:
+        """Get whether the engine is active and queued commands should be executed."""
+        queue_status = self._state.queue_status
+        return (queue_status == QueueStatus.ACTIVE)
+
     def get_is_complete(self, command_id: str) -> bool:
         """Get whether a given command is completed.
 
@@ -481,6 +486,17 @@ class CommandView(HasState[CommandState]):
     def get_is_stopped(self) -> bool:
         """Get whether an engine stop has completed."""
         return self._state.is_hardware_stopped
+
+    def raise_if_not_started(self) -> None:
+        """Raise if a run has not started.
+
+        Mainly used to validate if an Action is allowed, raising if not.
+
+        Raises:
+            ProtocolEngineStoppedError: the engine has been stopped.
+        """
+        if not self.get_is_active():
+            raise ProtocolEngineStoppedError("A stop has already been requested.")
 
     # TODO(mc, 2021-12-07): reject adding commands to a stopped engine
     def raise_if_stop_requested(self) -> None:

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -488,6 +488,10 @@ class CommandView(HasState[CommandState]):
         """Get whether an engine stop has completed."""
         return self._state.is_hardware_stopped
 
+    def raise_if_pause_not_allowed(self) -> None:
+        self.raise_if_not_started()
+        self.raise_if_stop_requested()
+
     # TODO (tz, 5-31-22): change to is_running? after mc PR is merged
     def raise_if_not_started(self) -> None:
         """Raise if a run has not started.

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -494,10 +494,10 @@ class CommandView(HasState[CommandState]):
         Mainly used to validate if an Action is allowed, raising if not.
 
         Raises:
-            ProtocolEngineStoppedError: the engine has been stopped.
+            RunNotStartedError: Run is not started, therefor cannot be stopped.
         """
         if not self.get_is_active():
-            raise ProtocolEngineStoppedError("A stop has already been requested.")
+            raise RunNotStartedError("Cannot pause a run that was not started.")
 
     # TODO(mc, 2021-12-07): reject adding commands to a stopped engine
     def raise_if_stop_requested(self) -> None:

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -30,6 +30,7 @@ from ..errors import (
     ProtocolEngineStoppedError,
     ErrorOccurrence,
     RobotDoorOpenError,
+    RunNotStartedError,
 )
 from ..types import EngineStatus
 from .abstract_store import HasState, HandlesActions

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -489,6 +489,7 @@ class CommandView(HasState[CommandState]):
         return self._state.is_hardware_stopped
 
     def raise_if_pause_not_allowed(self) -> None:
+        """Raise if pausing a run is not allowed."""
         self.raise_if_not_started()
         self.raise_if_stop_requested()
 

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -270,6 +270,11 @@ def test_pause(
     )
 
 
+def test_pause_run_not_started(decoy: Decoy) -> None:
+    """Should raise an ProtocolEngineStoppedError error."""
+    raise NotImplementedError()
+
+
 @pytest.mark.parametrize("drop_tips_and_home", [True, False])
 @pytest.mark.parametrize("set_run_status", [True, False])
 async def test_finish(

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -11,7 +11,7 @@ from opentrons.hardware_control.modules import MagDeck, TempDeck
 from opentrons.protocols.models import LabwareDefinition
 
 from opentrons.protocol_engine import ProtocolEngine, commands
-from opentrons.protocol_engine.errors import ProtocolEngineStoppedError
+from opentrons.protocol_engine.errors import RunNotStartedError
 from opentrons.protocol_engine.types import (
     LabwareOffset,
     LabwareOffsetCreate,
@@ -277,12 +277,12 @@ def test_pause_run_not_started(
     state_store: StateStore,
     subject: ProtocolEngine,
 ) -> None:
-    """Should raise an ProtocolEngineStoppedError error."""
+    """Should raise an RunNotStartedError error."""
     decoy.when(state_store.commands.raise_if_not_started()).then_raise(
-        ProtocolEngineStoppedError("A stop has already been requested.")
+        RunNotStartedError("Cannot pause a run that was not started.")
     )
 
-    with pytest.raises(ProtocolEngineStoppedError):
+    with pytest.raises(RunNotStartedError):
         subject.pause()
 
 

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -266,8 +266,7 @@ def test_pause(
     subject.pause()
 
     decoy.verify(
-        state_store.commands.raise_if_not_started(),
-        state_store.commands.raise_if_stop_requested(),
+        state_store.commands.raise_if_pause_not_allowed(),
         action_dispatcher.dispatch(expected_action),
     )
 
@@ -278,7 +277,7 @@ def test_pause_run_not_started(
     subject: ProtocolEngine,
 ) -> None:
     """Should raise an RunNotStartedError error."""
-    decoy.when(state_store.commands.raise_if_not_started()).then_raise(
+    decoy.when(state_store.commands.raise_if_pause_not_allowed()).then_raise(
         RunNotStartedError("Cannot pause a run that was not started.")
     )
 

--- a/robot-server/tests/commands/test_router.py
+++ b/robot-server/tests/commands/test_router.py
@@ -59,23 +59,6 @@ async def test_create_command(
     decoy.verify(await protocol_engine.wait_for_command("abc123"), times=0)
 
 
-async def test_create_pause_command_run_not_started(
-    decoy: Decoy,
-    protocol_engine: ProtocolEngine,
-) -> None:
-    """It should raise a 409. trying to pause a not started run."""
-    pause_params = pe_commands.PauseParams()
-    command_create = pe_commands.PauseCreate(params=pause_params)
-
-    with pytest.raises(ApiError):
-        result = await create_command(
-            RequestModel(data=command_create),
-            waitUntilComplete=False,
-            timeout=42,
-            engine=protocol_engine,
-        )
-
-
 async def test_create_command_wait_for_complete(
     decoy: Decoy,
     protocol_engine: ProtocolEngine,

--- a/robot-server/tests/commands/test_router.py
+++ b/robot-server/tests/commands/test_router.py
@@ -59,6 +59,23 @@ async def test_create_command(
     decoy.verify(await protocol_engine.wait_for_command("abc123"), times=0)
 
 
+async def test_create_pause_command_run_not_started(
+    decoy: Decoy,
+    protocol_engine: ProtocolEngine,
+) -> None:
+    """It should raise a 409. trying to pause a not started run."""
+    pause_params = pe_commands.PauseParams()
+    command_create = pe_commands.PauseCreate(params=pause_params)
+
+    with pytest.raises(ApiError):
+        result = await create_command(
+            RequestModel(data=command_create),
+            waitUntilComplete=False,
+            timeout=42,
+            engine=protocol_engine,
+        )
+
+
 async def test_create_command_wait_for_complete(
     decoy: Decoy,
     protocol_engine: ProtocolEngine,

--- a/robot-server/tests/integration/http_api/runs/test_pause_run_not_started.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_pause_run_not_started.tavern.yaml
@@ -1,0 +1,34 @@
+test_name: Alter the value of run status and current
+
+marks:
+  - usefixtures:
+      - run_server
+
+stages:
+  - name: Create Empty Run
+    request:
+      url: '{host:s}:{port:d}/runs'
+      json:
+        data: {}
+      method: POST
+    response:
+      strict:
+        - json:off
+      status_code: 201
+      json:
+        data:
+          id: !anystr
+          status: idle
+          current: true
+      save:
+        json:
+          run_id: data.id
+  - name: Issue stop pause to Run that was not started
+    request:
+      url: '{host:s}:{port:d}/runs/{run_id}/actions'
+      json:
+        data:
+          actionType: pause
+      method: POST
+    response:
+      status_code: 409

--- a/robot-server/tests/integration/http_api/runs/test_pause_run_not_started.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_pause_run_not_started.tavern.yaml
@@ -23,6 +23,19 @@ stages:
       save:
         json:
           run_id: data.id
+  - name: Patch the Run
+    request:
+      url: '{host:s}:{port:d}/runs/{run_id}'
+      json:
+        data: { 'current': true }
+      method: PATCH
+    response:
+      strict:
+        - json:off
+      status_code: 200
+      json:
+        data:
+          id: "{run_id}"
   - name: Issue pause to a none active run
     request:
       url: '{host:s}:{port:d}/runs/{run_id}/actions'

--- a/robot-server/tests/integration/http_api/runs/test_pause_run_not_started.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_pause_run_not_started.tavern.yaml
@@ -1,4 +1,4 @@
-test_name: Alter the value of run status and current
+test_name: Make sure a non active run cannot be paused
 
 marks:
   - usefixtures:
@@ -23,19 +23,6 @@ stages:
       save:
         json:
           run_id: data.id
-  - name: Patch the Run
-    request:
-      url: '{host:s}:{port:d}/runs/{run_id}'
-      json:
-        data: { 'current': true }
-      method: PATCH
-    response:
-      strict:
-        - json:off
-      status_code: 200
-      json:
-        data:
-          id: "{run_id}"
   - name: Issue pause to a none active run
     request:
       url: '{host:s}:{port:d}/runs/{run_id}/actions'
@@ -45,3 +32,8 @@ stages:
       method: POST
     response:
       status_code: 409
+      json:
+        errors:
+          - id: 'RunActionNotAllowed'
+            title: 'Run Action Not Allowed'
+            detail: 'Cannot pause a run that was not started.'

--- a/robot-server/tests/integration/http_api/runs/test_pause_run_not_started.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_pause_run_not_started.tavern.yaml
@@ -23,7 +23,7 @@ stages:
       save:
         json:
           run_id: data.id
-  - name: Issue stop pause to Run that was not started
+  - name: Issue pause to a none active run
     request:
       url: '{host:s}:{port:d}/runs/{run_id}/actions'
       json:


### PR DESCRIPTION

# Overview

closes #10409.

If command queue status is not running raise a 409 on POST pause action

# Changelog

- added raise_if_not_started to raise the exception if a run was not started.
- Added exception RunNotStartedError.

# Review requests

1. names make sense?
2. added tests are sufficient?

# Risk assessment

Low. `ProcotolEngine.pause()` added a check for the queue status. 
