### PR TITLE
fix(api,update-server): Store names safely and reject names that would be invalid

### DIFF
--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -94,21 +94,28 @@ if IS_ROBOT:
 
 
 def name() -> str:
+    fallback = "opentrons-dev"
+
     if IS_ROBOT and ARCHITECTURE in (
         SystemArchitecture.BUILDROOT,
         SystemArchitecture.YOCTO,
     ):
         try:
-            return (
-                subprocess.check_output(["hostnamectl", "--pretty", "status"])
-                .strip()
-                .decode()
-            )
+            result = subprocess.check_output(
+                ["hostnamectl", "--pretty", "status"]
+            ).decode("utf-8")
+            # Strip the trailing newline, since it's not part of the actual name value.
+            # TODO(mm, 2022-07-18): When we upgrade to systemd 249, use
+            # `hostnamectl --json` for CLI output that we can parse more robustly.
+            assert len(result) >= 1 and result[-1] == "\n"
+            return result[:-1]
+
         except Exception:
             log.exception(
-                "Couldn't load name from /etc/machine-info, defaulting to dev"
+                f"Couldn't load name from /etc/machine-info, defaulting to {fallback}"
             )
-    return "opentrons-dev"
+
+    return fallback
 
 
 class ConfigElementType(enum.Enum):

--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -101,6 +101,9 @@ def name() -> str:
         SystemArchitecture.YOCTO,
     ):
         try:
+            # Read the name from the machine's pretty hostname, which is maintained
+            # by update-server. This retrieval logic needs to be kept in sync with
+            # update-server.
             result = subprocess.check_output(
                 ["hostnamectl", "--pretty", "status"]
             ).decode("utf-8")

--- a/update-server/otupdate/buildroot/__init__.py
+++ b/update-server/otupdate/buildroot/__init__.py
@@ -38,7 +38,7 @@ def get_version(version_file: str) -> Mapping[str, str]:
     return json.load(open(version_file, "r"))
 
 
-def get_app(
+async def get_app(
     name_synchronizer: name_management.NameSynchronizer,
     system_version_file: Optional[str] = None,
     config_file_override: Optional[str] = None,
@@ -89,7 +89,7 @@ def get_app(
         "Setup: "
         + "\n\t".join(
             [
-                # f"Device name: {name_synchronizer.get_name()}",
+                f"Device name: {await name_synchronizer.get_name()}",
                 "Buildroot version:         "
                 f'{version.get("buildroot_version", "unknown")}',
                 "\t(from git sha      " f'{version.get("buildroot_sha", "unknown")}',

--- a/update-server/otupdate/buildroot/__init__.py
+++ b/update-server/otupdate/buildroot/__init__.py
@@ -89,7 +89,7 @@ def get_app(
         "Setup: "
         + "\n\t".join(
             [
-                f"Device name: {name_synchronizer.get_name()}",
+                # f"Device name: {name_synchronizer.get_name()}",
                 "Buildroot version:         "
                 f'{version.get("buildroot_version", "unknown")}',
                 "\t(from git sha      " f'{version.get("buildroot_sha", "unknown")}',

--- a/update-server/otupdate/buildroot/__main__.py
+++ b/update-server/otupdate/buildroot/__main__.py
@@ -28,7 +28,7 @@ async def main() -> NoReturn:
 
     async with name_management.NameSynchronizer.start() as name_synchronizer:
         LOG.info("Building buildroot update server")
-        app = get_app(
+        app = await get_app(
             system_version_file=args.version_file,
             config_file_override=args.config_file,
             name_synchronizer=name_synchronizer,

--- a/update-server/otupdate/common/control.py
+++ b/update-server/otupdate/common/control.py
@@ -42,7 +42,7 @@ def build_health_endpoint(
             {
                 **health_response,
                 **{
-                    "name": get_name_synchronizer(request).get_name(),
+                    "name": await (get_name_synchronizer(request).get_name()),
                     "serialNumber": get_serial(),
                     "bootId": request.app[DEVICE_BOOT_ID_NAME],
                 },

--- a/update-server/otupdate/common/control.py
+++ b/update-server/otupdate/common/control.py
@@ -42,7 +42,7 @@ def build_health_endpoint(
             {
                 **health_response,
                 **{
-                    "name": await (get_name_synchronizer(request).get_name()),
+                    "name": await get_name_synchronizer(request).get_name(),
                     "serialNumber": get_serial(),
                     "bootId": request.app[DEVICE_BOOT_ID_NAME],
                 },

--- a/update-server/otupdate/common/name_management/__init__.py
+++ b/update-server/otupdate/common/name_management/__init__.py
@@ -112,7 +112,7 @@ async def get_name_endpoint(request: web.Request) -> web.Response:
     """
     name_synchronizer = get_name_synchronizer(request)
     return web.json_response(  # type: ignore[no-untyped-call,no-any-return]
-        data={"name": name_synchronizer.get_name()}, status=200
+        data={"name": await name_synchronizer.get_name()}, status=200
     )
 
 

--- a/update-server/otupdate/common/name_management/avahi.py
+++ b/update-server/otupdate/common/name_management/avahi.py
@@ -69,12 +69,7 @@ class AvahiClient:
 
         Args:
             service_name: The new Avahi service name under which to start advertising.
-                See `service_name_is_valid()`.
-
-        Raises:
-            Exception: If Avahi thinks the new service name is invalid. Beware:
-                the old name may not be restored and we may be left not advertising
-                at all.
+                Must be valid; see `service_name_is_valid()`.
         """
         assert service_name_is_valid(service_name)
         async with self._lock:

--- a/update-server/otupdate/common/name_management/name_synchronizer.py
+++ b/update-server/otupdate/common/name_management/name_synchronizer.py
@@ -75,7 +75,7 @@ class NameSynchronizer:
             callback=name_synchronizer._on_avahi_collision
         ):
             await avahi_client.start_advertising(
-                service_name=name_synchronizer.get_name()
+                service_name=await name_synchronizer.get_name()
             )
             yield name_synchronizer
 
@@ -91,23 +91,23 @@ class NameSynchronizer:
         await self._avahi_client.start_advertising(service_name=new_name)
         # Setting the Avahi service name can fail if Avahi doesn't like the new name.
         # Persist only after it succeeds, so we don't persist something invalid.
-        persisted_pretty_hostname = persist_pretty_hostname(new_name)
+        persisted_pretty_hostname = await persist_pretty_hostname(new_name)
         _log.info(
             f"Changed name to {repr(new_name)}"
-            f" (persisted {repr(persisted_pretty_hostname)})."
+            f" (persisted {repr(persisted_pretty_hostname)})."  # TODO
         )
-        return persisted_pretty_hostname
+        return new_name  # TODO
 
-    def get_name(self) -> str:
+    async def get_name(self) -> str:
         """Return the machine's current human-readable name.
 
         Note that this can change even if you haven't called `set_name()`,
         if it was necessary to avoid conflicts with other devices on the network.
         """
-        return get_pretty_hostname()
+        return await get_pretty_hostname()
 
     async def _on_avahi_collision(self) -> None:
-        current_name = self.get_name()
+        current_name = await self.get_name()
 
         # Assume that the service name was the thing that collided.
         # Theoretically it also could have been the static hostname,

--- a/update-server/otupdate/common/name_management/name_synchronizer.py
+++ b/update-server/otupdate/common/name_management/name_synchronizer.py
@@ -86,15 +86,12 @@ class NameSynchronizer:
         This first sets the Avahi service name, and then persists it
         as the pretty hostname.
 
-        Returns the new name. This is normally the same as the requested name,
-        but it it might be different if it had to be truncated, sanitized, etc.
-
         Raises:
             InvalidNameError: If the name could not be set to the given string.
                 The name is left unchanged.
         """
-        # Check that the new name is valid for both places before setting it on either
-        # place. This avoids a messy torn state if one succeeds and the other fails.
+        # Ensure the new name will be valid for both places before setting it on either.
+        # This avoids a messy torn state if one succeeds and the other fails.
         if not (
             avahi.service_name_is_valid(new_name)
             and pretty_hostname.pretty_hostname_is_valid(new_name)

--- a/update-server/otupdate/common/name_management/pretty_hostname.py
+++ b/update-server/otupdate/common/name_management/pretty_hostname.py
@@ -46,8 +46,10 @@ def pretty_hostname_is_valid(pretty_hostname: str) -> bool:
     To cover at least all of the above, we disallow code points in the Unicode
     "control" group.
     """
-    contains_control = any(unicodedata.category(c) == "Cc" for c in pretty_hostname)
-    return not contains_control
+    contains_control_characters = any(
+        unicodedata.category(c) == "Cc" for c in pretty_hostname
+    )
+    return not contains_control_characters
 
 
 async def get_pretty_hostname(default: str = "no name set") -> str:

--- a/update-server/otupdate/common/name_management/pretty_hostname.py
+++ b/update-server/otupdate/common/name_management/pretty_hostname.py
@@ -8,7 +8,7 @@ and how it's distinct from other names on the machine.
 import asyncio
 import unicodedata
 from logging import getLogger
-from typing import List, Optional, Union
+from typing import List, Union
 
 
 _log = getLogger(__name__)

--- a/update-server/otupdate/common/name_management/pretty_hostname.py
+++ b/update-server/otupdate/common/name_management/pretty_hostname.py
@@ -11,6 +11,10 @@ from logging import getLogger
 _log = getLogger(__name__)
 
 
+class InvalidPrettyHostnameError(ValueError):
+    pass
+
+
 def get_pretty_hostname(default: str = "no name set") -> str:
     """Get the currently-configured pretty hostname"""
     try:

--- a/update-server/otupdate/common/name_management/pretty_hostname.py
+++ b/update-server/otupdate/common/name_management/pretty_hostname.py
@@ -50,6 +50,8 @@ def pretty_hostname_is_valid(pretty_hostname: str) -> bool:
 
 async def get_pretty_hostname(default: str = "no name set") -> str:
     """Get the currently-configured pretty hostname"""
+    # NOTE: The `api` package also retrieves the pretty hostname.
+    # This logic must be kept in sync with the logic in `api`.
     result = (
         await _run_command(
             command="hostnamectl",

--- a/update-server/otupdate/common/name_management/pretty_hostname.py
+++ b/update-server/otupdate/common/name_management/pretty_hostname.py
@@ -90,14 +90,12 @@ async def persist_pretty_hostname(new_pretty_hostname: str) -> None:
     # TODO BEFORE MERGE: Explain this.
     await _run_command(command="systemctl", args=["restart", "systemd-hostnamed"])
 
-    set_pretty_hostname = await get_pretty_hostname()
-    if set_pretty_hostname != new_pretty_hostname:
-        # TODO BEFORE MERGE: Should we restore the original file contents here?
-        _log.error(
-            f"Tried to set pretty hostname to {new_pretty_hostname!r}"
-            f" but actually set it to {set_pretty_hostname!r}."
-            f" This is probably a bug in how we validate or escape it."
-        )
+    read_back_pretty_hostname = await get_pretty_hostname()
+    assert read_back_pretty_hostname == new_pretty_hostname, (
+        f"Tried to set pretty hostname to {new_pretty_hostname!r}"
+        f" but actually set it to {read_back_pretty_hostname!r}."
+        f" This is probably a bug in how we validate or escape the string."
+    )
 
 
 # TODO(mm, 2022-07-18): Deduplicate with identical subprocess error-checking code

--- a/update-server/otupdate/common/name_management/pretty_hostname.py
+++ b/update-server/otupdate/common/name_management/pretty_hostname.py
@@ -127,9 +127,31 @@ async def _run_command(
 
 
 def _quote_and_escape_pretty_hostname_value(pretty_hostname: str) -> str:
-    # TODO: Explain background of shell-ish syntax.
+    r"""Prepare a string to be used as the PRETTY_HOSTNAME value in /etc/machine-info.
+
+    This function implements the shell-like quoting and escaping rules described in
+    the /etc/machine-info documentation.
+
+    Given a string like:
+
+        Hello $ world
+
+    This returns:
+
+        "Hello \$ world"
+
+    (Including adding the double-quote characters at the beginning and end.)
+
+    The returned string can then be inserted into /etc/machine-info, like:
+
+        PRETTY_HOSTNAME="Hello \$ world"
+
+    https://www.freedesktop.org/software/systemd/man/machine-info.html
+    """
     assert pretty_hostname_is_valid(pretty_hostname)
     translation_table = str.maketrans(
+        # Escape dollar signs, double-quote characters, backslashes, and backticks
+        # with a single backslash each.
         {
             "$": r"\$",
             '"': r"\"",

--- a/update-server/otupdate/common/name_management/pretty_hostname.py
+++ b/update-server/otupdate/common/name_management/pretty_hostname.py
@@ -61,6 +61,9 @@ async def get_pretty_hostname(default: str = "no name set") -> str:
             args=["status", "--pretty"],
         )
     ).decode("utf-8")
+    # Strip the trailing newline, since it's not part of the actual name value.
+    # TODO(mm, 2022-07-18): When we upgrade to systemd 249, use `hostnamectl --json`
+    # for CLI output that we can parse more robustly.
     assert len(result) >= 1 and result[-1] == "\n"
     return result[:-1]
 

--- a/update-server/otupdate/common/name_management/pretty_hostname.py
+++ b/update-server/otupdate/common/name_management/pretty_hostname.py
@@ -5,6 +5,7 @@ and how it's distinct from other names on the machine.
 """
 
 
+import unicodedata
 from logging import getLogger
 
 
@@ -13,6 +14,38 @@ _log = getLogger(__name__)
 
 class InvalidPrettyHostnameError(ValueError):
     pass
+
+
+def pretty_hostname_is_valid(pretty_hostname: str) -> bool:
+    """Return whether we can persist ``pretty_hostname`` in /etc/machine-info.
+
+    Restrictions come from a few places:
+
+    1. For values in general that are stored in /etc/machine/info,
+       the file format documentation explicitly allows Unicode
+       but says "non-printable characters should not be used."
+       There isn't a formal definition of "non-printable" in Unicode,
+       so this is up to interpretation.
+
+       https://www.freedesktop.org/software/systemd/man/machine-info.html
+
+    2. For the pretty hostname specifically, systemd disallows
+       ASCII < 0x20 (space) and ASCII 0x7f (DEL), but allows everything else.
+
+       This is by experimenting with `hostnamectl set-hostname --pretty`
+       and by reading the source code of systemd-hostnamed.
+       systemd doesn't formally document its limitations on the pretty hostname.
+
+       https://github.com/systemd/systemd/blob/v239/src/hostname/hostnamed.c#L524
+
+    3. This module's parser would get confused by values that contain newlines,
+       since it sees the file as a list of newline-separated KEY=VALUE pairs.
+
+    To cover at least all of the above, we disallow code points in the Unicode
+    "control" group.
+    """
+    contains_control = any(unicodedata.category(c) == "Cc" for c in pretty_hostname)
+    return not contains_control
 
 
 def get_pretty_hostname(default: str = "no name set") -> str:
@@ -55,6 +88,23 @@ def persist_pretty_hostname(name: str) -> str:
     return checked_name
 
 
+def _quote_and_escape_pretty_hostname_value(pretty_hostname: str) -> str:
+    # TODO: Explain background of shell-ish syntax.
+    if not pretty_hostname_is_valid(pretty_hostname):
+        raise InvalidPrettyHostnameError()
+    translation_table = str.maketrans(
+        {
+            "$": r"\$",
+            '"': r"\"",
+            "\\": "\\\\",
+            "`": r"\`",
+        }
+    )
+    escaped = pretty_hostname.translate(translation_table)
+    quoted_and_escaped = f'"{escaped}"'
+    return quoted_and_escaped
+
+
 def _rewrite_machine_info(new_pretty_hostname: str) -> None:
     """Write a new value for the pretty hostname.
 
@@ -85,9 +135,8 @@ def _rewrite_machine_info_str(
     preserved_lines = [
         ln for ln in current_lines if not ln.startswith("PRETTY_HOSTNAME")
     ]
-    # FIXME(mm, 2022-04-27): This will not correctly store the pretty hostname
-    # if it contains newlines or certain other special characters.
-    # https://github.com/Opentrons/opentrons/issues/9960
-    new_lines = preserved_lines + [f"PRETTY_HOSTNAME={new_pretty_hostname}"]
+    new_lines = preserved_lines + [
+        f"PRETTY_HOSTNAME={_quote_and_escape_pretty_hostname_value(new_pretty_hostname)}"
+    ]
     new_contents = "\n".join(new_lines) + "\n"
     return new_contents

--- a/update-server/otupdate/common/name_management/pretty_hostname.py
+++ b/update-server/otupdate/common/name_management/pretty_hostname.py
@@ -19,7 +19,7 @@ def pretty_hostname_is_valid(pretty_hostname: str) -> bool:
 
     Restrictions come from a few places:
 
-    1. For values in general that are stored in /etc/machine/info,
+    1. For values in general that are stored in /etc/machine-info,
        the file format documentation explicitly allows Unicode
        but says "non-printable characters should not be used."
        There isn't a formal definition of "non-printable" in Unicode,
@@ -32,7 +32,7 @@ def pretty_hostname_is_valid(pretty_hostname: str) -> bool:
 
        This is by experimenting with `hostnamectl set-hostname --pretty`
        and by reading the source code of systemd-hostnamed.
-       systemd doesn't formally document its limitations on the pretty hostname.
+       systemd doesn't formally document these restrictions.
 
        https://github.com/systemd/systemd/blob/v239/src/hostname/hostnamed.c#L524
 
@@ -67,7 +67,7 @@ async def get_pretty_hostname(default: str = "no name set") -> str:
 async def persist_pretty_hostname(new_pretty_hostname: str) -> None:
     """Change the robot's pretty hostname.
 
-    Writes the new name to /etc/machine-info so it persists across reboots.
+    The new name will persist across reboots.
 
     Args:
         new_pretty_hostname: The name to set. Must be valid;

--- a/update-server/otupdate/common/name_management/pretty_hostname.py
+++ b/update-server/otupdate/common/name_management/pretty_hostname.py
@@ -87,7 +87,9 @@ async def persist_pretty_hostname(new_pretty_hostname: str) -> None:
     # As a workaround, rewrite /etc/machine-info ourselves.
     _rewrite_machine_info(new_pretty_hostname=new_pretty_hostname)
 
-    # TODO BEFORE MERGE: Explain this.
+    # Now that we've rewritten /etc/machine-info to contain the new pretty hostname,
+    # restart systemd-hostnamed so that commands like `hostnamectl status --pretty`
+    # pick it up immediately.
     await _run_command(command="systemctl", args=["restart", "systemd-hostnamed"])
 
     read_back_pretty_hostname = await get_pretty_hostname()

--- a/update-server/otupdate/openembedded/__init__.py
+++ b/update-server/otupdate/openembedded/__init__.py
@@ -43,7 +43,7 @@ def get_version_dict(version_file: Optional[str]) -> Mapping[str, str]:
     return version
 
 
-def get_app(
+async def get_app(
     name_synchronizer: name_management.NameSynchronizer,
     system_version_file: Optional[str] = None,
     config_file_override: Optional[str] = None,
@@ -96,7 +96,7 @@ def get_app(
         "Setup: "
         + "\n\t".join(
             [
-                # f"Device name: {name_synchronizer.get_name()}",
+                f"Device name: {await name_synchronizer.get_name()}",
                 "Buildroot version:         "
                 f'{version.get("buildroot_version", "unknown")}',
                 "\t(from git sha      " f'{version.get("buildroot_sha", "unknown")}',

--- a/update-server/otupdate/openembedded/__init__.py
+++ b/update-server/otupdate/openembedded/__init__.py
@@ -96,7 +96,7 @@ def get_app(
         "Setup: "
         + "\n\t".join(
             [
-                f"Device name: {name_synchronizer.get_name()}",
+                # f"Device name: {name_synchronizer.get_name()}",
                 "Buildroot version:         "
                 f'{version.get("buildroot_version", "unknown")}',
                 "\t(from git sha      " f'{version.get("buildroot_sha", "unknown")}',

--- a/update-server/otupdate/openembedded/__main__.py
+++ b/update-server/otupdate/openembedded/__main__.py
@@ -28,7 +28,7 @@ async def main() -> NoReturn:
 
     async with name_management.NameSynchronizer.start() as name_synchronizer:
         LOG.info("Building openembedded update server")
-        app = get_app(
+        app = await get_app(
             system_version_file=args.version_file,
             config_file_override=args.config_file,
             name_synchronizer=name_synchronizer,

--- a/update-server/tests/buildroot/conftest.py
+++ b/update-server/tests/buildroot/conftest.py
@@ -20,7 +20,7 @@ async def test_cli(
     """
     Build an app using dummy versions, then build a test client and return it
     """
-    app = buildroot.get_app(
+    app = await buildroot.get_app(
         name_synchronizer=mock_name_synchronizer,
         system_version_file=version_file_path,
         config_file_override=otupdate_config,

--- a/update-server/tests/buildroot/test_control.py
+++ b/update-server/tests/buildroot/test_control.py
@@ -15,7 +15,7 @@ async def test_health(
     mock_name_synchronizer: NameSynchronizer,
     decoy: Decoy,
 ):
-    decoy.when(mock_name_synchronizer.get_name()).then_return("test name")
+    decoy.when(await mock_name_synchronizer.get_name()).then_return("test name")
     resp = await test_cli.get("/server/update/health")
     assert resp.status == 200
     body = await resp.json()

--- a/update-server/tests/common/conftest.py
+++ b/update-server/tests/common/conftest.py
@@ -31,7 +31,7 @@ async def test_cli(
     Build an app using dummy versions, then build a test client and return it
     """
     cli_client_pkg = request.param
-    app = cli_client_pkg.get_app(
+    app = await cli_client_pkg.get_app(
         name_synchronizer=mock_name_synchronizer,
         system_version_file=version_file_path,
         config_file_override=otupdate_config,

--- a/update-server/tests/common/name_management/test_http_endpoints.py
+++ b/update-server/tests/common/name_management/test_http_endpoints.py
@@ -13,7 +13,7 @@ async def test_get_name(
     mock_name_synchronizer: NameSynchronizer,
     decoy: Decoy,
 ) -> None:
-    decoy.when(mock_name_synchronizer.get_name()).then_return("the returned name")
+    decoy.when(await mock_name_synchronizer.get_name()).then_return("the returned name")
 
     response = await (test_cli[0].get("/server/name"))  # type: ignore[no-untyped-call]
     assert response.status == 200

--- a/update-server/tests/common/name_management/test_name_synchronizer.py
+++ b/update-server/tests/common/name_management/test_name_synchronizer.py
@@ -112,7 +112,7 @@ async def test_set(
 
     decoy.verify(
         await mock_avahi_client.start_advertising("new name"),
-        mock_persist_pretty_hostname("new name"),
+        await mock_persist_pretty_hostname("new name"),
     )
 
 
@@ -134,7 +134,7 @@ async def test_set_does_not_persist_invalid_avahi_service_name(
     with pytest.raises(Exception, match="oh the humanity"):
         await started_up_subject.set_name("danger!")
 
-    decoy.verify(mock_persist_pretty_hostname(matchers.Anything()), times=0)
+    decoy.verify(await mock_persist_pretty_hostname(matchers.Anything()), times=0)
 
 
 async def test_get(
@@ -142,8 +142,8 @@ async def test_get(
     mock_get_pretty_hostname: _GET_PRETTY_HOSTNAME_SIGNATURE,
     decoy: Decoy,
 ) -> None:
-    decoy.when(mock_get_pretty_hostname()).then_return("the current name")
-    assert started_up_subject.get_name() == "the current name"
+    decoy.when(await mock_get_pretty_hostname()).then_return("the current name")
+    assert await started_up_subject.get_name() == "the current name"
 
 
 async def test_advertises_initial_name(
@@ -159,7 +159,7 @@ async def test_advertises_initial_name(
     as the Avahi service name, when it's started up.
     """
 
-    decoy.when(mock_get_pretty_hostname()).then_return("initial name")
+    decoy.when(await mock_get_pretty_hostname()).then_return("initial name")
     mock_collision_subscription_context_manager = decoy.mock()
     decoy.when(
         mock_avahi_client.listen_for_collisions(matchers.Anything())
@@ -191,7 +191,7 @@ async def test_collision_handling(
     2. Start advertising with it.
     3. Persist it as the pretty hostname.
     """
-    decoy.when(mock_get_pretty_hostname()).then_return("initial name")
+    decoy.when(await mock_get_pretty_hostname()).then_return("initial name")
     decoy.when(mock_alternative_service_name("initial name")).then_return(
         "alternative name"
     )
@@ -224,5 +224,5 @@ async def test_collision_handling(
         # just in case the alternative name turns out to be invalid in some way.
         # https://github.com/Opentrons/opentrons/issues/9960
         await mock_avahi_client.start_advertising("alternative name"),
-        mock_persist_pretty_hostname("alternative name"),
+        await mock_persist_pretty_hostname("alternative name"),
     )

--- a/update-server/tests/common/name_management/test_name_synchronizer.py
+++ b/update-server/tests/common/name_management/test_name_synchronizer.py
@@ -1,85 +1,44 @@
 import asyncio
-from typing import Any, AsyncGenerator, Callable
+from typing import Any, AsyncGenerator
 
 import pytest
 from decoy import Decoy, matchers
 
-from otupdate.common.name_management import name_synchronizer
+from otupdate.common.name_management import avahi, pretty_hostname
 from otupdate.common.name_management.name_synchronizer import NameSynchronizer
-from otupdate.common.name_management.avahi import (
-    AvahiClient,
-    alternative_service_name as real_alternative_service_name,
-)
-from otupdate.common.name_management.pretty_hostname import (
-    get_pretty_hostname as real_get_pretty_hostname,
-    persist_pretty_hostname as real_persist_pretty_hostname,
-)
 
 
-_GET_PRETTY_HOSTNAME_SIGNATURE = Callable[[], str]
-_PERSIST_PRETTY_HOSTNAME_SIGNATURE = Callable[[str], str]
-_ALTERNATIVE_SERVICE_NAME_SIGNATURE = Callable[[str], str]
-
-
-@pytest.fixture
-def mock_get_pretty_hostname(decoy: Decoy) -> _GET_PRETTY_HOSTNAME_SIGNATURE:
-    """Return a mock in the shape of the get_pretty_hostname() function."""
-    return decoy.mock(func=real_get_pretty_hostname)
-
-
-@pytest.fixture
-def monkeypatch_get_pretty_hostname(
-    monkeypatch: Any, mock_get_pretty_hostname: _GET_PRETTY_HOSTNAME_SIGNATURE
-) -> None:
-    """Replace the real get_pretty_hostname() with our mock."""
+@pytest.fixture(autouse=True)
+def monkeypatch_pretty_hostname_functions(decoy: Decoy, monkeypatch: Any) -> None:
+    """Replace the functions of pretty_hostname with mocks."""
+    mock_get_pretty_hostname = decoy.mock(func=pretty_hostname.get_pretty_hostname)
+    mock_persist_pretty_hostname = decoy.mock(
+        func=pretty_hostname.persist_pretty_hostname
+    )
     monkeypatch.setattr(
-        name_synchronizer, "get_pretty_hostname", mock_get_pretty_hostname
+        pretty_hostname, "get_pretty_hostname", mock_get_pretty_hostname
+    )
+    monkeypatch.setattr(
+        pretty_hostname, "persist_pretty_hostname", mock_persist_pretty_hostname
     )
 
 
-@pytest.fixture
-def mock_persist_pretty_hostname(decoy: Decoy) -> _PERSIST_PRETTY_HOSTNAME_SIGNATURE:
-    """Return a mock in the shape of the persist_pretty_hostname() function."""
-    return decoy.mock(func=real_persist_pretty_hostname)
+@pytest.fixture(autouse=True)
+def monkeypatch_alternative_service_name(decoy: Decoy, monkeypatch: Any) -> None:
+    """Replace avahi.alternative_service_name() with our mock."""
+    mock = decoy.mock(func=avahi.alternative_service_name)
+    monkeypatch.setattr(avahi, "alternative_service_name", mock)
 
 
 @pytest.fixture
-def monkeypatch_persist_pretty_hostname(
-    monkeypatch: Any, mock_persist_pretty_hostname: _PERSIST_PRETTY_HOSTNAME_SIGNATURE
-) -> None:
-    """Replace the real persist_pretty_hostname with our mock."""
-    monkeypatch.setattr(
-        name_synchronizer, "persist_pretty_hostname", mock_persist_pretty_hostname
-    )
-
-
-@pytest.fixture
-def mock_alternative_service_name(decoy: Decoy) -> _ALTERNATIVE_SERVICE_NAME_SIGNATURE:
-    """Return a mock in the shape of the alternative_service_name() function."""
-    return decoy.mock(func=real_alternative_service_name)
-
-
-@pytest.fixture
-def monkeypatch_alternative_service_name(
-    monkeypatch: Any, mock_alternative_service_name: _ALTERNATIVE_SERVICE_NAME_SIGNATURE
-) -> None:
-    """Replace the real alternative_service_name() with our mock."""
-    monkeypatch.setattr(
-        name_synchronizer, "alternative_service_name", mock_alternative_service_name
-    )
-
-
-@pytest.fixture
-def mock_avahi_client(decoy: Decoy) -> AvahiClient:
-    """Return a mock in the shape of an AvahiClient."""
-    return decoy.mock(cls=AvahiClient)
+def mock_avahi_client(decoy: Decoy) -> avahi.AvahiClient:
+    """Return a mock in the shape of an avahi.AvahiClient."""
+    return decoy.mock(cls=avahi.AvahiClient)
 
 
 @pytest.fixture
 async def started_up_subject(
-    monkeypatch_get_pretty_hostname: None,
-    monkeypatch_persist_pretty_hostname: None,
-    mock_avahi_client: AvahiClient,
+    mock_avahi_client: avahi.AvahiClient,
     decoy: Decoy,
     loop: asyncio.AbstractEventLoop,  # Required by aiohttp for async fixtures.
 ) -> AsyncGenerator[NameSynchronizer, None]:
@@ -101,8 +60,7 @@ async def started_up_subject(
 
 async def test_set(
     started_up_subject: NameSynchronizer,
-    mock_persist_pretty_hostname: _PERSIST_PRETTY_HOSTNAME_SIGNATURE,
-    mock_avahi_client: AvahiClient,
+    mock_avahi_client: avahi.AvahiClient,
     decoy: Decoy,
 ) -> None:
     """It should set the new name as the Avahi service name and then as the pretty
@@ -112,14 +70,13 @@ async def test_set(
 
     decoy.verify(
         await mock_avahi_client.start_advertising("new name"),
-        await mock_persist_pretty_hostname("new name"),
+        await pretty_hostname.persist_pretty_hostname("new name"),
     )
 
 
 async def test_set_does_not_persist_invalid_avahi_service_name(
     started_up_subject: NameSynchronizer,
-    mock_persist_pretty_hostname: _PERSIST_PRETTY_HOSTNAME_SIGNATURE,
-    mock_avahi_client: AvahiClient,
+    mock_avahi_client: avahi.AvahiClient,
     decoy: Decoy,
 ) -> None:
     """It should not persist any name that's not valid as an Avahi service name.
@@ -134,32 +91,31 @@ async def test_set_does_not_persist_invalid_avahi_service_name(
     with pytest.raises(Exception, match="oh the humanity"):
         await started_up_subject.set_name("danger!")
 
-    decoy.verify(await mock_persist_pretty_hostname(matchers.Anything()), times=0)
+    decoy.verify(
+        await pretty_hostname.persist_pretty_hostname(matchers.Anything()), times=0
+    )
 
 
 async def test_get(
     started_up_subject: NameSynchronizer,
-    mock_get_pretty_hostname: _GET_PRETTY_HOSTNAME_SIGNATURE,
     decoy: Decoy,
 ) -> None:
-    decoy.when(await mock_get_pretty_hostname()).then_return("the current name")
+    decoy.when(await pretty_hostname.get_pretty_hostname()).then_return(
+        "the current name"
+    )
     assert await started_up_subject.get_name() == "the current name"
 
 
 async def test_advertises_initial_name(
     started_up_subject: NameSynchronizer,
-    mock_get_pretty_hostname: _GET_PRETTY_HOSTNAME_SIGNATURE,
-    monkeypatch_get_pretty_hostname: None,
-    mock_persist_pretty_hostname: _PERSIST_PRETTY_HOSTNAME_SIGNATURE,
-    monkeypatch_persist_pretty_hostname: None,
-    mock_avahi_client: AvahiClient,
+    mock_avahi_client: avahi.AvahiClient,
     decoy: Decoy,
 ) -> None:
     """It should immediately start advertising the existing pretty hostname
     as the Avahi service name, when it's started up.
     """
 
-    decoy.when(await mock_get_pretty_hostname()).then_return("initial name")
+    decoy.when(await pretty_hostname.get_pretty_hostname()).then_return("initial name")
     mock_collision_subscription_context_manager = decoy.mock()
     decoy.when(
         mock_avahi_client.listen_for_collisions(matchers.Anything())
@@ -174,16 +130,10 @@ async def test_advertises_initial_name(
 
 
 async def test_collision_handling(
-    mock_get_pretty_hostname: _GET_PRETTY_HOSTNAME_SIGNATURE,
-    monkeypatch_get_pretty_hostname: None,
-    mock_persist_pretty_hostname: _PERSIST_PRETTY_HOSTNAME_SIGNATURE,
-    monkeypatch_persist_pretty_hostname: None,
-    mock_alternative_service_name: _ALTERNATIVE_SERVICE_NAME_SIGNATURE,
-    monkeypatch_alternative_service_name: None,
-    mock_avahi_client: AvahiClient,
+    mock_avahi_client: avahi.AvahiClient,
     decoy: Decoy,
 ) -> None:
-    """It should resolve naming collisions reported by the AvahiClient.
+    """It should resolve naming collisions reported by the avahi.AvahiClient.
 
     When notified of a collision, it should:
 
@@ -191,8 +141,8 @@ async def test_collision_handling(
     2. Start advertising with it.
     3. Persist it as the pretty hostname.
     """
-    decoy.when(await mock_get_pretty_hostname()).then_return("initial name")
-    decoy.when(mock_alternative_service_name("initial name")).then_return(
+    decoy.when(await pretty_hostname.get_pretty_hostname()).then_return("initial name")
+    decoy.when(avahi.alternative_service_name("initial name")).then_return(
         "alternative name"
     )
 
@@ -224,5 +174,5 @@ async def test_collision_handling(
         # just in case the alternative name turns out to be invalid in some way.
         # https://github.com/Opentrons/opentrons/issues/9960
         await mock_avahi_client.start_advertising("alternative name"),
-        await mock_persist_pretty_hostname("alternative name"),
+        await pretty_hostname.persist_pretty_hostname("alternative name"),
     )

--- a/update-server/tests/common/name_management/test_name_synchronizer.py
+++ b/update-server/tests/common/name_management/test_name_synchronizer.py
@@ -68,6 +68,8 @@ async def test_set(
     """
     await started_up_subject.set_name("new name")
 
+    # TODO: Mock out is_valid() funcs.
+
     decoy.verify(
         await mock_avahi_client.start_advertising("new name"),
         await pretty_hostname.persist_pretty_hostname("new name"),

--- a/update-server/tests/common/name_management/test_pretty_hostname.py
+++ b/update-server/tests/common/name_management/test_pretty_hostname.py
@@ -87,8 +87,11 @@ def test_rewrite_machine_info_is_idempotent(initial_contents: str) -> None:
         (r"\" \n \t", r'PRETTY_HOSTNAME="\\\" \\n \\t"'),
     ],
 )
-def test_escaping_and_quoting(input_pretty_hostname: str, expected_line: str) -> None:
+def test_valid_input_escaped_and_quoted(
+    input_pretty_hostname: str, expected_line: str
+) -> None:
     # TODO(mm, 2022-07-14): Rework so we don't have to test a private function.
+    assert pretty_hostname.pretty_hostname_is_valid(input_pretty_hostname)
     output = pretty_hostname._rewrite_machine_info_str(
         current_machine_info_contents="", new_pretty_hostname=input_pretty_hostname
     )
@@ -107,10 +110,5 @@ def test_escaping_and_quoting(input_pretty_hostname: str, expected_line: str) ->
         "bad \x7f input",  # ASCII DEL.
     ],
 )
-def test_raises_on_invalid_input(invalid_pretty_hostname: str) -> None:
-    # TODO(mm, 2022-07-14): Rework so we don't have to test a private function.
-    with pytest.raises(pretty_hostname.InvalidPrettyHostnameError):
-        pretty_hostname._rewrite_machine_info_str(
-            current_machine_info_contents="",
-            new_pretty_hostname=invalid_pretty_hostname,
-        )
+def test_invalid_input(invalid_pretty_hostname: str) -> None:
+    assert not pretty_hostname.pretty_hostname_is_valid(invalid_pretty_hostname)

--- a/update-server/tests/common/name_management/test_pretty_hostname.py
+++ b/update-server/tests/common/name_management/test_pretty_hostname.py
@@ -62,7 +62,7 @@ def test_rewrite_machine_info_is_idempotent(initial_contents: str) -> None:
         ("", 'PRETTY_HOSTNAME=""'),
         ("abcd", 'PRETTY_HOSTNAME="abcd"'),
         # Spaces are allowed and shouldn't be escaped.
-        ("Hello world", 'PRETTY_HOSTNAME="hello world"'),
+        ("hello world", 'PRETTY_HOSTNAME="hello world"'),
         # Non-ASCII is allowed and shouldn't be escaped.
         ("Oh boy 👉😎👉 non-ASCII", 'PRETTY_HOSTNAME="Oh boy 👉😎👉 non-ASCII"'),
         # Backslashes, double-quote characters, dollar signs, and backticks
@@ -71,10 +71,10 @@ def test_rewrite_machine_info_is_idempotent(initial_contents: str) -> None:
         (r"has two \\ backslashes", r'PRETTY_HOSTNAME="has two \\\\ backslashes"'),
         ('has " double-quote', r'PRETTY_HOSTNAME="has \" double-quote"'),
         ("has $ dollar sign", r'PRETTY_HOSTNAME="has \$ dollar sign"'),
-        ("has ` backtick", r'PRETTY_HOSTNAME="has \` backtick'),
+        ("has ` backtick", r'PRETTY_HOSTNAME="has \` backtick"'),
         # Unlike double-quote characters, single-quote characters shouldn't be escaped.
         # TODO: Verify this.
-        ("has ' single-quote", '''PRETTY_HOSTNAME=" has ' single-quote"'''),
+        ("has ' single-quote", '''PRETTY_HOSTNAME="has ' single-quote"'''),
         # Other ASCII characters shouldn't be escaped.
         ("!@#%^&*", 'PRETTY_HOSTNAME="!@#%^&*'),
         # Character sequences that would be esape sequences in C, Python, or the shell

--- a/update-server/tests/common/name_management/test_pretty_hostname.py
+++ b/update-server/tests/common/name_management/test_pretty_hostname.py
@@ -76,7 +76,10 @@ def test_rewrite_machine_info_is_idempotent(initial_contents: str) -> None:
         # TODO: Verify this.
         ("has ' single-quote", '''PRETTY_HOSTNAME="has ' single-quote"'''),
         # Other ASCII characters shouldn't be escaped.
-        ("!@#%^&*", 'PRETTY_HOSTNAME="!@#%^&*'),
+        ("!#%&()*+,-./", 'PRETTY_HOSTNAME="!#%&()*+,-./"'),
+        (":;<=>?@", 'PRETTY_HOSTNAME=":;<=>?@"'),
+        ("[]^_", 'PRETTY_HOSTNAME="[]^_"'),
+        ("{|}~", 'PRETTY_HOSTNAME="{|}~"'),
         # Character sequences that would be esape sequences in C, Python, or the shell
         # should not be processed as such here. For example, setting the name to the
         # string [<backslash>,<n>] should not cause an actual ASCII newline to be

--- a/update-server/tests/common/name_management/test_pretty_hostname.py
+++ b/update-server/tests/common/name_management/test_pretty_hostname.py
@@ -98,13 +98,13 @@ def test_escaping_and_quoting(input_pretty_hostname: str, expected_line: str) ->
 @pytest.mark.parametrize(
     "invalid_pretty_hostname",
     [
+        # A selection of inputs that `hostnamectl set-hostname --pretty` rejects.
         "bad \r input",
         "bad \n input",
         "bad \t input",
         "bad \b input",
         "bad \x00 input",  # ASCII NUL.
         "bad \x7f input",  # ASCII DEL.
-        "bad \u0091 input",  # Unicode PRIVATE USE ONE.
     ],
 )
 def test_raises_on_invalid_input(invalid_pretty_hostname: str) -> None:

--- a/update-server/tests/common/name_management/test_pretty_hostname.py
+++ b/update-server/tests/common/name_management/test_pretty_hostname.py
@@ -73,7 +73,6 @@ def test_rewrite_machine_info_is_idempotent(initial_contents: str) -> None:
         ("has $ dollar sign", r'PRETTY_HOSTNAME="has \$ dollar sign"'),
         ("has ` backtick", r'PRETTY_HOSTNAME="has \` backtick"'),
         # Unlike double-quote characters, single-quote characters shouldn't be escaped.
-        # TODO: Verify this.
         ("has ' single-quote", '''PRETTY_HOSTNAME="has ' single-quote"'''),
         # Other ASCII characters shouldn't be escaped.
         ("!#%&()*+,-./", 'PRETTY_HOSTNAME="!#%&()*+,-./"'),

--- a/update-server/tests/common/name_management/test_pretty_hostname.py
+++ b/update-server/tests/common/name_management/test_pretty_hostname.py
@@ -20,7 +20,7 @@ def test_rewrite_machine_info_updates_pretty_hostname(initial_contents: str) -> 
         initial_contents, "new_pretty_hostname"
     )
     assert (
-        "PRETTY_HOSTNAME=new_pretty_hostname" in rewrite.splitlines()
+        'PRETTY_HOSTNAME="new_pretty_hostname"' in rewrite.splitlines()
     ), "new PRETTY_HOSTNAME should be present."
     assert (
         rewrite.count("PRETTY_HOSTNAME") == 1

--- a/update-server/tests/common/name_management/test_pretty_hostname.py
+++ b/update-server/tests/common/name_management/test_pretty_hostname.py
@@ -60,7 +60,7 @@ def test_rewrite_machine_info_is_idempotent(initial_contents: str) -> None:
     [
         # The value should be quoted.
         ("", 'PRETTY_HOSTNAME=""'),
-        ("abcd", 'PRETTY_HOSTNAME="abcd"'),
+        ("AaBbCcDd1234", 'PRETTY_HOSTNAME="AaBbCcDd1234"'),
         # Spaces are allowed and shouldn't be escaped.
         ("hello world", 'PRETTY_HOSTNAME="hello world"'),
         # Non-ASCII is allowed and shouldn't be escaped.

--- a/update-server/tests/common/name_management/test_pretty_hostname.py
+++ b/update-server/tests/common/name_management/test_pretty_hostname.py
@@ -108,5 +108,6 @@ def test_raises_on_invalid_input(invalid_pretty_hostname: str) -> None:
     # TODO(mm, 2022-07-14): Rework so we don't have to test a private function.
     with pytest.raises(pretty_hostname.InvalidPrettyHostnameError):
         pretty_hostname._rewrite_machine_info_str(
-            current_machine_info_contents="", new_pretty_hostname=invalid_pretty_hostname
+            current_machine_info_contents="",
+            new_pretty_hostname=invalid_pretty_hostname,
         )

--- a/update-server/tests/openembedded/conftest.py
+++ b/update-server/tests/openembedded/conftest.py
@@ -32,7 +32,7 @@ async def test_cli(
     """
     Build an app using dummy versions, then build a test client and return it
     """
-    app = openembedded.get_app(
+    app = await openembedded.get_app(
         name_synchronizer=mock_name_synchronizer,
         system_version_file=version_file_path,
         config_file_override=otupdate_config,

--- a/update-server/tests/openembedded/test_control.py
+++ b/update-server/tests/openembedded/test_control.py
@@ -16,7 +16,7 @@ async def test_health(
     mock_name_synchronizer: NameSynchronizer,
     decoy: Decoy,
 ):
-    decoy.when(mock_name_synchronizer.get_name()).then_return("test name")
+    decoy.when(await mock_name_synchronizer.get_name()).then_return("test name")
     resp = await test_cli.get("/server/update/health")
     assert resp.status == 200
     body = await resp.json()


### PR DESCRIPTION
# Overview

This PR fixes several robot-side bugs related to robot names that contain more than just simple alphanumeric characters.

Closes #10197. Closes #10413. Closes #10687.


# Changelog

* Reject invalid strings for the robot's name.
    * A string is "invalid" if Avahi would reject it as the DNS-SD instance name, or if `hostnamectl set-hostname --pretty` would reject it as the pretty hostname.
    * We implement this validation logic ourselves, which kind of sucks.
    * If I did this right, this effectively fixes #10687 by, hopefully, never feeding Avahi a name that it won't like.
* **POTENTIALLY BREAKING CHANGE:** When an HTTP client tries to set an invalid name via `POST /server/name`, return a 400 error if the name is invalid.
* When rewriting `/etc/machine-info` to store a new pretty hostname, use quoting and backslash-escaping to preserve special characters.
    * We have to implement this escaping logic ourselves to follow `/etc/machine-info`'s nonstandard rules, unfortunately.
    * This fixes #10197.
* Restart `systemd-hostnamed` after we rewrite `/etc/machine-info` so it immediately picks up our modifications.
    * I'm pretty sure this fixes #10413.
* Make a small tweak to how *`api`* retrieves the pretty hostname, to keep it in sync with `update-server`.

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Manual testing

You'll need a real OT-2 to test this. Do a top-level `make push` to push both the `update-server` and `api` packages to it.

* Make sure setting the robot's name through the Opentrons App still works.
* Try manually changing the robot's name with HTTP `POST /server/name {"name": "new name"}`.
    * Try using crazy strings: empty, very long, special characters, beginning and ending with whitespace, etc.
    * The endpoint should either return 200 and set the name to what you specified, or return 400 and leave the name unchanged.
    * The endpoint should never return 500.
* Try `GET /server/name`, `GET /server/update/health`, and `GET /health` to see that the name is kept in sync between all 3 HTTP endpoints where it shows up.
     * You can also try `cd discovery-client && yarn run discovery` and look for the robot's 3 `name` fields to test the same thing.
* Try `dns-sd -B` to make sure that the robot's advertised instance name is always exactly what you set.

# Risk assessment

# Other approaches considered

* **Give up on nice names.** Disallow everything that would require quoting or escaping; allow only ASCII A-Z, a-z, and 0-9.
    * This thought makes me existentially sad, so I don't like it.
* **Shell out** to `hostnamectl set-hostname --pretty` instead of manually writing `/etc/machine-info`.
    * I tried a few things, but I couldn't get this to work. See https://github.com/Opentrons/opentrons/pull/10219#discussion_r869492163.
* **Totally decouple our code from the systemd pretty hostname.** Persist the robot's name in our own file somewhere, in a format that's easier to deal with.
    * This might be the right move, but it felt to me like questioning too much for this PR.
* **Avoid implementing our own validation logic.** Instead, handle errors from systemd and Avahi gracefully, and use them as the single source of truth for what's valid and invalid. [Ask for forgiveness instead of permission](https://docs.python.org/3.7/glossary.html#term-eafp), in other words.
    * I'm pretty conflicted about this.
    * On one hand, it would be really nice if we could avoid reimplementing the validation logic ourselves.  
    * On the other hand, we then have to implement *transactional recovery* logic. 
      ```mermaid
      graph TD
          set_avahi[Set Avahi service name] --> valid_for_avahi{Did it work?}
          valid_for_avahi -->|Yes| set_pretty_hostname[Set pretty hostname]
          valid_for_avahi -->|No| restore_avahi[Restore prior Avahi service name]
          set_pretty_hostname --> valid_as_pretty_hostname{Did it work?}
          valid_as_pretty_hostname -->|Yes| Done
          valid_as_pretty_hostname -->|No| restore_avahi_2[Restore prior Avahi service name] --> restore_pretty[Restore prior pretty hostname]
      ```
      This seemed doable, but messy in its own ways. Overall, it felt like a wash to me, versus the "look before you leap" approach that this PR currently takes.