### PR TITLE
refactor(protocol-designer): fix logic in edit modules modal

### DIFF
--- a/protocol-designer/fixtures/state/deck.js
+++ b/protocol-designer/fixtures/state/deck.js
@@ -55,6 +55,7 @@ const mockDeckSetup = {
   modules: {
     mag_mod: mockMagneticModule,
     temp_mod: mockTemperatureModule,
+    hs_mod: mockHeaterShakerModule,
   },
   pipettes: {},
 }

--- a/protocol-designer/src/components/modals/EditModulesModal/__tests__/EditModulesModal.test.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/__tests__/EditModulesModal.test.tsx
@@ -185,6 +185,14 @@ describe('Edit Modules Modal', () => {
         'The Heater-Shaker cannot be placed in front of or behind another module'
       )
     })
+    it('should NOT error when moving a heater shaker adjacent to a slot it is in', () => {
+      // initial deck setup has HS in slot 1
+      getInitialDeckSetupMock.mockReturnValue(getMockDeckSetup())
+      // move heater shaker to slot 2
+      props.moduleOnDeck = { ...getMockHeaterShakerModule(), slot: '2' }
+      const wrapper = render(props)
+      expect(wrapper.find(SlotDropdown).childAt(0).prop('error')).toBeFalsy()
+    })
     it('should error when selecting a module when there is a heater shaker adjacent', () => {
       const initialDeckSetup = getMockDeckSetup()
       getInitialDeckSetupMock.mockReturnValue({

--- a/protocol-designer/src/components/modals/EditModulesModal/index.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.tsx
@@ -16,7 +16,6 @@ import {
   THERMOCYCLER_MODULE_TYPE,
   MAGNETIC_MODULE_TYPE,
   HEATERSHAKER_MODULE_TYPE,
-  HEATERSHAKER_MODULE_V1,
   THERMOCYCLER_MODULE_V1,
   ModuleType,
   ModuleModel,
@@ -119,24 +118,31 @@ export const EditModulesModal = (props: EditModulesModalProps): JSX.Element => {
     if (!selectedModel) {
       errors.selectedModel = i18n.t('alert.field.required')
     }
-    const isModuleAdjacentToHeaterShaker = some(
-      initialDeckSetup.modules,
-      hwModule =>
-        hwModule.type === HEATERSHAKER_MODULE_TYPE &&
-        getAreSlotsAdjacent(hwModule.slot, selectedSlot)
-    )
+    const isModuleAdjacentToHeaterShaker =
+      // if the module is a heater shaker, it can't be adjacent to another heater shaker
+      // because PD does not support MoaM
+      moduleOnDeck?.type !== HEATERSHAKER_MODULE_TYPE &&
+      some(
+        initialDeckSetup.modules,
+        hwModule =>
+          hwModule.type === HEATERSHAKER_MODULE_TYPE &&
+          getAreSlotsAdjacent(hwModule.slot, selectedSlot)
+      )
 
     if (isModuleAdjacentToHeaterShaker) {
       errors.selectedSlot = i18n.t(
         'alert.module_placement.HEATER_SHAKER_ADJACENT_TO_MODULE.body',
         { selectedSlot }
       )
-    } else if (selectedModel === HEATERSHAKER_MODULE_V1) {
+    } else if (moduleOnDeck?.type === HEATERSHAKER_MODULE_TYPE) {
       const isHeaterShakerAdjacentToAnotherModule = some(
         initialDeckSetup.modules,
-        hwModule => getAreSlotsAdjacent(hwModule.slot, selectedSlot)
+        hwModule =>
+          getAreSlotsAdjacent(hwModule.slot, selectedSlot) &&
+          // if the other module is a heater shaker it's the same heater shaker (reflecting current state)
+          // since the form has not been saved yet and PD does not support MoaM
+          hwModule.type !== HEATERSHAKER_MODULE_TYPE
       )
-
       if (isHeaterShakerAdjacentToAnotherModule) {
         errors.selectedSlot = i18n.t(
           'alert.module_placement.HEATER_SHAKER_ADJACENT_TO_ANOTHER_MODULE.body',


### PR DESCRIPTION
# Overview
This PR fixes a bug where you could not place a heater shaker adjacent to the slot it's currently in. 

closes #10863


# Review requests

Make a protocol with a HS
Try to move the HS to a slot adjacent (i.e. slot 4, since it gets placed in slot 1 initially)
You should no longer see an eror

# Risk assessment
Low
