### PR TITLE
fix(app): no longer require app restart after python override path config is updated

### DIFF
--- a/app-shell/src/protocol-analysis/__tests__/protocolAnalysis.test.ts
+++ b/app-shell/src/protocol-analysis/__tests__/protocolAnalysis.test.ts
@@ -1,6 +1,6 @@
 import { when, resetAllWhenMocks } from 'jest-when'
 
-import { Config, getConfig } from '../../config'
+import { Config, getConfig, handleConfigChange } from '../../config'
 import { getValidLabwareFilePaths } from '../../labware'
 import { selectPythonPath, getPythonPath } from '../getPythonPath'
 import { executeAnalyzeCli } from '../executeAnalyzeCli'
@@ -29,6 +29,9 @@ const mockWriteFailedAnalysis = writeFailedAnalysis as jest.MockedFunction<
 const mockGetValidLabwareFilePaths = getValidLabwareFilePaths as jest.MockedFunction<
   typeof getValidLabwareFilePaths
 >
+const mockHandleConfigChange = handleConfigChange as jest.MockedFunction<
+  typeof handleConfigChange
+>
 
 describe('analyzeProtocolSource', () => {
   afterEach(() => {
@@ -45,6 +48,13 @@ describe('analyzeProtocolSource', () => {
     initializePython()
 
     expect(mockSelectPythonPath).toHaveBeenCalledWith('/some/override/python')
+
+    // the 'python.pathToPythonOverride' change handler
+    const changeHandler = mockHandleConfigChange.mock.calls[0][1]
+    const otherOverridePath = '/some/other/path/to/python'
+    changeHandler(otherOverridePath, '/some/override/python')
+
+    expect(mockSelectPythonPath).toHaveBeenCalledWith(otherOverridePath)
   })
 
   it('should get the Python path and execute the analyze CLI with custom labware', () => {

--- a/app-shell/src/protocol-analysis/__tests__/protocolAnalysis.test.ts
+++ b/app-shell/src/protocol-analysis/__tests__/protocolAnalysis.test.ts
@@ -48,13 +48,15 @@ describe('analyzeProtocolSource', () => {
     initializePython()
 
     expect(mockSelectPythonPath).toHaveBeenCalledWith('/some/override/python')
+    expect(mockHandleConfigChange).toHaveBeenCalledWith(
+      'python.pathToPythonOverride',
+      expect.any(Function)
+    )
 
     // the 'python.pathToPythonOverride' change handler
     const changeHandler = mockHandleConfigChange.mock.calls[0][1]
-    const otherOverridePath = '/some/other/path/to/python'
-    changeHandler(otherOverridePath, '/some/override/python')
-
-    expect(mockSelectPythonPath).toHaveBeenCalledWith(otherOverridePath)
+    changeHandler('/new/override/python', '/old/path/does/not/matter')
+    expect(mockSelectPythonPath).toHaveBeenCalledWith('/new/override/python')
   })
 
   it('should get the Python path and execute the analyze CLI with custom labware', () => {

--- a/app-shell/src/protocol-analysis/index.ts
+++ b/app-shell/src/protocol-analysis/index.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '../log'
-import { getConfig } from '../config'
+import { getConfig, handleConfigChange } from '../config'
 
 import { getValidLabwareFilePaths } from '../labware'
 import { selectPythonPath, getPythonPath } from './getPythonPath'
@@ -11,6 +11,10 @@ const log = createLogger('protocol-analysis')
 export function initializePython(): void {
   const pathToPythonOverride = getConfig().python.pathToPythonOverride
   selectPythonPath(pathToPythonOverride)
+
+  handleConfigChange('python.pathToPythonOverride', newValue => {
+    selectPythonPath(newValue)
+  })
 }
 
 export function analyzeProtocolSource(


### PR DESCRIPTION
# Overview

Instead of requiring the app to restart in order to incorporate a new pathToPythonOverride config
value, handle the config change on the fly

Closes #10612

# Review requests

- Change the value of the `pathToPythonOverride` advanced app setting on the build of this branch. Your change should be incorporated without requiring the app to be restarted.  Uploading a new protocol is a good way to test calling into the python interpreter before and after. 

# Risk assessment
low
