### PR TITLE
refactor(api): add load labware from def'n to engine-based PAPI core

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -1,9 +1,10 @@
 """ProtocolEngine-based Protocol API core implementation."""
 from typing import Dict, Optional
 
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
-
+from opentrons_shared_data.labware.labware_definition import LabwareDefinition
+from opentrons_shared_data.labware.dev_types import LabwareDefinition as LabwareDefDict
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
+
 from opentrons.types import Mount, MountType, Location, DeckLocation, DeckSlotName
 from opentrons.hardware_control import SyncHardwareAPI
 from opentrons.hardware_control.modules.types import ModuleModel
@@ -16,6 +17,7 @@ from opentrons.protocol_engine import DeckSlotLocation
 from opentrons.protocol_engine.clients import SyncClient as ProtocolEngineClient
 
 from ..protocol import AbstractProtocol, LoadModuleResult
+from ..labware import LabwareLoadParams
 from .labware import LabwareCore
 from .instrument import InstrumentCore
 
@@ -42,14 +44,14 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore]):
         """
         raise NotImplementedError("ProtocolEngine PAPI core not implemented")
 
-    def get_bundled_labware(self) -> Optional[Dict[str, LabwareDefinition]]:
+    def get_bundled_labware(self) -> Optional[Dict[str, LabwareDefDict]]:
         """Get a map of labware names to definition dicts.
 
         Deprecated method used for past experiment with ZIP protocols.
         """
         raise NotImplementedError("ProtocolEngine PAPI core not implemented")
 
-    def get_extra_labware(self) -> Optional[Dict[str, LabwareDefinition]]:
+    def get_extra_labware(self) -> Optional[Dict[str, LabwareDefDict]]:
         """Get a map of extra labware names to definition dicts.
 
         Used to assist load custom labware definitions.
@@ -68,14 +70,15 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore]):
         """Get whether the protocol is being analyzed or actually run."""
         raise NotImplementedError("ProtocolEngine PAPI core not implemented")
 
-    def load_labware_from_definition(
+    def add_labware_definition(
         self,
-        labware_def: LabwareDefinition,
-        location: DeckSlotName,
-        label: Optional[str],
-    ) -> LabwareCore:
-        """Load a labware using its definition dictionary."""
-        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+        definition: LabwareDefDict,
+    ) -> LabwareLoadParams:
+        """Add a labware definition to the set of loadable definitions."""
+        uri = self._engine_client.add_labware_definition(
+            LabwareDefinition.parse_obj(definition)
+        )
+        return LabwareLoadParams.from_uri(uri)
 
     def load_labware(
         self,

--- a/api/src/opentrons/protocol_api/core/labware.py
+++ b/api/src/opentrons/protocol_api/core/labware.py
@@ -26,9 +26,9 @@ class LabwareLoadParams(NamedTuple):
     load_name: str
     version: int
 
-    def as_uri(self) -> str:
+    def as_uri(self) -> LabwareUri:
         """Get the labware's definition URI from the load parameters."""
-        return f"{self.namespace}/{self.load_name}/{self.version}"
+        return LabwareUri(f"{self.namespace}/{self.load_name}/{self.version}")
 
     @classmethod
     def from_uri(cls, uri: LabwareUri) -> LabwareLoadParams:

--- a/api/src/opentrons/protocol_api/core/labware.py
+++ b/api/src/opentrons/protocol_api/core/labware.py
@@ -1,17 +1,20 @@
 """The interface that implements InstrumentContext."""
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from typing import Any, Generic, Dict, List, NamedTuple, Optional, TypeVar
+
+from opentrons_shared_data.labware.dev_types import (
+    LabwareUri,
+    LabwareParameters as LabwareParametersDict,
+    LabwareDefinition as LabwareDefinitionDict,
+)
 
 from opentrons.protocols.geometry.deck_item import DeckItem
 from opentrons.protocols.geometry.labware_geometry import AbstractLabwareGeometry
 from opentrons.protocols.api_support.tip_tracker import TipTracker
 from opentrons.protocols.api_support.well_grid import WellGrid
 from opentrons.types import Point
-from opentrons_shared_data.labware.dev_types import (
-    LabwareParameters as LabwareParametersDict,
-    LabwareDefinition as LabwareDefinitionDict,
-)
 
 from .well import WellCoreType
 
@@ -26,6 +29,11 @@ class LabwareLoadParams(NamedTuple):
     def as_uri(self) -> str:
         """Get the labware's definition URI from the load parameters."""
         return f"{self.namespace}/{self.load_name}/{self.version}"
+
+    @classmethod
+    def from_uri(cls, uri: LabwareUri) -> LabwareLoadParams:
+        namespace, load_name, version_str = uri.split("/")
+        return cls(namespace, load_name, int(version_str))
 
 
 class AbstractLabware(DeckItem, ABC, Generic[WellCoreType]):

--- a/api/src/opentrons/protocol_api/core/protocol.py
+++ b/api/src/opentrons/protocol_api/core/protocol.py
@@ -18,7 +18,7 @@ from opentrons.protocols.api_support.util import AxisMaxSpeeds
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 from .instrument import InstrumentCoreType
-from .labware import LabwareCoreType
+from .labware import LabwareCoreType, LabwareLoadParams
 
 
 @dataclass(frozen=True)
@@ -57,12 +57,11 @@ class AbstractProtocol(ABC, Generic[InstrumentCoreType, LabwareCoreType]):
         ...
 
     @abstractmethod
-    def load_labware_from_definition(
+    def add_labware_definition(
         self,
-        labware_def: LabwareDefinition,
-        location: DeckSlotName,
-        label: Optional[str],
-    ) -> LabwareCoreType:
+        definition: LabwareDefinition,
+    ) -> LabwareLoadParams:
+        """Add a labware defintion to the set of loadable definitions."""
         ...
 
     @abstractmethod
@@ -74,6 +73,7 @@ class AbstractProtocol(ABC, Generic[InstrumentCoreType, LabwareCoreType]):
         namespace: Optional[str],
         version: Optional[int],
     ) -> LabwareCoreType:
+        """Load a labware using its identifying parameters."""
         ...
 
     @abstractmethod

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -279,42 +279,15 @@ class ProtocolContext(CommandPublisher):
                           as in the run log and the calibration view in the
                           Opentrons app.
         """
-        # todo(mm, 2021-11-22): The duplication between here and load_labware()
-        # is getting bad.
-        deck_slot = validation.ensure_deck_slot(location)
+        load_params = self._implementation.add_labware_definition(labware_def)
 
-        labware_core = self._implementation.load_labware_from_definition(
-            labware_def=labware_def, location=deck_slot, label=label
+        return self.load_labware(
+            load_name=load_params.load_name,
+            namespace=load_params.namespace,
+            version=load_params.version,
+            location=location,
+            label=label,
         )
-
-        labware_load_params = labware_core.get_load_params()
-
-        provided_labware_offset = self._labware_offset_provider.find(
-            load_params=labware_load_params,
-            requested_module_model=None,
-            deck_slot=deck_slot,
-        )
-
-        labware_core.set_calibration(provided_labware_offset.delta)
-
-        # TODO(mc, 2022-09-02): add API version
-        # https://opentrons.atlassian.net/browse/RSS-97
-        result = Labware(implementation=labware_core)
-
-        self.equipment_broker.publish(
-            LabwareLoadInfo(
-                labware_definition=labware_core.get_definition(),
-                labware_namespace=labware_load_params.namespace,
-                labware_load_name=labware_load_params.load_name,
-                labware_version=labware_load_params.version,
-                deck_slot=deck_slot,
-                on_module=False,
-                offset_id=provided_labware_offset.offset_id,
-                labware_display_name=labware_core.get_user_display_name(),
-            )
-        )
-
-        return result
 
     @requires_version(2, 0)
     def load_labware(

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -2,8 +2,10 @@
 from typing import cast, Optional
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
-from opentrons.types import MountType
+from opentrons_shared_data.labware.dev_types import LabwareUri
+from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 
+from opentrons.types import MountType
 
 from .. import commands
 from ..state import StateView
@@ -27,6 +29,13 @@ class SyncClient:
     def state(self) -> StateView:
         """Get a view of the engine's state."""
         return self._transport.state
+
+    def add_labware_definition(self, definition: LabwareDefinition) -> LabwareUri:
+        """Add a labware definition to the engine."""
+        return self._transport.call_method(
+            "add_labware_definition",
+            definition=definition,
+        )
 
     def load_labware(
         self,

--- a/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
@@ -3,6 +3,10 @@ import pytest
 from decoy import Decoy
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.labware.dev_types import (
+    LabwareDefinition as LabwareDefDict,
+    LabwareUri,
+)
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 
 from opentrons.types import Mount, MountType, DeckSlotName
@@ -10,6 +14,7 @@ from opentrons.protocol_engine import commands
 from opentrons.protocol_engine.clients import SyncClient as EngineClient
 from opentrons.protocol_engine.types import DeckSlotLocation
 
+from opentrons.protocol_api.core.labware import LabwareLoadParams
 from opentrons.protocol_api.core.engine import ProtocolCore, InstrumentCore, LabwareCore
 
 
@@ -77,3 +82,21 @@ def test_load_labware(
 
     assert isinstance(result, LabwareCore)
     assert result.labware_id == "abc123"
+
+
+def test_add_labware_definition(
+    decoy: Decoy,
+    minimal_labware_def: LabwareDefDict,
+    mock_engine_client: EngineClient,
+    subject: ProtocolCore,
+) -> None:
+    """It should add a laware definition to the engine."""
+    decoy.when(
+        mock_engine_client.add_labware_definition(
+            definition=LabwareDefinition.parse_obj(minimal_labware_def)
+        )
+    ).then_return(LabwareUri("hello/world/123"))
+
+    result = subject.add_labware_definition(minimal_labware_def)
+
+    assert result == LabwareLoadParams("hello", "world", 123)

--- a/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
@@ -11,8 +11,10 @@ the subject's methods in a synchronous context in a child thread to ensure:
 import pytest
 from decoy import Decoy
 
-from opentrons.protocols.models import LabwareDefinition
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.labware.dev_types import LabwareUri
+from opentrons_shared_data.labware.labware_definition import LabwareDefinition
+
 from opentrons.types import DeckSlotName, MountType
 from opentrons.protocol_engine import DeckSlotLocation, commands
 from opentrons.protocol_engine.clients import SyncClient, AbstractSyncTransport
@@ -35,6 +37,27 @@ def transport(decoy: Decoy) -> AbstractSyncTransport:
 def subject(transport: AbstractSyncTransport) -> SyncClient:
     """Get a SyncProtocolEngine test subject."""
     return SyncClient(transport=transport)
+
+
+def test_add_labware_definition(
+    decoy: Decoy,
+    transport: AbstractSyncTransport,
+    subject: SyncClient,
+) -> None:
+    """It should add a labware definition."""
+    labware_definition = LabwareDefinition.construct(namespace="hello")  # type: ignore[call-arg]
+    expected_labware_uri = LabwareUri("hello/world/123")
+
+    decoy.when(
+        transport.call_method(
+            "add_labware_definition",
+            definition=labware_definition,
+        )
+    ).then_return(expected_labware_uri)
+
+    result = subject.add_labware_definition(labware_definition)
+
+    assert result == expected_labware_uri
 
 
 def test_load_labware(

--- a/shared-data/python/opentrons_shared_data/labware/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/labware/dev_types.py
@@ -3,11 +3,11 @@
 types in this file by and large require the use of typing_extensions.
 this module shouldn't be imported unless typing.TYPE_CHECKING is true.
 """
-from typing import Dict, List, Union
+from typing import Dict, List, NewType, Union
 from typing_extensions import Literal, TypedDict
 
-# TODO(mc, 2022-06-16): move here, shouldn't be in pipettes
-from ..pipette.dev_types import LabwareUri as LabwareUri  # noqa: F401
+
+LabwareUri = NewType("LabwareUri", str)
 
 LabwareDisplayCategory = Union[
     Literal["tipRack"],

--- a/shared-data/python/opentrons_shared_data/pipette/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/pipette/dev_types.py
@@ -11,7 +11,7 @@ from typing_extensions import Literal, TypedDict
 
 # TODO(mc, 2022-06-16): remove type alias when able
 # and when certain removal will not break any pickling
-from ..labware.dev_types import LabwareUri as LabwareUri  # noqa: F401
+from ..labware.dev_types import LabwareUri as LabwareUri
 
 
 PipetteName = Literal[

--- a/shared-data/python/opentrons_shared_data/pipette/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/pipette/dev_types.py
@@ -9,8 +9,9 @@ from typing import Dict, List, NewType, Union
 
 from typing_extensions import Literal, TypedDict
 
-# TODO(mc, 2022-06-16): move to labware.dev_types
-LabwareUri = NewType("LabwareUri", str)
+# TODO(mc, 2022-06-16): remove type alias when able
+# and when certain removal will not break any pickling
+from ..labware.dev_types import LabwareUri as LabwareUri  # noqa: F401
 
 
 PipetteName = Literal[


### PR DESCRIPTION
## Overview

This PR adds support for `load_labware_from_definition` to the PE-based PAPI core.

Closes RCORE-101

## Changelog

- Update PAPI core interfaces to support `load_labware_from_definition` in PE core

## Review requests

See more detailed test plan in RCORE-101:

```shell
make -C robot-server dev OT_API_FF_enableProtocolEnginePAPICore=1
```

- [ ] Load labware from definition works with FF on
- [ ] Load labware from definition works with FF off

# Risk assessment

There is one behavioral change this PR makes: once you call `load_labware_from_definition`, you may call `load_labware` with the load parameters from that definition, and that subsequent `load_labware` will succeed. This change is across both the legacy and `ProtocolEngine`-based cores.

This certainly won't break any protocols (you can also still call `load_labware_from_definition` multiple times with the same custom definition), and I think it's a serious improvement in the `ProtocolCore` interface.
