### PR TITLE
refactor(app): design QA for Attach/Detach flows

### DIFF
--- a/app/src/assets/localization/en/change_pipette.json
+++ b/app/src/assets/localization/en/change_pipette.json
@@ -7,7 +7,7 @@
   "remove_pipette": "<h1>Remove the pipette</h1><block>Hold onto the pipette so it does not fall. Disconnect the pipette from the robot by pulling the white connector tab.</block>",
   "confirm_detachment": "Confirm detachment",
   "confirming_detachment": "Confirming detachment",
-  "confirming_attachment": "COnfirming attachmend",
+  "confirming_attachment": "Confirming attachment",
   "continue": "Continue",
   "go_back": "Go back",
   "confirm_attachment": "Confirm attachment",

--- a/app/src/assets/localization/en/change_pipette.json
+++ b/app/src/assets/localization/en/change_pipette.json
@@ -17,7 +17,7 @@
   "tighten_screws_single": "Starting with screw #1, tighten the screws with a clockwise motion.",
   "tighten_screws_multi": "<block>Starting with screw #1, <strong>loosely</strong> tighten the screws with a clockwise motion. You will tighten them fully in a later step.</block>",
   "attach_pipette_type": "Attach a {{pipetteName}} Pipette",
-  "level_the_pipette": "<h1>Level the pipette</h1><block>Using your hand, <strong>gently and slowly</strong> push the pipette up.</block><block>Place the calibration block in slot1/3 with the tall/short surface on the left/right side.</block><block>Pull the pipette down so <strong>all 8 nozzles touch</strong> the surface of the block.</block><block>While <strong>holding the pipette down,</strong> tighten the three screws.</block><block>Gently and slowly push the pipette back up.</block>",
+  "level_the_pipette": "<h1>Level the pipette</h1><block>Using your hand, <strong>gently and slowly</strong> push the pipette up.</block><block>Place the calibration block in slot 1/3 with the tall/short surface on the left/right side.</block><block>Pull the pipette down so <strong>all 8 nozzles touch</strong> the surface of the block.</block><block>While <strong>holding the pipette down,</strong> tighten the three screws.</block><block>Gently and slowly push the pipette back up.</block>",
   "confirm_level": "Confirm level",
   "pipette_movement": "{{mount}} pipette carriage moving {{location}}.",
   "to_front_right": "to front right",

--- a/app/src/assets/localization/en/change_pipette.json
+++ b/app/src/assets/localization/en/change_pipette.json
@@ -6,6 +6,8 @@
   "loosen_the_screws": "<h1>Loosen the screws</h1><block>Using a 2.5 mm screwdriver, loosen the three screws on the back of the pipette that is currently attached.</block>",
   "remove_pipette": "<h1>Remove the pipette</h1><block>Hold onto the pipette so it does not fall. Disconnect the pipette from the robot by pulling the white connector tab.</block>",
   "confirm_detachment": "Confirm detachment",
+  "confirming_detachment": "Confirming detachment",
+  "confirming_attachment": "COnfirming attachmend",
   "continue": "Continue",
   "go_back": "Go back",
   "confirm_attachment": "Confirm attachment",

--- a/app/src/assets/localization/en/shared.json
+++ b/app/src/assets/localization/en/shared.json
@@ -38,6 +38,6 @@
   "a_software_update_is_available": "A software update is available for this robot. Update to run protocols.",
   "robot_is_busy_no_protocol_run_allowed": "This robot is busy and can’t run this protocol right now. <robotLink>Go to Robot</robotLink>",
   "reanalyze": "Reanalyze",
-  "step": "Step: {{current}} / {{max}}",
+  "step": "Step {{current}} / {{max}}",
   "none": "None"
 }

--- a/app/src/atoms/SelectField/Select.tsx
+++ b/app/src/atoms/SelectField/Select.tsx
@@ -122,6 +122,8 @@ export function Select(props: SelectComponentProps): JSX.Element {
       marginLeft: SPACING.spacingSS,
       color: COLORS.darkBlackEnabled,
       fontSize: TYPOGRAPHY.fontSizeP,
+      marginTop: '0.2rem',
+
     }),
     singleValue: (styles: CSSObjectWithLabel) => ({
       ...styles,

--- a/app/src/atoms/SelectField/Select.tsx
+++ b/app/src/atoms/SelectField/Select.tsx
@@ -127,6 +127,7 @@ export function Select(props: SelectComponentProps): JSX.Element {
       ...styles,
       marginRight: '0.75rem',
       marginLeft: SPACING.spacing2,
+      marginTop: '0.2rem',
     }),
     valueContainer: NO_STYLE_FN,
   }

--- a/app/src/atoms/SelectField/Select.tsx
+++ b/app/src/atoms/SelectField/Select.tsx
@@ -123,7 +123,6 @@ export function Select(props: SelectComponentProps): JSX.Element {
       color: COLORS.darkBlackEnabled,
       fontSize: TYPOGRAPHY.fontSizeP,
       marginTop: '0.2rem',
-
     }),
     singleValue: (styles: CSSObjectWithLabel) => ({
       ...styles,

--- a/app/src/atoms/SelectField/Select.tsx
+++ b/app/src/atoms/SelectField/Select.tsx
@@ -10,7 +10,6 @@ import {
   DIRECTION_ROW,
   POSITION_RELATIVE,
   POSITION_ABSOLUTE,
-  SIZE_1,
 } from '@opentrons/components'
 
 import type {
@@ -83,17 +82,20 @@ export function Select(props: SelectComponentProps): JSX.Element {
       ...styles,
       backgroundColor: COLORS.white,
       width: props.width != null ? props.width : 'auto',
-      boxShadow: '0px 1px 3px rgba(0, 0, 0, 0.2)',
+      boxShadowcha: '0px 1px 3px rgba(0, 0, 0, 0.2)',
       borderRadius: '4px 4px 0px 0px',
       marginTop: SPACING.spacing2,
       fontSize: TYPOGRAPHY.fontSizeP,
     }),
     menuList: (styles: CSSObjectWithLabel) => ({
       ...styles,
-      maxHeight: '38vh',
+      maxHeight: '55vh',
       overflowY: 'scroll',
     }),
-    menuPortal: NO_STYLE_FN,
+    menuPortal: (styles: CSSObjectWithLabel) => ({
+      ...styles,
+      zIndex: 10,
+    }),
     multiValue: NO_STYLE_FN,
     multiValueLabel: NO_STYLE_FN,
     multiValueRemove: NO_STYLE_FN,
@@ -149,18 +151,15 @@ function DropdownIndicator(
     <components.DropdownIndicator {...props}>
       <Box
         position={POSITION_ABSOLUTE}
-        top="0.75rem"
-        right={SPACING.spacing2}
+        top="0.55rem"
+        right={SPACING.spacing3}
         width={SPACING.spacingM}
       >
-        <Icon
-          name={
-            Boolean(props.selectProps.menuIsOpen)
-              ? 'chevron-up'
-              : 'chevron-down'
-          }
-          height={SIZE_1}
-        />
+        {Boolean(props.selectProps.menuIsOpen) ? (
+          <Icon transform="rotate(180deg)" name="menu-down" height="1.25rem" />
+        ) : (
+          <Icon name="menu-down" height="1.25rem" />
+        )}
       </Box>
     </components.DropdownIndicator>
   )

--- a/app/src/atoms/StepMeter/index.tsx
+++ b/app/src/atoms/StepMeter/index.tsx
@@ -34,10 +34,10 @@ export const StepMeter = (props: StepMeterProps): JSX.Element => {
     height: 100%;
     background-color: ${COLORS.blueEnabled};
     width: ${percentComplete};
-    webkit-transition: width 1s ease-in-out;
-    moz-transition: width 1s ease-in-out;
-    o-transition: width 1s ease-in-out;
-    transition: width 1s ease-in-out;
+    webkit-transition: width 0.5s ease-in-out;
+    moz-transition: width 0.5s ease-in-out;
+    o-transition: width 0.5s ease-in-out;
+    transition: width 0.5s ease-in-out;
   `
 
   return (

--- a/app/src/molecules/InProgressModal/InProgressModal.tsx
+++ b/app/src/molecules/InProgressModal/InProgressModal.tsx
@@ -18,12 +18,11 @@ export function InProgressModal(props: Props): JSX.Element {
     <Flex
       alignItems={ALIGN_CENTER}
       flexDirection={DIRECTION_COLUMN}
-      height="100%"
-      transform="translateY(75%)"
+      marginY="8.25rem"
     >
       <Icon
         name="ot-spinner"
-        size="5.1rem"
+        size="5.125rem"
         color={COLORS.darkGreyEnabled}
         aria-label="spinner"
         spin

--- a/app/src/molecules/InProgressModal/InProgressModal.tsx
+++ b/app/src/molecules/InProgressModal/InProgressModal.tsx
@@ -18,7 +18,7 @@ export function InProgressModal(props: Props): JSX.Element {
     <Flex
       alignItems={ALIGN_CENTER}
       flexDirection={DIRECTION_COLUMN}
-      marginY="8.25rem"
+      marginY="8rem"
     >
       <Icon
         name="ot-spinner"

--- a/app/src/molecules/PipetteSelect/index.tsx
+++ b/app/src/molecules/PipetteSelect/index.tsx
@@ -77,8 +77,11 @@ export const PipetteSelect = (props: PipetteSelectProps): JSX.Element => {
     <Select
       isSearchable={false}
       options={groupedOptions}
+      menuPortalTarget={document.body}
+      styles={{ menuPortal: base => ({ ...base, zIndex: 10 }) }}
       value={value}
       defaultValue={defaultValue}
+      width="14rem"
       tabIndex={tabIndex}
       onChange={(
         option: SingleValue<SelectOption> | MultiValue<SelectOption>,

--- a/app/src/molecules/SimpleWizardBody/index.tsx
+++ b/app/src/molecules/SimpleWizardBody/index.tsx
@@ -27,8 +27,8 @@ export function SimpleWizardBody(props: Props): JSX.Element {
         alignItems={ALIGN_CENTER}
         flexDirection={DIRECTION_COLUMN}
         height="100%"
-        marginBottom="6.3125rem"
-        marginTop="6.75rem"
+        marginBottom="5.6875rem"
+        marginTop="6.8125rem"
       >
         <Icon
           name={isSuccess ? 'ot-check' : 'ot-alert'}
@@ -43,7 +43,14 @@ export function SimpleWizardBody(props: Props): JSX.Element {
         >
           {header}
         </StyledText>
-        <StyledText as="p">{subHeader}</StyledText>
+        <StyledText
+          as="p"
+          marginX={SPACING.spacing6}
+          textAlign={ALIGN_CENTER}
+          height="1.75rem"
+        >
+          {subHeader}
+        </StyledText>
       </Flex>
       <Flex
         paddingX={SPACING.spacing6}

--- a/app/src/molecules/SimpleWizardBody/index.tsx
+++ b/app/src/molecules/SimpleWizardBody/index.tsx
@@ -45,7 +45,7 @@ export function SimpleWizardBody(props: Props): JSX.Element {
         </StyledText>
         <StyledText
           as="p"
-          marginX={SPACING.spacing6}
+          marginX="6.25rem"
           textAlign={ALIGN_CENTER}
           height="1.75rem"
         >

--- a/app/src/molecules/SimpleWizardBody/index.tsx
+++ b/app/src/molecules/SimpleWizardBody/index.tsx
@@ -6,6 +6,7 @@ import {
   Icon,
   JUSTIFY_FLEX_END,
   SPACING,
+  TYPOGRAPHY,
 } from '@opentrons/components'
 import { StyledText } from '../../atoms/text'
 
@@ -26,17 +27,17 @@ export function SimpleWizardBody(props: Props): JSX.Element {
         alignItems={ALIGN_CENTER}
         flexDirection={DIRECTION_COLUMN}
         height="100%"
-        marginTop="5.8rem"
-        marginBottom="5.68rem"
+        marginBottom="6.3125rem"
+        marginTop="6.75rem"
       >
         <Icon
           name={isSuccess ? 'ot-check' : 'ot-alert'}
-          size="4rem"
+          size="2.5rem"
           color={iconColor}
           aria-label={isSuccess ? 'ot-check' : 'ot-alert'}
         />
         <StyledText
-          as="h1"
+          css={TYPOGRAPHY.h1Default}
           marginTop={SPACING.spacing5}
           marginBottom={SPACING.spacing3}
         >

--- a/app/src/molecules/WizardHeader/WizardHeader.stories.tsx
+++ b/app/src/molecules/WizardHeader/WizardHeader.stories.tsx
@@ -18,3 +18,18 @@ Primary.args = {
   currentStep: 2,
   title: 'Tip Length Calibration',
 }
+
+export const CurrentStepZero = Template.bind({})
+CurrentStepZero.args = {
+  totalSteps: 5,
+  currentStep: 0,
+  title: 'Tip Length Calibration',
+}
+
+export const ErrorState = Template.bind({})
+ErrorState.args = {
+  totalSteps: 5,
+  currentStep: 1,
+  isErrorState: true,
+  title: 'Tip Length Calibration',
+}

--- a/app/src/molecules/WizardHeader/__tests__/WizardHeader.test.tsx
+++ b/app/src/molecules/WizardHeader/__tests__/WizardHeader.test.tsx
@@ -38,10 +38,10 @@ describe('WizardHeader', () => {
     fireEvent.click(exit)
     expect(props.onExit).toHaveBeenCalled()
     getByText('step meter')
-    getByText('Step: 1 / 5')
+    getByText('Step 1 / 5')
   })
 
-  it('renders correct information with no step count visible', () => {
+  it('renders correct information with no step count visible due to currentStep = 0', () => {
     props = {
       ...props,
       currentStep: 0,
@@ -50,6 +50,19 @@ describe('WizardHeader', () => {
     const { getByText, getByRole } = render(props)
     getByText('Tip Length Calibrations')
     getByRole('button', { name: 'Exit' })
-    expect(screen.queryByText('Step: 0 / 5')).not.toBeInTheDocument()
+    expect(screen.queryByText('Step 0 / 5')).not.toBeInTheDocument()
+  })
+
+  it('renders correct information with no step count visible due to error state', () => {
+    props = {
+      ...props,
+      currentStep: 1,
+      isErrorState: true,
+    }
+
+    const { getByText, getByRole } = render(props)
+    getByText('Tip Length Calibrations')
+    getByRole('button', { name: 'Exit' })
+    expect(screen.queryByText('Step 1 / 5')).not.toBeInTheDocument()
   })
 })

--- a/app/src/molecules/WizardHeader/index.tsx
+++ b/app/src/molecules/WizardHeader/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
+import { css } from 'styled-components'
 import {
   Box,
   Btn,
@@ -17,12 +18,33 @@ interface WizardHeaderProps {
   totalSteps: number
   currentStep: number | null
   title: string
+  isErrorState?: boolean
   onExit?: () => void
 }
 
+const EXIT_BUTTON_STYLE = css`
+  ${TYPOGRAPHY.pSemiBold};
+  text-transform: ${TYPOGRAPHY.textTransformCapitalize};
+  color: ${COLORS.darkGreyEnabled};
+
+  &:hover {
+    opacity: 70%;
+  }
+`
 export const WizardHeader = (props: WizardHeaderProps): JSX.Element => {
-  const { totalSteps, currentStep, title, onExit } = props
+  const { totalSteps, currentStep, title, isErrorState, onExit } = props
   const { t } = useTranslation('shared')
+
+  let stepCounter: JSX.Element | null = null
+  if (isErrorState) {
+    stepCounter = null
+  } else if (currentStep != null && currentStep > 0) {
+    stepCounter = (
+      <StyledText css={TYPOGRAPHY.pSemiBold} color={COLORS.darkGreyEnabled}>
+        {t('step', { current: currentStep, max: totalSteps })}
+      </StyledText>
+    )
+  }
 
   return (
     <Box backgroundColor={COLORS.white}>
@@ -35,24 +57,11 @@ export const WizardHeader = (props: WizardHeaderProps): JSX.Element => {
           <StyledText css={TYPOGRAPHY.pSemiBold} marginRight={SPACING.spacing3}>
             {title}
           </StyledText>
-          {currentStep != null && currentStep > 0 ? (
-            <StyledText
-              css={TYPOGRAPHY.pSemiBold}
-              color={COLORS.darkGreyEnabled}
-            >
-              {t('step', { current: currentStep, max: totalSteps })}
-            </StyledText>
-          ) : null}
+          {stepCounter}
         </Flex>
         {onExit != null ? (
           <Btn onClick={onExit} aria-label="Exit">
-            <StyledText
-              css={TYPOGRAPHY.pSemiBold}
-              textTransform={TYPOGRAPHY.textTransformCapitalize}
-              color={COLORS.darkGreyEnabled}
-            >
-              {t('exit')}
-            </StyledText>
+            <StyledText css={EXIT_BUTTON_STYLE}>{t('exit')}</StyledText>
           </Btn>
         ) : null}
       </Flex>

--- a/app/src/organisms/ChangePipette/CheckPipettesButton.tsx
+++ b/app/src/organisms/ChangePipette/CheckPipettesButton.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { useSelector } from 'react-redux'
+import { useTranslation } from 'react-i18next'
 import {
   useDispatchApiRequests,
   getRequestById,
@@ -8,32 +9,44 @@ import {
 } from '../../redux/robot-api'
 import { useFeatureFlag } from '../../redux/config'
 import { fetchPipettes, FETCH_PIPETTES } from '../../redux/pipettes'
+import { StyledText } from '../../atoms/text'
 import {
   PrimaryButton as DeprecatedPrimaryButton,
   Icon,
   DIRECTION_ROW,
-  SPACING,
   Flex,
   COLORS,
   ALIGN_CENTER,
+  SPACING,
 } from '@opentrons/components'
 import { PrimaryButton } from '../../atoms/buttons'
 
 import type { State } from '../../redux/types'
 import type { RequestState } from '../../redux/robot-api/types'
+import type { PipetteModelSpecs } from '@opentrons/shared-data'
 
 export interface CheckPipetteButtonProps {
   robotName: string
-  children: React.ReactNode
+  children?: React.ReactNode
   className?: string
   hidden?: boolean
+  actualPipette?: PipetteModelSpecs
   onDone?: () => void
 }
 
 export function CheckPipettesButton(
   props: CheckPipetteButtonProps
 ): JSX.Element | null {
-  const { robotName, onDone, children, className, hidden = false } = props
+  const {
+    robotName,
+    onDone,
+    children,
+    className,
+    actualPipette,
+    hidden = false,
+  } = props
+  const { t } = useTranslation('change_pipette')
+
   const enableChangePipetteWizard = useFeatureFlag('enableChangePipetteWizard')
   const fetchPipettesRequestId = React.useRef<string | null>(null)
   const [dispatch] = useDispatchApiRequests(dispatchedAction => {
@@ -53,7 +66,7 @@ export function CheckPipettesButton(
       ? getRequestById(state, fetchPipettesRequestId.current)
       : null
   )?.status
-  const pending = requestStatus === PENDING
+  const isPending = requestStatus === PENDING
 
   React.useEffect(() => {
     if (requestStatus === SUCCESS && onDone) onDone()
@@ -62,10 +75,10 @@ export function CheckPipettesButton(
   const displayButton = hidden ? null : (
     <DeprecatedPrimaryButton
       onClick={handleClick}
-      disabled={pending}
+      disabled={isPending}
       className={className}
     >
-      {pending ? <Icon name="ot-spinner" height="1rem" spin /> : children}
+      {isPending ? <Icon name="ot-spinner" height="1rem" spin /> : children}
     </DeprecatedPrimaryButton>
   )
 
@@ -76,15 +89,25 @@ export function CheckPipettesButton(
         color={COLORS.white}
         alignItems={ALIGN_CENTER}
       >
-        {pending ? (
-          <Icon
-            name="ot-spinner"
-            height="1rem"
-            spin
-            marginRight={SPACING.spacing2}
-          />
-        ) : null}
-        {children}
+        {isPending ? (
+          <>
+            <Icon
+              name="ot-spinner"
+              height="1rem"
+              spin
+              marginRight={SPACING.spacing3}
+            />
+            <StyledText>
+              {actualPipette
+                ? t('confirming_detachment')
+                : t('confirming_attachment')}
+            </StyledText>
+          </>
+        ) : actualPipette ? (
+          t('confirm_detachment')
+        ) : (
+          t('confirm_attachment')
+        )}
       </Flex>
     </PrimaryButton>
   ) : (

--- a/app/src/organisms/ChangePipette/CheckPipettesButton.tsx
+++ b/app/src/organisms/ChangePipette/CheckPipettesButton.tsx
@@ -89,7 +89,9 @@ export function CheckPipettesButton(
         color={COLORS.white}
         alignItems={ALIGN_CENTER}
       >
-        {isPending ? (
+        {children != null ? (
+          children
+        ) : isPending ? (
           <>
             <Icon
               name="ot-spinner"

--- a/app/src/organisms/ChangePipette/ClearDeckModal/index.tsx
+++ b/app/src/organisms/ChangePipette/ClearDeckModal/index.tsx
@@ -5,6 +5,7 @@ import {
   Flex,
   SPACING,
   JUSTIFY_FLEX_END,
+  TYPOGRAPHY,
 } from '@opentrons/components'
 import { StyledText } from '../../../atoms/text'
 import { PrimaryButton } from '../../../atoms/buttons'
@@ -21,15 +22,20 @@ export function ClearDeckModal(props: ClearDeckModalProps): JSX.Element {
     <>
       <Flex
         flexDirection={DIRECTION_COLUMN}
-        marginBottom="12.25rem"
         paddingX={SPACING.spacing6}
         paddingTop={SPACING.spacing6}
+        marginBottom="13.375rem"
       >
         <Trans
           t={t}
           i18nKey="remove_labware_before_start"
           components={{
-            h1: <StyledText as="h1" marginBottom={SPACING.spacing4} />,
+            h1: (
+              <StyledText
+                css={TYPOGRAPHY.h1Default}
+                marginBottom={SPACING.spacing4}
+              />
+            ),
             block: <StyledText as="p" />,
           }}
         />

--- a/app/src/organisms/ChangePipette/InstructionStep.tsx
+++ b/app/src/organisms/ChangePipette/InstructionStep.tsx
@@ -34,13 +34,21 @@ export function InstructionStep(props: Props): JSX.Element {
 
   return (
     <Flex justifyContent={JUSTIFY_SPACE_EVENLY}>
-      <Box marginRight={SPACING.spacingXXL}>{children}</Box>
-      <img
-        src={display}
-        height={diagram === 'tab' ? '100%' : '270px'}
-        width="275px"
-        alt={`${direction}-${mount}-${channelsKey}-${displayCategory}-${diagram}`}
-      />
+      <Box marginRight={SPACING.spacingXXL} width="18.6875rem">
+        {children}
+      </Box>
+      <Box
+        marginTop={diagram === 'tab' ? '4.1875rem' : '0.75rem'}
+        marginLeft={diagram === 'tab' ? '1.5625rem' : SPACING.spacingXXL}
+        marginRight={SPACING.spacing6}
+      >
+        <img
+          src={display}
+          height={diagram === 'tab' ? '100%' : '245px'}
+          width={diagram === 'tab' ? '240px' : '200px'}
+          alt={`${direction}-${mount}-${channelsKey}-${displayCategory}-${diagram}`}
+        />
+      </Box>
     </Flex>
   )
 }

--- a/app/src/organisms/ChangePipette/Instructions.tsx
+++ b/app/src/organisms/ChangePipette/Instructions.tsx
@@ -90,9 +90,11 @@ export function Instructions(props: Props): JSX.Element {
         <Flex
           paddingX={SPACING.spacing6}
           paddingTop={SPACING.spacing6}
-          marginBottom="12.9rem"
+          marginBottom="12.8rem"
         >
-          {direction === 'attach' && wantedPipette === null ? (
+          {direction === 'attach' &&
+          stepPage === 0 &&
+          wantedPipette === null ? (
             <PipetteSelection onPipetteChange={setWantedName} />
           ) : null}
         </Flex>
@@ -160,7 +162,7 @@ export function Instructions(props: Props): JSX.Element {
             marginX={SPACING.spacing6}
             alignSelf={ALIGN_FLEX_END}
             //  spacing changes to keep buttons at same height across pages
-            marginTop={stepPage === 0 ? SPACING.spacing5 : '9.25rem'}
+            marginTop={stepPage === 0 ? SPACING.spacing6 : '5.9rem'}
           >
             <Btn
               onClick={stepPage === 0 ? back : () => setStepPage(stepPage - 1)}

--- a/app/src/organisms/ChangePipette/Instructions.tsx
+++ b/app/src/organisms/ChangePipette/Instructions.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { css } from 'styled-components'
 import { Trans, useTranslation } from 'react-i18next'
 import { shouldLevel } from '@opentrons/shared-data'
 import {
@@ -40,6 +41,16 @@ interface Props {
   stepPage: number
   setStepPage: React.Dispatch<React.SetStateAction<number>>
 }
+
+const GO_BACK_BUTTON_STYLE = css`
+  ${TYPOGRAPHY.pSemiBold};
+  text-transform: ${TYPOGRAPHY.textTransformCapitalize};
+  color: ${COLORS.darkGreyEnabled};
+
+  &:hover {
+    opacity: 70%;
+  }
+`
 
 export function Instructions(props: Props): JSX.Element {
   const {
@@ -104,7 +115,10 @@ export function Instructions(props: Props): JSX.Element {
                     i18nKey={stepPage === 0 ? stepOne : stepTwo}
                     components={{
                       h1: (
-                        <StyledText as="h1" marginBottom={SPACING.spacing4} />
+                        <StyledText
+                          css={TYPOGRAPHY.h1Default}
+                          marginBottom={SPACING.spacing4}
+                        />
                       ),
                       block: <StyledText as="p" />,
                     }}
@@ -139,24 +153,19 @@ export function Instructions(props: Props): JSX.Element {
             marginX={SPACING.spacing6}
             alignSelf={ALIGN_FLEX_END}
             //  spacing changes to keep buttons at same height across pages
-            marginTop={stepPage === 0 ? SPACING.spacingSS : '8rem'}
+            marginTop={stepPage === 0 ? SPACING.spacing5 : '9.25rem'}
           >
             <Btn
               onClick={stepPage === 0 ? back : () => setStepPage(stepPage - 1)}
             >
-              <StyledText
-                css={TYPOGRAPHY.pSemiBold}
-                textTransform={TYPOGRAPHY.textTransformCapitalize}
-                color={COLORS.darkGreyEnabled}
-              >
-                {t('go_back')}
-              </StyledText>
+              <StyledText css={GO_BACK_BUTTON_STYLE}>{t('go_back')}</StyledText>
             </Btn>
             {stepPage === 0 ? (
               continueButton
             ) : (
               <CheckPipettesButton
                 robotName={robotName}
+                actualPipette={actualPipette ?? undefined}
                 onDone={
                   wantedPipette != null &&
                   actualPipette != null &&
@@ -164,11 +173,7 @@ export function Instructions(props: Props): JSX.Element {
                     ? () => setStepPage(2)
                     : confirm
                 }
-              >
-                {actualPipette
-                  ? t('confirm_detachment')
-                  : t('confirm_attachment')}
-              </CheckPipettesButton>
+              />
             )}
           </Flex>
         </>

--- a/app/src/organisms/ChangePipette/Instructions.tsx
+++ b/app/src/organisms/ChangePipette/Instructions.tsx
@@ -92,7 +92,7 @@ export function Instructions(props: Props): JSX.Element {
           paddingTop={SPACING.spacing6}
           marginBottom="12.9rem"
         >
-          {direction === 'attach' ? (
+          {direction === 'attach' && wantedPipette === null ? (
             <PipetteSelection onPipetteChange={setWantedName} />
           ) : null}
         </Flex>
@@ -123,6 +123,7 @@ export function Instructions(props: Props): JSX.Element {
                       block: <StyledText as="p" />,
                     }}
                   />
+
                   {direction === 'attach' && stepPage === 0 ? (
                     channels === 8 ? (
                       <Flex flexDirection={DIRECTION_ROW}>
@@ -130,7 +131,13 @@ export function Instructions(props: Props): JSX.Element {
                           t={t}
                           i18nKey="tighten_screws_multi"
                           components={{
-                            strong: <strong />,
+                            strong: (
+                              <strong
+                                style={{
+                                  fontWeight: TYPOGRAPHY.fontWeightSemiBold,
+                                }}
+                              />
+                            ),
                             block: (
                               <StyledText as="p" marginTop={SPACING.spacing4} />
                             ),
@@ -182,7 +189,7 @@ export function Instructions(props: Props): JSX.Element {
           mount={mount}
           pipetteModelName={actualPipette ? actualPipette.name : ''}
           confirm={confirm}
-          back={back}
+          back={() => setStepPage(1)}
         />
       )}
     </>

--- a/app/src/organisms/ChangePipette/LevelPipette.tsx
+++ b/app/src/organisms/ChangePipette/LevelPipette.tsx
@@ -72,11 +72,9 @@ export function LevelPipette(props: LevelPipetteProps): JSX.Element {
               t={t}
               i18nKey={'level_the_pipette'}
               components={{
-                bold: (
+                strong: (
                   <strong
-                    style={{
-                      fontWeight: TYPOGRAPHY.fontWeightSemiBold,
-                    }}
+                    style={{ fontWeight: TYPOGRAPHY.fontWeightSemiBold }}
                   />
                 ),
                 h1: (

--- a/app/src/organisms/ChangePipette/LevelPipette.tsx
+++ b/app/src/organisms/ChangePipette/LevelPipette.tsx
@@ -33,8 +33,8 @@ function LevelingVideo(props: {
   return (
     <video
       css={css`
-        width: 100%;
-        max-height: 15rem;
+        width: 275px;
+        max-height: 270px;
         margin-top: ${SPACING.spacing4};
         margin-left: ${SPACING.spacing4};
       `}
@@ -65,8 +65,9 @@ export function LevelPipette(props: LevelPipetteProps): JSX.Element {
         <Flex
           flexDirection={DIRECTION_ROW}
           justifyContent={JUSTIFY_SPACE_BETWEEN}
+          marginBottom="40px"
         >
-          <Flex flexDirection={DIRECTION_COLUMN} marginRight="0.2rem">
+          <Flex flexDirection={DIRECTION_COLUMN}>
             <Trans
               t={t}
               i18nKey={'level_the_pipette'}

--- a/app/src/organisms/ChangePipette/LevelPipette.tsx
+++ b/app/src/organisms/ChangePipette/LevelPipette.tsx
@@ -72,7 +72,12 @@ export function LevelPipette(props: LevelPipetteProps): JSX.Element {
               i18nKey={'level_the_pipette'}
               components={{
                 bold: <strong />,
-                h1: <StyledText as="h1" marginBottom={SPACING.spacing4} />,
+                h1: (
+                  <StyledText
+                    css={TYPOGRAPHY.h1Default}
+                    marginBottom={SPACING.spacing4}
+                  />
+                ),
                 block: (
                   <StyledText
                     css={css`

--- a/app/src/organisms/ChangePipette/LevelPipette.tsx
+++ b/app/src/organisms/ChangePipette/LevelPipette.tsx
@@ -66,12 +66,18 @@ export function LevelPipette(props: LevelPipetteProps): JSX.Element {
           flexDirection={DIRECTION_ROW}
           justifyContent={JUSTIFY_SPACE_BETWEEN}
         >
-          <Flex flexDirection={DIRECTION_COLUMN}>
+          <Flex flexDirection={DIRECTION_COLUMN} marginRight="0.2rem">
             <Trans
               t={t}
               i18nKey={'level_the_pipette'}
               components={{
-                bold: <strong />,
+                bold: (
+                  <strong
+                    style={{
+                      fontWeight: TYPOGRAPHY.fontWeightSemiBold,
+                    }}
+                  />
+                ),
                 h1: (
                   <StyledText
                     css={TYPOGRAPHY.h1Default}

--- a/app/src/organisms/ChangePipette/PipetteSelection.tsx
+++ b/app/src/organisms/ChangePipette/PipetteSelection.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Flex, DIRECTION_COLUMN, SPACING } from '@opentrons/components'
+import {
+  Flex,
+  DIRECTION_COLUMN,
+  SPACING,
+  TYPOGRAPHY,
+} from '@opentrons/components'
 import { OT3_PIPETTES } from '@opentrons/shared-data'
 import { StyledText } from '../../atoms/text'
 import { PipetteSelect } from '../../molecules/PipetteSelect'
@@ -11,14 +16,16 @@ export function PipetteSelection(props: PipetteSelectionProps): JSX.Element {
   const { t } = useTranslation('change_pipette')
   return (
     <Flex flexDirection={DIRECTION_COLUMN}>
-      <StyledText as="h1" marginBottom={SPACING.spacing5}>
+      <StyledText css={TYPOGRAPHY.h1Default} marginBottom={SPACING.spacing5}>
         {t('choose_pipette')}
       </StyledText>
-      <PipetteSelect
-        pipetteName={props.pipetteName}
-        onPipetteChange={props.onPipetteChange}
-        nameBlocklist={OT3_PIPETTES}
-      />
+      <Flex marginBottom="1.2rem">
+        <PipetteSelect
+          pipetteName={props.pipetteName}
+          onPipetteChange={props.onPipetteChange}
+          nameBlocklist={OT3_PIPETTES}
+        />
+      </Flex>
     </Flex>
   )
 }

--- a/app/src/organisms/ChangePipette/__tests__/ChangePipette.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/ChangePipette.test.tsx
@@ -174,7 +174,6 @@ describe('ChangePipette', () => {
 
     //  Instructions page
     getByText('Attach a pipette')
-    getByText('Step: 1 / 3')
     getByText('mock pipette selection')
     exit = getByLabelText('Exit')
     fireEvent.click(exit)
@@ -182,7 +181,7 @@ describe('ChangePipette', () => {
     //  Exit modal page
     getByText('mock exit modal')
     getByText('Attach a pipette')
-    getByText('Step: 1 / 3')
+    getByText('Step 1 / 3')
     exit = getByLabelText('Exit')
     fireEvent.click(exit)
     expect(props.closeModal).toHaveBeenCalled()
@@ -212,7 +211,6 @@ describe('ChangePipette', () => {
 
     //  Instructions page
     getByText('Attach a pipette')
-    getByText('Step: 1 / 3')
 
     //  attach the pipette
     act(() => {
@@ -253,7 +251,7 @@ describe('ChangePipette', () => {
 
     //  Instructions page 1
     getByText('Detach P300 Single GEN2 from Left Mount')
-    getByText('Step: 1 / 3')
+    getByText('Step 1 / 3')
     getByText('Loosen the screws')
     getByText(
       'Using a 2.5 mm screwdriver, loosen the three screws on the back of the pipette that is currently attached.'
@@ -263,7 +261,7 @@ describe('ChangePipette', () => {
 
     //  Instructions page 2
     getByText('Detach P300 Single GEN2 from Left Mount')
-    getByText('Step: 2 / 3')
+    getByText('Step 2 / 3')
     getByText('Remove the pipette')
     getByText(
       'Hold onto the pipette so it does not fall. Disconnect the pipette from the robot by pulling the white connector tab.'
@@ -274,7 +272,7 @@ describe('ChangePipette', () => {
 
     //  Exit modal page
     getByText('Detach P300 Single GEN2 from Left Mount')
-    getByText('Step: 2 / 3')
+    getByText('Step 2 / 3')
     getByText('mock exit modal')
     const exitModal = getByLabelText('Exit')
     fireEvent.click(exitModal)

--- a/app/src/organisms/ChangePipette/__tests__/ChangePipette.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/ChangePipette.test.tsx
@@ -89,6 +89,7 @@ const mockInProgress = InProgressModal as jest.MockedFunction<
 const mockConfirmPipette = ConfirmPipette as jest.MockedFunction<
   typeof ConfirmPipette
 >
+
 const mockExitModal = ExitModal as jest.MockedFunction<typeof ExitModal>
 
 const render = (props: React.ComponentProps<typeof ChangePipette>) => {
@@ -181,7 +182,6 @@ describe('ChangePipette', () => {
     //  Exit modal page
     getByText('mock exit modal')
     getByText('Attach a pipette')
-    getByText('Step 1 / 3')
     exit = getByLabelText('Exit')
     fireEvent.click(exit)
     expect(props.closeModal).toHaveBeenCalled()

--- a/app/src/organisms/ChangePipette/__tests__/ChangePipette.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/ChangePipette.test.tsx
@@ -182,9 +182,6 @@ describe('ChangePipette', () => {
     //  Exit modal page
     getByText('mock exit modal')
     getByText('Attach a pipette')
-    exit = getByLabelText('Exit')
-    fireEvent.click(exit)
-    expect(props.closeModal).toHaveBeenCalled()
   })
 
   it('the go back button functions as expected', () => {
@@ -274,9 +271,6 @@ describe('ChangePipette', () => {
     getByText('Detach P300 Single GEN2 from Left Mount')
     getByText('Step 2 / 3')
     getByText('mock exit modal')
-    const exitModal = getByLabelText('Exit')
-    fireEvent.click(exitModal)
-    expect(props.closeModal).toHaveBeenCalled()
   })
 
   it('renders the wizard pages for detaching a single channel pipette and goes through the whole flow', () => {

--- a/app/src/organisms/ChangePipette/__tests__/CheckPipettesButton.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/CheckPipettesButton.test.tsx
@@ -92,4 +92,16 @@ describe('CheckPipettesButton', () => {
     fireEvent.click(btn)
     expect(dispatchApiRequest).toBeCalledWith(mockFetchPipettes('otie'))
   })
+
+  it('renders the confirm detachment btn with ff and with children and clicking on it calls fetchPipettes', () => {
+    props = {
+      ...props,
+      actualPipette: MOCK_ACTUAL_PIPETTE,
+    }
+    const { getByLabelText, getByText } = render(props)
+    const btn = getByLabelText('Confirm')
+    getByText('btn text')
+    fireEvent.click(btn)
+    expect(dispatchApiRequest).toBeCalledWith(mockFetchPipettes('otie'))
+  })
 })

--- a/app/src/organisms/ChangePipette/__tests__/CheckPipettesButton.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/CheckPipettesButton.test.tsx
@@ -3,10 +3,12 @@ import { fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../i18n'
 import * as RobotApi from '../../../redux/robot-api'
+import { mockPipetteInfo } from '../../../redux/pipettes/__fixtures__'
 import { useFeatureFlag } from '../../../redux/config'
 import { fetchPipettes } from '../../../redux/pipettes'
 import { CheckPipettesButton } from '../CheckPipettesButton'
 import type { DispatchApiRequestType } from '../../../redux/robot-api'
+import type { PipetteModelSpecs } from '@opentrons/shared-data'
 
 jest.mock('../../../redux/robot-api')
 jest.mock('../../../redux/pipettes')
@@ -21,11 +23,23 @@ const mockUseDispatchApiRequests = RobotApi.useDispatchApiRequests as jest.Mocke
 const mockFeatureFlag = useFeatureFlag as jest.MockedFunction<
   typeof useFeatureFlag
 >
+const mockGetRequestById = RobotApi.getRequestById as jest.MockedFunction<
+  typeof RobotApi.getRequestById
+>
 const render = (props: React.ComponentProps<typeof CheckPipettesButton>) => {
   return renderWithProviders(<CheckPipettesButton {...props} />, {
     i18nInstance: i18n,
   })[0]
 }
+
+const MOCK_ACTUAL_PIPETTE = {
+  ...mockPipetteInfo.pipetteSpecs,
+  model: 'model',
+  tipLength: {
+    value: 20,
+  },
+} as PipetteModelSpecs
+
 describe('CheckPipettesButton', () => {
   let props: React.ComponentProps<typeof CheckPipettesButton>
   let dispatchApiRequest: DispatchApiRequestType
@@ -37,20 +51,45 @@ describe('CheckPipettesButton', () => {
       onDone: jest.fn(),
     }
     dispatchApiRequest = jest.fn()
-    mockFeatureFlag.mockReturnValue(false)
+    mockFeatureFlag.mockReturnValue(true)
+    mockGetRequestById.mockReturnValue(null)
     mockUseDispatchApiRequests.mockReturnValue([dispatchApiRequest, ['id']])
   })
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
   it('renders the button without ff and clicking on it calls fetchPipettes', () => {
+    mockFeatureFlag.mockReturnValue(false)
     const { getByRole } = render(props)
     const btn = getByRole('button', { name: 'btn text' })
     fireEvent.click(btn)
-    expect(mockFetchPipettes).toHaveBeenCalled()
+    expect(dispatchApiRequest).toBeCalledWith(mockFetchPipettes('otie'))
   })
-  it('renders the button with ff and clicking on it calls fetchPipettes', () => {
-    mockFeatureFlag.mockReturnValue(true)
-    const { getByLabelText } = render(props)
+  it('renders the confirm attachment btn with ff and clicking on it calls fetchPipettes', () => {
+    props = {
+      robotName: 'otie',
+      hidden: false,
+      onDone: jest.fn(),
+    }
+    const { getByLabelText, getByText } = render(props)
     const btn = getByLabelText('Confirm')
+    getByText('Confirm attachment')
     fireEvent.click(btn)
-    expect(mockFetchPipettes).toHaveBeenCalled()
+    expect(dispatchApiRequest).toBeCalledWith(mockFetchPipettes('otie'))
+  })
+
+  it('renders the confirm detachment btn with ff and clicking on it calls fetchPipettes', () => {
+    props = {
+      robotName: 'otie',
+      hidden: false,
+      onDone: jest.fn(),
+      actualPipette: MOCK_ACTUAL_PIPETTE,
+    }
+    const { getByLabelText, getByText } = render(props)
+    const btn = getByLabelText('Confirm')
+    getByText('Confirm detachment')
+    fireEvent.click(btn)
+    expect(dispatchApiRequest).toBeCalledWith(mockFetchPipettes('otie'))
   })
 })

--- a/app/src/organisms/ChangePipette/__tests__/LevelPipette.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/LevelPipette.test.tsx
@@ -75,7 +75,7 @@ describe('LevelPipette', () => {
     )
     getByText(
       nestedTextMatcher(
-        'Place the calibration block in slot1/3 with the tall/short surface on the left/right side.'
+        'Place the calibration block in slot 1/3 with the tall/short surface on the left/right side.'
       )
     )
     getByText(

--- a/app/src/organisms/ChangePipette/index.tsx
+++ b/app/src/organisms/ChangePipette/index.tsx
@@ -263,7 +263,7 @@ export function ChangePipette(props: Props): JSX.Element | null {
       title = attachWizardHeader
     }
 
-    exitWizardHeader = confirmExit ? closeModal : () => setConfirmExit(true)
+    exitWizardHeader = confirmExit ? undefined : () => setConfirmExit(true)
     currentStep = instructionsCurrentStep
     wizardTitle = title
 
@@ -306,7 +306,8 @@ export function ChangePipette(props: Props): JSX.Element | null {
         ? EIGHT_CHANNEL_STEPS
         : SINGLE_CHANNEL_STEPS
       : SINGLE_CHANNEL_STEPS - 1
-    exitWizardHeader = success ? homePipAndExit : () => setConfirmExit(true)
+    exitWizardHeader =
+      success || confirmExit ? undefined : () => setConfirmExit(true)
 
     wizardTitle =
       (wantedPipette == null && actualPipette == null) ||

--- a/app/src/organisms/ChangePipette/index.tsx
+++ b/app/src/organisms/ChangePipette/index.tsx
@@ -172,7 +172,8 @@ export function ChangePipette(props: Props): JSX.Element | null {
   )
   const eightChannel = wantedPipette?.channels === 8
   const direction = actualPipette ? DETACH : ATTACH
-  const isSelectPipetteStep = direction === ATTACH && wantedName === null
+  const isSelectPipetteStep =
+    direction === ATTACH && wantedName === null && wizardStep === INSTRUCTIONS
 
   const exitModal = (
     <ExitModal

--- a/app/src/organisms/ChangePipette/index.tsx
+++ b/app/src/organisms/ChangePipette/index.tsx
@@ -3,7 +3,7 @@ import { useSelector, useDispatch } from 'react-redux'
 import { useHistory } from 'react-router-dom'
 import { getPipetteNameSpecs, shouldLevel } from '@opentrons/shared-data'
 import { useTranslation } from 'react-i18next'
-import { SPACING } from '@opentrons/components'
+import { SPACING, TYPOGRAPHY } from '@opentrons/components'
 import {
   useDispatchApiRequests,
   getRequestById,
@@ -172,6 +172,8 @@ export function ChangePipette(props: Props): JSX.Element | null {
   )
   const eightChannel = wantedPipette?.channels === 8
   const direction = actualPipette ? DETACH : ATTACH
+  const isSelectPipetteStep = direction === ATTACH && wantedName === null
+
   const exitModal = (
     <ExitModal
       back={() => setConfirmExit(false)}
@@ -192,6 +194,12 @@ export function ChangePipette(props: Props): JSX.Element | null {
     }
   }
 
+  const success =
+    // success if we were trying to detach and nothing's attached
+    (!actualPipette && !wantedPipette) ||
+    // or if the names of wanted and attached match
+    actualPipette?.name === wantedPipette?.name
+
   let exitWizardHeader
   let wizardTitle: string =
     actualPipette?.displayName != null
@@ -207,7 +215,7 @@ export function ChangePipette(props: Props): JSX.Element | null {
     contents = (
       <InProgressModal>
         <StyledText
-          as="h1"
+          css={TYPOGRAPHY.h1Default}
           marginTop={SPACING.spacing5}
           marginBottom={SPACING.spacing3}
         >
@@ -282,12 +290,6 @@ export function ChangePipette(props: Props): JSX.Element | null {
       />
     )
   } else if (wizardStep === CONFIRM) {
-    const success =
-      // success if we were trying to detach and nothing's attached
-      (!actualPipette && !wantedPipette) ||
-      // or if the names of wanted and attached match
-      actualPipette?.name === wantedPipette?.name
-
     const attachedIncorrectPipette = Boolean(
       !success && wantedPipette && actualPipette
     )
@@ -337,10 +339,11 @@ export function ChangePipette(props: Props): JSX.Element | null {
 
   if (enableChangePipetteWizard) {
     return (
-      <ModalShell height="28.12rem" width="47rem">
+      <ModalShell width="42.375rem">
         <WizardHeader
           totalSteps={eightChannel ? EIGHT_CHANNEL_STEPS : SINGLE_CHANNEL_STEPS}
-          currentStep={currentStep}
+          currentStep={isSelectPipetteStep ? 0 : currentStep}
+          isErrorState={!success && wizardStep === CONFIRM}
           title={wizardTitle}
           onExit={exitWizardHeader}
         />


### PR DESCRIPTION
closes RLIQ-122

# Overview

addresses the design QA feedback provided by Mel for the Attach/Detach pipette flows. Touches `ChangePipette` and children components as well as a few tweaks to `WizardHeader` and `Select`

# Changelog

- make adjustments to `ChangePipette` and children components
- extend prop in `WizardHeader` to account for if you hit an error state. During an error state, the step counter is not shown
- adjust top margin in `Select` component that is shared between channel, networking tab, and pipette selection
- adjust `StepMeter` animation speed
- add hover state to `WizardHeader` exit button
- adjust spacings to be exact from Design System

# Review requests

- review the changes I made to the shared components (particularly `Select`, `StepMeter` and `WizardHeader`)
- go through the flow with and without FF turned on to make sure legacy flow still looks the same
- test out where the `Select` is being used to make sure it looks correct in all locations

# Risk assessment

low