### PR TITLE
docs(protocol-engine) Clarify `pipetteRetracted` field

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/open_labware_latch.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/open_labware_latch.py
@@ -27,7 +27,10 @@ class OpenLabwareLatchResult(BaseModel):
 
     pipetteRetracted: bool = Field(
         ...,
-        description="Whether the pipette was retracted/ homed before starting shake.",
+        description=(
+            "Whether this command automatically retracted the pipettes"
+            " before opening the latch, to avoid a potential collision."
+        ),
     )
 
 

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/set_and_wait_for_shake_speed.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/set_and_wait_for_shake_speed.py
@@ -30,7 +30,10 @@ class SetAndWaitForShakeSpeedResult(BaseModel):
 
     pipetteRetracted: bool = Field(
         ...,
-        description="Whether the pipette was retracted/ homed before starting shake.",
+        description=(
+            "Whether this command automatically retracted the pipettes"
+            " before starting the shake, to avoid a potential collision."
+        ),
     )
 
 


### PR DESCRIPTION
# Overview

Clarify some points about the `heaterShaker` result field in the Protocol Engine commands `heaterShaker/openLabwareLatch` and `heaterShaker/setAndWaitForShakeSpeed`.

Jira ticket: RSS-89

# Changelog

* Clarify that the field describes whether the *command* caused an *automatic* pipette retraction—in other words, this command does not describe
* Describe that the purpose of this pipette retraction is to avoid a potential collision.
* Fix a copy-paste mistake where both commands' docstrings referred to shaking, instead of one referring to shaking and the other referring to opening the latch.

# Review requests

* Clear and concise?
* Anything else we want to mention?

# Risk assessment

No risk.