### PR TITLE
fix(discovery-client): fix off by one error in remove logic

### DIFF
--- a/discovery-client/src/store/__tests__/hostsByIpReducer.test.ts
+++ b/discovery-client/src/store/__tests__/hostsByIpReducer.test.ts
@@ -525,6 +525,25 @@ describe('hostsByIp reducer', () => {
         serverHealthError: null,
         robotName: 'opentrons-dev',
       },
+    }
+    const nextState = hostsByIpReducer(initialState, action)
+
+    expect(nextState).toEqual({})
+  })
+
+  it('should handle "client:REMOVE_ROBOT" with multiple matching hosts', () => {
+    const action = Actions.removeRobot('opentrons-dev')
+    const initialState = {
+      '127.0.0.1': {
+        ip: '127.0.0.1',
+        port: 31950,
+        seen: false,
+        healthStatus: null,
+        serverHealthStatus: null,
+        healthError: null,
+        serverHealthError: null,
+        robotName: 'opentrons-dev',
+      },
       '127.0.0.2': {
         ip: '127.0.0.2',
         port: 31950,

--- a/discovery-client/src/store/reducer.ts
+++ b/discovery-client/src/store/reducer.ts
@@ -141,7 +141,7 @@ export const hostsByIpReducer = (
         return robotName === targetRobotName
       })
 
-      return removals.length > 1 ? omit(state, removals) : state
+      return removals.length > 0 ? omit(state, removals) : state
     }
 
     case Actions.SERVICE_FOUND: {


### PR DESCRIPTION
## Overview

Found a silly little off-by-one error in the Discovery Client's robot removal logic while testing robot renames.

This _can_ be a cause for duplicate robots remaining in the "unavailable" list with their old name after a rename, but the other cause is hard-to-avoid race with mDNS advertisements from the robot being renamed, so you probably won't notice much improvement after this PR. Still a bug though!

(mDNS advertisement race listed above is tracked by #10689)

## Review requests

- [ ] Code and test changes make sense

## Risk assessment

Low.