### PR TITLE
refactor(api): fix up merge errors from 6.0.1 sync

### DIFF
--- a/api/src/opentrons/protocol_runner/create_simulating_runner.py
+++ b/api/src/opentrons/protocol_runner/create_simulating_runner.py
@@ -1,11 +1,7 @@
 """Simulating ProtocolRunner factory."""
 
 from opentrons.config import feature_flags
-from opentrons.hardware_control import (
-    API as HardwareAPI,
-    SynchronousAdapter,
-    HardwareControlAPI,
-)
+from opentrons.hardware_control import API as HardwareAPI, HardwareControlAPI
 from opentrons.protocol_engine import (
     Config as ProtocolEngineConfig,
     create_protocol_engine,
@@ -66,7 +62,7 @@ async def create_simulating_runner() -> ProtocolRunner:
 
     simulating_legacy_context_creator = (
         LegacySimulatingContextCreator(
-            sync_hardware_api=SynchronousAdapter(simulating_hardware_api),
+            hardware_api=simulating_hardware_api,
             labware_offset_provider=offset_provider,
         )
         if not feature_flags.disable_fast_protocol_upload()

--- a/api/src/opentrons/protocol_runner/legacy_wrappers.py
+++ b/api/src/opentrons/protocol_runner/legacy_wrappers.py
@@ -106,7 +106,7 @@ class LegacyContextCreator:
         Args:
             hardware_api: The hardware control interface.
                 Will be wrapped in a `SynchronousAdapter`.
-                May be real hardware or a simluator.
+                May be real hardware or a simulator.
             labware_offset_provider: Interface for the context to load labware offsets.
         """
         self._hardware_api = hardware_api


### PR DESCRIPTION
## Overview

This PR fixes some remaining errors from the 6.0.1 sync merge to get CI green again on the Python side.

## Changelog

- refactor(api): fix up merge errors from 6.0.1 sync

## Review requests

- [ ] CI is green

## Risk assessment

Low if CI is green
