### PR TITLE
fix(app): fix pipette settings when allPipetteConfig FF is on

### DIFF
--- a/app/src/organisms/ConfigurePipette/ConfigForm.tsx
+++ b/app/src/organisms/ConfigurePipette/ConfigForm.tsx
@@ -83,7 +83,10 @@ export class ConfigForm extends React.Component<ConfigFormProps> {
   }
 
   getVisibleFields: () => PipetteSettingsFieldsMap = () => {
-    if (this.props.__showHiddenFields) return this.props.settings
+    if (this.props.__showHiddenFields) {
+      return omit(this.props.settings, [QUIRK_KEY])
+    }
+
     return pick(this.props.settings, [
       ...PLUNGER_KEYS,
       ...POWER_KEYS,


### PR DESCRIPTION
## Overview

When the `allPipetteConfig` feature-flag is on, the pipette settings form erroneously adds a `quirks` field to the `PATCH /settings/pipettes/:id` request body, which is invalid.

This PR ensures the `quirks` field is omitted from the body, which does not affect the ability to actually set/unset quirks.

Closes RAUT-184

## Changelog

- fix(app): fix pipette settings when allPipetteConfig FF is on

## Review requests

Pipette config form logic has no unit tests, so please smoke test carefully.

- [ ] Changing pipette value fields work with FF off
- [ ] Change pipette quirks checkboxes work with FF off
    - Note: not all pipettes have quirks
- [ ] Changing pipette value fields work with FF on
- [ ] Change pipette quirks checkboxes work with FF on

## Risk assessment

Low, bug fix that is only in play when a feature flag is on. In the past, we have pointed users to this feature flag, though.
