### PR TITLE
style(app): app_fixed_spacing_for_calibration_modals

### DIFF
--- a/app/src/molecules/JogControls/DirectionControl.tsx
+++ b/app/src/molecules/JogControls/DirectionControl.tsx
@@ -134,7 +134,6 @@ export function DirectionControl(props: DirectionControlProps): JSX.Element {
           gridGap={SPACING.spacing1}
           gridTemplateRows="repeat(2, [row] 2rem)"
           gridTemplateColumns="repeat(3, [col] 2rem)"
-          marginBottom={SPACING.spacing5}
         >
           {controls.map(
             ({ bearing, gridRow, gridColumn, iconName, axis, sign }) => (

--- a/app/src/molecules/JogControls/index.tsx
+++ b/app/src/molecules/JogControls/index.tsx
@@ -49,7 +49,6 @@ export function JogControls(props: JogControlsProps): JSX.Element {
     <Flex
       justifyContent={JUSTIFY_CENTER}
       alignSelf={ALIGN_STRETCH}
-      marginBottom={SPACING.spacing5}
       {...styleProps}
     >
       <StepSizeControl

--- a/app/src/molecules/JogControls/index.tsx
+++ b/app/src/molecules/JogControls/index.tsx
@@ -1,12 +1,7 @@
 // jog controls component
 import * as React from 'react'
 
-import {
-  SPACING,
-  Flex,
-  JUSTIFY_CENTER,
-  ALIGN_STRETCH,
-} from '@opentrons/components'
+import { Flex, JUSTIFY_CENTER, ALIGN_STRETCH } from '@opentrons/components'
 
 import { DirectionControl } from './DirectionControl'
 import { StepSizeControl } from './StepSizeControl'

--- a/app/src/organisms/CalibrationPanels/MeasureNozzle.tsx
+++ b/app/src/organisms/CalibrationPanels/MeasureNozzle.tsx
@@ -17,6 +17,7 @@ import {
   TEXT_TRANSFORM_UPPERCASE,
   FONT_WEIGHT_SEMIBOLD,
   FONT_SIZE_HEADER,
+  SPACING,
   SPACING_2,
   SPACING_3,
   SPACING_4,
@@ -198,6 +199,7 @@ export function MeasureNozzle(props: CalibrationPanelProps): JSX.Element {
           stepSizes={[0.1, 1]}
           planes={[VERTICAL_PLANE]}
           width="100%"
+          marginBottom={SPACING.spacing5}
         />
         <Flex width="100%" justifyContent={JUSTIFY_CENTER} marginY={SPACING_3}>
           <PrimaryBtn onClick={proceed} flex="1">

--- a/app/src/organisms/CalibrationPanels/MeasureTip.tsx
+++ b/app/src/organisms/CalibrationPanels/MeasureTip.tsx
@@ -16,6 +16,7 @@ import {
   TEXT_TRANSFORM_UPPERCASE,
   FONT_WEIGHT_SEMIBOLD,
   FONT_SIZE_HEADER,
+  SPACING,
   SPACING_2,
   SPACING_3,
   SPACING_4,
@@ -212,6 +213,7 @@ export function MeasureTip(props: CalibrationPanelProps): JSX.Element {
           stepSizes={[0.1, 1]}
           planes={[VERTICAL_PLANE]}
           width="100%"
+          marginBottom={SPACING.spacing5}
         />
         <Flex width="100%" justifyContent={JUSTIFY_CENTER} marginY={SPACING_3}>
           <PrimaryBtn title="saveTipLengthButton" onClick={proceed} flex="1">

--- a/app/src/organisms/CalibrationPanels/SaveXYPoint.tsx
+++ b/app/src/organisms/CalibrationPanels/SaveXYPoint.tsx
@@ -8,6 +8,7 @@ import {
   Text,
   FONT_SIZE_BODY_2,
   DIRECTION_ROW,
+  SPACING,
   SPACING_3,
   SPACING_5,
   BORDER_SOLID_LIGHT,
@@ -308,6 +309,7 @@ export function SaveXYPoint(props: CalibrationPanelProps): JSX.Element {
             : [HORIZONTAL_PLANE]
         }
         auxiliaryControl={allowVertical ? null : <AllowVerticalPrompt />}
+        marginBottom={SPACING.spacing5}
       />
       <Flex
         width="100%"

--- a/app/src/organisms/CalibrationPanels/SaveZPoint.tsx
+++ b/app/src/organisms/CalibrationPanels/SaveZPoint.tsx
@@ -11,6 +11,7 @@ import {
   FONT_SIZE_BODY_2,
   FONT_BODY_2_DARK,
   DIRECTION_ROW,
+  SPACING,
   SPACING_3,
   SPACING_5,
   BORDER_SOLID_LIGHT,
@@ -218,6 +219,7 @@ export function SaveZPoint(props: CalibrationPanelProps): JSX.Element {
         }
         auxiliaryControl={allowHorizontal ? null : <AllowHorizontalPrompt />}
         width="100%"
+        marginBottom={SPACING.spacing5}
       />
       <Flex
         width="100%"

--- a/app/src/organisms/CalibrationPanels/TipPickUp.tsx
+++ b/app/src/organisms/CalibrationPanels/TipPickUp.tsx
@@ -13,6 +13,7 @@ import {
   JUSTIFY_CENTER,
   JUSTIFY_SPACE_BETWEEN,
   POSITION_RELATIVE,
+  SPACING,
   SPACING_1,
   SPACING_2,
   SPACING_3,
@@ -154,7 +155,7 @@ export function TipPickUp(props: CalibrationPanelProps): JSX.Element {
             </Box>
           </Flex>
         </Box>
-        <JogControls jog={jog} />
+        <JogControls jog={jog} marginBottom={SPACING.spacing5} />
         <Flex width="100%" justifyContent={JUSTIFY_CENTER}>
           <PrimaryBtn onClick={pickUpTip} flex="1" marginX={SPACING_5}>
             {TIP_PICK_UP_BUTTON_TEXT}


### PR DESCRIPTION
# Overview

Corrected branch issue, removed code from DirectionControl.tsx and refactored the spacing calibration modals code to reside in the JogControls component instead.

#10677

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->
 
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
Refactored the following files to include marginBottom spacing set to marginBottom={SPACING.spacing5}
- MeasureNozzle.tsx
- MeasureTip.tsx
- SaveXYPoint.tsx
- SaveZPoint.tsx
- TipPickUp.tsx

# Review requests
Low
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low