### PR TITLE
feat(robot-server): allow live commands when run is current and unstarted

### DIFF
--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -77,6 +77,7 @@ class EngineStore:
         """
         if (
             self._runner_engine_pair is not None
+            and self.engine.state_view.commands.has_been_played()
             and not self.engine.state_view.commands.get_is_stopped()
         ):
             raise EngineConflictError("An engine for a run is currently active")

--- a/robot-server/tests/integration/http_api/commands/test_home.tavern.yaml
+++ b/robot-server/tests/integration/http_api/commands/test_home.tavern.yaml
@@ -105,7 +105,7 @@ stages:
       save:
         json:
           run_id: data.id
-  - name: issue home Command is blocked
+  - name: issue home Command
     request:
       url: '{host:s}:{port:d}/commands'
       method: POST
@@ -118,9 +118,7 @@ stages:
     response:
       strict:
         - json:off
-      status_code: 409
+      status_code: 201
       json:
-        errors:
-          - id: RunActive
-            title: Run Active
-            detail: There is an active run. Close the current run to issue commands via POST /commands.
+        data:
+          status: succeeded

--- a/robot-server/tests/integration/http_api/commands/test_mag_commands.tavern.yaml
+++ b/robot-server/tests/integration/http_api/commands/test_mag_commands.tavern.yaml
@@ -150,7 +150,7 @@ stages:
         waitUntilComplete: true
       json:
         data:
-          commandType: magneticModule/disengage"
+          commandType: magneticModule/disengage
           params:
             moduleId: '{magneticModuleV1_id}'
     response:

--- a/robot-server/tests/integration/http_api/commands/test_mag_commands.tavern.yaml
+++ b/robot-server/tests/integration/http_api/commands/test_mag_commands.tavern.yaml
@@ -156,9 +156,7 @@ stages:
     response:
       strict:
         - json:off
-      status_code: 409
+      status_code: 201
       json:
-        errors:
-          - id: RunActive
-            title: Run Active
-            detail: There is an active run. Close the current run to issue commands via POST /commands.
+        data:
+          status: succeeded

--- a/robot-server/tests/integration/http_api/commands/test_set_rail_lights.tavern.yaml
+++ b/robot-server/tests/integration/http_api/commands/test_set_rail_lights.tavern.yaml
@@ -100,7 +100,7 @@ stages:
       save:
         json:
           run_id: data.id
-  - name: issue setRailLights Command on = true is blocked
+  - name: issue setRailLights Command on = true
     request:
       url: '{host:s}:{port:d}/commands'
       method: POST
@@ -114,9 +114,7 @@ stages:
     response:
       strict:
         - json:off
-      status_code: 409
+      status_code: 201
       json:
-        errors:
-          - id: RunActive
-            title: Run Active
-            detail: There is an active run. Close the current run to issue commands via POST /commands.
+        data:
+          status: succeeded

--- a/robot-server/tests/integration/http_api/commands/test_temp_commands.tavern.yaml
+++ b/robot-server/tests/integration/http_api/commands/test_temp_commands.tavern.yaml
@@ -150,9 +150,10 @@ stages:
         waitUntilComplete: true
       json:
         data:
-          commandType: 'temperatureModule/setTargetTemperature'
+          commandType: temperatureModule/setTargetTemperature
           params:
             moduleId: '{temperatureModuleV1_id}'
+            celsius: 55
     response:
       strict:
         - json:off

--- a/robot-server/tests/integration/http_api/commands/test_temp_commands.tavern.yaml
+++ b/robot-server/tests/integration/http_api/commands/test_temp_commands.tavern.yaml
@@ -156,9 +156,7 @@ stages:
     response:
       strict:
         - json:off
-      status_code: 409
+      status_code: 201
       json:
-        errors:
-          - id: RunActive
-            title: Run Active
-            detail: There is an active run. Close the current run to issue commands via POST /commands.
+        data:
+          status: succeeded

--- a/robot-server/tests/runs/test_engine_store.py
+++ b/robot-server/tests/runs/test_engine_store.py
@@ -152,9 +152,18 @@ async def test_get_default_engine(subject: EngineStore) -> None:
     assert repeated_result is result
 
 
-async def test_get_default_engine_conflict(subject: EngineStore) -> None:
-    """It should not allow a default engine if another engine is active."""
+async def test_get_default_engine_current_unstarted(subject: EngineStore) -> None:
+    """It should allow a default engine if another engine current but unstarted."""
     await subject.create(run_id="run-id", labware_offsets=[], protocol=None)
+
+    result = await subject.get_default_engine()
+    assert isinstance(result, ProtocolEngine)
+
+
+async def test_get_default_engine_conflict(subject: EngineStore) -> None:
+    """It should not allow a default engine if another engine is unstarted."""
+    await subject.create(run_id="run-id", labware_offsets=[], protocol=None)
+    subject.engine.play()
 
     with pytest.raises(EngineConflictError):
         await subject.get_default_engine()

--- a/robot-server/tests/runs/test_engine_store.py
+++ b/robot-server/tests/runs/test_engine_store.py
@@ -161,7 +161,7 @@ async def test_get_default_engine_current_unstarted(subject: EngineStore) -> Non
 
 
 async def test_get_default_engine_conflict(subject: EngineStore) -> None:
-    """It should not allow a default engine if another engine is unstarted."""
+    """It should not allow a default engine if another engine is executing commands."""
     await subject.create(run_id="run-id", labware_offsets=[], protocol=None)
     subject.engine.play()
 


### PR DESCRIPTION
# Overview
This PR allows live commands to be run if a run is current and not actively running protocol commands.

Pairing credit to @mcous 

# Changelog
- Allow live commands when run is current and unstarted

# Review requests

Try to issue a live command after a protocol as been uploaded in the app, they should get successfully run.

I tested on a robot + heater shaker and seems to work, but would appreciate if someone else could also verify
# Risk assessment

Low
