### PR TITLE
refactor(robot-server): Use a custom SQLAlchemy type to preserve UTC-ness of datetimes

### DIFF
--- a/robot-server/robot_server/persistence/__init__.py
+++ b/robot-server/robot_server/persistence/__init__.py
@@ -12,7 +12,7 @@ from typing_extensions import Final
 from robot_server.app_state import AppState, AppStateAccessor, get_app_state
 from robot_server.settings import get_settings
 
-from .database import create_sql_engine, sqlite_rowid, ensure_utc_datetime
+from .database import create_sql_engine, sqlite_rowid
 from .tables import protocol_table, analysis_table, run_table, action_table
 
 _sql_engine_accessor = AppStateAccessor[sqlalchemy.engine.Engine]("sql_engine")
@@ -119,5 +119,4 @@ __all__ = [
     "action_table",
     # database utilities and helpers
     "sqlite_rowid",
-    "ensure_utc_datetime",
 ]

--- a/robot-server/robot_server/persistence/database.py
+++ b/robot-server/robot_server/persistence/database.py
@@ -1,5 +1,4 @@
 """SQLite database initialization and utilities."""
-from datetime import datetime, timezone
 from pathlib import Path
 
 import sqlalchemy
@@ -57,22 +56,3 @@ def _open_db_no_cleanup(db_file_path: Path) -> sqlalchemy.engine.Engine:
         cursor.close()
 
     return engine
-
-
-def ensure_utc_datetime(dt: object) -> datetime:
-    """Ensure an object is a TZ-aware UTC datetime.
-
-    Args:
-        dt: A UTC-coded datetime to be insterted into the database,
-            or a naive (timezone-less) datetime pulled from the database.
-
-    Returns:
-        A datetime with its timezone set to UTC.
-    """
-    assert isinstance(dt, datetime), f"{dt} is not a datetime"
-
-    if dt.tzinfo is None:
-        return dt.replace(tzinfo=timezone.utc)
-    else:
-        assert dt.tzinfo == timezone.utc, f"Expected '{dt}' to be UTC"
-        return dt

--- a/robot-server/robot_server/persistence/tables.py
+++ b/robot-server/robot_server/persistence/tables.py
@@ -1,5 +1,6 @@
 """SQLite table schemas."""
 import sqlalchemy
+from .utc_datetime import UTCDateTime
 
 _metadata = sqlalchemy.MetaData()
 
@@ -24,12 +25,9 @@ protocol_table = sqlalchemy.Table(
         sqlalchemy.String,
         primary_key=True,
     ),
-    # NOTE: This column stores naive (timezone-less) datetimes.
-    # Timezones are stripped from inserted values, due to SQLite limitations.
-    # To ensure proper functionality, all inserted datetimes must be UTC.
     sqlalchemy.Column(
         "created_at",
-        sqlalchemy.DateTime,
+        UTCDateTime,
         nullable=False,
     ),
     sqlalchemy.Column("protocol_key", sqlalchemy.String, nullable=True),
@@ -71,10 +69,9 @@ run_table = sqlalchemy.Table(
         sqlalchemy.String,
         primary_key=True,
     ),
-    # NOTE: See above note about naive datetimes
     sqlalchemy.Column(
         "created_at",
-        sqlalchemy.DateTime,
+        UTCDateTime,
         nullable=False,
     ),
     sqlalchemy.Column(
@@ -90,11 +87,7 @@ run_table = sqlalchemy.Table(
     # column added in schema v1
     sqlalchemy.Column("engine_status", sqlalchemy.String, nullable=True),
     # column added in schema v1
-    sqlalchemy.Column(
-        "_updated_at",
-        sqlalchemy.DateTime,
-        nullable=True,
-    ),
+    sqlalchemy.Column("_updated_at", UTCDateTime, nullable=True),
 )
 
 action_table = sqlalchemy.Table(
@@ -105,8 +98,7 @@ action_table = sqlalchemy.Table(
         sqlalchemy.String,
         primary_key=True,
     ),
-    # NOTE: See above note about naive datetimes
-    sqlalchemy.Column("created_at", sqlalchemy.DateTime, nullable=False),
+    sqlalchemy.Column("created_at", UTCDateTime, nullable=False),
     sqlalchemy.Column("action_type", sqlalchemy.String, nullable=False),
     sqlalchemy.Column(
         "run_id",

--- a/robot-server/robot_server/persistence/utc_datetime.py
+++ b/robot-server/robot_server/persistence/utc_datetime.py
@@ -1,0 +1,60 @@
+"""A SQL column type to store UTC datetimes."""
+
+
+from datetime import datetime, timezone
+from typing import Optional
+import sqlalchemy
+
+
+class UTCDateTime(sqlalchemy.types.TypeDecorator[datetime]):
+    """A SQL column type to store UTC datetimes.
+
+    Usage example:
+
+        table = sqlalchemy.Table(
+            ...
+            sqlalchemy.Column("my_datetime_column", UTCDateTime)
+        )
+
+    Opentrons robot-server code should always use this instead of SQLAlchemy's
+    built-in DateTime type.
+
+    Motivation:
+
+    We generally want our datetimes to have a UTC timezone so they're unambiguous.
+    Unfortunately, when we use SQLAlchemy's built-in DateTime type with SQLite,
+    the timezone gets stripped upon insertion, and subsequent reads return a naive
+    (timezone-less) datetime.
+
+    Using this type instead preserves the UTC-ness of the timestamp.
+
+    * When a Python datetime object gets inserted into SQL:
+
+      This asserts that the Python object has its timezone set to UTC.
+      Then stores the timestamp into SQL without any explicit timezone.
+      This matches how we were storing them before.
+
+    * When a datetime is extracted from SQL:
+
+      This returns it as a Python datetime object that's marked with the UTC timezone.
+    """
+
+    impl = sqlalchemy.types.DateTime
+    cache_ok = True
+
+    def process_bind_param(
+        self, value: Optional[datetime], dialect: object
+    ) -> Optional[datetime]:
+        """Prepare a Python datetime object to inserted into SQL via SQLAlchemy."""
+        if value is not None:
+            assert value.tzinfo == timezone.utc, f"Expected '{value}' to be UTC"
+        return value
+
+    def process_result_value(
+        self, value: Optional[datetime], dialect: object
+    ) -> Optional[datetime]:
+        """Process a Python datetime object that SQLAlchemy just extracted from SQL."""
+        if value is not None:
+            assert value.tzinfo is None
+            return value.replace(tzinfo=timezone.utc)
+        return None

--- a/robot-server/robot_server/protocols/protocol_store.py
+++ b/robot-server/robot_server/protocols/protocol_store.py
@@ -17,7 +17,6 @@ from robot_server.persistence import (
     protocol_table,
     run_table,
     sqlite_rowid,
-    ensure_utc_datetime,
 )
 
 
@@ -440,7 +439,7 @@ def _convert_sql_row_to_dataclass(
 ) -> _DBProtocolResource:
     protocol_id = sql_row.id
     protocol_key = sql_row.protocol_key
-    created_at = ensure_utc_datetime(sql_row.created_at)
+    created_at = sql_row.created_at
 
     assert isinstance(protocol_id, str), f"Protocol ID {protocol_id} not a string"
     assert protocol_key is None or isinstance(
@@ -459,6 +458,6 @@ def _convert_dataclass_to_sql_values(
 ) -> Dict[str, object]:
     return {
         "id": resource.protocol_id,
-        "created_at": ensure_utc_datetime(resource.created_at),
+        "created_at": resource.created_at,
         "protocol_key": resource.protocol_key,
     }

--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -12,7 +12,7 @@ from opentrons.util.helpers import utc_now
 from opentrons.protocol_engine import StateSummary, CommandSlice
 from opentrons.protocol_engine.commands import Command
 
-from robot_server.persistence import run_table, action_table, ensure_utc_datetime
+from robot_server.persistence import run_table, action_table
 from robot_server.protocols import ProtocolNotFoundError
 
 from .action_models import RunAction, RunActionType
@@ -385,7 +385,7 @@ def _convert_row_to_run(
 ) -> RunResource:
     run_id = row.id
     protocol_id = row.protocol_id
-    created_at = ensure_utc_datetime(row.created_at)
+    created_at = row.created_at
 
     assert isinstance(run_id, str), f"Run ID {run_id} is not a string"
     assert protocol_id is None or isinstance(
@@ -399,7 +399,7 @@ def _convert_row_to_run(
         actions=[
             RunAction(
                 id=action_row.id,
-                createdAt=ensure_utc_datetime(action_row.created_at),
+                createdAt=action_row.created_at,
                 actionType=RunActionType(action_row.action_type),
             )
             for action_row in action_rows
@@ -410,7 +410,7 @@ def _convert_row_to_run(
 def _convert_run_to_sql_values(run: RunResource) -> Dict[str, object]:
     return {
         "id": run.run_id,
-        "created_at": ensure_utc_datetime(run.created_at),
+        "created_at": run.created_at,
         "protocol_id": run.protocol_id,
     }
 
@@ -418,7 +418,7 @@ def _convert_run_to_sql_values(run: RunResource) -> Dict[str, object]:
 def _convert_action_to_sql_values(action: RunAction, run_id: str) -> Dict[str, object]:
     return {
         "id": action.id,
-        "created_at": ensure_utc_datetime(action.createdAt),
+        "created_at": action.createdAt,
         "action_type": action.actionType.value,
         "run_id": run_id,
     }

--- a/robot-server/tests/protocols/test_analysis_store.py
+++ b/robot-server/tests/protocols/test_analysis_store.py
@@ -1,7 +1,7 @@
 """Tests for the AnalysisStore interface."""
 import pytest
 
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, NamedTuple
 
@@ -60,7 +60,7 @@ def make_dummy_protocol_resource(protocol_id: str) -> ProtocolResource:
     """
     return ProtocolResource(
         protocol_id=protocol_id,
-        created_at=datetime(year=2021, month=1, day=1),
+        created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
         source=ProtocolSource(
             directory=Path("/dev/null"),
             main_file=Path("/dev/null"),
@@ -213,7 +213,7 @@ analysis_result_specs: List[AnalysisResultSpec] = [
                 id="pause-1",
                 key="command-key",
                 status=pe_commands.CommandStatus.SUCCEEDED,
-                createdAt=datetime(year=2021, month=1, day=1),
+                createdAt=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
                 params=pe_commands.WaitForResumeParams(message="hello world"),
                 result=pe_commands.WaitForResumeResult(),
             )
@@ -226,7 +226,7 @@ analysis_result_specs: List[AnalysisResultSpec] = [
         errors=[
             pe_errors.ErrorOccurrence(
                 id="error-id",
-                createdAt=datetime(year=2021, month=1, day=1),
+                createdAt=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
                 errorType="BadError",
                 detail="oh no",
             )


### PR DESCRIPTION
# Overview

This refactors how robot-server stores `datetime`s in its SQL database.

Because of a SQLAlchemy+SQLite trap, we need to be careful when we store `datetime`s, or we can accidentally erase their timezones. This has caused user-facing bugs related to time sorting. See PR #10053 for historical background.

This iterates on PR #10053 to hopefully make it a little harder for us to get this wrong.

# Changelog

* Formerly, every place that accessed a `datetime` column was responsible for calling `ensure_utc_datetime()` to fix up the `datetime`. This PR uses [a custom SQLAlchemy type](https://docs.sqlalchemy.org/en/14/core/custom_types.html#augmenting-existing-types) to move the fixup code into the SQLAlchemy column itself. This way, we only have to remember to declare the table correctly, instead of remembering to always access it correctly.
* Made the preconditions stricter.
    * Before, when *reading* a `datetime` from the database, we supported SQLAlchemy giving us either a `datetime` with `.tzinfo == None` *or* `.tzinfo == timezone.utc`. Now, we enforce that it has `.tzinfo == None`,  to match what it always is in practice.
    * Before, when *inserting* a `datetime` into the database, it could have either `.tzinfo == None` *or* `.tzinfo == timezone.utc`. Now, we enforce that it has `.tzinfo == timezone.utc`, matching what it always is in practice.
    * These changes are intended to make it easier to understand what kinds of datetimes we have floating around in the various layers.

# Review requests

* Do we think the added strictness, described above, is a good idea? I'm on the fence about it.
* Is the name `UTCDateTime` good?
* Does `UTCDateTime`'s docstring look good? I had trouble explaining it succinctly and clearly.

# Risk assessment


The added strictness can break something if there is any code in `robot-server` that creates a `datetime` without `tzinfo=timezone.utc` and then tries to store it in the database. After a brief audit of the places where we do `datetime.now()`, I think we're okay—and even if there were a bug, I would expect one of the persistence integration tests to catch the problem.