### PR TITLE
refactor(protocol-designer): remove heater shaker feature flag

### DIFF
--- a/protocol-designer/src/components/StepCreationButton.tsx
+++ b/protocol-designer/src/components/StepCreationButton.tsx
@@ -27,7 +27,6 @@ import {
 } from './modals/ConfirmDeleteModal'
 import { Portal } from './portals/MainPageModalPortal'
 import { stepIconsByType, StepType } from '../form-types'
-import { selectors as featureFlagSelectors } from '../feature-flags'
 import styles from './listButtons.css'
 
 interface StepButtonComponentProps {
@@ -104,34 +103,18 @@ export function StepButtonItem(props: StepButtonItemProps): JSX.Element {
 }
 
 export const StepCreationButton = (): JSX.Element => {
-  const enableHeaterShaker = useSelector(
-    featureFlagSelectors.getEnabledHeaterShaker
-  )
-
   const getSupportedSteps = (): Array<
     Exclude<StepType, 'manualIntervention'>
-  > => {
-    if (enableHeaterShaker) {
-      return [
-        'moveLiquid',
-        'mix',
-        'pause',
-        'heaterShaker',
-        'magnet',
-        'temperature',
-        'thermocycler',
-      ]
-    } else {
-      return [
-        'moveLiquid',
-        'mix',
-        'pause',
-        'magnet',
-        'temperature',
-        'thermocycler',
-      ]
-    }
-  }
+  > => [
+    'moveLiquid',
+    'mix',
+    'pause',
+    'heaterShaker',
+    'magnet',
+    'temperature',
+    'thermocycler',
+  ]
+
   const currentFormIsPresaved = useSelector(
     stepFormSelectors.getCurrentFormIsPresaved
   )

--- a/protocol-designer/src/components/__tests__/StepCreationButton.test.tsx
+++ b/protocol-designer/src/components/__tests__/StepCreationButton.test.tsx
@@ -13,7 +13,6 @@ import {
 
 import * as stepFormSelectors from '../../step-forms/selectors'
 import { actions as stepsActions, getIsMultiSelectMode } from '../../ui/steps'
-import { selectors } from '../../feature-flags'
 
 import { PrimaryButton, Tooltip } from '@opentrons/components'
 import {
@@ -33,17 +32,11 @@ const getCurrentFormHasUnsavedChangesMock =
   stepFormSelectors.getCurrentFormHasUnsavedChanges
 const getInitialDeckSetupMock = stepFormSelectors.getInitialDeckSetup
 const getIsMultiSelectModeMock = getIsMultiSelectMode
-const getEnabledHeaterShaker = selectors.getEnabledHeaterShaker
-
 describe('StepCreationButton', () => {
   let store: any
 
   beforeEach(() => {
     store = mockStore()
-
-    when(getEnabledHeaterShaker)
-      .calledWith(expect.anything())
-      .mockReturnValue(true)
 
     when(getCurrentFormIsPresavedMock)
       .calledWith(expect.anything())

--- a/protocol-designer/src/components/modals/FilePipettesModal/ModuleFields.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/ModuleFields.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { useSelector } from 'react-redux'
 import { CheckboxField, DropdownField, FormGroup } from '@opentrons/components'
 import { i18n } from '../../../localization'
 import {
@@ -7,7 +6,6 @@ import {
   MODELS_FOR_MODULE_TYPE,
 } from '../../../constants'
 import { ModuleDiagram } from '../../modules'
-import { selectors as featureFlagSelectors } from '../../../feature-flags'
 
 import styles from './FilePipettesModal.css'
 
@@ -67,13 +65,8 @@ export function ModuleFields(props: ModuleFieldsProps): JSX.Element {
     errors,
     touched,
   } = props
-  const enableHeaterShaker = useSelector(
-    featureFlagSelectors.getEnabledHeaterShaker
-  )
   // @ts-expect-error(sa, 2021-6-21): Object.keys not smart enough to take the keys of FormModulesByType
-  const modules: ModuleType[] = enableHeaterShaker
-    ? Object.keys(values)
-    : Object.keys(values).filter(module => module !== 'heaterShakerModuleType')
+  const modules: ModuleType[] = Object.keys(values)
   const handleOnDeckChange = (type: ModuleType) => (e: React.ChangeEvent) => {
     const targetToClear = `modulesByType.${type}.model`
 

--- a/protocol-designer/src/components/modals/FilePipettesModal/__tests__/ModuleFields.test.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/__tests__/ModuleFields.test.tsx
@@ -12,13 +12,6 @@ import { CheckboxField } from '@opentrons/components'
 import { DEFAULT_MODEL_FOR_MODULE_TYPE } from '../../../../constants'
 import { ModuleDiagram } from '../../../modules'
 import { ModuleFields, ModuleFieldsProps } from '../ModuleFields'
-import { selectors as featureFlagSelectors } from '../../../../feature-flags'
-
-jest.mock('../../../../feature-flags')
-
-const getEnabledHeaterShakerMock = featureFlagSelectors.getEnabledHeaterShaker as jest.MockedFunction<
-  typeof featureFlagSelectors.getEnabledHeaterShaker
->
 
 describe('ModuleFields', () => {
   let magnetModuleOnDeck,
@@ -69,8 +62,6 @@ describe('ModuleFields', () => {
       touched: null,
       errors: null,
     }
-
-    getEnabledHeaterShakerMock.mockReturnValue(false)
   })
 
   function render(props: ModuleFieldsProps) {
@@ -84,7 +75,7 @@ describe('ModuleFields', () => {
   it('renders a module selection element for every module', () => {
     const wrapper = render(props)
 
-    expect(wrapper.find(CheckboxField)).toHaveLength(3)
+    expect(wrapper.find(CheckboxField)).toHaveLength(4)
   })
 
   it('adds module to protocol when checkbox is selected and resets the model field', () => {

--- a/protocol-designer/src/components/modules/EditModulesCard.tsx
+++ b/protocol-designer/src/components/modules/EditModulesCard.tsx
@@ -29,10 +29,6 @@ export interface Props {
 export function EditModulesCard(props: Props): JSX.Element {
   const { modules, openEditModuleModal } = props
 
-  const enableHeaterShaker = useSelector(
-    featureFlagSelectors.getEnabledHeaterShaker
-  )
-
   const pipettesByMount = useSelector(
     stepFormSelectors.getPipettesForEditPipetteForm
   )
@@ -70,11 +66,7 @@ export function EditModulesCard(props: Props): JSX.Element {
 
   const warningsEnabled = !moduleRestrictionsDisabled
 
-  const SUPPORTED_MODULE_TYPES_FILTERED = enableHeaterShaker
-    ? SUPPORTED_MODULE_TYPES
-    : SUPPORTED_MODULE_TYPES.filter(
-        moduleType => moduleType !== 'heaterShakerModuleType'
-      )
+  const SUPPORTED_MODULE_TYPES_FILTERED = SUPPORTED_MODULE_TYPES
 
   return (
     <Card title="Modules">

--- a/protocol-designer/src/components/modules/__tests__/EditModulesCard.test.tsx
+++ b/protocol-designer/src/components/modules/__tests__/EditModulesCard.test.tsx
@@ -29,9 +29,6 @@ const getDisableModuleRestrictionsMock = featureFlagSelectors.getDisableModuleRe
 const getPipettesForEditPipetteFormMock = stepFormSelectors.getPipettesForEditPipetteForm as jest.MockedFunction<
   typeof stepFormSelectors.getPipettesForEditPipetteForm
 >
-const getEnabledHeaterShakerMock = featureFlagSelectors.getEnabledHeaterShaker as jest.MockedFunction<
-  typeof featureFlagSelectors.getEnabledHeaterShaker
->
 
 describe('EditModulesCard', () => {
   let store: any
@@ -79,7 +76,6 @@ describe('EditModulesCard', () => {
         tiprackDefURI: null,
       },
     })
-    getEnabledHeaterShakerMock.mockReturnValue(true)
 
     props = {
       modules: {},

--- a/protocol-designer/src/feature-flags/reducers.ts
+++ b/protocol-designer/src/feature-flags/reducers.ts
@@ -19,8 +19,6 @@ const initialFlags: Flags = {
   PRERELEASE_MODE: process.env.OT_PD_PRERELEASE_MODE === '1' || false,
   OT_PD_DISABLE_MODULE_RESTRICTIONS:
     process.env.OT_PD_DISABLE_MODULE_RESTRICTIONS === '1' || false,
-  OT_PD_ENABLE_HEATER_SHAKER:
-    process.env.OT_PD_ENABLE_HEATER_SHAKER === '1' || false,
   OT_PD_ENABLE_LIQUID_COLOR_ENHANCEMENTS:
     process.env.OT_PD_ENABLE_LIQUID_COLOR_ENHANCEMENTS === '1' || false,
 }

--- a/protocol-designer/src/feature-flags/selectors.ts
+++ b/protocol-designer/src/feature-flags/selectors.ts
@@ -15,12 +15,6 @@ export const getDisableModuleRestrictions: Selector<
   getFeatureFlagData,
   flags => flags.OT_PD_DISABLE_MODULE_RESTRICTIONS
 )
-
-export const getEnabledHeaterShaker: Selector<boolean> = createSelector(
-  getFeatureFlagData,
-  flags => flags.OT_PD_ENABLE_HEATER_SHAKER ?? false
-)
-
 export const getEnabledLiquidColorEnhancements: Selector<boolean> = createSelector(
   getFeatureFlagData,
   flags => flags.OT_PD_ENABLE_LIQUID_COLOR_ENHANCEMENTS ?? false

--- a/protocol-designer/src/feature-flags/types.ts
+++ b/protocol-designer/src/feature-flags/types.ts
@@ -16,12 +16,12 @@ export const DEPRECATED_FLAGS = [
   'BATCH_EDIT_ENABLED',
   'OT_PD_ENABLE_BATCH_EDIT_MIX',
   'OT_PD_ENABLE_SCHEMA_V6',
+  'OT_PD_ENABLE_HEATER_SHAKER',
 ]
 // union of feature flag string constant IDs
 export type FlagTypes =
   | 'PRERELEASE_MODE'
   | 'OT_PD_DISABLE_MODULE_RESTRICTIONS'
-  | 'OT_PD_ENABLE_HEATER_SHAKER'
   | 'OT_PD_ENABLE_LIQUID_COLOR_ENHANCEMENTS'
 // flags that are not in this list only show in prerelease mode
 export const userFacingFlags: FlagTypes[] = [

--- a/protocol-designer/src/localization/en/feature_flags.json
+++ b/protocol-designer/src/localization/en/feature_flags.json
@@ -12,10 +12,6 @@
     "title": "Enable mix batch edit",
     "description": "Allow users to batch edit mix forms"
   },
-  "OT_PD_ENABLE_HEATER_SHAKER": {
-    "title": "Enable heater shaker module",
-    "description": "Allow adding heater shaker module and steps to protocols"
-  },
   "OT_PD_ENABLE_SCHEMA_V6": {
     "title": "Enable schema v6 support",
     "description": "Allow users to migrate older protocols to schema v6"


### PR DESCRIPTION
# Overview

This PR removes the HS feature flag in PD

# Review requests
- Check that the HS FF no longer shows up in settings tab
- HS module should show up by default in the file creation modal
- You should be able to add HS steps in the design tab

# Risk assessment

Low
