### PR TITLE
refactor(app): refactor to switch from css prop to overflorWrap

### DIFF
--- a/app/src/atoms/Slideout/index.tsx
+++ b/app/src/atoms/Slideout/index.tsx
@@ -129,7 +129,7 @@ export const Slideout = (props: Props): JSX.Element | null => {
             >
               <StyledText
                 as="h2"
-                css={{ 'overflow-wrap': 'anywhere' }}
+                overflowWrap="anywhere"
                 fontWeight={TYPOGRAPHY.fontWeightSemiBold}
                 data-testid={`Slideout_title_${title}`}
               >

--- a/app/src/organisms/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/index.tsx
@@ -162,7 +162,7 @@ export function ChooseProtocolSlideout(
                   <StyledText
                     as="p"
                     fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-                    css={{ 'overflow-wrap': 'anywhere' }}
+                    overflowWrap="anywhere"
                   >
                     {storedProtocol.mostRecentAnalysis?.metadata
                       ?.protocolName ??
@@ -185,7 +185,7 @@ export function ChooseProtocolSlideout(
                 <StyledText
                   as="label"
                   color={COLORS.errorText}
-                  css={{ 'overflow-wrap': 'anywhere' }}
+                  overflowWrap="anywhere"
                   display={DISPLAY_BLOCK}
                   marginTop={`-${SPACING.spacing2}`}
                   marginBottom={SPACING.spacing3}

--- a/app/src/organisms/ChooseRobotSlideout/AvailableRobotOption.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/AvailableRobotOption.tsx
@@ -64,9 +64,7 @@ export function AvailableRobotOption(
           <Box maxWidth="9.5rem">
             <StyledText
               as="p"
-              css={css`
-                overflow-wrap: break-word;
-              `}
+              overflowWrap="break-word"
               fontWeight={TYPOGRAPHY.fontWeightSemiBold}
             >
               {robotName}

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -248,7 +248,7 @@ export function ChooseRobotSlideout(
                   <StyledText
                     as="label"
                     color={COLORS.errorText}
-                    css={{ 'overflow-wrap': 'anywhere' }}
+                    overflowWrap="anywhere"
                     display={DISPLAY_INLINE_BLOCK}
                     marginTop={`-${SPACING.spacing2}`}
                     marginBottom={SPACING.spacing3}

--- a/app/src/organisms/Devices/HistoricalProtocolRun.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRun.tsx
@@ -112,7 +112,7 @@ export function HistoricalProtocolRun(
             as="p"
             width="35%"
             data-testid={`RecentProtocolRuns_Protocol_${protocolKey}`}
-            css={{ 'overflow-wrap': 'anywhere' }}
+            overflowWrap="anywhere"
           >
             {protocolName}
           </StyledText>

--- a/app/src/organisms/Devices/RobotStatusBanner.tsx
+++ b/app/src/organisms/Devices/RobotStatusBanner.tsx
@@ -37,7 +37,7 @@ export function RobotStatusBanner(props: RobotStatusBannerProps): JSX.Element {
         <StyledText
           as="label"
           paddingRight={SPACING.spacing3}
-          css={{ 'overflow-wrap': 'anywhere' }}
+          overflowWrap="anywhere"
         >
           {`${displayName}; ${t(`run_details:status_${currentRunStatus}`)}`}
         </StyledText>
@@ -71,7 +71,7 @@ export function RobotStatusBanner(props: RobotStatusBannerProps): JSX.Element {
               as="h3"
               marginRight={SPACING.spacing3}
               id={`RobotStatusBanner_${name}_robotName`}
-              css={{ 'overflow-wrap': 'anywhere' }}
+              overflowWrap="anywhere"
             >
               {name}
             </StyledText>

--- a/app/src/organisms/LabwareDetails/index.tsx
+++ b/app/src/organisms/LabwareDetails/index.tsx
@@ -123,7 +123,7 @@ export function LabwareDetails(props: LabwareDetailsProps): JSX.Element {
         backgroundColor={COLORS.lightGrey}
         padding={SPACING.spacing4}
         marginBottom={SPACING.spacing5}
-        css={{ 'overflow-wrap': 'break-word' }}
+        overflowWrap="break-word"
       >
         <StyledText as="h6">{t('api_name')}</StyledText>
         <Link
@@ -131,7 +131,7 @@ export function LabwareDetails(props: LabwareDetailsProps): JSX.Element {
           onClick={() => navigator.clipboard.writeText(apiName)}
           role="button"
         >
-          <Flex alignItems={ALIGN_CENTER} css={{ 'overflow-wrap': 'anywhere' }}>
+          <Flex alignItems={ALIGN_CENTER} overflowWrap="anywhere">
             {apiName} <Icon height={SIZE_1} name="copy-text" />
           </Flex>
         </Link>

--- a/app/src/organisms/ProtocolDetails/index.tsx
+++ b/app/src/organisms/ProtocolDetails/index.tsx
@@ -414,7 +414,7 @@ export function ProtocolDetails(
               <StyledText
                 as="p"
                 marginRight={SPACING.spacingM}
-                css={{ 'overflow-wrap': 'anywhere' }}
+                overflowWrap="anywhere"
               >
                 {analysisStatus === 'loading' ? t('shared:loading') : author}
               </StyledText>


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This will remove css={{}} for overflow-wrap
fix #11010

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- switch from css={{overflow-wrap: ''}} to `overflowWrap`
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- [ ] wrapping text correctly
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
