### PR TITLE
fix(ot3): modify the device info integration test to check for all expected nodes during broadcast

### DIFF
--- a/hardware/tests/firmware_integration/test_device_info.py
+++ b/hardware/tests/firmware_integration/test_device_info.py
@@ -36,7 +36,12 @@ async def test_broadcast(
             NodeId.pipette_left,
             NodeId.gantry_x,
             NodeId.gantry_y,
+            NodeId.pipette_left_bootloader,
         }
+        # The simulator loads up a bootloader simulator using the
+        # left pipette bootloader node id. Since we send a broadcast message
+        # out, we need to make sure we read all of the device info request
+        # messages so that `test_each_node` does not fail.
         while len(nodes):
             message, arbitration_id = await can_messenger_queue.read()
             assert arbitration_id.parts.message_id == MessageId.device_info_response


### PR DESCRIPTION
## Overview

The `run_simulators.sh` script used by the emulation nightly tests actually also runs a bootloader
with a pipette_left_bootloader NodeId. This will sometimes cause the `test_each_node` test to fail
in the `test_device_info.py` file because it is reading from the queued up can messages and does not
expect a pipette_left_bootloader message to be there.

## Review Requests

@DerekMaggio please verify that this fixes your issue. I was unable to reproduce the failure on my computer.