### PR TITLE
feat(protocol-designer): add new liquid icon design

### DIFF
--- a/protocol-designer/src/components/LiquidsSidebar/index.tsx
+++ b/protocol-designer/src/components/LiquidsSidebar/index.tsx
@@ -11,6 +11,8 @@ import { OrderedLiquids } from '../../labware-ingred/types'
 import * as labwareIngredActions from '../../labware-ingred/actions'
 import { BaseState, ThunkDispatch } from '../../types'
 
+import styles from './styles.css'
+
 interface SP {
   liquids: OrderedLiquids
   selectedLiquid?: string | null
@@ -35,6 +37,7 @@ function LiquidsSidebarComponent(props: Props): JSX.Element {
           iconName="circle"
           iconProps={{
             style: { fill: displayColor ?? swatchColors(ingredientId) },
+            className: styles.liquid_icon_container,
           }}
           title={name || `Unnamed Ingredient ${ingredientId}`} // fallback, should not happen
         />

--- a/protocol-designer/src/components/LiquidsSidebar/styles.css
+++ b/protocol-designer/src/components/LiquidsSidebar/styles.css
@@ -1,0 +1,11 @@
+@import '@opentrons/components';
+
+.liquid_icon_container {
+  border-style: solid;
+  border-width: 1px;
+  border-color: #e3e3e3;
+  border-radius: 4px;
+  background-color: var(--c-white);
+  height: 2.25rem;
+  padding: 0.5rem;
+}


### PR DESCRIPTION
# Overview

This PR updates the liquid icon design in protocol designer. closes #10602

<img width="296" alt="image" src="https://user-images.githubusercontent.com/14794021/178391211-d71641a2-0eb3-48d3-9801-13ee16e86992.png">

# Changelog

- Update liquid icon styling 

# Review requests

- Create new liquids and check that the icon design matches [Figma](https://www.figma.com/file/2xjSLHXquNsKvC1mV9NMjr/Milestone-2?node-id=955%3A144974)

# Risk assessment

low, stylistic
