### PR TITLE
fix(engine): include modules w/o labware in motion planning

### DIFF
--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -56,13 +56,18 @@ class GeometryView:
 
         return self._get_highest_z_from_labware_data(labware_data)
 
+    # TODO(mc, 2022-06-24): rename this method
     def get_all_labware_highest_z(self) -> float:
         """Get the highest Z-point across all labware."""
         return max(
-            [
+            *(
                 self._get_highest_z_from_labware_data(lw_data)
                 for lw_data in self._labware.get_all()
-            ]
+            ),
+            *(
+                self._modules.get_overall_height(module.id)
+                for module in self._modules.get_all()
+            ),
         )
 
     def get_labware_parent_position(self, labware_id: str) -> Point:

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -463,8 +463,6 @@ class ModuleView(HasState[ModuleState]):
             z=definition.labwareOffset.z,
         )
 
-    # TODO(mc, 2022-01-19): this method is missing unit test coverage and
-    # is also unused. Remove or add tests.
     def get_overall_height(self, module_id: str) -> float:
         """Get the height of the module."""
         return self.get_dimensions(module_id).bareOverallHeight

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -15,6 +15,7 @@ from opentrons.protocol_engine.types import (
     DeckSlotLocation,
     ModuleLocation,
     LoadedLabware,
+    LoadedModule,
     WellLocation,
     WellOrigin,
     WellOffset,
@@ -213,6 +214,7 @@ def test_get_all_labware_highest_z(
     well_plate_def: LabwareDefinition,
     reservoir_def: LabwareDefinition,
     labware_view: LabwareView,
+    module_view: ModuleView,
     subject: GeometryView,
 ) -> None:
     """It should get the highest Z amongst all labware."""
@@ -233,6 +235,8 @@ def test_get_all_labware_highest_z(
 
     plate_offset = LabwareOffsetVector(x=1, y=-2, z=3)
     reservoir_offset = LabwareOffsetVector(x=1, y=-2, z=3)
+
+    decoy.when(module_view.get_all()).then_return([])
 
     decoy.when(labware_view.get_all()).then_return([plate, reservoir])
     decoy.when(labware_view.get("plate-id")).then_return(plate)
@@ -260,6 +264,26 @@ def test_get_all_labware_highest_z(
     all_z = subject.get_all_labware_highest_z()
 
     assert all_z == max(plate_z, reservoir_z)
+
+
+def test_get_all_labware_highest_z_with_modules(
+    decoy: Decoy,
+    labware_view: LabwareView,
+    module_view: ModuleView,
+    subject: GeometryView,
+) -> None:
+    """It should get the highest Z including modules."""
+    module_1 = LoadedModule.construct(id="module-id-1")  # type: ignore[call-arg]
+    module_2 = LoadedModule.construct(id="module-id-2")  # type: ignore[call-arg]
+
+    decoy.when(labware_view.get_all()).then_return([])
+    decoy.when(module_view.get_all()).then_return([module_1, module_2])
+    decoy.when(module_view.get_overall_height("module-id-1")).then_return(42.0)
+    decoy.when(module_view.get_overall_height("module-id-2")).then_return(1337.0)
+
+    result = subject.get_all_labware_highest_z()
+
+    assert result == 1337.0
 
 
 def test_get_labware_position(

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -1174,3 +1174,33 @@ def test_thermocycler_validate_target_lid_temperature_raises(
 
     with pytest.raises(errors.InvalidTargetTemperatureError):
         subject.validate_target_lid_temperature(input_temperature)
+
+
+@pytest.mark.parametrize(
+    ("module_definition", "expected_height"),
+    [
+        (lazy_fixture("thermocycler_v1_def"), 98.0),
+        (lazy_fixture("tempdeck_v1_def"), 84.0),
+        (lazy_fixture("tempdeck_v2_def"), 84.0),
+        (lazy_fixture("magdeck_v1_def"), 110.152),
+        (lazy_fixture("magdeck_v2_def"), 110.152),
+        (lazy_fixture("heater_shaker_v1_def"), 82.0),
+    ],
+)
+def test_get_overall_height(
+    module_definition: ModuleDefinition,
+    expected_height: float,
+) -> None:
+    """It should get a module's overall height."""
+    subject = make_module_view(
+        slot_by_module_id={"module-id": DeckSlotName.SLOT_7},
+        hardware_by_module_id={
+            "module-id": HardwareModule(
+                serial_number="serial-number",
+                definition=module_definition,
+            )
+        },
+    )
+
+    result = subject.get_overall_height("module-id")
+    assert result == expected_height


### PR DESCRIPTION
## Overview

This PR fixes a bug in ProtocolEngine's motion planning. Modules loaded into the engine without a labware would not be taken into account when calculating the safe travel height for arc movements. This could potentially lead to collisions during LPC if a protocol loaded modules in such a way.

### Videos

In this setup, I placed a blue piece of paper over a magnetic module so you can see the travel height of the pipette as it arcs

**`release_6.0.0` / `edge`**

https://user-images.githubusercontent.com/2963448/175611290-a3eb22af-413d-4f09-9cfb-9d2555d20090.MOV


**This branch**

https://user-images.githubusercontent.com/2963448/175611337-35ee418e-5aa3-4783-98f8-4af4278a4b71.MOV

## Changelog

- When getting the tallest item on the deck, check all labware _and_ all modules

## Review requests

Reproduction procedure below. Compare this logic to the PAPIv2 motion planning logic in `src/opentrons/protocols/geometry/planning.py`

## Risk assessment

My main question is if I've misunderstood something about thermocyclers. If I have, this could lead to spurious errors during. However, I'm not seeing any differences in max-Z calculations.

## Steps to reproduce

I reproduced the buggy behavior using an HTTP protocol, since this mirrors what LPC will be doing.

- P300 single pipette on the right mount
- Tip rack loaded in slot 4
- Well plate loaded in slot 3
- Magnetic module loaded in slot 2 (but not physically placed there, because we're testing for collisions)

Procedure:
1. Create run
2. Home
3. Load P300 single onto the right mount
4. Load well plate into slot 3
5. Load tip rack into slot 4
6. Load magnetic module into slot 2
7. Pick up a tip (with a little offset because that's what I need on my robot)
8. Move to well A1 of well plate
9. Move back to well A1 of the tip rack

```
POST /runs
{"data": {}}

POST /runs/:run_id/commands?waitUntilComplete=true
{
    "data": {
        "commandType": "home",
        "params": {}
    }
}

POST /runs/:run_id/commands?waitUntilComplete=true
{
    "data": {
        "commandType": "loadPipette",
        "params": {
            "pipetteName": "p300_single",
            "mount": "right",
            "pipetteId": "pipette-id"
        }
    }
}

POST /runs/:run_id/commands?waitUntilComplete=true
{
    "data": {
        "commandType": "loadLabware",
        "params": {
            "loadName": "corning_96_wellplate_360ul_flat",
            "version": 1,
            "namespace": "opentrons",
            "location": {"slotName": "3"},
            "labwareId": "well-plate-id"
        }
    }
}

POST /runs/:run_id/commands?waitUntilComplete=true
{
    "data": {
        "commandType": "loadLabware",
        "params": {
            "loadName": "opentrons_96_tiprack_300ul",
            "version": 1,
            "namespace": "opentrons",
            "location": {"slotName": "4"},
            "labwareId": "tip-rack-id"
        }
    }
}

POST /runs/:run_id/commands?waitUntilComplete=true
{
    "data": {
        "commandType": "loadModule",
        "params": {
            "model": "magneticModuleV2",
            "location": {"slotName": "2"},
            "moduleId": "module-id"
        }
    }
}

POST /runs/:run_id/commands?waitUntilComplete=true
{
    "data": {
        "commandType": "pickUpTip",
        "params": {
            "labwareId": "tip-rack-id",
            "pipetteId": "pipette-id",
            "wellName": "A1",
            "wellLocation": {
                "offset": { "x": 1, "y": 1, "z": 0 }
            }
        }
    }
}

POST /runs/:run_id/commands?waitUntilComplete=true
{
    "data": {
        "commandType": "moveToWell",
        "params": {
            "labwareId": "well-plate-id",
            "pipetteId": "pipette-id",
            "wellName": "A1"
        }
    }
}


POST /runs/:run_id/commands?waitUntilComplete=true
{
    "data": {
        "commandType": "moveToWell",
        "params": {
            "labwareId": "tip-rack-id",
            "pipetteId": "pipette-id",
            "wellName": "A1"
        }
    }
}