### PR TITLE
feat(api): add gripper grip and release to OT3api

### DIFF
--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -213,13 +213,13 @@ DEFAULT_RUN_CURRENT: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoa
     high_throughput={
         OT3AxisKind.X: 1.0,
         OT3AxisKind.Y: 1.0,
-        OT3AxisKind.Z: 1.0,
+        OT3AxisKind.Z: 1.4,
         OT3AxisKind.P: 1.0,
     },
     low_throughput={
         OT3AxisKind.X: 1.0,
         OT3AxisKind.Y: 1.0,
-        OT3AxisKind.Z: 1.0,
+        OT3AxisKind.Z: 1.4,
         OT3AxisKind.P: 1.0,
     },
     two_low_throughput={
@@ -227,7 +227,7 @@ DEFAULT_RUN_CURRENT: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoa
         OT3AxisKind.Y: 1.0,
     },
     gripper={
-        OT3AxisKind.Z: 1.0,
+        OT3AxisKind.Z: 1.4,
     },
 )
 

--- a/api/src/opentrons/config/gripper_config.py
+++ b/api/src/opentrons/config/gripper_config.py
@@ -81,7 +81,7 @@ def piecewise_force_conversion(
     function for the slope and y-intercept of a force/duty-cycle function, where each
     sub-list in the sequence contains:
 
-    :return: the force/duty-cycle value for the specified volume
+    :return: the duty-cycle value for the specified force
     """
     # pick the first item from the seq for which the target is less than
     # the bracketing element
@@ -94,7 +94,5 @@ def piecewise_force_conversion(
                 return (x[0] - newton) / m + x[1]
             else:
                 return newton * x[1] / x[0]
-
-    # Compatibility with previous implementation of search.
-    #  list(filter(lambda x: ul <= x[0], sequence))[0]
-    raise IndexError()
+    # return max duty cycle in config
+    return sequence[-1][1]

--- a/api/src/opentrons/config/gripper_config.py
+++ b/api/src/opentrons/config/gripper_config.py
@@ -78,8 +78,11 @@ def piecewise_force_conversion(
 ) -> float:
     """
     Takes a force in newton and a sequence representing a piecewise
-    function for the slope and y-intercept of a force/duty-cycle function, where each
-    sub-list in the sequence contains:
+    function for the slope for a force/duty-cycle function, where each
+    sub-list in the sequence contains the slope and valid domain for
+    the specific linear segment.
+
+    The values come from shared-data/gripper/definitions/gripperVx.json.
 
     :return: the duty-cycle value for the specified force
     """

--- a/api/src/opentrons/config/gripper_config.py
+++ b/api/src/opentrons/config/gripper_config.py
@@ -71,3 +71,28 @@ def load(
         pin_two_offset_from_base=_get_offset(gripper_def.pin_two_offset_from_base),
         quirks=gripper_def.quirks,
     )
+
+
+def piecewise_force_conversion(newton: float, sequence: List[List[float]]) -> float:
+    """
+    Takes a force in newton and a sequence representing a piecewise
+    function for the slope and y-intercept of a force/duty-cycle function, where each
+    sub-list in the sequence contains:
+
+      - the max volume for the piece of the function (minimum implied from the
+        max of the previous item or 0
+      - the slope of the segment
+      - the y-intercept of the segment
+
+    :return: the force/duty-cycle value for the specified volume
+    """
+    # pick the first item from the seq for which the target is less than
+    # the bracketing element
+    for x in sequence:
+        if newton <= x[0]:
+            # use that element to calculate the movement distance in mm
+            return x[1] * newton + x[2]
+
+    # Compatibility with previous implementation of search.
+    #  list(filter(lambda x: ul <= x[0], sequence))[0]
+    raise IndexError()

--- a/api/src/opentrons/config/gripper_config.py
+++ b/api/src/opentrons/config/gripper_config.py
@@ -73,25 +73,27 @@ def load(
     )
 
 
-def piecewise_force_conversion(newton: float, sequence: List[List[float]]) -> float:
+def piecewise_force_conversion(
+    newton: float, sequence: List[Tuple[float, int]]
+) -> float:
     """
     Takes a force in newton and a sequence representing a piecewise
     function for the slope and y-intercept of a force/duty-cycle function, where each
     sub-list in the sequence contains:
 
-      - the max volume for the piece of the function (minimum implied from the
-        max of the previous item or 0
-      - the slope of the segment
-      - the y-intercept of the segment
-
     :return: the force/duty-cycle value for the specified volume
     """
     # pick the first item from the seq for which the target is less than
     # the bracketing element
-    for x in sequence:
+    for i, x in enumerate(sequence):
         if newton <= x[0]:
-            # use that element to calculate the movement distance in mm
-            return x[1] * newton + x[2]
+            if i > 0:
+                # get slope m
+                prev_x = sequence[i - 1]
+                m = (x[0] - prev_x[0]) / (x[1] - prev_x[1])
+                return (x[0] - newton) / m + x[1]
+            else:
+                return newton * x[1] / x[0]
 
     # Compatibility with previous implementation of search.
     #  list(filter(lambda x: ul <= x[0], sequence))[0]

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -321,20 +321,15 @@ class OT3Controller:
         self,
         duration: float,
         duty_cycle: float,
-        frequency: float = 320000,
         stop_condition: MoveStopCondition = MoveStopCondition.none,
     ) -> bool:
-        move_group = create_gripper_jaw_move_group(
-            duration, duty_cycle, frequency, stop_condition
-        )
+        move_group = create_gripper_jaw_move_group(duration, duty_cycle, stop_condition)
         runner = MoveGroupRunner(move_groups=[move_group])
         await runner.run(can_messenger=self._messenger)
         return True
 
-    async def gripper_home_jaw(
-        self, duration: float, duty_cycle: float, frequency: float = 320000
-    ) -> bool:
-        move_group = create_gripper_jaw_home_group(duration, duty_cycle, frequency)
+    async def gripper_home_jaw(self) -> bool:
+        move_group = create_gripper_jaw_home_group()
         runner = MoveGroupRunner(move_groups=[move_group])
         await runner.run(can_messenger=self._messenger)
         return True

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -286,6 +286,8 @@ class OT3Controller:
         if move_group_pipette:
             coros.append(runner_pipette.run(can_messenger=self._messenger))
         positions = await asyncio.gather(*coros)
+        if OT3Axis.G in checked_axes:
+            await self.gripper_home_jaw()
         for position in positions:
             self._position.update(position)
 

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -323,17 +323,15 @@ class OT3Controller:
         self,
         duty_cycle: float,
         stop_condition: MoveStopCondition = MoveStopCondition.none,
-    ) -> bool:
+    ) -> None:
         move_group = create_gripper_jaw_move_group(duty_cycle, stop_condition)
         runner = MoveGroupRunner(move_groups=[move_group])
         await runner.run(can_messenger=self._messenger)
-        return True
 
-    async def gripper_home_jaw(self) -> bool:
+    async def gripper_home_jaw(self) -> None:
         move_group = create_gripper_jaw_home_group()
         runner = MoveGroupRunner(move_groups=[move_group])
         await runner.run(can_messenger=self._messenger)
-        return True
 
     async def get_attached_instruments(
         self, expected: Dict[OT3Mount, PipetteName]

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -29,8 +29,8 @@ from .ot3utils import (
     node_to_axis,
     sub_system_to_node_id,
     sensor_node_for_mount,
-    create_gripper_move_group,
-    create_gripper_home_group,
+    create_gripper_jaw_move_group,
+    create_gripper_jaw_home_group,
 )
 
 try:
@@ -317,24 +317,24 @@ class OT3Controller:
         """
         return await self.home(axes)
 
-    async def gripper_move(
+    async def gripper_move_jaw(
         self,
         duration: float,
         duty_cycle: float,
         frequency: float = 320000,
         stop_condition: MoveStopCondition = MoveStopCondition.none,
     ) -> bool:
-        move_group = create_gripper_move_group(
+        move_group = create_gripper_jaw_move_group(
             duration, duty_cycle, frequency, stop_condition
         )
         runner = MoveGroupRunner(move_groups=[move_group])
         await runner.run(can_messenger=self._messenger)
         return True
 
-    async def gripper_home(
+    async def gripper_home_jaw(
         self, duration: float, duty_cycle: float, frequency: float = 320000
     ) -> bool:
-        move_group = create_gripper_home_group(duration, duty_cycle, frequency)
+        move_group = create_gripper_jaw_home_group(duration, duty_cycle, frequency)
         runner = MoveGroupRunner(move_groups=[move_group])
         await runner.run(can_messenger=self._messenger)
         return True

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -51,6 +51,7 @@ from opentrons_hardware.hardware_control.current_settings import (
     set_hold_current,
     set_currents,
 )
+from opentrons_hardware.hardware_control import gripper_settings as gripper_hc
 from opentrons_hardware.firmware_bindings.constants import (
     NodeId,
     PipetteName as FirmwarePipetteName,
@@ -314,6 +315,13 @@ class OT3Controller:
             New position.
         """
         return await self.home(axes)
+
+    async def move_gripper(self, moves) -> bool:
+        runner = MoveGroupRunner(move_groups=[move_group])
+        await runner.run(can_messenger=self._messenger)
+        # TODO: should return encoder value once implemented
+        return True
+
 
     async def get_attached_instruments(
         self, expected: Dict[OT3Mount, PipetteName]

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -319,11 +319,10 @@ class OT3Controller:
 
     async def gripper_move_jaw(
         self,
-        duration: float,
         duty_cycle: float,
         stop_condition: MoveStopCondition = MoveStopCondition.none,
     ) -> bool:
-        move_group = create_gripper_jaw_move_group(duration, duty_cycle, stop_condition)
+        move_group = create_gripper_jaw_move_group(duty_cycle, stop_condition)
         runner = MoveGroupRunner(move_groups=[move_group])
         await runner.run(can_messenger=self._messenger)
         return True

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -235,12 +235,11 @@ class OT3Simulator:
 
     async def gripper_move_jaw(
         self,
-        duration: float,
         duty_cycle: float,
         stop_condition: MoveStopCondition = MoveStopCondition.none,
     ) -> bool:
         """Move gripper inward."""
-        _ = create_gripper_jaw_move_group(duration, duty_cycle, stop_condition)
+        _ = create_gripper_jaw_move_group(duty_cycle, stop_condition)
         return True
 
     async def gripper_home_jaw(self) -> bool:

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -237,23 +237,15 @@ class OT3Simulator:
         self,
         duration: float,
         duty_cycle: float,
-        frequency: float = 320000,
         stop_condition: MoveStopCondition = MoveStopCondition.none,
     ) -> bool:
         """Move gripper inward."""
-        _ = create_gripper_jaw_move_group(
-            duration, duty_cycle, frequency, stop_condition
-        )
+        _ = create_gripper_jaw_move_group(duration, duty_cycle, stop_condition)
         return True
 
-    async def gripper_home_jaw(
-        self,
-        duration: float,
-        duty_cycle: float,
-        frequency: float = 320000,
-    ) -> bool:
+    async def gripper_home_jaw(self) -> bool:
         """Move gripper outward."""
-        _ = create_gripper_jaw_home_group(duration, duty_cycle, frequency)
+        _ = create_gripper_jaw_home_group()
         return True
 
     def _attached_to_mount(

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -26,6 +26,8 @@ from .ot3utils import (
     get_current_settings,
     node_to_axis,
     axis_to_node,
+    create_gripper_move_group,
+    create_gripper_home_group,
 )
 
 from opentrons_hardware.firmware_bindings.constants import NodeId
@@ -230,6 +232,27 @@ class OT3Simulator:
             New position.
         """
         return axis_convert(self._position, 0.0)
+
+    async def gripper_move(
+        self,
+        duration: float,
+        duty_cycle: float,
+        frequency: float = 320000,
+        stop_condition: MoveStopCondition = MoveStopCondition.none,
+    ) -> bool:
+        """Move gripper inward."""
+        _ = create_gripper_move_group(duration, duty_cycle, frequency, stop_condition)
+        return True
+
+    async def gripper_home(
+        self,
+        duration: float,
+        duty_cycle: float,
+        frequency: float = 320000,
+    ) -> bool:
+        """Move gripper outward."""
+        _ = create_gripper_home_group(duration, duty_cycle, frequency)
+        return True
 
     def _attached_to_mount(
         self, mount: OT3Mount, expected_instr: Optional[PipetteName]

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -26,8 +26,8 @@ from .ot3utils import (
     get_current_settings,
     node_to_axis,
     axis_to_node,
-    create_gripper_move_group,
-    create_gripper_home_group,
+    create_gripper_jaw_move_group,
+    create_gripper_jaw_home_group,
 )
 
 from opentrons_hardware.firmware_bindings.constants import NodeId
@@ -233,7 +233,7 @@ class OT3Simulator:
         """
         return axis_convert(self._position, 0.0)
 
-    async def gripper_move(
+    async def gripper_move_jaw(
         self,
         duration: float,
         duty_cycle: float,
@@ -241,17 +241,19 @@ class OT3Simulator:
         stop_condition: MoveStopCondition = MoveStopCondition.none,
     ) -> bool:
         """Move gripper inward."""
-        _ = create_gripper_move_group(duration, duty_cycle, frequency, stop_condition)
+        _ = create_gripper_jaw_move_group(
+            duration, duty_cycle, frequency, stop_condition
+        )
         return True
 
-    async def gripper_home(
+    async def gripper_home_jaw(
         self,
         duration: float,
         duty_cycle: float,
         frequency: float = 320000,
     ) -> bool:
         """Move gripper outward."""
-        _ = create_gripper_home_group(duration, duty_cycle, frequency)
+        _ = create_gripper_jaw_home_group(duration, duty_cycle, frequency)
         return True
 
     def _attached_to_mount(

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -237,15 +237,13 @@ class OT3Simulator:
         self,
         duty_cycle: float,
         stop_condition: MoveStopCondition = MoveStopCondition.none,
-    ) -> bool:
+    ) -> None:
         """Move gripper inward."""
         _ = create_gripper_jaw_move_group(duty_cycle, stop_condition)
-        return True
 
-    async def gripper_home_jaw(self) -> bool:
+    async def gripper_home_jaw(self) -> None:
         """Move gripper outward."""
         _ = create_gripper_jaw_home_group()
-        return True
 
     def _attached_to_mount(
         self, mount: OT3Mount, expected_instr: Optional[PipetteName]

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -35,6 +35,7 @@ from opentrons_hardware.hardware_control.motion import (
 
 GRIPPER_JAW_HOME_TIME: float = 120
 GRIPPER_JAW_FREQUENCY: float = 320000
+GRIPPER_JAW_HOME_DC: float = 100
 
 # TODO: These methods exist to defer uses of NodeId to inside
 # method bodies, which won't be evaluated until called. This is needed
@@ -243,7 +244,7 @@ def create_gripper_jaw_home_group() -> MoveGroup:
     step = create_gripper_jaw_step(
         duration=np.float64(GRIPPER_JAW_HOME_TIME),
         frequency=np.float32(GRIPPER_JAW_FREQUENCY),
-        duty_cycle=np.float32(1),
+        duty_cycle=np.float32(GRIPPER_JAW_HOME_DC),
         stop_condition=MoveStopCondition.limit_switch,
         move_type=MoveType.home,
     )

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -30,7 +30,7 @@ from opentrons_hardware.hardware_control.motion import (
     MoveGroup,
     MoveType,
     MoveStopCondition,
-    create_gripper_step,
+    create_gripper_jaw_step,
 )
 
 # TODO: These methods exist to defer uses of NodeId to inside
@@ -221,13 +221,13 @@ def create_home_group(
     return move_group
 
 
-def create_gripper_move_group(
+def create_gripper_jaw_move_group(
     duration: float,
     duty_cycle: float,
     frequency: float,
     stop_condition: MoveStopCondition = MoveStopCondition.none,
 ) -> MoveGroup:
-    step = create_gripper_step(
+    step = create_gripper_jaw_step(
         duration=np.float64(duration),
         frequency=np.float32(frequency),
         duty_cycle=np.float32(duty_cycle),
@@ -237,12 +237,12 @@ def create_gripper_move_group(
     return move_group
 
 
-def create_gripper_home_group(
+def create_gripper_jaw_home_group(
     duration: float,
     duty_cycle: float,
     frequency: float,
 ) -> MoveGroup:
-    step = create_gripper_step(
+    step = create_gripper_jaw_step(
         duration=np.float64(duration),
         frequency=np.float32(frequency),
         duty_cycle=np.float32(duty_cycle),

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -33,6 +33,9 @@ from opentrons_hardware.hardware_control.motion import (
     create_gripper_jaw_step,
 )
 
+GRIPPER_JAW_HOME_TIME: float = 120
+GRIPPER_JAW_FREQUENCY: float = 320000
+
 # TODO: These methods exist to defer uses of NodeId to inside
 # method bodies, which won't be evaluated until called. This is needed
 # because the robot server doesn't have opentrons_ot3_firmware as a dep
@@ -224,12 +227,11 @@ def create_home_group(
 def create_gripper_jaw_move_group(
     duration: float,
     duty_cycle: float,
-    frequency: float,
     stop_condition: MoveStopCondition = MoveStopCondition.none,
 ) -> MoveGroup:
     step = create_gripper_jaw_step(
         duration=np.float64(duration),
-        frequency=np.float32(frequency),
+        frequency=np.float32(GRIPPER_JAW_FREQUENCY),
         duty_cycle=np.float32(duty_cycle),
         stop_condition=stop_condition,
     )
@@ -237,15 +239,11 @@ def create_gripper_jaw_move_group(
     return move_group
 
 
-def create_gripper_jaw_home_group(
-    duration: float,
-    duty_cycle: float,
-    frequency: float,
-) -> MoveGroup:
+def create_gripper_jaw_home_group() -> MoveGroup:
     step = create_gripper_jaw_step(
-        duration=np.float64(duration),
-        frequency=np.float32(frequency),
-        duty_cycle=np.float32(duty_cycle),
+        duration=np.float64(GRIPPER_JAW_HOME_TIME),
+        frequency=np.float32(GRIPPER_JAW_FREQUENCY),
+        duty_cycle=np.float32(1),
         stop_condition=MoveStopCondition.limit_switch,
         move_type=MoveType.home,
     )

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -34,6 +34,7 @@ from opentrons_hardware.hardware_control.motion import (
 )
 
 GRIPPER_JAW_HOME_TIME: float = 120
+GRIPPER_JAW_GRIP_TIME: float = 2
 GRIPPER_JAW_FREQUENCY: float = 320000
 GRIPPER_JAW_HOME_DC: float = 100
 
@@ -226,12 +227,11 @@ def create_home_group(
 
 
 def create_gripper_jaw_move_group(
-    duration: float,
     duty_cycle: float,
     stop_condition: MoveStopCondition = MoveStopCondition.none,
 ) -> MoveGroup:
     step = create_gripper_jaw_step(
-        duration=np.float64(duration),
+        duration=np.float64(GRIPPER_JAW_GRIP_TIME),
         frequency=np.float32(GRIPPER_JAW_FREQUENCY),
         duty_cycle=np.float32(duty_cycle),
         stop_condition=stop_condition,

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -28,6 +28,7 @@ from opentrons_hardware.hardware_control.motion import (
     NodeIdMotionValues,
     create_home_step,
     MoveGroup,
+    MoveType,
     MoveStopCondition,
     create_gripper_step,
 )
@@ -246,6 +247,7 @@ def create_gripper_home_group(
         frequency=np.float32(frequency),
         duty_cycle=np.float32(duty_cycle),
         stop_condition=MoveStopCondition.limit_switch,
+        move_type=MoveType.home,
     )
     move_group: MoveGroup = [step]
     return move_group

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -29,6 +29,7 @@ from opentrons_hardware.hardware_control.motion import (
     create_home_step,
     MoveGroup,
     MoveStopCondition,
+    create_gripper_step,
 )
 
 # TODO: These methods exist to defer uses of NodeId to inside
@@ -214,6 +215,37 @@ def create_home_group(
     step = create_home_step(
         distance=node_id_distances,
         velocity=node_id_velocities,
+    )
+    move_group: MoveGroup = [step]
+    return move_group
+
+
+def create_gripper_move_group(
+    duration: float,
+    duty_cycle: float,
+    frequency: float,
+    stop_condition: MoveStopCondition = MoveStopCondition.none,
+) -> MoveGroup:
+    step = create_gripper_step(
+        duration=np.float64(duration),
+        frequency=np.float32(frequency),
+        duty_cycle=np.float32(duty_cycle),
+        stop_condition=stop_condition,
+    )
+    move_group: MoveGroup = [step]
+    return move_group
+
+
+def create_gripper_home_group(
+    duration: float,
+    duty_cycle: float,
+    frequency: float,
+) -> MoveGroup:
+    step = create_gripper_step(
+        duration=np.float64(duration),
+        frequency=np.float32(frequency),
+        duty_cycle=np.float32(duty_cycle),
+        stop_condition=MoveStopCondition.limit_switch,
     )
     move_group: MoveGroup = [step]
     return move_group

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -34,8 +34,8 @@ from opentrons_hardware.hardware_control.motion import (
 )
 
 GRIPPER_JAW_HOME_TIME: float = 120
-GRIPPER_JAW_GRIP_TIME: float = 2
-GRIPPER_JAW_FREQUENCY: float = 320000
+GRIPPER_JAW_GRIP_TIME: float = 1
+GRIPPER_JAW_FREQUENCY: float = 32000
 GRIPPER_JAW_HOME_DC: float = 100
 
 # TODO: These methods exist to defer uses of NodeId to inside

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -35,7 +35,6 @@ from opentrons_hardware.hardware_control.motion import (
 
 GRIPPER_JAW_HOME_TIME: float = 120
 GRIPPER_JAW_GRIP_TIME: float = 1
-GRIPPER_JAW_FREQUENCY: float = 32000
 GRIPPER_JAW_HOME_DC: float = 100
 
 # TODO: These methods exist to defer uses of NodeId to inside
@@ -232,7 +231,6 @@ def create_gripper_jaw_move_group(
 ) -> MoveGroup:
     step = create_gripper_jaw_step(
         duration=np.float64(GRIPPER_JAW_GRIP_TIME),
-        frequency=np.float32(GRIPPER_JAW_FREQUENCY),
         duty_cycle=np.float32(duty_cycle),
         stop_condition=stop_condition,
     )
@@ -243,7 +241,6 @@ def create_gripper_jaw_move_group(
 def create_gripper_jaw_home_group() -> MoveGroup:
     step = create_gripper_jaw_step(
         duration=np.float64(GRIPPER_JAW_HOME_TIME),
-        frequency=np.float32(GRIPPER_JAW_FREQUENCY),
         duty_cycle=np.float32(GRIPPER_JAW_HOME_DC),
         stop_condition=MoveStopCondition.limit_switch,
         move_type=MoveType.home,

--- a/api/src/opentrons/hardware_control/dev_types.py
+++ b/api/src/opentrons/hardware_control/dev_types.py
@@ -21,6 +21,7 @@ from opentrons.drivers.types import MoveSplit
 from opentrons.types import Mount
 from opentrons.config.pipette_config import PipetteConfig
 from opentrons.config.gripper_config import GripperConfig
+from opentrons.hardware_control.types import GripperJawState
 
 
 class InstrumentSpec(TypedDict):
@@ -91,8 +92,7 @@ class GripperDict(InstrumentDict):
     name: GripperName
     model: GripperModel
     gripper_id: str
-    has_gripped: bool
-    ready_to_grip: bool
+    state: GripperJawState
 
 
 class InstrumentHardwareConfigs(TypedDict):

--- a/api/src/opentrons/hardware_control/instruments/gripper.py
+++ b/api/src/opentrons/hardware_control/instruments/gripper.py
@@ -80,6 +80,9 @@ class Gripper(AbstractInstrument[gripper_config.GripperConfig]):
         # TODO: add critical point implementation
         return Point(0, 0, 0)
 
+    def force_per_duty_cycle(self, newton: float):
+        return gripper_config.piecewise_force_conversion(newton, self.config.jaw_force_per_duty_cycle)
+
     def __str__(self) -> str:
         return f"{self._config.display_name}"
 

--- a/api/src/opentrons/hardware_control/instruments/gripper.py
+++ b/api/src/opentrons/hardware_control/instruments/gripper.py
@@ -80,7 +80,7 @@ class Gripper(AbstractInstrument[gripper_config.GripperConfig]):
         # TODO: add critical point implementation
         return Point(0, 0, 0)
 
-    def force_per_duty_cycle(self, newton: float) -> float:
+    def duty_cycle_by_force(self, newton: float) -> float:
         return gripper_config.piecewise_force_conversion(
             newton, self.config.jaw_force_per_duty_cycle
         )

--- a/api/src/opentrons/hardware_control/instruments/gripper.py
+++ b/api/src/opentrons/hardware_control/instruments/gripper.py
@@ -9,7 +9,7 @@ from typing import Any, Optional, Set
 from opentrons.types import Point
 from opentrons.calibration_storage.types import GripperCalibrationOffset
 from opentrons.config import gripper_config
-from opentrons.hardware_control.types import CriticalPoint
+from opentrons.hardware_control.types import CriticalPoint, GripperJawState
 from .instrument_abc import AbstractInstrument
 from opentrons.hardware_control.dev_types import AttachedGripper, GripperDict
 
@@ -39,12 +39,19 @@ class Gripper(AbstractInstrument[gripper_config.GripperConfig]):
         self._model = self._config.model
         self._calibration_offset = gripper_cal_offset
         self._gripper_id = gripper_id
-        self.has_gripped = False
-        self.ready_to_grip = False
+        self._state = GripperJawState.UNHOMED
         self._log = mod_log.getChild(self._gripper_id)
         self._log.info(
             f"loaded: {self._model}, gripper offset: {self._calibration_offset}"
         )
+
+    @property
+    def state(self) -> GripperJawState:
+        return self._state
+
+    @state.setter
+    def state(self, s: GripperJawState) -> None:
+        self._state = s
 
     @property
     def config(self) -> gripper_config.GripperConfig:
@@ -97,8 +104,7 @@ class Gripper(AbstractInstrument[gripper_config.GripperConfig]):
             "model": self._config.model,
             "gripper_id": self._gripper_id,
             "display_name": self._config.display_name,
-            "has_gripped": self.has_gripped,
-            "ready_to_grip": self.ready_to_grip,
+            "state": self._state,
         }
         return d
 

--- a/api/src/opentrons/hardware_control/instruments/gripper.py
+++ b/api/src/opentrons/hardware_control/instruments/gripper.py
@@ -39,8 +39,8 @@ class Gripper(AbstractInstrument[gripper_config.GripperConfig]):
         self._model = self._config.model
         self._calibration_offset = gripper_cal_offset
         self._gripper_id = gripper_id
-        self._has_gripped = False
-        self._ready_to_grip = False
+        self.has_gripped = False
+        self.ready_to_grip = False
         self._log = mod_log.getChild(self._gripper_id)
         self._log.info(
             f"loaded: {self._model}, gripper offset: {self._calibration_offset}"
@@ -80,8 +80,10 @@ class Gripper(AbstractInstrument[gripper_config.GripperConfig]):
         # TODO: add critical point implementation
         return Point(0, 0, 0)
 
-    def force_per_duty_cycle(self, newton: float):
-        return gripper_config.piecewise_force_conversion(newton, self.config.jaw_force_per_duty_cycle)
+    def force_per_duty_cycle(self, newton: float) -> float:
+        return gripper_config.piecewise_force_conversion(
+            newton, self.config.jaw_force_per_duty_cycle
+        )
 
     def __str__(self) -> str:
         return f"{self._config.display_name}"
@@ -95,8 +97,8 @@ class Gripper(AbstractInstrument[gripper_config.GripperConfig]):
             "model": self._config.model,
             "gripper_id": self._gripper_id,
             "display_name": self._config.display_name,
-            "has_gripped": self._has_gripped,
-            "ready_to_grip": self._ready_to_grip,
+            "has_gripped": self.has_gripped,
+            "ready_to_grip": self.ready_to_grip,
         }
         return d
 

--- a/api/src/opentrons/hardware_control/instruments/gripper_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/gripper_handler.py
@@ -91,7 +91,7 @@ class GripperHandler:
     def set_jaw_state(self, state: GripperJawState) -> None:
         self.verify_gripper().state = state
 
-    def get_duty_cycle_by_grip_force(self, newton: Optional[float] = 0) -> float:
+    def get_duty_cycle_by_grip_force(self, newton: Optional[float] = None) -> float:
         gripper = self.verify_gripper()
         if not newton:
             newton = DEFAULT_GRIP_FORCE_IN_NEWTON

--- a/api/src/opentrons/hardware_control/instruments/gripper_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/gripper_handler.py
@@ -20,7 +20,7 @@ class GripError(Exception):
 
 
 # TODO: verify value with HW and put this value in gripper config
-DEFAULT_GRIP_FORCE_IN_NEWTON = 3
+DEFAULT_GRIP_FORCE_IN_NEWTON = 3.0
 
 
 class GripperHandler:
@@ -70,12 +70,16 @@ class GripperHandler:
 
     def ready_for_grip(self) -> None:
         gripper = self._verify_gripper()
-        if gripper._has_gripped:
+        if gripper.has_gripped:
             raise GripError("Gripper is already gripping")
 
     def set_ready_to_grip(self, val: bool) -> None:
         gripper = self._verify_gripper()
-        gripper._ready_to_grip = val
+        gripper.ready_to_grip = val
+
+    def set_has_gripped(self, val: bool) -> None:
+        gripper = self._verify_gripper()
+        gripper.has_gripped = val
 
     def get_duty_cycle_by_grip_force(self, newton: Optional[float] = 0) -> float:
         gripper = self._verify_gripper()
@@ -83,4 +87,3 @@ class GripperHandler:
             newton = DEFAULT_GRIP_FORCE_IN_NEWTON
         duty_cycle = newton / gripper.force_per_duty_cycle(newton)
         return duty_cycle
-

--- a/api/src/opentrons/hardware_control/instruments/gripper_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/gripper_handler.py
@@ -30,7 +30,7 @@ class GripperHandler:
     def has_gripper(self) -> bool:
         return bool(self._gripper)
 
-    def verify_gripper(self) -> Gripper:
+    def get_gripper(self) -> Gripper:
         gripper = self._gripper
         if not gripper:
             raise GripperNotAttachedError(
@@ -75,7 +75,7 @@ class GripperHandler:
 
     def check_ready_for_grip(self) -> None:
         """Raise an exception if it is not currently valid to grip."""
-        gripper = self.verify_gripper()
+        gripper = self.get_gripper()
         self.check_ready_for_jaw_move()
         if gripper.state == GripperJawState.GRIPPING:
             raise GripError("Gripper is already gripping")
@@ -84,15 +84,15 @@ class GripperHandler:
 
     def check_ready_for_jaw_move(self) -> None:
         """Raise an exception if it is not currently valid to move the jaw."""
-        gripper = self.verify_gripper()
+        gripper = self.get_gripper()
         if gripper.state == GripperJawState.UNHOMED:
             raise GripError("Gripper jaw must be homed before moving")
 
     def set_jaw_state(self, state: GripperJawState) -> None:
-        self.verify_gripper().state = state
+        self.get_gripper().state = state
 
     def get_duty_cycle_by_grip_force(self, newton: Optional[float] = None) -> float:
-        gripper = self.verify_gripper()
+        gripper = self.get_gripper()
         if not newton:
             newton = DEFAULT_GRIP_FORCE_IN_NEWTON
         return gripper.duty_cycle_by_force(newton)

--- a/api/src/opentrons/hardware_control/instruments/gripper_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/gripper_handler.py
@@ -13,6 +13,16 @@ class GripperNotAttachedError(Exception):
     pass
 
 
+class GripError(Exception):
+    """An error raised if a gripper is accessed that is not attached"""
+
+    pass
+
+
+# TODO: verify value with HW and put this value in gripper config
+DEFAULT_GRIP_FORCE_IN_NEWTON = 3
+
+
 class GripperHandler:
     def __init__(self, gripper: Optional[Gripper] = None):
         self._gripper = gripper
@@ -57,3 +67,20 @@ class GripperHandler:
             return None
         else:
             return self._gripper.as_dict()
+
+    def ready_for_grip(self) -> None:
+        gripper = self._verify_gripper()
+        if gripper._has_gripped:
+            raise GripError("Gripper is already gripping")
+
+    def set_ready_to_grip(self, val: bool) -> None:
+        gripper = self._verify_gripper()
+        gripper._ready_to_grip = val
+
+    def get_duty_cycle_by_grip_force(self, newton: Optional[float] = 0) -> float:
+        gripper = self._verify_gripper()
+        if not newton:
+            newton = DEFAULT_GRIP_FORCE_IN_NEWTON
+        duty_cycle = newton / gripper.force_per_duty_cycle(newton)
+        return duty_cycle
+

--- a/api/src/opentrons/hardware_control/instruments/gripper_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/gripper_handler.py
@@ -14,7 +14,7 @@ class GripperNotAttachedError(Exception):
 
 
 class GripError(Exception):
-    """An error raised if a gripper is accessed that is not attached"""
+    """An error raised if a gripper action is blocked"""
 
     pass
 
@@ -30,7 +30,9 @@ class GripperHandler:
     def _verify_gripper(self) -> Gripper:
         gripper = self._gripper
         if not gripper:
-            raise GripperNotAttachedError
+            raise GripperNotAttachedError(
+                "Cannot perform action without gripper attached"
+            )
         return gripper
 
     def reset_gripper(self) -> None:
@@ -85,5 +87,4 @@ class GripperHandler:
         gripper = self._verify_gripper()
         if not newton:
             newton = DEFAULT_GRIP_FORCE_IN_NEWTON
-        duty_cycle = newton / gripper.force_per_duty_cycle(newton)
-        return duty_cycle
+        return gripper.duty_cycle_by_force(newton)

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -915,6 +915,24 @@ class OT3API(
     async def update_deck_calibration(self, new_transform: RobotCalibration) -> None:
         pass
 
+    async def _gripper_move(self, duty_cycle: float) -> None:
+        try:
+            await self._backend.(origin, moves[0])
+        except Exception:
+            self._log.exception("Gripper motion failed")
+            raise
+        
+
+    async def prepare_for_grip(self) -> None:
+        try:
+            await self._gripper_handler.ready_for_grip()
+            dc = self._gripper_handler.get_duty_cycle_by_grip_force()
+            await self._gripper_move()
+        except Exception:
+            self._log.exception("Failed to prepare for grip")
+            raise
+        self._gripper_handler.set_ready_to_grip(True)
+
     # Pipette action API
     async def prepare_for_aspirate(
         self, mount: Union[top_types.Mount, OT3Mount], rate: float = 1.0

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -556,7 +556,7 @@ class OT3API(
         Home the jaw of the gripper.
         """
         gripper = self._gripper_handler.verify_gripper()
-        await self._release()
+        await self._ungrip()
         gripper.state = GripperJawState.HOMED_READY
 
     async def home_plunger(self, mount: Union[top_types.Mount, OT3Mount]) -> None:
@@ -940,7 +940,7 @@ class OT3API(
             raise
 
     @ExecutionManagerProvider.wait_for_running
-    async def _release(self) -> None:
+    async def _ungrip(self) -> None:
         """Move the gripper jaw outward to reach the homing switch."""
         try:
             await self._backend.gripper_home_jaw()
@@ -953,10 +953,10 @@ class OT3API(
         dc = self._gripper_handler.get_duty_cycle_by_grip_force(force_newtons)
         await self._grip(duty_cycle=dc)
 
-    async def release(self) -> None:
+    async def ungrip(self) -> None:
         # get default grip force for release if not provided
         self._gripper_handler.check_ready_for_jaw_move()
-        await self._release()
+        await self._ungrip()
         self._gripper_handler.set_jaw_state(GripperJawState.HOMED_READY)
 
     # Pipette action API

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -919,7 +919,9 @@ class OT3API(
     async def _grip(self, duration: float, duty_cycle: float) -> None:
         """Move the gripper jaw inward to close."""
         try:
-            await self._backend.gripper_move(duration=duration, duty_cycle=duty_cycle)
+            await self._backend.gripper_move_jaw(
+                duration=duration, duty_cycle=duty_cycle
+            )
         except Exception:
             self._log.exception("Gripper grip failed")
             raise
@@ -928,7 +930,9 @@ class OT3API(
     async def _release(self, duration: float, duty_cycle: float) -> None:
         """Move the gripper jaw outward to reach the homing switch."""
         try:
-            await self._backend.gripper_home(duration=duration, duty_cycle=duty_cycle)
+            await self._backend.gripper_home_jaw(
+                duration=duration, duty_cycle=duty_cycle
+            )
         except Exception:
             self._log.exception("Gripper home failed")
             raise

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -944,7 +944,7 @@ class OT3API(
 
     async def grip(self, duration: float, newton: float) -> None:
         dc = self._gripper_handler.get_duty_cycle_by_grip_force(newton)
-        await self._grip(duty_cycle=dc, duration=duration)
+        await self._grip(duration=duration, duty_cycle=dc)
         self._gripper_handler.set_has_gripped(True)
         self._gripper_handler.set_ready_to_grip(False)
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -927,12 +927,10 @@ class OT3API(
         pass
 
     @ExecutionManagerProvider.wait_for_running
-    async def _grip(self, duration: float, duty_cycle: float) -> None:
+    async def _grip(self, duty_cycle: float) -> None:
         """Move the gripper jaw inward to close."""
         try:
-            await self._backend.gripper_move_jaw(
-                duration=duration, duty_cycle=duty_cycle
-            )
+            await self._backend.gripper_move_jaw(duty_cycle=duty_cycle)
         except Exception:
             self._log.exception("Gripper grip failed")
             raise
@@ -946,12 +944,12 @@ class OT3API(
             self._log.exception("Gripper home failed")
             raise
 
-    async def grip(self, duration: float, newton: float) -> None:
+    async def grip(self, force_newtons: float) -> None:
         self._gripper_handler.check_ready_for_grip()
-        dc = self._gripper_handler.get_duty_cycle_by_grip_force(newton)
-        await self._grip(duration=duration, duty_cycle=dc)
+        dc = self._gripper_handler.get_duty_cycle_by_grip_force(force_newtons)
+        await self._grip(duty_cycle=dc)
 
-    async def release(self, duration: float, newton: Optional[float] = None) -> None:
+    async def release(self) -> None:
         # get default grip force for release if not provided
         self._gripper_handler.check_ready_for_jaw_move()
         await self._release()

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -555,7 +555,7 @@ class OT3API(
         """
         Home the jaw of the gripper.
         """
-        gripper = self._gripper_handler.verify_gripper()
+        gripper = self._gripper_handler.get_gripper()
         await self._ungrip()
         gripper.state = GripperJawState.HOMED_READY
 
@@ -851,7 +851,7 @@ class OT3API(
                 self._current_position.update(position)
                 if OT3Axis.G in checked_axes:
                     try:
-                        gripper = self._gripper_handler.verify_gripper()
+                        gripper = self._gripper_handler.get_gripper()
                         gripper.state = GripperJawState.HOMED_READY
                     except GripperNotAttachedError:
                         pass

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -444,3 +444,21 @@ class NoTipAttachedError(RuntimeError):
 
 class TipAttachedError(RuntimeError):
     pass
+
+
+class GripperJawState(enum.Enum):
+    UNHOMED = enum.auto()
+    #: the gripper must be homed before it can do anything
+    HOMED_READY = enum.auto()
+    #: the gripper has been homed and is at its fully-open homed position
+    GRIPPING = enum.auto()
+    #: the gripper is actively force-control gripping something
+    HOLDING_CLOSED = enum.auto()
+    #: the gripper is in position-control mode somewhere other than its
+    #: open position and probably should be opened before gripping something
+    HOLDING_OPENED = enum.auto()
+    #: the gripper is holding itself open but not quite at its homed position
+
+    @property
+    def ready_for_grip(self) -> bool:
+        return self in [GripperJawState.HOMED_READY, GripperJawState.HOLDING_OPENED]

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -322,7 +322,7 @@ async def test_gripper_home_jaw(controller: OT3Controller, mock_move_group_run):
 
 
 async def test_gripper_grip(controller: OT3Controller, mock_move_group_run):
-    await controller.gripper_move_jaw(duration=2.0, duty_cycle=50)
+    await controller.gripper_move_jaw(duty_cycle=50)
     for call in mock_move_group_run.call_args_list:
         move_group_runner = call[0][0]
         for move_group in move_group_runner._move_groups:

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -307,8 +307,8 @@ def test_nodeid_filter_probed_core():
     ) == set([NodeId.gantry_y, NodeId.pipette_left])
 
 
-async def test_gripper_home(controller: OT3Controller, mock_move_group_run):
-    await controller.gripper_home(duration=2.0, duty_cycle=50)
+async def test_gripper_home_jaw(controller: OT3Controller, mock_move_group_run):
+    await controller.gripper_home_jaw(duration=2.0, duty_cycle=50)
     for call in mock_move_group_run.call_args_list:
         move_group_runner = call[0][0]
         for move_group in move_group_runner._move_groups:
@@ -322,7 +322,7 @@ async def test_gripper_home(controller: OT3Controller, mock_move_group_run):
 
 
 async def test_gripper_grip(controller: OT3Controller, mock_move_group_run):
-    await controller.gripper_move(duration=2.0, duty_cycle=50)
+    await controller.gripper_move_jaw(duration=2.0, duty_cycle=50)
     for call in mock_move_group_run.call_args_list:
         move_group_runner = call[0][0]
         for move_group in move_group_runner._move_groups:

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -308,7 +308,7 @@ def test_nodeid_filter_probed_core():
 
 
 async def test_gripper_home_jaw(controller: OT3Controller, mock_move_group_run):
-    await controller.gripper_home_jaw(duration=2.0, duty_cycle=50)
+    await controller.gripper_home_jaw()
     for call in mock_move_group_run.call_args_list:
         move_group_runner = call[0][0]
         for move_group in move_group_runner._move_groups:

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -354,13 +354,13 @@ async def test_gripper_action(
     with pytest.raises(
         GripperNotAttachedError, match="Cannot perform action without gripper attached"
     ):
-        await ot3_hardware.grip(2.0, 5.0)
+        await ot3_hardware.grip(5.0)
     mock_grip.assert_not_called()
 
     with pytest.raises(
         GripperNotAttachedError, match="Cannot perform action without gripper attached"
     ):
-        await ot3_hardware.release(2.0, 5.0)
+        await ot3_hardware.release()
     mock_release.assert_not_called()
 
     # cache gripper
@@ -369,18 +369,17 @@ async def test_gripper_action(
     await ot3_hardware.cache_gripper(instr_data)
 
     with pytest.raises(GripError, match="Gripper jaw must be homed before moving"):
-        await ot3_hardware.grip(2.0, 5.0)
+        await ot3_hardware.grip(5.0)
     await ot3_hardware.home_gripper_jaw()
     mock_release.assert_called_once()
     mock_release.reset_mock()
     await ot3_hardware.home([OT3Axis.G])
     mock_release.assert_called_once()
     mock_release.reset_mock()
-    await ot3_hardware.grip(2.0, 5.0)
+    await ot3_hardware.grip(5.0)
     mock_grip.assert_called_once_with(
-        2.0,
         gc.piecewise_force_conversion(5.0, gripper_config.jaw_force_per_duty_cycle),
     )
 
-    await ot3_hardware.release(2.0, 10.0)
+    await ot3_hardware.release()
     mock_release.assert_called_once()

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -10,6 +10,9 @@ from opentrons.hardware_control.dev_types import (
     InstrumentDict,
     AttachedGripper,
 )
+from opentrons.hardware_control.instruments.gripper_handler import (
+    GripperNotAttachedError,
+)
 from opentrons.hardware_control.types import OT3Mount, OT3Axis
 from opentrons.hardware_control.ot3api import OT3API
 from opentrons.hardware_control import ThreadManager
@@ -54,6 +57,32 @@ def mock_gantry_position(ot3_hardware: ThreadManager[OT3API]) -> Iterator[AsyncM
         ),
     ) as mock_gantry_pos:
         yield mock_gantry_pos
+
+
+@pytest.fixture
+def mock_grip(ot3_hardware: ThreadManager[OT3API]) -> Iterator[AsyncMock]:
+    with patch.object(
+        ot3_hardware.managed_obj,
+        "_grip",
+        AsyncMock(
+            spec=ot3_hardware.managed_obj._grip,
+            wraps=ot3_hardware.managed_obj._grip,
+        ),
+    ) as mock_move:
+        yield mock_move
+
+
+@pytest.fixture
+def mock_release(ot3_hardware: ThreadManager[OT3API]) -> Iterator[AsyncMock]:
+    with patch.object(
+        ot3_hardware.managed_obj,
+        "_release",
+        AsyncMock(
+            spec=ot3_hardware.managed_obj._release,
+            wraps=ot3_hardware.managed_obj._release,
+        ),
+    ) as mock_move:
+        yield mock_move
 
 
 @pytest.mark.parametrize(
@@ -314,3 +343,38 @@ async def test_cache_gripper(ot3_hardware: ThreadManager[OT3API]) -> None:
     # make sure the property attached_gripper returns GripperDict
     assert ot3_hardware.attached_gripper is not None
     assert ot3_hardware.attached_gripper["gripper_id"] == "g12345"
+
+
+async def test_gripper_action(
+    ot3_hardware: ThreadManager[OT3API],
+    mock_grip: AsyncMock,
+    mock_release: AsyncMock,
+) -> None:
+    with pytest.raises(
+        GripperNotAttachedError, match="Cannot perform action without gripper attached"
+    ):
+        await ot3_hardware.grip(2.0, 5.0)
+    mock_grip.assert_not_called()
+
+    with pytest.raises(
+        GripperNotAttachedError, match="Cannot perform action without gripper attached"
+    ):
+        await ot3_hardware.release(2.0, 5.0)
+    mock_release.assert_not_called()
+
+    # cache gripper
+    gripper_config = gc.load(GripperModel.V1, "g12345")
+    instr_data = AttachedGripper(config=gripper_config, id="g12345")
+    await ot3_hardware.cache_gripper(instr_data)
+
+    await ot3_hardware.grip(2.0, 5.0)
+    mock_grip.assert_called_once_with(
+        2.0,
+        gc.piecewise_force_conversion(5.0, gripper_config.jaw_force_per_duty_cycle),
+    )
+
+    await ot3_hardware.release(2.0, 10.0)
+    mock_release.assert_called_once_with(
+        2.0,
+        gc.piecewise_force_conversion(10.0, gripper_config.jaw_force_per_duty_cycle),
+    )

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -374,8 +374,6 @@ async def test_gripper_action(
     mock_release.assert_called_once()
     mock_release.reset_mock()
     await ot3_hardware.home([OT3Axis.G])
-    mock_release.assert_called_once()
-    mock_release.reset_mock()
     await ot3_hardware.grip(5.0)
     mock_grip.assert_called_once_with(
         gc.piecewise_force_conversion(5.0, gripper_config.jaw_force_per_duty_cycle),

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -391,7 +391,6 @@ class BrushedMotorVrefPayload(utils.BinarySerializable):
 class BrushedMotorPwmPayload(utils.BinarySerializable):
     """A request to set the pwm of a brushed motor."""
 
-    freq: utils.UInt32Field
     duty_cycle: utils.UInt32Field
 
 
@@ -407,7 +406,6 @@ class GripperInfoResponsePayload(utils.BinarySerializable):
 class GripperMoveRequestPayload(AddToMoveGroupRequestPayload):
     """A request to move gripper."""
 
-    freq: utils.UInt32Field
     duty_cycle: utils.UInt32Field
 
 

--- a/hardware/opentrons_hardware/hardware_control/constants.py
+++ b/hardware/opentrons_hardware/hardware_control/constants.py
@@ -1,5 +1,8 @@
 """Hardware Control Constants."""
 from typing_extensions import Final
 
+gripper_interrupts_per_sec: Final = 32000
+"""The number of gripper motor interrupts per second."""
+
 interrupts_per_sec: Final = 100000
 """The number of motor interrupts per second."""

--- a/hardware/opentrons_hardware/hardware_control/constants.py
+++ b/hardware/opentrons_hardware/hardware_control/constants.py
@@ -1,7 +1,7 @@
 """Hardware Control Constants."""
 from typing_extensions import Final
 
-gripper_interrupts_per_sec: Final = 32000
+brushed_motor_interrupts_per_sec: Final = 32000
 """The number of gripper motor interrupts per second."""
 
 interrupts_per_sec: Final = 100000

--- a/hardware/opentrons_hardware/hardware_control/gripper_settings.py
+++ b/hardware/opentrons_hardware/hardware_control/gripper_settings.py
@@ -9,7 +9,7 @@ from opentrons_hardware.firmware_bindings.messages.message_definitions import (
 )
 from opentrons_hardware.firmware_bindings.utils import UInt8Field, UInt32Field
 from opentrons_hardware.firmware_bindings.constants import NodeId
-from .constants import gripper_interrupts_per_sec
+from .constants import brushed_motor_interrupts_per_sec
 
 
 async def set_reference_voltage(
@@ -54,7 +54,9 @@ async def grip(
             payload=payloads.GripperMoveRequestPayload(
                 group_id=UInt8Field(group_id),
                 seq_id=UInt8Field(seq_id),
-                duration=UInt32Field(int(duration_sec * gripper_interrupts_per_sec)),
+                duration=UInt32Field(
+                    int(duration_sec * brushed_motor_interrupts_per_sec)
+                ),
                 duty_cycle=UInt32Field(duty_cycle),
             )
         ),

--- a/hardware/opentrons_hardware/hardware_control/gripper_settings.py
+++ b/hardware/opentrons_hardware/hardware_control/gripper_settings.py
@@ -9,6 +9,7 @@ from opentrons_hardware.firmware_bindings.messages.message_definitions import (
 )
 from opentrons_hardware.firmware_bindings.utils import UInt8Field, UInt32Field
 from opentrons_hardware.firmware_bindings.constants import NodeId
+from .constants import gripper_interrupts_per_sec
 
 
 async def set_reference_voltage(
@@ -28,16 +29,13 @@ async def set_reference_voltage(
 
 async def set_pwm_param(
     can_messenger: CanMessenger,
-    freq: int,
     duty_cycle: int,
 ) -> None:
     """Set gripper brushed motor reference voltage."""
     await can_messenger.send(
         node_id=NodeId.gripper,
         message=SetBrushedMotorPwmRequest(
-            payload=payloads.BrushedMotorPwmPayload(
-                freq=UInt32Field(freq), duty_cycle=UInt32Field(duty_cycle)
-            )
+            payload=payloads.BrushedMotorPwmPayload(duty_cycle=UInt32Field(duty_cycle))
         ),
     )
 
@@ -47,7 +45,6 @@ async def grip(
     group_id: int,
     seq_id: int,
     duration_sec: float,
-    freq: int,
     duty_cycle: int,
 ) -> None:
     """Start grip motion."""
@@ -57,8 +54,7 @@ async def grip(
             payload=payloads.GripperMoveRequestPayload(
                 group_id=UInt8Field(group_id),
                 seq_id=UInt8Field(seq_id),
-                duration=UInt32Field(int(duration_sec * freq)),
-                freq=UInt32Field(freq),
+                duration=UInt32Field(int(duration_sec * gripper_interrupts_per_sec)),
                 duty_cycle=UInt32Field(duty_cycle),
             )
         ),
@@ -66,7 +62,7 @@ async def grip(
 
 
 async def home(
-    can_messenger: CanMessenger, group_id: int, seq_id: int, freq: int, duty_cycle: int
+    can_messenger: CanMessenger, group_id: int, seq_id: int, duty_cycle: int
 ) -> None:
     """Start home motion."""
     await can_messenger.send(
@@ -76,7 +72,6 @@ async def home(
                 group_id=UInt8Field(group_id),
                 seq_id=UInt8Field(seq_id),
                 duration=UInt32Field(0),
-                freq=UInt32Field(freq),
                 duty_cycle=UInt32Field(duty_cycle),
             )
         ),

--- a/hardware/opentrons_hardware/hardware_control/motion.py
+++ b/hardware/opentrons_hardware/hardware_control/motion.py
@@ -173,8 +173,9 @@ def create_gripper_step(
     duration: np.float64,
     duty_cycle: np.float32,
     frequency: np.float32 = np.float32(320000),
-    stop_condition: MoveStopCondition = MoveStopCondition.none
+    stop_condition: MoveStopCondition = MoveStopCondition.none,
 ) -> MoveGroupStep:
+    """Creates a step for gripper jaw action."""
     step: MoveGroupStep = {}
     step[NodeId.gripper_g] = MoveGroupSingleGripperStep(
         duration_sec=duration,

--- a/hardware/opentrons_hardware/hardware_control/motion.py
+++ b/hardware/opentrons_hardware/hardware_control/motion.py
@@ -169,7 +169,7 @@ def create_tip_action_step(
     return step
 
 
-def create_gripper_step(
+def create_gripper_jaw_step(
     duration: np.float64,
     duty_cycle: np.float32,
     frequency: np.float32 = np.float32(320000),

--- a/hardware/opentrons_hardware/hardware_control/motion.py
+++ b/hardware/opentrons_hardware/hardware_control/motion.py
@@ -67,8 +67,8 @@ class MoveGroupSingleGripperStep:
     """A single gripper move in a move group."""
 
     duration_sec: np.float64
-    pwm_frequency: np.float32
     pwm_duty_cycle: np.float32
+    pwm_frequency: np.float32 = np.float32(320000)
     stop_condition: MoveStopCondition = MoveStopCondition.none
     move_type: MoveType = MoveType.linear
 
@@ -171,16 +171,15 @@ def create_tip_action_step(
 
 def create_gripper_step(
     duration: np.float64,
-    dut
+    duty_cycle: np.float32,
+    frequency: np.float32 = np.float32(320000),
+    stop_condition: MoveStopCondition = MoveStopCondition.none
 ) -> MoveGroupStep:
     step: MoveGroupStep = {}
     step[NodeId.gripper_g] = MoveGroupSingleGripperStep(
-        
+        duration_sec=duration,
+        pwm_frequency=frequency,
+        pwm_duty_cycle=duty_cycle,
+        stop_condition=stop_condition,
     )
-    DEFAULT_PWM_FREQ = 320000
-
-    duration_sec: np.float64
-    pwm_frequency: np.float32
-    pwm_duty_cycle: np.float32
-    stop_condition: MoveStopCondition = MoveStopCondition.none
-    move_type: MoveType = MoveType.linear
+    return step

--- a/hardware/opentrons_hardware/hardware_control/motion.py
+++ b/hardware/opentrons_hardware/hardware_control/motion.py
@@ -167,3 +167,20 @@ def create_tip_action_step(
             action=action,
         )
     return step
+
+
+def create_gripper_step(
+    duration: np.float64,
+    dut
+) -> MoveGroupStep:
+    step: MoveGroupStep = {}
+    step[NodeId.gripper_g] = MoveGroupSingleGripperStep(
+        
+    )
+    DEFAULT_PWM_FREQ = 320000
+
+    duration_sec: np.float64
+    pwm_frequency: np.float32
+    pwm_duty_cycle: np.float32
+    stop_condition: MoveStopCondition = MoveStopCondition.none
+    move_type: MoveType = MoveType.linear

--- a/hardware/opentrons_hardware/hardware_control/motion.py
+++ b/hardware/opentrons_hardware/hardware_control/motion.py
@@ -174,6 +174,7 @@ def create_gripper_step(
     duty_cycle: np.float32,
     frequency: np.float32 = np.float32(320000),
     stop_condition: MoveStopCondition = MoveStopCondition.none,
+    move_type: MoveType = MoveType.linear,
 ) -> MoveGroupStep:
     """Creates a step for gripper jaw action."""
     step: MoveGroupStep = {}
@@ -182,5 +183,6 @@ def create_gripper_step(
         pwm_frequency=frequency,
         pwm_duty_cycle=duty_cycle,
         stop_condition=stop_condition,
+        move_type=move_type,
     )
     return step

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -27,7 +27,7 @@ from opentrons_hardware.firmware_bindings.messages.payloads import (
     GripperMoveRequestPayload,
     TipActionRequestPayload,
 )
-from .constants import interrupts_per_sec, gripper_interrupts_per_sec
+from .constants import interrupts_per_sec, brushed_motor_interrupts_per_sec
 from opentrons_hardware.hardware_control.motion import (
     MoveGroups,
     MoveGroupSingleAxisStep,
@@ -200,7 +200,7 @@ class MoveGroupRunner:
                 group_id=UInt8Field(group),
                 seq_id=UInt8Field(seq),
                 duration=UInt32Field(
-                    int(step.duration_sec * gripper_interrupts_per_sec)
+                    int(step.duration_sec * brushed_motor_interrupts_per_sec)
                 ),
                 duty_cycle=UInt32Field(int(step.pwm_duty_cycle)),
             )
@@ -211,7 +211,7 @@ class MoveGroupRunner:
                 group_id=UInt8Field(group),
                 seq_id=UInt8Field(seq),
                 duration=UInt32Field(
-                    int(step.duration_sec * gripper_interrupts_per_sec)
+                    int(step.duration_sec * brushed_motor_interrupts_per_sec)
                 ),
                 duty_cycle=UInt32Field(int(step.pwm_duty_cycle)),
             )

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -27,7 +27,7 @@ from opentrons_hardware.firmware_bindings.messages.payloads import (
     GripperMoveRequestPayload,
     TipActionRequestPayload,
 )
-from .constants import interrupts_per_sec
+from .constants import interrupts_per_sec, gripper_interrupts_per_sec
 from opentrons_hardware.hardware_control.motion import (
     MoveGroups,
     MoveGroupSingleAxisStep,
@@ -199,8 +199,9 @@ class MoveGroupRunner:
             home_payload = GripperMoveRequestPayload(
                 group_id=UInt8Field(group),
                 seq_id=UInt8Field(seq),
-                duration=UInt32Field(int(step.duration_sec * step.pwm_frequency)),
-                freq=UInt32Field(int(step.pwm_frequency)),
+                duration=UInt32Field(
+                    int(step.duration_sec * gripper_interrupts_per_sec)
+                ),
                 duty_cycle=UInt32Field(int(step.pwm_duty_cycle)),
             )
             return GripperHomeRequest(payload=home_payload)
@@ -209,8 +210,9 @@ class MoveGroupRunner:
             linear_payload = GripperMoveRequestPayload(
                 group_id=UInt8Field(group),
                 seq_id=UInt8Field(seq),
-                duration=UInt32Field(int(step.duration_sec * step.pwm_frequency)),
-                freq=UInt32Field(int(step.pwm_frequency)),
+                duration=UInt32Field(
+                    int(step.duration_sec * gripper_interrupts_per_sec)
+                ),
                 duty_cycle=UInt32Field(int(step.pwm_duty_cycle)),
             )
             return GripperGripRequest(payload=linear_payload)

--- a/hardware/opentrons_hardware/scripts/gripper.py
+++ b/hardware/opentrons_hardware/scripts/gripper.py
@@ -23,7 +23,9 @@ from opentrons_hardware.hardware_control.gripper_settings import (
     home,
 )
 from opentrons_hardware.firmware_bindings.utils import UInt8Field
-from opentrons_hardware.hardware_control.constants import gripper_interrupts_per_sec
+from opentrons_hardware.hardware_control.constants import (
+    brushed_motor_interrupts_per_sec,
+)
 
 GetInputFunc = Callable[[str], str]
 OutputFunc = Callable[[str], None]
@@ -79,7 +81,7 @@ def output_details(i: int, duty_cycle: int, v_ref: float) -> None:
     print(f"\n\033[95mRound {i}:\033[0m")
     print("--------")
     print(f"V_ref: {v_ref * 100} mA")
-    print(f"PWM: {gripper_interrupts_per_sec}Hz {duty_cycle}%\n")
+    print(f"PWM: {brushed_motor_interrupts_per_sec}Hz {duty_cycle}%\n")
 
 
 async def run_test(messenger: CanMessenger) -> None:

--- a/hardware/opentrons_hardware/scripts/gripper.py
+++ b/hardware/opentrons_hardware/scripts/gripper.py
@@ -23,7 +23,7 @@ from opentrons_hardware.hardware_control.gripper_settings import (
     home,
 )
 from opentrons_hardware.firmware_bindings.utils import UInt8Field
-
+from opentrons_hardware.hardware_control.constants import gripper_interrupts_per_sec
 
 GetInputFunc = Callable[[str], str]
 OutputFunc = Callable[[str], None]
@@ -74,36 +74,35 @@ async def execute_move(messenger: CanMessenger) -> None:
     )
 
 
-def output_details(i: int, freq: int, duty_cycle: int, v_ref: float) -> None:
+def output_details(i: int, duty_cycle: int, v_ref: float) -> None:
     """Print out test details."""
     print(f"\n\033[95mRound {i}:\033[0m")
     print("--------")
     print(f"V_ref: {v_ref * 100} mA")
-    print(f"PWM: {freq}Hz {duty_cycle}%\n")
+    print(f"PWM: {gripper_interrupts_per_sec}Hz {duty_cycle}%\n")
 
 
 async def run_test(messenger: CanMessenger) -> None:
     """Run the for test."""
     print("Gripper testing begins... \n")
-    pwm_freq = prompt_int_input("PWM frequency in Hz (int)")
     pwm_duty = prompt_int_input("PWM duty cycle in % (int)")
 
     """Setup gripper"""
     try:
-        await set_pwm_param(messenger, pwm_freq, pwm_duty)
+        await set_pwm_param(messenger, pwm_duty)
 
         for i, v in enumerate(vref_list):
             await set_reference_voltage(messenger, v)
-            output_details(i, pwm_freq, pwm_duty, v)
+            output_details(i, pwm_duty, v)
 
             input(in_green("Press Enter to grip...\n"))
 
-            await grip(messenger, 0, 0, 0, 0, 0)
+            await grip(messenger, 0, 0, 0, 0)
             await execute_move(messenger)
 
             input(in_green("Press Enter to release...\n"))
 
-            await home(messenger, 0, 0, 0, 0)
+            await home(messenger, 0, 0, 0)
             await execute_move(messenger)
 
     except asyncio.CancelledError:

--- a/hardware/opentrons_hardware/scripts/gripper_currents.py
+++ b/hardware/opentrons_hardware/scripts/gripper_currents.py
@@ -80,25 +80,24 @@ async def run_test(messenger: CanMessenger) -> None:
     v_ref = prompt_float_input(
         "Set reference voltage in A (float, \033[96m0.5A\033[0m)"
     )
-    pwm_freq = prompt_int_input("Set PWM frequency in Hz (int, \033[96m32000Hz\033[0m)")
 
     try:
         await set_reference_voltage(messenger, v_ref)
 
         while True:
             duty = prompt_int_input("\nDuty cycle in % (int)")
-            await set_pwm_param(messenger, pwm_freq, duty)
+            await set_pwm_param(messenger, duty)
             print(f"\n\033[95m{duty}%\033[0m")
             print("--------")
 
             input(in_green("Press Enter to grip...\n"))
 
-            await grip(messenger, 0, 0, 0, 0, 0)
+            await grip(messenger, 0, 0, 0, 0)
             await execute_move(messenger)
 
             input(in_green("Press Enter to release...\n"))
 
-            await home(messenger, 0, 0, 0, 0)
+            await home(messenger, 0, 0, 0)
             await execute_move(messenger)
 
     except asyncio.CancelledError:


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Adds very basic functions for gripper jaw movements. We can specify a force in Newton and a duration in seconds for the gripper grip and release. Grip would move the gripper jaw inwards to close. Release would move the jaw outwards until the homing switch is triggered.