### PR TITLE
refactor(ot-3): modify what types of tools we can detect on the OT-3

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -156,12 +156,10 @@ class ToolType(int, Enum):
     """Tool types detected on Head."""
 
     undefined_tool = 0x00
-    pipette_96_chan = 0x01
-    pipette_384_chan = 0x02
-    pipette_single_chan = 0x03
-    pipette_multi_chan = 0x04
-    gripper = 0x05
-    nothing_attached = 0x06
+    pipette = 0x01
+    gripper = 0x02
+    nothing_attached = 0x03
+    tool_error = 0x04
 
 
 @unique

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -155,11 +155,10 @@ class ErrorCode(int, Enum):
 class ToolType(int, Enum):
     """Tool types detected on Head."""
 
-    undefined_tool = 0x00
-    pipette = 0x01
-    gripper = 0x02
-    nothing_attached = 0x03
-    tool_error = 0x04
+    pipette = 0x00
+    gripper = 0x01
+    nothing_attached = 0x02
+    tool_error = 0x03
 
 
 @unique

--- a/hardware/opentrons_hardware/hardware_control/tools/detector.py
+++ b/hardware/opentrons_hardware/hardware_control/tools/detector.py
@@ -28,7 +28,7 @@ def _handle_detection_result(
         try:
             return ToolType(i)
         except ValueError:
-            return ToolType.undefined_tool
+            return ToolType.tool_error
 
     return ToolDetectionResult(
         left=_check_tool(response.payload.z_motor.value),
@@ -139,10 +139,7 @@ class OneshotToolDetector:
             should_respond: Set[NodeId] = set()
 
             def _should_query(attach_response: ToolType) -> bool:
-                return attach_response not in (
-                    ToolType.undefined_tool,
-                    ToolType.nothing_attached,
-                )
+                return attach_response != ToolType.nothing_attached
 
             if _should_query(attached.left):
                 should_respond.add(NodeId.pipette_left)

--- a/hardware/tests/firmware_integration/test_attached_tools.py
+++ b/hardware/tests/firmware_integration/test_attached_tools.py
@@ -34,9 +34,9 @@ async def test_attached_tools_request(
     message, arbitration_id = await asyncio.wait_for(can_messenger_queue.read(), 1)
 
     expected_payload = ToolsDetectedNotificationPayload(
-        z_motor=ToolField(ToolType.undefined_tool),
-        a_motor=ToolField(ToolType.undefined_tool),
-        gripper=ToolField(ToolType.undefined_tool),
+        z_motor=ToolField(ToolType.nothing_attached),
+        a_motor=ToolField(ToolType.tool_error),
+        gripper=ToolField(ToolType.nothing_attached),
     )
 
     assert arbitration_id.parts.message_id == PushToolsDetectedNotification.message_id

--- a/hardware/tests/opentrons_hardware/hardware_control/tools/test_detector.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/tools/test_detector.py
@@ -30,25 +30,25 @@ def subject(
     argvalues=[
         [
             payloads.ToolsDetectedNotificationPayload(
-                z_motor=ToolField(ToolType.pipette_96_chan.value),
-                a_motor=ToolField(ToolType.pipette_384_chan.value),
+                z_motor=ToolField(ToolType.pipette.value),
+                a_motor=ToolField(ToolType.pipette.value),
                 gripper=ToolField(ToolType.gripper.value),
             ),
             ToolDetectionResult(
-                left=ToolType.pipette_96_chan,
-                right=ToolType.pipette_384_chan,
+                left=ToolType.pipette,
+                right=ToolType.pipette,
                 gripper=ToolType.gripper,
             ),
         ],
         [
             payloads.ToolsDetectedNotificationPayload(
                 z_motor=ToolField(221),
-                a_motor=ToolField(ToolType.pipette_384_chan.value),
+                a_motor=ToolField(ToolType.pipette.value),
                 gripper=ToolField(ToolType.gripper.value),
             ),
             ToolDetectionResult(
                 left=ToolType.undefined_tool,
-                right=ToolType.pipette_384_chan,
+                right=ToolType.pipette,
                 gripper=ToolType.gripper,
             ),
         ],

--- a/hardware/tests/opentrons_hardware/hardware_control/tools/test_detector.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/tools/test_detector.py
@@ -47,7 +47,7 @@ def subject(
                 gripper=ToolField(ToolType.gripper.value),
             ),
             ToolDetectionResult(
-                left=ToolType.undefined_tool,
+                left=ToolType.tool_error,
                 right=ToolType.pipette,
                 gripper=ToolType.gripper,
             ),

--- a/hardware/tests/opentrons_hardware/hardware_control/tools/test_oneshot.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/tools/test_oneshot.py
@@ -46,9 +46,9 @@ async def test_suppresses_undefined(
                     NodeId.host,
                     message_definitions.PushToolsDetectedNotification(
                         payload=payloads.ToolsDetectedNotificationPayload(
-                            z_motor=ToolField(ToolType.undefined_tool.value),
-                            a_motor=ToolField(ToolType.undefined_tool.value),
-                            gripper=ToolField(ToolType.undefined_tool.value),
+                            z_motor=ToolField(ToolType.nothing_attached.value),
+                            a_motor=ToolField(ToolType.nothing_attached.value),
+                            gripper=ToolField(ToolType.nothing_attached.value),
                         )
                     ),
                     NodeId.head,

--- a/hardware/tests/opentrons_hardware/hardware_control/tools/test_oneshot.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/tools/test_oneshot.py
@@ -132,7 +132,7 @@ async def test_sends_only_required_followups(
                     message_definitions.PushToolsDetectedNotification(
                         payload=payloads.ToolsDetectedNotificationPayload(
                             z_motor=ToolField(ToolType.nothing_attached.value),
-                            a_motor=ToolField(ToolType.pipette_multi_chan.value),
+                            a_motor=ToolField(ToolType.pipette.value),
                             gripper=ToolField(ToolType.nothing_attached.value),
                         )
                     ),
@@ -198,8 +198,8 @@ async def test_sends_all_required_followups(
                     NodeId.host,
                     message_definitions.PushToolsDetectedNotification(
                         payload=payloads.ToolsDetectedNotificationPayload(
-                            z_motor=ToolField(ToolType.pipette_single_chan.value),
-                            a_motor=ToolField(ToolType.pipette_multi_chan.value),
+                            z_motor=ToolField(ToolType.pipette.value),
+                            a_motor=ToolField(ToolType.pipette.value),
                             gripper=ToolField(ToolType.gripper.value),
                         )
                     ),
@@ -291,7 +291,7 @@ async def test_handles_bad_serials(
                     NodeId.host,
                     message_definitions.PushToolsDetectedNotification(
                         payload=payloads.ToolsDetectedNotificationPayload(
-                            z_motor=ToolField(ToolType.pipette_single_chan.value),
+                            z_motor=ToolField(ToolType.pipette.value),
                             a_motor=ToolField(ToolType.nothing_attached.value),
                             gripper=ToolField(ToolType.nothing_attached.value),
                         )
@@ -350,7 +350,7 @@ async def test_no_instrument_info_response(
                     message_definitions.PushToolsDetectedNotification(
                         payload=payloads.ToolsDetectedNotificationPayload(
                             z_motor=ToolField(ToolType.nothing_attached.value),
-                            a_motor=ToolField(ToolType.pipette_single_chan.value),
+                            a_motor=ToolField(ToolType.pipette.value),
                             gripper=ToolField(ToolType.nothing_attached.value),
                         )
                     ),


### PR DESCRIPTION
# Overview
Awhile ago, we no longer wanted to try and determine the instrument type based on the ADC because it
was too variable. This PR changes the tool types we can support to: A pipette, a gripper, nothing attached, tool error and undefined.

# Review requests

- Did I forget anything?

# Risk assessment

Low.
