### PR TITLE
fix(can): ensure that the pcan parameters match new values for 500KHz bit timing

### DIFF
--- a/hardware/opentrons_hardware/drivers/can_bus/build.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/build.py
@@ -26,6 +26,8 @@ async def build_driver(driver_settings: settings.DriverSettings) -> AbstractCanD
             interface=driver_settings.interface,
             bitrate=driver_settings.bit_rate,
             channel=driver_settings.channel,
+            fcan_clock=driver_settings.fcan_clock,
+            sample_rate=driver_settings.sample_rate,
         )
 
 

--- a/hardware/opentrons_hardware/drivers/can_bus/driver.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/driver.py
@@ -73,10 +73,10 @@ class CanDriver(AbstractCanDriver):
             # Special FDCAN parameters for use of PCAN driver.
             extra_kwargs = {
                 "f_clock_mhz": 20,
-                "nom_brp": 5,
-                "nom_tseg1": 13,
-                "nom_tseg2": 2,
-                "nom_sjw": 16,
+                "nom_brp": 2,
+                "nom_tseg1": 15,
+                "nom_tseg2": 4,
+                "nom_sjw": 1,
             }
         return CanDriver(
             bus=Bus(

--- a/hardware/opentrons_hardware/drivers/can_bus/driver.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/driver.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import asyncio
 import platform
-from typing import Optional
+from typing import Optional, Union, Dict, Any
 
 from can import Notifier, Bus, AsyncBufferedReader, Message
 
@@ -11,6 +11,7 @@ from opentrons_hardware.firmware_bindings.arbitration_id import ArbitrationId
 from opentrons_hardware.firmware_bindings.message import CanMessage
 from .errors import ErrorFrameCanError
 from .abstract_driver import AbstractCanDriver
+from .settings import calculate_fdcan_parameters, PCANParameters
 
 log = logging.getLogger(__name__)
 
@@ -55,6 +56,8 @@ class CanDriver(AbstractCanDriver):
         interface: str,
         channel: Optional[str] = None,
         bitrate: Optional[int] = None,
+        fcan_clock: Optional[int] = None,
+        sample_rate: Optional[float] = None,
     ) -> CanDriver:
         """Build a CanDriver.
 
@@ -63,21 +66,18 @@ class CanDriver(AbstractCanDriver):
             interface: The interface for pycan to use.
                 see https://python-can.readthedocs.io/en/master/interfaces.html
             channel: Optional channel
+            fcan_clock: The clock used by the can analyzer, defaults to 20MHz
+            sample_rate: The sample rate in which to sample the data, defaults to 87.5
 
         Returns:
             A CanDriver instance.
         """
         log.info(f"CAN connect: {interface}-{channel}-{bitrate}")
-        extra_kwargs = {}
+        extra_kwargs: Union[PCANParameters, Dict[Any, Any]] = {}
         if interface == "pcan":
             # Special FDCAN parameters for use of PCAN driver.
-            extra_kwargs = {
-                "f_clock_mhz": 20,
-                "nom_brp": 2,
-                "nom_tseg1": 15,
-                "nom_tseg2": 4,
-                "nom_sjw": 1,
-            }
+            extra_kwargs = calculate_fdcan_parameters(fcan_clock, bitrate, sample_rate)
+
         return CanDriver(
             bus=Bus(
                 channel=channel,

--- a/hardware/opentrons_hardware/drivers/can_bus/driver.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/driver.py
@@ -58,6 +58,7 @@ class CanDriver(AbstractCanDriver):
         bitrate: Optional[int] = None,
         fcan_clock: Optional[int] = None,
         sample_rate: Optional[float] = None,
+        jump_width: Optional[int] = None,
     ) -> CanDriver:
         """Build a CanDriver.
 
@@ -68,6 +69,7 @@ class CanDriver(AbstractCanDriver):
             channel: Optional channel
             fcan_clock: The clock used by the can analyzer, defaults to 20MHz
             sample_rate: The sample rate in which to sample the data, defaults to 87.5
+            jump_width: The max time the sampling period can be lengthened or shortened
 
         Returns:
             A CanDriver instance.
@@ -76,7 +78,9 @@ class CanDriver(AbstractCanDriver):
         extra_kwargs: Union[PCANParameters, Dict[Any, Any]] = {}
         if interface == "pcan":
             # Special FDCAN parameters for use of PCAN driver.
-            extra_kwargs = calculate_fdcan_parameters(fcan_clock, bitrate, sample_rate)
+            extra_kwargs = calculate_fdcan_parameters(
+                fcan_clock, bitrate, sample_rate, jump_width
+            )
 
         return CanDriver(
             bus=Bus(

--- a/hardware/opentrons_hardware/drivers/can_bus/settings.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/settings.py
@@ -1,10 +1,19 @@
 """Driver settings."""
-from typing_extensions import Final
+from typing_extensions import Final, TypedDict
+from typing import Optional
 from pydantic import BaseSettings, Field
+
+from math import floor
 
 DEFAULT_INTERFACE: Final = "socketcan"
 
-DEFAULT_BITRATE: Final = 500000
+DEFAULT_BITRATE: Final[int] = 500000
+
+DEFAULT_FDCAN_CLK: Final[int] = 20  # 20 MHZ
+MINIMUM_FDCAN_CLK: Final[int] = 10
+DEFAULT_SAMPLE_RATE: Final[float] = 87.5
+DEFAULT_JUMP_WIDTH_SEG: Final[int] = 1
+
 
 DEFAULT_CHANNEL: Final = "can0"
 
@@ -13,6 +22,16 @@ DEFAULT_HOST: Final = "localhost"
 DEFAULT_PORT: Final = 9898
 
 OPENTRONS_INTERFACE: Final = "opentrons_sock"
+
+
+class PCANParameters(TypedDict):
+    """FDCan parameters for PCAN."""
+
+    f_clock_mhz: int
+    nom_brp: int
+    nom_tseg1: int
+    nom_tseg2: int
+    nom_sjw: int
 
 
 class DriverSettings(BaseSettings):
@@ -31,6 +50,48 @@ class DriverSettings(BaseSettings):
 
     host: str = Field(DEFAULT_HOST, description=f"{OPENTRONS_INTERFACE} only.")
     port: int = Field(DEFAULT_PORT, description=f"{OPENTRONS_INTERFACE} only.")
+    fcan_clock: int = Field(DEFAULT_FDCAN_CLK, description="pcan only.")
+    sample_rate: float = Field(DEFAULT_SAMPLE_RATE, description="pcan only.")
 
     class Config:  # noqa: D106
         env_prefix = "OT3_CAN_DRIVER_"
+
+
+def calculate_fdcan_parameters(
+    fcan_clock: Optional[int], bitrate: Optional[int], sample_rate: Optional[float]
+) -> PCANParameters:
+    """Calculate FDCAN Timing Parameters.
+
+    Args:
+        fcan_clock: The clock used by the analyzer
+        bitrate: The bitrate of data transfer
+        sample_rate: When to sample the data.
+
+
+    """
+    if not fcan_clock:
+        fcan_clock = DEFAULT_FDCAN_CLK
+    if not bitrate:
+        bitrate = DEFAULT_BITRATE
+    if not sample_rate:
+        sample_rate = DEFAULT_SAMPLE_RATE
+
+    sample_rate_percent = sample_rate / 100
+    bit_time = 1 / bitrate  # us units
+    time_quanta_ns = 1 / fcan_clock
+    time_quanta_unitless = bit_time / time_quanta_ns
+
+    # Given a sample rate, we can say that
+    # (jump_width_seg + TSEG1)/(jump_width_seg + TSEG1 + TSEG2) = sample_rate
+    # and also that (jump_width_seg + TSEG1 + TSEG2) = unitless_time_quanta (tq)
+    tseg_1 = (sample_rate_percent * time_quanta_unitless) - DEFAULT_JUMP_WIDTH_SEG
+    tseg_2 = time_quanta_unitless - DEFAULT_JUMP_WIDTH_SEG - tseg_1
+    brp = fcan_clock // MINIMUM_FDCAN_CLK  # clock prescaler (unitless)
+
+    return PCANParameters(
+        f_clock_mhz=fcan_clock,
+        nom_brp=brp,
+        nom_tseg1=floor(tseg_1),
+        nom_tseg2=floor(tseg_2),
+        nom_sjw=DEFAULT_JUMP_WIDTH_SEG,
+    )

--- a/hardware/opentrons_hardware/drivers/can_bus/settings.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/settings.py
@@ -9,10 +9,18 @@ DEFAULT_INTERFACE: Final = "socketcan"
 
 DEFAULT_BITRATE: Final[int] = 500000
 
-DEFAULT_FDCAN_CLK: Final[int] = 20  # 20 MHZ
-MINIMUM_FDCAN_CLK: Final[int] = 10
-DEFAULT_SAMPLE_RATE: Final[float] = 87.5
+DEFAULT_FDCAN_CLK: Final[int] = 20  # MHz
+DEFAULT_SAMPLE_RATE: Final[float] = 80
 DEFAULT_JUMP_WIDTH_SEG: Final[int] = 1
+SYNC_QUANTUM: Final[int] = 1
+TIME_QUANTUM_DURATION_NS: Final[int] = 100
+SECOND_TO_MICROSECOND: Final[int] = 1000000
+
+MAX_FCAN_CLK: Final[int] = 80  # MHz
+MAX_BRP: Final[int] = 1024
+MAX_SJW: Final[int] = 128
+MAX_TSEG1: Final[int] = 256
+MAX_TSEG2: Final[int] = 128
 
 
 DEFAULT_CHANNEL: Final = "can0"
@@ -22,6 +30,8 @@ DEFAULT_HOST: Final = "localhost"
 DEFAULT_PORT: Final = 9898
 
 OPENTRONS_INTERFACE: Final = "opentrons_sock"
+
+US_TO_NS: Final = 1000
 
 
 class PCANParameters(TypedDict):
@@ -52,13 +62,30 @@ class DriverSettings(BaseSettings):
     port: int = Field(DEFAULT_PORT, description=f"{OPENTRONS_INTERFACE} only.")
     fcan_clock: int = Field(DEFAULT_FDCAN_CLK, description="pcan only.")
     sample_rate: float = Field(DEFAULT_SAMPLE_RATE, description="pcan only.")
+    jump_width: int = Field(DEFAULT_JUMP_WIDTH_SEG, descript="pcan only.")
 
     class Config:  # noqa: D106
         env_prefix = "OT3_CAN_DRIVER_"
 
 
+def _check_calculated_bit_timing_values(
+    brp: float, tseg_1: float, tseg_2: float
+) -> None:
+    if not brp.is_integer():
+        raise ValueError(f"BRP is {brp} and must be an integer")
+    if brp > MAX_BRP:
+        raise ValueError(f"Calculated BRP {brp} exceeds max value {MAX_BRP}")
+    if tseg_1 > MAX_TSEG1:
+        raise ValueError(f"Calculated TSEG1 {tseg_1} exceeds max value {MAX_TSEG1}")
+    if tseg_2 > MAX_TSEG2:
+        raise ValueError(f"Calculated TSEG2 {tseg_2} exceeds max value {MAX_TSEG2}")
+
+
 def calculate_fdcan_parameters(
-    fcan_clock: Optional[int], bitrate: Optional[int], sample_rate: Optional[float]
+    fcan_clock: Optional[int],
+    bitrate: Optional[int],
+    sample_rate: Optional[float],
+    jump_width: Optional[int],
 ) -> PCANParameters:
     """Calculate FDCAN Timing Parameters.
 
@@ -66,6 +93,7 @@ def calculate_fdcan_parameters(
         fcan_clock: The clock used by the analyzer
         bitrate: The bitrate of data transfer
         sample_rate: When to sample the data.
+        jump_width: The max time the sampling period can be lengthened or shortened
 
 
     """
@@ -75,23 +103,37 @@ def calculate_fdcan_parameters(
         bitrate = DEFAULT_BITRATE
     if not sample_rate:
         sample_rate = DEFAULT_SAMPLE_RATE
+    if not jump_width:
+        jump_width = DEFAULT_JUMP_WIDTH_SEG
+
+    if fcan_clock > MAX_FCAN_CLK:
+        raise ValueError(
+            f"Clock value {fcan_clock} exceeds max value of {MAX_FCAN_CLK}"
+        )
+    if jump_width > MAX_SJW:
+        raise ValueError(
+            f"Jump width value {jump_width} exceeds max value of {MAX_SJW}"
+        )
 
     sample_rate_percent = sample_rate / 100
-    bit_time = 1 / bitrate  # us units
-    time_quanta_ns = 1 / fcan_clock
-    time_quanta_unitless = bit_time / time_quanta_ns
+    bit_time_us = (1 / bitrate) * SECOND_TO_MICROSECOND
+    time_quantum_us = 1 / fcan_clock
+    time_quanta_count = (bit_time_us * US_TO_NS) // TIME_QUANTUM_DURATION_NS
 
     # Given a sample rate, we can say that
-    # (jump_width_seg + TSEG1)/(jump_width_seg + TSEG1 + TSEG2) = sample_rate
-    # and also that (jump_width_seg + TSEG1 + TSEG2) = unitless_time_quanta (tq)
-    tseg_1 = (sample_rate_percent * time_quanta_unitless) - DEFAULT_JUMP_WIDTH_SEG
-    tseg_2 = time_quanta_unitless - DEFAULT_JUMP_WIDTH_SEG - tseg_1
-    brp = fcan_clock // MINIMUM_FDCAN_CLK  # clock prescaler (unitless)
+    # (sync_quantum + TSEG1)/(sync_quantum + TSEG1 + TSEG2) = sample_rate
+    # and also that (sync_quantum + TSEG1 + TSEG2) = time_quanta_count (tq)
+    tseg_1 = (sample_rate_percent * time_quanta_count) - SYNC_QUANTUM
+    tseg_2 = time_quanta_count - SYNC_QUANTUM - tseg_1
+    brp = TIME_QUANTUM_DURATION_NS / (
+        time_quantum_us * US_TO_NS
+    )  # clock prescaler (unitless)
+    _check_calculated_bit_timing_values(brp, tseg_1, tseg_2)
 
     return PCANParameters(
         f_clock_mhz=fcan_clock,
-        nom_brp=brp,
+        nom_brp=int(brp),
         nom_tseg1=floor(tseg_1),
         nom_tseg2=floor(tseg_2),
-        nom_sjw=DEFAULT_JUMP_WIDTH_SEG,
+        nom_sjw=jump_width,
     )

--- a/hardware/opentrons_hardware/scripts/can_args.py
+++ b/hardware/opentrons_hardware/scripts/can_args.py
@@ -49,6 +49,20 @@ def add_can_args(parser: ArgumentParser) -> ArgumentParser:
         required=False,
         help=f"host to connect to for {settings.OPENTRONS_INTERFACE} interface",
     )
+    parser.add_argument(
+        "--fcan_clk",
+        type=int,
+        default=settings.DEFAULT_FDCAN_CLK,
+        required=False,
+        help="Clock (MHz) for can analyzer, only for pcan interface",
+    )
+    parser.add_argument(
+        "--sample_rate",
+        type=float,
+        default=settings.DEFAULT_SAMPLE_RATE,
+        required=False,
+        help="Sample rate for can analyzer, only for pcan interface",
+    )
     return parser
 
 

--- a/hardware/opentrons_hardware/scripts/can_args.py
+++ b/hardware/opentrons_hardware/scripts/can_args.py
@@ -63,6 +63,13 @@ def add_can_args(parser: ArgumentParser) -> ArgumentParser:
         required=False,
         help="Sample rate for can analyzer, only for pcan interface",
     )
+    parser.add_argument(
+        "--jump_width",
+        type=int,
+        default=settings.DEFAULT_JUMP_WIDTH_SEG,
+        required=False,
+        help="Jump width seg for can analyzer, only for pcan interface",
+    )
     return parser
 
 

--- a/hardware/tests/opentrons_hardware/drivers/can_bus/test_settings.py
+++ b/hardware/tests/opentrons_hardware/drivers/can_bus/test_settings.py
@@ -1,0 +1,100 @@
+"""Tests for pcan bit timing calculations."""
+import pytest
+
+from typing import Optional
+from opentrons_hardware.drivers.can_bus import settings
+
+
+@pytest.mark.parametrize(
+    argnames=["fcan_clock", "bitrate", "sample_rate", "jump_width", "expected"],
+    argvalues=[
+        [
+            None,
+            None,
+            None,
+            None,
+            settings.PCANParameters(
+                f_clock_mhz=20, nom_brp=2, nom_tseg1=15, nom_tseg2=4, nom_sjw=1
+            ),
+        ],
+        [
+            40,
+            250000,
+            None,
+            None,
+            settings.PCANParameters(
+                f_clock_mhz=40, nom_brp=4, nom_tseg1=31, nom_tseg2=8, nom_sjw=1
+            ),
+        ],
+        [
+            None,
+            None,
+            87.5,
+            None,
+            settings.PCANParameters(
+                f_clock_mhz=20, nom_brp=2, nom_tseg1=16, nom_tseg2=2, nom_sjw=1
+            ),
+        ],
+        [
+            60,
+            None,
+            None,
+            4,
+            settings.PCANParameters(
+                f_clock_mhz=60, nom_brp=6, nom_tseg1=15, nom_tseg2=4, nom_sjw=4
+            ),
+        ],
+    ],
+)
+def test_valid_calculate_bit_timings(
+    fcan_clock: Optional[int],
+    bitrate: Optional[int],
+    sample_rate: Optional[float],
+    jump_width: Optional[int],
+    expected: settings.PCANParameters,
+) -> None:
+    """Test valid bit timing calculations."""
+    result = settings.calculate_fdcan_parameters(
+        fcan_clock, bitrate, sample_rate, jump_width
+    )
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    argnames=["fcan_clock", "bitrate", "sample_rate", "jump_width", "match_str"],
+    argvalues=[
+        [
+            90,
+            None,
+            None,
+            None,
+            "Clock value 90 exceeds max value of 80",
+        ],
+        [
+            None,
+            None,
+            None,
+            130,
+            "Jump width value 130 exceeds max value of 128",
+        ],
+        [
+            80,
+            10000,
+            None,
+            None,
+            "Calculated TSEG1 799.0 exceeds max value 256",
+        ],
+    ],
+)
+def test_invalid_calculate_bit_timings(
+    fcan_clock: Optional[int],
+    bitrate: Optional[int],
+    sample_rate: Optional[float],
+    jump_width: Optional[int],
+    match_str: str,
+) -> None:
+    """Test invalid bit timing calculations."""
+    with pytest.raises(ValueError, match=match_str):
+        settings.calculate_fdcan_parameters(
+            fcan_clock, bitrate, sample_rate, jump_width
+        )


### PR DESCRIPTION
# Overview

The parameters used to generate the correct timings for CAN have changed. They need to be updated in the python can driver as well.

# Changelog

- Change fd can parameters used in pcan

# Risk assessment

Low.