### PR TITLE
fix(app): H-S fix tooltip text position in overflow menu button

### DIFF
--- a/app/src/atoms/MenuList/index.tsx
+++ b/app/src/atoms/MenuList/index.tsx
@@ -23,7 +23,6 @@ export const MenuList = (props: MenuListProps): JSX.Element | null => {
       top="2.6rem"
       right={`calc(50% + ${SPACING.spacing2})`}
       flexDirection={DIRECTION_COLUMN}
-      whiteSpace="nowrap"
     >
       {props.buttons}
     </Flex>

--- a/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
+++ b/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
@@ -25,7 +25,7 @@ interface ModuleOverflowMenuProps {
 export const ModuleOverflowMenu = (
   props: ModuleOverflowMenuProps
 ): JSX.Element | null => {
-  const { t } = useTranslation(['device_details', 'heater_shaker'])
+  const { t } = useTranslation(['heater_shaker'])
   const {
     module,
     runId,
@@ -57,38 +57,37 @@ export const ModuleOverflowMenu = (
   }
 
   return (
-    <>
-      <Flex position={POSITION_RELATIVE}>
-        <MenuList
-          buttons={[
-            (menuOverflowItemsByModuleType[
-              module.moduleType
-            ] as MenuItemsByModuleType[ModuleType]).map(
-              (item: any, index: number) => {
-                return (
-                  <React.Fragment key={`${index}_${module.moduleType}`}>
-                    <MenuItem
-                      key={`${index}_${module.moduleModel}`}
-                      onClick={() => item.onClick(item.isSecondary)}
-                      data-testid={`module_setting_${module.moduleModel}`}
-                      disabled={item.disabledReason || isDisabled}
-                      {...targetProps}
-                    >
-                      {item.setSetting}
-                    </MenuItem>
-                    {item.disabledReason && (
-                      <Tooltip tooltipProps={tooltipProps}>
-                        {t('heater_shaker:cannot_shake')}
-                      </Tooltip>
-                    )}
-                    {item.menuButtons}
-                  </React.Fragment>
-                )
-              }
-            ),
-          ]}
-        />
-      </Flex>
-    </>
+    <Flex position={POSITION_RELATIVE}>
+      <MenuList
+        buttons={[
+          (menuOverflowItemsByModuleType[
+            module.moduleType
+          ] as MenuItemsByModuleType[ModuleType]).map(
+            (item: any, index: number) => {
+              return (
+                <React.Fragment key={`${index}_${module.moduleType}`}>
+                  <MenuItem
+                    key={`${index}_${module.moduleModel}`}
+                    onClick={() => item.onClick(item.isSecondary)}
+                    data-testid={`module_setting_${module.moduleModel}`}
+                    disabled={item.disabledReason || isDisabled}
+                    whiteSpace="nowrap"
+                    {...targetProps}
+                  >
+                    {item.setSetting}
+                  </MenuItem>
+                  {item.disabledReason && (
+                    <Tooltip tooltipProps={tooltipProps}>
+                      {t('cannot_shake')}
+                    </Tooltip>
+                  )}
+                  {item.menuButtons}
+                </React.Fragment>
+              )
+            }
+          ),
+        ]}
+      />
+    </Flex>
   )
 }

--- a/app/src/organisms/ModuleCard/hooks.tsx
+++ b/app/src/organisms/ModuleCard/hooks.tsx
@@ -172,6 +172,7 @@ export function useModuleOverflowMenu(
       key={`hs_attach_to_deck_${module.moduleModel}`}
       data-testid={`hs_attach_to_deck_${module.moduleModel}`}
       onClick={() => handleWizardClick()}
+      whiteSpace="nowrap"
     >
       {t('heater_shaker:show_attachment_instructions')}
     </MenuItem>


### PR DESCRIPTION
closes RAUT-153

# Overview

Tooltip text wasn't wrapping correctly because we had a `whiteSpace: "nowrap"` defined in the parent component. Refactored to only include `nowrap` on the buttons with the longest text as a hacky way to get around this error. A more eloquent fix I think would take a larger refactor with the `useModuleOverflowMenu` hook which can be completed at a later time

Additionally, it looks like the `disabledReason` in the `useModuleOverflowMenu` hook isn't being used at all (because we refactored the HS overflow menu to not have the `Set shake` button anymore). We should remove that + the unused logic in a followup refactor.

# Changelog

- remove `nowrap` from `MenuList` (which is only being used for module card overflow menus)
- add `nowrap` to a few buttons within the `ModuleOverflowMenu`
- slight cleanup of `ModuleOverflowMenu` to remove the unneeded i18n json file and the unnecessary react fragment

# Review requests

- with the H-S is shaking, look at the tooltip for the latch button in the overflow menu. it should wrap correctly.

# Risk assessment

low