### PR TITLE
refactor(protocol-designer): use updated HS labware names in labware filters

### DIFF
--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
@@ -76,10 +76,10 @@ const RECOMMENDED_LABWARE_BY_MODULE: { [K in ModuleType]: string[] } = {
   [MAGNETIC_MODULE_TYPE]: ['nest_96_wellplate_100ul_pcr_full_skirt'],
   [THERMOCYCLER_MODULE_TYPE]: ['nest_96_wellplate_100ul_pcr_full_skirt'],
   [HEATERSHAKER_MODULE_TYPE]: [
-    'opentrons_96_deepwell_adapter_nest_wellplate_2ml_deep',
+    'opentrons_96_deep_well_adapter_nest_wellplate_2ml_deep',
     'opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat',
-    'opentrons_96_pcr_plate_adapter_nest_wellplate_100ul_pcr_full_skirt',
-    'opentrons_flat_plate_adapter_corning_384_wellplate_112ul_flat',
+    'opentrons_96_pcr_adapter_nest_wellplate_100ul_pcr_full_skirt',
+    'opentrons_universal_flat_adapter_corning_384_wellplate_112ul_flat',
   ],
 }
 

--- a/protocol-designer/src/utils/labwareModuleCompatibility.ts
+++ b/protocol-designer/src/utils/labwareModuleCompatibility.ts
@@ -52,10 +52,10 @@ const COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE: Record<
     'nest_96_wellplate_100ul_pcr_full_skirt',
   ],
   [HEATERSHAKER_MODULE_TYPE]: [
-    'opentrons_96_deepwell_adapter_nest_wellplate_2ml_deep',
+    'opentrons_96_deep_well_adapter_nest_wellplate_2ml_deep',
     'opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat',
-    'opentrons_96_pcr_plate_adapter_nest_wellplate_100ul_pcr_full_skirt',
-    'opentrons_flat_plate_adapter_corning_384_wellplate_112ul_flat',
+    'opentrons_96_pcr_adapter_nest_wellplate_100ul_pcr_full_skirt',
+    'opentrons_universal_flat_adapter_corning_384_wellplate_112ul_flat',
   ],
 }
 export const getLabwareIsCompatible = (


### PR DESCRIPTION
# Overview

As part of https://github.com/Opentrons/opentrons/pull/10964 HS labware load names were modified. This follows up that PR by using these updated load names in our recommended/compatible labware filters. 


# Review requests

Open this branch build of PD, add a HS to a protocol, and add labware on top of it. You should see 4 labware in the dropdown (before only 1 showed up since we changed 3 of the load names). 

# Risk assessment

Low