### PR TITLE
fix(robot-server): fully delete current run

### DIFF
--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -174,8 +174,7 @@ class RunDataManager:
         """
         if run_id == self._engine_store.current_run_id:
             await self._engine_store.clear()
-        else:
-            self._run_store.remove(run_id=run_id)
+        self._run_store.remove(run_id=run_id)
 
     async def update(self, run_id: str, current: Optional[bool]) -> Run:
         """Get and potentially archive a run.

--- a/robot-server/tests/integration/http_api/runs/test_deletion.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_deletion.tavern.yaml
@@ -1,0 +1,31 @@
+test_name: Create and delete a run
+
+marks:
+  - usefixtures:
+      - run_server
+
+stages:
+  - name: Create Empty Run
+    request:
+      url: '{host:s}:{port:d}/runs'
+      json:
+        data: {}
+      method: POST
+    response:
+      status_code: 201
+      save:
+        json:
+          run_id: data.id
+  - name: Delete run
+    request:
+      url: '{host:s}:{port:d}/runs/{run_id}'
+      method: DELETE
+    response:
+      status_code: 200
+      json: {}
+  - name: Try to get deleted run
+    request:
+      url: '{host:s}:{port:d}/runs/{run_id}'
+      method: GET
+    response:
+      status_code: 404

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -438,8 +438,9 @@ async def test_delete_current_run(
 
     await subject.delete(run_id=run_id)
 
-    decoy.verify(await mock_engine_store.clear(), times=1)
-    decoy.verify(mock_run_store.remove(run_id=run_id), times=0)
+    decoy.verify(
+        await mock_engine_store.clear(), mock_run_store.remove(run_id=run_id), times=1
+    )
 
 
 async def test_delete_historical_run(

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -439,7 +439,8 @@ async def test_delete_current_run(
     await subject.delete(run_id=run_id)
 
     decoy.verify(
-        await mock_engine_store.clear(), mock_run_store.remove(run_id=run_id), times=1
+        await mock_engine_store.clear(),
+        mock_run_store.remove(run_id=run_id),
     )
 
 


### PR DESCRIPTION
# Overview
Closes #10909 

Addresses bug where deleting a current run would only remove it from the `engine_store` but not the `run_store`, resulting the run still existing in memory.

# Changelog
- Fixed bug where current runs were not deleted from `run_store`
- Added simple tavern test for deleting a current run

# Review requests

# Risk assessment
Low