### PR TITLE
fix(app): add firstNonSetupIndex to historical run commands query cursor

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/RunLog.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/RunLog.tsx
@@ -162,6 +162,7 @@ export function RunLog({ robotName, runId }: RunLogProps): JSX.Element | null {
         firstPostInitialPlayRunCommandIndex.current =
           lastKnownPrePlayRunCommandIndex.current +
           foundPostPlayRunCommandIndex +
+          firstNonSetupIndex +
           1
       } else {
         lastKnownPrePlayRunCommandIndex.current =


### PR DESCRIPTION
# Overview

this omits the non setup commands from the commands query for historical runs, which was the cause
of some run commands at the end of the run log not being fetched

closes #11135

# Changelog

 - Fixes historical run record commands query cursor

# Review requests

confirm that all run commands for a completed historical run record show a start and end time

tested with:
[logo_modules_custom_lw_6.0.py.zip](https://github.com/Opentrons/opentrons/files/9134273/logo_modules_custom_lw_6.0.py.zip)

# Risk assessment

low
