### PR TITLE
feat(app): interactive liquid list view items

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -121,5 +121,9 @@
   "liquid_setup_step_title": "Initial Liquid Setup",
   "liquid_setup_step_description": "View liquid starting locations and volumes",
   "list_view": "List View",
-  "map_view": "Map View"
+  "map_view": "Map View",
+  "location": "Location",
+  "labware_name": "Labware Name",
+  "volume": "Volume",
+  "slot_location": "Slot {{slotName}}"
 }

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
-import sum from 'lodash/sum'
+import { useTranslation } from 'react-i18next'
+import { css } from 'styled-components'
 import {
   Flex,
   SPACING,
@@ -13,12 +14,13 @@ import {
   BORDERS,
   ALIGN_CENTER,
   SIZE_AUTO,
+  JUSTIFY_SPACE_BETWEEN,
+  Box,
 } from '@opentrons/components'
 import { MICRO_LITERS } from '@opentrons/shared-data'
 import { StyledText } from '../../../../atoms/text'
 
 import type { Liquid } from './getMockLiquidData'
-import { css } from 'styled-components'
 
 interface SetupLiquidsListProps {
   liquids: Liquid[] | null
@@ -38,6 +40,7 @@ export function SetupLiquidsList(props: SetupLiquidsListProps): JSX.Element {
       flexDirection={DIRECTION_COLUMN}
       maxHeight={'31.25rem'}
       overflowY={'auto'}
+      data-testid={'SetupLiquidsList_ListView'}
     >
       {liquids?.map(liquid => (
         <LiquidsListItem
@@ -45,7 +48,7 @@ export function SetupLiquidsList(props: SetupLiquidsListProps): JSX.Element {
           description={liquid.description}
           displayColor={liquid.displayColor}
           displayName={liquid.displayName}
-          volume={sum(Object.values(liquid.volumeByWell))}
+          locations={liquid.locations}
         />
       ))}
     </Flex>
@@ -56,55 +59,131 @@ interface LiquidsListItemProps {
   description: string | null
   displayColor: string
   displayName: string
-  volume: number
+  locations: Array<{
+    slotName: string
+    labwareName: string
+    volumeByWell: { [well: string]: number }
+  }>
 }
 
 export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
-  const { description, displayColor, displayName, volume } = props
+  const { description, displayColor, displayName, locations } = props
+  const [openItem, setOpenItem] = React.useState(false)
+  const { t } = useTranslation('protocol_setup')
   return (
-    <Flex
+    <Box
       css={BORDERS.cardOutlineBorder}
-      flexDirection={DIRECTION_ROW}
       marginBottom={SPACING.spacing3}
       padding={SPACING.spacing4}
+      onClick={() => setOpenItem(!openItem)}
+      backgroundColor={openItem ? COLORS.lightGrey : COLORS.white}
+      data-testid={'LiquidsListItem_Row'}
     >
-      <Flex
-        css={BORDERS.cardOutlineBorder}
-        padding={'0.75rem'}
-        height={'max-content'}
-      >
-        <Icon name="circle" color={displayColor} size={SIZE_1} />
-      </Flex>
-      <Flex flexDirection={DIRECTION_COLUMN} justifyContent={JUSTIFY_CENTER}>
-        <StyledText
-          as="p"
-          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-          marginX={SPACING.spacing4}
+      <Flex flexDirection={DIRECTION_ROW}>
+        <Flex
+          css={BORDERS.cardOutlineBorder}
+          padding={'0.75rem'}
+          height={'max-content'}
+          backgroundColor={COLORS.white}
         >
-          {displayName}
-        </StyledText>
-        <StyledText
-          as="p"
-          fontWeight={TYPOGRAPHY.fontWeightRegular}
-          color={COLORS.darkGreyEnabled}
-          marginX={SPACING.spacing4}
+          <Icon name="circle" color={displayColor} size={SIZE_1} />
+        </Flex>
+        <Flex flexDirection={DIRECTION_COLUMN} justifyContent={JUSTIFY_CENTER}>
+          <StyledText
+            as="p"
+            fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+            marginX={SPACING.spacing4}
+          >
+            {displayName}
+          </StyledText>
+          <StyledText
+            as="p"
+            fontWeight={TYPOGRAPHY.fontWeightRegular}
+            color={COLORS.darkGreyEnabled}
+            marginX={SPACING.spacing4}
+          >
+            {description != null ? description : null}
+          </StyledText>
+        </Flex>
+        <Flex
+          backgroundColor={COLORS.darkBlack + '1A'}
+          borderRadius={BORDERS.radiusSoftCorners}
+          height={'max-content'}
+          paddingY={SPACING.spacing2}
+          paddingX={SPACING.spacing3}
+          alignSelf={ALIGN_CENTER}
+          marginLeft={SIZE_AUTO}
         >
-          {description != null ? description : null}
-        </StyledText>
+          <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightRegular}>
+            {locations
+              .flatMap(obj => Object.values(obj.volumeByWell))
+              .reduce((prev, curr) => prev + curr, 0)}{' '}
+            {MICRO_LITERS}
+          </StyledText>
+        </Flex>
       </Flex>
-      <Flex
-        backgroundColor={COLORS.darkBlack + '1A'}
-        borderRadius={BORDERS.radiusSoftCorners}
-        height={'max-content'}
-        paddingY={SPACING.spacing2}
-        paddingX={SPACING.spacing3}
-        alignSelf={ALIGN_CENTER}
-        marginLeft={SIZE_AUTO}
-      >
-        <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightRegular}>
-          {volume} {MICRO_LITERS}
-        </StyledText>
-      </Flex>
-    </Flex>
+      {openItem ? (
+        <Flex flexDirection={DIRECTION_COLUMN}>
+          <Flex
+            flexDirection={DIRECTION_ROW}
+            justifyContent={JUSTIFY_SPACE_BETWEEN}
+            marginTop={SPACING.spacing4}
+          >
+            <StyledText
+              as="p"
+              fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+              marginLeft={SPACING.spacing4}
+            >
+              {t('location')}
+            </StyledText>
+            <StyledText
+              as="p"
+              fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+              marginRight={SPACING.spacing6}
+            >
+              {t('labware_name')}
+            </StyledText>
+            <StyledText
+              as="p"
+              fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+              marginRight={SPACING.spacing4}
+            >
+              {t('volume')}
+            </StyledText>
+          </Flex>
+          {locations.map((location, index) => {
+            return (
+              <Box
+                key={index}
+                borderRadius={'4px'}
+                marginY={SPACING.spacing3}
+                padding={SPACING.spacing4}
+                backgroundColor={COLORS.white}
+                data-testid={`LiquidsListItem_slotRow_${index}`}
+              >
+                <Flex
+                  flexDirection={DIRECTION_ROW}
+                  justifyContent={JUSTIFY_SPACE_BETWEEN}
+                >
+                  <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightRegular}>
+                    {t('slot_location', { slotName: location.slotName })}
+                  </StyledText>
+                  <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightRegular}>
+                    {location.labwareName}
+                  </StyledText>
+                  <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightRegular}>
+                    {Object.values(location.volumeByWell).reduce(
+                      (prev, curr) => prev + curr,
+                      0
+                    )}{' '}
+                    {MICRO_LITERS}
+                  </StyledText>
+                </Flex>
+              </Box>
+            )
+          })}
+        </Flex>
+      ) : null}
+    </Box>
   )
 }

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
@@ -130,7 +130,7 @@ export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
           </StyledText>
         </Flex>
       </Flex>
-      {openItem ? (
+      {openItem && (
         <Flex flexDirection={DIRECTION_COLUMN}>
           <Flex
             flexDirection={DIRECTION_ROW}
@@ -191,7 +191,7 @@ export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
             )
           })}
         </Flex>
-      ) : null}
+      )}
     </Box>
   )
 }

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
@@ -70,9 +70,17 @@ export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
   const { description, displayColor, displayName, locations } = props
   const [openItem, setOpenItem] = React.useState(false)
   const { t } = useTranslation('protocol_setup')
+  const LIQUID_CARD_STYLE = css`
+    ${BORDERS.cardOutlineBorder}
+
+    &:hover {
+      background-color: ${COLORS.background};
+      border: 1px solid ${COLORS.medGreyHover};
+    }
+  `
   return (
     <Box
-      css={BORDERS.cardOutlineBorder}
+      css={LIQUID_CARD_STYLE}
       marginBottom={SPACING.spacing3}
       padding={SPACING.spacing4}
       onClick={() => setOpenItem(!openItem)}

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/SetupLiquidsList.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/SetupLiquidsList.test.tsx
@@ -2,19 +2,24 @@ import * as React from 'react'
 import { i18n } from '../../../../../i18n'
 import { renderWithProviders } from '@opentrons/components'
 import { SetupLiquidsList } from '../SetupLiquidsList'
+import { fireEvent } from '@testing-library/react'
 
-const MOCK_LIQUIDS = [
+const MOCK_LIQUID = [
   {
     liquidId: '0',
     displayName: 'mock liquid 1',
     description: 'mock sample',
     displayColor: '#ff4888',
-    labwareId:
-      '08433310-e1d8-11ec-8729-359ce212aee2:opentrons/opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical_acrylic/1',
-    volumeByWell: {
-      C1: 50,
-      C2: 50,
-    },
+    locations: [
+      {
+        labwareName: 'Mock Labware',
+        slotName: '5',
+        volumeByWell: {
+          C1: 50,
+          C2: 50,
+        },
+      },
+    ],
   },
 ]
 
@@ -27,7 +32,7 @@ const render = (props: React.ComponentProps<typeof SetupLiquidsList>) => {
 describe('SetupLiquidsList', () => {
   let props: React.ComponentProps<typeof SetupLiquidsList>
   beforeEach(() => {
-    props = { liquids: MOCK_LIQUIDS }
+    props = { liquids: MOCK_LIQUID }
   })
 
   it('renders the total volume of the liquid, sample display name, and description', () => {
@@ -35,5 +40,16 @@ describe('SetupLiquidsList', () => {
     getByText('100 µL')
     getByText('mock liquid 1')
     getByText('mock sample')
+  })
+
+  it('renders slot and labware info when clicking a liquid item', () => {
+    const [{ getByText }] = render(props)
+    const row = getByText('mock liquid 1')
+    fireEvent.click(row)
+    getByText('Location')
+    getByText('Labware Name')
+    getByText('Volume')
+    getByText('Slot 5')
+    getByText('Mock Labware')
   })
 })

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/getMockLiquidData.ts
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/getMockLiquidData.ts
@@ -21,6 +21,21 @@ const mockLiquids = {
     displayColor: '#50d5ff',
   },
 }
+const mockLabware = {
+  'b1e79d50-e112-11ec-8729-359ce212aee2:opentrons/eppendorf_96_tiprack_10ul_eptips/1': {
+    displayName: 'Eppendorf Tips',
+    definitionId: 'opentrons/eppendorf_96_tiprack_10ul_eptips/1',
+  },
+  'f2ded1f0-e1d7-11ec-8729-359ce212aee2': {
+    displayName: 'Well Plate',
+    definitionId: 'example/plate/1',
+  },
+  '08433310-e1d8-11ec-8729-359ce212aee2:opentrons/opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical_acrylic/1': {
+    displayName: 'Opentrons Tube Rack',
+    definitionId:
+      'opentrons/opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical_acrylic/1',
+  },
+}
 const mockCommands = [
   {
     key: '61731400-e1d8-11ec-8729-359ce212aee2',
@@ -96,6 +111,15 @@ const mockCommands = [
       volumeByWell: { A2: 20, B2: 20, A3: 20, B3: 20 },
     },
   },
+  {
+    commandType: 'loadLiquid',
+    key: '61731404-e1d8-11ec-8729-359ce212bee2',
+    params: {
+      liquidId: '3',
+      labwareId: 'f2ded1f0-e1d7-11ec-8729-359ce212aee2',
+      volumeByWell: { A2: 20, B2: 20, A3: 20, B3: 20 },
+    },
+  },
 ]
 
 export interface Liquid {
@@ -103,29 +127,64 @@ export interface Liquid {
   displayName: string
   description: string
   displayColor: string
-  labwareId: string
-  volumeByWell: any
+  locations: Array<{
+    slotName: string
+    labwareName: string
+    volumeByWell: { [well: string]: number }
+  }>
 }
 
 export function getMockLiquidData(): Liquid[] | null {
   const loadLiquidCommands = mockCommands.filter(
     command => command.commandType === 'loadLiquid'
   )
+  const loadLabwareCommands = mockCommands.filter(
+    command => command.commandType === 'loadLabware'
+  )
   const mockLiquidEntries = Object.entries(mockLiquids)
+  const mockLabwareEntries = Object.entries(mockLabware)
+
   const liquids: Liquid[] = []
-  loadLiquidCommands.forEach(command => {
-    const liquidId = command.params.liquidId
-    const liquidIndex = mockLiquidEntries.findIndex(
-      liquid => liquidId === liquid[0]
+
+  mockLiquidEntries.forEach(liquid => {
+    const commandsByLiquidId = loadLiquidCommands.filter(
+      command => command.params.liquidId === liquid[0]
     )
-    const liquidValue = mockLiquidEntries[liquidIndex][1]
+    const locations: Array<{
+      slotName: string
+      labwareName: string
+      volumeByWell: { [well: string]: number }
+    }> = []
+    commandsByLiquidId.forEach(command => {
+      const labwareIndex = mockLabwareEntries.findIndex(
+        labware => labware[0] === command.params.labwareId
+      )
+      const displayName = mockLabwareEntries[labwareIndex][1].displayName
+
+      const loadLabwareCommandById = loadLabwareCommands.filter(
+        labware => labware.params.labwareId === command.params.labwareId
+      )
+      const slot =
+        loadLabwareCommandById[0].params.location?.slotName != null
+          ? loadLabwareCommandById[0].params.location?.slotName
+          : ''
+
+      const volumeByWell =
+        command.params.volumeByWell != null ? command.params.volumeByWell : {}
+
+      locations.push({
+        slotName: slot,
+        labwareName: displayName,
+        volumeByWell: volumeByWell,
+      })
+    })
+
     liquids.push({
-      liquidId: liquidId ?? '',
-      displayName: liquidValue.displayName,
-      description: liquidValue.description,
-      displayColor: liquidValue.displayColor,
-      labwareId: command.params.labwareId ?? '',
-      volumeByWell: command.params.volumeByWell,
+      liquidId: liquid[0] ?? '',
+      displayName: liquid[1].displayName,
+      description: liquid[1].description,
+      displayColor: liquid[1].displayColor,
+      locations: locations,
     })
   })
   return liquids


### PR DESCRIPTION

# Overview

This PR makes each liquid list view item interactive and presents the liquid information across all
labware. closes #10571

![image](https://user-images.githubusercontent.com/14794021/172885243-62c984dc-f472-4dd7-acdc-c99f468fe6fb.png)

Hover state:
![image](https://user-images.githubusercontent.com/14794021/172904314-a0e645ba-ff27-4bfb-8c37-a99b372288ce.png)


# Changelog

- Update liquids interface
- Add open state with labware information to list items

# Review requests

- Check that clicking each liquid item will trigger the open state and it renders the information regarding the liquid and labware correctly.

# Risk assessment

low
