### PR TITLE
fix(app): Fix tip length cal fetch on device details

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibration.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibration.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
+import { useDispatch } from 'react-redux'
 
 import {
   Flex,
@@ -7,13 +8,19 @@ import {
   COLORS,
   SPACING,
   TYPOGRAPHY,
+  useInterval,
 } from '@opentrons/components'
 
 import { StyledText } from '../../../atoms/text'
 import * as PipetteConstants from '../../../redux/pipettes/constants'
+import * as PipetteOffset from '../../../redux/calibration/pipette-offset'
+import * as Pipettes from '../../../redux/pipettes'
 import { useRunPipetteInfoByMount } from '../hooks'
 import { SetupPipetteCalibrationItem } from './SetupPipetteCalibrationItem'
 
+import type { Dispatch } from '../../../redux/types'
+
+const CALIBRATIONS_FETCH_MS = 5000
 interface SetupPipetteCalibrationProps {
   robotName: string
   runId: string
@@ -24,8 +31,19 @@ export function SetupPipetteCalibration({
   runId,
 }: SetupPipetteCalibrationProps): JSX.Element {
   const { t } = useTranslation('protocol_setup')
-
+  const dispatch = useDispatch<Dispatch>()
   const runPipetteInfoByMount = useRunPipetteInfoByMount(robotName, runId)
+
+  useInterval(
+    () => {
+      if (robotName != null) {
+        dispatch(Pipettes.fetchPipettes(robotName))
+        dispatch(PipetteOffset.fetchPipetteOffsetCalibrations(robotName))
+      }
+    },
+    CALIBRATIONS_FETCH_MS,
+    true
+  )
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing3}>

--- a/app/src/organisms/Devices/ProtocolRun/SetupTipLengthCalibration.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupTipLengthCalibration.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
+import { useDispatch } from 'react-redux'
 
 import {
   Flex,
@@ -11,9 +12,12 @@ import {
 
 import { StyledText } from '../../../atoms/text'
 import * as PipetteConstants from '../../../redux/pipettes/constants'
+import * as TipLength from '../../../redux/calibration/tip-length'
 import { useRunPipetteInfoByMount } from '../hooks'
 import { SetupCalibrationItem } from './SetupCalibrationItem'
 import { SetupTipLengthCalibrationButton } from './SetupTipLengthCalibrationButton'
+
+import type { Dispatch } from '../../../redux/types'
 
 interface SetupTipLengthCalibrationProps {
   robotName: string
@@ -25,8 +29,13 @@ export function SetupTipLengthCalibration({
   runId,
 }: SetupTipLengthCalibrationProps): JSX.Element {
   const { t } = useTranslation(['protocol_setup', 'devices_landing'])
+  const dispatch = useDispatch<Dispatch>()
 
   const runPipetteInfoByMount = useRunPipetteInfoByMount(robotName, runId)
+
+  React.useEffect(() => {
+    robotName && dispatch(TipLength.fetchTipLengthCalibrations(robotName))
+  }, [dispatch, robotName])
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing3}>

--- a/app/src/organisms/Devices/ProtocolRun/SetupTipLengthCalibration.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupTipLengthCalibration.tsx
@@ -8,6 +8,7 @@ import {
   COLORS,
   SPACING,
   TYPOGRAPHY,
+  useInterval,
 } from '@opentrons/components'
 
 import { StyledText } from '../../../atoms/text'
@@ -19,6 +20,7 @@ import { SetupTipLengthCalibrationButton } from './SetupTipLengthCalibrationButt
 
 import type { Dispatch } from '../../../redux/types'
 
+const CALIBRATIONS_FETCH_MS = 5000
 interface SetupTipLengthCalibrationProps {
   robotName: string
   runId: string
@@ -30,12 +32,15 @@ export function SetupTipLengthCalibration({
 }: SetupTipLengthCalibrationProps): JSX.Element {
   const { t } = useTranslation(['protocol_setup', 'devices_landing'])
   const dispatch = useDispatch<Dispatch>()
-
   const runPipetteInfoByMount = useRunPipetteInfoByMount(robotName, runId)
 
-  React.useEffect(() => {
-    robotName && dispatch(TipLength.fetchTipLengthCalibrations(robotName))
-  }, [dispatch, robotName])
+  useInterval(
+    () =>
+      robotName != null &&
+      dispatch(TipLength.fetchTipLengthCalibrations(robotName)),
+    CALIBRATIONS_FETCH_MS,
+    true
+  )
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing3}>


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This will close #10531 also the same issue on pipette offset calibration.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- Add a fetch function SetupTipLengthCalibration
- Add a fetch function SetupPipetteOffsetCalibration
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- Protocols setup page: the display is updated after the pipette offset cal
- Protocols setup page: the display is updated after the tip length cal

For testing, this may need to use a real robot

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
