### PR TITLE
fix(app): avoid the name conflict issue in the same network

### DIFF
--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -115,6 +115,7 @@
   "rename_robot_button": "Rename robot",
   "rename_robot_input_limitation_label": "35 characters max",
   "rename_robot_input_limitation_detail": "Please enter 35 characters max using valid inputs: letters and numbers",
+  "robot_name_already_exists": "Robot name already exists",
   "factory_reset_slideout_title": "Factory Reset",
   "factory_reset_slideout_description": "Select the robot data to clear.",
   "factory_reset_slideout_warning_message": "Factory resets cannot be undone",

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/RenameRobotSlideout.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/RenameRobotSlideout.tsx
@@ -70,9 +70,7 @@ export function RenameRobotSlideout({
       if (!regexPattern.test(newName)) {
         errors.newRobotName = t('rename_robot_input_limitation_detail')
       }
-      if (
-        healthyReachableRobots.find(robot => newName === robot.name) != null
-      ) {
+      if (healthyReachableRobots.some(robot => newName === robot.name)) {
         errors.newRobotName = t('robot_name_already_exists')
       }
       return errors

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/RenameRobotSlideout.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/RenameRobotSlideout.tsx
@@ -58,7 +58,6 @@ export function RenameRobotSlideout({
   const reachableRobots = useSelector((state: State) =>
     getReachableRobots(state)
   )
-
   const unreachableRobots = useSelector((state: State) =>
     getUnreachableRobots(state)
   )
@@ -71,11 +70,11 @@ export function RenameRobotSlideout({
       const newName = values.newRobotName
       console.log('form robotName', robotName)
       setPreviousRobotName(robotName)
-      const duplicatedName = unreachableRobots.find(
+      const sameNameRobotInUnavailable = unreachableRobots.find(
         robot => robot.name === newName
       )
-      if (duplicatedName != null) {
-        dispatch(removeRobot(previousRobotName))
+      if (sameNameRobotInUnavailable != null) {
+        dispatch(removeRobot(sameNameRobotInUnavailable.name))
       }
       updateRobotName(newName)
       resetForm({ values: { newRobotName: '' } })
@@ -99,8 +98,7 @@ export function RenameRobotSlideout({
 
   const { updateRobotName } = useUpdateRobotNameMutation({
     onSuccess: (data: UpdatedRobotName) => {
-      // remove the previous robot name from the list
-      // console.log('previousRobotName', previousRobotName)
+      // TODO: 6/10/2022 kj for the robot name, we need to use GET: /server/name
       // data.name != null && history.push(`/devices/${data.name}/robot-settings`)
       // TODO 6/9/2022 kj this is a temporary fix to avoid the issue
       // https://github.com/Opentrons/opentrons/issues/10709

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/RenameRobotSlideout.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/RenameRobotSlideout.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { useDispatch } from 'react-redux'
+import { useSelector, useDispatch } from 'react-redux'
 import { useHistory } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useFormik } from 'formik'
@@ -11,14 +11,17 @@ import {
   COLORS,
 } from '@opentrons/components'
 import { useUpdateRobotNameMutation } from '@opentrons/react-api-client'
-import { removeRobot } from '../../../../../redux/discovery'
+import {
+  removeRobot,
+  getConnectableRobots,
+} from '../../../../../redux/discovery'
 import { Slideout } from '../../../../../atoms/Slideout'
 import { StyledText } from '../../../../../atoms/text'
 import { PrimaryButton } from '../../../../../atoms/buttons'
 import { InputField } from '../../../../../atoms/InputField'
 
 import type { UpdatedRobotName } from '@opentrons/api-client'
-import type { Dispatch } from '../../../../../redux/types'
+import type { State, Dispatch } from '../../../../../redux/types'
 interface RenameRobotSlideoutProps {
   isExpanded: boolean
   onCloseClick: () => void
@@ -47,6 +50,9 @@ export function RenameRobotSlideout({
   )
   const history = useHistory()
   const dispatch = useDispatch<Dispatch>()
+  const healthyReachableRobots = useSelector((state: State) =>
+    getConnectableRobots(state)
+  )
 
   const formik = useFormik({
     initialValues: {
@@ -63,6 +69,11 @@ export function RenameRobotSlideout({
       const newName = values.newRobotName
       if (!regexPattern.test(newName)) {
         errors.newRobotName = t('rename_robot_input_limitation_detail')
+      }
+      if (
+        healthyReachableRobots.find(robot => newName === robot.name) != null
+      ) {
+        errors.newRobotName = t('robot_name_already_exists')
       }
       return errors
     },

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/__tests__/RenameRobotSlideout.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/__tests__/RenameRobotSlideout.test.tsx
@@ -6,7 +6,7 @@ import { i18n } from '../../../../../../i18n'
 import { getConnectableRobots } from '../../../../../../redux/discovery'
 import {
   mockConnectableRobot,
-  mockUnreachableRobot,
+  // mockUnreachableRobot,
 } from '../../../../../../redux/discovery/__fixtures__'
 
 import { RenameRobotSlideout } from '../RenameRobotSlideout'


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR will avoid the same name robot issue in the same network. if there is the same name in the same network, the app shows an error message.
![Screen Shot 2022-06-10 at 11 04 45 AM](https://user-images.githubusercontent.com/474225/173100893-113e0034-c44c-4113-af1d-0adbf9e65eab.png)

In terms of the error message, this should be temporary. We need to ask about the reasonable message to @emilywools and @ecormany 
Also need support from the design team since if we remove unavailable robot, we will need to add a modal to get confirmation from users.

#10709

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
# Changelog
- Add validation to the form
- Add the test case
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- If type an existing name, the slideout shows an error message (This function only works with a real robot)
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
