### PR TITLE
refactor(api): add opentrons.protocol_engine.types alias to PipetteName

### DIFF
--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -18,7 +18,7 @@ from opentrons_shared_data.pipette.dev_types import (  # noqa: F401
     # TODO(mc, 2022-09-01): re-consider pickle usage in robot-server.
     # This re-export of PipetteName prevents pickle breakage
     # https://opentrons.atlassian.net/browse/RSS-94
-    # PipetteNameType as PipetteName,
+    PipetteNameType as PipetteName,
 )
 
 

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -11,9 +11,14 @@ from opentrons_shared_data.pipette.dev_types import PipetteNameType
 from opentrons.types import MountType, DeckSlotName
 from opentrons.hardware_control.modules import ModuleType as ModuleType
 
-# convenience re-export of LabwareUri type
+
 from opentrons_shared_data.pipette.dev_types import (  # noqa: F401
+    # convenience re-export of LabwareUri type
     LabwareUri as LabwareUri,
+    # TODO(mc, 2022-09-01): re-consider pickle usage in robot-server.
+    # This re-export of PipetteName prevents pickle breakage
+    # https://opentrons.atlassian.net/browse/RSS-94
+    # PipetteNameType as PipetteName,
 )
 
 
@@ -159,7 +164,7 @@ class ModuleModel(str, Enum):
     def is_thermocycler_module_model(
         cls, model: ModuleModel
     ) -> TypeGuard[ThermocyclerModuleModel]:
-        """Whether a given model is a Thermocyler Module."""
+        """Whether a given model is a Thermocycler Module."""
         return model in [cls.THERMOCYCLER_MODULE_V1, cls.THERMOCYCLER_MODULE_V2]
 
     @classmethod


### PR DESCRIPTION
## Overview

Fix unpickling error.

This PR is part of RSS-94

## Changelog

- Add alias to `protocol_engine.types` package so that instances of what used to be `opentrons.protocol_engine.types.PipetteName` can be unpickled as `opentrons_shared_data.pipette.dev_types.PipetteNameType`

## Review requests

To test, launch the dev server with persistence enabled:

```shell
make -C robot-server dev OT_ROBOT_SERVER_persistence_directory=/Users/$(id -un)/.opentrons/opentrons_robot_server
```

1. On a commit prior to #11402 / b596abd, upload a protocol that loads at least one pipette
    - `POST /protocols`
2. Fetch the protocol analysis
    - `GET /protocols/:id/analyses`
5. Quit the dev server and check out `edge`
6. Re-launch the dev server
7. Confirm that fetching the protocol analysis fails with a `500 Internal Server Error`
5. Quit the dev server and check out `api-fix-pickle`
6. Re-launch the dev server
7. Confirm you can fetch the protocol analysis

## Risk assessment

Low, bug fix with straightforward smoke test
