### PR TITLE
refactor(app): add stories and test for mini card

### DIFF
--- a/app/src/molecules/MiniCard/MiniCard.stories.tsx
+++ b/app/src/molecules/MiniCard/MiniCard.stories.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react'
+import {
+  SPACING,
+  Box,
+  COLORS,
+  TYPOGRAPHY,
+  Flex,
+  ALIGN_CENTER,
+} from '@opentrons/components'
+import OT2_PNG from '../../assets/images/OT2-R_HERO.png'
+import { MiniCard } from './'
+import { StyledText } from '../../atoms/text'
+
+import type { Story, Meta } from '@storybook/react'
+
+export default {
+  title: 'App/Molecules/MiniCard',
+  component: MiniCard,
+} as Meta
+
+const Template: Story<React.ComponentProps<typeof MiniCard>> = args => (
+  <MiniCard {...args} />
+)
+
+const Children = (
+  <Flex alignItems={ALIGN_CENTER}>
+    <Box backgroundColor={COLORS.white}>
+      <img src={OT2_PNG} style={{ width: '3rem' }} />
+    </Box>
+    <StyledText
+      as="p"
+      marginLeft={SPACING.spacing3}
+      fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+    >
+      MiniCard stories protocol
+    </StyledText>
+  </Flex>
+)
+
+export const Primary = Template.bind({})
+Primary.args = {
+  onClick: () => {},
+  isSelected: true,
+  children: Children,
+  isError: false,
+}

--- a/app/src/molecules/MiniCard/MiniCard.stories.tsx
+++ b/app/src/molecules/MiniCard/MiniCard.stories.tsx
@@ -9,6 +9,7 @@ import {
 } from '@opentrons/components'
 import OT2_PNG from '../../assets/images/OT2-R_HERO.png'
 import { MiniCard } from './'
+import { Slideout } from '../../atoms/Slideout'
 import { StyledText } from '../../atoms/text'
 
 import type { Story, Meta } from '@storybook/react'
@@ -19,7 +20,11 @@ export default {
 } as Meta
 
 const Template: Story<React.ComponentProps<typeof MiniCard>> = args => (
-  <MiniCard {...args} />
+  <Slideout title="MiniCard" onCloseClick={() => {}} isExpanded={true}>
+    <MiniCard {...args} />
+    <MiniCard {...args} isSelected={false} />
+    <MiniCard {...args} isSelected={false} />
+  </Slideout>
 )
 
 const Children = (

--- a/app/src/molecules/MiniCard/__tests__/MiniCard.test.tsx
+++ b/app/src/molecules/MiniCard/__tests__/MiniCard.test.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react'
+import { fireEvent } from '@testing-library/react'
+import {
+  renderWithProviders,
+  COLORS,
+  SPACING,
+  BORDERS,
+} from '@opentrons/components'
+import { MiniCard } from '../'
+
+const render = (props: React.ComponentProps<typeof MiniCard>) => {
+  return renderWithProviders(<MiniCard {...props} />)[0]
+}
+
+describe('MiniCard', () => {
+  let props: React.ComponentProps<typeof MiniCard>
+
+  beforeEach(() => {
+    props = {
+      onClick: jest.fn(),
+      isSelected: false,
+      children: 'mock mini card',
+      isError: false,
+    }
+  })
+
+  it('renders the correct style unselectedOptionStyles', () => {
+    const { getByText } = render(props)
+    const miniCard = getByText('mock mini card')
+    expect(miniCard).toHaveStyle(`background-color: ${COLORS.white}`)
+    expect(miniCard).toHaveStyle(`border: 1px solid ${COLORS.medGreyEnabled}`)
+    expect(miniCard).toHaveStyle(`border-radius: ${BORDERS.radiusSoftCorners}`)
+    expect(miniCard).toHaveStyle(`padding: ${SPACING.spacing3}`)
+    expect(miniCard).toHaveStyle(`width: 100%`)
+    expect(miniCard).toHaveStyle(`cursor: pointer`)
+  })
+
+  it('renders the correct style selectedOptionStyles', () => {
+    props.isSelected = true
+    const { getByText } = render(props)
+    const miniCard = getByText('mock mini card')
+    expect(miniCard).toHaveStyle(`background-color: ${COLORS.lightBlue}`)
+    expect(miniCard).toHaveStyle(`border: 1px solid ${COLORS.blueEnabled}`)
+    expect(miniCard).toHaveStyle(`border-radius: ${BORDERS.radiusSoftCorners}`)
+    expect(miniCard).toHaveStyle(`padding: ${SPACING.spacing3}`)
+    expect(miniCard).toHaveStyle(`width: 100%`)
+    expect(miniCard).toHaveStyle(`cursor: pointer`)
+    expect(miniCard).toHaveStyleRule(
+      'border',
+      `1px solid ${COLORS.blueEnabled}`,
+      {
+        modifier: ':hover',
+      }
+    )
+    expect(miniCard).toHaveStyleRule(
+      'background-color',
+      `${COLORS.lightBlue}`,
+      {
+        modifier: ':hover',
+      }
+    )
+  })
+
+  it('renders the correct style errorOptionStyles', () => {
+    props.isError = true
+    props.isSelected = true
+    const { getByText } = render(props)
+    const miniCard = getByText('mock mini card')
+    expect(miniCard).toHaveStyle(`background-color: ${COLORS.errorBackground}`)
+    expect(miniCard).toHaveStyle(`border: 1px solid ${COLORS.errorEnabled}`)
+    expect(miniCard).toHaveStyle(`border-radius: ${BORDERS.radiusSoftCorners}`)
+    expect(miniCard).toHaveStyle(`padding: ${SPACING.spacing3}`)
+    expect(miniCard).toHaveStyle(`width: 100%`)
+    expect(miniCard).toHaveStyle(`cursor: pointer`)
+    expect(miniCard).toHaveStyleRule(
+      'border',
+      `1px solid ${COLORS.errorEnabled}`,
+      {
+        modifier: ':hover',
+      }
+    )
+    expect(miniCard).toHaveStyleRule(
+      'background-color',
+      `${COLORS.errorBackground}`,
+      {
+        modifier: ':hover',
+      }
+    )
+  })
+
+  it('calls mock function when clicking mini card', () => {
+    const { getByText } = render(props)
+    const miniCard = getByText('mock mini card')
+    fireEvent.click(miniCard)
+    expect(props.onClick).toHaveBeenCalled()
+  })
+})

--- a/app/src/molecules/Modal/Modal.stories.tsx
+++ b/app/src/molecules/Modal/Modal.stories.tsx
@@ -26,7 +26,7 @@ const Children = (
     </StyledText>
 
     <PrimaryBtn
-      backgroundColor={COLORS.blue}
+      backgroundColor={COLORS.blueEnabled}
       marginTop="28rem"
       textTransform={TYPOGRAPHY.textTransformNone}
     >


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Add stories and test for MiniCard. This will close [RAUT-186](https://opentrons.atlassian.net/browse/RAUT-186)

<img width="1672" alt="Screen Shot 2022-08-28 at 2 51 05 PM" src="https://user-images.githubusercontent.com/474225/187090060-4a58b9bb-8bdb-4474-8502-61151b1c257e.png">


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- add stories
- add test
- fix color const (Modal)
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- [ ] test cases cover basics
- [ ] stories displays MiniCard
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
