### PR TITLE
fix(app): confirm attachment modal logic refactor

### DIFF
--- a/app/src/organisms/ModuleCard/TestShakeSlideout.tsx
+++ b/app/src/organisms/ModuleCard/TestShakeSlideout.tsx
@@ -293,7 +293,7 @@ export const TestShakeSlideout = (
             textTransform={TYPOGRAPHY.textTransformCapitalize}
             marginLeft={SIZE_AUTO}
             marginTop={SPACING.spacing3}
-            onClick={confirmAttachment}
+            onClick={isShaking ? sendCommands : confirmAttachment}
             disabled={
               !isLatchClosed ||
               (shakeValue === null && !isShaking) ||


### PR DESCRIPTION
closes RAUT-152

# Overview

Confirm attachment modal was showing up for both sending and stop shaking in the `TestShakeSlideout`

# Changelog

- change logic to not go through conditional confirm if you are stopping the shake

# Review requests

- set a shaking command via the `TestShakeSlideout`, with modal turned on, you should see the modal. 
- stop the shaking command via the `TestShakeSlideout`, you shouldn't see the modal

# Risk assessment

low