### PR TITLE
[WIP] refactor(app): Refactor Robotsettings Calibrationtab for isBobotBusy

### DIFF
--- a/app/src/organisms/Devices/RobotSettings/CalibrationDetails/OverflowMenu.tsx
+++ b/app/src/organisms/Devices/RobotSettings/CalibrationDetails/OverflowMenu.tsx
@@ -210,7 +210,7 @@ export function OverflowMenu({
       {showOverflowMenu ? (
         <Flex
           ref={calsOverflowWrapperRef}
-          width={calType === 'pipetteOffset' ? '11.5rem' : '17.25rem'}
+          whiteSpace="nowrap"
           zIndex={10}
           borderRadius={'4px 4px 0px 0px'}
           boxShadow={'0px 1px 3px rgba(0, 0, 0, 0.2)'}

--- a/app/src/organisms/Devices/RobotSettings/CalibrationDetails/OverflowMenu.tsx
+++ b/app/src/organisms/Devices/RobotSettings/CalibrationDetails/OverflowMenu.tsx
@@ -28,7 +28,6 @@ import { useTrackEvent } from '../../../../redux/analytics'
 import { EVENT_CALIBRATION_DOWNLOADED } from '../../../../redux/calibration'
 import {
   useDeckCalibrationData,
-  useIsRobotBusy,
   usePipetteOffsetCalibrations,
   useTipLengthCalibrations,
 } from '../../hooks'
@@ -53,7 +52,7 @@ interface OverflowMenuProps {
   robotName: string
   mount: Mount
   serialNumber: string | null
-  updateRobotStatus: (isRobotBusy: boolean) => void
+  isRobotBusy: boolean
 }
 
 export function OverflowMenu({
@@ -61,7 +60,7 @@ export function OverflowMenu({
   robotName,
   mount,
   serialNumber,
-  updateRobotStatus,
+  isRobotBusy,
 }: OverflowMenuProps): JSX.Element {
   const { t } = useTranslation('device_settings')
   const doTrackEvent = useTrackEvent()
@@ -88,7 +87,6 @@ export function OverflowMenu({
     calBlockModalState,
     setCalBlockModalState,
   ] = React.useState<CalBlockModalState>(CAL_BLOCK_MODAL_CLOSED)
-  const isBusy = useIsRobotBusy()
 
   interface StartWizardOptions {
     keepTipLength: boolean
@@ -136,9 +134,7 @@ export function OverflowMenu({
     e: React.MouseEvent
   ): void => {
     e.preventDefault()
-    if (isBusy) {
-      updateRobotStatus(true)
-    } else {
+    if (!isRobotBusy) {
       if (calType === 'pipetteOffset') {
         if (applicablePipetteOffsetCal != null) {
           // recalibrate pipette offset
@@ -224,7 +220,10 @@ export function OverflowMenu({
           right={0}
           flexDirection={DIRECTION_COLUMN}
         >
-          <MenuItem onClick={e => handleCalibration(calType, e)}>
+          <MenuItem
+            onClick={e => handleCalibration(calType, e)}
+            disabled={isRobotBusy}
+          >
             {calType === 'pipetteOffset'
               ? applicablePipetteOffsetCal != null
                 ? t('overflow_menu_recalibrate_pipette')

--- a/app/src/organisms/Devices/RobotSettings/CalibrationDetails/PipetteOffsetCalibrationItems.tsx
+++ b/app/src/organisms/Devices/RobotSettings/CalibrationDetails/PipetteOffsetCalibrationItems.tsx
@@ -48,13 +48,13 @@ const BODY_STYLE = css`
 interface PipetteOffsetCalibrationItemsProps {
   robotName: string
   formattedPipetteOffsetCalibrations: FormattedPipetteOffsetCalibration[]
-  updateRobotStatus: (isRobotBusy: boolean) => void
+  isRobotBusy: boolean
 }
 
 export function PipetteOffsetCalibrationItems({
   robotName,
   formattedPipetteOffsetCalibrations,
-  updateRobotStatus,
+  isRobotBusy,
 }: PipetteOffsetCalibrationItemsProps): JSX.Element {
   const { t } = useTranslation('device_settings')
 
@@ -159,7 +159,7 @@ export function PipetteOffsetCalibrationItems({
                     robotName={robotName}
                     mount={calibration.mount}
                     serialNumber={calibration.serialNumber ?? null}
-                    updateRobotStatus={updateRobotStatus}
+                    isRobotBusy={isRobotBusy}
                   />
                 </StyledTableCell>
               </StyledTableRow>

--- a/app/src/organisms/Devices/RobotSettings/CalibrationDetails/TipLengthCalibrationItems.tsx
+++ b/app/src/organisms/Devices/RobotSettings/CalibrationDetails/TipLengthCalibrationItems.tsx
@@ -50,14 +50,14 @@ interface TipLengthCalibrationItemsProps {
   robotName: string
   formattedPipetteOffsetCalibrations: FormattedPipetteOffsetCalibration[]
   formattedTipLengthCalibrations: FormattedTipLengthCalibration[]
-  updateRobotStatus: (isRobotBusy: boolean) => void
+  isRobotBusy: boolean
 }
 
 export function TipLengthCalibrationItems({
   robotName,
   formattedPipetteOffsetCalibrations,
   formattedTipLengthCalibrations,
-  updateRobotStatus,
+  isRobotBusy,
 }: TipLengthCalibrationItemsProps): JSX.Element {
   const { t } = useTranslation('device_settings')
   const customLabwareDefs = useSelector((state: State) => {
@@ -133,7 +133,7 @@ export function TipLengthCalibrationItems({
                     ? calibration.mount
                     : checkMountWithAttachedPipettes(calibration.serialNumber)
                 }
-                updateRobotStatus={updateRobotStatus}
+                isRobotBusy={isRobotBusy}
               />
             </StyledTableCell>
           </StyledTableRow>

--- a/app/src/organisms/Devices/RobotSettings/CalibrationDetails/__test__/OverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/CalibrationDetails/__test__/OverflowMenu.test.tsx
@@ -7,7 +7,7 @@ import { renderWithProviders, Mount } from '@opentrons/components'
 import { i18n } from '../../../../../i18n'
 import { mockDeckCalData } from '../../../../../redux/calibration/__fixtures__'
 import { useCalibratePipetteOffset } from '../../../../CalibratePipetteOffset/useCalibratePipetteOffset'
-import { useDeckCalibrationData, useIsRobotBusy } from '../../../hooks'
+import { useDeckCalibrationData } from '../../../hooks'
 
 import { OverflowMenu } from '../OverflowMenu'
 
@@ -36,14 +36,9 @@ jest.mock('../../../hooks')
 const mockUseCalibratePipetteOffset = useCalibratePipetteOffset as jest.MockedFunction<
   typeof useCalibratePipetteOffset
 >
-const mockUseIsRobotBusy = useIsRobotBusy as jest.MockedFunction<
-  typeof useIsRobotBusy
->
 const mockUseDeckCalibrationData = useDeckCalibrationData as jest.MockedFunction<
   typeof useDeckCalibrationData
 >
-
-const mockUpdateRobotStatus = jest.fn()
 
 describe('OverflowMenu', () => {
   let props: React.ComponentProps<typeof OverflowMenu>
@@ -54,10 +49,9 @@ describe('OverflowMenu', () => {
       robotName: ROBOT_NAME,
       mount: 'left' as Mount,
       serialNumber: 'serialNumber',
-      updateRobotStatus: mockUpdateRobotStatus,
+      isRobotBusy: false,
     }
     mockUseCalibratePipetteOffset.mockReturnValue([startCalibration, null])
-    mockUseIsRobotBusy.mockReturnValue(false)
     mockUseDeckCalibrationData.mockReturnValue({
       isDeckCalibrated: true,
       deckCalibrationData: mockDeckCalData,
@@ -142,28 +136,29 @@ describe('OverflowMenu', () => {
   })
 
   it('should call update robot status if a robot is busy - pipette offset', () => {
-    mockUseIsRobotBusy.mockReturnValue(true)
+    props = {
+      ...props,
+      isRobotBusy: true,
+    }
     const [{ getByText, getByLabelText }] = render(props)
     const button = getByLabelText('CalibrationOverflowMenu_button')
     fireEvent.click(button)
     const calibrationButton = getByText('Calibrate Pipette Offset')
-    fireEvent.click(calibrationButton)
-    expect(mockUpdateRobotStatus).toHaveBeenCalled()
+    expect(calibrationButton).toBeDisabled()
   })
 
   it('should call update robot status if a robot is busy - tip length', () => {
     props = {
       ...props,
       calType: 'tipLength',
+      isRobotBusy: true,
     }
-    mockUseIsRobotBusy.mockReturnValue(true)
     const [{ getByText, getByLabelText }] = render(props)
     const button = getByLabelText('CalibrationOverflowMenu_button')
     fireEvent.click(button)
     const calibrationButton = getByText(
       'Recalibrate Tip Length and Pipette Offset'
     )
-    fireEvent.click(calibrationButton)
-    expect(mockUpdateRobotStatus).toHaveBeenCalled()
+    expect(calibrationButton).toBeDisabled()
   })
 })

--- a/app/src/organisms/Devices/RobotSettings/CalibrationDetails/__test__/PipetteOffsetCalibrationItems.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/CalibrationDetails/__test__/PipetteOffsetCalibrationItems.test.tsx
@@ -50,7 +50,7 @@ const mockAttachedPipettes: AttachedPipettesByMount = {
   left: mockAttachedPipette,
   right: mockAttachedPipette,
 } as any
-const mockUpdateRobotStatus = jest.fn()
+
 const mockUseAttachedPipettes = useAttachedPipettes as jest.MockedFunction<
   typeof useAttachedPipettes
 >
@@ -67,7 +67,7 @@ describe('PipetteOffsetCalibrationItems', () => {
     props = {
       robotName: ROBOT_NAME,
       formattedPipetteOffsetCalibrations: mockPipetteOffsetCalibrations,
-      updateRobotStatus: mockUpdateRobotStatus,
+      isRobotBusy: false,
     }
   })
 

--- a/app/src/organisms/Devices/RobotSettings/CalibrationDetails/__test__/TipLengthCalibrationItems.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/CalibrationDetails/__test__/TipLengthCalibrationItems.test.tsx
@@ -52,8 +52,6 @@ const mockTipLengthCalibrations = [
   },
 ]
 
-const mockUpdateRobotStatus = jest.fn()
-
 const render = (
   props: React.ComponentProps<typeof TipLengthCalibrationItems>
 ): ReturnType<typeof renderWithProviders> => {
@@ -70,7 +68,7 @@ describe('TipLengthCalibrationItems', () => {
       robotName: ROBOT_NAME,
       formattedPipetteOffsetCalibrations: mockPipetteOffsetCalibrations,
       formattedTipLengthCalibrations: mockTipLengthCalibrations,
-      updateRobotStatus: mockUpdateRobotStatus,
+      isRobotBusy: false,
     }
   })
 

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
@@ -621,7 +621,7 @@ export function RobotSettingsCalibration({
           </Box>
           <TertiaryButton
             onClick={() => handleClickDeckCalibration()}
-            disabled={disabledOrBusyReason != null}
+            disabled={disabledOrBusyReason != null || isRobotBusy}
           >
             {deckCalibrationButtonText}
           </TertiaryButton>
@@ -703,11 +703,11 @@ export function RobotSettingsCalibration({
           <TertiaryButton
             {...targetProps}
             onClick={handleHealthCheckClick}
-            disabled={calCheckButtonDisabled}
+            disabled={calCheckButtonDisabled || isRobotBusy}
           >
             {t('health_check_button')}
           </TertiaryButton>
-          {calCheckButtonDisabled && (
+          {calCheckButtonDisabled && !isRobotBusy && (
             <Tooltip tooltipProps={tooltipProps}>
               {t('fully_calibrate_before_checking_health')}
             </Tooltip>

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
@@ -138,7 +138,7 @@ export function RobotSettingsCalibration({
   ] = React.useState<string>('')
   const [showCalBlockModal, setShowCalBlockModal] = React.useState(false)
   const isRunStartedOrLegacySessionInProgress = useRunStartedOrLegacySessionInProgress()
-  const isBusy = useIsRobotBusy()
+  const isRobotBusy = useIsRobotBusy({ poll: true })
 
   const robot = useRobot(robotName)
   const notConnectable = robot?.status !== CONNECTABLE
@@ -314,7 +314,7 @@ export function RobotSettingsCalibration({
   const handleHealthCheck = (
     hasBlockModalResponse: boolean | null = null
   ): void => {
-    if (isBusy) {
+    if (isRobotBusy) {
       updateRobotStatus(true)
     } else {
       if (
@@ -488,6 +488,10 @@ export function RobotSettingsCalibration({
     }
   }, [createStatus])
 
+  React.useEffect(() => {
+    updateRobotStatus(isRobotBusy)
+  }, [isRobotBusy, updateRobotStatus])
+
   // Note: following fetch need to reflect the latest state of calibrations
   // when a user does calibration or rename a robot.
   useInterval(
@@ -652,7 +656,7 @@ export function RobotSettingsCalibration({
             <PipetteOffsetCalibrationItems
               robotName={robotName}
               formattedPipetteOffsetCalibrations={formatPipetteOffsetCalibrations()}
-              updateRobotStatus={updateRobotStatus}
+              isRobotBusy={isRobotBusy}
             />
           ) : (
             <StyledText as="label">{t('not_calibrated')}</StyledText>
@@ -677,7 +681,7 @@ export function RobotSettingsCalibration({
               robotName={robotName}
               formattedPipetteOffsetCalibrations={formatPipetteOffsetCalibrations()}
               formattedTipLengthCalibrations={formatTipLengthCalibrations()}
-              updateRobotStatus={updateRobotStatus}
+              isRobotBusy={isRobotBusy}
             />
           ) : (
             <StyledText as="label">{t('not_calibrated')}</StyledText>

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsNetworking.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsNetworking.tsx
@@ -26,12 +26,13 @@ import {
   /* postWifiDisconnect, */
 } from '../../../redux/networking'
 // import * as RobotApi from '../../../redux/robot-api'
+import { useIsRobotBusy } from '../hooks'
 import { TemporarySelectNetwork } from './TemporarySelectNetwork'
 
 import type { State, Dispatch } from '../../../redux/types'
 interface NetworkingProps {
   robotName: string
-  isRobotBusy: boolean
+  updateRobotStatus: (isRobotBusy: boolean) => void
 }
 
 // ToDo kj modify ConnectModal to align with new design
@@ -43,11 +44,12 @@ const LIST_REFRESH_MS = 10000
 
 export function RobotSettingsNetworking({
   robotName,
-  isRobotBusy,
+  updateRobotStatus,
 }: NetworkingProps): JSX.Element {
   const { t } = useTranslation('device_settings')
   const list = useSelector((state: State) => getWifiList(state, robotName))
   const dispatch = useDispatch<Dispatch>()
+  const isRobotBusy = useIsRobotBusy({ poll: true })
   // const [dispatchApi] = RobotApi.useDispatchApiRequest()
 
   const { wifi, ethernet } = useSelector((state: State) =>
@@ -62,6 +64,10 @@ export function RobotSettingsNetworking({
     dispatch(fetchStatus(robotName))
     dispatch(fetchWifiList(robotName))
   }, [robotName, dispatch])
+
+  React.useEffect(() => {
+    updateRobotStatus(isRobotBusy)
+  }, [isRobotBusy, updateRobotStatus])
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN}>

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsNetworking.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsNetworking.tsx
@@ -31,10 +31,10 @@ import { TemporarySelectNetwork } from './TemporarySelectNetwork'
 import type { State, Dispatch } from '../../../redux/types'
 interface NetworkingProps {
   robotName: string
-  updateRobotStatus: (isRobotBusy: boolean) => void
+  isRobotBusy: boolean
 }
 
-// ToDo modify ConnectModal to align with new design
+// ToDo kj modify ConnectModal to align with new design
 // This is temporary until we can get the new design details
 const HELP_CENTER_URL =
   'https://support.opentrons.com/s/article/Get-started-Connect-to-your-OT-2-over-USB'
@@ -43,7 +43,7 @@ const LIST_REFRESH_MS = 10000
 
 export function RobotSettingsNetworking({
   robotName,
-  updateRobotStatus,
+  isRobotBusy,
 }: NetworkingProps): JSX.Element {
   const { t } = useTranslation('device_settings')
   const list = useSelector((state: State) => getWifiList(state, robotName))
@@ -100,7 +100,7 @@ export function RobotSettingsNetworking({
               <Box width="25%" marginRight={SPACING.spacing3}>
                 <TemporarySelectNetwork
                   robotName={robotName}
-                  updateRobotStatus={updateRobotStatus}
+                  isRobotBusy={isRobotBusy}
                 />
               </Box>
             </Flex>
@@ -139,14 +139,14 @@ export function RobotSettingsNetworking({
           <Flex flexDirection={DIRECTION_COLUMN}>
             <TemporarySelectNetwork
               robotName={robotName}
-              updateRobotStatus={updateRobotStatus}
+              isRobotBusy={isRobotBusy}
             />
           </Flex>
         )}
       </Box>
       <Divider />
       <Flex marginTop={SPACING.spacing5} marginBottom={SPACING.spacing4}>
-        {ethernet !== null && ethernet.ipAddress !== null ? (
+        {ethernet?.ipAddress != null ? (
           <Icon
             size={SPACING.spacing4}
             name="ot-check"
@@ -167,7 +167,7 @@ export function RobotSettingsNetworking({
       </Flex>
       <Box paddingLeft="3.5rem">
         <Flex marginBottom={SPACING.spacing4}>
-          {ethernet !== null && ethernet.ipAddress !== null ? (
+          {ethernet?.ipAddress != null ? (
             <>
               <Flex
                 flexDirection={DIRECTION_COLUMN}

--- a/app/src/organisms/Devices/RobotSettings/TemporarySelectNetwork.tsx
+++ b/app/src/organisms/Devices/RobotSettings/TemporarySelectNetwork.tsx
@@ -11,7 +11,6 @@ import { SelectSsid } from './ConnectNetwork/SelectSsid'
 import { ConnectModal } from './ConnectNetwork/ConnectModal'
 import { DisconnectModal } from './ConnectNetwork/DisconnectModal'
 import { ResultModal } from './ConnectNetwork/ResultModal'
-import { useIsRobotBusy } from '../hooks'
 import { CONNECT, DISCONNECT, JOIN_OTHER } from './ConnectNetwork/constants'
 
 import type { State, Dispatch } from '../../../redux/types'
@@ -23,14 +22,14 @@ import type {
 
 interface TempSelectNetworkProps {
   robotName: string
-  updateRobotStatus: (isRobotBusy: boolean) => void
+  isRobotBusy: boolean
 }
 
 const LIST_REFRESH_MS = 10000
 
 export const TemporarySelectNetwork = ({
   robotName,
-  updateRobotStatus,
+  isRobotBusy,
 }: TempSelectNetworkProps): JSX.Element => {
   const list = useSelector((state: State) =>
     Networking.getWifiList(state, robotName)
@@ -47,7 +46,6 @@ export const TemporarySelectNetwork = ({
   const [changeState, setChangeState] = React.useState<NetworkChangeState>({
     type: null,
   })
-  const isBusy = useIsRobotBusy()
   const dispatch = useDispatch<Dispatch>()
   const [dispatchApi, requestIds] = RobotApi.useDispatchApiRequest()
   const requestState = useSelector((state: State) => {
@@ -85,9 +83,7 @@ export const TemporarySelectNetwork = ({
   }, [robotName, dispatch, changeState.type])
 
   const handleSelectConnect = (ssid: string): void => {
-    if (isBusy) {
-      updateRobotStatus(true)
-    } else {
+    if (!isRobotBusy) {
       const network = list.find((nw: WifiNetwork) => nw.ssid === ssid)
       if (network != null) {
         const { ssid, securityType } = network
@@ -101,18 +97,14 @@ export const TemporarySelectNetwork = ({
   }
 
   const handleSelectDisconnect = (): void => {
-    if (isBusy) {
-      updateRobotStatus(true)
-    } else {
+    if (!isRobotBusy) {
       const ssid = activeNetwork?.ssid
       ssid != null && setChangeState({ type: DISCONNECT, ssid })
     }
   }
 
   const handleSelectJoinOther = (): void => {
-    if (isBusy) {
-      updateRobotStatus(true)
-    } else {
+    if (isRobotBusy) {
       setChangeState({ type: JOIN_OTHER, ssid: null })
     }
   }
@@ -135,7 +127,7 @@ export const TemporarySelectNetwork = ({
         onJoinOther={handleSelectJoinOther}
         onDisconnect={handleSelectDisconnect}
       />
-      {changeState.type && (
+      {changeState.type != null && (
         <Portal>
           {requestState != null ? (
             <ResultModal
@@ -143,10 +135,7 @@ export const TemporarySelectNetwork = ({
               ssid={changeState.ssid}
               isPending={requestState.status === RobotApi.PENDING}
               error={
-                'error' in requestState &&
-                requestState.error &&
-                'message' in requestState.error &&
-                requestState.error.message
+                'error' in requestState && 'message' in requestState.error
                   ? requestState.error
                   : null
               }

--- a/app/src/organisms/Devices/RobotSettings/TemporarySelectNetwork.tsx
+++ b/app/src/organisms/Devices/RobotSettings/TemporarySelectNetwork.tsx
@@ -104,7 +104,7 @@ export const TemporarySelectNetwork = ({
   }
 
   const handleSelectJoinOther = (): void => {
-    if (isRobotBusy) {
+    if (!isRobotBusy) {
       setChangeState({ type: JOIN_OTHER, ssid: null })
     }
   }
@@ -127,7 +127,7 @@ export const TemporarySelectNetwork = ({
         onJoinOther={handleSelectJoinOther}
         onDisconnect={handleSelectDisconnect}
       />
-      {changeState.type != null && (
+      {changeState.type && (
         <Portal>
           {requestState != null ? (
             <ResultModal
@@ -135,7 +135,10 @@ export const TemporarySelectNetwork = ({
               ssid={changeState.ssid}
               isPending={requestState.status === RobotApi.PENDING}
               error={
-                'error' in requestState && 'message' in requestState.error
+                'error' in requestState &&
+                requestState.error &&
+                'message' in requestState.error &&
+                requestState.error.message
                   ? requestState.error
                   : null
               }

--- a/app/src/organisms/Devices/RobotSettings/__tests__/RobotSettingsCalibration.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/__tests__/RobotSettingsCalibration.test.tsx
@@ -312,8 +312,7 @@ describe('RobotSettingsCalibration', () => {
     mockUseIsRobotBusy.mockReturnValue(true)
     const [{ getByRole }] = render()
     const button = getByRole('button', { name: 'Calibrate deck' })
-    fireEvent.click(button)
-    expect(mockUpdateRobotStatus).toHaveBeenCalled()
+    expect(button).toBeDisabled()
   })
 
   it('renders the warning banner when deck calibration is not good', () => {
@@ -442,7 +441,6 @@ describe('RobotSettingsCalibration', () => {
     mockUseIsRobotBusy.mockReturnValue(true)
     const [{ getByRole }] = render()
     const button = getByRole('button', { name: 'Check health' })
-    fireEvent.click(button)
-    expect(mockUpdateRobotStatus).toHaveBeenCalled()
+    expect(button).toBeDisabled()
   })
 })

--- a/app/src/organisms/Devices/RobotSettings/__tests__/RobotSettingsNetworking.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/__tests__/RobotSettingsNetworking.test.tsx
@@ -10,6 +10,9 @@ import { RobotSettingsNetworking } from '../RobotSettingsNetworking'
 
 jest.mock('../../../../redux/networking/selectors')
 jest.mock('../../../../redux/robot-api/selectors')
+jest.mock('../../hooks')
+
+const mockUpdateRobotStatus = jest.fn()
 
 const mockGetNetworkInterfaces = Networking.getNetworkInterfaces as jest.MockedFunction<
   typeof Networking.getNetworkInterfaces
@@ -22,7 +25,10 @@ const mockGetWifiList = Networking.getWifiList as jest.MockedFunction<
 const render = () => {
   return renderWithProviders(
     <MemoryRouter>
-      <RobotSettingsNetworking robotName="otie" isRobotBusy={false} />
+      <RobotSettingsNetworking
+        robotName="otie"
+        updateRobotStatus={mockUpdateRobotStatus}
+      />
     </MemoryRouter>,
     {
       i18nInstance: i18n,

--- a/app/src/organisms/Devices/RobotSettings/__tests__/RobotSettingsNetworking.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/__tests__/RobotSettingsNetworking.test.tsx
@@ -11,8 +11,6 @@ import { RobotSettingsNetworking } from '../RobotSettingsNetworking'
 jest.mock('../../../../redux/networking/selectors')
 jest.mock('../../../../redux/robot-api/selectors')
 
-const mockUpdateRobotStatus = jest.fn()
-
 const mockGetNetworkInterfaces = Networking.getNetworkInterfaces as jest.MockedFunction<
   typeof Networking.getNetworkInterfaces
 >
@@ -24,10 +22,7 @@ const mockGetWifiList = Networking.getWifiList as jest.MockedFunction<
 const render = () => {
   return renderWithProviders(
     <MemoryRouter>
-      <RobotSettingsNetworking
-        robotName="otie"
-        updateRobotStatus={mockUpdateRobotStatus}
-      />
+      <RobotSettingsNetworking robotName="otie" isRobotBusy={false} />
     </MemoryRouter>,
     {
       i18nInstance: i18n,

--- a/app/src/organisms/Devices/RobotSettings/__tests__/TemporarySelectNetwork.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/__tests__/TemporarySelectNetwork.test.tsx
@@ -14,7 +14,6 @@ import { SelectSsid } from '../ConnectNetwork/SelectSsid'
 import { ConnectModal } from '../ConnectNetwork/ConnectModal'
 import { DisconnectModal } from '../ConnectNetwork/DisconnectModal'
 import { ResultModal } from '../ConnectNetwork/ResultModal'
-import { useIsRobotBusy } from '../../hooks'
 
 import { TemporarySelectNetwork } from '../TemporarySelectNetwork'
 
@@ -23,7 +22,6 @@ import { RequestState } from '../../../../redux/robot-api/types'
 
 jest.mock('../../../../redux/networking/selectors')
 jest.mock('../../../../redux/robot-api/selectors')
-jest.mock('../../hooks')
 
 // mock out ConnectModal to prevent warning logs from async formik
 // validation happening outside an `act`
@@ -72,9 +70,6 @@ const mockGetCanDisconnect = Networking.getCanDisconnect as jest.MockedFunction<
 const mockGetRequestById = RobotApi.getRequestById as jest.MockedFunction<
   typeof RobotApi.getRequestById
 >
-const mockUseIsRobotBusy = useIsRobotBusy as jest.MockedFunction<
-  typeof useIsRobotBusy
->
 
 describe('<TemporarySelectNetwork />', () => {
   let dispatch: any
@@ -117,8 +112,6 @@ describe('<TemporarySelectNetwork />', () => {
       expect(robotName).toEqual(mockRobotName)
       return true
     })
-
-    mockUseIsRobotBusy.mockReturnValue(false)
 
     render = () => {
       return mount(

--- a/app/src/organisms/Devices/RobotSettings/__tests__/TemporarySelectNetwork.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/__tests__/TemporarySelectNetwork.test.tsx
@@ -52,7 +52,6 @@ const mockWifiKeys = [
 ]
 
 const mockEapOptions = [Fixtures.mockEapOption]
-const mockUpdateRobotStatus = jest.fn()
 
 const mockGetWifiList = Networking.getWifiList as jest.MockedFunction<
   typeof Networking.getWifiList
@@ -125,7 +124,7 @@ describe('<TemporarySelectNetwork />', () => {
       return mount(
         <TemporarySelectNetwork
           robotName={mockRobotName}
-          updateRobotStatus={mockUpdateRobotStatus}
+          isRobotBusy={false}
         />,
         {
           wrappingComponent: Provider,

--- a/app/src/pages/Devices/RobotSettings/index.tsx
+++ b/app/src/pages/Devices/RobotSettings/index.tsx
@@ -18,7 +18,7 @@ import { ApiHostProvider } from '@opentrons/react-api-client'
 import { CONNECTABLE, UNREACHABLE, REACHABLE } from '../../../redux/discovery'
 import { StyledText } from '../../../atoms/text'
 import { Banner } from '../../../atoms/Banner'
-import { useIsRobotBusy, useRobot } from '../../../organisms/Devices/hooks'
+import { useRobot } from '../../../organisms/Devices/hooks'
 import { Line } from '../../../atoms/structure'
 import { NavTab } from '../../../atoms/NavTab'
 import { RobotSettingsCalibration } from '../../../organisms/Devices/RobotSettings/RobotSettingsCalibration'
@@ -42,8 +42,6 @@ export function RobotSettings(): JSX.Element | null {
     if (isRobotBusy) setShowRobotBusyBanner(true)
   }
 
-  const isRobotBusy = useIsRobotBusy({ poll: true })
-
   const robotSettingsContentByTab: {
     [K in RobotSettingsTab]: () => JSX.Element
   } = {
@@ -56,7 +54,7 @@ export function RobotSettings(): JSX.Element | null {
     networking: () => (
       <RobotSettingsNetworking
         robotName={robotName}
-        isRobotBusy={isRobotBusy}
+        updateRobotStatus={updateRobotStatus}
       />
     ),
     advanced: () => (

--- a/app/src/pages/Devices/RobotSettings/index.tsx
+++ b/app/src/pages/Devices/RobotSettings/index.tsx
@@ -18,7 +18,7 @@ import { ApiHostProvider } from '@opentrons/react-api-client'
 import { CONNECTABLE, UNREACHABLE, REACHABLE } from '../../../redux/discovery'
 import { StyledText } from '../../../atoms/text'
 import { Banner } from '../../../atoms/Banner'
-import { useRobot } from '../../../organisms/Devices/hooks'
+import { useIsRobotBusy, useRobot } from '../../../organisms/Devices/hooks'
 import { Line } from '../../../atoms/structure'
 import { NavTab } from '../../../atoms/NavTab'
 import { RobotSettingsCalibration } from '../../../organisms/Devices/RobotSettings/RobotSettingsCalibration'
@@ -42,6 +42,8 @@ export function RobotSettings(): JSX.Element | null {
     if (isRobotBusy) setShowRobotBusyBanner(true)
   }
 
+  const isRobotBusy = useIsRobotBusy({ poll: true })
+
   const robotSettingsContentByTab: {
     [K in RobotSettingsTab]: () => JSX.Element
   } = {
@@ -54,7 +56,7 @@ export function RobotSettings(): JSX.Element | null {
     networking: () => (
       <RobotSettingsNetworking
         robotName={robotName}
-        updateRobotStatus={updateRobotStatus}
+        isRobotBusy={isRobotBusy}
       />
     ),
     advanced: () => (


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This will fix https://github.com/Opentrons/opentrons/issues/11128's calibration tab part. This PR brings useIsRobotBusy to each RobotSettings tab and removes it from the RobotSettingCalibration child component. In addition, this can make buttons disabled when a robot is running protocol or has a session/sessions

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- add useIsRobotBusy in RobotSettingCalibration and pass boolean to pipette cal, tip length cal, and overflow menu
- add disabled state to overflow menu
- switch hard-coded width with `whiteSpace="nowrap"`
- update test case
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- [ ] When running a protocol, a banner is displayed between the title RobotSettings and the tab bar
- [ ] When running a protocol, deck cal button and check health button are disabled
- [ ] When running a protocol, Calibration button in overflow menu (pipette and tip length) is disabled
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
