### PR TITLE
fix(app): fix long labware name display issue on slideout

### DIFF
--- a/app/src/organisms/Labware/LabwareDetails/StyledComponents/ExpandingTitle.tsx
+++ b/app/src/organisms/Labware/LabwareDetails/StyledComponents/ExpandingTitle.tsx
@@ -4,11 +4,11 @@ import {
   Icon,
   Link,
   Box,
-  SPACING,
   DIRECTION_ROW,
   JUSTIFY_SPACE_BETWEEN,
   ALIGN_CENTER,
   TYPOGRAPHY,
+  SIZE_1,
 } from '@opentrons/components'
 import { StyledText } from '../../../../atoms/text'
 import { Divider } from '../../../../atoms/structure'
@@ -37,7 +37,7 @@ export function ExpandingTitle(props: ExpandingTitleProps): JSX.Element {
           <Link role="button" onClick={toggleDiagramVisible}>
             <Icon
               name={diagramVisible ? 'chevron-up' : 'chevron-down'}
-              width={SPACING.spacingSM}
+              size={SIZE_1}
             />
           </Link>
         )}

--- a/app/src/organisms/Labware/LabwareDetails/StyledComponents/LabeledValue.tsx
+++ b/app/src/organisms/Labware/LabwareDetails/StyledComponents/LabeledValue.tsx
@@ -4,6 +4,8 @@ import {
   DIRECTION_ROW,
   Flex,
   JUSTIFY_SPACE_BETWEEN,
+  COLORS,
+  SPACING,
 } from '@opentrons/components'
 import { StyledText } from '../../../../atoms/text'
 
@@ -18,8 +20,11 @@ export function LabeledValue(props: LabeledValueProps): JSX.Element {
       flexDirection={DIRECTION_ROW}
       justifyContent={JUSTIFY_SPACE_BETWEEN}
       alignItems={ALIGN_CENTER}
+      paddingY={SPACING.spacing3}
     >
-      <StyledText as="h6">{props.label}</StyledText>
+      <StyledText as="h6" color={COLORS.darkGreyEnabled}>
+        {props.label}
+      </StyledText>
       <StyledText as="p">{props.value}</StyledText>
     </Flex>
   )

--- a/app/src/organisms/Labware/LabwareDetails/index.tsx
+++ b/app/src/organisms/Labware/LabwareDetails/index.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { format } from 'date-fns'
+import { css } from 'styled-components'
+
 import {
   Box,
   Link,
@@ -31,6 +33,16 @@ import { Gallery } from './Gallery'
 import { CustomLabwareOverflowMenu } from '../CustomLabwareOverflowMenu'
 import type { LabwareDefAndDate } from '../hooks'
 
+const CLOSE_ICON_STYLE = css`
+  border-radius: 50%;
+
+  &:hover {
+    background: #16212d26;
+  }
+  &:active {
+    background: #16212d40;
+  }
+`
 export interface LabwareDetailsProps {
   onClose: () => void
   labware: LabwareDefAndDate
@@ -66,7 +78,7 @@ export function LabwareDetails(props: LabwareDetailsProps): JSX.Element {
           {props.labware.definition.metadata.displayName}
         </StyledText>
         <Link onClick={props.onClose} role="button">
-          <Icon name="close" height={SPACING.spacing5} />
+          <Icon name="close" height={SPACING.spacing5} css={CLOSE_ICON_STYLE} />
         </Link>
       </Flex>
       {!isCustomDefinition && (

--- a/app/src/organisms/Labware/LabwareDetails/index.tsx
+++ b/app/src/organisms/Labware/LabwareDetails/index.tsx
@@ -115,7 +115,7 @@ export function LabwareDetails(props: LabwareDetailsProps): JSX.Element {
           onClick={() => navigator.clipboard.writeText(apiName)}
           role="button"
         >
-          <Flex alignItems={ALIGN_CENTER}>
+          <Flex alignItems={ALIGN_CENTER} css={{ 'overflow-wrap': 'anywhere' }}>
             {apiName} <Icon height={SIZE_1} name="copy-text" />
           </Flex>
         </Link>


### PR DESCRIPTION


<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR will fix a long labware apiName display issue on slideout.
fix #10641
Also, fix #10618 partially,  labware definition slideout feedback 


![Screen Shot 2022-06-13 at 8 59 39 PM](https://user-images.githubusercontent.com/474225/173471946-e4c741df-4dfc-4212-9158-c49e9fa6490b.png)


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- Add css property to Flex: `css={{ 'overflow-wrap': 'anywhere' }}`
- Modify style to align with Figma's design
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- When selecting `appliedbiosystemsmicroamp_384_wellplate_40ul`, the api name is wrapped

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
