### PR TITLE
fix(papi-v2): allow pick_up_tip to pick up from exact location 

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -23,8 +23,7 @@ from opentrons.protocols.api_support.util import (
 from opentrons.protocols.context.instrument import AbstractInstrument
 from opentrons.protocols.api_support.types import APIVersion
 
-# from .labware import Labware, OutOfTipsError, Well
-from opentrons.protocol_api import labware
+from . import labware
 from opentrons.protocols.advanced_control import transfers
 
 if TYPE_CHECKING:

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -695,7 +695,6 @@ class InstrumentContext(publisher.CommandPublisher):
             tiprack = location.parent
             target = location
             move_to_location = target.top()
-            print(target)
         elif not location:
             tiprack, target = labware.next_available_tip(
                 self.starting_tip, self.tip_racks, self.channels

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -7,7 +7,8 @@ from opentrons.broker import Broker
 from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons import types, hardware_control as hc
 from opentrons.commands import commands as cmds
-from opentrons.commands.publisher import CommandPublisher, publish, publish_context
+from opentrons.commands.publisher import CommandPublisher, publish
+from opentrons.commands import publisher
 from opentrons.protocols.advanced_control.mix import mix_from_kwargs
 from opentrons.protocols.api_support.instrument import (
     validate_blowout_location,
@@ -223,7 +224,7 @@ class InstrumentContext(CommandPublisher):
 
         c_vol = self._implementation.get_available_volume() if not volume else volume
 
-        with publish_context(
+        with publisher.publish_context(
             broker=self.broker,
             command=cmds.aspirate(
                 instrument=self,
@@ -317,7 +318,7 @@ class InstrumentContext(CommandPublisher):
 
         c_vol = self.current_volume if not volume else volume
 
-        with publish_context(
+        with publisher.publish_context(
             broker=self.broker,
             command=cmds.dispense(
                 instrument=self,
@@ -384,7 +385,7 @@ class InstrumentContext(CommandPublisher):
 
         c_vol = self._implementation.get_available_volume() if not volume else volume
 
-        with publish_context(
+        with publisher.publish_context(
             broker=self.broker,
             command=cmds.mix(
                 instrument=self,
@@ -455,7 +456,7 @@ class InstrumentContext(CommandPublisher):
                 "knows where it is."
             )
 
-        with publish_context(
+        with publisher.publish_context(
             broker=self.broker,
             command=cmds.blow_out(
                 instrument=self,
@@ -711,11 +712,11 @@ class InstrumentContext(CommandPublisher):
 
         assert tiprack.is_tiprack, "{} is not a tiprack".format(str(tiprack))
         instrument.validate_tiprack(self.name, tiprack, logger)
-
-        with publish_context(
+        with publisher.publish_context(
             broker=self.broker,
             command=cmds.pick_up_tip(instrument=self, location=target),
         ):
+            print("in publisher")
             self.move_to(target.top(), publish=False)
             self._implementation.pick_up_tip(
                 well=target._impl,
@@ -834,7 +835,7 @@ class InstrumentContext(CommandPublisher):
                 " However, it is a {}".format(location)
             )
 
-        with publish_context(
+        with publisher.publish_context(
             broker=self.broker,
             command=cmds.drop_tip(instrument=self, location=target),
         ):
@@ -869,7 +870,7 @@ class InstrumentContext(CommandPublisher):
 
         mount_name = self._implementation.get_mount().name.lower()
 
-        with publish_context(broker=self.broker, command=cmds.home(mount_name)):
+        with publisher.publish_context(broker=self.broker, command=cmds.home(mount_name)):
             self._implementation.home()
 
         return self
@@ -1206,7 +1207,7 @@ class InstrumentContext(CommandPublisher):
         publish_ctx = nullcontext()
 
         if publish:
-            publish_ctx = publish_context(
+            publish_ctx = publisher.publish_context(
                 broker=self.broker,
                 command=cmds.move_to(
                     instrument=self,

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -22,7 +22,8 @@ from opentrons.protocols.api_support.util import (
 )
 from opentrons.protocols.context.instrument import AbstractInstrument
 from opentrons.protocols.api_support.types import APIVersion
-from .labware import Labware, OutOfTipsError, Well, next_available_tip
+from .labware import Labware, OutOfTipsError, Well
+from opentrons.protocol_api import labware
 from opentrons.protocols.advanced_control import transfers
 
 if TYPE_CHECKING:
@@ -694,8 +695,9 @@ class InstrumentContext(publisher.CommandPublisher):
             tiprack = location.parent
             target = location
             move_to_location = target.top()
+            print(target)
         elif not location:
-            tiprack, target = next_available_tip(
+            tiprack, target = labware.next_available_tip(
                 self.starting_tip, self.tip_racks, self.channels
             )
             move_to_location = target.top()
@@ -1093,7 +1095,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 blow_out_strategy = transfers.BlowOutStrategy.TRASH
 
         if new_tip != types.TransferTipPolicy.NEVER:
-            tr, next_tip = next_available_tip(
+            tr, next_tip = labware.next_available_tip(
                 self.starting_tip, self.tip_racks, self.channels
             )
             max_volume = min(next_tip.max_volume, self.max_volume)

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -715,7 +715,7 @@ class InstrumentContext(CommandPublisher):
             broker=self.broker,
             command=cmds.pick_up_tip(instrument=self, location=target),
         ):
-            self.move_to(target.top(), publish=False)
+            self.move_to(target, publish=False)
             self._implementation.pick_up_tip(
                 well=target._impl,
                 tip_length=self._tip_length_for(tiprack),
@@ -1214,7 +1214,6 @@ class InstrumentContext(CommandPublisher):
                     location=location or self._ctx.location_cache,  # type: ignore[arg-type]
                 ),
             )
-
         with publish_ctx:
             self._implementation.move_to(
                 location=location,

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -12,7 +12,6 @@ from opentrons.commands import publisher
 from opentrons.protocols.advanced_control.mix import mix_from_kwargs
 from opentrons.protocols.api_support.instrument import (
     validate_blowout_location,
-    tip_length_for,
     determine_drop_target,
     validate_can_aspirate,
     validate_can_dispense,
@@ -716,7 +715,6 @@ class InstrumentContext(CommandPublisher):
             broker=self.broker,
             command=cmds.pick_up_tip(instrument=self, location=target),
         ):
-            print("in publisher")
             self.move_to(target.top(), publish=False)
             self._implementation.pick_up_tip(
                 well=target._impl,
@@ -1443,4 +1441,4 @@ class InstrumentContext(CommandPublisher):
 
     def _tip_length_for(self, tiprack: Labware) -> float:
         """Get the tip length, including overlap, for a tip from this rack"""
-        return tip_length_for(self.hw_pipette, tiprack)
+        return instrument.tip_length_for(self.hw_pipette, tiprack)

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -870,7 +870,9 @@ class InstrumentContext(CommandPublisher):
 
         mount_name = self._implementation.get_mount().name.lower()
 
-        with publisher.publish_context(broker=self.broker, command=cmds.home(mount_name)):
+        with publisher.publish_context(
+            broker=self.broker, command=cmds.home(mount_name)
+        ):
             self._implementation.home()
 
         return self

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -12,11 +12,11 @@ from opentrons.protocols.advanced_control.mix import mix_from_kwargs
 from opentrons.protocols.api_support.instrument import (
     validate_blowout_location,
     tip_length_for,
-    validate_tiprack,
     determine_drop_target,
     validate_can_aspirate,
     validate_can_dispense,
 )
+from opentrons.protocols.api_support import instrument
 from opentrons.protocols.api_support.labware_like import LabwareLike
 from opentrons.protocol_api.module_contexts import ThermocyclerContext
 from opentrons.protocols.api_support.util import (
@@ -80,7 +80,7 @@ class InstrumentContext(CommandPublisher):
         self._tip_racks = tip_racks or list()
         for tip_rack in self.tip_racks:
             assert tip_rack.is_tiprack
-            validate_tiprack(self.name, tip_rack, logger)
+            instrument.validate_tiprack(self.name, tip_rack, logger)
         if trash is None:
             self.trash_container = self._ctx.fixed_trash
         else:
@@ -710,7 +710,7 @@ class InstrumentContext(CommandPublisher):
             )
 
         assert tiprack.is_tiprack, "{} is not a tiprack".format(str(tiprack))
-        validate_tiprack(self.name, tiprack, logger)
+        instrument.validate_tiprack(self.name, tiprack, logger)
 
         with publish_context(
             broker=self.broker,

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -8,16 +8,8 @@ from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons import types, hardware_control as hc
 from opentrons.commands import commands as cmds
 
-# from opentrons.commands.publisher import CommandPublisher, publish
 from opentrons.commands import publisher
 from opentrons.protocols.advanced_control.mix import mix_from_kwargs
-
-# from opentrons.protocols.api_support.instrument import (
-#     validate_blowout_location,
-#     determine_drop_target,
-#     validate_can_aspirate,
-#     validate_can_dispense,
-# )
 from opentrons.protocols.api_support import instrument
 from opentrons.protocols.api_support.labware_like import LabwareLike
 from opentrons.protocol_api.module_contexts import ThermocyclerContext

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -683,10 +683,11 @@ class InstrumentContext(publisher.CommandPublisher):
         if location and isinstance(location, types.Location):
             if location.labware.is_labware:
                 tiprack = location.labware.as_labware()
-                target_well: labware.Well = tiprack.next_tip(self.channels)  # type: ignore
-                move_to_location = target_well.top()
-                if not target_well:
+                next_tip = tiprack.next_tip(self.channels)
+                if not next_tip:
                     raise labware.OutOfTipsError
+                target_well = next_tip
+                move_to_location = target_well.top()
             elif location.labware.is_well:
                 target_well = location.labware.as_well()
                 tiprack = target_well.parent

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -221,7 +221,6 @@ def test_pick_up_from_well(
 ) -> None:
     """Should pick up tip from supplied well location top."""
     expected_location = Location(Point(0, 0, 0), mock_well)
-    # input_location = Well(mock_well_implementation)
 
     decoy.when(subject._ctx._modules).then_return([])
     decoy.when(mock_labware.use_tips(start_well=mock_well, num_channels=0)).then_return(
@@ -229,10 +228,7 @@ def test_pick_up_from_well(
     )
 
     decoy.when(mock_well.parent).then_return(mock_labware)
-    # TODO (tz, 7-11-22): Do I need this? failing on tiprack printing as str
-    decoy.when(mock_labware.is_tiprack()).then_return(True)
-    decoy.when(mock_labware._is_tiprack).then_return(True)
-    decoy.when(mock_abstract_labware.is_tiprack()).then_return(True)
+    decoy.when(mock_well.top()).then_return(expected_location)
 
     subject.pick_up_tip(location=mock_well)
 

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -20,7 +20,7 @@ from opentrons.protocol_api import labware
 
 
 @pytest.fixture(autouse=True)
-def patch_mock_next_available_tip(
+def mock_labware_module(
     decoy: Decoy,
     monkeypatch: pytest.MonkeyPatch,
     mock_labware: Labware,
@@ -35,7 +35,7 @@ def patch_mock_next_available_tip(
 
 
 @pytest.fixture(autouse=True)
-def _patch_mock_instrument_module(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
+def _mock_instrument_module(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
     """Replace instrument module method calls with a mock."""
     mock_validate_tiprack = decoy.mock(func=instrument.validate_tiprack)
     monkeypatch.setattr(
@@ -241,14 +241,14 @@ def test_pick_up_from_no_location(
     mock_instrument_implementation: AbstractInstrument,
     mock_well_implementation: WellImplementation,
     mock_labware: Labware,
-    patch_mock_next_available_tip: Any,
+    mock_labware_module: Any,
 ) -> None:
     """Should pick up tip from next_available_tip.top()."""
     mock_well = decoy.mock(cls=Well)
 
     expected_location = Location(Point(0, 0, 0), mock_well)
 
-    decoy.when(patch_mock_next_available_tip(None, [], 0)).then_return(
+    decoy.when(mock_labware_module(None, [], 0)).then_return(
         (mock_labware, mock_well)
     )
     decoy.when(mock_labware.use_tips(start_well=mock_well, num_channels=0)).then_return(

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -1,9 +1,8 @@
 """Tests for the InstrumentContext class."""
 import pytest
-from pytest_lazyfixture import lazy_fixture
+from pytest_lazyfixture import lazy_fixture  # type: ignore[import]
 
 from decoy import Decoy, matchers
-from typing import Union, Optional
 
 from opentrons.protocol_api import ProtocolContext
 from opentrons.protocol_api.instrument_context import InstrumentContext
@@ -12,12 +11,29 @@ from opentrons.types import Location, Point, LocationLabware
 from opentrons.broker import Broker
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocol_api.labware import Well, Labware
-from opentrons.protocols.context.protocol_api.labware import LabwareImplementation
-from opentrons.protocols.context.well import WellImplementation, WellGeometry
+from opentrons.protocols.context.well import WellImplementation
+from opentrons.protocols.geometry.well_geometry import WellGeometry
 from opentrons.protocols.api_support.instrument import validate_tiprack, tip_length_for
 from opentrons.commands import publisher
-from opentrons.protocol_api import labware
+from opentrons.protocol_api.labware import next_available_tip
 
+
+@pytest.fixture(autouse=True)
+def patch_mock_next_available_tip(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace next_available_tip() with a mock."""
+    mock_next_available_tip = decoy.mock(func=next_available_tip)
+    monkeypatch.setattr(
+        "opentrons.protocol_api.labware.next_available_tip",
+        mock_next_available_tip,
+    )
+    print("mocking mock_next_available_tip")
+    decoy.when(
+        mock_next_available_tip(
+            starting_tip=matchers.Anything(),
+            tip_racks=matchers.Anything(),
+            channels=matchers.Anything()
+        )
+    ).then_return(decoy.mock(name="next_available_tip"))
 
 @pytest.fixture(autouse=True)
 def patch_mock_validate_tiprack(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -94,10 +110,7 @@ def mock_labware(decoy: Decoy) -> Labware:
 @pytest.fixture
 def mock_well_implementation(mock_well_geometry: WellGeometry) -> WellImplementation:
     return WellImplementation(
-        well_geometry=mock_well_geometry,
-        display_name="test",
-        has_tip=True,
-        name="A1"
+        well_geometry=mock_well_geometry, display_name="test", has_tip=True, name="A1"
     )
 
 
@@ -105,31 +118,12 @@ def mock_well_implementation(mock_well_geometry: WellGeometry) -> WellImplementa
 def mock_well_geometry(decoy: Decoy) -> WellGeometry:
     return decoy.mock(cls=WellGeometry)
 
-@pytest.fixture
-def opentrons_96_tiprack_300ul_def():
-    labware_name = "opentrons_96_tiprack_300ul"
-    return labware.get_labware_definition(labware_name)
-
-
-@pytest.fixture
-def opentrons_96_tiprack_300ul(opentrons_96_tiprack_300ul_def):
-    return labware.Labware(
-        implementation=LabwareImplementation(
-            definition=opentrons_96_tiprack_300ul_def,
-            parent=Location(Point(0, 0, 0), "Test Slot"),
-        )
-    )
-
 
 @pytest.mark.parametrize(
     "input_point, labware, expected_point_call",
     [
         (Point(-100, -100, 0), lazy_fixture("mock_well"), Point(-100, -100, 0)),
-        (
-            Point(-100, -100, 0),
-            lazy_fixture("mock_labware"),
-            Point(-100, -100, 0)
-        ),
+        (Point(-100, -100, 0), lazy_fixture("mock_labware"), Point(-100, -100, 0)),
     ],
 )
 def test_pick_up_from_location(
@@ -140,10 +134,9 @@ def test_pick_up_from_location(
     mock_well_geometry: WellGeometry,
     mock_well: Well,
     mock_labware: Labware,
-    input_point: Union[Point, Well],
-    labware: Optional[LocationLabware],
-    expected_point_call: Optional[Point],
-    opentrons_96_tiprack_300ul,
+    input_point: Point,
+    labware: LocationLabware,
+    expected_point_call: Point,
 ) -> None:
     """Should pick up tip from supplied location of types.Location."""
 
@@ -151,15 +144,12 @@ def test_pick_up_from_location(
     expected_location = Location(point=expected_point_call, labware=mock_well)
 
     decoy.when(subject._ctx._modules).then_return([])
-    tiprack = opentrons_96_tiprack_300ul
-    print("tiprack")
-    print(tiprack)
-    print(type(tiprack))
-    print(tiprack._implementation.is_tiprack())
     decoy.when(mock_labware.next_tip(None)).then_return(mock_well)
-    # decoy.when(Well(mock_labware.next_tip(None)).top()).then_return(tiprack)
+
+    decoy.when(mock_well.top()).then_return(expected_location)
 
     subject.pick_up_tip(location=input_location)
+
     decoy.verify(
         mock_instrument_implementation.move_to(
             location=expected_location,
@@ -170,20 +160,17 @@ def test_pick_up_from_location(
         times=1,
     )
 
-def test_pick_up_from_location(
+
+def test_pick_up_from_well(
     decoy: Decoy,
     subject: InstrumentContext,
     mock_instrument_implementation: AbstractInstrument,
     mock_well_implementation: WellImplementation,
-    mock_well_geometry: WellGeometry,
     mock_well: Well,
-    mock_labware: Labware,
 ) -> None:
     """Should pick up tip from supplied location of types.Location."""
-
-    input_location = Well(mock_instrument_implementation)
-    print("after Well")
-    expected_location = Location(point=input_location, labware=mock_well)
+    expected_location = Location(Point(0, 0, 0), mock_well)
+    input_location = Well(mock_well_implementation)
 
     subject.pick_up_tip(location=input_location)
     decoy.verify(

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -1,19 +1,25 @@
 """Tests for the InstrumentContext class."""
 import pytest
+import sys
 
 from decoy import Decoy
+
 from opentrons.protocol_api import ProtocolContext
 
 from opentrons.protocol_api.instrument_context import InstrumentContext
 from opentrons.protocols.context.instrument import AbstractInstrument
-from opentrons.hardware_control.instruments.pipette import Pipette
-# from opentrons.config import pipette_config
-# from opentrons.calibration_storage import types as cal_types
-from opentrons.protocols.context.well import WellImplementation
 from opentrons.types import Mount, Location, Point
 from opentrons.broker import Broker
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocol_api.labware import Well
+from opentrons.protocols.api_support.instrument import validate_tiprack
+
+@pytest.fixture(autouse=True)
+def patch_mock_validate_tiprack(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace motion_planning.get_waypoints() with a mock."""
+    mock_validate_tiprack = decoy.mock(func=validate_tiprack)
+    monkeypatch.setattr("opentrons.protocols.api_support.instrument.validate_tiprack", mock_validate_tiprack)
+
 
 
 @pytest.fixture
@@ -22,18 +28,8 @@ def mock_protocol_context(decoy: Decoy) -> ProtocolContext:
 
 
 @pytest.fixture
-def mock_pipette_implementation(decoy: Decoy) -> Pipette:
-    return decoy.mock(cls=Pipette)
-        # Pipette(
-        #     config=pipette_config.load("p10_single_v1"),
-        #     pipette_offset_cal=cal_types.PipetteOffsetByPipetteMount(
-        #         offset=[0, 0, 0],
-        #         source=cal_types.SourceType.user,
-        #         status=cal_types.CalibrationStatus(),
-        #     ),
-        #     pipette_id="test-id",
-        # ),
-    # )
+def mock_pipette_implementation(decoy: Decoy) -> AbstractInstrument:
+    return decoy.mock(cls=AbstractInstrument)
 
 
 @pytest.fixture
@@ -43,13 +39,11 @@ def subject(decoy: Decoy, mock_pipette_implementation: AbstractInstrument, mock_
 
 def test_pick_up_from_location(decoy: Decoy, subject: InstrumentContext) -> None:
     """Should pick up tip from supplied location."""
-    # tiprack = mock_protocol_context.load_labware("opentrons_96_tiprack_300ul", 1)
-    #
-    # decoy.when(mock_protocol_context.load_instrument("p300_single", Mount.LEFT, tip_racks=[tiprack]))
-    mock_well_implementation = decoy.mock(cls=WellImplementation)
+    mock_well = decoy.mock(cls=Well)
+
     target = Point(-100, -100, 0)
-    location = Location(point=Point(-100, -100, 0), labware="opentrons_96_tiprack_300ul")
-    # Well(well_implementation=mock_well_implementation))
+    location = Location(point=Point(-100, -100, 0), labware=mock_well)
+
     subject.pick_up_tip(location=location)
 
     decoy.verify(subject.move_to(target))

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -221,21 +221,20 @@ def test_pick_up_from_well(
 ) -> None:
     """Should pick up tip from supplied well location top."""
     expected_location = Location(Point(0, 0, 0), mock_well)
-    input_location = Well(mock_well_implementation)
+    # input_location = Well(mock_well_implementation)
 
     decoy.when(subject._ctx._modules).then_return([])
     decoy.when(mock_labware.use_tips(start_well=mock_well, num_channels=0)).then_return(
         False
     )
 
-    decoy.when(input_location.parent).then_return(mock_labware)
-
+    decoy.when(mock_well.parent).then_return(mock_labware)
     # TODO (tz, 7-11-22): Do I need this? failing on tiprack printing as str
     decoy.when(mock_labware.is_tiprack()).then_return(True)
     decoy.when(mock_labware._is_tiprack).then_return(True)
     decoy.when(mock_abstract_labware.is_tiprack()).then_return(True)
 
-    subject.pick_up_tip(location=input_location)
+    subject.pick_up_tip(location=mock_well)
 
     decoy.verify(
         mock_instrument_implementation.move_to(
@@ -263,6 +262,7 @@ def test_pick_up_from_no_location(
     decoy.when(mock_labware.use_tips(start_well=mock_well, num_channels=0)).then_return(
         False
     )
+
     decoy.when(mock_well.top()).then_return(expected_location)
 
     subject.pick_up_tip(location=None)

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -94,8 +94,6 @@ def subject(
         at_version=APIVersion(2, 0),
     )
 
-    decoy.when(subject.channels).then_return(0)
-
     return subject
 
 
@@ -159,7 +157,7 @@ def test_pick_up_from_exact_labware_location(
     input_location = Location(point=Point(-100, -100, 0), labware=mock_labware)
     expected_location = Location(point=Point(-100, -100, 0), labware=mock_well)
 
-    decoy.when(mock_labware.next_tip(0)).then_return(mock_well)
+    decoy.when(mock_labware.next_tip(None)).then_return(mock_well)
 
     decoy.when(mock_well.top()).then_return(expected_location)
 
@@ -215,7 +213,7 @@ def test_pick_up_from_well(
     mock_well = decoy.mock(cls=Well)
     expected_location = Location(Point(0, 0, 0), mock_well)
 
-    decoy.when(mock_labware.use_tips(start_well=mock_well, num_channels=0)).then_return(
+    decoy.when(mock_labware.use_tips(start_well=mock_well, num_channels=None)).then_return(
         False
     )
 
@@ -248,8 +246,8 @@ def test_pick_up_from_no_location(
 
     expected_location = Location(Point(0, 0, 0), mock_well)
 
-    decoy.when(mock_labware_module(None, [], 0)).then_return((mock_labware, mock_well))
-    decoy.when(mock_labware.use_tips(start_well=mock_well, num_channels=0)).then_return(
+    decoy.when(mock_labware_module(None, [], None)).then_return((mock_labware, mock_well))
+    decoy.when(mock_labware.use_tips(start_well=mock_well, num_channels=None)).then_return(
         False
     )
 

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -78,6 +78,7 @@ def patch_mock_publish_context(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) ->
 @pytest.fixture
 def mock_protocol_context(decoy: Decoy) -> ProtocolContext:
     mock_protocol_context = decoy.mock(cls=ProtocolContext)
+    decoy.when(mock_protocol_context._modules).then_return([])
     return mock_protocol_context
 
 
@@ -157,7 +158,6 @@ def test_pick_up_from_location(
     input_location = Location(point=input_point, labware=labware)
     expected_location = Location(point=expected_point_call, labware=mock_well)
 
-    decoy.when(subject._ctx._modules).then_return([])
     decoy.when(mock_labware.next_tip(0)).then_return(mock_well)
 
     decoy.when(mock_well.top()).then_return(expected_location)
@@ -190,8 +190,6 @@ def test_pick_up_from_manipulated_location(
     expected_location = Location(Point(x=-100, y=-100, z=0), labware=mock_well)
     move_to_location = initial_location.move(point=Point(x=-100, y=-100, z=0))
 
-    decoy.when(subject._ctx._modules).then_return([])
-
     subject.pick_up_tip(location=move_to_location)
 
     decoy.verify(
@@ -217,7 +215,6 @@ def test_pick_up_from_well(
     mock_well = decoy.mock(cls=Well)
     expected_location = Location(Point(0, 0, 0), mock_well)
 
-    decoy.when(subject._ctx._modules).then_return([])
     decoy.when(mock_labware.use_tips(start_well=mock_well, num_channels=0)).then_return(
         False
     )
@@ -250,7 +247,6 @@ def test_pick_up_from_no_location(
 
     expected_location = Location(Point(0, 0, 0), mock_well)
 
-    decoy.when(subject._ctx._modules).then_return([])
     decoy.when(mock_labware.use_tips(start_well=mock_well, num_channels=0)).then_return(
         False
     )

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -2,12 +2,19 @@
 import pytest
 
 from decoy import Decoy
+from opentrons.protocol_api import ProtocolContext
 
 from opentrons.protocol_api.instrument_context import InstrumentContext
 from opentrons.protocols.context.instrument import AbstractInstrument
 from opentrons.hardware_control.instruments.pipette import Pipette
 # from opentrons.config import pipette_config
 # from opentrons.calibration_storage import types as cal_types
+from opentrons.types import Mount, Location, Point
+
+
+@pytest.fixture
+def mock_protocol_context(decoy: Decoy) -> ProtocolContext:
+    return decoy.mock(cls=ProtocolContext)
 
 
 @pytest.fixture
@@ -26,9 +33,17 @@ def mock_pipette_implementation(decoy: Decoy) -> Pipette:
 
 
 @pytest.fixture
-def subject(decoy: Decoy,mock_pipette_implementation: AbstractInstrument) -> InstrumentContext:
-    return decoy.mock(cls=InstrumentContext)
+def subject(decoy: Decoy, mock_pipette_implementation: AbstractInstrument, mock_protocol_context: ProtocolContext) -> InstrumentContext:
+    InstrumentContext(implementation=mock_pipette_implementation, ctx=mock_protocol_context)
 
 
-def test_pick_up_from_location(subject: InstrumentContext) -> None:
+def test_pick_up_from_location(decoy: Decoy, subject: InstrumentContext) -> None:
     """Should pick up tip from supplied location."""
+    # tiprack = mock_protocol_context.load_labware("opentrons_96_tiprack_300ul", 1)
+    #
+    # decoy.when(mock_protocol_context.load_instrument("p300_single", Mount.LEFT, tip_racks=[tiprack]))
+    target = Point(-100, -100, 0)
+
+    subject.pick_up_tip(location=Location(Point(-100, -100, 0), labware="Well"))
+
+    decoy.verify(subject.move_to(target))

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -43,10 +43,10 @@ def _mock_instrument_module(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> No
         mock_validate_tiprack,
     )
 
-    mock_validate_tiprack = decoy.mock(func=instrument.tip_length_for)
+    mock_tip_length_for = decoy.mock(func=instrument.tip_length_for)
     monkeypatch.setattr(
         "opentrons.protocols.api_support.instrument.tip_length_for",
-        mock_validate_tiprack,
+        mock_tip_length_for,
     )
 
 
@@ -248,9 +248,7 @@ def test_pick_up_from_no_location(
 
     expected_location = Location(Point(0, 0, 0), mock_well)
 
-    decoy.when(mock_labware_module(None, [], 0)).then_return(
-        (mock_labware, mock_well)
-    )
+    decoy.when(mock_labware_module(None, [], 0)).then_return((mock_labware, mock_well))
     decoy.when(mock_labware.use_tips(start_well=mock_well, num_channels=0)).then_return(
         False
     )

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -157,7 +157,9 @@ def test_pick_up_from_exact_labware_location(
     input_location = Location(point=Point(-100, -100, 0), labware=mock_labware)
     expected_location = Location(point=Point(-100, -100, 0), labware=mock_well)
 
-    decoy.when(mock_labware.next_tip(None)).then_return(mock_well)
+    decoy.when(mock_labware.next_tip(None)).then_return(  # type: ignore[arg-type]
+        mock_well
+    )
 
     decoy.when(mock_well.top()).then_return(expected_location)
 
@@ -213,9 +215,9 @@ def test_pick_up_from_well(
     mock_well = decoy.mock(cls=Well)
     expected_location = Location(Point(0, 0, 0), mock_well)
 
-    decoy.when(mock_labware.use_tips(start_well=mock_well, num_channels=None)).then_return(
-        False
-    )
+    decoy.when(
+        mock_labware.use_tips(start_well=mock_well, num_channels=None)  # type: ignore[arg-type]
+    ).then_return(False)
 
     decoy.when(mock_well.parent).then_return(mock_labware)
     decoy.when(mock_well.top()).then_return(expected_location)
@@ -246,10 +248,12 @@ def test_pick_up_from_no_location(
 
     expected_location = Location(Point(0, 0, 0), mock_well)
 
-    decoy.when(mock_labware_module(None, [], None)).then_return((mock_labware, mock_well))
-    decoy.when(mock_labware.use_tips(start_well=mock_well, num_channels=None)).then_return(
-        False
+    decoy.when(mock_labware_module(None, [], None)).then_return(
+        (mock_labware, mock_well)
     )
+    decoy.when(
+        mock_labware.use_tips(start_well=mock_well, num_channels=None)  # type: ignore[arg-type]
+    ).then_return(False)
 
     decoy.when(mock_well.top()).then_return(expected_location)
 

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -102,8 +102,6 @@ def subject(
     )
 
     decoy.when(subject.channels).then_return(0)
-    # decoy.when(subject.starting_tip).then_return(None)
-    # decoy.when(subject.tip_racks).then_return([mock_labware])
 
     return subject
 
@@ -117,14 +115,11 @@ def mock_well(decoy: Decoy) -> Well:
 def mock_abstract_labware(decoy: Decoy) -> AbstractLabware:
     return decoy.mock(cls=AbstractLabware)
 
-# @pytest.fixture
-# def mock_labware(decoy: Decoy, mock_abstract_labware: AbstractLabware) -> Labware:
-#     return Labware(implementation=mock_abstract_labware)
-
 
 @pytest.fixture
 def mock_labware(decoy: Decoy, mock_abstract_labware: AbstractLabware) -> Labware:
     return decoy.mock(cls=Labware)
+
 
 @pytest.fixture
 def mock_well_implementation(mock_well_geometry: WellGeometry) -> WellImplementation:

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -24,9 +24,9 @@ def patch_mock_next_available_tip(
     decoy: Decoy,
     monkeypatch: pytest.MonkeyPatch,
     mock_labware: Labware,
-    mock_well: Well,
 ) -> None:
     """Replace next_available_tip() with a mock."""
+    mock_well = decoy.mock(cls=Well)
     mock_next_available_tip = decoy.mock(func=next_available_tip)
     monkeypatch.setattr(
         "opentrons.protocol_api.labware.next_available_tip",
@@ -146,14 +146,14 @@ def test_pick_up_from_location(
     mock_instrument_implementation: AbstractInstrument,
     mock_well_implementation: WellImplementation,
     mock_well_geometry: WellGeometry,
-    mock_well: Well,
     mock_labware: Labware,
+    mock_well: Well,
     input_point: Point,
     labware: LocationLabware,
     expected_point_call: Point,
 ) -> None:
     """Should pick up tip from supplied location of types.Location."""
-
+    # mock_well = decoy.mock(cls=Well)
     input_location = Location(point=input_point, labware=labware)
     expected_location = Location(point=expected_point_call, labware=mock_well)
 
@@ -181,11 +181,11 @@ def test_pick_up_from_manipulated_location(
     mock_instrument_implementation: AbstractInstrument,
     mock_well_implementation: WellImplementation,
     mock_well_geometry: WellGeometry,
-    mock_well: Well,
     mock_labware: Labware,
 ) -> None:
     """Should pick up tip from move result of types.Location."""
 
+    mock_well = decoy.mock(cls=Well)
     initial_location = Location(Point(0, 0, 0), labware=mock_well)
     expected_location = Location(Point(x=-100, y=-100, z=0), labware=mock_well)
     move_to_location = initial_location.move(point=Point(x=-100, y=-100, z=0))
@@ -211,10 +211,10 @@ def test_pick_up_from_well(
     mock_instrument_implementation: AbstractInstrument,
     mock_well_implementation: WellImplementation,
     mock_abstract_labware: AbstractLabware,
-    mock_well: Well,
     mock_labware: Labware,
 ) -> None:
     """Should pick up tip from supplied well location top."""
+    mock_well = decoy.mock(cls=Well)
     expected_location = Location(Point(0, 0, 0), mock_well)
 
     decoy.when(subject._ctx._modules).then_return([])
@@ -243,10 +243,11 @@ def test_pick_up_from_no_location(
     subject: InstrumentContext,
     mock_instrument_implementation: AbstractInstrument,
     mock_well_implementation: WellImplementation,
-    mock_well: Well,
     mock_labware: Labware,
 ) -> None:
     """Should pick up tip from next_available_tip.top()."""
+    mock_well = decoy.mock(cls=Well)
+
     expected_location = Location(Point(0, 0, 0), mock_well)
 
     decoy.when(subject._ctx._modules).then_return([])

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -11,9 +11,8 @@ from opentrons.types import Location, Point
 from opentrons.broker import Broker
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocol_api.labware import Well
-from opentrons.protocols.api_support.instrument import validate_tiprack
+from opentrons.protocols.api_support.instrument import validate_tiprack, tip_length_for
 from opentrons.commands import publisher
-
 
 @pytest.fixture(autouse=True)
 def patch_mock_validate_tiprack(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -21,6 +20,15 @@ def patch_mock_validate_tiprack(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -
     mock_validate_tiprack = decoy.mock(func=validate_tiprack)
     monkeypatch.setattr(
         "opentrons.protocols.api_support.instrument.validate_tiprack",
+        mock_validate_tiprack,
+    )
+
+@pytest.fixture(autouse=True)
+def patch_mock_tip_length_for(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace tip_length_for() with a mock."""
+    mock_validate_tiprack = decoy.mock(func=tip_length_for)
+    monkeypatch.setattr(
+        "opentrons.protocols.api_support.instrument.tip_length_for",
         mock_validate_tiprack,
     )
 
@@ -44,35 +52,38 @@ def patch_mock_publish_context(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) ->
 
 @pytest.fixture
 def mock_protocol_context(decoy: Decoy) -> ProtocolContext:
-    return decoy.mock(cls=ProtocolContext)
+    mock_protocol_context = decoy.mock(cls=ProtocolContext)
+    return mock_protocol_context
 
 
 @pytest.fixture
-def mock_pipette_implementation(decoy: Decoy) -> AbstractInstrument:
+def mock_instrument_implementation(decoy: Decoy) -> AbstractInstrument:
     return decoy.mock(cls=AbstractInstrument)
 
 
 @pytest.fixture
 def subject(
     decoy: Decoy,
-    mock_pipette_implementation: AbstractInstrument,
+    mock_instrument_implementation: AbstractInstrument,
     mock_protocol_context: ProtocolContext,
 ) -> InstrumentContext:
     return InstrumentContext(
-        implementation=mock_pipette_implementation,
+        implementation=mock_instrument_implementation,
         ctx=mock_protocol_context,
         broker=Broker(),
         at_version=APIVersion(2, 0),
     )
 
 
-def test_pick_up_from_location(decoy: Decoy, subject: InstrumentContext) -> None:
+def test_pick_up_from_location(decoy: Decoy, subject: InstrumentContext, mock_instrument_implementation: AbstractInstrument) -> None:
     """Should pick up tip from supplied location."""
     mock_well = decoy.mock(cls=Well)
 
     point = Point(-100, -100, 0)
     location = Location(point=point, labware=mock_well)
 
+    decoy.when(subject._ctx._modules).then_return([])
+
     subject.pick_up_tip(location=location)
 
-    decoy.verify(subject.move_to(location))
+    decoy.verify(subject.move_to(location), times=1)

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -23,7 +23,6 @@ def patch_mock_validate_tiprack(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -
         mock_validate_tiprack,
     )
 
-
 @pytest.fixture
 def mock_protocol_context(decoy: Decoy) -> ProtocolContext:
     return decoy.mock(cls=ProtocolContext)

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -1,6 +1,5 @@
 """Tests for the InstrumentContext class."""
 import pytest
-import sys
 
 from decoy import Decoy
 
@@ -8,18 +7,21 @@ from opentrons.protocol_api import ProtocolContext
 
 from opentrons.protocol_api.instrument_context import InstrumentContext
 from opentrons.protocols.context.instrument import AbstractInstrument
-from opentrons.types import Mount, Location, Point
+from opentrons.types import Location, Point
 from opentrons.broker import Broker
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocol_api.labware import Well
 from opentrons.protocols.api_support.instrument import validate_tiprack
 
+
 @pytest.fixture(autouse=True)
 def patch_mock_validate_tiprack(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
     """Replace motion_planning.get_waypoints() with a mock."""
     mock_validate_tiprack = decoy.mock(func=validate_tiprack)
-    monkeypatch.setattr("opentrons.protocols.api_support.instrument.validate_tiprack", mock_validate_tiprack)
-
+    monkeypatch.setattr(
+        "opentrons.protocols.api_support.instrument.validate_tiprack",
+        mock_validate_tiprack,
+    )
 
 
 @pytest.fixture
@@ -33,17 +35,26 @@ def mock_pipette_implementation(decoy: Decoy) -> AbstractInstrument:
 
 
 @pytest.fixture
-def subject(decoy: Decoy, mock_pipette_implementation: AbstractInstrument, mock_protocol_context: ProtocolContext) -> InstrumentContext:
-    return InstrumentContext(implementation=mock_pipette_implementation, ctx=mock_protocol_context, broker=Broker(), at_version=APIVersion(2, 0))
+def subject(
+    decoy: Decoy,
+    mock_pipette_implementation: AbstractInstrument,
+    mock_protocol_context: ProtocolContext,
+) -> InstrumentContext:
+    return InstrumentContext(
+        implementation=mock_pipette_implementation,
+        ctx=mock_protocol_context,
+        broker=Broker(),
+        at_version=APIVersion(2, 0),
+    )
 
 
 def test_pick_up_from_location(decoy: Decoy, subject: InstrumentContext) -> None:
     """Should pick up tip from supplied location."""
     mock_well = decoy.mock(cls=Well)
 
-    target = Point(-100, -100, 0)
-    location = Location(point=Point(-100, -100, 0), labware=mock_well)
+    point = Point(-100, -100, 0)
+    location = Location(point=point, labware=mock_well)
 
     subject.pick_up_tip(location=location)
 
-    decoy.verify(subject.move_to(target))
+    decoy.verify(subject.move_to(location))

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -87,14 +87,14 @@ def test_pick_up_from_location(
 
     point = Point(-100, -100, 0)
     location = Location(point=point, labware=mock_well)
-    target = location.labware.as_well()
+
     decoy.when(subject._ctx._modules).then_return([])
 
     subject.pick_up_tip(location=location)
 
     decoy.verify(
         mock_instrument_implementation.move_to(
-            location=target, force_direct=False, minimum_z_height=None, speed=None
+            location=location, force_direct=False, minimum_z_height=None, speed=None
         ),
         times=1,
     )

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -4,7 +4,6 @@ import pytest
 from decoy import Decoy, matchers
 
 from opentrons.protocol_api import ProtocolContext
-
 from opentrons.protocol_api.instrument_context import InstrumentContext
 from opentrons.protocols.context.instrument import AbstractInstrument
 from opentrons.types import Location, Point

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -1,13 +1,12 @@
 """Tests for the InstrumentContext class."""
 import pytest
-from pytest_lazyfixture import lazy_fixture  # type: ignore[import]
 
 from decoy import Decoy, matchers
 
 from opentrons.protocol_api import ProtocolContext
 from opentrons.protocol_api.instrument_context import InstrumentContext
 from opentrons.protocols.context.instrument import AbstractInstrument
-from opentrons.types import Location, Point, LocationLabware
+from opentrons.types import Location, Point
 from opentrons.broker import Broker
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocol_api.labware import Well, Labware
@@ -129,29 +128,17 @@ def mock_well_geometry(decoy: Decoy) -> WellGeometry:
     return decoy.mock(cls=WellGeometry)
 
 
-# @pytest.mark.parametrize(
-#     "input_point, labware, expected_point_call",
-#     [
-#         (Point(-100, -100, 0), lazy_fixture("mock_well"), Point(-100, -100, 0)),
-#         (Point(-100, -100, 0), lazy_fixture("mock_labware"), Point(-100, -100, 0)),
-#     ],
-# )
 def test_pick_up_from_exact_well_location(
     decoy: Decoy,
     subject: InstrumentContext,
     mock_instrument_implementation: AbstractInstrument,
     mock_well_implementation: WellImplementation,
     mock_well_geometry: WellGeometry,
-    mock_labware: Labware,
 ) -> None:
-    """Should pick up tip from supplied location of types.Location."""
+    """Should pick up tip from supplied exact Well Location."""
     mock_well = decoy.mock(cls=Well)
     input_location = Location(point=Point(-100, -100, 0), labware=mock_well)
     expected_location = Location(point=Point(-100, -100, 0), labware=mock_well)
-
-    decoy.when(mock_labware.next_tip(0)).then_return(mock_well)
-
-    decoy.when(mock_well.top()).then_return(expected_location)
 
     subject.pick_up_tip(location=input_location)
 
@@ -174,7 +161,7 @@ def test_pick_up_from_exact_labware_location(
     mock_well_geometry: WellGeometry,
     mock_labware: Labware,
 ) -> None:
-    """Should pick up tip from supplied location of types.Location."""
+    """Should pick up tip from supplied exact labware Location."""
     mock_well = decoy.mock(cls=Well)
     input_location = Location(point=Point(-100, -100, 0), labware=mock_labware)
     expected_location = Location(point=Point(-100, -100, 0), labware=mock_well)

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -3,6 +3,7 @@ import pytest
 from pytest_lazyfixture import lazy_fixture
 
 from decoy import Decoy, matchers
+from typing import Union, Optional
 
 from opentrons.protocol_api import ProtocolContext
 from opentrons.protocol_api.instrument_context import InstrumentContext
@@ -10,9 +11,12 @@ from opentrons.protocols.context.instrument import AbstractInstrument
 from opentrons.types import Location, Point, LocationLabware
 from opentrons.broker import Broker
 from opentrons.protocols.api_support.types import APIVersion
-from opentrons.protocol_api.labware import Well
+from opentrons.protocol_api.labware import Well, Labware
+from opentrons.protocols.context.protocol_api.labware import LabwareImplementation
+from opentrons.protocols.context.well import WellImplementation, WellGeometry
 from opentrons.protocols.api_support.instrument import validate_tiprack, tip_length_for
 from opentrons.commands import publisher
+from opentrons.protocol_api import labware
 
 
 @pytest.fixture(autouse=True)
@@ -82,31 +86,90 @@ def mock_well(decoy: Decoy) -> Well:
     return decoy.mock(cls=Well)
 
 
+@pytest.fixture
+def mock_labware(decoy: Decoy) -> Labware:
+    return decoy.mock(cls=Labware)
+
+
+@pytest.fixture
+def mock_well_implementation(mock_well_geometry) -> WellImplementation:
+    return WellImplementation(
+        well_geometry=mock_well_geometry,
+        display_name="test",
+        has_tip=True,
+        name="test"
+    )
+
+
+@pytest.fixture
+def mock_well_geometry(decoy: Decoy) -> WellGeometry:
+    return decoy.mock(cls=WellGeometry)
+
+@pytest.fixture
+def opentrons_96_tiprack_300ul_def():
+    labware_name = "opentrons_96_tiprack_300ul"
+    return labware.get_labware_definition(labware_name)
+
+
+@pytest.fixture
+def opentrons_96_tiprack_300ul(opentrons_96_tiprack_300ul_def):
+    return labware.Labware(
+        implementation=LabwareImplementation(
+            definition=opentrons_96_tiprack_300ul_def,
+            parent=Location(Point(0, 0, 0), "Test Slot"),
+        )
+    )
+
+
 @pytest.mark.parametrize(
-    "input_point, labware, expected_point_call",
+    "input_point, labware, expected_point_call, is_type_location",
     [
+        (Point(-100, -100, 0), lazy_fixture("mock_well"), Point(-100, -100, 0), True),
         (
             Point(-100, -100, 0),
-            lazy_fixture("mock_well"),
+            lazy_fixture("mock_labware"),
             Point(-100, -100, 0),
-        )
+            True,
+        ),
+        (
+            Well(well_implementation=lazy_fixture("mock_well_implementation")),
+            False,
+        ),
     ],
 )
 def test_pick_up_from_location(
     decoy: Decoy,
     subject: InstrumentContext,
     mock_instrument_implementation: AbstractInstrument,
+    mock_well_implementation: WellImplementation,
+    mock_well_geometry: WellGeometry,
     mock_well: Well,
-    input_point: Point,
-    labware: LocationLabware,
-    expected_point_call: Point,
+    mock_labware: Labware,
+    input_point: Union[Point, Well],
+    labware: Optional[LocationLabware],
+    expected_point_call: Optional[Point],
+    opentrons_96_tiprack_300ul,
+    is_type_location: bool,
 ) -> None:
     """Should pick up tip from supplied location."""
+    if is_type_location:
+        input_location = Location(point=input_point, labware=labware)
+        expected_location = Location(point=expected_point_call, labware=mock_well)
+    else:
+        input_location = Well(mock_instrument_implementation)
+        expected_location = Location(point=expected_point_call, labware=mock_well)
 
     decoy.when(subject._ctx._modules).then_return([])
-    input_location = Location(point=input_point, labware=labware)
+    decoy.when(mock_well_implementation.get_geometry()).then_return(mock_well_geometry)
+    tiprack = opentrons_96_tiprack_300ul
+    print("tiprack")
+    print(tiprack)
+    print(type(tiprack))
+    print(tiprack._implementation.is_tiprack())
+    decoy.when(mock_labware.next_tip(None)).then_return(mock_well)
+    # decoy.when(Well(mock_labware.next_tip(None)).top()).then_return(tiprack)
+
     subject.pick_up_tip(location=input_location)
-    expected_location = Location(point=expected_point_call, labware=labware)
     decoy.verify(
         mock_instrument_implementation.move_to(
             location=expected_location,

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -15,24 +15,25 @@ from opentrons.protocols.api_support.instrument import validate_tiprack
 from opentrons.commands import publisher
 
 
-
 @pytest.fixture(autouse=True)
 def patch_mock_validate_tiprack(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Replace motion_planning.get_waypoints() with a mock."""
+    """Replace validate_tiprack() with a mock."""
     mock_validate_tiprack = decoy.mock(func=validate_tiprack)
     monkeypatch.setattr(
         "opentrons.protocols.api_support.instrument.validate_tiprack",
         mock_validate_tiprack,
     )
 
+
 @pytest.fixture(autouse=True)
 def patch_mock_publish_context(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Replace motion_planning.get_waypoints() with a mock."""
+    """Replace publish_context() with a mock."""
     mock_publish_context = decoy.mock(func=publisher.publish_context)
     monkeypatch.setattr(
         "opentrons.commands.publisher.publish_context",
         mock_publish_context,
     )
+
 
 @pytest.fixture
 def mock_protocol_context(decoy: Decoy) -> ProtocolContext:

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -32,11 +32,9 @@ def patch_mock_next_available_tip(
         mock_next_available_tip,
     )
 
-    decoy.when(
-        mock_next_available_tip(
-            None, [], 0
-        )
-    ).then_return((mock_labware, mock_well))
+    decoy.when(mock_next_available_tip(None, [], 0)).then_return(
+        (mock_labware, mock_well)
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -232,19 +230,22 @@ def test_pick_up_from_manipulated_location(
 #         times=1,
 #     )
 
+
 def test_pick_up_from_no_location(
     decoy: Decoy,
     subject: InstrumentContext,
     mock_instrument_implementation: AbstractInstrument,
     mock_well_implementation: WellImplementation,
     mock_well: Well,
-    mock_labware: Labware
+    mock_labware: Labware,
 ) -> None:
     """Should pick up tip from next_available_tip.top()."""
     expected_location = Location(Point(0, 0, 0), mock_well)
 
     decoy.when(subject._ctx._modules).then_return([])
-    decoy.when(mock_labware.use_tips(start_well=mock_well, num_channels=0)).then_return(False)
+    decoy.when(mock_labware.use_tips(start_well=mock_well, num_channels=0)).then_return(
+        False
+    )
     decoy.when(mock_well.top()).then_return(expected_location)
 
     subject.pick_up_tip(location=None)

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -9,7 +9,11 @@ from opentrons.protocols.context.instrument import AbstractInstrument
 from opentrons.hardware_control.instruments.pipette import Pipette
 # from opentrons.config import pipette_config
 # from opentrons.calibration_storage import types as cal_types
+from opentrons.protocols.context.well import WellImplementation
 from opentrons.types import Mount, Location, Point
+from opentrons.broker import Broker
+from opentrons.protocols.api_support.types import APIVersion
+from opentrons.protocol_api.labware import Well
 
 
 @pytest.fixture
@@ -34,7 +38,7 @@ def mock_pipette_implementation(decoy: Decoy) -> Pipette:
 
 @pytest.fixture
 def subject(decoy: Decoy, mock_pipette_implementation: AbstractInstrument, mock_protocol_context: ProtocolContext) -> InstrumentContext:
-    InstrumentContext(implementation=mock_pipette_implementation, ctx=mock_protocol_context)
+    return InstrumentContext(implementation=mock_pipette_implementation, ctx=mock_protocol_context, broker=Broker(), at_version=APIVersion(2, 0))
 
 
 def test_pick_up_from_location(decoy: Decoy, subject: InstrumentContext) -> None:
@@ -42,8 +46,10 @@ def test_pick_up_from_location(decoy: Decoy, subject: InstrumentContext) -> None
     # tiprack = mock_protocol_context.load_labware("opentrons_96_tiprack_300ul", 1)
     #
     # decoy.when(mock_protocol_context.load_instrument("p300_single", Mount.LEFT, tip_racks=[tiprack]))
+    mock_well_implementation = decoy.mock(cls=WellImplementation)
     target = Point(-100, -100, 0)
-
-    subject.pick_up_tip(location=Location(Point(-100, -100, 0), labware="Well"))
+    location = Location(point=Point(-100, -100, 0), labware="opentrons_96_tiprack_300ul")
+    # Well(well_implementation=mock_well_implementation))
+    subject.pick_up_tip(location=location)
 
     decoy.verify(subject.move_to(target))

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -12,6 +12,8 @@ from opentrons.broker import Broker
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocol_api.labware import Well
 from opentrons.protocols.api_support.instrument import validate_tiprack
+from opentrons.commands import publisher
+
 
 
 @pytest.fixture(autouse=True)
@@ -21,6 +23,15 @@ def patch_mock_validate_tiprack(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setattr(
         "opentrons.protocols.api_support.instrument.validate_tiprack",
         mock_validate_tiprack,
+    )
+
+@pytest.fixture(autouse=True)
+def patch_mock_publish_context(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace motion_planning.get_waypoints() with a mock."""
+    mock_publish_context = decoy.mock(func=publisher.publish_context)
+    monkeypatch.setattr(
+        "opentrons.commands.publisher.publish_context",
+        mock_publish_context,
     )
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -1,0 +1,34 @@
+"""Tests for the InstrumentContext class."""
+import pytest
+
+from decoy import Decoy
+
+from opentrons.protocol_api.instrument_context import InstrumentContext
+from opentrons.protocols.context.instrument import AbstractInstrument
+from opentrons.hardware_control.instruments.pipette import Pipette
+# from opentrons.config import pipette_config
+# from opentrons.calibration_storage import types as cal_types
+
+
+@pytest.fixture
+def mock_pipette_implementation(decoy: Decoy) -> Pipette:
+    return decoy.mock(cls=Pipette)
+        # Pipette(
+        #     config=pipette_config.load("p10_single_v1"),
+        #     pipette_offset_cal=cal_types.PipetteOffsetByPipetteMount(
+        #         offset=[0, 0, 0],
+        #         source=cal_types.SourceType.user,
+        #         status=cal_types.CalibrationStatus(),
+        #     ),
+        #     pipette_id="test-id",
+        # ),
+    # )
+
+
+@pytest.fixture
+def subject(decoy: Decoy,mock_pipette_implementation: AbstractInstrument) -> InstrumentContext:
+    return decoy.mock(cls=InstrumentContext)
+
+
+def test_pick_up_from_location(subject: InstrumentContext) -> None:
+    """Should pick up tip from supplied location."""

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -201,34 +201,36 @@ def test_pick_up_from_manipulated_location(
     )
 
 
-# def test_pick_up_from_well(
-#     decoy: Decoy,
-#     subject: InstrumentContext,
-#     mock_instrument_implementation: AbstractInstrument,
-#     mock_well_implementation: WellImplementation,
-#     mock_well: Well,
-#     mock_labware: Labware
-# ) -> None:
-#     """Should pick up tip from supplied location of types.Location."""
-#     expected_location = Location(Point(0, 0, 0), mock_well)
-#     input_location = Well(mock_well_implementation)
-#
-#     decoy.when(subject._ctx._modules).then_return([])
-#     decoy.when(mock_labware.use_tips(start_well=mock_well, num_channels=None)).then_return(False)
-#
-#     decoy.when(mock_well.parent).then_return(mock_labware)
-#
-#     subject.pick_up_tip(location=input_location)
-#
-#     decoy.verify(
-#         mock_instrument_implementation.move_to(
-#             location=expected_location,
-#             force_direct=False,
-#             minimum_z_height=None,
-#             speed=None,
-#         ),
-#         times=1,
-#     )
+def test_pick_up_from_well(
+    decoy: Decoy,
+    subject: InstrumentContext,
+    mock_instrument_implementation: AbstractInstrument,
+    mock_well_implementation: WellImplementation,
+    mock_well: Well,
+    mock_labware: Labware,
+) -> None:
+    """Should pick up tip from supplied well location top."""
+    expected_location = Location(Point(0, 0, 0), mock_well)
+    input_location = Well(mock_well_implementation)
+
+    decoy.when(subject._ctx._modules).then_return([])
+    decoy.when(mock_labware.use_tips(start_well=mock_well, num_channels=0)).then_return(
+        False
+    )
+
+    decoy.when(input_location.parent).then_return(mock_labware)
+
+    subject.pick_up_tip(location=input_location)
+
+    decoy.verify(
+        mock_instrument_implementation.move_to(
+            location=expected_location,
+            force_direct=False,
+            minimum_z_height=None,
+            speed=None,
+        ),
+        times=1,
+    )
 
 
 def test_pick_up_from_no_location(

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -35,18 +35,14 @@ def patch_mock_next_available_tip(
 
 
 @pytest.fixture(autouse=True)
-def patch_mock_validate_tiprack(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Replace validate_tiprack() with a mock."""
+def _patch_mock_instrument_module(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace instrument module method calls with a mock."""
     mock_validate_tiprack = decoy.mock(func=instrument.validate_tiprack)
     monkeypatch.setattr(
         "opentrons.protocols.api_support.instrument.validate_tiprack",
         mock_validate_tiprack,
     )
 
-
-@pytest.fixture(autouse=True)
-def patch_mock_tip_length_for(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Replace tip_length_for() with a mock."""
     mock_validate_tiprack = decoy.mock(func=instrument.tip_length_for)
     monkeypatch.setattr(
         "opentrons.protocols.api_support.instrument.tip_length_for",
@@ -245,7 +241,7 @@ def test_pick_up_from_no_location(
     mock_instrument_implementation: AbstractInstrument,
     mock_well_implementation: WellImplementation,
     mock_labware: Labware,
-    patch_mock_next_available_tip: Any
+    patch_mock_next_available_tip: Any,
 ) -> None:
     """Should pick up tip from next_available_tip.top()."""
     mock_well = decoy.mock(cls=Well)

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -14,6 +14,7 @@ from opentrons.protocol_api.labware import Well
 from opentrons.protocols.api_support.instrument import validate_tiprack, tip_length_for
 from opentrons.commands import publisher
 
+
 @pytest.fixture(autouse=True)
 def patch_mock_validate_tiprack(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
     """Replace validate_tiprack() with a mock."""
@@ -22,6 +23,7 @@ def patch_mock_validate_tiprack(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -
         "opentrons.protocols.api_support.instrument.validate_tiprack",
         mock_validate_tiprack,
     )
+
 
 @pytest.fixture(autouse=True)
 def patch_mock_tip_length_for(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -75,15 +77,24 @@ def subject(
     )
 
 
-def test_pick_up_from_location(decoy: Decoy, subject: InstrumentContext, mock_instrument_implementation: AbstractInstrument) -> None:
+def test_pick_up_from_location(
+    decoy: Decoy,
+    subject: InstrumentContext,
+    mock_instrument_implementation: AbstractInstrument,
+) -> None:
     """Should pick up tip from supplied location."""
     mock_well = decoy.mock(cls=Well)
 
     point = Point(-100, -100, 0)
     location = Location(point=point, labware=mock_well)
-
+    target = location.labware.as_well()
     decoy.when(subject._ctx._modules).then_return([])
 
     subject.pick_up_tip(location=location)
 
-    decoy.verify(mock_instrument_implementation.move_to(location=location, force_direct=False, minimum_z_height=0, speed=0), times=1)
+    decoy.verify(
+        mock_instrument_implementation.move_to(
+            location=target, force_direct=False, minimum_z_height=None, speed=None
+        ),
+        times=1,
+    )

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -86,4 +86,4 @@ def test_pick_up_from_location(decoy: Decoy, subject: InstrumentContext, mock_in
 
     subject.pick_up_tip(location=location)
 
-    decoy.verify(subject.move_to(location), times=1)
+    decoy.verify(mock_instrument_implementation.move_to(location=location, force_direct=False, minimum_z_height=0, speed=0), times=1)

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -1,7 +1,7 @@
 """Tests for the InstrumentContext class."""
 import pytest
 
-from decoy import Decoy
+from decoy import Decoy, matchers
 
 from opentrons.protocol_api import ProtocolContext
 
@@ -33,6 +33,13 @@ def patch_mock_publish_context(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) ->
         "opentrons.commands.publisher.publish_context",
         mock_publish_context,
     )
+
+    decoy.when(
+        mock_publish_context(
+            broker=matchers.Anything(),
+            command=matchers.Anything(),
+        )
+    ).then_return(decoy.mock(name="publish-context"))
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -13,9 +13,9 @@ from opentrons.protocol_api.labware import Well, Labware
 from opentrons.protocols.context.well import WellImplementation
 from opentrons.protocols.context.labware import AbstractLabware
 from opentrons.protocols.geometry.well_geometry import WellGeometry
-from opentrons.protocols.api_support.instrument import validate_tiprack, tip_length_for
+from opentrons.protocols.api_support import instrument
 from opentrons.commands import publisher
-from opentrons.protocol_api.labware import next_available_tip
+from opentrons.protocol_api import labware
 
 
 @pytest.fixture(autouse=True)
@@ -26,7 +26,7 @@ def patch_mock_next_available_tip(
 ) -> None:
     """Replace next_available_tip() with a mock."""
     mock_well = decoy.mock(cls=Well)
-    mock_next_available_tip = decoy.mock(func=next_available_tip)
+    mock_next_available_tip = decoy.mock(func=labware.next_available_tip)
     monkeypatch.setattr(
         "opentrons.protocol_api.labware.next_available_tip",
         mock_next_available_tip,
@@ -40,7 +40,7 @@ def patch_mock_next_available_tip(
 @pytest.fixture(autouse=True)
 def patch_mock_validate_tiprack(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
     """Replace validate_tiprack() with a mock."""
-    mock_validate_tiprack = decoy.mock(func=validate_tiprack)
+    mock_validate_tiprack = decoy.mock(func=instrument.validate_tiprack)
     monkeypatch.setattr(
         "opentrons.protocols.api_support.instrument.validate_tiprack",
         mock_validate_tiprack,
@@ -50,7 +50,7 @@ def patch_mock_validate_tiprack(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -
 @pytest.fixture(autouse=True)
 def patch_mock_tip_length_for(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
     """Replace tip_length_for() with a mock."""
-    mock_validate_tiprack = decoy.mock(func=tip_length_for)
+    mock_validate_tiprack = decoy.mock(func=instrument.tip_length_for)
     monkeypatch.setattr(
         "opentrons.protocols.api_support.instrument.tip_length_for",
         mock_validate_tiprack,
@@ -195,14 +195,13 @@ def test_pick_up_from_manipulated_location(
 
     mock_well = decoy.mock(cls=Well)
     initial_location = Location(Point(0, 0, 0), labware=mock_well)
-    expected_location = Location(Point(x=-100, y=-100, z=0), labware=mock_well)
     move_to_location = initial_location.move(point=Point(x=-100, y=-100, z=0))
 
     subject.pick_up_tip(location=move_to_location)
 
     decoy.verify(
         mock_instrument_implementation.move_to(
-            location=expected_location,
+            location=move_to_location,
             force_direct=False,
             minimum_z_height=None,
             speed=None,


### PR DESCRIPTION
# Overview

closes #7774.
PAPIv2 documentation mentions picking up tip from a specified location.
The implementation details always moved to top.
If type is `types.Location` and `is_well()` we use specified location.

# Changelog

- Added decoy test file to test instrument_context
- Changed imports in instrument_context to use global imports 
- changed logic when pick_up_tip is called to use location when using types.Location and when the type is Well

# Review requests

1. is it ok I changed to global imports? 
3. Do we write tests for the other scenario's to make sure nothing else is effected? its being tested in the old tests 
4. Are the tests sufficient? 

# Risk assessment

Medium. Changed logic of pick_up_tip end point in PAPIV2. Need to make sure it works and nothing else is effected 
