### PR TITLE
refactor(app): refactor Robotsettings networktab for isrobotbusy

### DIFF
--- a/app/src/organisms/Devices/RobotSettings/ConnectNetwork/SelectSsid/__tests__/SelectSsid.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/ConnectNetwork/SelectSsid/__tests__/SelectSsid.test.tsx
@@ -18,6 +18,7 @@ describe('SelectSsid component', () => {
   const handleConnect = jest.fn()
   const handleJoinOther = jest.fn()
   const handleDisconnect = jest.fn()
+  let mockIsRobotBusy = false
 
   const render = (showDisconnect = true) => {
     return mount(
@@ -28,6 +29,7 @@ describe('SelectSsid component', () => {
         onJoinOther={handleJoinOther}
         onDisconnect={handleDisconnect}
         showWifiDisconnect={showDisconnect}
+        isRobotBusy={mockIsRobotBusy}
       />
     )
   }
@@ -41,6 +43,14 @@ describe('SelectSsid component', () => {
     const selectField = wrapper.find(SelectField)
 
     expect(selectField).toHaveLength(1)
+  })
+
+  it('renders a disabled SeleectField if a robot is busy', () => {
+    mockIsRobotBusy = true
+    const wrapper = render()
+    const selectField = wrapper.find(SelectField)
+
+    expect(selectField.prop('disabled')).toBe(true)
   })
 
   it('maps ssid list to an ssid option group', () => {

--- a/app/src/organisms/Devices/RobotSettings/ConnectNetwork/SelectSsid/index.tsx
+++ b/app/src/organisms/Devices/RobotSettings/ConnectNetwork/SelectSsid/index.tsx
@@ -19,6 +19,7 @@ export interface SelectSsidProps {
   onConnect: (ssid: string) => unknown
   onJoinOther: () => unknown
   onDisconnect: () => unknown
+  isRobotBusy: boolean
 }
 
 const FIELD_NAME = '__SelectSsid__'
@@ -70,6 +71,7 @@ export function SelectSsid(props: SelectSsidProps): JSX.Element {
     onJoinOther,
     onDisconnect,
     showWifiDisconnect,
+    isRobotBusy,
   } = props
 
   const handleValueChange = (_: string, value: string): void => {
@@ -104,6 +106,7 @@ export function SelectSsid(props: SelectSsidProps): JSX.Element {
 
   return (
     <StyledSelectField
+      disabled={isRobotBusy}
       name={FIELD_NAME}
       value={value}
       options={formatOptions(list, showWifiDisconnect)}

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsNetworking.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsNetworking.tsx
@@ -26,12 +26,13 @@ import {
   /* postWifiDisconnect, */
 } from '../../../redux/networking'
 // import * as RobotApi from '../../../redux/robot-api'
+import { useIsRobotBusy } from '../hooks'
 import { TemporarySelectNetwork } from './TemporarySelectNetwork'
 
 import type { State, Dispatch } from '../../../redux/types'
 interface NetworkingProps {
   robotName: string
-  isRobotBusy: boolean
+  updateRobotStatus: (isRobotBusy: boolean) => void
 }
 
 // ToDo kj modify ConnectModal to align with new design
@@ -43,11 +44,12 @@ const LIST_REFRESH_MS = 10000
 
 export function RobotSettingsNetworking({
   robotName,
-  isRobotBusy,
+  updateRobotStatus,
 }: NetworkingProps): JSX.Element {
   const { t } = useTranslation('device_settings')
   const list = useSelector((state: State) => getWifiList(state, robotName))
   const dispatch = useDispatch<Dispatch>()
+  const isRobotBusy = useIsRobotBusy({ poll: true })
   // const [dispatchApi] = RobotApi.useDispatchApiRequest()
 
   const { wifi, ethernet } = useSelector((state: State) =>
@@ -62,6 +64,10 @@ export function RobotSettingsNetworking({
     dispatch(fetchStatus(robotName))
     dispatch(fetchWifiList(robotName))
   }, [robotName, dispatch])
+
+  React.useEffect(() => {
+    updateRobotStatus(isRobotBusy)
+  }, [isRobotBusy, updateRobotStatus])
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN}>

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsNetworking.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsNetworking.tsx
@@ -31,10 +31,10 @@ import { TemporarySelectNetwork } from './TemporarySelectNetwork'
 import type { State, Dispatch } from '../../../redux/types'
 interface NetworkingProps {
   robotName: string
-  updateRobotStatus: (isRobotBusy: boolean) => void
+  isRobotBusy: boolean
 }
 
-// ToDo modify ConnectModal to align with new design
+// ToDo kj modify ConnectModal to align with new design
 // This is temporary until we can get the new design details
 const HELP_CENTER_URL =
   'https://support.opentrons.com/s/article/Get-started-Connect-to-your-OT-2-over-USB'
@@ -43,7 +43,7 @@ const LIST_REFRESH_MS = 10000
 
 export function RobotSettingsNetworking({
   robotName,
-  updateRobotStatus,
+  isRobotBusy,
 }: NetworkingProps): JSX.Element {
   const { t } = useTranslation('device_settings')
   const list = useSelector((state: State) => getWifiList(state, robotName))
@@ -100,7 +100,7 @@ export function RobotSettingsNetworking({
               <Box width="25%" marginRight={SPACING.spacing3}>
                 <TemporarySelectNetwork
                   robotName={robotName}
-                  updateRobotStatus={updateRobotStatus}
+                  isRobotBusy={isRobotBusy}
                 />
               </Box>
             </Flex>
@@ -139,14 +139,14 @@ export function RobotSettingsNetworking({
           <Flex flexDirection={DIRECTION_COLUMN}>
             <TemporarySelectNetwork
               robotName={robotName}
-              updateRobotStatus={updateRobotStatus}
+              isRobotBusy={isRobotBusy}
             />
           </Flex>
         )}
       </Box>
       <Divider />
       <Flex marginTop={SPACING.spacing5} marginBottom={SPACING.spacing4}>
-        {ethernet !== null && ethernet.ipAddress !== null ? (
+        {ethernet?.ipAddress != null ? (
           <Icon
             size={SPACING.spacing4}
             name="ot-check"
@@ -167,7 +167,7 @@ export function RobotSettingsNetworking({
       </Flex>
       <Box paddingLeft="3.5rem">
         <Flex marginBottom={SPACING.spacing4}>
-          {ethernet !== null && ethernet.ipAddress !== null ? (
+          {ethernet?.ipAddress != null ? (
             <>
               <Flex
                 flexDirection={DIRECTION_COLUMN}

--- a/app/src/organisms/Devices/RobotSettings/TemporarySelectNetwork.tsx
+++ b/app/src/organisms/Devices/RobotSettings/TemporarySelectNetwork.tsx
@@ -11,7 +11,6 @@ import { SelectSsid } from './ConnectNetwork/SelectSsid'
 import { ConnectModal } from './ConnectNetwork/ConnectModal'
 import { DisconnectModal } from './ConnectNetwork/DisconnectModal'
 import { ResultModal } from './ConnectNetwork/ResultModal'
-import { useIsRobotBusy } from '../hooks'
 import { CONNECT, DISCONNECT, JOIN_OTHER } from './ConnectNetwork/constants'
 
 import type { State, Dispatch } from '../../../redux/types'
@@ -23,14 +22,14 @@ import type {
 
 interface TempSelectNetworkProps {
   robotName: string
-  updateRobotStatus: (isRobotBusy: boolean) => void
+  isRobotBusy: boolean
 }
 
 const LIST_REFRESH_MS = 10000
 
 export const TemporarySelectNetwork = ({
   robotName,
-  updateRobotStatus,
+  isRobotBusy,
 }: TempSelectNetworkProps): JSX.Element => {
   const list = useSelector((state: State) =>
     Networking.getWifiList(state, robotName)
@@ -47,7 +46,6 @@ export const TemporarySelectNetwork = ({
   const [changeState, setChangeState] = React.useState<NetworkChangeState>({
     type: null,
   })
-  const isBusy = useIsRobotBusy()
   const dispatch = useDispatch<Dispatch>()
   const [dispatchApi, requestIds] = RobotApi.useDispatchApiRequest()
   const requestState = useSelector((state: State) => {
@@ -85,9 +83,7 @@ export const TemporarySelectNetwork = ({
   }, [robotName, dispatch, changeState.type])
 
   const handleSelectConnect = (ssid: string): void => {
-    if (isBusy) {
-      updateRobotStatus(true)
-    } else {
+    if (!isRobotBusy) {
       const network = list.find((nw: WifiNetwork) => nw.ssid === ssid)
       if (network != null) {
         const { ssid, securityType } = network
@@ -101,18 +97,14 @@ export const TemporarySelectNetwork = ({
   }
 
   const handleSelectDisconnect = (): void => {
-    if (isBusy) {
-      updateRobotStatus(true)
-    } else {
+    if (!isRobotBusy) {
       const ssid = activeNetwork?.ssid
       ssid != null && setChangeState({ type: DISCONNECT, ssid })
     }
   }
 
   const handleSelectJoinOther = (): void => {
-    if (isBusy) {
-      updateRobotStatus(true)
-    } else {
+    if (isRobotBusy) {
       setChangeState({ type: JOIN_OTHER, ssid: null })
     }
   }
@@ -135,7 +127,7 @@ export const TemporarySelectNetwork = ({
         onJoinOther={handleSelectJoinOther}
         onDisconnect={handleSelectDisconnect}
       />
-      {changeState.type && (
+      {changeState.type != null && (
         <Portal>
           {requestState != null ? (
             <ResultModal
@@ -143,10 +135,7 @@ export const TemporarySelectNetwork = ({
               ssid={changeState.ssid}
               isPending={requestState.status === RobotApi.PENDING}
               error={
-                'error' in requestState &&
-                requestState.error &&
-                'message' in requestState.error &&
-                requestState.error.message
+                'error' in requestState && 'message' in requestState.error
                   ? requestState.error
                   : null
               }

--- a/app/src/organisms/Devices/RobotSettings/TemporarySelectNetwork.tsx
+++ b/app/src/organisms/Devices/RobotSettings/TemporarySelectNetwork.tsx
@@ -126,6 +126,7 @@ export const TemporarySelectNetwork = ({
         onConnect={handleSelectConnect}
         onJoinOther={handleSelectJoinOther}
         onDisconnect={handleSelectDisconnect}
+        isRobotBusy={isRobotBusy}
       />
       {changeState.type && (
         <Portal>

--- a/app/src/organisms/Devices/RobotSettings/TemporarySelectNetwork.tsx
+++ b/app/src/organisms/Devices/RobotSettings/TemporarySelectNetwork.tsx
@@ -104,7 +104,7 @@ export const TemporarySelectNetwork = ({
   }
 
   const handleSelectJoinOther = (): void => {
-    if (isRobotBusy) {
+    if (!isRobotBusy) {
       setChangeState({ type: JOIN_OTHER, ssid: null })
     }
   }
@@ -127,7 +127,7 @@ export const TemporarySelectNetwork = ({
         onJoinOther={handleSelectJoinOther}
         onDisconnect={handleSelectDisconnect}
       />
-      {changeState.type != null && (
+      {changeState.type && (
         <Portal>
           {requestState != null ? (
             <ResultModal
@@ -135,7 +135,10 @@ export const TemporarySelectNetwork = ({
               ssid={changeState.ssid}
               isPending={requestState.status === RobotApi.PENDING}
               error={
-                'error' in requestState && 'message' in requestState.error
+                'error' in requestState &&
+                requestState.error &&
+                'message' in requestState.error &&
+                requestState.error.message
                   ? requestState.error
                   : null
               }

--- a/app/src/organisms/Devices/RobotSettings/__tests__/RobotSettingsNetworking.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/__tests__/RobotSettingsNetworking.test.tsx
@@ -10,6 +10,9 @@ import { RobotSettingsNetworking } from '../RobotSettingsNetworking'
 
 jest.mock('../../../../redux/networking/selectors')
 jest.mock('../../../../redux/robot-api/selectors')
+jest.mock('../../hooks')
+
+const mockUpdateRobotStatus = jest.fn()
 
 const mockGetNetworkInterfaces = Networking.getNetworkInterfaces as jest.MockedFunction<
   typeof Networking.getNetworkInterfaces
@@ -22,7 +25,10 @@ const mockGetWifiList = Networking.getWifiList as jest.MockedFunction<
 const render = () => {
   return renderWithProviders(
     <MemoryRouter>
-      <RobotSettingsNetworking robotName="otie" isRobotBusy={false} />
+      <RobotSettingsNetworking
+        robotName="otie"
+        updateRobotStatus={mockUpdateRobotStatus}
+      />
     </MemoryRouter>,
     {
       i18nInstance: i18n,

--- a/app/src/organisms/Devices/RobotSettings/__tests__/RobotSettingsNetworking.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/__tests__/RobotSettingsNetworking.test.tsx
@@ -11,8 +11,6 @@ import { RobotSettingsNetworking } from '../RobotSettingsNetworking'
 jest.mock('../../../../redux/networking/selectors')
 jest.mock('../../../../redux/robot-api/selectors')
 
-const mockUpdateRobotStatus = jest.fn()
-
 const mockGetNetworkInterfaces = Networking.getNetworkInterfaces as jest.MockedFunction<
   typeof Networking.getNetworkInterfaces
 >
@@ -24,10 +22,7 @@ const mockGetWifiList = Networking.getWifiList as jest.MockedFunction<
 const render = () => {
   return renderWithProviders(
     <MemoryRouter>
-      <RobotSettingsNetworking
-        robotName="otie"
-        updateRobotStatus={mockUpdateRobotStatus}
-      />
+      <RobotSettingsNetworking robotName="otie" isRobotBusy={false} />
     </MemoryRouter>,
     {
       i18nInstance: i18n,

--- a/app/src/organisms/Devices/RobotSettings/__tests__/TemporarySelectNetwork.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/__tests__/TemporarySelectNetwork.test.tsx
@@ -14,7 +14,6 @@ import { SelectSsid } from '../ConnectNetwork/SelectSsid'
 import { ConnectModal } from '../ConnectNetwork/ConnectModal'
 import { DisconnectModal } from '../ConnectNetwork/DisconnectModal'
 import { ResultModal } from '../ConnectNetwork/ResultModal'
-import { useIsRobotBusy } from '../../hooks'
 
 import { TemporarySelectNetwork } from '../TemporarySelectNetwork'
 
@@ -23,7 +22,6 @@ import { RequestState } from '../../../../redux/robot-api/types'
 
 jest.mock('../../../../redux/networking/selectors')
 jest.mock('../../../../redux/robot-api/selectors')
-jest.mock('../../hooks')
 
 // mock out ConnectModal to prevent warning logs from async formik
 // validation happening outside an `act`
@@ -72,9 +70,6 @@ const mockGetCanDisconnect = Networking.getCanDisconnect as jest.MockedFunction<
 const mockGetRequestById = RobotApi.getRequestById as jest.MockedFunction<
   typeof RobotApi.getRequestById
 >
-const mockUseIsRobotBusy = useIsRobotBusy as jest.MockedFunction<
-  typeof useIsRobotBusy
->
 
 describe('<TemporarySelectNetwork />', () => {
   let dispatch: any
@@ -117,8 +112,6 @@ describe('<TemporarySelectNetwork />', () => {
       expect(robotName).toEqual(mockRobotName)
       return true
     })
-
-    mockUseIsRobotBusy.mockReturnValue(false)
 
     render = () => {
       return mount(

--- a/app/src/organisms/Devices/RobotSettings/__tests__/TemporarySelectNetwork.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/__tests__/TemporarySelectNetwork.test.tsx
@@ -52,7 +52,6 @@ const mockWifiKeys = [
 ]
 
 const mockEapOptions = [Fixtures.mockEapOption]
-const mockUpdateRobotStatus = jest.fn()
 
 const mockGetWifiList = Networking.getWifiList as jest.MockedFunction<
   typeof Networking.getWifiList
@@ -125,7 +124,7 @@ describe('<TemporarySelectNetwork />', () => {
       return mount(
         <TemporarySelectNetwork
           robotName={mockRobotName}
-          updateRobotStatus={mockUpdateRobotStatus}
+          isRobotBusy={false}
         />,
         {
           wrappingComponent: Provider,

--- a/app/src/pages/Devices/RobotSettings/index.tsx
+++ b/app/src/pages/Devices/RobotSettings/index.tsx
@@ -18,7 +18,7 @@ import { ApiHostProvider } from '@opentrons/react-api-client'
 import { CONNECTABLE, UNREACHABLE, REACHABLE } from '../../../redux/discovery'
 import { StyledText } from '../../../atoms/text'
 import { Banner } from '../../../atoms/Banner'
-import { useIsRobotBusy, useRobot } from '../../../organisms/Devices/hooks'
+import { useRobot } from '../../../organisms/Devices/hooks'
 import { Line } from '../../../atoms/structure'
 import { NavTab } from '../../../atoms/NavTab'
 import { RobotSettingsCalibration } from '../../../organisms/Devices/RobotSettings/RobotSettingsCalibration'
@@ -42,8 +42,6 @@ export function RobotSettings(): JSX.Element | null {
     if (isRobotBusy) setShowRobotBusyBanner(true)
   }
 
-  const isRobotBusy = useIsRobotBusy({ poll: true })
-
   const robotSettingsContentByTab: {
     [K in RobotSettingsTab]: () => JSX.Element
   } = {
@@ -56,7 +54,7 @@ export function RobotSettings(): JSX.Element | null {
     networking: () => (
       <RobotSettingsNetworking
         robotName={robotName}
-        isRobotBusy={isRobotBusy}
+        updateRobotStatus={updateRobotStatus}
       />
     ),
     advanced: () => (

--- a/app/src/pages/Devices/RobotSettings/index.tsx
+++ b/app/src/pages/Devices/RobotSettings/index.tsx
@@ -18,7 +18,7 @@ import { ApiHostProvider } from '@opentrons/react-api-client'
 import { CONNECTABLE, UNREACHABLE, REACHABLE } from '../../../redux/discovery'
 import { StyledText } from '../../../atoms/text'
 import { Banner } from '../../../atoms/Banner'
-import { useRobot } from '../../../organisms/Devices/hooks'
+import { useIsRobotBusy, useRobot } from '../../../organisms/Devices/hooks'
 import { Line } from '../../../atoms/structure'
 import { NavTab } from '../../../atoms/NavTab'
 import { RobotSettingsCalibration } from '../../../organisms/Devices/RobotSettings/RobotSettingsCalibration'
@@ -42,6 +42,8 @@ export function RobotSettings(): JSX.Element | null {
     if (isRobotBusy) setShowRobotBusyBanner(true)
   }
 
+  const isRobotBusy = useIsRobotBusy({ poll: true })
+
   const robotSettingsContentByTab: {
     [K in RobotSettingsTab]: () => JSX.Element
   } = {
@@ -54,7 +56,7 @@ export function RobotSettings(): JSX.Element | null {
     networking: () => (
       <RobotSettingsNetworking
         robotName={robotName}
-        updateRobotStatus={updateRobotStatus}
+        isRobotBusy={isRobotBusy}
       />
     ),
     advanced: () => (


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This will fix #11128's network tab part. This PR brings `useIsRobotBusy` to each RobotSettings tab and removes it from the RobotSettingNetwork child component.
Calling `useIsRobotBusy` causes the error, `Error: Rendered more hooks than during the previous render.`
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- Add useIsRobotBusy to the RobotSettings page and remove the function to update the boolean to display Banner
- Remove useIsRobotBusy from components and pass isRobotBusy(boolean)
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- [ ] when running a protocol, the banner is displayed between the page title and tabs
- [ ] when running a protocol, the network selector is disabled
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
