### PR TITLE
feat(app, components): align Liquid Setup UI with Figma

### DIFF
--- a/app/src/molecules/ToggleGroup/useToggleGroup.tsx
+++ b/app/src/molecules/ToggleGroup/useToggleGroup.tsx
@@ -20,7 +20,8 @@ const BUTTON_GROUP_STYLES = css`
     font-size: 11px;
     line-height: 14px;
     box-shadow: none;
-
+    padding-top: 6px;
+    padding-bottom: 8px;
     &:focus {
       box-shadow: none;
       color: ${COLORS.white};

--- a/app/src/molecules/ToggleGroup/useToggleGroup.tsx
+++ b/app/src/molecules/ToggleGroup/useToggleGroup.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { css } from 'styled-components'
-import { BORDERS, COLORS, Flex } from '@opentrons/components'
+import { BORDERS, COLORS, Flex, SPACING } from '@opentrons/components'
 import {
   blue,
   lightGrey,
@@ -55,12 +55,16 @@ const BUTTON_GROUP_STYLES = css`
 `
 
 const ACTIVE_STYLE = css`
+  padding-left: ${SPACING.spacing3};
+  padding-right: ${SPACING.spacing3};
   background-color: ${blue};
   color: ${COLORS.white};
   pointer-events: none;
 `
 
 const DEFAULT_STYLE = css`
+  padding-left: ${SPACING.spacing3};
+  padding-right: ${SPACING.spacing3};
   background-color: ${COLORS.white};
   color: ${COLORS.black};
 `

--- a/app/src/molecules/ToggleGroup/useToggleGroup.tsx
+++ b/app/src/molecules/ToggleGroup/useToggleGroup.tsx
@@ -9,7 +9,6 @@ import {
 import { PrimaryButton } from '../../atoms/buttons'
 
 const BUTTON_GROUP_STYLES = css`
-  border: 1px ${medGrey} solid;
   border-radius: ${BORDERS.radiusSoftCorners};
   margin-top: -1px;
   width: fit-content;
@@ -17,7 +16,6 @@ const BUTTON_GROUP_STYLES = css`
   button {
     height: 28px;
     width: auto;
-    border: none;
     font-weight: 400;
     font-size: 11px;
     line-height: 14px;
@@ -47,10 +45,12 @@ const BUTTON_GROUP_STYLES = css`
 
   button:first-child {
     border-radius: ${BORDERS.radiusSoftCorners} 0 0 ${BORDERS.radiusSoftCorners};
+    border-right: none;
   }
 
   button:last-child {
     border-radius: 0 ${BORDERS.radiusSoftCorners} ${BORDERS.radiusSoftCorners} 0;
+    border-left: none;
   }
 `
 
@@ -67,6 +67,7 @@ const DEFAULT_STYLE = css`
   padding-right: ${SPACING.spacing3};
   background-color: ${COLORS.white};
   color: ${COLORS.black};
+  border: 1px ${medGrey} solid;
 `
 
 export const useToggleGroup = (

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunSetup.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunSetup.tsx
@@ -209,6 +209,7 @@ export function ProtocolRunSetup({
               </Flex>
             ))
           )}
+          
         </>
       ) : (
         <StyledText alignSelf={ALIGN_CENTER} color={COLORS.darkGreyEnabled}>

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunSetup.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunSetup.tsx
@@ -209,7 +209,6 @@ export function ProtocolRunSetup({
               </Flex>
             ))
           )}
-          
         </>
       ) : (
         <StyledText alignSelf={ALIGN_CENTER} color={COLORS.darkGreyEnabled}>

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidDetailCard.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidDetailCard.tsx
@@ -72,7 +72,7 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
       >
         <Flex
           css={BORDERS.cardOutlineBorder}
-          padding={'0.75rem'}
+          padding={'0.5rem'}
           height={'max-content'}
           width={'max-content'}
           backgroundColor={COLORS.white}
@@ -80,7 +80,7 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
           <Icon name="circle" color={displayColor} size={SIZE_1} />
         </Flex>
         <StyledText
-          as="p"
+          as="h3"
           fontWeight={TYPOGRAPHY.fontWeightSemiBold}
           marginTop={SPACING.spacing3}
         >

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidDetailCard.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidDetailCard.tsx
@@ -60,7 +60,6 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
     <Box
       css={selectedValue === liquidId ? ACTIVE_STYLE : LIQUID_CARD_STYLE}
       borderRadius={BORDERS.radiusSoftCorners}
-      marginBottom={SPACING.spacing3}
       padding={SPACING.spacing4}
       backgroundColor={COLORS.white}
       onClick={() => setSelectedValue(liquidId)}
@@ -118,20 +117,20 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
                 key={index}
                 flexDirection={DIRECTION_ROW}
                 justifyContent={JUSTIFY_SPACE_BETWEEN}
+                paddingBottom={
+                  index !== volumePerWellRange.length - 1
+                    ? SPACING.spacing3
+                    : '0'
+                }
               >
                 <StyledText
                   as="p"
                   fontWeight={TYPOGRAPHY.fontWeightRegular}
-                  marginTop={SPACING.spacing3}
                   marginRight={SPACING.spacing2}
                 >
                   {well.wellName}
                 </StyledText>
-                <StyledText
-                  as="p"
-                  fontWeight={TYPOGRAPHY.fontWeightRegular}
-                  marginTop={SPACING.spacing3}
-                >
+                <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightRegular}>
                   {well.volume} {MICRO_LITERS}
                 </StyledText>
               </Flex>

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
@@ -91,7 +91,7 @@ export const LiquidsLabwareDetailsModal = (
             maxHeight={'27.125rem'}
             overflowY={'auto'}
             minWidth={'10.313rem'}
-            gridGap={SPACING.spacing4}
+            gridGap={SPACING.spacing3}
           >
             {filteredLiquidsInLoadOrder.map((liquid, index) => {
               const labwareInfoEntry = Object.entries(labwareInfo).find(
@@ -125,6 +125,7 @@ export const LiquidsLabwareDetailsModal = (
             width="100%"
             maxHeight="25rem"
             marginLeft={SPACING.spacing4}
+            marginTop={SPACING.spacing3}
           >
             <Flex flexDirection={DIRECTION_ROW}>
               <Flex flexDirection={DIRECTION_COLUMN}>

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
@@ -81,7 +81,8 @@ export const LiquidsLabwareDetailsModal = (
       title={labwareName}
       contentBackgroundColor={COLORS.background}
       closeOnOutsideClick
-      width="46.875rem"
+      marginX={SPACING.spacing5}
+      width="45rem"
     >
       <Box>
         <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing3}>

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
@@ -115,7 +115,7 @@ export const LiquidsLabwareDetailsModal = (
               )
             })}
           </Flex>
-          <Flex flexDirection={DIRECTION_COLUMN} marginX={SPACING.spacingL}>
+          <Flex flexDirection={DIRECTION_COLUMN} marginLeft={SPACING.spacing4}>
             <Flex flexDirection={DIRECTION_ROW}>
               <Flex flexDirection={DIRECTION_COLUMN}>
                 <StyledText
@@ -133,7 +133,10 @@ export const LiquidsLabwareDetailsModal = (
                   {slotName}
                 </StyledText>
               </Flex>
-              <Flex flexDirection={DIRECTION_COLUMN} marginX={SPACING.spacingL}>
+              <Flex
+                flexDirection={DIRECTION_COLUMN}
+                marginLeft={SPACING.spacing5}
+              >
                 <StyledText
                   as="h6"
                   fontWeight={TYPOGRAPHY.fontWeightRegular}

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
@@ -41,9 +41,6 @@ export const LiquidsLabwareDetailsModal = (
 ): JSX.Element | null => {
   const { liquidId, labwareId, runId, closeModal } = props
   const { t } = useTranslation('protocol_setup')
-  const [selectedValue, setSelectedValue] = React.useState<typeof liquidId>(
-    liquidId
-  )
   const currentLiquidRef = React.useRef<HTMLDivElement>(null)
   const labwareRenderInfo = useLabwareRenderInfoForRunById(runId)[labwareId]
   const commands = useProtocolDetailsForRun(runId).protocolData?.commands
@@ -60,6 +57,12 @@ export const LiquidsLabwareDetailsModal = (
     ?.filter(command => command.commandType === 'loadLabware')
     ?.find(command => command.result.labwareId === labwareId)
   const labwareWellOrdering = loadLabwareCommand?.result.definition.ordering
+  const filteredLiquidsInLoadOrder = liquids.filter(liquid => {
+    return Object.keys(labwareInfo).some(key => key === liquid.liquidId)
+  })
+  const [selectedValue, setSelectedValue] = React.useState<typeof liquidId>(
+    liquidId ?? filteredLiquidsInLoadOrder[0].liquidId
+  )
 
   const scrollToCurrentItem = (): void => {
     currentLiquidRef.current?.scrollIntoView({ behavior: 'smooth' })
@@ -88,24 +91,26 @@ export const LiquidsLabwareDetailsModal = (
             maxHeight={'27.125rem'}
             overflowY={'auto'}
             minWidth={'10.313rem'}
+            gridGap={SPACING.spacing4}
           >
-            {Object.entries(labwareInfo).map((entry, index) => {
-              const liquidInfo = liquids.find(
-                liquid => liquid.liquidId === entry[0]
+            {filteredLiquidsInLoadOrder.map((liquid, index) => {
+              const labwareInfoEntry = Object.entries(labwareInfo).find(
+                entry => entry[0] === liquid.liquidId
               )
+
               return (
-                liquidInfo != null && (
+                labwareInfoEntry != null && (
                   <Flex
                     key={index}
                     ref={
-                      selectedValue === liquidInfo.liquidId
+                      selectedValue === liquid.liquidId
                         ? currentLiquidRef
                         : undefined
                     }
                   >
                     <LiquidDetailCard
-                      {...liquidInfo}
-                      volumeByWell={entry[1][0].volumeByWell}
+                      {...liquid}
+                      volumeByWell={labwareInfoEntry[1][0].volumeByWell}
                       labwareWellOrdering={labwareWellOrdering}
                       setSelectedValue={setSelectedValue}
                       selectedValue={selectedValue}
@@ -115,7 +120,12 @@ export const LiquidsLabwareDetailsModal = (
               )
             })}
           </Flex>
-          <Flex flexDirection={DIRECTION_COLUMN} marginLeft={SPACING.spacing4}>
+          <Flex
+            flexDirection={DIRECTION_COLUMN}
+            width="100%"
+            maxHeight="25rem"
+            marginLeft={SPACING.spacing4}
+          >
             <Flex flexDirection={DIRECTION_ROW}>
               <Flex flexDirection={DIRECTION_COLUMN}>
                 <StyledText
@@ -153,7 +163,7 @@ export const LiquidsLabwareDetailsModal = (
                 </StyledText>
               </Flex>
             </Flex>
-            <Box width={'30.625rem'}>
+            <Flex flex="1 1 30rem" flexDirection={DIRECTION_COLUMN}>
               <svg viewBox="0 -10 130 100" transform="scale(1, -1)">
                 <LabwareRender
                   definition={labwareRenderInfo.labwareDef}
@@ -166,7 +176,7 @@ export const LiquidsLabwareDetailsModal = (
                   }
                 />
               </svg>
-            </Box>
+            </Flex>
           </Flex>
         </Flex>
       </Box>

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
@@ -7,10 +7,10 @@ import {
 } from '@opentrons/api-client'
 import {
   Box,
+  Flex,
   COLORS,
   DIRECTION_COLUMN,
   DIRECTION_ROW,
-  Flex,
   SPACING,
   TYPOGRAPHY,
   LabwareRender,
@@ -44,6 +44,7 @@ export const LiquidsLabwareDetailsModal = (
   const [selectedValue, setSelectedValue] = React.useState<typeof liquidId>(
     liquidId
   )
+  const currentLiquidRef = React.useRef<HTMLDivElement>(null)
   const labwareRenderInfo = useLabwareRenderInfoForRunById(runId)[labwareId]
   const commands = useProtocolDetailsForRun(runId).protocolData?.commands
   const liquids = parseLiquidsInLoadOrder()
@@ -60,6 +61,12 @@ export const LiquidsLabwareDetailsModal = (
     ?.find(command => command.result.labwareId === labwareId)
   const labwareWellOrdering = loadLabwareCommand?.result.definition.ordering
 
+  const scrollToCurrentItem = (): void => {
+    currentLiquidRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }
+  React.useEffect(() => {
+    scrollToCurrentItem()
+  }, [])
   const HIDE_SCROLLBAR = css`
     ::-webkit-scrollbar {
       display: none;
@@ -88,14 +95,22 @@ export const LiquidsLabwareDetailsModal = (
               )
               return (
                 liquidInfo != null && (
-                  <LiquidDetailCard
+                  <Flex
                     key={index}
-                    {...liquidInfo}
-                    volumeByWell={entry[1][0].volumeByWell}
-                    labwareWellOrdering={labwareWellOrdering}
-                    setSelectedValue={setSelectedValue}
-                    selectedValue={selectedValue}
-                  />
+                    ref={
+                      selectedValue === liquidInfo.liquidId
+                        ? currentLiquidRef
+                        : undefined
+                    }
+                  >
+                    <LiquidDetailCard
+                      {...liquidInfo}
+                      volumeByWell={entry[1][0].volumeByWell}
+                      labwareWellOrdering={labwareWellOrdering}
+                      setSelectedValue={setSelectedValue}
+                      selectedValue={selectedValue}
+                    />
+                  </Flex>
                 )
               )
             })}

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
@@ -133,7 +133,7 @@ export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
             flexDirection={DIRECTION_ROW}
             justifyContent={JUSTIFY_FLEX_START}
             gridGap={SPACING.spacing4}
-            marginTop={SPACING.spacing4}
+            marginY={SPACING.spacing4}
           >
             <StyledText
               as="p"
@@ -170,7 +170,7 @@ export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
                 css={LIQUID_CARD_ITEM_STYLE}
                 key={index}
                 borderRadius={'4px'}
-                marginY={SPACING.spacing3}
+                marginBottom={SPACING.spacing3}
                 padding={SPACING.spacing4}
                 backgroundColor={COLORS.white}
                 data-testid={`LiquidsListItem_slotRow_${index}`}

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
@@ -133,10 +133,11 @@ export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
             flexDirection={DIRECTION_ROW}
             justifyContent={JUSTIFY_FLEX_START}
             gridGap={SPACING.spacing4}
-            marginY={SPACING.spacing4}
+            marginTop={SPACING.spacing4}
+            marginBottom={SPACING.spacing3}
           >
             <StyledText
-              as="p"
+              as="label"
               fontWeight={TYPOGRAPHY.fontWeightSemiBold}
               marginLeft={SPACING.spacing4}
               width="8.125rem"
@@ -144,14 +145,14 @@ export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
               {t('location')}
             </StyledText>
             <StyledText
-              as="p"
+              as="label"
               fontWeight={TYPOGRAPHY.fontWeightSemiBold}
               marginRight={SPACING.spacing6}
             >
               {t('labware_name')}
             </StyledText>
             <StyledText
-              as="p"
+              as="label"
               fontWeight={TYPOGRAPHY.fontWeightSemiBold}
               width="4.25rem"
               marginLeft="auto"

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
@@ -154,7 +154,6 @@ export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
               as="p"
               fontWeight={TYPOGRAPHY.fontWeightSemiBold}
               width="4.25rem"
-              flexShrink="0"
               marginLeft="auto"
               marginRight={SPACING.spacing4}
             >
@@ -198,7 +197,6 @@ export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
                     as="p"
                     fontWeight={TYPOGRAPHY.fontWeightRegular}
                     minWidth="4.25rem"
-                    flexShrink="0"
                     marginLeft="auto"
                   >
                     {getTotalVolumePerLiquidLabwarePair(

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
@@ -54,6 +54,7 @@ export function SetupLiquidsList(props: SetupLiquidsListProps): JSX.Element {
       maxHeight={'31.25rem'}
       overflowY={'auto'}
       data-testid={'SetupLiquidsList_ListView'}
+      gridGap={SPACING.spacing3}
     >
       {liquidsInLoadOrder?.map(liquid => (
         <LiquidsListItem
@@ -91,23 +92,21 @@ export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
     ${BORDERS.cardOutlineBorder}
 
     &:hover {
-      background-color: ${COLORS.background};
+      cursor: pointer;
       border: 1px solid ${COLORS.medGreyHover};
     }
   `
   const LIQUID_CARD_ITEM_STYLE = css`
-    ${BORDERS.cardOutlineBorder}
-
+    border: 1px solid ${COLORS.white};
     &:hover {
       cursor: pointer;
-      border: 1px solid ${COLORS.medGreyHover};
+      ${BORDERS.cardOutlineBorder}
     }
   `
 
   return (
     <Box
       css={LIQUID_CARD_STYLE}
-      marginBottom={SPACING.spacing3}
       padding={SPACING.spacing4}
       onClick={() => setOpenItem(!openItem)}
       backgroundColor={openItem ? COLORS.lightGrey : COLORS.white}
@@ -186,7 +185,7 @@ export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
                   <StyledText
                     as="p"
                     fontWeight={TYPOGRAPHY.fontWeightRegular}
-                    width="8.125rem"
+                    minWidth="8.125rem"
                   >
                     {t('slot_location', {
                       slotName: slotName,
@@ -198,7 +197,7 @@ export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
                   <StyledText
                     as="p"
                     fontWeight={TYPOGRAPHY.fontWeightRegular}
-                    width="4.25rem"
+                    minWidth="4.25rem"
                     flexShrink="0"
                     marginLeft="auto"
                   >

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
@@ -19,7 +19,6 @@ import {
   BORDERS,
   ALIGN_CENTER,
   SIZE_AUTO,
-  JUSTIFY_SPACE_BETWEEN,
   Box,
   JUSTIFY_FLEX_START,
 } from '@opentrons/components'

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
@@ -21,6 +21,7 @@ import {
   SIZE_AUTO,
   JUSTIFY_SPACE_BETWEEN,
   Box,
+  JUSTIFY_FLEX_START,
 } from '@opentrons/components'
 import { MICRO_LITERS } from '@opentrons/shared-data'
 import { useProtocolDetailsForRun } from '../../../Devices/hooks'
@@ -132,13 +133,15 @@ export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
         <Flex flexDirection={DIRECTION_COLUMN}>
           <Flex
             flexDirection={DIRECTION_ROW}
-            justifyContent={JUSTIFY_SPACE_BETWEEN}
+            justifyContent={JUSTIFY_FLEX_START}
+            gridGap={SPACING.spacing4}
             marginTop={SPACING.spacing4}
           >
             <StyledText
               as="p"
               fontWeight={TYPOGRAPHY.fontWeightSemiBold}
               marginLeft={SPACING.spacing4}
+              width="8.125rem"
             >
               {t('location')}
             </StyledText>
@@ -152,6 +155,9 @@ export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
             <StyledText
               as="p"
               fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+              width="4.25rem"
+              flexShrink="0"
+              marginLeft="auto"
               marginRight={SPACING.spacing4}
             >
               {t('volume')}
@@ -175,9 +181,14 @@ export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
               >
                 <Flex
                   flexDirection={DIRECTION_ROW}
-                  justifyContent={JUSTIFY_SPACE_BETWEEN}
+                  justifyContent={JUSTIFY_FLEX_START}
+                  gridGap={SPACING.spacing4}
                 >
-                  <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightRegular}>
+                  <StyledText
+                    as="p"
+                    fontWeight={TYPOGRAPHY.fontWeightRegular}
+                    width="8.125rem"
+                  >
                     {t('slot_location', {
                       slotName: slotName,
                     })}
@@ -185,7 +196,13 @@ export function LiquidsListItem(props: LiquidsListItemProps): JSX.Element {
                   <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightRegular}>
                     {labwareName}
                   </StyledText>
-                  <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightRegular}>
+                  <StyledText
+                    as="p"
+                    fontWeight={TYPOGRAPHY.fontWeightRegular}
+                    width="4.25rem"
+                    flexShrink="0"
+                    marginLeft="auto"
+                  >
                     {getTotalVolumePerLiquidLabwarePair(
                       liquidId,
                       labware.labwareId,

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsMap.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsMap.tsx
@@ -11,6 +11,8 @@ import {
   RobotWorkSpace,
   LabwareRender,
   Module,
+  ALIGN_CENTER,
+  JUSTIFY_CENTER,
 } from '@opentrons/components'
 import {
   inferModuleOrientationFromXCoordinate,
@@ -58,7 +60,13 @@ export function SetupLiquidsMap(props: SetupLiquidsMapProps): JSX.Element {
   >(null)
 
   return (
-    <Flex flex="1" maxHeight="180vh" flexDirection={DIRECTION_COLUMN}>
+    <Flex
+      flex="1"
+      maxHeight="80vh"
+      flexDirection={DIRECTION_COLUMN}
+      alignItems={ALIGN_CENTER}
+      justifyContent={JUSTIFY_CENTER}
+    >
       <RobotWorkSpace
         deckDef={(standardDeckDef as unknown) as DeckDefinition}
         viewBox={DECK_MAP_VIEWBOX}

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/LiquidsLabwareDetailsModal.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/LiquidsLabwareDetailsModal.test.tsx
@@ -67,6 +67,7 @@ const render = (
 describe('LiquidsLabwareDetailsModal', () => {
   let props: React.ComponentProps<typeof LiquidsLabwareDetailsModal>
   beforeEach(() => {
+    window.HTMLElement.prototype.scrollIntoView = function () {}
     props = {
       liquidId: '4',
       labwareId: '123',

--- a/components/src/hardware-sim/Labware/LabwareRender.css
+++ b/components/src/hardware-sim/Labware/LabwareRender.css
@@ -1,7 +1,7 @@
 @import '../..';
 
 .highlighted_well {
-  filter: drop-shadow(0 0 1.5px rgba(0, 108, 250, 1));
+  filter: drop-shadow(0 0 1.8px rgba(0, 108, 250, 1));
 }
 
 .selected_well {

--- a/components/src/hardware-sim/Labware/LabwareRender.css
+++ b/components/src/hardware-sim/Labware/LabwareRender.css
@@ -1,10 +1,7 @@
 @import '../..';
 
 .highlighted_well {
-  stroke: var(--c-black);
-  stroke-width: 0.5px;
-  fill: color-mod(var(--c-highlight) alpha(10%));
-  filter: drop-shadow(0 0 1px rgba(0, 108, 250, 1));
+  filter: drop-shadow(0 0 1.5px rgba(0, 108, 250, 1));
 }
 
 .selected_well {

--- a/components/src/hardware-sim/Labware/LabwareRender.css
+++ b/components/src/hardware-sim/Labware/LabwareRender.css
@@ -1,8 +1,10 @@
 @import '../..';
 
 .highlighted_well {
-  stroke: var(--c-highlight);
-  fill: color-mod(var(--c-highlight) alpha(20%));
+  stroke: var(--c-black);
+  stroke-width: 0.5px;
+  fill: color-mod(var(--c-highlight) alpha(10%));
+  filter: drop-shadow(0 0 1px rgba(0, 108, 250, 1));
 }
 
 .selected_well {

--- a/components/src/hardware-sim/Labware/LabwareRender.tsx
+++ b/components/src/hardware-sim/Labware/LabwareRender.tsx
@@ -78,17 +78,17 @@ export const LabwareRender = (props: LabwareRenderProps): JSX.Element => {
           strokeByWell={props.wellStroke}
         />
       )}
-      {props.wellFill && (
-        <FilledWells
-          definition={props.definition}
-          fillByWell={props.wellFill}
-        />
-      )}
       {props.highlightedWells && (
         <StyledWells
           className={styles.highlighted_well}
           definition={props.definition}
           wells={props.highlightedWells}
+        />
+      )}
+      {props.wellFill && (
+        <FilledWells
+          definition={props.definition}
+          fillByWell={props.wellFill}
         />
       )}
       {props.selectedWells && (

--- a/components/src/modals/BaseModal.tsx
+++ b/components/src/modals/BaseModal.tsx
@@ -96,6 +96,7 @@ export function BaseModal(props: BaseModalProps): JSX.Element {
       bottom="0"
       zIndex="1"
       backgroundColor={overlayColor}
+      cursor="default"
       onClick={e => {
         e.stopPropagation()
         if (onOutsideClick) onOutsideClick(e)


### PR DESCRIPTION
fix #11037

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
A few UI fixes on liquid setup to align with the Figma designs

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

1.  Align labware name column in liquids list view
2.  Adjust flex shrink on total volume so it doesn't shrink when window does
3.  Modal should scroll to highlighted liquid card on open
4.  Match Figma for well highlight styling
5. # Review requests

<!--
Describe any requests for your reviewers here.
-->
Look over changes, let me know if anything else needs to be fixed!
# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Low