### PR TITLE
fix(hardware): remove 0-bytes from pipette serials

### DIFF
--- a/hardware/opentrons_hardware/hardware_control/tools/detector.py
+++ b/hardware/opentrons_hardware/hardware_control/tools/detector.py
@@ -82,7 +82,7 @@ class OneshotToolDetector:
     @staticmethod
     def _decode_or_default(orig: bytes) -> str:
         try:
-            return orig.decode()
+            return orig.decode(errors="replace").split("\x00")[0]
         except UnicodeDecodeError:
             return repr(orig)
 


### PR DESCRIPTION
0-bytes will be at the end of serial numbers, and we can't use them in paths, so we'd better strip them.