### PR TITLE
fix(heater-shaker): updated dfu locking mechanism

### DIFF
--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -442,10 +442,9 @@ class HeaterShaker(mod_abc.AbstractModule):
 
     async def prep_for_update(self) -> str:
         await self._poller.stop_and_wait()
-        async with update.protect_dfu_transition():
-            await self._driver.enter_programming_mode()
-            dfu_info = await update.find_dfu_device(pid=DFU_PID)
-            return dfu_info
+        await self._driver.enter_programming_mode()
+        dfu_info = await update.find_dfu_device(pid=DFU_PID)
+        return dfu_info
 
 
 @dataclass

--- a/api/src/opentrons/hardware_control/modules/update.py
+++ b/api/src/opentrons/hardware_control/modules/update.py
@@ -29,18 +29,19 @@ async def update_firmware(
 
     raises an UpdateError with the reason for the failure.
     """
-    flash_port_or_dfu_serial = await module.prep_for_update()
-    kwargs: Dict[str, Any] = {
-        "stdout": asyncio.subprocess.PIPE,
-        "stderr": asyncio.subprocess.PIPE,
-        "loop": loop,
-    }
-    successful, res = await module.bootloader()(
-        flash_port_or_dfu_serial, str(firmware_file), kwargs
-    )
-    if not successful:
-        log.info(f"Bootloader reponse: {res}")
-        raise UpdateError(res)
+    async with protect_dfu_transition():
+        flash_port_or_dfu_serial = await module.prep_for_update()
+        kwargs: Dict[str, Any] = {
+            "stdout": asyncio.subprocess.PIPE,
+            "stderr": asyncio.subprocess.PIPE,
+            "loop": loop,
+        }
+        successful, res = await module.bootloader()(
+            flash_port_or_dfu_serial, str(firmware_file), kwargs
+        )
+        if not successful:
+            log.info(f"Bootloader reponse: {res}")
+            raise UpdateError(res)
 
 
 async def find_bootloader_port() -> str:

--- a/api/src/opentrons/hardware_control/modules/update.py
+++ b/api/src/opentrons/hardware_control/modules/update.py
@@ -11,12 +11,12 @@ from contextlib import asynccontextmanager
 
 log = logging.getLogger(__name__)
 
-_dfu_transition_lock = ThreadedAsyncLock()
+_update_transition_lock = ThreadedAsyncLock()
 
 
 @asynccontextmanager
-async def protect_dfu_transition() -> AsyncGenerator[None, None]:
-    async with _dfu_transition_lock.lock():
+async def protect_update_transition() -> AsyncGenerator[None, None]:
+    async with _update_transition_lock.lock():
         yield
 
 
@@ -29,7 +29,7 @@ async def update_firmware(
 
     raises an UpdateError with the reason for the failure.
     """
-    async with protect_dfu_transition():
+    async with protect_update_transition():
         flash_port_or_dfu_serial = await module.prep_for_update()
         kwargs: Dict[str, Any] = {
             "stdout": asyncio.subprocess.PIPE,


### PR DESCRIPTION
## overview

Adds locking mechanism to module updates such that only one module will be able to be updated at one time. 

## review

Successfully tested on robot with two heater-shaker modules by connecting to robot (`make term host=THE.ROBOT.IP.ADDRESS`), starting logging (`journalctl -f`), and clicking both modules' `Update module firmware` button in quick succession (log below).

```
Sep 12 20:54:10 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'dfu \n'
Sep 12 20:54:10 OT2CEP20200811B09 opentrons-api[5956]: Searching for a dfu device with PID df11
Sep 12 20:54:10 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:10 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.12 T:None OK\n'
Sep 12 20:54:10 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:10 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:10 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:10 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:11 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:11 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /modules HTTP/1.1" 200 OK
Sep 12 20:54:11 OT2CEP20200811B09 kernel: usb 1-1.3.4: USB disconnect, device number 21
Sep 12 20:54:11 OT2CEP20200811B09 opentrons-api[5956]: Module Removed: ModuleAtPort(port='/dev/ot_module_heatershaker3', name='heatershaker', usb_port=USBPort(name='', port_number=0, device_path='', hub=None))
Sep 12 20:54:11 OT2CEP20200811B09 opentrons-api[5956]: Module heatershaker detached from port /dev/ot_module_heatershaker3
Sep 12 20:54:12 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:12 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.11 T:None OK\n'
Sep 12 20:54:12 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:12 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:12 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:12 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:12 OT2CEP20200811B09 kernel: usb 1-1.3.4: new full-speed USB device number 24 using dwc_otg
Sep 12 20:54:12 OT2CEP20200811B09 kernel: usb 1-1.3.4: New USB device found, idVendor=0483, idProduct=df11
Sep 12 20:54:12 OT2CEP20200811B09 kernel: usb 1-1.3.4: New USB device strings: Mfr=1, Product=2, SerialNumber=3
Sep 12 20:54:12 OT2CEP20200811B09 kernel: usb 1-1.3.4: Product: STM32  BOOTLOADER
Sep 12 20:54:12 OT2CEP20200811B09 kernel: usb 1-1.3.4: Manufacturer: STMicroelectronics
Sep 12 20:54:12 OT2CEP20200811B09 kernel: usb 1-1.3.4: SerialNumber: 2040B5562033
Sep 12 20:54:12 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /health HTTP/1.1" 200 OK
Sep 12 20:54:12 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /robot/lights HTTP/1.1" 200 OK
Sep 12 20:54:12 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:12 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:13 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:13 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.12 T:None OK\n'
Sep 12 20:54:13 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:13 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:13 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:13 OT2CEP20200811B09 opentrons-api[5956]: Found device with PID df11
Sep 12 20:54:13 OT2CEP20200811B09 opentrons-api[5956]: Found device with PID df11
Sep 12 20:54:13 OT2CEP20200811B09 opentrons-api[5956]: Starting firmware upload via dfu util
Sep 12 20:54:13 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:13 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:14 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:14 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.11 T:None OK\n'
Sep 12 20:54:14 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:14 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:14 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:14 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:14 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:14 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /pipettes HTTP/1.1" 200 OK
Sep 12 20:54:15 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:15 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.12 T:None OK\n'
Sep 12 20:54:15 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:15 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:15 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:15 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:15 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:16 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:16 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.11 T:None OK\n'
Sep 12 20:54:16 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:16 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:16 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:16 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:16 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:16 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /modules HTTP/1.1" 200 OK
Sep 12 20:54:17 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:17 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.10 T:None OK\n'
Sep 12 20:54:17 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:17 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:17 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:17 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:17 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /robot/lights HTTP/1.1" 200 OK
Sep 12 20:54:17 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:18 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:18 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.11 T:None OK\n'
Sep 12 20:54:18 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:18 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:18 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:18 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:18 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:19 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:19 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.10 T:None OK\n'
Sep 12 20:54:19 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:19 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:19 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:19 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:19 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:19 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /pipettes HTTP/1.1" 200 OK
Sep 12 20:54:20 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:20 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:20 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.11 T:None OK\n'
Sep 12 20:54:20 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:20 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:20 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:20 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:21 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:21 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:21 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.11 T:None OK\n'
Sep 12 20:54:21 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:21 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:21 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:21 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:21 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /modules HTTP/1.1" 200 OK
Sep 12 20:54:22 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /robot/lights HTTP/1.1" 200 OK
Sep 12 20:54:22 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:22 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:22 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.08 T:None OK\n'
Sep 12 20:54:22 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:22 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:22 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:22 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:23 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:23 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:23 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.11 T:None OK\n'
Sep 12 20:54:23 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:23 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:23 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:23 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:24 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:24 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /pipettes HTTP/1.1" 200 OK
Sep 12 20:54:24 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:24 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.11 T:None OK\n'
Sep 12 20:54:24 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:24 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:24 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:24 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:25 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:25 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:25 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.12 T:None OK\n'
Sep 12 20:54:25 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:25 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:25 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:25 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:26 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:26 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /modules HTTP/1.1" 200 OK
Sep 12 20:54:26 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:26 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.11 T:None OK\n'
Sep 12 20:54:26 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:26 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:26 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:26 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:27 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /health HTTP/1.1" 200 OK
Sep 12 20:54:27 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /robot/lights HTTP/1.1" 200 OK
Sep 12 20:54:27 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:27 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:27 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.11 T:None OK\n'
Sep 12 20:54:27 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:27 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:27 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:27 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:28 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:28 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:28 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.11 T:None OK\n'
Sep 12 20:54:28 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:28 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:28 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:28 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:29 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:29 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /pipettes HTTP/1.1" 200 OK
Sep 12 20:54:29 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:29 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.12 T:None OK\n'
Sep 12 20:54:29 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:29 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:29 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:29 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:30 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:30 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:30 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.11 T:None OK\n'
Sep 12 20:54:30 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:30 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:30 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:30 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:31 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:31 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /modules HTTP/1.1" 200 OK
Sep 12 20:54:31 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:31 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.11 T:None OK\n'
Sep 12 20:54:31 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:31 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:31 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:32 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:32 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /robot/lights HTTP/1.1" 200 OK
Sep 12 20:54:32 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:33 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:33 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.11 T:None OK\n'
Sep 12 20:54:33 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:33 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:33 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:33 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:33 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:34 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:34 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.12 T:None OK\n'
Sep 12 20:54:34 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:34 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:34 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:34 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:34 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:34 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /pipettes HTTP/1.1" 200 OK
Sep 12 20:54:35 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:35 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.12 T:None OK\n'
Sep 12 20:54:35 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:35 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:35 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:35 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:35 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:36 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:36 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.11 T:None OK\n'
Sep 12 20:54:36 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:36 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:36 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:36 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:36 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:36 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /modules HTTP/1.1" 200 OK
Sep 12 20:54:37 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:37 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.12 T:None OK\n'
Sep 12 20:54:37 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:37 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:37 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:37 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:37 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /robot/lights HTTP/1.1" 200 OK
Sep 12 20:54:37 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:38 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:38 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.11 T:None OK\n'
Sep 12 20:54:38 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:38 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:38 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:38 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:38 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:39 OT2CEP20200811B09 systemd[1]: Starting Run clock file update script...
Sep 12 20:54:39 OT2CEP20200811B09 systemd[1]: Started Run clock file update script.
Sep 12 20:54:39 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:39 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.12 T:None OK\n'
Sep 12 20:54:39 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:39 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:39 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:39 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:39 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:39 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /pipettes HTTP/1.1" 200 OK
Sep 12 20:54:40 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:40 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.11 T:None OK\n'
Sep 12 20:54:40 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:40 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:40 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:40 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:40 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:41 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:41 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.11 T:None OK\n'
Sep 12 20:54:41 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:41 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:41 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:41 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:41 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:41 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /modules HTTP/1.1" 200 OK
Sep 12 20:54:42 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:42 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.12 T:None OK\n'
Sep 12 20:54:42 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:42 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:42 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:42 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:42 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /health HTTP/1.1" 200 OK
Sep 12 20:54:42 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /robot/lights HTTP/1.1" 200 OK
Sep 12 20:54:42 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:42 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:43 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:43 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:43 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.12 T:None OK\n'
Sep 12 20:54:43 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:43 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:43 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:43 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:44 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:44 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:44 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.12 T:None OK\n'
Sep 12 20:54:44 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:44 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:44 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:44 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:44 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /pipettes HTTP/1.1" 200 OK
Sep 12 20:54:45 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:45 OT2CEP20200811B09 kernel: usb 1-1.3.4: reset full-speed USB device number 24 using dwc_otg
Sep 12 20:54:45 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:45 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.12 T:None OK\n'
Sep 12 20:54:45 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:45 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:45 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:45 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:45 OT2CEP20200811B09 kernel: usb 1-1.3.4: device descriptor read/64, error -32
Sep 12 20:54:45 OT2CEP20200811B09 kernel: usb 1-1.3.4: device descriptor read/64, error -32
Sep 12 20:54:46 OT2CEP20200811B09 kernel: usb 1-1.3.4: reset full-speed USB device number 24 using dwc_otg
Sep 12 20:54:46 OT2CEP20200811B09 kernel: usb 1-1.3.4: device descriptor read/64, error -32
Sep 12 20:54:46 OT2CEP20200811B09 kernel: usb 1-1.3.4: device descriptor read/64, error -32
Sep 12 20:54:46 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:46 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:54:46 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.11 T:None OK\n'
Sep 12 20:54:46 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:54:46 OT2CEP20200811B09 kernel: usb 1-1.3.4: reset full-speed USB device number 24 using dwc_otg
Sep 12 20:54:46 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:46 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:54:46 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:46 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /modules HTTP/1.1" 200 OK
Sep 12 20:54:47 OT2CEP20200811B09 kernel: usb 1-1.3.4: device not accepting address 24, error -32
Sep 12 20:54:47 OT2CEP20200811B09 kernel: usb 1-1.3.4: reset full-speed USB device number 24 using dwc_otg
Sep 12 20:54:47 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /robot/lights HTTP/1.1" 200 OK
Sep 12 20:54:47 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:47 OT2CEP20200811B09 kernel: usb 1-1.3.4: device not accepting address 24, error -32
Sep 12 20:54:47 OT2CEP20200811B09 kernel: usb 1-1.3.4: USB disconnect, device number 24
Sep 12 20:54:47 OT2CEP20200811B09 opentrons-api[5956]: Firmware upload successful
Sep 12 20:54:47 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "POST /modules/HSDVT22041145/update HTTP/1.1" 200 OK
Sep 12 20:54:47 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'dfu \n'
Sep 12 20:54:47 OT2CEP20200811B09 opentrons-api[5956]: Searching for a dfu device with PID df11
Sep 12 20:54:47 OT2CEP20200811B09 kernel: usb 1-1.3.4: new full-speed USB device number 25 using dwc_otg
Sep 12 20:54:47 OT2CEP20200811B09 kernel: usb 1-1.3.4: device descriptor read/64, error -32
Sep 12 20:54:47 OT2CEP20200811B09 kernel: usb 1-1.3.4: device descriptor read/64, error -32
Sep 12 20:54:48 OT2CEP20200811B09 kernel: usb 1-1.3.4: new full-speed USB device number 26 using dwc_otg
Sep 12 20:54:48 OT2CEP20200811B09 kernel: usb 1-1.3.4: device descriptor read/64, error -32
Sep 12 20:54:48 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:48 OT2CEP20200811B09 kernel: usb 1-1.3.4: device descriptor read/64, error -32
Sep 12 20:54:48 OT2CEP20200811B09 kernel: usb 1-1.3-port4: attempt power cycle
Sep 12 20:54:49 OT2CEP20200811B09 kernel: usb 1-1.3.4: new full-speed USB device number 27 using dwc_otg
Sep 12 20:54:49 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:49 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /pipettes HTTP/1.1" 200 OK
Sep 12 20:54:49 OT2CEP20200811B09 kernel: usb 1-1.3.4: device not accepting address 27, error -32
Sep 12 20:54:49 OT2CEP20200811B09 kernel: usb 1-1.3.4: new full-speed USB device number 28 using dwc_otg
Sep 12 20:54:50 OT2CEP20200811B09 kernel: usb 1-1.3.4: device not accepting address 28, error -32
Sep 12 20:54:50 OT2CEP20200811B09 kernel: usb 1-1.3-port4: unable to enumerate USB device
Sep 12 20:54:50 OT2CEP20200811B09 kernel: usb 1-1.3.3: USB disconnect, device number 23
Sep 12 20:54:50 OT2CEP20200811B09 opentrons-api[5956]: Module Removed: ModuleAtPort(port='/dev/ot_module_heatershaker4', name='heatershaker', usb_port=USBPort(name='', port_number=0, device_path='', hub=None))
Sep 12 20:54:50 OT2CEP20200811B09 opentrons-api[5956]: Module heatershaker detached from port /dev/ot_module_heatershaker4
Sep 12 20:54:50 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:50 OT2CEP20200811B09 kernel: usb 1-1.3.3: new full-speed USB device number 29 using dwc_otg
Sep 12 20:54:50 OT2CEP20200811B09 kernel: usb 1-1.3.3: New USB device found, idVendor=0483, idProduct=df11
Sep 12 20:54:50 OT2CEP20200811B09 kernel: usb 1-1.3.3: New USB device strings: Mfr=1, Product=2, SerialNumber=3
Sep 12 20:54:50 OT2CEP20200811B09 kernel: usb 1-1.3.3: Product: STM32  BOOTLOADER
Sep 12 20:54:50 OT2CEP20200811B09 kernel: usb 1-1.3.3: Manufacturer: STMicroelectronics
Sep 12 20:54:50 OT2CEP20200811B09 kernel: usb 1-1.3.3: SerialNumber: 2037B53F2033
Sep 12 20:54:50 OT2CEP20200811B09 opentrons-api[5956]: Found device with PID df11
Sep 12 20:54:50 OT2CEP20200811B09 opentrons-api[5956]: Found device with PID df11
Sep 12 20:54:50 OT2CEP20200811B09 opentrons-api[5956]: Starting firmware upload via dfu util
Sep 12 20:54:51 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:51 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /modules HTTP/1.1" 200 OK
Sep 12 20:54:52 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /robot/lights HTTP/1.1" 200 OK
Sep 12 20:54:52 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:53 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:54 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:54 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /pipettes HTTP/1.1" 200 OK
Sep 12 20:54:55 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:56 OT2CEP20200811B09 kernel: usb 1-1.3.4: new full-speed USB device number 30 using dwc_otg
Sep 12 20:54:56 OT2CEP20200811B09 kernel: usb 1-1.3.4: New USB device found, idVendor=0483, idProduct=4853
Sep 12 20:54:56 OT2CEP20200811B09 kernel: usb 1-1.3.4: New USB device strings: Mfr=1, Product=2, SerialNumber=3
Sep 12 20:54:56 OT2CEP20200811B09 kernel: usb 1-1.3.4: Product: Heater/Shaker FS
Sep 12 20:54:56 OT2CEP20200811B09 kernel: usb 1-1.3.4: Manufacturer: Opentrons
Sep 12 20:54:56 OT2CEP20200811B09 kernel: usb 1-1.3.4: SerialNumber: 5F355DF82033
Sep 12 20:54:56 OT2CEP20200811B09 kernel: cdc_acm 1-1.3.4:1.0: ttyACM3: USB ACM device
Sep 12 20:54:56 OT2CEP20200811B09 opentrons-api[5956]: Module Added: ModuleAtPort(port='/dev/ot_module_heatershaker3', name='heatershaker', usb_port=USBPort(name='', port_number=0, device_path='', hub=None))
Sep 12 20:54:56 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:56 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M115 \n'
Sep 12 20:54:56 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M115 FW:v1.0.2 HW:Opentrons Heater-Shaker SerialNo:HSDVT22041145 OK\n'
Sep 12 20:54:56 OT2CEP20200811B09 opentrons-api[5956]: Module heatershaker discovered and attached at port /dev/ot_module_heatershaker3, new_instance: <opentrons.hardware_control.modules.heater_shaker.HeaterShaker object at 0x58415550>
Sep 12 20:54:56 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:54:56 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.01 T:None OK\n'
Sep 12 20:54:56 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:54:56 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:56 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:54:56 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:56 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /modules HTTP/1.1" 200 OK
Sep 12 20:54:56 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /runs HTTP/1.1" 200 OK
Sep 12 20:54:57 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /robot/lights HTTP/1.1" 200 OK
Sep 12 20:54:57 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:57 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /health HTTP/1.1" 200 OK
Sep 12 20:54:57 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:54:57 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.02 T:None OK\n'
Sep 12 20:54:57 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:54:57 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:57 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:54:57 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:58 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:58 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:54:58 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.01 T:None OK\n'
Sep 12 20:54:58 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:54:58 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:58 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:54:58 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:54:59 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:54:59 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /pipettes HTTP/1.1" 200 OK
Sep 12 20:54:59 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:54:59 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.01 T:None OK\n'
Sep 12 20:54:59 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:54:59 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:54:59 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:54:59 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:00 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:00 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /sessions HTTP/1.1" 200 OK
Sep 12 20:55:00 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /modules HTTP/1.1" 200 OK
Sep 12 20:55:00 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /runs HTTP/1.1" 200 OK
Sep 12 20:55:00 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:00 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.01 T:None OK\n'
Sep 12 20:55:00 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:00 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:00 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:00 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:01 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:01 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /runs HTTP/1.1" 200 OK
Sep 12 20:55:01 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:01 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.02 T:None OK\n'
Sep 12 20:55:01 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:01 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:01 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:01 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:02 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /robot/lights HTTP/1.1" 200 OK
Sep 12 20:55:02 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:02 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:02 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.00 T:None OK\n'
Sep 12 20:55:02 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:02 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:02 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:02 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:03 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:03 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:03 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.02 T:None OK\n'
Sep 12 20:55:03 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:03 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:03 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:03 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:04 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:04 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /pipettes HTTP/1.1" 200 OK
Sep 12 20:55:04 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:05 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.01 T:None OK\n'
Sep 12 20:55:05 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:05 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:05 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:05 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:05 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:05 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /modules HTTP/1.1" 200 OK
Sep 12 20:55:06 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:06 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.02 T:None OK\n'
Sep 12 20:55:06 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:06 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:06 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:06 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:06 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:07 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:07 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.00 T:None OK\n'
Sep 12 20:55:07 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:07 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:07 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:07 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:07 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /robot/lights HTTP/1.1" 200 OK
Sep 12 20:55:07 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:08 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:08 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.01 T:None OK\n'
Sep 12 20:55:08 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:08 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:08 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:08 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:08 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:09 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:09 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.01 T:None OK\n'
Sep 12 20:55:09 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:09 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:09 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:09 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:09 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:09 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /pipettes HTTP/1.1" 200 OK
Sep 12 20:55:10 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:10 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.02 T:None OK\n'
Sep 12 20:55:10 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:10 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:10 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:10 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:10 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:10 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /modules HTTP/1.1" 200 OK
Sep 12 20:55:11 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:11 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.01 T:None OK\n'
Sep 12 20:55:11 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:11 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:11 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:11 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:11 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:12 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:12 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.02 T:None OK\n'
Sep 12 20:55:12 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:12 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:12 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:12 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:12 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /robot/lights HTTP/1.1" 200 OK
Sep 12 20:55:12 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:12 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:12 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /health HTTP/1.1" 200 OK
Sep 12 20:55:13 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:13 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.02 T:None OK\n'
Sep 12 20:55:13 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:13 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:13 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:13 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:13 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:14 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:14 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.00 T:None OK\n'
Sep 12 20:55:14 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:14 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:14 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:14 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:14 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:14 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /pipettes HTTP/1.1" 200 OK
Sep 12 20:55:15 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:15 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:15 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.01 T:None OK\n'
Sep 12 20:55:15 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:15 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:15 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:15 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:15 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /modules HTTP/1.1" 200 OK
Sep 12 20:55:16 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:16 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:16 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.01 T:None OK\n'
Sep 12 20:55:16 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:16 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:16 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:16 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:17 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /robot/lights HTTP/1.1" 200 OK
Sep 12 20:55:17 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:17 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:17 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.02 T:None OK\n'
Sep 12 20:55:17 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:17 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:17 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:17 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:18 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:18 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:18 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.02 T:None OK\n'
Sep 12 20:55:18 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:18 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:18 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:18 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:19 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:19 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:19 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.01 T:None OK\n'
Sep 12 20:55:19 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:19 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:19 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:19 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:19 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /pipettes HTTP/1.1" 200 OK
Sep 12 20:55:20 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:20 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:20 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.01 T:None OK\n'
Sep 12 20:55:20 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:20 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /modules HTTP/1.1" 200 OK
Sep 12 20:55:20 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:20 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:20 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:21 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:21 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:21 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.02 T:None OK\n'
Sep 12 20:55:21 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:21 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:21 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:21 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:22 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /robot/lights HTTP/1.1" 200 OK
Sep 12 20:55:22 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:22 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:22 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.01 T:None OK\n'
Sep 12 20:55:22 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:22 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:22 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:22 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:23 OT2CEP20200811B09 kernel: usb 1-1.3.3: reset full-speed USB device number 29 using dwc_otg
Sep 12 20:55:23 OT2CEP20200811B09 kernel: usb 1-1.3.3: device descriptor read/64, error -32
Sep 12 20:55:23 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:23 OT2CEP20200811B09 kernel: usb 1-1.3.3: device descriptor read/64, error -32
Sep 12 20:55:23 OT2CEP20200811B09 kernel: usb 1-1.3.3: reset full-speed USB device number 29 using dwc_otg
Sep 12 20:55:23 OT2CEP20200811B09 kernel: usb 1-1.3.3: device descriptor read/64, error -32
Sep 12 20:55:23 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:23 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.01 T:None OK\n'
Sep 12 20:55:23 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:23 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:23 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:23 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:24 OT2CEP20200811B09 kernel: usb 1-1.3.3: device descriptor read/64, error -32
Sep 12 20:55:24 OT2CEP20200811B09 kernel: usb 1-1.3.3: reset full-speed USB device number 29 using dwc_otg
Sep 12 20:55:24 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:24 OT2CEP20200811B09 kernel: usb 1-1.3.3: device not accepting address 29, error -32
Sep 12 20:55:24 OT2CEP20200811B09 kernel: usb 1-1.3.3: reset full-speed USB device number 29 using dwc_otg
Sep 12 20:55:24 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /pipettes HTTP/1.1" 200 OK
Sep 12 20:55:24 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:24 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.02 T:None OK\n'
Sep 12 20:55:24 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:24 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:24 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:24 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:25 OT2CEP20200811B09 kernel: usb 1-1.3.3: device not accepting address 29, error -32
Sep 12 20:55:25 OT2CEP20200811B09 kernel: usb 1-1.3.3: USB disconnect, device number 29
Sep 12 20:55:25 OT2CEP20200811B09 opentrons-api[5956]: Firmware upload successful
Sep 12 20:55:25 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "POST /modules/EMPTYSN/update HTTP/1.1" 200 OK
Sep 12 20:55:25 OT2CEP20200811B09 kernel: usb 1-1.3.3: new full-speed USB device number 31 using dwc_otg
Sep 12 20:55:25 OT2CEP20200811B09 kernel: usb 1-1.3.3: device descriptor read/64, error -32
Sep 12 20:55:25 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:25 OT2CEP20200811B09 kernel: usb 1-1.3.3: device descriptor read/64, error -32
Sep 12 20:55:25 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /modules HTTP/1.1" 200 OK
Sep 12 20:55:25 OT2CEP20200811B09 kernel: usb 1-1.3.3: new full-speed USB device number 32 using dwc_otg
Sep 12 20:55:25 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:25 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.02 T:None OK\n'
Sep 12 20:55:25 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:25 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:25 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:25 OT2CEP20200811B09 kernel: usb 1-1.3.3: device descriptor read/64, error -32
Sep 12 20:55:25 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:26 OT2CEP20200811B09 kernel: usb 1-1.3.3: device descriptor read/64, error -32
Sep 12 20:55:26 OT2CEP20200811B09 kernel: usb 1-1.3-port3: attempt power cycle
Sep 12 20:55:26 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:26 OT2CEP20200811B09 kernel: usb 1-1.3.3: new full-speed USB device number 33 using dwc_otg
Sep 12 20:55:26 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:26 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.01 T:None OK\n'
Sep 12 20:55:26 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:26 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:26 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:26 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:27 OT2CEP20200811B09 kernel: usb 1-1.3.3: device not accepting address 33, error -32
Sep 12 20:55:27 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /robot/lights HTTP/1.1" 200 OK
Sep 12 20:55:27 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:27 OT2CEP20200811B09 kernel: usb 1-1.3.3: new full-speed USB device number 34 using dwc_otg
Sep 12 20:55:28 OT2CEP20200811B09 kernel: usb 1-1.3.3: device not accepting address 34, error -32
Sep 12 20:55:28 OT2CEP20200811B09 kernel: usb 1-1.3-port3: unable to enumerate USB device
Sep 12 20:55:28 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:28 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /health HTTP/1.1" 200 OK
Sep 12 20:55:28 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:28 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.02 T:None OK\n'
Sep 12 20:55:28 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:28 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:28 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:28 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:29 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:29 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.03 T:None OK\n'
Sep 12 20:55:29 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:29 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:29 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:29 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:29 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:29 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /pipettes HTTP/1.1" 200 OK
Sep 12 20:55:30 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:30 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.02 T:None OK\n'
Sep 12 20:55:30 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:30 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:30 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:30 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:30 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:30 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /modules HTTP/1.1" 200 OK
Sep 12 20:55:31 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:31 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.01 T:None OK\n'
Sep 12 20:55:31 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:31 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:31 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:31 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:31 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:32 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:32 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.02 T:None OK\n'
Sep 12 20:55:32 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:32 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:32 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:32 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:32 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /robot/lights HTTP/1.1" 200 OK
Sep 12 20:55:32 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:33 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:33 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.02 T:None OK\n'
Sep 12 20:55:33 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:33 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:33 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:33 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:33 OT2CEP20200811B09 uvicorn[5956]: INFO:      - "GET /calibration/pipette_offset HTTP/1.1" 200 OK
Sep 12 20:55:33 OT2CEP20200811B09 kernel: usb 1-1.3.3: new full-speed USB device number 35 using dwc_otg
Sep 12 20:55:33 OT2CEP20200811B09 kernel: usb 1-1.3.3: New USB device found, idVendor=0483, idProduct=4853
Sep 12 20:55:33 OT2CEP20200811B09 kernel: usb 1-1.3.3: New USB device strings: Mfr=1, Product=2, SerialNumber=3
Sep 12 20:55:33 OT2CEP20200811B09 kernel: usb 1-1.3.3: Product: Heater/Shaker FS
Sep 12 20:55:33 OT2CEP20200811B09 kernel: usb 1-1.3.3: Manufacturer: Opentrons
Sep 12 20:55:33 OT2CEP20200811B09 kernel: usb 1-1.3.3: SerialNumber: 5F325DEC2033
Sep 12 20:55:33 OT2CEP20200811B09 kernel: cdc_acm 1-1.3.3:1.0: ttyACM4: USB ACM device
Sep 12 20:55:33 OT2CEP20200811B09 opentrons-api[5956]: Module Added: ModuleAtPort(port='/dev/ot_module_heatershaker4', name='heatershaker', usb_port=USBPort(name='', port_number=0, device_path='', hub=None))
Sep 12 20:55:34 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M115 \n'
Sep 12 20:55:34 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M115 FW:v1.0.2 HW:Opentrons Heater-Shaker SerialNo:EMPTYSN OK\n'
Sep 12 20:55:34 OT2CEP20200811B09 opentrons-api[5956]: Module heatershaker discovered and attached at port /dev/ot_module_heatershaker4, new_instance: <opentrons.hardware_control.modules.heater_shaker.HeaterShaker object at 0x6eab40d0>
Sep 12 20:55:34 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M105 \n'
Sep 12 20:55:34 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M105 C:26.12 T:None OK\n'
Sep 12 20:55:34 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M123 \n'
Sep 12 20:55:34 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:34 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Write -> b'M241 \n'
Sep 12 20:55:34 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M105 \n'
Sep 12 20:55:34 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M105 C:26.01 T:None OK\n'
Sep 12 20:55:34 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M123 \n'
Sep 12 20:55:34 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M123 C:0 T:0 OK\n'
Sep 12 20:55:34 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Write -> b'M241 \n'
Sep 12 20:55:34 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker3: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
Sep 12 20:55:34 OT2CEP20200811B09 opentrons-api-serial[5956]: /dev/ot_module_heatershaker4: Read <- b'M241 STATUS:IDLE_CLOSED OK\n'
```