### PR TITLE
fix(app): historical runs labware offset should list display names

### DIFF
--- a/app/src/molecules/OffsetVector/index.tsx
+++ b/app/src/molecules/OffsetVector/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Flex, SPACING } from '@opentrons/components'
+import { Flex, SPACING, TYPOGRAPHY } from '@opentrons/components'
 import { StyledText } from '../../atoms/text'
 
 import type { StyleProps } from '@opentrons/components'
@@ -8,28 +8,41 @@ interface OffsetVectorProps extends StyleProps {
   x: number
   y: number
   z: number
+  as?: React.ComponentProps<typeof StyledText>['as']
 }
 
 export function OffsetVector(props: OffsetVectorProps): JSX.Element {
-  const { x, y, z, ...styleProps } = props
+  const { x, y, z, as = 'h6', ...styleProps } = props
   return (
     <Flex {...styleProps}>
-      <StyledText as={'h6'} marginRight={SPACING.spacing2}>
+      <StyledText
+        as={as}
+        marginRight={SPACING.spacing2}
+        fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+      >
         X
       </StyledText>
-      <StyledText as={'h6'} marginRight={SPACING.spacing3}>
+      <StyledText as={as} marginRight={SPACING.spacing3}>
         {x.toFixed(2)}
       </StyledText>
-      <StyledText as={'h6'} marginRight={SPACING.spacing2}>
+      <StyledText
+        as={as}
+        marginRight={SPACING.spacing2}
+        fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+      >
         Y
       </StyledText>
-      <StyledText as={'h6'} marginRight={SPACING.spacing3}>
+      <StyledText as={as} marginRight={SPACING.spacing3}>
         {y.toFixed(2)}
       </StyledText>
-      <StyledText as={'h6'} marginRight={SPACING.spacing2}>
+      <StyledText
+        as={as}
+        marginRight={SPACING.spacing2}
+        fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+      >
         Z
       </StyledText>
-      <StyledText as={'h6'} marginRight={SPACING.spacing3}>
+      <StyledText as={as} marginRight={SPACING.spacing3}>
         {z.toFixed(2)}
       </StyledText>
     </Flex>

--- a/app/src/organisms/Devices/HistoricalProtocolRun.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRun.tsx
@@ -33,7 +33,6 @@ interface HistoricalProtocolRunProps {
   protocolName: string
   robotName: string
   robotIsBusy: boolean
-  key: number
   protocolKey?: string
 }
 
@@ -41,7 +40,7 @@ export function HistoricalProtocolRun(
   props: HistoricalProtocolRunProps
 ): JSX.Element | null {
   const { t } = useTranslation('run_details')
-  const { run, protocolName, robotIsBusy, robotName, protocolKey, key } = props
+  const { run, protocolName, robotIsBusy, robotName, protocolKey } = props
   const history = useHistory()
   const [offsetDrawerOpen, setOffsetDrawerOpen] = React.useState(false)
   const storedProtocols = useSelector((state: State) =>
@@ -85,7 +84,7 @@ export function HistoricalProtocolRun(
         <StyledText
           as="p"
           width="25%"
-          data-testid={`RecentProtocolRuns_Run_${key}`}
+          data-testid={`RecentProtocolRuns_Run_${protocolKey}`}
           onClick={() =>
             history.push(
               `${robotName}/protocol-runs/${run.id}/protocolRunDetailsTab?`
@@ -101,7 +100,7 @@ export function HistoricalProtocolRun(
           <StyledText
             as="p"
             width="35%"
-            data-testid={`RecentProtocolRuns_Protocol_${props.key}`}
+            data-testid={`RecentProtocolRuns_Protocol_${protocolKey}`}
             onClick={() => history.push(`/protocols/${protocolKey}`)}
             css={CLICK_STYLE}
           >
@@ -111,7 +110,7 @@ export function HistoricalProtocolRun(
           <StyledText
             as="p"
             width="35%"
-            data-testid={`RecentProtocolRuns_Protocol_${props.key}`}
+            data-testid={`RecentProtocolRuns_Protocol_${protocolKey}`}
             css={{ 'overflow-wrap': 'anywhere' }}
           >
             {protocolName}
@@ -121,7 +120,7 @@ export function HistoricalProtocolRun(
           as="p"
           width="20%"
           textTransform="capitalize"
-          data-testid={`RecentProtocolRuns_Status_${props.key}`}
+          data-testid={`RecentProtocolRuns_Status_${protocolKey}`}
         >
           {runStatus === 'running' && (
             <Icon

--- a/app/src/organisms/Devices/HistoricalProtocolRunOffsetDrawer.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRunOffsetDrawer.tsx
@@ -11,6 +11,11 @@ import {
   JUSTIFY_FLEX_START,
   DIRECTION_COLUMN,
 } from '@opentrons/components'
+import {
+  getLabwareDefURI,
+  getLabwareDisplayName,
+  getModuleDisplayName,
+} from '@opentrons/shared-data'
 import { StyledText } from '../../atoms/text'
 import { Banner } from '../../atoms/Banner'
 import { useProtocolDetailsForRun, useDeckCalibrationData } from './hooks'
@@ -27,7 +32,6 @@ export function HistoricalProtocolRunOffsetDrawer(
 ): JSX.Element | null {
   const { t } = useTranslation('run_details')
   const { run, robotName } = props
-  const [showOutOfDateBanner, setShowOutOfDateBanner] = React.useState(false)
   const allLabwareOffsets = run.labwareOffsets?.sort(
     (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
   )
@@ -50,7 +54,6 @@ export function HistoricalProtocolRunOffsetDrawer(
       ? deckCalibrationData.lastModified
       : null
   const protocolDetails = useProtocolDetailsForRun(run.id)
-  const labwareDetails = protocolDetails.protocolData?.labware
 
   if (uniqueLabwareOffsets == null || uniqueLabwareOffsets.length === 0) {
     return (
@@ -70,15 +73,12 @@ export function HistoricalProtocolRunOffsetDrawer(
       </Box>
     )
   }
-  if (
+  const isOutOfDate =
     typeof lastModifiedDeckCal === 'string' &&
     new Date(lastModifiedDeckCal).getTime() >
       new Date(
         uniqueLabwareOffsets[uniqueLabwareOffsets?.length - 1].createdAt
       ).getTime()
-  ) {
-    setShowOutOfDateBanner(true)
-  }
 
   return (
     <Box
@@ -86,7 +86,7 @@ export function HistoricalProtocolRunOffsetDrawer(
       width="100%"
       padding={SPACING.spacing3}
     >
-      {showOutOfDateBanner && (
+      {isOutOfDate ? (
         <Banner
           type="warning"
           marginLeft={SPACING.spacing5}
@@ -99,7 +99,7 @@ export function HistoricalProtocolRunOffsetDrawer(
             <StyledText as="p">{t('robot_was_recalibrated')}</StyledText>
           </Flex>
         </Banner>
-      )}
+      ) : null}
       <Flex
         justifyContent={JUSTIFY_FLEX_START}
         borderBottom={BORDERS.lineBorder}
@@ -111,7 +111,7 @@ export function HistoricalProtocolRunOffsetDrawer(
           as="label"
           fontWeight={TYPOGRAPHY.fontWeightSemiBold}
           textTransform={TYPOGRAPHY.textTransformCapitalize}
-          dataTest-id={`RecentProtocolRun_OffsetDrawer_locationTitle`}
+          datatest-id={`RecentProtocolRun_OffsetDrawer_locationTitle`}
         >
           {t('location')}
         </StyledText>
@@ -120,7 +120,7 @@ export function HistoricalProtocolRunOffsetDrawer(
           width="33%"
           fontWeight={TYPOGRAPHY.fontWeightSemiBold}
           textTransform={TYPOGRAPHY.textTransformCapitalize}
-          dataTest-id={`RecentProtocolRun_OffsetDrawer_labwareTitle`}
+          datatest-id={`RecentProtocolRun_OffsetDrawer_labwareTitle`}
         >
           {t('labware')}
         </StyledText>
@@ -129,19 +129,19 @@ export function HistoricalProtocolRunOffsetDrawer(
           width="40%"
           fontWeight={TYPOGRAPHY.fontWeightSemiBold}
           textTransform={TYPOGRAPHY.textTransformCapitalize}
-          dataTest-id={`RecentProtocolRun_OffsetDrawer_labwareOffsetDataTitle`}
+          datatest-id={`RecentProtocolRun_OffsetDrawer_labwareOffsetDataTitle`}
         >
           {t('labware_offset_data')}
         </StyledText>
       </Flex>
       {uniqueLabwareOffsets.map((offset, index) => {
-        let labwareName = offset.definitionUri
-        if (labwareDetails != null) {
-          labwareName =
-            Object.values(labwareDetails)?.find(labware =>
-              labware.definitionId.includes(offset.definitionUri)
-            )?.displayName ?? offset.definitionUri
-        }
+        const definition = Object.values(
+          protocolDetails.protocolData?.labwareDefinitions ?? {}
+        ).find(def => getLabwareDefURI(def) === offset.definitionUri)
+        const labwareName =
+          definition != null
+            ? getLabwareDisplayName(definition)
+            : offset.definitionUri
 
         return (
           <Flex
@@ -155,17 +155,19 @@ export function HistoricalProtocolRunOffsetDrawer(
             <StyledText width="25%" as="label">
               {t('slot', { slotName: offset.location.slotName })}
               {offset.location.moduleModel != null &&
-                ` - ${offset.location.moduleModel}`}
+                ` - ${getModuleDisplayName(offset.location.moduleModel)}`}
             </StyledText>
-            <StyledText as="label" width="33%">
+            <StyledText
+              as="label"
+              width="33%"
+              overflow="hidden"
+              textOverflow="ellipsis"
+              title={labwareName}
+            >
               {labwareName}
             </StyledText>
             <StyledText as="label" width="40%">
-              <OffsetVector
-                x={offset.vector.x}
-                y={offset.vector.y}
-                z={offset.vector.z}
-              />
+              <OffsetVector {...offset.vector} />
             </StyledText>
           </Flex>
         )

--- a/app/src/organisms/Devices/HistoricalProtocolRunOffsetDrawer.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRunOffsetDrawer.tsx
@@ -166,9 +166,12 @@ export function HistoricalProtocolRunOffsetDrawer(
             >
               {labwareName}
             </StyledText>
-            <StyledText as="label" width="40%">
-              <OffsetVector {...offset.vector} />
-            </StyledText>
+            <OffsetVector
+              {...offset.vector}
+              width="40%"
+              fontSize={TYPOGRAPHY.fontSizeLabel}
+              as="label"
+            />
           </Flex>
         )
       })}

--- a/app/src/organisms/Devices/__tests__/HistoricalProtocolRun.test.tsx
+++ b/app/src/organisms/Devices/__tests__/HistoricalProtocolRun.test.tsx
@@ -58,7 +58,6 @@ describe('RecentProtocolRuns', () => {
       protocolKey: 'protocolKeyStub',
       robotIsBusy: false,
       run: run,
-      key: 1,
     }
     mockHistoricalProtocolRunOverflowMenu.mockReturnValue(
       <div>mock HistoricalProtocolRunOverflowMenu</div>
@@ -91,7 +90,6 @@ describe('RecentProtocolRuns', () => {
       protocolKey: '12345',
       robotIsBusy: false,
       run: run,
-      key: 1,
     }
     const { getByText } = render(props)
     const protocolBtn = getByText('my protocol')

--- a/components/src/primitives/style-props.ts
+++ b/components/src/primitives/style-props.ts
@@ -17,6 +17,7 @@ const TYPOGRAPHY_PROPS = [
   'textAlign',
   'textTransform',
   'textDecoration',
+  'textOverflow',
 ] as const
 
 const SPACING_PROPS = [


### PR DESCRIPTION
# Overview

This fixes a bug where the definition uri and raw module model of labware offsets would be shown in
place of their display names in the historical runs listing of the device detail page. 

While the protocol details are loading, the labware definition uri will be shown as a fallback. Because the uri is unbroken by spaces this PR also ensures that names that are incapable of wrapping will ellipsize and the full name will be present in the `title` tag of the element (which will appear on hover).

Closes #11062

# Changelog

- add the `textOverflow` style prop
- fix a couple of react warnings about misuse of data test ids and the `key` prop

# Review requests

- [ ] ensure that historical run labware offsets display as expected

# Risk assessment
low