### PR TITLE
fix(app): h-S overflow menu tooltip visibility

### DIFF
--- a/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
+++ b/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { Flex, POSITION_RELATIVE, useHoverTooltip } from '@opentrons/components'
-import { ModuleType } from '@opentrons/shared-data'
 import { MenuList } from '../../atoms/MenuList'
 import { MenuItem } from '../../atoms/MenuList/MenuItem'
 import { Tooltip } from '../../atoms/Tooltip'
 import { useIsRobotBusy } from '../Devices/hooks'
 import { MenuItemsByModuleType, useModuleOverflowMenu } from './hooks'
 
+import type { ModuleType } from '@opentrons/shared-data'
 import type { AttachedModule } from '../../redux/modules/types'
 
 interface ModuleOverflowMenuProps {

--- a/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
+++ b/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { Flex, POSITION_RELATIVE, useHoverTooltip } from '@opentrons/components'
+import { ModuleType } from '@opentrons/shared-data'
 import { MenuList } from '../../atoms/MenuList'
 import { MenuItem } from '../../atoms/MenuList/MenuItem'
 import { Tooltip } from '../../atoms/Tooltip'
+import { useIsRobotBusy } from '../Devices/hooks'
 import { MenuItemsByModuleType, useModuleOverflowMenu } from './hooks'
 
 import type { AttachedModule } from '../../redux/modules/types'
-import type { ModuleType } from '@opentrons/shared-data'
-import { useIsRobotBusy } from '../Devices/hooks'
 
 interface ModuleOverflowMenuProps {
   module: AttachedModule
@@ -43,16 +43,16 @@ export const ModuleOverflowMenu = (
   )
   const isBusy = useIsRobotBusy() && runId == null
   return (
-    <>
-      <Flex position={POSITION_RELATIVE}>
-        <MenuList
-          buttons={[
-            (menuOverflowItemsByModuleType[
-              module.moduleType
-            ] as MenuItemsByModuleType[ModuleType]).map(
-              (item: any, index: number) => {
-                return (
-                  <>
+    <Flex position={POSITION_RELATIVE}>
+      <MenuList
+        buttons={[
+          (menuOverflowItemsByModuleType[
+            module.moduleType
+          ] as MenuItemsByModuleType[ModuleType]).map(
+            (item: any, index: number) => {
+              return (
+                <>
+                  {item.disabledReason ? (
                     <MenuItem
                       minWidth="10.6rem"
                       key={`${index}_${module.moduleModel}`}
@@ -63,19 +63,29 @@ export const ModuleOverflowMenu = (
                     >
                       {item.setSetting}
                     </MenuItem>
-                    {item.disabledReason && (
-                      <Tooltip tooltipProps={tooltipProps}>
-                        {t('cannot_shake', { ns: 'heater_shaker' })}
-                      </Tooltip>
-                    )}
-                    {item.menuButtons}
-                  </>
-                )
-              }
-            ),
-          ]}
-        />
-      </Flex>
-    </>
+                  ) : (
+                    <MenuItem
+                      minWidth="10.6rem"
+                      key={`${index}_${module.moduleModel}`}
+                      onClick={() => item.onClick(item.isSecondary)}
+                      data-testid={`module_setting_${module.moduleModel}`}
+                      disabled={isBusy}
+                    >
+                      {item.setSetting}
+                    </MenuItem>
+                  )}
+                  {item.disabledReason && (
+                    <Tooltip tooltipProps={tooltipProps}>
+                      {t('heater_shaker:cannot_shake')}
+                    </Tooltip>
+                  )}
+                  {item.menuButtons}
+                </>
+              )
+            }
+          ),
+        ]}
+      />
+    </Flex>
   )
 }


### PR DESCRIPTION
closes #11043

# Overview

This fixes the tooltip logic for the h-s overflow menu. Now, when the latch is opened and the shaker button is disabled, the tooltip only shows up for the shake button.

# Changelog

- changed logic in `ModuleOverflowMenu` so the tooltip props are only added to the menu button that is disabled
- removed unnecessary react fragment

# Review requests

- for the H-S card, when your latch is opened and the shake button is disabled, hover over the disabled button. there should be a tooltip. Hover over the set temp button, there should not be a tooltip.

# Risk assessment

low