### PR TITLE
refactor(app): change magnetic module slideout values and units

### DIFF
--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -18,7 +18,7 @@
   "max_engage_height": "Max Engage Height",
   "labware_bottom": "Labware Bottom",
   "disengaged": "Disengaged",
-  "gen_2_num": "{{num}} mm",
+  "num_units": "{{num}} mm",
   "set_engage_height": "Set Engage Height",
   "tc_lid": "Lid",
   "tc_block": "Block",

--- a/app/src/organisms/Devices/ModuleCard/MagneticModuleSlideout.tsx
+++ b/app/src/organisms/Devices/ModuleCard/MagneticModuleSlideout.tsx
@@ -7,28 +7,27 @@ import {
 import { useModuleIdFromRun } from './useModuleIdFromRun'
 import {
   Flex,
-  Text,
   DIRECTION_ROW,
   DIRECTION_COLUMN,
   JUSTIFY_SPACE_BETWEEN,
   TEXT_TRANSFORM_UPPERCASE,
-  JUSTIFY_FLEX_END,
   COLORS,
   TYPOGRAPHY,
   SPACING,
+  JUSTIFY_END,
 } from '@opentrons/components'
 import {
   getModuleDisplayName,
   MAGNETIC_MODULE_TYPE_LABWARE_BOTTOM_HEIGHT,
   MAGNETIC_MODULE_V1,
   MAGNETIC_MODULE_V1_DISNEGAGED_HEIGHT,
-  MAGNETIC_MODULE_V1_MAX_ENGAGE_HEIGHT,
+  MAGNETIC_MODULES_MAX_ENGAGE_HEIGHT,
   MAGNETIC_MODULE_V2_DISNEGAGED_HEIGHT,
-  MAGNETIC_MODULE_V2_MAX_ENGAGE_HEIGHT,
   MM,
 } from '@opentrons/shared-data'
 import { Slideout } from '../../../atoms/Slideout'
 import { InputField } from '../../../atoms/InputField'
+import { StyledText } from '../../../atoms/text'
 import { PrimaryButton } from '../../../atoms/buttons'
 
 import type { TFunctionResult } from 'i18next'
@@ -38,7 +37,7 @@ import type { MagneticModuleEngageMagnetCreateCommand } from '@opentrons/shared-
 
 interface ModelContents {
   version: string
-  units: string | null
+  units: string
   maxHeight: number
   labwareBottomHeight: number
   disengagedHeight: number
@@ -48,8 +47,8 @@ const getInfoByModel = (model: MagneticModuleModel): ModelContents => {
   if (model === MAGNETIC_MODULE_V1) {
     return {
       version: 'GEN 1',
-      units: null,
-      maxHeight: MAGNETIC_MODULE_V1_MAX_ENGAGE_HEIGHT,
+      units: MM,
+      maxHeight: MAGNETIC_MODULES_MAX_ENGAGE_HEIGHT,
       labwareBottomHeight: MAGNETIC_MODULE_TYPE_LABWARE_BOTTOM_HEIGHT,
       disengagedHeight: MAGNETIC_MODULE_V1_DISNEGAGED_HEIGHT,
     }
@@ -57,7 +56,7 @@ const getInfoByModel = (model: MagneticModuleModel): ModelContents => {
     return {
       version: 'GEN 2',
       units: MM,
-      maxHeight: MAGNETIC_MODULE_V2_MAX_ENGAGE_HEIGHT,
+      maxHeight: MAGNETIC_MODULES_MAX_ENGAGE_HEIGHT,
       labwareBottomHeight: MAGNETIC_MODULE_TYPE_LABWARE_BOTTOM_HEIGHT,
       disengagedHeight: MAGNETIC_MODULE_V2_DISNEGAGED_HEIGHT,
     }
@@ -95,15 +94,15 @@ export const MagneticModuleSlideout = (
 
   switch (info.version) {
     case 'GEN 1': {
-      max = info.maxHeight
-      labwareBottom = info.labwareBottomHeight
-      disengageHeight = info.disengagedHeight
+      max = t('num_units', { num: info.maxHeight })
+      labwareBottom = t('num_units', { num: info.labwareBottomHeight })
+      disengageHeight = t('num_units', { num: info.disengagedHeight })
       break
     }
     case 'GEN 2': {
-      max = t('gen_2_num', { num: info.maxHeight })
-      labwareBottom = t('gen_2_num', { num: info.labwareBottomHeight })
-      disengageHeight = t('gen_2_num', { num: info.disengagedHeight })
+      max = t('num_units', { num: info.maxHeight })
+      labwareBottom = t('num_units', { num: info.labwareBottomHeight })
+      disengageHeight = t('num_units', { num: info.disengagedHeight })
     }
   }
 
@@ -158,7 +157,7 @@ export const MagneticModuleSlideout = (
         </PrimaryButton>
       }
     >
-      <Text
+      <StyledText
         fontWeight={TYPOGRAPHY.fontWeightRegular}
         fontSize={TYPOGRAPHY.fontSizeP}
         color={COLORS.darkBlack}
@@ -170,13 +169,10 @@ export const MagneticModuleSlideout = (
             module.moduleModel === MAGNETIC_MODULE_V1
               ? MAGNETIC_MODULE_V1_DISNEGAGED_HEIGHT
               : MAGNETIC_MODULE_V2_DISNEGAGED_HEIGHT,
-          higher:
-            module.moduleModel === MAGNETIC_MODULE_V1
-              ? MAGNETIC_MODULE_V1_MAX_ENGAGE_HEIGHT
-              : MAGNETIC_MODULE_V2_MAX_ENGAGE_HEIGHT,
+          higher: MAGNETIC_MODULES_MAX_ENGAGE_HEIGHT,
         })}
-      </Text>
-      <Text
+      </StyledText>
+      <StyledText
         fontSize={TYPOGRAPHY.fontSizeH6}
         color={COLORS.darkGreyEnabled}
         fontWeight={TYPOGRAPHY.fontWeightSemiBold}
@@ -186,7 +182,7 @@ export const MagneticModuleSlideout = (
         data-testid={`MagneticModuleSlideout_body_subtitle_${module.serialNumber}`}
       >
         {t('height_ranges', { gen: info.version })}
-      </Text>
+      </StyledText>
       <Flex
         backgroundColor={COLORS.background}
         flexDirection={DIRECTION_ROW}
@@ -199,20 +195,32 @@ export const MagneticModuleSlideout = (
           flexDirection={DIRECTION_COLUMN}
           data-testid={`MagneticModuleSlideout_body_data_text_${module.serialNumber}`}
         >
-          <Text paddingBottom={SPACING.spacing3}>{t('max_engage_height')}</Text>
-          <Text paddingBottom={SPACING.spacing3}>{t('labware_bottom')}</Text>
-          <Text>{t('disengaged')}</Text>
+          <StyledText paddingBottom={SPACING.spacing3}>
+            {t('max_engage_height')}
+          </StyledText>
+          <StyledText paddingBottom={SPACING.spacing3}>
+            {t('labware_bottom')}
+          </StyledText>
+          <StyledText>{t('disengaged')}</StyledText>
         </Flex>
         <Flex
           flexDirection={DIRECTION_COLUMN}
-          justifyContent={JUSTIFY_FLEX_END}
+          justifyContent={JUSTIFY_END}
           data-testid={`MagneticModuleSlideout_body_data_num_${module.serialNumber}`}
         >
-          <Text paddingBottom={SPACING.spacing3}>{max}</Text>
-          <Text paddingBottom={SPACING.spacing3} paddingLeft={SPACING.spacing2}>
+          <StyledText
+            paddingLeft={SPACING.spacing3}
+            paddingBottom={SPACING.spacing3}
+          >
+            {max}
+          </StyledText>
+          <StyledText
+            paddingLeft={SPACING.spacing4}
+            paddingBottom={SPACING.spacing3}
+          >
             {labwareBottom}
-          </Text>
-          <Text>{disengageHeight}</Text>
+          </StyledText>
+          <StyledText>{disengageHeight}</StyledText>
         </Flex>
       </Flex>
       <Flex
@@ -220,14 +228,14 @@ export const MagneticModuleSlideout = (
         flexDirection={DIRECTION_COLUMN}
         data-testid={`MagneticModuleSlideout_input_field_${module.serialNumber}`}
       >
-        <Text
+        <StyledText
           fontWeight={TYPOGRAPHY.fontWeightSemiBold}
           fontSize={TYPOGRAPHY.fontSizeH6}
           color={COLORS.darkGrey}
           paddingBottom={SPACING.spacing3}
         >
           {t('set_engage_height')}
-        </Text>
+        </StyledText>
         <InputField
           data-testid={`${module.moduleModel}`}
           id={`${module.moduleModel}`}

--- a/app/src/organisms/Devices/ModuleCard/MagneticModuleSlideout.tsx
+++ b/app/src/organisms/Devices/ModuleCard/MagneticModuleSlideout.tsx
@@ -160,7 +160,6 @@ export const MagneticModuleSlideout = (
       <StyledText
         fontWeight={TYPOGRAPHY.fontWeightRegular}
         fontSize={TYPOGRAPHY.fontSizeP}
-        color={COLORS.darkBlack}
         paddingTop={SPACING.spacing2}
         data-testid={`MagneticModuleSlideout_body_text_${module.serialNumber}`}
       >

--- a/app/src/organisms/Devices/ModuleCard/__tests__/MagneticModuleSlideout.test.tsx
+++ b/app/src/organisms/Devices/ModuleCard/__tests__/MagneticModuleSlideout.test.tsx
@@ -64,15 +64,15 @@ describe('MagneticModuleSlideout', () => {
 
     getByText('Set Engage Height for Magnetic Module GEN1')
     getByText(
-      'Set the engage height for this Magnetic Module. Enter an integer between -5 and 40.'
+      'Set the engage height for this Magnetic Module. Enter an integer between -2.5 and 20.'
     )
     getByText('GEN 1 Height Ranges')
     getByText('Max Engage Height')
     getByText('Labware Bottom')
     getByText('Disengaged')
-    getByText('40')
-    getByText('0')
-    getByText('-5')
+    getByText('20 mm')
+    getByText('0 mm')
+    getByText('-2.5 mm')
     getByText('Set Engage Height')
     getByText('Confirm')
   })
@@ -87,15 +87,15 @@ describe('MagneticModuleSlideout', () => {
 
     getByText('Set Engage Height for Magnetic Module GEN2')
     getByText(
-      'Set the engage height for this Magnetic Module. Enter an integer between -4 and 16.'
+      'Set the engage height for this Magnetic Module. Enter an integer between -2.5 and 20.'
     )
     getByText('GEN 2 Height Ranges')
     getByText('Max Engage Height')
     getByText('Labware Bottom')
     getByText('Disengaged')
-    getByText('16 mm')
+    getByText('20 mm')
     getByText('0 mm')
-    getByText('-4 mm')
+    getByText('-2.5 mm') // TODO(jr, 6/14/22): change this to -4 when ticket #9585 merges
     getByText('Set Engage Height')
     getByText('Confirm')
   })

--- a/shared-data/js/constants.ts
+++ b/shared-data/js/constants.ts
@@ -93,14 +93,11 @@ export const OT3_PIPETTES = [
   'p1000_single_gen3',
   'p20_single_gen3',
 ]
-//  GEN2 magnetic module info
+//  magnetic module info
 export const MM: 'mm' = 'mm'
-export const MAGNETIC_MODULE_V2_MAX_ENGAGE_HEIGHT = 16
-export const MAGNETIC_MODULE_V2_DISNEGAGED_HEIGHT = -4
-
-//  GEN 1 magnetic module info
-export const MAGNETIC_MODULE_V1_MAX_ENGAGE_HEIGHT = 40
-export const MAGNETIC_MODULE_V1_DISNEGAGED_HEIGHT = -5
+export const MAGNETIC_MODULES_MAX_ENGAGE_HEIGHT = 20
+export const MAGNETIC_MODULE_V2_DISNEGAGED_HEIGHT = -2.5 //  TODO(jr, 6/14/22): change this to -4 when ticket #9585 merges
+export const MAGNETIC_MODULE_V1_DISNEGAGED_HEIGHT = -2.5
 
 export const MAGNETIC_MODULE_TYPE_LABWARE_BOTTOM_HEIGHT = 0
 


### PR DESCRIPTION
closes #10736 

# Overview

This PR changes the Magnetic module slideouts so the min and max heights are correct. This also adds the units to the GEN 1 magnetic module slideout, as well as some refactoring in the component to utilize `StyledText`

<img width="314" alt="Screen Shot 2022-06-14 at 3 57 58 PM" src="https://user-images.githubusercontent.com/66035149/173677645-8c19f23d-3450-4a41-9f3d-55d6610e077b.png">

# Changelog

- change `MagneticModuleSlideout` and test
- adjust the corresponding constants 

# Review requests

- connect to a robot that has a magnetic module attached and turned on. click on the overflow btn and select "engage height". The slideout should include the correct units for the corresponding module generation. (Note: right now the min and max values are the same for both gens, however, once ticket #9585 is addressed, the GEN1 min range will change)

# Risk assessment

low