### PR TITLE
refactor(app): rm need to create new components on every render of app tab content

### DIFF
--- a/app/src/pages/AppSettings/index.tsx
+++ b/app/src/pages/AppSettings/index.tsx
@@ -31,18 +31,18 @@ export function AppSettings(): JSX.Element {
   const { appSettingsTab } = useParams<NavRouteParams>()
 
   const appSettingsContentByTab: {
-    [K in AppSettingsTab]: () => JSX.Element
+    [K in AppSettingsTab]: JSX.Element
   } = {
-    general: GeneralSettings,
-    privacy: PrivacySettings,
-    advanced: AdvancedSettings,
-    'feature-flags': FeatureFlags,
+    general: <GeneralSettings />,
+    privacy: <PrivacySettings />,
+    advanced: <AdvancedSettings />,
+    'feature-flags': <FeatureFlags />,
   }
 
-  const AppSettingsContent =
-    appSettingsContentByTab[appSettingsTab] ??
+  const appSettingsContent = appSettingsContentByTab[appSettingsTab] ?? (
     // default to the general tab if no tab or nonexistent tab is passed as a param
-    (() => <Redirect to={`/app-settings/general`} />)
+    <Redirect to={`/app-settings/general`} />
+  )
 
   return (
     <Flex paddingX={SPACING.spacing4} paddingY={SPACING.spacing4}>
@@ -76,7 +76,7 @@ export function AppSettings(): JSX.Element {
           </Flex>
         </Box>
         <Line />
-        <AppSettingsContent />
+        {appSettingsContent}
       </Box>
     </Flex>
   )

--- a/app/src/pages/Devices/ProtocolRunDetails/index.tsx
+++ b/app/src/pages/Devices/ProtocolRunDetails/index.tsx
@@ -131,38 +131,29 @@ export function ProtocolRunDetails(): JSX.Element | null {
 
   const robot = useRobot(robotName)
   useSyncRobotClock(robotName)
-  interface ProtocolRunDetailsTabProps {
-    protocolRunHeaderRef: React.RefObject<HTMLDivElement> | null
-    robotName: string
-    runId: string
-  }
 
   const protocolRunDetailsContentByTab: {
-    [K in ProtocolRunDetailsTab]: ({
-      protocolRunHeaderRef,
-      robotName,
-      runId,
-    }: ProtocolRunDetailsTabProps) => JSX.Element | null
+    [K in ProtocolRunDetailsTab]: JSX.Element | null
   } = {
-    setup: () => (
+    setup: (
       <ProtocolRunSetup
         protocolRunHeaderRef={protocolRunHeaderRef}
         robotName={robotName}
         runId={runId}
       />
     ),
-    'module-controls': () => (
+    'module-controls': (
       <ProtocolRunModuleControls robotName={robotName} runId={runId} />
     ),
-    'run-log': () => <RunLog robotName={robotName} runId={runId} />,
+    'run-log': <RunLog robotName={robotName} runId={runId} />,
   }
 
-  const ProtocolRunDetailsContent =
-    protocolRunDetailsContentByTab[protocolRunDetailsTab] ??
+  const protocolRunDetailsContent = protocolRunDetailsContentByTab[
+    protocolRunDetailsTab
+  ] ?? (
     // default to the setup tab if no tab or nonexistent tab is passed as a param
-    (() => (
-      <Redirect to={`/devices/${robotName}/protocol-runs/${runId}/setup`} />
-    ))
+    <Redirect to={`/devices/${robotName}/protocol-runs/${runId}/setup`} />
+  )
 
   React.useEffect(() => {
     dispatch(fetchProtocols())
@@ -207,11 +198,7 @@ export function ProtocolRunDetails(): JSX.Element | null {
               BORDERS.radiusSoftCorners
             }`}
           >
-            <ProtocolRunDetailsContent
-              protocolRunHeaderRef={protocolRunHeaderRef}
-              robotName={robotName}
-              runId={runId}
-            />
+            {protocolRunDetailsContent}
           </Box>
         </Flex>
       </Box>

--- a/app/src/pages/Devices/RobotSettings/index.tsx
+++ b/app/src/pages/Devices/RobotSettings/index.tsx
@@ -43,21 +43,21 @@ export function RobotSettings(): JSX.Element | null {
   }
 
   const robotSettingsContentByTab: {
-    [K in RobotSettingsTab]: () => JSX.Element
+    [K in RobotSettingsTab]: JSX.Element
   } = {
-    calibration: () => (
+    calibration: (
       <RobotSettingsCalibration
         robotName={robotName}
         updateRobotStatus={updateRobotStatus}
       />
     ),
-    networking: () => (
+    networking: (
       <RobotSettingsNetworking
         robotName={robotName}
         updateRobotStatus={updateRobotStatus}
       />
     ),
-    advanced: () => (
+    advanced: (
       <RobotSettingsAdvanced
         robotName={robotName}
         updateRobotStatus={updateRobotStatus}
@@ -76,7 +76,7 @@ export function RobotSettings(): JSX.Element | null {
     return <Redirect to={`/devices/${robotName}/robot-settings/networking`} />
   }
 
-  const RobotSettingsContent =
+  const robotSettingsContent =
     robotSettingsContentByTab[robotSettingsTab] ??
     // default to the calibration tab if no tab or nonexistent tab is passed as a param
     (() => <Redirect to={`/devices/${robotName}/robot-settings/calibration`} />)
@@ -135,7 +135,7 @@ export function RobotSettings(): JSX.Element | null {
             hostname={robot?.ip ?? null}
             port={robot?.port ?? null}
           >
-            <RobotSettingsContent />
+            {robotSettingsContent}
           </ApiHostProvider>
         </Box>
       </Flex>

--- a/app/src/pages/Devices/RobotSettings/index.tsx
+++ b/app/src/pages/Devices/RobotSettings/index.tsx
@@ -76,10 +76,10 @@ export function RobotSettings(): JSX.Element | null {
     return <Redirect to={`/devices/${robotName}/robot-settings/networking`} />
   }
 
-  const robotSettingsContent =
-    robotSettingsContentByTab[robotSettingsTab] ??
+  const robotSettingsContent = robotSettingsContentByTab[robotSettingsTab] ?? (
     // default to the calibration tab if no tab or nonexistent tab is passed as a param
-    (() => <Redirect to={`/devices/${robotName}/robot-settings/calibration`} />)
+    <Redirect to={`/devices/${robotName}/robot-settings/calibration`} />
+  )
 
   return (
     <Box


### PR DESCRIPTION
# Overview
As part of an earlier unnecessarily remounting component refactor we found a few more places where we were unnecessarily creating new components on every render. This PR refactors that out and adjusts some similar code to maintain consistency.
Closes #11208.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- refactor `AppSettings`, `ProtocolRunDetails`, and `RobotSettings` so these components do not create new components on every tab state change.

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- Confirm that all tabs still work properly.
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Low