### PR TITLE
fix(app): App fix deck cal button disabled issue

### DIFF
--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
@@ -198,13 +198,13 @@ export function RobotSettingsCalibration({
 
   const isPending =
     useSelector<State, RequestState | null>(state =>
-      trackedRequestId.current
+      trackedRequestId.current != null
         ? RobotApi.getRequestById(state, trackedRequestId.current)
         : null
     )?.status === RobotApi.PENDING
 
   const createRequest = useSelector((state: State) =>
-    createRequestId.current
+    createRequestId.current != null
       ? RobotApi.getRequestById(state, createRequestId.current)
       : null
   )
@@ -215,7 +215,7 @@ export function RobotSettingsCalibration({
 
   const isJogging =
     useSelector((state: State) =>
-      jogRequestId.current
+      jogRequestId.current != null
         ? RobotApi.getRequestById(state, jogRequestId.current)
         : null
     )?.status === RobotApi.PENDING

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
@@ -50,6 +50,7 @@ import {
   useTipLengthCalibrations,
   useDeckCalibrationStatus,
   useIsRobotBusy,
+  useAttachedPipettes,
 } from '../hooks'
 import { DeckCalibrationConfirmModal } from './DeckCalibrationConfirmModal'
 import { PipetteOffsetCalibrationItems } from './CalibrationDetails/PipetteOffsetCalibrationItems'
@@ -183,9 +184,7 @@ export function RobotSettingsCalibration({
   const deckCalibrationData = useDeckCalibrationData(robot?.name)
   const pipetteOffsetCalibrations = usePipetteOffsetCalibrations(robot?.name)
   const tipLengthCalibrations = useTipLengthCalibrations(robot?.name)
-  const attachedPipettes = useSelector((state: State) => {
-    return Pipettes.getAttachedPipettes(state, robotName)
-  })
+  const attachedPipettes = useAttachedPipettes()
 
   const isRunning = useSelector(robotSelectors.getIsRunning)
 
@@ -283,9 +282,10 @@ export function RobotSettingsCalibration({
     )
   }
 
-  const deckCalibrationButtonText = deckCalibrationData.isDeckCalibrated
-    ? t('deck_calibration_recalibrate_button')
-    : t('deck_calibration_calibrate_button')
+  const deckCalibrationButtonText =
+    deckCalStatus && deckCalStatus !== Calibration.DECK_CAL_STATUS_IDENTITY
+      ? t('deck_calibration_recalibrate_button')
+      : t('deck_calibration_calibrate_button')
 
   const disabledOrBusyReason = isPending
     ? t('robot_calibration:deck_calibration_spinner', {
@@ -520,7 +520,7 @@ export function RobotSettingsCalibration({
         {createStatus === RobotApi.FAILURE && (
           <AlertModal
             alertOverlay
-            heading={t('deck_calibration_failure')}
+            heading={t('robot_calibration:deck_calibration_failure')}
             buttons={[
               {
                 children: t('shared:ok'),

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
@@ -194,27 +194,28 @@ export function RobotSettingsCalibration({
   )
 
   const pipettePresent =
-    !(attachedPipettes?.left == null) || !(attachedPipettes?.right == null)
+    !(attachedPipettes.left == null) || !(attachedPipettes.right == null)
 
   const isPending =
     useSelector<State, RequestState | null>(state =>
-      trackedRequestId.current != null
+      trackedRequestId.current
         ? RobotApi.getRequestById(state, trackedRequestId.current)
         : null
     )?.status === RobotApi.PENDING
 
   const createRequest = useSelector((state: State) =>
-    createRequestId.current != null
+    createRequestId.current
       ? RobotApi.getRequestById(state, createRequestId.current)
       : null
   )
+
   const createStatus = createRequest?.status
 
   const configHasCalibrationBlock = useSelector(Config.getHasCalibrationBlock)
 
   const isJogging =
     useSelector((state: State) =>
-      jogRequestId.current != null
+      jogRequestId.current
         ? RobotApi.getRequestById(state, jogRequestId.current)
         : null
     )?.status === RobotApi.PENDING
@@ -609,7 +610,7 @@ export function RobotSettingsCalibration({
           </Box>
           <TertiaryButton
             onClick={() => handleClickDeckCalibration()}
-            disabled={disabledOrBusyReason !== null}
+            disabled={disabledOrBusyReason != null}
           >
             {deckCalibrationButtonText}
           </TertiaryButton>

--- a/app/src/organisms/Devices/RobotSettings/__tests__/RobotSettingsCalibration.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/__tests__/RobotSettingsCalibration.test.tsx
@@ -271,7 +271,7 @@ describe('RobotSettingsCalibration', () => {
     getByText(
       'Deck calibration measures the deck position relative to the gantry. This calibration is the foundation for tip length and pipette offset calibrations. Calibrate your deck during new robot setup. Redo deck calibration if you relocate your robot.'
     )
-    getByRole('button', { name: 'Recalibrate deck' })
+    getByRole('button', { name: 'Calibrate deck' })
     getByText('Last calibrated: September 15, 2021 00:00')
   })
 
@@ -298,9 +298,7 @@ describe('RobotSettingsCalibration', () => {
     getByRole('button', { name: 'Calibrate now' })
   })
 
-  // TODO kj 06/02/2022 temporarily skip this case and this will be solved by another PR
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('should call update robot status if a robot is busy - deck cal', () => {
+  it('should call update robot status if a robot is busy - deck cal', () => {
     mockUseDeckCalibrationStatus.mockReturnValue(
       Calibration.DECK_CAL_STATUS_IDENTITY
     )
@@ -311,7 +309,7 @@ describe('RobotSettingsCalibration', () => {
     mockGetIsRunning.mockReturnValue(false)
     mockUseIsRobotBusy.mockReturnValue(true)
     const [{ getByRole }] = render()
-    const button = getByRole('button', { name: 'Recalibrate deck' })
+    const button = getByRole('button', { name: 'Calibrate deck' })
     fireEvent.click(button)
     expect(mockUpdateRobotStatus).toHaveBeenCalled()
   })
@@ -330,21 +328,21 @@ describe('RobotSettingsCalibration', () => {
   it('recalibration button is disabled when a robot is unreachable', () => {
     mockUseRobot.mockReturnValue(mockUnreachableRobot)
     const [{ getByRole }] = render()
-    const button = getByRole('button', { name: 'Recalibrate deck' })
+    const button = getByRole('button', { name: 'Calibrate deck' })
     expect(button).toBeDisabled()
   })
 
   it('recalibration button is disabled when a robot is running', () => {
     mockGetIsRunning.mockReturnValue(true)
     const [{ getByRole }] = render()
-    const button = getByRole('button', { name: 'Recalibrate deck' })
+    const button = getByRole('button', { name: 'Calibrate deck' })
     expect(button).toBeDisabled()
   })
 
-  it('recalibration button is disabled when a robot pipettes are null', () => {
+  it('deck calibration button is disabled when a robot pipettes are null', () => {
     mockUseAttachedPipettes.mockReturnValue({ left: null, right: null })
     const [{ getByRole }] = render()
-    const button = getByRole('button', { name: 'Recalibrate deck' })
+    const button = getByRole('button', { name: 'Calibrate deck' })
     expect(button).toBeDisabled()
   })
 
@@ -392,7 +390,7 @@ describe('RobotSettingsCalibration', () => {
   it('renders a Check health button', () => {
     const [{ getByRole }] = render()
     const button = getByRole('button', { name: 'Check health' })
-    expect(button).toBeDisabled()
+    expect(button).not.toBeDisabled()
   })
 
   it('Health check button is disabled when a robot is unreachable', () => {


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
The issue was that the component used `Pipettes.getAttachedPipettes` instead of hooks for attached pipettes data.
This will close #10638 
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- Remove `Pipettes.getAttachedPipettes` and use `useAttachedPipettes`
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- deck cal button is not disabled when pipette/pipettes are attached (not calibrated)
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
