### PR TITLE
refactor(protocol-designer): adjust tip positioning graphic

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionZAxisViz.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionZAxisViz.tsx
@@ -6,7 +6,7 @@ import WELL_CROSS_SECTION_IMAGE from '../../../../images/well_cross_section.svg'
 
 import styles from './TipPositionInput.css'
 
-const WELL_HEIGHT_PIXELS = 48
+const WELL_HEIGHT_PIXELS = 145
 const PIXEL_DECIMALS = 2
 interface Props {
   mmFromBottom: number


### PR DESCRIPTION
closes RQA-164

# Overview

tip positioning graphic was too high, this PR fixes it to depict 1mm from the bottom more accurately

<img width="646" alt="Screen Shot 2022-08-05 at 12 01 56 PM" src="https://user-images.githubusercontent.com/66035149/183116383-273c16da-64fe-4bab-9d8e-35d5337a368c.png">

# Changelog

- change value in `TipPositionZAxisViz`

# Review requests

- is image more accurate?

# Risk assessment

low