### PR TITLE
fix(app): disable device details module controls when robot is busy

### DIFF
--- a/app/src/organisms/Devices/ModuleCard/ModuleOverflowMenu.tsx
+++ b/app/src/organisms/Devices/ModuleCard/ModuleOverflowMenu.tsx
@@ -8,6 +8,7 @@ import { MenuItemsByModuleType, useModuleOverflowMenu } from './hooks'
 
 import type { AttachedModule } from '../../../redux/modules/types'
 import type { ModuleType } from '@opentrons/shared-data'
+import { useIsRobotBusy } from '../hooks'
 
 interface ModuleOverflowMenuProps {
   module: AttachedModule
@@ -40,7 +41,7 @@ export const ModuleOverflowMenu = (
     handleWizardClick,
     handleSlideoutClick
   )
-
+  const isBusy = useIsRobotBusy() && runId == null
   return (
     <>
       <Flex position={POSITION_RELATIVE}>
@@ -57,7 +58,7 @@ export const ModuleOverflowMenu = (
                       key={`${index}_${module.moduleModel}`}
                       onClick={() => item.onClick(item.isSecondary)}
                       data-testid={`module_setting_${module.moduleModel}`}
-                      disabled={item.disabledReason}
+                      disabled={item.disabledReason || isBusy}
                       {...targetProps}
                     >
                       {item.setSetting}

--- a/app/src/organisms/Devices/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
@@ -10,11 +10,17 @@ import {
 } from '../../../../redux/modules/__fixtures__'
 import { ModuleOverflowMenu } from '../ModuleOverflowMenu'
 import { useModuleIdFromRun } from '../useModuleIdFromRun'
+import { useIsRobotBusy } from '../../hooks'
 
 jest.mock('../useModuleIdFromRun')
+jest.mock('../../hooks')
 
 const mockUseModuleIdFromRun = useModuleIdFromRun as jest.MockedFunction<
   typeof useModuleIdFromRun
+>
+
+const mockUseIsRobotBusy = useIsRobotBusy as jest.MockedFunction<
+  typeof useIsRobotBusy
 >
 
 const render = (props: React.ComponentProps<typeof ModuleOverflowMenu>) => {
@@ -447,5 +453,24 @@ describe('ModuleOverflowMenu', () => {
     })
     expect(btn).not.toBeDisabled()
     fireEvent.click(btn)
+  })
+
+  it('should disable module control buttons when the robot is busy', () => {
+    mockUseIsRobotBusy.mockReturnValue(true)
+
+    props = {
+      module: mockTCBlockHeating,
+      handleSlideoutClick: jest.fn(),
+      handleAboutClick: jest.fn(),
+      handleTestShakeClick: jest.fn(),
+      handleWizardClick: jest.fn(),
+    }
+
+    const { getByRole } = render(props)
+
+    const btn = getByRole('button', {
+      name: 'Deactivate block',
+    })
+    expect(btn).toBeDisabled()
   })
 })

--- a/app/src/organisms/Devices/ModuleCard/hooks.tsx
+++ b/app/src/organisms/Devices/ModuleCard/hooks.tsx
@@ -16,7 +16,7 @@ import { getProtocolModulesInfo } from '../../Devices/ProtocolRun/utils/getProto
 import { MenuItem } from '../../../atoms/MenuList/MenuItem'
 import { Tooltip } from '../../../atoms/Tooltip'
 import { useCurrentRunId } from '../../ProtocolUpload/hooks'
-import { useProtocolDetailsForRun } from '../hooks'
+import { useIsRobotBusy, useProtocolDetailsForRun } from '../hooks'
 import { useModuleIdFromRun } from './useModuleIdFromRun'
 
 import type {
@@ -131,6 +131,7 @@ export function useModuleOverflowMenu(
   const { toggleLatch, isLatchClosed } = useLatchControls(module, runId)
   const [targetProps, tooltipProps] = useHoverTooltip()
   const { moduleIdFromRun } = useModuleIdFromRun(module, runId)
+  const isBusy = useIsRobotBusy() && runId == null
 
   const isLatchDisabled =
     module.moduleType === HEATERSHAKER_MODULE_TYPE &&
@@ -143,7 +144,7 @@ export function useModuleOverflowMenu(
         key={`hs_labware_latch_${module.moduleModel}`}
         data-testid={`hs_labware_latch_${module.moduleModel}`}
         onClick={toggleLatch}
-        disabled={isLatchDisabled}
+        disabled={isLatchDisabled || isBusy}
         {...targetProps}
       >
         {t(isLatchClosed ? 'open_labware_latch' : 'close_labware_latch', {
@@ -185,6 +186,7 @@ export function useModuleOverflowMenu(
       minWidth="10.6rem"
       onClick={() => handleTestShakeClick()}
       key={`hs_test_shake_btn_${module.moduleModel}`}
+      disabled={isBusy}
     >
       {t('test_shake', { ns: 'heater_shaker' })}
     </MenuItem>


### PR DESCRIPTION
# Overview

This PR disables device details module controls when the robot is busy to prevent sending commands due
to a 409 conflict on the commands end point. closes #10609

![Screen Shot 2022-06-03 at 12 52 42 PM](https://user-images.githubusercontent.com/14794021/171913134-867ab713-e383-423d-8794-1e4e99196434.png)

# Changelog

- Include `useIsRobotBusy` response to module control disabled reason

# Review requests

- Check that when the run is current the module controls that send commands, only on the device details page are disabled.

# Risk assessment

low