### PR TITLE
fix(app): fix historical protocol run timestamps

### DIFF
--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -30,6 +30,7 @@ export interface RunData {
   id: string
   createdAt: string
   completedAt?: string
+  startedAt?: string
   current: boolean
   status: RunStatus
   actions: RunAction[]

--- a/app/src/organisms/Devices/HistoricalProtocolRun.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRun.tsx
@@ -17,7 +17,6 @@ import { StyledText } from '../../atoms/text'
 import { getStoredProtocols } from '../../redux/protocol-storage'
 import { formatInterval } from '../RunTimeControl/utils'
 import { formatTimestamp } from './utils'
-import { useRunTimestamps } from '../RunTimeControl/hooks'
 import { EMPTY_TIMESTAMP } from './constants'
 import { HistoricalProtocolRunOverflowMenu as OverflowMenu } from './HistoricalProtocolRunOverflowMenu'
 import { HistoricalProtocolRunOffsetDrawer as OffsetDrawer } from './HistoricalProtocolRunOffsetDrawer'
@@ -45,7 +44,6 @@ export function HistoricalProtocolRun(
   const { run, protocolName, robotIsBusy, robotName, protocolKey, key } = props
   const history = useHistory()
   const [offsetDrawerOpen, setOffsetDrawerOpen] = React.useState(false)
-  const { startedAt, completedAt } = useRunTimestamps(run.id)
   const storedProtocols = useSelector((state: State) =>
     getStoredProtocols(state)
   )
@@ -53,10 +51,10 @@ export function HistoricalProtocolRun(
   const runDisplayName = formatTimestamp(run.createdAt)
   let duration = EMPTY_TIMESTAMP
   if (runStatus !== 'idle') {
-    if (completedAt != null && startedAt != null) {
-      duration = formatInterval(startedAt, completedAt)
-    } else if (startedAt != null) {
-      duration = formatInterval(startedAt, new Date().toString())
+    if (run.completedAt != null && run.startedAt != null) {
+      duration = formatInterval(run.startedAt, run.completedAt)
+    } else if (run.startedAt != null) {
+      duration = formatInterval(run.startedAt, new Date().toString())
     }
   }
   const protocolKeyInStoredKeys = storedProtocols.find(


### PR DESCRIPTION
# Overview
the recent refactor performed poorly, reverting to using `run`'s timestamps on `HistoricalProtocolRun`, but we need to add `startedAt` to `RunData` to do so

# Changelog
- HistoricalProtocolRun uses `run`s timestampsd
- add `startedAt` to `RunData`

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Ensure we use run's timestamps and shows run duration roughly equal to what we see in protocol run header
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Low