### PR TITLE
fix(app): pipette card banners and historical protocol run protocolNames render fix

### DIFF
--- a/app/src/organisms/Devices/ModuleCard/index.tsx
+++ b/app/src/organisms/Devices/ModuleCard/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
-import { last } from 'lodash'
+import last from 'lodash/last'
 import {
   Box,
   Flex,

--- a/app/src/organisms/Devices/PipetteCard/PipetteSettingsSlideout.tsx
+++ b/app/src/organisms/Devices/PipetteCard/PipetteSettingsSlideout.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { last } from 'lodash'
+import last from 'lodash/last'
 import { useDispatch, useSelector } from 'react-redux'
 import { Flex, useInterval } from '@opentrons/components'
 import { PipetteModelSpecs } from '@opentrons/shared-data'

--- a/app/src/organisms/Devices/PipetteCard/__tests__/PipetteCard.test.tsx
+++ b/app/src/organisms/Devices/PipetteCard/__tests__/PipetteCard.test.tsx
@@ -6,6 +6,7 @@ import { LEFT, RIGHT } from '@opentrons/shared-data'
 import { i18n } from '../../../../i18n'
 import { getHasCalibrationBlock } from '../../../../redux/config'
 import { Banner } from '../../../../atoms/Banner'
+import { useDispatchApiRequest } from '../../../../redux/robot-api'
 import { AskForCalibrationBlockModal } from '../../../CalibrateTipLength'
 import { useCalibratePipetteOffset } from '../../../CalibratePipetteOffset/useCalibratePipetteOffset'
 import {
@@ -23,6 +24,7 @@ import {
 import { mockDeckCalData } from '../../../../redux/calibration/__fixtures__'
 
 import type { DeckCalibrationInfo } from '../../../../redux/calibration/api-types'
+import type { DispatchApiRequestType } from '../../../../redux/robot-api'
 
 jest.mock('../PipetteOverflowMenu')
 jest.mock('../../../../redux/config')
@@ -31,6 +33,7 @@ jest.mock('../../../CalibrateTipLength')
 jest.mock('../../hooks')
 jest.mock('../../../../atoms/Banner')
 jest.mock('../AboutPipetteSlideout')
+jest.mock('../../../../redux/robot-api')
 
 const mockPipetteOverflowMenu = PipetteOverflowMenu as jest.MockedFunction<
   typeof PipetteOverflowMenu
@@ -52,6 +55,9 @@ const mockUseDeckCalibrationData = useDeckCalibrationData as jest.MockedFunction
 >
 const mockAboutPipettesSlideout = AboutPipetteSlideout as jest.MockedFunction<
   typeof AboutPipetteSlideout
+>
+const mockUseDispatchApiRequest = useDispatchApiRequest as jest.MockedFunction<
+  typeof useDispatchApiRequest
 >
 const mockBanner = Banner as jest.MockedFunction<typeof Banner>
 
@@ -82,9 +88,11 @@ const mockBadDeckCal: DeckCalibrationInfo = {
 const mockRobotName = 'mockRobotName'
 describe('PipetteCard', () => {
   let startWizard: any
+  let dispatchApiRequest: DispatchApiRequestType
 
   beforeEach(() => {
     startWizard = jest.fn()
+    dispatchApiRequest = jest.fn()
     when(mockAboutPipettesSlideout).mockReturnValue(
       <div>mock about slideout</div>
     )
@@ -102,6 +110,10 @@ describe('PipetteCard', () => {
     when(mockAskForCalibrationBlockModal).mockReturnValue(
       <div>Mock AskForCalibrationBlockModal</div>
     )
+    when(mockUseDispatchApiRequest).mockReturnValue([
+      dispatchApiRequest,
+      ['id'],
+    ])
   })
   afterEach(() => {
     jest.resetAllMocks()

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -141,183 +141,168 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
   }
 
   return (
-    <>
-      {isFetching ? null : (
-        <Flex
-          backgroundColor={COLORS.background}
-          borderRadius={BORDERS.radiusSoftCorners}
-          marginBottom={SPACING.spacing3}
-          marginX={SPACING.spacing2}
-          width={'100%'}
-          data-testid={`PipetteCard_${pipetteName}`}
-        >
-          {showChangePipette && (
-            <ChangePipette
-              robotName={robotName}
-              mount={mount}
-              closeModal={() => setChangePipette(false)}
-            />
-          )}
-          {showSlideout && pipetteInfo != null && pipetteId != null && (
-            <PipetteSettingsSlideout
-              robotName={robotName}
-              pipetteName={pipetteInfo.displayName}
-              onCloseClick={() => setShowSlideout(false)}
-              isExpanded={true}
-              pipetteId={pipetteId}
-            />
-          )}
-          {PipetteOffsetCalibrationWizard}
-          {showAboutSlideout && pipetteInfo != null && pipetteId != null && (
-            <AboutPipetteSlideout
-              pipetteId={pipetteId}
-              pipetteName={pipetteInfo.displayName}
-              onCloseClick={() => setShowAboutSlideout(false)}
-              isExpanded={true}
-            />
-          )}
-          {showCalBlockModal && (
-            <Portal level="top">
-              <AskForCalibrationBlockModal
-                onResponse={hasBlockModalResponse => {
-                  startPipetteOffsetCalibrationBlockModal(hasBlockModalResponse)
-                }}
-                titleBarTitle={t('protocol_setup:pipette_offset_cal')}
-                closePrompt={() => setShowCalBlockModal(false)}
-              />
-            </Portal>
-          )}
-          <Box padding={`${SPACING.spacing4} ${SPACING.spacing3}`} width="100%">
-            <Flex flexDirection={DIRECTION_ROW} paddingRight={SPACING.spacing3}>
-              <Flex alignItems={ALIGN_START}>
-                {pipetteInfo === null ? null : (
-                  <InstrumentDiagram
-                    pipetteSpecs={pipetteInfo}
-                    mount={mount}
-                    transform="scale(0.3)"
-                    size="3.125rem"
-                    transformOrigin="20% -10%"
-                  />
-                )}
-              </Flex>
-              <Flex
-                flexDirection={DIRECTION_COLUMN}
-                paddingLeft={SPACING.spacing3}
-              >
-                {!isDeckCalibrated &&
-                pipetteOffsetCalibration == null &&
-                pipetteInfo != null &&
-                showBanner &&
-                !isFetching ? (
-                  <Flex paddingBottom={SPACING.spacing2}>
-                    <Banner
-                      type="error"
-                      onCloseClick={() => setShowBanner(false)}
-                    >
-                      {t('deck_cal_missing')}
-                    </Banner>
-                  </Flex>
-                ) : null}
-                {isDeckCalibrated &&
-                pipetteOffsetCalibration == null &&
-                pipetteInfo != null &&
-                showBanner &&
-                !isFetching ? (
-                  <Flex paddingBottom={SPACING.spacing2}>
-                    <Banner
-                      type="error"
-                      onCloseClick={() => setShowBanner(false)}
-                    >
-                      <Flex flexDirection={DIRECTION_COLUMN}>
-                        {t('pipette_offset_calibration_needed')}
-                        <Btn
-                          textAlign={ALIGN_START}
-                          fontSize={TYPOGRAPHY.fontSizeP}
-                          textDecoration={TEXT_DECORATION_UNDERLINE}
-                          onClick={handleCalibrate}
-                        >
-                          {t('calibrate_now')}
-                        </Btn>
-                      </Flex>
-                    </Banner>
-                  </Flex>
-                ) : null}
-                {isDeckCalibrated && badCalibration && showBanner ? (
-                  <Flex paddingBottom={SPACING.spacing2}>
-                    <Banner
-                      type="warning"
-                      onCloseClick={() => setShowBanner(false)}
-                    >
-                      <Flex flexDirection={DIRECTION_COLUMN}>
-                        {t('pipette_cal_recommended')}
-                        <Btn
-                          textAlign={ALIGN_START}
-                          fontSize={TYPOGRAPHY.fontSizeP}
-                          textDecoration={TEXT_DECORATION_UNDERLINE}
-                          onClick={handleCalibrate}
-                        >
-                          {t('recalibrate_now')}
-                        </Btn>
-                      </Flex>
-                    </Banner>
-                  </Flex>
-                ) : null}
-                <StyledText
-                  textTransform={TEXT_TRANSFORM_UPPERCASE}
-                  color={COLORS.darkGrey}
-                  fontWeight={FONT_WEIGHT_REGULAR}
-                  fontSize={FONT_SIZE_CAPTION}
-                  paddingBottom={SPACING.spacing2}
-                  data-testid={`PipetteCard_mount_${pipetteName}`}
-                >
-                  {t('mount', {
-                    side: mount === LEFT ? t('left') : t('right'),
-                  })}
-                </StyledText>
-                <Flex
-                  paddingBottom={SPACING.spacing2}
-                  data-testid={`PipetteCard_display_name_${pipetteName}`}
-                >
-                  <StyledText fontSize={TYPOGRAPHY.fontSizeP}>
-                    {pipetteName ?? t('empty')}
-                  </StyledText>
-                </Flex>
-              </Flex>
-            </Flex>
-          </Box>
-          <Box
-            alignSelf={ALIGN_START}
-            padding={SPACING.spacing2}
-            data-testid={`PipetteCard_overflow_btn_${pipetteName}`}
-          >
-            <OverflowBtn
-              aria-label="overflow"
-              onClick={() => {
-                setShowOverflowMenu(
-                  prevShowOverflowMenu => !prevShowOverflowMenu
-                )
-              }}
-            />
-          </Box>
-          {showOverflowMenu && (
-            <Box
-              ref={pipetteOverflowWrapperRef}
-              data-testid={`PipetteCard_overflow_menu_${pipetteName}`}
-              onClick={() => setShowOverflowMenu(false)}
-            >
-              <PipetteOverflowMenu
-                pipetteName={pipetteName ?? t('empty')}
-                mount={mount}
-                handleChangePipette={handleChangePipette}
-                handleCalibrate={handleCalibrate}
-                handleSettingsSlideout={handleSettingsSlideout}
-                handleAboutSlideout={handleAboutSlideout}
-                isPipetteCalibrated={pipetteOffsetCalibration != null}
-              />
-            </Box>
-          )}
-        </Flex>
+    <Flex
+      backgroundColor={COLORS.background}
+      borderRadius={BORDERS.radiusSoftCorners}
+      marginBottom={SPACING.spacing3}
+      marginX={SPACING.spacing2}
+      width={'100%'}
+      data-testid={`PipetteCard_${pipetteName}`}
+    >
+      {showChangePipette && (
+        <ChangePipette
+          robotName={robotName}
+          mount={mount}
+          closeModal={() => setChangePipette(false)}
+        />
       )}
-    </>
+      {showSlideout && pipetteInfo != null && pipetteId != null && (
+        <PipetteSettingsSlideout
+          robotName={robotName}
+          pipetteName={pipetteInfo.displayName}
+          onCloseClick={() => setShowSlideout(false)}
+          isExpanded={true}
+          pipetteId={pipetteId}
+        />
+      )}
+      {PipetteOffsetCalibrationWizard}
+      {showAboutSlideout && pipetteInfo != null && pipetteId != null && (
+        <AboutPipetteSlideout
+          pipetteId={pipetteId}
+          pipetteName={pipetteInfo.displayName}
+          onCloseClick={() => setShowAboutSlideout(false)}
+          isExpanded={true}
+        />
+      )}
+      {showCalBlockModal && (
+        <Portal level="top">
+          <AskForCalibrationBlockModal
+            onResponse={hasBlockModalResponse => {
+              startPipetteOffsetCalibrationBlockModal(hasBlockModalResponse)
+            }}
+            titleBarTitle={t('protocol_setup:pipette_offset_cal')}
+            closePrompt={() => setShowCalBlockModal(false)}
+          />
+        </Portal>
+      )}
+      <Box padding={`${SPACING.spacing4} ${SPACING.spacing3}`} width="100%">
+        <Flex flexDirection={DIRECTION_ROW} paddingRight={SPACING.spacing3}>
+          <Flex alignItems={ALIGN_START}>
+            {pipetteInfo === null ? null : (
+              <InstrumentDiagram
+                pipetteSpecs={pipetteInfo}
+                mount={mount}
+                transform="scale(0.3)"
+                size="3.125rem"
+                transformOrigin="20% -10%"
+              />
+            )}
+          </Flex>
+          <Flex flexDirection={DIRECTION_COLUMN} paddingLeft={SPACING.spacing3}>
+            {!isDeckCalibrated &&
+            pipetteOffsetCalibration == null &&
+            pipetteInfo != null &&
+            showBanner &&
+            !isFetching ? (
+              <Flex paddingBottom={SPACING.spacing2}>
+                <Banner type="error" onCloseClick={() => setShowBanner(false)}>
+                  {t('deck_cal_missing')}
+                </Banner>
+              </Flex>
+            ) : null}
+            {isDeckCalibrated &&
+            pipetteOffsetCalibration == null &&
+            pipetteInfo != null &&
+            showBanner &&
+            !isFetching ? (
+              <Flex paddingBottom={SPACING.spacing2}>
+                <Banner type="error" onCloseClick={() => setShowBanner(false)}>
+                  <Flex flexDirection={DIRECTION_COLUMN}>
+                    {t('pipette_offset_calibration_needed')}
+                    <Btn
+                      textAlign={ALIGN_START}
+                      fontSize={TYPOGRAPHY.fontSizeP}
+                      textDecoration={TEXT_DECORATION_UNDERLINE}
+                      onClick={handleCalibrate}
+                    >
+                      {t('calibrate_now')}
+                    </Btn>
+                  </Flex>
+                </Banner>
+              </Flex>
+            ) : null}
+            {isDeckCalibrated && badCalibration && showBanner ? (
+              <Flex paddingBottom={SPACING.spacing2}>
+                <Banner
+                  type="warning"
+                  onCloseClick={() => setShowBanner(false)}
+                >
+                  <Flex flexDirection={DIRECTION_COLUMN}>
+                    {t('pipette_cal_recommended')}
+                    <Btn
+                      textAlign={ALIGN_START}
+                      fontSize={TYPOGRAPHY.fontSizeP}
+                      textDecoration={TEXT_DECORATION_UNDERLINE}
+                      onClick={handleCalibrate}
+                    >
+                      {t('recalibrate_now')}
+                    </Btn>
+                  </Flex>
+                </Banner>
+              </Flex>
+            ) : null}
+            <StyledText
+              textTransform={TEXT_TRANSFORM_UPPERCASE}
+              color={COLORS.darkGrey}
+              fontWeight={FONT_WEIGHT_REGULAR}
+              fontSize={FONT_SIZE_CAPTION}
+              paddingBottom={SPACING.spacing2}
+              data-testid={`PipetteCard_mount_${pipetteName}`}
+            >
+              {t('mount', {
+                side: mount === LEFT ? t('left') : t('right'),
+              })}
+            </StyledText>
+            <Flex
+              paddingBottom={SPACING.spacing2}
+              data-testid={`PipetteCard_display_name_${pipetteName}`}
+            >
+              <StyledText fontSize={TYPOGRAPHY.fontSizeP}>
+                {pipetteName ?? t('empty')}
+              </StyledText>
+            </Flex>
+          </Flex>
+        </Flex>
+      </Box>
+      <Box
+        alignSelf={ALIGN_START}
+        padding={SPACING.spacing2}
+        data-testid={`PipetteCard_overflow_btn_${pipetteName}`}
+      >
+        <OverflowBtn
+          aria-label="overflow"
+          onClick={() => {
+            setShowOverflowMenu(prevShowOverflowMenu => !prevShowOverflowMenu)
+          }}
+        />
+      </Box>
+      {showOverflowMenu && (
+        <Box
+          ref={pipetteOverflowWrapperRef}
+          data-testid={`PipetteCard_overflow_menu_${pipetteName}`}
+          onClick={() => setShowOverflowMenu(false)}
+        >
+          <PipetteOverflowMenu
+            pipetteName={pipetteName ?? t('empty')}
+            mount={mount}
+            handleChangePipette={handleChangePipette}
+            handleCalibrate={handleCalibrate}
+            handleSettingsSlideout={handleSettingsSlideout}
+            handleAboutSlideout={handleAboutSlideout}
+            isPipetteCalibrated={pipetteOffsetCalibration != null}
+          />
+        </Box>
+      )}
+    </Flex>
   )
 }

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -86,7 +86,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
   )
   const latestRequestId = last(requestIds)
   const isFetching = useSelector<State, boolean>(state =>
-    latestRequestId
+    latestRequestId != null
       ? getRequestById(state, latestRequestId)?.status === 'pending'
       : false
   )

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -20,13 +20,17 @@ import {
   Btn,
   TEXT_DECORATION_UNDERLINE,
 } from '@opentrons/components'
-import { LEFT } from '../../../redux/pipettes'
+import { fetchPipettes, LEFT } from '../../../redux/pipettes'
 import { OverflowBtn } from '../../../atoms/MenuList/OverflowBtn'
 import { Portal } from '../../../App/portal'
 import { StyledText } from '../../../atoms/text'
 import { getHasCalibrationBlock } from '../../../redux/config'
+import { useDispatchApiRequest } from '../../../redux/robot-api'
 import { Banner } from '../../../atoms/Banner'
-import { fetchPipetteOffsetCalibrations } from '../../../redux/calibration'
+import {
+  fetchCalibrationStatus,
+  fetchPipetteOffsetCalibrations,
+} from '../../../redux/calibration'
 import { ChangePipette } from '../../ChangePipette'
 import { useCalibratePipetteOffset } from '../../CalibratePipetteOffset/useCalibratePipetteOffset'
 import {
@@ -57,6 +61,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
   const [showOverflowMenu, setShowOverflowMenu] = React.useState(false)
   const { pipetteInfo, mount, robotName, pipetteId } = props
   const dispatch = useDispatch<Dispatch>()
+  const [dispatchRequest] = useDispatchApiRequest()
   const pipetteName = pipetteInfo?.displayName
   const pipetteOverflowWrapperRef = useOnClickOutside({
     onClickOutside: () => setShowOverflowMenu(false),
@@ -86,6 +91,16 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
     pipetteOffsetCalibration === null ? 1000 : FETCH_PIPETTE_CAL_MS,
     true
   )
+
+  
+  React.useEffect(() => {
+    dispatchRequest(fetchPipettes(robotName, true))
+    dispatchRequest(fetchCalibrationStatus(robotName))
+    dispatchRequest(fetchPipetteOffsetCalibrations(robotName))
+  }, [dispatchRequest, robotName])
+
+  console.log(pipetteOffsetCalibration)
+  console.log(isDeckCalibrated)
 
   const badCalibration = pipetteOffsetCalibration?.status.markedBad
 

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector, useDispatch } from 'react-redux'
+import last from 'lodash/last'
 import {
   Box,
   Flex,
@@ -25,7 +26,7 @@ import { OverflowBtn } from '../../../atoms/MenuList/OverflowBtn'
 import { Portal } from '../../../App/portal'
 import { StyledText } from '../../../atoms/text'
 import { getHasCalibrationBlock } from '../../../redux/config'
-import { useDispatchApiRequest } from '../../../redux/robot-api'
+import { getRequestById, useDispatchApiRequest } from '../../../redux/robot-api'
 import { Banner } from '../../../atoms/Banner'
 import {
   fetchCalibrationStatus,
@@ -45,7 +46,7 @@ import { AboutPipetteSlideout } from './AboutPipetteSlideout'
 
 import type { AttachedPipette, Mount } from '../../../redux/pipettes/types'
 import type { PipetteModelSpecs } from '@opentrons/shared-data'
-import type { Dispatch } from '../../../redux/types'
+import type { Dispatch, State } from '../../../redux/types'
 
 interface PipetteCardProps {
   pipetteInfo: PipetteModelSpecs | null
@@ -61,7 +62,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
   const [showOverflowMenu, setShowOverflowMenu] = React.useState(false)
   const { pipetteInfo, mount, robotName, pipetteId } = props
   const dispatch = useDispatch<Dispatch>()
-  const [dispatchRequest] = useDispatchApiRequest()
+  const [dispatchRequest, requestIds] = useDispatchApiRequest()
   const pipetteName = pipetteInfo?.displayName
   const pipetteOverflowWrapperRef = useOnClickOutside({
     onClickOutside: () => setShowOverflowMenu(false),
@@ -83,6 +84,12 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
     pipetteId,
     mount
   )
+  const latestRequestId = last(requestIds)
+  const isFetching = useSelector<State, boolean>(state =>
+    latestRequestId
+      ? getRequestById(state, latestRequestId)?.status === 'pending'
+      : false
+  )
 
   useInterval(
     () => {
@@ -92,15 +99,10 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
     true
   )
 
-  
   React.useEffect(() => {
     dispatchRequest(fetchPipettes(robotName, true))
     dispatchRequest(fetchCalibrationStatus(robotName))
-    dispatchRequest(fetchPipetteOffsetCalibrations(robotName))
   }, [dispatchRequest, robotName])
-
-  console.log(pipetteOffsetCalibration)
-  console.log(isDeckCalibrated)
 
   const badCalibration = pipetteOffsetCalibration?.status.markedBad
 
@@ -137,165 +139,185 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
   const handleSettingsSlideout = (): void => {
     setShowSlideout(true)
   }
+
   return (
-    <Flex
-      backgroundColor={COLORS.background}
-      borderRadius={BORDERS.radiusSoftCorners}
-      marginBottom={SPACING.spacing3}
-      marginX={SPACING.spacing2}
-      width={'100%'}
-      data-testid={`PipetteCard_${pipetteName}`}
-    >
-      {showChangePipette && (
-        <ChangePipette
-          robotName={robotName}
-          mount={mount}
-          closeModal={() => setChangePipette(false)}
-        />
-      )}
-      {showSlideout && pipetteInfo != null && pipetteId != null && (
-        <PipetteSettingsSlideout
-          robotName={robotName}
-          pipetteName={pipetteInfo.displayName}
-          onCloseClick={() => setShowSlideout(false)}
-          isExpanded={true}
-          pipetteId={pipetteId}
-        />
-      )}
-      {PipetteOffsetCalibrationWizard}
-      {showAboutSlideout && pipetteInfo != null && pipetteId != null && (
-        <AboutPipetteSlideout
-          pipetteId={pipetteId}
-          pipetteName={pipetteInfo.displayName}
-          onCloseClick={() => setShowAboutSlideout(false)}
-          isExpanded={true}
-        />
-      )}
-      {showCalBlockModal && (
-        <Portal level="top">
-          <AskForCalibrationBlockModal
-            onResponse={hasBlockModalResponse => {
-              startPipetteOffsetCalibrationBlockModal(hasBlockModalResponse)
-            }}
-            titleBarTitle={t('protocol_setup:pipette_offset_cal')}
-            closePrompt={() => setShowCalBlockModal(false)}
-          />
-        </Portal>
-      )}
-      <Box padding={`${SPACING.spacing4} ${SPACING.spacing3}`} width="100%">
-        <Flex flexDirection={DIRECTION_ROW} paddingRight={SPACING.spacing3}>
-          <Flex alignItems={ALIGN_START}>
-            {pipetteInfo === null ? null : (
-              <InstrumentDiagram
-                pipetteSpecs={pipetteInfo}
-                mount={mount}
-                transform="scale(0.3)"
-                size="3.125rem"
-                transformOrigin="20% -10%"
-              />
-            )}
-          </Flex>
-          <Flex flexDirection={DIRECTION_COLUMN} paddingLeft={SPACING.spacing3}>
-            {!isDeckCalibrated &&
-            pipetteOffsetCalibration == null &&
-            pipetteInfo != null &&
-            showBanner ? (
-              <Flex paddingBottom={SPACING.spacing2}>
-                <Banner type="error" onCloseClick={() => setShowBanner(false)}>
-                  {t('deck_cal_missing')}
-                </Banner>
-              </Flex>
-            ) : null}
-            {isDeckCalibrated &&
-            pipetteOffsetCalibration == null &&
-            pipetteInfo != null &&
-            showBanner ? (
-              <Flex paddingBottom={SPACING.spacing2}>
-                <Banner type="error" onCloseClick={() => setShowBanner(false)}>
-                  <Flex flexDirection={DIRECTION_COLUMN}>
-                    {t('pipette_offset_calibration_needed')}
-                    <Btn
-                      textAlign={ALIGN_START}
-                      fontSize={TYPOGRAPHY.fontSizeP}
-                      textDecoration={TEXT_DECORATION_UNDERLINE}
-                      onClick={handleCalibrate}
-                    >
-                      {t('calibrate_now')}
-                    </Btn>
-                  </Flex>
-                </Banner>
-              </Flex>
-            ) : null}
-            {isDeckCalibrated && badCalibration && showBanner ? (
-              <Flex paddingBottom={SPACING.spacing2}>
-                <Banner
-                  type="warning"
-                  onCloseClick={() => setShowBanner(false)}
-                >
-                  <Flex flexDirection={DIRECTION_COLUMN}>
-                    {t('pipette_cal_recommended')}
-                    <Btn
-                      textAlign={ALIGN_START}
-                      fontSize={TYPOGRAPHY.fontSizeP}
-                      textDecoration={TEXT_DECORATION_UNDERLINE}
-                      onClick={handleCalibrate}
-                    >
-                      {t('recalibrate_now')}
-                    </Btn>
-                  </Flex>
-                </Banner>
-              </Flex>
-            ) : null}
-            <StyledText
-              textTransform={TEXT_TRANSFORM_UPPERCASE}
-              color={COLORS.darkGrey}
-              fontWeight={FONT_WEIGHT_REGULAR}
-              fontSize={FONT_SIZE_CAPTION}
-              paddingBottom={SPACING.spacing2}
-              data-testid={`PipetteCard_mount_${pipetteName}`}
-            >
-              {t('mount', { side: mount === LEFT ? t('left') : t('right') })}
-            </StyledText>
-            <Flex
-              paddingBottom={SPACING.spacing2}
-              data-testid={`PipetteCard_display_name_${pipetteName}`}
-            >
-              <StyledText fontSize={TYPOGRAPHY.fontSizeP}>
-                {pipetteName ?? t('empty')}
-              </StyledText>
-            </Flex>
-          </Flex>
-        </Flex>
-      </Box>
-      <Box
-        alignSelf={ALIGN_START}
-        padding={SPACING.spacing2}
-        data-testid={`PipetteCard_overflow_btn_${pipetteName}`}
-      >
-        <OverflowBtn
-          aria-label="overflow"
-          onClick={() => {
-            setShowOverflowMenu(prevShowOverflowMenu => !prevShowOverflowMenu)
-          }}
-        />
-      </Box>
-      {showOverflowMenu && (
-        <Box
-          ref={pipetteOverflowWrapperRef}
-          data-testid={`PipetteCard_overflow_menu_${pipetteName}`}
-          onClick={() => setShowOverflowMenu(false)}
+    <>
+      {isFetching ? null : (
+        <Flex
+          backgroundColor={COLORS.background}
+          borderRadius={BORDERS.radiusSoftCorners}
+          marginBottom={SPACING.spacing3}
+          marginX={SPACING.spacing2}
+          width={'100%'}
+          data-testid={`PipetteCard_${pipetteName}`}
         >
-          <PipetteOverflowMenu
-            pipetteName={pipetteName ?? t('empty')}
-            mount={mount}
-            handleChangePipette={handleChangePipette}
-            handleCalibrate={handleCalibrate}
-            handleSettingsSlideout={handleSettingsSlideout}
-            handleAboutSlideout={handleAboutSlideout}
-            isPipetteCalibrated={pipetteOffsetCalibration != null}
-          />
-        </Box>
+          {showChangePipette && (
+            <ChangePipette
+              robotName={robotName}
+              mount={mount}
+              closeModal={() => setChangePipette(false)}
+            />
+          )}
+          {showSlideout && pipetteInfo != null && pipetteId != null && (
+            <PipetteSettingsSlideout
+              robotName={robotName}
+              pipetteName={pipetteInfo.displayName}
+              onCloseClick={() => setShowSlideout(false)}
+              isExpanded={true}
+              pipetteId={pipetteId}
+            />
+          )}
+          {PipetteOffsetCalibrationWizard}
+          {showAboutSlideout && pipetteInfo != null && pipetteId != null && (
+            <AboutPipetteSlideout
+              pipetteId={pipetteId}
+              pipetteName={pipetteInfo.displayName}
+              onCloseClick={() => setShowAboutSlideout(false)}
+              isExpanded={true}
+            />
+          )}
+          {showCalBlockModal && (
+            <Portal level="top">
+              <AskForCalibrationBlockModal
+                onResponse={hasBlockModalResponse => {
+                  startPipetteOffsetCalibrationBlockModal(hasBlockModalResponse)
+                }}
+                titleBarTitle={t('protocol_setup:pipette_offset_cal')}
+                closePrompt={() => setShowCalBlockModal(false)}
+              />
+            </Portal>
+          )}
+          <Box padding={`${SPACING.spacing4} ${SPACING.spacing3}`} width="100%">
+            <Flex flexDirection={DIRECTION_ROW} paddingRight={SPACING.spacing3}>
+              <Flex alignItems={ALIGN_START}>
+                {pipetteInfo === null ? null : (
+                  <InstrumentDiagram
+                    pipetteSpecs={pipetteInfo}
+                    mount={mount}
+                    transform="scale(0.3)"
+                    size="3.125rem"
+                    transformOrigin="20% -10%"
+                  />
+                )}
+              </Flex>
+              <Flex
+                flexDirection={DIRECTION_COLUMN}
+                paddingLeft={SPACING.spacing3}
+              >
+                {!isDeckCalibrated &&
+                pipetteOffsetCalibration == null &&
+                pipetteInfo != null &&
+                showBanner &&
+                !isFetching ? (
+                  <Flex paddingBottom={SPACING.spacing2}>
+                    <Banner
+                      type="error"
+                      onCloseClick={() => setShowBanner(false)}
+                    >
+                      {t('deck_cal_missing')}
+                    </Banner>
+                  </Flex>
+                ) : null}
+                {isDeckCalibrated &&
+                pipetteOffsetCalibration == null &&
+                pipetteInfo != null &&
+                showBanner &&
+                !isFetching ? (
+                  <Flex paddingBottom={SPACING.spacing2}>
+                    <Banner
+                      type="error"
+                      onCloseClick={() => setShowBanner(false)}
+                    >
+                      <Flex flexDirection={DIRECTION_COLUMN}>
+                        {t('pipette_offset_calibration_needed')}
+                        <Btn
+                          textAlign={ALIGN_START}
+                          fontSize={TYPOGRAPHY.fontSizeP}
+                          textDecoration={TEXT_DECORATION_UNDERLINE}
+                          onClick={handleCalibrate}
+                        >
+                          {t('calibrate_now')}
+                        </Btn>
+                      </Flex>
+                    </Banner>
+                  </Flex>
+                ) : null}
+                {isDeckCalibrated && badCalibration && showBanner ? (
+                  <Flex paddingBottom={SPACING.spacing2}>
+                    <Banner
+                      type="warning"
+                      onCloseClick={() => setShowBanner(false)}
+                    >
+                      <Flex flexDirection={DIRECTION_COLUMN}>
+                        {t('pipette_cal_recommended')}
+                        <Btn
+                          textAlign={ALIGN_START}
+                          fontSize={TYPOGRAPHY.fontSizeP}
+                          textDecoration={TEXT_DECORATION_UNDERLINE}
+                          onClick={handleCalibrate}
+                        >
+                          {t('recalibrate_now')}
+                        </Btn>
+                      </Flex>
+                    </Banner>
+                  </Flex>
+                ) : null}
+                <StyledText
+                  textTransform={TEXT_TRANSFORM_UPPERCASE}
+                  color={COLORS.darkGrey}
+                  fontWeight={FONT_WEIGHT_REGULAR}
+                  fontSize={FONT_SIZE_CAPTION}
+                  paddingBottom={SPACING.spacing2}
+                  data-testid={`PipetteCard_mount_${pipetteName}`}
+                >
+                  {t('mount', {
+                    side: mount === LEFT ? t('left') : t('right'),
+                  })}
+                </StyledText>
+                <Flex
+                  paddingBottom={SPACING.spacing2}
+                  data-testid={`PipetteCard_display_name_${pipetteName}`}
+                >
+                  <StyledText fontSize={TYPOGRAPHY.fontSizeP}>
+                    {pipetteName ?? t('empty')}
+                  </StyledText>
+                </Flex>
+              </Flex>
+            </Flex>
+          </Box>
+          <Box
+            alignSelf={ALIGN_START}
+            padding={SPACING.spacing2}
+            data-testid={`PipetteCard_overflow_btn_${pipetteName}`}
+          >
+            <OverflowBtn
+              aria-label="overflow"
+              onClick={() => {
+                setShowOverflowMenu(
+                  prevShowOverflowMenu => !prevShowOverflowMenu
+                )
+              }}
+            />
+          </Box>
+          {showOverflowMenu && (
+            <Box
+              ref={pipetteOverflowWrapperRef}
+              data-testid={`PipetteCard_overflow_menu_${pipetteName}`}
+              onClick={() => setShowOverflowMenu(false)}
+            >
+              <PipetteOverflowMenu
+                pipetteName={pipetteName ?? t('empty')}
+                mount={mount}
+                handleChangePipette={handleChangePipette}
+                handleCalibrate={handleCalibrate}
+                handleSettingsSlideout={handleSettingsSlideout}
+                handleAboutSlideout={handleAboutSlideout}
+                isPipetteCalibrated={pipetteOffsetCalibration != null}
+              />
+            </Box>
+          )}
+        </Flex>
       )}
-    </Flex>
+    </>
   )
 }

--- a/app/src/organisms/Devices/RecentProtocolRuns.tsx
+++ b/app/src/organisms/Devices/RecentProtocolRuns.tsx
@@ -43,7 +43,7 @@ export function RecentProtocolRuns({
   const robotIsBusy = currentRunId != null
   const latestRequestId = last(requestIds)
   const isFetching = useSelector<State, boolean>(state =>
-    latestRequestId
+    latestRequestId != null
       ? getRequestById(state, latestRequestId)?.status === 'pending'
       : false
   )

--- a/app/src/organisms/Devices/RecentProtocolRuns.tsx
+++ b/app/src/organisms/Devices/RecentProtocolRuns.tsx
@@ -15,6 +15,8 @@ import {
   DIRECTION_COLUMN,
   JUSTIFY_SPACE_AROUND,
 } from '@opentrons/components'
+import { useDispatchApiRequest } from '../../redux/robot-api'
+import { fetchProtocols } from '../../redux/protocol-storage'
 import { StyledText } from '../../atoms/text'
 import { useCurrentRunId } from '../ProtocolUpload/hooks'
 import { HistoricalProtocolRun } from './HistoricalProtocolRun'
@@ -29,11 +31,16 @@ export function RecentProtocolRuns({
 }: RecentProtocolRunsProps): JSX.Element | null {
   const { t } = useTranslation('device_details')
   const isRobotViewable = useIsRobotViewable(robotName)
+  const [dispatchRequest] = useDispatchApiRequest()
   const runsQueryResponse = useAllRunsQuery()
   const runs = runsQueryResponse?.data?.data
   const protocols = useAllProtocolsQuery()
   const currentRunId = useCurrentRunId()
   const robotIsBusy = currentRunId != null
+
+  React.useEffect(() => {
+    dispatchRequest(fetchProtocols())
+  }, [dispatchRequest, robotName])
 
   return (
     <Flex

--- a/app/src/organisms/Devices/RecentProtocolRuns.tsx
+++ b/app/src/organisms/Devices/RecentProtocolRuns.tsx
@@ -4,6 +4,8 @@ import {
   useAllRunsQuery,
   useAllProtocolsQuery,
 } from '@opentrons/react-api-client'
+import last from 'lodash/last'
+
 import {
   Flex,
   Box,
@@ -15,12 +17,14 @@ import {
   DIRECTION_COLUMN,
   JUSTIFY_SPACE_AROUND,
 } from '@opentrons/components'
-import { useDispatchApiRequest } from '../../redux/robot-api'
+import { getRequestById, useDispatchApiRequest } from '../../redux/robot-api'
 import { fetchProtocols } from '../../redux/protocol-storage'
 import { StyledText } from '../../atoms/text'
 import { useCurrentRunId } from '../ProtocolUpload/hooks'
 import { HistoricalProtocolRun } from './HistoricalProtocolRun'
 import { useIsRobotViewable } from './hooks'
+import { useSelector } from 'react-redux'
+import type { State } from '../../redux/types'
 
 interface RecentProtocolRunsProps {
   robotName: string
@@ -31,12 +35,18 @@ export function RecentProtocolRuns({
 }: RecentProtocolRunsProps): JSX.Element | null {
   const { t } = useTranslation('device_details')
   const isRobotViewable = useIsRobotViewable(robotName)
-  const [dispatchRequest] = useDispatchApiRequest()
+  const [dispatchRequest, requestIds] = useDispatchApiRequest()
   const runsQueryResponse = useAllRunsQuery()
   const runs = runsQueryResponse?.data?.data
   const protocols = useAllProtocolsQuery()
   const currentRunId = useCurrentRunId()
   const robotIsBusy = currentRunId != null
+  const latestRequestId = last(requestIds)
+  const isFetching = useSelector<State, boolean>(state =>
+    latestRequestId
+      ? getRequestById(state, latestRequestId)?.status === 'pending'
+      : false
+  )
 
   React.useEffect(() => {
     dispatchRequest(fetchProtocols())
@@ -116,11 +126,12 @@ export function RecentProtocolRuns({
                 const protocol = protocols?.data?.data.find(
                   protocol => protocol.id === run.protocolId
                 )
-                const protocolName =
-                  protocol?.metadata.protocolName ??
-                  protocol?.files[0].name ??
-                  run.protocolId ??
-                  ''
+                const protocolName = isFetching
+                  ? protocol?.metadata.protocolName ??
+                    protocol?.files[0].name ??
+                    run.protocolId ??
+                    ''
+                  : ''
 
                 return (
                   <HistoricalProtocolRun

--- a/app/src/organisms/Devices/__tests__/RecentProtocolRuns.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RecentProtocolRuns.test.tsx
@@ -3,16 +3,19 @@ import { UseQueryResult } from 'react-query'
 import { renderWithProviders } from '@opentrons/components'
 import { useAllRunsQuery } from '@opentrons/react-api-client'
 import { i18n } from '../../../i18n'
+import { useDispatchApiRequest } from '../../../redux/robot-api'
 import { useIsRobotViewable } from '../hooks'
 import { RecentProtocolRuns } from '../RecentProtocolRuns'
 import { HistoricalProtocolRun } from '../HistoricalProtocolRun'
 
 import type { Runs } from '@opentrons/api-client'
+import type { DispatchApiRequestType } from '../../../redux/robot-api'
 
 jest.mock('@opentrons/react-api-client')
 jest.mock('../hooks')
 jest.mock('../../ProtocolUpload/hooks')
 jest.mock('../HistoricalProtocolRun')
+jest.mock('../../../redux/robot-api')
 
 const mockUseIsRobotViewable = useIsRobotViewable as jest.MockedFunction<
   typeof useIsRobotViewable
@@ -23,7 +26,9 @@ const mockUseAllRunsQuery = useAllRunsQuery as jest.MockedFunction<
 const mockHistoricalProtocolRun = HistoricalProtocolRun as jest.MockedFunction<
   typeof HistoricalProtocolRun
 >
-
+const mockUseDispatchApiRequest = useDispatchApiRequest as jest.MockedFunction<
+  typeof useDispatchApiRequest
+>
 const render = () => {
   return renderWithProviders(<RecentProtocolRuns robotName="otie" />, {
     i18nInstance: i18n,
@@ -31,10 +36,14 @@ const render = () => {
 }
 
 describe('RecentProtocolRuns', () => {
+  let dispatchApiRequest: DispatchApiRequestType
+
   beforeEach(() => {
+    dispatchApiRequest = jest.fn()
     mockHistoricalProtocolRun.mockReturnValue(
       <div>mock HistoricalProtocolRun</div>
     )
+    mockUseDispatchApiRequest.mockReturnValue([dispatchApiRequest, ['id']])
   })
   afterEach(() => {
     jest.resetAllMocks()


### PR DESCRIPTION
partially fixes #10658

# Overview

This PR fixes the rendering issue when you open the Robot Overview page for the first time. The Banners on the pipette cards shouldn't be there unless you haven't completed a calibration. The historical protocol runs should display either null or the protocol name

# Changelog

- add `useDispatchApiRequest` to `PipetteCard` so the banners render null until the state is no longer pending
- add `useDispatchApiRequest` and `useEffect` to `RecentProtocolRuns` to fetch the protocols. when the protocol name from the protocol metadata is not fetched it, the `protocolName` will be an empty string

# Review requests

- make sure your pipettes have been calibrated and deck calibration is complete. Click on the robot card to go to the robot overview, the pipette cards should not render the banners
- run a few protocols so your historical protocol run has a history. then refresh the page, the historical protocol run protocolNames should be either null or render the protocol name

# Risk assessment

low