### PR TITLE
fix(app): fix ProtocolRunningContent remounting issue

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -370,31 +370,33 @@ export function ProtocolRunHeader({
     closeCurrentRun()
   }
 
-  const ClearProtocolBanner = (): JSX.Element | null => {
-    switch (runStatus) {
-      case RUN_STATUS_FAILED: {
-        return (
-          <Banner type="error" onCloseClick={handleClearClick}>
-            <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} width="100%">
-              {`${t('run_failed')}.`}
-            </Flex>
-          </Banner>
-        )
-      }
-      case RUN_STATUS_SUCCEEDED: {
-        return (
-          <Banner type="success" onCloseClick={handleClearClick}>
-            <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} width="100%">
-              {`${t('run_completed')}.`}
-            </Flex>
-          </Banner>
-        )
-      }
+  let ClearProtocolBanner: React.ReactNode
+  switch (runStatus) {
+    case RUN_STATUS_FAILED: {
+      ClearProtocolBanner = (
+        <Banner type="error" onCloseClick={handleClearClick}>
+          <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} width="100%">
+            {`${t('run_failed')}.`}
+          </Flex>
+        </Banner>
+      )
+      break
     }
-    return null
+    case RUN_STATUS_SUCCEEDED: {
+      ClearProtocolBanner = (
+        <Banner type="success" onCloseClick={handleClearClick}>
+          <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} width="100%">
+            {`${t('run_completed')}.`}
+          </Flex>
+        </Banner>
+      )
+      break
+    }
+    default:
+      ClearProtocolBanner = null
   }
 
-  const ProtocolRunningContent = (): JSX.Element | null =>
+  const ProtocolRunningContent: React.ReactNode =
     runStatus != null ? (
       <Flex
         backgroundColor={COLORS.lightGrey}
@@ -501,7 +503,7 @@ export function ProtocolRunHeader({
           </StyledText>
         )}
       </Flex>
-      {analysisErrors && analysisErrors?.length > 0 && (
+      {analysisErrors != null && analysisErrors?.length > 0 && (
         <ProtocolAnalysisErrorBanner errors={analysisErrors} />
       )}
       {runStatus === RUN_STATUS_BLOCKED_BY_OPEN_DOOR ? (
@@ -510,7 +512,7 @@ export function ProtocolRunHeader({
       {runStatus === RUN_STATUS_STOPPED ? (
         <Banner type="warning">{`${t('run_canceled')}.`}</Banner>
       ) : null}
-      {isCurrentRun ? <ClearProtocolBanner /> : null}
+      {isCurrentRun ? ClearProtocolBanner : null}
       <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
         <Box minWidth={SIZE_4}>
           <StyledText
@@ -615,7 +617,7 @@ export function ProtocolRunHeader({
           )}
         </Flex>
       </Flex>
-      <ProtocolRunningContent />
+      {ProtocolRunningContent}
       {showConfirmCancelModal ? (
         <ConfirmCancelModal
           onClose={() => setShowConfirmCancelModal(false)}

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -370,10 +370,10 @@ export function ProtocolRunHeader({
     closeCurrentRun()
   }
 
-  let ClearProtocolBanner: React.ReactNode
+  let clearProtocolBanner: JSX.Element | null
   switch (runStatus) {
     case RUN_STATUS_FAILED: {
-      ClearProtocolBanner = (
+      clearProtocolBanner = (
         <Banner type="error" onCloseClick={handleClearClick}>
           <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} width="100%">
             {`${t('run_failed')}.`}
@@ -383,7 +383,7 @@ export function ProtocolRunHeader({
       break
     }
     case RUN_STATUS_SUCCEEDED: {
-      ClearProtocolBanner = (
+      clearProtocolBanner = (
         <Banner type="success" onCloseClick={handleClearClick}>
           <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} width="100%">
             {`${t('run_completed')}.`}
@@ -393,10 +393,10 @@ export function ProtocolRunHeader({
       break
     }
     default:
-      ClearProtocolBanner = null
+      clearProtocolBanner = null
   }
 
-  const ProtocolRunningContent: React.ReactNode =
+  const protocolRunningContent: JSX.Element | null =
     runStatus != null ? (
       <Flex
         backgroundColor={COLORS.lightGrey}
@@ -512,7 +512,7 @@ export function ProtocolRunHeader({
       {runStatus === RUN_STATUS_STOPPED ? (
         <Banner type="warning">{`${t('run_canceled')}.`}</Banner>
       ) : null}
-      {isCurrentRun ? ClearProtocolBanner : null}
+      {isCurrentRun ? clearProtocolBanner : null}
       <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
         <Box minWidth={SIZE_4}>
           <StyledText
@@ -617,7 +617,7 @@ export function ProtocolRunHeader({
           )}
         </Flex>
       </Flex>
-      {ProtocolRunningContent}
+      {protocolRunningContent}
       {showConfirmCancelModal ? (
         <ConfirmCancelModal
           onClose={() => setShowConfirmCancelModal(false)}


### PR DESCRIPTION
# Overview
We were creating a new child component inside ProtocolRunHeader on each render of ProtocolRunHeader, we don't want to do that since that nested component will mount and unmount on every render of the parent component. Instead, if we want to break up the JSX we should either create an entirely new component outside of the component that we are refactoring or if we want to assign something to a variable from inside the parent component, it should be a `ReactNode`, which is the type that the render function returns, so it can be null, some JSX, a string, etc. 

Edit: I 'm used to defaulting to React.Node but we use JSX.Element so im sticking with that. the important thing is that we arent creating Components that return this type.

Closes #10956
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- `ProtocolRunHeader` no longer creates new components on every render, it creates some `ReactNode`'s. This fixes the mounting/unmounting bug.

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Check that the UI in the ProtocolRunHeader is no longer remounting over and over.
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
