### PR TITLE
feat(app): use started at timestamp in run log

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/RunLog.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/RunLog.tsx
@@ -174,7 +174,9 @@ export function RunLog({ robotName, runId }: RunLogProps): JSX.Element | null {
       ? dropWhile(
           runCommands,
           runCommandSummary =>
-            new Date(runCommandSummary.createdAt) <= runStartDateTime
+            new Date(
+              runCommandSummary.startedAt ?? runCommandSummary.createdAt
+            ) <= runStartDateTime
         )
       : []
 

--- a/app/src/organisms/RunDetails/CommandList.tsx
+++ b/app/src/organisms/RunDetails/CommandList.tsx
@@ -128,7 +128,9 @@ export function CommandList(): JSX.Element | null {
       ? dropWhile(
           runCommands,
           runCommandSummary =>
-            new Date(runCommandSummary.createdAt) <= runStartDateTime
+            new Date(
+              runCommandSummary.startedAt ?? runCommandSummary.createdAt
+            ) <= runStartDateTime
         )
       : []
 


### PR DESCRIPTION
# Overview

The run log was not populating timestamps properly for JSON v6 protocols because we were using the `createdAt` timestamp instead of the `startedAt` timestamp when calculating the duration since a command started. This PR prefers `startedAt` when available, and falls back to `createdAt` when it's not. 

# Changelog

- Use started at timestamp in run log

# Review requests

Upload a JSON v6 protocol to the app and run it. The run log should populate the correct the duration of each command just like it does for python protocols.

# Risk assessment

Low
