### PR TITLE
fix(app): protocol Run Record protocolName no longer renders runId

### DIFF
--- a/app/src/organisms/Devices/RecentProtocolRuns.tsx
+++ b/app/src/organisms/Devices/RecentProtocolRuns.tsx
@@ -4,8 +4,6 @@ import {
   useAllRunsQuery,
   useAllProtocolsQuery,
 } from '@opentrons/react-api-client'
-import last from 'lodash/last'
-
 import {
   Flex,
   Box,
@@ -17,14 +15,10 @@ import {
   DIRECTION_COLUMN,
   JUSTIFY_SPACE_AROUND,
 } from '@opentrons/components'
-import { getRequestById, useDispatchApiRequest } from '../../redux/robot-api'
-import { fetchProtocols } from '../../redux/protocol-storage'
 import { StyledText } from '../../atoms/text'
 import { useCurrentRunId } from '../ProtocolUpload/hooks'
 import { HistoricalProtocolRun } from './HistoricalProtocolRun'
 import { useIsRobotViewable, useRunStatuses } from './hooks'
-import { useSelector } from 'react-redux'
-import type { State } from '../../redux/types'
 
 interface RecentProtocolRunsProps {
   robotName: string
@@ -33,25 +27,14 @@ interface RecentProtocolRunsProps {
 export function RecentProtocolRuns({
   robotName,
 }: RecentProtocolRunsProps): JSX.Element | null {
-  const { t } = useTranslation('device_details')
+  const { t } = useTranslation(['device_details', 'shared'])
   const isRobotViewable = useIsRobotViewable(robotName)
-  const [dispatchRequest, requestIds] = useDispatchApiRequest()
   const runsQueryResponse = useAllRunsQuery()
   const runs = runsQueryResponse?.data?.data
   const protocols = useAllProtocolsQuery()
   const currentRunId = useCurrentRunId()
   const { isRunTerminal } = useRunStatuses()
   const robotIsBusy = currentRunId != null ? !isRunTerminal : false
-  const latestRequestId = last(requestIds)
-  const isFetching = useSelector<State, boolean>(state =>
-    latestRequestId != null
-      ? getRequestById(state, latestRequestId)?.status === 'pending'
-      : false
-  )
-
-  React.useEffect(() => {
-    dispatchRequest(fetchProtocols())
-  }, [dispatchRequest, robotName])
 
   return (
     <Flex
@@ -127,12 +110,12 @@ export function RecentProtocolRuns({
                 const protocol = protocols?.data?.data.find(
                   protocol => protocol.id === run.protocolId
                 )
-                const protocolName = isFetching
-                  ? protocol?.metadata.protocolName ??
-                    protocol?.files[0].name ??
-                    run.protocolId ??
-                    ''
-                  : ''
+
+                const protocolName =
+                  protocol?.metadata.protocolName ??
+                  protocol?.files[0].name ??
+                  t('shared:loading') ??
+                  ''
 
                 return (
                   <HistoricalProtocolRun

--- a/app/src/organisms/Devices/__tests__/RecentProtocolRuns.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RecentProtocolRuns.test.tsx
@@ -3,19 +3,16 @@ import { UseQueryResult } from 'react-query'
 import { renderWithProviders } from '@opentrons/components'
 import { useAllRunsQuery } from '@opentrons/react-api-client'
 import { i18n } from '../../../i18n'
-import { useDispatchApiRequest } from '../../../redux/robot-api'
 import { useIsRobotViewable, useRunStatuses } from '../hooks'
 import { RecentProtocolRuns } from '../RecentProtocolRuns'
 import { HistoricalProtocolRun } from '../HistoricalProtocolRun'
 
 import type { Runs } from '@opentrons/api-client'
-import type { DispatchApiRequestType } from '../../../redux/robot-api'
 
 jest.mock('@opentrons/react-api-client')
 jest.mock('../hooks')
 jest.mock('../../ProtocolUpload/hooks')
 jest.mock('../HistoricalProtocolRun')
-jest.mock('../../../redux/robot-api')
 
 const mockUseIsRobotViewable = useIsRobotViewable as jest.MockedFunction<
   typeof useIsRobotViewable
@@ -25,9 +22,6 @@ const mockUseAllRunsQuery = useAllRunsQuery as jest.MockedFunction<
 >
 const mockHistoricalProtocolRun = HistoricalProtocolRun as jest.MockedFunction<
   typeof HistoricalProtocolRun
->
-const mockUseDispatchApiRequest = useDispatchApiRequest as jest.MockedFunction<
-  typeof useDispatchApiRequest
 >
 const mockUseRunStatues = useRunStatuses as jest.MockedFunction<
   typeof useRunStatuses
@@ -39,10 +33,7 @@ const render = () => {
 }
 
 describe('RecentProtocolRuns', () => {
-  let dispatchApiRequest: DispatchApiRequestType
-
   beforeEach(() => {
-    dispatchApiRequest = jest.fn()
     mockUseRunStatues.mockReturnValue({
       isLegacySessionInProgress: false,
       isRunStill: false,
@@ -52,7 +43,6 @@ describe('RecentProtocolRuns', () => {
     mockHistoricalProtocolRun.mockReturnValue(
       <div>mock HistoricalProtocolRun</div>
     )
-    mockUseDispatchApiRequest.mockReturnValue([dispatchApiRequest, ['id']])
   })
   afterEach(() => {
     jest.resetAllMocks()


### PR DESCRIPTION
closes #10899 closes #10658

# Overview

This fixes the bug where the `runid` renders in the protocol name section. Now, if `protocolName` and protocol file are still rendering, `Loading...` will be in place

# Changelog

- change `RecentProtocolRun` and test
- remove unnecessary fetching that I previously added because I thought it fixed this bug

# Review requests

- run a few protocols to get a protocol run record. Refresh the app, the protocol name should say "Loading..." instead of `runId`

# Risk assessment

low