### PR TITLE
feat(hardware): add ot3 gpio driver, set estop

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -19,7 +19,6 @@ from typing import (
     Iterator,
 )
 from opentrons.config.types import OT3Config, GantryLoad
-from opentrons.drivers.rpi_drivers.gpio_simulator import SimulatingGPIOCharDev
 from opentrons.config import pipette_config, gripper_config
 from .ot3utils import (
     axis_convert,
@@ -83,6 +82,7 @@ from opentrons_hardware.hardware_control.tool_sensors import (
     capacitive_probe,
     capacitive_pass,
 )
+from opentrons_hardware.drivers.gpio import OT3GPIO
 
 if TYPE_CHECKING:
     from opentrons_shared_data.pipette.dev_types import PipetteName, PipetteModel
@@ -92,7 +92,6 @@ if TYPE_CHECKING:
         OT3AttachedInstruments,
         InstrumentHardwareConfigs,
     )
-    from opentrons.drivers.rpi_drivers.dev_types import GPIODriverLike
 
 log = logging.getLogger(__name__)
 
@@ -127,7 +126,7 @@ class OT3Controller:
             driver: The Can Driver
         """
         self._configuration = config
-        self._gpio_dev = SimulatingGPIOCharDev("simulated")
+        self._gpio_dev = OT3GPIO("hardware_control")
         self._module_controls: Optional[AttachedModulesControl] = None
         self._messenger = CanMessenger(driver=driver)
         self._messenger.start()
@@ -177,7 +176,7 @@ class OT3Controller:
         )
 
     @property
-    def gpio_chardev(self) -> GPIODriverLike:
+    def gpio_chardev(self) -> OT3GPIO:
         """Get the GPIO device."""
         return self._gpio_dev
 

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -18,7 +18,6 @@ from typing import (
 )
 
 from opentrons.config.types import OT3Config, GantryLoad
-from opentrons.drivers.rpi_drivers.gpio_simulator import SimulatingGPIOCharDev
 from opentrons.config import pipette_config, gripper_config
 from opentrons_shared_data.pipette import dummy_model_for_name
 from .ot3utils import (
@@ -56,7 +55,7 @@ from opentrons.hardware_control.dev_types import (
     AttachedGripper,
     OT3AttachedInstruments,
 )
-from opentrons.drivers.rpi_drivers.dev_types import GPIODriverLike
+from opentrons_hardware.drivers.gpio import OT3GPIO
 
 log = logging.getLogger(__name__)
 
@@ -88,14 +87,11 @@ class OT3Simulator:
         Returns:
             Instance.
         """
-        gpio = SimulatingGPIOCharDev("gpiochip0")
-        await gpio.setup()
         return cls(
             attached_instruments,
             attached_modules,
             config,
             loop,
-            gpio,
             strict_attached_instruments,
         )
 
@@ -105,7 +101,6 @@ class OT3Simulator:
         attached_modules: List[str],
         config: OT3Config,
         loop: asyncio.AbstractEventLoop,
-        gpio_chardev: GPIODriverLike,
         strict_attached_instruments: bool = True,
     ) -> None:
         """Construct.
@@ -116,7 +111,7 @@ class OT3Simulator:
         """
         self._configuration = config
         self._loop = loop
-        self._gpio_dev = SimulatingGPIOCharDev("simulated")
+        self._gpio_dev = OT3GPIO()
         self._strict_attached = bool(strict_attached_instruments)
         self._stubbed_attached_modules = attached_modules
 
@@ -157,7 +152,7 @@ class OT3Simulator:
         self._current_settings: Optional[OT3AxisMap[CurrentConfig]] = None
 
     @property
-    def gpio_chardev(self) -> GPIODriverLike:
+    def gpio_chardev(self) -> OT3GPIO:
         """Get the GPIO device."""
         return self._gpio_dev
 

--- a/hardware/opentrons_hardware/drivers/gpio/__init__.py
+++ b/hardware/opentrons_hardware/drivers/gpio/__init__.py
@@ -21,6 +21,7 @@ class OT3GPIO:
         """
         try:
             import gpiod  # type: ignore[import]
+
             return gpiod
         except ImportError:
             LOG.warning("could not import gpiod")

--- a/hardware/opentrons_hardware/drivers/gpio/__init__.py
+++ b/hardware/opentrons_hardware/drivers/gpio/__init__.py
@@ -34,9 +34,12 @@ class OT3GPIO:
         other programs trying to find out who holds a line) then it will be used;
         otherwise, the default is opentrons.
         """
+        self._consumer_name = consumer_name or CONSUMER_NAME_DEFAULT
         self._gpiod = self._get_gpiod()
         self._estop_out_line = self._gpiod.find_line(ESTOP_OUT_GPIO_NAME)
-        self._estop_out_line.request("opentrons", type=self._gpiod.LINE_REQ_DIR_OUT)
+        self._estop_out_line.request(
+            self._consumer_name, type=self._gpiod.LINE_REQ_DIR_OUT
+        )
         self.release_estop()
 
     def assert_estop(self) -> None:

--- a/hardware/opentrons_hardware/drivers/gpio/__init__.py
+++ b/hardware/opentrons_hardware/drivers/gpio/__init__.py
@@ -21,7 +21,6 @@ class OT3GPIO:
         """
         try:
             import gpiod  # type: ignore[import]
-
             return gpiod
         except ImportError:
             LOG.warning("could not import gpiod")
@@ -40,13 +39,13 @@ class OT3GPIO:
         self._estop_out_line.request(
             self._consumer_name, type=self._gpiod.LINE_REQ_DIR_OUT
         )
-        self.release_estop()
+        self.deactivate_estop()
 
-    def assert_estop(self) -> None:
+    def activate_estop(self) -> None:
         """Assert the emergency stop, which will disable all motors."""
         self._estop_out_line.set_value(0)
 
-    def release_estop(self) -> None:
+    def deactivate_estop(self) -> None:
         """Stop asserting the emergency stop.
 
         If no other node is asserting estop, then motors can be enabled

--- a/hardware/opentrons_hardware/drivers/gpio/__init__.py
+++ b/hardware/opentrons_hardware/drivers/gpio/__init__.py
@@ -1,0 +1,52 @@
+"""Drivers for SOM gpio pins."""
+from typing import Any, Optional
+from typing_extensions import Final
+from unittest import mock
+from logging import getLogger
+
+CONSUMER_NAME_DEFAULT: Final[str] = "opentrons"
+ESTOP_OUT_GPIO_NAME: Final[str] = "SODIMM_210"
+
+LOG = getLogger(__name__)
+
+
+class OT3GPIO:
+    """Driver class for OT3 gpio lines."""
+
+    @staticmethod
+    def _get_gpiod() -> Any:
+        """Import the libgpiod bindings.
+
+        If gpiod is not available, a mock will be used and the problem will be logged.
+        """
+        try:
+            import gpiod  # type: ignore[import]
+
+            return gpiod
+        except ImportError:
+            LOG.warning("could not import gpiod")
+            return mock.MagicMock()
+
+    def __init__(self, consumer_name: Optional[str] = None) -> None:
+        """Build the GPIO handler.
+
+        If a consumer name is provided (which can add more semantic information to
+        other programs trying to find out who holds a line) then it will be used;
+        otherwise, the default is opentrons.
+        """
+        self._gpiod = self._get_gpiod()
+        self._estop_out_line = self._gpiod.find_line(ESTOP_OUT_GPIO_NAME)
+        self._estop_out_line.request("opentrons", type=self._gpiod.LINE_REQ_DIR_OUT)
+        self.release_estop()
+
+    def assert_estop(self) -> None:
+        """Assert the emergency stop, which will disable all motors."""
+        self._estop_out_line.set_value(0)
+
+    def release_estop(self) -> None:
+        """Stop asserting the emergency stop.
+
+        If no other node is asserting estop, then motors can be enabled
+        again.
+        """
+        self._estop_out_line.set_value(1)

--- a/hardware/opentrons_hardware/scripts/can_comm.py
+++ b/hardware/opentrons_hardware/scripts/can_comm.py
@@ -8,6 +8,7 @@ from logging.config import dictConfig
 from typing import Type, Sequence, Callable, TypeVar
 
 from opentrons_hardware.drivers.can_bus import build
+from opentrons_hardware.drivers.gpio import OT3GPIO
 from opentrons_hardware.firmware_bindings.constants import (
     MessageId,
     NodeId,
@@ -229,6 +230,9 @@ async def run_ui(driver: AbstractCanDriver) -> None:
 
 async def run(args: argparse.Namespace) -> None:
     """Entry point for script."""
+    # build a gpio handler which will automatically release estop
+    gpio = OT3GPIO()
+    gpio.release_estop()
     async with build.driver(build_settings(args)) as driver:
         await (run_ui(driver))
 

--- a/hardware/opentrons_hardware/scripts/can_comm.py
+++ b/hardware/opentrons_hardware/scripts/can_comm.py
@@ -232,7 +232,7 @@ async def run(args: argparse.Namespace) -> None:
     """Entry point for script."""
     # build a gpio handler which will automatically release estop
     gpio = OT3GPIO()
-    gpio.release_estop()
+    gpio.deactivate_estop()
     async with build.driver(build_settings(args)) as driver:
         await (run_ui(driver))
 

--- a/hardware/opentrons_hardware/scripts/can_control.py
+++ b/hardware/opentrons_hardware/scripts/can_control.py
@@ -76,7 +76,7 @@ async def run(args: argparse.Namespace) -> None:
     """Entry point for script."""
     # build a GPIO handler which will automatically release estop
     gpio = OT3GPIO()
-    gpio.release_estop()
+    gpio.deactivate_estop()
     async with build.driver(build_settings(args)) as driver, CanMessenger(
         driver
     ) as messenger:

--- a/hardware/opentrons_hardware/scripts/can_control.py
+++ b/hardware/opentrons_hardware/scripts/can_control.py
@@ -13,6 +13,7 @@ from typing import TextIO, Optional
 
 from opentrons_hardware.drivers.can_bus import build, CanMessenger
 from opentrons_hardware.drivers.can_bus.abstract_driver import AbstractCanDriver
+from opentrons_hardware.drivers.gpio import OT3GPIO
 
 from opentrons_hardware.firmware_bindings.message import CanMessage
 from opentrons_hardware.scripts.can_args import add_can_args, build_settings
@@ -73,6 +74,9 @@ async def input_task(
 
 async def run(args: argparse.Namespace) -> None:
     """Entry point for script."""
+    # build a GPIO handler which will automatically release estop
+    gpio = OT3GPIO()
+    gpio.release_estop()
     async with build.driver(build_settings(args)) as driver, CanMessenger(
         driver
     ) as messenger:

--- a/hardware/opentrons_hardware/scripts/move.py
+++ b/hardware/opentrons_hardware/scripts/move.py
@@ -101,7 +101,7 @@ async def run(args: argparse.Namespace) -> None:
     async with build.can_messenger(build_settings(args)) as messenger:
         # build a GPIO handler, which will automatically release estop
         gpio = OT3GPIO(__name__)
-        gpio.release_estop()
+        gpio.deactivate_estop()
         await run_move(messenger)
 
 

--- a/hardware/opentrons_hardware/scripts/move.py
+++ b/hardware/opentrons_hardware/scripts/move.py
@@ -19,6 +19,8 @@ from opentrons_hardware.hardware_control.motion import (
 from opentrons_hardware.hardware_control.move_group_runner import MoveGroupRunner
 from opentrons_hardware.scripts.can_args import add_can_args, build_settings
 
+from opentrons_hardware.drivers.gpio import OT3GPIO
+
 log = logging.getLogger(__name__)
 
 LOG_CONFIG = {
@@ -97,6 +99,9 @@ async def run_move(messenger: CanMessenger) -> None:
 async def run(args: argparse.Namespace) -> None:
     """Entry point for script."""
     async with build.can_messenger(build_settings(args)) as messenger:
+        # build a GPIO handler, which will automatically release estop
+        gpio = OT3GPIO(__name__)
+        gpio.release_estop()
         await run_move(messenger)
 
 


### PR DESCRIPTION
Add a GPIO driver for the OT3. It's like the rpi_gpio driver, but OT3
drivers live in opentrons_hardware. There isn't a lot of duplicated
code.

The annoying thing is that libgpiod isn't really ever going to be
runnable in a test context, so the code automatically switches out for a
mock if libgpiod isn't available.

With libgpiod and with the effort toradex put in to giving gpios
appropriate semantic names, we can pull out the estop gpio line and set
it high, which allows motors to be enabled - on new hardware, with that
line connected, if you don't explicitly set that line high nothing moves.
