### PR TITLE
test(app): create tests for ProtocolsLanding and ProtocolList

### DIFF
--- a/app/src/organisms/ProtocolsLanding/ProtocolList.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolList.tsx
@@ -119,6 +119,7 @@ export function ProtocolList(props: ProtocolListProps): JSX.Element | null {
               marginLeft={SPACING.spacing3}
               css={SORT_BY_BUTTON_STYLE}
               onClick={toggleSetShowSortByMenu}
+              data-testId={`ProtocolList_SortByMenu`}
             >
               <StyledText
                 as="p"

--- a/app/src/organisms/ProtocolsLanding/ProtocolList.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolList.tsx
@@ -119,7 +119,7 @@ export function ProtocolList(props: ProtocolListProps): JSX.Element | null {
               marginLeft={SPACING.spacing3}
               css={SORT_BY_BUTTON_STYLE}
               onClick={toggleSetShowSortByMenu}
-              data-testId={`ProtocolList_SortByMenu`}
+              data-testid="ProtocolList_SortByMenu"
             >
               <StyledText
                 as="p"

--- a/app/src/organisms/ProtocolsLanding/__tests__/ProtocolList.test.tsx
+++ b/app/src/organisms/ProtocolsLanding/__tests__/ProtocolList.test.tsx
@@ -67,7 +67,8 @@ describe('ProtocolList', () => {
     getByRole('button', { name: 'Import' })
     getByText('All Protocols')
     getByText('mock empty state links')
-    getAllByText('mock protocol card')
+    const cards = getAllByText('mock protocol card')
+    expect(cards.length).toBe(2)
   })
 
   it('renders and clicks on import button and opens slideout', () => {

--- a/app/src/organisms/ProtocolsLanding/__tests__/ProtocolList.test.tsx
+++ b/app/src/organisms/ProtocolsLanding/__tests__/ProtocolList.test.tsx
@@ -1,0 +1,130 @@
+import * as React from 'react'
+import { BrowserRouter } from 'react-router-dom'
+import { when } from 'jest-when'
+import { fireEvent } from '@testing-library/react'
+import { renderWithProviders } from '@opentrons/components'
+import { i18n } from '../../../i18n'
+import {
+  storedProtocolData,
+  storedProtocolDataTwo,
+} from '../../../redux/protocol-storage/__fixtures__'
+import { ProtocolList } from '../ProtocolList'
+import { useSortedProtocols } from '../hooks'
+import { EmptyStateLinks } from '../EmptyStateLinks'
+import { ProtocolCard } from '../ProtocolCard'
+
+jest.mock('../hooks')
+jest.mock('../../../redux/protocol-storage')
+jest.mock('../../../redux/config')
+jest.mock('../EmptyStateLinks')
+jest.mock('../ProtocolCard')
+
+const mockUseSortedProtocols = useSortedProtocols as jest.MockedFunction<
+  typeof useSortedProtocols
+>
+const mockEmptyStateLinks = EmptyStateLinks as jest.MockedFunction<
+  typeof EmptyStateLinks
+>
+const mockProtocolCard = ProtocolCard as jest.MockedFunction<
+  typeof ProtocolCard
+>
+
+const render = (props: React.ComponentProps<typeof ProtocolList>) => {
+  return renderWithProviders(
+    <BrowserRouter>
+      <ProtocolList {...props} />
+    </BrowserRouter>,
+    {
+      i18nInstance: i18n,
+    }
+  )[0]
+}
+
+describe('ProtocolList', () => {
+  let props: React.ComponentProps<typeof ProtocolList>
+
+  beforeEach(() => {
+    props = {
+      storedProtocols: [storedProtocolData, storedProtocolDataTwo],
+    }
+    when(mockProtocolCard).mockReturnValue(<div>mock protocol card</div>)
+    when(mockEmptyStateLinks).mockReturnValue(<div>mock empty state links</div>)
+    when(mockUseSortedProtocols)
+      .calledWith('alphabetical', [storedProtocolData, storedProtocolDataTwo])
+      .mockReturnValue([storedProtocolData, storedProtocolDataTwo])
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('renders the heading, correct info for 2 protocols, and in alphabetical order', () => {
+    const { getByText, getAllByText, getByRole } = render(props)
+
+    getByRole('heading', { name: 'Protocols' })
+    getByText('Sort by')
+    getByText('Alphabetical')
+    getByRole('button', { name: 'Import' })
+    getByText('All Protocols')
+    getByText('mock empty state links')
+    getAllByText('mock protocol card')
+  })
+
+  it('renders Alphabetical button and clicking on it open overflow menu and can select alphabetical', () => {
+    const { getByRole, getByTestId } = render(props)
+    fireEvent.click(getByTestId('ProtocolList_SortByMenu'))
+    const alphabetical = getByRole('button', { name: 'Alphabetical' })
+    getByRole('button', { name: 'Most recent updates' })
+    getByRole('button', { name: 'Reverse alphabetical' })
+    getByRole('button', { name: 'Oldest updates' })
+    fireEvent.click(alphabetical)
+    expect(mockUseSortedProtocols).toHaveBeenCalledWith('alphabetical', [
+      storedProtocolData,
+      storedProtocolDataTwo,
+    ])
+  })
+
+  it('renders Alphabetical button and clicking on it open overflow menu and can select reverse', () => {
+    when(mockUseSortedProtocols)
+      .calledWith('reverse', [storedProtocolData, storedProtocolDataTwo])
+      .mockReturnValue([storedProtocolDataTwo, storedProtocolData])
+    const { getByRole, getByText, getByTestId } = render(props)
+    fireEvent.click(getByTestId('ProtocolList_SortByMenu'))
+    getByRole('button', { name: 'Alphabetical' })
+    getByRole('button', { name: 'Most recent updates' })
+    const reverse = getByRole('button', { name: 'Reverse alphabetical' })
+    getByRole('button', { name: 'Oldest updates' })
+    fireEvent.click(reverse)
+    getByText('Reverse alphabetical')
+  })
+
+  it('renders Alphabetical button and clicking on it open overflow menu and can select recent', () => {
+    when(mockUseSortedProtocols)
+      .calledWith('recent', [storedProtocolData, storedProtocolDataTwo])
+      .mockReturnValue([storedProtocolData, storedProtocolDataTwo])
+
+    const { getByRole, getByText, getByTestId } = render(props)
+    fireEvent.click(getByTestId('ProtocolList_SortByMenu'))
+    getByRole('button', { name: 'Alphabetical' })
+    const recent = getByRole('button', { name: 'Most recent updates' })
+    getByRole('button', { name: 'Reverse alphabetical' })
+    getByRole('button', { name: 'Oldest updates' })
+    fireEvent.click(recent)
+    getByText('Most recent updates')
+  })
+
+  it('renders Alphabetical button and clicking on it open overflow menu and can select oldest', () => {
+    when(mockUseSortedProtocols)
+      .calledWith('oldest', [storedProtocolData, storedProtocolDataTwo])
+      .mockReturnValue([storedProtocolDataTwo, storedProtocolData])
+
+    const { getByRole, getByText, getByTestId } = render(props)
+    fireEvent.click(getByTestId('ProtocolList_SortByMenu'))
+    getByRole('button', { name: 'Alphabetical' })
+    getByRole('button', { name: 'Most recent updates' })
+    getByRole('button', { name: 'Reverse alphabetical' })
+    const oldest = getByRole('button', { name: 'Oldest updates' })
+    fireEvent.click(oldest)
+    getByText('Oldest updates')
+  })
+})

--- a/app/src/organisms/ProtocolsLanding/__tests__/ProtocolList.test.tsx
+++ b/app/src/organisms/ProtocolsLanding/__tests__/ProtocolList.test.tsx
@@ -70,6 +70,13 @@ describe('ProtocolList', () => {
     getAllByText('mock protocol card')
   })
 
+  it('renders and clicks on import button and opens slideout', () => {
+    const { getByText, getByRole } = render(props)
+    const btn = getByRole('button', { name: 'Import' })
+    fireEvent.click(btn)
+    getByText('Import a Protocol')
+  })
+
   it('renders Alphabetical button and clicking on it open overflow menu and can select alphabetical', () => {
     const { getByRole, getByTestId } = render(props)
     fireEvent.click(getByTestId('ProtocolList_SortByMenu'))

--- a/app/src/pages/Protocols/ProtocolsLanding/__tests__/ProtocolsLanding.test.tsx
+++ b/app/src/pages/Protocols/ProtocolsLanding/__tests__/ProtocolsLanding.test.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react'
+import { renderWithProviders } from '@opentrons/components'
+
+import { ProtocolsEmptyState } from '../../../../organisms/ProtocolsLanding/ProtocolsEmptyState'
+import { getStoredProtocols } from '../../../../redux/protocol-storage'
+import { storedProtocolData } from '../../../../redux/protocol-storage/__fixtures__'
+import { ProtocolList } from '../../../../organisms/ProtocolsLanding/ProtocolList'
+import { ProtocolsLanding } from '..'
+
+jest.mock('../../../../redux/protocol-storage')
+jest.mock('../../../../organisms/ProtocolsLanding/ProtocolsEmptyState')
+jest.mock('../../../../organisms/ProtocolsLanding/ProtocolList')
+
+const mockGetStoredProtocols = getStoredProtocols as jest.MockedFunction<
+  typeof getStoredProtocols
+>
+const mockProtocolList = ProtocolList as jest.MockedFunction<
+  typeof ProtocolList
+>
+const mockProtocolsEmptyState = ProtocolsEmptyState as jest.MockedFunction<
+  typeof ProtocolsEmptyState
+>
+
+const render = () => {
+  return renderWithProviders(<ProtocolsLanding />)[0]
+}
+
+describe('ProtocolsLanding', () => {
+  it('renders the protocol list component', () => {
+    mockGetStoredProtocols.mockReturnValue([storedProtocolData])
+    mockProtocolList.mockReturnValue(<div>mock protocol list</div>)
+    const { getByText } = render()
+    getByText('mock protocol list')
+  })
+  it('renders the empt state component', () => {
+    mockGetStoredProtocols.mockReturnValue([])
+    mockProtocolsEmptyState.mockReturnValue(<div>mock empty state</div>)
+    const { getByText } = render()
+    getByText('mock empty state')
+  })
+})

--- a/app/src/redux/protocol-storage/__fixtures__/index.ts
+++ b/app/src/redux/protocol-storage/__fixtures__/index.ts
@@ -17,3 +17,11 @@ export const storedProtocolDir: StoredProtocolDir = {
   srcFilePaths: ['path/to/protocol/dir/src/mainFile'],
   analysisFilePaths: ['path/to/protocol/dir/analysis/8675309.json'],
 }
+
+export const storedProtocolDataTwo: StoredProtocolData = {
+  protocolKey: 'protocolKeyStubTwo',
+  mostRecentAnalysis: (simpleAnalysisFileFixture as any) as ProtocolAnalysisOutput,
+  srcFileNames: ['fakeSrcFileNameTwo'],
+  srcFiles: ['fakeSrcFileTwo' as any],
+  modified: 987654321,
+}


### PR DESCRIPTION
closes #11219

# Overview

Create missing tests for `ProtocolsLanding` and `ProtocolList`

# Changelog

- create `ProtocolLanding.test` and `ProtocolList.test`
- add test fixture
- add `data-testid` to use for testing

# Review requests
Ï
- make sure tests add enough coverage to each component

# Risk assessment

low