### PR TITLE
refactor(app): HS refactor Wizard to only issue live commands

### DIFF
--- a/app/src/organisms/Devices/HeaterShakerWizard/AttachAdapter.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/AttachAdapter.tsx
@@ -17,7 +17,7 @@ import heaterShakerAdapterAlignment from '@opentrons/app/src/assets/images/heate
 import { TertiaryButton } from '../../../atoms/buttons'
 import { Tooltip } from '../../../atoms/Tooltip'
 import { StyledText } from '../../../atoms/text'
-import { useLatchControlsLiveEndpoint } from '../../ModuleCard/hooks'
+import { useLatchControls } from '../../ModuleCard/hooks'
 
 import type { HeaterShakerModule } from '../../../redux/modules/types'
 
@@ -27,7 +27,7 @@ interface AttachAdapterProps {
 export function AttachAdapter(props: AttachAdapterProps): JSX.Element {
   const { module } = props
   const { t } = useTranslation('heater_shaker')
-  const { toggleLatch, isLatchClosed } = useLatchControlsLiveEndpoint(module)
+  const { toggleLatch, isLatchClosed } = useLatchControls(module)
   const [targetProps, tooltipProps] = useHoverTooltip()
   const isShaking = module.data.speedStatus !== 'idle'
 

--- a/app/src/organisms/Devices/HeaterShakerWizard/AttachAdapter.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/AttachAdapter.tsx
@@ -17,18 +17,17 @@ import heaterShakerAdapterAlignment from '@opentrons/app/src/assets/images/heate
 import { TertiaryButton } from '../../../atoms/buttons'
 import { Tooltip } from '../../../atoms/Tooltip'
 import { StyledText } from '../../../atoms/text'
-import { useLatchControls } from '../../ModuleCard/hooks'
+import { useLatchControlsLiveEndpoint } from '../../ModuleCard/hooks'
 
 import type { HeaterShakerModule } from '../../../redux/modules/types'
 
 interface AttachAdapterProps {
   module: HeaterShakerModule
-  currentRunId?: string
 }
 export function AttachAdapter(props: AttachAdapterProps): JSX.Element {
-  const { module, currentRunId } = props
+  const { module } = props
   const { t } = useTranslation('heater_shaker')
-  const { toggleLatch, isLatchClosed } = useLatchControls(module, currentRunId)
+  const { toggleLatch, isLatchClosed } = useLatchControlsLiveEndpoint(module)
   const [targetProps, tooltipProps] = useHoverTooltip()
   const isShaking = module.data.speedStatus !== 'idle'
 

--- a/app/src/organisms/Devices/HeaterShakerWizard/TestShake.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/TestShake.tsx
@@ -1,9 +1,6 @@
 import React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
-import {
-  useCreateCommandMutation,
-  useCreateLiveCommandMutation,
-} from '@opentrons/react-api-client'
+import { useCreateLiveCommandMutation } from '@opentrons/react-api-client'
 import {
   ALIGN_CENTER,
   ALIGN_FLEX_START,
@@ -29,9 +26,7 @@ import { StyledText } from '../../../atoms/text'
 import { Divider } from '../../../atoms/structure'
 import { InputField } from '../../../atoms/InputField'
 import { Collapsible } from '../../ModuleCard/Collapsible'
-import { useLatchControls } from '../../ModuleCard/hooks'
-import { useModuleIdFromRun } from '../../ModuleCard/useModuleIdFromRun'
-import { useRunStatuses } from '../hooks'
+import { useLatchControlsLiveEndpoint } from '../../ModuleCard/hooks'
 import { HeaterShakerModuleCard } from './HeaterShakerModuleCard'
 
 import type { HeaterShakerModule } from '../../../redux/modules/types'
@@ -46,34 +41,29 @@ interface TestShakeProps {
   module: HeaterShakerModule
   setCurrentPage: React.Dispatch<React.SetStateAction<number>>
   moduleFromProtocol?: ProtocolModuleInfo
-  currentRunId?: string
 }
 
 export function TestShake(props: TestShakeProps): JSX.Element {
-  const { module, setCurrentPage, moduleFromProtocol, currentRunId } = props
+  const { module, setCurrentPage, moduleFromProtocol } = props
   const { t } = useTranslation(['heater_shaker', 'device_details'])
   const { createLiveCommand } = useCreateLiveCommandMutation()
-  const { createCommand } = useCreateCommandMutation()
   const [isExpanded, setExpanded] = React.useState(false)
-  const { isRunIdle, isRunTerminal } = useRunStatuses()
   const [shakeValue, setShakeValue] = React.useState<string | null>(null)
   const [targetProps, tooltipProps] = useHoverTooltip()
-  const { toggleLatch, isLatchClosed } = useLatchControls(module, currentRunId)
-  const { moduleIdFromRun } = useModuleIdFromRun(module, currentRunId ?? null)
+  const { toggleLatch, isLatchClosed } = useLatchControlsLiveEndpoint(module)
   const isShaking = module.data.speedStatus !== 'idle'
-  const moduleId = isRunIdle ? moduleIdFromRun : module.id
 
   const closeLatchCommand: HeaterShakerCloseLatchCreateCommand = {
     commandType: 'heaterShaker/closeLabwareLatch',
     params: {
-      moduleId,
+      moduleId: module.id,
     },
   }
 
   const setShakeCommand: HeaterShakerSetAndWaitForShakeSpeedCreateCommand = {
     commandType: 'heaterShaker/setAndWaitForShakeSpeed',
     params: {
-      moduleId,
+      moduleId: module.id,
       rpm: shakeValue !== null ? parseInt(shakeValue) : 0,
     },
   }
@@ -81,7 +71,7 @@ export function TestShake(props: TestShakeProps): JSX.Element {
   const stopShakeCommand: HeaterShakerDeactivateShakerCreateCommand = {
     commandType: 'heaterShaker/deactivateShaker',
     params: {
-      moduleId,
+      moduleId: module.id,
     },
   }
 
@@ -92,25 +82,15 @@ export function TestShake(props: TestShakeProps): JSX.Element {
 
     for (const command of commands) {
       // await each promise to make sure the server receives requests in the right order
-      if (isRunIdle && currentRunId != null) {
-        await createCommand({
-          runId: currentRunId,
-          command,
-        }).catch((e: Error) => {
-          console.error(
-            `error setting module status with command type ${command.commandType}: ${e.message}`
-          )
-        })
-      } else if (isRunTerminal || currentRunId == null) {
-        await createLiveCommand({
-          command,
-        }).catch((e: Error) => {
-          console.error(
-            `error setting module status with command type ${command.commandType}: ${e.message}`
-          )
-        })
-      }
+      await createLiveCommand({
+        command,
+      }).catch((e: Error) => {
+        console.error(
+          `error setting module status with command type ${command.commandType}: ${e.message}`
+        )
+      })
     }
+
     setShakeValue(null)
   }
 

--- a/app/src/organisms/Devices/HeaterShakerWizard/TestShake.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/TestShake.tsx
@@ -26,7 +26,7 @@ import { StyledText } from '../../../atoms/text'
 import { Divider } from '../../../atoms/structure'
 import { InputField } from '../../../atoms/InputField'
 import { Collapsible } from '../../ModuleCard/Collapsible'
-import { useLatchControlsLiveEndpoint } from '../../ModuleCard/hooks'
+import { useLatchControls } from '../../ModuleCard/hooks'
 import { HeaterShakerModuleCard } from './HeaterShakerModuleCard'
 
 import type { HeaterShakerModule } from '../../../redux/modules/types'
@@ -50,7 +50,7 @@ export function TestShake(props: TestShakeProps): JSX.Element {
   const [isExpanded, setExpanded] = React.useState(false)
   const [shakeValue, setShakeValue] = React.useState<string | null>(null)
   const [targetProps, tooltipProps] = useHoverTooltip()
-  const { toggleLatch, isLatchClosed } = useLatchControlsLiveEndpoint(module)
+  const { toggleLatch, isLatchClosed } = useLatchControls(module)
   const isShaking = module.data.speedStatus !== 'idle'
 
   const closeLatchCommand: HeaterShakerCloseLatchCreateCommand = {

--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/AttachAdapter.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/AttachAdapter.test.tsx
@@ -4,14 +4,13 @@ import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../../i18n'
 import { mockHeaterShaker } from '../../../../redux/modules/__fixtures__'
 import { AttachAdapter } from '../AttachAdapter'
-import { useLatchControls } from '../../../ModuleCard/hooks'
-import { RUN_ID_1 } from '../../../RunTimeControl/__fixtures__'
+import { useLatchControlsLiveEndpoint } from '../../../ModuleCard/hooks'
 import type { HeaterShakerModule } from '../../../../redux/modules/types'
 
 jest.mock('../../../ModuleCard/hooks')
 
-const mockUseLatchControls = useLatchControls as jest.MockedFunction<
-  typeof useLatchControls
+const mockUseLatchControlsLiveEndpoint = useLatchControlsLiveEndpoint as jest.MockedFunction<
+  typeof useLatchControlsLiveEndpoint
 >
 
 const render = (props: React.ComponentProps<typeof AttachAdapter>) => {
@@ -49,7 +48,7 @@ describe('AttachAdapter', () => {
     props = {
       module: mockHeaterShaker,
     }
-    mockUseLatchControls.mockReturnValue({
+    mockUseLatchControlsLiveEndpoint.mockReturnValue({
       toggleLatch: mockToggleLatch,
       isLatchClosed: true,
     })
@@ -83,7 +82,7 @@ describe('AttachAdapter', () => {
     expect(mockToggleLatch).toHaveBeenCalled()
   })
   it('renders button and clicking on it sends latch command to close', () => {
-    mockUseLatchControls.mockReturnValue({
+    mockUseLatchControlsLiveEndpoint.mockReturnValue({
       toggleLatch: mockToggleLatch,
       isLatchClosed: false,
     })
@@ -99,15 +98,5 @@ describe('AttachAdapter', () => {
     const { getByRole } = render(props)
     const btn = getByRole('button', { name: 'Open Labware Latch' })
     expect(btn).toBeDisabled()
-  })
-  it('renders button and clicking on it sends latch command to open when a run id is present', () => {
-    props = {
-      module: mockHeaterShaker,
-      currentRunId: RUN_ID_1,
-    }
-    const { getByRole } = render(props)
-    const btn = getByRole('button', { name: 'Open Labware Latch' })
-    fireEvent.click(btn)
-    expect(mockToggleLatch).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/AttachAdapter.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/AttachAdapter.test.tsx
@@ -4,13 +4,13 @@ import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../../i18n'
 import { mockHeaterShaker } from '../../../../redux/modules/__fixtures__'
 import { AttachAdapter } from '../AttachAdapter'
-import { useLatchControlsLiveEndpoint } from '../../../ModuleCard/hooks'
+import { useLatchControls } from '../../../ModuleCard/hooks'
 import type { HeaterShakerModule } from '../../../../redux/modules/types'
 
 jest.mock('../../../ModuleCard/hooks')
 
-const mockUseLatchControlsLiveEndpoint = useLatchControlsLiveEndpoint as jest.MockedFunction<
-  typeof useLatchControlsLiveEndpoint
+const mockUseLatchControls = useLatchControls as jest.MockedFunction<
+  typeof useLatchControls
 >
 
 const render = (props: React.ComponentProps<typeof AttachAdapter>) => {
@@ -48,7 +48,7 @@ describe('AttachAdapter', () => {
     props = {
       module: mockHeaterShaker,
     }
-    mockUseLatchControlsLiveEndpoint.mockReturnValue({
+    mockUseLatchControls.mockReturnValue({
       toggleLatch: mockToggleLatch,
       isLatchClosed: true,
     })
@@ -82,7 +82,7 @@ describe('AttachAdapter', () => {
     expect(mockToggleLatch).toHaveBeenCalled()
   })
   it('renders button and clicking on it sends latch command to close', () => {
-    mockUseLatchControlsLiveEndpoint.mockReturnValue({
+    mockUseLatchControls.mockReturnValue({
       toggleLatch: mockToggleLatch,
       isLatchClosed: false,
     })

--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/HeaterShakerWizard.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/HeaterShakerWizard.test.tsx
@@ -6,7 +6,6 @@ import { i18n } from '../../../../i18n'
 import { useAttachedModules } from '../../hooks'
 import { mockHeaterShaker } from '../../../../redux/modules/__fixtures__'
 import heaterShakerCommands from '@opentrons/shared-data/protocol/fixtures/6/heaterShakerCommands.json'
-import { RUN_ID_1 } from '../../../RunTimeControl/__fixtures__'
 import { HeaterShakerWizard } from '..'
 import { Introduction } from '../Introduction'
 import { KeyParts } from '../KeyParts'
@@ -122,7 +121,6 @@ describe('HeaterShakerWizard', () => {
         protocolLoadOrder: 1,
         slotName: '1',
       } as ProtocolModuleInfo,
-      currentRunId: RUN_ID_1,
     }
     const { getByText, getByRole } = render(props)
 

--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/TestShake.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/TestShake.test.tsx
@@ -6,7 +6,7 @@ import {
   useCreateLiveCommandMutation,
 } from '@opentrons/react-api-client'
 import { i18n } from '../../../../i18n'
-import { useLatchControlsLiveEndpoint } from '../../../ModuleCard/hooks'
+import { useLatchControls } from '../../../ModuleCard/hooks'
 import heaterShakerCommands from '@opentrons/shared-data/protocol/fixtures/6/heaterShakerCommands.json'
 import { mockHeaterShaker } from '../../../../redux/modules/__fixtures__'
 import { useModuleIdFromRun } from '../../../ModuleCard/useModuleIdFromRun'
@@ -25,8 +25,8 @@ jest.mock('../../hooks')
 const mockUseLiveCommandMutation = useCreateLiveCommandMutation as jest.MockedFunction<
   typeof useCreateLiveCommandMutation
 >
-const mockUseLatchControlsLiveEndpoint = useLatchControlsLiveEndpoint as jest.MockedFunction<
-  typeof useLatchControlsLiveEndpoint
+const mockUseLatchControls = useLatchControls as jest.MockedFunction<
+  typeof useLatchControls
 >
 const mockHeaterShakerModuleCard = HeaterShakerModuleCard as jest.MockedFunction<
   typeof HeaterShakerModuleCard
@@ -141,7 +141,7 @@ describe('TestShake', () => {
     mockHeaterShakerModuleCard.mockReturnValue(
       <div>Mock Heater Shaker Module Card</div>
     )
-    mockUseLatchControlsLiveEndpoint.mockReturnValue({
+    mockUseLatchControls.mockReturnValue({
       toggleLatch: jest.fn(),
       isLatchClosed: true,
     } as any)
@@ -194,7 +194,7 @@ describe('TestShake', () => {
       moduleFromProtocol: undefined,
     }
 
-    mockUseLatchControlsLiveEndpoint.mockReturnValue({
+    mockUseLatchControls.mockReturnValue({
       toggleLatch: mockToggleLatch,
       isLatchClosed: false,
     })
@@ -249,7 +249,7 @@ describe('TestShake', () => {
       moduleFromProtocol: undefined,
     }
 
-    mockUseLatchControlsLiveEndpoint.mockReturnValue({
+    mockUseLatchControls.mockReturnValue({
       toggleLatch: mockToggleLatch,
       isLatchClosed: false,
     })
@@ -285,7 +285,7 @@ describe('TestShake', () => {
       moduleFromProtocol: undefined,
     }
 
-    mockUseLatchControlsLiveEndpoint.mockReturnValue({
+    mockUseLatchControls.mockReturnValue({
       toggleLatch: mockToggleLatch,
       isLatchClosed: true,
     })
@@ -303,7 +303,7 @@ describe('TestShake', () => {
       moduleFromProtocol: undefined,
     }
 
-    mockUseLatchControlsLiveEndpoint.mockReturnValue({
+    mockUseLatchControls.mockReturnValue({
       toggleLatch: mockToggleLatch,
       isLatchClosed: false,
     })

--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/TestShake.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/TestShake.test.tsx
@@ -1,15 +1,11 @@
 import * as React from 'react'
 import { nestedTextMatcher, renderWithProviders } from '@opentrons/components'
 import { fireEvent, waitFor } from '@testing-library/react'
-import {
-  useCreateCommandMutation,
-  useCreateLiveCommandMutation,
-} from '@opentrons/react-api-client'
+import { useCreateLiveCommandMutation } from '@opentrons/react-api-client'
 import { i18n } from '../../../../i18n'
 import { useLatchControls } from '../../../ModuleCard/hooks'
 import heaterShakerCommands from '@opentrons/shared-data/protocol/fixtures/6/heaterShakerCommands.json'
 import { mockHeaterShaker } from '../../../../redux/modules/__fixtures__'
-import { useModuleIdFromRun } from '../../../ModuleCard/useModuleIdFromRun'
 import { useRunStatuses } from '../../hooks'
 import { TestShake } from '../TestShake'
 import { HeaterShakerModuleCard } from '../HeaterShakerModuleCard'
@@ -19,7 +15,6 @@ import type { ProtocolModuleInfo } from '../../../Devices/ProtocolRun/utils/getP
 jest.mock('@opentrons/react-api-client')
 jest.mock('../HeaterShakerModuleCard')
 jest.mock('../../../ModuleCard/hooks')
-jest.mock('../../../ModuleCard/useModuleIdFromRun')
 jest.mock('../../hooks')
 
 const mockUseLiveCommandMutation = useCreateLiveCommandMutation as jest.MockedFunction<
@@ -30,9 +25,6 @@ const mockUseLatchControls = useLatchControls as jest.MockedFunction<
 >
 const mockHeaterShakerModuleCard = HeaterShakerModuleCard as jest.MockedFunction<
   typeof HeaterShakerModuleCard
->
-const mockUseModuleIdFromRun = useModuleIdFromRun as jest.MockedFunction<
-  typeof useModuleIdFromRun
 >
 const mockUseRunStatuses = useRunStatuses as jest.MockedFunction<
   typeof useRunStatuses
@@ -145,9 +137,6 @@ describe('TestShake', () => {
       toggleLatch: jest.fn(),
       isLatchClosed: true,
     } as any)
-    mockUseModuleIdFromRun.mockReturnValue({
-      moduleIdFromRun: 'heatershaker_id',
-    })
     mockUseRunStatuses.mockReturnValue({
       isRunStill: false,
       isRunTerminal: false,
@@ -266,7 +255,7 @@ describe('TestShake', () => {
       moduleFromProtocol: undefined,
     }
 
-    mockUseLatchControlsLiveEndpoint.mockReturnValue({
+    mockUseLatchControls.mockReturnValue({
       toggleLatch: mockToggleLatch,
       isLatchClosed: false,
     })
@@ -314,7 +303,7 @@ describe('TestShake', () => {
     expect(mockToggleLatch).toHaveBeenCalled()
   })
 
-  it('entering an input for shake speed and clicking start should begin shaking when there is no run id', async () => {
+  it('entering an input for shake speed and clicking start should begin shaking', async () => {
     props = {
       module: mockCloseLatchHeaterShaker,
       setCurrentPage: jest.fn(),
@@ -373,7 +362,7 @@ describe('TestShake', () => {
   })
 
   //  next test is sending module commands when run is terminal and through module controls
-  it('entering an input for shake speed and clicking start should close the latch and begin shaking when there is a run id and run is terminal', async () => {
+  it('entering an input for shake speed and clicking start should close the latch and begin shaking when run is terminal', async () => {
     mockUseRunStatuses.mockReturnValue({
       isRunStill: false,
       isRunTerminal: true,

--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/TestShake.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/TestShake.test.tsx
@@ -6,8 +6,7 @@ import {
   useCreateLiveCommandMutation,
 } from '@opentrons/react-api-client'
 import { i18n } from '../../../../i18n'
-import { useLatchControls } from '../../../ModuleCard/hooks'
-import { RUN_ID_1 } from '../../../RunTimeControl/__fixtures__'
+import { useLatchControlsLiveEndpoint } from '../../../ModuleCard/hooks'
 import heaterShakerCommands from '@opentrons/shared-data/protocol/fixtures/6/heaterShakerCommands.json'
 import { mockHeaterShaker } from '../../../../redux/modules/__fixtures__'
 import { useModuleIdFromRun } from '../../../ModuleCard/useModuleIdFromRun'
@@ -26,11 +25,8 @@ jest.mock('../../hooks')
 const mockUseLiveCommandMutation = useCreateLiveCommandMutation as jest.MockedFunction<
   typeof useCreateLiveCommandMutation
 >
-const mockUseCommandMutation = useCreateCommandMutation as jest.MockedFunction<
-  typeof useCreateCommandMutation
->
-const mockUseLatchControls = useLatchControls as jest.MockedFunction<
-  typeof useLatchControls
+const mockUseLatchControlsLiveEndpoint = useLatchControlsLiveEndpoint as jest.MockedFunction<
+  typeof useLatchControlsLiveEndpoint
 >
 const mockHeaterShakerModuleCard = HeaterShakerModuleCard as jest.MockedFunction<
   typeof HeaterShakerModuleCard
@@ -130,7 +126,6 @@ const mockMovingHeaterShaker = {
 describe('TestShake', () => {
   let props: React.ComponentProps<typeof TestShake>
   let mockCreateLiveCommand = jest.fn()
-  let mockCreateCommand = jest.fn()
   const mockToggleLatch = jest.fn()
   beforeEach(() => {
     props = {
@@ -143,15 +138,11 @@ describe('TestShake', () => {
     mockUseLiveCommandMutation.mockReturnValue({
       createLiveCommand: mockCreateLiveCommand,
     } as any)
-    mockCreateCommand = jest.fn()
-    mockUseCommandMutation.mockReturnValue({
-      createCommand: mockCreateCommand,
-    } as any)
     mockHeaterShakerModuleCard.mockReturnValue(
       <div>Mock Heater Shaker Module Card</div>
     )
-    mockUseLatchControls.mockReturnValue({
-      handleLatch: jest.fn(),
+    mockUseLatchControlsLiveEndpoint.mockReturnValue({
+      toggleLatch: jest.fn(),
       isLatchClosed: true,
     } as any)
     mockUseModuleIdFromRun.mockReturnValue({
@@ -203,7 +194,7 @@ describe('TestShake', () => {
       moduleFromProtocol: undefined,
     }
 
-    mockUseLatchControls.mockReturnValue({
+    mockUseLatchControlsLiveEndpoint.mockReturnValue({
       toggleLatch: mockToggleLatch,
       isLatchClosed: false,
     })
@@ -258,7 +249,7 @@ describe('TestShake', () => {
       moduleFromProtocol: undefined,
     }
 
-    mockUseLatchControls.mockReturnValue({
+    mockUseLatchControlsLiveEndpoint.mockReturnValue({
       toggleLatch: mockToggleLatch,
       isLatchClosed: false,
     })
@@ -275,7 +266,7 @@ describe('TestShake', () => {
       moduleFromProtocol: undefined,
     }
 
-    mockUseLatchControls.mockReturnValue({
+    mockUseLatchControlsLiveEndpoint.mockReturnValue({
       toggleLatch: mockToggleLatch,
       isLatchClosed: false,
     })
@@ -294,7 +285,7 @@ describe('TestShake', () => {
       moduleFromProtocol: undefined,
     }
 
-    mockUseLatchControls.mockReturnValue({
+    mockUseLatchControlsLiveEndpoint.mockReturnValue({
       toggleLatch: mockToggleLatch,
       isLatchClosed: true,
     })
@@ -312,7 +303,7 @@ describe('TestShake', () => {
       moduleFromProtocol: undefined,
     }
 
-    mockUseLatchControls.mockReturnValue({
+    mockUseLatchControlsLiveEndpoint.mockReturnValue({
       toggleLatch: mockToggleLatch,
       isLatchClosed: false,
     })
@@ -358,7 +349,7 @@ describe('TestShake', () => {
     })
   })
 
-  it('when the heater shaker is shaking clicking stop should deactivate the shaking when there is no run id', () => {
+  it('when the heater shaker is shaking clicking stop should deactivate the shaking', () => {
     props = {
       module: mockMovingHeaterShaker,
       setCurrentPage: jest.fn(),
@@ -393,49 +384,6 @@ describe('TestShake', () => {
       module: mockHeaterShaker,
       setCurrentPage: jest.fn(),
       moduleFromProtocol: HEATER_SHAKER_PROTOCOL_MODULE_INFO,
-      currentRunId: RUN_ID_1,
-    }
-
-    const { getByRole } = render(props)
-    const button = getByRole('button', { name: /Start Shaking/i })
-    const input = getByRole('spinbutton')
-    fireEvent.change(input, { target: { value: '300' } })
-    fireEvent.click(button)
-
-    await waitFor(() => {
-      expect(mockCreateLiveCommand).toHaveBeenCalledWith({
-        command: {
-          commandType: 'heaterShaker/closeLabwareLatch',
-          params: {
-            moduleId: 'heatershaker_id',
-          },
-        },
-      })
-
-      expect(mockCreateLiveCommand).toHaveBeenCalledWith({
-        command: {
-          commandType: 'heaterShaker/setAndWaitForShakeSpeed',
-          params: {
-            moduleId: 'heatershaker_id',
-            rpm: 300,
-          },
-        },
-      })
-    })
-  })
-
-  //  next test is sending module commands when run is terminal and through device details module cards
-  it('entering an input for shake speed and clicking start should close the labware latch and begin shaking when there is a run id, run is terminal, and through device details', async () => {
-    mockUseRunStatuses.mockReturnValue({
-      isRunStill: false,
-      isRunTerminal: true,
-      isRunIdle: false,
-    })
-    props = {
-      module: mockCloseLatchHeaterShaker,
-      setCurrentPage: jest.fn(),
-      moduleFromProtocol: undefined,
-      currentRunId: RUN_ID_1,
     }
 
     const { getByRole } = render(props)

--- a/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/index.tsx
@@ -30,13 +30,12 @@ import type { ProtocolModuleInfo } from '../../Devices/ProtocolRun/utils/getProt
 interface HeaterShakerWizardProps {
   onCloseClick: () => unknown
   moduleFromProtocol?: ProtocolModuleInfo
-  currentRunId?: string
 }
 
 export const HeaterShakerWizard = (
   props: HeaterShakerWizardProps
 ): JSX.Element | null => {
-  const { onCloseClick, moduleFromProtocol, currentRunId } = props
+  const { onCloseClick, moduleFromProtocol } = props
   const { t } = useTranslation(['heater_shaker', 'shared'])
   const [currentPage, setCurrentPage] = React.useState(0)
   const { robotName } = useParams<NavRouteParams>()
@@ -92,9 +91,7 @@ export const HeaterShakerWizard = (
         buttonContent = t('btn_test_shake')
         return (
           // heaterShaker should never be null because isPrimaryCTAEnabled would be disabled otherwise
-          heaterShaker != null ? (
-            <AttachAdapter module={heaterShaker} currentRunId={currentRunId} />
-          ) : null
+          heaterShaker != null ? <AttachAdapter module={heaterShaker} /> : null
         )
       case 5:
         buttonContent = t('complete')
@@ -103,7 +100,6 @@ export const HeaterShakerWizard = (
             module={heaterShaker}
             setCurrentPage={setCurrentPage}
             moduleFromProtocol={moduleFromProtocol}
-            currentRunId={currentRunId}
           />
         ) : null
       default:

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -240,15 +240,20 @@ export function ProtocolRunHeader({
     }
   }, [analysisErrors])
 
+  const isIdle = runStatus === RUN_STATUS_IDLE
+
   const handlePlayButtonClick = (): void => {
     if (isShaking) {
       setShowIsShakingModal(true)
-    } else if (isHeaterShakerInProtocol && !isShaking) {
+    } else if (
+      isHeaterShakerInProtocol &&
+      !isShaking &&
+      (isIdle || runStatus === RUN_STATUS_STOPPED)
+    ) {
       confirmAttachment()
     } else {
       play()
 
-      const isIdle = runStatus === RUN_STATUS_IDLE
       const eventProperties =
         isIdle && robotAnalyticsData != null ? robotAnalyticsData : {}
       const eventName = isIdle ? 'runStart' : 'runResume'

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware.tsx
@@ -210,7 +210,6 @@ export function SetupLabware({
             <ModuleExtraAttention
               moduleTypes={moduleTypesThatRequireExtraAttention}
               modulesInfo={moduleRenderInfoById}
-              runId={runId}
             />
           ) : null}
           <Box margin="0 auto" maxWidth="46.25rem" width="100%">

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ModuleExtraAttention.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ModuleExtraAttention.test.tsx
@@ -2,9 +2,8 @@ import * as React from 'react'
 import { fireEvent } from '@testing-library/react'
 import { HeaterShakerModule } from '@opentrons/api-client'
 import { renderWithProviders } from '@opentrons/components'
-import { useCreateCommandMutation } from '@opentrons/react-api-client'
+import { useCreateLiveCommandMutation } from '@opentrons/react-api-client'
 import { i18n } from '../../../../i18n'
-import { RUN_ID_1 } from '../../../RunTimeControl/__fixtures__'
 import { ModuleExtraAttention } from '../ModuleExtraAttention'
 import {
   mockHeaterShaker as mockHeaterShakerAttachedModule,
@@ -16,8 +15,8 @@ import type { AttachedModule } from '../../../../redux/modules/types'
 
 jest.mock('@opentrons/react-api-client')
 
-const mockUseCreateCommandMutation = useCreateCommandMutation as jest.MockedFunction<
-  typeof useCreateCommandMutation
+const mockUseCreateLiveCommandMutation = useCreateLiveCommandMutation as jest.MockedFunction<
+  typeof useCreateLiveCommandMutation
 >
 
 const MOCK_MAGNETIC_MODULE_COORDS = [10, 20, 0]
@@ -111,14 +110,14 @@ const render = (props: React.ComponentProps<typeof ModuleExtraAttention>) => {
 
 describe('ModuleExtraAttention', () => {
   let props: React.ComponentProps<typeof ModuleExtraAttention>
-  let mockCreateCommand = jest.fn()
+  let mockCreateLiveCommand = jest.fn()
 
   beforeEach(() => {
-    props = { moduleTypes: [], modulesInfo: {}, runId: RUN_ID_1 }
-    mockCreateCommand = jest.fn()
-    mockCreateCommand.mockResolvedValue(null)
-    mockUseCreateCommandMutation.mockReturnValue({
-      createCommand: mockCreateCommand,
+    props = { moduleTypes: [], modulesInfo: {} }
+    mockCreateLiveCommand = jest.fn()
+    mockCreateLiveCommand.mockResolvedValue(null)
+    mockUseCreateLiveCommandMutation.mockReturnValue({
+      createLiveCommand: mockCreateLiveCommand,
     } as any)
   })
 
@@ -145,7 +144,6 @@ describe('ModuleExtraAttention', () => {
           attachedModuleMatch: null,
         },
       },
-      runId: RUN_ID_1,
     }
 
     const { getByText } = render(props)
@@ -172,7 +170,6 @@ describe('ModuleExtraAttention', () => {
           attachedModuleMatch: mockHeaterShakerAttachedModule as AttachedModule,
         },
       },
-      runId: RUN_ID_1,
     }
 
     const { getByText, getByRole } = render(props)
@@ -180,14 +177,13 @@ describe('ModuleExtraAttention', () => {
     getByText('Use latch controls for easy placement of labware.')
     const closeBtn = getByRole('button', { name: 'Close Labware Latch' })
     fireEvent.click(closeBtn)
-    expect(mockCreateCommand).toHaveBeenCalledWith({
+    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
       command: {
         commandType: 'heaterShaker/closeLabwareLatch',
         params: {
-          moduleId: mockHeaterShaker.moduleId,
+          moduleId: mockHeaterShakerAttachedModule.id,
         },
       },
-      runId: RUN_ID_1,
     })
   })
 
@@ -209,20 +205,18 @@ describe('ModuleExtraAttention', () => {
           attachedModuleMatch: mockHeaterShakerLatchClosed as AttachedModule,
         },
       },
-      runId: RUN_ID_1,
     }
 
     const { getByRole } = render(props)
     const openBtn = getByRole('button', { name: 'Open Labware Latch' })
     fireEvent.click(openBtn)
-    expect(mockCreateCommand).toHaveBeenCalledWith({
+    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
       command: {
         commandType: 'heaterShaker/openLabwareLatch',
         params: {
-          moduleId: mockHeaterShaker.moduleId,
+          moduleId: mockHeaterShakerLatchClosed.id,
         },
       },
-      runId: RUN_ID_1,
     })
   })
 
@@ -244,7 +238,6 @@ describe('ModuleExtraAttention', () => {
           attachedModuleMatch: mockThermocyclerAttachedModule as AttachedModule,
         },
       },
-      runId: RUN_ID_1,
     }
 
     const { getByText } = render(props)

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { BrowserRouter } from 'react-router-dom'
 import '@testing-library/jest-dom'
-import { fireEvent, waitFor } from '@testing-library/react'
+import { fireEvent, waitFor, screen } from '@testing-library/react'
 import { when, resetAllWhenMocks } from 'jest-when'
 import {
   RUN_STATUS_IDLE,
@@ -664,6 +664,8 @@ describe('ProtocolRunHeader', () => {
   })
 
   it('if a heater shaker is shaking, clicking on start run should render HeaterShakerIsRunningModal', () => {
+    when(mockUseRunStatus).calledWith(RUN_ID).mockReturnValue(RUN_STATUS_IDLE)
+
     mockUseModulesQuery.mockReturnValue({
       data: { data: [mockMovingHeaterShaker] },
     } as any)
@@ -673,7 +675,7 @@ describe('ProtocolRunHeader', () => {
     getByText('Mock HeaterShakerIsRunningModal')
   })
 
-  it('renders the confirm attachment modal when there is a heater shaker in the protocol and the heater shaker is idle status', () => {
+  it('does not render the confirm attachment modal when there is a heater shaker in the protocol and run is idle', () => {
     mockUseModulesQuery.mockReturnValue({
       data: { data: [mockHeaterShaker] },
     } as any)
@@ -684,6 +686,21 @@ describe('ProtocolRunHeader', () => {
     fireEvent.click(button)
     getByText('mock confirm attachment modal')
     expect(mockTrackProtocolRunEvent).toBeCalledTimes(0)
+  })
+
+  it('renders the confirm attachment modal when there is a heater shaker in the protocol and the heater shaker is idle status and run is paused', () => {
+    when(mockUseRunStatus).calledWith(RUN_ID).mockReturnValue(RUN_STATUS_PAUSED)
+
+    mockUseModulesQuery.mockReturnValue({
+      data: { data: [mockHeaterShaker] },
+    } as any)
+    mockUseIsHeaterShakerInProtocol.mockReturnValue(true)
+    const [{ getByRole }] = render()
+
+    const button = getByRole('button', { name: 'Resume run' })
+    fireEvent.click(button)
+    expect(mockConfirmAttachmentModal).not.toHaveBeenCalled()
+    expect(mockTrackProtocolRunEvent).toBeCalledTimes(1)
   })
 
   it('does NOT render confirm attachment modal when the user already confirmed the heater shaker is attached', () => {

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { BrowserRouter } from 'react-router-dom'
 import '@testing-library/jest-dom'
-import { fireEvent, waitFor, screen } from '@testing-library/react'
+import { fireEvent, waitFor } from '@testing-library/react'
 import { when, resetAllWhenMocks } from 'jest-when'
 import {
   RUN_STATUS_IDLE,
@@ -695,11 +695,11 @@ describe('ProtocolRunHeader', () => {
       data: { data: [mockHeaterShaker] },
     } as any)
     mockUseIsHeaterShakerInProtocol.mockReturnValue(true)
-    const [{ getByRole }] = render()
+    const [{ queryByText, getByRole }] = render()
 
     const button = getByRole('button', { name: 'Resume run' })
     fireEvent.click(button)
-    expect(mockConfirmAttachmentModal).not.toHaveBeenCalled()
+    expect(queryByText('mock confirm attachment modal')).toBeFalsy()
     expect(mockTrackProtocolRunEvent).toBeCalledTimes(1)
   })
 

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/SetupLabware.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/SetupLabware.test.tsx
@@ -515,7 +515,6 @@ describe('LabwareSetup', () => {
               attachedModuleMatch: null,
             },
           },
-          runId: RUN_ID,
         })
       )
       .mockReturnValue(

--- a/app/src/organisms/ModuleCard/TestShakeSlideout.tsx
+++ b/app/src/organisms/ModuleCard/TestShakeSlideout.tsx
@@ -74,7 +74,7 @@ export const TestShakeSlideout = (
   const [targetProps, tooltipProps] = useHoverTooltip({
     placement: 'left',
   })
-  const { toggleLatch, isLatchClosed } = useLatchControls(module, currentRunId)
+  const { toggleLatch, isLatchClosed } = useLatchControls(module)
   const { moduleIdFromRun } = useModuleIdFromRun(module, currentRunId ?? null)
   const configHasHeaterShakerAttached = useSelector(getIsHeaterShakerAttached)
   const [shakeValue, setShakeValue] = React.useState<string | null>(null)

--- a/app/src/organisms/ModuleCard/__tests__/TestShakeSlideout.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/TestShakeSlideout.test.tsx
@@ -270,28 +270,6 @@ describe('TestShakeSlideout', () => {
       })
     })
   })
-  //  next 2 tests are sending module commands when run is idle and through module controls
-  it('renders the open labware latch button and clicking it opens the latch when there is a runId and run is idle', () => {
-    mockUseRunStatuses.mockReturnValue({
-      isRunStill: false,
-      isRunTerminal: false,
-      isRunIdle: true,
-    })
-
-    props = {
-      module: mockCloseLatchHeaterShaker,
-      onCloseClick: jest.fn(),
-      isExpanded: true,
-      isLoadedInRun: true,
-      currentRunId: 'test123',
-    }
-
-    const { getByRole } = render(props)
-    const button = getByRole('button', { name: /Open/i })
-    fireEvent.click(button)
-    expect(mockToggleLatch).toHaveBeenCalled()
-  })
-
   it('entering an input for shake speed and clicking start should begin shaking when there is a runId and run is idle', async () => {
     mockUseRunStatuses.mockReturnValue({
       isRunStill: false,

--- a/app/src/organisms/ModuleCard/__tests__/hooks.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/hooks.test.tsx
@@ -20,12 +20,10 @@ import {
   useProtocolDetailsForRun,
   useRunStatuses,
 } from '../../Devices/hooks'
-import { RUN_ID_1 } from '../../RunTimeControl/__fixtures__'
 import {
   useLatchControls,
   useModuleOverflowMenu,
   useIsHeaterShakerInProtocol,
-  useLatchControlsLiveEndpoint,
 } from '../hooks'
 import { useModuleIdFromRun } from '../useModuleIdFromRun'
 
@@ -200,88 +198,9 @@ const mockTCLidHeating = {
   usbPort: { hub: 1, port: 1, path: '/dev/ot_module_thermocycler0' },
 } as any
 
-describe('useLatchControlsLiveEndpoint', () => {
-  const store: Store<any> = createStore(jest.fn(), {})
-  let mockCreateLiveCommand = jest.fn()
-
-  beforeEach(() => {
-    store.dispatch = jest.fn()
-    mockCreateLiveCommand = jest.fn()
-    mockCreateLiveCommand.mockResolvedValue(null)
-    mockUseRunStatuses.mockReturnValue({
-      isRunStill: false,
-      isRunIdle: false,
-      isRunTerminal: false,
-    })
-    mockUseLiveCommandMutation.mockReturnValue({
-      createLiveCommand: mockCreateLiveCommand,
-    } as any)
-    mockUseIsRobotBusy.mockReturnValue(false)
-  })
-
-  afterEach(() => {
-    jest.restoreAllMocks()
-  })
-
-  it('should return latch is open and handle latch function and command to close latch', () => {
-    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
-      <I18nextProvider i18n={i18n}>
-        <Provider store={store}>{children}</Provider>
-      </I18nextProvider>
-    )
-    mockUseModuleIdFromRun.mockReturnValue({
-      moduleIdFromRun: 'heatershaker_id',
-    })
-    const { result } = renderHook(
-      () => useLatchControlsLiveEndpoint(mockHeaterShaker),
-      {
-        wrapper,
-      }
-    )
-    const { isLatchClosed } = result.current
-
-    expect(isLatchClosed).toBe(false)
-    act(() => result.current.toggleLatch())
-    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
-      command: {
-        commandType: 'heaterShaker/closeLabwareLatch',
-        params: {
-          moduleId: mockHeaterShaker.id,
-        },
-      },
-    })
-  })
-  it('should return if latch is closed and handle latch function opens latch', () => {
-    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
-      <I18nextProvider i18n={i18n}>
-        <Provider store={store}>{children}</Provider>
-      </I18nextProvider>
-    )
-    const { result } = renderHook(
-      () => useLatchControlsLiveEndpoint(mockCloseLatchHeaterShaker),
-      {
-        wrapper,
-      }
-    )
-    const { isLatchClosed } = result.current
-
-    expect(isLatchClosed).toBe(true)
-    act(() => result.current.toggleLatch())
-    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
-      command: {
-        commandType: 'heaterShaker/openLabwareLatch',
-        params: {
-          moduleId: mockCloseLatchHeaterShaker.id,
-        },
-      },
-    })
-  })
-})
-
 describe('useLatchControls', () => {
   const store: Store<any> = createStore(jest.fn(), {})
   let mockCreateLiveCommand = jest.fn()
-  let mockCreateCommand = jest.fn()
 
   beforeEach(() => {
     store.dispatch = jest.fn()
@@ -296,11 +215,6 @@ describe('useLatchControls', () => {
       createLiveCommand: mockCreateLiveCommand,
     } as any)
     mockUseIsRobotBusy.mockReturnValue(false)
-    mockCreateCommand = jest.fn()
-    mockCreateCommand.mockResolvedValue(null)
-    mockUseCreateCommandMutation.mockReturnValue({
-      createCommand: mockCreateCommand,
-    } as any)
   })
 
   afterEach(() => {
@@ -349,39 +263,6 @@ describe('useLatchControls', () => {
     expect(isLatchClosed).toBe(true)
     act(() => result.current.toggleLatch())
     expect(mockCreateLiveCommand).toHaveBeenCalledWith({
-      command: {
-        commandType: 'heaterShaker/openLabwareLatch',
-        params: {
-          moduleId: mockCloseLatchHeaterShaker.id,
-        },
-      },
-    })
-  })
-
-  it('should return if latch is closed and handle latch function opens latch when run is idle', () => {
-    mockUseRunStatuses.mockReturnValue({
-      isRunStill: false,
-      isRunIdle: true,
-      isRunTerminal: false,
-    })
-
-    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
-      <I18nextProvider i18n={i18n}>
-        <Provider store={store}>{children}</Provider>
-      </I18nextProvider>
-    )
-    const { result } = renderHook(
-      () => useLatchControls(mockCloseLatchHeaterShaker, RUN_ID_1),
-      {
-        wrapper,
-      }
-    )
-    const { isLatchClosed } = result.current
-
-    expect(isLatchClosed).toBe(true)
-    act(() => result.current.toggleLatch())
-    expect(mockCreateCommand).toHaveBeenCalledWith({
-      runId: RUN_ID_1,
       command: {
         commandType: 'heaterShaker/openLabwareLatch',
         params: {

--- a/app/src/organisms/ModuleCard/hooks.tsx
+++ b/app/src/organisms/ModuleCard/hooks.tsx
@@ -53,12 +53,8 @@ interface LatchControls {
   isLatchClosed: boolean
 }
 
-//  TODO(jr, 7/28/22): delete this hook when all module commands are sent using live endpoint
-export function useLatchControlsLiveEndpoint(
-  module: AttachedModule
-): LatchControls {
+export function useLatchControls(module: AttachedModule): LatchControls {
   const { createLiveCommand } = useCreateLiveCommandMutation()
-
   const isLatchClosed =
     module.moduleType === 'heaterShakerModuleType' &&
     (module.data.labwareLatchStatus === 'idle_closed' ||
@@ -85,56 +81,6 @@ export function useLatchControlsLiveEndpoint(
     })
   }
 
-  return { toggleLatch, isLatchClosed }
-}
-
-export function useLatchControls(
-  module: AttachedModule,
-  runId?: string | null
-): LatchControls {
-  const { createLiveCommand } = useCreateLiveCommandMutation()
-  const { createCommand } = useCreateCommandMutation()
-  const { isRunIdle } = useRunStatuses()
-  const { moduleIdFromRun } = useModuleIdFromRun(
-    module,
-    runId != null ? runId : null
-  )
-  const isLatchClosed =
-    module.moduleType === 'heaterShakerModuleType' &&
-    (module.data.labwareLatchStatus === 'idle_closed' ||
-      module.data.labwareLatchStatus === 'closing')
-
-  const latchCommand:
-    | HeaterShakerOpenLatchCreateCommand
-    | HeaterShakerCloseLatchCreateCommand = {
-    commandType: isLatchClosed
-      ? 'heaterShaker/openLabwareLatch'
-      : 'heaterShaker/closeLabwareLatch',
-    params: {
-      moduleId: isRunIdle ? moduleIdFromRun : module.id,
-    },
-  }
-
-  const toggleLatch = (): void => {
-    if (runId != null && isRunIdle) {
-      createCommand({
-        runId: runId,
-        command: latchCommand,
-      }).catch((e: Error) => {
-        console.error(
-          `error setting module status with command type ${latchCommand.commandType} and run id ${runId}: ${e.message}`
-        )
-      })
-    } else {
-      createLiveCommand({
-        command: latchCommand,
-      }).catch((e: Error) => {
-        console.error(
-          `error setting module status with command type ${latchCommand.commandType}: ${e.message}`
-        )
-      })
-    }
-  }
   return { toggleLatch, isLatchClosed }
 }
 export type MenuItemsByModuleType = {
@@ -170,7 +116,7 @@ export function useModuleOverflowMenu(
   const { t } = useTranslation(['device_details', 'heater_shaker'])
   const { createLiveCommand } = useCreateLiveCommandMutation()
   const { createCommand } = useCreateCommandMutation()
-  const { toggleLatch, isLatchClosed } = useLatchControls(module, runId)
+  const { toggleLatch, isLatchClosed } = useLatchControls(module)
   const [targetProps, tooltipProps] = useHoverTooltip()
   const { moduleIdFromRun } = useModuleIdFromRun(module, runId)
   const isLegacySessionInProgress = useIsLegacySessionInProgress()

--- a/app/src/organisms/ModuleCard/index.tsx
+++ b/app/src/organisms/ModuleCard/index.tsx
@@ -224,15 +224,9 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
       width="100%"
       data-testid={`ModuleCard_${module.serialNumber}`}
     >
-      {showWizard &&
-        (currentRunId != null ? (
-          <HeaterShakerWizard
-            onCloseClick={() => setShowWizard(false)}
-            currentRunId={currentRunId}
-          />
-        ) : (
-          <HeaterShakerWizard onCloseClick={() => setShowWizard(false)} />
-        ))}
+      {showWizard && (
+        <HeaterShakerWizard onCloseClick={() => setShowWizard(false)} />
+      )}
       {showSlideout && (
         <ModuleSlideout
           module={module}

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/HeaterShakerBanner.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/HeaterShakerBanner.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next'
 import { COLORS } from '@opentrons/components'
 import { Divider } from '../../../../../atoms/structure/Divider'
 import { HeaterShakerWizard } from '../../../../Devices/HeaterShakerWizard'
-import { useCurrentRunId } from '../../../../ProtocolUpload/hooks'
 import { ModuleRenderInfoForProtocol } from '../../../../Devices/hooks'
 import { Banner, BannerItem } from '../Banner/Banner'
 
@@ -17,10 +16,7 @@ export function HeaterShakerBanner(
 ): JSX.Element | null {
   const [showWizard, setShowWizard] = React.useState(false)
   const { displayName, modules } = props
-  const currentRunId = useCurrentRunId()
   const { t } = useTranslation('heater_shaker')
-
-  if (currentRunId == null) return null
 
   return (
     <Banner title={t('attach_heater_shaker_to_deck', { name: displayName })}>
@@ -30,7 +26,6 @@ export function HeaterShakerBanner(
             <HeaterShakerWizard
               onCloseClick={() => setShowWizard(false)}
               moduleFromProtocol={module}
-              currentRunId={currentRunId}
             />
           )}
           {index > 0 && <Divider color={COLORS.medGrey} />}

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/__tests__/HeaterShakerBanner.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/__tests__/HeaterShakerBanner.test.tsx
@@ -4,12 +4,9 @@ import { renderWithProviders } from '@opentrons/components'
 import { HeaterShakerBanner } from '../HeaterShakerBanner'
 import heaterShakerCommands from '@opentrons/shared-data/protocol/fixtures/6/heaterShakerCommands.json'
 import { mockHeaterShaker } from '../../../../../../redux/modules/__fixtures__'
-import { useCurrentRunId } from '../../../../../ProtocolUpload/hooks'
 import { ModuleRenderInfoForProtocol } from '../../../../../Devices/hooks'
-import { RUN_ID_1 } from '../../../../../RunTimeControl/__fixtures__'
 import type { ModuleModel, ModuleType } from '@opentrons/shared-data'
 
-jest.mock('../../../../../ProtocolUpload/hooks')
 const mockHeaterShakerDefinition = {
   moduleId: 'someHeaterShakerModule',
   model: 'heaterShakerModuleV1' as ModuleModel,
@@ -56,10 +53,6 @@ const HEATER_SHAKER_PROTOCOL_MODULE_INFO_2 = {
   slotName: '3',
 } as ModuleRenderInfoForProtocol
 
-const mockUseCurrentRunId = useCurrentRunId as jest.MockedFunction<
-  typeof useCurrentRunId
->
-
 const render = (props: React.ComponentProps<typeof HeaterShakerBanner>) => {
   return renderWithProviders(<HeaterShakerBanner {...props} />, {
     i18nInstance: i18n,
@@ -73,7 +66,6 @@ describe('HeaterShakerBanner', () => {
       displayName: 'HeaterShakerV1',
       modules: [HEATER_SHAKER_PROTOCOL_MODULE_INFO],
     }
-    mockUseCurrentRunId.mockReturnValue(RUN_ID_1)
   })
 
   it('should render banner component', () => {


### PR DESCRIPTION
closes #11250 

# Overview

Upon discussion, we decided to only allow the H-S wizard commands to send commands to the stateless live endpoint.

Additionally, this PR extends logic so the `confirmAttachment` modal only shows up when a run has just started (you select 'start run' when the run is `idle` or `stopped` - 'stopped' is when you run a protocol again.) 

# Changelog

- change usage of `createCommandMutation` to `createLiveCommandMutation` in `ModulesExtraAttention`, and modify `useLatchControls`, `AttachAdapter`, and `TestShake`. Refactor components to not need run ID and fix associated components
- extend logic in `ProtocolRunHeader` and add test case

# Review requests

- test that H-S wizard works okay, no matter how it is accessed. And test the Labware Setup H-S latch button when you upload a H-S protocol

# Risk assessment

low