### PR TITLE
feat(shared-data): add initial OT-3 labware definitions 

### DIFF
--- a/labware-library/src/filters.tsx
+++ b/labware-library/src/filters.tsx
@@ -62,8 +62,7 @@ export function getFilteredDefinitions(filters: FilterParams): LabwareList {
   return getAllDefinitions().filter(
     def =>
       testCategory(filters.category, def) &&
-      testManufacturer(filters.manufacturer, def) &&
-      testOT3Definition(def)
+      testManufacturer(filters.manufacturer, def)
   )
 }
 
@@ -88,10 +87,4 @@ export function testCategory(
     category === FILTER_OFF ||
     category === definition.metadata.displayCategory
   )
-}
-
-// TODO(lc 8-24-2022) This is a temporary function
-// to filter out the new ot3 tiprack definitions
-export function testOT3Definition(definition: LabwareDefinition): boolean {
-  return !definition.metadata.displayName.includes('OT-3')
 }

--- a/labware-library/src/filters.tsx
+++ b/labware-library/src/filters.tsx
@@ -62,7 +62,8 @@ export function getFilteredDefinitions(filters: FilterParams): LabwareList {
   return getAllDefinitions().filter(
     def =>
       testCategory(filters.category, def) &&
-      testManufacturer(filters.manufacturer, def)
+      testManufacturer(filters.manufacturer, def) &&
+      testOT3Definition(def)
   )
 }
 
@@ -87,4 +88,10 @@ export function testCategory(
     category === FILTER_OFF ||
     category === definition.metadata.displayCategory
   )
+}
+
+// TODO(lc 8-24-2022) This is a temporary function
+// to filter out the new ot3 tiprack definitions
+export function testOT3Definition(definition: LabwareDefinition): boolean {
+  return !definition.metadata.displayName.includes('OT-3')
 }

--- a/shared-data/js/getLabware.ts
+++ b/shared-data/js/getLabware.ts
@@ -36,6 +36,13 @@ export const LABWAREV2_DO_NOT_LIST = [
   'eppendorf_96_tiprack_10ul_eptips',
   'opentrons_calibrationblock_short_side_left',
   'opentrons_calibrationblock_short_side_right',
+  // TODO(lc 8-24-2022) We are temporarily filtering
+  // out ot-3 labware definitions right now. We should
+  // have a way to filter these in the future to display
+  // the definitions. See RLIQ-117 for details.
+  'opentrons_ot3_96_tiprack_20ul',
+  'opentrons_ot3_96_tiprack_200ul',
+  'opentrons_ot3_96_tiprack_1000ul',
 ]
 // NOTE(sa, 2020-7-14): in PD we do not want to list calibration blocks
 // but we still might want the rest of the labware in LABWAREV2_DO_NOT_LIST
@@ -43,6 +50,13 @@ export const LABWAREV2_DO_NOT_LIST = [
 export const PD_DO_NOT_LIST = [
   'opentrons_calibrationblock_short_side_left',
   'opentrons_calibrationblock_short_side_right',
+  // TODO(lc 8-24-2022) We are temporarily filtering
+  // out ot-3 labware definitions right now. We should
+  // have a way to filter these in the future to display
+  // the definitions. See RLIQ-117 for details.
+  'opentrons_ot3_96_tiprack_20ul',
+  'opentrons_ot3_96_tiprack_200ul',
+  'opentrons_ot3_96_tiprack_1000ul',
 ]
 
 export function getLabwareV1Def(

--- a/shared-data/labware/definitions/2/opentrons_ot3_96_tiprack_1000ul/1.json
+++ b/shared-data/labware/definitions/2/opentrons_ot3_96_tiprack_1000ul/1.json
@@ -1,0 +1,1125 @@
+{
+    "ordering": [
+        [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "E1",
+            "F1",
+            "G1",
+            "H1"
+        ],
+        [
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "E2",
+            "F2",
+            "G2",
+            "H2"
+        ],
+        [
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "E3",
+            "F3",
+            "G3",
+            "H3"
+        ],
+        [
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "E4",
+            "F4",
+            "G4",
+            "H4"
+        ],
+        [
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "E5",
+            "F5",
+            "G5",
+            "H5"
+        ],
+        [
+            "A6",
+            "B6",
+            "C6",
+            "D6",
+            "E6",
+            "F6",
+            "G6",
+            "H6"
+        ],
+        [
+            "A7",
+            "B7",
+            "C7",
+            "D7",
+            "E7",
+            "F7",
+            "G7",
+            "H7"
+        ],
+        [
+            "A8",
+            "B8",
+            "C8",
+            "D8",
+            "E8",
+            "F8",
+            "G8",
+            "H8"
+        ],
+        [
+            "A9",
+            "B9",
+            "C9",
+            "D9",
+            "E9",
+            "F9",
+            "G9",
+            "H9"
+        ],
+        [
+            "A10",
+            "B10",
+            "C10",
+            "D10",
+            "E10",
+            "F10",
+            "G10",
+            "H10"
+        ],
+        [
+            "A11",
+            "B11",
+            "C11",
+            "D11",
+            "E11",
+            "F11",
+            "G11",
+            "H11"
+        ],
+        [
+            "A12",
+            "B12",
+            "C12",
+            "D12",
+            "E12",
+            "F12",
+            "G12",
+            "H12"
+        ]
+    ],
+    "brand": {
+        "brand": "opentrons OT-3",
+        "brandId": []
+    },
+    "metadata": {
+        "displayName": "Opentrons OT-3 96 Tip Rack 1000 µL",
+        "displayCategory": "tipRack",
+        "displayVolumeUnits": "µL",
+        "tags": []
+    },
+    "dimensions": {
+        "xDimension": 127.76,
+        "yDimension": 85.48,
+        "zDimension": 99
+    },
+    "wells": {
+        "A1": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 14.38,
+            "y": 74.1,
+            "z": 3.4
+        },
+        "B1": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 14.38,
+            "y": 65.1,
+            "z": 3.4
+        },
+        "C1": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 14.38,
+            "y": 56.1,
+            "z": 3.4
+        },
+        "D1": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 14.38,
+            "y": 47.1,
+            "z": 3.4
+        },
+        "E1": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 14.38,
+            "y": 38.1,
+            "z": 3.4
+        },
+        "F1": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 14.38,
+            "y": 29.1,
+            "z": 3.4
+        },
+        "G1": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 14.38,
+            "y": 20.1,
+            "z": 3.4
+        },
+        "H1": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 14.38,
+            "y": 11.1,
+            "z": 3.4
+        },
+        "A2": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 23.38,
+            "y": 74.1,
+            "z": 3.4
+        },
+        "B2": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 23.38,
+            "y": 65.1,
+            "z": 3.4
+        },
+        "C2": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 23.38,
+            "y": 56.1,
+            "z": 3.4
+        },
+        "D2": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 23.38,
+            "y": 47.1,
+            "z": 3.4
+        },
+        "E2": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 23.38,
+            "y": 38.1,
+            "z": 3.4
+        },
+        "F2": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 23.38,
+            "y": 29.1,
+            "z": 3.4
+        },
+        "G2": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 23.38,
+            "y": 20.1,
+            "z": 3.4
+        },
+        "H2": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 23.38,
+            "y": 11.1,
+            "z": 3.4
+        },
+        "A3": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 32.38,
+            "y": 74.1,
+            "z": 3.4
+        },
+        "B3": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 32.38,
+            "y": 65.1,
+            "z": 3.4
+        },
+        "C3": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 32.38,
+            "y": 56.1,
+            "z": 3.4
+        },
+        "D3": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 32.38,
+            "y": 47.1,
+            "z": 3.4
+        },
+        "E3": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 32.38,
+            "y": 38.1,
+            "z": 3.4
+        },
+        "F3": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 32.38,
+            "y": 29.1,
+            "z": 3.4
+        },
+        "G3": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 32.38,
+            "y": 20.1,
+            "z": 3.4
+        },
+        "H3": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 32.38,
+            "y": 11.1,
+            "z": 3.4
+        },
+        "A4": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 41.38,
+            "y": 74.1,
+            "z": 3.4
+        },
+        "B4": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 41.38,
+            "y": 65.1,
+            "z": 3.4
+        },
+        "C4": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 41.38,
+            "y": 56.1,
+            "z": 3.4
+        },
+        "D4": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 41.38,
+            "y": 47.1,
+            "z": 3.4
+        },
+        "E4": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 41.38,
+            "y": 38.1,
+            "z": 3.4
+        },
+        "F4": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 41.38,
+            "y": 29.1,
+            "z": 3.4
+        },
+        "G4": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 41.38,
+            "y": 20.1,
+            "z": 3.4
+        },
+        "H4": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 41.38,
+            "y": 11.1,
+            "z": 3.4
+        },
+        "A5": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 50.38,
+            "y": 74.1,
+            "z": 3.4
+        },
+        "B5": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 50.38,
+            "y": 65.1,
+            "z": 3.4
+        },
+        "C5": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 50.38,
+            "y": 56.1,
+            "z": 3.4
+        },
+        "D5": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 50.38,
+            "y": 47.1,
+            "z": 3.4
+        },
+        "E5": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 50.38,
+            "y": 38.1,
+            "z": 3.4
+        },
+        "F5": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 50.38,
+            "y": 29.1,
+            "z": 3.4
+        },
+        "G5": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 50.38,
+            "y": 20.1,
+            "z": 3.4
+        },
+        "H5": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 50.38,
+            "y": 11.1,
+            "z": 3.4
+        },
+        "A6": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 59.38,
+            "y": 74.1,
+            "z": 3.4
+        },
+        "B6": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 59.38,
+            "y": 65.1,
+            "z": 3.4
+        },
+        "C6": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 59.38,
+            "y": 56.1,
+            "z": 3.4
+        },
+        "D6": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 59.38,
+            "y": 47.1,
+            "z": 3.4
+        },
+        "E6": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 59.38,
+            "y": 38.1,
+            "z": 3.4
+        },
+        "F6": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 59.38,
+            "y": 29.1,
+            "z": 3.4
+        },
+        "G6": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 59.38,
+            "y": 20.1,
+            "z": 3.4
+        },
+        "H6": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 59.38,
+            "y": 11.1,
+            "z": 3.4
+        },
+        "A7": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 68.38,
+            "y": 74.1,
+            "z": 3.4
+        },
+        "B7": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 68.38,
+            "y": 65.1,
+            "z": 3.4
+        },
+        "C7": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 68.38,
+            "y": 56.1,
+            "z": 3.4
+        },
+        "D7": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 68.38,
+            "y": 47.1,
+            "z": 3.4
+        },
+        "E7": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 68.38,
+            "y": 38.1,
+            "z": 3.4
+        },
+        "F7": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 68.38,
+            "y": 29.1,
+            "z": 3.4
+        },
+        "G7": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 68.38,
+            "y": 20.1,
+            "z": 3.4
+        },
+        "H7": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 68.38,
+            "y": 11.1,
+            "z": 3.4
+        },
+        "A8": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 77.38,
+            "y": 74.1,
+            "z": 3.4
+        },
+        "B8": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 77.38,
+            "y": 65.1,
+            "z": 3.4
+        },
+        "C8": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 77.38,
+            "y": 56.1,
+            "z": 3.4
+        },
+        "D8": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 77.38,
+            "y": 47.1,
+            "z": 3.4
+        },
+        "E8": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 77.38,
+            "y": 38.1,
+            "z": 3.4
+        },
+        "F8": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 77.38,
+            "y": 29.1,
+            "z": 3.4
+        },
+        "G8": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 77.38,
+            "y": 20.1,
+            "z": 3.4
+        },
+        "H8": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 77.38,
+            "y": 11.1,
+            "z": 3.4
+        },
+        "A9": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 86.38,
+            "y": 74.1,
+            "z": 3.4
+        },
+        "B9": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 86.38,
+            "y": 65.1,
+            "z": 3.4
+        },
+        "C9": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 86.38,
+            "y": 56.1,
+            "z": 3.4
+        },
+        "D9": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 86.38,
+            "y": 47.1,
+            "z": 3.4
+        },
+        "E9": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 86.38,
+            "y": 38.1,
+            "z": 3.4
+        },
+        "F9": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 86.38,
+            "y": 29.1,
+            "z": 3.4
+        },
+        "G9": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 86.38,
+            "y": 20.1,
+            "z": 3.4
+        },
+        "H9": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 86.38,
+            "y": 11.1,
+            "z": 3.4
+        },
+        "A10": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 95.38,
+            "y": 74.1,
+            "z": 3.4
+        },
+        "B10": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 95.38,
+            "y": 65.1,
+            "z": 3.4
+        },
+        "C10": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 95.38,
+            "y": 56.1,
+            "z": 3.4
+        },
+        "D10": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 95.38,
+            "y": 47.1,
+            "z": 3.4
+        },
+        "E10": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 95.38,
+            "y": 38.1,
+            "z": 3.4
+        },
+        "F10": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 95.38,
+            "y": 29.1,
+            "z": 3.4
+        },
+        "G10": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 95.38,
+            "y": 20.1,
+            "z": 3.4
+        },
+        "H10": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 95.38,
+            "y": 11.1,
+            "z": 3.4
+        },
+        "A11": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 104.38,
+            "y": 74.1,
+            "z": 3.4
+        },
+        "B11": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 104.38,
+            "y": 65.1,
+            "z": 3.4
+        },
+        "C11": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 104.38,
+            "y": 56.1,
+            "z": 3.4
+        },
+        "D11": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 104.38,
+            "y": 47.1,
+            "z": 3.4
+        },
+        "E11": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 104.38,
+            "y": 38.1,
+            "z": 3.4
+        },
+        "F11": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 104.38,
+            "y": 29.1,
+            "z": 3.4
+        },
+        "G11": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 104.38,
+            "y": 20.1,
+            "z": 3.4
+        },
+        "H11": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 104.38,
+            "y": 11.1,
+            "z": 3.4
+        },
+        "A12": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 113.38,
+            "y": 74.1,
+            "z": 3.4
+        },
+        "B12": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 113.38,
+            "y": 65.1,
+            "z": 3.4
+        },
+        "C12": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 113.38,
+            "y": 56.1,
+            "z": 3.4
+        },
+        "D12": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 113.38,
+            "y": 47.1,
+            "z": 3.4
+        },
+        "E12": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 113.38,
+            "y": 38.1,
+            "z": 3.4
+        },
+        "F12": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 113.38,
+            "y": 29.1,
+            "z": 3.4
+        },
+        "G12": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 113.38,
+            "y": 20.1,
+            "z": 3.4
+        },
+        "H12": {
+            "depth": 95.6,
+            "totalLiquidVolume": 1000,
+            "shape": "circular",
+            "diameter": 5.47,
+            "x": 113.38,
+            "y": 11.1,
+            "z": 3.4
+        }
+    },
+    "groups": [
+        {
+            "metadata": {},
+            "wells": [
+                "A1",
+                "B1",
+                "C1",
+                "D1",
+                "E1",
+                "F1",
+                "G1",
+                "H1",
+                "A2",
+                "B2",
+                "C2",
+                "D2",
+                "E2",
+                "F2",
+                "G2",
+                "H2",
+                "A3",
+                "B3",
+                "C3",
+                "D3",
+                "E3",
+                "F3",
+                "G3",
+                "H3",
+                "A4",
+                "B4",
+                "C4",
+                "D4",
+                "E4",
+                "F4",
+                "G4",
+                "H4",
+                "A5",
+                "B5",
+                "C5",
+                "D5",
+                "E5",
+                "F5",
+                "G5",
+                "H5",
+                "A6",
+                "B6",
+                "C6",
+                "D6",
+                "E6",
+                "F6",
+                "G6",
+                "H6",
+                "A7",
+                "B7",
+                "C7",
+                "D7",
+                "E7",
+                "F7",
+                "G7",
+                "H7",
+                "A8",
+                "B8",
+                "C8",
+                "D8",
+                "E8",
+                "F8",
+                "G8",
+                "H8",
+                "A9",
+                "B9",
+                "C9",
+                "D9",
+                "E9",
+                "F9",
+                "G9",
+                "H9",
+                "A10",
+                "B10",
+                "C10",
+                "D10",
+                "E10",
+                "F10",
+                "G10",
+                "H10",
+                "A11",
+                "B11",
+                "C11",
+                "D11",
+                "E11",
+                "F11",
+                "G11",
+                "H11",
+                "A12",
+                "B12",
+                "C12",
+                "D12",
+                "E12",
+                "F12",
+                "G12",
+                "H12"
+            ]
+        }
+    ],
+    "parameters": {
+        "format": "96Standard",
+        "quirks": [],
+        "isTiprack": true,
+        "tipLength": 95.6,
+        "tipOverlap": 10.5,
+        "isMagneticModuleCompatible": false,
+        "loadName": "opentrons_ot3_96_tiprack_1000ul"
+    },
+    "namespace": "opentrons",
+    "version": 1,
+    "schemaVersion": 2,
+    "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+    }
+}

--- a/shared-data/labware/definitions/2/opentrons_ot3_96_tiprack_1000ul/1.json
+++ b/shared-data/labware/definitions/2/opentrons_ot3_96_tiprack_1000ul/1.json
@@ -1,1125 +1,1017 @@
 {
-    "ordering": [
-        [
-            "A1",
-            "B1",
-            "C1",
-            "D1",
-            "E1",
-            "F1",
-            "G1",
-            "H1"
-        ],
-        [
-            "A2",
-            "B2",
-            "C2",
-            "D2",
-            "E2",
-            "F2",
-            "G2",
-            "H2"
-        ],
-        [
-            "A3",
-            "B3",
-            "C3",
-            "D3",
-            "E3",
-            "F3",
-            "G3",
-            "H3"
-        ],
-        [
-            "A4",
-            "B4",
-            "C4",
-            "D4",
-            "E4",
-            "F4",
-            "G4",
-            "H4"
-        ],
-        [
-            "A5",
-            "B5",
-            "C5",
-            "D5",
-            "E5",
-            "F5",
-            "G5",
-            "H5"
-        ],
-        [
-            "A6",
-            "B6",
-            "C6",
-            "D6",
-            "E6",
-            "F6",
-            "G6",
-            "H6"
-        ],
-        [
-            "A7",
-            "B7",
-            "C7",
-            "D7",
-            "E7",
-            "F7",
-            "G7",
-            "H7"
-        ],
-        [
-            "A8",
-            "B8",
-            "C8",
-            "D8",
-            "E8",
-            "F8",
-            "G8",
-            "H8"
-        ],
-        [
-            "A9",
-            "B9",
-            "C9",
-            "D9",
-            "E9",
-            "F9",
-            "G9",
-            "H9"
-        ],
-        [
-            "A10",
-            "B10",
-            "C10",
-            "D10",
-            "E10",
-            "F10",
-            "G10",
-            "H10"
-        ],
-        [
-            "A11",
-            "B11",
-            "C11",
-            "D11",
-            "E11",
-            "F11",
-            "G11",
-            "H11"
-        ],
-        [
-            "A12",
-            "B12",
-            "C12",
-            "D12",
-            "E12",
-            "F12",
-            "G12",
-            "H12"
-        ]
-    ],
-    "brand": {
-        "brand": "opentrons OT-3",
-        "brandId": []
+  "ordering": [
+    ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
+    ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
+    ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
+    ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
+    ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
+    ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
+    ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
+    ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
+    ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
+    ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
+    ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
+    ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
+  ],
+  "brand": {
+    "brand": "opentrons OT-3",
+    "brandId": []
+  },
+  "metadata": {
+    "displayName": "Opentrons OT-3 96 Tip Rack 1000 µL",
+    "displayCategory": "tipRack",
+    "displayVolumeUnits": "µL",
+    "tags": []
+  },
+  "dimensions": {
+    "xDimension": 127.76,
+    "yDimension": 85.48,
+    "zDimension": 99
+  },
+  "wells": {
+    "A1": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 14.38,
+      "y": 74.1,
+      "z": 3.4
     },
-    "metadata": {
-        "displayName": "Opentrons OT-3 96 Tip Rack 1000 µL",
-        "displayCategory": "tipRack",
-        "displayVolumeUnits": "µL",
-        "tags": []
+    "B1": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 14.38,
+      "y": 65.1,
+      "z": 3.4
     },
-    "dimensions": {
-        "xDimension": 127.76,
-        "yDimension": 85.48,
-        "zDimension": 99
+    "C1": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 14.38,
+      "y": 56.1,
+      "z": 3.4
     },
-    "wells": {
-        "A1": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 14.38,
-            "y": 74.1,
-            "z": 3.4
-        },
-        "B1": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 14.38,
-            "y": 65.1,
-            "z": 3.4
-        },
-        "C1": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 14.38,
-            "y": 56.1,
-            "z": 3.4
-        },
-        "D1": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 14.38,
-            "y": 47.1,
-            "z": 3.4
-        },
-        "E1": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 14.38,
-            "y": 38.1,
-            "z": 3.4
-        },
-        "F1": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 14.38,
-            "y": 29.1,
-            "z": 3.4
-        },
-        "G1": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 14.38,
-            "y": 20.1,
-            "z": 3.4
-        },
-        "H1": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 14.38,
-            "y": 11.1,
-            "z": 3.4
-        },
-        "A2": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 23.38,
-            "y": 74.1,
-            "z": 3.4
-        },
-        "B2": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 23.38,
-            "y": 65.1,
-            "z": 3.4
-        },
-        "C2": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 23.38,
-            "y": 56.1,
-            "z": 3.4
-        },
-        "D2": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 23.38,
-            "y": 47.1,
-            "z": 3.4
-        },
-        "E2": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 23.38,
-            "y": 38.1,
-            "z": 3.4
-        },
-        "F2": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 23.38,
-            "y": 29.1,
-            "z": 3.4
-        },
-        "G2": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 23.38,
-            "y": 20.1,
-            "z": 3.4
-        },
-        "H2": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 23.38,
-            "y": 11.1,
-            "z": 3.4
-        },
-        "A3": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 32.38,
-            "y": 74.1,
-            "z": 3.4
-        },
-        "B3": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 32.38,
-            "y": 65.1,
-            "z": 3.4
-        },
-        "C3": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 32.38,
-            "y": 56.1,
-            "z": 3.4
-        },
-        "D3": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 32.38,
-            "y": 47.1,
-            "z": 3.4
-        },
-        "E3": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 32.38,
-            "y": 38.1,
-            "z": 3.4
-        },
-        "F3": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 32.38,
-            "y": 29.1,
-            "z": 3.4
-        },
-        "G3": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 32.38,
-            "y": 20.1,
-            "z": 3.4
-        },
-        "H3": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 32.38,
-            "y": 11.1,
-            "z": 3.4
-        },
-        "A4": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 41.38,
-            "y": 74.1,
-            "z": 3.4
-        },
-        "B4": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 41.38,
-            "y": 65.1,
-            "z": 3.4
-        },
-        "C4": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 41.38,
-            "y": 56.1,
-            "z": 3.4
-        },
-        "D4": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 41.38,
-            "y": 47.1,
-            "z": 3.4
-        },
-        "E4": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 41.38,
-            "y": 38.1,
-            "z": 3.4
-        },
-        "F4": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 41.38,
-            "y": 29.1,
-            "z": 3.4
-        },
-        "G4": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 41.38,
-            "y": 20.1,
-            "z": 3.4
-        },
-        "H4": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 41.38,
-            "y": 11.1,
-            "z": 3.4
-        },
-        "A5": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 50.38,
-            "y": 74.1,
-            "z": 3.4
-        },
-        "B5": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 50.38,
-            "y": 65.1,
-            "z": 3.4
-        },
-        "C5": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 50.38,
-            "y": 56.1,
-            "z": 3.4
-        },
-        "D5": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 50.38,
-            "y": 47.1,
-            "z": 3.4
-        },
-        "E5": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 50.38,
-            "y": 38.1,
-            "z": 3.4
-        },
-        "F5": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 50.38,
-            "y": 29.1,
-            "z": 3.4
-        },
-        "G5": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 50.38,
-            "y": 20.1,
-            "z": 3.4
-        },
-        "H5": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 50.38,
-            "y": 11.1,
-            "z": 3.4
-        },
-        "A6": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 59.38,
-            "y": 74.1,
-            "z": 3.4
-        },
-        "B6": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 59.38,
-            "y": 65.1,
-            "z": 3.4
-        },
-        "C6": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 59.38,
-            "y": 56.1,
-            "z": 3.4
-        },
-        "D6": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 59.38,
-            "y": 47.1,
-            "z": 3.4
-        },
-        "E6": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 59.38,
-            "y": 38.1,
-            "z": 3.4
-        },
-        "F6": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 59.38,
-            "y": 29.1,
-            "z": 3.4
-        },
-        "G6": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 59.38,
-            "y": 20.1,
-            "z": 3.4
-        },
-        "H6": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 59.38,
-            "y": 11.1,
-            "z": 3.4
-        },
-        "A7": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 68.38,
-            "y": 74.1,
-            "z": 3.4
-        },
-        "B7": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 68.38,
-            "y": 65.1,
-            "z": 3.4
-        },
-        "C7": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 68.38,
-            "y": 56.1,
-            "z": 3.4
-        },
-        "D7": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 68.38,
-            "y": 47.1,
-            "z": 3.4
-        },
-        "E7": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 68.38,
-            "y": 38.1,
-            "z": 3.4
-        },
-        "F7": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 68.38,
-            "y": 29.1,
-            "z": 3.4
-        },
-        "G7": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 68.38,
-            "y": 20.1,
-            "z": 3.4
-        },
-        "H7": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 68.38,
-            "y": 11.1,
-            "z": 3.4
-        },
-        "A8": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 77.38,
-            "y": 74.1,
-            "z": 3.4
-        },
-        "B8": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 77.38,
-            "y": 65.1,
-            "z": 3.4
-        },
-        "C8": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 77.38,
-            "y": 56.1,
-            "z": 3.4
-        },
-        "D8": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 77.38,
-            "y": 47.1,
-            "z": 3.4
-        },
-        "E8": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 77.38,
-            "y": 38.1,
-            "z": 3.4
-        },
-        "F8": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 77.38,
-            "y": 29.1,
-            "z": 3.4
-        },
-        "G8": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 77.38,
-            "y": 20.1,
-            "z": 3.4
-        },
-        "H8": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 77.38,
-            "y": 11.1,
-            "z": 3.4
-        },
-        "A9": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 86.38,
-            "y": 74.1,
-            "z": 3.4
-        },
-        "B9": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 86.38,
-            "y": 65.1,
-            "z": 3.4
-        },
-        "C9": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 86.38,
-            "y": 56.1,
-            "z": 3.4
-        },
-        "D9": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 86.38,
-            "y": 47.1,
-            "z": 3.4
-        },
-        "E9": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 86.38,
-            "y": 38.1,
-            "z": 3.4
-        },
-        "F9": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 86.38,
-            "y": 29.1,
-            "z": 3.4
-        },
-        "G9": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 86.38,
-            "y": 20.1,
-            "z": 3.4
-        },
-        "H9": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 86.38,
-            "y": 11.1,
-            "z": 3.4
-        },
-        "A10": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 95.38,
-            "y": 74.1,
-            "z": 3.4
-        },
-        "B10": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 95.38,
-            "y": 65.1,
-            "z": 3.4
-        },
-        "C10": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 95.38,
-            "y": 56.1,
-            "z": 3.4
-        },
-        "D10": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 95.38,
-            "y": 47.1,
-            "z": 3.4
-        },
-        "E10": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 95.38,
-            "y": 38.1,
-            "z": 3.4
-        },
-        "F10": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 95.38,
-            "y": 29.1,
-            "z": 3.4
-        },
-        "G10": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 95.38,
-            "y": 20.1,
-            "z": 3.4
-        },
-        "H10": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 95.38,
-            "y": 11.1,
-            "z": 3.4
-        },
-        "A11": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 104.38,
-            "y": 74.1,
-            "z": 3.4
-        },
-        "B11": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 104.38,
-            "y": 65.1,
-            "z": 3.4
-        },
-        "C11": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 104.38,
-            "y": 56.1,
-            "z": 3.4
-        },
-        "D11": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 104.38,
-            "y": 47.1,
-            "z": 3.4
-        },
-        "E11": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 104.38,
-            "y": 38.1,
-            "z": 3.4
-        },
-        "F11": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 104.38,
-            "y": 29.1,
-            "z": 3.4
-        },
-        "G11": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 104.38,
-            "y": 20.1,
-            "z": 3.4
-        },
-        "H11": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 104.38,
-            "y": 11.1,
-            "z": 3.4
-        },
-        "A12": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 113.38,
-            "y": 74.1,
-            "z": 3.4
-        },
-        "B12": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 113.38,
-            "y": 65.1,
-            "z": 3.4
-        },
-        "C12": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 113.38,
-            "y": 56.1,
-            "z": 3.4
-        },
-        "D12": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 113.38,
-            "y": 47.1,
-            "z": 3.4
-        },
-        "E12": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 113.38,
-            "y": 38.1,
-            "z": 3.4
-        },
-        "F12": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 113.38,
-            "y": 29.1,
-            "z": 3.4
-        },
-        "G12": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 113.38,
-            "y": 20.1,
-            "z": 3.4
-        },
-        "H12": {
-            "depth": 95.6,
-            "totalLiquidVolume": 1000,
-            "shape": "circular",
-            "diameter": 5.47,
-            "x": 113.38,
-            "y": 11.1,
-            "z": 3.4
-        }
+    "D1": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 14.38,
+      "y": 47.1,
+      "z": 3.4
     },
-    "groups": [
-        {
-            "metadata": {},
-            "wells": [
-                "A1",
-                "B1",
-                "C1",
-                "D1",
-                "E1",
-                "F1",
-                "G1",
-                "H1",
-                "A2",
-                "B2",
-                "C2",
-                "D2",
-                "E2",
-                "F2",
-                "G2",
-                "H2",
-                "A3",
-                "B3",
-                "C3",
-                "D3",
-                "E3",
-                "F3",
-                "G3",
-                "H3",
-                "A4",
-                "B4",
-                "C4",
-                "D4",
-                "E4",
-                "F4",
-                "G4",
-                "H4",
-                "A5",
-                "B5",
-                "C5",
-                "D5",
-                "E5",
-                "F5",
-                "G5",
-                "H5",
-                "A6",
-                "B6",
-                "C6",
-                "D6",
-                "E6",
-                "F6",
-                "G6",
-                "H6",
-                "A7",
-                "B7",
-                "C7",
-                "D7",
-                "E7",
-                "F7",
-                "G7",
-                "H7",
-                "A8",
-                "B8",
-                "C8",
-                "D8",
-                "E8",
-                "F8",
-                "G8",
-                "H8",
-                "A9",
-                "B9",
-                "C9",
-                "D9",
-                "E9",
-                "F9",
-                "G9",
-                "H9",
-                "A10",
-                "B10",
-                "C10",
-                "D10",
-                "E10",
-                "F10",
-                "G10",
-                "H10",
-                "A11",
-                "B11",
-                "C11",
-                "D11",
-                "E11",
-                "F11",
-                "G11",
-                "H11",
-                "A12",
-                "B12",
-                "C12",
-                "D12",
-                "E12",
-                "F12",
-                "G12",
-                "H12"
-            ]
-        }
-    ],
-    "parameters": {
-        "format": "96Standard",
-        "quirks": [],
-        "isTiprack": true,
-        "tipLength": 95.6,
-        "tipOverlap": 10.5,
-        "isMagneticModuleCompatible": false,
-        "loadName": "opentrons_ot3_96_tiprack_1000ul"
+    "E1": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 14.38,
+      "y": 38.1,
+      "z": 3.4
     },
-    "namespace": "opentrons",
-    "version": 1,
-    "schemaVersion": 2,
-    "cornerOffsetFromSlot": {
-        "x": 0,
-        "y": 0,
-        "z": 0
+    "F1": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 14.38,
+      "y": 29.1,
+      "z": 3.4
+    },
+    "G1": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 14.38,
+      "y": 20.1,
+      "z": 3.4
+    },
+    "H1": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 14.38,
+      "y": 11.1,
+      "z": 3.4
+    },
+    "A2": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 23.38,
+      "y": 74.1,
+      "z": 3.4
+    },
+    "B2": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 23.38,
+      "y": 65.1,
+      "z": 3.4
+    },
+    "C2": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 23.38,
+      "y": 56.1,
+      "z": 3.4
+    },
+    "D2": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 23.38,
+      "y": 47.1,
+      "z": 3.4
+    },
+    "E2": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 23.38,
+      "y": 38.1,
+      "z": 3.4
+    },
+    "F2": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 23.38,
+      "y": 29.1,
+      "z": 3.4
+    },
+    "G2": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 23.38,
+      "y": 20.1,
+      "z": 3.4
+    },
+    "H2": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 23.38,
+      "y": 11.1,
+      "z": 3.4
+    },
+    "A3": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 32.38,
+      "y": 74.1,
+      "z": 3.4
+    },
+    "B3": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 32.38,
+      "y": 65.1,
+      "z": 3.4
+    },
+    "C3": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 32.38,
+      "y": 56.1,
+      "z": 3.4
+    },
+    "D3": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 32.38,
+      "y": 47.1,
+      "z": 3.4
+    },
+    "E3": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 32.38,
+      "y": 38.1,
+      "z": 3.4
+    },
+    "F3": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 32.38,
+      "y": 29.1,
+      "z": 3.4
+    },
+    "G3": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 32.38,
+      "y": 20.1,
+      "z": 3.4
+    },
+    "H3": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 32.38,
+      "y": 11.1,
+      "z": 3.4
+    },
+    "A4": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 41.38,
+      "y": 74.1,
+      "z": 3.4
+    },
+    "B4": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 41.38,
+      "y": 65.1,
+      "z": 3.4
+    },
+    "C4": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 41.38,
+      "y": 56.1,
+      "z": 3.4
+    },
+    "D4": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 41.38,
+      "y": 47.1,
+      "z": 3.4
+    },
+    "E4": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 41.38,
+      "y": 38.1,
+      "z": 3.4
+    },
+    "F4": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 41.38,
+      "y": 29.1,
+      "z": 3.4
+    },
+    "G4": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 41.38,
+      "y": 20.1,
+      "z": 3.4
+    },
+    "H4": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 41.38,
+      "y": 11.1,
+      "z": 3.4
+    },
+    "A5": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 50.38,
+      "y": 74.1,
+      "z": 3.4
+    },
+    "B5": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 50.38,
+      "y": 65.1,
+      "z": 3.4
+    },
+    "C5": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 50.38,
+      "y": 56.1,
+      "z": 3.4
+    },
+    "D5": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 50.38,
+      "y": 47.1,
+      "z": 3.4
+    },
+    "E5": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 50.38,
+      "y": 38.1,
+      "z": 3.4
+    },
+    "F5": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 50.38,
+      "y": 29.1,
+      "z": 3.4
+    },
+    "G5": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 50.38,
+      "y": 20.1,
+      "z": 3.4
+    },
+    "H5": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 50.38,
+      "y": 11.1,
+      "z": 3.4
+    },
+    "A6": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 59.38,
+      "y": 74.1,
+      "z": 3.4
+    },
+    "B6": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 59.38,
+      "y": 65.1,
+      "z": 3.4
+    },
+    "C6": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 59.38,
+      "y": 56.1,
+      "z": 3.4
+    },
+    "D6": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 59.38,
+      "y": 47.1,
+      "z": 3.4
+    },
+    "E6": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 59.38,
+      "y": 38.1,
+      "z": 3.4
+    },
+    "F6": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 59.38,
+      "y": 29.1,
+      "z": 3.4
+    },
+    "G6": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 59.38,
+      "y": 20.1,
+      "z": 3.4
+    },
+    "H6": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 59.38,
+      "y": 11.1,
+      "z": 3.4
+    },
+    "A7": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 68.38,
+      "y": 74.1,
+      "z": 3.4
+    },
+    "B7": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 68.38,
+      "y": 65.1,
+      "z": 3.4
+    },
+    "C7": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 68.38,
+      "y": 56.1,
+      "z": 3.4
+    },
+    "D7": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 68.38,
+      "y": 47.1,
+      "z": 3.4
+    },
+    "E7": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 68.38,
+      "y": 38.1,
+      "z": 3.4
+    },
+    "F7": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 68.38,
+      "y": 29.1,
+      "z": 3.4
+    },
+    "G7": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 68.38,
+      "y": 20.1,
+      "z": 3.4
+    },
+    "H7": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 68.38,
+      "y": 11.1,
+      "z": 3.4
+    },
+    "A8": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 77.38,
+      "y": 74.1,
+      "z": 3.4
+    },
+    "B8": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 77.38,
+      "y": 65.1,
+      "z": 3.4
+    },
+    "C8": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 77.38,
+      "y": 56.1,
+      "z": 3.4
+    },
+    "D8": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 77.38,
+      "y": 47.1,
+      "z": 3.4
+    },
+    "E8": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 77.38,
+      "y": 38.1,
+      "z": 3.4
+    },
+    "F8": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 77.38,
+      "y": 29.1,
+      "z": 3.4
+    },
+    "G8": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 77.38,
+      "y": 20.1,
+      "z": 3.4
+    },
+    "H8": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 77.38,
+      "y": 11.1,
+      "z": 3.4
+    },
+    "A9": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 86.38,
+      "y": 74.1,
+      "z": 3.4
+    },
+    "B9": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 86.38,
+      "y": 65.1,
+      "z": 3.4
+    },
+    "C9": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 86.38,
+      "y": 56.1,
+      "z": 3.4
+    },
+    "D9": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 86.38,
+      "y": 47.1,
+      "z": 3.4
+    },
+    "E9": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 86.38,
+      "y": 38.1,
+      "z": 3.4
+    },
+    "F9": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 86.38,
+      "y": 29.1,
+      "z": 3.4
+    },
+    "G9": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 86.38,
+      "y": 20.1,
+      "z": 3.4
+    },
+    "H9": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 86.38,
+      "y": 11.1,
+      "z": 3.4
+    },
+    "A10": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 95.38,
+      "y": 74.1,
+      "z": 3.4
+    },
+    "B10": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 95.38,
+      "y": 65.1,
+      "z": 3.4
+    },
+    "C10": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 95.38,
+      "y": 56.1,
+      "z": 3.4
+    },
+    "D10": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 95.38,
+      "y": 47.1,
+      "z": 3.4
+    },
+    "E10": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 95.38,
+      "y": 38.1,
+      "z": 3.4
+    },
+    "F10": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 95.38,
+      "y": 29.1,
+      "z": 3.4
+    },
+    "G10": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 95.38,
+      "y": 20.1,
+      "z": 3.4
+    },
+    "H10": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 95.38,
+      "y": 11.1,
+      "z": 3.4
+    },
+    "A11": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 104.38,
+      "y": 74.1,
+      "z": 3.4
+    },
+    "B11": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 104.38,
+      "y": 65.1,
+      "z": 3.4
+    },
+    "C11": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 104.38,
+      "y": 56.1,
+      "z": 3.4
+    },
+    "D11": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 104.38,
+      "y": 47.1,
+      "z": 3.4
+    },
+    "E11": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 104.38,
+      "y": 38.1,
+      "z": 3.4
+    },
+    "F11": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 104.38,
+      "y": 29.1,
+      "z": 3.4
+    },
+    "G11": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 104.38,
+      "y": 20.1,
+      "z": 3.4
+    },
+    "H11": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 104.38,
+      "y": 11.1,
+      "z": 3.4
+    },
+    "A12": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 113.38,
+      "y": 74.1,
+      "z": 3.4
+    },
+    "B12": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 113.38,
+      "y": 65.1,
+      "z": 3.4
+    },
+    "C12": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 113.38,
+      "y": 56.1,
+      "z": 3.4
+    },
+    "D12": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 113.38,
+      "y": 47.1,
+      "z": 3.4
+    },
+    "E12": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 113.38,
+      "y": 38.1,
+      "z": 3.4
+    },
+    "F12": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 113.38,
+      "y": 29.1,
+      "z": 3.4
+    },
+    "G12": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 113.38,
+      "y": 20.1,
+      "z": 3.4
+    },
+    "H12": {
+      "depth": 95.6,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 5.47,
+      "x": 113.38,
+      "y": 11.1,
+      "z": 3.4
     }
+  },
+  "groups": [
+    {
+      "metadata": {},
+      "wells": [
+        "A1",
+        "B1",
+        "C1",
+        "D1",
+        "E1",
+        "F1",
+        "G1",
+        "H1",
+        "A2",
+        "B2",
+        "C2",
+        "D2",
+        "E2",
+        "F2",
+        "G2",
+        "H2",
+        "A3",
+        "B3",
+        "C3",
+        "D3",
+        "E3",
+        "F3",
+        "G3",
+        "H3",
+        "A4",
+        "B4",
+        "C4",
+        "D4",
+        "E4",
+        "F4",
+        "G4",
+        "H4",
+        "A5",
+        "B5",
+        "C5",
+        "D5",
+        "E5",
+        "F5",
+        "G5",
+        "H5",
+        "A6",
+        "B6",
+        "C6",
+        "D6",
+        "E6",
+        "F6",
+        "G6",
+        "H6",
+        "A7",
+        "B7",
+        "C7",
+        "D7",
+        "E7",
+        "F7",
+        "G7",
+        "H7",
+        "A8",
+        "B8",
+        "C8",
+        "D8",
+        "E8",
+        "F8",
+        "G8",
+        "H8",
+        "A9",
+        "B9",
+        "C9",
+        "D9",
+        "E9",
+        "F9",
+        "G9",
+        "H9",
+        "A10",
+        "B10",
+        "C10",
+        "D10",
+        "E10",
+        "F10",
+        "G10",
+        "H10",
+        "A11",
+        "B11",
+        "C11",
+        "D11",
+        "E11",
+        "F11",
+        "G11",
+        "H11",
+        "A12",
+        "B12",
+        "C12",
+        "D12",
+        "E12",
+        "F12",
+        "G12",
+        "H12"
+      ]
+    }
+  ],
+  "parameters": {
+    "format": "96Standard",
+    "quirks": [],
+    "isTiprack": true,
+    "tipLength": 95.6,
+    "tipOverlap": 10.5,
+    "isMagneticModuleCompatible": false,
+    "loadName": "opentrons_ot3_96_tiprack_1000ul"
+  },
+  "namespace": "opentrons",
+  "version": 1,
+  "schemaVersion": 2,
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  }
 }

--- a/shared-data/labware/definitions/2/opentrons_ot3_96_tiprack_200ul/1.json
+++ b/shared-data/labware/definitions/2/opentrons_ot3_96_tiprack_200ul/1.json
@@ -1,1125 +1,1017 @@
 {
-    "ordering": [
-        [
-            "A1",
-            "B1",
-            "C1",
-            "D1",
-            "E1",
-            "F1",
-            "G1",
-            "H1"
-        ],
-        [
-            "A2",
-            "B2",
-            "C2",
-            "D2",
-            "E2",
-            "F2",
-            "G2",
-            "H2"
-        ],
-        [
-            "A3",
-            "B3",
-            "C3",
-            "D3",
-            "E3",
-            "F3",
-            "G3",
-            "H3"
-        ],
-        [
-            "A4",
-            "B4",
-            "C4",
-            "D4",
-            "E4",
-            "F4",
-            "G4",
-            "H4"
-        ],
-        [
-            "A5",
-            "B5",
-            "C5",
-            "D5",
-            "E5",
-            "F5",
-            "G5",
-            "H5"
-        ],
-        [
-            "A6",
-            "B6",
-            "C6",
-            "D6",
-            "E6",
-            "F6",
-            "G6",
-            "H6"
-        ],
-        [
-            "A7",
-            "B7",
-            "C7",
-            "D7",
-            "E7",
-            "F7",
-            "G7",
-            "H7"
-        ],
-        [
-            "A8",
-            "B8",
-            "C8",
-            "D8",
-            "E8",
-            "F8",
-            "G8",
-            "H8"
-        ],
-        [
-            "A9",
-            "B9",
-            "C9",
-            "D9",
-            "E9",
-            "F9",
-            "G9",
-            "H9"
-        ],
-        [
-            "A10",
-            "B10",
-            "C10",
-            "D10",
-            "E10",
-            "F10",
-            "G10",
-            "H10"
-        ],
-        [
-            "A11",
-            "B11",
-            "C11",
-            "D11",
-            "E11",
-            "F11",
-            "G11",
-            "H11"
-        ],
-        [
-            "A12",
-            "B12",
-            "C12",
-            "D12",
-            "E12",
-            "F12",
-            "G12",
-            "H12"
-        ]
-    ],
-    "brand": {
-        "brand": "opentrons OT-3",
-        "brandId": []
+  "ordering": [
+    ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
+    ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
+    ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
+    ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
+    ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
+    ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
+    ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
+    ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
+    ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
+    ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
+    ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
+    ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
+  ],
+  "brand": {
+    "brand": "opentrons OT-3",
+    "brandId": []
+  },
+  "metadata": {
+    "displayName": "Opentrons OT-3 96 Tip Rack 200 µL",
+    "displayCategory": "tipRack",
+    "displayVolumeUnits": "µL",
+    "tags": []
+  },
+  "dimensions": {
+    "xDimension": 127.76,
+    "yDimension": 85.48,
+    "zDimension": 99
+  },
+  "wells": {
+    "A1": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 14.38,
+      "y": 74.1,
+      "z": 40.65
     },
-    "metadata": {
-        "displayName": "Opentrons OT-3 96 Tip Rack 200 µL",
-        "displayCategory": "tipRack",
-        "displayVolumeUnits": "µL",
-        "tags": []
+    "B1": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 14.38,
+      "y": 65.1,
+      "z": 40.65
     },
-    "dimensions": {
-        "xDimension": 127.76,
-        "yDimension": 85.48,
-        "zDimension": 99
+    "C1": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 14.38,
+      "y": 56.1,
+      "z": 40.65
     },
-    "wells": {
-        "A1": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 14.38,
-            "y": 74.1,
-            "z": 40.65
-        },
-        "B1": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 14.38,
-            "y": 65.1,
-            "z": 40.65
-        },
-        "C1": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 14.38,
-            "y": 56.1,
-            "z": 40.65
-        },
-        "D1": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 14.38,
-            "y": 47.1,
-            "z": 40.65
-        },
-        "E1": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 14.38,
-            "y": 38.1,
-            "z": 40.65
-        },
-        "F1": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 14.38,
-            "y": 29.1,
-            "z": 40.65
-        },
-        "G1": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 14.38,
-            "y": 20.1,
-            "z": 40.65
-        },
-        "H1": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 14.38,
-            "y": 11.1,
-            "z": 40.65
-        },
-        "A2": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 23.38,
-            "y": 74.1,
-            "z": 40.65
-        },
-        "B2": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 23.38,
-            "y": 65.1,
-            "z": 40.65
-        },
-        "C2": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 23.38,
-            "y": 56.1,
-            "z": 40.65
-        },
-        "D2": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 23.38,
-            "y": 47.1,
-            "z": 40.65
-        },
-        "E2": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 23.38,
-            "y": 38.1,
-            "z": 40.65
-        },
-        "F2": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 23.38,
-            "y": 29.1,
-            "z": 40.65
-        },
-        "G2": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 23.38,
-            "y": 20.1,
-            "z": 40.65
-        },
-        "H2": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 23.38,
-            "y": 11.1,
-            "z": 40.65
-        },
-        "A3": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 32.38,
-            "y": 74.1,
-            "z": 40.65
-        },
-        "B3": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 32.38,
-            "y": 65.1,
-            "z": 40.65
-        },
-        "C3": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 32.38,
-            "y": 56.1,
-            "z": 40.65
-        },
-        "D3": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 32.38,
-            "y": 47.1,
-            "z": 40.65
-        },
-        "E3": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 32.38,
-            "y": 38.1,
-            "z": 40.65
-        },
-        "F3": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 32.38,
-            "y": 29.1,
-            "z": 40.65
-        },
-        "G3": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 32.38,
-            "y": 20.1,
-            "z": 40.65
-        },
-        "H3": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 32.38,
-            "y": 11.1,
-            "z": 40.65
-        },
-        "A4": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 41.38,
-            "y": 74.1,
-            "z": 40.65
-        },
-        "B4": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 41.38,
-            "y": 65.1,
-            "z": 40.65
-        },
-        "C4": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 41.38,
-            "y": 56.1,
-            "z": 40.65
-        },
-        "D4": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 41.38,
-            "y": 47.1,
-            "z": 40.65
-        },
-        "E4": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 41.38,
-            "y": 38.1,
-            "z": 40.65
-        },
-        "F4": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 41.38,
-            "y": 29.1,
-            "z": 40.65
-        },
-        "G4": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 41.38,
-            "y": 20.1,
-            "z": 40.65
-        },
-        "H4": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 41.38,
-            "y": 11.1,
-            "z": 40.65
-        },
-        "A5": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 50.38,
-            "y": 74.1,
-            "z": 40.65
-        },
-        "B5": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 50.38,
-            "y": 65.1,
-            "z": 40.65
-        },
-        "C5": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 50.38,
-            "y": 56.1,
-            "z": 40.65
-        },
-        "D5": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 50.38,
-            "y": 47.1,
-            "z": 40.65
-        },
-        "E5": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 50.38,
-            "y": 38.1,
-            "z": 40.65
-        },
-        "F5": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 50.38,
-            "y": 29.1,
-            "z": 40.65
-        },
-        "G5": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 50.38,
-            "y": 20.1,
-            "z": 40.65
-        },
-        "H5": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 50.38,
-            "y": 11.1,
-            "z": 40.65
-        },
-        "A6": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 59.38,
-            "y": 74.1,
-            "z": 40.65
-        },
-        "B6": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 59.38,
-            "y": 65.1,
-            "z": 40.65
-        },
-        "C6": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 59.38,
-            "y": 56.1,
-            "z": 40.65
-        },
-        "D6": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 59.38,
-            "y": 47.1,
-            "z": 40.65
-        },
-        "E6": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 59.38,
-            "y": 38.1,
-            "z": 40.65
-        },
-        "F6": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 59.38,
-            "y": 29.1,
-            "z": 40.65
-        },
-        "G6": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 59.38,
-            "y": 20.1,
-            "z": 40.65
-        },
-        "H6": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 59.38,
-            "y": 11.1,
-            "z": 40.65
-        },
-        "A7": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 68.38,
-            "y": 74.1,
-            "z": 40.65
-        },
-        "B7": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 68.38,
-            "y": 65.1,
-            "z": 40.65
-        },
-        "C7": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 68.38,
-            "y": 56.1,
-            "z": 40.65
-        },
-        "D7": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 68.38,
-            "y": 47.1,
-            "z": 40.65
-        },
-        "E7": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 68.38,
-            "y": 38.1,
-            "z": 40.65
-        },
-        "F7": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 68.38,
-            "y": 29.1,
-            "z": 40.65
-        },
-        "G7": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 68.38,
-            "y": 20.1,
-            "z": 40.65
-        },
-        "H7": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 68.38,
-            "y": 11.1,
-            "z": 40.65
-        },
-        "A8": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 77.38,
-            "y": 74.1,
-            "z": 40.65
-        },
-        "B8": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 77.38,
-            "y": 65.1,
-            "z": 40.65
-        },
-        "C8": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 77.38,
-            "y": 56.1,
-            "z": 40.65
-        },
-        "D8": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 77.38,
-            "y": 47.1,
-            "z": 40.65
-        },
-        "E8": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 77.38,
-            "y": 38.1,
-            "z": 40.65
-        },
-        "F8": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 77.38,
-            "y": 29.1,
-            "z": 40.65
-        },
-        "G8": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 77.38,
-            "y": 20.1,
-            "z": 40.65
-        },
-        "H8": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 77.38,
-            "y": 11.1,
-            "z": 40.65
-        },
-        "A9": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 86.38,
-            "y": 74.1,
-            "z": 40.65
-        },
-        "B9": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 86.38,
-            "y": 65.1,
-            "z": 40.65
-        },
-        "C9": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 86.38,
-            "y": 56.1,
-            "z": 40.65
-        },
-        "D9": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 86.38,
-            "y": 47.1,
-            "z": 40.65
-        },
-        "E9": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 86.38,
-            "y": 38.1,
-            "z": 40.65
-        },
-        "F9": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 86.38,
-            "y": 29.1,
-            "z": 40.65
-        },
-        "G9": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 86.38,
-            "y": 20.1,
-            "z": 40.65
-        },
-        "H9": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 86.38,
-            "y": 11.1,
-            "z": 40.65
-        },
-        "A10": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 95.38,
-            "y": 74.1,
-            "z": 40.65
-        },
-        "B10": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 95.38,
-            "y": 65.1,
-            "z": 40.65
-        },
-        "C10": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 95.38,
-            "y": 56.1,
-            "z": 40.65
-        },
-        "D10": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 95.38,
-            "y": 47.1,
-            "z": 40.65
-        },
-        "E10": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 95.38,
-            "y": 38.1,
-            "z": 40.65
-        },
-        "F10": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 95.38,
-            "y": 29.1,
-            "z": 40.65
-        },
-        "G10": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 95.38,
-            "y": 20.1,
-            "z": 40.65
-        },
-        "H10": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 95.38,
-            "y": 11.1,
-            "z": 40.65
-        },
-        "A11": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 104.38,
-            "y": 74.1,
-            "z": 40.65
-        },
-        "B11": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 104.38,
-            "y": 65.1,
-            "z": 40.65
-        },
-        "C11": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 104.38,
-            "y": 56.1,
-            "z": 40.65
-        },
-        "D11": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 104.38,
-            "y": 47.1,
-            "z": 40.65
-        },
-        "E11": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 104.38,
-            "y": 38.1,
-            "z": 40.65
-        },
-        "F11": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 104.38,
-            "y": 29.1,
-            "z": 40.65
-        },
-        "G11": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 104.38,
-            "y": 20.1,
-            "z": 40.65
-        },
-        "H11": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 104.38,
-            "y": 11.1,
-            "z": 40.65
-        },
-        "A12": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 113.38,
-            "y": 74.1,
-            "z": 40.65
-        },
-        "B12": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 113.38,
-            "y": 65.1,
-            "z": 40.65
-        },
-        "C12": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 113.38,
-            "y": 56.1,
-            "z": 40.65
-        },
-        "D12": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 113.38,
-            "y": 47.1,
-            "z": 40.65
-        },
-        "E12": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 113.38,
-            "y": 38.1,
-            "z": 40.65
-        },
-        "F12": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 113.38,
-            "y": 29.1,
-            "z": 40.65
-        },
-        "G12": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 113.38,
-            "y": 20.1,
-            "z": 40.65
-        },
-        "H12": {
-            "depth": 58.35,
-            "totalLiquidVolume": 200,
-            "shape": "circular",
-            "diameter": 5.59,
-            "x": 113.38,
-            "y": 11.1,
-            "z": 40.65
-        }
+    "D1": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 14.38,
+      "y": 47.1,
+      "z": 40.65
     },
-    "groups": [
-        {
-            "metadata": {},
-            "wells": [
-                "A1",
-                "B1",
-                "C1",
-                "D1",
-                "E1",
-                "F1",
-                "G1",
-                "H1",
-                "A2",
-                "B2",
-                "C2",
-                "D2",
-                "E2",
-                "F2",
-                "G2",
-                "H2",
-                "A3",
-                "B3",
-                "C3",
-                "D3",
-                "E3",
-                "F3",
-                "G3",
-                "H3",
-                "A4",
-                "B4",
-                "C4",
-                "D4",
-                "E4",
-                "F4",
-                "G4",
-                "H4",
-                "A5",
-                "B5",
-                "C5",
-                "D5",
-                "E5",
-                "F5",
-                "G5",
-                "H5",
-                "A6",
-                "B6",
-                "C6",
-                "D6",
-                "E6",
-                "F6",
-                "G6",
-                "H6",
-                "A7",
-                "B7",
-                "C7",
-                "D7",
-                "E7",
-                "F7",
-                "G7",
-                "H7",
-                "A8",
-                "B8",
-                "C8",
-                "D8",
-                "E8",
-                "F8",
-                "G8",
-                "H8",
-                "A9",
-                "B9",
-                "C9",
-                "D9",
-                "E9",
-                "F9",
-                "G9",
-                "H9",
-                "A10",
-                "B10",
-                "C10",
-                "D10",
-                "E10",
-                "F10",
-                "G10",
-                "H10",
-                "A11",
-                "B11",
-                "C11",
-                "D11",
-                "E11",
-                "F11",
-                "G11",
-                "H11",
-                "A12",
-                "B12",
-                "C12",
-                "D12",
-                "E12",
-                "F12",
-                "G12",
-                "H12"
-            ]
-        }
-    ],
-    "parameters": {
-        "format": "96Standard",
-        "quirks": [],
-        "isTiprack": true,
-        "tipLength": 58.35,
-        "tipOverlap": 10.5,
-        "isMagneticModuleCompatible": false,
-        "loadName": "opentrons_ot3_96_tiprack_200ul"
+    "E1": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 14.38,
+      "y": 38.1,
+      "z": 40.65
     },
-    "namespace": "opentrons",
-    "version": 1,
-    "schemaVersion": 2,
-    "cornerOffsetFromSlot": {
-        "x": 0,
-        "y": 0,
-        "z": 0
+    "F1": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 14.38,
+      "y": 29.1,
+      "z": 40.65
+    },
+    "G1": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 14.38,
+      "y": 20.1,
+      "z": 40.65
+    },
+    "H1": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 14.38,
+      "y": 11.1,
+      "z": 40.65
+    },
+    "A2": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 23.38,
+      "y": 74.1,
+      "z": 40.65
+    },
+    "B2": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 23.38,
+      "y": 65.1,
+      "z": 40.65
+    },
+    "C2": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 23.38,
+      "y": 56.1,
+      "z": 40.65
+    },
+    "D2": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 23.38,
+      "y": 47.1,
+      "z": 40.65
+    },
+    "E2": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 23.38,
+      "y": 38.1,
+      "z": 40.65
+    },
+    "F2": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 23.38,
+      "y": 29.1,
+      "z": 40.65
+    },
+    "G2": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 23.38,
+      "y": 20.1,
+      "z": 40.65
+    },
+    "H2": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 23.38,
+      "y": 11.1,
+      "z": 40.65
+    },
+    "A3": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 32.38,
+      "y": 74.1,
+      "z": 40.65
+    },
+    "B3": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 32.38,
+      "y": 65.1,
+      "z": 40.65
+    },
+    "C3": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 32.38,
+      "y": 56.1,
+      "z": 40.65
+    },
+    "D3": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 32.38,
+      "y": 47.1,
+      "z": 40.65
+    },
+    "E3": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 32.38,
+      "y": 38.1,
+      "z": 40.65
+    },
+    "F3": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 32.38,
+      "y": 29.1,
+      "z": 40.65
+    },
+    "G3": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 32.38,
+      "y": 20.1,
+      "z": 40.65
+    },
+    "H3": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 32.38,
+      "y": 11.1,
+      "z": 40.65
+    },
+    "A4": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 41.38,
+      "y": 74.1,
+      "z": 40.65
+    },
+    "B4": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 41.38,
+      "y": 65.1,
+      "z": 40.65
+    },
+    "C4": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 41.38,
+      "y": 56.1,
+      "z": 40.65
+    },
+    "D4": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 41.38,
+      "y": 47.1,
+      "z": 40.65
+    },
+    "E4": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 41.38,
+      "y": 38.1,
+      "z": 40.65
+    },
+    "F4": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 41.38,
+      "y": 29.1,
+      "z": 40.65
+    },
+    "G4": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 41.38,
+      "y": 20.1,
+      "z": 40.65
+    },
+    "H4": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 41.38,
+      "y": 11.1,
+      "z": 40.65
+    },
+    "A5": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 50.38,
+      "y": 74.1,
+      "z": 40.65
+    },
+    "B5": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 50.38,
+      "y": 65.1,
+      "z": 40.65
+    },
+    "C5": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 50.38,
+      "y": 56.1,
+      "z": 40.65
+    },
+    "D5": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 50.38,
+      "y": 47.1,
+      "z": 40.65
+    },
+    "E5": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 50.38,
+      "y": 38.1,
+      "z": 40.65
+    },
+    "F5": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 50.38,
+      "y": 29.1,
+      "z": 40.65
+    },
+    "G5": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 50.38,
+      "y": 20.1,
+      "z": 40.65
+    },
+    "H5": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 50.38,
+      "y": 11.1,
+      "z": 40.65
+    },
+    "A6": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 59.38,
+      "y": 74.1,
+      "z": 40.65
+    },
+    "B6": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 59.38,
+      "y": 65.1,
+      "z": 40.65
+    },
+    "C6": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 59.38,
+      "y": 56.1,
+      "z": 40.65
+    },
+    "D6": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 59.38,
+      "y": 47.1,
+      "z": 40.65
+    },
+    "E6": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 59.38,
+      "y": 38.1,
+      "z": 40.65
+    },
+    "F6": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 59.38,
+      "y": 29.1,
+      "z": 40.65
+    },
+    "G6": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 59.38,
+      "y": 20.1,
+      "z": 40.65
+    },
+    "H6": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 59.38,
+      "y": 11.1,
+      "z": 40.65
+    },
+    "A7": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 68.38,
+      "y": 74.1,
+      "z": 40.65
+    },
+    "B7": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 68.38,
+      "y": 65.1,
+      "z": 40.65
+    },
+    "C7": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 68.38,
+      "y": 56.1,
+      "z": 40.65
+    },
+    "D7": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 68.38,
+      "y": 47.1,
+      "z": 40.65
+    },
+    "E7": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 68.38,
+      "y": 38.1,
+      "z": 40.65
+    },
+    "F7": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 68.38,
+      "y": 29.1,
+      "z": 40.65
+    },
+    "G7": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 68.38,
+      "y": 20.1,
+      "z": 40.65
+    },
+    "H7": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 68.38,
+      "y": 11.1,
+      "z": 40.65
+    },
+    "A8": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 77.38,
+      "y": 74.1,
+      "z": 40.65
+    },
+    "B8": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 77.38,
+      "y": 65.1,
+      "z": 40.65
+    },
+    "C8": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 77.38,
+      "y": 56.1,
+      "z": 40.65
+    },
+    "D8": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 77.38,
+      "y": 47.1,
+      "z": 40.65
+    },
+    "E8": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 77.38,
+      "y": 38.1,
+      "z": 40.65
+    },
+    "F8": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 77.38,
+      "y": 29.1,
+      "z": 40.65
+    },
+    "G8": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 77.38,
+      "y": 20.1,
+      "z": 40.65
+    },
+    "H8": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 77.38,
+      "y": 11.1,
+      "z": 40.65
+    },
+    "A9": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 86.38,
+      "y": 74.1,
+      "z": 40.65
+    },
+    "B9": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 86.38,
+      "y": 65.1,
+      "z": 40.65
+    },
+    "C9": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 86.38,
+      "y": 56.1,
+      "z": 40.65
+    },
+    "D9": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 86.38,
+      "y": 47.1,
+      "z": 40.65
+    },
+    "E9": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 86.38,
+      "y": 38.1,
+      "z": 40.65
+    },
+    "F9": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 86.38,
+      "y": 29.1,
+      "z": 40.65
+    },
+    "G9": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 86.38,
+      "y": 20.1,
+      "z": 40.65
+    },
+    "H9": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 86.38,
+      "y": 11.1,
+      "z": 40.65
+    },
+    "A10": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 95.38,
+      "y": 74.1,
+      "z": 40.65
+    },
+    "B10": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 95.38,
+      "y": 65.1,
+      "z": 40.65
+    },
+    "C10": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 95.38,
+      "y": 56.1,
+      "z": 40.65
+    },
+    "D10": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 95.38,
+      "y": 47.1,
+      "z": 40.65
+    },
+    "E10": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 95.38,
+      "y": 38.1,
+      "z": 40.65
+    },
+    "F10": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 95.38,
+      "y": 29.1,
+      "z": 40.65
+    },
+    "G10": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 95.38,
+      "y": 20.1,
+      "z": 40.65
+    },
+    "H10": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 95.38,
+      "y": 11.1,
+      "z": 40.65
+    },
+    "A11": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 104.38,
+      "y": 74.1,
+      "z": 40.65
+    },
+    "B11": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 104.38,
+      "y": 65.1,
+      "z": 40.65
+    },
+    "C11": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 104.38,
+      "y": 56.1,
+      "z": 40.65
+    },
+    "D11": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 104.38,
+      "y": 47.1,
+      "z": 40.65
+    },
+    "E11": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 104.38,
+      "y": 38.1,
+      "z": 40.65
+    },
+    "F11": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 104.38,
+      "y": 29.1,
+      "z": 40.65
+    },
+    "G11": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 104.38,
+      "y": 20.1,
+      "z": 40.65
+    },
+    "H11": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 104.38,
+      "y": 11.1,
+      "z": 40.65
+    },
+    "A12": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 113.38,
+      "y": 74.1,
+      "z": 40.65
+    },
+    "B12": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 113.38,
+      "y": 65.1,
+      "z": 40.65
+    },
+    "C12": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 113.38,
+      "y": 56.1,
+      "z": 40.65
+    },
+    "D12": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 113.38,
+      "y": 47.1,
+      "z": 40.65
+    },
+    "E12": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 113.38,
+      "y": 38.1,
+      "z": 40.65
+    },
+    "F12": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 113.38,
+      "y": 29.1,
+      "z": 40.65
+    },
+    "G12": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 113.38,
+      "y": 20.1,
+      "z": 40.65
+    },
+    "H12": {
+      "depth": 58.35,
+      "totalLiquidVolume": 200,
+      "shape": "circular",
+      "diameter": 5.59,
+      "x": 113.38,
+      "y": 11.1,
+      "z": 40.65
     }
+  },
+  "groups": [
+    {
+      "metadata": {},
+      "wells": [
+        "A1",
+        "B1",
+        "C1",
+        "D1",
+        "E1",
+        "F1",
+        "G1",
+        "H1",
+        "A2",
+        "B2",
+        "C2",
+        "D2",
+        "E2",
+        "F2",
+        "G2",
+        "H2",
+        "A3",
+        "B3",
+        "C3",
+        "D3",
+        "E3",
+        "F3",
+        "G3",
+        "H3",
+        "A4",
+        "B4",
+        "C4",
+        "D4",
+        "E4",
+        "F4",
+        "G4",
+        "H4",
+        "A5",
+        "B5",
+        "C5",
+        "D5",
+        "E5",
+        "F5",
+        "G5",
+        "H5",
+        "A6",
+        "B6",
+        "C6",
+        "D6",
+        "E6",
+        "F6",
+        "G6",
+        "H6",
+        "A7",
+        "B7",
+        "C7",
+        "D7",
+        "E7",
+        "F7",
+        "G7",
+        "H7",
+        "A8",
+        "B8",
+        "C8",
+        "D8",
+        "E8",
+        "F8",
+        "G8",
+        "H8",
+        "A9",
+        "B9",
+        "C9",
+        "D9",
+        "E9",
+        "F9",
+        "G9",
+        "H9",
+        "A10",
+        "B10",
+        "C10",
+        "D10",
+        "E10",
+        "F10",
+        "G10",
+        "H10",
+        "A11",
+        "B11",
+        "C11",
+        "D11",
+        "E11",
+        "F11",
+        "G11",
+        "H11",
+        "A12",
+        "B12",
+        "C12",
+        "D12",
+        "E12",
+        "F12",
+        "G12",
+        "H12"
+      ]
+    }
+  ],
+  "parameters": {
+    "format": "96Standard",
+    "quirks": [],
+    "isTiprack": true,
+    "tipLength": 58.35,
+    "tipOverlap": 10.5,
+    "isMagneticModuleCompatible": false,
+    "loadName": "opentrons_ot3_96_tiprack_200ul"
+  },
+  "namespace": "opentrons",
+  "version": 1,
+  "schemaVersion": 2,
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  }
 }

--- a/shared-data/labware/definitions/2/opentrons_ot3_96_tiprack_200ul/1.json
+++ b/shared-data/labware/definitions/2/opentrons_ot3_96_tiprack_200ul/1.json
@@ -1,0 +1,1125 @@
+{
+    "ordering": [
+        [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "E1",
+            "F1",
+            "G1",
+            "H1"
+        ],
+        [
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "E2",
+            "F2",
+            "G2",
+            "H2"
+        ],
+        [
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "E3",
+            "F3",
+            "G3",
+            "H3"
+        ],
+        [
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "E4",
+            "F4",
+            "G4",
+            "H4"
+        ],
+        [
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "E5",
+            "F5",
+            "G5",
+            "H5"
+        ],
+        [
+            "A6",
+            "B6",
+            "C6",
+            "D6",
+            "E6",
+            "F6",
+            "G6",
+            "H6"
+        ],
+        [
+            "A7",
+            "B7",
+            "C7",
+            "D7",
+            "E7",
+            "F7",
+            "G7",
+            "H7"
+        ],
+        [
+            "A8",
+            "B8",
+            "C8",
+            "D8",
+            "E8",
+            "F8",
+            "G8",
+            "H8"
+        ],
+        [
+            "A9",
+            "B9",
+            "C9",
+            "D9",
+            "E9",
+            "F9",
+            "G9",
+            "H9"
+        ],
+        [
+            "A10",
+            "B10",
+            "C10",
+            "D10",
+            "E10",
+            "F10",
+            "G10",
+            "H10"
+        ],
+        [
+            "A11",
+            "B11",
+            "C11",
+            "D11",
+            "E11",
+            "F11",
+            "G11",
+            "H11"
+        ],
+        [
+            "A12",
+            "B12",
+            "C12",
+            "D12",
+            "E12",
+            "F12",
+            "G12",
+            "H12"
+        ]
+    ],
+    "brand": {
+        "brand": "opentrons OT-3",
+        "brandId": []
+    },
+    "metadata": {
+        "displayName": "Opentrons OT-3 96 Tip Rack 200 µL",
+        "displayCategory": "tipRack",
+        "displayVolumeUnits": "µL",
+        "tags": []
+    },
+    "dimensions": {
+        "xDimension": 127.76,
+        "yDimension": 85.48,
+        "zDimension": 99
+    },
+    "wells": {
+        "A1": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 14.38,
+            "y": 74.1,
+            "z": 40.65
+        },
+        "B1": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 14.38,
+            "y": 65.1,
+            "z": 40.65
+        },
+        "C1": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 14.38,
+            "y": 56.1,
+            "z": 40.65
+        },
+        "D1": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 14.38,
+            "y": 47.1,
+            "z": 40.65
+        },
+        "E1": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 14.38,
+            "y": 38.1,
+            "z": 40.65
+        },
+        "F1": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 14.38,
+            "y": 29.1,
+            "z": 40.65
+        },
+        "G1": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 14.38,
+            "y": 20.1,
+            "z": 40.65
+        },
+        "H1": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 14.38,
+            "y": 11.1,
+            "z": 40.65
+        },
+        "A2": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 23.38,
+            "y": 74.1,
+            "z": 40.65
+        },
+        "B2": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 23.38,
+            "y": 65.1,
+            "z": 40.65
+        },
+        "C2": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 23.38,
+            "y": 56.1,
+            "z": 40.65
+        },
+        "D2": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 23.38,
+            "y": 47.1,
+            "z": 40.65
+        },
+        "E2": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 23.38,
+            "y": 38.1,
+            "z": 40.65
+        },
+        "F2": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 23.38,
+            "y": 29.1,
+            "z": 40.65
+        },
+        "G2": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 23.38,
+            "y": 20.1,
+            "z": 40.65
+        },
+        "H2": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 23.38,
+            "y": 11.1,
+            "z": 40.65
+        },
+        "A3": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 32.38,
+            "y": 74.1,
+            "z": 40.65
+        },
+        "B3": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 32.38,
+            "y": 65.1,
+            "z": 40.65
+        },
+        "C3": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 32.38,
+            "y": 56.1,
+            "z": 40.65
+        },
+        "D3": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 32.38,
+            "y": 47.1,
+            "z": 40.65
+        },
+        "E3": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 32.38,
+            "y": 38.1,
+            "z": 40.65
+        },
+        "F3": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 32.38,
+            "y": 29.1,
+            "z": 40.65
+        },
+        "G3": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 32.38,
+            "y": 20.1,
+            "z": 40.65
+        },
+        "H3": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 32.38,
+            "y": 11.1,
+            "z": 40.65
+        },
+        "A4": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 41.38,
+            "y": 74.1,
+            "z": 40.65
+        },
+        "B4": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 41.38,
+            "y": 65.1,
+            "z": 40.65
+        },
+        "C4": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 41.38,
+            "y": 56.1,
+            "z": 40.65
+        },
+        "D4": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 41.38,
+            "y": 47.1,
+            "z": 40.65
+        },
+        "E4": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 41.38,
+            "y": 38.1,
+            "z": 40.65
+        },
+        "F4": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 41.38,
+            "y": 29.1,
+            "z": 40.65
+        },
+        "G4": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 41.38,
+            "y": 20.1,
+            "z": 40.65
+        },
+        "H4": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 41.38,
+            "y": 11.1,
+            "z": 40.65
+        },
+        "A5": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 50.38,
+            "y": 74.1,
+            "z": 40.65
+        },
+        "B5": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 50.38,
+            "y": 65.1,
+            "z": 40.65
+        },
+        "C5": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 50.38,
+            "y": 56.1,
+            "z": 40.65
+        },
+        "D5": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 50.38,
+            "y": 47.1,
+            "z": 40.65
+        },
+        "E5": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 50.38,
+            "y": 38.1,
+            "z": 40.65
+        },
+        "F5": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 50.38,
+            "y": 29.1,
+            "z": 40.65
+        },
+        "G5": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 50.38,
+            "y": 20.1,
+            "z": 40.65
+        },
+        "H5": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 50.38,
+            "y": 11.1,
+            "z": 40.65
+        },
+        "A6": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 59.38,
+            "y": 74.1,
+            "z": 40.65
+        },
+        "B6": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 59.38,
+            "y": 65.1,
+            "z": 40.65
+        },
+        "C6": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 59.38,
+            "y": 56.1,
+            "z": 40.65
+        },
+        "D6": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 59.38,
+            "y": 47.1,
+            "z": 40.65
+        },
+        "E6": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 59.38,
+            "y": 38.1,
+            "z": 40.65
+        },
+        "F6": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 59.38,
+            "y": 29.1,
+            "z": 40.65
+        },
+        "G6": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 59.38,
+            "y": 20.1,
+            "z": 40.65
+        },
+        "H6": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 59.38,
+            "y": 11.1,
+            "z": 40.65
+        },
+        "A7": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 68.38,
+            "y": 74.1,
+            "z": 40.65
+        },
+        "B7": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 68.38,
+            "y": 65.1,
+            "z": 40.65
+        },
+        "C7": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 68.38,
+            "y": 56.1,
+            "z": 40.65
+        },
+        "D7": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 68.38,
+            "y": 47.1,
+            "z": 40.65
+        },
+        "E7": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 68.38,
+            "y": 38.1,
+            "z": 40.65
+        },
+        "F7": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 68.38,
+            "y": 29.1,
+            "z": 40.65
+        },
+        "G7": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 68.38,
+            "y": 20.1,
+            "z": 40.65
+        },
+        "H7": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 68.38,
+            "y": 11.1,
+            "z": 40.65
+        },
+        "A8": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 77.38,
+            "y": 74.1,
+            "z": 40.65
+        },
+        "B8": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 77.38,
+            "y": 65.1,
+            "z": 40.65
+        },
+        "C8": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 77.38,
+            "y": 56.1,
+            "z": 40.65
+        },
+        "D8": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 77.38,
+            "y": 47.1,
+            "z": 40.65
+        },
+        "E8": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 77.38,
+            "y": 38.1,
+            "z": 40.65
+        },
+        "F8": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 77.38,
+            "y": 29.1,
+            "z": 40.65
+        },
+        "G8": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 77.38,
+            "y": 20.1,
+            "z": 40.65
+        },
+        "H8": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 77.38,
+            "y": 11.1,
+            "z": 40.65
+        },
+        "A9": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 86.38,
+            "y": 74.1,
+            "z": 40.65
+        },
+        "B9": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 86.38,
+            "y": 65.1,
+            "z": 40.65
+        },
+        "C9": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 86.38,
+            "y": 56.1,
+            "z": 40.65
+        },
+        "D9": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 86.38,
+            "y": 47.1,
+            "z": 40.65
+        },
+        "E9": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 86.38,
+            "y": 38.1,
+            "z": 40.65
+        },
+        "F9": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 86.38,
+            "y": 29.1,
+            "z": 40.65
+        },
+        "G9": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 86.38,
+            "y": 20.1,
+            "z": 40.65
+        },
+        "H9": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 86.38,
+            "y": 11.1,
+            "z": 40.65
+        },
+        "A10": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 95.38,
+            "y": 74.1,
+            "z": 40.65
+        },
+        "B10": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 95.38,
+            "y": 65.1,
+            "z": 40.65
+        },
+        "C10": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 95.38,
+            "y": 56.1,
+            "z": 40.65
+        },
+        "D10": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 95.38,
+            "y": 47.1,
+            "z": 40.65
+        },
+        "E10": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 95.38,
+            "y": 38.1,
+            "z": 40.65
+        },
+        "F10": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 95.38,
+            "y": 29.1,
+            "z": 40.65
+        },
+        "G10": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 95.38,
+            "y": 20.1,
+            "z": 40.65
+        },
+        "H10": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 95.38,
+            "y": 11.1,
+            "z": 40.65
+        },
+        "A11": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 104.38,
+            "y": 74.1,
+            "z": 40.65
+        },
+        "B11": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 104.38,
+            "y": 65.1,
+            "z": 40.65
+        },
+        "C11": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 104.38,
+            "y": 56.1,
+            "z": 40.65
+        },
+        "D11": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 104.38,
+            "y": 47.1,
+            "z": 40.65
+        },
+        "E11": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 104.38,
+            "y": 38.1,
+            "z": 40.65
+        },
+        "F11": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 104.38,
+            "y": 29.1,
+            "z": 40.65
+        },
+        "G11": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 104.38,
+            "y": 20.1,
+            "z": 40.65
+        },
+        "H11": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 104.38,
+            "y": 11.1,
+            "z": 40.65
+        },
+        "A12": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 113.38,
+            "y": 74.1,
+            "z": 40.65
+        },
+        "B12": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 113.38,
+            "y": 65.1,
+            "z": 40.65
+        },
+        "C12": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 113.38,
+            "y": 56.1,
+            "z": 40.65
+        },
+        "D12": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 113.38,
+            "y": 47.1,
+            "z": 40.65
+        },
+        "E12": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 113.38,
+            "y": 38.1,
+            "z": 40.65
+        },
+        "F12": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 113.38,
+            "y": 29.1,
+            "z": 40.65
+        },
+        "G12": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 113.38,
+            "y": 20.1,
+            "z": 40.65
+        },
+        "H12": {
+            "depth": 58.35,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.59,
+            "x": 113.38,
+            "y": 11.1,
+            "z": 40.65
+        }
+    },
+    "groups": [
+        {
+            "metadata": {},
+            "wells": [
+                "A1",
+                "B1",
+                "C1",
+                "D1",
+                "E1",
+                "F1",
+                "G1",
+                "H1",
+                "A2",
+                "B2",
+                "C2",
+                "D2",
+                "E2",
+                "F2",
+                "G2",
+                "H2",
+                "A3",
+                "B3",
+                "C3",
+                "D3",
+                "E3",
+                "F3",
+                "G3",
+                "H3",
+                "A4",
+                "B4",
+                "C4",
+                "D4",
+                "E4",
+                "F4",
+                "G4",
+                "H4",
+                "A5",
+                "B5",
+                "C5",
+                "D5",
+                "E5",
+                "F5",
+                "G5",
+                "H5",
+                "A6",
+                "B6",
+                "C6",
+                "D6",
+                "E6",
+                "F6",
+                "G6",
+                "H6",
+                "A7",
+                "B7",
+                "C7",
+                "D7",
+                "E7",
+                "F7",
+                "G7",
+                "H7",
+                "A8",
+                "B8",
+                "C8",
+                "D8",
+                "E8",
+                "F8",
+                "G8",
+                "H8",
+                "A9",
+                "B9",
+                "C9",
+                "D9",
+                "E9",
+                "F9",
+                "G9",
+                "H9",
+                "A10",
+                "B10",
+                "C10",
+                "D10",
+                "E10",
+                "F10",
+                "G10",
+                "H10",
+                "A11",
+                "B11",
+                "C11",
+                "D11",
+                "E11",
+                "F11",
+                "G11",
+                "H11",
+                "A12",
+                "B12",
+                "C12",
+                "D12",
+                "E12",
+                "F12",
+                "G12",
+                "H12"
+            ]
+        }
+    ],
+    "parameters": {
+        "format": "96Standard",
+        "quirks": [],
+        "isTiprack": true,
+        "tipLength": 58.35,
+        "tipOverlap": 10.5,
+        "isMagneticModuleCompatible": false,
+        "loadName": "opentrons_ot3_96_tiprack_200ul"
+    },
+    "namespace": "opentrons",
+    "version": 1,
+    "schemaVersion": 2,
+    "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+    }
+}

--- a/shared-data/labware/definitions/2/opentrons_ot3_96_tiprack_50ul/1.json
+++ b/shared-data/labware/definitions/2/opentrons_ot3_96_tiprack_50ul/1.json
@@ -1,0 +1,1125 @@
+{
+    "ordering": [
+        [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "E1",
+            "F1",
+            "G1",
+            "H1"
+        ],
+        [
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "E2",
+            "F2",
+            "G2",
+            "H2"
+        ],
+        [
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "E3",
+            "F3",
+            "G3",
+            "H3"
+        ],
+        [
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "E4",
+            "F4",
+            "G4",
+            "H4"
+        ],
+        [
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "E5",
+            "F5",
+            "G5",
+            "H5"
+        ],
+        [
+            "A6",
+            "B6",
+            "C6",
+            "D6",
+            "E6",
+            "F6",
+            "G6",
+            "H6"
+        ],
+        [
+            "A7",
+            "B7",
+            "C7",
+            "D7",
+            "E7",
+            "F7",
+            "G7",
+            "H7"
+        ],
+        [
+            "A8",
+            "B8",
+            "C8",
+            "D8",
+            "E8",
+            "F8",
+            "G8",
+            "H8"
+        ],
+        [
+            "A9",
+            "B9",
+            "C9",
+            "D9",
+            "E9",
+            "F9",
+            "G9",
+            "H9"
+        ],
+        [
+            "A10",
+            "B10",
+            "C10",
+            "D10",
+            "E10",
+            "F10",
+            "G10",
+            "H10"
+        ],
+        [
+            "A11",
+            "B11",
+            "C11",
+            "D11",
+            "E11",
+            "F11",
+            "G11",
+            "H11"
+        ],
+        [
+            "A12",
+            "B12",
+            "C12",
+            "D12",
+            "E12",
+            "F12",
+            "G12",
+            "H12"
+        ]
+    ],
+    "brand": {
+        "brand": "opentrons OT-3",
+        "brandId": []
+    },
+    "metadata": {
+        "displayName": "Opentrons OT-3 96 Tip Rack 50 µL",
+        "displayCategory": "tipRack",
+        "displayVolumeUnits": "µL",
+        "tags": []
+    },
+    "dimensions": {
+        "xDimension": 127.76,
+        "yDimension": 85.48,
+        "zDimension": 99
+    },
+    "wells": {
+        "A1": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 14.38,
+            "y": 74.1,
+            "z": 41.1
+        },
+        "B1": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 14.38,
+            "y": 65.1,
+            "z": 41.1
+        },
+        "C1": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 14.38,
+            "y": 56.1,
+            "z": 41.1
+        },
+        "D1": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 14.38,
+            "y": 47.1,
+            "z": 41.1
+        },
+        "E1": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 14.38,
+            "y": 38.1,
+            "z": 41.1
+        },
+        "F1": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 14.38,
+            "y": 29.1,
+            "z": 41.1
+        },
+        "G1": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 14.38,
+            "y": 20.1,
+            "z": 41.1
+        },
+        "H1": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 14.38,
+            "y": 11.1,
+            "z": 41.1
+        },
+        "A2": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 23.38,
+            "y": 74.1,
+            "z": 41.1
+        },
+        "B2": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 23.38,
+            "y": 65.1,
+            "z": 41.1
+        },
+        "C2": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 23.38,
+            "y": 56.1,
+            "z": 41.1
+        },
+        "D2": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 23.38,
+            "y": 47.1,
+            "z": 41.1
+        },
+        "E2": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 23.38,
+            "y": 38.1,
+            "z": 41.1
+        },
+        "F2": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 23.38,
+            "y": 29.1,
+            "z": 41.1
+        },
+        "G2": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 23.38,
+            "y": 20.1,
+            "z": 41.1
+        },
+        "H2": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 23.38,
+            "y": 11.1,
+            "z": 41.1
+        },
+        "A3": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 32.38,
+            "y": 74.1,
+            "z": 41.1
+        },
+        "B3": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 32.38,
+            "y": 65.1,
+            "z": 41.1
+        },
+        "C3": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 32.38,
+            "y": 56.1,
+            "z": 41.1
+        },
+        "D3": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 32.38,
+            "y": 47.1,
+            "z": 41.1
+        },
+        "E3": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 32.38,
+            "y": 38.1,
+            "z": 41.1
+        },
+        "F3": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 32.38,
+            "y": 29.1,
+            "z": 41.1
+        },
+        "G3": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 32.38,
+            "y": 20.1,
+            "z": 41.1
+        },
+        "H3": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 32.38,
+            "y": 11.1,
+            "z": 41.1
+        },
+        "A4": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 41.38,
+            "y": 74.1,
+            "z": 41.1
+        },
+        "B4": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 41.38,
+            "y": 65.1,
+            "z": 41.1
+        },
+        "C4": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 41.38,
+            "y": 56.1,
+            "z": 41.1
+        },
+        "D4": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 41.38,
+            "y": 47.1,
+            "z": 41.1
+        },
+        "E4": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 41.38,
+            "y": 38.1,
+            "z": 41.1
+        },
+        "F4": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 41.38,
+            "y": 29.1,
+            "z": 41.1
+        },
+        "G4": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 41.38,
+            "y": 20.1,
+            "z": 41.1
+        },
+        "H4": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 41.38,
+            "y": 11.1,
+            "z": 41.1
+        },
+        "A5": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 50.38,
+            "y": 74.1,
+            "z": 41.1
+        },
+        "B5": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 50.38,
+            "y": 65.1,
+            "z": 41.1
+        },
+        "C5": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 50.38,
+            "y": 56.1,
+            "z": 41.1
+        },
+        "D5": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 50.38,
+            "y": 47.1,
+            "z": 41.1
+        },
+        "E5": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 50.38,
+            "y": 38.1,
+            "z": 41.1
+        },
+        "F5": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 50.38,
+            "y": 29.1,
+            "z": 41.1
+        },
+        "G5": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 50.38,
+            "y": 20.1,
+            "z": 41.1
+        },
+        "H5": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 50.38,
+            "y": 11.1,
+            "z": 41.1
+        },
+        "A6": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 59.38,
+            "y": 74.1,
+            "z": 41.1
+        },
+        "B6": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 59.38,
+            "y": 65.1,
+            "z": 41.1
+        },
+        "C6": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 59.38,
+            "y": 56.1,
+            "z": 41.1
+        },
+        "D6": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 59.38,
+            "y": 47.1,
+            "z": 41.1
+        },
+        "E6": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 59.38,
+            "y": 38.1,
+            "z": 41.1
+        },
+        "F6": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 59.38,
+            "y": 29.1,
+            "z": 41.1
+        },
+        "G6": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 59.38,
+            "y": 20.1,
+            "z": 41.1
+        },
+        "H6": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 59.38,
+            "y": 11.1,
+            "z": 41.1
+        },
+        "A7": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 68.38,
+            "y": 74.1,
+            "z": 41.1
+        },
+        "B7": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 68.38,
+            "y": 65.1,
+            "z": 41.1
+        },
+        "C7": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 68.38,
+            "y": 56.1,
+            "z": 41.1
+        },
+        "D7": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 68.38,
+            "y": 47.1,
+            "z": 41.1
+        },
+        "E7": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 68.38,
+            "y": 38.1,
+            "z": 41.1
+        },
+        "F7": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 68.38,
+            "y": 29.1,
+            "z": 41.1
+        },
+        "G7": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 68.38,
+            "y": 20.1,
+            "z": 41.1
+        },
+        "H7": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 68.38,
+            "y": 11.1,
+            "z": 41.1
+        },
+        "A8": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 77.38,
+            "y": 74.1,
+            "z": 41.1
+        },
+        "B8": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 77.38,
+            "y": 65.1,
+            "z": 41.1
+        },
+        "C8": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 77.38,
+            "y": 56.1,
+            "z": 41.1
+        },
+        "D8": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 77.38,
+            "y": 47.1,
+            "z": 41.1
+        },
+        "E8": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 77.38,
+            "y": 38.1,
+            "z": 41.1
+        },
+        "F8": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 77.38,
+            "y": 29.1,
+            "z": 41.1
+        },
+        "G8": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 77.38,
+            "y": 20.1,
+            "z": 41.1
+        },
+        "H8": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 77.38,
+            "y": 11.1,
+            "z": 41.1
+        },
+        "A9": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 86.38,
+            "y": 74.1,
+            "z": 41.1
+        },
+        "B9": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 86.38,
+            "y": 65.1,
+            "z": 41.1
+        },
+        "C9": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 86.38,
+            "y": 56.1,
+            "z": 41.1
+        },
+        "D9": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 86.38,
+            "y": 47.1,
+            "z": 41.1
+        },
+        "E9": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 86.38,
+            "y": 38.1,
+            "z": 41.1
+        },
+        "F9": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 86.38,
+            "y": 29.1,
+            "z": 41.1
+        },
+        "G9": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 86.38,
+            "y": 20.1,
+            "z": 41.1
+        },
+        "H9": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 86.38,
+            "y": 11.1,
+            "z": 41.1
+        },
+        "A10": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 95.38,
+            "y": 74.1,
+            "z": 41.1
+        },
+        "B10": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 95.38,
+            "y": 65.1,
+            "z": 41.1
+        },
+        "C10": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 95.38,
+            "y": 56.1,
+            "z": 41.1
+        },
+        "D10": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 95.38,
+            "y": 47.1,
+            "z": 41.1
+        },
+        "E10": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 95.38,
+            "y": 38.1,
+            "z": 41.1
+        },
+        "F10": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 95.38,
+            "y": 29.1,
+            "z": 41.1
+        },
+        "G10": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 95.38,
+            "y": 20.1,
+            "z": 41.1
+        },
+        "H10": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 95.38,
+            "y": 11.1,
+            "z": 41.1
+        },
+        "A11": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 104.38,
+            "y": 74.1,
+            "z": 41.1
+        },
+        "B11": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 104.38,
+            "y": 65.1,
+            "z": 41.1
+        },
+        "C11": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 104.38,
+            "y": 56.1,
+            "z": 41.1
+        },
+        "D11": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 104.38,
+            "y": 47.1,
+            "z": 41.1
+        },
+        "E11": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 104.38,
+            "y": 38.1,
+            "z": 41.1
+        },
+        "F11": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 104.38,
+            "y": 29.1,
+            "z": 41.1
+        },
+        "G11": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 104.38,
+            "y": 20.1,
+            "z": 41.1
+        },
+        "H11": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 104.38,
+            "y": 11.1,
+            "z": 41.1
+        },
+        "A12": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 113.38,
+            "y": 74.1,
+            "z": 41.1
+        },
+        "B12": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 113.38,
+            "y": 65.1,
+            "z": 41.1
+        },
+        "C12": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 113.38,
+            "y": 56.1,
+            "z": 41.1
+        },
+        "D12": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 113.38,
+            "y": 47.1,
+            "z": 41.1
+        },
+        "E12": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 113.38,
+            "y": 38.1,
+            "z": 41.1
+        },
+        "F12": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 113.38,
+            "y": 29.1,
+            "z": 41.1
+        },
+        "G12": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 113.38,
+            "y": 20.1,
+            "z": 41.1
+        },
+        "H12": {
+            "depth": 57.9,
+            "totalLiquidVolume": 50,
+            "shape": "circular",
+            "diameter": 5.58,
+            "x": 113.38,
+            "y": 11.1,
+            "z": 41.1
+        }
+    },
+    "groups": [
+        {
+            "metadata": {},
+            "wells": [
+                "A1",
+                "B1",
+                "C1",
+                "D1",
+                "E1",
+                "F1",
+                "G1",
+                "H1",
+                "A2",
+                "B2",
+                "C2",
+                "D2",
+                "E2",
+                "F2",
+                "G2",
+                "H2",
+                "A3",
+                "B3",
+                "C3",
+                "D3",
+                "E3",
+                "F3",
+                "G3",
+                "H3",
+                "A4",
+                "B4",
+                "C4",
+                "D4",
+                "E4",
+                "F4",
+                "G4",
+                "H4",
+                "A5",
+                "B5",
+                "C5",
+                "D5",
+                "E5",
+                "F5",
+                "G5",
+                "H5",
+                "A6",
+                "B6",
+                "C6",
+                "D6",
+                "E6",
+                "F6",
+                "G6",
+                "H6",
+                "A7",
+                "B7",
+                "C7",
+                "D7",
+                "E7",
+                "F7",
+                "G7",
+                "H7",
+                "A8",
+                "B8",
+                "C8",
+                "D8",
+                "E8",
+                "F8",
+                "G8",
+                "H8",
+                "A9",
+                "B9",
+                "C9",
+                "D9",
+                "E9",
+                "F9",
+                "G9",
+                "H9",
+                "A10",
+                "B10",
+                "C10",
+                "D10",
+                "E10",
+                "F10",
+                "G10",
+                "H10",
+                "A11",
+                "B11",
+                "C11",
+                "D11",
+                "E11",
+                "F11",
+                "G11",
+                "H11",
+                "A12",
+                "B12",
+                "C12",
+                "D12",
+                "E12",
+                "F12",
+                "G12",
+                "H12"
+            ]
+        }
+    ],
+    "parameters": {
+        "format": "96Standard",
+        "quirks": [],
+        "isTiprack": true,
+        "tipLength": 57.9,
+        "tipOverlap": 10.5,
+        "isMagneticModuleCompatible": false,
+        "loadName": "opentrons_ot3_96_tiprack_50ul"
+    },
+    "namespace": "opentrons",
+    "version": 1,
+    "schemaVersion": 2,
+    "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+    }
+}

--- a/shared-data/labware/definitions/2/opentrons_ot3_96_tiprack_50ul/1.json
+++ b/shared-data/labware/definitions/2/opentrons_ot3_96_tiprack_50ul/1.json
@@ -1,1125 +1,1017 @@
 {
-    "ordering": [
-        [
-            "A1",
-            "B1",
-            "C1",
-            "D1",
-            "E1",
-            "F1",
-            "G1",
-            "H1"
-        ],
-        [
-            "A2",
-            "B2",
-            "C2",
-            "D2",
-            "E2",
-            "F2",
-            "G2",
-            "H2"
-        ],
-        [
-            "A3",
-            "B3",
-            "C3",
-            "D3",
-            "E3",
-            "F3",
-            "G3",
-            "H3"
-        ],
-        [
-            "A4",
-            "B4",
-            "C4",
-            "D4",
-            "E4",
-            "F4",
-            "G4",
-            "H4"
-        ],
-        [
-            "A5",
-            "B5",
-            "C5",
-            "D5",
-            "E5",
-            "F5",
-            "G5",
-            "H5"
-        ],
-        [
-            "A6",
-            "B6",
-            "C6",
-            "D6",
-            "E6",
-            "F6",
-            "G6",
-            "H6"
-        ],
-        [
-            "A7",
-            "B7",
-            "C7",
-            "D7",
-            "E7",
-            "F7",
-            "G7",
-            "H7"
-        ],
-        [
-            "A8",
-            "B8",
-            "C8",
-            "D8",
-            "E8",
-            "F8",
-            "G8",
-            "H8"
-        ],
-        [
-            "A9",
-            "B9",
-            "C9",
-            "D9",
-            "E9",
-            "F9",
-            "G9",
-            "H9"
-        ],
-        [
-            "A10",
-            "B10",
-            "C10",
-            "D10",
-            "E10",
-            "F10",
-            "G10",
-            "H10"
-        ],
-        [
-            "A11",
-            "B11",
-            "C11",
-            "D11",
-            "E11",
-            "F11",
-            "G11",
-            "H11"
-        ],
-        [
-            "A12",
-            "B12",
-            "C12",
-            "D12",
-            "E12",
-            "F12",
-            "G12",
-            "H12"
-        ]
-    ],
-    "brand": {
-        "brand": "opentrons OT-3",
-        "brandId": []
+  "ordering": [
+    ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
+    ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
+    ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
+    ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
+    ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
+    ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
+    ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
+    ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
+    ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
+    ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
+    ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
+    ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
+  ],
+  "brand": {
+    "brand": "opentrons OT-3",
+    "brandId": []
+  },
+  "metadata": {
+    "displayName": "Opentrons OT-3 96 Tip Rack 50 µL",
+    "displayCategory": "tipRack",
+    "displayVolumeUnits": "µL",
+    "tags": []
+  },
+  "dimensions": {
+    "xDimension": 127.76,
+    "yDimension": 85.48,
+    "zDimension": 99
+  },
+  "wells": {
+    "A1": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 14.38,
+      "y": 74.1,
+      "z": 41.1
     },
-    "metadata": {
-        "displayName": "Opentrons OT-3 96 Tip Rack 50 µL",
-        "displayCategory": "tipRack",
-        "displayVolumeUnits": "µL",
-        "tags": []
+    "B1": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 14.38,
+      "y": 65.1,
+      "z": 41.1
     },
-    "dimensions": {
-        "xDimension": 127.76,
-        "yDimension": 85.48,
-        "zDimension": 99
+    "C1": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 14.38,
+      "y": 56.1,
+      "z": 41.1
     },
-    "wells": {
-        "A1": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 14.38,
-            "y": 74.1,
-            "z": 41.1
-        },
-        "B1": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 14.38,
-            "y": 65.1,
-            "z": 41.1
-        },
-        "C1": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 14.38,
-            "y": 56.1,
-            "z": 41.1
-        },
-        "D1": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 14.38,
-            "y": 47.1,
-            "z": 41.1
-        },
-        "E1": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 14.38,
-            "y": 38.1,
-            "z": 41.1
-        },
-        "F1": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 14.38,
-            "y": 29.1,
-            "z": 41.1
-        },
-        "G1": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 14.38,
-            "y": 20.1,
-            "z": 41.1
-        },
-        "H1": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 14.38,
-            "y": 11.1,
-            "z": 41.1
-        },
-        "A2": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 23.38,
-            "y": 74.1,
-            "z": 41.1
-        },
-        "B2": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 23.38,
-            "y": 65.1,
-            "z": 41.1
-        },
-        "C2": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 23.38,
-            "y": 56.1,
-            "z": 41.1
-        },
-        "D2": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 23.38,
-            "y": 47.1,
-            "z": 41.1
-        },
-        "E2": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 23.38,
-            "y": 38.1,
-            "z": 41.1
-        },
-        "F2": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 23.38,
-            "y": 29.1,
-            "z": 41.1
-        },
-        "G2": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 23.38,
-            "y": 20.1,
-            "z": 41.1
-        },
-        "H2": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 23.38,
-            "y": 11.1,
-            "z": 41.1
-        },
-        "A3": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 32.38,
-            "y": 74.1,
-            "z": 41.1
-        },
-        "B3": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 32.38,
-            "y": 65.1,
-            "z": 41.1
-        },
-        "C3": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 32.38,
-            "y": 56.1,
-            "z": 41.1
-        },
-        "D3": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 32.38,
-            "y": 47.1,
-            "z": 41.1
-        },
-        "E3": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 32.38,
-            "y": 38.1,
-            "z": 41.1
-        },
-        "F3": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 32.38,
-            "y": 29.1,
-            "z": 41.1
-        },
-        "G3": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 32.38,
-            "y": 20.1,
-            "z": 41.1
-        },
-        "H3": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 32.38,
-            "y": 11.1,
-            "z": 41.1
-        },
-        "A4": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 41.38,
-            "y": 74.1,
-            "z": 41.1
-        },
-        "B4": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 41.38,
-            "y": 65.1,
-            "z": 41.1
-        },
-        "C4": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 41.38,
-            "y": 56.1,
-            "z": 41.1
-        },
-        "D4": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 41.38,
-            "y": 47.1,
-            "z": 41.1
-        },
-        "E4": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 41.38,
-            "y": 38.1,
-            "z": 41.1
-        },
-        "F4": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 41.38,
-            "y": 29.1,
-            "z": 41.1
-        },
-        "G4": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 41.38,
-            "y": 20.1,
-            "z": 41.1
-        },
-        "H4": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 41.38,
-            "y": 11.1,
-            "z": 41.1
-        },
-        "A5": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 50.38,
-            "y": 74.1,
-            "z": 41.1
-        },
-        "B5": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 50.38,
-            "y": 65.1,
-            "z": 41.1
-        },
-        "C5": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 50.38,
-            "y": 56.1,
-            "z": 41.1
-        },
-        "D5": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 50.38,
-            "y": 47.1,
-            "z": 41.1
-        },
-        "E5": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 50.38,
-            "y": 38.1,
-            "z": 41.1
-        },
-        "F5": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 50.38,
-            "y": 29.1,
-            "z": 41.1
-        },
-        "G5": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 50.38,
-            "y": 20.1,
-            "z": 41.1
-        },
-        "H5": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 50.38,
-            "y": 11.1,
-            "z": 41.1
-        },
-        "A6": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 59.38,
-            "y": 74.1,
-            "z": 41.1
-        },
-        "B6": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 59.38,
-            "y": 65.1,
-            "z": 41.1
-        },
-        "C6": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 59.38,
-            "y": 56.1,
-            "z": 41.1
-        },
-        "D6": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 59.38,
-            "y": 47.1,
-            "z": 41.1
-        },
-        "E6": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 59.38,
-            "y": 38.1,
-            "z": 41.1
-        },
-        "F6": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 59.38,
-            "y": 29.1,
-            "z": 41.1
-        },
-        "G6": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 59.38,
-            "y": 20.1,
-            "z": 41.1
-        },
-        "H6": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 59.38,
-            "y": 11.1,
-            "z": 41.1
-        },
-        "A7": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 68.38,
-            "y": 74.1,
-            "z": 41.1
-        },
-        "B7": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 68.38,
-            "y": 65.1,
-            "z": 41.1
-        },
-        "C7": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 68.38,
-            "y": 56.1,
-            "z": 41.1
-        },
-        "D7": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 68.38,
-            "y": 47.1,
-            "z": 41.1
-        },
-        "E7": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 68.38,
-            "y": 38.1,
-            "z": 41.1
-        },
-        "F7": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 68.38,
-            "y": 29.1,
-            "z": 41.1
-        },
-        "G7": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 68.38,
-            "y": 20.1,
-            "z": 41.1
-        },
-        "H7": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 68.38,
-            "y": 11.1,
-            "z": 41.1
-        },
-        "A8": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 77.38,
-            "y": 74.1,
-            "z": 41.1
-        },
-        "B8": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 77.38,
-            "y": 65.1,
-            "z": 41.1
-        },
-        "C8": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 77.38,
-            "y": 56.1,
-            "z": 41.1
-        },
-        "D8": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 77.38,
-            "y": 47.1,
-            "z": 41.1
-        },
-        "E8": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 77.38,
-            "y": 38.1,
-            "z": 41.1
-        },
-        "F8": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 77.38,
-            "y": 29.1,
-            "z": 41.1
-        },
-        "G8": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 77.38,
-            "y": 20.1,
-            "z": 41.1
-        },
-        "H8": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 77.38,
-            "y": 11.1,
-            "z": 41.1
-        },
-        "A9": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 86.38,
-            "y": 74.1,
-            "z": 41.1
-        },
-        "B9": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 86.38,
-            "y": 65.1,
-            "z": 41.1
-        },
-        "C9": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 86.38,
-            "y": 56.1,
-            "z": 41.1
-        },
-        "D9": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 86.38,
-            "y": 47.1,
-            "z": 41.1
-        },
-        "E9": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 86.38,
-            "y": 38.1,
-            "z": 41.1
-        },
-        "F9": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 86.38,
-            "y": 29.1,
-            "z": 41.1
-        },
-        "G9": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 86.38,
-            "y": 20.1,
-            "z": 41.1
-        },
-        "H9": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 86.38,
-            "y": 11.1,
-            "z": 41.1
-        },
-        "A10": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 95.38,
-            "y": 74.1,
-            "z": 41.1
-        },
-        "B10": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 95.38,
-            "y": 65.1,
-            "z": 41.1
-        },
-        "C10": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 95.38,
-            "y": 56.1,
-            "z": 41.1
-        },
-        "D10": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 95.38,
-            "y": 47.1,
-            "z": 41.1
-        },
-        "E10": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 95.38,
-            "y": 38.1,
-            "z": 41.1
-        },
-        "F10": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 95.38,
-            "y": 29.1,
-            "z": 41.1
-        },
-        "G10": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 95.38,
-            "y": 20.1,
-            "z": 41.1
-        },
-        "H10": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 95.38,
-            "y": 11.1,
-            "z": 41.1
-        },
-        "A11": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 104.38,
-            "y": 74.1,
-            "z": 41.1
-        },
-        "B11": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 104.38,
-            "y": 65.1,
-            "z": 41.1
-        },
-        "C11": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 104.38,
-            "y": 56.1,
-            "z": 41.1
-        },
-        "D11": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 104.38,
-            "y": 47.1,
-            "z": 41.1
-        },
-        "E11": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 104.38,
-            "y": 38.1,
-            "z": 41.1
-        },
-        "F11": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 104.38,
-            "y": 29.1,
-            "z": 41.1
-        },
-        "G11": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 104.38,
-            "y": 20.1,
-            "z": 41.1
-        },
-        "H11": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 104.38,
-            "y": 11.1,
-            "z": 41.1
-        },
-        "A12": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 113.38,
-            "y": 74.1,
-            "z": 41.1
-        },
-        "B12": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 113.38,
-            "y": 65.1,
-            "z": 41.1
-        },
-        "C12": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 113.38,
-            "y": 56.1,
-            "z": 41.1
-        },
-        "D12": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 113.38,
-            "y": 47.1,
-            "z": 41.1
-        },
-        "E12": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 113.38,
-            "y": 38.1,
-            "z": 41.1
-        },
-        "F12": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 113.38,
-            "y": 29.1,
-            "z": 41.1
-        },
-        "G12": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 113.38,
-            "y": 20.1,
-            "z": 41.1
-        },
-        "H12": {
-            "depth": 57.9,
-            "totalLiquidVolume": 50,
-            "shape": "circular",
-            "diameter": 5.58,
-            "x": 113.38,
-            "y": 11.1,
-            "z": 41.1
-        }
+    "D1": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 14.38,
+      "y": 47.1,
+      "z": 41.1
     },
-    "groups": [
-        {
-            "metadata": {},
-            "wells": [
-                "A1",
-                "B1",
-                "C1",
-                "D1",
-                "E1",
-                "F1",
-                "G1",
-                "H1",
-                "A2",
-                "B2",
-                "C2",
-                "D2",
-                "E2",
-                "F2",
-                "G2",
-                "H2",
-                "A3",
-                "B3",
-                "C3",
-                "D3",
-                "E3",
-                "F3",
-                "G3",
-                "H3",
-                "A4",
-                "B4",
-                "C4",
-                "D4",
-                "E4",
-                "F4",
-                "G4",
-                "H4",
-                "A5",
-                "B5",
-                "C5",
-                "D5",
-                "E5",
-                "F5",
-                "G5",
-                "H5",
-                "A6",
-                "B6",
-                "C6",
-                "D6",
-                "E6",
-                "F6",
-                "G6",
-                "H6",
-                "A7",
-                "B7",
-                "C7",
-                "D7",
-                "E7",
-                "F7",
-                "G7",
-                "H7",
-                "A8",
-                "B8",
-                "C8",
-                "D8",
-                "E8",
-                "F8",
-                "G8",
-                "H8",
-                "A9",
-                "B9",
-                "C9",
-                "D9",
-                "E9",
-                "F9",
-                "G9",
-                "H9",
-                "A10",
-                "B10",
-                "C10",
-                "D10",
-                "E10",
-                "F10",
-                "G10",
-                "H10",
-                "A11",
-                "B11",
-                "C11",
-                "D11",
-                "E11",
-                "F11",
-                "G11",
-                "H11",
-                "A12",
-                "B12",
-                "C12",
-                "D12",
-                "E12",
-                "F12",
-                "G12",
-                "H12"
-            ]
-        }
-    ],
-    "parameters": {
-        "format": "96Standard",
-        "quirks": [],
-        "isTiprack": true,
-        "tipLength": 57.9,
-        "tipOverlap": 10.5,
-        "isMagneticModuleCompatible": false,
-        "loadName": "opentrons_ot3_96_tiprack_50ul"
+    "E1": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 14.38,
+      "y": 38.1,
+      "z": 41.1
     },
-    "namespace": "opentrons",
-    "version": 1,
-    "schemaVersion": 2,
-    "cornerOffsetFromSlot": {
-        "x": 0,
-        "y": 0,
-        "z": 0
+    "F1": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 14.38,
+      "y": 29.1,
+      "z": 41.1
+    },
+    "G1": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 14.38,
+      "y": 20.1,
+      "z": 41.1
+    },
+    "H1": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 14.38,
+      "y": 11.1,
+      "z": 41.1
+    },
+    "A2": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 23.38,
+      "y": 74.1,
+      "z": 41.1
+    },
+    "B2": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 23.38,
+      "y": 65.1,
+      "z": 41.1
+    },
+    "C2": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 23.38,
+      "y": 56.1,
+      "z": 41.1
+    },
+    "D2": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 23.38,
+      "y": 47.1,
+      "z": 41.1
+    },
+    "E2": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 23.38,
+      "y": 38.1,
+      "z": 41.1
+    },
+    "F2": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 23.38,
+      "y": 29.1,
+      "z": 41.1
+    },
+    "G2": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 23.38,
+      "y": 20.1,
+      "z": 41.1
+    },
+    "H2": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 23.38,
+      "y": 11.1,
+      "z": 41.1
+    },
+    "A3": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 32.38,
+      "y": 74.1,
+      "z": 41.1
+    },
+    "B3": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 32.38,
+      "y": 65.1,
+      "z": 41.1
+    },
+    "C3": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 32.38,
+      "y": 56.1,
+      "z": 41.1
+    },
+    "D3": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 32.38,
+      "y": 47.1,
+      "z": 41.1
+    },
+    "E3": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 32.38,
+      "y": 38.1,
+      "z": 41.1
+    },
+    "F3": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 32.38,
+      "y": 29.1,
+      "z": 41.1
+    },
+    "G3": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 32.38,
+      "y": 20.1,
+      "z": 41.1
+    },
+    "H3": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 32.38,
+      "y": 11.1,
+      "z": 41.1
+    },
+    "A4": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 41.38,
+      "y": 74.1,
+      "z": 41.1
+    },
+    "B4": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 41.38,
+      "y": 65.1,
+      "z": 41.1
+    },
+    "C4": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 41.38,
+      "y": 56.1,
+      "z": 41.1
+    },
+    "D4": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 41.38,
+      "y": 47.1,
+      "z": 41.1
+    },
+    "E4": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 41.38,
+      "y": 38.1,
+      "z": 41.1
+    },
+    "F4": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 41.38,
+      "y": 29.1,
+      "z": 41.1
+    },
+    "G4": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 41.38,
+      "y": 20.1,
+      "z": 41.1
+    },
+    "H4": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 41.38,
+      "y": 11.1,
+      "z": 41.1
+    },
+    "A5": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 50.38,
+      "y": 74.1,
+      "z": 41.1
+    },
+    "B5": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 50.38,
+      "y": 65.1,
+      "z": 41.1
+    },
+    "C5": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 50.38,
+      "y": 56.1,
+      "z": 41.1
+    },
+    "D5": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 50.38,
+      "y": 47.1,
+      "z": 41.1
+    },
+    "E5": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 50.38,
+      "y": 38.1,
+      "z": 41.1
+    },
+    "F5": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 50.38,
+      "y": 29.1,
+      "z": 41.1
+    },
+    "G5": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 50.38,
+      "y": 20.1,
+      "z": 41.1
+    },
+    "H5": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 50.38,
+      "y": 11.1,
+      "z": 41.1
+    },
+    "A6": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 59.38,
+      "y": 74.1,
+      "z": 41.1
+    },
+    "B6": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 59.38,
+      "y": 65.1,
+      "z": 41.1
+    },
+    "C6": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 59.38,
+      "y": 56.1,
+      "z": 41.1
+    },
+    "D6": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 59.38,
+      "y": 47.1,
+      "z": 41.1
+    },
+    "E6": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 59.38,
+      "y": 38.1,
+      "z": 41.1
+    },
+    "F6": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 59.38,
+      "y": 29.1,
+      "z": 41.1
+    },
+    "G6": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 59.38,
+      "y": 20.1,
+      "z": 41.1
+    },
+    "H6": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 59.38,
+      "y": 11.1,
+      "z": 41.1
+    },
+    "A7": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 68.38,
+      "y": 74.1,
+      "z": 41.1
+    },
+    "B7": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 68.38,
+      "y": 65.1,
+      "z": 41.1
+    },
+    "C7": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 68.38,
+      "y": 56.1,
+      "z": 41.1
+    },
+    "D7": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 68.38,
+      "y": 47.1,
+      "z": 41.1
+    },
+    "E7": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 68.38,
+      "y": 38.1,
+      "z": 41.1
+    },
+    "F7": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 68.38,
+      "y": 29.1,
+      "z": 41.1
+    },
+    "G7": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 68.38,
+      "y": 20.1,
+      "z": 41.1
+    },
+    "H7": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 68.38,
+      "y": 11.1,
+      "z": 41.1
+    },
+    "A8": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 77.38,
+      "y": 74.1,
+      "z": 41.1
+    },
+    "B8": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 77.38,
+      "y": 65.1,
+      "z": 41.1
+    },
+    "C8": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 77.38,
+      "y": 56.1,
+      "z": 41.1
+    },
+    "D8": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 77.38,
+      "y": 47.1,
+      "z": 41.1
+    },
+    "E8": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 77.38,
+      "y": 38.1,
+      "z": 41.1
+    },
+    "F8": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 77.38,
+      "y": 29.1,
+      "z": 41.1
+    },
+    "G8": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 77.38,
+      "y": 20.1,
+      "z": 41.1
+    },
+    "H8": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 77.38,
+      "y": 11.1,
+      "z": 41.1
+    },
+    "A9": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 86.38,
+      "y": 74.1,
+      "z": 41.1
+    },
+    "B9": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 86.38,
+      "y": 65.1,
+      "z": 41.1
+    },
+    "C9": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 86.38,
+      "y": 56.1,
+      "z": 41.1
+    },
+    "D9": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 86.38,
+      "y": 47.1,
+      "z": 41.1
+    },
+    "E9": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 86.38,
+      "y": 38.1,
+      "z": 41.1
+    },
+    "F9": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 86.38,
+      "y": 29.1,
+      "z": 41.1
+    },
+    "G9": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 86.38,
+      "y": 20.1,
+      "z": 41.1
+    },
+    "H9": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 86.38,
+      "y": 11.1,
+      "z": 41.1
+    },
+    "A10": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 95.38,
+      "y": 74.1,
+      "z": 41.1
+    },
+    "B10": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 95.38,
+      "y": 65.1,
+      "z": 41.1
+    },
+    "C10": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 95.38,
+      "y": 56.1,
+      "z": 41.1
+    },
+    "D10": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 95.38,
+      "y": 47.1,
+      "z": 41.1
+    },
+    "E10": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 95.38,
+      "y": 38.1,
+      "z": 41.1
+    },
+    "F10": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 95.38,
+      "y": 29.1,
+      "z": 41.1
+    },
+    "G10": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 95.38,
+      "y": 20.1,
+      "z": 41.1
+    },
+    "H10": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 95.38,
+      "y": 11.1,
+      "z": 41.1
+    },
+    "A11": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 104.38,
+      "y": 74.1,
+      "z": 41.1
+    },
+    "B11": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 104.38,
+      "y": 65.1,
+      "z": 41.1
+    },
+    "C11": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 104.38,
+      "y": 56.1,
+      "z": 41.1
+    },
+    "D11": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 104.38,
+      "y": 47.1,
+      "z": 41.1
+    },
+    "E11": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 104.38,
+      "y": 38.1,
+      "z": 41.1
+    },
+    "F11": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 104.38,
+      "y": 29.1,
+      "z": 41.1
+    },
+    "G11": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 104.38,
+      "y": 20.1,
+      "z": 41.1
+    },
+    "H11": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 104.38,
+      "y": 11.1,
+      "z": 41.1
+    },
+    "A12": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 113.38,
+      "y": 74.1,
+      "z": 41.1
+    },
+    "B12": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 113.38,
+      "y": 65.1,
+      "z": 41.1
+    },
+    "C12": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 113.38,
+      "y": 56.1,
+      "z": 41.1
+    },
+    "D12": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 113.38,
+      "y": 47.1,
+      "z": 41.1
+    },
+    "E12": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 113.38,
+      "y": 38.1,
+      "z": 41.1
+    },
+    "F12": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 113.38,
+      "y": 29.1,
+      "z": 41.1
+    },
+    "G12": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 113.38,
+      "y": 20.1,
+      "z": 41.1
+    },
+    "H12": {
+      "depth": 57.9,
+      "totalLiquidVolume": 50,
+      "shape": "circular",
+      "diameter": 5.58,
+      "x": 113.38,
+      "y": 11.1,
+      "z": 41.1
     }
+  },
+  "groups": [
+    {
+      "metadata": {},
+      "wells": [
+        "A1",
+        "B1",
+        "C1",
+        "D1",
+        "E1",
+        "F1",
+        "G1",
+        "H1",
+        "A2",
+        "B2",
+        "C2",
+        "D2",
+        "E2",
+        "F2",
+        "G2",
+        "H2",
+        "A3",
+        "B3",
+        "C3",
+        "D3",
+        "E3",
+        "F3",
+        "G3",
+        "H3",
+        "A4",
+        "B4",
+        "C4",
+        "D4",
+        "E4",
+        "F4",
+        "G4",
+        "H4",
+        "A5",
+        "B5",
+        "C5",
+        "D5",
+        "E5",
+        "F5",
+        "G5",
+        "H5",
+        "A6",
+        "B6",
+        "C6",
+        "D6",
+        "E6",
+        "F6",
+        "G6",
+        "H6",
+        "A7",
+        "B7",
+        "C7",
+        "D7",
+        "E7",
+        "F7",
+        "G7",
+        "H7",
+        "A8",
+        "B8",
+        "C8",
+        "D8",
+        "E8",
+        "F8",
+        "G8",
+        "H8",
+        "A9",
+        "B9",
+        "C9",
+        "D9",
+        "E9",
+        "F9",
+        "G9",
+        "H9",
+        "A10",
+        "B10",
+        "C10",
+        "D10",
+        "E10",
+        "F10",
+        "G10",
+        "H10",
+        "A11",
+        "B11",
+        "C11",
+        "D11",
+        "E11",
+        "F11",
+        "G11",
+        "H11",
+        "A12",
+        "B12",
+        "C12",
+        "D12",
+        "E12",
+        "F12",
+        "G12",
+        "H12"
+      ]
+    }
+  ],
+  "parameters": {
+    "format": "96Standard",
+    "quirks": [],
+    "isTiprack": true,
+    "tipLength": 57.9,
+    "tipOverlap": 10.5,
+    "isMagneticModuleCompatible": false,
+    "loadName": "opentrons_ot3_96_tiprack_50ul"
+  },
+  "namespace": "opentrons",
+  "version": 1,
+  "schemaVersion": 2,
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  }
 }


### PR DESCRIPTION
# Overview

We will be using different types of tipracks for the new robot. These definitions represent the
official opentrons non-filtered tipracks. 

# Changelog

- Added tiprack definitions for 50ul, 200ul and 1000ul tipracks
- Filtering out the new tipracks from any user facing locations

# Review requests

I need a JS person to help me figure out all the other locations we may need to filter out these new definitions.

# Risk assessment

Low. Should only be used during EVT testing.
