### PR TITLE
refactor(api): standardize direction terms for slots adjacent to Heater-Shaker

### DIFF
--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -914,7 +914,7 @@ class HeaterShakerContext(ModuleContext[HeaterShakerGeometry]):
         """
         if self.target_temperature is None:
             raise NoTargetTemperatureSetError(
-                f"Heater-shaker module {self} does not have a target temperature set."
+                f"Heater-Shaker Module {self} does not have a target temperature set."
             )
         self._module.await_temperature(awaiting_temperature=self.target_temperature)
 
@@ -939,7 +939,7 @@ class HeaterShakerContext(ModuleContext[HeaterShakerGeometry]):
         else:
             # TODO: Figure out whether to issue close latch behind the scenes instead
             raise CannotPerformModuleAction(
-                "Cannot start H/S shake unless labware latch is closed."
+                "Cannot start shaking unless labware latch is closed."
             )
 
     @requires_version(2, 13)
@@ -990,7 +990,7 @@ class HeaterShakerContext(ModuleContext[HeaterShakerGeometry]):
     ) -> None:
         """
         Raise an error if attempting to perform a move that's deemed unsafe due to
-        the presence of the heater-shaker.
+        the presence of the Heater-Shaker.
         """
         is_labware_latch_closed = (
             self._module.labware_latch_status

--- a/api/src/opentrons/protocol_api/module_validation_and_errors.py
+++ b/api/src/opentrons/protocol_api/module_validation_and_errors.py
@@ -21,9 +21,9 @@ def validate_heater_shaker_temperature(celsius: float) -> float:
         return celsius
     else:
         raise InvalidTargetTemperatureError(
-            f"Heater-Shaker got an invalid temperature {celsius} degree Celsius."
-            f" Valid range is {HEATER_SHAKER_TEMPERATURE_MIN} ->"
-            f" {HEATER_SHAKER_SPEED_MAX}."
+            f"Cannot set Heater-Shaker to {celsius} °C."
+            f" Valid range is {HEATER_SHAKER_TEMPERATURE_MIN}-"
+            f" {HEATER_SHAKER_TEMPERATURE_MAX} °C."
         )
 
 

--- a/api/src/opentrons/protocol_api/module_validation_and_errors.py
+++ b/api/src/opentrons/protocol_api/module_validation_and_errors.py
@@ -33,6 +33,6 @@ def validate_heater_shaker_speed(rpm: int) -> int:
         return rpm
     else:
         raise InvalidTargetSpeedError(
-            f"Heater-Shaker got invalid speed of {rpm} rpm. Valid range is "
-            f"{HEATER_SHAKER_SPEED_MIN} -> {HEATER_SHAKER_SPEED_MAX}."
+            f"Cannot set Heater-Shaker to shake at {rpm} rpm. Valid speed range is "
+            f"{HEATER_SHAKER_SPEED_MIN}-{HEATER_SHAKER_SPEED_MAX} rpm."
         )

--- a/api/src/opentrons/protocol_api/module_validation_and_errors.py
+++ b/api/src/opentrons/protocol_api/module_validation_and_errors.py
@@ -23,7 +23,7 @@ def validate_heater_shaker_temperature(celsius: float) -> float:
         raise InvalidTargetTemperatureError(
             f"Cannot set Heater-Shaker to {celsius} °C."
             f" Valid range is {HEATER_SHAKER_TEMPERATURE_MIN}-"
-            f" {HEATER_SHAKER_TEMPERATURE_MAX} °C."
+            f"{HEATER_SHAKER_TEMPERATURE_MAX} °C."
         )
 
 

--- a/api/src/opentrons/protocol_api_experimental/errors.py
+++ b/api/src/opentrons/protocol_api_experimental/errors.py
@@ -49,7 +49,7 @@ class NoTargetTemperatureError(ValueError):
 
 
 class InvalidTargetSpeedError(ValueError):
-    """Error raised if a heater-shaker target speed is invalid."""
+    """Error raised if a Heater-Shaker target speed is invalid."""
 
 
 __all__ = [

--- a/api/src/opentrons/protocol_api_experimental/errors.py
+++ b/api/src/opentrons/protocol_api_experimental/errors.py
@@ -41,7 +41,7 @@ class InvalidMagnetEngageHeightError(ValueError):
 
 
 class InvalidTargetTemperatureError(ValueError):
-    """Error raised if a module with heating abilities gets an invalid target temp."""
+    """Error raised if a module with heating abilities gets an invalid target temperature."""
 
 
 class NoTargetTemperatureError(ValueError):

--- a/api/src/opentrons/protocol_api_experimental/module_contexts/heater_shaker_module_context.py
+++ b/api/src/opentrons/protocol_api_experimental/module_contexts/heater_shaker_module_context.py
@@ -91,8 +91,7 @@ class HeaterShakerModuleContext:
         """
         if not MIN_ALLOWED_SPEED <= rpm <= MAX_ALLOWED_SPEED:
             raise InvalidTargetSpeedError(
-                f"Speed should be in range {MIN_ALLOWED_SPEED} - {MAX_ALLOWED_SPEED}"
-                f"RPM."
+                f"Speed should be in range {MIN_ALLOWED_SPEED}-{MAX_ALLOWED_SPEED} rpm."
             )
         raise NotImplementedError()
 

--- a/api/src/opentrons/protocol_engine/execution/heater_shaker_movement_flagger.py
+++ b/api/src/opentrons/protocol_engine/execution/heater_shaker_movement_flagger.py
@@ -1,4 +1,4 @@
-"""Helpers for flagging unsafe movements around a heater-shaker Module."""
+"""Helpers for flagging unsafe movements around a Heater-Shaker Module."""
 
 from typing import List
 
@@ -27,7 +27,7 @@ def raise_if_movement_restricted(
         )
         dest_heater_shaker = destination_slot == hs_movement_restrictor.deck_slot
 
-        # If heater-shaker is running, can't move to or around it
+        # If Heater-Shaker is running, can't move to or around it
         if (
             any([dest_east_west, dest_north_south, dest_heater_shaker])
             and hs_movement_restrictor.plate_shaking
@@ -36,22 +36,22 @@ def raise_if_movement_restricted(
                 "Cannot move pipette to Heater-Shaker or adjacent slot while module is shaking"
             )
 
-        # If heater-shaker's latch is open, can't move to it or east and west of it
+        # If Heater-Shaker's latch is open, can't move to it or east and west of it
         elif (
             dest_east_west or dest_heater_shaker
         ) and not hs_movement_restrictor.latch_closed:
             raise PipetteMovementRestrictedByHeaterShakerError(
-                "Cannot move pipette east or west of or to Heater-Shaker while latch is open"
+                "Cannot move pipette to Heater-Shaker or adjacent slot to the left or right while labware latch is open"
             )
 
         elif is_multi_channel:
             # Can't go to east/west slot under any circumstances if pipette is multi-channel
             if dest_east_west:
                 raise PipetteMovementRestrictedByHeaterShakerError(
-                    "Cannot move multi-channel pipette east or west of Heater-Shaker"
+                    "Cannot move 8-Channel pipette to slot adjacent to the left or right of Heater-Shaker"
                 )
             # Can only go north/south if the labware is a tip rack
             elif dest_north_south and not destination_is_tip_rack:
                 raise PipetteMovementRestrictedByHeaterShakerError(
-                    "Cannot move multi-channel pipette to non-tip rack labware north or south of Heater-Shaker"
+                    "Cannot move 8-Channel pipette to non-tip-rack labware adjacent to the front or back of Heater-Shaker"
                 )

--- a/api/src/opentrons/protocol_engine/execution/heater_shaker_movement_flagger.py
+++ b/api/src/opentrons/protocol_engine/execution/heater_shaker_movement_flagger.py
@@ -53,5 +53,5 @@ def raise_if_movement_restricted(
             # Can only go north/south if the labware is a tip rack
             elif dest_north_south and not destination_is_tip_rack:
                 raise PipetteMovementRestrictedByHeaterShakerError(
-                    "Cannot move 8-Channel pipette to non-tip-rack labware adjacent to the front or back of Heater-Shaker"
+                    "Cannot move 8-Channel pipette to non-tip-rack labware directly in front of or behind a Heater-Shaker"
                 )

--- a/api/src/opentrons/protocol_engine/state/module_substates/heater_shaker_module_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/heater_shaker_module_substate.py
@@ -52,8 +52,9 @@ class HeaterShakerModuleSubState:
             return celsius
         else:
             raise InvalidTargetTemperatureError(
-                f"Heater-Shaker got an invalid temperature {celsius} degree Celsius."
-                f" Valid range is {HEATER_SHAKER_TEMPERATURE_RANGE}."
+                f"Cannot set Heater-Shaker to {celsius} °C."
+                f" Valid range is {HEATER_SHAKER_TEMPERATURE_MIN}-"
+                f" {HEATER_SHAKER_TEMPERATURE_MAX} °C."
             )
 
     @staticmethod

--- a/api/src/opentrons/protocol_engine/state/module_substates/heater_shaker_module_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/heater_shaker_module_substate.py
@@ -53,8 +53,7 @@ class HeaterShakerModuleSubState:
         else:
             raise InvalidTargetTemperatureError(
                 f"Cannot set Heater-Shaker to {celsius} °C."
-                f" Valid range is {HEATER_SHAKER_TEMPERATURE_MIN}-"
-                f" {HEATER_SHAKER_TEMPERATURE_MAX} °C."
+                f" Valid range is {HEATER_SHAKER_TEMPERATURE_RANGE} °C."
             )
 
     @staticmethod
@@ -66,7 +65,7 @@ class HeaterShakerModuleSubState:
         else:
             raise InvalidTargetSpeedError(
                 f"Cannot set Heater-Shaker to shake at {rpm} rpm. Valid speed range is "
-                f"{HEATER_SHAKER_SPEED_MIN}-{HEATER_SHAKER_SPEED_MAX} rpm."
+                f"{HEATER_SHAKER_SPEED_RANGE} rpm."
             )
 
     def raise_if_labware_latch_not_closed(self) -> None:

--- a/api/src/opentrons/protocol_engine/state/module_substates/heater_shaker_module_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/heater_shaker_module_substate.py
@@ -64,20 +64,20 @@ class HeaterShakerModuleSubState:
             return rpm_int
         else:
             raise InvalidTargetSpeedError(
-                f"Heater-Shaker got invalid speed of {rpm}RPM. Valid range is "
-                f"{HEATER_SHAKER_SPEED_RANGE}."
+                f"Cannot set Heater-Shaker to shake at {rpm} rpm. Valid speed range is "
+                f"{HEATER_SHAKER_SPEED_MIN}-{HEATER_SHAKER_SPEED_MAX} rpm."
             )
 
     def raise_if_labware_latch_not_closed(self) -> None:
         """Raise an error if labware is not latched on the heater-shaker."""
         if not self.is_labware_latch_closed:
             raise CannotPerformModuleAction(
-                "Heater-Shaker can't start shaking while the labware latch is open."
+                "Heater-Shaker cannot start shaking while the labware latch is open."
             )
 
     def raise_if_shaking(self) -> None:
         """Raise an error if the heater-shaker is currently shaking."""
         if self.is_plate_shaking:
             raise CannotPerformModuleAction(
-                "Heater-Shaker can't open its labware latch while it is shaking."
+                "Heater-Shaker cannot open its labware latch while it is shaking."
             )

--- a/api/src/opentrons/protocols/geometry/module_geometry.py
+++ b/api/src/opentrons/protocols/geometry/module_geometry.py
@@ -79,7 +79,7 @@ class NoSuchModuleError(Exception):
 
 
 class PipetteMovementRestrictedByHeaterShakerError(Exception):
-    """Error raised when trying to move to labware restricted by heater-shaker."""
+    """Error raised when trying to move to labware restricted by Heater-Shaker."""
 
 
 # TODO (spp, 2022-05-09): add tests
@@ -343,14 +343,14 @@ class ThermocyclerGeometry(ModuleGeometry):
 
 
 class HeaterShakerGeometry(ModuleGeometry):
-    """Class holding the state of a heater-shaker's physical geometry."""
+    """Class holding the state of a Heater-Shaker's physical geometry."""
 
     # TODO(mc, 2022-06-16): move these constants to the module definition
     MAX_X_ADJACENT_ITEM_HEIGHT = 53.0
     """Maximum height of an adjacent item in the x-direction.
 
     This value selected to avoid interference
-    with the heater-shaker's labware latch.
+    with the Heater-Shaker's labware latch.
 
     For background, see: https://github.com/Opentrons/opentrons/issues/10316
     """
@@ -402,7 +402,7 @@ class HeaterShakerGeometry(ModuleGeometry):
         is_labware_latch_closed: bool,
         is_plate_shaking: bool,
     ) -> None:
-        """Raise error if unsafe to move pipette due to heater-shaker placement."""
+        """Raise error if unsafe to move pipette due to Heater-Shaker placement."""
         assert isinstance(self.parent, str), "Could not determine module slot location"
 
         heater_shaker_slot = int(self.parent)
@@ -410,7 +410,7 @@ class HeaterShakerGeometry(ModuleGeometry):
         dest_north_south = to_slot in get_north_south_slots(heater_shaker_slot)
         dest_heater_shaker = to_slot == heater_shaker_slot
 
-        # If heater-shaker is running, can't move to or around it
+        # If Heater-Shaker is running, can't move to or around it
         if (
             any([dest_east_west, dest_north_south, dest_heater_shaker])
             and is_plate_shaking
@@ -419,31 +419,31 @@ class HeaterShakerGeometry(ModuleGeometry):
                 "Cannot move pipette to Heater-Shaker or adjacent slot while module is shaking"
             )
 
-        # If heater-shaker's latch is open, can't move to it or east and west of it
+        # If Heater-Shaker's latch is open, can't move to it or east and west of it
         elif (dest_east_west or dest_heater_shaker) and not is_labware_latch_closed:
             raise PipetteMovementRestrictedByHeaterShakerError(
-                "Cannot move pipette east or west of or to Heater-Shaker while latch is open"
+                "Cannot move pipette to Heater-Shaker or adjacent slot to the left or right while labware latch is open"
             )
 
         elif is_using_multichannel:
             # Can't go to east/west slot under any circumstances if pipette is multi-channel
             if dest_east_west:
                 raise PipetteMovementRestrictedByHeaterShakerError(
-                    "Cannot move multi-channel pipette east or west of Heater-Shaker"
+                    "Cannot move 8-Channel pipette to slot adjacent to the left or right of Heater-Shaker"
                 )
             # Can only go north/south if the labware is a tip rack
             elif dest_north_south and not is_tiprack:
                 raise PipetteMovementRestrictedByHeaterShakerError(
-                    "Cannot move multi-channel pipette to non-tip rack labware north or south of Heater-Shaker"
+                    "Cannot move 8-Channel pipette to non-tip-rack labware adjacent to the front or back of Heater-Shaker"
                 )
 
     def is_pipette_blocking_shake_movement(
         self, pipette_location: Optional[Location]
     ) -> bool:
-        """Check whether pipette is parked adjacent to heater-shaker.
+        """Check whether pipette is parked adjacent to Heater-Shaker.
 
-        Returns True if pipette's last known location was on east/west/north/south of or
-        on the heater-shaker. Also returns True if last location is not known or is
+        Returns True if pipette's last known location was in a slot adjacent to or
+        on the Heater-Shaker. Also returns True if last location is not known or is
         not associated with a slot.
         """
         if pipette_location is None:
@@ -471,11 +471,11 @@ class HeaterShakerGeometry(ModuleGeometry):
     def is_pipette_blocking_latch_movement(
         self, pipette_location: Optional[Location]
     ) -> bool:
-        """Check whether pipette is parked east or west of heater-shaker.
+        """Check whether pipette is parked left or right of Heater-Shaker.
 
-        Returns True is pipette's last known location was on east/west of or on the
-        heater-shaker. Also returns True if last location is not known or is not
-        associated with a slot.
+        Returns True is pipette's last known location was on the Heater-Shaker
+        or in a slot adjacent to its left or right. Also returns True if last
+        location is not known or is not associated with a slot.
         """
         if pipette_location is None:
             # If we don't know the pipette's latest location then let's be extra
@@ -805,7 +805,7 @@ def resolve_module_model(module_model_or_load_name: str) -> ModuleModel:
         "thermocycler": ThermocyclerModuleModel.THERMOCYCLER_V1,
         "thermocycler module": ThermocyclerModuleModel.THERMOCYCLER_V1,
         "thermocycler module gen2": ThermocyclerModuleModel.THERMOCYCLER_V2,
-        # No alias for heater-shaker. Use heater-shaker model name for loading.
+        # No alias for Heater-Shaker. Use Heater-Shaker model name for loading.
     }
 
     lower_name = module_model_or_load_name.lower()

--- a/api/src/opentrons/protocols/geometry/module_geometry.py
+++ b/api/src/opentrons/protocols/geometry/module_geometry.py
@@ -434,7 +434,7 @@ class HeaterShakerGeometry(ModuleGeometry):
             # Can only go north/south if the labware is a tip rack
             elif dest_north_south and not is_tiprack:
                 raise PipetteMovementRestrictedByHeaterShakerError(
-                    "Cannot move 8-Channel pipette to non-tip-rack labware adjacent to the front or back of Heater-Shaker"
+                    "Cannot move 8-Channel pipette to non-tip-rack labware directly in front of or behind a Heater-Shaker"
                 )
 
     def is_pipette_blocking_shake_movement(

--- a/api/tests/opentrons/protocol_engine/execution/test_heater_shaker_movement_flagger.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_heater_shaker_movement_flagger.py
@@ -132,14 +132,16 @@ async def test_raises_when_moving_to_restricted_slots_while_latch_open(
             8,
             False,
             pytest.raises(
-                PipetteMovementRestrictedByHeaterShakerError, match="non-tip-rack labware"
+                PipetteMovementRestrictedByHeaterShakerError,
+                match="non-tip-rack labware",
             ),
         ],  # north, non-tiprack
         [
             2,
             False,
             pytest.raises(
-                PipetteMovementRestrictedByHeaterShakerError, match="non-tip-rack labware"
+                PipetteMovementRestrictedByHeaterShakerError,
+                match="non-tip-rack labware",
             ),
         ],  # south, non-tiprack
         [8, True, does_not_raise()],  # north, tiprack

--- a/api/tests/opentrons/protocol_engine/execution/test_heater_shaker_movement_flagger.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_heater_shaker_movement_flagger.py
@@ -118,28 +118,28 @@ async def test_raises_when_moving_to_restricted_slots_while_latch_open(
             4,
             False,
             pytest.raises(
-                PipetteMovementRestrictedByHeaterShakerError, match="east or west"
+                PipetteMovementRestrictedByHeaterShakerError, match="left or right"
             ),
         ],  # east
         [
             6,
             False,
             pytest.raises(
-                PipetteMovementRestrictedByHeaterShakerError, match="east or west"
+                PipetteMovementRestrictedByHeaterShakerError, match="left or right"
             ),
         ],  # west
         [
             8,
             False,
             pytest.raises(
-                PipetteMovementRestrictedByHeaterShakerError, match="tip rack"
+                PipetteMovementRestrictedByHeaterShakerError, match="non-tip-rack labware"
             ),
         ],  # north, non-tiprack
         [
             2,
             False,
             pytest.raises(
-                PipetteMovementRestrictedByHeaterShakerError, match="tip rack"
+                PipetteMovementRestrictedByHeaterShakerError, match="non-tip-rack labware"
             ),
         ],  # south, non-tiprack
         [8, True, does_not_raise()],  # north, tiprack

--- a/api/tests/opentrons/protocols/geometry/test_module_geometry.py
+++ b/api/tests/opentrons/protocols/geometry/test_module_geometry.py
@@ -308,28 +308,28 @@ def test_raises_when_moving_to_restricted_slots_while_latch_open(
             4,
             False,
             pytest.raises(
-                PipetteMovementRestrictedByHeaterShakerError, match="east or west"
+                PipetteMovementRestrictedByHeaterShakerError, match="left or right"
             ),
         ],  # east
         [
             6,
             False,
             pytest.raises(
-                PipetteMovementRestrictedByHeaterShakerError, match="east or west"
+                PipetteMovementRestrictedByHeaterShakerError, match="left or right"
             ),
         ],  # west
         [
             8,
             False,
             pytest.raises(
-                PipetteMovementRestrictedByHeaterShakerError, match="tip rack"
+                PipetteMovementRestrictedByHeaterShakerError, match="non-tip-rack labware"
             ),
         ],  # north, non-tiprack
         [
             2,
             False,
             pytest.raises(
-                PipetteMovementRestrictedByHeaterShakerError, match="tip rack"
+                PipetteMovementRestrictedByHeaterShakerError, match="non-tip-rack labware"
             ),
         ],  # south, non-tiprack
         [8, True, does_not_raise()],  # north, tiprack

--- a/api/tests/opentrons/protocols/geometry/test_module_geometry.py
+++ b/api/tests/opentrons/protocols/geometry/test_module_geometry.py
@@ -322,14 +322,16 @@ def test_raises_when_moving_to_restricted_slots_while_latch_open(
             8,
             False,
             pytest.raises(
-                PipetteMovementRestrictedByHeaterShakerError, match="non-tip-rack labware"
+                PipetteMovementRestrictedByHeaterShakerError,
+                match="non-tip-rack labware",
             ),
         ],  # north, non-tiprack
         [
             2,
             False,
             pytest.raises(
-                PipetteMovementRestrictedByHeaterShakerError, match="non-tip-rack labware"
+                PipetteMovementRestrictedByHeaterShakerError,
+                match="non-tip-rack labware",
             ),
         ],  # south, non-tiprack
         [8, True, does_not_raise()],  # north, tiprack


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

Aims to update all user-facing language (error strings, docstrings, etc.) so they describe slots adjacent to the Heater Shaker as "left (of)", "right (of)", "behind", or "in front of" it.

This does _not_ rename any internal functions that use the alternative terminology north/south/east/west and the comment strings directly associated with them. It does clean up some other comments.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

- Rewrote `PipetteMovementRestrictedByHeaterShakerError` strings
- more TK

# Review requests

<!--
Describe any requests for your reviewers here.
-->

- Check that this PR does in fact cover all uses of Heater-Shaker-adjacent slot terminology in simulation and in the app.

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

Low. Display strings, docs, and comments are affected.