### PR TITLE
fix(app): fix toast display issue on RobotSettings Advanced tab

### DIFF
--- a/app/src/atoms/Toast/__tests__/Toast.test.tsx
+++ b/app/src/atoms/Toast/__tests__/Toast.test.tsx
@@ -115,13 +115,14 @@ describe('Toast', () => {
     expect(props.onClose).toHaveBeenCalled()
   })
 
-  it('should stay more than 3 seconds when requiredTimeout is false', () => {
+  it('should stay more than 3 seconds when requiredTimeout is true', async () => {
+    jest.useFakeTimers()
     props = {
       message: 'test message',
       type: 'info',
       closeButton: false,
       onClose: jest.fn(),
-      requiredTimeout: false,
+      disableTimeout: true,
     }
     const { getByText } = render(props)
     getByText('test message')
@@ -133,5 +134,26 @@ describe('Toast', () => {
       jest.advanceTimersByTime(3000)
     })
     expect(props.onClose).not.toHaveBeenCalled()
+  })
+
+  it('should not stay more than 3 seconds when requiredTimeout is false', async () => {
+    jest.useFakeTimers()
+    props = {
+      message: 'test message',
+      type: 'info',
+      closeButton: false,
+      onClose: jest.fn(),
+      disableTimeout: false,
+    }
+    const { getByText } = render(props)
+    getByText('test message')
+    act(() => {
+      jest.advanceTimersByTime(100)
+    })
+    expect(props.onClose).not.toHaveBeenCalled()
+    act(() => {
+      jest.advanceTimersByTime(3000)
+    })
+    expect(props.onClose).toHaveBeenCalled()
   })
 })

--- a/app/src/atoms/Toast/index.tsx
+++ b/app/src/atoms/Toast/index.tsx
@@ -23,7 +23,7 @@ export interface ToastProps {
   icon?: IconProps
   closeButton?: boolean
   onClose: () => void
-  requiredTimeout?: boolean
+  disableTimeout?: boolean
 }
 
 const EXPANDED_STYLE = css`
@@ -71,9 +71,9 @@ const toastStyleByType: {
 }
 
 export function Toast(props: ToastProps): JSX.Element {
-  const { message, type, icon, closeButton, onClose, requiredTimeout } = props
+  const { message, type, icon, closeButton, onClose, disableTimeout } = props
 
-  if ((requiredTimeout ?? true) || requiredTimeout == null) {
+  if (!disableTimeout || disableTimeout == null) {
     setTimeout(() => {
       onClose()
     }, 3000)

--- a/app/src/atoms/Toast/index.tsx
+++ b/app/src/atoms/Toast/index.tsx
@@ -73,7 +73,7 @@ const toastStyleByType: {
 export function Toast(props: ToastProps): JSX.Element {
   const { message, type, icon, closeButton, onClose, requiredTimeout } = props
 
-  if (!(requiredTimeout ?? false)) {
+  if ((requiredTimeout ?? true) || requiredTimeout == null) {
     setTimeout(() => {
       onClose()
     }, 3000)

--- a/app/src/atoms/Toast/index.tsx
+++ b/app/src/atoms/Toast/index.tsx
@@ -71,9 +71,16 @@ const toastStyleByType: {
 }
 
 export function Toast(props: ToastProps): JSX.Element {
-  const { message, type, icon, closeButton, onClose, disableTimeout } = props
+  const {
+    message,
+    type,
+    icon,
+    closeButton,
+    onClose,
+    disableTimeout = false,
+  } = props
 
-  if (!disableTimeout || disableTimeout == null) {
+  if (!disableTimeout) {
     setTimeout(() => {
       onClose()
     }, 3000)

--- a/app/src/organisms/Devices/DownloadRunLogToast.tsx
+++ b/app/src/organisms/Devices/DownloadRunLogToast.tsx
@@ -74,7 +74,7 @@ export function DownloadRunLogToast({
       icon={isError ? undefined : toastIcon}
       closeButton={isError}
       onClose={onClose}
-      requiredTimeout={false}
+      disableTimeout={true}
     />
   )
 }

--- a/app/src/organisms/Devices/DownloadRunLogToast.tsx
+++ b/app/src/organisms/Devices/DownloadRunLogToast.tsx
@@ -74,7 +74,7 @@ export function DownloadRunLogToast({
       icon={isError ? undefined : toastIcon}
       closeButton={isError}
       onClose={onClose}
-      requiredTimeout={true}
+      requiredTimeout={false}
     />
   )
 }

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsAdvanced.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsAdvanced.tsx
@@ -129,7 +129,7 @@ export function RobotSettingsAdvanced({
           icon={toastIcon}
           closeButton={false}
           onClose={() => setShowDownloadToast(false)}
-          requiredTimeout={false}
+          requiredTimeout={true}
         />
       )}
       <Box>

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsAdvanced.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsAdvanced.tsx
@@ -129,7 +129,7 @@ export function RobotSettingsAdvanced({
           icon={toastIcon}
           closeButton={false}
           onClose={() => setShowDownloadToast(false)}
-          requiredTimeout={false}
+          disableTimeout={true}
         />
       )}
       <Box>

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsAdvanced.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsAdvanced.tsx
@@ -129,7 +129,7 @@ export function RobotSettingsAdvanced({
           icon={toastIcon}
           closeButton={false}
           onClose={() => setShowDownloadToast(false)}
-          requiredTimeout={true}
+          requiredTimeout={false}
         />
       )}
       <Box>


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR fixes the following.
1. The Downloading logs Toast display issue
Currently, the toast shows up over and over since this toast passes the wrong prop value to the Toast component
2.  `requiredTimeout` issue
`requiredTimeout` is to deactivate default `setTimeout` but the current implementation would make devs confused.
Because `requiredTimeout={true}` deactivate setTimeout and the prop name is inappropriate.

Close #10624


https://user-images.githubusercontent.com/474225/172207790-7e61ac71-1fde-48ce-b471-158d3f74ddf9.mov



<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- Chage Toast `requiredTimeout` to `disableTimeout`
- Update passed value of the RobotSettings Advanced tab
- Update DownloadRunLogToast prop name
- Update Toast test cases (add an explicit, `disabledTimeout={false}`)
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- Downloading Toast stays until the end of downloading logs
Step1. Click `Devises` Tab
Step2. Click the overflow menu on a device and click `RobotSettings`
Step3. Click `Advanced` Tab
Step4. Click `Download logs` button
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
