### PR TITLE
fix(app): rm analyzing state in run header for historical runs

### DIFF
--- a/app/src/atoms/Banner/index.tsx
+++ b/app/src/atoms/Banner/index.tsx
@@ -11,6 +11,7 @@ import {
   TYPOGRAPHY,
   BORDERS,
   Btn,
+  SIZE_1,
 } from '@opentrons/components'
 
 import type { StyleProps } from '@opentrons/components'
@@ -31,6 +32,8 @@ export interface BannerProps extends StyleProps {
   onCloseClick?: (() => unknown) | React.MouseEventHandler<HTMLButtonElement>
   /** Override the default Alert Icon */
   icon?: IconProps
+  /** some banner onCloseClicks fire events, this allows a spinner after click but before event finishes */
+  isLoading?: boolean
 }
 
 const BANNER_PROPS_BY_TYPE: Record<
@@ -65,7 +68,7 @@ const BANNER_PROPS_BY_TYPE: Record<
 }
 
 export function Banner(props: BannerProps): JSX.Element {
-  const { type, onCloseClick, icon, children, ...styleProps } = props
+  const { type, onCloseClick, icon, children, isLoading, ...styleProps } = props
   const bannerProps = BANNER_PROPS_BY_TYPE[type]
 
   const iconProps = {
@@ -98,7 +101,7 @@ export function Banner(props: BannerProps): JSX.Element {
       <Flex flex="1" alignItems={ALIGN_CENTER}>
         {props.children}
       </Flex>
-      {props.onCloseClick && (
+      {props.onCloseClick && !isLoading && (
         <Btn
           data-testid="Banner_close-button"
           onClick={props.onCloseClick}
@@ -107,6 +110,14 @@ export function Banner(props: BannerProps): JSX.Element {
         >
           <Icon name="close" aria-label="close_icon" />
         </Btn>
+      )}
+      {isLoading && (
+        <Icon
+          name="ot-spinner"
+          size={SIZE_1}
+          aria-label={`ot-spinner`}
+          spin
+        />
       )}
     </Flex>
   )

--- a/app/src/atoms/Banner/index.tsx
+++ b/app/src/atoms/Banner/index.tsx
@@ -33,7 +33,7 @@ export interface BannerProps extends StyleProps {
   /** Override the default Alert Icon */
   icon?: IconProps
   /** some banner onCloseClicks fire events, this allows a spinner after click but before event finishes */
-  isLoading?: boolean
+  isCloseActionLoading?: boolean
 }
 
 const BANNER_PROPS_BY_TYPE: Record<
@@ -68,7 +68,14 @@ const BANNER_PROPS_BY_TYPE: Record<
 }
 
 export function Banner(props: BannerProps): JSX.Element {
-  const { type, onCloseClick, icon, children, isLoading, ...styleProps } = props
+  const {
+    type,
+    onCloseClick,
+    icon,
+    children,
+    isCloseActionLoading,
+    ...styleProps
+  } = props
   const bannerProps = BANNER_PROPS_BY_TYPE[type]
 
   const iconProps = {
@@ -101,7 +108,7 @@ export function Banner(props: BannerProps): JSX.Element {
       <Flex flex="1" alignItems={ALIGN_CENTER}>
         {props.children}
       </Flex>
-      {props.onCloseClick && !isLoading && (
+      {onCloseClick && !isCloseActionLoading && (
         <Btn
           data-testid="Banner_close-button"
           onClick={props.onCloseClick}
@@ -111,13 +118,8 @@ export function Banner(props: BannerProps): JSX.Element {
           <Icon name="close" aria-label="close_icon" />
         </Btn>
       )}
-      {isLoading && (
-        <Icon
-          name="ot-spinner"
-          size={SIZE_1}
-          aria-label={`ot-spinner`}
-          spin
-        />
+      {isCloseActionLoading && (
+        <Icon name="ot-spinner" size={SIZE_1} aria-label={`ot-spinner`} spin />
       )}
     </Flex>
   )

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -127,13 +127,15 @@ export function ProtocolRunHeader({
   const isHeaterShakerInProtocol = useIsHeaterShakerInProtocol()
   const configHasHeaterShakerAttached = useSelector(getIsHeaterShakerAttached)
   const createdAtTimestamp = useRunCreatedAtTimestamp(runId)
-  const { protocolData, displayName, protocolKey } = useProtocolDetailsForRun(
-    runId
-  )
+  const {
+    protocolData,
+    displayName,
+    protocolKey,
+    isProtocolAnalyzing,
+  } = useProtocolDetailsForRun(runId)
   const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId)
   const robotAnalyticsData = useRobotAnalyticsData(robotName)
   const isRobotViewable = useIsRobotViewable(robotName)
-  const isProtocolAnalyzing = protocolData == null && isRobotViewable
   const runStatus = useRunStatus(runId)
   const { analysisErrors } = useProtocolAnalysisErrors(runId)
   const isRunCurrent = Boolean(useRunQuery(runId)?.data?.data?.current)
@@ -280,6 +282,7 @@ export function ProtocolRunHeader({
     isMutationLoading ||
     isRobotBusy ||
     isProtocolAnalyzing ||
+    protocolData == null ||
     runStatus === RUN_STATUS_FINISHING ||
     runStatus === RUN_STATUS_PAUSE_REQUESTED ||
     runStatus === RUN_STATUS_STOP_REQUESTED ||
@@ -376,7 +379,11 @@ export function ProtocolRunHeader({
   switch (runStatus) {
     case RUN_STATUS_FAILED: {
       clearProtocolBanner = (
-        <Banner type="error" onCloseClick={handleClearClick}>
+        <Banner
+          type="error"
+          onCloseClick={handleClearClick}
+          isLoading={isClosingCurrentRun}
+        >
           <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} width="100%">
             {`${t('run_failed')}.`}
           </Flex>
@@ -386,7 +393,11 @@ export function ProtocolRunHeader({
     }
     case RUN_STATUS_SUCCEEDED: {
       clearProtocolBanner = (
-        <Banner type="success" onCloseClick={handleClearClick}>
+        <Banner
+          type="success"
+          onCloseClick={handleClearClick}
+          isLoading={isClosingCurrentRun}
+        >
           <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} width="100%">
             {`${t('run_completed')}.`}
           </Flex>

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -382,7 +382,7 @@ export function ProtocolRunHeader({
         <Banner
           type="error"
           onCloseClick={handleClearClick}
-          isLoading={isClosingCurrentRun}
+          isCloseActionLoading={isClosingCurrentRun}
         >
           <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} width="100%">
             {`${t('run_failed')}.`}
@@ -396,7 +396,7 @@ export function ProtocolRunHeader({
         <Banner
           type="success"
           onCloseClick={handleClearClick}
-          isLoading={isClosingCurrentRun}
+          isCloseActionLoading={isClosingCurrentRun}
         >
           <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} width="100%">
             {`${t('run_completed')}.`}

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -177,6 +177,7 @@ const PROTOCOL_DETAILS = {
   displayName: PROTOCOL_NAME,
   protocolData: simpleV6Protocol,
   protocolKey: 'fakeProtocolKey',
+  isProtocolAnalyzing: false,
 }
 
 const mockMovingHeaterShaker = {
@@ -344,6 +345,7 @@ describe('ProtocolRunHeader', () => {
       displayName: null,
       protocolData: null,
       protocolKey: null,
+      isProtocolAnalyzing: true,
     })
 
     const [{ getByRole }] = render()
@@ -734,5 +736,17 @@ describe('ProtocolRunHeader', () => {
     waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith('/devices')
     })
+  })
+  it('renders banner with spinner if currently closing current run', async () => {
+    when(mockUseRunStatus)
+      .calledWith(RUN_ID)
+      .mockReturnValue(RUN_STATUS_SUCCEEDED)
+    when(mockUseCloseCurrentRun).calledWith().mockReturnValue({
+      isClosingCurrentRun: true,
+      closeCurrentRun: mockCloseCurrentRun,
+    })
+    const [{ getByText, getByLabelText }] = render()
+    getByText('Run completed.')
+    getByLabelText('ot-spinner')
   })
 })

--- a/app/src/organisms/Devices/hooks/__tests__/useProtocolDetailsForRun.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useProtocolDetailsForRun.test.tsx
@@ -79,6 +79,7 @@ describe('useProtocolDetailsForRun hook', () => {
       displayName: null,
       protocolData: null,
       protocolKey: null,
+      isProtocolAnalyzing: false,
     })
   })
 
@@ -111,6 +112,7 @@ describe('useProtocolDetailsForRun hook', () => {
       displayName: 'fake protocol',
       protocolData: simpleV6Protocol,
       protocolKey: 'fakeProtocolKey',
+      isProtocolAnalyzing: false,
     })
   })
 })

--- a/app/src/organisms/Devices/hooks/useProtocolDetailsForRun.ts
+++ b/app/src/organisms/Devices/hooks/useProtocolDetailsForRun.ts
@@ -13,7 +13,7 @@ export interface ProtocolDetails {
   displayName: string | null
   protocolData: ProtocolAnalysisFile<{}> | null
   protocolKey: string | null
-  isProtocolAnalyzing: boolean
+  isProtocolAnalyzing?: boolean
 }
 
 export function useProtocolDetailsForRun(

--- a/app/src/organisms/Devices/hooks/useProtocolDetailsForRun.ts
+++ b/app/src/organisms/Devices/hooks/useProtocolDetailsForRun.ts
@@ -13,6 +13,7 @@ export interface ProtocolDetails {
   displayName: string | null
   protocolData: ProtocolAnalysisFile<{}> | null
   protocolKey: string | null
+  isProtocolAnalyzing: boolean
 }
 
 export function useProtocolDetailsForRun(
@@ -56,5 +57,7 @@ export function useProtocolDetailsForRun(
     protocolData:
       mostRecentAnalysis != null ? schemaV6Adapter(mostRecentAnalysis) : null,
     protocolKey: protocolRecord?.data.key ?? null,
+    isProtocolAnalyzing:
+      mostRecentAnalysis != null && mostRecentAnalysis?.status === 'pending',
   }
 }


### PR DESCRIPTION
# Overview
Remove the analyzing state for historical runs in header. Change X icon to spinner in run header banner after clicked.
Closes #10740, #10904.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- adds `isProtocolAnalyzing` to `useProtocolDetailsForRun` to use for rendering analyzing state on new runs in header
- adds `isCloseActionLoading` to `Banner` component so we can render loading spinner instead of X icon after an async close action has been fired via banner

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- confirm that historical run detail page does not render analyzing on robot state in button
- confirm that when a protocol is analyzing for new runs that state is reflected
- confirm that after clicking X on banner for completed or failed run on details page the banner renders spinner until action is complete
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
