### PR TITLE
feat(app): update React Select to 5.4.0 and add to App package.json

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -45,6 +45,7 @@
     "react-intersection-observer": "^8.33.1",
     "react-redux": "7.2.1",
     "react-router-dom": "5.1.1",
+    "react-select": "5.4.0",
     "redux": "4.0.5",
     "redux-observable": "1.1.0",
     "redux-thunk": "2.3.0",

--- a/app/src/atoms/SelectField/Select.stories.tsx
+++ b/app/src/atoms/SelectField/Select.stories.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react'
+
+import { Select } from './Select'
+
+import type { Story, Meta } from '@storybook/react'
+
+export default {
+  title: 'App/Atoms/Select',
+  component: Select,
+} as Meta
+
+const Template: Story<React.ComponentProps<typeof Select>> = args => (
+  <Select {...args} />
+)
+export const Basic = Template.bind({})
+Basic.parameters = {
+  docs: {
+    description: {
+      component:
+        'Thin wrapper around `react-select` to apply our Opentrons-specific styles. All props are passed directly to [`react-select`](https://react-select.com/props) except for `styles`, `components`, and `classNamePrefix`. The `className` prop appends to the `className` we pass `react-select`. Those props are not passed directly because they provide the base styling of the component',
+    },
+  },
+}
+Basic.args = {
+  options: [
+    { label: 'DNA', value: 'dna' },
+    { label: 'RNA', value: 'rna' },
+    { label: 'Protein', value: 'protein', isDisabled: true },
+  ],
+}
+
+export const GroupedOptions = Template.bind({})
+GroupedOptions.parameters = {
+  docs: {
+    description: {
+      component: 'You can also pass grouped options:',
+    },
+  },
+}
+GroupedOptions.args = {
+  options: [
+    {
+      label: 'Nucleic Acids',
+      options: [
+        { label: 'DNA', value: 'dna' },
+        { label: 'RNA', value: 'rna' },
+      ],
+    },
+    {
+      label: 'Polypeptides',
+      options: [
+        { label: 'Dipeptide', value: 'dipeptide' },
+        { label: 'Tripeptide', value: 'Tripeptide' },
+      ],
+    },
+  ],
+}
+
+export const Controlled = Template.bind({})
+Controlled.parameters = {
+  docs: {
+    description: {
+      component:
+        'Passing `value` controls the input. **Note that `value` has the same format as an entry in `options`**',
+    },
+  },
+}
+Controlled.args = {
+  value: { label: 'DNA', value: 'dna' },
+  options: [
+    { label: 'DNA', value: 'dna' },
+    { label: 'RNA', value: 'rna' },
+    { label: 'Protein', value: 'protein' },
+  ],
+}
+
+export const FormattedOptionLabel = Template.bind({})
+FormattedOptionLabel.parameters = {
+  docs: {
+    description: {
+      component:
+        'You can control the renders of individual options with the `formatOptionLabel` prop:',
+    },
+  },
+}
+FormattedOptionLabel.args = {
+  options: [
+    { label: 'DNA', value: 'dna' },
+    { label: 'RNA', value: 'rna' },
+    { label: 'Protein', value: 'protein' },
+  ],
+  formatOptionLabel: (option, { context }) =>
+    context === 'menu' && option.value === 'rna' ? (
+      <span style={{ color: 'green' }}>{option.label}</span>
+    ) : (
+      option.label
+    ),
+}

--- a/app/src/atoms/SelectField/Select.stories.tsx
+++ b/app/src/atoms/SelectField/Select.stories.tsx
@@ -27,6 +27,7 @@ Basic.args = {
     { label: 'RNA', value: 'rna' },
     { label: 'Protein', value: 'protein', isDisabled: true },
   ],
+  width: '10rem',
 }
 
 export const GroupedOptions = Template.bind({})
@@ -54,6 +55,7 @@ GroupedOptions.args = {
       ],
     },
   ],
+  width: '10rem',
 }
 
 export const Controlled = Template.bind({})
@@ -72,6 +74,7 @@ Controlled.args = {
     { label: 'RNA', value: 'rna' },
     { label: 'Protein', value: 'protein' },
   ],
+  width: '10rem',
 }
 
 export const FormattedOptionLabel = Template.bind({})
@@ -89,6 +92,7 @@ FormattedOptionLabel.args = {
     { label: 'RNA', value: 'rna' },
     { label: 'Protein', value: 'protein' },
   ],
+  width: '10rem',
   formatOptionLabel: (option, { context }) =>
     context === 'menu' && option.value === 'rna' ? (
       <span style={{ color: 'green' }}>{option.label}</span>

--- a/app/src/atoms/SelectField/Select.stories.tsx
+++ b/app/src/atoms/SelectField/Select.stories.tsx
@@ -17,7 +17,7 @@ Basic.parameters = {
   docs: {
     description: {
       component:
-        'Thin wrapper around `react-select` to apply our Opentrons-specific styles. All props are passed directly to [`react-select`](https://react-select.com/props) except for `styles`, `components`, and `classNamePrefix`. The `className` prop appends to the `className` we pass `react-select`. Those props are not passed directly because they provide the base styling of the component',
+        'Thin wrapper around `react-select` to apply our Opentrons-specific styles in the app.',
     },
   },
 }

--- a/app/src/atoms/SelectField/Select.tsx
+++ b/app/src/atoms/SelectField/Select.tsx
@@ -99,8 +99,10 @@ export function Select(props: SelectComponentProps): JSX.Element {
     }),
     option: (styles: any, state: any) => ({
       ...styles,
-      color: state.isDisabled ? COLORS.greyDisabled : COLORS.darkBlack,
-      backgroundColor: state.isSelected ? COLORS.lightBlue : COLORS.white,
+      color: Boolean(state.isDisabled) ? COLORS.greyDisabled : COLORS.darkBlack,
+      backgroundColor: Boolean(state.isSelected)
+        ? COLORS.lightBlue
+        : COLORS.white,
       '&:hover': {
         backgroundColor: COLORS.lightBlue,
       },
@@ -112,6 +114,7 @@ export function Select(props: SelectComponentProps): JSX.Element {
       ...styles,
       marginLeft: SPACING.spacingSS,
       color: COLORS.darkBlack,
+      fontSize: TYPOGRAPHY.fontSizeP,
     }),
     singleValue: (styles: any) => ({
       ...styles,
@@ -143,7 +146,11 @@ function DropdownIndicator(
         width={SPACING.spacingM}
       >
         <Icon
-          name={props.selectProps.menuIsOpen ? 'chevron-up' : 'chevron-down'}
+          name={
+            Boolean(props.selectProps.menuIsOpen)
+              ? 'chevron-up'
+              : 'chevron-down'
+          }
           height={TYPOGRAPHY.lineHeight16}
         />
       </Box>

--- a/app/src/atoms/SelectField/Select.tsx
+++ b/app/src/atoms/SelectField/Select.tsx
@@ -53,7 +53,6 @@ export function Select(props: SelectComponentProps): JSX.Element {
     container: (styles: any) => ({
       ...styles,
       position: POSITION_RELATIVE,
-      fontSize: TYPOGRAPHY.fontSizeP,
     }),
     dropdownIndicator: NO_STYLE_FN,
     group: NO_STYLE_FN,
@@ -71,6 +70,7 @@ export function Select(props: SelectComponentProps): JSX.Element {
       position: POSITION_ABSOLUTE,
       top: SPACING.spacingXS,
       paddingLeft: '0.375rem',
+      fontSize: TYPOGRAPHY.fontSizeP,
     }),
     loadingIndicator: NO_STYLE_FN,
     loadingMessage: NO_STYLE_FN,
@@ -83,7 +83,11 @@ export function Select(props: SelectComponentProps): JSX.Element {
       marginTop: SPACING.spacing2,
       fontSize: TYPOGRAPHY.fontSizeP,
     }),
-    menuList: NO_STYLE_FN,
+    menuList: (styles: any) => ({
+      ...styles,
+      maxHeight: '38vh',
+      overflowY: 'scroll',
+    }),
     menuPortal: NO_STYLE_FN,
     multiValue: NO_STYLE_FN,
     multiValueLabel: NO_STYLE_FN,

--- a/app/src/atoms/SelectField/Select.tsx
+++ b/app/src/atoms/SelectField/Select.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import ReactSelect, { components, DropdownIndicatorProps } from 'react-select'
-import { css, CSSObject } from 'styled-components'
+import { CSSObject } from 'styled-components'
 import {
   Icon,
   BORDERS,
@@ -30,17 +30,6 @@ interface SelectComponentProps extends SelectProps {
 const VOID_STYLE: unknown = undefined
 const NO_STYLE_FN = (): CSSObject => VOID_STYLE as CSSObject
 
-const SELECT_STYLES = css`
-  position: ${POSITION_RELATIVE};
-  font-size: ${TYPOGRAPHY.fontSizeP};
-`
-
-const INDICATOR_STYLES = css`
-  position: ${POSITION_ABSOLUTE};
-  top: 0.75rem;
-  right: ${SPACING.spacing2};
-  width: ${SPACING.spacingM};
-`
 export function Select(props: SelectComponentProps): JSX.Element {
   const CLEAR_DEFAULT_STYLES_AND_SET_NEW_STYLES = {
     clearIndicator: NO_STYLE_FN,
@@ -53,7 +42,6 @@ export function Select(props: SelectComponentProps): JSX.Element {
       borderColor: COLORS.medGrey,
       boxShadow: 'none',
       padding: '0.375rem',
-      margin: '0rem',
       flexDirection: DIRECTION_ROW,
       '&:hover': {
         borderColor: COLORS.medGreyHover,
@@ -62,7 +50,11 @@ export function Select(props: SelectComponentProps): JSX.Element {
         borderColor: COLORS.medGreyHover,
       },
     }),
-    container: NO_STYLE_FN,
+    container: (styles: any) => ({
+      ...styles,
+      position: POSITION_RELATIVE,
+      fontSize: TYPOGRAPHY.fontSizeP,
+    }),
     dropdownIndicator: NO_STYLE_FN,
     group: NO_STYLE_FN,
     groupHeading: NO_STYLE_FN,
@@ -71,7 +63,7 @@ export function Select(props: SelectComponentProps): JSX.Element {
     input: (styles: any) => ({
       ...styles,
       zIndex: 5,
-      position: 'absolute',
+      position: POSITION_ABSOLUTE,
       top: SPACING.spacingXS,
       paddingLeft: '0.375rem',
     }),
@@ -83,6 +75,7 @@ export function Select(props: SelectComponentProps): JSX.Element {
       width: props.width != null ? props.width : 'auto',
       boxShadow: '0px 1px 3px rgba(0, 0, 0, 0.2)',
       borderRadius: '4px 4px 0px 0px',
+      marginTop: SPACING.spacing2,
     }),
     menuList: NO_STYLE_FN,
     menuPortal: NO_STYLE_FN,
@@ -124,7 +117,6 @@ export function Select(props: SelectComponentProps): JSX.Element {
       {...props}
       styles={CLEAR_DEFAULT_STYLES_AND_SET_NEW_STYLES}
       components={{ DropdownIndicator }}
-      css={SELECT_STYLES}
     />
   )
 }
@@ -134,7 +126,12 @@ function DropdownIndicator(
 ): JSX.Element {
   return (
     <components.DropdownIndicator {...props}>
-      <Box css={INDICATOR_STYLES}>
+      <Box
+        position={POSITION_ABSOLUTE}
+        top="0.75rem"
+        right={SPACING.spacing2}
+        width={SPACING.spacingM}
+      >
         <Icon
           name={props.selectProps.menuIsOpen ? 'chevron-up' : 'chevron-down'}
           height={TYPOGRAPHY.lineHeight16}

--- a/app/src/atoms/SelectField/Select.tsx
+++ b/app/src/atoms/SelectField/Select.tsx
@@ -1,0 +1,147 @@
+import * as React from 'react'
+import ReactSelect, { components, DropdownIndicatorProps } from 'react-select'
+import { css, CSSObject } from 'styled-components'
+import {
+  Icon,
+  BORDERS,
+  TYPOGRAPHY,
+  COLORS,
+  Box,
+  SPACING,
+  DIRECTION_ROW,
+  POSITION_RELATIVE,
+  POSITION_ABSOLUTE,
+} from '@opentrons/components'
+
+import type { Props as ReactSelectProps } from 'react-select'
+
+export type ChangeAction =
+  | 'select-option'
+  | 'deselect-option'
+  | 'remove-value'
+  | 'pop-value'
+  | 'set-value'
+  | 'clear'
+  | 'create-option'
+
+export interface SelectOption {
+  value: string
+  label?: string
+  isDisabled?: boolean
+}
+
+export type SelectProps = ReactSelectProps<SelectOption>
+
+const VOID_STYLE: unknown = undefined
+const NO_STYLE_FN = (): CSSObject => VOID_STYLE as CSSObject
+
+const CLEAR_STYLES = {
+  clearIndicator: NO_STYLE_FN,
+  control: (styles: any) => ({
+    ...styles,
+    borderRadius: BORDERS.radiusRoundEdge,
+    border: BORDERS.lineBorder,
+    width: '14rem',
+    borderColor: COLORS.medGrey,
+    boxShadow: 'none',
+    padding: '0.375rem',
+    margin: '0rem',
+    flexDirection: DIRECTION_ROW,
+    '&:hover': {
+      borderColor: COLORS.medGreyHover,
+    },
+    '&:active': {
+      borderColor: COLORS.medGreyHover,
+    },
+  }),
+  container: NO_STYLE_FN,
+  dropdownIndicator: NO_STYLE_FN,
+  group: NO_STYLE_FN,
+  groupHeading: NO_STYLE_FN,
+  indicatorsContainer: NO_STYLE_FN,
+  indicatorSeparator: NO_STYLE_FN,
+  input: (styles: any) => ({
+    ...styles,
+    zIndex: 5,
+    position: 'absolute',
+    top: SPACING.spacingXS,
+    paddingLeft: '0.375rem',
+  }),
+  loadingIndicator: NO_STYLE_FN,
+  loadingMessage: NO_STYLE_FN,
+  menu: (styles: any) => ({
+    ...styles,
+    backgroundColor: COLORS.white,
+    width: 'auto',
+    minWidth: '14rem',
+    boxShadow: '0px 1px 3px rgba(0, 0, 0, 0.2)',
+    borderRadius: '4px 4px 0px 0px',
+  }),
+  menuList: NO_STYLE_FN,
+  menuPortal: NO_STYLE_FN,
+  multiValue: NO_STYLE_FN,
+  multiValueLabel: NO_STYLE_FN,
+  multiValueRemove: NO_STYLE_FN,
+  noOptionsMessage: (styles: any) => ({
+    ...styles,
+    padding: '0.375rem',
+    color: COLORS.darkBlack,
+  }),
+  option: (styles: any) => ({
+    ...styles,
+    backgroundColor: COLORS.white,
+    '&:hover': {
+      backgroundColor: COLORS.lightBlue,
+    },
+    '&:active': {
+      backgroundColor: COLORS.lightBlue,
+    },
+  }),
+  placeholder: (styles: any) => ({
+    ...styles,
+    marginLeft: SPACING.spacingSS,
+    color: COLORS.darkBlack,
+  }),
+  singleValue: (styles: any) => ({
+    ...styles,
+    marginRight: '0.75rem',
+  }),
+  valueContainer: NO_STYLE_FN,
+}
+
+const SELECT_STYLES = css`
+  position: ${POSITION_RELATIVE};
+  font-size: ${TYPOGRAPHY.fontSizeP};
+`
+
+const INDICATOR_STYLES = css`
+  position: ${POSITION_ABSOLUTE};
+  top: 0.75rem;
+  right: ${SPACING.spacing2};
+  width: ${SPACING.spacingM};
+`
+export function Select(props: SelectProps): JSX.Element {
+  return (
+    <ReactSelect
+      {...props}
+      styles={CLEAR_STYLES}
+      components={{ DropdownIndicator }}
+      css={SELECT_STYLES}
+    />
+  )
+}
+
+function DropdownIndicator(
+  props: DropdownIndicatorProps<SelectOption>
+): JSX.Element {
+  return (
+    <components.DropdownIndicator {...props}>
+      <Box css={INDICATOR_STYLES}>
+        <Icon
+          name={props.selectProps.menuIsOpen ? 'chevron-up' : 'chevron-down'}
+          height={TYPOGRAPHY.lineHeight16}
+        />
+      </Box>
+    </components.DropdownIndicator>
+  )
+}

--- a/app/src/atoms/SelectField/Select.tsx
+++ b/app/src/atoms/SelectField/Select.tsx
@@ -15,15 +15,6 @@ import {
 
 import type { Props as ReactSelectProps } from 'react-select'
 
-export type ChangeAction =
-  | 'select-option'
-  | 'deselect-option'
-  | 'remove-value'
-  | 'pop-value'
-  | 'set-value'
-  | 'clear'
-  | 'create-option'
-
 export interface SelectOption {
   value: string
   label?: string
@@ -32,82 +23,12 @@ export interface SelectOption {
 
 export type SelectProps = ReactSelectProps<SelectOption>
 
+interface SelectComponentProps extends SelectProps {
+  width?: string
+}
+
 const VOID_STYLE: unknown = undefined
 const NO_STYLE_FN = (): CSSObject => VOID_STYLE as CSSObject
-
-const CLEAR_STYLES = {
-  clearIndicator: NO_STYLE_FN,
-  control: (styles: any) => ({
-    ...styles,
-    borderRadius: BORDERS.radiusRoundEdge,
-    border: BORDERS.lineBorder,
-    width: '14rem',
-    borderColor: COLORS.medGrey,
-    boxShadow: 'none',
-    padding: '0.375rem',
-    margin: '0rem',
-    flexDirection: DIRECTION_ROW,
-    '&:hover': {
-      borderColor: COLORS.medGreyHover,
-    },
-    '&:active': {
-      borderColor: COLORS.medGreyHover,
-    },
-  }),
-  container: NO_STYLE_FN,
-  dropdownIndicator: NO_STYLE_FN,
-  group: NO_STYLE_FN,
-  groupHeading: NO_STYLE_FN,
-  indicatorsContainer: NO_STYLE_FN,
-  indicatorSeparator: NO_STYLE_FN,
-  input: (styles: any) => ({
-    ...styles,
-    zIndex: 5,
-    position: 'absolute',
-    top: SPACING.spacingXS,
-    paddingLeft: '0.375rem',
-  }),
-  loadingIndicator: NO_STYLE_FN,
-  loadingMessage: NO_STYLE_FN,
-  menu: (styles: any) => ({
-    ...styles,
-    backgroundColor: COLORS.white,
-    width: 'auto',
-    minWidth: '14rem',
-    boxShadow: '0px 1px 3px rgba(0, 0, 0, 0.2)',
-    borderRadius: '4px 4px 0px 0px',
-  }),
-  menuList: NO_STYLE_FN,
-  menuPortal: NO_STYLE_FN,
-  multiValue: NO_STYLE_FN,
-  multiValueLabel: NO_STYLE_FN,
-  multiValueRemove: NO_STYLE_FN,
-  noOptionsMessage: (styles: any) => ({
-    ...styles,
-    padding: '0.375rem',
-    color: COLORS.darkBlack,
-  }),
-  option: (styles: any) => ({
-    ...styles,
-    backgroundColor: COLORS.white,
-    '&:hover': {
-      backgroundColor: COLORS.lightBlue,
-    },
-    '&:active': {
-      backgroundColor: COLORS.lightBlue,
-    },
-  }),
-  placeholder: (styles: any) => ({
-    ...styles,
-    marginLeft: SPACING.spacingSS,
-    color: COLORS.darkBlack,
-  }),
-  singleValue: (styles: any) => ({
-    ...styles,
-    marginRight: '0.75rem',
-  }),
-  valueContainer: NO_STYLE_FN,
-}
 
 const SELECT_STYLES = css`
   position: ${POSITION_RELATIVE};
@@ -120,11 +41,88 @@ const INDICATOR_STYLES = css`
   right: ${SPACING.spacing2};
   width: ${SPACING.spacingM};
 `
-export function Select(props: SelectProps): JSX.Element {
+export function Select(props: SelectComponentProps): JSX.Element {
+  const CLEAR_DEFAULT_STYLES_AND_SET_NEW_STYLES = {
+    clearIndicator: NO_STYLE_FN,
+    control: (styles: any) => ({
+      ...styles,
+      borderRadius: BORDERS.radiusRoundEdge,
+      border: BORDERS.lineBorder,
+      width: props.width != null ? props.width : 'auto',
+      height: SPACING.spacing4,
+      borderColor: COLORS.medGrey,
+      boxShadow: 'none',
+      padding: '0.375rem',
+      margin: '0rem',
+      flexDirection: DIRECTION_ROW,
+      '&:hover': {
+        borderColor: COLORS.medGreyHover,
+      },
+      '&:active': {
+        borderColor: COLORS.medGreyHover,
+      },
+    }),
+    container: NO_STYLE_FN,
+    dropdownIndicator: NO_STYLE_FN,
+    group: NO_STYLE_FN,
+    groupHeading: NO_STYLE_FN,
+    indicatorsContainer: NO_STYLE_FN,
+    indicatorSeparator: NO_STYLE_FN,
+    input: (styles: any) => ({
+      ...styles,
+      zIndex: 5,
+      position: 'absolute',
+      top: SPACING.spacingXS,
+      paddingLeft: '0.375rem',
+    }),
+    loadingIndicator: NO_STYLE_FN,
+    loadingMessage: NO_STYLE_FN,
+    menu: (styles: any) => ({
+      ...styles,
+      backgroundColor: COLORS.white,
+      width: props.width != null ? props.width : 'auto',
+      boxShadow: '0px 1px 3px rgba(0, 0, 0, 0.2)',
+      borderRadius: '4px 4px 0px 0px',
+    }),
+    menuList: NO_STYLE_FN,
+    menuPortal: NO_STYLE_FN,
+    multiValue: NO_STYLE_FN,
+    multiValueLabel: NO_STYLE_FN,
+    multiValueRemove: NO_STYLE_FN,
+    noOptionsMessage: (styles: any) => ({
+      ...styles,
+      padding: '0.375rem',
+      color: COLORS.darkBlack,
+    }),
+    option: (styles: any, state: any) => ({
+      ...styles,
+      color: COLORS.darkBlack,
+      backgroundColor: state.isSelected ? COLORS.lightBlue : COLORS.white,
+      '&:hover': {
+        backgroundColor: COLORS.lightBlue,
+      },
+      '&:active': {
+        backgroundColor: COLORS.lightBlue,
+      },
+    }),
+    placeholder: (styles: any) => ({
+      ...styles,
+      marginLeft: SPACING.spacingSS,
+      color: COLORS.darkBlack,
+    }),
+    singleValue: (styles: any) => ({
+      ...styles,
+      marginRight: '0.75rem',
+      marginTop: SPACING.spacing1,
+      marginLeft: SPACING.spacing3,
+    }),
+    valueContainer: NO_STYLE_FN,
+  }
+
   return (
     <ReactSelect
       {...props}
-      styles={CLEAR_STYLES}
+      styles={CLEAR_DEFAULT_STYLES_AND_SET_NEW_STYLES}
       components={{ DropdownIndicator }}
       css={SELECT_STYLES}
     />

--- a/app/src/atoms/SelectField/Select.tsx
+++ b/app/src/atoms/SelectField/Select.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import ReactSelect, { components, DropdownIndicatorProps } from 'react-select'
-import { CSSObject } from 'styled-components'
 import {
   Icon,
   BORDERS,
@@ -13,7 +12,12 @@ import {
   POSITION_ABSOLUTE,
 } from '@opentrons/components'
 
-import type { Props as ReactSelectProps } from 'react-select'
+import type {
+  Props as ReactSelectProps,
+  StylesConfig,
+  OptionProps,
+  CSSObjectWithLabel,
+} from 'react-select'
 
 export interface SelectOption {
   value: string
@@ -28,12 +32,12 @@ interface SelectComponentProps extends SelectProps {
 }
 
 const VOID_STYLE: unknown = undefined
-const NO_STYLE_FN = (): CSSObject => VOID_STYLE as CSSObject
+const NO_STYLE_FN = (): CSSObjectWithLabel => VOID_STYLE as CSSObjectWithLabel
 
 export function Select(props: SelectComponentProps): JSX.Element {
-  const CLEAR_DEFAULT_STYLES_AND_SET_NEW_STYLES = {
+  const CLEAR_DEFAULT_STYLES_AND_SET_NEW_STYLES: StylesConfig<SelectOption> = {
     clearIndicator: NO_STYLE_FN,
-    control: (styles: any) => ({
+    control: (styles: CSSObjectWithLabel) => ({
       ...styles,
       borderRadius: BORDERS.radiusRoundEdge,
       border: BORDERS.lineBorder,
@@ -50,21 +54,21 @@ export function Select(props: SelectComponentProps): JSX.Element {
         borderColor: COLORS.medGreyHover,
       },
     }),
-    container: (styles: any) => ({
+    container: (styles: CSSObjectWithLabel) => ({
       ...styles,
       position: POSITION_RELATIVE,
     }),
     dropdownIndicator: NO_STYLE_FN,
     group: NO_STYLE_FN,
-    groupHeading: (styles: any) => ({
+    groupHeading: (styles: CSSObjectWithLabel) => ({
       ...styles,
       color: COLORS.darkBlack,
-      fontWeight: TYPOGRAPHY.pSemiBold,
+      fontWeight: TYPOGRAPHY.fontWeightSemiBold,
       fontSize: TYPOGRAPHY.fontSizeP,
     }),
     indicatorsContainer: NO_STYLE_FN,
     indicatorSeparator: NO_STYLE_FN,
-    input: (styles: any) => ({
+    input: (styles: CSSObjectWithLabel) => ({
       ...styles,
       zIndex: 5,
       position: POSITION_ABSOLUTE,
@@ -74,7 +78,7 @@ export function Select(props: SelectComponentProps): JSX.Element {
     }),
     loadingIndicator: NO_STYLE_FN,
     loadingMessage: NO_STYLE_FN,
-    menu: (styles: any) => ({
+    menu: (styles: CSSObjectWithLabel) => ({
       ...styles,
       backgroundColor: COLORS.white,
       width: props.width != null ? props.width : 'auto',
@@ -83,7 +87,7 @@ export function Select(props: SelectComponentProps): JSX.Element {
       marginTop: SPACING.spacing2,
       fontSize: TYPOGRAPHY.fontSizeP,
     }),
-    menuList: (styles: any) => ({
+    menuList: (styles: CSSObjectWithLabel) => ({
       ...styles,
       maxHeight: '38vh',
       overflowY: 'scroll',
@@ -92,12 +96,12 @@ export function Select(props: SelectComponentProps): JSX.Element {
     multiValue: NO_STYLE_FN,
     multiValueLabel: NO_STYLE_FN,
     multiValueRemove: NO_STYLE_FN,
-    noOptionsMessage: (styles: any) => ({
+    noOptionsMessage: (styles: CSSObjectWithLabel) => ({
       ...styles,
       padding: '0.375rem',
       color: COLORS.darkBlack,
     }),
-    option: (styles: any, state: any) => ({
+    option: (styles: CSSObjectWithLabel, state: OptionProps<SelectOption>) => ({
       ...styles,
       color: Boolean(state.isDisabled) ? COLORS.greyDisabled : COLORS.darkBlack,
       backgroundColor: Boolean(state.isSelected)
@@ -110,13 +114,13 @@ export function Select(props: SelectComponentProps): JSX.Element {
         backgroundColor: COLORS.lightBlue,
       },
     }),
-    placeholder: (styles: any) => ({
+    placeholder: (styles: CSSObjectWithLabel) => ({
       ...styles,
       marginLeft: SPACING.spacingSS,
       color: COLORS.darkBlack,
       fontSize: TYPOGRAPHY.fontSizeP,
     }),
-    singleValue: (styles: any) => ({
+    singleValue: (styles: CSSObjectWithLabel) => ({
       ...styles,
       marginRight: '0.75rem',
       marginTop: SPACING.spacing1,

--- a/app/src/atoms/SelectField/Select.tsx
+++ b/app/src/atoms/SelectField/Select.tsx
@@ -10,6 +10,7 @@ import {
   DIRECTION_ROW,
   POSITION_RELATIVE,
   POSITION_ABSOLUTE,
+  SIZE_1,
 } from '@opentrons/components'
 
 import type {
@@ -123,7 +124,6 @@ export function Select(props: SelectComponentProps): JSX.Element {
     singleValue: (styles: CSSObjectWithLabel) => ({
       ...styles,
       marginRight: '0.75rem',
-      marginTop: SPACING.spacing1,
       marginLeft: SPACING.spacing2,
     }),
     valueContainer: NO_STYLE_FN,
@@ -155,7 +155,7 @@ function DropdownIndicator(
               ? 'chevron-up'
               : 'chevron-down'
           }
-          height={TYPOGRAPHY.lineHeight16}
+          height={SIZE_1}
         />
       </Box>
     </components.DropdownIndicator>

--- a/app/src/atoms/SelectField/Select.tsx
+++ b/app/src/atoms/SelectField/Select.tsx
@@ -57,7 +57,12 @@ export function Select(props: SelectComponentProps): JSX.Element {
     }),
     dropdownIndicator: NO_STYLE_FN,
     group: NO_STYLE_FN,
-    groupHeading: NO_STYLE_FN,
+    groupHeading: (styles: any) => ({
+      ...styles,
+      color: COLORS.darkBlack,
+      fontWeight: TYPOGRAPHY.pSemiBold,
+      fontSize: TYPOGRAPHY.fontSizeP,
+    }),
     indicatorsContainer: NO_STYLE_FN,
     indicatorSeparator: NO_STYLE_FN,
     input: (styles: any) => ({
@@ -76,6 +81,7 @@ export function Select(props: SelectComponentProps): JSX.Element {
       boxShadow: '0px 1px 3px rgba(0, 0, 0, 0.2)',
       borderRadius: '4px 4px 0px 0px',
       marginTop: SPACING.spacing2,
+      fontSize: TYPOGRAPHY.fontSizeP,
     }),
     menuList: NO_STYLE_FN,
     menuPortal: NO_STYLE_FN,
@@ -89,7 +95,7 @@ export function Select(props: SelectComponentProps): JSX.Element {
     }),
     option: (styles: any, state: any) => ({
       ...styles,
-      color: COLORS.darkBlack,
+      color: state.isDisabled ? COLORS.greyDisabled : COLORS.darkBlack,
       backgroundColor: state.isSelected ? COLORS.lightBlue : COLORS.white,
       '&:hover': {
         backgroundColor: COLORS.lightBlue,
@@ -107,7 +113,7 @@ export function Select(props: SelectComponentProps): JSX.Element {
       ...styles,
       marginRight: '0.75rem',
       marginTop: SPACING.spacing1,
-      marginLeft: SPACING.spacing3,
+      marginLeft: SPACING.spacing2,
     }),
     valueContainer: NO_STYLE_FN,
   }

--- a/app/src/atoms/SelectField/index.tsx
+++ b/app/src/atoms/SelectField/index.tsx
@@ -36,9 +36,9 @@ export interface SelectFieldProps {
   ) => void
   /** blur handler called with (name) */
   onLoseFocus?: (name: string) => void
-  /** optional prop to make select not searchable through typing into the search field*/
+  /** optional prop to make select not searchable through typing into the search field  */
   isSearchable?: boolean
-  /** optional width to specify the width of the select field and dropdown menu*/
+  /** optional width to specify the width of the select field and dropdown menu */
   width?: string
 }
 

--- a/app/src/atoms/SelectField/index.tsx
+++ b/app/src/atoms/SelectField/index.tsx
@@ -62,13 +62,13 @@ export function SelectField(props: SelectFieldProps): JSX.Element {
     error,
     onValueChange,
     onLoseFocus,
-    isSearchable,
+    isSearchable = true,
     width,
   } = props
   // @ts-expect-error(mc, 2021-03-19): resolve this error
   const allOptions = options.flatMap(og => og.options || [og])
   const value = find(allOptions, opt => opt.value === props.value) || null
-  const caption = error || props.caption
+  const caption = error != null || props.caption
 
   return (
     <>
@@ -91,9 +91,9 @@ export function SelectField(props: SelectFieldProps): JSX.Element {
           const value = (opt as SelectOption).value
           onValueChange?.(name, value, e)
         }}
-        onBlur={() => onLoseFocus && onLoseFocus(name)}
+        onBlur={() => onLoseFocus?.(name)}
       />
-      {caption && <Flex css={CAPTION_STYLE}>{caption}</Flex>}
+      {caption != null && <Flex css={CAPTION_STYLE}>{caption}</Flex>}
     </>
   )
 }

--- a/app/src/atoms/SelectField/index.tsx
+++ b/app/src/atoms/SelectField/index.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react'
-import cx from 'classnames'
 import find from 'lodash/find'
-
 import { Select } from './Select'
-import styles from './SelectField.css'
+import { COLORS, Flex, TYPOGRAPHY } from '@opentrons/components'
+import { css } from 'styled-components'
 
-import type { SelectProps } from './Select'
+import type { SelectProps, SelectOption } from './Select'
 import type { ActionMeta, MultiValue, SingleValue } from 'react-select'
-import type { SelectOption } from '.'
 
 export interface SelectFieldProps {
   /** optional HTML id for container */
@@ -17,7 +15,7 @@ export interface SelectFieldProps {
   /** react-Select option, usually label, value */
   options: NonNullable<SelectProps['options']>
   /** currently selected value */
-  value?: string | null
+  value: string | null | undefined
   /** disable the select */
   disabled?: SelectProps['isDisabled']
   /** optional placeholder  */
@@ -26,21 +24,27 @@ export interface SelectFieldProps {
   menuPosition?: SelectProps['menuPosition']
   /** render function for the option label passed to react-select */
   formatOptionLabel?: SelectProps['formatOptionLabel']
-  /** optional className */
-  className?: string
   /** optional caption. hidden when `error` is given */
   caption?: React.ReactNode
   /** if included, use error style and display error instead of caption */
   error?: string | null | undefined
-  /** change handler called with (name, value) */
+  /** change handler called with (name, value, actionMeta) */
   onValueChange?: (
     name: string,
     value: string,
     actionMeta: ActionMeta<SelectOption>
   ) => void
   /** blur handler called with (name) */
-  onLoseFocus?: (name: string) => void
+  onLoseFocus?: (name: string) => unknown
 }
+
+const CAPTION_STYLE = css`
+  font-size: ${TYPOGRAPHY.fontSizeCaption};
+  &.error {
+    color: ${COLORS.error};
+    font-weight: ${TYPOGRAPHY.fontWeightSemiBold};
+  }
+`
 
 export function SelectField(props: SelectFieldProps): JSX.Element {
   const {
@@ -51,7 +55,6 @@ export function SelectField(props: SelectFieldProps): JSX.Element {
     placeholder,
     menuPosition,
     formatOptionLabel,
-    className,
     error,
     onValueChange,
     onLoseFocus,
@@ -60,15 +63,10 @@ export function SelectField(props: SelectFieldProps): JSX.Element {
   const allOptions = options.flatMap(og => og.options || [og])
   const value = find(allOptions, opt => opt.value === props.value) || null
   const caption = error || props.caption
-  // @ts-expect-error(sa, 2021-6-23): cast value to boolean
-  const captionCx = cx(styles.select_caption, { [styles.error]: error })
-  // @ts-expect-error(sa, 2021-6-23): cast value to boolean
-  const fieldCx = cx(styles.select_field, { [styles.error]: error }, className)
 
   return (
-    <div>
+    <>
       <Select
-        className={fieldCx}
         id={id}
         name={name}
         options={options}
@@ -86,7 +84,7 @@ export function SelectField(props: SelectFieldProps): JSX.Element {
         }}
         onBlur={() => onLoseFocus && onLoseFocus(name)}
       />
-      {caption && <p className={captionCx}>{caption}</p>}
-    </div>
+      {caption && <Flex css={CAPTION_STYLE}>{caption}</Flex>}
+    </>
   )
 }

--- a/app/src/atoms/SelectField/index.tsx
+++ b/app/src/atoms/SelectField/index.tsx
@@ -15,7 +15,7 @@ export interface SelectFieldProps {
   /** react-Select option, usually label, value */
   options: NonNullable<SelectProps['options']>
   /** currently selected value */
-  value: string | null | undefined
+  value: string | null
   /** disable the select */
   disabled?: SelectProps['isDisabled']
   /** optional placeholder  */
@@ -27,7 +27,7 @@ export interface SelectFieldProps {
   /** optional caption. hidden when `error` is given */
   caption?: React.ReactNode
   /** if included, use error style and display error instead of caption */
-  error?: string | null | undefined
+  error?: string | null
   /** change handler called with (name, value, actionMeta) */
   onValueChange?: (
     name: string,
@@ -35,7 +35,11 @@ export interface SelectFieldProps {
     actionMeta: ActionMeta<SelectOption>
   ) => void
   /** blur handler called with (name) */
-  onLoseFocus?: (name: string) => unknown
+  onLoseFocus?: (name: string) => void
+  /** optional prop to make select not searchable through typing into the search field*/
+  isSearchable?: boolean
+  /** optional width to specify the width of the select field and dropdown menu*/
+  width?: string
 }
 
 const CAPTION_STYLE = css`
@@ -58,6 +62,8 @@ export function SelectField(props: SelectFieldProps): JSX.Element {
     error,
     onValueChange,
     onLoseFocus,
+    isSearchable,
+    width,
   } = props
   // @ts-expect-error(mc, 2021-03-19): resolve this error
   const allOptions = options.flatMap(og => og.options || [og])
@@ -73,7 +79,10 @@ export function SelectField(props: SelectFieldProps): JSX.Element {
         value={value}
         isDisabled={disabled}
         placeholder={placeholder}
+        isSearchable={isSearchable}
         menuPosition={menuPosition}
+        width={width}
+        tabIndex={2}
         formatOptionLabel={formatOptionLabel}
         onChange={(
           opt: SingleValue<SelectOption> | MultiValue<SelectOption>,

--- a/app/src/atoms/SelectField/index.tsx
+++ b/app/src/atoms/SelectField/index.tsx
@@ -65,8 +65,9 @@ export function SelectField(props: SelectFieldProps): JSX.Element {
     isSearchable = true,
     width,
   } = props
-  // @ts-expect-error(mc, 2021-03-19): resolve this error
-  const allOptions = options.flatMap(og => og.options || [og])
+  const allOptions = options.flatMap(og =>
+    'options' in og ? og.options : [og]
+  )
   const value = find(allOptions, opt => opt.value === props.value) || null
   const caption = error != null || props.caption
 

--- a/app/src/organisms/CalibrationPanels/ChooseTipRack.tsx
+++ b/app/src/organisms/CalibrationPanels/ChooseTipRack.tsx
@@ -51,7 +51,8 @@ import type {
 import type { State } from '../../redux/types'
 import type { SelectOption, SelectOptionOrGroup } from '@opentrons/components'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
-import { Mount } from '../../redux/pipettes/types'
+import type { Mount } from '../../redux/pipettes/types'
+import type { MultiValue, SingleValue } from 'react-select'
 
 const HEADER = 'choose tip rack'
 const INTRO = 'Choose what tip rack you would like to use to calibrate your'
@@ -184,20 +185,23 @@ export function ChooseTipRack(props: ChooseTipRackProps): JSX.Element {
         ]
       : [...opentronsTipRacksOptions]
 
-  const [selectedValue, setSelectedValue] = React.useState<SelectOption>(
+  const [selectedValue, setSelectedValue] = React.useState<
+    SingleValue<SelectOption> | MultiValue<SelectOption>
+  >(
     chosenTipRack
       ? formatOptionsFromLabwareDef(chosenTipRack)
       : formatOptionsFromLabwareDef(tipRack.definition)
   )
 
   const handleValueChange = (
-    selected: SelectOption | null,
+    selected: SingleValue<SelectOption> | MultiValue<SelectOption>,
     _: unknown
   ): void => {
     selected && setSelectedValue(selected)
   }
   const handleUseTipRack = (): void => {
-    const selectedTipRack = tipRackByUriMap[selectedValue.value]
+    const value = (selectedValue as SelectOption).value
+    const selectedTipRack = tipRackByUriMap[value]
     // @ts-expect-error(sa, 2021-05-26): need to type narrow, avoiding src code change for now
     if (!isEqual(chosenTipRack, selectedTipRack.definition)) {
       // @ts-expect-error(sa, 2021-05-26): need to type narrow, avoiding src code change for now
@@ -268,7 +272,7 @@ export function ChooseTipRack(props: ChooseTipRackProps): JSX.Element {
               showCalibrationText={
                 sessionType === Sessions.SESSION_TYPE_PIPETTE_OFFSET_CALIBRATION
               }
-              selectedValue={selectedValue}
+              selectedValue={selectedValue as SelectOption}
               tipRackByUriMap={tipRackByUriMap}
             />
           </Box>

--- a/app/src/organisms/CalibrationPanels/ChooseTipRack.tsx
+++ b/app/src/organisms/CalibrationPanels/ChooseTipRack.tsx
@@ -202,10 +202,11 @@ export function ChooseTipRack(props: ChooseTipRackProps): JSX.Element {
   const handleUseTipRack = (): void => {
     const value = (selectedValue as SelectOption).value
     const selectedTipRack = tipRackByUriMap[value]
-    // @ts-expect-error(sa, 2021-05-26): need to type narrow, avoiding src code change for now
-    if (!isEqual(chosenTipRack, selectedTipRack.definition)) {
-      // @ts-expect-error(sa, 2021-05-26): need to type narrow, avoiding src code change for now
-      handleChosenTipRack(selectedTipRack.definition)
+    if (!isEqual(chosenTipRack, selectedTipRack?.definition)) {
+      handleChosenTipRack(
+        (selectedTipRack?.definition != null && selectedTipRack.definition) ||
+          null
+      )
     }
     closeModal()
   }

--- a/app/src/organisms/CalibrationPanels/ChosenTipRackRender.tsx
+++ b/app/src/organisms/CalibrationPanels/ChosenTipRackRender.tsx
@@ -52,7 +52,7 @@ export function ChosenTipRackRender(
   const loadName: keyof typeof labwareImages = selectedValue.value.split(
     '/'
   )[1] as any
-  const displayName = selectedValue.label
+  const displayName = selectedValue?.label
   const calibrationData = tipRackByUriMap[selectedValue.value]?.calibration
 
   const imageSrc =

--- a/app/src/organisms/Devices/RobotSettings/ConnectNetwork/ConnectModal/__tests__/KeyFileField.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/ConnectNetwork/ConnectModal/__tests__/KeyFileField.test.tsx
@@ -10,6 +10,8 @@ import * as FormState from '../form-state'
 import { LABEL_ADD_NEW_KEY } from '../../i18n'
 
 import type { ShallowWrapper } from 'enzyme'
+import type { ActionMeta } from 'react-select'
+import type { SelectOption } from '@opentrons/components'
 
 jest.mock('../form-state')
 
@@ -127,7 +129,11 @@ describe('ConnectModal KeyFileField', () => {
     const wrapper = render()
     const select = wrapper.find(SelectField)
 
-    select.invoke('onValueChange')?.(fieldName, 'new-key-id')
+    select.invoke('onValueChange')?.(
+      fieldName,
+      'new-key-id',
+      ('input-change' as unknown) as ActionMeta<SelectOption>
+    )
     expect(setValue).toHaveBeenCalledWith('new-key-id')
   })
 
@@ -137,7 +143,11 @@ describe('ConnectModal KeyFileField', () => {
     const options = select.prop('options').flatMap((o: any) => o.options)
     const addNewOpt = options.find(o => o?.label === LABEL_ADD_NEW_KEY)
 
-    select.invoke('onValueChange')?.(fieldName, addNewOpt?.value)
+    select.invoke('onValueChange')?.(
+      fieldName,
+      addNewOpt?.value,
+      ('input-change' as unknown) as ActionMeta<SelectOption>
+    )
     expect(setValue).not.toHaveBeenCalledWith(addNewOpt?.value)
   })
 

--- a/app/src/organisms/Devices/RobotSettings/ConnectNetwork/ConnectModal/__tests__/SecurityField.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/ConnectNetwork/ConnectModal/__tests__/SecurityField.test.tsx
@@ -8,6 +8,8 @@ import * as FormState from '../form-state'
 
 import { LABEL_SECURITY_NONE, LABEL_SECURITY_PSK } from '../../i18n'
 import { SECURITY_NONE, SECURITY_WPA_PSK } from '../../constants'
+import type { ActionMeta } from 'react-select'
+import type { SelectOption } from '@opentrons/components'
 
 jest.mock('../form-state')
 
@@ -112,7 +114,12 @@ describe('ConnectModal SecurityField', () => {
     const wrapper = render()
     const select = wrapper.find(SelectField)
 
-    select.invoke('onValueChange')?.(fieldName, SECURITY_NONE)
+    select.invoke('onValueChange')?.(
+      fieldName,
+      SECURITY_NONE,
+      ('input-change' as unknown) as ActionMeta<SelectOption>
+    )
+
     expect(setValue).toHaveBeenCalledWith(SECURITY_NONE)
   })
 

--- a/app/src/organisms/Devices/RobotSettings/ConnectNetwork/SelectSsid/__tests__/SelectSsid.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/ConnectNetwork/SelectSsid/__tests__/SelectSsid.test.tsx
@@ -1,12 +1,16 @@
 import * as React from 'react'
 import { mount } from 'enzyme'
-import { SelectField, CONTEXT_VALUE, CONTEXT_MENU } from '@opentrons/components'
+import { CONTEXT_VALUE, CONTEXT_MENU } from '@opentrons/components'
 
+import { SelectField } from '../../../../../../atoms/SelectField'
 import * as Fixtures from '../../../../../../redux/networking/__fixtures__'
 import { LABEL_JOIN_OTHER_NETWORK, DISCONNECT_FROM_SSID } from '../../i18n'
 
 import { SelectSsid } from '..'
 import { NetworkOptionLabel } from '../NetworkOptionLabel'
+
+import type { ActionMeta } from 'react-select'
+import type { SelectOption } from '../../../../../../atoms/SelectField/Select'
 
 const mockWifiList = [
   { ...Fixtures.mockWifiNetwork, ssid: 'foo', active: true },
@@ -107,7 +111,11 @@ describe('SelectSsid component', () => {
     const wrapper = render()
     const selectField = wrapper.find(SelectField)
 
-    selectField.invoke('onValueChange')?.('_', 'foo')
+    selectField.invoke('onValueChange')?.(
+      '_',
+      'foo',
+      ('input-change' as unknown) as ActionMeta<SelectOption>
+    )
 
     expect(handleConnect).toHaveBeenCalledWith('foo')
   })
@@ -121,7 +129,11 @@ describe('SelectSsid component', () => {
     )?.value
 
     expect(joinOtherValue).toEqual(expect.any(String))
-    selectField.invoke('onValueChange')?.('_', joinOtherValue)
+    selectField.invoke('onValueChange')?.(
+      '_',
+      joinOtherValue,
+      ('input-change' as unknown) as ActionMeta<SelectOption>
+    )
 
     expect(handleJoinOther).toHaveBeenCalled()
   })
@@ -135,7 +147,11 @@ describe('SelectSsid component', () => {
     )?.value
 
     expect(disconectValue).toEqual(expect.any(String))
-    selectField.invoke('onValueChange')?.('_', disconectValue)
+    selectField.invoke('onValueChange')?.(
+      '_',
+      disconectValue,
+      ('input-change' as unknown) as ActionMeta<SelectOption>
+    )
 
     expect(handleDisconnect).toHaveBeenCalled()
   })

--- a/app/src/organisms/Devices/RobotSettings/ConnectNetwork/SelectSsid/index.tsx
+++ b/app/src/organisms/Devices/RobotSettings/ConnectNetwork/SelectSsid/index.tsx
@@ -103,6 +103,7 @@ export function SelectSsid(props: SelectSsidProps): JSX.Element {
       placeholder={Copy.SELECT_NETWORK}
       onValueChange={handleValueChange}
       formatOptionLabel={formatOptionLabel}
+      width="14rem"
     />
   )
 }

--- a/app/src/organisms/Devices/RobotSettings/ConnectNetwork/SelectSsid/index.tsx
+++ b/app/src/organisms/Devices/RobotSettings/ConnectNetwork/SelectSsid/index.tsx
@@ -1,14 +1,10 @@
 import * as React from 'react'
-import styled from 'styled-components'
-
-import { SelectField, CONTEXT_MENU } from '@opentrons/components'
+import { CONTEXT_MENU } from '@opentrons/components'
+import { SelectField } from '../../../../../atoms/SelectField'
 import * as Copy from '../i18n'
 import { NetworkOptionLabel, NetworkActionLabel } from './NetworkOptionLabel'
 
-import type {
-  SelectFieldProps,
-  SelectOptionOrGroup,
-} from '@opentrons/components'
+import type { SelectOptionOrGroup } from '@opentrons/components'
 
 import type { WifiNetwork } from '../types'
 
@@ -39,12 +35,6 @@ const makeSelectDisconnectGroup = (
     { value: DISCONNECT_WIFI_VALUE, label: Copy.DISCONNECT_FROM_SSID(ssid) },
   ],
 })
-
-const StyledSelectField: React.ComponentType<SelectFieldProps> = styled(
-  SelectField
-)`
-  max-width: 16.875rem;
-`
 
 const formatOptions = (
   list: WifiNetwork[],
@@ -85,7 +75,7 @@ export function SelectSsid(props: SelectSsidProps): JSX.Element {
   }
 
   const formatOptionLabel: React.ComponentProps<
-    typeof StyledSelectField
+    typeof SelectField
   >['formatOptionLabel'] = (option, { context }): JSX.Element | null => {
     const { value, label } = option
 
@@ -105,7 +95,7 @@ export function SelectSsid(props: SelectSsidProps): JSX.Element {
   }
 
   return (
-    <StyledSelectField
+    <SelectField
       disabled={isRobotBusy}
       name={FIELD_NAME}
       value={value}

--- a/app/src/organisms/Devices/RobotSettings/ConnectNetwork/SelectSsid/index.tsx
+++ b/app/src/organisms/Devices/RobotSettings/ConnectNetwork/SelectSsid/index.tsx
@@ -103,7 +103,7 @@ export function SelectSsid(props: SelectSsidProps): JSX.Element {
       placeholder={Copy.SELECT_NETWORK}
       onValueChange={handleValueChange}
       formatOptionLabel={formatOptionLabel}
-      width="14rem"
+      width="16rem"
     />
   )
 }

--- a/app/src/pages/AppSettings/AdvancedSettings.tsx
+++ b/app/src/pages/AppSettings/AdvancedSettings.tsx
@@ -192,7 +192,11 @@ export function AdvancedSettings(): JSX.Element {
   >['formatOptionLabel'] = (option, index): JSX.Element => {
     const { label, value } = option
     return (
-      <StyledText as="p" textTransform={TEXT_TRANSFORM_CAPITALIZE} id={index}>
+      <StyledText
+        as="p"
+        textTransform={TYPOGRAPHY.textTransformCapitalize}
+        id={index}
+      >
         {value === 'latest' ? label : value}
       </StyledText>
     )

--- a/app/src/pages/AppSettings/AdvancedSettings.tsx
+++ b/app/src/pages/AppSettings/AdvancedSettings.tsx
@@ -190,10 +190,10 @@ export function AdvancedSettings(): JSX.Element {
   const formatOptionLabel: React.ComponentProps<
     typeof SelectField
   >['formatOptionLabel'] = (option, index): JSX.Element => {
-    const { value } = option
+    const { label, value } = option
     return (
       <StyledText as="p" textTransform={TEXT_TRANSFORM_CAPITALIZE} id={index}>
-        {value === 'latest' ? 'Stable' : value}
+        {value === 'latest' ? label : value}
       </StyledText>
     )
   }

--- a/app/src/pages/AppSettings/AdvancedSettings.tsx
+++ b/app/src/pages/AppSettings/AdvancedSettings.tsx
@@ -273,18 +273,16 @@ export function AdvancedSettings(): JSX.Element {
               {t('update_description')}
             </StyledText>
           </Box>
-          <Box width="10rem">
-            <SelectField
-              name={'__updateChannel__'}
-              options={channelOptions}
-              onValueChange={handleChannel}
-              value={channel}
-              placeholder={channel}
-              formatOptionLabel={formatOptionLabel}
-              isSearchable={false}
-              width="10rem"
-            />
-          </Box>
+          <SelectField
+            name={'__UpdateChannel__'}
+            options={channelOptions}
+            onValueChange={handleChannel}
+            value={channel}
+            placeholder={channel}
+            formatOptionLabel={formatOptionLabel}
+            isSearchable={false}
+            width="10rem"
+          />
         </Flex>
         <Divider marginY={SPACING.spacing5} />
         <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>

--- a/app/src/pages/AppSettings/AdvancedSettings.tsx
+++ b/app/src/pages/AppSettings/AdvancedSettings.tsx
@@ -9,7 +9,6 @@ import {
   Box,
   Link,
   Icon,
-  DropdownField,
   RadioGroup,
   SPACING_AUTO,
   ALIGN_CENTER,
@@ -34,6 +33,8 @@ import {
 } from '../../redux/discovery'
 import { Modal } from '../../atoms/Modal'
 import { Portal } from '../../App/portal'
+import { SelectOption } from '../../atoms/SelectField/Select'
+import { SelectField } from '../../atoms/SelectField'
 import { Toast } from '../../atoms/Toast'
 import { useTrackEvent } from '../../redux/analytics'
 import {
@@ -51,7 +52,6 @@ import { StyledText } from '../../atoms/text'
 import { Banner } from '../../atoms/Banner'
 
 import type { Dispatch, State } from '../../redux/types'
-import type { DropdownOption } from '@opentrons/components'
 
 const ALWAYS_BLOCK: 'always-block' = 'always-block'
 const ALWAYS_TRASH: 'always-trash' = 'always-trash'
@@ -77,7 +77,7 @@ export function AdvancedSettings(): JSX.Element {
   const trackEvent = useTrackEvent()
   const devToolsOn = useSelector(Config.getDevtoolsEnabled)
   const channel = useSelector(Config.getUpdateChannel)
-  const channelOptions: DropdownOption[] = useSelector(
+  const channelOptions: SelectOption[] = useSelector(
     Config.getUpdateChannelOptions
   )
   const labwarePath = useSelector(CustomLabware.getCustomLabwareDirectory)
@@ -180,11 +180,23 @@ export function AdvancedSettings(): JSX.Element {
   }
 
   const toggleDevtools = (): unknown => dispatch(Config.toggleDevtools())
-  const handleChannel: React.ChangeEventHandler<HTMLSelectElement> = event =>
-    dispatch(Config.updateConfigValue('update.channel', event.target.value))
+  const handleChannel = (_: string, value: string): void => {
+    dispatch(Config.updateConfigValue('update.channel', value))
+  }
   const displayUnavailRobots = useSelector((state: State) => {
     return Config.getConfig(state)?.discovery.disableCache ?? false
   })
+
+  const formatOptionLabel: React.ComponentProps<
+    typeof SelectField
+  >['formatOptionLabel'] = (option, index): JSX.Element => {
+    const { value } = option
+    return (
+      <StyledText as="p" textTransform={TEXT_TRANSFORM_CAPITALIZE} id={index}>
+        {value === 'latest' ? 'Stable' : value}
+      </StyledText>
+    )
+  }
 
   return (
     <>
@@ -258,11 +270,15 @@ export function AdvancedSettings(): JSX.Element {
             </StyledText>
           </Box>
           <Box width="10rem">
-            <DropdownField
+            <SelectField
+              name={'__updateChannel__'}
               options={channelOptions}
-              onChange={handleChannel}
+              onValueChange={handleChannel}
               value={channel}
-              id={`AdvancedSettings_${channel}`}
+              placeholder={channel}
+              formatOptionLabel={formatOptionLabel}
+              isSearchable={false}
+              width="10rem"
             />
           </Box>
         </Flex>

--- a/app/src/pages/AppSettings/__test__/AdvancedSettings.test.tsx
+++ b/app/src/pages/AppSettings/__test__/AdvancedSettings.test.tsx
@@ -97,11 +97,11 @@ describe('AdvancedSettings', () => {
     getCustomLabwarePath.mockReturnValue('')
     getChannelOptions.mockReturnValue([
       {
-        name: 'Stable',
+        label: 'Stable',
         value: 'latest',
       },
-      { name: 'Beta', value: 'beta' },
-      { name: 'Alpha', value: 'alpha' },
+      { label: 'Beta', value: 'beta' },
+      { label: 'Alpha', value: 'alpha' },
     ])
     mockGetU2EAdapterDevice.mockReturnValue(Fixtures.mockWindowsRealtekDevice)
     mockGetUnreachableRobots.mockReturnValue([mockUnreachableRobot])

--- a/app/src/pages/AppSettings/__test__/AdvancedSettings.test.tsx
+++ b/app/src/pages/AppSettings/__test__/AdvancedSettings.test.tsx
@@ -126,14 +126,12 @@ describe('AdvancedSettings', () => {
     getByText('Clear Unavailable Robots')
     getByText('Enable Developer Tools')
   })
-  it('renders the update channel section', () => {
+  it('renders the update channel combobox and section', () => {
     const [{ getByText, getByRole }] = render()
     getByText(
       'Stable receives the latest stable releases. Beta allows you to try out new features before they have completed testing and launch in the Stable channel.'
     )
-    getByRole('option', { name: 'Stable' })
-    getByRole('option', { name: 'Beta' })
-    getByRole('option', { name: 'Alpha' })
+    getByRole('combobox', { name: '' })
   })
   it('renders the custom labware section with source folder selected', () => {
     getCustomLabwarePath.mockReturnValue('/mock/custom-labware-path')

--- a/app/src/redux/config/__tests__/selectors.test.ts
+++ b/app/src/redux/config/__tests__/selectors.test.ts
@@ -47,8 +47,8 @@ describe('shell selectors', () => {
     it('should return "latest" and "beta" options if config is unknown', () => {
       const state: State = { config: null } as any
       expect(Selectors.getUpdateChannelOptions(state)).toEqual([
-        { name: 'Stable', value: 'latest' },
-        { name: 'Beta', value: 'beta' },
+        { label: 'Stable', value: 'latest' },
+        { label: 'Beta', value: 'beta' },
       ])
     })
 
@@ -57,8 +57,8 @@ describe('shell selectors', () => {
         config: { devtools: false, update: { channel: 'latest' } },
       } as any
       expect(Selectors.getUpdateChannelOptions(state)).toEqual([
-        { name: 'Stable', value: 'latest' },
-        { name: 'Beta', value: 'beta' },
+        { label: 'Stable', value: 'latest' },
+        { label: 'Beta', value: 'beta' },
       ])
     })
 
@@ -67,9 +67,9 @@ describe('shell selectors', () => {
         config: { devtools: true, update: { channel: 'latest' } },
       } as any
       expect(Selectors.getUpdateChannelOptions(state)).toEqual([
-        { name: 'Stable', value: 'latest' },
-        { name: 'Beta', value: 'beta' },
-        { name: 'Alpha', value: 'alpha' },
+        { label: 'Stable', value: 'latest' },
+        { label: 'Beta', value: 'beta' },
+        { label: 'Alpha', value: 'alpha' },
       ])
     })
 
@@ -78,9 +78,9 @@ describe('shell selectors', () => {
         config: { devtools: false, update: { channel: 'alpha' } },
       } as any
       expect(Selectors.getUpdateChannelOptions(state)).toEqual([
-        { name: 'Stable', value: 'latest' },
-        { name: 'Beta', value: 'beta' },
-        { name: 'Alpha', value: 'alpha' },
+        { label: 'Stable', value: 'latest' },
+        { label: 'Beta', value: 'beta' },
+        { label: 'Alpha', value: 'alpha' },
       ])
     })
   })

--- a/app/src/redux/config/selectors.ts
+++ b/app/src/redux/config/selectors.ts
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect'
-import type { DropdownOption } from '@opentrons/components'
 import type { State } from '../types'
 import type { Config, FeatureFlags, UpdateChannel } from './types'
+import type { SelectOption } from '../../atoms/SelectField/Select'
 
 export const getConfig = (state: State): Config | null => state.config
 
@@ -42,16 +42,16 @@ export const getPathToPythonOverride: (
 )
 
 const UPDATE_CHANNEL_OPTS = [
-  { name: 'Stable', value: 'latest' as UpdateChannel },
-  { name: 'Beta', value: 'beta' as UpdateChannel },
+  { label: 'Stable', value: 'latest' as UpdateChannel },
+  { label: 'Beta', value: 'beta' as UpdateChannel },
 ]
 
 const UPDATE_CHANNEL_OPTS_WITH_ALPHA = [
   ...UPDATE_CHANNEL_OPTS,
-  { name: 'Alpha', value: 'alpha' as UpdateChannel },
+  { label: 'Alpha', value: 'alpha' as UpdateChannel },
 ]
 
-export const getUpdateChannelOptions = (state: State): DropdownOption[] => {
+export const getUpdateChannelOptions = (state: State): SelectOption[] => {
   return state.config?.devtools || state.config?.update.channel === 'alpha'
     ? UPDATE_CHANNEL_OPTS_WITH_ALPHA
     : UPDATE_CHANNEL_OPTS

--- a/components/package.json
+++ b/components/package.json
@@ -26,7 +26,6 @@
     "@types/lodash": "^4.14.168",
     "@types/react": "^17.0.1",
     "@types/react-router-dom": "^5.1.7",
-    "@types/react-select": "^4.0.13",
     "@types/styled-components": "^5.1.7",
     "@types/webpack-env": "^1.16.0",
     "classnames": "2.2.5",
@@ -34,7 +33,7 @@
     "lodash": "4.17.15",
     "react-popper": "1.0.0",
     "react-remove-scroll": "2.4.3",
-    "react-select": "3.0.8",
+    "react-select": "5.4.0",
     "styled-components": "5.1.1"
   },
   "browser": {

--- a/components/src/forms/Select.tsx
+++ b/components/src/forms/Select.tsx
@@ -10,7 +10,7 @@ import type { CSSObject } from 'styled-components'
 import type {
   Props as ReactSelectProps,
   MenuProps,
-  IndicatorProps,
+  DropdownIndicatorProps,
 } from 'react-select'
 
 export { reactSelectComponents }
@@ -71,7 +71,11 @@ const CLEAR_STYLES = {
   groupHeading: NO_STYLE_FN,
   indicatorsContainer: NO_STYLE_FN,
   indicatorSeparator: NO_STYLE_FN,
-  input: NO_STYLE_FN,
+  input: (styles: any) => ({
+    ...styles,
+    zIndex: 2,
+    position: 'absolute',
+  }),
   loadingIndicator: NO_STYLE_FN,
   loadingMessage: NO_STYLE_FN,
   menu: NO_STYLE_FN,
@@ -102,7 +106,7 @@ export function Select(props: SelectProps): JSX.Element {
 }
 
 function DropdownIndicator(
-  props: IndicatorProps<SelectOption, false>
+  props: DropdownIndicatorProps<SelectOption>
 ): JSX.Element {
   return (
     <reactSelectComponents.DropdownIndicator {...props}>
@@ -117,10 +121,7 @@ function DropdownIndicator(
   )
 }
 
-// TODO(bc, 2021-03-09): reactSelectComponents.Menu children type expects single element
-// add do nothing <> fragment around contents to satisfy react select type
-const Menu = (props: MenuProps<SelectOption, false>): JSX.Element => (
-  /* @ts-expect-error(mc, 2021-03-19): investigate this error, as Menu might require a single child */
+const Menu = (props: MenuProps<SelectOption>): JSX.Element => (
   <reactSelectComponents.Menu {...props}>
     <div className={styles.menu}>{props.children}</div>
     <div className={styles.menu_control_bridge} />

--- a/components/src/forms/Select.tsx
+++ b/components/src/forms/Select.tsx
@@ -1,16 +1,19 @@
 import * as React from 'react'
-import ReactSelect, { components as reactSelectComponents } from 'react-select'
+import ReactSelect, {
+  components as reactSelectComponents,
+  DropdownIndicatorProps,
+} from 'react-select'
 import cx from 'classnames'
 
 import { Icon } from '../icons'
 import { POSITION_ABSOLUTE, POSITION_FIXED } from '../styles'
 import styles from './Select.css'
 
-import type { CSSObject } from 'styled-components'
 import type {
   Props as ReactSelectProps,
   MenuProps,
-  DropdownIndicatorProps,
+  StylesConfig,
+  CSSObjectWithLabel,
 } from 'react-select'
 
 export { reactSelectComponents }
@@ -60,9 +63,9 @@ export type SelectOptionContext = typeof CONTEXT_MENU | typeof CONTEXT_VALUE
 export type SelectProps = ReactSelectProps<SelectOption>
 
 const VOID_STYLE: unknown = undefined
-const NO_STYLE_FN = (): CSSObject => VOID_STYLE as CSSObject
+const NO_STYLE_FN = (): CSSObjectWithLabel => VOID_STYLE as CSSObjectWithLabel
 
-const CLEAR_STYLES = {
+const CLEAR_STYLES: StylesConfig<SelectOption> = {
   clearIndicator: NO_STYLE_FN,
   container: NO_STYLE_FN,
   control: NO_STYLE_FN,
@@ -71,7 +74,7 @@ const CLEAR_STYLES = {
   groupHeading: NO_STYLE_FN,
   indicatorsContainer: NO_STYLE_FN,
   indicatorSeparator: NO_STYLE_FN,
-  input: (styles: any) => ({
+  input: (styles: CSSObjectWithLabel) => ({
     ...styles,
     zIndex: 2,
     position: 'absolute',

--- a/components/src/forms/SelectField.tsx
+++ b/components/src/forms/SelectField.tsx
@@ -31,7 +31,7 @@ export interface SelectFieldProps {
   /** optional caption. hidden when `error` is given */
   caption?: React.ReactNode
   /** if included, use error style and display error instead of caption */
-  error?: string | null | undefined
+  error?: string | null
   /** change handler called with (name, value) */
   onValueChange?: (
     name: string,

--- a/components/src/forms/__tests__/SelectField.test.tsx
+++ b/components/src/forms/__tests__/SelectField.test.tsx
@@ -103,7 +103,7 @@ describe('SelectField', () => {
     ).find(Select)
 
     selectWrapper.invoke('onChange')?.(options[1], {} as any)
-    expect(handleValueChange).toHaveBeenCalledWith('field', 'bar')
+    expect(handleValueChange).toHaveBeenCalledWith('field', 'bar', {})
     selectWrapper.invoke('onBlur')?.({} as any)
     expect(handleLoseFocus).toHaveBeenCalledWith('field')
   })

--- a/components/src/instrument/PipetteSelect.tsx
+++ b/components/src/instrument/PipetteSelect.tsx
@@ -12,12 +12,16 @@ import styles from './PipetteSelect.css'
 
 import type { SelectOption } from '../forms'
 import type { PipetteNameSpecs } from '@opentrons/shared-data'
+import type { ActionMeta, SingleValue, MultiValue } from 'react-select'
 
 export interface PipetteSelectProps {
   /** currently selected value, optional in case selecting triggers immediate action */
   pipetteName?: string | null
   /** react-select change handler */
-  onPipetteChange: (pipetteName: string | null) => unknown
+  onPipetteChange: (
+    pipetteName: string | null,
+    e: ActionMeta<SelectOption>
+  ) => unknown
   /** list of pipette names to omit */
   nameBlocklist?: string[]
   /** whether or not "None" shows up as the default option */
@@ -86,12 +90,16 @@ export const PipetteSelect = (props: PipetteSelectProps): JSX.Element => {
       options={groupedOptions}
       value={value}
       defaultValue={defaultValue}
-      tabIndex={tabIndex as string}
+      tabIndex={tabIndex as number}
       id={id}
-      onChange={option => {
-        // TODO(mc, 2021-03-19): use optional chaining
-        const value = option && option.value ? option.value : null
-        props.onPipetteChange(value)
+      onChange={(
+        option: SingleValue<SelectOption> | MultiValue<SelectOption>,
+        e: ActionMeta<SelectOption>
+      ) => {
+        const value = (option as SelectOption).value
+          ? (option as SelectOption).value
+          : null
+        props.onPipetteChange(value, e)
       }}
       formatOptionLabel={(option, { context }) => {
         const { value } = option

--- a/components/src/instrument/PipetteSelect.tsx
+++ b/components/src/instrument/PipetteSelect.tsx
@@ -21,7 +21,7 @@ export interface PipetteSelectProps {
   onPipetteChange: (
     pipetteName: string | null,
     e: ActionMeta<SelectOption>
-  ) => unknown
+  ) => void
   /** list of pipette names to omit */
   nameBlocklist?: string[]
   /** whether or not "None" shows up as the default option */

--- a/labware-library/src/labware-creator/components/__tests__/sections/CreateNewDefinition.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/CreateNewDefinition.test.tsx
@@ -30,7 +30,7 @@ describe('CreateNewDefinition', () => {
 
     getByTestId('fakeChildField')
 
-    const labwareTypeDropdown = getByRole('textbox', {
+    const labwareTypeDropdown = getByRole('combobox', {
       name: /what type of labware are you creating\?.*/i,
     })
     expect(labwareTypeDropdown).toHaveValue('')
@@ -64,6 +64,6 @@ describe('CreateNewDefinition', () => {
       wrapInFormik(<CreateNewDefinition {...props} />, formikConfig)
     )
 
-    expect(queryByRole('textbox')).toBe(null)
+    expect(queryByRole('combobox')).toBe(null)
   })
 })

--- a/labware-library/src/labware-creator/components/__tests__/sections/Export.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/Export.test.tsx
@@ -53,7 +53,7 @@ describe('Export', () => {
         'The protocol requires a Single Channel pipette on the right mount of your robot.'
     )
 
-    screen.getByRole('textbox', { name: /test pipette/i })
+    screen.getByText(/test pipette/i)
     screen.getByRole('button', { name: /export/i })
   })
 

--- a/protocol-designer/src/components/modals/FilePipettesModal/__tests__/PipetteFields.test.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/__tests__/PipetteFields.test.tsx
@@ -15,6 +15,9 @@ import { PipetteDiagram } from '../PipetteDiagram'
 import { FormPipette } from '../../../../step-forms'
 import { LabwareDefinition2 } from '../../../../../../shared-data/lib/js/types.d'
 
+import type { ActionMeta } from 'react-select'
+import type { SelectOption } from '@opentrons/components'
+
 jest.mock('../../../../feature-flags/selectors')
 jest.mock('../../../../labware-defs/selectors')
 jest.mock('../../../../labware-defs/utils')
@@ -113,7 +116,10 @@ describe('PipetteFields', () => {
     const wrapper = render(props)
     const leftPipette = wrapper.find(PipetteSelect).at(0)
 
-    leftPipette.prop('onPipetteChange')('p50')
+    leftPipette.prop('onPipetteChange')(
+      'p50',
+      ('input-change' as unknown) as ActionMeta<SelectOption>
+    )
 
     expect(props.onSetFieldTouched).toHaveBeenCalledWith(leftTiprackKey, false)
     expect((props.onSetFieldValue as jest.Mock).mock.calls).toEqual([

--- a/yarn.lock
+++ b/yarn.lock
@@ -254,6 +254,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz#5ac822ce97eec46741ab70a517971e443a70c5a9"
   integrity sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==
 
+"@babel/helper-plugin-utils@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.6.tgz#9448974dd4fb1d80fefe72e8a0af37809cd30d6d"
+  integrity sha512-gvZnm1YAAxh13eJdkb9EWHBnF3eAub3XTLCZEehHT2kWxiKVRL64+ae5Y6Ivne0mVHmMYKT+xWgZO+gQhuLUBg==
+
 "@babel/helper-remap-async-to-generator@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.14.5.tgz#51439c913612958f54a987a4ffc9ee587a2045d6"
@@ -588,6 +593,13 @@
   integrity sha512-1yRi7yAtB0ETgxdY9ti/p2TivUxJkTdhu/ZbF9MshVGqOx1TdB3b7xCXs49Fupgg50N45KcAsRP/ZqWjs9SRjg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-syntax-jsx@^7.12.13":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz#a8feef63b010150abd97f1649ec296e849943ca0"
+  integrity sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.18.6"
 
 "@babel/plugin-syntax-jsx@^7.14.5":
   version "7.14.5"
@@ -1103,7 +1115,7 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.5", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.0", "@babel/runtime@^7.14.5", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.5", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.0", "@babel/runtime@^7.14.5", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.14.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
   integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
@@ -1114,6 +1126,13 @@
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.7.tgz#03ff99f64106588c9c403c6ecb8c3bafbbdff1fa"
   integrity sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.8.7":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.6.tgz#6a1ef59f838debd670421f8c7f2cbb8da9751580"
+  integrity sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1268,7 +1287,25 @@
     dir-compare "^2.4.0"
     fs-extra "^9.0.1"
 
-"@emotion/cache@^10.0.27", "@emotion/cache@^10.0.9":
+"@emotion/babel-plugin@^11.7.1":
+  version "11.9.2"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.9.2.tgz#723b6d394c89fb2ef782229d92ba95a740576e95"
+  integrity sha512-Pr/7HGH6H6yKgnVFNEj2MVlreu3ADqftqjqwUvDy/OJzKFgxKeTQ+eeUf20FOTuHVkDON2iNa25rAXVYtWJCjw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.12.13"
+    "@babel/plugin-syntax-jsx" "^7.12.13"
+    "@babel/runtime" "^7.13.10"
+    "@emotion/hash" "^0.8.0"
+    "@emotion/memoize" "^0.7.5"
+    "@emotion/serialize" "^1.0.2"
+    babel-plugin-macros "^2.6.1"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^4.0.0"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+    stylis "4.0.13"
+
+"@emotion/cache@^10.0.27":
   version "10.0.29"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"
   integrity sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==
@@ -1278,7 +1315,18 @@
     "@emotion/utils" "0.11.3"
     "@emotion/weak-memoize" "0.2.5"
 
-"@emotion/core@^10.0.9", "@emotion/core@^10.1.1":
+"@emotion/cache@^11.4.0", "@emotion/cache@^11.9.3":
+  version "11.9.3"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.9.3.tgz#96638449f6929fd18062cfe04d79b29b44c0d6cb"
+  integrity sha512-0dgkI/JKlCXa+lEXviaMtGBL0ynpx4osh7rjOXE71q9bIF8G+XhJgvi+wDu0B0IdCVx37BffiwXlN9I3UuzFvg==
+  dependencies:
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/sheet" "^1.1.1"
+    "@emotion/utils" "^1.0.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    stylis "4.0.13"
+
+"@emotion/core@^10.1.1":
   version "10.1.1"
   resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.1.1.tgz#c956c1365f2f2481960064bcb8c4732e5fb612c3"
   integrity sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==
@@ -1290,7 +1338,7 @@
     "@emotion/sheet" "0.9.4"
     "@emotion/utils" "0.11.3"
 
-"@emotion/css@^10.0.27", "@emotion/css@^10.0.9":
+"@emotion/css@^10.0.27":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/css/-/css-10.0.27.tgz#3a7458198fbbebb53b01b2b87f64e5e21241e14c"
   integrity sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==
@@ -1333,10 +1381,23 @@
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.6.6.tgz#004b98298d04c7ca3b4f50ca2035d4f60d2eed1b"
   integrity sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ==
 
-"@emotion/memoize@^0.7.4":
+"@emotion/memoize@^0.7.4", "@emotion/memoize@^0.7.5":
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
   integrity sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==
+
+"@emotion/react@^11.8.1":
+  version "11.9.3"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.9.3.tgz#f4f4f34444f6654a2e550f5dab4f2d360c101df9"
+  integrity sha512-g9Q1GcTOlzOEjqwuLF/Zd9LC+4FljjPjDfxSM7KmEakm+hsHXk+bYZ2q+/hTJzr0OUNkujo72pXLQvXj6H+GJQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@emotion/babel-plugin" "^11.7.1"
+    "@emotion/cache" "^11.9.3"
+    "@emotion/serialize" "^1.0.4"
+    "@emotion/utils" "^1.1.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    hoist-non-react-statics "^3.3.1"
 
 "@emotion/serialize@^0.11.15", "@emotion/serialize@^0.11.16":
   version "0.11.16"
@@ -1349,10 +1410,10 @@
     "@emotion/utils" "0.11.3"
     csstype "^2.5.7"
 
-"@emotion/serialize@^1.0.0":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.2.tgz#77cb21a0571c9f68eb66087754a65fa97bfcd965"
-  integrity sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==
+"@emotion/serialize@^1.0.2", "@emotion/serialize@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.4.tgz#ff31fd11bb07999611199c2229e152faadc21a3c"
+  integrity sha512-1JHamSpH8PIfFwAMryO2bNka+y8+KA5yga5Ocf2d7ZEiJjb7xlLW7aknBGZqJLajuLOvJ+72vN+IBSwPlXD1Pg==
   dependencies:
     "@emotion/hash" "^0.8.0"
     "@emotion/memoize" "^0.7.4"
@@ -1364,6 +1425,11 @@
   version "0.9.4"
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-0.9.4.tgz#894374bea39ec30f489bbfc3438192b9774d32e5"
   integrity sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==
+
+"@emotion/sheet@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.1.1.tgz#015756e2a9a3c7c5f11d8ec22966a8dbfbfac787"
+  integrity sha512-J3YPccVRMiTZxYAY0IOq3kd+hUP8idY8Kz6B/Cyo+JuXq52Ek+zbPbSQUrVQp95aJ+lsAW7DPL1P2Z+U1jGkKA==
 
 "@emotion/styled-base@^10.0.27":
   version "10.0.31"
@@ -1413,7 +1479,12 @@
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.0.0.tgz#abe06a83160b10570816c913990245813a2fd6af"
   integrity sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA==
 
-"@emotion/weak-memoize@0.2.5":
+"@emotion/utils@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.1.0.tgz#86b0b297f3f1a0f2bdb08eeac9a2f49afd40d0cf"
+  integrity sha512-iRLa/Y4Rs5H/f2nimczYmS5kFJEbpiVvgN3XVfZ022IYhuNA1IRSHEizcof88LtCTXtl9S2Cxt32KgaXEu72JQ==
+
+"@emotion/weak-memoize@0.2.5", "@emotion/weak-memoize@^0.2.5":
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
@@ -4073,7 +4144,7 @@
     "@types/react" "*"
     "@types/reactcss" "*"
 
-"@types/react-dom@*", "@types/react-dom@>=16.9.0":
+"@types/react-dom@>=16.9.0":
   version "17.0.7"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.7.tgz#b8ee15ead9e5d6c2c858b44949fdf2ebe5212232"
   integrity sha512-Wd5xvZRlccOrCTej8jZkoFZuZRKHzanDDv1xglI33oBNFMWrqOSzrvWFw7ngSiZjrpJAzPKFtX7JvuXpkNmQHA==
@@ -4107,16 +4178,6 @@
     "@types/history" "*"
     "@types/react" "*"
 
-"@types/react-select@^4.0.13":
-  version "4.0.15"
-  resolved "https://registry.yarnpkg.com/@types/react-select/-/react-select-4.0.15.tgz#2e6a1cff22c4bbae6c95b8dbee5b5097c12eae54"
-  integrity sha512-GPyBFYGMVFCtF4eg9riodEco+s2mflR10Nd5csx69+bcdvX6Uo9H/jgrIqovBU9yxBppB9DS66OwD6xxgVqOYQ==
-  dependencies:
-    "@emotion/serialize" "^1.0.0"
-    "@types/react" "*"
-    "@types/react-dom" "*"
-    "@types/react-transition-group" "*"
-
 "@types/react-syntax-highlighter@11.0.5":
   version "11.0.5"
   resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.5.tgz#0d546261b4021e1f9d85b50401c0a42acb106087"
@@ -4131,10 +4192,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-transition-group@*":
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.1.tgz#e1a3cb278df7f47f17b5082b1b3da17170bd44b1"
-  integrity sha512-vIo69qKKcYoJ8wKCJjwSgCTM+z3chw3g18dkrDfVX665tMH7tmbDxEAnPdey4gTlwZz5QuHGzd+hul0OVZDqqQ==
+"@types/react-transition-group@^4.4.0":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.5.tgz#aae20dcf773c5aa275d5b9f7cdbca638abc5e416"
+  integrity sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==
   dependencies:
     "@types/react" "*"
 
@@ -5411,7 +5472,7 @@ babel-plugin-jest-hoist@^26.6.2:
     "@types/babel__core" "^7.0.0"
     "@types/babel__traverse" "^7.0.6"
 
-babel-plugin-macros@^2.0.0, babel-plugin-macros@^2.8.0:
+babel-plugin-macros@^2.0.0, babel-plugin-macros@^2.6.1, babel-plugin-macros@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz#0f958a7cc6556b1e65344465d99111a1e5e10138"
   integrity sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==
@@ -8529,12 +8590,13 @@ dom-converter@^0.2.0:
   dependencies:
     utila "~0.4"
 
-dom-helpers@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
-  integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
+dom-helpers@^5.0.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
+  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
   dependencies:
-    "@babel/runtime" "^7.1.2"
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 dom-serializer@0:
   version "0.2.2"
@@ -11576,7 +11638,7 @@ hoist-non-react-statics@^2.3.1:
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -17598,7 +17660,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.0.0, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.0, prop-types@^15.7.2:
+prop-types@^15.0.0, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.0, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -18123,13 +18185,6 @@ react-i18next@^11.7.3:
     "@babel/runtime" "^7.14.5"
     html-parse-stringify "^3.0.1"
 
-react-input-autosize@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.2.tgz#fcaa7020568ec206bc04be36f4eb68e647c4d8c2"
-  integrity sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==
-  dependencies:
-    prop-types "^15.5.8"
-
 react-inspector@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-5.1.1.tgz#58476c78fde05d5055646ed8ec02030af42953c8"
@@ -18266,19 +18321,18 @@ react-router@5.1.1:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-select@3.0.8:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.0.8.tgz#06ff764e29db843bcec439ef13e196865242e0c1"
-  integrity sha512-v9LpOhckLlRmXN5A6/mGGEft4FMrfaBFTGAnuPHcUgVId7Je42kTq9y0Z+Ye5z8/j0XDT3zUqza8gaRaI1PZIg==
+react-select@5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.4.0.tgz#81f6ac73906126706f104751ee14437bd16798f4"
+  integrity sha512-CjE9RFLUvChd5SdlfG4vqxZd55AZJRrLrHzkQyTYeHlpOztqcgnyftYAolJ0SGsBev6zAs6qFrjm6KU3eo2hzg==
   dependencies:
-    "@babel/runtime" "^7.4.4"
-    "@emotion/cache" "^10.0.9"
-    "@emotion/core" "^10.0.9"
-    "@emotion/css" "^10.0.9"
+    "@babel/runtime" "^7.12.0"
+    "@emotion/cache" "^11.4.0"
+    "@emotion/react" "^11.8.1"
+    "@types/react-transition-group" "^4.4.0"
     memoize-one "^5.0.0"
     prop-types "^15.6.0"
-    react-input-autosize "^2.2.2"
-    react-transition-group "^2.2.1"
+    react-transition-group "^4.3.0"
 
 react-shallow-renderer@^16.13.1:
   version "16.14.1"
@@ -18363,15 +18417,15 @@ react-textarea-autosize@^8.3.0:
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
 
-react-transition-group@^2.2.1:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
-  integrity sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==
+react-transition-group@^4.3.0:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.2.tgz#8b59a56f09ced7b55cbd53c36768b922890d5470"
+  integrity sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==
   dependencies:
-    dom-helpers "^3.4.0"
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
-    react-lifecycles-compat "^3.0.4"
 
 react@17.0.1:
   version "17.0.1"
@@ -20747,6 +20801,11 @@ stylis-rule-sheet@^0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
   integrity sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==
+
+stylis@4.0.13:
+  version "4.0.13"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.13.tgz#f5db332e376d13cc84ecfe5dace9a2a51d954c91"
+  integrity sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag==
 
 stylis@^3.5.0:
   version "3.5.4"


### PR DESCRIPTION
# Overview

Update `React Select` from `3.0.8` to `5.4.0` in the components `package.json` and fix ts errors from legacy components. Add `React Select 5.4.0` to the app `package.json` and make new `Select` component that has new styling

Follow up to this pr: https://github.com/Opentrons/opentrons/pull/11020

# Changelog

- change `React Select` in components `package.json` and add it to app `package.json`
- make new `Select` and `SelectField` and story in the App/Atoms folder
- update all TS errors in the legacy components
- update `getUpdateChannelOptions` selector to return object that matches `SelectOptions` instead of `DropdownOptions`
- changes between React Select 3x to 5x that needed to be addressed:
1. `Indicator` got renamed to `dropdownIndicator`
2. `comboBox` role got added which includes `textBox`  and any sort of role that is in a react select component
3.  new React Select version 5x is rewritten in TS so no longer need `@types/react-select` as a dependency
4. `onChange` handler type changes slightly to always be passed as an array if `isMulti` is true or single if `isMulti` is null

# Review requests

- does the new component used in Robot Settings -> Networking tab match designs?
- does the new dropdown component used in App Settings -> Advanced match designs?
- smoke test app, ll, pd, do the dropdown menus work as expected?

# Risk assessment

 low