### PR TITLE
fix(api): ensure pipette cannot move down from origin to travel height

### DIFF
--- a/api/src/opentrons/motion_planning/waypoints.py
+++ b/api/src/opentrons/motion_planning/waypoints.py
@@ -92,7 +92,7 @@ def get_waypoints(
     # if either of those exceed max_travel_z, just use max_travel_z
     # if max_travel_z does not provide enough clearance, check above would
     # raise an ArcOutOfBoundsError
-    # if origin.z is higher than the selected travel z, travel at origin z instead
+    # if origin.z is higher than the selected travel z, travel at origin.z instead
     travel_z = max(
         min(max_travel_z, max(min_travel_z + travel_z_margin, dest.z)),
         origin.z,

--- a/api/src/opentrons/protocols/geometry/planning.py
+++ b/api/src/opentrons/protocols/geometry/planning.py
@@ -213,7 +213,7 @@ def plan_moves(
     force_direct: bool = False,
     minimum_lw_z_margin: float = None,
     minimum_z_height: float = None,
-    use_experimental_waypoint_planning: bool = False,
+    use_experimental_waypoint_planning: bool = True,
 ) -> List[Tuple[types.Point, Optional[CriticalPoint]]]:
     """Plan moves between one :py:class:`.Location` and another.
 

--- a/api/src/opentrons/protocols/geometry/planning.py
+++ b/api/src/opentrons/protocols/geometry/planning.py
@@ -213,7 +213,7 @@ def plan_moves(
     force_direct: bool = False,
     minimum_lw_z_margin: float = None,
     minimum_z_height: float = None,
-    use_experimental_waypoint_planning: bool = True,
+    use_experimental_waypoint_planning: bool = False,
 ) -> List[Tuple[types.Point, Optional[CriticalPoint]]]:
     """Plan moves between one :py:class:`.Location` and another.
 

--- a/api/tests/opentrons/motion_planning/test_waypoints.py
+++ b/api/tests/opentrons/motion_planning/test_waypoints.py
@@ -42,7 +42,7 @@ def test_get_waypoints_in_labware_arc() -> None:
     ]
 
 
-def test_get_waypoints_in_labware_arc_with_high_origin() -> None:
+def test_get_waypoints_in_labware_arc_with_high_dest() -> None:
     """It should favor dest height over travel z if point is higher."""
     result = get_waypoints(
         origin=Point(1, 1, 10),
@@ -59,7 +59,7 @@ def test_get_waypoints_in_labware_arc_with_high_origin() -> None:
     ]
 
 
-def test_get_waypoints_in_labware_arc_with_high_dest() -> None:
+def test_get_waypoints_in_labware_arc_with_high_origin() -> None:
     """It should favor origin height over travel z if point is higher."""
     result = get_waypoints(
         origin=Point(1, 1, 11),
@@ -73,6 +73,23 @@ def test_get_waypoints_in_labware_arc_with_high_dest() -> None:
     assert result == [
         Waypoint(Point(2, 2, 11)),
         Waypoint(Point(2, 2, 10)),
+    ]
+
+
+def test_get_waypoints_in_labware_arc_with_extra_high_origin() -> None:
+    """It should favor origin height over max travel z if higher."""
+    result = get_waypoints(
+        origin=Point(1, 1, 11),
+        dest=Point(2, 2, 5),
+        move_type=MoveType.IN_LABWARE_ARC,
+        min_travel_z=6,
+        # max_travel_z lower than starting point
+        max_travel_z=10,
+    )
+
+    assert result == [
+        Waypoint(Point(2, 2, 11)),
+        Waypoint(Point(2, 2, 5)),
     ]
 
 


### PR DESCRIPTION
## Overview

In testing the motion planning module used by JSONv6 against the g-code regression suite (by flipping [this option](https://github.com/Opentrons/opentrons/blob/477e8155c66c2cdc3873bf89a618c340a438a10d/api/src/opentrons/protocols/geometry/planning.py#L216) to force PAPIv2 to use the newer motion planning algorithm), I noticed a small regression:

If, in a given move, the pipette's starting position is higher than that pipette model's declared maximum travel height, the pipette will move diagonally downwards from the starting point to the declared maximum travel height, before continuing to move normally to the destination. This was due to the fact that the planning algorithm always assumed that the `origin` was below the `max_travel_z`.

This PR removes that assumption and sets the travel height at the pipette's starting height if it's higher than the calculated move height. A similar change was not needed for the move destination, because the algorithm already verifies that the destination is in bounds before calculating the move.

Closes RSS-95

## Changelog

- Set the travel height as the pipette's starting height, even if it's higher than the calculated maximum safe travel height

## Review requests

This one is pretty hard to reproduce / verify on hardware. Luckily, we have the unit tests and the g-code regression suite!

Since I'm having trouble running the full g-code suite on my own machine, I temporarily set the PAPIv2 flag mentioned above to [see what the regression suite did](https://github.com/Opentrons/opentrons/actions/runs/2974772042).

**G-code regression results:**


- ✅ 2-modules
- ✅ swift-smoke
- ✅ swift-turbo
- ✅ omega
- fast
    - All passed except  `set_max_speed`
    ```diff
    --- a/g-code-testing/g_code_test_data/comparison_files/protocols/2.13/set_max_speed.txt
    +++ b/g-code-testing/g_code_test_data/comparison_files/protocols/2.13/set_max_speed.txt
    @@ -155,10 +155,6 @@ smoothie: M114.2 -> Getting current position for all axes -> The current positio
     smoothie: M400 -> Waiting for motors to stop moving ->
     smoothie: M203.1 Z18.0 -> Setting the max speed for the following axes: Z-Axis: 18.0 ->
     smoothie: M400 -> Waiting for motors to stop moving ->
    -smoothie: M203.1 A125.0 B40.0 C40.0 X600.0 Y400.0 Z125.0 -> Setting the max speed for the following axes: X-Axis: 600.0 Y-Axis: 400.0 Z-Axis: 125.0 A-Axis: 125.0 B-Axis: 40.0 C-Axis: 40.0 ->
    -smoothie: M400 -> Waiting for motors to stop moving ->
    -smoothie: M203.1 Z18.0 -> Setting the max speed for the following axes: Z-Axis: 18.0 ->
    -smoothie: M400 -> Waiting for motors to stop moving ->
     smoothie: M907 A0.1 B0.05 C0.3 X1.25 Y1.25 Z0.1 -> Setting the current (in amps) to: X-Axis Motor: 1.25 Y-Axis Motor: 1.25 Z-Axis Motor: 0.1 A-Axis Motor: 0.1 B-Axis Motor: 0.05 C-Axis Motor: 0.3 ->
     smoothie: G4 P0.005 -> Pausing movement for 0.005ms ->
     smoothie: G0 X144.62 Y44.99 -> Moving the robot as follows: The gantry to 144.62 on the X-Axis The gantry to 44.99 on the Y-Axis ->
     ```
    - I believe this deviation to be expected, since the new motion planning algorithm omits the initial move upwards if it's redundant
    - If I remove the condition in the new logic that omits the redundant endpoint, there is no g-code diff
    - It looks like maybe the hardware API still issues speed set and reset g-codes for no-op moves?


## Risk assessment

Low because regression suite is passing / producing expected diffs. The original motion bug itself was not unsafe, just awkward, because the lowest point the diagonally downwards move could reach was still a validated safe height
