### PR TITLE
feat(ot3, api): allow custom axis accelerations in hardware controller

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -5,6 +5,7 @@ from opentrons.hardware_control.types import (
     OT3Axis,
     OT3AxisKind,
     OT3AxisMap,
+    OT3AxisKindMap,
     CurrentConfig,
     OT3SubSystem,
     OT3Mount,
@@ -44,6 +45,8 @@ GRIPPER_JAW_HOME_DC: float = 100
 # to NodeId that are interpreted at import time because then the robot
 # server tests fail when importing hardware controller. This is obviously
 # terrible and needs to be fixed.
+
+AxisMapPayload = TypeVar("AxisMapPayload")
 
 
 def axis_nodes() -> List["NodeId"]:
@@ -185,6 +188,16 @@ def get_system_constraints(
     return constraints
 
 
+def axis_kind_to_axis_map(
+    axis_kind_map: OT3AxisKindMap[AxisMapPayload],
+) -> OT3AxisMap[AxisMapPayload]:
+    new_map = {}
+    for axis_kind in axis_kind_map.keys():
+        for axis in OT3Axis.of_kind(axis_kind):
+            new_map[axis] = axis_kind_map[axis_kind]
+    return new_map
+
+
 def _convert_to_node_id_dict(
     axis_pos: Coordinates[OT3Axis, CoordinateValue],
 ) -> NodeIdMotionValues:
@@ -259,9 +272,6 @@ def create_gripper_jaw_home_group() -> MoveGroup:
     )
     move_group: MoveGroup = [step]
     return move_group
-
-
-AxisMapPayload = TypeVar("AxisMapPayload")
 
 
 def axis_convert(

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -209,17 +209,17 @@ class OT3API(
         )
         await self._backend.update_to_default_current_settings(gantry_load)
 
-    def override_axis_acceleration(self, acc: OT3AxisKindMap[float]) -> None:
+    def override_axis_acceleration(self, axis_kind_acc: OT3AxisKindMap[float]) -> None:
         """Temporarily override default gantry load acceleration for OT3AxisKind.
 
         This method may be used when an instrument is transferring labware with
         a liquid that would require a change in acceleration. This
         should be called before a _move() command.
 
-        Note: custom constraints will not be saved to the robot settings file.
+        Note: temporary constraints will not be saved to the robot settings file.
         """
-        accelerataions = axis_kind_to_axis_map(acc)
-        self._move_manager.override_accelerations(accelerataions)
+        axis_accelerations = axis_kind_to_axis_map(axis_kind_acc)
+        self._move_manager.override_accelerations(axis_accelerations)
 
     def use_default_system_constraints(self) -> None:
         """Use motion constraints found in robot settings."""

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -277,6 +277,7 @@ class OT3SubSystem(enum.Enum):
 BCAxes = Union[Axis, OT3Axis]
 AxisMapValue = TypeVar("AxisMapValue")
 OT3AxisMap = Dict[OT3Axis, AxisMapValue]
+OT3AxisKindMap = Dict[OT3AxisKind, AxisMapValue]
 
 
 @dataclass

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_utils.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_utils.py
@@ -1,7 +1,7 @@
 from opentrons_hardware.hardware_control.motion_planning import Move
 from opentrons.hardware_control.backends import ot3utils
 from opentrons_hardware.firmware_bindings.constants import NodeId
-from opentrons.hardware_control.types import OT3Axis
+from opentrons.hardware_control.types import OT3Axis, OT3AxisKind
 
 
 def test_create_step():
@@ -25,3 +25,43 @@ def test_create_step():
     assert len(move_group) == 3
     for step in move_group:
         assert set(present_nodes) == set(step.keys())
+
+
+def test_axis_kind_to_axis_map_function():
+    # Map with all OT3AxisKind enums
+    axis_kind_map = {
+        OT3AxisKind.X: 1,
+        OT3AxisKind.Y: 2,
+        OT3AxisKind.Z: 3,
+        OT3AxisKind.P: 4,
+        OT3AxisKind.Z_G: 5,
+        OT3AxisKind.OTHER: 6,
+    }
+    axis_map = ot3utils.axis_kind_to_axis_map(axis_kind_map)
+    assert axis_map == {
+        OT3Axis.X: 1,
+        OT3Axis.Y: 2,
+        OT3Axis.Z_L: 3,
+        OT3Axis.Z_R: 3,
+        OT3Axis.P_L: 4,
+        OT3Axis.P_R: 4,
+        OT3Axis.Z_G: 5,
+        OT3Axis.Q: 6,
+        OT3Axis.G: 6,
+    }
+
+    # Map with a few OT3AxisKind enums
+    axis_kind_map = {
+        OT3AxisKind.X: 1,
+        OT3AxisKind.Y: 2,
+        OT3AxisKind.P: 4,
+        OT3AxisKind.Z_G: 5,
+    }
+    axis_map = ot3utils.axis_kind_to_axis_map(axis_kind_map)
+    assert axis_map == {
+        OT3Axis.X: 1,
+        OT3Axis.Y: 2,
+        OT3Axis.P_L: 4,
+        OT3Axis.P_R: 4,
+        OT3Axis.Z_G: 5,
+    }

--- a/hardware/opentrons_hardware/hardware_control/motion_planning/move_manager.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/move_manager.py
@@ -1,6 +1,8 @@
 """Move manager."""
 import logging
+import numpy as np
 from typing import Dict, List, Tuple, Generic
+
 from opentrons_hardware.hardware_control.motion_planning import move_utils
 from opentrons_hardware.hardware_control.motion_planning.types import (
     Coordinates,
@@ -29,7 +31,7 @@ class MoveManager(Generic[AxisKey]):
     def override_accelerations(self, acc_dict: Dict[AxisKey, CoordinateValue]) -> None:
         """Update max acceleration constraint for specified axes."""
         for axis, val in acc_dict.items():
-            self._constraints[axis].max_acceleration = val
+            self._constraints[axis].max_acceleration = np.float64(val)
 
     def update_constraints(self, constraints: SystemConstraints[AxisKey]) -> None:
         """Update all system constraints when instruments are changed."""

--- a/hardware/opentrons_hardware/hardware_control/motion_planning/move_manager.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/move_manager.py
@@ -1,6 +1,6 @@
 """Move manager."""
 import logging
-from typing import List, Tuple, Generic
+from typing import Dict, List, Tuple, Generic
 from opentrons_hardware.hardware_control.motion_planning import move_utils
 from opentrons_hardware.hardware_control.motion_planning.types import (
     Coordinates,
@@ -26,8 +26,13 @@ class MoveManager(Generic[AxisKey]):
         self._constraints = constraints
         self._blend_log: List[List[Move[AxisKey]]] = []
 
+    def override_accelerations(self, acc_dict: Dict[AxisKey, CoordinateValue]) -> None:
+        """Update max acceleration constraint for specified axes."""
+        for axis, val in acc_dict.items():
+            self._constraints[axis].max_acceleration = val
+
     def update_constraints(self, constraints: SystemConstraints[AxisKey]) -> None:
-        """Update system constraints when instruments are changed."""
+        """Update all system constraints when instruments are changed."""
         self._constraints = constraints
 
     def _clear_blend_log(self) -> None:

--- a/hardware/opentrons_hardware/hardware_control/motion_planning/types.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/types.py
@@ -228,9 +228,6 @@ class AxisConstraints:
             ),
         )
 
-    def __setattr__(self, name: str, value: CoordinateValue) -> None:
-        object.__setattr__(self, name, np.float64(value))
-
 
 SystemConstraints = Dict[AxisKey, AxisConstraints]
 ConstraintAxisMap = Dict[AxisKey, CoordinateValue]

--- a/hardware/opentrons_hardware/hardware_control/motion_planning/types.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/types.py
@@ -228,8 +228,12 @@ class AxisConstraints:
             ),
         )
 
+    def __setattr__(self, name: str, value: CoordinateValue) -> None:
+        object.__setattr__(self, name, np.float64(value))
+
 
 SystemConstraints = Dict[AxisKey, AxisConstraints]
+ConstraintAxisMap = Dict[AxisKey, CoordinateValue]
 
 
 class ZeroLengthMoveError(ValueError, Generic[AxisKey, CoordinateValue]):

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_utils.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_utils.py
@@ -1,7 +1,7 @@
 """Tests for move util functions."""
 import pytest
 import numpy as np
-from typing import Iterator, List
+from typing import Iterator, List, Union
 from hypothesis import given, strategies as st, assume
 
 from opentrons_hardware.hardware_control.motion_planning.move_manager import MoveManager
@@ -540,7 +540,7 @@ def test_triangle_matching() -> None:
 
 def test_system_constraint_acceleration_override() -> None:
     """Only specified axis accelerations should be modified."""
-    new_accs: ConstraintAxisMap[int] = {
+    new_accs: ConstraintAxisMap[str, Union[int, float]] = {
         "X": 1,
         "Y": 2,
         "A": 3,

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_utils.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_utils.py
@@ -19,6 +19,7 @@ from opentrons_hardware.hardware_control.motion_planning.types import (
     Move,
     MoveTarget,
     SystemConstraints,
+    ConstraintAxisMap,
     is_unit_vector,
 )
 
@@ -535,3 +536,25 @@ def test_triangle_matching() -> None:
     assert active_move.blocks[0].distance + active_move.blocks[
         2
     ].distance == pytest.approx(active_move.distance)
+
+
+def test_system_constraint_acceleration_override() -> None:
+    """Only specified axis accelerations should be modified."""
+    new_accs: ConstraintAxisMap[int] = {
+        "X": 1,
+        "Y": 2,
+        "A": 3,
+    }
+
+    acc_results = CONSTRAINTS
+    acc_results["X"].max_acceleration = np.float64(1)
+    acc_results["Y"].max_acceleration = np.float64(2)
+    acc_results["A"].max_acceleration = np.float64(3)
+
+    manager = MoveManager(CONSTRAINTS)
+    # before acc override
+    assert manager._constraints == CONSTRAINTS
+
+    manager.override_accelerations(new_accs)
+    # after acc override
+    assert manager._constraints == acc_results


### PR DESCRIPTION

# Overview
Sometimes, we want the ability to change the max acceleration per axis from the hardware controller during a robot run. For instance, when the gripper is moving a labware filled with reagents, the max acceleration for the gantry axes should probably be slower than the defaults to minimize the chance of spillage.

This PR allows us to temporarily change the acceleration of the OT3 axes for a brief period of time. The custom accelerations used here will not replace the defaults or the values found in robot settings. 

We should also be able to easily revert the system constraint changes for basic operation, by loading the default or saved acceleration values found in robot settings. 

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Question
Should we really be overriding the system constraint values in the `MoveManager` like this? Alternatively, we can create a separate protocol constraint class that gets passed down to the MoveManager. These constraints will be protocol/run-specific, and will be reset once a run is finished. That'll be more complicated than what I have done here and I'm not sure if it's an overkill.
