### PR TITLE
fix(app): fix protocol run event tracking

### DIFF
--- a/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
@@ -21,6 +21,7 @@ import { MenuItem } from '../../atoms/MenuList/MenuItem'
 import { useRunControls } from '../RunTimeControl/hooks'
 import { RUN_LOG_WINDOW_SIZE } from './constants'
 import { DownloadRunLogToast } from './DownloadRunLogToast'
+import { useTrackEvent } from '../../redux/analytics'
 import type { Run } from '@opentrons/api-client'
 
 export interface HistoricalProtocolRunOverflowMenuProps {
@@ -111,10 +112,16 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
     setShowDownloadRunLogToast(true)
     closeOverflowMenu(e)
   }
+  const trackEvent = useTrackEvent()
   const { reset } = useRunControls(runId, onResetSuccess)
   const { deleteRun } = useDeleteRunMutation()
 
-  const handleDelete: React.MouseEventHandler<HTMLButtonElement> = e => {
+  const handleResetClick = (): void => {
+    trackEvent({ name: 'runAgain', properties: {} })
+    reset()
+  }
+
+  const handleDeleteClick: React.MouseEventHandler<HTMLButtonElement> = e => {
     e.preventDefault()
     e.stopPropagation()
     deleteRun(runId)
@@ -140,7 +147,7 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
         </MenuItem>
       </NavLink>
       <MenuItem
-        onClick={reset}
+        onClick={handleResetClick}
         disabled={robotIsBusy}
         data-testid={`RecentProtocolRun_OverflowMenu_rerunNow`}
       >
@@ -154,7 +161,7 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
       </MenuItem>
       <Divider />
       <MenuItem
-        onClick={handleDelete}
+        onClick={handleDeleteClick}
         data-testid={`RecentProtocolRun_OverflowMenu_deleteRun`}
       >
         {t('delete_run')}

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -229,7 +229,24 @@ export function ProtocolRunHeader({
       setShowIsShakingModal(true)
     } else if (isHeaterShakerInProtocol && !isShaking) {
       confirmAttachment()
-    } else play()
+    } else {
+      if (runStatus === RUN_STATUS_IDLE) {
+        trackEvent({ name: 'runStart', properties: {} })
+      } else {
+        trackEvent({ name: 'runResume', properties: {} })
+      }
+      play()
+    }
+  }
+
+  const handlePauseButtonClick = (): void => {
+    trackEvent({ name: 'runPause', properties: {} })
+    pause()
+  }
+
+  const handleResetButtonClick = (): void => {
+    trackEvent({ name: 'runAgain', properties: {} })
+    reset()
   }
 
   const isRunControlButtonDisabled =
@@ -259,12 +276,12 @@ export function ProtocolRunHeader({
     case RUN_STATUS_RUNNING:
       buttonIconName = 'pause'
       buttonText = t('pause_run')
-      handleButtonClick = pause
+      handleButtonClick = handlePauseButtonClick
       break
     case RUN_STATUS_STOP_REQUESTED:
       buttonIconName = null
       buttonText = t('canceling_run')
-      handleButtonClick = reset
+      handleButtonClick = handleResetButtonClick
       break
     case RUN_STATUS_STOPPED:
     case RUN_STATUS_FINISHING:
@@ -272,7 +289,7 @@ export function ProtocolRunHeader({
     case RUN_STATUS_SUCCEEDED:
       buttonIconName = 'play'
       buttonText = t('run_again')
-      handleButtonClick = reset
+      handleButtonClick = handleResetButtonClick
       break
   }
 

--- a/app/src/organisms/RunDetails/ConfirmCancelModal.tsx
+++ b/app/src/organisms/RunDetails/ConfirmCancelModal.tsx
@@ -6,9 +6,10 @@ import {
   NewSecondaryBtn,
   SPACING_3,
 } from '@opentrons/components'
+import { useStopRunMutation } from '@opentrons/react-api-client'
 
 import { Portal } from '../../App/portal'
-import { useStopRunMutation } from '@opentrons/react-api-client'
+import { useTrackEvent } from '../../redux/analytics'
 
 export interface ConfirmCancelModalProps {
   onClose: () => unknown
@@ -21,8 +22,13 @@ export function ConfirmCancelModal(
   const { onClose, runId } = props
   const { stopRun } = useStopRunMutation()
   const { t } = useTranslation('run_details')
+  const trackEvent = useTrackEvent()
 
   const cancel = (): void => {
+    if (runId != null) {
+      trackEvent({ name: 'runCancel', properties: {} })
+      stopRun(runId)
+    }
     runId != null && stopRun(runId)
     onClose()
   }

--- a/app/src/organisms/RunDetails/ConfirmCancelModal.tsx
+++ b/app/src/organisms/RunDetails/ConfirmCancelModal.tsx
@@ -29,7 +29,6 @@ export function ConfirmCancelModal(
       trackEvent({ name: 'runCancel', properties: {} })
       stopRun(runId)
     }
-    runId != null && stopRun(runId)
     onClose()
   }
 

--- a/app/src/organisms/RunDetails/index.tsx
+++ b/app/src/organisms/RunDetails/index.tsx
@@ -38,11 +38,13 @@ import {
   useCurrentRunId,
   useIsProtocolRunLoaded,
 } from '../ProtocolUpload/hooks'
+import { useTrackEvent } from '../../redux/analytics'
 import { getConnectedRobotName } from '../../redux/robot/selectors'
 import type { State } from '../../redux/types'
 
 export function RunDetails(): JSX.Element | null {
   const { t } = useTranslation(['run_details', 'shared'])
+  const trackEvent = useTrackEvent()
   const robotName = useSelector<State>(getConnectedRobotName)
   const runId = useCurrentRunId()
   const { displayName } = useProtocolDetails()
@@ -71,6 +73,7 @@ export function RunDetails(): JSX.Element | null {
   ] = React.useState<boolean>(false)
 
   const handleCancelClick = (): void => {
+    trackEvent({ name: 'runPause', properties: {} })
     pause()
     setShowConfirmCancelModal(true)
   }


### PR DESCRIPTION
# Overview
Add event tracking to run protocol events (pause, resume, start, cancel, run again, finish)
Closes #10749
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- added tracking to run protocol events

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Confirm that events fire. I've added a few questions to this draft regarding event properties and the finish run event.
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
