### PR TITLE
fix(PAPIv2): allow presses=0 to hover over tip when calling pick_up_tip

### DIFF
--- a/api/src/opentrons/hardware_control/instruments/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/pipette_handler.py
@@ -657,7 +657,7 @@ class PipetteHandlerProvider(Generic[MountType]):
             raise TipAttachedError("Cannot pick up tip with a tip attached")
         self._ihp_log.debug(f"Picking up tip on {mount.name}")
 
-        if not presses or presses < 0:
+        if presses is None or presses < 0:
             checked_presses = instrument.config.pick_up_presses
         else:
             checked_presses = presses

--- a/api/tests/opentrons/hardware_control/test_pipette_handler.py
+++ b/api/tests/opentrons/hardware_control/test_pipette_handler.py
@@ -36,4 +36,6 @@ def test_plan_check_pick_up_tip_with_presses_0(
     decoy.when(mock_pipette.config.pick_up_distance).then_return(0)
     decoy.when(mock_pipette.config.pick_up_increment).then_return(0)
 
-    result = subject.plan_check_pick_up_tip(mount, tip_length, presses, increment)
+    spec, _add_tip_to_instrs = subject.plan_check_pick_up_tip(mount, tip_length, presses, increment)
+
+    assert spec.presses == []

--- a/api/tests/opentrons/hardware_control/test_pipette_handler.py
+++ b/api/tests/opentrons/hardware_control/test_pipette_handler.py
@@ -1,0 +1,36 @@
+"""Tests for the HardwareApi class."""
+import pytest
+import asyncio
+
+from decoy import Decoy
+from typing import Dict, Optional
+
+from opentrons import types
+from opentrons.hardware_control.instruments.pipette import Pipette
+from opentrons.hardware_control.instruments.pipette_handler import PipetteHandlerProvider
+from opentrons.hardware_control.backends import Controller
+from opentrons.config.types import RobotConfig
+
+
+@pytest.fixture
+def subject(
+    decoy: Decoy
+) -> PipetteHandlerProvider:
+    inst_by_mount = {types.MountType.LEFT, decoy.mock(cls=Pipette)}
+    subject = PipetteHandlerProvider(attached_instruments=inst_by_mount)
+
+    return subject
+
+
+async def test_plan_check_pick_up_tip_with_presses_0(decoy: Decoy, subject: PipetteHandlerProvider) -> None:
+    """Should return an array with 0 length."""
+    tip_length = 25.0
+    mount = types.Mount.LEFT
+    presses = 0
+    increment = None
+
+    # decoy.when(subject.get_pipette(mount)).then_return(decoy.mock(cls=Pipette))
+    await subject.plan_check_pick_up_tip(mount, tip_length, presses, increment)
+
+
+

--- a/api/tests/opentrons/hardware_control/test_pipette_handler.py
+++ b/api/tests/opentrons/hardware_control/test_pipette_handler.py
@@ -22,7 +22,7 @@ def subject(decoy: Decoy, mock_pipette: Pipette) -> PipetteHandlerProvider:
     return subject
 
 
-@pytest.mark.parametrize("presses_input, expected_array_length", [(0, 0)])
+@pytest.mark.parametrize("presses_input, expected_array_length", [(0, 0), (None, 3), (3, 3)])
 def test_plan_check_pick_up_tip_with_presses_0(
     decoy: Decoy, subject: PipetteHandlerProvider,
     mock_pipette: Pipette,
@@ -39,6 +39,9 @@ def test_plan_check_pick_up_tip_with_presses_0(
     decoy.when(mock_pipette.config.quirks).then_return([])
     decoy.when(mock_pipette.config.pick_up_distance).then_return(0)
     decoy.when(mock_pipette.config.pick_up_increment).then_return(0)
+
+    if presses_input is None:
+        decoy.when(mock_pipette.config.pick_up_presses).then_return(expected_array_length)
 
     spec, _add_tip_to_instrs = subject.plan_check_pick_up_tip(mount, tip_length, presses, increment)
 

--- a/api/tests/opentrons/hardware_control/test_pipette_handler.py
+++ b/api/tests/opentrons/hardware_control/test_pipette_handler.py
@@ -22,12 +22,15 @@ def subject(decoy: Decoy, mock_pipette: Pipette) -> PipetteHandlerProvider:
     return subject
 
 
-@pytest.mark.parametrize("presses_input, expected_array_length", [(0, 0), (None, 3), (3, 3)])
-def test_plan_check_pick_up_tip_with_presses_0(
-    decoy: Decoy, subject: PipetteHandlerProvider,
+@pytest.mark.parametrize(
+    "presses_input, expected_array_length", [(0, 0), (None, 3), (3, 3)]
+)
+def test_plan_check_pick_up_tip_with_presses_argument(
+    decoy: Decoy,
+    subject: PipetteHandlerProvider,
     mock_pipette: Pipette,
     presses_input: int,
-    expected_array_length: int
+    expected_array_length: int,
 ) -> None:
     """Should return an array with expected length."""
     tip_length = 25.0
@@ -41,8 +44,12 @@ def test_plan_check_pick_up_tip_with_presses_0(
     decoy.when(mock_pipette.config.pick_up_increment).then_return(0)
 
     if presses_input is None:
-        decoy.when(mock_pipette.config.pick_up_presses).then_return(expected_array_length)
+        decoy.when(mock_pipette.config.pick_up_presses).then_return(
+            expected_array_length
+        )
 
-    spec, _add_tip_to_instrs = subject.plan_check_pick_up_tip(mount, tip_length, presses, increment)
+    spec, _add_tip_to_instrs = subject.plan_check_pick_up_tip(
+        mount, tip_length, presses, increment
+    )
 
     assert len(spec.presses) == expected_array_length

--- a/api/tests/opentrons/hardware_control/test_pipette_handler.py
+++ b/api/tests/opentrons/hardware_control/test_pipette_handler.py
@@ -22,13 +22,17 @@ def subject(decoy: Decoy, mock_pipette: Pipette) -> PipetteHandlerProvider:
     return subject
 
 
+@pytest.mark.parametrize("presses_input, expected_array_length", [(0, 0)])
 def test_plan_check_pick_up_tip_with_presses_0(
-    decoy: Decoy, subject: PipetteHandlerProvider, mock_pipette
+    decoy: Decoy, subject: PipetteHandlerProvider,
+    mock_pipette: Pipette,
+    presses_input: int,
+    expected_array_length: int
 ) -> None:
-    """Should return an array with 0 length."""
+    """Should return an array with expected length."""
     tip_length = 25.0
     mount = types.Mount.LEFT
-    presses = 0
+    presses = presses_input
     increment = None
 
     decoy.when(mock_pipette.has_tip).then_return(False)
@@ -38,4 +42,4 @@ def test_plan_check_pick_up_tip_with_presses_0(
 
     spec, _add_tip_to_instrs = subject.plan_check_pick_up_tip(mount, tip_length, presses, increment)
 
-    assert spec.presses == []
+    assert len(spec.presses) == expected_array_length


### PR DESCRIPTION
# Overview

closes #9414.
allow argument `presses=0` when calling pick_up_tip() in APIv2

# Changelog

- changed condition in plan_check_pick_up_tip to check for None instead of not
- Added a new test suite to test pipette_handler.py

# Review requests

- [x] tested on a robot.
- [ ] I really want to add a test for the hardware api layer to make sure _move is being called once when supplied presses=0 but its turning into a rabbit whole. any suggestions? 
- [ ] are the tests sufficient? 

# Risk assessment

Very small change but could affect pick_up_tip() functionality.