### PR TITLE
feat(app): wire up the use attached pipette button and fix various bugs

### DIFF
--- a/app/src/organisms/ChangePipette/CheckPipettesButton.tsx
+++ b/app/src/organisms/ChangePipette/CheckPipettesButton.tsx
@@ -82,6 +82,40 @@ export function CheckPipettesButton(
     </DeprecatedPrimaryButton>
   )
 
+  const icon = (
+    <Icon name="ot-spinner" height="1rem" spin marginRight={SPACING.spacing3} />
+  )
+
+  let body
+  if (children != null && !isPending) {
+    body = children
+  } else if (children != null && isPending) {
+    body = (
+      <>
+        {icon}
+        {children}
+      </>
+    )
+  } else if (children == null && isPending) {
+    body = (
+      <>
+        <Icon
+          name="ot-spinner"
+          height="1rem"
+          spin
+          marginRight={SPACING.spacing3}
+        />
+        <StyledText>
+          {actualPipette
+            ? t('confirming_detachment')
+            : t('confirming_attachment')}
+        </StyledText>
+      </>
+    )
+  } else if (children == null && !isPending) {
+    body = actualPipette ? t('confirm_detachment') : t('confirm_attachment')
+  }
+
   return enableChangePipetteWizard ? (
     <PrimaryButton onClick={handleClick} aria-label="Confirm">
       <Flex
@@ -89,27 +123,7 @@ export function CheckPipettesButton(
         color={COLORS.white}
         alignItems={ALIGN_CENTER}
       >
-        {children != null ? (
-          children
-        ) : isPending ? (
-          <>
-            <Icon
-              name="ot-spinner"
-              height="1rem"
-              spin
-              marginRight={SPACING.spacing3}
-            />
-            <StyledText>
-              {actualPipette
-                ? t('confirming_detachment')
-                : t('confirming_attachment')}
-            </StyledText>
-          </>
-        ) : actualPipette ? (
-          t('confirm_detachment')
-        ) : (
-          t('confirm_attachment')
-        )}
+        {body}
       </Flex>
     </PrimaryButton>
   ) : (

--- a/app/src/organisms/ChangePipette/ConfirmPipette.tsx
+++ b/app/src/organisms/ChangePipette/ConfirmPipette.tsx
@@ -29,7 +29,7 @@ export interface ConfirmPipetteProps {
   displayName: string
   displayCategory: PipetteDisplayCategory | null
   mount: Mount
-  useWrongWantedPipette: PipetteNameSpecs | null
+  wrongWantedPipette: PipetteNameSpecs | null
   setWrongWantedPipette: React.Dispatch<
     React.SetStateAction<PipetteNameSpecs | null>
   >
@@ -45,7 +45,7 @@ export function ConfirmPipette(props: ConfirmPipetteProps): JSX.Element {
     success,
     mount,
     tryAgain,
-    useWrongWantedPipette,
+    wrongWantedPipette,
     actualPipette,
     setConfirmPipetteLevel,
     confirmPipetteLevel,
@@ -65,10 +65,10 @@ export function ConfirmPipette(props: ConfirmPipetteProps): JSX.Element {
     let header
     let subHeader
 
-    if ((wantedPipette && success) || useWrongWantedPipette) {
+    if ((wantedPipette && success) || wrongWantedPipette) {
       header = t('pipette_attached')
       subHeader = t('pipette_is_ready_to_use', {
-        pipette: useWrongWantedPipette
+        pipette: wrongWantedPipette
           ? actualPipette?.displayName
           : wantedPipette?.displayName,
       })
@@ -98,7 +98,7 @@ export function ConfirmPipette(props: ConfirmPipetteProps): JSX.Element {
   const { header, subHeader } = getPipetteStatusDetails({ ...props })
 
   return !confirmPipetteLevel &&
-    useWrongWantedPipette &&
+    wrongWantedPipette &&
     actualPipette != null &&
     actualPipette.channels === 8 ? (
     <LevelPipette
@@ -110,7 +110,7 @@ export function ConfirmPipette(props: ConfirmPipetteProps): JSX.Element {
   ) : (
     <SimpleWizardBody
       iconColor={
-        success || useWrongWantedPipette || confirmPipetteLevel
+        success || wrongWantedPipette || confirmPipetteLevel
           ? COLORS.successEnabled
           : COLORS.errorEnabled
       }
@@ -119,10 +119,10 @@ export function ConfirmPipette(props: ConfirmPipetteProps): JSX.Element {
       isSuccess={success}
     >
       <>
-        {!success && !useWrongWantedPipette && !confirmPipetteLevel && (
+        {!success && !wrongWantedPipette && !confirmPipetteLevel && (
           <TryAgainButton {...props} />
         )}
-        {success || useWrongWantedPipette || confirmPipetteLevel ? (
+        {success || wrongWantedPipette || confirmPipetteLevel ? (
           <SuccessAndExitButtons
             {...props}
             confirmPipetteLevel={confirmPipetteLevel}
@@ -142,11 +142,11 @@ function TryAgainButton(props: ConfirmPipetteProps): JSX.Element {
     tryAgain,
     exit,
     setWrongWantedPipette,
-    useWrongWantedPipette,
+    wrongWantedPipette,
   } = props
   const { t } = useTranslation('change_pipette')
 
-  if (wantedPipette && attachedWrong && !useWrongWantedPipette) {
+  if (wantedPipette && attachedWrong && !wrongWantedPipette) {
     return (
       <>
         <SecondaryButton
@@ -189,13 +189,13 @@ function SuccessAndExitButtons(props: ConfirmPipetteProps): JSX.Element {
     exit,
     toCalibrationDashboard,
     success,
-    useWrongWantedPipette,
+    wrongWantedPipette,
     confirmPipetteLevel,
   } = props
   const { t } = useTranslation('change_pipette')
   return (
     <>
-      {useWrongWantedPipette ||
+      {wrongWantedPipette ||
       (success && actualPipette && !actualPipetteOffset) ||
       confirmPipetteLevel ? (
         <SecondaryButton

--- a/app/src/organisms/ChangePipette/ConfirmPipette.tsx
+++ b/app/src/organisms/ChangePipette/ConfirmPipette.tsx
@@ -33,6 +33,8 @@ export interface ConfirmPipetteProps {
   setWrongWantedPipette: React.Dispatch<
     React.SetStateAction<PipetteNameSpecs | null>
   >
+  confirmPipetteLevel: boolean
+  setConfirmPipetteLevel: React.Dispatch<React.SetStateAction<boolean>>
   tryAgain: () => void
   exit: () => void
   toCalibrationDashboard: () => void
@@ -49,11 +51,10 @@ export function ConfirmPipette(props: ConfirmPipetteProps): JSX.Element {
     tryAgain,
     useWrongWantedPipette,
     actualPipette,
+    setConfirmPipetteLevel,
+    confirmPipetteLevel,
   } = props
   const { t } = useTranslation('change_pipette')
-  const [confirmPipetteLevel, setConfirmPipetteLevel] = React.useState<boolean>(
-    false
-  )
 
   const getPipetteStatusDetails = (
     props: ConfirmPipetteProps

--- a/app/src/organisms/ChangePipette/ConfirmPipette.tsx
+++ b/app/src/organisms/ChangePipette/ConfirmPipette.tsx
@@ -101,6 +101,8 @@ export function ConfirmPipette(props: ConfirmPipetteProps): JSX.Element {
 
   const { header, subHeader } = getPipetteStatusDetails({ ...props })
 
+  const isWrongWantedPipette = wrongWantedPipette != null
+
   return !confirmPipetteLevel &&
     wrongWantedPipette &&
     actualPipette != null &&
@@ -120,7 +122,7 @@ export function ConfirmPipette(props: ConfirmPipetteProps): JSX.Element {
       }
       header={header}
       subHeader={subHeader}
-      isSuccess={success}
+      isSuccess={success || isWrongWantedPipette || confirmPipetteLevel}
     >
       <>
         {!success && !wrongWantedPipette && !confirmPipetteLevel && (
@@ -194,14 +196,12 @@ function SuccessAndExitButtons(props: ConfirmPipetteProps): JSX.Element {
     toCalibrationDashboard,
     success,
     wrongWantedPipette,
-    confirmPipetteLevel,
   } = props
   const { t } = useTranslation('change_pipette')
   return (
     <>
-      {wrongWantedPipette ||
-      (success && actualPipette && !actualPipetteOffset) ||
-      confirmPipetteLevel ? (
+      {!actualPipetteOffset &&
+      (wrongWantedPipette || (success && actualPipette)) ? (
         <SecondaryButton
           marginRight={SPACING.spacing3}
           onClick={toCalibrationDashboard}

--- a/app/src/organisms/ChangePipette/ConfirmPipette.tsx
+++ b/app/src/organisms/ChangePipette/ConfirmPipette.tsx
@@ -22,6 +22,8 @@ import type { Mount } from '../../redux/pipettes/types'
 export interface ConfirmPipetteProps {
   robotName: string
   success: boolean
+  //  attachedWrong is referring to when a user attaches a pipette that is different
+  //  from wantedPipette
   attachedWrong: boolean
   wantedPipette: PipetteNameSpecs | null
   actualPipette: PipetteModelSpecs | null
@@ -29,6 +31,8 @@ export interface ConfirmPipetteProps {
   displayName: string
   displayCategory: PipetteDisplayCategory | null
   mount: Mount
+  //  wrongWantedPipette is referring to if the user attaches a pipette that is different
+  //  from wantedPipette and they want to use it anyway
   wrongWantedPipette: PipetteNameSpecs | null
   setWrongWantedPipette: React.Dispatch<
     React.SetStateAction<PipetteNameSpecs | null>

--- a/app/src/organisms/ChangePipette/ConfirmPipette.tsx
+++ b/app/src/organisms/ChangePipette/ConfirmPipette.tsx
@@ -40,10 +40,6 @@ export interface ConfirmPipetteProps {
   toCalibrationDashboard: () => void
 }
 
-export interface SuccessAndExitProps extends ConfirmPipetteProps {
-  confirmPipetteLevel: boolean
-}
-
 export function ConfirmPipette(props: ConfirmPipetteProps): JSX.Element {
   const {
     success,
@@ -186,7 +182,7 @@ function TryAgainButton(props: ConfirmPipetteProps): JSX.Element {
   )
 }
 
-function SuccessAndExitButtons(props: SuccessAndExitProps): JSX.Element {
+function SuccessAndExitButtons(props: ConfirmPipetteProps): JSX.Element {
   const {
     actualPipette,
     actualPipetteOffset,

--- a/app/src/organisms/ChangePipette/Instructions.tsx
+++ b/app/src/organisms/ChangePipette/Instructions.tsx
@@ -40,6 +40,7 @@ interface Props {
   confirm: () => void
   stepPage: number
   setStepPage: React.Dispatch<React.SetStateAction<number>>
+  attachedWrong: boolean
 }
 
 const GO_BACK_BUTTON_STYLE = css`
@@ -65,6 +66,7 @@ export function Instructions(props: Props): JSX.Element {
     stepPage,
     setStepPage,
     confirm,
+    attachedWrong,
   } = props
   const { t } = useTranslation('change_pipette')
 
@@ -177,7 +179,8 @@ export function Instructions(props: Props): JSX.Element {
                 onDone={
                   wantedPipette != null &&
                   actualPipette != null &&
-                  shouldLevel(wantedPipette)
+                  shouldLevel(wantedPipette) &&
+                  !attachedWrong
                     ? () => setStepPage(2)
                     : confirm
                 }

--- a/app/src/organisms/ChangePipette/LevelPipette.tsx
+++ b/app/src/organisms/ChangePipette/LevelPipette.tsx
@@ -65,7 +65,7 @@ export function LevelPipette(props: LevelPipetteProps): JSX.Element {
         <Flex
           flexDirection={DIRECTION_ROW}
           justifyContent={JUSTIFY_SPACE_BETWEEN}
-          marginBottom="40px"
+          marginBottom={SPACING.spacingXXL}
         >
           <Flex flexDirection={DIRECTION_COLUMN}>
             <Trans

--- a/app/src/organisms/ChangePipette/__tests__/ChangePipette.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/ChangePipette.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { act } from '@testing-library/react-hooks'
 import { fireEvent } from '@testing-library/react'
 import { when } from 'jest-when'
 import { renderWithProviders } from '@opentrons/components'
@@ -208,15 +207,6 @@ describe('ChangePipette', () => {
 
     //  Instructions page
     getByText('Attach a pipette')
-
-    //  attach the pipette
-    act(() => {
-      when(mockGetPipetteNameSpecs)
-        .calledWith('p300_single_gen2')
-        .mockReturnValue(mockP300PipetteNameSpecs)
-    })
-
-    //  TODO(jr, 08/30/22): extend this test for attaching a pipette so you can go through the remainder of the flow
   })
 
   it('renders the wizard pages for detaching a single channel pipette and exits on the 2nd page rendering exit modal', () => {
@@ -290,16 +280,6 @@ describe('ChangePipette', () => {
     fireEvent.click(cont)
 
     //  Instructions page 2
-    //  disconnect the attached pipette
-    act(() => {
-      mockGetAttachedPipettes.mockReturnValue({
-        left: null,
-        right: null,
-      })
-    })
-    const confirm = getByLabelText('Confirm')
-    fireEvent.click(confirm)
-
-    //  TODO(jr, 08/30/22): extend this test to test for the final confirm pipette page, need to remove attach pieptte
+    getByLabelText('Confirm')
   })
 })

--- a/app/src/organisms/ChangePipette/__tests__/ConfirmPipette.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/ConfirmPipette.test.tsx
@@ -99,6 +99,8 @@ describe('ConfirmPipette', () => {
       mount: LEFT,
       setWrongWantedPipette: jest.fn(),
       useWrongWantedPipette: null,
+      confirmPipetteLevel: false,
+      setConfirmPipetteLevel: jest.fn(),
     }
 
     const { getByText, getByRole } = render(props)
@@ -124,6 +126,8 @@ describe('ConfirmPipette', () => {
       mount: LEFT,
       setWrongWantedPipette: jest.fn(),
       useWrongWantedPipette: null,
+      confirmPipetteLevel: false,
+      setConfirmPipetteLevel: jest.fn(),
     }
 
     const { getByText, getByRole } = render(props)
@@ -157,6 +161,8 @@ describe('ConfirmPipette', () => {
       mount: LEFT,
       setWrongWantedPipette: jest.fn(),
       useWrongWantedPipette: null,
+      confirmPipetteLevel: false,
+      setConfirmPipetteLevel: jest.fn(),
     }
 
     const { getByText, getByRole } = render(props)
@@ -190,6 +196,8 @@ describe('ConfirmPipette', () => {
       mount: LEFT,
       setWrongWantedPipette: jest.fn(),
       useWrongWantedPipette: MOCK_ACTUAL_PIPETTE,
+      confirmPipetteLevel: false,
+      setConfirmPipetteLevel: jest.fn(),
     }
 
     const { getByText, getByRole } = render(props)
@@ -220,6 +228,8 @@ describe('ConfirmPipette', () => {
       mount: LEFT,
       setWrongWantedPipette: jest.fn(),
       useWrongWantedPipette: null,
+      confirmPipetteLevel: false,
+      setConfirmPipetteLevel: jest.fn(),
     }
 
     const { getByText, getByRole } = render(props)
@@ -237,7 +247,7 @@ describe('ConfirmPipette', () => {
     expect(props.setWrongWantedPipette).toHaveBeenCalled()
   })
 
-  it('Should show pipette leveling modal and success modal when incorrect pipette attached for 8 channel but user accepts it', () => {
+  it('Should show pipette leveling modal when incorrect pipette attached for 8 channel but user accepts it', () => {
     props = {
       robotName: 'otie',
       success: false,
@@ -253,6 +263,8 @@ describe('ConfirmPipette', () => {
       mount: LEFT,
       setWrongWantedPipette: jest.fn(),
       useWrongWantedPipette: MOCK_WANTED_PIPETTE,
+      confirmPipetteLevel: false,
+      setConfirmPipetteLevel: jest.fn(),
     }
 
     const { getByText, getByRole } = render(props)
@@ -262,12 +274,35 @@ describe('ConfirmPipette', () => {
     expect(props.tryAgain).toHaveBeenCalled()
     const continueBtn = getByRole('button', { name: 'Confirm level' })
     fireEvent.click(continueBtn)
+    expect(props.setConfirmPipetteLevel).toHaveBeenCalled()
+  })
+
+  it('renders the success modal when the confirmPipetteLevel is true when attaching an incorrect 8 channel pipette', () => {
+    props = {
+      robotName: 'otie',
+      success: false,
+      attachedWrong: true,
+      wantedPipette: MOCK_WANTED_PIPETTE,
+      actualPipette: MOCK_WANTED_PIPETTE as PipetteModelSpecs,
+      actualPipetteOffset: {} as PipetteOffsetCalibration,
+      displayName: '',
+      displayCategory: null,
+      tryAgain: jest.fn(),
+      exit: jest.fn(),
+      toCalibrationDashboard: jest.fn(),
+      mount: LEFT,
+      setWrongWantedPipette: jest.fn(),
+      useWrongWantedPipette: MOCK_WANTED_PIPETTE,
+      confirmPipetteLevel: true,
+      setConfirmPipetteLevel: jest.fn(),
+    }
+
+    const { getByText, getByRole } = render(props)
     getByText('Pipette attached!')
     getByText('P300 8-Channel GEN2 is now ready to use.')
     const btn = getByRole('button', { name: 'exit' })
     fireEvent.click(btn)
     expect(props.exit).toHaveBeenCalled()
-
     const pocBtn = getByRole('button', { name: 'Calibrate pipette offset' })
     fireEvent.click(pocBtn)
     expect(props.toCalibrationDashboard).toBeCalled()
@@ -290,6 +325,8 @@ describe('ConfirmPipette', () => {
       mount: LEFT,
       setWrongWantedPipette: jest.fn(),
       useWrongWantedPipette: null,
+      confirmPipetteLevel: false,
+      setConfirmPipetteLevel: jest.fn(),
     }
 
     const { getByText, getByRole } = render(props)
@@ -323,6 +360,8 @@ describe('ConfirmPipette', () => {
       mount: LEFT,
       setWrongWantedPipette: jest.fn(),
       useWrongWantedPipette: null,
+      confirmPipetteLevel: false,
+      setConfirmPipetteLevel: jest.fn(),
     }
 
     const { getByText, getByRole } = render(props)
@@ -349,6 +388,8 @@ describe('ConfirmPipette', () => {
       mount: LEFT,
       setWrongWantedPipette: jest.fn(),
       useWrongWantedPipette: null,
+      confirmPipetteLevel: false,
+      setConfirmPipetteLevel: jest.fn(),
     }
 
     const { getByText, getByRole } = render(props)

--- a/app/src/organisms/ChangePipette/__tests__/ConfirmPipette.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/ConfirmPipette.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { renderWithProviders } from '@opentrons/components'
-import { fireEvent } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import { i18n } from '../../../i18n'
 import { LEFT } from '@opentrons/shared-data'
 import { mockPipetteInfo } from '../../../redux/pipettes/__fixtures__'
@@ -206,10 +206,9 @@ describe('ConfirmPipette', () => {
     const btn = getByRole('button', { name: 'exit' })
     fireEvent.click(btn)
     expect(props.exit).toHaveBeenCalled()
-
-    const pocBtn = getByRole('button', { name: 'Calibrate pipette offset' })
-    fireEvent.click(pocBtn)
-    expect(props.toCalibrationDashboard).toBeCalled()
+    expect(
+      screen.queryByRole('button', { name: 'Calibrate pipette offset' })
+    ).not.toBeInTheDocument()
   })
 
   it('renders incorrect pipette attached for eight channel when the actual pipette is different', () => {
@@ -277,14 +276,14 @@ describe('ConfirmPipette', () => {
     expect(props.setConfirmPipetteLevel).toHaveBeenCalled()
   })
 
-  it('renders the success modal when the confirmPipetteLevel is true when attaching an incorrect 8 channel pipette', () => {
+  it('renders the success modal when the confirmPipetteLevel is true when attaching an incorrect 8 channel pipette with no pipetteoffset data', () => {
     props = {
       robotName: 'otie',
       success: false,
       attachedWrong: true,
       wantedPipette: MOCK_WANTED_PIPETTE,
       actualPipette: MOCK_WANTED_PIPETTE as PipetteModelSpecs,
-      actualPipetteOffset: {} as PipetteOffsetCalibration,
+      actualPipetteOffset: null,
       displayName: '',
       displayCategory: null,
       tryAgain: jest.fn(),

--- a/app/src/organisms/ChangePipette/__tests__/ConfirmPipette.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/ConfirmPipette.test.tsx
@@ -2,11 +2,16 @@ import * as React from 'react'
 import { renderWithProviders } from '@opentrons/components'
 import { fireEvent } from '@testing-library/react'
 import { i18n } from '../../../i18n'
-import { ConfirmPipette } from '../ConfirmPipette'
-import { PipetteModelSpecs, PipetteNameSpecs } from '@opentrons/shared-data'
+import { LEFT } from '@opentrons/shared-data'
 import { mockPipetteInfo } from '../../../redux/pipettes/__fixtures__'
-import { PipetteOffsetCalibration } from '../../../redux/calibration/types'
 import { CheckPipettesButton } from '../CheckPipettesButton'
+import { ConfirmPipette } from '../ConfirmPipette'
+
+import type {
+  PipetteModelSpecs,
+  PipetteNameSpecs,
+} from '@opentrons/shared-data'
+import type { PipetteOffsetCalibration } from '../../../redux/calibration/types'
 
 jest.mock('../CheckPipettesButton')
 
@@ -26,6 +31,11 @@ const MOCK_ACTUAL_PIPETTE = {
   tipLength: {
     value: 20,
   },
+} as PipetteModelSpecs
+
+const MOCK_ACTUAL_PIPETTE_EIGHT_CHANNEL = {
+  channels: 8,
+  name: 'p10_multi',
 } as PipetteModelSpecs
 
 const MOCK_WANTED_PIPETTE = {
@@ -86,6 +96,7 @@ describe('ConfirmPipette', () => {
       tryAgain: jest.fn(),
       exit: jest.fn(),
       toCalibrationDashboard: jest.fn(),
+      mount: LEFT,
     }
 
     const { getByText, getByRole } = render(props)
@@ -108,6 +119,7 @@ describe('ConfirmPipette', () => {
       tryAgain: jest.fn(),
       exit: jest.fn(),
       toCalibrationDashboard: jest.fn(),
+      mount: LEFT,
     }
 
     const { getByText, getByRole } = render(props)
@@ -125,7 +137,7 @@ describe('ConfirmPipette', () => {
     expect(props.tryAgain).toBeCalled()
   })
 
-  it('Should show incorrect pipette attached when the actual pipette is different', () => {
+  it.only('Should show incorrect pipette attached for single channel when the actual pipette is different', () => {
     props = {
       robotName: 'otie',
       success: false,
@@ -138,6 +150,7 @@ describe('ConfirmPipette', () => {
       tryAgain: jest.fn(),
       exit: jest.fn(),
       toCalibrationDashboard: jest.fn(),
+      mount: LEFT,
     }
 
     const { getByText, getByRole } = render(props)
@@ -145,16 +158,55 @@ describe('ConfirmPipette', () => {
     getByText(
       'The attached does not match the P300 8-Channel GEN2 you had originally selected.'
     )
-
-    const useAttachedBtn = getByRole('button', { name: 'Use attached pipette' })
-    fireEvent.click(useAttachedBtn)
-    expect(props.exit).toBeCalled()
-
     const detachTryAgainBtn = getByRole('button', {
       name: 'Detach and try again',
     })
     fireEvent.click(detachTryAgainBtn)
     expect(props.tryAgain).toBeCalled()
+    const useAttachedBtn = getByRole('button', { name: 'Use attached pipette' })
+    fireEvent.click(useAttachedBtn)
+    //  goes to success page since incorrect pipette is what you want and it is single channel
+    getByText('Pipette attached!')
+    getByText('P10 Single-Channel is now ready to use.')
+    const btn = getByRole('button', { name: 'exit' })
+    fireEvent.click(btn)
+    expect(props.exit).toHaveBeenCalled()
+
+    const pocBtn = getByRole('button', { name: 'Calibrate pipette offset' })
+    fireEvent.click(pocBtn)
+    expect(props.toCalibrationDashboard).toBeCalled()
+  })
+
+  it('renders incorrect pipette attached for eight channel when the actual pipette is different', () => {
+    props = {
+      robotName: 'otie',
+      success: false,
+      attachedWrong: true,
+      wantedPipette: MOCK_WANTED_PIPETTE,
+      actualPipette: MOCK_ACTUAL_PIPETTE_EIGHT_CHANNEL,
+      actualPipetteOffset: {} as PipetteOffsetCalibration,
+      displayName: '',
+      displayCategory: null,
+      tryAgain: jest.fn(),
+      exit: jest.fn(),
+      toCalibrationDashboard: jest.fn(),
+      mount: LEFT,
+    }
+
+    const { getByText, getByRole } = render(props)
+    getByText('Incorrect pipette attached')
+    getByText(
+      'The attached does not match the P300 8-Channel GEN2 you had originally selected.'
+    )
+    const detachTryAgainBtn = getByRole('button', {
+      name: 'Detach and try again',
+    })
+    fireEvent.click(detachTryAgainBtn)
+    expect(props.tryAgain).toBeCalled()
+    const useAttachedBtn = getByRole('button', { name: 'Use attached pipette' })
+    fireEvent.click(useAttachedBtn)
+    //  goes to success page since incorrect pipette is what you want and it is single channel
+    getByText('blah')
   })
 
   it('Should show unable to detect pipette when a pipette is not connected', () => {
@@ -171,6 +223,7 @@ describe('ConfirmPipette', () => {
       tryAgain: jest.fn(),
       exit: jest.fn(),
       toCalibrationDashboard: jest.fn(),
+      mount: LEFT,
     }
 
     const { getByText, getByRole } = render(props)
@@ -201,6 +254,7 @@ describe('ConfirmPipette', () => {
       tryAgain: jest.fn(),
       exit: jest.fn(),
       toCalibrationDashboard: jest.fn(),
+      mount: LEFT,
     }
 
     const { getByText, getByRole } = render(props)
@@ -224,6 +278,7 @@ describe('ConfirmPipette', () => {
       tryAgain: jest.fn(),
       exit: jest.fn(),
       toCalibrationDashboard: jest.fn(),
+      mount: LEFT,
     }
 
     const { getByText, getByRole } = render(props)

--- a/app/src/organisms/ChangePipette/__tests__/ConfirmPipette.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/ConfirmPipette.test.tsx
@@ -98,7 +98,7 @@ describe('ConfirmPipette', () => {
       toCalibrationDashboard: jest.fn(),
       mount: LEFT,
       setWrongWantedPipette: jest.fn(),
-      useWrongWantedPipette: null,
+      wrongWantedPipette: null,
       confirmPipetteLevel: false,
       setConfirmPipetteLevel: jest.fn(),
     }
@@ -125,7 +125,7 @@ describe('ConfirmPipette', () => {
       toCalibrationDashboard: jest.fn(),
       mount: LEFT,
       setWrongWantedPipette: jest.fn(),
-      useWrongWantedPipette: null,
+      wrongWantedPipette: null,
       confirmPipetteLevel: false,
       setConfirmPipetteLevel: jest.fn(),
     }
@@ -160,7 +160,7 @@ describe('ConfirmPipette', () => {
       toCalibrationDashboard: jest.fn(),
       mount: LEFT,
       setWrongWantedPipette: jest.fn(),
-      useWrongWantedPipette: null,
+      wrongWantedPipette: null,
       confirmPipetteLevel: false,
       setConfirmPipetteLevel: jest.fn(),
     }
@@ -195,7 +195,7 @@ describe('ConfirmPipette', () => {
       toCalibrationDashboard: jest.fn(),
       mount: LEFT,
       setWrongWantedPipette: jest.fn(),
-      useWrongWantedPipette: MOCK_ACTUAL_PIPETTE,
+      wrongWantedPipette: MOCK_ACTUAL_PIPETTE,
       confirmPipetteLevel: false,
       setConfirmPipetteLevel: jest.fn(),
     }
@@ -227,7 +227,7 @@ describe('ConfirmPipette', () => {
       toCalibrationDashboard: jest.fn(),
       mount: LEFT,
       setWrongWantedPipette: jest.fn(),
-      useWrongWantedPipette: null,
+      wrongWantedPipette: null,
       confirmPipetteLevel: false,
       setConfirmPipetteLevel: jest.fn(),
     }
@@ -262,7 +262,7 @@ describe('ConfirmPipette', () => {
       toCalibrationDashboard: jest.fn(),
       mount: LEFT,
       setWrongWantedPipette: jest.fn(),
-      useWrongWantedPipette: MOCK_WANTED_PIPETTE,
+      wrongWantedPipette: MOCK_WANTED_PIPETTE,
       confirmPipetteLevel: false,
       setConfirmPipetteLevel: jest.fn(),
     }
@@ -292,7 +292,7 @@ describe('ConfirmPipette', () => {
       toCalibrationDashboard: jest.fn(),
       mount: LEFT,
       setWrongWantedPipette: jest.fn(),
-      useWrongWantedPipette: MOCK_WANTED_PIPETTE,
+      wrongWantedPipette: MOCK_WANTED_PIPETTE,
       confirmPipetteLevel: true,
       setConfirmPipetteLevel: jest.fn(),
     }
@@ -324,7 +324,7 @@ describe('ConfirmPipette', () => {
       toCalibrationDashboard: jest.fn(),
       mount: LEFT,
       setWrongWantedPipette: jest.fn(),
-      useWrongWantedPipette: null,
+      wrongWantedPipette: null,
       confirmPipetteLevel: false,
       setConfirmPipetteLevel: jest.fn(),
     }
@@ -359,7 +359,7 @@ describe('ConfirmPipette', () => {
       toCalibrationDashboard: jest.fn(),
       mount: LEFT,
       setWrongWantedPipette: jest.fn(),
-      useWrongWantedPipette: null,
+      wrongWantedPipette: null,
       confirmPipetteLevel: false,
       setConfirmPipetteLevel: jest.fn(),
     }
@@ -387,7 +387,7 @@ describe('ConfirmPipette', () => {
       toCalibrationDashboard: jest.fn(),
       mount: LEFT,
       setWrongWantedPipette: jest.fn(),
-      useWrongWantedPipette: null,
+      wrongWantedPipette: null,
       confirmPipetteLevel: false,
       setConfirmPipetteLevel: jest.fn(),
     }

--- a/app/src/organisms/ChangePipette/__tests__/ConfirmPipette.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/ConfirmPipette.test.tsx
@@ -97,6 +97,8 @@ describe('ConfirmPipette', () => {
       exit: jest.fn(),
       toCalibrationDashboard: jest.fn(),
       mount: LEFT,
+      setWrongWantedPipette: jest.fn(),
+      useWrongWantedPipette: null,
     }
 
     const { getByText, getByRole } = render(props)
@@ -120,6 +122,8 @@ describe('ConfirmPipette', () => {
       exit: jest.fn(),
       toCalibrationDashboard: jest.fn(),
       mount: LEFT,
+      setWrongWantedPipette: jest.fn(),
+      useWrongWantedPipette: null,
     }
 
     const { getByText, getByRole } = render(props)
@@ -137,7 +141,7 @@ describe('ConfirmPipette', () => {
     expect(props.tryAgain).toBeCalled()
   })
 
-  it.only('Should show incorrect pipette attached for single channel when the actual pipette is different', () => {
+  it('Should show incorrect pipette attached for single channel when the actual pipette is different', () => {
     props = {
       robotName: 'otie',
       success: false,
@@ -151,6 +155,8 @@ describe('ConfirmPipette', () => {
       exit: jest.fn(),
       toCalibrationDashboard: jest.fn(),
       mount: LEFT,
+      setWrongWantedPipette: jest.fn(),
+      useWrongWantedPipette: null,
     }
 
     const { getByText, getByRole } = render(props)
@@ -165,7 +171,28 @@ describe('ConfirmPipette', () => {
     expect(props.tryAgain).toBeCalled()
     const useAttachedBtn = getByRole('button', { name: 'Use attached pipette' })
     fireEvent.click(useAttachedBtn)
-    //  goes to success page since incorrect pipette is what you want and it is single channel
+    expect(props.setWrongWantedPipette).toHaveBeenCalled()
+  })
+
+  it('Should show success modal when incorrect pipette attached but user accepts it', () => {
+    props = {
+      robotName: 'otie',
+      success: false,
+      attachedWrong: true,
+      wantedPipette: MOCK_ACTUAL_PIPETTE,
+      actualPipette: MOCK_ACTUAL_PIPETTE,
+      actualPipetteOffset: {} as PipetteOffsetCalibration,
+      displayName: '',
+      displayCategory: null,
+      tryAgain: jest.fn(),
+      exit: jest.fn(),
+      toCalibrationDashboard: jest.fn(),
+      mount: LEFT,
+      setWrongWantedPipette: jest.fn(),
+      useWrongWantedPipette: MOCK_ACTUAL_PIPETTE,
+    }
+
+    const { getByText, getByRole } = render(props)
     getByText('Pipette attached!')
     getByText('P10 Single-Channel is now ready to use.')
     const btn = getByRole('button', { name: 'exit' })
@@ -191,6 +218,8 @@ describe('ConfirmPipette', () => {
       exit: jest.fn(),
       toCalibrationDashboard: jest.fn(),
       mount: LEFT,
+      setWrongWantedPipette: jest.fn(),
+      useWrongWantedPipette: null,
     }
 
     const { getByText, getByRole } = render(props)
@@ -205,8 +234,43 @@ describe('ConfirmPipette', () => {
     expect(props.tryAgain).toBeCalled()
     const useAttachedBtn = getByRole('button', { name: 'Use attached pipette' })
     fireEvent.click(useAttachedBtn)
-    //  goes to success page since incorrect pipette is what you want and it is single channel
-    getByText('blah')
+    expect(props.setWrongWantedPipette).toHaveBeenCalled()
+  })
+
+  it('Should show pipette leveling modal and success modal when incorrect pipette attached for 8 channel but user accepts it', () => {
+    props = {
+      robotName: 'otie',
+      success: false,
+      attachedWrong: true,
+      wantedPipette: MOCK_WANTED_PIPETTE,
+      actualPipette: MOCK_WANTED_PIPETTE as PipetteModelSpecs,
+      actualPipetteOffset: {} as PipetteOffsetCalibration,
+      displayName: '',
+      displayCategory: null,
+      tryAgain: jest.fn(),
+      exit: jest.fn(),
+      toCalibrationDashboard: jest.fn(),
+      mount: LEFT,
+      setWrongWantedPipette: jest.fn(),
+      useWrongWantedPipette: MOCK_WANTED_PIPETTE,
+    }
+
+    const { getByText, getByRole } = render(props)
+    getByText('Level the pipette')
+    const goBack = getByRole('button', { name: 'Go back' })
+    fireEvent.click(goBack)
+    expect(props.tryAgain).toHaveBeenCalled()
+    const continueBtn = getByRole('button', { name: 'Confirm level' })
+    fireEvent.click(continueBtn)
+    getByText('Pipette attached!')
+    getByText('P300 8-Channel GEN2 is now ready to use.')
+    const btn = getByRole('button', { name: 'exit' })
+    fireEvent.click(btn)
+    expect(props.exit).toHaveBeenCalled()
+
+    const pocBtn = getByRole('button', { name: 'Calibrate pipette offset' })
+    fireEvent.click(pocBtn)
+    expect(props.toCalibrationDashboard).toBeCalled()
   })
 
   it('Should show unable to detect pipette when a pipette is not connected', () => {
@@ -224,6 +288,8 @@ describe('ConfirmPipette', () => {
       exit: jest.fn(),
       toCalibrationDashboard: jest.fn(),
       mount: LEFT,
+      setWrongWantedPipette: jest.fn(),
+      useWrongWantedPipette: null,
     }
 
     const { getByText, getByRole } = render(props)
@@ -255,6 +321,8 @@ describe('ConfirmPipette', () => {
       exit: jest.fn(),
       toCalibrationDashboard: jest.fn(),
       mount: LEFT,
+      setWrongWantedPipette: jest.fn(),
+      useWrongWantedPipette: null,
     }
 
     const { getByText, getByRole } = render(props)
@@ -279,6 +347,8 @@ describe('ConfirmPipette', () => {
       exit: jest.fn(),
       toCalibrationDashboard: jest.fn(),
       mount: LEFT,
+      setWrongWantedPipette: jest.fn(),
+      useWrongWantedPipette: null,
     }
 
     const { getByText, getByRole } = render(props)

--- a/app/src/organisms/ChangePipette/__tests__/Instructions.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/Instructions.test.tsx
@@ -1,17 +1,23 @@
 import * as React from 'react'
 import { nestedTextMatcher, renderWithProviders } from '@opentrons/components'
 import { fireEvent, screen } from '@testing-library/react'
-import { LEFT, PipetteModelSpecs } from '@opentrons/shared-data'
+import { LEFT } from '@opentrons/shared-data'
 import { fixtureP10Multi } from '@opentrons/shared-data/pipette/fixtures/name'
 import { i18n } from '../../../i18n'
 import { mockPipetteInfo } from '../../../redux/pipettes/__fixtures__'
+import { LevelPipette } from '../LevelPipette'
 import { Instructions } from '../Instructions'
 import { CheckPipettesButton } from '../CheckPipettesButton'
+import type { PipetteModelSpecs } from '@opentrons/shared-data'
 
 jest.mock('../CheckPipettesButton')
+jest.mock('../LevelPipette')
 
 const mockCheckPipettesButton = CheckPipettesButton as jest.MockedFunction<
   typeof CheckPipettesButton
+>
+const mockLevelPipette = LevelPipette as jest.MockedFunction<
+  typeof LevelPipette
 >
 
 const render = (props: React.ComponentProps<typeof Instructions>) => {
@@ -44,6 +50,7 @@ describe('Instructions', () => {
       back: jest.fn(),
       setStepPage: jest.fn(),
       stepPage: 0,
+      attachedWrong: false,
     }
     mockCheckPipettesButton.mockReturnValue(
       <div>mock check pipettes button</div>
@@ -94,6 +101,7 @@ describe('Instructions', () => {
       back: jest.fn(),
       setStepPage: jest.fn(),
       stepPage: 0,
+      attachedWrong: false,
     }
     const { getByText, getByRole } = render(props)
     getByText('Choose a pipette to attach')
@@ -116,6 +124,7 @@ describe('Instructions', () => {
       back: jest.fn(),
       setStepPage: jest.fn(),
       stepPage: 0,
+      attachedWrong: false,
     }
     const { getByText, getByRole, getByAltText } = render(props)
     getByText('Insert screws')
@@ -147,6 +156,7 @@ describe('Instructions', () => {
       back: jest.fn(),
       setStepPage: jest.fn(),
       stepPage: 1,
+      attachedWrong: false,
     }
     const { getByText, getByRole, getByAltText } = render(props)
     getByText('Attach the pipette')
@@ -173,6 +183,7 @@ describe('Instructions', () => {
       back: jest.fn(),
       setStepPage: jest.fn(),
       stepPage: 0,
+      attachedWrong: false,
     }
     const { getByText, getByRole, getByAltText } = render(props)
     getByText('Insert screws')
@@ -203,6 +214,7 @@ describe('Instructions', () => {
       back: jest.fn(),
       setStepPage: jest.fn(),
       stepPage: 1,
+      attachedWrong: false,
     }
     const { getByText, getByRole, getByAltText } = render(props)
     getByText('Attach the pipette')
@@ -216,6 +228,50 @@ describe('Instructions', () => {
     getByText('mock check pipettes button')
   })
 
-  //  TOD0(JR, 29.08.22): figure out how to mock the checkPipetteButton so you can click on it
-  //  and render the LevelPipette component
+  it('renders the attach flow 2nd page when a p10 8 channel is selected and the pipette is wrong', () => {
+    props = {
+      robotName: 'otie',
+      mount: LEFT,
+      wantedPipette: fixtureP10Multi,
+      actualPipette: null,
+      displayCategory: 'GEN1',
+      direction: 'attach',
+      setWantedName: jest.fn(),
+      confirm: jest.fn(),
+      back: jest.fn(),
+      setStepPage: jest.fn(),
+      stepPage: 1,
+      attachedWrong: true,
+    }
+    const { getByText, getByRole, getByAltText } = render(props)
+    getByText('Attach the pipette')
+    getByText(
+      'Push in the white connector tab until you feel it plug into the pipette.'
+    )
+    getByAltText('attach-left-multi-GEN1-tab')
+    const goBack = getByRole('button', { name: 'Go back' })
+    fireEvent.click(goBack)
+    expect(props.setStepPage).toHaveBeenCalled()
+    getByText('mock check pipettes button')
+  })
+
+  it('renders the attach flow 3rd page when a p300 8 channel is selected', () => {
+    mockLevelPipette.mockReturnValue(<div>mockLevelPipette</div>)
+    props = {
+      robotName: 'otie',
+      mount: LEFT,
+      wantedPipette: fixtureP10Multi,
+      actualPipette: fixtureP10Multi as PipetteModelSpecs,
+      displayCategory: 'GEN1',
+      direction: 'attach',
+      setWantedName: jest.fn(),
+      confirm: jest.fn(),
+      back: jest.fn(),
+      setStepPage: jest.fn(),
+      stepPage: 2,
+      attachedWrong: false,
+    }
+    const { getByText } = render(props)
+    getByText('mockLevelPipette')
+  })
 })

--- a/app/src/organisms/ChangePipette/index.tsx
+++ b/app/src/organisms/ChangePipette/index.tsx
@@ -112,6 +112,9 @@ export function ChangePipette(props: Props): JSX.Element | null {
     useWrongWantedPipette,
     setWrongWantedPipette,
   ] = React.useState<PipetteNameSpecs | null>(wantedPipette)
+  const [confirmPipetteLevel, setConfirmPipetteLevel] = React.useState<boolean>(
+    false
+  )
 
   const movementStatus = useSelector((state: State) => {
     return getMovementStatus(state, robotName)
@@ -179,7 +182,7 @@ export function ChangePipette(props: Props): JSX.Element | null {
     0
   )
 
-  const eightChannel = actualPipette?.channels === 8
+  const eightChannel = wantedPipette?.channels === 8
 
   const direction = actualPipette ? DETACH : ATTACH
   const isSelectPipetteStep =
@@ -204,6 +207,7 @@ export function ChangePipette(props: Props): JSX.Element | null {
       instructionsCurrentStep = 3
     }
   }
+  console.log(instructionsCurrentStep)
 
   const success =
     // success if we were trying to detach and nothing's attached
@@ -314,10 +318,15 @@ export function ChangePipette(props: Props): JSX.Element | null {
     }
 
     let wizardCurrentStep: number = 0
-    if (success || useWrongWantedPipette != null) {
+    //  if success and wrong pipette is attached that does not have the level pipette screen
+    if (success || (useWrongWantedPipette != null && confirmPipetteLevel)) {
       wizardCurrentStep = eightChannel
         ? EIGHT_CHANNEL_STEPS
         : SINGLE_CHANNEL_STEPS
+      //  if attached wrong pipette and has level pipette screen
+    } else if (useWrongWantedPipette != null && !confirmPipetteLevel) {
+      wizardCurrentStep = EIGHT_CHANNEL_STEPS - 1
+      //  if in error state
     } else {
       wizardCurrentStep = SINGLE_CHANNEL_STEPS - 1
     }
@@ -332,7 +341,10 @@ export function ChangePipette(props: Props): JSX.Element | null {
             mount: mount[0].toUpperCase() + mount.slice(1),
           })
         : t('attach_name_pipette', {
-            pipette: wantedPipette?.displayName,
+            pipette:
+              useWrongWantedPipette != null
+                ? useWrongWantedPipette.displayName
+                : wantedPipette?.displayName,
           })
 
     contents = confirmExit ? (
@@ -349,6 +361,8 @@ export function ChangePipette(props: Props): JSX.Element | null {
           },
           useWrongWantedPipette: useWrongWantedPipette,
           setWrongWantedPipette: setWrongWantedPipette,
+          setConfirmPipetteLevel: setConfirmPipetteLevel,
+          confirmPipetteLevel: confirmPipetteLevel,
           exit: homePipAndExit,
           actualPipetteOffset: actualPipetteOffset,
           toCalibrationDashboard: toCalDashboard,

--- a/app/src/organisms/ChangePipette/index.tsx
+++ b/app/src/organisms/ChangePipette/index.tsx
@@ -109,7 +109,7 @@ export function ChangePipette(props: Props): JSX.Element | null {
       : null
   )
   const [
-    useWrongWantedPipette,
+    wrongWantedPipette,
     setWrongWantedPipette,
   ] = React.useState<PipetteNameSpecs | null>(wantedPipette)
   const [confirmPipetteLevel, setConfirmPipetteLevel] = React.useState<boolean>(
@@ -318,12 +318,12 @@ export function ChangePipette(props: Props): JSX.Element | null {
 
     let wizardCurrentStep: number = 0
     //  if success and wrong pipette is attached that does not have the level pipette screen
-    if (success || (useWrongWantedPipette != null && confirmPipetteLevel)) {
+    if (success || (wrongWantedPipette != null && confirmPipetteLevel)) {
       wizardCurrentStep = eightChannel
         ? EIGHT_CHANNEL_STEPS
         : SINGLE_CHANNEL_STEPS
       //  if attached wrong pipette and has level pipette screen
-    } else if (useWrongWantedPipette != null && !confirmPipetteLevel) {
+    } else if (wrongWantedPipette != null && !confirmPipetteLevel) {
       wizardCurrentStep = EIGHT_CHANNEL_STEPS - 1
       //  if in error state
     } else {
@@ -341,8 +341,8 @@ export function ChangePipette(props: Props): JSX.Element | null {
           })
         : t('attach_name_pipette', {
             pipette:
-              useWrongWantedPipette != null
-                ? useWrongWantedPipette.displayName
+              wrongWantedPipette != null
+                ? wrongWantedPipette.displayName
                 : wantedPipette?.displayName,
           })
 
@@ -358,7 +358,7 @@ export function ChangePipette(props: Props): JSX.Element | null {
             setWantedName(null)
             setWizardStep(INSTRUCTIONS)
           },
-          useWrongWantedPipette: useWrongWantedPipette,
+          wrongWantedPipette: wrongWantedPipette,
           setWrongWantedPipette: setWrongWantedPipette,
           setConfirmPipetteLevel: setConfirmPipetteLevel,
           confirmPipetteLevel: confirmPipetteLevel,

--- a/app/src/organisms/ChangePipette/index.tsx
+++ b/app/src/organisms/ChangePipette/index.tsx
@@ -317,12 +317,12 @@ export function ChangePipette(props: Props): JSX.Element | null {
     }
 
     let wizardCurrentStep: number = 0
-    //  if success and wrong pipette is attached that does not have the level pipette screen
+    //  if success is true OR the wrong pipette was attached and wanted and it is not on the LevelPipette screen
     if (success || (wrongWantedPipette != null && confirmPipetteLevel)) {
       wizardCurrentStep = eightChannel
         ? EIGHT_CHANNEL_STEPS
         : SINGLE_CHANNEL_STEPS
-      //  if attached wrong pipette and has level pipette screen
+      //  if wrong pipette is attached and wanted and is an 8 channel on the LevelPipette screen
     } else if (wrongWantedPipette != null && !confirmPipetteLevel) {
       wizardCurrentStep = EIGHT_CHANNEL_STEPS - 1
       //  if in error state

--- a/app/src/organisms/ChangePipette/index.tsx
+++ b/app/src/organisms/ChangePipette/index.tsx
@@ -207,7 +207,6 @@ export function ChangePipette(props: Props): JSX.Element | null {
       instructionsCurrentStep = 3
     }
   }
-  console.log(instructionsCurrentStep)
 
   const success =
     // success if we were trying to detach and nothing's attached

--- a/app/src/organisms/ChangePipette/index.tsx
+++ b/app/src/organisms/ChangePipette/index.tsx
@@ -79,6 +79,14 @@ export function ChangePipette(props: Props): JSX.Element | null {
   const history = useHistory()
   const enableChangePipetteWizard = useFeatureFlag('enableChangePipetteWizard')
   const dispatch = useDispatch<Dispatch>()
+  // const [
+  //   useWrongPipetteOneChannel,
+  //   setUseWrongPipetteOneChannel,
+  // ] = React.useState<boolean>(false)
+  // const [
+  //   useWrongPipetteEightChannel,
+  //   setUseWrongPipetteEightChannel,
+  // ] = React.useState<boolean>(false)
   const finalRequestId = React.useRef<string | null | undefined>(null)
   const [dispatchApiRequests] = useDispatchApiRequests(dispatchedAction => {
     if (
@@ -170,7 +178,17 @@ export function ChangePipette(props: Props): JSX.Element | null {
   const [instructionStepPage, instructionSetStepPage] = React.useState<number>(
     0
   )
+  // let pipetteChannels: number = 1
+  // if (useWrongPipetteEightChannel) {
+  //   pipetteChannels = 8
+  // } else if (useWrongPipetteOneChannel) {
+  //   pipetteChannels = 1
+  // } else if (wantedPipette != null) {
+  //   wantedPipette.channels = 8
+  // }
+
   const eightChannel = wantedPipette?.channels === 8
+
   const direction = actualPipette ? DETACH : ATTACH
   const isSelectPipetteStep =
     direction === ATTACH && wantedName === null && wizardStep === INSTRUCTIONS
@@ -301,11 +319,16 @@ export function ChangePipette(props: Props): JSX.Element | null {
       history.push(`/devices/${robotName}/robot-settings/calibration`)
     }
 
-    currentStep = success
-      ? eightChannel
+    let wizardCurrentStep: number = 0
+    if (success) {
+      wizardCurrentStep = eightChannel
         ? EIGHT_CHANNEL_STEPS
         : SINGLE_CHANNEL_STEPS
-      : SINGLE_CHANNEL_STEPS - 1
+    } else {
+      wizardCurrentStep = SINGLE_CHANNEL_STEPS - 1
+    }
+
+    currentStep = wizardCurrentStep
     exitWizardHeader =
       success || confirmExit ? undefined : () => setConfirmExit(true)
 
@@ -331,6 +354,10 @@ export function ChangePipette(props: Props): JSX.Element | null {
             setWantedName(null)
             setWizardStep(INSTRUCTIONS)
           },
+          // useWrongPipetteOneChannel: useWrongPipetteOneChannel,
+          // setUseWrongPipetteOneChannel: setUseWrongPipetteOneChannel,
+          // useWrongPipetteEightChannel: useWrongPipetteEightChannel,
+          // setUseWrongPipetteEightChannel: setUseWrongPipetteEightChannel,
           exit: homePipAndExit,
           actualPipetteOffset: actualPipetteOffset,
           toCalibrationDashboard: toCalDashboard,

--- a/app/src/organisms/ChangePipette/index.tsx
+++ b/app/src/organisms/ChangePipette/index.tsx
@@ -191,7 +191,11 @@ export function ChangePipette(props: Props): JSX.Element | null {
   const exitModal = (
     <ExitModal
       back={() => setConfirmExit(false)}
-      exit={homePipAndExit}
+      exit={
+        movementStatus !== HOMING && movementStatus !== MOVING
+          ? homePipAndExit
+          : () => console.log('Gantry is moving')
+      }
       direction={direction}
     />
   )

--- a/shared-data/js/constants.ts
+++ b/shared-data/js/constants.ts
@@ -99,6 +99,7 @@ export const OT3_PIPETTES = [
   'p20_single_gen3',
   'p50_single_gen3',
   'p50_multi_gen3',
+  'p1000_multi_gen3',
 ]
 //  magnetic module info
 export const MM: 'mm' = 'mm'

--- a/shared-data/js/constants.ts
+++ b/shared-data/js/constants.ts
@@ -97,6 +97,8 @@ export const OT3_PIPETTES = [
   'p300_single_gen3',
   'p1000_single_gen3',
   'p20_single_gen3',
+  'p50_single_gen3',
+  'p50_multi_gen3',
 ]
 //  magnetic module info
 export const MM: 'mm' = 'mm'


### PR DESCRIPTION
closes RLIQ-124 and  RLIQ-110

# Overview

in the attach pipette flow, the `use attached pipette` cta when you attach the wrong pipette initially just closed the flow. But now, if you have a single channel attached, it goes to the success modal. If you have an eight channel attached, to goes to the pipette leveling modal then the success modal.

This also addresses the bug where the wizard header would say the wrong thing if you select on the "go back" button from the Pipette leveling modal

Additionally, there is logic added so the pipette leveling modal only shows up if you attach the correct eight channel pipette.

# Changelog

- Extend props in `ConfirmPipette` to include logic for if the wrong pipette is attached, and also include `LevelPipette`
- Add logic in `Instructions` to tell if the wrong pipette was attached
- fix spacing to use constant in `LevelPipette`
- increase test coverage in `Instructions` and `ConfirmPipette`
- add logic to parent component `ChangePipette`

# Review requests

- go through an attach flow and attach the wrong single channel pipette. If you click on `use attached pipette` then you should get the success screen with the correct information (wizard header, body, button text, color)
- go through an attach flow and attach the wrong 8 channel pipette. If you click on `use attached pipette`,then you should get the PipetteLeveling screen. If you select the confirm button, you should get the success screen.
- go through an attach flow and make wanted pipette = 8 channel, and actual pipette = incorrect, you should not see the pieptte leveling screen anymore
- go through an attach flow and attach an 8 channel. get to the pipette leveling screen and click on the `go back` button. the wizard header should be correct

# Risk assessment

low