### PR TITLE
feat(app): display rows of wells with same liquid as a range

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidDetailCard.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidDetailCard.tsx
@@ -16,6 +16,7 @@ import * as React from 'react'
 import { css } from 'styled-components'
 import { Divider } from '../../../../atoms/structure'
 import { StyledText } from '../../../../atoms/text'
+import { getWellRangeForLiquidLabwarePair } from './utils'
 
 interface LiquidDetailCardProps {
   liquidId: string
@@ -25,6 +26,7 @@ interface LiquidDetailCardProps {
   volumeByWell: { [well: string]: number }
   setSelectedValue: React.Dispatch<React.SetStateAction<string | undefined>>
   selectedValue: string | undefined
+  labwareWellOrdering: string[][]
 }
 
 export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
@@ -36,6 +38,7 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
     volumeByWell,
     setSelectedValue,
     selectedValue,
+    labwareWellOrdering,
   } = props
   const LIQUID_CARD_STYLE = css`
     ${BORDERS.cardOutlineBorder}
@@ -49,6 +52,10 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
     background-color: ${COLORS.lightBlue};
     border: 1px solid ${COLORS.blue};
   `
+  const volumePerWellRange = getWellRangeForLiquidLabwarePair(
+    volumeByWell,
+    labwareWellOrdering
+  )
   return (
     <Box
       css={selectedValue === liquidId ? ACTIVE_STYLE : LIQUID_CARD_STYLE}
@@ -105,7 +112,7 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
       {selectedValue === liquidId ? (
         <>
           <Divider marginX={'-1rem'} marginY={SPACING.spacing4} />
-          {Object.entries(volumeByWell).map((well, index) => {
+          {volumePerWellRange.map((well, index) => {
             return (
               <Flex
                 key={index}
@@ -118,14 +125,14 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
                   marginTop={SPACING.spacing3}
                   marginRight={SPACING.spacing2}
                 >
-                  {well[0]}
+                  {well.wellName}
                 </StyledText>
                 <StyledText
                   as="p"
                   fontWeight={TYPOGRAPHY.fontWeightRegular}
                   marginTop={SPACING.spacing3}
                 >
-                  {well[1]} {MICRO_LITERS}
+                  {well.volume} {MICRO_LITERS}
                 </StyledText>
               </Flex>
             )

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
@@ -27,7 +27,6 @@ import {
   getLiquidsByIdForLabware,
   getWellFillFromLabwareId,
   getWellGroupForLiquidId,
-  getWellRangeForLiquidLabwarePair,
 } from './utils'
 
 interface LiquidsLabwareDetailsModalProps {
@@ -56,7 +55,11 @@ export const LiquidsLabwareDetailsModal = (
   )
   const labwareInfo = getLiquidsByIdForLabware(labwareId, labwareByLiquidId)
   const { slotName, labwareName } = getSlotLabwareName(labwareId, commands)
-  getWellRangeForLiquidLabwarePair()
+  const loadLabwareCommand = commands
+    ?.filter(command => command.commandType === 'loadLabware')
+    ?.find(command => command.result.labwareId === labwareId)
+  const labwareWellOrdering = loadLabwareCommand?.result.definition.ordering
+
   const HIDE_SCROLLBAR = css`
     ::-webkit-scrollbar {
       display: none;
@@ -89,6 +92,7 @@ export const LiquidsLabwareDetailsModal = (
                     key={index}
                     {...liquidInfo}
                     volumeByWell={entry[1][0].volumeByWell}
+                    labwareWellOrdering={labwareWellOrdering}
                     setSelectedValue={setSelectedValue}
                     selectedValue={selectedValue}
                   />

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
@@ -27,6 +27,7 @@ import {
   getLiquidsByIdForLabware,
   getWellFillFromLabwareId,
   getWellGroupForLiquidId,
+  getWellRangeForLiquidLabwarePair,
 } from './utils'
 
 interface LiquidsLabwareDetailsModalProps {
@@ -55,7 +56,7 @@ export const LiquidsLabwareDetailsModal = (
   )
   const labwareInfo = getLiquidsByIdForLabware(labwareId, labwareByLiquidId)
   const { slotName, labwareName } = getSlotLabwareName(labwareId, commands)
-
+  getWellRangeForLiquidLabwarePair()
   const HIDE_SCROLLBAR = css`
     ::-webkit-scrollbar {
       display: none;

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/LiquidDetailCard.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/LiquidDetailCard.test.tsx
@@ -16,6 +16,11 @@ describe('LiquidDetailCard', () => {
       description: 'Mock Description',
       displayColor: '#FFF',
       volumeByWell: { A1: 50, B1: 50 },
+      labwareWellOrdering: [
+        ['A1', 'B1', 'C1', 'D1'],
+        ['A2', 'B2', 'C2', 'D2'],
+        ['A3', 'B3', 'C3', 'D3'],
+      ],
       setSelectedValue: jest.fn(),
       selectedValue: '2',
     }
@@ -35,5 +40,14 @@ describe('LiquidDetailCard', () => {
     getByText('A1')
     getByText('B1')
     getAllByText(nestedTextMatcher('50 µL'))
+  })
+  it('renders well range for volume info if selected', () => {
+    const [{ getByText }] = render({
+      ...props,
+      selectedValue: '0',
+      volumeByWell: { A1: 50, B1: 50, C1: 50, D1: 50 },
+    })
+    getByText('A1: D1')
+    getByText(nestedTextMatcher('50 µL'))
   })
 })

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/utils.test.ts
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/utils.test.ts
@@ -5,6 +5,7 @@ import {
   getSlotLabwareName,
   getLiquidsByIdForLabware,
   getWellGroupForLiquidId,
+  getWellRangeForLiquidLabwarePair,
 } from '../utils'
 import { getLabwareDisplayName } from '@opentrons/shared-data'
 import type { LabwareByLiquidId, Liquid } from '@opentrons/api-client'
@@ -201,6 +202,27 @@ const MOCK_LABWARE_BY_LIQUID_ID_FOR_LABWARE = {
   ],
 }
 
+const MOCK_WELL_ORDERING = [
+  ['A1', 'B1', 'C1', 'D1'],
+  ['A2', 'B2', 'C2', 'D2'],
+  ['A3', 'B3', 'C3', 'D3'],
+  ['A4', 'B4', 'C4', 'D4'],
+  ['A5', 'B5', 'C5', 'D5'],
+  ['A6', 'B6', 'C6', 'D6'],
+]
+const MOCK_VOLUME_BY_WELL = {
+  A1: 50,
+  C5: 100,
+  A3: 100,
+  A4: 100,
+  B3: 100,
+  B4: 100,
+  C3: 100,
+  C4: 100,
+  D3: 100,
+  D4: 100,
+}
+
 jest.mock('@opentrons/shared-data')
 const mockGetLabwareDisplayName = getLabwareDisplayName as jest.MockedFunction<
   typeof getLabwareDisplayName
@@ -314,6 +336,20 @@ describe('getWellGroupForLiquidId', () => {
     }
     expect(
       getWellGroupForLiquidId(MOCK_LABWARE_BY_LIQUID_ID_FOR_LABWARE, '7')
+    ).toEqual(expected)
+  })
+})
+
+describe('getWellRangeForLiquidLabwarePair', () => {
+  it('returns correctly ranged wells', () => {
+    const expected = [
+      { wellName: 'A1', volume: 50 },
+      { wellName: 'A3: D3', volume: 100 },
+      { wellName: 'A4: D4', volume: 100 },
+      { wellName: 'C5', volume: 100 },
+    ]
+    expect(
+      getWellRangeForLiquidLabwarePair(MOCK_VOLUME_BY_WELL, MOCK_WELL_ORDERING)
     ).toEqual(expected)
   })
 })

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/utils.ts
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/utils.ts
@@ -136,3 +136,59 @@ export function getWellGroupForLiquidId(
     return { ...allWells, ...someWells }
   }, {})
 }
+
+// labware ordering
+// liquids by id for labware
+// start at top [0][0]
+// check if this is in volumeByWell
+// if yes, store volume and check [0][1]
+// if yes through [0][end], store index [0] and the volume
+// if no, check [1][0]
+// once you reach the end, look see if adjacent indeces have same volume
+// then range them based on [0][0] to [last][last]
+
+export function getWellRangeForLiquidLabwarePair(): any {
+  const volumeByWell = {
+    A3: 100,
+    A4: 100,
+    B3: 100,
+    B4: 100,
+    C3: 100,
+    C4: 100,
+    D3: 100,
+    D4: 100,
+  }
+  const ordering = [
+    ['A1', 'B1', 'C1', 'D1'],
+    ['A2', 'B2', 'C2', 'D2'],
+    ['A3', 'B3', 'C3', 'D3'],
+    ['A4', 'B4', 'C4', 'D4'],
+    ['A5', 'B5', 'C5', 'D5'],
+    ['A6', 'B6', 'C6', 'D6'],
+  ]
+
+  const myArray = ordering.reduce((totalAcc, row, index) => {
+    const rowValues = row.reduce((rowAcc, well, index) => {
+      if (index === 0 && volumeByWell[well] != null) {
+        return [{ wellName: well, volume: volumeByWell[well] }]
+      } else if (
+        rowAcc[0] != null &&
+        volumeByWell[well] != null &&
+        volumeByWell[well] === rowAcc[0].volume
+      ) {
+        return [rowAcc[0], { wellName: well, volume: volumeByWell[well] }]
+      } else {
+        return []
+      }
+    }, [])
+    // in outer reduce -- if no rowValues, add every volume by well for that row
+    // or if rowValues is greater than 2 ??
+    if (rowValues.length === 2) {
+      const rangeString = `${rowValues[0].wellName}: ${rowValues[1].wellName}`
+      totalAcc.push({ range: rangeString, volume: rowValues[0].volume })
+    }
+    return totalAcc
+  }, [])
+
+  console.log(myArray)
+}


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
When a liquid is selected in the liquid labware details modal, display rows of wells with the same liquid as a range instead of listing out each well individually 

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

1. Add util `getWellRangeForLiquidLabwarePair` that will return an array of objects containing a `wellName` string that will either be a single well or well range and the corresponding volume
2. Use this util in `LiquidDetailCard` to show ranges instead of individual wells

# Review requests

<!--
Describe any requests for your reviewers here.
-->
Look over util logic, play around with this and make sure works as intented

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
