### PR TITLE
feat(protocol-designer): bump PD version to 6.0

### DIFF
--- a/protocol-designer/webpack.config.js
+++ b/protocol-designer/webpack.config.js
@@ -16,7 +16,7 @@ const PROTOCOL_DESIGNER_ENV_VAR_PREFIX = 'OT_PD_'
 // Also remove all OT_PD_VERSION env vars, the version should always
 // be gleaned from the package.json
 
-const OT_PD_VERSION = '5.2.6'
+const OT_PD_VERSION = '6.0.0'
 const OT_PD_BUILD_DATE = new Date().toUTCString()
 
 const JS_ENTRY = path.join(__dirname, 'src/index.tsx')


### PR DESCRIPTION
# Overview
This PR bumps the PD version to 6.0

closes #9853

# Changelog

- Bump PD version to 6.0

# Review requests
Navigate to the settings tab, the PD version should be 6.0

# Risk assessment

Low
