### PR TITLE
feat(step-generation): deactivate heater shaker after timer finishes

### DIFF
--- a/step-generation/src/__tests__/heaterShaker.test.ts
+++ b/step-generation/src/__tests__/heaterShaker.test.ts
@@ -1,0 +1,118 @@
+import {
+  HEATERSHAKER_MODULE_TYPE,
+  HEATERSHAKER_MODULE_V1,
+} from '@opentrons/shared-data'
+import { heaterShaker } from '../commandCreators'
+import { getModuleState } from '../robotStateSelectors'
+import { getSuccessResult } from '../fixtures/commandFixtures'
+
+import type { InvariantContext, RobotState, HeaterShakerArgs } from '../types'
+import { getInitialRobotStateStandard, makeContext } from '../fixtures'
+
+jest.mock('../robotStateSelectors')
+
+const mockGetModuleState = getModuleState as jest.MockedFunction<
+  typeof getModuleState
+>
+
+describe('heaterShaker compound command creator', () => {
+  let heaterShakerArgs: HeaterShakerArgs
+  const HEATER_SHAKER_ID = 'heaterShakerId'
+  const HEATER_SHAKER_SLOT = '1'
+  let robotState: RobotState
+  let invariantContext: InvariantContext
+  beforeEach(() => {
+    heaterShakerArgs = {
+      module: HEATER_SHAKER_ID,
+      rpm: null,
+      commandCreatorFnName: 'heaterShaker',
+      targetTemperature: null,
+      latchOpen: false,
+      timerMinutes: null,
+      timerSeconds: null,
+    }
+    invariantContext = {
+      ...makeContext(),
+      moduleEntities: {
+        [HEATER_SHAKER_ID]: {
+          id: HEATER_SHAKER_ID,
+          type: HEATERSHAKER_MODULE_TYPE,
+          model: HEATERSHAKER_MODULE_V1,
+        },
+      },
+    }
+    const state = getInitialRobotStateStandard(invariantContext)
+
+    robotState = {
+      ...state,
+      modules: {
+        ...state.modules,
+        [HEATER_SHAKER_ID]: {
+          slot: HEATER_SHAKER_SLOT,
+        } as any,
+      },
+    }
+    mockGetModuleState.mockReturnValue({
+      type: HEATERSHAKER_MODULE_TYPE,
+    } as any)
+  })
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+  it('should delay and deactivate the heater shaker when a user specificies a timer', () => {
+    heaterShakerArgs = {
+      ...heaterShakerArgs,
+      rpm: 444,
+      targetTemperature: 80,
+      timerSeconds: 30,
+    }
+    const result = heaterShaker(heaterShakerArgs, invariantContext, robotState)
+
+    expect(getSuccessResult(result).commands).toEqual([
+      {
+        commandType: 'heaterShaker/closeLabwareLatch',
+        params: {
+          moduleId: 'heaterShakerId',
+        },
+      },
+      {
+        commandType: 'heaterShaker/setTargetTemperature',
+        params: {
+          celsius: 80,
+          moduleId: 'heaterShakerId',
+        },
+      },
+      {
+        commandType: 'heaterShaker/waitForTemperature',
+        params: {
+          moduleId: 'heaterShakerId',
+        },
+      },
+      {
+        commandType: 'heaterShaker/setAndWaitForShakeSpeed',
+        params: {
+          moduleId: 'heaterShakerId',
+          rpm: 444,
+        },
+      },
+      {
+        commandType: 'delay',
+        params: {
+          seconds: 30,
+        },
+      },
+      {
+        commandType: 'heaterShaker/deactivateShaker',
+        params: {
+          moduleId: 'heaterShakerId',
+        },
+      },
+      {
+        commandType: 'heaterShaker/deactivateHeater',
+        params: {
+          moduleId: 'heaterShakerId',
+        },
+      },
+    ])
+  })
+})

--- a/step-generation/src/__tests__/heaterShaker.test.ts
+++ b/step-generation/src/__tests__/heaterShaker.test.ts
@@ -115,4 +115,43 @@ describe('heaterShaker compound command creator', () => {
       },
     ])
   })
+  it('should NOT delay and deactivate the heater shaker when a user specificies a timer tthat is 0 seconds', () => {
+    heaterShakerArgs = {
+      ...heaterShakerArgs,
+      rpm: 444,
+      targetTemperature: 80,
+      timerSeconds: 0,
+      timerMinutes: 0,
+    }
+    const result = heaterShaker(heaterShakerArgs, invariantContext, robotState)
+
+    expect(getSuccessResult(result).commands).toEqual([
+      {
+        commandType: 'heaterShaker/closeLabwareLatch',
+        params: {
+          moduleId: 'heaterShakerId',
+        },
+      },
+      {
+        commandType: 'heaterShaker/setTargetTemperature',
+        params: {
+          celsius: 80,
+          moduleId: 'heaterShakerId',
+        },
+      },
+      {
+        commandType: 'heaterShaker/waitForTemperature',
+        params: {
+          moduleId: 'heaterShakerId',
+        },
+      },
+      {
+        commandType: 'heaterShaker/setAndWaitForShakeSpeed',
+        params: {
+          moduleId: 'heaterShakerId',
+          rpm: 444,
+        },
+      },
+    ])
+  })
 })

--- a/step-generation/src/commandCreators/compound/heaterShaker.ts
+++ b/step-generation/src/commandCreators/compound/heaterShaker.ts
@@ -7,6 +7,7 @@ import {
   HeaterShakerModuleState,
 } from '../../types'
 import { getModuleState } from '../../robotStateSelectors'
+import { delay } from '../atomic/delay'
 import { heaterShakerOpenLatch } from '../atomic/heaterShakerOpenLatch'
 import { heaterShakerCloseLatch } from '../atomic/heaterShakerCloseLatch'
 import { heaterShakerDeactivateHeater } from '../atomic/heaterShakerDeactivateHeater'
@@ -83,6 +84,30 @@ export const heaterShaker: CommandCreator<HeaterShakerArgs> = (
         moduleId: args.module,
         commandCreatorFnName: 'setShakeSpeed',
         rpm: args.rpm,
+      })
+    )
+  }
+
+  if (args.timerMinutes != null || args.timerSeconds != null) {
+    const totalSeconds =
+      (args.timerSeconds ?? 0) + (args.timerMinutes ?? 0) * 60
+    commandCreators.push(
+      curryCommandCreator(delay, {
+        commandCreatorFnName: 'delay',
+        description: null,
+        name: null,
+        meta: null,
+        wait: totalSeconds,
+      })
+    )
+    commandCreators.push(
+      curryCommandCreator(heaterShakerStopShake, {
+        moduleId: args.module,
+      })
+    )
+    commandCreators.push(
+      curryCommandCreator(heaterShakerDeactivateHeater, {
+        moduleId: args.module,
       })
     )
   }

--- a/step-generation/src/commandCreators/compound/heaterShaker.ts
+++ b/step-generation/src/commandCreators/compound/heaterShaker.ts
@@ -88,7 +88,10 @@ export const heaterShaker: CommandCreator<HeaterShakerArgs> = (
     )
   }
 
-  if (args.timerMinutes != null || args.timerSeconds != null) {
+  if (
+    (args.timerMinutes != null && args.timerMinutes !== 0) ||
+    (args.timerSeconds != null && args.timerSeconds !== 0)
+  ) {
     const totalSeconds =
       (args.timerSeconds ?? 0) + (args.timerMinutes ?? 0) * 60
     commandCreators.push(


### PR DESCRIPTION
# Overview

This PR updates the heater shaker compound command creator to emit a delay command, followed by deactivate heater + stop shake commands if a user specifies a timer. 
closes #10875

# Changelog

- Deactivate heater shaker after timer finishes

# Review requests
Create a protocol with a heater shaker timed step
In the JSON command list when you export, you should see a delay command, followed by deactivate heater + stop shake commands

# Risk assessment
Low
