### PR TITLE
feat(engine): move pipettes away if blocking heater-shaker open latch or start shake

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/open_labware_latch.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/open_labware_latch.py
@@ -6,7 +6,6 @@ from typing_extensions import Literal, Type
 from pydantic import BaseModel, Field
 
 from opentrons.protocol_engine.types import MotorAxis
-from opentrons.motion_planning.adjacent_slots_getters import get_east_west_slots
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
@@ -52,17 +51,10 @@ class OpenLabwareLatchImpl(
 
         hs_module_substate.raise_if_shaking()
 
-        # Check if pipette would block opening the latch
-        current_well = self._state_view.pipettes.get_current_well()
-        if current_well is not None:
-            pipette_deck_slot = int(self._state_view.geometry.get_ancestor_slot_name(current_well.labware_id))
-            hs_deck_slot = int(self._state_view.modules.get_location(hs_module_substate.module_id).slotName)
-            conflicting_slots = get_east_west_slots(hs_deck_slot) + [hs_deck_slot]
-            pipette_blocking = pipette_deck_slot in conflicting_slots
-        else:
-            pipette_blocking = True
-
-        if pipette_blocking:
+        # Check if pipette would block opening latch if east, west, or on top of module
+        if self._state_view.motion.check_pipette_blocking_hs_latch(
+            hs_module_substate.module_id
+        ):
             await self._movement.home(
                 [
                     MotorAxis.RIGHT_Z,

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/open_labware_latch.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/open_labware_latch.py
@@ -51,10 +51,11 @@ class OpenLabwareLatchImpl(
 
         hs_module_substate.raise_if_shaking()
 
-        # Check if pipette would block opening latch if east, west, or on top of module
+        # Move pipette away if it is close to the heater-shaker
         if self._state_view.motion.check_pipette_blocking_hs_latch(
             hs_module_substate.module_id
         ):
+            # TODO(jbl 2022-07-28) replace home movement with a retract movement
             await self._movement.home(
                 [
                     MotorAxis.RIGHT_Z,

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/set_and_wait_for_shake_speed.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/set_and_wait_for_shake_speed.py
@@ -6,7 +6,6 @@ from typing_extensions import Literal, Type
 from pydantic import BaseModel, Field
 
 from opentrons.protocol_engine.types import MotorAxis
-from opentrons.motion_planning.adjacent_slots_getters import get_adjacent_slots
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/set_and_wait_for_shake_speed.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/set_and_wait_for_shake_speed.py
@@ -60,10 +60,11 @@ class SetAndWaitForShakeSpeedImpl(
         # Verify speed from hs module view
         validated_speed = hs_module_substate.validate_target_speed(params.rpm)
 
-        # Check if pipette would block opening latch if adjacent or on top of module
+        # Move pipette away if it is close to the heater-shaker
         if self._state_view.motion.check_pipette_blocking_hs_shaker(
             hs_module_substate.module_id
         ):
+            # TODO(jbl 2022-07-28) replace home movement with a retract movement
             await self._movement.home(
                 [
                     MotorAxis.RIGHT_Z,

--- a/api/src/opentrons/protocol_engine/state/motion.py
+++ b/api/src/opentrons/protocol_engine/state/motion.py
@@ -184,7 +184,7 @@ class MotionView:
     def check_pipette_blocking_hs_latch(
         self, hs_module_id: HeaterShakerModuleId
     ) -> bool:
-        """Check if pipette would block h/s latch from opening."""
+        """Check if pipette would block h/s latch from opening if it is easy, west or on module."""
         pipette_blocking = True
         current_well = self._pipettes.get_current_well()
         if current_well is not None:
@@ -199,7 +199,7 @@ class MotionView:
     def check_pipette_blocking_hs_shaker(
         self, hs_module_id: HeaterShakerModuleId
     ) -> bool:
-        """Check if pipette would block h/s latch from starting shake."""
+        """Check if pipette would block h/s latch from starting shake if it is adjacent or on module."""
         pipette_blocking = True
         current_well = self._pipettes.get_current_well()
         if current_well is not None:

--- a/api/src/opentrons/protocol_engine/state/motion.py
+++ b/api/src/opentrons/protocol_engine/state/motion.py
@@ -184,7 +184,7 @@ class MotionView:
     def check_pipette_blocking_hs_latch(
         self, hs_module_id: HeaterShakerModuleId
     ) -> bool:
-        """Check if pipette would block h/s latch from opening if it is easy, west or on module."""
+        """Check if pipette would block h/s latch from opening if it is east, west or on module."""
         pipette_blocking = True
         current_well = self._pipettes.get_current_well()
         if current_well is not None:

--- a/api/src/opentrons/protocol_engine/state/motion.py
+++ b/api/src/opentrons/protocol_engine/state/motion.py
@@ -184,7 +184,7 @@ class MotionView:
     def check_pipette_blocking_hs_latch(
         self, hs_module_id: HeaterShakerModuleId
     ) -> bool:
-        """Check if pipette would block h/s latch from opening"""
+        """Check if pipette would block h/s latch from opening."""
         pipette_blocking = True
         current_well = self._pipettes.get_current_well()
         if current_well is not None:
@@ -199,7 +199,7 @@ class MotionView:
     def check_pipette_blocking_hs_shaker(
         self, hs_module_id: HeaterShakerModuleId
     ) -> bool:
-        """Check if pipette would block h/s latch from starting shake"""
+        """Check if pipette would block h/s latch from starting shake."""
         pipette_blocking = True
         current_well = self._pipettes.get_current_well()
         if current_well is not None:

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -20,6 +20,8 @@ from ..commands import (
     DropTipResult,
     HomeResult,
     BlowOutResult,
+    TouchTipResult,
+    thermocycler,
 )
 from ..actions import Action, UpdateCommandAction
 from .abstract_store import HasState, HandlesActions
@@ -81,6 +83,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                 AspirateResult,
                 DispenseResult,
                 BlowOutResult,
+                TouchTipResult,
             ),
         ):
             self._state.current_well = CurrentWell(
@@ -90,7 +93,15 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             )
 
         # TODO(mc, 2021-11-12): wipe out current_well on movement failures, too
-        elif isinstance(command.result, (HomeResult, MoveToCoordinatesResult)):
+        elif isinstance(
+            command.result,
+            (
+                HomeResult,
+                MoveToCoordinatesResult,
+                thermocycler.OpenLidResult,
+                thermocycler.CloseLidResult,
+            ),
+        ):
             # A command left the pipette in a place that we can't associate
             # with a logical well location. Set the current well to None
             # to reflect the fact that it's now unknown.

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_open_labware_latch.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_open_labware_latch.py
@@ -8,20 +8,24 @@ from opentrons.protocol_engine.state.module_substates import (
     HeaterShakerModuleSubState,
     HeaterShakerModuleId,
 )
-from opentrons.protocol_engine.execution import EquipmentHandler
+from opentrons.protocol_engine.execution import EquipmentHandler, MovementHandler
 from opentrons.protocol_engine.commands import heater_shaker
 from opentrons.protocol_engine.commands.heater_shaker.open_labware_latch import (
     OpenLabwareLatchImpl,
 )
+from opentrons.protocol_engine.types import MotorAxis
 
 
 async def test_open_labware_latch(
     decoy: Decoy,
     state_view: StateView,
     equipment: EquipmentHandler,
+    movement: MovementHandler,
 ) -> None:
     """It should be able to open the module's labware latch."""
-    subject = OpenLabwareLatchImpl(state_view=state_view, equipment=equipment)
+    subject = OpenLabwareLatchImpl(
+        state_view=state_view, equipment=equipment, movement=movement
+    )
     data = heater_shaker.OpenLabwareLatchParams(moduleId="input-heater-shaker-id")
 
     hs_module_substate = decoy.mock(cls=HeaterShakerModuleSubState)
@@ -37,6 +41,12 @@ async def test_open_labware_latch(
         HeaterShakerModuleId("heater-shaker-id")
     )
 
+    decoy.when(
+        state_view.motion.check_pipette_blocking_hs_latch(
+            HeaterShakerModuleId("heater-shaker-id")
+        )
+    ).then_return(True)
+
     # Get stubbed hardware module
     decoy.when(
         equipment.get_module_hardware_api(HeaterShakerModuleId("heater-shaker-id"))
@@ -44,6 +54,8 @@ async def test_open_labware_latch(
 
     result = await subject.execute(data)
     decoy.verify(
-        hs_module_substate.raise_if_shaking(), await hs_hardware.open_labware_latch()
+        hs_module_substate.raise_if_shaking(),
+        await movement.home([MotorAxis.RIGHT_Z, MotorAxis.LEFT_Z]),
+        await hs_hardware.open_labware_latch(),
     )
     assert result == heater_shaker.OpenLabwareLatchResult()

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_set_and_wait_for_shake_speed.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_set_and_wait_for_shake_speed.py
@@ -8,20 +8,24 @@ from opentrons.protocol_engine.state.module_substates import (
     HeaterShakerModuleSubState,
     HeaterShakerModuleId,
 )
-from opentrons.protocol_engine.execution import EquipmentHandler
+from opentrons.protocol_engine.execution import EquipmentHandler, MovementHandler
 from opentrons.protocol_engine.commands import heater_shaker
 from opentrons.protocol_engine.commands.heater_shaker.set_and_wait_for_shake_speed import (
     SetAndWaitForShakeSpeedImpl,
 )
+from opentrons.protocol_engine.types import MotorAxis
 
 
 async def test_set_and_wait_for_shake_speed(
     decoy: Decoy,
     state_view: StateView,
     equipment: EquipmentHandler,
+    movement: MovementHandler,
 ) -> None:
     """It should be able to set the module's shake speed."""
-    subject = SetAndWaitForShakeSpeedImpl(state_view=state_view, equipment=equipment)
+    subject = SetAndWaitForShakeSpeedImpl(
+        state_view=state_view, equipment=equipment, movement=movement
+    )
     data = heater_shaker.SetAndWaitForShakeSpeedParams(
         moduleId="input-heater-shaker-id",
         rpm=1234.56,
@@ -40,6 +44,12 @@ async def test_set_and_wait_for_shake_speed(
         HeaterShakerModuleId("heater-shaker-id")
     )
 
+    decoy.when(
+        state_view.motion.check_pipette_blocking_hs_shaker(
+            HeaterShakerModuleId("heater-shaker-id")
+        )
+    ).then_return(True)
+
     # Stub speed validation from hs module view
     decoy.when(hs_module_substate.validate_target_speed(rpm=1234.56)).then_return(1234)
 
@@ -51,6 +61,7 @@ async def test_set_and_wait_for_shake_speed(
     result = await subject.execute(data)
     decoy.verify(
         hs_module_substate.raise_if_labware_latch_not_closed(),
+        await movement.home([MotorAxis.RIGHT_Z, MotorAxis.LEFT_Z]),
         await hs_hardware.set_speed(rpm=1234),
     )
     assert result == heater_shaker.SetAndWaitForShakeSpeedResult()

--- a/api/tests/opentrons/protocol_engine/state/test_motion_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_motion_view.py
@@ -15,7 +15,6 @@ from opentrons.protocol_engine.types import (
     WellOffset,
     PipetteName,
     LoadedPipette,
-    DeckSlotName,
     DeckSlotLocation,
 )
 from opentrons.protocol_engine.state import PipetteLocationData
@@ -596,15 +595,22 @@ def test_check_pipette_blocking_hs_latch(
     labware_deck_slot: DeckSlotName,
     expected_result: bool,
 ) -> None:
+    """It should return True if pipette is blocking opening the latch."""
     decoy.when(pipette_view.get_current_well()).then_return(
-        CurrentWell(pipette_id="pipette-id", labware_id="labware-id", well_name="A1"))
+        CurrentWell(pipette_id="pipette-id", labware_id="labware-id", well_name="A1")
+    )
 
-    decoy.when(geometry_view.get_ancestor_slot_name("labware-id")).then_return(labware_deck_slot)
+    decoy.when(geometry_view.get_ancestor_slot_name("labware-id")).then_return(
+        labware_deck_slot
+    )
 
-    decoy.when(mock_module_view.get_location(HeaterShakerModuleId("heater-shaker-id"))).then_return(
-        DeckSlotLocation(slotName=DeckSlotName.SLOT_5))
+    decoy.when(
+        mock_module_view.get_location(HeaterShakerModuleId("heater-shaker-id"))
+    ).then_return(DeckSlotLocation(slotName=DeckSlotName.SLOT_5))
 
-    result = subject.check_pipette_blocking_hs_latch(HeaterShakerModuleId("heater-shaker-id"))
+    result = subject.check_pipette_blocking_hs_latch(
+        HeaterShakerModuleId("heater-shaker-id")
+    )
 
     assert result == expected_result
 
@@ -629,14 +635,21 @@ def test_check_pipette_blocking_hs_shake(
     labware_deck_slot: DeckSlotName,
     expected_result: bool,
 ) -> None:
+    """It should return True if pipette is blocking the h/s from shaking."""
     decoy.when(pipette_view.get_current_well()).then_return(
-        CurrentWell(pipette_id="pipette-id", labware_id="labware-id", well_name="A1"))
+        CurrentWell(pipette_id="pipette-id", labware_id="labware-id", well_name="A1")
+    )
 
-    decoy.when(geometry_view.get_ancestor_slot_name("labware-id")).then_return(labware_deck_slot)
+    decoy.when(geometry_view.get_ancestor_slot_name("labware-id")).then_return(
+        labware_deck_slot
+    )
 
-    decoy.when(mock_module_view.get_location(HeaterShakerModuleId("heater-shaker-id"))).then_return(
-        DeckSlotLocation(slotName=DeckSlotName.SLOT_5))
+    decoy.when(
+        mock_module_view.get_location(HeaterShakerModuleId("heater-shaker-id"))
+    ).then_return(DeckSlotLocation(slotName=DeckSlotName.SLOT_5))
 
-    result = subject.check_pipette_blocking_hs_shaker(HeaterShakerModuleId("heater-shaker-id"))
+    result = subject.check_pipette_blocking_hs_shaker(
+        HeaterShakerModuleId("heater-shaker-id")
+    )
 
     assert result == expected_result


### PR DESCRIPTION
# Overview
In protocol engine, adds check to `openLabwareLatch` and `setAndWaitForShakeSpeed` to determine if pipette is in an unsafe location for these operations. If they are (or location cannot be determined), the pipettes will home on the z-axis

# Changelog
- Pipette will home on z-axis for `openLabwareLatch` and `setAndWaitForShakeSpeed` commands if determined to be in unsafe or unknown location
- Added methods to `MotionView` for determining if pipettes are blocking a shake or open latch command
- Fixed `touchTip` and thermocycler `openLid` and `closeLid` commands not updating engine's `current_well` properly

# Review requests
- Needs to be tested on real robot
- `check_pipette_blocking_hs_shaker` and `check_pipette_blocking_hs_latch` methods are both very similar, but I couldn't figure out a good method to combine them. Open to any ideas to reduce repeating ourselves there.

# Risk assessment
Medium, this only affects two commands but if z-axis homing does not work properly for all expected situations the pipette could be in a bad location when these operations start.