### PR TITLE
refactor(protocol-designer): fix title bar in new protocol modal

### DIFF
--- a/protocol-designer/src/containers/TitleBar.css
+++ b/protocol-designer/src/containers/TitleBar.css
@@ -14,7 +14,6 @@
 .sticky_bar {
   position: sticky;
   top: 0;
-  z-index: 101;
 }
 
 .title_wrapper {


### PR DESCRIPTION
# Overview
Quick one liner so that the title bar does not show up on top of the new protocol modal.

closes #10844

screenshot below:

![Screen Shot 2022-06-21 at 12 46 07 PM](https://user-images.githubusercontent.com/5788529/174854088-7b891483-706f-4052-ae5a-110407791491.png)

# Review requests

Make sure new file modal renders on top of the title bar. Also take a look at the liquids tab to verify you can still see the title bar.
# Risk assessment
Low
