### PR TITLE
fix(protocol-designer): truncate labware type name

### DIFF
--- a/protocol-designer/src/components/IngredientsList/LabwareDetailsCard/labwareDetailsCard.css
+++ b/protocol-designer/src/components/IngredientsList/LabwareDetailsCard/labwareDetailsCard.css
@@ -6,6 +6,10 @@
 
 .column_2_3 {
   lost-column: 2/3;
+  margin-bottom: 0.2rem;
+  overflow: hidden;
+  display: inline-block;
+  text-overflow: ellipsis;
 }
 
 .row {


### PR DESCRIPTION
closes RAUT-145

# Overview

PD `LabwareDetailsCard` Labware Type `displayName` was cut off. This truncates the name instead, to follow the same pattern as the Labware Nickname displayed below it.

<img width="304" alt="Screen Shot 2022-08-18 at 2 44 04 PM" src="https://user-images.githubusercontent.com/66035149/185470567-b037ab8f-5c27-49c4-b575-3d52a0ef027d.png">

# Changelog

- add`overflow`, `display`, and `text-overflow` to the `LabwareDetailsCard` css flow

# Review requests

- in PD, create a protocol and go to the Design tab. Add a labware with a long name. When clicking on the labware to add a nickname and details, the `LabwareDetailsCard` on the left where the Timeline is displayed will appear. Check that the long labware name is truncated.

# Risk assessment

low