### PR TITLE
fix(engine): thermocycler movement flagger in analysis

### DIFF
--- a/api/src/opentrons/protocol_engine/execution/thermocycler_movement_flagger.py
+++ b/api/src/opentrons/protocol_engine/execution/thermocycler_movement_flagger.py
@@ -15,9 +15,9 @@ from opentrons.hardware_control.modules import (
     Thermocycler as HardwareThermocycler,
 )
 
-from ..types import ModuleLocation, ModuleModel as PEModuleModel
+from ..types import ModuleLocation
 from ..state import StateStore
-from ..errors import ThermocyclerNotOpenError
+from ..errors import ThermocyclerNotOpenError, WrongModuleTypeError
 
 
 class ThermocyclerMovementFlagger:
@@ -45,7 +45,8 @@ class ThermocyclerMovementFlagger:
         """Flag unsafe movements to a Thermocycler.
 
         If the given labware is in a Thermocycler, and that Thermocycler's lid isn't
-        currently open according to the hardware API, raises ThermocyclerNotOpenError.
+        currently open according the engine's thermocycler state as well as
+        the hardware API (for non-virtual modules), raises ThermocyclerNotOpenError.
 
         Otherwise, no-ops.
 
@@ -67,55 +68,59 @@ class ThermocyclerMovementFlagger:
                Thermocycler through this method, this method may see the lid as open
                even though it's in transit.
         """
+        module_id = self._get_parent_module_id(labware_id=labware_id)
+        if module_id is None:
+            return  # Labware not on a module.
         try:
-            thermocycler = await self._find_containing_thermocycler(
-                labware_id=labware_id
+            tc_substate = self._state_store.modules.get_thermocycler_module_substate(
+                module_id=module_id
+            )
+        except WrongModuleTypeError:
+            return  # Labware on a module, but not a Thermocycler.
+
+        if not tc_substate.is_lid_open:
+            raise ThermocyclerNotOpenError(
+                "Thermocycler must be open when moving to labware inside it."
             )
 
-        except self._HardwareThermocyclerMissingError as e:
-            raise ThermocyclerNotOpenError(
-                "Thermocycler must be open when moving to labware inside it,"
-                " but can't confirm Thermocycler's current status."
-            ) from e
-
-        if thermocycler is not None:
-            lid_status = thermocycler.lid_status
-            if lid_status != ThermocyclerLidStatus.OPEN:
-                raise ThermocyclerNotOpenError(
-                    f"Thermocycler must be open when moving to labware inside it,"
-                    f' but Thermocycler is currently "{lid_status}".'
+        # There is a chance that the engine might not have the most latest lid status.
+        # Do a hardware state check just to be sure that the lid is truly open.
+        if not self._state_store.config.use_virtual_modules:
+            try:
+                thermocycler = await self._find_hardware_thermocycler(
+                    module_id=module_id
                 )
+            except self._HardwareThermocyclerMissingError as e:
+                raise ThermocyclerNotOpenError(
+                    "Thermocycler must be open when moving to labware inside it,"
+                    " but can't confirm Thermocycler's current status."
+                ) from e
 
-    async def _find_containing_thermocycler(
+            if thermocycler is not None:
+                lid_status = thermocycler.lid_status
+                if lid_status != ThermocyclerLidStatus.OPEN:
+                    raise ThermocyclerNotOpenError(
+                        f"Thermocycler must be open when moving to labware inside it,"
+                        f' but Thermocycler is currently "{lid_status}".'
+                    )
+
+    async def _find_hardware_thermocycler(
         self,
-        labware_id: str,
+        module_id: str,
     ) -> Optional[HardwareThermocycler]:
-        """Find the hardware Thermocycler containing the given labware.
+        """Find the hardware Thermocycler corresponding with the module ID.
 
         Returns:
-            If the labware was loaded into a Thermocycler,
-            the interface to control that Thermocycler's hardware.
+            The interface to control that Thermocycler's hardware.
             Otherwise, None.
 
         Raises:
-            _HardwareThermocyclerMissingError: If the labware was loaded into a
-                Thermocycler, but we can't find that Thermocycler in the hardware API,
-                so we can't fetch its current lid status.
+            _HardwareThermocyclerMissingError: If we can't find that Thermocycler in
+                the hardware API, so we can't fetch its current lid status.
                 It's unclear if this can happen in practice...
                 maybe if the module disconnects between when it was loaded into
                 Protocol Engine and when this function is called?
         """
-        module_id = self._get_parent_module_id(labware_id=labware_id)
-        if module_id is None:
-            return None  # Labware not on a module.
-
-        module_model = self._state_store.modules.get_model(module_id=module_id)
-        if module_model not in [
-            PEModuleModel.THERMOCYCLER_MODULE_V1,
-            PEModuleModel.THERMOCYCLER_MODULE_V2,
-        ]:
-            return None  # Labware on a module, but not a Thermocycler.
-
         thermocycler_serial = self._state_store.modules.get_serial_number(
             module_id=module_id
         )
@@ -145,6 +150,8 @@ class ThermocyclerMovementFlagger:
             The matching hardware Thermocycler, or None if none was found.
         """
         available_modules, simulating_module = await self._hardware_api.find_modules(
+            # Using a placeholder model since it is only required for creating
+            # a simulating module, which we don't use here.
             by_model=OpentronsThermocyclerModuleModel.THERMOCYCLER_V1,
             # Hard-coding instead of using
             # opentrons.protocols.geometry.module_geometry.resolve_module_type(),

--- a/api/src/opentrons/protocol_engine/state/module_substates/thermocycler_module_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/thermocycler_module_substate.py
@@ -31,6 +31,7 @@ class ThermocyclerModuleSubState:
     """
 
     module_id: ThermocyclerModuleId
+    is_lid_open: bool
     target_block_temperature: Optional[float]
     target_lid_temperature: Optional[float]
 

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -352,6 +352,7 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
                 target_block_temperature=block_temperature,
                 target_lid_temperature=None,
             )
+        # TODO (spp, 2022-08-01): set is_lid_open to False upon lid commands' failure
         elif isinstance(command.result, thermocycler.OpenLidResult):
             self._state.substate_by_module_id[module_id] = ThermocyclerModuleSubState(
                 module_id=ThermocyclerModuleId(module_id),

--- a/api/tests/opentrons/protocol_engine/execution/test_thermocycler_movement_flagger.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_thermocycler_movement_flagger.py
@@ -111,7 +111,7 @@ class LidStatusAndRaiseSpec(NamedTuple):
         ),
         LidStatusAndRaiseSpec(
             lid_status=None,
-            expected_raise_cm=pytest.raises(ThermocyclerNotOpenError),
+            expected_raise_cm=pytest.raises(AssertionError),
         ),
         LidStatusAndRaiseSpec(
             lid_status=ThermocyclerLidStatus.OPEN,

--- a/api/tests/opentrons/protocol_engine/state/test_module_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_store.py
@@ -81,6 +81,7 @@ def test_initial_state() -> None:
             ModuleModel.THERMOCYCLER_MODULE_V1,
             ThermocyclerModuleSubState(
                 module_id=ThermocyclerModuleId("module-id"),
+                is_lid_open=False,
                 target_block_temperature=None,
                 target_lid_temperature=None,
             ),
@@ -167,10 +168,12 @@ def test_load_module(
                 "data": {
                     "targetTemp": 123,
                     "lidTarget": 321,
+                    "lid": "open",
                 },
             },
             ThermocyclerModuleSubState(
                 module_id=ThermocyclerModuleId("module-id"),
+                is_lid_open=True,
                 target_block_temperature=123,
                 target_lid_temperature=321,
             ),
@@ -385,10 +388,10 @@ def test_handle_tempdeck_temperature_commands(
     }
 
 
-def test_handle_thermocycler_block_temperature_commands(
+def test_handle_thermocycler_temperature_commands(
     thermocycler_v1_def: ModuleDefinition,
 ) -> None:
-    """It should update Tempdeck's `plate_target_temperature` correctly."""
+    """It should update thermocycler's temperature statuses correctly."""
     load_module_cmd = commands.LoadModule.construct(  # type: ignore[call-arg]
         params=commands.LoadModuleParams(
             model=ModuleModel.THERMOCYCLER_MODULE_V1,
@@ -428,6 +431,7 @@ def test_handle_thermocycler_block_temperature_commands(
     assert subject.state.substate_by_module_id == {
         "module-id": ThermocyclerModuleSubState(
             module_id=ThermocyclerModuleId("module-id"),
+            is_lid_open=False,
             target_block_temperature=42.4,
             target_lid_temperature=None,
         )
@@ -436,6 +440,7 @@ def test_handle_thermocycler_block_temperature_commands(
     assert subject.state.substate_by_module_id == {
         "module-id": ThermocyclerModuleSubState(
             module_id=ThermocyclerModuleId("module-id"),
+            is_lid_open=False,
             target_block_temperature=42.4,
             target_lid_temperature=35.3,
         )
@@ -444,6 +449,7 @@ def test_handle_thermocycler_block_temperature_commands(
     assert subject.state.substate_by_module_id == {
         "module-id": ThermocyclerModuleSubState(
             module_id=ThermocyclerModuleId("module-id"),
+            is_lid_open=False,
             target_block_temperature=42.4,
             target_lid_temperature=None,
         )
@@ -452,6 +458,57 @@ def test_handle_thermocycler_block_temperature_commands(
     assert subject.state.substate_by_module_id == {
         "module-id": ThermocyclerModuleSubState(
             module_id=ThermocyclerModuleId("module-id"),
+            is_lid_open=False,
+            target_block_temperature=None,
+            target_lid_temperature=None,
+        )
+    }
+
+
+def test_handle_thermocycler_lid_commands(
+    thermocycler_v1_def: ModuleDefinition,
+) -> None:
+    """It should update thermocycler's lid status after executing lid commands."""
+    load_module_cmd = commands.LoadModule.construct(  # type: ignore[call-arg]
+        params=commands.LoadModuleParams(
+            model=ModuleModel.THERMOCYCLER_MODULE_V1,
+            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+        ),
+        result=commands.LoadModuleResult(
+            moduleId="module-id",
+            model=ModuleModel.THERMOCYCLER_MODULE_V1,
+            serialNumber="serial-number",
+            definition=thermocycler_v1_def,
+        ),
+    )
+
+    open_lid_cmd = tc_commands.OpenLid.construct(  # type: ignore[call-arg]
+        params=tc_commands.OpenLidParams(moduleId="module-id"),
+        result=tc_commands.OpenLidResult(),
+    )
+    close_lid_cmd = tc_commands.CloseLid.construct(  # type: ignore[call-arg]
+        params=tc_commands.CloseLidParams(moduleId="module-id"),
+        result=tc_commands.CloseLidResult(),
+    )
+
+    subject = ModuleStore()
+
+    subject.handle_action(actions.UpdateCommandAction(command=load_module_cmd))
+    subject.handle_action(actions.UpdateCommandAction(command=open_lid_cmd))
+    assert subject.state.substate_by_module_id == {
+        "module-id": ThermocyclerModuleSubState(
+            module_id=ThermocyclerModuleId("module-id"),
+            is_lid_open=True,
+            target_block_temperature=None,
+            target_lid_temperature=None,
+        )
+    }
+
+    subject.handle_action(actions.UpdateCommandAction(command=close_lid_cmd))
+    assert subject.state.substate_by_module_id == {
+        "module-id": ThermocyclerModuleSubState(
+            module_id=ThermocyclerModuleId("module-id"),
+            is_lid_open=False,
             target_block_temperature=None,
             target_lid_temperature=None,
         )

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -1146,6 +1146,7 @@ def test_thermocycler_get_target_temperatures(
         substate_by_module_id={
             "module-id": ThermocyclerModuleSubState(
                 module_id=ThermocyclerModuleId("module-id"),
+                is_lid_open=False,
                 target_block_temperature=14,
                 target_lid_temperature=28,
             )
@@ -1171,6 +1172,7 @@ def test_thermocycler_get_target_temperatures_no_target(
         substate_by_module_id={
             "module-id": ThermocyclerModuleSubState(
                 module_id=ThermocyclerModuleId("module-id"),
+                is_lid_open=False,
                 target_block_temperature=None,
                 target_lid_temperature=None,
             )
@@ -1199,6 +1201,7 @@ def module_view_with_thermocycler(thermocycler_v1_def: ModuleDefinition) -> Modu
                 module_id=ThermocyclerModuleId("module-id"),
                 target_block_temperature=None,
                 target_lid_temperature=None,
+                is_lid_open=False,
             )
         },
     )


### PR DESCRIPTION
# Overview

Closes #11235 

Fixes a bug where protocols with thermocyclers were not fetching correct lid status due to a conflict between the engine's 'virtual module' and hardware control's 'simulating thermocycler'.

# Changelog

- added lid status caching to engine's thermocycler substate
- updated module store to update state on lid commands
- Changed the movement flagger logic to check if lid is open based on engine's lid status first, then if it says the lid is open, re-check hardware thermocycler's lid status if a thermocycler is attached. If it's an analysis, don't check hardware status.

# Review requests

- Check that the code makes sense and isn't obscure
- Test that JSON protocol analyses raise or not raise errors correctly 
- Test that JSON protocol runs raise or not raise errors as expected
- Does this affect any module control card/ LPC behavior? (since the movement flagger is going to check engine's lid status first which is initialized to 'no open')

# Risk assessment

Medium. Bug fix, so technically no risk for the case of the bug but it also touches the part of the code that was originally working so will need to make sure it still works. Also depends on answer to question about effects on app/ LPC behavior.
