### PR TITLE
refactor(OT3): make gripper z its own axis kind

### DIFF
--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -65,6 +65,7 @@ DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad
         OT3AxisKind.Y: 40,
         OT3AxisKind.Z: 20,
         OT3AxisKind.P: 100,
+        OT3AxisKind.Z_G: 20,
     },
     high_throughput={
         OT3AxisKind.X: 40,
@@ -93,6 +94,7 @@ DEFAULT_ACCELERATIONS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryL
         OT3AxisKind.Y: 100,
         OT3AxisKind.Z: 100,
         OT3AxisKind.P: 100,
+        OT3AxisKind.Z_G: 100,
     },
     high_throughput={
         OT3AxisKind.X: 100,
@@ -122,6 +124,7 @@ DEFAULT_MAX_SPEED_DISCONTINUITY: Final[
         OT3AxisKind.X: 40,
         OT3AxisKind.Y: 40,
         OT3AxisKind.Z: 40,
+        OT3AxisKind.Z_G: 10,
         OT3AxisKind.P: 10,
     },
     high_throughput={
@@ -153,6 +156,7 @@ DEFAULT_DIRECTION_CHANGE_SPEED_DISCONTINUITY: Final[
         OT3AxisKind.Y: 20,
         OT3AxisKind.Z: 20,
         OT3AxisKind.P: 20,
+        OT3AxisKind.Z_G: 10,
     },
     high_throughput={
         OT3AxisKind.X: 20,
@@ -181,6 +185,7 @@ DEFAULT_HOLD_CURRENT: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLo
         OT3AxisKind.Y: 0.1,
         OT3AxisKind.Z: 0.1,
         OT3AxisKind.P: 0.1,
+        OT3AxisKind.Z_G: 0.1,
     },
     high_throughput={
         OT3AxisKind.X: 0.1,
@@ -209,6 +214,7 @@ DEFAULT_RUN_CURRENT: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoa
         OT3AxisKind.Y: 1.4,
         OT3AxisKind.Z: 1.4,
         OT3AxisKind.P: 1.4,
+        OT3AxisKind.Z_G: 1.4,
     },
     high_throughput={
         OT3AxisKind.X: 1.0,

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -148,7 +148,13 @@ def get_current_settings(
 ) -> OT3AxisMap[CurrentConfig]:
     conf_by_pip = config.by_gantry_load(gantry_load)
     currents = {}
-    for axis_kind in [OT3AxisKind.P, OT3AxisKind.X, OT3AxisKind.Y, OT3AxisKind.Z]:
+    for axis_kind in [
+        OT3AxisKind.P,
+        OT3AxisKind.X,
+        OT3AxisKind.Y,
+        OT3AxisKind.Z,
+        OT3AxisKind.Z_G,
+    ]:
         for axis in OT3Axis.of_kind(axis_kind):
             currents[axis] = CurrentConfig(
                 conf_by_pip["hold_current"][axis_kind],
@@ -163,7 +169,13 @@ def get_system_constraints(
 ) -> "SystemConstraints[OT3Axis]":
     conf_by_pip = config.by_gantry_load(gantry_load)
     constraints = {}
-    for axis_kind in [OT3AxisKind.P, OT3AxisKind.X, OT3AxisKind.Y, OT3AxisKind.Z]:
+    for axis_kind in [
+        OT3AxisKind.P,
+        OT3AxisKind.X,
+        OT3AxisKind.Y,
+        OT3AxisKind.Z,
+        OT3AxisKind.Z_G,
+    ]:
         for axis in OT3Axis.of_kind(axis_kind):
             constraints[axis] = AxisConstraints.build(
                 conf_by_pip["acceleration"][axis_kind],

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -102,14 +102,19 @@ class OT3AxisKind(enum.Enum):
     Y = 1
     #: Gantry Y axis
     Z = 2
-    #: Z axis (of the left and right and gripper mounts)
+    #: Z axis (of the left and right)
     P = 3
     #: Plunger axis (of the left and right pipettes)
-    OTHER = 4
+    Z_G = 4
+    #: Gripper Z axis
+    OTHER = 5
     #: The internal axes of high throughput pipettes, for instance
 
     def __str__(self) -> str:
         return self.name
+
+    def is_z_axis(self) -> bool:
+        return self in [OT3AxisKind.Z, OT3AxisKind.Z_G]
 
 
 class OT3Axis(enum.Enum):
@@ -199,7 +204,7 @@ class OT3Axis(enum.Enum):
             cls.Y: OT3AxisKind.Y,
             cls.Z_L: OT3AxisKind.Z,
             cls.Z_R: OT3AxisKind.Z,
-            cls.Z_G: OT3AxisKind.Z,
+            cls.Z_G: OT3AxisKind.Z_G,
             cls.Q: OT3AxisKind.OTHER,
             cls.G: OT3AxisKind.OTHER,
         }
@@ -211,7 +216,8 @@ class OT3Axis(enum.Enum):
             OT3AxisKind.P: [cls.P_R, cls.P_L],
             OT3AxisKind.X: [cls.X],
             OT3AxisKind.Y: [cls.Y],
-            OT3AxisKind.Z: [cls.Z_G, cls.Z_L, cls.Z_R],
+            OT3AxisKind.Z: [cls.Z_L, cls.Z_R],
+            OT3AxisKind.Z_G: [cls.Z_G],
             OT3AxisKind.OTHER: [cls.Q, cls.G],
         }
         return kind_map[kind]
@@ -231,7 +237,7 @@ class OT3Axis(enum.Enum):
         return self.name
 
     def of_point(self, point: top_types.Point) -> float:
-        if OT3Axis.to_kind(self) == OT3AxisKind.Z:
+        if OT3Axis.to_kind(self).is_z_axis():
             return point.z
         elif self == OT3Axis.X:
             return point.x
@@ -241,7 +247,7 @@ class OT3Axis(enum.Enum):
             raise KeyError(self)
 
     def set_in_point(self, point: top_types.Point, position: float) -> top_types.Point:
-        if OT3Axis.to_kind(self) == OT3AxisKind.Z:
+        if OT3Axis.to_kind(self).is_z_axis():
             return point._replace(z=position)
         elif self == OT3Axis.X:
             return point._replace(x=position)

--- a/api/tests/opentrons/config/ot3_settings.py
+++ b/api/tests/opentrons/config/ot3_settings.py
@@ -9,6 +9,7 @@ ot3_dummy_settings = {
                 "Y": 2,
                 "Z": 15,
                 "P": 2,
+                "Z_G": 5,
             },
             "low_throughput": {
                 "X": 3,
@@ -25,6 +26,7 @@ ot3_dummy_settings = {
             "two_low_throughput": {"X": 1.1, "Y": 2.2},
             "gripper": {
                 "Z": 2.8,
+                "Z_G": 6,
             },
         },
         "default_max_speed": {
@@ -33,6 +35,7 @@ ot3_dummy_settings = {
                 "Y": 2,
                 "Z": 3,
                 "P": 4,
+                "Z_G": 5,
             },
             "low_throughput": {
                 "X": 1,
@@ -60,6 +63,7 @@ ot3_dummy_settings = {
                 "Y": 20,
                 "Z": 30,
                 "P": 40,
+                "Z_G": 50,
             },
             "low_throughput": {
                 "X": 1,
@@ -87,6 +91,7 @@ ot3_dummy_settings = {
                 "Y": 10,
                 "Z": 15,
                 "P": 20,
+                "Z_G": 15,
             },
             "low_throughput": {
                 "X": 0.8,
@@ -116,6 +121,7 @@ ot3_dummy_settings = {
                 "Y": 0.7,
                 "Z": 0.7,
                 "P": 0.8,
+                "Z_G": 0.5,
             },
             "low_throughput": {
                 "X": 0.7,
@@ -140,6 +146,7 @@ ot3_dummy_settings = {
                 "Y": 7.0,
                 "Z": 7.0,
                 "P": 5.0,
+                "Z_G": 5.0,
             },
             "low_throughput": {
                 "X": 1,

--- a/api/tests/opentrons/config/test_defaults_ot3.py
+++ b/api/tests/opentrons/config/test_defaults_ot3.py
@@ -172,24 +172,28 @@ def test_motion_settings_dataclass() -> None:
         OT3AxisKind.Y: 2,
         OT3AxisKind.Z: 15,
         OT3AxisKind.P: 2,
+        OT3AxisKind.Z_G: 5,
     }
     assert none_setting["default_max_speed"] == {
         OT3AxisKind.X: 1,
         OT3AxisKind.Y: 2,
         OT3AxisKind.Z: 3,
         OT3AxisKind.P: 4,
+        OT3AxisKind.Z_G: 5,
     }
     assert none_setting["max_speed_discontinuity"] == {
         OT3AxisKind.X: 10,
         OT3AxisKind.Y: 20,
         OT3AxisKind.Z: 30,
         OT3AxisKind.P: 40,
+        OT3AxisKind.Z_G: 50,
     }
     assert none_setting["direction_change_speed_discontinuity"] == {
         OT3AxisKind.X: 5,
         OT3AxisKind.Y: 10,
         OT3AxisKind.Z: 15,
         OT3AxisKind.P: 20,
+        OT3AxisKind.Z_G: 15,
     }
 
     gripper_setting = motion_settings.by_gantry_load(GantryLoad.GRIPPER)
@@ -198,24 +202,28 @@ def test_motion_settings_dataclass() -> None:
         OT3AxisKind.Y: 2,
         OT3AxisKind.Z: 2.8,
         OT3AxisKind.P: 2,
+        OT3AxisKind.Z_G: 6,
     }
     assert gripper_setting["default_max_speed"] == {
         OT3AxisKind.X: 1,
         OT3AxisKind.Y: 2,
         OT3AxisKind.Z: 2.8,
         OT3AxisKind.P: 4,
+        OT3AxisKind.Z_G: 5,
     }
     assert gripper_setting["max_speed_discontinuity"] == {
         OT3AxisKind.X: 10,
         OT3AxisKind.Y: 20,
         OT3AxisKind.Z: 2.8,
         OT3AxisKind.P: 40,
+        OT3AxisKind.Z_G: 50,
     }
     assert gripper_setting["direction_change_speed_discontinuity"] == {
         OT3AxisKind.X: 5,
         OT3AxisKind.Y: 10,
         OT3AxisKind.Z: 2.8,
         OT3AxisKind.P: 20,
+        OT3AxisKind.Z_G: 15,
     }
 
     two_low_setting = motion_settings.by_gantry_load(GantryLoad.TWO_LOW_THROUGHPUT)
@@ -224,22 +232,26 @@ def test_motion_settings_dataclass() -> None:
         OT3AxisKind.Y: 2.2,
         OT3AxisKind.Z: 15,
         OT3AxisKind.P: 2,
+        OT3AxisKind.Z_G: 5,
     }
     assert two_low_setting["default_max_speed"] == {
         OT3AxisKind.X: 4,
         OT3AxisKind.Y: 3,
         OT3AxisKind.Z: 2,
         OT3AxisKind.P: 1,
+        OT3AxisKind.Z_G: 5,
     }
     assert two_low_setting["max_speed_discontinuity"] == {
         OT3AxisKind.X: 1,
         OT3AxisKind.Y: 2,
         OT3AxisKind.Z: 3,
         OT3AxisKind.P: 6,
+        OT3AxisKind.Z_G: 50,
     }
     assert two_low_setting["direction_change_speed_discontinuity"] == {
         OT3AxisKind.X: 0.5,
         OT3AxisKind.Y: 1,
         OT3AxisKind.Z: 1.5,
         OT3AxisKind.P: 3,
+        OT3AxisKind.Z_G: 15,
     }

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -147,7 +147,7 @@ class MoveCompletedPayload(MoveGroupResponsePayload):
 
     seq_id: utils.UInt8Field
     current_position_um: utils.UInt32Field
-    encoder_position: utils.Int32Field
+    encoder_position_um: utils.Int32Field
     ack_id: utils.UInt8Field
 
 

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -146,7 +146,7 @@ class MoveGroupRunner:
                         completion.payload.seq_id.value,
                     ),
                     float(completion.payload.current_position_um.value) / 1000.0,
-                    float(completion.payload.encoder_position.value) / 1000.0,
+                    float(completion.payload.encoder_position_um.value) / 1000.0,
                 )
             )
         # for each node, pull the position from the completion with the largest

--- a/hardware/tests/opentrons_hardware/drivers/can_bus/test_can_messenger.py
+++ b/hardware/tests/opentrons_hardware/drivers/can_bus/test_can_messenger.py
@@ -78,7 +78,7 @@ async def test_context(mock_driver: AsyncMock) -> None:
                     group_id=UInt8Field(1),
                     seq_id=UInt8Field(2),
                     current_position_um=UInt32Field(3),
-                    encoder_position=Int32Field(3),
+                    encoder_position_um=Int32Field(3),
                     ack_id=UInt8Field(4),
                 )
             ),

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -362,7 +362,7 @@ class MockSendMoveCompleter:
                         group_id=message.payload.group_id,
                         seq_id=UInt8Field(seq_id),
                         current_position_um=UInt32Field(int(move.distance_mm * 1000)),
-                        encoder_position=Int32Field(int(move.distance_mm * 4000)),
+                        encoder_position_um=Int32Field(int(move.distance_mm * 4000)),
                         ack_id=UInt8Field(1),
                     )
                     arbitration_id = ArbitrationId(
@@ -467,7 +467,7 @@ def _build_arb(from_node: NodeId) -> ArbitrationId:
                             group_id=UInt8Field(2),
                             seq_id=UInt8Field(2),
                             current_position_um=UInt32Field(10000),
-                            encoder_position=Int32Field(10000 * 4),
+                            encoder_position_um=Int32Field(10000 * 4),
                         )
                     ),
                 ),
@@ -479,7 +479,7 @@ def _build_arb(from_node: NodeId) -> ArbitrationId:
                             group_id=UInt8Field(2),
                             seq_id=UInt8Field(1),
                             current_position_um=UInt32Field(20000),
-                            encoder_position=Int32Field(10000 * 4),
+                            encoder_position_um=Int32Field(10000 * 4),
                         )
                     ),
                 ),
@@ -491,7 +491,7 @@ def _build_arb(from_node: NodeId) -> ArbitrationId:
                             group_id=UInt8Field(1),
                             seq_id=UInt8Field(2),
                             current_position_um=UInt32Field(30000),
-                            encoder_position=Int32Field(10000 * 4),
+                            encoder_position_um=Int32Field(10000 * 4),
                         )
                     ),
                 ),
@@ -509,7 +509,7 @@ def _build_arb(from_node: NodeId) -> ArbitrationId:
                             group_id=UInt8Field(2),
                             seq_id=UInt8Field(2),
                             current_position_um=UInt32Field(10000),
-                            encoder_position=Int32Field(10000 * 4),
+                            encoder_position_um=Int32Field(10000 * 4),
                         )
                     ),
                 ),
@@ -521,7 +521,7 @@ def _build_arb(from_node: NodeId) -> ArbitrationId:
                             group_id=UInt8Field(2),
                             seq_id=UInt8Field(1),
                             current_position_um=UInt32Field(20000),
-                            encoder_position=Int32Field(10000 * 4),
+                            encoder_position_um=Int32Field(10000 * 4),
                         )
                     ),
                 ),
@@ -533,7 +533,7 @@ def _build_arb(from_node: NodeId) -> ArbitrationId:
                             group_id=UInt8Field(1),
                             seq_id=UInt8Field(2),
                             current_position_um=UInt32Field(30000),
-                            encoder_position=Int32Field(10000 * 4),
+                            encoder_position_um=Int32Field(10000 * 4),
                         )
                     ),
                 ),

--- a/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
@@ -120,7 +120,7 @@ async def test_capacitive_probe(
                             group_id=UInt8Field(0),
                             seq_id=UInt8Field(0),
                             current_position_um=UInt32Field(10000),
-                            encoder_position=Int32Field(10000),
+                            encoder_position_um=Int32Field(10000),
                             ack_id=UInt8Field(0),
                         )
                     ),
@@ -207,7 +207,7 @@ async def test_capacitive_sweep(
                             group_id=UInt8Field(0),
                             seq_id=UInt8Field(0),
                             current_position_um=UInt32Field(10000),
-                            encoder_position=Int32Field(10000),
+                            encoder_position_um=Int32Field(10000),
                             ack_id=UInt8Field(0),
                         )
                     ),


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We previously tried to use the same speed/acceleration values for all of the mount axes (LEFT, RIGHT and GRIPPER). But since the specs of the gripper Z motor are so different from the pipette mounts, let's separate it from the other z axes. 

I'm sneaking in some changes need to happen to opentrons_hardware that is required by Opentrons/ot3-firmware/pull/420  on the firmware side.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
