### PR TITLE
fix(app): add default message for waitForResume commands

### DIFF
--- a/app/src/assets/localization/en/run_details.json
+++ b/app/src/assets/localization/en/run_details.json
@@ -53,6 +53,7 @@
   "drop_tip": "Dropping tip in {{well_name}} of {{labware}} in {{labware_location}}",
   "end_of_protocol": "End of protocol",
   "comment": "Comment",
+  "wait_for_resume": "Pausing protocol",
   "anticipated": "Anticipated steps",
   "protocol_steps": "Protocol steps",
   "protocol_run_failed": "Protocol run failed",

--- a/app/src/organisms/Devices/ProtocolRun/StepText.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/StepText.tsx
@@ -122,7 +122,7 @@ export function StepText(props: Props): JSX.Element | null {
     }
     case 'pause':
     case 'waitForResume': {
-      messageNode = displayCommand.params?.message ?? displayCommand.commandType
+      messageNode = displayCommand.params?.message ?? t('wait_for_resume')
       break
     }
     case 'loadLabware':

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/StepText.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/StepText.test.tsx
@@ -83,6 +83,16 @@ const MOCK_WAIT_FOR_RESUME_COMMAND: RunTimeCommand = {
   completedAt: 'end timestamp',
 } as any
 
+const MOCK_WAIT_FOR_RESUME_NO_MESSAGE_COMMAND: RunTimeCommand = {
+  id: '1234',
+  commandType: 'waitForResume',
+  params: {},
+  status: 'running',
+  result: {},
+  startedAt: 'start timestamp',
+  completedAt: 'end timestamp',
+} as any
+
 const MOCK_LOAD_COMMAND = {
   id: '1234',
   commandType: 'loadModule',
@@ -139,6 +149,16 @@ describe('StepText', () => {
       runCommand: MOCK_WAIT_FOR_RESUME_COMMAND as RunCommandSummary,
     })
     getByText('THIS IS THE PAUSE MESSAGE')
+  })
+
+  it('renders correct text for wait for resume without message', () => {
+    const { getByText } = render({
+      robotName: ROBOT_NAME,
+      runId: RUN_ID,
+      analysisCommand: null,
+      runCommand: MOCK_WAIT_FOR_RESUME_NO_MESSAGE_COMMAND as RunCommandSummary,
+    })
+    getByText('Pausing protocol')
   })
 
   it('renders correct command text for load commands', () => {


### PR DESCRIPTION
## Overview

#10852 changed the `commandType` of the `pause` command to `waitForResume`. However, the app was using the `commandType` string as the default pause command message in the case of a missing user-specified message. So, the user-facing UI _also_ changed from `pause` to `waitForResume`. This was unintentional.

This PR adds an explicit default pause message via i18n to the `StepText` component to fix the issue.

Closes #10948

## Changelog

- Show `Pausing protocol` instead of `waitForResume` if a pause step has no user-specified message

## Review requests

- Upload the testing protocol from #10948 and verify the step UI says "Pausing protocol"
- Add a `msg` argument to `ctx.pause` in the testing protocol, verify user-specified message is in the step UI

## Risk assessment

Very low