### PR TITLE
test(update-server): Make minor fixes to tests

### DIFF
--- a/update-server/tests/buildroot/test_control.py
+++ b/update-server/tests/buildroot/test_control.py
@@ -1,14 +1,16 @@
 """test the buildroot endpoints in otupdate.common.control """
 from typing import Dict
 
-from aiohttp.test_utils import TestClient
+# Avoid pytest trying to collect TestClient because it begins with "Test".
+from aiohttp.test_utils import TestClient as HTTPTestClient
+
 from decoy import Decoy
 
 from otupdate.common.name_management import NameSynchronizer
 
 
 async def test_health(
-    test_cli: TestClient,
+    test_cli: HTTPTestClient,
     version_dict: Dict[str, str],
     mock_name_synchronizer: NameSynchronizer,
     decoy: Decoy,

--- a/update-server/tests/common/conftest.py
+++ b/update-server/tests/common/conftest.py
@@ -8,7 +8,9 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
-from aiohttp.test_utils import TestClient
+
+# Avoid pytest trying to collect TestClient because it begins with "Test".
+from aiohttp.test_utils import TestClient as HTTPTestClient
 
 from otupdate import buildroot, common
 
@@ -24,7 +26,7 @@ one_up = os.path.abspath(os.path.join(__file__, "../../"))
 @pytest.fixture(params=[openembedded, buildroot])
 async def test_cli(
     aiohttp_client, otupdate_config, request, version_file_path, mock_name_synchronizer
-) -> Tuple[TestClient, str]:
+) -> Tuple[HTTPTestClient, str]:
     """
     Build an app using dummy versions, then build a test client and return it
     """

--- a/update-server/tests/common/test_control.py
+++ b/update-server/tests/common/test_control.py
@@ -4,12 +4,13 @@ import asyncio
 from typing import Tuple
 from unittest import mock
 
-from aiohttp.test_utils import TestClient
+# Avoid pytest trying to collect TestClient because it begins with "Test".
+from aiohttp.test_utils import TestClient as HTTPTestClient
 
 from otupdate.common import control
 
 
-async def test_restart(test_cli: Tuple[TestClient, str], monkeypatch) -> None:
+async def test_restart(test_cli: Tuple[HTTPTestClient, str], monkeypatch) -> None:
     """It should restart the robot"""
     restart_mock = mock.Mock()
 

--- a/update-server/tests/common/test_update.py
+++ b/update-server/tests/common/test_update.py
@@ -8,7 +8,9 @@ import zipfile
 from typing import Tuple
 
 import pytest
-from aiohttp.test_utils import TestClient
+
+# Avoid pytest trying to collect TestClient because it begins with "Test".
+from aiohttp.test_utils import TestClient as HTTPTestClient
 
 from otupdate.buildroot import update, config, update_actions
 from otupdate.common import file_actions
@@ -21,7 +23,7 @@ from tests.openembedded.conftest import (
 
 
 @pytest.fixture
-async def update_session(test_cli: Tuple[TestClient, str]):
+async def update_session(test_cli: Tuple[HTTPTestClient, str]):
     resp = await test_cli[0].post("/server/update/begin")
     body = await resp.json()
     yield body["token"]
@@ -32,7 +34,7 @@ def session_endpoint(token, endpoint):
     return f"/server/update/{token}/{endpoint}"
 
 
-async def test_begin(test_cli: Tuple[TestClient, str]):
+async def test_begin(test_cli: Tuple[HTTPTestClient, str]):
     # Creating a session should work
     resp = await test_cli[0].post("/server/update/begin")
     body = await resp.json()
@@ -48,7 +50,7 @@ async def test_begin(test_cli: Tuple[TestClient, str]):
     assert "message" in body
 
 
-async def test_cancel(test_cli: Tuple[TestClient, str]):
+async def test_cancel(test_cli: Tuple[HTTPTestClient, str]):
     # cancelling when there’s a session should work great
     resp = await test_cli[0].post("/server/update/begin")
     assert test_cli[0].server.app.get(update.SESSION_VARNAME)
@@ -139,7 +141,7 @@ async def test_session_catches_validation_fail(
 
 
 async def test_update_happypath(
-    test_cli: Tuple[TestClient, str],
+    test_cli: Tuple[HTTPTestClient, str],
     update_session,
     downloaded_update_file_consolidated,
     loop,

--- a/update-server/tests/openembedded/conftest.py
+++ b/update-server/tests/openembedded/conftest.py
@@ -42,11 +42,6 @@ async def test_cli(
     return client
 
 
-def mock_root_fs_interface_() -> MagicMock:
-    """Mock RootFSInterface."""
-    return MagicMock(spec=RootFSInterface)
-
-
 @pytest.fixture
 def mock_root_fs_interface() -> MagicMock:
     """Mock RootFSInterface."""

--- a/update-server/tests/openembedded/test_control.py
+++ b/update-server/tests/openembedded/test_control.py
@@ -2,14 +2,16 @@
 
 from typing import Dict
 
-from aiohttp.test_utils import TestClient
+# Avoid pytest trying to collect TestClient because it begins with "Test".
+from aiohttp.test_utils import TestClient as HTTPTestClient
+
 from decoy import Decoy
 
 from otupdate.common.name_management import NameSynchronizer
 
 
 async def test_health(
-    test_cli: TestClient,
+    test_cli: HTTPTestClient,
     version_dict: Dict[str, str],
     mock_name_synchronizer: NameSynchronizer,
     decoy: Decoy,


### PR DESCRIPTION
# Changelog

* Delete a duplicate definition of a fixture that seemed accidental.
* Resolve spurious PyTest warnings:

  ```
  PytestCollectionWarning: cannot collect test class 'TestClient' because it has a __init__ constructor
  ```

# Risk analysis

No risk to production code. Changes are just to tests.