### PR TITLE
feat(app): fix choose protocol/robot slideout robot busy error logic

### DIFF
--- a/app/src/organisms/ChooseProtocolSlideout/__tests__/ChooseProtocolSlideout.test.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/__tests__/ChooseProtocolSlideout.test.tsx
@@ -109,7 +109,7 @@ describe('ChooseProtocolSlideout', () => {
       createRunFromProtocolSource: mockCreateRunFromProtocol,
       isCreatingRun: false,
       reset: jest.fn(),
-      runCreationErrorCode: 'error code',
+      isErrorCode409: false,
     })
     const [{ getByRole, getByText }] = render({
       robot: mockConnectableRobot,
@@ -131,7 +131,7 @@ describe('ChooseProtocolSlideout', () => {
       createRunFromProtocolSource: mockCreateRunFromProtocol,
       isCreatingRun: false,
       reset: jest.fn(),
-      runCreationErrorCode: '409',
+      isErrorCode409: true,
     })
     const [{ getByRole, getByText }] = render({
       robot: mockConnectableRobot,

--- a/app/src/organisms/ChooseProtocolSlideout/__tests__/ChooseProtocolSlideout.test.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/__tests__/ChooseProtocolSlideout.test.tsx
@@ -109,7 +109,7 @@ describe('ChooseProtocolSlideout', () => {
       createRunFromProtocolSource: mockCreateRunFromProtocol,
       isCreatingRun: false,
       reset: jest.fn(),
-      isErrorCode409: false,
+      runCreationErrorCode: 500,
     })
     const [{ getByRole, getByText }] = render({
       robot: mockConnectableRobot,
@@ -131,7 +131,7 @@ describe('ChooseProtocolSlideout', () => {
       createRunFromProtocolSource: mockCreateRunFromProtocol,
       isCreatingRun: false,
       reset: jest.fn(),
-      isErrorCode409: true,
+      runCreationErrorCode: 409,
     })
     const [{ getByRole, getByText }] = render({
       robot: mockConnectableRobot,

--- a/app/src/organisms/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/index.tsx
@@ -70,7 +70,7 @@ export function ChooseProtocolSlideout(
     runCreationError,
     isCreatingRun,
     reset: resetCreateRun,
-    isErrorCode409,
+    runCreationErrorCode,
   } = useCreateRunFromProtocol({
     onSuccess: ({ data: runData }) => {
       history.push(`/devices/${name}/protocol-runs/${runData.id}`)
@@ -174,7 +174,7 @@ export function ChooseProtocolSlideout(
                   marginTop={`-${SPACING.spacing2}`}
                   marginBottom={SPACING.spacing3}
                 >
-                  {isErrorCode409 ? (
+                  {runCreationErrorCode === 409 ? (
                     <Trans
                       t={t}
                       i18nKey="shared:robot_is_busy_no_protocol_run_allowed"

--- a/app/src/organisms/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/index.tsx
@@ -70,7 +70,7 @@ export function ChooseProtocolSlideout(
     runCreationError,
     isCreatingRun,
     reset: resetCreateRun,
-    runCreationErrorCode,
+    isErrorCode409,
   } = useCreateRunFromProtocol({
     onSuccess: ({ data: runData }) => {
       history.push(`/devices/${name}/protocol-runs/${runData.id}`)
@@ -174,7 +174,7 @@ export function ChooseProtocolSlideout(
                   marginTop={`-${SPACING.spacing2}`}
                   marginBottom={SPACING.spacing3}
                 >
-                  {runCreationErrorCode === '409' ? (
+                  {isErrorCode409 ? (
                     <Trans
                       t={t}
                       i18nKey="shared:robot_is_busy_no_protocol_run_allowed"

--- a/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
@@ -227,7 +227,7 @@ describe('ChooseRobotSlideout', () => {
       createRunFromProtocolSource: mockCreateRunFromProtocolSource,
       isCreatingRun: false,
       reset: jest.fn(),
-      runCreationErrorCode: 'error code',
+      isErrorCode409: false,
     })
     const [{ getByRole, getByText }] = render({
       storedProtocolData: storedProtocolDataFixture,
@@ -249,7 +249,7 @@ describe('ChooseRobotSlideout', () => {
       createRunFromProtocolSource: mockCreateRunFromProtocolSource,
       isCreatingRun: false,
       reset: jest.fn(),
-      runCreationErrorCode: '409',
+      isErrorCode409: true,
     })
     const [{ getByRole, getByText }] = render({
       storedProtocolData: storedProtocolDataFixture,

--- a/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
@@ -227,7 +227,7 @@ describe('ChooseRobotSlideout', () => {
       createRunFromProtocolSource: mockCreateRunFromProtocolSource,
       isCreatingRun: false,
       reset: jest.fn(),
-      isErrorCode409: false,
+      runCreationErrorCode: 500,
     })
     const [{ getByRole, getByText }] = render({
       storedProtocolData: storedProtocolDataFixture,
@@ -249,7 +249,7 @@ describe('ChooseRobotSlideout', () => {
       createRunFromProtocolSource: mockCreateRunFromProtocolSource,
       isCreatingRun: false,
       reset: jest.fn(),
-      isErrorCode409: true,
+      runCreationErrorCode: 409,
     })
     const [{ getByRole, getByText }] = render({
       storedProtocolData: storedProtocolDataFixture,

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -76,7 +76,7 @@ export function ChooseRobotSlideout(
     runCreationError,
     reset: resetCreateRun,
     isCreatingRun,
-    runCreationErrorCode,
+    isErrorCode409,
   } = useCreateRunFromProtocol(
     {
       onSuccess: ({ data: runData }) => {
@@ -223,7 +223,7 @@ export function ChooseRobotSlideout(
                     marginTop={`-${SPACING.spacing2}`}
                     marginBottom={SPACING.spacing3}
                   >
-                    {runCreationErrorCode === '409' ? (
+                    {isErrorCode409 ? (
                       <Trans
                         t={t}
                         i18nKey="shared:robot_is_busy_no_protocol_run_allowed"

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -76,7 +76,7 @@ export function ChooseRobotSlideout(
     runCreationError,
     reset: resetCreateRun,
     isCreatingRun,
-    isErrorCode409,
+    runCreationErrorCode,
   } = useCreateRunFromProtocol(
     {
       onSuccess: ({ data: runData }) => {
@@ -223,7 +223,7 @@ export function ChooseRobotSlideout(
                     marginTop={`-${SPACING.spacing2}`}
                     marginBottom={SPACING.spacing3}
                   >
-                    {isErrorCode409 ? (
+                    {runCreationErrorCode === 409 ? (
                       <Trans
                         t={t}
                         i18nKey="shared:robot_is_busy_no_protocol_run_allowed"

--- a/app/src/organisms/ChooseRobotSlideout/useCreateRunFromProtocol.ts
+++ b/app/src/organisms/ChooseRobotSlideout/useCreateRunFromProtocol.ts
@@ -24,7 +24,7 @@ export interface UseCreateRun {
   >
   isCreatingRun: boolean
   runCreationError: string | null
-  runCreationErrorCode: string | null
+  isErrorCode409: boolean
   reset: () => void
 }
 
@@ -85,7 +85,10 @@ export function useCreateRunFromProtocol(
   error != null && console.error(error)
   error = error?.length > 255 ? t('protocol_run_general_error_msg') : error
 
-  const errorCode = protocolError?.code ?? runError?.code ?? null
+  const isErrorCode409 =
+    protocolError?.message.includes('409') ??
+    runError?.message.includes('409') ??
+    false
 
   return {
     createRunFromProtocolSource: (
@@ -100,7 +103,7 @@ export function useCreateRunFromProtocol(
     },
     isCreatingRun: isCreatingProtocol || isCreatingRun,
     runCreationError: error,
-    runCreationErrorCode: errorCode,
+    isErrorCode409: isErrorCode409,
     reset: () => {
       resetProtocolMutation()
       resetRunMutation()

--- a/app/src/organisms/ChooseRobotSlideout/useCreateRunFromProtocol.ts
+++ b/app/src/organisms/ChooseRobotSlideout/useCreateRunFromProtocol.ts
@@ -24,7 +24,7 @@ export interface UseCreateRun {
   >
   isCreatingRun: boolean
   runCreationError: string | null
-  isErrorCode409: boolean
+  runCreationErrorCode: number | null
   reset: () => void
 }
 
@@ -85,10 +85,8 @@ export function useCreateRunFromProtocol(
   error != null && console.error(error)
   error = error?.length > 255 ? t('protocol_run_general_error_msg') : error
 
-  const isErrorCode409 =
-    protocolError?.message.includes('409') ??
-    runError?.message.includes('409') ??
-    false
+  const errorCode =
+    protocolError?.response?.status ?? runError?.response?.status ?? null
 
   return {
     createRunFromProtocolSource: (
@@ -103,7 +101,7 @@ export function useCreateRunFromProtocol(
     },
     isCreatingRun: isCreatingProtocol || isCreatingRun,
     runCreationError: error,
-    isErrorCode409: isErrorCode409,
+    runCreationErrorCode: errorCode,
     reset: () => {
       resetProtocolMutation()
       resetRunMutation()


### PR DESCRIPTION
closes #11060


# Overview

fix logic in ` useCreateRunFromProtocol` to look for `protocolError?.response?.status ?? runError?.response?.status` instead of `runError?.code`

# Changelog

- change prop and logic in ` useCreateRunFromProtocol` and update usage in slideouts

# Review requests

- start protocol on robot and pause protocol. Try to upload another protocol and click `proceed to setup`. You should get correct error 

# Risk assessment

low