### PR TITLE
fix(app): update factoryreset options description

### DIFF
--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -113,7 +113,7 @@
   "factory_reset_slideout_title": "Factory Reset",
   "factory_reset_slideout_description": "Select the robot data to clear.",
   "factory_resets_cannot_be_undone": "Factory resets cannot be undone",
-  "robot_calibration_data": "Robot calibration data",
+  "robot_calibration_data": "Robot Calibration Data",
   "calibration_description": "Resetting Deck and/or Tip Length Calibration data will also clear Pipette Offset Calibration data.",
   "protocol_run_history": "Protocol Run History",
   "boot_scripts": "Boot Scripts",

--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -134,5 +134,6 @@
   "view_opentrons_release_notes": "View full Opentrons release notes",
   "remind_me_later": "Remind me later",
   "update_robot_now": "Update robot now",
-  "reinstall": "reinstall"
+  "reinstall": "reinstall",
+  "protocol_run_history_description": "Resetting run history will also clear Labware Offset data."
 }

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/FactoryResetSlideout.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/FactoryResetSlideout.tsx
@@ -194,6 +194,9 @@ export function FactoryResetSlideout({
               {t('download')}
             </Link>
           </Flex>
+          <StyledText as="p" marginBottom={SPACING.spacing3}>
+            {t('protocol_run_history_description')}
+          </StyledText>
           {runHistoryOption.map(opt => (
             <CheckboxField
               key={opt.id}

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/__tests__/FactoryResetSlideout.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/__tests__/FactoryResetSlideout.test.tsx
@@ -65,7 +65,7 @@ describe('RobotSettings FactoryResetSlideout', () => {
     getByText('Factory Reset')
     getByText('Select the robot data to clear.')
     getByText('Factory resets cannot be undone')
-    getByText('Robot calibration data')
+    getByText('Robot Calibration Data')
     getByText(
       'Resetting Deck and/or Tip Length Calibration data will also clear Pipette Offset Calibration data.'
     )

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/__tests__/FactoryResetSlideout.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/__tests__/FactoryResetSlideout.test.tsx
@@ -70,6 +70,7 @@ describe('RobotSettings FactoryResetSlideout', () => {
       'Resetting Deck and/or Tip Length Calibration data will also clear Pipette Offset Calibration data.'
     )
     getByText('Protocol Run History')
+    getByText('Resetting run history will also clear Labware Offset data.')
     getByText('Clear BootScript Foo')
     getByText('Clear Calibration Bar')
     getByText('RunsHistory FooBar')


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Add a description to Protocol Run History on Factory Reset slideout. 
This will close RAUT-194.

![Screen Shot 2022-09-07 at 12 14 06 PM](https://user-images.githubusercontent.com/474225/188928314-92ef101c-7498-4114-99e8-7991fe18217f.png)


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- add description to the slideout
- update the test

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- the description for protocol run history shows up when opening the slideout
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
