### PR TITLE
refactor(app): update module mismatch warning label

### DIFF
--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/Banner/Banner.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/Banner/Banner.tsx
@@ -12,6 +12,7 @@ import {
   NewPrimaryBtn,
   TEXT_TRANSFORM_NONE,
   SIZE_6,
+  SIZE_2,
 } from '@opentrons/components'
 import { StyledText } from '../../../../../atoms/text'
 
@@ -42,18 +43,14 @@ export function Banner(props: BannerProps): JSX.Element | null {
           >
             <Flex>
               <Icon
-                size={SPACING.spacing6}
+                size={SIZE_2}
                 color={COLORS.darkGreyEnabled}
                 name="information"
                 paddingRight={SPACING.spacing3}
-                paddingBottom={TYPOGRAPHY.fontSizeCaption}
+                paddingBottom={SPACING.spacingSM}
                 aria-label="information_icon"
               />
-              <StyledText
-                as="h3"
-                data-testid={`banner_title_${title}`}
-                color={COLORS.darkBlack}
-              >
+              <StyledText as="h3" data-testid={`banner_title_${title}`}>
                 {title}
               </StyledText>
             </Flex>

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/Banner/Banner.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/Banner/Banner.tsx
@@ -12,18 +12,16 @@ import {
   NewPrimaryBtn,
   TEXT_TRANSFORM_NONE,
   SIZE_6,
-  Btn,
 } from '@opentrons/components'
 import { StyledText } from '../../../../../atoms/text'
 
 interface BannerProps {
   title: string
   children?: React.ReactNode
-  onClose?: () => void
 }
 
 export function Banner(props: BannerProps): JSX.Element | null {
-  const { title, children, onClose } = props
+  const { title, children } = props
 
   return (
     <React.Fragment>
@@ -59,11 +57,6 @@ export function Banner(props: BannerProps): JSX.Element | null {
                 {title}
               </StyledText>
             </Flex>
-            {onClose != null ? (
-              <Btn size="1.5rem" onClick={onClose} aria-label="close">
-                <Icon name={'close'} color={COLORS.darkGrey} />
-              </Btn>
-            ) : null}
           </Flex>
         </Flex>
         {children}

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/Banner/Banner.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/Banner/Banner.tsx
@@ -12,15 +12,18 @@ import {
   NewPrimaryBtn,
   TEXT_TRANSFORM_NONE,
   SIZE_6,
+  Btn,
 } from '@opentrons/components'
+import { StyledText } from '../../../../../atoms/text'
 
 interface BannerProps {
   title: string
   children?: React.ReactNode
+  onClose?: () => void
 }
 
 export function Banner(props: BannerProps): JSX.Element | null {
-  const { title, children } = props
+  const { title, children, onClose } = props
 
   return (
     <React.Fragment>
@@ -35,22 +38,32 @@ export function Banner(props: BannerProps): JSX.Element | null {
           flexDirection={DIRECTION_COLUMN}
           justifyContent={JUSTIFY_SPACE_BETWEEN}
         >
-          <Flex flexDirection={DIRECTION_ROW}>
-            <Icon
-              size={SPACING.spacing6}
-              color={COLORS.darkGreyEnabled}
-              name="information"
-              paddingRight={SPACING.spacing3}
-              paddingBottom={TYPOGRAPHY.fontSizeCaption}
-              aria-label="information_icon"
-            />
-            <Text
-              fontSize={TYPOGRAPHY.fontSizeH3}
-              data-testid={`banner_title_${title}`}
-              color={COLORS.darkBlack}
-            >
-              {title}
-            </Text>
+          <Flex
+            flexDirection={DIRECTION_ROW}
+            justifyContent={JUSTIFY_SPACE_BETWEEN}
+          >
+            <Flex>
+              <Icon
+                size={SPACING.spacing6}
+                color={COLORS.darkGreyEnabled}
+                name="information"
+                paddingRight={SPACING.spacing3}
+                paddingBottom={TYPOGRAPHY.fontSizeCaption}
+                aria-label="information_icon"
+              />
+              <StyledText
+                as="h3"
+                data-testid={`banner_title_${title}`}
+                color={COLORS.darkBlack}
+              >
+                {title}
+              </StyledText>
+            </Flex>
+            {onClose != null ? (
+              <Btn size="1.5rem" onClick={onClose} aria-label="close">
+                <Icon name={'close'} color={COLORS.darkGrey} />
+              </Btn>
+            ) : null}
           </Flex>
         </Flex>
         {children}

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/Banner/__tests__/Banner.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/Banner/__tests__/Banner.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
 import { Banner } from '../Banner'
 
@@ -27,17 +26,5 @@ describe('HeaterShakerBanner', () => {
     }
     const { getByText } = render(props)
     getByText('TITLE')
-  })
-
-  it('should render exit button and it is clickable', () => {
-    props = {
-      title: 'TITLE',
-      onClose: jest.fn(),
-    }
-    const { getByText, getByLabelText } = render(props)
-    getByText('TITLE')
-    const btn = getByLabelText('close')
-    fireEvent.click(btn)
-    expect(props.onClose).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/Banner/__tests__/Banner.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/Banner/__tests__/Banner.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
 import { Banner } from '../Banner'
 
@@ -26,5 +27,17 @@ describe('HeaterShakerBanner', () => {
     }
     const { getByText } = render(props)
     getByText('TITLE')
+  })
+
+  it('should render exit button and it is clickable', () => {
+    props = {
+      title: 'TITLE',
+      onClose: jest.fn(),
+    }
+    const { getByText, getByLabelText } = render(props)
+    getByText('TITLE')
+    const btn = getByLabelText('close')
+    fireEvent.click(btn)
+    expect(props.onClose).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/UnMatchedModuleWarning.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/UnMatchedModuleWarning.tsx
@@ -1,22 +1,7 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import {
-  Btn,
-  Box,
-  Flex,
-  Icon,
-  Text,
-  SIZE_2,
-  SPACING_1,
-  SPACING_2,
-  SPACING_3,
-  COLOR_WARNING,
-  COLOR_WARNING_LIGHT,
-  C_DARK_GRAY,
-  JUSTIFY_SPACE_BETWEEN,
-  DIRECTION_COLUMN,
-  COLOR_WARNING_DARK,
-} from '@opentrons/components'
+import { StyledText } from '../../../../atoms/text'
+import { Banner } from './Banner/Banner'
 
 interface UnMatchedModuleWarningProps {
   isAnyModuleUnnecessary: boolean
@@ -33,41 +18,12 @@ export const UnMatchedModuleWarning = (
   if (!isVisible) return null
 
   return (
-    <React.Fragment>
-      <Flex
-        marginY={SPACING_3}
-        backgroundColor={COLOR_WARNING_LIGHT}
-        color={C_DARK_GRAY}
-        id={'ModuleMismatch'}
-      >
-        <Flex flexDirection={DIRECTION_COLUMN} flex={'auto'} margin={SPACING_3}>
-          <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
-            <Flex>
-              <Box size={SIZE_2} paddingY={SPACING_1} paddingRight={SPACING_2}>
-                <Icon name="alert-circle" color={COLOR_WARNING} />
-              </Box>
-              <Text
-                as="h4"
-                marginY={SPACING_2}
-                id={`ModuleMismatch_title`}
-                color={COLOR_WARNING_DARK}
-              >
-                {t('module_mismatch_title')}
-              </Text>
-            </Flex>
-            <Btn
-              size={SIZE_2}
-              onClick={() => setShowModulesMismatch(false)}
-              aria-label="close"
-            >
-              <Icon name={'close'} color={COLOR_WARNING} />
-            </Btn>
-          </Flex>
-          <Text paddingTop={SPACING_1} fontSize={'0.7rem'}>
-            {t('module_mismatch_body')}
-          </Text>
-        </Flex>
-      </Flex>
-    </React.Fragment>
+    <Banner
+      title={t('module_mismatch_title')}
+      onClose={() => setShowModulesMismatch(false)}
+      data-testid={`UnMatchedModuleWarning_banner`}
+    >
+      <StyledText as="p">{t('module_mismatch_body')}</StyledText>
+    </Banner>
   )
 }

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/UnMatchedModuleWarning.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/UnMatchedModuleWarning.tsx
@@ -6,9 +6,9 @@ import {
   DIRECTION_COLUMN,
   JUSTIFY_SPACE_BETWEEN,
   DIRECTION_ROW,
-  TYPOGRAPHY,
   SPACING,
   Icon,
+  SIZE_2,
 } from '@opentrons/components'
 import { StyledText } from '../../../../atoms/text'
 
@@ -36,16 +36,15 @@ export const UnMatchedModuleWarning = (
       >
         <Flex>
           <Icon
-            size={SPACING.spacing6}
+            size={SIZE_2}
             color={COLORS.darkGreyEnabled}
             name="information"
             paddingRight={SPACING.spacing3}
-            paddingBottom={'0.625rem'}
+            paddingBottom={SPACING.spacingSM}
             aria-label="information_icon"
           />
           <StyledText
-            fontSize={TYPOGRAPHY.fontSizeP}
-            fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+            as="p"
             data-testid={`UnMatchedModuleWarning_title`}
             color={COLORS.darkBlack}
           >

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/UnMatchedModuleWarning.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/UnMatchedModuleWarning.tsx
@@ -1,7 +1,16 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
+import {
+  COLORS,
+  Flex,
+  DIRECTION_COLUMN,
+  JUSTIFY_SPACE_BETWEEN,
+  DIRECTION_ROW,
+  TYPOGRAPHY,
+  SPACING,
+  Icon,
+} from '@opentrons/components'
 import { StyledText } from '../../../../atoms/text'
-import { Banner } from './Banner/Banner'
 
 interface UnMatchedModuleWarningProps {
   isAnyModuleUnnecessary: boolean
@@ -11,19 +20,50 @@ export const UnMatchedModuleWarning = (
   props: UnMatchedModuleWarningProps
 ): JSX.Element | null => {
   const { t } = useTranslation('protocol_setup')
-  const [showModulesMismatch, setShowModulesMismatch] = React.useState<boolean>(
-    true
-  )
-  const isVisible = showModulesMismatch && props.isAnyModuleUnnecessary
+  const isVisible = props.isAnyModuleUnnecessary
   if (!isVisible) return null
 
   return (
-    <Banner
-      title={t('module_mismatch_title')}
-      onClose={() => setShowModulesMismatch(false)}
-      data-testid={`UnMatchedModuleWarning_banner`}
+    <Flex
+      marginTop={SPACING.spacing4}
+      flexDirection={DIRECTION_COLUMN}
+      backgroundColor={COLORS.background}
+      padding={SPACING.spacing5}
     >
-      <StyledText as="p">{t('module_mismatch_body')}</StyledText>
-    </Banner>
+      <Flex
+        flexDirection={DIRECTION_ROW}
+        justifyContent={JUSTIFY_SPACE_BETWEEN}
+      >
+        <Flex>
+          <Icon
+            size={SPACING.spacing6}
+            color={COLORS.darkGreyEnabled}
+            name="information"
+            paddingRight={SPACING.spacing3}
+            paddingBottom={'0.625rem'}
+            aria-label="information_icon"
+          />
+          <StyledText
+            fontSize={TYPOGRAPHY.fontSizeP}
+            fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+            data-testid={`UnMatchedModuleWarning_title`}
+            color={COLORS.darkBlack}
+          >
+            {t('module_mismatch_title')}
+          </StyledText>
+        </Flex>
+      </Flex>
+
+      <StyledText
+        as="p"
+        marginLeft={SPACING.spacing6}
+        marginRight={SPACING.spacing4}
+        color={COLORS.darkGrey}
+        width="100%"
+        data-testid={`UnMatchedModuleWarning_body`}
+      >
+        {t('module_mismatch_body')}
+      </StyledText>
+    </Flex>
   )
 }

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/__tests__/UnMatchedModuleWarning.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/__tests__/UnMatchedModuleWarning.test.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react'
-import { fireEvent } from '@testing-library/react'
 import { i18n } from '../../../../../i18n'
-import { UnMatchedModuleWarning } from '../UnMatchedModuleWarning'
 import { renderWithProviders } from '@opentrons/components'
+import { UnMatchedModuleWarning } from '../UnMatchedModuleWarning'
 
 const render = (props: React.ComponentProps<typeof UnMatchedModuleWarning>) => {
   return renderWithProviders(<UnMatchedModuleWarning {...props} />, {
@@ -17,10 +16,11 @@ describe('UnMatchedModuleWarning', () => {
   })
 
   it('should render the correct title', () => {
-    const { getByText } = render(props)
+    const { getByText, getByLabelText } = render(props)
     getByText(
       'This robot has connected modules that are not specified in this protocol'
     )
+    getByLabelText('information_icon')
   })
   it('should render the correct body', () => {
     const { getByText } = render(props)
@@ -29,12 +29,9 @@ describe('UnMatchedModuleWarning', () => {
     )
   })
 
-  it('should close warning when button is clicked', () => {
-    const { queryByText, getByRole } = render(props)
-    const closeButton = getByRole('button', {
-      name: /close/i,
-    })
-    fireEvent.click(closeButton)
+  it('should not render text when boolean is false', () => {
+    props = { isAnyModuleUnnecessary: false }
+    const { queryByText } = render(props)
     expect(
       queryByText(
         'This robot has connected modules that are not specified in this protocol'

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/__tests__/UnMatchedModuleWarning.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/__tests__/UnMatchedModuleWarning.test.tsx
@@ -16,12 +16,11 @@ describe('UnMatchedModuleWarning', () => {
     props = { isAnyModuleUnnecessary: true }
   })
 
-  it('should render the correct header', () => {
-    const { getByRole } = render(props)
-    getByRole('heading', {
-      name:
-        'This robot has connected modules that are not specified in this protocol',
-    })
+  it('should render the correct title', () => {
+    const { getByText } = render(props)
+    getByText(
+      'This robot has connected modules that are not specified in this protocol'
+    )
   })
   it('should render the correct body', () => {
     const { getByText } = render(props)


### PR DESCRIPTION
closes #10971 

# Overview

Updated the module mismatch warning to match our other setup warning designs

<img width="827" alt="Screen Shot 2022-06-30 at 10 21 12 AM" src="https://user-images.githubusercontent.com/66035149/176701529-8ba74ebd-0117-494d-82ef-ae1f2d4ac862.png">


# Changelog

- updated `unMatchedModuleWarning` and test 

# Review requests

- slack jethary for an example protocol to use
- upload the protocol and go to Protocol setup, and select Module Setup
- I am not sure where the designs are for this in figma but if something looks off, please let me know. 

# Risk assessment

low