### PR TITLE
refactor(api): use deck def for slot positions

### DIFF
--- a/api/src/opentrons/protocols/geometry/deck.py
+++ b/api/src/opentrons/protocols/geometry/deck.py
@@ -44,19 +44,15 @@ class CalibrationPosition:
 class Deck(UserDict):
     def __init__(self) -> None:
         super().__init__()
-        row_offset = 90.5
-        col_offset = 132.5
-        for idx in range(1, 13):
-            self.data[idx] = None
-        self._positions = {
-            idx + 1: types.Point((idx % 3) * col_offset, idx // 3 * row_offset, 0)
-            for idx in range(12)
-        }
-        self._highest_z = 0.0
         # TODO(mc, 2022-06-17): move deck type selection
         # (and maybe deck definition loading) out of this constructor
         # to decouple from config (and environment) reading / loading
         self._definition = load_deck(deck_type(), DEFAULT_DECK_DEFINITION_VERSION)
+        self._positions = {}
+        for slot in self._definition["locations"]["orderedSlots"]:
+            self.data[int(slot["id"])] = None
+            self._positions[int(slot["id"])] = types.Point(*slot["position"])
+        self._highest_z = 0.0
         self._load_fixtures()
         self._thermocycler_present = False
 

--- a/api/tests/opentrons/protocol_api/test_labware_load.py
+++ b/api/tests/opentrons/protocol_api/test_labware_load.py
@@ -1,38 +1,56 @@
 import pytest
 from opentrons import protocol_api as papi, types
+from opentrons_shared_data.deck.dev_types import DeckDefinitionV3
 
 
 labware_name = "corning_96_wellplate_360ul_flat"
 
 
-def test_load_to_slot(ctx):
+def test_load_to_slot(
+    ctx: papi.ProtocolContext, deck_definition: DeckDefinitionV3
+) -> None:
+    slot_1 = [
+        slot
+        for slot in deck_definition["locations"]["orderedSlots"]
+        if slot["id"] == "1"
+    ][0]
+    slot_2 = [
+        slot
+        for slot in deck_definition["locations"]["orderedSlots"]
+        if slot["id"] == "2"
+    ][0]
     labware = ctx.load_labware(labware_name, "1")
-    assert labware._implementation.get_geometry().offset == types.Point(0, 0, 0)
+
+    assert labware._implementation.get_geometry().offset == types.Point(
+        *slot_1["position"]
+    )
     other = ctx.load_labware(labware_name, 2)
-    assert other._implementation.get_geometry().offset == types.Point(132.5, 0, 0)
+    assert other._implementation.get_geometry().offset == types.Point(
+        *slot_2["position"]
+    )
 
 
-def test_loaded(ctx):
+def test_loaded(ctx: papi.ProtocolContext) -> None:
     labware = ctx.load_labware(labware_name, "1")
     assert ctx.loaded_labwares[1] == labware
 
 
-def test_get_incorrect_definition_by_name():
+def test_get_incorrect_definition_by_name() -> None:
     with pytest.raises(FileNotFoundError):
         papi.labware.get_labware_definition("fake_labware")
 
 
-def test_get_mixed_case_labware_def():
+def test_get_mixed_case_labware_def() -> None:
     dfn = papi.labware.get_labware_definition("COrnIng_96_wElLplaTE_360UL_Flat")
     assert dfn["parameters"]["loadName"] == labware_name
 
 
-def test_load_label(ctx):
+def test_load_label(ctx: papi.ProtocolContext) -> None:
     labware = ctx.load_labware(labware_name, "1", "my cool labware")
     assert "my cool labware" in str(labware)
     assert labware._implementation.get_label() == "my cool labware"
 
 
-def test_deprecated_load(ctx):
+def test_deprecated_load(ctx: papi.ProtocolContext) -> None:
     labware = ctx.load_labware_by_name(labware_name, "1", "my cool labware")
     assert "my cool labware" in str(labware)


### PR DESCRIPTION
We have a nice deck definition system where we describe the physical
geometry of the deck in json. We used that for position in most
contexts, but when executing APIv2 protocols we used the old-style
direct calculation of slot offsets for the positions we load labware
into. This doesn't work for the OT-3.

By changing that logic to also depend on the deck definition, which is
then selected based on what machine is running, we can get correct
positioning for both machines.

## Testing
In theory, this could affect OT-2s. I think, however, that the test of labware loading helps with this, and any changes that come out of this certainly will get caught by gcode regression testing.