### PR TITLE
fix(shared-data): Make JSONv6 loadLabware match implementation by changing .location and .displayName

### DIFF
--- a/shared-data/protocol/fixtures/6/simpleV6.json
+++ b/shared-data/protocol/fixtures/6/simpleV6.json
@@ -1278,8 +1278,7 @@
         "labwareId": "destPlateId",
         "location": {
           "moduleId": "magneticModuleId"
-        },
-        "displayName": "Sample Collection Plate"
+        }
       }
     },
     {

--- a/shared-data/protocol/schemas/6.json
+++ b/shared-data/protocol/schemas/6.json
@@ -1064,6 +1064,7 @@
                 "enum": ["loadLabware"]
               },
               "params": {
+                "description": "Input parameters to the `loadLabware` command. NOTE: Unlike most commands, `loadLabware` commands issued over HTTP have different parameters than ones in JSON protocols. This schema describes JSON protocols.",
                 "required": ["labwareId", "location"],
                 "properties": {
                   "labwareId": {

--- a/shared-data/protocol/schemas/6.json
+++ b/shared-data/protocol/schemas/6.json
@@ -1068,7 +1068,7 @@
                 "properties": {
                   "labwareId": {
                     "type": "string",
-                    "description": "Unique identifier of labware to load"
+                    "description": "Unique identifier of labware to load. Must be a key from the top-level `labware` object."
                   },
                   "location": {
                     "description": "Physical destination location to load labware into (e.g. '1' || 'someModuleId')",
@@ -1091,15 +1091,6 @@
                           }
                         }
                       },
-                      {
-                        "required": ["labwareId"],
-                        "properties": {
-                          "labwareId": {
-                            "description": "Unique identifier of destination labware. Must be a key from the top level 'labware' object.",
-                            "type": "string"
-                          }
-                        }
-                      }
                     ],
                     "displayName": {
                       "type": "string",

--- a/shared-data/protocol/schemas/6.json
+++ b/shared-data/protocol/schemas/6.json
@@ -1090,7 +1090,7 @@
                             "type": "string"
                           }
                         }
-                      },
+                      }
                     ],
                     "displayName": {
                       "type": "string",

--- a/shared-data/protocol/schemas/6.json
+++ b/shared-data/protocol/schemas/6.json
@@ -1091,11 +1091,7 @@
                           }
                         }
                       }
-                    ],
-                    "displayName": {
-                      "type": "string",
-                      "description": "Optional user-defined nickname for this labware instance within the protocol"
-                    }
+                    ]
                   }
                 }
               }

--- a/shared-data/protocol/schemas/7-draft.json
+++ b/shared-data/protocol/schemas/7-draft.json
@@ -1068,7 +1068,7 @@
                 "properties": {
                   "labwareId": {
                     "type": "string",
-                    "description": "Unique identifier of labware to load"
+                    "description": "Unique identifier of labware to load. Must be a key from the top-level `labware` object."
                   },
                   "location": {
                     "description": "Physical destination location to load labware into (e.g. '1' || 'someModuleId')",
@@ -1091,15 +1091,6 @@
                           }
                         }
                       },
-                      {
-                        "required": ["labwareId"],
-                        "properties": {
-                          "labwareId": {
-                            "description": "Unique identifier of destination labware. Must be a key from the top level 'labware' object.",
-                            "type": "string"
-                          }
-                        }
-                      }
                     ],
                     "displayName": {
                       "type": "string",

--- a/shared-data/protocol/schemas/7-draft.json
+++ b/shared-data/protocol/schemas/7-draft.json
@@ -1090,7 +1090,7 @@
                             "type": "string"
                           }
                         }
-                      },
+                      }
                     ],
                     "displayName": {
                       "type": "string",

--- a/shared-data/protocol/schemas/7-draft.json
+++ b/shared-data/protocol/schemas/7-draft.json
@@ -1091,11 +1091,7 @@
                           }
                         }
                       }
-                    ],
-                    "displayName": {
-                      "type": "string",
-                      "description": "Optional user-defined nickname for this labware instance within the protocol"
-                    }
+                    ]
                   }
                 }
               }


### PR DESCRIPTION
# Overview

This PR makes two fixes to the v6 JSON protocol schema.

Jira link: RSS-90

# Changelog

## Disallow loading labware atop labware

Currently, the v6 JSON protocol schema allows `loadLabware` commands like:

```json
{
  "commandType": "loadLabware",
  "id": "3abc123",
  "params": {
    "labwareId": "sourcePlateId",
    "location": {
      "labwareId": "6def456"
    }
  }
},
```

This says to load a new labware (`3abc123`) atop an existing labware (`6def456`). Protocol Engine does not support this, and never has. So, a protocol that attempts this will not run.

This PR changes the schema to match the reality of JSON v6 protocols: you can only do `loadLabware` on a deck slot or module.

This part of the schema dates back to at least #8271. The schema was originally planned to be a broad, aspirational specification of what we *should* implement, but in the history of that PR, it was reworked as a description of what we *were* implementing in the short term. I think this is just a left-over aspirational thing that we missed.

If we ever do support this, it may be added to the JSON protocol v7 schema.

## Remove the `displayName` field from the `loadLabware` command

`displayName` *is* a valid parameter to `loadLabware` commands in Protocol Engine, but JSON protocol commands are not always Protocol Engine commands.

See https://github.com/Opentrons/opentrons/pull/11408#discussion_r956445873.

# Review requests

Are these changes safe to make from the JS side? See risk assessment below.

# Risk assessment

Low on the robot side. Does not change production behavior on the robot, because the robot parses commands independently of this schema file.

*May* change production behavior on the app, because the app *does* validate JSON documents directly against this schema file, I think? May cause an error to pop up in a new place if a user imports a protocol with one of these bad `loadLabware` commands.