### PR TITLE
feat(app): revamp LevelPipette component wizard style

### DIFF
--- a/app/src/assets/localization/en/change_pipette.json
+++ b/app/src/assets/localization/en/change_pipette.json
@@ -14,5 +14,7 @@
   "attach_the_pipette": "<h1>Attach the pipette</h1><block>Push in the white connector tab until you feel it plug into the pipette.</block>",
   "tighten_screws_single": "Starting with screw #1, tighten the screws with a clockwise motion.",
   "tighten_screws_multi": "<block>Starting with screw #1, <strong>loosely</strong> tighten the screws with a clockwise motion. You will tighten them fully in a later step.</block>",
-  "attach_pipette_type": "Attach a {{pipetteName}} Pipette"
+  "attach_pipette_type": "Attach a {{pipetteName}} Pipette",
+  "level_the_pipette": "<h1>Level the pipette</h1><block>Using your hand, <strong>gently and slowly</strong> push the pipette up.</block><block>Place the calibration block in slot1/3 with the tall/short surface on the left/right side.</block><block>Pull the pipette down so <strong>all 8 nozzles touch</strong> the surface of the block.</block><block>While <strong>holding the pipette down,</strong> tighten the three screws.</block><block>Gently and slowly push the pipette back up.</block>",
+  "confirm_level": "Confirm level"
 }

--- a/app/src/organisms/ChangePipette/DeprecatedLevelPipette.tsx
+++ b/app/src/organisms/ChangePipette/DeprecatedLevelPipette.tsx
@@ -87,7 +87,9 @@ function LevelingVideo(props: {
     </div>
   )
 }
-
+/**
+ * @deprecated use LevelPipette instead
+ */
 export function DeprecatedLevelPipette(props: Props): JSX.Element {
   const {
     title,

--- a/app/src/organisms/ChangePipette/DeprecatedLevelPipette.tsx
+++ b/app/src/organisms/ChangePipette/DeprecatedLevelPipette.tsx
@@ -1,0 +1,130 @@
+import * as React from 'react'
+import cx from 'classnames'
+
+import {
+  Icon,
+  ModalPage,
+  PrimaryBtn,
+  SecondaryBtn,
+  SPACING_2,
+} from '@opentrons/components'
+import styles from './styles.css'
+
+import type {
+  PipetteNameSpecs,
+  PipetteModelSpecs,
+  PipetteDisplayCategory,
+} from '@opentrons/shared-data'
+
+import type { Mount } from '../../redux/pipettes/types'
+import type { PipetteOffsetCalibration } from '../../redux/calibration/types'
+
+// TODO: i18n
+const EXIT_BUTTON_MESSAGE = 'confirm pipette is leveled'
+const EXIT_WITHOUT_CAL = 'exit without calibrating'
+const CONTINUE_TO_PIP_OFFSET = 'continue to pipette offset calibration'
+const LEVEL_MESSAGE = (displayName: string): string =>
+  `Next, level the ${displayName}`
+const CONNECTED_MESSAGE = (displayName: string): string =>
+  `${displayName} connected`
+
+interface Props {
+  robotName: string
+  mount: Mount
+  title: string
+  subtitle: string
+  wantedPipette: PipetteNameSpecs | null
+  actualPipette: PipetteModelSpecs | null
+  actualPipetteOffset: PipetteOffsetCalibration | null
+  displayName: string
+  displayCategory: PipetteDisplayCategory | null
+  pipetteModelName: string
+  back: () => unknown
+  exit: () => unknown
+  startPipetteOffsetCalibration: () => void
+}
+
+function Status(props: { displayName: string }): JSX.Element {
+  const iconName = 'check-circle'
+  const iconClass = cx(styles.confirm_icon, {
+    [styles.success]: true,
+    [styles.failure]: false,
+  })
+
+  return (
+    <div className={styles.leveling_title}>
+      <Icon name={iconName} className={iconClass} />
+      {CONNECTED_MESSAGE(props.displayName)}
+    </div>
+  )
+}
+
+function LevelingInstruction(props: { displayName: string }): JSX.Element {
+  return (
+    <div className={styles.leveling_instruction}>
+      {LEVEL_MESSAGE(props.displayName)}
+    </div>
+  )
+}
+
+function LevelingVideo(props: {
+  pipetteName: string
+  mount: Mount
+}): JSX.Element {
+  const { pipetteName, mount } = props
+  return (
+    <div className={styles.leveling_video_wrapper}>
+      <video
+        className={styles.leveling_video}
+        autoPlay={true}
+        loop={true}
+        controls={true}
+      >
+        <source
+          src={require(`../../assets/videos/pip-leveling/${pipetteName}-${mount}.webm`)}
+        />
+      </video>
+    </div>
+  )
+}
+
+export function DeprecatedLevelPipette(props: Props): JSX.Element {
+  const {
+    title,
+    subtitle,
+    pipetteModelName,
+    displayName,
+    actualPipetteOffset,
+    mount,
+    back,
+    exit,
+    startPipetteOffsetCalibration,
+  } = props
+
+  return (
+    <ModalPage
+      titleBar={{
+        title: title,
+        subtitle: subtitle,
+        back: { onClick: back, disabled: false },
+      }}
+      contentsClassName={styles.leveling_modal}
+    >
+      <Status displayName={displayName} />
+      <LevelingInstruction displayName={displayName} />
+      <LevelingVideo pipetteName={pipetteModelName} mount={mount} />
+      {!actualPipetteOffset && (
+        <PrimaryBtn
+          marginBottom={SPACING_2}
+          width="100%"
+          onClick={startPipetteOffsetCalibration}
+        >
+          {CONTINUE_TO_PIP_OFFSET}
+        </PrimaryBtn>
+      )}
+      <SecondaryBtn marginBottom={SPACING_2} width="100%" onClick={exit}>
+        {actualPipetteOffset ? EXIT_BUTTON_MESSAGE : EXIT_WITHOUT_CAL}
+      </SecondaryBtn>
+    </ModalPage>
+  )
+}

--- a/app/src/organisms/ChangePipette/LevelPipette.tsx
+++ b/app/src/organisms/ChangePipette/LevelPipette.tsx
@@ -25,9 +25,9 @@ interface LevelPipetteProps {
   mount: Mount
   wantedPipette: PipetteNameSpecs | null
   pipetteModelName: string
-  back: () => unknown
-  exit: () => unknown
-  confirm: () => unknown
+  back: () => void
+  exit: () => void
+  confirm: () => void
   currentStep: number
   totalSteps: number
 }
@@ -96,13 +96,7 @@ export function LevelPipette(props: LevelPipetteProps): JSX.Element {
               i18nKey={'level_the_pipette'}
               components={{
                 bold: <strong />,
-                h1: (
-                  <StyledText
-                    as="h1"
-                    marginBottom={SPACING.spacing4}
-                    color={COLORS.darkBlackEnabled}
-                  />
-                ),
+                h1: <StyledText as="h1" marginBottom={SPACING.spacing4} />,
                 block: (
                   <StyledText
                     css={css`

--- a/app/src/organisms/ChangePipette/LevelPipette.tsx
+++ b/app/src/organisms/ChangePipette/LevelPipette.tsx
@@ -69,7 +69,7 @@ export function LevelPipette(props: LevelPipetteProps): JSX.Element {
   } = props
 
   const { t } = useTranslation('change_pipette')
-  console.log(pipetteModelName, wantedPipette)
+
   return (
     <>
       <WizardHeader

--- a/app/src/organisms/ChangePipette/__tests__/LevelPipette.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/LevelPipette.test.tsx
@@ -1,0 +1,111 @@
+import * as React from 'react'
+import { fireEvent } from '@testing-library/react'
+import { nestedTextMatcher, renderWithProviders } from '@opentrons/components'
+import { i18n } from '../../../i18n'
+import { LEFT, PipetteNameSpecs } from '@opentrons/shared-data'
+import { LevelPipette } from '../LevelPipette'
+
+const render = (props: React.ComponentProps<typeof LevelPipette>) => {
+  return renderWithProviders(<LevelPipette {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+const MOCK_WANTED_PIPETTE = {
+  displayName: 'P300 8-Channel GEN2',
+  displayCategory: 'GEN2',
+  defaultAspirateFlowRate: {
+    value: 94,
+    min: 1,
+    max: 275,
+    valuesByApiLevel: {
+      '2.0': 94,
+    },
+  },
+  defaultDispenseFlowRate: {
+    value: 94,
+    min: 1,
+    max: 275,
+    valuesByApiLevel: {
+      '2.0': 94,
+    },
+  },
+  defaultBlowOutFlowRate: {
+    value: 94,
+    min: 1,
+    max: 275,
+    valuesByApiLevel: {
+      '2.0': 94,
+    },
+  },
+  channels: 8,
+  minVolume: 20,
+  maxVolume: 300,
+  smoothieConfigs: {
+    stepsPerMM: 3200,
+    homePosition: 155.75,
+    travelDistance: 60,
+  },
+  defaultTipracks: [
+    'opentrons/opentrons_96_tiprack_300ul/1',
+    'opentrons/opentrons_96_filtertiprack_200ul/1',
+  ],
+  name: 'p300_multi_gen2',
+} as PipetteNameSpecs
+
+describe('LevelPipette', () => {
+  let props: React.ComponentProps<typeof LevelPipette>
+
+  beforeEach(() => {
+    props = {
+      mount: LEFT,
+      wantedPipette: MOCK_WANTED_PIPETTE,
+      pipetteModelName: MOCK_WANTED_PIPETTE.name,
+      back: jest.fn(),
+      exit: jest.fn(),
+      confirm: jest.fn(),
+      currentStep: 6,
+      totalSteps: 8,
+    }
+  })
+
+  it('renders title and description', () => {
+    const { getByText } = render(props)
+    getByText('Attach a P300 8-Channel GEN2 Pipette')
+    getByText(nestedTextMatcher('Level the pipette'))
+    getByText(
+      nestedTextMatcher(
+        'Using your hand, gently and slowly push the pipette up.'
+      )
+    )
+    getByText(
+      nestedTextMatcher(
+        'Place the calibration block in slot1/3 with the tall/short surface on the left/right side.'
+      )
+    )
+    getByText(
+      nestedTextMatcher(
+        'Pull the pipette down so all 8 nozzles touch the surface of the block.'
+      )
+    )
+    getByText(
+      nestedTextMatcher(
+        'While holding the pipette down, tighten the three screws.'
+      )
+    )
+    getByText(nestedTextMatcher('Gently and slowly push the pipette back up.'))
+  })
+
+  it('the CTAs should be clickable', () => {
+    const { getByRole } = render(props)
+    const goBack = getByRole('button', { name: 'Go back' })
+    const exit = getByRole('button', { name: 'Exit' })
+    const cont = getByRole('button', { name: 'Confirm level' })
+    fireEvent.click(goBack)
+    expect(props.back).toHaveBeenCalled()
+    fireEvent.click(exit)
+    expect(props.exit).toHaveBeenCalled()
+    fireEvent.click(cont)
+    expect(props.confirm).toHaveBeenCalled()
+  })
+})

--- a/app/src/organisms/ChangePipette/__tests__/LevelPipette.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/LevelPipette.test.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
 import { fireEvent } from '@testing-library/react'
 import { nestedTextMatcher, renderWithProviders } from '@opentrons/components'
-import { i18n } from '../../../i18n'
 import { LEFT, PipetteNameSpecs } from '@opentrons/shared-data'
+import { i18n } from '../../../i18n'
 import { LevelPipette } from '../LevelPipette'
 
 const render = (props: React.ComponentProps<typeof LevelPipette>) => {

--- a/app/src/organisms/ChangePipette/index.tsx
+++ b/app/src/organisms/ChangePipette/index.tsx
@@ -36,6 +36,7 @@ import { DeprecatedInstructions } from './DeprecatedInstructions'
 import { ConfirmPipette } from './ConfirmPipette'
 import { RequestInProgressModal } from './RequestInProgressModal'
 import { LevelPipette } from './LevelPipette'
+import { DeprecatedLevelPipette } from './DeprecatedLevelPipette'
 import { ClearDeckAlertModal } from './ClearDeckModal/ClearDeckAlertModal'
 
 import {
@@ -272,8 +273,20 @@ export function ChangePipette(props: Props): JSX.Element | null {
     }
 
     if (success && wantedPipette && shouldLevel(wantedPipette)) {
-      return (
-        <LevelPipette
+      return enableChangePipetteWizard ? (
+        <ModalShell height="28.12rem" width="47rem">
+          <LevelPipette
+            {...basePropsWithPipettes}
+            pipetteModelName={actualPipette ? actualPipette.name : ''}
+            exit={() => setConfirmExit(true)}
+            confirm={homePipAndExit}
+            back={() => setWizardStep(CLEAR_DECK)}
+            currentStep={6}
+            totalSteps={8}
+          />
+        </ModalShell>
+      ) : (
+        <DeprecatedLevelPipette
           {...{
             pipetteModelName: actualPipette ? actualPipette.name : '',
             ...basePropsWithPipettes,


### PR DESCRIPTION

# Overview

This PR updates the style and flow for the LevelPipette component in the change pipette wizard. closes [RLIQ-52](https://opentrons.atlassian.net/browse/RLIQ-52?atlOrigin=eyJpIjoiNWJjZjExNjhmZjIxNDNjYjlmMTNiZWJmNmY5OTA1ZTEiLCJwIjoiaiJ9)

![Screen Shot 2022-08-22 at 8 51 55 PM](https://user-images.githubusercontent.com/14794021/186054862-a74380e2-c5f9-481b-a087-d413211e0365.png)

# Changelog

- Deprecate old `LevelPipette` -> `DeprecatedLevelPipette`
- Update styling for new `LevelPipette` component

# Review requests

- Check that for the multichannel pipette, when attaching it displays the new component while behind the feature flag.

# Risk assessment

low, behind FF