### PR TITLE
feat(protocol-designer): restrict H-S slot access and reorder components

### DIFF
--- a/protocol-designer/src/components/modals/FilePipettesModal/__tests__/index.test.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/__tests__/index.test.tsx
@@ -205,14 +205,14 @@ describe('FilePipettesModal', () => {
       expect(props.onSave).toHaveBeenCalledWith({
         modules: [
           {
-            type: MAGNETIC_MODULE_TYPE,
-            model: MAGNETIC_MODULE_V1,
-            slot: '9',
-          },
-          {
             type: HEATERSHAKER_MODULE_TYPE,
             model: HEATERSHAKER_MODULE_V1,
             slot: '1',
+          },
+          {
+            type: MAGNETIC_MODULE_TYPE,
+            model: MAGNETIC_MODULE_V1,
+            slot: '9',
           },
         ],
         newProtocolFields: { name: '' },

--- a/protocol-designer/src/components/modals/FilePipettesModal/index.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/index.tsx
@@ -82,6 +82,11 @@ const initialFormState: FormState = {
     right: { pipetteName: '', tiprackDefURI: null },
   },
   modulesByType: {
+    [HEATERSHAKER_MODULE_TYPE]: {
+      onDeck: false,
+      model: HEATERSHAKER_MODULE_V1,
+      slot: '1',
+    },
     [MAGNETIC_MODULE_TYPE]: {
       onDeck: false,
       model: null,
@@ -96,11 +101,6 @@ const initialFormState: FormState = {
       onDeck: false,
       model: THERMOCYCLER_MODULE_V1, // Default to GEN1 for TC only
       slot: SPAN7_8_10_11_SLOT,
-    },
-    [HEATERSHAKER_MODULE_TYPE]: {
-      onDeck: false,
-      model: HEATERSHAKER_MODULE_V1,
-      slot: '1',
     },
   },
 }

--- a/protocol-designer/src/modules/moduleData.ts
+++ b/protocol-designer/src/modules/moduleData.ts
@@ -8,10 +8,10 @@ import {
 } from '@opentrons/shared-data'
 import { DropdownOption } from '@opentrons/components'
 export const SUPPORTED_MODULE_TYPES: ModuleType[] = [
+  HEATERSHAKER_MODULE_TYPE,
   MAGNETIC_MODULE_TYPE,
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
-  HEATERSHAKER_MODULE_TYPE,
 ]
 type SupportedSlotMap = Record<ModuleType, DropdownOption[]>
 export const SUPPORTED_MODULE_SLOTS: SupportedSlotMap = {
@@ -35,12 +35,12 @@ export const SUPPORTED_MODULE_SLOTS: SupportedSlotMap = {
   ],
   [HEATERSHAKER_MODULE_TYPE]: [
     {
-      name: 'Slot 6 (supported)',
-      value: '6',
+      name: 'Slot 1 (supported)',
+      value: '1',
     },
   ],
 }
-export const ALL_MODULE_SLOTS: DropdownOption[] = [
+const ALL_MODULE_SLOTS: DropdownOption[] = [
   {
     name: 'Slot 1',
     value: '1',
@@ -70,6 +70,28 @@ export const ALL_MODULE_SLOTS: DropdownOption[] = [
     value: '10',
   },
 ]
+const HEATER_SHAKER_SLOTS: DropdownOption[] = [
+  {
+    name: 'Slot 1',
+    value: '1',
+  },
+  {
+    name: 'Slot 3',
+    value: '3',
+  },
+  {
+    name: 'Slot 4',
+    value: '4',
+  },
+  {
+    name: 'Slot 7',
+    value: '7',
+  },
+  {
+    name: 'Slot 10',
+    value: '10',
+  },
+]
 export function getAllModuleSlotsByType(
   moduleType: ModuleType
 ): DropdownOption[] {
@@ -77,6 +99,11 @@ export function getAllModuleSlotsByType(
 
   if (moduleType === THERMOCYCLER_MODULE_TYPE) {
     return supportedSlotOption
+  }
+  if (moduleType === HEATERSHAKER_MODULE_TYPE) {
+    return supportedSlotOption.concat(
+      HEATER_SHAKER_SLOTS.filter(s => s.value !== supportedSlotOption[0].value)
+    )
   }
 
   const allOtherSlots = ALL_MODULE_SLOTS.filter(


### PR DESCRIPTION
# Overview
This PR restricts slots you can put the H-S in, and reorders the module cards so that the H-S shows up first.

closes #9993


# Review requests
Go through ACs in the ticket (#9993)

# Risk assessment

Low