### PR TITLE
refactor(app): disable sending shake command when input out of range

### DIFF
--- a/app/src/organisms/Devices/HeaterShakerWizard/TestShake.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/TestShake.tsx
@@ -200,7 +200,11 @@ export function TestShake(props: TestShakeProps): JSX.Element {
             marginLeft={SIZE_AUTO}
             marginTop={SPACING.spacing4}
             onClick={handleShakeCommand}
-            disabled={!isLatchClosed || (shakeValue === null && !isShaking)}
+            disabled={
+              !isLatchClosed ||
+              (shakeValue === null && !isShaking) ||
+              errorMessage != null
+            }
             {...targetProps}
           >
             {isShaking ? t('stop_shaking') : t('start_shaking')}

--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/TestShake.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/TestShake.test.tsx
@@ -213,7 +213,7 @@ describe('TestShake', () => {
     expect(button).toBeEnabled()
   })
 
-  it('renders the start shaking button and is enabled', () => {
+  it('renders the start shaking button and is disabled', () => {
     props = {
       module: mockCloseLatchHeaterShaker,
       setCurrentPage: jest.fn(),
@@ -264,6 +264,25 @@ describe('TestShake', () => {
     })
 
     const { getByRole } = render(props)
+    const button = getByRole('button', { name: /Start/i })
+    expect(button).toBeDisabled()
+  })
+
+  it('start shake button should be disabled if the input is out of range', () => {
+    props = {
+      module: mockOpenLatchHeaterShaker,
+      setCurrentPage: jest.fn(),
+      moduleFromProtocol: undefined,
+    }
+
+    mockUseLatchControls.mockReturnValue({
+      toggleLatch: mockToggleLatch,
+      isLatchClosed: false,
+    })
+
+    const { getByRole } = render(props)
+    const input = getByRole('spinbutton')
+    fireEvent.change(input, { target: { value: '0' } })
     const button = getByRole('button', { name: /Start/i })
     expect(button).toBeDisabled()
   })
@@ -338,7 +357,7 @@ describe('TestShake', () => {
     const { getByRole } = render(props)
     const button = getByRole('button', { name: /Stop Shaking/i })
     const input = getByRole('spinbutton')
-    fireEvent.change(input, { target: { value: '0' } })
+    fireEvent.change(input, { target: { value: '200' } })
     fireEvent.click(button)
 
     expect(mockCreateLiveCommand).toHaveBeenCalledWith({

--- a/app/src/organisms/ModuleCard/TestShakeSlideout.tsx
+++ b/app/src/organisms/ModuleCard/TestShakeSlideout.tsx
@@ -227,30 +227,18 @@ export const TestShakeSlideout = (
               {getLatchStatus(module.data.labwareLatchStatus)}
             </Text>
           </Flex>
-          {isShaking ? (
-            <TertiaryButton
-              marginTop={SPACING.spacing2}
-              textTransform={TYPOGRAPHY.textTransformCapitalize}
-              fontSize={TYPOGRAPHY.fontSizeCaption}
-              marginLeft={SIZE_AUTO}
-              onClick={toggleLatch}
-              disabled={isShaking}
-              {...targetProps}
-            >
-              {!isLatchClosed ? t('close_latch') : t('open_latch')}
-            </TertiaryButton>
-          ) : (
-            <TertiaryButton
-              marginTop={SPACING.spacing2}
-              textTransform={TYPOGRAPHY.textTransformCapitalize}
-              fontSize={TYPOGRAPHY.fontSizeCaption}
-              marginLeft={SIZE_AUTO}
-              onClick={toggleLatch}
-              disabled={isShaking}
-            >
-              {!isLatchClosed ? t('close_latch') : t('open_latch')}
-            </TertiaryButton>
-          )}
+          <TertiaryButton
+            marginTop={SPACING.spacing2}
+            textTransform={TYPOGRAPHY.textTransformCapitalize}
+            fontSize={TYPOGRAPHY.fontSizeCaption}
+            marginLeft={SIZE_AUTO}
+            onClick={toggleLatch}
+            disabled={isShaking}
+            {...(isShaking && targetProps)}
+          >
+            {!isLatchClosed ? t('close_latch') : t('open_latch')}
+          </TertiaryButton>
+
           {isShaking ? (
             <Tooltip tooltipProps={tooltipProps}>
               {t('cannot_open_latch')}
@@ -289,28 +277,22 @@ export const TestShakeSlideout = (
               fontSize={TYPOGRAPHY.fontSizeCaption}
             ></Text>
           </Flex>
-          {!isLatchClosed || (shakeValue === null && !isShaking) ? (
-            <TertiaryButton
-              textTransform={TYPOGRAPHY.textTransformCapitalize}
-              marginLeft={SIZE_AUTO}
-              marginTop={SPACING.spacing3}
-              onClick={confirmAttachment}
-              disabled={!isLatchClosed || (shakeValue === null && !isShaking)}
-              {...targetProps}
-            >
-              {isShaking ? t('shared:stop') : t('shared:start')}
-            </TertiaryButton>
-          ) : (
-            <TertiaryButton
-              textTransform={TYPOGRAPHY.textTransformCapitalize}
-              marginLeft={SIZE_AUTO}
-              marginTop={SPACING.spacing3}
-              onClick={confirmAttachment}
-              disabled={!isLatchClosed || (shakeValue === null && !isShaking)}
-            >
-              {isShaking ? t('shared:stop') : t('shared:start')}
-            </TertiaryButton>
-          )}
+          <TertiaryButton
+            textTransform={TYPOGRAPHY.textTransformCapitalize}
+            marginLeft={SIZE_AUTO}
+            marginTop={SPACING.spacing3}
+            onClick={confirmAttachment}
+            disabled={
+              !isLatchClosed ||
+              (shakeValue === null && !isShaking) ||
+              errorMessage != null
+            }
+            {...((!isLatchClosed || (shakeValue === null && !isShaking)) &&
+              targetProps)}
+          >
+            {isShaking ? t('shared:stop') : t('shared:start')}
+          </TertiaryButton>
+
           {!isLatchClosed ? (
             <Tooltip tooltipProps={tooltipProps}>{t('cannot_shake')}</Tooltip>
           ) : null}


### PR DESCRIPTION
# Overview

This PR addresses design feedback to disable the shake button when inputs are out of range in both the test shake slideout and test shake wizard page.

# Changelog

- Do not allow users to set a shake speed that is out of bounds

# Review requests

Try to set a shake speed that is out of bounds in the test shake slideout + test shake wizard page. The CTAs should get disabled.

# Risk assessment

Low
