### PR TITLE
feat(protocol-designer): update export modal

### DIFF
--- a/protocol-designer/cypress/integration/newProtocol.spec.js
+++ b/protocol-designer/cypress/integration/newProtocol.spec.js
@@ -138,13 +138,13 @@ describe('Desktop Navigation', () => {
         cy.contains('Your protocol has no steps').should('not.exist')
       })
 
-      it('displays a warning modal saying the protocol needs to be run on robot stack version 5.1 or higher', () => {
+      it('displays a warning modal saying the protocol needs to be run on robot stack version 6.1 or higher', () => {
         cy.get('button').contains('Export').click()
         // skip the first modal we checked for (your protocol has no steps)
         cy.get('button').contains('CONTINUE WITH EXPORT').click()
         // check that the robot stack version modal starts
         cy.contains(
-          'This protocol uses settings that can only run on app and robot server version 5.1 or higher'
+          'This protocol uses settings that can only run on app and robot server version 6.1 or higher'
         ).should('exist')
       })
 

--- a/protocol-designer/cypress/integration/newProtocol.spec.js
+++ b/protocol-designer/cypress/integration/newProtocol.spec.js
@@ -144,7 +144,7 @@ describe('Desktop Navigation', () => {
         cy.get('button').contains('CONTINUE WITH EXPORT').click()
         // check that the robot stack version modal starts
         cy.contains(
-          'This protocol uses settings that can only run on app and robot server version 6.1 or higher'
+          'This protocol can only run on app and robot server version 6.1 or higher'
         ).should('exist')
       })
 

--- a/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
+++ b/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
@@ -33,7 +33,6 @@ export interface Props {
   pipettesOnDeck: InitialDeckSetup['pipettes']
   modulesOnDeck: InitialDeckSetup['modules']
   savedStepForms: SavedStepFormState
-  schemaVersion: number
 }
 
 interface WarningContent {
@@ -143,9 +142,9 @@ function getWarningContent({
 export const v6WarningContent: JSX.Element = (
   <div>
     <p>
-      {i18n.t(`alert.hint.export_v6_protocol_5_10.body1`)}{' '}
-      <strong>{i18n.t(`alert.hint.export_v6_protocol_5_10.body2`)}</strong>
-      {i18n.t(`alert.hint.export_v6_protocol_5_10.body3`)}
+      {i18n.t(`alert.hint.export_v6_protocol_6_10.body1`)}{' '}
+      <strong>{i18n.t(`alert.hint.export_v6_protocol_6_10.body2`)}</strong>
+      {i18n.t(`alert.hint.export_v6_protocol_6_10.body3`)}
     </p>
   </div>
 )
@@ -160,7 +159,6 @@ export function FileSidebar(props: Props): JSX.Element {
     modulesOnDeck,
     pipettesOnDeck,
     savedStepForms,
-    schemaVersion,
   } = props
   const [
     showExportWarningModal,
@@ -204,7 +202,7 @@ export function FileSidebar(props: Props): JSX.Element {
     content: React.ReactNode
   } => {
     return {
-      hintKey: 'export_v6_protocol_5_10',
+      hintKey: 'export_v6_protocol_6_10',
       content: v6WarningContent,
     }
   }
@@ -241,13 +239,8 @@ export function FileSidebar(props: Props): JSX.Element {
                 children: 'CONTINUE WITH EXPORT',
                 className: modalStyles.long_button,
                 onClick: () => {
-                  if (schemaVersion > 3) {
-                    setShowExportWarningModal(false)
-                    setShowBlockingHint(true)
-                  } else {
-                    onDownload()
-                    setShowExportWarningModal(false)
-                  }
+                  setShowExportWarningModal(false)
+                  setShowBlockingHint(true)
                 },
               },
             ]}
@@ -273,11 +266,9 @@ export function FileSidebar(props: Props): JSX.Element {
                 if (hasWarning) {
                   resetScrollElements()
                   setShowExportWarningModal(true)
-                } else if (schemaVersion > 3) {
+                } else {
                   resetScrollElements()
                   setShowBlockingHint(true)
-                } else {
-                  onDownload()
                 }
               }}
               disabled={!canDownload}

--- a/protocol-designer/src/components/FileSidebar/__tests__/FileSidebar.test.tsx
+++ b/protocol-designer/src/components/FileSidebar/__tests__/FileSidebar.test.tsx
@@ -46,7 +46,6 @@ describe('FileSidebar', () => {
       pipettesOnDeck: {},
       modulesOnDeck: {},
       savedStepForms: {},
-      schemaVersion: 3,
     }
 
     commands = [
@@ -119,16 +118,6 @@ describe('FileSidebar', () => {
     expect(downloadButton.prop('disabled')).toEqual(true)
   })
 
-  it('export button exports protocol when no errors', () => {
-    // @ts-expect-error(sa, 2021-6-22): props.fileData might be null
-    props.fileData.commands = commands
-    const wrapper = shallow(<FileSidebar {...props} />)
-    const downloadButton = wrapper.find(PrimaryButton).at(0)
-    downloadButton.simulate('click')
-
-    expect(props.onDownload).toHaveBeenCalled()
-  })
-
   it('warning modal is shown when export is clicked with no command', () => {
     const wrapper = shallow(<FileSidebar {...props} />)
     const downloadButton = wrapper.find(PrimaryButton).at(0)
@@ -137,10 +126,6 @@ describe('FileSidebar', () => {
 
     expect(alertModal).toHaveLength(1)
     expect(alertModal.prop('heading')).toEqual('Your protocol has no steps')
-
-    const continueButton = alertModal.dive().find(OutlineButton).at(1)
-    continueButton.simulate('click')
-    expect(props.onDownload).toHaveBeenCalled()
   })
 
   it('warning modal is shown when export is clicked with unused pipette', () => {
@@ -163,10 +148,6 @@ describe('FileSidebar', () => {
     expect(alertModal.html()).not.toContain(
       pipettesOnDeck.pipetteLeftId.spec.displayName
     )
-
-    const continueButton = alertModal.dive().find(OutlineButton).at(1)
-    continueButton.simulate('click')
-    expect(props.onDownload).toHaveBeenCalled()
   })
 
   it('warning modal is shown when export is clicked with unused module', () => {
@@ -183,10 +164,6 @@ describe('FileSidebar', () => {
     expect(alertModal).toHaveLength(1)
     expect(alertModal.prop('heading')).toEqual('Unused module')
     expect(alertModal.html()).toContain('Magnetic module')
-
-    const continueButton = alertModal.dive().find(OutlineButton).at(1)
-    continueButton.simulate('click')
-    expect(props.onDownload).toHaveBeenCalled()
   })
 
   it('warning modal is shown when export is clicked with unused module and pipette', () => {
@@ -211,10 +188,6 @@ describe('FileSidebar', () => {
     expect(alertModal.html()).not.toContain(
       pipettesOnDeck.pipetteLeftId.spec.displayName
     )
-
-    const continueButton = alertModal.dive().find(OutlineButton).at(1)
-    continueButton.simulate('click')
-    expect(props.onDownload).toHaveBeenCalled()
   })
 
   it('blocking hint is shown', () => {
@@ -228,13 +201,13 @@ describe('FileSidebar', () => {
 
     mockUseBlockingHint.mockReturnValue(<MockHintComponent />)
 
-    const wrapper = mount(<FileSidebar {...props} schemaVersion={5} />)
+    const wrapper = mount(<FileSidebar {...props} />)
 
     expect(wrapper.exists(MockHintComponent)).toEqual(true)
     // Before save button is clicked, enabled should be false
     expect(mockUseBlockingHint).toHaveBeenNthCalledWith(1, {
       enabled: false,
-      hintKey: 'export_v6_protocol_5_10',
+      hintKey: 'export_v6_protocol_6_10',
       content: v6WarningContent,
       handleCancel: expect.any(Function),
       handleContinue: expect.any(Function),
@@ -246,7 +219,7 @@ describe('FileSidebar', () => {
     // After save button is clicked, enabled should be true
     expect(mockUseBlockingHint).toHaveBeenLastCalledWith({
       enabled: true,
-      hintKey: 'export_v6_protocol_5_10',
+      hintKey: 'export_v6_protocol_6_10',
       content: v6WarningContent,
       handleCancel: expect.any(Function),
       handleContinue: expect.any(Function),

--- a/protocol-designer/src/components/FileSidebar/index.ts
+++ b/protocol-designer/src/components/FileSidebar/index.ts
@@ -19,7 +19,6 @@ interface SP {
   pipettesOnDeck: InitialDeckSetup['pipettes']
   modulesOnDeck: InitialDeckSetup['modules']
   savedStepForms: SavedStepFormState
-  schemaVersion: 6
 }
 export const FileSidebar = connect(
   mapStateToProps,
@@ -41,7 +40,6 @@ function mapStateToProps(state: BaseState): SP {
     // Ignore clicking 'CREATE NEW' button in these cases
     _canCreateNew: !selectors.getNewProtocolModal(state),
     _hasUnsavedChanges: loadFileSelectors.getHasUnsavedChanges(state),
-    schemaVersion: 6,
   }
 }
 
@@ -59,7 +57,6 @@ function mergeProps(
     pipettesOnDeck,
     modulesOnDeck,
     savedStepForms,
-    schemaVersion,
   } = stateProps
   const { dispatch } = dispatchProps
   return {
@@ -80,6 +77,5 @@ function mergeProps(
     pipettesOnDeck,
     modulesOnDeck,
     savedStepForms,
-    schemaVersion,
   }
 }

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -51,7 +51,7 @@
     },
     "export_v6_protocol_6_10": {
       "title": "Robot and app update may be required",
-      "body1": "This protocol uses settings that can only run on app and robot server version",
+      "body1": "This protocol can only run on app and robot server version",
       "body2": "6.1 or higher",
       "body3": ". Please ensure your OT-2 is updated to the correct version."
     },

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -49,10 +49,10 @@
       "title": "Missing labware",
       "body": "Your module has no labware on it. We recommend you add labware before proceeding."
     },
-    "export_v6_protocol_5_10": {
+    "export_v6_protocol_6_10": {
       "title": "Robot and app update may be required",
       "body1": "This protocol uses settings that can only run on app and robot server version",
-      "body2": "5.1 or higher",
+      "body2": "6.1 or higher",
       "body3": ". Please ensure your OT-2 is updated to the correct version."
     },
     "change_magnet_module_model": {

--- a/protocol-designer/src/tutorial/index.ts
+++ b/protocol-designer/src/tutorial/index.ts
@@ -9,7 +9,7 @@ type HintKey =  // normal hints
   | 'protocol_can_enter_batch_edit'
   // blocking hints
   | 'custom_labware_with_modules'
-  | 'export_v6_protocol_5_10'
+  | 'export_v6_protocol_6_10'
   | 'change_magnet_module_model'
 // DEPRECATED HINTS (keep a record to avoid name collisions with old persisted dismissal states)
 // 'export_v4_protocol'


### PR DESCRIPTION
# Overview

This PR updates the PD export modal to indicate that robot stack version 6.1 is required to run exported PD protocols. 
closes #9987

# Changelog

- Update export modal

# Risk assessment

Low
