### PR TITLE
fix(app): temporary redirect to devices page

### DIFF
--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/RenameRobotSlideout.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/RenameRobotSlideout.tsx
@@ -73,9 +73,9 @@ export function RenameRobotSlideout({
       // remove the previous robot name from the list
       dispatch(removeRobot(previousRobotName))
       // data.name != null && history.push(`/devices/${data.name}/robot-settings`)
-      // TODO kj: this is a temporary fix to avoid Download logs button disabled issue
-      // Once fix react tree rendering issue, the push direction will be switched to robot-settings
-      data.name != null && history.push(`/devices/${data.name}`)
+      // TODO 6/9/2022 kj this is a temporary fix to avoid the issue
+      // https://github.com/Opentrons/opentrons/issues/10709
+      data.name != null && history.push(`/devices`)
     },
     onError: (error: Error) => {
       // TODO kj 5/25/2022: when a user lost connection while the user is renaming a robot,


### PR DESCRIPTION
Avoid the issue that is in #10709

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This is a temporary solution to for the issue in #10709 and fixes #10720
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- Change the redirect path to `/devices`.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- After renaming a robot, the app redirect to the devices landing page
- 
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
