### PR TITLE
feat(protocol-designer): add timeline error for tall labware east west of a heater shaker

### DIFF
--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -121,6 +121,9 @@
       "HEATER_SHAKER_IS_SHAKING": {
         "title": "Heater-Shaker is shaking",
         "body": "A pipette cannot interact with labware on the Heater-Shaker Module while it is shaking."
+      },
+      "TALL_LABWARE_EAST_WEST_OF_HEATER_SHAKER": {
+        "body": "The Heater-Shaker labware latch will collide with labware over 53 mm. Move labware to a different slot."
       }
     },
     "warning": {

--- a/step-generation/src/__tests__/heaterShakerOpenLatch.test.ts
+++ b/step-generation/src/__tests__/heaterShakerOpenLatch.test.ts
@@ -1,0 +1,105 @@
+import { when, resetAllWhenMocks } from 'jest-when'
+import { getLabwareDefURI } from '@opentrons/shared-data'
+import { heaterShakerOpenLatch } from '../commandCreators/atomic/heaterShakerOpenLatch'
+import _fixtureTiprack1000ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_1000_ul.json'
+import { getIsTallLabwareEastWestOfHeaterShaker } from '../utils'
+import {
+  getErrorResult,
+  getInitialRobotStateStandard,
+  makeContext,
+} from '../fixtures'
+import type { InvariantContext, RobotState } from '../types'
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
+
+jest.mock('../utils', () => {
+  const actualUtils = jest.requireActual('../utils')
+  return {
+    ...actualUtils,
+    getIsTallLabwareEastWestOfHeaterShaker: jest.fn(),
+  }
+})
+
+const fixtureTiprack1000ul = _fixtureTiprack1000ul as LabwareDefinition2
+
+const mockGetIsTallLabwareEastWestOfHeaterShaker = getIsTallLabwareEastWestOfHeaterShaker as jest.MockedFunction<
+  typeof getIsTallLabwareEastWestOfHeaterShaker
+>
+describe('heaterShakerOpenLatch', () => {
+  const HEATER_SHAKER_ID = 'heaterShakerId'
+  const HEATER_SHAKER_SLOT = '1'
+  let robotState: RobotState
+  let invariantContext: InvariantContext
+  beforeEach(() => {
+    const context = makeContext()
+    invariantContext = {
+      ...context,
+      labwareEntities: {
+        ...context.labwareEntities,
+        tiprack2Id: {
+          id: 'tiprack2Id',
+          // this tiprack is tall enough to trigger the latch open warning
+          labwareDefURI: getLabwareDefURI(fixtureTiprack1000ul),
+          def: fixtureTiprack1000ul,
+        },
+      },
+    }
+    const state = getInitialRobotStateStandard(invariantContext)
+
+    robotState = {
+      ...state,
+      modules: {
+        ...state.modules,
+        [HEATER_SHAKER_ID]: {
+          slot: HEATER_SHAKER_SLOT,
+        } as any,
+      },
+    }
+  })
+  afterEach(() => {
+    resetAllWhenMocks()
+  })
+  it('should return an error when there is labware east/west that is above 53 mm', () => {
+    when(mockGetIsTallLabwareEastWestOfHeaterShaker)
+      .calledWith(
+        robotState.labware,
+        invariantContext.labwareEntities,
+        HEATER_SHAKER_SLOT
+      )
+      .mockReturnValue(true)
+    const result = heaterShakerOpenLatch(
+      {
+        moduleId: HEATER_SHAKER_ID,
+      },
+      invariantContext,
+      robotState
+    )
+    expect(getErrorResult(result).errors).toHaveLength(1)
+    expect(getErrorResult(result).errors[0]).toMatchObject({
+      type: 'TALL_LABWARE_EAST_WEST_OF_HEATER_SHAKER',
+    })
+  })
+  it('should return an open latch command when there is no labware that is too tall east/west of the heater shaker', () => {
+    when(mockGetIsTallLabwareEastWestOfHeaterShaker)
+      .calledWith(
+        robotState.labware,
+        invariantContext.labwareEntities,
+        HEATER_SHAKER_SLOT
+      )
+      .mockReturnValue(false)
+    const result = heaterShakerOpenLatch(
+      {
+        moduleId: HEATER_SHAKER_ID,
+      },
+      invariantContext,
+      robotState
+    )
+    expect(result).toEqual({
+      commands: [
+        {
+          commandType: 'heaterShakerModule/openLatch',
+          params: { moduleId: 'heaterShakerId' },
+        },
+      ],
+    })
+  })
+})

--- a/step-generation/src/__tests__/utils.test.ts
+++ b/step-generation/src/__tests__/utils.test.ts
@@ -6,7 +6,7 @@ import {
   THERMOCYCLER_MODULE_TYPE,
   LabwareDefinition2,
   getIsLabwareAboveHeight,
-  MAX_LABWARE_HEIGHT_EAST_WEST_HEATER_SHAKER_MM
+  MAX_LABWARE_HEIGHT_EAST_WEST_HEATER_SHAKER_MM,
 } from '@opentrons/shared-data'
 import {
   fixtureP10Single,

--- a/step-generation/src/commandCreators/atomic/heaterShakerOpenLatch.ts
+++ b/step-generation/src/commandCreators/atomic/heaterShakerOpenLatch.ts
@@ -1,10 +1,28 @@
+import * as errorCreators from '../../errorCreators'
+import { getIsTallLabwareEastWestOfHeaterShaker } from '../../utils'
 import type { ModuleOnlyParams } from '@opentrons/shared-data/protocol/types/schemaV6/command/module'
 import type { CommandCreator } from '../../types'
+
+const LEFT_SLOTS = ['1', '4', '7']
 export const heaterShakerOpenLatch: CommandCreator<ModuleOnlyParams> = (
   args,
   invariantContext,
   prevRobotState
 ) => {
+  const heaterShakerSlot = prevRobotState.modules[args.moduleId].slot
+  if (
+    getIsTallLabwareEastWestOfHeaterShaker(
+      prevRobotState.labware,
+      invariantContext.labwareEntities,
+      heaterShakerSlot
+    )
+  ) {
+    // if H-S is in a left slot, labware must be to the right
+    const leftOrRight = LEFT_SLOTS.includes(heaterShakerSlot) ? 'right' : 'left'
+    return {
+      errors: [errorCreators.tallLabwareEastWestOfHeaterShaker(leftOrRight)],
+    }
+  }
   return {
     commands: [
       {

--- a/step-generation/src/commandCreators/atomic/heaterShakerOpenLatch.ts
+++ b/step-generation/src/commandCreators/atomic/heaterShakerOpenLatch.ts
@@ -3,7 +3,7 @@ import { getIsTallLabwareEastWestOfHeaterShaker } from '../../utils'
 import type { ModuleOnlyParams } from '@opentrons/shared-data/protocol/types/schemaV6/command/module'
 import type { CommandCreator } from '../../types'
 
-const LEFT_SLOTS = ['1', '4', '7']
+const LEFT_SLOTS = ['1', '4', '7', '10']
 export const heaterShakerOpenLatch: CommandCreator<ModuleOnlyParams> = (
   args,
   invariantContext,

--- a/step-generation/src/errorCreators.ts
+++ b/step-generation/src/errorCreators.ts
@@ -133,3 +133,12 @@ export const heaterShakerIsShaking = (): CommandCreatorError => {
     message: 'Attempted to pipette into a heater-shaker when it is shaking.',
   }
 }
+
+export const tallLabwareEastWestOfHeaterShaker = (
+  position: 'left' | 'right'
+): CommandCreatorError => {
+  return {
+    type: 'TALL_LABWARE_EAST_WEST_OF_HEATER_SHAKER',
+    message: `Labware over 53 mm is ${position} of this Heater-Shaker module.`,
+  }
+}

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -475,6 +475,8 @@ export type ErrorType =
   | 'INVALID_SLOT'
   | 'HEATER_SHAKER_LATCH_OPEN'
   | 'HEATER_SHAKER_IS_SHAKING'
+  | 'TALL_LABWARE_EAST_WEST_OF_HEATER_SHAKER'
+
 export interface CommandCreatorError {
   message: string
   type: ErrorType

--- a/step-generation/src/utils/getIsTallLabwareEastWestOfHeaterShaker.ts
+++ b/step-generation/src/utils/getIsTallLabwareEastWestOfHeaterShaker.ts
@@ -1,0 +1,36 @@
+import some from 'lodash/some'
+import type { LabwareEntities, RobotState } from '../types'
+import { getIsLabwareAboveHeight } from '@opentrons/shared-data'
+import { MAX_LABWARE_HEIGHT_EAST_WEST_HEATER_SHAKER_MM } from '../../../shared-data/js/constants'
+
+// this util only works for outter slots (where we can safely place modules in PD)
+const getSlotNextTo = (slot: string): string | null => {
+  const SLOT_ADJACENT_MAP: Record<string, string> = {
+    '1': '2',
+    '3': '2',
+    '4': '5',
+    '6': '5',
+    '7': '8',
+    '9': '8',
+    '10': '11',
+  }
+
+  return SLOT_ADJACENT_MAP[slot] ?? null
+}
+
+export const getIsTallLabwareEastWestOfHeaterShaker = (
+  labwareState: RobotState['labware'],
+  labwareEntities: LabwareEntities,
+  heaterShakerSlot: string
+): boolean => {
+  const isTallLabwareEastWestOfHeaterShaker = some(
+    labwareState,
+    (labwareProperties, labwareId) =>
+      getSlotNextTo(heaterShakerSlot) === labwareProperties.slot &&
+      getIsLabwareAboveHeight(
+        labwareEntities[labwareId].def,
+        MAX_LABWARE_HEIGHT_EAST_WEST_HEATER_SHAKER_MM
+      )
+  )
+  return isTallLabwareEastWestOfHeaterShaker
+}

--- a/step-generation/src/utils/index.ts
+++ b/step-generation/src/utils/index.ts
@@ -6,6 +6,7 @@ import { thermocyclerPipetteCollision } from './thermocyclerPipetteCollision'
 import { pipetteIntoHeaterShakerLatchOpen } from './pipetteIntoHeaterShakerLatchOpen'
 import { pipetteIntoHeaterShakerWhileShaking } from './pipetteIntoHeaterShakerWhileShaking'
 import { orderWells } from './orderWells'
+import { getIsTallLabwareEastWestOfHeaterShaker } from './getIsTallLabwareEastWestOfHeaterShaker'
 export {
   commandCreatorsTimeline,
   curryCommandCreator,
@@ -15,6 +16,7 @@ export {
   thermocyclerPipetteCollision,
   pipetteIntoHeaterShakerLatchOpen,
   pipetteIntoHeaterShakerWhileShaking,
+  getIsTallLabwareEastWestOfHeaterShaker,
 }
 export * from './commandCreatorArgsGetters'
 export * from './misc'


### PR DESCRIPTION
# Overview

closes #10444

# Changelog

- Add timeline error for tall labware east west of a heater shaker

# Review requests

- Create a protocol with a H-S and a tall piece of labware (like a p1000 tiprack)
- In the deckmap, drag the labware to be next to the H-S
- You should see a timeline error that matches the ticket (#10444) AC

# Risk assessment

Low
