### PR TITLE
refactor(app): H-s refactor logic in useLabwareLatch hook and wizard

### DIFF
--- a/app/src/organisms/Devices/HeaterShakerWizard/AttachAdapter.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/AttachAdapter.tsx
@@ -23,12 +23,12 @@ import type { HeaterShakerModule } from '../../../redux/modules/types'
 
 interface AttachAdapterProps {
   module: HeaterShakerModule
+  isLoadedInRun: boolean
   currentRunId?: string
 }
 export function AttachAdapter(props: AttachAdapterProps): JSX.Element {
-  const { module, currentRunId } = props
+  const { module, isLoadedInRun, currentRunId } = props
   const { t } = useTranslation('heater_shaker')
-  const isLoadedInRun = currentRunId != null ? true : false
   const { toggleLatch, isLatchClosed } = useLatchControls(
     module,
     isLoadedInRun,

--- a/app/src/organisms/Devices/HeaterShakerWizard/AttachAdapter.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/AttachAdapter.tsx
@@ -23,12 +23,17 @@ import type { HeaterShakerModule } from '../../../redux/modules/types'
 
 interface AttachAdapterProps {
   module: HeaterShakerModule
-  runId?: string
+  currentRunId?: string
 }
 export function AttachAdapter(props: AttachAdapterProps): JSX.Element {
-  const { module, runId } = props
+  const { module, currentRunId } = props
   const { t } = useTranslation('heater_shaker')
-  const { toggleLatch, isLatchClosed } = useLatchControls(module, runId)
+  const isLoadedInRun = currentRunId != null ? true : false
+  const { toggleLatch, isLatchClosed } = useLatchControls(
+    module,
+    isLoadedInRun,
+    currentRunId
+  )
   const [targetProps, tooltipProps] = useHoverTooltip()
   const isShaking = module.data.speedStatus !== 'idle'
 

--- a/app/src/organisms/Devices/HeaterShakerWizard/TestShake.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/TestShake.tsx
@@ -39,19 +39,23 @@ import type { ProtocolModuleInfo } from '../../Devices/ProtocolRun/utils/getProt
 interface TestShakeProps {
   module: HeaterShakerModule
   setCurrentPage: React.Dispatch<React.SetStateAction<number>>
+  isLoadedInRun: boolean
   moduleFromProtocol?: ProtocolModuleInfo
   currentRunId?: string
 }
 
 export function TestShake(props: TestShakeProps): JSX.Element {
-  const { module, setCurrentPage, moduleFromProtocol, currentRunId } = props
+  const {
+    module,
+    setCurrentPage,
+    isLoadedInRun,
+    moduleFromProtocol,
+    currentRunId,
+  } = props
   const { t } = useTranslation(['heater_shaker', 'device_details'])
   const { createLiveCommand } = useCreateLiveCommandMutation()
   const { createCommand } = useCreateCommandMutation()
-  const [isExpanded, setExpanded] = React.useState(false)
   const { isRunIdle, isRunTerminal } = useRunStatuses()
-  const isLoadedInRun = currentRunId != null ? true : false
-  const [shakeValue, setShakeValue] = React.useState<string | null>(null)
   const [targetProps, tooltipProps] = useHoverTooltip()
   const { toggleLatch, isLatchClosed } = useLatchControls(
     module,
@@ -62,6 +66,9 @@ export function TestShake(props: TestShakeProps): JSX.Element {
     module,
     currentRunId != null ? currentRunId : null
   )
+  const [isExpanded, setExpanded] = React.useState<boolean>(false)
+  const [shakeValue, setShakeValue] = React.useState<string | null>(null)
+  const isShaking = module.data.speedStatus !== 'idle'
 
   let moduleId: string | null = null
   if (isRunIdle && currentRunId != null && isLoadedInRun) {
@@ -69,7 +76,6 @@ export function TestShake(props: TestShakeProps): JSX.Element {
   } else if ((currentRunId != null && isRunTerminal) || currentRunId == null) {
     moduleId = module.id
   }
-  const isShaking = module.data.speedStatus !== 'idle'
 
   const setShakeCommand: HeaterShakerSetAndWaitForShakeSpeedCreateCommand = {
     commandType: 'heaterShaker/setAndWaitForShakeSpeed',
@@ -86,9 +92,6 @@ export function TestShake(props: TestShakeProps): JSX.Element {
     },
   }
 
-  console.log(setShakeCommand)
-  console.log(currentRunId)
-
   const handleShakeCommand = (): void => {
     if (isRunIdle && currentRunId != null && isLoadedInRun) {
       createCommand({
@@ -98,7 +101,7 @@ export function TestShake(props: TestShakeProps): JSX.Element {
         console.error(
           `error setting module status with command type ${
             stopShakeCommand.commandType ?? setShakeCommand.commandType
-          } and run id ${currentRunId}: ${e.message}`
+          }: ${e.message}`
         )
       })
     } else if (

--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/AttachAdapter.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/AttachAdapter.test.tsx
@@ -3,8 +3,9 @@ import { fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../../i18n'
 import { mockHeaterShaker } from '../../../../redux/modules/__fixtures__'
-import { AttachAdapter } from '../AttachAdapter'
 import { useLatchControls } from '../../../ModuleCard/hooks'
+import { RUN_ID_1 } from '../../../RunTimeControl/__fixtures__'
+import { AttachAdapter } from '../AttachAdapter'
 import type { HeaterShakerModule } from '../../../../redux/modules/types'
 
 jest.mock('../../../ModuleCard/hooks')
@@ -98,5 +99,15 @@ describe('AttachAdapter', () => {
     const { getByRole } = render(props)
     const btn = getByRole('button', { name: 'Open Labware Latch' })
     expect(btn).toBeDisabled()
+  })
+  it('renders button and clicking on it sends latch command to open when current run id is not null', () => {
+    props = {
+      module: mockHeaterShaker,
+      currentRunId: RUN_ID_1,
+    }
+    const { getByRole } = render(props)
+    const btn = getByRole('button', { name: 'Open Labware Latch' })
+    fireEvent.click(btn)
+    expect(mockUseLatchControls).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/AttachAdapter.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/AttachAdapter.test.tsx
@@ -48,6 +48,7 @@ describe('AttachAdapter', () => {
   beforeEach(() => {
     props = {
       module: mockHeaterShaker,
+      isLoadedInRun: false,
     }
     mockUseLatchControls.mockReturnValue({
       toggleLatch: jest.fn(),
@@ -95,6 +96,7 @@ describe('AttachAdapter', () => {
   it('renders button and it is disabled when heater-shaker is shaking', () => {
     props = {
       module: mockHeaterShakeShaking,
+      isLoadedInRun: false,
     }
     const { getByRole } = render(props)
     const btn = getByRole('button', { name: 'Open Labware Latch' })
@@ -104,6 +106,7 @@ describe('AttachAdapter', () => {
     props = {
       module: mockHeaterShaker,
       currentRunId: RUN_ID_1,
+      isLoadedInRun: true,
     }
     const { getByRole } = render(props)
     const btn = getByRole('button', { name: 'Open Labware Latch' })

--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/HeaterShakerWizard.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/HeaterShakerWizard.test.tsx
@@ -61,6 +61,7 @@ describe('HeaterShakerWizard', () => {
   beforeEach(() => {
     props = {
       onCloseClick: jest.fn(),
+      isLoadedInRun: false,
     }
     mockUseAttachedModules.mockReturnValue([mockHeaterShaker])
     mockIntroduction.mockReturnValue(<div>Mock Introduction</div>)
@@ -110,6 +111,7 @@ describe('HeaterShakerWizard', () => {
     props = {
       onCloseClick: jest.fn(),
       currentRunId: RUN_ID_1,
+      isLoadedInRun: true,
       moduleFromProtocol: {
         moduleId: 'heater_shaker_id',
         x: 0,

--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/HeaterShakerWizard.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/HeaterShakerWizard.test.tsx
@@ -6,6 +6,7 @@ import { i18n } from '../../../../i18n'
 import { useAttachedModules } from '../../hooks'
 import { mockHeaterShaker } from '../../../../redux/modules/__fixtures__'
 import heaterShakerCommands from '@opentrons/shared-data/protocol/fixtures/6/heaterShakerCommands.json'
+import { RUN_ID_1 } from '../../../RunTimeControl/__fixtures__'
 import { HeaterShakerWizard } from '..'
 import { Introduction } from '../Introduction'
 import { KeyParts } from '../KeyParts'
@@ -108,6 +109,7 @@ describe('HeaterShakerWizard', () => {
   it('renders wizard and returns the correct pages when the buttons are clicked and protocol is known', () => {
     props = {
       onCloseClick: jest.fn(),
+      currentRunId: RUN_ID_1,
       moduleFromProtocol: {
         moduleId: 'heater_shaker_id',
         x: 0,

--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/TestShake.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/TestShake.test.tsx
@@ -136,6 +136,7 @@ describe('TestShake', () => {
       setCurrentPage: jest.fn(),
       module: mockHeaterShaker,
       moduleFromProtocol: undefined,
+      isLoadedInRun: false,
     }
     mockCreateLiveCommand = jest.fn()
     mockCreateLiveCommand.mockResolvedValue(null)
@@ -152,7 +153,7 @@ describe('TestShake', () => {
     mockUseRunStatuses.mockReturnValue({
       isLegacySessionInProgress: false,
       isRunStill: false,
-      isRunTerminal: true,
+      isRunTerminal: false,
       isRunIdle: false,
     })
     mockUseLatchControls.mockReturnValue({
@@ -181,6 +182,7 @@ describe('TestShake', () => {
       setCurrentPage: jest.fn(),
       module: mockHeaterShaker,
       moduleFromProtocol: HEATER_SHAKER_PROTOCOL_MODULE_INFO,
+      isLoadedInRun: true,
     }
     const { getByText } = render(props)
     getByText(
@@ -201,6 +203,7 @@ describe('TestShake', () => {
       module: mockHeaterShaker,
       setCurrentPage: jest.fn(),
       moduleFromProtocol: undefined,
+      isLoadedInRun: false,
     }
 
     mockUseLatchControls.mockReturnValue({
@@ -218,6 +221,7 @@ describe('TestShake', () => {
       module: mockCloseLatchHeaterShaker,
       setCurrentPage: jest.fn(),
       moduleFromProtocol: undefined,
+      isLoadedInRun: false,
     }
 
     const { getByRole } = render(props)
@@ -256,6 +260,7 @@ describe('TestShake', () => {
       module: mockOpenLatchHeaterShaker,
       setCurrentPage: jest.fn(),
       moduleFromProtocol: undefined,
+      isLoadedInRun: false,
     }
 
     mockUseLatchControls.mockReturnValue({
@@ -273,6 +278,7 @@ describe('TestShake', () => {
       module: mockCloseLatchHeaterShaker,
       setCurrentPage: jest.fn(),
       moduleFromProtocol: undefined,
+      isLoadedInRun: false,
     }
 
     mockUseLatchControls.mockReturnValue({
@@ -291,6 +297,7 @@ describe('TestShake', () => {
       module: mockOpenLatchHeaterShaker,
       setCurrentPage: jest.fn(),
       moduleFromProtocol: undefined,
+      isLoadedInRun: false,
     }
 
     mockUseLatchControls.mockReturnValue({
@@ -309,6 +316,7 @@ describe('TestShake', () => {
       module: mockCloseLatchHeaterShaker,
       setCurrentPage: jest.fn(),
       moduleFromProtocol: undefined,
+      isLoadedInRun: false,
     }
 
     const { getByRole } = render(props)
@@ -333,6 +341,7 @@ describe('TestShake', () => {
       module: mockMovingHeaterShaker,
       setCurrentPage: jest.fn(),
       moduleFromProtocol: undefined,
+      isLoadedInRun: false,
     }
 
     const { getByRole } = render(props)
@@ -351,19 +360,20 @@ describe('TestShake', () => {
     })
   })
 
-  it('renders protocol with runId and entering an input for shake speed and clicking start should begin shaking', () => {
-    props = {
-      module: mockCloseLatchHeaterShaker,
-      setCurrentPage: jest.fn(),
-      moduleFromProtocol: HEATER_SHAKER_PROTOCOL_MODULE_INFO,
-      currentRunId: RUN_ID_1,
-    }
+  it.only('renders protocol with runId and entering an input for shake speed and clicking start should begin shaking when run is idle', () => {
     mockUseRunStatuses.mockReturnValue({
       isLegacySessionInProgress: false,
       isRunStill: true,
       isRunTerminal: false,
       isRunIdle: true,
     })
+    props = {
+      module: mockHeaterShaker,
+      setCurrentPage: jest.fn(),
+      moduleFromProtocol: HEATER_SHAKER_PROTOCOL_MODULE_INFO,
+      currentRunId: RUN_ID_1,
+      isLoadedInRun: true,
+    }
     const { getByRole } = render(props)
     const button = getByRole('button', { name: /Start Shaking/i })
     const input = getByRole('spinbutton')
@@ -371,6 +381,7 @@ describe('TestShake', () => {
     fireEvent.click(button)
 
     expect(mockCreateCommand).toHaveBeenCalledWith({
+      runId: RUN_ID_1,
       command: {
         commandType: 'heaterShaker/setAndWaitForShakeSpeed',
         params: {
@@ -378,7 +389,39 @@ describe('TestShake', () => {
           rpm: 300,
         },
       },
-      runId: RUN_ID_1,
+    })
+  })
+
+  it('entering an input for shake speed and clicking start should begin shaking when there is a runId and run is terminal', () => {
+    mockUseRunStatuses.mockReturnValue({
+      isLegacySessionInProgress: false,
+      isRunStill: false,
+      isRunTerminal: true,
+      isRunIdle: false,
+    })
+
+    props = {
+      module: mockHeaterShaker,
+      setCurrentPage: jest.fn(),
+      moduleFromProtocol: HEATER_SHAKER_PROTOCOL_MODULE_INFO,
+      currentRunId: RUN_ID_1,
+      isLoadedInRun: true,
+    }
+
+    const { getByRole } = render(props)
+    const button = getByRole('button', { name: /Start Shaking/i })
+    const input = getByRole('spinbutton')
+    fireEvent.change(input, { target: { value: '300' } })
+    fireEvent.click(button)
+
+    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
+      command: {
+        commandType: 'heaterShaker/setAndWaitForShakeSpeed',
+        params: {
+          moduleId: 'heatershaker_id',
+          rpm: 300,
+        },
+      },
     })
   })
 })

--- a/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
@@ -30,6 +30,7 @@ import type { ProtocolModuleInfo } from '../../Devices/ProtocolRun/utils/getProt
 
 interface HeaterShakerWizardProps {
   onCloseClick: () => unknown
+  isLoadedInRun: boolean
   moduleFromProtocol?: ProtocolModuleInfo
   currentRunId?: string
 }
@@ -37,7 +38,12 @@ interface HeaterShakerWizardProps {
 export const HeaterShakerWizard = (
   props: HeaterShakerWizardProps
 ): JSX.Element | null => {
-  const { onCloseClick, moduleFromProtocol, currentRunId } = props
+  const {
+    onCloseClick,
+    isLoadedInRun,
+    moduleFromProtocol,
+    currentRunId,
+  } = props
   const { t } = useTranslation(['heater_shaker', 'shared'])
   const [currentPage, setCurrentPage] = React.useState(0)
   const { robotName } = useParams<NavRouteParams>()
@@ -96,23 +102,22 @@ export const HeaterShakerWizard = (
           heaterShaker != null ? (
             <AttachAdapter
               module={heaterShaker}
+              isLoadedInRun={isLoadedInRun}
               currentRunId={currentRunId != null ? currentRunId : undefined}
             />
           ) : null
         )
       case 5:
         buttonContent = t('complete')
-        return (
-          // heaterShaker should never be null because isPrimaryCTAEnabled would be disabled otherwise
-          heaterShaker != null ? (
-            <TestShake
-              module={heaterShaker}
-              setCurrentPage={setCurrentPage}
-              moduleFromProtocol={moduleFromProtocol}
-              currentRunId={currentRunId != null ? currentRunId : undefined}
-            />
-          ) : null
-        )
+        return heaterShaker != null ? (
+          <TestShake
+            module={heaterShaker}
+            setCurrentPage={setCurrentPage}
+            isLoadedInRun={isLoadedInRun}
+            moduleFromProtocol={moduleFromProtocol}
+            currentRunId={currentRunId != null ? currentRunId : undefined}
+          />
+        ) : null
       default:
         return null
     }

--- a/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
@@ -7,6 +7,7 @@ import { Interstitial } from '../../../atoms/Interstitial/Interstitial'
 import { HEATERSHAKER_MODULE_TYPE } from '../../../redux/modules'
 import { PrimaryButton, SecondaryButton } from '../../../atoms/buttons'
 import { Tooltip } from '../../../atoms/Tooltip'
+import { useCurrentRunId } from '../../ProtocolUpload/hooks'
 import { useAttachedModules } from '../hooks'
 import { Introduction } from './Introduction'
 import { KeyParts } from './KeyParts'
@@ -30,13 +31,13 @@ import type { ProtocolModuleInfo } from '../../Devices/ProtocolRun/utils/getProt
 interface HeaterShakerWizardProps {
   onCloseClick: () => unknown
   moduleFromProtocol?: ProtocolModuleInfo
-  runId?: string
+  currentRunId?: string
 }
 
 export const HeaterShakerWizard = (
   props: HeaterShakerWizardProps
 ): JSX.Element | null => {
-  const { onCloseClick, moduleFromProtocol, runId } = props
+  const { onCloseClick, moduleFromProtocol, currentRunId } = props
   const { t } = useTranslation(['heater_shaker', 'shared'])
   const [currentPage, setCurrentPage] = React.useState(0)
   const { robotName } = useParams<NavRouteParams>()
@@ -93,7 +94,10 @@ export const HeaterShakerWizard = (
         return (
           // heaterShaker should never be null because isPrimaryCTAEnabled would be disabled otherwise
           heaterShaker != null ? (
-            <AttachAdapter module={heaterShaker} runId={runId} />
+            <AttachAdapter
+              module={heaterShaker}
+              currentRunId={currentRunId != null ? currentRunId : undefined}
+            />
           ) : null
         )
       case 5:
@@ -105,7 +109,7 @@ export const HeaterShakerWizard = (
               module={heaterShaker}
               setCurrentPage={setCurrentPage}
               moduleFromProtocol={moduleFromProtocol}
-              runId={runId}
+              currentRunId={currentRunId != null ? currentRunId : undefined}
             />
           ) : null
         )

--- a/app/src/organisms/Devices/ProtocolRun/SetupModules.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModules.tsx
@@ -91,7 +91,6 @@ export const SetupModules = ({
         <HeaterShakerBanner
           displayName={heaterShakerModules[0]?.moduleDef.displayName}
           modules={heaterShakerModules}
-          runId={runId}
         />
       ) : null}
       {showMultipleModulesModal ? (

--- a/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
+++ b/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
@@ -60,38 +60,36 @@ export const ModuleOverflowMenu = (
   }
 
   return (
-    <>
-      <Flex position={POSITION_RELATIVE}>
-        <MenuList
-          buttons={[
-            (menuOverflowItemsByModuleType[
-              module.moduleType
-            ] as MenuItemsByModuleType[ModuleType]).map(
-              (item: any, index: number) => {
-                return (
-                  <React.Fragment key={`${index}_${module.moduleType}`}>
-                    <MenuItem
-                      key={`${index}_${module.moduleModel}`}
-                      onClick={() => item.onClick(item.isSecondary)}
-                      data-testid={`module_setting_${module.moduleModel}`}
-                      disabled={item.disabledReason || isDisabled}
-                      {...targetProps}
-                    >
-                      {item.setSetting}
-                    </MenuItem>
-                    {item.disabledReason && (
-                      <Tooltip tooltipProps={tooltipProps}>
-                        {t('cannot_shake', { ns: 'heater_shaker' })}
-                      </Tooltip>
-                    )}
-                    {item.menuButtons}
-                  </React.Fragment>
-                )
-              }
-            ),
-          ]}
-        />
-      </Flex>
-    </>
+    <Flex position={POSITION_RELATIVE}>
+      <MenuList
+        buttons={[
+          (menuOverflowItemsByModuleType[
+            module.moduleType
+          ] as MenuItemsByModuleType[ModuleType]).map(
+            (item: any, index: number) => {
+              return (
+                <React.Fragment key={`${index}_${module.moduleType}`}>
+                  <MenuItem
+                    key={`${index}_${module.moduleModel}`}
+                    onClick={() => item.onClick(item.isSecondary)}
+                    data-testid={`module_setting_${module.moduleModel}`}
+                    disabled={item.disabledReason || isDisabled}
+                    {...targetProps}
+                  >
+                    {item.setSetting}
+                  </MenuItem>
+                  {item.disabledReason && (
+                    <Tooltip tooltipProps={tooltipProps}>
+                      {t('heater_shaker:cannot_shake')}
+                    </Tooltip>
+                  )}
+                  {item.menuButtons}
+                </React.Fragment>
+              )
+            }
+          ),
+        ]}
+      />
+    </Flex>
   )
 }

--- a/app/src/organisms/ModuleCard/__tests__/hooks.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/hooks.test.tsx
@@ -234,9 +234,12 @@ describe('useLatchControls', () => {
     mockUseModuleIdFromRun.mockReturnValue({
       moduleIdFromRun: 'heatershaker_id',
     })
-    const { result } = renderHook(() => useLatchControls(mockHeaterShaker), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () => useLatchControls(mockHeaterShaker, false),
+      {
+        wrapper,
+      }
+    )
     const { isLatchClosed } = result.current
 
     expect(isLatchClosed).toBe(false)
@@ -257,7 +260,33 @@ describe('useLatchControls', () => {
       </I18nextProvider>
     )
     const { result } = renderHook(
-      () => useLatchControls(mockCloseLatchHeaterShaker),
+      () => useLatchControls(mockCloseLatchHeaterShaker, false),
+      {
+        wrapper,
+      }
+    )
+    const { isLatchClosed } = result.current
+
+    expect(isLatchClosed).toBe(true)
+    act(() => result.current.toggleLatch())
+    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
+      command: {
+        commandType: 'heaterShaker/openLabwareLatch',
+        params: {
+          moduleId: mockCloseLatchHeaterShaker.id,
+        },
+      },
+    })
+  })
+
+  it('should return if latch is close and handle latch function to open latch when runId is not null', () => {
+    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+      <I18nextProvider i18n={i18n}>
+        <Provider store={store}>{children}</Provider>
+      </I18nextProvider>
+    )
+    const { result } = renderHook(
+      () => useLatchControls(mockCloseLatchHeaterShaker, false),
       {
         wrapper,
       }

--- a/app/src/organisms/ModuleCard/hooks.tsx
+++ b/app/src/organisms/ModuleCard/hooks.tsx
@@ -30,7 +30,10 @@ import type {
   TemperatureModuleDeactivateCreateCommand,
 } from '@opentrons/shared-data/protocol/types/schemaV6/command/module'
 
-import type { AttachedModule } from '../../redux/modules/types'
+import type {
+  AttachedModule,
+  HeaterShakerModule,
+} from '../../redux/modules/types'
 
 export function useIsHeaterShakerInProtocol(): boolean {
   const currentRunId = useCurrentRunId()
@@ -50,23 +53,22 @@ interface LatchControls {
 }
 
 export function useLatchControls(
-  module: AttachedModule,
+  module: HeaterShakerModule,
   isLoadedInRun: boolean,
-  runId?: string | null
+  currentRunId?: string | null
 ): LatchControls {
   const { createLiveCommand } = useCreateLiveCommandMutation()
   const { createCommand } = useCreateCommandMutation()
-  const currentRunId = useCurrentRunId()
   const { isRunTerminal, isRunIdle } = useRunStatuses()
 
-  // const { moduleIdFromRun } = useModuleIdFromRun(
-  //   module,
-  //   currentRunId != null ? currentRunId : null
-  // )
+  const { moduleIdFromRun } = useModuleIdFromRun(
+    module,
+    currentRunId != null ? currentRunId : null
+  )
 
   let moduleId: string | null = null
   if (isRunIdle && currentRunId != null && isLoadedInRun) {
-    moduleId = '123'
+    moduleId = moduleIdFromRun
   } else if ((currentRunId != null && isRunTerminal) || currentRunId == null) {
     moduleId = module.id
   }
@@ -94,7 +96,7 @@ export function useLatchControls(
         command: latchCommand,
       }).catch((e: Error) => {
         console.error(
-          `error setting module status with command type ${latchCommand.commandType} and run id ${runId}: ${e.message}`
+          `error setting module status with command type ${latchCommand.commandType} and run id ${currentRunId}: ${e.message}`
         )
       })
     } else if (
@@ -147,7 +149,7 @@ export function useModuleOverflowMenu(
   const { createCommand } = useCreateCommandMutation()
   const currentRunId = useCurrentRunId()
   const { toggleLatch, isLatchClosed } = useLatchControls(
-    module,
+    module as HeaterShakerModule,
     isLoadedInRun,
     currentRunId
   )

--- a/app/src/organisms/ModuleCard/index.tsx
+++ b/app/src/organisms/ModuleCard/index.tsx
@@ -218,6 +218,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
     setShowWizard(true)
   }
 
+
   return (
     <Flex
       backgroundColor={COLORS.background}
@@ -227,10 +228,10 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
       data-testid={`ModuleCard_${module.serialNumber}`}
     >
       {showWizard &&
-        (runId != null ? (
+        (currentRunId != null ? (
           <HeaterShakerWizard
             onCloseClick={() => setShowWizard(false)}
-            runId={runId}
+            currentRunId={currentRunId}
           />
         ) : (
           <HeaterShakerWizard onCloseClick={() => setShowWizard(false)} />
@@ -258,7 +259,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
           module={module as HeaterShakerModule}
           isExpanded={showTestShake}
           onCloseClick={() => setShowTestShake(false)}
-          runId={runId}
+          runId={currentRunId != null ? currentRunId : undefined}
         />
       )}
       <Box padding={`${SPACING.spacing4} ${SPACING.spacing3}`} width="100%">

--- a/app/src/organisms/ModuleCard/index.tsx
+++ b/app/src/organisms/ModuleCard/index.tsx
@@ -218,7 +218,6 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
     setShowWizard(true)
   }
 
-
   return (
     <Flex
       backgroundColor={COLORS.background}
@@ -231,10 +230,14 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
         (currentRunId != null ? (
           <HeaterShakerWizard
             onCloseClick={() => setShowWizard(false)}
+            isLoadedInRun={false}
             currentRunId={currentRunId}
           />
         ) : (
-          <HeaterShakerWizard onCloseClick={() => setShowWizard(false)} />
+          <HeaterShakerWizard
+            onCloseClick={() => setShowWizard(false)}
+            isLoadedInRun={false}
+          />
         ))}
       {showSlideout && (
         <ModuleSlideout
@@ -259,7 +262,8 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
           module={module as HeaterShakerModule}
           isExpanded={showTestShake}
           onCloseClick={() => setShowTestShake(false)}
-          runId={currentRunId != null ? currentRunId : undefined}
+          isLoadedInRun={isLoadedInRun}
+          currentRunId={currentRunId != null ? currentRunId : undefined}
         />
       )}
       <Box padding={`${SPACING.spacing4} ${SPACING.spacing3}`} width="100%">

--- a/app/src/organisms/ModuleCard/useModuleIdFromRun.ts
+++ b/app/src/organisms/ModuleCard/useModuleIdFromRun.ts
@@ -1,6 +1,6 @@
 import { useAttachedModules, useProtocolDetailsForRun } from '../Devices/hooks'
-import type { AttachedModule } from '../../redux/modules/types'
 import { getModuleDef2 } from '@opentrons/shared-data'
+import type { AttachedModule } from '../../redux/modules/types'
 
 export interface ModuleIdFromRun {
   moduleIdFromRun: string

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/HeaterShakerBanner.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/HeaterShakerBanner.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { COLORS } from '@opentrons/components'
 import { Divider } from '../../../../../atoms/structure/Divider'
+import { useCurrentRunId } from '../../../../ProtocolUpload/hooks'
 import { HeaterShakerWizard } from '../../../../Devices/HeaterShakerWizard'
 import { ModuleRenderInfoForProtocol } from '../../../../Devices/hooks'
 import { Banner, BannerItem } from '../Banner/Banner'
@@ -9,14 +10,14 @@ import { Banner, BannerItem } from '../Banner/Banner'
 interface HeaterShakerBannerProps {
   displayName: string
   modules: ModuleRenderInfoForProtocol[]
-  runId: string
 }
 
 export function HeaterShakerBanner(
   props: HeaterShakerBannerProps
 ): JSX.Element | null {
   const [showWizard, setShowWizard] = React.useState(false)
-  const { displayName, modules, runId } = props
+  const { displayName, modules } = props
+  const currentRunId = useCurrentRunId()
   const { t } = useTranslation('heater_shaker')
   return (
     <Banner title={t('attach_heater_shaker_to_deck', { name: displayName })}>
@@ -26,7 +27,7 @@ export function HeaterShakerBanner(
             <HeaterShakerWizard
               onCloseClick={() => setShowWizard(false)}
               moduleFromProtocol={module}
-              runId={runId}
+              currentRunId={currentRunId != null ? currentRunId : undefined}
             />
           )}
           {index > 0 && <Divider color={COLORS.medGrey} />}

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/HeaterShakerBanner.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/HeaterShakerBanner.tsx
@@ -28,6 +28,7 @@ export function HeaterShakerBanner(
               onCloseClick={() => setShowWizard(false)}
               moduleFromProtocol={module}
               currentRunId={currentRunId != null ? currentRunId : undefined}
+              isLoadedInRun={true}
             />
           )}
           {index > 0 && <Divider color={COLORS.medGrey} />}


### PR DESCRIPTION
closes #11179

# Overview

Refactor logic in `useLabwareLatch` and throughout the H-S wizard, particularly the `testShake` and `attachAdapter` components

# Changelog

- refactor logic so sending labware latch and shake commands via the wizard accessed on `pipettes and modules` section of the module cards works when the run has not started

# Review requests

- load a protocol but don't start it. The wizard accessed through the `pipettes and modules` module cards should work and pressing the latch button on the `attachAdapter` page should work. And pressing the buttons on the `testShake` page should work as well
- the wizard should work as expected when accessed during protocol setup
- wizard should work as expected when accessed via module controls when a run is still (in terminal state or has not started)

# Risk assessment

low