### PR TITLE
refactor(discovery-client,app): robust robot model detection

### DIFF
--- a/app-shell/src/__tests__/discovery.test.ts
+++ b/app-shell/src/__tests__/discovery.test.ts
@@ -294,6 +294,7 @@ describe('app-shell/discovery', () => {
                   serverHealthStatus: null,
                   healthError: null,
                   serverHealthError: null,
+                  advertisedModel: null,
                 },
                 {
                   ip: '169.254.92.130',
@@ -303,6 +304,7 @@ describe('app-shell/discovery', () => {
                   serverHealthStatus: null,
                   healthError: null,
                   serverHealthError: null,
+                  advertisedModel: null,
                 },
                 {
                   ip: '169.254.239.127',
@@ -312,6 +314,7 @@ describe('app-shell/discovery', () => {
                   serverHealthStatus: null,
                   healthError: null,
                   serverHealthError: null,
+                  advertisedModel: null,
                 },
               ],
             },

--- a/app-shell/src/discovery.ts
+++ b/app-shell/src/discovery.ts
@@ -71,6 +71,7 @@ const migrateLegacyServices = (
               serverHealthStatus: null,
               healthError: null,
               serverHealthError: null,
+              advertisedModel: null,
             },
           ]
         : []

--- a/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
@@ -213,7 +213,7 @@ describe('ChooseRobotSlideout', () => {
   })
   it('if selected robot is on a different version of the software than the app, disable CTA and show link to device details in options', () => {
     when(mockGetBuildrootUpdateDisplayInfo)
-      .calledWith((undefined as any) as State, 'opentrons-robot-name')
+      .calledWith(({} as any) as State, 'opentrons-robot-name')
       .mockReturnValue({
         autoUpdateAction: 'upgrade',
         autoUpdateDisabledReason: null,

--- a/app/src/organisms/Devices/RobotCard.tsx
+++ b/app/src/organisms/Devices/RobotCard.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 import { Link, useHistory } from 'react-router-dom'
 import { css } from 'styled-components'
@@ -23,7 +24,11 @@ import { getModuleDisplayName } from '@opentrons/shared-data'
 import OT2_PNG from '../../assets/images/OT2-R_HERO.png'
 import { StyledText } from '../../atoms/text'
 import { SecondaryTertiaryButton } from '../../atoms/buttons'
-import { CONNECTABLE, UNREACHABLE } from '../../redux/discovery'
+import {
+  CONNECTABLE,
+  UNREACHABLE,
+  getRobotModelByName,
+} from '../../redux/discovery'
 import { ModuleIcon } from '../../molecules/ModuleIcon'
 import { useCurrentRunId } from '../../organisms/ProtocolUpload/hooks'
 import { useCurrentRunStatus } from '../../organisms/RunTimeControl/hooks'
@@ -37,6 +42,7 @@ import { ReachableBanner } from './ReachableBanner'
 import { RobotOverflowMenu } from './RobotOverflowMenu'
 
 import type { DiscoveredRobot } from '../../redux/discovery/types'
+import type { State } from '../../redux/types'
 
 const ROBOT_CARD_STYLE = css`
   border: 1px solid ${COLORS.medGrey};
@@ -77,6 +83,9 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
   const { robot } = props
   const { name: robotName = null, local } = robot
   const history = useHistory()
+  const robotModel = useSelector((state: State) =>
+    getRobotModelByName(state, robot?.name)
+  )?.split(' ')[0]
 
   return robotName != null ? (
     <Flex
@@ -108,7 +117,7 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
               color={COLORS.darkGreyEnabled}
             >
               {/* robot_model can be seen in the health response, but only for "connectable" robots. Probably best to leave as "OT-2" for now */}
-              OT-2
+              {robotModel}
             </StyledText>
             <Flex alignItems={ALIGN_CENTER} paddingBottom={SPACING.spacing4}>
               <Flex alignItems={ALIGN_CENTER}>

--- a/app/src/organisms/Devices/RobotCard.tsx
+++ b/app/src/organisms/Devices/RobotCard.tsx
@@ -87,8 +87,6 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
     getRobotModelByName(state, robot?.name)
   )
 
-  console.log('robotModel', robotModel)
-
   return robotName != null ? (
     <Flex
       alignItems={ALIGN_CENTER}

--- a/app/src/organisms/Devices/RobotCard.tsx
+++ b/app/src/organisms/Devices/RobotCard.tsx
@@ -85,7 +85,9 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
   const history = useHistory()
   const robotModel = useSelector((state: State) =>
     getRobotModelByName(state, robot?.name)
-  )?.split(' ')[0]
+  )
+
+  console.log('robotModel', robotModel)
 
   return robotName != null ? (
     <Flex

--- a/app/src/organisms/Devices/RobotCard.tsx
+++ b/app/src/organisms/Devices/RobotCard.tsx
@@ -116,7 +116,6 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
               id={`RobotStatusBanner_${robotName}_robotModel`}
               color={COLORS.darkGreyEnabled}
             >
-              {/* robot_model can be seen in the health response, but only for "connectable" robots. Probably best to leave as "OT-2" for now */}
               {robotModel}
             </StyledText>
             <Flex alignItems={ALIGN_CENTER} paddingBottom={SPACING.spacing4}>

--- a/app/src/organisms/Devices/RobotStatusBanner.tsx
+++ b/app/src/organisms/Devices/RobotStatusBanner.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 
@@ -18,8 +19,10 @@ import { StyledText } from '../../atoms/text'
 import { useCurrentRunId } from '../../organisms/ProtocolUpload/hooks'
 import { useCurrentRunStatus } from '../../organisms/RunTimeControl/hooks'
 import { useProtocolDetailsForRun } from './hooks'
+import { getRobotModelByName } from '../../redux/discovery'
 
 import type { DiscoveredRobot } from '../../redux/discovery/types'
+import type { State } from '../../redux/types'
 
 type RobotStatusBannerProps = Pick<DiscoveredRobot, 'name' | 'local'>
 
@@ -30,6 +33,9 @@ export function RobotStatusBanner(props: RobotStatusBannerProps): JSX.Element {
   const currentRunId = useCurrentRunId()
   const currentRunStatus = useCurrentRunStatus()
   const { displayName } = useProtocolDetailsForRun(currentRunId)
+  const robotModel = useSelector((state: State) =>
+    getRobotModelByName(state, name)
+  )?.split(' ')[0]
 
   const runningProtocolBanner: JSX.Element | null =
     currentRunId != null ? (
@@ -63,7 +69,7 @@ export function RobotStatusBanner(props: RobotStatusBannerProps): JSX.Element {
           paddingBottom={SPACING.spacing1}
           id={`RobotStatusBanner_${name}_robotModel`}
         >
-          OT-2
+          {robotModel}
         </StyledText>
         <Flex alignItems={ALIGN_CENTER} paddingBottom={SPACING.spacing4}>
           <Flex alignItems={ALIGN_CENTER}>

--- a/app/src/organisms/Devices/RobotStatusBanner.tsx
+++ b/app/src/organisms/Devices/RobotStatusBanner.tsx
@@ -60,8 +60,6 @@ export function RobotStatusBanner(props: RobotStatusBannerProps): JSX.Element {
 
   return (
     <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
-      {/* robot_model can be seen in the health response, but only for "connectable" robots.
-    Probably best to leave as "OT-2" for now */}
       <Flex flexDirection={DIRECTION_COLUMN}>
         <StyledText
           as="h6"

--- a/app/src/organisms/Devices/RobotStatusBanner.tsx
+++ b/app/src/organisms/Devices/RobotStatusBanner.tsx
@@ -37,8 +37,6 @@ export function RobotStatusBanner(props: RobotStatusBannerProps): JSX.Element {
     getRobotModelByName(state, name)
   )
 
-  console.log('robotModel', robotModel)
-
   const runningProtocolBanner: JSX.Element | null =
     currentRunId != null ? (
       <Flex alignItems={ALIGN_CENTER}>

--- a/app/src/organisms/Devices/RobotStatusBanner.tsx
+++ b/app/src/organisms/Devices/RobotStatusBanner.tsx
@@ -35,7 +35,9 @@ export function RobotStatusBanner(props: RobotStatusBannerProps): JSX.Element {
   const { displayName } = useProtocolDetailsForRun(currentRunId)
   const robotModel = useSelector((state: State) =>
     getRobotModelByName(state, name)
-  )?.split(' ')[0]
+  )
+
+  console.log('robotModel', robotModel)
 
   const runningProtocolBanner: JSX.Element | null =
     currentRunId != null ? (

--- a/app/src/organisms/Devices/__tests__/RobotCard.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotCard.test.tsx
@@ -173,7 +173,7 @@ describe('RobotCard', () => {
       })
     when(mockGetRobotModelByName)
       .calledWith(MOCK_STATE, mockConnectableRobot.name)
-      .mockReturnValue(ROBOT_MODEL_OT2)
+      .mockReturnValue('OT-2')
   })
   afterEach(() => {
     jest.resetAllMocks()
@@ -217,7 +217,7 @@ describe('RobotCard', () => {
     props = { robot: { ...mockConnectableRobot, name: 'buzz' } }
     when(mockGetRobotModelByName)
       .calledWith(MOCK_STATE, 'buzz')
-      .mockReturnValue(ROBOT_MODEL_OT3)
+      .mockReturnValue('OT-3')
     const [{ getByText }] = render(props)
     getByText('OT-3')
     getByText('buzz')

--- a/app/src/organisms/Devices/__tests__/RobotCard.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotCard.test.tsx
@@ -14,6 +14,11 @@ import {
 } from '../../../redux/pipettes/__fixtures__'
 import { mockConnectableRobot } from '../../../redux/discovery/__fixtures__'
 import { getBuildrootUpdateDisplayInfo } from '../../../redux/buildroot'
+import { getRobotModelByName } from '../../../redux/discovery'
+import {
+  ROBOT_MODEL_OT2,
+  ROBOT_MODEL_OT3,
+} from '../../../redux/discovery/constants'
 import {
   useAttachedModules,
   useAttachedPipettes,
@@ -28,6 +33,7 @@ import { RobotCard } from '../RobotCard'
 import type { ProtocolAnalysisFile } from '@opentrons/shared-data'
 
 jest.mock('../../../redux/buildroot/selectors')
+jest.mock('../../../redux/discovery/selectors')
 jest.mock('../../../organisms/ProtocolUpload/hooks')
 jest.mock('../../../organisms/RunTimeControl/hooks')
 jest.mock('../../ProtocolUpload/hooks')
@@ -60,6 +66,9 @@ const mockUpdateRobotBanner = UpdateRobotBanner as jest.MockedFunction<
 >
 const mockGetBuildrootUpdateDisplayInfo = getBuildrootUpdateDisplayInfo as jest.MockedFunction<
   typeof getBuildrootUpdateDisplayInfo
+>
+const mockGetRobotModelByName = getRobotModelByName as jest.MockedFunction<
+  typeof getRobotModelByName
 >
 
 const simpleV6Protocol = (_uncastedSimpleV6Protocol as unknown) as ProtocolAnalysisFile<{}>
@@ -109,6 +118,7 @@ describe('RobotCard', () => {
         protocolData: {} as ProtocolAnalysisFile<{}>,
         protocolKey: null,
       })
+    mockGetRobotModelByName.mockReturnValue(ROBOT_MODEL_OT2)
   })
   afterEach(() => {
     jest.resetAllMocks()
@@ -142,9 +152,16 @@ describe('RobotCard', () => {
     getByText('Modules')
   })
 
-  it('renders the type of robot and robot name', () => {
+  it('renders the model of robot and robot name - OT-2', () => {
     const [{ getByText }] = render()
     getByText('OT-2')
+    getByText(mockConnectableRobot.name)
+  })
+
+  it('renders the model of robot and robot name - OT-3', () => {
+    mockGetRobotModelByName.mockReturnValue(ROBOT_MODEL_OT3)
+    const [{ getByText }] = render()
+    getByText('OT-3')
     getByText(mockConnectableRobot.name)
   })
 

--- a/app/src/organisms/Devices/__tests__/RobotStatusBanner.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotStatusBanner.test.tsx
@@ -125,7 +125,7 @@ describe('RobotStatusBanner', () => {
       })
     when(mockGetRobotModelByName)
       .calledWith(MOCK_STATE, 'otie')
-      .mockReturnValue(ROBOT_MODEL_OT2)
+      .mockReturnValue('OT-2')
   })
   afterEach(() => {
     resetAllWhenMocks()
@@ -141,7 +141,7 @@ describe('RobotStatusBanner', () => {
     props.name = 'buzz'
     when(mockGetRobotModelByName)
       .calledWith(MOCK_STATE, props.name)
-      .mockReturnValue(ROBOT_MODEL_OT3)
+      .mockReturnValue('OT-3')
     const [{ getByText }] = render(props)
     getByText('OT-3')
     getByText('buzz')

--- a/app/src/organisms/Devices/__tests__/RobotStatusBanner.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotStatusBanner.test.tsx
@@ -7,17 +7,27 @@ import { renderWithProviders } from '@opentrons/components'
 import _uncastedSimpleV6Protocol from '@opentrons/shared-data/protocol/fixtures/6/simpleV6.json'
 
 import { i18n } from '../../../i18n'
+import { getRobotModelByName } from '../../../redux/discovery'
+import {
+  ROBOT_MODEL_OT2,
+  ROBOT_MODEL_OT3,
+} from '../../../redux/discovery/constants'
 import { useCurrentRunId } from '../../../organisms/ProtocolUpload/hooks'
 import { useCurrentRunStatus } from '../../../organisms/RunTimeControl/hooks'
 import { useProtocolDetailsForRun } from '../hooks'
+
 import { RobotStatusBanner } from '../RobotStatusBanner'
 
 import type { ProtocolAnalysisFile } from '@opentrons/shared-data'
 
+jest.mock('../../../redux/discovery/selectors')
 jest.mock('../../../organisms/ProtocolUpload/hooks')
 jest.mock('../../../organisms/RunTimeControl/hooks')
 jest.mock('../hooks')
 
+const mockGetRobotModelByName = getRobotModelByName as jest.MockedFunction<
+  typeof getRobotModelByName
+>
 const mockUseCurrentRunId = useCurrentRunId as jest.MockedFunction<
   typeof useCurrentRunId
 >
@@ -49,6 +59,7 @@ const render = () => {
 
 describe('RobotStatusBanner', () => {
   beforeEach(() => {
+    mockGetRobotModelByName.mockReturnValue(ROBOT_MODEL_OT2)
     when(mockUseCurrentRunId).calledWith().mockReturnValue(null)
     when(mockUseCurrentRunStatus).calledWith().mockReturnValue(null)
     when(mockUseProtocolDetailsForRun)
@@ -63,9 +74,16 @@ describe('RobotStatusBanner', () => {
     resetAllWhenMocks()
   })
 
-  it('renders the type of robot and robot name', () => {
+  it('renders the model of robot and robot name - OT-2', () => {
     const [{ getByText }] = render()
     getByText('OT-2')
+    getByText('otie')
+  })
+
+  it('renders the model of robot and robot name - OT-3', () => {
+    mockGetRobotModelByName.mockReturnValue(ROBOT_MODEL_OT3)
+    const [{ getByText }] = render()
+    getByText('OT-3')
     getByText('otie')
   })
 

--- a/app/src/redux/discovery/__fixtures__/index.ts
+++ b/app/src/redux/discovery/__fixtures__/index.ts
@@ -58,6 +58,7 @@ export const mockBaseRobot: BaseRobot = {
   local: null,
   health: null,
   serverHealth: null,
+  robotModel: 'OT-2 Standard',
 }
 
 export const mockConnectableRobot: Robot = {

--- a/app/src/redux/discovery/__tests__/selectors.test.ts
+++ b/app/src/redux/discovery/__tests__/selectors.test.ts
@@ -1,7 +1,11 @@
 // discovery selectors tests
 import {
-  mockHealthResponse,
-  mockServerHealthResponse,
+  mockLegacyHealthResponse,
+  mockLegacyServerHealthResponse,
+  mockOT2HealthResponse,
+  mockOT2ServerHealthResponse,
+  mockOT3HealthResponse,
+  mockOT3ServerHealthResponse,
   mockHealthErrorStringResponse,
   mockHealthFetchErrorResponse,
 } from '@opentrons/discovery-client/src/__fixtures__'
@@ -13,6 +17,8 @@ import {
   CONNECTABLE,
   REACHABLE,
   UNREACHABLE,
+  ROBOT_MODEL_OT2,
+  ROBOT_MODEL_OT3,
 } from '../constants'
 
 import * as discovery from '../selectors'
@@ -25,7 +31,7 @@ const MOCK_STATE: State = {
     robotsByName: {
       foo: {
         name: 'foo',
-        health: mockHealthResponse,
+        health: mockLegacyHealthResponse,
         serverHealth: null,
         addresses: [
           {
@@ -36,13 +42,14 @@ const MOCK_STATE: State = {
             serverHealthStatus: HEALTH_STATUS_NOT_OK,
             healthError: null,
             serverHealthError: mockHealthErrorStringResponse,
+            advertisedModel: null,
           },
         ],
       },
       bar: {
         name: 'bar',
-        health: mockHealthResponse,
-        serverHealth: mockServerHealthResponse,
+        health: mockLegacyHealthResponse,
+        serverHealth: mockLegacyServerHealthResponse,
         addresses: [
           {
             ip: '10.0.0.2',
@@ -52,13 +59,14 @@ const MOCK_STATE: State = {
             serverHealthStatus: HEALTH_STATUS_OK,
             healthError: null,
             serverHealthError: null,
+            advertisedModel: null,
           },
         ],
       },
       baz: {
         name: 'baz',
-        health: mockHealthResponse,
-        serverHealth: mockServerHealthResponse,
+        health: mockOT2HealthResponse,
+        serverHealth: mockOT2ServerHealthResponse,
         addresses: [
           {
             ip: '10.0.0.3',
@@ -68,13 +76,14 @@ const MOCK_STATE: State = {
             serverHealthStatus: HEALTH_STATUS_OK,
             healthError: mockHealthErrorStringResponse,
             serverHealthError: null,
+            advertisedModel: ROBOT_MODEL_OT2,
           },
         ],
       },
       qux: {
         name: 'qux',
-        health: mockHealthResponse,
-        serverHealth: mockServerHealthResponse,
+        health: mockOT3HealthResponse,
+        serverHealth: mockOT3ServerHealthResponse,
         addresses: [
           {
             ip: '10.0.0.4',
@@ -84,13 +93,14 @@ const MOCK_STATE: State = {
             serverHealthStatus: HEALTH_STATUS_UNREACHABLE,
             healthError: mockHealthFetchErrorResponse,
             serverHealthError: mockHealthFetchErrorResponse,
+            advertisedModel: ROBOT_MODEL_OT3,
           },
         ],
       },
       fizz: {
         name: 'fizz',
-        health: mockHealthResponse,
-        serverHealth: mockServerHealthResponse,
+        health: mockOT2HealthResponse,
+        serverHealth: mockOT2ServerHealthResponse,
         addresses: [
           {
             ip: '10.0.0.5',
@@ -100,21 +110,40 @@ const MOCK_STATE: State = {
             serverHealthStatus: HEALTH_STATUS_UNREACHABLE,
             healthError: mockHealthFetchErrorResponse,
             serverHealthError: mockHealthFetchErrorResponse,
+            advertisedModel: ROBOT_MODEL_OT2,
           },
         ],
       },
       buzz: {
         name: 'buzz',
-        health: mockHealthResponse,
-        serverHealth: mockServerHealthResponse,
+        health: mockOT2HealthResponse,
+        serverHealth: mockOT2ServerHealthResponse,
         addresses: [],
+        advertisedModel: ROBOT_MODEL_OT2,
+      },
+      fizzbuzz: {
+        name: 'fizzbuzz',
+        health: mockOT3HealthResponse,
+        serverHealth: mockOT3ServerHealthResponse,
+        addresses: [
+          {
+            ip: '10.0.0.2',
+            port: 31950,
+            seen: true,
+            healthStatus: HEALTH_STATUS_OK,
+            serverHealthStatus: HEALTH_STATUS_OK,
+            healthError: null,
+            serverHealthError: null,
+            advertisedModel: ROBOT_MODEL_OT3,
+          },
+        ],
       },
     },
   },
 } as any
 
 // foo is connectable because health is defined and healthStatus of primary
-// address is "ok"
+// address is "ok". These are all saying it's an OT-2, so it's an OT-2
 const EXPECTED_FOO = {
   name: 'foo',
   displayName: 'foo',
@@ -122,12 +151,13 @@ const EXPECTED_FOO = {
   connected: false,
   local: false,
   seen: true,
-  health: mockHealthResponse,
+  health: mockLegacyHealthResponse,
   serverHealth: null,
   healthStatus: HEALTH_STATUS_OK,
   serverHealthStatus: HEALTH_STATUS_NOT_OK,
   ip: '10.0.0.1',
   port: 31950,
+  robotModel: ROBOT_MODEL_OT2,
 }
 
 // bar is connectable because health is defined and healthStatus of primary
@@ -139,16 +169,18 @@ const EXPECTED_BAR = {
   connected: true,
   local: false,
   seen: true,
-  health: mockHealthResponse,
-  serverHealth: mockServerHealthResponse,
+  health: mockLegacyHealthResponse,
+  serverHealth: mockLegacyServerHealthResponse,
   healthStatus: HEALTH_STATUS_OK,
   serverHealthStatus: HEALTH_STATUS_OK,
   ip: '10.0.0.2',
   port: 31950,
+  robotModel: ROBOT_MODEL_OT2,
 }
 
 // baz is reachable because healthStatus is "notOk", which means it responded
-// with an error code
+// with an error code. The cached health values still indicate that it's an
+// OT-2.
 const EXPECTED_BAZ = {
   name: 'baz',
   displayName: 'baz',
@@ -156,16 +188,18 @@ const EXPECTED_BAZ = {
   connected: false,
   local: false,
   seen: true,
-  health: mockHealthResponse,
-  serverHealth: mockServerHealthResponse,
+  health: mockOT2HealthResponse,
+  serverHealth: mockOT2ServerHealthResponse,
   healthStatus: HEALTH_STATUS_NOT_OK,
   serverHealthStatus: HEALTH_STATUS_OK,
   ip: '10.0.0.3',
   port: 31950,
+  robotModel: ROBOT_MODEL_OT2,
 }
 
 // qux is reachable because it was recently seen, even though primary IP is
-// not currently responding in any way
+// not currently responding in any way. Cached health responses have no model
+// data, but the MDNS data says it's an OT-3.
 const EXPECTED_QUX = {
   name: 'qux',
   displayName: 'qux',
@@ -173,16 +207,18 @@ const EXPECTED_QUX = {
   connected: false,
   local: false,
   seen: true,
-  health: mockHealthResponse,
-  serverHealth: mockServerHealthResponse,
+  health: mockOT3HealthResponse,
+  serverHealth: mockOT3ServerHealthResponse,
   healthStatus: HEALTH_STATUS_UNREACHABLE,
   serverHealthStatus: HEALTH_STATUS_UNREACHABLE,
   ip: '10.0.0.4',
   port: 31950,
+  robotModel: ROBOT_MODEL_OT3,
 }
 
 // fizz is unreachable because IP is unreachable and we haven't seen any of
-// this robot's IP addresses recently
+// this robot's IP addresses recently. Cached health responses indicate it's
+// an OT-2.
 const EXPECTED_FIZZ = {
   name: 'fizz',
   displayName: 'fizz',
@@ -190,12 +226,13 @@ const EXPECTED_FIZZ = {
   connected: false,
   local: false,
   seen: false,
-  health: mockHealthResponse,
-  serverHealth: mockServerHealthResponse,
+  health: mockOT2HealthResponse,
+  serverHealth: mockOT2ServerHealthResponse,
   healthStatus: HEALTH_STATUS_UNREACHABLE,
   serverHealthStatus: HEALTH_STATUS_UNREACHABLE,
   ip: '10.0.0.5',
   port: 31950,
+  robotModel: ROBOT_MODEL_OT2,
 }
 
 // buzz is unreachable because we don't have any IP addresses for it
@@ -206,12 +243,31 @@ const EXPECTED_BUZZ = {
   connected: false,
   local: null,
   seen: false,
-  health: mockHealthResponse,
-  serverHealth: mockServerHealthResponse,
+  health: mockOT2HealthResponse,
+  serverHealth: mockOT2ServerHealthResponse,
   healthStatus: null,
   serverHealthStatus: null,
   ip: null,
   port: null,
+  advertisedModel: ROBOT_MODEL_OT2,
+  robotModel: ROBOT_MODEL_OT2,
+}
+
+// fizzbuzz is as foo and therefore connectable, but is an OT-3
+const EXPECTED_FIZZBUZZ = {
+  name: 'fizzbuzz',
+  displayName: 'fizzbuzz',
+  status: CONNECTABLE,
+  connected: false,
+  local: false,
+  seen: true,
+  health: mockOT3HealthResponse,
+  serverHealth: mockOT3ServerHealthResponse,
+  healthStatus: HEALTH_STATUS_OK,
+  serverHealthStatus: HEALTH_STATUS_OK,
+  ip: '10.0.0.2',
+  port: 31950,
+  robotModel: ROBOT_MODEL_OT3,
 }
 
 describe('discovery selectors', () => {
@@ -246,13 +302,14 @@ describe('discovery selectors', () => {
         EXPECTED_QUX,
         EXPECTED_FIZZ,
         EXPECTED_BUZZ,
+        EXPECTED_FIZZBUZZ,
       ],
     },
     {
       name: 'getConnectableRobots grabs robots with connectable status',
       selector: discovery.getConnectableRobots,
       state: MOCK_STATE,
-      expected: [EXPECTED_FOO, EXPECTED_BAR],
+      expected: [EXPECTED_FOO, EXPECTED_BAR, EXPECTED_FIZZBUZZ],
     },
     {
       name: 'getReachableRobots grabs robots with reachable status',
@@ -274,8 +331,8 @@ describe('discovery selectors', () => {
           robotsByName: {
             'opentrons-foo': {
               name: 'opentrons-foo',
-              health: mockHealthResponse,
-              serverHealth: mockServerHealthResponse,
+              health: mockOT2HealthResponse,
+              serverHealth: mockOT2ServerHealthResponse,
               addresses: [],
             },
           },
@@ -295,8 +352,8 @@ describe('discovery selectors', () => {
           robotsByName: {
             'opentrons-foo': {
               name: 'opentrons-foo',
-              health: mockHealthResponse,
-              serverHealth: mockServerHealthResponse,
+              health: mockLegacyHealthResponse,
+              serverHealth: mockLegacyServerHealthResponse,
               addresses: [
                 {
                   ip: 'fd00:0:cafe:fefe::1',
@@ -306,6 +363,7 @@ describe('discovery selectors', () => {
                   serverHealthStatus: HEALTH_STATUS_UNREACHABLE,
                   healthError: null,
                   serverHealthError: mockHealthFetchErrorResponse,
+                  advertisedModel: null,
                 },
               ],
             },
@@ -325,7 +383,13 @@ describe('discovery selectors', () => {
       name: 'getViewableRobots returns connectable and reachable robots',
       selector: discovery.getViewableRobots,
       state: MOCK_STATE,
-      expected: [EXPECTED_FOO, EXPECTED_BAR, EXPECTED_BAZ, EXPECTED_QUX],
+      expected: [
+        EXPECTED_FOO,
+        EXPECTED_BAR,
+        EXPECTED_FIZZBUZZ,
+        EXPECTED_BAZ,
+        EXPECTED_QUX,
+      ],
     },
     {
       name: 'getConnectedRobot returns connected robot if connectable',
@@ -510,6 +574,34 @@ describe('discovery selectors', () => {
       state: MOCK_STATE,
       args: ['baz'],
       expected: EXPECTED_BAZ.health.api_version,
+    },
+    {
+      name: 'getRobotType returns type of a connectable OT-3',
+      selector: discovery.getRobotModelByName,
+      state: MOCK_STATE,
+      args: ['fizzbuzz'],
+      expected: EXPECTED_FIZZBUZZ.robotModel,
+    },
+    {
+      name: 'getRobotType returns type of a connectable OT-2',
+      selector: discovery.getRobotModelByName,
+      state: MOCK_STATE,
+      args: ['foo'],
+      expected: EXPECTED_FOO.robotModel,
+    },
+    {
+      name: 'getRobotType returns OT-2 for a reachable but cached robot',
+      selector: discovery.getRobotModelByName,
+      state: MOCK_STATE,
+      args: ['baz'],
+      expected: EXPECTED_BAZ.robotModel,
+    },
+    {
+      name: 'getRobotType returns OT-2 by default for an unreachable robot',
+      selector: discovery.getRobotModelByName,
+      state: MOCK_STATE,
+      args: ['qux'],
+      expected: EXPECTED_QUX.robotModel,
     },
   ]
 

--- a/app/src/redux/discovery/__tests__/selectors.test.ts
+++ b/app/src/redux/discovery/__tests__/selectors.test.ts
@@ -580,28 +580,28 @@ describe('discovery selectors', () => {
       selector: discovery.getRobotModelByName,
       state: MOCK_STATE,
       args: ['fizzbuzz'],
-      expected: EXPECTED_FIZZBUZZ.robotModel,
+      expected: 'OT-3',
     },
     {
       name: 'getRobotType returns type of a connectable OT-2',
       selector: discovery.getRobotModelByName,
       state: MOCK_STATE,
       args: ['foo'],
-      expected: EXPECTED_FOO.robotModel,
+      expected: 'OT-2',
     },
     {
       name: 'getRobotType returns OT-2 for a reachable but cached robot',
       selector: discovery.getRobotModelByName,
       state: MOCK_STATE,
       args: ['baz'],
-      expected: EXPECTED_BAZ.robotModel,
+      expected: 'OT-2',
     },
     {
       name: 'getRobotType returns OT-2 by default for an unreachable robot',
       selector: discovery.getRobotModelByName,
       state: MOCK_STATE,
       args: ['qux'],
-      expected: EXPECTED_QUX.robotModel,
+      expected: 'OT-3',
     },
   ]
 

--- a/app/src/redux/discovery/constants.ts
+++ b/app/src/redux/discovery/constants.ts
@@ -1,6 +1,8 @@
 export const CONNECTABLE: 'connectable' = 'connectable'
 export const REACHABLE: 'reachable' = 'reachable'
 export const UNREACHABLE: 'unreachable' = 'unreachable'
+export const ROBOT_MODEL_OT2: 'OT-2 Standard' = 'OT-2 Standard'
+export const ROBOT_MODEL_OT3: 'OT-3 Standard' = 'OT-3 Standard'
 
 // TODO(mc, 2021-02-17): values below duplicated from Discovery Client source
 // discovery-client/src/constants.ts
@@ -24,3 +26,6 @@ export const RE_HOSTNAME_IPV6_LL: RegExp = /^\[?(?:fd00|fe80)/
 export const RE_HOSTNAME_IPV4_LL: RegExp = /^169\.254\.\d+\.\d+$/
 export const RE_HOSTNAME_LOCALHOST: RegExp = /^localhost$/
 export const RE_HOSTNAME_LOOPBACK: RegExp = /^127\.0\.0\.1$/
+
+export const RE_ROBOT_MODEL_OT3: RegExp = /^OT-3.*/
+export const RE_ROBOT_MODEL_OT2: RegExp = /^OT-2.*/

--- a/app/src/redux/discovery/selectors.ts
+++ b/app/src/redux/discovery/selectors.ts
@@ -248,7 +248,7 @@ export const getRobotModel = (robot: DiscoveredRobot): RobotModel => {
 export const getRobotModelByName = (
   state: State,
   robotName: string
-): RobotModel | null => {
+): string | null => {
   const robot = getRobotByName(state, robotName)
-  return robot != null ? getRobotModel(robot) : null
+  return robot != null ? getRobotModel(robot)?.split(/\s/)[0] : null
 }

--- a/app/src/redux/discovery/selectors.ts
+++ b/app/src/redux/discovery/selectors.ts
@@ -250,5 +250,5 @@ export const getRobotModelByName = (
   robotName: string
 ): RobotModel | null => {
   const robot = getRobotByName(state, robotName)
-  return robot !=null ? getRobotModel(robot) : null
+  return robot != null ? getRobotModel(robot) : null
 }

--- a/app/src/redux/discovery/selectors.ts
+++ b/app/src/redux/discovery/selectors.ts
@@ -16,6 +16,10 @@ import {
   CONNECTABLE,
   REACHABLE,
   UNREACHABLE,
+  RE_ROBOT_MODEL_OT3,
+  RE_ROBOT_MODEL_OT2,
+  ROBOT_MODEL_OT2,
+  ROBOT_MODEL_OT3,
 } from './constants'
 
 // TODO(mc, 2018-10-10): fix circular dependency with RPC API client
@@ -29,6 +33,7 @@ import {
   ReachableRobot,
   UnreachableRobot,
   ViewableRobot,
+  RobotModel,
 } from './types'
 
 type GetConnectableRobots = (state: State) => Robot[]
@@ -54,6 +59,27 @@ const isLocal = (ip: string): boolean => {
 
 const ipToHostname = (ip: string): string => (isIp.v6(ip) ? `[${ip}]` : ip)
 
+const makeRobotModel = (
+  healthModel: string | null,
+  serverHealthModel: string | null,
+  advertisedModel: string | null
+): RobotModel => {
+  return (
+    [healthModel, serverHealthModel, advertisedModel].reduce(
+      (
+        bestModel: RobotModel | null,
+        modelEntry: string | null
+      ): RobotModel | null => {
+        if (bestModel || !modelEntry) return bestModel
+        if (RE_ROBOT_MODEL_OT3.test(modelEntry)) return ROBOT_MODEL_OT3
+        if (RE_ROBOT_MODEL_OT2.test(modelEntry)) return ROBOT_MODEL_OT2
+        return null
+      },
+      null
+    ) ?? ROBOT_MODEL_OT2
+  )
+}
+
 export function getScanning(state: State): boolean {
   return state.discovery.scanning
 }
@@ -67,8 +93,9 @@ export const getDiscoveredRobots: (
     return Object.keys(robotsMap).map((robotName: string) => {
       const robot = robotsMap[robotName]
       const { addresses, ...robotState } = robot
-      const { health } = robotState
+      const { health, serverHealth } = robotState
       const addr = head(addresses)
+      const advertisedModel = addr?.advertisedModel ?? null
       const ip = addr?.ip ? ipToHostname(addr.ip) : null
       const port = addr?.port ?? null
       const healthStatus = addr?.healthStatus ?? null
@@ -79,6 +106,11 @@ export const getDiscoveredRobots: (
         connected: robotName === connectedRobotName,
         local: ip !== null ? isLocal(ip) : null,
         seen: addr?.seen === true,
+        robotModel: makeRobotModel(
+          health?.robot_model ?? null,
+          serverHealth?.robotModel ?? null,
+          advertisedModel ?? null
+        ),
       }
 
       if (ip !== null && port !== null && healthStatus && serverHealthStatus) {
@@ -207,4 +239,16 @@ export const getRobotApiVersionByName = (
 ): string | null => {
   const robot = getRobotByName(state, robotName)
   return robot ? getRobotApiVersion(robot) : null
+}
+
+export const getRobotModel = (robot: DiscoveredRobot): RobotModel => {
+  return robot.robotModel
+}
+
+export const getRobotModelByName = (
+  state: State,
+  robotName: string
+): RobotType | null => {
+  const robot = getRobotByName(state, robotName)
+  return robot ? getRobotModel(robot) : null
 }

--- a/app/src/redux/discovery/selectors.ts
+++ b/app/src/redux/discovery/selectors.ts
@@ -248,7 +248,7 @@ export const getRobotModel = (robot: DiscoveredRobot): RobotModel => {
 export const getRobotModelByName = (
   state: State,
   robotName: string
-): RobotType | null => {
+): RobotModel | null => {
   const robot = getRobotByName(state, robotName)
   return robot ? getRobotModel(robot) : null
 }

--- a/app/src/redux/discovery/selectors.ts
+++ b/app/src/redux/discovery/selectors.ts
@@ -250,5 +250,5 @@ export const getRobotModelByName = (
   robotName: string
 ): RobotModel | null => {
   const robot = getRobotByName(state, robotName)
-  return robot ? getRobotModel(robot) : null
+  return robot !=null ? getRobotModel(robot) : null
 }

--- a/app/src/redux/discovery/types.ts
+++ b/app/src/redux/discovery/types.ts
@@ -9,6 +9,8 @@ import {
   CONNECTABLE,
   REACHABLE,
   UNREACHABLE,
+  ROBOT_MODEL_OT2,
+  ROBOT_MODEL_OT3,
 } from './constants'
 
 export type { DiscoveryClientRobot, HealthStatus }
@@ -20,6 +22,8 @@ export type ConnectivityStatus =
   | typeof REACHABLE
   | typeof UNREACHABLE
 
+export type RobotModel = typeof ROBOT_MODEL_OT2 | typeof ROBOT_MODEL_OT3
+
 export interface DiscoveryState {
   scanning: boolean
   robotsByName: RobotsMap
@@ -30,6 +34,7 @@ export interface BaseRobot extends Omit<DiscoveryClientRobot, 'addresses'> {
   connected: boolean
   local: boolean | null
   seen: boolean
+  robotModel: RobotModel
 }
 
 // fully connectable robot

--- a/components/src/testing/utils/renderWithProviders.tsx
+++ b/components/src/testing/utils/renderWithProviders.tsx
@@ -24,6 +24,7 @@ export function renderWithProviders<State>(
 
   const store: Store<State> = createStore(jest.fn(), initialState)
   store.dispatch = jest.fn()
+  store.getState = jest.fn(() => initialState)
 
   const queryClient = new QueryClient()
 

--- a/discovery-client/Makefile
+++ b/discovery-client/Makefile
@@ -25,5 +25,5 @@ clean:
 lib: export NODE_ENV := production
 lib: $(main_out) $(cli_out)
 
-$(main_out) $(cli_out): src/*.ts src/mdns-browser/*.ts src/store/*.ts package.json webpack.config.js tsconfig.json
+$(main_out) $(cli_out):
 	yarn webpack

--- a/discovery-client/Makefile
+++ b/discovery-client/Makefile
@@ -25,5 +25,5 @@ clean:
 lib: export NODE_ENV := production
 lib: $(main_out) $(cli_out)
 
-$(main_out) $(cli_out):
+$(main_out) $(cli_out): src/*.ts src/mdns-browser/*.ts src/store/*.ts package.json webpack.config.js tsconfig.json
 	yarn webpack

--- a/discovery-client/src/__fixtures__/health.ts
+++ b/discovery-client/src/__fixtures__/health.ts
@@ -1,17 +1,54 @@
-export const mockHealthResponse = {
+export const mockLegacyHealthResponse = {
   name: 'opentrons-dev',
   api_version: '1.2.3',
   fw_version: '4.5.6',
   system_version: '7.8.9',
+  robot_model: 'OT-2 Standard',
 }
 
-export const mockServerHealthResponse = {
+export const mockOT3HealthResponse = {
+  name: 'opentrons-dev',
+  api_version: '1.2.3',
+  fw_version: '4.5.6',
+  system_version: '7.8.9',
+  robot_model: 'OT-3 Standard',
+}
+
+export const mockOT2HealthResponse = {
+  name: 'opentrons-dev',
+  api_version: '1.2.3',
+  fw_version: '4.5.6',
+  system_version: '7.8.9',
+  robot_model: 'OT-2 Standard',
+}
+
+export const mockLegacyServerHealthResponse = {
   name: 'opentrons-dev',
   apiServerVersion: '1.2.3',
   serialNumber: '12345',
   updateServerVersion: '1.2.3',
   smoothieVersion: '4.5.6',
   systemVersion: '7.8.9',
+}
+
+export const mockOT3ServerHealthResponse = {
+  name: 'opentrons-dev',
+  apiServerVersion: '1.2.3',
+  serialNumber: '12345',
+  updateServerVersion: '1.2.3',
+  smoothieVersion: '4.5.6',
+  systemVersion: '7.8.9',
+  robotModel: 'OT-3 Standard',
+}
+
+export const mockOT2ServerHealthResponse = {
+  name: 'opentrons-dev',
+  apiServerVersion: '1.2.3',
+  serialNumber: '12345',
+  updateServerVersion: '1.2.3',
+  smoothieVersion: '4.5.6',
+  systemVersion: '7.8.9',
+  robotModel: 'OT-2 Standard',
 }
 
 export const mockHealthErrorJsonResponse = {

--- a/discovery-client/src/__tests__/discovery-client.test.ts
+++ b/discovery-client/src/__tests__/discovery-client.test.ts
@@ -1,4 +1,11 @@
-import { mockHealthResponse, mockServerHealthResponse } from '../__fixtures__'
+import {
+  mockLegacyHealthResponse,
+  mockLegacyServerHealthResponse,
+  mockOT2HealthResponse,
+  mockOT2ServerHealthResponse,
+  mockOT3HealthResponse,
+  mockOT3ServerHealthResponse,
+} from '../__fixtures__'
 import { HEALTH_STATUS_OK } from '../constants'
 import * as HealthPollerModule from '../health-poller'
 import * as MdnsBrowserModule from '../mdns-browser'
@@ -103,7 +110,12 @@ describe('discovery client', () => {
     const client = createDiscoveryClient({ onListChange, logger })
 
     client.start({ healthPollInterval: 5000 })
-    emitService({ name: 'opentrons-dev', ip: '127.0.0.1', port: 31950 })
+    emitService({
+      name: 'opentrons-dev',
+      ip: '127.0.0.1',
+      port: 31950,
+      robotModel: 'OT-3 Standard',
+    })
 
     expect(onListChange).toHaveBeenCalledWith([
       {
@@ -119,6 +131,7 @@ describe('discovery client', () => {
             serverHealthStatus: null,
             healthError: null,
             serverHealthError: null,
+            advertisedModel: 'OT-3 Standard',
           },
         ],
       },
@@ -129,12 +142,17 @@ describe('discovery client', () => {
     const client = createDiscoveryClient({ onListChange, logger })
 
     client.start({ healthPollInterval: 5000 })
-    emitService({ name: 'opentrons-dev', ip: '127.0.0.1', port: 31950 })
+    emitService({
+      name: 'opentrons-dev',
+      ip: '127.0.0.1',
+      port: 31950,
+      robotModel: null,
+    })
     emitPollResult({
       ip: '127.0.0.1',
       port: 31950,
-      health: mockHealthResponse,
-      serverHealth: mockServerHealthResponse,
+      health: mockLegacyHealthResponse,
+      serverHealth: mockLegacyServerHealthResponse,
       healthError: null,
       serverHealthError: null,
     })
@@ -142,8 +160,8 @@ describe('discovery client', () => {
     expect(onListChange).toHaveBeenLastCalledWith([
       {
         name: 'opentrons-dev',
-        health: mockHealthResponse,
-        serverHealth: mockServerHealthResponse,
+        health: mockLegacyHealthResponse,
+        serverHealth: mockLegacyServerHealthResponse,
         addresses: [
           {
             ip: '127.0.0.1',
@@ -153,6 +171,7 @@ describe('discovery client', () => {
             serverHealthStatus: HEALTH_STATUS_OK,
             healthError: null,
             serverHealthError: null,
+            advertisedModel: null,
           },
         ],
       },
@@ -163,8 +182,18 @@ describe('discovery client', () => {
     const client = createDiscoveryClient({ onListChange, logger })
 
     client.start({ healthPollInterval: 5000 })
-    emitService({ name: 'opentrons-dev', ip: '127.0.0.1', port: 31950 })
-    emitService({ name: 'opentrons-dev', ip: '127.0.0.1', port: 31950 })
+    emitService({
+      name: 'opentrons-dev',
+      ip: '127.0.0.1',
+      port: 31950,
+      robotModel: 'OT-2 Standard',
+    })
+    emitService({
+      name: 'opentrons-dev',
+      ip: '127.0.0.1',
+      port: 31950,
+      robotModel: 'OT-2 Standard',
+    })
 
     expect(onListChange).toHaveBeenCalledTimes(1)
   })
@@ -173,7 +202,12 @@ describe('discovery client', () => {
     const client = createDiscoveryClient({ onListChange, logger })
 
     client.start({ healthPollInterval: 5000 })
-    emitService({ name: 'opentrons-dev', ip: '127.0.0.1', port: 31950 })
+    emitService({
+      name: 'opentrons-dev',
+      ip: '127.0.0.1',
+      port: 31950,
+      robotModel: 'OT-3 Standard',
+    })
 
     expect(healthPoller.start).toHaveBeenLastCalledWith({
       list: [{ ip: '127.0.0.1', port: 31950 }],
@@ -184,8 +218,18 @@ describe('discovery client', () => {
     const client = createDiscoveryClient({ onListChange, logger })
 
     client.start({ healthPollInterval: 5000 })
-    emitService({ name: 'opentrons-dev', ip: '127.0.0.1', port: 31950 })
-    emitService({ name: 'opentrons-dev', ip: '127.0.0.1', port: 31950 })
+    emitService({
+      name: 'opentrons-dev',
+      ip: '127.0.0.1',
+      port: 31950,
+      robotModel: null,
+    })
+    emitService({
+      name: 'opentrons-dev',
+      ip: '127.0.0.1',
+      port: 31950,
+      robotModel: null,
+    })
 
     expect(healthPoller.start).toHaveBeenCalledTimes(2)
   })
@@ -209,7 +253,12 @@ describe('discovery client', () => {
     healthPoller.start.mockClear()
 
     // this shouldn't happen while the mDNS browser stopped but is useful to testing
-    emitService({ name: 'opentrons-dev', ip: '127.0.0.1', port: 31950 })
+    emitService({
+      name: 'opentrons-dev',
+      ip: '127.0.0.1',
+      port: 31950,
+      robotModel: null,
+    })
 
     expect(onListChange).toHaveBeenCalledTimes(0)
     expect(healthPoller.start).toHaveBeenCalledTimes(0)
@@ -220,8 +269,8 @@ describe('discovery client', () => {
     const initialRobots = [
       {
         name: 'opentrons-dev',
-        health: mockHealthResponse,
-        serverHealth: mockServerHealthResponse,
+        health: mockOT3HealthResponse,
+        serverHealth: mockOT3ServerHealthResponse,
         addresses: [
           {
             ip: '127.0.0.1',
@@ -231,6 +280,7 @@ describe('discovery client', () => {
             serverHealthStatus: HEALTH_STATUS_OK,
             healthError: null,
             serverHealthError: null,
+            advertisedModel: 'OT-3 Standard',
           },
         ],
       },
@@ -245,8 +295,8 @@ describe('discovery client', () => {
     expect(client.getRobots()).toEqual([
       {
         name: 'opentrons-dev',
-        health: mockHealthResponse,
-        serverHealth: mockServerHealthResponse,
+        health: mockOT3HealthResponse,
+        serverHealth: mockOT3ServerHealthResponse,
         addresses: [
           {
             ip: '127.0.0.1',
@@ -256,6 +306,7 @@ describe('discovery client', () => {
             serverHealthStatus: null,
             healthError: null,
             serverHealthError: null,
+            advertisedModel: 'OT-3 Standard',
           },
         ],
       },
@@ -267,8 +318,8 @@ describe('discovery client', () => {
     const initialRobots = [
       {
         name: 'opentrons-dev',
-        health: mockHealthResponse,
-        serverHealth: mockServerHealthResponse,
+        health: mockOT2HealthResponse,
+        serverHealth: mockOT2ServerHealthResponse,
         addresses: [
           {
             ip: '127.0.0.1',
@@ -278,6 +329,7 @@ describe('discovery client', () => {
             serverHealthStatus: HEALTH_STATUS_OK,
             healthError: null,
             serverHealthError: null,
+            advertisedModel: 'OT-2 Standard',
           },
         ],
       },
@@ -312,8 +364,8 @@ describe('discovery client', () => {
     const initialRobots = [
       {
         name: 'opentrons-dev',
-        health: mockHealthResponse,
-        serverHealth: mockServerHealthResponse,
+        health: mockLegacyHealthResponse,
+        serverHealth: mockLegacyServerHealthResponse,
         addresses: [
           {
             ip: '127.0.0.1',
@@ -323,6 +375,7 @@ describe('discovery client', () => {
             serverHealthStatus: HEALTH_STATUS_OK,
             healthError: null,
             serverHealthError: null,
+            advertisedModel: null,
           },
           {
             ip: '127.0.0.2',
@@ -332,6 +385,7 @@ describe('discovery client', () => {
             serverHealthStatus: HEALTH_STATUS_OK,
             healthError: null,
             serverHealthError: null,
+            advertisedModel: null,
           },
         ],
       },

--- a/discovery-client/src/__tests__/health-poller.test.ts
+++ b/discovery-client/src/__tests__/health-poller.test.ts
@@ -187,10 +187,10 @@ describe('health poller', () => {
 
   it('should map successful fetch responses to onPollResult', () => {
     stubFetchOnce('http://127.0.0.1:31950/health')(
-      makeMockJsonResponse(Fixtures.mockHealthResponse)
+      makeMockJsonResponse(Fixtures.mockLegacyHealthResponse)
     )
     stubFetchOnce('http://127.0.0.1:31950/server/update/health')(
-      makeMockJsonResponse(Fixtures.mockServerHealthResponse)
+      makeMockJsonResponse(Fixtures.mockLegacyServerHealthResponse)
     )
 
     poller.start({ list: [HOST_1], interval: 1000 })
@@ -201,8 +201,8 @@ describe('health poller', () => {
       expect(onPollResult).toHaveBeenCalledWith({
         ip: '127.0.0.1',
         port: 31950,
-        health: Fixtures.mockHealthResponse,
-        serverHealth: Fixtures.mockServerHealthResponse,
+        health: Fixtures.mockLegacyHealthResponse,
+        serverHealth: Fixtures.mockLegacyServerHealthResponse,
         healthError: null,
         serverHealthError: null,
       })
@@ -214,7 +214,7 @@ describe('health poller', () => {
       makeMockJsonResponse({ message: 'some error' }, false, 400)
     )
     stubFetchOnce('http://127.0.0.1:31950/server/update/health')(
-      makeMockJsonResponse(Fixtures.mockServerHealthResponse)
+      makeMockJsonResponse(Fixtures.mockOT3ServerHealthResponse)
     )
 
     poller.start({ list: [HOST_1], interval: 1000 })
@@ -225,7 +225,7 @@ describe('health poller', () => {
         ip: '127.0.0.1',
         port: 31950,
         health: null,
-        serverHealth: Fixtures.mockServerHealthResponse,
+        serverHealth: Fixtures.mockOT3ServerHealthResponse,
         healthError: { status: 400, body: { message: 'some error' } },
         serverHealthError: null,
       })

--- a/discovery-client/src/mdns-browser/__fixtures__/mdns-browser-service.ts
+++ b/discovery-client/src/mdns-browser/__fixtures__/mdns-browser-service.ts
@@ -27,3 +27,63 @@ export const mockBrowserService: BrowserService = {
   interfaceIndex: 0,
   networkInterface: 'en0',
 }
+
+export const mockBrowserServiceWithRobotModel: BrowserService = {
+  addresses: ['192.168.1.42'],
+  query: ['_http._tcp.local'],
+  type: [
+    ({
+      name: 'http',
+      protocol: 'tcp',
+      subtypes: [],
+      description: 'Web Site',
+    } as unknown) as ServiceType,
+  ],
+  txt: ['robotModel=OT-2 Standard'],
+  port: 31950,
+  fullname: 'opentrons-dev._http._tcp.local',
+  host: 'opentrons-dev.local',
+  interfaceIndex: 0,
+  networkInterface: 'en0',
+}
+
+export const mockBrowserServiceWithSurpriseTXT: BrowserService = {
+  addresses: ['192.168.1.42'],
+  query: ['_http._tcp.local'],
+  type: [
+    ({
+      name: 'http',
+      protocol: 'tcp',
+      subtypes: [],
+      description: 'Web Site',
+    } as unknown) as ServiceType,
+  ],
+  txt: [
+    'robotModel=OT-3 Standard',
+    'robotModel=OT-2 Standard',
+    'hello hello hello',
+  ],
+  port: 31950,
+  fullname: 'opentrons-dev._http._tcp.local',
+  host: 'opentrons-dev.local',
+  interfaceIndex: 0,
+  networkInterface: 'en0',
+}
+
+export const mockBrowserServiceWithoutTXT: BrowserService = {
+  addresses: ['192.168.1.42'],
+  query: ['_http._tcp.local'],
+  type: [
+    ({
+      name: 'http',
+      protocol: 'tcp',
+      subtypes: [],
+      description: 'Web Site',
+    } as unknown) as ServiceType,
+  ],
+  port: 31950,
+  fullname: 'opentrons-dev._http._tcp.local',
+  host: 'opentrons-dev.local',
+  interfaceIndex: 0,
+  networkInterface: 'en0',
+}

--- a/discovery-client/src/mdns-browser/__tests__/mdns-browser.test.ts
+++ b/discovery-client/src/mdns-browser/__tests__/mdns-browser.test.ts
@@ -2,7 +2,13 @@ import Mdns from 'mdns-js'
 import { when } from 'jest-when'
 import { isEqual } from 'lodash'
 
-import { mockBaseBrowser, mockBrowserService } from '../__fixtures__'
+import {
+  mockBaseBrowser,
+  mockBrowserService,
+  mockBrowserServiceWithRobotModel,
+  mockBrowserServiceWithSurpriseTXT,
+  mockBrowserServiceWithoutTXT,
+} from '../__fixtures__'
 import * as Ifaces from '../interfaces'
 import { repeatCall as mockRepeatCall } from '../repeat-call'
 import { createMdnsBrowser } from '..'
@@ -194,6 +200,52 @@ describe('mdns browser', () => {
       name: 'opentrons-dev',
       ip: '192.168.1.42',
       port: 31950,
+      robotModel: null,
+    })
+  })
+
+  it('forwards robot model when specified', () => {
+    const browser = createMdnsBrowser({ onService, ports: [31950] })
+
+    browser.start()
+    mockBaseBrowser.emit('ready')
+    mockBaseBrowser.emit('update', mockBrowserServiceWithRobotModel)
+
+    expect(onService).toHaveBeenCalledWith({
+      name: 'opentrons-dev',
+      ip: '192.168.1.42',
+      port: 31950,
+      robotModel: 'OT-2 Standard',
+    })
+  })
+
+  it('handles totally missing txt records', () => {
+    const browser = createMdnsBrowser({ onService, ports: [31950] })
+
+    browser.start()
+    mockBaseBrowser.emit('ready')
+    mockBaseBrowser.emit('update', mockBrowserServiceWithoutTXT)
+
+    expect(onService).toHaveBeenCalledWith({
+      name: 'opentrons-dev',
+      ip: '192.168.1.42',
+      port: 31950,
+      robotModel: null,
+    })
+  })
+
+  it('handles unexpected txt records', () => {
+    const browser = createMdnsBrowser({ onService, ports: [31950] })
+
+    browser.start()
+    mockBaseBrowser.emit('ready')
+    mockBaseBrowser.emit('update', mockBrowserServiceWithSurpriseTXT)
+
+    expect(onService).toHaveBeenCalledWith({
+      name: 'opentrons-dev',
+      ip: '192.168.1.42',
+      port: 31950,
+      robotModel: 'OT-3 Standard',
     })
   })
 
@@ -242,6 +294,7 @@ describe('mdns browser', () => {
       name: 'opentrons-dev',
       ip: '192.168.1.42',
       port: 31950,
+      robotModel: null,
     })
   })
 
@@ -258,6 +311,7 @@ describe('mdns browser', () => {
       name: 'opentrons-dev',
       ip: '192.168.1.42',
       port: 12345,
+      robotModel: null,
     })
   })
 })

--- a/discovery-client/src/mdns-browser/index.ts
+++ b/discovery-client/src/mdns-browser/index.ts
@@ -19,18 +19,17 @@ export type { MdnsBrowser, MdnsBrowserOptions, MdnsBrowserService }
 const IFACE_POLL_INTERVAL_MS = 5000
 const QUERY_INTERVAL_MS = [4000, 8000, 16000, 32000, 64000, 128000]
 
-const robotModelFromTxt = (records: string[] | undefined): string | null => {
-  return records
-    ? records.reduce((cached: string | null, elem: string): string | null => {
-        return (
-          cached ??
-          elem.match(/robotModel=(?<robotModel>.*)/)?.groups?.robotModel ??
-          null
-        )
-      }, null)
-    : null
-}
+const RE_ROBOT_MODEL = /robotModel=(?<robotModel>.*)/
 
+const robotModelFromTxt = (records: string[] | undefined): string | null => {
+  records = records ?? []
+
+  const model = records
+    .map((e: string) => e.match(RE_ROBOT_MODEL)?.groups?.robotModel)
+    .find(maybeModel => maybeModel != null)
+
+  return model ?? null
+}
 /**
  * Create a mDNS browser wrapper can be started and stopped and calls
  * `onService` when the underlying browser receives an advertisement

--- a/discovery-client/src/mdns-browser/index.ts
+++ b/discovery-client/src/mdns-browser/index.ts
@@ -19,6 +19,18 @@ export type { MdnsBrowser, MdnsBrowserOptions, MdnsBrowserService }
 const IFACE_POLL_INTERVAL_MS = 5000
 const QUERY_INTERVAL_MS = [4000, 8000, 16000, 32000, 64000, 128000]
 
+const robotModelFromTxt = (records: string[] | undefined): string | null => {
+  return records
+    ? records.reduce((cached: string | null, elem: string): string | null => {
+        return (
+          cached ??
+          elem.match(/robotModel=(?<robotModel>.*)/)?.groups?.robotModel ??
+          null
+        )
+      }, null)
+    : null
+}
+
 /**
  * Create a mDNS browser wrapper can be started and stopped and calls
  * `onService` when the underlying browser receives an advertisement
@@ -58,7 +70,7 @@ export function createMdnsBrowser(options: MdnsBrowserOptions): MdnsBrowser {
         })
       })
       .on('update', (service: BaseBrowserService) => {
-        const { fullname, addresses, port } = service
+        const { fullname, addresses, port, txt } = service
         const ip = addresses.find(address => net.isIPv4(address))
 
         if (
@@ -68,7 +80,8 @@ export function createMdnsBrowser(options: MdnsBrowserOptions): MdnsBrowser {
           ports.includes(port)
         ) {
           const name = fullname.replace(/\._http\._tcp.local$/, '')
-          onService({ name, ip, port })
+          const robotModel = robotModelFromTxt(txt)
+          onService({ name, ip, port, robotModel })
         } else {
           log('silly', 'Ignoring mDNS service', { service })
         }

--- a/discovery-client/src/mdns-browser/types.ts
+++ b/discovery-client/src/mdns-browser/types.ts
@@ -10,6 +10,8 @@ export interface MdnsBrowserService {
   ip: string
   /** The port the service is using */
   port: number
+  /** If present, the machine type from the TXT record linked with the service */
+  robotModel: string | null
 }
 
 /**

--- a/discovery-client/src/store/__tests__/actions.test.ts
+++ b/discovery-client/src/store/__tests__/actions.test.ts
@@ -44,11 +44,17 @@ describe('discovery client action creators', () => {
       name: 'opentrons-dev',
       ip: '127.0.0.1',
       port: 31950,
+      robotModel: null,
     })
 
     expect(action).toEqual({
       type: 'mdns:SERVICE_FOUND',
-      payload: { name: 'opentrons-dev', ip: '127.0.0.1', port: 31950 },
+      payload: {
+        name: 'opentrons-dev',
+        ip: '127.0.0.1',
+        port: 31950,
+        robotModel: null,
+      },
     })
   })
 

--- a/discovery-client/src/store/__tests__/hostsByIpReducer.test.ts
+++ b/discovery-client/src/store/__tests__/hostsByIpReducer.test.ts
@@ -1,7 +1,11 @@
 // discovery client reducer
 import {
-  mockHealthResponse,
-  mockServerHealthResponse,
+  mockLegacyHealthResponse,
+  mockLegacyServerHealthResponse,
+  mockOT3ServerHealthResponse,
+  mockOT2HealthResponse,
+  mockOT2ServerHealthResponse,
+  mockOT3HealthResponse,
   mockHealthErrorJsonResponse,
   mockHealthFetchErrorResponse,
 } from '../../__fixtures__/health'
@@ -29,6 +33,7 @@ describe('hostsByIp reducer', () => {
         healthError: null,
         serverHealthError: null,
         robotName: 'opentrons-dev',
+        advertisedModel: null,
       },
     }
     const action = Actions.initializeState({})
@@ -48,6 +53,7 @@ describe('hostsByIp reducer', () => {
         healthError: null,
         serverHealthError: null,
         robotName: 'opentrons-dev',
+        advertisedModel: null,
       },
     }
 
@@ -55,8 +61,8 @@ describe('hostsByIp reducer', () => {
       initialRobots: [
         {
           name: 'opentrons-1',
-          health: mockHealthResponse,
-          serverHealth: mockServerHealthResponse,
+          health: mockLegacyHealthResponse,
+          serverHealth: mockLegacyServerHealthResponse,
           addresses: [
             {
               ip: '127.0.0.2',
@@ -66,13 +72,14 @@ describe('hostsByIp reducer', () => {
               serverHealthStatus: null,
               healthError: null,
               serverHealthError: null,
+              advertisedModel: null,
             },
           ],
         },
         {
           name: 'opentrons-2',
           health: null,
-          serverHealth: mockServerHealthResponse,
+          serverHealth: mockOT3ServerHealthResponse,
           addresses: [
             {
               ip: '127.0.0.3',
@@ -82,6 +89,7 @@ describe('hostsByIp reducer', () => {
               serverHealthStatus: Constants.HEALTH_STATUS_NOT_OK,
               healthError: mockHealthErrorJsonResponse,
               serverHealthError: mockHealthErrorJsonResponse,
+              advertisedModel: 'OT-3 Standard',
             },
             {
               ip: '127.0.0.4',
@@ -91,12 +99,13 @@ describe('hostsByIp reducer', () => {
               serverHealthStatus: Constants.HEALTH_STATUS_UNREACHABLE,
               healthError: mockHealthFetchErrorResponse,
               serverHealthError: mockHealthFetchErrorResponse,
+              advertisedModel: 'OT-3 Standard',
             },
           ],
         },
         {
           name: 'opentrons-3',
-          health: mockHealthResponse,
+          health: mockOT2HealthResponse,
           serverHealth: null,
           addresses: [],
         },
@@ -114,6 +123,7 @@ describe('hostsByIp reducer', () => {
         healthError: null,
         serverHealthError: null,
         robotName: 'opentrons-1',
+        advertisedModel: null,
       },
       '127.0.0.3': {
         ip: '127.0.0.3',
@@ -124,6 +134,7 @@ describe('hostsByIp reducer', () => {
         healthError: null,
         serverHealthError: null,
         robotName: 'opentrons-2',
+        advertisedModel: 'OT-3 Standard',
       },
       '127.0.0.4': {
         ip: '127.0.0.4',
@@ -134,6 +145,7 @@ describe('hostsByIp reducer', () => {
         healthError: null,
         serverHealthError: null,
         robotName: 'opentrons-2',
+        advertisedModel: 'OT-3 Standard',
       },
     })
   })
@@ -143,6 +155,7 @@ describe('hostsByIp reducer', () => {
       name: 'opentrons-dev',
       ip: '127.0.0.1',
       port: 31950,
+      robotModel: null,
     })
     const initialState = {}
 
@@ -156,6 +169,7 @@ describe('hostsByIp reducer', () => {
         healthError: null,
         serverHealthError: null,
         robotName: 'opentrons-dev',
+        advertisedModel: null,
       },
     })
   })
@@ -165,6 +179,7 @@ describe('hostsByIp reducer', () => {
       name: 'opentrons-dev',
       ip: '127.0.0.1',
       port: 31950,
+      robotModel: 'OT-3 Standard',
     })
     const initialState = {
       '127.0.0.1': {
@@ -176,6 +191,7 @@ describe('hostsByIp reducer', () => {
         healthError: null,
         serverHealthError: null,
         robotName: 'opentrons-dev',
+        advertisedModel: null,
       },
     }
     const nextState = hostsByIpReducer(initialState, action)
@@ -190,6 +206,7 @@ describe('hostsByIp reducer', () => {
         healthError: null,
         serverHealthError: null,
         robotName: 'opentrons-dev',
+        advertisedModel: 'OT-3 Standard',
       },
     })
   })
@@ -199,6 +216,7 @@ describe('hostsByIp reducer', () => {
       name: 'opentrons-dev',
       ip: '127.0.0.1',
       port: 31950,
+      robotModel: 'OT-2 Standard',
     })
     const initialState = {
       '127.0.0.1': {
@@ -210,6 +228,7 @@ describe('hostsByIp reducer', () => {
         healthError: null,
         serverHealthError: mockHealthErrorJsonResponse,
         robotName: 'opentrons-dev',
+        advertisedModel: 'OT-2 Standard',
       },
     }
     const nextState = hostsByIpReducer(initialState, action)
@@ -223,6 +242,7 @@ describe('hostsByIp reducer', () => {
       name: 'opentrons-dev',
       ip: '127.0.0.1',
       port: 31950,
+      robotModel: null,
     })
     const initialState = {
       '127.0.0.1': {
@@ -234,6 +254,7 @@ describe('hostsByIp reducer', () => {
         healthError: mockHealthErrorJsonResponse,
         serverHealthError: mockHealthErrorJsonResponse,
         robotName: 'opentrons-old-dev',
+        advertisedModel: null,
       },
     }
     const nextState = hostsByIpReducer(initialState, action)
@@ -248,6 +269,7 @@ describe('hostsByIp reducer', () => {
         healthError: null,
         serverHealthError: null,
         robotName: 'opentrons-dev',
+        advertisedModel: null,
       },
     })
   })
@@ -256,8 +278,8 @@ describe('hostsByIp reducer', () => {
     const action = Actions.healthPolled({
       ip: '127.0.0.1',
       port: 31950,
-      health: mockHealthResponse,
-      serverHealth: mockServerHealthResponse,
+      health: mockOT2HealthResponse,
+      serverHealth: mockOT2ServerHealthResponse,
       healthError: null,
       serverHealthError: null,
     })
@@ -274,6 +296,7 @@ describe('hostsByIp reducer', () => {
         healthError: null,
         serverHealthError: null,
         robotName: 'opentrons-dev',
+        advertisedModel: null,
       },
     })
   })
@@ -282,8 +305,8 @@ describe('hostsByIp reducer', () => {
     const action = Actions.healthPolled({
       ip: '127.0.0.1',
       port: 31950,
-      health: mockHealthResponse,
-      serverHealth: mockServerHealthResponse,
+      health: mockOT2HealthResponse,
+      serverHealth: mockOT2ServerHealthResponse,
       healthError: null,
       serverHealthError: null,
     })
@@ -297,6 +320,7 @@ describe('hostsByIp reducer', () => {
         healthError: mockHealthFetchErrorResponse,
         serverHealthError: mockHealthFetchErrorResponse,
         robotName: 'opentrons-dev',
+        advertisedModel: 'OT-2 Standard',
       },
     }
     const nextState = hostsByIpReducer(initialState, action)
@@ -311,6 +335,7 @@ describe('hostsByIp reducer', () => {
         healthError: null,
         serverHealthError: null,
         robotName: 'opentrons-dev',
+        advertisedModel: 'OT-2 Standard',
       },
     })
   })
@@ -319,8 +344,8 @@ describe('hostsByIp reducer', () => {
     const action = Actions.healthPolled({
       ip: '127.0.0.1',
       port: 31950,
-      health: mockHealthResponse,
-      serverHealth: mockServerHealthResponse,
+      health: mockOT3HealthResponse,
+      serverHealth: mockOT3ServerHealthResponse,
       healthError: null,
       serverHealthError: null,
     })
@@ -334,6 +359,7 @@ describe('hostsByIp reducer', () => {
         healthError: mockHealthFetchErrorResponse,
         serverHealthError: mockHealthFetchErrorResponse,
         robotName: 'not-opentrons-dev',
+        advertisedModel: 'OT-3 Standard',
       },
     }
     const nextState = hostsByIpReducer(initialState, action)
@@ -348,6 +374,7 @@ describe('hostsByIp reducer', () => {
         healthError: null,
         serverHealthError: null,
         robotName: 'opentrons-dev',
+        advertisedModel: 'OT-3 Standard',
       },
     })
   })
@@ -356,8 +383,8 @@ describe('hostsByIp reducer', () => {
     const action = Actions.healthPolled({
       ip: '127.0.0.1',
       port: 31950,
-      health: mockHealthResponse,
-      serverHealth: mockServerHealthResponse,
+      health: mockOT2HealthResponse,
+      serverHealth: mockOT2ServerHealthResponse,
       healthError: null,
       serverHealthError: null,
     })
@@ -371,6 +398,7 @@ describe('hostsByIp reducer', () => {
         healthError: null,
         serverHealthError: null,
         robotName: 'opentrons-dev',
+        advertisedModel: null,
       },
     }
     const nextState = hostsByIpReducer(initialState, action)
@@ -397,6 +425,7 @@ describe('hostsByIp reducer', () => {
         healthError: null,
         serverHealthError: null,
         robotName: 'opentrons-dev',
+        advertisedModel: 'OT-3 Standard',
       },
     }
     const nextState = hostsByIpReducer(initialState, action)
@@ -411,6 +440,7 @@ describe('hostsByIp reducer', () => {
         healthError: mockHealthFetchErrorResponse,
         serverHealthError: mockHealthFetchErrorResponse,
         robotName: 'opentrons-dev',
+        advertisedModel: 'OT-3 Standard',
       },
     })
   })
@@ -419,8 +449,8 @@ describe('hostsByIp reducer', () => {
     const action = Actions.healthPolled({
       ip: '127.0.0.1',
       port: 31950,
-      health: mockHealthResponse,
-      serverHealth: mockServerHealthResponse,
+      health: mockOT2HealthResponse,
+      serverHealth: mockOT2ServerHealthResponse,
       healthError: null,
       serverHealthError: null,
     })
@@ -434,6 +464,7 @@ describe('hostsByIp reducer', () => {
         healthError: null,
         serverHealthError: null,
         robotName: 'opentrons-dev',
+        advertisedModel: null,
       },
       '127.0.0.3': {
         ip: '127.0.0.3',
@@ -444,6 +475,7 @@ describe('hostsByIp reducer', () => {
         healthError: mockHealthErrorJsonResponse,
         serverHealthError: mockHealthErrorJsonResponse,
         robotName: 'opentrons-dev',
+        advertisedModel: null,
       },
       '127.0.0.4': {
         ip: '127.0.0.4',
@@ -454,6 +486,7 @@ describe('hostsByIp reducer', () => {
         healthError: mockHealthFetchErrorResponse,
         serverHealthError: mockHealthFetchErrorResponse,
         robotName: 'opentrons-dev',
+        advertisedModel: null,
       },
       '127.0.0.5': {
         ip: '127.0.0.5',
@@ -464,6 +497,7 @@ describe('hostsByIp reducer', () => {
         healthError: mockHealthFetchErrorResponse,
         serverHealthError: mockHealthFetchErrorResponse,
         robotName: 'opentrons-other',
+        advertisedModel: null,
       },
     }
     const nextState = hostsByIpReducer(initialState, action)
@@ -478,6 +512,7 @@ describe('hostsByIp reducer', () => {
         healthError: null,
         serverHealthError: null,
         robotName: 'opentrons-dev',
+        advertisedModel: null,
       },
       '127.0.0.2': {
         ip: '127.0.0.2',
@@ -488,6 +523,7 @@ describe('hostsByIp reducer', () => {
         healthError: null,
         serverHealthError: null,
         robotName: 'opentrons-dev',
+        advertisedModel: null,
       },
       '127.0.0.3': {
         ip: '127.0.0.3',
@@ -498,6 +534,7 @@ describe('hostsByIp reducer', () => {
         healthError: mockHealthErrorJsonResponse,
         serverHealthError: mockHealthErrorJsonResponse,
         robotName: 'opentrons-dev',
+        advertisedModel: null,
       },
       '127.0.0.5': {
         ip: '127.0.0.5',
@@ -508,6 +545,7 @@ describe('hostsByIp reducer', () => {
         healthError: mockHealthFetchErrorResponse,
         serverHealthError: mockHealthFetchErrorResponse,
         robotName: 'opentrons-other',
+        advertisedModel: null,
       },
     })
   })
@@ -524,6 +562,7 @@ describe('hostsByIp reducer', () => {
         healthError: null,
         serverHealthError: null,
         robotName: 'opentrons-dev',
+        advertisedModel: null,
       },
     }
     const nextState = hostsByIpReducer(initialState, action)
@@ -543,6 +582,7 @@ describe('hostsByIp reducer', () => {
         healthError: null,
         serverHealthError: null,
         robotName: 'opentrons-dev',
+        advertisedModel: null,
       },
       '127.0.0.2': {
         ip: '127.0.0.2',
@@ -553,6 +593,7 @@ describe('hostsByIp reducer', () => {
         healthError: null,
         serverHealthError: null,
         robotName: 'opentrons-dev',
+        advertisedModel: null,
       },
       '127.0.0.3': {
         ip: '127.0.0.3',
@@ -563,6 +604,7 @@ describe('hostsByIp reducer', () => {
         healthError: null,
         serverHealthError: null,
         robotName: 'opentrons-other',
+        advertisedModel: null,
       },
     }
     const nextState = hostsByIpReducer(initialState, action)
@@ -577,6 +619,7 @@ describe('hostsByIp reducer', () => {
         healthError: null,
         serverHealthError: null,
         robotName: 'opentrons-other',
+        advertisedModel: null,
       },
     })
   })

--- a/discovery-client/src/store/__tests__/robotsByNameReducer.test.ts
+++ b/discovery-client/src/store/__tests__/robotsByNameReducer.test.ts
@@ -105,6 +105,7 @@ describe('robotsByName reducer', () => {
       name: 'opentrons-dev',
       ip: '127.0.0.1',
       port: 31950,
+      robotModel: null,
     })
     const initialState: RobotsByNameMap = {
       'opentrons-dev': {

--- a/discovery-client/src/store/__tests__/robotsByNameReducer.test.ts
+++ b/discovery-client/src/store/__tests__/robotsByNameReducer.test.ts
@@ -1,7 +1,7 @@
 // discovery client reducer
 import {
-  mockHealthResponse,
-  mockServerHealthResponse,
+  mockLegacyHealthResponse,
+  mockLegacyServerHealthResponse,
   mockHealthErrorJsonResponse,
 } from '../../__fixtures__/health'
 
@@ -43,19 +43,19 @@ describe('robotsByName reducer', () => {
       initialRobots: [
         {
           name: 'opentrons-1',
-          health: mockHealthResponse,
-          serverHealth: mockServerHealthResponse,
+          health: mockLegacyHealthResponse,
+          serverHealth: mockLegacyServerHealthResponse,
           addresses: [],
         },
         {
           name: 'opentrons-2',
           health: null,
-          serverHealth: mockServerHealthResponse,
+          serverHealth: mockLegacyServerHealthResponse,
           addresses: [],
         },
         {
           name: 'opentrons-3',
-          health: mockHealthResponse,
+          health: mockLegacyHealthResponse,
           serverHealth: null,
           addresses: [],
         },
@@ -66,17 +66,17 @@ describe('robotsByName reducer', () => {
     expect(state).toEqual({
       'opentrons-1': {
         name: 'opentrons-1',
-        health: mockHealthResponse,
-        serverHealth: mockServerHealthResponse,
+        health: mockLegacyHealthResponse,
+        serverHealth: mockLegacyServerHealthResponse,
       },
       'opentrons-2': {
         name: 'opentrons-2',
         health: null,
-        serverHealth: mockServerHealthResponse,
+        serverHealth: mockLegacyServerHealthResponse,
       },
       'opentrons-3': {
         name: 'opentrons-3',
-        health: mockHealthResponse,
+        health: mockLegacyHealthResponse,
         serverHealth: null,
       },
     })
@@ -87,6 +87,7 @@ describe('robotsByName reducer', () => {
       name: 'opentrons-dev',
       ip: '127.0.0.1',
       port: 31950,
+      robotModel: null,
     })
     const initialState = {}
 
@@ -125,8 +126,8 @@ describe('robotsByName reducer', () => {
     const action = Actions.healthPolled({
       ip: '127.0.0.1',
       port: 31950,
-      health: mockHealthResponse,
-      serverHealth: mockServerHealthResponse,
+      health: mockLegacyHealthResponse,
+      serverHealth: mockLegacyServerHealthResponse,
       healthError: null,
       serverHealthError: null,
     })
@@ -136,8 +137,8 @@ describe('robotsByName reducer', () => {
     expect(nextState).toEqual({
       'opentrons-dev': {
         name: 'opentrons-dev',
-        health: mockHealthResponse,
-        serverHealth: mockServerHealthResponse,
+        health: mockLegacyHealthResponse,
+        serverHealth: mockLegacyServerHealthResponse,
       },
     })
   })
@@ -146,8 +147,8 @@ describe('robotsByName reducer', () => {
     const action = Actions.healthPolled({
       ip: '127.0.0.1',
       port: 31950,
-      health: mockHealthResponse,
-      serverHealth: mockServerHealthResponse,
+      health: mockLegacyHealthResponse,
+      serverHealth: mockLegacyServerHealthResponse,
       healthError: null,
       serverHealthError: null,
     })
@@ -163,8 +164,8 @@ describe('robotsByName reducer', () => {
     expect(nextState).toEqual({
       'opentrons-dev': {
         name: 'opentrons-dev',
-        health: mockHealthResponse,
-        serverHealth: mockServerHealthResponse,
+        health: mockLegacyHealthResponse,
+        serverHealth: mockLegacyServerHealthResponse,
       },
     })
   })
@@ -181,8 +182,8 @@ describe('robotsByName reducer', () => {
     const initialState = {
       'opentrons-dev': {
         name: 'opentrons-dev',
-        health: mockHealthResponse,
-        serverHealth: mockServerHealthResponse,
+        health: mockLegacyHealthResponse,
+        serverHealth: mockLegacyServerHealthResponse,
       },
     }
     const nextState = robotsByNameReducer(initialState, action)
@@ -196,7 +197,7 @@ describe('robotsByName reducer', () => {
     const action = Actions.healthPolled({
       ip: '127.0.0.1',
       port: 31950,
-      health: mockHealthResponse,
+      health: mockLegacyHealthResponse,
       serverHealth: null,
       healthError: null,
       serverHealthError: mockHealthErrorJsonResponse,
@@ -205,7 +206,7 @@ describe('robotsByName reducer', () => {
       'opentrons-dev': {
         name: 'opentrons-dev',
         health: null,
-        serverHealth: mockServerHealthResponse,
+        serverHealth: mockLegacyServerHealthResponse,
       },
     }
     const nextState = robotsByNameReducer(initialState, action)
@@ -213,8 +214,8 @@ describe('robotsByName reducer', () => {
     expect(nextState).toEqual({
       'opentrons-dev': {
         name: 'opentrons-dev',
-        health: mockHealthResponse,
-        serverHealth: mockServerHealthResponse,
+        health: mockLegacyHealthResponse,
+        serverHealth: mockLegacyServerHealthResponse,
       },
     })
   })
@@ -224,14 +225,14 @@ describe('robotsByName reducer', () => {
       ip: '127.0.0.1',
       port: 31950,
       health: null,
-      serverHealth: mockServerHealthResponse,
+      serverHealth: mockLegacyServerHealthResponse,
       healthError: mockHealthErrorJsonResponse,
       serverHealthError: null,
     })
     const initialState = {
       'opentrons-dev': {
         name: 'opentrons-dev',
-        health: mockHealthResponse,
+        health: mockLegacyHealthResponse,
         serverHealth: null,
       },
     }
@@ -240,8 +241,8 @@ describe('robotsByName reducer', () => {
     expect(nextState).toEqual({
       'opentrons-dev': {
         name: 'opentrons-dev',
-        health: mockHealthResponse,
-        serverHealth: mockServerHealthResponse,
+        health: mockLegacyHealthResponse,
+        serverHealth: mockLegacyServerHealthResponse,
       },
     })
   })
@@ -250,17 +251,17 @@ describe('robotsByName reducer', () => {
     const action = Actions.healthPolled({
       ip: '127.0.0.1',
       port: 31950,
-      health: mockHealthResponse,
-      serverHealth: mockServerHealthResponse,
+      health: mockLegacyHealthResponse,
+      serverHealth: mockLegacyServerHealthResponse,
       healthError: null,
       serverHealthError: null,
     })
     const initialState = {
       'opentrons-dev': {
         name: 'opentrons-dev',
-        health: { ...mockHealthResponse, api_version: '0.0.0' },
+        health: { ...mockLegacyHealthResponse, api_version: '0.0.0' },
         serverHealth: {
-          ...mockServerHealthResponse,
+          ...mockLegacyServerHealthResponse,
           apiServerVersion: '0.0.0',
         },
       },
@@ -270,8 +271,8 @@ describe('robotsByName reducer', () => {
     expect(nextState).toEqual({
       'opentrons-dev': {
         name: 'opentrons-dev',
-        health: mockHealthResponse,
-        serverHealth: mockServerHealthResponse,
+        health: mockLegacyHealthResponse,
+        serverHealth: mockLegacyServerHealthResponse,
       },
     })
   })
@@ -280,16 +281,16 @@ describe('robotsByName reducer', () => {
     const action = Actions.healthPolled({
       ip: '127.0.0.1',
       port: 31950,
-      health: mockHealthResponse,
-      serverHealth: mockServerHealthResponse,
+      health: mockLegacyHealthResponse,
+      serverHealth: mockLegacyServerHealthResponse,
       healthError: null,
       serverHealthError: null,
     })
     const initialState = {
       'opentrons-dev': {
         name: 'opentrons-dev',
-        health: mockHealthResponse,
-        serverHealth: mockServerHealthResponse,
+        health: mockLegacyHealthResponse,
+        serverHealth: mockLegacyServerHealthResponse,
       },
     }
     const nextState = robotsByNameReducer(initialState, action)
@@ -304,8 +305,8 @@ describe('robotsByName reducer', () => {
     const initialState = {
       'opentrons-dev': {
         name: 'opentrons-dev',
-        health: mockHealthResponse,
-        serverHealth: mockServerHealthResponse,
+        health: mockLegacyHealthResponse,
+        serverHealth: mockLegacyServerHealthResponse,
       },
     }
     const nextState = robotsByNameReducer(initialState, action)
@@ -318,8 +319,8 @@ describe('robotsByName reducer', () => {
     const initialState = {
       'opentrons-other': {
         name: 'opentrons-dev',
-        health: mockHealthResponse,
-        serverHealth: mockServerHealthResponse,
+        health: mockLegacyHealthResponse,
+        serverHealth: mockLegacyServerHealthResponse,
       },
     }
     const nextState = robotsByNameReducer(initialState, action)

--- a/discovery-client/src/store/__tests__/selectors.test.ts
+++ b/discovery-client/src/store/__tests__/selectors.test.ts
@@ -1,6 +1,6 @@
 import {
-  mockHealthResponse,
-  mockServerHealthResponse,
+  mockLegacyHealthResponse,
+  mockLegacyServerHealthResponse,
   mockHealthErrorJsonResponse,
   mockHealthFetchErrorResponse,
 } from '../../__fixtures__/health'
@@ -19,17 +19,17 @@ const STATE: State = {
   robotsByName: {
     'opentrons-1': {
       name: 'opentrons-1',
-      health: mockHealthResponse,
-      serverHealth: mockServerHealthResponse,
+      health: mockLegacyHealthResponse,
+      serverHealth: mockLegacyServerHealthResponse,
     },
     'opentrons-2': {
       name: 'opentrons-2',
       health: null,
-      serverHealth: mockServerHealthResponse,
+      serverHealth: mockLegacyServerHealthResponse,
     },
     'opentrons-3': {
       name: 'opentrons-3',
-      health: mockHealthResponse,
+      health: mockLegacyHealthResponse,
       serverHealth: null,
     },
   },
@@ -43,6 +43,7 @@ const STATE: State = {
       healthError: null,
       serverHealthError: null,
       robotName: 'opentrons-1',
+      advertisedModel: null,
     },
     '127.0.0.3': {
       ip: '127.0.0.3',
@@ -53,6 +54,7 @@ const STATE: State = {
       healthError: mockHealthErrorJsonResponse,
       serverHealthError: mockHealthErrorJsonResponse,
       robotName: 'opentrons-2',
+      advertisedModel: 'OT-2 Standard',
     },
     '127.0.0.4': {
       ip: '127.0.0.4',
@@ -63,6 +65,7 @@ const STATE: State = {
       healthError: mockHealthFetchErrorResponse,
       serverHealthError: mockHealthFetchErrorResponse,
       robotName: 'opentrons-2',
+      advertisedModel: 'OT-2 Standard',
     },
   },
   manualAddresses: [
@@ -77,17 +80,17 @@ describe('discovery client state selectors', () => {
     expect(Selectors.getRobotStates(STATE)).toEqual([
       {
         name: 'opentrons-1',
-        health: mockHealthResponse,
-        serverHealth: mockServerHealthResponse,
+        health: mockLegacyHealthResponse,
+        serverHealth: mockLegacyServerHealthResponse,
       },
       {
         name: 'opentrons-2',
         health: null,
-        serverHealth: mockServerHealthResponse,
+        serverHealth: mockLegacyServerHealthResponse,
       },
       {
         name: 'opentrons-3',
-        health: mockHealthResponse,
+        health: mockLegacyHealthResponse,
         serverHealth: null,
       },
     ])
@@ -104,6 +107,7 @@ describe('discovery client state selectors', () => {
         healthError: null,
         serverHealthError: null,
         robotName: 'opentrons-1',
+        advertisedModel: null,
       },
       {
         ip: '127.0.0.3',
@@ -114,6 +118,7 @@ describe('discovery client state selectors', () => {
         healthError: mockHealthErrorJsonResponse,
         serverHealthError: mockHealthErrorJsonResponse,
         robotName: 'opentrons-2',
+        advertisedModel: 'OT-2 Standard',
       },
       {
         ip: '127.0.0.4',
@@ -124,6 +129,7 @@ describe('discovery client state selectors', () => {
         healthError: mockHealthFetchErrorResponse,
         serverHealthError: mockHealthFetchErrorResponse,
         robotName: 'opentrons-2',
+        advertisedModel: 'OT-2 Standard',
       },
     ])
   })
@@ -132,8 +138,8 @@ describe('discovery client state selectors', () => {
     expect(Selectors.getRobots(STATE)).toEqual([
       {
         name: 'opentrons-1',
-        health: mockHealthResponse,
-        serverHealth: mockServerHealthResponse,
+        health: mockLegacyHealthResponse,
+        serverHealth: mockLegacyServerHealthResponse,
         addresses: [
           {
             ip: '127.0.0.2',
@@ -143,13 +149,14 @@ describe('discovery client state selectors', () => {
             serverHealthStatus: null,
             healthError: null,
             serverHealthError: null,
+            advertisedModel: null,
           },
         ],
       },
       {
         name: 'opentrons-2',
         health: null,
-        serverHealth: mockServerHealthResponse,
+        serverHealth: mockLegacyServerHealthResponse,
         addresses: [
           {
             ip: '127.0.0.3',
@@ -159,6 +166,7 @@ describe('discovery client state selectors', () => {
             serverHealthStatus: HEALTH_STATUS_NOT_OK,
             healthError: mockHealthErrorJsonResponse,
             serverHealthError: mockHealthErrorJsonResponse,
+            advertisedModel: 'OT-2 Standard',
           },
           {
             ip: '127.0.0.4',
@@ -168,12 +176,13 @@ describe('discovery client state selectors', () => {
             serverHealthStatus: HEALTH_STATUS_UNREACHABLE,
             healthError: mockHealthFetchErrorResponse,
             serverHealthError: mockHealthFetchErrorResponse,
+            advertisedModel: 'OT-2 Standard',
           },
         ],
       },
       {
         name: 'opentrons-3',
-        health: mockHealthResponse,
+        health: mockLegacyHealthResponse,
         serverHealth: null,
         addresses: [],
       },

--- a/discovery-client/src/store/types.ts
+++ b/discovery-client/src/store/types.ts
@@ -67,6 +67,8 @@ export interface HostState extends Address {
   serverHealthError: HealthErrorResponse | null
   /** Robot that this IP points to */
   robotName: string
+  /** the robot model advertised in mdns, if known */
+  advertisedModel: string | null
 }
 
 export interface RobotsByNameMap {

--- a/discovery-client/src/types.ts
+++ b/discovery-client/src/types.ts
@@ -17,6 +17,7 @@ export interface HealthResponse {
   protocol_api_version?: [number, number]
   minimum_protocol_api_version?: [number, number]
   maximum_protocol_api_version?: [number, number]
+  robot_model?: string
 }
 
 export type Capability =
@@ -39,6 +40,7 @@ export interface ServerHealthResponse {
   systemVersion: string
   capabilities?: CapabilityMap
   bootId?: string
+  robotModel?: string
 }
 
 export interface HealthErrorResponse {


### PR DESCRIPTION
We previously could figure out whether a robot was an OT-2 or OT-3 based
on an element of the robot server health response, sent to us by the
discovery client. However, this isn't robust enough for all the
different places we display information about robots - somtimes we can't
get the health response but still want to display information.

As of https://github.com/Opentrons/opentrons/pull/11295 , robots
advertise their robot model in
- a TXT record attached to their MDNS advertisements
- the health response presented by the update server
in addition to the presentation in the health response from the robot
server.

The discovery client now harvests (and presents proper types for) all
this data and sends it upstream to whatever is listening, with a new
advertisedModel field for the MDNS response, and a proper shape for the
health data from the update server.

We need to coalesce these three data sources into a single robust
presentation of the robot model, which we do in the app's 
discovery-client interface layer. That coalesced data goes in the app's 
redux store.

We coalesce the data by taking the first valid element from the
prioritized list (/health, /server/update/health, mdns) where validity
means that the response is present; the key containing the model is
present; and the model is regex-valid to known models. If any element is
missing or not present, it is skipped. If no element is valid or
present, then for now we default to saying that the robot is an OT-2. In
the future, that might be a decision we want to make at a higher level.

## Review Requests
- It's been a while since I wrote any jslike, and technically this is the first time I've written typescript; please don't hold back on style or anything else
- Similarly, still getting back into the swing of the way things are tested in the app
- Do we want a different style of selector? Do we want a separate hook for this? 
- I think @koji was doing a frontend pr that will work great on top of this, but also I can add some frontend stuff if we want, like changing the displayed model in the devices page

## Testing
- A bit of a pain without any UI given that we don't actually store the coalesced data in redux, that logic is in a selector. Willing to change that, but for now we really just need to make sure nothing crashes I guess.

Closes RCORE-67
