### PR TITLE
feat(step-generation): raise latch open error if latch state is null

### DIFF
--- a/step-generation/src/__tests__/utils.test.ts
+++ b/step-generation/src/__tests__/utils.test.ts
@@ -951,6 +951,10 @@ describe('getIsHeaterShakerEastWestWithLatchOpen', () => {
   it('should return true when there is heater shaker with its latch open next to the labware', () => {
     expect(getIsHeaterShakerEastWestWithLatchOpen(modules, slot)).toBe(true)
   })
+  it('should return true when there is heater shaker with its latch open state null to the labware', () => {
+    ;(modules.heaterShakerId.moduleState as any).latchOpen = null
+    expect(getIsHeaterShakerEastWestWithLatchOpen(modules, slot)).toBe(true)
+  })
   it('should return false when there is no heater shaker in the protocol', () => {
     modules = {}
     expect(getIsHeaterShakerEastWestWithLatchOpen(modules, slot)).toBe(false)

--- a/step-generation/src/utils/heaterShakerCollision.ts
+++ b/step-generation/src/utils/heaterShakerCollision.ts
@@ -23,7 +23,7 @@ export const getIsHeaterShakerEastWestWithLatchOpen = (
     hwModules,
     hwModule =>
       hwModule.moduleState.type === HEATERSHAKER_MODULE_TYPE &&
-      hwModule.moduleState.latchOpen === true &&
+      hwModule.moduleState.latchOpen !== false &&
       getAreSlotsHorizontallyAdjacent(hwModule.slot, slot)
   )
 


### PR DESCRIPTION
# Overview

This PR throws a latch open error when pipetting east/west of a HS if the latch state is null. This mimics the PE behavior, because technically a user could start a protocol with the latch open

# Changelog

- Raise latch open error if latch state is null

# Review requests

Make a PD protocol and try to pipette E/W of a H-S without explicitly closing the latch. You should get a timeline error.
# Risk assessment

Low
