### PR TITLE
fix(api): Do not pause in the middle of a Thermocycler profile

### DIFF
--- a/api/src/opentrons/hardware_control/emulation/simulations.py
+++ b/api/src/opentrons/hardware_control/emulation/simulations.py
@@ -7,7 +7,7 @@ class Simulation:
 
 
 class Temperature(Simulation):
-    """A model with a current and target temperature. The current temperate is
+    """A model with a current and target temperature. The current temperature is
     always moving towards the target.
     """
 
@@ -53,8 +53,8 @@ class Temperature(Simulation):
 
 
 class TemperatureWithHold(Temperature):
-    """A model with a current, target temperature and hold time. The current
-    temperate is always moving towards the target.
+    """A model with a current temperature, target temperature, and hold time.
+    The current temperature is always moving towards the target.
 
     When the current temperature is within close enough from target the hold time
     decrements once per tick.

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -232,6 +232,22 @@ class Thermocycler(mod_abc.AbstractModule):
         Returns: None
         """
         await self.wait_for_is_running()
+        await self._set_temperature_no_pause(
+            temperature=temperature,
+            hold_time_seconds=hold_time_seconds,
+            hold_time_minutes=hold_time_minutes,
+            ramp_rate=ramp_rate,
+            volume=volume,
+        )
+
+    async def _set_temperature_no_pause(
+        self,
+        temperature: float,
+        hold_time_seconds: Optional[float],
+        hold_time_minutes: Optional[float],
+        ramp_rate: Optional[float],
+        volume: Optional[float],
+    ) -> None:
         seconds = hold_time_seconds if hold_time_seconds is not None else 0
         minutes = hold_time_minutes if hold_time_minutes is not None else 0
         total_seconds = seconds + (minutes * 60)
@@ -245,7 +261,6 @@ class Thermocycler(mod_abc.AbstractModule):
         # Wait for target temperature to be set.
         retries = 0
         while self.target != temperature or not self.hold_time_probably_set(hold_time):
-            await self.wait_for_is_running()
             # Wait for the poller to update
             await self.wait_next_poll()
             retries += 1
@@ -282,7 +297,6 @@ class Thermocycler(mod_abc.AbstractModule):
         # Wait for target temperature to be set.
         retries = 0
         while self.target != temperature:
-            await self.wait_for_is_running()
             # Wait for the poller to update
             await self.wait_next_poll()
             retries += 1
@@ -328,7 +342,6 @@ class Thermocycler(mod_abc.AbstractModule):
         # Wait for target to be set
         retries = 0
         while self.lid_target != temperature:
-            await self.wait_for_is_running()
             # Wait for the poller to update
             await self.wait_next_poll()
             retries += 1
@@ -348,7 +361,6 @@ class Thermocycler(mod_abc.AbstractModule):
         # Wait for target to be set
         retries = 0
         while self.lid_target != temperature:
-            await self.wait_for_is_running()
             # Wait for the poller to update
             await self.wait_next_poll()
             retries += 1
@@ -570,13 +582,11 @@ class Thermocycler(mod_abc.AbstractModule):
 
         Returns: None
         """
-        await self.wait_for_is_running()
-
         temperature = step.get("temperature")
         hold_time_minutes = step.get("hold_time_minutes", None)
         hold_time_seconds = step.get("hold_time_seconds", None)
         ramp_rate = step.get("ramp_rate", None)
-        await self.set_temperature(
+        await self._set_temperature_no_pause(
             temperature=temperature,  # type: ignore
             hold_time_minutes=hold_time_minutes,
             hold_time_seconds=hold_time_seconds,

--- a/api/tests/opentrons/hardware_control/integration/test_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/integration/test_thermocycler.py
@@ -1,6 +1,9 @@
 import asyncio
-from typing import Iterator
+from typing import AsyncGenerator
+
+import anyio
 import pytest
+
 from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.hardware_control import ExecutionManager
 from opentrons.hardware_control.emulation.settings import Settings
@@ -9,12 +12,18 @@ from opentrons.hardware_control.modules.types import TemperatureStatus
 
 
 @pytest.fixture
+def execution_manager() -> ExecutionManager:
+    """Return the ExecutionManager used by the Thermocycler test subject."""
+    return ExecutionManager()
+
+
+@pytest.fixture
 async def thermocycler(
-    emulation_app: Iterator[None],
+    emulation_app: None,
     emulator_settings: Settings,
-) -> Thermocycler:
-    """Thermocycler fixture."""
-    execution_manager = ExecutionManager()
+    execution_manager: ExecutionManager,
+) -> AsyncGenerator[Thermocycler, None]:
+    """Return a Thermocycler test subject."""
     module = await Thermocycler.build(
         port=f"socket://127.0.0.1:{emulator_settings.thermocycler_proxy.driver_port}",
         execution_manager=execution_manager,
@@ -27,7 +36,7 @@ async def thermocycler(
     await module.cleanup()
 
 
-def test_device_info(thermocycler: Thermocycler):
+def test_device_info(thermocycler: Thermocycler) -> None:
     """It should have device info."""
     assert {
         "model": "v02",
@@ -36,7 +45,7 @@ def test_device_info(thermocycler: Thermocycler):
     } == thermocycler.device_info
 
 
-async def test_lid_status(thermocycler: Thermocycler):
+async def test_lid_status(thermocycler: Thermocycler) -> None:
     """It should run open and close lid."""
     await thermocycler.wait_next_poll()
     assert thermocycler.lid_status == "open"
@@ -48,7 +57,7 @@ async def test_lid_status(thermocycler: Thermocycler):
     assert thermocycler.lid_status == "open"
 
 
-async def test_lid_temperature(thermocycler: Thermocycler):
+async def test_lid_temperature(thermocycler: Thermocycler) -> None:
     """It should change lid temperature."""
     await thermocycler.set_lid_temperature(temperature=50)
     assert thermocycler.lid_target == 50
@@ -61,7 +70,7 @@ async def test_lid_temperature(thermocycler: Thermocycler):
     assert thermocycler.lid_target is None
 
 
-async def test_plate_temperature(thermocycler: Thermocycler):
+async def test_plate_temperature(thermocycler: Thermocycler) -> None:
     """It should change  plate temperature."""
     await thermocycler.set_temperature(temperature=52, hold_time_seconds=10)
     assert thermocycler.temperature == 52
@@ -77,7 +86,7 @@ async def test_plate_temperature(thermocycler: Thermocycler):
     assert thermocycler.target is None
 
 
-async def test_cycle_temperatures(thermocycler: Thermocycler):
+async def test_cycle_temperatures(thermocycler: Thermocycler) -> None:
     """It should cycle the temperature."""
     assert thermocycler.current_cycle_index is None
     assert thermocycler.current_step_index is None
@@ -116,7 +125,7 @@ async def test_cycle_temperatures(thermocycler: Thermocycler):
     assert thermocycler.total_step_count is None
 
 
-async def test_wait_for_temperatures(thermocycler: Thermocycler):
+async def test_wait_for_temperatures(thermocycler: Thermocycler) -> None:
     """It should wait for temperature and be at holding status"""
     await thermocycler.set_target_block_temperature(40.0)
     await thermocycler.set_target_lid_temperature(50.0)
@@ -124,3 +133,121 @@ async def test_wait_for_temperatures(thermocycler: Thermocycler):
     await thermocycler.wait_for_lid_temperature(temperature=50.0)
     assert thermocycler.status == TemperatureStatus.HOLDING
     assert thermocycler.lid_temp_status == TemperatureStatus.HOLDING
+
+
+async def test_cycle_cannot_be_interrupted_by_pause(
+    thermocycler: Thermocycler,
+    execution_manager: ExecutionManager,
+) -> None:
+    """If the execution manager is paused, it should not suspend the current cycle.
+
+    https://github.com/Opentrons/opentrons/issues/5496
+    """
+    temp_1 = 40.0
+    temp_2 = 50.0
+    final_temp = 60.0
+
+    # Start at a known temperature.
+    await thermocycler.set_temperature(temperature=temp_1)
+
+    # Oscillate between two temperatures for a while
+    # and then end on a third temperature.
+    steps = [
+        *[
+            {"temperature": temp_1},
+            {"temperature": temp_2},
+        ]
+        * 10,
+        {"temperature": final_temp},
+    ]
+
+    cycle_temperatures_task = asyncio.create_task(
+        thermocycler.cycle_temperatures(steps=steps, repetitions=1)
+    )
+
+    # Sleep until we're somewhere in the middle of the steps, probably mid-ramp.
+    # The overall time to complete all steps depends on the temperature change required,
+    # the emulator's poll frequency, and the emulator's temperature change per poll.
+    # We rely on this sleep time being less than whatever that is.
+    await asyncio.sleep(0.1)
+    # Make sure we're actually in the middle of the steps.
+    assert thermocycler.temperature != final_temp
+
+    # 10 poll/sec
+    # 1 deg / poll  (10 deg/sec)
+    #
+    await execution_manager.pause()
+
+    # All of the steps should complete, despite the pause.
+    #
+    # If the subject has a bug where the pause actually takes effect,
+    # this would stall forever. The anyio.fail_after() turns that into a TimeoutError
+    # for nicer reporting.
+    with anyio.fail_after(10):
+        await cycle_temperatures_task
+        assert thermocycler.temperature == final_temp
+
+
+async def test_cycle_can_be_blocked_by_preexisting_pause(
+    thermocycler: Thermocycler,
+    execution_manager: ExecutionManager,
+) -> None:
+    """A pre-existing pause should block a new cycle from starting.
+
+    Not to be confused with a pause that happens in the middle of a cycle.
+    """
+    temp_1 = 40.0
+    temp_2 = 50.0
+
+    await thermocycler.set_temperature(temperature=temp_1)
+
+    await execution_manager.pause()
+
+    with pytest.raises(TimeoutError):
+        with anyio.fail_after(1.0):
+            # Should block forever, if not for the anyio.fail_after().
+            steps = [{"temperature": temp_2}]
+            await thermocycler.cycle_temperatures(steps=steps, repetitions=1)
+
+    assert thermocycler.temperature == temp_1
+
+
+async def test_cycle_can_be_cancelled(
+    thermocycler: Thermocycler,
+    execution_manager: ExecutionManager,
+) -> None:
+    """A cycle should be cancellable (even though it isn't pausable)."""
+    temp_1 = 40.0
+    temp_2 = 50.0
+    final_temp = 60.0
+
+    # Start at a known temperature.
+    await thermocycler.set_temperature(temperature=temp_1)
+
+    # Oscillate between two temperatures for a while
+    # and then end on a third temperature.
+    steps = [
+        *[
+            {"temperature": temp_1},
+            {"temperature": temp_2},
+        ]
+        * 10,
+        {"temperature": final_temp},
+    ]
+
+    cycle_temperatures_task = asyncio.create_task(
+        thermocycler.cycle_temperatures(steps=steps, repetitions=1)
+    )
+
+    # Sleep until we're somewhere in the middle of the steps, probably mid-ramp.
+    # The overall time to complete all steps depends on the temperature change required,
+    # the emulator's poll frequency, and the emulator's temperature change per poll.
+    # We rely on this sleep time being less than whatever that is.
+    await asyncio.sleep(0.1)
+    # Make sure we're actually in the middle of the steps.
+    assert thermocycler.temperature != final_temp
+
+    await execution_manager.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await cycle_temperatures_task

--- a/api/tests/opentrons/hardware_control/integration/test_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/integration/test_thermocycler.py
@@ -173,9 +173,6 @@ async def test_cycle_cannot_be_interrupted_by_pause(
     # Make sure we're actually in the middle of the steps.
     assert thermocycler.temperature != final_temp
 
-    # 10 poll/sec
-    # 1 deg / poll  (10 deg/sec)
-    #
     await execution_manager.pause()
 
     # All of the steps should complete, despite the pause.


### PR DESCRIPTION
# Overview

Fixes #5496.

# Changelog

* Rework `Thermocycler.cycle_temperatures()` so that it has just a single pause opportunity at the very beginning—never in the middle of a cycle.
* Similarly, remove pause opportunities in the middle of `set_temperature()`, `wait_for_block_temperature()`, `set_lid_temperature()`, and `wait_for_lid_temperature()`. They now only have a single opportunity at the very beginning.
    * This is for code consistency with `cycle_temperatures()` so it doesn't look like `cycle_temperatures()` omits these opportunities accidentally.
    * I believe the only user-facing effect of this change is for the run log. It's less likely now for a pause to be reported as during one of these commands, and more likely for it to be reported for the command immediately before or after. I don't believe this changes the temperature-ramping behavior.

# Review requests

* Please double-check my thinking for `set_temperature()`, `wait_for_block_temperature()`, `set_lid_temperature()`, and `wait_for_lid_temperature()`, as mentioned in the changelog.
* Although we're disabling *pausing a protocol* in the middle of a cycle, we definitely want to retain the ability to *cancel a protocol* in the middle of a cycle. Is my understanding correct that I don't need to do anything special in order to do that? Some calling code will do the equivalent of `task.cancel()`, causing an `asyncio.CancelledError` to be raised from somewhere within the `Thermocycler` internals?
* I could use help with the tests. See my GitHub comment.

# Manual testing

```python
metadata = {"apiLevel": "2.12"}

def run(protocol):
    tc = protocol.load_module("thermocycler")
    tc.close_lid()
    tc.execute_profile([{"temperature": 40}, {"temperature": 50}], repetitions=3)
    tc.open_lid()
```

* A pause before a Thermocycler profile starts should prevent the profile from beginning.
* A pause during a Thermocycler profile should take effect after the Thermocycler profile ends.
* A run should still be promptly cancellable in the middle of a Thermocycler profile.

# Risk assessment

Since this is a small changeset, I think risk is fairly low as long as my assumptions are correct. See the review requests.

In the worst case, there's risk of breaking something about pause, cancel, or resume behavior.