### PR TITLE
fix(engine): disallow setup commands while run is paused

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/command.py
+++ b/api/src/opentrons/protocol_engine/commands/command.py
@@ -36,7 +36,7 @@ class CommandStatus(str, Enum):
 
 
 class CommandIntent(str, Enum):
-    """Source that generated a given command.
+    """Run intent for a given command.
 
     Props:
         PROTOCOL: the command is part of the protocol run itself.
@@ -70,8 +70,7 @@ class BaseCommandCreate(GenericModel, Generic[CommandParamsT]):
             " and added to the end of the existing command queue."
             "\n\n"
             "If `setup`, the command will be treated as part of run setup."
-            " A setup command may only be enqueued if the run has not started"
-            " or is currently paused."
+            " A setup command may only be enqueued if the run has not started."
             "\n\n"
             "Use setup commands for activities like pre-run calibration checks"
             " and module setup, like pre-heating."

--- a/api/tests/opentrons/protocol_engine/state/test_command_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view.py
@@ -109,7 +109,7 @@ def test_get_next_queued_returns_first_queued() -> None:
 
 @pytest.mark.parametrize(
     "queue_status",
-    [QueueStatus.SETUP, QueueStatus.RUNNING, QueueStatus.PAUSED],
+    [QueueStatus.SETUP, QueueStatus.RUNNING],
 )
 def test_get_next_queued_prioritizes_setup_command_queue(
     queue_status: QueueStatus,
@@ -136,9 +136,22 @@ def test_get_next_queued_returns_none_when_no_pending() -> None:
 
 @pytest.mark.parametrize("queue_status", [QueueStatus.SETUP, QueueStatus.PAUSED])
 def test_get_next_queued_returns_none_if_not_running(queue_status: QueueStatus) -> None:
-    """It should return None if the engine is not running."""
+    """It should not return protocol commands if the engine is not running."""
     subject = get_command_view(
         queue_status=queue_status,
+        queued_setup_command_ids=[],
+        queued_command_ids=["command-id-1", "command-id-2"],
+    )
+    result = subject.get_next_queued()
+
+    assert result is None
+
+
+def test_get_next_queued_returns_no_commands_if_paused() -> None:
+    """It should not return any type of command if the engine is paused."""
+    subject = get_command_view(
+        queue_status=QueueStatus.PAUSED,
+        queued_setup_command_ids=["setup-id-1", "setup-id-2"],
         queued_command_ids=["command-id-1", "command-id-2"],
     )
     result = subject.get_next_queued()
@@ -269,9 +282,9 @@ action_allowed_specs: List[ActionAllowedSpec] = [
         action=StopAction(),
         expected_error=None,
     ),
-    # queue command is usually allowed
+    # queue command is allowed during setup
     ActionAllowedSpec(
-        subject=get_command_view(),
+        subject=get_command_view(queue_status=QueueStatus.SETUP),
         action=QueueCommandAction(
             request=cmd.HomeCreate(params=cmd.HomeParams()),
             command_id="command-id",
@@ -328,6 +341,20 @@ action_allowed_specs: List[ActionAllowedSpec] = [
             created_at=datetime(year=2021, month=1, day=1),
         ),
         expected_error=errors.RunStoppedError,
+    ),
+    # queue setup command is disallowed if paused
+    ActionAllowedSpec(
+        subject=get_command_view(queue_status=QueueStatus.PAUSED),
+        action=QueueCommandAction(
+            request=cmd.HomeCreate(
+                params=cmd.HomeParams(),
+                intent=cmd.CommandIntent.SETUP,
+            ),
+            command_id="command-id",
+            command_key="command-key",
+            created_at=datetime(year=2021, month=1, day=1),
+        ),
+        expected_error=errors.SetupCommandNotAllowedError,
     ),
     # queue setup command is disallowed if running
     ActionAllowedSpec(

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -123,7 +123,7 @@ async def get_current_run_engine_from_url(
         - Setup commands (`data.source == "setup"`)
         - Protocol commands (`data.source == "protocol"`)
 
-        Setup commands may be enqueued while the run is idle or paused.
+        Setup commands may be enqueued before the run has been started.
         You could use setup commands to prepare a module or
         run labware calibration procedures.
 
@@ -146,7 +146,9 @@ async def get_current_run_engine_from_url(
     responses={
         status.HTTP_201_CREATED: {"model": SimpleBody[pe_commands.Command]},
         status.HTTP_404_NOT_FOUND: {"model": ErrorBody[RunNotFound]},
-        status.HTTP_409_CONFLICT: {"model": ErrorBody[RunStopped]},
+        status.HTTP_409_CONFLICT: {
+            "model": ErrorBody[Union[RunStopped, CommandNotAllowed]]
+        },
     },
 )
 async def create_run_command(


### PR DESCRIPTION
## Overview

Server-side resolution of #10647. Ticket requires app-side changes to fully close.

## Changelog

- fix(engine): disallow setup commands while run is paused

## Review requests

Smoke test plan - technically testable with simulator, emulator, and robot, but robot is easiest because you can actually pause the protocol run before it completes.

1. Upload protocol
2. Create run
3. Create setup command (e.g. home)
    - [ ] Verify command runs
4. Start the run
5. Pause the run
6. Attempt to create another setup command
    - [ ] Verify command is rejected with 409

I can't figure out a good way to add an acceptance test for this for the same reason smoke-testing against the simulator is difficult. That being said, unit test coverage is good, and existing acceptance tests mean we can feel confident that the unit tested code is wired up properly. 

## Risk assessment

Low