### PR TITLE
feat(protocol-designer): export TC load module commands with slot 7

### DIFF
--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -9,6 +9,7 @@ import {
   FIXED_TRASH_ID,
   OT2_STANDARD_DECKID,
   OT2_STANDARD_MODEL,
+  THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import { getFileMetadata } from './fileFields'
 import { getInitialRobotState, getRobotStateTimeline } from './commands'
@@ -247,6 +248,10 @@ export const createFile: Selector<ProtocolFile> = createSelector(
         module: typeof initialRobotState.modules[keyof typeof initialRobotState.modules],
         moduleId: string
       ): LoadModuleCreateCommand => {
+        // translate the magic TC location string to 7 so PE can read it
+        if (module.moduleState.type === THERMOCYCLER_MODULE_TYPE) {
+          module.slot = '7'
+        }
         const loadModuleCommand = {
           key: uuid(),
           commandType: 'loadModule' as const,


### PR DESCRIPTION

# Overview
This PR makes sure that PD exports TC load module commands with slot 7 (rather than the magic `span7_8_10_11` we use elsewhere. This is a hard requirement for PE.

closes #10808

# Changelog

- Export TC load module commands with slot 7

# Review requests
Export a protocol with a TC
Inspect the load module commands in the JSON file, the slot name the TC is in should be '7'

# Risk assessment

Low
