### PR TITLE
fix(app): App fix deck cal banner misleading issue

### DIFF
--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -37,7 +37,7 @@
   "last_calibrated": "Last calibrated: {{date}}",
   "not_calibrated": "Not calibrated yet",
   "deck_calibration_missing": "Deck calibration missing",
-  "deck_calibration_missing_no_pipette": "Deck calibration missing. Attach a pipette to perform Deck calibration.",
+  "deck_calibration_missing_no_pipette": "Deck calibration missing. Attach a pipette to perform deck calibration.",
   "deck_calibration_recommended": "Deck calibration recommended",
   "calibrate_now": "Calibrate now",
   "recalibrate_now": "Recalibrate now",

--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -37,6 +37,7 @@
   "last_calibrated": "Last calibrated: {{date}}",
   "not_calibrated": "Not calibrated yet",
   "deck_calibration_missing": "Deck calibration missing",
+  "deck_calibration_missing_no_pipette": "Deck calibration missing. Attach a pipette to perform Deck calibration.",
   "deck_calibration_recommended": "Deck calibration recommended",
   "calibrate_now": "Calibrate now",
   "recalibrate_now": "Recalibrate now",

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
@@ -557,6 +557,11 @@ export function RobotSettingsCalibration({
       </Box>
       <Line />
       {/* DeckCalibration Section */}
+      {!pipettePresent && checkDeckCalibrationStatus() === 'error' && (
+        <Banner marginTop={SPACING.spacing5} type="error">
+          <StyledText>{t('deck_calibration_missing_no_pipette')}</StyledText>
+        </Banner>
+      )}
       {checkDeckCalibrationStatus() !== null && (
         <Banner
           marginTop={SPACING.spacing5}

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
@@ -466,8 +466,6 @@ export function RobotSettingsCalibration({
     true
   )
 
-  console.log('checkDeckCalibrationStatus', checkDeckCalibrationStatus())
-
   return (
     <>
       <Portal level="top">
@@ -564,7 +562,7 @@ export function RobotSettingsCalibration({
           <StyledText>{t('deck_calibration_missing_no_pipette')}</StyledText>
         </Banner>
       )}
-      {checkDeckCalibrationStatus() !== null && (
+      {pipettePresent && checkDeckCalibrationStatus() !== null && (
         <Banner
           marginTop={SPACING.spacing5}
           type={checkDeckCalibrationStatus() === 'error' ? 'error' : 'warning'}

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
@@ -12,7 +12,6 @@ import {
   COLORS,
   SPACING,
   TYPOGRAPHY,
-  TEXT_DECORATION_UNDERLINE,
   useHoverTooltip,
   TOOLTIP_LEFT,
   Mount,
@@ -447,6 +446,47 @@ export function RobotSettingsCalibration({
     }
   }
 
+  const DeckCalibrationBanner = (): JSX.Element | null => {
+    const currentDeckStatus = checkDeckCalibrationStatus()
+    return (
+      <>
+        {!pipettePresent
+          ? currentDeckStatus === 'error' && (
+              <Banner marginTop={SPACING.spacing5} type="error">
+                <StyledText>
+                  {t('deck_calibration_missing_no_pipette')}
+                </StyledText>
+              </Banner>
+            )
+          : currentDeckStatus != null && (
+              <Banner
+                marginTop={SPACING.spacing5}
+                type={currentDeckStatus === 'error' ? 'error' : 'warning'}
+              >
+                <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} width="100%">
+                  <StyledText as="p">
+                    {currentDeckStatus === 'error'
+                      ? t('deck_calibration_missing')
+                      : t('deck_calibration_recommended')}
+                  </StyledText>
+                  <Link
+                    role="button"
+                    color={COLORS.darkBlack}
+                    css={TYPOGRAPHY.pRegular}
+                    textDecoration={TYPOGRAPHY.textDecorationUnderline}
+                    onClick={() => handleClickDeckCalibration()}
+                  >
+                    {currentDeckStatus === 'error'
+                      ? t('calibrate_now')
+                      : t('recalibrate_now')}
+                  </Link>
+                </Flex>
+              </Banner>
+            )}
+      </>
+    )
+  }
+
   React.useEffect(() => {
     if (createStatus === RobotApi.SUCCESS) {
       createRequestId.current = null
@@ -557,36 +597,7 @@ export function RobotSettingsCalibration({
       </Box>
       <Line />
       {/* DeckCalibration Section */}
-      {!pipettePresent && checkDeckCalibrationStatus() === 'error' && (
-        <Banner marginTop={SPACING.spacing5} type="error">
-          <StyledText>{t('deck_calibration_missing_no_pipette')}</StyledText>
-        </Banner>
-      )}
-      {pipettePresent && checkDeckCalibrationStatus() !== null && (
-        <Banner
-          marginTop={SPACING.spacing5}
-          type={checkDeckCalibrationStatus() === 'error' ? 'error' : 'warning'}
-        >
-          <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} width="100%">
-            <StyledText as="p">
-              {checkDeckCalibrationStatus() === 'error'
-                ? t('deck_calibration_missing')
-                : t('deck_calibration_recommended')}
-            </StyledText>
-            <Link
-              role="button"
-              color={COLORS.darkBlack}
-              css={TYPOGRAPHY.pRegular}
-              textDecoration={TEXT_DECORATION_UNDERLINE}
-              onClick={() => handleClickDeckCalibration()}
-            >
-              {checkDeckCalibrationStatus() === 'error'
-                ? t('calibrate_now')
-                : t('recalibrate_now')}
-            </Link>
-          </Flex>
-        </Banner>
-      )}
+      <DeckCalibrationBanner />
       <Box paddingTop={SPACING.spacing5} paddingBottom={SPACING.spacing5}>
         <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>
           <Box marginRight={SPACING.spacing6}>

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
@@ -446,46 +446,39 @@ export function RobotSettingsCalibration({
     }
   }
 
-  const DeckCalibrationBanner = (): JSX.Element | null => {
-    const currentDeckStatus = checkDeckCalibrationStatus()
-    return (
-      <>
-        {!pipettePresent
-          ? currentDeckStatus === 'error' && (
-              <Banner marginTop={SPACING.spacing5} type="error">
-                <StyledText>
-                  {t('deck_calibration_missing_no_pipette')}
-                </StyledText>
-              </Banner>
-            )
-          : currentDeckStatus != null && (
-              <Banner
-                marginTop={SPACING.spacing5}
-                type={currentDeckStatus === 'error' ? 'error' : 'warning'}
-              >
-                <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} width="100%">
-                  <StyledText as="p">
-                    {currentDeckStatus === 'error'
-                      ? t('deck_calibration_missing')
-                      : t('deck_calibration_recommended')}
-                  </StyledText>
-                  <Link
-                    role="button"
-                    color={COLORS.darkBlack}
-                    css={TYPOGRAPHY.pRegular}
-                    textDecoration={TYPOGRAPHY.textDecorationUnderline}
-                    onClick={() => handleClickDeckCalibration()}
-                  >
-                    {currentDeckStatus === 'error'
-                      ? t('calibrate_now')
-                      : t('recalibrate_now')}
-                  </Link>
-                </Flex>
-              </Banner>
-            )}
-      </>
-    )
-  }
+  const currentDeckStatus = checkDeckCalibrationStatus()
+
+  const deckCalibrationBanner = !pipettePresent
+    ? currentDeckStatus === 'error' && (
+        <Banner marginTop={SPACING.spacing5} type="error">
+          <StyledText>{t('deck_calibration_missing_no_pipette')}</StyledText>
+        </Banner>
+      )
+    : currentDeckStatus != null && (
+        <Banner
+          marginTop={SPACING.spacing5}
+          type={currentDeckStatus === 'error' ? 'error' : 'warning'}
+        >
+          <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} width="100%">
+            <StyledText as="p">
+              {currentDeckStatus === 'error'
+                ? t('deck_calibration_missing')
+                : t('deck_calibration_recommended')}
+            </StyledText>
+            <Link
+              role="button"
+              color={COLORS.darkBlack}
+              css={TYPOGRAPHY.pRegular}
+              textDecoration={TYPOGRAPHY.textDecorationUnderline}
+              onClick={() => handleClickDeckCalibration()}
+            >
+              {currentDeckStatus === 'error'
+                ? t('calibrate_now')
+                : t('recalibrate_now')}
+            </Link>
+          </Flex>
+        </Banner>
+      )
 
   React.useEffect(() => {
     if (createStatus === RobotApi.SUCCESS) {
@@ -597,7 +590,7 @@ export function RobotSettingsCalibration({
       </Box>
       <Line />
       {/* DeckCalibration Section */}
-      <DeckCalibrationBanner />
+      {deckCalibrationBanner}
       <Box paddingTop={SPACING.spacing5} paddingBottom={SPACING.spacing5}>
         <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>
           <Box marginRight={SPACING.spacing6}>

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
@@ -466,6 +466,8 @@ export function RobotSettingsCalibration({
     true
   )
 
+  console.log('checkDeckCalibrationStatus', checkDeckCalibrationStatus())
+
   return (
     <>
       <Portal level="top">
@@ -557,7 +559,7 @@ export function RobotSettingsCalibration({
       </Box>
       <Line />
       {/* DeckCalibration Section */}
-      {!pipettePresent && (
+      {!pipettePresent && checkDeckCalibrationStatus() === 'error' && (
         <Banner marginTop={SPACING.spacing5} type="error">
           <StyledText>{t('deck_calibration_missing_no_pipette')}</StyledText>
         </Banner>

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
@@ -557,7 +557,7 @@ export function RobotSettingsCalibration({
       </Box>
       <Line />
       {/* DeckCalibration Section */}
-      {!pipettePresent && checkDeckCalibrationStatus() === 'error' && (
+      {!pipettePresent && (
         <Banner marginTop={SPACING.spacing5} type="error">
           <StyledText>{t('deck_calibration_missing_no_pipette')}</StyledText>
         </Banner>

--- a/app/src/organisms/Devices/RobotSettings/__tests__/RobotSettingsCalibration.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/__tests__/RobotSettingsCalibration.test.tsx
@@ -227,6 +227,18 @@ describe('RobotSettingsCalibration', () => {
     getByText('Pipette Offset calibration missing')
   })
 
+  it('renders the error banner when a user has no pipette', () => {
+    const mockEmptyAttachedPipettes: AttachedPipettesByMount = {
+      left: null,
+      right: null,
+    } as any
+    mockUseAttachedPipettes.mockReturnValue(mockEmptyAttachedPipettes)
+    const [{ getByText }] = render()
+    getByText(
+      'Deck calibration missing. Attach a pipette to perform Deck calibration.'
+    )
+  })
+
   // it('renders the warning banner when calibration is marked bad', () => {
   //   mockUsePipetteOffsetCalibrations.mockReturnValue([
   //     mockPipetteOffsetCalibration4,

--- a/app/src/organisms/Devices/RobotSettings/__tests__/RobotSettingsCalibration.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/__tests__/RobotSettingsCalibration.test.tsx
@@ -238,7 +238,7 @@ describe('RobotSettingsCalibration', () => {
     mockUseAttachedPipettes.mockReturnValue(mockEmptyAttachedPipettes)
     const [{ getByText }] = render()
     getByText(
-      'Deck calibration missing. Attach a pipette to perform Deck calibration.'
+      'Deck calibration missing. Attach a pipette to perform deck calibration.'
     )
   })
 

--- a/app/src/organisms/Devices/RobotSettings/__tests__/RobotSettingsCalibration.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/__tests__/RobotSettingsCalibration.test.tsx
@@ -228,6 +228,9 @@ describe('RobotSettingsCalibration', () => {
   })
 
   it('renders the error banner when a user has no pipette', () => {
+    mockUseDeckCalibrationStatus.mockReturnValue(
+      Calibration.DECK_CAL_STATUS_IDENTITY
+    )
     const mockEmptyAttachedPipettes: AttachedPipettesByMount = {
       left: null,
       right: null,


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This will fix #10952

This banner shows up when a user has no pipette and deck cal status isn't `OK`.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- add a new banner to RobotSettingsCalibration
- 
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
