### PR TITLE
test(api): enable strict typechecking of opentrons.config tests

### DIFF
--- a/api/mypy.ini
+++ b/api/mypy.ini
@@ -24,28 +24,6 @@ disallow_incomplete_defs = False
 no_implicit_optional = False
 warn_return_any = False
 
-[mypy-tests.opentrons.config.test_reset]
-disallow_untyped_defs = False
-disallow_untyped_calls = False
-no_implicit_optional = False
-
-[mypy-tests.opentrons.config.test_pipette_config]
-disallow_untyped_defs = False
-disallow_untyped_calls = False
-no_implicit_optional = False
-
-[mypy-tests.opentrons.config.test_advanced_settings]
-disallow_untyped_defs = False
-disallow_untyped_calls = False
-no_implicit_optional = False
-
-[mypy-tests.opentrons.config.test_advanced_settings_migration]
-disallow_untyped_defs = False
-disallow_untyped_calls = False
-no_implicit_optional = False
-
-
-
 # ~30 errors
 [mypy-tests.opentrons.drivers.*]
 disallow_untyped_defs = False

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Any, Dict
 
 import pytest
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import]
@@ -11,7 +11,7 @@ def migrated_file_version() -> int:
 
 
 @pytest.fixture
-def default_file_settings() -> Dict[str, Optional[bool]]:
+def default_file_settings() -> Dict[str, Any]:
     return {
         "shortFixedTrash": None,
         "deckCalibrationDots": None,
@@ -25,12 +25,12 @@ def default_file_settings() -> Dict[str, Optional[bool]]:
 
 
 @pytest.fixture
-def empty_settings():
+def empty_settings() -> Dict[str, Any]:
     return {}
 
 
 @pytest.fixture
-def version_less():
+def version_less() -> Dict[str, Any]:
     return {
         "shortFixedTrash": True,
         "calibrateToBottom": True,
@@ -41,7 +41,7 @@ def version_less():
 
 
 @pytest.fixture
-def v1_config():
+def v1_config() -> Dict[str, Any]:
     return {
         "_version": 1,
         "shortFixedTrash": True,
@@ -54,7 +54,7 @@ def v1_config():
 
 
 @pytest.fixture
-def v2_config(v1_config):
+def v2_config(v1_config: Dict[str, Any]) -> Dict[str, Any]:
     r = v1_config.copy()
     r.update(
         {
@@ -66,21 +66,21 @@ def v2_config(v1_config):
 
 
 @pytest.fixture
-def v3_config(v2_config):
+def v3_config(v2_config: Dict[str, Any]) -> Dict[str, Any]:
     r = v2_config.copy()
     r.update({"_version": 3, "enableApi1BackCompat": False})
     return r
 
 
 @pytest.fixture
-def v4_config(v3_config):
+def v4_config(v3_config: Dict[str, Any]) -> Dict[str, Any]:
     r = v3_config.copy()
     r.update({"_version": 4, "useV1HttpApi": False})
     return r
 
 
 @pytest.fixture
-def v5_config(v4_config):
+def v5_config(v4_config: Dict[str, Any]) -> Dict[str, Any]:
     r = v4_config.copy()
     r.update(
         {
@@ -92,7 +92,7 @@ def v5_config(v4_config):
 
 
 @pytest.fixture
-def v6_config(v5_config):
+def v6_config(v5_config: Dict[str, Any]) -> Dict[str, Any]:
     r = v5_config.copy()
     r.update(
         {
@@ -104,7 +104,7 @@ def v6_config(v5_config):
 
 
 @pytest.fixture
-def v7_config(v6_config):
+def v7_config(v6_config: Dict[str, Any]) -> Dict[str, Any]:
     r = v6_config.copy()
     r.update(
         {
@@ -116,7 +116,7 @@ def v7_config(v6_config):
 
 
 @pytest.fixture
-def v8_config(v7_config):
+def v8_config(v7_config: Dict[str, Any]) -> Dict[str, Any]:
     r = v7_config.copy()
     r.update(
         {
@@ -128,7 +128,7 @@ def v8_config(v7_config):
 
 
 @pytest.fixture
-def v9_config(v8_config):
+def v9_config(v8_config: Dict[str, Any]) -> Dict[str, Any]:
     r = v8_config.copy()
     r.update(
         {
@@ -140,7 +140,7 @@ def v9_config(v8_config):
 
 
 @pytest.fixture
-def v10_config(v9_config):
+def v10_config(v9_config: Dict[str, Any]) -> Dict[str, Any]:
     r = v9_config.copy()
     r.pop("useProtocolApi2")
     r.pop("enableApi1BackCompat")
@@ -157,7 +157,7 @@ def v10_config(v9_config):
 
 
 @pytest.fixture
-def v11_config(v10_config):
+def v11_config(v10_config: Dict[str, Any]) -> Dict[str, Any]:
     r = v10_config.copy()
     r.pop("enableProtocolEngine")
     r.update({"_version": 11})
@@ -165,7 +165,7 @@ def v11_config(v10_config):
 
 
 @pytest.fixture
-def v12_config(v11_config):
+def v12_config(v11_config: Dict[str, Any]) -> Dict[str, Any]:
     r = v11_config.copy()
     r.update(
         {
@@ -177,7 +177,7 @@ def v12_config(v11_config):
 
 
 @pytest.fixture
-def v13_config(v12_config):
+def v13_config(v12_config: Dict[str, Any]) -> Dict[str, Any]:
     r = v12_config.copy()
     r.pop("calibrateToBottom")
     r.update({"_version": 13})
@@ -185,7 +185,7 @@ def v13_config(v12_config):
 
 
 @pytest.fixture
-def v14_config(v13_config):
+def v14_config(v13_config: Dict[str, Any]) -> Dict[str, Any]:
     r = v13_config.copy()
     r.pop("enableHttpProtocolSessions")
     r.update({"_version": 14})
@@ -213,11 +213,15 @@ def v14_config(v13_config):
         lazy_fixture("v14_config"),
     ],
 )
-def old_settings(request):
-    return request.param
+def old_settings(request: pytest.FixtureRequest) -> Dict[str, Any]:
+    return request.param  # type: ignore[attr-defined, no-any-return]
 
 
-def test_migrations(old_settings, migrated_file_version, default_file_settings):
+def test_migrations(
+    old_settings: Dict[str, Any],
+    migrated_file_version: int,
+    default_file_settings: Dict[str, Any],
+) -> None:
     settings, version = _migrate(old_settings)
 
     expected = default_file_settings.copy()
@@ -233,7 +237,10 @@ def test_migrations(old_settings, migrated_file_version, default_file_settings):
     assert settings == expected
 
 
-def test_migrates_versionless_old_config(migrated_file_version, default_file_settings):
+def test_migrates_versionless_old_config(
+    migrated_file_version: int,
+    default_file_settings: Dict[str, Any],
+) -> None:
     settings, version = _migrate(
         {
             "short-fixed-trash": False,
@@ -256,7 +263,10 @@ def test_migrates_versionless_old_config(migrated_file_version, default_file_set
     assert settings == expected
 
 
-def test_ignores_invalid_keys(migrated_file_version, default_file_settings):
+def test_ignores_invalid_keys(
+    migrated_file_version: int,
+    default_file_settings: Dict[str, Any],
+) -> None:
     settings, version = _migrate(
         {
             "split-labware-def": True,
@@ -268,7 +278,7 @@ def test_ignores_invalid_keys(migrated_file_version, default_file_settings):
     assert settings == default_file_settings
 
 
-def test_ensures_config():
+def test_ensures_config() -> None:
     assert _ensure(
         {"_version": 3, "shortFixedTrash": False, "disableLogAggregation": True}
     ) == {

--- a/api/tests/opentrons/config/test_reset.py
+++ b/api/tests/opentrons/config/test_reset.py
@@ -1,44 +1,47 @@
-from unittest.mock import patch
+from typing import Generator
+from unittest.mock import MagicMock, patch
+
 import pytest
+
 from opentrons.config import reset
 
 
 @pytest.fixture
-def mock_reset_boot_scripts():
+def mock_reset_boot_scripts() -> Generator[MagicMock, None, None]:
     with patch("opentrons.config.reset.reset_boot_scripts") as m:
         yield m
 
 
 @pytest.fixture
-def mock_reset_pipette_offset():
+def mock_reset_pipette_offset() -> Generator[MagicMock, None, None]:
     with patch("opentrons.config.reset.reset_pipette_offset") as m:
         yield m
 
 
 @pytest.fixture
-def mock_reset_deck_calibration():
+def mock_reset_deck_calibration() -> Generator[MagicMock, None, None]:
     with patch("opentrons.config.reset.reset_deck_calibration") as m:
         yield m
 
 
 @pytest.fixture
-def mock_reset_tip_length_calibrations():
+def mock_reset_tip_length_calibrations() -> Generator[MagicMock, None, None]:
     with patch("opentrons.config.reset.reset_tip_length_calibrations") as m:
         yield m
 
 
 @pytest.fixture
-def mock_cal_storage_delete():
+def mock_cal_storage_delete() -> Generator[MagicMock, None, None]:
     with patch("opentrons.config.reset.delete", autospec=True) as m:
         yield m
 
 
 def test_reset_empty_set(
-    mock_reset_boot_scripts,
-    mock_reset_pipette_offset,
-    mock_reset_deck_calibration,
-    mock_reset_tip_length_calibrations,
-):
+    mock_reset_boot_scripts: MagicMock,
+    mock_reset_pipette_offset: MagicMock,
+    mock_reset_deck_calibration: MagicMock,
+    mock_reset_tip_length_calibrations: MagicMock,
+) -> None:
     reset.reset(set())
     mock_reset_boot_scripts.assert_not_called()
     mock_reset_pipette_offset.assert_not_called()
@@ -47,11 +50,11 @@ def test_reset_empty_set(
 
 
 def test_reset_all_set(
-    mock_reset_boot_scripts,
-    mock_reset_pipette_offset,
-    mock_reset_deck_calibration,
-    mock_reset_tip_length_calibrations,
-):
+    mock_reset_boot_scripts: MagicMock,
+    mock_reset_pipette_offset: MagicMock,
+    mock_reset_deck_calibration: MagicMock,
+    mock_reset_tip_length_calibrations: MagicMock,
+) -> None:
     reset.reset(
         {
             reset.ResetOptionId.boot_scripts,
@@ -66,18 +69,18 @@ def test_reset_all_set(
     mock_reset_tip_length_calibrations.assert_called_once()
 
 
-def test_deck_calibration_reset(mock_cal_storage_delete):
+def test_deck_calibration_reset(mock_cal_storage_delete: MagicMock) -> None:
     reset.reset_deck_calibration()
     mock_cal_storage_delete.delete_robot_deck_attitude.assert_called_once()
     mock_cal_storage_delete.clear_pipette_offset_calibrations.assert_called_once()
 
 
-def test_tip_length_calibrations_reset(mock_cal_storage_delete):
+def test_tip_length_calibrations_reset(mock_cal_storage_delete: MagicMock) -> None:
     reset.reset_tip_length_calibrations()
     mock_cal_storage_delete.clear_tip_length_calibration.assert_called_once()
     mock_cal_storage_delete.clear_pipette_offset_calibrations.assert_called_once()
 
 
-def test_pipette_offset_reset(mock_cal_storage_delete):
+def test_pipette_offset_reset(mock_cal_storage_delete: MagicMock) -> None:
     reset.reset_pipette_offset()
     mock_cal_storage_delete.clear_pipette_offset_calibrations.assert_called_once()


### PR DESCRIPTION
## Overview

Don't mind me, just chipping away at untyped `api` code. This time, the tests for `opentrons.config`

## Changelog

- Enable strict typing for `tests.opentrons.config`
- Fix typechecking failures

## Review requests

Nothing too specific. Let me know if you disagree with any annotation choices and/or you think a different annotation would work better.

## Risk assessment

Very low. Changes were to test files, only, and those changes are all type annotations
