### PR TITLE
feat(app): device Details design qa round 2 and fix card overflow btn bugs

### DIFF
--- a/app/src/atoms/MenuList/index.tsx
+++ b/app/src/atoms/MenuList/index.tsx
@@ -16,6 +16,7 @@ export const MenuList = (props: MenuListProps): JSX.Element | null => {
   return (
     <Box
       borderRadius={'4px 4px 0px 0px'}
+      zIndex={10}
       boxShadow={'0px 1px 3px rgba(0, 0, 0, 0.2)'}
       position={POSITION_ABSOLUTE}
       backgroundColor={COLORS.white}

--- a/app/src/organisms/Devices/HistoricalProtocolRun.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRun.tsx
@@ -104,7 +104,7 @@ export function HistoricalProtocolRun(
             data-testid={`RecentProtocolRuns_Protocol_${props.key}`}
             onClick={() => history.push(`/protocols/${protocolKey}`)}
             css={CLICK_STYLE}
-            marginRight={SPACING.spacing3}
+            marginRight={SPACING.spacing4}
           >
             {protocolName}
           </StyledText>

--- a/app/src/organisms/Devices/HistoricalProtocolRun.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRun.tsx
@@ -104,6 +104,7 @@ export function HistoricalProtocolRun(
             data-testid={`RecentProtocolRuns_Protocol_${props.key}`}
             onClick={() => history.push(`/protocols/${protocolKey}`)}
             css={CLICK_STYLE}
+            marginRight={SPACING.spacing3}
           >
             {protocolName}
           </StyledText>

--- a/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
@@ -156,7 +156,6 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
       top={SPACING.spacing6}
       right={0}
       flexDirection={DIRECTION_COLUMN}
-      height="10.5rem"
     >
       <NavLink to={`/devices/${robotName}/protocol-runs/${runId}/run-log`}>
         <MenuItem data-testid={`RecentProtocolRun_OverflowMenu_viewRunRecord`}>
@@ -182,7 +181,7 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
       >
         {t('download_run_log')}
       </MenuItem>
-      <Divider />
+      <Divider marginY="0" />
       <MenuItem
         onClick={handleDeleteClick}
         data-testid={`RecentProtocolRun_OverflowMenu_deleteRun`}

--- a/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next'
 import { NavLink, useHistory } from 'react-router-dom'
 import {
   Flex,
-  SPACING,
   POSITION_ABSOLUTE,
   ALIGN_FLEX_END,
   DIRECTION_COLUMN,
@@ -153,7 +152,7 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
       boxShadow={'0px 1px 3px rgba(0, 0, 0, 0.2)'}
       position={POSITION_ABSOLUTE}
       backgroundColor={COLORS.white}
-      top={SPACING.spacing6}
+      top={'2.3rem'}
       right={0}
       flexDirection={DIRECTION_COLUMN}
     >

--- a/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
@@ -11,6 +11,7 @@ import {
   COLORS,
   useOnClickOutside,
   useHoverTooltip,
+  Box,
 } from '@opentrons/components'
 import {
   useDeleteRunMutation,
@@ -46,9 +47,9 @@ export function HistoricalProtocolRunOverflowMenu(
     showOverflowMenu,
     setShowOverflowMenu,
   } = useMenuHandleClickOutside()
-  const protocolRunOverflowWrapperRef = useOnClickOutside({
+  const protocolRunOverflowWrapperRef = useOnClickOutside<HTMLDivElement>({
     onClickOutside: () => setShowOverflowMenu(false),
-  }) as React.RefObject<HTMLDivElement>
+  })
   const [
     showDownloadRunLogToast,
     setShowDownloadRunLogToast,
@@ -70,7 +71,7 @@ export function HistoricalProtocolRunOverflowMenu(
       <OverflowBtn alignSelf={ALIGN_FLEX_END} onClick={handleOverflowClick} />
       {showOverflowMenu && (
         <>
-          <div
+          <Box
             ref={protocolRunOverflowWrapperRef}
             data-testid={`HistoricalProtocolRunOverflowMenu_${runId}`}
           >
@@ -79,7 +80,7 @@ export function HistoricalProtocolRunOverflowMenu(
               closeOverflowMenu={handleOverflowClick}
               setShowDownloadRunLogToast={setShowDownloadRunLogToast}
             />
-          </div>
+          </Box>
           <MenuOverlay />
         </>
       )}

--- a/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
@@ -18,6 +18,7 @@ import {
 } from '@opentrons/react-api-client'
 import { Divider } from '../../atoms/structure'
 import { Tooltip } from '../../atoms/Tooltip'
+import { useMenuHandleClickOutside } from '../../atoms/MenuList/hooks'
 import { OverflowBtn } from '../../atoms/MenuList/OverflowBtn'
 import { MenuItem } from '../../atoms/MenuList/MenuItem'
 import { useRunControls } from '../RunTimeControl/hooks'
@@ -39,7 +40,12 @@ export function HistoricalProtocolRunOverflowMenu(
   props: HistoricalProtocolRunOverflowMenuProps
 ): JSX.Element {
   const { runId, robotName } = props
-  const [showOverflowMenu, setShowOverflowMenu] = React.useState<boolean>(false)
+  const {
+    MenuOverlay,
+    handleOverflowClick,
+    showOverflowMenu,
+    setShowOverflowMenu,
+  } = useMenuHandleClickOutside()
   const protocolRunOverflowWrapperRef = useOnClickOutside({
     onClickOutside: () => setShowOverflowMenu(false),
   }) as React.RefObject<HTMLDivElement>
@@ -47,11 +53,6 @@ export function HistoricalProtocolRunOverflowMenu(
     showDownloadRunLogToast,
     setShowDownloadRunLogToast,
   ] = React.useState<boolean>(false)
-  const handleOverflowClick: React.MouseEventHandler<HTMLButtonElement> = e => {
-    e.preventDefault()
-    e.stopPropagation()
-    setShowOverflowMenu(!showOverflowMenu)
-  }
 
   const commands = useAllCommandsQuery(
     runId,
@@ -68,16 +69,19 @@ export function HistoricalProtocolRunOverflowMenu(
     >
       <OverflowBtn alignSelf={ALIGN_FLEX_END} onClick={handleOverflowClick} />
       {showOverflowMenu && (
-        <div
-          ref={protocolRunOverflowWrapperRef}
-          data-testid={`HistoricalProtocolRunOverflowMenu_${runId}`}
-        >
-          <MenuDropdown
-            {...props}
-            closeOverflowMenu={handleOverflowClick}
-            setShowDownloadRunLogToast={setShowDownloadRunLogToast}
-          />
-        </div>
+        <>
+          <div
+            ref={protocolRunOverflowWrapperRef}
+            data-testid={`HistoricalProtocolRunOverflowMenu_${runId}`}
+          >
+            <MenuDropdown
+              {...props}
+              closeOverflowMenu={handleOverflowClick}
+              setShowDownloadRunLogToast={setShowDownloadRunLogToast}
+            />
+          </div>
+          <MenuOverlay />
+        </>
       )}
       {runTotalCommandCount != null && showDownloadRunLogToast ? (
         <DownloadRunLogToast

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -25,6 +25,7 @@ import { fetchPipettes, LEFT } from '../../../redux/pipettes'
 import { OverflowBtn } from '../../../atoms/MenuList/OverflowBtn'
 import { Portal } from '../../../App/portal'
 import { StyledText } from '../../../atoms/text'
+import { useMenuHandleClickOutside } from '../../../atoms/MenuList/hooks'
 import { getHasCalibrationBlock } from '../../../redux/config'
 import { getRequestById, useDispatchApiRequest } from '../../../redux/robot-api'
 import { Banner } from '../../../atoms/Banner'
@@ -59,8 +60,13 @@ const FETCH_PIPETTE_CAL_MS = 30000
 
 export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
   const { t } = useTranslation(['device_details', 'protocol_setup'])
-  const [showOverflowMenu, setShowOverflowMenu] = React.useState(false)
   const { pipetteInfo, mount, robotName, pipetteId } = props
+  const {
+    MenuOverlay,
+    handleOverflowClick,
+    showOverflowMenu,
+    setShowOverflowMenu,
+  } = useMenuHandleClickOutside()
   const dispatch = useDispatch<Dispatch>()
   const [dispatchRequest, requestIds] = useDispatchApiRequest()
   const pipetteName = pipetteInfo?.displayName
@@ -278,29 +284,27 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
         padding={SPACING.spacing2}
         data-testid={`PipetteCard_overflow_btn_${pipetteName}`}
       >
-        <OverflowBtn
-          aria-label="overflow"
-          onClick={() => {
-            setShowOverflowMenu(prevShowOverflowMenu => !prevShowOverflowMenu)
-          }}
-        />
+        <OverflowBtn aria-label="overflow" onClick={handleOverflowClick} />
       </Box>
       {showOverflowMenu && (
-        <Box
-          ref={pipetteOverflowWrapperRef}
-          data-testid={`PipetteCard_overflow_menu_${pipetteName}`}
-          onClick={() => setShowOverflowMenu(false)}
-        >
-          <PipetteOverflowMenu
-            pipetteName={pipetteName ?? t('empty')}
-            mount={mount}
-            handleChangePipette={handleChangePipette}
-            handleCalibrate={handleCalibrate}
-            handleSettingsSlideout={handleSettingsSlideout}
-            handleAboutSlideout={handleAboutSlideout}
-            isPipetteCalibrated={pipetteOffsetCalibration != null}
-          />
-        </Box>
+        <>
+          <Box
+            ref={pipetteOverflowWrapperRef}
+            data-testid={`PipetteCard_overflow_menu_${pipetteName}`}
+            onClick={() => setShowOverflowMenu(false)}
+          >
+            <PipetteOverflowMenu
+              pipetteName={pipetteName ?? t('empty')}
+              mount={mount}
+              handleChangePipette={handleChangePipette}
+              handleCalibrate={handleCalibrate}
+              handleSettingsSlideout={handleSettingsSlideout}
+              handleAboutSlideout={handleAboutSlideout}
+              isPipetteCalibrated={pipetteOffsetCalibration != null}
+            />
+          </Box>
+          <MenuOverlay />
+        </>
       )}
     </Flex>
   )

--- a/app/src/organisms/Devices/PipettesAndModules.tsx
+++ b/app/src/organisms/Devices/PipettesAndModules.tsx
@@ -25,7 +25,7 @@ import { ModuleCard } from '../ModuleCard'
 import { useIsRobotViewable, useRunStatuses } from './hooks'
 import { PipetteCard } from './PipetteCard'
 
-const MIN_HEIGHT_STYLING = css`
+const MIN_HEIGHT_OVER_3_STYLING = css`
   max-height: 37rem;
 
   @media (min-width: 700px) {
@@ -34,6 +34,22 @@ const MIN_HEIGHT_STYLING = css`
 
   @media (min-width: 800px) {
     max-height: 30rem;
+  }
+
+  @media (min-width: 900px) {
+    max-height: 22rem;
+  }
+`
+
+const MIN_HEIGHT_UNDER_3_STYLING = css`
+  max-height: 29rem;
+
+  @media (min-width: 700px) {
+    max-height: 27rem;
+  }
+
+  @media (min-width: 800px) {
+    max-height: 25rem;
   }
 
   @media (min-width: 900px) {
@@ -120,7 +136,11 @@ export function PipettesAndModules({
               justifyContent={JUSTIFY_START}
               flexDirection={DIRECTION_COLUMN}
               flexWrap={WRAP}
-              css={MIN_HEIGHT_STYLING}
+              css={
+                attachedModules.length > 3
+                  ? MIN_HEIGHT_OVER_3_STYLING
+                  : MIN_HEIGHT_UNDER_3_STYLING
+              }
             >
               {attachedModules.map((module, index) => {
                 return (

--- a/app/src/organisms/Devices/PipettesAndModules.tsx
+++ b/app/src/organisms/Devices/PipettesAndModules.tsx
@@ -2,6 +2,8 @@ import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { getPipetteModelSpecs, LEFT, RIGHT } from '@opentrons/shared-data'
 import { useModulesQuery, usePipettesQuery } from '@opentrons/react-api-client'
+import { css } from 'styled-components'
+
 import {
   Flex,
   ALIGN_CENTER,
@@ -23,6 +25,21 @@ import { ModuleCard } from '../ModuleCard'
 import { useIsRobotViewable, useRunStatuses } from './hooks'
 import { PipetteCard } from './PipetteCard'
 
+const MIN_HEIGHT_STYLING = css`
+  max-height: 37rem;
+
+  @media (min-width: 700px) {
+    max-height: 32rem;
+  }
+
+  @media (min-width: 800px) {
+    max-height: 30rem;
+  }
+
+  @media (min-width: 900px) {
+    max-height: 22rem;
+  }
+`
 const EQUIPMENT_POLL_MS = 5000
 interface PipettesAndModulesProps {
   robotName: string
@@ -103,7 +120,7 @@ export function PipettesAndModules({
               justifyContent={JUSTIFY_START}
               flexDirection={DIRECTION_COLUMN}
               flexWrap={WRAP}
-              maxHeight={attachedModules.length <= 3 ? '27rem ' : '34rem'}
+              css={MIN_HEIGHT_STYLING}
             >
               {attachedModules.map((module, index) => {
                 return (

--- a/app/src/organisms/Devices/RecentProtocolRuns.tsx
+++ b/app/src/organisms/Devices/RecentProtocolRuns.tsx
@@ -40,7 +40,8 @@ export function RecentProtocolRuns({
     <Flex
       alignItems={ALIGN_FLEX_START}
       backgroundColor={COLORS.white}
-      css={BORDERS.cardOutlineBorder}
+      border={`${SPACING.spacingXXS} ${BORDERS.styleSolid}  ${COLORS.medGrey}`}
+      borderRadius={BORDERS.radiusSoftCorners}
       flexDirection={DIRECTION_COLUMN}
       width="100%"
       marginBottom="6rem"

--- a/app/src/organisms/Devices/RobotOverview.tsx
+++ b/app/src/organisms/Devices/RobotOverview.tsx
@@ -129,6 +129,7 @@ export function RobotOverview({
           </Flex>
           <PrimaryButton
             {...targetProps}
+            marginBottom={SPACING.spacing4}
             textTransform={TEXT_TRANSFORM_NONE}
             disabled={
               (currentRunId != null ? !isRunTerminal : false) ||

--- a/app/src/organisms/ModuleCard/index.tsx
+++ b/app/src/organisms/ModuleCard/index.tsx
@@ -45,6 +45,7 @@ import {
 } from '../../redux/robot-api'
 import { Banner } from '../../atoms/Banner'
 import { Toast } from '../../atoms/Toast'
+import { useMenuHandleClickOutside } from '../../atoms/MenuList/hooks'
 import { Tooltip } from '../../atoms/Tooltip'
 import { useCurrentRunStatus } from '../RunTimeControl/hooks'
 import { HeaterShakerWizard } from '../Devices/HeaterShakerWizard'
@@ -86,7 +87,15 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
   const { t } = useTranslation('device_details')
   const { module, robotName, isLoadedInRun, runId, slotName } = props
   const dispatch = useDispatch<Dispatch>()
-  const [showOverflowMenu, setShowOverflowMenu] = React.useState(false)
+  const {
+    MenuOverlay,
+    handleOverflowClick,
+    showOverflowMenu,
+    setShowOverflowMenu,
+  } = useMenuHandleClickOutside()
+  const moduleOverflowWrapperRef = useOnClickOutside({
+    onClickOutside: () => setShowOverflowMenu(false),
+  }) as React.RefObject<HTMLDivElement>
   const [showSlideout, setShowSlideout] = React.useState(false)
   const [hasSecondary, setHasSecondary] = React.useState(false)
   const [showSuccessToast, setShowSuccessToast] = React.useState(false)
@@ -132,10 +141,6 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
 
   const isOverflowBtnDisabled =
     runStatus === RUN_STATUS_RUNNING || runStatus === RUN_STATUS_FINISHING
-
-  const moduleOverflowWrapperRef = useOnClickOutside({
-    onClickOutside: () => setShowOverflowMenu(false),
-  }) as React.RefObject<HTMLDivElement>
 
   const isTooHot =
     module.moduleModel === 'heaterShakerModuleV1' &&
@@ -216,202 +221,197 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
   }
 
   return (
-    <React.Fragment>
-      <Flex
-        backgroundColor={COLORS.background}
-        borderRadius={SPACING.spacing2}
-        marginBottom={SPACING.spacing3}
-        width={'100%'}
-        data-testid={`ModuleCard_${module.serialNumber}`}
-      >
-        {showWizard &&
-          (runId != null ? (
-            <HeaterShakerWizard
-              onCloseClick={() => setShowWizard(false)}
-              runId={runId}
-            />
-          ) : (
-            <HeaterShakerWizard onCloseClick={() => setShowWizard(false)} />
-          ))}
-        {showSlideout && (
-          <ModuleSlideout
-            module={module}
-            runId={currentRunId != null ? currentRunId : undefined}
-            isSecondary={hasSecondary}
-            showSlideout={showSlideout}
-            onCloseClick={() => setShowSlideout(false)}
-            isLoadedInRun={isLoadedInRun}
-          />
-        )}
-        {showAboutModule && (
-          <AboutModuleSlideout
-            module={module}
-            isExpanded={showAboutModule}
-            onCloseClick={() => setShowAboutModule(false)}
-            firmwareUpdateClick={handleUpdateClick}
-          />
-        )}
-        {showTestShake && (
-          <TestShakeSlideout
-            module={module as HeaterShakerModule}
-            isExpanded={showTestShake}
-            onCloseClick={() => setShowTestShake(false)}
+    <Flex
+      backgroundColor={COLORS.background}
+      borderRadius={SPACING.spacing2}
+      marginBottom={SPACING.spacing3}
+      width={'100%'}
+      data-testid={`ModuleCard_${module.serialNumber}`}
+    >
+      {showWizard &&
+        (runId != null ? (
+          <HeaterShakerWizard
+            onCloseClick={() => setShowWizard(false)}
             runId={runId}
           />
-        )}
-        <Box padding={`${SPACING.spacing4} ${SPACING.spacing3}`} width="100%">
-          <Flex flexDirection={DIRECTION_ROW} paddingRight={SPACING.spacing3}>
-            <Flex alignItems={ALIGN_START} opacity={isPending ? '50%' : '100%'}>
-              <img
-                width="60px"
-                height="54px"
-                src={image}
-                alt={module.moduleModel}
+        ) : (
+          <HeaterShakerWizard onCloseClick={() => setShowWizard(false)} />
+        ))}
+      {showSlideout && (
+        <ModuleSlideout
+          module={module}
+          runId={currentRunId != null ? currentRunId : undefined}
+          isSecondary={hasSecondary}
+          showSlideout={showSlideout}
+          onCloseClick={() => setShowSlideout(false)}
+          isLoadedInRun={isLoadedInRun}
+        />
+      )}
+      {showAboutModule && (
+        <AboutModuleSlideout
+          module={module}
+          isExpanded={showAboutModule}
+          onCloseClick={() => setShowAboutModule(false)}
+          firmwareUpdateClick={handleUpdateClick}
+        />
+      )}
+      {showTestShake && (
+        <TestShakeSlideout
+          module={module as HeaterShakerModule}
+          isExpanded={showTestShake}
+          onCloseClick={() => setShowTestShake(false)}
+          runId={runId}
+        />
+      )}
+      <Box padding={`${SPACING.spacing4} ${SPACING.spacing3}`} width="100%">
+        <Flex flexDirection={DIRECTION_ROW} paddingRight={SPACING.spacing3}>
+          <Flex alignItems={ALIGN_START} opacity={isPending ? '50%' : '100%'}>
+            <img
+              width="60px"
+              height="54px"
+              src={image}
+              alt={module.moduleModel}
+            />
+          </Flex>
+          <Flex flexDirection={DIRECTION_COLUMN} paddingLeft={SPACING.spacing3}>
+            {showSuccessToast && (
+              <Toast
+                message={t('firmware_update_installation_successful')}
+                type="success"
+                onClose={() => setShowSuccessToast(false)}
               />
-            </Flex>
-            <Flex
-              flexDirection={DIRECTION_COLUMN}
-              paddingLeft={SPACING.spacing3}
-            >
-              {showSuccessToast && (
-                <Toast
-                  message={t('firmware_update_installation_successful')}
-                  type="success"
-                  onClose={() => setShowSuccessToast(false)}
+            )}
+            {latestRequest != null && latestRequest.status === FAILURE && (
+              <FirmwareUpdateFailedModal
+                module={module}
+                onCloseClick={handleCloseErrorModal}
+                errorMessage={getErrorResponseMessage(latestRequest.error)}
+              />
+            )}
+            {module.hasAvailableUpdate && showBanner && !isPending ? (
+              <Flex
+                paddingBottom={SPACING.spacing2}
+                width="100%"
+                flexDirection={DIRECTION_COLUMN}
+                data-testid={`ModuleCard_firmware_update_banner_${module.serialNumber}`}
+              >
+                <Banner
+                  type="warning"
+                  onCloseClick={() => setShowBanner(false)}
+                >
+                  <Flex flexDirection={DIRECTION_COLUMN}>
+                    {t('firmware_update_available')}
+                    <Btn
+                      textAlign={ALIGN_START}
+                      fontSize={TYPOGRAPHY.fontSizeP}
+                      textDecoration={TEXT_DECORATION_UNDERLINE}
+                      onClick={() => handleUpdateClick()}
+                    >
+                      {t('update_now')}
+                    </Btn>
+                  </Flex>
+                </Banner>
+              </Flex>
+            ) : null}
+            {isTooHot ? (
+              <Flex
+                width="100%"
+                flexDirection={DIRECTION_COLUMN}
+                paddingRight={SPACING.spacingM}
+                paddingBottom={SPACING.spacing3}
+                data-testid={`ModuleCard_too_hot_banner_${module.serialNumber}`}
+              >
+                <Banner type="warning" icon={hotToTouch}>
+                  <Trans
+                    t={t}
+                    i18nKey="hot_to_the_touch"
+                    components={{
+                      bold: <strong />,
+                      block: <Text fontSize={TYPOGRAPHY.fontSizeP} />,
+                    }}
+                  />
+                </Banner>
+              </Flex>
+            ) : null}
+            {isPending ? (
+              <Flex
+                flexDirection={DIRECTION_ROW}
+                fontSize={TYPOGRAPHY.fontSizeP}
+                data-testid={`ModuleCard_update_pending_${module.serialNumber}`}
+              >
+                <Icon
+                  width={SPACING.spacingSM}
+                  name="ot-spinner"
+                  spin
+                  aria-label="ot-spinner"
                 />
-              )}
-              {latestRequest != null && latestRequest.status === FAILURE && (
-                <FirmwareUpdateFailedModal
-                  module={module}
-                  onCloseClick={handleCloseErrorModal}
-                  errorMessage={getErrorResponseMessage(latestRequest.error)}
-                />
-              )}
-              {module.hasAvailableUpdate && showBanner && !isPending ? (
+                <Text marginLeft={SPACING.spacing3}>
+                  {t('updating_firmware')}
+                </Text>
+              </Flex>
+            ) : (
+              <>
+                <Text
+                  textTransform={TEXT_TRANSFORM_UPPERCASE}
+                  color={COLORS.darkGrey}
+                  fontWeight={FONT_WEIGHT_REGULAR}
+                  fontSize={FONT_SIZE_CAPTION}
+                  paddingBottom={SPACING.spacing2}
+                  data-testid={`module_card_usb_port_${module.serialNumber}`}
+                >
+                  {module.moduleType !== THERMOCYCLER_MODULE_TYPE &&
+                  slotName != null
+                    ? t('deck_slot', { slot: slotName }) + ' - '
+                    : null}
+                  {t(module.usbPort.port === null ? 'usb_hub' : 'usb_port', {
+                    port: module.usbPort.hub ?? module.usbPort.port,
+                  })}
+                </Text>
                 <Flex
                   paddingBottom={SPACING.spacing2}
-                  width="100%"
-                  flexDirection={DIRECTION_COLUMN}
-                  data-testid={`ModuleCard_firmware_update_banner_${module.serialNumber}`}
-                >
-                  <Banner
-                    type="warning"
-                    onCloseClick={() => setShowBanner(false)}
-                  >
-                    <Flex flexDirection={DIRECTION_COLUMN}>
-                      {t('firmware_update_available')}
-                      <Btn
-                        textAlign={ALIGN_START}
-                        fontSize={TYPOGRAPHY.fontSizeP}
-                        textDecoration={TEXT_DECORATION_UNDERLINE}
-                        onClick={() => handleUpdateClick()}
-                      >
-                        {t('update_now')}
-                      </Btn>
-                    </Flex>
-                  </Banner>
-                </Flex>
-              ) : null}
-              {isTooHot ? (
-                <Flex
-                  width="100%"
-                  flexDirection={DIRECTION_COLUMN}
-                  paddingRight={SPACING.spacingM}
-                  paddingBottom={SPACING.spacing3}
-                  data-testid={`ModuleCard_too_hot_banner_${module.serialNumber}`}
-                >
-                  <Banner type="warning" icon={hotToTouch}>
-                    <Trans
-                      t={t}
-                      i18nKey="hot_to_the_touch"
-                      components={{
-                        bold: <strong />,
-                        block: <Text fontSize={TYPOGRAPHY.fontSizeP} />,
-                      }}
-                    />
-                  </Banner>
-                </Flex>
-              ) : null}
-              {isPending ? (
-                <Flex
-                  flexDirection={DIRECTION_ROW}
+                  data-testid={`ModuleCard_display_name_${module.serialNumber}`}
                   fontSize={TYPOGRAPHY.fontSizeP}
-                  data-testid={`ModuleCard_update_pending_${module.serialNumber}`}
                 >
-                  <Icon
-                    width={SPACING.spacingSM}
-                    name="ot-spinner"
-                    spin
-                    aria-label="ot-spinner"
+                  <ModuleIcon
+                    moduleType={module.moduleType}
+                    size="1rem"
+                    marginRight={SPACING.spacing1}
+                    color={COLORS.darkGreyEnabled}
                   />
-                  <Text marginLeft={SPACING.spacing3}>
-                    {t('updating_firmware')}
-                  </Text>
+                  <Text>{getModuleDisplayName(module.moduleModel)}</Text>
                 </Flex>
-              ) : (
-                <>
-                  <Text
-                    textTransform={TEXT_TRANSFORM_UPPERCASE}
-                    color={COLORS.darkGrey}
-                    fontWeight={FONT_WEIGHT_REGULAR}
-                    fontSize={FONT_SIZE_CAPTION}
-                    paddingBottom={SPACING.spacing2}
-                    data-testid={`module_card_usb_port_${module.serialNumber}`}
-                  >
-                    {module.moduleType !== THERMOCYCLER_MODULE_TYPE &&
-                    slotName != null
-                      ? t('deck_slot', { slot: slotName }) + ' - '
-                      : null}
-                    {t(module.usbPort.port === null ? 'usb_hub' : 'usb_port', {
-                      port: module.usbPort.hub ?? module.usbPort.port,
-                    })}
-                  </Text>
-                  <Flex
-                    paddingBottom={SPACING.spacing2}
-                    data-testid={`ModuleCard_display_name_${module.serialNumber}`}
-                    fontSize={TYPOGRAPHY.fontSizeP}
-                  >
-                    <ModuleIcon
-                      moduleType={module.moduleType}
-                      size="1rem"
-                      marginRight={SPACING.spacing1}
-                      color={COLORS.darkGreyEnabled}
-                    />
-                    <Text>{getModuleDisplayName(module.moduleModel)}</Text>
-                  </Flex>
-                </>
-              )}
-              <Flex
-                opacity={isPending ? '50%' : '100%'}
-                flexDirection={DIRECTION_COLUMN}
-              >
-                {moduleData}
-              </Flex>
+              </>
+            )}
+            <Flex
+              opacity={isPending ? '50%' : '100%'}
+              flexDirection={DIRECTION_COLUMN}
+            >
+              {moduleData}
             </Flex>
           </Flex>
-        </Box>
+        </Flex>
+      </Box>
 
-        <Box
-          alignSelf={ALIGN_START}
-          padding={SPACING.spacing2}
-          data-testid={`ModuleCard_overflow_btn_${module.serialNumber}`}
-          opacity={isPending ? '50%' : '100%'}
-        >
-          <OverflowBtn
-            aria-label="overflow"
-            disabled={isOverflowBtnDisabled}
-            {...targetProps}
-            onClick={() => {
-              setShowOverflowMenu(prevShowOverflowMenu => !prevShowOverflowMenu)
-            }}
-          />
-          {isOverflowBtnDisabled && (
-            <Tooltip tooltipProps={tooltipProps}>
-              {t('module_actions_unavailable')}
-            </Tooltip>
-          )}
-        </Box>
-        {showOverflowMenu && (
+      <Box
+        alignSelf={ALIGN_START}
+        padding={SPACING.spacing2}
+        data-testid={`ModuleCard_overflow_btn_${module.serialNumber}`}
+        opacity={isPending ? '50%' : '100%'}
+      >
+        <OverflowBtn
+          aria-label="overflow"
+          disabled={isOverflowBtnDisabled}
+          {...targetProps}
+          onClick={handleOverflowClick}
+        />
+        {isOverflowBtnDisabled && (
+          <Tooltip tooltipProps={tooltipProps}>
+            {t('module_actions_unavailable')}
+          </Tooltip>
+        )}
+      </Box>
+      {showOverflowMenu && (
+        <>
           <Box
             ref={moduleOverflowWrapperRef}
             data-testid={`ModuleCard_overflow_menu_${module.serialNumber}`}
@@ -427,9 +427,10 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
               isLoadedInRun={isLoadedInRun}
             />
           </Box>
-        )}
-      </Flex>
-    </React.Fragment>
+          <MenuOverlay />
+        </>
+      )}
+    </Flex>
   )
 }
 

--- a/app/src/pages/Devices/DeviceDetails/index.tsx
+++ b/app/src/pages/Devices/DeviceDetails/index.tsx
@@ -32,7 +32,9 @@ export function DeviceDetails(): JSX.Element | null {
         minWidth={SIZE_6}
         height="100%"
         overflow={OVERFLOW_SCROLL}
-        padding={SPACING.spacing4}
+        paddingX={SPACING.spacing4}
+        paddingTop={SPACING.spacing4}
+        paddingBottom={SPACING.spacing7}
       >
         {/* TODO(va, 2022-06-17) update border color to
             COLORS.medGreyEnabled when PR #10664 is merged */}
@@ -44,7 +46,7 @@ export function DeviceDetails(): JSX.Element | null {
           flexDirection={DIRECTION_COLUMN}
           marginBottom={SPACING.spacing4}
           paddingX={SPACING.spacing4}
-          paddingBottom={SPACING.spacing4}
+          paddingBottom={SPACING.spacing2}
           width="100%"
         >
           <RobotOverview robotName={robotName} />


### PR DESCRIPTION
closes #10892 and #10797

# Overview

- Address design qa feedback on device details page including module card display, historical protocol run design tweaks, and fixing a bug with the pipette overflow menu, module overflow menu, and historical protocol run overflow menu not closing when clicking on the overflow button

# Changelog

- change `DeviceDetails` and associated components
- fix bug in `pipetteCard` by adding `MenuOverlay` and using the `useMenuHandleClickOutside` hook
- fix bug in `moduleCard` by adding `MenuOverlay` and using the `useMenuHandleClickOutside` hook and adding `zIndex` to `MenuList`
- fix bug in `historicalRunOverfowMenu` by adding `MenuOverlay` and using the `useMenuHandleClickOutside` hook
- add some logic for module card `minHeight` depending on viewport size and how many module cards there are

# Review requests

- review Device Details, does it match designs?
- does logic for module card `minHeight` make sense
- do the overflow menu buttons in pipette card and module card close when you click on the overflow btn?

# Risk assessment

low