### PR TITLE
fix(heater-shaker): fix async error handling

### DIFF
--- a/api/src/opentrons/drivers/asyncio/communication/__init__.py
+++ b/api/src/opentrons/drivers/asyncio/communication/__init__.py
@@ -1,4 +1,4 @@
-from .serial_connection import SerialConnection
+from .serial_connection import SerialConnection, AsyncResponseSerialConnection
 from opentrons.drivers.asyncio.communication.errors import (
     SerialException,
     NoResponse,
@@ -9,6 +9,7 @@ from .async_serial import AsyncSerial
 
 __all__ = [
     "SerialConnection",
+    "AsyncResponseSerialConnection",
     "AsyncSerial",
     "SerialException",
     "NoResponse",

--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -331,7 +331,7 @@ class AsyncResponseSerialConnection(SerialConnection):
             name=name,
             ack=ack,
             retry_wait_time_seconds=retry_wait_time_seconds,
-            error_keyword=error_keyword or "error",
+            error_keyword=error_keyword or "err",
             alarm_keyword=alarm_keyword or "alarm",
             async_error_ack=async_error_ack or "async",
         )

--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -447,13 +447,14 @@ class AsyncResponseSerialConnection(SerialConnection):
                 response.append(await self._serial.read_until(match=self._ack))
                 log.debug(f"{self._name}: Read <- {response[-1]!r}")
 
-            if any(self._async_error_ack.encode() in r for r in response):
-                # Remove ack from response
-                ackless_response = r.replace(self._ack, b"")
-                str_response = self.process_raw_response(
-                    command=data, response=ackless_response.decode()
-                )
-                self.raise_on_error(response=str_response)
+            for r in response:
+                if self._async_error_ack.encode() in r:
+                    # Remove ack from response
+                    ackless_response = r.replace(self._ack, b"")
+                    str_response = self.process_raw_response(
+                        command=data, response=ackless_response.decode()
+                    )
+                    self.raise_on_error(response=str_response)
 
             if self._ack in response[-1]:
                 # Remove ack from response

--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -312,7 +312,7 @@ class AsyncResponseSerialConnection(SerialConnection):
                            (default: alarm)
             reset_buffer_before_write: whether to reset the read buffer before
               every write
-            async_error_ack: optional string that will indicate an asynchronous 
+            async_error_ack: optional string that will indicate an asynchronous
                              error when detected (default: async)
 
         Returns: AsyncResponseSerialConnection
@@ -360,7 +360,7 @@ class AsyncResponseSerialConnection(SerialConnection):
                            exception when detected
             alarm_keyword: string that will cause an AlarmResponse
                            exception when detected
-            async_error_ack: string that will indicate an asynchronous 
+            async_error_ack: string that will indicate an asynchronous
                              error when detected
         """
         super().__init__(
@@ -438,7 +438,7 @@ class AsyncResponseSerialConnection(SerialConnection):
             log.debug(f"{self._name}: Write -> {data_encode!r}")
             await self._serial.write(data=data_encode)
 
-            response: List[str] = []
+            response: List[bytes] = []
             response.append(await self._serial.read_until(match=self._ack))
             log.debug(f"{self._name}: Read <- {response[-1]!r}")
 
@@ -455,11 +455,11 @@ class AsyncResponseSerialConnection(SerialConnection):
                 )
                 self.raise_on_error(response=str_response)
 
-            if self._ack in response:
+            if self._ack in response[-1]:
                 # Remove ack from response
-                response = response.replace(self._ack, b"")
+                ackless_response = response[-1].replace(self._ack, b"")
                 str_response = self.process_raw_response(
-                    command=data, response=response.decode()
+                    command=data, response=ackless_response.decode()
                 )
                 self.raise_on_error(response=str_response)
                 return str_response

--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -223,7 +223,7 @@ class SerialConnection:
             response = await self._serial.read_until(match=self._ack)
             log.debug(f"{self.name}: Read <- {response!r}")
 
-            while (self._error_keyword.encode() in response.lower() and self._gcode_ack.encode() not in response.lower()):
+            while self._gcode_ack.encode() not in response.lower():
                 #check for multiple a priori async errors
                 response = await self._serial.read_until(match=self._ack)
                 log.debug(f"{self.name}: Read <- {response!r}")

--- a/api/src/opentrons/drivers/heater_shaker/driver.py
+++ b/api/src/opentrons/drivers/heater_shaker/driver.py
@@ -6,7 +6,7 @@ import asyncio
 from typing import Optional, Dict
 from opentrons.drivers import utils
 from opentrons.drivers.command_builder import CommandBuilder
-from opentrons.drivers.asyncio.communication import SerialConnection
+from opentrons.drivers.asyncio.communication import AsyncResponseSerialConnection
 from opentrons.drivers.heater_shaker.abstract import AbstractHeaterShakerDriver
 from opentrons.drivers.types import Temperature, RPM, HeaterShakerLabwareLatchStatus
 
@@ -48,19 +48,18 @@ class HeaterShakerDriver(AbstractHeaterShakerDriver):
 
         Returns: driver
         """
-        connection = await SerialConnection.create(
+        connection = await AsyncResponseSerialConnection.create(
             port=port,
             baud_rate=HS_BAUDRATE,
             timeout=DEFAULT_HS_TIMEOUT,
             ack=HS_ACK,
             loop=loop,
             error_keyword=HS_ERROR_KEYWORD,
-            handle_async=True,
             async_error_ack=HS_ASYNC_ERROR_ACK,
         )
         return cls(connection=connection)
 
-    def __init__(self, connection: SerialConnection) -> None:
+    def __init__(self, connection: AsyncResponseSerialConnection) -> None:
         """
         Constructor
 

--- a/api/src/opentrons/drivers/heater_shaker/driver.py
+++ b/api/src/opentrons/drivers/heater_shaker/driver.py
@@ -30,7 +30,7 @@ DEFAULT_HS_TIMEOUT = 40
 HS_COMMAND_TERMINATOR = "\n"
 HS_ACK = "OK" + HS_COMMAND_TERMINATOR
 HS_ERROR_KEYWORD = "err"
-HS_GCODE_ACK = "gcode response"
+HS_ASYNC_ERROR_ACK = "async"
 DEFAULT_COMMAND_RETRIES = 0
 
 
@@ -56,7 +56,7 @@ class HeaterShakerDriver(AbstractHeaterShakerDriver):
             loop=loop,
             error_keyword=HS_ERROR_KEYWORD,
             handle_async=True,
-            gcode_ack=HS_GCODE_ACK,
+            async_error_ack=HS_ASYNC_ERROR_ACK,
         )
         return cls(connection=connection)
 

--- a/api/src/opentrons/drivers/heater_shaker/driver.py
+++ b/api/src/opentrons/drivers/heater_shaker/driver.py
@@ -30,6 +30,7 @@ DEFAULT_HS_TIMEOUT = 40
 HS_COMMAND_TERMINATOR = "\n"
 HS_ACK = "OK" + HS_COMMAND_TERMINATOR
 HS_ERROR_KEYWORD = "err"
+HS_GCODE_ACK = "gcode response"
 DEFAULT_COMMAND_RETRIES = 0
 
 
@@ -54,6 +55,8 @@ class HeaterShakerDriver(AbstractHeaterShakerDriver):
             ack=HS_ACK,
             loop=loop,
             error_keyword=HS_ERROR_KEYWORD,
+            handle_async=True,
+            gcode_ack=HS_GCODE_ACK,
         )
         return cls(connection=connection)
 

--- a/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
+++ b/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
@@ -1,10 +1,14 @@
-from typing import Type
+from typing import Type, Union
 
 import pytest
 from mock import AsyncMock, call
+import mock
 
 from opentrons.drivers.asyncio.communication.async_serial import AsyncSerial
-from opentrons.drivers.asyncio.communication.serial_connection import SerialConnection
+from opentrons.drivers.asyncio.communication.serial_connection import (
+    SerialConnection,
+    AsyncResponseSerialConnection,
+)
 from opentrons.drivers.asyncio.communication import (
     NoResponse,
     AlarmResponse,
@@ -22,25 +26,70 @@ def ack() -> str:
     return "ack"
 
 
+SerialKind = Union[AsyncResponseSerialConnection, SerialConnection]
+
+
 # Async because SerialConnection.__init__() needs an event loop,
 # so this fixture needs to run in an event loop.
-@pytest.fixture
-async def subject(mock_serial_port: AsyncMock, ack: str) -> SerialConnection:
+@pytest.fixture(
+    params=[AsyncResponseSerialConnection, SerialConnection],  # type: ignore[return]
+)
+async def subject(
+    request: pytest.FixtureRequest, mock_serial_port: AsyncMock, ack: str
+) -> SerialKind:
     """Create the test subject."""
-    SerialConnection.RETRY_WAIT_TIME = 0  # type: ignore[attr-defined]
-    return SerialConnection(
+    serial_class = request.param  # type: ignore[attr-defined]
+    serial_class.RETRY_WAIT_TIME = 0
+    if serial_class == AsyncResponseSerialConnection:
+        return serial_class(  # type: ignore[no-any-return]
+            serial=mock_serial_port,
+            ack=ack,
+            name="name",
+            port="port",
+            retry_wait_time_seconds=0,
+            error_keyword="err",
+            alarm_keyword="alarm",
+            async_error_ack="async",
+        )
+    elif serial_class == SerialConnection:
+        return serial_class(  # type: ignore[no-any-return]
+            serial=mock_serial_port,
+            ack=ack,
+            name="name",
+            port="port",
+            retry_wait_time_seconds=0,
+            error_keyword="error",
+            alarm_keyword="alarm",
+        )
+
+
+@pytest.fixture
+async def async_subject(
+    mock_serial_port: AsyncMock, ack: str
+) -> AsyncResponseSerialConnection:
+    """Create the test async subject."""
+    AsyncResponseSerialConnection.RETRY_WAIT_TIME = 0  # type: ignore[attr-defined]
+    return AsyncResponseSerialConnection(
         serial=mock_serial_port,
         ack=ack,
         name="name",
         port="port",
         retry_wait_time_seconds=0,
-        error_keyword="error",
+        error_keyword="err",
         alarm_keyword="alarm",
+        async_error_ack="async",
     )
 
 
+@pytest.fixture
+async def subject_raise_on_error_patched(async_subject):
+    raise_on_error_mock = mock.MagicMock()
+    with mock.patch.object(async_subject, "raise_on_error", raise_on_error_mock):
+        yield async_subject
+
+
 async def test_send_command(
-    mock_serial_port: AsyncMock, subject: SerialConnection, ack: str
+    mock_serial_port: AsyncMock, subject: SerialKind, ack: str
 ) -> None:
     """It should send a command."""
     serial_response = "response data " + ack
@@ -54,7 +103,7 @@ async def test_send_command(
 
 
 async def test_send_command_with_retry(
-    mock_serial_port: AsyncMock, subject: SerialConnection, ack: str
+    mock_serial_port: AsyncMock, subject: SerialKind, ack: str
 ) -> None:
     """It should retry sending after a read failure."""
     serial_response = "response data " + ack
@@ -75,7 +124,7 @@ async def test_send_command_with_retry(
 
 
 async def test_send_command_with_retry_exhausted(
-    mock_serial_port: AsyncMock, subject: SerialConnection
+    mock_serial_port: AsyncMock, subject: SerialKind
 ) -> None:
     """It should raise after retries exhausted."""
     mock_serial_port.read_until.side_effect = (b"", b"", b"")
@@ -85,7 +134,7 @@ async def test_send_command_with_retry_exhausted(
 
 
 async def test_send_command_response(
-    mock_serial_port: AsyncMock, subject: SerialConnection, ack: str
+    mock_serial_port: AsyncMock, subject: SerialKind, ack: str
 ) -> None:
     """It should return response without the ack and stripped."""
     response_data = "response data"
@@ -112,16 +161,50 @@ async def test_send_command_response(
     ],
 )
 def test_raise_on_error(
-    subject: SerialConnection, response: str, exception_type: Type[Exception]
+    subject: SerialKind, response: str, exception_type: Type[Exception]
 ) -> None:
     """It should raise an exception on error/alarm responses."""
     with pytest.raises(expected_exception=exception_type, match=response):
         subject.raise_on_error(response)
 
 
-async def test_on_retry(mock_serial_port: AsyncMock, subject: SerialConnection) -> None:
+async def test_on_retry(mock_serial_port: AsyncMock, subject: SerialKind) -> None:
     """It should try to re-open connection."""
     await subject.on_retry()
 
     mock_serial_port.close.assert_called_once()
     mock_serial_port.open.assert_called_once()
+
+
+async def test_send_data_async_error_response(
+    mock_serial_port: AsyncMock,
+    subject_raise_on_error_patched: AsyncResponseSerialConnection,
+    ack: str,
+) -> None:
+    """It should return response without the ack and stripped."""
+    error_response = "async ERR106:main motor:speedsensor failed"
+    serial_error_response = f" {error_response}  {ack}"
+    encoded_error_response = serial_error_response.encode()
+    successful_response = "G28"
+    serial_successful_response = f" {successful_response}  {ack}"
+    encoded_successful_response = serial_successful_response.encode()
+    mock_serial_port.read_until.side_effect = [
+        encoded_error_response,
+        encoded_successful_response,
+    ]
+
+    response = await subject_raise_on_error_patched._send_data(data="G28")
+
+    assert response == successful_response
+    mock_serial_port.read_until.assert_has_calls(
+        calls=[
+            call(match=ack.encode()),
+            call(match=ack.encode()),
+        ]
+    )
+    subject_raise_on_error_patched.raise_on_error.assert_has_calls(  # type: ignore[attr-defined]
+        calls=[
+            call(response=error_response),
+            call(response=successful_response),
+        ]
+    )

--- a/api/tests/opentrons/drivers/heater_shaker/test_driver.py
+++ b/api/tests/opentrons/drivers/heater_shaker/test_driver.py
@@ -1,6 +1,8 @@
 import pytest
 from mock import AsyncMock
-from opentrons.drivers.asyncio.communication.serial_connection import SerialConnection
+from opentrons.drivers.asyncio.communication.serial_connection import (
+    AsyncResponseSerialConnection,
+)
 from opentrons.drivers.heater_shaker import driver
 from opentrons.drivers.command_builder import CommandBuilder
 from opentrons.drivers.types import Temperature, RPM, HeaterShakerLabwareLatchStatus
@@ -8,7 +10,7 @@ from opentrons.drivers.types import Temperature, RPM, HeaterShakerLabwareLatchSt
 
 @pytest.fixture
 def connection() -> AsyncMock:
-    return AsyncMock(spec=SerialConnection)
+    return AsyncMock(spec=AsyncResponseSerialConnection)
 
 
 @pytest.fixture


### PR DESCRIPTION
Currently, all gcode messages sent by firmware contain the ack "OK". The hardware controller class doesn't have a way of differentiating responses to gcode commands from asynchronous error messages. Opentrons/opentrons-modules #401 prepends the latter with an identifier "async", the firmware-side fix to RET-1178. This api-side fix checks if any asynchronous errors are present when reading for an expected response to an issued gcode command.

Example:
1. send `M3 S500`
2a. receive `M3 OK` if successful
2b. receive `ERRxxx: ...` if unsuccessful
2c. receive `async ERRxxx:...` followed by (2a)/(2b) if asynchronous error is raised after last poll and before (2a)/(2b) received

Question: should we store asynchronous error(s) and raise exception(s) on them after processing the gcode response message, or discard the error(s) and let the poller handle them?

To-do: update TC2 and TD3 driver SerialConnection constructors