### PR TITLE
style(app): add margin bottom spacing 1.5 rem btw down arrow svg and bottom button

### DIFF
--- a/app/src/molecules/JogControls/DirectionControl.tsx
+++ b/app/src/molecules/JogControls/DirectionControl.tsx
@@ -134,7 +134,7 @@ export function DirectionControl(props: DirectionControlProps): JSX.Element {
           gridGap={SPACING.spacing1}
           gridTemplateRows="repeat(2, [row] 2rem)"
           gridTemplateColumns="repeat(3, [col] 2rem)"
-          marginBottom={SPACING.spacing3}
+          marginBottom={SPACING.spacing5}
         >
           {controls.map(
             ({ bearing, gridRow, gridColumn, iconName, axis, sign }) => (

--- a/app/src/molecules/JogControls/DirectionControl.tsx
+++ b/app/src/molecules/JogControls/DirectionControl.tsx
@@ -134,6 +134,7 @@ export function DirectionControl(props: DirectionControlProps): JSX.Element {
           gridGap={SPACING.spacing1}
           gridTemplateRows="repeat(2, [row] 2rem)"
           gridTemplateColumns="repeat(3, [col] 2rem)"
+          marginBottom={SPACING.spacing3}
         >
           {controls.map(
             ({ bearing, gridRow, gridColumn, iconName, axis, sign }) => (


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

PR fixes the spacing issue seen in the original screenshot.
![Screen Shot 2022-06-01 at 3.18.44 PM.png](https://images.zenhubusercontent.com/5e2720c7aaf6ad22b4062408/ab8b747e-505c-4593-a45f-074bea70dbd6)

Closes #10504

# Changelog

I added margin bottom spacing to be 1.5 rem.  Please see in app and via the screenshot below.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
You can launch the app and now see the spacing between the down arrow and bottom button properly.

![Screen Shot 2022-06-08 at 4 01 41 PM](https://user-images.githubusercontent.com/102996638/172706581-f4c0e756-3a3d-481e-bc3e-3dc2b74f083c.png)

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
