### PR TITLE
refactor(runner): delegate "was run started" logic to ProtocolEngine

### DIFF
--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -518,7 +518,7 @@ class CommandView(HasState[CommandState]):
         """Get whether an engine stop has completed."""
         return self._state.run_completed_at is not None
 
-    def get_is_started(self) -> bool:
+    def has_been_played(self) -> bool:
         """Get whether engine has started."""
         return self._state.run_started_at is not None
 

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -519,7 +519,7 @@ class CommandView(HasState[CommandState]):
         return self._state.run_completed_at is not None
 
     def get_is_started(self) -> bool:
-        """Get whether run engine has started."""
+        """Get whether engine has started."""
         return self._state.run_started_at is not None
 
     def validate_action_allowed(

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -518,6 +518,10 @@ class CommandView(HasState[CommandState]):
         """Get whether an engine stop has completed."""
         return self._state.run_completed_at is not None
 
+    def get_is_started(self) -> bool:
+        """Get whether run engine has started."""
+        return self._state.run_started_at is not None
+
     def validate_action_allowed(
         self,
         action: Union[PlayAction, PauseAction, StopAction, QueueCommandAction],

--- a/api/src/opentrons/protocol_runner/protocol_runner.py
+++ b/api/src/opentrons/protocol_runner/protocol_runner.py
@@ -81,7 +81,6 @@ class ProtocolRunner:
             ),
         )
         self._legacy_executor = legacy_executor or LegacyExecutor()
-        self._was_started = False
         # TODO(mc, 2022-01-11): replace task queue with specific implementations
         # of runner interface
         self._task_queue = task_queue or TaskQueue(cleanup_func=protocol_engine.finish)
@@ -91,7 +90,7 @@ class ProtocolRunner:
 
         This value is latched; once it is True, it will never become False.
         """
-        return self._was_started
+        return self._protocol_engine.state_view.commands.get_is_started()
 
     def load(self, protocol_source: ProtocolSource) -> None:
         """Load a ProtocolSource into managed ProtocolEngine.
@@ -122,7 +121,6 @@ class ProtocolRunner:
 
     def play(self) -> None:
         """Start or resume the run."""
-        self._was_started = True
         self._protocol_engine.play()
 
     def pause(self) -> None:
@@ -131,7 +129,7 @@ class ProtocolRunner:
 
     async def stop(self) -> None:
         """Stop (cancel) the run."""
-        if self._was_started:
+        if self.was_started():
             await self._protocol_engine.stop()
         else:
             await self._protocol_engine.finish(

--- a/api/src/opentrons/protocol_runner/protocol_runner.py
+++ b/api/src/opentrons/protocol_runner/protocol_runner.py
@@ -90,7 +90,7 @@ class ProtocolRunner:
 
         This value is latched; once it is True, it will never become False.
         """
-        return self._protocol_engine.state_view.commands.get_is_started()
+        return self._protocol_engine.state_view.commands.has_been_played()
 
     def load(self, protocol_source: ProtocolSource) -> None:
         """Load a ProtocolSource into managed ProtocolEngine.

--- a/api/tests/opentrons/protocol_engine/state/test_command_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view.py
@@ -233,10 +233,10 @@ def test_get_is_stopped() -> None:
 def test_get_is_started() -> None:
     """It should return true if start requested and no command running."""
     subject = get_command_view(run_started_at=None)
-    assert subject.get_is_started() is False
+    assert subject.has_been_played() is False
 
     subject = get_command_view(run_started_at=datetime(year=2021, day=1, month=1))
-    assert subject.get_is_started() is True
+    assert subject.has_been_played() is True
 
 
 class ActionAllowedSpec(NamedTuple):

--- a/api/tests/opentrons/protocol_engine/state/test_command_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view.py
@@ -230,6 +230,15 @@ def test_get_is_stopped() -> None:
     assert subject.get_is_stopped() is True
 
 
+def test_get_is_started() -> None:
+    """It should return true if start requested and no command running."""
+    subject = get_command_view(run_started_at=None)
+    assert subject.get_is_started() is False
+
+    subject = get_command_view(run_started_at=datetime(year=2021, day=1, month=1))
+    assert subject.get_is_started() is True
+
+
 class ActionAllowedSpec(NamedTuple):
     """Spec data to test CommandView.validate_action_allowed."""
 

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner.py
@@ -200,7 +200,6 @@ async def test_run(
     subject: ProtocolRunner,
 ) -> None:
     """It should run a protocol to completion."""
-
     decoy.when(protocol_engine.state_view.commands.get_is_started()).then_return(
         False, True
     )

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner.py
@@ -201,7 +201,9 @@ async def test_run(
 ) -> None:
     """It should run a protocol to completion."""
 
-    decoy.when(protocol_engine.state_view.commands.get_is_started()).then_return(False, True)
+    decoy.when(protocol_engine.state_view.commands.get_is_started()).then_return(
+        False, True
+    )
 
     assert subject.was_started() is False
     await subject.run()

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner.py
@@ -167,7 +167,7 @@ async def test_stop(
     subject: ProtocolRunner,
 ) -> None:
     """It should halt a protocol run with stop."""
-    decoy.when(protocol_engine.state_view.commands.get_is_started()).then_return(True)
+    decoy.when(protocol_engine.state_view.commands.has_been_played()).then_return(True)
 
     subject.play()
     await subject.stop()
@@ -182,7 +182,7 @@ async def test_stop_never_started(
     subject: ProtocolRunner,
 ) -> None:
     """It should clean up rather than halt if the runner was never started."""
-    decoy.when(protocol_engine.state_view.commands.get_is_started()).then_return(False)
+    decoy.when(protocol_engine.state_view.commands.has_been_played()).then_return(False)
 
     await subject.stop()
 
@@ -200,7 +200,7 @@ async def test_run(
     subject: ProtocolRunner,
 ) -> None:
     """It should run a protocol to completion."""
-    decoy.when(protocol_engine.state_view.commands.get_is_started()).then_return(
+    decoy.when(protocol_engine.state_view.commands.has_been_played()).then_return(
         False, True
     )
 

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner.py
@@ -167,6 +167,8 @@ async def test_stop(
     subject: ProtocolRunner,
 ) -> None:
     """It should halt a protocol run with stop."""
+    decoy.when(protocol_engine.state_view.commands.get_is_started()).then_return(True)
+
     subject.play()
     await subject.stop()
 
@@ -180,6 +182,8 @@ async def test_stop_never_started(
     subject: ProtocolRunner,
 ) -> None:
     """It should clean up rather than halt if the runner was never started."""
+    decoy.when(protocol_engine.state_view.commands.get_is_started()).then_return(False)
+
     await subject.stop()
 
     decoy.verify(
@@ -196,6 +200,9 @@ async def test_run(
     subject: ProtocolRunner,
 ) -> None:
     """It should run a protocol to completion."""
+
+    decoy.when(protocol_engine.state_view.commands.get_is_started()).then_return(False, True)
+
     assert subject.was_started() is False
     await subject.run()
     assert subject.was_started() is True


### PR DESCRIPTION
# Overview

removed _was_started prop to use commands state run_started_at

# Changelog

- Removed _was_started from ProtocolRunner
- Add get_is_started in CommandView 

# Review requests

Very small change. Make sure nothing breaks.

# Risk assessment

Very low. Should not impact logic. using prop from CommandView instead of setting through ProtocolRunner.
