### PR TITLE
fix(app): rm duplicate module in module controls

### DIFF
--- a/app/src/organisms/Devices/PipettesAndModules.tsx
+++ b/app/src/organisms/Devices/PipettesAndModules.tsx
@@ -46,10 +46,7 @@ export function PipettesAndModules({
   // or left column will contain 1 more item than right column
   const halfAttachedModulesSize = Math.ceil(attachedModules?.length / 2)
   const leftColumnModules = attachedModules?.slice(0, halfAttachedModulesSize)
-  const rightColumnModules =
-    attachedModules?.length > 1
-      ? attachedModules?.slice(-halfAttachedModulesSize)
-      : []
+  const rightColumnModules = attachedModules?.slice(halfAttachedModulesSize)
 
   return (
     <Flex

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunModuleControls.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunModuleControls.tsx
@@ -74,10 +74,7 @@ export const ProtocolRunModuleControls = ({
   // or left column will contain 1 more item than right column
   const halfAttachedModulesSize = Math.ceil(attachedModules?.length / 2)
   const leftColumnModules = attachedModules?.slice(0, halfAttachedModulesSize)
-  const rightColumnModules =
-    attachedModules?.length > 1
-      ? attachedModules?.slice(-halfAttachedModulesSize)
-      : []
+  const rightColumnModules = attachedModules?.slice(halfAttachedModulesSize)
 
   return attachedModules.length === 0 ? (
     <Flex justifyContent={JUSTIFY_CENTER}>


### PR DESCRIPTION
# Overview
Removes duplicate module in protocol run module controls tab.
Closes #11193.

# Changelog
- fixes array slicing in `ProtocolRunModuleControls` and `PipettesAndModules`
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- confirm duplicate module is removed
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Low