### PR TITLE
fix(app): disable input fields when H-S is shaking

### DIFF
--- a/app/src/organisms/Devices/HeaterShakerWizard/TestShake.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/TestShake.tsx
@@ -188,6 +188,7 @@ export function TestShake(props: TestShakeProps): JSX.Element {
                 max: HS_RPM_MAX,
               })}
               error={errorMessage}
+              disabled={isShaking}
             />
           </Flex>
           <TertiaryButton

--- a/app/src/organisms/Devices/HeaterShakerWizard/__tests__/TestShake.test.tsx
+++ b/app/src/organisms/Devices/HeaterShakerWizard/__tests__/TestShake.test.tsx
@@ -346,8 +346,9 @@ describe('TestShake', () => {
     }
 
     const { getByRole } = render(props)
-    const button = getByRole('button', { name: /Stop Shaking/i })
     const input = getByRole('spinbutton')
+    expect(input).toBeDisabled()
+    const button = getByRole('button', { name: /Stop Shaking/i })
     fireEvent.change(input, { target: { value: '200' } })
     fireEvent.click(button)
 

--- a/app/src/organisms/ModuleCard/HeaterShakerSlideout.tsx
+++ b/app/src/organisms/ModuleCard/HeaterShakerSlideout.tsx
@@ -53,6 +53,7 @@ export const HeaterShakerSlideout = (
   const moduleName = getModuleDisplayName(module.moduleModel)
   const { moduleIdFromRun } = useModuleIdFromRun(module, currentRunId ?? null)
   const modulePart = t('temperature')
+  const isShaking = module.data.speedStatus !== 'idle'
 
   const sendSetTemperatureOrShakeCommand: React.MouseEventHandler<HTMLInputElement> = e => {
     e.preventDefault()
@@ -156,6 +157,7 @@ export const HeaterShakerSlideout = (
               unit: unit,
             })}
             error={errorMessage}
+            disabled={isShaking}
           />
         </form>
       </Flex>

--- a/app/src/organisms/ModuleCard/TestShakeSlideout.tsx
+++ b/app/src/organisms/ModuleCard/TestShakeSlideout.tsx
@@ -282,6 +282,7 @@ export const TestShakeSlideout = (
                 max: HS_RPM_MAX,
               })}
               error={errorMessage}
+              disabled={isShaking}
             />
             <StyledText
               color={COLORS.darkGreyEnabled}

--- a/app/src/organisms/ModuleCard/__tests__/HeaterShakerSlideout.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/HeaterShakerSlideout.test.tsx
@@ -34,6 +34,28 @@ const render = (props: React.ComponentProps<typeof HeaterShakerSlideout>) => {
   })[0]
 }
 
+const mockMovingHeaterShaker = {
+  id: 'heatershaker_id',
+  moduleModel: 'heaterShakerModuleV1',
+  moduleType: 'heaterShakerModuleType',
+  serialNumber: 'jkl123',
+  hardwareRevision: 'heatershaker_v4.0',
+  firmwareVersion: 'v2.0.0',
+  hasAvailableUpdate: true,
+  data: {
+    labwareLatchStatus: 'idle_closed',
+    speedStatus: 'speeding up',
+    temperatureStatus: 'idle',
+    currentSpeed: null,
+    currentTemperature: null,
+    targetSpeed: null,
+    targetTemp: null,
+    errorDetails: null,
+    status: 'idle',
+  },
+  usbPort: { path: '/dev/ot_module_heatershaker0', port: 1 },
+} as any
+
 describe('HeaterShakerSlideout', () => {
   let props: React.ComponentProps<typeof HeaterShakerSlideout>
   let mockCreateLiveCommand = jest.fn()
@@ -157,5 +179,17 @@ describe('HeaterShakerSlideout', () => {
       },
     })
     expect(button).not.toBeEnabled()
+  })
+
+  it('input value is disabled when heater shaker is shaking', () => {
+    props = {
+      module: mockMovingHeaterShaker,
+      isExpanded: true,
+      onCloseClick: jest.fn(),
+      isLoadedInRun: false,
+    }
+    const { getByTestId } = render(props)
+    const input = getByTestId('heaterShakerModuleV1_setTemp')
+    expect(input).toBeDisabled()
   })
 })

--- a/app/src/organisms/ModuleCard/__tests__/TestShakeSlideout.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/TestShakeSlideout.test.tsx
@@ -208,7 +208,7 @@ describe('TestShakeSlideout', () => {
     expect(button).toBeDisabled()
   })
 
-  it('open latch button should be disabled if the module is shaking', () => {
+  it('open latch button and input field should be disabled if the module is shaking', () => {
     props = {
       module: mockMovingHeaterShaker,
       onCloseClick: jest.fn(),
@@ -218,6 +218,8 @@ describe('TestShakeSlideout', () => {
 
     const { getByRole } = render(props)
     const button = getByRole('button', { name: /Open/i })
+    const input = getByRole('spinbutton')
+    expect(input).toBeDisabled()
     expect(button).toBeDisabled()
   })
 


### PR DESCRIPTION
closes RAUT-68
# Overview

When the H-S is shaking, previously, you were able to still input something into the input field and then clicking on the button doesn't do anything since the H-S is already in motion. This disables the input field in both the `TestShake` and `TestShakeSlideout` and also the `HeaterShakerSlideout` (temp slideout)

# Changelog

- add disabled prop to the input field for `TestShakeSlideout`, `TestShake`, and `HeaterShakerSlideout` so the H-S has to be stopped before you can send any other command
- add test case to each test

# Review requests

- with the H-S shaking, you should no longer be able to add anything to the input field

# Risk assessment

low