### PR TITLE
ci(labware-library): only run e2e tests on Ubuntu

### DIFF
--- a/.github/workflows/ll-test-build-deploy.yaml
+++ b/.github/workflows/ll-test-build-deploy.yaml
@@ -68,20 +68,16 @@ jobs:
           flags: labware-library
 
   e2e-test:
-    name: 'labware library e2e tests on ${{ matrix.os }}'
+    name: 'labware library e2e tests '
     needs: ['js-unit-test']
     timeout-minutes: 30
-    strategy:
-      matrix:
-        os: ['ubuntu-18.04', 'macos-latest']
-    runs-on: '${{ matrix.os }}'
+    runs-on: 'ubuntu-18.04'
     steps:
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'
         with:
           node-version: '14'
       - name: 'install libudev for usb-detection'
-        if: startsWith(matrix.os, 'ubuntu')
         run: sudo apt-get update && sudo apt-get install libudev-dev
       - name: 'cache yarn cache'
         uses: actions/cache@v2

--- a/.github/workflows/ll-test-build-deploy.yaml
+++ b/.github/workflows/ll-test-build-deploy.yaml
@@ -68,7 +68,7 @@ jobs:
           flags: labware-library
 
   e2e-test:
-    name: 'labware library e2e tests '
+    name: 'labware library e2e tests'
     needs: ['js-unit-test']
     timeout-minutes: 30
     runs-on: 'ubuntu-18.04'


### PR DESCRIPTION
## Overview

This PR follows up on #10446 and does the same thing on Labware Library CI for the exact same reason.

## Changelog

- ci(labware-library): only run e2e tests on Ubuntu

## Review requests

- [ ] You agree with this change


## Risk assessment

Pretty low; we do nothing OS-specific that I know of in Labware Library that would make these tests extra valuable.