### PR TITLE
refactor(app): adjust height to remove flash between instruction steps

### DIFF
--- a/app/src/organisms/ChangePipette/Instructions.tsx
+++ b/app/src/organisms/ChangePipette/Instructions.tsx
@@ -105,7 +105,7 @@ export function Instructions(props: Props): JSX.Element {
             <Flex
               paddingX={SPACING.spacing6}
               paddingTop={SPACING.spacing6}
-              height="100%"
+              height="14.5rem"
             >
               <InstructionStep
                 diagram={stepPage === 0 ? 'screws' : 'tab'}
@@ -161,8 +161,7 @@ export function Instructions(props: Props): JSX.Element {
             marginBottom={SPACING.spacing6}
             marginX={SPACING.spacing6}
             alignSelf={ALIGN_FLEX_END}
-            //  spacing changes to keep buttons at same height across pages
-            marginTop={stepPage === 0 ? SPACING.spacing6 : '5.9rem'}
+            marginTop="5.9rem"
           >
             <Btn
               onClick={stepPage === 0 ? back : () => setStepPage(stepPage - 1)}


### PR DESCRIPTION
closes RLIQ-125

# Overview

the `Instructions` pages of the attach/detach pipette flow has a flash between step 1 and step 2 (see the video attached in the ticket). This PR fixes that flash by removing the percentage height and adding a fixed height.

# Changelog

- change height in `Instructions`

# Review requests

- go through the attach and detach pipette flows to get through the instruction pages. You shouldn't see a flash.

# Risk assessment

low