### PR TITLE
fix(components): fix link tabIndex

### DIFF
--- a/components/src/primitives/Link.tsx
+++ b/components/src/primitives/Link.tsx
@@ -22,7 +22,7 @@ export const Link: PrimitiveComponent<'a', LinkProps> = styled.a
     (props: LinkProps): React.ComponentProps<PrimitiveComponent<'a'>> => {
       return props.external === true
         ? { target: '_blank', rel: 'noopener noreferrer' }
-        : { tabindex: '0' }
+        : { tabIndex: '0' }
     }
   )`
   text-decoration: none;


### PR DESCRIPTION

# Overview

fixes a tab index typo in the link component to resolve a console error. re: https://github.com/Opentrons/opentrons/pull/10930

# Changelog

 - Fixes a tab index typo in the link component to resolve a console error

# Review requests

confirm link tabbing works, no console error

# Risk assessment

low
