### PR TITLE
fix(app): remove nav focus state on app load

### DIFF
--- a/app/src/App/Navbar.tsx
+++ b/app/src/App/Navbar.tsx
@@ -42,6 +42,11 @@ const NavbarLink = styled(NavLink)`
     background-color: ${COLORS.darkGreyHover};
   }
 
+  &:focus-visible.active {
+    box-shadow: none;
+    outline: none;
+  }
+
   &:active {
     background-color: ${COLORS.darkBlackPressed};
   }


### PR DESCRIPTION
# Overview
This will remove the focus state in the nav on app load. According to the following issue in the w3c css working group, the `focus-visible` state on page load is expected behavior: https://github.com/w3c/csswg-drafts/issues/5885 (i think, this discussion is not always easy to follow)
This is because on page load the app is programmatically moving focus to this element via react router and for accessibility reasons if focus is moved programmatically when no prior element is focused (such as on page load) the focus-visible selector is active. At least that's how I understand the discussion there.

We can keep the focus-visible on load, or implement some solution such as I've done here, which is to remove the focus-visible from the currently active item. A better fix would be to prevent react router from focusing on the nav element but i havent found a way to do that yet.

# Changelog
- removes focus-visible from active nav item
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Check that on app load nav item is not in focus-visible state
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
