### PR TITLE
feat(hardware): Load pipette model from pipette serial

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -380,7 +380,7 @@ class OT3Controller:
         def _synthesize_model_name(
             name: FirmwarePipetteName, model: int
         ) -> "PipetteModel":
-            return cast("PipetteModel", name.name + "_v3." + str(model))
+            return cast("PipetteModel", f"{name.name}_v{model//10}.{model%10}")
 
         def _build_attached_pip(
             attached: ohc_tool_types.PipetteInformation,

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -68,6 +68,8 @@ from opentrons.hardware_control.types import (
     OT3AxisMap,
     CurrentConfig,
     OT3SubSystem,
+    InvalidPipetteName,
+    InvalidPipetteModel,
 )
 from opentrons_hardware.hardware_control.motion import (
     MoveStopCondition,
@@ -363,6 +365,59 @@ class OT3Controller:
         runner = MoveGroupRunner(move_groups=[move_group])
         await runner.run(can_messenger=self._messenger)
 
+    @staticmethod
+    def _synthesize_model_name(name: FirmwarePipetteName, model: str) -> "PipetteModel":
+        return cast("PipetteModel", f"{name.name}_v{model}")
+
+    @staticmethod
+    def _build_attached_pip(
+        attached: ohc_tool_types.PipetteInformation, mount: OT3Mount
+    ) -> AttachedPipette:
+        if attached.name == FirmwarePipetteName.unknown:
+            raise InvalidPipetteName(name=attached.name_int, mount=mount)
+        try:
+            return {
+                "config": pipette_config.load(
+                    OT3Controller._synthesize_model_name(attached.name, attached.model)
+                ),
+                "id": attached.serial,
+            }
+        except KeyError:
+            raise InvalidPipetteModel(
+                name=attached.name.name, model=attached.model, mount=mount
+            )
+
+    @staticmethod
+    def _build_attached_gripper(
+        attached: ohc_tool_types.GripperInformation,
+    ) -> AttachedGripper:
+        model = gripper_config.info_num_to_model(attached.model)
+        serial = attached.serial
+        return {
+            "config": gripper_config.load(model, serial),
+            "id": serial,
+        }
+
+    @staticmethod
+    def _generate_attached_instrs(
+        attached: ohc_tool_types.ToolSummary,
+    ) -> Iterator[Tuple[OT3Mount, OT3AttachedInstruments]]:
+        if attached.left:
+            yield (
+                OT3Mount.LEFT,
+                OT3Controller._build_attached_pip(attached.left, OT3Mount.LEFT),
+            )
+        if attached.right:
+            yield (
+                OT3Mount.RIGHT,
+                OT3Controller._build_attached_pip(attached.right, OT3Mount.RIGHT),
+            )
+        if attached.gripper:
+            yield (
+                OT3Mount.GRIPPER,
+                OT3Controller._build_attached_gripper(attached.gripper),
+            )
+
     async def get_attached_instruments(
         self, expected: Dict[OT3Mount, PipetteName]
     ) -> Dict[OT3Mount, OT3AttachedInstruments]:
@@ -377,42 +432,7 @@ class OT3Controller:
         await self._probe_core()
         attached = await self._tool_detector.detect()
 
-        def _synthesize_model_name(
-            name: FirmwarePipetteName, model: int
-        ) -> "PipetteModel":
-            return cast("PipetteModel", f"{name.name}_v{model//10}.{model%10}")
-
-        def _build_attached_pip(
-            attached: ohc_tool_types.PipetteInformation,
-        ) -> AttachedPipette:
-            return {
-                "config": pipette_config.load(
-                    _synthesize_model_name(attached.name, attached.model)
-                ),
-                "id": attached.serial,
-            }
-
-        def _build_attached_gripper(
-            attached: ohc_tool_types.GripperInformation,
-        ) -> AttachedGripper:
-            model = gripper_config.info_num_to_model(attached.model)
-            serial = attached.serial
-            return {
-                "config": gripper_config.load(model, serial),
-                "id": serial,
-            }
-
-        def _generate_attached_instrs(
-            attached: ohc_tool_types.ToolSummary,
-        ) -> Iterator[Tuple[OT3Mount, OT3AttachedInstruments]]:
-            if attached.left:
-                yield (OT3Mount.LEFT, _build_attached_pip(attached.left))
-            if attached.right:
-                yield (OT3Mount.RIGHT, _build_attached_pip(attached.right))
-            if attached.gripper:
-                yield (OT3Mount.GRIPPER, _build_attached_gripper(attached.gripper))
-
-        current_tools = dict(_generate_attached_instrs(attached))
+        current_tools = dict(OT3Controller._generate_attached_instrs(attached))
         self._present_nodes -= set(
             axis_to_node(OT3Axis.of_main_tool_actuator(mount)) for mount in OT3Mount
         )

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -497,3 +497,32 @@ class GripperNotAttachedError(Exception):
     """An error raised if a gripper is accessed that is not attached"""
 
     pass
+
+
+class InvalidPipetteName(KeyError):
+    """Raised for an invalid pipette."""
+
+    def __init__(self, name: int, mount: OT3Mount) -> None:
+        self.name = name
+        self.mount = mount
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}: name={self.name} mount={self.mount}>"
+
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__}: Pipette name key {self.name} on mount {self.mount.name} is not valid"
+
+
+class InvalidPipetteModel(KeyError):
+    """Raised for a pipette with an unknown model."""
+
+    def __init__(self, name: str, model: str, mount: OT3Mount) -> None:
+        self.name = name
+        self.model = model
+        self.mount = mount
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}: name={self.name}, model={self.model}, mount={self.mount}>"
+
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__}: {self.name} on {self.mount.name} has an unknown model {self.model}"

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -1,4 +1,5 @@
 import pytest
+from typing import TYPE_CHECKING
 from itertools import chain
 from mock import AsyncMock, patch
 from opentrons.hardware_control.backends.ot3controller import OT3Controller
@@ -8,7 +9,10 @@ from opentrons.hardware_control.backends.ot3utils import (
 from opentrons_hardware.drivers.can_bus import CanMessenger
 from opentrons.config.types import OT3Config
 from opentrons.config.robot_configs import build_config_ot3
-from opentrons_hardware.firmware_bindings.constants import NodeId, PipetteName
+from opentrons_hardware.firmware_bindings.constants import (
+    NodeId,
+    PipetteName as FirmwarePipetteName,
+)
 from opentrons_hardware.drivers.can_bus.abstract_driver import AbstractCanDriver
 from opentrons.hardware_control.types import OT3Axis, OT3Mount
 
@@ -22,6 +26,9 @@ from opentrons_hardware.hardware_control.tools.types import (
     PipetteInformation,
     GripperInformation,
 )
+
+if TYPE_CHECKING:
+    from opentrons_shared_data.pipette.dev_types import PipetteName, PipetteModel
 
 
 @pytest.fixture
@@ -255,8 +262,34 @@ async def test_probing(
     )
 
 
+@pytest.mark.parametrize(
+    "tool_summary,pipette_id,pipette_name,pipette_model,gripper_id,gripper_name",
+    [
+        (
+            ToolSummary(
+                left=PipetteInformation(
+                    name=FirmwarePipetteName.p1000_single, model=30, serial="hello"
+                ),
+                right=None,
+                gripper=GripperInformation(model=0, serial="fake_serial"),
+            ),
+            "hello",
+            "p1000_single_gen3",
+            "p1000_single_v3.0",
+            "fake_serial",
+            "gripper",
+        ),
+    ],
+)
 async def test_get_attached_instruments(
-    controller: OT3Controller, mock_tool_detector: OneshotToolDetector
+    controller: OT3Controller,
+    mock_tool_detector: OneshotToolDetector,
+    tool_summary: ToolSummary,
+    pipette_id: str,
+    pipette_name: "PipetteName",
+    pipette_model: "PipetteModel",
+    gripper_id: str,
+    gripper_name: str,
 ):
     async def fake_probe(can_messenger, expected, timeout):
         return set((NodeId.gantry_x, NodeId.gantry_y, NodeId.head, NodeId.gripper))
@@ -264,19 +297,16 @@ async def test_get_attached_instruments(
     with patch("opentrons.hardware_control.backends.ot3controller.probe", fake_probe):
         assert await controller.get_attached_instruments({}) == {}
 
-    mock_tool_detector.return_value = ToolSummary(
-        left=PipetteInformation(name=PipetteName.p1000_single, model=0, serial="hello"),
-        right=None,
-        gripper=GripperInformation(model=0, serial="fake_serial"),
-    )
+    mock_tool_detector.return_value = tool_summary
 
     with patch("opentrons.hardware_control.backends.ot3controller.probe", fake_probe):
         detected = await controller.get_attached_instruments({})
     assert list(detected.keys()) == [OT3Mount.LEFT, OT3Mount.GRIPPER]
-    assert detected[OT3Mount.LEFT]["id"] == "hello"
-    assert detected[OT3Mount.LEFT]["config"].name == "p1000_single_gen3"
-    assert detected[OT3Mount.GRIPPER]["id"] == "fake_serial"
-    assert detected[OT3Mount.GRIPPER]["config"].name == "gripper"
+    assert detected[OT3Mount.LEFT]["id"] == pipette_id
+    assert detected[OT3Mount.LEFT]["config"].name == pipette_name
+    assert detected[OT3Mount.LEFT]["config"].model == pipette_model
+    assert detected[OT3Mount.GRIPPER]["id"] == gripper_id
+    assert detected[OT3Mount.GRIPPER]["config"].name == gripper_name
 
 
 def test_nodeid_replace_head():

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -195,6 +195,8 @@ class PipetteName(int, Enum):
 
     p1000_single = 0x00
     p1000_multi = 0x01
+    p50_single = 0x02
+    p50_multi = 0x03
 
 
 @unique

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -197,6 +197,7 @@ class PipetteName(int, Enum):
     p1000_multi = 0x01
     p50_single = 0x02
     p50_multi = 0x03
+    unknown = 0xFFFF
 
 
 @unique

--- a/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
@@ -144,7 +144,7 @@ class SerialDataCodeField(utils.BinaryFieldBase[bytes]):
     model number, and the name.
     """
 
-    NUM_BYTES = 12
+    NUM_BYTES = 16
     FORMAT = f"{NUM_BYTES}s"
 
     @classmethod

--- a/hardware/opentrons_hardware/hardware_control/tools/detector.py
+++ b/hardware/opentrons_hardware/hardware_control/tools/detector.py
@@ -7,14 +7,13 @@ from typing import AsyncIterator, Set, Dict, Tuple, Union
 from opentrons_hardware.drivers.can_bus.can_messenger import WaitableCallback
 from opentrons_hardware.firmware_bindings.constants import ToolType, PipetteName
 from opentrons_hardware.firmware_bindings.messages import message_definitions
-from opentrons_hardware.firmware_bindings import NodeId
+from opentrons_hardware.firmware_bindings import NodeId, ArbitrationId
 from opentrons_hardware.drivers.can_bus import CanMessenger
 from .types import (
     PipetteInformation,
     ToolSummary,
     GripperInformation,
 )
-
 from opentrons_hardware.hardware_control.tools.types import ToolDetectionResult
 
 log = logging.getLogger(__name__)
@@ -80,6 +79,13 @@ class OneshotToolDetector:
         self._messenger = messenger
 
     @staticmethod
+    def _decode_or_default(orig: bytes) -> str:
+        try:
+            return orig.decode()
+        except UnicodeDecodeError:
+            return repr(orig)
+
+    @staticmethod
     async def _await_responses(
         callback: WaitableCallback,
         for_nodes: Set[NodeId],
@@ -88,45 +94,66 @@ class OneshotToolDetector:
         """Wait for pipette or gripper information and send back through a queue."""
         seen: Set[NodeId] = set()
 
-        def _decode_or_default(orig: bytes) -> str:
-            try:
-                return orig.decode()
-            except UnicodeDecodeError:
-                return repr(orig)
-
         while not for_nodes.issubset(seen):
             async for response, arbitration_id in callback:
                 if isinstance(response, message_definitions.PipetteInfoResponse):
-                    node = NodeId(arbitration_id.parts.originating_node_id)
-                    seen.add(node)
-                    await response_queue.put(
-                        (
-                            node,
-                            PipetteInformation(
-                                name=PipetteName(response.payload.name.value),
-                                model=response.payload.model.value,
-                                serial=_decode_or_default(
-                                    response.payload.serial.value
-                                ),
-                            ),
-                        )
+                    node = await OneshotToolDetector._handle_pipette_info(
+                        response_queue, response, arbitration_id
                     )
+                    seen.add(node)
                     break
                 elif isinstance(response, message_definitions.GripperInfoResponse):
-                    node = NodeId(arbitration_id.parts.originating_node_id)
-                    seen.add(node)
-                    await response_queue.put(
-                        (
-                            node,
-                            GripperInformation(
-                                model=response.payload.model.value,
-                                serial=_decode_or_default(
-                                    response.payload.serial.value
-                                ),
-                            ),
-                        )
+                    node = await OneshotToolDetector._handle_gripper_info(
+                        response_queue, response, arbitration_id
                     )
+                    seen.add(node)
                     break
+
+    @staticmethod
+    async def _handle_gripper_info(
+        response_queue: "asyncio.Queue[Tuple[NodeId, Union[PipetteInformation, GripperInformation]]]",
+        response: message_definitions.GripperInfoResponse,
+        arbitration_id: ArbitrationId,
+    ) -> NodeId:
+        node = NodeId(arbitration_id.parts.originating_node_id)
+        await response_queue.put(
+            (
+                node,
+                GripperInformation(
+                    model=response.payload.model.value,
+                    serial=OneshotToolDetector._decode_or_default(
+                        response.payload.serial.value
+                    ),
+                ),
+            )
+        )
+        return node
+
+    @staticmethod
+    async def _handle_pipette_info(
+        response_queue: "asyncio.Queue[Tuple[NodeId, Union[PipetteInformation, GripperInformation]]]",
+        response: message_definitions.PipetteInfoResponse,
+        arbitration_id: ArbitrationId,
+    ) -> NodeId:
+        node = NodeId(arbitration_id.parts.originating_node_id)
+        try:
+            name = PipetteName(response.payload.name.value)
+        except ValueError:
+            name = PipetteName.unknown
+        await response_queue.put(
+            (
+                node,
+                PipetteInformation(
+                    name=name,
+                    name_int=response.payload.name.value,
+                    model=response.payload.model.value,
+                    serial=OneshotToolDetector._decode_or_default(
+                        response.payload.serial.value
+                    ),
+                ),
+            )
+        )
+        return node
 
     async def detect(self, timeout_sec: float = 1.0) -> ToolSummary:
         """Run once and detect tools."""

--- a/hardware/opentrons_hardware/hardware_control/tools/detector.py
+++ b/hardware/opentrons_hardware/hardware_control/tools/detector.py
@@ -8,6 +8,7 @@ from opentrons_hardware.drivers.can_bus.can_messenger import WaitableCallback
 from opentrons_hardware.firmware_bindings.constants import ToolType, PipetteName
 from opentrons_hardware.firmware_bindings.messages import message_definitions
 from opentrons_hardware.firmware_bindings import NodeId, ArbitrationId
+from opentrons_hardware.pipettes.serials import model_versionstring_from_int
 from opentrons_hardware.drivers.can_bus import CanMessenger
 from .types import (
     PipetteInformation,
@@ -146,7 +147,7 @@ class OneshotToolDetector:
                 PipetteInformation(
                     name=name,
                     name_int=response.payload.name.value,
-                    model=response.payload.model.value,
+                    model=model_versionstring_from_int(response.payload.model.value),
                     serial=OneshotToolDetector._decode_or_default(
                         response.payload.serial.value
                     ),

--- a/hardware/opentrons_hardware/hardware_control/tools/types.py
+++ b/hardware/opentrons_hardware/hardware_control/tools/types.py
@@ -28,7 +28,7 @@ class PipetteInformation:
 
     name: PipetteName
     name_int: int
-    model: int
+    model: str
     serial: str
 
 

--- a/hardware/opentrons_hardware/hardware_control/tools/types.py
+++ b/hardware/opentrons_hardware/hardware_control/tools/types.py
@@ -27,6 +27,7 @@ class PipetteInformation:
     """Model the information you can retrieve from a pipette."""
 
     name: PipetteName
+    name_int: int
     model: int
     serial: str
 

--- a/hardware/opentrons_hardware/pipettes/__init__.py
+++ b/hardware/opentrons_hardware/pipettes/__init__.py
@@ -1,0 +1,1 @@
+"""Tools for handling pipette data."""

--- a/hardware/opentrons_hardware/pipettes/serials.py
+++ b/hardware/opentrons_hardware/pipettes/serials.py
@@ -68,3 +68,8 @@ def serial_val_from_parts(name: PipetteName, model: int, serialval: bytes) -> by
     you will not get what you put in.
     """
     return struct.pack(">HH16s", name.value, model, _ensure_length(serialval, 16))
+
+
+def model_versionstring_from_int(model: int) -> str:
+    """Format the encoded model from an int into a dotted version string."""
+    return f"{model//10}.{model%10}"

--- a/hardware/opentrons_hardware/pipettes/serials.py
+++ b/hardware/opentrons_hardware/pipettes/serials.py
@@ -1,0 +1,69 @@
+"""Handle parsing and providing pipette information."""
+import re
+from typing import Dict, Tuple
+import struct
+from opentrons_hardware.firmware_bindings.constants import PipetteName
+
+SERIAL_RE = re.compile("^(?P<name>P.{3,3})V(?P<model>[0-9]{2,2})(?P<code>.{,8})$")
+
+
+NAME_LOOKUP: Dict[str, PipetteName] = {
+    "P1KS": PipetteName.p1000_single,
+    "P1KM": PipetteName.p1000_multi,
+    "P50S": PipetteName.p50_single,
+    "P50M": PipetteName.p50_multi,
+}
+
+SERIAL_FORMAT_MSG = (
+    f'Serial numbers must have the format PNNNVMMXXXXXX... where NNN is one of {", ".join(NAME_LOOKUP.keys())}, '
+    "MM is a two-digit model number, and the rest is some serial code."
+)
+
+
+def info_from_serial_string(serialval: str) -> Tuple[PipetteName, int, bytes]:
+    """Parse pipette information from a serial code.
+
+    The return value is the serial parts: the name, the model, and the serial.
+
+    Note: this is not the inverse of serial_val_from_parts. The input should be
+    something a human scans, not something returned from a pipette. A bytestring
+    from a pipette is probably not valid ascii and even if it is, you won't get
+    the expected values from passing it to this function.
+    """
+    matches = SERIAL_RE.match(serialval.strip())
+    if not matches:
+        raise ValueError(
+            f"The serial number {serialval.strip()} is not valid. {SERIAL_FORMAT_MSG}"
+        )
+    try:
+        name = NAME_LOOKUP[matches.group("name")]
+    except KeyError:
+        raise ValueError(
+            f"The pipette name part of the serial number ({matches.group('name')}) is unknown. {SERIAL_FORMAT_MSG}"
+        )
+    model = int(matches.group("model"))
+
+    def make_8_bytes(input_val: bytes) -> bytes:
+        """Makes a bytestring exactly 8 bytes long by limiting length and padding with 0."""
+        return (input_val + (b"\x00" * 8))[:8]
+
+    return (
+        name,
+        model,
+        make_8_bytes(matches.group("code").encode("ascii")),
+    )
+
+
+def serial_val_from_parts(name: PipetteName, model: int, serialval: bytes) -> bytes:
+    """Encode pipette information into a bytestring suitable for EEPROM storage.
+
+    Note: this is not the inverse of info_from_serial_string. info_from_serial_string
+    parses information from a human-entered string that is probably the pipette barcode.
+    This function takes that information and specifically encodes it in a bytestring for
+    storage on the pipette, which includes binary data. If you call
+
+    serial_val_from_parts(*info_from_serial_str(somestr.encode('ascii'))).decode('ascii')
+
+    you will not get what you put in.
+    """
+    return struct.pack("<HH8s", name.value, model, serialval)

--- a/hardware/opentrons_hardware/pipettes/serials.py
+++ b/hardware/opentrons_hardware/pipettes/serials.py
@@ -4,7 +4,7 @@ from typing import Dict, Tuple
 import struct
 from opentrons_hardware.firmware_bindings.constants import PipetteName
 
-SERIAL_RE = re.compile("^(?P<name>P.{3,3})V(?P<model>[0-9]{2,2})(?P<code>.{,8})$")
+SERIAL_RE = re.compile("^(?P<name>P.{3,3})V(?P<model>[0-9]{2,2})(?P<code>.{,12})$")
 
 
 NAME_LOOKUP: Dict[str, PipetteName] = {
@@ -18,6 +18,11 @@ SERIAL_FORMAT_MSG = (
     f'Serial numbers must have the format PNNNVMMXXXXXX... where NNN is one of {", ".join(NAME_LOOKUP.keys())}, '
     "MM is a two-digit model number, and the rest is some serial code."
 )
+
+
+def _ensure_length(input_val: bytes, target_length: int) -> bytes:
+    """Makes a bytestring exactly 12 bytes long by limiting length and padding with 0."""
+    return (input_val + (b"\x00" * target_length))[:target_length]
 
 
 def info_from_serial_string(serialval: str) -> Tuple[PipetteName, int, bytes]:
@@ -43,14 +48,10 @@ def info_from_serial_string(serialval: str) -> Tuple[PipetteName, int, bytes]:
         )
     model = int(matches.group("model"))
 
-    def make_8_bytes(input_val: bytes) -> bytes:
-        """Makes a bytestring exactly 8 bytes long by limiting length and padding with 0."""
-        return (input_val + (b"\x00" * 8))[:8]
-
     return (
         name,
         model,
-        make_8_bytes(matches.group("code").encode("ascii")),
+        _ensure_length(matches.group("code").encode("ascii"), 16),
     )
 
 
@@ -66,4 +67,4 @@ def serial_val_from_parts(name: PipetteName, model: int, serialval: bytes) -> by
 
     you will not get what you put in.
     """
-    return struct.pack("<HH8s", name.value, model, serialval)
+    return struct.pack(">HH16s", name.value, model, _ensure_length(serialval, 16))

--- a/hardware/opentrons_hardware/scripts/provision_pipette.py
+++ b/hardware/opentrons_hardware/scripts/provision_pipette.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Provisions pipette EEPROMs.
+
+This can be used either on a production line or locally.
+
+A log of what has been flashed to pipettes can be found at
+provision_pipette.log.
+"""
+
+import asyncio
+import logging
+import logging.config
+import argparse
+import datetime
+from typing import Tuple
+
+from opentrons_hardware.drivers.can_bus import build, CanMessenger, WaitableCallback
+from opentrons_hardware.firmware_bindings.utils import UInt16Field
+from opentrons_hardware.firmware_bindings.messages import (
+    message_definitions,
+    payloads,
+    fields,
+)
+from opentrons_hardware.firmware_bindings.constants import NodeId, PipetteName
+from opentrons_hardware.scripts.can_args import add_can_args, build_settings
+from opentrons_hardware.pipettes import serials
+
+
+async def run(
+    args: argparse.Namespace, base_log: logging.Logger, trace_log: logging.Logger
+) -> None:
+    """Script entrypoint."""
+    which_pipette = {"left": NodeId.pipette_left, "right": NodeId.pipette_right}[
+        args.which
+    ]
+    async with build.driver(build_settings(args)) as driver, CanMessenger(
+        driver
+    ) as messenger:
+        await flash_serials(messenger, which_pipette, base_log, trace_log)
+
+
+async def flash_serials(
+    messenger: CanMessenger,
+    which_pipette: NodeId,
+    base_log: logging.Logger,
+    trace_log: logging.Logger,
+) -> None:
+    """Flash serials in a loop."""
+    while True:
+        should_quit = await get_and_update_serial_once(
+            messenger, which_pipette, base_log, trace_log
+        )
+        if should_quit:
+            return
+
+
+async def get_serial(
+    prompt: str, base_log: logging.Logger
+) -> Tuple[PipetteName, int, bytes]:
+    """Get a serial number that is correct and parseable."""
+    loop = asyncio.get_running_loop()
+    while True:
+        serial = await loop.run_in_executor(None, lambda: input(prompt))
+        try:
+            name, model, data = serials.info_from_serial_string(serial)
+        except Exception as e:
+            base_log.exception("invalid serial")
+            if isinstance(Exception, KeyboardInterrupt):
+                raise
+            print(str(e))
+        else:
+            return name, model, data
+
+
+async def update_serial_and_confirm(
+    messenger: CanMessenger,
+    which_pipette: NodeId,
+    name: PipetteName,
+    model: int,
+    data: bytes,
+    base_log: logging.Logger,
+    trace_log: logging.Logger,
+    attempts: int = 3,
+    attempt_timeout_s: float = 1.0,
+) -> None:
+    """Update and verify the update of serial data."""
+    for attempt in range(attempts):
+        base_log.debug(f"beginning set and confirm attempt {attempt}")
+        set_message = message_definitions.SetSerialNumber(
+            payload=payloads.SerialNumberPayload(
+                serial=fields.SerialField(
+                    serials.serial_val_from_parts(name, model, data)
+                )
+            )
+        )
+        await messenger.send(which_pipette, set_message)
+
+        base_log.debug(f"Sent set-serial: {set_message}")
+        await messenger.send(which_pipette, message_definitions.InstrumentInfoRequest())
+        target = datetime.datetime.now() + datetime.timedelta(seconds=attempt_timeout_s)
+        try:
+            while True:
+                with WaitableCallback(messenger) as wc:
+                    message, arb = await asyncio.wait_for(
+                        wc.read(), (target - datetime.datetime.now()).total_seconds()
+                    )
+                    if (
+                        isinstance(message, message_definitions.PipetteInfoResponse)
+                        and arb.originating_node_id == which_pipette
+                    ):
+                        if (
+                            message.payload.name == fields.PipetteNameField(name.value)
+                            and message.payload.model == UInt16Field(model)
+                            and message.payload.serial == fields.SerialField(data)
+                        ):
+                            base_log.info(f"serial confirmed on attempt {attempt}")
+                            return
+                        else:
+                            base_log.debug("message relevant serial NOT confirmed")
+                    base_log.debug(f"message {type(message)} is not relevant")
+                    base_log.debug(
+                        f"{(target-datetime.datetime.now()).total_seconds()} remaining in attempt {attempt}"
+                    )
+        except asyncio.TimeoutError:
+            continue
+
+
+async def get_and_update_serial_once(
+    messenger: CanMessenger,
+    which_pipette: NodeId,
+    base_log: logging.Logger,
+    trace_log: logging.Logger,
+) -> None:
+    """Read and update a single serial."""
+    name, model, data = await get_serial(
+        f'Enter serial for pipette on {which_pipette.name.split("_")[-1]}: ', base_log
+    )
+    try:
+        await update_serial_and_confirm(
+            messenger, which_pipette, name, model, data, base_log, trace_log
+        )
+        trace_log.info('SUCCESS,{name.name},{model},{data.encode("ascii")}')
+    except Exception:
+        base_log.exception("Update failed")
+        trace_log.info('FAILURE,{name.name},{model},{data.encode("ascii")}')
+        raise
+
+
+def log_config(log_level: int) -> Tuple[logging.Logger, logging.Logger]:
+    """Configure logging."""
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "disable_existing_loggers": True,
+            "formatters": {
+                "basic": {"format": "%(asctime)s %(name)s %(levelname)s %(message)s"},
+                "production_trace": {"format": "%(asctime)s %(message)s"},
+            },
+            "handlers": {
+                "main_log_handler": {
+                    "class": "logging.handlers.RotatingFileHandler",
+                    "formatter": "basic",
+                    "filename": "provision_pipette_debug.log",
+                    "maxBytes": 5000000,
+                    "level": log_level,
+                    "backupCount": 3,
+                },
+                "stream_handler": {
+                    "class": "logging.handlers.StreamHandler",
+                    "formatter": "basic",
+                    "level": log_level,
+                },
+                "trace_log_handler": {
+                    "class": "logging.handlers.RotatingFileHandler",
+                    "formatter": "basic",
+                    "filename": "provision_pipette.log",
+                    "maxBytes": 5000000,
+                    "level": logging.INFO,
+                    "backupCount": 3,
+                },
+            },
+            "loggers": {
+                "": {
+                    "handlers": (
+                        ["main_log_handler"]
+                        if log_level > logging.INFO
+                        else ["main_log_handler", "stream_handler"]
+                    ),
+                    "level": log_level,
+                },
+                "trace_log": {
+                    "handlers": ["trace_log_handler"],
+                    "level": logging.INFO,
+                },
+            },
+        }
+    )
+    return logging.getLogger(__name__), logging.getLogger("trace_log")
+
+
+def main() -> None:
+    """Entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "-l",
+        "--log-level",
+        help=(
+            "Developer logging level. At DEBUG or below, logs are written "
+            "to console; at INFO or above, logs are only written to "
+            "provision_pipettes_debug.log"
+        ),
+        type=str,
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default="WARNING",
+    )
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Run just once and quit instead of staying in a loop",
+    )
+    parser.add_argument(
+        "-w",
+        "--which",
+        type=str,
+        choices=["left", "right"],
+        help="Which pipette to flash",
+    )
+    add_can_args(parser)
+
+    args = parser.parse_args()
+    base_log, trace_log = log_config(getattr(logging, args.log_level))
+    asyncio.run(run(args, base_log, trace_log))
+
+
+if __name__ == "__main__":
+    main()

--- a/hardware/tests/firmware_integration/test_sensors.py
+++ b/hardware/tests/firmware_integration/test_sensors.py
@@ -70,7 +70,7 @@ async def test_write_to_sensors(
 @pytest.mark.parametrize(
     argnames=["sensor_type", "expected_data"],
     argvalues=[
-        [SensorType.capacitive, 0.46],
+        [SensorType.capacitive, 0.02],
         # Data should be 12.7291 for humidity
         [SensorType.environment, (0.0, 57.67)],
         [SensorType.pressure, 0.02],
@@ -141,7 +141,7 @@ async def test_read_from_sensors(
         # a request is sent in simulation. When the capacitive
         # driver refactor happens, we should investigate this
         # further. For now this should allow the tests to pass.
-        [SensorType.capacitive, 0.92],
+        [SensorType.capacitive, 0.05],
         [SensorType.pressure, 0.02],
         # Data should be 12.7291 for humidity
         [SensorType.environment, (0.0, 57.67)],

--- a/hardware/tests/firmware_integration/test_serial_number.py
+++ b/hardware/tests/firmware_integration/test_serial_number.py
@@ -61,6 +61,7 @@ async def test_set_serial_gripper(
         (PipetteName.p1000_single, 31, b"2020190802A02"),
         (PipetteName.p50_multi, 500, b""),
         (PipetteName.p50_single, 0, b"asdasdasdasdasda"),
+        (PipetteName.unknown, 0xFFFF, b"\xff" * 16),
     ],
 )
 @pytest.mark.requires_emulator

--- a/hardware/tests/opentrons_hardware/hardware_control/tools/test_oneshot.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/tools/test_oneshot.py
@@ -168,7 +168,7 @@ async def test_sends_only_required_followups(
     assert tools.right == types.PipetteInformation(
         name=PipetteName.p1000_single,
         name_int=PipetteName.p1000_single.value,
-        model=2,
+        model="0.2",
         serial="20220809A022",
     )
     assert tools.gripper is None
@@ -232,7 +232,7 @@ async def test_sends_all_required_followups(
                     message_definitions.PipetteInfoResponse(
                         payload=payloads.PipetteInfoResponsePayload(
                             name=PipetteNameField(PipetteName.p1000_multi.value),
-                            model=UInt16Field(4),
+                            model=UInt16Field(34),
                             serial=SerialDataCodeField(b"20231005A220"),
                         )
                     ),
@@ -259,13 +259,13 @@ async def test_sends_all_required_followups(
     assert tools.left == types.PipetteInformation(
         name=PipetteName.p1000_single,
         name_int=PipetteName.p1000_single.value,
-        model=2,
+        model="0.2",
         serial="20220809A022",
     )
     assert tools.right == types.PipetteInformation(
         name=PipetteName.p1000_multi,
         name_int=PipetteName.p1000_multi.value,
-        model=4,
+        model="3.4",
         serial="20231005A220",
     )
     assert tools.gripper == types.GripperInformation(model=1, serial="20220531A01")
@@ -316,7 +316,7 @@ async def test_handles_bad_serials(
         if isinstance(message, message_definitions.InstrumentInfoRequest):
             payload = payloads.PipetteInfoResponsePayload(
                 name=PipetteNameField(100),
-                model=UInt16Field(4),
+                model=UInt16Field(31),
                 serial=SerialDataCodeField(
                     b"\x00\x01\x02\x03\x04\0x05\x06\x07\x08\x09\x0a\x0b"
                 ),
@@ -338,7 +338,7 @@ async def test_handles_bad_serials(
     assert tools.left == types.PipetteInformation(
         name=PipetteName.unknown,
         name_int=100,
-        model=4,
+        model="3.1",
         serial="\x00\x01\x02\x03\x04\0x05\x06\x07\x08\x09\x0a\x0b",
     )
 

--- a/hardware/tests/opentrons_hardware/hardware_control/tools/test_oneshot.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/tools/test_oneshot.py
@@ -166,7 +166,10 @@ async def test_sends_only_required_followups(
 
     assert tools.left is None
     assert tools.right == types.PipetteInformation(
-        name=PipetteName.p1000_single, model=2, serial="20220809A022"
+        name=PipetteName.p1000_single,
+        name_int=PipetteName.p1000_single.value,
+        model=2,
+        serial="20220809A022",
     )
     assert tools.gripper is None
 
@@ -254,10 +257,16 @@ async def test_sends_all_required_followups(
     tools = await subject.detect()
 
     assert tools.left == types.PipetteInformation(
-        name=PipetteName.p1000_single, model=2, serial="20220809A022"
+        name=PipetteName.p1000_single,
+        name_int=PipetteName.p1000_single.value,
+        model=2,
+        serial="20220809A022",
     )
     assert tools.right == types.PipetteInformation(
-        name=PipetteName.p1000_multi, model=4, serial="20231005A220"
+        name=PipetteName.p1000_multi,
+        name_int=PipetteName.p1000_multi.value,
+        model=4,
+        serial="20231005A220",
     )
     assert tools.gripper == types.GripperInformation(model=1, serial="20220531A01")
 
@@ -306,7 +315,7 @@ async def test_handles_bad_serials(
     ) -> List[Tuple[NodeId, MessageDefinition, NodeId]]:
         if isinstance(message, message_definitions.InstrumentInfoRequest):
             payload = payloads.PipetteInfoResponsePayload(
-                name=PipetteNameField(PipetteName.p1000_multi.value),
+                name=PipetteNameField(100),
                 model=UInt16Field(4),
                 serial=SerialDataCodeField(
                     b"\x00\x01\x02\x03\x04\0x05\x06\x07\x08\x09\x0a\x0b"
@@ -327,7 +336,8 @@ async def test_handles_bad_serials(
     tools = await subject.detect()
 
     assert tools.left == types.PipetteInformation(
-        name=PipetteName.p1000_multi,
+        name=PipetteName.unknown,
+        name_int=100,
         model=4,
         serial="\x00\x01\x02\x03\x04\0x05\x06\x07\x08\x09\x0a\x0b",
     )

--- a/hardware/tests/opentrons_hardware/pipettes/test_serials.py
+++ b/hardware/tests/opentrons_hardware/pipettes/test_serials.py
@@ -88,3 +88,20 @@ def test_serial_validity(scannedval: str) -> None:
 def test_serial_val_from_parts(name: PipetteName, model: int, data: bytes) -> None:
     """Make sure that valid inputs don't cause exceptions."""
     serials.serial_val_from_parts(name, model, data)
+
+
+@pytest.mark.parametrize(
+    "model,versionstr",
+    [
+        (0, "0.0"),
+        (10, "1.0"),
+        (1, "0.1"),
+        (30, "3.0"),
+        (31, "3.1"),
+        (4150, "415.0"),
+        (0xFFFF, "6553.5"),
+    ],
+)
+def test_versionstring_from_int(model: int, versionstr: str) -> None:
+    """Test versionstring."""
+    assert serials.model_versionstring_from_int(model) == versionstr

--- a/hardware/tests/opentrons_hardware/pipettes/test_serials.py
+++ b/hardware/tests/opentrons_hardware/pipettes/test_serials.py
@@ -1,0 +1,64 @@
+"""Test serial setting."""
+import pytest
+from opentrons_hardware.pipettes import serials
+from opentrons_hardware.firmware_bindings.constants import PipetteName
+
+
+@pytest.mark.parametrize(
+    "scanned_val,name,model,serial",
+    [
+        ("P1KSV0102022022", PipetteName.p1000_single, 1, b"02022022"),
+        ("P50MV29AABBCCDD", PipetteName.p50_multi, 29, b"AABBCCDD"),
+        ("P1KMV1000000000", PipetteName.p1000_multi, 10, b"00000000"),
+        ("P50SV01", PipetteName.p50_single, 1, b"\x00\x00\x00\x00\x00\x00\x00\x00"),
+    ],
+)
+def test_scan_valid_serials(
+    scanned_val: str, name: PipetteName, model: int, serial: bytes
+) -> None:
+    """Various known-good serials."""
+    parsed_name, parsed_model, parsed_serial = serials.info_from_serial_string(
+        scanned_val
+    )
+    assert parsed_name == name
+    assert parsed_model == model
+    assert parsed_serial == serial
+
+
+@pytest.mark.parametrize("scannedval", ["P111V02", "P1ksV22", "P3HSV12"])
+def test_pipette_name_validity(scannedval: str) -> None:
+    """Pipette name lookup matching."""
+    with pytest.raises(ValueError, match="The pipette name part.*"):
+        serials.info_from_serial_string(scannedval)
+
+
+@pytest.mark.parametrize(
+    "scannedval",
+    [
+        "",
+        "P",
+        "P1KS123",
+        "P1KSVVV",
+        "P1KSV0A",
+        "P1KSV0102022022123123123",
+    ],
+)
+def test_serial_validity(scannedval: str) -> None:
+    """Various regex failures."""
+    with pytest.raises(ValueError, match="The serial number.*"):
+        serials.info_from_serial_string(scannedval)
+
+
+@pytest.mark.parametrize("name", [name for name in PipetteName])
+@pytest.mark.parametrize("model", [0, 1, 10, 0xFF])
+@pytest.mark.parametrize(
+    "data",
+    [
+        b"\x00\x00\x00\x00\x00\x00\x00\x00",
+        b"\xff\xff\xff\xff\xff\xff\xff\xff",
+        b"hello  ",
+    ],
+)
+def test_serial_val_from_parts(name: PipetteName, model: int, data: bytes) -> None:
+    """Make sure that valid inputs don't cause exceptions."""
+    serials.serial_val_from_parts(name, model, data)

--- a/hardware/tests/opentrons_hardware/pipettes/test_serials.py
+++ b/hardware/tests/opentrons_hardware/pipettes/test_serials.py
@@ -7,11 +7,36 @@ from opentrons_hardware.firmware_bindings.constants import PipetteName
 @pytest.mark.parametrize(
     "scanned_val,name,model,serial",
     [
-        ("P1KSV0102022022", PipetteName.p1000_single, 1, b"02022022"),
-        ("P1KSV3120211129A08", PipetteName.p1000_single, 31, b"20211129A008"),
-        ("P50MV29AABBCCDD", PipetteName.p50_multi, 29, b"AABBCCDD"),
-        ("P1KMV1000000000", PipetteName.p1000_multi, 10, b"00000000"),
-        ("P50SV01", PipetteName.p50_single, 1, b"\x00\x00\x00\x00\x00\x00\x00\x00"),
+        (
+            "P1KSV0102022022",
+            PipetteName.p1000_single,
+            1,
+            b"02022022\x00\x00\x00\x00\x00\x00\x00\x00",
+        ),
+        (
+            "P1KSV3120211129A08",
+            PipetteName.p1000_single,
+            31,
+            b"20211129A08\x00\x00\x00\x00\x00",
+        ),
+        (
+            "P50MV29AABBCCDD",
+            PipetteName.p50_multi,
+            29,
+            b"AABBCCDD\x00\x00\x00\x00\x00\x00\x00\x00",
+        ),
+        (
+            "P1KMV1000000000",
+            PipetteName.p1000_multi,
+            10,
+            b"00000000\x00\x00\x00\x00\x00\x00\x00\x00",
+        ),
+        (
+            "P50SV01",
+            PipetteName.p50_single,
+            1,
+            b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
+        ),
     ],
 )
 def test_scan_valid_serials(
@@ -55,9 +80,9 @@ def test_serial_validity(scannedval: str) -> None:
 @pytest.mark.parametrize(
     "data",
     [
-        b"\x00\x00\x00\x00\x00\x00\x00\x00",
-        b"\xff\xff\xff\xff\xff\xff\xff\xff",
-        b"hello  ",
+        b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
+        b"\xff\xff\xff\xff\xff\xff\xff\xff\x00\x00\x00\x00",
+        b"hello  \x00\x00\x00\x00",
     ],
 )
 def test_serial_val_from_parts(name: PipetteName, model: int, data: bytes) -> None:

--- a/hardware/tests/opentrons_hardware/pipettes/test_serials.py
+++ b/hardware/tests/opentrons_hardware/pipettes/test_serials.py
@@ -8,6 +8,7 @@ from opentrons_hardware.firmware_bindings.constants import PipetteName
     "scanned_val,name,model,serial",
     [
         ("P1KSV0102022022", PipetteName.p1000_single, 1, b"02022022"),
+        ("P1KSV3120211129A08", PipetteName.p1000_single, 31, b"20211129A008"),
         ("P50MV29AABBCCDD", PipetteName.p50_multi, 29, b"AABBCCDD"),
         ("P1KMV1000000000", PipetteName.p1000_multi, 10, b"00000000"),
         ("P50SV01", PipetteName.p50_single, 1, b"\x00\x00\x00\x00\x00\x00\x00\x00"),


### PR DESCRIPTION
On the OT-2, we store the literal serial number of a pipette on its EEPROM. When we detect whether it's connected, we read that serial number and parse it out in python.

We could do that here, but we have access to a lot more smarts on the pipette now, so instead let's parse the serial at flash time and store a binary-packed value for the name and model. The datecode part is still stored literally. 

Locally, we can parse it pretty easily, and use it as the model for the rest of the system (which we more or less already do - not many changes on the read side).

The write side is very different. Let's add a script for writing pipette serials but actually make it part of the system this time.

## Testing
- Write and read some serial numbers! You'll need https://github.com/Opentrons/ot3-firmware/pull/437 on the pipette

## TODO
- [x] This needs proper integration tests

Closes RET-1168
Closes RET-1167