### PR TITLE
fix(api,shared-data): Fix incorrect rejection of `thermocycler/runProfile` commands

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/thermocycler/run_profile.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/run_profile.py
@@ -19,7 +19,7 @@ class RunProfileStepParams(BaseModel):
     """Input parameters for an individual Thermocycler profile step."""
 
     celsius: float = Field(..., description="Target temperature in °C.")
-    holdSeconds: int = Field(
+    holdSeconds: float = Field(
         ..., description="Time to hold target temperature at in seconds."
     )
 

--- a/api/tests/opentrons/protocol_runner/test_json_command_translator.py
+++ b/api/tests/opentrons/protocol_runner/test_json_command_translator.py
@@ -308,7 +308,7 @@ VALID_TEST_PARAMS = [
                         holdSeconds=5.55,
                     ),
                 ],
-            )
+            ),
         ),
         pe_commands.thermocycler.RunProfileCreate(
             params=pe_commands.thermocycler.RunProfileParams(
@@ -316,17 +316,15 @@ VALID_TEST_PARAMS = [
                 blockMaxVolumeUl=1.11,
                 profile=[
                     pe_commands.thermocycler.RunProfileStepParams(
-                        celsius=2.22,
-                        holdSeconds=3.33
+                        celsius=2.22, holdSeconds=3.33
                     ),
                     pe_commands.thermocycler.RunProfileStepParams(
-                        celsius=4.44,
-                        holdSeconds=5.55
+                        celsius=4.44, holdSeconds=5.55
                     ),
                 ],
             ),
         ),
-    )
+    ),
 ]
 
 

--- a/api/tests/opentrons/protocol_runner/test_json_command_translator.py
+++ b/api/tests/opentrons/protocol_runner/test_json_command_translator.py
@@ -292,6 +292,41 @@ VALID_TEST_PARAMS = [
             )
         ),
     ),
+    (
+        protocol_schema_v6.Command(
+            commandType="thermocycler/runProfile",
+            params=protocol_schema_v6.Params(
+                moduleId="module-id-abc123",
+                blockMaxVolumeUl=1.11,
+                profile=[
+                    protocol_schema_v6.ProfileStep(
+                        celsius=2.22,
+                        holdSeconds=3.33,
+                    ),
+                    protocol_schema_v6.ProfileStep(
+                        celsius=4.44,
+                        holdSeconds=5.55,
+                    ),
+                ],
+            )
+        ),
+        pe_commands.thermocycler.RunProfileCreate(
+            params=pe_commands.thermocycler.RunProfileParams(
+                moduleId="module-id-abc123",
+                blockMaxVolumeUl=1.11,
+                profile=[
+                    pe_commands.thermocycler.RunProfileStepParams(
+                        celsius=2.22,
+                        holdSeconds=3.33
+                    ),
+                    pe_commands.thermocycler.RunProfileStepParams(
+                        celsius=4.44,
+                        holdSeconds=5.55
+                    ),
+                ],
+            ),
+        ),
+    )
 ]
 
 

--- a/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v6.py
+++ b/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v6.py
@@ -25,6 +25,7 @@ class ProfileStep(BaseModel):
     celsius: float
     holdSeconds: float
 
+
 class WellLocation(BaseModel):
     origin: Optional[str]
     offset: Optional[OffsetVector]

--- a/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v6.py
+++ b/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v6.py
@@ -21,12 +21,16 @@ class Location(BaseModel):
     moduleId: Optional[str]
 
 
-# TODO (tamar 3/15/22): split apart all the command payloads when we tackle #9583
+class ProfileStep(BaseModel):
+    celsius: float
+    holdSeconds: float
+
 class WellLocation(BaseModel):
     origin: Optional[str]
     offset: Optional[OffsetVector]
 
 
+# TODO (tamar 3/15/22): split apart all the command payloads when we tackle #9583
 class Params(BaseModel):
     slotName: Optional[str]
     axes: Optional[List[str]]
@@ -57,6 +61,7 @@ class Params(BaseModel):
     rpm: Optional[float]
     height: Optional[float]
     offset: Optional[OffsetVector]
+    profile: Optional[List[ProfileStep]]
 
 
 class Command(BaseModel):


### PR DESCRIPTION
# Overview

This PR fixes RSS-26, a problem where we were incorrectly rejecting valid `thermocycler/runProfile` commands in v6 JSON protocols.

# Changelog

* Fix our JSONv6 protocol models, which were missing the `thermocycler/runProfile` command's `profile` field, to match our Protocol Engine models, which correctly include that field.
    * This omission was caused by a known item of tech debt, #9803. This PR does not address that underlying tech debt.
* Also, while I'm here, change `holdSeconds` so that we preserve its specified value as a `float` instead of truncating it to an `int`.
   * `float` matches what our internal hardware API accepts, at least according to its type signature: https://github.com/Opentrons/opentrons/blob/5b2f19d7ccf9030940a0b2e68e5e5ba4adeb416c/api/src/opentrons/hardware_control/modules/types.py#L27
   * It also more closely matches the JSON schema, which specifies this field as a `number`, as opposed to an `integer`. https://github.com/Opentrons/opentrons/blob/5b2f19d7ccf9030940a0b2e68e5e5ba4adeb416c/shared-data/protocol/schemas/6.json#L862-L865


<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

* Can anyone think of a reason why it would be unsafe to change `holdSeconds` from an `int` to a `float`?

# Risk assessment

Low. v6 JSON protocols do not yet exist in the wild, so this will not break any production behavior.

`holdSeconds` changing from `int` to `float` is potentially meaningful because it affects what values we allow to propagate deeper into our hardware control code. See review requests.