### PR TITLE
feat(app): create ClearDeckModal and deprecate ClearDeckAlertModal

### DIFF
--- a/app/src/assets/localization/en/change_pipette.json
+++ b/app/src/assets/localization/en/change_pipette.json
@@ -1,0 +1,6 @@
+{
+  "attach_pipette": "Attach a pipette",
+  "detach_pipette": "Detach {{pipette}} from {{mount}} Mount",
+  "remove_labware_before_start": "<h1>Before you begin</h1><block>Before starting, remove all labware from the deck and all tips from pipettes. The gantry will move to the front of the robot.</block>",
+  "get_started": "Get started"
+}

--- a/app/src/assets/localization/en/index.ts
+++ b/app/src/assets/localization/en/index.ts
@@ -1,5 +1,6 @@
 import shared from './shared.json'
 import app_settings from './app_settings.json'
+import change_pipette from './change_pipette.json'
 import commands_run_log from './commands_run_log.json'
 import device_details from './device_details.json'
 import device_settings from './device_settings.json'
@@ -26,6 +27,7 @@ import top_navigation from './top_navigation.json'
 export const en = {
   shared,
   app_settings,
+  change_pipette,
   commands_run_log,
   device_details,
   device_settings,

--- a/app/src/organisms/ChangePipette/ClearDeckModal/ClearDeckAlertModal.tsx
+++ b/app/src/organisms/ChangePipette/ClearDeckModal/ClearDeckAlertModal.tsx
@@ -6,9 +6,14 @@ import removeTrashSrc from '../../../assets/images/remove-trash@3x.png'
 import { Portal } from '../../../App/portal'
 import styles from './styles.css'
 
-export interface ClearDeckAlertModalProps {
+const HEADING = 'Before continuing, please remove:'
+
+/**
+ * @deprecated Use CheckDeckModalProps
+ */
+interface ClearDeckAlertModalProps {
   onContinueClick?: () => unknown
-  onCancelClick?: () => unknown
+  onCancelClick: () => unknown
   parentUrl?: string
   cancelText: string
   continueText: string
@@ -16,8 +21,9 @@ export interface ClearDeckAlertModalProps {
   children?: React.ReactNode
 }
 
-const HEADING = 'Before continuing, please remove:'
-
+/**
+ * @deprecated Use {@link CheckDeckModal}
+ */
 export function ClearDeckAlertModal(
   props: ClearDeckAlertModalProps
 ): JSX.Element {

--- a/app/src/organisms/ChangePipette/ClearDeckModal/index.tsx
+++ b/app/src/organisms/ChangePipette/ClearDeckModal/index.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react'
+import { Trans, useTranslation } from 'react-i18next'
+import {
+  DIRECTION_COLUMN,
+  Flex,
+  SPACING,
+  JUSTIFY_FLEX_END,
+} from '@opentrons/components'
+import { WizardHeader } from '../../../atoms/WizardHeader'
+import { StyledText } from '../../../atoms/text'
+import { PrimaryButton } from '../../../atoms/buttons'
+
+import type { Mount } from '../../../redux/robot/types'
+import type { PipetteModelSpecs } from '@opentrons/shared-data'
+
+export interface ClearDeckModalProps {
+  onContinueClick: () => unknown
+  onCancelClick: () => unknown
+  totalSteps: number
+  currentStep: number
+  mount: Mount
+  pipetteName?: PipetteModelSpecs['displayName']
+}
+
+export function ClearDeckModal(props: ClearDeckModalProps): JSX.Element {
+  const {
+    onContinueClick,
+    onCancelClick,
+    totalSteps,
+    currentStep,
+    mount,
+    pipetteName,
+  } = props
+  const { t } = useTranslation('change_pipette')
+
+  return (
+    <>
+      <WizardHeader
+        totalSteps={totalSteps}
+        currentStep={currentStep}
+        title={
+          pipetteName != null
+            ? t('detach_pipette', {
+                pipette: pipetteName,
+                mount: mount[0].toUpperCase() + mount.slice(1),
+              })
+            : t('attach_pipette')
+        }
+        onExit={onCancelClick}
+      />
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        marginBottom="13.5rem"
+        paddingX={SPACING.spacing6}
+        paddingTop={SPACING.spacing6}
+      >
+        <Trans
+          t={t}
+          i18nKey="remove_labware_before_start"
+          components={{
+            h1: <StyledText as="h1" marginBottom={SPACING.spacing4} />,
+            block: <StyledText as="p" />,
+          }}
+        />
+      </Flex>
+      <Flex justifyContent={JUSTIFY_FLEX_END} marginBottom={SPACING.spacing6}>
+        <PrimaryButton marginX={SPACING.spacing6} onClick={onContinueClick}>
+          {t('get_started')}
+        </PrimaryButton>
+      </Flex>
+    </>
+  )
+}

--- a/app/src/organisms/ChangePipette/ClearDeckModal/index.tsx
+++ b/app/src/organisms/ChangePipette/ClearDeckModal/index.tsx
@@ -10,16 +10,12 @@ import { WizardHeader } from '../../../atoms/WizardHeader'
 import { StyledText } from '../../../atoms/text'
 import { PrimaryButton } from '../../../atoms/buttons'
 
-import type { Mount } from '../../../redux/robot/types'
-import type { PipetteModelSpecs } from '@opentrons/shared-data'
-
 export interface ClearDeckModalProps {
   onContinueClick: () => unknown
   onCancelClick: () => unknown
   totalSteps: number
   currentStep: number
-  mount: Mount
-  pipetteName?: PipetteModelSpecs['displayName']
+  title: string
 }
 
 export function ClearDeckModal(props: ClearDeckModalProps): JSX.Element {
@@ -28,8 +24,7 @@ export function ClearDeckModal(props: ClearDeckModalProps): JSX.Element {
     onCancelClick,
     totalSteps,
     currentStep,
-    mount,
-    pipetteName,
+    title,
   } = props
   const { t } = useTranslation('change_pipette')
 
@@ -38,14 +33,7 @@ export function ClearDeckModal(props: ClearDeckModalProps): JSX.Element {
       <WizardHeader
         totalSteps={totalSteps}
         currentStep={currentStep}
-        title={
-          pipetteName != null
-            ? t('detach_pipette', {
-                pipette: pipetteName,
-                mount: mount[0].toUpperCase() + mount.slice(1),
-              })
-            : t('attach_pipette')
-        }
+        title={title}
         onExit={onCancelClick}
       />
       <Flex

--- a/app/src/organisms/ChangePipette/ClearDeckModal/styles.css
+++ b/app/src/organisms/ChangePipette/ClearDeckModal/styles.css
@@ -1,0 +1,42 @@
+@import '@opentrons/components';
+
+.alert_instructions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.alert_list {
+  padding-left: 1rem;
+  padding-right: 4rem;
+  list-style-type: none;
+
+  & > li {
+    line-height: 2;
+  }
+
+  & > p {
+    @apply --font-body-2-dark;
+
+    margin: 0;
+  }
+}
+
+.alert_diagram {
+  max-height: 10rem;
+}
+
+.alert_note_heading {
+  @apply --font-body-2-dark;
+
+  margin-top: 1.5rem;
+  margin-bottom: 0.25rem;
+  font-weight: var(--fw-semibold);
+  text-transform: uppercase;
+}
+
+.alert_button {
+  width: auto;
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+}

--- a/app/src/organisms/ChangePipette/__tests__/ClearDeckModal.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/ClearDeckModal.test.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react'
 import { fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
-import { LEFT, RIGHT } from '@opentrons/shared-data'
 import { i18n } from '../../../i18n'
 import { ClearDeckModal } from '../ClearDeckModal'
-import type { PipetteModelSpecs } from '@opentrons/shared-data'
 
 const render = (props: React.ComponentProps<typeof ClearDeckModal>) => {
   return renderWithProviders(<ClearDeckModal {...props} />, {
@@ -19,7 +17,7 @@ describe('ClearDeckModal', () => {
       onCancelClick: jest.fn(),
       totalSteps: 5,
       currentStep: 1,
-      mount: LEFT,
+      title: 'Attach a pipette',
     }
   })
   it('renders the correct information when pipette is not attached', () => {
@@ -40,8 +38,7 @@ describe('ClearDeckModal', () => {
   it('renders the correct information when a p10 single gen 1 is attached', () => {
     props = {
       ...props,
-      mount: RIGHT,
-      pipetteName: 'P10 Single-Channel GEN1' as PipetteModelSpecs['displayName'],
+      title: 'Detach P10 Single-Channel GEN1 from Right Mount',
     }
     const { getByText, getByRole } = render(props)
     getByText('Detach P10 Single-Channel GEN1 from Right Mount')

--- a/app/src/organisms/ChangePipette/__tests__/ClearDeckModal.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/ClearDeckModal.test.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react'
+import { fireEvent } from '@testing-library/react'
+import { renderWithProviders } from '@opentrons/components'
+import { LEFT, RIGHT } from '@opentrons/shared-data'
+import { i18n } from '../../../i18n'
+import { ClearDeckModal } from '../ClearDeckModal'
+import type { PipetteModelSpecs } from '@opentrons/shared-data'
+
+const render = (props: React.ComponentProps<typeof ClearDeckModal>) => {
+  return renderWithProviders(<ClearDeckModal {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+describe('ClearDeckModal', () => {
+  let props: React.ComponentProps<typeof ClearDeckModal>
+  beforeEach(() => {
+    props = {
+      onContinueClick: jest.fn(),
+      onCancelClick: jest.fn(),
+      totalSteps: 5,
+      currentStep: 1,
+      mount: LEFT,
+    }
+  })
+  it('renders the correct information when pipette is not attached', () => {
+    const { getByText, getByRole } = render(props)
+    getByText('Attach a pipette')
+    getByText('Before you begin')
+    getByText(
+      'Before starting, remove all labware from the deck and all tips from pipettes. The gantry will move to the front of the robot.'
+    )
+    const exit = getByRole('button', { name: 'exit' })
+    fireEvent.click(exit)
+    expect(props.onCancelClick).toHaveBeenCalled()
+    const cont = getByRole('button', { name: 'Get started' })
+    fireEvent.click(cont)
+    expect(props.onContinueClick).toHaveBeenCalled()
+  })
+
+  it('renders the correct information when a p10 single gen 1 is attached', () => {
+    props = {
+      ...props,
+      mount: RIGHT,
+      pipetteName: 'P10 Single-Channel GEN1' as PipetteModelSpecs['displayName'],
+    }
+    const { getByText, getByRole } = render(props)
+    getByText('Detach P10 Single-Channel GEN1 from Right Mount')
+    getByText('Before you begin')
+    getByText(
+      'Before starting, remove all labware from the deck and all tips from pipettes. The gantry will move to the front of the robot.'
+    )
+    const exit = getByRole('button', { name: 'exit' })
+    fireEvent.click(exit)
+    expect(props.onCancelClick).toHaveBeenCalled()
+    const cont = getByRole('button', { name: 'Get started' })
+    fireEvent.click(cont)
+    expect(props.onContinueClick).toHaveBeenCalled()
+  })
+})

--- a/app/src/organisms/ChangePipette/index.tsx
+++ b/app/src/organisms/ChangePipette/index.tsx
@@ -26,12 +26,15 @@ import {
 import { useCalibratePipetteOffset } from '../CalibratePipetteOffset/useCalibratePipetteOffset'
 import { AskForCalibrationBlockModal } from '../CalibrateTipLength/AskForCalibrationBlockModal'
 import { INTENT_CALIBRATE_PIPETTE_OFFSET } from '../../organisms/CalibrationPanels'
-import { ClearDeckAlertModal } from './ClearDeckAlertModal'
+import { useFeatureFlag } from '../../redux/config'
+import { ModalShell } from '../../molecules/Modal'
+import { ClearDeckModal } from './ClearDeckModal/index'
 import { ExitAlertModal } from './ExitAlertModal'
 import { Instructions } from './Instructions'
 import { ConfirmPipette } from './ConfirmPipette'
 import { RequestInProgressModal } from './RequestInProgressModal'
 import { LevelPipette } from './LevelPipette'
+import { ClearDeckAlertModal } from './ClearDeckModal/ClearDeckAlertModal'
 
 import {
   ATTACH,
@@ -61,6 +64,7 @@ const PIPETTE_OFFSET_CALIBRATION = 'pipette offset calibration'
 
 export function ChangePipette(props: Props): JSX.Element | null {
   const { robotName, mount, closeModal } = props
+  const enableChangePipetteWizard = useFeatureFlag('enableChangePipetteWizard')
   const dispatch = useDispatch<Dispatch>()
   const finalRequestId = React.useRef<string | null | undefined>(null)
   const [dispatchApiRequests] = useDispatchApiRequests(dispatchedAction => {
@@ -157,7 +161,21 @@ export function ChangePipette(props: Props): JSX.Element | null {
   }
 
   if (wizardStep === CLEAR_DECK) {
-    return (
+    return enableChangePipetteWizard ? (
+      <ModalShell height="28.12rem">
+        <ClearDeckModal
+          totalSteps={5}
+          currentStep={1}
+          mount={mount}
+          pipetteName={actualPipette?.displayName}
+          onCancelClick={closeModal}
+          onContinueClick={() => {
+            dispatch(move(robotName, CHANGE_PIPETTE, mount, true))
+            setWizardStep(INSTRUCTIONS)
+          }}
+        />
+      </ModalShell>
+    ) : (
       <ClearDeckAlertModal
         cancelText={CANCEL}
         continueText={MOVE_PIPETTE_TO_FRONT}

--- a/app/src/organisms/ChangePipette/index.tsx
+++ b/app/src/organisms/ChangePipette/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { getPipetteNameSpecs, shouldLevel } from '@opentrons/shared-data'
+import { useTranslation } from 'react-i18next'
 
 import {
   useDispatchApiRequests,
@@ -64,6 +65,7 @@ const PIPETTE_OFFSET_CALIBRATION = 'pipette offset calibration'
 
 export function ChangePipette(props: Props): JSX.Element | null {
   const { robotName, mount, closeModal } = props
+  const { t } = useTranslation('change_pipette')
   const enableChangePipetteWizard = useFeatureFlag('enableChangePipetteWizard')
   const dispatch = useDispatch<Dispatch>()
   const finalRequestId = React.useRef<string | null | undefined>(null)
@@ -166,8 +168,14 @@ export function ChangePipette(props: Props): JSX.Element | null {
         <ClearDeckModal
           totalSteps={5}
           currentStep={1}
-          mount={mount}
-          pipetteName={actualPipette?.displayName}
+          title={
+            actualPipette?.displayName != null
+              ? t('detach_pipette', {
+                  pipette: actualPipette.displayName,
+                  mount: mount[0].toUpperCase() + mount.slice(1),
+                })
+              : t('attach_pipette')
+          }
           onCancelClick={closeModal}
           onContinueClick={() => {
             dispatch(move(robotName, CHANGE_PIPETTE, mount, true))


### PR DESCRIPTION
closes RLIQ-42 (https://opentrons.atlassian.net/browse/RLIQ-42)

# Overview

this PR creates a new modal to use in the attach and detach pipettes wizard

<img width="953" alt="Screen Shot 2022-08-15 at 4 42 05 PM" src="https://user-images.githubusercontent.com/66035149/184714773-f2e05962-531d-4892-b5fb-ff535196b7de.png">

# Changelog

- create `ClearDeckModal` and deprecate the old one, create test
- add FF to `changePipette` 
- create `change_pipette.json` for i18n keys that will be a part of the wizards

# Review requests

- turn the FF on, check both the attach and detach 1st page wizards. They should match designs. 
- attach pipette version should be static
- detach pipette version should specify the mount and the pipette name

NOTE: `StepMeter` information (`currentStep` `totalSteps` will be wired in at the end!)

# Risk assessment

low