### PR TITLE
refactor(api): ot3: noncontact calibration

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -79,7 +79,10 @@ from opentrons_hardware.hardware_control.motion import (
 from opentrons_hardware.hardware_control.types import NodeMap
 from opentrons_hardware.hardware_control.tools import detector, types as ohc_tool_types
 
-from opentrons_hardware.hardware_control.tool_sensors import capacitive_probe
+from opentrons_hardware.hardware_control.tool_sensors import (
+    capacitive_probe,
+    capacitive_pass,
+)
 
 if TYPE_CHECKING:
     from opentrons_shared_data.pipette.dev_types import PipetteName, PipetteModel
@@ -655,3 +658,20 @@ class OT3Controller:
         )
 
         self._position[axis_to_node(moving)] = pos
+
+    async def capacitive_pass(
+        self,
+        mount: OT3Mount,
+        moving: OT3Axis,
+        distance_mm: float,
+        speed_mm_per_s: float,
+    ) -> List[float]:
+        data = await capacitive_pass(
+            self._messenger,
+            sensor_node_for_mount(mount),
+            axis_to_node(moving),
+            distance_mm,
+            speed_mm_per_s,
+        )
+        self._position[axis_to_node(moving)] += distance_mm
+        return data

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -416,3 +416,13 @@ class OT3Simulator:
         speed_mm_per_s: float,
     ) -> None:
         self._position[axis_to_node(moving)] += distance_mm
+
+    async def capacitive_pass(
+        self,
+        mount: OT3Mount,
+        moving: OT3Axis,
+        distance_mm: float,
+        speed_mm_per_s: float,
+    ) -> List[float]:
+        self._position[axis_to_node(moving)] += distance_mm
+        return []

--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -215,7 +215,7 @@ async def find_slot_center_binary(
         1,
     )
     LOG.info(f"Found -y edge at {minus_y_edge}mm")
-    return (plus_x_edge + minus_x_edge) / 2, (plus_y_edge + minus_y_edge)
+    return (plus_x_edge + minus_x_edge) / 2, (plus_y_edge + minus_y_edge) / 2
 
 
 async def find_axis_center(
@@ -296,7 +296,16 @@ def _edges_from_data(
     """
     now_str = datetime.datetime.now().strftime("%d-%m-%y-%H:%M:%S")
 
+    # The width of the averaging kernel defines how strong the averaging is - a wider
+    # kernel, or filter, has a lower rolloff frequency and will smooth more. This
+    # calculation sets the width at 5% of the length of the data, and then makes that
+    # value an even number
     average_width_samples = (int(floor(0.05 * len(data))) // 2) * 2
+    # an averaging kernel would be an array of length N with elements each set to 1/N;
+    # when convolved with a data stream, this will (ignoring edge effects) produce
+    # an N-sample rolling average. by inverting the sign of half the kernel, which is
+    # why we need it to be even, we do the same thing but while also taking a finite
+    # difference.
     average_difference_kernel = np.concatenate(  # type: ignore
         (
             np.full(average_width_samples // 2, 1 / average_width_samples),

--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -1,14 +1,23 @@
 """Functions and utilites for OT3 calibration."""
 from typing_extensions import Final, Literal
-from math import copysign
+from typing import Union, Tuple, List
+import numpy as np
+from enum import Enum
+from math import copysign, floor
 from logging import getLogger
 from .ot3api import OT3API
 from .types import OT3Mount, OT3Axis
 from opentrons.types import Point
+import json
 
 LOG = getLogger(__name__)
 
 CAL_TRANSIT_HEIGHT: Final[float] = 10
+
+
+class CalibrationMethod(Enum):
+    BINARY_SEARCH = "binary search"
+    NONCONTACT_PASS = "noncontact pass"
 
 
 class EarlyCapacitiveSenseTrigger(RuntimeError):
@@ -16,6 +25,14 @@ class EarlyCapacitiveSenseTrigger(RuntimeError):
         super().__init__(
             f"Calibration triggered early at z={triggered_at}mm, "
             f"expected {nominal_point}"
+        )
+
+
+class InaccurateNonContactSweepError(RuntimeError):
+    def __init__(self, nominal_width: float, detected_width: float) -> None:
+        super().__init__(
+            f"Calibration detected a slot width of {detected_width:.3f}mm "
+            f"which is too far from the design width of {nominal_width:.3f}mm"
         )
 
 
@@ -65,7 +82,7 @@ async def find_edge(
     hcapi: OT3API,
     mount: OT3Mount,
     slot_edge_nominal: Point,
-    search_axis: OT3Axis,
+    search_axis: Union[Literal[OT3Axis.X, OT3Axis.Y]],
     search_direction: Literal[1, -1],
 ) -> float:
     """
@@ -160,7 +177,181 @@ async def find_edge(
     return _element_of_axis(checking_pos, search_axis)
 
 
-async def calibrate_mount(hcapi: OT3API, mount: OT3Mount) -> Point:
+async def find_slot_center_binary(
+    hcapi: OT3API, mount: OT3Mount, deck_height: float
+) -> Tuple[float, float]:
+    """Find the center of the calibration slot by binary-searching its edges.
+
+    Returns the XY-center of the slot.
+    """
+    # Find all four edges of the calibration slot
+    plus_x_edge = await find_edge(
+        hcapi,
+        mount,
+        Point(*hcapi.config.calibration.edge_sense.plus_x_pos)._replace(z=deck_height),
+        OT3Axis.X,
+        -1,
+    )
+    LOG.info(f"Found +x edge at {plus_x_edge}mm")
+    minus_x_edge = await find_edge(
+        hcapi,
+        mount,
+        Point(*hcapi.config.calibration.edge_sense.minus_x_pos)._replace(z=deck_height),
+        OT3Axis.X,
+        1,
+    )
+    LOG.info(f"Found -x edge at {minus_x_edge}mm")
+    plus_y_edge = await find_edge(
+        hcapi,
+        mount,
+        Point(*hcapi.config.calibration.edge_sense.plus_y_pos)._replace(z=deck_height),
+        OT3Axis.Y,
+        -1,
+    )
+    LOG.info(f"Found +y edge at {plus_y_edge}mm")
+    minus_y_edge = await find_edge(
+        hcapi,
+        mount,
+        Point(*hcapi.config.calibration.edge_sense.minus_y_pos)._replace(z=deck_height),
+        OT3Axis.Y,
+        1,
+    )
+    LOG.info(f"Found -y edge at {minus_y_edge}mm")
+    return (plus_x_edge + minus_x_edge) / 2, (plus_y_edge + minus_y_edge)
+
+
+async def find_axis_center(
+    hcapi: OT3API,
+    mount: OT3Mount,
+    minus_edge_nominal: Point,
+    plus_edge_nominal: Point,
+    axis: Union[Literal[OT3Axis.X, OT3Axis.Y]],
+) -> float:
+    """Find the center of the calibration slot on the specified axis.
+
+    Sweep from the specified left edge to the specified right edge while taking
+    capacitive sense data. When the probe is over the deck, the capacitance will
+    be higher than when the probe is over the slot. By postprocessing the data,
+    we determine where the slot edges are, and return those positions.
+    """
+    WIDTH_TOLERANCE_MM: float = 0.5
+    here = await hcapi.gantry_position(mount)
+    await hcapi.move_to(mount, here._replace(z=CAL_TRANSIT_HEIGHT))
+    edge_settings = hcapi.config.calibration.edge_sense
+
+    start = axis.set_in_point(
+        minus_edge_nominal,
+        axis.of_point(minus_edge_nominal) - edge_settings.search_initial_tolerance_mm,
+    )
+    end = axis.set_in_point(
+        plus_edge_nominal,
+        axis.of_point(plus_edge_nominal) + edge_settings.search_initial_tolerance_mm,
+    )
+
+    await hcapi.move_to(mount, start._replace(z=CAL_TRANSIT_HEIGHT))
+
+    data = await hcapi.capacitive_sweep(
+        mount, axis, start, end, edge_settings.pass_settings.speed_mm_per_s
+    )
+
+    left_edge, right_edge = _edges_from_data(
+        data, axis.of_point(end) - axis.of_point(start)
+    )
+    nominal_width = axis.of_point(plus_edge_nominal) - axis.of_point(minus_edge_nominal)
+    detected_width = right_edge - left_edge
+    left_edge_absolute = axis.of_point(start) + left_edge
+    right_edge_absolute = axis.of_point(end) + right_edge
+    if abs(detected_width - nominal_width) > WIDTH_TOLERANCE_MM:
+        raise InaccurateNonContactSweepError(nominal_width, detected_width)
+    return (left_edge_absolute + right_edge_absolute) / 2
+
+
+def _edges_from_data(data: List[float], distance: float) -> Tuple[float, float]:
+    """
+    Postprocess the capacitance data taken from a sweep to find the calibration slot.
+
+    The sweep should have covered both edges, going off the deck into the slot,
+    all the way across the slot, and back onto the deck on the other side.
+
+    Capacitance is proportional to the area of the "plates" involved in the sensing. To
+    a first approximation, these are the flat circular face of the bottom of the probe,
+    and the deck. When the probe begins to cross the edge of the deck, the area of the
+    second "plate" - the deck - ends abruptly, in a straight line transverse to motion.
+    As the probe crosses, less and less of that circular face is over the deck.
+
+    That means that the rate of change with respect to the overlap distance (or time, at
+    constant velocity) is maximized as the center of the probe passes the edge of the
+    deck.
+
+    We can therefore apply a combined smoothing and differencing convolution kernel to
+    the timeseries data and set the locations of the edges as the locations of the
+    extrema of the difference of the series.
+    """
+    LOG.debug(
+        json.dumps(
+            {"details": {"type": "slot sweep"}, "data": data, "distance": distance}
+        )
+    )
+    average_width_samples = (int(floor(0.05 * len(data))) // 2) * 2
+    average_difference_kernel = np.concatenate(  # type: ignore
+        (
+            np.full(average_width_samples / 2, 1 / average_width_samples),
+            np.full(average_width_samples / 2, -1 / average_width_samples),
+        )
+    )
+    differenced = np.convolve(np.array(data), average_difference_kernel, mode="valid")
+    # These are the indices of the minimum difference (which should be the left edge,
+    # where the probe is halfway through moving off the deck, and the slope of the
+    # data is most negative) and the maximum difference (which should be the right
+    # edge, where the probe is halfway through moving back onto the deck, and the slope
+    # of the data is most positive)
+    left_edge_sample = np.argmin(differenced)
+    right_edge_sample = np.argmax(differenced)
+    mm_per_elem = distance / len(data)
+    # The differenced data is shorter than the input data because we used valid outputs
+    # of the convolution only to avoid edge effects; that means we need to account for
+    # the distance in the cut-off data
+    distance_prefix = ((len(data) - len(differenced)) / 2) * mm_per_elem
+    left_edge_offset = left_edge_sample * mm_per_elem
+    left_edge = left_edge_offset + distance_prefix
+    right_edge_offset = right_edge_sample * mm_per_elem
+    right_edge = right_edge_offset + distance_prefix
+    LOG.info(
+        "Found edges ({left_edge:.3f}, {right_edge:.3f}) "
+        "from offsets ({left_edge_offset:.3f}, {right_edge_offset:.3f}) "
+        "with {len(data)} cap samples over {distance}mm "
+        "using a kernel width of {len(average_difference_kernel)}"
+    )
+    return float(left_edge), float(right_edge)
+
+
+async def find_slot_center_noncontact(
+    hcapi: OT3API, mount: OT3Mount, deck_height: float
+) -> Tuple[float, float]:
+    NONCONTACT_INTERVAL_MM: float = 0.1
+    target_z = deck_height + NONCONTACT_INTERVAL_MM
+    x_center = await find_axis_center(
+        hcapi,
+        mount,
+        Point(*hcapi.config.calibration.edge_sense.minus_x_pos)._replace(z=target_z),
+        Point(*hcapi.config.calibration.edge_sense.plus_x_pos)._replace(z=target_z),
+        OT3Axis.X,
+    )
+    y_center = await find_axis_center(
+        hcapi,
+        mount,
+        Point(*hcapi.config.calibration.edge_sense.minus_y_pos)._replace(z=target_z),
+        Point(*hcapi.config.calibration.edge_sense.plus_y_pos)._replace(z=target_z),
+        OT3Axis.Y,
+    )
+    return x_center, y_center
+
+
+async def calibrate_mount(
+    hcapi: OT3API,
+    mount: OT3Mount,
+    method: CalibrationMethod = CalibrationMethod.BINARY_SEARCH,
+) -> Point:
     """
     Run automatic calibration for the tool attached to the specified mount.
 
@@ -184,44 +375,16 @@ async def calibrate_mount(hcapi: OT3API, mount: OT3Mount) -> Point:
     # also be used to baseline the edge detection points.
     z_pos = await find_deck_position(hcapi, mount)
     LOG.info(f"Found deck at {z_pos}mm")
-    # Next, find all four edges of the calibration slot
-    plus_x_edge = await find_edge(
-        hcapi,
-        mount,
-        Point(*hcapi.config.calibration.edge_sense.plus_x_pos)._replace(z=z_pos),
-        OT3Axis.X,
-        -1,
-    )
-    LOG.info(f"Found +x edge at {plus_x_edge}mm")
-    minus_x_edge = await find_edge(
-        hcapi,
-        mount,
-        Point(*hcapi.config.calibration.edge_sense.minus_x_pos)._replace(z=z_pos),
-        OT3Axis.X,
-        1,
-    )
-    LOG.info(f"Found -x edge at {minus_x_edge}mm")
-    plus_y_edge = await find_edge(
-        hcapi,
-        mount,
-        Point(*hcapi.config.calibration.edge_sense.plus_y_pos)._replace(z=z_pos),
-        OT3Axis.Y,
-        -1,
-    )
-    LOG.info(f"Found +y edge at {plus_y_edge}mm")
-    minus_y_edge = await find_edge(
-        hcapi,
-        mount,
-        Point(*hcapi.config.calibration.edge_sense.minus_y_pos)._replace(z=z_pos),
-        OT3Axis.Y,
-        1,
-    )
-    LOG.info(f"Found -y edge at {minus_y_edge}mm")
 
-    # The center of the calibration slot is the average of the edge positions
-    # in-plane, and the absolute sense value out-of-plane
-    center = Point(
-        (plus_x_edge + minus_x_edge) / 2, (plus_y_edge + minus_y_edge) / 2, z_pos
-    )
+    if method == CalibrationMethod.BINARY_SEARCH:
+        x_center, y_center = await find_slot_center_binary(hcapi, mount, z_pos)
+    elif method == CalibrationMethod.NONCONTACT_PASS:
+        x_center, y_center = await find_slot_center_noncontact(hcapi, mount, z_pos)
+    else:
+        raise RuntimeError("Unknown calibration method")
+
+    # The center of the calibration slot is the xy-center in-plane, and
+    # the absolute sense value out-of-plane
+    center = Point(x_center, y_center, z_pos)
     LOG.info(f"Found calibration value {center} for mount {mount.name}")
     return center

--- a/api/src/opentrons/hardware_control/scripts/repl.py
+++ b/api/src/opentrons/hardware_control/scripts/repl.py
@@ -35,6 +35,8 @@ from opentrons.hardware_control.ot3_calibration import (  # noqa: E402
     calibrate_mount,
     find_edge,
     find_deck_position,
+    CalibrationMethod,
+    find_axis_center,
 )
 from opentrons.hardware_control.protocols import HardwareControlAPI  # noqa: E402
 from opentrons.hardware_control.thread_manager import ThreadManager  # noqa: E402
@@ -101,6 +103,8 @@ def do_interact(api: ThreadManager[HardwareControlAPI]) -> None:
             "find_edge": wrap_async_util_fn(find_edge, api),
             "find_deck_position": wrap_async_util_fn(find_deck_position, api),
             "do_calibration": partial(do_calibration, api),
+            "CalibrationMethod": CalibrationMethod,
+            "find_axis_center": wrap_async_util_fn(find_axis_center, api),
         },
     )
 

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -82,7 +82,27 @@ def mock_backend_capacitive_probe(
             ot3_hardware._backend._position[axis_to_node(moving)] += distance_mm / 2
 
         mock_probe.side_effect = _update_position
+
         yield mock_probe
+
+
+@pytest.fixture
+def mock_backend_capacitive_pass(
+    ot3_hardware: ThreadManager[OT3API],
+) -> Iterator[AsyncMock]:
+    backend = ot3_hardware.managed_obj._backend
+    with patch.object(
+        backend, "capacitive_pass", AsyncMock(spec=backend.capacitive_pass)
+    ) as mock_pass:
+
+        async def _update_position(
+            mount: OT3Mount, moving: OT3Axis, distance_mm: float, speed_mm_per_s: float
+        ) -> None:
+            ot3_hardware._backend._position[axis_to_node(moving)] += distance_mm / 2
+            return [1, 2, 3, 4, 5, 6, 8]
+
+        mock_pass.side_effect = _update_position
+        yield mock_pass
 
 
 @pytest.mark.parametrize(
@@ -204,5 +224,57 @@ async def test_capacitive_probe_invalid_axes(
 ) -> None:
     with pytest.raises(RuntimeError, match=r"Probing must be done with.*"):
         await ot3_hardware.capacitive_probe(mount, moving, 2, fake_settings)
+    mock_move_to.assert_not_called()
+    mock_backend_capacitive_probe.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "axis,begin,end,distance",
+    [
+        # Points must be passed through the attitude transform and therefore
+        # flipped
+        (OT3Axis.X, Point(0, 0, 0), Point(1, 0, 0), -1),
+        (OT3Axis.Y, Point(0, 0, 0), Point(0, -1, 0), 1),
+    ],
+)
+async def test_capacitive_sweep(
+    axis: OT3Axis,
+    begin: Point,
+    end: Point,
+    distance: float,
+    ot3_hardware: ThreadManager[OT3API],
+    mock_move_to: AsyncMock,
+    mock_backend_capacitive_pass: AsyncMock,
+) -> None:
+    data = await ot3_hardware.capacitive_sweep(OT3Mount.RIGHT, axis, begin, end, 3)
+    assert data == [1, 2, 3, 4, 5, 6, 8]
+    mock_backend_capacitive_pass.assert_called_once_with(
+        OT3Mount.RIGHT, axis, distance, 3
+    )
+
+
+@pytest.mark.parametrize(
+    "mount,moving",
+    (
+        [OT3Mount.RIGHT, OT3Axis.Z_L],
+        [OT3Mount.LEFT, OT3Axis.Z_R],
+        [OT3Mount.RIGHT, OT3Axis.P_L],
+        [OT3Mount.RIGHT, OT3Axis.P_R],
+        [OT3Mount.LEFT, OT3Axis.P_L],
+        [OT3Mount.RIGHT, OT3Axis.P_R],
+    ),
+)
+async def test_capacitive_sweep_invalid_axes(
+    ot3_hardware: ThreadManager[OT3API],
+    mock_move_to: AsyncMock,
+    mock_backend_capacitive_probe: AsyncMock,
+    mount: OT3Mount,
+    moving: OT3Axis,
+    fake_settings: CapacitivePassSettings,
+) -> None:
+    with pytest.raises(RuntimeError, match=r"Probing must be done with.*"):
+        await ot3_hardware.capacitive_sweep(
+            mount, moving, Point(0, 0, 0), Point(1, 0, 0), 2
+        )
     mock_move_to.assert_not_called()
     mock_backend_capacitive_probe.assert_not_called()

--- a/api/tests/opentrons/hardware_control/test_ot3_calibration.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_calibration.py
@@ -2,9 +2,10 @@
 import copy
 from dataclasses import replace
 import pytest
+import json
 from typing import Iterator, Tuple
 from typing_extensions import Literal
-from mock import patch, AsyncMock
+from mock import patch, AsyncMock, Mock
 from opentrons.hardware_control import ThreadManager
 from opentrons.hardware_control.ot3api import OT3API
 from opentrons.hardware_control.types import OT3Mount, OT3Axis
@@ -13,8 +14,20 @@ from opentrons.hardware_control.ot3_calibration import (
     find_edge,
     EarlyCapacitiveSenseTrigger,
     find_deck_position,
+    find_slot_center_binary,
+    find_slot_center_noncontact,
+    calibrate_mount,
+    CalibrationMethod,
+    _edges_from_data,
+    InaccurateNonContactSweepError
 )
 from opentrons.types import Point
+
+
+@pytest.fixture(autouse=True)
+def mock_save_json():
+    with patch("json.dump", Mock(spec=json.dump)) as jd:
+        yield jd
 
 
 @pytest.fixture
@@ -41,6 +54,25 @@ def mock_capacitive_probe(ot3_hardware: ThreadManager[OT3API]) -> Iterator[Async
         ),
     ) as mock_probe:
         yield mock_probe
+
+@pytest.fixture
+def mock_capacitive_sweep(ot3_hardware: ThreadManager[OT3API]) -> Iterator[AsyncMock]:
+    with patch.object(
+            ot3_hardware.managed_obj,
+            'capacitive_sweep',
+            AsyncMock(
+                spec=ot3_hardware.managed_obj.capacitive_sweep,
+                wraps=ot3_hardware.managed_obj.capacitive_sweep
+            ),
+    ) as mock_sweep:
+        yield mock_sweep
+
+
+@pytest.fixture
+def mock_data_analysis() -> Iterator[Mock]:
+    with patch('opentrons.hardware_control.ot3_calibration._edges_from_data',
+               Mock(spec=_edges_from_data)) as efd:
+        yield efd
 
 
 def _update_edge_sense_config(
@@ -171,3 +203,54 @@ async def test_find_deck_checks_z_only(
     second_move_point = mock_move_to.call_args_list[1][0][1]
     assert second_move_point.x == config_point.x
     assert second_move_point.y == config_point.y
+
+
+async def test_method_enum(ot3_hardware: ThreadManager[OT3API]) -> None:
+    with patch(
+        "opentrons.hardware_control.ot3_calibration.find_slot_center_binary",
+        AsyncMock(spec=find_slot_center_binary),
+    ) as binary, patch(
+        "opentrons.hardware_control.ot3_calibration.find_slot_center_noncontact",
+        AsyncMock(spec=find_slot_center_noncontact),
+    ) as noncontact, patch(
+        "opentrons.hardware_control.ot3_calibration.find_deck_position",
+        AsyncMock(spec=find_deck_position),
+    ) as find_deck:
+        find_deck.return_value = 10
+        binary.return_value = (1.0, 2.0)
+        noncontact.return_value = (3.0, 4.0)
+        binval = await calibrate_mount(
+            ot3_hardware, OT3Mount.RIGHT, CalibrationMethod.BINARY_SEARCH
+        )
+        find_deck.assert_called_once()
+        binary.assert_called_once()
+        noncontact.assert_not_called()
+        assert binval == Point(1.0, 2.0, 10)
+
+        find_deck.reset_mock()
+        binary.reset_mock()
+        noncontact.reset_mock()
+
+        ncval = await calibrate_mount(
+            ot3_hardware, OT3Mount.LEFT, CalibrationMethod.NONCONTACT_PASS
+        )
+        find_deck.assert_called_once()
+        binary.assert_not_called()
+        noncontact.assert_called_once()
+        assert ncval == Point(3.0, 4.0, 10)
+
+
+async def test_noncontact_sanity(
+        ot3_hardware: ThreadManager[OT3API],
+        override_cal_config: None,
+        mock_move_to: AsyncMock,
+        mock_capacitive_sweep: AsyncMock,
+        mock_data_analysis: Mock,
+) -> None:
+    mock_data_analysis.return_value = (-1000, 1000)
+    with pytest.raises(InaccurateNonContactSweepError):
+        await find_axis_center(
+            ot3_hardware, OT3Mount.RIGHT,
+            ot3_hardware.config.calibration.edge_sense.minus_x_pos,
+            ot3_hardware.config.calibration.edge_sense.plus_x_pos,
+            OT3Axis.X)

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -69,6 +69,7 @@ class MoveGroupRunner:
         """
         self._move_groups = move_groups
         self._start_at_index = start_at_index
+        self._is_prepped: bool = False
 
     @staticmethod
     def _has_moves(move_groups: MoveGroups) -> bool:
@@ -77,6 +78,35 @@ class MoveGroupRunner:
                 for node, step in move.items():
                     return True
         return False
+
+    async def prep(self, can_messenger: CanMessenger) -> None:
+        """Prepare the move group. The first thing that happens during run().
+
+        prep() and execute() can be used to replace a single call to run() to
+        ensure tighter timing, if you want something else to start as soon as
+        possible to the actual execution of the move.
+        """
+        if not self._has_moves(self._move_groups):
+            log.debug("No moves. Nothing to do.")
+            return
+        await self._clear_groups(can_messenger)
+        await self._send_groups(can_messenger)
+        self._is_prepped = True
+
+    async def execute(self, can_messenger: CanMessenger) -> NodeDict[float]:
+        """Execute a pre-prepared move group. The second thing that run() does.
+
+        prep() and execute() can be used to replace a single call to run() to
+        ensure tighter timing, if you want something else to start as soon as
+        possible to the actual execution of the move.
+        """
+        if not self._has_moves(self._move_groups):
+            log.debug("No moves. Nothing to do.")
+            return {}
+        if not self._is_prepped:
+            raise RuntimeError("A group must be prepped before it can be executed.")
+        move_completion_data = await self._move(can_messenger)
+        return self._accumulate_move_completions(move_completion_data)
 
     async def run(self, can_messenger: CanMessenger) -> NodeDict[float]:
         """Run the move group.
@@ -87,15 +117,17 @@ class MoveGroupRunner:
         Returns:
             The current position after the move for all the axes that
             acknowledged completing moves.
-        """
-        if not self._has_moves(self._move_groups):
-            log.debug("No moves. Nothing to do.")
-            return {}
 
-        await self._clear_groups(can_messenger)
-        await self._send_groups(can_messenger)
-        move_completion_data = await self._move(can_messenger)
-        return self._accumulate_move_completions(move_completion_data)
+        This function first prepares all connected devices to move (by sending
+        all the data for the moves over) and then executes the move with a
+        single call.
+
+        prep() and execute() can be used to replace a single call to run() to
+        ensure tighter timing, if you want something else to start as soon as
+        possible to the actual execution of the move.
+        """
+        await self.prep(can_messenger)
+        return await self.execute(can_messenger)
 
     @staticmethod
     def _accumulate_move_completions(completions: _Completions) -> NodeDict[float]:
@@ -278,8 +310,15 @@ class MoveScheduler:
             f"{'is' if (node_id, seq_id) in self._moves[group_id] else 'isn''t'}"
             " in group"
         )
-        self._moves[group_id].remove((node_id, seq_id))
-        self._completion_queue.put_nowait((arbitration_id, message))
+        try:
+            self._moves[group_id].remove((node_id, seq_id))
+            self._completion_queue.put_nowait((arbitration_id, message))
+        except KeyError:
+            log.warning(
+                f"Got a move ack for ({node_id}, {seq_id}) which is not in this "
+                "group; may have leaked from an earlier timed-out group"
+            )
+
         if not self._moves[group_id]:
             log.info(f"Move group {group_id} has completed.")
             self._event.set()
@@ -343,8 +382,13 @@ class MoveScheduler:
             )
 
             try:
+                # TODO: The max here can be removed once can_driver.send() no longer
+                # returns before the message actually hits the bus. Right now it
+                # returns when the message is enqueued in the kernel, meaning that
+                # for short move durations we can see the timeout expiring before
+                # the execute even gets sent.
                 await asyncio.wait_for(
-                    self._event.wait(), self._durations[group_id] * 1.1
+                    self._event.wait(), max(1.0, self._durations[group_id] * 1.1)
                 )
             except asyncio.TimeoutError:
                 log.warning("Move set timed out")

--- a/hardware/tests/conftest.py
+++ b/hardware/tests/conftest.py
@@ -20,7 +20,9 @@ class MockCanMessageNotifier:
 
     def __init__(self) -> None:
         """Constructor."""
-        self._listeners: List[MessageListenerCallback] = []
+        self._listeners: List[
+            Tuple[MessageListenerCallback, Optional[MessageListenerCallbackFilter]]
+        ] = []
 
     def add_listener(
         self,
@@ -28,11 +30,13 @@ class MockCanMessageNotifier:
         filter: Optional[MessageListenerCallbackFilter] = None,
     ) -> None:
         """Add listener."""
-        self._listeners.append(listener)
+        self._listeners.append((listener, filter))
 
     def notify(self, message: MessageDefinition, arbitration_id: ArbitrationId) -> None:
         """Notify."""
-        for listener in self._listeners:
+        for listener, filter in self._listeners:
+            if filter and not filter(arbitration_id):
+                continue
             listener(message, arbitration_id)
 
 

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -174,9 +174,8 @@ async def test_single_group_clear(
     """It should send a clear group command before setup."""
     subject = MoveGroupRunner(move_groups=move_group_single)
     await subject._clear_groups(can_messenger=mock_can_messenger)
-    mock_can_messenger.send.assert_called_once_with(
-        node_id=NodeId.broadcast,
-        message=md.ClearAllMoveGroupsRequest(),
+    mock_can_messenger.send.assert_has_calls(
+        [call(node_id=NodeId.broadcast, message=md.ClearAllMoveGroupsRequest())],
     )
 
 
@@ -185,10 +184,9 @@ async def test_multi_group_clear(
 ) -> None:
     """It should send a clear group command before setup."""
     subject = MoveGroupRunner(move_groups=move_group_multiple)
-    await subject._clear_groups(can_messenger=mock_can_messenger)
-    mock_can_messenger.send.assert_called_once_with(
-        node_id=NodeId.broadcast,
-        message=md.ClearAllMoveGroupsRequest(),
+    await subject.prep(can_messenger=mock_can_messenger)
+    mock_can_messenger.send.assert_has_calls(
+        [call(node_id=NodeId.broadcast, message=md.ClearAllMoveGroupsRequest())],
     )
 
 
@@ -197,7 +195,7 @@ async def test_home(
 ) -> None:
     """Test Home Request Functionality."""
     subject = MoveGroupRunner(move_groups=move_group_home_single)
-    await subject._send_groups(can_messenger=mock_can_messenger)
+    await subject.prep(can_messenger=mock_can_messenger)
     step = move_group_home_single[0][0].get(NodeId.head)
     assert isinstance(step, MoveGroupSingleAxisStep)
     mock_can_messenger.send.assert_any_call(
@@ -218,7 +216,7 @@ async def test_single_send_setup_commands(
 ) -> None:
     """It should send all the move group set up commands."""
     subject = MoveGroupRunner(move_groups=move_group_single)
-    await subject._send_groups(can_messenger=mock_can_messenger)
+    await subject.prep(can_messenger=mock_can_messenger)
     step = move_group_single[0][0].get(NodeId.head)
     assert isinstance(step, MoveGroupSingleAxisStep)
     mock_can_messenger.send.assert_any_call(
@@ -241,7 +239,7 @@ async def test_multi_send_setup_commands(
 ) -> None:
     """It should send all the move group set up commands."""
     subject = MoveGroupRunner(move_groups=move_group_multiple)
-    await subject._send_groups(can_messenger=mock_can_messenger)
+    await subject.prep(can_messenger=mock_can_messenger)
 
     # Group 0
     step = move_group_multiple[0][0].get(NodeId.head)

--- a/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
@@ -7,17 +7,27 @@ from typing import Iterator, List, Tuple, AsyncIterator, Any
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     ExecuteMoveGroupRequest,
     MoveCompleted,
+    ReadFromSensorResponse,
 )
 from opentrons_hardware.firmware_bindings.messages import MessageDefinition
-from opentrons_hardware.firmware_bindings.messages.payloads import MoveCompletedPayload
-from opentrons_hardware.firmware_bindings.utils import UInt8Field, UInt32Field
+from opentrons_hardware.firmware_bindings.messages.payloads import (
+    MoveCompletedPayload,
+    ReadFromSensorResponsePayload,
+)
+from opentrons_hardware.firmware_bindings.utils import (
+    UInt8Field,
+    UInt32Field,
+    Int32Field,
+)
 from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
+from opentrons_hardware.firmware_bindings.messages.fields import SensorTypeField
 
 
 from tests.conftest import CanLoopback
 
 from opentrons_hardware.hardware_control.tool_sensors import (
     capacitive_probe,
+    capacitive_pass,
     ProbeTarget,
 )
 from opentrons_hardware.firmware_bindings.constants import (
@@ -136,3 +146,70 @@ async def test_capacitive_probe(
         ANY,
         log=ANY,
     )
+
+
+@pytest.mark.parametrize(
+    "target_node,motor_node,distance,speed,",
+    [
+        (NodeId.pipette_left, NodeId.head_l, 10, 10),
+        (NodeId.pipette_right, NodeId.head_r, 10, -10),
+        (NodeId.gripper, NodeId.gripper_z, -10, 10),
+        (NodeId.pipette_left, NodeId.gantry_x, -10, -10),
+        (NodeId.gripper, NodeId.gantry_y, 10, 10),
+    ],
+)
+async def test_capacitive_sweep(
+    mock_messenger: AsyncMock,
+    message_send_loopback: CanLoopback,
+    mock_sensor_threshold: AsyncMock,
+    mock_bind_sync: AsyncMock,
+    target_node: ProbeTarget,
+    motor_node: NodeId,
+    distance: float,
+    speed: float,
+) -> None:
+    """Test capacitive sweep."""
+
+    def move_responder(
+        node_id: NodeId, message: MessageDefinition
+    ) -> List[Tuple[NodeId, MessageDefinition, NodeId]]:
+        message.payload.serialize()
+        if isinstance(message, ExecuteMoveGroupRequest):
+            sensor_values: List[Tuple[NodeId, MessageDefinition, NodeId]] = [
+                (
+                    NodeId.host,
+                    ReadFromSensorResponse(
+                        payload=ReadFromSensorResponsePayload(
+                            sensor=SensorTypeField(SensorType.capacitive.value),
+                            sensor_data=Int32Field(i << 16),
+                        )
+                    ),
+                    target_node,
+                )
+                for i in range(10)
+            ]
+            move_ack: List[Tuple[NodeId, MessageDefinition, NodeId]] = [
+                (
+                    NodeId.host,
+                    MoveCompleted(
+                        payload=MoveCompletedPayload(
+                            group_id=UInt8Field(0),
+                            seq_id=UInt8Field(0),
+                            current_position_um=UInt32Field(10000),
+                            encoder_position=UInt32Field(10000),
+                            ack_id=UInt8Field(0),
+                        )
+                    ),
+                    motor_node,
+                ),
+            ]
+            return sensor_values + move_ack
+        else:
+            return []
+
+    message_send_loopback.add_responder(move_responder)
+
+    result = await capacitive_pass(
+        mock_messenger, target_node, motor_node, distance, speed
+    )
+    assert result == list(range(10))

--- a/hardware/tests/opentrons_hardware/sensors/test_scheduler.py
+++ b/hardware/tests/opentrons_hardware/sensors/test_scheduler.py
@@ -1,0 +1,92 @@
+"""Tests for the sensor scheduler."""
+
+import mock
+import asyncio
+from typing import Iterator
+from opentrons_hardware.sensors import scheduler, utils
+from opentrons_hardware.firmware_bindings.constants import (
+    NodeId,
+    SensorType,
+    SensorOutputBinding,
+)
+from opentrons_hardware.firmware_bindings.arbitration_id import (
+    ArbitrationId,
+    ArbitrationIdParts,
+)
+
+from opentrons_hardware.firmware_bindings.utils import Int32Field
+
+from opentrons_hardware.firmware_bindings.messages.fields import (
+    SensorTypeField,
+    SensorOutputBindingField,
+)
+
+from opentrons_hardware.firmware_bindings.messages.message_definitions import (
+    ReadFromSensorResponse,
+    BindSensorOutputRequest,
+)
+from opentrons_hardware.firmware_bindings.messages.payloads import (
+    BindSensorOutputRequestPayload,
+    ReadFromSensorResponsePayload,
+)
+
+from tests.conftest import MockCanMessageNotifier
+
+
+async def test_capture_output(
+    mock_messenger: mock.AsyncMock,
+    can_message_notifier: MockCanMessageNotifier,
+) -> None:
+    """Test that data is received from the polling function."""
+    subject = scheduler.SensorScheduler()
+    stim_message = BindSensorOutputRequest(
+        payload=BindSensorOutputRequestPayload(
+            sensor=SensorTypeField(SensorType.capacitive),
+            binding=SensorOutputBindingField(SensorOutputBinding.report.value),
+        )
+    )
+    reset_message = BindSensorOutputRequest(
+        payload=BindSensorOutputRequestPayload(
+            sensor=SensorTypeField(SensorType.capacitive),
+            binding=SensorOutputBindingField(SensorOutputBinding.none.value),
+        )
+    )
+    async with subject.capture_output(
+        utils.SensorInformation(
+            sensor_type=SensorType.capacitive, node_id=NodeId.pipette_left
+        ),
+        mock_messenger,
+    ) as output_queue:
+        mock_messenger.send.assert_called_with(
+            node_id=NodeId.pipette_left, message=stim_message
+        )
+        for i in range(10):
+            can_message_notifier.notify(
+                ReadFromSensorResponse(
+                    payload=ReadFromSensorResponsePayload(
+                        sensor=SensorTypeField(SensorType.capacitive.value),
+                        sensor_data=Int32Field(i << 16),
+                    )
+                ),
+                ArbitrationId(
+                    parts=ArbitrationIdParts(
+                        message_id=ReadFromSensorResponse.message_id,
+                        node_id=NodeId.host,
+                        originating_node_id=NodeId.pipette_left,
+                        function_code=0,
+                    )
+                ),
+            )
+    mock_messenger.send.assert_called_with(
+        node_id=NodeId.pipette_left, message=reset_message
+    )
+
+    def _drain() -> Iterator[float]:
+        while True:
+            try:
+                yield output_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+
+    for index, value in enumerate(_drain()):
+        assert value == index


### PR DESCRIPTION
This calibration method, rather than doing a binary search to find the
edges of the slot, sweeps a single pass over the entirety of the slot in
an axis while recording the capacitive sensor's output. By moving at a
constant speed, we should get a trace that approximates the geometry of
the slot, with rolled-off edges corresponding to the area of the probe
face that remains above the deck. Because the probe face is circular,
the rate of change of the signal should be at its most extreme when the
center of the probe is over the slot edge, when the most area is passing
by the edge. We should therefore be able to find the extrema of the
finite difference of the capacitive sensor output and set the edges
equal to the extrema.

This commit is a prototype; more needs to be done to integrate this
properly, like moving a couple constants into config, and making carved
out elements of configuration for parts of the behavior rather than
reusing configuration elements used for the binary search protocol.
