### PR TITLE
fix(app): Address Choose a robot to run slideout design feedback

### DIFF
--- a/app/src/molecules/MiniCard/index.tsx
+++ b/app/src/molecules/MiniCard/index.tsx
@@ -20,7 +20,6 @@ const unselectedOptionStyles = css`
   cursor: pointer;
 
   &:hover {
-    background-color: ${COLORS.background};
     border: 1px solid ${COLORS.medGreyHover};
   }
 `

--- a/app/src/organisms/ChooseRobotSlideout/AvailableRobotOption.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/AvailableRobotOption.tsx
@@ -50,19 +50,23 @@ export function AvailableRobotOption(
         <img
           src={OT2_PNG}
           css={css`
-            width: 6rem;
+            width: 4rem;
+            height: 3.5625rem;
           `}
         />
         <Flex
           flexDirection={DIRECTION_COLUMN}
           marginLeft={SPACING.spacing4}
           marginTop={SPACING.spacing3}
+          marginBottom={SPACING.spacing4}
         >
           <StyledText as="h6">{robotModel}</StyledText>
           <Box maxWidth="9.5rem">
             <StyledText
               as="p"
-              css={{ 'overflow-wrap': 'break-word' }}
+              css={css`
+                overflow-wrap: break-word;
+              `}
               fontWeight={TYPOGRAPHY.fontWeightSemiBold}
             >
               {robotName}

--- a/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
@@ -168,7 +168,7 @@ describe('ChooseRobotSlideout', () => {
       onCloseClick: jest.fn(),
       showSlideout: true,
     })
-    const refreshButton = getByRole('button', { name: 'Refresh list' })
+    const refreshButton = getByRole('button', { name: 'refresh' })
     fireEvent.click(refreshButton)
     expect(mockStartDiscovery).toHaveBeenCalled()
     expect(dispatch).toHaveBeenCalledWith({ type: 'mockStartDiscovery' })
@@ -187,7 +187,6 @@ describe('ChooseRobotSlideout', () => {
     expect(proceedButton).not.toBeDisabled()
     const otherRobot = getByText('otherRobot')
     otherRobot.click() // unselect default robot
-    expect(proceedButton).toBeDisabled()
     const mockRobot = getByText('opentrons-robot-name')
     mockRobot.click()
     expect(proceedButton).not.toBeDisabled()

--- a/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
@@ -187,6 +187,7 @@ describe('ChooseRobotSlideout', () => {
     expect(proceedButton).not.toBeDisabled()
     const otherRobot = getByText('otherRobot')
     otherRobot.click() // unselect default robot
+    expect(proceedButton).not.toBeDisabled()
     const mockRobot = getByText('opentrons-robot-name')
     mockRobot.click()
     expect(proceedButton).not.toBeDisabled()

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -168,7 +168,7 @@ export function ChooseRobotSlideout(
               <StyledText
                 as="p"
                 color={COLORS.darkGreyEnabled}
-                marginRight="0.625rem"
+                marginRight={SPACING.spacingSM}
               >
                 {t('app_settings:searching')}
               </StyledText>

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -23,6 +23,7 @@ import {
   JUSTIFY_CENTER,
   SIZE_4,
   TEXT_ALIGN_CENTER,
+  DIRECTION_ROW,
 } from '@opentrons/components'
 
 import {
@@ -52,7 +53,7 @@ interface ChooseRobotSlideoutProps extends StyleProps {
 export function ChooseRobotSlideout(
   props: ChooseRobotSlideoutProps
 ): JSX.Element | null {
-  const { t } = useTranslation(['protocol_details', 'shared'])
+  const { t } = useTranslation(['protocol_details', 'shared', 'app_settings'])
   const { storedProtocolData, showSlideout, onCloseClick, ...restProps } = props
   const dispatch = useDispatch<Dispatch>()
   const history = useHistory()
@@ -159,20 +160,33 @@ export function ChooseRobotSlideout(
       <Flex flexDirection={DIRECTION_COLUMN}>
         <Flex
           alignSelf={ALIGN_FLEX_END}
-          marginY={SPACING.spacing3}
+          marginBottom={SPACING.spacing3}
           height={SIZE_2}
         >
           {isScanning ? (
-            <Icon name="ot-spinner" spin size={SIZE_1} />
+            <Flex flexDirection={DIRECTION_ROW} alignItems={ALIGN_CENTER}>
+              <StyledText
+                as="p"
+                color={COLORS.darkGreyEnabled}
+                marginRight="0.625rem"
+              >
+                {t('app_settings:searching')}
+              </StyledText>
+              <Icon
+                name="ot-spinner"
+                spin
+                size="1.25rem"
+                color={COLORS.darkGreyEnabled}
+              />
+            </Flex>
           ) : (
             <Link
-              color={COLORS.blue}
               onClick={() => dispatch(startDiscovery())}
               textTransform={TEXT_TRANSFORM_CAPITALIZE}
               role="button"
-              css={TYPOGRAPHY.pSemiBold}
+              css={TYPOGRAPHY.linkPSemiBold}
             >
-              {t('shared:refresh_list')}
+              {t('shared:refresh')}
             </Link>
           )}
         </Flex>
@@ -243,7 +257,9 @@ export function ChooseRobotSlideout(
                 t={t}
                 i18nKey="view_unavailable_robots"
                 components={{
-                  devicesLink: <NavLink to="/devices" />,
+                  devicesLink: (
+                    <NavLink to="/devices" css={TYPOGRAPHY.linkPSemiBold} />
+                  ),
                 }}
               />
             </StyledText>

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -217,7 +217,7 @@ export function ChooseRobotSlideout(
                   onClick={() => {
                     if (!isCreatingRun) {
                       resetCreateRun()
-                      setSelectedRobot(isSelected ? null : robot)
+                      setSelectedRobot(robot)
                     }
                   }}
                   isError={runCreationError != null}


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR will address choose a robot to run slideout design feedback.
Will close #11029 and #11057

exported (13) as a new issue
#11094

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- update ChooseRobotSlideout styling
- remove Mini card hover backgrond
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- [ ] Addressed design feedback #11029
- [ ] When clicking the selected mini card, the card won't be unselected
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
