### PR TITLE
refactor(protocol-designer): remove too tall labware check in edit modules modal

### DIFF
--- a/protocol-designer/src/components/modals/EditModulesModal/index.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.tsx
@@ -13,7 +13,6 @@ import {
 } from '@opentrons/components'
 import {
   getAreSlotsAdjacent,
-  getIsLabwareAboveHeight,
   THERMOCYCLER_MODULE_TYPE,
   MAGNETIC_MODULE_TYPE,
   HEATERSHAKER_MODULE_TYPE,
@@ -21,7 +20,6 @@ import {
   THERMOCYCLER_MODULE_V1,
   ModuleType,
   ModuleModel,
-  MAX_LABWARE_HEIGHT_EAST_WEST_HEATER_SHAKER_MM,
 } from '@opentrons/shared-data'
 import { i18n } from '../../../localization'
 import {
@@ -149,28 +147,12 @@ export const EditModulesModal = (props: EditModulesModalProps): JSX.Element => {
         { selectedSlot }
       )
     } else if (selectedModel === HEATERSHAKER_MODULE_V1) {
-      const labwareNextToHeaterShaker = getLabwareOnSlot(
-        initialDeckSetup,
-        getSlotNextTo(selectedSlot) ?? ''
-      )
-
       const isHeaterShakerAdjacentToAnotherModule = some(
         initialDeckSetup.modules,
         hwModule => getAreSlotsAdjacent(hwModule.slot, selectedSlot)
       )
 
-      if (
-        labwareNextToHeaterShaker &&
-        getIsLabwareAboveHeight(
-          labwareNextToHeaterShaker.def,
-          MAX_LABWARE_HEIGHT_EAST_WEST_HEATER_SHAKER_MM
-        )
-      ) {
-        errors.selectedSlot = i18n.t(
-          'alert.module_placement.HEATER_SHAKER_ADJACENT_LABWARE_TOO_TALL.body',
-          { selectedSlot }
-        )
-      } else if (isHeaterShakerAdjacentToAnotherModule) {
+      if (isHeaterShakerAdjacentToAnotherModule) {
         errors.selectedSlot = i18n.t(
           'alert.module_placement.HEATER_SHAKER_ADJACENT_TO_ANOTHER_MODULE.body',
           { selectedSlot }

--- a/protocol-designer/src/components/modals/EditModulesModal/index.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.tsx
@@ -68,21 +68,6 @@ export interface EditModulesFormValues {
   selectedSlot: string
 }
 
-// this util only works for outter slots (where we can safely place modules in PD)
-const getSlotNextTo = (slot: string): string | null => {
-  const SLOT_ADJACENT_MAP: Record<string, string> = {
-    '1': '2',
-    '3': '2',
-    '4': '5',
-    '6': '5',
-    '7': '8',
-    '9': '8',
-    '10': '11',
-  }
-
-  return SLOT_ADJACENT_MAP[slot] ?? null
-}
-
 export const EditModulesModal = (props: EditModulesModalProps): JSX.Element => {
   const {
     moduleType,


### PR DESCRIPTION
# Overview

This PR removes a check in the edit modules that makes sure there is no labware next to a heater shaker above 53 mm. This will get caught in step generation when the labware latch is open.

Thanks to @jerader for [catching this](https://github.com/Opentrons/opentrons/pull/10660#pullrequestreview-999817296)!

# Review requests

Create a protocol with a H-S and a tiprack, and try to edit the location of the H-S in the edit modules modal. You should no longer see an error saying that the labware next to the HS is too tall.

# Risk assessment

Low
