### PR TITLE
feat(step-generation, protocol-designer): add H-S timeline error when pipetting E-W with latch open

### DIFF
--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -124,6 +124,9 @@
       },
       "TALL_LABWARE_EAST_WEST_OF_HEATER_SHAKER": {
         "body": "The Heater-Shaker labware latch will collide with labware over 53 mm. Move labware to a different slot."
+      },
+      "HEATER_SHAKER_EAST_WEST_LATCH_OPEN": {
+        "body": "Pipettes cannot access labware on, or to the left or right of, the Heater-Shaker while the labware latch is open. Create a step before this one that closes the latch."
       }
     },
     "warning": {

--- a/step-generation/src/__tests__/moveToWell.test.ts
+++ b/step-generation/src/__tests__/moveToWell.test.ts
@@ -1,9 +1,11 @@
+import { when } from 'jest-when'
 import { expectTimelineError } from '../__utils__/testMatchers'
 import { moveToWell } from '../commandCreators/atomic/moveToWell'
 import {
   thermocyclerPipetteCollision,
   pipetteIntoHeaterShakerLatchOpen,
   pipetteIntoHeaterShakerWhileShaking,
+  getIsHeaterShakerEastWestWithLatchOpen,
 } from '../utils'
 import {
   getRobotStateWithTipStandard,
@@ -18,6 +20,8 @@ import type { InvariantContext, RobotState } from '../types'
 jest.mock('../utils/thermocyclerPipetteCollision')
 jest.mock('../utils/pipetteIntoHeaterShakerLatchOpen')
 jest.mock('../utils/pipetteIntoHeaterShakerWhileShaking')
+jest.mock('../utils/getIsHeaterShakerEastWestWithLatchOpen')
+
 const mockThermocyclerPipetteCollision = thermocyclerPipetteCollision as jest.MockedFunction<
   typeof thermocyclerPipetteCollision
 >
@@ -26,6 +30,9 @@ const mockPipetteIntoHeaterShakerLatchOpen = pipetteIntoHeaterShakerLatchOpen as
 >
 const mockPipetteIntoHeaterShakerWhileShaking = pipetteIntoHeaterShakerWhileShaking as jest.MockedFunction<
   typeof pipetteIntoHeaterShakerWhileShaking
+>
+const mockGetIsHeaterShakerEastWestWithLatchOpen = getIsHeaterShakerEastWestWithLatchOpen as jest.MockedFunction<
+  typeof getIsHeaterShakerEastWestWithLatchOpen
 >
 describe('moveToWell', () => {
   let robotStateWithTip: RobotState
@@ -297,6 +304,28 @@ describe('moveToWell', () => {
     })
     expect(getErrorResult(result).errors[1]).toMatchObject({
       type: 'HEATER_SHAKER_IS_SHAKING',
+    })
+  })
+  it('should return an error when moving to a well east/west of a heater shaker with its latch open', () => {
+    when(mockGetIsHeaterShakerEastWestWithLatchOpen)
+      .calledWith(
+        robotStateWithTip.modules,
+        robotStateWithTip.labware[SOURCE_LABWARE]
+      )
+      .mockReturnValue(true)
+
+    const result = moveToWell(
+      {
+        pipette: DEFAULT_PIPETTE,
+        labware: SOURCE_LABWARE,
+        well: 'A1',
+      },
+      invariantContext,
+      robotStateWithTip
+    )
+    expect(getErrorResult(result).errors).toHaveLength(1)
+    expect(getErrorResult(result).errors[0]).toMatchObject({
+      type: 'HEATER_SHAKER_EAST_WEST_LATCH_OPEN',
     })
   })
 })

--- a/step-generation/src/__tests__/utils.test.ts
+++ b/step-generation/src/__tests__/utils.test.ts
@@ -7,6 +7,7 @@ import {
   LabwareDefinition2,
   getIsLabwareAboveHeight,
   MAX_LABWARE_HEIGHT_EAST_WEST_HEATER_SHAKER_MM,
+  HEATERSHAKER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import {
   fixtureP10Single,
@@ -31,10 +32,15 @@ import {
 import { Diff, thermocyclerStateDiff } from '../utils/thermocyclerStateDiff'
 import { getIsTallLabwareEastWestOfHeaterShaker } from '../utils/getIsTallLabwareEastWestOfHeaterShaker'
 import { DEFAULT_CONFIG } from '../fixtures'
-import { orderWells, thermocyclerPipetteCollision } from '../utils'
+import {
+  getIsHeaterShakerEastWestWithLatchOpen,
+  orderWells,
+  thermocyclerPipetteCollision,
+} from '../utils'
 import type { RobotState } from '../'
 import type {
   LabwareEntities,
+  LabwareTemporalProperties,
   ThermocyclerModuleState,
   ThermocyclerStateStepArgs,
   WellOrderOption,
@@ -914,6 +920,50 @@ describe('getIsTallLabwareEastWestOfHeaterShaker', () => {
       .mockReturnValue(true)
     expect(
       getIsTallLabwareEastWestOfHeaterShaker(labwareState, labwareEntities, '1')
+    ).toBe(false)
+  })
+})
+describe('getIsHeaterShakerEastWestWithLatchOpen', () => {
+  let labwareTemporalProperties: LabwareTemporalProperties
+  let modules: RobotState['modules']
+  beforeEach(() => {
+    labwareTemporalProperties = { slot: '2' }
+    modules = {
+      heaterShakerId: {
+        slot: '1',
+        moduleState: {
+          type: HEATERSHAKER_MODULE_TYPE,
+          targetTemp: null,
+          targetSpeed: null,
+          latchOpen: true,
+        },
+      },
+    }
+  })
+  afterEach(() => {
+    resetAllWhenMocks()
+  })
+  it('should return true when there is heater shaker with its latch open next to the labware', () => {
+    expect(
+      getIsHeaterShakerEastWestWithLatchOpen(modules, labwareTemporalProperties)
+    ).toBe(true)
+  })
+  it('should return false when there is no heater shaker in the protocol', () => {
+    modules = {}
+    expect(
+      getIsHeaterShakerEastWestWithLatchOpen(modules, labwareTemporalProperties)
+    ).toBe(false)
+  })
+  it('should return false when the heater shaker is not next to the labware', () => {
+    modules.heaterShakerId.slot = '6'
+    expect(
+      getIsHeaterShakerEastWestWithLatchOpen(modules, labwareTemporalProperties)
+    ).toBe(false)
+  })
+  it('should return false when the heater shaker slot is closed', () => {
+    ;(modules.heaterShakerId.moduleState as any).latchOpen = false
+    expect(
+      getIsHeaterShakerEastWestWithLatchOpen(modules, labwareTemporalProperties)
     ).toBe(false)
   })
 })

--- a/step-generation/src/commandCreators/atomic/aspirate.ts
+++ b/step-generation/src/commandCreators/atomic/aspirate.ts
@@ -5,6 +5,7 @@ import {
   thermocyclerPipetteCollision,
   pipetteIntoHeaterShakerLatchOpen,
   pipetteIntoHeaterShakerWhileShaking,
+  getIsHeaterShakerEastWestWithLatchOpen,
 } from '../../utils'
 import type { CreateCommand } from '@opentrons/shared-data'
 import type { AspirateParams } from '@opentrons/shared-data/protocol/types/schemaV3'
@@ -89,6 +90,14 @@ export const aspirate: CommandCreator<AspirateParams> = (
     )
   ) {
     errors.push(errorCreators.heaterShakerIsShaking())
+  }
+  if (
+    getIsHeaterShakerEastWestWithLatchOpen(
+      prevRobotState.modules,
+      prevRobotState.labware[labware]
+    )
+  ) {
+    errors.push(errorCreators.heaterShakerEastWestWithLatchOpen())
   }
 
   if (errors.length === 0 && pipetteSpec && pipetteSpec.maxVolume < volume) {

--- a/step-generation/src/commandCreators/atomic/dispense.ts
+++ b/step-generation/src/commandCreators/atomic/dispense.ts
@@ -4,6 +4,7 @@ import {
   thermocyclerPipetteCollision,
   pipetteIntoHeaterShakerLatchOpen,
   pipetteIntoHeaterShakerWhileShaking,
+  getIsHeaterShakerEastWestWithLatchOpen,
 } from '../../utils'
 import type { CreateCommand } from '@opentrons/shared-data'
 import type { DispenseParams } from '@opentrons/shared-data/protocol/types/schemaV3'
@@ -78,6 +79,15 @@ export const dispense: CommandCreator<DispenseParams> = (
     )
   ) {
     errors.push(errorCreators.heaterShakerIsShaking())
+  }
+
+  if (
+    getIsHeaterShakerEastWestWithLatchOpen(
+      prevRobotState.modules,
+      prevRobotState.labware[labware]
+    )
+  ) {
+    errors.push(errorCreators.heaterShakerEastWestWithLatchOpen())
   }
 
   if (errors.length > 0) {

--- a/step-generation/src/commandCreators/atomic/moveToWell.ts
+++ b/step-generation/src/commandCreators/atomic/moveToWell.ts
@@ -4,6 +4,7 @@ import {
   thermocyclerPipetteCollision,
   pipetteIntoHeaterShakerLatchOpen,
   pipetteIntoHeaterShakerWhileShaking,
+  getIsHeaterShakerEastWestWithLatchOpen,
 } from '../../utils'
 import type { CreateCommand } from '@opentrons/shared-data'
 import type { MoveToWellParams as v5MoveToWellParams } from '@opentrons/shared-data/protocol/types/schemaV5'
@@ -80,6 +81,15 @@ export const moveToWell: CommandCreator<v5MoveToWellParams> = (
     )
   ) {
     errors.push(errorCreators.heaterShakerIsShaking())
+  }
+
+  if (
+    getIsHeaterShakerEastWestWithLatchOpen(
+      prevRobotState.modules,
+      prevRobotState.labware[labware]
+    )
+  ) {
+    errors.push(errorCreators.heaterShakerEastWestWithLatchOpen())
   }
 
   if (errors.length > 0) {

--- a/step-generation/src/errorCreators.ts
+++ b/step-generation/src/errorCreators.ts
@@ -142,3 +142,10 @@ export const tallLabwareEastWestOfHeaterShaker = (
     message: `Labware over 53 mm is ${position} of this Heater-Shaker module.`,
   }
 }
+
+export const heaterShakerEastWestWithLatchOpen = (): CommandCreatorError => {
+  return {
+    type: 'HEATER_SHAKER_EAST_WEST_LATCH_OPEN',
+    message: 'The Heater-Shaker labware latch is open',
+  }
+}

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -476,6 +476,7 @@ export type ErrorType =
   | 'HEATER_SHAKER_LATCH_OPEN'
   | 'HEATER_SHAKER_IS_SHAKING'
   | 'TALL_LABWARE_EAST_WEST_OF_HEATER_SHAKER'
+  | 'HEATER_SHAKER_EAST_WEST_LATCH_OPEN'
 
 export interface CommandCreatorError {
   message: string

--- a/step-generation/src/utils/getIsHeaterShakerEastWestWithLatchOpen.ts
+++ b/step-generation/src/utils/getIsHeaterShakerEastWestWithLatchOpen.ts
@@ -1,0 +1,21 @@
+import some from 'lodash/some'
+import {
+  getAreSlotsHorizontallyAdjacent,
+  HEATERSHAKER_MODULE_TYPE,
+} from '@opentrons/shared-data'
+import type { LabwareTemporalProperties, RobotState } from '../types'
+
+export const getIsHeaterShakerEastWestWithLatchOpen = (
+  hwModules: RobotState['modules'],
+  labwareTemporalProperties: LabwareTemporalProperties
+): boolean =>
+  some(
+    hwModules,
+    hwModule =>
+      hwModule.moduleState.type === HEATERSHAKER_MODULE_TYPE &&
+      hwModule.moduleState.latchOpen === true &&
+      getAreSlotsHorizontallyAdjacent(
+        hwModule.slot,
+        labwareTemporalProperties.slot
+      )
+  )

--- a/step-generation/src/utils/getIsTallLabwareEastWestOfHeaterShaker.ts
+++ b/step-generation/src/utils/getIsTallLabwareEastWestOfHeaterShaker.ts
@@ -1,22 +1,10 @@
 import some from 'lodash/some'
+import {
+  getAreSlotsHorizontallyAdjacent,
+  getIsLabwareAboveHeight,
+  MAX_LABWARE_HEIGHT_EAST_WEST_HEATER_SHAKER_MM,
+} from '@opentrons/shared-data'
 import type { LabwareEntities, RobotState } from '../types'
-import { getIsLabwareAboveHeight } from '@opentrons/shared-data'
-import { MAX_LABWARE_HEIGHT_EAST_WEST_HEATER_SHAKER_MM } from '../../../shared-data/js/constants'
-
-// this util only works for outter slots (where we can safely place modules in PD)
-const getSlotNextTo = (slot: string): string | null => {
-  const SLOT_ADJACENT_MAP: Record<string, string> = {
-    '1': '2',
-    '3': '2',
-    '4': '5',
-    '6': '5',
-    '7': '8',
-    '9': '8',
-    '10': '11',
-  }
-
-  return SLOT_ADJACENT_MAP[slot] ?? null
-}
 
 export const getIsTallLabwareEastWestOfHeaterShaker = (
   labwareState: RobotState['labware'],
@@ -26,7 +14,10 @@ export const getIsTallLabwareEastWestOfHeaterShaker = (
   const isTallLabwareEastWestOfHeaterShaker = some(
     labwareState,
     (labwareProperties, labwareId) =>
-      getSlotNextTo(heaterShakerSlot) === labwareProperties.slot &&
+      getAreSlotsHorizontallyAdjacent(
+        heaterShakerSlot,
+        labwareProperties.slot
+      ) &&
       getIsLabwareAboveHeight(
         labwareEntities[labwareId].def,
         MAX_LABWARE_HEIGHT_EAST_WEST_HEATER_SHAKER_MM

--- a/step-generation/src/utils/index.ts
+++ b/step-generation/src/utils/index.ts
@@ -7,6 +7,7 @@ import { pipetteIntoHeaterShakerLatchOpen } from './pipetteIntoHeaterShakerLatch
 import { pipetteIntoHeaterShakerWhileShaking } from './pipetteIntoHeaterShakerWhileShaking'
 import { orderWells } from './orderWells'
 import { getIsTallLabwareEastWestOfHeaterShaker } from './getIsTallLabwareEastWestOfHeaterShaker'
+import { getIsHeaterShakerEastWestWithLatchOpen } from './getIsHeaterShakerEastWestWithLatchOpen'
 export {
   commandCreatorsTimeline,
   curryCommandCreator,
@@ -17,6 +18,7 @@ export {
   pipetteIntoHeaterShakerLatchOpen,
   pipetteIntoHeaterShakerWhileShaking,
   getIsTallLabwareEastWestOfHeaterShaker,
+  getIsHeaterShakerEastWestWithLatchOpen,
 }
 export * from './commandCreatorArgsGetters'
 export * from './misc'


### PR DESCRIPTION
# Overview
This PR adds a check in basic pipetting command creators to trigger a timeline warning when pipetting E-W of the H-S when the labware latch is open

closes #10510

# Changelog

- Add H-S timeline error when pipetting E-W with latch open

# Review requests
Create a protocol with a H-S
Open the labware latch
Try to make a transfer step east/west of the H-S
You should see a timeline error that matches the ticket (#10510) in figma

# Risk assessment
Low
