### PR TITLE
fix(app): show H-S wizard when module is powered off

### DIFF
--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/HeaterShakerBanner.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/HeaterShakerBanner.tsx
@@ -23,15 +23,19 @@ export function HeaterShakerBanner(
     <Banner title={t('attach_heater_shaker_to_deck', { name: displayName })}>
       {modules.map((module, index) => (
         <React.Fragment key={index}>
-          {wizardId === module.moduleId &&
-            module.attachedModuleMatch?.moduleType ===
-              HEATERSHAKER_MODULE_TYPE && (
-              <HeaterShakerWizard
-                onCloseClick={() => setWizardId(null)}
-                moduleFromProtocol={module}
-                attachedModule={module.attachedModuleMatch}
-              />
-            )}
+          {wizardId === module.moduleId && (
+            <HeaterShakerWizard
+              onCloseClick={() => setWizardId(null)}
+              moduleFromProtocol={module}
+              attachedModule={
+                module.attachedModuleMatch != null &&
+                module.attachedModuleMatch?.moduleType ===
+                  HEATERSHAKER_MODULE_TYPE
+                  ? module.attachedModuleMatch
+                  : null
+              }
+            />
+          )}
           {index > 0 && <Divider color={COLORS.medGrey} />}
           <BannerItem
             title={t('module_in_slot', {


### PR DESCRIPTION


# Overview

This PR fixes the bug where the H-S wizard would not show when the module was powered off. closes [RAUT-149](https://opentrons.atlassian.net/browse/RAUT-149)

# Changelog

- Refactor type check in `HeaterShakerBanner` component

# Review requests

- Check that the heater shaker wizard does show when clicking `view instructions` when the module is disconnected/powered off.
- Check that the wizard functions properly.

# Risk assessment
low