### PR TITLE
test(protocol-engine): broaden acceptance criteria of wait for duration tests

### DIFF
--- a/api/tests/opentrons/protocol_engine/execution/test_run_control_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_run_control_handler.py
@@ -84,7 +84,7 @@ async def test_wait_for_duration(
 
     # NOTE: margin of error selected empirically
     # this is flakey test risk in CI
-    assert end - start == pytest.approx(0.2, abs=0.1)
+    assert end - start >= 0.1
 
 
 async def test_wait_for_duration_ignore_pause(
@@ -108,4 +108,4 @@ async def test_wait_for_duration_ignore_pause(
 
     # NOTE: margin of error selected empirically
     # this is flakey test risk in CI
-    assert end - start == pytest.approx(0, abs=0.1)
+    assert end - start <= 0.1


### PR DESCRIPTION
## Overview

The unit tests for `waitForDuration` use real, small delays to test functionality. This introduced flakiness into CI, especially in macOS. This PR makes a small change to the tests: rather than test that the implementation waits for **approximately** the requested time, we check that it waits for **at least approximately** the requested time.

We believe this implementation will be a lot less flaky while still preserving the niceness of having a unit test that actually checks a real wait is or isn't happening.

Re: RSS-25

## Changelog

- test(protocol-engine): broaden acceptance criteria of wait for duration tests

## Review requests

- [ ] Test changes make sense
- [ ] CI is green across all OSes

# Risk assessment

Very low, unit test only change