### PR TITLE
refactor(app): h-S refactor useLatchControls hook send command logic

### DIFF
--- a/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
+++ b/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
@@ -78,7 +78,7 @@ export const ModuleOverflowMenu = (
                     </MenuItem>
                     {item.disabledReason && (
                       <Tooltip tooltipProps={tooltipProps}>
-                        {t('cannot_shake', { ns: 'heater_shaker' })}
+                        {t('heater_shaker:cannot_shake')}
                       </Tooltip>
                     )}
                     {item.menuButtons}

--- a/app/src/organisms/ModuleCard/__tests__/hooks.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/hooks.test.tsx
@@ -20,7 +20,7 @@ import {
   useProtocolDetailsForRun,
   useRunStatuses,
 } from '../../Devices/hooks'
-
+import { RUN_ID_1 } from '../../RunTimeControl/__fixtures__'
 import {
   useLatchControls,
   useModuleOverflowMenu,
@@ -209,7 +209,7 @@ describe('useLatchControls', () => {
     mockCreateLiveCommand = jest.fn()
     mockCreateLiveCommand.mockResolvedValue(null)
     mockUseRunStatuses.mockReturnValue({
-      isRunStill: true,
+      isRunStill: false,
       isRunIdle: false,
       isRunTerminal: false,
     })
@@ -253,7 +253,7 @@ describe('useLatchControls', () => {
       },
     })
   })
-  it('should return if latch is close and handle latch function to open latch', () => {
+  it('should return if latch is closed and handle latch function opens latch', () => {
     const wrapper: React.FunctionComponent<{}> = ({ children }) => (
       <I18nextProvider i18n={i18n}>
         <Provider store={store}>{children}</Provider>
@@ -270,6 +270,39 @@ describe('useLatchControls', () => {
     expect(isLatchClosed).toBe(true)
     act(() => result.current.toggleLatch())
     expect(mockCreateLiveCommand).toHaveBeenCalledWith({
+      command: {
+        commandType: 'heaterShaker/openLabwareLatch',
+        params: {
+          moduleId: mockCloseLatchHeaterShaker.id,
+        },
+      },
+    })
+  })
+
+  it('should return if latch is closed and handle latch function opens latch when run is idle', () => {
+    mockUseRunStatuses.mockReturnValue({
+      isRunStill: false,
+      isRunIdle: true,
+      isRunTerminal: false,
+    })
+
+    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+      <I18nextProvider i18n={i18n}>
+        <Provider store={store}>{children}</Provider>
+      </I18nextProvider>
+    )
+    const { result } = renderHook(
+      () => useLatchControls(mockCloseLatchHeaterShaker, RUN_ID_1),
+      {
+        wrapper,
+      }
+    )
+    const { isLatchClosed } = result.current
+
+    expect(isLatchClosed).toBe(true)
+    act(() => result.current.toggleLatch())
+    expect(mockCreateCommand).toHaveBeenCalledWith({
+      runId: RUN_ID_1,
       command: {
         commandType: 'heaterShaker/openLabwareLatch',
         params: {

--- a/app/src/organisms/ModuleCard/hooks.tsx
+++ b/app/src/organisms/ModuleCard/hooks.tsx
@@ -59,7 +59,7 @@ export function useLatchControls(
 ): LatchControls {
   const { createLiveCommand } = useCreateLiveCommandMutation()
   const { createCommand } = useCreateCommandMutation()
-  const { isRunTerminal } = useRunStatuses()
+  const { isRunIdle } = useRunStatuses()
   const { moduleIdFromRun } = useModuleIdFromRun(
     module,
     runId != null ? runId : null
@@ -76,12 +76,12 @@ export function useLatchControls(
       ? 'heaterShaker/openLabwareLatch'
       : 'heaterShaker/closeLabwareLatch',
     params: {
-      moduleId: !isRunTerminal ? moduleIdFromRun : module.id,
+      moduleId: isRunIdle ? moduleIdFromRun : module.id,
     },
   }
 
   const toggleLatch = (): void => {
-    if (runId != null && !isRunTerminal) {
+    if (runId != null && isRunIdle) {
       createCommand({
         runId: runId,
         command: latchCommand,


### PR DESCRIPTION
# Overview

this fixes the `useLatchControls` hook logic to match other module command logic and adds missing test case to test for this

# Changelog

- change `useLatchControls` hook logic and add test

# Review requests

- all labware latch buttons should work in the app now (module cards, slideout, wizard, and run is terminal and idle and runId is null)

# Risk assessment

low