### PR TITLE
refactor(app): h-S refactor module command logic in wizard to work in terminal state

### DIFF
--- a/app/src/organisms/Devices/HeaterShakerWizard/AttachAdapter.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/AttachAdapter.tsx
@@ -23,12 +23,12 @@ import type { HeaterShakerModule } from '../../../redux/modules/types'
 
 interface AttachAdapterProps {
   module: HeaterShakerModule
-  runId?: string
+  currentRunId?: string
 }
 export function AttachAdapter(props: AttachAdapterProps): JSX.Element {
-  const { module, runId } = props
+  const { module, currentRunId } = props
   const { t } = useTranslation('heater_shaker')
-  const { toggleLatch, isLatchClosed } = useLatchControls(module, runId)
+  const { toggleLatch, isLatchClosed } = useLatchControls(module, currentRunId)
   const [targetProps, tooltipProps] = useHoverTooltip()
   const isShaking = module.data.speedStatus !== 'idle'
 

--- a/app/src/organisms/Devices/HeaterShakerWizard/TestShake.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/TestShake.tsx
@@ -65,7 +65,6 @@ export function TestShake(props: TestShakeProps): JSX.Element {
   } else if ((currentRunId != null && isRunTerminal) || currentRunId == null) {
     moduleId = module.id
   }
-
   const setShakeCommand: HeaterShakerSetAndWaitForShakeSpeedCreateCommand = {
     commandType: 'heaterShaker/setAndWaitForShakeSpeed',
     params: {
@@ -80,8 +79,6 @@ export function TestShake(props: TestShakeProps): JSX.Element {
       moduleId: moduleId != null ? moduleId : '',
     },
   }
-  console.log(isRunIdle && currentRunId != null)
-  console.log(moduleId)
 
   const handleShakeCommand = (): void => {
     if (isRunIdle && currentRunId != null) {

--- a/app/src/organisms/Devices/HeaterShakerWizard/TestShake.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/TestShake.tsx
@@ -59,16 +59,15 @@ export function TestShake(props: TestShakeProps): JSX.Element {
   )
   const isShaking = module.data.speedStatus !== 'idle'
 
-  let moduleId: string | null = null
+  let moduleId: string = module.id
   if (isRunIdle && currentRunId != null) {
     moduleId = moduleIdFromRun
-  } else if ((currentRunId != null && isRunTerminal) || currentRunId == null) {
-    moduleId = module.id
   }
+
   const setShakeCommand: HeaterShakerSetAndWaitForShakeSpeedCreateCommand = {
     commandType: 'heaterShaker/setAndWaitForShakeSpeed',
     params: {
-      moduleId: moduleId != null ? moduleId : '',
+      moduleId,
       rpm: shakeValue !== null ? parseInt(shakeValue) : 0,
     },
   }
@@ -76,7 +75,7 @@ export function TestShake(props: TestShakeProps): JSX.Element {
   const stopShakeCommand: HeaterShakerDeactivateShakerCreateCommand = {
     commandType: 'heaterShaker/deactivateShaker',
     params: {
-      moduleId: moduleId != null ? moduleId : '',
+      moduleId,
     },
   }
 

--- a/app/src/organisms/Devices/HeaterShakerWizard/TestShake.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/TestShake.tsx
@@ -53,10 +53,7 @@ export function TestShake(props: TestShakeProps): JSX.Element {
   const [shakeValue, setShakeValue] = React.useState<string | null>(null)
   const [targetProps, tooltipProps] = useHoverTooltip()
   const { toggleLatch, isLatchClosed } = useLatchControls(module, currentRunId)
-  const { moduleIdFromRun } = useModuleIdFromRun(
-    module,
-    currentRunId != null ? currentRunId : null
-  )
+  const { moduleIdFromRun } = useModuleIdFromRun(module, currentRunId ?? null)
   const isShaking = module.data.speedStatus !== 'idle'
 
   const setShakeCommand: HeaterShakerSetAndWaitForShakeSpeedCreateCommand = {

--- a/app/src/organisms/Devices/HeaterShakerWizard/TestShake.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/TestShake.tsx
@@ -26,7 +26,7 @@ import { InputField } from '../../../atoms/InputField'
 import { Collapsible } from '../../ModuleCard/Collapsible'
 import { useLatchControls } from '../../ModuleCard/hooks'
 import { useModuleIdFromRun } from '../../ModuleCard/useModuleIdFromRun'
-
+import { useRunStatuses } from '../hooks'
 import { HeaterShakerModuleCard } from './HeaterShakerModuleCard'
 
 import type { HeaterShakerModule } from '../../../redux/modules/types'
@@ -40,28 +40,36 @@ interface TestShakeProps {
   module: HeaterShakerModule
   setCurrentPage: React.Dispatch<React.SetStateAction<number>>
   moduleFromProtocol?: ProtocolModuleInfo
-  runId?: string
+  currentRunId?: string
 }
 
 export function TestShake(props: TestShakeProps): JSX.Element {
-  const { module, setCurrentPage, moduleFromProtocol, runId } = props
+  const { module, setCurrentPage, moduleFromProtocol, currentRunId } = props
   const { t } = useTranslation(['heater_shaker', 'device_details'])
   const { createLiveCommand } = useCreateLiveCommandMutation()
   const { createCommand } = useCreateCommandMutation()
   const [isExpanded, setExpanded] = React.useState(false)
+  const { isRunIdle, isRunTerminal } = useRunStatuses()
   const [shakeValue, setShakeValue] = React.useState<string | null>(null)
   const [targetProps, tooltipProps] = useHoverTooltip()
-  const { toggleLatch, isLatchClosed } = useLatchControls(module, runId)
+  const { toggleLatch, isLatchClosed } = useLatchControls(module, currentRunId)
   const { moduleIdFromRun } = useModuleIdFromRun(
     module,
-    runId != null ? runId : null
+    currentRunId != null ? currentRunId : null
   )
   const isShaking = module.data.speedStatus !== 'idle'
+
+  let moduleId: string | null = null
+  if (isRunIdle && currentRunId != null) {
+    moduleId = moduleIdFromRun
+  } else if ((currentRunId != null && isRunTerminal) || currentRunId == null) {
+    moduleId = module.id
+  }
 
   const setShakeCommand: HeaterShakerSetAndWaitForShakeSpeedCreateCommand = {
     commandType: 'heaterShaker/setAndWaitForShakeSpeed',
     params: {
-      moduleId: runId != null ? moduleIdFromRun : module.id,
+      moduleId: moduleId != null ? moduleId : '',
       rpm: shakeValue !== null ? parseInt(shakeValue) : 0,
     },
   }
@@ -69,23 +77,28 @@ export function TestShake(props: TestShakeProps): JSX.Element {
   const stopShakeCommand: HeaterShakerDeactivateShakerCreateCommand = {
     commandType: 'heaterShaker/deactivateShaker',
     params: {
-      moduleId: runId != null ? moduleIdFromRun : module.id,
+      moduleId: moduleId != null ? moduleId : '',
     },
   }
+  console.log(isRunIdle && currentRunId != null)
+  console.log(moduleId)
 
   const handleShakeCommand = (): void => {
-    if (runId != null) {
+    if (isRunIdle && currentRunId != null) {
       createCommand({
-        runId: runId,
+        runId: currentRunId,
         command: isShaking ? stopShakeCommand : setShakeCommand,
       }).catch((e: Error) => {
         console.error(
           `error setting module status with command type ${
             stopShakeCommand.commandType ?? setShakeCommand.commandType
-          } and run id ${runId}: ${e.message}`
+          }: ${e.message}`
         )
       })
-    } else {
+    } else if (
+      (currentRunId != null && isRunTerminal) ||
+      currentRunId == null
+    ) {
       createLiveCommand({
         command: isShaking ? stopShakeCommand : setShakeCommand,
       }).catch((e: Error) => {

--- a/app/src/organisms/Devices/HeaterShakerWizard/TestShake.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/TestShake.tsx
@@ -59,15 +59,10 @@ export function TestShake(props: TestShakeProps): JSX.Element {
   )
   const isShaking = module.data.speedStatus !== 'idle'
 
-  let moduleId: string = module.id
-  if (isRunIdle && currentRunId != null) {
-    moduleId = moduleIdFromRun
-  }
-
   const setShakeCommand: HeaterShakerSetAndWaitForShakeSpeedCreateCommand = {
     commandType: 'heaterShaker/setAndWaitForShakeSpeed',
     params: {
-      moduleId,
+      moduleId: isRunIdle ? moduleIdFromRun : module.id,
       rpm: shakeValue !== null ? parseInt(shakeValue) : 0,
     },
   }
@@ -75,7 +70,7 @@ export function TestShake(props: TestShakeProps): JSX.Element {
   const stopShakeCommand: HeaterShakerDeactivateShakerCreateCommand = {
     commandType: 'heaterShaker/deactivateShaker',
     params: {
-      moduleId,
+      moduleId: isRunIdle ? moduleIdFromRun : module.id,
     },
   }
 
@@ -91,10 +86,7 @@ export function TestShake(props: TestShakeProps): JSX.Element {
           }: ${e.message}`
         )
       })
-    } else if (
-      (currentRunId != null && isRunTerminal) ||
-      currentRunId == null
-    ) {
+    } else if (isRunTerminal || currentRunId == null) {
       createLiveCommand({
         command: isShaking ? stopShakeCommand : setShakeCommand,
       }).catch((e: Error) => {

--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/AttachAdapter.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/AttachAdapter.test.tsx
@@ -5,6 +5,7 @@ import { i18n } from '../../../../i18n'
 import { mockHeaterShaker } from '../../../../redux/modules/__fixtures__'
 import { AttachAdapter } from '../AttachAdapter'
 import { useLatchControls } from '../../../ModuleCard/hooks'
+import { RUN_ID_1 } from '../../../RunTimeControl/__fixtures__'
 import type { HeaterShakerModule } from '../../../../redux/modules/types'
 
 jest.mock('../../../ModuleCard/hooks')
@@ -98,5 +99,15 @@ describe('AttachAdapter', () => {
     const { getByRole } = render(props)
     const btn = getByRole('button', { name: 'Open Labware Latch' })
     expect(btn).toBeDisabled()
+  })
+  it('renders button and clicking on it sends latch command to open when a run id is present', () => {
+    props = {
+      module: mockHeaterShaker,
+      currentRunId: RUN_ID_1,
+    }
+    const { getByRole } = render(props)
+    const btn = getByRole('button', { name: 'Open Labware Latch' })
+    fireEvent.click(btn)
+    expect(mockUseLatchControls).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/AttachAdapter.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/AttachAdapter.test.tsx
@@ -44,13 +44,13 @@ const mockHeaterShakeShaking: HeaterShakerModule = {
 
 describe('AttachAdapter', () => {
   let props: React.ComponentProps<typeof AttachAdapter>
-
+  const mockToggleLatch = jest.fn()
   beforeEach(() => {
     props = {
       module: mockHeaterShaker,
     }
     mockUseLatchControls.mockReturnValue({
-      toggleLatch: jest.fn(),
+      toggleLatch: mockToggleLatch,
       isLatchClosed: true,
     })
   })
@@ -80,17 +80,17 @@ describe('AttachAdapter', () => {
     const { getByRole } = render(props)
     const btn = getByRole('button', { name: 'Open Labware Latch' })
     fireEvent.click(btn)
-    expect(mockUseLatchControls).toHaveBeenCalled()
+    expect(mockToggleLatch).toHaveBeenCalled()
   })
   it('renders button and clicking on it sends latch command to close', () => {
     mockUseLatchControls.mockReturnValue({
-      toggleLatch: jest.fn(),
+      toggleLatch: mockToggleLatch,
       isLatchClosed: false,
     })
     const { getByRole } = render(props)
     const btn = getByRole('button', { name: 'Close Labware Latch' })
     fireEvent.click(btn)
-    expect(mockUseLatchControls).toHaveBeenCalled()
+    expect(mockToggleLatch).toHaveBeenCalled()
   })
   it('renders button and it is disabled when heater-shaker is shaking', () => {
     props = {
@@ -108,6 +108,6 @@ describe('AttachAdapter', () => {
     const { getByRole } = render(props)
     const btn = getByRole('button', { name: 'Open Labware Latch' })
     fireEvent.click(btn)
-    expect(mockUseLatchControls).toHaveBeenCalled()
+    expect(mockToggleLatch).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/HeaterShakerWizard.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/HeaterShakerWizard.test.tsx
@@ -6,6 +6,7 @@ import { i18n } from '../../../../i18n'
 import { useAttachedModules } from '../../hooks'
 import { mockHeaterShaker } from '../../../../redux/modules/__fixtures__'
 import heaterShakerCommands from '@opentrons/shared-data/protocol/fixtures/6/heaterShakerCommands.json'
+import { RUN_ID_1 } from '../../../RunTimeControl/__fixtures__'
 import { HeaterShakerWizard } from '..'
 import { Introduction } from '../Introduction'
 import { KeyParts } from '../KeyParts'
@@ -121,6 +122,7 @@ describe('HeaterShakerWizard', () => {
         protocolLoadOrder: 1,
         slotName: '1',
       } as ProtocolModuleInfo,
+      currentRunId: RUN_ID_1,
     }
     const { getByText, getByRole } = render(props)
 

--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/TestShake.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/TestShake.test.tsx
@@ -351,17 +351,17 @@ describe('TestShake', () => {
     })
   })
 
-  //  next test is sending module commands when run is idle and through module controls
-  it.only('entering an input for shake speed and clicking start should begin shaking when there is a run id', () => {
+  //  next test is sending module commands when run is terminal and through module controls
+  it('entering an input for shake speed and clicking start should begin shaking when there is a run id and run is terminal', () => {
     mockUseRunStatuses.mockReturnValue({
       isLegacySessionInProgress: false,
       isRunStill: false,
-      isRunTerminal: false,
-      isRunIdle: true,
+      isRunTerminal: true,
+      isRunIdle: false,
     })
 
     props = {
-      module: mockCloseLatchHeaterShaker,
+      module: mockHeaterShaker,
       setCurrentPage: jest.fn(),
       moduleFromProtocol: HEATER_SHAKER_PROTOCOL_MODULE_INFO,
       currentRunId: RUN_ID_1,
@@ -373,8 +373,7 @@ describe('TestShake', () => {
     fireEvent.change(input, { target: { value: '300' } })
     fireEvent.click(button)
 
-    expect(mockCreateCommand).toHaveBeenCalledWith({
-      runId: props.currentRunId,
+    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
       command: {
         commandType: 'heaterShaker/setAndWaitForShakeSpeed',
         params: {

--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/TestShake.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/TestShake.test.tsx
@@ -352,7 +352,7 @@ describe('TestShake', () => {
   })
 
   //  next test is sending module commands when run is idle and through module controls
-  it('entering an input for shake speed and clicking start should begin shaking when there is a run id', () => {
+  it.only('entering an input for shake speed and clicking start should begin shaking when there is a run id', () => {
     mockUseRunStatuses.mockReturnValue({
       isLegacySessionInProgress: false,
       isRunStill: false,
@@ -375,39 +375,6 @@ describe('TestShake', () => {
 
     expect(mockCreateCommand).toHaveBeenCalledWith({
       runId: props.currentRunId,
-      command: {
-        commandType: 'heaterShaker/setAndWaitForShakeSpeed',
-        params: {
-          moduleId: 'heatershaker_id',
-          rpm: 300,
-        },
-      },
-    })
-  })
-
-  //  next test is sending module commands when run is terminal and through module controls
-  it('entering an input for shake speed and clicking start should begin shaking when there is a run id and run is terminal', () => {
-    mockUseRunStatuses.mockReturnValue({
-      isLegacySessionInProgress: false,
-      isRunStill: false,
-      isRunTerminal: true,
-      isRunIdle: false,
-    })
-
-    props = {
-      module: mockCloseLatchHeaterShaker,
-      setCurrentPage: jest.fn(),
-      moduleFromProtocol: HEATER_SHAKER_PROTOCOL_MODULE_INFO,
-      currentRunId: RUN_ID_1,
-    }
-
-    const { getByRole } = render(props)
-    const button = getByRole('button', { name: /Start Shaking/i })
-    const input = getByRole('spinbutton')
-    fireEvent.change(input, { target: { value: '300' } })
-    fireEvent.click(button)
-
-    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
       command: {
         commandType: 'heaterShaker/setAndWaitForShakeSpeed',
         params: {

--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/TestShake.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/TestShake.test.tsx
@@ -131,6 +131,7 @@ describe('TestShake', () => {
   let props: React.ComponentProps<typeof TestShake>
   let mockCreateLiveCommand = jest.fn()
   let mockCreateCommand = jest.fn()
+  const mockToggleLatch = jest.fn()
   beforeEach(() => {
     props = {
       setCurrentPage: jest.fn(),
@@ -204,7 +205,7 @@ describe('TestShake', () => {
     }
 
     mockUseLatchControls.mockReturnValue({
-      toggleLatch: jest.fn(),
+      toggleLatch: mockToggleLatch,
       isLatchClosed: false,
     })
 
@@ -259,7 +260,7 @@ describe('TestShake', () => {
     }
 
     mockUseLatchControls.mockReturnValue({
-      toggleLatch: jest.fn(),
+      toggleLatch: mockToggleLatch,
       isLatchClosed: false,
     })
 
@@ -276,14 +277,14 @@ describe('TestShake', () => {
     }
 
     mockUseLatchControls.mockReturnValue({
-      toggleLatch: jest.fn(),
+      toggleLatch: mockToggleLatch,
       isLatchClosed: true,
     })
 
     const { getByRole } = render(props)
     const button = getByRole('button', { name: /Open Labware Latch/i })
     fireEvent.click(button)
-    expect(mockUseLatchControls).toHaveBeenCalled()
+    expect(mockToggleLatch).toHaveBeenCalled()
   })
 
   it('clicking the close latch button should close the heater shaker latch', () => {
@@ -294,14 +295,14 @@ describe('TestShake', () => {
     }
 
     mockUseLatchControls.mockReturnValue({
-      toggleLatch: jest.fn(),
+      toggleLatch: mockToggleLatch,
       isLatchClosed: false,
     })
 
     const { getByRole } = render(props)
     const button = getByRole('button', { name: /Close Labware Latch/i })
     fireEvent.click(button)
-    expect(mockUseLatchControls).toHaveBeenCalled()
+    expect(mockToggleLatch).toHaveBeenCalled()
   })
 
   it('entering an input for shake speed and clicking start should begin shaking when there is no run id', () => {

--- a/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
@@ -30,13 +30,13 @@ import type { ProtocolModuleInfo } from '../../Devices/ProtocolRun/utils/getProt
 interface HeaterShakerWizardProps {
   onCloseClick: () => unknown
   moduleFromProtocol?: ProtocolModuleInfo
-  runId?: string
+  currentRunId?: string
 }
 
 export const HeaterShakerWizard = (
   props: HeaterShakerWizardProps
 ): JSX.Element | null => {
-  const { onCloseClick, moduleFromProtocol, runId } = props
+  const { onCloseClick, moduleFromProtocol, currentRunId } = props
   const { t } = useTranslation(['heater_shaker', 'shared'])
   const [currentPage, setCurrentPage] = React.useState(0)
   const { robotName } = useParams<NavRouteParams>()
@@ -93,22 +93,19 @@ export const HeaterShakerWizard = (
         return (
           // heaterShaker should never be null because isPrimaryCTAEnabled would be disabled otherwise
           heaterShaker != null ? (
-            <AttachAdapter module={heaterShaker} runId={runId} />
+            <AttachAdapter module={heaterShaker} currentRunId={currentRunId} />
           ) : null
         )
       case 5:
         buttonContent = t('complete')
-        return (
-          // heaterShaker should never be null because isPrimaryCTAEnabled would be disabled otherwise
-          heaterShaker != null ? (
-            <TestShake
-              module={heaterShaker}
-              setCurrentPage={setCurrentPage}
-              moduleFromProtocol={moduleFromProtocol}
-              runId={runId}
-            />
-          ) : null
-        )
+        return heaterShaker != null ? (
+          <TestShake
+            module={heaterShaker}
+            setCurrentPage={setCurrentPage}
+            moduleFromProtocol={moduleFromProtocol}
+            currentRunId={currentRunId}
+          />
+        ) : null
       default:
         return null
     }

--- a/app/src/organisms/Devices/ProtocolRun/SetupModules.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModules.tsx
@@ -91,7 +91,6 @@ export const SetupModules = ({
         <HeaterShakerBanner
           displayName={heaterShakerModules[0]?.moduleDef.displayName}
           modules={heaterShakerModules}
-          runId={runId}
         />
       ) : null}
       {showMultipleModulesModal ? (

--- a/app/src/organisms/ModuleCard/TestShakeSlideout.tsx
+++ b/app/src/organisms/ModuleCard/TestShakeSlideout.tsx
@@ -73,10 +73,7 @@ export const TestShakeSlideout = (
     placement: 'left',
   })
   const { toggleLatch, isLatchClosed } = useLatchControls(module, currentRunId)
-  const { moduleIdFromRun } = useModuleIdFromRun(
-    module,
-    currentRunId != null ? currentRunId : null
-  )
+  const { moduleIdFromRun } = useModuleIdFromRun(module, currentRunId ?? null)
   const configHasHeaterShakerAttached = useSelector(getIsHeaterShakerAttached)
   const [shakeValue, setShakeValue] = React.useState<string | null>(null)
   const [showWizard, setShowWizard] = React.useState<boolean>(false)

--- a/app/src/organisms/ModuleCard/TestShakeSlideout.tsx
+++ b/app/src/organisms/ModuleCard/TestShakeSlideout.tsx
@@ -64,7 +64,7 @@ export const TestShakeSlideout = (
     isLoadedInRun,
     currentRunId,
   } = props
-  const { t } = useTranslation(['device_details', 'shared', 'heater_shaker'])
+  const { t } = useTranslation(['heater_shaker', 'device_details', 'shared'])
   const { createLiveCommand } = useCreateLiveCommandMutation()
   const { isRunIdle, isRunTerminal } = useRunStatuses()
   const { createCommand } = useCreateCommandMutation()
@@ -140,7 +140,7 @@ export const TestShakeSlideout = (
   const errorMessage =
     shakeValue != null &&
     (parseInt(shakeValue) < HS_RPM_MIN || parseInt(shakeValue) > HS_RPM_MAX)
-      ? t('input_out_of_range', { ns: 'device_details' })
+      ? t('device_details:input_out_of_range')
       : null
 
   const getLatchStatus = (latchStatus: LatchStatus): string => {
@@ -152,7 +152,7 @@ export const TestShakeSlideout = (
       }
       case 'closing':
       case 'idle_closed': {
-        return t('heater_shaker:closed')
+        return t('closed')
       }
       default:
         return latchStatus
@@ -161,7 +161,7 @@ export const TestShakeSlideout = (
 
   return (
     <Slideout
-      title={t('test_shake', { ns: 'heater_shaker' })}
+      title={t('test_shake')}
       onCloseClick={onCloseClick}
       isExpanded={isExpanded}
       footer={
@@ -226,7 +226,7 @@ export const TestShakeSlideout = (
               fontWeight={TYPOGRAPHY.fontWeightSemiBold}
               color={COLORS.darkBlack}
             >
-              {t('heater_shaker:labware_latch')}
+              {t('labware_latch')}
             </Text>
             <Text
               textTransform={TYPOGRAPHY.textTransformCapitalize}
@@ -248,9 +248,7 @@ export const TestShakeSlideout = (
               disabled={isShaking}
               {...targetProps}
             >
-              {!isLatchClosed
-                ? t('heater_shaker:close_latch')
-                : t('heater_shaker:open_latch')}
+              {!isLatchClosed ? t('close_latch') : t('open_latch')}
             </TertiaryButton>
           ) : (
             <TertiaryButton
@@ -261,14 +259,12 @@ export const TestShakeSlideout = (
               onClick={toggleLatch}
               disabled={isShaking}
             >
-              {!isLatchClosed
-                ? t('heater_shaker:close_latch')
-                : t('heater_shaker:open_latch')}
+              {!isLatchClosed ? t('close_latch') : t('open_latch')}
             </TertiaryButton>
           )}
           {isShaking ? (
             <Tooltip tooltipProps={tooltipProps}>
-              {t('heater_shaker:cannot_open_latch')}
+              {t('cannot_open_latch')}
             </Tooltip>
           ) : null}
         </Flex>
@@ -279,7 +275,7 @@ export const TestShakeSlideout = (
           color={COLORS.darkBlack}
           marginTop={SPACING.spacing4}
         >
-          {t('heater_shaker:shake_speed')}
+          {t('shake_speed')}
         </Text>
         <Flex flexDirection={DIRECTION_ROW} alignItems={ALIGN_FLEX_START}>
           <Flex
@@ -293,7 +289,7 @@ export const TestShakeSlideout = (
               value={shakeValue}
               onChange={e => setShakeValue(e.target.value)}
               type="number"
-              caption={t('heater_shaker:min_max_rpm', {
+              caption={t('min_max_rpm', {
                 min: HS_RPM_MIN,
                 max: HS_RPM_MAX,
               })}
@@ -327,9 +323,7 @@ export const TestShakeSlideout = (
             </TertiaryButton>
           )}
           {!isLatchClosed ? (
-            <Tooltip tooltipProps={tooltipProps}>
-              {t('heater_shaker:cannot_shake')}
-            </Tooltip>
+            <Tooltip tooltipProps={tooltipProps}>{t('cannot_shake')}</Tooltip>
           ) : null}
         </Flex>
       </Flex>
@@ -343,7 +337,7 @@ export const TestShakeSlideout = (
         id={'HeaterShaker_Attachment_Instructions'}
         onClick={() => setShowWizard(true)}
       >
-        {t('heater_shaker:show_attachment_instructions')}
+        {t('show_attachment_instructions')}
       </Link>
     </Slideout>
   )

--- a/app/src/organisms/ModuleCard/TestShakeSlideout.tsx
+++ b/app/src/organisms/ModuleCard/TestShakeSlideout.tsx
@@ -35,6 +35,7 @@ import { Divider } from '../../atoms/structure'
 import { InputField } from '../../atoms/InputField'
 import { Tooltip } from '../../atoms/Tooltip'
 import { HeaterShakerWizard } from '../Devices/HeaterShakerWizard'
+import { useRunStatuses } from '../Devices/hooks'
 import { ConfirmAttachmentModal } from './ConfirmAttachmentModal'
 import { useLatchControls } from './hooks'
 import { useModuleIdFromRun } from './useModuleIdFromRun'
@@ -49,34 +50,49 @@ interface TestShakeSlideoutProps {
   module: HeaterShakerModule
   onCloseClick: () => unknown
   isExpanded: boolean
-  runId?: string
+  isLoadedInRun: boolean
+  currentRunId?: string
 }
 
 export const TestShakeSlideout = (
   props: TestShakeSlideoutProps
 ): JSX.Element | null => {
-  const { module, onCloseClick, isExpanded, runId } = props
+  const {
+    module,
+    onCloseClick,
+    isExpanded,
+    isLoadedInRun,
+    currentRunId,
+  } = props
   const { t } = useTranslation(['device_details', 'shared', 'heater_shaker'])
   const { createLiveCommand } = useCreateLiveCommandMutation()
+  const { isRunIdle, isRunTerminal } = useRunStatuses()
   const { createCommand } = useCreateCommandMutation()
   const name = getModuleDisplayName(module.moduleModel)
   const [targetProps, tooltipProps] = useHoverTooltip({
     placement: 'left',
   })
-  const { toggleLatch, isLatchClosed } = useLatchControls(module, runId)
+  const { toggleLatch, isLatchClosed } = useLatchControls(module, currentRunId)
   const { moduleIdFromRun } = useModuleIdFromRun(
     module,
-    runId != null ? runId : null
+    currentRunId != null ? currentRunId : null
   )
   const configHasHeaterShakerAttached = useSelector(getIsHeaterShakerAttached)
   const [shakeValue, setShakeValue] = React.useState<string | null>(null)
   const [showWizard, setShowWizard] = React.useState<boolean>(false)
   const isShaking = module.data.speedStatus !== 'idle'
 
+  let moduleId: string | null = null
+  if (isRunIdle && currentRunId != null && isLoadedInRun) {
+    moduleId = moduleIdFromRun
+  } else if ((currentRunId != null && isRunTerminal) || currentRunId == null) {
+    moduleId = module.id
+  }
+
   const setShakeCommand: HeaterShakerSetAndWaitForShakeSpeedCreateCommand = {
     commandType: 'heaterShaker/setAndWaitForShakeSpeed',
     params: {
-      moduleId: runId != null ? moduleIdFromRun : module.id,
+      moduleId: moduleId != null ? moduleId : '',
       rpm: shakeValue !== null ? parseInt(shakeValue) : 0,
     },
   }
@@ -84,14 +100,14 @@ export const TestShakeSlideout = (
   const stopShakeCommand: HeaterShakerDeactivateShakerCreateCommand = {
     commandType: 'heaterShaker/deactivateShaker',
     params: {
-      moduleId: runId != null ? moduleIdFromRun : module.id,
+      moduleId: moduleId != null ? moduleId : '',
     },
   }
 
   const handleShakeCommand = (): void => {
-    if (runId != null) {
+    if (isRunIdle && currentRunId != null && isLoadedInRun) {
       createCommand({
-        runId: runId,
+        runId: currentRunId,
         command: isShaking ? stopShakeCommand : setShakeCommand,
       }).catch((e: Error) => {
         console.error(
@@ -100,7 +116,10 @@ export const TestShakeSlideout = (
           }: ${e.message}`
         )
       })
-    } else {
+    } else if (
+      (currentRunId != null && isRunTerminal) ||
+      currentRunId == null
+    ) {
       createLiveCommand({
         command: isShaking ? stopShakeCommand : setShakeCommand,
       }).catch((e: Error) => {

--- a/app/src/organisms/ModuleCard/TestShakeSlideout.tsx
+++ b/app/src/organisms/ModuleCard/TestShakeSlideout.tsx
@@ -82,17 +82,15 @@ export const TestShakeSlideout = (
   const [showWizard, setShowWizard] = React.useState<boolean>(false)
   const isShaking = module.data.speedStatus !== 'idle'
 
-  let moduleId: string | null = null
+  let moduleId: string = module.id
   if (isRunIdle && currentRunId != null && isLoadedInRun) {
     moduleId = moduleIdFromRun
-  } else if ((currentRunId != null && isRunTerminal) || currentRunId == null) {
-    moduleId = module.id
   }
 
   const setShakeCommand: HeaterShakerSetAndWaitForShakeSpeedCreateCommand = {
     commandType: 'heaterShaker/setAndWaitForShakeSpeed',
     params: {
-      moduleId: moduleId != null ? moduleId : '',
+      moduleId,
       rpm: shakeValue !== null ? parseInt(shakeValue) : 0,
     },
   }
@@ -100,7 +98,7 @@ export const TestShakeSlideout = (
   const stopShakeCommand: HeaterShakerDeactivateShakerCreateCommand = {
     commandType: 'heaterShaker/deactivateShaker',
     params: {
-      moduleId: moduleId != null ? moduleId : '',
+      moduleId,
     },
   }
 

--- a/app/src/organisms/ModuleCard/TestShakeSlideout.tsx
+++ b/app/src/organisms/ModuleCard/TestShakeSlideout.tsx
@@ -82,15 +82,10 @@ export const TestShakeSlideout = (
   const [showWizard, setShowWizard] = React.useState<boolean>(false)
   const isShaking = module.data.speedStatus !== 'idle'
 
-  let moduleId: string = module.id
-  if (isRunIdle && currentRunId != null && isLoadedInRun) {
-    moduleId = moduleIdFromRun
-  }
-
   const setShakeCommand: HeaterShakerSetAndWaitForShakeSpeedCreateCommand = {
     commandType: 'heaterShaker/setAndWaitForShakeSpeed',
     params: {
-      moduleId,
+      moduleId: isRunIdle ? moduleIdFromRun : module.id,
       rpm: shakeValue !== null ? parseInt(shakeValue) : 0,
     },
   }
@@ -98,7 +93,7 @@ export const TestShakeSlideout = (
   const stopShakeCommand: HeaterShakerDeactivateShakerCreateCommand = {
     commandType: 'heaterShaker/deactivateShaker',
     params: {
-      moduleId,
+      moduleId: isRunIdle ? moduleIdFromRun : module.id,
     },
   }
 
@@ -114,10 +109,7 @@ export const TestShakeSlideout = (
           }: ${e.message}`
         )
       })
-    } else if (
-      (currentRunId != null && isRunTerminal) ||
-      currentRunId == null
-    ) {
+    } else if (isRunTerminal || currentRunId == null) {
       createLiveCommand({
         command: isShaking ? stopShakeCommand : setShakeCommand,
       }).catch((e: Error) => {

--- a/app/src/organisms/ModuleCard/__tests__/TestShakeSlideout.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/TestShakeSlideout.test.tsx
@@ -119,6 +119,7 @@ describe('TestShakeSlideout', () => {
   let props: React.ComponentProps<typeof TestShakeSlideout>
   let mockCreateLiveCommand = jest.fn()
   let mockCreateCommand = jest.fn()
+  const mockToggleLatch = jest.fn()
   beforeEach(() => {
     props = {
       module: mockHeaterShaker,
@@ -127,7 +128,7 @@ describe('TestShakeSlideout', () => {
       isLoadedInRun: false,
     }
     mockUseLatchControls.mockReturnValue({
-      handleLatch: jest.fn(),
+      toggleLatch: mockToggleLatch,
       isLatchClosed: true,
     } as any)
     mockCreateLiveCommand = jest.fn()
@@ -199,7 +200,7 @@ describe('TestShakeSlideout', () => {
       isLoadedInRun: false,
     }
     mockUseLatchControls.mockReturnValue({
-      toggleLatch: jest.fn(),
+      toggleLatch: mockToggleLatch,
       isLatchClosed: false,
     })
 
@@ -279,7 +280,7 @@ describe('TestShakeSlideout', () => {
     const { getByRole } = render(props)
     const button = getByRole('button', { name: /Open/i })
     fireEvent.click(button)
-    expect(mockUseLatchControls).toHaveBeenCalled()
+    expect(mockToggleLatch).toHaveBeenCalled()
   })
 
   it('entering an input for shake speed and clicking start should begin shaking when there is a runId and run is idle', () => {

--- a/app/src/organisms/ModuleCard/hooks.tsx
+++ b/app/src/organisms/ModuleCard/hooks.tsx
@@ -202,6 +202,7 @@ export function useModuleOverflowMenu(
         key={`test_shake_${module.moduleModel}`}
         id={`test_shake_${module.moduleModel}`}
         data-testid={`test_shake_${module.moduleModel}`}
+        disabled={isDisabled}
         onClick={() =>
           handleDeactivationCommand('heaterShaker/deactivateShaker')
         }

--- a/app/src/organisms/ModuleCard/index.tsx
+++ b/app/src/organisms/ModuleCard/index.tsx
@@ -227,10 +227,10 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
       data-testid={`ModuleCard_${module.serialNumber}`}
     >
       {showWizard &&
-        (runId != null ? (
+        (currentRunId != null ? (
           <HeaterShakerWizard
             onCloseClick={() => setShowWizard(false)}
-            runId={runId}
+            currentRunId={currentRunId}
           />
         ) : (
           <HeaterShakerWizard onCloseClick={() => setShowWizard(false)} />
@@ -258,7 +258,8 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
           module={module as HeaterShakerModule}
           isExpanded={showTestShake}
           onCloseClick={() => setShowTestShake(false)}
-          runId={runId}
+          isLoadedInRun={isLoadedInRun}
+          currentRunId={currentRunId != null ? currentRunId : undefined}
         />
       )}
       <Box padding={`${SPACING.spacing4} ${SPACING.spacing3}`} width="100%">

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/HeaterShakerBanner.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/HeaterShakerBanner.tsx
@@ -3,20 +3,21 @@ import { useTranslation } from 'react-i18next'
 import { COLORS } from '@opentrons/components'
 import { Divider } from '../../../../../atoms/structure/Divider'
 import { HeaterShakerWizard } from '../../../../Devices/HeaterShakerWizard'
+import { useCurrentRunId } from '../../../../ProtocolUpload/hooks'
 import { ModuleRenderInfoForProtocol } from '../../../../Devices/hooks'
 import { Banner, BannerItem } from '../Banner/Banner'
 
 interface HeaterShakerBannerProps {
   displayName: string
   modules: ModuleRenderInfoForProtocol[]
-  runId: string
 }
 
 export function HeaterShakerBanner(
   props: HeaterShakerBannerProps
 ): JSX.Element | null {
   const [showWizard, setShowWizard] = React.useState(false)
-  const { displayName, modules, runId } = props
+  const { displayName, modules } = props
+  const currentRunId = useCurrentRunId()
   const { t } = useTranslation('heater_shaker')
   return (
     <Banner title={t('attach_heater_shaker_to_deck', { name: displayName })}>
@@ -26,7 +27,7 @@ export function HeaterShakerBanner(
             <HeaterShakerWizard
               onCloseClick={() => setShowWizard(false)}
               moduleFromProtocol={module}
-              runId={runId}
+              currentRunId={currentRunId != null ? currentRunId : undefined}
             />
           )}
           {index > 0 && <Divider color={COLORS.medGrey} />}

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/HeaterShakerBanner.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/HeaterShakerBanner.tsx
@@ -19,6 +19,9 @@ export function HeaterShakerBanner(
   const { displayName, modules } = props
   const currentRunId = useCurrentRunId()
   const { t } = useTranslation('heater_shaker')
+
+  if (currentRunId == null) return null
+
   return (
     <Banner title={t('attach_heater_shaker_to_deck', { name: displayName })}>
       {modules.map((module, index) => (
@@ -27,7 +30,7 @@ export function HeaterShakerBanner(
             <HeaterShakerWizard
               onCloseClick={() => setShowWizard(false)}
               moduleFromProtocol={module}
-              currentRunId={currentRunId != null ? currentRunId : undefined}
+              currentRunId={currentRunId}
             />
           )}
           {index > 0 && <Divider color={COLORS.medGrey} />}

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/__tests__/HeaterShakerBanner.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/__tests__/HeaterShakerBanner.test.tsx
@@ -4,9 +4,12 @@ import { renderWithProviders } from '@opentrons/components'
 import { HeaterShakerBanner } from '../HeaterShakerBanner'
 import heaterShakerCommands from '@opentrons/shared-data/protocol/fixtures/6/heaterShakerCommands.json'
 import { mockHeaterShaker } from '../../../../../../redux/modules/__fixtures__'
+import { useCurrentRunId } from '../../../../../ProtocolUpload/hooks'
 import { ModuleRenderInfoForProtocol } from '../../../../../Devices/hooks'
-import { ModuleModel, ModuleType } from '@opentrons/shared-data'
+import { RUN_ID_1 } from '../../../../../RunTimeControl/__fixtures__'
+import type { ModuleModel, ModuleType } from '@opentrons/shared-data'
 
+jest.mock('../../../../../ProtocolUpload/hooks')
 const mockHeaterShakerDefinition = {
   moduleId: 'someHeaterShakerModule',
   model: 'heaterShakerModuleV1' as ModuleModel,
@@ -53,6 +56,10 @@ const HEATER_SHAKER_PROTOCOL_MODULE_INFO_2 = {
   slotName: '3',
 } as ModuleRenderInfoForProtocol
 
+const mockUseCurrentRunId = useCurrentRunId as jest.MockedFunction<
+  typeof useCurrentRunId
+>
+
 const render = (props: React.ComponentProps<typeof HeaterShakerBanner>) => {
   return renderWithProviders(<HeaterShakerBanner {...props} />, {
     i18nInstance: i18n,
@@ -63,10 +70,10 @@ describe('HeaterShakerBanner', () => {
   let props: React.ComponentProps<typeof HeaterShakerBanner>
   beforeEach(() => {
     props = {
-      runId: '1',
       displayName: 'HeaterShakerV1',
       modules: [HEATER_SHAKER_PROTOCOL_MODULE_INFO],
     }
+    mockUseCurrentRunId.mockReturnValue(RUN_ID_1)
   })
 
   it('should render banner component', () => {
@@ -84,7 +91,6 @@ describe('HeaterShakerBanner', () => {
 
   it('should not render heater shaker wizard button if no heater shaker is present', () => {
     props = {
-      runId: '1',
       displayName: 'HeaterShakerV1',
       modules: [],
     }
@@ -96,7 +102,6 @@ describe('HeaterShakerBanner', () => {
 
   it('should render two heater shaker banner items when there are two heater shakers in the protocol', () => {
     props = {
-      runId: '1',
       displayName: 'HeaterShakerV1',
       modules: [
         HEATER_SHAKER_PROTOCOL_MODULE_INFO,


### PR DESCRIPTION
closes #11179


# Overview

this PR refactors the logic through the heater shaker wizard and the test shake slideout so that you can send commands to the correct module id when a run is idle, a run is terminal, and through both sets of the module cards

# Changelog

- refactor logic in `heaterShakerWizard` `AttachAdapter` `TestShake`
- refactor logic in `TestShakeSlideout`
- make test shake button disabled when run is idle
- fix affected components

# Review requests

- in the app before uploading a protocol, go to the module cards in device details. Test that all the options in the Heater shaker overflow menu work (temp, latch, shake) go through the wizard, make sure all module control buttons work in attach adapter and test shake
- uploaded a protocol, go to module controls, make sure all the module controls work in the overflow menu of the H-S.
- when run is still idle/not started, go to the device details overflow menu for H-S, all buttons should be dissabled except for `About Module` and launching the H-S wizard. Click on the wizard, go through the whole flow, make sure every module control button works
- complete the run. Now it is in terminal state. Test that the module controls work for the H-S in both sets of module cards (in module controls and device details)

I don't have H-S, would be good to test on one

# Risk assessment

low