### PR TITLE
fix(api): include command error details in top-level fatal error

### DIFF
--- a/api/src/opentrons/protocol_engine/errors/exceptions.py
+++ b/api/src/opentrons/protocol_engine/errors/exceptions.py
@@ -162,12 +162,4 @@ class CannotPerformModuleAction(ProtocolEngineError):
 
 
 class ProtocolCommandFailedError(ProtocolEngineError):
-    """An error raised if a fatal command execution error has occurred.
-
-    Args:
-        command_id: The ID of the command that failed.
-    """
-
-    def __init__(self, command_id: str) -> None:
-        super().__init__(f"Command {command_id} failed to execute")
-        self.command_id = command_id
+    """An error raised if a fatal command execution error has occurred."""

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -522,7 +522,7 @@ class CommandView(HasState[CommandState]):
             for command_id in self._state.all_command_ids:
                 command = self._state.commands_by_id[command_id].command
                 if command.error and command.intent != CommandIntent.SETUP:
-                    raise ProtocolCommandFailedError(command_id=command_id)
+                    raise ProtocolCommandFailedError(command.error.detail)
             return True
         else:
             return False

--- a/api/tests/opentrons/protocol_engine/state/test_command_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view.py
@@ -230,10 +230,8 @@ def test_get_all_complete_fatal_command_failure() -> None:
         commands=[completed_command, failed_command],
     )
 
-    with pytest.raises(errors.ProtocolCommandFailedError) as exc_info:
+    with pytest.raises(errors.ProtocolCommandFailedError, match="Oh no"):
         subject.get_all_complete()
-
-    assert exc_info.value.command_id == "command-id-2"
 
 
 def test_get_all_complete_setup_not_fatal() -> None:

--- a/robot-server/tests/integration/http_api/runs/test_json_v6_run_failure.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_json_v6_run_failure.tavern.yaml
@@ -58,8 +58,7 @@ stages:
             - id: !anystr
               errorType: ProtocolCommandFailedError
               createdAt: !anystr
-              detail: !re_search '^Command [a-f0-9-]+ failed to execute$'
-
+              detail: 'Cannot perform DROPTIP without a tip attached'
   - name: Verify commands contain the expected results
     request:
       url: '{host:s}:{port:d}/runs/{run_id}/commands'


### PR DESCRIPTION
## Overview

This PR makes a small change to bring fatal analysis/run error reporting for JSONv6 in line with the behavior of PAPIv2 protocols by re-using the `detail` message of the command's error in the top-level run/analysis error.

Re: RSS-43

## Changelog

- fix(api): inlcude command error details in top-level fatal error

## Review requests

After some rubber ducking, we decided to go with this minimal approach. There's a lot of improvements we can (and should!) do to this error reporting system, but this PR represents a good, non-blocking, clean slate for those future changes.

## Risk assessment

Very low. Unit and acceptance tests were updated. Smoke tested with the dev app and robot server and seemed to behave.