### PR TITLE
refactor(app): LPC stop shaking and close labware latch

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckStepDetail.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckStepDetail.tsx
@@ -90,7 +90,9 @@ export const LabwarePositionCheckStepDetail = (
     (
       command: LabwarePositionCheckCreateCommand
     ): command is LabwarePositionCheckMovementCommand =>
-      command.commandType !== 'thermocycler/openLid'
+      command.commandType !== 'thermocycler/openLid' &&
+      command.commandType !== 'heaterShaker/deactivateShaker' &&
+      command.commandType !== 'heaterShaker/closeLabwareLatch'
   )
   const command = stepMovementCommands[0]
 

--- a/app/src/organisms/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
+++ b/app/src/organisms/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
@@ -307,7 +307,9 @@ export function useLabwarePositionCheck(
     (
       command: LabwarePositionCheckCreateCommand
     ): command is LabwarePositionCheckMovementCommand =>
-      command.commandType !== 'thermocycler/openLid'
+      command.commandType !== 'thermocycler/openLid' &&
+      command.commandType !== 'heaterShaker/closeLabwareLatch' &&
+      command.commandType !== 'heaterShaker/deactivateShaker'
   )
   const currentCommand = LPCMovementCommands[currentCommandIndex]
   const prevCommand = LPCMovementCommands[currentCommandIndex - 1]

--- a/app/src/organisms/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
+++ b/app/src/organisms/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
@@ -40,7 +40,11 @@ import type {
   SetupRunTimeCommand,
 } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
 import type { DropTipCreateCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/pipetting'
-import type { TCOpenLidCreateCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/module'
+import type {
+  HeaterShakerCloseLatchCreateCommand,
+  HeaterShakerDeactivateShakerCreateCommand,
+  TCOpenLidCreateCommand,
+} from '@opentrons/shared-data/protocol/types/schemaV6/command/module'
 import type {
   HomeCreateCommand,
   SavePositionCreateCommand,
@@ -78,6 +82,8 @@ type LPCPrepCommand =
   | HomeCreateCommand
   | SetupRunTimeCommand
   | TCOpenLidCreateCommand
+  | HeaterShakerDeactivateShakerCreateCommand
+  | HeaterShakerCloseLatchCreateCommand
 
 const JOG_COMMAND_TIMEOUT = 10000 // 10 seconds
 
@@ -109,6 +115,8 @@ const useLpcCtaText = (
                 .location.slotName,
       })
     }
+    case 'heaterShaker/deactivateShaker':
+    case 'heaterShaker/closeLabwareLatch':
     case 'thermocycler/openLid': {
       const moduleId = command.params.moduleId
       const slot = getModuleInitialLoadInfo(moduleId, commands).location
@@ -215,6 +223,14 @@ const isTCOpenCommand = (
 ): command is TCOpenLidCreateCommand =>
   command.commandType === 'thermocycler/openLid'
 
+const isHSCommand = (
+  command: CreateCommand
+): command is
+  | HeaterShakerDeactivateShakerCreateCommand
+  | HeaterShakerCloseLatchCreateCommand =>
+  command.commandType === 'heaterShaker/deactivateShaker' ||
+  command.commandType === 'heaterShaker/closeLabwareLatch'
+
 const isLoadLabwareCommand = (
   command: RunTimeCommand
 ): command is LoadLabwareRunTimeCommand => command.commandType === 'loadLabware'
@@ -272,8 +288,9 @@ export function useLabwarePositionCheck(
       }
       return command
     }) ?? []
-  // TC open lid commands come from the LPC command generator
+  // TC open lid commands + HS commands come from the LPC command generator
   const TCOpenCommands = LPCCommands.filter(isTCOpenCommand) ?? []
+  const HSCommands = LPCCommands.filter(isHSCommand) ?? []
   const homeCommand: HomeCreateCommand = {
     commandType: 'home',
     params: {},
@@ -282,6 +299,7 @@ export function useLabwarePositionCheck(
   const prepCommands: LPCPrepCommand[] = [
     ...loadCommands,
     ...TCOpenCommands,
+    ...HSCommands,
     homeCommand,
   ]
   // LPCMovementCommands will be run during the guided LPC flow

--- a/app/src/organisms/LabwarePositionCheck/types.ts
+++ b/app/src/organisms/LabwarePositionCheck/types.ts
@@ -1,7 +1,11 @@
 import { SECTIONS } from './constants'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { MoveToWellCreateCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/gantry'
-import type { TCOpenLidCreateCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/module'
+import type {
+  HeaterShakerCloseLatchCreateCommand,
+  HeaterShakerDeactivateShakerCreateCommand,
+  TCOpenLidCreateCommand,
+} from '@opentrons/shared-data/protocol/types/schemaV6/command/module'
 import type {
   DropTipCreateCommand,
   PickUpTipCreateCommand,
@@ -14,6 +18,8 @@ export type LabwarePositionCheckCreateCommand =
   | PickUpTipCreateCommand
   | DropTipCreateCommand
   | TCOpenLidCreateCommand
+  | HeaterShakerDeactivateShakerCreateCommand
+  | HeaterShakerCloseLatchCreateCommand
 // LabwarePositionCheckMovementCommand is used to distinguish commands that have pipette + labware ids
 export type LabwarePositionCheckMovementCommand =
   | MoveToWellCreateCommand

--- a/app/src/organisms/LabwarePositionCheck/utils/stepCreators.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/stepCreators.ts
@@ -111,21 +111,21 @@ export const getMoveToLabwareSteps = (
     } else if (isLabwareOnTopOfHS) {
       // @ts-expect-error we know there is a moduleId key on type LabwareLocation because the labware is on top of a HS
       const moduleId = getLabwareLocation(labwareId, commands).moduleId
-      const stopShakingCommand: HeaterShakerDeactivateShakerCreateCommand = {
-        commandType: 'heaterShaker/deactivateShaker',
-        params: {
-          moduleId,
-        },
-      }
       const closeLatchCommand: HeaterShakerCloseLatchCreateCommand = {
         commandType: 'heaterShaker/closeLabwareLatch',
         params: {
           moduleId,
         },
       }
+      const stopShakingCommand: HeaterShakerDeactivateShakerCreateCommand = {
+        commandType: 'heaterShaker/deactivateShaker',
+        params: {
+          moduleId,
+        },
+      }
       moveToLabwareCommands = [
-        stopShakingCommand,
         closeLatchCommand,
+        stopShakingCommand,
         moveToWellCommand,
       ]
     } else {

--- a/app/src/organisms/LabwarePositionCheck/utils/stepCreators.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/stepCreators.ts
@@ -2,6 +2,7 @@ import {
   getModuleType,
   ProtocolFile,
   RunTimeCommand,
+  HEATERSHAKER_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import { getLabwareLocation } from '../../Devices/ProtocolRun/utils/getLabwareLocation'
@@ -10,7 +11,11 @@ import type {
   LabwarePositionCheckStep,
   Section,
 } from '../types'
-import type { TCOpenLidCreateCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/module'
+import type {
+  TCOpenLidCreateCommand,
+  HeaterShakerDeactivateShakerCreateCommand,
+  HeaterShakerCloseLatchCreateCommand,
+} from '@opentrons/shared-data/protocol/types/schemaV6/command/module'
 import type { MoveToWellCreateCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/gantry'
 
 const getIsLabwareOnTopOfTC = (
@@ -23,6 +28,19 @@ const getIsLabwareOnTopOfTC = (
     'moduleId' in labwareLocation &&
     getModuleType(modules[labwareLocation.moduleId].model) ===
       THERMOCYCLER_MODULE_TYPE
+  )
+}
+
+const getIsLabwareOnTopOfHS = (
+  modules: ProtocolFile<{}>['modules'],
+  labwareId: string,
+  commands: RunTimeCommand[]
+): boolean => {
+  const labwareLocation = getLabwareLocation(labwareId, commands)
+  return (
+    'moduleId' in labwareLocation &&
+    getModuleType(modules[labwareLocation.moduleId].model) ===
+      HEATERSHAKER_MODULE_TYPE
   )
 }
 
@@ -71,6 +89,12 @@ export const getMoveToLabwareSteps = (
       labwareId,
       commands
     )
+
+    const isLabwareOnTopOfHS = getIsLabwareOnTopOfHS(
+      modules,
+      labwareId,
+      commands
+    )
     // change this to a create command
     let moveToLabwareCommands: LabwarePositionCheckCreateCommand[] = []
 
@@ -84,6 +108,26 @@ export const getMoveToLabwareSteps = (
         },
       }
       moveToLabwareCommands = [openTCLidCommand, moveToWellCommand]
+    } else if (isLabwareOnTopOfHS) {
+      // @ts-expect-error we know there is a moduleId key on type LabwareLocation because the labware is on top of a HS
+      const moduleId = getLabwareLocation(labwareId, commands).moduleId
+      const stopShakingCommand: HeaterShakerDeactivateShakerCreateCommand = {
+        commandType: 'heaterShaker/deactivateShaker',
+        params: {
+          moduleId,
+        },
+      }
+      const closeLatchCommand: HeaterShakerCloseLatchCreateCommand = {
+        commandType: 'heaterShaker/closeLabwareLatch',
+        params: {
+          moduleId,
+        },
+      }
+      moveToLabwareCommands = [
+        stopShakingCommand,
+        closeLatchCommand,
+        moveToWellCommand,
+      ]
     } else {
       moveToLabwareCommands = [moveToWellCommand]
     }


### PR DESCRIPTION
# Overview
This PR closes the labware latch and stops the heater shaker from shaking before executing any LPC movement commands. 

closes #11126


# Changelog
- Close labware latch and stop shaking before LPC

# Review requests
I already tested on a robot and it seems to work! 

If you have a HS handy, set a shake speed in the HS module card then start LPC. The HS should stop shaking and you should be able to perform LPC like usual.
# Risk assessment

Low
