### PR TITLE
refactor(app): remove need for hardcoded heights in module grids

### DIFF
--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -203,14 +203,22 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
               />
             )}
           </Flex>
-          <Flex flexDirection={DIRECTION_COLUMN} paddingLeft={SPACING.spacing3}>
+          <Flex
+            flexDirection={DIRECTION_COLUMN}
+            flex="100%"
+            paddingLeft={SPACING.spacing3}
+          >
             {!isDeckCalibrated &&
             pipetteOffsetCalibration == null &&
             pipetteInfo != null &&
             showBanner &&
             !isFetching ? (
               <Flex paddingBottom={SPACING.spacing2}>
-                <Banner type="error" onCloseClick={() => setShowBanner(false)}>
+                <Banner
+                  type="error"
+                  flex="100%"
+                  onCloseClick={() => setShowBanner(false)}
+                >
                   {t('deck_cal_missing')}
                 </Banner>
               </Flex>
@@ -221,7 +229,11 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
             showBanner &&
             !isFetching ? (
               <Flex paddingBottom={SPACING.spacing2}>
-                <Banner type="error" onCloseClick={() => setShowBanner(false)}>
+                <Banner
+                  type="error"
+                  flex="100%"
+                  onCloseClick={() => setShowBanner(false)}
+                >
                   <Flex flexDirection={DIRECTION_COLUMN}>
                     {t('pipette_offset_calibration_needed')}
                     <Btn
@@ -240,6 +252,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
               <Flex paddingBottom={SPACING.spacing2}>
                 <Banner
                   type="warning"
+                  flex="100%"
                   onCloseClick={() => setShowBanner(false)}
                 >
                   <Flex flexDirection={DIRECTION_COLUMN}>

--- a/app/src/organisms/Devices/PipettesAndModules.tsx
+++ b/app/src/organisms/Devices/PipettesAndModules.tsx
@@ -12,7 +12,6 @@ import {
   JUSTIFY_CENTER,
   SIZE_3,
   SPACING,
-  DIRECTION_ROW,
   TYPOGRAPHY,
 } from '@opentrons/components'
 

--- a/app/src/organisms/Devices/PipettesAndModules.tsx
+++ b/app/src/organisms/Devices/PipettesAndModules.tsx
@@ -41,7 +41,7 @@ export function PipettesAndModules({
 
   const attachedModules =
     useModulesQuery({ refetchInterval: EQUIPMENT_POLL_MS })?.data?.data ?? []
-  // split modules in half and map into ech column separately to avoid
+  // split modules in half and map into each column separately to avoid
   // the need for hardcoded heights without limitation, array will be split equally
   // or left column will contain 1 more item than right column
   const halfAttachedModulesSize = Math.ceil(attachedModules?.length / 2)

--- a/app/src/organisms/Devices/PipettesAndModules.tsx
+++ b/app/src/organisms/Devices/PipettesAndModules.tsx
@@ -2,9 +2,9 @@ import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { getPipetteModelSpecs, LEFT, RIGHT } from '@opentrons/shared-data'
 import { useModulesQuery, usePipettesQuery } from '@opentrons/react-api-client'
-import { css } from 'styled-components'
 
 import {
+  Box,
   Flex,
   ALIGN_CENTER,
   ALIGN_FLEX_START,
@@ -12,8 +12,6 @@ import {
   JUSTIFY_CENTER,
   SIZE_3,
   SPACING,
-  WRAP,
-  JUSTIFY_START,
   DIRECTION_ROW,
   TYPOGRAPHY,
 } from '@opentrons/components'
@@ -25,37 +23,6 @@ import { ModuleCard } from '../ModuleCard'
 import { useIsRobotViewable, useRunStatuses } from './hooks'
 import { PipetteCard } from './PipetteCard'
 
-export const MIN_HEIGHT_OVER_3_STYLING = css`
-  max-height: 37rem;
-
-  @media (min-width: 700px) {
-    max-height: 32rem;
-  }
-
-  @media (min-width: 800px) {
-    max-height: 30rem;
-  }
-
-  @media (min-width: 900px) {
-    max-height: 22rem;
-  }
-`
-
-export const MIN_HEIGHT_UNDER_3_STYLING = css`
-  max-height: 29rem;
-
-  @media (min-width: 700px) {
-    max-height: 27rem;
-  }
-
-  @media (min-width: 800px) {
-    max-height: 25rem;
-  }
-
-  @media (min-width: 900px) {
-    max-height: 22rem;
-  }
-`
 const EQUIPMENT_POLL_MS = 5000
 interface PipettesAndModulesProps {
   robotName: string
@@ -66,14 +33,24 @@ export function PipettesAndModules({
 }: PipettesAndModulesProps): JSX.Element | null {
   const { t } = useTranslation('device_details')
 
-  const attachedModules =
-    useModulesQuery({ refetchInterval: EQUIPMENT_POLL_MS })?.data?.data ?? []
   const attachedPipettes = usePipettesQuery({
     refetchInterval: EQUIPMENT_POLL_MS,
   })?.data ?? { left: undefined, right: undefined }
   const isRobotViewable = useIsRobotViewable(robotName)
   const currentRunId = useCurrentRunId()
   const { isRunTerminal } = useRunStatuses()
+
+  const attachedModules =
+    useModulesQuery({ refetchInterval: EQUIPMENT_POLL_MS })?.data?.data ?? []
+  // split modules in half and map into ech column separately to avoid
+  // the need for hardcoded heights without limitation, array will be split equally
+  // or left column will contain 1 more item than right column
+  const halfAttachedModulesSize = Math.ceil(attachedModules?.length / 2)
+  const leftColumnModules = attachedModules?.slice(0, halfAttachedModulesSize)
+  const rightColumnModules =
+    attachedModules?.length > 1
+      ? attachedModules?.slice(-halfAttachedModulesSize)
+      : []
 
   return (
     <Flex
@@ -108,8 +85,8 @@ export function PipettesAndModules({
           </Flex>
         )}
         {isRobotViewable ? (
-          <Flex flexDirection={DIRECTION_COLUMN} width="100%">
-            <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing3}>
+          <Box width="100%">
+            <Flex gridGap={SPACING.spacing3}>
               <PipetteCard
                 pipetteId={attachedPipettes.left?.id}
                 pipetteInfo={
@@ -132,34 +109,29 @@ export function PipettesAndModules({
                 robotName={robotName}
               />
             </Flex>
-            <Flex
-              justifyContent={JUSTIFY_START}
-              flexDirection={DIRECTION_COLUMN}
-              flexWrap={WRAP}
-              css={
-                attachedModules.length > 3
-                  ? MIN_HEIGHT_OVER_3_STYLING
-                  : MIN_HEIGHT_UNDER_3_STYLING
-              }
-            >
-              {attachedModules.map((module, index) => {
-                return (
-                  <Flex
-                    flex="1"
-                    marginRight={SPACING.spacing3}
+            <Flex gridGap={SPACING.spacing3}>
+              <Box flex="50%">
+                {leftColumnModules.map((module, index) => (
+                  <ModuleCard
                     key={`moduleCard_${module.moduleType}_${index}`}
-                    width={`calc(50% - ${SPACING.spacing2})`}
-                  >
-                    <ModuleCard
-                      module={module}
-                      robotName={robotName}
-                      isLoadedInRun={false}
-                    />
-                  </Flex>
-                )
-              })}
+                    robotName={robotName}
+                    module={module}
+                    isLoadedInRun={false}
+                  />
+                ))}
+              </Box>
+              <Box flex="50%">
+                {rightColumnModules.map((module, index) => (
+                  <ModuleCard
+                    key={`moduleCard_${module.moduleType}_${index}`}
+                    robotName={robotName}
+                    module={module}
+                    isLoadedInRun={false}
+                  />
+                ))}
+              </Box>
             </Flex>
-          </Flex>
+          </Box>
         ) : (
           <StyledText as="p" id="PipettesAndModules_offline">
             {t('offline_pipettes_and_modules')}

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunModuleControls.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunModuleControls.tsx
@@ -63,11 +63,14 @@ export const ProtocolRunModuleControls = ({
   }, [])
 
   // split modules in half and map into ech column separately to avoid
-  // the need for hardcoded heights without limitation, array will  be split equally
+  // the need for hardcoded heights without limitation, array will be split equally
   // or left column will contain 1 more item than right column
   const halfAttachedModulesSize = Math.ceil(attachedModules?.length / 2)
   const leftColumnModules = attachedModules?.slice(0, halfAttachedModulesSize)
-  const rightColumnModules = attachedModules?.slice(-halfAttachedModulesSize)
+  const rightColumnModules =
+    attachedModules?.length > 1
+      ? attachedModules?.slice(-halfAttachedModulesSize)
+      : []
 
   return (
     <Flex

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunModuleControls.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunModuleControls.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react'
 import {
+  Box,
   DIRECTION_COLUMN,
+  DIRECTION_ROW,
   Flex,
+  JUSTIFY_SPACE_BETWEEN,
   JUSTIFY_START,
   SPACING,
   WRAP,
@@ -15,10 +18,6 @@ import { useCreateCommandMutation } from '@opentrons/react-api-client'
 
 import type { LoadModuleRunTimeCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
 import type { RunTimeCommand } from '@opentrons/shared-data'
-import {
-  MIN_HEIGHT_OVER_3_STYLING,
-  MIN_HEIGHT_UNDER_3_STYLING,
-} from '../PipettesAndModules'
 
 interface ProtocolRunModuleControlsProps {
   robotName: string
@@ -72,25 +71,21 @@ export const ProtocolRunModuleControls = ({
     }
   }, [])
 
+  const halfAttachedModulesSize = Math.ceil(attachedModules?.length / 2)
+  const firstHalfModules = attachedModules?.slice(0, halfAttachedModulesSize)
+  const secondHalfModules = attachedModules?.slice(-halfAttachedModulesSize)
+  console.log(firstHalfModules, secondHalfModules)
   return (
     <Flex
-      justifyContent={JUSTIFY_START}
-      flexWrap={WRAP}
-      flexDirection={DIRECTION_COLUMN}
-      css={
-        attachedModules.length > 3
-          ? MIN_HEIGHT_OVER_3_STYLING
-          : MIN_HEIGHT_UNDER_3_STYLING
-      }
+      gridGap={SPACING.spacing3}
+      paddingTop={SPACING.spacing3}
+      paddingX={SPACING.spacing1}
+      flexDirection={DIRECTION_ROW}
+      width="100%"
     >
-      {attachedModules.map((module, index) => {
-        return (
-          <Flex
-            width={`calc(50% - ${SPACING.spacing3})`}
-            marginTop={SPACING.spacing3}
-            marginX={SPACING.spacing2}
-            key={`moduleCard_${module.moduleDef.moduleType}_${index}`}
-          >
+      <Box flex="50%">
+        {firstHalfModules.map((module, index) => (
+          <Box key={`moduleCard_${module.moduleDef.moduleType}_${index}`}>
             {module.attachedModuleMatch != null ? (
               <ModuleCard
                 robotName={robotName}
@@ -100,9 +95,24 @@ export const ProtocolRunModuleControls = ({
                 isLoadedInRun={true}
               />
             ) : null}
-          </Flex>
-        )
-      })}
+          </Box>
+        ))}
+      </Box>
+      <Box flex="50%">
+        {secondHalfModules.map((module, index) => (
+          <Box key={`moduleCard_${module.moduleDef.moduleType}_${index}`}>
+            {module.attachedModuleMatch != null ? (
+              <ModuleCard
+                robotName={robotName}
+                runId={runId}
+                module={module.attachedModuleMatch}
+                slotName={module.slotName}
+                isLoadedInRun={true}
+              />
+            ) : null}
+          </Box>
+        ))}
+      </Box>
     </Flex>
   )
 }

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunModuleControls.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunModuleControls.tsx
@@ -79,13 +79,16 @@ export const ProtocolRunModuleControls = ({
     <Flex
       gridGap={SPACING.spacing3}
       paddingTop={SPACING.spacing3}
-      paddingX={SPACING.spacing1}
+      paddingX={SPACING.spacing2}
       flexDirection={DIRECTION_ROW}
       width="100%"
     >
       <Box flex="50%">
         {firstHalfModules.map((module, index) => (
-          <Box key={`moduleCard_${module.moduleDef.moduleType}_${index}`}>
+          <Box
+            key={`moduleCard_${module.moduleDef.moduleType}_${index}`}
+            marginBottom={SPACING.spacing4}
+          >
             {module.attachedModuleMatch != null ? (
               <ModuleCard
                 robotName={robotName}

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunModuleControls.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunModuleControls.tsx
@@ -62,7 +62,7 @@ export const ProtocolRunModuleControls = ({
     }
   }, [])
 
-  // split modules in half and map into ech column separately to avoid
+  // split modules in half and map into each column separately to avoid
   // the need for hardcoded heights without limitation, array will be split equally
   // or left column will contain 1 more item than right column
   const halfAttachedModulesSize = Math.ceil(attachedModules?.length / 2)

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunModuleControls.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunModuleControls.tsx
@@ -1,14 +1,5 @@
 import * as React from 'react'
-import {
-  Box,
-  DIRECTION_COLUMN,
-  DIRECTION_ROW,
-  Flex,
-  JUSTIFY_SPACE_BETWEEN,
-  JUSTIFY_START,
-  SPACING,
-  WRAP,
-} from '@opentrons/components'
+import { Box, Flex, SPACING } from '@opentrons/components'
 import { ModuleCard } from '../../ModuleCard'
 import {
   useModuleRenderInfoForProtocolById,
@@ -71,50 +62,46 @@ export const ProtocolRunModuleControls = ({
     }
   }, [])
 
+  // split modules in half and map into ech column separately to avoid
+  // the need for hardcoded heights without limitation, array will  be split equally
+  // or left column will contain 1 more item than right column
   const halfAttachedModulesSize = Math.ceil(attachedModules?.length / 2)
-  const firstHalfModules = attachedModules?.slice(0, halfAttachedModulesSize)
-  const secondHalfModules = attachedModules?.slice(-halfAttachedModulesSize)
-  console.log(firstHalfModules, secondHalfModules)
+  const leftColumnModules = attachedModules?.slice(0, halfAttachedModulesSize)
+  const rightColumnModules = attachedModules?.slice(-halfAttachedModulesSize)
+
   return (
     <Flex
       gridGap={SPACING.spacing3}
       paddingTop={SPACING.spacing3}
       paddingX={SPACING.spacing2}
-      flexDirection={DIRECTION_ROW}
-      width="100%"
     >
       <Box flex="50%">
-        {firstHalfModules.map((module, index) => (
-          <Box
-            key={`moduleCard_${module.moduleDef.moduleType}_${index}`}
-            marginBottom={SPACING.spacing4}
-          >
-            {module.attachedModuleMatch != null ? (
-              <ModuleCard
-                robotName={robotName}
-                runId={runId}
-                module={module.attachedModuleMatch}
-                slotName={module.slotName}
-                isLoadedInRun={true}
-              />
-            ) : null}
-          </Box>
-        ))}
+        {leftColumnModules.map((module, index) =>
+          module.attachedModuleMatch != null ? (
+            <ModuleCard
+              key={`moduleCard_${module.moduleDef.moduleType}_${index}`}
+              robotName={robotName}
+              runId={runId}
+              module={module.attachedModuleMatch}
+              slotName={module.slotName}
+              isLoadedInRun={true}
+            />
+          ) : null
+        )}
       </Box>
       <Box flex="50%">
-        {secondHalfModules.map((module, index) => (
-          <Box key={`moduleCard_${module.moduleDef.moduleType}_${index}`}>
-            {module.attachedModuleMatch != null ? (
-              <ModuleCard
-                robotName={robotName}
-                runId={runId}
-                module={module.attachedModuleMatch}
-                slotName={module.slotName}
-                isLoadedInRun={true}
-              />
-            ) : null}
-          </Box>
-        ))}
+        {rightColumnModules.map((module, index) =>
+          module.attachedModuleMatch != null ? (
+            <ModuleCard
+              key={`moduleCard_${module.moduleDef.moduleType}_${index}`}
+              robotName={robotName}
+              runId={runId}
+              module={module.attachedModuleMatch}
+              slotName={module.slotName}
+              isLoadedInRun={true}
+            />
+          ) : null
+        )}
       </Box>
     </Flex>
   )

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunModuleControls.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunModuleControls.tsx
@@ -75,8 +75,9 @@ export const ProtocolRunModuleControls = ({
   return (
     <Flex
       gridGap={SPACING.spacing3}
-      paddingTop={SPACING.spacing3}
-      paddingX={SPACING.spacing2}
+      paddingTop={SPACING.spacing4}
+      paddingBottom={SPACING.spacing3}
+      paddingX={SPACING.spacing4}
     >
       <Box flex="50%">
         {leftColumnModules.map((module, index) =>

--- a/app/src/organisms/ModuleCard/HeaterShakerModuleData.tsx
+++ b/app/src/organisms/ModuleCard/HeaterShakerModuleData.tsx
@@ -13,6 +13,7 @@ import {
   TYPOGRAPHY,
   TEXT_TRANSFORM_CAPITALIZE,
   SIZE_1,
+  WRAP,
 } from '@opentrons/components'
 import { StatusLabel } from '../../atoms/StatusLabel'
 import type {
@@ -26,27 +27,6 @@ interface HeaterShakerModuleDataProps {
   moduleData: HeaterShakerModule['data']
   showTemperatureData?: boolean
 }
-
-const MODULE_STATUS_STYLING = css`
-  display: grid;
-  grid-template-columns: repeat(1, 1fr);
-
-  @media (min-width: 800px) {
-    grid-template-columns: repeat(2, 1fr);
-  }
-  @media (min-width: 900px) {
-    grid-template-columns: repeat(3, 1fr);
-  }
-`
-
-const HS_MODULE_CARD_STYLING = css`
-  display: grid;
-  grid-template-columns: repeat(1, 1fr);
-
-  @media (min-width: 800px) {
-    grid-template-columns: repeat(2, 1fr);
-  }
-`
 
 export const HeaterShakerModuleData = (
   props: HeaterShakerModuleDataProps
@@ -129,13 +109,10 @@ export const HeaterShakerModuleData = (
   }
 
   return (
-    <Flex
-      css={showTemperatureData ? MODULE_STATUS_STYLING : HS_MODULE_CARD_STYLING}
-    >
+    <Flex flexWrap={WRAP} gridGap={`${SPACING.spacing1} ${SPACING.spacing6}`}>
       {showTemperatureData && (
         <Flex
           flexDirection={DIRECTION_COLUMN}
-          marginRight={SPACING.spacing6}
           data-testid={`heater_shaker_module_data_temp`}
         >
           <Text

--- a/app/src/organisms/ModuleCard/HeaterShakerModuleData.tsx
+++ b/app/src/organisms/ModuleCard/HeaterShakerModuleData.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { css } from 'styled-components'
 import {
   Flex,
   Text,

--- a/app/src/organisms/ModuleCard/ThermocyclerModuleData.tsx
+++ b/app/src/organisms/ModuleCard/ThermocyclerModuleData.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { css } from 'styled-components'
 import { StatusLabel } from '../../atoms/StatusLabel'
 import {
   Flex,
@@ -73,6 +72,7 @@ export const ThermocyclerModuleData = (
       <Flex
         flexDirection={DIRECTION_COLUMN}
         data-testid={`thermocycler_module_data_lid`}
+        gridColumn="1/4"
       >
         <Text
           textTransform={TEXT_TRANSFORM_UPPERCASE}
@@ -100,6 +100,7 @@ export const ThermocyclerModuleData = (
       <Flex
         flexDirection={DIRECTION_COLUMN}
         data-testid={`thermocycler_module_data_block`}
+        gridColumn="5/8"
       >
         <Text
           textTransform={TEXT_TRANSFORM_UPPERCASE}

--- a/app/src/organisms/ModuleCard/ThermocyclerModuleData.tsx
+++ b/app/src/organisms/ModuleCard/ThermocyclerModuleData.tsx
@@ -12,6 +12,7 @@ import {
   DIRECTION_COLUMN,
   COLORS,
   SPACING,
+  WRAP,
 } from '@opentrons/components'
 
 import type { ThermocyclerStatus } from '../../redux/modules/api-types'
@@ -23,15 +24,6 @@ interface ThermocyclerModuleProps {
   lidTemp: number | null
   lidTarget: number | null
 }
-
-const MODULE_STATUS_STYLING = css`
-  display: grid;
-  grid-template-columns: repeat(1, 1fr);
-
-  @media (min-width: 800px) {
-    grid-template-columns: repeat(2, 1fr);
-  }
-`
 
 export const ThermocyclerModuleData = (
   props: ThermocyclerModuleProps
@@ -77,7 +69,7 @@ export const ThermocyclerModuleData = (
   }
 
   return (
-    <Flex css={MODULE_STATUS_STYLING}>
+    <Flex flexWrap={WRAP} gridGap={`${SPACING.spacing1} ${SPACING.spacing6}`}>
       <Flex
         flexDirection={DIRECTION_COLUMN}
         data-testid={`thermocycler_module_data_lid`}

--- a/app/src/organisms/ModuleCard/index.tsx
+++ b/app/src/organisms/ModuleCard/index.tsx
@@ -273,7 +273,11 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
               alt={module.moduleModel}
             />
           </Flex>
-          <Flex flexDirection={DIRECTION_COLUMN} flex={"100%"} paddingLeft={SPACING.spacing3}>
+          <Flex
+            flexDirection={DIRECTION_COLUMN}
+            flex={'100%'}
+            paddingLeft={SPACING.spacing3}
+          >
             {showSuccessToast && (
               <Toast
                 message={t('firmware_update_installation_successful')}

--- a/app/src/organisms/ModuleCard/index.tsx
+++ b/app/src/organisms/ModuleCard/index.tsx
@@ -273,7 +273,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
               alt={module.moduleModel}
             />
           </Flex>
-          <Flex flexDirection={DIRECTION_COLUMN} paddingLeft={SPACING.spacing3}>
+          <Flex flexDirection={DIRECTION_COLUMN} flex={"100%"} paddingLeft={SPACING.spacing3}>
             {showSuccessToast && (
               <Toast
                 message={t('firmware_update_installation_successful')}

--- a/app/src/organisms/ModuleCard/index.tsx
+++ b/app/src/organisms/ModuleCard/index.tsx
@@ -273,7 +273,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
               alt={module.moduleModel}
             />
           </Flex>
-          <Flex flexDirection={DIRECTION_COLUMN} flex={"100%"} paddingLeft={SPACING.spacing3}>
+          <Flex flexDirection={DIRECTION_COLUMN} flex="100%" paddingLeft={SPACING.spacing3}>
             {showSuccessToast && (
               <Toast
                 message={t('firmware_update_installation_successful')}

--- a/robot-server/robot_server/modules/module_data_mapper.py
+++ b/robot-server/robot_server/modules/module_data_mapper.py
@@ -125,7 +125,7 @@ class ModuleDataMapper:
             serialNumber=module_identity.serial_number,
             firmwareVersion=module_identity.firmware_version,
             hardwareRevision=module_identity.hardware_revision,
-            hasAvailableUpdate=has_available_update,
+            hasAvailableUpdate=True,
             usbPort=UsbPort(
                 port=usb_port.port_number,
                 hub=usb_port.hub,

--- a/robot-server/robot_server/modules/module_data_mapper.py
+++ b/robot-server/robot_server/modules/module_data_mapper.py
@@ -125,7 +125,7 @@ class ModuleDataMapper:
             serialNumber=module_identity.serial_number,
             firmwareVersion=module_identity.firmware_version,
             hardwareRevision=module_identity.hardware_revision,
-            hasAvailableUpdate=True,
+            hasAvailableUpdate=has_available_update,
             usbPort=UsbPort(
                 port=usb_port.port_number,
                 hub=usb_port.hub,


### PR DESCRIPTION
# Overview

The hardcoded heights are brittle and break the layout if the modules grow larger than we expect. It also breaks if we incorrectly account for smaller window sizes. With each breakage we add more breakpoints and adjust the heights. We can avoid using hardcoded heights and achieve the desired design if we instead split the modules into two arrays and map into each column separately.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- use two columns and split attached modules array for less brittle layout

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
confirm layout works with various number of modules and sizes and at all breakpoints
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
