### PR TITLE
refactor(protocol-designer): throw timeline error when heater shaker module id is missing

### DIFF
--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -873,6 +873,7 @@ export const savedStepForms = (
         } else if (
           (form.stepType === 'magnet' ||
             form.stepType === 'temperature' ||
+            form.stepType === 'heaterShaker' ||
             form.stepType === 'pause') &&
           form.moduleId === moduleId
         ) {

--- a/step-generation/src/__tests__/heaterShaker.test.ts
+++ b/step-generation/src/__tests__/heaterShaker.test.ts
@@ -4,7 +4,7 @@ import {
 } from '@opentrons/shared-data'
 import { heaterShaker } from '../commandCreators'
 import { getModuleState } from '../robotStateSelectors'
-import { getSuccessResult } from '../fixtures/commandFixtures'
+import { getErrorResult, getSuccessResult } from '../fixtures/commandFixtures'
 
 import type { InvariantContext, RobotState, HeaterShakerArgs } from '../types'
 import { getInitialRobotStateStandard, makeContext } from '../fixtures'
@@ -58,6 +58,18 @@ describe('heaterShaker compound command creator', () => {
   })
   afterEach(() => {
     jest.restoreAllMocks()
+  })
+  it('should return an error when there is no module id', () => {
+    heaterShakerArgs = {
+      ...heaterShakerArgs,
+      module: null,
+    }
+    const result = heaterShaker(heaterShakerArgs, invariantContext, robotState)
+
+    expect(getErrorResult(result).errors).toHaveLength(1)
+    expect(getErrorResult(result).errors[0]).toMatchObject({
+      type: 'MISSING_MODULE',
+    })
   })
   it('should delay and deactivate the heater shaker when a user specificies a timer', () => {
     heaterShakerArgs = {

--- a/step-generation/src/commandCreators/compound/heaterShaker.ts
+++ b/step-generation/src/commandCreators/compound/heaterShaker.ts
@@ -4,7 +4,6 @@ import {
   CommandCreator,
   CurriedCommandCreator,
   HeaterShakerArgs,
-  HeaterShakerModuleState,
 } from '../../types'
 import { getModuleState } from '../../robotStateSelectors'
 import { delay } from '../atomic/delay'
@@ -21,12 +20,14 @@ export const heaterShaker: CommandCreator<HeaterShakerArgs> = (
   invariantContext,
   prevRobotState
 ) => {
-  const heaterShakerState = getModuleState(
-    prevRobotState,
-    args.module
-  ) as HeaterShakerModuleState
+  if (args.module == null) {
+    return {
+      errors: [errorCreators.missingModuleError()],
+    }
+  }
+  const heaterShakerState = getModuleState(prevRobotState, args.module)
 
-  if (heaterShakerState === null) {
+  if (heaterShakerState == null) {
     return {
       errors: [errorCreators.missingModuleError()],
     }

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -323,7 +323,7 @@ export type SetShakeSpeedArgs = ShakeSpeedParams & {
 }
 
 export interface HeaterShakerArgs {
-  module: string
+  module: string | null
   rpm: number | null
   commandCreatorFnName: 'heaterShaker'
   targetTemperature: number | null


### PR DESCRIPTION
# Overview
This PR nulls out a HS module id in the HS step form when deleting a HS, and throws a corresponding timeline error when the module id is null

Closes #11280


# Review requests

Add a HS step, then delete the HS from the protocol. You should no longer get an unresponsive app, and you should see a timeline error in the HS step form.
# Risk assessment

Low
