### PR TITLE
fix(ot3): properly stop can messenger tasks and modify script inputs

### DIFF
--- a/hardware/opentrons_hardware/scripts/sensor_utils.py
+++ b/hardware/opentrons_hardware/scripts/sensor_utils.py
@@ -98,9 +98,9 @@ async def handle_pressure_sensor(
         )
         csv = CSVFormatter.build(metadata, list(metadata.to_dict().keys()))
     end_time = start_time + timedelta(minutes=command.minutes)
+    messenger = CanMessenger(driver=driver)
+    messenger.start()
     while datetime.now() < end_time:
-        messenger = CanMessenger(driver=driver)
-        messenger.start()
         data = await s_driver.read(messenger, pressure, offset=False, timeout=10)
         curr_time = datetime.now().strftime(hms)
         if isinstance(data, SensorDataType):
@@ -115,6 +115,7 @@ async def handle_pressure_sensor(
     log.info(text_end_time)
     if csv:
         csv.write(text_end_time)
+    await messenger.stop()
 
 
 async def handle_capacitive_sensor(
@@ -159,6 +160,7 @@ async def handle_capacitive_sensor(
     log.info(text_end_time)
     if csv:
         csv.write(text_end_time)
+    await messenger.stop()
 
 
 async def handle_environment_sensor(
@@ -206,3 +208,4 @@ async def handle_environment_sensor(
     log.info(text_end_time)
     if csv:
         csv.write(text_end_time)
+    await messenger.stop()

--- a/hardware/opentrons_hardware/scripts/sensor_utils.py
+++ b/hardware/opentrons_hardware/scripts/sensor_utils.py
@@ -22,7 +22,7 @@ class SensorRun:
     sensor_type: SensorType
     serial_number: str
     auto_zero: bool
-    minutes: int
+    minutes: float
     mount: str
 
 
@@ -32,7 +32,7 @@ class CSVMetaData:
 
     serial: str
     sensor: str
-    repeats: int
+    minutes: float
     auto_zero: bool
     start_time: str
 

--- a/hardware/opentrons_hardware/scripts/sensors.py
+++ b/hardware/opentrons_hardware/scripts/sensors.py
@@ -67,12 +67,11 @@ def prompt_sensor_type(
 
 
 def prompt_str_input(prompt_name: str, get_user_input: GetInputFunc) -> str:
-    """Prompt to choose a member of the enum.
+    """Prompt to type in a particular string.
 
     Args:
         output_func: Function to output text to user.
         get_user_input: Function to get user input.
-        enum_type: an enum type
 
     Returns:
         The choice.
@@ -84,20 +83,43 @@ def prompt_str_input(prompt_name: str, get_user_input: GetInputFunc) -> str:
         raise InvalidInput(str(e))
 
 
-def prompt_int_input(prompt_name: str, get_user_input: GetInputFunc) -> int:
-    """Prompt to choose a member of the enum.
+def prompt_float_input(prompt_name: str, get_user_input: GetInputFunc) -> int:
+    """Prompt a float input.
 
     Args:
         output_func: Function to output text to user.
         get_user_input: Function to get user input.
-        enum_type: an enum type
 
     Returns:
         The choice.
 
     """
     try:
-        return int(get_user_input(f"{prompt_name}:"))
+        return float(get_user_input(f"{prompt_name}:"))
+    except (ValueError, IndexError) as e:
+        raise InvalidInput(str(e))
+
+
+def prompt_bool_input(prompt_name: str, get_user_input: GetInputFunc) -> bool:
+    """Prompt user for a yes or no answer.
+
+    Args:
+        output_func: Function to output text to user.
+        get_user_input: Function to get user input.
+
+    Returns:
+        The choice.
+
+    """
+    answer_map = {
+        'yes': 1,
+        'no': 0,
+        'y': 1,
+        'n': 0
+    }
+    try:
+        answer = str(get_user_input(f"{prompt_name} Type in yes or no:"))
+        return bool(answer_map[answer])
     except (ValueError, IndexError) as e:
         raise InvalidInput(str(e))
 
@@ -111,9 +133,9 @@ def prompt_message(
         'pipette mounts:"left" or "right", gripper mount: "gripper"', get_user_input
     )
     serial_number = prompt_str_input("instrument serial number", get_user_input)
-    auto_zero = prompt_int_input("auto zero", get_user_input)
-    minutes = prompt_int_input("script run time in minutes", get_user_input)
-    output_to_csv = bool(prompt_int_input("output to csv?", get_user_input))
+    auto_zero = prompt_bool_input("auto zero?", get_user_input)
+    minutes = prompt_float_input("script run time in minutes", get_user_input)
+    output_to_csv = prompt_bool_input("output to csv?", get_user_input)
 
     sensor_run = SensorRun(sensor_type, serial_number, bool(auto_zero), minutes, mount)
     return sensor_run, output_to_csv

--- a/hardware/opentrons_hardware/scripts/sensors.py
+++ b/hardware/opentrons_hardware/scripts/sensors.py
@@ -83,7 +83,7 @@ def prompt_str_input(prompt_name: str, get_user_input: GetInputFunc) -> str:
         raise InvalidInput(str(e))
 
 
-def prompt_float_input(prompt_name: str, get_user_input: GetInputFunc) -> int:
+def prompt_float_input(prompt_name: str, get_user_input: GetInputFunc) -> float:
     """Prompt a float input.
 
     Args:
@@ -111,12 +111,7 @@ def prompt_bool_input(prompt_name: str, get_user_input: GetInputFunc) -> bool:
         The choice.
 
     """
-    answer_map = {
-        'yes': 1,
-        'no': 0,
-        'y': 1,
-        'n': 0
-    }
+    answer_map = {"yes": 1, "no": 0, "y": 1, "n": 0}
     try:
         answer = str(get_user_input(f"{prompt_name} Type in yes or no:"))
         return bool(answer_map[answer])


### PR DESCRIPTION
# Overview

We were not properly handling can messenger tasks once we've finished reading from sensors. This
caused task running errors if you tried to do multiple successions of sensor reads while the script
is running -- which is the whole point of the script.