### PR TITLE
fix(app): fix choose protocol slideout design feedback

### DIFF
--- a/app/src/organisms/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/index.tsx
@@ -127,26 +127,31 @@ export function ChooseProtocolSlideout(
                   }
                 }}
               >
-                <Flex
-                  marginRight={SPACING.spacing4}
-                  height="6rem"
-                  width="6rem"
-                  justifyContent={JUSTIFY_CENTER}
-                  alignItems={ALIGN_CENTER}
-                >
-                  <DeckThumbnail
-                    commands={storedProtocol.mostRecentAnalysis?.commands ?? []}
-                  />
-                </Flex>
-                <StyledText
-                  as="p"
-                  fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-                  css={{ 'overflow-wrap': 'anywhere' }}
-                >
-                  {storedProtocol.mostRecentAnalysis?.metadata?.protocolName ??
-                    first(storedProtocol.srcFileNames) ??
-                    storedProtocol.protocolKey}
-                </StyledText>
+                <Box display="grid" gridTemplateColumns="1fr 3fr">
+                  <Box
+                    marginY="auto"
+                    backgroundColor={isSelected ? COLORS.white : 'inherit'}
+                    marginRight={SPACING.spacing4}
+                    height="4.25rem"
+                    width="4.75rem"
+                  >
+                    <DeckThumbnail
+                      commands={
+                        storedProtocol.mostRecentAnalysis?.commands ?? []
+                      }
+                    />
+                  </Box>
+                  <StyledText
+                    as="p"
+                    fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+                    css={{ 'overflow-wrap': 'anywhere' }}
+                  >
+                    {storedProtocol.mostRecentAnalysis?.metadata
+                      ?.protocolName ??
+                      first(storedProtocol.srcFileNames) ??
+                      storedProtocol.protocolKey}
+                  </StyledText>
+                </Box>
                 {runCreationError != null && isSelected ? (
                   <>
                     <Box flex="1 1 auto" />
@@ -200,7 +205,11 @@ export function ChooseProtocolSlideout(
             <Trans
               t={t}
               i18nKey="to_run_protocol_go_to_protocols_page"
-              components={{ navlink: <Link to="/protocols" /> }}
+              components={{
+                navlink: (
+                  <Link to="/protocols" css={TYPOGRAPHY.linkPSemiBold} />
+                ),
+              }}
             />
           </StyledText>
         </Flex>


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This will close #11028.

![Screen Shot 2022-07-07 at 6 11 25 PM](https://user-images.githubusercontent.com/474225/177884206-8b00fdec-3a90-423c-a043-8569ba63c79b.png)


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- update Choose slideout styling to address the design feedback
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- [ ] when a user has no protocol file, the link in the slideout shows our blue color
- [ ] when selecting a protocol, the protocol's SVG has a white background
- [ ] SVG size is 76x68 (4.75rem x 4.25rem)
- [ ] SVG is centralized vertically

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
