### PR TITLE
fix(app-shell): use existing logic to feed custom labware to analysis

### DIFF
--- a/app-shell/src/protocol-analysis/executeAnalyzeCli.ts
+++ b/app-shell/src/protocol-analysis/executeAnalyzeCli.ts
@@ -5,9 +5,8 @@ const log = createLogger('protocol-analysis/executeAnalyzeCli')
 
 export function executeAnalyzeCli(
   pythonPath: string,
-  sourcePath: string,
   outputPath: string,
-  ...auxSourcePaths: string[]
+  sourcePaths: string[]
 ): Promise<void> {
   return execa(pythonPath, [
     '-m',

--- a/app-shell/src/protocol-analysis/executeAnalyzeCli.ts
+++ b/app-shell/src/protocol-analysis/executeAnalyzeCli.ts
@@ -13,8 +13,7 @@ export function executeAnalyzeCli(
     'opentrons.cli',
     'analyze',
     `--json-output=${outputPath}`,
-    sourcePath,
-    ...auxSourcePaths,
+    ...sourcePaths,
   ])
     .then(output => {
       log.debug('Output from opentrons.cli', { output })

--- a/app-shell/src/protocol-analysis/getPythonPath.ts
+++ b/app-shell/src/protocol-analysis/getPythonPath.ts
@@ -19,6 +19,7 @@ export function selectPythonPath(pythonOverride: string | null): void {
       pythonOverride,
       path.join(pythonOverride, 'bin/python3'),
       path.join(pythonOverride, 'python.exe'),
+      path.join(pythonOverride, 'scripts/python.exe'),
       ...candidates,
     ]
   }

--- a/app-shell/src/protocol-analysis/index.ts
+++ b/app-shell/src/protocol-analysis/index.ts
@@ -1,8 +1,7 @@
-import path from 'path'
-import globby from 'globby'
 import { createLogger } from '../log'
 import { getConfig } from '../config'
 
+import { getValidLabwareFilePaths } from '../labware'
 import { selectPythonPath, getPythonPath } from './getPythonPath'
 import { executeAnalyzeCli } from './executeAnalyzeCli'
 import { writeFailedAnalysis } from './writeFailedAnalysis'
@@ -18,19 +17,11 @@ export function analyzeProtocolSource(
   sourcePath: string,
   outputPath: string
 ): Promise<void> {
-  const auxLabwareDirContents = globby.sync(
-    path.posix.join(getConfig().labware.directory, '**')
-  )
-
-  return getPythonPath()
-    .then(pythonPath =>
-      executeAnalyzeCli(
-        pythonPath,
-        sourcePath,
-        outputPath,
-        ...auxLabwareDirContents
-      )
-    )
+  return Promise.all([getPythonPath(), getValidLabwareFilePaths()])
+    .then(([pythonPath, customLabwarePaths]) => {
+      const sourcePaths = [sourcePath, ...customLabwarePaths]
+      return executeAnalyzeCli(pythonPath, outputPath, sourcePaths)
+    })
     .then(() => {
       log.debug(`Analysis of ${sourcePath} written to ${outputPath}`)
     })


### PR DESCRIPTION
## Overview

This PR replaces custom labware file fetching logic that wasn't working on windows with existing logic from `app-shell/src/labware` to feed custom labware files to app-side protocol analysis.

Fixes #10798 

## Changelog

- fix(app-shell): use existing logic to feed custom labware to analysis

## Review requests

- [ ] Analysis with custom labware works on Windows
- [ ] Analysis with custom labware works on macOS
- [ ] Analysis with custom labware works on Linux

## Risk assessment

Low. Bug fix, existing custom labware file finding logic is very battle-tested in prod.