### PR TITLE
build(app-shell): build app's python env with pandas as dependency to match robot's env

### DIFF
--- a/app-shell/scripts/before-build.js
+++ b/app-shell/scripts/before-build.js
@@ -90,7 +90,7 @@ module.exports = function beforeBuild(context) {
         `--target=${path.join(PYTHON_DESTINATION, sitePackages)}`,
         path.join(__dirname, '../../shared-data/python'),
         path.join(__dirname, '../../api'),
-        'pandas==0.25.3',
+        'pandas==1.4.3',
       ])
     })
     .then(({ stdout }) => {

--- a/app-shell/scripts/before-build.js
+++ b/app-shell/scripts/before-build.js
@@ -72,7 +72,9 @@ module.exports = function beforeBuild(context) {
       return decompress(data, PYTHON_DESTINATION)
     })
     .then(() => {
-      console.log('Standalone Python extracted, installing `opentrons` package')
+      console.log(
+        'Standalone Python extracted, installing `opentrons` and `pandas` packages'
+      )
 
       const sitePackages =
         platformName === 'win32'
@@ -88,10 +90,13 @@ module.exports = function beforeBuild(context) {
         `--target=${path.join(PYTHON_DESTINATION, sitePackages)}`,
         path.join(__dirname, '../../shared-data/python'),
         path.join(__dirname, '../../api'),
+        'pandas==0.25.3',
       ])
     })
     .then(({ stdout }) => {
-      console.log("`opentrons` package installed to app's Python environment")
+      console.log(
+        "`opentrons` and `pandas` packages installed to app's Python environment"
+      )
       console.debug('pip output:', stdout)
       // must return a truthy value, or else electron-builder will
       // skip installing project dependencies into the package


### PR DESCRIPTION
# Overview

Include the `pandas` library in the app's python environment as it is a default package available on
the OT2's python environment.

Closes https://github.com/Opentrons/opentrons/issues/10874

# Changelog

- add `pandas` version `0.25.3` via pip in the app-shell's setup of it's bundled python environment

# Review requests

- please take the app build generated by CI for this branch and upload a protocol that import's and uses the `pandas` python library. App-side protocol analysis should succeed

# Risk assessment
med, `pandas` is a very heavy dependency to add to the app's build, otherwise there is not much risk