### PR TITLE
docs(shared-data): Specify moveToCoordinates critical point

### DIFF
--- a/shared-data/protocol/schemas/6.json
+++ b/shared-data/protocol/schemas/6.json
@@ -402,7 +402,7 @@
           },
 
           {
-            "description": "Move To Coordinates",
+            "description": "Move To Coordinates: Move the pipette's critical point to the specified coordinates. The pipette's critical point is a reference point on the pipette. The critical point can be one of the following: (1) Single-channel pipette with no tip: end of nozzle. (2) Multi-channel pipette with no tip: end of backmost nozzle. (3) Single-channel pipette with a tip: end of tip. (4) Multi-channel pipette with tip: end of tip on backmost nozzle.",
             "type": "object",
             "required": ["commandType", "params"],
             "properties": {

--- a/shared-data/protocol/schemas/6.json
+++ b/shared-data/protocol/schemas/6.json
@@ -402,7 +402,7 @@
           },
 
           {
-            "description": "Move To Coordinates: Move the pipette's critical point to the specified coordinates. The pipette's critical point is a reference point on the pipette. The critical point can be one of the following: (1) Single-channel pipette with no tip: end of nozzle. (2) Multi-channel pipette with no tip: end of backmost nozzle. (3) Single-channel pipette with a tip: end of tip. (4) Multi-channel pipette with tip: end of tip on backmost nozzle.",
+            "description": "Move To Coordinates: Move the pipette's critical point to the specified coordinates. The pipette's critical point is a reference point on the pipette. The critical point can be one of the following: (1) Single-Channel pipette with no tip: end of nozzle. (2) 8-Channel pipette with no tip: end of backmost nozzle. (3) Single-Channel pipette with a tip: end of tip. (4) 8-Channel pipette with tip: end of tip on backmost nozzle.",
             "type": "object",
             "required": ["commandType", "params"],
             "properties": {
@@ -1013,7 +1013,7 @@
           },
 
           {
-            "description": "Move To Well: Move the pipette's critical point to the specified well in a labware, with an optional offset. The pipette's critical point is a reference point on the pipette. The critical point can be one of the following: (1) Single-channel pipette with no tip: end of nozzle. (2) Multi-channel pipette with no tip: end of backmost nozzle. (3) Single-channel pipette with a tip: end of tip. (4) Multi-channel pipette with tip: end of tip on backmost nozzle.",
+            "description": "Move To Well: Move the pipette's critical point to the specified well in a labware, with an optional offset. The pipette's critical point is a reference point on the pipette. The critical point can be one of the following: (1) Single-Channel pipette with no tip: end of nozzle. (2) 8-Channel pipette with no tip: end of backmost nozzle. (3) Single-Channel pipette with a tip: end of tip. (4) 8-Channel pipette with tip: end of tip on backmost nozzle.",
             "type": "object",
             "required": ["commandType", "params"],
             "properties": {


### PR DESCRIPTION
# Overview

This PR updates the `moveToCoordinates` description in `shared-data` to describe how the critical point depends on whether the pipette is a Single-Channel or 8-Channel, and whether it has a tip attached.

The language exactly copies what we already have for `moveToWell`:

https://github.com/Opentrons/opentrons/blob/d5e06d1e1b4bf4ac8825c0f2eaefe8d22153a795/shared-data/protocol/schemas/6.json#L1016-L1021

It also updates uses of the phrases "single-channel" and "multi-channel" to "Single-Channel" and "8-Channel," per our documentation style guide.

# Review requests

Is this the behavior everyone expects?

# Risk assessment

None. Changes are just to developer-facing documentation.
