### PR TITLE
refactor(api): ot3: remove broadcast motor enable

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -163,13 +163,6 @@ class OT3Controller:
             hold_currents[axis] = settings.hold_current
         return hold_currents
 
-    async def setup_motors(self) -> None:
-        """Set up the motors."""
-        await self._messenger.send(
-            node_id=NodeId.broadcast,
-            message=EnableMotorRequest(),
-        )
-
     @property
     def gpio_chardev(self) -> OT3GPIO:
         """Get the GPIO device."""

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -55,9 +55,6 @@ from opentrons_hardware.firmware_bindings.constants import (
     NodeId,
     PipetteName as FirmwarePipetteName,
 )
-from opentrons_hardware.firmware_bindings.messages.message_definitions import (
-    EnableMotorRequest,
-)
 from opentrons_hardware import firmware_update
 
 from opentrons.hardware_control.module_control import AttachedModulesControl

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -236,7 +236,6 @@ class OT3API(
         else:
             checked_config = config
         backend = await OT3Controller.build(checked_config)
-        await backend.setup_motors()
         api_instance = cls(backend, loop=checked_loop, config=checked_config)
         await api_instance.cache_instruments()
         module_controls = await AttachedModulesControl.build(


### PR DESCRIPTION
This isn't necessary because the motors now enable themselves when they
begin to move. That makes the enable_motors call useful only for telling
motors to actively hold their position, not a requirement before
anything can happen.

Since moves send commands to all motors for sequencing purposes, all the motors will get engaged.