### PR TITLE
refactor(api): remove heater shaker feature flag

### DIFF
--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -176,14 +176,6 @@ settings = [
         ),
         restart_required=True,
     ),
-    SettingDefinition(
-        _id="enableHeaterShakerPAPI",
-        title="Enable Heater-Shaker Python API support",
-        description=(
-            "Do not enable. This is an Opentrons internal setting to test a new module."
-        ),
-        restart_required=False,
-    ),
 ]
 
 if ARCHITECTURE == SystemArchitecture.BUILDROOT:
@@ -460,6 +452,16 @@ def _migrate14to15(previous: SettingsMap) -> SettingsMap:
     return newmap
 
 
+def _migrate15to16(previous: SettingsMap) -> SettingsMap:
+    """Migrate to version 16 of the feature flags file.
+
+    - Removes deprecated enableProtocolEngine option
+    """
+    removals = ["enableHeaterShakerPAPI"]
+    newmap = {k: v for k, v in previous.items() if k not in removals}
+    return newmap
+
+
 _MIGRATIONS = [
     _migrate0to1,
     _migrate1to2,
@@ -476,6 +478,7 @@ _MIGRATIONS = [
     _migrate12to13,
     _migrate13to14,
     _migrate14to15,
+    _migrate15to16
 ]
 """
 List of all migrations to apply, indexed by (version - 1). See _migrate below

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -478,7 +478,7 @@ _MIGRATIONS = [
     _migrate12to13,
     _migrate13to14,
     _migrate14to15,
-    _migrate15to16
+    _migrate15to16,
 ]
 """
 List of all migrations to apply, indexed by (version - 1). See _migrate below

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -455,7 +455,7 @@ def _migrate14to15(previous: SettingsMap) -> SettingsMap:
 def _migrate15to16(previous: SettingsMap) -> SettingsMap:
     """Migrate to version 16 of the feature flags file.
 
-    - Removes deprecated enableProtocolEngine option
+    - Removes deprecated enableHeaterShakerPAPI option
     """
     removals = ["enableHeaterShakerPAPI"]
     newmap = {k: v for k, v in previous.items() if k not in removals}

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -29,8 +29,3 @@ def enable_ot3_hardware_controller() -> bool:
     """Get whether to use the ot3 hardware controller."""
 
     return advs.get_setting_with_env_overload("enableOT3HardwareController")
-
-
-def enable_heater_shaker_python_api() -> bool:
-    """Get whether to use the Heater-Shaker python API."""
-    return advs.get_setting_with_env_overload("enableHeaterShakerPAPI")

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -811,31 +811,31 @@ class HeaterShakerContext(ModuleContext[HeaterShakerGeometry]):
         self._loop = loop
         super().__init__(ctx, geometry, requested_as, at_version)
 
-    @property
+    @property  # type: ignore[misc]
     @requires_version(2, 13)
     def target_temperature(self) -> Optional[float]:
         """Target temperature of the heater-shaker's plate."""
         return self._module.target_temperature
 
-    @property
+    @property  # type: ignore[misc]
     @requires_version(2, 13)
     def current_temperature(self) -> float:
         """Current temperature of the heater-shaker's plate."""
         return self._module.temperature
 
-    @property
+    @property  # type: ignore[misc]
     @requires_version(2, 13)
     def current_speed(self) -> int:
         """Current speed of the heater-shaker's plate."""
         return self._module.speed
 
-    @property
+    @property  # type: ignore[misc]
     @requires_version(2, 13)
     def target_speed(self) -> Optional[int]:
         """Target speed of the heater-shaker's plate."""
         return self._module.target_speed
 
-    @property
+    @property  # type: ignore[misc]
     @requires_version(2, 13)
     def temperature_status(self) -> str:
         """Heater-shaker's temperature status string.
@@ -849,7 +849,7 @@ class HeaterShakerContext(ModuleContext[HeaterShakerGeometry]):
         """
         return self._module.temperature_status.value
 
-    @property
+    @property  # type: ignore[misc]
     @requires_version(2, 13)
     def speed_status(self) -> str:
         """Heater-shaker's speed status string.
@@ -863,7 +863,7 @@ class HeaterShakerContext(ModuleContext[HeaterShakerGeometry]):
         """
         return self._module.speed_status.value
 
-    @property
+    @property  # type: ignore[misc]
     @requires_version(2, 13)
     def labware_latch_status(self) -> str:
         """Heater-shaker's labware latch status string.

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -811,32 +811,32 @@ class HeaterShakerContext(ModuleContext[HeaterShakerGeometry]):
         self._loop = loop
         super().__init__(ctx, geometry, requested_as, at_version)
 
-    # TODO: add API version requirement
     @property
+    @requires_version(2, 13)
     def target_temperature(self) -> Optional[float]:
         """Target temperature of the heater-shaker's plate."""
         return self._module.target_temperature
 
-    # TODO: add API version requirement
     @property
+    @requires_version(2, 13)
     def current_temperature(self) -> float:
         """Current temperature of the heater-shaker's plate."""
         return self._module.temperature
 
-    # TODO: add API version requirement
     @property
+    @requires_version(2, 13)
     def current_speed(self) -> int:
         """Current speed of the heater-shaker's plate."""
         return self._module.speed
 
-    # TODO: add API version requirement
     @property
+    @requires_version(2, 13)
     def target_speed(self) -> Optional[int]:
         """Target speed of the heater-shaker's plate."""
         return self._module.target_speed
 
-    # TODO: add API version requirement
     @property
+    @requires_version(2, 13)
     def temperature_status(self) -> str:
         """Heater-shaker's temperature status string.
 
@@ -849,8 +849,8 @@ class HeaterShakerContext(ModuleContext[HeaterShakerGeometry]):
         """
         return self._module.temperature_status.value
 
-    # TODO: add API version requirement
     @property
+    @requires_version(2, 13)
     def speed_status(self) -> str:
         """Heater-shaker's speed status string.
 
@@ -863,8 +863,8 @@ class HeaterShakerContext(ModuleContext[HeaterShakerGeometry]):
         """
         return self._module.speed_status.value
 
-    # TODO: add API version requirement
     @property
+    @requires_version(2, 13)
     def labware_latch_status(self) -> str:
         """Heater-shaker's labware latch status string.
 
@@ -878,7 +878,7 @@ class HeaterShakerContext(ModuleContext[HeaterShakerGeometry]):
         """
         return self._module.labware_latch_status.value
 
-    # TODO: add API version requirement
+    @requires_version(2, 13)
     def set_and_wait_for_temperature(self, celsius: float) -> None:
         """Set the target temperature and wait for it to be reached.
 
@@ -889,7 +889,7 @@ class HeaterShakerContext(ModuleContext[HeaterShakerGeometry]):
         self.set_target_temperature(celsius=celsius)
         self.wait_for_temperature()
 
-    # TODO: add API version requirement
+    @requires_version(2, 13)
     @publish(command=cmds.heater_shaker_set_target_temperature)
     def set_target_temperature(self, celsius: float) -> None:
         """Set target temperature and return immediately.
@@ -904,7 +904,7 @@ class HeaterShakerContext(ModuleContext[HeaterShakerGeometry]):
         validated_temp = validate_heater_shaker_temperature(celsius=celsius)
         self._module.start_set_temperature(celsius=validated_temp)
 
-    # TODO: add API version requirement
+    @requires_version(2, 13)
     @publish(command=cmds.heater_shaker_wait_for_temperature)
     def wait_for_temperature(self) -> None:
         """Wait for the Heater-Shaker to reach its target temperature.
@@ -918,7 +918,7 @@ class HeaterShakerContext(ModuleContext[HeaterShakerGeometry]):
             )
         self._module.await_temperature(awaiting_temperature=self.target_temperature)
 
-    # TODO: add API version requirement
+    @requires_version(2, 13)
     @publish(command=cmds.heater_shaker_set_and_wait_for_shake_speed)
     def set_and_wait_for_shake_speed(self, rpm: int) -> None:
         """Set and wait for target speed.
@@ -942,7 +942,7 @@ class HeaterShakerContext(ModuleContext[HeaterShakerGeometry]):
                 "Cannot start H/S shake unless labware latch is closed."
             )
 
-    # TODO: add API version requirement
+    @requires_version(2, 13)
     @publish(command=cmds.heater_shaker_open_labware_latch)
     def open_labware_latch(self) -> None:
         """Open the Heater-Shaker's labware latch.
@@ -965,19 +965,19 @@ class HeaterShakerContext(ModuleContext[HeaterShakerGeometry]):
         self._prepare_for_latch_open()
         self._module.open_labware_latch()
 
-    # TODO: add API version requirement
+    @requires_version(2, 13)
     @publish(command=cmds.heater_shaker_close_labware_latch)
     def close_labware_latch(self) -> None:
         """Close heater-shaker's labware latch"""
         self._module.close_labware_latch()
 
-    # TODO: add API version requirement
+    @requires_version(2, 13)
     @publish(command=cmds.heater_shaker_deactivate_shaker)
     def deactivate_shaker(self) -> None:
         """Stop shaking."""
         self._module.deactivate_shaker()
 
-    # TODO: add API version requirement
+    @requires_version(2, 13)
     @publish(command=cmds.heater_shaker_deactivate_heater)
     def deactivate_heater(self) -> None:
         """Stop heating."""

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -487,13 +487,6 @@ class ProtocolContext(CommandPublisher):
         if not load_result:
             raise RuntimeError(f"Could not find specified module: {module_name}")
 
-        # TODO(mc, 2022-06-14): remove guard for heater-shaker production release
-        if (
-            load_result.type == ModuleType.HEATER_SHAKER
-            and not ff.enable_heater_shaker_python_api()
-        ):
-            raise UnsupportedAPIError("Heater-Shaker module is not yet supported")
-
         mod_class = {
             ModuleType.MAGNETIC: MagneticModuleContext,
             ModuleType.TEMPERATURE: TemperatureModuleContext,

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -17,7 +17,6 @@ from collections import OrderedDict
 
 from opentrons import types
 from opentrons.broker import Broker
-from opentrons.config import feature_flags as ff
 from opentrons.equipment_broker import EquipmentBroker
 from opentrons.hardware_control import SyncHardwareAPI
 from opentrons.hardware_control.modules.types import ModuleType
@@ -28,7 +27,6 @@ from opentrons.protocols.api_support.util import (
     AxisMaxSpeeds,
     requires_version,
     APIVersionError,
-    UnsupportedAPIError,
 )
 from opentrons.protocols.context.labware import AbstractLabware
 from opentrons.protocols.context.protocol import AbstractProtocol

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -7,7 +7,7 @@ from opentrons.config.advanced_settings import _migrate, _ensure
 
 @pytest.fixture
 def migrated_file_version() -> int:
-    return 15
+    return 16
 
 
 @pytest.fixture
@@ -21,7 +21,6 @@ def default_file_settings() -> Dict[str, Any]:
         "enableDoorSafetySwitch": None,
         "disableFastProtocolUpload": None,
         "enableOT3HardwareController": None,
-        "enableHeaterShakerPAPI": None,
     }
 
 
@@ -305,5 +304,4 @@ def test_ensures_config() -> None:
         "enableDoorSafetySwitch": None,
         "disableFastProtocolUpload": None,
         "enableOT3HardwareController": None,
-        "enableHeaterShakerPAPI": None,
     }

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -150,15 +150,6 @@ async def enable_ot3_hardware_controller(
     yield
     await config.advanced_settings.set_adv_setting("enableOT3HardwareController", False)
 
-
-@pytest.fixture()
-async def enable_heater_shaker_python_api() -> AsyncGenerator[None, None]:
-    """Fixture enabling heater-shaker PAPI support."""
-    await config.advanced_settings.set_adv_setting("enableHeaterShakerPAPI", True)
-    yield
-    await config.advanced_settings.set_adv_setting("enableHeaterShakerPAPI", False)
-
-
 # -----end feature flag fixtures-----------
 
 

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -150,6 +150,7 @@ async def enable_ot3_hardware_controller(
     yield
     await config.advanced_settings.set_adv_setting("enableOT3HardwareController", False)
 
+
 # -----end feature flag fixtures-----------
 
 

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -3,7 +3,7 @@
 import asyncio
 import json
 from unittest import mock
-from typing import Any, Dict, AsyncGenerator
+from typing import Any, Dict
 
 from opentrons_shared_data import load_shared_data
 from opentrons_shared_data.pipette.dev_types import LabwareUri

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -1226,7 +1226,6 @@ def test_move_to_with_thermocycler(
 def test_move_to_with_heater_shaker(
     ctx: papi.ProtocolContext,
     hardware: ThreadManagedHardware,
-    enable_heater_shaker_python_api: AsyncGenerator[None, None],
 ) -> None:
     """Test move_to raises for unsafe moves with heater-shaker."""
 

--- a/api/tests/opentrons/protocol_api/test_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_module_context.py
@@ -2,8 +2,6 @@ import pytest
 import json
 import mock
 
-from typing import AsyncGenerator
-
 import opentrons.protocol_api as papi
 import opentrons.protocols.geometry as papi_geometry
 
@@ -33,7 +31,6 @@ from opentrons.protocols.context.protocol_api.protocol_context import (
 from opentrons.protocols.geometry.module_geometry import (
     PipetteMovementRestrictedByHeaterShakerError,
 )
-from opentrons.protocols.api_support import util as api_util
 from opentrons_shared_data import load_shared_data
 
 
@@ -205,9 +202,7 @@ def test_incorrect_module_error(ctx_with_tempdeck):
         ("heaterShakerModuleV1", papi.HeaterShakerContext, "heaterShakerModuleV1"),
     ],
 )
-def test_load_simulating_module(
-    ctx, loadname, klass, model
-):
+def test_load_simulating_module(ctx, loadname, klass, model):
     """Check that a known module will not throw an error if in simulation mode.
 
     Note: This is basically an integration test that checks that a module can be

--- a/api/tests/opentrons/protocol_api/test_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_module_context.py
@@ -127,7 +127,6 @@ async def ctx_with_heater_shaker(
     mock_hardware: mock.AsyncMock,
     mock_module_controller: mock.MagicMock,
     mock_pipette_location: mock.MagicMock,
-    enable_heater_shaker_python_api: AsyncGenerator[None, None],
 ) -> ProtocolContext:
     """Context fixture with a mock heater-shaker."""
     mock_module_controller.model.return_value = "heaterShakerModuleV1"
@@ -207,7 +206,7 @@ def test_incorrect_module_error(ctx_with_tempdeck):
     ],
 )
 def test_load_simulating_module(
-    ctx, loadname, klass, model, enable_heater_shaker_python_api
+    ctx, loadname, klass, model
 ):
     """Check that a known module will not throw an error if in simulation mode.
 
@@ -585,31 +584,6 @@ def test_heater_shaker_loading(
     """It should load a heater-shaker in the specified slot."""
     mod = ctx_with_heater_shaker.load_module("heaterShakerModuleV1", 3)
     assert ctx_with_heater_shaker.deck[3] == mod.geometry
-
-
-# TODO(mc, 2022-06-14): remove this test for heater-shaker production release
-def test_loading_heater_shaker_fails_prerelease(
-    mock_hardware: mock.AsyncMock,
-    mock_module_controller: mock.MagicMock,
-) -> None:
-    """It should raise an error if h/s loaded without feature flag enabled."""
-    mock_module_controller.model.return_value = "heaterShakerModuleV1"
-
-    def find_modules(resolved_model: ModuleModel, resolved_type: ModuleType):
-        if (
-            resolved_model == HeaterShakerModuleModel.HEATER_SHAKER_V1
-            and resolved_type == ModuleType.HEATER_SHAKER
-        ):
-            return [mock_module_controller], None
-        return []
-
-    mock_hardware.find_modules.side_effect = find_modules
-    ctx_with_heater_shaker = ProtocolContext(
-        implementation=ProtocolContextImplementation(sync_hardware=mock_hardware)
-    )
-
-    with pytest.raises(api_util.UnsupportedAPIError):
-        ctx_with_heater_shaker.load_module("heaterShakerModuleV1", 1)
 
 
 def test_heater_shaker_set_target_temperature(

--- a/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_module_commands.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_module_commands.py
@@ -52,7 +52,6 @@ def modules_legacy_python_protocol_file(tmp_path: Path) -> Path:
 
 async def test_runner_with_modules_in_legacy_python(
     modules_legacy_python_protocol_file: Path,
-    enable_heater_shaker_python_api: None,
 ) -> None:
     """It should map legacy module commands."""
     protocol_reader = ProtocolReader()

--- a/robot-server/tests/integration/test_settings.tavern.yaml
+++ b/robot-server/tests/integration/test_settings.tavern.yaml
@@ -54,12 +54,6 @@ stages:
             description: !re_search 'Opentrons-internal setting to test new hardware'
             restart_required: true
             value: !anything
-          - id: enableHeaterShakerPAPI
-            old_id: Null
-            title: Enable Heater-Shaker Python API support
-            description: !re_search 'Opentrons internal setting to test a new module'
-            restart_required: false
-            value: !anything
         links: !anydict
 
 ---


### PR DESCRIPTION
# Overview

closes #10775.
remove heater shaker feature flag.

# Changelog

- Removed heater shaker advance setting.
- Added a migration function
- Remove\updated related tests 

# Review requests

are all feature flag changes removed? 

# Risk assessment

small. heater shaker should now be available without setting the feature flag. 