### PR TITLE
fix(app): change error text when creation error is run is busy

### DIFF
--- a/app/src/assets/localization/en/protocol_details.json
+++ b/app/src/assets/localization/en/protocol_details.json
@@ -30,5 +30,6 @@
   "quantity": "Quantity",
   "go_to_labware_definition": "Go to labware definition",
   "protocol_designer_version": "Protocol Designer {{version}}",
-  "python_api_version": "Python API {{version}}"
+  "python_api_version": "Python API {{version}}",
+  "robot_is_busy_no_protocol_run_allowed": "This robot is busy and can’t run this protocol right now. Go to robot."
 }

--- a/app/src/assets/localization/en/protocol_details.json
+++ b/app/src/assets/localization/en/protocol_details.json
@@ -31,5 +31,5 @@
   "go_to_labware_definition": "Go to labware definition",
   "protocol_designer_version": "Protocol Designer {{version}}",
   "python_api_version": "Python API {{version}}",
-  "robot_is_busy_no_protocol_run_allowed": "This robot is busy and can’t run this protocol right now. Go to robot."
+  "robot_is_busy_no_protocol_run_allowed": "This robot is busy and can’t run this protocol right now. <robotLink>Go to Robot</robotLink>"
 }

--- a/app/src/assets/localization/en/protocol_details.json
+++ b/app/src/assets/localization/en/protocol_details.json
@@ -30,6 +30,5 @@
   "quantity": "Quantity",
   "go_to_labware_definition": "Go to labware definition",
   "protocol_designer_version": "Protocol Designer {{version}}",
-  "python_api_version": "Python API {{version}}",
-  "robot_is_busy_no_protocol_run_allowed": "This robot is busy and can’t run this protocol right now. <robotLink>Go to Robot</robotLink>"
+  "python_api_version": "Python API {{version}}"
 }

--- a/app/src/assets/localization/en/shared.json
+++ b/app/src/assets/localization/en/shared.json
@@ -34,5 +34,6 @@
   "robot_was_seen_but_is_unreachable": "This robot has been seen recently, but is currently not reachable at IP address {{hostname}}",
   "protocol_run_general_error_msg": "Protocol run could not be created on the robot.",
   "proceed_to_setup": "Proceed to setup",
-  "a_software_update_is_available": "A software update is available for this robot. Update to run protocols."
+  "a_software_update_is_available": "A software update is available for this robot. Update to run protocols.",
+  "robot_is_busy_no_protocol_run_allowed": "This robot is busy and can’t run this protocol right now. <robotLink>Go to Robot</robotLink>"
 }

--- a/app/src/organisms/ChooseProtocolSlideout/__tests__/ChooseProtocolSlideout.test.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/__tests__/ChooseProtocolSlideout.test.tsx
@@ -109,6 +109,7 @@ describe('ChooseProtocolSlideout', () => {
       createRunFromProtocolSource: mockCreateRunFromProtocol,
       isCreatingRun: false,
       reset: jest.fn(),
+      runCreationErrorCode: 'error code',
     })
     const [{ getByRole, getByText }] = render({
       robot: mockConnectableRobot,
@@ -122,5 +123,30 @@ describe('ChooseProtocolSlideout', () => {
       protocolKey: storedProtocolDataFixture.protocolKey,
     })
     expect(getByText('run creation error')).toBeInTheDocument()
+  })
+
+  it('renders error state when run creation error code is 409', () => {
+    mockUseCreateRunFromProtocol.mockReturnValue({
+      runCreationError: 'Current run is not idle or stopped.',
+      createRunFromProtocolSource: mockCreateRunFromProtocol,
+      isCreatingRun: false,
+      reset: jest.fn(),
+      runCreationErrorCode: '409',
+    })
+    const [{ getByRole, getByText }] = render({
+      robot: mockConnectableRobot,
+      onCloseClick: jest.fn(),
+      showSlideout: true,
+    })
+    const proceedButton = getByRole('button', { name: 'Proceed to setup' })
+    proceedButton.click()
+    expect(mockCreateRunFromProtocol).toHaveBeenCalledWith({
+      files: [expect.any(File)],
+      protocolKey: storedProtocolDataFixture.protocolKey,
+    })
+    getByText('This robot is busy and can’t run this protocol right now.')
+    const link = getByRole('link', { name: 'Go to Robot' })
+    fireEvent.click(link)
+    expect(link.getAttribute('href')).toEqual('/devices/opentrons-robot-name')
   })
 })

--- a/app/src/organisms/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/index.tsx
@@ -2,9 +2,10 @@ import * as React from 'react'
 import path from 'path'
 import first from 'lodash/first'
 import { Trans, useTranslation } from 'react-i18next'
-import { Link, useHistory } from 'react-router-dom'
+import { Link, NavLink, useHistory } from 'react-router-dom'
 import { ApiHostProvider } from '@opentrons/react-api-client'
 import { useSelector } from 'react-redux'
+import { css } from 'styled-components'
 
 import {
   SPACING,
@@ -69,6 +70,7 @@ export function ChooseProtocolSlideout(
     runCreationError,
     isCreatingRun,
     reset: resetCreateRun,
+    runCreationErrorCode,
   } = useCreateRunFromProtocol({
     onSuccess: ({ data: runData }) => {
       history.push(`/devices/${name}/protocol-runs/${runData.id}`)
@@ -172,7 +174,25 @@ export function ChooseProtocolSlideout(
                   marginTop={`-${SPACING.spacing2}`}
                   marginBottom={SPACING.spacing3}
                 >
-                  {runCreationError}
+                  {runCreationErrorCode === '409' ? (
+                    <Trans
+                      t={t}
+                      i18nKey="shared:robot_is_busy_no_protocol_run_allowed"
+                      components={{
+                        robotLink: (
+                          <NavLink
+                            css={css`
+                              color: ${COLORS.errorText};
+                              text-decoration: ${TYPOGRAPHY.textDecorationUnderline};
+                            `}
+                            to={`/devices/${robot.name}`}
+                          />
+                        ),
+                      }}
+                    />
+                  ) : (
+                    runCreationError
+                  )}
                 </StyledText>
               ) : null}
             </Flex>

--- a/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
@@ -241,4 +241,29 @@ describe('ChooseRobotSlideout', () => {
     })
     expect(getByText('run creation error')).toBeInTheDocument()
   })
+
+  it('renders error state when run creation error is busy', () => {
+    mockUseCreateRunFromProtocol.mockReturnValue({
+      runCreationError: 'Current run is not idle or stopped.',
+      createRunFromProtocolSource: mockCreateRunFromProtocolSource,
+      isCreatingRun: false,
+      reset: jest.fn(),
+    })
+    const [{ getByRole, getByText }] = render({
+      storedProtocolData: storedProtocolDataFixture,
+      onCloseClick: jest.fn(),
+      showSlideout: true,
+    })
+    const proceedButton = getByRole('button', { name: 'Proceed to setup' })
+    proceedButton.click()
+    expect(mockCreateRunFromProtocolSource).toHaveBeenCalledWith({
+      files: [expect.any(File)],
+      protocolKey: storedProtocolDataFixture.protocolKey,
+    })
+    expect(
+      getByText(
+        'This robot is busy and can’t run this protocol right now. Go to robot.'
+      )
+    ).toBeInTheDocument()
+  })
 })

--- a/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
@@ -227,6 +227,7 @@ describe('ChooseRobotSlideout', () => {
       createRunFromProtocolSource: mockCreateRunFromProtocolSource,
       isCreatingRun: false,
       reset: jest.fn(),
+      runCreationErrorCode: 'error code',
     })
     const [{ getByRole, getByText }] = render({
       storedProtocolData: storedProtocolDataFixture,
@@ -242,12 +243,13 @@ describe('ChooseRobotSlideout', () => {
     expect(getByText('run creation error')).toBeInTheDocument()
   })
 
-  it('renders error state when run creation error is busy', () => {
+  it('renders error state when run creation error code is 409', () => {
     mockUseCreateRunFromProtocol.mockReturnValue({
       runCreationError: 'Current run is not idle or stopped.',
       createRunFromProtocolSource: mockCreateRunFromProtocolSource,
       isCreatingRun: false,
       reset: jest.fn(),
+      runCreationErrorCode: '409',
     })
     const [{ getByRole, getByText }] = render({
       storedProtocolData: storedProtocolDataFixture,

--- a/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
@@ -260,10 +260,9 @@ describe('ChooseRobotSlideout', () => {
       files: [expect.any(File)],
       protocolKey: storedProtocolDataFixture.protocolKey,
     })
-    expect(
-      getByText(
-        'This robot is busy and can’t run this protocol right now. Go to robot.'
-      )
-    ).toBeInTheDocument()
+    getByText('This robot is busy and can’t run this protocol right now.')
+    const link = getByRole('link', { name: 'Go to Robot' })
+    fireEvent.click(link)
+    expect(link.getAttribute('href')).toEqual('/devices/opentrons-robot-name')
   })
 })

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -76,6 +76,7 @@ export function ChooseRobotSlideout(
     runCreationError,
     reset: resetCreateRun,
     isCreatingRun,
+    runCreationErrorCode,
   } = useCreateRunFromProtocol(
     {
       onSuccess: ({ data: runData }) => {
@@ -222,11 +223,10 @@ export function ChooseRobotSlideout(
                     marginTop={`-${SPACING.spacing2}`}
                     marginBottom={SPACING.spacing3}
                   >
-                    {runCreationError ===
-                    'Current run is not idle or stopped.' ? (
+                    {runCreationErrorCode === '409' ? (
                       <Trans
                         t={t}
-                        i18nKey="robot_is_busy_no_protocol_run_allowed"
+                        i18nKey="shared:robot_is_busy_no_protocol_run_allowed"
                         components={{
                           robotLink: (
                             <NavLink

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -4,6 +4,7 @@ import first from 'lodash/first'
 import { useTranslation, Trans } from 'react-i18next'
 import { useSelector, useDispatch } from 'react-redux'
 import { NavLink, useHistory } from 'react-router-dom'
+import { css } from 'styled-components'
 
 import {
   SPACING,
@@ -212,7 +213,7 @@ export function ChooseRobotSlideout(
                     isSelectedRobotOnWrongVersionOfSoftware
                   }
                 />
-                {runCreationError != null && isSelected && (
+                {isSelected && (
                   <StyledText
                     as="label"
                     color={COLORS.errorText}
@@ -221,9 +222,26 @@ export function ChooseRobotSlideout(
                     marginTop={`-${SPACING.spacing2}`}
                     marginBottom={SPACING.spacing3}
                   >
-                    {runCreationError === 'Current run is not idle or stopped.'
-                      ? t('robot_is_busy_no_protocol_run_allowed')
-                      : runCreationError}
+                    {runCreationError ===
+                    'Current run is not idle or stopped.' ? (
+                      <Trans
+                        t={t}
+                        i18nKey="robot_is_busy_no_protocol_run_allowed"
+                        components={{
+                          robotLink: (
+                            <NavLink
+                              css={css`
+                                color: ${COLORS.errorText};
+                                text-decoration: ${TYPOGRAPHY.textDecorationUnderline};
+                              `}
+                              to={`/devices/${robot.name}`}
+                            />
+                          ),
+                        }}
+                      />
+                    ) : (
+                      runCreationError
+                    )}
                   </StyledText>
                 )}
               </Flex>
@@ -245,7 +263,7 @@ export function ChooseRobotSlideout(
                 t={t}
                 i18nKey="view_unavailable_robots"
                 components={{
-                  devicesLink: <NavLink to="/devices" />,
+                  robotLink: <NavLink to="/devices" />,
                 }}
               />
             </StyledText>

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -221,7 +221,9 @@ export function ChooseRobotSlideout(
                     marginTop={`-${SPACING.spacing2}`}
                     marginBottom={SPACING.spacing3}
                   >
-                    {runCreationError}
+                    {runCreationError === 'Current run is not idle or stopped.'
+                      ? t('robot_is_busy_no_protocol_run_allowed')
+                      : runCreationError}
                   </StyledText>
                 )}
               </Flex>

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -263,7 +263,7 @@ export function ChooseRobotSlideout(
                 t={t}
                 i18nKey="view_unavailable_robots"
                 components={{
-                  robotLink: <NavLink to="/devices" />,
+                  devicesLink: <NavLink to="/devices" />,
                 }}
               />
             </StyledText>

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -213,7 +213,7 @@ export function ChooseRobotSlideout(
                     isSelectedRobotOnWrongVersionOfSoftware
                   }
                 />
-                {isSelected && (
+                {runCreationError != null && isSelected && (
                   <StyledText
                     as="label"
                     color={COLORS.errorText}

--- a/app/src/organisms/ChooseRobotSlideout/useCreateRunFromProtocol.ts
+++ b/app/src/organisms/ChooseRobotSlideout/useCreateRunFromProtocol.ts
@@ -24,6 +24,7 @@ export interface UseCreateRun {
   >
   isCreatingRun: boolean
   runCreationError: string | null
+  runCreationErrorCode: string | null
   reset: () => void
 }
 
@@ -84,6 +85,8 @@ export function useCreateRunFromProtocol(
   error != null && console.error(error)
   error = error?.length > 255 ? t('protocol_run_general_error_msg') : error
 
+  const errorCode = protocolError?.code ?? runError?.code ?? ''
+
   return {
     createRunFromProtocolSource: (
       { files: srcFiles, protocolKey },
@@ -97,6 +100,7 @@ export function useCreateRunFromProtocol(
     },
     isCreatingRun: isCreatingProtocol || isCreatingRun,
     runCreationError: error,
+    runCreationErrorCode: errorCode,
     reset: () => {
       resetProtocolMutation()
       resetRunMutation()

--- a/app/src/organisms/ChooseRobotSlideout/useCreateRunFromProtocol.ts
+++ b/app/src/organisms/ChooseRobotSlideout/useCreateRunFromProtocol.ts
@@ -85,7 +85,7 @@ export function useCreateRunFromProtocol(
   error != null && console.error(error)
   error = error?.length > 255 ? t('protocol_run_general_error_msg') : error
 
-  const errorCode = protocolError?.code ?? runError?.code ?? ''
+  const errorCode = protocolError?.code ?? runError?.code ?? null
 
   return {
     createRunFromProtocolSource: (


### PR DESCRIPTION
closes #11060

# Overview

When run creation error code is 409, I added logic to display `This robot is busy and can’t run this protocol right now. Go to robot.` in both instances in Choose a protocol and Choose a robot slideout


<img width="310" alt="Screen Shot 2022-07-11 at 10 15 59 AM" src="https://user-images.githubusercontent.com/66035149/178285230-11bb714c-4490-4653-9388-076125198e06.png">

# Changelog

- add logic to Choose a robot slideout and add test
- add logic to Choose a protocol slideout and add test
- extend prop in `useCreateRunFromProtocol` (there seems to be no test for this hook, maybe a followup PR can be to create one)

# Review requests

- run a protocol on a robot and while the robot is busy, try to run another protocol. you should get the correct error text

# Risk assessment

low