### PR TITLE
refactor(app): poll robot lights status

### DIFF
--- a/app/src/organisms/Devices/RobotOverview.tsx
+++ b/app/src/organisms/Devices/RobotOverview.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import {
   Box,
   Flex,
+  useInterval,
   ALIGN_CENTER,
   ALIGN_START,
   C_MED_LIGHT_GRAY,
@@ -20,6 +21,8 @@ import {
 import OT2_PNG from '../../assets/images/OT2-R_HERO.png'
 import { ToggleButton, PrimaryButton } from '../../atoms/buttons'
 import { StyledText } from '../../atoms/text'
+import { useDispatchApiRequest } from '../../redux/robot-api'
+import { fetchLights } from '../../redux/robot-controls'
 import { useCurrentRunId } from '../ProtocolUpload/hooks'
 import { ChooseProtocolSlideout } from '../ChooseProtocolSlideout'
 import { Portal } from '../../App/portal'
@@ -30,6 +33,8 @@ import { ReachableBanner } from './ReachableBanner'
 import { RobotOverviewOverflowMenu } from './RobotOverviewOverflowMenu'
 import { useLights, useRobot } from './hooks'
 
+const EQUIPMENT_POLL_MS = 5000
+
 interface RobotOverviewProps {
   robotName: string
 }
@@ -38,6 +43,7 @@ export function RobotOverview({
   robotName,
 }: RobotOverviewProps): JSX.Element | null {
   const { t } = useTranslation(['device_details', 'shared'])
+  const [dispatchRequest] = useDispatchApiRequest()
 
   const robot = useRobot(robotName)
   const [
@@ -46,6 +52,14 @@ export function RobotOverview({
   ] = React.useState<boolean>(false)
   const { lightsOn, toggleLights } = useLights(robotName)
   const currentRunId = useCurrentRunId()
+
+  useInterval(
+    () => {
+      dispatchRequest(fetchLights(robotName))
+    },
+    EQUIPMENT_POLL_MS,
+    true
+  )
 
   return robot != null ? (
     <Flex

--- a/app/src/organisms/Devices/__tests__/RobotOverview.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotOverview.test.tsx
@@ -8,12 +8,18 @@ import { i18n } from '../../../i18n'
 import { useCurrentRunId } from '../../ProtocolUpload/hooks'
 import { ChooseProtocolSlideout } from '../../ChooseProtocolSlideout'
 import { mockConnectableRobot } from '../../../redux/discovery/__fixtures__'
+import { useDispatchApiRequest } from '../../../redux/robot-api'
+import { fetchLights } from '../../../redux/robot-controls'
 import { useLights, useRobot } from '../hooks'
 import { UpdateRobotBanner } from '../../UpdateRobotBanner'
 import { RobotStatusBanner } from '../RobotStatusBanner'
 import { RobotOverview } from '../RobotOverview'
 import { RobotOverviewOverflowMenu } from '../RobotOverviewOverflowMenu'
 
+import type { DispatchApiRequestType } from '../../../redux/robot-api'
+
+jest.mock('../../../redux/robot-api')
+jest.mock('../../../redux/robot-controls')
 jest.mock('../../ProtocolUpload/hooks')
 jest.mock('../hooks')
 jest.mock('../RobotStatusBanner')
@@ -40,6 +46,10 @@ const mockUpdateRobotBanner = UpdateRobotBanner as jest.MockedFunction<
 const mockRobotOverviewOverflowMenu = RobotOverviewOverflowMenu as jest.MockedFunction<
   typeof RobotOverviewOverflowMenu
 >
+const mockUseDispatchApiRequest = useDispatchApiRequest as jest.MockedFunction<
+  typeof useDispatchApiRequest
+>
+const mockFetchLights = fetchLights as jest.MockedFunction<typeof fetchLights>
 
 const mockToggleLights = jest.fn()
 
@@ -55,7 +65,11 @@ const render = () => {
 }
 
 describe('RobotOverview', () => {
+  let dispatchApiRequest: DispatchApiRequestType
+
   beforeEach(() => {
+    dispatchApiRequest = jest.fn()
+    mockUseDispatchApiRequest.mockReturnValue([dispatchApiRequest, []])
     mockUseLights.mockReturnValue({
       lightsOn: false,
       toggleLights: mockToggleLights,
@@ -91,6 +105,11 @@ describe('RobotOverview', () => {
   it('renders a UpdateRobotBanner component', () => {
     const [{ getByText }] = render()
     getByText('Mock UpdateRobotBanner')
+  })
+
+  it('fetches lights status', () => {
+    render()
+    expect(dispatchApiRequest).toBeCalledWith(mockFetchLights('otie'))
   })
 
   it('renders a lights toggle button', () => {

--- a/app/src/organisms/Devices/hooks/__tests__/useLights.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useLights.test.tsx
@@ -6,11 +6,7 @@ import { renderHook } from '@testing-library/react-hooks'
 import { QueryClient, QueryClientProvider } from 'react-query'
 
 import { useDispatchApiRequest } from '../../../../redux/robot-api'
-import {
-  fetchLights,
-  updateLights,
-  getLightsOn,
-} from '../../../../redux/robot-controls'
+import { updateLights, getLightsOn } from '../../../../redux/robot-controls'
 import { useLights } from '..'
 
 import type { DispatchApiRequestType } from '../../../../redux/robot-api'
@@ -18,7 +14,6 @@ import type { DispatchApiRequestType } from '../../../../redux/robot-api'
 jest.mock('../../../../redux/robot-api')
 jest.mock('../../../../redux/robot-controls')
 
-const mockFetchLights = fetchLights as jest.MockedFunction<typeof fetchLights>
 const mockGetLightsOn = getLightsOn as jest.MockedFunction<typeof getLightsOn>
 const mockUpdateLights = updateLights as jest.MockedFunction<
   typeof updateLights
@@ -57,7 +52,6 @@ describe('useLights hook', () => {
 
     const { result } = renderHook(() => useLights('otie'), { wrapper })
 
-    expect(dispatchApiRequest).toBeCalledWith(mockFetchLights('otie'))
     expect(result.current.lightsOn).toEqual(true)
     result.current.toggleLights()
     expect(dispatchApiRequest).toBeCalledWith(mockUpdateLights('otie', false))
@@ -72,7 +66,6 @@ describe('useLights hook', () => {
       wrapper,
     })
 
-    expect(dispatchApiRequest).toBeCalledWith(mockFetchLights('otie'))
     expect(result.current.lightsOn).toEqual(false)
     result.current.toggleLights()
     expect(dispatchApiRequest).toBeCalledWith(mockUpdateLights('otie', true))

--- a/app/src/organisms/Devices/hooks/useLights.ts
+++ b/app/src/organisms/Devices/hooks/useLights.ts
@@ -1,12 +1,7 @@
-import React from 'react'
 import { useSelector } from 'react-redux'
 
 import { useDispatchApiRequest } from '../../../redux/robot-api'
-import {
-  fetchLights,
-  updateLights,
-  getLightsOn,
-} from '../../../redux/robot-controls'
+import { updateLights, getLightsOn } from '../../../redux/robot-controls'
 
 import type { State } from '../../../redux/types'
 
@@ -20,12 +15,6 @@ export function useLights(
   const toggleLights = (): void => {
     dispatchRequest(updateLights(robotName, !lightsOn))
   }
-
-  React.useEffect(() => {
-    if (robotName != null) {
-      dispatchRequest(fetchLights(robotName))
-    }
-  }, [dispatchRequest, robotName])
 
   return { lightsOn, toggleLights }
 }


### PR DESCRIPTION
# Overview

poll robot lights status on a 5 second interval within the RobotOverview component

closes #10246

# Changelog

 - Polls robot lights status

# Review requests

if possible, confirm that lights status updated on client 1 is reflected on client 2. and, that the RobotOverview component is the correct place to poll on a 5 second interval.

# Risk assessment

low
