### PR TITLE
fix(app): labware setup H-S latch command add runId

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ModuleExtraAttention.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ModuleExtraAttention.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { useCreateLiveCommandMutation } from '@opentrons/react-api-client'
+import { useCreateCommandMutation } from '@opentrons/react-api-client'
 import {
   HEATERSHAKER_MODULE_TYPE,
   MAGNETIC_MODULE_TYPE,
@@ -25,12 +25,13 @@ import type { ModuleTypesThatRequiresExtraAttention } from '../../ProtocolSetup/
 interface ModuleExtraAttentionProps {
   moduleTypes: ModuleType[]
   modulesInfo: { [moduleId: string]: ModuleRenderInfoForProtocol }
+  runId: string
 }
 
 export const ModuleExtraAttention = (
   props: ModuleExtraAttentionProps
 ): JSX.Element => {
-  const { moduleTypes, modulesInfo } = props
+  const { moduleTypes, modulesInfo, runId } = props
   const { t } = useTranslation('protocol_setup')
   const [
     secureLabwareModalType,
@@ -55,6 +56,7 @@ export const ModuleExtraAttention = (
             {index > 0 && <Divider color={COLORS.medGrey} />}
             {
               <ModuleExtraAttentionItem
+                runId={runId}
                 moduleInfo={module}
                 onClick={() =>
                   setSecureLabwareModalType(module.moduleDef.moduleType)
@@ -71,14 +73,15 @@ export const ModuleExtraAttention = (
 interface ModuleExtraAttentionItemProps {
   moduleInfo: ModuleRenderInfoForProtocol
   onClick: () => unknown
+  runId: string
 }
 
 const ModuleExtraAttentionItem = (
   props: ModuleExtraAttentionItemProps
 ): JSX.Element | null => {
-  const { moduleInfo, onClick } = props
+  const { moduleInfo, onClick, runId } = props
   const { t } = useTranslation(['heater_shaker', 'protocol_setup'])
-  const { createLiveCommand } = useCreateLiveCommandMutation()
+  const { createCommand } = useCreateCommandMutation()
 
   switch (moduleInfo.moduleDef.moduleType) {
     case MAGNETIC_MODULE_TYPE:
@@ -113,7 +116,8 @@ const ModuleExtraAttentionItem = (
         }
 
         const toggleLatch = (): void => {
-          createLiveCommand({
+          createCommand({
+            runId: runId,
             command: latchCommand,
           }).catch((e: Error) => {
             console.error(

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware.tsx
@@ -210,6 +210,7 @@ export function SetupLabware({
             <ModuleExtraAttention
               moduleTypes={moduleTypesThatRequireExtraAttention}
               modulesInfo={moduleRenderInfoById}
+              runId={runId}
             />
           ) : null}
           <RobotWorkSpace

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ModuleExtraAttention.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ModuleExtraAttention.test.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react'
+import { fireEvent } from '@testing-library/react'
+import { HeaterShakerModule } from '@opentrons/api-client'
 import { renderWithProviders } from '@opentrons/components'
+import { useCreateCommandMutation } from '@opentrons/react-api-client'
 import { i18n } from '../../../../i18n'
+import { RUN_ID_1 } from '../../../RunTimeControl/__fixtures__'
 import { ModuleExtraAttention } from '../ModuleExtraAttention'
 import {
   mockHeaterShaker as mockHeaterShakerAttachedModule,
@@ -9,6 +13,12 @@ import {
 
 import type { ModuleModel, ModuleType } from '@opentrons/shared-data'
 import type { AttachedModule } from '../../../../redux/modules/types'
+
+jest.mock('@opentrons/react-api-client')
+
+const mockUseCreateCommandMutation = useCreateCommandMutation as jest.MockedFunction<
+  typeof useCreateCommandMutation
+>
 
 const MOCK_MAGNETIC_MODULE_COORDS = [10, 20, 0]
 const mockMagneticModule = {
@@ -71,6 +81,28 @@ const mockThermocycler = {
   quirks: [],
 }
 
+export const mockHeaterShakerLatchClosed: HeaterShakerModule = {
+  id: 'heatershaker_id',
+  moduleModel: 'heaterShakerModuleV1',
+  moduleType: 'heaterShakerModuleType',
+  serialNumber: 'jkl123',
+  hardwareRevision: 'heatershaker_v4.0',
+  firmwareVersion: 'v2.0.0',
+  hasAvailableUpdate: true,
+  data: {
+    labwareLatchStatus: 'idle_closed',
+    speedStatus: 'idle',
+    temperatureStatus: 'idle',
+    currentSpeed: null,
+    currentTemperature: null,
+    targetSpeed: null,
+    targetTemperature: null,
+    errorDetails: null,
+    status: 'idle',
+  },
+  usbPort: { path: '/dev/ot_module_heatershaker0', port: 1, hub: null },
+}
+
 const render = (props: React.ComponentProps<typeof ModuleExtraAttention>) => {
   return renderWithProviders(<ModuleExtraAttention {...props} />, {
     i18nInstance: i18n,
@@ -79,8 +111,15 @@ const render = (props: React.ComponentProps<typeof ModuleExtraAttention>) => {
 
 describe('ModuleExtraAttention', () => {
   let props: React.ComponentProps<typeof ModuleExtraAttention>
+  let mockCreateCommand = jest.fn()
+
   beforeEach(() => {
-    props = { moduleTypes: [], modulesInfo: {} }
+    props = { moduleTypes: [], modulesInfo: {}, runId: RUN_ID_1 }
+    mockCreateCommand = jest.fn()
+    mockCreateCommand.mockResolvedValue(null)
+    mockUseCreateCommandMutation.mockReturnValue({
+      createCommand: mockCreateCommand,
+    } as any)
   })
 
   it('should render the correct title', () => {
@@ -106,6 +145,7 @@ describe('ModuleExtraAttention', () => {
           attachedModuleMatch: null,
         },
       },
+      runId: RUN_ID_1,
     }
 
     const { getByText } = render(props)
@@ -114,7 +154,7 @@ describe('ModuleExtraAttention', () => {
     getByText('View instructions')
   })
 
-  it('if there is a heater shaker module it should show the correct item and button function', () => {
+  it('if there is a heater shaker module it should show the correct item and clicking on button sends close command', () => {
     props = {
       moduleTypes: [mockHeaterShaker.moduleType],
       modulesInfo: {
@@ -132,12 +172,58 @@ describe('ModuleExtraAttention', () => {
           attachedModuleMatch: mockHeaterShakerAttachedModule as AttachedModule,
         },
       },
+      runId: RUN_ID_1,
     }
 
-    const { getByText } = render(props)
+    const { getByText, getByRole } = render(props)
     getByText('Heater Shaker Module in Slot 1')
     getByText('Use latch controls for easy placement of labware.')
-    getByText('Close Labware Latch')
+    const closeBtn = getByRole('button', { name: 'Close Labware Latch' })
+    fireEvent.click(closeBtn)
+    expect(mockCreateCommand).toHaveBeenCalledWith({
+      command: {
+        commandType: 'heaterShaker/closeLabwareLatch',
+        params: {
+          moduleId: mockHeaterShaker.moduleId,
+        },
+      },
+      runId: RUN_ID_1,
+    })
+  })
+
+  it('if there is a heater shaker module and clicking on button sends open latch command', () => {
+    props = {
+      moduleTypes: [mockHeaterShaker.moduleType],
+      modulesInfo: {
+        [mockHeaterShaker.moduleId]: {
+          moduleId: mockHeaterShaker.moduleId,
+          x: 1,
+          y: 1,
+          z: 1,
+          moduleDef: mockHeaterShaker as any,
+          nestedLabwareDisplayName: 'Source Plate',
+          nestedLabwareDef: null,
+          nestedLabwareId: null,
+          protocolLoadOrder: 0,
+          slotName: '1',
+          attachedModuleMatch: mockHeaterShakerLatchClosed as AttachedModule,
+        },
+      },
+      runId: RUN_ID_1,
+    }
+
+    const { getByRole } = render(props)
+    const openBtn = getByRole('button', { name: 'Open Labware Latch' })
+    fireEvent.click(openBtn)
+    expect(mockCreateCommand).toHaveBeenCalledWith({
+      command: {
+        commandType: 'heaterShaker/openLabwareLatch',
+        params: {
+          moduleId: mockHeaterShaker.moduleId,
+        },
+      },
+      runId: RUN_ID_1,
+    })
   })
 
   it('if there is a thermocycler module it should show the correct information', () => {
@@ -158,6 +244,7 @@ describe('ModuleExtraAttention', () => {
           attachedModuleMatch: mockThermocyclerAttachedModule as AttachedModule,
         },
       },
+      runId: RUN_ID_1,
     }
 
     const { getByText } = render(props)

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ModuleExtraAttention.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ModuleExtraAttention.test.tsx
@@ -81,7 +81,7 @@ const mockThermocycler = {
   quirks: [],
 }
 
-export const mockHeaterShakerLatchClosed: HeaterShakerModule = {
+const mockHeaterShakerLatchClosed: HeaterShakerModule = {
   id: 'heatershaker_id',
   moduleModel: 'heaterShakerModuleV1',
   moduleType: 'heaterShakerModuleType',

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/SetupLabware.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/SetupLabware.test.tsx
@@ -516,6 +516,7 @@ describe('LabwareSetup', () => {
               attachedModuleMatch: null,
             },
           },
+          runId: RUN_ID,
         })
       )
       .mockReturnValue(


### PR DESCRIPTION
closes #11048 & #11125

# Overview

The labware setup extra attention banner for the H-S has a button that allows you to open/close the latch. However, the latch command didn't include the runId which is required to send commands to modules during setup. 

# Changelog

- refactor command logic to include `runId` in `ModuleExtraAttention` and fix test

# Review requests

- does logic sound correct? Try to test this on a h-s if you can! I am still unable to upload H-S protocols for some reason

# Risk assessment

low