### PR TITLE
chore(app-shell): build: optionally skip python

### DIFF
--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -31,9 +31,15 @@ publish_update := $(filter v%,$(OT_TAG))
 branch_suffix := $(if $(publish_update),,-$(subst /,-,$(OT_BRANCH)))
 build_id := $(or $(and $(OT_BUILD),b$(OT_BUILD)$(branch_suffix)),dev)
 
+# set this to anythin on commandline invocations of this makefile to skip bundling
+# standalone python, as is necessary for on-device app builds:
+# make dist no_python_bundle=true or =1 or whatever
+no_python_bundle ?=
+
 builder := electron-builder \
 	--config electron-builder.config.js \
 	--publish never
+
 
 electron := electron . \
 	--devtools \
@@ -80,6 +86,7 @@ package-deps: clean lib deps
 
 package dist-posix dist-osx dist-linux dist-win: export NODE_ENV := production
 package dist-posix dist-osx dist-linux dist-win: export BUILD_ID := $(build_id)
+package dist-posix dist-osx dist-linux dist-win: export NO_PYTHON := $(if $(no_python_bundle),true,false)
 
 .PHONY: package
 package: package-deps

--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -31,7 +31,7 @@ publish_update := $(filter v%,$(OT_TAG))
 branch_suffix := $(if $(publish_update),,-$(subst /,-,$(OT_BRANCH)))
 build_id := $(or $(and $(OT_BUILD),b$(OT_BUILD)$(branch_suffix)),dev)
 
-# set this to anythin on commandline invocations of this makefile to skip bundling
+# set this to anything on command-line invocations of this makefile to skip bundling
 # standalone python, as is necessary for on-device app builds:
 # make dist no_python_bundle=true or =1 or whatever
 no_python_bundle ?=

--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -3,6 +3,7 @@ const path = require('path')
 
 const { OT_APP_DEPLOY_BUCKET, OT_APP_DEPLOY_FOLDER } = process.env
 const DEV_MODE = process.env.NODE_ENV !== 'production'
+const USE_PYTHON = process.env.NO_PYTHON !== 'true'
 
 module.exports = {
   appId: 'com.opentrons.app',
@@ -18,7 +19,7 @@ module.exports = {
     '!Makefile',
     '!python',
   ],
-  extraResources: ['python'],
+  extraResources: USE_PYTHON ? ['python'] : [],
   /* eslint-disable no-template-curly-in-string */
   artifactName: '${productName}-v${version}-${os}-${env.BUILD_ID}.${ext}',
   /* eslint-enable no-template-curly-in-string */

--- a/app-shell/scripts/before-build.js
+++ b/app-shell/scripts/before-build.js
@@ -6,6 +6,8 @@ const download = require('download')
 const decompress = require('decompress')
 const crypto = require('crypto')
 const execa = require('execa')
+const USE_PYTHON = process.env.NO_PYTHON !== 'true'
+
 
 const HOST_PYTHON = process.env.HOST_PYTHON ?? 'python3.10'
 
@@ -44,12 +46,12 @@ module.exports = function beforeBuild(context) {
   const { platform, arch } = context
   const platformName = platform.nodeName
   const standalonePython = PYTHON_BY_PLATFORM?.[platformName]?.[arch]
-
-  if (standalonePython == null) {
-    console.warn(`No standalone Python found for ${platformName}+${arch}`)
-    return Promise.resolve()
+  if (!USE_PYTHON) {
+    return Promise.resolve(true)
   }
-
+  if (standalonePython == null) {
+    throw new Error(`No standalone Python found for ${platformName}+${arch}`)
+  }
   const { url, sha256 } = standalonePython
 
   console.log(

--- a/app-shell/scripts/before-build.js
+++ b/app-shell/scripts/before-build.js
@@ -8,7 +8,6 @@ const crypto = require('crypto')
 const execa = require('execa')
 const USE_PYTHON = process.env.NO_PYTHON !== 'true'
 
-
 const HOST_PYTHON = process.env.HOST_PYTHON ?? 'python3.10'
 
 const PYTHON_BY_PLATFORM = {


### PR DESCRIPTION
On builds that are creating apps for the robot, we need to not bundle
python - bundling python takes us down a long and winding road of trying
to cross-compile all the dependencies. Add a makefile argument that will
skip installing python, and change the before-build script so that it
raises an error if there is no python in the environment map if that arg
is not present.
