### PR TITLE
fix(app): disable protocol runs when robot update available

### DIFF
--- a/app/src/assets/localization/en/shared.json
+++ b/app/src/assets/localization/en/shared.json
@@ -33,5 +33,6 @@
   "robot_is_reachable_but_not_responding": "This robot's API server is not responding correctly to requests at IP address {{hostname}}",
   "robot_was_seen_but_is_unreachable": "This robot has been seen recently, but is currently not reachable at IP address {{hostname}}",
   "protocol_run_general_error_msg": "Protocol run could not be created on the robot.",
-  "proceed_to_setup": "Proceed to setup"
+  "proceed_to_setup": "Proceed to setup",
+  "a_software_update_is_available": "A software update is available for this robot. Update to run protocols."
 }

--- a/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
@@ -12,13 +12,13 @@ import {
   COLORS,
   useOnClickOutside,
   useHoverTooltip,
-  Tooltip,
 } from '@opentrons/components'
 import {
   useDeleteRunMutation,
   useAllCommandsQuery,
 } from '@opentrons/react-api-client'
 import { Divider } from '../../atoms/structure'
+import { Tooltip } from '../../atoms/Tooltip'
 import { OverflowBtn } from '../../atoms/MenuList/OverflowBtn'
 import { MenuItem } from '../../atoms/MenuList/MenuItem'
 import { useRunControls } from '../RunTimeControl/hooks'
@@ -172,7 +172,7 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
         {t('rerun_now')}
       </MenuItem>
       {isRobotOnWrongVersionOfSoftware && (
-        <Tooltip {...tooltipProps}>
+        <Tooltip tooltipProps={tooltipProps}>
           {t('shared:a_software_update_is_available')}
         </Tooltip>
       )}

--- a/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 import { NavLink, useHistory } from 'react-router-dom'
 import {
@@ -10,6 +11,8 @@ import {
   POSITION_RELATIVE,
   COLORS,
   useOnClickOutside,
+  useHoverTooltip,
+  Tooltip,
 } from '@opentrons/components'
 import {
   useDeleteRunMutation,
@@ -22,7 +25,10 @@ import { useRunControls } from '../RunTimeControl/hooks'
 import { RUN_LOG_WINDOW_SIZE } from './constants'
 import { DownloadRunLogToast } from './DownloadRunLogToast'
 import { useTrackProtocolRunEvent } from './hooks'
+import { getBuildrootUpdateDisplayInfo } from '../../redux/buildroot'
+
 import type { Run } from '@opentrons/api-client'
+import type { State } from '../../redux/types'
 
 export interface HistoricalProtocolRunOverflowMenuProps {
   runId: string
@@ -101,7 +107,12 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
     closeOverflowMenu,
     setShowDownloadRunLogToast,
   } = props
-
+  const isRobotOnWrongVersionOfSoftware = ['upgrade', 'downgrade'].includes(
+    useSelector((state: State) => {
+      return getBuildrootUpdateDisplayInfo(state, robotName)
+    })?.autoUpdateAction
+  )
+  const [targetProps, tooltipProps] = useHoverTooltip()
   const onResetSuccess = (createRunResponse: Run): void =>
     history.push(
       `/devices/${robotName}/protocol-runs/${createRunResponse.data.id}/run-log`
@@ -153,12 +164,18 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
         </MenuItem>
       </NavLink>
       <MenuItem
+        {...targetProps}
         onClick={handleResetClick}
-        disabled={robotIsBusy}
+        disabled={robotIsBusy || isRobotOnWrongVersionOfSoftware}
         data-testid={`RecentProtocolRun_OverflowMenu_rerunNow`}
       >
         {t('rerun_now')}
       </MenuItem>
+      {isRobotOnWrongVersionOfSoftware && (
+        <Tooltip {...tooltipProps}>
+          {t('shared:a_software_update_is_available')}
+        </Tooltip>
+      )}
       <MenuItem
         data-testid={`RecentProtocolRun_OverflowMenu_downloadRunLog`}
         onClick={onDownloadClick}

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -47,6 +47,7 @@ import {
   useConditionalConfirm,
 } from '@opentrons/components'
 
+import { getBuildrootUpdateDisplayInfo } from '../../../redux/buildroot'
 import { ProtocolAnalysisErrorBanner } from './ProtocolAnalysisErrorBanner'
 import { ProtocolAnalysisErrorModal } from './ProtocolAnalysisErrorModal'
 import { Banner } from '../../../atoms/Banner'
@@ -82,6 +83,7 @@ import { formatTimestamp } from '../utils'
 import { EMPTY_TIMESTAMP } from '../constants'
 
 import type { Run } from '@opentrons/api-client'
+import type { State } from '../../../redux/types'
 import type { HeaterShakerModule } from '../../../redux/modules/types'
 
 const EQUIPMENT_POLL_MS = 5000
@@ -276,6 +278,11 @@ export function ProtocolRunHeader({
     trackProtocolRunEvent({ name: 'runAgain' })
   }
 
+  const isRobotOnWrongVersionOfSoftware = ['upgrade', 'downgrade'].includes(
+    useSelector((state: State) => {
+      return getBuildrootUpdateDisplayInfo(state, robotName)
+    })?.autoUpdateAction
+  )
   const isRunControlButtonDisabled =
     (isCurrentRun && !isSetupComplete) ||
     isMutationLoading ||
@@ -284,7 +291,8 @@ export function ProtocolRunHeader({
     runStatus === RUN_STATUS_FINISHING ||
     runStatus === RUN_STATUS_PAUSE_REQUESTED ||
     runStatus === RUN_STATUS_STOP_REQUESTED ||
-    runStatus === RUN_STATUS_BLOCKED_BY_OPEN_DOOR
+    runStatus === RUN_STATUS_BLOCKED_BY_OPEN_DOOR ||
+    isRobotOnWrongVersionOfSoftware
 
   let handleButtonClick = (): void => {}
   let buttonIconName: IconName | null = null
@@ -330,6 +338,8 @@ export function ProtocolRunHeader({
     disableReason = t('setup_incomplete')
   } else if (isRobotBusy) {
     disableReason = t('robot_is_busy')
+  } else if (isRobotOnWrongVersionOfSoftware) {
+    disableReason = t('shared:a_software_update_is_available')
   }
 
   const buttonIcon =

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -26,7 +26,6 @@ import {
   Flex,
   Icon,
   IconName,
-  Tooltip,
   useHoverTooltip,
   useInterval,
   ALIGN_CENTER,
@@ -55,6 +54,7 @@ import { PrimaryButton, SecondaryButton } from '../../../atoms/buttons'
 import { useTrackEvent } from '../../../redux/analytics'
 import { getIsHeaterShakerAttached } from '../../../redux/config'
 import { StyledText } from '../../../atoms/text'
+import { Tooltip } from '../../../atoms/Tooltip'
 import {
   useCloseCurrentRun,
   useCurrentRunId,
@@ -623,7 +623,7 @@ export function ProtocolRunHeader({
             <StyledText css={TYPOGRAPHY.pSemiBold}>{buttonText}</StyledText>
           </PrimaryButton>
           {disableReason != null && (
-            <Tooltip {...tooltipProps}>{disableReason}</Tooltip>
+            <Tooltip tooltipProps={tooltipProps}>{disableReason}</Tooltip>
           )}
         </Flex>
       </Flex>

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -46,6 +46,7 @@ import {
 } from '../../../../organisms/RunTimeControl/__fixtures__'
 import { mockHeaterShaker } from '../../../../redux/modules/__fixtures__'
 import { useTrackEvent } from '../../../../redux/analytics'
+import { getBuildrootUpdateDisplayInfo } from '../../../../redux/buildroot'
 import { getIsHeaterShakerAttached } from '../../../../redux/config'
 
 import {
@@ -93,6 +94,7 @@ jest.mock('../../../ModuleCard/ConfirmAttachmentModal')
 jest.mock('../../../ModuleCard/hooks')
 jest.mock('../../../../redux/analytics')
 jest.mock('../../../../redux/config')
+jest.mock('../../../../redux/buildroot/selectors')
 
 const mockGetIsHeaterShakerAttached = getIsHeaterShakerAttached as jest.MockedFunction<
   typeof getIsHeaterShakerAttached
@@ -157,6 +159,9 @@ const mockUseTrackEvent = useTrackEvent as jest.MockedFunction<
 >
 const mockUseIsRobotViewable = useIsRobotViewable as jest.MockedFunction<
   typeof useIsRobotViewable
+>
+const mockGetBuildrootUpdateDisplayInfo = getBuildrootUpdateDisplayInfo as jest.MockedFunction<
+  typeof getBuildrootUpdateDisplayInfo
 >
 
 const ROBOT_NAME = 'otie'
@@ -245,6 +250,11 @@ describe('ProtocolRunHeader', () => {
       analysisErrors: null,
     })
     mockUseIsHeaterShakerInProtocol.mockReturnValue(false)
+    mockGetBuildrootUpdateDisplayInfo.mockReturnValue({
+      autoUpdateAction: 'reinstall',
+      autoUpdateDisabledReason: null,
+      updateFromFileDisabledReason: null,
+    })
     when(mockUseCurrentRunId).calledWith().mockReturnValue(RUN_ID)
     when(mockUseCloseCurrentRun).calledWith().mockReturnValue({
       isClosingCurrentRun: false,
@@ -407,6 +417,19 @@ describe('ProtocolRunHeader', () => {
     const button = getByRole('button', { name: 'Start run' })
     expect(button).toBeDisabled()
     getByText('Complete required steps in Setup tab')
+  })
+
+  it('disables the Start Run button with tooltip if robot software update is available', () => {
+    mockGetBuildrootUpdateDisplayInfo.mockReturnValue({
+      autoUpdateAction: 'upgrade',
+      autoUpdateDisabledReason: null,
+      updateFromFileDisabledReason: null,
+    })
+
+    const [{ getByRole, getByText }] = render()
+    const button = getByRole('button', { name: 'Start run' })
+    expect(button).toBeDisabled()
+    getByText('A software update is available for this robot. Update to run protocols.')
   })
 
   it('renders a pause run button, start time, and end time when run is running, and calls trackProtocolRunEvent when button clicked', () => {

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -429,7 +429,9 @@ describe('ProtocolRunHeader', () => {
     const [{ getByRole, getByText }] = render()
     const button = getByRole('button', { name: 'Start run' })
     expect(button).toBeDisabled()
-    getByText('A software update is available for this robot. Update to run protocols.')
+    getByText(
+      'A software update is available for this robot. Update to run protocols.'
+    )
   })
 
   it('renders a pause run button, start time, and end time when run is running, and calls trackProtocolRunEvent when button clicked', () => {

--- a/app/src/organisms/Devices/RobotOverflowMenu.tsx
+++ b/app/src/organisms/Devices/RobotOverflowMenu.tsx
@@ -12,12 +12,12 @@ import {
   ALIGN_FLEX_END,
   TEXT_TRANSFORM_CAPITALIZE,
   useHoverTooltip,
-  Tooltip,
 } from '@opentrons/components'
 
 import { CONNECTABLE, removeRobot } from '../../redux/discovery'
 import { getBuildrootUpdateDisplayInfo } from '../../redux/buildroot'
 import { OverflowBtn } from '../../atoms/MenuList/OverflowBtn'
+import { Tooltip } from '../../atoms/Tooltip'
 import { Divider } from '../../atoms/structure'
 import { MenuItem } from '../../atoms/MenuList/MenuItem'
 import { Portal } from '../../App/portal'
@@ -86,7 +86,7 @@ export function RobotOverflowMenu(props: RobotOverflowMenuProps): JSX.Element {
           {t('run_a_protocol')}
         </MenuItem>
         {isRobotOnWrongVersionOfSoftware && (
-          <Tooltip {...tooltipProps}>
+          <Tooltip tooltipProps={tooltipProps}>
             {t('shared:a_software_update_is_available')}
           </Tooltip>
         )}

--- a/app/src/organisms/Devices/RobotOverview.tsx
+++ b/app/src/organisms/Devices/RobotOverview.tsx
@@ -20,11 +20,11 @@ import {
   POSITION_ABSOLUTE,
   POSITION_RELATIVE,
   useHoverTooltip,
-  Tooltip,
 } from '@opentrons/components'
 
 import OT2_PNG from '../../assets/images/OT2-R_HERO.png'
 import { ToggleButton, PrimaryButton } from '../../atoms/buttons'
+import { Tooltip } from '../../atoms/Tooltip'
 import { StyledText } from '../../atoms/text'
 import { useDispatchApiRequest } from '../../redux/robot-api'
 import { fetchLights } from '../../redux/robot-controls'
@@ -142,7 +142,7 @@ export function RobotOverview({
             {t('run_a_protocol')}
           </PrimaryButton>
           {isRobotOnWrongVersionOfSoftware && (
-            <Tooltip {...tooltipProps}>
+            <Tooltip tooltipProps={tooltipProps}>
               {t('shared:a_software_update_is_available')}
             </Tooltip>
           )}

--- a/app/src/organisms/Devices/RobotOverview.tsx
+++ b/app/src/organisms/Devices/RobotOverview.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -18,6 +19,8 @@ import {
   TEXT_TRANSFORM_UPPERCASE,
   POSITION_ABSOLUTE,
   POSITION_RELATIVE,
+  useHoverTooltip,
+  Tooltip,
 } from '@opentrons/components'
 
 import OT2_PNG from '../../assets/images/OT2-R_HERO.png'
@@ -34,6 +37,9 @@ import { RobotStatusBanner } from './RobotStatusBanner'
 import { ReachableBanner } from './ReachableBanner'
 import { RobotOverviewOverflowMenu } from './RobotOverviewOverflowMenu'
 import { useLights, useRobot, useRunStatuses } from './hooks'
+import { getBuildrootUpdateDisplayInfo } from '../../redux/buildroot'
+
+import type { State } from '../../redux/types'
 
 const EQUIPMENT_POLL_MS = 5000
 
@@ -45,7 +51,13 @@ export function RobotOverview({
   robotName,
 }: RobotOverviewProps): JSX.Element | null {
   const { t } = useTranslation(['device_details', 'shared'])
+  const [targetProps, tooltipProps] = useHoverTooltip()
   const [dispatchRequest] = useDispatchApiRequest()
+  const isRobotOnWrongVersionOfSoftware = ['upgrade', 'downgrade'].includes(
+    useSelector((state: State) => {
+      return getBuildrootUpdateDisplayInfo(state, robotName)
+    })?.autoUpdateAction
+  )
 
   const robot = useRobot(robotName)
   const [
@@ -116,10 +128,12 @@ export function RobotOverview({
             </Flex>
           </Flex>
           <PrimaryButton
+            {...targetProps}
             textTransform={TEXT_TRANSFORM_NONE}
             disabled={
               (currentRunId != null ? !isRunTerminal : false) ||
-              robot.status !== CONNECTABLE
+              robot.status !== CONNECTABLE ||
+              isRobotOnWrongVersionOfSoftware
             }
             onClick={() => {
               setShowChooseProtocolSlideout(true)
@@ -127,6 +141,11 @@ export function RobotOverview({
           >
             {t('run_a_protocol')}
           </PrimaryButton>
+          {isRobotOnWrongVersionOfSoftware && (
+            <Tooltip {...tooltipProps}>
+              {t('shared:a_software_update_is_available')}
+            </Tooltip>
+          )}
           {robot.status === CONNECTABLE ? (
             <Portal level="top">
               <ChooseProtocolSlideout

--- a/app/src/organisms/Devices/__tests__/RobotCard.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotCard.test.tsx
@@ -13,6 +13,7 @@ import {
   mockRightProtoPipette,
 } from '../../../redux/pipettes/__fixtures__'
 import { mockConnectableRobot } from '../../../redux/discovery/__fixtures__'
+import { getBuildrootUpdateDisplayInfo } from '../../../redux/buildroot'
 import {
   useAttachedModules,
   useAttachedPipettes,
@@ -26,6 +27,7 @@ import { RobotCard } from '../RobotCard'
 
 import type { ProtocolAnalysisFile } from '@opentrons/shared-data'
 
+jest.mock('../../../redux/buildroot/selectors')
 jest.mock('../../../organisms/ProtocolUpload/hooks')
 jest.mock('../../../organisms/RunTimeControl/hooks')
 jest.mock('../../ProtocolUpload/hooks')
@@ -55,6 +57,9 @@ const mockChooseProtocolSlideout = ChooseProtocolSlideout as jest.MockedFunction
 >
 const mockUpdateRobotBanner = UpdateRobotBanner as jest.MockedFunction<
   typeof UpdateRobotBanner
+>
+const mockGetBuildrootUpdateDisplayInfo = getBuildrootUpdateDisplayInfo as jest.MockedFunction<
+  typeof getBuildrootUpdateDisplayInfo
 >
 
 const simpleV6Protocol = (_uncastedSimpleV6Protocol as unknown) as ProtocolAnalysisFile<{}>
@@ -90,6 +95,11 @@ describe('RobotCard', () => {
       </div>
     ))
     mockUpdateRobotBanner.mockReturnValue(<div>Mock UpdateRobotBanner</div>)
+    mockGetBuildrootUpdateDisplayInfo.mockReturnValue({
+      autoUpdateAction: 'reinstall',
+      autoUpdateDisabledReason: null,
+      updateFromFileDisabledReason: null,
+    })
     when(mockUseCurrentRunId).calledWith().mockReturnValue(null)
     when(mockUseCurrentRunStatus).calledWith().mockReturnValue(null)
     when(mockUseProtocolDetailsForRun)

--- a/app/src/organisms/Devices/__tests__/RobotOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotOverflowMenu.test.tsx
@@ -8,12 +8,14 @@ import { useCurrentRunId } from '../../ProtocolUpload/hooks'
 import { ChooseProtocolSlideout } from '../../ChooseProtocolSlideout'
 import { ConnectionTroubleshootingModal } from '../ConnectionTroubleshootingModal'
 import { RobotOverflowMenu } from '../RobotOverflowMenu'
+import { getBuildrootUpdateDisplayInfo } from '../../../redux/buildroot'
 
 import {
   mockUnreachableRobot,
   mockConnectedRobot,
 } from '../../../redux/discovery/__fixtures__'
 
+jest.mock('../../../redux/buildroot/selectors')
 jest.mock('../../ProtocolUpload/hooks')
 jest.mock('../../ChooseProtocolSlideout')
 jest.mock('../ConnectionTroubleshootingModal')
@@ -26,6 +28,9 @@ const mockChooseProtocolSlideout = ChooseProtocolSlideout as jest.MockedFunction
 >
 const mockConnectionTroubleshootingModal = ConnectionTroubleshootingModal as jest.MockedFunction<
   typeof ConnectionTroubleshootingModal
+>
+const mockGetBuildrootUpdateDisplayInfo = getBuildrootUpdateDisplayInfo as jest.MockedFunction<
+  typeof getBuildrootUpdateDisplayInfo
 >
 
 const render = (props: React.ComponentProps<typeof RobotOverflowMenu>) => {
@@ -50,6 +55,11 @@ describe('RobotOverflowMenu', () => {
     mockChooseProtocolSlideout.mockReturnValue(
       <div>choose protocol slideout</div>
     )
+    mockGetBuildrootUpdateDisplayInfo.mockReturnValue({
+      autoUpdateAction: 'reinstall',
+      autoUpdateDisabledReason: null,
+      updateFromFileDisabledReason: null,
+    })
   })
   afterEach(() => {
     jest.resetAllMocks()
@@ -89,5 +99,19 @@ describe('RobotOverflowMenu', () => {
     getByText('Forget unavailable robot')
     fireEvent.click(why)
     getByText('mock troubleshooting modal')
+  })
+
+  it('disables the run a protocol menu item if robot software update is available', () => {
+    mockUseCurrentRunId.mockReturnValue(null)
+    mockGetBuildrootUpdateDisplayInfo.mockReturnValue({
+      autoUpdateAction: 'upgrade',
+      autoUpdateDisabledReason: null,
+      updateFromFileDisabledReason: null,
+    })
+    const { getByText, getByLabelText } = render(props)
+    const btn = getByLabelText('RobotOverflowMenu_button')
+    fireEvent.click(btn)
+    const run = getByText('Run a protocol')
+    expect(run).toBeDisabled()
   })
 })

--- a/app/src/organisms/Devices/__tests__/RobotOverview.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotOverview.test.tsx
@@ -9,6 +9,7 @@ import { useCurrentRunId } from '../../ProtocolUpload/hooks'
 import { ChooseProtocolSlideout } from '../../ChooseProtocolSlideout'
 import { mockConnectableRobot } from '../../../redux/discovery/__fixtures__'
 import { useDispatchApiRequest } from '../../../redux/robot-api'
+import { getBuildrootUpdateDisplayInfo } from '../../../redux/buildroot'
 import { fetchLights } from '../../../redux/robot-controls'
 import { useLights, useRobot, useRunStatuses } from '../hooks'
 import { UpdateRobotBanner } from '../../UpdateRobotBanner'
@@ -20,6 +21,7 @@ import type { DispatchApiRequestType } from '../../../redux/robot-api'
 
 jest.mock('../../../redux/robot-api')
 jest.mock('../../../redux/robot-controls')
+jest.mock('../../../redux/buildroot/selectors')
 jest.mock('../../ProtocolUpload/hooks')
 jest.mock('../hooks')
 jest.mock('../RobotStatusBanner')
@@ -52,6 +54,9 @@ const mockUseDispatchApiRequest = useDispatchApiRequest as jest.MockedFunction<
 const mockUseRunStatues = useRunStatuses as jest.MockedFunction<
   typeof useRunStatuses
 >
+const mockGetBuildrootUpdateDisplayInfo = getBuildrootUpdateDisplayInfo as jest.MockedFunction<
+  typeof getBuildrootUpdateDisplayInfo
+>
 const mockFetchLights = fetchLights as jest.MockedFunction<typeof fetchLights>
 
 const mockToggleLights = jest.fn()
@@ -77,6 +82,11 @@ describe('RobotOverview', () => {
       isRunStill: false,
       isRunTerminal: true,
       isRunIdle: false,
+    })
+    mockGetBuildrootUpdateDisplayInfo.mockReturnValue({
+      autoUpdateAction: 'reinstall',
+      autoUpdateDisabledReason: null,
+      updateFromFileDisabledReason: null,
     })
     mockUseDispatchApiRequest.mockReturnValue([dispatchApiRequest, []])
     mockUseLights.mockReturnValue({
@@ -163,6 +173,18 @@ describe('RobotOverview', () => {
     const [{ getByRole }] = render()
     const runButton = getByRole('button', { name: 'Run a protocol' })
     expect(runButton).toBeDisabled()
+  })
+
+  it('disables the run a protocol button if robot software update is available', () => {
+    mockGetBuildrootUpdateDisplayInfo.mockReturnValue({
+      autoUpdateAction: 'upgrade',
+      autoUpdateDisabledReason: null,
+      updateFromFileDisabledReason: null,
+    })
+
+    const [{ getByRole }] = render()
+    const button = getByRole('button', { name: 'Run a protocol' })
+    expect(button).toBeDisabled()
   })
 
   it('renders run a protocol button as not disabled when run id is null but run status is not terminal', () => {


### PR DESCRIPTION
# Overview
When robot update is available disable run protocol buttons.
Closes #10935.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- disables device landing page robot card run a protocol in the overflow menu
- disables device detail page run a protocol button
- disables device detail page rerun protocol now from the overflow menu
- disables run detail page run again button
- adds tooltip to each of these

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Confirm that these items are disabled when robot software update is available
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Medium, this affects potentially blocking runs, need to ensure logic is sound
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
