### PR TITLE
fix(api): make sure instrument serial numbers are either 1 or 0

### DIFF
--- a/api/src/opentrons/config/gripper_config.py
+++ b/api/src/opentrons/config/gripper_config.py
@@ -48,6 +48,8 @@ def _get_offset(def_offset: GripperOffset) -> Offset:
 
 def info_num_to_model(num: int) -> GripperModel:
     model_map = {0: GripperModel.V1, 1: GripperModel.V1}
+    if num not in model_map:
+        num = 0
     return model_map[num]
 
 

--- a/api/src/opentrons/config/gripper_config.py
+++ b/api/src/opentrons/config/gripper_config.py
@@ -49,6 +49,7 @@ def _get_offset(def_offset: GripperOffset) -> Offset:
 def info_num_to_model(num: int) -> GripperModel:
     model_map = {0: GripperModel.V1, 1: GripperModel.V1}
     if num not in model_map:
+        # Right now, the only valid info num entry for pipette and gripper configs is 0
         num = 0
     return model_map[num]
 

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -31,6 +31,7 @@ from .ot3utils import (
     sensor_node_for_mount,
     create_gripper_jaw_move_group,
     create_gripper_jaw_home_group,
+    EEPROM_UNWRITTEN,
 )
 
 try:
@@ -378,8 +379,7 @@ class OT3Controller:
         attached = await self._tool_detector.detect()
 
         def _check_if_eeprom_unwritten(model: int) -> str:
-            unknown_model_num = 65535
-            if model == unknown_model_num:
+            if model == EEPROM_UNWRITTEN:
                 log.warning("Changing unknown model number to 0")
                 return "0"
             return str(model)

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -377,12 +377,12 @@ class OT3Controller:
         await self._probe_core()
         attached = await self._tool_detector.detect()
 
-        def _check_if_eeprom_unwritten(model: int) -> int:
+        def _check_if_eeprom_unwritten(model: int) -> str:
             unknown_model_num = 65535
             if model == unknown_model_num:
                 log.warning("Changing unknown model number to 0")
-                return 0
-            return model
+                return "0"
+            return str(model)
 
         def _synthesize_model_name(
             name: FirmwarePipetteName, model: int
@@ -391,7 +391,7 @@ class OT3Controller:
             #   may need to change also
             return cast(
                 "PipetteModel",
-                name.name + "_v3." + str(_check_if_eeprom_unwritten(model)),
+                name.name + "_v3." + _check_if_eeprom_unwritten(model),
             )
 
         def _build_attached_pip(

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -377,18 +377,15 @@ class OT3Controller:
         await self._probe_core()
         attached = await self._tool_detector.detect()
 
-        def _synthesize_model_name(
-            name: FirmwarePipetteName, model: int
-        ) -> "PipetteModel":
+        def _synthesize_model_name(name: FirmwarePipetteName) -> "PipetteModel":
+            model = 0
             return cast("PipetteModel", name.name + "_v3." + str(model))
 
         def _build_attached_pip(
             attached: ohc_tool_types.PipetteInformation,
         ) -> AttachedPipette:
             return {
-                "config": pipette_config.load(
-                    _synthesize_model_name(attached.name, attached.model)
-                ),
+                "config": pipette_config.load(_synthesize_model_name(attached.name)),
                 "id": attached.serial,
             }
 

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -28,6 +28,7 @@ from .ot3utils import (
     axis_to_node,
     create_gripper_jaw_move_group,
     create_gripper_jaw_home_group,
+    EEPROM_UNWRITTEN,
 )
 
 from opentrons_hardware.firmware_bindings.constants import NodeId
@@ -340,8 +341,7 @@ class OT3Simulator:
     def synthesize_model_name(self, model: int) -> "PipetteModel":
         # TODO: the way we look up pipette config info is changing, so this
         #   may need to change also
-        unknown_model_num = 65535
-        if model == unknown_model_num:
+        if model == EEPROM_UNWRITTEN:
             model = 0
         return cast("PipetteModel", "DummyPipette" + "_v3." + str(model))
 

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -336,6 +336,15 @@ class OT3Simulator:
             for mount in OT3Mount
         }
 
+    # might wanna simulate synthesize model name
+    def synthesize_model_name(self, model: int) -> "PipetteModel":
+        # TODO: the way we look up pipette config info is changing, so this
+        #   may need to change also
+        unknown_model_num = 65535
+        if model == unknown_model_num:
+            model = 0
+        return cast("PipetteModel", "DummyPipette" + "_v3." + str(model))
+
     async def set_active_current(self, axis_currents: OT3AxisMap[float]) -> None:
         """Set the active current.
 

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -37,6 +37,8 @@ GRIPPER_JAW_HOME_TIME: float = 120
 GRIPPER_JAW_GRIP_TIME: float = 1
 GRIPPER_JAW_HOME_DC: float = 100
 
+EEPROM_UNWRITTEN = 65535
+
 # TODO: These methods exist to defer uses of NodeId to inside
 # method bodies, which won't be evaluated until called. This is needed
 # because the robot server doesn't have opentrons_ot3_firmware as a dep

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -256,9 +256,12 @@ async def test_probing(
 
 
 model_numbers = [0, 65535]
+
+
 @pytest.mark.parametrize("model", model_numbers)
-async def test_get_attached_instruments(model: int,
-    controller: OT3Controller, mock_tool_detector: OneshotToolDetector):
+async def test_get_attached_instruments(
+    model: int, controller: OT3Controller, mock_tool_detector: OneshotToolDetector
+):
     async def fake_probe(can_messenger, expected, timeout):
         return set((NodeId.gantry_x, NodeId.gantry_y, NodeId.head, NodeId.gripper))
 
@@ -266,7 +269,9 @@ async def test_get_attached_instruments(model: int,
         assert await controller.get_attached_instruments({}) == {}
 
     mock_tool_detector.return_value = ToolSummary(
-        left=PipetteInformation(name=PipetteName.p1000_single, model=model, serial="hello"),
+        left=PipetteInformation(
+            name=PipetteName.p1000_single, model=model, serial="hello"
+        ),
         right=None,
         gripper=GripperInformation(model=model, serial="fake_serial"),
     )
@@ -278,6 +283,7 @@ async def test_get_attached_instruments(model: int,
     assert detected[OT3Mount.LEFT]["config"].name == "p1000_single_gen3"
     assert detected[OT3Mount.GRIPPER]["id"] == "fake_serial"
     assert detected[OT3Mount.GRIPPER]["config"].name == "gripper"
+
 
 def test_nodeid_replace_head():
     assert OT3Controller._replace_head_node(set([NodeId.head, NodeId.gantry_x])) == set(

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -255,9 +255,10 @@ async def test_probing(
     )
 
 
-async def test_get_attached_instruments(
-    controller: OT3Controller, mock_tool_detector: OneshotToolDetector
-):
+model_numbers = [0, 65535]
+@pytest.mark.parametrize("model", model_numbers)
+async def test_get_attached_instruments(model: int,
+    controller: OT3Controller, mock_tool_detector: OneshotToolDetector):
     async def fake_probe(can_messenger, expected, timeout):
         return set((NodeId.gantry_x, NodeId.gantry_y, NodeId.head, NodeId.gripper))
 
@@ -265,9 +266,9 @@ async def test_get_attached_instruments(
         assert await controller.get_attached_instruments({}) == {}
 
     mock_tool_detector.return_value = ToolSummary(
-        left=PipetteInformation(name=PipetteName.p1000_single, model=0, serial="hello"),
+        left=PipetteInformation(name=PipetteName.p1000_single, model=model, serial="hello"),
         right=None,
-        gripper=GripperInformation(model=0, serial="fake_serial"),
+        gripper=GripperInformation(model=model, serial="fake_serial"),
     )
 
     with patch("opentrons.hardware_control.backends.ot3controller.probe", fake_probe):
@@ -277,7 +278,6 @@ async def test_get_attached_instruments(
     assert detected[OT3Mount.LEFT]["config"].name == "p1000_single_gen3"
     assert detected[OT3Mount.GRIPPER]["id"] == "fake_serial"
     assert detected[OT3Mount.GRIPPER]["config"].name == "gripper"
-
 
 def test_nodeid_replace_head():
     assert OT3Controller._replace_head_node(set([NodeId.head, NodeId.gantry_x])) == set(

--- a/api/tests/opentrons/hardware_control/test_pipette.py
+++ b/api/tests/opentrons/hardware_control/test_pipette.py
@@ -4,7 +4,6 @@ from opentrons.types import Point
 from opentrons.hardware_control.instruments import pipette
 from opentrons.hardware_control import types
 from opentrons.config import pipette_config
-from opentrons.hardware_control.backends.ot3simulator import OT3Simulator
 
 
 PIP_CAL = cal_types.PipetteOffsetByPipetteMount(

--- a/api/tests/opentrons/hardware_control/test_pipette.py
+++ b/api/tests/opentrons/hardware_control/test_pipette.py
@@ -124,8 +124,6 @@ def test_tip_overlap(config_model):
     assert pip.config.tip_overlap == pipette_config.configs[config_model]["tipOverlap"]
 
 
-
-
 def test_flow_rate_setting():
     pip = pipette.Pipette(pipette_config.load("p300_single_v2.0"), PIP_CAL, "testId")
     # pipettes should load settings from config at init time

--- a/api/tests/opentrons/hardware_control/test_pipette.py
+++ b/api/tests/opentrons/hardware_control/test_pipette.py
@@ -124,20 +124,6 @@ def test_tip_overlap(config_model):
     assert pip.config.tip_overlap == pipette_config.configs[config_model]["tipOverlap"]
 
 
-model_numbers = [0, 1, 65535, 700]
-
-
-@pytest.mark.parametrize("model", model_numbers)
-def test_synthesize_model_name(model):
-    """This test makes sure that pipette model names are not being set to an unknown model number
-    as a result of the eeprom being unwritten.
-    """
-    model_name = OT3Simulator.synthesize_model_name(model)
-    unknown_model_num = 65535
-    if model != unknown_model_num:
-        assert model_name[-(len(str(model))) :] == str(model)
-    else:
-        assert model_name[-1] == "0"
 
 
 def test_flow_rate_setting():

--- a/api/tests/opentrons/hardware_control/test_pipette.py
+++ b/api/tests/opentrons/hardware_control/test_pipette.py
@@ -4,6 +4,8 @@ from opentrons.types import Point
 from opentrons.hardware_control.instruments import pipette
 from opentrons.hardware_control import types
 from opentrons.config import pipette_config
+from opentrons.hardware_control.backends.ot3simulator import OT3Simulator
+
 
 PIP_CAL = cal_types.PipetteOffsetByPipetteMount(
     offset=[0, 0, 0],
@@ -120,6 +122,22 @@ def test_tip_overlap(config_model):
     loaded = pipette_config.load(config_model)
     pip = pipette.Pipette(loaded, PIP_CAL, "testId")
     assert pip.config.tip_overlap == pipette_config.configs[config_model]["tipOverlap"]
+
+
+model_numbers = [0, 1, 65535, 700]
+
+
+@pytest.mark.parametrize("model", model_numbers)
+def test_synthesize_model_name(model):
+    """This test makes sure that pipette model names are not being set to an unknown model number
+    as a result of the eeprom being unwritten.
+    """
+    model_name = OT3Simulator.synthesize_model_name(model)
+    unknown_model_num = 65535
+    if model != unknown_model_num:
+        assert model_name[-(len(str(model))) :] == str(model)
+    else:
+        assert model_name[-1] == "0"
 
 
 def test_flow_rate_setting():


### PR DESCRIPTION
If an instrument's serial number isn't written to the eeprom, it was previously defaulting to `65535`, which would cause a lookup error in `OT3API` and prevent it from being used. 

This code defaults all pipette model numbers to 0, and defaults gripper model numbers to 0 if it otherwise wouldn't be found 