### PR TITLE
refactor(api,hardware): remove setuprequest

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -56,7 +56,6 @@ from opentrons_hardware.firmware_bindings.constants import (
     PipetteName as FirmwarePipetteName,
 )
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
-    SetupRequest,
     EnableMotorRequest,
 )
 from opentrons_hardware import firmware_update
@@ -166,10 +165,6 @@ class OT3Controller:
 
     async def setup_motors(self) -> None:
         """Set up the motors."""
-        await self._messenger.send(
-            node_id=NodeId.broadcast,
-            message=SetupRequest(),
-        )
         await self._messenger.send(
             node_id=NodeId.broadcast,
             message=EnableMotorRequest(),

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -71,8 +71,6 @@ class MessageId(int, Enum):
 
     move_request = 0x10
 
-    setup_request = 0x02
-
     write_eeprom = 0x201
     read_eeprom_request = 0x202
     read_eeprom_response = 0x203

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -93,11 +93,6 @@ class MoveRequest:  # noqa: D101
 
 
 @dataclass
-class SetupRequest(EmptyPayloadMessage):  # noqa: D101
-    message_id: Literal[MessageId.setup_request] = MessageId.setup_request
-
-
-@dataclass
 class WriteToEEPromRequest:  # noqa: D101
     payload: payloads.EEPromDataPayload
     payload_type: Type[payloads.EEPromDataPayload] = payloads.EEPromDataPayload

--- a/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
@@ -20,7 +20,6 @@ MessageDefinition = Union[
     defs.EnableMotorRequest,
     defs.DisableMotorRequest,
     defs.MoveRequest,
-    defs.SetupRequest,
     defs.WriteToEEPromRequest,
     defs.ReadFromEEPromRequest,
     defs.ReadFromEEPromResponse,

--- a/hardware/opentrons_hardware/scripts/gripper.py
+++ b/hardware/opentrons_hardware/scripts/gripper.py
@@ -10,7 +10,6 @@ from logging.config import dictConfig
 from opentrons_hardware.drivers.can_bus import build
 from opentrons_hardware.firmware_bindings.messages import payloads
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
-    SetupRequest,
     DisableMotorRequest,
     ExecuteMoveGroupRequest,
 )
@@ -91,7 +90,6 @@ async def run_test(messenger: CanMessenger) -> None:
 
     """Setup gripper"""
     try:
-        await messenger.send(node_id=NodeId.gripper, message=SetupRequest())
         await set_pwm_param(messenger, pwm_freq, pwm_duty)
 
         for i, v in enumerate(vref_list):

--- a/hardware/opentrons_hardware/scripts/gripper_currents.py
+++ b/hardware/opentrons_hardware/scripts/gripper_currents.py
@@ -9,7 +9,6 @@ from logging.config import dictConfig
 
 from opentrons_hardware.drivers.can_bus import build
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
-    SetupRequest,
     DisableMotorRequest,
     ExecuteMoveGroupRequest,
 )
@@ -84,7 +83,6 @@ async def run_test(messenger: CanMessenger) -> None:
     pwm_freq = prompt_int_input("Set PWM frequency in Hz (int, \033[96m32000Hz\033[0m)")
 
     try:
-        await messenger.send(node_id=NodeId.gripper, message=SetupRequest())
         await set_reference_voltage(messenger, v_ref)
 
         while True:

--- a/hardware/opentrons_hardware/scripts/gripper_lifetime.py
+++ b/hardware/opentrons_hardware/scripts/gripper_lifetime.py
@@ -9,7 +9,6 @@ from typing import Callable
 from logging.config import dictConfig
 
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
-    SetupRequest,
     EnableMotorRequest,
 )
 from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
@@ -92,7 +91,6 @@ async def run(args: argparse.Namespace) -> None:
     messenger = CanMessenger(driver=driver)
     messenger.start()
     await set_reference_voltage(messenger, vref)
-    await messenger.send(node_id=NodeId.gripper_g, message=SetupRequest())
     await messenger.send(node_id=NodeId.gripper_g, message=EnableMotorRequest())
 
     move_groups: MoveGroups = []

--- a/hardware/opentrons_hardware/scripts/high_throughput_tip_handling.py
+++ b/hardware/opentrons_hardware/scripts/high_throughput_tip_handling.py
@@ -8,7 +8,6 @@ from typing import Callable
 from logging.config import dictConfig
 
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
-    SetupRequest,
     EnableMotorRequest,
 )
 from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
@@ -69,7 +68,6 @@ async def run(args: argparse.Namespace) -> None:
 
     messenger = CanMessenger(driver=driver)
     messenger.start()
-    await messenger.send(node_id=NodeId.broadcast, message=SetupRequest())
     await messenger.send(node_id=NodeId.broadcast, message=EnableMotorRequest())
 
     pick_up_tip_runner = MoveGroupRunner(

--- a/hardware/opentrons_hardware/scripts/move.py
+++ b/hardware/opentrons_hardware/scripts/move.py
@@ -9,7 +9,6 @@ from opentrons_hardware.drivers.can_bus import build, CanMessenger
 from opentrons_hardware.firmware_bindings.constants import NodeId
 
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
-    SetupRequest,
     EnableMotorRequest,
 )
 from opentrons_hardware.hardware_control.motion import (
@@ -47,7 +46,6 @@ LOG_CONFIG = {
 
 async def run_move(messenger: CanMessenger) -> None:
     """Run the move."""
-    await messenger.send(node_id=NodeId.broadcast, message=SetupRequest())
     await messenger.send(node_id=NodeId.broadcast, message=EnableMotorRequest())
 
     # TODO (al, 2021-11-11): Allow creating groups from command line or config file.

--- a/hardware/opentrons_hardware/scripts/sensor_pass.py
+++ b/hardware/opentrons_hardware/scripts/sensor_pass.py
@@ -102,9 +102,6 @@ async def run_test(messenger: CanMessenger, args: argparse.Namespace) -> None:
         raise RuntimeError(f"could not find targets for {args.mount} in {found}")
 
     await messenger.send(
-        node_id=NodeId.broadcast, message=message_definitions.SetupRequest()
-    )
-    await messenger.send(
         node_id=NodeId.broadcast, message=message_definitions.EnableMotorRequest()
     )
 


### PR DESCRIPTION
This was a request that commanded all the nodes to do some built-in
setup. Instead, all the nodes can just do it themselves when they boot
up, and it's not possible to forget to send the message anymore.
