### PR TITLE
fix(heater-shaker): reduce motion classifier delta

### DIFF
--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -160,7 +160,7 @@ class HeaterShaker(mod_abc.AbstractModule):
         Returns:
             The status
         """
-        DELTA: Final = 100
+        DELTA: Final = 40
         status = SpeedStatus.IDLE
         if speed.target is not None:
             diff = speed.target - speed.current


### PR DESCRIPTION
With improved speed reading filtering (Opentrons/opentrons-modules #403), we now see current speed return values within +/-20rpm of target speed. This updates the motion regime classifier DELTA to 40 from 100, for a factor of safety of roughly 2