### PR TITLE
refactor(protocol-designer): move liquids UI enhancements behind feature flag

### DIFF
--- a/protocol-designer/src/components/IngredientsList/index.tsx
+++ b/protocol-designer/src/components/IngredientsList/index.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import { useSelector } from 'react-redux'
 import { selectors } from '../../labware-ingred/selectors'
+import { selectors as featureFlagSelectors } from '../../feature-flags'
 import { IconButton, SidePanel } from '@opentrons/components'
 import { sortWells } from '@opentrons/shared-data'
 import { i18n } from '../../localization'
@@ -49,6 +50,9 @@ const LiquidGroupCard = (props: LiquidGroupCardProps): JSX.Element | null => {
     .sort(sortWells)
     .filter(well => labwareWellContents[well][groupId])
 
+  const enableLiquidColorEnhancements = useSelector(
+    featureFlagSelectors.getEnabledLiquidColorEnhancements
+  )
   const liquidDisplayColors = useSelector(selectors.getLiquidDisplayColors)
 
   if (wellsWithIngred.length < 1) {
@@ -61,7 +65,9 @@ const LiquidGroupCard = (props: LiquidGroupCardProps): JSX.Element | null => {
       title={ingredGroup.name || i18n.t('card.unnamedLiquid')}
       iconProps={{
         style: {
-          fill: liquidDisplayColors[Number(groupId)] ?? swatchColors(groupId),
+          fill: enableLiquidColorEnhancements
+            ? liquidDisplayColors[Number(groupId)] ?? swatchColors(groupId)
+            : swatchColors(groupId),
         },
       }}
       iconName="circle"

--- a/protocol-designer/src/components/LiquidsPage/LiquidEditForm.tsx
+++ b/protocol-designer/src/components/LiquidsPage/LiquidEditForm.tsx
@@ -13,6 +13,7 @@ import {
   PrimaryButton,
 } from '@opentrons/components'
 import { selectors } from '../../labware-ingred/selectors'
+import { selectors as featureFlagSelectors } from '../../feature-flags'
 import styles from './LiquidEditForm.css'
 import formStyles from '../forms/forms.css'
 
@@ -50,6 +51,9 @@ export const liquidEditFormSchema: Yup.Schema<
 
 export function LiquidEditForm(props: Props): JSX.Element {
   const { deleteLiquidGroup, cancelForm, canDelete, saveForm } = props
+  const enableLiquidColorEnhancements = useSelector(
+    featureFlagSelectors.getEnabledLiquidColorEnhancements
+  )
   const selectedLiquid = useSelector(selectors.getSelectedLiquidGroupState)
   const nextGroupId = useSelector(selectors.getNextLiquidGroupId)
   const liquidId = selectedLiquid.liquidGroupId ?? nextGroupId
@@ -114,16 +118,18 @@ export function LiquidEditForm(props: Props): JSX.Element {
                     onChange={handleChange}
                   />
                 </FormGroup>
-                <FormGroup label={i18n.t('form.liquid_edit.displayColor')}>
-                  <Field
-                    name="displayColor"
-                    component={ColorPicker}
-                    value={values.displayColor}
-                    onChange={(color: ColorResult['hex']) => {
-                      setFieldValue('displayColor', color)
-                    }}
-                  />
-                </FormGroup>
+                {enableLiquidColorEnhancements ? (
+                  <FormGroup label={i18n.t('form.liquid_edit.displayColor')}>
+                    <Field
+                      name="displayColor"
+                      component={ColorPicker}
+                      value={values.displayColor}
+                      onChange={(color: ColorResult['hex']) => {
+                        setFieldValue('displayColor', color)
+                      }}
+                    />
+                  </FormGroup>
+                ) : null}
               </div>
             </section>
 

--- a/protocol-designer/src/components/LiquidsSidebar/index.tsx
+++ b/protocol-designer/src/components/LiquidsSidebar/index.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react'
-import { connect } from 'react-redux'
+import { connect, useSelector } from 'react-redux'
 import { i18n } from '../../localization'
 import { PrimaryButton, SidePanel } from '@opentrons/components'
 import { PDTitledList } from '../lists'
 import { swatchColors } from '../swatchColors'
 import listButtonStyles from '../listButtons.css'
 
+import { selectors as featureFlagSelectors } from '../../feature-flags'
 import { selectors as labwareIngredSelectors } from '../../labware-ingred/selectors'
 import { OrderedLiquids } from '../../labware-ingred/types'
 import * as labwareIngredActions from '../../labware-ingred/actions'
@@ -27,6 +28,9 @@ type Props = SP & DP
 
 function LiquidsSidebarComponent(props: Props): JSX.Element {
   const { liquids, selectedLiquid, createNewLiquid, selectLiquid } = props
+  const enableLiquidColorEnhancements = useSelector(
+    featureFlagSelectors.getEnabledLiquidColorEnhancements
+  )
   return (
     <SidePanel title="Liquids">
       {liquids.map(({ ingredientId, name, displayColor }) => (
@@ -36,8 +40,14 @@ function LiquidsSidebarComponent(props: Props): JSX.Element {
           onClick={() => selectLiquid(ingredientId)}
           iconName="circle"
           iconProps={{
-            style: { fill: displayColor ?? swatchColors(ingredientId) },
-            className: styles.liquid_icon_container,
+            style: {
+              fill: enableLiquidColorEnhancements
+                ? displayColor ?? swatchColors(ingredientId)
+                : swatchColors(ingredientId),
+            },
+            ...(enableLiquidColorEnhancements && {
+              className: styles.liquid_icon_container,
+            }),
           }}
           title={name || `Unnamed Ingredient ${ingredientId}`} // fallback, should not happen
         />


### PR DESCRIPTION
# Overview

This PR moves the PD liquids UI enhancements behind the feature flag.

# Changelog

- Move UI changes and `ColorPicker` component behind the liquids enhancement feature flag.

# Review requests

- Check that when the feature flag is **disabled** none of the liquids UI enhancements are showing including the `ColorPicker` component.
- Check that when the feature flag is **enabled** all the liquids UI enhancements are showing including the `ColorPicker` component.

# Risk assessment

low, behind FF
