### PR TITLE
fix(app): fix devices landing page text wrapping

### DIFF
--- a/app/src/organisms/Devices/RobotCard.tsx
+++ b/app/src/organisms/Devices/RobotCard.tsx
@@ -66,7 +66,6 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
   React.useEffect(() => {
     const handleResize = (): void => {
       setRobotCardWidth(getElementProperty('width'))
-      console.log('robotCard', robotCardWidth)
     }
     window.addEventListener('resize', handleResize)
   })
@@ -192,21 +191,6 @@ function AttachedPipettes(props: {
   const { robotName, robotCardWidth } = props
   const { t } = useTranslation('devices_landing')
   const attachedPipettes = useAttachedPipettes()
-  // const pipetteRef = React.useRef(null)
-  // const { getElementProperty } = useGetElementDOMRectProperty<HTMLDivElement>(
-  //   pipetteRef
-  // )
-  // const [pipetteWidth, setPipetteWidth] = React.useState<number>(
-  //   getElementProperty('width')
-  // )
-
-  // React.useEffect(() => {
-  //   const handleResize = (): void => {
-  //     setPipetteWidth(getElementProperty('width'))
-  //     console.log(pipetteWidth)
-  //   }
-  //   window.addEventListener('resize', handleResize)
-  // })
 
   return (
     <Box

--- a/app/src/organisms/Devices/RobotCard.tsx
+++ b/app/src/organisms/Devices/RobotCard.tsx
@@ -196,7 +196,6 @@ function AttachedPipettes(props: {
 
   return (
     <Box
-      // ref={pipetteRef}
       display="grid"
       css={
         robotCardWidth >= ROBOT_CARD_WRAP_SIZE

--- a/app/src/organisms/Devices/RobotCard.tsx
+++ b/app/src/organisms/Devices/RobotCard.tsx
@@ -61,16 +61,20 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
   const { getElementProperty } = useGetElementDOMRectProperty<HTMLDivElement>(
     robotCardRef
   )
-  const [robotCardWidth, setRobotCardWidth] = React.useState<number>(
+  const [robotCardWidth, setRobotCardWidth] = React.useState<number | null>(
     getElementProperty('width')
   )
 
+  const handleResize = React.useCallback((): void => {
+    setRobotCardWidth(getElementProperty('width'))
+  }, [getElementProperty])
+
   React.useEffect(() => {
-    const handleResize = (): void => {
-      setRobotCardWidth(getElementProperty('width'))
-    }
     window.addEventListener('resize', handleResize)
-  })
+    return () => {
+      window.removeEventListener('resize', handleResize)
+    }
+  }, [handleResize])
 
   return robotName != null ? (
     <Flex
@@ -134,7 +138,7 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
           <Box
             display="grid"
             css={
-              robotCardWidth >= ROBOT_CARD_WRAP_SIZE
+              robotCardWidth == null || robotCardWidth >= ROBOT_CARD_WRAP_SIZE
                 ? { 'grid-template-columns': '4fr 1fr' }
                 : { 'grid-template-rows': '2fr 1fr' }
             }
@@ -188,7 +192,7 @@ function AttachedModules(props: { robotName: string }): JSX.Element | null {
 }
 function AttachedPipettes(props: {
   robotName: string
-  robotCardWidth: number
+  robotCardWidth: number | null
 }): JSX.Element {
   const { robotName, robotCardWidth } = props
   const { t } = useTranslation('devices_landing')
@@ -198,7 +202,7 @@ function AttachedPipettes(props: {
     <Box
       display="grid"
       css={
-        robotCardWidth >= ROBOT_CARD_WRAP_SIZE
+        robotCardWidth == null || robotCardWidth >= ROBOT_CARD_WRAP_SIZE
           ? { 'grid-template-columns': '1fr 1fr' }
           : { 'grid-template-rows': '1fr' }
       }

--- a/app/src/organisms/Devices/RobotCard.tsx
+++ b/app/src/organisms/Devices/RobotCard.tsx
@@ -46,6 +46,8 @@ const ROBOT_CARD_STYLE = css`
   }
 `
 
+const ROBOT_CARD_WRAP_SIZE = 650
+
 interface RobotCardProps {
   robot: DiscoveredRobot
 }
@@ -132,7 +134,7 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
           <Box
             display="grid"
             css={
-              robotCardWidth >= 650
+              robotCardWidth >= ROBOT_CARD_WRAP_SIZE
                 ? { 'grid-template-columns': '4fr 1fr' }
                 : { 'grid-template-rows': '2fr 1fr' }
             }
@@ -197,7 +199,7 @@ function AttachedPipettes(props: {
       // ref={pipetteRef}
       display="grid"
       css={
-        robotCardWidth >= 650
+        robotCardWidth >= ROBOT_CARD_WRAP_SIZE
           ? { 'grid-template-columns': '1fr 1fr' }
           : { 'grid-template-rows': '1fr' }
       }

--- a/app/src/organisms/Devices/RobotCard.tsx
+++ b/app/src/organisms/Devices/RobotCard.tsx
@@ -35,6 +35,7 @@ import {
 } from './hooks'
 import { ReachableBanner } from './ReachableBanner'
 import { RobotOverflowMenu } from './RobotOverflowMenu'
+import { useGetElementDOMRectProperty } from '../../organisms/ProtocolsLanding/useGetElementDOMRectProperty'
 
 import type { DiscoveredRobot } from '../../redux/discovery/types'
 
@@ -54,6 +55,22 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
   const { name: robotName = null, local } = robot
   const history = useHistory()
 
+  const robotCardRef = React.useRef(null)
+  const { getElementProperty } = useGetElementDOMRectProperty<HTMLDivElement>(
+    robotCardRef
+  )
+  const [robotCardWidth, setRobotCardWidth] = React.useState<number>(
+    getElementProperty('width')
+  )
+
+  React.useEffect(() => {
+    const handleResize = (): void => {
+      setRobotCardWidth(getElementProperty('width'))
+      console.log('robotCard', robotCardWidth)
+    }
+    window.addEventListener('resize', handleResize)
+  })
+
   return robotName != null ? (
     <Flex
       alignItems={ALIGN_CENTER}
@@ -66,6 +83,7 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
       width="100%"
       onClick={() => history.push(`/devices/${robotName}`)}
       cursor="pointer"
+      ref={robotCardRef}
     >
       <img
         src={OT2_PNG}
@@ -112,14 +130,20 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
           ) : null}
         </Flex>
         {robot.status === CONNECTABLE ? (
-          <Flex flexDirection={DIRECTION_ROW}>
-            <Flex flex="4">
-              <AttachedPipettes robotName={robotName} />
-            </Flex>
-            <Flex flex="1">
-              <AttachedModules robotName={robotName} />
-            </Flex>
-          </Flex>
+          <Box
+            display="grid"
+            css={
+              robotCardWidth >= 650
+                ? { 'grid-template-columns': '4fr 1fr' }
+                : { 'grid-template-rows': '2fr 1fr' }
+            }
+          >
+            <AttachedPipettes
+              robotName={robotName}
+              robotCardWidth={robotCardWidth}
+            />
+            <AttachedModules robotName={robotName} />
+          </Box>
         ) : null}
       </Box>
       <RobotOverflowMenu robot={robot} alignSelf={ALIGN_START} />
@@ -132,10 +156,10 @@ function AttachedModules(props: { robotName: string }): JSX.Element | null {
   const { t } = useTranslation('devices_landing')
   const attachedModules = useAttachedModules()
   return attachedModules.length > 0 ? (
-    <Flex
-      flexDirection={DIRECTION_COLUMN}
+    <Box
+      display="grid"
+      gridTemplateRows="1fr 1fr"
       paddingRight={SPACING.spacing4}
-      width="100%"
     >
       <StyledText
         as="h6"
@@ -156,23 +180,45 @@ function AttachedModules(props: { robotName: string }): JSX.Element | null {
           />
         ))}
       </Flex>
-    </Flex>
+    </Box>
   ) : (
     <Flex width="100%"></Flex>
   )
 }
-function AttachedPipettes(props: { robotName: string }): JSX.Element {
-  const { robotName } = props
+function AttachedPipettes(props: {
+  robotName: string
+  robotCardWidth: number
+}): JSX.Element {
+  const { robotName, robotCardWidth } = props
   const { t } = useTranslation('devices_landing')
   const attachedPipettes = useAttachedPipettes()
+  // const pipetteRef = React.useRef(null)
+  // const { getElementProperty } = useGetElementDOMRectProperty<HTMLDivElement>(
+  //   pipetteRef
+  // )
+  // const [pipetteWidth, setPipetteWidth] = React.useState<number>(
+  //   getElementProperty('width')
+  // )
+
+  // React.useEffect(() => {
+  //   const handleResize = (): void => {
+  //     setPipetteWidth(getElementProperty('width'))
+  //     console.log(pipetteWidth)
+  //   }
+  //   window.addEventListener('resize', handleResize)
+  // })
+
   return (
-    <Flex flexDirection={DIRECTION_ROW} width="100%">
-      <Flex
-        flex="1"
-        flexDirection={DIRECTION_COLUMN}
-        paddingRight={SPACING.spacing4}
-        width="100%"
-      >
+    <Box
+      // ref={pipetteRef}
+      display="grid"
+      css={
+        robotCardWidth >= 650
+          ? { 'grid-template-columns': '1fr 1fr' }
+          : { 'grid-template-rows': '1fr' }
+      }
+    >
+      <Box gridTemplateRows="1fr 1fr" paddingRight={SPACING.spacing4}>
         <StyledText
           as="h6"
           textTransform={TEXT_TRANSFORM_UPPERCASE}
@@ -184,13 +230,8 @@ function AttachedPipettes(props: { robotName: string }): JSX.Element {
         <StyledText as="p" id={`RobotCard_${robotName}_leftMountPipette`}>
           {attachedPipettes?.left?.modelSpecs.displayName ?? t('empty')}
         </StyledText>
-      </Flex>
-      <Flex
-        flex="1"
-        flexDirection={DIRECTION_COLUMN}
-        paddingRight={SPACING.spacing4}
-        width="100%"
-      >
+      </Box>
+      <Box gridTemplateRows="1fr 1fr" paddingRight={SPACING.spacing4}>
         <StyledText
           as="h6"
           textTransform={TEXT_TRANSFORM_UPPERCASE}
@@ -202,8 +243,8 @@ function AttachedPipettes(props: { robotName: string }): JSX.Element {
         <StyledText as="p" id={`RobotCard_${robotName}_rightMountPipette`}>
           {attachedPipettes?.right?.modelSpecs.displayName ?? t('empty')}
         </StyledText>
-      </Flex>
-    </Flex>
+      </Box>
+    </Box>
   )
 }
 

--- a/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
@@ -136,7 +136,6 @@ function AnalysisInfo(props: AnalysisInfoProps): JSX.Element {
     targetRef
   )
   const width = getElementProperty('width')
-  const height = getElementProperty('height')
 
   // TODO kj 07/06/2022: Currently, using hardcoded number to align elements
   // This should be removed in the future
@@ -280,7 +279,7 @@ function AnalysisInfo(props: AnalysisInfoProps): JSX.Element {
             data-testid={`ProtocolCard_date_${protocolDisplayName}`}
             marginTop={SPACING.spacing3}
             justifyContent={
-              height == null || height <= 880 ? JUSTIFY_FLEX_END : FLEX_NONE
+              width == null || width <= 880 ? JUSTIFY_FLEX_END : FLEX_NONE
             }
           >
             <StyledText

--- a/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
@@ -135,6 +135,8 @@ function AnalysisInfo(props: AnalysisInfoProps): JSX.Element {
   const { getElementProperty } = useGetElementDOMRectProperty<HTMLDivElement>(
     targetRef
   )
+  const width = getElementProperty('width')
+  const height = getElementProperty('height')
 
   // TODO kj 07/06/2022: Currently, using hardcoded number to align elements
   // This should be removed in the future
@@ -146,9 +148,7 @@ function AnalysisInfo(props: AnalysisInfoProps): JSX.Element {
         size="6rem"
         height="auto"
         justifyContent={JUSTIFY_CENTER}
-        alignItems={
-          getElementProperty('width') <= 800 ? ALIGN_START : ALIGN_CENTER
-        }
+        alignItems={width == null || width <= 800 ? ALIGN_START : ALIGN_CENTER}
         data-testid={`ProtocolCard_deckLayout_${protocolDisplayName}`}
       >
         {
@@ -280,7 +280,7 @@ function AnalysisInfo(props: AnalysisInfoProps): JSX.Element {
             data-testid={`ProtocolCard_date_${protocolDisplayName}`}
             marginTop={SPACING.spacing3}
             justifyContent={
-              getElementProperty('height') <= 880 ? JUSTIFY_FLEX_END : FLEX_NONE
+              height == null || height <= 880 ? JUSTIFY_FLEX_END : FLEX_NONE
             }
           >
             <StyledText

--- a/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
@@ -147,7 +147,7 @@ function AnalysisInfo(props: AnalysisInfoProps): JSX.Element {
         height="auto"
         justifyContent={JUSTIFY_CENTER}
         alignItems={
-          getElementProperty('height') <= 880 ? ALIGN_START : ALIGN_CENTER
+          getElementProperty('width') <= 800 ? ALIGN_START : ALIGN_CENTER
         }
         data-testid={`ProtocolCard_deckLayout_${protocolDisplayName}`}
       >

--- a/app/src/organisms/ProtocolsLanding/useGetElementDOMRectProperty.ts
+++ b/app/src/organisms/ProtocolsLanding/useGetElementDOMRectProperty.ts
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 type DOMRectProperty = keyof Omit<DOMRect, 'toJSON'>
 interface props {
-  getElementProperty: (property: DOMRectProperty) => number
+  getElementProperty: (property: DOMRectProperty) => number | null
 }
 
 /**
@@ -26,13 +26,13 @@ export const useGetElementDOMRectProperty = <T extends HTMLElement>(
   elementRef: React.RefObject<T>
 ): props => {
   const getElementProperty = React.useCallback(
-    (targetProperty: DOMRectProperty): number => {
+    (targetProperty: DOMRectProperty): number | null => {
       const clientRect = elementRef.current?.getBoundingClientRect()
       if (clientRect != null) {
         return clientRect[targetProperty]
       }
-      // if clientRect is undefined, return 0
-      return 0
+      // if clientRect is undefined, return null
+      return null
     },
     [elementRef]
   )


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This will fix #10886.

The current implementation is based on 👇
![IMG_0379](https://user-images.githubusercontent.com/474225/178594244-b4a87631-4fbb-4ac3-ac09-5cc637d137a1.jpg)


![Screen Shot 2022-07-12 at 4 22 59 PM](https://user-images.githubusercontent.com/474225/178588193-32437865-c91c-43f8-83f3-7fe885c031a6.png)


https://user-images.githubusercontent.com/474225/178589606-e2c4e3dc-ef11-4543-b2bd-6a9ad2de6e73.mov



<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- Switch to grid from flex box for pipettes and modules
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- The app never wraps the pipettes name 
- When pipettes and modules are aligned vertically, the order is LEFT`, `RIGHT`, `MODULES`
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
