### PR TITLE
fix(robot-server): calculate magnetic module gen 1 height 

### DIFF
--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -20,6 +20,9 @@ MAX_ENGAGE_HEIGHT = {
 }
 
 # Measured in model-specific units (half-mm for GEN1, mm for GEN2).
+# TODO(mc, 2022-06-13): the value for gen1 is off by 1.5 mm
+# The correct value is 8.0 half-mm (4.0 mm)
+# https://github.com/Opentrons/opentrons/issues/9529
 OFFSET_TO_LABWARE_BOTTOM = {"magneticModuleV1": 5, "magneticModuleV2": 2.5}
 
 

--- a/robot-server/robot_server/modules/module_data_mapper.py
+++ b/robot-server/robot_server/modules/module_data_mapper.py
@@ -58,6 +58,8 @@ class ModuleDataMapper:
             module_data = MagneticModuleData(
                 status=MagneticStatus(live_data["status"]),
                 engaged=cast(bool, live_data["data"].get("engaged")),
+                # Calculate adjustments for MAGNETIC_MODULE_V1
+                # https://github.com/Opentrons/opentrons/blob/edge/api/src/opentrons/protocol_engine/state/module_substates/magnetic_module_substate.py#L43
                 height=live_data_height / 2
                 if module_model == ModuleModel.MAGNETIC_MODULE_V1
                 else live_data_height,

--- a/robot-server/robot_server/modules/module_data_mapper.py
+++ b/robot-server/robot_server/modules/module_data_mapper.py
@@ -66,7 +66,7 @@ class ModuleDataMapper:
             # Also, magnetic module v1 reports height in half millimeters
             height_from_base = live_data_height - OFFSET_TO_LABWARE_BOTTOM[model]
             if module_model == ModuleModel.MAGNETIC_MODULE_V1:
-                height_from_base = height_from_base / 2
+                height_from_base /= 2
 
             module_data = MagneticModuleData(
                 status=MagneticStatus(live_data["status"]),

--- a/robot-server/robot_server/modules/module_data_mapper.py
+++ b/robot-server/robot_server/modules/module_data_mapper.py
@@ -54,10 +54,13 @@ class ModuleDataMapper:
         # rely on Pydantic to check/coerce data fields from dicts at run time
         if module_type == ModuleType.MAGNETIC:
             module_cls = MagneticModule
+            live_data_height = cast(float, live_data["data"].get("height"))
             module_data = MagneticModuleData(
                 status=MagneticStatus(live_data["status"]),
                 engaged=cast(bool, live_data["data"].get("engaged")),
-                height=cast(float, live_data["data"].get("height")),
+                height=live_data_height / 2
+                if module_model == ModuleModel.MAGNETIC_MODULE_V1
+                else live_data_height,
             )
 
         elif module_type == ModuleType.TEMPERATURE:

--- a/robot-server/tests/modules/test_module_data_mapper.py
+++ b/robot-server/tests/modules/test_module_data_mapper.py
@@ -33,20 +33,29 @@ from robot_server.modules.module_models import (
     [
         (
             "magneticModuleV1",
-            {"status": "engaged", "data": {"engaged": True, "height": 42}},
+            {"status": "disengaged", "data": {"engaged": False, "height": 0.0}},
             MagneticModuleData(
-                status=MagneticStatus.ENGAGED,
-                engaged=True,
-                height=21,
+                status=MagneticStatus.DISENGAGED,
+                engaged=False,
+                height=-2.5,
             ),
         ),
         (
             "magneticModuleV1",
+            {"status": "engaged", "data": {"engaged": True, "height": 42}},
+            MagneticModuleData(
+                status=MagneticStatus.ENGAGED,
+                engaged=True,
+                height=18.5,
+            ),
+        ),
+        (
+            "magneticModuleV2",
             {"status": "disengaged", "data": {"engaged": False, "height": 0.0}},
             MagneticModuleData(
                 status=MagneticStatus.DISENGAGED,
                 engaged=False,
-                height=0.0,
+                height=-2.5,
             ),
         ),
         (
@@ -55,16 +64,7 @@ from robot_server.modules.module_models import (
             MagneticModuleData(
                 status=MagneticStatus.ENGAGED,
                 engaged=True,
-                height=42,
-            ),
-        ),
-        (
-            "magneticModuleV2",
-            {"status": "disengaged", "data": {"engaged": False, "height": 0.0}},
-            MagneticModuleData(
-                status=MagneticStatus.DISENGAGED,
-                engaged=False,
-                height=0.0,
+                height=39.5,
             ),
         ),
     ],

--- a/robot-server/tests/modules/test_module_data_mapper.py
+++ b/robot-server/tests/modules/test_module_data_mapper.py
@@ -1,6 +1,5 @@
 """Tests for robot_server.modules.module_data_mapper."""
 import pytest
-from typing import Dict
 
 from opentrons.protocol_engine import ModuleModel
 from opentrons.drivers.rpi_drivers.types import USBPort as HardwareUSBPort
@@ -30,34 +29,50 @@ from robot_server.modules.module_models import (
 
 
 @pytest.mark.parametrize(
-    ("input_model", "input_data", "output_data"),
+    ("input_model", "input_data", "expected_output_data"),
     [
         (
             "magneticModuleV1",
             {"status": "engaged", "data": {"engaged": True, "height": 42}},
-            {"data": {"height": 21}},
+            MagneticModuleData(
+                status=MagneticStatus.ENGAGED,
+                engaged=True,
+                height=21,
+            ),
         ),
         (
             "magneticModuleV1",
             {"status": "disengaged", "data": {"engaged": False, "height": 0.0}},
-            {"data": {"height": 0.0}},
+            MagneticModuleData(
+                status=MagneticStatus.DISENGAGED,
+                engaged=False,
+                height=0.0,
+            ),
         ),
         (
             "magneticModuleV2",
             {"status": "engaged", "data": {"engaged": True, "height": 42}},
-            {"data": {"height": 42}},
+            MagneticModuleData(
+                status=MagneticStatus.ENGAGED,
+                engaged=True,
+                height=42,
+            ),
         ),
         (
             "magneticModuleV2",
             {"status": "disengaged", "data": {"engaged": False, "height": 0.0}},
-            {"data": {"height": 0.0}},
+            MagneticModuleData(
+                status=MagneticStatus.DISENGAGED,
+                engaged=False,
+                height=0.0,
+            ),
         ),
     ],
 )
 def test_maps_magnetic_module_data(
     input_model: str,
     input_data: LiveData,
-    output_data: Dict[str, float],
+    expected_output_data: MagneticModuleData,
 ) -> None:
     """It should map hardware data to a magnetic module."""
     module_identity = ModuleIdentity(
@@ -92,11 +107,7 @@ def test_maps_magnetic_module_data(
         moduleType=ModuleType.MAGNETIC,
         moduleModel=ModuleModel(input_model),  # type: ignore[arg-type]
         usbPort=UsbPort(port=101, hub=202, path="/dev/null"),
-        data=MagneticModuleData(
-            status=MagneticStatus(input_data["status"]),
-            engaged=input_data["data"]["engaged"],  # type: ignore[arg-type]
-            height=output_data["data"]["height"],  # type: ignore[index]
-        ),
+        data=expected_output_data,
     )
 
 

--- a/robot-server/tests/modules/test_module_data_mapper.py
+++ b/robot-server/tests/modules/test_module_data_mapper.py
@@ -1,5 +1,6 @@
 """Tests for robot_server.modules.module_data_mapper."""
 import pytest
+from typing import Dict
 
 from opentrons.protocol_engine import ModuleModel
 from opentrons.drivers.rpi_drivers.types import USBPort as HardwareUSBPort
@@ -29,17 +30,35 @@ from robot_server.modules.module_models import (
 
 
 @pytest.mark.parametrize(
-    "input_model",
-    ["magneticModuleV1", "magneticModuleV2"],
-)
-@pytest.mark.parametrize(
-    "input_data",
+    ("input_model", "input_data", "output_data"),
     [
-        {"status": "engaged", "data": {"engaged": True, "height": 42}},
-        {"status": "disengaged", "data": {"engaged": False, "height": 0.0}},
+        (
+            "magneticModuleV1",
+            {"status": "engaged", "data": {"engaged": True, "height": 42}},
+            {"data": {"height": 21}},
+        ),
+        (
+            "magneticModuleV1",
+            {"status": "disengaged", "data": {"engaged": False, "height": 0.0}},
+            {"data": {"height": 0.0}},
+        ),
+        (
+            "magneticModuleV2",
+            {"status": "engaged", "data": {"engaged": True, "height": 42}},
+            {"data": {"height": 42}},
+        ),
+        (
+            "magneticModuleV2",
+            {"status": "disengaged", "data": {"engaged": False, "height": 0.0}},
+            {"data": {"height": 0.0}},
+        ),
     ],
 )
-def test_maps_magnetic_module_data(input_model: str, input_data: LiveData) -> None:
+def test_maps_magnetic_module_data(
+    input_model: str,
+    input_data: LiveData,
+    output_data: Dict[str, float],
+) -> None:
     """It should map hardware data to a magnetic module."""
     module_identity = ModuleIdentity(
         module_id="module-id",
@@ -76,7 +95,7 @@ def test_maps_magnetic_module_data(input_model: str, input_data: LiveData) -> No
         data=MagneticModuleData(
             status=MagneticStatus(input_data["status"]),
             engaged=input_data["data"]["engaged"],  # type: ignore[arg-type]
-            height=input_data["data"]["height"],  # type: ignore[arg-type]
+            height=output_data["data"]["height"],  # type: ignore[index]
         ),
     )
 


### PR DESCRIPTION
## Overview

Closes #9515.

Engage command implementation adjusts Gen1 magdeck height from base.
Need to do the opposite when getting the height.

## Changelog

- Subtract home-to-base offset from HW reported magnetic module height
- Half reported height for GEN1 magnetic modules to account for half-mm units from HW API

## Review requests

- Code and tests look good
- Works on hardware*

### Known issues

*On GEN1 magnetic modules, the engage height that the module moves to will be about 1.5mm too low; see #9585. In other words, if you command a GEN1 module to go to `height: 0`, it will report `height: 0` in `GET /modules` but the magnets will be physically about 1.5mm below the labware base. This appears to be a long-standing HW API bug, and this PR will not attempt to compensate for it.

## Risk assessment

Low, we've only changed how heights are reported via `GET /modules`. We haven't changed anything about the operation of the modules themselves.
