### PR TITLE
refactor(app): h-S modal update hover states and checkbox to match designs

### DIFF
--- a/app/src/atoms/MenuList/index.tsx
+++ b/app/src/atoms/MenuList/index.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
 import {
-  Box,
   COLORS,
   POSITION_ABSOLUTE,
-  SPACING_1,
-  ButtonProps,
   DIRECTION_COLUMN,
+  ButtonProps,
+  Flex,
+  SPACING,
 } from '@opentrons/components'
 
 interface MenuListProps {
@@ -14,17 +14,18 @@ interface MenuListProps {
 
 export const MenuList = (props: MenuListProps): JSX.Element | null => {
   return (
-    <Box
+    <Flex
       borderRadius={'4px 4px 0px 0px'}
       zIndex={10}
       boxShadow={'0px 1px 3px rgba(0, 0, 0, 0.2)'}
       position={POSITION_ABSOLUTE}
       backgroundColor={COLORS.white}
       top="2.6rem"
-      right={`calc(50% + ${SPACING_1})`}
+      right={`calc(50% + ${SPACING.spacing2})`}
       flexDirection={DIRECTION_COLUMN}
+      whiteSpace="nowrap"
     >
       {props.buttons}
-    </Box>
+    </Flex>
   )
 }

--- a/app/src/organisms/ModuleCard/ConfirmAttachmentModal.tsx
+++ b/app/src/organisms/ModuleCard/ConfirmAttachmentModal.tsx
@@ -108,7 +108,6 @@ export const ConfirmAttachmentModal = (
             role="button"
             onClick={onCloseClick}
             textTransform={TYPOGRAPHY.textTransformCapitalize}
-            fontWeight={TYPOGRAPHY.fontWeightSemiBold}
             marginRight={SPACING.spacing5}
             css={TYPOGRAPHY.linkPSemiBold}
           >

--- a/app/src/organisms/ModuleCard/ConfirmAttachmentModal.tsx
+++ b/app/src/organisms/ModuleCard/ConfirmAttachmentModal.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch } from 'react-redux'
 import {
-  CheckboxField,
   DIRECTION_ROW,
   Flex,
   JUSTIFY_FLEX_END,
@@ -11,14 +10,15 @@ import {
   SPACING,
   TYPOGRAPHY,
   DIRECTION_COLUMN,
-  Btn,
-  COLORS,
+  Link,
+  ALIGN_CENTER,
 } from '@opentrons/components'
 import { PrimaryButton } from '../../atoms/buttons'
 import { Modal } from '../../atoms/Modal'
 import { Dispatch } from '../../redux/types'
 import { UpdateConfigValueAction } from '../../redux/config/types'
 import { updateConfigValue } from '../../redux/config'
+import { CheckboxField } from '../../atoms/CheckboxField'
 
 export function setHeaterShakerAttached(
   heaterShakerAttached: boolean
@@ -96,6 +96,7 @@ export const ConfirmAttachmentModal = (
         flexDirection={DIRECTION_ROW}
         paddingTop={SPACING.spacingXL}
         justifyContent={JUSTIFY_FLEX_END}
+        alignItems={ALIGN_CENTER}
       >
         <Flex
           paddingRight={SPACING.spacing2}
@@ -103,15 +104,16 @@ export const ConfirmAttachmentModal = (
             isProceedToRunModal ? `on_start_protocol` : `on_set_shake`
           }`}
         >
-          <Btn
+          <Link
+            role="button"
             onClick={onCloseClick}
             textTransform={TYPOGRAPHY.textTransformCapitalize}
-            color={COLORS.blue}
             fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-            marginRight={SPACING.spacing6}
+            marginRight={SPACING.spacing5}
+            css={TYPOGRAPHY.linkPSemiBold}
           >
             {t('shared:cancel')}
-          </Btn>
+          </Link>
         </Flex>
 
         <Flex

--- a/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
+++ b/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
@@ -71,8 +71,6 @@ export const ModuleOverflowMenu = (
                 return (
                   <React.Fragment key={`${index}_${module.moduleType}`}>
                     <MenuItem
-                      width="100%"
-                      whiteSpace="nowrap"
                       key={`${index}_${module.moduleModel}`}
                       onClick={() => item.onClick(item.isSecondary)}
                       data-testid={`module_setting_${module.moduleModel}`}

--- a/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
+++ b/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
@@ -71,7 +71,8 @@ export const ModuleOverflowMenu = (
                 return (
                   <React.Fragment key={`${index}_${module.moduleType}`}>
                     <MenuItem
-                      minWidth="10.6rem"
+                      width="100%"
+                      whiteSpace="nowrap"
                       key={`${index}_${module.moduleModel}`}
                       onClick={() => item.onClick(item.isSecondary)}
                       data-testid={`module_setting_${module.moduleModel}`}

--- a/app/src/organisms/ModuleCard/TestShakeSlideout.tsx
+++ b/app/src/organisms/ModuleCard/TestShakeSlideout.tsx
@@ -112,7 +112,6 @@ export const TestShakeSlideout = (
       })
     }
     setShakeValue(null)
-    onCloseClick()
   }
 
   const {

--- a/app/src/organisms/ModuleCard/TestShakeSlideout.tsx
+++ b/app/src/organisms/ModuleCard/TestShakeSlideout.tsx
@@ -112,6 +112,7 @@ export const TestShakeSlideout = (
       })
     }
     setShakeValue(null)
+    onCloseClick()
   }
 
   const {
@@ -131,7 +132,7 @@ export const TestShakeSlideout = (
       case 'opening':
       case 'idle_open':
       case 'idle_unknown': {
-        return t('open', { ns: 'shared' })
+        return t('shared:open')
       }
       case 'closing':
       case 'idle_closed': {
@@ -154,7 +155,7 @@ export const TestShakeSlideout = (
           onClick={onCloseClick}
           data-testid={`Temp_Slideout_set_temp_btn_${name}`}
         >
-          {t('close', { ns: 'shared' })}
+          {t('shared:close')}
         </PrimaryButton>
       }
     >
@@ -187,7 +188,7 @@ export const TestShakeSlideout = (
         </Flex>
         <Flex flexDirection={DIRECTION_COLUMN} fontSize={TYPOGRAPHY.fontSizeP}>
           <Text fontWeight={TYPOGRAPHY.fontWeightRegular}>
-            {t('test_shake_slideout_banner_info', { ns: 'heater_shaker' })}
+            {t('heater_shaker:test_shake_slideout_banner_info')}
           </Text>
         </Flex>
       </Flex>
@@ -276,8 +277,7 @@ export const TestShakeSlideout = (
               value={shakeValue}
               onChange={e => setShakeValue(e.target.value)}
               type="number"
-              caption={t('min_max_rpm', {
-                ns: 'heater_shaker',
+              caption={t('heater_shaker:min_max_rpm', {
                 min: HS_RPM_MIN,
                 max: HS_RPM_MAX,
               })}
@@ -321,10 +321,9 @@ export const TestShakeSlideout = (
         <HeaterShakerWizard onCloseClick={() => setShowWizard(false)} />
       )}
       <Link
+        role="button"
         marginTop={SPACING.spacing2}
-        fontSize={TYPOGRAPHY.fontSizeP}
-        fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-        color={COLORS.blue}
+        css={TYPOGRAPHY.linkPSemiBold}
         id={'HeaterShaker_Attachment_Instructions'}
         onClick={() => setShowWizard(true)}
       >

--- a/app/src/organisms/ModuleCard/__tests__/TestShakeSlideout.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/TestShakeSlideout.test.tsx
@@ -232,7 +232,7 @@ describe('TestShakeSlideout', () => {
     const input = getByRole('spinbutton')
     fireEvent.change(input, { target: { value: '300' } })
     fireEvent.click(button)
-
+    expect(props.onCloseClick).toHaveBeenCalled()
     expect(mockCreateLiveCommand).toHaveBeenCalledWith({
       command: {
         commandType: 'heaterShaker/setAndWaitForShakeSpeed',
@@ -271,7 +271,7 @@ describe('TestShakeSlideout', () => {
     const input = getByRole('spinbutton')
     fireEvent.change(input, { target: { value: '300' } })
     fireEvent.click(button)
-
+    expect(props.onCloseClick).toHaveBeenCalled()
     expect(mockCreateCommand).toHaveBeenCalledWith({
       runId: props.runId,
       command: {

--- a/app/src/organisms/ModuleCard/__tests__/TestShakeSlideout.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/TestShakeSlideout.test.tsx
@@ -232,7 +232,7 @@ describe('TestShakeSlideout', () => {
     const input = getByRole('spinbutton')
     fireEvent.change(input, { target: { value: '300' } })
     fireEvent.click(button)
-    expect(props.onCloseClick).toHaveBeenCalled()
+
     expect(mockCreateLiveCommand).toHaveBeenCalledWith({
       command: {
         commandType: 'heaterShaker/setAndWaitForShakeSpeed',
@@ -271,7 +271,7 @@ describe('TestShakeSlideout', () => {
     const input = getByRole('spinbutton')
     fireEvent.change(input, { target: { value: '300' } })
     fireEvent.click(button)
-    expect(props.onCloseClick).toHaveBeenCalled()
+
     expect(mockCreateCommand).toHaveBeenCalledWith({
       runId: props.runId,
       command: {

--- a/app/src/organisms/ModuleCard/hooks.tsx
+++ b/app/src/organisms/ModuleCard/hooks.tsx
@@ -154,7 +154,7 @@ export function useModuleOverflowMenu(
   const labwareLatchBtn = (
     <>
       <MenuItem
-        minWidth="10.6rem"
+        width="100%"
         key={`hs_labware_latch_${module.moduleModel}`}
         data-testid={`hs_labware_latch_${module.moduleModel}`}
         onClick={toggleLatch}
@@ -175,7 +175,7 @@ export function useModuleOverflowMenu(
 
   const aboutModuleBtn = (
     <MenuItem
-      minWidth="10.6rem"
+      width="100%"
       key={`about_module_${module.moduleModel}`}
       id={`about_module_${module.moduleModel}`}
       data-testid={`about_module_${module.moduleModel}`}
@@ -187,7 +187,7 @@ export function useModuleOverflowMenu(
 
   const attachToDeckBtn = (
     <MenuItem
-      minWidth="10.6rem"
+      whiteSpace="nowrap"
       key={`hs_attach_to_deck_${module.moduleModel}`}
       data-testid={`hs_attach_to_deck_${module.moduleModel}`}
       onClick={() => handleWizardClick()}
@@ -199,7 +199,7 @@ export function useModuleOverflowMenu(
     module.moduleType === HEATERSHAKER_MODULE_TYPE &&
     module.data.speedStatus !== 'idle' ? (
       <MenuItem
-        minWidth="10.6rem"
+        width="100%"
         key={`about_module_${module.moduleModel}`}
         id={`about_module_${module.moduleModel}`}
         data-testid={`about_module_${module.moduleModel}`}
@@ -211,7 +211,7 @@ export function useModuleOverflowMenu(
       </MenuItem>
     ) : (
       <MenuItem
-        minWidth="10.6rem"
+        width="100%"
         onClick={() => handleTestShakeClick()}
         key={`hs_test_shake_btn_${module.moduleModel}`}
         disabled={isDisabled}

--- a/app/src/organisms/ModuleCard/hooks.tsx
+++ b/app/src/organisms/ModuleCard/hooks.tsx
@@ -161,13 +161,16 @@ export function useModuleOverflowMenu(
         disabled={isLatchDisabled || isDisabled}
         {...targetProps}
       >
-        {t(isLatchClosed ? 'open_labware_latch' : 'close_labware_latch', {
-          ns: 'heater_shaker',
-        })}
+        {t(
+          isLatchClosed
+            ? 'heater_shaker:open_labware_latch'
+            : 'heater_shaker:close_labware_latch',
+          {}
+        )}
       </MenuItem>
       {isLatchDisabled ? (
         <Tooltip tooltipProps={tooltipProps}>
-          {t('cannot_open_latch', { ns: 'heater_shaker' })}
+          {t('heater_shaker:cannot_open_latch')}
         </Tooltip>
       ) : null}
     </>
@@ -192,7 +195,7 @@ export function useModuleOverflowMenu(
       data-testid={`hs_attach_to_deck_${module.moduleModel}`}
       onClick={() => handleWizardClick()}
     >
-      {t('show_attachment_instructions', { ns: 'heater_shaker' })}
+      {t('heater_shaker:show_attachment_instructions')}
     </MenuItem>
   )
   const testShakeBtn =
@@ -200,14 +203,14 @@ export function useModuleOverflowMenu(
     module.data.speedStatus !== 'idle' ? (
       <MenuItem
         width="100%"
-        key={`about_module_${module.moduleModel}`}
-        id={`about_module_${module.moduleModel}`}
-        data-testid={`about_module_${module.moduleModel}`}
+        key={`test_shake_${module.moduleModel}`}
+        id={`test_shake_${module.moduleModel}`}
+        data-testid={`test_shake_${module.moduleModel}`}
         onClick={() =>
           handleDeactivationCommand('heaterShaker/deactivateShaker')
         }
       >
-        {t('deactivate_shaker', { ns: 'heater_shaker' })}
+        {t('heater_shaker:deactivate_shaker')}
       </MenuItem>
     ) : (
       <MenuItem
@@ -216,7 +219,7 @@ export function useModuleOverflowMenu(
         key={`hs_test_shake_btn_${module.moduleModel}`}
         disabled={isDisabled}
       >
-        {t('test_shake', { ns: 'heater_shaker' })}
+        {t('heater_shaker:test_shake')}
       </MenuItem>
     )
 
@@ -335,8 +338,8 @@ export function useModuleOverflowMenu(
         setSetting:
           module.moduleType === HEATERSHAKER_MODULE_TYPE &&
           module.data.temperatureStatus !== 'idle'
-            ? t('deactivate_heater', { ns: 'heater_shaker' })
-            : t('set_temperature', { ns: 'heater_shaker' }),
+            ? t('heater_shaker:deactivate_heater')
+            : t('heater_shaker:set_temperature'),
         isSecondary: false,
         disabledReason: false,
         menuButtons: [

--- a/app/src/organisms/ModuleCard/hooks.tsx
+++ b/app/src/organisms/ModuleCard/hooks.tsx
@@ -154,7 +154,6 @@ export function useModuleOverflowMenu(
   const labwareLatchBtn = (
     <>
       <MenuItem
-        width="100%"
         key={`hs_labware_latch_${module.moduleModel}`}
         data-testid={`hs_labware_latch_${module.moduleModel}`}
         onClick={toggleLatch}
@@ -178,7 +177,6 @@ export function useModuleOverflowMenu(
 
   const aboutModuleBtn = (
     <MenuItem
-      width="100%"
       key={`about_module_${module.moduleModel}`}
       id={`about_module_${module.moduleModel}`}
       data-testid={`about_module_${module.moduleModel}`}
@@ -190,7 +188,6 @@ export function useModuleOverflowMenu(
 
   const attachToDeckBtn = (
     <MenuItem
-      whiteSpace="nowrap"
       key={`hs_attach_to_deck_${module.moduleModel}`}
       data-testid={`hs_attach_to_deck_${module.moduleModel}`}
       onClick={() => handleWizardClick()}
@@ -202,7 +199,6 @@ export function useModuleOverflowMenu(
     module.moduleType === HEATERSHAKER_MODULE_TYPE &&
     module.data.speedStatus !== 'idle' ? (
       <MenuItem
-        width="100%"
         key={`test_shake_${module.moduleModel}`}
         id={`test_shake_${module.moduleModel}`}
         data-testid={`test_shake_${module.moduleModel}`}
@@ -214,7 +210,6 @@ export function useModuleOverflowMenu(
       </MenuItem>
     ) : (
       <MenuItem
-        width="100%"
         onClick={() => handleTestShakeClick()}
         key={`hs_test_shake_btn_${module.moduleModel}`}
         disabled={isDisabled}


### PR DESCRIPTION
closes #11162 and #11160

# Overview

There were a few design elements in the modal that weren't updated such as the checkbox field and the hover state

Additionally, this changes the `maxWidth` of the module overflow menu items so the text spans 1 line for each button

# Changelog

- update various aspects in the `ConfirmAttachmentModal`
- add hover state to the link in the `TestShake` + a few refactoring of the usage of i18n
- add `whiteSpace="nowrap"` and `width = 100%` to module overflow menus
- fix duplicate key in `useModuleOverflowMenu`

# Review requests

- does it match designs? Do the overflow menu buttons work as expected and look okay?

# Risk assessment

low