### PR TITLE
fix(app): fix labware offset text alignment, fix historical run log missing timestamps

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/LabwareInfoOverlay.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/LabwareInfoOverlay.tsx
@@ -17,6 +17,7 @@ import {
   Icon,
   DIRECTION_ROW,
   ALIGN_FLEX_START,
+  JUSTIFY_SPACE_BETWEEN,
 } from '@opentrons/components'
 import { StyledText } from '../../../atoms/text'
 
@@ -56,7 +57,7 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
     >
       <Flex
         flexDirection={DIRECTION_ROW}
-        justifyContent={JUSTIFY_FLEX_END}
+        justifyContent={JUSTIFY_SPACE_BETWEEN}
         alignItems={ALIGN_FLEX_START}
         gridGap={SPACING.spacing2}
       >

--- a/app/src/organisms/Devices/ProtocolRun/RunLog.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/RunLog.tsx
@@ -162,7 +162,7 @@ export function RunLog({ robotName, runId }: RunLogProps): JSX.Element | null {
         firstPostInitialPlayRunCommandIndex.current =
           lastKnownPrePlayRunCommandIndex.current +
           foundPostPlayRunCommandIndex +
-          2
+          1
       } else {
         lastKnownPrePlayRunCommandIndex.current =
           lastKnownPrePlayRunCommandIndex.current + runCommands.length

--- a/app/src/organisms/ProtocolUpload/hooks/useCurrentProtocol.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useCurrentProtocol.ts
@@ -1,4 +1,3 @@
-import * as React from 'react'
 import { useProtocolQuery } from '@opentrons/react-api-client'
 import { useCurrentRun } from './useCurrentRun'
 
@@ -7,12 +6,9 @@ import type { Protocol } from '@opentrons/api-client'
 export function useCurrentProtocol(): Protocol | null {
   const currentProtocolId = useCurrentRun()?.data?.protocolId ?? null
 
-  const enableProtocolPolling = React.useRef<boolean>(true)
-  const { data: protocolRecord } = useProtocolQuery(
-    currentProtocolId,
-    { staleTime: Infinity },
-    enableProtocolPolling.current
-  )
+  const { data: protocolRecord } = useProtocolQuery(currentProtocolId, {
+    staleTime: Infinity,
+  })
 
   return protocolRecord ?? null
 }


### PR DESCRIPTION
# Overview

Ensure that labware names are left aligned in the LabwareInfoOverlay, even if an offset is present.
Ensure that historical runs which involved more than 60 LPC (or otherwise pre-play) run commands are
able to correctly glean the first post play run command in the absence of a current command key.
Remove unnecessary polling of the protocol record from the run detail page.

Closes #11109, Closes #11108

# Changelog

- fix text alignment on labware info overlay so that all text is left aligned
- handle the edge case in the run log where a run is in a terminal state (no current command) and there were more than 60 LPC commands
- do not unnecessarily poll the GET /protocol/:protocolId endpoint for the protocol metadata

# Review requests

- confirm labware info overlay alignment, with and without an offset present
- confirm that all historical runs properly display runtime information for executed commands

# Risk assessment
low
