### PR TITLE
fix(app): H-S confirm attachment modal form stopPropagation addition

### DIFF
--- a/app/src/organisms/ModuleCard/HeaterShakerSlideout.tsx
+++ b/app/src/organisms/ModuleCard/HeaterShakerSlideout.tsx
@@ -152,7 +152,12 @@ export const HeaterShakerSlideout = (
         })
       }
     }
-    isSetShake ? confirmAttachment() : setHsValue(null)
+    if (isSetShake) {
+      confirmAttachment()
+    } else {
+      setHsValue(null)
+      onCloseClick()
+    }
   }
 
   let errorMessage

--- a/app/src/organisms/ModuleCard/HeaterShakerSlideout.tsx
+++ b/app/src/organisms/ModuleCard/HeaterShakerSlideout.tsx
@@ -119,7 +119,10 @@ export const HeaterShakerSlideout = (
     !configHasHeaterShakerAttached
   )
 
-  const sendSetTemperatureOrShakeCommand = (): void => {
+  const sendSetTemperatureOrShakeCommand: React.MouseEventHandler<HTMLInputElement> = e => {
+    e.preventDefault()
+    e.stopPropagation()
+
     if (hsValue != null && !isSetShake) {
       const setTempCommand: HeaterShakerStartSetTargetTemperatureCreateCommand = {
         commandType: 'heaterShaker/setTargetTemperature',
@@ -150,7 +153,6 @@ export const HeaterShakerSlideout = (
       }
     }
     isSetShake ? confirmAttachment() : setHsValue(null)
-    onCloseClick()
   }
 
   let errorMessage

--- a/app/src/organisms/ModuleCard/__tests__/HeaterShakerSlideout.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/HeaterShakerSlideout.test.tsx
@@ -241,6 +241,7 @@ describe('HeaterShakerSlideout', () => {
     fireEvent.change(input, { target: { value: '40' } })
     expect(button).toBeEnabled()
     fireEvent.click(button)
+    expect(props.onCloseClick).toHaveBeenCalled()
 
     expect(mockCreateCommand).toHaveBeenCalledWith({
       runId: props.currentRunId,


### PR DESCRIPTION
closes #10881

# Overview

There are 2 bugs that both don't exist on `edge` since they were introduced by some additions I made to `release_6.0.0`. That is why I made this off of the `release_6.0.0` branch

1st bug: When I added the input tag, type `submit` to allow you to submit your value using the keyboard, it introduced a bug where the confirm attachment modal would not appear correctly. This PR fixes it by adding `stopPropagation` and `preventDefault`

2nd bug: I had `onCloseClick` called for both temp and shaking commands, causing the modal + slideout to close completely whenever you hit submit on the slideout

# Changelog

- add `stopPropagation` and `preventDefault` to handle click
- add logic for `onCloseClick()` to only occur when you are on the temp slideout

# Review requests

- try to submit a shaking command via heater-shaker slideout. The confirm attachment modal should pop up and work as expected.

# Risk assessment

low