### PR TITLE
fix(app): unattached pipette calibration bugfix

### DIFF
--- a/app/src/organisms/Devices/RobotSettings/CalibrationDetails/OverflowMenu.tsx
+++ b/app/src/organisms/Devices/RobotSettings/CalibrationDetails/OverflowMenu.tsx
@@ -224,16 +224,15 @@ export function OverflowMenu({
           right={0}
           flexDirection={DIRECTION_COLUMN}
         >
-          <MenuItem
-            onClick={e => handleCalibration(calType, e)}
-            disabled={mount == null}
-          >
-            {calType === 'pipetteOffset'
-              ? applicablePipetteOffsetCal != null
-                ? t('recalibrate_pipette')
-                : t('calibrate_pipette')
-              : t('recalibrate_tip_and_pipette')}
-          </MenuItem>
+          {mount != null && (
+            <MenuItem onClick={e => handleCalibration(calType, e)}>
+              {calType === 'pipetteOffset'
+                ? applicablePipetteOffsetCal != null
+                  ? t('recalibrate_pipette')
+                  : t('calibrate_pipette')
+                : t('recalibrate_tip_and_pipette')}
+            </MenuItem>
+          )}
           <MenuItem onClick={e => handleDownload(calType, e)}>
             {t('download_calibration_data')}
           </MenuItem>

--- a/app/src/organisms/Devices/RobotSettings/CalibrationDetails/OverflowMenu.tsx
+++ b/app/src/organisms/Devices/RobotSettings/CalibrationDetails/OverflowMenu.tsx
@@ -51,7 +51,7 @@ type CalBlockModalState =
 interface OverflowMenuProps {
   calType: 'pipetteOffset' | 'tipLength'
   robotName: string
-  mount?: Mount
+  mount: Mount
   serialNumber: string | null
   updateRobotStatus: (isRobotBusy: boolean) => void
 }

--- a/app/src/organisms/Devices/RobotSettings/CalibrationDetails/OverflowMenu.tsx
+++ b/app/src/organisms/Devices/RobotSettings/CalibrationDetails/OverflowMenu.tsx
@@ -51,7 +51,7 @@ type CalBlockModalState =
 interface OverflowMenuProps {
   calType: 'pipetteOffset' | 'tipLength'
   robotName: string
-  mount: Mount
+  mount?: Mount
   serialNumber: string | null
   updateRobotStatus: (isRobotBusy: boolean) => void
 }
@@ -224,7 +224,10 @@ export function OverflowMenu({
           right={0}
           flexDirection={DIRECTION_COLUMN}
         >
-          <MenuItem onClick={e => handleCalibration(calType, e)}>
+          <MenuItem
+            onClick={e => handleCalibration(calType, e)}
+            disabled={mount == null}
+          >
             {calType === 'pipetteOffset'
               ? applicablePipetteOffsetCal != null
                 ? t('recalibrate_pipette')

--- a/app/src/organisms/Devices/RobotSettings/CalibrationDetails/__test__/OverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/CalibrationDetails/__test__/OverflowMenu.test.tsx
@@ -117,18 +117,18 @@ describe('OverflowMenu', () => {
     getByText('Download calibration data')
   })
 
-  it('should disable calibrate menu item when mount is undefined', () => {
+  it('should not render calibrate menu item when mount is undefined', () => {
     props = {
       ...props,
       mount: undefined as any,
     }
-    const [{ getByRole }] = render(props)
+    const [{ getByRole, queryByRole }] = render(props)
     const button = getByRole('button', {
       name: 'CalibrationOverflowMenu_button',
     })
     fireEvent.click(button)
-    const menuItem = getByRole('button', { name: 'Calibrate Pipette Offset' })
-    expect(menuItem).toBeDisabled()
+    const menuItem = queryByRole('button', { name: 'Calibrate Pipette Offset' })
+    expect(menuItem).not.toBeInTheDocument()
   })
 
   it('call a function when clicking download tip length calibrations data', async () => {

--- a/app/src/organisms/Devices/RobotSettings/CalibrationDetails/__test__/OverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/CalibrationDetails/__test__/OverflowMenu.test.tsx
@@ -10,7 +10,6 @@ import { useCalibratePipetteOffset } from '../../../../CalibratePipetteOffset/us
 import { useDeckCalibrationData, useIsRobotBusy } from '../../../hooks'
 
 import { OverflowMenu } from '../OverflowMenu'
-import { PipetteMount } from '@opentrons/shared-data'
 
 const render = (
   props: React.ComponentProps<typeof OverflowMenu>

--- a/app/src/organisms/Devices/RobotSettings/CalibrationDetails/__test__/OverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/CalibrationDetails/__test__/OverflowMenu.test.tsx
@@ -117,6 +117,20 @@ describe('OverflowMenu', () => {
     getByText('Download calibration data')
   })
 
+  it('should disable calibrate menu item when mount in undefined', () => {
+    props = {
+      ...props,
+      mount: undefined,
+    }
+    const [{ getByRole }] = render(props)
+    const button = getByRole('button', {
+      name: 'CalibrationOverflowMenu_button',
+    })
+    fireEvent.click(button)
+    const menuItem = getByRole('button', { name: 'Calibrate Pipette Offset' })
+    expect(menuItem).toBeDisabled()
+  })
+
   it('call a function when clicking download tip length calibrations data', async () => {
     const [{ getByText, getByLabelText }] = render(props)
     const button = getByLabelText('CalibrationOverflowMenu_button')

--- a/app/src/organisms/Devices/RobotSettings/CalibrationDetails/__test__/OverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/CalibrationDetails/__test__/OverflowMenu.test.tsx
@@ -10,6 +10,7 @@ import { useCalibratePipetteOffset } from '../../../../CalibratePipetteOffset/us
 import { useDeckCalibrationData, useIsRobotBusy } from '../../../hooks'
 
 import { OverflowMenu } from '../OverflowMenu'
+import { PipetteMount } from '@opentrons/shared-data'
 
 const render = (
   props: React.ComponentProps<typeof OverflowMenu>
@@ -120,7 +121,7 @@ describe('OverflowMenu', () => {
   it('should disable calibrate menu item when mount is undefined', () => {
     props = {
       ...props,
-      mount: undefined,
+      mount: undefined as any,
     }
     const [{ getByRole }] = render(props)
     const button = getByRole('button', {

--- a/app/src/organisms/Devices/RobotSettings/CalibrationDetails/__test__/OverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/CalibrationDetails/__test__/OverflowMenu.test.tsx
@@ -117,7 +117,7 @@ describe('OverflowMenu', () => {
     getByText('Download calibration data')
   })
 
-  it('should disable calibrate menu item when mount in undefined', () => {
+  it('should disable calibrate menu item when mount is undefined', () => {
     props = {
       ...props,
       mount: undefined,


### PR DESCRIPTION
# Overview
Fixes unattached calibrate pipette bug by removing menu item if `mount` is `undefined` in "CalibrationDetails/OverflowMenu".
Closes RAUT-189.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- removes calibrate button in menu overflow if `mount` is `undefined`
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- confirm that menu overflow item is disabled only when appropriate
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
