### PR TITLE
test(api): mock config.feature_flags rather than writing to file system

### DIFF
--- a/api/mypy.ini
+++ b/api/mypy.ini
@@ -4,7 +4,7 @@ show_error_codes = True
 warn_unused_configs = True
 strict = True
 # TODO(mc, 2021-09-12): work through and remove these exclusions
-exclude = tests/opentrons/(hardware_control|protocols/advanced_control|protocols/api_support|protocols/context|protocols/duration|protocols/execution|protocols/fixtures|protocols/geometry)/
+exclude = tests/opentrons/(hardware_control|protocols/advanced_control|protocols/api_support|protocols/duration|protocols/execution|protocols/fixtures|protocols/geometry)/
 
 [pydantic-mypy]
 init_forbid_extra = True

--- a/api/src/opentrons/__init__.py
+++ b/api/src/opentrons/__init__.py
@@ -7,7 +7,6 @@ import asyncio
 import re
 from typing import Any, List, Tuple
 
-from opentrons.config.feature_flags import enable_ot3_hardware_controller
 from opentrons.drivers.serial_communication import get_ports_by_name
 from opentrons.hardware_control import (
     API as HardwareAPI,
@@ -104,7 +103,7 @@ def _get_motor_control_serial_port() -> Any:
 
 def should_use_ot3() -> bool:
     """Return true if ot3 hardware controller should be used."""
-    if enable_ot3_hardware_controller():
+    if ff.enable_ot3_hardware_controller():
         try:
             from opentrons_hardware.drivers.can_bus import CanDriver  # noqa: F401
 

--- a/api/src/opentrons/config/robot_configs.py
+++ b/api/src/opentrons/config/robot_configs.py
@@ -6,8 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Union, Optional, cast
 from typing_extensions import Literal
 
-from . import CONFIG, defaults_ot3, defaults_ot2, gripper_config
-from .feature_flags import enable_ot3_hardware_controller
+from . import CONFIG, defaults_ot3, defaults_ot2, gripper_config, feature_flags as ff
 from opentrons.hardware_control.types import BoardRevision
 from .types import CurrentDict, RobotConfig, AxisDict, OT3Config
 
@@ -33,7 +32,7 @@ def build_config(robot_settings: Dict[str, Any]) -> Union[RobotConfig, OT3Config
     object.
     """
     default_robot_model: Union[Literal["OT-3 Standard"], Literal["OT-2 Standard"]] = (
-        "OT-3 Standard" if enable_ot3_hardware_controller() else "OT-2 Standard"
+        "OT-3 Standard" if ff.enable_ot3_hardware_controller() else "OT-2 Standard"
     )
     robot_model = robot_settings.get("model", default_robot_model)
     if robot_model == "OT-3 Standard":
@@ -166,14 +165,14 @@ def _save_config_data(data: str, filename: Union[str, Path]) -> None:
 
 
 def default_deck_calibration() -> List[List[float]]:
-    if enable_ot3_hardware_controller():
+    if ff.enable_ot3_hardware_controller():
         return defaults_ot3.DEFAULT_DECK_TRANSFORM
     else:
         return defaults_ot2.DEFAULT_DECK_CALIBRATION_V2
 
 
 def default_pipette_offset() -> List[float]:
-    if enable_ot3_hardware_controller():
+    if ff.enable_ot3_hardware_controller():
         return defaults_ot3.DEFAULT_PIPETTE_OFFSET
     else:
         return defaults_ot2.DEFAULT_PIPETTE_OFFSET

--- a/api/src/opentrons/hardware_control/scripts/repl.py
+++ b/api/src/opentrons/hardware_control/scripts/repl.py
@@ -29,7 +29,7 @@ import logging  # noqa: E402
 
 from opentrons.types import Mount, Point  # noqa: E402
 from opentrons.hardware_control.types import Axis, CriticalPoint  # noqa: E402
-from opentrons.config.feature_flags import enable_ot3_hardware_controller  # noqa: E402
+from opentrons.config import feature_flags as ff  # noqa: E402
 from opentrons.hardware_control.types import OT3Axis, OT3Mount  # noqa: E402
 from opentrons.hardware_control.ot3_calibration import (  # noqa: E402
     calibrate_mount,
@@ -41,7 +41,7 @@ from opentrons.hardware_control.ot3_calibration import (  # noqa: E402
 from opentrons.hardware_control.protocols import HardwareControlAPI  # noqa: E402
 from opentrons.hardware_control.thread_manager import ThreadManager  # noqa: E402
 
-if enable_ot3_hardware_controller():
+if ff.enable_ot3_hardware_controller():
     from opentrons.hardware_control.ot3api import OT3API
 
     HCApi: Union[Type[OT3API], Type["API"]] = OT3API

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -1,13 +1,11 @@
 # Uncomment to enable logging during tests
-# import logging
-# from logging.config import dictConfig
 from __future__ import annotations
 import asyncio
+import inspect
 import io
 import json
 import os
 import pathlib
-import tempfile
 import zipfile
 from typing import (
     TYPE_CHECKING,
@@ -24,6 +22,7 @@ from typing import (
 from typing_extensions import TypedDict
 
 import pytest
+from decoy import Decoy
 
 try:
     import aionotify  # type: ignore[import]
@@ -90,68 +89,30 @@ def labware_offset_tempdir(ot_config_tempdir: pathlib.Path) -> pathlib.Path:
     return config.get_opentrons_path("labware_calibration_offsets_dir_v2")
 
 
-@pytest.fixture(autouse=True)
-def clear_feature_flags() -> Generator[None, None, None]:
-    ff_file = config.CONFIG["feature_flags_file"]
-    if os.path.exists(ff_file):
-        os.remove(ff_file)
-    yield
-    if os.path.exists(ff_file):
-        os.remove(ff_file)
-
-
 @pytest.fixture()
-def wifi_keys_tempdir() -> Generator[str, None, None]:
-    old_wifi_keys = config.CONFIG["wifi_keys_dir"]
-    with tempfile.TemporaryDirectory() as td:
-        config.CONFIG["wifi_keys_dir"] = pathlib.Path(td)
-        yield td
-        config.CONFIG["wifi_keys_dir"] = old_wifi_keys
-
-
-@pytest.fixture()
-def is_robot(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
+def is_robot(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(config, "IS_ROBOT", True)
-    yield
-    monkeypatch.setattr(config, "IS_ROBOT", False)
 
 
-# -------feature flag fixtures-------------
-@pytest.fixture()
-async def short_trash_flag() -> AsyncGenerator[None, None]:
-    await config.advanced_settings.set_adv_setting("shortFixedTrash", True)
-    yield
-    await config.advanced_settings.set_adv_setting("shortFixedTrash", False)
+@pytest.fixture
+def mock_feature_flags(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
+    for name, func in inspect.getmembers(config.feature_flags, inspect.isfunction):
+        mock_get_ff = decoy.mock(func=func)
+        decoy.when(mock_get_ff()).then_return(False)
+        monkeypatch.setattr(config.feature_flags, name, mock_get_ff)
 
 
-@pytest.fixture()
-async def old_aspiration() -> AsyncGenerator[None, None]:
-    await config.advanced_settings.set_adv_setting("useOldAspirationFunctions", True)
-    yield
-    await config.advanced_settings.set_adv_setting("useOldAspirationFunctions", False)
-
-
-@pytest.fixture()
-async def enable_door_safety_switch() -> AsyncGenerator[None, None]:
-    await config.advanced_settings.set_adv_setting("enableDoorSafetySwitch", True)
-    yield
-    await config.advanced_settings.set_adv_setting("enableDoorSafetySwitch", False)
-
-
-@pytest.fixture()
+@pytest.fixture
 async def enable_ot3_hardware_controller(
     request: pytest.FixtureRequest,
-) -> AsyncGenerator[None, None]:
+    decoy: Decoy,
+    mock_feature_flags: None,
+) -> None:
     # this is from the command line parameters added in root conftest
     if request.config.getoption("--ot2-only"):
         pytest.skip("testing only ot2")
 
-    await config.advanced_settings.set_adv_setting("enableOT3HardwareController", True)
-    yield
-    await config.advanced_settings.set_adv_setting("enableOT3HardwareController", False)
-
-
-# -----end feature flag fixtures-----------
+    decoy.when(config.feature_flags.enable_ot3_hardware_controller()).then_return(True)
 
 
 @pytest.fixture()
@@ -174,19 +135,17 @@ def protocol(protocol_file: str) -> Generator[Protocol, None, None]:
 
 
 @pytest.fixture()
-def virtual_smoothie_env(
-    monkeypatch: pytest.MonkeyPatch,
-) -> Generator[None, None, None]:
+def virtual_smoothie_env(monkeypatch: pytest.MonkeyPatch) -> None:
     # TODO (ben 20180426): move this to the .env file
     monkeypatch.setenv("ENABLE_VIRTUAL_SMOOTHIE", "true")
-    yield
-    monkeypatch.setenv("ENABLE_VIRTUAL_SMOOTHIE", "false")
 
 
 @pytest.fixture(params=["ot2", "ot3"])
 async def machine_variant_ffs(
     request: pytest.FixtureRequest,
-) -> AsyncGenerator[None, None]:
+    decoy: Decoy,
+    mock_feature_flags: None,
+) -> None:
     device_param = request.param  # type: ignore[attr-defined]
 
     if request.node.get_closest_marker("ot3_only") and device_param == "ot2":
@@ -194,16 +153,8 @@ async def machine_variant_ffs(
     if request.node.get_closest_marker("ot2_only") and device_param == "ot3":
         pytest.skip()
 
-    old = config.advanced_settings.get_adv_setting("enableOT3HardwareController")
-    assert old
-    old_value = old.value
-
-    await config.advanced_settings.set_adv_setting(
-        "enableOT3HardwareController", device_param == "ot3"
-    )
-    yield
-    await config.advanced_settings.set_adv_setting(
-        "enableOT3HardwareController", old_value
+    decoy.when(config.feature_flags.enable_ot3_hardware_controller()).then_return(
+        device_param == "ot3"
     )
 
 
@@ -263,6 +214,8 @@ async def ot3_hardware(
 )
 async def hardware(
     request: pytest.FixtureRequest,
+    decoy: Decoy,
+    mock_feature_flags: None,
     virtual_smoothie_env: None,
 ) -> AsyncGenerator[ThreadManagedHardware, None]:
     hw_builder = request.param()  # type: ignore[attr-defined]
@@ -275,16 +228,11 @@ async def hardware(
         pytest.skip("testing only ot2")
 
     async for hw in hw_builder():
-        if hw_builder == _build_ot3_hw:
-            await config.advanced_settings.set_adv_setting(
-                "enableOT3HardwareController", True
-            )
-        try:
-            yield hw
-        finally:
-            await config.advanced_settings.set_adv_setting(
-                "enableOT3HardwareController", False
-            )
+        decoy.when(config.feature_flags.enable_ot3_hardware_controller()).then_return(
+            hw_builder == _build_ot3_hw
+        )
+
+        yield hw
 
 
 # Async because ProtocolContext.__init__() needs an event loop,
@@ -305,12 +253,12 @@ async def ctx(
 
 @pytest.fixture()
 async def smoothie(
+    virtual_smoothie_env: None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> AsyncGenerator[SmoothieDriverType, None]:
     from opentrons.drivers.smoothie_drivers import SmoothieDriver
     from opentrons.config import robot_configs
 
-    monkeypatch.setenv("ENABLE_VIRTUAL_SMOOTHIE", "true")
     driver = SmoothieDriver(
         robot_configs.load_ot2(), SimulatingGPIOCharDev("simulated")
     )
@@ -321,26 +269,19 @@ async def smoothie(
     except AttributeError:
         # if the test disconnected
         pass
-    monkeypatch.setenv("ENABLE_VIRTUAL_SMOOTHIE", "false")
 
 
-@pytest.fixture()
-def hardware_controller_lockfile() -> Generator[str, None, None]:
-    old_lockfile = config.CONFIG["hardware_controller_lockfile"]
-    with tempfile.TemporaryDirectory() as td:
-        config.CONFIG["hardware_controller_lockfile"] = (
-            pathlib.Path(td) / "hardware.lock"
-        )
-        yield td
-        config.CONFIG["hardware_controller_lockfile"] = old_lockfile
+@pytest.fixture
+def hardware_controller_lockfile(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> pathlib.Path:
+    lockfile_dir = tmp_path / "hardware_controller_lockfile"
+    lockfile_dir.mkdir()
+    lockfile = lockfile_dir / "hardware.lock"
 
+    monkeypatch.setitem(config.CONFIG, "hardware_controller_lockfile", lockfile)
 
-@pytest.fixture()
-def running_on_pi() -> Generator[None, None, None]:
-    oldpi = config.IS_ROBOT
-    config.IS_ROBOT = True
-    yield
-    config.IS_ROBOT = oldpi
+    return lockfile_dir
 
 
 @pytest.mark.skipif(

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -2,6 +2,7 @@ import asyncio
 import mock
 
 import pytest
+from decoy import Decoy
 
 try:
     import aionotify
@@ -10,7 +11,7 @@ except (OSError, ModuleNotFoundError):
 
 import typeguard
 
-from opentrons import types
+from opentrons import types, config
 from opentrons.hardware_control import API
 from opentrons.hardware_control.types import Axis, OT3Mount
 from opentrons.hardware_control.dev_types import PipetteDict
@@ -171,7 +172,7 @@ async def test_cache_instruments_hc(
     monkeypatch,
     dummy_instruments,
     hardware_controller_lockfile,
-    running_on_pi,
+    is_robot,
     cntrlr_mock_connect,
 ):
     hw_api_cntrlr = await API.build_hardware_controller(loop=asyncio.get_running_loop())
@@ -345,7 +346,9 @@ async def test_aspirate_new(dummy_instruments):
     assert pos[Axis.B] == new_plunger_pos
 
 
-async def test_aspirate_old(dummy_instruments, old_aspiration):
+async def test_aspirate_old(decoy: Decoy, mock_feature_flags: None, dummy_instruments):
+    decoy.when(config.feature_flags.use_old_aspiration_functions()).then_return(True)
+
     hw_api = await API.build_hardware_simulator(
         attached_instruments=dummy_instruments, loop=asyncio.get_running_loop()
     )

--- a/api/tests/opentrons/protocol_engine/conftest.py
+++ b/api/tests/opentrons/protocol_engine/conftest.py
@@ -1,8 +1,6 @@
 """ProtocolEngine shared test fixtures."""
 import pytest
-from typing import AsyncGenerator
 
-from opentrons import config
 from opentrons_shared_data import load_shared_data
 from opentrons_shared_data.deck import load as load_deck
 from opentrons_shared_data.deck.dev_types import DeckDefinitionV3
@@ -13,14 +11,6 @@ from opentrons.protocols.api_support.constants import (
     SHORT_TRASH_DECK,
 )
 from opentrons.protocol_engine.types import ModuleDefinition
-
-
-@pytest.fixture(scope="function")
-async def short_trash_flag() -> AsyncGenerator[None, None]:
-    """Feature flag simulator for short fixed trash."""
-    await config.advanced_settings.set_adv_setting("shortFixedTrash", True)
-    yield
-    await config.advanced_settings.set_adv_setting("shortFixedTrash", False)
 
 
 @pytest.fixture(scope="session")

--- a/api/tests/opentrons/protocol_engine/resources/test_deck_data_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_deck_data_provider.py
@@ -2,6 +2,7 @@
 import pytest
 from decoy import Decoy
 
+from opentrons.config import feature_flags
 from opentrons_shared_data.deck.dev_types import DeckDefinitionV3
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.types import DeckSlotName
@@ -36,11 +37,14 @@ async def test_get_deck_definition(
 
 
 async def test_get_deck_definition_short_trash(
+    decoy: Decoy,
     short_trash_deck_def: DeckDefinitionV3,
     subject: DeckDataProvider,
-    short_trash_flag: None,
+    mock_feature_flags: None,
 ) -> None:
     """It should be able to load the short-trash deck definition."""
+    decoy.when(feature_flags.short_fixed_trash()).then_return(True)
+
     result = await subject.get_deck_definition()
     assert result == short_trash_deck_def
 

--- a/api/tests/opentrons/system/test_wifi.py
+++ b/api/tests/opentrons/system/test_wifi.py
@@ -1,12 +1,24 @@
 import os
 import tempfile
 import random
+from pathlib import Path
 
 import pytest
+
+from opentrons import config
 from opentrons.system import wifi
 
 
-def test_check_eap_config(wifi_keys_tempdir):
+@pytest.fixture()
+def wifi_keys_tempdir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    wifi_keys_dir = tmp_path / "wifi_keys"
+    wifi_keys_dir.mkdir()
+    monkeypatch.setitem(config.CONFIG, "wifi_keys_dir", wifi_keys_dir)
+
+    return wifi_keys_dir
+
+
+def test_check_eap_config(wifi_keys_tempdir: Path):
     wifi_key_id = "88188cafcf"
     os.mkdir(os.path.join(wifi_keys_tempdir, wifi_key_id))
     with open(os.path.join(wifi_keys_tempdir, wifi_key_id, "test.pem"), "w") as f:

--- a/robot-server/robot_server/health/router.py
+++ b/robot-server/robot_server/health/router.py
@@ -3,7 +3,6 @@ from fastapi import APIRouter, Depends, status
 
 from opentrons import __version__, config, protocol_api
 from opentrons.hardware_control import HardwareControlAPI
-from opentrons.config.feature_flags import enable_ot3_hardware_controller
 
 from robot_server.hardware import get_hardware
 from robot_server.service.legacy.models import V1BasicResponse
@@ -44,9 +43,11 @@ async def get_health(hardware: HardwareControlAPI = Depends(get_hardware)) -> He
         system_version=config.OT_SYSTEM_VERSION,
         maximum_protocol_api_version=list(protocol_api.MAX_SUPPORTED_VERSION),
         minimum_protocol_api_version=list(protocol_api.MIN_SUPPORTED_VERSION),
-        robot_model="OT-3 Standard"
-        if enable_ot3_hardware_controller()
-        else "OT-2 Standard",
+        robot_model=(
+            "OT-3 Standard"
+            if config.feature_flags.enable_ot3_hardware_controller()
+            else "OT-2 Standard"
+        ),
         links=HealthLinks(
             apiLog="/logs/api.log",
             serialLog="/logs/serial.log",


### PR DESCRIPTION
## Overview

This PR mocks `opentrons.config.feature_flags` in unit tests rather than writing to the `feature_flags.json` file. This allows for the `api` unit tests run concurrently with the `robot-server` unit tests and dev server

Closes RSS-84

## Changelog

- mock config.feature_flags rather than writing to file system
- fix/remove various other fixtures
    - Deleted/removed some unused ones
    - Converted some fixtures to use `monkeypatch` and `tmp_path` rather than `yield` for more reliable cleanup

## Review requests

- [ ] Tests pass locally
- [ ] Tests pass in CI

## Risk assessment

Low if CI is green
