### PR TITLE
feat(papi-v2): restrict placement of heater-shaker modules

### DIFF
--- a/api/src/opentrons/protocols/geometry/deck.py
+++ b/api/src/opentrons/protocols/geometry/deck.py
@@ -2,27 +2,23 @@ import functools
 import logging
 from collections import UserDict
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, List, Dict, Set
+from typing import Optional, List
 
-from opentrons import types
-from opentrons.protocol_api.labware import load as load_lw, Labware
-from opentrons.protocols.api_support.constants import deck_type
-from opentrons.protocols.api_support.labware_like import LabwareLike
-from opentrons.protocols.geometry.deck_item import DeckItem
-from opentrons.hardware_control.modules.types import ModuleType
-from opentrons.protocols.geometry.module_geometry import (
-    ModuleGeometry,
-    ThermocyclerGeometry,
-)
 from opentrons_shared_data.deck import (
     DEFAULT_DECK_DEFINITION_VERSION,
     load as load_deck,
 )
+from opentrons_shared_data.deck.dev_types import SlotDefV3
 
-if TYPE_CHECKING:
-    from opentrons_shared_data.deck.dev_types import (
-        SlotDefV3,
-    )
+from opentrons import types
+from opentrons.hardware_control.modules.types import ModuleType
+from opentrons.protocol_api.labware import load as load_lw, Labware
+from opentrons.protocols.api_support.constants import deck_type
+from opentrons.protocols.api_support.labware_like import LabwareLike
+
+from . import deck_conflict
+from .deck_item import DeckItem
+from .module_geometry import ModuleGeometry, ThermocyclerGeometry
 
 MODULE_LOG = logging.getLogger(__name__)
 
@@ -46,7 +42,7 @@ class CalibrationPosition:
 
 
 class Deck(UserDict):
-    def __init__(self, load_name: Optional[str] = None) -> None:
+    def __init__(self) -> None:
         super().__init__()
         row_offset = 90.5
         col_offset = 132.5
@@ -57,15 +53,23 @@ class Deck(UserDict):
             for idx in range(12)
         }
         self._highest_z = 0.0
-        if not load_name:
-            load_name = deck_type()
-        self._definition = load_deck(load_name, DEFAULT_DECK_DEFINITION_VERSION)
+        self._definition = load_deck(deck_type(), DEFAULT_DECK_DEFINITION_VERSION)
         self._load_fixtures()
         self._thermocycler_present = False
 
     def _load_fixtures(self):
         for f in self._definition["locations"]["fixtures"]:
             slot_name = self._check_name(f["slot"])  # type: ignore
+            # TODO(mc, 2022-06-15): this loads the fixed trash as an instance of
+            # opentrons.protocol_api.labware.Labware instance
+            # However, all other labware will be added to the Deck as instances of
+            # opentrons.protocols.context.labware.AbstractLabware
+            # And modules will be added as instances of
+            # opentrons.protocols.geometry.module_geometry.ModuleGeometry
+            # This mix of public and private interaces as members of a public
+            # Deck interface is confusing and should be resolved.
+            # Id Deck is public, all items in a Deck should be instances of
+            # other public APIs.
             loaded_f = load_lw(
                 f["labware"], self.position_for(slot_name)  # type: ignore
             )
@@ -110,30 +114,17 @@ class Deck(UserDict):
 
     def __setitem__(self, key: types.DeckLocation, val: DeckItem) -> None:
         slot_key_int = self._check_name(key)
-        item = self.data.get(slot_key_int)
+        existing_items = {
+            slot: item for slot, item in self.data.items() if item is not None
+        }
 
-        overlapping_items = self._get_collisions_for_item(slot_key_int, val)
-        if item is not None:
-            if slot_key_int == 12:
-                if FIXED_TRASH_ID in item.parameters.get("quirks", []):
-                    pass
-                else:
-                    raise ValueError(f"Deck slot {key} is for fixed trash only")
-            else:
-                raise ValueError(
-                    f"Deck slot {key} already"
-                    f" has an item: {self.data[slot_key_int].load_name}"
-                )
-        elif overlapping_items:
-            flattened_overlappers = [
-                f"{item.load_name} in slot {slot}"
-                for slot, sublist in overlapping_items.items()
-                for item in sublist
-            ]
-            raise ValueError(
-                f"Could not load {val} because it would"
-                f" interfere with {', '.join(flattened_overlappers)}"
-            )
+        # will raise DeckConflictError if items conflict
+        deck_conflict.check(
+            existing_items=existing_items,
+            new_location=slot_key_int,
+            new_item=val,
+        )
+
         self.data[slot_key_int] = val
         self._highest_z = max(val.highest_z, self._highest_z)
         self._thermocycler_present = any(
@@ -286,32 +277,6 @@ class Deck(UserDict):
             self._check_name(f.get("slot")) for f in fixtures if f.get("slot")
         }
         return [s for s in self.data.keys() if s not in fixture_slots]
-
-    def _get_collisions_for_item(
-        self, slot_key: types.DeckLocation, item: DeckItem
-    ) -> Dict[types.DeckLocation, List[DeckItem]]:
-        """Return the loaded deck items that collide with the given item."""
-
-        def get_item_covered_slot_keys(sk, i) -> Set[str]:
-            if isinstance(i, ThermocyclerGeometry):
-                return i.covered_slots
-            elif i is not None:
-                return set([sk])
-            else:
-                return set()
-
-        item_slot_keys = get_item_covered_slot_keys(slot_key, item)
-        colliding_items: Dict[types.DeckLocation, List[DeckItem]] = {}
-
-        for slot_key, existing_item in self.data.items():
-            occupied_slot_keys = get_item_covered_slot_keys(slot_key, existing_item)
-            conflicting_slot_keys = occupied_slot_keys & item_slot_keys
-
-            if len(conflicting_slot_keys) > 0:
-                for conflict in conflicting_slot_keys:
-                    colliding_items.setdefault(conflict, []).append(existing_item)
-
-        return colliding_items
 
     @property
     def thermocycler_present(self) -> bool:

--- a/api/src/opentrons/protocols/geometry/deck.py
+++ b/api/src/opentrons/protocols/geometry/deck.py
@@ -53,6 +53,9 @@ class Deck(UserDict):
             for idx in range(12)
         }
         self._highest_z = 0.0
+        # TODO(mc, 2022-06-17): move deck type selection
+        # (and maybe deck definition loading) out of this constructor
+        # to decouple from config (and environment) reading / loading
         self._definition = load_deck(deck_type(), DEFAULT_DECK_DEFINITION_VERSION)
         self._load_fixtures()
         self._thermocycler_present = False

--- a/api/src/opentrons/protocols/geometry/deck.py
+++ b/api/src/opentrons/protocols/geometry/deck.py
@@ -61,15 +61,15 @@ class Deck(UserDict):
         for f in self._definition["locations"]["fixtures"]:
             slot_name = self._check_name(f["slot"])  # type: ignore
             # TODO(mc, 2022-06-15): this loads the fixed trash as an instance of
-            # opentrons.protocol_api.labware.Labware instance
-            # However, all other labware will be added to the Deck as instances of
-            # opentrons.protocols.context.labware.AbstractLabware
+            # `opentrons.protocol_api.labware.Labware`
+            # However, all other labware will be added to the `Deck` as instances of
+            # `opentrons.protocols.context.labware.AbstractLabware`
             # And modules will be added as instances of
-            # opentrons.protocols.geometry.module_geometry.ModuleGeometry
-            # This mix of public and private interaces as members of a public
-            # Deck interface is confusing and should be resolved.
-            # Id Deck is public, all items in a Deck should be instances of
-            # other public APIs.
+            # `opentrons.protocols.geometry.module_geometry.ModuleGeometry`
+            # This mix of public and private interfaces as members of a public
+            # `Deck` interface is confusing and should be resolved.
+            # If `Deck` is public, all items in a `Deck` should be
+            # instances of other public APIs.
             loaded_f = load_lw(
                 f["labware"], self.position_for(slot_name)  # type: ignore
             )

--- a/api/src/opentrons/protocols/geometry/deck_conflict.py
+++ b/api/src/opentrons/protocols/geometry/deck_conflict.py
@@ -146,6 +146,15 @@ def _create_restrictions(item: DeckItem, location: int) -> List[_DeckRestriction
             )
 
     if isinstance(item, HeaterShakerGeometry):
+        for covered_location in _get_adjacent_locations(location):
+            restrictions.append(
+                _NoModule(
+                    location=covered_location,
+                    source_item=item,
+                    source_location=location,
+                )
+            )
+
         for covered_location in _get_east_west_locations(location):
             restrictions.append(
                 _MaxHeight(
@@ -154,15 +163,6 @@ def _create_restrictions(item: DeckItem, location: int) -> List[_DeckRestriction
                     source_location=location,
                     max_height=item.MAX_X_ADJACENT_ITEM_HEIGHT,
                     allowed_labware=item.ALLOWED_ADJACENT_TALL_LABWARE,
-                )
-            )
-
-        for covered_location in _get_north_south_locations(location):
-            restrictions.append(
-                _NoModule(
-                    location=covered_location,
-                    source_item=item,
-                    source_location=location,
                 )
             )
 
@@ -208,10 +208,12 @@ def _get_east_west_locations(location: int) -> List[int]:
         return [location - 1]
 
 
-def _get_north_south_locations(location: int) -> List[int]:
+def _get_adjacent_locations(location: int) -> List[int]:
     if location in [1, 2, 3]:
-        return [location + 3]
+        north_south = [location + 3]
     elif location in [4, 5, 6, 7, 8, 9]:
-        return [location - 3, location + 3]
+        north_south = [location - 3, location + 3]
     else:
-        return [location - 3]
+        north_south = [location - 3]
+
+    return north_south + _get_east_west_locations(location)

--- a/api/src/opentrons/protocols/geometry/deck_conflict.py
+++ b/api/src/opentrons/protocols/geometry/deck_conflict.py
@@ -17,7 +17,7 @@ from opentrons.protocols.geometry.module_geometry import (
 from .deck_item import DeckItem
 
 
-FIXED_TRASH_SLOT: Final = 12
+_FIXED_TRASH_SLOT: Final = 12
 
 
 class _NotAllowed(NamedTuple):
@@ -61,7 +61,7 @@ class _NoModule(NamedTuple):
 class _FixedTrash(NamedTuple):
     """Only fixed-trash labware is allowed in this slot."""
 
-    location: int = FIXED_TRASH_SLOT
+    location: int = _FIXED_TRASH_SLOT
 
     def is_allowed(self, item: DeckItem) -> bool:
         if isinstance(item, AbstractLabware):
@@ -126,7 +126,7 @@ def check(
 def _create_restrictions(item: DeckItem, location: int) -> List[_DeckRestriction]:
     restrictions: List[_DeckRestriction] = []
 
-    if location != FIXED_TRASH_SLOT:
+    if location != _FIXED_TRASH_SLOT:
         restrictions.append(
             _NotAllowed(
                 location=location,

--- a/api/src/opentrons/protocols/geometry/deck_conflict.py
+++ b/api/src/opentrons/protocols/geometry/deck_conflict.py
@@ -1,0 +1,288 @@
+"""Check a deck layout for conflicts."""
+# TODO(mc, 2022-06-15): decouple this interface from DeckItem
+# (and ModuleGeometry) so it can be used in ProtocolEngine
+from typing import Dict, List, Mapping, NamedTuple, Optional, Union
+from typing_extensions import Final
+
+from opentrons.protocol_api.labware import Labware
+from opentrons.protocols.context.labware import AbstractLabware
+from opentrons.protocols.geometry.module_geometry import (
+    ModuleGeometry,
+    ThermocyclerGeometry,
+    HeaterShakerGeometry,
+)
+
+from .deck_item import DeckItem
+
+
+FIXED_TRASH_SLOT: Final = 12
+
+
+class _NotAllowed(NamedTuple):
+    """Nothing is allowed in this slot."""
+
+    source_item: DeckItem
+    source_location: int
+
+    def is_allowed(self, item: DeckItem) -> bool:
+        return False
+
+
+class _MaxHeight(NamedTuple):
+    """Nothing over a certain height is allowed in this slot."""
+
+    source_item: DeckItem
+    source_location: int
+    max_height: float
+    max_tip_rack_height: float
+
+    def is_allowed(self, item: DeckItem) -> bool:
+        height_limit = (
+            self.max_tip_rack_height
+            if (isinstance(item, AbstractLabware) and item.is_tiprack())
+            else self.max_height
+        )
+
+        return item.highest_z < height_limit
+
+
+class _NoModule(NamedTuple):
+    """A module is not allowed in this slot."""
+
+    source_item: DeckItem
+    source_location: int
+
+    def is_allowed(self, item: DeckItem) -> bool:
+        return not isinstance(item, ModuleGeometry)
+
+
+class _OnlyTrash(NamedTuple):
+    """Only fixed-trash labware is allowed in this slot."""
+
+    source_location: int = FIXED_TRASH_SLOT
+
+    def is_allowed(self, item: DeckItem) -> bool:
+        if isinstance(item, AbstractLabware):
+            return "fixedTrash" in item.get_quirks()
+        if isinstance(item, Labware):
+            return "fixedTrash" in item.quirks
+
+        return False
+
+
+_DeckRestriction = Union[_NotAllowed, _MaxHeight, _NoModule, _OnlyTrash]
+"""A restriction on what is allowed in a given slot."""
+
+
+class DeckConflictError(ValueError):
+    """Adding an item to the deck would cause a conflict."""
+
+
+class DeckItemConflictError(DeckConflictError):
+    """Adding an item to the deck would conflict with an existing item."""
+
+    def __init__(
+        self,
+        new_item: DeckItem,
+        new_location: int,
+        existing_item: DeckItem,
+        existing_location: int,
+    ) -> None:
+        super().__init__(
+            f"{existing_item.load_name} in slot {existing_location}"
+            f" prevents {new_item.load_name} from using slot {new_location}."
+        )
+
+
+def check(
+    existing_items: Mapping[int, DeckItem],
+    new_item: DeckItem,
+    new_location: int,
+) -> None:
+    """Check a deck layout for conflicts.
+
+    Args:
+        items: A list of location, item tuples to check.
+
+    Raises:
+        DeckConflictError: The given layout has at least one conflict.
+    """
+    restrictions: Dict[int, _DeckRestriction] = {FIXED_TRASH_SLOT: _OnlyTrash()}
+
+    # build restrictions driven by existing items
+    for location, item in existing_items.items():
+        restrictions = _create_restrictions(
+            item=item,
+            location=location,
+            existing_restrictions=restrictions,
+        )
+
+    # check new item against existing restrictions
+    _check_restrictions(
+        new_item=new_item,
+        new_location=new_location,
+        restrictions=restrictions,
+    )
+
+    # check new restrictions required by new item
+    # do not interfere with existing items
+    _create_restrictions(
+        item=new_item,
+        location=new_location,
+        existing_items=existing_items,
+        existing_restrictions=restrictions,
+    )
+
+
+def _create_restrictions(
+    item: DeckItem,
+    location: int,
+    existing_restrictions: Mapping[int, _DeckRestriction],
+    existing_items: Optional[Mapping[int, DeckItem]] = None,
+) -> Dict[int, _DeckRestriction]:
+    restrictions = dict(existing_restrictions)
+    existing_items = existing_items or {}
+
+    if location != FIXED_TRASH_SLOT:
+        restrictions[location] = _create_not_allowed_restriction(
+            existing_items=existing_items,
+            restriction_location=location,
+            source_item=item,
+            source_location=location,
+        )
+
+    if isinstance(item, ThermocyclerGeometry):
+        for covered_location in item.covered_slots:
+            restrictions[covered_location] = _create_not_allowed_restriction(
+                existing_items=existing_items,
+                restriction_location=covered_location,
+                source_item=item,
+                source_location=location,
+            )
+
+    if isinstance(item, HeaterShakerGeometry):
+        for covered_location in _get_east_west_locations(location):
+            restrictions[covered_location] = _create_max_height_restriction(
+                existing_items=existing_items,
+                restriction_location=covered_location,
+                source_item=item,
+                source_location=location,
+                max_height=item.MAX_ADJACENT_ITEM_HEIGHT,
+                max_tip_rack_height=item.MAX_ADJACENT_TIP_RACK_HEIGHT,
+            )
+
+        for covered_location in _get_north_south_locations(location):
+            restrictions[covered_location] = _create_no_module_restriction(
+                existing_items=existing_items,
+                restriction_location=covered_location,
+                source_item=item,
+                source_location=location,
+            )
+
+    return restrictions
+
+
+def _check_restrictions(
+    new_item: DeckItem,
+    new_location: int,
+    restrictions: Dict[int, _DeckRestriction],
+) -> None:
+    restriction = restrictions.get(new_location, None)
+
+    if restriction is not None and not restriction.is_allowed(new_item):
+        if isinstance(restriction, _OnlyTrash):
+            raise DeckConflictError(
+                f"Only fixed-trash is allowed in slot {restriction.source_location}"
+            )
+        else:
+            raise DeckItemConflictError(
+                new_item,
+                new_location,
+                restriction.source_item,
+                restriction.source_location,
+            )
+
+
+def _create_not_allowed_restriction(
+    existing_items: Mapping[int, DeckItem],
+    restriction_location: int,
+    source_item: DeckItem,
+    source_location: int,
+) -> _NotAllowed:
+    restriction = _NotAllowed(source_item=source_item, source_location=source_location)
+    existing_item = existing_items.get(restriction_location)
+
+    if existing_item is not None and not restriction.is_allowed(existing_item):
+        raise DeckItemConflictError(
+            new_item=source_item,
+            new_location=source_location,
+            existing_item=existing_items[restriction_location],
+            existing_location=restriction_location,
+        )
+
+    return restriction
+
+
+def _create_max_height_restriction(
+    existing_items: Mapping[int, DeckItem],
+    restriction_location: int,
+    source_item: DeckItem,
+    source_location: int,
+    max_height: float,
+    max_tip_rack_height: float,
+) -> _MaxHeight:
+    restriction = _MaxHeight(
+        source_item=source_item,
+        source_location=source_location,
+        max_height=max_height,
+        max_tip_rack_height=max_tip_rack_height,
+    )
+    existing_item = existing_items.get(restriction_location)
+
+    if existing_item is not None and not restriction.is_allowed(existing_item):
+        raise DeckItemConflictError(
+            new_item=source_item,
+            new_location=source_location,
+            existing_item=existing_items[restriction_location],
+            existing_location=restriction_location,
+        )
+
+    return restriction
+
+
+def _create_no_module_restriction(
+    existing_items: Mapping[int, DeckItem],
+    restriction_location: int,
+    source_item: DeckItem,
+    source_location: int,
+) -> _NoModule:
+    restriction = _NoModule(source_item=source_item, source_location=source_location)
+    existing_item = existing_items.get(restriction_location)
+
+    if existing_item is not None and not restriction.is_allowed(existing_item):
+        raise DeckItemConflictError(
+            new_item=source_item,
+            new_location=source_location,
+            existing_item=existing_items[restriction_location],
+            existing_location=restriction_location,
+        )
+
+    return restriction
+
+
+def _get_east_west_locations(location: int) -> List[int]:
+    if location in [1, 4, 7, 10]:
+        return [location + 1]
+    elif location in [2, 5, 8, 11]:
+        return [location - 1, location + 1]
+    else:
+        return [location - 1]
+
+
+def _get_north_south_locations(location: int) -> List[int]:
+    if location in [1, 2, 3]:
+        return [location + 3]
+    elif location in [4, 5, 6, 7, 8, 9]:
+        return [location - 3, location + 3]
+    else:
+        return [location - 3]

--- a/api/src/opentrons/protocols/geometry/module_geometry.py
+++ b/api/src/opentrons/protocols/geometry/module_geometry.py
@@ -17,6 +17,7 @@ from opentrons import types
 from opentrons.protocols.context.protocol_api.labware import LabwareImplementation
 
 from opentrons_shared_data import module
+from opentrons_shared_data.labware.dev_types import LabwareUri
 
 from opentrons.drivers.types import HeaterShakerLabwareLatchStatus
 
@@ -336,8 +337,31 @@ class ThermocyclerGeometry(ModuleGeometry):
 class HeaterShakerGeometry(ModuleGeometry):
     """Class holding the state of a heater-shaker's physical geometry."""
 
-    MAX_ADJACENT_ITEM_HEIGHT = 53.0
-    MAX_ADJACENT_TIP_RACK_HEIGHT = 70.0
+    # TODO(mc, 2022-06-16): move these constants to the module definition
+    MAX_X_ADJACENT_ITEM_HEIGHT = 53.0
+    """Maximum height of an adjacent item in the x-direction.
+
+    This value selected to avoid interference
+    with the heater-shaker's labware latch.
+
+    For background, see: https://github.com/Opentrons/opentrons/issues/10316
+    """
+
+    ALLOWED_ADJACENT_TALL_LABWARE = [
+        LabwareUri("opentrons/opentrons_96_filtertiprack_10ul/1"),
+        LabwareUri("opentrons/opentrons_96_filtertiprack_200ul/1"),
+        LabwareUri("opentrons/opentrons_96_filtertiprack_20ul/1"),
+        LabwareUri("opentrons/opentrons_96_tiprack_10ul/1"),
+        LabwareUri("opentrons/opentrons_96_tiprack_20ul/1"),
+        LabwareUri("opentrons/opentrons_96_tiprack_300ul/1"),
+    ]
+    """URI's of labware that are allowed to exceed the height limit above.
+
+    These labware do not take up the full with of the slot
+    in the area that would interfere with the labware latch.
+
+    For background, see: https://github.com/Opentrons/opentrons/issues/10316
+    """
 
     def __init__(
         self,

--- a/api/src/opentrons/protocols/geometry/module_geometry.py
+++ b/api/src/opentrons/protocols/geometry/module_geometry.py
@@ -10,7 +10,6 @@ import functools
 import logging
 import re
 from typing import Mapping, Optional, Union, TYPE_CHECKING
-from typing_extensions import Final
 
 import numpy as np
 import jsonschema  # type: ignore[import]
@@ -337,8 +336,8 @@ class ThermocyclerGeometry(ModuleGeometry):
 class HeaterShakerGeometry(ModuleGeometry):
     """Class holding the state of a heater-shaker's physical geometry."""
 
-    MAX_ADJACENT_ITEM_HEIGHT: Final = 53.0
-    MAX_ADJACENT_TIP_RACK_HEIGHT: Final = 70.0
+    MAX_ADJACENT_ITEM_HEIGHT = 53.0
+    MAX_ADJACENT_TIP_RACK_HEIGHT = 70.0
 
     def __init__(
         self,

--- a/api/src/opentrons/protocols/geometry/module_geometry.py
+++ b/api/src/opentrons/protocols/geometry/module_geometry.py
@@ -10,6 +10,7 @@ import functools
 import logging
 import re
 from typing import Mapping, Optional, Union, TYPE_CHECKING
+from typing_extensions import Final
 
 import numpy as np
 import jsonschema  # type: ignore[import]
@@ -335,6 +336,9 @@ class ThermocyclerGeometry(ModuleGeometry):
 
 class HeaterShakerGeometry(ModuleGeometry):
     """Class holding the state of a heater-shaker's physical geometry."""
+
+    MAX_ADJACENT_ITEM_HEIGHT: Final = 53.0
+    MAX_ADJACENT_TIP_RACK_HEIGHT: Final = 70.0
 
     def __init__(
         self,

--- a/api/tests/opentrons/protocols/geometry/test_deck.py
+++ b/api/tests/opentrons/protocols/geometry/test_deck.py
@@ -117,3 +117,5 @@ def test_item_collisions(
 
     with pytest.raises(deck_conflict.DeckConflictError, match="oh no"):
         subject[7] = module_item
+
+    assert subject[7] is None

--- a/api/tests/opentrons/protocols/geometry/test_deck.py
+++ b/api/tests/opentrons/protocols/geometry/test_deck.py
@@ -1,0 +1,119 @@
+"""Tests for the opentrons.protocols.geometry.Deck interface."""
+from typing import Any
+
+import pytest
+from decoy import Decoy
+
+from opentrons.hardware_control.modules import ModuleType
+from opentrons.protocols.geometry import deck_conflict
+from opentrons.protocols.geometry.deck import Deck
+from opentrons.protocols.geometry.deck_item import DeckItem
+from opentrons.protocols.geometry.module_geometry import ModuleGeometry
+
+
+@pytest.fixture(autouse=True)
+def mock_deck_conflict_check(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock out the deck conflict checker."""
+    mock_check = decoy.mock(func=deck_conflict.check)
+    monkeypatch.setattr(deck_conflict, "check", mock_check)
+
+
+@pytest.fixture
+def subject() -> Deck:
+    """Get a Deck test subject."""
+    return Deck()
+
+
+@pytest.mark.parametrize("slot_number", range(1, 12))
+def test_slot_names(decoy: Decoy, slot_number: int, subject: Deck) -> None:
+    """Ensure item get/set/delete works with both strs and ints."""
+    deck_item = decoy.mock(cls=DeckItem)
+    decoy.when(deck_item.highest_z).then_return(42)
+
+    slot_name = str(slot_number)
+
+    subject[slot_number] = deck_item
+    assert subject[slot_number] is deck_item
+    assert subject[slot_name] is deck_item
+
+    del subject[slot_number]
+    assert subject[slot_number] is None
+    assert subject[slot_name] is None
+
+    subject[slot_name] = deck_item
+    assert subject[slot_number] is deck_item
+    assert subject[slot_name] is deck_item
+
+    del subject[slot_name]
+    assert subject[slot_number] is None
+    assert subject[slot_name] is None
+
+
+@pytest.mark.parametrize("bad_slot", [0, 13, "0", "13", "hello world"])
+def test_invalid_slot_names(decoy: Decoy, bad_slot: Any, subject: Deck) -> None:
+    with pytest.raises(ValueError, match="Unknown slot"):
+        subject[bad_slot]
+
+    with pytest.raises(ValueError, match="Unknown slot"):
+        subject[bad_slot] = decoy.mock(cls=DeckItem)
+
+
+def test_highest_z(decoy: Decoy, subject: Deck) -> None:
+    item_10 = decoy.mock(cls=DeckItem)
+    decoy.when(item_10.highest_z).then_return(10)
+
+    item_100 = decoy.mock(cls=DeckItem)
+    decoy.when(item_100.highest_z).then_return(100)
+
+    del subject[12]
+    assert subject.highest_z == 0
+
+    subject[1] = item_10
+    assert subject.highest_z == 10
+
+    subject[2] = item_100
+    assert subject.highest_z == 100
+
+    decoy.when(item_100.highest_z).then_return(50)
+    subject.recalculate_high_z()
+    assert subject.highest_z == 50
+
+    del subject[1]
+    assert subject.highest_z == 50
+
+    del subject[2]
+    assert subject.highest_z == 0
+
+
+def test_item_collisions(
+    decoy: Decoy,
+    subject: Deck,
+) -> None:
+    labware_item = decoy.mock(cls=DeckItem)
+    decoy.when(labware_item.highest_z).then_return(42)
+
+    module_item = decoy.mock(cls=ModuleGeometry)
+    decoy.when(module_item.module_type).then_return(ModuleType.THERMOCYCLER)
+    decoy.when(module_item.highest_z).then_return(42)
+
+    subject["4"] = labware_item
+    decoy.verify(
+        deck_conflict.check(
+            existing_items={12: subject.get_fixed_trash()},  # type: ignore[dict-item]
+            new_location=4,
+            new_item=labware_item,
+        ),
+        times=1,
+    )
+    assert subject[4] == labware_item
+
+    decoy.when(
+        deck_conflict.check(
+            existing_items={4: labware_item, 12: subject.get_fixed_trash()},  # type: ignore[dict-item]
+            new_location=7,
+            new_item=module_item,
+        )
+    ).then_raise(deck_conflict.DeckConflictError("oh no"))
+
+    with pytest.raises(deck_conflict.DeckConflictError, match="oh no"):
+        subject[7] = module_item

--- a/api/tests/opentrons/protocols/geometry/test_deck.py
+++ b/api/tests/opentrons/protocols/geometry/test_deck.py
@@ -49,7 +49,7 @@ def test_slot_names(decoy: Decoy, slot_number: int, subject: Deck) -> None:
     assert subject[slot_name] is None
 
 
-@pytest.mark.parametrize("bad_slot", [0, 13, "0", "13", "hello world"])
+@pytest.mark.parametrize("bad_slot", [0, 13, 1.0, "0", "13", "1.0", "hello world"])
 def test_invalid_slot_names(decoy: Decoy, bad_slot: Any, subject: Deck) -> None:
     with pytest.raises(ValueError, match="Unknown slot"):
         subject[bad_slot]

--- a/api/tests/opentrons/protocols/geometry/test_deck_conflict.py
+++ b/api/tests/opentrons/protocols/geometry/test_deck_conflict.py
@@ -1,0 +1,381 @@
+"""Tests for opentrons.protocols.geometry.deck_conflict."""
+import pytest
+from decoy import Decoy
+
+from opentrons.protocol_api.labware import Labware
+from opentrons.protocols.geometry.deck_item import DeckItem
+from opentrons.protocols.geometry.module_geometry import (
+    ModuleGeometry,
+    ThermocyclerGeometry,
+    HeaterShakerGeometry,
+)
+from opentrons.protocols.context.labware import AbstractLabware
+
+from opentrons.protocols.geometry.deck_conflict import DeckConflictError, check
+
+
+def test_empty_no_conflict(decoy: Decoy) -> None:
+    """It should not raise on empty input."""
+    item = decoy.mock(cls=DeckItem)
+    check(existing_items={}, new_item=item, new_location=1)
+
+
+def test_no_multiple_locations(decoy: Decoy) -> None:
+    """It should not allow two items in the same slot."""
+    item_1 = decoy.mock(cls=DeckItem)
+    item_2 = decoy.mock(cls=DeckItem)
+
+    decoy.when(item_1.load_name).then_return("some_item_1")
+    decoy.when(item_2.load_name).then_return("some_item_2")
+
+    with pytest.raises(
+        DeckConflictError,
+        match="some_item_1 in slot 1 prevents some_item_2 from using slot 1",
+    ):
+        check(existing_items={1: item_1}, new_item=item_2, new_location=1)
+
+
+def test_only_trash_in_12(decoy: Decoy) -> None:
+    """It should only allow trash labware in slot 12."""
+    trash_labware = decoy.mock(cls=Labware)
+    trash_labware_impl = decoy.mock(cls=AbstractLabware)
+    not_trash = decoy.mock(cls=DeckItem)
+
+    decoy.when(trash_labware.quirks).then_return(["fixedTrash"])
+    decoy.when(trash_labware_impl.get_quirks()).then_return(["fixedTrash"])
+
+    check(existing_items={}, new_item=trash_labware, new_location=12)
+    check(existing_items={}, new_item=trash_labware_impl, new_location=12)
+
+    with pytest.raises(
+        DeckConflictError, match="Only fixed-trash is allowed in slot 12"
+    ):
+        check(existing_items={}, new_item=not_trash, new_location=12)
+
+
+def test_trash_override(decoy: Decoy) -> None:
+    """It should only the trash labware to be replaced"""
+    trash_labware = decoy.mock(cls=Labware)
+    trash_labware_impl = decoy.mock(cls=AbstractLabware)
+
+    decoy.when(trash_labware.quirks).then_return(["fixedTrash"])
+    decoy.when(trash_labware_impl.get_quirks()).then_return(["fixedTrash"])
+
+    check(
+        existing_items={12: trash_labware},
+        new_item=trash_labware_impl,
+        new_location=12,
+    )
+
+
+@pytest.mark.parametrize("labware_location", [8, 10, 11])
+def test_no_labware_when_thermocycler(decoy: Decoy, labware_location: int) -> None:
+    """It should reject labware if a thermocycler is placed."""
+    thermocycler = decoy.mock(cls=ThermocyclerGeometry)
+    labware = decoy.mock(cls=DeckItem)
+
+    decoy.when(thermocycler.load_name).then_return("some_thermocycler")
+    decoy.when(thermocycler.covered_slots).then_return({7, 8, 10, 11})
+    decoy.when(labware.load_name).then_return("some_labware")
+
+    with pytest.raises(
+        DeckConflictError,
+        match=(
+            "some_thermocycler in slot 7 prevents"
+            f" some_labware from using slot {labware_location}"
+        ),
+    ):
+        check(
+            existing_items={7: thermocycler},
+            new_location=labware_location,
+            new_item=labware,
+        )
+
+    with pytest.raises(
+        DeckConflictError,
+        match=(
+            f"some_labware in slot {labware_location}"
+            " prevents some_thermocycler from using slot 7"
+        ),
+    ):
+        check(
+            existing_items={labware_location: labware},
+            new_location=7,
+            new_item=thermocycler,
+        )
+
+
+@pytest.mark.parametrize(
+    ("heater_shaker_location", "labware_location"),
+    [
+        (1, 2),
+        (2, 1),
+        (2, 3),
+        (3, 2),
+        (4, 5),
+        (5, 4),
+        (5, 6),
+        (6, 5),
+        (7, 8),
+        (8, 7),
+        (8, 9),
+        (9, 8),
+        (10, 11),
+        (11, 10),
+    ],
+)
+def test_labware_when_heater_shaker(
+    decoy: Decoy,
+    heater_shaker_location: int,
+    labware_location: int,
+) -> None:
+    """It should allow short labware east and west if a heater-shaker is placed."""
+    heater_shaker = decoy.mock(cls=HeaterShakerGeometry)
+    labware = decoy.mock(cls=DeckItem)
+
+    decoy.when(heater_shaker.load_name).then_return("some_heater_shaker")
+    decoy.when(heater_shaker.MAX_ADJACENT_ITEM_HEIGHT).then_return(10)
+    decoy.when(labware.load_name).then_return("some_labware")
+    decoy.when(labware.highest_z).then_return(9.9)
+
+    check(
+        existing_items={heater_shaker_location: heater_shaker},
+        new_location=labware_location,
+        new_item=labware,
+    )
+    check(
+        existing_items={labware_location: labware},
+        new_location=heater_shaker_location,
+        new_item=heater_shaker,
+    )
+
+
+@pytest.mark.parametrize(
+    ("heater_shaker_location", "labware_location"),
+    [
+        (1, 2),
+        (2, 1),
+        (2, 3),
+        (3, 2),
+        (4, 5),
+        (5, 4),
+        (5, 6),
+        (6, 5),
+        (7, 8),
+        (8, 7),
+        (8, 9),
+        (9, 8),
+        (10, 11),
+        (11, 10),
+    ],
+)
+def test_no_labware_when_heater_shaker(
+    decoy: Decoy,
+    heater_shaker_location: int,
+    labware_location: int,
+) -> None:
+    """It should not allow tall labware east and west if a heater-shaker is placed."""
+    heater_shaker = decoy.mock(cls=HeaterShakerGeometry)
+    labware = decoy.mock(cls=DeckItem)
+
+    decoy.when(heater_shaker.load_name).then_return("some_heater_shaker")
+    decoy.when(heater_shaker.MAX_ADJACENT_ITEM_HEIGHT).then_return(10)
+    decoy.when(labware.load_name).then_return("some_labware")
+    decoy.when(labware.highest_z).then_return(10.1)
+
+    with pytest.raises(
+        DeckConflictError,
+        match=(
+            f"some_heater_shaker in slot {heater_shaker_location}"
+            f" prevents some_labware from using slot {labware_location}"
+        ),
+    ):
+        check(
+            existing_items={heater_shaker_location: heater_shaker},
+            new_location=labware_location,
+            new_item=labware,
+        )
+
+    with pytest.raises(
+        DeckConflictError,
+        match=(
+            f"some_labware in slot {labware_location}"
+            f" prevents some_heater_shaker from using slot {heater_shaker_location}"
+        ),
+    ):
+        check(
+            existing_items={labware_location: labware},
+            new_location=heater_shaker_location,
+            new_item=heater_shaker,
+        )
+
+
+@pytest.mark.parametrize(
+    ("heater_shaker_location", "other_module_location"),
+    [
+        (1, 4),
+        (2, 5),
+        (3, 6),
+        (4, 1),
+        (4, 7),
+        (5, 2),
+        (5, 8),
+        (6, 3),
+        (6, 9),
+        (7, 4),
+        (7, 10),
+        (8, 5),
+        (8, 11),
+        (9, 6),
+    ],
+)
+def test_no_modules_when_heater_shaker(
+    decoy: Decoy,
+    heater_shaker_location: int,
+    other_module_location: int,
+) -> None:
+    """It should not other modules north and south of the H/S.
+
+    All modules are taller than the H/S height restriction,
+    so this test only checks modules specifically in N/S.
+    """
+    heater_shaker = decoy.mock(cls=HeaterShakerGeometry)
+    other_module = decoy.mock(cls=ModuleGeometry)
+
+    decoy.when(heater_shaker.load_name).then_return("some_heater_shaker")
+    decoy.when(other_module.load_name).then_return("some_other_module")
+
+    with pytest.raises(
+        DeckConflictError,
+        match=(
+            f"some_heater_shaker in slot {heater_shaker_location}"
+            f" prevents some_other_module from using slot {other_module_location}"
+        ),
+    ):
+        check(
+            existing_items={heater_shaker_location: heater_shaker},
+            new_location=other_module_location,
+            new_item=other_module,
+        )
+
+    with pytest.raises(
+        DeckConflictError,
+        match=(
+            f"some_other_module in slot {other_module_location}"
+            f" prevents some_heater_shaker from using slot {heater_shaker_location}"
+        ),
+    ):
+        check(
+            existing_items={other_module_location: other_module},
+            new_location=heater_shaker_location,
+            new_item=heater_shaker,
+        )
+
+
+@pytest.mark.parametrize(
+    ("heater_shaker_location", "tip_rack_location"),
+    [
+        (1, 2),
+        (2, 1),
+        (2, 3),
+        (3, 2),
+        (4, 5),
+        (5, 4),
+        (5, 6),
+        (6, 5),
+        (7, 8),
+        (8, 7),
+        (8, 9),
+        (9, 8),
+        (10, 11),
+        (11, 10),
+    ],
+)
+def test_tip_rack_when_heater_shaker(
+    decoy: Decoy,
+    heater_shaker_location: int,
+    tip_rack_location: int,
+) -> None:
+    """It should allow short tip racks east and west if a heater-shaker is placed."""
+    heater_shaker = decoy.mock(cls=HeaterShakerGeometry)
+    tip_rack = decoy.mock(cls=AbstractLabware)
+
+    decoy.when(heater_shaker.load_name).then_return("some_heater_shaker")
+    decoy.when(heater_shaker.MAX_ADJACENT_ITEM_HEIGHT).then_return(10)
+    decoy.when(heater_shaker.MAX_ADJACENT_TIP_RACK_HEIGHT).then_return(12)
+    decoy.when(tip_rack.load_name).then_return("some_tip_rack")
+    decoy.when(tip_rack.highest_z).then_return(11)
+    decoy.when(tip_rack.is_tiprack()).then_return(True)
+
+    check(
+        existing_items={heater_shaker_location: heater_shaker},
+        new_location=tip_rack_location,
+        new_item=tip_rack,
+    )
+    check(
+        existing_items={tip_rack_location: tip_rack},
+        new_location=heater_shaker_location,
+        new_item=heater_shaker,
+    )
+
+
+@pytest.mark.parametrize(
+    ("heater_shaker_location", "tip_rack_location"),
+    [
+        (1, 2),
+        (2, 1),
+        (2, 3),
+        (3, 2),
+        (4, 5),
+        (5, 4),
+        (5, 6),
+        (6, 5),
+        (7, 8),
+        (8, 7),
+        (8, 9),
+        (9, 8),
+        (10, 11),
+        (11, 10),
+    ],
+)
+def test_no_tip_rack_when_heater_shaker(
+    decoy: Decoy,
+    heater_shaker_location: int,
+    tip_rack_location: int,
+) -> None:
+    """It should not allow tall tip racks east and west if a heater-shaker is placed."""
+    heater_shaker = decoy.mock(cls=HeaterShakerGeometry)
+    tip_rack = decoy.mock(cls=AbstractLabware)
+
+    decoy.when(heater_shaker.load_name).then_return("some_heater_shaker")
+    decoy.when(heater_shaker.MAX_ADJACENT_ITEM_HEIGHT).then_return(10)
+    decoy.when(heater_shaker.MAX_ADJACENT_TIP_RACK_HEIGHT).then_return(12)
+    decoy.when(tip_rack.load_name).then_return("some_tip_rack")
+    decoy.when(tip_rack.highest_z).then_return(13)
+    decoy.when(tip_rack.is_tiprack()).then_return(True)
+
+    with pytest.raises(
+        DeckConflictError,
+        match=(
+            f"some_heater_shaker in slot {heater_shaker_location}"
+            f" prevents some_tip_rack from using slot {tip_rack_location}"
+        ),
+    ):
+        check(
+            existing_items={heater_shaker_location: heater_shaker},
+            new_location=tip_rack_location,
+            new_item=tip_rack,
+        )
+
+    with pytest.raises(
+        DeckConflictError,
+        match=(
+            f"some_tip_rack in slot {tip_rack_location}"
+            f" prevents some_heater_shaker from using slot {heater_shaker_location}"
+        ),
+    ):
+        check(
+            existing_items={tip_rack_location: tip_rack},
+            new_location=heater_shaker_location,
+            new_item=heater_shaker,
+        )

--- a/api/tests/opentrons/protocols/geometry/test_deck_conflict.py
+++ b/api/tests/opentrons/protocols/geometry/test_deck_conflict.py
@@ -64,7 +64,7 @@ def test_only_trash_in_12(decoy: Decoy) -> None:
 
 
 def test_trash_override(decoy: Decoy) -> None:
-    """It should only the trash labware to be replaced"""
+    """It should allow the trash labware to be replaced with another trash labware"""
     trash_labware = decoy.mock(cls=Labware)
     trash_labware_impl = decoy.mock(cls=AbstractLabware)
 

--- a/shared-data/python/opentrons_shared_data/labware/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/labware/dev_types.py
@@ -4,9 +4,10 @@ types in this file by and large require the use of typing_extensions.
 this module shouldn't be imported unless typing.TYPE_CHECKING is true.
 """
 from typing import Dict, List, Union
-
 from typing_extensions import Literal, TypedDict
 
+# TODO(mc, 2022-06-16): move here, shouldn't be in pipettes
+from ..pipette.dev_types import LabwareUri as LabwareUri  # noqa: F401
 
 LabwareDisplayCategory = Union[
     Literal["tipRack"],

--- a/shared-data/python/opentrons_shared_data/pipette/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/pipette/dev_types.py
@@ -8,8 +8,9 @@ from typing import Dict, List, NewType, Union
 
 from typing_extensions import Literal, TypedDict
 
-
+# TODO(mc, 2022-06-16): move to labware.dev_types
 LabwareUri = NewType("LabwareUri", str)
+
 # Explicit listing of pipette names because we don't frequently get new ones
 PipetteName = Union[
     Literal["p10_single"],


### PR DESCRIPTION
## Overview

This PR adds deck restrictions when placing Heater-Shaker modules. Closes #10316.

I had been working with placement restrictions in `Deck` for #9419, and I found the existing logic to be a little fraught and not well covered by unit tests. Since it wasn't going to scale to heater shaker, I wrote a new deck conflict checking module: `opentrons.protocols.geometry.deck_conflict`.

## Changelog

### Main events

- Ensure tall items (including modules, which are tall) cannot be present east/west of a H/S
    - Allow tip-racks to be present with a different height limit that is greater than the height of a P300 tip rack but less than the height of a P1000 tip rack
- Ensure modules cannot be present north/south of a H/S

### Other stuff

- Ensure only fixed-trash can be loaded into slot 12
    - Previous implementation allowed any labware to be loaded into slot 12 if a fixed trash was already present, which is all the time because that's how the `Deck` is initialized

## Review requests

I tried something a little different to inject the deck conflict check logic into `Deck` so it would play a little nicer with how the code was already set up. I didn't want old code to prevent me from using `Decoy` here, so I went the `monkeypatch` route rather than creating a `DeckConflictChecker` class with a static method. I've been looking for an excuse to try this injection method out, and I don't completely hate it.

Also, I used a lot of `Decoy` mocks in this one! All the subclasses of `DeckItem` are not pure value objects / prohibitively difficult to create in isolation. I decided the isolation from that mess that `Decoy` mocks brought outweighed the fact that there is logic (as opposed to arrangement) under test in `deck_conflict`.

Let me know what you think about these tests!

## Risk assessment

Medium. Existing code was non-trivial, not well covered by unit tests, and buggy. That being said, we've got a lot of high-level tests that exercise this code (and caught bugs in my implementation while I was developing).
