### PR TITLE
fix(app): robot Update banner renders when bot is unavailable fix

### DIFF
--- a/app/src/organisms/UpdateRobotBanner/__tests__/UpdateRobotBanner.test.tsx
+++ b/app/src/organisms/UpdateRobotBanner/__tests__/UpdateRobotBanner.test.tsx
@@ -3,7 +3,10 @@ import { renderWithProviders } from '@opentrons/components'
 import { fireEvent, screen } from '@testing-library/react'
 import { i18n } from '../../../i18n'
 import * as Buildroot from '../../../redux/buildroot'
-import { mockConnectableRobot } from '../../../redux/discovery/__fixtures__'
+import {
+  mockConnectableRobot,
+  mockReachableRobot,
+} from '../../../redux/discovery/__fixtures__'
 import { UpdateBuildroot } from '../../Devices/RobotSettings/UpdateBuildroot'
 import { UpdateRobotBanner } from '..'
 
@@ -69,5 +72,15 @@ describe('UpdateRobotBanner', () => {
     })
     const { getByText } = render(props)
     getByText('A software update is available for this robot.')
+  })
+
+  it('should render nothing if robot health status is not ok', () => {
+    props = {
+      robot: mockReachableRobot,
+    }
+    const bannerText = screen.queryByText(
+      'A software update is available for this robot.'
+    )
+    expect(bannerText).toBeNull()
   })
 })

--- a/app/src/organisms/UpdateRobotBanner/index.tsx
+++ b/app/src/organisms/UpdateRobotBanner/index.tsx
@@ -7,6 +7,7 @@ import {
   TYPOGRAPHY,
   Btn,
   useInterval,
+  DIRECTION_COLUMN,
 } from '@opentrons/components'
 import { Portal } from '../../App/portal'
 import { StyledText } from '../../atoms/text'
@@ -59,8 +60,10 @@ export function UpdateRobotBanner(props: UpdateRobotBannerProps): JSX.Element {
   }
 
   return (
-    <Flex onClick={e => e.stopPropagation()}>
-      {autoUpdateAction === 'upgrade' || autoUpdateAction === 'downgrade' ? (
+    <Flex onClick={e => e.stopPropagation()} flexDirection={DIRECTION_COLUMN}>
+      {(autoUpdateAction === 'upgrade' || autoUpdateAction === 'downgrade') &&
+      robot !== null &&
+      robot.healthStatus === 'ok' ? (
         <Banner type="warning" onCloseClick={handleCloseBanner} {...styleProps}>
           <StyledText as="p" marginRight={SPACING.spacing2}>
             {t('robot_server_versions_banner_title')}


### PR DESCRIPTION
closes #10670

# Overview

Previously, when a robot is reachable but the health status is 'not ok', it appears in the Unavailable section of the Device Landing page with the update robot banner still available and clickable. This fixes that bug so the banner is no longer there.

# Changelog

- edit logic in `updateRobotBanner` to also look for if the robot health status is not ok

# Review requests

- with a robot with an update available, connect to it, then turn off the robot. When it is in the Unavailable robot section, the update robot banner should not be present.

# Risk assessment

low