### PR TITLE
fix(app): sanitize legacy command text in new run log to protect for non string values

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/StepText.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/StepText.tsx
@@ -138,8 +138,15 @@ export function StepText(props: Props): JSX.Element | null {
       break
     }
     case 'custom': {
+      const { legacyCommandText } = displayCommand.params ?? {}
+      const sanitizedCommandText =
+        typeof legacyCommandText === 'object'
+          ? JSON.stringify(legacyCommandText)
+          : String(legacyCommandText)
       messageNode =
-        displayCommand.params?.legacyCommandText ?? displayCommand.commandType
+        legacyCommandText != null
+          ? sanitizedCommandText
+          : displayCommand.commandType
       break
     }
     default: {

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/StepText.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/StepText.test.tsx
@@ -202,4 +202,21 @@ describe('StepText', () => {
       'Picking up tip from wellName of fake_display_name in fake_labware_location'
     )
   })
+
+  it('renders correct command text for for legacy command with non-string text', () => {
+    const { getByText } = render({
+      robotName: ROBOT_NAME,
+      runId: RUN_ID,
+      analysisCommand: null,
+      runCommand: {
+        ...MOCK_COMMAND_SUMMARY,
+        commandType: 'custom',
+        params: {
+          legacyCommandType: 'anyLegacyCommand',
+          legacyCommandText: { someKey: ['someValue', 'someOtherValue'] },
+        },
+      },
+    })
+    getByText('{"someKey":["someValue","someOtherValue"]}')
+  })
 })


### PR DESCRIPTION
Following up on the work from #11127 which introduced the bug fix to legacy code that is slated for
removal accidentally. This adds it to the correct location
