### PR TITLE
feat(app): show text if no modules plugged in but required during setup

### DIFF
--- a/app/src/assets/localization/en/protocol_details.json
+++ b/app/src/assets/localization/en/protocol_details.json
@@ -30,5 +30,6 @@
   "quantity": "Quantity",
   "go_to_labware_definition": "Go to labware definition",
   "protocol_designer_version": "Protocol Designer {{version}}",
-  "python_api_version": "Python API {{version}}"
+  "python_api_version": "Python API {{version}}",
+  "connect_modules_to_see_controls": "Connect modules to see controls"
 }

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunModuleControls.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunModuleControls.tsx
@@ -1,11 +1,19 @@
 import * as React from 'react'
-import { Box, Flex, SPACING } from '@opentrons/components'
+import {
+  COLORS,
+  Flex,
+  SPACING,
+  JUSTIFY_CENTER,
+  Box,
+} from '@opentrons/components'
+import { useCreateCommandMutation } from '@opentrons/react-api-client'
+import { useTranslation } from 'react-i18next'
+import { StyledText } from '../../../atoms/text'
 import { ModuleCard } from '../../ModuleCard'
 import {
   useModuleRenderInfoForProtocolById,
   useProtocolDetailsForRun,
 } from '../hooks'
-import { useCreateCommandMutation } from '@opentrons/react-api-client'
 
 import type { LoadModuleRunTimeCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
 import type { RunTimeCommand } from '@opentrons/shared-data'
@@ -18,7 +26,8 @@ interface ProtocolRunModuleControlsProps {
 export const ProtocolRunModuleControls = ({
   robotName,
   runId,
-}: ProtocolRunModuleControlsProps): JSX.Element | null => {
+}: ProtocolRunModuleControlsProps): JSX.Element => {
+  const { t } = useTranslation('protocol_details')
   const moduleRenderInfoForProtocolById = useModuleRenderInfoForProtocolById(
     robotName,
     runId
@@ -26,10 +35,8 @@ export const ProtocolRunModuleControls = ({
   const attachedModules = Object.values(moduleRenderInfoForProtocolById).filter(
     module => module.attachedModuleMatch != null
   )
-
   const { protocolData } = useProtocolDetailsForRun(runId)
   const { createCommand } = useCreateCommandMutation()
-
   const loadCommands: LoadModuleRunTimeCommand[] =
     protocolData !== null
       ? protocolData?.commands.filter(
@@ -72,7 +79,17 @@ export const ProtocolRunModuleControls = ({
       ? attachedModules?.slice(-halfAttachedModulesSize)
       : []
 
-  return (
+  return attachedModules.length === 0 ? (
+    <Flex justifyContent={JUSTIFY_CENTER}>
+      <StyledText
+        as="p"
+        color={COLORS.darkGreyEnabled}
+        marginY={SPACING.spacing4}
+      >
+        {t('connect_modules_to_see_controls')}
+      </StyledText>
+    </Flex>
+  ) : (
     <Flex
       gridGap={SPACING.spacing3}
       paddingTop={SPACING.spacing4}

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunModuleControls.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunModuleControls.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useTranslation } from 'react-i18next'
 import {
   COLORS,
   Flex,
@@ -7,7 +8,6 @@ import {
   Box,
 } from '@opentrons/components'
 import { useCreateCommandMutation } from '@opentrons/react-api-client'
-import { useTranslation } from 'react-i18next'
 import { StyledText } from '../../../atoms/text'
 import { ModuleCard } from '../../ModuleCard'
 import {

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunModuleControls.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunModuleControls.test.tsx
@@ -227,4 +227,29 @@ describe('ProtocolRunModuleControls', () => {
 
     getByText('mock Heater-Shaker Module Card')
   })
+
+  it('renders correct text when module is not attached but required for protocol', () => {
+    when(mockUseModuleRenderInfoForProtocolById)
+      .calledWith(ROBOT_NAME, RUN_ID)
+      .mockReturnValue({
+        [mockHeaterShakerDef.moduleId]: {
+          moduleId: 'heaterShakerModuleId',
+          x: '0',
+          y: '20',
+          z: '30',
+          moduleDef: mockHeaterShakerDef,
+          nestedLabwareDef: null,
+          nestedLabwareId: null,
+          protocolLoadOrder: 1,
+          attachedModuleMatch: null,
+        },
+      } as any)
+
+    const { getByText } = render({
+      robotName: 'otie',
+      runId: 'test123',
+    })
+
+    getByText('Connect modules to see controls')
+  })
 })


### PR DESCRIPTION
closes #10947

# Overview

Add text to Module Controls section if there are no modules attached but required

<img width="859" alt="Screen Shot 2022-07-14 at 3 22 00 PM" src="https://user-images.githubusercontent.com/66035149/179066267-6f65325c-6f13-4465-b558-6bff834b35ad.png">

# Changelog

- add logic to `ProtocolRunModuleControls`, fix test

# Review requests

- run protocol with modules required but don't have any module plugged in. Go to the module controls tab. You should see the correct text
- if the protocol doesn't need a module, the module controls tab should not show up at all (this is current behavior but verify that is still the case)

# Risk assessment

low