### PR TITLE
fix(app): fix refresh robots spinner spacing and double icon

### DIFF
--- a/app/src/pages/Devices/DevicesLanding/index.tsx
+++ b/app/src/pages/Devices/DevicesLanding/index.tsx
@@ -121,27 +121,26 @@ export function DevicesLanding(): JSX.Element {
 function DevicesLoadingState(): JSX.Element {
   const { t } = useTranslation('devices_landing')
   return (
-    <Flex flexDirection={DIRECTION_COLUMN} alignItems={ALIGN_CENTER}>
-      <StyledText as="h1" marginTop="20vh">
-        {t('looking_for_robots')}
-      </StyledText>
+    <Flex
+      flexDirection={DIRECTION_COLUMN}
+      alignItems={ALIGN_CENTER}
+      marginTop="10vh"
+      marginBottom="10vh"
+    >
+      <StyledText as="h1">{t('looking_for_robots')}</StyledText>
       <Icon
         name="ot-spinner"
         aria-label="ot-spinner"
         spin
         size={SIZE_2}
         marginTop={SPACING.spacing4}
+        marginBottom={SPACING.spacing4}
       />
       <ExternalLink
         href={TROUBLESHOOTING_CONNECTION_PROBLEMS_URL}
         id="DevicesEmptyState_troubleshootingConnectionProblems"
       >
         {t('troubleshooting_connection_problems')}
-        <Icon
-          name="open-in-new"
-          size="0.675rem"
-          marginLeft={SPACING.spacing2}
-        />
       </ExternalLink>
     </Flex>
   )


### PR DESCRIPTION
# Overview
Address 6.0 beta feedback re: refreshing robot spinner spacing and double icon
Closes #10483

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- fixed spacing
- removed extra icon
<img width="1023" alt="Screen Shot 2022-06-07 at 12 57 26 PM" src="https://user-images.githubusercontent.com/6225496/172439901-e73ada07-817e-43b0-b3af-7e8e68f0334e.png">


<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Click refresh robots button to confirm spacing is fixed and double open in new window icon has been removed.
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Low
