### PR TITLE
fix(api): move to safe plunger position after every drop-tip

### DIFF
--- a/api/src/opentrons/hardware_control/instrument_handler.py
+++ b/api/src/opentrons/hardware_control/instrument_handler.py
@@ -784,19 +784,10 @@ class InstrumentHandlerProvider(Generic[MountType]):
                     home_after_safety_margin=abs(bottom_pos - droptip_pos),
                     home_axes=home_axes,
                 ),
-            ]
-            if home_after:
-                base.append(
-                    DropTipMove(
-                        target_position=bottom_pos, current=plunger_currents, speed=None
-                    )
-                )
-            # always move to a known position after a drop-tip
-            base.append(
-                DropTipMove(
+                DropTipMove(  # always finish drop-tip at a known safe plunger position
                     target_position=bottom_pos, current=plunger_currents, speed=None
-                )
-            )
+                ),
+            ]
             return base
 
         return build

--- a/api/src/opentrons/hardware_control/instrument_handler.py
+++ b/api/src/opentrons/hardware_control/instrument_handler.py
@@ -791,6 +791,12 @@ class InstrumentHandlerProvider(Generic[MountType]):
                         target_position=bottom_pos, current=plunger_currents, speed=None
                     )
                 )
+            # always move to a known position after a drop-tip
+            base.append(
+                DropTipMove(
+                    target_position=bottom_pos, current=plunger_currents, speed=None
+                )
+            )
             return base
 
         return build


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

closes #10772

# Overview

This PR puts all pipette plunger position into a known state (`bottom`) after every call to `.drop_tip()`. Previously, the plunger would end up in different positions depending on if you added the `home_after=False` argument or not, resulting in collisions on Gen-2 multi-channels when `home_after=False`.

# Changelog

Adds a single plunger movement to `bottom` plunger position.

# Risk assessment

I don't see much risk here. This fixes a collision our software currently causes.
