### PR TITLE
feat(app, protocol-designer): fix well highlighted state for liquid setup

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/LabwareInfoOverlay.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/LabwareInfoOverlay.tsx
@@ -9,7 +9,6 @@ import {
   SPACING,
   COLORS,
   TYPOGRAPHY,
-  OVERLAY_BLACK_80,
   DISPLAY_FLEX,
   DIRECTION_COLUMN,
   JUSTIFY_FLEX_END,
@@ -19,10 +18,10 @@ import {
   JUSTIFY_SPACE_BETWEEN,
 } from '@opentrons/components'
 import { StyledText } from '../../../atoms/text'
+import { OffsetVector } from '../../../molecules/OffsetVector'
+import { useLabwareOffsetForLabware } from '../../LabwarePositionCheck/hooks/useLabwareOffsetForLabware'
 
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
-import { useLabwareOffsetForLabware } from '../../LabwarePositionCheck/hooks/useLabwareOffsetForLabware'
-import { OffsetVector } from '../../../molecules/OffsetVector'
 interface LabwareInfoProps {
   displayName: string | null
   definitionDisplayName: string
@@ -47,7 +46,7 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
 
   return (
     <Box
-      backgroundColor={hover ? COLORS.blueEnabled : OVERLAY_BLACK_80}
+      backgroundColor={hover ? COLORS.blueEnabled : '#000000B3'}
       borderRadius="0 0 0.4rem 0.4rem"
       fontSize={TYPOGRAPHY.fontSizeCaption}
       padding={SPACING.spacing2}

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
@@ -52,7 +52,6 @@ export const LiquidsLabwareDetailsModal = (
     liquids,
     labwareByLiquidId
   )
-  console.log(wellFill)
   const labwareInfo = getLiquidsByIdForLabware(labwareId, labwareByLiquidId)
   const { slotName, labwareName } = getSlotLabwareName(labwareId, commands)
   const loadLabwareCommand = commands

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
@@ -27,6 +27,7 @@ import {
   getLiquidsByIdForLabware,
   getWellFillFromLabwareId,
   getWellGroupForLiquidId,
+  getDisabledWellGroupForLiquidId,
 } from './utils'
 
 interface LiquidsLabwareDetailsModalProps {
@@ -51,6 +52,7 @@ export const LiquidsLabwareDetailsModal = (
     liquids,
     labwareByLiquidId
   )
+  console.log(wellFill)
   const labwareInfo = getLiquidsByIdForLabware(labwareId, labwareByLiquidId)
   const { slotName, labwareName } = getSlotLabwareName(labwareId, commands)
   const loadLabwareCommand = commands
@@ -63,7 +65,6 @@ export const LiquidsLabwareDetailsModal = (
   const [selectedValue, setSelectedValue] = React.useState<typeof liquidId>(
     liquidId ?? filteredLiquidsInLoadOrder[0].liquidId
   )
-
   const scrollToCurrentItem = (): void => {
     currentLiquidRef.current?.scrollIntoView({ behavior: 'smooth' })
   }
@@ -75,6 +76,9 @@ export const LiquidsLabwareDetailsModal = (
       display: none;
     }
   `
+  const liquidIds = filteredLiquidsInLoadOrder.map(liquid => liquid.liquidId)
+  const disabledLiquidIds = liquidIds.filter(id => id !== selectedValue)
+
   return (
     <Modal
       onClose={closeModal}
@@ -102,7 +106,6 @@ export const LiquidsLabwareDetailsModal = (
               const labwareInfoEntry = Object.entries(labwareInfo).find(
                 entry => entry[0] === liquid.liquidId
               )
-
               return (
                 labwareInfoEntry != null && (
                   <Flex
@@ -180,6 +183,10 @@ export const LiquidsLabwareDetailsModal = (
                       ? getWellGroupForLiquidId(labwareInfo, selectedValue)
                       : {}
                   }
+                  disabledWells={getDisabledWellGroupForLiquidId(
+                    labwareInfo,
+                    disabledLiquidIds
+                  )}
                 />
               </svg>
             </Flex>

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/utils.test.ts
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/utils.test.ts
@@ -5,6 +5,7 @@ import {
   getLiquidsByIdForLabware,
   getWellGroupForLiquidId,
   getWellRangeForLiquidLabwarePair,
+  getDisabledWellGroupForLiquidId,
 } from '../utils'
 import type { LabwareByLiquidId, Liquid } from '@opentrons/api-client'
 
@@ -260,6 +261,41 @@ describe('getWellGroupForLiquidId', () => {
     }
     expect(
       getWellGroupForLiquidId(MOCK_LABWARE_BY_LIQUID_ID_FOR_LABWARE, '7')
+    ).toEqual(expected)
+  })
+})
+
+describe('getDisabledWellGroupForLiquidId', () => {
+  it('returns wellgroup object for the specified liquidId', () => {
+    const expectedSeven = {
+      A1: null,
+      A2: null,
+      B1: null,
+      B2: null,
+      C1: null,
+      C2: null,
+      D1: null,
+      D2: null,
+    }
+
+    const expectedNineteen = {
+      A5: null,
+      A6: null,
+      B5: null,
+      B6: null,
+      C5: null,
+      C6: null,
+      D5: null,
+      D6: null,
+    }
+
+    const expected = [expectedSeven, expectedNineteen]
+
+    expect(
+      getDisabledWellGroupForLiquidId(MOCK_LABWARE_BY_LIQUID_ID_FOR_LABWARE, [
+        '7',
+        '19',
+      ])
     ).toEqual(expected)
   })
 })

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/utils.ts
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/utils.ts
@@ -94,6 +94,28 @@ export function getWellGroupForLiquidId(
   }, {})
 }
 
+export function getDisabledWellGroupForLiquidId(
+  labwareByLiquidId: LabwareByLiquidId,
+  liquidIds: string[]
+): WellGroup[] {
+  const wellGroups = liquidIds.map(liquidId => {
+    const labwareInfo = labwareByLiquidId[liquidId]
+    return labwareInfo.reduce((allWells, { volumeByWell }) => {
+      const someWells = Object.entries(volumeByWell).reduce(
+        (someWells, [wellName]) => {
+          return {
+            ...someWells,
+            [wellName]: null,
+          }
+        },
+        {}
+      )
+      return { ...allWells, ...someWells }
+    }, {})
+  })
+  return wellGroups
+}
+
 export function getWellRangeForLiquidLabwarePair(
   volumeByWell: { [well: string]: number },
   labwareWellOrdering: string[][]

--- a/components/src/hardware-sim/Labware/LabwareRender.css
+++ b/components/src/hardware-sim/Labware/LabwareRender.css
@@ -1,12 +1,17 @@
 @import '../..';
 
 .highlighted_well {
-  stroke: var(--c-highlight);
-  fill: color-mod(var(--c-highlight) alpha(20%));
+  stroke: var(--c-blue-enabled);
+  fill: color-mod(var(--c-blue-enabled) alpha(20%));
+}
+
+.disabled_well {
+  stroke: var(--c-light-grey-hover);
+  fill: color-mod(var(--c-light-grey-hover) alpha(40%));
 }
 
 .selected_well {
-  stroke: var(--c-highlight);
+  stroke: var(--c-blue-enabled);
   fill: transparent;
 }
 

--- a/components/src/hardware-sim/Labware/LabwareRender.css
+++ b/components/src/hardware-sim/Labware/LabwareRender.css
@@ -7,7 +7,7 @@
 
 .disabled_well {
   stroke: var(--c-light-grey-hover);
-  fill: color-mod(var(--c-light-grey-hover) alpha(40%));
+  fill: color-mod(var(--c-lightest-gray) alpha(70%));
 }
 
 .selected_well {

--- a/components/src/hardware-sim/Labware/LabwareRender.css
+++ b/components/src/hardware-sim/Labware/LabwareRender.css
@@ -7,7 +7,7 @@
 
 .disabled_well {
   stroke: var(--c-light-grey-hover);
-  fill: color-mod(var(--c-lightest-gray) alpha(70%));
+  fill: color-mod(var(--c-lightest-gray) alpha(80%));
 }
 
 .selected_well {

--- a/components/src/hardware-sim/Labware/LabwareRender.tsx
+++ b/components/src/hardware-sim/Labware/LabwareRender.tsx
@@ -32,7 +32,7 @@ export interface LabwareRenderProps {
   wellLabelOption?: WellLabelOption
   /** wells to highlight */
   highlightedWells?: WellGroup | null
-  /** wells to disabled */
+  /** option for none highlighted wells to be disabled */
   disabledWells?: WellGroup[]
   missingTips?: WellGroup | null
   /** color to render well labels */

--- a/components/src/hardware-sim/Labware/LabwareRender.tsx
+++ b/components/src/hardware-sim/Labware/LabwareRender.tsx
@@ -31,13 +31,15 @@ export interface LabwareRenderProps {
   /** option to show well labels inside or outside of labware outline */
   wellLabelOption?: WellLabelOption
   /** wells to highlight */
-  highlightedWells?: WellGroup | null | undefined
-  missingTips?: WellGroup | null | undefined
+  highlightedWells?: WellGroup | null
+  /** wells to disabled */
+  disabledWells?: WellGroup[]
+  missingTips?: WellGroup | null
   /** color to render well labels */
   wellLabelColor?: string
   /** option to highlight well labels with specified color */
   highlightedWellLabels?: HighlightedWellLabels
-  selectedWells?: WellGroup | null | undefined
+  selectedWells?: WellGroup | null
   /** CSS color to fill specified wells */
   wellFill?: WellFill
   /** CSS color to stroke specified wells */
@@ -78,17 +80,27 @@ export const LabwareRender = (props: LabwareRenderProps): JSX.Element => {
           strokeByWell={props.wellStroke}
         />
       )}
+      {props.wellFill && (
+        <FilledWells
+          definition={props.definition}
+          fillByWell={props.wellFill}
+        />
+      )}
+      {props.disabledWells != null
+        ? props.disabledWells.map((well, index) => (
+            <StyledWells
+              key={index}
+              className={styles.disabled_well}
+              definition={props.definition}
+              wells={well}
+            />
+          ))
+        : null}
       {props.highlightedWells && (
         <StyledWells
           className={styles.highlighted_well}
           definition={props.definition}
           wells={props.highlightedWells}
-        />
-      )}
-      {props.wellFill && (
-        <FilledWells
-          definition={props.definition}
-          fillByWell={props.wellFill}
         />
       )}
       {props.selectedWells && (

--- a/components/src/hardware-sim/Labware/labwareInternals/LabwareOutline.css
+++ b/components/src/hardware-sim/Labware/labwareInternals/LabwareOutline.css
@@ -12,5 +12,4 @@
 
 .hover_outline {
   stroke: #006cfa;
-  filter: drop-shadow(0 0 3px rgba(0, 108, 250, 1));
 }

--- a/components/src/styles/colors.css
+++ b/components/src/styles/colors.css
@@ -36,7 +36,6 @@
   --c-error-light: #ffc0c0;
   --c-success: #60b120;
   --c-blue-enabled: #006cfa;
-  --c-blue-pressed: #0050b8;
   --c-light-grey-hover: #c6c6c6;
 
   /* Misc */

--- a/components/src/styles/colors.css
+++ b/components/src/styles/colors.css
@@ -35,6 +35,9 @@
   --c-error: #d12929;
   --c-error-light: #ffc0c0;
   --c-success: #60b120;
+  --c-blue-enabled: #006cfa;
+  --c-blue-pressed: #0050b8;
+  --c-light-grey-hover: #c6c6c6;
 
   /* Misc */
   --c-selection-overlay: color-mod(var(--c-highlight) alpha(0.3));

--- a/components/src/ui-style-constants/colors.ts
+++ b/components/src/ui-style-constants/colors.ts
@@ -70,7 +70,6 @@ export const aquamarine = '#9dffd8'
 export const orangePeel = '#ff9900'
 export const skyBlue = '#50d5ff'
 export const popPink = '#ff80f5'
-export const richBlue = '#0380fb'
 export const springGreen = '#7eff42'
 export const tartRed = '#ff4f4f'
 export const whaleGrey = '#9395a0'
@@ -82,7 +81,6 @@ export const liquidColors = [
   orangePeel,
   skyBlue,
   popPink,
-  richBlue,
   springGreen,
   tartRed,
   whaleGrey,


### PR DESCRIPTION
closes RLIQ-37

# Overview

Fixes a bunch of misc well UI states outlined in the ticket - the changes affect both PD and the App

# Changelog

- remove `richBlue` from liquid setup option
- add a few constants to `colors.css` to be used in a few styles sheets
- extend prop in `LabwareRender` to include `disabledWells` which are the wells that are not highlighted in the app liquid setups section
- create `util`: `getDisabledWellGroupForLiquidId` and added a test

Note: the addition of the `activeState` is removed from the AC, after discussions with Sarah and Mel

# Review requests

- smoke test in App and Pd and make sure everything looks as expected

# Risk assessment

low