### PR TITLE
fix(app): see how to restore a previous sw version btn fix

### DIFF
--- a/app/src/pages/AppSettings/GeneralSettings.tsx
+++ b/app/src/pages/AppSettings/GeneralSettings.tsx
@@ -18,9 +18,7 @@ import {
   COLORS,
   ALIGN_START,
   DIRECTION_COLUMN,
-  Btn,
 } from '@opentrons/components'
-import { css } from 'styled-components'
 
 import { TertiaryButton, ToggleButton } from '../../atoms/buttons'
 import { ExternalLink } from '../../atoms/Link/ExternalLink'
@@ -53,15 +51,6 @@ const GITHUB_LINK =
 
 const ENABLE_APP_UPDATE_NOTIFICATIONS = 'Enable app update notifications'
 const EVENT_APP_UPDATE_NOTIFICATIONS_TOGGLED = 'appUpdateNotificationsToggled'
-
-const PREVIOUS_VERSION_LINK_STYLE = css`
-  ${TYPOGRAPHY.linkPSemiBold}
-
-  &:focus-visible {
-    box-shadow: 0 0 0 3px ${COLORS.warning};
-    background-color: transparent;
-  }
-`
 
 export function GeneralSettings(): JSX.Element {
   const { t } = useTranslation(['app_settings', 'shared'])
@@ -201,14 +190,14 @@ export function GeneralSettings(): JSX.Element {
           </Box>
           <Box>
             <Flex flexDirection={DIRECTION_COLUMN}>
-              <Btn
-                textAlign={ALIGN_START}
-                css={PREVIOUS_VERSION_LINK_STYLE}
+              <Link
+                role="button"
+                css={TYPOGRAPHY.linkPSemiBold}
                 onClick={() => setShowPreviousVersionModal(true)}
                 id="GeneralSettings_previousVersionLink"
               >
                 {t('restore_previous')}
-              </Btn>
+              </Link>
               <ExternalLink
                 href={SOFTWARE_SYNC_URL}
                 id="GeneralSettings_appAndRobotSync"

--- a/app/src/pages/AppSettings/GeneralSettings.tsx
+++ b/app/src/pages/AppSettings/GeneralSettings.tsx
@@ -18,7 +18,9 @@ import {
   COLORS,
   ALIGN_START,
   DIRECTION_COLUMN,
+  Btn,
 } from '@opentrons/components'
+import { css } from 'styled-components'
 
 import { TertiaryButton, ToggleButton } from '../../atoms/buttons'
 import { ExternalLink } from '../../atoms/Link/ExternalLink'
@@ -51,6 +53,15 @@ const GITHUB_LINK =
 
 const ENABLE_APP_UPDATE_NOTIFICATIONS = 'Enable app update notifications'
 const EVENT_APP_UPDATE_NOTIFICATIONS_TOGGLED = 'appUpdateNotificationsToggled'
+
+const PREVIOUS_VERSION_LINK_STYLE = css`
+  ${TYPOGRAPHY.linkPSemiBold}
+
+  &:focus-visible {
+    box-shadow: 0 0 0 3px ${COLORS.warning};
+    background-color: transparent;
+  }
+`
 
 export function GeneralSettings(): JSX.Element {
   const { t } = useTranslation(['app_settings', 'shared'])
@@ -190,15 +201,14 @@ export function GeneralSettings(): JSX.Element {
           </Box>
           <Box>
             <Flex flexDirection={DIRECTION_COLUMN}>
-              <Link
-                role="button"
-                css={TYPOGRAPHY.linkPSemiBold}
-                href={''}
+              <Btn
+                textAlign={ALIGN_START}
+                css={PREVIOUS_VERSION_LINK_STYLE}
                 onClick={() => setShowPreviousVersionModal(true)}
                 id="GeneralSettings_previousVersionLink"
               >
                 {t('restore_previous')}
-              </Link>
+              </Btn>
               <ExternalLink
                 href={SOFTWARE_SYNC_URL}
                 id="GeneralSettings_appAndRobotSync"


### PR DESCRIPTION
closes #10972

# Overview

link had an empty string `href` specified which was causing the bug

# Changelog

- remove `href`

# Review requests

- go to General Settings, click on the `See how to restore a previous software version` button. It should open a modal. The modal links + buttons should work

# Risk assessment

low