### PR TITLE
refactor(api): add labware loading to PE PAPIv2 core

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/labware.py
+++ b/api/src/opentrons/protocol_api/core/engine/labware.py
@@ -1,8 +1,96 @@
 """ProtocolEngine-based Labware core implementations."""
+from typing import List, Dict, Optional
+
+from opentrons.protocols.geometry.labware_geometry import LabwareGeometry
+from opentrons.protocols.api_support.tip_tracker import TipTracker
+from opentrons.protocols.api_support.well_grid import WellGrid
+from opentrons.types import Point
+from opentrons_shared_data.labware.dev_types import LabwareParameters, LabwareDefinition
 
 from ..labware import AbstractLabware
 from .well import WellCore
 
 
 class LabwareCore(AbstractLabware[WellCore]):
-    """Labware API core using a ProtocolEngine."""
+    """Labware API core using a ProtocolEngine.
+
+    Args:
+        labware_id: ProtocolEngine ID of the loaded labware.
+    """
+
+    def __init__(self, labware_id: str) -> None:
+        self._labware_id = labware_id
+
+    @property
+    def labware_id(self) -> str:
+        """The labware's unique ProtocolEngine ID."""
+        return self._labware_id
+
+    @property
+    def highest_z(self) -> float:
+        raise NotImplementedError("LabwareCore not implemented")
+
+    @property
+    def separate_calibration(self) -> bool:
+        raise NotImplementedError("LabwareCore not implemented")
+
+    @property
+    def load_name(self) -> str:
+        raise NotImplementedError("LabwareCore not implemented")
+
+    def get_uri(self) -> str:
+        raise NotImplementedError("LabwareCore not implemented")
+
+    def get_display_name(self) -> str:
+        raise NotImplementedError("LabwareCore not implemented")
+
+    def get_label(self) -> Optional[str]:
+        raise NotImplementedError("LabwareCore not implemented")
+
+    def get_name(self) -> str:
+        raise NotImplementedError("LabwareCore not implemented")
+
+    def set_name(self, new_name: str) -> None:
+        raise NotImplementedError("LabwareCore not implemented")
+
+    def get_definition(self) -> LabwareDefinition:
+        raise NotImplementedError("LabwareCore not implemented")
+
+    def get_parameters(self) -> LabwareParameters:
+        raise NotImplementedError("LabwareCore not implemented")
+
+    def get_quirks(self) -> List[str]:
+        raise NotImplementedError("LabwareCore not implemented")
+
+    def set_calibration(self, delta: Point) -> None:
+        raise NotImplementedError("LabwareCore not implemented")
+
+    def get_calibrated_offset(self) -> Point:
+        raise NotImplementedError("LabwareCore not implemented")
+
+    def is_tiprack(self) -> bool:
+        raise NotImplementedError("LabwareCore not implemented")
+
+    def get_tip_length(self) -> float:
+        raise NotImplementedError("LabwareCore not implemented")
+
+    def set_tip_length(self, length: float) -> None:
+        raise NotImplementedError("LabwareCore not implemented")
+
+    def reset_tips(self) -> None:
+        raise NotImplementedError("LabwareCore not implemented")
+
+    def get_tip_tracker(self) -> TipTracker:
+        raise NotImplementedError("LabwareCore not implemented")
+
+    def get_well_grid(self) -> WellGrid:
+        raise NotImplementedError("LabwareCore not implemented")
+
+    def get_wells(self) -> List[WellCore]:
+        raise NotImplementedError("LabwareCore not implemented")
+
+    def get_wells_by_name(self) -> Dict[str, WellCore]:
+        raise NotImplementedError("LabwareCore not implemented")
+
+    def get_geometry(self) -> LabwareGeometry:
+        raise NotImplementedError("LabwareCore not implemented")

--- a/api/src/opentrons/protocol_api/core/engine/labware.py
+++ b/api/src/opentrons/protocol_api/core/engine/labware.py
@@ -1,6 +1,7 @@
 """ProtocolEngine-based Labware core implementations."""
 from typing import List, Dict, Optional
 
+from opentrons.calibration_storage import helpers
 from opentrons.protocols.geometry.labware_geometry import LabwareGeometry
 from opentrons.protocols.api_support.tip_tracker import TipTracker
 from opentrons.protocols.api_support.well_grid import WellGrid
@@ -18,8 +19,9 @@ class LabwareCore(AbstractLabware[WellCore]):
         labware_id: ProtocolEngine ID of the loaded labware.
     """
 
-    def __init__(self, labware_id: str) -> None:
+    def __init__(self, labware_id: str, definition: LabwareDefinition) -> None:
         self._labware_id = labware_id
+        self._definition = definition
 
     @property
     def labware_id(self) -> str:
@@ -39,13 +41,14 @@ class LabwareCore(AbstractLabware[WellCore]):
         raise NotImplementedError("LabwareCore not implemented")
 
     def get_uri(self) -> str:
-        raise NotImplementedError("LabwareCore not implemented")
+        return helpers.uri_from_definition(self._definition)
 
     def get_display_name(self) -> str:
         raise NotImplementedError("LabwareCore not implemented")
 
     def get_label(self) -> Optional[str]:
-        raise NotImplementedError("LabwareCore not implemented")
+        # TODO(jbl 2022-09-01) implement real get_label
+        return "no-op"
 
     def get_name(self) -> str:
         raise NotImplementedError("LabwareCore not implemented")
@@ -54,7 +57,7 @@ class LabwareCore(AbstractLabware[WellCore]):
         raise NotImplementedError("LabwareCore not implemented")
 
     def get_definition(self) -> LabwareDefinition:
-        raise NotImplementedError("LabwareCore not implemented")
+        return self._definition
 
     def get_parameters(self) -> LabwareParameters:
         raise NotImplementedError("LabwareCore not implemented")
@@ -63,7 +66,8 @@ class LabwareCore(AbstractLabware[WellCore]):
         raise NotImplementedError("LabwareCore not implemented")
 
     def set_calibration(self, delta: Point) -> None:
-        raise NotImplementedError("LabwareCore not implemented")
+        # TODO(jbl 2022-09-01) implement set calibration
+        pass
 
     def get_calibrated_offset(self) -> Point:
         raise NotImplementedError("LabwareCore not implemented")

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -71,7 +71,7 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore]):
     def load_labware_from_definition(
         self,
         labware_def: LabwareDefinition,
-        location: DeckLocation,
+        location: DeckSlotName,
         label: Optional[str],
     ) -> LabwareCore:
         """Load a labware using its definition dictionary."""
@@ -86,10 +86,9 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore]):
         version: Optional[int],
     ) -> LabwareCore:
         """Load a labware using its identifying parameters."""
-        deck_slot = DeckSlotLocation(slotName=DeckSlotName.from_primitive(location))
         load_result = self._engine_client.load_labware(
             load_name=load_name,
-            location=deck_slot,
+            location=DeckSlotLocation(slotName=location),
             namespace=namespace if namespace is not None else OPENTRONS_NAMESPACE,
             version=version or 1,
             display_name=label,

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -80,7 +80,7 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore]):
     def load_labware(
         self,
         load_name: str,
-        location: DeckLocation,
+        location: DeckSlotName,
         label: Optional[str],
         namespace: Optional[str],
         version: Optional[int],

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -1,5 +1,5 @@
 """ProtocolEngine-based Protocol API core implementation."""
-from typing import Dict, Optional
+from typing import Dict, Optional, cast
 
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
@@ -94,7 +94,12 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore]):
             version=version or 1,
             display_name=label,
         )
-        return LabwareCore(labware_id=load_result.labwareId)
+        return LabwareCore(
+            labware_id=load_result.labwareId,
+            definition=cast(
+                LabwareDefinition, load_result.definition.dict(exclude_none=True)
+            ),
+        )
 
     def load_module(
         self,

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -4,13 +4,14 @@ from typing import Dict, Optional
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
-from opentrons.types import Mount, MountType, Location, DeckLocation
+from opentrons.types import Mount, MountType, Location, DeckLocation, DeckSlotName
 from opentrons.hardware_control import SyncHardwareAPI
 from opentrons.hardware_control.modules.types import ModuleModel
 from opentrons.protocols.api_support.util import AxisMaxSpeeds
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.protocols.geometry.deck_item import DeckItem
 
+from opentrons.protocol_engine import DeckSlotLocation
 from opentrons.protocol_engine.clients import SyncClient as ProtocolEngineClient
 
 from ..protocol import AbstractProtocol, LoadModuleResult
@@ -84,7 +85,10 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore]):
         version: Optional[int],
     ) -> LabwareCore:
         """Load a labware using its identifying parameters."""
-        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+        deck_slot = DeckSlotLocation(slotName=DeckSlotName.from_primitive(location))
+        load_result = self._engine_client.load_labware(
+            load_name=load_name, location=deck_slot, namespace=namespace, version=version, display_name=label)
+        return LabwareCore(labware_id=load_result.labwareId)
 
     def load_module(
         self,

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -1,5 +1,5 @@
 """ProtocolEngine-based Protocol API core implementation."""
-from typing import Dict, Optional, cast
+from typing import Dict, Optional
 
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
@@ -96,9 +96,7 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore]):
         )
         return LabwareCore(
             labware_id=load_result.labwareId,
-            definition=cast(
-                LabwareDefinition, load_result.definition.dict(exclude_none=True)
-            ),
+            engine_client=self._engine_client,
         )
 
     def load_module(

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -7,6 +7,7 @@ from opentrons_shared_data.pipette.dev_types import PipetteNameType
 from opentrons.types import Mount, MountType, Location, DeckLocation, DeckSlotName
 from opentrons.hardware_control import SyncHardwareAPI
 from opentrons.hardware_control.modules.types import ModuleModel
+from opentrons.protocols.api_support.constants import OPENTRONS_NAMESPACE
 from opentrons.protocols.api_support.util import AxisMaxSpeeds
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.protocols.geometry.deck_item import DeckItem
@@ -87,7 +88,12 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore]):
         """Load a labware using its identifying parameters."""
         deck_slot = DeckSlotLocation(slotName=DeckSlotName.from_primitive(location))
         load_result = self._engine_client.load_labware(
-            load_name=load_name, location=deck_slot, namespace=namespace, version=version, display_name=label)
+            load_name=load_name,
+            location=deck_slot,
+            namespace=namespace if namespace is not None else OPENTRONS_NAMESPACE,
+            version=version or 1,
+            display_name=label,
+        )
         return LabwareCore(labware_id=load_result.labwareId)
 
     def load_module(

--- a/api/src/opentrons/protocol_api/core/labware.py
+++ b/api/src/opentrons/protocol_api/core/labware.py
@@ -1,16 +1,31 @@
 """The interface that implements InstrumentContext."""
 
 from abc import ABC, abstractmethod
-from typing import Any, Generic, Dict, List, Optional, TypeVar
+from typing import Any, Generic, Dict, List, NamedTuple, Optional, TypeVar
 
 from opentrons.protocols.geometry.deck_item import DeckItem
 from opentrons.protocols.geometry.labware_geometry import AbstractLabwareGeometry
 from opentrons.protocols.api_support.tip_tracker import TipTracker
 from opentrons.protocols.api_support.well_grid import WellGrid
 from opentrons.types import Point
-from opentrons_shared_data.labware.dev_types import LabwareParameters, LabwareDefinition
+from opentrons_shared_data.labware.dev_types import (
+    LabwareParameters as LabwareParametersDict,
+    LabwareDefinition as LabwareDefinitionDict,
+)
 
 from .well import WellCoreType
+
+
+class LabwareLoadParams(NamedTuple):
+    """Unique load parameters of a labware."""
+
+    namespace: str
+    load_name: str
+    version: int
+
+    def as_uri(self) -> str:
+        """Get the labware's definition URI from the load parameters."""
+        return f"{self.namespace}/{self.load_name}/{self.version}"
 
 
 class AbstractLabware(DeckItem, ABC, Generic[WellCoreType]):
@@ -21,11 +36,17 @@ class AbstractLabware(DeckItem, ABC, Generic[WellCoreType]):
         ...
 
     @abstractmethod
-    def get_display_name(self) -> str:
+    def get_load_params(self) -> LabwareLoadParams:
         ...
 
     @abstractmethod
-    def get_label(self) -> Optional[str]:
+    def get_display_name(self) -> str:
+        """Get a display name for the labware, falling back to the definition."""
+        ...
+
+    @abstractmethod
+    def get_user_display_name(self) -> Optional[str]:
+        """Get the user-specified display name of the labware, if set."""
         ...
 
     @abstractmethod
@@ -37,11 +58,12 @@ class AbstractLabware(DeckItem, ABC, Generic[WellCoreType]):
         ...
 
     @abstractmethod
-    def get_definition(self) -> LabwareDefinition:
+    def get_definition(self) -> LabwareDefinitionDict:
+        """Get the labware's definition as a plain dictionary."""
         ...
 
     @abstractmethod
-    def get_parameters(self) -> LabwareParameters:
+    def get_parameters(self) -> LabwareParametersDict:
         ...
 
     @abstractmethod

--- a/api/src/opentrons/protocol_api/core/labware.py
+++ b/api/src/opentrons/protocol_api/core/labware.py
@@ -64,6 +64,7 @@ class AbstractLabware(DeckItem, ABC, Generic[WellCoreType]):
 
     @abstractmethod
     def get_parameters(self) -> LabwareParametersDict:
+        """Get the labware's definition's `parameters` field as a plain dictionary."""
         ...
 
     @abstractmethod

--- a/api/src/opentrons/protocol_api/core/labware_offset_provider.py
+++ b/api/src/opentrons/protocol_api/core/labware_offset_provider.py
@@ -6,6 +6,8 @@ from opentrons.hardware_control.modules import ModuleModel as HardwareModuleMode
 from opentrons.protocol_engine import ProtocolEngine, LabwareOffsetLocation, ModuleModel
 from opentrons.types import DeckSlotName, Point
 
+from .labware import LabwareLoadParams
+
 
 @dataclass
 class ProvidedLabwareOffset:
@@ -27,7 +29,7 @@ class AbstractLabwareOffsetProvider(ABC):
     @abstractmethod
     def find(
         self,
-        labware_definition_uri: str,
+        load_params: LabwareLoadParams,
         requested_module_model: Optional[HardwareModuleModel],
         deck_slot: DeckSlotName,
     ) -> ProvidedLabwareOffset:
@@ -55,7 +57,7 @@ class NullLabwareOffsetProvider(AbstractLabwareOffsetProvider):
 
     def find(
         self,
-        labware_definition_uri: str,
+        load_params: LabwareLoadParams,
         requested_module_model: Optional[HardwareModuleModel],
         deck_slot: DeckSlotName,
     ) -> ProvidedLabwareOffset:
@@ -71,7 +73,7 @@ class LabwareOffsetProvider(AbstractLabwareOffsetProvider):
 
     def find(
         self,
-        labware_definition_uri: str,
+        load_params: LabwareLoadParams,
         requested_module_model: Optional[HardwareModuleModel],
         deck_slot: DeckSlotName,
     ) -> ProvidedLabwareOffset:
@@ -80,7 +82,7 @@ class LabwareOffsetProvider(AbstractLabwareOffsetProvider):
         See the parent class for param details.
         """
         offset = self._labware_view.find_applicable_labware_offset(
-            definition_uri=labware_definition_uri,
+            definition_uri=load_params.as_uri(),
             location=LabwareOffsetLocation(
                 slotName=deck_slot,
                 moduleModel=(

--- a/api/src/opentrons/protocol_api/core/protocol.py
+++ b/api/src/opentrons/protocol_api/core/protocol.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Dict, Generic, Optional
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
-from opentrons.types import Mount, Location, DeckLocation
+from opentrons.types import Mount, Location, DeckLocation, DeckSlotName
 from opentrons.hardware_control import SyncHardwareAPI, SynchronousAdapter
 from opentrons.hardware_control.modules import AbstractModule
 from opentrons.hardware_control.modules.types import ModuleModel, ModuleType
@@ -60,7 +60,7 @@ class AbstractProtocol(ABC, Generic[InstrumentCoreType, LabwareCoreType]):
     def load_labware_from_definition(
         self,
         labware_def: LabwareDefinition,
-        location: DeckLocation,
+        location: DeckSlotName,
         label: Optional[str],
     ) -> LabwareCoreType:
         ...
@@ -69,7 +69,7 @@ class AbstractProtocol(ABC, Generic[InstrumentCoreType, LabwareCoreType]):
     def load_labware(
         self,
         load_name: str,
-        location: DeckLocation,
+        location: DeckSlotName,
         label: Optional[str],
         namespace: Optional[str],
         version: Optional[int],

--- a/api/src/opentrons/protocol_api/core/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/labware.py
@@ -9,7 +9,7 @@ from opentrons.protocols.api_support.well_grid import WellGrid
 from opentrons.types import Point, Location
 from opentrons_shared_data.labware.dev_types import LabwareParameters, LabwareDefinition
 
-from ..labware import AbstractLabware
+from ..labware import AbstractLabware, LabwareLoadParams
 from .well import WellImplementation
 
 
@@ -58,10 +58,17 @@ class LabwareImplementation(AbstractLabware[WellImplementation]):
     def get_uri(self) -> str:
         return helpers.uri_from_definition(self._definition)
 
+    def get_load_params(self) -> LabwareLoadParams:
+        return LabwareLoadParams(
+            namespace=self._definition["namespace"],
+            load_name=self._definition["parameters"]["loadName"],
+            version=self._definition["version"],
+        )
+
     def get_display_name(self) -> str:
         return self._display_name
 
-    def get_label(self) -> Optional[str]:
+    def get_user_display_name(self) -> Optional[str]:
         return self._label
 
     def get_name(self) -> str:

--- a/api/src/opentrons/protocol_api/core/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/protocol_context.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional, Set
 from collections import OrderedDict
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
-from opentrons.types import Mount, Location, DeckLocation
+from opentrons.types import Mount, Location, DeckLocation, DeckSlotName
 from opentrons.hardware_control import SyncHardwareAPI, SynchronousAdapter
 from opentrons.hardware_control.modules import AbstractModule, ModuleModel
 from opentrons.hardware_control.types import DoorState, PauseType
@@ -104,11 +104,11 @@ class ProtocolContextImplementation(
     def load_labware_from_definition(
         self,
         labware_def: LabwareDefinition,
-        location: DeckLocation,
+        location: DeckSlotName,
         label: Optional[str],
     ) -> LabwareImplementation:
         """Load a labware from definition"""
-        parent = self.get_deck().position_for(location)
+        parent = self.get_deck().position_for(location.value)
         labware_obj = load_from_definition(labware_def, parent, label)
         self._deck_layout[location] = labware_obj
         return labware_obj
@@ -116,7 +116,7 @@ class ProtocolContextImplementation(
     def load_labware(
         self,
         load_name: str,
-        location: DeckLocation,
+        location: DeckSlotName,
         label: Optional[str],
         namespace: Optional[str],
         version: Optional[int],

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -11,19 +11,21 @@ from opentrons.hardware_control.types import Axis
 from opentrons.commands import module_commands as cmds
 from opentrons.commands.publisher import CommandPublisher, publish
 from opentrons.protocols.api_support.types import APIVersion
+from opentrons.protocols.api_support.util import requires_version
 
+from opentrons.protocols.geometry.module_geometry import (
+    ModuleGeometry,
+    ThermocyclerGeometry,
+    HeaterShakerGeometry,
+)
+
+from . import validation
 from .module_validation_and_errors import (
     validate_heater_shaker_temperature,
     validate_heater_shaker_speed,
 )
 from .labware import Labware, load, load_from_definition
 from .load_info import LabwareLoadInfo
-from opentrons.protocols.geometry.module_geometry import (
-    ModuleGeometry,
-    ThermocyclerGeometry,
-    HeaterShakerGeometry,
-)
-from opentrons.protocols.api_support.util import requires_version
 
 if TYPE_CHECKING:
     from .protocol_context import ProtocolContext
@@ -95,34 +97,35 @@ class ModuleContext(CommandPublisher, Generic[GeometryType]):
                         :py:meth:`load_labware`.
         :returns: The properly-linked labware object
         """
+        # TODO(mc, 2022-09-02): move to module_core
         mod_labware = self._geometry.add_labware(labware)
-        labware_namespace, labware_load_name, labware_version = labware.uri.split("/")
-        module_loc = self._geometry.parent
 
-        assert isinstance(module_loc, (int, str)), "Unexpected labware object parent"
-        deck_slot = types.DeckSlotName.from_primitive(module_loc)
+        labware_core = mod_labware._implementation
+        deck_slot = validation.ensure_deck_slot(self._geometry.parent)  # type: ignore[arg-type]
+        load_params = labware_core.get_load_params()
 
         provided_offset = self._ctx._labware_offset_provider.find(
-            labware_definition_uri=labware.uri,
+            load_params=load_params,
             requested_module_model=self.requested_as,
             deck_slot=deck_slot,
         )
 
-        labware.set_calibration(provided_offset.delta)
+        labware_core.set_calibration(provided_offset.delta)
         self._ctx._implementation.get_deck().recalculate_high_z()
 
         self._ctx.equipment_broker.publish(
             LabwareLoadInfo(
-                labware_definition=labware._implementation.get_definition(),
-                labware_namespace=labware_namespace,
-                labware_load_name=labware_load_name,
-                labware_version=int(labware_version),
+                labware_definition=labware_core.get_definition(),
+                labware_namespace=load_params.namespace,
+                labware_load_name=load_params.load_name,
+                labware_version=load_params.version,
                 deck_slot=deck_slot,
                 on_module=True,
                 offset_id=provided_offset.offset_id,
-                labware_display_name=labware._implementation.get_label(),
+                labware_display_name=labware_core.get_user_display_name(),
             )
         )
+
         return mod_labware
 
     @requires_version(2, 0)

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -101,6 +101,7 @@ class ProtocolContext(CommandPublisher):
         ],
         labware_offset_provider: AbstractLabwareOffsetProvider,
         broker: Optional[Broker] = None,
+        equipment_broker: Optional[EquipmentBroker[LoadInfo]] = None,
     ) -> None:
         """Build a :py:class:`.ProtocolContext`.
 
@@ -116,6 +117,7 @@ class ProtocolContext(CommandPublisher):
         self._api_version = api_version
         self._implementation = implementation
         self._labware_offset_provider = labware_offset_provider
+        self._equipment_broker = equipment_broker or EquipmentBroker()
 
         if self._api_version > MAX_SUPPORTED_VERSION:
             raise RuntimeError(
@@ -132,8 +134,6 @@ class ProtocolContext(CommandPublisher):
         self._commands: List[str] = []
         self._unsubscribe_commands: Optional[Callable[[], None]] = None
         self.clear_commands()
-
-        self._equipment_broker = EquipmentBroker[LoadInfo]()
 
     @property
     def equipment_broker(self) -> EquipmentBroker[LoadInfo]:
@@ -282,31 +282,34 @@ class ProtocolContext(CommandPublisher):
         # todo(mm, 2021-11-22): The duplication between here and load_labware()
         # is getting bad.
 
-        implementation = self._implementation.load_labware_from_definition(
+        labware_core = self._implementation.load_labware_from_definition(
             labware_def=labware_def, location=location, label=label
         )
-        result = Labware(implementation=implementation)
 
-        result_namespace, result_load_name, result_version = result.uri.split("/")
+        labware_load_params = labware_core.get_load_params()
 
         provided_labware_offset = self._labware_offset_provider.find(
-            labware_definition_uri=result.uri,
+            load_params=labware_load_params,
             requested_module_model=None,
             deck_slot=DeckSlotName.from_primitive(location),
         )
 
-        result.set_calibration(delta=provided_labware_offset.delta)
+        labware_core.set_calibration(provided_labware_offset.delta)
+
+        # TODO(mc, 2022-09-02): add API version
+        # https://opentrons.atlassian.net/browse/RSS-97
+        result = Labware(implementation=labware_core)
 
         self.equipment_broker.publish(
             LabwareLoadInfo(
-                labware_definition=result._implementation.get_definition(),
-                labware_namespace=result_namespace,
-                labware_load_name=result_load_name,
-                labware_version=int(result_version),
+                labware_definition=labware_core.get_definition(),
+                labware_namespace=labware_load_params.namespace,
+                labware_load_name=labware_load_params.load_name,
+                labware_version=labware_load_params.version,
                 deck_slot=DeckSlotName.from_primitive(location),
                 on_module=False,
                 offset_id=provided_labware_offset.offset_id,
-                labware_display_name=implementation.get_label(),
+                labware_display_name=labware_core.get_user_display_name(),
             )
         )
 
@@ -345,36 +348,42 @@ class ProtocolContext(CommandPublisher):
         """
         # todo(mm, 2021-11-22): The duplication between here and
         # load_labware_from_definition() is getting bad.
+        deck_slot = validation.ensure_deck_slot(location)
 
-        implementation = self._implementation.load_labware(
+        labware_core = self._implementation.load_labware(
             load_name=load_name,
-            location=location,
+            location=deck_slot,
             label=label,
             namespace=namespace,
             version=version,
         )
-        result = Labware(implementation=implementation)
 
-        result_namespace, result_load_name, result_version = result.uri.split("/")
+        labware_load_params = labware_core.get_load_params()
 
-        provided_labware_offset = self._labware_offset_provider.find(
-            labware_definition_uri=result.uri,
+        # TODO(mc, 2022-09-02): move labware offset provider to legacy core
+        labware_offset = self._labware_offset_provider.find(
+            load_params=labware_load_params,
+            deck_slot=deck_slot,
             requested_module_model=None,
-            deck_slot=DeckSlotName.from_primitive(location),
         )
 
-        result.set_calibration(delta=provided_labware_offset.delta)
+        labware_core.set_calibration(labware_offset.delta)
 
+        # TODO(mc, 2022-09-02): add API version
+        # https://opentrons.atlassian.net/browse/RSS-97
+        result = Labware(implementation=labware_core)
+
+        # TODO(mc, 2022-09-02): move equipment broker to legacy core
         self.equipment_broker.publish(
             LabwareLoadInfo(
-                labware_definition=result._implementation.get_definition(),
-                labware_namespace=result_namespace,
-                labware_load_name=result_load_name,
-                labware_version=int(result_version),
-                deck_slot=DeckSlotName.from_primitive(location),
+                labware_definition=labware_core.get_definition(),
+                labware_namespace=labware_load_params.namespace,
+                labware_load_name=labware_load_params.load_name,
+                labware_version=labware_load_params.version,
+                deck_slot=deck_slot,
                 on_module=False,
-                offset_id=provided_labware_offset.offset_id,
-                labware_display_name=implementation.get_label(),
+                offset_id=labware_offset.offset_id,
+                labware_display_name=labware_core.get_user_display_name(),
             )
         )
 

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -281,9 +281,10 @@ class ProtocolContext(CommandPublisher):
         """
         # todo(mm, 2021-11-22): The duplication between here and load_labware()
         # is getting bad.
+        deck_slot = validation.ensure_deck_slot(location)
 
         labware_core = self._implementation.load_labware_from_definition(
-            labware_def=labware_def, location=location, label=label
+            labware_def=labware_def, location=deck_slot, label=label
         )
 
         labware_load_params = labware_core.get_load_params()
@@ -291,7 +292,7 @@ class ProtocolContext(CommandPublisher):
         provided_labware_offset = self._labware_offset_provider.find(
             load_params=labware_load_params,
             requested_module_model=None,
-            deck_slot=DeckSlotName.from_primitive(location),
+            deck_slot=deck_slot,
         )
 
         labware_core.set_calibration(provided_labware_offset.delta)
@@ -306,7 +307,7 @@ class ProtocolContext(CommandPublisher):
                 labware_namespace=labware_load_params.namespace,
                 labware_load_name=labware_load_params.load_name,
                 labware_version=labware_load_params.version,
-                deck_slot=DeckSlotName.from_primitive(location),
+                deck_slot=deck_slot,
                 on_module=False,
                 offset_id=provided_labware_offset.offset_id,
                 labware_display_name=labware_core.get_user_display_name(),
@@ -366,7 +367,6 @@ class ProtocolContext(CommandPublisher):
             deck_slot=deck_slot,
             requested_module_model=None,
         )
-
         labware_core.set_calibration(labware_offset.delta)
 
         # TODO(mc, 2022-09-02): add API version

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -1,7 +1,7 @@
 from typing import Union
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
-from opentrons.types import Mount
+from opentrons.types import Mount, DeckSlotName
 
 
 def ensure_mount(mount: Union[str, Mount]) -> Mount:
@@ -34,3 +34,14 @@ def ensure_pipette_name(pipette_name: str) -> PipetteNameType:
         raise ValueError(
             f"Cannot resolve {pipette_name} to pipette, must be given valid pipette name."
         ) from e
+
+
+def ensure_deck_slot(deck_slot: Union[int, str]) -> DeckSlotName:
+    """Ensure that a primitive value matches a named deck slot."""
+    if not isinstance(deck_slot, (int, str)):
+        raise TypeError(f"Deck slot must be a string or integer, but got {deck_slot}")
+
+    try:
+        return DeckSlotName(str(deck_slot))
+    except ValueError as e:
+        raise ValueError(f"'{deck_slot}' is not a valid deck slot") from e

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -34,6 +34,7 @@ class SyncClient:
         load_name: str,
         namespace: str,
         version: int,
+        display_name: Optional[str],
     ) -> commands.LoadLabwareResult:
         """Execute a LoadLabware command and return the result."""
         request = commands.LoadLabwareCreate(
@@ -42,6 +43,7 @@ class SyncClient:
                 loadName=load_name,
                 namespace=namespace,
                 version=version,
+                displayName=display_name,
             )
         )
         result = self._transport.execute_command(request=request)

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -34,7 +34,7 @@ class SyncClient:
         load_name: str,
         namespace: str,
         version: int,
-        display_name: Optional[str],
+        display_name: Optional[str] = None,
     ) -> commands.LoadLabwareResult:
         """Execute a LoadLabware command and return the result."""
         request = commands.LoadLabwareCreate(

--- a/api/src/opentrons/protocol_engine/commands/load_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/load_labware.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
-from opentrons.protocols.models import LabwareDefinition
+from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 
 from ..types import LabwareLocation
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -139,6 +139,7 @@ class LabwareStore(HasState[LabwareState], HandlesActions):
                 loadName=command.result.definition.parameters.loadName,
                 definitionUri=definition_uri,
                 offsetId=command.result.offsetId,
+                displayName=command.params.displayName,
             )
 
             self._state.definitions_by_uri[definition_uri] = command.result.definition
@@ -194,6 +195,10 @@ class LabwareView(HasState[LabwareState]):
         return self.get_definition_by_uri(
             LabwareUri(self.get(labware_id).definitionUri)
         )
+
+    def get_display_name(self, labware_id: str) -> Optional[str]:
+        """Get the labware's user-specified display name, if set."""
+        return self.get(labware_id).displayName
 
     def get_deck_definition(self) -> DeckDefinitionV3:
         """Get the current deck definition."""

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -331,6 +331,10 @@ class LoadedLabware(BaseModel):
             " so the default of (0, 0, 0) will be used."
         ),
     )
+    displayName: Optional[str] = Field(
+        None,
+        description="A user-specified display name for this labware, if provided.",
+    )
 
 
 class Liquid(BaseModel):

--- a/api/src/opentrons/protocols/models/__init__.py
+++ b/api/src/opentrons/protocols/models/__init__.py
@@ -2,11 +2,12 @@
 # More detailed sub-models are always available through the underlying
 # submodules.
 #
-# If re-exporting something, its name should still make sense when it's separatred
+# If re-exporting something, its name should still make sense when it's separated
 # from the name of its parent submodule. e.g. re-exporting models.json_protocol.Labware
 # as models.Labware could be confusing.
 
-# TODO(mc, 2022-03-11): remove this re-export
+# TODO(mc, 2022-03-11): remove this re-export when it won't break pickling
+# https://opentrons.atlassian.net/browse/RSS-94
 from opentrons_shared_data.labware.labware_definition import (
     LabwareDefinition,
     WellDefinition,

--- a/api/tests/opentrons/protocol_api/core/engine/__init__.py
+++ b/api/tests/opentrons/protocol_api/core/engine/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for opentrons.protocol_api.core.engine."""

--- a/api/tests/opentrons/protocol_api/core/engine/test_labware_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_labware_core.py
@@ -1,0 +1,73 @@
+"""Tests for opentrons.protocol_api.core.engine.LabwareCore."""
+from typing import cast
+
+import pytest
+from decoy import Decoy
+
+from opentrons_shared_data.labware.dev_types import LabwareDefinition as LabwareDefDict
+from opentrons_shared_data.labware.labware_definition import (
+    LabwareDefinition,
+    Parameters as LabwareDefinitionParameters,
+)
+
+from opentrons.types import Point
+from opentrons.protocol_engine.clients import SyncClient as EngineClient
+
+from opentrons.protocol_api.core.labware import LabwareLoadParams
+from opentrons.protocol_api.core.engine import LabwareCore
+
+
+@pytest.fixture
+def mock_engine_client(decoy: Decoy) -> EngineClient:
+    """Get a mock ProtocolEngine synchronous client."""
+    return decoy.mock(cls=EngineClient)
+
+
+def test_get_load_params(decoy: Decoy, mock_engine_client: EngineClient) -> None:
+    """It should be able to get the definition's load parameters."""
+    labware_definition = LabwareDefinition.construct(  # type: ignore[call-arg]
+        namespace="hello",
+        version=42,
+        parameters=LabwareDefinitionParameters.construct(loadName="world"),  # type: ignore[call-arg]
+    )
+
+    decoy.when(
+        mock_engine_client.state.labware.get_definition("cool-labware")
+    ).then_return(labware_definition)
+
+    subject = LabwareCore(labware_id="cool-labware", engine_client=mock_engine_client)
+    result = subject.get_load_params()
+
+    assert result == LabwareLoadParams("hello", "world", 42)
+
+
+def test_set_calibration(mock_engine_client: EngineClient) -> None:
+    """It should no-op if calibration is set."""
+    subject = LabwareCore(labware_id="cool-labware", engine_client=mock_engine_client)
+    subject.set_calibration(Point(1, 2, 3))
+
+
+def test_get_definition(decoy: Decoy, mock_engine_client: EngineClient) -> None:
+    """It should get the labware's definition as a dictionary."""
+    labware_definition = LabwareDefinition.construct(namespace="hello")  # type: ignore[call-arg]
+
+    decoy.when(
+        mock_engine_client.state.labware.get_definition("cool-labware")
+    ).then_return(labware_definition)
+
+    subject = LabwareCore(labware_id="cool-labware", engine_client=mock_engine_client)
+    result = subject.get_definition()
+
+    assert result == cast(LabwareDefDict, {"namespace": "hello"})
+
+
+def test_get_user_display_name(decoy: Decoy, mock_engine_client: EngineClient) -> None:
+    """It should get the labware's user-provided label, if any."""
+    decoy.when(
+        mock_engine_client.state.labware.get_display_name("cool-labware")
+    ).then_return("Cool Label")
+
+    subject = LabwareCore(labware_id="cool-labware", engine_client=mock_engine_client)
+    result = subject.get_user_display_name()
+
+    assert result == "Cool Label"

--- a/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
@@ -3,14 +3,16 @@ import pytest
 from decoy import Decoy
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
+from opentrons_shared_data.labware.dev_types import (
+    LabwareDefinition as LabwareDefinitionDict,
+)
 
-from opentrons.types import Mount, MountType
+from opentrons.types import Mount, MountType, DeckSlotName
 from opentrons.protocols.models import LabwareDefinition
 
 from opentrons.protocol_engine import commands
 from opentrons.protocol_engine.clients import SyncClient as EngineClient
-from opentrons.protocol_engine.types import DeckSlotLocation, DeckSlotName
+from opentrons.protocol_engine.types import DeckSlotLocation
 
 from opentrons.protocol_api.core.engine import ProtocolCore, InstrumentCore, LabwareCore
 
@@ -49,7 +51,7 @@ def test_load_instrument(
 
 def test_load_labware(
     decoy: Decoy,
-    minimal_labware_def: LabwareDefinition,
+    minimal_labware_def: LabwareDefinitionDict,
     mock_engine_client: EngineClient,
     subject: ProtocolCore,
 ) -> None:

--- a/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
@@ -3,9 +3,6 @@ import pytest
 from decoy import Decoy
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
-from opentrons_shared_data.labware.dev_types import (
-    LabwareDefinition as LabwareDefinitionDict,
-)
 
 from opentrons.types import Mount, MountType, DeckSlotName
 from opentrons.protocols.models import LabwareDefinition
@@ -51,7 +48,6 @@ def test_load_instrument(
 
 def test_load_labware(
     decoy: Decoy,
-    minimal_labware_def: LabwareDefinitionDict,
     mock_engine_client: EngineClient,
     subject: ProtocolCore,
 ) -> None:
@@ -67,14 +63,14 @@ def test_load_labware(
     ).then_return(
         commands.LoadLabwareResult(
             labwareId="abc123",
-            definition=LabwareDefinition.parse_obj(minimal_labware_def),
+            definition=LabwareDefinition.construct(),  # type: ignore[call-arg]
             offsetId=None,
         )
     )
 
     result = subject.load_labware(
         load_name="some_labware",
-        location="5",
+        location=DeckSlotName.SLOT_5,
         label="some_display_name",  # maps to optional display name
         namespace="some_explicit_namespace",
         version=9001,

--- a/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
@@ -3,10 +3,9 @@ import pytest
 from decoy import Decoy
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 
 from opentrons.types import Mount, MountType, DeckSlotName
-from opentrons.protocols.models import LabwareDefinition
-
 from opentrons.protocol_engine import commands
 from opentrons.protocol_engine.clients import SyncClient as EngineClient
 from opentrons.protocol_engine.types import DeckSlotLocation

--- a/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
@@ -3,11 +3,16 @@ import pytest
 from decoy import Decoy
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.labware.dev_types import LabwareDefinition
+
 from opentrons.types import Mount, MountType
+from opentrons.protocols.models import LabwareDefinition
+
 from opentrons.protocol_engine import commands
 from opentrons.protocol_engine.clients import SyncClient as EngineClient
+from opentrons.protocol_engine.types import DeckSlotLocation, DeckSlotName
 
-from opentrons.protocol_api.core.engine import ProtocolCore, InstrumentCore
+from opentrons.protocol_api.core.engine import ProtocolCore, InstrumentCore, LabwareCore
 
 
 @pytest.fixture
@@ -40,3 +45,38 @@ def test_load_instrument(
 
     assert isinstance(result, InstrumentCore)
     assert result.pipette_id == "cool-pipette"
+
+
+def test_load_labware(
+    decoy: Decoy,
+    minimal_labware_def: LabwareDefinition,
+    mock_engine_client: EngineClient,
+    subject: ProtocolCore,
+) -> None:
+    """It should issue a LoadLabware command."""
+    decoy.when(
+        mock_engine_client.load_labware(
+            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_5),
+            load_name="some_labware",
+            display_name="some_display_name",
+            namespace="some_explicit_namespace",
+            version=9001,
+        )
+    ).then_return(
+        commands.LoadLabwareResult(
+            labwareId="abc123",
+            definition=LabwareDefinition.parse_obj(minimal_labware_def),
+            offsetId=None,
+        )
+    )
+
+    result = subject.load_labware(
+        load_name="some_labware",
+        location="5",
+        label="some_display_name",  # maps to optional display name
+        namespace="some_explicit_namespace",
+        version=9001,
+    )
+
+    assert isinstance(result, LabwareCore)
+    assert result.labware_id == "abc123"

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -6,9 +6,7 @@ import pytest
 from decoy import Decoy, matchers
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
-from opentrons_shared_data.labware.dev_types import (
-    LabwareDefinition as LabwareDefinitionDict,
-)
+from opentrons_shared_data.labware.dev_types import LabwareDefinition as LabwareDefDict
 
 from opentrons.types import Mount, Point, DeckSlotName
 from opentrons.equipment_broker import EquipmentBroker
@@ -155,7 +153,7 @@ def test_load_labware(
     """It should create a labware using its execution core."""
     mock_labware_core = decoy.mock(cls=AbstractLabware)
     labware_load_params = LabwareLoadParams("you", "are", 1337)
-    labware_definition_dict = cast(LabwareDefinitionDict, {"labwareDef": True})
+    labware_definition_dict = cast(LabwareDefDict, {"labwareDef": True})
     labware_offset = ProvidedLabwareOffset(delta=Point(1, 2, 3), offset_id="offset-123")
 
     decoy.when(validation.ensure_deck_slot(42)).then_return(DeckSlotName.SLOT_5)

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -1,11 +1,17 @@
 """Tests for the ProtocolContext public interface."""
 import inspect
+from typing import cast
 
 import pytest
 from decoy import Decoy, matchers
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.labware.dev_types import (
+    LabwareDefinition as LabwareDefinitionDict,
+)
+
 from opentrons.types import Mount, Point, DeckSlotName
+from opentrons.equipment_broker import EquipmentBroker
 from opentrons.protocol_api import (
     MAX_SUPPORTED_VERSION,
     ProtocolContext,
@@ -14,13 +20,18 @@ from opentrons.protocol_api import (
     validation,
 )
 
+from opentrons.protocol_api.load_info import LoadInfo, LabwareLoadInfo
+
 from opentrons.protocol_api.core.protocol import (
     AbstractProtocol as BaseAbstractProtocol,
 )
 from opentrons.protocol_api.core.instrument import (
     AbstractInstrument as BaseAbstractInstrument,
 )
-from opentrons.protocol_api.core.labware import AbstractLabware as BaseAbstractLabware
+from opentrons.protocol_api.core.labware import (
+    AbstractLabware as BaseAbstractLabware,
+    LabwareLoadParams,
+)
 from opentrons.protocol_api.core.well import AbstractWellCore
 from opentrons.protocol_api.core.labware_offset_provider import (
     AbstractLabwareOffsetProvider,
@@ -51,15 +62,23 @@ def mock_labware_offset_provider(decoy: Decoy) -> AbstractLabwareOffsetProvider:
 
 
 @pytest.fixture
+def mock_equipment_broker(decoy: Decoy) -> EquipmentBroker[LoadInfo]:
+    """Get a mock equipment broker."""
+    return decoy.mock(cls=EquipmentBroker)
+
+
+@pytest.fixture
 def subject(
     mock_core: AbstractProtocol,
     mock_labware_offset_provider: AbstractLabwareOffsetProvider,
+    mock_equipment_broker: EquipmentBroker[LoadInfo],
 ) -> ProtocolContext:
     """Get a ProtocolContext test subject with its dependencies mocked out."""
     return ProtocolContext(
         api_version=MAX_SUPPORTED_VERSION,
         implementation=mock_core,
         labware_offset_provider=mock_labware_offset_provider,
+        equipment_broker=mock_equipment_broker,
     )
 
 
@@ -129,36 +148,45 @@ def test_load_instrument_replace(
 def test_load_labware(
     decoy: Decoy,
     mock_labware_offset_provider: AbstractLabwareOffsetProvider,
+    mock_equipment_broker: EquipmentBroker[LoadInfo],
     mock_core: AbstractProtocol,
     subject: ProtocolContext,
 ) -> None:
     """It should create a labware using its execution core."""
     mock_labware_core = decoy.mock(cls=AbstractLabware)
+    labware_load_params = LabwareLoadParams("you", "are", 1337)
+    labware_definition_dict = cast(LabwareDefinitionDict, {"labwareDef": True})
+    labware_offset = ProvidedLabwareOffset(delta=Point(1, 2, 3), offset_id="offset-123")
+
+    decoy.when(validation.ensure_deck_slot(42)).then_return(DeckSlotName.SLOT_5)
 
     decoy.when(
         mock_core.load_labware(
             load_name="some_labware",
-            location=5,
+            location=DeckSlotName.SLOT_5,
             label="some_display_name",
             namespace="some_namespace",
             version=1337,
         )
     ).then_return(mock_labware_core)
 
+    decoy.when(mock_labware_core.load_name).then_return(labware_load_params.load_name)
+    decoy.when(mock_labware_core.get_user_display_name()).then_return("Display Label")
     decoy.when(mock_labware_core.get_name()).then_return("Display Name")
-    decoy.when(mock_labware_core.get_uri()).then_return("you/are/1337")
+    decoy.when(mock_labware_core.get_load_params()).then_return(labware_load_params)
+    decoy.when(mock_labware_core.get_definition()).then_return(labware_definition_dict)
 
     decoy.when(
         mock_labware_offset_provider.find(
-            labware_definition_uri="you/are/1337",
+            load_params=labware_load_params,
             requested_module_model=None,
             deck_slot=DeckSlotName.SLOT_5,
         )
-    ).then_return(ProvidedLabwareOffset(delta=Point(0, 0, 0), offset_id=None))
+    ).then_return(labware_offset)
 
     result = subject.load_labware(
         load_name="some_labware",
-        location=5,
+        location=42,
         label="some_display_name",
         namespace="some_namespace",
         version=1337,
@@ -166,3 +194,21 @@ def test_load_labware(
 
     assert isinstance(result, Labware)
     assert result.name == "Display Name"
+
+    decoy.verify(
+        # TODO(mc, 2022-09-02): labware offset provider to legacy core
+        mock_labware_core.set_calibration(labware_offset.delta),
+        # TODO(mc, 2022-09-02): move equipment broker to legacy core
+        mock_equipment_broker.publish(
+            LabwareLoadInfo(
+                labware_definition=labware_definition_dict,
+                labware_namespace=labware_load_params.namespace,
+                labware_load_name=labware_load_params.load_name,
+                labware_version=labware_load_params.version,
+                deck_slot=DeckSlotName.SLOT_5,
+                on_module=False,
+                offset_id="offset-123",
+                labware_display_name="Display Label",
+            )
+        ),
+    )

--- a/api/tests/opentrons/protocol_api/test_validation.py
+++ b/api/tests/opentrons/protocol_api/test_validation.py
@@ -55,7 +55,7 @@ def test_ensure_pipette_input_invalid() -> None:
     ],
 )
 def test_ensure_deck_slot(input_value: Union[str, int], expected: DeckSlotName) -> None:
-    """It should map strings and ints to DeckSlotName values"""
+    """It should map strings and ints to DeckSlotName values."""
     result = subject.ensure_deck_slot(input_value)
     assert result == expected
 

--- a/api/tests/opentrons/protocol_api_old/core/test_labware_offset_provider.py
+++ b/api/tests/opentrons/protocol_api_old/core/test_labware_offset_provider.py
@@ -17,6 +17,7 @@ from opentrons.protocol_engine import (
 )
 from opentrons.protocol_engine.state import LabwareView
 
+from opentrons.protocol_api.core.labware import LabwareLoadParams
 from opentrons.protocol_api.core.labware_offset_provider import (
     LabwareOffsetProvider,
     ProvidedLabwareOffset,
@@ -66,7 +67,7 @@ def test_find_something(
     )
 
     result = subject.find(
-        labware_definition_uri="some_namespace/some_load_name/123",
+        load_params=LabwareLoadParams("some_namespace", "some_load_name", 123),
         requested_module_model=TemperatureModuleModel.TEMPERATURE_V1,
         deck_slot=DeckSlotName.SLOT_1,
     )
@@ -92,7 +93,7 @@ def test_find_nothing(
     decoy.when(decoy_call_rehearsal).then_return(None)
 
     result = subject.find(
-        labware_definition_uri="some_namespace/some_load_name/123",
+        load_params=LabwareLoadParams("some_namespace", "some_load_name", 123),
         requested_module_model=TemperatureModuleModel.TEMPERATURE_V1,
         deck_slot=DeckSlotName.SLOT_1,
     )

--- a/api/tests/opentrons/protocol_api_old/test_labware_load.py
+++ b/api/tests/opentrons/protocol_api_old/test_labware_load.py
@@ -48,7 +48,7 @@ def test_get_mixed_case_labware_def() -> None:
 def test_load_label(ctx: papi.ProtocolContext) -> None:
     labware = ctx.load_labware(labware_name, "1", "my cool labware")
     assert "my cool labware" in str(labware)
-    assert labware._implementation.get_label() == "my cool labware"
+    assert labware._implementation.get_user_display_name() == "my cool labware"
 
 
 def test_deprecated_load(ctx: papi.ProtocolContext) -> None:

--- a/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
@@ -37,47 +37,43 @@ def subject(transport: AbstractSyncTransport) -> SyncClient:
     return SyncClient(transport=transport)
 
 
-@pytest.fixture
-def stubbed_load_labware_result(
+def test_load_labware(
     decoy: Decoy,
     transport: AbstractSyncTransport,
     tip_rack_def: LabwareDefinition,
-) -> commands.LoadLabwareResult:
-    """Set up the protocol engine with default stubbed response for load labware."""
-    request = commands.LoadLabwareCreate(
+    subject: SyncClient,
+) -> None:
+    """It should execute a load labware command."""
+    expected_request = commands.LoadLabwareCreate(
         params=commands.LoadLabwareParams(
             location=DeckSlotLocation(slotName=DeckSlotName.SLOT_5),
             loadName="some_labware",
             namespace="opentrons",
             version=1,
             labwareId=None,
+            displayName="some_display_name"
         )
     )
 
-    result = commands.LoadLabwareResult(
+    expected_result = commands.LoadLabwareResult(
         labwareId="abc123",
         definition=tip_rack_def,
         offsetId=None,
     )
 
-    decoy.when(transport.execute_command(request=request)).then_return(result)
+    decoy.when(transport.execute_command(request=expected_request)).then_return(
+        expected_result
+    )
 
-    return result
-
-
-def test_load_labware(
-    stubbed_load_labware_result: commands.LoadLabwareResult,
-    subject: SyncClient,
-) -> None:
-    """It should execute a load labware command."""
     result = subject.load_labware(
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_5),
         load_name="some_labware",
         namespace="opentrons",
         version=1,
+        display_name="some_display_name"
     )
 
-    assert result == stubbed_load_labware_result
+    assert result == expected_result
 
 
 def test_load_module(

--- a/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
@@ -51,7 +51,7 @@ def test_load_labware(
             namespace="opentrons",
             version=1,
             labwareId=None,
-            displayName="some_display_name"
+            displayName="some_display_name",
         )
     )
 
@@ -70,7 +70,7 @@ def test_load_labware(
         load_name="some_labware",
         namespace="opentrons",
         version=1,
-        display_name="some_display_name"
+        display_name="some_display_name",
     )
 
     assert result == expected_result

--- a/api/tests/opentrons/protocol_engine/state/command_fixtures.py
+++ b/api/tests/opentrons/protocol_engine/state/command_fixtures.py
@@ -109,6 +109,7 @@ def create_load_labware_command(
     location: LabwareLocation,
     definition: LabwareDefinition,
     offset_id: Optional[str],
+    display_name: Optional[str],
 ) -> cmd.LoadLabware:
     """Create a completed LoadLabware command."""
     params = cmd.LoadLabwareParams(
@@ -117,10 +118,13 @@ def create_load_labware_command(
         version=definition.version,
         location=location,
         labwareId=None,
+        displayName=display_name,
     )
 
     result = cmd.LoadLabwareResult(
-        labwareId=labware_id, definition=definition, offsetId=offset_id
+        labwareId=labware_id,
+        definition=definition,
+        offsetId=offset_id,
     )
 
     return cmd.LoadLabware(

--- a/api/tests/opentrons/protocol_engine/state/test_labware_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_store.py
@@ -118,6 +118,7 @@ def test_handles_load_labware(
         labware_id="test-labware-id",
         definition=well_plate_def,
         offset_id="offset-id",
+        display_name="display-name",
     )
 
     expected_definition_uri = uri_from_details(
@@ -132,6 +133,7 @@ def test_handles_load_labware(
         definitionUri=expected_definition_uri,
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
         offsetId="offset-id",
+        displayName="display-name",
     )
 
     subject.handle_action(

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -28,6 +28,7 @@ plate = LoadedLabware(
     location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
     definitionUri="some-plate-uri",
     offsetId=None,
+    displayName="Fancy Plate Name",
 )
 
 reservoir = LoadedLabware(
@@ -614,3 +615,16 @@ def test_find_applicable_labware_offset() -> None:
         )
         is None
     )
+
+
+def test_get_display_name() -> None:
+    """It should get a labware's user-specified load name"""
+    subject = get_labware_view(
+        labware_by_id={
+            "plate_with_display_name": plate,
+            "reservoir_without_display_name": reservoir,
+        },
+    )
+
+    assert subject.get_display_name("plate_with_display_name") == "Fancy Plate Name"
+    assert subject.get_display_name("reservoir_without_display_name") is None

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -618,7 +618,7 @@ def test_find_applicable_labware_offset() -> None:
 
 
 def test_get_display_name() -> None:
-    """It should get a labware's user-specified load name."""
+    """It should get a labware's user-specified display name."""
     subject = get_labware_view(
         labware_by_id={
             "plate_with_display_name": plate,

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -618,7 +618,7 @@ def test_find_applicable_labware_offset() -> None:
 
 
 def test_get_display_name() -> None:
-    """It should get a labware's user-specified load name"""
+    """It should get a labware's user-specified load name."""
     subject = get_labware_view(
         labware_by_id={
             "plate_with_display_name": plate,

--- a/api/tests/opentrons/protocol_runner/smoke_tests/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/test_protocol_runner.py
@@ -125,6 +125,7 @@ async def test_runner_with_json(json_protocol_file: Path) -> None:
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
         loadName="opentrons_96_tiprack_300ul",
         definitionUri="opentrons/opentrons_96_tiprack_300ul/1",
+        displayName="Opentrons 96 Tip Rack 300 µL",
         # fixme(mm, 2021-11-11): We should smoke-test that the engine picks up labware
         # offsets, but it's unclear to me what the best way of doing that is, since
         # we don't have access to the engine here to add offsets to it.
@@ -236,6 +237,7 @@ async def test_runner_with_legacy_json(legacy_json_protocol_file: Path) -> None:
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
         loadName="opentrons_96_tiprack_300ul",
         definitionUri="opentrons/opentrons_96_tiprack_300ul/1",
+        displayName="Opentrons 96 Tip Rack 300 µL",
         # fixme(mm, 2021-11-11): When legacy running supports labware offsets, check
         # for that here.
         offsetId=None,

--- a/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
@@ -88,21 +88,25 @@ stages:
               - id: fixedTrash
                 loadName: opentrons_1_trash_1100ml_fixed
                 definitionUri: opentrons/opentrons_1_trash_1100ml_fixed/1
+                displayName: Trash
                 location:
                   slotName: '12'
               - id: sourcePlateId
                 loadName: foo_8_plate_33ul
                 definitionUri: example/foo_8_plate_33ul/1
+                displayName: Source Plate
                 location:
                   moduleId: temperatureModuleId
               - id: destPlateId
                 loadName: foo_8_plate_33ul
                 definitionUri: example/foo_8_plate_33ul/1
+                displayName: Sample Collection Plate
                 location:
                   moduleId: magneticModuleId
               - id: tipRackId
                 loadName: opentrons_96_tiprack_10ul
                 definitionUri: opentrons/opentrons_96_tiprack_10ul/1
+                displayName: Opentrons 96 Tip Rack 10 µL
                 location:
                   slotName: '8'
             commands:
@@ -231,12 +235,12 @@ stages:
                 key: !anystr
                 status: succeeded
                 params:
-                  liquidId: "waterId"
-                  labwareId: "sourcePlateId"
+                  liquidId: 'waterId'
+                  labwareId: 'sourcePlateId'
                   volumeByWell:
                     A1: 100
                     B1: 100
-                result: { }
+                result: {}
                 startedAt: !anystr
                 completedAt: !anystr
               - id: !anystr


### PR DESCRIPTION
# Overview

Closes RCORE-101

This PR adds `load_labware` support to `ProtocolEngine`-based PAPIv2 core, in addition to fleshing out a minimal `LabwareCore` with mostly non-implemented methods. 

# Changelog

- Adds `load_labware` implementation to PE-based PAPIv2 core
- Adds enough methods to `LabwareCore` for labware loading to work, leaving the rest as `NotImplementedError`

# Review requests

More detailed acceptance testing information in ticket

- [ ] Smoke test load_labware with python protocol with feature flag on
    - Only `ctx.load_labware` will work
    - Verify all optional parameters may be included / omitted
- [ ] Smoke test load_labware with python protocol with feature flag off
    - [ ] `ctx.load_labware`
    - [ ] `ctx.load_labware_from_definition`
    - [ ] `module_ctx.load_labware`
    - [ ] `module_ctx.load_labware_from_definition`

# Risk assessment

Medium, change is contained within feature flag, but some minor architectural changes were made:

- Added user-provided display name ("label") tracking to ProtocolEngine state
- Minor changes made to `AbstractLabware` core interface, requiring changes to existing PAPIv2 core
    - Core can return the URI as structured data rather than a string to improve data flows
    - Renamed `get_label` to `get_user_display_name` to remove ambiguity

These changes also bubbled into labware-on-module loading in a way that ensured existing tests stayed passing. However, caught one large, existing bug while working on this PR (RSS-97), that the existing tests did not catch, so the existing test suite probably can't be super relied upon.