### PR TITLE
fix(app): if robot is not connectable during run, navigate to devices

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -74,6 +74,7 @@ import {
   useRunCalibrationStatus,
   useRunCreatedAtTimestamp,
   useUnmatchedModulesForProtocol,
+  useIsRobotViewable,
 } from '../hooks'
 import { formatTimestamp } from '../utils'
 import { useIsHeaterShakerInProtocol } from '../ModuleCard/hooks'
@@ -134,7 +135,8 @@ export function ProtocolRunHeader({
   const { protocolData, displayName, protocolKey } = useProtocolDetailsForRun(
     runId
   )
-  const isProtocolAnalyzing = protocolData == null
+  const isRobotViewable = useIsRobotViewable(robotName)
+  const isProtocolAnalyzing = protocolData == null && isRobotViewable
   const runStatus = useRunStatus(runId)
   const { analysisErrors } = useProtocolAnalysisErrors(runId)
   const isRunCurrent = Boolean(useRunQuery(runId)?.data?.data?.current)
@@ -143,8 +145,14 @@ export function ProtocolRunHeader({
     useModulesQuery({ refetchInterval: EQUIPMENT_POLL_MS })?.data?.data ?? []
   // NOTE: we are polling pipettes, though not using their value directly here
   usePipettesQuery({ refetchInterval: EQUIPMENT_POLL_MS })
-
   const { startedAt, stoppedAt, completedAt } = useRunTimestamps(runId)
+
+  React.useEffect(() => {
+    if (protocolData != null && !isRobotViewable) {
+      history.push(`/devices`)
+    }
+  }, [protocolData, isRobotViewable, history])
+
   React.useEffect(() => {
     if (runStatus === RUN_STATUS_STOPPED && isRunCurrent) {
       runId != null && dismissCurrentRun(runId)

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { BrowserRouter } from 'react-router-dom'
 import '@testing-library/jest-dom'
-import { fireEvent } from '@testing-library/react'
+import { fireEvent, waitFor } from '@testing-library/react'
 import { when, resetAllWhenMocks } from 'jest-when'
 import {
   RUN_STATUS_IDLE,
@@ -54,6 +54,7 @@ import {
   useRunCalibrationStatus,
   useRunCreatedAtTimestamp,
   useUnmatchedModulesForProtocol,
+  useIsRobotViewable,
 } from '../../hooks'
 import { useIsHeaterShakerInProtocol } from '../../ModuleCard/hooks'
 import { ConfirmAttachmentModal } from '../../ModuleCard/ConfirmAttachmentModal'
@@ -150,6 +151,9 @@ const mockConfirmAttachmentModal = ConfirmAttachmentModal as jest.MockedFunction
 const mockUseTrackEvent = useTrackEvent as jest.MockedFunction<
   typeof useTrackEvent
 >
+const mockUseIsRobotViewable = useIsRobotViewable as jest.MockedFunction<
+  typeof useIsRobotViewable
+>
 
 const ROBOT_NAME = 'otie'
 const RUN_ID = '95e67900-bc9f-4fbf-92c6-cc4d7226a51b'
@@ -225,6 +229,7 @@ describe('ProtocolRunHeader', () => {
       },
     } as any)
     mockGetIsHeaterShakerAttached.mockReturnValue(false)
+    mockUseIsRobotViewable.mockReturnValue(true)
     mockConfirmAttachmentModal.mockReturnValue(
       <div>mock confirm attachment modal</div>
     )
@@ -660,5 +665,11 @@ describe('ProtocolRunHeader', () => {
       })
     const [{ getByText }] = render()
     getByText('Protocol analysis failed.')
+  })
+  it('renders the devices page when robot is not viewable but protocol is loaded', async () => {
+    mockUseIsRobotViewable.mockReturnValue(false)
+    waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/devices')
+    })
   })
 })


### PR DESCRIPTION
closes #10584 

# Overview

When you are running a protocol and turn off the robot/lose connection to robot/robot is not CONNECTABLE, the app should redirect to the devices page

# Changelog

- add `useIsRobotViewable` to `ProtocolRunHeader` and fix test

# Review requests

- upload a protocol (you can start or not start it), turn off your robot. The app should navigate to the devices page rather than staying on the protocol run page

# Risk assessment

low