### PR TITLE
refactor(hardware_bindings): update serial reading/writing to account for full and partial serial number expectations

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
@@ -125,14 +125,27 @@ class PipetteNameField(utils.UInt16Field):
 
 
 class SerialField(utils.BinaryFieldBase[bytes]):
-    """The serial number of a pipette or gripper.
+    """The full serial number of a pipette or gripper.
+    """
+
+    NUM_BYTES = 20
+    FORMAT = f"{NUM_BYTES}s"
+
+    @classmethod
+    def from_string(cls, t: str) -> SerialField:
+        """Create from a string."""
+        return cls(binascii.unhexlify(t)[: cls.NUM_BYTES])
+
+
+class SerialDataCodeField(utils.BinaryFieldBase[bytes]):
+    """The serial number Datacode of a pipette or gripper.
 
     This is sized to handle only the datecode part of the serial
     number; the full field can be synthesized from this, the
     model number, and the name.
     """
 
-    NUM_BYTES = 20
+    NUM_BYTES = 12
     FORMAT = f"{NUM_BYTES}s"
 
     @classmethod

--- a/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
@@ -125,8 +125,7 @@ class PipetteNameField(utils.UInt16Field):
 
 
 class SerialField(utils.BinaryFieldBase[bytes]):
-    """The full serial number of a pipette or gripper.
-    """
+    """The full serial number of a pipette or gripper."""
 
     NUM_BYTES = 20
     FORMAT = f"{NUM_BYTES}s"
@@ -149,7 +148,7 @@ class SerialDataCodeField(utils.BinaryFieldBase[bytes]):
     FORMAT = f"{NUM_BYTES}s"
 
     @classmethod
-    def from_string(cls, t: str) -> SerialField:
+    def from_string(cls, t: str) -> SerialDataCodeField:
         """Create from a string."""
         return cls(binascii.unhexlify(t)[: cls.NUM_BYTES])
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
@@ -132,7 +132,7 @@ class SerialField(utils.BinaryFieldBase[bytes]):
     model number, and the name.
     """
 
-    NUM_BYTES = 12
+    NUM_BYTES = 20
     FORMAT = f"{NUM_BYTES}s"
 
     @classmethod

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -78,7 +78,7 @@ class EEPromReadPayload(utils.BinarySerializable):
     """Eeprom read request payload ."""
 
     address: utils.UInt16Field
-    data_length: utils.UInt8Field
+    data_length: utils.UInt16Field
 
 
 @dataclass

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -17,6 +17,7 @@ from .fields import (
     SensorOutputBindingField,
     EepromDataField,
     SerialField,
+    SerialDataCodeField,
     SensorThresholdModeField,
     PipetteTipActionTypeField,
 )
@@ -384,7 +385,7 @@ class PipetteInfoResponsePayload(utils.BinarySerializable):
 
     name: PipetteNameField
     model: utils.UInt16Field
-    serial: SerialDataCode
+    serial: SerialDataCodeField
 
 
 @dataclass
@@ -406,7 +407,7 @@ class GripperInfoResponsePayload(utils.BinarySerializable):
     """A response carrying data about an attached gripper."""
 
     model: utils.UInt16Field
-    serial: SerialDataCode
+    serial: SerialDataCodeField
 
 
 @dataclass

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -384,7 +384,7 @@ class PipetteInfoResponsePayload(utils.BinarySerializable):
 
     name: PipetteNameField
     model: utils.UInt16Field
-    serial: SerialField
+    serial: SerialDataCode
 
 
 @dataclass
@@ -406,7 +406,7 @@ class GripperInfoResponsePayload(utils.BinarySerializable):
     """A response carrying data about an attached gripper."""
 
     model: utils.UInt16Field
-    serial: SerialField
+    serial: SerialDataCode
 
 
 @dataclass

--- a/hardware/tests/firmware_integration/test_eeprom.py
+++ b/hardware/tests/firmware_integration/test_eeprom.py
@@ -16,7 +16,7 @@ from opentrons_hardware.firmware_bindings.messages.payloads import (
     EEPromDataPayload,
     EEPromReadPayload,
 )
-from opentrons_hardware.firmware_bindings.utils import UInt8Field, UInt16Field
+from opentrons_hardware.firmware_bindings.utils import UInt16Field
 
 from opentrons_hardware.drivers.can_bus import CanMessenger, WaitableCallback
 
@@ -64,7 +64,7 @@ async def test_read_write(
         message=WriteToEEPromRequest(
             payload=EEPromDataPayload(
                 address=UInt16Field(address),
-                data_length=UInt8Field(len(data)),
+                data_length=UInt16Field(len(data)),
                 data=EepromDataField(data),
             )
         ),
@@ -72,7 +72,7 @@ async def test_read_write(
 
     read_message = ReadFromEEPromRequest(
         payload=EEPromReadPayload(
-            address=UInt16Field(address), data_length=UInt8Field(len(data))
+            address=UInt16Field(address), data_length=UInt16Field(len(data))
         )
     )
     await can_messenger.send(node_id=eeprom_node_id, message=read_message)

--- a/hardware/tests/opentrons_hardware/hardware_control/tools/test_oneshot.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/tools/test_oneshot.py
@@ -9,7 +9,7 @@ from mock import AsyncMock, call
 from opentrons_hardware.firmware_bindings.messages.fields import (
     ToolField,
     PipetteNameField,
-    SerialField,
+    SerialDataCodeField,
 )
 from opentrons_hardware.firmware_bindings.utils import UInt16Field
 from opentrons_hardware.hardware_control.tools import detector, types
@@ -148,7 +148,7 @@ async def test_sends_only_required_followups(
             payload = payloads.PipetteInfoResponsePayload(
                 name=PipetteNameField(PipetteName.p1000_single.value),
                 model=UInt16Field(2),
-                serial=SerialField(b"20220809A022"),
+                serial=SerialDataCodeField(b"20220809A022"),
             )
             return [
                 (
@@ -219,7 +219,7 @@ async def test_sends_all_required_followups(
                         payload=payloads.PipetteInfoResponsePayload(
                             name=PipetteNameField(PipetteName.p1000_single.value),
                             model=UInt16Field(2),
-                            serial=SerialField(b"20220809A022"),
+                            serial=SerialDataCodeField(b"20220809A022"),
                         )
                     ),
                     NodeId.pipette_left,
@@ -230,7 +230,7 @@ async def test_sends_all_required_followups(
                         payload=payloads.PipetteInfoResponsePayload(
                             name=PipetteNameField(PipetteName.p1000_multi.value),
                             model=UInt16Field(4),
-                            serial=SerialField(b"20231005A220"),
+                            serial=SerialDataCodeField(b"20231005A220"),
                         )
                     ),
                     NodeId.pipette_right,
@@ -240,7 +240,7 @@ async def test_sends_all_required_followups(
                     message_definitions.GripperInfoResponse(
                         payload=payloads.GripperInfoResponsePayload(
                             model=UInt16Field(1),
-                            serial=SerialField(b"20220531A01"),
+                            serial=SerialDataCodeField(b"20220531A01"),
                         )
                     ),
                     NodeId.gripper,
@@ -308,7 +308,7 @@ async def test_handles_bad_serials(
             payload = payloads.PipetteInfoResponsePayload(
                 name=PipetteNameField(PipetteName.p1000_multi.value),
                 model=UInt16Field(4),
-                serial=SerialField(
+                serial=SerialDataCodeField(
                     b"\x00\x01\x02\x03\x04\0x05\x06\x07\x08\x09\x0a\x0b"
                 ),
             )


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Update the can message in regards to read/writing serial numbers from peripheral devices, this lets the device write a full serial while not breaking the [pipette/gripper]InfoResponse message format that expects only the 12 digit data code portion of the serial number

This PR corresponds with the PR for RET-1078-2-eeprom-filesystem-clean-history in ot3-firmware repo
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- Create an additional message field SerialDataCode
- Use SerialDataCode for the [pipette/gripper]InfoResponse messages
- Increase the size of the SerialField so it can contain a full serial number
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

[ahiuchingau](https://github.com/ahiuchingau) was the last person to touch this
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low Risk, only effects ot-3 work
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
