### PR TITLE
fix(app): fix pipette calibration modal auto closing

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibrationItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibrationItem.tsx
@@ -147,31 +147,33 @@ export function SetupPipetteCalibrationItem({
             </Tooltip>
           ) : null}
         </Flex>
-        {PipetteOffsetCalibrationWizard}
-        {showCalBlockModal && (
-          <Portal level="top">
-            <AskForCalibrationBlockModal
-              onResponse={hasBlockModalResponse => {
-                startPipetteOffsetCalibrationBlockModal(hasBlockModalResponse)
-              }}
-              titleBarTitle={t('pipette_offset_cal')}
-              closePrompt={() => setShowCalBlockModal(false)}
-            />
-          </Portal>
-        )}
       </>
     )
   }
 
   return (
-    <SetupCalibrationItem
-      button={button}
-      calibratedDate={attached ? pipetteInfo.pipetteCalDate : null}
-      subText={subText}
-      label={t(`devices_landing:${mount}_mount`)}
-      title={pipetteInfo.pipetteSpecs?.displayName}
-      id={`PipetteCalibration_${mount}MountTitle`}
-      runId={runId}
-    />
+    <>
+      <SetupCalibrationItem
+        button={button}
+        calibratedDate={attached ? pipetteInfo.pipetteCalDate : null}
+        subText={subText}
+        label={t(`devices_landing:${mount}_mount`)}
+        title={pipetteInfo.pipetteSpecs?.displayName}
+        id={`PipetteCalibration_${mount}MountTitle`}
+        runId={runId}
+      />
+      {PipetteOffsetCalibrationWizard}
+      {showCalBlockModal && (
+        <Portal level="top">
+          <AskForCalibrationBlockModal
+            onResponse={hasBlockModalResponse => {
+              startPipetteOffsetCalibrationBlockModal(hasBlockModalResponse)
+            }}
+            titleBarTitle={t('pipette_offset_cal')}
+            closePrompt={() => setShowCalBlockModal(false)}
+          />
+        </Portal>
+      )}
+    </>
   )
 }

--- a/app/src/pages/Devices/DeviceDetails/index.tsx
+++ b/app/src/pages/Devices/DeviceDetails/index.tsx
@@ -23,9 +23,8 @@ import type { NavRouteParams } from '../../../App/types'
 export function DeviceDetails(): JSX.Element | null {
   const { robotName } = useParams<NavRouteParams>()
   const robot = useRobot(robotName)
-  console.log('RENDERED DEV')
+
   useSyncRobotClock(robotName)
-  console.log('RENDERED n', robotName)
 
   return robot != null ? (
     <ApiHostProvider key={robot.name} hostname={robot.ip ?? null}>


### PR DESCRIPTION
# Overview
Fixes pipette calibration modal auto closing.
Closes #10941
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- no longer conditionally render calibration modal in `SetupPipetteCalibrationItem`

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
confirm that modal does not close on its own
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Low