### PR TITLE
fix(app): close labware slideout when labware deleted

### DIFF
--- a/app/src/organisms/Labware/CustomLabwareOverflowMenu.tsx
+++ b/app/src/organisms/Labware/CustomLabwareOverflowMenu.tsx
@@ -31,12 +31,13 @@ const LABWARE_CREATOR_HREF = 'https://labware.opentrons.com/create/'
 
 interface CustomLabwareOverflowMenuProps {
   filename: string
+  onDelete: () => void
 }
 
 export function CustomLabwareOverflowMenu(
   props: CustomLabwareOverflowMenuProps
 ): JSX.Element {
-  const { filename } = props
+  const { filename, onDelete } = props
   const { t } = useTranslation(['labware_landing'])
   const dispatch = useDispatch<Dispatch>()
   const [showOverflowMenu, setShowOverflowMenu] = React.useState<boolean>(false)
@@ -47,10 +48,10 @@ export function CustomLabwareOverflowMenu(
     confirm: confirmDeleteLabware,
     showConfirmation: showDeleteConfirmation,
     cancel: cancelDeleteLabware,
-  } = useConditionalConfirm(
-    () => dispatch(deleteCustomLabwareFile(filename)),
-    true
-  )
+  } = useConditionalConfirm(() => {
+    dispatch(deleteCustomLabwareFile(filename))
+    onDelete()
+  }, true)
   const handleOpenInFolder: React.MouseEventHandler<HTMLButtonElement> = e => {
     e.preventDefault()
     e.stopPropagation()

--- a/app/src/organisms/Labware/CustomLabwareOverflowMenu.tsx
+++ b/app/src/organisms/Labware/CustomLabwareOverflowMenu.tsx
@@ -31,7 +31,7 @@ const LABWARE_CREATOR_HREF = 'https://labware.opentrons.com/create/'
 
 interface CustomLabwareOverflowMenuProps {
   filename: string
-  onDelete: () => void
+  onDelete?: () => void
 }
 
 export function CustomLabwareOverflowMenu(
@@ -50,7 +50,7 @@ export function CustomLabwareOverflowMenu(
     cancel: cancelDeleteLabware,
   } = useConditionalConfirm(() => {
     dispatch(deleteCustomLabwareFile(filename))
-    onDelete()
+    onDelete?.()
   }, true)
   const handleOpenInFolder: React.MouseEventHandler<HTMLButtonElement> = e => {
     e.preventDefault()

--- a/app/src/organisms/Labware/LabwareDetails/index.tsx
+++ b/app/src/organisms/Labware/LabwareDetails/index.tsx
@@ -91,7 +91,10 @@ export function LabwareDetails(props: LabwareDetailsProps): JSX.Element {
           >
             {t('last_updated')} {format(new Date(modified), 'MM/dd/yyyy')}
           </StyledText>
-          <CustomLabwareOverflowMenu filename={filename} />
+          <CustomLabwareOverflowMenu
+            filename={filename}
+            onDelete={props.onClose}
+          />
         </Flex>
       )}
     </Flex>


### PR DESCRIPTION
# Overview
Fixes closing labware slideout when slideout is deleted from slideout overflow menu.
Closes #10482

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- adds optional `onDelete` prop to `CustomLabwareOverflowMenuProps`

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Delete a labware from the slideout menu to confirm that slideout closes immediately upon deletion.
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Low
