### PR TITLE
refactor(api): hardware control - change instr handler name to pip handler and move files to `instruments` module

### DIFF
--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -61,6 +61,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_SANDBOX_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SANDBOX_SECRET }}
+          AWS_DEFAULT_REGION: us-east-2
         uses: './.github/actions/webstack/deploy-to-sandbox'
         with:
           domain: 'docs.opentrons.com'

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -14,8 +14,6 @@ from .adapters import SynchronousAdapter
 from .api import API
 from .pause_manager import PauseManager
 from .backends import Controller, Simulator
-from .pipette import Pipette
-from .gripper import Gripper
 from .types import (
     CriticalPoint,
     NoTipAttachedError,
@@ -28,7 +26,7 @@ from .thread_manager import ThreadManager
 from .execution_manager import ExecutionManager
 from .threaded_async_lock import ThreadedAsyncLock, ThreadedAsyncForbidden
 from .protocols import HardwareControlAPI
-from .instrument_abc import AbstractInstrument
+from .instruments import AbstractInstrument, Pipette, Gripper
 
 ThreadManagedHardware = ThreadManager[HardwareControlAPI]
 SyncHardwareAPI = SynchronousAdapter[HardwareControlAPI]

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -24,7 +24,10 @@ from opentrons.config import robot_configs
 from opentrons.config.types import RobotConfig, OT3Config
 
 from .util import use_or_initialize_loop, check_motion_bounds
-from .pipette import generate_hardware_configs, load_from_config_and_check_skip
+from .instruments.pipette import (
+    generate_hardware_configs,
+    load_from_config_and_check_skip,
+)
 from .backends import Controller, Simulator
 from .execution_manager import ExecutionManagerProvider
 from .pause_manager import PauseManager
@@ -48,7 +51,7 @@ from .robot_calibration import (
     RobotCalibration,
 )
 from .protocols import HardwareControlAPI
-from .instrument_handler import InstrumentHandlerProvider
+from .instruments.pipette_handler import PipetteHandlerProvider
 from .motion_utilities import (
     target_position_from_absolute,
     target_position_from_relative,
@@ -64,7 +67,7 @@ mod_log = logging.getLogger(__name__)
 class API(
     ExecutionManagerProvider,
     RobotCalibrationProvider,
-    InstrumentHandlerProvider[top_types.Mount],
+    PipetteHandlerProvider[top_types.Mount],
     # This MUST be kept last in the inheritance list so that it is
     # deprioritized in the method resolution order; otherwise, invocations
     # of methods that are present in the protocol will call the (empty,
@@ -121,7 +124,7 @@ class API(
         self._pause_manager = PauseManager(self._door_state)
         ExecutionManagerProvider.__init__(self, isinstance(backend, Simulator))
         RobotCalibrationProvider.__init__(self)
-        InstrumentHandlerProvider.__init__(
+        PipetteHandlerProvider.__init__(
             self, {top_types.Mount.LEFT: None, top_types.Mount.RIGHT: None}
         )
 
@@ -488,7 +491,7 @@ class API(
         """Reset the stored state of the system."""
         self._pause_manager.reset()
         await self._execution_manager.reset()
-        await InstrumentHandlerProvider.reset(self)
+        await PipetteHandlerProvider.reset(self)
 
     # Gantry/frame (i.e. not pipette) action API
     async def home_z(self, mount: Optional[top_types.Mount] = None) -> None:
@@ -1053,7 +1056,7 @@ class API(
     def get_instrument_max_height(
         self, mount: top_types.Mount, critical_point: Optional[CriticalPoint] = None
     ) -> float:
-        return InstrumentHandlerProvider.instrument_max_height(
+        return PipetteHandlerProvider.instrument_max_height(
             self, mount, self._config.z_retract_distance, critical_point
         )
 

--- a/api/src/opentrons/hardware_control/instruments/__init__.py
+++ b/api/src/opentrons/hardware_control/instruments/__init__.py
@@ -1,0 +1,6 @@
+from .instrument_abc import AbstractInstrument
+from .pipette import Pipette
+from .gripper import Gripper
+
+
+__all__ = ["AbstractInstrument", "Pipette", "Gripper"]

--- a/api/src/opentrons/hardware_control/instruments/gripper.py
+++ b/api/src/opentrons/hardware_control/instruments/gripper.py
@@ -9,8 +9,8 @@ from typing import Any, Dict, Optional, Union
 from opentrons.types import Point
 from opentrons.calibration_storage.types import GripperCalibrationOffset
 from opentrons.config import gripper_config
+from opentrons.hardware_control.types import CriticalPoint
 from .instrument_abc import AbstractInstrument
-from .types import CriticalPoint
 
 RECONFIG_KEYS = {"quirks"}
 

--- a/api/src/opentrons/hardware_control/instruments/instrument_abc.py
+++ b/api/src/opentrons/hardware_control/instruments/instrument_abc.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Optional, Generic, TypeVar
 
 from opentrons.types import Point
-from .types import CriticalPoint
+from opentrons.hardware_control.types import CriticalPoint
 
 
 InstrumentConfig = TypeVar("InstrumentConfig")

--- a/api/src/opentrons/hardware_control/instruments/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/pipette.py
@@ -16,7 +16,7 @@ from opentrons.config import pipette_config, robot_configs
 from opentrons.config.types import RobotConfig, OT3Config
 from opentrons.drivers.types import MoveSplit
 from .instrument_abc import AbstractInstrument
-from .types import CriticalPoint, BoardRevision, OT3AxisKind
+from opentrons.hardware_control.types import CriticalPoint, BoardRevision, OT3AxisKind
 
 
 if TYPE_CHECKING:
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
         PipetteName,
         PipetteModel,
     )
-    from .dev_types import InstrumentHardwareConfigs
+    from opentrons.hardware_control.dev_types import InstrumentHardwareConfigs
 
 
 RECONFIG_KEYS = {"quirks"}

--- a/api/src/opentrons/hardware_control/instruments/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/pipette_handler.py
@@ -137,7 +137,7 @@ class PipetteHandlerProvider(Generic[MountType]):
         Also available as :py:meth:`get_attached_instruments`.
 
         This returns a dictified version of the
-        :py:class:`hardware_control.pipette.Pipette` as a dict keyed by
+        :py:class:`hardware_control.instruments.pipette.Pipette` as a dict keyed by
         the :py:class:`top_types.Mount` to which the pipette is attached.
         If no pipette is attached on a given mount, the mount key will
         still be present but will have the value ``None``.

--- a/api/src/opentrons/hardware_control/instruments/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/pipette_handler.py
@@ -19,7 +19,7 @@ from typing import (
 from opentrons_shared_data.pipette.dev_types import UlPerMmAction
 
 from opentrons import types as top_types
-from .types import (
+from opentrons.hardware_control.types import (
     CriticalPoint,
     HardwareAction,
     TipAttachedError,
@@ -28,15 +28,15 @@ from .types import (
     OT3Axis,
     OT3Mount,
 )
-from .constants import (
+from opentrons.hardware_control.constants import (
     SHAKE_OFF_TIPS_SPEED,
     SHAKE_OFF_TIPS_PICKUP_DISTANCE,
     DROP_TIP_RELEASE_DISTANCE,
     SHAKE_OFF_TIPS_DROP_DISTANCE,
 )
 
-from .robot_calibration import load_pipette_offset
-from .dev_types import PipetteDict
+from opentrons.hardware_control.robot_calibration import load_pipette_offset
+from opentrons.hardware_control.dev_types import PipetteDict
 from .pipette import Pipette
 
 
@@ -94,13 +94,13 @@ class DropTipSpec(Generic[AxisType]):
     ending_current: Dict[AxisType, float]
 
 
-class InstrumentHandlerProvider(Generic[MountType]):
+class PipetteHandlerProvider(Generic[MountType]):
     IHP_LOG = MOD_LOG.getChild("InstrumentHandler")
 
     def __init__(self, attached_instruments: InstrumentsByMount[MountType]):
         assert attached_instruments
         self._attached_instruments: InstrumentsByMount[MountType] = attached_instruments
-        self._ihp_log = InstrumentHandlerProvider.IHP_LOG.getChild(str(id(self)))
+        self._ihp_log = PipetteHandlerProvider.IHP_LOG.getChild(str(id(self)))
 
     def reset_instrument(self, mount: Optional[MountType] = None) -> None:
         """
@@ -892,7 +892,7 @@ class InstrumentHandlerProvider(Generic[MountType]):
         return pip
 
 
-class OT3InstrumentHandler(InstrumentHandlerProvider[OT3Mount]):
+class OT3PipetteHandler(PipetteHandlerProvider[OT3Mount]):
     """Override for correct plunger_position."""
 
     def plunger_position(

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -160,7 +160,7 @@ class OT3API(
             )
         )
 
-        self._instrument_handler = OT3PipetteHandler({m: None for m in OT3Mount})
+        self._pipette_handler = OT3PipetteHandler({m: None for m in OT3Mount})
         ExecutionManagerProvider.__init__(self, isinstance(backend, OT3Simulator))
 
     def set_robot_calibration(self, robot_calibration: RobotCalibration) -> None:
@@ -422,12 +422,12 @@ class OT3API(
             pip_offset_cal = load_pipette_offset(pip_id, mount.to_mount())
             p, may_skip = load_from_config_and_check_skip(
                 config,
-                self._instrument_handler.hardware_instruments[mount],
+                self._pipette_handler.hardware_instruments[mount],
                 req_instr,
                 pip_id,
                 pip_offset_cal,
             )
-            self._instrument_handler.hardware_instruments[mount] = p
+            self._pipette_handler.hardware_instruments[mount] = p
             if req_instr and p:
                 p.act_as(req_instr)
 
@@ -443,7 +443,7 @@ class OT3API(
         await self._backend.probe_network()
         await self.set_gantry_load(
             self._gantry_load_from_instruments(
-                self._instrument_handler.attached_instruments
+                self._pipette_handler.attached_instruments
             )
         )
 
@@ -504,7 +504,7 @@ class OT3API(
         """Reset the stored state of the system."""
         self._pause_manager.reset()
         await self._execution_manager.reset()
-        await self._instrument_handler.reset()
+        await self._pipette_handler.reset()
         await self.cache_instruments()
 
     # Gantry/frame (i.e. not pipette) action API
@@ -527,7 +527,7 @@ class OT3API(
 
         checked_mount = OT3Mount.from_mount(mount)
         await self.home([OT3Axis.of_main_tool_actuator(checked_mount)])
-        instr = self._instrument_handler.hardware_instruments[checked_mount]
+        instr = self._pipette_handler.hardware_instruments[checked_mount]
         if instr:
             target_pos = target_position_from_plunger(
                 checked_mount, instr.config.bottom, self._current_position
@@ -877,14 +877,14 @@ class OT3API(
     ) -> None:
         """Prepare the pipette for aspiration."""
         checked_mount = OT3Mount.from_mount(mount)
-        instrument = self._instrument_handler.get_pipette(checked_mount)
+        instrument = self._pipette_handler.get_pipette(checked_mount)
 
-        self._instrument_handler.ready_for_tip_action(
+        self._pipette_handler.ready_for_tip_action(
             instrument, HardwareAction.PREPARE_ASPIRATE
         )
 
         if instrument.current_volume == 0:
-            speed = self._instrument_handler.plunger_speed(
+            speed = self._pipette_handler.plunger_speed(
                 instrument, instrument.blow_out_flow_rate, "aspirate"
             )
             bottom = instrument.config.bottom
@@ -907,7 +907,7 @@ class OT3API(
         """
         Aspirate a volume of liquid (in microliters/uL) using this pipette."""
         realmount = OT3Mount.from_mount(mount)
-        aspirate_spec = self._instrument_handler.plan_check_aspirate(
+        aspirate_spec = self._pipette_handler.plan_check_aspirate(
             realmount, volume, rate
         )
         if not aspirate_spec:
@@ -944,7 +944,7 @@ class OT3API(
         """
         Dispense a volume of liquid in microliters(uL) using this pipette."""
         realmount = OT3Mount.from_mount(mount)
-        dispense_spec = self._instrument_handler.plan_check_dispense(
+        dispense_spec = self._pipette_handler.plan_check_dispense(
             realmount, volume, rate
         )
         if not dispense_spec:
@@ -977,7 +977,7 @@ class OT3API(
         the current location of pipette
         """
         realmount = OT3Mount.from_mount(mount)
-        blowout_spec = self._instrument_handler.plan_check_blow_out(realmount)
+        blowout_spec = self._pipette_handler.plan_check_blow_out(realmount)
         await self._backend.set_active_current(
             {blowout_spec.axis: blowout_spec.current}
         )
@@ -1009,7 +1009,7 @@ class OT3API(
     ) -> None:
         """Pick up tip from current location."""
         realmount = OT3Mount.from_mount(mount)
-        spec, _add_tip_to_instrs = self._instrument_handler.plan_check_pick_up_tip(
+        spec, _add_tip_to_instrs = self._pipette_handler.plan_check_pick_up_tip(
             realmount, tip_length, presses, increment
         )
         await self._backend.set_active_current(
@@ -1051,7 +1051,7 @@ class OT3API(
     def set_current_tiprack_diameter(
         self, mount: Union[top_types.Mount, OT3Mount], tiprack_diameter: float
     ) -> None:
-        instrument = self._instrument_handler.get_pipette(OT3Mount.from_mount(mount))
+        instrument = self._pipette_handler.get_pipette(OT3Mount.from_mount(mount))
         self._log.info(
             "Updating tip rack diameter on pipette mount: "
             f"{mount.name}, tip diameter: {tiprack_diameter} mm"
@@ -1061,7 +1061,7 @@ class OT3API(
     def set_working_volume(
         self, mount: Union[top_types.Mount, OT3Mount], tip_volume: int
     ) -> None:
-        instrument = self._instrument_handler.get_pipette(OT3Mount.from_mount(mount))
+        instrument = self._pipette_handler.get_pipette(OT3Mount.from_mount(mount))
         self._log.info(
             "Updating working volume on pipette mount:"
             f"{mount.name}, tip volume: {tip_volume} ul"
@@ -1073,9 +1073,7 @@ class OT3API(
     ) -> None:
         """Drop tip at the current location."""
         realmount = OT3Mount.from_mount(mount)
-        spec, _remove = self._instrument_handler.plan_check_drop_tip(
-            realmount, home_after
-        )
+        spec, _remove = self._pipette_handler.plan_check_drop_tip(realmount, home_after)
         for move in spec.drop_moves:
             await self._backend.set_active_current(
                 {
@@ -1133,7 +1131,7 @@ class OT3API(
         mount: Union[top_types.Mount, OT3Mount],
         cp_override: Optional[CriticalPoint] = None,
     ) -> top_types.Point:
-        return self._instrument_handler.critical_point_for(
+        return self._pipette_handler.critical_point_for(
             OT3Mount.from_mount(mount), cp_override
         )
 
@@ -1142,14 +1140,14 @@ class OT3API(
         # override required for type matching
         return {
             m.to_mount(): i
-            for m, i in self._instrument_handler.hardware_instruments.items()
+            for m, i in self._pipette_handler.hardware_instruments.items()
             if m != OT3Mount.GRIPPER
         }
 
     def get_attached_instruments(self) -> Dict[top_types.Mount, PipetteDict]:
         return {
             m.to_mount(): pd
-            for m, pd in self._instrument_handler.get_attached_instruments().items()
+            for m, pd in self._pipette_handler.get_attached_instruments().items()
             if m != OT3Mount.GRIPPER
         }
 
@@ -1160,20 +1158,18 @@ class OT3API(
             checked_mount: Optional[OT3Mount] = OT3Mount.from_mount(mount)
         else:
             checked_mount = None
-        self._instrument_handler.reset_instrument(checked_mount)
+        self._pipette_handler.reset_instrument(checked_mount)
 
     def get_attached_instrument(
         self, mount: Union[top_types.Mount, OT3Mount]
     ) -> PipetteDict:
-        return self._instrument_handler.get_attached_instrument(
-            OT3Mount.from_mount(mount)
-        )
+        return self._pipette_handler.get_attached_instrument(OT3Mount.from_mount(mount))
 
     @property
     def attached_instruments(self) -> Dict[top_types.Mount, PipetteDict]:
         return {
             m.to_mount(): d
-            for m, d in self._instrument_handler.attached_instruments.items()
+            for m, d in self._pipette_handler.attached_instruments.items()
             if m != OT3Mount.GRIPPER
         }
 
@@ -1185,7 +1181,7 @@ class OT3API(
         blow_out: Optional[float] = None,
         drop_tip: Optional[float] = None,
     ) -> None:
-        self._instrument_handler.calibrate_plunger(
+        self._pipette_handler.calibrate_plunger(
             OT3Mount.from_mount(mount), top, bottom, blow_out, drop_tip
         )
 
@@ -1196,7 +1192,7 @@ class OT3API(
         dispense: Optional[float] = None,
         blow_out: Optional[float] = None,
     ) -> None:
-        return self._instrument_handler.set_flow_rate(
+        return self._pipette_handler.set_flow_rate(
             OT3Mount.from_mount(mount), aspirate, dispense, blow_out
         )
 
@@ -1207,7 +1203,7 @@ class OT3API(
         dispense: Optional[float] = None,
         blow_out: Optional[float] = None,
     ) -> None:
-        self._instrument_handler.set_pipette_speed(
+        self._pipette_handler.set_pipette_speed(
             OT3Mount.from_mount(mount), aspirate, dispense, blow_out
         )
 
@@ -1231,10 +1227,10 @@ class OT3API(
     async def add_tip(
         self, mount: Union[top_types.Mount, OT3Mount], tip_length: float
     ) -> None:
-        await self._instrument_handler.add_tip(OT3Mount.from_mount(mount), tip_length)
+        await self._pipette_handler.add_tip(OT3Mount.from_mount(mount), tip_length)
 
     async def remove_tip(self, mount: Union[top_types.Mount, OT3Mount]) -> None:
-        await self._instrument_handler.remove_tip(OT3Mount.from_mount(mount))
+        await self._pipette_handler.remove_tip(OT3Mount.from_mount(mount))
 
     async def capacitive_probe(
         self,

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -37,7 +37,7 @@ from opentrons_hardware.hardware_control.motion_planning import (
 
 
 from .util import use_or_initialize_loop, check_motion_bounds
-from .pipette import (
+from .instruments.pipette import (
     generate_hardware_configs_ot3,
     load_from_config_and_check_skip,
 )
@@ -73,7 +73,7 @@ from .robot_calibration import (
 
 
 from .protocols import HardwareControlAPI
-from .instrument_handler import OT3InstrumentHandler, InstrumentsByMount
+from .instruments.pipette_handler import OT3PipetteHandler, InstrumentsByMount
 from .motion_utilities import (
     target_position_from_absolute,
     target_position_from_relative,
@@ -160,7 +160,7 @@ class OT3API(
             )
         )
 
-        self._instrument_handler = OT3InstrumentHandler({m: None for m in OT3Mount})
+        self._instrument_handler = OT3PipetteHandler({m: None for m in OT3Mount})
         ExecutionManagerProvider.__init__(self, isinstance(backend, OT3Simulator))
 
     def set_robot_calibration(self, robot_calibration: RobotCalibration) -> None:

--- a/api/src/opentrons/hardware_control/protocols/instrument_configurer.py
+++ b/api/src/opentrons/hardware_control/protocols/instrument_configurer.py
@@ -53,7 +53,7 @@ class InstrumentConfigurer(Protocol):
         Also available as :py:meth:`get_attached_instruments`.
 
         This returns a dictified version of the
-        hardware_control.pipette.Pipette as a dict keyed by
+        hardware_control.instruments.pipette.Pipette as a dict keyed by
         the Mount to which the pipette is attached.
         If no pipette is attached on a given mount, the mount key will
         still be present but will have the value ``None``.

--- a/api/src/opentrons/hardware_control/protocols/instrument_configurer.py
+++ b/api/src/opentrons/hardware_control/protocols/instrument_configurer.py
@@ -4,7 +4,7 @@ from typing_extensions import Protocol
 from opentrons_shared_data.pipette.dev_types import PipetteName
 from opentrons.types import Mount
 
-from ..pipette import Pipette
+from opentrons.hardware_control.instruments.pipette import Pipette
 from ..dev_types import PipetteDict
 from ..types import CriticalPoint
 

--- a/api/tests/opentrons/hardware_control/test_gripper.py
+++ b/api/tests/opentrons/hardware_control/test_gripper.py
@@ -1,6 +1,6 @@
 from opentrons.types import Point
 from opentrons.hardware_control.robot_calibration import load_gripper_calibration_offset
-from opentrons.hardware_control import gripper
+from opentrons.hardware_control.instruments import gripper
 from opentrons.config import gripper_config
 from opentrons.calibration_storage.delete import clear_gripper_calibration_offsets
 

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -120,7 +120,7 @@ def get_plunger_speed(api):
     if isinstance(api, API):
         return api.plunger_speed
     else:
-        return api._instrument_handler.plunger_speed
+        return api._pipette_handler.plunger_speed
 
 
 async def test_cache_instruments(sim_and_instr):

--- a/api/tests/opentrons/hardware_control/test_pipette.py
+++ b/api/tests/opentrons/hardware_control/test_pipette.py
@@ -1,7 +1,8 @@
 import pytest
 from opentrons.calibration_storage import types as cal_types
 from opentrons.types import Point
-from opentrons.hardware_control import pipette, types
+from opentrons.hardware_control.instruments import pipette
+from opentrons.hardware_control import types
 from opentrons.config import pipette_config
 
 PIP_CAL = cal_types.PipetteOffsetByPipetteMount(

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -16,7 +16,7 @@ from opentrons.protocols.context.protocol_api.protocol_context import (
 )
 from opentrons.types import Mount, Point, Location, TransferTipPolicy
 from opentrons.hardware_control import API, NoTipAttachedError
-from opentrons.hardware_control.pipette import Pipette
+from opentrons.hardware_control.instruments.pipette import Pipette
 from opentrons.hardware_control.types import Axis
 from opentrons.protocols.advanced_control import transfers as tf
 from opentrons.config.pipette_config import config_names

--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -17,7 +17,7 @@ from opentrons.calibration_storage.types import TipLengthCalNotFound
 from opentrons.calibration_storage import helpers
 from opentrons.hardware_control import robot_calibration as robot_cal
 from opentrons.hardware_control import HardwareControlAPI, CriticalPoint
-from opentrons.hardware_control.pipette import Pipette
+from opentrons.hardware_control.instruments.pipette import Pipette
 from opentrons.protocol_api import labware
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.types import Mount, Point, Location

--- a/robot-server/robot_server/robot/calibration/util.py
+++ b/robot-server/robot_server/robot/calibration/util.py
@@ -2,7 +2,7 @@ import logging
 import contextlib
 from typing import Set, Dict, Any, Union, List, Optional, TYPE_CHECKING
 
-from opentrons.hardware_control import Pipette
+from opentrons.hardware_control.instruments import Pipette
 from opentrons.hardware_control.util import plan_arc
 from opentrons.hardware_control.types import CriticalPoint
 from opentrons.protocol_api import labware

--- a/robot-server/tests/robot/calibration/check/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/check/test_user_flow.py
@@ -2,7 +2,7 @@ from typing import List, Tuple
 from mock import call, MagicMock, patch
 
 import pytest
-from opentrons.hardware_control import pipette
+from opentrons.hardware_control.instruments import pipette
 from opentrons.types import Mount, Point
 from opentrons.calibration_storage import get, modify, types as CSTypes
 from opentrons.config import robot_configs

--- a/robot-server/tests/robot/calibration/deck/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/deck/test_user_flow.py
@@ -3,7 +3,7 @@ from mock import MagicMock, call
 from typing import List, Tuple
 from opentrons.calibration_storage import types as cal_types
 from opentrons.types import Mount, Point
-from opentrons.hardware_control import pipette
+from opentrons.hardware_control.instruments import pipette
 from opentrons.config import robot_configs
 from opentrons.config.pipette_config import load
 from opentrons.protocol_api import labware

--- a/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
@@ -6,7 +6,7 @@ from typing import List, Tuple, Dict, Any
 from opentrons import config
 from opentrons.calibration_storage import helpers, types as CSTypes
 from opentrons.types import Mount, Point
-from opentrons.hardware_control import pipette
+from opentrons.hardware_control.instruments import pipette
 from opentrons.config.pipette_config import load
 from opentrons.protocol_api import labware
 

--- a/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
@@ -4,7 +4,7 @@ from mock import ANY, patch, call
 from typing import List, Tuple, Dict, Any
 from opentrons import config
 from opentrons.types import Mount, Point
-from opentrons.hardware_control import pipette
+from opentrons.hardware_control.instruments import pipette
 from opentrons.protocol_api.labware import get_labware_definition
 from opentrons.config.pipette_config import load
 from opentrons.calibration_storage import types as cal_types


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
For OT2, the names `pipette` and `instrument` are interchangeable because pipette is the only instrument type available. 

However, in the OT3, we got `pipette` and `gripper` as available instruments. To make this less confusing, the current instrument handler will be renamed to Pipette handler. 

This PR also adds an `instruments` module to hardware control api so we can manage instrument-related code easier.

A follow-up PR will add a GripperHandler to the OT3 api, and have a member `InstrumentManager` to take care of `cache_instruments` and `reset_instruments` (should handle both Pipettes and Gripper).

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
