### PR TITLE
fix(app): hide device error screen while scanning

### DIFF
--- a/app/src/pages/Devices/DeviceDetails/index.tsx
+++ b/app/src/pages/Devices/DeviceDetails/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom'
 
 import {
@@ -17,14 +18,18 @@ import { useRobot, useSyncRobotClock } from '../../../organisms/Devices/hooks'
 import { PipettesAndModules } from '../../../organisms/Devices/PipettesAndModules'
 import { RecentProtocolRuns } from '../../../organisms/Devices/RecentProtocolRuns'
 import { RobotOverview } from '../../../organisms/Devices/RobotOverview'
+import { getScanning } from '../../../redux/discovery'
 
 import type { NavRouteParams } from '../../../App/types'
 
 export function DeviceDetails(): JSX.Element | null {
   const { robotName } = useParams<NavRouteParams>()
   const robot = useRobot(robotName)
+  const isScanning = useSelector(getScanning)
 
   useSyncRobotClock(robotName)
+
+  if (robot == null && isScanning) return null
 
   return robot != null ? (
     <ApiHostProvider key={robot.name} hostname={robot.ip ?? null}>
@@ -59,7 +64,9 @@ export function DeviceDetails(): JSX.Element | null {
     /* eslint-disable */
     <div style={{ fontFamily: 'courier', marginLeft: '8px' }}>
       <br />
+      <div>
       Can't find robot!
+      </div>
       <br />
       <br />
       MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMWX0KNMMMMMMMMMMMMMMMMMMMMMMMMM


### PR DESCRIPTION
# Overview

the temp no robot found error screen implemented in https://github.com/Opentrons/opentrons/pull/11191 was showing briefly on the device details page on page load. this blocks the error screen while discovery is scanning. does some device details test file TLC as well.

# Changelog

 - Hides device error screen while scanning

# Review requests

confirm that error screen no longer flashes briefly on device details page load

# Risk assessment

low
