### PR TITLE
fix(app): update robot banner no longer accessible when robot is busy

### DIFF
--- a/app/src/organisms/Devices/RobotCard.tsx
+++ b/app/src/organisms/Devices/RobotCard.tsx
@@ -30,6 +30,7 @@ import { UpdateRobotBanner } from '../UpdateRobotBanner'
 import {
   useAttachedModules,
   useAttachedPipettes,
+  useIsRobotBusy,
   useProtocolDetailsForRun,
 } from './hooks'
 import { ReachableBanner } from './ReachableBanner'
@@ -45,6 +46,7 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
   const { robot } = props
   const { name: robotName = null, local } = robot
   const history = useHistory()
+  const isRobotBusy = useIsRobotBusy()
   return robotName != null ? (
     <Flex
       alignItems={ALIGN_CENTER}
@@ -64,7 +66,9 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
         id={`RobotCard_${robotName}_robotImage`}
       />
       <Box padding={SPACING.spacing3} width="100%">
-        <UpdateRobotBanner robot={robot} marginBottom={SPACING.spacing3} />
+        {!isRobotBusy ? (
+          <UpdateRobotBanner robot={robot} marginBottom={SPACING.spacing3} />
+        ) : null}
         <ReachableBanner robot={robot} />
         <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
           <Flex flexDirection={DIRECTION_COLUMN}>

--- a/app/src/organisms/Devices/RobotOverview.tsx
+++ b/app/src/organisms/Devices/RobotOverview.tsx
@@ -31,7 +31,7 @@ import { UpdateRobotBanner } from '../UpdateRobotBanner'
 import { RobotStatusBanner } from './RobotStatusBanner'
 import { ReachableBanner } from './ReachableBanner'
 import { RobotOverviewOverflowMenu } from './RobotOverviewOverflowMenu'
-import { useLights, useRobot } from './hooks'
+import { useIsRobotBusy, useLights, useRobot } from './hooks'
 
 const EQUIPMENT_POLL_MS = 5000
 
@@ -52,6 +52,7 @@ export function RobotOverview({
   ] = React.useState<boolean>(false)
   const { lightsOn, toggleLights } = useLights(robotName)
   const currentRunId = useCurrentRunId()
+  const isRobotBusy = useIsRobotBusy()
 
   useInterval(
     () => {
@@ -78,7 +79,7 @@ export function RobotOverview({
       />
       <Box padding={SPACING.spacing3} width="100%">
         <ReachableBanner robot={robot} />
-        {robot != null ? (
+        {robot != null && !isRobotBusy ? (
           <UpdateRobotBanner robot={robot} marginBottom={SPACING.spacing3} />
         ) : null}
         {robot?.status === CONNECTABLE ? (

--- a/app/src/organisms/Devices/__tests__/RobotCard.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotCard.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { when, resetAllWhenMocks } from 'jest-when'
+import { screen } from '@testing-library/react'
 
 import { renderWithProviders } from '@opentrons/components'
 import { RUN_STATUS_RUNNING } from '@opentrons/api-client'
@@ -16,6 +17,7 @@ import { mockConnectableRobot } from '../../../redux/discovery/__fixtures__'
 import {
   useAttachedModules,
   useAttachedPipettes,
+  useIsRobotBusy,
   useProtocolDetailsForRun,
 } from '../hooks'
 import { useCurrentRunId } from '../../../organisms/ProtocolUpload/hooks'
@@ -56,6 +58,9 @@ const mockChooseProtocolSlideout = ChooseProtocolSlideout as jest.MockedFunction
 const mockUpdateRobotBanner = UpdateRobotBanner as jest.MockedFunction<
   typeof UpdateRobotBanner
 >
+const mockUseIsRobotBusy = useIsRobotBusy as jest.MockedFunction<
+  typeof useIsRobotBusy
+>
 
 const simpleV6Protocol = (_uncastedSimpleV6Protocol as unknown) as ProtocolAnalysisFile<{}>
 const PROTOCOL_DETAILS = {
@@ -77,6 +82,7 @@ const render = () => {
 
 describe('RobotCard', () => {
   beforeEach(() => {
+    mockUseIsRobotBusy.mockReturnValue(false)
     mockUseAttachedModules.mockReturnValue(
       mockFetchModulesSuccessActionPayloadModules
     )
@@ -115,6 +121,11 @@ describe('RobotCard', () => {
   it('renders a UpdateRobotBanner component', () => {
     const [{ getByText }] = render()
     getByText('Mock UpdateRobotBanner')
+  })
+
+  it('does not render a UpdateRobotBanner component when robot is busy', () => {
+    mockUseIsRobotBusy.mockReturnValue(true)
+    expect(screen.queryByText('Mock UpdateRobotBanner')).toBeNull()
   })
 
   it('renders the type of pipettes attached to left and right mounts', () => {

--- a/app/src/organisms/Devices/__tests__/RobotOverview.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotOverview.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { MemoryRouter } from 'react-router-dom'
-import { fireEvent } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 
 import { renderWithProviders } from '@opentrons/components'
 
@@ -10,7 +10,7 @@ import { ChooseProtocolSlideout } from '../../ChooseProtocolSlideout'
 import { mockConnectableRobot } from '../../../redux/discovery/__fixtures__'
 import { useDispatchApiRequest } from '../../../redux/robot-api'
 import { fetchLights } from '../../../redux/robot-controls'
-import { useLights, useRobot } from '../hooks'
+import { useIsRobotBusy, useLights, useRobot } from '../hooks'
 import { UpdateRobotBanner } from '../../UpdateRobotBanner'
 import { RobotStatusBanner } from '../RobotStatusBanner'
 import { RobotOverview } from '../RobotOverview'
@@ -29,6 +29,9 @@ jest.mock('../RobotOverviewOverflowMenu')
 
 const OT2_PNG_FILE_NAME = 'OT2-R_HERO.png'
 
+const mockUseIsRobotBusy = useIsRobotBusy as jest.MockedFunction<
+  typeof useIsRobotBusy
+>
 const mockUseLights = useLights as jest.MockedFunction<typeof useLights>
 const mockUseRobot = useRobot as jest.MockedFunction<typeof useRobot>
 const mockUseCurrentRunId = useCurrentRunId as jest.MockedFunction<
@@ -69,6 +72,7 @@ describe('RobotOverview', () => {
 
   beforeEach(() => {
     dispatchApiRequest = jest.fn()
+    mockUseIsRobotBusy.mockReturnValue(false)
     mockUseDispatchApiRequest.mockReturnValue([dispatchApiRequest, []])
     mockUseLights.mockReturnValue({
       lightsOn: false,
@@ -105,6 +109,11 @@ describe('RobotOverview', () => {
   it('renders a UpdateRobotBanner component', () => {
     const [{ getByText }] = render()
     getByText('Mock UpdateRobotBanner')
+  })
+
+  it('does not render a UpdateRobotBanner component when robot is busy', () => {
+    mockUseIsRobotBusy.mockReturnValue(true)
+    expect(screen.queryByText('Mock UpdateRobotBanner')).toBeNull()
   })
 
   it('fetches lights status', () => {


### PR DESCRIPTION
closes #10311

# Overview

The update robot banner should no longer be rendered when the robot is busy from all 3 locations that the banner is accessible, this matches the current behavior in `RobotServerVersion`

This PR fixes the banner render logic in:

1. robot card
2. robot overview

# Changelog

- add `useIsRobotBusy` hook to robot card and robot overview and fix tests

# Review requests

- when an update is available, load a protocol to the robot  - the update robot banner should no longer be visible from the Robot Card and the Robot Overview

# Risk assessment

low