### PR TITLE
chore(app): add python executable for arm64-linux

### DIFF
--- a/app-shell/scripts/before-build.js
+++ b/app-shell/scripts/before-build.js
@@ -25,6 +25,10 @@ const PYTHON_BY_PLATFORM = {
       sha256:
         'b9989411bed71ba4867538c991f20b55f549dd9131905733f0df9f3fde81ad1d',
     },
+    arm64: {
+      url: 'https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5+20220630-aarch64-unknown-linux-gnu-install_only.tar.gz',
+      sha256: '012fa37c12d2647d76d004dc003302563864d2f1cd0731b71eeafad63d28b3f0'
+    },
   },
   win32: {
     x64: {

--- a/app-shell/scripts/before-build.js
+++ b/app-shell/scripts/before-build.js
@@ -26,8 +26,10 @@ const PYTHON_BY_PLATFORM = {
         'b9989411bed71ba4867538c991f20b55f549dd9131905733f0df9f3fde81ad1d',
     },
     arm64: {
-      url: 'https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5+20220630-aarch64-unknown-linux-gnu-install_only.tar.gz',
-      sha256: '012fa37c12d2647d76d004dc003302563864d2f1cd0731b71eeafad63d28b3f0'
+      url:
+        'https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5+20220630-aarch64-unknown-linux-gnu-install_only.tar.gz',
+      sha256:
+        '012fa37c12d2647d76d004dc003302563864d2f1cd0731b71eeafad63d28b3f0',
     },
   },
   win32: {


### PR DESCRIPTION
This is used in the builds for the OT-3 on-device display. It's kind of
gross to add another python interpreter to the robot build, and I think
in the future we should refactor the app to use the installed python
stuff in on-device mode, but with this option absent then `beforeBuild`
resolves to false when invoked from electron-builder, which silently
skips dependency gathering and results in a broken app, so this is a bit better.
