### PR TITLE
feat(app): add map view to liquid labware modal

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
@@ -13,12 +13,21 @@ import {
   Flex,
   SPACING,
   TYPOGRAPHY,
+  LabwareRender,
 } from '@opentrons/components'
-import { useProtocolDetailsForRun } from '../../../Devices/hooks'
+import {
+  useProtocolDetailsForRun,
+  useLabwareRenderInfoForRunById,
+} from '../../../Devices/hooks'
 import { Modal } from '../../../../atoms/Modal'
 import { StyledText } from '../../../../atoms/text'
 import { LiquidDetailCard } from './LiquidDetailCard'
-import { getSlotLabwareName, getLiquidsByIdForLabware } from './utils'
+import {
+  getSlotLabwareName,
+  getLiquidsByIdForLabware,
+  getWellFillFromLabwareId,
+  getWellGroupForLiquidId,
+} from './utils'
 
 interface LiquidsLabwareDetailsModalProps {
   liquidId?: string
@@ -35,11 +44,15 @@ export const LiquidsLabwareDetailsModal = (
   const [selectedValue, setSelectedValue] = React.useState<typeof liquidId>(
     liquidId
   )
-
+  const labwareRenderInfo = useLabwareRenderInfoForRunById(runId)[labwareId]
   const commands = useProtocolDetailsForRun(runId).protocolData?.commands
   const liquids = parseLiquidsInLoadOrder()
   const labwareByLiquidId = parseLabwareInfoByLiquidId()
-
+  const wellFill = getWellFillFromLabwareId(
+    labwareId,
+    liquids,
+    labwareByLiquidId
+  )
   const labwareInfo = getLiquidsByIdForLabware(labwareId, labwareByLiquidId)
   const { slotName, labwareName } = getSlotLabwareName(labwareId, commands)
 
@@ -57,12 +70,13 @@ export const LiquidsLabwareDetailsModal = (
       width="46.875rem"
     >
       <Box>
-        <Flex flexDirection={DIRECTION_ROW}>
+        <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing3}>
           <Flex
             flexDirection={DIRECTION_COLUMN}
             css={HIDE_SCROLLBAR}
             maxHeight={'27.125rem'}
             overflowY={'auto'}
+            minWidth="165px"
           >
             {Object.entries(labwareInfo).map((entry, index) => {
               const liquidInfo = liquids.find(
@@ -116,7 +130,20 @@ export const LiquidsLabwareDetailsModal = (
                 </StyledText>
               </Flex>
             </Flex>
-            <Box>Labware render placeholder</Box>
+            <Box width="490px">
+              <svg viewBox="0 -10 130 100" transform="scale(1, -1)">
+                <LabwareRender
+                  definition={labwareRenderInfo.labwareDef}
+                  wellFill={wellFill}
+                  wellLabelOption="SHOW_LABEL_INSIDE"
+                  highlightedWells={
+                    selectedValue != null
+                      ? getWellGroupForLiquidId(labwareInfo, selectedValue)
+                      : {}
+                  }
+                />
+              </svg>
+            </Box>
           </Flex>
         </Flex>
       </Box>

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
@@ -76,7 +76,7 @@ export const LiquidsLabwareDetailsModal = (
             css={HIDE_SCROLLBAR}
             maxHeight={'27.125rem'}
             overflowY={'auto'}
-            minWidth="165px"
+            minWidth={'10.313rem'}
           >
             {Object.entries(labwareInfo).map((entry, index) => {
               const liquidInfo = liquids.find(
@@ -130,7 +130,7 @@ export const LiquidsLabwareDetailsModal = (
                 </StyledText>
               </Flex>
             </Flex>
-            <Box width="490px">
+            <Box width={'30.625rem'}>
               <svg viewBox="0 -10 130 100" transform="scale(1, -1)">
                 <LabwareRender
                   definition={labwareRenderInfo.labwareDef}

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsMap.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsMap.tsx
@@ -22,6 +22,7 @@ import {
   useModuleRenderInfoForProtocolById,
 } from '../../hooks'
 import { LabwareInfoOverlay } from '../LabwareInfoOverlay'
+import { LiquidsLabwareDetailsModal } from './LiquidsLabwareDetailsModal'
 import { getWellFillFromLabwareId } from './utils'
 import type { DeckDefinition } from '@opentrons/shared-data'
 
@@ -52,6 +53,9 @@ export function SetupLiquidsMap(props: SetupLiquidsMapProps): JSX.Element {
   const labwareRenderInfoById = useLabwareRenderInfoForRunById(runId)
   const liquids = parseLiquidsInLoadOrder()
   const labwareByLiquidId = parseLabwareInfoByLiquidId()
+  const [liquidDetailsLabwareId, setLiquidDetailsLabwareId] = React.useState<
+    string | null
+  >(null)
 
   return (
     <Flex flex="1" maxHeight="180vh" flexDirection={DIRECTION_COLUMN}>
@@ -118,6 +122,12 @@ export function SetupLiquidsMap(props: SetupLiquidsMapProps): JSX.Element {
                       transform={`translate(${x},${y})`}
                       onMouseEnter={() => setHoverLabwareId(labwareId)}
                       onMouseLeave={() => setHoverLabwareId('')}
+                      onClick={() =>
+                        labwareHasLiquid
+                          ? setLiquidDetailsLabwareId(labwareId)
+                          : null
+                      }
+                      cursor={labwareHasLiquid ? 'pointer' : ''}
                     >
                       <LabwareRender
                         definition={labwareDef}
@@ -140,6 +150,13 @@ export function SetupLiquidsMap(props: SetupLiquidsMapProps): JSX.Element {
           </>
         )}
       </RobotWorkSpace>
+      {liquidDetailsLabwareId != null && (
+        <LiquidsLabwareDetailsModal
+          labwareId={liquidDetailsLabwareId}
+          runId={runId}
+          closeModal={() => setLiquidDetailsLabwareId(null)}
+        />
+      )}
     </Flex>
   )
 }

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/utils.test.ts
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/utils.test.ts
@@ -4,6 +4,7 @@ import {
   getTotalVolumePerLiquidLabwarePair,
   getSlotLabwareName,
   getLiquidsByIdForLabware,
+  getWellGroupForLiquidId,
 } from '../utils'
 import { getLabwareDisplayName } from '@opentrons/shared-data'
 import type { LabwareByLiquidId, Liquid } from '@opentrons/api-client'
@@ -149,6 +150,57 @@ const MOCK_COMMANDS = [
   },
 ]
 
+const MOCK_LABWARE_BY_LIQUID_ID_FOR_LABWARE = {
+  '4': [
+    {
+      labwareId:
+        '60e8b050-3412-11eb-ad93-ed232a2337cf:opentrons/corning_24_wellplate_3.4ml_flat/1',
+      volumeByWell: {
+        A3: 100,
+        A4: 100,
+        B3: 100,
+        B4: 100,
+        C3: 100,
+        C4: 100,
+        D3: 100,
+        D4: 100,
+      },
+    },
+  ],
+  '7': [
+    {
+      labwareId:
+        '60e8b050-3412-11eb-ad93-ed232a2337cf:opentrons/corning_24_wellplate_3.4ml_flat/1',
+      volumeByWell: {
+        A1: 100,
+        A2: 100,
+        B1: 100,
+        B2: 100,
+        C1: 100,
+        C2: 100,
+        D1: 100,
+        D2: 100,
+      },
+    },
+  ],
+  '19': [
+    {
+      labwareId:
+        '60e8b050-3412-11eb-ad93-ed232a2337cf:opentrons/corning_24_wellplate_3.4ml_flat/1',
+      volumeByWell: {
+        A5: 100,
+        A6: 100,
+        B5: 100,
+        B6: 100,
+        C5: 100,
+        C6: 100,
+        D5: 100,
+        D6: 100,
+      },
+    },
+  ],
+}
+
 jest.mock('@opentrons/shared-data')
 const mockGetLabwareDisplayName = getLabwareDisplayName as jest.MockedFunction<
   typeof getLabwareDisplayName
@@ -242,58 +294,26 @@ describe('getSlotLabwareName', () => {
 
 describe('getLiquidsByIdForLabware', () => {
   it('returns liquid info by labware id', () => {
-    const expected = {
-      '4': [
-        {
-          labwareId:
-            '60e8b050-3412-11eb-ad93-ed232a2337cf:opentrons/corning_24_wellplate_3.4ml_flat/1',
-          volumeByWell: {
-            A3: 100,
-            A4: 100,
-            B3: 100,
-            B4: 100,
-            C3: 100,
-            C4: 100,
-            D3: 100,
-            D4: 100,
-          },
-        },
-      ],
-      '7': [
-        {
-          labwareId:
-            '60e8b050-3412-11eb-ad93-ed232a2337cf:opentrons/corning_24_wellplate_3.4ml_flat/1',
-          volumeByWell: {
-            A1: 100,
-            A2: 100,
-            B1: 100,
-            B2: 100,
-            C1: 100,
-            C2: 100,
-            D1: 100,
-            D2: 100,
-          },
-        },
-      ],
-      '19': [
-        {
-          labwareId:
-            '60e8b050-3412-11eb-ad93-ed232a2337cf:opentrons/corning_24_wellplate_3.4ml_flat/1',
-          volumeByWell: {
-            A5: 100,
-            A6: 100,
-            B5: 100,
-            B6: 100,
-            C5: 100,
-            C6: 100,
-            D5: 100,
-            D6: 100,
-          },
-        },
-      ],
-    }
     expect(
       getLiquidsByIdForLabware(LABWARE_ID, MOCK_LABWARE_BY_LIQUID_ID as any)
+    ).toEqual(MOCK_LABWARE_BY_LIQUID_ID_FOR_LABWARE)
+  })
+})
+
+describe('getWellGroupForLiquidId', () => {
+  it('returns wellgroup object for the specified liquidId', () => {
+    const expected = {
+      A1: null,
+      A2: null,
+      B1: null,
+      B2: null,
+      C1: null,
+      C2: null,
+      D1: null,
+      D2: null,
+    }
+    expect(
+      getWellGroupForLiquidId(MOCK_LABWARE_BY_LIQUID_ID_FOR_LABWARE, '7')
     ).toEqual(expected)
   })
 })

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/utils.ts
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/utils.ts
@@ -1,5 +1,6 @@
 import { getLabwareDisplayName, RunTimeCommand } from '@opentrons/shared-data'
 import type { LabwareByLiquidId, Liquid } from '@opentrons/api-client'
+import { WellGroup } from '@opentrons/components'
 
 export function getWellFillFromLabwareId(
   labwareId: string,
@@ -115,4 +116,23 @@ export function getLiquidsByIdForLabware(
     },
     {}
   )
+}
+
+export function getWellGroupForLiquidId(
+  labwareByLiquidId: LabwareByLiquidId,
+  liquidId: string
+): WellGroup {
+  const labwareInfo = labwareByLiquidId[liquidId]
+  return labwareInfo.reduce((allWells, { volumeByWell }) => {
+    const someWells = Object.entries(volumeByWell).reduce(
+      (someWells, [wellName]) => {
+        return {
+          ...someWells,
+          [wellName]: null,
+        }
+      },
+      {}
+    )
+    return { ...allWells, ...someWells }
+  }, {})
 }


### PR DESCRIPTION
closes #10521

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
Finish out the liquid labware modal by adding the labware render and launching from map view
![Screen Shot 2022-06-22 at 5 00 08 PM](https://user-images.githubusercontent.com/14302493/175135162-9a43548c-df29-4ddd-9649-bbb39b0ee1b6.png)

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

1. Launch liquid labware modal by clicking on a labware with liquid in the liquid setup map view
2. Add Labware Render to the modal 
3. Highlight wells of selected liquid on the left, added new util to get the WellGroup for this

# Review requests

<!--
Describe any requests for your reviewers here.
-->
Test it out!
# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Low, behind FF