### PR TITLE
refactor(app): updateRobotBanner color, copy update, no longer dismissible

### DIFF
--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -77,7 +77,7 @@
   "robot_rename_button": "Rename robot",
   "robot_server_versions": "Robot Server Versions",
   "robot_server_versions_status": "up to date",
-  "robot_server_versions_banner_title": "A software update is available for this robot.",
+  "robot_software_update_required": "A robot software update is required to run protocols with this version of the Opentrons App.",
   "robot_server_versions_view_update": "View update",
   "robot_serial_number": "Robot Serial Number",
   "firmware_version": "Firmware Version",

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/__tests__/RobotServerVersion.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/__tests__/RobotServerVersion.test.tsx
@@ -76,7 +76,9 @@ describe('RobotSettings RobotServerVersion', () => {
       updateFromFileDisabledReason: null,
     })
     const [{ getByText }] = render()
-    getByText('A software update is available for this robot.')
+    getByText(
+      'A robot software update is required to run protocols with this version of the Opentrons App.'
+    )
     const btn = getByText('View update')
     fireEvent.click(btn)
     getByText('mock update buildroot')
@@ -89,7 +91,9 @@ describe('RobotSettings RobotServerVersion', () => {
       updateFromFileDisabledReason: null,
     })
     const [{ getByText }] = render()
-    getByText('A software update is available for this robot.')
+    getByText(
+      'A robot software update is required to run protocols with this version of the Opentrons App.'
+    )
     const btn = getByText('View update')
     fireEvent.click(btn)
     getByText('mock update buildroot')

--- a/app/src/organisms/UpdateRobotBanner/__tests__/UpdateRobotBanner.test.tsx
+++ b/app/src/organisms/UpdateRobotBanner/__tests__/UpdateRobotBanner.test.tsx
@@ -46,7 +46,9 @@ describe('UpdateRobotBanner', () => {
 
   it('should display correct information', () => {
     const { getByText, getByRole } = render(props)
-    getByText('A software update is available for this robot.')
+    getByText(
+      'A robot software update is required to run protocols with this version of the Opentrons App.'
+    )
     const btn = getByRole('button', { name: 'View update' })
     fireEvent.click(btn)
     getByText('mockUpdateBuildroot')
@@ -59,7 +61,7 @@ describe('UpdateRobotBanner', () => {
       updateFromFileDisabledReason: null,
     })
     const bannerText = screen.queryByText(
-      'A software update is available for this robot.'
+      'A robot software update is required to run protocols with this version of the Opentrons App.'
     )
     expect(bannerText).toBeNull()
   })
@@ -70,15 +72,10 @@ describe('UpdateRobotBanner', () => {
       autoUpdateDisabledReason: null,
       updateFromFileDisabledReason: null,
     })
-    const { getByText, getByTestId } = render(props)
-    getByText('A software update is available for this robot.')
-
-    const closeButton = getByTestId('Banner_close-button')
-    fireEvent.click(closeButton)
-    const bannerText = screen.queryByText(
-      'A software update is available for this robot.'
+    const { getByText } = render(props)
+    getByText(
+      'A robot software update is required to run protocols with this version of the Opentrons App.'
     )
-    expect(bannerText).toBeNull()
   })
 
   it('should render nothing if robot health status is not ok', () => {
@@ -86,7 +83,7 @@ describe('UpdateRobotBanner', () => {
       robot: mockReachableRobot,
     }
     const bannerText = screen.queryByText(
-      'A software update is available for this robot.'
+      'A robot software update is required to run protocols with this version of the Opentrons App.'
     )
     expect(bannerText).toBeNull()
   })

--- a/app/src/organisms/UpdateRobotBanner/index.tsx
+++ b/app/src/organisms/UpdateRobotBanner/index.tsx
@@ -30,7 +30,6 @@ export function UpdateRobotBanner(props: UpdateRobotBannerProps): JSX.Element {
   const { autoUpdateAction } = useSelector((state: State) => {
     return getBuildrootUpdateDisplayInfo(state, robot?.name)
   })
-  const [showUpdateBanner, setShowUpdateBanner] = React.useState<boolean>(true)
   const [
     showSoftwareUpdateModal,
     setShowSoftwareUpdateModal,
@@ -42,25 +41,14 @@ export function UpdateRobotBanner(props: UpdateRobotBannerProps): JSX.Element {
     setShowSoftwareUpdateModal(true)
   }
 
-  const handleCloseUpdateBanner: React.MouseEventHandler = e => {
-    e.preventDefault()
-    e.stopPropagation()
-    setShowUpdateBanner(false)
-  }
-
   return (
     <Flex onClick={e => e.stopPropagation()} flexDirection={DIRECTION_COLUMN}>
       {(autoUpdateAction === 'upgrade' || autoUpdateAction === 'downgrade') &&
       robot !== null &&
-      robot.healthStatus === 'ok' &&
-      showUpdateBanner ? (
-        <Banner
-          type="warning"
-          onCloseClick={handleCloseUpdateBanner}
-          {...styleProps}
-        >
+      robot.healthStatus === 'ok' ? (
+        <Banner type="error" {...styleProps}>
           <StyledText as="p" marginRight={SPACING.spacing2}>
-            {t('robot_server_versions_banner_title')}
+            {t('robot_software_update_required')}
           </StyledText>
           <Btn
             onClick={handleLaunchModal}


### PR DESCRIPTION
closes #10970


# Overview

Change Update Robot Banner to red, copy update, and remove ability to dismiss it

<img width="928" alt="Screen Shot 2022-06-30 at 3 54 27 PM" src="https://user-images.githubusercontent.com/66035149/176768458-0cb35e3b-ddb3-4810-a513-ca5c9d85ba02.png">

<img width="937" alt="Screen Shot 2022-06-30 at 3 55 15 PM" src="https://user-images.githubusercontent.com/66035149/176768461-3eef0780-9f3a-4c50-9a4e-ea774597b716.png">

<img width="931" alt="Screen Shot 2022-06-30 at 4 11 39 PM" src="https://user-images.githubusercontent.com/66035149/176769099-99f8f793-a050-4806-80ee-c09e49c69dc3.png">

# Changelog

- update `UpdateRobotBanner` and test
- change i18n key in `device_settings`

# Review requests

- with an update available, examine how the banner looks in `RobotCard`, `RobotOverview`, and `UpdateRobotBanner`

# Risk assessment

low