### PR TITLE
fix(ot3): fix failing sensor integration test

### DIFF
--- a/hardware/tests/firmware_integration/test_sensors.py
+++ b/hardware/tests/firmware_integration/test_sensors.py
@@ -232,7 +232,6 @@ async def test_set_threshold_sensors(
     await can_messenger.send(node_id=NodeId.pipette_left, message=set_threshold)
 
     response, arbitration_id = await asyncio.wait_for(can_messenger_queue.read(), 1)
-    breakpoint()
     assert isinstance(response, SensorThresholdResponse)
     expected_data = set_threshold.payload.threshold.value
 

--- a/hardware/tests/firmware_integration/test_sensors.py
+++ b/hardware/tests/firmware_integration/test_sensors.py
@@ -152,7 +152,7 @@ async def test_baseline_poll_sensors(
     can_messenger: CanMessenger,
     can_messenger_queue: WaitableCallback,
     sensor_type: SensorType,
-    expected_value: Union[float, Tuple],
+    expected_value: Union[float, Tuple[float, float]],
 ) -> None:
     """We should be able to poll the pressure and capacitive sensor."""
     poll_sensor = BaselineSensorRequest(
@@ -232,7 +232,7 @@ async def test_set_threshold_sensors(
     await can_messenger.send(node_id=NodeId.pipette_left, message=set_threshold)
 
     response, arbitration_id = await asyncio.wait_for(can_messenger_queue.read(), 1)
-
+    breakpoint()
     assert isinstance(response, SensorThresholdResponse)
     expected_data = set_threshold.payload.threshold.value
 


### PR DESCRIPTION
# Overview
The capacitive sensor seems to double the value returned for a reading, each time a request is sent in simulation. When the capacitive driver refactor happens, we should investigate this further. For now this should allow the tests to pass. The test started failing when caila fixed a typing mismatch in the baseline sensor request CAN message.

# Changelog

- Add in an additional test for the environment sensor
- Fix the failing integration test.


# Risk assessment
Low