### PR TITLE
feat(protocol-designer): add HS announcement modal

### DIFF
--- a/protocol-designer/src/components/modals/AnnouncementModal/announcements.tsx
+++ b/protocol-designer/src/components/modals/AnnouncementModal/announcements.tsx
@@ -120,4 +120,27 @@ export const announcements: Announcement[] = [
       </>
     ),
   },
+  {
+    announcementKey: 'heaterShakerSupport',
+    image: (
+      <div className={styles.modules_diagrams_row}>
+        <img
+          className={styles.modules_diagram}
+          src={require('../../../images/modules/heatershaker.png')}
+        />
+      </div>
+    ),
+    heading: "We've updated the Protocol Designer",
+    message: (
+      <>
+        <p>
+          The Opentrons Protocol Designer now supports our Heater-Shaker Module!
+        </p>
+        <p>
+          Protocols using a Heater-Shaker Module require Opentrons App version
+          <strong> 6.1+ </strong> to run.
+        </p>
+      </>
+    ),
+  },
 ]

--- a/protocol-designer/src/components/modals/AnnouncementModal/announcements.tsx
+++ b/protocol-designer/src/components/modals/AnnouncementModal/announcements.tsx
@@ -137,7 +137,7 @@ export const announcements: Announcement[] = [
           The Opentrons Protocol Designer now supports our Heater-Shaker Module!
         </p>
         <p>
-          Protocols using a Heater-Shaker Module require Opentrons App version
+          All protocols now require Opentrons App version
           <strong> 6.1+ </strong> to run.
         </p>
       </>


### PR DESCRIPTION
# Overview
This PR updates the PD announcement modal to show off HS support!

closes #9973

# Changelog

- Update announcement modal for HS support


# Review requests
- clear your browser's local storage. in your console type in `localStorage.clear()`
- refresh, you should see the new announcement modal that matches the design in the ticket (#9973)

# Risk assessment

Low
