### PR TITLE
feat(engine): open and close thermocycler lid

### DIFF
--- a/api/src/opentrons/protocol_api_experimental/module_contexts/thermocycler_module_context.py
+++ b/api/src/opentrons/protocol_api_experimental/module_contexts/thermocycler_module_context.py
@@ -25,6 +25,14 @@ class ThermocyclerModuleContext:  # noqa: D101
         """Turn off the well block heater."""
         self._engine_client.thermocycler_deactivate_block(self._module_id)
 
+    def open_lid(self) -> None:
+        """Opens a thermocycler's lid."""
+        self._engine_client.thermocycler_open_lid(self._module_id)
+
+    def close_lid(self) -> None:
+        """Closes a thermocycler's lid."""
+        self._engine_client.thermocycler_close_lid(self._module_id)
+
     # TODO(mc, 2022-04-29): if you go down to the driver level, there is a
     # separate "deactivate all" g-code. Is this functionally different than
     # deactivating the lid and block in sequence like this?

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -237,3 +237,23 @@ class SyncClient:
         )
         result = self._transport.execute_command(request=request)
         return cast(commands.thermocycler.DeactivateLidResult, result)
+
+    def thermocycler_open_lid(
+        self, module_id: str
+    ) -> commands.thermocycler.OpenLidResult:
+        """Execute a `thermocycler/openLid` command and return the result."""
+        request = commands.thermocycler.OpenLidCreate(
+            params=commands.thermocycler.OpenLidParams(moduleId=module_id)
+        )
+        result = self._transport.execute_command(request=request)
+        return cast(commands.thermocycler.OpenLidResult, result)
+
+    def thermocycler_close_lid(
+        self, module_id: str
+    ) -> commands.thermocycler.CloseLidResult:
+        """Execute a `thermocycler/closeLid` command and return the result."""
+        request = commands.thermocycler.CloseLidCreate(
+            params=commands.thermocycler.CloseLidParams(moduleId=module_id)
+        )
+        result = self._transport.execute_command(request=request)
+        return cast(commands.thermocycler.CloseLidResult, result)

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -169,6 +169,7 @@ Command = Union[
     thermocycler.WaitForLidTemperature,
     thermocycler.DeactivateBlock,
     thermocycler.DeactivateLid,
+    thermocycler.OpenLid,
 ]
 
 CommandParams = Union[
@@ -206,6 +207,7 @@ CommandParams = Union[
     thermocycler.WaitForLidTemperatureParams,
     thermocycler.DeactivateBlockParams,
     thermocycler.DeactivateLidParams,
+    thermocycler.OpenLidParams,
 ]
 
 CommandType = Union[
@@ -243,6 +245,7 @@ CommandType = Union[
     thermocycler.WaitForLidTemperatureCommandType,
     thermocycler.DeactivateBlockCommandType,
     thermocycler.DeactivateLidCommandType,
+    thermocycler.OpenLidCommandType,
 ]
 
 CommandCreate = Union[
@@ -279,6 +282,7 @@ CommandCreate = Union[
     thermocycler.WaitForLidTemperatureCreate,
     thermocycler.DeactivateBlockCreate,
     thermocycler.DeactivateLidCreate,
+    thermocycler.OpenLidCreate,
 ]
 
 CommandResult = Union[
@@ -316,4 +320,5 @@ CommandResult = Union[
     thermocycler.WaitForLidTemperatureResult,
     thermocycler.DeactivateBlockResult,
     thermocycler.DeactivateLidResult,
+    thermocycler.OpenLidResult,
 ]

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -170,6 +170,7 @@ Command = Union[
     thermocycler.DeactivateBlock,
     thermocycler.DeactivateLid,
     thermocycler.OpenLid,
+    thermocycler.CloseLid,
 ]
 
 CommandParams = Union[
@@ -208,6 +209,7 @@ CommandParams = Union[
     thermocycler.DeactivateBlockParams,
     thermocycler.DeactivateLidParams,
     thermocycler.OpenLidParams,
+    thermocycler.CloseLidParams,
 ]
 
 CommandType = Union[
@@ -246,6 +248,7 @@ CommandType = Union[
     thermocycler.DeactivateBlockCommandType,
     thermocycler.DeactivateLidCommandType,
     thermocycler.OpenLidCommandType,
+    thermocycler.CloseLidCommandType,
 ]
 
 CommandCreate = Union[
@@ -283,6 +286,7 @@ CommandCreate = Union[
     thermocycler.DeactivateBlockCreate,
     thermocycler.DeactivateLidCreate,
     thermocycler.OpenLidCreate,
+    thermocycler.CloseLidCreate,
 ]
 
 CommandResult = Union[
@@ -321,4 +325,5 @@ CommandResult = Union[
     thermocycler.DeactivateBlockResult,
     thermocycler.DeactivateLidResult,
     thermocycler.OpenLidResult,
+    thermocycler.CloseLidResult,
 ]

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/__init__.py
@@ -48,6 +48,14 @@ from .deactivate_lid import (
     DeactivateLidCreate,
 )
 
+from .open_lid import (
+    OpenLidCommandType,
+    OpenLidParams,
+    OpenLidResult,
+    OpenLid,
+    OpenLidCreate,
+)
+
 
 __all__ = [
     # Set target block temperature command models
@@ -86,4 +94,10 @@ __all__ = [
     "DeactivateLidResult",
     "DeactivateLid",
     "DeactivateLidCreate",
+    # Open lid command models
+    "OpenLidCommandType",
+    "OpenLidParams",
+    "OpenLidResult",
+    "OpenLid",
+    "OpenLidCreate",
 ]

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/__init__.py
@@ -56,6 +56,14 @@ from .open_lid import (
     OpenLidCreate,
 )
 
+from .close_lid import (
+    CloseLidCommandType,
+    CloseLidParams,
+    CloseLidResult,
+    CloseLid,
+    CloseLidCreate,
+)
+
 
 __all__ = [
     # Set target block temperature command models
@@ -100,4 +108,10 @@ __all__ = [
     "OpenLidResult",
     "OpenLid",
     "OpenLidCreate",
+    # Close lid command models
+    "CloseLidCommandType",
+    "CloseLidParams",
+    "CloseLidResult",
+    "CloseLid",
+    "CloseLidCreate",
 ]

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/close_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/close_lid.py
@@ -25,8 +25,6 @@ class CloseLidParams(BaseModel):
 class CloseLidResult(BaseModel):
     """Result data from closing a Thermocycler's lid."""
 
-    # TODO return lid status?
-
 
 class CloseLidImpl(AbstractCommandImpl[CloseLidParams, CloseLidResult]):
     """Execution implementation of a Thermocycler's close lid command."""

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/close_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/close_lid.py
@@ -1,0 +1,73 @@
+"""Command models to close a Thermocycler's lid."""
+from __future__ import annotations
+from typing import Optional, TYPE_CHECKING
+from typing_extensions import Literal, Type
+
+from pydantic import BaseModel, Field
+
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+if TYPE_CHECKING:
+    from opentrons.protocol_engine.state import StateView
+    from opentrons.protocol_engine.execution import EquipmentHandler
+
+
+CloseLidCommandType = Literal["thermocycler/closeLid"]
+
+
+class CloseLidParams(BaseModel):
+    """Input parameters to close a Thermocycler's lid."""
+
+    moduleId: str = Field(..., description="Unique ID of the Thermocycler.")
+
+
+class CloseLidResult(BaseModel):
+    """Result data from closing a Thermocycler's lid."""
+
+    # TODO return lid status?
+
+
+class CloseLidImpl(AbstractCommandImpl[CloseLidParams, CloseLidResult]):
+    """Execution implementation of a Thermocycler's close lid command."""
+
+    def __init__(
+        self,
+        state_view: StateView,
+        equipment: EquipmentHandler,
+        **unused_dependencies: object,
+    ) -> None:
+        self._state_view = state_view
+        self._equipment = equipment
+
+    async def execute(self, params: CloseLidParams) -> CloseLidResult:
+        """Close a Thermocycler's lid."""
+        thermocycler_state = self._state_view.modules.get_thermocycler_module_substate(
+            params.moduleId
+        )
+        thermocycler_hardware = self._equipment.get_module_hardware_api(
+            thermocycler_state.module_id
+        )
+
+        if thermocycler_hardware is not None:
+            await thermocycler_hardware.close()
+
+        return CloseLidResult()
+
+
+class CloseLid(BaseCommand[CloseLidParams, CloseLidResult]):
+    """A command to close a Thermocycler's lid."""
+
+    commandType: CloseLidCommandType = "thermocycler/closeLid"
+    params: CloseLidParams
+    result: Optional[CloseLidResult]
+
+    _ImplementationCls: Type[CloseLidImpl] = CloseLidImpl
+
+
+class CloseLidCreate(BaseCommandCreate[CloseLidParams]):
+    """A request to close a Thermocycler's lid."""
+
+    commandType: CloseLidCommandType = "thermocycler/closeLid"
+    params: CloseLidParams
+
+    _CommandCls: Type[CloseLid] = CloseLid

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/open_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/open_lid.py
@@ -25,8 +25,6 @@ class OpenLidParams(BaseModel):
 class OpenLidResult(BaseModel):
     """Result data from opening a Thermocycler's lid."""
 
-    # TODO return lid status?
-
 
 class OpenLidImpl(AbstractCommandImpl[OpenLidParams, OpenLidResult]):
     """Execution implementation of a Thermocycler's open lid command."""

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/open_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/open_lid.py
@@ -1,0 +1,73 @@
+"""Command models to open a Thermocycler's lid."""
+from __future__ import annotations
+from typing import Optional, TYPE_CHECKING
+from typing_extensions import Literal, Type
+
+from pydantic import BaseModel, Field
+
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+if TYPE_CHECKING:
+    from opentrons.protocol_engine.state import StateView
+    from opentrons.protocol_engine.execution import EquipmentHandler
+
+
+OpenLidCommandType = Literal["thermocycler/openLid"]
+
+
+class OpenLidParams(BaseModel):
+    """Input parameters to open a Thermocycler's lid."""
+
+    moduleId: str = Field(..., description="Unique ID of the Thermocycler.")
+
+
+class OpenLidResult(BaseModel):
+    """Result data from opening a Thermocycler's lid."""
+
+    # TODO return lid status?
+
+
+class OpenLidImpl(AbstractCommandImpl[OpenLidParams, OpenLidResult]):
+    """Execution implementation of a Thermocycler's open lid command."""
+
+    def __init__(
+        self,
+        state_view: StateView,
+        equipment: EquipmentHandler,
+        **unused_dependencies: object,
+    ) -> None:
+        self._state_view = state_view
+        self._equipment = equipment
+
+    async def execute(self, params: OpenLidParams) -> OpenLidResult:
+        """Open a Thermocycler's lid."""
+        thermocycler_state = self._state_view.modules.get_thermocycler_module_substate(
+            params.moduleId
+        )
+        thermocycler_hardware = self._equipment.get_module_hardware_api(
+            thermocycler_state.module_id
+        )
+
+        if thermocycler_hardware is not None:
+            await thermocycler_hardware.open()
+
+        return OpenLidResult()
+
+
+class OpenLid(BaseCommand[OpenLidParams, OpenLidResult]):
+    """A command to open a Thermocycler's lid."""
+
+    commandType: OpenLidCommandType = "thermocycler/openLid"
+    params: OpenLidParams
+    result: Optional[OpenLidResult]
+
+    _ImplementationCls: Type[OpenLidImpl] = OpenLidImpl
+
+
+class OpenLidCreate(BaseCommandCreate[OpenLidParams]):
+    """A request to open a Thermocycler's lid."""
+
+    commandType: OpenLidCommandType = "thermocycler/openLid"
+    params: OpenLidParams
+
+    _CommandCls: Type[OpenLid] = OpenLid

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/open_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/open_lid.py
@@ -6,10 +6,11 @@ from typing_extensions import Literal, Type
 from pydantic import BaseModel, Field
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from opentrons.protocol_engine.types import MotorAxis
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
-    from opentrons.protocol_engine.execution import EquipmentHandler
+    from opentrons.protocol_engine.execution import EquipmentHandler, MovementHandler
 
 
 OpenLidCommandType = Literal["thermocycler/openLid"]
@@ -34,10 +35,12 @@ class OpenLidImpl(AbstractCommandImpl[OpenLidParams, OpenLidResult]):
         self,
         state_view: StateView,
         equipment: EquipmentHandler,
+        movement: MovementHandler,
         **unused_dependencies: object,
     ) -> None:
         self._state_view = state_view
         self._equipment = equipment
+        self._movement = movement
 
     async def execute(self, params: OpenLidParams) -> OpenLidResult:
         """Open a Thermocycler's lid."""
@@ -46,6 +49,17 @@ class OpenLidImpl(AbstractCommandImpl[OpenLidParams, OpenLidResult]):
         )
         thermocycler_hardware = self._equipment.get_module_hardware_api(
             thermocycler_state.module_id
+        )
+
+        # move the pipettes and gantry over the trash
+        # do not home plunger axes because pipettes may be holding liquid
+        await self._movement.home(
+            [
+                MotorAxis.X,
+                MotorAxis.Y,
+                MotorAxis.RIGHT_Z,
+                MotorAxis.LEFT_Z,
+            ]
         )
 
         if thermocycler_hardware is not None:

--- a/api/tests/opentrons/protocol_api_experimental/module_contexts/test_thermocycler_module_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/module_contexts/test_thermocycler_module_context.py
@@ -66,3 +66,25 @@ def test_deactivate(
         engine_client.thermocycler_deactivate_lid(subject_module_id),
         engine_client.thermocycler_deactivate_block(subject_module_id),
     )
+
+
+def test_open_lid(
+    decoy: Decoy,
+    engine_client: SyncClient,
+    subject_module_id: str,
+    subject: ThermocyclerModuleContext,
+) -> None:
+    """It should use the engine client to open the lid."""
+    subject.open_lid()
+    decoy.verify(engine_client.thermocycler_open_lid(subject_module_id), times=1)
+
+
+def test_close_lid(
+    decoy: Decoy,
+    engine_client: SyncClient,
+    subject_module_id: str,
+    subject: ThermocyclerModuleContext,
+) -> None:
+    """It should use the engine client to close the lid."""
+    subject.close_lid()
+    decoy.verify(engine_client.thermocycler_close_lid(subject_module_id), times=1)

--- a/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
@@ -358,6 +358,38 @@ def test_thermocycler_deactivate_lid(
     assert result == response
 
 
+def test_thermocycler_open_lid(
+    decoy: Decoy,
+    transport: AbstractSyncTransport,
+    subject: SyncClient,
+) -> None:
+    """It should execute a Thermocycler's open lid command."""
+    request = commands.thermocycler.OpenLidCreate(
+        params=commands.thermocycler.OpenLidParams(moduleId="module-id")
+    )
+    response = commands.thermocycler.OpenLidResult()
+    decoy.when(transport.execute_command(request=request)).then_return(response)
+    result = subject.thermocycler_open_lid(module_id="module-id")
+
+    assert result == response
+
+
+def test_thermocycler_close_lid(
+    decoy: Decoy,
+    transport: AbstractSyncTransport,
+    subject: SyncClient,
+) -> None:
+    """It should execute a Thermocycler's close lid command."""
+    request = commands.thermocycler.CloseLidCreate(
+        params=commands.thermocycler.CloseLidParams(moduleId="module-id")
+    )
+    response = commands.thermocycler.CloseLidResult()
+    decoy.when(transport.execute_command(request=request)).then_return(response)
+    result = subject.thermocycler_close_lid(module_id="module-id")
+
+    assert result == response
+
+
 def test_blow_out(
     decoy: Decoy,
     transport: AbstractSyncTransport,

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_close_lid.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_close_lid.py
@@ -1,0 +1,47 @@
+"""Test Thermocycler close lid command implementation."""
+from decoy import Decoy
+
+from opentrons.hardware_control.modules import Thermocycler
+
+from opentrons.protocol_engine.state import StateView
+from opentrons.protocol_engine.state.module_substates import (
+    ThermocyclerModuleSubState,
+    ThermocyclerModuleId,
+)
+from opentrons.protocol_engine.execution import EquipmentHandler
+from opentrons.protocol_engine.commands import thermocycler as tc_commands
+from opentrons.protocol_engine.commands.thermocycler.close_lid import (
+    CloseLidImpl,
+)
+
+
+async def test_close_lid(
+    decoy: Decoy,
+    state_view: StateView,
+    equipment: EquipmentHandler,
+) -> None:
+    """It should be able to close the specified module's lid."""
+    subject = CloseLidImpl(state_view=state_view, equipment=equipment)
+
+    data = tc_commands.CloseLidParams(moduleId="input-thermocycler-id")
+    expected_module_id = ThermocyclerModuleId("thermocycler-id")
+    expected_result = tc_commands.CloseLidResult()
+
+    tc_module_substate = decoy.mock(cls=ThermocyclerModuleSubState)
+    tc_hardware = decoy.mock(cls=Thermocycler)
+
+    decoy.when(
+        state_view.modules.get_thermocycler_module_substate("input-thermocycler-id")
+    ).then_return(tc_module_substate)
+
+    decoy.when(tc_module_substate.module_id).then_return(expected_module_id)
+
+    # Get attached hardware modules
+    decoy.when(equipment.get_module_hardware_api(expected_module_id)).then_return(
+        tc_hardware
+    )
+
+    result = await subject.execute(data)
+
+    decoy.verify(await tc_hardware.close(), times=1)
+    assert result == expected_result

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_open_lid.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_open_lid.py
@@ -1,0 +1,47 @@
+"""Test Thermocycler open lid command implementation."""
+from decoy import Decoy
+
+from opentrons.hardware_control.modules import Thermocycler
+
+from opentrons.protocol_engine.state import StateView
+from opentrons.protocol_engine.state.module_substates import (
+    ThermocyclerModuleSubState,
+    ThermocyclerModuleId,
+)
+from opentrons.protocol_engine.execution import EquipmentHandler
+from opentrons.protocol_engine.commands import thermocycler as tc_commands
+from opentrons.protocol_engine.commands.thermocycler.open_lid import (
+    OpenLidImpl,
+)
+
+
+async def test_open_lid(
+    decoy: Decoy,
+    state_view: StateView,
+    equipment: EquipmentHandler,
+) -> None:
+    """It should be able to open the specified module's lid."""
+    subject = OpenLidImpl(state_view=state_view, equipment=equipment)
+
+    data = tc_commands.OpenLidParams(moduleId="input-thermocycler-id")
+    expected_module_id = ThermocyclerModuleId("thermocycler-id")
+    expected_result = tc_commands.OpenLidResult()
+
+    tc_module_substate = decoy.mock(cls=ThermocyclerModuleSubState)
+    tc_hardware = decoy.mock(cls=Thermocycler)
+
+    decoy.when(
+        state_view.modules.get_thermocycler_module_substate("input-thermocycler-id")
+    ).then_return(tc_module_substate)
+
+    decoy.when(tc_module_substate.module_id).then_return(expected_module_id)
+
+    # Get attached hardware modules
+    decoy.when(equipment.get_module_hardware_api(expected_module_id)).then_return(
+        tc_hardware
+    )
+
+    result = await subject.execute(data)
+
+    decoy.verify(await tc_hardware.open(), times=1)
+    assert result == expected_result

--- a/robot-server/robot_server/commands/stateless_commands.py
+++ b/robot-server/robot_server/commands/stateless_commands.py
@@ -13,9 +13,8 @@ StatelessCommandCreate = Union[
     commands.thermocycler.SetTargetLidTemperatureCreate,
     commands.thermocycler.DeactivateBlockCreate,
     commands.thermocycler.DeactivateLidCreate,
-    # TODO(mc, 2022-03-18): implement these commands
-    # commands.thermocycler.OpenLidCreate,
-    # commands.thermocycler.CloseLidCreate,
+    commands.thermocycler.OpenLidCreate,
+    commands.thermocycler.CloseLidCreate,
     commands.heater_shaker.SetTargetTemperatureCreate,
     commands.heater_shaker.SetAndWaitForShakeSpeedCreate,
     commands.heater_shaker.DeactivateHeaterCreate,
@@ -35,9 +34,8 @@ StatelessCommand = Union[
     commands.thermocycler.SetTargetLidTemperature,
     commands.thermocycler.DeactivateBlock,
     commands.thermocycler.DeactivateLid,
-    # TODO(mc, 2022-03-18): implement these commands
-    # commands.thermocycler.OpenLid,
-    # commands.thermocycler.CloseLid,
+    commands.thermocycler.OpenLid,
+    commands.thermocycler.CloseLid,
     commands.heater_shaker.SetTargetTemperature,
     commands.heater_shaker.SetAndWaitForShakeSpeed,
     commands.heater_shaker.DeactivateHeater,


### PR DESCRIPTION
# Overview
Addresses #9556

Adds thermocycler module's open lid and close lid to protocol engine and PAPIv3

# Changelog
- Added openLid to Protocol Engine
- Added closeLid to Protocol Engine
- Added open_lid and close_lid to PAPIv3 thermocycler module context

# Review requests
- Should open/close lid response include the lid state (and should that be kept track of in the module store?)

# Risk assessment
Low, relatively simple additions and does not affect existing code.