### PR TITLE
fix(api,update-server): Synchronize robot name more tightly between between api and update-server

### DIFF
--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -108,9 +108,9 @@ def name() -> str:
         #
         # We let the exception propagate so the caller (probably an HTTP client
         # polling /health) can retry later.
-        result = subprocess.check_output(
-            ["hostnamectl", "--pretty", "status"]
-        ).decode("utf-8")
+        result = subprocess.check_output(["hostnamectl", "--pretty", "status"]).decode(
+            "utf-8"
+        )
 
         # Strip the trailing newline, since it's not part of the actual name value.
         # TODO(mm, 2022-07-18): When we upgrade to systemd 249, use

--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -94,31 +94,32 @@ if IS_ROBOT:
 
 
 def name() -> str:
-    fallback = "opentrons-dev"
-
     if IS_ROBOT and ARCHITECTURE in (
         SystemArchitecture.BUILDROOT,
         SystemArchitecture.YOCTO,
     ):
-        try:
-            # Read the name from the machine's pretty hostname, which is maintained
-            # by update-server. This retrieval logic needs to be kept in sync with
-            # update-server.
-            result = subprocess.check_output(
-                ["hostnamectl", "--pretty", "status"]
-            ).decode("utf-8")
-            # Strip the trailing newline, since it's not part of the actual name value.
-            # TODO(mm, 2022-07-18): When we upgrade to systemd 249, use
-            # `hostnamectl --json` for CLI output that we can parse more robustly.
-            assert len(result) >= 1 and result[-1] == "\n"
-            return result[:-1]
+        # Read the name from the machine's pretty hostname, which is maintained
+        # by update-server. This retrieval logic needs to be kept in sync with
+        # update-server.
 
-        except Exception:
-            log.exception(
-                f"Couldn't load name from /etc/machine-info, defaulting to {fallback}"
-            )
+        # NOTE: This call to hostnamectl can fail momentarily if it runs
+        # at the same time as a systemd-hostnamed restart.
+        # update-server triggers such restarts regularly, any time the name changes.
+        #
+        # We let the exception propagate so the caller (probably an HTTP client
+        # polling /health) can retry later.
+        result = subprocess.check_output(
+            ["hostnamectl", "--pretty", "status"]
+        ).decode("utf-8")
 
-    return fallback
+        # Strip the trailing newline, since it's not part of the actual name value.
+        # TODO(mm, 2022-07-18): When we upgrade to systemd 249, use
+        # `hostnamectl --json` for CLI output that we can parse more robustly.
+        assert len(result) >= 1 and result[-1] == "\n"
+        return result[:-1]
+
+    else:
+        return "opentrons-dev"
 
 
 class ConfigElementType(enum.Enum):

--- a/update-server/otupdate/buildroot/__init__.py
+++ b/update-server/otupdate/buildroot/__init__.py
@@ -38,7 +38,7 @@ def get_version(version_file: str) -> Mapping[str, str]:
     return json.load(open(version_file, "r"))
 
 
-def get_app(
+async def get_app(
     name_synchronizer: name_management.NameSynchronizer,
     system_version_file: Optional[str] = None,
     config_file_override: Optional[str] = None,
@@ -89,7 +89,7 @@ def get_app(
         "Setup: "
         + "\n\t".join(
             [
-                f"Device name: {name_synchronizer.get_name()}",
+                f"Device name: {await name_synchronizer.get_name()}",
                 "Buildroot version:         "
                 f'{version.get("buildroot_version", "unknown")}',
                 "\t(from git sha      " f'{version.get("buildroot_sha", "unknown")}',

--- a/update-server/otupdate/buildroot/__main__.py
+++ b/update-server/otupdate/buildroot/__main__.py
@@ -28,7 +28,7 @@ async def main() -> NoReturn:
 
     async with name_management.NameSynchronizer.start() as name_synchronizer:
         LOG.info("Building buildroot update server")
-        app = get_app(
+        app = await get_app(
             system_version_file=args.version_file,
             config_file_override=args.config_file,
             name_synchronizer=name_synchronizer,

--- a/update-server/otupdate/common/control.py
+++ b/update-server/otupdate/common/control.py
@@ -42,7 +42,7 @@ def build_health_endpoint(
             {
                 **health_response,
                 **{
-                    "name": get_name_synchronizer(request).get_name(),
+                    "name": await get_name_synchronizer(request).get_name(),
                     "serialNumber": get_serial(),
                     "bootId": request.app[DEVICE_BOOT_ID_NAME],
                 },

--- a/update-server/otupdate/common/name_management/__init__.py
+++ b/update-server/otupdate/common/name_management/__init__.py
@@ -112,7 +112,7 @@ async def get_name_endpoint(request: web.Request) -> web.Response:
     """
     name_synchronizer = get_name_synchronizer(request)
     return web.json_response(  # type: ignore[no-untyped-call,no-any-return]
-        data={"name": name_synchronizer.get_name()}, status=200
+        data={"name": await name_synchronizer.get_name()}, status=200
     )
 
 

--- a/update-server/otupdate/common/name_management/name_synchronizer.py
+++ b/update-server/otupdate/common/name_management/name_synchronizer.py
@@ -75,7 +75,7 @@ class NameSynchronizer:
             callback=name_synchronizer._on_avahi_collision
         ):
             await avahi_client.start_advertising(
-                service_name=name_synchronizer.get_name()
+                service_name=await name_synchronizer.get_name()
             )
             yield name_synchronizer
 
@@ -91,23 +91,23 @@ class NameSynchronizer:
         await self._avahi_client.start_advertising(service_name=new_name)
         # Setting the Avahi service name can fail if Avahi doesn't like the new name.
         # Persist only after it succeeds, so we don't persist something invalid.
-        persisted_pretty_hostname = persist_pretty_hostname(new_name)
+        persisted_pretty_hostname = await persist_pretty_hostname(new_name)
         _log.info(
             f"Changed name to {repr(new_name)}"
             f" (persisted {repr(persisted_pretty_hostname)})."
         )
         return persisted_pretty_hostname
 
-    def get_name(self) -> str:
+    async def get_name(self) -> str:
         """Return the machine's current human-readable name.
 
         Note that this can change even if you haven't called `set_name()`,
         if it was necessary to avoid conflicts with other devices on the network.
         """
-        return get_pretty_hostname()
+        return await get_pretty_hostname()
 
     async def _on_avahi_collision(self) -> None:
-        current_name = self.get_name()
+        current_name = await self.get_name()
 
         # Assume that the service name was the thing that collided.
         # Theoretically it also could have been the static hostname,

--- a/update-server/otupdate/common/name_management/pretty_hostname.py
+++ b/update-server/otupdate/common/name_management/pretty_hostname.py
@@ -55,7 +55,9 @@ async def persist_pretty_hostname(name: str) -> str:
     # Now that we've rewritten /etc/machine-info to contain the new pretty hostname,
     # restart systemd-hostnamed so that commands like `hostnamectl status --pretty`
     # pick it up immediately.
-    await _run_command(command="systemctl", args=["restart", "systemd-hostnamed"])
+    await _run_command(
+        command="systemctl", args=["reload-or-restart", "systemd-hostnamed"]
+    )
 
     return checked_name
 

--- a/update-server/otupdate/common/name_management/pretty_hostname.py
+++ b/update-server/otupdate/common/name_management/pretty_hostname.py
@@ -22,7 +22,7 @@ async def get_pretty_hostname(default: str = "no name set") -> str:
     # NOTE: The `api` package also retrieves the pretty hostname.
     # This logic must be kept in sync with the logic in `api`.
     result = (
-        await _run_command(
+        await _run_subprocess(
             command="hostnamectl",
             args=["--pretty", "status"],
         )
@@ -55,7 +55,7 @@ async def persist_pretty_hostname(name: str) -> str:
     # Now that we've rewritten /etc/machine-info to contain the new pretty hostname,
     # restart systemd-hostnamed so that commands like `hostnamectl status --pretty`
     # pick it up immediately.
-    await _run_command(
+    await _run_subprocess(
         command="systemctl", args=["reload-or-restart", "systemd-hostnamed"]
     )
 
@@ -102,7 +102,7 @@ def _rewrite_machine_info_str(
 
 # TODO(mm, 2022-07-18): Deduplicate with identical subprocess error-checking code
 # in .avahi and .static_hostname modules.
-async def _run_command(
+async def _run_subprocess(
     command: Union[str, bytes],
     args: List[Union[str, bytes]],
 ) -> bytes:

--- a/update-server/otupdate/common/name_management/pretty_hostname.py
+++ b/update-server/otupdate/common/name_management/pretty_hostname.py
@@ -24,8 +24,7 @@ async def get_pretty_hostname(default: str = "no name set") -> str:
     result = (
         await _run_command(
             command="hostnamectl",
-            # Only get the pretty hostname, not the static or transient one.
-            args=["status", "--pretty"],
+            args=["--pretty", "status"],
         )
     ).decode("utf-8")
     # Strip the trailing newline, since it's not part of the actual name value.

--- a/update-server/otupdate/common/name_management/pretty_hostname.py
+++ b/update-server/otupdate/common/name_management/pretty_hostname.py
@@ -14,7 +14,11 @@ _log = getLogger(__name__)
 
 
 async def get_pretty_hostname(default: str = "no name set") -> str:
-    """Get the currently-configured pretty hostname"""
+    """Get the currently-configured pretty hostname.
+
+    May raise an exception from the underlying ``hostnamectl`` process
+    if this happens to run at the same time systemd-hostnamed is restarting.
+    """
     # NOTE: The `api` package also retrieves the pretty hostname.
     # This logic must be kept in sync with the logic in `api`.
     result = (

--- a/update-server/otupdate/common/name_management/pretty_hostname.py
+++ b/update-server/otupdate/common/name_management/pretty_hostname.py
@@ -5,33 +5,33 @@ and how it's distinct from other names on the machine.
 """
 
 
+import asyncio
 from logging import getLogger
+from typing import List, Union
 
 
 _log = getLogger(__name__)
 
 
-def get_pretty_hostname(default: str = "no name set") -> str:
+async def get_pretty_hostname(default: str = "no name set") -> str:
     """Get the currently-configured pretty hostname"""
-    try:
-        with open("/etc/machine-info") as emi:
-            contents = emi.read()
-    except OSError:
-        _log.exception("Couldn't read /etc/machine-info")
-        contents = ""
-    for line in contents.split("\n"):
-        if line.startswith("PRETTY_HOSTNAME="):
-            # FIXME(mm, 2022-04-27): This will not correctly read the pretty hostname
-            # if it's quoted or contains escaped characters.
-            # https://github.com/Opentrons/opentrons/issues/10197
-            # Perhaps we should query the pretty hostname from hostnamectl instead of
-            # implementing our own parsing.
-            return "=".join(line.split("=")[1:])
-    _log.warning(f"No PRETTY_HOSTNAME in {contents}, defaulting to {default}")
-    return default
+    # NOTE: The `api` package also retrieves the pretty hostname.
+    # This logic must be kept in sync with the logic in `api`.
+    result = (
+        await _run_command(
+            command="hostnamectl",
+            # Only get the pretty hostname, not the static or transient one.
+            args=["status", "--pretty"],
+        )
+    ).decode("utf-8")
+    # Strip the trailing newline, since it's not part of the actual name value.
+    # TODO(mm, 2022-07-18): When we upgrade to systemd 249, use `hostnamectl --json`
+    # for CLI output that we can parse more robustly.
+    assert len(result) >= 1 and result[-1] == "\n"
+    return result[:-1]
 
 
-def persist_pretty_hostname(name: str) -> str:
+async def persist_pretty_hostname(name: str) -> str:
     """Change the robot's pretty hostname.
 
     Writes the new name to /etc/machine-info so it persists across reboots.
@@ -47,7 +47,13 @@ def persist_pretty_hostname(name: str) -> str:
         checked_name = name
     except OSError:
         _log.exception("Could not set pretty hostname")
-        checked_name = get_pretty_hostname()
+        checked_name = await get_pretty_hostname()
+
+    # Now that we've rewritten /etc/machine-info to contain the new pretty hostname,
+    # restart systemd-hostnamed so that commands like `hostnamectl status --pretty`
+    # pick it up immediately.
+    await _run_command(command="systemctl", args=["restart", "systemd-hostnamed"])
+
     return checked_name
 
 
@@ -87,3 +93,29 @@ def _rewrite_machine_info_str(
     new_lines = preserved_lines + [f"PRETTY_HOSTNAME={new_pretty_hostname}"]
     new_contents = "\n".join(new_lines) + "\n"
     return new_contents
+
+
+# TODO(mm, 2022-07-18): Deduplicate with identical subprocess error-checking code
+# in .avahi and .static_hostname modules.
+async def _run_command(
+    command: Union[str, bytes],
+    args: List[Union[str, bytes]],
+) -> bytes:
+    process = await asyncio.create_subprocess_exec(
+        command,
+        *args,
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await process.communicate()
+    ret = process.returncode
+    if ret != 0:
+        _log.error(
+            f"Error calling {command!r}: {ret} "
+            f"stdout: {stdout!r} stderr: {stderr!r}"
+        )
+        # TODO(mm, 2022-07-18): Use a structured and specific exception type
+        # once this function is deduplicated.
+        raise RuntimeError(f"Error calling {command!r}")
+    return stdout

--- a/update-server/otupdate/openembedded/__init__.py
+++ b/update-server/otupdate/openembedded/__init__.py
@@ -43,7 +43,7 @@ def get_version_dict(version_file: Optional[str]) -> Mapping[str, str]:
     return version
 
 
-def get_app(
+async def get_app(
     name_synchronizer: name_management.NameSynchronizer,
     system_version_file: Optional[str] = None,
     config_file_override: Optional[str] = None,
@@ -96,7 +96,7 @@ def get_app(
         "Setup: "
         + "\n\t".join(
             [
-                f"Device name: {name_synchronizer.get_name()}",
+                f"Device name: {await name_synchronizer.get_name()}",
                 "Buildroot version:         "
                 f'{version.get("buildroot_version", "unknown")}',
                 "\t(from git sha      " f'{version.get("buildroot_sha", "unknown")}',

--- a/update-server/otupdate/openembedded/__main__.py
+++ b/update-server/otupdate/openembedded/__main__.py
@@ -28,7 +28,7 @@ async def main() -> NoReturn:
 
     async with name_management.NameSynchronizer.start() as name_synchronizer:
         LOG.info("Building openembedded update server")
-        app = get_app(
+        app = await get_app(
             system_version_file=args.version_file,
             config_file_override=args.config_file,
             name_synchronizer=name_synchronizer,

--- a/update-server/tests/buildroot/conftest.py
+++ b/update-server/tests/buildroot/conftest.py
@@ -20,7 +20,7 @@ async def test_cli(
     """
     Build an app using dummy versions, then build a test client and return it
     """
-    app = buildroot.get_app(
+    app = await buildroot.get_app(
         name_synchronizer=mock_name_synchronizer,
         system_version_file=version_file_path,
         config_file_override=otupdate_config,

--- a/update-server/tests/buildroot/test_control.py
+++ b/update-server/tests/buildroot/test_control.py
@@ -15,7 +15,7 @@ async def test_health(
     mock_name_synchronizer: NameSynchronizer,
     decoy: Decoy,
 ):
-    decoy.when(mock_name_synchronizer.get_name()).then_return("test name")
+    decoy.when(await mock_name_synchronizer.get_name()).then_return("test name")
     resp = await test_cli.get("/server/update/health")
     assert resp.status == 200
     body = await resp.json()

--- a/update-server/tests/common/conftest.py
+++ b/update-server/tests/common/conftest.py
@@ -31,7 +31,7 @@ async def test_cli(
     Build an app using dummy versions, then build a test client and return it
     """
     cli_client_pkg = request.param
-    app = cli_client_pkg.get_app(
+    app = await cli_client_pkg.get_app(
         name_synchronizer=mock_name_synchronizer,
         system_version_file=version_file_path,
         config_file_override=otupdate_config,

--- a/update-server/tests/common/name_management/test_http_endpoints.py
+++ b/update-server/tests/common/name_management/test_http_endpoints.py
@@ -13,7 +13,7 @@ async def test_get_name(
     mock_name_synchronizer: NameSynchronizer,
     decoy: Decoy,
 ) -> None:
-    decoy.when(mock_name_synchronizer.get_name()).then_return("the returned name")
+    decoy.when(await mock_name_synchronizer.get_name()).then_return("the returned name")
 
     response = await (test_cli[0].get("/server/name"))  # type: ignore[no-untyped-call]
     assert response.status == 200

--- a/update-server/tests/common/name_management/test_name_synchronizer.py
+++ b/update-server/tests/common/name_management/test_name_synchronizer.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, AsyncGenerator, Callable
+from typing import Any, AsyncGenerator, Awaitable, Callable
 
 import pytest
 from decoy import Decoy, matchers
@@ -16,8 +16,10 @@ from otupdate.common.name_management.pretty_hostname import (
 )
 
 
-_GET_PRETTY_HOSTNAME_SIGNATURE = Callable[[], str]
-_PERSIST_PRETTY_HOSTNAME_SIGNATURE = Callable[[str], str]
+# TODO(mm, 2022-07-19): Mock out these functions differently so we don't have to
+# write out their signatures.
+_GET_PRETTY_HOSTNAME_SIGNATURE = Callable[[], Awaitable[str]]
+_PERSIST_PRETTY_HOSTNAME_SIGNATURE = Callable[[str], Awaitable[str]]
 _ALTERNATIVE_SERVICE_NAME_SIGNATURE = Callable[[str], str]
 
 
@@ -112,7 +114,7 @@ async def test_set(
 
     decoy.verify(
         await mock_avahi_client.start_advertising("new name"),
-        mock_persist_pretty_hostname("new name"),
+        await mock_persist_pretty_hostname("new name"),
     )
 
 
@@ -134,7 +136,7 @@ async def test_set_does_not_persist_invalid_avahi_service_name(
     with pytest.raises(Exception, match="oh the humanity"):
         await started_up_subject.set_name("danger!")
 
-    decoy.verify(mock_persist_pretty_hostname(matchers.Anything()), times=0)
+    decoy.verify(await mock_persist_pretty_hostname(matchers.Anything()), times=0)
 
 
 async def test_get(
@@ -142,8 +144,8 @@ async def test_get(
     mock_get_pretty_hostname: _GET_PRETTY_HOSTNAME_SIGNATURE,
     decoy: Decoy,
 ) -> None:
-    decoy.when(mock_get_pretty_hostname()).then_return("the current name")
-    assert started_up_subject.get_name() == "the current name"
+    decoy.when(await mock_get_pretty_hostname()).then_return("the current name")
+    assert await started_up_subject.get_name() == "the current name"
 
 
 async def test_advertises_initial_name(
@@ -159,7 +161,7 @@ async def test_advertises_initial_name(
     as the Avahi service name, when it's started up.
     """
 
-    decoy.when(mock_get_pretty_hostname()).then_return("initial name")
+    decoy.when(await mock_get_pretty_hostname()).then_return("initial name")
     mock_collision_subscription_context_manager = decoy.mock()
     decoy.when(
         mock_avahi_client.listen_for_collisions(matchers.Anything())
@@ -191,7 +193,7 @@ async def test_collision_handling(
     2. Start advertising with it.
     3. Persist it as the pretty hostname.
     """
-    decoy.when(mock_get_pretty_hostname()).then_return("initial name")
+    decoy.when(await mock_get_pretty_hostname()).then_return("initial name")
     decoy.when(mock_alternative_service_name("initial name")).then_return(
         "alternative name"
     )
@@ -224,5 +226,5 @@ async def test_collision_handling(
         # just in case the alternative name turns out to be invalid in some way.
         # https://github.com/Opentrons/opentrons/issues/9960
         await mock_avahi_client.start_advertising("alternative name"),
-        mock_persist_pretty_hostname("alternative name"),
+        await mock_persist_pretty_hostname("alternative name"),
     )

--- a/update-server/tests/openembedded/conftest.py
+++ b/update-server/tests/openembedded/conftest.py
@@ -32,7 +32,7 @@ async def test_cli(
     """
     Build an app using dummy versions, then build a test client and return it
     """
-    app = openembedded.get_app(
+    app = await openembedded.get_app(
         name_synchronizer=mock_name_synchronizer,
         system_version_file=version_file_path,
         config_file_override=otupdate_config,

--- a/update-server/tests/openembedded/test_control.py
+++ b/update-server/tests/openembedded/test_control.py
@@ -16,7 +16,7 @@ async def test_health(
     mock_name_synchronizer: NameSynchronizer,
     decoy: Decoy,
 ):
-    decoy.when(mock_name_synchronizer.get_name()).then_return("test name")
+    decoy.when(await mock_name_synchronizer.get_name()).then_return("test name")
     resp = await test_cli.get("/server/update/health")
     assert resp.status == 200
     body = await resp.json()


### PR DESCRIPTION
# Overview

This PR fixes bugs that could cause a robot's name to be different depending on whether you were looking at `GET /server/update/health` or `GET /health`.

Closes #10413.

# Changelog

* In `update-server`, when retrieving the robot's pretty hostname, do not manually parse it from `/etc/machine-info`. Instead, shell out to `hostnamectl --pretty status`. This is to match how `api` has been doing it.
* When parsing the output of `hostnamectl --pretty status`, do not unnecessarily strip leading and trailing whitespace.
    * Stripping whitespace might be reasonable, but I don't think this is the place to do it, because it makes it harder to keep the robot's name in sync across the various places where it's visible.
* In `update-server`, whenever we rewrite `/etc/machine-info` to store a new name, also restart `systemd-hostnamed`.
    * This is necessary for the `hostnamectl --pretty status` calls in `update-server` and `api` to reliably pick up the new value.
* Do not fall back to the name `"opentrons-develop"` if shelling out to `hostnamectl` fails. Instead, just let the endpoint return `500`.
    * This interacted poorly with the `systemd-hostnamed` restart described above, and it seemed unused.

# Review requests

* [x] Confirm that you can still rename the OT-2 through the Opentrons App.
    * Tested by @SyntaxColoring.
* [x] Confirm that this fixes #10413.
    * Tested by @SyntaxColoring.
* [x] Do we expect the removal of the fallback name `"opentrons-develop"` to cause any problems on dev machines?
    * Tested by @SyntaxColoring with `make -C robot-server test` and `make -C robot-server dev`. I'm pretty sure we're okay.
* [x] `GET /health`, `GET /server/update/health`, and `GET /server/name` may now temporarily return a `500` error if they're called within a few seconds of a rename. This is due to implementation limitations that I don't think are feasibly avoidable right now. See the comments in the code. Do we expect this to cause any robot discovery problems?
     * Discussed briefly in-person with @shlokamin. Off the top of his head, he thinks it should be fine.
     * Discussed with @mcous in the thread below.

# Risk assessment

Medium.

There’s a risk that the temporary 500 after a name change will confuse `discovery-client` and screw up robot connectivity.

There's also a risk that something not covered by CI is relying on the fallback name `opentrons-develop`. In that case, `robot-server`'s `GET /health` call will start failing with a 500 error.