### PR TITLE
fix(app): sanitize legacy command text in run log to protect for non string values

### DIFF
--- a/app/src/organisms/RunDetails/CommandText.tsx
+++ b/app/src/organisms/RunDetails/CommandText.tsx
@@ -126,8 +126,15 @@ export function CommandText(props: Props): JSX.Element | null {
       break
     }
     case 'custom': {
+      const { legacyCommandText } = displayCommand.params ?? {}
+      const sanitizedCommandText =
+        typeof legacyCommandText === 'object'
+          ? JSON.stringify(legacyCommandText)
+          : String(legacyCommandText)
       messageNode =
-        displayCommand.params?.legacyCommandText ?? displayCommand.commandType
+        legacyCommandText != null
+          ? sanitizedCommandText
+          : displayCommand.commandType
       break
     }
     default: {

--- a/app/src/organisms/RunDetails/__tests__/CommandText.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/CommandText.test.tsx
@@ -158,4 +158,19 @@ describe('CommandText', () => {
       'Picking up tip from wellName of fake_display_name in fake_labware_location'
     )
   })
+
+  it('renders correct command text for for legacy command with non-string text', () => {
+    const { getByText } = render({
+      analysisCommand: null,
+      runCommand: {
+        ...MOCK_COMMAND_SUMMARY,
+        commandType: 'custom',
+        params: {
+          legacyCommandType: 'anyLegacyCommand',
+          legacyCommandText: { someKey: ['someValue', 'someOtherValue'] },
+        },
+      },
+    })
+    getByText('{"someKey":["someValue","someOtherValue"]}')
+  })
 })


### PR DESCRIPTION
# Overview

The legacy command mapper may pass non-string values in the `legacyCommandText`  value of the `custom` commands that we're parsing in the Run Log.  

This add's a bit of parsing protection to that value before we try to render it into the app.

# Review requests

- [ ] app shouldn't white screen if a python comment has a dictionary as a parameter

# Risk assessment
low