### PR TITLE
feat(app): wire up WizardHeader and StepMeter in ChangePipette

### DIFF
--- a/app/src/molecules/InProgressModal/InProgressModal.tsx
+++ b/app/src/molecules/InProgressModal/InProgressModal.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { WizardHeader } from '../WizardHeader'
 import {
   ALIGN_CENTER,
   COLORS,
@@ -9,37 +8,27 @@ import {
 } from '@opentrons/components'
 
 interface Props {
-  wizardHeaderTitle: string
-  currentStep: number
-  totalSteps: number
   children?: JSX.Element
 }
 
 export function InProgressModal(props: Props): JSX.Element {
-  const { wizardHeaderTitle, totalSteps, currentStep, children } = props
+  const { children } = props
 
   return (
-    <>
-      <WizardHeader
-        totalSteps={totalSteps}
-        currentStep={currentStep}
-        title={wizardHeaderTitle}
+    <Flex
+      alignItems={ALIGN_CENTER}
+      flexDirection={DIRECTION_COLUMN}
+      height="100%"
+      transform="translateY(75%)"
+    >
+      <Icon
+        name="ot-spinner"
+        size="5.1rem"
+        color={COLORS.darkGreyEnabled}
+        aria-label="spinner"
+        spin
       />
-      <Flex
-        alignItems={ALIGN_CENTER}
-        flexDirection={DIRECTION_COLUMN}
-        height="100%"
-        transform="translateY(50%)"
-      >
-        <Icon
-          name="ot-spinner"
-          size="5.1rem"
-          color={COLORS.darkGreyEnabled}
-          aria-label="spinner"
-          spin
-        />
-        {children}
-      </Flex>
-    </>
+      {children}
+    </Flex>
   )
 }

--- a/app/src/molecules/InProgressModal/__tests__/InProgressModal.test.tsx
+++ b/app/src/molecules/InProgressModal/__tests__/InProgressModal.test.tsx
@@ -10,29 +10,18 @@ const render = (props: React.ComponentProps<typeof InProgressModal>) => {
 }
 describe('InProgressModal', () => {
   let props: React.ComponentProps<typeof InProgressModal>
-  beforeEach(() => {
-    props = {
-      wizardHeaderTitle: 'Attach a pipette',
-      currentStep: 1,
-      totalSteps: 6,
-    }
-  })
+
   it('renders the correct text with no child', () => {
-    const { getByText, getByLabelText } = render(props)
-    getByText('Attach a pipette')
-    getByText('Step: 1 / 6')
+    const { getByLabelText } = render(props)
     getByLabelText('spinner')
   })
 
   it('renders the correct text with child', () => {
     props = {
-      ...props,
       children: <div>Moving gantry...</div>,
     }
     const { getByText, getByLabelText } = render(props)
-    getByText('Attach a pipette')
     getByText('Moving gantry...')
-    getByText('Step: 1 / 6')
     getByLabelText('spinner')
   })
 })

--- a/app/src/molecules/SimpleWizardBody/SimpleWizardBody.stories.tsx
+++ b/app/src/molecules/SimpleWizardBody/SimpleWizardBody.stories.tsx
@@ -3,21 +3,19 @@ import { COLORS } from '@opentrons/components'
 import { PrimaryButton } from '../../atoms/buttons'
 import { ModalShell } from '../Modal'
 import { WizardHeader } from '../WizardHeader'
-import { SimpleWizardModal } from './index'
+import { SimpleWizardBody } from './index'
 
 import type { Story, Meta } from '@storybook/react'
 
 export default {
-  title: 'App/Molecules/SimpleWizardModal',
-  component: SimpleWizardModal,
+  title: 'App/Molecules/SimpleWizardBody',
+  component: SimpleWizardBody,
 } as Meta
 
-const Template: Story<
-  React.ComponentProps<typeof SimpleWizardModal>
-> = args => (
+const Template: Story<React.ComponentProps<typeof SimpleWizardBody>> = args => (
   <ModalShell>
     <WizardHeader currentStep={3} totalSteps={4} title="Attach a pipette" />
-    <SimpleWizardModal {...args} />
+    <SimpleWizardBody {...args} />
   </ModalShell>
 )
 

--- a/app/src/molecules/SimpleWizardBody/__tests__/SimpleWizardBody.test.tsx
+++ b/app/src/molecules/SimpleWizardBody/__tests__/SimpleWizardBody.test.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react'
 import { COLORS, renderWithProviders } from '@opentrons/components'
-import { SimpleWizardModal } from '..'
+import { SimpleWizardBody } from '..'
 
-const render = (props: React.ComponentProps<typeof SimpleWizardModal>) => {
-  return renderWithProviders(<SimpleWizardModal {...props} />)[0]
+const render = (props: React.ComponentProps<typeof SimpleWizardBody>) => {
+  return renderWithProviders(<SimpleWizardBody {...props} />)[0]
 }
-describe('SimpleWizardModal', () => {
-  let props: React.ComponentProps<typeof SimpleWizardModal>
+describe('SimpleWizardBody', () => {
+  let props: React.ComponentProps<typeof SimpleWizardBody>
   beforeEach(() => {
     props = {
       iconColor: COLORS.errorText,

--- a/app/src/molecules/SimpleWizardBody/index.tsx
+++ b/app/src/molecules/SimpleWizardBody/index.tsx
@@ -17,7 +17,7 @@ interface Props {
   isSuccess: boolean
 }
 
-export function SimpleWizardModal(props: Props): JSX.Element {
+export function SimpleWizardBody(props: Props): JSX.Element {
   const { iconColor, children, header, subHeader, isSuccess } = props
 
   return (

--- a/app/src/molecules/SimpleWizardModal/SimpleWizardModal.stories.tsx
+++ b/app/src/molecules/SimpleWizardModal/SimpleWizardModal.stories.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react'
 import { COLORS } from '@opentrons/components'
-import { TEMPERATURE_MODULE_V1 } from '@opentrons/shared-data'
 import { PrimaryButton } from '../../atoms/buttons'
+import { ModalShell } from '../Modal'
+import { WizardHeader } from '../WizardHeader'
 import { SimpleWizardModal } from './index'
 
 import type { Story, Meta } from '@storybook/react'
@@ -13,7 +14,12 @@ export default {
 
 const Template: Story<
   React.ComponentProps<typeof SimpleWizardModal>
-> = args => <SimpleWizardModal {...args} />
+> = args => (
+  <ModalShell>
+    <WizardHeader currentStep={3} totalSteps={4} title="Attach a pipette" />
+    <SimpleWizardModal {...args} />
+  </ModalShell>
+)
 
 export const AlertIcon = Template.bind({})
 AlertIcon.args = {
@@ -22,10 +28,6 @@ AlertIcon.args = {
   subHeader: 'Are you sure you want to exit before detaching your pipette?',
   isSuccess: false,
   children: <PrimaryButton>{'Exit'}</PrimaryButton>,
-  onExit: () => console.log('exit'),
-  title: 'Attach a pipette',
-  currentStep: 5,
-  totalSteps: 6,
 }
 
 export const SuccessIcon = Template.bind({})
@@ -33,10 +35,6 @@ SuccessIcon.args = {
   iconColor: COLORS.successEnabled,
   header: 'Pipette still detected',
   subHeader: 'Are you sure you want to exit before detaching your pipette?',
-  isSuccess: TEMPERATURE_MODULE_V1,
+  isSuccess: true,
   children: <PrimaryButton>{'Exit'}</PrimaryButton>,
-  onExit: () => console.log('exit'),
-  title: 'Attach a pipette',
-  currentStep: 5,
-  totalSteps: 6,
 }

--- a/app/src/molecules/SimpleWizardModal/__tests__/SimpleWizardModal.test.tsx
+++ b/app/src/molecules/SimpleWizardModal/__tests__/SimpleWizardModal.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { fireEvent } from '@testing-library/react'
 import { COLORS, renderWithProviders } from '@opentrons/components'
 import { SimpleWizardModal } from '..'
 
@@ -14,10 +13,6 @@ describe('SimpleWizardModal', () => {
       children: <div>children</div>,
       header: 'header',
       subHeader: 'subheader',
-      onExit: jest.fn(),
-      title: 'title',
-      currentStep: 5,
-      totalSteps: 7,
       isSuccess: false,
     }
   })
@@ -26,10 +21,6 @@ describe('SimpleWizardModal', () => {
     getByText('header')
     getByText('subheader')
     getByLabelText('ot-alert')
-    getByText('title')
-    const exitBtn = getByLabelText('Exit')
-    fireEvent.click(exitBtn)
-    expect(props.onExit).toHaveBeenCalled()
   })
 
   it('renders the correct information when it is success', () => {
@@ -41,9 +32,5 @@ describe('SimpleWizardModal', () => {
     getByText('header')
     getByText('subheader')
     getByLabelText('ot-check')
-    getByText('title')
-    const exitBtn = getByLabelText('Exit')
-    fireEvent.click(exitBtn)
-    expect(props.onExit).toHaveBeenCalled()
   })
 })

--- a/app/src/molecules/SimpleWizardModal/index.tsx
+++ b/app/src/molecules/SimpleWizardModal/index.tsx
@@ -8,8 +8,6 @@ import {
   SPACING,
 } from '@opentrons/components'
 import { StyledText } from '../../atoms/text'
-import { ModalShell } from '../Modal'
-import { WizardHeader } from '../WizardHeader'
 
 interface Props {
   iconColor: string
@@ -17,66 +15,42 @@ interface Props {
   header: string
   subHeader: string
   isSuccess: boolean
-  onExit: () => void
-  title: string
-  currentStep: number
-  totalSteps: number
 }
 
 export function SimpleWizardModal(props: Props): JSX.Element {
-  const {
-    iconColor,
-    children,
-    header,
-    subHeader,
-    isSuccess,
-    onExit,
-    title,
-    currentStep,
-    totalSteps,
-  } = props
+  const { iconColor, children, header, subHeader, isSuccess } = props
 
   return (
-    <ModalShell width="47rem" height="28.12rem">
-      <Flex flexDirection={DIRECTION_COLUMN}>
-        <WizardHeader
-          currentStep={currentStep}
-          totalSteps={totalSteps}
-          title={title}
-          onExit={onExit}
+    <Flex flexDirection={DIRECTION_COLUMN}>
+      <Flex
+        alignItems={ALIGN_CENTER}
+        flexDirection={DIRECTION_COLUMN}
+        height="100%"
+        marginTop="5.8rem"
+        marginBottom="5.68rem"
+      >
+        <Icon
+          name={isSuccess ? 'ot-check' : 'ot-alert'}
+          size="4rem"
+          color={iconColor}
+          aria-label={isSuccess ? 'ot-check' : 'ot-alert'}
         />
-        <Flex flexDirection={DIRECTION_COLUMN}>
-          <Flex
-            alignItems={ALIGN_CENTER}
-            flexDirection={DIRECTION_COLUMN}
-            height="100%"
-            marginTop="5.8rem"
-            marginBottom="5.68rem"
-          >
-            <Icon
-              name={isSuccess ? 'ot-check' : 'ot-alert'}
-              size="4rem"
-              color={iconColor}
-              aria-label={isSuccess ? 'ot-check' : 'ot-alert'}
-            />
-            <StyledText
-              as="h1"
-              marginTop={SPACING.spacing5}
-              marginBottom={SPACING.spacing3}
-            >
-              {header}
-            </StyledText>
-            <StyledText as="p">{subHeader}</StyledText>
-          </Flex>
-          <Flex
-            paddingX={SPACING.spacing6}
-            paddingBottom={SPACING.spacing6}
-            justifyContent={JUSTIFY_FLEX_END}
-          >
-            {children}
-          </Flex>
-        </Flex>
+        <StyledText
+          as="h1"
+          marginTop={SPACING.spacing5}
+          marginBottom={SPACING.spacing3}
+        >
+          {header}
+        </StyledText>
+        <StyledText as="p">{subHeader}</StyledText>
       </Flex>
-    </ModalShell>
+      <Flex
+        paddingX={SPACING.spacing6}
+        paddingBottom={SPACING.spacing6}
+        justifyContent={JUSTIFY_FLEX_END}
+      >
+        {children}
+      </Flex>
+    </Flex>
   )
 }

--- a/app/src/organisms/CalibrateTipLength/AskForCalibrationBlockModal.tsx
+++ b/app/src/organisms/CalibrateTipLength/AskForCalibrationBlockModal.tsx
@@ -47,9 +47,7 @@ interface Props {
   titleBarTitle: string
   closePrompt: () => void
 }
-/**
- * @deprecated use the new modal when it is created
- */
+
 export function AskForCalibrationBlockModal(props: Props): JSX.Element {
   const [rememberPreference, setRememberPreference] = React.useState<boolean>(
     false

--- a/app/src/organisms/CalibrateTipLength/AskForCalibrationBlockModal.tsx
+++ b/app/src/organisms/CalibrateTipLength/AskForCalibrationBlockModal.tsx
@@ -47,6 +47,9 @@ interface Props {
   titleBarTitle: string
   closePrompt: () => void
 }
+/**
+ * @deprecated use the new modal when it is created
+ */
 export function AskForCalibrationBlockModal(props: Props): JSX.Element {
   const [rememberPreference, setRememberPreference] = React.useState<boolean>(
     false

--- a/app/src/organisms/ChangePipette/CheckPipettesButton.tsx
+++ b/app/src/organisms/ChangePipette/CheckPipettesButton.tsx
@@ -70,7 +70,7 @@ export function CheckPipettesButton(
   )
 
   return enableChangePipetteWizard ? (
-    <PrimaryButton onClick={handleClick}>
+    <PrimaryButton onClick={handleClick} aria-label="Confirm">
       <Flex
         flexDirection={DIRECTION_ROW}
         color={COLORS.white}

--- a/app/src/organisms/ChangePipette/ClearDeckModal/index.tsx
+++ b/app/src/organisms/ChangePipette/ClearDeckModal/index.tsx
@@ -6,36 +6,19 @@ import {
   SPACING,
   JUSTIFY_FLEX_END,
 } from '@opentrons/components'
-import { WizardHeader } from '../../../molecules/WizardHeader'
 import { StyledText } from '../../../atoms/text'
 import { PrimaryButton } from '../../../atoms/buttons'
 
 export interface ClearDeckModalProps {
-  onContinueClick: () => unknown
-  onCancelClick: () => unknown
-  totalSteps: number
-  currentStep: number
-  title: string
+  onContinueClick: () => void
 }
 
 export function ClearDeckModal(props: ClearDeckModalProps): JSX.Element {
-  const {
-    onContinueClick,
-    onCancelClick,
-    totalSteps,
-    currentStep,
-    title,
-  } = props
+  const { onContinueClick } = props
   const { t } = useTranslation('change_pipette')
 
   return (
     <>
-      <WizardHeader
-        totalSteps={totalSteps}
-        currentStep={currentStep}
-        title={title}
-        onExit={onCancelClick}
-      />
       <Flex
         flexDirection={DIRECTION_COLUMN}
         marginBottom="12.25rem"

--- a/app/src/organisms/ChangePipette/ConfirmPipette.tsx
+++ b/app/src/organisms/ChangePipette/ConfirmPipette.tsx
@@ -28,7 +28,7 @@ export interface ConfirmPipetteProps {
   displayCategory: PipetteDisplayCategory | null
   tryAgain: () => void
   exit: () => void
-  startPipetteOffsetCalibration: () => void
+  toCalibrationDashboard: () => void
 }
 
 export function ConfirmPipette(props: ConfirmPipetteProps): JSX.Element {
@@ -135,7 +135,7 @@ function SuccessAndExitButtons(props: ConfirmPipetteProps): JSX.Element {
     actualPipette,
     actualPipetteOffset,
     exit,
-    startPipetteOffsetCalibration,
+    toCalibrationDashboard,
     success,
   } = props
   const { t } = useTranslation('change_pipette')
@@ -144,7 +144,7 @@ function SuccessAndExitButtons(props: ConfirmPipetteProps): JSX.Element {
       {success && actualPipette && !actualPipetteOffset && (
         <SecondaryButton
           marginRight={SPACING.spacing3}
-          onClick={startPipetteOffsetCalibration}
+          onClick={toCalibrationDashboard}
         >
           {t('calibrate_pipette_offset')}
         </SecondaryButton>

--- a/app/src/organisms/ChangePipette/ConfirmPipette.tsx
+++ b/app/src/organisms/ChangePipette/ConfirmPipette.tsx
@@ -15,12 +15,10 @@ import type {
   PipetteModelSpecs,
   PipetteDisplayCategory,
 } from '@opentrons/shared-data'
-import type { Mount } from '../../redux/pipettes/types'
 import type { PipetteOffsetCalibration } from '../../redux/calibration/types'
 
 export interface ConfirmPipetteProps {
   robotName: string
-  mount: Mount
   success: boolean
   attachedWrong: boolean
   wantedPipette: PipetteNameSpecs | null
@@ -31,20 +29,10 @@ export interface ConfirmPipetteProps {
   tryAgain: () => void
   exit: () => void
   startPipetteOffsetCalibration: () => void
-  currentStep: number
-  totalSteps: number
 }
 
 export function ConfirmPipette(props: ConfirmPipetteProps): JSX.Element {
-  const {
-    wantedPipette,
-    actualPipette,
-    success,
-    exit,
-    currentStep,
-    totalSteps,
-    mount,
-  } = props
+  const { success } = props
   const { t } = useTranslation('change_pipette')
 
   const getPipetteStatusDetails = (
@@ -84,26 +72,12 @@ export function ConfirmPipette(props: ConfirmPipetteProps): JSX.Element {
 
   const { header, subHeader } = getPipetteStatusDetails({ ...props })
 
-  let title
-
-  if ((!wantedPipette && !actualPipette) || (!wantedPipette && actualPipette)) {
-    title = t('detatch_pipette_from_mount', {
-      mount: mount[0].toUpperCase() + mount.slice(1),
-    })
-  } else {
-    title = t('attach_name_pipette', { pipette: wantedPipette?.displayName })
-  }
-
   return (
     <SimpleWizardModal
       iconColor={success ? COLORS.successEnabled : COLORS.errorEnabled}
       header={header}
       subHeader={subHeader}
       isSuccess={success}
-      onExit={exit}
-      title={title}
-      currentStep={currentStep}
-      totalSteps={totalSteps}
     >
       <>
         {!success && <TryAgainButton {...props} />}

--- a/app/src/organisms/ChangePipette/ConfirmPipette.tsx
+++ b/app/src/organisms/ChangePipette/ConfirmPipette.tsx
@@ -7,7 +7,7 @@ import {
   TEXT_TRANSFORM_CAPITALIZE,
 } from '@opentrons/components'
 import { CheckPipettesButton } from './CheckPipettesButton'
-import { SimpleWizardModal } from '../../molecules/SimpleWizardModal'
+import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 import { PrimaryButton, SecondaryButton } from '../../atoms/buttons'
 
 import type {
@@ -73,7 +73,7 @@ export function ConfirmPipette(props: ConfirmPipetteProps): JSX.Element {
   const { header, subHeader } = getPipetteStatusDetails({ ...props })
 
   return (
-    <SimpleWizardModal
+    <SimpleWizardBody
       iconColor={success ? COLORS.successEnabled : COLORS.errorEnabled}
       header={header}
       subHeader={subHeader}
@@ -83,7 +83,7 @@ export function ConfirmPipette(props: ConfirmPipetteProps): JSX.Element {
         {!success && <TryAgainButton {...props} />}
         {success && <SuccessAndExitButtons {...props} />}
       </>
-    </SimpleWizardModal>
+    </SimpleWizardBody>
   )
 }
 

--- a/app/src/organisms/ChangePipette/ExitModal.tsx
+++ b/app/src/organisms/ChangePipette/ExitModal.tsx
@@ -6,7 +6,7 @@ import {
   TEXT_TRANSFORM_CAPITALIZE,
 } from '@opentrons/components'
 import { AlertPrimaryButton, SecondaryButton } from '../../atoms/buttons'
-import { SimpleWizardModal } from '../../molecules/SimpleWizardModal'
+import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 
 import type { Direction } from './types'
 
@@ -22,7 +22,7 @@ export function ExitModal(props: Props): JSX.Element {
   const flow = direction === 'attach' ? t('attaching') : t('detaching')
 
   return (
-    <SimpleWizardModal
+    <SimpleWizardBody
       iconColor={COLORS.warningEnabled}
       header={t('progress_will_be_lost')}
       subHeader={t('are_you_sure_exit', { direction: flow })}
@@ -37,6 +37,6 @@ export function ExitModal(props: Props): JSX.Element {
       >
         {t('shared:exit')}
       </AlertPrimaryButton>
-    </SimpleWizardModal>
+    </SimpleWizardBody>
   )
 }

--- a/app/src/organisms/ChangePipette/ExitModal.tsx
+++ b/app/src/organisms/ChangePipette/ExitModal.tsx
@@ -5,71 +5,38 @@ import {
   SPACING,
   TEXT_TRANSFORM_CAPITALIZE,
 } from '@opentrons/components'
-import { Portal } from '../../App/portal'
 import { AlertPrimaryButton, SecondaryButton } from '../../atoms/buttons'
 import { SimpleWizardModal } from '../../molecules/SimpleWizardModal'
 
-import type { Mount } from '@opentrons/components'
-import type { PipetteModelSpecs } from '@opentrons/shared-data'
 import type { Direction } from './types'
 
 interface Props {
   back: () => void
   exit: () => void
   direction: Direction
-  currentStep: number
-  totalSteps: number
-  mount: Mount
-  displayName?: PipetteModelSpecs['displayName']
 }
 
 export function ExitModal(props: Props): JSX.Element {
-  const {
-    back,
-    exit,
-    direction,
-    currentStep,
-    totalSteps,
-    mount,
-    displayName,
-  } = props
+  const { back, exit, direction } = props
   const { t } = useTranslation(['change_pipette', 'shared'])
   const flow = direction === 'attach' ? t('attaching') : t('detaching')
 
-  let title: string = t('attach_pipette')
-  if (direction === 'attach' && displayName != null) {
-    title = t('attach_name_pipette', { pipette: displayName })
-  } else if (direction === 'detach' && displayName == null) {
-    title = t('detach')
-  } else if (direction === 'detach' && displayName != null) {
-    title = t('detach_pipette', {
-      pipette: displayName,
-      mount: mount[0].toUpperCase() + mount.slice(1),
-    })
-  }
-
   return (
-    <Portal level="top">
-      <SimpleWizardModal
-        iconColor={COLORS.warningEnabled}
-        header={t('progress_will_be_lost')}
-        subHeader={t('are_you_sure_exit', { direction: flow })}
-        onExit={exit}
-        isSuccess={false}
-        title={title}
-        currentStep={currentStep}
-        totalSteps={totalSteps}
+    <SimpleWizardModal
+      iconColor={COLORS.warningEnabled}
+      header={t('progress_will_be_lost')}
+      subHeader={t('are_you_sure_exit', { direction: flow })}
+      isSuccess={false}
+    >
+      <SecondaryButton onClick={back} marginRight={SPACING.spacing2}>
+        {t('go_back')}
+      </SecondaryButton>
+      <AlertPrimaryButton
+        textTransform={TEXT_TRANSFORM_CAPITALIZE}
+        onClick={exit}
       >
-        <SecondaryButton onClick={back} marginRight={SPACING.spacing2}>
-          {t('go_back')}
-        </SecondaryButton>
-        <AlertPrimaryButton
-          textTransform={TEXT_TRANSFORM_CAPITALIZE}
-          onClick={exit}
-        >
-          {t('shared:exit')}
-        </AlertPrimaryButton>
-      </SimpleWizardModal>
-    </Portal>
+        {t('shared:exit')}
+      </AlertPrimaryButton>
+    </SimpleWizardModal>
   )
 }

--- a/app/src/organisms/ChangePipette/Instructions.tsx
+++ b/app/src/organisms/ChangePipette/Instructions.tsx
@@ -12,8 +12,6 @@ import {
   DIRECTION_ROW,
   ALIGN_FLEX_END,
 } from '@opentrons/components'
-import { ModalShell } from '../../molecules/Modal'
-import { WizardHeader } from '../../molecules/WizardHeader'
 import { StyledText } from '../../atoms/text'
 import { PrimaryButton } from '../../atoms/buttons'
 import { CheckPipettesButton } from './CheckPipettesButton'
@@ -37,11 +35,10 @@ interface Props {
   displayCategory: PipetteDisplayCategory | null
   direction: Direction
   setWantedName: (name: string | null) => void
-  confirm: () => void
-  exit: () => void
   back: () => void
-  currentStep: number
-  totalSteps: number
+  confirm: () => void
+  stepPage: number
+  setStepPage: React.Dispatch<React.SetStateAction<number>>
 }
 
 export function Instructions(props: Props): JSX.Element {
@@ -52,15 +49,13 @@ export function Instructions(props: Props): JSX.Element {
     actualPipette,
     setWantedName,
     direction,
-    confirm,
-    exit,
     back,
-    currentStep,
-    totalSteps,
     mount,
+    stepPage,
+    setStepPage,
+    confirm,
   } = props
   const { t } = useTranslation('change_pipette')
-  const [stepPage, setStepPage] = React.useState<number>(0)
 
   const channels = actualPipette
     ? actualPipette.channels
@@ -78,126 +73,112 @@ export function Instructions(props: Props): JSX.Element {
     </PrimaryButton>
   )
 
-  const attachWizardHeader = noPipetteSelected
-    ? t('attach_pipette')
-    : t('attach_pipette_type', {
-        pipetteName: wantedPipette?.displayName,
-      })
-
   return (
     <>
-      <WizardHeader
-        currentStep={stepPage === 0 ? currentStep : currentStep + 1}
-        totalSteps={totalSteps}
-        onExit={exit}
-        title={
-          actualPipette?.displayName != null
-            ? t('detach_pipette', {
-                pipette: actualPipette.displayName,
-                mount: mount[0].toUpperCase() + mount.slice(1),
-              })
-            : attachWizardHeader
-        }
-      />
       {!actualPipette && !wantedPipette && (
         <Flex
           paddingX={SPACING.spacing6}
           paddingTop={SPACING.spacing6}
           marginBottom="12.9rem"
         >
-          <PipetteSelection onPipetteChange={setWantedName} />
+          {direction === 'attach' ? (
+            <PipetteSelection onPipetteChange={setWantedName} />
+          ) : null}
         </Flex>
       )}
-      {(actualPipette || wantedPipette) && (
-        <Flex
-          paddingX={SPACING.spacing6}
-          paddingTop={SPACING.spacing6}
-          height="100%"
-        >
-          <InstructionStep
-            diagram={stepPage === 0 ? 'screws' : 'tab'}
-            {...{ direction, mount, channels, displayCategory }}
-          >
-            <Flex flexDirection={DIRECTION_COLUMN}>
-              <Trans
-                t={t}
-                i18nKey={stepPage === 0 ? stepOne : stepTwo}
-                components={{
-                  h1: <StyledText as="h1" marginBottom={SPACING.spacing4} />,
-                  block: <StyledText as="p" />,
-                }}
-              />
-              {direction === 'attach' && stepPage === 0 ? (
-                channels === 8 ? (
-                  <Flex flexDirection={DIRECTION_ROW}>
-                    <Trans
-                      t={t}
-                      i18nKey="tighten_screws_multi"
-                      components={{
-                        strong: <strong />,
-                        block: (
-                          <StyledText as="p" marginTop={SPACING.spacing4} />
-                        ),
-                      }}
-                    />
-                  </Flex>
-                ) : (
-                  <StyledText marginTop={SPACING.spacing4} as="p">
-                    {t('tighten_screws_single')}
-                  </StyledText>
-                )
-              ) : null}
+      {stepPage < 2 ? (
+        <>
+          {(actualPipette || wantedPipette) && (
+            <Flex
+              paddingX={SPACING.spacing6}
+              paddingTop={SPACING.spacing6}
+              height="100%"
+            >
+              <InstructionStep
+                diagram={stepPage === 0 ? 'screws' : 'tab'}
+                {...{ direction, mount, channels, displayCategory }}
+              >
+                <Flex flexDirection={DIRECTION_COLUMN}>
+                  <Trans
+                    t={t}
+                    i18nKey={stepPage === 0 ? stepOne : stepTwo}
+                    components={{
+                      h1: (
+                        <StyledText as="h1" marginBottom={SPACING.spacing4} />
+                      ),
+                      block: <StyledText as="p" />,
+                    }}
+                  />
+                  {direction === 'attach' && stepPage === 0 ? (
+                    channels === 8 ? (
+                      <Flex flexDirection={DIRECTION_ROW}>
+                        <Trans
+                          t={t}
+                          i18nKey="tighten_screws_multi"
+                          components={{
+                            strong: <strong />,
+                            block: (
+                              <StyledText as="p" marginTop={SPACING.spacing4} />
+                            ),
+                          }}
+                        />
+                      </Flex>
+                    ) : (
+                      <StyledText marginTop={SPACING.spacing4} as="p">
+                        {t('tighten_screws_single')}
+                      </StyledText>
+                    )
+                  ) : null}
+                </Flex>
+              </InstructionStep>
             </Flex>
-          </InstructionStep>
-        </Flex>
-      )}
-      <Flex
-        justifyContent={JUSTIFY_SPACE_BETWEEN}
-        marginBottom={SPACING.spacing6}
-        marginX={SPACING.spacing6}
-        alignSelf={ALIGN_FLEX_END}
-        //  spacing changes to keep buttons at same height across pages
-        marginTop={stepPage === 0 ? SPACING.spacingSS : '8rem'}
-      >
-        <Btn onClick={stepPage === 0 ? back : () => setStepPage(0)}>
-          <StyledText
-            css={TYPOGRAPHY.pSemiBold}
-            textTransform={TYPOGRAPHY.textTransformCapitalize}
-            color={COLORS.darkGreyEnabled}
+          )}
+          <Flex
+            justifyContent={JUSTIFY_SPACE_BETWEEN}
+            marginBottom={SPACING.spacing6}
+            marginX={SPACING.spacing6}
+            alignSelf={ALIGN_FLEX_END}
+            //  spacing changes to keep buttons at same height across pages
+            marginTop={stepPage === 0 ? SPACING.spacingSS : '8rem'}
           >
-            {t('go_back')}
-          </StyledText>
-        </Btn>
-        {stepPage === 0 ? (
-          continueButton
-        ) : (
-          <CheckPipettesButton
-            robotName={robotName}
-            onDone={
-              wantedPipette != null &&
-              actualPipette != null &&
-              shouldLevel(wantedPipette)
-                ? () => setStepPage(2)
-                : confirm
-            }
-          >
-            {actualPipette ? t('confirm_detachment') : t('confirm_attachment')}
-          </CheckPipettesButton>
-        )}
-      </Flex>
-      {stepPage === 2 && (
-        <ModalShell height="28.12rem" width="47rem">
-          <LevelPipette
-            mount={mount}
-            wantedPipette={wantedPipette}
-            pipetteModelName={actualPipette ? actualPipette.name : ''}
-            exit={exit}
-            confirm={confirm}
-            back={back}
-            currentStep={currentStep}
-            totalSteps={totalSteps}
-          />
-        </ModalShell>
+            <Btn
+              onClick={stepPage === 0 ? back : () => setStepPage(stepPage - 1)}
+            >
+              <StyledText
+                css={TYPOGRAPHY.pSemiBold}
+                textTransform={TYPOGRAPHY.textTransformCapitalize}
+                color={COLORS.darkGreyEnabled}
+              >
+                {t('go_back')}
+              </StyledText>
+            </Btn>
+            {stepPage === 0 ? (
+              continueButton
+            ) : (
+              <CheckPipettesButton
+                robotName={robotName}
+                onDone={
+                  wantedPipette != null &&
+                  actualPipette != null &&
+                  shouldLevel(wantedPipette)
+                    ? () => setStepPage(2)
+                    : confirm
+                }
+              >
+                {actualPipette
+                  ? t('confirm_detachment')
+                  : t('confirm_attachment')}
+              </CheckPipettesButton>
+            )}
+          </Flex>
+        </>
+      ) : (
+        <LevelPipette
+          mount={mount}
+          pipetteModelName={actualPipette ? actualPipette.name : ''}
+          confirm={confirm}
+          back={back}
+        />
       )}
     </>
   )

--- a/app/src/organisms/ChangePipette/LevelPipette.tsx
+++ b/app/src/organisms/ChangePipette/LevelPipette.tsx
@@ -13,23 +13,16 @@ import {
   SPACING,
   TYPOGRAPHY,
 } from '@opentrons/components'
-
-import { WizardHeader } from '../../molecules/WizardHeader'
 import { StyledText } from '../../atoms/text'
 import { PrimaryButton } from '../../atoms/buttons'
 
-import type { PipetteNameSpecs } from '@opentrons/shared-data'
 import type { Mount } from '../../redux/pipettes/types'
 
 interface LevelPipetteProps {
   mount: Mount
-  wantedPipette: PipetteNameSpecs | null
   pipetteModelName: string
   back: () => void
-  exit: () => void
   confirm: () => void
-  currentStep: number
-  totalSteps: number
 }
 
 function LevelingVideo(props: {
@@ -57,29 +50,12 @@ function LevelingVideo(props: {
 }
 
 export function LevelPipette(props: LevelPipetteProps): JSX.Element {
-  const {
-    mount,
-    pipetteModelName,
-    wantedPipette,
-    back,
-    exit,
-    confirm,
-    currentStep,
-    totalSteps,
-  } = props
+  const { mount, pipetteModelName, back, confirm } = props
 
   const { t } = useTranslation('change_pipette')
 
   return (
     <>
-      <WizardHeader
-        currentStep={currentStep}
-        totalSteps={totalSteps}
-        onExit={exit}
-        title={t('attach_pipette_type', {
-          pipetteName: wantedPipette?.displayName,
-        })}
-      />
       <Flex
         flexDirection={DIRECTION_COLUMN}
         paddingX={SPACING.spacing6}

--- a/app/src/organisms/ChangePipette/__tests__/ChangePipette.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/ChangePipette.test.tsx
@@ -1,31 +1,47 @@
 import * as React from 'react'
+import { act } from '@testing-library/react-hooks'
+import { fireEvent } from '@testing-library/react'
+import { when } from 'jest-when'
 import { renderWithProviders } from '@opentrons/components'
 import { getPipetteNameSpecs } from '@opentrons/shared-data'
 import { getAttachedPipettes } from '../../../redux/pipettes'
 import { i18n } from '../../../i18n'
 import { getHasCalibrationBlock, useFeatureFlag } from '../../../redux/config'
-import { ChangePipette } from '..'
 import { getMovementStatus } from '../../../redux/robot-controls'
 import { getCalibrationForPipette } from '../../../redux/calibration'
-import { useCalibratePipetteOffset } from '../../CalibratePipetteOffset/useCalibratePipetteOffset'
+import { InProgressModal } from '../../../molecules/InProgressModal/InProgressModal'
 import {
-  DispatchApiRequestType,
   getRequestById,
+  SUCCESS,
   useDispatchApiRequests,
 } from '../../../redux/robot-api'
+import { useCalibratePipetteOffset } from '../../CalibratePipetteOffset/useCalibratePipetteOffset'
+import { PipetteSelection } from '../PipetteSelection'
+import { ExitModal } from '../ExitModal'
+import { ConfirmPipette } from '../ConfirmPipette'
+import { ChangePipette } from '..'
 
-jest.mock('@opentrons/shared-data', () => ({
-  getAllPipetteNames: jest.fn(
-    jest.requireActual('@opentrons/shared-data').getAllPipetteNames
-  ),
-  getPipetteNameSpecs: jest.fn(),
-}))
+import type { PipetteNameSpecs } from '@opentrons/shared-data'
+import type { AttachedPipette } from '../../../redux/pipettes/types'
+import type { DispatchApiRequestType } from '../../../redux/robot-api'
+
+jest.mock('@opentrons/shared-data', () => {
+  const actualSharedData = jest.requireActual('@opentrons/shared-data')
+  return {
+    ...actualSharedData,
+    getPipetteNameSpecs: jest.fn(),
+  }
+})
 jest.mock('../../../redux/config')
 jest.mock('../../../redux/pipettes')
 jest.mock('../../../redux/robot-controls')
 jest.mock('../../../redux/calibration')
 jest.mock('../../CalibratePipetteOffset/useCalibratePipetteOffset')
 jest.mock('../../../redux/robot-api')
+jest.mock('../PipetteSelection')
+jest.mock('../ExitModal')
+jest.mock('../../../molecules/InProgressModal/InProgressModal')
+jest.mock('../ConfirmPipette')
 
 const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<
   typeof useFeatureFlag
@@ -54,15 +70,44 @@ const mockGetRequestById = getRequestById as jest.MockedFunction<
 const mockUseDispatchApiRequests = useDispatchApiRequests as jest.MockedFunction<
   typeof useDispatchApiRequests
 >
+const mockPipetteSelection = PipetteSelection as jest.MockedFunction<
+  typeof PipetteSelection
+>
+const mockInProgress = InProgressModal as jest.MockedFunction<
+  typeof InProgressModal
+>
+const mockConfirmPipette = ConfirmPipette as jest.MockedFunction<
+  typeof ConfirmPipette
+>
+const mockExitModal = ExitModal as jest.MockedFunction<typeof ExitModal>
+
 const render = (props: React.ComponentProps<typeof ChangePipette>) => {
   return renderWithProviders(<ChangePipette {...props} />, {
     i18nInstance: i18n,
   })[0]
 }
 
+const mockP300PipetteNameSpecs = {
+  name: 'p300_single_gen2',
+  displayName: 'P300 Single GEN2',
+  channels: 1,
+  displayCategory: 'GEN2',
+} as PipetteNameSpecs
+
+const mockAttachedPipettes = {
+  id: 'abc',
+  name: 'p300_single_gen2',
+  model: 'p300_single_v2.0',
+  tip_length: 42,
+  mount_axis: 'c',
+  plunger_axis: 'd',
+  modelSpecs: mockP300PipetteNameSpecs,
+}
+
 describe('ChangePipette', () => {
   let props: React.ComponentProps<typeof ChangePipette>
   let dispatchApiRequest: DispatchApiRequestType
+  let startWizard: any
 
   beforeEach(() => {
     props = {
@@ -70,19 +115,189 @@ describe('ChangePipette', () => {
       mount: 'left',
       closeModal: jest.fn(),
     }
+    startWizard = jest.fn()
     dispatchApiRequest = jest.fn()
     mockUseFeatureFlag.mockReturnValue(true)
-    mockGetPipetteNameSpecs.mockReturnValue(null)
     mockGetAttachedPipettes.mockReturnValue({ left: null, right: null })
     mockGetRequestById.mockReturnValue(null)
-    mockUseDispatchApiRequests.mockReturnValue([dispatchApiRequest, []])
     mockGetCalibrationForPipette.mockReturnValue(null)
-    mockGetMovementStatus.mockReturnValue(null)
     mockGetHasCalibrationBlock.mockReturnValue(false)
+    mockGetMovementStatus.mockReturnValue(null)
+    mockGetPipetteNameSpecs.mockReturnValue(null)
+
+    when(mockUseCalibratePipetteOffset).mockReturnValue([startWizard, null])
+    when(mockUseDispatchApiRequests).mockReturnValue([
+      dispatchApiRequest,
+      ['id'],
+    ])
   })
 
-  it('renders the Clear deck page of the wizard flow', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('renders the in progress modal when the movement status is moving', () => {
+    mockGetMovementStatus.mockReturnValue('moving')
+    mockInProgress.mockReturnValue(<div>mock in progress modal</div>)
     const { getByText } = render(props)
-    getByText('test')
+    getByText('Attach a pipette')
+    getByText('mock in progress modal')
+  })
+
+  it('renders the wizard pages for attaching a pipette and clicking on the exit button will render the exit modal', () => {
+    mockPipetteSelection.mockReturnValue(<div>mock pipette selection</div>)
+    mockExitModal.mockReturnValue(<div>mock exit modal</div>)
+
+    const { getByText, getByLabelText, getByRole } = render(props)
+    //  Clear deck modal page
+    let exit = getByLabelText('Exit')
+    getByText('Attach a pipette')
+    getByText('Before you begin')
+    getByText(
+      'Before starting, remove all labware from the deck and all tips from pipettes. The gantry will move to the front of the robot.'
+    )
+    fireEvent.click(exit)
+    expect(props.closeModal).toHaveBeenCalled()
+
+    const cont = getByRole('button', { name: 'Get started' })
+    fireEvent.click(cont)
+
+    //  Instructions page
+    getByText('Attach a pipette')
+    getByText('Step: 1 / 3')
+    getByText('mock pipette selection')
+    exit = getByLabelText('Exit')
+    fireEvent.click(exit)
+
+    //  Exit modal page
+    getByText('mock exit modal')
+    getByText('Attach a pipette')
+    getByText('Step: 1 / 3')
+    exit = getByLabelText('Exit')
+    fireEvent.click(exit)
+    expect(props.closeModal).toHaveBeenCalled()
+  })
+
+  it('the go back button functions as expected', () => {
+    mockPipetteSelection.mockReturnValue(<div>mock pipette selection</div>)
+
+    const { getByText, getByRole } = render(props)
+    //  Clear deck modal page
+    getByText('Before you begin')
+    const cont = getByRole('button', { name: 'Get started' })
+    fireEvent.click(cont)
+
+    //  Instructions page
+    const goBack = getByRole('button', { name: 'Go back' })
+    fireEvent.click(goBack)
+    getByText('Before you begin')
+  })
+
+  it('renders the wizard pages for attaching a pipette and goes through flow', () => {
+    mockPipetteSelection.mockReturnValue(<div>mock pipette selection</div>)
+    const { getByText, getByRole } = render(props)
+    //  Clear deck modal page
+    const cont = getByRole('button', { name: 'Get started' })
+    fireEvent.click(cont)
+
+    //  Instructions page
+    getByText('Attach a pipette')
+    getByText('Step: 1 / 3')
+
+    //  attach the pipette
+    act(() => {
+      when(mockGetPipetteNameSpecs)
+        .calledWith('p300_single_gen2')
+        .mockReturnValue(mockP300PipetteNameSpecs)
+    })
+
+    //  TODO(jr, 08/30/22): extend this test for attaching a pipette so you can go through the remainder of the flow
+  })
+
+  it('renders the wizard pages for detaching a single channel pipette and exits on the 2nd page rendering exit modal', () => {
+    mockExitModal.mockReturnValue(<div>mock exit modal</div>)
+    mockGetRequestById.mockReturnValue({
+      status: SUCCESS,
+      response: {
+        method: 'POST',
+        ok: true,
+        path: '/',
+        status: 200,
+      },
+    })
+    mockGetAttachedPipettes.mockReturnValue({
+      left: mockAttachedPipettes as AttachedPipette,
+      right: null,
+    })
+    const { getByText, getByLabelText, getByRole } = render(props)
+
+    //  Clear deck modal page
+    getByLabelText('Exit')
+    getByText('Detach P300 Single GEN2 from Left Mount')
+    getByText('Before you begin')
+    getByText(
+      'Before starting, remove all labware from the deck and all tips from pipettes. The gantry will move to the front of the robot.'
+    )
+    let cont = getByRole('button', { name: 'Get started' })
+    fireEvent.click(cont)
+
+    //  Instructions page 1
+    getByText('Detach P300 Single GEN2 from Left Mount')
+    getByText('Step: 1 / 3')
+    getByText('Loosen the screws')
+    getByText(
+      'Using a 2.5 mm screwdriver, loosen the three screws on the back of the pipette that is currently attached.'
+    )
+    cont = getByRole('button', { name: 'Continue' })
+    fireEvent.click(cont)
+
+    //  Instructions page 2
+    getByText('Detach P300 Single GEN2 from Left Mount')
+    getByText('Step: 2 / 3')
+    getByText('Remove the pipette')
+    getByText(
+      'Hold onto the pipette so it does not fall. Disconnect the pipette from the robot by pulling the white connector tab.'
+    )
+    getByLabelText('Confirm')
+    const exit = getByLabelText('Exit')
+    fireEvent.click(exit)
+
+    //  Exit modal page
+    getByText('Detach P300 Single GEN2 from Left Mount')
+    getByText('Step: 2 / 3')
+    getByText('mock exit modal')
+    const exitModal = getByLabelText('Exit')
+    fireEvent.click(exitModal)
+    expect(props.closeModal).toHaveBeenCalled()
+  })
+
+  it('renders the wizard pages for detaching a single channel pipette and goes through the whole flow', () => {
+    mockConfirmPipette.mockReturnValue(<div>mock confirm pipette</div>)
+    mockGetAttachedPipettes.mockReturnValue({
+      left: mockAttachedPipettes as AttachedPipette,
+      right: null,
+    })
+    const { getByLabelText, getByRole } = render(props)
+
+    //  Clear deck modal page
+    let cont = getByRole('button', { name: 'Get started' })
+    fireEvent.click(cont)
+
+    //  Instructions page 1
+    cont = getByRole('button', { name: 'Continue' })
+    fireEvent.click(cont)
+
+    //  Instructions page 2
+    //  disconnect the attached pipette
+    act(() => {
+      mockGetAttachedPipettes.mockReturnValue({
+        left: null,
+        right: null,
+      })
+    })
+    const confirm = getByLabelText('Confirm')
+    fireEvent.click(confirm)
+
+    //  TODO(jr, 08/30/22): extend this test to test for the final confirm pipette page, need to remove attach pieptte
   })
 })

--- a/app/src/organisms/ChangePipette/__tests__/ChangePipette.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/ChangePipette.test.tsx
@@ -1,0 +1,3 @@
+describe('ChangePipette', () => {
+  it.todo('write the tests for ChangePipette')
+})

--- a/app/src/organisms/ChangePipette/__tests__/ChangePipette.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/ChangePipette.test.tsx
@@ -25,6 +25,16 @@ import type { PipetteNameSpecs } from '@opentrons/shared-data'
 import type { AttachedPipette } from '../../../redux/pipettes/types'
 import type { DispatchApiRequestType } from '../../../redux/robot-api'
 
+const mockPush = jest.fn()
+
+jest.mock('react-router-dom', () => {
+  const reactRouterDom = jest.requireActual('react-router-dom')
+  return {
+    ...reactRouterDom,
+    useHistory: () => ({ push: mockPush } as any),
+  }
+})
+
 jest.mock('@opentrons/shared-data', () => {
   const actualSharedData = jest.requireActual('@opentrons/shared-data')
   return {

--- a/app/src/organisms/ChangePipette/__tests__/ChangePipette.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/ChangePipette.test.tsx
@@ -1,3 +1,88 @@
+import * as React from 'react'
+import { renderWithProviders } from '@opentrons/components'
+import { getPipetteNameSpecs } from '@opentrons/shared-data'
+import { getAttachedPipettes } from '../../../redux/pipettes'
+import { i18n } from '../../../i18n'
+import { getHasCalibrationBlock, useFeatureFlag } from '../../../redux/config'
+import { ChangePipette } from '..'
+import { getMovementStatus } from '../../../redux/robot-controls'
+import { getCalibrationForPipette } from '../../../redux/calibration'
+import { useCalibratePipetteOffset } from '../../CalibratePipetteOffset/useCalibratePipetteOffset'
+import {
+  DispatchApiRequestType,
+  getRequestById,
+  useDispatchApiRequests,
+} from '../../../redux/robot-api'
+
+jest.mock('@opentrons/shared-data', () => ({
+  getAllPipetteNames: jest.fn(
+    jest.requireActual('@opentrons/shared-data').getAllPipetteNames
+  ),
+  getPipetteNameSpecs: jest.fn(),
+}))
+jest.mock('../../../redux/config')
+jest.mock('../../../redux/pipettes')
+jest.mock('../../../redux/robot-controls')
+jest.mock('../../../redux/calibration')
+jest.mock('../../CalibratePipetteOffset/useCalibratePipetteOffset')
+jest.mock('../../../redux/robot-api')
+
+const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<
+  typeof useFeatureFlag
+>
+const mockGetPipetteNameSpecs = getPipetteNameSpecs as jest.MockedFunction<
+  typeof getPipetteNameSpecs
+>
+const mockGetAttachedPipettes = getAttachedPipettes as jest.MockedFunction<
+  typeof getAttachedPipettes
+>
+const mockGetMovementStatus = getMovementStatus as jest.MockedFunction<
+  typeof getMovementStatus
+>
+const mockGetCalibrationForPipette = getCalibrationForPipette as jest.MockedFunction<
+  typeof getCalibrationForPipette
+>
+const mockUseCalibratePipetteOffset = useCalibratePipetteOffset as jest.MockedFunction<
+  typeof useCalibratePipetteOffset
+>
+const mockGetHasCalibrationBlock = getHasCalibrationBlock as jest.MockedFunction<
+  typeof getHasCalibrationBlock
+>
+const mockGetRequestById = getRequestById as jest.MockedFunction<
+  typeof getRequestById
+>
+const mockUseDispatchApiRequests = useDispatchApiRequests as jest.MockedFunction<
+  typeof useDispatchApiRequests
+>
+const render = (props: React.ComponentProps<typeof ChangePipette>) => {
+  return renderWithProviders(<ChangePipette {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
 describe('ChangePipette', () => {
-  it.todo('write the tests for ChangePipette')
+  let props: React.ComponentProps<typeof ChangePipette>
+  let dispatchApiRequest: DispatchApiRequestType
+
+  beforeEach(() => {
+    props = {
+      robotName: 'otie',
+      mount: 'left',
+      closeModal: jest.fn(),
+    }
+    dispatchApiRequest = jest.fn()
+    mockUseFeatureFlag.mockReturnValue(true)
+    mockGetPipetteNameSpecs.mockReturnValue(null)
+    mockGetAttachedPipettes.mockReturnValue({ left: null, right: null })
+    mockGetRequestById.mockReturnValue(null)
+    mockUseDispatchApiRequests.mockReturnValue([dispatchApiRequest, []])
+    mockGetCalibrationForPipette.mockReturnValue(null)
+    mockGetMovementStatus.mockReturnValue(null)
+    mockGetHasCalibrationBlock.mockReturnValue(false)
+  })
+
+  it('renders the Clear deck page of the wizard flow', () => {
+    const { getByText } = render(props)
+    getByText('test')
+  })
 })

--- a/app/src/organisms/ChangePipette/__tests__/CheckPipettesButton.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/CheckPipettesButton.test.tsx
@@ -48,8 +48,8 @@ describe('CheckPipettesButton', () => {
   })
   it('renders the button with ff and clicking on it calls fetchPipettes', () => {
     mockFeatureFlag.mockReturnValue(true)
-    const { getByRole } = render(props)
-    const btn = getByRole('button', { name: 'btn text' })
+    const { getByLabelText } = render(props)
+    const btn = getByLabelText('Confirm')
     fireEvent.click(btn)
     expect(mockFetchPipettes).toHaveBeenCalled()
   })

--- a/app/src/organisms/ChangePipette/__tests__/ClearDeckModal.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/ClearDeckModal.test.tsx
@@ -14,41 +14,22 @@ describe('ClearDeckModal', () => {
   beforeEach(() => {
     props = {
       onContinueClick: jest.fn(),
-      onCancelClick: jest.fn(),
-      totalSteps: 5,
-      currentStep: 1,
-      title: 'Attach a pipette',
     }
   })
   it('renders the correct information when pipette is not attached', () => {
-    const { getByText, getByRole } = render(props)
-    getByText('Attach a pipette')
+    const { getByText } = render(props)
     getByText('Before you begin')
     getByText(
       'Before starting, remove all labware from the deck and all tips from pipettes. The gantry will move to the front of the robot.'
     )
-    const exit = getByRole('button', { name: 'Exit' })
-    fireEvent.click(exit)
-    expect(props.onCancelClick).toHaveBeenCalled()
-    const cont = getByRole('button', { name: 'Get started' })
-    fireEvent.click(cont)
-    expect(props.onContinueClick).toHaveBeenCalled()
   })
 
-  it('renders the correct information when a p10 single gen 1 is attached', () => {
-    props = {
-      ...props,
-      title: 'Detach P10 Single-Channel GEN1 from Right Mount',
-    }
+  it('renders the correct information when pipette is attached', () => {
     const { getByText, getByRole } = render(props)
-    getByText('Detach P10 Single-Channel GEN1 from Right Mount')
     getByText('Before you begin')
     getByText(
       'Before starting, remove all labware from the deck and all tips from pipettes. The gantry will move to the front of the robot.'
     )
-    const exit = getByRole('button', { name: 'Exit' })
-    fireEvent.click(exit)
-    expect(props.onCancelClick).toHaveBeenCalled()
     const cont = getByRole('button', { name: 'Get started' })
     fireEvent.click(cont)
     expect(props.onContinueClick).toHaveBeenCalled()

--- a/app/src/organisms/ChangePipette/__tests__/ConfirmPipette.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/ConfirmPipette.test.tsx
@@ -3,11 +3,7 @@ import { renderWithProviders } from '@opentrons/components'
 import { fireEvent } from '@testing-library/react'
 import { i18n } from '../../../i18n'
 import { ConfirmPipette } from '../ConfirmPipette'
-import {
-  LEFT,
-  PipetteModelSpecs,
-  PipetteNameSpecs,
-} from '@opentrons/shared-data'
+import { PipetteModelSpecs, PipetteNameSpecs } from '@opentrons/shared-data'
 import { mockPipetteInfo } from '../../../redux/pipettes/__fixtures__'
 import { PipetteOffsetCalibration } from '../../../redux/calibration/types'
 import { CheckPipettesButton } from '../CheckPipettesButton'
@@ -80,7 +76,6 @@ describe('ConfirmPipette', () => {
   it('Should detach a pipette successfully', () => {
     props = {
       robotName: 'otie',
-      mount: LEFT,
       success: true,
       attachedWrong: false,
       wantedPipette: null,
@@ -91,24 +86,18 @@ describe('ConfirmPipette', () => {
       tryAgain: jest.fn(),
       exit: jest.fn(),
       startPipetteOffsetCalibration: jest.fn(),
-      currentStep: 5,
-      totalSteps: 8,
     }
 
-    const { getByText, getAllByRole } = render(props)
-    getByText('Detach Pipette from Left Mount')
+    const { getByText, getByRole } = render(props)
     getByText('Successfully detached pipette!')
-    const btns = getAllByRole('button', { name: 'Exit' })
-    btns.forEach(btn => {
-      fireEvent.click(btn)
-      expect(props.exit).toBeCalled()
-    })
+    const btn = getByRole('button', { name: 'exit' })
+    fireEvent.click(btn)
+    expect(props.exit).toHaveBeenCalled()
   })
 
   it('Should detect a pipette if still attached when detaching', () => {
     props = {
       robotName: 'otie',
-      mount: LEFT,
       success: false,
       attachedWrong: false,
       wantedPipette: null,
@@ -119,12 +108,9 @@ describe('ConfirmPipette', () => {
       tryAgain: jest.fn(),
       exit: jest.fn(),
       startPipetteOffsetCalibration: jest.fn(),
-      currentStep: 5,
-      totalSteps: 8,
     }
 
     const { getByText, getByRole } = render(props)
-    getByText('Detach Pipette from Left Mount')
     getByText('Pipette still detected')
     getByText(
       'Check again to ensure that pipette is unplugged and entirely detached from the robot.'
@@ -142,7 +128,6 @@ describe('ConfirmPipette', () => {
   it('Should show incorrect pipette attached when the actual pipette is different', () => {
     props = {
       robotName: 'otie',
-      mount: LEFT,
       success: false,
       attachedWrong: true,
       wantedPipette: MOCK_WANTED_PIPETTE,
@@ -153,12 +138,9 @@ describe('ConfirmPipette', () => {
       tryAgain: jest.fn(),
       exit: jest.fn(),
       startPipetteOffsetCalibration: jest.fn(),
-      currentStep: 5,
-      totalSteps: 8,
     }
 
     const { getByText, getByRole } = render(props)
-    getByText('Attach a P300 8-Channel GEN2 Pipette')
     getByText('Incorrect pipette attached')
     getByText(
       'The attached does not match the P300 8-Channel GEN2 you had originally selected.'
@@ -179,7 +161,6 @@ describe('ConfirmPipette', () => {
     mockCheckPipettesButton.mockReturnValue(<div>mock re-check connection</div>)
     props = {
       robotName: 'otie',
-      mount: LEFT,
       success: false,
       attachedWrong: false,
       wantedPipette: MOCK_WANTED_PIPETTE,
@@ -190,12 +171,9 @@ describe('ConfirmPipette', () => {
       tryAgain: jest.fn(),
       exit: jest.fn(),
       startPipetteOffsetCalibration: jest.fn(),
-      currentStep: 5,
-      totalSteps: 8,
     }
 
     const { getByText, getByRole } = render(props)
-    getByText('Attach a P300 8-Channel GEN2 Pipette')
     getByText('Unable to detect P300 8-Channel GEN2')
     getByText(
       'Make sure to press the white connector tab in as far as you can, and that you feel it connect with the pipette.'
@@ -213,7 +191,6 @@ describe('ConfirmPipette', () => {
   it('Should attach a pipette successfully', () => {
     props = {
       robotName: 'otie',
-      mount: LEFT,
       success: true,
       attachedWrong: false,
       wantedPipette: MOCK_ACTUAL_PIPETTE,
@@ -224,26 +201,19 @@ describe('ConfirmPipette', () => {
       tryAgain: jest.fn(),
       exit: jest.fn(),
       startPipetteOffsetCalibration: jest.fn(),
-      currentStep: 5,
-      totalSteps: 8,
     }
 
-    const { getByText, getAllByRole } = render(props)
-    getByText('Attach a P10 Single-Channel Pipette')
+    const { getByText, getByRole } = render(props)
     getByText('Pipette attached!')
     getByText('P10 Single-Channel is now ready to use.')
-
-    const exitBtns = getAllByRole('button', { name: 'Exit' })
-    exitBtns.forEach(btn => {
-      fireEvent.click(btn)
-      expect(props.exit).toBeCalled()
-    })
+    const btn = getByRole('button', { name: 'exit' })
+    fireEvent.click(btn)
+    expect(props.exit).toHaveBeenCalled()
   })
 
   it('Should attach a pipette successfully when there is no POC data', () => {
     props = {
       robotName: 'otie',
-      mount: LEFT,
       success: true,
       attachedWrong: false,
       wantedPipette: MOCK_ACTUAL_PIPETTE,
@@ -254,20 +224,14 @@ describe('ConfirmPipette', () => {
       tryAgain: jest.fn(),
       exit: jest.fn(),
       startPipetteOffsetCalibration: jest.fn(),
-      currentStep: 5,
-      totalSteps: 8,
     }
 
-    const { getByText, getAllByRole, getByRole } = render(props)
-    getByText('Attach a P10 Single-Channel Pipette')
+    const { getByText, getByRole } = render(props)
     getByText('Pipette attached!')
     getByText('P10 Single-Channel is now ready to use.')
-
-    const exitBtns = getAllByRole('button', { name: 'Exit' })
-    exitBtns.forEach(btn => {
-      fireEvent.click(btn)
-      expect(props.exit).toBeCalled()
-    })
+    const btn = getByRole('button', { name: 'exit' })
+    fireEvent.click(btn)
+    expect(props.exit).toHaveBeenCalled()
 
     const pocBtn = getByRole('button', { name: 'Calibrate pipette offset' })
     fireEvent.click(pocBtn)

--- a/app/src/organisms/ChangePipette/__tests__/ConfirmPipette.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/ConfirmPipette.test.tsx
@@ -85,7 +85,7 @@ describe('ConfirmPipette', () => {
       displayCategory: 'GEN1',
       tryAgain: jest.fn(),
       exit: jest.fn(),
-      startPipetteOffsetCalibration: jest.fn(),
+      toCalibrationDashboard: jest.fn(),
     }
 
     const { getByText, getByRole } = render(props)
@@ -107,7 +107,7 @@ describe('ConfirmPipette', () => {
       displayCategory: 'GEN1',
       tryAgain: jest.fn(),
       exit: jest.fn(),
-      startPipetteOffsetCalibration: jest.fn(),
+      toCalibrationDashboard: jest.fn(),
     }
 
     const { getByText, getByRole } = render(props)
@@ -137,7 +137,7 @@ describe('ConfirmPipette', () => {
       displayCategory: null,
       tryAgain: jest.fn(),
       exit: jest.fn(),
-      startPipetteOffsetCalibration: jest.fn(),
+      toCalibrationDashboard: jest.fn(),
     }
 
     const { getByText, getByRole } = render(props)
@@ -170,7 +170,7 @@ describe('ConfirmPipette', () => {
       displayCategory: null,
       tryAgain: jest.fn(),
       exit: jest.fn(),
-      startPipetteOffsetCalibration: jest.fn(),
+      toCalibrationDashboard: jest.fn(),
     }
 
     const { getByText, getByRole } = render(props)
@@ -200,7 +200,7 @@ describe('ConfirmPipette', () => {
       displayCategory: null,
       tryAgain: jest.fn(),
       exit: jest.fn(),
-      startPipetteOffsetCalibration: jest.fn(),
+      toCalibrationDashboard: jest.fn(),
     }
 
     const { getByText, getByRole } = render(props)
@@ -223,7 +223,7 @@ describe('ConfirmPipette', () => {
       displayCategory: null,
       tryAgain: jest.fn(),
       exit: jest.fn(),
-      startPipetteOffsetCalibration: jest.fn(),
+      toCalibrationDashboard: jest.fn(),
     }
 
     const { getByText, getByRole } = render(props)
@@ -235,6 +235,6 @@ describe('ConfirmPipette', () => {
 
     const pocBtn = getByRole('button', { name: 'Calibrate pipette offset' })
     fireEvent.click(pocBtn)
-    expect(props.startPipetteOffsetCalibration).toBeCalled()
+    expect(props.toCalibrationDashboard).toBeCalled()
   })
 })

--- a/app/src/organisms/ChangePipette/__tests__/ExitModal.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/ExitModal.test.tsx
@@ -3,68 +3,39 @@ import { fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../i18n'
 import { ExitModal } from '../ExitModal'
-import { LEFT } from '@opentrons/shared-data'
 
 const render = (props: React.ComponentProps<typeof ExitModal>) => {
   return renderWithProviders(<ExitModal {...props} />, {
     i18nInstance: i18n,
   })[0]
 }
-describe('CExitModal', () => {
+describe('ExitModal', () => {
   let props: React.ComponentProps<typeof ExitModal>
   beforeEach(() => {
     props = {
       back: jest.fn(),
       exit: jest.fn(),
       direction: 'attach',
-      currentStep: 4,
-      totalSteps: 8,
-      mount: LEFT,
     }
   })
   it('renders the correct information and buttons for attach when no pipette is attached', () => {
-    const { getByText, getByRole, getByLabelText } = render(props)
-    getByText('Attach a pipette')
-    getByText('Step: 4 / 8')
+    const { getByText, getByRole } = render(props)
     getByText('Progress will be lost')
     getByText('Are you sure you want to exit before attaching your pipette?')
     const back = getByRole('button', { name: 'Go back' })
-    const exitIcon = getByLabelText('Exit')
     const exit = getByRole('button', { name: 'exit' })
     fireEvent.click(back)
     expect(props.back).toHaveBeenCalled()
     fireEvent.click(exit)
     expect(props.exit).toHaveBeenCalled()
-    fireEvent.click(exitIcon)
-    expect(props.exit).toHaveBeenCalled()
   })
 
-  it('renders the correct wizardHeader text and body text for detach when no pipette is attached', () => {
+  it('renders the correct text and body text for detach when no pipette is attached', () => {
     props = {
       ...props,
       direction: 'detach',
     }
     const { getByText } = render(props)
-    getByText('Detach pipette')
     getByText('Are you sure you want to exit before detaching your pipette?')
-  })
-
-  it('renders the correct wizardHeader text for attach when pipette is attached', () => {
-    props = {
-      ...props,
-      displayName: 'P10 Single-Channel GEN1',
-    }
-    const { getByText } = render(props)
-    getByText('Attach a P10 Single-Channel GEN1 Pipette')
-  })
-
-  it('renders the correct wizardHeader text for detach when pipette is attached', () => {
-    props = {
-      ...props,
-      direction: 'detach',
-      displayName: 'P10 Single-Channel GEN1',
-    }
-    const { getByText } = render(props)
-    getByText('Detach P10 Single-Channel GEN1 from Left Mount')
   })
 })

--- a/app/src/organisms/ChangePipette/__tests__/Instructions.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/Instructions.test.tsx
@@ -41,37 +41,43 @@ describe('Instructions', () => {
       direction: 'detach',
       setWantedName: jest.fn(),
       confirm: jest.fn(),
-      exit: jest.fn(),
       back: jest.fn(),
-      currentStep: 5,
-      totalSteps: 8,
+      setStepPage: jest.fn(),
+      stepPage: 0,
     }
-  })
-  it('renders the detach flow and buttons work as expected', () => {
     mockCheckPipettesButton.mockReturnValue(
       <div>mock check pipettes button</div>
     )
+  })
+  it('renders 1st page of the detach pipette flow', () => {
     const { getByText, getByRole, getByAltText } = render(props)
-    getByText('Detach P10 Single-Channel from Left Mount')
-    getByText('Step: 5 / 8')
     getByText('Loosen the screws')
     getByText(
       'Using a 2.5 mm screwdriver, loosen the three screws on the back of the pipette that is currently attached.'
     )
     getByAltText('detach-left-single-GEN1-screws')
     const goBack = getByRole('button', { name: 'Go back' })
-    const exit = getByRole('button', { name: 'Exit' })
     const cont = getByRole('button', { name: 'Continue' })
     fireEvent.click(goBack)
     expect(props.back).toHaveBeenCalled()
-    fireEvent.click(exit)
-    expect(props.exit).toHaveBeenCalled()
     fireEvent.click(cont)
+    expect(props.setStepPage).toHaveBeenCalled()
+  })
+
+  it('renders 2nd page of the detach pipette flow', () => {
+    props = {
+      ...props,
+      stepPage: 1,
+    }
+    const { getByText, getByRole, getByAltText } = render(props)
     getByText('Remove the pipette')
     getByText(
       'Hold onto the pipette so it does not fall. Disconnect the pipette from the robot by pulling the white connector tab.'
     )
     getByAltText('detach-left-single-GEN1-tab')
+    const goBack = getByRole('button', { name: 'Go back' })
+    fireEvent.click(goBack)
+    expect(props.setStepPage).toHaveBeenCalled()
     getByText('mock check pipettes button')
   })
 
@@ -85,27 +91,19 @@ describe('Instructions', () => {
       direction: 'attach',
       setWantedName: jest.fn(),
       confirm: jest.fn(),
-      exit: jest.fn(),
       back: jest.fn(),
-      currentStep: 5,
-      totalSteps: 8,
+      setStepPage: jest.fn(),
+      stepPage: 0,
     }
     const { getByText, getByRole } = render(props)
-    getByText('Attach a pipette')
-    getByText('Step: 5 / 8')
     getByText('Choose a pipette to attach')
     const goBack = getByRole('button', { name: 'Go back' })
-    const exit = getByRole('button', { name: 'Exit' })
     fireEvent.click(goBack)
     expect(props.back).toHaveBeenCalled()
-    fireEvent.click(exit)
     expect(screen.queryByText('Continue')).not.toBeInTheDocument()
   })
 
-  it('renders the attach flow when a p10 single gen 1 is selected', () => {
-    mockCheckPipettesButton.mockReturnValue(
-      <div>mock check pipettes button</div>
-    )
+  it('renders the 1st page of the attach flow when a p10 single gen 1 is selected', () => {
     props = {
       robotName: 'otie',
       mount: LEFT,
@@ -115,14 +113,11 @@ describe('Instructions', () => {
       direction: 'attach',
       setWantedName: jest.fn(),
       confirm: jest.fn(),
-      exit: jest.fn(),
       back: jest.fn(),
-      currentStep: 5,
-      totalSteps: 8,
+      setStepPage: jest.fn(),
+      stepPage: 0,
     }
     const { getByText, getByRole, getByAltText } = render(props)
-    getByText('Attach a P10 Single-Channel Pipette')
-    getByText('Step: 5 / 8')
     getByText('Insert screws')
     getByText(
       'Using a 2.5 mm screwdriver, insert the the three screws on the back of the pipette.'
@@ -132,24 +127,40 @@ describe('Instructions', () => {
     )
     getByAltText('attach-left-single-GEN1-screws')
     const goBack = getByRole('button', { name: 'Go back' })
-    const exit = getByRole('button', { name: 'Exit' })
     fireEvent.click(goBack)
     expect(props.back).toHaveBeenCalled()
-    fireEvent.click(exit)
     const cont = getByRole('button', { name: 'Continue' })
     fireEvent.click(cont)
+    expect(props.setStepPage).toHaveBeenCalled()
+  })
+
+  it('renders the 2nd page of the attach flow when a p10 single gen 1 is selected', () => {
+    props = {
+      robotName: 'otie',
+      mount: LEFT,
+      wantedPipette: mockPipetteInfo.pipetteSpecs,
+      actualPipette: null,
+      displayCategory: 'GEN1',
+      direction: 'attach',
+      setWantedName: jest.fn(),
+      confirm: jest.fn(),
+      back: jest.fn(),
+      setStepPage: jest.fn(),
+      stepPage: 1,
+    }
+    const { getByText, getByRole, getByAltText } = render(props)
     getByText('Attach the pipette')
     getByText(
       'Push in the white connector tab until you feel it plug into the pipette.'
     )
     getByAltText('attach-left-single-GEN1-tab')
+    const goBack = getByRole('button', { name: 'Go back' })
+    fireEvent.click(goBack)
+    expect(props.setStepPage).toHaveBeenCalled()
     getByText('mock check pipettes button')
   })
 
-  it('renders the attach flow when a p10 8 channel is selected', () => {
-    mockCheckPipettesButton.mockReturnValue(
-      <div>mock check pipettes button</div>
-    )
+  it('renders the attach flow 1st page when a p10 8 channel is selected', () => {
     props = {
       robotName: 'otie',
       mount: LEFT,
@@ -159,14 +170,11 @@ describe('Instructions', () => {
       direction: 'attach',
       setWantedName: jest.fn(),
       confirm: jest.fn(),
-      exit: jest.fn(),
       back: jest.fn(),
-      currentStep: 5,
-      totalSteps: 8,
+      setStepPage: jest.fn(),
+      stepPage: 0,
     }
     const { getByText, getByRole, getByAltText } = render(props)
-    getByText('Attach a P10 8-Channel Pipette')
-    getByText('Step: 5 / 8')
     getByText('Insert screws')
     getByText(
       'Using a 2.5 mm screwdriver, insert the the three screws on the back of the pipette.'
@@ -179,11 +187,35 @@ describe('Instructions', () => {
     getByAltText('attach-left-multi-GEN1-screws')
     const cont = getByRole('button', { name: 'Continue' })
     fireEvent.click(cont)
+    expect(props.setStepPage).toHaveBeenCalled()
+  })
+
+  it('renders the attach flow 2nd page when a p10 8 channel is selected', () => {
+    props = {
+      robotName: 'otie',
+      mount: LEFT,
+      wantedPipette: fixtureP10Multi,
+      actualPipette: null,
+      displayCategory: 'GEN1',
+      direction: 'attach',
+      setWantedName: jest.fn(),
+      confirm: jest.fn(),
+      back: jest.fn(),
+      setStepPage: jest.fn(),
+      stepPage: 1,
+    }
+    const { getByText, getByRole, getByAltText } = render(props)
     getByText('Attach the pipette')
     getByText(
       'Push in the white connector tab until you feel it plug into the pipette.'
     )
     getByAltText('attach-left-multi-GEN1-tab')
+    const goBack = getByRole('button', { name: 'Go back' })
+    fireEvent.click(goBack)
+    expect(props.setStepPage).toHaveBeenCalled()
     getByText('mock check pipettes button')
   })
+
+  //  TOD0(JR, 29.08.22): figure out how to mock the checkPipetteButton so you can click on it
+  //  and render the LevelPipette component
 })

--- a/app/src/organisms/ChangePipette/__tests__/LevelPipette.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/LevelPipette.test.tsx
@@ -59,19 +59,14 @@ describe('LevelPipette', () => {
   beforeEach(() => {
     props = {
       mount: LEFT,
-      wantedPipette: MOCK_WANTED_PIPETTE,
       pipetteModelName: MOCK_WANTED_PIPETTE.name,
       back: jest.fn(),
-      exit: jest.fn(),
       confirm: jest.fn(),
-      currentStep: 6,
-      totalSteps: 8,
     }
   })
 
   it('renders title and description', () => {
     const { getByText } = render(props)
-    getByText('Attach a P300 8-Channel GEN2 Pipette')
     getByText(nestedTextMatcher('Level the pipette'))
     getByText(
       nestedTextMatcher(
@@ -99,12 +94,9 @@ describe('LevelPipette', () => {
   it('the CTAs should be clickable', () => {
     const { getByRole } = render(props)
     const goBack = getByRole('button', { name: 'Go back' })
-    const exit = getByRole('button', { name: 'Exit' })
     const cont = getByRole('button', { name: 'Confirm level' })
     fireEvent.click(goBack)
     expect(props.back).toHaveBeenCalled()
-    fireEvent.click(exit)
-    expect(props.exit).toHaveBeenCalled()
     fireEvent.click(cont)
     expect(props.confirm).toHaveBeenCalled()
   })

--- a/app/src/organisms/ChangePipette/constants.ts
+++ b/app/src/organisms/ChangePipette/constants.ts
@@ -5,3 +5,6 @@ export const CLEAR_DECK: 'clearDeck' = 'clearDeck'
 export const INSTRUCTIONS: 'instructions' = 'instructions'
 export const CONFIRM: 'confirm' = 'confirm'
 export const CALIBRATE_PIPETTE: 'calibratePipette' = 'calibratePipette'
+
+export const SINGLE_CHANNEL_STEPS: 3 = 3
+export const EIGHT_CHANNEL_STEPS: 4 = 4

--- a/app/src/organisms/ChangePipette/index.tsx
+++ b/app/src/organisms/ChangePipette/index.tsx
@@ -111,9 +111,7 @@ export function ChangePipette(props: Props): JSX.Element | null {
   })?.status
 
   React.useEffect(() => {
-    if (homePipStatus === SUCCESS) {
-      closeModal()
-    }
+    if (homePipStatus === SUCCESS) closeModal()
   }, [homePipStatus, closeModal])
 
   const homePipAndExit = React.useCallback(
@@ -221,8 +219,9 @@ export function ChangePipette(props: Props): JSX.Element | null {
       direction === ATTACH && wantedPipette === null
     const attachWizardHeader = noPipetteSelectedAttach
       ? t('attach_pipette')
-      : t('attach_pipette_type', {
-          pipetteName: wantedPipette?.displayName,
+      : //  TODO refactor this, feels like a more eloquant alternative
+        t('attach_pipette_type', {
+          pipetteName: wantedPipette != null ? wantedPipette.displayName : '',
         })
 
     const noPipetteDetach =
@@ -291,19 +290,16 @@ export function ChangePipette(props: Props): JSX.Element | null {
     currentStep = success ? (eightChannel ? 4 : totalSteps) : totalSteps - 1
     exitWizardHeader = success ? homePipAndExit : () => setConfirmExit(true)
 
-    let title
-    if (
-      (!wantedPipette && !actualPipette) ||
-      (!wantedPipette && actualPipette)
-    ) {
-      title = t('detatch_pipette_from_mount', {
-        mount: mount[0].toUpperCase() + mount.slice(1),
-      })
-    } else {
-      title = t('attach_name_pipette', { pipette: wantedPipette?.displayName })
-    }
+    wizardTitle =
+      (wantedPipette == null && actualPipette == null) ||
+      (wantedPipette == null && actualPipette)
+        ? t('detatch_pipette_from_mount', {
+            mount: mount[0].toUpperCase() + mount.slice(1),
+          })
+        : t('attach_name_pipette', {
+            pipette: wantedPipette != null ? wantedPipette.displayName : '',
+          })
 
-    wizardTitle = title
     contents = confirmExit ? (
       <ExitModal
         back={() => setConfirmExit(false)}

--- a/app/src/organisms/ChangePipette/index.tsx
+++ b/app/src/organisms/ChangePipette/index.tsx
@@ -36,6 +36,7 @@ import { ExitModal } from './ExitModal'
 import { Instructions } from './Instructions'
 import { ClearDeckModal } from './ClearDeckModal/index'
 import { ConfirmPipette } from './ConfirmPipette'
+//  remove lines 40 - 46 when removing FF
 import { AskForCalibrationBlockModal } from '../CalibrateTipLength/AskForCalibrationBlockModal'
 import { ExitAlertModal } from './ExitAlertModal'
 import { DeprecatedInstructions } from './DeprecatedInstructions'

--- a/app/src/organisms/ChangePipette/index.tsx
+++ b/app/src/organisms/ChangePipette/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { getPipetteNameSpecs, shouldLevel } from '@opentrons/shared-data'
 import { useTranslation } from 'react-i18next'
-
+import { SPACING } from '@opentrons/components'
 import {
   useDispatchApiRequests,
   getRequestById,
@@ -24,13 +24,14 @@ import {
   HOME,
 } from '../../redux/robot-controls'
 
-import { useCalibratePipetteOffset } from '../CalibratePipetteOffset/useCalibratePipetteOffset'
-import { AskForCalibrationBlockModal } from '../CalibrateTipLength/AskForCalibrationBlockModal'
 import { INTENT_CALIBRATE_PIPETTE_OFFSET } from '../../organisms/CalibrationPanels'
 import { useFeatureFlag } from '../../redux/config'
 import { ModalShell } from '../../molecules/Modal'
+import { WizardHeader } from '../../molecules/WizardHeader'
 import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
 import { StyledText } from '../../atoms/text'
+import { useCalibratePipetteOffset } from '../CalibratePipetteOffset/useCalibratePipetteOffset'
+import { AskForCalibrationBlockModal } from '../CalibrateTipLength/AskForCalibrationBlockModal'
 import { ExitModal } from './ExitModal'
 import { Instructions } from './Instructions'
 import { ClearDeckModal } from './ClearDeckModal/index'
@@ -41,7 +42,6 @@ import { DeprecatedConfirmPipette } from './DeprecatedConfirmPipette'
 import { RequestInProgressModal } from './RequestInProgressModal'
 import { DeprecatedLevelPipette } from './DeprecatedLevelPipette'
 import { ClearDeckAlertModal } from './ClearDeckModal/ClearDeckAlertModal'
-import { SPACING } from '@opentrons/components'
 
 import {
   ATTACH,
@@ -155,70 +155,6 @@ export function ChangePipette(props: Props): JSX.Element | null {
     mount,
   }
 
-  if (
-    movementStatus !== null &&
-    //  when FF is removed, change this logic so the modal only appears when movement status is MOVING
-    (movementStatus === HOMING || movementStatus === MOVING)
-  ) {
-    return enableChangePipetteWizard && movementStatus === MOVING ? (
-      <ModalShell height="28.12rem" width="47rem">
-        <InProgressModal
-          wizardHeaderTitle={t('attach_pipette')}
-          currentStep={1}
-          totalSteps={5}
-        >
-          <StyledText
-            as="h1"
-            marginTop={SPACING.spacing5}
-            marginBottom={SPACING.spacing3}
-          >
-            {t('moving_gantry')}
-          </StyledText>
-        </InProgressModal>
-      </ModalShell>
-    ) : (
-      <RequestInProgressModal
-        {...baseProps}
-        movementStatus={movementStatus}
-        isPipetteHoming={homePipStatus === PENDING}
-      />
-    )
-  }
-
-  if (wizardStep === CLEAR_DECK) {
-    return enableChangePipetteWizard ? (
-      <ModalShell height="28.12rem" width="47rem">
-        <ClearDeckModal
-          totalSteps={5}
-          currentStep={0}
-          title={
-            actualPipette?.displayName != null
-              ? t('detach_pipette', {
-                  pipette: actualPipette.displayName,
-                  mount: mount[0].toUpperCase() + mount.slice(1),
-                })
-              : t('attach_pipette')
-          }
-          onCancelClick={closeModal}
-          onContinueClick={() => {
-            dispatch(move(robotName, CHANGE_PIPETTE, mount, true))
-            setWizardStep(INSTRUCTIONS)
-          }}
-        />
-      </ModalShell>
-    ) : (
-      <ClearDeckAlertModal
-        cancelText={CANCEL}
-        continueText={MOVE_PIPETTE_TO_FRONT}
-        onCancelClick={closeModal}
-        onContinueClick={() => {
-          dispatch(move(robotName, CHANGE_PIPETTE, mount, true))
-          setWizardStep(INSTRUCTIONS)
-        }}
-      />
-    )
-  }
-
   const basePropsWithPipettes = {
     ...baseProps,
     robotName,
@@ -228,69 +164,117 @@ export function ChangePipette(props: Props): JSX.Element | null {
     displayCategory:
       actualPipette?.displayCategory || wantedPipette?.displayCategory || null,
   }
+  const totalSteps = 3
+  const [instructionStepPage, instructionSetStepPage] = React.useState<number>(
+    0
+  )
+  const eightChannel = wantedPipette != null && wantedPipette.channels === 8
+  const direction = actualPipette ? DETACH : ATTACH
 
+  //  this is the logic for the Instructions page that renders 3 pages within the component
+  let instructionsCurrentStep: number = totalSteps
   if (wizardStep === INSTRUCTIONS) {
-    const direction = actualPipette ? DETACH : ATTACH
-
-    return (
-      <>
-        {confirmExit &&
-          (enableChangePipetteWizard ? (
-            <ExitModal
-              back={() => setConfirmExit(false)}
-              exit={homePipAndExit}
-              direction={direction}
-              currentStep={5}
-              totalSteps={8}
-              mount={mount}
-              displayName={
-                actualPipette?.displayName || wantedPipette?.displayName
-              }
-            />
-          ) : (
-            <ExitAlertModal
-              back={() => setConfirmExit(false)}
-              exit={homePipAndExit}
-            />
-          ))}
-        {enableChangePipetteWizard ? (
-          <ModalShell height="28.12rem" width="47rem">
-            <Instructions
-              {...{
-                ...basePropsWithPipettes,
-                direction,
-                setWantedName,
-                confirm: () => setWizardStep(CONFIRM),
-                back: () => setWizardStep(CLEAR_DECK),
-                exit: () => setConfirmExit(true),
-                currentStep: 5,
-                totalSteps: 8,
-                title:
-                  actualPipette?.displayName != null
-                    ? t('detach_pipette', {
-                        pipette: actualPipette.displayName,
-                        mount: mount[0].toUpperCase() + mount.slice(1),
-                      })
-                    : t('attach_pipette'),
-              }}
-            />
-          </ModalShell>
-        ) : (
-          <DeprecatedInstructions
-            {...{
-              ...basePropsWithPipettes,
-              direction,
-              setWantedName,
-              confirm: () => setWizardStep(CONFIRM),
-              exit: () => setConfirmExit(true),
-            }}
-          />
-        )}
-      </>
-    )
+    if (instructionStepPage === 0) {
+      instructionsCurrentStep = 1
+    } else if (instructionStepPage === 1) {
+      instructionsCurrentStep = 2
+    } else if (instructionStepPage === 2) {
+      instructionsCurrentStep = 3
+    }
   }
 
-  if (wizardStep === CONFIRM) {
+  let exitWizardHeader
+  let wizardTitle: string =
+    actualPipette?.displayName != null
+      ? t('detach_pipette', {
+          pipette: actualPipette.displayName,
+          mount: mount[0].toUpperCase() + mount.slice(1),
+        })
+      : t('attach_pipette')
+  let currentStep: number = 0
+  let contents: JSX.Element | null = null
+
+  if (movementStatus !== null && movementStatus === MOVING) {
+    contents = (
+      <InProgressModal>
+        <StyledText
+          as="h1"
+          marginTop={SPACING.spacing5}
+          marginBottom={SPACING.spacing3}
+        >
+          {t('moving_gantry')}
+        </StyledText>
+      </InProgressModal>
+    )
+  } else if (wizardStep === CLEAR_DECK) {
+    exitWizardHeader = closeModal
+    contents = (
+      <ClearDeckModal
+        onContinueClick={() => {
+          dispatch(move(robotName, CHANGE_PIPETTE, mount, true))
+          setWizardStep(INSTRUCTIONS)
+        }}
+      />
+    )
+  } else if (wizardStep === INSTRUCTIONS) {
+    const noPipetteSelectedAttach =
+      direction === ATTACH && wantedPipette === null
+    const attachWizardHeader = noPipetteSelectedAttach
+      ? t('attach_pipette')
+      : t('attach_pipette_type', {
+          pipetteName: wantedPipette?.displayName,
+        })
+
+    const noPipetteDetach =
+      direction === DETACH && actualPipette === null && wantedPipette === null
+    const detachWizardHeader = noPipetteDetach
+      ? t('detach')
+      : t('detach_pipette', {
+          pipette:
+            actualPipette?.displayName || wantedPipette?.displayName || '',
+          mount: mount[0].toUpperCase() + mount.slice(1),
+        })
+
+    exitWizardHeader = confirmExit ? closeModal : () => setConfirmExit(true)
+    currentStep = instructionsCurrentStep
+    wizardTitle =
+      //  for some reason when the pipette is leveling, the direction is detach BUT should be attach
+      instructionStepPage === 2
+        ? t('attach_pipette_type', {
+            pipetteName: wantedPipette?.displayName,
+          })
+        : actualPipette?.displayName != null
+        ? detachWizardHeader
+        : attachWizardHeader
+
+    contents = confirmExit ? (
+      <ExitModal
+        back={() => setConfirmExit(false)}
+        exit={homePipAndExit}
+        direction={direction}
+      />
+    ) : (
+      <Instructions
+        {...{
+          ...basePropsWithPipettes,
+          direction,
+          setWantedName,
+          confirm: () => setWizardStep(CONFIRM),
+          back: () => setWizardStep(CLEAR_DECK),
+          stepPage: instructionStepPage,
+          setStepPage: instructionSetStepPage,
+          totalSteps: eightChannel ? 4 : totalSteps,
+          title:
+            actualPipette?.displayName != null
+              ? t('detach_pipette', {
+                  pipette: actualPipette.displayName,
+                  mount: mount[0].toUpperCase() + mount.slice(1),
+                })
+              : t('attach_pipette'),
+        }}
+      />
+    )
+  } else if (wizardStep === CONFIRM) {
     const success =
       // success if we were trying to detach and nothing's attached
       (!actualPipette && !wantedPipette) ||
@@ -300,69 +284,51 @@ export function ChangePipette(props: Props): JSX.Element | null {
     const attachedWrong = Boolean(!success && wantedPipette && actualPipette)
 
     const launchPOC = (): void => {
-      // home before cal flow to account for skips when attaching pipette
       setWizardStep(CALIBRATE_PIPETTE)
       dispatchApiRequests(home(robotName, ROBOT))
       startPipetteOffsetWizard()
     }
-    if (
-      !enableChangePipetteWizard &&
-      success &&
-      wantedPipette &&
-      shouldLevel(wantedPipette)
-    ) {
-      return (
-        <DeprecatedLevelPipette
-          {...{
-            pipetteModelName: actualPipette ? actualPipette.name : '',
-            ...basePropsWithPipettes,
-            back: () => setWizardStep(INSTRUCTIONS),
-            exit: homePipAndExit,
-            actualPipetteOffset: actualPipetteOffset,
-            startPipetteOffsetCalibration: launchPOC,
-          }}
-        />
-      )
-    } else {
-      return enableChangePipetteWizard ? (
-        <ConfirmPipette
-          {...{
-            ...basePropsWithPipettes,
-            success,
-            attachedWrong,
-            tryAgain: () => {
-              setWantedName(null)
-              setWizardStep(INSTRUCTIONS)
-            },
-            exit: homePipAndExit,
-            actualPipetteOffset: actualPipetteOffset,
-            startPipetteOffsetCalibration: launchPOC,
-            currentStep: 5,
-            totalSteps: 8,
-          }}
-        />
-      ) : (
-        <DeprecatedConfirmPipette
-          {...{
-            ...basePropsWithPipettes,
-            success,
-            attachedWrong,
-            tryAgain: () => {
-              setWantedName(null)
-              setWizardStep(INSTRUCTIONS)
-            },
-            back: () => setWizardStep(INSTRUCTIONS),
-            exit: homePipAndExit,
-            actualPipetteOffset: actualPipetteOffset,
-            startPipetteOffsetCalibration: launchPOC,
-          }}
-        />
-      )
-    }
-  }
+    currentStep = success ? (eightChannel ? 4 : totalSteps) : totalSteps - 1
+    exitWizardHeader = success ? homePipAndExit : () => setConfirmExit(true)
 
-  if (wizardStep === CALIBRATE_PIPETTE) {
-    return showCalBlockModal ? (
+    let title
+    if (
+      (!wantedPipette && !actualPipette) ||
+      (!wantedPipette && actualPipette)
+    ) {
+      title = t('detatch_pipette_from_mount', {
+        mount: mount[0].toUpperCase() + mount.slice(1),
+      })
+    } else {
+      title = t('attach_name_pipette', { pipette: wantedPipette?.displayName })
+    }
+
+    wizardTitle = title
+    contents = confirmExit ? (
+      <ExitModal
+        back={() => setConfirmExit(false)}
+        exit={homePipAndExit}
+        direction={direction}
+      />
+    ) : (
+      <ConfirmPipette
+        {...{
+          ...basePropsWithPipettes,
+          success,
+          attachedWrong,
+          tryAgain: () => {
+            setWantedName(null)
+            setWizardStep(INSTRUCTIONS)
+          },
+          exit: homePipAndExit,
+          actualPipetteOffset: actualPipetteOffset,
+          startPipetteOffsetCalibration: launchPOC,
+        }}
+      />
+    )
+  } else if (wizardStep === CALIBRATE_PIPETTE) {
+    contents = showCalBlockModal ? (
+      //  TODO(Jr, 29.08.22): update this modal with the new calibration block modal found in the POC flow when it is created
       <AskForCalibrationBlockModal
         titleBarTitle={PIPETTE_OFFSET_CALIBRATION}
         onResponse={startPipetteOffsetWizard}
@@ -373,6 +339,138 @@ export function ChangePipette(props: Props): JSX.Element | null {
     )
   }
 
+  if (enableChangePipetteWizard) {
+    return (
+      <ModalShell height="28.12rem" width="47rem">
+        <WizardHeader
+          totalSteps={eightChannel ? 4 : totalSteps}
+          currentStep={currentStep}
+          title={wizardTitle}
+          onExit={exitWizardHeader}
+        />
+        {contents}
+      </ModalShell>
+    )
+  } else {
+    //  TODO(Jr, 29.08.22): this whole else can be removed when we remove the FF
+    if (
+      movementStatus !== null &&
+      (movementStatus === HOMING || movementStatus === MOVING)
+    ) {
+      return (
+        <RequestInProgressModal
+          {...baseProps}
+          movementStatus={movementStatus}
+          isPipetteHoming={homePipStatus === PENDING}
+        />
+      )
+    }
+    if (wizardStep === CLEAR_DECK) {
+      return (
+        <ClearDeckAlertModal
+          cancelText={CANCEL}
+          continueText={MOVE_PIPETTE_TO_FRONT}
+          onCancelClick={closeModal}
+          onContinueClick={() => {
+            dispatch(move(robotName, CHANGE_PIPETTE, mount, true))
+            setWizardStep(INSTRUCTIONS)
+          }}
+        />
+      )
+    }
+
+    if (wizardStep === INSTRUCTIONS) {
+      const direction = actualPipette ? DETACH : ATTACH
+
+      return (
+        <>
+          {confirmExit && (
+            <ExitAlertModal
+              back={() => setConfirmExit(false)}
+              exit={homePipAndExit}
+            />
+          )}
+          (
+          <DeprecatedInstructions
+            {...{
+              ...basePropsWithPipettes,
+              direction,
+              setWantedName,
+              confirm: () => setWizardStep(CONFIRM),
+              exit: () => setConfirmExit(true),
+            }}
+          />
+          )
+        </>
+      )
+    }
+
+    if (wizardStep === CONFIRM) {
+      const success =
+        // success if we were trying to detach and nothing's attached
+        (!actualPipette && !wantedPipette) ||
+        // or if the names of wanted and attached match
+        actualPipette?.name === wantedPipette?.name
+
+      const attachedWrong = Boolean(!success && wantedPipette && actualPipette)
+
+      const launchPOC = (): void => {
+        // home before cal flow to account for skips when attaching pipette
+        setWizardStep(CALIBRATE_PIPETTE)
+        dispatchApiRequests(home(robotName, ROBOT))
+        startPipetteOffsetWizard()
+      }
+      if (
+        !enableChangePipetteWizard &&
+        success &&
+        wantedPipette &&
+        shouldLevel(wantedPipette)
+      ) {
+        return (
+          <DeprecatedLevelPipette
+            {...{
+              pipetteModelName: actualPipette ? actualPipette.name : '',
+              ...basePropsWithPipettes,
+              back: () => setWizardStep(INSTRUCTIONS),
+              exit: homePipAndExit,
+              actualPipetteOffset: actualPipetteOffset,
+              startPipetteOffsetCalibration: launchPOC,
+            }}
+          />
+        )
+      } else {
+        return (
+          <DeprecatedConfirmPipette
+            {...{
+              ...basePropsWithPipettes,
+              success,
+              attachedWrong,
+              tryAgain: () => {
+                setWantedName(null)
+                setWizardStep(INSTRUCTIONS)
+              },
+              back: () => setWizardStep(INSTRUCTIONS),
+              exit: homePipAndExit,
+              actualPipetteOffset: actualPipetteOffset,
+              startPipetteOffsetCalibration: launchPOC,
+            }}
+          />
+        )
+      }
+    }
+
+    if (wizardStep === CALIBRATE_PIPETTE) {
+      return showCalBlockModal ? (
+        <AskForCalibrationBlockModal
+          titleBarTitle={PIPETTE_OFFSET_CALIBRATION}
+          onResponse={startPipetteOffsetWizard}
+          closePrompt={homePipAndExit}
+        />
+      ) : (
+        PipetteOffsetCalibrationWizard
+      )
+    }
+  }
   // this will never be reached
   return null
 }

--- a/app/src/organisms/ChangePipette/types.ts
+++ b/app/src/organisms/ChangePipette/types.ts
@@ -5,5 +5,6 @@ export type WizardStep =
   | 'instructions'
   | 'confirm'
   | 'calibratePipette'
+//  TODO(JR, 08.31.22): remove `calibratePipette` from WizardStep when we remove FF
 
 export type Diagram = 'screws' | 'tab'


### PR DESCRIPTION
closes RLIQ-57 partially closes RLIQ-110

# Overview

this PR wires up the `WizardHeader` component in the `ChangePipette` attach/detach flow. Also does a huge refactor to remove the `WizardHeader` and `ModalShell` from all the child components and into the parent component (`ChangePipette`) This also organizes `ChangePipette` so the deprecate components are organized away from the new components. There is now an easy split to be able to remove the deprecated components when we remove the FF

# Changelog

- refactor all child components to remove the `ModalShell` and `WizardHeader`, remove all associated components such as `currentStep`, `title` and `totalSteps`
- create `ChangePipette` test (still a WIP and might be completed in a followup PR when we remove the FF - this is partially addressing RLIQ-110)
- Change `SimpleWizardModal` to remove the `ModalShell` and `WizardHeader`, fix test and edit story to accommodate that change
- add deprecated tag to `AskForCalibrationBlockModal` because that wil be updated when we update the POC flow

# Review requests

- i sprinkled in a few comments already. A bit of the logic might be hard to read in the `ChangePipette` component, please call out anything that looks weird/seems confusing
- I smoke tested all 4 flows already (attach/detach single/multi pipettes) But would be nice to have a second pair of eyes on this

# Risk assessment

low