### PR TITLE
test(api): Adjust wait times in pause tests to reduce flakiness

### DIFF
--- a/api/tests/opentrons/protocol_engine/execution/test_run_control_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_run_control_handler.py
@@ -85,12 +85,12 @@ async def test_wait_for_duration(
         EngineConfigs(ignore_pause=False)
     )
     start = datetime.now()
-    await subject.wait_for_duration(seconds=0.1)
+    await subject.wait_for_duration(seconds=0.2)
     end = datetime.now()
 
     # NOTE: margin of error selected empirically
     # this is flakey test risk in CI
-    assert (end - start).total_seconds() == pytest.approx(0.1, abs=0.05)
+    assert (end - start).total_seconds() == pytest.approx(0.2, abs=0.1)
 
 
 async def test_wait_for_duration_ignore_pause(
@@ -108,9 +108,9 @@ async def test_wait_for_duration_ignore_pause(
         EngineConfigs(ignore_pause=True)
     )
     start = datetime.now()
-    await subject.wait_for_duration(seconds=0.1)
+    await subject.wait_for_duration(seconds=1.0)
     end = datetime.now()
 
     # NOTE: margin of error selected empirically
     # this is flakey test risk in CI
-    assert (end - start).total_seconds() == pytest.approx(0, abs=0.05)
+    assert (end - start).total_seconds() == pytest.approx(0, abs=0.1)

--- a/api/tests/opentrons/protocol_engine/execution/test_run_control_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_run_control_handler.py
@@ -108,6 +108,9 @@ async def test_wait_for_duration_ignore_pause(
         EngineConfigs(ignore_pause=True)
     )
     start = time_monotonic()
+    # This wait time would be disruptively long for the test suite,
+    # but it only matters when the subject has a bug and this test fails,
+    # which should be rare.
     await subject.wait_for_duration(seconds=1.0)
     end = time_monotonic()
 

--- a/api/tests/opentrons/protocol_engine/execution/test_run_control_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_run_control_handler.py
@@ -1,5 +1,5 @@
 """Run control side-effect handler."""
-from datetime import datetime
+from time import monotonic as time_monotonic
 
 import pytest
 from decoy import Decoy, matchers
@@ -84,13 +84,13 @@ async def test_wait_for_duration(
     decoy.when(mock_state_store.get_configs()).then_return(
         EngineConfigs(ignore_pause=False)
     )
-    start = datetime.now()
+    start = time_monotonic()
     await subject.wait_for_duration(seconds=0.2)
-    end = datetime.now()
+    end = time_monotonic()
 
     # NOTE: margin of error selected empirically
     # this is flakey test risk in CI
-    assert (end - start).total_seconds() == pytest.approx(0.2, abs=0.1)
+    assert end - start == pytest.approx(0.2, abs=0.1)
 
 
 async def test_wait_for_duration_ignore_pause(
@@ -107,10 +107,10 @@ async def test_wait_for_duration_ignore_pause(
     decoy.when(mock_state_store.get_configs()).then_return(
         EngineConfigs(ignore_pause=True)
     )
-    start = datetime.now()
+    start = time_monotonic()
     await subject.wait_for_duration(seconds=1.0)
-    end = datetime.now()
+    end = time_monotonic()
 
     # NOTE: margin of error selected empirically
     # this is flakey test risk in CI
-    assert (end - start).total_seconds() == pytest.approx(0, abs=0.1)
+    assert end - start == pytest.approx(0, abs=0.1)


### PR DESCRIPTION
# Overview

Some of Protocol Engine's unit tests involve sleeping for an amount of time, and then asserting that the clock advanced by the expected amount.

This is helpful for testing stuff like the `waitForDuration` command, which should stall the protocol during the actual run, but do nothing when the protocol is only being analyzed.

However, it looks like the specific time ranges we've chosen [are a little flakey in CI](https://github.com/Opentrons/opentrons/runs/7044603487?check_suite_focus=true) because they're so tight.

```
>       assert (end - start).total_seconds() == pytest.approx(0.1, abs=0.05)
E       assert 0.199728 == 0.1 ± 5.0e-02
E         comparison failed
E         Obtained: 0.199728
E         Expected: 0.1 ± 5.0e-02
tests/opentrons/protocol_engine/execution/test_run_control_handler.py:93: AssertionError
```

# Changelog

This PR:

* Makes the time ranges a little sloppier to make the tests less sensitive to natural variation in how long our code takes to run.
* Switches the time comparison to use a monotonic clock instead of the wall clock, so the tests aren't sensitive to things like NTP synchronization or leap seconds.

# Risk assessment

None. Changes are only to unit tests.