### PR TITLE
fix(api): allow aspirate/dispense at arbitrary locations

### DIFF
--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -255,3 +255,4 @@ Version 2.13
 
 - :py:meth:`.InstrumentContext.drop_tip` now has a ``prep_after`` parameter.
 - :py:meth:`.InstrumentContext.home` may home *both* pipettes as needed to avoid collision risks.
+- :py:meth:`.InstrumentContext.aspirate` and :py:meth:`.InstrumentContext.dispense` will avoid interacting directly with modules.

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -195,7 +195,9 @@ class InstrumentContext(publisher.CommandPublisher):
                 "knows where it is."
             )
         if self.api_version >= APIVersion(2, 11):
-            instrument.validate_can_aspirate(dest)
+            instrument.validate_takes_liquid(
+                location=dest, reject_module=self.api_version >= APIVersion(2, 13)
+            )
 
         if self.current_volume == 0:
             # Make sure we're at the top of the labware and clear of any
@@ -314,7 +316,9 @@ class InstrumentContext(publisher.CommandPublisher):
                 "knows where it is."
             )
         if self.api_version >= APIVersion(2, 11):
-            instrument.validate_can_dispense(loc)
+            instrument.validate_takes_liquid(
+                location=loc, reject_module=self.api_version >= APIVersion(2, 13)
+            )
 
         c_vol = self.current_volume if not volume else volume
 

--- a/api/tests/opentrons/protocols/api_support/test_instrument.py
+++ b/api/tests/opentrons/protocols/api_support/test_instrument.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+from opentrons.protocol_api import ProtocolContext
 from opentrons.protocol_api.labware import Well
 from opentrons.protocols.api_support.instrument import (
     determine_drop_target,
@@ -54,23 +55,45 @@ def test_determine_drop_target(api_version, expected_point):
     assert r.point == expected_point
 
 
-def test_validate_validate_takes_liquid(ctx):
+@pytest.mark.parametrize("reject_module", [True, False])
+def test_validate_takes_liquid(ctx: ProtocolContext, reject_module: bool) -> None:
     well_plate = ctx.load_labware("corning_96_wellplate_360ul_flat", 1)
     tip_rack = ctx.load_labware("opentrons_96_tiprack_300ul", 2)
 
-    validate_takes_liquid(Location(Point(1, 2, 3), None), False)
-    validate_takes_liquid(Location(Point(1, 2, 3), well_plate), False)
-    validate_takes_liquid(Location(Point(1, 2, 3), well_plate.wells()[0]), False)
-    validate_takes_liquid(well_plate.wells()[0].top(), False)
+    validate_takes_liquid(
+        location=Location(Point(1, 2, 3), None),
+        reject_module=reject_module,
+    )
+    validate_takes_liquid(
+        location=Location(Point(1, 2, 3), well_plate),
+        reject_module=reject_module,
+    )
+    validate_takes_liquid(
+        location=Location(Point(1, 2, 3), well_plate.wells()[0]),
+        reject_module=reject_module,
+    )
+    validate_takes_liquid(
+        location=well_plate.wells()[0].top(),
+        reject_module=reject_module,
+    )
 
     with pytest.raises(ValueError, match="Cannot aspirate/dispense to a tip rack"):
-        validate_takes_liquid(Location(Point(1, 2, 3), tip_rack), False)
+        validate_takes_liquid(
+            location=Location(Point(1, 2, 3), tip_rack),
+            reject_module=reject_module,
+        )
 
     with pytest.raises(ValueError, match="Cannot aspirate/dispense to a tip rack"):
-        validate_takes_liquid(Location(Point(1, 2, 3), tip_rack.wells()[0]), False)
+        validate_takes_liquid(
+            location=Location(Point(1, 2, 3), tip_rack.wells()[0]),
+            reject_module=reject_module,
+        )
 
     with pytest.raises(ValueError, match="Cannot aspirate/dispense to a tip rack"):
-        validate_takes_liquid(tip_rack.wells_by_name()["A1"].top(), False)
+        validate_takes_liquid(
+            location=tip_rack.wells_by_name()["A1"].top(),
+            reject_module=reject_module,
+        )
 
 
 def test_validate_validate_takes_liquid_module_location(ctx):

--- a/api/tests/opentrons/protocols/api_support/test_instrument.py
+++ b/api/tests/opentrons/protocols/api_support/test_instrument.py
@@ -96,7 +96,7 @@ def test_validate_takes_liquid(ctx: ProtocolContext, reject_module: bool) -> Non
         )
 
 
-def test_validate_validate_takes_liquid_module_location(ctx):
+def test_validate_takes_liquid_module_location(ctx):
     module = ctx.load_module("magdeck", 1)
 
     validate_takes_liquid(


### PR DESCRIPTION
## Overview

The addition of tip-rack checking for aspirate/dispense in #7788 introduced a regression where previously valid `aspirate` and `dispense` calls to arbitrary deck coordinates would fail. This PR fixes the problems with the logic that was added in that PR to ensure `aspirate` and `dispense` work as expected.

Closes #11302, re: RSS-70

## Changelog

- fix(api): allow aspirate/dispense at arbitrary locations

## Review requests

This bug was caused by misunderstandings with how to use the `LabwareLike` interface via `Location.labware`. We're experiencing similar issues in #11296.

See reproduction protocol in RSS-70 to validate that this PR does its job.

## Risk assessment

Low
