### PR TITLE
test(update-server): Start type-checking tests

### DIFF
--- a/update-server/Makefile
+++ b/update-server/Makefile
@@ -53,7 +53,7 @@ test:
 
 .PHONY: lint
 lint:
-	$(python) -m mypy otupdate
+	$(python) -m mypy otupdate tests
 	$(python) -m black --check ./otupdate ./tests
 	$(python) -m flake8 otupdate tests
 

--- a/update-server/mypy.ini
+++ b/update-server/mypy.ini
@@ -2,6 +2,7 @@
 strict = True
 show_error_codes = True
 plugins = decoy.mypy
+warn_unused_configs = True
 
 
 # The dbus and systemd packages will not be installed in non-Linux dev environments.
@@ -17,39 +18,108 @@ ignore_missing_imports=True
 
 # ~6 errors
 [mypy-otupdate.common.control]
-disallow_untyped_defs= False
+disallow_untyped_defs = False
 disallow_untyped_calls = False
 warn_return_any = False
 
 # ~8 errors
 [mypy-otupdate.common.session]
-disallow_untyped_defs= False
+disallow_untyped_defs = False
 disallow_untyped_calls = False
 warn_return_any = False
 
 # ~28 errors
 [mypy-otupdate.common.update]
-disallow_untyped_defs= False
+disallow_untyped_defs = False
 disallow_untyped_calls = False
 warn_return_any = False
 
 # ~ 17 errors
 [mypy-otupdate.buildroot]
-disallow_untyped_defs= False
+disallow_untyped_defs = False
 disallow_untyped_calls = False
 warn_return_any = False
 
 # ~5 errors
 [mypy-otupdate.buildroot.update_actions]
-disallow_untyped_defs= False
+disallow_untyped_defs = False
 disallow_untyped_calls = False
 
 # ~16 errors
 [mypy-otupdate.openembedded]
-disallow_untyped_defs= False
+disallow_untyped_defs = False
 disallow_untyped_calls = False
 
 # ~5 errors
 [mypy-otupdate.openembedded.updater]
-disallow_untyped_defs= False
+disallow_untyped_defs = False
 disallow_untyped_calls = False
+
+# ~7 errors
+[mypy-tests.conftest]
+ignore_errors = True
+
+# ~2 errors
+[mypy-tests.buildroot.conftest]
+ignore_errors = True
+
+# ~2 errors
+[mypy-tests.buildroot.test_control]
+ignore_errors = True
+
+# ~10 errors
+[mypy-tests.buildroot.test_ssh_key_management]
+ignore_errors = True
+
+# ~2 errors
+[mypy-tests.buildroot.test_update_actions]
+ignore_errors = True
+
+# ~15 errors
+[mypy-tests.common.conftest]
+ignore_errors = True
+
+# ~15 errors
+[mypy-tests.common.config]
+ignore_errors = True
+
+# ~11 errors
+[mypy-tests.common.test_config]
+ignore_errors = True
+
+# ~2 errors
+[mypy-tests.common.test_control]
+ignore_errors = True
+
+# ~10 errors
+[mypy-tests.common.test_file_actions]
+ignore_errors = True
+
+# ~34 errors
+[mypy-tests.common.test_update]
+ignore_errors = True
+
+# ~5 errors
+[mypy-tests.openembedded.conftest]
+ignore_errors = True
+
+# ~2 errors
+[mypy-tests.openembedded.test_control]
+ignore_errors = True
+
+# ~15 errors
+[mypy-tests.openembedded.test_updater]
+ignore_errors = True
+
+
+
+
+
+# FIX BEFORE MERGE
+# ~11 errors
+[mypy-tests.common.name_management]
+ignore_errors=True
+[mypy-tests.common.name_management.test_http_endpoints]
+ignore_errors=True
+[mypy-tests.common.name_management.test_pretty_hostname]
+ignore_errors=True

--- a/update-server/mypy.ini
+++ b/update-server/mypy.ini
@@ -110,16 +110,3 @@ ignore_errors = True
 # ~15 errors
 [mypy-tests.openembedded.test_updater]
 ignore_errors = True
-
-
-
-
-
-# FIX BEFORE MERGE
-# ~11 errors
-[mypy-tests.common.name_management]
-ignore_errors=True
-[mypy-tests.common.name_management.test_http_endpoints]
-ignore_errors=True
-[mypy-tests.common.name_management.test_pretty_hostname]
-ignore_errors=True

--- a/update-server/tests/common/name_management/test_http_endpoints.py
+++ b/update-server/tests/common/name_management/test_http_endpoints.py
@@ -1,35 +1,53 @@
-async def test_get_name(test_cli, mock_name_synchronizer, decoy) -> None:
+from typing import Tuple
+
+# Avoid pytest trying to collect TestClient because it begins with "Test".
+from aiohttp.test_utils import TestClient as HTTPTestClient
+
+from decoy import Decoy
+
+from otupdate.common.name_management.name_synchronizer import NameSynchronizer
+
+
+async def test_get_name(
+    test_cli: Tuple[HTTPTestClient, str],
+    mock_name_synchronizer: NameSynchronizer,
+    decoy: Decoy,
+) -> None:
     decoy.when(mock_name_synchronizer.get_name()).then_return("the returned name")
 
-    response = await (test_cli[0].get("/server/name"))
+    response = await (test_cli[0].get("/server/name"))  # type: ignore[no-untyped-call]
     assert response.status == 200
 
     body = await response.json()
     assert body["name"] == "the returned name"
 
 
-async def test_set_name_valid(test_cli, mock_name_synchronizer, decoy) -> None:
+async def test_set_name_valid(
+    test_cli: Tuple[HTTPTestClient, str],
+    mock_name_synchronizer: NameSynchronizer,
+    decoy: Decoy,
+) -> None:
     decoy.when(await mock_name_synchronizer.set_name("the input name")).then_return(
         "the returned name"
     )
 
-    response = await test_cli[0].post("/server/name", json={"name": "the input name"})
+    response = await test_cli[0].post("/server/name", json={"name": "the input name"})  # type: ignore[no-untyped-call]
     assert response.status == 200
 
     body = await response.json()
     assert body["name"] == "the returned name"
 
 
-async def test_set_name_not_json(test_cli) -> None:
-    response = await test_cli[0].post("/server/name", data="bada bing bada boom")
+async def test_set_name_not_json(test_cli: Tuple[HTTPTestClient, str]) -> None:
+    response = await test_cli[0].post("/server/name", data="bada bing bada boom")  # type: ignore[no-untyped-call]
     assert response.status == 400
 
 
-async def test_set_name_field_missing(test_cli) -> None:
-    response = await test_cli[0].post("/server/name", json={})
+async def test_set_name_field_missing(test_cli: Tuple[HTTPTestClient, str]) -> None:
+    response = await test_cli[0].post("/server/name", json={})  # type: ignore[no-untyped-call]
     assert response.status == 400
 
 
-async def test_set_name_field_not_a_str(test_cli) -> None:
-    response = await test_cli[0].post("/server/name", json={"name": 2})
+async def test_set_name_field_not_a_str(test_cli: Tuple[HTTPTestClient, str]) -> None:
+    response = await test_cli[0].post("/server/name", json={"name": 2})  # type: ignore[no-untyped-call]
     assert response.status == 400

--- a/update-server/tests/common/name_management/test_pretty_hostname.py
+++ b/update-server/tests/common/name_management/test_pretty_hostname.py
@@ -14,7 +14,7 @@ machine_info_examples = [
 
 
 @pytest.mark.parametrize("initial_contents", machine_info_examples)
-def test_rewrite_machine_info_updates_pretty_hostname(initial_contents) -> None:
+def test_rewrite_machine_info_updates_pretty_hostname(initial_contents: str) -> None:
     # TODO(mm, 2022-04-27): Rework so we don't have to test a private function.
     rewrite = pretty_hostname._rewrite_machine_info_str(
         initial_contents, "new_pretty_hostname"
@@ -28,7 +28,7 @@ def test_rewrite_machine_info_updates_pretty_hostname(initial_contents) -> None:
 
 
 @pytest.mark.parametrize("initial_contents", machine_info_examples)
-def test_rewrite_machine_info_preserves_other_lines(initial_contents) -> None:
+def test_rewrite_machine_info_preserves_other_lines(initial_contents: str) -> None:
     # TODO(mm, 2022-04-27): Rework so we don't have to test a private function.
     initial_lines = Counter(initial_contents.splitlines())
     rewrite_string = pretty_hostname._rewrite_machine_info_str(
@@ -44,7 +44,7 @@ def test_rewrite_machine_info_preserves_other_lines(initial_contents) -> None:
 
 # Covers this bug: https://github.com/Opentrons/opentrons/pull/4671
 @pytest.mark.parametrize("initial_contents", machine_info_examples)
-def test_rewrite_machine_info_is_idempotent(initial_contents) -> None:
+def test_rewrite_machine_info_is_idempotent(initial_contents: str) -> None:
     # TODO(mm, 2022-04-27): Rework so we don't have to test a private function.
     first_rewrite = pretty_hostname._rewrite_machine_info_str(
         initial_contents, "new_pretty_hostname"


### PR DESCRIPTION
# Overview

This PR takes a first step to type-check update-server's test files via mypy. Formerly, we didn't type-check them at all.

# Changelog

* The test files under `tests/common/name_management` are now type-checked.
* Following our usual strategy for incrementally adding type-checking...
  * All other test files are explicitly ignored for now, with a `# TODO`, 
  * Newly created test files will automatically be type-checked when we add them, unless we add them to the ignore list.

# Review requests

Double-check that my changes to the test files only affect type-checking and do not affect behavior.

# Risk assessment

No risk to production code. This should only affect dev setups and CI.
