### PR TITLE
refactor(api): add initial ModuleCore tests and interfaces

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -1,0 +1,7 @@
+"""Protocol API module implementation logic."""
+from ..module import AbstractModuleCore
+from .labware import LabwareCore
+
+
+class ModuleCore(AbstractModuleCore[LabwareCore]):
+    """Module core logic implementation for Python protocols."""

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -5,7 +5,7 @@ from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons_shared_data.labware.dev_types import LabwareDefinition as LabwareDefDict
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
 
-from opentrons.types import Mount, MountType, Location, DeckLocation, DeckSlotName
+from opentrons.types import Mount, MountType, Location, DeckSlotName
 from opentrons.hardware_control import SyncHardwareAPI
 from opentrons.hardware_control.modules.types import ModuleModel
 from opentrons.protocols.api_support.constants import OPENTRONS_NAMESPACE
@@ -105,7 +105,7 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
     def load_module(
         self,
         model: ModuleModel,
-        location: Optional[DeckLocation],
+        location: Optional[DeckSlotName],
         configuration: Optional[str],
     ) -> Optional[LoadModuleResult]:
         """Load a module into the protocol."""

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -20,13 +20,14 @@ from ..protocol import AbstractProtocol, LoadModuleResult
 from ..labware import LabwareLoadParams
 from .labware import LabwareCore
 from .instrument import InstrumentCore
+from .module_core import ModuleCore
 
 
 # TODO(mc, 2022-08-24): many of these methods are likely unnecessary
 # in a ProtocolEngine world. As we develop this core, we should remove
 # and consolidate logic as we need to across all cores rather than
 # necessarily try to support every one of these behaviors in the engine.
-class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore]):
+class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
     """Protocol API core using a ProtocolEngine.
 
     Args:

--- a/api/src/opentrons/protocol_api/core/module.py
+++ b/api/src/opentrons/protocol_api/core/module.py
@@ -1,0 +1,21 @@
+"""Core module logic abstract interfaces."""
+from abc import ABC, abstractmethod
+from typing import Any, Generic, TypeVar
+
+from opentrons.hardware_control.modules.types import ModuleModel
+from .labware import LabwareCoreType
+
+
+class AbstractModuleCore(ABC, Generic[LabwareCoreType]):
+    """Abstract core module interface."""
+
+    @abstractmethod
+    def get_model(self) -> ModuleModel:
+        """Get the module's model identifier."""
+
+    @abstractmethod
+    def get_serial_number(self) -> str:
+        """Get the module's unique hardware serial number."""
+
+
+ModuleCoreType = TypeVar("ModuleCoreType", bound=AbstractModuleCore[Any])

--- a/api/src/opentrons/protocol_api/core/protocol.py
+++ b/api/src/opentrons/protocol_api/core/protocol.py
@@ -83,7 +83,7 @@ class AbstractProtocol(
     def load_module(
         self,
         model: ModuleModel,
-        deck_slot: DeckSlotName,
+        deck_slot: Optional[DeckSlotName],
         configuration: Optional[str],
     ) -> Optional[LoadModuleResult]:
         ...

--- a/api/src/opentrons/protocol_api/core/protocol.py
+++ b/api/src/opentrons/protocol_api/core/protocol.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Dict, Generic, Optional
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
-from opentrons.types import Mount, Location, DeckLocation, DeckSlotName
+from opentrons.types import Mount, Location, DeckSlotName
 from opentrons.hardware_control import SyncHardwareAPI, SynchronousAdapter
 from opentrons.hardware_control.modules import AbstractModule
 from opentrons.hardware_control.modules.types import ModuleModel, ModuleType
@@ -19,6 +19,7 @@ from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 from .instrument import InstrumentCoreType
 from .labware import LabwareCoreType, LabwareLoadParams
+from .module import ModuleCoreType
 
 
 @dataclass(frozen=True)
@@ -30,7 +31,9 @@ class LoadModuleResult:
     module: SynchronousAdapter[AbstractModule]
 
 
-class AbstractProtocol(ABC, Generic[InstrumentCoreType, LabwareCoreType]):
+class AbstractProtocol(
+    ABC, Generic[InstrumentCoreType, LabwareCoreType, ModuleCoreType]
+):
     @abstractmethod
     def get_bundled_data(self) -> Dict[str, bytes]:
         """Get a mapping of name to contents"""
@@ -80,7 +83,7 @@ class AbstractProtocol(ABC, Generic[InstrumentCoreType, LabwareCoreType]):
     def load_module(
         self,
         model: ModuleModel,
-        location: Optional[DeckLocation],
+        deck_slot: DeckSlotName,
         configuration: Optional[str],
     ) -> Optional[LoadModuleResult]:
         ...

--- a/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
@@ -1,0 +1,7 @@
+"""Legacy Protocol API module implementation logic."""
+from ..module import AbstractModuleCore
+from .labware import LabwareImplementation
+
+
+class LegacyModuleCore(AbstractModuleCore[LabwareImplementation]):
+    """Legacy ModuleCore implementation for pre-ProtocolEngine protocols."""

--- a/api/src/opentrons/protocol_api/core/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/protocol_context.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
 
-from opentrons.types import Mount, Location, DeckLocation, DeckSlotName
+from opentrons.types import Mount, Location, DeckSlotName
 from opentrons.equipment_broker import EquipmentBroker
 from opentrons.hardware_control import SyncHardwareAPI, SynchronousAdapter
 from opentrons.hardware_control.modules import AbstractModule, ModuleModel
@@ -23,13 +23,16 @@ from ..labware import LabwareLoadParams
 from .instrument_context import InstrumentContextImplementation
 from .labware_offset_provider import AbstractLabwareOffsetProvider
 from .labware import LabwareImplementation
+from .legacy_module_core import LegacyModuleCore
 from .load_info import LoadInfo, InstrumentLoadInfo, LabwareLoadInfo, ModuleLoadInfo
 
 logger = logging.getLogger(__name__)
 
 
 class ProtocolContextImplementation(
-    AbstractProtocol[InstrumentContextImplementation, LabwareImplementation]
+    AbstractProtocol[
+        InstrumentContextImplementation, LabwareImplementation, LegacyModuleCore
+    ]
 ):
     def __init__(
         self,
@@ -185,13 +188,13 @@ class ProtocolContextImplementation(
     def load_module(
         self,
         model: ModuleModel,
-        location: Optional[DeckLocation],
+        deck_slot: DeckSlotName,
         configuration: Optional[str],
     ) -> Optional[LoadModuleResult]:
         """Load a module."""
         resolved_type = module_geometry.resolve_module_type(model)
         resolved_location = self._deck_layout.resolve_module_location(
-            resolved_type, location
+            resolved_type, deck_slot.value
         )
 
         # Try to find in the hardware instance

--- a/api/src/opentrons/protocol_api/core/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/protocol_context.py
@@ -188,13 +188,13 @@ class ProtocolContextImplementation(
     def load_module(
         self,
         model: ModuleModel,
-        deck_slot: DeckSlotName,
+        deck_slot: Optional[DeckSlotName],
         configuration: Optional[str],
     ) -> Optional[LoadModuleResult]:
         """Load a module."""
         resolved_type = module_geometry.resolve_module_type(model)
         resolved_location = self._deck_layout.resolve_module_location(
-            resolved_type, deck_slot.value
+            resolved_type, deck_slot
         )
 
         # Try to find in the hardware instance

--- a/api/src/opentrons/protocol_api/core/simulator/protocol_context.py
+++ b/api/src/opentrons/protocol_api/core/simulator/protocol_context.py
@@ -7,6 +7,7 @@ from opentrons.types import Mount
 from ..protocol import AbstractProtocol
 from ..protocol_api.protocol_context import ProtocolContextImplementation
 from ..protocol_api.labware import LabwareImplementation
+from ..protocol_api.legacy_module_core import LegacyModuleCore
 from ..protocol_api.load_info import InstrumentLoadInfo
 
 from .instrument_context import InstrumentContextSimulation
@@ -16,7 +17,9 @@ logger = logging.getLogger(__name__)
 
 class ProtocolContextSimulation(
     ProtocolContextImplementation,
-    AbstractProtocol[InstrumentContextSimulation, LabwareImplementation],
+    AbstractProtocol[
+        InstrumentContextSimulation, LabwareImplementation, LegacyModuleCore
+    ],
 ):
     _instruments: Dict[Mount, Optional[InstrumentContextSimulation]]  # type: ignore[assignment]
 

--- a/api/src/opentrons/protocol_api/create_protocol_context.py
+++ b/api/src/opentrons/protocol_api/create_protocol_context.py
@@ -70,7 +70,7 @@ def create_protocol_context(
     """
     sync_hardware: SynchronousAdapter[HardwareControlAPI]
     labware_offset_provider: AbstractLabwareOffsetProvider
-    core: AbstractProtocol[Any, Any]
+    core: AbstractProtocol[Any, Any, Any]
 
     if isinstance(hardware_api, ThreadManager):
         sync_hardware = hardware_api.sync

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -301,8 +301,6 @@ class ProtocolContext(CommandPublisher):
         :param int version: The version of the labware definition. If
             unspecified, will use version 1.
         """
-        # todo(mm, 2021-11-22): The duplication between here and
-        # load_labware_from_definition() is getting bad.
         deck_slot = validation.ensure_deck_slot(location)
 
         labware_core = self._implementation.load_labware(
@@ -413,12 +411,11 @@ class ProtocolContext(CommandPublisher):
             )
 
         requested_model = validation.ensure_module_model(module_name)
-        deck_slot = validation.ensure_module_deck_slot(
-            location=location, model=requested_model
-        )
-
+        deck_slot = None if location is None else validation.ensure_deck_slot(location)
         load_result = self._implementation.load_module(
-            model=requested_model, deck_slot=deck_slot, configuration=configuration
+            model=requested_model,
+            deck_slot=deck_slot,
+            configuration=configuration,
         )
 
         if not load_result:

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -96,21 +96,3 @@ def ensure_module_model(load_name: str) -> ModuleModel:
         )
 
     return model
-
-
-def ensure_module_deck_slot(
-    location: Union[int, str, None],
-    model: ModuleModel,
-) -> DeckSlotName:
-    """Ensure that a requested module load location is correct."""
-    if location is not None:
-        deck_slot = ensure_deck_slot(location)
-    elif isinstance(model, ThermocyclerModuleModel):
-        deck_slot = DeckSlotName.SLOT_7
-    else:
-        raise ValueError(f"Location required for {model.value}")
-
-    if isinstance(model, ThermocyclerModuleModel) and deck_slot != DeckSlotName.SLOT_7:
-        raise ValueError(f"{model.value} must be placed in slot 7")
-
-    return deck_slot

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -104,17 +104,13 @@ def ensure_module_deck_slot(
 ) -> DeckSlotName:
     """Ensure that a requested module load location is correct."""
     if location is not None:
-        checked_location = ensure_deck_slot(location)
+        deck_slot = ensure_deck_slot(location)
+    elif isinstance(model, ThermocyclerModuleModel):
+        deck_slot = DeckSlotName.SLOT_7
+    else:
+        raise ValueError(f"Location required for {model.value}")
 
-    if location is None:
-        if not isinstance(model, ThermocyclerModuleModel):
-            raise ValueError(f"Location required for {model.value}")
-        checked_location = DeckSlotName.SLOT_7
-
-    if (
-        isinstance(model, ThermocyclerModuleModel)
-        and checked_location != DeckSlotName.SLOT_7
-    ):
+    if isinstance(model, ThermocyclerModuleModel) and deck_slot != DeckSlotName.SLOT_7:
         raise ValueError(f"{model.value} must be placed in slot 7")
 
-    return checked_location
+    return deck_slot

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -1,7 +1,15 @@
-from typing import Union
+from typing import Dict, Union
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
+
 from opentrons.types import Mount, DeckSlotName
+from opentrons.hardware_control.modules.types import (
+    ModuleModel,
+    MagneticModuleModel,
+    TemperatureModuleModel,
+    ThermocyclerModuleModel,
+    HeaterShakerModuleModel,
+)
 
 
 def ensure_mount(mount: Union[str, Mount]) -> Mount:
@@ -45,3 +53,68 @@ def ensure_deck_slot(deck_slot: Union[int, str]) -> DeckSlotName:
         return DeckSlotName(str(deck_slot))
     except ValueError as e:
         raise ValueError(f"'{deck_slot}' is not a valid deck slot") from e
+
+
+_MODULE_ALIASES: Dict[str, ModuleModel] = {
+    "magdeck": MagneticModuleModel.MAGNETIC_V1,
+    "magnetic module": MagneticModuleModel.MAGNETIC_V1,
+    "magnetic module gen2": MagneticModuleModel.MAGNETIC_V2,
+    "tempdeck": TemperatureModuleModel.TEMPERATURE_V1,
+    "temperature module": TemperatureModuleModel.TEMPERATURE_V1,
+    "temperature module gen2": TemperatureModuleModel.TEMPERATURE_V2,
+    "thermocycler": ThermocyclerModuleModel.THERMOCYCLER_V1,
+    "thermocycler module": ThermocyclerModuleModel.THERMOCYCLER_V1,
+    "thermocycler module gen2": ThermocyclerModuleModel.THERMOCYCLER_V2,
+    # No alias for heater-shaker. Use heater-shaker model name for loading.
+}
+
+_MODULE_MODELS: Dict[str, ModuleModel] = {
+    "magneticModuleV1": MagneticModuleModel.MAGNETIC_V1,
+    "magneticModuleV2": MagneticModuleModel.MAGNETIC_V2,
+    "temperatureModuleV1": TemperatureModuleModel.TEMPERATURE_V1,
+    "temperatureModuleV2": TemperatureModuleModel.TEMPERATURE_V2,
+    "thermocyclerModuleV1": ThermocyclerModuleModel.THERMOCYCLER_V1,
+    "thermocyclerModuleV2": ThermocyclerModuleModel.THERMOCYCLER_V2,
+    "heaterShakerModuleV1": HeaterShakerModuleModel.HEATER_SHAKER_V1,
+}
+
+
+def ensure_module_model(load_name: str) -> ModuleModel:
+    """Ensure that a requested module load name matches a known module model."""
+    if not isinstance(load_name, str):
+        raise TypeError(f"Module load name must be a string, but got {load_name}")
+
+    model = _MODULE_ALIASES.get(load_name.lower()) or _MODULE_MODELS.get(load_name)
+
+    if model is None:
+        valid_names = '", "'.join(_MODULE_ALIASES.keys())
+        valid_models = '", "'.join(_MODULE_MODELS.keys())
+        raise ValueError(
+            f"{load_name} is not a valid module load name.\n"
+            f'Valid names (ignoring case): "{valid_names}"\n'
+            f'You may also use their exact models: "{valid_models}"'
+        )
+
+    return model
+
+
+def ensure_module_deck_slot(
+    location: Union[int, str, None],
+    model: ModuleModel,
+) -> DeckSlotName:
+    """Ensure that a requested module load location is correct."""
+    if location is not None:
+        checked_location = ensure_deck_slot(location)
+
+    if location is None:
+        if not isinstance(model, ThermocyclerModuleModel):
+            raise ValueError(f"Location required for {model.value}")
+        checked_location = DeckSlotName.SLOT_7
+
+    if (
+        isinstance(model, ThermocyclerModuleModel)
+        and checked_location != DeckSlotName.SLOT_7
+    ):
+        raise ValueError(f"{model.value} must be placed in slot 7")
+
+    return checked_location

--- a/api/src/opentrons/protocols/geometry/deck.py
+++ b/api/src/opentrons/protocols/geometry/deck.py
@@ -215,7 +215,7 @@ class Deck(UserDict):
             if module_type.value in compatible_modules:
                 return location
             else:
-                raise AssertionError(
+                raise ValueError(
                     f"A {dn_from_type[module_type]} cannot be loaded"
                     f" into slot {location}"
                 )
@@ -232,7 +232,7 @@ class Deck(UserDict):
                     "A {dn_from_type[module_type]} cannot be used with this deck"
                 )
             else:
-                raise AssertionError(
+                raise ValueError(
                     f"{dn_from_type[module_type]}s do not have default"
                     " location, you must specify a slot"
                 )

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -9,16 +9,18 @@ from opentrons_shared_data.pipette.dev_types import PipetteNameType
 from opentrons_shared_data.labware.dev_types import LabwareDefinition as LabwareDefDict
 
 from opentrons.types import Mount, DeckSlotName
+from opentrons.hardware_control.modules.types import TemperatureModuleModel
 from opentrons.protocol_api import (
     MAX_SUPPORTED_VERSION,
     ProtocolContext,
     InstrumentContext,
+    ModuleContext,
     Labware,
     validation,
 )
 from opentrons.protocol_api.core.labware import LabwareLoadParams
 
-from .types import InstrumentCore, LabwareCore, ProtocolCore
+from .types import InstrumentCore, LabwareCore, ModuleCore, ProtocolCore
 
 
 @pytest.fixture(autouse=True)
@@ -175,3 +177,41 @@ def test_load_labware_from_definition(
 
     assert isinstance(result, Labware)
     assert result.name == "Full Name"
+
+
+@pytest.mark.xfail(strict=True, reason="Not yet implemented")
+def test_load_module(
+    decoy: Decoy,
+    mock_core: ProtocolCore,
+    subject: ProtocolContext,
+) -> None:
+    """It should load a module."""
+    mock_module_core = decoy.mock(cls=ModuleCore)
+
+    decoy.when(validation.ensure_module_model("spline reticulator")).then_return(
+        TemperatureModuleModel.TEMPERATURE_V1
+    )
+    decoy.when(
+        validation.ensure_module_deck_slot(
+            location=42, model=TemperatureModuleModel.TEMPERATURE_V1
+        )
+    ).then_return(DeckSlotName.SLOT_3)
+
+    decoy.when(
+        mock_core.load_module(
+            model=TemperatureModuleModel.TEMPERATURE_V1,
+            deck_slot=DeckSlotName.SLOT_3,
+            configuration=None,
+        )
+    ).then_return(
+        mock_module_core  # type: ignore[arg-type]
+    )
+
+    decoy.when(mock_module_core.get_model()).then_return(
+        TemperatureModuleModel.TEMPERATURE_V2
+    )
+    decoy.when(mock_module_core.get_serial_number()).then_return("cap'n crunch")
+
+    result = subject.load_module(module_name="spline reticulator", location=42)
+
+    assert isinstance(result, ModuleContext)

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -191,11 +191,7 @@ def test_load_module(
     decoy.when(validation.ensure_module_model("spline reticulator")).then_return(
         TemperatureModuleModel.TEMPERATURE_V1
     )
-    decoy.when(
-        validation.ensure_module_deck_slot(
-            location=42, model=TemperatureModuleModel.TEMPERATURE_V1
-        )
-    ).then_return(DeckSlotName.SLOT_3)
+    decoy.when(validation.ensure_deck_slot(42)).then_return(DeckSlotName.SLOT_3)
 
     decoy.when(
         mock_core.load_module(

--- a/api/tests/opentrons/protocol_api/test_validation.py
+++ b/api/tests/opentrons/protocol_api/test_validation.py
@@ -1,5 +1,5 @@
 """Tests for Protocol API input validation."""
-from typing import Any, List, Union, Type
+from typing import List, Union
 
 import pytest
 
@@ -116,43 +116,3 @@ def test_ensure_module_model_invalid() -> None:
 
     with pytest.raises(TypeError, match="must be a string"):
         subject.ensure_module_model(42)  # type: ignore[arg-type]
-
-
-@pytest.mark.parametrize(
-    ("location", "model", "expected_slot"),
-    [
-        (1, MagneticModuleModel.MAGNETIC_V1, DeckSlotName.SLOT_1),
-        ("3", MagneticModuleModel.MAGNETIC_V1, DeckSlotName.SLOT_3),
-        (7, ThermocyclerModuleModel.THERMOCYCLER_V1, DeckSlotName.SLOT_7),
-        ("7", ThermocyclerModuleModel.THERMOCYCLER_V2, DeckSlotName.SLOT_7),
-        (None, ThermocyclerModuleModel.THERMOCYCLER_V1, DeckSlotName.SLOT_7),
-        (None, ThermocyclerModuleModel.THERMOCYCLER_V2, DeckSlotName.SLOT_7),
-    ],
-)
-def test_ensure_module_deck_slot(
-    location: Union[int, str, None],
-    model: ModuleModel,
-    expected_slot: DeckSlotName,
-) -> None:
-    """It should map an optional int/str location to a deck slot for a module."""
-    result = subject.ensure_module_deck_slot(location, model)
-    assert result == expected_slot
-
-
-@pytest.mark.parametrize(
-    ("location", "model", "expected_error_type", "expected_message"),
-    [
-        (None, TemperatureModuleModel.TEMPERATURE_V1, ValueError, "Location required"),
-        (8, ThermocyclerModuleModel.THERMOCYCLER_V1, ValueError, "slot 7"),
-        ({}, MagneticModuleModel.MAGNETIC_V1, TypeError, "string or integer"),
-    ],
-)
-def test_ensure_module_deck_slot_invalid(
-    location: Any,
-    model: ModuleModel,
-    expected_error_type: Type[Exception],
-    expected_message: str,
-) -> None:
-    """It should reject semantically invalid deck slots."""
-    with pytest.raises(expected_error_type, match=expected_message):
-        subject.ensure_module_deck_slot(location, model)

--- a/api/tests/opentrons/protocol_api/types.py
+++ b/api/tests/opentrons/protocol_api/types.py
@@ -2,9 +2,11 @@
 from opentrons.protocol_api.core.protocol import AbstractProtocol
 from opentrons.protocol_api.core.instrument import AbstractInstrument
 from opentrons.protocol_api.core.labware import AbstractLabware
+from opentrons.protocol_api.core.module import AbstractModuleCore
 from opentrons.protocol_api.core.well import AbstractWellCore
 
 
 InstrumentCore = AbstractInstrument[AbstractWellCore]
 LabwareCore = AbstractLabware[AbstractWellCore]
-ProtocolCore = AbstractProtocol[InstrumentCore, LabwareCore]
+ModuleCore = AbstractModuleCore[LabwareCore]
+ProtocolCore = AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]

--- a/api/tests/opentrons/protocol_api_old/core/simulator/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api_old/core/simulator/test_protocol_context.py
@@ -8,16 +8,16 @@ from opentrons.types import Mount
 from opentrons.protocol_api.core.protocol import (
     AbstractProtocol as BaseAbstractProtocol,
 )
-from opentrons.protocol_api.core.labware import AbstractLabware as BaseAbstractLabware
-from opentrons.protocol_api.core.instrument import (
-    AbstractInstrument as BaseAbstractInstrument,
-)
+from opentrons.protocol_api.core.labware import AbstractLabware
+from opentrons.protocol_api.core.instrument import AbstractInstrument
+from opentrons.protocol_api.core.module import AbstractModuleCore
 from opentrons.protocol_api.core.well import AbstractWellCore
 
 
-AbstractInstrument = BaseAbstractInstrument[AbstractWellCore]
-AbstractLabware = BaseAbstractLabware[AbstractWellCore]
-AbstractProtocol = BaseAbstractProtocol[AbstractInstrument, AbstractLabware]
+InstrumentCore = AbstractInstrument[AbstractWellCore]
+LabwareCore = AbstractLabware[AbstractWellCore]
+ModuleCore = AbstractModuleCore[LabwareCore]
+ProtocolCore = BaseAbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]
 
 
 @pytest.fixture(
@@ -26,12 +26,12 @@ AbstractProtocol = BaseAbstractProtocol[AbstractInstrument, AbstractLabware]
         lazy_fixture("simulating_protocol_context"),
     ]
 )
-def subject(request: pytest.FixtureRequest) -> AbstractProtocol:
+def subject(request: pytest.FixtureRequest) -> ProtocolCore:
     return request.param  # type: ignore[attr-defined, no-any-return]
 
 
 def test_replacing_instrument_tip_state(
-    subject: AbstractProtocol, labware: AbstractLabware
+    subject: ProtocolCore, labware: LabwareCore
 ) -> None:
     """It should refer to same state when replacing the same pipette."""
     # This test validates that bug https://github.com/Opentrons/opentrons/issues/8273

--- a/api/tests/opentrons/protocol_api_old/test_module_context.py
+++ b/api/tests/opentrons/protocol_api_old/test_module_context.py
@@ -160,13 +160,13 @@ def test_load_module_default_slot(ctx_with_thermocycler):
 
 def test_no_slot_module_error(ctx_with_magdeck):
     ctx_with_magdeck.home()
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         assert ctx_with_magdeck.load_module("magdeck")
 
 
 def test_invalid_slot_module_error(ctx_with_thermocycler):
     ctx_with_thermocycler.home()
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         assert ctx_with_thermocycler.load_module("thermocycler", 1)
 
 


### PR DESCRIPTION
## Overview

This PR continues work on RCORE-103 by adding initial tests for `ProtocolContext.load_labware` and adding skeleton classes for the dependencies that the tests shook out.

## Changelog

- Add `AbstractModuleCore` to `opentrons.protocol_api.core`
    - Add `ModuleCore` implementation to `opentrons.protocol_api.core.engine` (future PAPIv2 core)
    - Add `LegacyModuleCore` implementation to `opentrons.protocol_api.core.protocol_api` (current PAPIv2 core)
- Update protocol core abstract class + implementations to account for specific module implementations
- Update `opentrons.protocol_api.validation` module with argument validators for load module

## Review requests

This PR is in the middle of the stack, so it won't be super useful to test (smoke or otherwise) compared to later PRs. Concentrate on code + tests + interface design.

If you would like to smoke test, use #11449

## Risk assessment

Low, very little actual implementation changes in here