### PR TITLE
fix(app): protocol sort order changing when clicking sort menu

### DIFF
--- a/app/src/organisms/ProtocolsLanding/hooks.tsx
+++ b/app/src/organisms/ProtocolsLanding/hooks.tsx
@@ -20,6 +20,9 @@ export function useSortedProtocols(
     )
 
     if (sortBy === 'alphabetical') {
+      if (protocolNameA.toLowerCase() === protocolNameB.toLowerCase()) {
+        return b.modified - a.modified
+      }
       return protocolNameA.toLowerCase() > protocolNameB.toLowerCase() ? 1 : -1
     } else if (sortBy === 'reverse') {
       return protocolNameA.toLowerCase() > protocolNameB.toLowerCase() ? -1 : 1


### PR DESCRIPTION


<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR fixes the issue where in the presence of protocols with the same names, clicking the sort menu would change the order of the protocols. closes #10398

# Changelog

- Updated `useSortedProtocols` logic

# Review requests

- In `edge` upload a protocol and then re-upload it a few seconds later for a different date added timestamp. In the `Protocols` tab both protocols should have the same name. Click the sort menu and close it rapidly, you should notice the sort order for the protocols with the same names changes.
- Switch to this branch, perform the same action of click the sort menu on and off, you should NOT see changes in the sort order. The most recent of the protocols with the same names should show up first.

# Risk assessment

low