### PR TITLE
refactor(hardware): split move prep and run

### DIFF
--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -69,6 +69,7 @@ class MoveGroupRunner:
         """
         self._move_groups = move_groups
         self._start_at_index = start_at_index
+        self._is_prepped: bool = False
 
     @staticmethod
     def _has_moves(move_groups: MoveGroups) -> bool:
@@ -77,6 +78,35 @@ class MoveGroupRunner:
                 for node, step in move.items():
                     return True
         return False
+
+    async def prep(self, can_messenger: CanMessenger) -> None:
+        """Prepare the move group. The first thing that happens during run().
+
+        prep() and execute() can be used to replace a single call to run() to
+        ensure tighter timing, if you want something else to start as soon as
+        possible to the actual execution of the move.
+        """
+        if not self._has_moves(self._move_groups):
+            log.debug("No moves. Nothing to do.")
+            return
+        await self._clear_groups(can_messenger)
+        await self._send_groups(can_messenger)
+        self._is_prepped = True
+
+    async def execute(self, can_messenger: CanMessenger) -> NodeDict[float]:
+        """Execute a pre-prepared move group. The second thing that run() does.
+
+        prep() and execute() can be used to replace a single call to run() to
+        ensure tighter timing, if you want something else to start as soon as
+        possible to the actual execution of the move.
+        """
+        if not self._has_moves(self._move_groups):
+            log.debug("No moves. Nothing to do.")
+            return {}
+        if not self._is_prepped:
+            raise RuntimeError("A group must be prepped before it can be executed.")
+        move_completion_data = await self._move(can_messenger)
+        return self._accumulate_move_completions(move_completion_data)
 
     async def run(self, can_messenger: CanMessenger) -> NodeDict[float]:
         """Run the move group.
@@ -87,15 +117,17 @@ class MoveGroupRunner:
         Returns:
             The current position after the move for all the axes that
             acknowledged completing moves.
-        """
-        if not self._has_moves(self._move_groups):
-            log.debug("No moves. Nothing to do.")
-            return {}
 
-        await self._clear_groups(can_messenger)
-        await self._send_groups(can_messenger)
-        move_completion_data = await self._move(can_messenger)
-        return self._accumulate_move_completions(move_completion_data)
+        This function first prepares all connected devices to move (by sending
+        all the data for the moves over) and then executes the move with a
+        single call.
+
+        prep() and execute() can be used to replace a single call to run() to
+        ensure tighter timing, if you want something else to start as soon as
+        possible to the actual execution of the move.
+        """
+        await self.prep(can_messenger)
+        return await self.execute(can_messenger)
 
     @staticmethod
     def _accumulate_move_completions(completions: _Completions) -> NodeDict[float]:
@@ -278,8 +310,15 @@ class MoveScheduler:
             f"{'is' if (node_id, seq_id) in self._moves[group_id] else 'isn''t'}"
             " in group"
         )
-        self._moves[group_id].remove((node_id, seq_id))
-        self._completion_queue.put_nowait((arbitration_id, message))
+        try:
+            self._moves[group_id].remove((node_id, seq_id))
+            self._completion_queue.put_nowait((arbitration_id, message))
+        except KeyError:
+            log.warning(
+                f"Got a move ack for ({node_id}, {seq_id}) which is not in this "
+                "group; may have leaked from an earlier timed-out group"
+            )
+
         if not self._moves[group_id]:
             log.info(f"Move group {group_id} has completed.")
             self._event.set()
@@ -343,8 +382,13 @@ class MoveScheduler:
             )
 
             try:
+                # TODO: The max here can be removed once can_driver.send() no longer
+                # returns before the message actually hits the bus. Right now it
+                # returns when the message is enqueued in the kernel, meaning that
+                # for short move durations we can see the timeout expiring before
+                # the execute even gets sent.
                 await asyncio.wait_for(
-                    self._event.wait(), self._durations[group_id] * 1.1
+                    self._event.wait(), max(1.0, self._durations[group_id] * 1.1)
                 )
             except asyncio.TimeoutError:
                 log.warning("Move set timed out")

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -174,9 +174,8 @@ async def test_single_group_clear(
     """It should send a clear group command before setup."""
     subject = MoveGroupRunner(move_groups=move_group_single)
     await subject._clear_groups(can_messenger=mock_can_messenger)
-    mock_can_messenger.send.assert_called_once_with(
-        node_id=NodeId.broadcast,
-        message=md.ClearAllMoveGroupsRequest(),
+    mock_can_messenger.send.assert_has_calls(
+        [call(node_id=NodeId.broadcast, message=md.ClearAllMoveGroupsRequest())],
     )
 
 
@@ -185,10 +184,9 @@ async def test_multi_group_clear(
 ) -> None:
     """It should send a clear group command before setup."""
     subject = MoveGroupRunner(move_groups=move_group_multiple)
-    await subject._clear_groups(can_messenger=mock_can_messenger)
-    mock_can_messenger.send.assert_called_once_with(
-        node_id=NodeId.broadcast,
-        message=md.ClearAllMoveGroupsRequest(),
+    await subject.prep(can_messenger=mock_can_messenger)
+    mock_can_messenger.send.assert_has_calls(
+        [call(node_id=NodeId.broadcast, message=md.ClearAllMoveGroupsRequest())],
     )
 
 
@@ -197,7 +195,7 @@ async def test_home(
 ) -> None:
     """Test Home Request Functionality."""
     subject = MoveGroupRunner(move_groups=move_group_home_single)
-    await subject._send_groups(can_messenger=mock_can_messenger)
+    await subject.prep(can_messenger=mock_can_messenger)
     step = move_group_home_single[0][0].get(NodeId.head)
     assert isinstance(step, MoveGroupSingleAxisStep)
     mock_can_messenger.send.assert_any_call(
@@ -218,7 +216,7 @@ async def test_single_send_setup_commands(
 ) -> None:
     """It should send all the move group set up commands."""
     subject = MoveGroupRunner(move_groups=move_group_single)
-    await subject._send_groups(can_messenger=mock_can_messenger)
+    await subject.prep(can_messenger=mock_can_messenger)
     step = move_group_single[0][0].get(NodeId.head)
     assert isinstance(step, MoveGroupSingleAxisStep)
     mock_can_messenger.send.assert_any_call(
@@ -241,7 +239,7 @@ async def test_multi_send_setup_commands(
 ) -> None:
     """It should send all the move group set up commands."""
     subject = MoveGroupRunner(move_groups=move_group_multiple)
-    await subject._send_groups(can_messenger=mock_can_messenger)
+    await subject.prep(can_messenger=mock_can_messenger)
 
     # Group 0
     step = move_group_multiple[0][0].get(NodeId.head)


### PR DESCRIPTION
The MoveGroupRunner when executed provisions all moves to the axis
controllers and then runs them, all in the same coroutine. This is
usually fine, but sometimes callers want to do some other preparation
immediately before the execute message goes out. By allowing the prep
phase (sending all the move groups) and the execute phase (beginning the
motion) to be split, we can add this funcitonality.

Additionally, there's a problem with the can driver where `send()` returns when the message gets to the kernel, not when it goes to the bus. That means that for extremely short moves, the move group timeout can elapse before the move does, even sometimes before the execute is issued. By setting a minimum timeout, we can avoid this, but the longer term fix is for `send()` to block until the message gets to the wire.