### PR TITLE
fix(api): ensure correct sync hardware API is used for analysis

### DIFF
--- a/api/src/opentrons/protocol_runner/create_simulating_runner.py
+++ b/api/src/opentrons/protocol_runner/create_simulating_runner.py
@@ -1,11 +1,7 @@
 """Simulating ProtocolRunner factory."""
 
 from opentrons.config import feature_flags
-from opentrons.hardware_control import (
-    API as HardwareAPI,
-    SynchronousAdapter,
-    HardwareControlAPI,
-)
+from opentrons.hardware_control import API as HardwareAPI, HardwareControlAPI
 from opentrons.protocol_engine import EngineConfigs, create_protocol_engine
 
 from .legacy_wrappers import LegacySimulatingContextCreator
@@ -63,7 +59,7 @@ async def create_simulating_runner() -> ProtocolRunner:
 
     simulating_legacy_context_creator = (
         LegacySimulatingContextCreator(
-            sync_hardware_api=SynchronousAdapter(simulating_hardware_api),
+            hardware_api=simulating_hardware_api,
             labware_offset_provider=offset_provider,
         )
         if not feature_flags.disable_fast_protocol_upload()

--- a/api/src/opentrons/protocol_runner/protocol_runner.py
+++ b/api/src/opentrons/protocol_runner/protocol_runner.py
@@ -1,7 +1,7 @@
 """Protocol run control and management."""
-from typing import List, NamedTuple, Optional, cast
+from typing import List, NamedTuple, Optional
 
-from opentrons.hardware_control import HardwareControlAPI, ThreadManagedHardware
+from opentrons.hardware_control import HardwareControlAPI
 from opentrons.protocol_reader import (
     ProtocolSource,
     PythonProtocolConfig,
@@ -73,9 +73,7 @@ class ProtocolRunner:
         self._python_executor = python_executor or PythonExecutor()
         self._legacy_file_reader = legacy_file_reader or LegacyFileReader()
         self._legacy_context_creator = legacy_context_creator or LegacyContextCreator(
-            # TODO(mc, 2022-02-05): handle this cast more gracefully, probably in
-            # a more specific runner implementation as mentioned in TODO below
-            sync_hardware_api=cast(ThreadManagedHardware, hardware_api).sync,
+            hardware_api=hardware_api,
             labware_offset_provider=LegacyLabwareOffsetProvider(
                 labware_view=protocol_engine.state_view.labware,
             ),

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -264,13 +264,13 @@ def session_manager(hardware: HardwareControlAPI) -> SessionManager:
 
 
 @pytest.fixture
-def set_enable_http_protocol_sessions(
+def set_disable_fast_analysis(
     request_session: requests.Session,
 ) -> Iterator[None]:
     """For integration tests that need to set then clear the
     enableHttpProtocolSessions feature flag"""
     url = "http://localhost:31950/settings"
-    data = {"id": "enableHttpProtocolSessions", "value": True}
+    data = {"id": "disableFastProtocolUpload", "value": True}
     request_session.post(url, json=data)
     yield None
     data["value"] = None

--- a/robot-server/tests/integration/http_api/protocols/test_upload.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_upload.tavern.yaml
@@ -65,3 +65,47 @@ stages:
         errors:
           - id: ProtocolNotFound
             title: Protocol Not Found
+
+---
+test_name: Upload, analyze and analyze using "slow analysis"
+
+marks:
+  - usefixtures:
+      - run_server
+      - set_disable_fast_analysis
+
+stages:
+  - name: Upload simple Python protocol
+    request:
+      url: '{host:s}:{port:d}/protocols'
+      method: POST
+      files:
+        files: 'tests/integration/protocols/simple.py'
+    response:
+      save:
+        json:
+          protocol_id: data.id
+          analysis_id: data.analysisSummaries[0].id
+      status_code: 201
+
+  - name: Retry until analyses status is completed and result is ok.
+    max_retries: 10
+    delay_after: 0.1
+    request:
+      url: '{host:s}:{port:d}/protocols/{protocol_id}/analyses'
+      method: GET
+    response:
+      strict:
+        - json:off
+      status_code: 200
+      json:
+        data:
+          - id: '{analysis_id}'
+            status: completed
+            result: ok
+  - name: Delete the protocol
+    request:
+      url: '{host:s}:{port:d}/protocols/{protocol_id}'
+      method: DELETE
+    response:
+      status_code: 200


### PR DESCRIPTION
## Overview

Addresses RSS-11

## Test Plan

We need smoke tests for the following items on an OT-2 or emulator:

- "Enable older protocol analysis method" - **ON**
    - [x] Protocol upload is able to create and analyze a protocol
        - Tested by @SyntaxColoring  
    - [x] That protocol is able to run
        - Tested by @SyntaxColoring  
- "Enable older protocol analysis method" - **OFF** (system default)
    - [x] Protocol upload is able to create and analyze a protocol
        - Tested by @SyntaxColoring  
    - [x] That protocol is able to run
        - Tested by @SyntaxColoring  

The nature of the bug and the fix is that these are all binary tests. If the run / analysis proceeds at all, then we're good.

Protocol upload + analysis == `POST /protocols`
Protocol run == `POST /runs { protocolId }`

## Risk Assessment

Medium

- The code changed affects both protocol analysis and protocol run
- Whether or not protocol runs _must_ be assessed on real hardware or the Docker-based emulator
