### PR TITLE
refactor(app): close labware latch before setting shake speed

### DIFF
--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/TestShake.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/TestShake.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { nestedTextMatcher, renderWithProviders } from '@opentrons/components'
-import { fireEvent } from '@testing-library/react'
+import { fireEvent, waitFor } from '@testing-library/react'
 import {
   useCreateCommandMutation,
   useCreateLiveCommandMutation,
@@ -323,7 +323,7 @@ describe('TestShake', () => {
     expect(mockToggleLatch).toHaveBeenCalled()
   })
 
-  it('entering an input for shake speed and clicking start should begin shaking when there is no run id', () => {
+  it('entering an input for shake speed and clicking start should begin shaking when there is no run id', async () => {
     props = {
       module: mockCloseLatchHeaterShaker,
       setCurrentPage: jest.fn(),
@@ -336,14 +336,25 @@ describe('TestShake', () => {
     fireEvent.change(input, { target: { value: '300' } })
     fireEvent.click(button)
 
-    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
-      command: {
-        commandType: 'heaterShaker/setAndWaitForShakeSpeed',
-        params: {
-          moduleId: 'heatershaker_id',
-          rpm: 300,
+    await waitFor(() => {
+      expect(mockCreateLiveCommand).toHaveBeenCalledWith({
+        command: {
+          commandType: 'heaterShaker/closeLabwareLatch',
+          params: {
+            moduleId: 'heatershaker_id',
+          },
         },
-      },
+      })
+
+      expect(mockCreateLiveCommand).toHaveBeenCalledWith({
+        command: {
+          commandType: 'heaterShaker/setAndWaitForShakeSpeed',
+          params: {
+            moduleId: 'heatershaker_id',
+            rpm: 300,
+          },
+        },
+      })
     })
   })
 
@@ -371,7 +382,7 @@ describe('TestShake', () => {
   })
 
   //  next test is sending module commands when run is terminal and through module controls
-  it('entering an input for shake speed and clicking start should begin shaking when there is a run id and run is terminal', () => {
+  it('entering an input for shake speed and clicking start should close the latch and begin shaking when there is a run id and run is terminal', async () => {
     mockUseRunStatuses.mockReturnValue({
       isRunStill: false,
       isRunTerminal: true,
@@ -391,19 +402,30 @@ describe('TestShake', () => {
     fireEvent.change(input, { target: { value: '300' } })
     fireEvent.click(button)
 
-    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
-      command: {
-        commandType: 'heaterShaker/setAndWaitForShakeSpeed',
-        params: {
-          moduleId: 'heatershaker_id',
-          rpm: 300,
+    await waitFor(() => {
+      expect(mockCreateLiveCommand).toHaveBeenCalledWith({
+        command: {
+          commandType: 'heaterShaker/closeLabwareLatch',
+          params: {
+            moduleId: 'heatershaker_id',
+          },
         },
-      },
+      })
+
+      expect(mockCreateLiveCommand).toHaveBeenCalledWith({
+        command: {
+          commandType: 'heaterShaker/setAndWaitForShakeSpeed',
+          params: {
+            moduleId: 'heatershaker_id',
+            rpm: 300,
+          },
+        },
+      })
     })
   })
 
   //  next test is sending module commands when run is terminal and through device details module cards
-  it('entering an input for shake speed and clicking start should begin shaking when there is a run id, run is terminal, and through device details', () => {
+  it('entering an input for shake speed and clicking start should close the labware latch and begin shaking when there is a run id, run is terminal, and through device details', async () => {
     mockUseRunStatuses.mockReturnValue({
       isRunStill: false,
       isRunTerminal: true,
@@ -422,14 +444,25 @@ describe('TestShake', () => {
     fireEvent.change(input, { target: { value: '300' } })
     fireEvent.click(button)
 
-    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
-      command: {
-        commandType: 'heaterShaker/setAndWaitForShakeSpeed',
-        params: {
-          moduleId: 'heatershaker_id',
-          rpm: 300,
+    await waitFor(() => {
+      expect(mockCreateLiveCommand).toHaveBeenCalledWith({
+        command: {
+          commandType: 'heaterShaker/closeLabwareLatch',
+          params: {
+            moduleId: 'heatershaker_id',
+          },
         },
-      },
+      })
+
+      expect(mockCreateLiveCommand).toHaveBeenCalledWith({
+        command: {
+          commandType: 'heaterShaker/setAndWaitForShakeSpeed',
+          params: {
+            moduleId: 'heatershaker_id',
+            rpm: 300,
+          },
+        },
+      })
     })
   })
 })

--- a/app/src/organisms/ModuleCard/__tests__/TestShakeSlideout.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/TestShakeSlideout.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { i18n } from '../../../i18n'
-import { fireEvent } from '@testing-library/react'
+import { fireEvent, waitFor } from '@testing-library/react'
 import {
   useCreateCommandMutation,
   useCreateLiveCommandMutation,
@@ -235,7 +235,7 @@ describe('TestShakeSlideout', () => {
     expect(mockUseLatchControls).toHaveBeenCalled()
   })
 
-  it('entering an input for shake speed and clicking start should begin shaking', () => {
+  it('entering an input for shake speed and clicking start should begin shaking', async () => {
     props = {
       module: mockHeaterShaker,
       onCloseClick: jest.fn(),
@@ -249,14 +249,25 @@ describe('TestShakeSlideout', () => {
     fireEvent.change(input, { target: { value: '300' } })
     fireEvent.click(button)
 
-    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
-      command: {
-        commandType: 'heaterShaker/setAndWaitForShakeSpeed',
-        params: {
-          moduleId: 'heatershaker_id',
-          rpm: 300,
+    await waitFor(() => {
+      expect(mockCreateLiveCommand).toHaveBeenCalledWith({
+        command: {
+          commandType: 'heaterShaker/closeLabwareLatch',
+          params: {
+            moduleId: 'heatershaker_id',
+          },
         },
-      },
+      })
+
+      expect(mockCreateLiveCommand).toHaveBeenCalledWith({
+        command: {
+          commandType: 'heaterShaker/setAndWaitForShakeSpeed',
+          params: {
+            moduleId: 'heatershaker_id',
+            rpm: 300,
+          },
+        },
+      })
     })
   })
   //  next 2 tests are sending module commands when run is idle and through module controls
@@ -281,7 +292,7 @@ describe('TestShakeSlideout', () => {
     expect(mockToggleLatch).toHaveBeenCalled()
   })
 
-  it('entering an input for shake speed and clicking start should begin shaking when there is a runId and run is idle', () => {
+  it('entering an input for shake speed and clicking start should begin shaking when there is a runId and run is idle', async () => {
     mockUseRunStatuses.mockReturnValue({
       isRunStill: false,
       isRunTerminal: false,
@@ -301,20 +312,32 @@ describe('TestShakeSlideout', () => {
     fireEvent.change(input, { target: { value: '300' } })
     fireEvent.click(button)
 
-    expect(mockCreateCommand).toHaveBeenCalledWith({
-      runId: props.currentRunId,
-      command: {
-        commandType: 'heaterShaker/setAndWaitForShakeSpeed',
-        params: {
-          moduleId: 'heatershaker_id',
-          rpm: 300,
+    await waitFor(() => {
+      expect(mockCreateCommand).toHaveBeenCalledWith({
+        runId: 'test123',
+        command: {
+          commandType: 'heaterShaker/closeLabwareLatch',
+          params: {
+            moduleId: 'heatershaker_id',
+          },
         },
-      },
+      })
+
+      expect(mockCreateCommand).toHaveBeenCalledWith({
+        runId: 'test123',
+        command: {
+          commandType: 'heaterShaker/setAndWaitForShakeSpeed',
+          params: {
+            moduleId: 'heatershaker_id',
+            rpm: 300,
+          },
+        },
+      })
     })
   })
 
   //  next test is sending module commands when run is terminal and through module controls
-  it('entering an input for shake speed and clicking start should begin shaking when there is a runId and run is terminal', () => {
+  it('entering an input for shake speed and clicking start should begin shaking when there is a runId and run is terminal', async () => {
     mockUseRunStatuses.mockReturnValue({
       isRunStill: false,
       isRunTerminal: true,
@@ -334,19 +357,30 @@ describe('TestShakeSlideout', () => {
     fireEvent.change(input, { target: { value: '300' } })
     fireEvent.click(button)
 
-    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
-      command: {
-        commandType: 'heaterShaker/setAndWaitForShakeSpeed',
-        params: {
-          moduleId: 'heatershaker_id',
-          rpm: 300,
+    await waitFor(() => {
+      expect(mockCreateLiveCommand).toHaveBeenCalledWith({
+        command: {
+          commandType: 'heaterShaker/closeLabwareLatch',
+          params: {
+            moduleId: 'heatershaker_id',
+          },
         },
-      },
+      })
+
+      expect(mockCreateLiveCommand).toHaveBeenCalledWith({
+        command: {
+          commandType: 'heaterShaker/setAndWaitForShakeSpeed',
+          params: {
+            moduleId: 'heatershaker_id',
+            rpm: 300,
+          },
+        },
+      })
     })
   })
 
   //  next test is sending module commands when run is terminal and through device details module cards
-  it('entering an input for shake speed and clicking start should begin shaking when there is a runId, through device details, and run is terminal', () => {
+  it('entering an input for shake speed and clicking start should begin shaking when there is a runId, through device details, and run is terminal', async () => {
     mockUseRunStatuses.mockReturnValue({
       isRunStill: false,
       isRunTerminal: true,
@@ -366,14 +400,25 @@ describe('TestShakeSlideout', () => {
     fireEvent.change(input, { target: { value: '300' } })
     fireEvent.click(button)
 
-    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
-      command: {
-        commandType: 'heaterShaker/setAndWaitForShakeSpeed',
-        params: {
-          moduleId: 'heatershaker_id',
-          rpm: 300,
+    await waitFor(() => {
+      expect(mockCreateLiveCommand).toHaveBeenCalledWith({
+        command: {
+          commandType: 'heaterShaker/closeLabwareLatch',
+          params: {
+            moduleId: 'heatershaker_id',
+          },
         },
-      },
+      })
+
+      expect(mockCreateLiveCommand).toHaveBeenCalledWith({
+        command: {
+          commandType: 'heaterShaker/setAndWaitForShakeSpeed',
+          params: {
+            moduleId: 'heatershaker_id',
+            rpm: 300,
+          },
+        },
+      })
     })
   })
 })


### PR DESCRIPTION
# Overview

This PR closes the HS labware latch before issuing a set shake command to sync up PE state with hardware controller state.

Fixes the issue where you could not set a shake speed on a HS if the latch was already closed when it was plugged in/booted up.

# Changelog

- Close labware latch before setting shake speed in HS wizard and slideout

# Review requests

In both the HS wizard + test shake slideout, open your network dev tools and check to see there are 2 HTTP POST requests when setting a shake speed:
1. to close the latch
2. to set the shake speed

We should also verify this fixes the [issue](https://github.com/Opentrons/opentrons/pull/11156#pullrequestreview-1052908282) @ecormany found when issuing a set shake command in the slideout and then starting LPC

# Risk assessment
Low
