### PR TITLE
fix(app, react-api-client): add run creation spinner and handle errors in slideouts during run creation

### DIFF
--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -110,6 +110,5 @@
   "power_force": "Power / Force",
   "robot_is_busy": "Robot is busy",
   "this_robot_will_restart_with_update": "<block>This robot has to restart to update its software. Restarting will immediately stop the current run or calibration.</block><block>Do you want to update now anyway?</block>",
-  "yes_update_now": "Yes, update now",
-  "proceed_to_setup": "Proceed to setup"
+  "yes_update_now": "Yes, update now"
 }

--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -110,5 +110,6 @@
   "power_force": "Power / Force",
   "robot_is_busy": "Robot is busy",
   "this_robot_will_restart_with_update": "<block>This robot has to restart to update its software. Restarting will immediately stop the current run or calibration.</block><block>Do you want to update now anyway?</block>",
-  "yes_update_now": "Yes, update now"
+  "yes_update_now": "Yes, update now",
+  "proceed_to_setup": "Proceed to setup"
 }

--- a/app/src/assets/localization/en/protocol_details.json
+++ b/app/src/assets/localization/en/protocol_details.json
@@ -10,7 +10,6 @@
   "left_mount": "left mount",
   "liquids": "liquids",
   "org_or_author": "org/author",
-  "proceed_to_setup": "Proceed to setup",
   "modules": "modules",
   "no_available_robots_found": "No available robots found",
   "read_more": "read more",

--- a/app/src/assets/localization/en/shared.json
+++ b/app/src/assets/localization/en/shared.json
@@ -32,5 +32,6 @@
   "reset_all": "Reset all",
   "robot_is_reachable_but_not_responding": "This robot's API server is not responding correctly to requests at IP address {{hostname}}",
   "robot_was_seen_but_is_unreachable": "This robot has been seen recently, but is currently not reachable at IP address {{hostname}}",
-  "protocol_run_general_error_msg": "Protocol run could not be created on the robot."
+  "protocol_run_general_error_msg": "Protocol run could not be created on the robot.",
+  "proceed_to_setup": "Proceed to setup"
 }

--- a/app/src/assets/localization/en/shared.json
+++ b/app/src/assets/localization/en/shared.json
@@ -31,5 +31,6 @@
   "confirm": "Confirm",
   "reset_all": "Reset all",
   "robot_is_reachable_but_not_responding": "This robot's API server is not responding correctly to requests at IP address {{hostname}}",
-  "robot_was_seen_but_is_unreachable": "This robot has been seen recently, but is currently not reachable at IP address {{hostname}}"
+  "robot_was_seen_but_is_unreachable": "This robot has been seen recently, but is currently not reachable at IP address {{hostname}}",
+  "protocol_run_general_error_msg": "Protocol run could not be created on the robot."
 }

--- a/app/src/organisms/ChooseProtocolSlideout/__tests__/ChooseProtocolSlideout.test.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/__tests__/ChooseProtocolSlideout.test.tsx
@@ -108,6 +108,7 @@ describe('ChooseProtocolSlideout', () => {
       runCreationError: 'run creation error',
       createRunFromProtocolSource: mockCreateRunFromProtocol,
       isCreatingRun: false,
+      reset: jest.fn(),
     })
     const [{ getByRole, getByText }] = render({
       robot: mockConnectableRobot,

--- a/app/src/organisms/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/index.tsx
@@ -85,17 +85,18 @@ export function ChooseProtocolSlideout(
         </ApiHostProvider>
       }
     >
-      <Flex justifyContent={ALIGN_FLEX_END}>
-        {isCreatingRun ? (
+      {isCreatingRun ? (
+        <Flex justifyContent={ALIGN_FLEX_END}>
+          (
           <Icon
             name="ot-spinner"
             marginBottom={SPACING.spacing3}
             spin
             size={SIZE_1}
           />
-        ) : null}
-      </Flex>
-
+          )
+        </Flex>
+      ) : null}
       {storedProtocols.length > 0 ? (
         storedProtocols.map(storedProtocol => {
           const isSelected =

--- a/app/src/organisms/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/index.tsx
@@ -20,7 +20,6 @@ import {
   Icon,
   COLORS,
   TEXT_ALIGN_CENTER,
-  ALIGN_FLEX_END,
 } from '@opentrons/components'
 
 import { getStoredProtocols } from '../../redux/protocol-storage'
@@ -85,16 +84,6 @@ export function ChooseProtocolSlideout(
         </ApiHostProvider>
       }
     >
-      {isCreatingRun ? (
-        <Flex justifyContent={ALIGN_FLEX_END}>
-          <Icon
-            name="ot-spinner"
-            marginBottom={SPACING.spacing3}
-            spin
-            size={SIZE_1}
-          />
-        </Flex>
-      ) : null}
       {storedProtocols.length > 0 ? (
         storedProtocols.map(storedProtocol => {
           const isSelected =
@@ -222,21 +211,21 @@ function CreateRunButton(props: CreateRunButtonProps): JSX.Element {
     isCreatingRun,
   } = useCreateRunFromProtocol({
     onSuccess: ({ data: runData }) => {
+      setIsCreatingRun(false)
+      setError(null)
       history.push(`/devices/${robotName}/protocol-runs/${runData.id}`)
-    },
+    }
   })
 
   React.useEffect(() => {
     if (runCreationError != null) {
+      setIsCreatingRun(false)
       setError(runCreationError)
     }
-  }, [runCreationError, setError])
-
-  React.useEffect(() => {
-    setIsCreatingRun(isCreatingRun)
-  }, [isCreatingRun, setIsCreatingRun])
+  }, [runCreationError, setError, setIsCreatingRun])
 
   const handleClick: React.MouseEventHandler<HTMLButtonElement> = () => {
+    setIsCreatingRun(true)
     createRunFromProtocolSource({ files: srcFileObjects, protocolKey })
   }
 
@@ -247,7 +236,11 @@ function CreateRunButton(props: CreateRunButtonProps): JSX.Element {
       width="100%"
       {...buttonProps}
     >
-      {t('proceed_to_setup')}
+      {isCreatingRun ? (
+        <Icon name="ot-spinner" spin size={SIZE_1} />
+      ) : (
+        t('proceed_to_setup')
+      )}
     </PrimaryButton>
   )
 }

--- a/app/src/organisms/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/index.tsx
@@ -8,6 +8,7 @@ import { useSelector } from 'react-redux'
 
 import {
   SPACING,
+  SIZE_1,
   TYPOGRAPHY,
   ALIGN_CENTER,
   JUSTIFY_CENTER,
@@ -54,6 +55,7 @@ export function ChooseProtocolSlideout(
   const [createRunError, setCreateRunError] = React.useState<string | null>(
     null
   )
+  const [isCreatingRun, setIsCreatingRun] = React.useState<boolean>(false)
 
   const srcFileObjects =
     selectedProtocol != null
@@ -76,11 +78,13 @@ export function ChooseProtocolSlideout(
             }
             srcFileObjects={srcFileObjects}
             setError={setCreateRunError}
+            setIsCreatingRun={setIsCreatingRun}
             robotName={name}
           />
         </ApiHostProvider>
       }
     >
+      {isCreatingRun ? <Icon name="ot-spinner" spin size={SIZE_1} /> : null}
       {storedProtocols.length > 0 ? (
         storedProtocols.map(storedProtocol => {
           const isSelected =
@@ -186,6 +190,7 @@ interface CreateRunButtonProps
   protocolKey: string
   robotName: string
   setError: (error: string | null) => void
+  setIsCreatingRun: (value: boolean) => void
 }
 function CreateRunButton(props: CreateRunButtonProps): JSX.Element {
   const { t } = useTranslation('protocol_details')
@@ -195,6 +200,7 @@ function CreateRunButton(props: CreateRunButtonProps): JSX.Element {
     srcFileObjects,
     robotName,
     setError,
+    setIsCreatingRun,
     disabled,
     ...buttonProps
   } = props
@@ -213,6 +219,10 @@ function CreateRunButton(props: CreateRunButtonProps): JSX.Element {
       setError(runCreationError)
     }
   }, [runCreationError, setError])
+
+  React.useEffect(() => {
+    setIsCreatingRun(isCreatingRun)
+  }, [isCreatingRun, setIsCreatingRun])
 
   const handleClick: React.MouseEventHandler<HTMLButtonElement> = () => {
     createRunFromProtocolSource({ files: srcFileObjects, protocolKey })

--- a/app/src/organisms/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/index.tsx
@@ -101,7 +101,7 @@ export function ChooseProtocolSlideout(
             {isCreatingRun ? (
               <Icon name="ot-spinner" spin size={SIZE_1} />
             ) : (
-              t('proceed_to_setup')
+              t('shared:proceed_to_setup')
             )}
           </PrimaryButton>
         </ApiHostProvider>
@@ -162,6 +162,7 @@ export function ChooseProtocolSlideout(
                 <StyledText
                   as="label"
                   color={COLORS.errorText}
+                  css={{ 'overflow-wrap': 'anywhere' }}
                   display={DISPLAY_BLOCK}
                   marginTop={`-${SPACING.spacing2}`}
                   marginBottom={SPACING.spacing3}

--- a/app/src/organisms/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/index.tsx
@@ -20,6 +20,7 @@ import {
   Icon,
   COLORS,
   TEXT_ALIGN_CENTER,
+  ALIGN_FLEX_END,
 } from '@opentrons/components'
 
 import { getStoredProtocols } from '../../redux/protocol-storage'
@@ -84,7 +85,17 @@ export function ChooseProtocolSlideout(
         </ApiHostProvider>
       }
     >
-      {isCreatingRun ? <Icon name="ot-spinner" spin size={SIZE_1} /> : null}
+      <Flex justifyContent={ALIGN_FLEX_END}>
+        {isCreatingRun ? (
+          <Icon
+            name="ot-spinner"
+            marginBottom={SPACING.spacing3}
+            spin
+            size={SIZE_1}
+          />
+        ) : null}
+      </Flex>
+
       {storedProtocols.length > 0 ? (
         storedProtocols.map(storedProtocol => {
           const isSelected =

--- a/app/src/organisms/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/index.tsx
@@ -87,14 +87,12 @@ export function ChooseProtocolSlideout(
     >
       {isCreatingRun ? (
         <Flex justifyContent={ALIGN_FLEX_END}>
-          (
           <Icon
             name="ot-spinner"
             marginBottom={SPACING.spacing3}
             spin
             size={SIZE_1}
           />
-          )
         </Flex>
       ) : null}
       {storedProtocols.length > 0 ? (

--- a/app/src/organisms/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/index.tsx
@@ -109,8 +109,10 @@ export function ChooseProtocolSlideout(
                 isSelected={isSelected}
                 isError={createRunError != null}
                 onClick={() => {
-                  setCreateRunError(null)
-                  setSelectedProtocol(storedProtocol)
+                  if (!isCreatingRun) {
+                    setCreateRunError(null)
+                    setSelectedProtocol(storedProtocol)
+                  }
                 }}
               >
                 <Flex

--- a/app/src/organisms/ChooseRobotSlideout/AvailableRobotOption.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/AvailableRobotOption.tsx
@@ -23,8 +23,8 @@ interface AvailableRobotOptionProps {
   local: boolean | null
   onClick: () => void
   isSelected: boolean
-  isError?: boolean
   isOnDifferentSoftwareVersion: boolean
+  isError?: boolean
 }
 
 export function AvailableRobotOption(

--- a/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
@@ -223,6 +223,7 @@ describe('ChooseRobotSlideout', () => {
       runCreationError: 'run creation error',
       createRunFromProtocolSource: mockCreateRunFromProtocolSource,
       isCreatingRun: false,
+      reset: jest.fn(),
     })
     const [{ getByRole, getByText }] = render({
       storedProtocolData: storedProtocolDataFixture,

--- a/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
@@ -85,11 +85,13 @@ const render = (props: React.ComponentProps<typeof ChooseRobotSlideout>) => {
 }
 
 let mockCloseCurrentRun: jest.Mock
+let mockResetCreateRun: jest.Mock
 let mockCreateRunFromProtocolSource: jest.Mock
 
 describe('ChooseRobotSlideout', () => {
   beforeEach(() => {
     mockCloseCurrentRun = jest.fn()
+    mockResetCreateRun = jest.fn()
     mockCreateRunFromProtocolSource = jest.fn()
     mockGetBuildrootUpdateDisplayInfo.mockReturnValue({
       autoUpdateAction: '',
@@ -112,6 +114,7 @@ describe('ChooseRobotSlideout', () => {
     } as ProtocolDetails)
     mockUseCreateRunFromProtocol.mockReturnValue({
       createRunFromProtocolSource: mockCreateRunFromProtocolSource,
+      reset: mockResetCreateRun,
     } as any)
   })
   afterEach(() => {

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -150,7 +150,7 @@ export function ChooseRobotSlideout(
           {isCreatingRun ? (
             <Icon name="ot-spinner" spin size={SIZE_1} />
           ) : (
-            t('proceed_to_setup')
+            t('shared:proceed_to_setup')
           )}
         </PrimaryButton>
       }
@@ -216,6 +216,7 @@ export function ChooseRobotSlideout(
                   <StyledText
                     as="label"
                     color={COLORS.errorText}
+                    css={{ 'overflow-wrap': 'anywhere' }}
                     display={DISPLAY_INLINE_BLOCK}
                     marginTop={`-${SPACING.spacing2}`}
                     marginBottom={SPACING.spacing3}

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -184,8 +184,10 @@ export function ChooseRobotSlideout(
                   robotModel="OT-2"
                   local={robot.local}
                   onClick={() => {
-                    setCreateRunError(null)
-                    setSelectedRobot(isSelected ? null : robot)
+                    if (!isCreatingRun) {
+                      setCreateRunError(null)
+                      setSelectedRobot(isSelected ? null : robot)
+                    }
                   }}
                   isError={createRunError != null}
                   isSelected={isSelected}

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -58,6 +58,7 @@ export function ChooseRobotSlideout(
   const [createRunError, setCreateRunError] = React.useState<string | null>(
     null
   )
+  const [isCreatingRun, setIsCreatingRun] = React.useState<boolean>(false)
   const dispatch = useDispatch<Dispatch>()
   const isScanning = useSelector((state: State) => getScanning(state))
 
@@ -126,11 +127,12 @@ export function ChooseRobotSlideout(
         >
           <CreateRunButton
             disabled={
-              selectedRobot == null || isSelectedRobotOnWrongVersionOfSoftware
+              selectedRobot == null // || isSelectedRobotOnWrongVersionOfSoftware
             }
             protocolKey={protocolKey}
             srcFileObjects={srcFileObjects}
             setError={setCreateRunError}
+            setIsCreatingRun={setIsCreatingRun}
             robotName={selectedRobot != null ? selectedRobot.name : ''}
           />
         </ApiHostProvider>
@@ -143,7 +145,7 @@ export function ChooseRobotSlideout(
           marginY={SPACING.spacing3}
           height={SIZE_2}
         >
-          {isScanning ? (
+          {isScanning || isCreatingRun ? (
             <Icon name="ot-spinner" spin size={SIZE_1} />
           ) : (
             <Link
@@ -238,6 +240,7 @@ interface CreateRunButtonProps
   protocolKey: string
   robotName: string
   setError: (error: string | null) => void
+  setIsCreatingRun: (value: boolean) => void
 }
 function CreateRunButton(props: CreateRunButtonProps): JSX.Element {
   const { t } = useTranslation('protocol_details')
@@ -247,6 +250,7 @@ function CreateRunButton(props: CreateRunButtonProps): JSX.Element {
     srcFileObjects,
     robotName,
     setError,
+    setIsCreatingRun,
     disabled,
     ...buttonProps
   } = props
@@ -265,6 +269,10 @@ function CreateRunButton(props: CreateRunButtonProps): JSX.Element {
       setError(runCreationError)
     }
   }, [runCreationError, setError])
+
+  React.useEffect(() => {
+    setIsCreatingRun(isCreatingRun)
+  }, [isCreatingRun, setIsCreatingRun])
 
   const handleClick: React.MouseEventHandler<HTMLButtonElement> = () => {
     createRunFromProtocolSource({ files: srcFileObjects, protocolKey })

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -145,7 +145,7 @@ export function ChooseRobotSlideout(
           marginY={SPACING.spacing3}
           height={SIZE_2}
         >
-          {isScanning || isCreatingRun ? (
+          {isScanning ? (
             <Icon name="ot-spinner" spin size={SIZE_1} />
           ) : (
             <Link
@@ -262,21 +262,21 @@ function CreateRunButton(props: CreateRunButtonProps): JSX.Element {
     isCreatingRun,
   } = useCreateRunFromProtocol({
     onSuccess: ({ data: runData }) => {
+      setIsCreatingRun(false)
+      setError(null)
       history.push(`/devices/${robotName}/protocol-runs/${runData.id}`)
     },
   })
 
   React.useEffect(() => {
     if (runCreationError != null) {
+      setIsCreatingRun(false)
       setError(runCreationError)
     }
-  }, [runCreationError, setError])
-
-  React.useEffect(() => {
-    setIsCreatingRun(isCreatingRun)
-  }, [isCreatingRun, setIsCreatingRun])
+  }, [runCreationError, setError, setIsCreatingRun])
 
   const handleClick: React.MouseEventHandler<HTMLButtonElement> = () => {
+    setIsCreatingRun(true)
     createRunFromProtocolSource({ files: srcFileObjects, protocolKey })
   }
 
@@ -287,7 +287,11 @@ function CreateRunButton(props: CreateRunButtonProps): JSX.Element {
       disabled={isCreatingRun || disabled}
       {...buttonProps}
     >
-      {t('proceed_to_setup')}
+      {isCreatingRun ? (
+        <Icon name="ot-spinner" spin size={SIZE_1} />
+      ) : (
+        t('proceed_to_setup')
+      )}
     </PrimaryButton>
   )
 }

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -127,7 +127,7 @@ export function ChooseRobotSlideout(
         >
           <CreateRunButton
             disabled={
-              selectedRobot == null // || isSelectedRobotOnWrongVersionOfSoftware
+              selectedRobot == null || isSelectedRobotOnWrongVersionOfSoftware
             }
             protocolKey={protocolKey}
             srcFileObjects={srcFileObjects}

--- a/app/src/organisms/ChooseRobotSlideout/useCreateRunFromProtocol.ts
+++ b/app/src/organisms/ChooseRobotSlideout/useCreateRunFromProtocol.ts
@@ -1,4 +1,3 @@
-import * as React from 'react'
 import { useQueryClient } from 'react-query'
 import {
   useHost,

--- a/app/src/organisms/ChooseRobotSlideout/useCreateRunFromProtocol.ts
+++ b/app/src/organisms/ChooseRobotSlideout/useCreateRunFromProtocol.ts
@@ -73,7 +73,7 @@ export function useCreateRunFromProtocol(
     host
   )
 
-  const error =
+  let error =
     protocolError != null || runError != null
       ? protocolError?.response?.data?.errors?.[0]?.detail ??
         protocolError?.response?.data ??
@@ -81,6 +81,7 @@ export function useCreateRunFromProtocol(
         runError?.response?.data ??
         t('protocol_run_general_error_msg')
       : null
+  error = error?.length > 255 ? t('protocol_run_general_error_msg') : error
 
   return {
     createRunFromProtocolSource: (

--- a/app/src/organisms/ChooseRobotSlideout/useCreateRunFromProtocol.ts
+++ b/app/src/organisms/ChooseRobotSlideout/useCreateRunFromProtocol.ts
@@ -81,6 +81,7 @@ export function useCreateRunFromProtocol(
         runError?.response?.data ??
         t('protocol_run_general_error_msg')
       : null
+  console.error(error)
   error = error?.length > 255 ? t('protocol_run_general_error_msg') : error
 
   return {

--- a/app/src/organisms/ChooseRobotSlideout/useCreateRunFromProtocol.ts
+++ b/app/src/organisms/ChooseRobotSlideout/useCreateRunFromProtocol.ts
@@ -6,6 +6,8 @@ import {
   useCreateRunMutation,
 } from '@opentrons/react-api-client'
 import { useSelector } from 'react-redux'
+import { useTranslation } from 'react-i18next'
+
 import { getValidCustomLabwareFiles } from '../../redux/custom-labware/selectors'
 
 import type { UseMutateFunction } from 'react-query'
@@ -30,6 +32,7 @@ export function useCreateRunFromProtocol(
 ): UseCreateRun {
   const host = useHost()
   const queryClient = useQueryClient()
+  const { t } = useTranslation('shared')
   const [runCreationError, setRunCreationError] = React.useState<string | null>(
     null
   )
@@ -49,7 +52,10 @@ export function useCreateRunFromProtocol(
       options.onSuccess?.(...args)
     },
     onError: error => {
-      setRunCreationError(error.response?.data.errors[0].detail ?? null)
+      setRunCreationError(
+        error.response?.data.errors[0].detail ??
+          t('protocol_run_general_error_msg')
+      )
     },
   })
   const {
@@ -60,7 +66,10 @@ export function useCreateRunFromProtocol(
       createRun({ protocolId: data.data.id })
     },
     onError: error => {
-      setRunCreationError(error.response?.data.errors[0].detail ?? null)
+      setRunCreationError(
+        error.response?.data.errors[0].detail ??
+          t('protocol_run_general_error_msg')
+      )
     },
   })
 

--- a/app/src/organisms/ChooseRobotSlideout/useCreateRunFromProtocol.ts
+++ b/app/src/organisms/ChooseRobotSlideout/useCreateRunFromProtocol.ts
@@ -81,7 +81,7 @@ export function useCreateRunFromProtocol(
         runError?.response?.data ??
         t('protocol_run_general_error_msg')
       : null
-  console.error(error)
+  error != null && console.error(error)
   error = error?.length > 255 ? t('protocol_run_general_error_msg') : error
 
   return {

--- a/react-api-client/src/protocols/useCreateProtocolMutation.ts
+++ b/react-api-client/src/protocols/useCreateProtocolMutation.ts
@@ -57,7 +57,7 @@ export function useCreateProtocolMutation(
               )
             )
             .catch(e => {
-              console.error(e)
+              throw e
             })
           return response.data
         }

--- a/react-api-client/src/protocols/useCreateProtocolMutation.ts
+++ b/react-api-client/src/protocols/useCreateProtocolMutation.ts
@@ -61,7 +61,9 @@ export function useCreateProtocolMutation(
             })
           return response.data
         }
-      ),
+      ).catch(e => {
+        throw e
+      }),
     options
   )
   return {

--- a/react-api-client/src/protocols/useCreateProtocolMutation.ts
+++ b/react-api-client/src/protocols/useCreateProtocolMutation.ts
@@ -33,9 +33,11 @@ export type UseCreateProtocolMutationOptions = UseMutationOptions<
 >
 
 export function useCreateProtocolMutation(
-  options: UseCreateProtocolMutationOptions = {}
+  options: UseCreateProtocolMutationOptions = {},
+  hostOverride?: HostConfig | null
 ): UseCreateProtocolMutationResult {
-  const host = useHost()
+  const contextHost = useHost()
+  const host = hostOverride ?? contextHost
   const queryClient = useQueryClient()
 
   const mutation = useMutation<
@@ -45,8 +47,8 @@ export function useCreateProtocolMutation(
   >(
     [host, 'protocols'],
     ({ files: protocolFiles, protocolKey }) =>
-      createProtocol(host as HostConfig, protocolFiles, protocolKey).then(
-        response => {
+      createProtocol(host as HostConfig, protocolFiles, protocolKey)
+        .then(response => {
           const protocolId = response.data.data.id
           queryClient
             .invalidateQueries([host, 'protocols'])
@@ -60,10 +62,10 @@ export function useCreateProtocolMutation(
               throw e
             })
           return response.data
-        }
-      ).catch(e => {
-        throw e
-      }),
+        })
+        .catch(e => {
+          throw e
+        }),
     options
   )
   return {

--- a/react-api-client/src/runs/useCreateRunMutation.ts
+++ b/react-api-client/src/runs/useCreateRunMutation.ts
@@ -28,9 +28,11 @@ export type UseCreateRunMutationOptions = UseMutationOptions<
 >
 
 export function useCreateRunMutation(
-  options: UseCreateRunMutationOptions = {}
+  options: UseCreateRunMutationOptions = {},
+  hostOverride?: HostConfig | null
 ): UseCreateRunMutationResult {
-  const host = useHost()
+  const contextHost = useHost()
+  const host = hostOverride ?? contextHost
   const mutation = useMutation<Run, AxiosError, CreateRunData>(
     [host, 'runs'],
     createRunData =>


### PR DESCRIPTION
# Overview
During run creation on the slideout we show the spinner icon, and we now throw errors from the `useCreateProtocolMutation` just as we do in the `useCreateRunMutation` in `api-client`. previously we were logging the error in the former so the error did not bubble up to the hooks that were using it in the app and the app was not able to handle that error path.

# Changelog
- `CreateRun` buttons on slideouts now watch for `isCreatingRun` and change the state for this boolean in parent component to display spinner

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
confirm that spinner appear on both slideouts when proceed to run button is clicked and run creation is in process
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Low