### PR TITLE
feat(app): add liquid setup list view static list

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -121,5 +121,6 @@
   "liquid_setup_step_title": "Initial Liquid Setup",
   "liquid_setup_step_description": "View liquid starting locations and volumes",
   "list_view": "List View",
-  "map_view": "Map View"
+  "map_view": "Map View",
+  "volume_with_units": "{{volume}} {{units}}"
 }

--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -121,6 +121,5 @@
   "liquid_setup_step_title": "Initial Liquid Setup",
   "liquid_setup_step_description": "View liquid starting locations and volumes",
   "list_view": "List View",
-  "map_view": "Map View",
-  "volume_with_units": "{{volume}} {{units}}"
+  "map_view": "Map View"
 }

--- a/app/src/molecules/ToggleGroup/useToggleGroup.tsx
+++ b/app/src/molecules/ToggleGroup/useToggleGroup.tsx
@@ -12,7 +12,7 @@ const BUTTON_GROUP_STYLES = css`
   border: 1px ${medGrey} solid;
   border-radius: ${BORDERS.radiusSoftCorners};
   margin-top: -1px;
-  display: inline-block;
+  width: fit-content;
 
   button {
     height: 28px;

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import sum from 'lodash/sum'
-import { useTranslation } from 'react-i18next'
 import {
   Flex,
   SPACING,
@@ -27,7 +26,7 @@ interface SetupLiquidsListProps {
 
 const HIDE_SCROLLBAR = css`
   ::-webkit-scrollbar {
-    display: none; /* for Chrome, Safari, and Opera */
+    display: none;
   }
 `
 
@@ -37,7 +36,7 @@ export function SetupLiquidsList(props: SetupLiquidsListProps): JSX.Element {
     <Flex
       css={HIDE_SCROLLBAR}
       flexDirection={DIRECTION_COLUMN}
-      height="300px"
+      maxHeight={'31.25rem'}
       overflowY={'auto'}
     >
       {liquids?.map(liquid => (
@@ -62,18 +61,15 @@ interface LiquidsListItemProps {
 
 export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
   const { description, displayColor, displayName, volume } = props
-  const { t } = useTranslation('protocol_setup')
   return (
     <Flex
-      border={`1px solid ${COLORS.medGrey}`}
-      borderRadius={BORDERS.radiusSoftCorners}
+      css={BORDERS.cardOutlineBorder}
       flexDirection={DIRECTION_ROW}
       marginBottom={SPACING.spacing3}
       padding={SPACING.spacing4}
     >
       <Flex
-        border={`1px solid ${COLORS.medGrey}`}
-        borderRadius={BORDERS.radiusSoftCorners}
+        css={BORDERS.cardOutlineBorder}
         padding={'0.75rem'}
         height={'max-content'}
       >
@@ -106,7 +102,7 @@ export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
         marginLeft={SIZE_AUTO}
       >
         <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightRegular}>
-          {t('volume_with_units', { volume: volume, units: MICRO_LITERS })}
+          {volume} {MICRO_LITERS}
         </StyledText>
       </Flex>
     </Flex>

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
@@ -1,10 +1,114 @@
 import * as React from 'react'
-import { JUSTIFY_CENTER, Flex, SPACING } from '@opentrons/components'
+import sum from 'lodash/sum'
+import { useTranslation } from 'react-i18next'
+import {
+  Flex,
+  SPACING,
+  Icon,
+  COLORS,
+  DIRECTION_ROW,
+  DIRECTION_COLUMN,
+  TYPOGRAPHY,
+  JUSTIFY_CENTER,
+  SIZE_1,
+  BORDERS,
+  ALIGN_CENTER,
+  SIZE_AUTO,
+} from '@opentrons/components'
+import { MICRO_LITERS } from '@opentrons/shared-data'
+import { StyledText } from '../../../../atoms/text'
 
-export function SetupLiquidsList(): JSX.Element {
+import type { Liquid } from './getMockLiquidData'
+import { css } from 'styled-components'
+
+interface SetupLiquidsListProps {
+  liquids: Liquid[] | null
+}
+
+const HIDE_SCROLLBAR = css`
+  ::-webkit-scrollbar {
+    display: none; /* for Chrome, Safari, and Opera */
+  }
+`
+
+export function SetupLiquidsList(props: SetupLiquidsListProps): JSX.Element {
+  const { liquids } = props
   return (
-    <Flex justifyContent={JUSTIFY_CENTER} marginX={SPACING.spacing4}>
-      List view placeholder
+    <Flex
+      css={HIDE_SCROLLBAR}
+      flexDirection={DIRECTION_COLUMN}
+      height="300px"
+      overflowY={'auto'}
+    >
+      {liquids?.map(liquid => (
+        <LiquidsListItem
+          key={liquid.liquidId}
+          description={liquid.description}
+          displayColor={liquid.displayColor}
+          displayName={liquid.displayName}
+          volume={sum(Object.values(liquid.volumeByWell))}
+        />
+      ))}
+    </Flex>
+  )
+}
+
+interface LiquidsListItemProps {
+  description: string | null
+  displayColor: string
+  displayName: string
+  volume: number
+}
+
+export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
+  const { description, displayColor, displayName, volume } = props
+  const { t } = useTranslation('protocol_setup')
+  return (
+    <Flex
+      border={`1px solid ${COLORS.medGrey}`}
+      borderRadius={BORDERS.radiusSoftCorners}
+      flexDirection={DIRECTION_ROW}
+      marginBottom={SPACING.spacing3}
+      padding={SPACING.spacing4}
+    >
+      <Flex
+        border={`1px solid ${COLORS.medGrey}`}
+        borderRadius={BORDERS.radiusSoftCorners}
+        padding={'0.75rem'}
+        height={'max-content'}
+      >
+        <Icon name="circle" color={displayColor} size={SIZE_1} />
+      </Flex>
+      <Flex flexDirection={DIRECTION_COLUMN} justifyContent={JUSTIFY_CENTER}>
+        <StyledText
+          as="p"
+          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+          marginX={SPACING.spacing4}
+        >
+          {displayName}
+        </StyledText>
+        <StyledText
+          as="p"
+          fontWeight={TYPOGRAPHY.fontWeightRegular}
+          color={COLORS.darkGreyEnabled}
+          marginX={SPACING.spacing4}
+        >
+          {description != null ? description : null}
+        </StyledText>
+      </Flex>
+      <Flex
+        backgroundColor={COLORS.darkBlack + '1A'}
+        borderRadius={BORDERS.radiusSoftCorners}
+        height={'max-content'}
+        paddingY={SPACING.spacing2}
+        paddingX={SPACING.spacing3}
+        alignSelf={ALIGN_CENTER}
+        marginLeft={SIZE_AUTO}
+      >
+        <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightRegular}>
+          {t('volume_with_units', { volume: volume, units: MICRO_LITERS })}
+        </StyledText>
+      </Flex>
     </Flex>
   )
 }

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/SetupLiquidsList.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/SetupLiquidsList.test.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react'
+import { i18n } from '../../../../../i18n'
+import { renderWithProviders } from '@opentrons/components'
+import { SetupLiquidsList } from '../SetupLiquidsList'
+
+const MOCK_LIQUIDS = [
+  {
+    liquidId: '0',
+    displayName: 'mock liquid 1',
+    description: 'mock sample',
+    displayColor: '#ff4888',
+    labwareId:
+      '08433310-e1d8-11ec-8729-359ce212aee2:opentrons/opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical_acrylic/1',
+    volumeByWell: {
+      C1: 50,
+      C2: 50,
+    },
+  },
+]
+
+const render = (props: React.ComponentProps<typeof SetupLiquidsList>) => {
+  return renderWithProviders(<SetupLiquidsList {...props} />, {
+    i18nInstance: i18n,
+  })
+}
+
+describe('SetupLiquidsList', () => {
+  let props: React.ComponentProps<typeof SetupLiquidsList>
+  beforeEach(() => {
+    props = { liquids: MOCK_LIQUIDS }
+  })
+
+  it('renders the total volume of the liquid, sample display name, and description', () => {
+    const [{ getByText }] = render(props)
+    getByText('100 µL')
+    getByText('mock liquid 1')
+    getByText('mock sample')
+  })
+})

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/getMockLiquidData.ts
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/getMockLiquidData.ts
@@ -15,6 +15,11 @@ const mockLiquids = {
     description: 'sample',
     displayColor: '#ff4888',
   },
+  '3': {
+    displayName: 'liquid 4',
+    description: 'sample 4',
+    displayColor: '#ff4888',
+  },
 }
 const mockCommands = [
   {
@@ -81,9 +86,19 @@ const mockCommands = [
       volumeByWell: { A1: 20, B1: 20, A2: 20, B2: 20 },
     },
   },
+  {
+    commandType: 'loadLiquid',
+    key: '61731404-e1d8-11ec-8729-359ce212bee2',
+    params: {
+      liquidId: '3',
+      labwareId:
+        '08433310-e1d8-11ec-8729-359ce212aee2:opentrons/opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical_acrylic/1',
+      volumeByWell: { A2: 20, B2: 20, A3: 20, B3: 20 },
+    },
+  },
 ]
 
-interface Liquid {
+export interface Liquid {
   liquidId: string
   displayName: string
   description: string

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/getMockLiquidData.ts
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/getMockLiquidData.ts
@@ -18,7 +18,7 @@ const mockLiquids = {
   '3': {
     displayName: 'liquid 4',
     description: 'sample 4',
-    displayColor: '#ff4888',
+    displayColor: '#50d5ff',
   },
 }
 const mockCommands = [

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/index.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/index.tsx
@@ -11,6 +11,7 @@ import { useToggleGroup } from '../../../../molecules/ToggleGroup/useToggleGroup
 import { ProceedToRunButton } from '../ProceedToRunButton'
 import { SetupLiquidsList } from './SetupLiquidsList'
 import { SetupLiquidsMap } from './SetupLiquidsMap'
+import { getMockLiquidData } from './getMockLiquidData'
 
 interface SetupLiquidsProps {
   protocolRunHeaderRef: React.RefObject<HTMLDivElement> | null
@@ -24,25 +25,27 @@ export function SetupLiquids(props: SetupLiquidsProps): JSX.Element {
     t('list_view'),
     t('map_view')
   )
+  const liquidsData = getMockLiquidData()
   return (
     <Flex
       flexDirection={DIRECTION_COLUMN}
       justifyContent={JUSTIFY_CENTER}
-      alignItems={ALIGN_CENTER}
-      marginTop={SPACING.spacing4}
-      gridGap={SPACING.spacing6}
+      marginTop={SPACING.spacing6}
+      gridGap={SPACING.spacing4}
     >
       {toggleGroup}
       {selectedValue === t('list_view') ? (
-        <SetupLiquidsList />
+        <SetupLiquidsList liquids={liquidsData} />
       ) : (
         <SetupLiquidsMap />
       )}
-      <ProceedToRunButton
-        protocolRunHeaderRef={props.protocolRunHeaderRef}
-        robotName={props.robotName}
-        runId={props.runId}
-      />
+      <Flex alignSelf={ALIGN_CENTER}>
+        <ProceedToRunButton
+          protocolRunHeaderRef={props.protocolRunHeaderRef}
+          robotName={props.robotName}
+          runId={props.runId}
+        />
+      </Flex>
     </Flex>
   )
 }

--- a/shared-data/js/constants.ts
+++ b/shared-data/js/constants.ts
@@ -112,6 +112,7 @@ export const TEMP_LID_MIN = 37
 export const TEMP_LID_MAX = 110
 export const HS_TEMP_MIN = 37
 export const HS_TEMP_MAX = 95
+export const MICRO_LITERS = 'µL'
 
 // Heater shaker module info
 export const RPM: 'RPM' = 'RPM'


### PR DESCRIPTION


# Overview

This PR adds the static list component for the liquid setup list view section. closes #10517

https://user-images.githubusercontent.com/14794021/171884940-819e64a2-b7cf-4afe-ba57-0bf82112cf46.mov

# Changelog

- Add `SetupLiquidsList`
- Add `LiquidsListItem`

# Review requests

- Check the Liquids Setup List View section. Check that it meets the AC and the design specs in the Figma.

Note: unit tests are being added shortly

# Risk assessment

low