### PR TITLE
build(app-shell): replace slash in branch for dev build filename

### DIFF
--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -28,7 +28,7 @@ publish_dir := dist/publish
 # if branch exists -> b$(BUILD_NUMBER)-$(BRANCH_NAME)
 # only copy update files publish directory on tagged builds
 publish_update := $(filter v%,$(OT_TAG))
-branch_suffix := $(if $(publish_update),,-$(OT_BRANCH))
+branch_suffix := $(if $(publish_update),,-$(subst /,-,$(OT_BRANCH)))
 build_id := $(or $(and $(OT_BUILD),b$(OT_BUILD)$(branch_suffix)),dev)
 
 builder := electron-builder \
@@ -45,6 +45,10 @@ electron := electron . \
 
 # standard targets
 #####################################################################
+
+.PHONY: branch-suffix
+branch-suffix:
+	echo $(branch_suffix)
 
 .PHONY: all
 all: package


### PR DESCRIPTION
## Overview

Turns out the app-shell dev build really hates it if you put slashes in branch names. Nobody seems to have noticed because, uh, I guess nobody was using slashes in their branch names? Fun times.

## Changelog

- build(app-shell): replace slash in branch for dev build filename

## Review requests

I've named this branch with a slash, so if CI passes for this PR then the fix works.

## Risk assessment

Very low. Branch names are only involved for dev, not prod, app assets
