### PR TITLE
 fix(app): module slideouts with multiple controls delete value on close

### DIFF
--- a/app/src/organisms/ModuleCard/HeaterShakerSlideout.tsx
+++ b/app/src/organisms/ModuleCard/HeaterShakerSlideout.tsx
@@ -170,6 +170,11 @@ export const HeaterShakerSlideout = (
   const inputMin = isSetShake ? HS_RPM_MIN : HS_TEMP_MIN
   const unit = isSetShake ? RPM : CELSIUS
 
+  const handleCloseSlideout = (): void => {
+    setHsValue(null)
+    onCloseClick()
+  }
+
   return (
     <>
       {showConfirmationModal && (
@@ -186,7 +191,7 @@ export const HeaterShakerSlideout = (
           part: modulePart,
           name: moduleName,
         })}
-        onCloseClick={onCloseClick}
+        onCloseClick={handleCloseSlideout}
         isExpanded={isExpanded}
         footer={
           <SubmitPrimaryButton

--- a/app/src/organisms/ModuleCard/ThermocyclerModuleSlideout.tsx
+++ b/app/src/organisms/ModuleCard/ThermocyclerModuleSlideout.tsx
@@ -134,10 +134,15 @@ export const ThermocyclerModuleSlideout = (
     onCloseClick()
   }
 
+  const handleCloseSlideout = (): void => {
+    setTempValue(null)
+    onCloseClick()
+  }
+
   return (
     <Slideout
       title={t('tc_set_temperature', { part: modulePart, name: moduleName })}
-      onCloseClick={onCloseClick}
+      onCloseClick={handleCloseSlideout}
       isExpanded={isExpanded}
       footer={
         <SubmitPrimaryButton

--- a/app/src/organisms/ModuleCard/__tests__/HeaterShakerSlideout.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/HeaterShakerSlideout.test.tsx
@@ -157,6 +157,25 @@ describe('HeaterShakerSlideout', () => {
     })
     expect(button).not.toBeEnabled()
   })
+
+  it('renders the exit button and when clicked, deletes the value input', () => {
+    props = {
+      module: mockHeaterShaker,
+      isSetShake: false,
+      isExpanded: true,
+      onCloseClick: jest.fn(),
+      isLoadedInRun: false,
+    }
+    const { getByLabelText, getByTestId } = render(props)
+    const button = getByLabelText('exit')
+    const input = getByTestId('heaterShakerModuleV1_false')
+    fireEvent.change(input, { target: { value: '40' } })
+    fireEvent.click(button)
+
+    expect(props.onCloseClick).toHaveBeenCalled()
+    expect(input).not.toHaveValue()
+  })
+
   it('renders heater shaker form field and when button is clicked, confirm attachment modal is not rendered', () => {
     mockGetIsHeaterShakerAttached.mockReturnValue(true)
     props = {

--- a/app/src/organisms/ModuleCard/__tests__/ThermocyclerModuleSlideout.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/ThermocyclerModuleSlideout.test.tsx
@@ -157,6 +157,24 @@ describe('ThermocyclerModuleSlideout', () => {
     expect(button).not.toBeEnabled()
   })
 
+  it('renders the exit button and when clicked, deletes the value input', () => {
+    props = {
+      module: mockThermocycler,
+      isSecondaryTemp: true,
+      isExpanded: true,
+      onCloseClick: jest.fn(),
+      isLoadedInRun: false,
+    }
+    const { getByLabelText, getByTestId } = render(props)
+    const button = getByLabelText('exit')
+    const input = getByTestId('thermocyclerModuleV1_true')
+    fireEvent.change(input, { target: { value: '45' } })
+    fireEvent.click(button)
+
+    expect(props.onCloseClick).toHaveBeenCalled()
+    expect(input).not.toHaveValue()
+  })
+
   it('renders the button and it is not clickable until there is something in form field for the TC Block when there is a runId', () => {
     mockUseRunStatuses.mockReturnValue({
       isLegacySessionInProgress: false,


### PR DESCRIPTION
closes #10865 re #10839

# Overview

- if you add a value to the H-S or TC slideouts and close the slideout, the value will delete.

# Changelog

- add on close logic to `HeaterSHakerSlideout` and `ThermocyclerModuleSlideout` and add test cases

# Review requests

- open a H-S slideout and add a value in the input field. Close out of the slideout without deleting the value. Open the other slideout, the input value should be null
- repeat with the thermocycler slideouts

# Risk assessment

low