### PR TITLE
feat(step-generation, protocol-designer): generate error when pipetting NSEW of HS while shaking

### DIFF
--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -127,6 +127,10 @@
       },
       "HEATER_SHAKER_EAST_WEST_LATCH_OPEN": {
         "body": "Pipettes cannot access labware on, or to the left or right of, the Heater-Shaker while the labware latch is open. Create a step before this one that closes the latch."
+      },
+      "HEATER_SHAKER_NORTH_SOUTH_EAST_WEST_SHAKING": {
+        "title": "The Heater-Shaker is shaking",
+        "body": "Pipettes cannot access labware on or adjacent to the Heater-Shaker while it is shaking. Create a step before this one that deactivates the shaker."
       }
     },
     "warning": {

--- a/shared-data/js/__tests__/getAreSlotsAdjacent.test.ts
+++ b/shared-data/js/__tests__/getAreSlotsAdjacent.test.ts
@@ -1,6 +1,10 @@
-import { getAreSlotsHorizontallyAdjacent } from '../helpers'
+import {
+  getAreSlotsAdjacent,
+  getAreSlotsHorizontallyAdjacent,
+  getAreSlotsVerticallyAdjacent,
+} from '../helpers'
 
-describe('getAreSlotsAdjacent', () => {
+describe('getAreSlotsHorizontallyAdjacent', () => {
   it('should return false if a slots are falsey', () => {
     expect(getAreSlotsHorizontallyAdjacent(null, null)).toBe(false)
     expect(getAreSlotsHorizontallyAdjacent()).toBe(false)
@@ -36,5 +40,89 @@ describe('getAreSlotsAdjacent', () => {
     expect(getAreSlotsHorizontallyAdjacent('8', '9')).toBe(true)
     expect(getAreSlotsHorizontallyAdjacent('8', '9')).toBe(true)
     expect(getAreSlotsHorizontallyAdjacent('10', '11')).toBe(true)
+  })
+})
+describe('getAreSlotsVerticallyAdjacent', () => {
+  it('should return false if a slots are falsey', () => {
+    expect(getAreSlotsVerticallyAdjacent(null, null)).toBe(false)
+    expect(getAreSlotsVerticallyAdjacent()).toBe(false)
+    expect(getAreSlotsVerticallyAdjacent('1')).toBe(false)
+    expect(getAreSlotsVerticallyAdjacent(null, '1')).toBe(false)
+    expect(getAreSlotsVerticallyAdjacent('1', null)).toBe(false)
+  })
+  it('should return false if called with a non numerical slot', () => {
+    expect(getAreSlotsVerticallyAdjacent('1', 'not a numerical slot')).toBe(
+      false
+    )
+  })
+  it('should return false if called with a slot that is larger than the number of slots in the deck def', () => {
+    expect(getAreSlotsVerticallyAdjacent('1', '12')).toBe(false) // trash slot does not count
+    expect(getAreSlotsVerticallyAdjacent('1', '13')).toBe(false)
+  })
+  it('should return false if the slots horizontally adjacent', () => {
+    expect(getAreSlotsVerticallyAdjacent('1', '2')).toBe(false)
+    expect(getAreSlotsVerticallyAdjacent('2', '3')).toBe(false)
+    expect(getAreSlotsVerticallyAdjacent('4', '5')).toBe(false)
+  })
+  it('should return false if slots are vetical but separated by a slot', () => {
+    expect(getAreSlotsVerticallyAdjacent('1', '7')).toBe(false)
+    expect(getAreSlotsVerticallyAdjacent('2', '8')).toBe(false)
+    expect(getAreSlotsVerticallyAdjacent('3', '9')).toBe(false)
+  })
+  it('should return true if the slots vertically adjacent', () => {
+    expect(getAreSlotsVerticallyAdjacent('1', '4')).toBe(true)
+    expect(getAreSlotsVerticallyAdjacent('2', '5')).toBe(true)
+    expect(getAreSlotsVerticallyAdjacent('3', '6')).toBe(true)
+    expect(getAreSlotsVerticallyAdjacent('4', '7')).toBe(true)
+    expect(getAreSlotsVerticallyAdjacent('5', '8')).toBe(true)
+    expect(getAreSlotsVerticallyAdjacent('6', '9')).toBe(true)
+    expect(getAreSlotsVerticallyAdjacent('7', '10')).toBe(true)
+    expect(getAreSlotsVerticallyAdjacent('8', '11')).toBe(true)
+  })
+})
+describe('getAreSlotsAdjacent', () => {
+  it('should return false if a slots are falsey', () => {
+    expect(getAreSlotsAdjacent(null, null)).toBe(false)
+    expect(getAreSlotsAdjacent()).toBe(false)
+    expect(getAreSlotsAdjacent('1')).toBe(false)
+    expect(getAreSlotsAdjacent(null, '1')).toBe(false)
+    expect(getAreSlotsAdjacent('1', null)).toBe(false)
+  })
+  it('should return false if called with a non numerical slot', () => {
+    expect(getAreSlotsAdjacent('1', 'not a numerical slot')).toBe(false)
+  })
+  it('should return false if called with a slot that is larger than the number of slots in the deck def', () => {
+    expect(getAreSlotsAdjacent('1', '12')).toBe(false) // trash slot does not count
+    expect(getAreSlotsAdjacent('1', '13')).toBe(false)
+  })
+  it('should return false if slots are horizontal but separated by a slot', () => {
+    expect(getAreSlotsHorizontallyAdjacent('1', '3')).toBe(false)
+    expect(getAreSlotsHorizontallyAdjacent('4', '6')).toBe(false)
+    expect(getAreSlotsHorizontallyAdjacent('7', '9')).toBe(false)
+  })
+  it('should return false if slots are vetical but separated by a slot', () => {
+    expect(getAreSlotsAdjacent('1', '7')).toBe(false)
+    expect(getAreSlotsAdjacent('2', '8')).toBe(false)
+    expect(getAreSlotsAdjacent('3', '9')).toBe(false)
+  })
+  it('should return true if the slots adjacent', () => {
+    // horizontally
+    expect(getAreSlotsHorizontallyAdjacent('1', '2')).toBe(true)
+    expect(getAreSlotsHorizontallyAdjacent('2', '3')).toBe(true)
+    expect(getAreSlotsHorizontallyAdjacent('4', '5')).toBe(true)
+    expect(getAreSlotsHorizontallyAdjacent('5', '6')).toBe(true)
+    expect(getAreSlotsHorizontallyAdjacent('7', '8')).toBe(true)
+    expect(getAreSlotsHorizontallyAdjacent('8', '9')).toBe(true)
+    expect(getAreSlotsHorizontallyAdjacent('8', '9')).toBe(true)
+    expect(getAreSlotsHorizontallyAdjacent('10', '11')).toBe(true)
+    // vertically
+    expect(getAreSlotsAdjacent('1', '4')).toBe(true)
+    expect(getAreSlotsAdjacent('2', '5')).toBe(true)
+    expect(getAreSlotsAdjacent('3', '6')).toBe(true)
+    expect(getAreSlotsAdjacent('4', '7')).toBe(true)
+    expect(getAreSlotsAdjacent('5', '8')).toBe(true)
+    expect(getAreSlotsAdjacent('6', '9')).toBe(true)
+    expect(getAreSlotsAdjacent('7', '10')).toBe(true)
+    expect(getAreSlotsAdjacent('8', '11')).toBe(true)
   })
 })

--- a/shared-data/js/helpers/index.ts
+++ b/shared-data/js/helpers/index.ts
@@ -217,12 +217,55 @@ export const getAreSlotsHorizontallyAdjacent = (
   const xPositionSlotA = slotAPosition[0]
   const xPositionSlotB = slotBPosition[0]
 
-  const areSlotsAdjacent =
+  const areSlotsHorizontallyAdjacent =
     yPositionSlotA === yPositionSlotB &&
     Math.abs(xPositionSlotA - xPositionSlotB) === slotWidth
 
-  return areSlotsAdjacent
+  return areSlotsHorizontallyAdjacent
 }
+export const getAreSlotsVerticallyAdjacent = (
+  slotNameA?: string | null,
+  slotNameB?: string | null
+): boolean => {
+  if (slotNameA == null || slotNameB == null) {
+    return false
+  }
+  const slotANumber = parseInt(slotNameA)
+  const slotBNumber = parseInt(slotNameB)
+
+  if (isNaN(slotBNumber) || isNaN(slotANumber)) {
+    return false
+  }
+  const orderedSlots = standardDeckDef.locations.orderedSlots
+  // intentionally not substracting by 1 because trash (slot 12) should not count
+  const numSlots = orderedSlots.length
+
+  if (slotBNumber > numSlots || slotANumber > numSlots) {
+    return false
+  }
+  // take the y coord of slot 4, and subtact from y coord of slot 1
+  const slotHeight = orderedSlots[3].position[1] - orderedSlots[0].position[1]
+  const slotAPosition = orderedSlots[slotANumber - 1].position
+  const slotBPosition = orderedSlots[slotBNumber - 1].position
+
+  const yPositionSlotA = slotAPosition[1]
+  const yPositionSlotB = slotBPosition[1]
+
+  const xPositionSlotA = slotAPosition[0]
+  const xPositionSlotB = slotBPosition[0]
+
+  const areSlotsVerticallyAdjacent =
+    xPositionSlotA === xPositionSlotB &&
+    Math.abs(yPositionSlotA - yPositionSlotB) === slotHeight
+
+  return areSlotsVerticallyAdjacent
+}
+export const getAreSlotsAdjacent = (
+  slotNameA?: string | null,
+  slotNameB?: string | null
+): boolean =>
+  getAreSlotsHorizontallyAdjacent(slotNameA, slotNameB) ||
+  getAreSlotsVerticallyAdjacent(slotNameA, slotNameB)
 
 export const getIsLabwareAboveHeight = (
   labwareDef: LabwareDefinition2,

--- a/step-generation/src/__tests__/aspirate.test.ts
+++ b/step-generation/src/__tests__/aspirate.test.ts
@@ -9,6 +9,7 @@ import {
   thermocyclerPipetteCollision,
   pipetteIntoHeaterShakerWhileShaking,
   getIsHeaterShakerEastWestWithLatchOpen,
+  pipetteAdjacentHeaterShakerWhileShaking,
 } from '../utils'
 import {
   getInitialRobotStateStandard,
@@ -30,6 +31,7 @@ jest.mock('../utils/thermocyclerPipetteCollision')
 jest.mock('../utils/pipetteIntoHeaterShakerLatchOpen')
 jest.mock('../utils/pipetteIntoHeaterShakerWhileShaking')
 jest.mock('../utils/getIsHeaterShakerEastWestWithLatchOpen')
+jest.mock('../utils/pipetteAdjacentHeaterShakerWhileShaking')
 
 const mockThermocyclerPipetteCollision = thermocyclerPipetteCollision as jest.MockedFunction<
   typeof thermocyclerPipetteCollision
@@ -42,6 +44,9 @@ const mockPipetteIntoHeaterShakerWhileShaking = pipetteIntoHeaterShakerWhileShak
 >
 const mockGetIsHeaterShakerEastWestWithLatchOpen = getIsHeaterShakerEastWestWithLatchOpen as jest.MockedFunction<
   typeof getIsHeaterShakerEastWestWithLatchOpen
+>
+const mockPipetteAdjacentHeaterShakerWhileShaking = pipetteAdjacentHeaterShakerWhileShaking as jest.MockedFunction<
+  typeof pipetteAdjacentHeaterShakerWhileShaking
 >
 
 describe('aspirate', () => {
@@ -293,6 +298,30 @@ describe('aspirate', () => {
     expect(getErrorResult(result).errors).toHaveLength(1)
     expect(getErrorResult(result).errors[0]).toMatchObject({
       type: 'HEATER_SHAKER_EAST_WEST_LATCH_OPEN',
+    })
+  })
+  it('should return an error when aspirating north/south/east/west of a heater shaker while it is shaking', () => {
+    when(mockPipetteAdjacentHeaterShakerWhileShaking)
+      .calledWith(
+        robotStateWithTip.modules,
+        robotStateWithTip.labware[SOURCE_LABWARE]
+      )
+      .mockReturnValue(true)
+
+    const result = aspirate(
+      {
+        ...flowRateAndOffsets,
+        pipette: DEFAULT_PIPETTE,
+        volume: 50,
+        labware: SOURCE_LABWARE,
+        well: 'A1',
+      } as AspDispAirgapParams,
+      invariantContext,
+      robotStateWithTip
+    )
+    expect(getErrorResult(result).errors).toHaveLength(1)
+    expect(getErrorResult(result).errors[0]).toMatchObject({
+      type: 'HEATER_SHAKER_NORTH_SOUTH_EAST_WEST_SHAKING',
     })
   })
 })

--- a/step-generation/src/__tests__/dispense.test.ts
+++ b/step-generation/src/__tests__/dispense.test.ts
@@ -4,6 +4,7 @@ import {
   pipetteIntoHeaterShakerLatchOpen,
   pipetteIntoHeaterShakerWhileShaking,
   getIsHeaterShakerEastWestWithLatchOpen,
+  pipetteAdjacentHeaterShakerWhileShaking,
 } from '../utils'
 import {
   getInitialRobotStateStandard,
@@ -22,6 +23,7 @@ jest.mock('../utils/thermocyclerPipetteCollision')
 jest.mock('../utils/pipetteIntoHeaterShakerLatchOpen')
 jest.mock('../utils/pipetteIntoHeaterShakerWhileShaking')
 jest.mock('../utils/getIsHeaterShakerEastWestWithLatchOpen')
+jest.mock('../utils/pipetteAdjacentHeaterShakerWhileShaking')
 
 const mockThermocyclerPipetteCollision = thermocyclerPipetteCollision as jest.MockedFunction<
   typeof thermocyclerPipetteCollision
@@ -35,6 +37,10 @@ const mockPipetteIntoHeaterShakerWhileShaking = pipetteIntoHeaterShakerWhileShak
 const mockGetIsHeaterShakerEastWestWithLatchOpen = getIsHeaterShakerEastWestWithLatchOpen as jest.MockedFunction<
   typeof getIsHeaterShakerEastWestWithLatchOpen
 >
+const mockPipetteAdjacentHeaterShakerWhileShaking = pipetteAdjacentHeaterShakerWhileShaking as jest.MockedFunction<
+  typeof pipetteAdjacentHeaterShakerWhileShaking
+>
+
 describe('dispense', () => {
   let initialRobotState: RobotState
   let robotStateWithTip: RobotState
@@ -172,6 +178,20 @@ describe('dispense', () => {
       expect(getErrorResult(result).errors).toHaveLength(1)
       expect(getErrorResult(result).errors[0]).toMatchObject({
         type: 'HEATER_SHAKER_EAST_WEST_LATCH_OPEN',
+      })
+    })
+    it('should return an error when dispensing north/south/east/west of a heater shaker while it is shaking', () => {
+      when(mockPipetteAdjacentHeaterShakerWhileShaking)
+        .calledWith(
+          robotStateWithTip.modules,
+          robotStateWithTip.labware[SOURCE_LABWARE]
+        )
+        .mockReturnValue(true)
+
+      const result = dispense(params, invariantContext, robotStateWithTip)
+      expect(getErrorResult(result).errors).toHaveLength(1)
+      expect(getErrorResult(result).errors[0]).toMatchObject({
+        type: 'HEATER_SHAKER_NORTH_SOUTH_EAST_WEST_SHAKING',
       })
     })
   })

--- a/step-generation/src/__tests__/moveToWell.test.ts
+++ b/step-generation/src/__tests__/moveToWell.test.ts
@@ -6,6 +6,7 @@ import {
   pipetteIntoHeaterShakerLatchOpen,
   pipetteIntoHeaterShakerWhileShaking,
   getIsHeaterShakerEastWestWithLatchOpen,
+  pipetteAdjacentHeaterShakerWhileShaking,
 } from '../utils'
 import {
   getRobotStateWithTipStandard,
@@ -21,6 +22,7 @@ jest.mock('../utils/thermocyclerPipetteCollision')
 jest.mock('../utils/pipetteIntoHeaterShakerLatchOpen')
 jest.mock('../utils/pipetteIntoHeaterShakerWhileShaking')
 jest.mock('../utils/getIsHeaterShakerEastWestWithLatchOpen')
+jest.mock('../utils/pipetteAdjacentHeaterShakerWhileShaking')
 
 const mockThermocyclerPipetteCollision = thermocyclerPipetteCollision as jest.MockedFunction<
   typeof thermocyclerPipetteCollision
@@ -34,6 +36,10 @@ const mockPipetteIntoHeaterShakerWhileShaking = pipetteIntoHeaterShakerWhileShak
 const mockGetIsHeaterShakerEastWestWithLatchOpen = getIsHeaterShakerEastWestWithLatchOpen as jest.MockedFunction<
   typeof getIsHeaterShakerEastWestWithLatchOpen
 >
+const mockPipetteAdjacentHeaterShakerWhileShaking = pipetteAdjacentHeaterShakerWhileShaking as jest.MockedFunction<
+  typeof pipetteAdjacentHeaterShakerWhileShaking
+>
+
 describe('moveToWell', () => {
   let robotStateWithTip: RobotState
   let invariantContext: InvariantContext
@@ -326,6 +332,28 @@ describe('moveToWell', () => {
     expect(getErrorResult(result).errors).toHaveLength(1)
     expect(getErrorResult(result).errors[0]).toMatchObject({
       type: 'HEATER_SHAKER_EAST_WEST_LATCH_OPEN',
+    })
+  })
+  it('should return an error when moving to a well north/south/east/west of a heater shaker while it is shaking', () => {
+    when(mockPipetteAdjacentHeaterShakerWhileShaking)
+      .calledWith(
+        robotStateWithTip.modules,
+        robotStateWithTip.labware[SOURCE_LABWARE]
+      )
+      .mockReturnValue(true)
+
+    const result = moveToWell(
+      {
+        pipette: DEFAULT_PIPETTE,
+        labware: SOURCE_LABWARE,
+        well: 'A1',
+      },
+      invariantContext,
+      robotStateWithTip
+    )
+    expect(getErrorResult(result).errors).toHaveLength(1)
+    expect(getErrorResult(result).errors[0]).toMatchObject({
+      type: 'HEATER_SHAKER_NORTH_SOUTH_EAST_WEST_SHAKING',
     })
   })
 })

--- a/step-generation/src/__tests__/utils.test.ts
+++ b/step-generation/src/__tests__/utils.test.ts
@@ -35,6 +35,7 @@ import { DEFAULT_CONFIG } from '../fixtures'
 import {
   getIsHeaterShakerEastWestWithLatchOpen,
   orderWells,
+  pipetteAdjacentHeaterShakerWhileShaking,
   thermocyclerPipetteCollision,
 } from '../utils'
 import type { RobotState } from '../'
@@ -965,5 +966,95 @@ describe('getIsHeaterShakerEastWestWithLatchOpen', () => {
     expect(
       getIsHeaterShakerEastWestWithLatchOpen(modules, labwareTemporalProperties)
     ).toBe(false)
+  })
+})
+describe('pipetteAdjacentHeaterShakerWhileShaking', () => {
+  let labwareTemporalProperties: LabwareTemporalProperties
+  let modules: RobotState['modules']
+  beforeEach(() => {
+    labwareTemporalProperties = { slot: '2' }
+    modules = {
+      heaterShakerId: {
+        slot: '1',
+        moduleState: {
+          type: HEATERSHAKER_MODULE_TYPE,
+          targetTemp: null,
+          targetSpeed: null,
+          latchOpen: null,
+        },
+      },
+    }
+  })
+  afterEach(() => {
+    resetAllWhenMocks()
+  })
+  it('should return false when there are no modules', () => {
+    modules = {}
+    expect(
+      pipetteAdjacentHeaterShakerWhileShaking(
+        modules,
+        labwareTemporalProperties
+      )
+    ).toBe(false)
+  })
+  it('should return false when there is no heater shaker ajacent to labware', () => {
+    labwareTemporalProperties.slot = '9'
+    expect(
+      pipetteAdjacentHeaterShakerWhileShaking(
+        modules,
+        labwareTemporalProperties
+      )
+    ).toBe(false)
+  })
+  it('should return false when the heater shaker is not shaking', () => {
+    expect(
+      pipetteAdjacentHeaterShakerWhileShaking(
+        modules,
+        labwareTemporalProperties
+      )
+    ).toBe(false)
+  })
+  it('should return true when there is a heater shaker north of labware shaking', () => {
+    modules.heaterShakerId.slot = '5'
+    ;(modules.heaterShakerId.moduleState as any).targetSpeed = 300
+    expect(
+      pipetteAdjacentHeaterShakerWhileShaking(
+        modules,
+        labwareTemporalProperties
+      )
+    ).toBe(true)
+  })
+  it('should return true when there is a heater shaker south of labware shaking', () => {
+    labwareTemporalProperties.slot = '9'
+    modules.heaterShakerId.slot = '6'
+    ;(modules.heaterShakerId.moduleState as any).targetSpeed = 300
+    expect(
+      pipetteAdjacentHeaterShakerWhileShaking(
+        modules,
+        labwareTemporalProperties
+      )
+    ).toBe(true)
+  })
+  it('should return true when there is a heater shaker east of labware shaking', () => {
+    labwareTemporalProperties.slot = '5'
+    modules.heaterShakerId.slot = '6'
+    ;(modules.heaterShakerId.moduleState as any).targetSpeed = 300
+    expect(
+      pipetteAdjacentHeaterShakerWhileShaking(
+        modules,
+        labwareTemporalProperties
+      )
+    ).toBe(true)
+  })
+  it('should return true when there is a heater shaker west of labware shaking', () => {
+    labwareTemporalProperties.slot = '5'
+    modules.heaterShakerId.slot = '4'
+    ;(modules.heaterShakerId.moduleState as any).targetSpeed = 300
+    expect(
+      pipetteAdjacentHeaterShakerWhileShaking(
+        modules,
+        labwareTemporalProperties
+      )
+    ).toBe(true)
   })
 })

--- a/step-generation/src/commandCreators/atomic/aspirate.ts
+++ b/step-generation/src/commandCreators/atomic/aspirate.ts
@@ -6,6 +6,7 @@ import {
   pipetteIntoHeaterShakerLatchOpen,
   pipetteIntoHeaterShakerWhileShaking,
   getIsHeaterShakerEastWestWithLatchOpen,
+  pipetteAdjacentHeaterShakerWhileShaking,
 } from '../../utils'
 import type { CreateCommand } from '@opentrons/shared-data'
 import type { AspirateParams } from '@opentrons/shared-data/protocol/types/schemaV3'
@@ -90,6 +91,14 @@ export const aspirate: CommandCreator<AspirateParams> = (
     )
   ) {
     errors.push(errorCreators.heaterShakerIsShaking())
+  }
+  if (
+    pipetteAdjacentHeaterShakerWhileShaking(
+      prevRobotState.modules,
+      prevRobotState.labware[labware]
+    )
+  ) {
+    errors.push(errorCreators.heaterShakerNorthSouthEastWestShaking())
   }
   if (
     getIsHeaterShakerEastWestWithLatchOpen(

--- a/step-generation/src/commandCreators/atomic/dispense.ts
+++ b/step-generation/src/commandCreators/atomic/dispense.ts
@@ -5,6 +5,7 @@ import {
   pipetteIntoHeaterShakerLatchOpen,
   pipetteIntoHeaterShakerWhileShaking,
   getIsHeaterShakerEastWestWithLatchOpen,
+  pipetteAdjacentHeaterShakerWhileShaking,
 } from '../../utils'
 import type { CreateCommand } from '@opentrons/shared-data'
 import type { DispenseParams } from '@opentrons/shared-data/protocol/types/schemaV3'
@@ -79,6 +80,15 @@ export const dispense: CommandCreator<DispenseParams> = (
     )
   ) {
     errors.push(errorCreators.heaterShakerIsShaking())
+  }
+
+  if (
+    pipetteAdjacentHeaterShakerWhileShaking(
+      prevRobotState.modules,
+      prevRobotState.labware[labware]
+    )
+  ) {
+    errors.push(errorCreators.heaterShakerNorthSouthEastWestShaking())
   }
 
   if (

--- a/step-generation/src/commandCreators/atomic/moveToWell.ts
+++ b/step-generation/src/commandCreators/atomic/moveToWell.ts
@@ -5,6 +5,7 @@ import {
   pipetteIntoHeaterShakerLatchOpen,
   pipetteIntoHeaterShakerWhileShaking,
   getIsHeaterShakerEastWestWithLatchOpen,
+  pipetteAdjacentHeaterShakerWhileShaking,
 } from '../../utils'
 import type { CreateCommand } from '@opentrons/shared-data'
 import type { MoveToWellParams as v5MoveToWellParams } from '@opentrons/shared-data/protocol/types/schemaV5'
@@ -81,6 +82,15 @@ export const moveToWell: CommandCreator<v5MoveToWellParams> = (
     )
   ) {
     errors.push(errorCreators.heaterShakerIsShaking())
+  }
+
+  if (
+    pipetteAdjacentHeaterShakerWhileShaking(
+      prevRobotState.modules,
+      prevRobotState.labware[labware]
+    )
+  ) {
+    errors.push(errorCreators.heaterShakerNorthSouthEastWestShaking())
   }
 
   if (

--- a/step-generation/src/errorCreators.ts
+++ b/step-generation/src/errorCreators.ts
@@ -149,3 +149,10 @@ export const heaterShakerEastWestWithLatchOpen = (): CommandCreatorError => {
     message: 'The Heater-Shaker labware latch is open',
   }
 }
+
+export const heaterShakerNorthSouthEastWestShaking = (): CommandCreatorError => {
+  return {
+    type: 'HEATER_SHAKER_NORTH_SOUTH_EAST_WEST_SHAKING',
+    message: 'The Heater-Shaker is shaking',
+  }
+}

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -477,6 +477,7 @@ export type ErrorType =
   | 'HEATER_SHAKER_IS_SHAKING'
   | 'TALL_LABWARE_EAST_WEST_OF_HEATER_SHAKER'
   | 'HEATER_SHAKER_EAST_WEST_LATCH_OPEN'
+  | 'HEATER_SHAKER_NORTH_SOUTH_EAST_WEST_SHAKING'
 
 export interface CommandCreatorError {
   message: string

--- a/step-generation/src/utils/index.ts
+++ b/step-generation/src/utils/index.ts
@@ -8,6 +8,7 @@ import { pipetteIntoHeaterShakerWhileShaking } from './pipetteIntoHeaterShakerWh
 import { orderWells } from './orderWells'
 import { getIsTallLabwareEastWestOfHeaterShaker } from './getIsTallLabwareEastWestOfHeaterShaker'
 import { getIsHeaterShakerEastWestWithLatchOpen } from './getIsHeaterShakerEastWestWithLatchOpen'
+import { pipetteAdjacentHeaterShakerWhileShaking } from './pipetteAdjacentHeaterShakerWhileShaking'
 export {
   commandCreatorsTimeline,
   curryCommandCreator,
@@ -17,6 +18,7 @@ export {
   thermocyclerPipetteCollision,
   pipetteIntoHeaterShakerLatchOpen,
   pipetteIntoHeaterShakerWhileShaking,
+  pipetteAdjacentHeaterShakerWhileShaking,
   getIsTallLabwareEastWestOfHeaterShaker,
   getIsHeaterShakerEastWestWithLatchOpen,
 }

--- a/step-generation/src/utils/pipetteAdjacentHeaterShakerWhileShaking.ts
+++ b/step-generation/src/utils/pipetteAdjacentHeaterShakerWhileShaking.ts
@@ -1,0 +1,19 @@
+import {
+  getAreSlotsAdjacent,
+  HEATERSHAKER_MODULE_TYPE,
+} from '@opentrons/shared-data'
+import some from 'lodash/some'
+import type { LabwareTemporalProperties, RobotState } from '../types'
+
+export const pipetteAdjacentHeaterShakerWhileShaking = (
+  hwModules: RobotState['modules'],
+  labwareTemporalProperties: LabwareTemporalProperties
+): boolean =>
+  some(
+    hwModules,
+    hwModule =>
+      hwModule.moduleState.type === HEATERSHAKER_MODULE_TYPE &&
+      hwModule.moduleState.targetSpeed != null &&
+      hwModule.moduleState.targetSpeed > 0 &&
+      getAreSlotsAdjacent(hwModule.slot, labwareTemporalProperties.slot)
+  )


### PR DESCRIPTION
# Overview

This PR adds a timeline error when users try to pipette NSEW of the heater shaker when the heater shaker is shaking.

closes #10509

# Changelog

- Generate error when pipetting NSEW of HS while shaking 

# Review requests
Create a protocol with a H-S
Set a shake speed
Try to pipette NWES of the H-S, you should see a timeline error that matches the ticket (#10509)

# Risk assessment

Low
