### PR TITLE
refactor(protocol-engine): Add skeleton of `moveToCoordinates` command

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/__init__.py
@@ -105,6 +105,14 @@ from .move_relative import (
     MoveRelativeCommandType,
 )
 
+from .move_to_coordinates import (
+    MoveToCoordinates,
+    MoveToCoordinatesParams,
+    MoveToCoordinatesCreate,
+    MoveToCoordinatesResult,
+    MoveToCoordinatesCommandType,
+)
+
 from .move_to_well import (
     MoveToWell,
     MoveToWellParams,
@@ -227,6 +235,12 @@ __all__ = [
     "MoveRelativeCreate",
     "MoveRelativeResult",
     "MoveRelativeCommandType",
+    # move to coordinates command models
+    "MoveToCoordinates",
+    "MoveToCoordinatesParams",
+    "MoveToCoordinatesCreate",
+    "MoveToCoordinatesResult",
+    "MoveToCoordinatesCommandType",
     # move to well command models
     "MoveToWell",
     "MoveToWellCreate",

--- a/api/src/opentrons/protocol_engine/commands/aspirate.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
-from .pipetting_common import BaseLiquidHandlingParams, BaseLiquidHandlingResult
+from .pipetting_common import (
+    PipetteIdMixin,
+    VolumeMixin,
+    WellLocationMixin,
+    BaseLiquidHandlingResult,
+)
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 if TYPE_CHECKING:
@@ -13,7 +18,7 @@ if TYPE_CHECKING:
 AspirateCommandType = Literal["aspirate"]
 
 
-class AspirateParams(BaseLiquidHandlingParams):
+class AspirateParams(PipetteIdMixin, VolumeMixin, WellLocationMixin):
     """Parameters required to aspirate from a specific well."""
 
     pass

--- a/api/src/opentrons/protocol_engine/commands/blow_out.py
+++ b/api/src/opentrons/protocol_engine/commands/blow_out.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 from pydantic import BaseModel
 
-from .pipetting_common import BasePipettingParams
+from .pipetting_common import PipetteIdMixin, WellLocationMixin
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 from opentrons.hardware_control import HardwareControlAPI
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 BlowOutCommandType = Literal["blowout"]
 
 
-class BlowOutParams(BasePipettingParams):
+class BlowOutParams(PipetteIdMixin, WellLocationMixin):
     """Payload required to blow-out a specific well."""
 
     pass

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -86,6 +86,14 @@ from .move_relative import (
     MoveRelativeCommandType,
 )
 
+from .move_to_coordinates import (
+    MoveToCoordinates,
+    MoveToCoordinatesParams,
+    MoveToCoordinatesCreate,
+    MoveToCoordinatesResult,
+    MoveToCoordinatesCommandType,
+)
+
 from .move_to_well import (
     MoveToWell,
     MoveToWellParams,
@@ -145,6 +153,7 @@ Command = Union[
     LoadModule,
     LoadPipette,
     MoveRelative,
+    MoveToCoordinates,
     MoveToWell,
     Pause,
     PickUpTip,
@@ -182,6 +191,7 @@ CommandParams = Union[
     LoadModuleParams,
     LoadPipetteParams,
     MoveRelativeParams,
+    MoveToCoordinatesParams,
     MoveToWellParams,
     PauseParams,
     PickUpTipParams,
@@ -219,6 +229,7 @@ CommandType = Union[
     LoadModuleCommandType,
     LoadPipetteCommandType,
     MoveRelativeCommandType,
+    MoveToCoordinatesCommandType,
     MoveToWellCommandType,
     PauseCommandType,
     PickUpTipCommandType,
@@ -255,6 +266,7 @@ CommandCreate = Union[
     LoadModuleCreate,
     LoadPipetteCreate,
     MoveRelativeCreate,
+    MoveToCoordinatesCreate,
     MoveToWellCreate,
     PauseCreate,
     PickUpTipCreate,
@@ -292,6 +304,7 @@ CommandResult = Union[
     LoadModuleResult,
     LoadPipetteResult,
     MoveRelativeResult,
+    MoveToCoordinatesResult,
     MoveToWellResult,
     PauseResult,
     PickUpTipResult,

--- a/api/src/opentrons/protocol_engine/commands/dispense.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
-from .pipetting_common import BaseLiquidHandlingParams, BaseLiquidHandlingResult
+from .pipetting_common import (
+    PipetteIdMixin,
+    VolumeMixin,
+    WellLocationMixin,
+    BaseLiquidHandlingResult,
+)
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 if TYPE_CHECKING:
@@ -13,7 +18,7 @@ if TYPE_CHECKING:
 DispenseCommandType = Literal["dispense"]
 
 
-class DispenseParams(BaseLiquidHandlingParams):
+class DispenseParams(PipetteIdMixin, VolumeMixin, WellLocationMixin):
     """Payload required to dispense to a specific well."""
 
     pass

--- a/api/src/opentrons/protocol_engine/commands/drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
-from .pipetting_common import BasePipettingParams
+from .pipetting_common import PipetteIdMixin, WellLocationMixin
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 if TYPE_CHECKING:
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 DropTipCommandType = Literal["dropTip"]
 
 
-class DropTipParams(BasePipettingParams):
+class DropTipParams(PipetteIdMixin, WellLocationMixin):
     """Payload required to drop a tip in a specific well."""
 
     pass

--- a/api/src/opentrons/protocol_engine/commands/move_to_coordinates.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_coordinates.py
@@ -1,0 +1,84 @@
+"""Move to coordinates command request, result, and implementation models."""
+from __future__ import annotations
+from pydantic import BaseModel, Field
+from typing import Optional, Type
+from typing_extensions import Literal
+
+from ..types import DeckPoint
+from .pipetting_common import PipetteIdMixin
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+
+MoveToCoordinatesCommandType = Literal["moveToCoordinates"]
+
+
+class MoveToCoordinatesParams(PipetteIdMixin):
+    """Payload required to move a pipette to coordinates."""
+
+    coordinates: DeckPoint = Field(
+        ...,
+        description="X, Y and Z coordinates in mm from deck's origin location (left-front-bottom corner of work space)",
+    )
+
+    minimumZHeight: Optional[float] = Field(
+        None,
+        description=(
+            "Optional minimal Z margin in mm."
+            " If this is larger than the API's default safe Z margin,"
+            " it will make the arc higher. If it's smaller, it will have no effect."
+            " Specifying this for movements that would not arc"
+            " (moving within the same well in the same labware)"
+            " will cause an arc movement instead."
+        ),
+    )
+
+    forceDirect: bool = Field(
+        False,
+        description=(
+            "If true, moving from one labware/well to another"
+            " will not arc to the default safe z,"
+            " but instead will move directly to the specified location."
+            " This will also force the `minimumZHeight` param to be ignored."
+            " A 'direct' movement is in X/Y/Z simultaneously."
+        ),
+    )
+
+
+class MoveToCoordinatesResult(BaseModel):
+    """Result data from the execution of a MoveToCoordinates command."""
+
+    pass
+
+
+class MoveToCoordinatesImplementation(
+    AbstractCommandImpl[MoveToCoordinatesParams, MoveToCoordinatesResult]
+):
+    """Move to coordinates command implementation."""
+
+    def __init__(self, **kwargs: object) -> None:
+        pass
+
+    async def execute(self, params: MoveToCoordinatesParams) -> MoveToCoordinatesResult:
+        """Move the requested pipette to the requested coordinates."""
+        raise NotImplementedError()
+
+
+class MoveToCoordinates(BaseCommand[MoveToCoordinatesParams, MoveToCoordinatesResult]):
+    """Move to well command model."""
+
+    commandType: MoveToCoordinatesCommandType = "moveToCoordinates"
+    params: MoveToCoordinatesParams
+    result: Optional[MoveToCoordinatesResult]
+
+    _ImplementationCls: Type[
+        MoveToCoordinatesImplementation
+    ] = MoveToCoordinatesImplementation
+
+
+class MoveToCoordinatesCreate(BaseCommandCreate[MoveToCoordinatesParams]):
+    """Move to coordinates command creation request model."""
+
+    commandType: MoveToCoordinatesCommandType = "moveToCoordinates"
+    params: MoveToCoordinatesParams
+
+    _CommandCls: Type[MoveToCoordinates] = MoveToCoordinates

--- a/api/src/opentrons/protocol_engine/commands/move_to_well.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_well.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
-from .pipetting_common import BasePipettingParams
+from .pipetting_common import PipetteIdMixin, WellLocationMixin
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 if TYPE_CHECKING:
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 MoveToWellCommandType = Literal["moveToWell"]
 
 
-class MoveToWellParams(BasePipettingParams):
+class MoveToWellParams(PipetteIdMixin, WellLocationMixin):
     """Payload required to move a pipette to a specific well."""
 
     pass

--- a/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
-from .pipetting_common import BasePipettingParams
+from .pipetting_common import PipetteIdMixin, WellLocationMixin
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 if TYPE_CHECKING:
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 PickUpTipCommandType = Literal["pickUpTip"]
 
 
-class PickUpTipParams(BasePipettingParams):
+class PickUpTipParams(PipetteIdMixin, WellLocationMixin):
     """Payload needed to move a pipette to a specific well."""
 
     pass

--- a/api/src/opentrons/protocol_engine/commands/pipetting_common.py
+++ b/api/src/opentrons/protocol_engine/commands/pipetting_common.py
@@ -4,13 +4,33 @@ from pydantic import BaseModel, Field
 from ..types import WellLocation
 
 
-class BasePipettingParams(BaseModel):
-    """Base class for data payloads of commands that interact with wells."""
+class PipetteIdMixin(BaseModel):
+    """Mixin for command requests that take a pipette ID."""
 
     pipetteId: str = Field(
         ...,
         description="Identifier of pipette to use for liquid handling.",
     )
+
+
+class VolumeMixin(BaseModel):
+    """Mixin for command requests that take a volume of liquid."""
+
+    volume: float = Field(
+        ...,
+        description="Amount of liquid in uL. Must be greater than 0 and less "
+        "than a pipette-specific maximum volume.",
+        gt=0,
+    )
+
+    # todo(mm, 2021-03-26): This class or one of its subclasses should have a
+    # field for liquid flow rate in microliters per second.
+    # See Opentrons/opentrons#4837 for terminology concerns.
+
+
+class WellLocationMixin(BaseModel):
+    """Mixin for command requests that take a location that's somewhere in a well."""
+
     labwareId: str = Field(
         ...,
         description="Identifier of labware to use.",
@@ -23,21 +43,6 @@ class BasePipettingParams(BaseModel):
         default_factory=WellLocation,
         description="Relative well location at which to perform the operation",
     )
-
-
-class BaseLiquidHandlingParams(BasePipettingParams):
-    """Base class for data payloads of commands that handle liquid."""
-
-    volume: float = Field(
-        ...,
-        description="Amount of liquid in uL. Must be greater than 0 and less "
-        "than a pipette-specific maximum volume.",
-        gt=0,
-    )
-
-    # todo(mm, 2021-03-26): This class or one of its subclasses should have a
-    # field for liquid flow rate in microliters per second.
-    # See Opentrons/opentrons#4837 for terminology concerns.
 
 
 class BaseLiquidHandlingResult(BaseModel):

--- a/api/src/opentrons/protocol_engine/commands/touch_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/touch_tip.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
-from .pipetting_common import BasePipettingParams
+from .pipetting_common import PipetteIdMixin, WellLocationMixin
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 from ..errors import TouchTipDisabledError, LabwareIsTipRackError
 
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 TouchTipCommandType = Literal["touchTip"]
 
 
-class TouchTipParams(BasePipettingParams):
+class TouchTipParams(PipetteIdMixin, WellLocationMixin):
     """Payload needed to touch a pipette tip the sides of a specific well."""
 
     pass

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_coordinates.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_coordinates.py
@@ -1,0 +1,25 @@
+"""Test move-to-coordinates commands."""
+import pytest
+from decoy import Decoy
+
+from opentrons.protocol_engine.types import DeckPoint
+
+from opentrons.protocol_engine.commands.move_to_coordinates import (
+    MoveToCoordinatesParams,
+    MoveToCoordinatesResult,
+    MoveToCoordinatesImplementation,
+)
+
+
+async def test_move_to_coordinates_implementation(decoy: Decoy) -> None:
+    """A MoveRelative command should have an execution implementation."""
+    subject = MoveToCoordinatesImplementation()
+    data = MoveToCoordinatesParams(
+        pipetteId="pipette-id",
+        coordinates=DeckPoint(x=1.11, y=2.22, z=3.33),
+        minimumZHeight=1000,
+        forceDirect=True,
+    )
+
+    with pytest.raises(NotImplementedError):
+        assert await subject.execute(data) == MoveToCoordinatesResult()

--- a/shared-data/protocol/schemas/6.json
+++ b/shared-data/protocol/schemas/6.json
@@ -392,8 +392,9 @@
                     "minimum": 0
                   },
                   "forceDirect": {
-                    "description": "Default is false. If true, moving from one labware/well to another will not arc to the default safe z, but instead will move directly to the specified location. This will also force the 'minimumZHeight' param to be ignored. A 'direct' movement is in X/Y/Z simultaneously",
-                    "type": "boolean"
+                    "description": "If true, moving from one labware/well to another will not arc to the default safe z, but instead will move directly to the specified location. This will also force the `minimumZHeight` param to be ignored. A 'direct' movement is in X/Y/Z simultaneously.",
+                    "type": "boolean",
+                    "default": false
                   }
                 }
               }
@@ -422,8 +423,9 @@
                     "minimum": 0
                   },
                   "forceDirect": {
-                    "description": "Default is false. If true, moving from one labware/well to another will not arc to the default safe z, but instead will move directly to the specified location. This will also force the 'minimumZHeight' param to be ignored. A 'direct' movement is in X/Y/Z simultaneously",
-                    "type": "boolean"
+                    "description": "If true, moving from one labware/well to another will not arc to the default safe z, but instead will move directly to the specified location. This will also force the `minimumZHeight` param to be ignored. A 'direct' movement is in X/Y/Z simultaneously.",
+                    "type": "boolean",
+                    "default": false
                   }
                 }
               }
@@ -968,8 +970,9 @@
                     "minimum": 0
                   },
                   "forceDirect": {
-                    "description": "Default is false. If true, moving from one labware/well to another will not arc to the default safe z, but instead will move directly to the specified location. This will also force the 'minimumZHeight' param to be ignored. A 'direct' movement is in X/Y/Z simultaneously",
-                    "type": "boolean"
+                    "description": "If true, moving from one labware/well to another will not arc to the default safe z, but instead will move directly to the specified location. This will also force the `minimumZHeight` param to be ignored. A 'direct' movement is in X/Y/Z simultaneously.",
+                    "type": "boolean",
+                    "default": false
                   }
                 }
               }


### PR DESCRIPTION
# Overview

This adds a Python model for the `moveToCoordinates` JSON Protocol v6 command. This is just the model; the actual functionality will be implemented in another PR.

This work goes towards #10757.

# Changelog

* Refactor the internal `BaseLiquidHandlingParams` and `BasePipettingParams` models.

  We now have a set of mixins—`PipetteIdMixin`, `VolumeMixin`, and `WellLocationMixin`—to reuse common input fields across command models.
  
  The benefit to this refactor is that it lets each command pick and choose from the mixins orthogonally. A command can use the common `pipette_id` field without also having to also use the `labwareId` field, for example. This is helpful as we start implementing things like `moveToCoordinates` and `aspirateInPlace`, which causes commands to share fields with each other in ways that are partial overlaps instead of strict supersets.

  The flattened class hierarchy and self-descriptive names also make it easier to see how the Python code maps to JSON shapes, in my opinion.

* Add a skeleton `moveToCoordinates` Protocol Engine command that raises `NotImplementedError` when it executes.
* In the JSON schema, use `"default": false` instead of spelling out that the default is `false` in the field's English description.

# Review requests

* [ ] The new `moveToCoordinates` model should exactly match what the `shared-data/protocol/schemas/6.json` schema specifies. In particular, please pay attention to which fields are required and which fields are omittable.
* [ ] Do we agree with the mixin refactor?
* [ ] The mixin refactor shouldn't have changed the constituent fields of any existing commands.

# Risk assessment

No risk to changing production behavior *right now* because this isn't used anywhere.

Some risk to causing confusing mismatches between the front-end and back-end later on if I got the fields wrong somehow. See review requests.