### PR TITLE
perf(robot-server): Minimize selected columns to speed up `GET /runs`

### DIFF
--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -222,7 +222,11 @@ class RunStore:
         Returns:
             All stored run entries.
         """
-        select_runs = sqlalchemy.select(run_table)
+        select_runs = sqlalchemy.select(
+            run_table.c.id,
+            run_table.c.protocol_id,
+            run_table.c.created_at,
+        )
         select_actions = sqlalchemy.select(action_table)
         actions_by_run_id = defaultdict(list)
 

--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -218,11 +218,7 @@ class RunStore:
         Returns:
             All stored run entries.
         """
-        select_runs = sqlalchemy.select(
-            run_table.c.id,
-            run_table.c.protocol_id,
-            run_table.c.created_at,
-        )
+        select_runs = sqlalchemy.select(_run_columns)
         select_actions = sqlalchemy.select(action_table)
         actions_by_run_id = defaultdict(list)
 

--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -89,11 +89,9 @@ class RunStore:
                 )
             )
         )
-        select_run_resource = sqlalchemy.select(
-            run_table.c.id,
-            run_table.c.protocol_id,
-            run_table.c.created_at,
-        ).where(run_table.c.id == run_id)
+        select_run_resource = sqlalchemy.select(_run_columns).where(
+            run_table.c.id == run_id
+        )
 
         select_actions = sqlalchemy.select(action_table).where(
             action_table.c.run_id == run_id
@@ -196,11 +194,9 @@ class RunStore:
         Raises:
             RunNotFoundError: The given run ID was not found.
         """
-        select_run_resource = sqlalchemy.select(
-            run_table.c.id,
-            run_table.c.protocol_id,
-            run_table.c.created_at,
-        ).where(run_table.c.id == run_id)
+        select_run_resource = sqlalchemy.select(_run_columns).where(
+            run_table.c.id == run_id
+        )
 
         select_actions = sqlalchemy.select(action_table).where(
             action_table.c.run_id == run_id
@@ -381,6 +377,10 @@ class RunStore:
         self.get_state_summary.cache_clear()
         self.get_command.cache_clear()
         self._get_all_unparsed_commands.cache_clear()
+
+
+# The columns that must be present in a row passed to _convert_row_to_run().
+_run_columns = [run_table.c.id, run_table.c.protocol_id, run_table.c.created_at]
 
 
 def _convert_row_to_run(


### PR DESCRIPTION
# Overview

This PR makes an optimization, for speed and memory usage, to the database accesses that back HTTP calls to `GET /runs`.

# Changelog

Formerly, we were selecting every column of every row in the `run` table.

With this PR, we exclude these columns from the selection, since their values were being thrown away:

https://github.com/Opentrons/opentrons/blob/5fa7f4eb58d4deb52acab254d01f399bee5410ce/robot-server/robot_server/persistence/tables.py#L87-L97

Excluding the `sqlalchemy.PickleType` columns is particularly meaningful. In addition to avoiding unnecessary I/O, it avoids unnecessary computation to construct depickled Python objects from the binary stream.

On my robot, this speeds an uncached `GET /runs` from ~4-5 seconds to ~0.8 seconds. The speedup on other robots will depend on what runs happen to be in the robot's database and how command-heavy they are.

# Review requests

None in particular.

# Risk assessment

This should be pretty low-risk because it's is a contained implementation change, and it's covered by existing unit and integration tests.
