### PR TITLE
refactor(app): hide menu items instead of disable in RobotOverviewOverflowMenu

### DIFF
--- a/app/src/assets/localization/en/devices_landing.json
+++ b/app/src/assets/localization/en/devices_landing.json
@@ -22,7 +22,7 @@
   "restart_the_app": "Restart the app",
   "restart_the_robot": "Restart the robot",
   "right_mount": "Right Mount",
-  "robot_settings": "robot settings",
+  "robot_settings": "Robot settings",
   "running": "running",
   "run_a_protocol": "Run a protocol",
   "see_how_to_setup_new_robot": "See how to set up a new robot",

--- a/app/src/assets/localization/en/robot_controls.json
+++ b/app/src/assets/localization/en/robot_controls.json
@@ -6,6 +6,6 @@
   "lights_label": "lights",
   "restart_button": "restart",
   "restart_description": "Restart robot.",
-  "restart_label": "restart robot",
+  "restart_label": "Restart robot",
   "title": "robot controls"
 }

--- a/app/src/organisms/Devices/RobotOverviewOverflowMenu.tsx
+++ b/app/src/organisms/Devices/RobotOverviewOverflowMenu.tsx
@@ -127,7 +127,6 @@ export const RobotOverviewOverflowMenu = (
             <>
               <MenuItem
                 onClick={handleClickRestart}
-                textTransform={TEXT_TRANSFORM_CAPITALIZE}
                 data-testid={`RobotOverviewOverflowMenu_restartRobot_${robot.name}`}
               >
                 {t('robot_controls:restart_label')}
@@ -145,7 +144,6 @@ export const RobotOverviewOverflowMenu = (
             onClick={() =>
               history.push(`/devices/${robot.name}/robot-settings`)
             }
-            textTransform={TEXT_TRANSFORM_CAPITALIZE}
             disabled={
               robot == null ||
               robot?.status === UNREACHABLE ||

--- a/app/src/organisms/Devices/RobotOverviewOverflowMenu.tsx
+++ b/app/src/organisms/Devices/RobotOverviewOverflowMenu.tsx
@@ -78,6 +78,7 @@ export const RobotOverviewOverflowMenu = (
   const { autoUpdateAction } = useSelector((state: State) => {
     return getBuildrootUpdateDisplayInfo(state, robot.name)
   })
+  const isRobotInUse = isRobotBusy || robot?.status !== CONNECTABLE
 
   return (
     <Flex
@@ -114,30 +115,31 @@ export const RobotOverviewOverflowMenu = (
           right={0}
           flexDirection={DIRECTION_COLUMN}
         >
-          {autoUpdateAction === 'upgrade' ? (
+          {autoUpdateAction === 'upgrade' && !isRobotInUse ? (
             <MenuItem
-              disabled={isRobotBusy || robot?.status !== CONNECTABLE}
               onClick={handleClickUpdateBuildroot}
               data-testid={`RobotOverviewOverflowMenu_updateSoftware_${robot.name}`}
             >
               {t('update_robot_software')}
             </MenuItem>
           ) : null}
-          <MenuItem
-            onClick={handleClickRestart}
-            textTransform={TEXT_TRANSFORM_CAPITALIZE}
-            disabled={isRobotBusy || robot?.status !== CONNECTABLE}
-            data-testid={`RobotOverviewOverflowMenu_restartRobot_${robot.name}`}
-          >
-            {t('robot_controls:restart_label')}
-          </MenuItem>
-          <MenuItem
-            onClick={handleClickHomeGantry}
-            disabled={isRobotBusy || robot?.status !== CONNECTABLE}
-            data-testid={`RobotOverviewOverflowMenu_homeGantry_${robot.name}`}
-          >
-            {t('home_gantry')}
-          </MenuItem>
+          {isRobotInUse ? null : (
+            <>
+              <MenuItem
+                onClick={handleClickRestart}
+                textTransform={TEXT_TRANSFORM_CAPITALIZE}
+                data-testid={`RobotOverviewOverflowMenu_restartRobot_${robot.name}`}
+              >
+                {t('robot_controls:restart_label')}
+              </MenuItem>
+              <MenuItem
+                onClick={handleClickHomeGantry}
+                data-testid={`RobotOverviewOverflowMenu_homeGantry_${robot.name}`}
+              >
+                {t('home_gantry')}
+              </MenuItem>
+            </>
+          )}
           <Divider marginY={'0'} />
           <MenuItem
             onClick={() =>

--- a/app/src/organisms/Devices/RobotOverviewOverflowMenu.tsx
+++ b/app/src/organisms/Devices/RobotOverviewOverflowMenu.tsx
@@ -9,7 +9,6 @@ import {
   POSITION_ABSOLUTE,
   POSITION_RELATIVE,
   SPACING,
-  TEXT_TRANSFORM_CAPITALIZE,
   useMountEffect,
 } from '@opentrons/components'
 import { checkShellUpdate } from '../../redux/shell'

--- a/app/src/organisms/Devices/__tests__/RobotOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotOverflowMenu.test.tsx
@@ -61,7 +61,7 @@ describe('RobotOverflowMenu', () => {
     const { getByText, getByLabelText } = render(props)
     const btn = getByLabelText('RobotOverflowMenu_button')
     fireEvent.click(btn)
-    getByText('robot settings')
+    getByText('Robot settings')
     const run = getByText('Run a protocol')
     fireEvent.click(run)
     getByText('choose protocol slideout')
@@ -71,7 +71,7 @@ describe('RobotOverflowMenu', () => {
     const { getByLabelText, getByRole } = render(props)
     const btn = getByLabelText('RobotOverflowMenu_button')
     fireEvent.click(btn)
-    getByRole('link', { name: 'robot settings' })
+    getByRole('link', { name: 'Robot settings' })
   })
 
   it('renders overflow menu items when the robot is not reachable', () => {

--- a/app/src/organisms/Devices/__tests__/RobotOverviewOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotOverviewOverflowMenu.test.tsx
@@ -106,9 +106,10 @@ describe('RobotOverviewOverflowMenu', () => {
     expect(screen.queryByText('Update robot software')).toBeNull()
     expect(screen.queryByText('restart robot')).toBeNull()
     expect(screen.queryByText('Home gantry')).toBeNull()
+    getByRole('button', { name: 'robot settings' })
   })
 
-  it('should rnot render menu items when the robot is not connectable', () => {
+  it('should not render menu items when the robot is not connectable', () => {
     when(mockUseIsRobotBusy).calledWith().mockReturnValue(true)
     when(mockUseCurrentRunStatus)
       .calledWith()
@@ -122,6 +123,7 @@ describe('RobotOverviewOverflowMenu', () => {
     expect(screen.queryByText('Update robot software')).toBeNull()
     expect(screen.queryByText('restart robot')).toBeNull()
     expect(screen.queryByText('Home gantry')).toBeNull()
+    getByRole('button', { name: 'robot settings' })
   })
 
   it('clicking home gantry should home the gantry', () => {

--- a/app/src/organisms/Devices/__tests__/RobotOverviewOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotOverviewOverflowMenu.test.tsx
@@ -80,9 +80,9 @@ describe('RobotOverviewOverflowMenu', () => {
     const updateRobotSoftwareBtn = getByRole('button', {
       name: 'Update robot software',
     })
-    const restartBtn = getByRole('button', { name: 'restart robot' })
+    const restartBtn = getByRole('button', { name: 'Restart robot' })
     const homeBtn = getByRole('button', { name: 'Home gantry' })
-    const settingsBtn = getByRole('button', { name: 'robot settings' })
+    const settingsBtn = getByRole('button', { name: 'Robot settings' })
 
     expect(updateRobotSoftwareBtn).toBeEnabled()
     expect(restartBtn).toBeEnabled()
@@ -104,9 +104,9 @@ describe('RobotOverviewOverflowMenu', () => {
     fireEvent.click(btn)
 
     expect(screen.queryByText('Update robot software')).toBeNull()
-    expect(screen.queryByText('restart robot')).toBeNull()
+    expect(screen.queryByText('Restart robot')).toBeNull()
     expect(screen.queryByText('Home gantry')).toBeNull()
-    getByRole('button', { name: 'robot settings' })
+    getByRole('button', { name: 'Robot settings' })
   })
 
   it('should not render menu items when the robot is not connectable', () => {
@@ -121,9 +121,9 @@ describe('RobotOverviewOverflowMenu', () => {
     fireEvent.click(btn)
 
     expect(screen.queryByText('Update robot software')).toBeNull()
-    expect(screen.queryByText('restart robot')).toBeNull()
+    expect(screen.queryByText('Restart robot')).toBeNull()
     expect(screen.queryByText('Home gantry')).toBeNull()
-    getByRole('button', { name: 'robot settings' })
+    getByRole('button', { name: 'Robot settings' })
   })
 
   it('clicking home gantry should home the gantry', () => {
@@ -144,7 +144,7 @@ describe('RobotOverviewOverflowMenu', () => {
     const btn = getByRole('button')
     fireEvent.click(btn)
 
-    const restartBtn = getByRole('button', { name: 'restart robot' })
+    const restartBtn = getByRole('button', { name: 'Restart robot' })
     fireEvent.click(restartBtn)
 
     expect(mockRestartRobot).toBeCalled()
@@ -158,8 +158,8 @@ describe('RobotOverviewOverflowMenu', () => {
     const { getByRole } = render(props)
     const btn = getByRole('button')
     fireEvent.click(btn)
-    getByRole('button', { name: 'restart robot' })
+    getByRole('button', { name: 'Restart robot' })
     getByRole('button', { name: 'Home gantry' })
-    getByRole('button', { name: 'robot settings' })
+    getByRole('button', { name: 'Robot settings' })
   })
 })

--- a/app/src/organisms/Devices/__tests__/RobotOverviewOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotOverviewOverflowMenu.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { when, resetAllWhenMocks } from 'jest-when'
-import { fireEvent } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
 import { RUN_STATUS_IDLE, RUN_STATUS_RUNNING } from '@opentrons/api-client'
 import { i18n } from '../../../i18n'
@@ -92,7 +92,7 @@ describe('RobotOverviewOverflowMenu', () => {
     getByText('mock update buildroot')
   })
 
-  it('should render disabled buttons in the menu when the robot is busy', () => {
+  it('should not render the menu items when robot is busy', () => {
     when(mockUseIsRobotBusy).calledWith().mockReturnValue(true)
     when(mockUseCurrentRunStatus)
       .calledWith()
@@ -103,18 +103,12 @@ describe('RobotOverviewOverflowMenu', () => {
     const btn = getByRole('button')
     fireEvent.click(btn)
 
-    const updateRobotSoftwareBtn = getByRole('button', {
-      name: 'Update robot software',
-    })
-    const restartBtn = getByRole('button', { name: 'restart robot' })
-    const homeBtn = getByRole('button', { name: 'Home gantry' })
-
-    expect(updateRobotSoftwareBtn).toBeDisabled()
-    expect(restartBtn).toBeDisabled()
-    expect(homeBtn).toBeDisabled()
+    expect(screen.queryByText('Update robot software')).toBeNull()
+    expect(screen.queryByText('restart robot')).toBeNull()
+    expect(screen.queryByText('Home gantry')).toBeNull()
   })
 
-  it('should render disabled buttons in the menu when the robot is not connectable', () => {
+  it('should rnot render menu items when the robot is not connectable', () => {
     when(mockUseIsRobotBusy).calledWith().mockReturnValue(true)
     when(mockUseCurrentRunStatus)
       .calledWith()
@@ -125,15 +119,9 @@ describe('RobotOverviewOverflowMenu', () => {
     const btn = getByRole('button')
     fireEvent.click(btn)
 
-    const updateRobotSoftwareBtn = getByRole('button', {
-      name: 'Update robot software',
-    })
-    const restartBtn = getByRole('button', { name: 'restart robot' })
-    const homeBtn = getByRole('button', { name: 'Home gantry' })
-
-    expect(updateRobotSoftwareBtn).toBeDisabled()
-    expect(restartBtn).toBeDisabled()
-    expect(homeBtn).toBeDisabled()
+    expect(screen.queryByText('Update robot software')).toBeNull()
+    expect(screen.queryByText('restart robot')).toBeNull()
+    expect(screen.queryByText('Home gantry')).toBeNull()
   })
 
   it('clicking home gantry should home the gantry', () => {


### PR DESCRIPTION
closes #10684

# Overview

This PR changes the design slightly of the robot overview overflow menu items when the robot is busy or unreachable. Instead of making the specific menu items disabled, this hides those menu items completely - this follows the same pattern used in the robot overflow menus (for both unavailable and available robots)

# Changelog

- edit `RobotOverviewOverflowMenu` and test

# Review requests

- Upload a protocol and go to Robot Overview page. Click on the overflow menu button for the robot. You should see only 1 menu item
- Cancel out of the run so the robot is no longer busy. You should see 3 menu items (4 menu items if you have an update available)

# Risk assessmentÏ

low