### PR TITLE
refactor(app): delete unused code in ModuleOverflowMenu

### DIFF
--- a/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
+++ b/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react'
-import { useTranslation } from 'react-i18next'
-import { Flex, POSITION_RELATIVE, useHoverTooltip } from '@opentrons/components'
+import { Flex, POSITION_RELATIVE } from '@opentrons/components'
 import { MenuList } from '../../atoms/MenuList'
 import { MenuItem } from '../../atoms/MenuList/MenuItem'
-import { Tooltip } from '../../atoms/Tooltip'
 import { useCurrentRunId } from '../ProtocolUpload/hooks'
 import { useRunStatuses, useIsLegacySessionInProgress } from '../Devices/hooks'
 import { useModuleOverflowMenu } from './hooks'
@@ -25,7 +23,6 @@ interface ModuleOverflowMenuProps {
 export const ModuleOverflowMenu = (
   props: ModuleOverflowMenuProps
 ): JSX.Element | null => {
-  const { t } = useTranslation(['device_details', 'heater_shaker'])
   const {
     module,
     runId,
@@ -35,7 +32,6 @@ export const ModuleOverflowMenu = (
     handleWizardClick,
     isLoadedInRun,
   } = props
-  const [targetProps, tooltipProps] = useHoverTooltip()
   const { menuOverflowItemsByModuleType } = useModuleOverflowMenu(
     module,
     runId,
@@ -57,38 +53,30 @@ export const ModuleOverflowMenu = (
   }
 
   return (
-    <>
-      <Flex position={POSITION_RELATIVE}>
-        <MenuList
-          buttons={[
-            (menuOverflowItemsByModuleType[
-              module.moduleType
-            ] as MenuItemsByModuleType[ModuleType]).map(
-              (item: any, index: number) => {
-                return (
-                  <React.Fragment key={`${index}_${module.moduleType}`}>
-                    <MenuItem
-                      key={`${index}_${module.moduleModel}`}
-                      onClick={() => item.onClick(item.isSecondary)}
-                      data-testid={`module_setting_${module.moduleModel}`}
-                      disabled={item.disabledReason || isDisabled}
-                      {...targetProps}
-                    >
-                      {item.setSetting}
-                    </MenuItem>
-                    {item.disabledReason && (
-                      <Tooltip tooltipProps={tooltipProps}>
-                        {t('heater_shaker:cannot_shake')}
-                      </Tooltip>
-                    )}
-                    {item.menuButtons}
-                  </React.Fragment>
-                )
-              }
-            ),
-          ]}
-        />
-      </Flex>
-    </>
+    <Flex position={POSITION_RELATIVE}>
+      <MenuList
+        buttons={[
+          (menuOverflowItemsByModuleType[
+            module.moduleType
+          ] as MenuItemsByModuleType[ModuleType]).map(
+            (item: any, index: number) => {
+              return (
+                <React.Fragment key={`${index}_${module.moduleType}`}>
+                  <MenuItem
+                    key={`${index}_${module.moduleModel}`}
+                    onClick={() => item.onClick(item.isSecondary)}
+                    data-testid={`module_setting_${module.moduleModel}`}
+                    disabled={isDisabled}
+                  >
+                    {item.setSetting}
+                  </MenuItem>
+                  {item.menuButtons}
+                </React.Fragment>
+              )
+            }
+          ),
+        ]}
+      />
+    </Flex>
   )
 }

--- a/app/src/organisms/ModuleCard/hooks.tsx
+++ b/app/src/organisms/ModuleCard/hooks.tsx
@@ -87,7 +87,6 @@ export type MenuItemsByModuleType = {
   [moduleType in AttachedModule['moduleType']]: Array<{
     setSetting: string
     isSecondary: boolean
-    disabledReason: boolean
     menuButtons: JSX.Element[] | null
     onClick: (isSecondary: boolean) => void
   }>
@@ -244,7 +243,6 @@ export function useModuleOverflowMenu(
             ? t('overflow_menu_deactivate_lid')
             : t('overflow_menu_lid_temp'),
         isSecondary: true,
-        disabledReason: false,
         menuButtons: null,
         onClick:
           module.moduleType === THERMOCYCLER_MODULE_TYPE &&
@@ -259,7 +257,6 @@ export function useModuleOverflowMenu(
             ? t('overflow_menu_deactivate_block')
             : t('overflow_menu_set_block_temp'),
         isSecondary: false,
-        disabledReason: false,
         menuButtons: [aboutModuleBtn],
         onClick:
           module.moduleType === THERMOCYCLER_MODULE_TYPE &&
@@ -276,7 +273,6 @@ export function useModuleOverflowMenu(
             ? t('overflow_menu_deactivate_temp')
             : t('overflow_menu_mod_temp'),
         isSecondary: false,
-        disabledReason: false,
         menuButtons: [aboutModuleBtn],
         onClick:
           module.data.status !== 'idle'
@@ -292,7 +288,6 @@ export function useModuleOverflowMenu(
             ? t('overflow_menu_disengage')
             : t('overflow_menu_engage'),
         isSecondary: false,
-        disabledReason: false,
         menuButtons: [aboutModuleBtn],
         onClick:
           module.data.status !== 'disengaged'
@@ -308,7 +303,6 @@ export function useModuleOverflowMenu(
             ? t('heater_shaker:deactivate_heater')
             : t('heater_shaker:set_temperature'),
         isSecondary: false,
-        disabledReason: false,
         menuButtons: [
           labwareLatchBtn,
           aboutModuleBtn,


### PR DESCRIPTION
closes RAUT-154

# Overview

This removes the unused `disabledReason` key in the `MenuItemsByModuleType` type that is being used in the `ModuleOverflowMenu` and the `useModuleOverflowMenu` hook. Additionally, this removes the unused `tooltip` in `ModuleOverflowMenu`, subsequently removing the usage of i18n in the component.

I originally thought this would be a large refactor because I thought I had to change the tests but the tests weren't thorough enough to test this unused code. So the tests remained the same.

# Changelog

- remove unused code from `useModuleOverflowMenu` and `ModuleOverflowMenu`

# Review requests

- smoke test the functionality (particularly when the buttons are disabled when run is in different states, etc) for all the module overflow menus. Buttons should be disabled when expected.

# Risk assessment

low