### PR TITLE
WIP: add new UI analytics events to the app 

### DIFF
--- a/app/src/organisms/AddCustomLabwareSlideout/__tests__/AddCustomLabwareSlideout.test.tsx
+++ b/app/src/organisms/AddCustomLabwareSlideout/__tests__/AddCustomLabwareSlideout.test.tsx
@@ -1,11 +1,20 @@
 import * as React from 'react'
 import { MemoryRouter } from 'react-router-dom'
+import { fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../i18n'
+import { useTrackEvent } from '../../../redux/analytics'
 import { AddCustomLabwareSlideout } from '..'
 
 jest.mock('../../../redux/custom-labware')
 jest.mock('../../../pages/Labware/helpers/getAllDefs')
+jest.mock('../../../redux/analytics')
+
+const mockUseTrackEvent = useTrackEvent as jest.MockedFunction<
+  typeof useTrackEvent
+>
+
+let mockTrackEvent: jest.Mock
 
 const render = (
   props: React.ComponentProps<typeof AddCustomLabwareSlideout>
@@ -27,12 +36,21 @@ describe('AddCustomLabwareSlideout', () => {
     onSuccess: jest.fn(() => null),
     onFailure: jest.fn(() => null),
   }
+  beforeEach(() => {
+    mockTrackEvent = jest.fn()
+    mockUseTrackEvent.mockReturnValue(mockTrackEvent)
+  })
 
-  it('renders correct title and labware cards', () => {
+  it('renders correct title and labware cards and clicking on button triggers analytics event', () => {
     const [{ getByText, getByRole }] = render(props)
     getByText('Import a Custom Labware Definition')
     getByText('Or choose a file from your computer to upload.')
-    getByRole('button', { name: 'Choose File' })
+    const btn = getByRole('button', { name: 'Choose File' })
+    fireEvent.click(btn)
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      name: 'addCustomLabware',
+      properties: {},
+    })
   })
 
   it('renders drag and drop section', () => {

--- a/app/src/organisms/AddCustomLabwareSlideout/index.tsx
+++ b/app/src/organisms/AddCustomLabwareSlideout/index.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../redux/custom-labware'
 import { Slideout } from '../../atoms/Slideout'
 import { StyledText } from '../../atoms/text'
+import { useTrackEvent } from '../../redux/analytics'
 import { UploadInput } from '../../molecules/UploadInput'
 import type { Dispatch } from '../../redux/types'
 
@@ -30,6 +31,7 @@ export function AddCustomLabwareSlideout(
 ): JSX.Element {
   const { t } = useTranslation(['labware_landing', 'shared'])
   const dispatch = useDispatch<Dispatch>()
+  const trackEvent = useTrackEvent()
 
   return (
     <Slideout
@@ -46,7 +48,13 @@ export function AddCustomLabwareSlideout(
           onUpload={(file: File) => {
             dispatch(addCustomLabwareFile(file.path))
           }}
-          onClick={() => dispatch(addCustomLabware())}
+          onClick={() => {
+            dispatch(addCustomLabware())
+            trackEvent({
+              name: 'addCustomLabware',
+              properties: {},
+            })
+          }}
           uploadText={t('choose_file_to_upload')}
           dragAndDropText={
             <StyledText as="p">

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/RenameRobotSlideout.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/RenameRobotSlideout.tsx
@@ -116,7 +116,7 @@ export function RenameRobotSlideout({
   })
 
   const handleSubmitRobotRename = (): void => {
-    trackEvent({ name: 'renameARobot', properties: {} })
+    trackEvent({ name: 'renameRobot', properties: {previousRobotName, newRobotName: formik.values.newRobotName} })
     formik.handleSubmit()
   }
 

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/RenameRobotSlideout.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/RenameRobotSlideout.tsx
@@ -116,7 +116,13 @@ export function RenameRobotSlideout({
   })
 
   const handleSubmitRobotRename = (): void => {
-    trackEvent({ name: 'renameRobot', properties: {previousRobotName, newRobotName: formik.values.newRobotName} })
+    trackEvent({
+      name: 'renameRobot',
+      properties: {
+        previousRobotName,
+        newRobotName: formik.values.newRobotName,
+      },
+    })
     formik.handleSubmit()
   }
 

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/RenameRobotSlideout.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/RenameRobotSlideout.tsx
@@ -102,6 +102,8 @@ export function RenameRobotSlideout({
       // TODO 6/9/2022 kj this is a temporary fix to avoid the issue
       // https://github.com/Opentrons/opentrons/issues/10709
       data.name != null && history.push(`/devices`)
+
+      // TODO: add analytics event
       dispatch(removeRobot(previousRobotName))
     },
     onError: (error: Error) => {

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/RenameRobotSlideout.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/RenameRobotSlideout.tsx
@@ -104,8 +104,6 @@ export function RenameRobotSlideout({
       // TODO 6/9/2022 kj this is a temporary fix to avoid the issue
       // https://github.com/Opentrons/opentrons/issues/10709
       data.name != null && history.push(`/devices`)
-
-      // TODO: add analytics event
       dispatch(removeRobot(previousRobotName))
     },
     onError: (error: Error) => {

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/RenameRobotSlideout.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/RenameRobotSlideout.tsx
@@ -17,6 +17,7 @@ import {
   getReachableRobots,
   getUnreachableRobots,
 } from '../../../../../redux/discovery'
+import { useTrackEvent } from '../../../../../redux/analytics'
 import { Slideout } from '../../../../../atoms/Slideout'
 import { StyledText } from '../../../../../atoms/text'
 import { PrimaryButton } from '../../../../../atoms/buttons'
@@ -50,6 +51,7 @@ export function RenameRobotSlideout({
   const [previousRobotName, setPreviousRobotName] = React.useState<string>(
     robotName
   )
+  const trackEvent = useTrackEvent()
   const history = useHistory()
   const dispatch = useDispatch<Dispatch>()
   const connectableRobots = useSelector((state: State) =>
@@ -113,6 +115,11 @@ export function RenameRobotSlideout({
     },
   })
 
+  const handleSubmitRobotRename = (): void => {
+    trackEvent({ name: 'renameARobot', properties: {} })
+    formik.handleSubmit()
+  }
+
   return (
     <Slideout
       title={t('rename_robot_slideout_title')}
@@ -120,7 +127,7 @@ export function RenameRobotSlideout({
       isExpanded={isExpanded}
       footer={
         <PrimaryButton
-          onClick={() => formik.handleSubmit()}
+          onClick={handleSubmitRobotRename}
           disabled={!(formik.isValid && formik.dirty)}
           width="100%"
         >

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/__tests__/RenameRobotSlideout.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/__tests__/RenameRobotSlideout.test.tsx
@@ -85,7 +85,7 @@ describe('RobotSettings RenameRobotSlideout', () => {
       fireEvent.click(renameButton)
       expect(mockTrackEvent).toHaveBeenCalledWith({
         name: 'renameRobot',
-        properties: {newRobotName: 'mockInput', previousRobotName: 'otie'},
+        properties: { newRobotName: 'mockInput', previousRobotName: 'otie' },
       })
     })
   })

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/__tests__/RenameRobotSlideout.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/__tests__/RenameRobotSlideout.test.tsx
@@ -84,8 +84,8 @@ describe('RobotSettings RenameRobotSlideout', () => {
       expect(renameButton).not.toBeDisabled()
       fireEvent.click(renameButton)
       expect(mockTrackEvent).toHaveBeenCalledWith({
-        name: 'renameARobot',
-        properties: {},
+        name: 'renameRobot',
+        properties: {newRobotName: 'mockInput', previousRobotName: 'otie'},
       })
     })
   })

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/__tests__/RenameRobotSlideout.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/__tests__/RenameRobotSlideout.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter } from 'react-router-dom'
 import { fireEvent, waitFor } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../../../../i18n'
+import { useTrackEvent } from '../../../../../../redux/analytics'
 import {
   getConnectableRobots,
   getReachableRobots,
@@ -15,6 +16,7 @@ import {
 import { RenameRobotSlideout } from '../RenameRobotSlideout'
 
 jest.mock('../../../../../../redux/discovery/selectors')
+jest.mock('../../../../../../redux/analytics')
 
 const mockGetConnectableRobots = getConnectableRobots as jest.MockedFunction<
   typeof getConnectableRobots
@@ -22,8 +24,13 @@ const mockGetConnectableRobots = getConnectableRobots as jest.MockedFunction<
 const mockGetReachableRobots = getReachableRobots as jest.MockedFunction<
   typeof getReachableRobots
 >
+const mockUseTrackEvent = useTrackEvent as jest.MockedFunction<
+  typeof useTrackEvent
+>
 
 const mockOnCloseClick = jest.fn()
+let mockTrackEvent: jest.Mock
+
 const render = () => {
   return renderWithProviders(
     <MemoryRouter>
@@ -39,6 +46,8 @@ const render = () => {
 
 describe('RobotSettings RenameRobotSlideout', () => {
   beforeEach(() => {
+    mockTrackEvent = jest.fn()
+    mockUseTrackEvent.mockReturnValue(mockTrackEvent)
     mockConnectableRobot.name = 'connectableOtie'
     mockReachableRobot.name = 'reachableOtie'
     mockGetConnectableRobots.mockReturnValue([mockConnectableRobot])
@@ -73,6 +82,11 @@ describe('RobotSettings RenameRobotSlideout', () => {
       expect(input).toHaveValue('mockInput')
       const renameButton = getByRole('button', { name: 'Rename robot' })
       expect(renameButton).not.toBeDisabled()
+      fireEvent.click(renameButton)
+      expect(mockTrackEvent).toHaveBeenCalledWith({
+        name: 'renameARobot',
+        properties: {},
+      })
     })
   })
 

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
@@ -501,6 +501,14 @@ export function RobotSettingsCalibration({
     true
   )
 
+  const handleHealthCheckClick = (): void => {
+    handleHealthCheck(null)
+    doTrackEvent({
+      name: 'calibrationHealthCheckButtonClicked',
+      properties: {},
+    })
+  }
+
   return (
     <>
       <Portal level="top">
@@ -690,7 +698,7 @@ export function RobotSettingsCalibration({
           </Box>
           <TertiaryButton
             {...targetProps}
-            onClick={() => handleHealthCheck(null)}
+            onClick={handleHealthCheckClick}
             disabled={calCheckButtonDisabled}
           >
             {t('health_check_button')}

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
@@ -305,6 +305,7 @@ export function RobotSettingsCalibration({
       session &&
       session.sessionType === Sessions.SESSION_TYPE_CALIBRATION_HEALTH_CHECK
     ) {
+      // TODO: add analytics event
       return session
     }
     return null

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
@@ -305,7 +305,7 @@ export function RobotSettingsCalibration({
       session &&
       session.sessionType === Sessions.SESSION_TYPE_CALIBRATION_HEALTH_CHECK
     ) {
-      // TODO: add analytics event
+      // TODO: add this analytics event when we deprecate this event firing in redux/analytics makeEvent
       return session
     }
     return null

--- a/app/src/organisms/Devices/RobotSettings/__tests__/RobotSettingsCalibration.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/__tests__/RobotSettingsCalibration.test.tsx
@@ -393,6 +393,11 @@ describe('RobotSettingsCalibration', () => {
     const [{ getByRole }] = render()
     const button = getByRole('button', { name: 'Check health' })
     expect(button).not.toBeDisabled()
+    fireEvent.click(button)
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      name: 'calibrationHealthCheckButtonClicked',
+      properties: {},
+    })
   })
 
   it('Health check button is disabled when a robot is unreachable', () => {

--- a/app/src/organisms/LabwareCard/CustomLabwareOverflowMenu.tsx
+++ b/app/src/organisms/LabwareCard/CustomLabwareOverflowMenu.tsx
@@ -22,6 +22,7 @@ import {
 import { OverflowBtn } from '../../atoms/MenuList/OverflowBtn'
 import { MenuItem } from '../../atoms/MenuList/MenuItem'
 import { AlertPrimaryButton } from '../../atoms/buttons'
+import { useTrackEvent } from '../../redux/analytics'
 import { StyledText } from '../../atoms/text'
 import { Divider } from '../../atoms/structure'
 import { Modal } from '../../atoms/Modal'
@@ -45,6 +46,7 @@ export function CustomLabwareOverflowMenu(
 ): JSX.Element {
   const { filename, onDelete } = props
   const { t } = useTranslation(['labware_landing', 'shared'])
+  const trackEvent = useTrackEvent()
   const dispatch = useDispatch<Dispatch>()
   const [showOverflowMenu, setShowOverflowMenu] = React.useState<boolean>(false)
   const overflowMenuRef = useOnClickOutside<HTMLDivElement>({
@@ -79,6 +81,10 @@ export function CustomLabwareOverflowMenu(
   const handleClickLabwareCreator: React.MouseEventHandler<HTMLButtonElement> = e => {
     e.preventDefault()
     e.stopPropagation()
+    trackEvent({
+      name: 'openLabwareCreatorFromBottomOfLabwareOverflowMenu',
+      properties: {},
+    })
     setShowOverflowMenu(false)
     window.open(LABWARE_CREATOR_HREF, '_blank')
   }

--- a/app/src/organisms/LabwareCard/CustomLabwareOverflowMenu.tsx
+++ b/app/src/organisms/LabwareCard/CustomLabwareOverflowMenu.tsx
@@ -22,7 +22,6 @@ import {
 import { OverflowBtn } from '../../atoms/MenuList/OverflowBtn'
 import { MenuItem } from '../../atoms/MenuList/MenuItem'
 import { AlertPrimaryButton } from '../../atoms/buttons'
-import { useTrackEvent } from '../../redux/analytics'
 import { StyledText } from '../../atoms/text'
 import { Divider } from '../../atoms/structure'
 import { Modal } from '../../atoms/Modal'
@@ -46,7 +45,6 @@ export function CustomLabwareOverflowMenu(
 ): JSX.Element {
   const { filename, onDelete } = props
   const { t } = useTranslation(['labware_landing', 'shared'])
-  const trackEvent = useTrackEvent()
   const dispatch = useDispatch<Dispatch>()
   const [showOverflowMenu, setShowOverflowMenu] = React.useState<boolean>(false)
   const overflowMenuRef = useOnClickOutside<HTMLDivElement>({
@@ -81,10 +79,6 @@ export function CustomLabwareOverflowMenu(
   const handleClickLabwareCreator: React.MouseEventHandler<HTMLButtonElement> = e => {
     e.preventDefault()
     e.stopPropagation()
-    trackEvent({
-      name: 'openLabwareCreatorFromBottomOfLabwareOverflowMenu',
-      properties: {},
-    })
     setShowOverflowMenu(false)
     window.open(LABWARE_CREATOR_HREF, '_blank')
   }

--- a/app/src/organisms/LabwareCard/CustomLabwareOverflowMenu.tsx
+++ b/app/src/organisms/LabwareCard/CustomLabwareOverflowMenu.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { useDispatch } from 'react-redux'
 import { useTranslation } from 'react-i18next'
+import { useTrackEvent } from '../../redux/analytics'
 import {
   Flex,
   Icon,
@@ -50,6 +51,7 @@ export function CustomLabwareOverflowMenu(
   const overflowMenuRef = useOnClickOutside<HTMLDivElement>({
     onClickOutside: () => setShowOverflowMenu(false),
   })
+  const trackEvent = useTrackEvent()
 
   const {
     confirm: confirmDeleteLabware,
@@ -79,6 +81,10 @@ export function CustomLabwareOverflowMenu(
   const handleClickLabwareCreator: React.MouseEventHandler<HTMLButtonElement> = e => {
     e.preventDefault()
     e.stopPropagation()
+    trackEvent({
+      name: 'openLabwareCreatorFromLabwareOverflowMenu',
+      properties: {},
+    })
     setShowOverflowMenu(false)
     window.open(LABWARE_CREATOR_HREF, '_blank')
   }

--- a/app/src/organisms/LabwareCard/__tests__/CustomLabwareOverflowMenu.test.tsx
+++ b/app/src/organisms/LabwareCard/__tests__/CustomLabwareOverflowMenu.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { fireEvent } from '@testing-library/react'
+import { useTrackEvent } from '../../../redux/analytics'
 import {
   renderWithProviders,
   useConditionalConfirm,
@@ -7,6 +8,7 @@ import {
 import { i18n } from '../../../i18n'
 import { CustomLabwareOverflowMenu } from '../CustomLabwareOverflowMenu'
 
+jest.mock('../../../redux/analytics')
 jest.mock('@opentrons/components/src/hooks')
 
 const render = (
@@ -20,8 +22,13 @@ const render = (
 const mockUseConditionalConfirm = useConditionalConfirm as jest.MockedFunction<
   typeof useConditionalConfirm
 >
+const mockUseTrackEvent = useTrackEvent as jest.MockedFunction<
+  typeof useTrackEvent
+>
+
 const mockConfirm = jest.fn()
 const mockCancel = jest.fn()
+let mockTrackEvent: jest.Mock
 
 describe('CustomLabwareOverflowMenu', () => {
   let props: React.ComponentProps<typeof CustomLabwareOverflowMenu>
@@ -36,6 +43,8 @@ describe('CustomLabwareOverflowMenu', () => {
       showConfirmation: true,
       cancel: mockCancel,
     })
+    mockTrackEvent = jest.fn()
+    mockUseTrackEvent.mockReturnValue(mockTrackEvent)
   })
 
   afterEach(() => {

--- a/app/src/organisms/LabwareCard/__tests__/LabwareCard.test.tsx
+++ b/app/src/organisms/LabwareCard/__tests__/LabwareCard.test.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react'
 import { renderWithProviders, nestedTextMatcher } from '@opentrons/components'
 import { i18n } from '../../../i18n'
-import { LabwareCard } from '..'
 import { useAllLabware } from '../../../pages/Labware/hooks'
 import { mockDefinition } from '../../../redux/custom-labware/__fixtures__'
+import { CustomLabwareOverflowMenu } from '../CustomLabwareOverflowMenu'
+import { LabwareCard } from '..'
 
 jest.mock('../../../pages/Labware/hooks')
-jest.mock('../../../pages/Labware/helpers/getAllDefs')
+jest.mock('../CustomLabwareOverflowMenu')
 jest.mock('@opentrons/components', () => {
   const actualComponents = jest.requireActual('@opentrons/components')
   return {
@@ -15,6 +16,9 @@ jest.mock('@opentrons/components', () => {
   }
 })
 
+const mockCustomLabwareOverflowMenu = CustomLabwareOverflowMenu as jest.MockedFunction<
+  typeof CustomLabwareOverflowMenu
+>
 const mockUseAllLabware = useAllLabware as jest.MockedFunction<
   typeof useAllLabware
 >
@@ -27,6 +31,9 @@ const render = (props: React.ComponentProps<typeof LabwareCard>) => {
 describe('LabwareCard', () => {
   let props: React.ComponentProps<typeof LabwareCard>
   beforeEach(() => {
+    mockCustomLabwareOverflowMenu.mockReturnValue(
+      <div>Mock CustomLabwareOverflowMenu</div>
+    )
     mockUseAllLabware.mockReturnValue([{ definition: mockDefinition }])
     props = {
       labware: {

--- a/app/src/organisms/LabwarePositionCheck/SummaryScreen.tsx
+++ b/app/src/organisms/LabwarePositionCheck/SummaryScreen.tsx
@@ -53,6 +53,7 @@ export const SummaryScreen = (props: {
   const { sections, primaryPipetteMount, secondaryPipetteMount } = introInfo
 
   const applyLabwareOffsets = (): void => {
+    // TODO: add analytics event
     if (labwareOffsets.length > 0) {
       labwareOffsets.forEach(labwareOffset => {
         createLabwareOffset({

--- a/app/src/organisms/LabwarePositionCheck/SummaryScreen.tsx
+++ b/app/src/organisms/LabwarePositionCheck/SummaryScreen.tsx
@@ -14,6 +14,7 @@ import {
   JUSTIFY_SPACE_BETWEEN,
 } from '@opentrons/components'
 import { useCreateLabwareOffsetMutation } from '@opentrons/react-api-client'
+import { useTrackEvent } from '../../redux/analytics'
 import { useCurrentRunId } from '../ProtocolUpload/hooks'
 import { useLPCSuccessToast } from '../ProtocolSetup/hooks'
 import { DeckMap } from './DeckMap'
@@ -35,6 +36,7 @@ export const SummaryScreen = (props: {
   const { t } = useTranslation('labware_position_check')
   const introInfo = useIntroInfo()
   const { protocolData } = useProtocolDetailsForRun(runId)
+  const trackEvent = useTrackEvent()
   useLabwareOffsets(
     savePositionCommandData,
     protocolData as ProtocolAnalysisFile
@@ -53,7 +55,7 @@ export const SummaryScreen = (props: {
   const { sections, primaryPipetteMount, secondaryPipetteMount } = introInfo
 
   const applyLabwareOffsets = (): void => {
-    // TODO: add analytics event
+    trackEvent({ name: 'applyLabwareOffsetData', properties: {} })
     if (labwareOffsets.length > 0) {
       labwareOffsets.forEach(labwareOffset => {
         createLabwareOffset({

--- a/app/src/organisms/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { when, resetAllWhenMocks } from 'jest-when'
 import { act } from 'react-dom/test-utils'
 import { fireEvent } from '@testing-library/dom'
+import { useTrackEvent } from '../../../redux/analytics'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../i18n'
 import { useProtocolDetailsForRun } from '../../Devices/hooks'
@@ -14,6 +15,7 @@ import { useIntroInfo, useLabwareOffsets } from '../hooks'
 import { Section } from '../types'
 import { useLPCSuccessToast } from '../../ProtocolSetup/hooks'
 
+jest.mock('../../../redux/analytics')
 jest.mock('../../ProtocolUpload/hooks')
 jest.mock('../../Devices/hooks')
 jest.mock('../../ProtocolSetup/hooks')
@@ -43,6 +45,9 @@ const mockUseLPCSuccessToast = useLPCSuccessToast as jest.MockedFunction<
 const mockUseCurrentRunId = useCurrentRunId as jest.MockedFunction<
   typeof useCurrentRunId
 >
+const mockUseTrackEvent = useTrackEvent as jest.MockedFunction<
+  typeof useTrackEvent
+>
 
 const MOCK_SECTIONS = ['PRIMARY_PIPETTE_TIPRACKS' as Section]
 const LABWARE_DEF_ID = 'LABWARE_DEF_ID'
@@ -59,6 +64,7 @@ const render = (props: React.ComponentProps<typeof SummaryScreen>) => {
   })[0]
 }
 
+let mockTrackEvent: jest.Mock
 describe('SummaryScreen', () => {
   let props: React.ComponentProps<typeof SummaryScreen>
 
@@ -107,6 +113,8 @@ describe('SummaryScreen', () => {
     when(mockUseLPCSuccessToast)
       .calledWith()
       .mockReturnValue({ setIsShowingLPCSuccessToast: _isShowing => {} })
+    mockTrackEvent = jest.fn()
+    when(mockUseTrackEvent).calledWith().mockReturnValue(mockTrackEvent)
   })
   afterEach(() => {
     resetAllWhenMocks()
@@ -135,5 +143,9 @@ describe('SummaryScreen', () => {
     })
     expect(props.onCloseClick).toHaveBeenCalled()
     expect(mockSetIsShowingLPCSuccessToast).toHaveBeenCalled()
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      name: 'applyLabwareOffsetData',
+      properties: {},
+    })
   })
 })

--- a/app/src/organisms/ProtocolsLanding/ProtocolOverflowMenu.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolOverflowMenu.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch } from 'react-redux'
-
+import { useTrackEvent } from '../../redux/analytics'
 import {
   Flex,
   COLORS,
@@ -43,11 +43,15 @@ export function ProtocolOverflowMenu(
     setShowOverflowMenu,
   } = useMenuHandleClickOutside()
   const dispatch = useDispatch<Dispatch>()
+  const trackEvent = useTrackEvent()
   const {
     confirm: confirmDeleteProtocol,
     showConfirmation: showDeleteConfirmation,
     cancel: cancelDeleteProtocol,
-  } = useConditionalConfirm(() => dispatch(removeProtocol(protocolKey)), true)
+  } = useConditionalConfirm(() => {
+    dispatch(removeProtocol(protocolKey))
+    trackEvent({ name: 'deleteProtocolFromApp', properties: {} })
+  }, true)
 
   const handleClickShowInFolder: React.MouseEventHandler<HTMLButtonElement> = e => {
     e.preventDefault()

--- a/app/src/organisms/ProtocolsLanding/UploadInput.tsx
+++ b/app/src/organisms/ProtocolsLanding/UploadInput.tsx
@@ -12,8 +12,10 @@ import {
 import { StyledText } from '../../atoms/text'
 import { UploadInput as FileImporter } from '../../molecules/UploadInput'
 import { addProtocol } from '../../redux/protocol-storage'
-import type { Dispatch } from '../../redux/types'
+import { useTrackEvent } from '../../redux/analytics'
 import { useLogger } from '../../logger'
+
+import type { Dispatch } from '../../redux/types'
 
 export interface UploadInputProps {
   onUpload?: () => void
@@ -24,12 +26,17 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
   const { t } = useTranslation(['protocol_info', 'shared'])
   const dispatch = useDispatch<Dispatch>()
   const logger = useLogger(__filename)
+  const trackEvent = useTrackEvent()
 
   const handleUpload = (file: File): void => {
     if (file.path === null) {
       logger.warn('Failed to upload file, path not found')
     }
     dispatch(addProtocol(file.path))
+    trackEvent({
+      name: 'importProtocolToApp',
+      properties: { protocolFileName: file.name },
+    })
     props.onUpload?.()
   }
 

--- a/app/src/organisms/ProtocolsLanding/__tests__/ProtocolOverflowMenu.test.tsx
+++ b/app/src/organisms/ProtocolsLanding/__tests__/ProtocolOverflowMenu.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
-
+import { useTrackEvent } from '../../../redux/analytics'
 import { renderWithProviders } from '@opentrons/components'
 
 import { i18n } from '../../../i18n'
@@ -12,6 +12,7 @@ import {
 
 import { ProtocolOverflowMenu } from '../ProtocolOverflowMenu'
 
+jest.mock('../../../redux/analytics')
 jest.mock('../../../redux/protocol-storage')
 
 const PROTOCOL_KEY = 'mock-protocol-key'
@@ -22,6 +23,9 @@ const mockViewProtocolSourceFolder = viewProtocolSourceFolder as jest.MockedFunc
 >
 const mockRemoveProtocol = removeProtocol as jest.MockedFunction<
   typeof removeProtocol
+>
+const mockUseTrackEvent = useTrackEvent as jest.MockedFunction<
+  typeof useTrackEvent
 >
 
 const render = () => {
@@ -36,8 +40,13 @@ const render = () => {
   )
 }
 
+let mockTrackEvent: jest.Mock
+
 describe('ProtocolOverflowMenu', () => {
-  beforeEach(() => {})
+  beforeEach(() => {
+    mockTrackEvent = jest.fn()
+    mockUseTrackEvent.mockReturnValue(mockTrackEvent)
+  })
 
   afterEach(() => {
     jest.resetAllMocks()

--- a/app/src/organisms/ProtocolsLanding/__tests__/UploadInput.test.tsx
+++ b/app/src/organisms/ProtocolsLanding/__tests__/UploadInput.test.tsx
@@ -13,7 +13,7 @@ const mockUseTrackEvent = useTrackEvent as jest.Mock<typeof useTrackEvent>
 
 describe('UploadInput', () => {
   let onUpload: jest.MockedFunction<() => {}>
-  let trackEvent: jest.MockedFunction<() => {}>
+  let trackEvent: jest.MockedFunction<any>
   let render: () => ReturnType<typeof renderWithProviders>[0]
 
   beforeEach(() => {
@@ -58,11 +58,13 @@ describe('UploadInput', () => {
   it('calls onUpload callback on choose file and trigger analytics event', () => {
     const { getByTestId } = render()
     const input = getByTestId('file_input')
-    fireEvent.change(input, { target: { files: [{ path: 'dummyFile', name: 'dummyName' }] } })
+    fireEvent.change(input, {
+      target: { files: [{ path: 'dummyFile', name: 'dummyName' }] },
+    })
     expect(onUpload).toHaveBeenCalled()
     expect(trackEvent).toHaveBeenCalledWith({
       name: 'importProtocolToApp',
-      properties: {protocolFileName: 'dummyName'},
+      properties: { protocolFileName: 'dummyName' },
     })
   })
 })

--- a/app/src/organisms/ProtocolsLanding/__tests__/UploadInput.test.tsx
+++ b/app/src/organisms/ProtocolsLanding/__tests__/UploadInput.test.tsx
@@ -4,14 +4,22 @@ import { fireEvent } from '@testing-library/react'
 import { BrowserRouter } from 'react-router-dom'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../i18n'
+import { useTrackEvent } from '../../../redux/analytics'
 import { UploadInput } from '../UploadInput'
+
+jest.mock('../../../redux/analytics')
+
+const mockUseTrackEvent = useTrackEvent as jest.Mock<typeof useTrackEvent>
 
 describe('UploadInput', () => {
   let onUpload: jest.MockedFunction<() => {}>
+  let trackEvent: jest.MockedFunction<() => {}>
   let render: () => ReturnType<typeof renderWithProviders>[0]
 
   beforeEach(() => {
     onUpload = jest.fn()
+    trackEvent = jest.fn()
+    mockUseTrackEvent.mockReturnValue(trackEvent)
     render = () => {
       return renderWithProviders(
         <BrowserRouter>
@@ -47,10 +55,14 @@ describe('UploadInput', () => {
     fireEvent.click(button)
     expect(input.click).toHaveBeenCalled()
   })
-  it('calls onUpload callback on choose file', () => {
+  it('calls onUpload callback on choose file and trigger analytics event', () => {
     const { getByTestId } = render()
     const input = getByTestId('file_input')
-    fireEvent.change(input, { target: { files: [{ path: 'dummyFile' }] } })
+    fireEvent.change(input, { target: { files: [{ path: 'dummyFile', name: 'dummyName' }] } })
     expect(onUpload).toHaveBeenCalled()
+    expect(trackEvent).toHaveBeenCalledWith({
+      name: 'importProtocolToApp',
+      properties: {protocolFileName: 'dummyName'},
+    })
   })
 })

--- a/app/src/pages/AppSettings/AdvancedSettings.tsx
+++ b/app/src/pages/AppSettings/AdvancedSettings.tsx
@@ -37,6 +37,7 @@ import {
 import { Modal } from '../../atoms/Modal'
 import { Portal } from '../../App/portal'
 import { Toast } from '../../atoms/Toast'
+import { useTrackEvent } from '../../redux/analytics'
 import {
   getU2EAdapterDevice,
   getU2EWindowsDriverStatus,
@@ -75,6 +76,7 @@ export function AdvancedSettings(): JSX.Element {
   const useTrashSurfaceForTipCal = useSelector((state: State) =>
     Config.getUseTrashSurfaceForTipCal(state)
   )
+  const trackEvent = useTrackEvent()
   const devToolsOn = useSelector(Config.getDevtoolsEnabled)
   const channel = useSelector(Config.getUpdateChannel)
   const channelOptions: DropdownOption[] = useSelector(
@@ -307,9 +309,13 @@ export function AdvancedSettings(): JSX.Element {
           {
             <TertiaryButton
               marginLeft={SPACING_AUTO}
-              onClick={() =>
+              onClick={() => {
                 dispatch(CustomLabware.changeCustomLabwareDirectory())
-              }
+                trackEvent({
+                  name: 'changeCustomLabwareSourceFolder',
+                  properties: {},
+                })
+              }}
               id="AdvancedSettings_changeLabwareSource"
             >
               {labwarePath !== ''

--- a/app/src/pages/AppSettings/AdvancedSettings.tsx
+++ b/app/src/pages/AppSettings/AdvancedSettings.tsx
@@ -167,6 +167,10 @@ export function AdvancedSettings(): JSX.Element {
 
   const handleClickPythonDirectoryChange: React.MouseEventHandler<HTMLButtonElement> = _event => {
     pythonDirectoryFileInput.current?.click()
+    trackEvent({
+      name: 'changePathToPythonDirectory',
+      properties: {},
+    })
   }
 
   const setPythonInterpreterDirectory: React.ChangeEventHandler<HTMLInputElement> = event => {

--- a/app/src/pages/AppSettings/__test__/AdvancedSettings.test.tsx
+++ b/app/src/pages/AppSettings/__test__/AdvancedSettings.test.tsx
@@ -289,6 +289,10 @@ describe('AdvancedSettings', () => {
     input.click = jest.fn()
     fireEvent.click(button)
     expect(input.click).toHaveBeenCalled()
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      name: 'changePathToPythonDirectory',
+      properties: {},
+    })
   })
 
   it('renders the path to python override text and button with a selected path', () => {

--- a/app/src/pages/AppSettings/__test__/AdvancedSettings.test.tsx
+++ b/app/src/pages/AppSettings/__test__/AdvancedSettings.test.tsx
@@ -15,6 +15,7 @@ import {
   mockReachableRobot,
   mockUnreachableRobot,
 } from '../../../redux/discovery/__fixtures__'
+import { useTrackEvent } from '../../../redux/analytics'
 import * as CustomLabware from '../../../redux/custom-labware'
 import * as Config from '../../../redux/config'
 import * as SystemInfo from '../../../redux/system-info'
@@ -28,6 +29,7 @@ jest.mock('../../../redux/custom-labware')
 jest.mock('../../../redux/discovery')
 jest.mock('../../../redux/system-info')
 jest.mock('@opentrons/components/src/hooks')
+jest.mock('../../../redux/analytics')
 
 const render = (): ReturnType<typeof renderWithProviders> => {
   return renderWithProviders(
@@ -80,11 +82,18 @@ const mockOpenPythonInterpreterDirectory = Config.openPythonInterpreterDirectory
   typeof Config.openPythonInterpreterDirectory
 >
 
+const mockUseTrackEvent = useTrackEvent as jest.MockedFunction<
+  typeof useTrackEvent
+>
+
+let mockTrackEvent: jest.Mock
 const mockConfirm = jest.fn()
 const mockCancel = jest.fn()
 
 describe('AdvancedSettings', () => {
   beforeEach(() => {
+    mockTrackEvent = jest.fn()
+    mockUseTrackEvent.mockReturnValue(mockTrackEvent)
     getCustomLabwarePath.mockReturnValue('')
     getChannelOptions.mockReturnValue([
       {
@@ -138,7 +147,12 @@ describe('AdvancedSettings', () => {
   it('renders the custom labware section with no source folder selected', () => {
     const [{ getByText, getByRole }] = render()
     getByText('No additional source folder specified')
-    getByRole('button', { name: 'Add labware source folder' })
+    const btn = getByRole('button', { name: 'Add labware source folder' })
+    fireEvent.click(btn)
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      name: 'changeCustomLabwareSourceFolder',
+      properties: {},
+    })
   })
   it('renders the tip length cal section', () => {
     const [{ getByRole }] = render()

--- a/app/src/pages/Labware/__tests__/Labware.test.tsx
+++ b/app/src/pages/Labware/__tests__/Labware.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../i18n'
+import { useTrackEvent } from '../../../redux/analytics'
 import { LabwareCard } from '../../../organisms/LabwareCard'
 import { AddCustomLabwareSlideout } from '../../../organisms/AddCustomLabwareSlideout'
 import { useAllLabware, useLabwareFailure, useNewLabwareName } from '../hooks'
@@ -13,6 +14,7 @@ jest.mock('../../../organisms/LabwareCard')
 jest.mock('../../../organisms/AddCustomLabwareSlideout')
 jest.mock('../hooks')
 jest.mock('../helpers/getAllDefs')
+jest.mock('../../../redux/analytics')
 
 const mockLabwareCard = LabwareCard as jest.MockedFunction<typeof LabwareCard>
 const mockAddCustomLabwareSlideout = AddCustomLabwareSlideout as jest.MockedFunction<
@@ -27,6 +29,11 @@ const mockUseLabwareFailure = useLabwareFailure as jest.MockedFunction<
 const mockUseNewLabwareName = useNewLabwareName as jest.MockedFunction<
   typeof useNewLabwareName
 >
+const mockUseTrackEvent = useTrackEvent as jest.MockedFunction<
+  typeof useTrackEvent
+>
+
+let mockTrackEvent: jest.Mock
 
 const render = () => {
   return renderWithProviders(
@@ -41,6 +48,8 @@ const render = () => {
 
 describe('Labware', () => {
   beforeEach(() => {
+    mockTrackEvent = jest.fn()
+    mockUseTrackEvent.mockReturnValue(mockTrackEvent)
     mockLabwareCard.mockReturnValue(<div>Mock Labware Card</div>)
     mockAddCustomLabwareSlideout.mockReturnValue(
       <div>Mock Add Custom Labware</div>
@@ -79,7 +88,12 @@ describe('Labware', () => {
   it('renders footer with labware creator link', () => {
     const [{ getByText, getByRole }] = render()
     getByText('Create a new labware definition')
-    getByRole('link', { name: 'Open Labware Creator' })
+    const btn = getByRole('link', { name: 'Open Labware Creator' })
+    fireEvent.click(btn)
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      name: 'openLabwareCreatorFromBottomOfLabwareLibraryList',
+      properties: {},
+    })
   })
   it('renders error toast if there is a failure', () => {
     mockUseLabwareFailure.mockReturnValue({

--- a/app/src/pages/Labware/index.tsx
+++ b/app/src/pages/Labware/index.tsx
@@ -25,6 +25,7 @@ import { StyledText } from '../../atoms/text'
 import { SecondaryButton } from '../../atoms/buttons'
 import { Toast } from '../../atoms/Toast'
 import { MenuItem } from '../../atoms/MenuList/MenuItem'
+import { useTrackEvent } from '../../redux/analytics'
 import { DropdownMenu } from '../../atoms/MenuList/DropdownMenu'
 import { LabwareCard } from '../../organisms/LabwareCard'
 import { AddCustomLabwareSlideout } from '../../organisms/AddCustomLabwareSlideout'
@@ -73,7 +74,7 @@ export function Labware(): JSX.Element {
   const [sortBy, setSortBy] = React.useState<LabwareSort>('alphabetical')
   const [showSortByMenu, setShowSortByMenu] = React.useState<boolean>(false)
   const toggleSetShowSortByMenu = (): void => setShowSortByMenu(!showSortByMenu)
-
+  const trackEvent = useTrackEvent()
   const [filterBy, setFilterBy] = React.useState<LabwareFilter>('all')
 
   const labware = useAllLabware(sortBy, filterBy)
@@ -229,6 +230,12 @@ export function Labware(): JSX.Element {
 
           <Link
             external
+            onClick={() =>
+              trackEvent({
+                name: 'openLabwareCreatorFromBottomOfLabwareLibraryList',
+                properties: {},
+              })
+            }
             href={LABWARE_CREATOR_HREF}
             css={TYPOGRAPHY.darkLinkLabelSemiBold}
           >


### PR DESCRIPTION
# Overview

Feel free to grab an event or two and put your name on it below:

- [x] (grabbed by: Sakib) Applying labware offset data - `applyLabwareOffsetData`
- [x] (grabbed by: Jethary) Starting calibration health check? - `calibrationHealthCheckButtonClicked`
- [x] (grabbed by: Koji in #10010) Launching Jupyter notebook from the App - `jupyterOpen`
- [x] (grabbed by: Jethary) Renaming a robot - `renameRobot`
- [x] (grabbed by: Brian) Importing a protocol - `importProtocolToApp`
- [x] (grabbed by: Sakib) Deleting a protocol from the app - `deleteProtocolFromApp` 
- [x] (grabbed by: Jethary) Importing a custom labware definition - `addCustomLabware`
- [x] (grabbed by: Jethary) Choosing an alt path to python - `changePathToPythonDirectory`
- [x] (grabbed by: Jethary) Specifying an additional labware source folder - `changeCustomLabwareSourceFolder`
- [x] (grabbed by: Sakib) Opening Labware Creator from the labware overflow menu - `openLabwareCreatorFromLabwareOverflowMenu`
- [x] (grabbed by: Jethary) Opening Labware Creator from the bottom of the labware library list - `openLabwareCreatorFromBottomOfLabwareLibraryList`
~- [ ] (grabbed by: ----) Running a protocol that failed analysis (Can we track this?)~ <-- will potentially tackle this one later

 Closes #10751

# Changelog


# Review requests


# Risk assessment

