### PR TITLE
fix(app): fix RobotSettings calibration conditions for buttons

### DIFF
--- a/app/src/organisms/Devices/RobotSettings/CalibrationDetails/OverflowMenu.tsx
+++ b/app/src/organisms/Devices/RobotSettings/CalibrationDetails/OverflowMenu.tsx
@@ -25,10 +25,10 @@ import {
 } from '../../../CalibrationPanels'
 import * as Config from '../../../../redux/config'
 import { useTrackEvent } from '../../../../redux/analytics'
+import { getIsRunning } from '../../../../redux/robot/selectors'
 import { EVENT_CALIBRATION_DOWNLOADED } from '../../../../redux/calibration'
 import {
   useDeckCalibrationData,
-  useIsRobotBusy,
   usePipetteOffsetCalibrations,
   useTipLengthCalibrations,
 } from '../../hooks'
@@ -63,7 +63,7 @@ export function OverflowMenu({
   serialNumber,
   updateRobotStatus,
 }: OverflowMenuProps): JSX.Element {
-  const { t } = useTranslation('device_settings')
+  const { t } = useTranslation(['device_settings', 'shared'])
   const doTrackEvent = useTrackEvent()
   const {
     menuOverlay,
@@ -88,7 +88,7 @@ export function OverflowMenu({
     calBlockModalState,
     setCalBlockModalState,
   ] = React.useState<CalBlockModalState>(CAL_BLOCK_MODAL_CLOSED)
-  const isBusy = useIsRobotBusy()
+  const isRunning = useSelector(getIsRunning)
 
   interface StartWizardOptions {
     keepTipLength: boolean
@@ -136,9 +136,7 @@ export function OverflowMenu({
     e: React.MouseEvent
   ): void => {
     e.preventDefault()
-    if (isBusy) {
-      updateRobotStatus(true)
-    } else {
+    if (!isRunning) {
       if (calType === 'pipetteOffset') {
         if (applicablePipetteOffsetCal != null) {
           // recalibrate pipette offset
@@ -183,6 +181,17 @@ export function OverflowMenu({
     setShowOverflowMenu(!showOverflowMenu)
   }
 
+  let disabledReason = null
+  if (isRunning) {
+    disabledReason = t('shared:disabled_protocol_is_running')
+  }
+
+  React.useEffect(() => {
+    if (isRunning) {
+      updateRobotStatus(true)
+    }
+  }, [isRunning, updateRobotStatus])
+
   // TODO 5/6/2021 kj: This is scoped out from 6.0
   // const handleDeleteCalibrationData = (
   //   calType: 'pipetteOffset' | 'tipLength'
@@ -214,7 +223,7 @@ export function OverflowMenu({
       {showOverflowMenu ? (
         <Flex
           ref={calsOverflowWrapperRef}
-          width={calType === 'pipetteOffset' ? '11.5rem' : '17.25rem'}
+          whiteSpace="nowrap"
           zIndex={10}
           borderRadius={'4px 4px 0px 0px'}
           boxShadow={'0px 1px 3px rgba(0, 0, 0, 0.2)'}
@@ -224,7 +233,10 @@ export function OverflowMenu({
           right={0}
           flexDirection={DIRECTION_COLUMN}
         >
-          <MenuItem onClick={e => handleCalibration(calType, e)}>
+          <MenuItem
+            onClick={e => handleCalibration(calType, e)}
+            disabled={disabledReason !== null}
+          >
             {calType === 'pipetteOffset'
               ? applicablePipetteOffsetCal != null
                 ? t('recalibrate_pipette')

--- a/app/src/organisms/Devices/RobotSettings/CalibrationDetails/__test__/OverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/CalibrationDetails/__test__/OverflowMenu.test.tsx
@@ -5,9 +5,10 @@ import { saveAs } from 'file-saver'
 import { renderWithProviders, Mount } from '@opentrons/components'
 
 import { i18n } from '../../../../../i18n'
+import { getIsRunning } from '../../../../../redux/robot/selectors'
 import { mockDeckCalData } from '../../../../../redux/calibration/__fixtures__'
 import { useCalibratePipetteOffset } from '../../../../CalibratePipetteOffset/useCalibratePipetteOffset'
-import { useDeckCalibrationData, useIsRobotBusy } from '../../../hooks'
+import { useDeckCalibrationData } from '../../../hooks'
 
 import { OverflowMenu } from '../OverflowMenu'
 
@@ -29,6 +30,7 @@ jest.mock('../../../../../redux/config')
 jest.mock('../../../../../redux/sessions/selectors')
 jest.mock('../../../../../redux/discovery')
 jest.mock('../../../../../redux/robot-api/selectors')
+jest.mock('../../../../../redux/robot/selectors')
 jest.mock('../../../../CalibratePipetteOffset/useCalibratePipetteOffset')
 jest.mock('../../../../ProtocolUpload/hooks')
 jest.mock('../../../hooks')
@@ -36,8 +38,8 @@ jest.mock('../../../hooks')
 const mockUseCalibratePipetteOffset = useCalibratePipetteOffset as jest.MockedFunction<
   typeof useCalibratePipetteOffset
 >
-const mockUseIsRobotBusy = useIsRobotBusy as jest.MockedFunction<
-  typeof useIsRobotBusy
+const mockGetIsRunning = getIsRunning as jest.MockedFunction<
+  typeof getIsRunning
 >
 const mockUseDeckCalibrationData = useDeckCalibrationData as jest.MockedFunction<
   typeof useDeckCalibrationData
@@ -57,7 +59,7 @@ describe('OverflowMenu', () => {
       updateRobotStatus: mockUpdateRobotStatus,
     }
     mockUseCalibratePipetteOffset.mockReturnValue([startCalibration, null])
-    mockUseIsRobotBusy.mockReturnValue(false)
+    mockGetIsRunning.mockReturnValue(false)
     mockUseDeckCalibrationData.mockReturnValue({
       isDeckCalibrated: true,
       deckCalibrationData: mockDeckCalData,
@@ -142,13 +144,12 @@ describe('OverflowMenu', () => {
   })
 
   it('should call update robot status if a robot is busy - pipette offset', () => {
-    mockUseIsRobotBusy.mockReturnValue(true)
+    mockGetIsRunning.mockReturnValue(true)
     const [{ getByText, getByLabelText }] = render(props)
     const button = getByLabelText('CalibrationOverflowMenu_button')
     fireEvent.click(button)
     const calibrationButton = getByText('Calibrate Pipette Offset')
-    fireEvent.click(calibrationButton)
-    expect(mockUpdateRobotStatus).toHaveBeenCalled()
+    expect(calibrationButton).toBeDisabled()
   })
 
   it('should call update robot status if a robot is busy - tip length', () => {
@@ -156,14 +157,13 @@ describe('OverflowMenu', () => {
       ...props,
       calType: 'tipLength',
     }
-    mockUseIsRobotBusy.mockReturnValue(true)
+    mockGetIsRunning.mockReturnValue(true)
     const [{ getByText, getByLabelText }] = render(props)
     const button = getByLabelText('CalibrationOverflowMenu_button')
     fireEvent.click(button)
     const calibrationButton = getByText(
       'Recalibrate Tip Length and Pipette Offset'
     )
-    fireEvent.click(calibrationButton)
-    expect(mockUpdateRobotStatus).toHaveBeenCalled()
+    expect(calibrationButton).toBeDisabled()
   })
 })

--- a/app/src/organisms/Devices/RobotSettings/CalibrationDetails/__test__/OverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/CalibrationDetails/__test__/OverflowMenu.test.tsx
@@ -143,7 +143,7 @@ describe('OverflowMenu', () => {
     expect(startCalibration).toHaveBeenCalled()
   })
 
-  it('should call update robot status if a robot is busy - pipette offset', () => {
+  it('alibration button should be disabled if a protocol is running - pipette offset', () => {
     mockGetIsRunning.mockReturnValue(true)
     const [{ getByText, getByLabelText }] = render(props)
     const button = getByLabelText('CalibrationOverflowMenu_button')
@@ -152,7 +152,7 @@ describe('OverflowMenu', () => {
     expect(calibrationButton).toBeDisabled()
   })
 
-  it('should call update robot status if a robot is busy - tip length', () => {
+  it('calibration button should be disabled if a protocol is running - tip length', () => {
     props = {
       ...props,
       calType: 'tipLength',

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
@@ -48,7 +48,6 @@ import {
   useRobot,
   useTipLengthCalibrations,
   useDeckCalibrationStatus,
-  useIsRobotBusy,
   useAttachedPipettes,
   useAttachedPipetteCalibrations,
   useRunStartedOrLegacySessionInProgress,
@@ -138,7 +137,6 @@ export function RobotSettingsCalibration({
   ] = React.useState<string>('')
   const [showCalBlockModal, setShowCalBlockModal] = React.useState(false)
   const isRunStartedOrLegacySessionInProgress = useRunStartedOrLegacySessionInProgress()
-  const isBusy = useIsRobotBusy()
 
   const robot = useRobot(robotName)
   const notConnectable = robot?.status !== CONNECTABLE
@@ -250,7 +248,7 @@ export function RobotSettingsCalibration({
     pipettePresent
 
   const calCheckButtonDisabled = healthCheckIsPossible
-    ? Boolean(buttonDisabledReason) || isPending
+    ? Boolean(buttonDisabledReason) || isPending || isRunning
     : true
 
   const onClickSaveAs: React.MouseEventHandler = e => {
@@ -314,29 +312,22 @@ export function RobotSettingsCalibration({
   const handleHealthCheck = (
     hasBlockModalResponse: boolean | null = null
   ): void => {
-    if (isBusy) {
-      updateRobotStatus(true)
+    if (hasBlockModalResponse === null && configHasCalibrationBlock === null) {
+      setShowCalBlockModal(true)
     } else {
-      if (
-        hasBlockModalResponse === null &&
-        configHasCalibrationBlock === null
-      ) {
-        setShowCalBlockModal(true)
-      } else {
-        setShowCalBlockModal(false)
-        dispatchRequests(
-          Sessions.ensureSession(
-            robotName,
-            Sessions.SESSION_TYPE_CALIBRATION_HEALTH_CHECK,
-            {
-              tipRacks: [],
-              hasCalibrationBlock: Boolean(
-                configHasCalibrationBlock ?? hasBlockModalResponse
-              ),
-            }
-          )
+      setShowCalBlockModal(false)
+      dispatchRequests(
+        Sessions.ensureSession(
+          robotName,
+          Sessions.SESSION_TYPE_CALIBRATION_HEALTH_CHECK,
+          {
+            tipRacks: [],
+            hasCalibrationBlock: Boolean(
+              configHasCalibrationBlock ?? hasBlockModalResponse
+            ),
+          }
         )
-      }
+      )
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This will fix  #11201

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- remove useIsRobotBusy from RobotSettingsCalibration and OverflowMenu
- add check running to each calibration
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- when setting up protocol, the app allows users to do each calibration
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
