### PR TITLE
fix(app): remove array brackets in devices landing page jsx

### DIFF
--- a/app/src/pages/Devices/DevicesLanding/index.tsx
+++ b/app/src/pages/Devices/DevicesLanding/index.tsx
@@ -88,54 +88,44 @@ export function DevicesLanding(): JSX.Element {
         <NewRobotSetupHelp />
       </Flex>
       {isScanning && noRobots ? <DevicesLoadingState /> : null}
-      {!isScanning && noRobots ? (
-        <DevicesEmptyState />
-      ) : (
-        [
-          !noRobots ? (
-            <>
-              <CollapsibleSection
-                marginY={SPACING.spacing3}
-                title={t('available', {
-                  count: [
-                    ...healthyReachableRobots,
-                    ...unhealthyReachableRobots,
-                  ].length,
-                })}
-              >
-                {healthyReachableRobots.map(robot => (
-                  <ApiHostProvider key={robot.name} hostname={robot.ip ?? null}>
-                    <RobotCard robot={robot} />
-                  </ApiHostProvider>
-                ))}
-                {unhealthyReachableRobots.map(robot => (
-                  <ApiHostProvider key={robot.name} hostname={robot.ip ?? null}>
-                    <RobotCard robot={robot} />
-                  </ApiHostProvider>
-                ))}
-              </CollapsibleSection>
-              <Divider />
-              <CollapsibleSection
-                marginY={SPACING.spacing3}
-                title={t('unavailable', {
-                  count: [...recentlySeenRobots, ...unreachableRobots].length,
-                })}
-                isExpandedInitially={healthyReachableRobots.length === 0}
-              >
-                {recentlySeenRobots.map(robot => (
-                  <RobotCard
-                    key={robot.name}
-                    robot={{ ...robot, local: null }}
-                  />
-                ))}
-                {unreachableRobots.map(robot => (
-                  <RobotCard key={robot.name} robot={robot} />
-                ))}
-              </CollapsibleSection>
-            </>
-          ) : null,
-        ]
-      )}
+      {!isScanning && noRobots ? <DevicesEmptyState /> : null}
+      {!noRobots ? (
+        <>
+          <CollapsibleSection
+            marginY={SPACING.spacing3}
+            title={t('available', {
+              count: [...healthyReachableRobots, ...unhealthyReachableRobots]
+                .length,
+            })}
+          >
+            {healthyReachableRobots.map(robot => (
+              <ApiHostProvider key={robot.name} hostname={robot.ip ?? null}>
+                <RobotCard robot={robot} />
+              </ApiHostProvider>
+            ))}
+            {unhealthyReachableRobots.map(robot => (
+              <ApiHostProvider key={robot.name} hostname={robot.ip ?? null}>
+                <RobotCard robot={robot} />
+              </ApiHostProvider>
+            ))}
+          </CollapsibleSection>
+          <Divider />
+          <CollapsibleSection
+            marginY={SPACING.spacing3}
+            title={t('unavailable', {
+              count: [...recentlySeenRobots, ...unreachableRobots].length,
+            })}
+            isExpandedInitially={healthyReachableRobots.length === 0}
+          >
+            {recentlySeenRobots.map(robot => (
+              <RobotCard key={robot.name} robot={{ ...robot, local: null }} />
+            ))}
+            {unreachableRobots.map(robot => (
+              <RobotCard key={robot.name} robot={robot} />
+            ))}
+          </CollapsibleSection>
+        </>
+      ) : null}
     </Box>
   )
 }


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

stray array brackets in the device landing page jsx were causing a console key error. also refactors
to unnest a ternary

<img width="1284" alt="Screen Shot 2022-07-05 at 12 16 02 PM" src="https://user-images.githubusercontent.com/29845468/177376441-d6aed191-707c-4af1-9f75-f75885db7a29.png">


# Changelog

 - Removes array brackets in devices landing page jsx

# Review requests

confirm that there is no longer a console error for the devices landing page, and that the refactored ternary logic is correct

# Risk assessment

low
