### PR TITLE
feat(app): add customLabware to labware filterBy

### DIFF
--- a/app/src/pages/Labware/__tests__/hooks.test.tsx
+++ b/app/src/pages/Labware/__tests__/hooks.test.tsx
@@ -102,6 +102,22 @@ describe('useAllLabware hook', () => {
     expect(labware2.modified).toBe(mockValidLabware.modified)
     expect(labware2.definition).toBe(mockValidLabware.definition)
   })
+  it('should return custom labware with customLabware filter', () => {
+    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+      <Provider store={store}>{children}</Provider>
+    )
+    const { result } = renderHook(
+      () => useAllLabware('alphabetical', 'customLabware'),
+      {
+        wrapper,
+      }
+    )
+    const labware1 = result.current[0]
+    const labware2 = result.current[1]
+
+    expect(labware1).toBe(mockValidLabware)
+    expect(labware2).toBeUndefined()
+  })
 })
 
 describe('useLabwareFailure hook', () => {

--- a/app/src/pages/Labware/hooks.tsx
+++ b/app/src/pages/Labware/hooks.tsx
@@ -25,10 +25,9 @@ export function useAllLabware(
 ): LabwareDefAndDate[] {
   const fullLabwareList: LabwareDefAndDate[] = []
   const labwareDefinitions = getAllDefinitions()
-  labwareDefinitions.map(def => fullLabwareList.push({ definition: def }))
+  labwareDefinitions.forEach(def => fullLabwareList.push({ definition: def }))
   const customLabwareList = useSelector(getCustomLabware)
-
-  customLabwareList.map(customLabware =>
+  customLabwareList.forEach(customLabware =>
     'definition' in customLabware
       ? fullLabwareList.push({
           modified: customLabware.modified,
@@ -37,7 +36,7 @@ export function useAllLabware(
         })
       : null
   )
-  fullLabwareList.sort(function (a, b) {
+  const sortLabware = (a: LabwareDefAndDate, b: LabwareDefAndDate): number => {
     if (a.definition.metadata.displayName < b.definition.metadata.displayName) {
       return sortBy === 'alphabetical' ? -1 : 1
     }
@@ -45,7 +44,12 @@ export function useAllLabware(
       return sortBy === 'alphabetical' ? 1 : -1
     }
     return 0
-  })
+  }
+
+  if (filterBy === 'customLabware') {
+    return (customLabwareList as LabwareDefAndDate[]).sort(sortLabware)
+  }
+  fullLabwareList.sort(sortLabware)
   if (filterBy !== 'all') {
     return fullLabwareList.filter(
       labwareItem =>

--- a/app/src/pages/Labware/index.tsx
+++ b/app/src/pages/Labware/index.tsx
@@ -48,6 +48,7 @@ const labwareDisplayCategoryFilters: LabwareFilter[] = [
   'tubeRack',
   'reservoir',
   'aluminumBlock',
+  'customLabware',
 ]
 
 const FILTER_OPTIONS: DropdownOption[] = []

--- a/app/src/pages/Labware/types.ts
+++ b/app/src/pages/Labware/types.ts
@@ -41,5 +41,6 @@ export type LabwareFilter =
   | 'tubeRack'
   | 'reservoir'
   | 'aluminumBlock'
+  | 'customLabware'
 
 export type LabwareSort = 'alphabetical' | 'reverse'


### PR DESCRIPTION
# Overview
Adds Custom Labware to labware page filter options.
Closes #10917.

# Changelog
- edit `LabwareFilter` type
- add `customLabware` to labware page filter options
- add `customLabware` filtering to `useAllLabware` hook

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- confirm filtering works correctly
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Low