### PR TITLE
feat(app): add delete protocol option to overflow menu and create modal

### DIFF
--- a/app/src/organisms/ProtocolDetails/OverflowMenu.tsx
+++ b/app/src/organisms/ProtocolDetails/OverflowMenu.tsx
@@ -10,16 +10,20 @@ import {
   POSITION_RELATIVE,
   ALIGN_FLEX_END,
   TYPOGRAPHY,
+  useConditionalConfirm,
 } from '@opentrons/components'
 import { useMenuHandleClickOutside } from '../../atoms/MenuList/hooks'
 import { OverflowBtn } from '../../atoms/MenuList/OverflowBtn'
 import { MenuItem } from '../../atoms/MenuList/MenuItem'
 import { ExternalLink } from '../../atoms/Link/ExternalLink'
 import { Divider } from '../../atoms/structure'
+import { Portal } from '../../App/portal'
 import {
   analyzeProtocol,
+  removeProtocol,
   viewProtocolSourceFolder,
 } from '../../redux/protocol-storage'
+import { ConfirmDeleteProtocolModal } from '../ProtocolsLanding/ConfirmDeleteProtocolModal'
 
 import type { Dispatch } from '../../redux/types'
 
@@ -30,7 +34,7 @@ interface OverflowMenuProps {
 
 export function OverflowMenu(props: OverflowMenuProps): JSX.Element {
   const { protocolKey, protocolType } = props
-  const { t } = useTranslation('protocol_details')
+  const { t } = useTranslation(['protocol_details', 'protocol_list'])
   const {
     MenuOverlay,
     handleOverflowClick,
@@ -38,6 +42,11 @@ export function OverflowMenu(props: OverflowMenuProps): JSX.Element {
     setShowOverflowMenu,
   } = useMenuHandleClickOutside()
   const dispatch = useDispatch<Dispatch>()
+  const {
+    confirm: confirmDeleteProtocol,
+    showConfirmation: showDeleteConfirmation,
+    cancel: cancelDeleteProtocol,
+  } = useConditionalConfirm(() => dispatch(removeProtocol(protocolKey)), true)
 
   const handleClickShowInFolder: React.MouseEventHandler<HTMLButtonElement> = e => {
     e.preventDefault()
@@ -49,9 +58,21 @@ export function OverflowMenu(props: OverflowMenuProps): JSX.Element {
     dispatch(analyzeProtocol(protocolKey))
     setShowOverflowMenu(!showOverflowMenu)
   }
+
+  const handleClickDelete: React.MouseEventHandler<HTMLButtonElement> = e => {
+    e.preventDefault()
+    e.stopPropagation()
+    confirmDeleteProtocol()
+    setShowOverflowMenu(!showOverflowMenu)
+  }
+
   return (
     <Flex flexDirection={DIRECTION_COLUMN} position={POSITION_RELATIVE}>
-      <OverflowBtn alignSelf={ALIGN_FLEX_END} onClick={handleOverflowClick} />
+      <OverflowBtn
+        data-testid="ProtocolDetailsOverflowMenu_overflowBtn"
+        alignSelf={ALIGN_FLEX_END}
+        onClick={handleOverflowClick}
+      />
       {showOverflowMenu ? (
         <Flex
           width={'12rem'}
@@ -64,10 +85,24 @@ export function OverflowMenu(props: OverflowMenuProps): JSX.Element {
           right={0}
           flexDirection={DIRECTION_COLUMN}
         >
-          <MenuItem onClick={handleClickShowInFolder}>
+          <MenuItem
+            onClick={handleClickShowInFolder}
+            data-testid="ProtocolDetailsOverflowMenu_showInFolder"
+          >
             {t('show_in_folder')}
           </MenuItem>
-          <MenuItem onClick={handleClickReanalyze}>{t('reanalyze')}</MenuItem>
+          <MenuItem
+            onClick={handleClickReanalyze}
+            data-testid="ProtocolDetailsOverflowMenu_reanalyze"
+          >
+            {t('reanalyze')}
+          </MenuItem>
+          <MenuItem
+            onClick={handleClickDelete}
+            data-testid="ProtocolDetailsOverflowMenu_deleteProtocol"
+          >
+            {t('protocol_list:delete_protocol')}
+          </MenuItem>
           {protocolType === 'json' ? (
             <>
               <Divider />
@@ -83,6 +118,18 @@ export function OverflowMenu(props: OverflowMenuProps): JSX.Element {
             </>
           ) : null}
         </Flex>
+      ) : null}
+      {showDeleteConfirmation ? (
+        <Portal level="top">
+          <ConfirmDeleteProtocolModal
+            cancelDeleteProtocol={(e: React.MouseEvent) => {
+              e.preventDefault()
+              e.stopPropagation()
+              cancelDeleteProtocol()
+            }}
+            handleClickDelete={handleClickDelete}
+          />
+        </Portal>
       ) : null}
       <MenuOverlay />
     </Flex>

--- a/app/src/organisms/ProtocolDetails/__tests__/OverflowMenu.test.tsx
+++ b/app/src/organisms/ProtocolDetails/__tests__/OverflowMenu.test.tsx
@@ -1,0 +1,109 @@
+import * as React from 'react'
+import { fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+import { renderWithProviders } from '@opentrons/components'
+
+import { i18n } from '../../../i18n'
+import {
+  removeProtocol,
+  viewProtocolSourceFolder,
+  analyzeProtocol,
+} from '../../../redux/protocol-storage'
+
+import { OverflowMenu } from '../OverflowMenu'
+
+jest.mock('../../../redux/protocol-storage')
+
+const PROTOCOL_KEY = 'mock-protocol-key'
+
+const mockViewProtocolSourceFolder = viewProtocolSourceFolder as jest.MockedFunction<
+  typeof viewProtocolSourceFolder
+>
+const mockRemoveProtocol = removeProtocol as jest.MockedFunction<
+  typeof removeProtocol
+>
+const mockAnalyzeProtocol = analyzeProtocol as jest.MockedFunction<
+  typeof analyzeProtocol
+>
+
+const render = () => {
+  return renderWithProviders(
+    <MemoryRouter>
+      <OverflowMenu protocolKey={PROTOCOL_KEY} protocolType="json" />
+    </MemoryRouter>,
+    { i18nInstance: i18n }
+  )
+}
+
+describe('ProtocolDetailsOverflowMenu', () => {
+  beforeEach(() => {})
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should render label when clicking overflowMenu', () => {
+    const [{ getByTestId, getByText, getByRole }] = render()
+    const button = getByTestId('ProtocolDetailsOverflowMenu_overflowBtn')
+    fireEvent.click(button)
+    getByText('Show in folder')
+    getByText('Reanalyze')
+    getByText('Delete protocol')
+    getByRole('link', { name: 'Open Protocol Designer' })
+  })
+
+  it('should call folder open function when clicking show in folder', () => {
+    const [{ getByTestId, getByText }] = render()
+    const button = getByTestId('ProtocolDetailsOverflowMenu_overflowBtn')
+    fireEvent.click(button)
+    const folderButton = getByText('Show in folder')
+    fireEvent.click(folderButton)
+    expect(mockViewProtocolSourceFolder).toHaveBeenCalled()
+  })
+
+  it('should call analyze function when clicking reanalyze', () => {
+    const [{ getByTestId, getByText }] = render()
+    const button = getByTestId('ProtocolDetailsOverflowMenu_overflowBtn')
+    fireEvent.click(button)
+    const analyzeBtn = getByText('Reanalyze')
+    fireEvent.click(analyzeBtn)
+    expect(mockAnalyzeProtocol).toHaveBeenCalled()
+  })
+
+  it('should render modal when clicking delete protocol button', () => {
+    const [{ getByTestId, getByText, getByRole }] = render()
+    const button = getByTestId('ProtocolDetailsOverflowMenu_overflowBtn')
+    fireEvent.click(button)
+    const deleteButton = getByText('Delete protocol')
+    fireEvent.click(deleteButton)
+    getByText('Delete this protocol?')
+    getByText(
+      'This protocol will be moved to this computer’s trash and may be unrecoverable.'
+    )
+    getByRole('button', { name: 'Yes, delete protocol' })
+    getByRole('button', { name: 'cancel' })
+  })
+
+  it('should call detele function when clicking yes button', () => {
+    const [{ getByTestId, getByText, getByRole }] = render()
+    const button = getByTestId('ProtocolDetailsOverflowMenu_overflowBtn')
+    fireEvent.click(button)
+    const deleteButton = getByText('Delete protocol')
+    fireEvent.click(deleteButton)
+    const yesButton = getByRole('button', { name: 'Yes, delete protocol' })
+    fireEvent.click(yesButton)
+    expect(mockRemoveProtocol).toHaveBeenCalled()
+  })
+
+  it('should close modal when clicking cancel button', () => {
+    const [{ getByTestId, getByText, getByRole, queryByText }] = render()
+    const button = getByTestId('ProtocolDetailsOverflowMenu_overflowBtn')
+    fireEvent.click(button)
+    const deleteButton = getByText('Delete protocol')
+    fireEvent.click(deleteButton)
+    const cancelButton = getByRole('button', { name: 'cancel' })
+    fireEvent.click(cancelButton)
+    expect(queryByText('Delete this protocol?')).not.toBeInTheDocument()
+  })
+})

--- a/app/src/organisms/ProtocolsLanding/ConfirmDeleteProtocolModal.tsx
+++ b/app/src/organisms/ProtocolsLanding/ConfirmDeleteProtocolModal.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Flex,
+  COLORS,
+  DIRECTION_COLUMN,
+  TYPOGRAPHY,
+  SPACING,
+  JUSTIFY_FLEX_END,
+  Link,
+  ALIGN_CENTER,
+  TEXT_TRANSFORM_CAPITALIZE,
+} from '@opentrons/components'
+import { Modal } from '../../atoms/Modal'
+import { StyledText } from '../../atoms/text'
+import { AlertPrimaryButton } from '../../atoms/buttons'
+
+interface ConfirmDeleteProtocolModalProps {
+  cancelDeleteProtocol: React.MouseEventHandler<HTMLAnchorElement> | undefined
+  handleClickDelete: React.MouseEventHandler<HTMLButtonElement>
+}
+
+export function ConfirmDeleteProtocolModal(
+  props: ConfirmDeleteProtocolModalProps
+): JSX.Element {
+  const { t } = useTranslation(['protocol_list', 'shared'])
+  return (
+    <Modal
+      type="warning"
+      onClose={props.cancelDeleteProtocol}
+      title={t('should_delete_this_protocol')}
+    >
+      <Flex flexDirection={DIRECTION_COLUMN}>
+        <StyledText as="p" marginBottom={SPACING.spacing5}>
+          {t('this_protocol_will_be_trashed')}
+        </StyledText>
+        <Flex justifyContent={JUSTIFY_FLEX_END} alignItems={ALIGN_CENTER}>
+          <Link
+            role="button"
+            onClick={props.cancelDeleteProtocol}
+            textTransform={TEXT_TRANSFORM_CAPITALIZE}
+            marginRight={SPACING.spacing5}
+            css={TYPOGRAPHY.linkPSemiBold}
+          >
+            {t('shared:cancel')}
+          </Link>
+          <AlertPrimaryButton
+            backgroundColor={COLORS.error}
+            onClick={props.handleClickDelete}
+          >
+            {t('yes_delete_this_protocol')}
+          </AlertPrimaryButton>
+        </Flex>
+      </Flex>
+    </Modal>
+  )
+}

--- a/app/src/organisms/ProtocolsLanding/ProtocolOverflowMenu.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolOverflowMenu.tsx
@@ -11,25 +11,17 @@ import {
   ALIGN_FLEX_END,
   SIZE_4,
   useConditionalConfirm,
-  SPACING,
-  TEXT_TRANSFORM_CAPITALIZE,
-  JUSTIFY_FLEX_END,
-  ALIGN_CENTER,
-  TYPOGRAPHY,
-  Link,
 } from '@opentrons/components'
 
 import { OverflowBtn } from '../../atoms/MenuList/OverflowBtn'
 import { MenuItem } from '../../atoms/MenuList/MenuItem'
 import { useMenuHandleClickOutside } from '../../atoms/MenuList/hooks'
-import { AlertPrimaryButton } from '../../atoms/buttons'
-import { StyledText } from '../../atoms/text'
-import { Modal } from '../../atoms/Modal'
 import { Portal } from '../../App/portal'
 import {
   removeProtocol,
   viewProtocolSourceFolder,
 } from '../../redux/protocol-storage'
+import { ConfirmDeleteProtocolModal } from './ConfirmDeleteProtocolModal'
 
 import type { StyleProps } from '@opentrons/components'
 import type { Dispatch } from '../../redux/types'
@@ -43,7 +35,7 @@ export function ProtocolOverflowMenu(
   props: ProtocolOverflowMenuProps
 ): JSX.Element {
   const { protocolKey, handleRunProtocol } = props
-  const { t } = useTranslation(['protocol_list', 'shared'])
+  const { t } = useTranslation('protocol_list')
   const {
     MenuOverlay,
     handleOverflowClick,
@@ -121,43 +113,14 @@ export function ProtocolOverflowMenu(
 
       {showDeleteConfirmation ? (
         <Portal level="top">
-          <Modal
-            type="warning"
-            onClose={(e: React.MouseEvent) => {
+          <ConfirmDeleteProtocolModal
+            cancelDeleteProtocol={(e: React.MouseEvent) => {
               e.preventDefault()
               e.stopPropagation()
               cancelDeleteProtocol()
             }}
-            title={t('should_delete_this_protocol')}
-          >
-            <Flex flexDirection={DIRECTION_COLUMN}>
-              <StyledText as="p" marginBottom={SPACING.spacing5}>
-                {t('this_protocol_will_be_trashed')}
-              </StyledText>
-              <Flex justifyContent={JUSTIFY_FLEX_END} alignItems={ALIGN_CENTER}>
-                <Link
-                  role="button"
-                  onClick={(e: React.MouseEvent) => {
-                    e.preventDefault()
-                    e.stopPropagation()
-                    cancelDeleteProtocol()
-                  }}
-                  textTransform={TEXT_TRANSFORM_CAPITALIZE}
-                  marginRight={SPACING.spacing5}
-                  css={TYPOGRAPHY.linkPSemiBold}
-                  fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-                >
-                  {t('shared:cancel')}
-                </Link>
-                <AlertPrimaryButton
-                  backgroundColor={COLORS.error}
-                  onClick={handleClickDelete}
-                >
-                  {t('yes_delete_this_protocol')}
-                </AlertPrimaryButton>
-              </Flex>
-            </Flex>
-          </Modal>
+            handleClickDelete={handleClickDelete}
+          />
         </Portal>
       ) : null}
       <MenuOverlay />

--- a/app/src/organisms/ProtocolsLanding/__tests__/ConfirmDeleteProtocolModal.test.tsx
+++ b/app/src/organisms/ProtocolsLanding/__tests__/ConfirmDeleteProtocolModal.test.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react'
+import { renderWithProviders } from '@opentrons/components'
+import { fireEvent } from '@testing-library/react'
+import { i18n } from '../../../i18n'
+import { ConfirmDeleteProtocolModal } from '../ConfirmDeleteProtocolModal'
+
+const render = (
+  props: React.ComponentProps<typeof ConfirmDeleteProtocolModal>
+) => {
+  return renderWithProviders(<ConfirmDeleteProtocolModal {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+describe('ConfirmDeleteProtocolModal', () => {
+  let props: React.ComponentProps<typeof ConfirmDeleteProtocolModal>
+
+  beforeEach(() => {
+    props = {
+      cancelDeleteProtocol: jest.fn(),
+      handleClickDelete: jest.fn(),
+    }
+  })
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('renders correct text', () => {
+    const { getByText } = render(props)
+    getByText('Delete this protocol?')
+    getByText(
+      'This protocol will be moved to this computer’s trash and may be unrecoverable.'
+    )
+  })
+
+  it('renders buttons and clicking on them call corresponding props', () => {
+    props = {
+      cancelDeleteProtocol: jest.fn(),
+      handleClickDelete: jest.fn(),
+    }
+    const { getByText, getByRole } = render(props)
+    const cancel = getByText('cancel')
+    fireEvent.click(cancel)
+    expect(props.cancelDeleteProtocol).toHaveBeenCalled()
+    const confirm = getByRole('button', { name: 'Yes, delete protocol' })
+    fireEvent.click(confirm)
+    expect(props.handleClickDelete).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
closes #10402

# Overview

This adds a `delete protocol` option to the Protocol details overflow menu and also pulls out the `Confirm delete protocol modal` from the `ProtocolOverflowMenu` and into it's own component to reuse the code. Also I created a few tests.

# Changelog

- pulled modal code out of `ProtocolOverflowMenu` and into its own component
- added the delete protocol option to the `OverflowMenu` in the protocol details. 
- created a test for the modal `ConfirmDeleteProtocolModal` and `OverflowMenu` (since there was no test for it previously)

# Review requests

- delete a protocol from protocol card's overflow menu. The modal should pop up and the cancel and delete protocol and exit icon should all work as expected
- delete the protocol from the protocol detail page overflow menu. The modal should pop up and the cancel and delete protocol and exit icon should all work as expected

# Risk assessment

low