### PR TITLE
refactor(robot-server) Restore a call to `RunStore.has()` that we removed for performance

### DIFF
--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -92,17 +92,10 @@ async def get_current_run_engine_from_url(
         engine_store: Engine store to pull current run ProtocolEngine.
         run_store: Run data storage.
     """
-    # HACK(mm, 2022-05-19):
-    # This call to run_store.has() is commented out because it
-    # seems to stall the robot, for mysterious reasons.
-    # While it's commented, requests with bad run IDs will incorrectly return
-    # HTTP 409 instead of 404.
-    # https://github.com/Opentrons/opentrons/issues/10333
-
-    # if not run_store.has(runId):
-    #     raise RunNotFound(detail=f"Run {runId} not found.").as_error(
-    #         status.HTTP_404_NOT_FOUND
-    #     )
+    if not run_store.has(runId):
+        raise RunNotFound(detail=f"Run {runId} not found.").as_error(
+            status.HTTP_404_NOT_FOUND
+        )
 
     if runId != engine_store.current_run_id:
         raise RunStopped(detail=f"Run {runId} is not the current run").as_error(

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -51,11 +51,6 @@ async def test_get_current_run_engine_from_url(
     assert result is mock_engine_store.engine
 
 
-# TODO(mm, 2022-05-19): Remove this xfail when we resolve mysteries about
-# performance problems and are able to add the call to run_store.has()
-# back into get_current_run_engine_from_url() without causing stalls.
-# https://github.com/Opentrons/opentrons/issues/10333
-@pytest.mark.xfail(strict=True)
 async def test_get_current_run_engine_no_run(
     decoy: Decoy,
     mock_engine_store: EngineStore,


### PR DESCRIPTION
# Overview

This undoes a performance workaround that we made in PR #10340. Based on testing, I now believe that workaround to be unnecessary.

This resolves part of the tech debt ticket #10353. See that ticket for background.

# My testing

I followed the reproduction steps I've outlined in #10353:

> * As mentioned by @y3rsh in issue #10333, use @y3rsh's test script in PR #10330 to make the robot move.
> * As mentioned by @y3rsh in issue #10345, flip back and forth between the Opentrons App's devices page and the robot details page to keep the robot busy with network traffic.

Except for the following changes:

* Instead of hitting Enter to cycle through points in the labware, I modified the script to use an infinite `while` loop.
* I changed the pipette that the script was using to match what I had on hand.
* I removed the Heater-Shaker from the test entirely.
* In addition to using the Opentrons App to create network traffic, I used Postman to spam `GET /runs/{some arbitrary run id}/commands?pageLength=1` to trigger calls to the `RunStore.has()` call.

I then tried various combinations of:

1. Uncommenting the router's call to `RunStore.has()`.
    * Didn't seem to make a difference.
2. Removing the `@lru_cache` on `RunStore.has()`.
    * Might have made a difference. I'm not sure.
3. Removing the `@lru_cache`s on every other `RunStore` and `ProtocolStore` method.
    * Made a big difference, but even then, it wasn't as severe as in @y3rsh's original videos. I saw stalls of maybe ~5 seconds at a time, not tens of seconds.
4. Changing the `RunStore.has()` implementation to select the entire row instead of just a single column. This is how it worked when @y3rsh originally reported the performance problems.
    * Didn't seem to make a difference.

# Review requests

* [ ] Do we agree with this change?
* [ ] Is there a better way I could have tried to reproduce the problem?

# Risk assessment

There's a risk of causing user-visible stalls if I'm wrong.

The fact that I couldn't reproduce the original problem exactly as reported by @y3rsh could be a hint that we're missing some crucial part of triggering it, falsely leading us to believe that this change is safe.