### PR TITLE
fix(robot-server): more gracefully degrade if protocol file storage corrupt

### DIFF
--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -401,6 +401,9 @@ class HeaterShaker(mod_abc.AbstractModule):
         To set speed, use start_set_speed. To set temperature,
         use start_set_temperature.
         """
+        # TODO(mc, 2022-07-06): may raise an `ExceptionGroup`
+        # which is an instance of BaseException, not Exception,
+        # and may evade our normal try/except blocks
         async with create_task_group() as tg:  # Does task cleanup
             tg.start_soon(self.await_speed, speed)
             tg.start_soon(self.await_temperature, temperature)

--- a/api/tests/opentrons/protocol_reader/test_file_reader_writer.py
+++ b/api/tests/opentrons/protocol_reader/test_file_reader_writer.py
@@ -123,6 +123,27 @@ async def test_read_opentrons_json_bad_validate() -> None:
         await subject.read([in_file])
 
 
+async def test_read_os_error(tmp_path: Path) -> None:
+    """It should raise an error if multiple file cannot be read."""
+    path_1 = tmp_path / "i_do_not_exist.txt"
+
+    subject = FileReaderWriter()
+
+    with pytest.raises(FileReadError, match='Could not find "i_do_not_exist.txt"'):
+        await subject.read([path_1])
+
+
+async def test_read_multiple_os_error(tmp_path: Path) -> None:
+    """It should raise an error if multiple file cannot be read."""
+    path_1 = tmp_path / "i_do_not_exist.txt"
+    path_2 = tmp_path / "neither_do_i.txt"
+
+    subject = FileReaderWriter()
+
+    with pytest.raises(FileReadError, match="Could not read files"):
+        await subject.read([path_1, path_2])
+
+
 async def test_write(tmp_path: Path) -> None:
     """It should write buffered files to disk."""
     directory = tmp_path / "target"


### PR DESCRIPTION
## Overview

This PR ensures the robot-server's ProtocolStore will somewhat gracefully degrade (while complaining loudly in the logs) if the device's internal protocol file storage becomes corrupted. Spiritual sibling PR to #10969.

This PR is not my finest work, but should hold up enough for the 6.0.0 given the edge-case nature of the bug in question.

## Changelog

This PR implements a behavior spec in a TODO comment in the `ProtocolStore`. If a protocol's file(s) cannot be read during store rehydration:

- Omit the protocol from `GET /protocols` responses
- Respond with an error from `GET /protocols/:protocol_id`
    - I left this as a `500`

Prior to this PR, if the robot's protocol file storage becomes corrupted, the client could experience threeish different problems, depending on the nature of the corruption:

- A single protocol's files become corrupted or unreadable:
    - All `/protocols` endpoints and `POST /runs` will `500`
    - One file is corrupt:
        - The 500 response is JSON, describing why the file couldn't be read
    - Multiple files are corrupt:
        - The 500 response is the plain text "Internal Server Error" 
- Multiple protocols' files become corrupted or unreadable: 
    - All `/protocols` endpoints and `POST /runs` will `500`
    - The 500 responses is the plain text "Internal Server Error" 

The cause of plain text "Internal Server Error" responses was the fact that [anyio.ExceptionGroup](https://anyio.readthedocs.io/en/stable/api.html#anyio.ExceptionGroup) is a `BaseException`, not an `Exception`. Various bits of protocol reading and `ProtocolStore` rehydration use `anyio` for concurrency, so if something went wrong in the wrong it, a raised `ExceptionGroup` would bypasses all of our (and Starlette's) exception handlers and thoroughly break the application.

Moving on from there to "why were we getting 500s at all?", a failed protocol file read during `ProtocolStore` rehydration would error out and cancel _all_ protocol file reads instead of containing the damage to the specific protocol(s) that had the problem file(s).

This PR guards and removes calls to `anyio.create_task_group` to catch `ExceptionGroups` and re-raise as something we can deal with, and throws in a very dirty patch to `ProtocolStore` to contain rehydration problems to the protocols in question, allowing the robot to continue operating.

## Review requests

This PR, as well as ProtocolStore rehydration in general, is not well unit tested. Changed need high scrutiny. I could definitely use testing feedback.

Thankfully enough, the issue is easily testable and reproducible on a dev server with persistence turned on:

```shell
make -C robot-server dev OT_ROBOT_SERVER_persistence_directory=path/to/opentrons_robot_server
```

You can add bad files (for example, completely empty `json` files) into protocol directories to trigger the `500` responses on `release_6.0.0` and hopefully not encounter error responses on this branch.
## Risk assessment

High, makes rushed changes to the robot's protocol persistence layer very close to a release.
