### PR TITLE
refactor(app): update H-S menu deactivate copy

### DIFF
--- a/app/src/assets/localization/en/heater_shaker.json
+++ b/app/src/assets/localization/en/heater_shaker.json
@@ -71,7 +71,7 @@
   "set_temperature": "Set module temperature",
   "how_to_attach_to_deck": "See how to attach to deck",
   "test_shake": "Test shake",
-  "deactivate": "Deactivate",
+  "deactivate_heater": "Deactivate heater",
   "stop_shaking": "Stop Shaking",
   "cannot_open_latch": "Cannot open labware latch while module is shaking.",
   "cannot_shake": "Cannot shake when labware latch is open",

--- a/app/src/organisms/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
@@ -395,7 +395,7 @@ describe('ModuleOverflowMenu', () => {
     const { getByRole } = render(props)
 
     const btn = getByRole('button', {
-      name: 'Deactivate',
+      name: 'Deactivate heater',
     })
     expect(btn).not.toBeDisabled()
     fireEvent.click(btn)

--- a/app/src/organisms/ModuleCard/hooks.tsx
+++ b/app/src/organisms/ModuleCard/hooks.tsx
@@ -295,7 +295,7 @@ export function useModuleOverflowMenu(
         setSetting:
           module.moduleType === HEATERSHAKER_MODULE_TYPE &&
           module.data.temperatureStatus !== 'idle'
-            ? t('deactivate', { ns: 'heater_shaker' })
+            ? t('deactivate_heater', { ns: 'heater_shaker' })
             : t('set_temperature', { ns: 'heater_shaker' }),
         isSecondary: false,
         disabledReason: false,


### PR DESCRIPTION

# Overview

This PR updates the "deactivate" copy to "deactivate heater" for better clarity.

closes #11059

# Changelog

- Update copy from "Deactivate" to "Deactivate heater"

# Review requests

- Check that the copy did update in the H-S menu

# Risk assessment

low, copy change