### PR TITLE
fix(app): H-S test shake input value no longer accepts decimals

### DIFF
--- a/app/src/organisms/Devices/HeaterShakerWizard/TestShake.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/TestShake.tsx
@@ -48,7 +48,7 @@ export function TestShake(props: TestShakeProps): JSX.Element {
   const { t } = useTranslation(['heater_shaker', 'device_details'])
   const { createLiveCommand } = useCreateLiveCommandMutation()
   const [isExpanded, setExpanded] = React.useState(false)
-  const [shakeValue, setShakeValue] = React.useState<string | null>(null)
+  const [shakeValue, setShakeValue] = React.useState<number | null>(null)
   const [targetProps, tooltipProps] = useHoverTooltip()
   const { toggleLatch, isLatchClosed } = useLatchControls(module)
   const isShaking = module.data.speedStatus !== 'idle'
@@ -64,7 +64,7 @@ export function TestShake(props: TestShakeProps): JSX.Element {
     commandType: 'heaterShaker/setAndWaitForShakeSpeed',
     params: {
       moduleId: module.id,
-      rpm: shakeValue !== null ? parseInt(shakeValue) : 0,
+      rpm: shakeValue !== null ? shakeValue : 0,
     },
   }
 
@@ -95,8 +95,7 @@ export function TestShake(props: TestShakeProps): JSX.Element {
   }
 
   const errorMessage =
-    shakeValue != null &&
-    (parseInt(shakeValue) < HS_RPM_MIN || parseInt(shakeValue) > HS_RPM_MAX)
+    shakeValue != null && (shakeValue < HS_RPM_MIN || shakeValue > HS_RPM_MAX)
       ? t('device_details:input_out_of_range')
       : null
 
@@ -181,8 +180,8 @@ export function TestShake(props: TestShakeProps): JSX.Element {
             <InputField
               data-testid="TestShake_shake_input"
               units={RPM}
-              value={shakeValue}
-              onChange={e => setShakeValue(e.target.value)}
+              value={shakeValue != null ? Math.round(shakeValue) : null}
+              onChange={e => setShakeValue(e.target.valueAsNumber)}
               type="number"
               caption={t('min_max_rpm', {
                 min: HS_RPM_MIN,

--- a/app/src/organisms/ModuleCard/HeaterShakerSlideout.tsx
+++ b/app/src/organisms/ModuleCard/HeaterShakerSlideout.tsx
@@ -103,64 +103,62 @@ export const HeaterShakerSlideout = (
   }
 
   return (
-    <>
-      <Slideout
-        title={t('set_status_heater_shaker', {
-          part: modulePart,
-          name: moduleName,
-        })}
-        onCloseClick={handleCloseSlideout}
-        isExpanded={isExpanded}
-        footer={
-          <SubmitPrimaryButton
-            form="HeaterShakerSlideout_submitValue"
-            value={t('confirm')}
-            onClick={sendSetTemperatureOrShakeCommand}
-            disabled={hsValue === null || errorMessage !== null}
-            data-testid={`HeaterShakerSlideout_btn_${module.serialNumber}`}
-          />
-        }
+    <Slideout
+      title={t('set_status_heater_shaker', {
+        part: modulePart,
+        name: moduleName,
+      })}
+      onCloseClick={handleCloseSlideout}
+      isExpanded={isExpanded}
+      footer={
+        <SubmitPrimaryButton
+          form="HeaterShakerSlideout_submitValue"
+          value={t('confirm')}
+          onClick={sendSetTemperatureOrShakeCommand}
+          disabled={hsValue === null || errorMessage !== null}
+          data-testid={`HeaterShakerSlideout_btn_${module.serialNumber}`}
+        />
+      }
+    >
+      <StyledText
+        fontWeight={TYPOGRAPHY.fontWeightRegular}
+        fontSize={TYPOGRAPHY.fontSizeP}
+        paddingTop={SPACING.spacing2}
+        data-testid={`HeaterShakerSlideout_title_${module.serialNumber}`}
+      >
+        {t('set_target_temp_of_hs')}
+      </StyledText>
+      <Flex
+        marginTop={SPACING.spacing4}
+        flexDirection={DIRECTION_COLUMN}
+        data-testid={`HeaterShakerSlideout_input_field_${module.serialNumber}`}
       >
         <StyledText
-          fontWeight={TYPOGRAPHY.fontWeightRegular}
-          fontSize={TYPOGRAPHY.fontSizeP}
-          paddingTop={SPACING.spacing2}
-          data-testid={`HeaterShakerSlideout_title_${module.serialNumber}`}
+          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+          fontSize={TYPOGRAPHY.fontSizeH6}
+          color={COLORS.darkGrey}
+          marginBottom={SPACING.spacing3}
         >
-          {t('set_target_temp_of_hs')}
+          {t('set_block_temp')}
         </StyledText>
-        <Flex
-          marginTop={SPACING.spacing4}
-          flexDirection={DIRECTION_COLUMN}
-          data-testid={`HeaterShakerSlideout_input_field_${module.serialNumber}`}
-        >
-          <StyledText
-            fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-            fontSize={TYPOGRAPHY.fontSizeH6}
-            color={COLORS.darkGrey}
-            marginBottom={SPACING.spacing3}
-          >
-            {t('set_block_temp')}
-          </StyledText>
-          <form id="HeaterShakerSlideout_submitValue">
-            <InputField
-              data-testid={`${module.moduleModel}_setTemp`}
-              id={`${module.moduleModel}_setTemp`}
-              units={unit}
-              autoFocus
-              value={hsValue != null ? Math.round(hsValue) : null}
-              onChange={e => setHsValue(e.target.valueAsNumber)}
-              type="number"
-              caption={t('module_status_range', {
-                min: inputMin,
-                max: inputMax,
-                unit: unit,
-              })}
-              error={errorMessage}
-            />
-          </form>
-        </Flex>
-      </Slideout>
-    </>
+        <form id="HeaterShakerSlideout_submitValue">
+          <InputField
+            data-testid={`${module.moduleModel}_setTemp`}
+            id={`${module.moduleModel}_setTemp`}
+            units={unit}
+            autoFocus
+            value={hsValue != null ? Math.round(hsValue) : null}
+            onChange={e => setHsValue(e.target.valueAsNumber)}
+            type="number"
+            caption={t('module_status_range', {
+              min: inputMin,
+              max: inputMax,
+              unit: unit,
+            })}
+            error={errorMessage}
+          />
+        </form>
+      </Flex>
+    </Slideout>
   )
 }

--- a/app/src/organisms/ModuleCard/TestShakeSlideout.tsx
+++ b/app/src/organisms/ModuleCard/TestShakeSlideout.tsx
@@ -77,7 +77,7 @@ export const TestShakeSlideout = (
   const { toggleLatch, isLatchClosed } = useLatchControls(module)
   const { moduleIdFromRun } = useModuleIdFromRun(module, currentRunId ?? null)
   const configHasHeaterShakerAttached = useSelector(getIsHeaterShakerAttached)
-  const [shakeValue, setShakeValue] = React.useState<string | null>(null)
+  const [shakeValue, setShakeValue] = React.useState<number | null>(null)
   const [showWizard, setShowWizard] = React.useState<boolean>(false)
   const isShaking = module.data.speedStatus !== 'idle'
   const moduleId = isRunIdle ? moduleIdFromRun : module.id
@@ -86,7 +86,7 @@ export const TestShakeSlideout = (
     commandType: 'heaterShaker/setAndWaitForShakeSpeed',
     params: {
       moduleId,
-      rpm: shakeValue !== null ? parseInt(shakeValue) : 0,
+      rpm: shakeValue !== null ? shakeValue : 0,
     },
   }
 
@@ -141,8 +141,7 @@ export const TestShakeSlideout = (
   } = useConditionalConfirm(sendCommands, !configHasHeaterShakerAttached)
 
   const errorMessage =
-    shakeValue != null &&
-    (parseInt(shakeValue) < HS_RPM_MIN || parseInt(shakeValue) > HS_RPM_MAX)
+    shakeValue != null && (shakeValue < HS_RPM_MIN || shakeValue > HS_RPM_MAX)
       ? t('device_details:input_out_of_range')
       : null
 
@@ -273,9 +272,10 @@ export const TestShakeSlideout = (
           >
             <InputField
               data-testid="TestShakeSlideout_shake_input"
+              autoFocus
               units={RPM}
-              value={shakeValue}
-              onChange={e => setShakeValue(e.target.value)}
+              value={shakeValue != null ? Math.round(shakeValue) : null}
+              onChange={e => setShakeValue(e.target.valueAsNumber)}
               type="number"
               caption={t('min_max_rpm', {
                 min: HS_RPM_MIN,


### PR DESCRIPTION
closes RAUT-140

# Overview

`TestShakeSlideout` and `TestShake` input value should no longer accept decimal points

# Changelog

- change input value `value` logic to only accept whole numbers within range for both components
- remove unnecessary React fragment in `HeaterShakerSlideout`
 
# Review requests

- review that the test shake slideout input value only accept whole numbers
- review that the test shake page of the H-S wizard input value only accepts whole numbers

# Risk assessment

low