### PR TITLE
fix(app): this will fix overflow menu overlapping issue on RobotSettings Calibration Tab

### DIFF
--- a/app/src/organisms/Devices/RobotSettings/CalibrationDetails/OverflowMenu.tsx
+++ b/app/src/organisms/Devices/RobotSettings/CalibrationDetails/OverflowMenu.tsx
@@ -11,6 +11,7 @@ import {
   POSITION_RELATIVE,
   ALIGN_FLEX_END,
   Mount,
+  useOnClickOutside,
 } from '@opentrons/components'
 
 import { OverflowBtn } from '../../../../atoms/MenuList/OverflowBtn'
@@ -63,6 +64,9 @@ export function OverflowMenu({
   const { t } = useTranslation('device_settings')
   const doTrackEvent = useTrackEvent()
   const [showOverflowMenu, setShowOverflowMenu] = React.useState<boolean>(false)
+  const calsOverflowWrapperRef = useOnClickOutside({
+    onClickOutside: () => setShowOverflowMenu(false),
+  }) as React.RefObject<HTMLDivElement>
   const [
     startPipetteOffsetCalibration,
     PipetteOffsetCalibrationWizard,
@@ -138,8 +142,8 @@ export function OverflowMenu({
       } else {
         startPipetteOffsetPossibleTLC({ keepTipLength: false })
       }
-      setShowOverflowMenu(!showOverflowMenu)
     }
+    setShowOverflowMenu(!showOverflowMenu)
   }
 
   const handleDownload = (
@@ -168,6 +172,7 @@ export function OverflowMenu({
 
   const handleOverflowClick: React.MouseEventHandler<HTMLButtonElement> = e => {
     e.preventDefault()
+    e.stopPropagation()
     setShowOverflowMenu(!showOverflowMenu)
   }
 
@@ -192,6 +197,7 @@ export function OverflowMenu({
       />
       {showOverflowMenu ? (
         <Flex
+          ref={calsOverflowWrapperRef}
           width={calType === 'pipetteOffset' ? '11.25rem' : '17.25rem'}
           zIndex={10}
           borderRadius={'4px 4px 0px 0px'}


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR fix the overflow menu overlapping issue on the RobotSetings calibration tab page
fix #10640


https://user-images.githubusercontent.com/474225/172490492-d505643b-d27e-4481-a8d7-25784d495892.mov



<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- Add useOnClickOutside to fix the overlapping issue
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- overflow menu doesn't overlap 
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
