### PR TITLE
feat(update-server): advertise robotModel

### DIFF
--- a/update-server/otupdate/buildroot/__init__.py
+++ b/update-server/otupdate/buildroot/__init__.py
@@ -120,4 +120,5 @@ def health_response(version_dict: Mapping[str, str]) -> Mapping[str, Any]:
             "buildrootUpdate": "/server/update/begin",
             "restart": "/server/restart",
         },
+        "robotModel": constants.MODEL_OT2,
     }

--- a/update-server/otupdate/buildroot/__main__.py
+++ b/update-server/otupdate/buildroot/__main__.py
@@ -7,7 +7,7 @@ from typing import NoReturn
 
 from . import get_app
 
-from otupdate.common import name_management, cli, systemd
+from otupdate.common import name_management, cli, systemd, constants
 from otupdate.common.run_application import run_and_notify_up
 
 
@@ -26,7 +26,9 @@ async def main() -> NoReturn:
     static_hostname = await name_management.set_up_static_hostname()
     LOG.info(f"Set static hostname to {static_hostname}")
 
-    async with name_management.NameSynchronizer.start() as name_synchronizer:
+    async with name_management.NameSynchronizer.start(
+        constants.MODEL_OT2
+    ) as name_synchronizer:
         LOG.info("Building buildroot update server")
         app = await get_app(
             system_version_file=args.version_file,

--- a/update-server/otupdate/common/constants.py
+++ b/update-server/otupdate/common/constants.py
@@ -1,5 +1,7 @@
 """ Constants to avoid circular deps """
 
+from typing_extensions import Final
+
 APP_VARIABLE_PREFIX = "com.opentrons.otupdate.buildroot."
 #: Prefix for variables in the aiohttp.web.Application dictlike
 
@@ -19,3 +21,6 @@ DEVICE_BOOT_ID_NAME = APP_VARIABLE_PREFIX + "boot_id"
 #:
 #: This ID only changes when the whole OT-2 operating system reboots.
 #: It doesn't change if some internal process merely crashes and restarts.
+
+MODEL_OT2: Final[str] = "OT-2 Standard"
+MODEL_OT3: Final[str] = "OT-3 Standard"

--- a/update-server/otupdate/common/name_management/avahi.py
+++ b/update-server/otupdate/common/name_management/avahi.py
@@ -315,7 +315,9 @@ class _SyncClient:
             # supplementary txt record with encoded machine type. this is
             # a dbus byte array rather than a dbus string for some reason
             # so it has to be manually encoded.
-            dbus.Array([f"robotModel={machine_type}".encode('UTF-8')], signature="ay"),  # TXT records
+            dbus.Array(
+                [f"robotModel={machine_type}".encode("UTF-8")], signature="ay"
+            ),  # TXT records
         )
 
         self._entry_group.Commit()

--- a/update-server/otupdate/common/name_management/name_synchronizer.py
+++ b/update-server/otupdate/common/name_management/name_synchronizer.py
@@ -66,6 +66,9 @@ class NameSynchronizer:
         Collision monitoring will stop when this context manager exits.
 
         Args:
+            machine_type: The robot model to advertise. This will be set in a TXT
+                record as "robotModel=${machine_type}" for clients to use to
+                identify the robot.
             avahi_client: The interface for communicating with Avahi.
                 Changeable for testing this class; should normally be left as
                 the default.

--- a/update-server/otupdate/openembedded/__init__.py
+++ b/update-server/otupdate/openembedded/__init__.py
@@ -125,4 +125,5 @@ def health_response(version_dict: Mapping[str, str]) -> Mapping[str, Any]:
             "openembeddedUpdate": "/server/update/begin",
             "restart": "/server/restart",
         },
+        "robotModel": constants.MODEL_OT3,
     }

--- a/update-server/otupdate/openembedded/__main__.py
+++ b/update-server/otupdate/openembedded/__main__.py
@@ -7,7 +7,7 @@ from typing import NoReturn
 
 from . import get_app
 
-from otupdate.common import name_management, cli, systemd
+from otupdate.common import name_management, cli, systemd, constants
 from otupdate.common.run_application import run_and_notify_up
 
 
@@ -26,7 +26,9 @@ async def main() -> NoReturn:
     static_hostname = await name_management.set_up_static_hostname()
     LOG.info(f"Set static hostname to {static_hostname}")
 
-    async with name_management.NameSynchronizer.start() as name_synchronizer:
+    async with name_management.NameSynchronizer.start(
+        constants.MODEL_OT3
+    ) as name_synchronizer:
         LOG.info("Building openembedded update server")
         app = await get_app(
             system_version_file=args.version_file,

--- a/update-server/tests/buildroot/test_control.py
+++ b/update-server/tests/buildroot/test_control.py
@@ -31,4 +31,5 @@ async def test_health(
             "restart": "/server/restart",
         },
         "serialNumber": "unknown",
+        "robotModel": "OT-2 Standard",
     }

--- a/update-server/tests/openembedded/test_control.py
+++ b/update-server/tests/openembedded/test_control.py
@@ -31,4 +31,5 @@ async def test_health(
             "restart": "/server/restart",
         },
         "serialNumber": "unknown",
+        "robotModel": "OT-3 Standard",
     }


### PR DESCRIPTION
The robot model is being advertised by the robot server's health
endpoint, which is good but not sufficient to robustly identify a
machine to a client across all its possible connection states and
styles.

This PR adds the robot model to
- The update server health endpoint
- a TXT record in the MDNS advertisement

This should allow identification of the machine model to be robust
across machines that are found on MDNS but unreachable; machines that
are connected with IPs with no MDNS advertisement; and everything in
between.

It does create a possible conflict (though the machine type is static
data that should not conflict). Resolution mechanisms in clients should
follow these rules:

- When more than one source (i.e. of update-server health, robot-server
health, and TXT record) is presenting a valid machine type, prioritize
in the order of 1) robot server; 2) update server; 3) MDNS
- If any source is not present (i.e. requests to `/health` or `/server/health` fail, or the MDNS advertisement is not found); or a source does not have the appropriate key (robot_model for
robot-server health, robotModel for
update-server health, the TXT record robotModel for MDNS), that source
should be disregarded
- If no source is present with a valid model entry, the robot may be assumed to be an OT-2 for now, though in the future this should be an explicit unknown-model state.

Closes RCORE-66

## Testing
- Run this on an OT-2 and OT-3
- Each should appropriately report its machine type, including on mdns
   -  it's hard to see this in MDNS; osx dns-sd can probably do it but I don't know how. You can use the wireshark query `ip.addr == 192.168.1.153 and udp.port eq 5353` (where you replace 192.168.1.153 with the ip of the robot you're testing) and look for a packet like this: `236	8.135402	192.168.1.153	224.0.0.251	MDNS	193	Standard query response 0x0000 TXT, cache flush PTR OliverT._http._tcp.local SRV, cache flush 0 0 31950 4849db.local PTR _http._tcp.local` and expand the response section to see the content