### PR TITLE
fix(app): close pipette and module overflow menus on click

### DIFF
--- a/app/src/organisms/Devices/ModuleCard/__tests__/ModuleCard.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/ModuleCard.test.tsx
@@ -229,9 +229,9 @@ describe('ModuleCard', () => {
     getByAltText('heaterShakerModuleV1')
   })
 
-  it('renders kebab icon and is clickable', () => {
+  it('renders kebab icon, opens and closes overflow menu on click', () => {
     mockUseModuleIdFromRun.mockReturnValue({ moduleIdFromRun: 'magdeck_id' })
-    const { getByRole, getByText } = render({
+    const { getByRole, getByText, queryByText } = render({
       module: mockMagneticModule,
       robotName: mockRobot.name,
     })
@@ -241,7 +241,9 @@ describe('ModuleCard', () => {
     getByText('Magnetic Module GEN1')
     fireEvent.click(overflowButton)
     expect(overflowButton).not.toBeDisabled()
-    getByText('mock module overflow menu')
+    const overflowMenu = getByText('mock module overflow menu')
+    overflowMenu.click()
+    expect(queryByText('mock module overflow menu')).toBeNull()
   })
 
   it('renders kebab icon and it is disabled when run is in progress', () => {

--- a/app/src/organisms/Devices/ModuleCard/index.tsx
+++ b/app/src/organisms/Devices/ModuleCard/index.tsx
@@ -417,9 +417,10 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
           )}
         </Box>
         {showOverflowMenu && (
-          <div
+          <Box
             ref={moduleOverflowWrapperRef}
             data-testid={`ModuleCard_overflow_menu_${module.serialNumber}`}
+            onClick={() => setShowOverflowMenu(false)}
           >
             <ModuleOverflowMenu
               handleAboutClick={handleAboutClick}
@@ -429,7 +430,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
               handleTestShakeClick={handleTestShakeClick}
               handleWizardClick={handleWizardClick}
             />
-          </div>
+          </Box>
         )}
       </Flex>
     </React.Fragment>

--- a/app/src/organisms/Devices/PipetteCard/__tests__/PipetteCard.test.tsx
+++ b/app/src/organisms/Devices/PipetteCard/__tests__/PipetteCard.test.tsx
@@ -187,8 +187,8 @@ describe('PipetteCard', () => {
     getByText('left Mount')
     getByText('Empty')
   })
-  it('renders kebab icon and is clickable', () => {
-    const { getByRole, getByText } = render({
+  it('renders kebab icon, opens and closes overflow menu on click', () => {
+    const { getByRole, getByText, queryByText } = render({
       pipetteInfo: mockRightSpecs,
       mount: RIGHT,
       robotName: mockRobotName,
@@ -200,6 +200,8 @@ describe('PipetteCard', () => {
 
     fireEvent.click(overflowButton)
     expect(overflowButton).not.toBeDisabled()
-    getByText('mock pipette overflow menu')
+    const overflowMenu = getByText('mock pipette overflow menu')
+    overflowMenu.click()
+    expect(queryByText('mock pipette overflow menu')).toBeNull()
   })
 })

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -53,7 +53,7 @@ interface PipetteCardProps {
 const FETCH_PIPETTE_CAL_MS = 30000
 
 export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
-  const { t } = useTranslation('device_details')
+  const { t } = useTranslation(['device_details', 'protocol_setup'])
   const [showOverflowMenu, setShowOverflowMenu] = React.useState(false)
   const { pipetteInfo, mount, robotName, pipetteId } = props
   const dispatch = useDispatch<Dispatch>()
@@ -162,7 +162,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
             onResponse={hasBlockModalResponse => {
               startPipetteOffsetCalibrationBlockModal(hasBlockModalResponse)
             }}
-            titleBarTitle={t('pipette_offset_cal')}
+            titleBarTitle={t('protocol_setup:pipette_offset_cal')}
             closePrompt={() => setShowCalBlockModal(false)}
           />
         </Portal>
@@ -265,9 +265,10 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
         />
       </Box>
       {showOverflowMenu && (
-        <div
+        <Box
           ref={pipetteOverflowWrapperRef}
           data-testid={`PipetteCard_overflow_menu_${pipetteName}`}
+          onClick={() => setShowOverflowMenu(false)}
         >
           <PipetteOverflowMenu
             pipetteName={pipetteName ?? t('empty')}
@@ -278,7 +279,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
             handleAboutSlideout={handleAboutSlideout}
             isPipetteCalibrated={pipetteOffsetCalibration != null}
           />
-        </div>
+        </Box>
       )}
     </Flex>
   )


### PR DESCRIPTION
# Overview

Closes the pipette card and module card overflow menus on click within the rendered overflow menu. also fixes a missing i18n translation key in the pipette card calibration block modal.

closes #10639

# Changelog

 - Closes the pipette card and module card overflow menus on click within the rendered overflow menu

# Review requests

check that the overflow menus close as expected on click

# Risk assessment

low