### PR TITLE
fix(app): fix Overflow menu state when a robot isn't connectable

### DIFF
--- a/app/src/atoms/MenuList/OverflowBtn.tsx
+++ b/app/src/atoms/MenuList/OverflowBtn.tsx
@@ -34,7 +34,10 @@ const overflowButtonStyles = css`
   }
 
   &:disabled circle {
-    fill: ${COLORS.errorText};
+    fill: ${COLORS.successDisabled};
+  }
+  &:disabled {
+    background-color: transparent;
   }
 `
 

--- a/app/src/atoms/MenuList/__tests__/OverflowBtn.test.tsx
+++ b/app/src/atoms/MenuList/__tests__/OverflowBtn.test.tsx
@@ -67,8 +67,12 @@ describe('OverflowBtn', () => {
       onClick: jest.fn(),
     })
 
-    expect(getByRole('button')).toHaveStyleRule('fill', `${COLORS.errorText}`, {
-      modifier: ':disabled circle',
-    })
+    expect(getByRole('button')).toHaveStyleRule(
+      'fill',
+      `${COLORS.successDisabled}`,
+      {
+        modifier: ':disabled circle',
+      }
+    )
   })
 })

--- a/app/src/organisms/Devices/RobotOverviewOverflowMenu.tsx
+++ b/app/src/organisms/Devices/RobotOverviewOverflowMenu.tsx
@@ -99,7 +99,7 @@ export const RobotOverviewOverflowMenu = (
       <OverflowBtn
         aria-label="overflow"
         onClick={handleOverflowClick}
-        disabled={robot.status === UNREACHABLE}
+        disabled={robot.status !== CONNECTABLE}
       />
       {showOverflowMenu ? (
         <Flex

--- a/app/src/organisms/Devices/__tests__/RobotOverviewOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotOverviewOverflowMenu.test.tsx
@@ -11,6 +11,7 @@ import { restartRobot } from '../../../redux/robot-admin'
 import {
   mockConnectableRobot,
   mockReachableRobot,
+  mockUnreachableRobot,
 } from '../../../redux/discovery/__fixtures__'
 import { useCurrentRunStatus } from '../../RunTimeControl/hooks'
 import { RobotOverviewOverflowMenu } from '../RobotOverviewOverflowMenu'
@@ -109,21 +110,14 @@ describe('RobotOverviewOverflowMenu', () => {
     getByRole('button', { name: 'Robot settings' })
   })
 
-  it('should not render menu items when the robot is not connectable', () => {
+  it('should not render menu items when the robot is reachable', () => {
     when(mockUseIsRobotBusy).calledWith().mockReturnValue(true)
     when(mockUseCurrentRunStatus)
       .calledWith()
       .mockReturnValue(RUN_STATUS_RUNNING)
-
     const { getByRole } = render({ robot: mockReachableRobot })
-
     const btn = getByRole('button')
-    fireEvent.click(btn)
-
-    expect(screen.queryByText('Update robot software')).toBeNull()
-    expect(screen.queryByText('Restart robot')).toBeNull()
-    expect(screen.queryByText('Home gantry')).toBeNull()
-    getByRole('button', { name: 'Robot settings' })
+    expect(btn).toBeDisabled()
   })
 
   it('clicking home gantry should home the gantry', () => {
@@ -161,5 +155,14 @@ describe('RobotOverviewOverflowMenu', () => {
     getByRole('button', { name: 'Restart robot' })
     getByRole('button', { name: 'Home gantry' })
     getByRole('button', { name: 'Robot settings' })
+  })
+  it('should not render menu items when the robot is unreachable', () => {
+    when(mockUseIsRobotBusy).calledWith().mockReturnValue(true)
+    when(mockUseCurrentRunStatus)
+      .calledWith()
+      .mockReturnValue(RUN_STATUS_RUNNING)
+    const { getByRole } = render({ robot: mockUnreachableRobot })
+    const btn = getByRole('button')
+    expect(btn).toBeDisabled()
   })
 })


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR will fix overflowmenu disable state and when a robot is reachable, make a overflow menu disabled.
fix #11223

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- update overflow menu disabled state
- change overflow menu disabled condition (unreachable -->  !connectable)
  On the device landing page, unreachable and reachable robots are displayed as unavailable robots.
- update test case for robot overflow menu
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- [ ] when a robot is reachable, the overflow menu is disabled on the device details page
  run app + robot-server
  terminate robot-server
  click a robot in unavailable list
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
