### PR TITLE
feat(app): create StepMeter and WizardHeader components

### DIFF
--- a/app/src/assets/localization/en/shared.json
+++ b/app/src/assets/localization/en/shared.json
@@ -36,5 +36,6 @@
   "protocol_run_general_error_msg": "Protocol run could not be created on the robot.",
   "proceed_to_setup": "Proceed to setup",
   "a_software_update_is_available": "A software update is available for this robot. Update to run protocols.",
-  "robot_is_busy_no_protocol_run_allowed": "This robot is busy and can’t run this protocol right now. <robotLink>Go to Robot</robotLink>"
+  "robot_is_busy_no_protocol_run_allowed": "This robot is busy and can’t run this protocol right now. <robotLink>Go to Robot</robotLink>",
+  "step": "Step: {{current}} / {{max}}"
 }

--- a/app/src/atoms/StepMeter/StepMeter.stories.tsx
+++ b/app/src/atoms/StepMeter/StepMeter.stories.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react'
+import {
+  Flex,
+  DIRECTION_ROW,
+  JUSTIFY_FLEX_END,
+  DIRECTION_COLUMN,
+  COLORS,
+  SPACING,
+} from '@opentrons/components'
+import { PrimaryButton, SecondaryButton } from '../buttons/index'
+import { StepMeter } from './index'
+
+import type { Story, Meta } from '@storybook/react'
+
+export default {
+  title: 'App/Atoms/StepMeter',
+  component: StepMeter,
+} as Meta
+
+const Template: Story<React.ComponentProps<typeof StepMeter>> = args => (
+  <StepMeter {...args} />
+)
+
+export const Primary = Template.bind({})
+Primary.args = {
+  totalSteps: 5,
+  currentStep: 2,
+  title: 'Tip Length Calibration',
+  body: (
+    <Flex flexDirection={DIRECTION_COLUMN}>
+      {'this is the body part of the StepMeter'}
+    </Flex>
+  ),
+  footer: (
+    <Flex flexDirection={DIRECTION_ROW} justifyContent={JUSTIFY_FLEX_END}>
+      <Flex marginRight={SPACING.spacing4}>
+        <PrimaryButton backgroundColor={COLORS.blue}>{'Back'}</PrimaryButton>
+      </Flex>
+      <SecondaryButton color={COLORS.blue}>{'Proceed'}</SecondaryButton>
+    </Flex>
+  ),
+  showStepCount: true,
+}
+
+export const NoStepCount = Template.bind({})
+NoStepCount.args = {
+  totalSteps: 5,
+  currentStep: 0,
+  title: 'Tip Length Calibration',
+  body: (
+    <Flex flexDirection={DIRECTION_COLUMN}>
+      {'this is the body part of the StepMeter'}
+    </Flex>
+  ),
+  footer: (
+    <Flex flexDirection={DIRECTION_ROW} justifyContent={JUSTIFY_FLEX_END}>
+      <Flex marginRight={SPACING.spacing4}>
+        <PrimaryButton backgroundColor={COLORS.blue}>{'Back'}</PrimaryButton>
+      </Flex>
+      <SecondaryButton color={COLORS.blue}>{'Proceed'}</SecondaryButton>
+    </Flex>
+  ),
+}

--- a/app/src/atoms/StepMeter/StepMeter.stories.tsx
+++ b/app/src/atoms/StepMeter/StepMeter.stories.tsx
@@ -1,13 +1,5 @@
 import * as React from 'react'
-import {
-  Flex,
-  DIRECTION_ROW,
-  JUSTIFY_FLEX_END,
-  DIRECTION_COLUMN,
-  COLORS,
-  SPACING,
-} from '@opentrons/components'
-import { PrimaryButton, SecondaryButton } from '../buttons/index'
+
 import { StepMeter } from './index'
 
 import type { Story, Meta } from '@storybook/react'
@@ -25,39 +17,4 @@ export const Primary = Template.bind({})
 Primary.args = {
   totalSteps: 5,
   currentStep: 2,
-  title: 'Tip Length Calibration',
-  body: (
-    <Flex flexDirection={DIRECTION_COLUMN}>
-      {'this is the body part of the StepMeter'}
-    </Flex>
-  ),
-  footer: (
-    <Flex flexDirection={DIRECTION_ROW} justifyContent={JUSTIFY_FLEX_END}>
-      <Flex marginRight={SPACING.spacing4}>
-        <PrimaryButton backgroundColor={COLORS.blue}>{'Back'}</PrimaryButton>
-      </Flex>
-      <SecondaryButton color={COLORS.blue}>{'Proceed'}</SecondaryButton>
-    </Flex>
-  ),
-  showStepCount: true,
-}
-
-export const NoStepCount = Template.bind({})
-NoStepCount.args = {
-  totalSteps: 5,
-  currentStep: 0,
-  title: 'Tip Length Calibration',
-  body: (
-    <Flex flexDirection={DIRECTION_COLUMN}>
-      {'this is the body part of the StepMeter'}
-    </Flex>
-  ),
-  footer: (
-    <Flex flexDirection={DIRECTION_ROW} justifyContent={JUSTIFY_FLEX_END}>
-      <Flex marginRight={SPACING.spacing4}>
-        <PrimaryButton backgroundColor={COLORS.blue}>{'Back'}</PrimaryButton>
-      </Flex>
-      <SecondaryButton color={COLORS.blue}>{'Proceed'}</SecondaryButton>
-    </Flex>
-  ),
 }

--- a/app/src/atoms/StepMeter/__tests__/StepMeter.test.tsx
+++ b/app/src/atoms/StepMeter/__tests__/StepMeter.test.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react'
+import { renderWithProviders } from '@opentrons/components'
+import { i18n } from '../../../i18n'
+import { StepMeter } from '..'
+
+const render = (props: React.ComponentProps<typeof StepMeter>) => {
+  return renderWithProviders(<StepMeter {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+describe('StepMeter', () => {
+  let props: React.ComponentProps<typeof StepMeter>
+
+  beforeEach(() => {
+    props = {
+      totalSteps: 5,
+      currentStep: 0,
+    }
+  })
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('renders progress bar at 0% width', () => {
+    const { getByTestId } = render(props)
+    getByTestId('StepMeter_ProgressBarContainer')
+    const bar = getByTestId('StepMeter_ProgressBar')
+    expect(bar).toHaveStyle('width: 0%')
+  })
+
+  it('renders progress bar at 40% width', () => {
+    props = {
+      ...props,
+      currentStep: 2,
+    }
+    const { getByTestId } = render(props)
+    getByTestId('StepMeter_ProgressBarContainer')
+    const bar = getByTestId('StepMeter_ProgressBar')
+    expect(bar).toHaveStyle('width: 40%')
+  })
+})

--- a/app/src/atoms/StepMeter/__tests__/StepMeter.test.tsx
+++ b/app/src/atoms/StepMeter/__tests__/StepMeter.test.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react'
+import { fireEvent } from '@testing-library/react'
+import { i18n } from '../../../i18n'
+import { renderWithProviders } from '@opentrons/components'
+import { StepMeter } from '..'
+
+const render = (props: React.ComponentProps<typeof StepMeter>) => {
+  return renderWithProviders(<StepMeter {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+describe('StepMeter', () => {
+  let props: React.ComponentProps<typeof StepMeter>
+
+  beforeEach(() => {
+    props = {
+      title: 'Tip Length Calibrations',
+      totalSteps: 5,
+      currentStep: 1,
+      body: <div>this is a body</div>,
+      exit: jest.fn(),
+    }
+  })
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('renders correct information with no step count visible and pressing on button calls props', () => {
+    const { getByText, getByRole } = render(props)
+    getByText('Tip Length Calibrations')
+    const exit = getByRole('button', { name: 'exit' })
+    getByText('this is a body')
+    fireEvent.click(exit)
+    expect(props.exit).toHaveBeenCalled()
+  })
+
+  it('renders correct information with step count visible', () => {
+    props = {
+      ...props,
+      showStepCount: true,
+    }
+
+    const { getByText, getByRole } = render(props)
+    getByText('Tip Length Calibrations')
+    getByRole('button', { name: 'exit' })
+    getByText('this is a body')
+    getByText('Step: 1 / 5')
+  })
+  it('renders correct information with a footer', () => {
+    props = {
+      ...props,
+      footer: <div>this is a footer</div>,
+    }
+
+    const { getByText, getByRole } = render(props)
+    getByText('Tip Length Calibrations')
+    getByRole('button', { name: 'exit' })
+    getByText('this is a body')
+    getByText('this is a footer')
+  })
+})

--- a/app/src/atoms/StepMeter/__tests__/StepMeter.test.tsx
+++ b/app/src/atoms/StepMeter/__tests__/StepMeter.test.tsx
@@ -22,21 +22,21 @@ describe('StepMeter', () => {
     jest.resetAllMocks()
   })
 
-  it('renders progress bar at 0% width', () => {
+  it('renders StepMeterBar at 0% width', () => {
     const { getByTestId } = render(props)
-    getByTestId('StepMeter_ProgressBarContainer')
-    const bar = getByTestId('StepMeter_ProgressBar')
+    getByTestId('StepMeter_StepMeterContainer')
+    const bar = getByTestId('StepMeter_StepMeterBar')
     expect(bar).toHaveStyle('width: 0%')
   })
 
-  it('renders progress bar at 40% width', () => {
+  it('renders StepMeterBar at 40% width', () => {
     props = {
       ...props,
       currentStep: 2,
     }
     const { getByTestId } = render(props)
-    getByTestId('StepMeter_ProgressBarContainer')
-    const bar = getByTestId('StepMeter_ProgressBar')
+    getByTestId('StepMeter_StepMeterContainer')
+    const bar = getByTestId('StepMeter_StepMeterBar')
     expect(bar).toHaveStyle('width: 40%')
   })
 })

--- a/app/src/atoms/StepMeter/__tests__/StepMeter.test.tsx
+++ b/app/src/atoms/StepMeter/__tests__/StepMeter.test.tsx
@@ -39,4 +39,16 @@ describe('StepMeter', () => {
     const bar = getByTestId('StepMeter_StepMeterBar')
     expect(bar).toHaveStyle('width: 40%')
   })
+
+  //  this case should never happen
+  it('renders StepMeterBar at 100% width when currentStep is above totalStep', () => {
+    props = {
+      ...props,
+      currentStep: 6,
+    }
+    const { getByTestId } = render(props)
+    getByTestId('StepMeter_StepMeterContainer')
+    const bar = getByTestId('StepMeter_StepMeterBar')
+    expect(bar).toHaveStyle('width: 100%')
+  })
 })

--- a/app/src/atoms/StepMeter/index.tsx
+++ b/app/src/atoms/StepMeter/index.tsx
@@ -1,0 +1,106 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { css } from 'styled-components'
+import {
+  Box,
+  Btn,
+  DIRECTION_ROW,
+  Flex,
+  JUSTIFY_SPACE_BETWEEN,
+  TYPOGRAPHY,
+  COLORS,
+  SPACING,
+  POSITION_RELATIVE,
+  BORDERS,
+  POSITION_ABSOLUTE,
+} from '@opentrons/components'
+import { StyledText } from '../text'
+
+interface StepMeterProps {
+  totalSteps: number
+  currentStep: number | null
+  title: string
+  body: JSX.Element
+  exit: () => void
+  showStepCount?: boolean
+  footer?: JSX.Element
+}
+
+export const StepMeter = (props: StepMeterProps): JSX.Element => {
+  const {
+    totalSteps,
+    currentStep,
+    title,
+    body,
+    exit,
+    showStepCount,
+    footer,
+  } = props
+  const { t } = useTranslation('shared')
+  const progress = currentStep || 0
+  const percentComplete = `${(progress / totalSteps) * 100}%`
+
+  const progressBarContainer = css`
+    position: ${POSITION_RELATIVE};
+    height: ${SPACING.spacing2};
+    margin-bottom: ${SPACING.spacing4};
+    background-color: #d9d9d9;
+  `
+  const progressBar = css`
+    position: ${POSITION_ABSOLUTE};
+    top: 0;
+    height: 100%;
+    background-color: ${COLORS.blue};
+    width: ${percentComplete};
+  `
+
+  return (
+    <Box
+      backgroundColor={COLORS.white}
+      boxShadow={BORDERS.smallDropShadow}
+      borderRadius="0px 0px 4px 4px"
+    >
+      <Flex
+        padding={`${SPACING.spacing4} ${SPACING.spacing6}`}
+        flexDirection={DIRECTION_ROW}
+        justifyContent={JUSTIFY_SPACE_BETWEEN}
+      >
+        <Flex flexDirection={DIRECTION_ROW}>
+          <StyledText css={TYPOGRAPHY.pSemiBold} marginRight={SPACING.spacing3}>
+            {title}
+          </StyledText>
+          {showStepCount ? (
+            <StyledText
+              css={TYPOGRAPHY.pSemiBold}
+              color={COLORS.darkGreyEnabled}
+            >
+              {t('step', { current: currentStep, max: totalSteps })}
+            </StyledText>
+          ) : null}
+        </Flex>
+        <Btn onClick={exit}>
+          <StyledText
+            css={TYPOGRAPHY.pSemiBold}
+            textTransform={TYPOGRAPHY.textTransformCapitalize}
+            color={COLORS.darkGreyEnabled}
+          >
+            {t('exit')}
+          </StyledText>
+        </Btn>
+      </Flex>
+      <Box css={progressBarContainer}>
+        <Box css={progressBar} />
+      </Box>
+      <Box
+        paddingTop={SPACING.spacing6}
+        paddingX={SPACING.spacing6}
+        overflowY="scroll"
+      >
+        {body}
+      </Box>
+      {footer != null ? (
+        <Box padding={`${SPACING.spacing5} ${SPACING.spacing6}`}>{footer}</Box>
+      ) : null}
+    </Box>
+  )
+}

--- a/app/src/atoms/StepMeter/index.tsx
+++ b/app/src/atoms/StepMeter/index.tsx
@@ -16,7 +16,12 @@ interface StepMeterProps {
 export const StepMeter = (props: StepMeterProps): JSX.Element => {
   const { totalSteps, currentStep } = props
   const progress = currentStep || 0
-  const percentComplete = `${(progress / totalSteps) * 100}%`
+  const percentComplete = `${
+    //    this logic puts a cap at 100% percentComplete which we should never run into
+    currentStep != null && currentStep > totalSteps
+      ? 100
+      : (progress / totalSteps) * 100
+  }%`
 
   const StepMeterContainer = css`
     position: ${POSITION_RELATIVE};

--- a/app/src/atoms/StepMeter/index.tsx
+++ b/app/src/atoms/StepMeter/index.tsx
@@ -28,7 +28,7 @@ export const StepMeter = (props: StepMeterProps): JSX.Element => {
     position: ${POSITION_ABSOLUTE};
     top: 0;
     height: 100%;
-    background-color: ${COLORS.blue};
+    background-color: ${COLORS.blueEnabled};
     width: ${percentComplete};
     webkit-transition: width 1s ease-in-out;
     moz-transition: width 1s ease-in-out;

--- a/app/src/atoms/StepMeter/index.tsx
+++ b/app/src/atoms/StepMeter/index.tsx
@@ -1,42 +1,20 @@
 import * as React from 'react'
-import { useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
 import {
   Box,
-  Btn,
-  DIRECTION_ROW,
-  Flex,
-  JUSTIFY_SPACE_BETWEEN,
-  TYPOGRAPHY,
   COLORS,
   SPACING,
   POSITION_RELATIVE,
-  BORDERS,
   POSITION_ABSOLUTE,
 } from '@opentrons/components'
-import { StyledText } from '../text'
 
 interface StepMeterProps {
   totalSteps: number
   currentStep: number | null
-  title: string
-  body: JSX.Element
-  exit: () => void
-  showStepCount?: boolean
-  footer?: JSX.Element
 }
 
 export const StepMeter = (props: StepMeterProps): JSX.Element => {
-  const {
-    totalSteps,
-    currentStep,
-    title,
-    body,
-    exit,
-    showStepCount,
-    footer,
-  } = props
-  const { t } = useTranslation('shared')
+  const { totalSteps, currentStep } = props
   const progress = currentStep || 0
   const percentComplete = `${(progress / totalSteps) * 100}%`
 
@@ -52,55 +30,15 @@ export const StepMeter = (props: StepMeterProps): JSX.Element => {
     height: 100%;
     background-color: ${COLORS.blue};
     width: ${percentComplete};
+    webkit-transition: width 1s ease-in-out;
+    moz-transition: width 1s ease-in-out;
+    o-transition: width 1s ease-in-out;
+    transition: width 1s ease-in-out;
   `
 
   return (
-    <Box
-      backgroundColor={COLORS.white}
-      boxShadow={BORDERS.smallDropShadow}
-      borderRadius="0px 0px 4px 4px"
-    >
-      <Flex
-        padding={`${SPACING.spacing4} ${SPACING.spacing6}`}
-        flexDirection={DIRECTION_ROW}
-        justifyContent={JUSTIFY_SPACE_BETWEEN}
-      >
-        <Flex flexDirection={DIRECTION_ROW}>
-          <StyledText css={TYPOGRAPHY.pSemiBold} marginRight={SPACING.spacing3}>
-            {title}
-          </StyledText>
-          {showStepCount ? (
-            <StyledText
-              css={TYPOGRAPHY.pSemiBold}
-              color={COLORS.darkGreyEnabled}
-            >
-              {t('step', { current: currentStep, max: totalSteps })}
-            </StyledText>
-          ) : null}
-        </Flex>
-        <Btn onClick={exit}>
-          <StyledText
-            css={TYPOGRAPHY.pSemiBold}
-            textTransform={TYPOGRAPHY.textTransformCapitalize}
-            color={COLORS.darkGreyEnabled}
-          >
-            {t('exit')}
-          </StyledText>
-        </Btn>
-      </Flex>
-      <Box css={progressBarContainer}>
-        <Box css={progressBar} />
-      </Box>
-      <Box
-        paddingTop={SPACING.spacing6}
-        paddingX={SPACING.spacing6}
-        overflowY="scroll"
-      >
-        {body}
-      </Box>
-      {footer != null ? (
-        <Box padding={`${SPACING.spacing5} ${SPACING.spacing6}`}>{footer}</Box>
-      ) : null}
+    <Box css={progressBarContainer}>
+      <Box css={progressBar} />
     </Box>
   )
 }

--- a/app/src/atoms/StepMeter/index.tsx
+++ b/app/src/atoms/StepMeter/index.tsx
@@ -37,8 +37,11 @@ export const StepMeter = (props: StepMeterProps): JSX.Element => {
   `
 
   return (
-    <Box css={progressBarContainer}>
-      <Box css={progressBar} />
+    <Box
+      data-testid="StepMeter_ProgressBarContainer"
+      css={progressBarContainer}
+    >
+      <Box data-testid="StepMeter_ProgressBar" css={progressBar} />
     </Box>
   )
 }

--- a/app/src/atoms/StepMeter/index.tsx
+++ b/app/src/atoms/StepMeter/index.tsx
@@ -18,13 +18,13 @@ export const StepMeter = (props: StepMeterProps): JSX.Element => {
   const progress = currentStep || 0
   const percentComplete = `${(progress / totalSteps) * 100}%`
 
-  const progressBarContainer = css`
+  const StepMeterContainer = css`
     position: ${POSITION_RELATIVE};
     height: ${SPACING.spacing2};
     margin-bottom: ${SPACING.spacing4};
     background-color: ${COLORS.medGreyEnabled};
   `
-  const progressBar = css`
+  const StepMeterBar = css`
     position: ${POSITION_ABSOLUTE};
     top: 0;
     height: 100%;
@@ -37,11 +37,8 @@ export const StepMeter = (props: StepMeterProps): JSX.Element => {
   `
 
   return (
-    <Box
-      data-testid="StepMeter_ProgressBarContainer"
-      css={progressBarContainer}
-    >
-      <Box data-testid="StepMeter_ProgressBar" css={progressBar} />
+    <Box data-testid="StepMeter_StepMeterContainer" css={StepMeterContainer}>
+      <Box data-testid="StepMeter_StepMeterBar" css={StepMeterBar} />
     </Box>
   )
 }

--- a/app/src/atoms/StepMeter/index.tsx
+++ b/app/src/atoms/StepMeter/index.tsx
@@ -22,7 +22,7 @@ export const StepMeter = (props: StepMeterProps): JSX.Element => {
     position: ${POSITION_RELATIVE};
     height: ${SPACING.spacing2};
     margin-bottom: ${SPACING.spacing4};
-    background-color: #d9d9d9;
+    background-color: ${COLORS.medGreyEnabled};
   `
   const progressBar = css`
     position: ${POSITION_ABSOLUTE};

--- a/app/src/atoms/WizardHeader/WizardHeader.stories.tsx
+++ b/app/src/atoms/WizardHeader/WizardHeader.stories.tsx
@@ -39,25 +39,4 @@ Primary.args = {
       <SecondaryButton color={COLORS.blue}>{'Proceed'}</SecondaryButton>
     </Flex>
   ),
-  showStepCount: true,
-}
-
-export const NoStepCount = Template.bind({})
-NoStepCount.args = {
-  totalSteps: 5,
-  currentStep: 0,
-  title: 'Tip Length Calibration',
-  body: (
-    <Flex flexDirection={DIRECTION_COLUMN}>
-      {'this is the body part of the StepMeter'}
-    </Flex>
-  ),
-  footer: (
-    <Flex flexDirection={DIRECTION_ROW} justifyContent={JUSTIFY_FLEX_END}>
-      <Flex marginRight={SPACING.spacing4}>
-        <PrimaryButton backgroundColor={COLORS.blue}>{'Back'}</PrimaryButton>
-      </Flex>
-      <SecondaryButton color={COLORS.blue}>{'Proceed'}</SecondaryButton>
-    </Flex>
-  ),
 }

--- a/app/src/atoms/WizardHeader/WizardHeader.stories.tsx
+++ b/app/src/atoms/WizardHeader/WizardHeader.stories.tsx
@@ -1,13 +1,4 @@
 import * as React from 'react'
-import {
-  Flex,
-  DIRECTION_ROW,
-  JUSTIFY_FLEX_END,
-  DIRECTION_COLUMN,
-  COLORS,
-  SPACING,
-} from '@opentrons/components'
-import { PrimaryButton, SecondaryButton } from '../buttons/index'
 import { WizardHeader } from './index'
 
 import type { Story, Meta } from '@storybook/react'
@@ -26,17 +17,4 @@ Primary.args = {
   totalSteps: 5,
   currentStep: 2,
   title: 'Tip Length Calibration',
-  body: (
-    <Flex flexDirection={DIRECTION_COLUMN}>
-      {'this is the body part of the Wizard'}
-    </Flex>
-  ),
-  footer: (
-    <Flex flexDirection={DIRECTION_ROW} justifyContent={JUSTIFY_FLEX_END}>
-      <Flex marginRight={SPACING.spacing4}>
-        <PrimaryButton backgroundColor={COLORS.blue}>{'Back'}</PrimaryButton>
-      </Flex>
-      <SecondaryButton color={COLORS.blue}>{'Proceed'}</SecondaryButton>
-    </Flex>
-  ),
 }

--- a/app/src/atoms/WizardHeader/WizardHeader.stories.tsx
+++ b/app/src/atoms/WizardHeader/WizardHeader.stories.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react'
+import {
+  Flex,
+  DIRECTION_ROW,
+  JUSTIFY_FLEX_END,
+  DIRECTION_COLUMN,
+  COLORS,
+  SPACING,
+} from '@opentrons/components'
+import { PrimaryButton, SecondaryButton } from '../buttons/index'
+import { WizardHeader } from './index'
+
+import type { Story, Meta } from '@storybook/react'
+
+export default {
+  title: 'App/Atoms/WizardHeader',
+  component: WizardHeader,
+} as Meta
+
+const Template: Story<React.ComponentProps<typeof WizardHeader>> = args => (
+  <WizardHeader {...args} />
+)
+
+export const Primary = Template.bind({})
+Primary.args = {
+  totalSteps: 5,
+  currentStep: 2,
+  title: 'Tip Length Calibration',
+  body: (
+    <Flex flexDirection={DIRECTION_COLUMN}>
+      {'this is the body part of the Wizard'}
+    </Flex>
+  ),
+  footer: (
+    <Flex flexDirection={DIRECTION_ROW} justifyContent={JUSTIFY_FLEX_END}>
+      <Flex marginRight={SPACING.spacing4}>
+        <PrimaryButton backgroundColor={COLORS.blue}>{'Back'}</PrimaryButton>
+      </Flex>
+      <SecondaryButton color={COLORS.blue}>{'Proceed'}</SecondaryButton>
+    </Flex>
+  ),
+  showStepCount: true,
+}
+
+export const NoStepCount = Template.bind({})
+NoStepCount.args = {
+  totalSteps: 5,
+  currentStep: 0,
+  title: 'Tip Length Calibration',
+  body: (
+    <Flex flexDirection={DIRECTION_COLUMN}>
+      {'this is the body part of the StepMeter'}
+    </Flex>
+  ),
+  footer: (
+    <Flex flexDirection={DIRECTION_ROW} justifyContent={JUSTIFY_FLEX_END}>
+      <Flex marginRight={SPACING.spacing4}>
+        <PrimaryButton backgroundColor={COLORS.blue}>{'Back'}</PrimaryButton>
+      </Flex>
+      <SecondaryButton color={COLORS.blue}>{'Proceed'}</SecondaryButton>
+    </Flex>
+  ),
+}

--- a/app/src/atoms/WizardHeader/__tests__/WizardHeader.test.tsx
+++ b/app/src/atoms/WizardHeader/__tests__/WizardHeader.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { fireEvent } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../i18n'
 import { StepMeter } from '../../StepMeter'
@@ -50,5 +50,6 @@ describe('WizardHeader', () => {
     const { getByText, getByRole } = render(props)
     getByText('Tip Length Calibrations')
     getByRole('button', { name: 'exit' })
+    expect(screen.queryByText('Step: 0 / 5')).not.toBeInTheDocument()
   })
 })

--- a/app/src/atoms/WizardHeader/__tests__/WizardHeader.test.tsx
+++ b/app/src/atoms/WizardHeader/__tests__/WizardHeader.test.tsx
@@ -22,9 +22,8 @@ describe('WizardHeader', () => {
     props = {
       title: 'Tip Length Calibrations',
       totalSteps: 5,
-      currentStep: 1,
-      body: <div>this is a body</div>,
       onExit: jest.fn(),
+      currentStep: 1,
     }
     mockStepMeter.mockReturnValue(<div>step meter</div>)
   })
@@ -36,7 +35,6 @@ describe('WizardHeader', () => {
     const { getByText, getByRole } = render(props)
     getByText('Tip Length Calibrations')
     const exit = getByRole('button', { name: 'exit' })
-    getByText('this is a body')
     fireEvent.click(exit)
     expect(props.onExit).toHaveBeenCalled()
     getByText('step meter')
@@ -45,28 +43,12 @@ describe('WizardHeader', () => {
 
   it('renders correct information with no step count visible', () => {
     props = {
-      title: 'Tip Length Calibrations',
-      totalSteps: 5,
-      currentStep: 0,
-      body: <div>this is a body</div>,
-      onExit: jest.fn(),
-    }
-
-    const { getByText, getByRole } = render(props)
-    getByText('Tip Length Calibrations')
-    getByRole('button', { name: 'exit' })
-    getByText('this is a body')
-  })
-  it('renders correct information with a footer', () => {
-    props = {
       ...props,
-      footer: <div>this is a footer</div>,
+      currentStep: 0,
     }
 
     const { getByText, getByRole } = render(props)
     getByText('Tip Length Calibrations')
     getByRole('button', { name: 'exit' })
-    getByText('this is a body')
-    getByText('this is a footer')
   })
 })

--- a/app/src/atoms/WizardHeader/__tests__/WizardHeader.test.tsx
+++ b/app/src/atoms/WizardHeader/__tests__/WizardHeader.test.tsx
@@ -32,7 +32,7 @@ describe('WizardHeader', () => {
     jest.resetAllMocks()
   })
 
-  it('renders correct information with no step count visible and pressing on button calls props', () => {
+  it('renders correct information with step count visible and pressing on button calls props', () => {
     const { getByText, getByRole } = render(props)
     getByText('Tip Length Calibrations')
     const exit = getByRole('button', { name: 'exit' })
@@ -40,19 +40,22 @@ describe('WizardHeader', () => {
     fireEvent.click(exit)
     expect(props.onExit).toHaveBeenCalled()
     getByText('step meter')
+    getByText('Step: 1 / 5')
   })
 
-  it('renders correct information with step count visible', () => {
+  it('renders correct information with no step count visible', () => {
     props = {
-      ...props,
-      showStepCount: true,
+      title: 'Tip Length Calibrations',
+      totalSteps: 5,
+      currentStep: 0,
+      body: <div>this is a body</div>,
+      onExit: jest.fn(),
     }
 
     const { getByText, getByRole } = render(props)
     getByText('Tip Length Calibrations')
     getByRole('button', { name: 'exit' })
     getByText('this is a body')
-    getByText('Step: 1 / 5')
   })
   it('renders correct information with a footer', () => {
     props = {

--- a/app/src/atoms/WizardHeader/__tests__/WizardHeader.test.tsx
+++ b/app/src/atoms/WizardHeader/__tests__/WizardHeader.test.tsx
@@ -1,17 +1,22 @@
 import * as React from 'react'
 import { fireEvent } from '@testing-library/react'
-import { i18n } from '../../../i18n'
 import { renderWithProviders } from '@opentrons/components'
-import { StepMeter } from '..'
+import { i18n } from '../../../i18n'
+import { StepMeter } from '../../StepMeter'
+import { WizardHeader } from '..'
 
-const render = (props: React.ComponentProps<typeof StepMeter>) => {
-  return renderWithProviders(<StepMeter {...props} />, {
+jest.mock('../../StepMeter')
+
+const mockStepMeter = StepMeter as jest.MockedFunction<typeof StepMeter>
+
+const render = (props: React.ComponentProps<typeof WizardHeader>) => {
+  return renderWithProviders(<WizardHeader {...props} />, {
     i18nInstance: i18n,
   })[0]
 }
 
-describe('StepMeter', () => {
-  let props: React.ComponentProps<typeof StepMeter>
+describe('WizardHeader', () => {
+  let props: React.ComponentProps<typeof WizardHeader>
 
   beforeEach(() => {
     props = {
@@ -19,8 +24,9 @@ describe('StepMeter', () => {
       totalSteps: 5,
       currentStep: 1,
       body: <div>this is a body</div>,
-      exit: jest.fn(),
+      onExit: jest.fn(),
     }
+    mockStepMeter.mockReturnValue(<div>step meter</div>)
   })
   afterEach(() => {
     jest.resetAllMocks()
@@ -32,7 +38,8 @@ describe('StepMeter', () => {
     const exit = getByRole('button', { name: 'exit' })
     getByText('this is a body')
     fireEvent.click(exit)
-    expect(props.exit).toHaveBeenCalled()
+    expect(props.onExit).toHaveBeenCalled()
+    getByText('step meter')
   })
 
   it('renders correct information with step count visible', () => {

--- a/app/src/atoms/WizardHeader/index.tsx
+++ b/app/src/atoms/WizardHeader/index.tsx
@@ -20,20 +20,11 @@ interface WizardHeaderProps {
   title: string
   body: JSX.Element
   onExit: () => void
-  showStepCount?: boolean
   footer?: JSX.Element
 }
 
 export const WizardHeader = (props: WizardHeaderProps): JSX.Element => {
-  const {
-    totalSteps,
-    currentStep,
-    title,
-    body,
-    onExit,
-    showStepCount,
-    footer,
-  } = props
+  const { totalSteps, currentStep, title, body, onExit, footer } = props
   const { t } = useTranslation('shared')
 
   return (
@@ -51,7 +42,7 @@ export const WizardHeader = (props: WizardHeaderProps): JSX.Element => {
           <StyledText css={TYPOGRAPHY.pSemiBold} marginRight={SPACING.spacing3}>
             {title}
           </StyledText>
-          {showStepCount ? (
+          {currentStep != null && currentStep > 0 ? (
             <StyledText
               css={TYPOGRAPHY.pSemiBold}
               color={COLORS.darkGreyEnabled}

--- a/app/src/atoms/WizardHeader/index.tsx
+++ b/app/src/atoms/WizardHeader/index.tsx
@@ -9,7 +9,6 @@ import {
   TYPOGRAPHY,
   COLORS,
   SPACING,
-  BORDERS,
 } from '@opentrons/components'
 import { StyledText } from '../text'
 import { StepMeter } from '../StepMeter'
@@ -18,21 +17,15 @@ interface WizardHeaderProps {
   totalSteps: number
   currentStep: number | null
   title: string
-  body: JSX.Element
   onExit: () => void
-  footer?: JSX.Element
 }
 
 export const WizardHeader = (props: WizardHeaderProps): JSX.Element => {
-  const { totalSteps, currentStep, title, body, onExit, footer } = props
+  const { totalSteps, currentStep, title, onExit } = props
   const { t } = useTranslation('shared')
 
   return (
-    <Box
-      backgroundColor={COLORS.white}
-      boxShadow={BORDERS.smallDropShadow}
-      borderRadius="0px 0px 4px 4px"
-    >
+    <Box backgroundColor={COLORS.white}>
       <Flex
         padding={`${SPACING.spacing4} ${SPACING.spacing6}`}
         flexDirection={DIRECTION_ROW}
@@ -64,16 +57,6 @@ export const WizardHeader = (props: WizardHeaderProps): JSX.Element => {
       </Flex>
 
       <StepMeter totalSteps={totalSteps} currentStep={currentStep} />
-      <Box
-        paddingTop={SPACING.spacing6}
-        paddingX={SPACING.spacing6}
-        overflowY="scroll"
-      >
-        {body}
-      </Box>
-      {footer != null ? (
-        <Box padding={`${SPACING.spacing5} ${SPACING.spacing6}`}>{footer}</Box>
-      ) : null}
     </Box>
   )
 }

--- a/app/src/atoms/WizardHeader/index.tsx
+++ b/app/src/atoms/WizardHeader/index.tsx
@@ -1,0 +1,88 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Box,
+  Btn,
+  DIRECTION_ROW,
+  Flex,
+  JUSTIFY_SPACE_BETWEEN,
+  TYPOGRAPHY,
+  COLORS,
+  SPACING,
+  BORDERS,
+} from '@opentrons/components'
+import { StyledText } from '../text'
+import { StepMeter } from '../StepMeter'
+
+interface WizardHeaderProps {
+  totalSteps: number
+  currentStep: number | null
+  title: string
+  body: JSX.Element
+  onExit: () => void
+  showStepCount?: boolean
+  footer?: JSX.Element
+}
+
+export const WizardHeader = (props: WizardHeaderProps): JSX.Element => {
+  const {
+    totalSteps,
+    currentStep,
+    title,
+    body,
+    onExit,
+    showStepCount,
+    footer,
+  } = props
+  const { t } = useTranslation('shared')
+
+  return (
+    <Box
+      backgroundColor={COLORS.white}
+      boxShadow={BORDERS.smallDropShadow}
+      borderRadius="0px 0px 4px 4px"
+    >
+      <Flex
+        padding={`${SPACING.spacing4} ${SPACING.spacing6}`}
+        flexDirection={DIRECTION_ROW}
+        justifyContent={JUSTIFY_SPACE_BETWEEN}
+      >
+        <Flex flexDirection={DIRECTION_ROW}>
+          <StyledText css={TYPOGRAPHY.pSemiBold} marginRight={SPACING.spacing3}>
+            {title}
+          </StyledText>
+          {showStepCount ? (
+            <StyledText
+              css={TYPOGRAPHY.pSemiBold}
+              color={COLORS.darkGreyEnabled}
+            >
+              {t('step', { current: currentStep, max: totalSteps })}
+            </StyledText>
+          ) : null}
+        </Flex>
+
+        <Btn onClick={onExit}>
+          <StyledText
+            css={TYPOGRAPHY.pSemiBold}
+            textTransform={TYPOGRAPHY.textTransformCapitalize}
+            color={COLORS.darkGreyEnabled}
+          >
+            {t('exit')}
+          </StyledText>
+        </Btn>
+      </Flex>
+
+      <StepMeter totalSteps={totalSteps} currentStep={currentStep} />
+      <Box
+        paddingTop={SPACING.spacing6}
+        paddingX={SPACING.spacing6}
+        overflowY="scroll"
+      >
+        {body}
+      </Box>
+      {footer != null ? (
+        <Box padding={`${SPACING.spacing5} ${SPACING.spacing6}`}>{footer}</Box>
+      ) : null}
+    </Box>
+  )
+}


### PR DESCRIPTION
closes RAUT-81 & RAUT-85

# Overview

This creates both `StepMeter` and `WizardHeader` in the atoms folder, creates a story for each, and a test for `WizardHeader`

# Changelog

- created `StepMeter` component, and a story
- created `WizardHeader` component, a story, and test

# Review requests

- review both stories in Storybook (check out branch and type `make -C components dev`). Check out all the props - should I make this component more generic or more specific?

# Risk assessment

low
