### PR TITLE
fix(robot-server): allow live commands if current run is terminal

### DIFF
--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -129,6 +129,8 @@ class ProtocolEngine:
         Raises:
             SetupCommandNotAllowed: the request specified a setup command,
                 but the engine was not idle or paused.
+            RunStoppedError: the run has been stopped, so no new commands
+                may be added.
         """
         command_id = self._model_utils.generate_id()
 

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -73,7 +73,10 @@ class EngineStore:
         Raises:
             EngineConflictError: if a run-specific engine is active.
         """
-        if self._runner_engine_pair is not None:
+        if (
+            self._runner_engine_pair is not None
+            and not self.engine.state_view.commands.get_is_stopped()
+        ):
             raise EngineConflictError("An engine for a run is currently active")
 
         engine = self._default_engine

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -205,6 +205,8 @@ async def create_run_command(
 
     except pe_errors.SetupCommandNotAllowedError as e:
         raise CommandNotAllowed(detail=str(e)).as_error(status.HTTP_409_CONFLICT)
+    except pe_errors.RunStoppedError as e:
+        raise RunStopped(detail=str(e)).as_error(status.HTTP_409_CONFLICT)
 
     if waitUntilComplete:
         with move_on_after(timeout / 1000.0):

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -221,6 +221,31 @@ async def test_add_conflicting_setup_command(
     assert exc_info.value.content["errors"][0]["detail"] == "oh no"
 
 
+async def test_add_command_to_stopped_engine(
+    decoy: Decoy,
+    mock_protocol_engine: ProtocolEngine,
+) -> None:
+    """It should raise an error if the setup command cannot be added."""
+    command_request = pe_commands.WaitForResumeCreate(
+        params=pe_commands.WaitForResumeParams(message="Hello"),
+        intent=pe_commands.CommandIntent.SETUP,
+    )
+
+    decoy.when(mock_protocol_engine.add_command(command_request)).then_raise(
+        pe_errors.RunStoppedError("oh no")
+    )
+
+    with pytest.raises(ApiError) as exc_info:
+        await create_run_command(
+            request_body=RequestModel(data=command_request),
+            waitUntilComplete=False,
+            protocol_engine=mock_protocol_engine,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.content["errors"][0]["detail"] == "oh no"
+
+
 async def test_get_run_commands(
     decoy: Decoy, mock_run_data_manager: RunDataManager
 ) -> None:

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -226,8 +226,8 @@ async def test_add_command_to_stopped_engine(
     mock_protocol_engine: ProtocolEngine,
 ) -> None:
     """It should raise an error if the setup command cannot be added."""
-    command_request = pe_commands.WaitForResumeCreate(
-        params=pe_commands.WaitForResumeParams(message="Hello"),
+    command_request = pe_commands.HomeCreate(
+        params=pe_commands.HomeParams(),
         intent=pe_commands.CommandIntent.SETUP,
     )
 

--- a/robot-server/tests/runs/test_engine_store.py
+++ b/robot-server/tests/runs/test_engine_store.py
@@ -158,3 +158,12 @@ async def test_get_default_engine_conflict(subject: EngineStore) -> None:
 
     with pytest.raises(EngineConflictError):
         await subject.get_default_engine()
+
+
+async def test_get_default_engine_run_stopped(subject: EngineStore) -> None:
+    """It allow a default engine if another engine is terminal."""
+    await subject.create(run_id="run-id", labware_offsets=[], protocol=None)
+    await subject.engine.finish()
+
+    result = await subject.get_default_engine()
+    assert isinstance(result, ProtocolEngine)


### PR DESCRIPTION
## Overview

This PR ensures that live `POST /commands` controls will work if there is a current run, but it has stopped and will therefor no longer be interacting with hardware.

## Changelog

- Allow `POST /commands` if there is a current run but it has finished
- Fix a `500` error that should've been a `409` in `POST /runs/:run_id/commands`

## Review requests

- [ ] Can issue module commands from Robot Overview page if a current run has completed

## Risk assessment

Low. Doesn't make existing issues with the concept of the `live_engine` any worse than they already are. We will still need to add actual hardware API locking into the picture at some point, regardless.