### PR TITLE
feat(app): liquid setup labware detail modal

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -127,5 +127,6 @@
   "location": "Location",
   "labware_name": "Labware Name",
   "volume": "Volume",
-  "slot_location": "Slot {{slotName}}"
+  "slot_location": "Slot {{slotName}}",
+  "slot_number": "Slot Number"
 }

--- a/app/src/atoms/Modal/index.tsx
+++ b/app/src/atoms/Modal/index.tsx
@@ -23,9 +23,11 @@ type ModalType = 'info' | 'warning' | 'error'
 export interface ModalProps extends BaseModalProps {
   type?: ModalType
   onClose?: React.MouseEventHandler
+  closeOnOutsideClick?: boolean
   title?: React.ReactNode
   children?: React.ReactNode
   icon?: IconProps
+  contentBackgroundColor?: string
 }
 
 const closeIconStyles = css`
@@ -45,7 +47,15 @@ const closeIconStyles = css`
 `
 
 export const Modal = (props: ModalProps): JSX.Element => {
-  const { type = 'info', onClose, title, children, maxHeight } = props
+  const {
+    type = 'info',
+    onClose,
+    closeOnOutsideClick,
+    title,
+    contentBackgroundColor,
+    children,
+    maxHeight,
+  } = props
   const header =
     title != null ? (
       <>
@@ -98,6 +108,8 @@ export const Modal = (props: ModalProps): JSX.Element => {
         box-shadow: ${BORDERS.smallDropShadow};
         max-height: ${maxHeight};
       `}
+      onOutsideClick={closeOnOutsideClick ? onClose : undefined}
+      contentBackgroundColor={contentBackgroundColor}
     >
       {children}
     </BaseModal>

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidDetailCard.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidDetailCard.tsx
@@ -1,0 +1,136 @@
+import {
+  BORDERS,
+  Box,
+  COLORS,
+  DIRECTION_COLUMN,
+  DIRECTION_ROW,
+  Flex,
+  Icon,
+  JUSTIFY_SPACE_BETWEEN,
+  SIZE_1,
+  SPACING,
+  TYPOGRAPHY,
+} from '@opentrons/components'
+import { MICRO_LITERS } from '@opentrons/shared-data'
+import * as React from 'react'
+import { css } from 'styled-components'
+import { Divider } from '../../../../atoms/structure'
+import { StyledText } from '../../../../atoms/text'
+
+interface LiquidDetailCardProps {
+  liquidId: string
+  displayName: string
+  description: string | null
+  displayColor: string
+  volumeByWell: { [well: string]: number }
+  setSelectedValue: React.Dispatch<React.SetStateAction<string | null>>
+  selectedValue: string | null
+}
+
+export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
+  const {
+    liquidId,
+    displayName,
+    description,
+    displayColor,
+    volumeByWell,
+    setSelectedValue,
+    selectedValue,
+  } = props
+  const LIQUID_CARD_STYLE = css`
+    ${BORDERS.cardOutlineBorder}
+
+    &:hover {
+      border: 1px solid ${COLORS.medGreyHover};
+      cursor: pointer;
+    }
+  `
+  const ACTIVE_STYLE = css`
+    background-color: ${COLORS.lightBlue};
+    border: 1px solid ${COLORS.blue};
+  `
+  return (
+    <Box
+      css={selectedValue === liquidId ? ACTIVE_STYLE : LIQUID_CARD_STYLE}
+      borderRadius={BORDERS.radiusSoftCorners}
+      marginBottom={SPACING.spacing3}
+      padding={SPACING.spacing4}
+      backgroundColor={COLORS.white}
+      onClick={() => setSelectedValue(liquidId)}
+      maxWidth={'10.3rem'}
+      minHeight={'max-content'}
+    >
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        justifyContent={JUSTIFY_SPACE_BETWEEN}
+      >
+        <Flex
+          css={BORDERS.cardOutlineBorder}
+          padding={'0.75rem'}
+          height={'max-content'}
+          width={'max-content'}
+          backgroundColor={COLORS.white}
+        >
+          <Icon name="circle" color={displayColor} size={SIZE_1} />
+        </Flex>
+        <StyledText
+          as="p"
+          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+          marginTop={SPACING.spacing3}
+        >
+          {displayName}
+        </StyledText>
+        <StyledText
+          as="p"
+          fontWeight={TYPOGRAPHY.fontWeightRegular}
+          color={COLORS.darkGreyEnabled}
+        >
+          {description != null ? description : null}
+        </StyledText>
+        <Flex
+          backgroundColor={COLORS.darkBlack + '1A'}
+          borderRadius={BORDERS.radiusSoftCorners}
+          height={'max-content'}
+          width={'max-content'}
+          paddingY={SPACING.spacing2}
+          paddingX={SPACING.spacing3}
+          marginTop={SPACING.spacing3}
+        >
+          <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightRegular}>
+            {Object.values(volumeByWell).reduce((prev, curr) => prev + curr, 0)}{' '}
+            {MICRO_LITERS}
+          </StyledText>
+        </Flex>
+      </Flex>
+      {selectedValue === liquidId ? (
+        <>
+          <Divider marginX={'-1rem'} marginY={SPACING.spacing4} />
+          {Object.entries(volumeByWell).map((well, index) => {
+            return (
+              <Flex
+                key={index}
+                flexDirection={DIRECTION_ROW}
+                justifyContent={JUSTIFY_SPACE_BETWEEN}
+              >
+                <StyledText
+                  as="p"
+                  fontWeight={TYPOGRAPHY.fontWeightRegular}
+                  marginTop={SPACING.spacing3}
+                >
+                  {well[0]}
+                </StyledText>
+                <StyledText
+                  as="p"
+                  fontWeight={TYPOGRAPHY.fontWeightRegular}
+                  marginTop={SPACING.spacing3}
+                >
+                  {well[1]} {MICRO_LITERS}
+                </StyledText>
+              </Flex>
+            )
+          })}
+        </>
+      ) : null}
+    </Box>
+  )
+}

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
 import {
   Box,
@@ -54,6 +55,7 @@ export const LiquidsLabwareDetailsModal = (
   props: LiquidsLabwareDetailsModalProps
 ): JSX.Element => {
   const { liquidId, closeModal } = props
+  const { t } = useTranslation('protocol_setup')
   const [selectedValue, setSelectedValue] = React.useState<
     typeof liquidId | null
   >(liquidId)
@@ -97,7 +99,7 @@ export const LiquidsLabwareDetailsModal = (
               color={COLORS.darkGreyEnabled}
               marginX={SPACING.spacingL}
             >
-              {'Slot Number'}
+              {t('slot_number')}
             </StyledText>
             <StyledText
               as="p"
@@ -115,7 +117,7 @@ export const LiquidsLabwareDetailsModal = (
               color={COLORS.darkGreyEnabled}
               marginX={SPACING.spacingL}
             >
-              {'Labware Name'}
+              {t('labware_name')}
             </StyledText>
             <StyledText
               as="p"

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
@@ -1,62 +1,62 @@
 import * as React from 'react'
-import { Modal } from '../../../../atoms/Modal'
+import { css } from 'styled-components'
 import {
-  BORDERS,
   Box,
   COLORS,
   DIRECTION_COLUMN,
   DIRECTION_ROW,
   Flex,
-  Icon,
-  JUSTIFY_SPACE_BETWEEN,
-  SIZE_1,
   SPACING,
   TYPOGRAPHY,
 } from '@opentrons/components'
-import { css } from 'styled-components'
+import { Modal } from '../../../../atoms/Modal'
 import { StyledText } from '../../../../atoms/text'
-import { MICRO_LITERS } from '@opentrons/shared-data/js/constants'
+import { LiquidDetailCard } from './LiquidDetailCard'
 
+// TODO(sh: 2022-06-14): remove mock data once liquids are implemented in analysis
 const MOCK_LIQUID_DATA = [
   {
     liquidId: '0',
     displayColor: '#B925FF',
     displayName: 'Cell Line 1',
     description: 'eluted stick samples',
-    volume: '100',
+    volumeByWell: { A1: 20 },
   },
   {
     liquidId: '1',
     displayColor: '#ffd600',
     displayName: 'Cell Line 2',
     description: 'eluted stick samples',
-    volume: '150',
+    volumeByWell: { A1: 100 },
   },
   {
     liquidId: '2',
     displayColor: '#9dffd8',
     displayName: 'Cell Line 3',
     description: 'eluted stick samples',
-    volume: '200',
+    volumeByWell: { A1: 200 },
   },
   {
     liquidId: '3',
     displayColor: '#ff9900',
     displayName: 'Cell Line 4',
     description: 'eluted stick samples',
-    volume: '300',
+    volumeByWell: { A1: 250 },
   },
 ]
 
 interface LiquidsLabwareDetailsModalProps {
+  liquidId: string
   closeModal: () => void
 }
 
 export const LiquidsLabwareDetailsModal = (
   props: LiquidsLabwareDetailsModalProps
 ): JSX.Element => {
-  const { closeModal } = props
-  const [selectedValue, setSelectedValue] = React.useState<string | null>('0')
+  const { liquidId, closeModal } = props
+  const [selectedValue, setSelectedValue] = React.useState<
+    typeof liquidId | null
+  >(liquidId)
 
   const HIDE_SCROLLBAR = css`
     ::-webkit-scrollbar {
@@ -78,10 +78,10 @@ export const LiquidsLabwareDetailsModal = (
             maxHeight={'27.125rem'}
             overflowY={'auto'}
           >
-            {MOCK_LIQUID_DATA.map((data, index) => {
+            {MOCK_LIQUID_DATA.map(data => {
               return (
                 <LiquidDetailCard
-                  key={index}
+                  key={data.liquidId}
                   {...data}
                   setSelectedValue={setSelectedValue}
                   selectedValue={selectedValue}
@@ -128,93 +128,5 @@ export const LiquidsLabwareDetailsModal = (
         </Flex>
       </Box>
     </Modal>
-  )
-}
-
-interface LiquidDetailCardProps {
-  liquidId: string
-  displayName: string
-  description: string | null
-  displayColor: string
-  volume: string
-  setSelectedValue: React.Dispatch<React.SetStateAction<string | null>>
-  selectedValue: string | null
-}
-
-export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
-  const {
-    liquidId,
-    displayName,
-    description,
-    displayColor,
-    volume,
-    setSelectedValue,
-    selectedValue,
-  } = props
-  const LIQUID_CARD_STYLE = css`
-    ${BORDERS.cardOutlineBorder}
-
-    &:hover {
-      border: 1px solid ${COLORS.medGreyHover};
-      cursor: pointer;
-    }
-  `
-  const ACTIVE_STYLE = css`
-    background-color: ${COLORS.lightBlue};
-    border: 1px solid ${COLORS.blue};
-  `
-  return (
-    <Box
-      css={selectedValue === liquidId ? ACTIVE_STYLE : LIQUID_CARD_STYLE}
-      borderRadius={BORDERS.radiusSoftCorners}
-      marginBottom={SPACING.spacing3}
-      padding={SPACING.spacing4}
-      backgroundColor={COLORS.white}
-      onClick={() => setSelectedValue(liquidId)}
-      maxWidth={'10.3rem'}
-      minHeight={'max-content'}
-    >
-      <Flex
-        flexDirection={DIRECTION_COLUMN}
-        justifyContent={JUSTIFY_SPACE_BETWEEN}
-      >
-        <Flex
-          css={BORDERS.cardOutlineBorder}
-          padding={'0.75rem'}
-          height={'max-content'}
-          width={'max-content'}
-          backgroundColor={COLORS.white}
-        >
-          <Icon name="circle" color={displayColor} size={SIZE_1} />
-        </Flex>
-        <StyledText
-          as="p"
-          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-          marginTop={SPACING.spacing3}
-        >
-          {displayName}
-        </StyledText>
-        <StyledText
-          as="p"
-          fontWeight={TYPOGRAPHY.fontWeightRegular}
-          color={COLORS.darkGreyEnabled}
-        >
-          {description != null ? description : null}
-        </StyledText>
-        <Flex
-          backgroundColor={COLORS.darkBlack + '1A'}
-          borderRadius={BORDERS.radiusSoftCorners}
-          height={'max-content'}
-          width={'max-content'}
-          paddingY={SPACING.spacing2}
-          paddingX={SPACING.spacing3}
-          marginTop={SPACING.spacing3}
-        >
-          <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightRegular}>
-            {volume} {MICRO_LITERS}
-          </StyledText>
-        </Flex>
-      </Flex>
-    </Box>
   )
 }

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
@@ -68,7 +68,8 @@ export const LiquidsLabwareDetailsModal = (
     <Modal
       onClose={closeModal}
       title={'Labware Name'}
-      backgroundColor={COLORS.background}
+      contentBackgroundColor={COLORS.background}
+      closeOnOutsideClick
     >
       <Box>
         <Flex flexDirection={DIRECTION_ROW}>

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
@@ -1,0 +1,220 @@
+import * as React from 'react'
+import { Modal } from '../../../../atoms/Modal'
+import {
+  BORDERS,
+  Box,
+  COLORS,
+  DIRECTION_COLUMN,
+  DIRECTION_ROW,
+  Flex,
+  Icon,
+  JUSTIFY_SPACE_BETWEEN,
+  SIZE_1,
+  SPACING,
+  TYPOGRAPHY,
+} from '@opentrons/components'
+import { css } from 'styled-components'
+import { StyledText } from '../../../../atoms/text'
+import { MICRO_LITERS } from '@opentrons/shared-data/js/constants'
+
+const MOCK_LIQUID_DATA = [
+  {
+    liquidId: '0',
+    displayColor: '#B925FF',
+    displayName: 'Cell Line 1',
+    description: 'eluted stick samples',
+    volume: '100',
+  },
+  {
+    liquidId: '1',
+    displayColor: '#ffd600',
+    displayName: 'Cell Line 2',
+    description: 'eluted stick samples',
+    volume: '150',
+  },
+  {
+    liquidId: '2',
+    displayColor: '#9dffd8',
+    displayName: 'Cell Line 3',
+    description: 'eluted stick samples',
+    volume: '200',
+  },
+  {
+    liquidId: '3',
+    displayColor: '#ff9900',
+    displayName: 'Cell Line 4',
+    description: 'eluted stick samples',
+    volume: '300',
+  },
+]
+
+interface LiquidsLabwareDetailsModalProps {
+  closeModal: () => void
+}
+
+export const LiquidsLabwareDetailsModal = (
+  props: LiquidsLabwareDetailsModalProps
+): JSX.Element => {
+  const { closeModal } = props
+  const [selectedValue, setSelectedValue] = React.useState<string | null>('0')
+
+  const HIDE_SCROLLBAR = css`
+    ::-webkit-scrollbar {
+      display: none;
+    }
+  `
+
+  return (
+    <Modal
+      onClose={closeModal}
+      title={'Labware Name'}
+      backgroundColor={COLORS.background}
+    >
+      <Box>
+        <Flex flexDirection={DIRECTION_ROW}>
+          <Flex
+            flexDirection={DIRECTION_COLUMN}
+            css={HIDE_SCROLLBAR}
+            maxHeight={'27.125rem'}
+            overflowY={'auto'}
+          >
+            {MOCK_LIQUID_DATA.map((data, index) => {
+              return (
+                <LiquidDetailCard
+                  key={index}
+                  {...data}
+                  setSelectedValue={setSelectedValue}
+                  selectedValue={selectedValue}
+                />
+              )
+            })}
+          </Flex>
+          <Flex flexDirection={DIRECTION_COLUMN}>
+            <StyledText
+              as="h6"
+              fontWeight={TYPOGRAPHY.fontWeightRegular}
+              color={COLORS.darkGreyEnabled}
+              marginX={SPACING.spacingL}
+            >
+              {'Slot Number'}
+            </StyledText>
+            <StyledText
+              as="p"
+              fontWeight={TYPOGRAPHY.fontWeightRegular}
+              color={COLORS.darkBlack}
+              marginX={SPACING.spacingL}
+            >
+              {'4'}
+            </StyledText>
+          </Flex>
+          <Flex flexDirection={DIRECTION_COLUMN}>
+            <StyledText
+              as="h6"
+              fontWeight={TYPOGRAPHY.fontWeightRegular}
+              color={COLORS.darkGreyEnabled}
+              marginX={SPACING.spacingL}
+            >
+              {'Labware Name'}
+            </StyledText>
+            <StyledText
+              as="p"
+              fontWeight={TYPOGRAPHY.fontWeightRegular}
+              color={COLORS.darkBlack}
+              marginX={SPACING.spacingL}
+            >
+              {'Example Labware'}
+            </StyledText>
+          </Flex>
+        </Flex>
+      </Box>
+    </Modal>
+  )
+}
+
+interface LiquidDetailCardProps {
+  liquidId: string
+  displayName: string
+  description: string | null
+  displayColor: string
+  volume: string
+  setSelectedValue: React.Dispatch<React.SetStateAction<string | null>>
+  selectedValue: string | null
+}
+
+export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
+  const {
+    liquidId,
+    displayName,
+    description,
+    displayColor,
+    volume,
+    setSelectedValue,
+    selectedValue,
+  } = props
+  const LIQUID_CARD_STYLE = css`
+    ${BORDERS.cardOutlineBorder}
+
+    &:hover {
+      border: 1px solid ${COLORS.medGreyHover};
+      cursor: pointer;
+    }
+  `
+  const ACTIVE_STYLE = css`
+    background-color: ${COLORS.lightBlue};
+    border: 1px solid ${COLORS.blue};
+  `
+  return (
+    <Box
+      css={selectedValue === liquidId ? ACTIVE_STYLE : LIQUID_CARD_STYLE}
+      borderRadius={BORDERS.radiusSoftCorners}
+      marginBottom={SPACING.spacing3}
+      padding={SPACING.spacing4}
+      backgroundColor={COLORS.white}
+      onClick={() => setSelectedValue(liquidId)}
+      maxWidth={'10.3rem'}
+      minHeight={'max-content'}
+    >
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        justifyContent={JUSTIFY_SPACE_BETWEEN}
+      >
+        <Flex
+          css={BORDERS.cardOutlineBorder}
+          padding={'0.75rem'}
+          height={'max-content'}
+          width={'max-content'}
+          backgroundColor={COLORS.white}
+        >
+          <Icon name="circle" color={displayColor} size={SIZE_1} />
+        </Flex>
+        <StyledText
+          as="p"
+          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+          marginTop={SPACING.spacing3}
+        >
+          {displayName}
+        </StyledText>
+        <StyledText
+          as="p"
+          fontWeight={TYPOGRAPHY.fontWeightRegular}
+          color={COLORS.darkGreyEnabled}
+        >
+          {description != null ? description : null}
+        </StyledText>
+        <Flex
+          backgroundColor={COLORS.darkBlack + '1A'}
+          borderRadius={BORDERS.radiusSoftCorners}
+          height={'max-content'}
+          width={'max-content'}
+          paddingY={SPACING.spacing2}
+          paddingX={SPACING.spacing3}
+          marginTop={SPACING.spacing3}
+        >
+          <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightRegular}>
+            {volume} {MICRO_LITERS}
+          </StyledText>
+        </Flex>
+      </Flex>
+    </Box>
+  )
+}

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
@@ -16,9 +16,11 @@ import {
   SIZE_AUTO,
   JUSTIFY_SPACE_BETWEEN,
   Box,
+  Overlay,
 } from '@opentrons/components'
 import { MICRO_LITERS } from '@opentrons/shared-data'
 import { StyledText } from '../../../../atoms/text'
+import { LiquidsLabwareDetailsModal } from './LiquidsLabwareDetailsModal'
 
 import type { Liquid } from './getMockLiquidData'
 
@@ -69,6 +71,10 @@ interface LiquidsListItemProps {
 export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
   const { description, displayColor, displayName, locations } = props
   const [openItem, setOpenItem] = React.useState(false)
+  const [
+    showLiquidLabwareDetails,
+    setShowLiquidLabwareDetails,
+  ] = React.useState(false)
   const { t } = useTranslation('protocol_setup')
   const LIQUID_CARD_STYLE = css`
     ${BORDERS.cardOutlineBorder}
@@ -78,6 +84,18 @@ export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
       border: 1px solid ${COLORS.medGreyHover};
     }
   `
+  const LIQUID_CARD_ITEM_STYLE = css`
+    ${BORDERS.cardOutlineBorder}
+
+    &:hover {
+      cursor: pointer;
+      border: 1px solid ${COLORS.medGreyHover};
+    }
+  `
+  const handleClickOutside: React.MouseEventHandler<HTMLDivElement> = e => {
+    e.preventDefault()
+    setShowLiquidLabwareDetails(!showLiquidLabwareDetails)
+  }
   return (
     <Box
       css={LIQUID_CARD_STYLE}
@@ -130,6 +148,17 @@ export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
           </StyledText>
         </Flex>
       </Flex>
+      {showLiquidLabwareDetails && (
+        <>
+          <LiquidsLabwareDetailsModal
+            closeModal={() => setShowLiquidLabwareDetails(false)}
+          />
+          <Overlay
+            onClick={handleClickOutside}
+            backgroundColor={COLORS.transparent}
+          />
+        </>
+      )}
       {openItem && (
         <Flex flexDirection={DIRECTION_COLUMN}>
           <Flex
@@ -162,12 +191,14 @@ export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
           {locations.map((location, index) => {
             return (
               <Box
+                css={LIQUID_CARD_ITEM_STYLE}
                 key={index}
                 borderRadius={'4px'}
                 marginY={SPACING.spacing3}
                 padding={SPACING.spacing4}
                 backgroundColor={COLORS.white}
                 data-testid={`LiquidsListItem_slotRow_${index}`}
+                onClick={() => setShowLiquidLabwareDetails(true)}
               >
                 <Flex
                   flexDirection={DIRECTION_ROW}

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
@@ -93,10 +93,6 @@ export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
       border: 1px solid ${COLORS.medGreyHover};
     }
   `
-  // const handleClickOutside: React.MouseEventHandler<HTMLDivElement> = e => {
-  //   e.preventDefault()
-  //   setShowLiquidLabwareDetails(!showLiquidLabwareDetails)
-  // }
   return (
     <Box
       css={LIQUID_CARD_STYLE}

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
@@ -16,7 +16,6 @@ import {
   SIZE_AUTO,
   JUSTIFY_SPACE_BETWEEN,
   Box,
-  Overlay,
 } from '@opentrons/components'
 import { MICRO_LITERS } from '@opentrons/shared-data'
 import { StyledText } from '../../../../atoms/text'
@@ -94,10 +93,10 @@ export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
       border: 1px solid ${COLORS.medGreyHover};
     }
   `
-  const handleClickOutside: React.MouseEventHandler<HTMLDivElement> = e => {
-    e.preventDefault()
-    setShowLiquidLabwareDetails(!showLiquidLabwareDetails)
-  }
+  // const handleClickOutside: React.MouseEventHandler<HTMLDivElement> = e => {
+  //   e.preventDefault()
+  //   setShowLiquidLabwareDetails(!showLiquidLabwareDetails)
+  // }
   return (
     <Box
       css={LIQUID_CARD_STYLE}
@@ -151,16 +150,10 @@ export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
         </Flex>
       </Flex>
       {showLiquidLabwareDetails && (
-        <>
-          <LiquidsLabwareDetailsModal
-            liquidId={liquidId}
-            closeModal={() => setShowLiquidLabwareDetails(false)}
-          />
-          <Overlay
-            onClick={handleClickOutside}
-            backgroundColor={COLORS.transparent}
-          />
-        </>
+        <LiquidsLabwareDetailsModal
+          liquidId={liquidId}
+          closeModal={() => setShowLiquidLabwareDetails(false)}
+        />
       )}
       {openItem && (
         <Flex flexDirection={DIRECTION_COLUMN}>

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
@@ -47,6 +47,7 @@ export function SetupLiquidsList(props: SetupLiquidsListProps): JSX.Element {
       {liquids?.map(liquid => (
         <LiquidsListItem
           key={liquid.liquidId}
+          liquidId={liquid.liquidId}
           description={liquid.description}
           displayColor={liquid.displayColor}
           displayName={liquid.displayName}
@@ -58,6 +59,7 @@ export function SetupLiquidsList(props: SetupLiquidsListProps): JSX.Element {
 }
 
 interface LiquidsListItemProps {
+  liquidId: string
   description: string | null
   displayColor: string
   displayName: string
@@ -69,7 +71,7 @@ interface LiquidsListItemProps {
 }
 
 export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
-  const { description, displayColor, displayName, locations } = props
+  const { liquidId, description, displayColor, displayName, locations } = props
   const [openItem, setOpenItem] = React.useState(false)
   const [
     showLiquidLabwareDetails,
@@ -151,6 +153,7 @@ export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
       {showLiquidLabwareDetails && (
         <>
           <LiquidsLabwareDetailsModal
+            liquidId={liquidId}
             closeModal={() => setShowLiquidLabwareDetails(false)}
           />
           <Overlay

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/LiquidDetailCard.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/LiquidDetailCard.test.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react'
+import { nestedTextMatcher, renderWithProviders } from '@opentrons/components'
+import { LiquidDetailCard } from '../LiquidDetailCard'
+
+const render = (props: React.ComponentProps<typeof LiquidDetailCard>) => {
+  return renderWithProviders(<LiquidDetailCard {...props} />)
+}
+
+describe('LiquidDetailCard', () => {
+  let props: React.ComponentProps<typeof LiquidDetailCard>
+
+  beforeEach(() => {
+    props = {
+      liquidId: '0',
+      displayName: 'Mock Liquid',
+      description: 'Mock Description',
+      displayColor: '#FFF',
+      volumeByWell: { A1: 50 },
+      setSelectedValue: jest.fn(),
+      selectedValue: '0',
+    }
+  })
+
+  it('renders liquid name, description, and volume', () => {
+    const [{ getByText, getAllByText }] = render(props)
+    getByText('Mock Liquid')
+    getByText('Mock Description')
+    getAllByText(nestedTextMatcher('50 µL'))
+  })
+
+  it('renders well volume information', () => {
+    const [{ getByText, getAllByText }] = render(props)
+    getByText('A1')
+    getAllByText(nestedTextMatcher('50 µL'))
+  })
+})

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/LiquidsLabwareDetailsModal.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/LiquidsLabwareDetailsModal.test.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react'
+import { i18n } from '../../../../../i18n'
+import { nestedTextMatcher, renderWithProviders } from '@opentrons/components'
+import { LiquidsLabwareDetailsModal } from '../LiquidsLabwareDetailsModal'
+import { LiquidDetailCard } from '../LiquidDetailCard'
+
+jest.mock('../LiquidDetailCard')
+
+const mockLiquidDetailCard = LiquidDetailCard as jest.MockedFunction<
+  typeof LiquidDetailCard
+>
+
+const render = (
+  props: React.ComponentProps<typeof LiquidsLabwareDetailsModal>
+) => {
+  return renderWithProviders(<LiquidsLabwareDetailsModal {...props} />, {
+    i18nInstance: i18n,
+  })
+}
+
+describe('LiquidsLabwareDetailsModal', () => {
+  beforeEach(() => {
+    mockLiquidDetailCard.mockReturnValue(<>mock LiquidDetailCard</>)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should render LiquidDetailCard', () => {
+    const [{ getByText }] = render({ liquidId: '0', closeModal: jest.fn() })
+    getByText(nestedTextMatcher('mock LiquidDetailCard'))
+  })
+})

--- a/components/src/modals/BaseModal.tsx
+++ b/components/src/modals/BaseModal.tsx
@@ -3,8 +3,8 @@ import * as React from 'react'
 import * as Styles from '../styles'
 import { Box, Flex } from '../primitives'
 import { COLORS, SPACING } from '../ui-style-constants'
-
 import type { StyleProps } from '../primitives'
+import { POSITION_FIXED } from '../styles'
 
 const BASE_STYLE = {
   position: Styles.POSITION_ABSOLUTE,
@@ -47,8 +47,12 @@ const CONTENT_STYLE = {
 } as const
 
 export interface BaseModalProps extends StyleProps {
+  /** Content background color, defaults to white **/
+  contentBackgroundColor?: string
   /** Overlay color, defaults to `OVERLAY_GRAY_90` */
   overlayColor?: string
+  /** Optional close on outside click **/
+  onOutsideClick?: React.MouseEventHandler
   /** Optional sticky header */
   header?: React.ReactNode
   /** Option to turn off headerStyles */
@@ -70,7 +74,9 @@ export interface BaseModalProps extends StyleProps {
  */
 export function BaseModal(props: BaseModalProps): JSX.Element {
   const {
+    contentBackgroundColor = COLORS.white,
     overlayColor = COLORS.backgroundOverlay,
+    onOutsideClick,
     zIndex = 10,
     header,
     footer,
@@ -83,18 +89,33 @@ export function BaseModal(props: BaseModalProps): JSX.Element {
 
   return (
     <Flex
-      {...BASE_STYLE}
+      position={POSITION_FIXED}
+      left="0"
+      right="0"
+      top="0"
+      bottom="0"
+      zIndex="1"
       backgroundColor={overlayColor}
-      zIndex={zIndex}
       onClick={e => {
         e.stopPropagation()
+        if (onOutsideClick) onOutsideClick(e)
       }}
     >
-      <Box {...MODAL_STYLE} {...styleProps}>
-        {header != null ? <Box {...headerStyle}>{header}</Box> : null}
-        <Box {...CONTENT_STYLE}>{children}</Box>
-        {footer != null ? <Box {...FOOTER_STYLE}>{footer}</Box> : null}
-      </Box>
+      <Flex {...BASE_STYLE} zIndex={zIndex}>
+        <Box
+          {...MODAL_STYLE}
+          {...styleProps}
+          onClick={e => {
+            e.stopPropagation()
+          }}
+        >
+          {header != null ? <Box {...headerStyle}>{header}</Box> : null}
+          <Box {...CONTENT_STYLE} backgroundColor={contentBackgroundColor}>
+            {children}
+          </Box>
+          {footer != null ? <Box {...FOOTER_STYLE}>{footer}</Box> : null}
+        </Box>
+      </Flex>
     </Flex>
   )
 }

--- a/components/src/modals/__tests__/BaseModal.test.tsx
+++ b/components/src/modals/__tests__/BaseModal.test.tsx
@@ -10,7 +10,7 @@ import { BaseModal } from '../BaseModal'
 describe('BaseModal', () => {
   it('should take up the whole parent', () => {
     const wrapper = shallow(<BaseModal />)
-    const box = wrapper.find(Flex).first()
+    const box = wrapper.find(Flex).at(1)
 
     expect({ ...box.props() }).toMatchObject({
       position: 'absolute',
@@ -40,17 +40,17 @@ describe('BaseModal', () => {
 
   it('should have a zIndex that can be overridden', () => {
     const wrapper = shallow(<BaseModal />)
-    const box = wrapper.find(Flex).first()
+    const box = wrapper.find(Flex).at(1)
 
     expect(box.prop('zIndex')).toBe(10)
 
     wrapper.setProps({ zIndex: 5 })
-    expect(wrapper.find(Flex).first().prop('zIndex')).toBe(5)
+    expect(wrapper.find(Flex).at(1).prop('zIndex')).toBe(5)
   })
 
   it('should have a white content box', () => {
     const wrapper = shallow(<BaseModal />)
-    const modal = wrapper.find(Flex).first()
+    const modal = wrapper.find(Flex).at(1)
     const content = modal.children(Box).first()
 
     expect({ ...content.props() }).toMatchObject({
@@ -64,7 +64,7 @@ describe('BaseModal', () => {
 
   it('should apply style props to content box', () => {
     const wrapper = shallow(<BaseModal maxWidth="32rem" />)
-    const modal = wrapper.find(Flex).first()
+    const modal = wrapper.find(Flex).at(1)
     const content = modal.children(Box).first()
 
     expect(content.prop('maxWidth')).toBe('32rem')


### PR DESCRIPTION
# Overview

This PR creates the initial liquid setup labware detail modal. closes #10669

https://user-images.githubusercontent.com/14794021/173696222-26da44eb-999b-4f1c-a0a4-151724a828a2.mov

# Changelog

- Add `LiquidsLabwareDetailsModal`

# Review requests

- When clicking a sub-item in the liquids list (list view), a modal should render.
- Liquids card with color, title, description, and volume render correct. Slot name and labware name should render as well.
- Liquid cards have a hover state that darkens the border
-  Liquid card has selected state that highlights the card and expands to show well list
-  Clicking another liquid card deselects the current highlighted liquid and highlights the newly selected card
 - You can close the modal by clicking the X
 - You can close the modal by clicking outside of the modal

# Risk assessment

low