### PR TITLE
refactor(app): update H-S attached modal setting copy

### DIFF
--- a/app/src/assets/localization/en/app_settings.json
+++ b/app/src/assets/localization/en/app_settings.json
@@ -54,7 +54,7 @@
   "add_folder_button": "Add labware source folder",
   "change_folder_button": "Change labware source folder",
   "tip_length_cal_method": "Tip Length Calibration Method",
-  "heater_shaker_attach_visible": "Confirm Heater-Shaker Module Attachment",
+  "heater_shaker_attach_visible": "Confirm Heater-Shaker is attached before using it",
   "heater_shaker_attach_description": "Display a reminder to attach the Heater-Shaker properly before running a test shake or using it in a protocol.",
   "cal_block": "Always use calibration block to calibrate",
   "trash_bin": "Always use trash bin to calibrate",

--- a/app/src/pages/AppSettings/__test__/AdvancedSettings.test.tsx
+++ b/app/src/pages/AppSettings/__test__/AdvancedSettings.test.tsx
@@ -241,7 +241,7 @@ describe('AdvancedSettings', () => {
   it('renders the toggle button on when showing heater shaker modal as false', () => {
     mockGetIsHeaterShakerAttached.mockReturnValue(true)
     const [{ getByRole, getByText }] = render()
-    getByText('Confirm Heater-Shaker Module Attachment')
+    getByText('Confirm Heater-Shaker is attached before using it')
     getByText(
       'Display a reminder to attach the Heater-Shaker properly before running a test shake or using it in a protocol.'
     )


### PR DESCRIPTION

# Overview

This PR updates the headline on the H-S attachment modal in AdvancedSettings.

closes #11083

# Changelog

- Update setting headline copy

# Review requests

- Check that the copy is updated
- The setting should always default to ON.

# Risk assessment

low, copy change
