### PR TITLE
feat(app): wire up Modal warning for Clear unavailable robots list button

### DIFF
--- a/app/src/assets/localization/en/app_settings.json
+++ b/app/src/assets/localization/en/app_settings.json
@@ -86,5 +86,10 @@
   "override_path": "override path",
   "no_specified_folder": "No path specified",
   "add_override_path": "Add override path",
-  "reset_to_default": "Reset to default"
+  "reset_to_default": "Reset to default",
+  "clear_unavailable_robots": "Clear unavailable robots?",
+  "clear_confirm": "Clear unavailable robots",
+  "clearing_cannot_be_undone": "Clearing the list of unavailable robots on the Devices page cannot be undone.",
+  "successfully_deleted_unavail_robots": "Successfully deleted unavailable robots",
+  "no_unavail_robots_to_clear": "No unavailable robots to clear"
 }

--- a/app/src/organisms/AppSettings/AdvancedSettings.tsx
+++ b/app/src/organisms/AppSettings/AdvancedSettings.tsx
@@ -103,8 +103,12 @@ export function AdvancedSettings(): JSX.Element {
     unreachableRobots.length > 0 || recentlySeenRobots.length > 0
 
   const handleDeleteUnavailRobots = (): void => {
-    isUnavailableRobots ? setShowSuccessToast(true) : setShowErrorToast(true)
-    dispatch(clearDiscoveryCache())
+    if (isUnavailableRobots) {
+      setShowSuccessToast(true)
+      dispatch(clearDiscoveryCache())
+    } else {
+      setShowErrorToast(true)
+    }
   }
 
   const {

--- a/app/src/organisms/AppSettings/AdvancedSettings.tsx
+++ b/app/src/organisms/AppSettings/AdvancedSettings.tsx
@@ -18,18 +18,34 @@ import {
   TYPOGRAPHY,
   DIRECTION_COLUMN,
   TEXT_DECORATION_UNDERLINE,
+  useConditionalConfirm,
+  TEXT_TRANSFORM_CAPITALIZE,
+  JUSTIFY_FLEX_END,
+  Btn,
+  DIRECTION_ROW,
 } from '@opentrons/components'
 import * as Config from '../../redux/config'
 import * as Calibration from '../../redux/calibration'
 import * as CustomLabware from '../../redux/custom-labware'
-import { clearDiscoveryCache } from '../../redux/discovery'
+import {
+  clearDiscoveryCache,
+  getReachableRobots,
+  getUnreachableRobots,
+} from '../../redux/discovery'
+import { Modal } from '../../atoms/Modal'
+import { Portal } from '../../App/portal'
+import { Toast } from '../../atoms/Toast'
 import {
   getU2EAdapterDevice,
   getU2EWindowsDriverStatus,
   OUTDATED,
 } from '../../redux/system-info'
 import { Divider } from '../../atoms/structure'
-import { TertiaryButton, ToggleButton } from '../../atoms/buttons'
+import {
+  AlertPrimaryButton,
+  TertiaryButton,
+  ToggleButton,
+} from '../../atoms/buttons'
 import { StyledText } from '../../atoms/text'
 import { Banner } from '../../atoms/Banner'
 
@@ -52,7 +68,7 @@ type BlockSelection =
   | typeof ALWAYS_PROMPT
 
 export function AdvancedSettings(): JSX.Element {
-  const { t } = useTranslation('app_settings')
+  const { t } = useTranslation(['app_settings', 'shared'])
   const pythonDirectoryFileInput = React.useRef<HTMLInputElement>(null)
   const useTrashSurfaceForTipCal = useSelector((state: State) =>
     Config.getUseTrashSurfaceForTipCal(state)
@@ -72,6 +88,30 @@ export function AdvancedSettings(): JSX.Element {
   const pathToPythonInterpreter = useSelector(Config.getPathToPythonOverride)
 
   const dispatch = useDispatch<Dispatch>()
+  const [showSuccessToast, setShowSuccessToast] = React.useState(false)
+  const [showErrorToast, setShowErrorToast] = React.useState(false)
+  const reachableRobots = useSelector((state: State) =>
+    getReachableRobots(state)
+  )
+  const unreachableRobots = useSelector((state: State) =>
+    getUnreachableRobots(state)
+  )
+  const recentlySeenRobots = reachableRobots.filter(
+    robot => robot.healthStatus !== 'ok'
+  )
+  const isUnavailableRobots =
+    unreachableRobots.length > 0 || recentlySeenRobots.length > 0
+
+  const handleDeleteUnavailRobots = (): void => {
+    isUnavailableRobots ? setShowSuccessToast(true) : setShowErrorToast(true)
+    dispatch(clearDiscoveryCache())
+  }
+
+  const {
+    confirm: confirmDeleteUnavailRobots,
+    showConfirmation: showConfirmDeleteUnavailRobots,
+    cancel: cancelExit,
+  } = useConditionalConfirm(handleDeleteUnavailRobots, true)
 
   const handleUseTrashSelection = (selection: BlockSelection): void => {
     switch (selection) {
@@ -144,6 +184,57 @@ export function AdvancedSettings(): JSX.Element {
           justifyContent={JUSTIFY_SPACE_BETWEEN}
           gridGap={SPACING.spacing4}
         >
+          {showSuccessToast && (
+            <Toast
+              message={t('successfully_deleted_unavail_robots')}
+              type={'success'}
+              onClose={() => setShowSuccessToast(false)}
+            />
+          )}
+          {showErrorToast && (
+            <Toast
+              message={t('no_unavail_robots_to_clear')}
+              type={'error'}
+              onClose={() => setShowErrorToast(false)}
+            />
+          )}
+          {showConfirmDeleteUnavailRobots ? (
+            <Portal level="top">
+              <Modal
+                type="warning"
+                title={t('clear_unavailable_robots')}
+                onClose={cancelExit}
+              >
+                <StyledText as="p">{t('clearing_cannot_be_undone')}</StyledText>
+                <Flex
+                  flexDirection={DIRECTION_ROW}
+                  paddingTop={SPACING.spacingXL}
+                  justifyContent={JUSTIFY_FLEX_END}
+                >
+                  <Flex
+                    paddingRight={SPACING.spacing2}
+                    data-testid={`AdvancedSettings_ConfirmClear_Cancel
+                    `}
+                  >
+                    <Btn
+                      onClick={cancelExit}
+                      textTransform={TEXT_TRANSFORM_CAPITALIZE}
+                      color={COLORS.blue}
+                      fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+                      marginRight={SPACING.spacing6}
+                    >
+                      {t('shared:cancel')}
+                    </Btn>
+                  </Flex>
+                  <Flex data-testid={`AdvancedSettings_ConfirmClear_Proceed`}>
+                    <AlertPrimaryButton onClick={confirmDeleteUnavailRobots}>
+                      {t('clear_confirm')}
+                    </AlertPrimaryButton>
+                  </Flex>
+                </Flex>
+              </Modal>
+            </Portal>
+          ) : null}
           <Box width="70%">
             <StyledText
               css={TYPOGRAPHY.h3SemiBold}
@@ -414,7 +505,7 @@ export function AdvancedSettings(): JSX.Element {
           </Box>
           <TertiaryButton
             marginLeft={SPACING_AUTO}
-            onClick={() => dispatch(clearDiscoveryCache())}
+            onClick={confirmDeleteUnavailRobots}
             id="AdvancedSettings_clearUnavailableRobots"
           >
             {t('clear_robots_button')}


### PR DESCRIPTION
closes #10511

# Overview

This PR wires up the Clear unavailable robots list button fully in the App Advanced settings. Now when you click on the button, a warning modal appears telling you what the action does. You can confirm or exit. If you confirm, there is a toast that renders at the bottom if you are successful or not. (Not successful means you tried to clear unavailable robots when there were none to clear)

# Changelog

- add `Modal` and `Toast` to `AdvancedSettings`
- add a few hooks/selectors: `useConditionalRender`, `getReachableRobots`, `getReachableRobots`
- update test

# Review requests

- when you have a robot under the `Unavailable Robots` section in the Devices Landing page, navigate to App Advanced Settings. Scroll down and find the `Clear unavailable robots list` button. When you click on it, a modal should render. Clicking on the confirm option, a success toast should render at the bottom of the page. When navigating back to the Devices Landing page, the unavailable robots should be gone.
- when you do not have a robot under the `Unavailable Robots` page, navigate back to the `Clear unavailable robots list` button. When you click on it, the same modal should appear. When you hit the confirm option, an error toast should render.

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
