### PR TITLE
fix(app): fix wrong event name for Mixpanel

### DIFF
--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/FactoryResetSlideout.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/FactoryResetSlideout.tsx
@@ -25,6 +25,7 @@ import {
   fetchResetConfigOptions,
 } from '../../../../../redux/robot-admin'
 import { useTrackEvent } from '../../../../../redux/analytics'
+import { EVENT_CALIBRATION_DOWNLOADED } from '../../../../../redux/calibration'
 import {
   useDeckCalibrationData,
   usePipetteOffsetCalibrations,
@@ -77,7 +78,7 @@ export function FactoryResetSlideout({
   const downloadCalibrationLogs: React.MouseEventHandler = e => {
     e.preventDefault()
     doTrackEvent({
-      name: 'EVENT_CALIBRATION_DOWNLOADED',
+      name: EVENT_CALIBRATION_DOWNLOADED,
       properties: {},
     })
     saveAs(


### PR DESCRIPTION


<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
The issue is that FactoryReset component uses `EVENT_CALIBRATION_DOWNLOADED`(string) instead of  importing `EVENT_CALIBRATION_DOWNLOADED`

This PR fixes wrong event name for Mixpanel
Fix #10744

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- import `EVENT_CALIBRATION_DOWNLOADED`
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- import `EVENT_CALIBRATION_DOWNLOADED` and use it as an event name(the actual value is `calibrationDataDownloaded `)
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
