### PR TITLE
fix(app): return valid custom labware when sorting

### DIFF
--- a/app/src/pages/Labware/__tests__/hooks.test.tsx
+++ b/app/src/pages/Labware/__tests__/hooks.test.tsx
@@ -7,7 +7,7 @@ import { I18nextProvider } from 'react-i18next'
 import { getAllDefs } from '../helpers/getAllDefs'
 
 import {
-  getCustomLabware,
+  getValidCustomLabware,
   getAddLabwareFailure,
   getAddNewLabwareName,
 } from '../../../redux/custom-labware'
@@ -25,8 +25,8 @@ import { FailedLabwareFile } from '../../../redux/custom-labware/types'
 jest.mock('../../../redux/custom-labware')
 jest.mock('../helpers/getAllDefs')
 
-const mockGetCustomLabware = getCustomLabware as jest.MockedFunction<
-  typeof getCustomLabware
+const mockGetValidCustomLabware = getValidCustomLabware as jest.MockedFunction<
+  typeof getValidCustomLabware
 >
 const mockGetAllAllDefs = getAllDefs as jest.MockedFunction<typeof getAllDefs>
 const mockGetAddLabwareFailure = getAddLabwareFailure as jest.MockedFunction<
@@ -40,7 +40,7 @@ describe('useAllLabware hook', () => {
   const store: Store<State> = createStore(jest.fn(), {})
   beforeEach(() => {
     mockGetAllAllDefs.mockReturnValue([mockDefinition])
-    mockGetCustomLabware.mockReturnValue([mockValidLabware])
+    mockGetValidCustomLabware.mockReturnValue([mockValidLabware])
     store.dispatch = jest.fn()
   })
   afterEach(() => {

--- a/app/src/pages/Labware/hooks.tsx
+++ b/app/src/pages/Labware/hooks.tsx
@@ -1,11 +1,11 @@
 import { useSelector, useDispatch } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 import {
-  getCustomLabware,
   getAddLabwareFailure,
   clearAddCustomLabwareFailure,
   getAddNewLabwareName,
   clearNewLabwareName,
+  getValidCustomLabware,
 } from '../../redux/custom-labware'
 import { getAllDefinitions } from './helpers/definitions'
 import type { Dispatch } from '../../redux/types'
@@ -26,7 +26,7 @@ export function useAllLabware(
   const fullLabwareList: LabwareDefAndDate[] = []
   const labwareDefinitions = getAllDefinitions()
   labwareDefinitions.forEach(def => fullLabwareList.push({ definition: def }))
-  const customLabwareList = useSelector(getCustomLabware)
+  const customLabwareList = useSelector(getValidCustomLabware)
   customLabwareList.forEach(customLabware =>
     'definition' in customLabware
       ? fullLabwareList.push({


### PR DESCRIPTION
# Overview

This PR fixes the custom labware sorting bug by returning valid custom labware only. closes [RAUT-155](https://opentrons.atlassian.net/browse/RAUT-155?atlOrigin=eyJpIjoiYWExM2M5YTZhOTVmNDM4ZGIzZjRlNTZmMWY5NjlkNTYiLCJwIjoiaiJ9)

# Changelog

- Changed `getCustomLabware` to `getValidCustomLabware`

# Review requests

- Check that the white screen issue no longer appears when filtering by custom labware when the source directory is changed.

# Risk assessment

low