### PR TITLE
refactor(app): Add StatusLabel to storybook

### DIFF
--- a/app/src/atoms/Slideout/Slideout.stories.tsx
+++ b/app/src/atoms/Slideout/Slideout.stories.tsx
@@ -26,7 +26,7 @@ const Children = (
     </StyledText>
 
     <PrimaryBtn
-      backgroundColor={COLORS.blue}
+      backgroundColor={COLORS.blueEnabled}
       marginTop="28rem"
       textTransform={TYPOGRAPHY.textTransformNone}
     >

--- a/app/src/atoms/StatusLabel/StatusLabel.stories.tsx
+++ b/app/src/atoms/StatusLabel/StatusLabel.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { COLORS } from '@opentrons/components'
 import { StatusLabel } from './index'
-// import { StyledText } from '../../atoms/text'
 import type { Story, Meta } from '@storybook/react'
 
 export default {

--- a/app/src/atoms/StatusLabel/StatusLabel.stories.tsx
+++ b/app/src/atoms/StatusLabel/StatusLabel.stories.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react'
+import { COLORS } from '@opentrons/components'
+import { StatusLabel } from './index'
+// import { StyledText } from '../../atoms/text'
+import type { Story, Meta } from '@storybook/react'
+
+export default {
+  title: 'App/Atoms/StatusLabel',
+  component: StatusLabel,
+} as Meta
+
+const Template: Story<React.ComponentProps<typeof StatusLabel>> = args => (
+  <StatusLabel {...args} />
+)
+
+export const Active = Template.bind({})
+Active.args = {
+  status: 'Heating',
+  backgroundColor: COLORS.medBlue,
+  iconColor: COLORS.blueEnabled,
+  pulse: true,
+}
+
+export const Holding = Template.bind({})
+Holding.args = {
+  status: 'Holding at target',
+  backgroundColor: COLORS.medBlue,
+  iconColor: COLORS.blueEnabled,
+  pulse: false,
+}
+
+export const Idle = Template.bind({})
+Idle.args = {
+  status: 'Idle',
+  backgroundColor: COLORS.medGreyEnabled,
+  iconColor: COLORS.darkGreyEnabled,
+  pulse: true,
+}
+
+export const Error = Template.bind({})
+Error.args = {
+  status: 'Error',
+  backgroundColor: COLORS.warningBackground,
+  iconColor: COLORS.warningEnabled,
+  pulse: true,
+}

--- a/app/src/atoms/StatusLabel/__tests__/StatusLabel.test.tsx
+++ b/app/src/atoms/StatusLabel/__tests__/StatusLabel.test.tsx
@@ -1,12 +1,5 @@
 import * as React from 'react'
-import {
-  C_BLUE,
-  C_DARK_BLACK,
-  C_DARK_GRAY,
-  C_SILVER_GRAY,
-  C_SKY_BLUE,
-  renderWithProviders,
-} from '@opentrons/components'
+import { C_SKY_BLUE, COLORS, renderWithProviders } from '@opentrons/components'
 import { StatusLabel } from '..'
 
 const render = (props: React.ComponentProps<typeof StatusLabel>) => {
@@ -20,7 +13,7 @@ describe('StatusLabel', () => {
     props = {
       status: 'Engaged',
       backgroundColor: C_SKY_BLUE,
-      iconColor: C_BLUE,
+      iconColor: COLORS.blueEnabled,
     }
     const { getByText } = render(props)
     expect(getByText('Engaged')).toHaveStyle('backgroundColor: C_SKY_BLUE')
@@ -30,7 +23,7 @@ describe('StatusLabel', () => {
     props = {
       status: 'Disengaged',
       backgroundColor: C_SKY_BLUE,
-      iconColor: C_BLUE,
+      iconColor: COLORS.blueEnabled,
     }
     const { getByText } = render(props)
     expect(getByText('Disengaged')).toHaveStyle('backgroundColor: C_SKY_BLUE')
@@ -39,9 +32,9 @@ describe('StatusLabel', () => {
   it('renders an idle status label with a gray background and text', () => {
     props = {
       status: 'Idle',
-      backgroundColor: C_SILVER_GRAY,
-      iconColor: C_DARK_GRAY,
-      textColor: C_DARK_BLACK,
+      backgroundColor: COLORS.medGreyEnabled,
+      iconColor: COLORS.darkGrey,
+      textColor: COLORS.darkBlackEnabled,
     }
     const { getByText } = render(props)
     expect(getByText('Idle')).toHaveStyle('backgroundColor: C_SILVER_GRAY')
@@ -52,7 +45,7 @@ describe('StatusLabel', () => {
     props = {
       status: 'holding at target',
       backgroundColor: C_SKY_BLUE,
-      iconColor: C_BLUE,
+      iconColor: COLORS.blueEnabled,
     }
     const { getByText } = render(props)
     expect(getByText('holding at target')).toHaveStyle(
@@ -64,7 +57,7 @@ describe('StatusLabel', () => {
     props = {
       status: 'cooling',
       backgroundColor: C_SKY_BLUE,
-      iconColor: C_BLUE,
+      iconColor: COLORS.blueEnabled,
     }
     const { getByText } = render(props)
     expect(getByText('cooling')).toHaveStyle('backgroundColor: C_SKY_BLUE')
@@ -74,7 +67,7 @@ describe('StatusLabel', () => {
     props = {
       status: 'heating',
       backgroundColor: C_SKY_BLUE,
-      iconColor: C_BLUE,
+      iconColor: COLORS.blueEnabled,
     }
     const { getByText } = render(props)
     expect(getByText('heating')).toHaveStyle('backgroundColor: C_SKY_BLUE')
@@ -84,7 +77,7 @@ describe('StatusLabel', () => {
     props = {
       status: 'Engaged',
       backgroundColor: C_SKY_BLUE,
-      iconColor: C_BLUE,
+      iconColor: COLORS.blueEnabled,
       pulse: true,
     }
     const { getByTestId } = render(props)

--- a/app/src/atoms/StatusLabel/index.tsx
+++ b/app/src/atoms/StatusLabel/index.tsx
@@ -5,7 +5,7 @@ import {
   JUSTIFY_SPACE_BETWEEN,
   SPACING,
   ALIGN_CENTER,
-  C_BLUE_PRESSED,
+  COLORS,
   TYPOGRAPHY,
 } from '@opentrons/components'
 
@@ -52,7 +52,7 @@ export const StatusLabel = (props: StatusLabelProps): JSX.Element | null => {
         </Icon>
         <StyledText
           fontSize={TYPOGRAPHY.fontSizeCaption}
-          color={textColor ?? C_BLUE_PRESSED}
+          color={textColor ?? COLORS.bluePressed}
           textTransform={TYPOGRAPHY.textTransformCapitalize}
           marginRight={SPACING.spacing2}
         >


### PR DESCRIPTION


<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR will add statuslabel to storybook and close [RAUT-120](https://opentrons.atlassian.net/jira/software/c/projects/RAUT/boards/75?modal=detail&selectedIssue=RAUT-120)

[Design](https://www.figma.com/file/l7BAJAGICr10ELsSqQD0Sr/Design-System?node-id=2160%3A88771)


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- add statuslabel stories
- update color const
- update color const in the test code
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- [ ] When run `make -C components dev`, StatusLable link shows up in the sidebar
- [ ] Under StatusLable, there are Active, Holding, Idle, and Error
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
