### PR TITLE
refactor(shared-data): Make a protocol schema v7 draft

### DIFF
--- a/shared-data/js/__tests__/deckSchemas.test.ts
+++ b/shared-data/js/__tests__/deckSchemas.test.ts
@@ -1,4 +1,4 @@
-/** Ensure that protocol schema v4 definition itself is functions as intended,
+/** Ensure that the deck schema itself functions as intended,
  *  and that all v4 protocol fixtures will validate */
 import Ajv from 'ajv'
 import path from 'path'

--- a/shared-data/js/__tests__/protocolSchemaV4.test.ts
+++ b/shared-data/js/__tests__/protocolSchemaV4.test.ts
@@ -34,8 +34,8 @@ describe('validate v4 protocol fixtures under JSON schema', () => {
         console.log(JSON.stringify(validationErrors, null, 4))
       }
 
-      expect(valid).toBe(true)
       expect(validationErrors).toBe(null)
+      expect(valid).toBe(true)
     })
   })
 })

--- a/shared-data/js/__tests__/protocolSchemaV4.test.ts
+++ b/shared-data/js/__tests__/protocolSchemaV4.test.ts
@@ -1,4 +1,4 @@
-/** Ensure that protocol schema v4 definition itself is functions as intended,
+/** Ensure that protocol schema v4 definition itself functions as intended,
  *  and that all v4 protocol fixtures will validate */
 import Ajv from 'ajv'
 import path from 'path'

--- a/shared-data/js/__tests__/protocolSchemaV5.test.ts
+++ b/shared-data/js/__tests__/protocolSchemaV5.test.ts
@@ -1,4 +1,4 @@
-/** Ensure that protocol schema v5 definition itself is functions as intended,
+/** Ensure that protocol schema v5 definition itself functions as intended,
  *  and that all v5 protocol fixtures will validate */
 import Ajv from 'ajv'
 import path from 'path'

--- a/shared-data/js/__tests__/protocolSchemaV5.test.ts
+++ b/shared-data/js/__tests__/protocolSchemaV5.test.ts
@@ -34,8 +34,8 @@ describe('validate v5 protocol fixtures under JSON schema', () => {
         console.log(JSON.stringify(validationErrors, null, 4))
       }
 
-      expect(valid).toBe(true)
       expect(validationErrors).toBe(null)
+      expect(valid).toBe(true)
     })
   })
 })

--- a/shared-data/js/__tests__/protocolSchemaV6.test.ts
+++ b/shared-data/js/__tests__/protocolSchemaV6.test.ts
@@ -1,4 +1,4 @@
-/** Ensure that protocol schema v6 definition itself is functions as intended,
+/** Ensure that protocol schema v6 definition itself functions as intended,
  *  and that all v6 protocol fixtures will validate */
 import Ajv from 'ajv'
 import path from 'path'

--- a/shared-data/js/__tests__/protocolSchemaV6.test.ts
+++ b/shared-data/js/__tests__/protocolSchemaV6.test.ts
@@ -34,8 +34,8 @@ describe('validate v6 protocol fixtures under JSON schema', () => {
         console.log(JSON.stringify(validationErrors, null, 4))
       }
 
-      expect(valid).toBe(true)
       expect(validationErrors).toBe(null)
+      expect(valid).toBe(true)
     })
   })
 })

--- a/shared-data/js/__tests__/protocolSchemaV7.test.ts
+++ b/shared-data/js/__tests__/protocolSchemaV7.test.ts
@@ -1,0 +1,132 @@
+/** Ensure that protocol schema v7 definition itself functions as intended,
+ *  and that all v7 protocol fixtures will validate */
+import Ajv from 'ajv'
+import path from 'path'
+import glob from 'glob'
+import omit from 'lodash/omit'
+
+import protocolSchema from '../../protocol/schemas/7-draft.json'
+import labwareV2Schema from '../../labware/schemas/2.json'
+import simpleV6Fixture from '../../protocol/fixtures/7/simpleV7.json'
+
+const fixturesGlobPath = path.join(
+  __dirname,
+  '../../protocol/fixtures/7/**/*.json'
+)
+
+const protocolFixtures = glob.sync(fixturesGlobPath)
+const ajv = new Ajv({ allErrors: true, jsonPointers: true })
+
+// v6 protocol schema contains reference to v2 labware schema, so give AJV access to it
+ajv.addSchema(labwareV2Schema)
+
+const validateProtocol = ajv.compile(protocolSchema)
+
+describe('validate v7 protocol fixtures under JSON schema', () => {
+  protocolFixtures.forEach(protocolPath => {
+    it(path.basename(protocolPath), () => {
+      const protocol = require(protocolPath)
+
+      const valid = validateProtocol(protocol)
+      const validationErrors = validateProtocol.errors
+
+      if (validationErrors) {
+        console.log(JSON.stringify(validationErrors, null, 4))
+      }
+
+      expect(valid).toBe(true)
+      expect(validationErrors).toBe(null)
+    })
+  })
+})
+
+describe('ensure bad protocol data fails validation', () => {
+  it('$otSharedSchema is required to be "#/protocol/schemas/6"', () => {
+    expect(validateProtocol(omit(simpleV6Fixture, '$otSharedSchema'))).toBe(
+      false
+    )
+    expect(
+      validateProtocol({
+        ...simpleV6Fixture,
+        $otSharedSchema: '#/protocol/schemas/3',
+      })
+    ).toBe(false)
+  })
+
+  it('schemaVersion is required to be 6', () => {
+    expect(validateProtocol(omit(simpleV6Fixture, 'schemaVersion'))).toBe(false)
+    expect(validateProtocol({ ...simpleV6Fixture, schemaVersion: 3 })).toBe(
+      false
+    )
+  })
+
+  it('reject bad values in "pipettes" objects', () => {
+    const badPipettes = {
+      missingKeys: {},
+      missingName: { mount: 'left' },
+      hasAdditionalProperties: {
+        mount: 'left',
+        name: 'pipetteName',
+        blah: 'blah',
+      },
+    }
+
+    Object.entries(badPipettes).forEach(([pipetteId, pipette]) => {
+      expect(
+        validateProtocol({
+          ...simpleV6Fixture,
+          pipettes: {
+            ...simpleV6Fixture.pipettes,
+            [pipetteId]: pipette,
+          },
+        })
+      ).toBe(false)
+    })
+  })
+
+  it('reject bad values in "labware" objects', () => {
+    const badLabware = {
+      noDefId: { displayName: 'myLabware' },
+      hasAdditionalProperties: {
+        slot: '1',
+        definitionId: 'defId',
+        blah: 'blah',
+      },
+    }
+
+    Object.entries(badLabware).forEach(([labwareId, labware]) => {
+      expect(
+        validateProtocol({
+          ...simpleV6Fixture,
+          labware: {
+            ...simpleV6Fixture.labware,
+            [labwareId]: labware,
+          },
+        })
+      ).toBe(false)
+    })
+  })
+
+  it('reject bad values in "modules" objects', () => {
+    const badModules = {
+      noModel: { moduleType: 'thermocycler' },
+      hasAdditionalProperties: {
+        model: 'thermocycler',
+        slot: '1',
+        blah: 'blah',
+      },
+    }
+
+    Object.entries(badModules).forEach(([moduleId, module]) => {
+      expect(
+        validateProtocol({
+          ...simpleV6Fixture,
+          modules: {
+            ...simpleV6Fixture.modules,
+            [moduleId]: module,
+          },
+        })
+      ).toBe(false)
+    })
+  })
+})

--- a/shared-data/js/__tests__/protocolSchemaV7.test.ts
+++ b/shared-data/js/__tests__/protocolSchemaV7.test.ts
@@ -34,8 +34,8 @@ describe('validate v7 protocol fixtures under JSON schema', () => {
         console.log(JSON.stringify(validationErrors, null, 4))
       }
 
-      expect(valid).toBe(true)
       expect(validationErrors).toBe(null)
+      expect(valid).toBe(true)
     })
   })
 })

--- a/shared-data/js/__tests__/protocolSchemaV7.test.ts
+++ b/shared-data/js/__tests__/protocolSchemaV7.test.ts
@@ -7,7 +7,7 @@ import omit from 'lodash/omit'
 
 import protocolSchema from '../../protocol/schemas/7-draft.json'
 import labwareV2Schema from '../../labware/schemas/2.json'
-import simpleV6Fixture from '../../protocol/fixtures/7/simpleV7.json'
+import simpleV7Fixture from '../../protocol/fixtures/7/simpleV7.json'
 
 const fixturesGlobPath = path.join(
   __dirname,
@@ -17,7 +17,7 @@ const fixturesGlobPath = path.join(
 const protocolFixtures = glob.sync(fixturesGlobPath)
 const ajv = new Ajv({ allErrors: true, jsonPointers: true })
 
-// v6 protocol schema contains reference to v2 labware schema, so give AJV access to it
+// v7 protocol schema contains reference to v2 labware schema, so give AJV access to it
 ajv.addSchema(labwareV2Schema)
 
 const validateProtocol = ajv.compile(protocolSchema)
@@ -41,21 +41,21 @@ describe('validate v7 protocol fixtures under JSON schema', () => {
 })
 
 describe('ensure bad protocol data fails validation', () => {
-  it('$otSharedSchema is required to be "#/protocol/schemas/6"', () => {
-    expect(validateProtocol(omit(simpleV6Fixture, '$otSharedSchema'))).toBe(
+  it('$otSharedSchema is required to be "#/protocol/schemas/7-draft"', () => {
+    expect(validateProtocol(omit(simpleV7Fixture, '$otSharedSchema'))).toBe(
       false
     )
     expect(
       validateProtocol({
-        ...simpleV6Fixture,
+        ...simpleV7Fixture,
         $otSharedSchema: '#/protocol/schemas/3',
       })
     ).toBe(false)
   })
 
-  it('schemaVersion is required to be 6', () => {
-    expect(validateProtocol(omit(simpleV6Fixture, 'schemaVersion'))).toBe(false)
-    expect(validateProtocol({ ...simpleV6Fixture, schemaVersion: 3 })).toBe(
+  it('schemaVersion is required to be 7', () => {
+    expect(validateProtocol(omit(simpleV7Fixture, 'schemaVersion'))).toBe(false)
+    expect(validateProtocol({ ...simpleV7Fixture, schemaVersion: 3 })).toBe(
       false
     )
   })
@@ -74,9 +74,9 @@ describe('ensure bad protocol data fails validation', () => {
     Object.entries(badPipettes).forEach(([pipetteId, pipette]) => {
       expect(
         validateProtocol({
-          ...simpleV6Fixture,
+          ...simpleV7Fixture,
           pipettes: {
-            ...simpleV6Fixture.pipettes,
+            ...simpleV7Fixture.pipettes,
             [pipetteId]: pipette,
           },
         })
@@ -97,9 +97,9 @@ describe('ensure bad protocol data fails validation', () => {
     Object.entries(badLabware).forEach(([labwareId, labware]) => {
       expect(
         validateProtocol({
-          ...simpleV6Fixture,
+          ...simpleV7Fixture,
           labware: {
-            ...simpleV6Fixture.labware,
+            ...simpleV7Fixture.labware,
             [labwareId]: labware,
           },
         })
@@ -120,9 +120,9 @@ describe('ensure bad protocol data fails validation', () => {
     Object.entries(badModules).forEach(([moduleId, module]) => {
       expect(
         validateProtocol({
-          ...simpleV6Fixture,
+          ...simpleV7Fixture,
           modules: {
-            ...simpleV6Fixture.modules,
+            ...simpleV7Fixture.modules,
             [moduleId]: module,
           },
         })

--- a/shared-data/protocol/fixtures/7/simpleV7.json
+++ b/shared-data/protocol/fixtures/7/simpleV7.json
@@ -1,0 +1,1513 @@
+{
+  "$otSharedSchema": "#/protocol/schemas/7-draft",
+  "schemaVersion": 7,
+  "metadata": {
+    "protocolName": "Simple test protocol",
+    "author": "engineering <engineering@opentrons.com>",
+    "description": "A short test protocol",
+    "created": 1223131231,
+    "tags": ["unitTest"]
+  },
+  "robot": {
+    "model": "OT-2 Standard",
+    "deckId": "ot2_standard"
+  },
+  "pipettes": {
+    "pipetteId": {
+      "name": "p10_single"
+    }
+  },
+  "modules": {
+    "magneticModuleId": {
+      "model": "magneticModuleV2"
+    },
+    "temperatureModuleId": {
+      "model": "temperatureModuleV2"
+    }
+  },
+  "labware": {
+    "fixedTrash": {
+      "displayName": "Trash",
+      "definitionId": "opentrons/opentrons_1_trash_1100ml_fixed/1"
+    },
+    "tipRackId": {
+      "displayName": "Opentrons 96 Tip Rack 10 µL",
+      "definitionId": "opentrons/opentrons_96_tiprack_10ul/1"
+    },
+    "sourcePlateId": {
+      "displayName": "Source Plate",
+      "definitionId": "example/plate/1"
+    },
+    "destPlateId": {
+      "displayName": "Sample Collection Plate",
+      "definitionId": "example/plate/1"
+    }
+  },
+  "liquids": {
+    "waterId": {
+      "displayName": "Water",
+      "description": "Liquid H2O",
+      "displayColor": "#7332a8"
+    }
+  },
+  "labwareDefinitions": {
+    "opentrons/opentrons_1_trash_1100ml_fixed/1": {
+      "ordering": [["A1"]],
+      "metadata": {
+        "displayCategory": "trash",
+        "displayVolumeUnits": "mL",
+        "displayName": "Opentrons Fixed Trash",
+        "tags": []
+      },
+      "schemaVersion": 2,
+      "version": 1,
+      "namespace": "opentrons",
+      "dimensions": {
+        "xDimension": 172.86,
+        "yDimension": 165.86,
+        "zDimension": 82
+      },
+      "parameters": {
+        "format": "trash",
+        "isTiprack": false,
+        "loadName": "opentrons_1_trash_1100ml_fixed",
+        "isMagneticModuleCompatible": false,
+        "quirks": ["fixedTrash", "centerMultichannelOnWells"]
+      },
+      "wells": {
+        "A1": {
+          "shape": "rectangular",
+          "yDimension": 165.67,
+          "xDimension": 107.11,
+          "totalLiquidVolume": 1100000,
+          "depth": 77,
+          "x": 82.84,
+          "y": 53.56,
+          "z": 5
+        }
+      },
+      "brand": {
+        "brand": "Opentrons"
+      },
+      "groups": [
+        {
+          "wells": ["A1"],
+          "metadata": {}
+        }
+      ],
+      "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      }
+    },
+    "opentrons/opentrons_96_tiprack_10ul/1": {
+      "ordering": [
+        ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
+        ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
+        ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
+        ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
+        ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
+        ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
+        ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
+        ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
+        ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
+        ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
+        ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
+        ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
+      ],
+      "brand": {
+        "brand": "Opentrons",
+        "brandId": [],
+        "links": [
+          "https://shop.opentrons.com/collections/opentrons-tips/products/opentrons-10ul-tips"
+        ]
+      },
+      "metadata": {
+        "displayName": "Opentrons 96 Tip Rack 10 µL",
+        "displayCategory": "tipRack",
+        "displayVolumeUnits": "µL",
+        "tags": []
+      },
+      "dimensions": {
+        "xDimension": 127.76,
+        "yDimension": 85.48,
+        "zDimension": 64.69
+      },
+      "wells": {
+        "A1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 11.24,
+          "z": 25.49
+        }
+      },
+      "groups": [
+        {
+          "metadata": {},
+          "wells": [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "E1",
+            "F1",
+            "G1",
+            "H1",
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "E2",
+            "F2",
+            "G2",
+            "H2",
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "E3",
+            "F3",
+            "G3",
+            "H3",
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "E4",
+            "F4",
+            "G4",
+            "H4",
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "E5",
+            "F5",
+            "G5",
+            "H5",
+            "A6",
+            "B6",
+            "C6",
+            "D6",
+            "E6",
+            "F6",
+            "G6",
+            "H6",
+            "A7",
+            "B7",
+            "C7",
+            "D7",
+            "E7",
+            "F7",
+            "G7",
+            "H7",
+            "A8",
+            "B8",
+            "C8",
+            "D8",
+            "E8",
+            "F8",
+            "G8",
+            "H8",
+            "A9",
+            "B9",
+            "C9",
+            "D9",
+            "E9",
+            "F9",
+            "G9",
+            "H9",
+            "A10",
+            "B10",
+            "C10",
+            "D10",
+            "E10",
+            "F10",
+            "G10",
+            "H10",
+            "A11",
+            "B11",
+            "C11",
+            "D11",
+            "E11",
+            "F11",
+            "G11",
+            "H11",
+            "A12",
+            "B12",
+            "C12",
+            "D12",
+            "E12",
+            "F12",
+            "G12",
+            "H12"
+          ]
+        }
+      ],
+      "parameters": {
+        "format": "96Standard",
+        "isTiprack": true,
+        "tipLength": 39.2,
+        "tipOverlap": 3.29,
+        "isMagneticModuleCompatible": false,
+        "loadName": "opentrons_96_tiprack_10ul"
+      },
+      "namespace": "opentrons",
+      "version": 1,
+      "schemaVersion": 2,
+      "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      }
+    },
+    "example/plate/1": {
+      "ordering": [
+        ["A1", "B1", "C1", "D1"],
+        ["A2", "B2", "C2", "D2"]
+      ],
+      "brand": {
+        "brand": "foo",
+        "brandId": []
+      },
+      "metadata": {
+        "displayName": "Foo 8 Well Plate 33uL",
+        "displayCategory": "wellPlate",
+        "displayVolumeUnits": "µL"
+      },
+      "dimensions": {
+        "xDimension": 127.75,
+        "yDimension": 85.5,
+        "zDimension": 100
+      },
+      "wells": {
+        "A1": {
+          "depth": 25,
+          "totalLiquidVolume": 33,
+          "shape": "circular",
+          "diameter": 10,
+          "x": 18.21,
+          "y": 75.43,
+          "z": 75
+        },
+        "B1": {
+          "depth": 25,
+          "totalLiquidVolume": 33,
+          "shape": "circular",
+          "diameter": 10,
+          "x": 18.21,
+          "y": 56.15,
+          "z": 75
+        },
+        "C1": {
+          "depth": 25,
+          "totalLiquidVolume": 33,
+          "shape": "circular",
+          "diameter": 10,
+          "x": 18.21,
+          "y": 36.87,
+          "z": 75
+        },
+        "D1": {
+          "depth": 25,
+          "totalLiquidVolume": 33,
+          "shape": "circular",
+          "diameter": 10,
+          "x": 18.21,
+          "y": 17.59,
+          "z": 75
+        },
+        "A2": {
+          "depth": 25,
+          "totalLiquidVolume": 33,
+          "shape": "circular",
+          "diameter": 10,
+          "x": 38.1,
+          "y": 75.43,
+          "z": 75
+        },
+        "B2": {
+          "depth": 25,
+          "totalLiquidVolume": 33,
+          "shape": "circular",
+          "diameter": 10,
+          "x": 38.1,
+          "y": 56.15,
+          "z": 75
+        },
+        "C2": {
+          "depth": 25,
+          "totalLiquidVolume": 33,
+          "shape": "circular",
+          "diameter": 10,
+          "x": 38.1,
+          "y": 36.87,
+          "z": 75
+        },
+        "D2": {
+          "depth": 25,
+          "totalLiquidVolume": 33,
+          "shape": "circular",
+          "diameter": 10,
+          "x": 38.1,
+          "y": 17.59,
+          "z": 75
+        }
+      },
+      "groups": [
+        {
+          "metadata": {},
+          "wells": ["A1", "B1", "C1", "A2", "B2", "C2"]
+        }
+      ],
+      "parameters": {
+        "format": "irregular",
+        "quirks": [],
+        "isTiprack": false,
+        "isMagneticModuleCompatible": false,
+        "loadName": "foo_8_plate_33ul"
+      },
+      "namespace": "example",
+      "version": 1,
+      "schemaVersion": 2,
+      "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      }
+    }
+  },
+  "commands": [
+    {
+      "commandType": "loadPipette",
+      "id": "0abc123",
+      "params": {
+        "pipetteId": "pipetteId",
+        "mount": "left"
+      }
+    },
+    {
+      "commandType": "loadModule",
+      "id": "1abc123",
+      "params": {
+        "moduleId": "magneticModuleId",
+        "location": { "slotName": "3" }
+      }
+    },
+    {
+      "commandType": "loadModule",
+      "id": "2abc123",
+      "params": {
+        "moduleId": "temperatureModuleId",
+        "location": { "slotName": "1" }
+      }
+    },
+    {
+      "commandType": "loadLabware",
+      "id": "3abc123",
+      "params": {
+        "labwareId": "sourcePlateId",
+        "location": {
+          "moduleId": "temperatureModuleId"
+        }
+      }
+    },
+    {
+      "commandType": "loadLabware",
+      "id": "4abc123",
+      "params": {
+        "labwareId": "destPlateId",
+        "location": {
+          "moduleId": "magneticModuleId"
+        },
+        "displayName": "Sample Collection Plate"
+      }
+    },
+    {
+      "commandType": "loadLabware",
+      "id": "5abc123",
+      "params": {
+        "labwareId": "tipRackId",
+        "location": { "slotName": "8" }
+      }
+    },
+    {
+      "commandType": "loadLabware",
+      "id": "6abc123",
+      "params": {
+        "labwareId": "fixedTrash",
+        "location": {
+          "slotName": "12"
+        }
+      }
+    },
+    {
+      "commandType": "loadLiquid",
+      "id": "7abc123",
+      "params": {
+        "liquidId": "waterId",
+        "labwareId": "sourcePlateId",
+        "volumeByWell": {
+          "A1": 100,
+          "B1": 100
+        }
+      }
+    },
+    {
+      "commandType": "home",
+      "id": "00abc123",
+      "params": {}
+    },
+    {
+      "commandType": "pickUpTip",
+      "id": "8abc123",
+      "params": {
+        "pipetteId": "pipetteId",
+        "labwareId": "tipRackId",
+        "wellName": "B1"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "id": "9abc123",
+      "params": {
+        "pipetteId": "pipetteId",
+        "labwareId": "sourcePlateId",
+        "wellName": "A1",
+        "volume": 5,
+        "flowRate": 3,
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "x": 0, "y": 0, "z": 2 }
+        }
+      }
+    },
+    {
+      "commandType": "delay",
+      "id": "10abc123",
+      "params": {
+        "seconds": 42
+      }
+    },
+    {
+      "commandType": "dispense",
+      "id": "11abc123",
+      "params": {
+        "pipetteId": "pipetteId",
+        "labwareId": "destPlateId",
+        "wellName": "B1",
+        "volume": 4.5,
+        "flowRate": 2.5,
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "x": 0, "y": 0, "z": 1 }
+        }
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "id": "12abc123",
+      "params": {
+        "pipetteId": "pipetteId",
+        "labwareId": "destPlateId",
+        "wellName": "B1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "x": 0, "y": 0, "z": 11 }
+        }
+      }
+    },
+    {
+      "commandType": "blowout",
+      "id": "13abc123",
+      "params": {
+        "pipetteId": "pipetteId",
+        "labwareId": "destPlateId",
+        "wellName": "B1",
+        "flowRate": 2,
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "x": 0, "y": 0, "z": 12 }
+        }
+      }
+    },
+    {
+      "commandType": "moveToSlot",
+      "id": "14abc123",
+      "params": {
+        "pipetteId": "pipetteId",
+        "slotName": "5",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "x": 1, "y": 2, "z": 3 }
+        }
+      }
+    },
+    {
+      "commandType": "moveToWell",
+      "id": "15abc123",
+      "params": {
+        "pipetteId": "pipetteId",
+        "labwareId": "destPlateId",
+        "wellName": "B2"
+      }
+    },
+    {
+      "commandType": "moveToWell",
+      "id": "16abc123",
+      "params": {
+        "pipetteId": "pipetteId",
+        "labwareId": "destPlateId",
+        "wellName": "B2",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "x": 2, "y": 3, "z": 10 }
+        },
+        "minimumZHeight": 35,
+        "forceDirect": true
+      }
+    },
+    {
+      "commandType": "dropTip",
+      "id": "17abc123",
+      "params": {
+        "pipetteId": "pipetteId",
+        "labwareId": "fixedTrash",
+        "wellName": "A1"
+      }
+    },
+    {
+      "commandType": "waitForResume",
+      "id": "18abc123",
+      "params": {
+        "message": "pause command"
+      }
+    },
+
+    {
+      "commandType": "moveToCoordinates",
+      "id": "16abc123",
+      "params": {
+        "pipetteId": "pipetteId",
+        "coordinates": { "x": 0, "y": 0, "z": 0 },
+        "minimumZHeight": 35,
+        "forceDirect": true
+      }
+    },
+    {
+      "commandType": "moveRelative",
+      "id": "18abc123",
+      "params": {
+        "pipetteId": "pipetteId",
+        "axis": "x",
+        "distance": 1
+      }
+    },
+    {
+      "commandType": "moveRelative",
+      "id": "19abc123",
+      "params": {
+        "pipetteId": "pipetteId",
+        "axis": "y",
+        "distance": 0.1
+      }
+    },
+    {
+      "commandType": "savePosition",
+      "id": "21abc123",
+      "params": {
+        "pipetteId": "pipetteId"
+      }
+    },
+    {
+      "commandType": "moveRelative",
+      "id": "20abc123",
+      "params": {
+        "pipetteId": "pipetteId",
+        "axis": "z",
+        "distance": 10
+      }
+    },
+    {
+      "commandType": "savePosition",
+      "id": "21abc123",
+      "params": {
+        "pipetteId": "pipetteId",
+        "positionId": "positionId"
+      }
+    }
+  ],
+  "commandAnnotations": [
+    {
+      "commandIds": [
+        "1abc123",
+        "2abc123",
+        "3abc123",
+        "4abc123",
+        "5abc123",
+        "6abc123",
+        "7abc123"
+      ],
+      "annotationType": "initialSetup"
+    }
+  ]
+}

--- a/shared-data/protocol/schemas/7-draft.json
+++ b/shared-data/protocol/schemas/7-draft.json
@@ -1,0 +1,1227 @@
+{
+  "$id": "opentronsProtocolSchemaV6",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+
+  "definitions": {
+    "pipetteName": {
+      "description": "Name of a pipette. Does not contain info about specific model/version. Should match keys in pipetteNameSpecs.json file",
+      "type": "string",
+      "enum": [
+        "p10_single",
+        "p10_multi",
+        "p20_single_gen2",
+        "p20_multi_gen2",
+        "p50_single",
+        "p50_multi",
+        "p300_single",
+        "p300_multi",
+        "p300_single_gen2",
+        "p300_multi_gen2",
+        "p1000_single",
+        "p1000_single_gen2"
+      ]
+    },
+
+    "moduleOnlyParams": {
+      "required": ["moduleId"],
+      "additionalProperties": false,
+      "properties": {
+        "moduleId": {
+          "type": "string",
+          "description": "Unique identifier of module to target. Must be a key from the top level 'modules' object"
+        }
+      }
+    },
+
+    "offset": {
+      "description": "x, y, and z component of offset vector in mm",
+      "properties": {
+        "x": { "type": "number" },
+        "y": { "type": "number" },
+        "z": { "type": "number" }
+      }
+    },
+
+    "pipetteAccessParams": {
+      "required": ["pipetteId", "labwareId", "wellName"],
+      "properties": {
+        "pipetteId": {
+          "type": "string"
+        },
+        "labwareId": {
+          "type": "string"
+        },
+        "wellName": {
+          "type": "string"
+        }
+      }
+    },
+
+    "volumeParams": {
+      "required": ["volume"],
+      "volume": {
+        "type": "number"
+      }
+    },
+
+    "flowRate": {
+      "required": ["flowRate"],
+      "properties": {
+        "flowRate": {
+          "description": "flow rate in ul/sec",
+          "type": "number",
+          "exclusiveMinimum": 0
+        }
+      }
+    },
+
+    "wellLocation": {
+      "properties": {
+        "origin": {
+          "type": "string",
+          "description": "reference location with respect to a well from which to apply an offset if given (e.g. 'bottom' || 'top')"
+        },
+        "offset": {
+          "$ref": "#/definitions/offset",
+          "description": "X, Y, Z offset from the specified origin with respect to well"
+        }
+      }
+    }
+  },
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$otSharedSchema",
+    "schemaVersion",
+    "metadata",
+    "robot",
+    "pipettes",
+    "labware",
+    "labwareDefinitions",
+    "commands"
+  ],
+  "properties": {
+    "$otSharedSchema": {
+      "description": "The path to a valid Opentrons shared schema relative to the shared-data directory, without its extension.",
+      "enum": ["#/protocol/schemas/6"]
+    },
+
+    "schemaVersion": {
+      "description": "Schema version of a protocol is a single integer",
+      "enum": [6]
+    },
+
+    "metadata": {
+      "description": "Optional metadata about the protocol",
+      "type": "object",
+
+      "properties": {
+        "protocolName": {
+          "description": "A short, human-readable name for the protocol",
+          "type": "string"
+        },
+        "author": {
+          "description": "The author or organization who created the protocol",
+          "type": "string"
+        },
+        "description": {
+          "description": "A text description of the protocol.",
+          "type": ["string", "null"]
+        },
+
+        "created": {
+          "description": "UNIX timestamp when this file was created",
+          "type": "number"
+        },
+        "lastModified": {
+          "description": "UNIX timestamp when this file was last modified",
+          "type": ["number", "null"]
+        },
+
+        "category": {
+          "description": "Category of protocol (eg, \"Basic Pipetting\")",
+          "type": ["string", "null"]
+        },
+        "subcategory": {
+          "description": "Subcategory of protocol (eg, \"Cell Plating\")",
+          "type": ["string", "null"]
+        },
+        "tags": {
+          "description": "Tags to be used in searching for this protocol",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+
+    "designerApplication": {
+      "description": "Optional data & metadata not required to execute the protocol, used by the application that created this protocol",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the application that created the protocol. Should be namespaced under the organization or individual who owns the organization, eg \"opentrons/protocol-designer\"",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version of the application that created the protocol",
+          "type": "string"
+        },
+        "data": {
+          "description": "Any data used by the application that created this protocol",
+          "type": "object"
+        }
+      }
+    },
+
+    "robot": {
+      "required": ["model", "deckId"],
+      "properties": {
+        "model": {
+          "description": "Model of the robot this protocol is written for",
+          "type": "string",
+          "enum": ["OT-2 Standard", "OT-3 Standard"]
+        },
+        "deckId": {
+          "description": "Identifier of physical deck this protocol is written for. This should match a top-level key in shared-data/deck/definitions/3.json",
+          "type": "string"
+        }
+      }
+    },
+
+    "pipettes": {
+      "description": "The pipettes used in this protocol, keyed by a unique identifier (pipetteId)",
+      "additionalProperties": false,
+      "patternProperties": {
+        ".+": {
+          "description": "Fields describing an individual pipette",
+          "type": "object",
+          "required": ["name"],
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/pipetteName"
+            }
+          }
+        }
+      }
+    },
+
+    "labwareDefinitions": {
+      "description": "All labware definitions used by labware in this protocol, keyed by a unique identifier (definitionId)",
+      "patternProperties": {
+        ".+": {
+          "$ref": "opentronsLabwareSchemaV2"
+        }
+      }
+    },
+
+    "labware": {
+      "description": "All instances of labware used in this protocol, and references to their definitions' labwareId, keyed by a unique identifier (labwareId)",
+      "patternProperties": {
+        ".+": {
+          "description": "Fields describing a single labware",
+          "type": "object",
+          "required": ["definitionId"],
+          "additionalProperties": false,
+          "properties": {
+            "definitionId": {
+              "description": "reference to this labware's ID in \"labwareDefinitions\"",
+              "type": "string"
+            },
+            "displayName": {
+              "description": "An optional human-readable nickname for this labware instance within this protocol. Eg \"Buffer Trough\"",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+
+    "liquids": {
+      "description": "All instances of liquid used in this protocol, keyed by a unique identifier (liquidId)",
+      "patternProperties": {
+        ".+": {
+          "description": "Fields describing a single liquid",
+          "type": "object",
+          "required": ["displayName", "description"],
+          "properties": {
+            "displayName": {
+              "description": "An human-readable name for this liquid.",
+              "type": "string"
+            },
+            "description": {
+              "description": "A description of this liquid.",
+              "type": "string"
+            },
+            "displayColor": {
+              "description": "Hex color code, with hash included, to represent the specified liquid. Standard three-value, four-value, six-value, and eight-value syntax are all acceptable.",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+
+    "modules": {
+      "description": "All modules used in this protocol keyed by a unique identifier (moduleId)",
+      "patternProperties": {
+        ".+": {
+          "description": "Fields describing a single module on the deck",
+          "type": "object",
+          "required": ["model"],
+          "additionalProperties": false,
+          "properties": {
+            "model": {
+              "description": "model of module. Eg 'magneticModuleV1' or 'magneticModuleV2'. This should match a top-level key in shared-data/module/definitions/2.json",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+
+    "commands": {
+      "description": "An array of command objects representing steps to be executed on the robot",
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "description": "Aspirate Liquid / Dispense Liquid / Aspirate Air Gap / Dispense Air Aap",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": {
+                "enum": ["aspirate", "dispense"]
+              },
+              "params": {
+                "allOf": [
+                  { "$ref": "#/definitions/flowRate" },
+                  { "$ref": "#/definitions/pipetteAccessParams" },
+                  { "$ref": "#/definitions/volumeParams" },
+                  {
+                    "wellLocation": { "$ref": "#/definitions/wellLocation" }
+                  }
+                ]
+              }
+            }
+          },
+
+          {
+            "description": "Blowout",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": {
+                "enum": ["blowout"]
+              },
+              "params": {
+                "allOf": [
+                  { "$ref": "#/definitions/flowRate" },
+                  { "$ref": "#/definitions/pipetteAccessParams" },
+                  {
+                    "wellLocation": { "$ref": "#/definitions/wellLocation" }
+                  }
+                ]
+              }
+            }
+          },
+
+          {
+            "description": "Touch Tip",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": {
+                "enum": ["touchTip"]
+              },
+              "params": {
+                "allOf": [
+                  { "$ref": "#/definitions/pipetteAccessParams" },
+                  {
+                    "wellLocation": { "$ref": "#/definitions/wellLocation" }
+                  }
+                ]
+              }
+            }
+          },
+
+          {
+            "description": "Pick Up Tip / Drop Tip",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": {
+                "enum": ["pickUpTip", "dropTip"]
+              },
+              "params": {
+                "allOf": [{ "$ref": "#/definitions/pipetteAccessParams" }]
+              }
+            }
+          },
+
+          {
+            "description": "Move To Slot. NOTE: this is an EXPERIMENTAL command, its behavior is subject to change in future releases.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": { "enum": ["moveToSlot"] },
+              "params": {
+                "type": "object",
+                "required": ["pipetteId", "slotName"],
+                "properties": {
+                  "pipetteId": { "type": "string" },
+                  "slotName": {
+                    "type": "string",
+                    "description": "Unique string identifier that corresponds to a slot in the referenced deck definition's locations"
+                  },
+                  "offset": {
+                    "$ref": "#/definitions/offset",
+                    "description": "Optional offset from slot bottom left corner, in mm"
+                  },
+                  "minimumZHeight": {
+                    "description": "Optional minimal Z margin in mm. If this is larger than the API's default safe Z margin, it will make the arc higher. If it's smaller, it will have no effect. Specifying this for movements that would not arc (moving within the same well in the same labware) will cause an arc movement instead.",
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  "forceDirect": {
+                    "description": "If true, moving from one labware/well to another will not arc to the default safe z, but instead will move directly to the specified location. This will also force the `minimumZHeight` param to be ignored. A 'direct' movement is in X/Y/Z simultaneously.",
+                    "type": "boolean",
+                    "default": false
+                  }
+                }
+              }
+            }
+          },
+
+          {
+            "description": "Move To Coordinates: Move the pipette's critical point to the specified coordinates. The pipette's critical point is a reference point on the pipette. The critical point can be one of the following: (1) Single-Channel pipette with no tip: end of nozzle. (2) 8-Channel pipette with no tip: end of backmost nozzle. (3) Single-Channel pipette with a tip: end of tip. (4) 8-Channel pipette with tip: end of tip on backmost nozzle.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": { "enum": ["moveToCoordinates"] },
+              "params": {
+                "type": "object",
+                "required": ["pipetteId", "coordinates"],
+                "properties": {
+                  "pipetteId": { "type": "string" },
+                  "coordinates": {
+                    "$ref": "#/definitions/offset",
+                    "description": "X, Y and Z coordinates in mm from deck's origin location (left-front-bottom corner of work space)"
+                  },
+                  "minimumZHeight": {
+                    "description": "Optional minimal Z margin in mm. If this is larger than the API's default safe Z margin, it will make the arc higher. If it's smaller, it will have no effect. Specifying this for movements that would not arc (moving within the same well in the same labware) will cause an arc movement instead.",
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  "forceDirect": {
+                    "description": "If true, moving from one labware/well to another will not arc to the default safe z, but instead will move directly to the specified location. This will also force the `minimumZHeight` param to be ignored. A 'direct' movement is in X/Y/Z simultaneously.",
+                    "type": "boolean",
+                    "default": false
+                  }
+                }
+              }
+            }
+          },
+
+          {
+            "description": "Move Relative",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": { "enum": ["moveRelative"] },
+              "params": {
+                "type": "object",
+                "required": ["pipetteId", "axis", "distance"],
+                "properties": {
+                  "pipetteId": { "type": "string" },
+                  "axis": {
+                    "description": "Axis to move the gantry",
+                    "enum": ["x", "y", "z"]
+                  },
+                  "distance": {
+                    "description": "Distance in mm to move the gantry (negative numbers are allowed)",
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          },
+
+          {
+            "description": "Save Position",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": { "enum": ["savePosition"] },
+              "params": {
+                "type": "object",
+                "required": ["pipetteId"],
+                "properties": {
+                  "pipetteId": { "type": "string" },
+                  "positionId": {
+                    "description": "Optional position ID, auto-assigned if left blank",
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+
+          {
+            "description": "Home",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": { "enum": ["home"] },
+              "params": {
+                "type": "object",
+                "properties": {
+                  "axes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "x",
+                        "y",
+                        "leftZ",
+                        "rightZ",
+                        "leftPlunger",
+                        "rightPlunger"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+
+          {
+            "title": "Delay (deprecated)",
+            "description": "Delay protocol execution for a time duration or until the user resumes the protocol. Deprecated; use `waitForResume` or `waitForDuration` commands instead.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": {
+                "enum": ["delay"]
+              },
+              "params": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "required": ["seconds"],
+                    "properties": {
+                      "seconds": {
+                        "description": "A number of seconds to wait, with fractional values allowed.",
+                        "type": "number",
+                        "exclusiveMinimum": 0
+                      },
+                      "message": {
+                        "description": "An optional message describing the delay."
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "required": ["waitForResume"],
+                    "properties": {
+                      "waitForResume": {
+                        "description": "A number of seconds to wait, with fractional values allowed.",
+                        "enum": [true]
+                      },
+                      "message": {
+                        "description": "An optional message describing the delay."
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+
+          {
+            "title": "Wait For Resume",
+            "description": "Pause protocol execution until the user manually resumes the protocol.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": {
+                "enum": ["waitForResume", "pause"]
+              },
+              "params": {
+                "type": "object",
+                "required": [],
+                "properties": {
+                  "message": {
+                    "description": "An optional message describing the pause."
+                  }
+                }
+              }
+            }
+          },
+
+          {
+            "title": "Wait For Duration",
+            "description": "Pause protocol execution for a given duration.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": {
+                "enum": ["waitForDuration"]
+              },
+              "params": {
+                "type": "object",
+                "required": [],
+                "properties": {
+                  "message": {
+                    "description": "An optional message describing the pause."
+                  }
+                }
+              }
+            }
+          },
+
+          {
+            "description": "Magnetic Module Engage: Engage magnet to specified height.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": {
+                "enum": ["magneticModule/engage"]
+              },
+              "params": {
+                "required": ["moduleId", "height"],
+                "properties": {
+                  "height": {
+                    "description": "How high, in millimeters, to raise the magnets.\n\nZero means the tops of the magnets are level with the ledge that the labware rests on. This will be slightly above the magnets' minimum height, the hardware home position. Negative values are allowed, to put the magnets below the ledge.\n\nUnits are always true millimeters. This is unlike certain labware definitions, engage commands in the Python Protocol API, and engage commands in older versions of the JSON protocol schema. Take care to convert properly.",
+                    "type": "number"
+                  },
+                  "moduleId": {
+                    "description": "Unique identifier of Magnetic Module to target. Must be a key from the top level 'modules' object.",
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+
+          {
+            "description": "Magnetic Module Disengage: Retract magnet to disengaged (home) position",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": {
+                "enum": ["magneticModule/disengage"]
+              },
+              "params": {
+                "$ref": "#/definitions/moduleOnlyParams"
+              }
+            }
+          },
+
+          {
+            "description": "Temperature Module Set Target Temperature: Module will begin moving to the target temperature. This command is non-blocking, it does not delay protocol execution while approaching the target temperature.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": {
+                "enum": ["temperatureModule/setTargetTemperature"]
+              },
+              "params": {
+                "required": ["moduleId", "celsius"],
+                "properties": {
+                  "moduleId": {
+                    "type": "string",
+                    "description": "Unique identifier of Temperature Module to target. Must be a key from the top level 'modules' object"
+                  },
+                  "celsius": { "type": "number" }
+                }
+              }
+            }
+          },
+
+          {
+            "description": "Temperature Module Wait For Temperature: Delay protocol execution until the specified temperature is reached.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": {
+                "enum": ["temperatureModule/waitForTemperature"]
+              },
+              "params": {
+                "required": ["moduleId"],
+                "properties": {
+                  "moduleId": {
+                    "type": "string",
+                    "description": "Unique identifier of Temperature Module to target. Must be a key from the top level 'modules' object"
+                  }
+                }
+              }
+            }
+          },
+
+          {
+            "description": "Temperature Module Deactivate: Module will stop actively controlling its temperature and drift to ambient temperature.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": { "enum": ["temperatureModule/deactivate"] },
+              "params": {
+                "$ref": "#/definitions/moduleOnlyParams"
+              }
+            }
+          },
+
+          {
+            "description": "Thermocycler Set Target Block Temperature: Well block will begin moving to the target temperature. This command is non-blocking, it does not delay protocol execution while approaching the target temperature.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": {
+                "enum": ["thermocycler/setTargetBlockTemperature"]
+              },
+              "params": {
+                "required": ["moduleId", "celsius"],
+                "properties": {
+                  "moduleId": {
+                    "type": "string",
+                    "description": "Unique identifier of Thermocycler Module to target. Must be a key from the top level 'modules' object"
+                  },
+                  "celsius": {
+                    "type": "number",
+                    "description": "Target temperature in °C."
+                  },
+                  "blockMaxVolumeUl": {
+                    "type": "number",
+                    "description": "Amount of liquid in uL of the most-full well in labware loaded onto the thermocycler."
+                  }
+                }
+              }
+            }
+          },
+
+          {
+            "description": "Thermocycler Set Target Lid Temperature: Lid will begin moving to the target temperature. This command is non-blocking, it does not delay protocol execution while approaching the target temperature.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": {
+                "enum": ["thermocycler/setTargetLidTemperature"]
+              },
+              "params": {
+                "required": ["moduleId", "celsius"],
+                "properties": {
+                  "moduleId": {
+                    "type": "string",
+                    "description": "Unique identifier of Thermocycler Module to target. Must be a key from the top level 'modules' object"
+                  },
+                  "celsius": { "type": "number" }
+                }
+              }
+            }
+          },
+
+          {
+            "description": "Thermocycler Wait For Block Temperature: Delay protocol execution until the specified well block target temperature is reached.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": {
+                "enum": ["thermocycler/waitForBlockTemperature"]
+              },
+              "params": {
+                "required": ["moduleId"],
+                "properties": {
+                  "moduleId": {
+                    "type": "string",
+                    "description": "Unique identifier of Thermocycler Module to target. Must be a key from the top level 'modules' object"
+                  }
+                }
+              }
+            }
+          },
+
+          {
+            "description": "Thermocycler Wait For Lid Temperature: Delay protocol execution until the specified lid target temperature is reached.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": { "enum": ["thermocycler/waitForLidTemperature"] },
+              "params": {
+                "required": ["moduleId"],
+                "properties": {
+                  "moduleId": {
+                    "type": "string",
+                    "description": "Unique identifier of Thermocycler Module to target. Must be a key from the top level 'modules' object"
+                  }
+                }
+              }
+            }
+          },
+
+          {
+            "description": "Thermocycler Deactivate Block: Module will stop actively controlling its well block temperature.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": { "enum": ["thermocycler/deactivateBlock"] },
+              "params": {
+                "$ref": "#/definitions/moduleOnlyParams"
+              }
+            }
+          },
+
+          {
+            "description": "Thermocycler Deactivate Lid: Module will stop actively controlling its lid temperature.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": { "enum": ["thermocycler/deactivateLid"] },
+              "params": {
+                "$ref": "#/definitions/moduleOnlyParams"
+              }
+            }
+          },
+
+          {
+            "description": "Thermocycler Open Lid: Open lid of the module. This command will delay protocol execution until the lid is fully open.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": { "enum": ["thermocycler/openLid"] },
+              "params": {
+                "$ref": "#/definitions/moduleOnlyParams"
+              }
+            }
+          },
+
+          {
+            "description": "Thermocycler Close Lid: Close the lid of the module. This command will delay protocol execution until the lid is fully closed.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": { "enum": ["thermocycler/closeLid"] },
+              "params": {
+                "$ref": "#/definitions/moduleOnlyParams"
+              }
+            }
+          },
+
+          {
+            "description": "Thermocycler Run Profile: Run the specified profile steps on the Thermocycler. This command is blocking, it delays protocol execution outside of thermocycler steps.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": { "enum": ["thermocycler/runProfile"] },
+              "params": {
+                "type": "object",
+                "required": ["moduleId", "profile"],
+                "properties": {
+                  "moduleId": {
+                    "type": "string",
+                    "description": "Unique identifier of Thermocycler Module to target. Must be a key from the top level 'modules' object"
+                  },
+                  "profile": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": ["celsius", "holdSeconds"],
+                      "properties": {
+                        "celsius": {
+                          "description": "Target temperature (in celsius) of profile step",
+                          "type": "number"
+                        },
+                        "holdSeconds": {
+                          "description": "Time (in seconds) to hold once temperature is reached",
+                          "type": "number"
+                        }
+                      }
+                    }
+                  },
+                  "blockMaxVolumeUl": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          },
+
+          {
+            "description": "Heater Shaker Module Start Set Target Temperature: Module will begin moving to the target temperature. This command is non-blocking, it does not delay protocol execution while approaching the target temperature.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": {
+                "enum": ["heaterShaker/setTargetTemperature"]
+              },
+              "params": {
+                "required": ["moduleId", "celsius"],
+                "properties": {
+                  "moduleId": {
+                    "type": "string",
+                    "description": "Unique identifier of Heater Shaker Module to target. Must be a key from the top level 'modules' object"
+                  },
+                  "celsius": {
+                    "type": "number",
+                    "description": "target temperature to heat to in °C"
+                  }
+                }
+              }
+            }
+          },
+
+          {
+            "description": "Heater Shaker Module Set Target Shake Speed: Start the module's shake procedure. The protocol will proceed once the target shake speed is reached.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": {
+                "enum": ["heaterShaker/setAndWaitForShakeSpeed"]
+              },
+              "params": {
+                "required": ["moduleId", "rpm"],
+                "properties": {
+                  "moduleId": {
+                    "type": "string",
+                    "description": "Unique identifier of Heater Shaker Module to target. Must be a key from the top level 'modules' object"
+                  },
+                  "rpm": {
+                    "type": "number",
+                    "description": "target orbital rotations per minute"
+                  }
+                }
+              }
+            }
+          },
+
+          {
+            "description": "Heater Shaker Module Wait For Temperature: Delay protocol execution until the previously supplied startSetTargetTemperature command's temperature parameter has been reached. Errors if no target temperature was set previously.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": {
+                "enum": ["heaterShaker/waitForTemperature"]
+              },
+              "params": {
+                "$ref": "#/definitions/moduleOnlyParams"
+              }
+            }
+          },
+
+          {
+            "description": "Heater Shaker Module Deactivate Heater: Module will stop actively heating and drift to ambient temperature.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": {
+                "enum": ["heaterShaker/deactivateHeater"]
+              },
+              "params": {
+                "$ref": "#/definitions/moduleOnlyParams"
+              }
+            }
+          },
+
+          {
+            "description": "Heater Shaker Module Deactivate Shaker: Module will stop actively shaking and ramp down to a still state",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": {
+                "enum": ["heaterShaker/deactivateShaker"]
+              },
+              "params": {
+                "$ref": "#/definitions/moduleOnlyParams"
+              }
+            }
+          },
+
+          {
+            "description": "Heater Shaker Module Open Latch: Open the module's labware latch.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": {
+                "enum": ["heaterShaker/openLabwareLatch"]
+              },
+              "params": {
+                "$ref": "#/definitions/moduleOnlyParams"
+              }
+            }
+          },
+
+          {
+            "description": "Heater Shaker Module Close Latch: Close the module's labware latch.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": {
+                "enum": ["heaterShaker/closeLabwareLatch"]
+              },
+              "params": {
+                "$ref": "#/definitions/moduleOnlyParams"
+              }
+            }
+          },
+
+          {
+            "description": "Move To Well: Move the pipette's critical point to the specified well in a labware, with an optional offset. The pipette's critical point is a reference point on the pipette. The critical point can be one of the following: (1) Single-Channel pipette with no tip: end of nozzle. (2) 8-Channel pipette with no tip: end of backmost nozzle. (3) Single-Channel pipette with a tip: end of tip. (4) 8-Channel pipette with tip: end of tip on backmost nozzle.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": { "enum": ["moveToWell"] },
+              "params": {
+                "type": "object",
+                "required": ["pipetteId", "labwareId", "wellName"],
+                "properties": {
+                  "pipetteId": { "type": "string" },
+                  "labwareId": { "type": "string" },
+                  "wellName": { "type": "string" },
+                  "wellLocation": { "$ref": "#/definitions/wellLocation" },
+                  "minimumZHeight": {
+                    "description": "Optional minimal Z margin in mm. If this is larger than the API's default safe Z margin, it will make the arc higher. If it's smaller, it will have no effect. Specifying this for movements that would not arc (moving within the same well in the same labware) will cause an arc movement instead.",
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  "forceDirect": {
+                    "description": "If true, moving from one labware/well to another will not arc to the default safe z, but instead will move directly to the specified location. This will also force the `minimumZHeight` param to be ignored. A 'direct' movement is in X/Y/Z simultaneously.",
+                    "type": "boolean",
+                    "default": false
+                  }
+                }
+              }
+            }
+          },
+
+          {
+            "description": "Load Pipette: This command is only meant to make the Opentrons system aware of a pipette's location. It does not instruct any specific hardware to carry out the physical action of moving the pipette to the location.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": {
+                "enum": ["loadPipette"]
+              },
+              "params": {
+                "required": ["pipetteId", "mount"],
+                "properties": {
+                  "pipetteId": {
+                    "type": "string",
+                    "description": "Unique identifier of pipette to load"
+                  },
+                  "mount": {
+                    "type": "string",
+                    "description": "Unique identifier of physical destination location to load pipette into (e.g. 'left')"
+                  }
+                }
+              }
+            }
+          },
+
+          {
+            "description": "Load Labware: This command is only meant to make the Opentrons system aware of a labware instance's location. It does not instruct any specific hardware to carry out the physical action of moving the labware instance to the location.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": {
+                "enum": ["loadLabware"]
+              },
+              "params": {
+                "required": ["labwareId", "location"],
+                "properties": {
+                  "labwareId": {
+                    "type": "string",
+                    "description": "Unique identifier of labware to load"
+                  },
+                  "location": {
+                    "description": "Physical destination location to load labware into (e.g. '1' || 'someModuleId')",
+                    "oneOf": [
+                      {
+                        "required": ["slotName"],
+                        "properties": {
+                          "slotName": {
+                            "description": "Unique string identifier that corresponds to a slot in the referenced deck definition's locations",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      {
+                        "required": ["moduleId"],
+                        "properties": {
+                          "moduleId": {
+                            "description": "Unique identifier of destination module. Must be a key from the top level 'modules' object.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      {
+                        "required": ["labwareId"],
+                        "properties": {
+                          "labwareId": {
+                            "description": "Unique identifier of destination labware. Must be a key from the top level 'labware' object.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    ],
+                    "displayName": {
+                      "type": "string",
+                      "description": "Optional user-defined nickname for this labware instance within the protocol"
+                    }
+                  }
+                }
+              }
+            }
+          },
+
+          {
+            "description": "Load Module: This command is only meant to make the Opentrons system aware of a module instance's location. It does not instruct any specific hardware to carry out the physical action of moving the module instance to the location.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": {
+                "enum": ["loadModule"]
+              },
+              "params": {
+                "required": ["moduleId", "location"],
+                "properties": {
+                  "moduleId": {
+                    "type": "string",
+                    "description": "Unique identifier of module to load"
+                  },
+                  "location": {
+                    "description": "Physical destination location to load module into (e.g. '1')",
+                    "oneOf": [
+                      {
+                        "required": ["slotName"],
+                        "properties": {
+                          "slotName": {
+                            "description": "Unique string identifier that corresponds to a slot in the referenced deck definition's locations",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+
+          {
+            "description": "Load Liquid: This command is only meant to make the Opentrons system aware of a liquid's location. It does not instruct any specific hardware to carry out the physical action of moving the liquid to the location.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": {
+                "enum": ["loadLiquid"]
+              },
+              "params": {
+                "required": ["liquidId", "labwareId", "volumeByWell"],
+                "properties": {
+                  "liquidId": {
+                    "type": "string",
+                    "description": "Unique identifier of instance of liquid to load. Must be a key from the top level 'liquids' object"
+                  },
+                  "labwareId": {
+                    "type": "string",
+                    "description": "Unique identifier of labware to load liquid into. Must be a key from the top level 'labware' object"
+                  },
+                  "volumeByWell": {
+                    "type": "object",
+                    "patternProperties": {
+                      ".+": {
+                        "description": "Volume in µL keyed by wellName from the specified labware",
+                        "type": "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "description": "Custom: This command is meant to allow non-canonical commands to be included in the commands list.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": {
+                "enum": ["custom"]
+              },
+              "params": {
+                "type": "object",
+                "description": "all of the parameters required to identify and execute this command"
+              }
+            }
+          }
+        ]
+      }
+    },
+
+    "commandAnnotations": {
+      "type": "array",
+      "items": {
+        "description": "An optional object of annotations associated with commands.",
+        "type": "object",
+        "required": ["commandIds", "annotationType"],
+        "properties": {
+          "commandIds": {
+            "description": "An array of command ids that correspond to the targeted grouping of this annotation",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "annotationType": {
+            "description": "The type of annotation (e.g. 'transfer', 'initialSetup')",
+            "type": "string"
+          },
+          "params": {
+            "description": "The parameters used to create this grouping of atomic commands",
+            "type": "object"
+          }
+        }
+      }
+    }
+  }
+}

--- a/shared-data/protocol/schemas/7-draft.json
+++ b/shared-data/protocol/schemas/7-draft.json
@@ -1,5 +1,5 @@
 {
-  "$id": "opentronsProtocolSchemaV6",
+  "$id": "opentronsProtocolSchemaV7",
   "$schema": "http://json-schema.org/draft-07/schema#",
 
   "definitions": {
@@ -104,12 +104,12 @@
   "properties": {
     "$otSharedSchema": {
       "description": "The path to a valid Opentrons shared schema relative to the shared-data directory, without its extension.",
-      "enum": ["#/protocol/schemas/6"]
+      "enum": ["#/protocol/schemas/7-draft"]
     },
 
     "schemaVersion": {
       "description": "Schema version of a protocol is a single integer",
-      "enum": [6]
+      "enum": [7]
     },
 
     "metadata": {


### PR DESCRIPTION
# Overview

This PR creates a draft of protocol schema v7.

Closes Jira RLAB-68. See that ticket for reasoning.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

* Create `protocol/schemas/7-draft.json`.
    * It is identical to `protocol/schemas/6.json`, except with references to `6` replaced with `7`.
* Create a `simpleV7.json` fixture.
    * It is identical to `simpleV6.json`, except with references to the v6 schema replaced with the v7 schema draft.
* Create basic tests to make sure the schema functions as intended.
    * These are identical to the tests for v6.
* For debuggability, swap the order of some `assert`s in our schema tests. Now, when they fail, they'll print out a reason why, instead of just "expected `true` but got `false`".

# Review requests

# Risk assessment

No risk to production code.
