### PR TITLE
fix(api): correct critical points for gen3 multis

### DIFF
--- a/api/src/opentrons/hardware_control/instruments/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/pipette.py
@@ -6,7 +6,7 @@ import functools
 """
 from dataclasses import asdict, replace
 import logging
-from typing import Any, Dict, Optional, Set, Tuple, Union, TYPE_CHECKING
+from typing import Any, Dict, Optional, Set, Tuple, Union
 
 from opentrons_shared_data.pipette import name_config as pipette_name_config
 
@@ -24,19 +24,21 @@ from opentrons.hardware_control.types import (
 )
 
 
-if TYPE_CHECKING:
-    from opentrons_shared_data.pipette.dev_types import (
-        UlPerMmAction,
-        PipetteName,
-        PipetteModel,
-    )
-    from opentrons.hardware_control.dev_types import InstrumentHardwareConfigs
+from opentrons_shared_data.pipette.dev_types import (
+    UlPerMmAction,
+    PipetteName,
+    PipetteModel,
+)
+from opentrons.hardware_control.dev_types import InstrumentHardwareConfigs
+from typing_extensions import Final
 
 
 RECONFIG_KEYS = {"quirks"}
 
 
 mod_log = logging.getLogger(__name__)
+
+INTERNOZZLE_SPACING_MM: Final[float] = 9
 
 
 class Pipette(AbstractInstrument[pipette_config.PipetteConfig]):
@@ -167,10 +169,18 @@ class Pipette(AbstractInstrument[pipette_config.PipetteConfig]):
             cp_type = CriticalPoint.TIP
             tip_length = self.current_tip_length
         if cp_override == CriticalPoint.XY_CENTER:
-            mod_offset_xy = [0, 0, offsets[2]]
+            mod_offset_xy = [
+                offsets[0],
+                offsets[1] - (INTERNOZZLE_SPACING_MM * (self._config.channels - 1) / 2),
+                offsets[2],
+            ]
             cp_type = CriticalPoint.XY_CENTER
         elif cp_override == CriticalPoint.FRONT_NOZZLE:
-            mod_offset_xy = [0, -offsets[1], offsets[2]]
+            mod_offset_xy = [
+                0,
+                (offsets[1] - INTERNOZZLE_SPACING_MM * (self._config.channels - 1)),
+                offsets[2],
+            ]
             cp_type = CriticalPoint.FRONT_NOZZLE
         else:
             mod_offset_xy = list(offsets)

--- a/api/tests/opentrons/hardware_control/test_pipette.py
+++ b/api/tests/opentrons/hardware_control/test_pipette.py
@@ -146,3 +146,18 @@ def test_flow_rate_setting():
     assert pip.dispense_flow_rate == 3
     assert pip.blow_out_flow_rate == 4
     assert pip.config is config
+
+
+@pytest.mark.parametrize("config_model", pipette_config.config_models)
+def test_xy_center(config_model):
+    loaded = pipette_config.load(config_model)
+    pip = pipette.Pipette(loaded, PIP_CAL, "testId")
+    if loaded.channels == 8:
+        cp_y_offset = 9 * 3.5
+    else:
+        cp_y_offset = 0
+    assert pip.critical_point(types.CriticalPoint.XY_CENTER) == Point(
+        loaded.nozzle_offset[0],
+        loaded.nozzle_offset[1] - cp_y_offset,
+        loaded.nozzle_offset[2],
+    )


### PR DESCRIPTION
The XY_CENTER and FRONT_NOZZLE critical points were calculated by
zeroing and inverting the y component of the nozzle offset,
respectively. This works for pipettes that are centered in Y relative to
their mounts (as on the OT-2), but it does not work for pipettes that
are not (as on the OT-3). The correct general solution is to move the
critical point by some multiple of the internozzle spacing, which is
always 9mm due to standardization of well plates.

Similarly, the gen1 and gen2 pipettes do not have an x component to
their nozzle offset. The XY_CENTER critical point functionality zeroed
this out, which had no effect; now, it very much does and needs to not happen.
