### PR TITLE
refactor(app): clean up H-S and ModduleSetup Banner components

### DIFF
--- a/app/src/organisms/Devices/HeaterShakerWizard/AttachAdapter.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/AttachAdapter.tsx
@@ -34,9 +34,7 @@ export function AttachAdapter(props: AttachAdapterProps): JSX.Element {
 
   return (
     <Flex
-      color={COLORS.darkBlack}
       flexDirection={DIRECTION_COLUMN}
-      fontSize={TYPOGRAPHY.fontSizeH2}
       fontWeight={TYPOGRAPHY.fontWeightSemiBold}
     >
       <Flex paddingBottom={SPACING.spacingL}>
@@ -52,7 +50,7 @@ export function AttachAdapter(props: AttachAdapterProps): JSX.Element {
         </StyledText>
         <Flex border={`${SPACING.spacingXXS} solid ${COLORS.medGrey}`}>
           <Flex
-            padding={`${SPACING.spacing2} 5rem ${SPACING.spacing4} 3rem`}
+            padding={`${SPACING.spacing2} 5rem ${SPACING.spacing4} ${SPACING.spacing7}`}
             data-testid={`attach_adapter_screw_in_adapter_image`}
           >
             <img height="160px" src={screwInAdapter} alt="screw_in_adapter" />

--- a/app/src/organisms/Devices/HeaterShakerWizard/AttachAdapter.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/AttachAdapter.tsx
@@ -17,6 +17,7 @@ import screwInAdapter from '@opentrons/app/src/assets/images/heater_shaker_adapt
 import heaterShakerAdapterAlignment from '@opentrons/app/src/assets/images/heater_shaker_adapter_alignment.png'
 import { TertiaryButton } from '../../../atoms/buttons'
 import { Tooltip } from '../../../atoms/Tooltip'
+import { StyledText } from '../../../atoms/text'
 import { useLatchControls } from '../../ModuleCard/hooks'
 
 import type { HeaterShakerModule } from '../../../redux/modules/types'
@@ -37,19 +38,19 @@ export function AttachAdapter(props: AttachAdapterProps): JSX.Element {
       color={COLORS.darkBlack}
       flexDirection={DIRECTION_COLUMN}
       fontSize={TYPOGRAPHY.fontSizeH2}
-      fontWeight={700}
+      fontWeight={TYPOGRAPHY.fontWeightSemiBold}
     >
       <Flex paddingBottom={SPACING.spacingL}>
         {t('step_3_of_4_attach_adapter')}
       </Flex>
       <Flex flexDirection={DIRECTION_ROW}>
-        <Text
+        <StyledText
           color={COLORS.darkGrey}
           paddingRight={SPACING.spacing4}
           data-testid={`attach_adapter_2a`}
         >
           {t('3a')}
-        </Text>
+        </StyledText>
         <Flex border={`${SPACING.spacingXXS} solid ${COLORS.medGrey}`}>
           <Flex
             padding={`${SPACING.spacing2} 5rem ${SPACING.spacing4} 3rem`}
@@ -88,15 +89,12 @@ export function AttachAdapter(props: AttachAdapterProps): JSX.Element {
                 fontSize={TYPOGRAPHY.fontSizeP}
                 paddingBottom={SPACING.spacing4}
               >
-                <Text
-                  fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-                  paddingBottom={SPACING.spacing2}
-                >
+                <StyledText paddingBottom={SPACING.spacing2}>
                   {t('attach_screwdriver_and_screw')}
-                </Text>
-                <Text fontWeight={TYPOGRAPHY.fontWeightRegular}>
+                </StyledText>
+                <StyledText fontWeight={TYPOGRAPHY.fontWeightRegular}>
                   {t('attach_screwdriver_and_screw_explanation')}
-                </Text>
+                </StyledText>
               </Flex>
             </Flex>
             <TertiaryButton
@@ -120,13 +118,13 @@ export function AttachAdapter(props: AttachAdapterProps): JSX.Element {
         </Flex>
       </Flex>
       <Flex flexDirection={DIRECTION_ROW} marginTop={SPACING.spacingSM}>
-        <Text
+        <StyledText
           color={COLORS.darkGrey}
           paddingRight={SPACING.spacing4}
           data-testid={`attach_adapter_2b`}
         >
           {t('3b')}
-        </Text>
+        </StyledText>
         <Flex
           border={`${SPACING.spacingXXS} solid ${COLORS.medGrey}`}
           width="100%"
@@ -147,21 +145,21 @@ export function AttachAdapter(props: AttachAdapterProps): JSX.Element {
             marginRight="3rem"
             data-testid={`attach_adapter_alignment_text`}
           >
-            <Text>{t('check_alignment')}</Text>
-            <Text paddingTop={SPACING.spacing4}>
+            <StyledText>{t('check_alignment')}</StyledText>
+            <StyledText paddingTop={SPACING.spacing4}>
               {t('a_properly_attached_adapter')}
-            </Text>
+            </StyledText>
           </Flex>
         </Flex>
       </Flex>
       <Flex flexDirection={DIRECTION_ROW} marginTop={SPACING.spacingSM}>
-        <Text
+        <StyledText
           color={COLORS.darkGrey}
           paddingRight={SPACING.spacing4}
           data-testid={`attach_adapter_3a`}
         >
           {t('3c')}
-        </Text>
+        </StyledText>
         <Flex
           border={`${SPACING.spacingXXS} solid ${COLORS.medGrey}`}
           flexDirection={DIRECTION_COLUMN}
@@ -171,7 +169,7 @@ export function AttachAdapter(props: AttachAdapterProps): JSX.Element {
           marginBottom={SPACING.spacingSM}
           data-testid={`attach_adapter_check_alignment_instructions`}
         >
-          <Text>{t('check_alignment_instructions')}</Text>
+          <StyledText>{t('check_alignment_instructions')}</StyledText>
         </Flex>
       </Flex>
     </Flex>

--- a/app/src/organisms/Devices/HeaterShakerWizard/AttachAdapter.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/AttachAdapter.tsx
@@ -4,7 +4,6 @@ import {
   COLORS,
   Flex,
   DIRECTION_COLUMN,
-  Text,
   DIRECTION_ROW,
   Icon,
   TYPOGRAPHY,

--- a/app/src/organisms/Devices/HeaterShakerWizard/AttachModule.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/AttachModule.tsx
@@ -45,7 +45,7 @@ export function AttachModule(props: AttachModuleProps): JSX.Element {
   return (
     <Flex flexDirection={DIRECTION_COLUMN}>
       <StyledText
-        fontSize={TYPOGRAPHY.h2Regular}
+        fontSize={TYPOGRAPHY.fontSizeH2}
         paddingBottom={SPACING.spacingL}
         fontWeight={TYPOGRAPHY.fontWeightSemiBold}
       >

--- a/app/src/organisms/Devices/HeaterShakerWizard/AttachModule.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/AttachModule.tsx
@@ -45,7 +45,6 @@ export function AttachModule(props: AttachModuleProps): JSX.Element {
   return (
     <Flex flexDirection={DIRECTION_COLUMN}>
       <StyledText
-        fontSize={TYPOGRAPHY.fontSizeH2}
         paddingBottom={SPACING.spacingL}
         fontWeight={TYPOGRAPHY.fontWeightSemiBold}
       >
@@ -176,7 +175,7 @@ export function AttachModule(props: AttachModuleProps): JSX.Element {
                     marginBottom={SPACING.spacing5}
                   />
                 ),
-                icon: <Icon name="clockwise-arrow" size={'1.313rem'} />,
+                icon: <Icon name="clockwise-arrow" size="1.313rem" />,
               }}
             />
           </Flex>
@@ -199,7 +198,7 @@ interface AttachedModuleItemProps {
 function AttachedModuleItem(props: AttachedModuleItemProps): JSX.Element {
   const { step } = props
   return (
-    <Flex flexDirection={DIRECTION_ROW} marginTop={'0.625rem'}>
+    <Flex flexDirection={DIRECTION_ROW} marginTop={SPACING.spacingSM}>
       <StyledText
         color={COLORS.darkGrey}
         paddingRight={SPACING.spacing4}

--- a/app/src/organisms/Devices/HeaterShakerWizard/AttachModule.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/AttachModule.tsx
@@ -45,7 +45,7 @@ export function AttachModule(props: AttachModuleProps): JSX.Element {
   return (
     <Flex flexDirection={DIRECTION_COLUMN}>
       <StyledText
-        as="h2"
+        fontSize={TYPOGRAPHY.h2Regular}
         paddingBottom={SPACING.spacingL}
         fontWeight={TYPOGRAPHY.fontWeightSemiBold}
       >

--- a/app/src/organisms/Devices/HeaterShakerWizard/AttachModule.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/AttachModule.tsx
@@ -17,6 +17,7 @@ import {
   getModuleDef2,
   inferModuleOrientationFromXCoordinate,
 } from '@opentrons/shared-data'
+import { StyledText } from '../../../atoms/text'
 import attachHeaterShakerModule from '../../../assets/images/heater_shaker_module_diagram.svg'
 import standardDeckDef from '@opentrons/shared-data/deck/definitions/3/ot2_standard.json'
 import screwdriverOrientedLeft from '../../../assets/images/screwdriver_oriented_left.svg'
@@ -42,14 +43,14 @@ export function AttachModule(props: AttachModuleProps): JSX.Element {
   ]
 
   return (
-    <Flex
-      color={COLORS.darkBlack}
-      flexDirection={DIRECTION_COLUMN}
-      fontSize={TYPOGRAPHY.fontSizeH2}
-    >
-      <Text paddingBottom={SPACING.spacingL} fontWeight={700}>
+    <Flex flexDirection={DIRECTION_COLUMN}>
+      <StyledText
+        as="h2"
+        paddingBottom={SPACING.spacingL}
+        fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+      >
         {t('step_1_of_4_attach_module')}
-      </Text>
+      </StyledText>
       <AttachedModuleItem step={t('1a')}>
         <Flex flexDirection={DIRECTION_ROW} marginLeft={SPACING.spacingXL}>
           <img src={attachHeaterShakerModule} alt="Attach Module to Deck" />
@@ -199,13 +200,13 @@ function AttachedModuleItem(props: AttachedModuleItemProps): JSX.Element {
   const { step } = props
   return (
     <Flex flexDirection={DIRECTION_ROW} marginTop={'0.625rem'}>
-      <Text
+      <StyledText
         color={COLORS.darkGrey}
         paddingRight={SPACING.spacing4}
         data-testid={`attach_module_${step}`}
       >
         {step}
-      </Text>
+      </StyledText>
       <Flex
         border={`${SPACING.spacingXXS} solid ${COLORS.medGrey}`}
         flexDirection={DIRECTION_COLUMN}

--- a/app/src/organisms/Devices/HeaterShakerWizard/Introduction.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/Introduction.tsx
@@ -4,7 +4,6 @@ import { css } from 'styled-components'
 import {
   Flex,
   DIRECTION_COLUMN,
-  Text,
   TYPOGRAPHY,
   COLORS,
   JUSTIFY_CENTER,

--- a/app/src/organisms/Devices/HeaterShakerWizard/Introduction.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/Introduction.tsx
@@ -23,6 +23,7 @@ import deepwell from '@opentrons/app/src/assets/images/deepwell_thermal_adapter.
 import pcr from '@opentrons/app/src/assets/images/pcr_thermal_adapter.png'
 import universal from '@opentrons/app/src/assets/images/universal_thermal_adapter.png'
 import screwdriver from '@opentrons/app/src/assets/images/t10_torx_screwdriver.png'
+import { StyledText } from '@opentrons/app/src/atoms/text/StyledText'
 
 import type {
   LabwareDefinition2,
@@ -129,29 +130,24 @@ export function Introduction(props: IntroductionProps): JSX.Element {
 
   return (
     <Flex
-      padding={TYPOGRAPHY.lineHeight20}
+      padding={SPACING.spacingM}
       flexDirection={DIRECTION_COLUMN}
-      color={COLORS.darkBlack}
-      fontWeight={TYPOGRAPHY.fontWeightRegular}
       marginBottom={labwareDefinition != null ? '4.313rem' : '9.375rem'}
     >
-      <Text
-        fontSize={TYPOGRAPHY.lineHeight16}
-        data-testid={`introduction_title`}
-      >
+      <StyledText css={TYPOGRAPHY.h2Regular} data-testid={`introduction_title`}>
         {t('use_this_heater_shaker_guide')}
-      </Text>
+      </StyledText>
       <Flex flexDirection={DIRECTION_COLUMN}>
         <Flex justifyContent={JUSTIFY_CENTER}>
-          <Text
-            paddingTop={TYPOGRAPHY.fontSizeH6}
+          <StyledText
+            paddingTop="0.563rem"
             fontSize={TYPOGRAPHY.fontSizeH4}
             flexDirection={DIRECTION_ROW}
             width={'21.5rem'}
             data-testid={`introduction_subtitle`}
           >
             {t('you_will_need')}
-          </Text>
+          </StyledText>
         </Flex>
         <Flex
           justifyContent={JUSTIFY_CENTER}

--- a/app/src/organisms/Devices/HeaterShakerWizard/Introduction.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/Introduction.tsx
@@ -142,7 +142,7 @@ export function Introduction(props: IntroductionProps): JSX.Element {
             paddingTop="0.563rem"
             fontSize={TYPOGRAPHY.fontSizeH4}
             flexDirection={DIRECTION_ROW}
-            width={'21.5rem'}
+            width="21.5rem"
             data-testid={`introduction_subtitle`}
           >
             {t('you_will_need')}
@@ -162,8 +162,8 @@ export function Introduction(props: IntroductionProps): JSX.Element {
             image={
               thermalAdapterName != null ? (
                 <Flex
-                  width={'6.2rem'}
-                  height={'4.313rem'}
+                  width="6.2rem"
+                  height="4.313rem"
                   css={THERMAL_ADAPTER_TRANSFORM}
                 >
                   <img src={adapterImage} alt={`${thermalAdapterName}`} />
@@ -184,7 +184,7 @@ export function Introduction(props: IntroductionProps): JSX.Element {
             }
             image={
               labwareDefinition != null ? (
-                <Flex width={'6.2rem'} height={'4.3rem'}>
+                <Flex width="6.2rem" height="4.3rem">
                   <RobotWorkSpace viewBox={VIEW_BOX}>
                     {() => {
                       return (

--- a/app/src/organisms/Devices/HeaterShakerWizard/PowerOn.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/PowerOn.tsx
@@ -11,9 +11,9 @@ import {
   Module,
   RobotWorkSpace,
   SPACING,
-  Text,
   TYPOGRAPHY,
 } from '@opentrons/components'
+import { StyledText } from '../../../atoms/text'
 import { ModuleInfo } from '../../ProtocolSetup/RunSetupCard/ModuleSetup/ModuleInfo'
 
 import type { HeaterShakerModule } from '../../../redux/modules/types'
@@ -28,9 +28,8 @@ export function PowerOn(props: PowerOnProps): JSX.Element {
   const moduleDef = getModuleDef2('heaterShakerModuleV1')
 
   return (
-    <React.Fragment>
+    <>
       <Flex
-        color={COLORS.darkBlack}
         flexDirection={DIRECTION_COLUMN}
         marginBottom="4rem"
         data-testid={`heater_shaker_power_on_text`}
@@ -40,8 +39,7 @@ export function PowerOn(props: PowerOnProps): JSX.Element {
           i18nKey="step_2_power_on"
           components={{
             strong: (
-              <Text
-                fontSize={TYPOGRAPHY.fontSizeH2}
+              <StyledText
                 fontWeight={TYPOGRAPHY.fontWeightSemiBold}
                 paddingBottom={SPACING.spacingSM}
               />
@@ -72,6 +70,6 @@ export function PowerOn(props: PowerOnProps): JSX.Element {
           </React.Fragment>
         )}
       </RobotWorkSpace>
-    </React.Fragment>
+    </>
   )
 }

--- a/app/src/organisms/Devices/HeaterShakerWizard/PowerOn.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/PowerOn.tsx
@@ -5,7 +5,6 @@ import {
   inferModuleOrientationFromXCoordinate,
 } from '@opentrons/shared-data'
 import {
-  COLORS,
   DIRECTION_COLUMN,
   Flex,
   Module,

--- a/app/src/organisms/Devices/HeaterShakerWizard/PowerOn.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/PowerOn.tsx
@@ -12,6 +12,7 @@ import {
   RobotWorkSpace,
   SPACING,
   Text,
+  TYPOGRAPHY,
 } from '@opentrons/components'
 import { ModuleInfo } from '../../ProtocolSetup/RunSetupCard/ModuleSetup/ModuleInfo'
 
@@ -38,7 +39,12 @@ export function PowerOn(props: PowerOnProps): JSX.Element {
           t={t}
           i18nKey="step_2_power_on"
           components={{
-            strong: <Text fontWeight={700} paddingBottom={SPACING.spacingSM} />,
+            strong: (
+              <Text
+                fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+                paddingBottom={SPACING.spacingSM}
+              />
+            ),
             block: <span />,
           }}
         />

--- a/app/src/organisms/Devices/HeaterShakerWizard/PowerOn.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/PowerOn.tsx
@@ -41,6 +41,7 @@ export function PowerOn(props: PowerOnProps): JSX.Element {
           components={{
             strong: (
               <Text
+                fontSize={TYPOGRAPHY.fontSizeH2}
                 fontWeight={TYPOGRAPHY.fontWeightSemiBold}
                 paddingBottom={SPACING.spacingSM}
               />

--- a/app/src/organisms/Devices/HeaterShakerWizard/TestShake.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/TestShake.tsx
@@ -103,15 +103,12 @@ export function TestShake(props: TestShakeProps): JSX.Element {
   const errorMessage =
     shakeValue != null &&
     (parseInt(shakeValue) < HS_RPM_MIN || parseInt(shakeValue) > HS_RPM_MAX)
-      ? t('input_out_of_range', { ns: 'device_details' })
+      ? t('device_details:input_out_of_range')
       : null
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN}>
-      <StyledText
-        fontSize={TYPOGRAPHY.fontSizeH2}
-        fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-      >
+      <StyledText fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
         {t('step_4_of_4')}
       </StyledText>
       <Flex
@@ -180,7 +177,7 @@ export function TestShake(props: TestShakeProps): JSX.Element {
           marginY={SPACING.spacingL}
           alignItems={ALIGN_FLEX_START}
         >
-          <Flex flexDirection={DIRECTION_COLUMN} maxWidth={'6.25rem'}>
+          <Flex flexDirection={DIRECTION_COLUMN} maxWidth="6.25rem">
             <StyledText
               fontSize={TYPOGRAPHY.fontSizeCaption}
               color={COLORS.darkGreyEnabled}
@@ -194,7 +191,6 @@ export function TestShake(props: TestShakeProps): JSX.Element {
               onChange={e => setShakeValue(e.target.value)}
               type="number"
               caption={t('min_max_rpm', {
-                ns: 'heater_shaker',
                 min: HS_RPM_MIN,
                 max: HS_RPM_MAX,
               })}
@@ -212,9 +208,7 @@ export function TestShake(props: TestShakeProps): JSX.Element {
             {isShaking ? t('stop_shaking') : t('start_shaking')}
           </TertiaryButton>
           {!isLatchClosed ? (
-            <Tooltip tooltipProps={tooltipProps}>
-              {t('cannot_shake', { ns: 'heater_shaker' })}
-            </Tooltip>
+            <Tooltip tooltipProps={tooltipProps}>{t('cannot_shake')}</Tooltip>
           ) : null}
         </Flex>
       </Flex>
@@ -229,7 +223,7 @@ export function TestShake(props: TestShakeProps): JSX.Element {
           alignItems={ALIGN_FLEX_START}
           marginY={SPACING.spacing6}
         >
-          <StyledText width={'22rem'} fontSize={TYPOGRAPHY.fontSizeH2}>
+          <StyledText width="22rem">
             {t('troubleshoot_step1_description')}
           </StyledText>
           <TertiaryButton
@@ -241,7 +235,7 @@ export function TestShake(props: TestShakeProps): JSX.Element {
           </TertiaryButton>
         </Flex>
         <Flex flexDirection={DIRECTION_ROW} alignItems={ALIGN_FLEX_START}>
-          <StyledText width={'22rem'} fontSize={TYPOGRAPHY.fontSizeH2}>
+          <StyledText width="22rem">
             {t('troubleshoot_step2_description')}
           </StyledText>
           <TertiaryButton

--- a/app/src/organisms/Devices/HeaterShakerWizard/TestShake.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/TestShake.tsx
@@ -21,6 +21,7 @@ import {
 import { RPM, HS_RPM_MAX, HS_RPM_MIN } from '@opentrons/shared-data'
 import { TertiaryButton } from '../../../atoms/buttons'
 import { Tooltip } from '../../../atoms/Tooltip'
+import { StyledText } from '../../../atoms/text'
 import { Divider } from '../../../atoms/structure'
 import { InputField } from '../../../atoms/InputField'
 import { Collapsible } from '../../ModuleCard/Collapsible'
@@ -107,13 +108,12 @@ export function TestShake(props: TestShakeProps): JSX.Element {
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN}>
-      <Text
-        color={COLORS.darkBlack}
+      <StyledText
         fontSize={TYPOGRAPHY.fontSizeH2}
-        fontWeight={700}
+        fontWeight={TYPOGRAPHY.fontWeightSemiBold}
       >
         {t('step_4_of_4')}
-      </Text>
+      </StyledText>
       <Flex
         marginTop={SPACING.spacing3}
         marginBottom={SPACING.spacing4}
@@ -181,12 +181,12 @@ export function TestShake(props: TestShakeProps): JSX.Element {
           alignItems={ALIGN_FLEX_START}
         >
           <Flex flexDirection={DIRECTION_COLUMN} maxWidth={'6.25rem'}>
-            <Text
+            <StyledText
               fontSize={TYPOGRAPHY.fontSizeCaption}
               color={COLORS.darkGreyEnabled}
             >
               {t('set_shake_speed')}
-            </Text>
+            </StyledText>
             <InputField
               data-testid={`TestShake_shake_input`}
               units={RPM}
@@ -229,7 +229,9 @@ export function TestShake(props: TestShakeProps): JSX.Element {
           alignItems={ALIGN_FLEX_START}
           marginY={SPACING.spacing6}
         >
-          <Text width={'22rem'}>{t('troubleshoot_step1_description')}</Text>
+          <StyledText width={'22rem'} fontSize={TYPOGRAPHY.fontSizeH2}>
+            {t('troubleshoot_step1_description')}
+          </StyledText>
           <TertiaryButton
             fontSize={TYPOGRAPHY.fontSizeCaption}
             marginLeft={SIZE_AUTO}
@@ -239,7 +241,9 @@ export function TestShake(props: TestShakeProps): JSX.Element {
           </TertiaryButton>
         </Flex>
         <Flex flexDirection={DIRECTION_ROW} alignItems={ALIGN_FLEX_START}>
-          <Text width={'22rem'}>{t('troubleshoot_step2_description')}</Text>
+          <StyledText width={'22rem'} fontSize={TYPOGRAPHY.fontSizeH2}>
+            {t('troubleshoot_step2_description')}
+          </StyledText>
           <TertiaryButton
             fontSize={TYPOGRAPHY.fontSizeCaption}
             marginLeft={SIZE_AUTO}

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/Banner/Banner.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/Banner/Banner.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import {
   COLORS,
   Flex,
-  Text,
   DIRECTION_COLUMN,
   JUSTIFY_SPACE_BETWEEN,
   DIRECTION_ROW,
@@ -12,7 +11,7 @@ import {
   SIZE_6,
   SIZE_1,
   JUSTIFY_CENTER,
-  ALIGN_FLEX_START,
+  ALIGN_CENTER,
 } from '@opentrons/components'
 
 import { StyledText } from '../../../../../atoms/text'
@@ -27,42 +26,36 @@ export function Banner(props: BannerProps): JSX.Element | null {
   const { title, children } = props
 
   return (
-    <React.Fragment>
+    <Flex
+      marginTop={SPACING.spacing4}
+      flexDirection={DIRECTION_COLUMN}
+      backgroundColor={COLORS.background}
+      padding={SPACING.spacing5}
+      justifyContent={JUSTIFY_SPACE_BETWEEN}
+    >
       <Flex
-        marginTop={TYPOGRAPHY.lineHeight16}
-        flexDirection={DIRECTION_COLUMN}
-        backgroundColor={COLORS.background}
-        padding={SPACING.spacing5}
+        flexDirection={DIRECTION_ROW}
         justifyContent={JUSTIFY_SPACE_BETWEEN}
       >
-        <Flex
-          flexDirection={DIRECTION_COLUMN}
-          justifyContent={JUSTIFY_SPACE_BETWEEN}
-        >
-          <Flex
-            flexDirection={DIRECTION_ROW}
-            justifyContent={JUSTIFY_SPACE_BETWEEN}
+        <Flex alignItems={JUSTIFY_CENTER}>
+          <Icon
+            size={SIZE_1}
+            color={COLORS.darkGreyEnabled}
+            name="information"
+            marginRight={SPACING.spacing3}
+            aria-label="information_icon"
+          />
+          <StyledText
+            css={TYPOGRAPHY.h3SemiBold}
+            data-testid={`banner_title_${title}`}
           >
-            <Flex alignItems={JUSTIFY_CENTER}>
-              <Icon
-                size={SIZE_1}
-                color={COLORS.darkGreyEnabled}
-                name="information"
-                marginRight={SPACING.spacing3}
-                aria-label="information_icon"
-              />
-              <StyledText
-                css={TYPOGRAPHY.h3SemiBold}
-                data-testid={`banner_title_${title}`}
-              >
-                {title}
-              </StyledText>
-            </Flex>
-          </Flex>
+            {title}
+          </StyledText>
         </Flex>
-        {children}
       </Flex>
-    </React.Fragment>
+
+      {children}
+    </Flex>
   )
 }
 
@@ -75,36 +68,27 @@ interface BannerItemProps {
 
 export const BannerItem = (props: BannerItemProps): JSX.Element => {
   return (
-    <>
-      <Text
-        fontSize={TYPOGRAPHY.fontSizeP}
-        fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-        color={COLORS.darkBlack}
-        paddingTop={SPACING.spacing4}
-      >
-        {props.title}
-      </Text>
-      <Flex
-        flexDirection={DIRECTION_ROW}
-        justifyContent={JUSTIFY_SPACE_BETWEEN}
-      >
-        <Text
+    <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} alignItems={ALIGN_CENTER}>
+      <Flex flexDirection={DIRECTION_COLUMN}>
+        <StyledText css={TYPOGRAPHY.pSemiBold} paddingTop={SPACING.spacing4}>
+          {props.title}
+        </StyledText>
+        <StyledText
+          as="p"
           marginTop={SPACING.spacing3}
           color={COLORS.darkGrey}
-          fontSize={TYPOGRAPHY.fontSizeP}
           maxWidth={SIZE_6}
           data-testid={`banner_subtitle_${props.title}`}
         >
           {props.body}
-        </Text>
-        <TertiaryButton
-          alignSelf={ALIGN_FLEX_START}
-          data-testid={`banner_open_wizard_btn`}
-          onClick={() => props.onClick()}
-        >
-          {props.btnText}
-        </TertiaryButton>
+        </StyledText>
       </Flex>
-    </>
+      <TertiaryButton
+        data-testid={`banner_open_wizard_btn`}
+        onClick={() => props.onClick()}
+      >
+        {props.btnText}
+      </TertiaryButton>
+    </Flex>
   )
 }

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/Banner/Banner.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/Banner/Banner.tsx
@@ -67,27 +67,28 @@ interface BannerItemProps {
 }
 
 export const BannerItem = (props: BannerItemProps): JSX.Element => {
+  const { title, body, btnText, onClick } = props
   return (
     <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} alignItems={ALIGN_CENTER}>
       <Flex flexDirection={DIRECTION_COLUMN}>
         <StyledText css={TYPOGRAPHY.pSemiBold} paddingTop={SPACING.spacing4}>
-          {props.title}
+          {title}
         </StyledText>
         <StyledText
           as="p"
           marginTop={SPACING.spacing3}
           color={COLORS.darkGrey}
           maxWidth={SIZE_6}
-          data-testid={`banner_subtitle_${props.title}`}
+          data-testid={`banner_subtitle_${title}`}
         >
-          {props.body}
+          {body}
         </StyledText>
       </Flex>
       <TertiaryButton
         data-testid={`banner_open_wizard_btn`}
-        onClick={() => props.onClick()}
+        onClick={() => onClick()}
       >
-        {props.btnText}
+        {btnText}
       </TertiaryButton>
     </Flex>
   )


### PR DESCRIPTION
# Overview

Clean up component to use `StyledText` and change to using correct typography constants

# Changelog

- clean up `banner`
- clean up various components in the H-S wizard
- implement the usage of `StyledText`

# Review requests

- review the banner component in the Labware Setup section and also the H-S wizard. Do they look okay? Do they match designs? Will likely get a pass from Design

# Risk assessment

low
