### PR TITLE
fix(app): disallow run level module control while the run is paused

### DIFF
--- a/app/src/pages/Devices/ProtocolRunDetails/__tests__/ProtocolRunDetails.test.tsx
+++ b/app/src/pages/Devices/ProtocolRunDetails/__tests__/ProtocolRunDetails.test.tsx
@@ -16,10 +16,12 @@ import { ProtocolRunModuleControls } from '../../../../organisms/Devices/Protoco
 import { ProtocolRunSetup } from '../../../../organisms/Devices/ProtocolRun/ProtocolRunSetup'
 import { RunLog } from '../../../../organisms/Devices/ProtocolRun/RunLog'
 import { useCurrentRunId } from '../../../../organisms/ProtocolUpload/hooks'
+import { useRunStatus } from '../../../../organisms/RunTimeControl/hooks'
 import { ProtocolRunDetails } from '..'
 import { ModuleModel, ModuleType } from '@opentrons/shared-data'
 
 import type { ProtocolAnalysisFile } from '@opentrons/shared-data'
+import { RUN_STATUS_IDLE, RUN_STATUS_RUNNING } from '@opentrons/api-client'
 
 jest.mock('../../../../organisms/Devices/hooks')
 jest.mock('../../../../organisms/Devices/ProtocolRun/ProtocolRunHeader')
@@ -27,6 +29,7 @@ jest.mock('../../../../organisms/Devices/ProtocolRun/ProtocolRunSetup')
 jest.mock('../../../../organisms/Devices/ProtocolRun/RunLog')
 jest.mock('../../../../organisms/Devices/ProtocolRun/ProtocolRunModuleControls')
 jest.mock('../../../../organisms/ProtocolUpload/hooks')
+jest.mock('../../../../organisms/RunTimeControl/hooks')
 
 const mockUseRobot = useRobot as jest.MockedFunction<typeof useRobot>
 const mockProtocolRunHeader = ProtocolRunHeader as jest.MockedFunction<
@@ -44,6 +47,9 @@ const mockUseModuleRenderInfoForProtocolById = useModuleRenderInfoForProtocolByI
 >
 const mockUseCurrentRunId = useCurrentRunId as jest.MockedFunction<
   typeof useCurrentRunId
+>
+const mockUseRunStatus = useRunStatus as jest.MockedFunction<
+  typeof useRunStatus
 >
 const mockUseProtocolDetailsForRun = useProtocolDetailsForRun as jest.MockedFunction<
   typeof useProtocolDetailsForRun
@@ -86,6 +92,7 @@ const RUN_ID = '95e67900-bc9f-4fbf-92c6-cc4d7226a51b'
 describe('ProtocolRunDetails', () => {
   beforeEach(() => {
     mockUseRobot.mockReturnValue(mockConnectableRobot)
+    mockUseRunStatus.mockReturnValue(RUN_STATUS_IDLE)
     mockProtocolRunHeader.mockReturnValue(<div>Mock ProtocolRunHeader</div>)
     mockRunLog.mockReturnValue(<div>Mock RunLog</div>)
     mockProtocolRunSetup.mockReturnValue(<div>Mock ProtocolRunSetup</div>)
@@ -212,6 +219,19 @@ describe('ProtocolRunDetails', () => {
     expect(queryByText('Mock ProtocolRunModuleControls')).toBeFalsy()
     setupTab.click()
     expect(queryByText('Mock ProtocolRunSetup')).toBeFalsy()
+    moduleTab.click()
+    expect(queryByText('Mock ProtocolRunModuleControls')).toBeFalsy()
+  })
+
+  it('disables module controls tab when the run current but not idle', () => {
+    mockUseCurrentRunId.mockReturnValue(RUN_ID)
+    mockUseRunStatus.mockReturnValue(RUN_STATUS_RUNNING)
+    const [{ getByText, queryByText }] = render(
+      `/devices/otie/protocol-runs/${RUN_ID}`
+    )
+
+    const moduleTab = getByText('Module Controls')
+    expect(queryByText('Mock ProtocolRunModuleControls')).toBeFalsy()
     moduleTab.click()
     expect(queryByText('Mock ProtocolRunModuleControls')).toBeFalsy()
   })

--- a/app/src/pages/Devices/ProtocolRunDetails/index.tsx
+++ b/app/src/pages/Devices/ProtocolRunDetails/index.tsx
@@ -22,6 +22,7 @@ import {
   TYPOGRAPHY,
 } from '@opentrons/components'
 import { ApiHostProvider } from '@opentrons/react-api-client'
+import { RUN_STATUS_IDLE } from '@opentrons/api-client'
 
 import { StyledText } from '../../../atoms/text'
 import { Tooltip } from '../../../atoms/Tooltip'
@@ -35,6 +36,7 @@ import { RunLog } from '../../../organisms/Devices/ProtocolRun/RunLog'
 import { ProtocolRunSetup } from '../../../organisms/Devices/ProtocolRun/ProtocolRunSetup'
 import { ProtocolRunModuleControls } from '../../../organisms/Devices/ProtocolRun/ProtocolRunModuleControls'
 import { useCurrentRunId } from '../../../organisms/ProtocolUpload/hooks'
+import { useRunStatus } from '../../../organisms/RunTimeControl/hooks'
 import { fetchProtocols } from '../../../redux/protocol-storage'
 
 import type { NavRouteParams, ProtocolRunDetailsTab } from '../../../App/types'
@@ -253,12 +255,13 @@ const ModuleControlsTab = (
   const { robotName, runId } = props
   const { t } = useTranslation('run_details')
   const currentRunId = useCurrentRunId()
+  const runStatus = useRunStatus(runId)
   const moduleRenderInfoForProtocolById = useModuleRenderInfoForProtocolById(
     robotName,
     runId
   )
 
-  const disabled = currentRunId !== runId
+  const disabled = currentRunId !== runId || runStatus !== RUN_STATUS_IDLE
   const tabDisabledReason = `${t('module_controls')} ${t(
     'not_available_for_a_completed_run'
   )}`
@@ -272,7 +275,7 @@ const ModuleControlsTab = (
         to={`/devices/${robotName}/protocol-runs/${runId}/module-controls`}
         tabName={t('module_controls')}
       />
-      {currentRunId !== runId ? (
+      {disabled ? (
         // redirect to run log if not current run
         <Redirect to={`/devices/${robotName}/protocol-runs/${runId}/run-log`} />
       ) : null}


### PR DESCRIPTION
# Overview

Only allow access to the module controls on the run detail page if the current run is idle and
unstarted.

re #10647

# Changelog

- Disable the run detail page's module control tab if the run is not 'idle'

# Review requests

- ensure that modules can't be controlled from the run detail page after a run has started.

# Risk assessment
low