### PR TITLE
style(app): fixed the svg sizing on the protocol card

### DIFF
--- a/app/src/molecules/DeckThumbnail/index.tsx
+++ b/app/src/molecules/DeckThumbnail/index.tsx
@@ -43,7 +43,7 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
     <RobotWorkSpace
       deckLayerBlocklist={deckSetupLayerBlocklist}
       deckDef={deckDef}
-      viewBox="-112 -100 560 500"
+      viewBox="-50 -20 550 480"
     >
       {({ deckSlotsById }) =>
         map<DeckSlot>(deckSlotsById, (slot: DeckSlot, slotId: string) => {

--- a/app/src/molecules/DeckThumbnail/index.tsx
+++ b/app/src/molecules/DeckThumbnail/index.tsx
@@ -43,7 +43,7 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
     <RobotWorkSpace
       deckLayerBlocklist={deckSetupLayerBlocklist}
       deckDef={deckDef}
-      viewBox="-50 -20 550 480"
+      viewBox="-80 -20 550 480"
     >
       {({ deckSlotsById }) =>
         map<DeckSlot>(deckSlotsById, (slot: DeckSlot, slotId: string) => {

--- a/app/src/molecules/DeckThumbnail/index.tsx
+++ b/app/src/molecules/DeckThumbnail/index.tsx
@@ -43,7 +43,7 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
     <RobotWorkSpace
       deckLayerBlocklist={deckSetupLayerBlocklist}
       deckDef={deckDef}
-      viewBox="-90 -40 560 500"
+      viewBox="-112 -100 560 500"
     >
       {({ deckSlotsById }) =>
         map<DeckSlot>(deckSlotsById, (slot: DeckSlot, slotId: string) => {


### PR DESCRIPTION
# Overview

Fixed the svg sizing on the protocol card

PR will resolve #10555

# Changelog

- Fixed the viewport sizing for the svg on the protocol card.

Before: Protocol Card & Protocol Detail Page
![Screen Shot 2022-06-21 at 2 38 26 PM](https://user-images.githubusercontent.com/102996638/174873863-c8f77eea-d564-4c5c-a08e-78ec8706166d.png)

![Screen Shot 2022-06-21 at 2 38 40 PM](https://user-images.githubusercontent.com/102996638/174873894-a57b10ce-793b-4d59-af32-9f9d65fd1b3c.png)

After:
![Screen Shot 2022-06-21 at 2 33 27 PM](https://user-images.githubusercontent.com/102996638/174873013-7a7fbe6c-6612-4ae9-8d0f-8f83c983acfc.png)

![Screen Shot 2022-06-21 at 2 34 46 PM](https://user-images.githubusercontent.com/102996638/174873227-4110eee3-bb37-4bb2-8910-6fe3b32f02f9.png)

# Review requests

Low

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
