### PR TITLE
fix(app): Fix text spacing issue on LPC screen

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckStepDetail.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckStepDetail.tsx
@@ -19,6 +19,7 @@ import {
   ALIGN_START,
   BORDERS,
   ALIGN_CENTER,
+  JUSTIFY_SPACE_AROUND,
 } from '@opentrons/components'
 import {
   getIsTiprack,
@@ -184,7 +185,7 @@ export const LabwarePositionCheckStepDetail = (
         padding={SPACING.spacing3}
       >
         <Flex
-          justifyContent={JUSTIFY_SPACE_BETWEEN}
+          justifyContent={JUSTIFY_SPACE_AROUND}
           alignItems={ALIGN_CENTER}
           marginBottom={SPACING.spacing3}
         >
@@ -201,18 +202,20 @@ export const LabwarePositionCheckStepDetail = (
               data-testid="LabwarePositionCheckStepDetail_liveOffset"
             />
           </Flex>
-          <StyledText as="p">{t('jog_controls_adjustment')}</StyledText>
-          {!showJogControls ? (
-            <Link
-              role="button"
-              fontSize={FONT_SIZE_BODY_2}
-              color={COLORS.blue}
-              onClick={() => setShowJogControls(true)}
-              id={`LabwarePositionCheckStepDetail_reveal_jog_controls`}
-            >
-              {t('reveal_jog_controls')}
-            </Link>
-          ) : null}
+          <Flex flexDirection={DIRECTION_COLUMN} paddingLeft={SPACING.spacing4}>
+            <StyledText as="p">{t('jog_controls_adjustment')}</StyledText>
+            {!showJogControls ? (
+              <Link
+                role="button"
+                fontSize={FONT_SIZE_BODY_2}
+                color={COLORS.blue}
+                onClick={() => setShowJogControls(true)}
+                id={`LabwarePositionCheckStepDetail_reveal_jog_controls`}
+              >
+                {t('reveal_jog_controls')}
+              </Link>
+            ) : null}
+          </Flex>
         </Flex>
         {showJogControls ? (
           <JogControls

--- a/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckStepDetail.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckStepDetail.tsx
@@ -215,6 +215,7 @@ export const LabwarePositionCheckStepDetail = (
         </Flex>
         {showJogControls ? (
           <JogControls
+            marginTop={SPACING.spacing3}
             jog={handleJog}
             stepSizes={[0.1, 1, 10]}
             planes={[HORIZONTAL_PLANE, VERTICAL_PLANE]}

--- a/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckStepDetail.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckStepDetail.tsx
@@ -184,11 +184,7 @@ export const LabwarePositionCheckStepDetail = (
         flexDirection={DIRECTION_COLUMN}
         padding={SPACING.spacing3}
       >
-        <Flex
-          justifyContent={JUSTIFY_SPACE_AROUND}
-          alignItems={ALIGN_CENTER}
-          marginBottom={SPACING.spacing3}
-        >
+        <Flex justifyContent={JUSTIFY_SPACE_AROUND} alignItems={ALIGN_CENTER}>
           <Flex
             backgroundColor={COLORS.background}
             flexDirection={DIRECTION_COLUMN}


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This will fix the text spacing issue on the LPC screen.
fix #110671

This change has been confirmed by Emily and Mel.
https://github.com/Opentrons/opentrons/issues/11061#issuecomment-1187616150

![Screen Shot 2022-07-18 at 1 11 11 PM](https://user-images.githubusercontent.com/474225/179566016-cad6825f-33f5-4b51-8418-098f82f3f6b6.png)
![Screen Shot 2022-07-18 at 1 11 19 PM](https://user-images.githubusercontent.com/474225/179566017-20369679-a156-411f-87cc-79995d140812.png)


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- Change text alignment (row --> col)
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- [ ] There is always space between lpc pos box and text 
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
