### PR TITLE
refactor(protocol-designer): add overflow-wrap to labware overlay text

### DIFF
--- a/components/src/legacy-hardware-sim/LabwareNameOverlay.css
+++ b/components/src/legacy-hardware-sim/LabwareNameOverlay.css
@@ -13,6 +13,7 @@
   font-weight: var(--fw-semibold);
   color: var(--c-font-light);
   text-transform: uppercase;
+  overflow-wrap: break-word;
 }
 
 .deck_slot:active {


### PR DESCRIPTION
closes RQA-165

# Overview

overlay text now goes onto another line if it is 1 word and too long to fit on 1 line. This component is used in a few other areas but i think this addition shouldn't affect any of those instances negatively. 

<img width="176" alt="Screen Shot 2022-08-05 at 12 22 25 PM" src="https://user-images.githubusercontent.com/66035149/183119784-2b91f5f9-42ed-420b-8f61-ae152eff9f88.png">

# Changelog

- add `overflow-wrap` to `LabwareNameOverlay.css`

# Review requests

- add a labware in PD and add a very long 1 word nickname. Should be able to see whole nickname now

# Risk assessment

low