### PR TITLE
refactor(app): protocol details page design qa feedback 1

### DIFF
--- a/app/src/organisms/ProtocolDetails/OverflowMenu.tsx
+++ b/app/src/organisms/ProtocolDetails/OverflowMenu.tsx
@@ -60,7 +60,7 @@ export function OverflowMenu(props: OverflowMenuProps): JSX.Element {
           boxShadow={'0px 1px 3px rgba(0, 0, 0, 0.2)'}
           position={POSITION_ABSOLUTE}
           backgroundColor={COLORS.white}
-          top="3rem"
+          top="2.3rem"
           right={0}
           flexDirection={DIRECTION_COLUMN}
         >

--- a/app/src/organisms/ProtocolDetails/ProtocolLabwareDetails.tsx
+++ b/app/src/organisms/ProtocolDetails/ProtocolLabwareDetails.tsx
@@ -61,7 +61,6 @@ export const ProtocolLabwareDetails = (
         <StyledText
           as="label"
           fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-          color={COLORS.darkBlack}
           marginBottom={SPACING.spacing3}
           data-testid={'ProtocolLabwareDetails_labware_name'}
           width="66%"
@@ -71,7 +70,6 @@ export const ProtocolLabwareDetails = (
         <StyledText
           as="label"
           fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-          color={COLORS.darkBlack}
           data-testid={'ProtocolLabwareDetails_quantity'}
         >
           {t('quantity')}
@@ -131,17 +129,11 @@ export const ProtocolLabwareDetailItem = (
           ) : (
             <Flex marginLeft={SPACING.spacingM} />
           )}
-          <StyledText
-            as="p"
-            color={COLORS.darkBlack}
-            paddingRight={SPACING.spacing6}
-          >
+          <StyledText as="p" paddingRight={SPACING.spacing6}>
             {displayName}
           </StyledText>
         </Flex>
-        <StyledText as="p" color={COLORS.darkBlack}>
-          {quantity}
-        </StyledText>
+        <StyledText as="p">{quantity}</StyledText>
         <LabwareDetailOverflowMenu labware={labware} />
       </Flex>
     </>

--- a/app/src/organisms/ProtocolDetails/ProtocolLabwareDetails.tsx
+++ b/app/src/organisms/ProtocolDetails/ProtocolLabwareDetails.tsx
@@ -9,7 +9,6 @@ import {
   Icon,
   POSITION_ABSOLUTE,
   POSITION_RELATIVE,
-  SIZE_5,
   SPACING,
   TYPOGRAPHY,
 } from '@opentrons/components'
@@ -61,6 +60,7 @@ export const ProtocolLabwareDetails = (
           color={COLORS.darkBlack}
           marginBottom={SPACING.spacing3}
           data-testid={'ProtocolLabwareDetails_labware_name'}
+          width="66%"
         >
           {t('labware_name')}
         </StyledText>
@@ -68,7 +68,6 @@ export const ProtocolLabwareDetails = (
           as="label"
           fontWeight={TYPOGRAPHY.fontWeightSemiBold}
           color={COLORS.darkBlack}
-          marginLeft={SIZE_5}
           data-testid={'ProtocolLabwareDetails_quantity'}
         >
           {t('quantity')}
@@ -110,22 +109,29 @@ export const ProtocolLabwareDetailItem = (
         marginY={SPACING.spacing3}
         alignItems={ALIGN_CENTER}
       >
-        <Flex flexDirection={DIRECTION_ROW} alignItems={ALIGN_CENTER}>
+        <Flex
+          flexDirection={DIRECTION_ROW}
+          alignItems={ALIGN_CENTER}
+          width="66%"
+          marginRight="1.25rem"
+        >
           {namespace === 'opentrons' ? (
             <Icon
               color={COLORS.blue}
               name="check-decagram"
-              height=".75rem"
+              height="0.75rem"
+              minHeight="0.75rem"
+              minWidth="0.75rem"
               marginRight={SPACING.spacing3}
             />
           ) : (
             <Flex marginLeft={SPACING.spacingM} />
           )}
-          <StyledText as="p" color={COLORS.darkBlack} width={SIZE_5}>
+          <StyledText as="p" color={COLORS.darkBlack} paddingRight="2rem">
             {displayName}
           </StyledText>
         </Flex>
-        <StyledText as="p" color={COLORS.darkBlack} marginLeft={'5rem'}>
+        <StyledText as="p" color={COLORS.darkBlack}>
           {quantity}
         </StyledText>
         <LabwareDetailOverflowMenu labware={labware} />

--- a/app/src/organisms/ProtocolDetails/ProtocolLabwareDetails.tsx
+++ b/app/src/organisms/ProtocolDetails/ProtocolLabwareDetails.tsx
@@ -52,7 +52,11 @@ export const ProtocolLabwareDetails = (
       : []
 
   return (
-    <Flex flexDirection={DIRECTION_COLUMN} width="100%">
+    <Flex
+      flexDirection={DIRECTION_COLUMN}
+      width="100%"
+      marginBottom={SPACING.spacing3}
+    >
       <Flex flexDirection={DIRECTION_ROW}>
         <StyledText
           as="label"
@@ -113,7 +117,7 @@ export const ProtocolLabwareDetailItem = (
           flexDirection={DIRECTION_ROW}
           alignItems={ALIGN_CENTER}
           width="66%"
-          marginRight="1.25rem"
+          marginRight={SPACING.spacingM}
         >
           {namespace === 'opentrons' ? (
             <Icon
@@ -127,7 +131,11 @@ export const ProtocolLabwareDetailItem = (
           ) : (
             <Flex marginLeft={SPACING.spacingM} />
           )}
-          <StyledText as="p" color={COLORS.darkBlack} paddingRight="2rem">
+          <StyledText
+            as="p"
+            color={COLORS.darkBlack}
+            paddingRight={SPACING.spacing6}
+          >
             {displayName}
           </StyledText>
         </Flex>
@@ -170,7 +178,7 @@ export const LabwareDetailOverflowMenu = (
       flexDirection={DIRECTION_COLUMN}
       position={POSITION_RELATIVE}
       marginRight={SPACING.spacing3}
-      marginLeft={'auto'}
+      marginLeft="auto"
     >
       <Flex>
         <OverflowBtn onClick={handleOverflowClick} />

--- a/app/src/organisms/ProtocolDetails/ProtocolLabwareDetails.tsx
+++ b/app/src/organisms/ProtocolDetails/ProtocolLabwareDetails.tsx
@@ -7,7 +7,6 @@ import {
   DIRECTION_ROW,
   Flex,
   Icon,
-  JUSTIFY_SPACE_BETWEEN,
   POSITION_ABSOLUTE,
   POSITION_RELATIVE,
   SIZE_5,
@@ -54,7 +53,7 @@ export const ProtocolLabwareDetails = (
       : []
 
   return (
-    <Flex flexDirection={DIRECTION_COLUMN}>
+    <Flex flexDirection={DIRECTION_COLUMN} width="100%">
       <Flex flexDirection={DIRECTION_ROW}>
         <StyledText
           as="label"
@@ -110,7 +109,6 @@ export const ProtocolLabwareDetailItem = (
         flexDirection={DIRECTION_ROW}
         marginY={SPACING.spacing3}
         alignItems={ALIGN_CENTER}
-        justifyContent={JUSTIFY_SPACE_BETWEEN}
       >
         <Flex flexDirection={DIRECTION_ROW} alignItems={ALIGN_CENTER}>
           {namespace === 'opentrons' ? (

--- a/app/src/organisms/ProtocolDetails/ProtocolLabwareDetails.tsx
+++ b/app/src/organisms/ProtocolDetails/ProtocolLabwareDetails.tsx
@@ -60,6 +60,7 @@ export const ProtocolLabwareDetails = (
           as="label"
           fontWeight={TYPOGRAPHY.fontWeightSemiBold}
           color={COLORS.darkBlack}
+          marginBottom={SPACING.spacing3}
           data-testid={'ProtocolLabwareDetails_labware_name'}
         >
           {t('labware_name')}
@@ -172,13 +173,13 @@ export const LabwareDetailOverflowMenu = (
       </Flex>
       {showOverflowMenu ? (
         <Flex
-          width={'11rem'}
+          width="11rem"
           zIndex={10}
           borderRadius={'4px 4px 0px 0px'}
           boxShadow={'0px 1px 3px rgba(0, 0, 0, 0.2)'}
           position={POSITION_ABSOLUTE}
           backgroundColor={COLORS.white}
-          top="3rem"
+          top="2.3rem"
           right={0}
           flexDirection={DIRECTION_COLUMN}
         >

--- a/app/src/organisms/ProtocolDetails/RobotConfigurationDetails.tsx
+++ b/app/src/organisms/ProtocolDetails/RobotConfigurationDetails.tsx
@@ -90,7 +90,7 @@ export const RobotConfigurationDetails = (
                           : module.params.location.slotName,
                     })}
                   </StyledText>
-                  <Flex>
+                  <Flex paddingLeft={SPACING.spacing4}>
                     <ModuleIcon
                       key={index}
                       moduleType={getModuleType(module.params.model)}

--- a/app/src/organisms/ProtocolDetails/RobotConfigurationDetails.tsx
+++ b/app/src/organisms/ProtocolDetails/RobotConfigurationDetails.tsx
@@ -30,6 +30,7 @@ interface RobotConfigurationDetailsProps {
   leftMountPipetteName: PipetteName | null
   rightMountPipetteName: PipetteName | null
   requiredModuleDetails: LoadModuleRunTimeCommand[] | null
+  isLoading: boolean
 }
 
 export const RobotConfigurationDetails = (
@@ -39,6 +40,7 @@ export const RobotConfigurationDetails = (
     leftMountPipetteName,
     rightMountPipetteName,
     requiredModuleDetails,
+    isLoading,
   } = props
   const { t } = useTranslation(['protocol_details', 'shared'])
 
@@ -47,16 +49,20 @@ export const RobotConfigurationDetails = (
       <RobotConfigurationDetailsItem
         label={t('left_mount')}
         item={
-          getPipetteNameSpecs(leftMountPipetteName as PipetteName)
-            ?.displayName ?? t('shared:not_used')
+          isLoading
+            ? t('shared:loading')
+            : getPipetteNameSpecs(leftMountPipetteName as PipetteName)
+                ?.displayName ?? t('shared:not_used')
         }
       />
       <Divider width="100%" />
       <RobotConfigurationDetailsItem
         label={t('right_mount')}
         item={
-          getPipetteNameSpecs(rightMountPipetteName as PipetteName)
-            ?.displayName ?? t('shared:not_used')
+          isLoading
+            ? t('shared:loading')
+            : getPipetteNameSpecs(rightMountPipetteName as PipetteName)
+                ?.displayName ?? t('shared:not_used')
         }
       />
       {requiredModuleDetails != null
@@ -90,7 +96,7 @@ export const RobotConfigurationDetails = (
                       key={index}
                       moduleType={getModuleType(module.params.model)}
                       height={SIZE_1}
-                      marginRight={SPACING.spacing3}
+                      marginRight={SPACING.spacing2}
                       alignSelf={ALIGN_CENTER}
                     />
                     <StyledText as="p">

--- a/app/src/organisms/ProtocolDetails/RobotConfigurationDetails.tsx
+++ b/app/src/organisms/ProtocolDetails/RobotConfigurationDetails.tsx
@@ -7,7 +7,6 @@ import {
   DIRECTION_ROW,
   Flex,
   ModuleIcon,
-  POSITION_ABSOLUTE,
   SIZE_1,
   SPACING,
   TEXT_TRANSFORM_CAPITALIZE,
@@ -79,9 +78,9 @@ export const RobotConfigurationDetails = (
                   <StyledText
                     as="h6"
                     fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-                    marginRight={SPACING.spacing4}
                     color={COLORS.darkGreyPressed}
                     textTransform={TEXT_TRANSFORM_UPPERCASE}
+                    minWidth="6rem"
                   >
                     {t('run_details:module_slot_number', {
                       slot_number:
@@ -91,14 +90,17 @@ export const RobotConfigurationDetails = (
                           : module.params.location.slotName,
                     })}
                   </StyledText>
-                  <Flex marginX={'6rem'} position={POSITION_ABSOLUTE}>
+                  <Flex>
                     <ModuleIcon
                       key={index}
                       moduleType={getModuleType(module.params.model)}
-                      height={SIZE_1}
                       marginRight={SPACING.spacing2}
                       alignSelf={ALIGN_CENTER}
+                      height={SIZE_1}
+                      minWidth={SIZE_1}
+                      minHeight={SIZE_1}
                     />
+
                     <StyledText as="p">
                       {getModuleDisplayName(module.params.model)}
                     </StyledText>
@@ -133,10 +135,11 @@ export const RobotConfigurationDetailsItem = (
         marginRight={SPACING.spacing4}
         color={COLORS.darkGreyPressed}
         textTransform={TEXT_TRANSFORM_UPPERCASE}
+        minWidth="6rem"
       >
         {label}
       </StyledText>
-      <Flex marginX={'6rem'} position={POSITION_ABSOLUTE}>
+      <Flex>
         <StyledText
           as="p"
           textTransform={TEXT_TRANSFORM_CAPITALIZE}

--- a/app/src/organisms/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
+++ b/app/src/organisms/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import '@testing-library/jest-dom'
 import { renderWithProviders } from '@opentrons/components'
 import { StaticRouter } from 'react-router-dom'
-import { fireEvent, getByText } from '@testing-library/react'
+import { fireEvent } from '@testing-library/react'
 import { i18n } from '../../../i18n'
 import {
   getConnectableRobots,

--- a/app/src/organisms/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
+++ b/app/src/organisms/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import '@testing-library/jest-dom'
 import { renderWithProviders } from '@opentrons/components'
 import { StaticRouter } from 'react-router-dom'
-import { fireEvent } from '@testing-library/react'
+import { fireEvent, getByText } from '@testing-library/react'
 import { i18n } from '../../../i18n'
 import {
   getConnectableRobots,
@@ -84,7 +84,7 @@ describe('ProtocolDetails', () => {
 
   it('renders protocol title as display name if present in metadata', () => {
     const protocolName = 'fakeProtocolDisplayName'
-    const { getByRole } = render({
+    const { getByText } = render({
       mostRecentAnalysis: {
         ...mockMostRecentAnalysis,
         createdAt,
@@ -99,10 +99,10 @@ describe('ProtocolDetails', () => {
         },
       },
     })
-    getByRole('heading', { name: 'fakeProtocolDisplayName' })
+    getByText('fakeProtocolDisplayName')
   })
   it('renders protocol title as file name if not in metadata', () => {
-    const { getByRole } = render({
+    const { getByText } = render({
       mostRecentAnalysis: {
         ...mockMostRecentAnalysis,
         createdAt,
@@ -117,9 +117,7 @@ describe('ProtocolDetails', () => {
         },
       },
     })
-    expect(
-      getByRole('heading', { name: 'fakeSrcFileName' })
-    ).toBeInTheDocument()
+    expect(getByText('fakeSrcFileName')).toBeInTheDocument()
   })
   it('renders deck setup section', () => {
     const { getByRole, getByText } = render({

--- a/app/src/organisms/ProtocolDetails/__tests__/RobotConfigurationDetails.test.tsx
+++ b/app/src/organisms/ProtocolDetails/__tests__/RobotConfigurationDetails.test.tsx
@@ -68,6 +68,7 @@ describe('RobotConfigurationDetails', () => {
       leftMountPipetteName: 'p10_single',
       rightMountPipetteName: null,
       requiredModuleDetails: null,
+      isLoading: false,
     }
     const { getByText } = render(props)
     getByText('left mount')
@@ -81,6 +82,7 @@ describe('RobotConfigurationDetails', () => {
       leftMountPipetteName: null,
       rightMountPipetteName: 'p10_single',
       requiredModuleDetails: null,
+      isLoading: false,
     }
     const { getByText } = render(props)
     getByText('left mount')
@@ -94,10 +96,23 @@ describe('RobotConfigurationDetails', () => {
       leftMountPipetteName: null,
       rightMountPipetteName: 'p10_single',
       requiredModuleDetails: mockRequiredModuleDetails,
+      isLoading: false,
     }
 
     const { getByText } = render(props)
     getByText('Slot 1')
     getByText('Magnetic Module GEN2')
+  })
+
+  it('renders loading for both pipettes when it is in a loading state', () => {
+    props = {
+      leftMountPipetteName: 'p10_single',
+      rightMountPipetteName: null,
+      requiredModuleDetails: null,
+      isLoading: true,
+    }
+    const { getAllByText, getByText } = render(props)
+    getByText('right mount')
+    getAllByText('Loading...')
   })
 })

--- a/app/src/organisms/ProtocolDetails/index.tsx
+++ b/app/src/organisms/ProtocolDetails/index.tsx
@@ -22,7 +22,6 @@ import {
   POSITION_RELATIVE,
   DISPLAY_BLOCK,
   Link,
-  Card,
   JUSTIFY_SPACE_BETWEEN,
   TEXT_TRANSFORM_CAPITALIZE,
   Text,
@@ -59,12 +58,22 @@ const defaultTabStyle = css`
   border-top: ${BORDERS.transparentLineBorder};
   border-left: ${BORDERS.transparentLineBorder};
   border-right: ${BORDERS.transparentLineBorder};
-  color: ${COLORS.darkGreyEnabled};
   padding: ${SPACING.spacing3} ${SPACING.spacing4};
   position: ${POSITION_RELATIVE};
 `
 
+const inactiveTabStyle = css`
+  color: ${COLORS.darkGreyEnabled};
+
+  &:hover {
+    color: ${COLORS.darkGreyEnabled};
+    background-color: #eeeeee;
+    border-radius: 4px 4px 0px 0px;
+  }
+`
+
 const currentTabStyle = css`
+  ${TYPOGRAPHY.pSemiBold}
   background-color: ${COLORS.white};
   border-top: ${BORDERS.lineBorder};
   border-left: ${BORDERS.lineBorder};
@@ -100,7 +109,10 @@ function RoundTab({
               ${defaultTabStyle}
               ${currentTabStyle}
             `
-          : defaultTabStyle
+          : css`
+              ${defaultTabStyle}
+              ${inactiveTabStyle}
+            `
       }
     >
       {children}
@@ -284,10 +296,12 @@ export function ProtocolDetails(
         showSlideout={showSlideout}
         storedProtocolData={props}
       />
-      <Card
+      <Box
         marginBottom={SPACING.spacing4}
         padding={SPACING.spacing4}
         backgroundColor={COLORS.white}
+        border={`1px solid ${COLORS.medGrey}`}
+        borderRadius={BORDERS.radiusSoftCorners}
       >
         {analysisStatus !== 'loading' &&
         mostRecentAnalysis != null &&
@@ -302,9 +316,8 @@ export function ProtocolDetails(
           justifyContent={JUSTIFY_SPACE_BETWEEN}
         >
           <StyledText
-            as="h3"
+            css={TYPOGRAPHY.h2SemiBold}
             marginBottom={SPACING.spacing4}
-            height="2.75rem"
             data-testid={`ProtocolDetails_${protocolDisplayName}`}
           >
             {protocolDisplayName}
@@ -324,7 +337,9 @@ export function ProtocolDetails(
             marginRight={SPACING.spacing4}
             data-testid={`ProtocolDetails_creationMethod`}
           >
-            <StyledText as="h6">{t('creation_method')}</StyledText>
+            <StyledText as="h6" color={COLORS.darkGreyEnabled}>
+              {t('creation_method')}
+            </StyledText>
             <StyledText as="p">
               {analysisStatus === 'loading'
                 ? t('shared:loading')
@@ -336,7 +351,9 @@ export function ProtocolDetails(
             marginRight={SPACING.spacing4}
             data-testid={`ProtocolDetails_lastUpdated`}
           >
-            <StyledText as="h6">{t('last_updated')}</StyledText>
+            <StyledText as="h6" color={COLORS.darkGreyEnabled}>
+              {t('last_updated')}
+            </StyledText>
             <StyledText as="p">
               {analysisStatus === 'loading'
                 ? t('shared:loading')
@@ -348,7 +365,9 @@ export function ProtocolDetails(
             marginRight={SPACING.spacing4}
             data-testid={`ProtocolDetails_lastAnalyzed`}
           >
-            <StyledText as="h6">{t('last_analyzed')}</StyledText>
+            <StyledText as="h6" color={COLORS.darkGreyEnabled}>
+              {t('last_analyzed')}
+            </StyledText>
             <StyledText as="p">
               {analysisStatus === 'loading'
                 ? t('shared:loading')
@@ -365,12 +384,14 @@ export function ProtocolDetails(
         <Divider marginY={SPACING.spacing4} />
         <Flex flexDirection={DIRECTION_ROW}>
           <Flex
-            flex="1"
+            flex="0.34"
             flexDirection={DIRECTION_COLUMN}
             marginRight={SPACING.spacing4}
             data-testid={`ProtocolDetails_author`}
           >
-            <StyledText as="h6">{t('org_or_author')}</StyledText>
+            <StyledText as="h6" color={COLORS.darkGreyEnabled}>
+              {t('org_or_author')}
+            </StyledText>
             <StyledText as="p">
               {analysisStatus === 'loading' ? t('shared:loading') : author}
             </StyledText>
@@ -381,7 +402,9 @@ export function ProtocolDetails(
             marginRight={SPACING.spacing4}
             data-testid={`ProtocolDetails_description`}
           >
-            <StyledText as="h6">{t('description')}</StyledText>
+            <StyledText as="h6" color={COLORS.darkGreyEnabled}>
+              {t('description')}
+            </StyledText>
             {analysisStatus === 'loading' ? (
               <StyledText as="p">{t('shared:loading')}</StyledText>
             ) : null}
@@ -393,16 +416,18 @@ export function ProtocolDetails(
             ) : null}
           </Flex>
         </Flex>
-      </Card>
+      </Box>
 
       <Flex
         flexDirection={DIRECTION_ROW}
         justifyContent={JUSTIFY_SPACE_BETWEEN}
       >
-        <Card
+        <Box
           flex="0 0 20rem"
           backgroundColor={COLORS.white}
           data-testid={`ProtocolDetails_deckMap`}
+          border={`1px solid ${COLORS.medGrey}`}
+          borderRadius={BORDERS.radiusSoftCorners}
         >
           <StyledText
             as="h3"
@@ -427,7 +452,7 @@ export function ProtocolDetails(
               }[analysisStatus]
             }
           </Box>
-        </Card>
+        </Box>
 
         <Flex
           width="100%"

--- a/app/src/organisms/ProtocolDetails/index.tsx
+++ b/app/src/organisms/ProtocolDetails/index.tsx
@@ -67,7 +67,7 @@ const inactiveTabStyle = css`
 
   &:hover {
     color: ${COLORS.darkGreyEnabled};
-    background-color: #eeeeee;
+    background-color: ${COLORS.fundamentalsBackgroundShade};
     border-radius: 4px 4px 0px 0px;
   }
 `

--- a/app/src/organisms/ProtocolDetails/index.tsx
+++ b/app/src/organisms/ProtocolDetails/index.tsx
@@ -309,7 +309,7 @@ export function ProtocolDetails(
       >
         <Box
           padding={`${SPACING.spacing4} 0 ${SPACING.spacing4} ${SPACING.spacing4}`}
-          width="115%"
+          width="100%"
         >
           {analysisStatus !== 'loading' &&
           mostRecentAnalysis != null &&

--- a/app/src/organisms/ProtocolDetails/index.tsx
+++ b/app/src/organisms/ProtocolDetails/index.tsx
@@ -282,6 +282,7 @@ export function ProtocolDetails(
         leftMountPipetteName={leftMountPipetteName}
         rightMountPipetteName={rightMountPipetteName}
         requiredModuleDetails={requiredModuleDetails}
+        isLoading={analysisStatus === 'loading'}
       />
     )
 
@@ -296,25 +297,28 @@ export function ProtocolDetails(
         showSlideout={showSlideout}
         storedProtocolData={props}
       />
-      <Box
-        marginBottom={SPACING.spacing4}
-        padding={SPACING.spacing4}
+
+      <Flex
         backgroundColor={COLORS.white}
         border={`1px solid ${COLORS.medGrey}`}
         borderRadius={BORDERS.radiusSoftCorners}
+        position={POSITION_RELATIVE}
+        flexDirection={DIRECTION_ROW}
+        width="100%"
+        marginBottom={SPACING.spacing4}
       >
-        {analysisStatus !== 'loading' &&
-        mostRecentAnalysis != null &&
-        mostRecentAnalysis.errors.length > 0 ? (
-          <ProtocolAnalysisFailure
-            protocolKey={protocolKey}
-            errors={mostRecentAnalysis.errors.map(e => e.detail)}
-          />
-        ) : null}
-        <Flex
-          flexDirection={DIRECTION_ROW}
-          justifyContent={JUSTIFY_SPACE_BETWEEN}
+        <Box
+          padding={`${SPACING.spacing4} 0 ${SPACING.spacing4} ${SPACING.spacing4}`}
+          width="115%"
         >
+          {analysisStatus !== 'loading' &&
+          mostRecentAnalysis != null &&
+          mostRecentAnalysis.errors.length > 0 ? (
+            <ProtocolAnalysisFailure
+              protocolKey={protocolKey}
+              errors={mostRecentAnalysis.errors.map(e => e.detail)}
+            />
+          ) : null}
           <StyledText
             css={TYPOGRAPHY.h2SemiBold}
             marginBottom={SPACING.spacing4}
@@ -322,102 +326,108 @@ export function ProtocolDetails(
           >
             {protocolDisplayName}
           </StyledText>
+          <Flex
+            flexDirection={DIRECTION_ROW}
+            justifyContent={JUSTIFY_SPACE_BETWEEN}
+          >
+            <Flex
+              flexDirection={DIRECTION_COLUMN}
+              marginRight={SPACING.spacing4}
+              data-testid={`ProtocolDetails_creationMethod`}
+            >
+              <StyledText as="h6" color={COLORS.darkGreyEnabled}>
+                {t('creation_method')}
+              </StyledText>
+              <StyledText as="p">
+                {analysisStatus === 'loading'
+                  ? t('shared:loading')
+                  : creationMethod}
+              </StyledText>
+            </Flex>
+            <Flex
+              flexDirection={DIRECTION_COLUMN}
+              marginRight={SPACING.spacing4}
+              data-testid={`ProtocolDetails_lastUpdated`}
+            >
+              <StyledText as="h6" color={COLORS.darkGreyEnabled}>
+                {t('last_updated')}
+              </StyledText>
+              <StyledText as="p">
+                {analysisStatus === 'loading'
+                  ? t('shared:loading')
+                  : format(new Date(modified), 'MMMM dd, yyyy HH:mm')}
+              </StyledText>
+            </Flex>
+            <Flex
+              flexDirection={DIRECTION_COLUMN}
+              marginRight={SPACING.spacing4}
+              data-testid={`ProtocolDetails_lastAnalyzed`}
+            >
+              <StyledText as="h6" color={COLORS.darkGreyEnabled}>
+                {t('last_analyzed')}
+              </StyledText>
+              <StyledText as="p">
+                {analysisStatus === 'loading'
+                  ? t('shared:loading')
+                  : lastAnalyzed}
+              </StyledText>
+            </Flex>
+            <PrimaryButton
+              onClick={() => setShowSlideout(true)}
+              data-testid={`ProtocolDetails_runProtocol`}
+              disabled={analysisStatus === 'loading'}
+            >
+              {t('run_protocol')}
+            </PrimaryButton>
+          </Flex>
+          <Divider marginY={SPACING.spacing4} />
+          <Flex flexDirection={DIRECTION_ROW}>
+            <Flex
+              flex="0.34"
+              flexDirection={DIRECTION_COLUMN}
+              marginRight={SPACING.spacing4}
+              data-testid={`ProtocolDetails_author`}
+            >
+              <StyledText as="h6" color={COLORS.darkGreyEnabled}>
+                {t('org_or_author')}
+              </StyledText>
+              <StyledText as="p">
+                {analysisStatus === 'loading' ? t('shared:loading') : author}
+              </StyledText>
+            </Flex>
+            <Flex
+              flex="1"
+              flexDirection={DIRECTION_COLUMN}
+              marginRight={SPACING.spacing4}
+              data-testid={`ProtocolDetails_description`}
+            >
+              <StyledText as="h6" color={COLORS.darkGreyEnabled}>
+                {t('description')}
+              </StyledText>
+              {analysisStatus === 'loading' ? (
+                <StyledText as="p">{t('shared:loading')}</StyledText>
+              ) : null}
+              {mostRecentAnalysis != null ? (
+                <ReadMoreContent
+                  metadata={mostRecentAnalysis.metadata}
+                  protocolType={mostRecentAnalysis.config.protocolType}
+                />
+              ) : null}
+            </Flex>
+          </Flex>
+        </Box>
+        <Box
+          position={POSITION_RELATIVE}
+          top={SPACING.spacing1}
+          right={SPACING.spacing1}
+        >
           <OverflowMenu
             protocolKey={protocolKey}
             protocolType={mostRecentAnalysis?.config?.protocolType ?? 'python'}
             data-testid={`ProtocolDetails_overFlowMenu`}
           />
-        </Flex>
-        <Flex
-          flexDirection={DIRECTION_ROW}
-          justifyContent={JUSTIFY_SPACE_BETWEEN}
-        >
-          <Flex
-            flexDirection={DIRECTION_COLUMN}
-            marginRight={SPACING.spacing4}
-            data-testid={`ProtocolDetails_creationMethod`}
-          >
-            <StyledText as="h6" color={COLORS.darkGreyEnabled}>
-              {t('creation_method')}
-            </StyledText>
-            <StyledText as="p">
-              {analysisStatus === 'loading'
-                ? t('shared:loading')
-                : creationMethod}
-            </StyledText>
-          </Flex>
-          <Flex
-            flexDirection={DIRECTION_COLUMN}
-            marginRight={SPACING.spacing4}
-            data-testid={`ProtocolDetails_lastUpdated`}
-          >
-            <StyledText as="h6" color={COLORS.darkGreyEnabled}>
-              {t('last_updated')}
-            </StyledText>
-            <StyledText as="p">
-              {analysisStatus === 'loading'
-                ? t('shared:loading')
-                : format(new Date(modified), 'MMMM dd, yyyy HH:mm')}
-            </StyledText>
-          </Flex>
-          <Flex
-            flexDirection={DIRECTION_COLUMN}
-            marginRight={SPACING.spacing4}
-            data-testid={`ProtocolDetails_lastAnalyzed`}
-          >
-            <StyledText as="h6" color={COLORS.darkGreyEnabled}>
-              {t('last_analyzed')}
-            </StyledText>
-            <StyledText as="p">
-              {analysisStatus === 'loading'
-                ? t('shared:loading')
-                : lastAnalyzed}
-            </StyledText>
-          </Flex>
-          <PrimaryButton
-            onClick={() => setShowSlideout(true)}
-            data-testid={`ProtocolDetails_runProtocol`}
-            disabled={analysisStatus === 'loading'}
-          >
-            {t('run_protocol')}
-          </PrimaryButton>
-        </Flex>
-        <Divider marginY={SPACING.spacing4} />
-        <Flex flexDirection={DIRECTION_ROW}>
-          <Flex
-            flex="0.34"
-            flexDirection={DIRECTION_COLUMN}
-            marginRight={SPACING.spacing4}
-            data-testid={`ProtocolDetails_author`}
-          >
-            <StyledText as="h6" color={COLORS.darkGreyEnabled}>
-              {t('org_or_author')}
-            </StyledText>
-            <StyledText as="p">
-              {analysisStatus === 'loading' ? t('shared:loading') : author}
-            </StyledText>
-          </Flex>
-          <Flex
-            flex="1"
-            flexDirection={DIRECTION_COLUMN}
-            marginRight={SPACING.spacing4}
-            data-testid={`ProtocolDetails_description`}
-          >
-            <StyledText as="h6" color={COLORS.darkGreyEnabled}>
-              {t('description')}
-            </StyledText>
-            {analysisStatus === 'loading' ? (
-              <StyledText as="p">{t('shared:loading')}</StyledText>
-            ) : null}
-            {mostRecentAnalysis != null ? (
-              <ReadMoreContent
-                metadata={mostRecentAnalysis.metadata}
-                protocolType={mostRecentAnalysis.config.protocolType}
-              />
-            ) : null}
-          </Flex>
-        </Flex>
-      </Box>
+        </Box>
+      </Flex>
 
       <Flex
         flexDirection={DIRECTION_ROW}
@@ -490,7 +500,11 @@ export function ProtocolDetails(
             } ${BORDERS.radiusSoftCorners} ${BORDERS.radiusSoftCorners} ${
               BORDERS.radiusSoftCorners
             }`}
-            padding={`${SPACING.spacing5} ${SPACING.spacing4}`}
+            padding={
+              currentTab === 'robot_config'
+                ? `${SPACING.spacing5} ${SPACING.spacing4}`
+                : `${SPACING.spacing4} ${SPACING.spacing4} 0 ${SPACING.spacing4}`
+            }
           >
             {getTabContents()}
           </Box>

--- a/app/src/organisms/ProtocolDetails/index.tsx
+++ b/app/src/organisms/ProtocolDetails/index.tsx
@@ -396,7 +396,11 @@ export function ProtocolDetails(
               <StyledText as="h6" color={COLORS.darkGreyEnabled}>
                 {t('org_or_author')}
               </StyledText>
-              <StyledText as="p">
+              <StyledText
+                as="p"
+                marginRight={SPACING.spacingM}
+                css={{ 'overflow-wrap': 'anywhere' }}
+              >
                 {analysisStatus === 'loading' ? t('shared:loading') : author}
               </StyledText>
             </Flex>

--- a/app/src/organisms/ProtocolDetails/index.tsx
+++ b/app/src/organisms/ProtocolDetails/index.tsx
@@ -96,7 +96,7 @@ const currentTabStyle = css`
 const GRID_STYLE = css`
   display: grid;
   width: 100%;
-  grid-template-columns: 26.6% 26.6% 26.6% 20%;
+  grid-template-columns: 26.6% 26.6% 26.6% 20.2%;
 `
 interface RoundTabProps extends React.ComponentProps<typeof Btn> {
   isCurrent: boolean

--- a/app/src/organisms/ProtocolDetails/index.tsx
+++ b/app/src/organisms/ProtocolDetails/index.tsx
@@ -377,6 +377,7 @@ export function ProtocolDetails(
           <PrimaryButton
             onClick={() => setShowSlideout(true)}
             data-testid={`ProtocolDetails_runProtocol`}
+            disabled={analysisStatus === 'loading'}
           >
             {t('run_protocol')}
           </PrimaryButton>

--- a/app/src/organisms/ProtocolDetails/index.tsx
+++ b/app/src/organisms/ProtocolDetails/index.tsx
@@ -92,6 +92,12 @@ const currentTabStyle = css`
     width: 100%;
   }
 `
+
+const GRID_STYLE = css`
+  display: grid;
+  width: 100%;
+  grid-template-columns: 26.6% 26.6% 26.6% 20%;
+`
 interface RoundTabProps extends React.ComponentProps<typeof Btn> {
   isCurrent: boolean
 }
@@ -326,13 +332,9 @@ export function ProtocolDetails(
           >
             {protocolDisplayName}
           </StyledText>
-          <Flex
-            flexDirection={DIRECTION_ROW}
-            justifyContent={JUSTIFY_SPACE_BETWEEN}
-          >
+          <Flex css={GRID_STYLE}>
             <Flex
               flexDirection={DIRECTION_COLUMN}
-              marginRight={SPACING.spacing4}
               data-testid={`ProtocolDetails_creationMethod`}
             >
               <StyledText as="h6" color={COLORS.darkGreyEnabled}>
@@ -346,7 +348,6 @@ export function ProtocolDetails(
             </Flex>
             <Flex
               flexDirection={DIRECTION_COLUMN}
-              marginRight={SPACING.spacing4}
               data-testid={`ProtocolDetails_lastUpdated`}
             >
               <StyledText as="h6" color={COLORS.darkGreyEnabled}>
@@ -360,7 +361,6 @@ export function ProtocolDetails(
             </Flex>
             <Flex
               flexDirection={DIRECTION_COLUMN}
-              marginRight={SPACING.spacing4}
               data-testid={`ProtocolDetails_lastAnalyzed`}
             >
               <StyledText as="h6" color={COLORS.darkGreyEnabled}>
@@ -372,20 +372,25 @@ export function ProtocolDetails(
                   : lastAnalyzed}
               </StyledText>
             </Flex>
-            <PrimaryButton
-              onClick={() => setShowSlideout(true)}
-              data-testid={`ProtocolDetails_runProtocol`}
-              disabled={analysisStatus === 'loading'}
+            <Flex
+              css={css`
+                display: grid;
+                justify-self: end;
+              `}
             >
-              {t('run_protocol')}
-            </PrimaryButton>
+              <PrimaryButton
+                onClick={() => setShowSlideout(true)}
+                data-testid={`ProtocolDetails_runProtocol`}
+                disabled={analysisStatus === 'loading'}
+              >
+                {t('run_protocol')}
+              </PrimaryButton>
+            </Flex>
           </Flex>
           <Divider marginY={SPACING.spacing4} />
-          <Flex flexDirection={DIRECTION_ROW}>
+          <Flex css={GRID_STYLE}>
             <Flex
-              flex="0.34"
               flexDirection={DIRECTION_COLUMN}
-              marginRight={SPACING.spacing4}
               data-testid={`ProtocolDetails_author`}
             >
               <StyledText as="h6" color={COLORS.darkGreyEnabled}>
@@ -396,9 +401,7 @@ export function ProtocolDetails(
               </StyledText>
             </Flex>
             <Flex
-              flex="1"
               flexDirection={DIRECTION_COLUMN}
-              marginRight={SPACING.spacing4}
               data-testid={`ProtocolDetails_description`}
             >
               <StyledText as="h6" color={COLORS.darkGreyEnabled}>

--- a/components/src/ui-style-constants/colors.ts
+++ b/components/src/ui-style-constants/colors.ts
@@ -5,6 +5,7 @@ export const lightBlue = '#f1f8ff'
 export const medGrey = '#e3e3e3'
 export const black = '#000000'
 export const transparent = 'transparent'
+export const fundamentalsBackgroundShade = '#eeeeee'
 
 // colors with states
 export const blueFocus = '#deecff'


### PR DESCRIPTION
closes #10906

# Overview

address design feedback on Protocol Details page: 

<img width="915" alt="Screen Shot 2022-06-28 at 1 56 47 PM" src="https://user-images.githubusercontent.com/66035149/176250589-24f18910-28a5-4933-8e35-2fed7b6b95a5.png">


# Changelog

- changed `ProtocolDetails` and `ProtocolLabwareDetails`

# Review requests

- upload a protocol and click on the protocol card to get the protocol labware details. does it match designs?

# Risk assessment

low
