### PR TITLE
fix(app): fix pipette offset cal data fetch issue on RobotSettings

### DIFF
--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
@@ -147,10 +147,6 @@ export function RobotSettingsCalibration({
   const deckCalStatus = useSelector((state: State) => {
     return Calibration.getDeckCalibrationStatus(state, robotName)
   })
-  // const attachedPipetteCalibrations = useSelector((state: State) => {
-  //   return Pipettes.getAttachedPipetteCalibrations(state, robotName)
-  // })
-
   const deckCalibrationStatus = useDeckCalibrationStatus(robotName)
   const dispatch = useDispatch<Dispatch>()
 
@@ -266,25 +262,9 @@ export function RobotSettingsCalibration({
     pipetteCalPresent &&
     pipettePresent
 
-  // console.log(
-  //   'first',
-  //   !([
-  //     Calibration.DECK_CAL_STATUS_SINGULARITY,
-  //     Calibration.DECK_CAL_STATUS_BAD_CALIBRATION,
-  //     Calibration.DECK_CAL_STATUS_IDENTITY,
-  //   ] as Array<typeof deckCalStatus>).includes(deckCalStatus)
-  // )
-  // console.log('second', pipetteCalPresent)
-  // console.log('third', pipettePresent)
-
   const calCheckButtonDisabled = healthCheckIsPossible
     ? Boolean(buttonDisabledReason) || isPending
     : true
-
-  // console.log('healthCheckIsPossible', healthCheckIsPossible)
-  // console.log('buttonDisabledReason', buttonDisabledReason)
-  // console.log('isPending', isPending)
-  // console.log('calCheckButtonDisabled', calCheckButtonDisabled)
 
   const onClickSaveAs: React.MouseEventHandler = e => {
     e.preventDefault()

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
@@ -53,6 +53,7 @@ import {
   useDeckCalibrationStatus,
   useIsRobotBusy,
   useAttachedPipettes,
+  useAttachedPipetteCalibrations,
 } from '../hooks'
 import { DeckCalibrationConfirmModal } from './DeckCalibrationConfirmModal'
 import { PipetteOffsetCalibrationItems } from './CalibrationDetails/PipetteOffsetCalibrationItems'
@@ -146,9 +147,10 @@ export function RobotSettingsCalibration({
   const deckCalStatus = useSelector((state: State) => {
     return Calibration.getDeckCalibrationStatus(state, robotName)
   })
-  const attachedPipetteCalibrations = useSelector((state: State) => {
-    return Pipettes.getAttachedPipetteCalibrations(state, robotName)
-  })
+  // const attachedPipetteCalibrations = useSelector((state: State) => {
+  //   return Pipettes.getAttachedPipetteCalibrations(state, robotName)
+  // })
+
   const deckCalibrationStatus = useDeckCalibrationStatus(robotName)
   const dispatch = useDispatch<Dispatch>()
 
@@ -187,6 +189,7 @@ export function RobotSettingsCalibration({
   const pipetteOffsetCalibrations = usePipetteOffsetCalibrations(robot?.name)
   const tipLengthCalibrations = useTipLengthCalibrations(robot?.name)
   const attachedPipettes = useAttachedPipettes()
+  const attachedPipetteCalibrations = useAttachedPipetteCalibrations(robotName)
 
   const isRunning = useSelector(robotSelectors.getIsRunning)
 
@@ -263,9 +266,25 @@ export function RobotSettingsCalibration({
     pipetteCalPresent &&
     pipettePresent
 
+  // console.log(
+  //   'first',
+  //   !([
+  //     Calibration.DECK_CAL_STATUS_SINGULARITY,
+  //     Calibration.DECK_CAL_STATUS_BAD_CALIBRATION,
+  //     Calibration.DECK_CAL_STATUS_IDENTITY,
+  //   ] as Array<typeof deckCalStatus>).includes(deckCalStatus)
+  // )
+  // console.log('second', pipetteCalPresent)
+  // console.log('third', pipettePresent)
+
   const calCheckButtonDisabled = healthCheckIsPossible
-    ? Boolean(buttonDisabledReason)
+    ? Boolean(buttonDisabledReason) || isPending
     : true
+
+  // console.log('healthCheckIsPossible', healthCheckIsPossible)
+  // console.log('buttonDisabledReason', buttonDisabledReason)
+  // console.log('isPending', isPending)
+  // console.log('calCheckButtonDisabled', calCheckButtonDisabled)
 
   const onClickSaveAs: React.MouseEventHandler = e => {
     e.preventDefault()

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
@@ -43,6 +43,8 @@ import * as Config from '../../../redux/config'
 import * as Sessions from '../../../redux/sessions'
 import * as Calibration from '../../../redux/calibration'
 import * as Pipettes from '../../../redux/pipettes'
+import * as PipetteOffset from '../../../redux/calibration/pipette-offset'
+import * as TipLength from '../../../redux/calibration/tip-length'
 import {
   useDeckCalibrationData,
   usePipetteOffsetCalibrations,
@@ -470,6 +472,8 @@ export function RobotSettingsCalibration({
       dispatch(Calibration.fetchCalibrationStatus(robotName))
       dispatch(Calibration.fetchPipetteOffsetCalibrations(robotName))
       dispatch(Calibration.fetchTipLengthCalibrations(robotName))
+      dispatch(PipetteOffset.fetchPipetteOffsetCalibrations(robotName))
+      dispatch(TipLength.fetchTipLengthCalibrations(robotName))
       checkPipetteCalibrationMissing()
     },
     CALS_FETCH_MS,

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
@@ -464,7 +464,8 @@ export function RobotSettingsCalibration({
     }
   }, [createStatus])
 
-  // Note this
+  // Note: following fetch need to reflect the latest state of calibrations
+  // when a user does calibration or rename a robot.
   useInterval(
     () => {
       dispatch(Calibration.fetchCalibrationStatus(robotName))

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
@@ -43,8 +43,6 @@ import * as Config from '../../../redux/config'
 import * as Sessions from '../../../redux/sessions'
 import * as Calibration from '../../../redux/calibration'
 import * as Pipettes from '../../../redux/pipettes'
-import * as PipetteOffset from '../../../redux/calibration/pipette-offset'
-import * as TipLength from '../../../redux/calibration/tip-length'
 import {
   useDeckCalibrationData,
   usePipetteOffsetCalibrations,
@@ -466,13 +464,12 @@ export function RobotSettingsCalibration({
     }
   }, [createStatus])
 
+  // Note this
   useInterval(
     () => {
       dispatch(Calibration.fetchCalibrationStatus(robotName))
       dispatch(Calibration.fetchPipetteOffsetCalibrations(robotName))
       dispatch(Calibration.fetchTipLengthCalibrations(robotName))
-      dispatch(PipetteOffset.fetchPipetteOffsetCalibrations(robotName))
-      dispatch(TipLength.fetchTipLengthCalibrations(robotName))
       checkPipetteCalibrationMissing()
     },
     CALS_FETCH_MS,


### PR DESCRIPTION
fix #10676

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This will fix #10676
Add data fetch to `useInterval` and switched `useAttachedPipetteCalibrations` from `Pipettes.getAttachedPipetteCalibrations`
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- Add polling to fetch pipette offset cal and tip length cal data
- Use `useAttachedPipetteCalibrations` to get attachedPipette Calibration data
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
- low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
