### PR TITLE
fix(app): robotSettings Calibrations tab section title text-align bug

### DIFF
--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsCalibration.tsx
@@ -639,7 +639,7 @@ export function RobotSettingsCalibration({
         </Banner>
       )}
       <Box paddingTop={SPACING.spacing5} paddingBottom={SPACING.spacing5}>
-        <Flex alignItems={ALIGN_CENTER} flexDirection={DIRECTION_COLUMN}>
+        <Flex flexDirection={DIRECTION_COLUMN}>
           <Box marginRight={SPACING.spacing6}>
             <Box css={TYPOGRAPHY.h3SemiBold} marginBottom={SPACING.spacing3}>
               {t('pipette_offset_calibrations_title')}
@@ -662,7 +662,7 @@ export function RobotSettingsCalibration({
       <Line />
       {/* Tip Length Calibration Section */}
       <Box paddingTop={SPACING.spacing5} paddingBottom={SPACING.spacing5}>
-        <Flex alignItems={ALIGN_CENTER} flexDirection={DIRECTION_COLUMN}>
+        <Flex flexDirection={DIRECTION_COLUMN}>
           <Box marginRight={SPACING.spacing6}>
             <Box css={TYPOGRAPHY.h3SemiBold} marginBottom={SPACING.spacing3}>
               {t('tip_length_calibrations_title')}


### PR DESCRIPTION

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This will fix Pipette Offset and Tip Length text-align bug when the window width around 1700px. 
This will close RAUT-122

less than 1600px
![Screen Shot 2022-08-09 at 12 26 07 PM](https://user-images.githubusercontent.com/474225/183757294-e4c45c1a-ed1a-4d9f-a270-fd4b4de60893.png)

more than 1700px
![Screen Shot 2022-08-09 at 12 26 22 PM](https://user-images.githubusercontent.com/474225/183757314-bd4a2418-d512-439c-a0c4-09f3f2a8aa95.png)

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- modify flex property for pipette offset section and tip length section
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- [ ] Pipette Offset section title position and Tip Length section title position are the same as other section titles when window width is less than 1600px
- [ ] Pipette Offset section title position and Tip Length section title position are the same as other section titles when window width is more than 1700px
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
- low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
