### PR TITLE
feat(hardware): ot3: set per-axis max speeds

### DIFF
--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -83,10 +83,7 @@ DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad
         OT3AxisKind.X: 600,
         OT3AxisKind.Y: 600,
     },
-    gripper={
-        OT3AxisKind.Z: 350,
-        OT3AxisKind.Z_G: 200
-    },
+    gripper={OT3AxisKind.Z: 350, OT3AxisKind.Z_G: 200},
 )
 
 DEFAULT_ACCELERATIONS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad(

--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -64,20 +64,20 @@ DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad
         OT3AxisKind.X: 120,
         OT3AxisKind.Y: 120,
         OT3AxisKind.Z: 20,
-        OT3AxisKind.P: 100,
+        OT3AxisKind.P: 45,
         OT3AxisKind.Z_G: 50,
     },
     high_throughput={
         OT3AxisKind.X: 120,
         OT3AxisKind.Y: 120,
         OT3AxisKind.Z: 20,
-        OT3AxisKind.P: 100,
+        OT3AxisKind.P: 45,
     },
     low_throughput={
         OT3AxisKind.X: 120,
         OT3AxisKind.Y: 120,
         OT3AxisKind.Z: 20,
-        OT3AxisKind.P: 100,
+        OT3AxisKind.P: 45,
     },
     two_low_throughput={
         OT3AxisKind.X: 120,

--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -61,30 +61,31 @@ DEFAULT_Z_RETRACT_DISTANCE: Final = 2
 
 DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad(
     none={
-        OT3AxisKind.X: 120,
-        OT3AxisKind.Y: 120,
-        OT3AxisKind.Z: 20,
+        OT3AxisKind.X: 600,
+        OT3AxisKind.Y: 600,
+        OT3AxisKind.Z: 350,
         OT3AxisKind.P: 45,
-        OT3AxisKind.Z_G: 50,
+        OT3AxisKind.Z_G: 200,
     },
     high_throughput={
-        OT3AxisKind.X: 120,
-        OT3AxisKind.Y: 120,
-        OT3AxisKind.Z: 20,
+        OT3AxisKind.X: 600,
+        OT3AxisKind.Y: 600,
+        OT3AxisKind.Z: 350,
         OT3AxisKind.P: 45,
     },
     low_throughput={
-        OT3AxisKind.X: 120,
-        OT3AxisKind.Y: 120,
-        OT3AxisKind.Z: 20,
+        OT3AxisKind.X: 600,
+        OT3AxisKind.Y: 600,
+        OT3AxisKind.Z: 350,
         OT3AxisKind.P: 45,
     },
     two_low_throughput={
-        OT3AxisKind.X: 120,
-        OT3AxisKind.Y: 120,
+        OT3AxisKind.X: 600,
+        OT3AxisKind.Y: 600,
     },
     gripper={
-        OT3AxisKind.Z: 20,
+        OT3AxisKind.Z: 350,
+        OT3AxisKind.Z_G: 200
     },
 )
 
@@ -181,30 +182,30 @@ DEFAULT_DIRECTION_CHANGE_SPEED_DISCONTINUITY: Final[
 
 DEFAULT_HOLD_CURRENT: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad(
     none={
-        OT3AxisKind.X: 0.1,
+        OT3AxisKind.X: 1.0,
         OT3AxisKind.Y: 0.1,
         OT3AxisKind.Z: 0.1,
         OT3AxisKind.P: 0.1,
         OT3AxisKind.Z_G: 0.1,
     },
     high_throughput={
-        OT3AxisKind.X: 0.1,
+        OT3AxisKind.X: 1.0,
         OT3AxisKind.Y: 0.1,
         OT3AxisKind.Z: 0.1,
         OT3AxisKind.P: 0.1,
     },
     low_throughput={
-        OT3AxisKind.X: 0.1,
+        OT3AxisKind.X: 1.0,
         OT3AxisKind.Y: 0.1,
         OT3AxisKind.Z: 0.1,
         OT3AxisKind.P: 0.1,
     },
     two_low_throughput={
-        OT3AxisKind.X: 0.1,
+        OT3AxisKind.X: 1.0,
         OT3AxisKind.Y: 0.1,
     },
     gripper={
-        OT3AxisKind.Z: 0.1,
+        OT3AxisKind.Z: 1.0,
     },
 )
 

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -181,6 +181,7 @@ def get_system_constraints(
                 conf_by_pip["acceleration"][axis_kind],
                 conf_by_pip["max_speed_discontinuity"][axis_kind],
                 conf_by_pip["direction_change_speed_discontinuity"][axis_kind],
+                conf_by_pip["default_max_speed"][axis_kind],
             )
     return constraints
 

--- a/api/tests/opentrons/config/ot3_settings.py
+++ b/api/tests/opentrons/config/ot3_settings.py
@@ -55,7 +55,7 @@ ot3_dummy_settings = {
                 "Z": 2,
                 "P": 1,
             },
-            "gripper": {"Z": 2.8},
+            "gripper": {"Z": 2.8, "Z_G": 5},
         },
         "max_speed_discontinuity": {
             "none": {

--- a/hardware/opentrons_hardware/hardware_control/motion_planning/move_manager.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/move_manager.py
@@ -40,7 +40,9 @@ class MoveManager(Generic[AxisKey]):
         target_list: List[MoveTarget[AxisKey]],
     ) -> List[Move[AxisKey]]:
         """Create a list of moves from the target list for blending."""
-        initial_moves = list(move_utils.targets_to_moves(origin, target_list))
+        initial_moves = list(
+            move_utils.targets_to_moves(origin, target_list, self._constraints)
+        )
         return self._add_dummy_start_end_to_moves(initial_moves)
 
     def _add_dummy_start_end_to_moves(

--- a/hardware/opentrons_hardware/hardware_control/motion_planning/move_utils.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/move_utils.py
@@ -55,8 +55,36 @@ def get_unit_vector(
     return unit_vector, distance
 
 
+def limit_max_speed(
+    unit_vector: Coordinates[AxisKey, np.float64],
+    max_linear_speed: np.float64,
+    constraints: SystemConstraints[AxisKey],
+) -> np.float64:
+    """Limit a linear speed to fall inside the max speed of any component.
+
+    The most-limiting max speed is a combination of the smallest-value max
+    speed for an axis and the value of that axis' unit vector component.
+    """
+    requested_axis_speeds = unit_vector_multiplication(unit_vector, max_linear_speed)
+    scale = np.float64(1)
+    for axis, speed in requested_axis_speeds.items():
+        if speed == 0.0:
+            continue
+        abs_speed = np.abs(speed)
+        axis_speed = constraints[axis].max_speed
+        axis_ratio = axis_speed / abs_speed
+        if axis_ratio < scale:
+            log.info(
+                f"speed {max_linear_speed} decreased by {axis_ratio} because {axis} speed limit is {axis_speed}"
+            )
+            scale = axis_ratio
+    return max_linear_speed * scale
+
+
 def targets_to_moves(
-    initial: Coordinates[AxisKey, CoordinateValue], targets: List[MoveTarget[AxisKey]]
+    initial: Coordinates[AxisKey, CoordinateValue],
+    targets: List[MoveTarget[AxisKey]],
+    constraints: SystemConstraints[AxisKey],
 ) -> Iterator[Move[AxisKey]]:
     """Transform a list of MoveTargets into a list of Moves."""
     all_axes: Set[AxisKey] = set()
@@ -67,25 +95,26 @@ def targets_to_moves(
     for target in targets:
         position = {k: np.float64(target.position.get(k, 0)) for k in all_axes}
         unit_vector, distance = get_unit_vector(initial_checked, position)
+        speed = limit_max_speed(unit_vector, target.max_speed, constraints)
         third_distance = np.float64(distance / 3)
         m = Move(
             unit_vector=unit_vector,
             distance=distance,
-            max_speed=target.max_speed,
+            max_speed=speed,
             blocks=(
                 Block(
                     distance=third_distance,
-                    initial_speed=target.max_speed,
+                    initial_speed=speed,
                     acceleration=np.float64(0),
                 ),
                 Block(
                     distance=third_distance,
-                    initial_speed=target.max_speed,
+                    initial_speed=speed,
                     acceleration=np.float64(0),
                 ),
                 Block(
                     distance=third_distance,
-                    initial_speed=target.max_speed,
+                    initial_speed=speed,
                     acceleration=np.float64(0),
                 ),
             ),

--- a/hardware/opentrons_hardware/hardware_control/motion_planning/types.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/types.py
@@ -211,6 +211,7 @@ class AxisConstraints:
     max_acceleration: np.float64
     max_speed_discont: np.float64
     max_direction_change_speed_discont: np.float64
+    max_speed: np.float64
 
     @classmethod
     def build(
@@ -218,6 +219,7 @@ class AxisConstraints:
         max_acceleration: CoordinateValue,
         max_speed_discont: CoordinateValue,
         max_direction_change_speed_discont: CoordinateValue,
+        max_speed: CoordinateValue,
     ) -> AxisConstraints:
         """Build AxisConstraints."""
         return cls(
@@ -226,6 +228,7 @@ class AxisConstraints:
             max_direction_change_speed_discont=np.float64(
                 max_direction_change_speed_discont
             ),
+            max_speed=np.float64(max_speed),
         )
 
 

--- a/hardware/tests/opentrons_hardware/hardware_control/test_motion_plan.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_motion_plan.py
@@ -27,6 +27,7 @@ def generate_axis_constraint(draw: st.DrawFn) -> AxisConstraints:
         max_acceleration=acc,
         max_speed_discont=speed_dist,
         max_direction_change_speed_discont=dir_change_dist,
+        max_speed=500,
     )
 
 


### PR DESCRIPTION
Currently, we can specify a linear speed that an individual move cannot
exceed. This limit is generally given by higher level code and is more
about scientific concerns (avoiding shaking, for instance) than about
robotics concerns.

However, there are also speed limits that are based on robotics
concerns. Any given axis has a speed it may not exceed due to physical
limits - the speed at which its dynamic friction overcomes its available
torque, the speed at which it's no longer possible to represent that
speed correctly in binary, etc - and that limit, too, must be
represented.

These speeds are properly part of an axis's constraints, so we add them
there.

We can implement the speed limit by making the input speed provisioned
on each Move object the smaller of the linear speed limit and the
projected axis-speed-limit-based value when we make a new Move object at
the beginning of a blend pass.

This happens by decomposing the linear speed through the move's unit
vector and comparing each component to the individual axis limit. If the
limit is lower, we can apply ratio between the axis speed limit and the
axis linear speed component to scale down the given speed.

Then, we can use the per-axis max speed values we've always had (and that have
been silently ignored) to actually provision the system constraints.

Closes RCORE-125