### PR TITLE
feat(protocol-designer): render modals within viewport

### DIFF
--- a/protocol-designer/src/components/modals/modal.css
+++ b/protocol-designer/src/components/modals/modal.css
@@ -1,6 +1,7 @@
 .modal {
   z-index: 100;
   align-items: flex-start;
+  position: fixed;
 
   & p {
     line-height: 1.5;


### PR DESCRIPTION
# Overview

This PR renders PD modals within the viewport, so that if a modal is rendered when a user is scrolled out of view, the modal will always render where the user can see it (without needing to scroll). 

# Changelog

- Render modals within viewport


# Review requests

- Create a new PD step when you're scrolled down to the bottom of the deckmap, click on the starting deck state button, the `unsaved step form` modal should render wihtin the viewport
- Play around with PD and make sure modals still render
# Risk assessment

Low
