### PR TITLE
refactor(app): adjust update app modal position and background opacity

### DIFF
--- a/app/src/organisms/AppSettings/GeneralSettings.tsx
+++ b/app/src/organisms/AppSettings/GeneralSettings.tsx
@@ -35,6 +35,7 @@ import {
   alertUnignored,
 } from '../../redux/alerts'
 import { useTrackEvent } from '../../redux/analytics'
+import { Portal } from '../../App/portal'
 import { UpdateAppModal } from '../UpdateAppModal'
 import { PreviousVersionModal } from './PreviousVersionModal'
 import { ConnectRobotSlideout } from './ConnectRobotSlideout'
@@ -244,7 +245,9 @@ export function GeneralSettings(): JSX.Element {
         </Flex>
       </Box>
       {showUpdateModal ? (
-        <UpdateAppModal closeModal={() => setShowUpdateModal(false)} />
+        <Portal level="top">
+          <UpdateAppModal closeModal={() => setShowUpdateModal(false)} />
+        </Portal>
       ) : null}
       {showPreviousVersionModal ? (
         <PreviousVersionModal

--- a/app/src/organisms/UpdateAppModal/index.tsx
+++ b/app/src/organisms/UpdateAppModal/index.tsx
@@ -28,7 +28,6 @@ import {
   Flex,
   Icon,
   SecondaryBtn,
-  COLORS,
   Text,
 } from '@opentrons/components'
 
@@ -158,7 +157,7 @@ export function UpdateAppModal(props: UpdateAppModalProps): JSX.Element {
   // component built with BaseModal
   return (
     <BaseModal
-      overlayColor="rgba(115,115,115,0.9)"
+      overlayColor="#737373e6"
       maxWidth="38rem"
       fontSize={FONT_SIZE_BODY_2}
       header={

--- a/app/src/organisms/UpdateAppModal/index.tsx
+++ b/app/src/organisms/UpdateAppModal/index.tsx
@@ -158,7 +158,7 @@ export function UpdateAppModal(props: UpdateAppModalProps): JSX.Element {
   // component built with BaseModal
   return (
     <BaseModal
-      overlayColor={`${COLORS.darkBlack}80`}
+      overlayColor="rgba(115,115,115,0.9)"
       maxWidth="38rem"
       fontSize={FONT_SIZE_BODY_2}
       header={

--- a/app/src/organisms/UpdateAppModal/index.tsx
+++ b/app/src/organisms/UpdateAppModal/index.tsx
@@ -28,6 +28,7 @@ import {
   Flex,
   Icon,
   SecondaryBtn,
+  COLORS,
   Text,
 } from '@opentrons/components'
 
@@ -157,6 +158,7 @@ export function UpdateAppModal(props: UpdateAppModalProps): JSX.Element {
   // component built with BaseModal
   return (
     <BaseModal
+      overlayColor={`${COLORS.darkBlack}80`}
       maxWidth="38rem"
       fontSize={FONT_SIZE_BODY_2}
       header={


### PR DESCRIPTION
closes #10434

# Overview

As outlined in the ticket, the update app modal launched during start up and when you navigate to the App general settings page is located in different positions. This PR fixes it as well as darkens the background

# Changelog

- edit `UpdateAppModal` background color
- add `Portal` to `GeneralSettings`

# Review requests

When you have a app update available:
- freshly launch the app, the modal should be centered in the middle of the overall app dimensions.
- navigate to the App general settings, the modal should be centered in the middle of the overall app dimensions.
- the background color of both should be dark enough to clearly differentiate between the modal vs app

# Risk assessment

low