### PR TITLE
refactor(api): wire a no-op ProtocolEngine core to PAPIv2 given FF

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/__init__.py
+++ b/api/src/opentrons/protocol_api/core/engine/__init__.py
@@ -1,0 +1,7 @@
+"""ProtocolEngine-based Protocol API implementation core."""
+from .protocol import ProtocolCore
+from .instrument import InstrumentCore
+from .labware import LabwareCore
+from .well import WellCore
+
+__all__ = ["ProtocolCore", "InstrumentCore", "LabwareCore", "WellCore"]

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1,7 +1,8 @@
 """ProtocolEngine-based InstrumentContext core implementation."""
 
 from ..instrument import AbstractInstrument
+from .well import WellCore
 
 
-class InstrumentCore(AbstractInstrument):
+class InstrumentCore(AbstractInstrument[WellCore]):
     """Instrument API core using a ProtocolEngine."""

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1,0 +1,7 @@
+"""ProtocolEngine-based InstrumentContext core implementation."""
+
+from ..instrument import AbstractInstrument
+
+
+class InstrumentCore(AbstractInstrument):
+    """Instrument API core using a ProtocolEngine."""

--- a/api/src/opentrons/protocol_api/core/engine/labware.py
+++ b/api/src/opentrons/protocol_api/core/engine/labware.py
@@ -1,7 +1,8 @@
 """ProtocolEngine-based Labware core implementations."""
 
 from ..labware import AbstractLabware
+from .well import WellCore
 
 
-class LabwareCore(AbstractLabware):
+class LabwareCore(AbstractLabware[WellCore]):
     """Labware API core using a ProtocolEngine."""

--- a/api/src/opentrons/protocol_api/core/engine/labware.py
+++ b/api/src/opentrons/protocol_api/core/engine/labware.py
@@ -1,0 +1,7 @@
+"""ProtocolEngine-based Labware core implementations."""
+
+from ..labware import AbstractLabware
+
+
+class LabwareCore(AbstractLabware):
+    """Labware API core using a ProtocolEngine."""

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -12,15 +12,15 @@ from opentrons.protocols.geometry.deck_item import DeckItem
 from opentrons.protocol_engine.clients import SyncClient as ProtocolEngineClient
 
 from ..protocol import AbstractProtocol, LoadModuleResult
-from ..labware import AbstractLabware
-from ..instrument import AbstractInstrument
+from .labware import LabwareCore
+from .instrument import InstrumentCore
 
 
 # TODO(mc, 2022-08-24): many of these methods are likely unnecessary
-# in a ProtocolEngine-world. As we develop this core, we should remove
+# in a ProtocolEngine world. As we develop this core, we should remove
 # and consolidate logic as we need to across all cores rather than
 # necessarily try to support every one of these behaviors in the engine.
-class ProtocolCore(AbstractProtocol):
+class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore]):
     """Protocol API core using a ProtocolEngine.
 
     Args:
@@ -69,7 +69,7 @@ class ProtocolCore(AbstractProtocol):
         labware_def: LabwareDefinition,
         location: DeckLocation,
         label: Optional[str],
-    ) -> AbstractLabware:
+    ) -> LabwareCore:
         """Load a labware using its definition dictionary."""
         raise NotImplementedError("ProtocolEngine PAPI core not implemented")
 
@@ -80,7 +80,7 @@ class ProtocolCore(AbstractProtocol):
         label: Optional[str],
         namespace: Optional[str],
         version: Optional[int],
-    ) -> AbstractLabware:
+    ) -> LabwareCore:
         """Load a labware using its identifying parameters."""
         raise NotImplementedError("ProtocolEngine PAPI core not implemented")
 
@@ -99,11 +99,11 @@ class ProtocolCore(AbstractProtocol):
 
     def load_instrument(
         self, instrument_name: str, mount: Mount, replace: bool
-    ) -> AbstractInstrument:
+    ) -> InstrumentCore:
         """Load an instrument into the protocol."""
         raise NotImplementedError("ProtocolEngine PAPI core not implemented")
 
-    def get_loaded_instruments(self) -> Dict[Mount, Optional[AbstractInstrument]]:
+    def get_loaded_instruments(self) -> Dict[Mount, Optional[InstrumentCore]]:
         """Get all loaded instruments by mount."""
         raise NotImplementedError("ProtocolEngine PAPI core not implemented")
 

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -1,0 +1,163 @@
+"""ProtocolEngine-based Protocol API core implementation."""
+from typing import Dict, Optional
+
+from opentrons_shared_data.labware.dev_types import LabwareDefinition
+
+from opentrons.types import Mount, Location, DeckLocation
+from opentrons.hardware_control import SyncHardwareAPI
+from opentrons.hardware_control.modules.types import ModuleModel
+from opentrons.protocols.api_support.util import AxisMaxSpeeds
+from opentrons.protocols.geometry.deck import Deck
+from opentrons.protocols.geometry.deck_item import DeckItem
+from opentrons.protocol_engine.clients import SyncClient as ProtocolEngineClient
+
+from ..protocol import AbstractProtocol, LoadModuleResult
+from ..labware import AbstractLabware
+from ..instrument import AbstractInstrument
+
+
+# TODO(mc, 2022-08-24): many of these methods are likely unnecessary
+# in a ProtocolEngine-world. As we develop this core, we should remove
+# and consolidate logic as we need to across all cores rather than
+# necessarily try to support every one of these behaviors in the engine.
+class ProtocolCore(AbstractProtocol):
+    """Protocol API core using a ProtocolEngine.
+
+    Args:
+        engine_client: A synchronous client to the ProtocolEngine
+            that is executing the protocol.
+    """
+
+    def __init__(self, engine_client: ProtocolEngineClient) -> None:
+        self._engine_client = engine_client
+
+    def get_bundled_data(self) -> Dict[str, bytes]:
+        """Get a map of file names to byte contents.
+
+        Deprecated method for past experiment with ZIP protocols.
+        """
+        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+
+    def get_bundled_labware(self) -> Optional[Dict[str, LabwareDefinition]]:
+        """Get a map of labware names to definition dicts.
+
+        Deprecated method used for past experiment with ZIP protocols.
+        """
+        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+
+    def get_extra_labware(self) -> Optional[Dict[str, LabwareDefinition]]:
+        """Get a map of extra labware names to definition dicts.
+
+        Used to assist load custom labware definitions.
+        """
+        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+
+    def get_max_speeds(self) -> AxisMaxSpeeds:
+        """Get a control interface for maximum move speeds."""
+        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+
+    def get_hardware(self) -> SyncHardwareAPI:
+        """Get direct access to a hardware control interface."""
+        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+
+    def is_simulating(self) -> bool:
+        """Get whether the protocol is being analyzed or actually run."""
+        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+
+    def load_labware_from_definition(
+        self,
+        labware_def: LabwareDefinition,
+        location: DeckLocation,
+        label: Optional[str],
+    ) -> AbstractLabware:
+        """Load a labware using its definition dictionary."""
+        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+
+    def load_labware(
+        self,
+        load_name: str,
+        location: DeckLocation,
+        label: Optional[str],
+        namespace: Optional[str],
+        version: Optional[int],
+    ) -> AbstractLabware:
+        """Load a labware using its identifying parameters."""
+        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+
+    def load_module(
+        self,
+        model: ModuleModel,
+        location: Optional[DeckLocation],
+        configuration: Optional[str],
+    ) -> Optional[LoadModuleResult]:
+        """Load a module into the protocol."""
+        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+
+    def get_loaded_modules(self) -> Dict[int, LoadModuleResult]:
+        """Get all loaded modules by deck slot number."""
+        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+
+    def load_instrument(
+        self, instrument_name: str, mount: Mount, replace: bool
+    ) -> AbstractInstrument:
+        """Load an instrument into the protocol."""
+        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+
+    def get_loaded_instruments(self) -> Dict[Mount, Optional[AbstractInstrument]]:
+        """Get all loaded instruments by mount."""
+        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+
+    def pause(self, msg: Optional[str]) -> None:
+        """Pause the protocol."""
+        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+
+    def resume(self) -> None:
+        """Resume the protocol."""
+        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+
+    def comment(self, msg: str) -> None:
+        """Create a comment in the protocol to be shown in the log."""
+        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+
+    def delay(self, seconds: float, msg: Optional[str]) -> None:
+        """Wait for a period of time before proceeding."""
+        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+
+    def home(self) -> None:
+        """Move all axes to their home positions."""
+        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+
+    def get_deck(self) -> Deck:
+        """Get an interface to get and modify the deck layout."""
+        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+
+    def get_fixed_trash(self) -> DeckItem:
+        """Get the fixed trash labware."""
+        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+
+    def set_rail_lights(self, on: bool) -> None:
+        """Set the device's rail lights."""
+        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+
+    def get_rail_lights_on(self) -> bool:
+        """Get whether the device's rail lights are on."""
+        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+
+    def door_closed(self) -> bool:
+        """Get whether the device's front door is closed."""
+        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+
+    def get_last_location(
+        self,
+        mount: Optional[Mount] = None,
+    ) -> Optional[Location]:
+        """Get the last accessed location."""
+        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+
+    def set_last_location(
+        self,
+        location: Optional[Location],
+        mount: Optional[Mount] = None,
+    ) -> None:
+        """Set the last accessed location."""
+        raise NotImplementedError("ProtocolEngine PAPI core not implemented")

--- a/api/src/opentrons/protocol_api/core/engine/well.py
+++ b/api/src/opentrons/protocol_api/core/engine/well.py
@@ -1,0 +1,8 @@
+"""ProtocolEngine-based Well core implementations."""
+
+
+from ..well import AbstractWellCore
+
+
+class WellCore(AbstractWellCore):
+    """Well API core using a ProtocolEngine."""

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -9,7 +9,7 @@ from opentrons import types
 from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.protocols.api_support.util import Clearances, PlungerSpeeds, FlowRates
 
-from .well import WellImplementation
+from .well import AbstractWellCore
 
 
 class AbstractInstrument(ABC):
@@ -35,14 +35,14 @@ class AbstractInstrument(ABC):
 
     @abstractmethod
     def touch_tip(
-        self, location: WellImplementation, radius: float, v_offset: float, speed: float
+        self, location: AbstractWellCore, radius: float, v_offset: float, speed: float
     ) -> None:
         ...
 
     @abstractmethod
     def pick_up_tip(
         self,
-        well: WellImplementation,
+        well: AbstractWellCore,
         tip_length: float,
         presses: typing.Optional[int],
         increment: typing.Optional[float],

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -3,16 +3,16 @@
 from __future__ import annotations
 
 from abc import abstractmethod, ABC
-import typing
+from typing import Any, Generic, Optional, TypeVar
 
 from opentrons import types
 from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.protocols.api_support.util import Clearances, PlungerSpeeds, FlowRates
 
-from .well import AbstractWellCore
+from .well import WellCoreType
 
 
-class AbstractInstrument(ABC):
+class AbstractInstrument(ABC, Generic[WellCoreType]):
     @abstractmethod
     def get_default_speed(self) -> float:
         ...
@@ -35,17 +35,17 @@ class AbstractInstrument(ABC):
 
     @abstractmethod
     def touch_tip(
-        self, location: AbstractWellCore, radius: float, v_offset: float, speed: float
+        self, location: WellCoreType, radius: float, v_offset: float, speed: float
     ) -> None:
         ...
 
     @abstractmethod
     def pick_up_tip(
         self,
-        well: AbstractWellCore,
+        well: WellCoreType,
         tip_length: float,
-        presses: typing.Optional[int],
-        increment: typing.Optional[float],
+        presses: Optional[int],
+        increment: Optional[float],
         prep_after: bool,
     ) -> None:
         ...
@@ -67,8 +67,8 @@ class AbstractInstrument(ABC):
         self,
         location: types.Location,
         force_direct: bool,
-        minimum_z_height: typing.Optional[float],
-        speed: typing.Optional[float],
+        minimum_z_height: Optional[float],
+        speed: Optional[float],
     ) -> None:
         ...
 
@@ -143,17 +143,20 @@ class AbstractInstrument(ABC):
     @abstractmethod
     def set_flow_rate(
         self,
-        aspirate: typing.Optional[float] = None,
-        dispense: typing.Optional[float] = None,
-        blow_out: typing.Optional[float] = None,
+        aspirate: Optional[float] = None,
+        dispense: Optional[float] = None,
+        blow_out: Optional[float] = None,
     ) -> None:
         ...
 
     @abstractmethod
     def set_pipette_speed(
         self,
-        aspirate: typing.Optional[float] = None,
-        dispense: typing.Optional[float] = None,
-        blow_out: typing.Optional[float] = None,
+        aspirate: Optional[float] = None,
+        dispense: Optional[float] = None,
+        blow_out: Optional[float] = None,
     ) -> None:
         ...
+
+
+InstrumentCoreType = TypeVar("InstrumentCoreType", bound=AbstractInstrument[Any])

--- a/api/src/opentrons/protocol_api/core/labware.py
+++ b/api/src/opentrons/protocol_api/core/labware.py
@@ -1,6 +1,6 @@
 """The interface that implements InstrumentContext."""
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from typing import List, Dict, Optional
 
 from opentrons.protocols.geometry.deck_item import DeckItem
@@ -10,11 +10,11 @@ from opentrons.protocols.api_support.well_grid import WellGrid
 from opentrons.types import Point
 from opentrons_shared_data.labware.dev_types import LabwareParameters, LabwareDefinition
 
-from .well import WellImplementation
+from .well import AbstractWellCore
 
 
-class AbstractLabware(DeckItem):
-    """Abstract base class of Labware Implementations"""
+class AbstractLabware(DeckItem, ABC):
+    """Labware implementation core interface."""
 
     @abstractmethod
     def get_uri(self) -> str:
@@ -81,11 +81,11 @@ class AbstractLabware(DeckItem):
         ...
 
     @abstractmethod
-    def get_wells(self) -> List[WellImplementation]:
+    def get_wells(self) -> List[AbstractWellCore]:
         ...
 
     @abstractmethod
-    def get_wells_by_name(self) -> Dict[str, WellImplementation]:
+    def get_wells_by_name(self) -> Dict[str, AbstractWellCore]:
         ...
 
     @abstractmethod

--- a/api/src/opentrons/protocol_api/core/labware.py
+++ b/api/src/opentrons/protocol_api/core/labware.py
@@ -1,7 +1,7 @@
 """The interface that implements InstrumentContext."""
 
 from abc import ABC, abstractmethod
-from typing import List, Dict, Optional
+from typing import Any, Generic, Dict, List, Optional, TypeVar
 
 from opentrons.protocols.geometry.deck_item import DeckItem
 from opentrons.protocols.geometry.labware_geometry import AbstractLabwareGeometry
@@ -10,10 +10,10 @@ from opentrons.protocols.api_support.well_grid import WellGrid
 from opentrons.types import Point
 from opentrons_shared_data.labware.dev_types import LabwareParameters, LabwareDefinition
 
-from .well import AbstractWellCore
+from .well import WellCoreType
 
 
-class AbstractLabware(DeckItem, ABC):
+class AbstractLabware(DeckItem, ABC, Generic[WellCoreType]):
     """Labware implementation core interface."""
 
     @abstractmethod
@@ -81,13 +81,16 @@ class AbstractLabware(DeckItem, ABC):
         ...
 
     @abstractmethod
-    def get_wells(self) -> List[AbstractWellCore]:
+    def get_wells(self) -> List[WellCoreType]:
         ...
 
     @abstractmethod
-    def get_wells_by_name(self) -> Dict[str, AbstractWellCore]:
+    def get_wells_by_name(self) -> Dict[str, WellCoreType]:
         ...
 
     @abstractmethod
     def get_geometry(self) -> AbstractLabwareGeometry:
         ...
+
+
+LabwareCoreType = TypeVar("LabwareCoreType", bound=AbstractLabware[Any])

--- a/api/src/opentrons/protocol_api/core/protocol.py
+++ b/api/src/opentrons/protocol_api/core/protocol.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from abc import abstractmethod, ABC
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Dict, Generic, Optional
 
-from opentrons import types
+from opentrons.types import Mount, Location, DeckLocation
 from opentrons.hardware_control import SyncHardwareAPI, SynchronousAdapter
 from opentrons.hardware_control.modules import AbstractModule
 from opentrons.hardware_control.modules.types import ModuleModel, ModuleType
@@ -16,10 +16,8 @@ from opentrons.protocols.geometry.module_geometry import ModuleGeometry
 from opentrons.protocols.api_support.util import AxisMaxSpeeds
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
-from .instrument import AbstractInstrument
-from .labware import AbstractLabware
-
-InstrumentDict = Dict[types.Mount, Optional[AbstractInstrument]]
+from .instrument import InstrumentCoreType
+from .labware import LabwareCoreType
 
 
 @dataclass(frozen=True)
@@ -31,7 +29,7 @@ class LoadModuleResult:
     module: SynchronousAdapter[AbstractModule]
 
 
-class AbstractProtocol(ABC):
+class AbstractProtocol(ABC, Generic[InstrumentCoreType, LabwareCoreType]):
     @abstractmethod
     def get_bundled_data(self) -> Dict[str, bytes]:
         """Get a mapping of name to contents"""
@@ -61,27 +59,27 @@ class AbstractProtocol(ABC):
     def load_labware_from_definition(
         self,
         labware_def: LabwareDefinition,
-        location: types.DeckLocation,
+        location: DeckLocation,
         label: Optional[str],
-    ) -> AbstractLabware:
+    ) -> LabwareCoreType:
         ...
 
     @abstractmethod
     def load_labware(
         self,
         load_name: str,
-        location: types.DeckLocation,
+        location: DeckLocation,
         label: Optional[str],
         namespace: Optional[str],
         version: Optional[int],
-    ) -> AbstractLabware:
+    ) -> LabwareCoreType:
         ...
 
     @abstractmethod
     def load_module(
         self,
         model: ModuleModel,
-        location: Optional[types.DeckLocation],
+        location: Optional[DeckLocation],
         configuration: Optional[str],
     ) -> Optional[LoadModuleResult]:
         ...
@@ -92,12 +90,12 @@ class AbstractProtocol(ABC):
 
     @abstractmethod
     def load_instrument(
-        self, instrument_name: str, mount: types.Mount, replace: bool
-    ) -> AbstractInstrument:
+        self, instrument_name: str, mount: Mount, replace: bool
+    ) -> InstrumentCoreType:
         ...
 
     @abstractmethod
-    def get_loaded_instruments(self) -> InstrumentDict:
+    def get_loaded_instruments(self) -> Dict[Mount, Optional[InstrumentCoreType]]:
         ...
 
     @abstractmethod
@@ -143,14 +141,14 @@ class AbstractProtocol(ABC):
     @abstractmethod
     def get_last_location(
         self,
-        mount: Optional[types.Mount] = None,
-    ) -> Optional[types.Location]:
+        mount: Optional[Mount] = None,
+    ) -> Optional[Location]:
         ...
 
     @abstractmethod
     def set_last_location(
         self,
-        location: Optional[types.Location],
-        mount: Optional[types.Mount] = None,
+        location: Optional[Location],
+        mount: Optional[Mount] = None,
     ) -> None:
         ...

--- a/api/src/opentrons/protocol_api/core/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/instrument_context.py
@@ -1,4 +1,5 @@
-from typing import Optional
+from __future__ import annotations
+from typing import TYPE_CHECKING, Optional
 
 from opentrons import types
 from opentrons.protocols.api_support.types import APIVersion
@@ -15,15 +16,17 @@ from opentrons.protocols.api_support.util import (
 from opentrons.protocols.geometry import planning
 
 from ..instrument import AbstractInstrument
-from ..protocol import AbstractProtocol
-from ..well import AbstractWellCore
+from .well import WellImplementation
+
+if TYPE_CHECKING:
+    from .protocol_context import ProtocolContextImplementation
 
 
-class InstrumentContextImplementation(AbstractInstrument):
+class InstrumentContextImplementation(AbstractInstrument[WellImplementation]):
     """Implementation of the InstrumentContext interface."""
 
     _api_version: APIVersion
-    _protocol_interface: AbstractProtocol
+    _protocol_interface: ProtocolContextImplementation
     _mount: types.Mount
     _instrument_name: str
     _default_speed: float
@@ -33,7 +36,7 @@ class InstrumentContextImplementation(AbstractInstrument):
 
     def __init__(
         self,
-        protocol_interface: AbstractProtocol,
+        protocol_interface: ProtocolContextImplementation,
         mount: types.Mount,
         instrument_name: str,
         default_speed: float,
@@ -75,7 +78,7 @@ class InstrumentContextImplementation(AbstractInstrument):
         self._protocol_interface.get_hardware().blow_out(self._mount)
 
     def touch_tip(
-        self, location: AbstractWellCore, radius: float, v_offset: float, speed: float
+        self, location: WellImplementation, radius: float, v_offset: float, speed: float
     ) -> None:
         """
         Touch the pipette tip to the sides of a well, with the intent of
@@ -100,7 +103,7 @@ class InstrumentContextImplementation(AbstractInstrument):
 
     def pick_up_tip(
         self,
-        well: AbstractWellCore,
+        well: WellImplementation,
         tip_length: float,
         presses: Optional[int],
         increment: Optional[float],

--- a/api/src/opentrons/protocol_api/core/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/instrument_context.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import TYPE_CHECKING, Optional
 
 from opentrons import types

--- a/api/src/opentrons/protocol_api/core/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/instrument_context.py
@@ -16,7 +16,7 @@ from opentrons.protocols.geometry import planning
 
 from ..instrument import AbstractInstrument
 from ..protocol import AbstractProtocol
-from ..well import WellImplementation
+from ..well import AbstractWellCore
 
 
 class InstrumentContextImplementation(AbstractInstrument):
@@ -75,7 +75,7 @@ class InstrumentContextImplementation(AbstractInstrument):
         self._protocol_interface.get_hardware().blow_out(self._mount)
 
     def touch_tip(
-        self, location: WellImplementation, radius: float, v_offset: float, speed: float
+        self, location: AbstractWellCore, radius: float, v_offset: float, speed: float
     ) -> None:
         """
         Touch the pipette tip to the sides of a well, with the intent of
@@ -100,7 +100,7 @@ class InstrumentContextImplementation(AbstractInstrument):
 
     def pick_up_tip(
         self,
-        well: WellImplementation,
+        well: AbstractWellCore,
         tip_length: float,
         presses: Optional[int],
         increment: Optional[float],

--- a/api/src/opentrons/protocol_api/core/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/labware.py
@@ -10,11 +10,10 @@ from opentrons.types import Point, Location
 from opentrons_shared_data.labware.dev_types import LabwareParameters, LabwareDefinition
 
 from ..labware import AbstractLabware
-from ..well import AbstractWellCore
 from .well import WellImplementation
 
 
-class LabwareImplementation(AbstractLabware):
+class LabwareImplementation(AbstractLabware[WellImplementation]):
     """Labware implementation core based on legacy PAPIv2 behavior.
 
     Args:
@@ -48,7 +47,7 @@ class LabwareImplementation(AbstractLabware):
         self._geometry = LabwareGeometry(definition, parent)
         # flatten list of list of well names.
         self._ordering = [well for col in definition["ordering"] for well in col]
-        self._wells: List[AbstractWellCore] = []
+        self._wells: List[WellImplementation] = []
         self._well_name_grid = WellGrid(wells=self._wells)
         self._tip_tracker = TipTracker(columns=self._well_name_grid.get_columns())
 
@@ -114,10 +113,10 @@ class LabwareImplementation(AbstractLabware):
     def get_well_grid(self) -> WellGrid:
         return self._well_name_grid
 
-    def get_wells(self) -> List[AbstractWellCore]:
+    def get_wells(self) -> List[WellImplementation]:
         return self._wells
 
-    def get_wells_by_name(self) -> Dict[str, AbstractWellCore]:
+    def get_wells_by_name(self) -> Dict[str, WellImplementation]:
         return {well.get_name(): well for well in self._wells}
 
     def get_geometry(self) -> LabwareGeometry:
@@ -135,7 +134,7 @@ class LabwareImplementation(AbstractLabware):
     def load_name(self) -> str:
         return self._parameters["loadName"]
 
-    def _build_wells(self) -> List[AbstractWellCore]:
+    def _build_wells(self) -> List[WellImplementation]:
         return [
             WellImplementation(
                 well_geometry=WellGeometry(

--- a/api/src/opentrons/protocol_api/core/protocol_api/well.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/well.py
@@ -1,0 +1,78 @@
+"""Legacy Well core implementation."""
+
+import re
+
+from opentrons.protocols.geometry.well_geometry import WellGeometry
+from opentrons_shared_data.labware.constants import WELL_NAME_PATTERN
+
+from ..well import AbstractWellCore
+
+
+class WellImplementation(AbstractWellCore):
+    """Well implementation core based on legacy PAPIv2 behavior.
+
+    Args:
+        well_geometry: Information about the well's geometry.
+        display_name: User-facing display name.
+        has_tip: Whether the well contains a tip.
+        name: Unique well name inside its labware, e.g. `A1`.
+            Must match pattern /^([A-Z]+)([0-9]+)$/.
+    """
+
+    pattern = re.compile(WELL_NAME_PATTERN, re.X)
+
+    def __init__(
+        self, well_geometry: WellGeometry, display_name: str, has_tip: bool, name: str
+    ) -> None:
+        self._display_name = display_name
+        self._has_tip = has_tip
+        self._name = name
+
+        match = WellImplementation.pattern.match(name)
+        assert match, (
+            f"could not match '{name}' using "
+            f"pattern '{WellImplementation.pattern.pattern}'"
+        )
+        self._row_name = match.group(1)
+        self._column_name = match.group(2)
+        self._geometry = well_geometry
+
+    def has_tip(self) -> bool:
+        """Whether the well contains a tip."""
+        return self._has_tip
+
+    def set_has_tip(self, value: bool) -> None:
+        """Set the well as containing or not containing a tip."""
+        self._has_tip = value
+
+    def get_display_name(self) -> str:
+        """Get the well's full display name."""
+        return self._display_name
+
+    def get_name(self) -> str:
+        """Get the name of the well (e.g. "A1")."""
+        return self._name
+
+    def get_column_name(self) -> str:
+        """Get the column portion of the well name (e.g. "A")."""
+        return self._column_name
+
+    def get_row_name(self) -> str:
+        """Get the row portion of the well name (e.g. "1")."""
+        return self._row_name
+
+    def get_geometry(self) -> WellGeometry:
+        """Get the well's geometry information interface."""
+        return self._geometry
+
+    def __repr__(self) -> str:
+        """Use the well's display name as its repr."""
+        return self.get_display_name()
+
+    # TODO(mc, 2022-08-24): comparing only names seems insufficient
+    def __eq__(self, other: object) -> bool:
+        """Assume that if name is the same then it's the same well."""
+        return (
+            isinstance(other, WellImplementation)
+            and self.get_name() == other.get_name()
+        )

--- a/api/src/opentrons/protocol_api/core/simulator/instrument_context.py
+++ b/api/src/opentrons/protocol_api/core/simulator/instrument_context.py
@@ -12,7 +12,7 @@ from opentrons.protocols.geometry import planning
 
 from ..instrument import AbstractInstrument
 from ..protocol import AbstractProtocol
-from ..well import WellImplementation
+from ..well import AbstractWellCore
 
 
 class InstrumentContextSimulation(AbstractInstrument):
@@ -73,13 +73,13 @@ class InstrumentContextSimulation(AbstractInstrument):
         )
 
     def touch_tip(
-        self, location: WellImplementation, radius: float, v_offset: float, speed: float
+        self, location: AbstractWellCore, radius: float, v_offset: float, speed: float
     ) -> None:
         pass
 
     def pick_up_tip(
         self,
-        well: WellImplementation,
+        well: AbstractWellCore,
         tip_length: float,
         presses: typing.Optional[int],
         increment: typing.Optional[float],

--- a/api/src/opentrons/protocol_api/core/simulator/instrument_context.py
+++ b/api/src/opentrons/protocol_api/core/simulator/instrument_context.py
@@ -1,4 +1,6 @@
-import typing
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
 
 from opentrons import types
 from opentrons.hardware_control import NoTipAttachedError, TipAttachedError
@@ -11,21 +13,23 @@ from opentrons.protocols.api_support.util import FlowRates, PlungerSpeeds, Clear
 from opentrons.protocols.geometry import planning
 
 from ..instrument import AbstractInstrument
-from ..protocol import AbstractProtocol
-from ..well import AbstractWellCore
+from ..protocol_api.well import WellImplementation
+
+if TYPE_CHECKING:
+    from .protocol_context import ProtocolContextSimulation
 
 
-class InstrumentContextSimulation(AbstractInstrument):
+class InstrumentContextSimulation(AbstractInstrument[WellImplementation]):
     """A simulation of an instrument context."""
 
     def __init__(
         self,
-        protocol_interface: AbstractProtocol,
+        protocol_interface: ProtocolContextSimulation,
         pipette_dict: PipetteDict,
         mount: types.Mount,
         instrument_name: str,
         default_speed: float = 400.0,
-        api_version: typing.Optional[APIVersion] = None,
+        api_version: Optional[APIVersion] = None,
     ):
         """Constructor."""
         self._protocol_interface = protocol_interface
@@ -73,16 +77,16 @@ class InstrumentContextSimulation(AbstractInstrument):
         )
 
     def touch_tip(
-        self, location: AbstractWellCore, radius: float, v_offset: float, speed: float
+        self, location: WellImplementation, radius: float, v_offset: float, speed: float
     ) -> None:
         pass
 
     def pick_up_tip(
         self,
-        well: AbstractWellCore,
+        well: WellImplementation,
         tip_length: float,
-        presses: typing.Optional[int],
-        increment: typing.Optional[float],
+        presses: Optional[int],
+        increment: Optional[float],
         prep_after: bool,
     ) -> None:
         geometry = well.get_geometry()
@@ -113,8 +117,8 @@ class InstrumentContextSimulation(AbstractInstrument):
         self,
         location: types.Location,
         force_direct: bool,
-        minimum_z_height: typing.Optional[float],
-        speed: typing.Optional[float],
+        minimum_z_height: Optional[float],
+        speed: Optional[float],
     ) -> None:
         """Simulation of only the motion planning portion of move_to."""
         last_location = self._protocol_interface.get_last_location()
@@ -188,9 +192,9 @@ class InstrumentContextSimulation(AbstractInstrument):
 
     def set_flow_rate(
         self,
-        aspirate: typing.Optional[float] = None,
-        dispense: typing.Optional[float] = None,
-        blow_out: typing.Optional[float] = None,
+        aspirate: Optional[float] = None,
+        dispense: Optional[float] = None,
+        blow_out: Optional[float] = None,
     ) -> None:
         self._protocol_interface.get_hardware().set_flow_rate(
             mount=self._mount,
@@ -202,9 +206,9 @@ class InstrumentContextSimulation(AbstractInstrument):
 
     def set_pipette_speed(
         self,
-        aspirate: typing.Optional[float] = None,
-        dispense: typing.Optional[float] = None,
-        blow_out: typing.Optional[float] = None,
+        aspirate: Optional[float] = None,
+        dispense: Optional[float] = None,
+        blow_out: Optional[float] = None,
     ) -> None:
         self._protocol_interface.get_hardware().set_pipette_speed(
             mount=self._mount,

--- a/api/src/opentrons/protocol_api/core/simulator/protocol_context.py
+++ b/api/src/opentrons/protocol_api/core/simulator/protocol_context.py
@@ -1,9 +1,11 @@
 import logging
+from typing import Dict, Optional
 
-from opentrons import types
+from opentrons.types import Mount
 
-from ..instrument import AbstractInstrument
+from ..protocol import AbstractProtocol
 from ..protocol_api.protocol_context import ProtocolContextImplementation
+from ..protocol_api.labware import LabwareImplementation
 
 from .instrument_context import InstrumentContextSimulation
 
@@ -11,10 +13,15 @@ from .instrument_context import InstrumentContextSimulation
 logger = logging.getLogger(__name__)
 
 
-class ProtocolContextSimulation(ProtocolContextImplementation):
-    def load_instrument(
-        self, instrument_name: str, mount: types.Mount, replace: bool
-    ) -> AbstractInstrument:
+class ProtocolContextSimulation(
+    ProtocolContextImplementation,
+    AbstractProtocol[InstrumentContextSimulation, LabwareImplementation],
+):
+    _instruments: Dict[Mount, Optional[InstrumentContextSimulation]]  # type: ignore[assignment]
+
+    def load_instrument(  # type: ignore[override]
+        self, instrument_name: str, mount: Mount, replace: bool
+    ) -> InstrumentContextSimulation:
         """Create a simulating instrument context."""
         instr = self._instruments[mount]
         if instr:

--- a/api/src/opentrons/protocol_api/core/well.py
+++ b/api/src/opentrons/protocol_api/core/well.py
@@ -1,74 +1,44 @@
-from __future__ import annotations
+"""Abstract interface for Well core implementations."""
 
-import re
+from abc import ABC, abstractmethod
 
 from opentrons.protocols.geometry.well_geometry import WellGeometry
-from opentrons_shared_data.labware.constants import WELL_NAME_PATTERN
 
 
-class WellImplementation:
+class AbstractWellCore(ABC):
+    """Well core interface."""
 
-    pattern = re.compile(WELL_NAME_PATTERN, re.X)
-
-    def __init__(
-        self, well_geometry: WellGeometry, display_name: str, has_tip: bool, name: str
-    ):
-        """
-        Construct a well
-
-        :param well_geometry: The well's geometry
-        :param display_name: a string that identifies a well. Used primarily
-            for debug and test purposes. Should be unique and human-readable--
-            something like "Tip C3 of Opentrons 300ul Tiprack on Slot 5" or
-            "Well D1 of Biorad 96 PCR Plate on Magnetic Module in Slot 1".
-            This is created by the caller and passed in, so here it is just
-            saved and made available.
-        :param has_tip: whether a tip is present
-        :param name: The well name (ie. A1, B4, C2, etc.)
-        """
-        self._display_name = display_name
-        self._has_tip = has_tip
-        self._name = name
-
-        match = WellImplementation.pattern.match(name)
-        assert match, (
-            f"could not match '{name}' using "
-            f"pattern '{WellImplementation.pattern.pattern}'"
-        )
-        self._row_name = match.group(1)
-        self._column_name = match.group(2)
-        self._geometry = well_geometry
-
+    @abstractmethod
     def has_tip(self) -> bool:
-        return self._has_tip
+        """Whether the well contains a tip."""
+        ...
 
+    @abstractmethod
     def set_has_tip(self, value: bool) -> None:
-        self._has_tip = value
+        """Set the well as containing or not containing a tip."""
+        ...
 
+    @abstractmethod
     def get_display_name(self) -> str:
-        return self._display_name
+        """Get the well's full display name."""
+        ...
 
+    @abstractmethod
     def get_name(self) -> str:
-        """The name of the well (ie A1, A2,... B3,...C10"""
-        return self._name
+        """Get the name of the well (e.g. "A1")."""
+        ...
 
+    @abstractmethod
     def get_column_name(self) -> str:
-        """The column portion of the well name"""
-        return self._column_name
+        """Get the column portion of the well name (e.g. "A")."""
+        ...
 
+    @abstractmethod
     def get_row_name(self) -> str:
-        """The row portion of the well name"""
-        return self._row_name
+        """Get the row portion of the well name (e.g. "1")."""
+        ...
 
+    @abstractmethod
     def get_geometry(self) -> WellGeometry:
-        return self._geometry
-
-    def __repr__(self) -> str:
-        return self.get_display_name()
-
-    def __eq__(self, other: object) -> bool:
-        """Assume that if name is the same then it's the same well"""
-        return (
-            isinstance(other, WellImplementation)
-            and self.get_name() == other.get_name()
-        )
+        """Get the well's geometry information interface."""
+        ...

--- a/api/src/opentrons/protocol_api/core/well.py
+++ b/api/src/opentrons/protocol_api/core/well.py
@@ -1,6 +1,7 @@
 """Abstract interface for Well core implementations."""
 
 from abc import ABC, abstractmethod
+from typing import TypeVar
 
 from opentrons.protocols.geometry.well_geometry import WellGeometry
 
@@ -42,3 +43,6 @@ class AbstractWellCore(ABC):
     def get_geometry(self) -> WellGeometry:
         """Get the well's geometry information interface."""
         ...
+
+
+WellCoreType = TypeVar("WellCoreType", bound=AbstractWellCore)

--- a/api/src/opentrons/protocol_api/create_protocol_context.py
+++ b/api/src/opentrons/protocol_api/create_protocol_context.py
@@ -1,4 +1,5 @@
 """ProtocolContext factory."""
+import asyncio
 from typing import Dict, Optional, Union
 
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
@@ -10,6 +11,7 @@ from opentrons.hardware_control import (
     SynchronousAdapter,
 )
 from opentrons.protocol_engine import ProtocolEngine
+from opentrons.protocol_engine.clients import SyncClient, ChildThreadTransport
 from opentrons.protocols.api_support.types import APIVersion
 
 from .protocol_context import ProtocolContext
@@ -22,6 +24,7 @@ from .core.labware_offset_provider import (
 from .core.protocol import AbstractProtocol
 from .core.protocol_api.protocol_context import ProtocolContextImplementation
 from .core.simulator.protocol_context import ProtocolContextSimulation
+from .core.engine import ProtocolCore
 
 
 def create_protocol_context(
@@ -29,6 +32,7 @@ def create_protocol_context(
     *,
     hardware_api: Union[HardwareControlAPI, ThreadManager[HardwareControlAPI]],
     protocol_engine: Optional[ProtocolEngine] = None,
+    protocol_engine_loop: Optional[asyncio.AbstractEventLoop] = None,
     use_simulating_core: bool = False,
     extra_labware: Optional[Dict[str, LabwareDefinition]] = None,
     bundled_labware: Optional[Dict[str, LabwareDefinition]] = None,
@@ -42,6 +46,8 @@ def create_protocol_context(
         protocol_engine: A ProtocolEngine to use for labware offsets
             and core protocol logic. If omitted, labware offsets will
             all be (0, 0, 0) and ProtocolEngine-based core will not work.
+        protocol_engine_loop: An event loop running in the thread where
+            ProtocolEngine mutations must occur.
         use_simulating_core: For pre-ProtocolEngine API versions,
             use a simulating protocol core that will skip _most_ calls
             to the `hardware_api`.
@@ -69,11 +75,21 @@ def create_protocol_context(
     else:
         labware_offset_provider = NullLabwareOffsetProvider()
 
+    # TODO(mc, 2022-8-22): replace with API version check
     if feature_flags.enable_protocol_engine_papi_core():
-        # TODO(mc, 2022-8-22): replace with API version check
-        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+        # TODO(mc, 2022-8-22): replace assertion with strict typing
+        assert (
+            protocol_engine is not None and protocol_engine_loop is not None
+        ), "ProtocolEngine PAPI core is enabled, but no ProtocolEngine given."
+
+        engine_client_transport = ChildThreadTransport(
+            engine=protocol_engine, loop=protocol_engine_loop
+        )
+        engine_client = SyncClient(transport=engine_client_transport)
+        core = ProtocolCore(engine_client=engine_client)
+
+    # TODO(mc, 2022-8-22): remove `disable_fast_protocol_upload`
     elif use_simulating_core and not feature_flags.disable_fast_protocol_upload():
-        # TODO(mc, 2022-8-22): remove `disable_fast_protocol_upload`
         core = ProtocolContextSimulation(
             sync_hardware=sync_hardware,
             api_version=api_version,
@@ -81,6 +97,7 @@ def create_protocol_context(
             bundled_data=bundled_data,
             extra_labware=extra_labware,
         )
+
     else:
         core = ProtocolContextImplementation(
             sync_hardware=sync_hardware,

--- a/api/src/opentrons/protocol_api/create_protocol_context.py
+++ b/api/src/opentrons/protocol_api/create_protocol_context.py
@@ -1,6 +1,6 @@
 """ProtocolContext factory."""
 import asyncio
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
@@ -63,7 +63,7 @@ def create_protocol_context(
     """
     sync_hardware: SynchronousAdapter[HardwareControlAPI]
     labware_offset_provider: AbstractLabwareOffsetProvider
-    core: AbstractProtocol
+    core: AbstractProtocol[Any, Any]
 
     if isinstance(hardware_api, ThreadManager):
         sync_hardware = hardware_api.sync

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -25,6 +25,7 @@ from opentrons.protocols.api_support.util import (
 )
 
 from .core.instrument import AbstractInstrument
+from .core.well import AbstractWellCore
 from .module_contexts import ThermocyclerContext, HeaterShakerContext
 from . import labware
 
@@ -61,7 +62,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
     def __init__(
         self,
-        implementation: AbstractInstrument,
+        implementation: AbstractInstrument[AbstractWellCore],
         ctx: ProtocolContext,
         broker: Broker,
         at_version: APIVersion,

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -245,7 +245,9 @@ class Labware(DeckItem):
     """
 
     def __init__(
-        self, implementation: AbstractLabware, api_level: Optional[APIVersion] = None
+        self,
+        implementation: AbstractLabware[Any],
+        api_level: Optional[APIVersion] = None,
     ) -> None:
         """
         :param implementation: The class that implements the public interface

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -267,7 +267,7 @@ class Labware(DeckItem):
                 f"version or update your robot."
             )
         self._api_version = api_level
-        self._implementation = implementation
+        self._implementation: AbstractLabware[AbstractWellCore] = implementation
 
     @property
     def separate_calibration(self) -> bool:

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -24,7 +24,7 @@ from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 from opentrons.protocols.geometry.deck_item import DeckItem
 
 from .core.labware import AbstractLabware
-from .core.well import WellImplementation
+from .core.well import AbstractWellCore
 
 if TYPE_CHECKING:
     from opentrons.protocols.geometry.module_geometry import (  # noqa: F401
@@ -57,7 +57,7 @@ class Well:
 
     def __init__(
         self,
-        well_implementation: WellImplementation,
+        well_implementation: AbstractWellCore,
         api_level: Optional[APIVersion] = None,
     ):
         """
@@ -684,7 +684,7 @@ class Labware(DeckItem):
         if self._is_tiprack:
             self._implementation.reset_tips()
 
-    def _well_from_impl(self, well: WellImplementation) -> Well:
+    def _well_from_impl(self, well: AbstractWellCore) -> Well:
         return Well(well_implementation=well, api_level=self._api_version)
 
 

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -35,6 +35,8 @@ from opentrons.protocols.geometry.module_geometry import (
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 
+from .core.instrument import AbstractInstrument
+from .core.well import AbstractWellCore
 from .core.labware import AbstractLabware
 from .core.protocol import AbstractProtocol
 from .core.labware_offset_provider import AbstractLabwareOffsetProvider
@@ -93,7 +95,9 @@ class ProtocolContext(CommandPublisher):
     def __init__(
         self,
         api_version: APIVersion,
-        implementation: AbstractProtocol,
+        implementation: AbstractProtocol[
+            AbstractInstrument[AbstractWellCore], AbstractLabware[AbstractWellCore]
+        ],
         labware_offset_provider: AbstractLabwareOffsetProvider,
         broker: Optional[Broker] = None,
     ) -> None:

--- a/api/src/opentrons/protocol_runner/legacy_wrappers.py
+++ b/api/src/opentrons/protocol_runner/legacy_wrappers.py
@@ -1,6 +1,8 @@
 """Wrappers for the legacy, Protocol API v2 execution pipeline."""
-from anyio import to_thread
+import asyncio
 from typing import cast
+
+from anyio import to_thread
 
 from opentrons_shared_data.labware.dev_types import (
     LabwareDefinition as LegacyLabwareDefinition,
@@ -113,6 +115,7 @@ class LegacyContextCreator:
             api_version=protocol.api_level,
             hardware_api=self._hardware_api,
             protocol_engine=self._protocol_engine,
+            protocol_engine_loop=asyncio.get_running_loop(),
             extra_labware=extra_labware,
             use_simulating_core=self._USE_SIMULATING_CORE,
         )

--- a/api/src/opentrons/protocols/api_support/tip_tracker.py
+++ b/api/src/opentrons/protocols/api_support/tip_tracker.py
@@ -1,10 +1,10 @@
 from itertools import dropwhile, takewhile
 from typing import Optional, Sequence
 
-from opentrons.protocol_api.core.well import WellImplementation
+from opentrons.protocol_api.core.well import AbstractWellCore
 
 
-Wells = Sequence[WellImplementation]
+Wells = Sequence[AbstractWellCore]
 WellColumns = Sequence[Wells]
 
 
@@ -13,8 +13,8 @@ class TipTracker:
         self._columns = columns
 
     def next_tip(
-        self, num_tips: int = 1, starting_tip: Optional[WellImplementation] = None
-    ) -> Optional[WellImplementation]:
+        self, num_tips: int = 1, starting_tip: Optional[AbstractWellCore] = None
+    ) -> Optional[AbstractWellCore]:
         """
         Find the next valid well for pick-up.
 
@@ -54,7 +54,7 @@ class TipTracker:
 
         try:
             first_long_enough = long_enough[0]
-            result: Optional[WellImplementation] = first_long_enough[0]
+            result: Optional[AbstractWellCore] = first_long_enough[0]
         except IndexError:
             result = None
 
@@ -62,7 +62,7 @@ class TipTracker:
 
     def use_tips(
         self,
-        start_well: WellImplementation,
+        start_well: AbstractWellCore,
         num_channels: int = 1,
         fail_if_full: bool = False,
     ):
@@ -114,7 +114,7 @@ class TipTracker:
         for well in target_wells:
             well.set_has_tip(False)
 
-    def previous_tip(self, num_tips: int = 1) -> Optional[WellImplementation]:
+    def previous_tip(self, num_tips: int = 1) -> Optional[AbstractWellCore]:
         """
         Find the best well to drop a tip in.
 
@@ -142,7 +142,7 @@ class TipTracker:
         except IndexError:
             return None
 
-    def return_tips(self, start_well: WellImplementation, num_channels: int = 1):
+    def return_tips(self, start_well: AbstractWellCore, num_channels: int = 1):
         """
         Re-adds tips to the tip tracker
 

--- a/api/src/opentrons/protocols/api_support/well_grid.py
+++ b/api/src/opentrons/protocols/api_support/well_grid.py
@@ -2,10 +2,10 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Dict, Sequence
 
-from opentrons.protocol_api.core.well import WellImplementation
+from opentrons.protocol_api.core.well import AbstractWellCore
 
 
-Wells = Sequence[WellImplementation]
+Wells = Sequence[AbstractWellCore]
 HeaderToWells = Dict[str, Wells]
 WellsByDimension = Sequence[Wells]
 
@@ -22,7 +22,7 @@ class WellGrid:
     def __init__(self, wells: Wells):
         """
         Construct well grid from a collection of well objects ordered as they
-         appear in ordering` field of Labware Defnition
+         appear in ordering` field of Labware Definition
         """
         self._grid = self._create_row_column(wells)
         self._row_headers = sorted(self._grid.rows.keys())

--- a/api/src/opentrons/protocols/labware/load.py
+++ b/api/src/opentrons/protocols/labware/load.py
@@ -8,7 +8,7 @@ from opentrons.types import Location
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 if TYPE_CHECKING:
-    from opentrons.protocol_api.core.labware import AbstractLabware
+    from opentrons.protocol_api.core.protocol_api.labware import LabwareImplementation
 
 
 MODULE_LOG = logging.getLogger(__name__)
@@ -18,7 +18,7 @@ def load_from_definition(
     definition: LabwareDefinition,
     parent: Location,
     label: str = None,
-) -> AbstractLabware:
+) -> LabwareImplementation:
     """
     Return a labware object constructed from a provided labware definition dict
 
@@ -49,7 +49,7 @@ def load(
     version: int = 1,
     bundled_defs: Dict[str, LabwareDefinition] = None,
     extra_defs: Dict[str, LabwareDefinition] = None,
-) -> AbstractLabware:
+) -> LabwareImplementation:
     """
     Return a labware object constructed from a labware definition dict looked
     up by name (definition must have been previously stored locally on the

--- a/api/tests/opentrons/protocol_api/core/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/core/protocol_api/test_instrument_context.py
@@ -8,7 +8,9 @@ from opentrons.types import Mount
 from opentrons.hardware_control import SyncHardwareAPI
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
-from opentrons.protocol_api.core.protocol import AbstractProtocol
+from opentrons.protocol_api.core.protocol_api.protocol_context import (
+    ProtocolContextImplementation,
+)
 
 from opentrons.protocol_api.core.protocol_api.instrument_context import (
     InstrumentContextImplementation,
@@ -46,15 +48,15 @@ def mock_sync_hardware_api(
 @pytest.fixture
 def mock_protocol_impl(
     decoy: Decoy, mock_sync_hardware_api: SyncHardwareAPI
-) -> AbstractProtocol:
-    protocol_impl = decoy.mock(cls=AbstractProtocol)
+) -> ProtocolContextImplementation:
+    protocol_impl = decoy.mock(cls=ProtocolContextImplementation)
     decoy.when(protocol_impl.get_hardware()).then_return(mock_sync_hardware_api)
     return protocol_impl
 
 
 @pytest.fixture
 def subject(
-    mock_protocol_impl: AbstractProtocol,
+    mock_protocol_impl: ProtocolContextImplementation,
     mount: Mount,
     api_version: APIVersion,
 ) -> InstrumentContextImplementation:
@@ -83,7 +85,7 @@ def test_home(
 
 
 @pytest.mark.parametrize("api_version", [APIVersion(2, 12)])
-def test_home_legacy_behvaior(
+def test_home_legacy_behavior(
     mount: Mount,
     decoy: Decoy,
     mock_sync_hardware_api: SyncHardwareAPI,

--- a/api/tests/opentrons/protocol_api/core/protocol_api/test_well_implementation.py
+++ b/api/tests/opentrons/protocol_api/core/protocol_api/test_well_implementation.py
@@ -1,5 +1,6 @@
 import pytest
-from opentrons.protocol_api.core.well import WellImplementation
+
+from opentrons.protocol_api.core.protocol_api.well import WellImplementation
 
 
 @pytest.mark.parametrize(

--- a/api/tests/opentrons/protocol_api/core/simulator/conftest.py
+++ b/api/tests/opentrons/protocol_api/core/simulator/conftest.py
@@ -1,11 +1,12 @@
 import pytest
 from opentrons import types
 from opentrons.hardware_control import ThreadManagedHardware
-from opentrons.protocol_api.core.instrument import AbstractInstrument
-from opentrons.protocol_api.core.labware import AbstractLabware
 from opentrons.protocol_api.core.protocol_api.labware import LabwareImplementation
 from opentrons.protocol_api.core.protocol_api.protocol_context import (
     ProtocolContextImplementation,
+)
+from opentrons.protocol_api.core.protocol_api.instrument_context import (
+    InstrumentContextImplementation,
 )
 from opentrons.protocol_api.core.simulator.instrument_context import (
     InstrumentContextSimulation,
@@ -33,7 +34,7 @@ def simulating_protocol_context(
 @pytest.fixture
 def instrument_context(
     protocol_context: ProtocolContextImplementation,
-) -> AbstractInstrument:
+) -> InstrumentContextImplementation:
     """Instrument context backed by hardware simulator."""
     return protocol_context.load_instrument(
         "p300_single_gen2", types.Mount.RIGHT, replace=False
@@ -43,7 +44,7 @@ def instrument_context(
 @pytest.fixture
 def second_instrument_context(
     protocol_context: ProtocolContextImplementation,
-) -> AbstractInstrument:
+) -> InstrumentContextImplementation:
     """Instrument context backed by hardware simulator."""
     return protocol_context.load_instrument(
         "p300_single_gen2", types.Mount.LEFT, replace=False
@@ -52,12 +53,12 @@ def second_instrument_context(
 
 @pytest.fixture
 def simulating_instrument_context(
-    protocol_context: ProtocolContextImplementation,
-    instrument_context: AbstractInstrument,
-) -> AbstractInstrument:
+    simulating_protocol_context: ProtocolContextSimulation,
+    instrument_context: InstrumentContextImplementation,
+) -> InstrumentContextSimulation:
     """A simulating instrument context."""
     return InstrumentContextSimulation(
-        protocol_interface=protocol_context,
+        protocol_interface=simulating_protocol_context,
         pipette_dict=instrument_context.get_pipette(),
         mount=types.Mount.RIGHT,
         instrument_name="p300_single_gen2",
@@ -66,12 +67,12 @@ def simulating_instrument_context(
 
 @pytest.fixture
 def second_simulating_instrument_context(
-    protocol_context: ProtocolContextImplementation,
-    second_instrument_context: AbstractInstrument,
-) -> AbstractInstrument:
+    simulating_protocol_context: ProtocolContextSimulation,
+    second_instrument_context: InstrumentContextImplementation,
+) -> InstrumentContextSimulation:
     """A simulating instrument context."""
     return InstrumentContextSimulation(
-        protocol_interface=protocol_context,
+        protocol_interface=simulating_protocol_context,
         pipette_dict=second_instrument_context.get_pipette(),
         mount=types.Mount.LEFT,
         instrument_name="p300_single_gen2",
@@ -79,7 +80,7 @@ def second_simulating_instrument_context(
 
 
 @pytest.fixture
-def labware(minimal_labware_def: LabwareDefinition) -> AbstractLabware:
+def labware(minimal_labware_def: LabwareDefinition) -> LabwareImplementation:
     """Labware fixture."""
     return LabwareImplementation(
         definition=minimal_labware_def,
@@ -88,7 +89,7 @@ def labware(minimal_labware_def: LabwareDefinition) -> AbstractLabware:
 
 
 @pytest.fixture
-def second_labware(minimal_labware_def: LabwareDefinition) -> AbstractLabware:
+def second_labware(minimal_labware_def: LabwareDefinition) -> LabwareImplementation:
     """Labware fixture."""
     return LabwareImplementation(
         definition=minimal_labware_def,

--- a/api/tests/opentrons/protocol_api/core/simulator/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/core/simulator/test_instrument_context.py
@@ -6,8 +6,15 @@ from pytest_lazyfixture import lazy_fixture  # type: ignore[import]
 
 from opentrons.hardware_control import NoTipAttachedError
 from opentrons.hardware_control.types import TipAttachedError
-from opentrons.protocol_api.core.labware import AbstractLabware
-from opentrons.protocol_api.core.instrument import AbstractInstrument
+from opentrons.protocol_api.core.labware import AbstractLabware as BaseAbstractLabware
+from opentrons.protocol_api.core.well import AbstractWellCore
+from opentrons.protocol_api.core.instrument import (
+    AbstractInstrument as BaseAbstractInstrument,
+)
+
+
+AbstractInstrument = BaseAbstractInstrument[AbstractWellCore]
+AbstractLabware = BaseAbstractLabware[AbstractWellCore]
 
 
 @pytest.fixture(

--- a/api/tests/opentrons/protocol_api/core/simulator/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/core/simulator/test_protocol_context.py
@@ -1,10 +1,21 @@
 """Test instrument context simulation."""
 import pytest
-from opentrons.protocol_api.core.protocol import AbstractProtocol
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import]
 
-from opentrons.protocol_api.core.labware import AbstractLabware
+from opentrons.protocol_api.core.protocol import (
+    AbstractProtocol as BaseAbstractProtocol,
+)
+from opentrons.protocol_api.core.labware import AbstractLabware as BaseAbstractLabware
+from opentrons.protocol_api.core.instrument import (
+    AbstractInstrument as BaseAbstractInstrument,
+)
+from opentrons.protocol_api.core.well import AbstractWellCore
 from opentrons import types
+
+
+AbstractInstrument = BaseAbstractInstrument[AbstractWellCore]
+AbstractLabware = BaseAbstractLabware[AbstractWellCore]
+AbstractProtocol = BaseAbstractProtocol[AbstractInstrument, AbstractLabware]
 
 
 @pytest.fixture(

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -12,6 +12,7 @@ from opentrons.protocol_api import ProtocolContext, labware
 from opentrons.protocol_api.instrument_context import InstrumentContext
 from opentrons.protocol_api.labware import Well, Labware
 from opentrons.protocol_api.core.instrument import AbstractInstrument
+from opentrons.protocol_api.core.well import AbstractWellCore
 
 
 @pytest.fixture(autouse=True)
@@ -65,7 +66,9 @@ def mock_protocol_context(decoy: Decoy) -> ProtocolContext:
 
 
 @pytest.fixture
-def mock_instrument_implementation(decoy: Decoy) -> AbstractInstrument:
+def mock_instrument_implementation(
+    decoy: Decoy,
+) -> AbstractInstrument[AbstractWellCore]:
     return decoy.mock(cls=AbstractInstrument)
 
 
@@ -76,7 +79,7 @@ def mock_labware(decoy: Decoy) -> Labware:
 
 @pytest.fixture
 def subject(
-    mock_instrument_implementation: AbstractInstrument,
+    mock_instrument_implementation: AbstractInstrument[AbstractWellCore],
     mock_protocol_context: ProtocolContext,
 ) -> InstrumentContext:
 
@@ -93,7 +96,7 @@ def subject(
 def test_pick_up_from_exact_well_location(
     decoy: Decoy,
     subject: InstrumentContext,
-    mock_instrument_implementation: AbstractInstrument,
+    mock_instrument_implementation: AbstractInstrument[AbstractWellCore],
 ) -> None:
     """Should pick up tip from supplied exact Well Location."""
     mock_well = decoy.mock(cls=Well)
@@ -116,7 +119,7 @@ def test_pick_up_from_exact_well_location(
 def test_pick_up_from_exact_labware_location(
     decoy: Decoy,
     subject: InstrumentContext,
-    mock_instrument_implementation: AbstractInstrument,
+    mock_instrument_implementation: AbstractInstrument[AbstractWellCore],
     mock_labware: Labware,
 ) -> None:
     """Should pick up tip from supplied exact labware Location."""
@@ -146,7 +149,7 @@ def test_pick_up_from_exact_labware_location(
 def test_pick_up_from_manipulated_location(
     decoy: Decoy,
     subject: InstrumentContext,
-    mock_instrument_implementation: AbstractInstrument,
+    mock_instrument_implementation: AbstractInstrument[AbstractWellCore],
 ) -> None:
     """Should pick up tip from move result of types.Location."""
 
@@ -170,7 +173,7 @@ def test_pick_up_from_manipulated_location(
 def test_pick_up_from_well(
     decoy: Decoy,
     subject: InstrumentContext,
-    mock_instrument_implementation: AbstractInstrument,
+    mock_instrument_implementation: AbstractInstrument[AbstractWellCore],
     mock_labware: Labware,
 ) -> None:
     """Should pick up tip from supplied well location top."""
@@ -200,7 +203,7 @@ def test_pick_up_from_well(
 def test_pick_up_from_no_location(
     decoy: Decoy,
     subject: InstrumentContext,
-    mock_instrument_implementation: AbstractInstrument,
+    mock_instrument_implementation: AbstractInstrument[AbstractWellCore],
     mock_labware: Labware,
 ) -> None:
     """Should pick up tip from next_available_tip.top()."""

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -9,7 +9,7 @@ from opentrons.protocol_api import labware, MAX_SUPPORTED_VERSION
 from opentrons.protocols.geometry import module_geometry
 from opentrons.protocols.geometry.well_geometry import WellGeometry
 from opentrons.protocol_api.core.protocol_api.labware import LabwareImplementation
-from opentrons.protocol_api.core.well import WellImplementation
+from opentrons.protocol_api.core.protocol_api.well import WellImplementation
 from opentrons.protocols.labware.definition import _get_parent_identifier
 
 from opentrons_shared_data import load_shared_data

--- a/api/tests/opentrons/protocols/api_support/test_instrument.py
+++ b/api/tests/opentrons/protocols/api_support/test_instrument.py
@@ -8,7 +8,7 @@ from opentrons.protocols.api_support.instrument import (
     validate_can_dispense,
 )
 from opentrons.protocols.geometry.well_geometry import WellGeometry
-from opentrons.protocol_api.core.well import WellImplementation
+from opentrons.protocol_api.core.protocol_api.well import WellImplementation
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.types import Point
 

--- a/api/tests/opentrons/protocols/api_support/test_tip_tracker.py
+++ b/api/tests/opentrons/protocols/api_support/test_tip_tracker.py
@@ -2,7 +2,7 @@ from typing import List
 
 import pytest
 from opentrons.protocols.api_support.tip_tracker import TipTracker
-from opentrons.protocol_api.core.well import WellImplementation
+from opentrons.protocol_api.core.protocol_api.well import WellImplementation
 from opentrons.protocols.api_support.well_grid import WellGrid
 
 

--- a/api/tests/opentrons/protocols/api_support/test_well_grid.py
+++ b/api/tests/opentrons/protocols/api_support/test_well_grid.py
@@ -2,9 +2,9 @@ from typing import List
 
 import pytest
 from opentrons.protocols.api_support.well_grid import WellGrid
-from opentrons.protocol_api.core.well import WellImplementation
+from opentrons.protocol_api.core.protocol_api.well import WellImplementation
 
-NONE: list = []
+NONE: List[str] = []
 ONE_VAL = ["A1"]
 NORMAL = [
     "A1",

--- a/api/tests/opentrons/protocols/execution/test_execute_json_v3.py
+++ b/api/tests/opentrons/protocols/execution/test_execute_json_v3.py
@@ -1,6 +1,6 @@
 from opentrons.protocols.geometry.well_geometry import WellGeometry
 from opentrons.protocol_api.core.protocol_api.labware import LabwareImplementation
-from opentrons.protocol_api.core.well import WellImplementation
+from opentrons.protocol_api.core.protocol_api.well import WellImplementation
 
 from unittest import mock
 from copy import deepcopy

--- a/api/tests/opentrons/protocols/execution/test_execute_json_v5.py
+++ b/api/tests/opentrons/protocols/execution/test_execute_json_v5.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 from opentrons.protocols.geometry.well_geometry import WellGeometry
-from opentrons.protocol_api.core.well import WellImplementation
+from opentrons.protocol_api.core.protocol_api.well import WellImplementation
 from opentrons.types import Point
 from opentrons.protocol_api import InstrumentContext, labware, MAX_SUPPORTED_VERSION
 from opentrons.protocols.execution.execute_json_v5 import _move_to_well


### PR DESCRIPTION
## Overview

This PR adds a skeleton `ProtocolEngine`-based `ProtocolCore` (and friends) to `opentrons.protocol_api.core`, to be used in Python protocols if the `enableProtocolEnginePAPICore` feature-flag is enabled.

Closes RCORE-99

## Changelog

- wire a no-op ProtocolEngine core to PAPIv2 given FF
- refactor `WellImplemenation` into `AbstractWellCore` and implementations, following the patterns set by `AbstractLabware` and `AbstractInstrument`
- Make the `Abstract...` classes in `core` generic, so that concrete implementations can be even more concrete
    - More specifically, it means a `core.engine.ProtocolCore` can declare itself as returning `core.engine.LabwareCore` rather than `core.labware.AbstractLabware`, etc.
    - This will be really important since the engine-based cores are going to differ significantly from the legacy cores
    - It wasn't important before because the fast sim cores do not really differ from the legacy cores 

## Review requests

- [ ] Smoke test protocol analysis in app
- [ ] Smoke test protocol analysis/run via on robot via HTTP
    - [ ] FF off: no noticeable regressions
    - [ ] FF on: completely no-op protocol succeeds
    - [ ] FF on: protocols that do anything at all fail with `NotImplementedError`

## Risk assessment

Low, changes are pretty contained compared to #11379
