### PR TITLE
fix(app): software update toggle logic refactor

### DIFF
--- a/app/src/pages/AppSettings/GeneralSettings.tsx
+++ b/app/src/pages/AppSettings/GeneralSettings.tsx
@@ -118,6 +118,7 @@ export function GeneralSettings(): JSX.Element {
               <Link
                 textDecoration={TEXT_DECORATION_UNDERLINE}
                 onClick={() => setShowUpdateModal(true)}
+                marginLeft={SPACING.spacing2}
               >
                 {t('view_update')}
               </Link>

--- a/app/src/pages/AppSettings/GeneralSettings.tsx
+++ b/app/src/pages/AppSettings/GeneralSettings.tsx
@@ -61,9 +61,6 @@ export function GeneralSettings(): JSX.Element {
     setShowPreviousVersionModal,
   ] = React.useState<boolean>(false)
   const updateAvailable = Boolean(useSelector(getAvailableShellUpdate))
-  const [showUpdateModal, setShowUpdateModal] = React.useState<boolean>(
-    updateAvailable
-  )
   const [showUpdateBanner, setShowUpdateBanner] = React.useState<boolean>(
     updateAvailable
   )
@@ -77,7 +74,9 @@ export function GeneralSettings(): JSX.Element {
     const ignored = getAlertIsPermanentlyIgnored(s, ALERT_APP_UPDATE_AVAILABLE)
     return ignored !== null ? !ignored : null
   })
-
+  const [showUpdateModal, setShowUpdateModal] = React.useState<boolean>(
+    updateAlertEnabled ? updateAvailable : false
+  )
   const handleToggle = (): void => {
     if (updateAlertEnabled !== null) {
       dispatch(
@@ -249,7 +248,7 @@ export function GeneralSettings(): JSX.Element {
           </TertiaryButton>
         </Flex>
       </Box>
-      {showUpdateModal && updateAlertEnabled ? (
+      {showUpdateModal ? (
         <Portal level="top">
           <UpdateAppModal closeModal={() => setShowUpdateModal(false)} />
         </Portal>


### PR DESCRIPTION
closes #10962

# Overview

Software update toggle button bug fix

# Changelog

- change logic a bit in `GeneralSettings` when the update software modal is rendered

# Review requests

- change your dev bot channel to Stable. Go to the general tab. The software update modal should pop up. If you toggle off the software update toggle, the modal should be available via the banner + button, but if you navigate off and on the page, the modal will NOT pop up.

# Risk assessment

low