### PR TITLE
build(protocol-designer, labware-library, components): explicitly define aws region in deploy step

### DIFF
--- a/.github/workflows/components-test-build-deploy.yaml
+++ b/.github/workflows/components-test-build-deploy.yaml
@@ -123,5 +123,6 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_SANDBOX_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SANDBOX_SECRET }}
+          AWS_DEFAULT_REGION: us-east-2
         run: |
           aws s3 sync ./dist s3://opentrons-components/${{ env.OT_BRANCH}} --acl public-read

--- a/.github/workflows/ll-test-build-deploy.yaml
+++ b/.github/workflows/ll-test-build-deploy.yaml
@@ -167,6 +167,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_SANDBOX_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SANDBOX_SECRET }}
+          AWS_DEFAULT_REGION: us-east-2
         uses: './.github/actions/webstack/deploy-to-sandbox'
         with:
           domain: 'labware.opentrons.com'

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -166,6 +166,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_SANDBOX_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SANDBOX_SECRET }}
+          AWS_DEFAULT_REGION: us-east-2
         uses: './.github/actions/webstack/deploy-to-sandbox'
         with:
           domain: 'designer.opentrons.com'


### PR DESCRIPTION
# Overview

Do the same thing that this PR did for the docs builds #10884, for the last three aws build deploy steps that didn't define the aws region explicitly yet (`protocol-designer`, `labware-library`, and `components`). 

# Review requests

- confirm that the deploy to s3 steps of the `protocol-designer`, `labware-library`, and `components` succeeds without erroring with exit code 255 

# Risk assessment
low
