### PR TITLE
refactor(app): remove bad LPC i18n string call

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/index.tsx
+++ b/app/src/organisms/LabwarePositionCheck/index.tsx
@@ -100,7 +100,6 @@ const LabwarePositionCheckComponent = (
           alertOverlay
         >
           <Box>
-            <Text>{t('error_modal_text')}</Text>
             <Text marginTop={SPACING_2}>Error: {error.message}</Text>
           </Box>
         </AlertModal>


### PR DESCRIPTION
# Overview

This PR removes a call to an i18n key that does not exist.

# Review requests

You can't really test this without LPC erroring out, but verify there is no `error_modal_text` key in any of our i18n files. 

# Risk assessment

Low
