### PR TITLE
fix(app): fix robot update banner

### DIFF
--- a/app/src/organisms/Devices/RobotCard.tsx
+++ b/app/src/organisms/Devices/RobotCard.tsx
@@ -57,7 +57,7 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
         id={`RobotCard_${name}_robotImage`}
       />
       <Box padding={SPACING.spacing3} width="100%">
-        <UpdateRobotBanner robotName={name} marginBottom={SPACING.spacing3} />
+        <UpdateRobotBanner robot={robot} marginBottom={SPACING.spacing3} />
         {robot.status !== UNREACHABLE ? (
           <RobotStatusBanner name={name} local={local} />
         ) : null}

--- a/app/src/organisms/Devices/RobotOverview.tsx
+++ b/app/src/organisms/Devices/RobotOverview.tsx
@@ -65,10 +65,9 @@ export function RobotOverview({
         id="RobotOverview_robotImage"
       />
       <Box padding={SPACING.spacing3} width="100%">
-        <UpdateRobotBanner
-          robotName={robot.name}
-          marginBottom={SPACING.spacing3}
-        />
+        {robot != null ? (
+          <UpdateRobotBanner robot={robot} marginBottom={SPACING.spacing3} />
+        ) : null}
         <RobotStatusBanner name={robot.name} local={robot.local} />
         <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
           <Flex

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/RobotServerVersion.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/RobotServerVersion.tsx
@@ -40,9 +40,9 @@ export function RobotServerVersion({
 
   return (
     <>
-      {autoUpdateAction !== 'reinstall' ? (
+      {autoUpdateAction !== 'reinstall' && robot != null ? (
         <Box marginBottom={SPACING.spacing4} width="100%">
-          <UpdateRobotBanner robotName={robotName} />
+          <UpdateRobotBanner robot={robot} />
         </Box>
       ) : (
         // TODO: add reinstall option

--- a/app/src/organisms/UpdateRobotBanner/__tests__/UpdateRobotBanner.test.tsx
+++ b/app/src/organisms/UpdateRobotBanner/__tests__/UpdateRobotBanner.test.tsx
@@ -3,17 +3,18 @@ import { renderWithProviders } from '@opentrons/components'
 import { fireEvent, screen } from '@testing-library/react'
 import { i18n } from '../../../i18n'
 import * as Buildroot from '../../../redux/buildroot'
-import { SoftwareUpdateModal } from '../../Devices/RobotSettings/AdvancedTab/SoftwareUpdateModal'
+import { mockConnectableRobot } from '../../../redux/discovery/__fixtures__'
+import { UpdateBuildroot } from '../../../pages/Robots/RobotSettings/UpdateBuildroot'
 import { UpdateRobotBanner } from '..'
 
-jest.mock('../../Devices/RobotSettings/AdvancedTab/SoftwareUpdateModal')
+jest.mock('../../../pages/Robots/RobotSettings/UpdateBuildroot')
 jest.mock('../../../redux/buildroot')
 
 const getBuildrootUpdateDisplayInfo = Buildroot.getBuildrootUpdateDisplayInfo as jest.MockedFunction<
   typeof Buildroot.getBuildrootUpdateDisplayInfo
 >
-const mockSoftwareUpdateModal = SoftwareUpdateModal as jest.MockedFunction<
-  typeof SoftwareUpdateModal
+const mockUpdateBuildroot = UpdateBuildroot as jest.MockedFunction<
+  typeof UpdateBuildroot
 >
 const render = (props: React.ComponentProps<typeof UpdateRobotBanner>) => {
   return renderWithProviders(<UpdateRobotBanner {...props} />, {
@@ -26,11 +27,9 @@ describe('UpdateRobotBanner', () => {
 
   beforeEach(() => {
     props = {
-      robotName: 'otie',
+      robot: mockConnectableRobot,
     }
-    mockSoftwareUpdateModal.mockReturnValue(
-      <div>mock software update modal</div>
-    )
+    mockUpdateBuildroot.mockReturnValue(<div>mockUpdateBuildroot</div>)
     getBuildrootUpdateDisplayInfo.mockReturnValue({
       autoUpdateAction: 'upgrade',
       autoUpdateDisabledReason: null,
@@ -47,7 +46,7 @@ describe('UpdateRobotBanner', () => {
     getByText('A software update is available for this robot.')
     const btn = getByRole('button', { name: 'View update' })
     fireEvent.click(btn)
-    getByText('mock software update modal')
+    getByText('mockUpdateBuildroot')
   })
 
   it('should render nothing if update is not available when autoUpdateAction returns reinstall', () => {

--- a/app/src/organisms/UpdateRobotBanner/__tests__/UpdateRobotBanner.test.tsx
+++ b/app/src/organisms/UpdateRobotBanner/__tests__/UpdateRobotBanner.test.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react'
+import { renderWithProviders } from '@opentrons/components'
+import { fireEvent, screen } from '@testing-library/react'
+import { i18n } from '../../../i18n'
+import * as Buildroot from '../../../redux/buildroot'
+import { SoftwareUpdateModal } from '../../Devices/RobotSettings/AdvancedTab/SoftwareUpdateModal'
+import { UpdateRobotBanner } from '..'
+
+jest.mock('../../Devices/RobotSettings/AdvancedTab/SoftwareUpdateModal')
+jest.mock('../../../redux/buildroot')
+
+const getBuildrootUpdateDisplayInfo = Buildroot.getBuildrootUpdateDisplayInfo as jest.MockedFunction<
+  typeof Buildroot.getBuildrootUpdateDisplayInfo
+>
+const mockSoftwareUpdateModal = SoftwareUpdateModal as jest.MockedFunction<
+  typeof SoftwareUpdateModal
+>
+const render = (props: React.ComponentProps<typeof UpdateRobotBanner>) => {
+  return renderWithProviders(<UpdateRobotBanner {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+describe('UpdateRobotBanner', () => {
+  let props: React.ComponentProps<typeof UpdateRobotBanner>
+
+  beforeEach(() => {
+    props = {
+      robotName: 'otie',
+    }
+    mockSoftwareUpdateModal.mockReturnValue(
+      <div>mock software update modal</div>
+    )
+    getBuildrootUpdateDisplayInfo.mockReturnValue({
+      autoUpdateAction: 'upgrade',
+      autoUpdateDisabledReason: null,
+      updateFromFileDisabledReason: null,
+    })
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should display correct information', () => {
+    const { getByText, getByRole } = render(props)
+    getByText('A software update is available for this robot.')
+    const btn = getByRole('button', { name: 'View update' })
+    fireEvent.click(btn)
+    getByText('mock software update modal')
+  })
+
+  it('should render nothing if update is not available when autoUpdateAction returns reinstall', () => {
+    getBuildrootUpdateDisplayInfo.mockReturnValue({
+      autoUpdateAction: 'reinstall',
+      autoUpdateDisabledReason: null,
+      updateFromFileDisabledReason: null,
+    })
+    const bannerText = screen.queryByText(
+      'A software update is available for this robot.'
+    )
+    expect(bannerText).toBeNull()
+  })
+
+  it('should render nothing if update is not available when autoUpdateAction returns downgrade', () => {
+    getBuildrootUpdateDisplayInfo.mockReturnValue({
+      autoUpdateAction: 'downgrade',
+      autoUpdateDisabledReason: null,
+      updateFromFileDisabledReason: null,
+    })
+    const bannerText = screen.queryByText(
+      'A software update is available for this robot.'
+    )
+    expect(bannerText).toBeNull()
+  })
+})

--- a/app/src/organisms/UpdateRobotBanner/__tests__/UpdateRobotBanner.test.tsx
+++ b/app/src/organisms/UpdateRobotBanner/__tests__/UpdateRobotBanner.test.tsx
@@ -68,9 +68,7 @@ describe('UpdateRobotBanner', () => {
       autoUpdateDisabledReason: null,
       updateFromFileDisabledReason: null,
     })
-    const bannerText = screen.queryByText(
-      'A software update is available for this robot.'
-    )
-    expect(bannerText).toBeNull()
+    const { getByText } = render(props)
+    getByText('A software update is available for this robot.')
   })
 })

--- a/app/src/organisms/UpdateRobotBanner/index.tsx
+++ b/app/src/organisms/UpdateRobotBanner/index.tsx
@@ -34,7 +34,12 @@ export function UpdateRobotBanner(props: UpdateRobotBannerProps): JSX.Element {
   ] = React.useState<boolean>(false)
 
   // check for available updates
-  useInterval(checkAppUpdate, UPDATE_RECHECK_DELAY_MS)
+  useInterval(
+    checkAppUpdate,
+    autoUpdateAction === 'upgrade' || autoUpdateAction === 'downgrade'
+      ? 1000
+      : UPDATE_RECHECK_DELAY_MS
+  )
 
   const handleLaunchModal: React.MouseEventHandler = e => {
     e.preventDefault()
@@ -48,7 +53,7 @@ export function UpdateRobotBanner(props: UpdateRobotBannerProps): JSX.Element {
 
   return (
     <>
-      {autoUpdateAction === 'upgrade' ? (
+      {autoUpdateAction === 'upgrade' || autoUpdateAction === 'downgrade' ? (
         <Banner type="warning" onCloseClick={handleCloseBanner} {...styleProps}>
           <StyledText as="p" marginRight={SPACING.spacing2}>
             {t('robot_server_versions_banner_title')}

--- a/app/src/organisms/UpdateRobotBanner/index.tsx
+++ b/app/src/organisms/UpdateRobotBanner/index.tsx
@@ -5,28 +5,30 @@ import { SPACING, TYPOGRAPHY, Btn, useInterval } from '@opentrons/components'
 import { Portal } from '../../App/portal'
 import { StyledText } from '../../atoms/text'
 import { Banner } from '../../atoms/Banner'
+import { UpdateBuildroot } from '../../pages/Robots/RobotSettings/UpdateBuildroot'
+import { UNREACHABLE } from '../../redux/discovery'
 import { checkShellUpdate } from '../../redux/shell'
 import { getBuildrootUpdateDisplayInfo } from '../../redux/buildroot'
-import { SoftwareUpdateModal } from '../Devices/RobotSettings/AdvancedTab/SoftwareUpdateModal'
 
 import type { StyleProps } from '@opentrons/components'
 import type { State, Dispatch } from '../../redux/types'
+import type { DiscoveredRobot } from '../../redux/discovery/types'
 
 interface UpdateRobotBannerProps extends StyleProps {
-  robotName: string
+  robot: DiscoveredRobot
 }
 
 const UPDATE_RECHECK_DELAY_MS = 60000
 
 export function UpdateRobotBanner(props: UpdateRobotBannerProps): JSX.Element {
-  const { robotName, ...styleProps } = props
+  const { robot, ...styleProps } = props
   const { t } = useTranslation('device_settings')
   const dispatch = useDispatch<Dispatch>()
   const checkAppUpdate = React.useCallback(() => dispatch(checkShellUpdate()), [
     dispatch,
   ])
   const { autoUpdateAction } = useSelector((state: State) => {
-    return getBuildrootUpdateDisplayInfo(state, robotName)
+    return getBuildrootUpdateDisplayInfo(state, robot.name)
   })
   const [
     showSoftwareUpdateModal,
@@ -67,11 +69,13 @@ export function UpdateRobotBanner(props: UpdateRobotBannerProps): JSX.Element {
           </Btn>
         </Banner>
       ) : null}
-      {showSoftwareUpdateModal ? (
+      {showSoftwareUpdateModal &&
+      robot != null &&
+      robot.status !== UNREACHABLE ? (
         <Portal level="top">
-          <SoftwareUpdateModal
-            robotName={robotName}
-            closeModal={() => setShowSoftwareUpdateModal(false)}
+          <UpdateBuildroot
+            robot={robot}
+            close={() => setShowSoftwareUpdateModal(false)}
           />
         </Portal>
       ) : null}

--- a/app/src/organisms/UpdateRobotBanner/index.tsx
+++ b/app/src/organisms/UpdateRobotBanner/index.tsx
@@ -28,9 +28,6 @@ export function UpdateRobotBanner(props: UpdateRobotBannerProps): JSX.Element {
   const { autoUpdateAction } = useSelector((state: State) => {
     return getBuildrootUpdateDisplayInfo(state, robotName)
   })
-  const [showUpdateBanner, setShowUpdateBanner] = React.useState<boolean>(
-    ['upgrade', 'downgrade'].includes(autoUpdateAction)
-  )
   const [
     showSoftwareUpdateModal,
     setShowSoftwareUpdateModal,
@@ -47,12 +44,11 @@ export function UpdateRobotBanner(props: UpdateRobotBannerProps): JSX.Element {
   const handleCloseBanner: React.MouseEventHandler = e => {
     e.preventDefault()
     e.stopPropagation()
-    setShowUpdateBanner(false)
   }
 
   return (
     <>
-      {showUpdateBanner ? (
+      {autoUpdateAction === 'upgrade' ? (
         <Banner type="warning" onCloseClick={handleCloseBanner} {...styleProps}>
           <StyledText as="p" marginRight={SPACING.spacing2}>
             {t('robot_server_versions_banner_title')}


### PR DESCRIPTION
closes #10041

# Overview

this PR fixes the bug where the robot update banner persists even after the robot has been updated. 

# Changelog

- edit logic in `UpdateRobotBanner` and create test

# Review requests

- if your robot needs to be updated, update it. After its complete, the banner should disappear. 

# Risk assessment

low