### PR TITLE
refactor(api,hardware): o3: add capacitive_pass

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -79,7 +79,10 @@ from opentrons_hardware.hardware_control.motion import (
 from opentrons_hardware.hardware_control.types import NodeMap
 from opentrons_hardware.hardware_control.tools import detector, types as ohc_tool_types
 
-from opentrons_hardware.hardware_control.tool_sensors import capacitive_probe
+from opentrons_hardware.hardware_control.tool_sensors import (
+    capacitive_probe,
+    capacitive_pass,
+)
 
 if TYPE_CHECKING:
     from opentrons_shared_data.pipette.dev_types import PipetteName, PipetteModel
@@ -655,3 +658,20 @@ class OT3Controller:
         )
 
         self._position[axis_to_node(moving)] = pos
+
+    async def capacitive_pass(
+        self,
+        mount: OT3Mount,
+        moving: OT3Axis,
+        distance_mm: float,
+        speed_mm_per_s: float,
+    ) -> List[float]:
+        data = await capacitive_pass(
+            self._messenger,
+            sensor_node_for_mount(mount),
+            axis_to_node(moving),
+            distance_mm,
+            speed_mm_per_s,
+        )
+        self._position[axis_to_node(moving)] += distance_mm
+        return data

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -416,3 +416,13 @@ class OT3Simulator:
         speed_mm_per_s: float,
     ) -> None:
         self._position[axis_to_node(moving)] += distance_mm
+
+    async def capacitive_pass(
+        self,
+        mount: OT3Mount,
+        moving: OT3Axis,
+        distance_mm: float,
+        speed_mm_per_s: float,
+    ) -> List[float]:
+        self._position[axis_to_node(moving)] += distance_mm
+        return []

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -82,7 +82,27 @@ def mock_backend_capacitive_probe(
             ot3_hardware._backend._position[axis_to_node(moving)] += distance_mm / 2
 
         mock_probe.side_effect = _update_position
+
         yield mock_probe
+
+
+@pytest.fixture
+def mock_backend_capacitive_pass(
+    ot3_hardware: ThreadManager[OT3API],
+) -> Iterator[AsyncMock]:
+    backend = ot3_hardware.managed_obj._backend
+    with patch.object(
+        backend, "capacitive_pass", AsyncMock(spec=backend.capacitive_pass)
+    ) as mock_pass:
+
+        async def _update_position(
+            mount: OT3Mount, moving: OT3Axis, distance_mm: float, speed_mm_per_s: float
+        ) -> None:
+            ot3_hardware._backend._position[axis_to_node(moving)] += distance_mm / 2
+            return [1, 2, 3, 4, 5, 6, 8]
+
+        mock_pass.side_effect = _update_position
+        yield mock_pass
 
 
 @pytest.mark.parametrize(
@@ -204,5 +224,57 @@ async def test_capacitive_probe_invalid_axes(
 ) -> None:
     with pytest.raises(RuntimeError, match=r"Probing must be done with.*"):
         await ot3_hardware.capacitive_probe(mount, moving, 2, fake_settings)
+    mock_move_to.assert_not_called()
+    mock_backend_capacitive_probe.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "axis,begin,end,distance",
+    [
+        # Points must be passed through the attitude transform and therefore
+        # flipped
+        (OT3Axis.X, Point(0, 0, 0), Point(1, 0, 0), -1),
+        (OT3Axis.Y, Point(0, 0, 0), Point(0, -1, 0), 1),
+    ],
+)
+async def test_capacitive_sweep(
+    axis: OT3Axis,
+    begin: Point,
+    end: Point,
+    distance: float,
+    ot3_hardware: ThreadManager[OT3API],
+    mock_move_to: AsyncMock,
+    mock_backend_capacitive_pass: AsyncMock,
+) -> None:
+    data = await ot3_hardware.capacitive_sweep(OT3Mount.RIGHT, axis, begin, end, 3)
+    assert data == [1, 2, 3, 4, 5, 6, 8]
+    mock_backend_capacitive_pass.assert_called_once_with(
+        OT3Mount.RIGHT, axis, distance, 3
+    )
+
+
+@pytest.mark.parametrize(
+    "mount,moving",
+    (
+        [OT3Mount.RIGHT, OT3Axis.Z_L],
+        [OT3Mount.LEFT, OT3Axis.Z_R],
+        [OT3Mount.RIGHT, OT3Axis.P_L],
+        [OT3Mount.RIGHT, OT3Axis.P_R],
+        [OT3Mount.LEFT, OT3Axis.P_L],
+        [OT3Mount.RIGHT, OT3Axis.P_R],
+    ),
+)
+async def test_capacitive_sweep_invalid_axes(
+    ot3_hardware: ThreadManager[OT3API],
+    mock_move_to: AsyncMock,
+    mock_backend_capacitive_probe: AsyncMock,
+    mount: OT3Mount,
+    moving: OT3Axis,
+    fake_settings: CapacitivePassSettings,
+) -> None:
+    with pytest.raises(RuntimeError, match=r"Probing must be done with.*"):
+        await ot3_hardware.capacitive_sweep(
+            mount, moving, Point(0, 0, 0), Point(1, 0, 0), 2
+        )
     mock_move_to.assert_not_called()
     mock_backend_capacitive_probe.assert_not_called()

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -69,6 +69,7 @@ class MoveGroupRunner:
         """
         self._move_groups = move_groups
         self._start_at_index = start_at_index
+        self._is_prepped: bool = False
 
     @staticmethod
     def _has_moves(move_groups: MoveGroups) -> bool:
@@ -77,6 +78,35 @@ class MoveGroupRunner:
                 for node, step in move.items():
                     return True
         return False
+
+    async def prep(self, can_messenger: CanMessenger) -> None:
+        """Prepare the move group. The first thing that happens during run().
+
+        prep() and execute() can be used to replace a single call to run() to
+        ensure tighter timing, if you want something else to start as soon as
+        possible to the actual execution of the move.
+        """
+        if not self._has_moves(self._move_groups):
+            log.debug("No moves. Nothing to do.")
+            return
+        await self._clear_groups(can_messenger)
+        await self._send_groups(can_messenger)
+        self._is_prepped = True
+
+    async def execute(self, can_messenger: CanMessenger) -> NodeDict[float]:
+        """Execute a pre-prepared move group. The second thing that run() does.
+
+        prep() and execute() can be used to replace a single call to run() to
+        ensure tighter timing, if you want something else to start as soon as
+        possible to the actual execution of the move.
+        """
+        if not self._has_moves(self._move_groups):
+            log.debug("No moves. Nothing to do.")
+            return {}
+        if not self._is_prepped:
+            raise RuntimeError("A group must be prepped before it can be executed.")
+        move_completion_data = await self._move(can_messenger)
+        return self._accumulate_move_completions(move_completion_data)
 
     async def run(self, can_messenger: CanMessenger) -> NodeDict[float]:
         """Run the move group.
@@ -87,15 +117,17 @@ class MoveGroupRunner:
         Returns:
             The current position after the move for all the axes that
             acknowledged completing moves.
-        """
-        if not self._has_moves(self._move_groups):
-            log.debug("No moves. Nothing to do.")
-            return {}
 
-        await self._clear_groups(can_messenger)
-        await self._send_groups(can_messenger)
-        move_completion_data = await self._move(can_messenger)
-        return self._accumulate_move_completions(move_completion_data)
+        This function first prepares all connected devices to move (by sending
+        all the data for the moves over) and then executes the move with a
+        single call.
+
+        prep() and execute() can be used to replace a single call to run() to
+        ensure tighter timing, if you want something else to start as soon as
+        possible to the actual execution of the move.
+        """
+        await self.prep(can_messenger)
+        return await self.execute(can_messenger)
 
     @staticmethod
     def _accumulate_move_completions(completions: _Completions) -> NodeDict[float]:
@@ -278,8 +310,15 @@ class MoveScheduler:
             f"{'is' if (node_id, seq_id) in self._moves[group_id] else 'isn''t'}"
             " in group"
         )
-        self._moves[group_id].remove((node_id, seq_id))
-        self._completion_queue.put_nowait((arbitration_id, message))
+        try:
+            self._moves[group_id].remove((node_id, seq_id))
+            self._completion_queue.put_nowait((arbitration_id, message))
+        except KeyError:
+            log.warning(
+                f"Got a move ack for ({node_id}, {seq_id}) which is not in this "
+                "group; may have leaked from an earlier timed-out group"
+            )
+
         if not self._moves[group_id]:
             log.info(f"Move group {group_id} has completed.")
             self._event.set()
@@ -343,8 +382,13 @@ class MoveScheduler:
             )
 
             try:
+                # TODO: The max here can be removed once can_driver.send() no longer
+                # returns before the message actually hits the bus. Right now it
+                # returns when the message is enqueued in the kernel, meaning that
+                # for short move durations we can see the timeout expiring before
+                # the execute even gets sent.
                 await asyncio.wait_for(
-                    self._event.wait(), self._durations[group_id] * 1.1
+                    self._event.wait(), max(1.0, self._durations[group_id] * 1.1)
                 )
             except asyncio.TimeoutError:
                 log.warning("Move set timed out")

--- a/hardware/tests/conftest.py
+++ b/hardware/tests/conftest.py
@@ -20,7 +20,9 @@ class MockCanMessageNotifier:
 
     def __init__(self) -> None:
         """Constructor."""
-        self._listeners: List[MessageListenerCallback] = []
+        self._listeners: List[
+            Tuple[MessageListenerCallback, Optional[MessageListenerCallbackFilter]]
+        ] = []
 
     def add_listener(
         self,
@@ -28,11 +30,13 @@ class MockCanMessageNotifier:
         filter: Optional[MessageListenerCallbackFilter] = None,
     ) -> None:
         """Add listener."""
-        self._listeners.append(listener)
+        self._listeners.append((listener, filter))
 
     def notify(self, message: MessageDefinition, arbitration_id: ArbitrationId) -> None:
         """Notify."""
-        for listener in self._listeners:
+        for listener, filter in self._listeners:
+            if filter and not filter(arbitration_id):
+                continue
             listener(message, arbitration_id)
 
 

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -174,9 +174,8 @@ async def test_single_group_clear(
     """It should send a clear group command before setup."""
     subject = MoveGroupRunner(move_groups=move_group_single)
     await subject._clear_groups(can_messenger=mock_can_messenger)
-    mock_can_messenger.send.assert_called_once_with(
-        node_id=NodeId.broadcast,
-        message=md.ClearAllMoveGroupsRequest(),
+    mock_can_messenger.send.assert_has_calls(
+        [call(node_id=NodeId.broadcast, message=md.ClearAllMoveGroupsRequest())],
     )
 
 
@@ -185,10 +184,9 @@ async def test_multi_group_clear(
 ) -> None:
     """It should send a clear group command before setup."""
     subject = MoveGroupRunner(move_groups=move_group_multiple)
-    await subject._clear_groups(can_messenger=mock_can_messenger)
-    mock_can_messenger.send.assert_called_once_with(
-        node_id=NodeId.broadcast,
-        message=md.ClearAllMoveGroupsRequest(),
+    await subject.prep(can_messenger=mock_can_messenger)
+    mock_can_messenger.send.assert_has_calls(
+        [call(node_id=NodeId.broadcast, message=md.ClearAllMoveGroupsRequest())],
     )
 
 
@@ -197,7 +195,7 @@ async def test_home(
 ) -> None:
     """Test Home Request Functionality."""
     subject = MoveGroupRunner(move_groups=move_group_home_single)
-    await subject._send_groups(can_messenger=mock_can_messenger)
+    await subject.prep(can_messenger=mock_can_messenger)
     step = move_group_home_single[0][0].get(NodeId.head)
     assert isinstance(step, MoveGroupSingleAxisStep)
     mock_can_messenger.send.assert_any_call(
@@ -218,7 +216,7 @@ async def test_single_send_setup_commands(
 ) -> None:
     """It should send all the move group set up commands."""
     subject = MoveGroupRunner(move_groups=move_group_single)
-    await subject._send_groups(can_messenger=mock_can_messenger)
+    await subject.prep(can_messenger=mock_can_messenger)
     step = move_group_single[0][0].get(NodeId.head)
     assert isinstance(step, MoveGroupSingleAxisStep)
     mock_can_messenger.send.assert_any_call(
@@ -241,7 +239,7 @@ async def test_multi_send_setup_commands(
 ) -> None:
     """It should send all the move group set up commands."""
     subject = MoveGroupRunner(move_groups=move_group_multiple)
-    await subject._send_groups(can_messenger=mock_can_messenger)
+    await subject.prep(can_messenger=mock_can_messenger)
 
     # Group 0
     step = move_group_multiple[0][0].get(NodeId.head)

--- a/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
@@ -7,17 +7,27 @@ from typing import Iterator, List, Tuple, AsyncIterator, Any
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     ExecuteMoveGroupRequest,
     MoveCompleted,
+    ReadFromSensorResponse,
 )
 from opentrons_hardware.firmware_bindings.messages import MessageDefinition
-from opentrons_hardware.firmware_bindings.messages.payloads import MoveCompletedPayload
-from opentrons_hardware.firmware_bindings.utils import UInt8Field, UInt32Field
+from opentrons_hardware.firmware_bindings.messages.payloads import (
+    MoveCompletedPayload,
+    ReadFromSensorResponsePayload,
+)
+from opentrons_hardware.firmware_bindings.utils import (
+    UInt8Field,
+    UInt32Field,
+    Int32Field,
+)
 from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
+from opentrons_hardware.firmware_bindings.messages.fields import SensorTypeField
 
 
 from tests.conftest import CanLoopback
 
 from opentrons_hardware.hardware_control.tool_sensors import (
     capacitive_probe,
+    capacitive_pass,
     ProbeTarget,
 )
 from opentrons_hardware.firmware_bindings.constants import (
@@ -136,3 +146,70 @@ async def test_capacitive_probe(
         ANY,
         log=ANY,
     )
+
+
+@pytest.mark.parametrize(
+    "target_node,motor_node,distance,speed,",
+    [
+        (NodeId.pipette_left, NodeId.head_l, 10, 10),
+        (NodeId.pipette_right, NodeId.head_r, 10, -10),
+        (NodeId.gripper, NodeId.gripper_z, -10, 10),
+        (NodeId.pipette_left, NodeId.gantry_x, -10, -10),
+        (NodeId.gripper, NodeId.gantry_y, 10, 10),
+    ],
+)
+async def test_capacitive_sweep(
+    mock_messenger: AsyncMock,
+    message_send_loopback: CanLoopback,
+    mock_sensor_threshold: AsyncMock,
+    mock_bind_sync: AsyncMock,
+    target_node: ProbeTarget,
+    motor_node: NodeId,
+    distance: float,
+    speed: float,
+) -> None:
+    """Test capacitive sweep."""
+
+    def move_responder(
+        node_id: NodeId, message: MessageDefinition
+    ) -> List[Tuple[NodeId, MessageDefinition, NodeId]]:
+        message.payload.serialize()
+        if isinstance(message, ExecuteMoveGroupRequest):
+            sensor_values: List[Tuple[NodeId, MessageDefinition, NodeId]] = [
+                (
+                    NodeId.host,
+                    ReadFromSensorResponse(
+                        payload=ReadFromSensorResponsePayload(
+                            sensor=SensorTypeField(SensorType.capacitive.value),
+                            sensor_data=Int32Field(i << 16),
+                        )
+                    ),
+                    target_node,
+                )
+                for i in range(10)
+            ]
+            move_ack: List[Tuple[NodeId, MessageDefinition, NodeId]] = [
+                (
+                    NodeId.host,
+                    MoveCompleted(
+                        payload=MoveCompletedPayload(
+                            group_id=UInt8Field(0),
+                            seq_id=UInt8Field(0),
+                            current_position_um=UInt32Field(10000),
+                            encoder_position=UInt32Field(10000),
+                            ack_id=UInt8Field(0),
+                        )
+                    ),
+                    motor_node,
+                ),
+            ]
+            return sensor_values + move_ack
+        else:
+            return []
+
+    message_send_loopback.add_responder(move_responder)
+
+    result = await capacitive_pass(
+        mock_messenger, target_node, motor_node, distance, speed
+    )
+    assert result == list(range(10))

--- a/hardware/tests/opentrons_hardware/sensors/test_scheduler.py
+++ b/hardware/tests/opentrons_hardware/sensors/test_scheduler.py
@@ -1,0 +1,92 @@
+"""Tests for the sensor scheduler."""
+
+import mock
+import asyncio
+from typing import Iterator
+from opentrons_hardware.sensors import scheduler, utils
+from opentrons_hardware.firmware_bindings.constants import (
+    NodeId,
+    SensorType,
+    SensorOutputBinding,
+)
+from opentrons_hardware.firmware_bindings.arbitration_id import (
+    ArbitrationId,
+    ArbitrationIdParts,
+)
+
+from opentrons_hardware.firmware_bindings.utils import Int32Field
+
+from opentrons_hardware.firmware_bindings.messages.fields import (
+    SensorTypeField,
+    SensorOutputBindingField,
+)
+
+from opentrons_hardware.firmware_bindings.messages.message_definitions import (
+    ReadFromSensorResponse,
+    BindSensorOutputRequest,
+)
+from opentrons_hardware.firmware_bindings.messages.payloads import (
+    BindSensorOutputRequestPayload,
+    ReadFromSensorResponsePayload,
+)
+
+from tests.conftest import MockCanMessageNotifier
+
+
+async def test_capture_output(
+    mock_messenger: mock.AsyncMock,
+    can_message_notifier: MockCanMessageNotifier,
+) -> None:
+    """Test that data is received from the polling function."""
+    subject = scheduler.SensorScheduler()
+    stim_message = BindSensorOutputRequest(
+        payload=BindSensorOutputRequestPayload(
+            sensor=SensorTypeField(SensorType.capacitive),
+            binding=SensorOutputBindingField(SensorOutputBinding.report.value),
+        )
+    )
+    reset_message = BindSensorOutputRequest(
+        payload=BindSensorOutputRequestPayload(
+            sensor=SensorTypeField(SensorType.capacitive),
+            binding=SensorOutputBindingField(SensorOutputBinding.none.value),
+        )
+    )
+    async with subject.capture_output(
+        utils.SensorInformation(
+            sensor_type=SensorType.capacitive, node_id=NodeId.pipette_left
+        ),
+        mock_messenger,
+    ) as output_queue:
+        mock_messenger.send.assert_called_with(
+            node_id=NodeId.pipette_left, message=stim_message
+        )
+        for i in range(10):
+            can_message_notifier.notify(
+                ReadFromSensorResponse(
+                    payload=ReadFromSensorResponsePayload(
+                        sensor=SensorTypeField(SensorType.capacitive.value),
+                        sensor_data=Int32Field(i << 16),
+                    )
+                ),
+                ArbitrationId(
+                    parts=ArbitrationIdParts(
+                        message_id=ReadFromSensorResponse.message_id,
+                        node_id=NodeId.host,
+                        originating_node_id=NodeId.pipette_left,
+                        function_code=0,
+                    )
+                ),
+            )
+    mock_messenger.send.assert_called_with(
+        node_id=NodeId.pipette_left, message=reset_message
+    )
+
+    def _drain() -> Iterator[float]:
+        while True:
+            try:
+                yield output_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+
+    for index, value in enumerate(_drain()):
+        assert value == index


### PR DESCRIPTION
This new method moves a motion axis while capturing capacitive sensor data, which can be useful for testing or some forms of calibration. Velocities should be kept slow enough to avoid acceleration so that the sensor data can be assumed to linearly map to position as samples/mm = len(samples)/distance.