### PR TITLE
refactor(step-generation): fix HS pipetting restrictions

### DIFF
--- a/step-generation/src/__tests__/getLabwareSlot.test.ts
+++ b/step-generation/src/__tests__/getLabwareSlot.test.ts
@@ -1,0 +1,22 @@
+import { getLabwareSlot } from '../utils'
+
+describe('getLabwareSlot', () => {
+  it('should return the slot the labware is in when it is NOT on top of a module', () => {
+    const labware = {
+      someLabwareId: { slot: '1' },
+    }
+    const modules = {}
+
+    expect(getLabwareSlot('someLabwareId', labware, modules)).toBe('1')
+  })
+  it('should return the slot the labware is in when it is on top of a module', () => {
+    const labware = {
+      someLabwareId: { slot: 'someModuleId' },
+    }
+    const modules = {
+      someModuleId: { slot: '2', moduleState: {} as any },
+    }
+
+    expect(getLabwareSlot('someLabwareId', labware, modules)).toBe('2')
+  })
+})

--- a/step-generation/src/commandCreators/atomic/aspirate.ts
+++ b/step-generation/src/commandCreators/atomic/aspirate.ts
@@ -7,6 +7,7 @@ import {
   pipetteIntoHeaterShakerWhileShaking,
   getIsHeaterShakerEastWestWithLatchOpen,
   pipetteAdjacentHeaterShakerWhileShaking,
+  getLabwareSlot,
   getIsHeaterShakerEastWestMultiChannelPipette,
   getIsHeaterShakerNorthSouthOfNonTiprackWithMultiChannelPipette,
   uuid,
@@ -25,6 +26,12 @@ export const aspirate: CommandCreator<AspirateParams> = (
   const actionName = 'aspirate'
   const errors: CommandCreatorError[] = []
   const pipetteSpec = invariantContext.pipetteEntities[pipette]?.spec
+
+  const slotName = getLabwareSlot(
+    labware,
+    prevRobotState.labware,
+    prevRobotState.modules
+  )
 
   if (!pipetteSpec) {
     errors.push(
@@ -96,18 +103,12 @@ export const aspirate: CommandCreator<AspirateParams> = (
     errors.push(errorCreators.heaterShakerIsShaking())
   }
   if (
-    pipetteAdjacentHeaterShakerWhileShaking(
-      prevRobotState.modules,
-      prevRobotState.labware[labware]?.slot
-    )
+    pipetteAdjacentHeaterShakerWhileShaking(prevRobotState.modules, slotName)
   ) {
     errors.push(errorCreators.heaterShakerNorthSouthEastWestShaking())
   }
   if (
-    getIsHeaterShakerEastWestWithLatchOpen(
-      prevRobotState.modules,
-      prevRobotState.labware[labware]?.slot
-    )
+    getIsHeaterShakerEastWestWithLatchOpen(prevRobotState.modules, slotName)
   ) {
     errors.push(errorCreators.heaterShakerEastWestWithLatchOpen())
   }
@@ -115,7 +116,7 @@ export const aspirate: CommandCreator<AspirateParams> = (
   if (
     getIsHeaterShakerEastWestMultiChannelPipette(
       prevRobotState.modules,
-      prevRobotState.labware[labware]?.slot,
+      slotName,
       pipetteSpec
     )
   ) {
@@ -124,7 +125,7 @@ export const aspirate: CommandCreator<AspirateParams> = (
   if (
     getIsHeaterShakerNorthSouthOfNonTiprackWithMultiChannelPipette(
       prevRobotState.modules,
-      prevRobotState.labware[labware]?.slot,
+      slotName,
       pipetteSpec,
       invariantContext.labwareEntities[labware]
     )

--- a/step-generation/src/commandCreators/atomic/dispense.ts
+++ b/step-generation/src/commandCreators/atomic/dispense.ts
@@ -6,6 +6,7 @@ import {
   pipetteIntoHeaterShakerWhileShaking,
   getIsHeaterShakerEastWestWithLatchOpen,
   pipetteAdjacentHeaterShakerWhileShaking,
+  getLabwareSlot,
   getIsHeaterShakerEastWestMultiChannelPipette,
   getIsHeaterShakerNorthSouthOfNonTiprackWithMultiChannelPipette,
   uuid,
@@ -24,6 +25,11 @@ export const dispense: CommandCreator<DispenseParams> = (
   const actionName = 'dispense'
   const errors: CommandCreatorError[] = []
   const pipetteSpec = invariantContext.pipetteEntities[pipette]?.spec
+  const slotName = getLabwareSlot(
+    labware,
+    prevRobotState.labware,
+    prevRobotState.modules
+  )
 
   if (!pipetteSpec) {
     errors.push(
@@ -96,19 +102,13 @@ export const dispense: CommandCreator<DispenseParams> = (
   }
 
   if (
-    pipetteAdjacentHeaterShakerWhileShaking(
-      prevRobotState.modules,
-      prevRobotState.labware[labware]?.slot
-    )
+    pipetteAdjacentHeaterShakerWhileShaking(prevRobotState.modules, slotName)
   ) {
     errors.push(errorCreators.heaterShakerNorthSouthEastWestShaking())
   }
 
   if (
-    getIsHeaterShakerEastWestWithLatchOpen(
-      prevRobotState.modules,
-      prevRobotState.labware[labware]?.slot
-    )
+    getIsHeaterShakerEastWestWithLatchOpen(prevRobotState.modules, slotName)
   ) {
     errors.push(errorCreators.heaterShakerEastWestWithLatchOpen())
   }
@@ -116,7 +116,7 @@ export const dispense: CommandCreator<DispenseParams> = (
   if (
     getIsHeaterShakerEastWestMultiChannelPipette(
       prevRobotState.modules,
-      prevRobotState.labware[labware]?.slot,
+      slotName,
       pipetteSpec
     )
   ) {
@@ -125,7 +125,7 @@ export const dispense: CommandCreator<DispenseParams> = (
   if (
     getIsHeaterShakerNorthSouthOfNonTiprackWithMultiChannelPipette(
       prevRobotState.modules,
-      prevRobotState.labware[labware]?.slot,
+      slotName,
       pipetteSpec,
       invariantContext.labwareEntities[labware]
     )

--- a/step-generation/src/commandCreators/atomic/moveToWell.ts
+++ b/step-generation/src/commandCreators/atomic/moveToWell.ts
@@ -6,6 +6,7 @@ import {
   pipetteIntoHeaterShakerWhileShaking,
   getIsHeaterShakerEastWestWithLatchOpen,
   pipetteAdjacentHeaterShakerWhileShaking,
+  getLabwareSlot,
   getIsHeaterShakerEastWestMultiChannelPipette,
   getIsHeaterShakerNorthSouthOfNonTiprackWithMultiChannelPipette,
   uuid,
@@ -27,6 +28,11 @@ export const moveToWell: CommandCreator<v5MoveToWellParams> = (
   // TODO(2020-07-30, IL): the below is duplicated or at least similar
   // across aspirate/dispense/blowout, we can probably DRY it up
   const pipetteSpec = invariantContext.pipetteEntities[pipette]?.spec
+  const slotName = getLabwareSlot(
+    labware,
+    prevRobotState.labware,
+    prevRobotState.modules
+  )
 
   if (!pipetteSpec) {
     errors.push(
@@ -88,19 +94,13 @@ export const moveToWell: CommandCreator<v5MoveToWellParams> = (
   }
 
   if (
-    pipetteAdjacentHeaterShakerWhileShaking(
-      prevRobotState.modules,
-      prevRobotState.labware[labware]?.slot
-    )
+    pipetteAdjacentHeaterShakerWhileShaking(prevRobotState.modules, slotName)
   ) {
     errors.push(errorCreators.heaterShakerNorthSouthEastWestShaking())
   }
 
   if (
-    getIsHeaterShakerEastWestWithLatchOpen(
-      prevRobotState.modules,
-      prevRobotState.labware[labware]?.slot
-    )
+    getIsHeaterShakerEastWestWithLatchOpen(prevRobotState.modules, slotName)
   ) {
     errors.push(errorCreators.heaterShakerEastWestWithLatchOpen())
   }
@@ -108,7 +108,7 @@ export const moveToWell: CommandCreator<v5MoveToWellParams> = (
   if (
     getIsHeaterShakerEastWestMultiChannelPipette(
       prevRobotState.modules,
-      prevRobotState.labware[labware]?.slot,
+      slotName,
       pipetteSpec
     )
   ) {
@@ -118,7 +118,7 @@ export const moveToWell: CommandCreator<v5MoveToWellParams> = (
   if (
     getIsHeaterShakerNorthSouthOfNonTiprackWithMultiChannelPipette(
       prevRobotState.modules,
-      prevRobotState.labware[labware]?.slot,
+      slotName,
       pipetteSpec,
       invariantContext.labwareEntities[labware]
     )

--- a/step-generation/src/utils/getLabwareSlot.ts
+++ b/step-generation/src/utils/getLabwareSlot.ts
@@ -1,0 +1,18 @@
+import { RobotState } from '../types'
+
+// this function returns the slot a labware is in (which should be a string 1-12)
+// the reason this function is needed is because if a labware is on top of a module
+// the "slot" value it holds is the module id of the module it occupies.
+export const getLabwareSlot = (
+  labwareId: string,
+  labware: RobotState['labware'],
+  modules: RobotState['modules']
+): string => {
+  const labwareSlotOrModuleId = labware[labwareId]?.slot
+  const isLabwareOnTopOfModule = labwareSlotOrModuleId in modules
+  const slotName = isLabwareOnTopOfModule
+    ? modules[labwareSlotOrModuleId].slot
+    : labwareSlotOrModuleId
+
+  return slotName
+}

--- a/step-generation/src/utils/index.ts
+++ b/step-generation/src/utils/index.ts
@@ -6,6 +6,7 @@ import { modulePipetteCollision } from './modulePipetteCollision'
 import { thermocyclerPipetteCollision } from './thermocyclerPipetteCollision'
 import { orderWells } from './orderWells'
 import { isValidSlot } from './isValidSlot'
+import { getLabwareSlot } from './getLabwareSlot'
 export {
   commandCreatorsTimeline,
   curryCommandCreator,
@@ -14,6 +15,7 @@ export {
   modulePipetteCollision,
   thermocyclerPipetteCollision,
   isValidSlot,
+  getLabwareSlot,
 }
 export * from './commandCreatorArgsGetters'
 export * from './misc'

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -307,7 +307,7 @@ export function makeInitialRobotState(args: {
   const {
     invariantContext,
     labwareLocations,
-    moduleLocations,
+    moduleLocations = {},
     pipetteLocations,
   } = args
   return {


### PR DESCRIPTION
# Overview

This PR fixes an issue where some HS pipetting restrictions were not getting raised. This was happening because (1) we were not raising them when replacing tips and (2) in some cases we were using the module id instead of the slot as inputs to functions that expected a slot (1-12). This was happening because in robot state if a labware is on top of a module, it's `slot` is the module id (super confusing). 


# Review requests

Try to access a tiprack next to a HS with an 8-channel pipette, you should get a timeline error.

# Risk assessment
Low