### PR TITLE
fix(app): fix labware info overlay styling with vector

### DIFF
--- a/app/src/molecules/OffsetVector/index.tsx
+++ b/app/src/molecules/OffsetVector/index.tsx
@@ -14,18 +14,24 @@ export function OffsetVector(props: OffsetVectorProps): JSX.Element {
   const { x, y, z, ...styleProps } = props
   return (
     <Flex {...styleProps}>
-      <StyledText as={'strong'} marginRight={SPACING.spacing2}>
+      <StyledText as={'h6'} marginRight={SPACING.spacing2}>
         X
       </StyledText>
-      <StyledText marginRight={SPACING.spacing3}>{x.toFixed(2)}</StyledText>
-      <StyledText as={'strong'} marginRight={SPACING.spacing2}>
+      <StyledText as={'h6'} marginRight={SPACING.spacing3}>
+        {x.toFixed(2)}
+      </StyledText>
+      <StyledText as={'h6'} marginRight={SPACING.spacing2}>
         Y
       </StyledText>
-      <StyledText marginRight={SPACING.spacing3}>{y.toFixed(2)}</StyledText>
-      <StyledText as={'strong'} marginRight={SPACING.spacing2}>
+      <StyledText as={'h6'} marginRight={SPACING.spacing3}>
+        {y.toFixed(2)}
+      </StyledText>
+      <StyledText as={'h6'} marginRight={SPACING.spacing2}>
         Z
       </StyledText>
-      <StyledText marginRight={SPACING.spacing3}>{z.toFixed(2)}</StyledText>
+      <StyledText as={'h6'} marginRight={SPACING.spacing3}>
+        {z.toFixed(2)}
+      </StyledText>
     </Flex>
   )
 }

--- a/app/src/organisms/Devices/ProtocolRun/LabwareInfoOverlay.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/LabwareInfoOverlay.tsx
@@ -9,7 +9,7 @@ import {
   SPACING,
   COLORS,
   TYPOGRAPHY,
-  OVERLAY_BLACK_70,
+  OVERLAY_BLACK_80,
   DISPLAY_FLEX,
   DIRECTION_COLUMN,
   JUSTIFY_FLEX_END,
@@ -37,7 +37,7 @@ const labwareDisplayNameStyle = css`
   white-space: initial;
   text-overflow: ellipsis;
   display: -webkit-box;
-  -webkit-line-clamp: 3;
+  -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
 `
 const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
@@ -47,7 +47,7 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
 
   return (
     <Box
-      backgroundColor={hover ? COLORS.blue : OVERLAY_BLACK_70}
+      backgroundColor={hover ? COLORS.blue : OVERLAY_BLACK_80}
       borderRadius={`0 0 0.4rem 0.4rem`}
       fontSize={FONT_SIZE_CAPTION}
       padding={SPACING.spacing2}

--- a/app/src/organisms/Devices/ProtocolRun/LabwareInfoOverlay.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/LabwareInfoOverlay.tsx
@@ -3,6 +3,7 @@ import { css } from 'styled-components'
 import { useTranslation } from 'react-i18next'
 import { getLabwareDisplayName } from '@opentrons/shared-data'
 import {
+  Box,
   Flex,
   RobotCoordsForeignDiv,
   SPACING,
@@ -45,19 +46,20 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
   const vector = useLabwareOffsetForLabware(runId, labwareId)?.vector
 
   return (
-    <Flex
+    <Box
       backgroundColor={hover ? COLORS.blue : OVERLAY_BLACK_70}
       borderRadius={`0 0 0.4rem 0.4rem`}
       fontSize={FONT_SIZE_CAPTION}
       padding={SPACING.spacing2}
       color={COLORS.white}
       id={`LabwareInfoOverlay_slot_${labwareId}_offsetBox`}
-      flexDirection={DIRECTION_ROW}
-      justifyContent={JUSTIFY_FLEX_END}
-      alignItems={ALIGN_FLEX_START}
-      gridGap={SPACING.spacing2}
     >
-      <>
+      <Flex
+        flexDirection={DIRECTION_ROW}
+        justifyContent={JUSTIFY_FLEX_END}
+        alignItems={ALIGN_FLEX_START}
+        gridGap={SPACING.spacing2}
+      >
         <StyledText
           as="h6"
           lineHeight={TYPOGRAPHY.fontSizeCaption}
@@ -66,23 +68,29 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
         >
           {displayName ?? definitionDisplayName}
         </StyledText>
-        {vector != null && (
-          <>
-            <StyledText
-              as="label"
-              fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-              textTransform={'uppercase'}
-            >
-              {t('offset_data')}
-            </StyledText>
-            <OffsetVector {...vector} />
-          </>
+        {props.labwareHasLiquid && (
+          <Icon
+            name="water"
+            color={COLORS.white}
+            width={'0'}
+            minWidth={'1rem'}
+          />
         )}
-      </>
-      {props.labwareHasLiquid && (
-        <Icon name="water" color={COLORS.white} width={'0'} minWidth={'1rem'} />
+      </Flex>
+      {vector != null && (
+        <>
+          <StyledText
+            as="h6"
+            lineHeight={TYPOGRAPHY.fontSizeCaption}
+            fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+            textTransform={'uppercase'}
+          >
+            {t('offset_data')}
+          </StyledText>
+          <OffsetVector {...vector} />
+        </>
       )}
-    </Flex>
+    </Box>
   )
 }
 

--- a/components/src/styles/colors.ts
+++ b/components/src/styles/colors.ts
@@ -48,8 +48,8 @@ export const OVERLAY_GRAY_90 = 'rgba(127, 127, 127, 0.9)'
 // darkest modal overlay used
 export const OVERLAY_BLACK_90 = 'rgba(0, 0, 0, 0.9)'
 
-// 70 percent opacity overlay
-export const OVERLAY_BLACK_70 = 'rgba(0, 0, 0, 0.7)'
+// 80 percent opacity overlay
+export const OVERLAY_BLACK_80 = 'rgba(0, 0, 0, 0.8)'
 
 // opacities
 export const OPACITY_DISABLED = 0.3


### PR DESCRIPTION
fix #10942

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
Fix display of labware name when vectors are shown
![Screen Shot 2022-07-05 at 3 54 16 PM](https://user-images.githubusercontent.com/14302493/177407097-1cb230a7-6f47-4166-9dcb-bbf6aeb60a89.png)
![Screen Shot 2022-07-05 at 3 54 09 PM](https://user-images.githubusercontent.com/14302493/177407101-961fcdf2-082d-4128-a738-1a75a3762e35.png)
![Screen Shot 2022-07-05 at 3 51 10 PM](https://user-images.githubusercontent.com/14302493/177407103-bb163139-1803-4091-b79f-50143011273b.png)

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
Update styling of vectors to match new text size
Take vector info out of flex

# Review requests

<!--
Describe any requests for your reviewers here.
-->
Verify this looks as expected 

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
