### PR TITLE
fix(shared-data): overlaps for gen3 pipettes

### DIFF
--- a/shared-data/pipette/definitions/pipetteModelSpecs.json
+++ b/shared-data/pipette/definitions/pipetteModelSpecs.json
@@ -5647,10 +5647,9 @@
         "type": "float"
       },
       "tipOverlap": {
-        "default": 9.7,
-        "opentrons/opentrons_96_tiprack_1000ul/1": 11.5,
-        "opentrons/opentrons_96_filtertiprack_1000ul/1": 11.5,
-        "opentrons/geb_96_tiprack_1000ul/1": 9.5
+        "default": 10.5,
+        "opentrons/opentrons_ot3_96_tiprack_1000ul/1": 10.5,
+        "opentrons/opentrons_ot3_96_tiprack_200ul/1": 10.5
       },
       "tipLength": {
         "value": 78.3,
@@ -5767,10 +5766,9 @@
         "type": "float"
       },
       "tipOverlap": {
-        "default": 9.7,
-        "opentrons/opentrons_96_tiprack_1000ul/1": 11.5,
-        "opentrons/opentrons_96_filtertiprack_1000ul/1": 11.5,
-        "opentrons/geb_96_tiprack_1000ul/1": 9.5
+        "default": 10.5,
+        "opentrons/opentrons_ot3_96_tiprack_1000ul/1": 10.5,
+        "opentrons/opentrons_ot3_96_tiprack_200ul/1": 10.5
       },
       "tipLength": {
         "value": 78.3,
@@ -5936,10 +5934,8 @@
         "type": "float"
       },
       "tipOverlap": {
-        "default": 9.7,
-        "opentrons/opentrons_96_tiprack_1000ul/1": 11.5,
-        "opentrons/opentrons_96_filtertiprack_1000ul/1": 11.5,
-        "opentrons/geb_96_tiprack_1000ul/1": 9.5
+        "default": 10.5,
+        "opentrons/opentrons_96_tiprack_50ul/1": 10.5
       },
       "tipLength": {
         "value": 78.3,
@@ -6106,10 +6102,8 @@
         "type": "float"
       },
       "tipOverlap": {
-        "default": 9.7,
-        "opentrons/opentrons_96_tiprack_1000ul/1": 11.5,
-        "opentrons/opentrons_96_filtertiprack_1000ul/1": 11.5,
-        "opentrons/geb_96_tiprack_1000ul/1": 9.5
+        "default": 10.5,
+        "opentrons/opentrons_96_tiprack_50ul/1": 10.5
       },
       "tipLength": {
         "value": 78.3,
@@ -6154,7 +6148,7 @@
         "type": "float"
       },
       "pickUpCurrent": {
-        "value": 1.4,
+        "value": 1.0,
         "min": 0.05,
         "max": 2.0,
         "units": "amps",
@@ -6226,10 +6220,9 @@
         "type": "float"
       },
       "tipOverlap": {
-        "default": 9.7,
-        "opentrons/opentrons_96_tiprack_1000ul/1": 11.5,
-        "opentrons/opentrons_96_filtertiprack_1000ul/1": 11.5,
-        "opentrons/geb_96_tiprack_1000ul/1": 9.5
+        "default": 10.5,
+        "opentrons/opentrons_ot3_96_tiprack_1000ul/1": 10.5,
+        "opentrons/opentrons_ot3_96_tiprack_200ul/1": 10.5
       },
       "tipLength": {
         "value": 78.3,
@@ -6274,7 +6267,7 @@
         "type": "float"
       },
       "pickUpCurrent": {
-        "value": 1.4,
+        "value": 1.0,
         "min": 0.05,
         "max": 2.0,
         "units": "amps",
@@ -6346,10 +6339,9 @@
         "type": "float"
       },
       "tipOverlap": {
-        "default": 9.7,
-        "opentrons/opentrons_96_tiprack_1000ul/1": 11.5,
-        "opentrons/opentrons_96_filtertiprack_1000ul/1": 11.5,
-        "opentrons/geb_96_tiprack_1000ul/1": 9.5
+        "default": 10.5,
+        "opentrons/opentrons_ot3_96_tiprack_1000ul/1": 10.5,
+        "opentrons/opentrons_ot3_96_tiprack_200ul/1": 10.5
       },
       "tipLength": {
         "value": 78.3,
@@ -6394,7 +6386,7 @@
         "type": "float"
       },
       "pickUpCurrent": {
-        "value": 1.4,
+        "value": 1.0,
         "min": 0.05,
         "max": 2.0,
         "units": "amps",
@@ -6515,10 +6507,8 @@
         "type": "float"
       },
       "tipOverlap": {
-        "default": 9.7,
-        "opentrons/opentrons_96_tiprack_1000ul/1": 11.5,
-        "opentrons/opentrons_96_filtertiprack_1000ul/1": 11.5,
-        "opentrons/geb_96_tiprack_1000ul/1": 9.5
+        "default": 10.5,
+        "opentrons/opentrons_96_tiprack_50ul/1": 10.5
       },
       "tipLength": {
         "value": 78.3,
@@ -6563,7 +6553,7 @@
         "type": "float"
       },
       "pickUpCurrent": {
-        "value": 1.4,
+        "value": 1.0,
         "min": 0.05,
         "max": 2.0,
         "units": "amps",
@@ -6684,10 +6674,8 @@
         "type": "float"
       },
       "tipOverlap": {
-        "default": 9.7,
-        "opentrons/opentrons_96_tiprack_1000ul/1": 11.5,
-        "opentrons/opentrons_96_filtertiprack_1000ul/1": 11.5,
-        "opentrons/geb_96_tiprack_1000ul/1": 9.5
+        "default": 10.5,
+        "opentrons/opentrons_96_tiprack_50ul/1": 10.5
       },
       "tipLength": {
         "value": 78.3,


### PR DESCRIPTION
Tip overlaps need to be in the pipette definitions for proper fallback
if there are no calibrated tip lengths.

In addition, lower the current used by multichannel gen3 pipettes when
picking up tip

Closes RCORE-120
Closes RCORE-121
