### PR TITLE
feat(app): add reinstall button to robot advanced settings

### DIFF
--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -141,5 +141,6 @@
   "software_update_modal_issue_tracker_link": "View Opentrons issue tracker",
   "software_update_modal_release_notes_link": "View full Opentrons release notes",
   "software_update_modal_remind_me_later_button": "Remind me later",
-  "software_update_modal_update_button": "Update robot now"
+  "software_update_modal_update_button": "Update robot now",
+  "reinstall": "reinstall"
 }

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/RobotServerVersion.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/RobotServerVersion.tsx
@@ -11,13 +11,17 @@ import {
   COLORS,
   Link,
   JUSTIFY_FLEX_END,
+  TEXT_TRANSFORM_CAPITALIZE,
 } from '@opentrons/components'
 import { StyledText } from '../../../../atoms/text'
-import { getRobotApiVersion } from '../../../../redux/discovery'
+import { Portal } from '../../../../App/portal'
+import { TertiaryButton } from '../../../../atoms/buttons'
+import { getRobotApiVersion, UNREACHABLE } from '../../../../redux/discovery'
 import { getBuildrootUpdateDisplayInfo } from '../../../../redux/buildroot'
 import { UpdateRobotBanner } from '../../../UpdateRobotBanner'
 import { useIsRobotBusy } from '../../hooks/useIsRobotBusy'
 import { useRobot } from '../../hooks'
+import { UpdateBuildroot } from '../UpdateBuildroot'
 
 import type { State } from '../../../../redux/types'
 
@@ -34,6 +38,7 @@ export function RobotServerVersion({
   const { t } = useTranslation(['device_settings', 'shared'])
   const robot = useRobot(robotName)
   const isBusy = useIsRobotBusy()
+  const [showVersionInfoModal, setShowVersionInfoModal] = React.useState(false)
   const { autoUpdateAction } = useSelector((state: State) => {
     return getBuildrootUpdateDisplayInfo(state, robotName)
   })
@@ -42,18 +47,19 @@ export function RobotServerVersion({
 
   return (
     <>
+      {showVersionInfoModal && robot != null && robot.status !== UNREACHABLE ? (
+        <Portal level="top">
+          <UpdateBuildroot
+            robot={robot}
+            close={() => setShowVersionInfoModal(false)}
+          />
+        </Portal>
+      ) : null}
       {autoUpdateAction !== 'reinstall' && robot != null && !isBusy ? (
         <Box marginBottom={SPACING.spacing4} width="100%">
           <UpdateRobotBanner robot={robot} />
         </Box>
-      ) : (
-        // TODO: add reinstall option
-        <Flex justifyContent={JUSTIFY_FLEX_END}>
-          <StyledText as="label" color={COLORS.darkGreyEnabled}>
-            {t('robot_server_versions_status')}
-          </StyledText>
-        </Flex>
-      )}
+      ) : null}
       <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>
         <Box width="70%">
           <StyledText
@@ -79,6 +85,23 @@ export function RobotServerVersion({
             >{` ${t('shared:github')}`}</Link>
           </StyledText>
         </Box>
+        {autoUpdateAction !== 'reinstall' && robot != null && !isBusy ? null : (
+          <Flex justifyContent={JUSTIFY_FLEX_END} alignItems="center">
+            <StyledText
+              as="label"
+              color={COLORS.darkGreyEnabled}
+              paddingRight={SPACING.spacing4}
+            >
+              {t('robot_server_versions_status')}
+            </StyledText>
+            <TertiaryButton
+              onClick={() => setShowVersionInfoModal(true)}
+              textTransform={TEXT_TRANSFORM_CAPITALIZE}
+            >
+              {t('reinstall')}
+            </TertiaryButton>
+          </Flex>
+        )}
       </Flex>
     </>
   )

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/__tests__/RobotServerVersion.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/__tests__/RobotServerVersion.test.tsx
@@ -66,9 +66,11 @@ describe('RobotSettings RobotServerVersion', () => {
   })
 
   it('should render the message, up to date, if the robot server version is the same as the latest version', () => {
-    // display 'up to data' message
-    const [{ getByText }] = render()
+    const [{ getByText, getByRole }] = render()
     getByText('up to date')
+    const reinstall = getByRole('button', { name: 'reinstall' })
+    fireEvent.click(reinstall)
+    getByText('mock update buildroot')
   })
 
   it('should render the warning message if the robot server version needs to upgrade', () => {


### PR DESCRIPTION
 closes #10435 

# Overview

This PR adds the reinstall button to the robot server version section of the robot advanced settings

<img width="915" alt="Screen Shot 2022-06-15 at 1 28 46 PM" src="https://user-images.githubusercontent.com/66035149/173889080-d8ff50a9-3825-4543-af9b-baee5ae204c3.png">

# Changelog

- add reinstall button and wire it up in `RobotServerVersion`

# Review requests

- go to robot advanced settings, if your software is up to date, there should be a reinstall button next to the the `up to date` text. Click on it should bring you to a modal that tells you that you are already up to date but you can reinstall anyway. Clicking `not now` will cancel the action. Clicking `Reinstall` will reinstall.

# Risk assessment

low
