### PR TITLE
feat(protocol-designer): add slot 6 as accepted slot for HS

### DIFF
--- a/protocol-designer/src/modules/moduleData.ts
+++ b/protocol-designer/src/modules/moduleData.ts
@@ -84,6 +84,10 @@ const HEATER_SHAKER_SLOTS: DropdownOption[] = [
     value: '4',
   },
   {
+    name: 'Slot 6',
+    value: '6',
+  },
+  {
     name: 'Slot 7',
     value: '7',
   },


### PR DESCRIPTION
# Overview
This PR adds slot 6 as an accepted slot for the HS

closes #11148

# Changelog

- Add slot 6 as accepted slot for HS

# Review requests

In the edit modules modal for the HS you should be able to select slot 6

# Risk assessment
Low.

