### PR TITLE
refactor(api): incorporate module core into non-engine PAPI

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -1,5 +1,5 @@
 """ProtocolEngine-based Protocol API core implementation."""
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons_shared_data.labware.dev_types import LabwareDefinition as LabwareDefDict
@@ -16,7 +16,7 @@ from opentrons.protocols.geometry.deck_item import DeckItem
 from opentrons.protocol_engine import DeckSlotLocation
 from opentrons.protocol_engine.clients import SyncClient as ProtocolEngineClient
 
-from ..protocol import AbstractProtocol, LoadModuleResult
+from ..protocol import AbstractProtocol
 from ..labware import LabwareLoadParams
 from .labware import LabwareCore
 from .instrument import InstrumentCore
@@ -84,12 +84,15 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
     def load_labware(
         self,
         load_name: str,
-        location: DeckSlotName,
+        location: Union[DeckSlotName, ModuleCore],
         label: Optional[str],
         namespace: Optional[str],
         version: Optional[int],
     ) -> LabwareCore:
         """Load a labware using its identifying parameters."""
+        if isinstance(location, ModuleCore):
+            raise NotImplementedError("Load labware on module not yet implemented")
+
         load_result = self._engine_client.load_labware(
             load_name=load_name,
             location=DeckSlotLocation(slotName=location),
@@ -107,12 +110,8 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
         model: ModuleModel,
         location: Optional[DeckSlotName],
         configuration: Optional[str],
-    ) -> Optional[LoadModuleResult]:
+    ) -> ModuleCore:
         """Load a module into the protocol."""
-        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
-
-    def get_loaded_modules(self) -> Dict[int, LoadModuleResult]:
-        """Get all loaded modules by deck slot number."""
         raise NotImplementedError("ProtocolEngine PAPI core not implemented")
 
     def load_instrument(

--- a/api/src/opentrons/protocol_api/core/module.py
+++ b/api/src/opentrons/protocol_api/core/module.py
@@ -2,20 +2,43 @@
 from abc import ABC, abstractmethod
 from typing import Any, Generic, TypeVar
 
-from opentrons.hardware_control.modules.types import ModuleModel
+from opentrons.hardware_control.modules.types import ModuleModel, ModuleType
+from opentrons.protocols.geometry.module_geometry import ModuleGeometry
+from opentrons.types import DeckSlotName
+
 from .labware import LabwareCoreType
 
 
 class AbstractModuleCore(ABC, Generic[LabwareCoreType]):
     """Abstract core module interface."""
 
+    @property
+    @abstractmethod
+    def geometry(self) -> ModuleGeometry:
+        """Get the module's geometry interface."""
+
     @abstractmethod
     def get_model(self) -> ModuleModel:
         """Get the module's model identifier."""
 
     @abstractmethod
+    def get_type(self) -> ModuleType:
+        """Get the module's general type identifier."""
+
+    @abstractmethod
+    def get_requested_model(self) -> ModuleModel:
+        """Get the model identifier the module was requested as.
+
+        This may differ from the actual model returned by `get_model`.
+        """
+
+    @abstractmethod
     def get_serial_number(self) -> str:
         """Get the module's unique hardware serial number."""
+
+    @abstractmethod
+    def get_deck_slot(self) -> DeckSlotName:
+        """Get the module's deck slot."""
 
 
 ModuleCoreType = TypeVar("ModuleCoreType", bound=AbstractModuleCore[Any])

--- a/api/src/opentrons/protocol_api/core/protocol.py
+++ b/api/src/opentrons/protocol_api/core/protocol.py
@@ -3,32 +3,20 @@
 from __future__ import annotations
 
 from abc import abstractmethod, ABC
-from dataclasses import dataclass
-from typing import Dict, Generic, Optional
+from typing import Dict, Generic, Optional, Union
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
 from opentrons.types import Mount, Location, DeckSlotName
-from opentrons.hardware_control import SyncHardwareAPI, SynchronousAdapter
-from opentrons.hardware_control.modules import AbstractModule
-from opentrons.hardware_control.modules.types import ModuleModel, ModuleType
+from opentrons.hardware_control import SyncHardwareAPI
+from opentrons.hardware_control.modules.types import ModuleModel
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.protocols.geometry.deck_item import DeckItem
-from opentrons.protocols.geometry.module_geometry import ModuleGeometry
 from opentrons.protocols.api_support.util import AxisMaxSpeeds
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 from .instrument import InstrumentCoreType
 from .labware import LabwareCoreType, LabwareLoadParams
 from .module import ModuleCoreType
-
-
-@dataclass(frozen=True)
-class LoadModuleResult:
-    """The result of load_module"""
-
-    type: ModuleType
-    geometry: ModuleGeometry
-    module: SynchronousAdapter[AbstractModule]
 
 
 class AbstractProtocol(
@@ -71,7 +59,7 @@ class AbstractProtocol(
     def load_labware(
         self,
         load_name: str,
-        location: DeckSlotName,
+        location: Union[DeckSlotName, ModuleCoreType],
         label: Optional[str],
         namespace: Optional[str],
         version: Optional[int],
@@ -85,11 +73,7 @@ class AbstractProtocol(
         model: ModuleModel,
         deck_slot: Optional[DeckSlotName],
         configuration: Optional[str],
-    ) -> Optional[LoadModuleResult]:
-        ...
-
-    @abstractmethod
-    def get_loaded_modules(self) -> Dict[int, LoadModuleResult]:
+    ) -> ModuleCoreType:
         ...
 
     @abstractmethod

--- a/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
@@ -1,7 +1,53 @@
 """Legacy Protocol API module implementation logic."""
+from typing import cast
+
+from opentrons.hardware_control import SynchronousAdapter
+from opentrons.hardware_control.modules import AbstractModule
+from opentrons.hardware_control.modules.types import ModuleModel, ModuleType
+from opentrons.protocols.geometry.module_geometry import ModuleGeometry
+from opentrons.types import DeckSlotName
+
 from ..module import AbstractModuleCore
 from .labware import LabwareImplementation
 
 
 class LegacyModuleCore(AbstractModuleCore[LabwareImplementation]):
     """Legacy ModuleCore implementation for pre-ProtocolEngine protocols."""
+
+    def __init__(
+        self,
+        sync_module_hardware: SynchronousAdapter[AbstractModule],
+        requested_model: ModuleModel,
+        geometry: ModuleGeometry,
+    ) -> None:
+        self._sync_module_hardware = sync_module_hardware
+        self._requested_model = requested_model
+        self._geometry = geometry
+
+    @property
+    def geometry(self) -> ModuleGeometry:
+        return self._geometry
+
+    def get_model(self) -> ModuleModel:
+        """Get the module's model identifier."""
+        return self._geometry.model
+
+    def get_type(self) -> ModuleType:
+        """Get the module's general type."""
+        return self._geometry.module_type
+
+    def get_requested_model(self) -> ModuleModel:
+        """Get the model identifier the module was requested as.
+
+        This may differ from the actual model returned by `get_model`.
+        """
+        return self._requested_model
+
+    def get_serial_number(self) -> str:
+        """Get the module's unique hardware serial number."""
+        device_info = self._sync_module_hardware.device_info
+        return cast(str, device_info["serial"])
+
+    def get_deck_slot(self) -> DeckSlotName:
+        """Get the module's deck slot."""
+        return DeckSlotName.from_primitive(self._geometry.parent)  # type: ignore[arg-type]

--- a/api/src/opentrons/protocol_api/core/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/protocol_context.py
@@ -251,7 +251,7 @@ class ProtocolContextImplementation(
                 requested_model=model,
                 loaded_model=module_core.get_model(),
                 module_serial=module_core.get_serial_number(),
-                deck_slot=deck_slot,
+                deck_slot=module_core.get_deck_slot(),
                 configuration=configuration,
             )
         )

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1247,7 +1247,7 @@ class InstrumentContext(publisher.CommandPublisher):
         if not from_loc:
             from_loc = types.Location(types.Point(0, 0, 0), LabwareLike(None))
 
-        for mod in self._ctx._modules:
+        for mod in self._ctx._modules.values():
             if isinstance(mod, ThermocyclerContext):
                 mod.flag_unsafe_move(to_loc=location, from_loc=from_loc)
             if isinstance(mod, HeaterShakerContext):

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -151,9 +151,13 @@ class ModuleContext(CommandPublisher, Generic[GeometryType]):
 
         # TODO(mc, 2022-09-02): add API version
         # https://opentrons.atlassian.net/browse/RSS-97
-        labware = Labware(implementation=labware_core)
+        labware = self._core.geometry.add_labware(Labware(implementation=labware_core))
 
-        return self._core.geometry.add_labware(labware)
+        # TODO(mc, 2022-09-08): move this into legacy PAPIv2 implementation
+        # by reworking the `Deck` and/or `ModuleGeometry` interface
+        self._protocol_core.get_deck().recalculate_high_z()
+
+        return labware
 
     @requires_version(2, 0)
     def load_labware_from_definition(

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import logging
-from typing import Generic, List, Optional, TYPE_CHECKING, TypeVar, cast
+from typing import Generic, List, Optional, TypeVar, cast
+
+from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 from opentrons import types
+from opentrons.broker import Broker
 from opentrons.drivers.types import HeaterShakerLabwareLatchStatus
-from opentrons.hardware_control import modules
+from opentrons.hardware_control import SynchronousAdapter, modules
 from opentrons.hardware_control.modules import ModuleModel, types as module_types
 from opentrons.hardware_control.types import Axis
 from opentrons.commands import module_commands as cmds
@@ -19,17 +22,18 @@ from opentrons.protocols.geometry.module_geometry import (
     HeaterShakerGeometry,
 )
 
-from . import validation
+from .core.protocol import AbstractProtocol
+from .core.instrument import AbstractInstrument
+from .core.labware import AbstractLabware
+from .core.module import AbstractModuleCore
+from .core.well import AbstractWellCore
+
 from .module_validation_and_errors import (
     validate_heater_shaker_temperature,
     validate_heater_shaker_speed,
 )
-from .labware import Labware, load, load_from_definition
-from .core.protocol_api.load_info import LabwareLoadInfo
+from .labware import Labware
 
-if TYPE_CHECKING:
-    from .protocol_context import ProtocolContext
-    from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 ENGAGE_HEIGHT_UNIT_CNV = 2
 MAGDECK_HALF_MM_LABWARE = [
@@ -40,9 +44,14 @@ MAGDECK_HALF_MM_LABWARE = [
     "usascientific_96_wellplate_2.4ml_deep",
 ]
 
-MODULE_LOG = logging.getLogger(__name__)
+_log = logging.getLogger(__name__)
 
 GeometryType = TypeVar("GeometryType", bound=ModuleGeometry)
+
+InstrumentCore = AbstractInstrument[AbstractWellCore]
+LabwareCore = AbstractLabware[AbstractWellCore]
+ModuleCore = AbstractModuleCore[LabwareCore]
+ProtocolCore = AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]
 
 
 class NoTargetTemperatureSetError(RuntimeError):
@@ -54,38 +63,30 @@ class CannotPerformModuleAction(RuntimeError):
 
 
 class ModuleContext(CommandPublisher, Generic[GeometryType]):
-    """An object representing a connected module.
+    """A connected module in the protocol.
 
     .. versionadded:: 2.0
     """
 
     def __init__(
         self,
-        ctx: ProtocolContext,
-        geometry: GeometryType,
-        requested_as: ModuleModel,
-        at_version: APIVersion,
+        core: ModuleCore,
+        protocol_core: ProtocolCore,
+        api_version: APIVersion,
+        broker: Broker,
     ) -> None:
-        """Build the ModuleContext.
-
-        This usually should not be instantiated directly; instead, modules
-        should be loaded using :py:meth:`ProtocolContext.load_module`.
-
-        :param ctx: The parent context for the module
-        :param geometry: The :py:class:`.ModuleGeometry` for the module
-        :param requested_as: See :py:obj:`requested_as`.
-        """
-        super().__init__(ctx.broker)
-        self._geometry = geometry
-        self._ctx = ctx
-        self._requested_as = requested_as
-        self._api_version = at_version
+        super().__init__(broker=broker)
+        self._core = core
+        self._protocol_core = protocol_core
+        self._api_version = api_version
+        self._labware: Optional[Labware] = None
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def api_version(self) -> APIVersion:
         return self._api_version
 
+    # TODO(mc, 2022-09-08): Remove this method
     @requires_version(2, 0)
     def load_labware_object(self, labware: Labware) -> Labware:
         """Specify the presence of a piece of labware on the module.
@@ -96,40 +97,19 @@ class ModuleContext(CommandPublisher, Generic[GeometryType]):
                         onto the module in one step, see
                         :py:meth:`load_labware`.
         :returns: The properly-linked labware object
+
+        ..deprecated: 2.14
         """
-        # TODO(mc, 2022-09-02): move to module_core
-        mod_labware = self._geometry.add_labware(labware)
-
-        labware_core = mod_labware._implementation
-        deck_slot = validation.ensure_deck_slot(self._geometry.parent)  # type: ignore[arg-type]
-        load_params = labware_core.get_load_params()
-
-        provided_offset = self._ctx._implementation._labware_offset_provider.find(  # type: ignore[attr-defined]
-            load_params=load_params,
-            requested_module_model=self.requested_as,
-            deck_slot=deck_slot,
+        _log.warning(
+            "`module.load_labware_object` is an internal, deprecated method."
+            " Use `module.load_labware` or `load_labware_by_definition` instead."
         )
+        assert (
+            labware.parent == self.geometry
+        ), "Labware is not configured with this module as its parent"
 
-        labware_core.set_calibration(provided_offset.delta)
-        self._ctx._implementation.get_deck().recalculate_high_z()
+        return self._core.geometry.add_labware(labware)
 
-        # TODO(mc, 2022-09-07): move into module or protocol core
-        self._ctx._implementation.equipment_broker.publish(  # type: ignore[attr-defined]
-            LabwareLoadInfo(
-                labware_definition=labware_core.get_definition(),
-                labware_namespace=load_params.namespace,
-                labware_load_name=load_params.load_name,
-                labware_version=load_params.version,
-                deck_slot=deck_slot,
-                on_module=True,
-                offset_id=provided_offset.offset_id,
-                labware_display_name=labware_core.get_user_display_name(),
-            )
-        )
-
-        return mod_labware
-
-    @requires_version(2, 0)
     def load_labware(
         self,
         name: str,
@@ -137,37 +117,43 @@ class ModuleContext(CommandPublisher, Generic[GeometryType]):
         namespace: Optional[str] = None,
         version: int = 1,
     ) -> Labware:
-        """Specify the presence of a piece of labware on the module.
+        """Load a labware onto the module by its load parameters.
 
         :param name: The name of the labware object.
-        :param str label: An optional special name to give the labware. If
-            specified, this is the name the labware will appear as in the run
-            log and the calibration view in the Opentrons app.
+        :param str label: An optional display name to give the labware.
+            If specified, this is the name the labware will use in the run log
+            and the calibration view in the Opentrons App.
         :param str namespace: The namespace the labware definition belongs to.
             If unspecified, will search 'opentrons' then 'custom_beta'
-        :param int version: The version of the labware definition. If
-            unspecified, will use version 1.
+        :param int version: The version of the labware definition.
+            If unspecified, will use version 1.
 
         :returns: The initialized and loaded labware object.
 
         .. versionadded:: 2.1
             The *label,* *namespace,* and *version* parameters.
         """
-        if self.api_version < APIVersion(2, 1) and (label or namespace or version):
-            MODULE_LOG.warning(
+        if self._api_version < APIVersion(2, 1) and (
+            label is not None or namespace is not None or version != 1
+        ):
+            _log.warning(
                 f"You have specified API {self.api_version}, but you "
                 "are trying to utilize new load_labware parameters in 2.1"
             )
-        lw = load(
-            name,
-            self._geometry.location,
-            label,
-            namespace,
-            version,
-            bundled_defs=self._ctx._implementation.get_bundled_labware(),
-            extra_defs=self._ctx._implementation.get_extra_labware(),
+
+        labware_core = self._protocol_core.load_labware(
+            load_name=name,
+            label=label,
+            namespace=namespace,
+            version=version,
+            location=self._core,
         )
-        return self.load_labware_object(lw)
+
+        # TODO(mc, 2022-09-02): add API version
+        # https://opentrons.atlassian.net/browse/RSS-97
+        labware = Labware(implementation=labware_core)
+
+        return self._core.geometry.add_labware(labware)
 
     @requires_version(2, 0)
     def load_labware_from_definition(
@@ -184,8 +170,14 @@ class ModuleContext(CommandPublisher, Generic[GeometryType]):
                           Opentrons app.
         :returns: The initialized and loaded labware object.
         """
-        lw = load_from_definition(definition, self._geometry.location, label)
-        return self.load_labware_object(lw)
+        load_params = self._protocol_core.add_labware_definition(definition)
+
+        return self.load_labware(
+            name=load_params.load_name,
+            namespace=load_params.namespace,
+            version=load_params.version,
+            label=label,
+        )
 
     @requires_version(2, 1)
     def load_labware_by_name(
@@ -199,26 +191,25 @@ class ModuleContext(CommandPublisher, Generic[GeometryType]):
         .. deprecated:: 2.0
             Use :py:meth:`load_labware` instead.
         """
-        MODULE_LOG.warning(
-            "load_labware_by_name is deprecated. Use load_labware instead."
+        _log.warning("load_labware_by_name is deprecated. Use load_labware instead.")
+        return self.load_labware(
+            name=name, label=label, namespace=namespace, version=version
         )
-        return self.load_labware(name, label, namespace, version)
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def labware(self) -> Optional[Labware]:
         """The labware (if any) present on this module."""
-        return self._geometry.labware
+        return self._core.geometry.labware
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)
-    # TODO (spp, 2022-07-27): Check if it is better to use GeometryType as the returnType
-    def geometry(self) -> ModuleGeometry:
+    def geometry(self) -> GeometryType:
         """The object representing the module as an item on the deck
 
         :returns: ModuleGeometry
         """
-        return self._geometry
+        return cast(GeometryType, self._core.geometry)
 
     @property
     def requested_as(self) -> ModuleModel:
@@ -231,11 +222,16 @@ class ModuleContext(CommandPublisher, Generic[GeometryType]):
 
         :meta private:
         """
-        return self._requested_as
+        return self._core.get_requested_model()
+
+    # TODO(mc, 2022-09-08): remove this property
+    @property
+    def _module(self) -> SynchronousAdapter[modules.AbstractModule]:
+        return self._core._sync_module_hardware  # type: ignore[attr-defined, no-any-return]
 
     def __repr__(self) -> str:
         return "{} at {} lw {}".format(
-            self.__class__.__name__, self._geometry, self.labware
+            self.__class__.__name__, self.geometry, self.labware
         )
 
 
@@ -271,18 +267,9 @@ class TemperatureModuleContext(ModuleContext[ModuleGeometry]):
 
     """
 
-    def __init__(
-        self,
-        ctx: ProtocolContext,
-        # TODO(mc, 2022-02-05): this type annotation is misleading;
-        # a SynchronousAdapter wrapper is actually passed in
-        hw_module: modules.tempdeck.TempDeck,
-        geometry: ModuleGeometry,
-        requested_as: ModuleModel,
-        at_version: APIVersion,
-    ) -> None:
-        self._module = hw_module
-        super().__init__(ctx, geometry, requested_as, at_version)
+    # TODO(mc, 2022-02-05): this type annotation is misleading;
+    # a SynchronousAdapter wrapper is actually passed in
+    _module: modules.tempdeck.TempDeck  # type: ignore[assignment]
 
     @publish(command=cmds.tempdeck_set_temp)
     @requires_version(2, 0)
@@ -356,18 +343,9 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
 
     """
 
-    def __init__(
-        self,
-        ctx: ProtocolContext,
-        # TODO(mc, 2022-02-05): this type annotation is misleading;
-        # a SynchronousAdapter wrapper is actually passed in
-        hw_module: modules.magdeck.MagDeck,
-        geometry: ModuleGeometry,
-        requested_as: ModuleModel,
-        at_version: APIVersion,
-    ) -> None:
-        self._module = hw_module
-        super().__init__(ctx, geometry, requested_as, at_version)
+    # TODO(mc, 2022-02-05): this type annotation is misleading;
+    # a SynchronousAdapter wrapper is actually passed in
+    _module: modules.magdeck.MagDeck  # type: ignore[assignment]
 
     @publish(command=cmds.magdeck_calibrate)
     @requires_version(2, 0)
@@ -385,7 +363,7 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
         Load labware onto a Magnetic Module, checking if it is compatible
         """
         if labware.magdeck_engage_height is None:
-            MODULE_LOG.warning(
+            _log.warning(
                 "This labware ({}) is not explicitly compatible with the"
                 " Magnetic Module. You will have to specify a height when"
                 " calling engage()."
@@ -451,9 +429,7 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
         # we will silently ignore it instead of raising APIVersionError.
         # Leaving this unfixed because we haven't thought through
         # how to do backwards-compatible fixes to our version checking itself.
-        elif height_from_base is not None and self._ctx._api_version >= APIVersion(
-            2, 2
-        ):
+        elif height_from_base is not None and self._api_version >= APIVersion(2, 2):
             dist = (
                 height_from_base
                 + modules.magdeck.OFFSET_TO_LABWARE_BOTTOM[self._module.model()]
@@ -488,7 +464,7 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
 
         engage_height = self.labware.magdeck_engage_height
 
-        is_api_breakpoint = self._ctx._api_version >= APIVersion(2, 3)
+        is_api_breakpoint = self._api_version >= APIVersion(2, 3)
         is_v1_module = self._module.model() == "magneticModuleV1"
         engage_height_is_in_half_mm = self.labware.load_name in MAGDECK_HALF_MM_LABWARE
 
@@ -521,67 +497,67 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
     .. versionadded:: 2.0
     """
 
-    def __init__(
-        self,
-        ctx: ProtocolContext,
-        # TODO(mc, 2022-02-05): this type annotation is misleading;
-        # a SynchronousAdapter wrapper is actually passed in
-        hw_module: modules.thermocycler.Thermocycler,
-        geometry: ThermocyclerGeometry,
-        requested_as: ModuleModel,
-        at_version: APIVersion,
-    ) -> None:
-        self._module = hw_module
-        super().__init__(ctx, geometry, requested_as, at_version)
+    # TODO(mc, 2022-02-05): this type annotation is misleading;
+    # a SynchronousAdapter wrapper is actually passed in
+    _module: modules.thermocycler.Thermocycler  # type: ignore[assignment]
+
+    def _get_fixed_trash(self) -> Labware:
+        trash = self._protocol_core.get_fixed_trash()
+
+        if isinstance(trash, AbstractLabware):
+            trash = Labware(implementation=trash)
+
+        return cast(Labware, trash)
 
     def _prepare_for_lid_move(self) -> None:
         loaded_instruments = [
             instr
-            for mount, instr in self._ctx._instruments.items()
+            for mount, instr in self._protocol_core.get_loaded_instruments().items()
             if instr is not None
         ]
         try:
-            instr = loaded_instruments[0]
+            instr_impl = loaded_instruments[0]
         except IndexError:
-            MODULE_LOG.warning(
+            _log.warning(
                 "Cannot assure a safe gantry position to avoid colliding"
                 " with the lid of the Thermocycler Module."
             )
         else:
-            ctx_impl = self._ctx._implementation
-            instr_impl = instr._implementation
+            ctx_impl = self._protocol_core
             hardware = ctx_impl.get_hardware()
-
             hardware.retract(instr_impl.get_mount())
             high_point = hardware.current_position(instr_impl.get_mount())
-            trash_top = self._ctx.fixed_trash.wells()[0].top()
+            trash_top = self._get_fixed_trash().wells()[0].top()
             safe_point = trash_top.point._replace(
                 z=high_point[Axis.by_mount(instr_impl.get_mount())]
             )
-            instr.move_to(types.Location(safe_point, None), force_direct=True)
+            instr_impl.move_to(
+                types.Location(safe_point, None),
+                force_direct=True,
+                minimum_z_height=None,
+                speed=None,
+            )
 
     def flag_unsafe_move(
         self, to_loc: types.Location, from_loc: types.Location
     ) -> None:
-        cast(ThermocyclerGeometry, self.geometry).flag_unsafe_move(
-            to_loc, from_loc, self.lid_position
-        )
+        self.geometry.flag_unsafe_move(to_loc, from_loc, self.lid_position)
 
     @publish(command=cmds.thermocycler_open)
     @requires_version(2, 0)
     def open_lid(self) -> str:
         """Opens the lid"""
         self._prepare_for_lid_move()
-        self._geometry.lid_status = self._module.open()  # type: ignore[assignment]
-        return self._geometry.lid_status
+        self.geometry.lid_status = self._module.open()  # type: ignore[assignment]
+        return self.geometry.lid_status
 
     @publish(command=cmds.thermocycler_close)
     @requires_version(2, 0)
     def close_lid(self) -> str:
         """Closes the lid"""
         self._prepare_for_lid_move()
-        self._geometry.lid_status = self._module.close()  # type: ignore[assignment]
-        return self._geometry.lid_status
+        self.geometry.lid_status = self._module.close()  # type: ignore[assignment]
+        return self.geometry.lid_status
 
     @publish(command=cmds.thermocycler_set_block_temp)
     @requires_version(2, 0)
@@ -793,18 +769,9 @@ class HeaterShakerContext(ModuleContext[HeaterShakerGeometry]):
     .. versionadded:: 2.13
     """
 
-    def __init__(
-        self,
-        ctx: ProtocolContext,
-        # TODO(mc, 2022-02-05): this type annotation is misleading;
-        # a SynchronousAdapter wrapper is actually passed in
-        hw_module: modules.heater_shaker.HeaterShaker,
-        geometry: HeaterShakerGeometry,
-        requested_as: ModuleModel,
-        at_version: APIVersion,
-    ) -> None:
-        self._module = hw_module
-        super().__init__(ctx, geometry, requested_as, at_version)
+    # TODO(mc, 2022-02-05): this type annotation is misleading;
+    # a SynchronousAdapter wrapper is actually passed in
+    _module: modules.heater_shaker.HeaterShaker  # type: ignore[assignment]
 
     @property  # type: ignore[misc]
     @requires_version(2, 13)
@@ -1014,7 +981,7 @@ class HeaterShakerContext(ModuleContext[HeaterShakerGeometry]):
                 "Cannot determine pipette movement safety."
             )
 
-        cast(HeaterShakerGeometry, self.geometry).flag_unsafe_move(
+        self.geometry.flag_unsafe_move(
             to_slot=int(destination_slot),
             is_tiprack=is_tiprack,
             is_using_multichannel=is_multichannel,
@@ -1027,26 +994,25 @@ class HeaterShakerContext(ModuleContext[HeaterShakerGeometry]):
         Before shaking, retracts pipettes if they're parked over a slot
         adjacent to the heater-shaker.
         """
-
-        if cast(HeaterShakerGeometry, self.geometry).is_pipette_blocking_shake_movement(
-            pipette_location=self._ctx.location_cache
+        protocol_core = self._protocol_core
+        if self.geometry.is_pipette_blocking_shake_movement(
+            pipette_location=protocol_core.get_last_location()
         ):
-            ctx_implementation = self._ctx._implementation
-            hardware = ctx_implementation.get_hardware()
+            hardware = protocol_core.get_hardware()
             for mount in types.Mount:
                 hardware.retract(mount=mount)
-            self._ctx.location_cache = None
+            protocol_core.set_last_location(None)
 
     def _prepare_for_latch_open(self) -> None:
         """
         Before opening latch, retracts pipettes if they're parked over a slot
         east/ west of the heater-shaker.
         """
-        if cast(HeaterShakerGeometry, self.geometry).is_pipette_blocking_latch_movement(
-            pipette_location=self._ctx.location_cache
+        protocol_core = self._protocol_core
+        if self.geometry.is_pipette_blocking_latch_movement(
+            pipette_location=protocol_core.get_last_location()
         ):
-            ctx_implementation = self._ctx._implementation
-            hardware = ctx_implementation.get_hardware()
+            hardware = protocol_core.get_hardware()
             for mount in types.Mount:
                 hardware.retract(mount=mount)
-            self._ctx.location_cache = None
+            protocol_core.set_last_location(None)

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -418,7 +418,7 @@ class ProtocolContext(CommandPublisher):
         )
 
         module_context = _create_module_context(
-            core=module_core,
+            module_core=module_core,
             protocol_core=self._implementation,
             broker=self._broker,
             api_version=self._api_version,

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -675,7 +675,7 @@ class ProtocolContext(CommandPublisher):
 
 
 def _create_module_context(
-    core: ModuleCore,
+    module_core: ModuleCore,
     protocol_core: ProtocolCore,
     api_version: APIVersion,
     broker: Broker,
@@ -687,10 +687,10 @@ def _create_module_context(
         ModuleType.THERMOCYCLER: ThermocyclerContext,
         ModuleType.HEATER_SHAKER: HeaterShakerContext,
     }
-    module_cls = module_constructors[core.get_type()]
+    module_cls = module_constructors[module_core.get_type()]
 
     return module_cls(
-        core=core,
+        core=module_core,
         protocol_core=protocol_core,
         api_version=api_version,
         broker=broker,

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -424,7 +424,7 @@ class ProtocolContext(CommandPublisher):
             api_version=self._api_version,
         )
 
-        self._modules[deck_slot] = module_context
+        self._modules[module_core.get_deck_slot()] = module_context
 
         return module_context
 

--- a/api/src/opentrons/protocols/geometry/deck.py
+++ b/api/src/opentrons/protocols/geometry/deck.py
@@ -53,9 +53,8 @@ class Deck(UserDict):
             self.data[int(slot["id"])] = None
             self._positions[int(slot["id"])] = types.Point(*slot["position"])
         self._highest_z = 0.0
-        self._thermocycler_present = False
         self._load_fixtures()
-        self.recalculate_high_z()
+        self._thermocycler_present = False
 
     def _load_fixtures(self):
         for f in self._definition["locations"]["fixtures"]:

--- a/api/src/opentrons/protocols/geometry/deck.py
+++ b/api/src/opentrons/protocols/geometry/deck.py
@@ -53,8 +53,9 @@ class Deck(UserDict):
             self.data[int(slot["id"])] = None
             self._positions[int(slot["id"])] = types.Point(*slot["position"])
         self._highest_z = 0.0
-        self._load_fixtures()
         self._thermocycler_present = False
+        self._load_fixtures()
+        self.recalculate_high_z()
 
     def _load_fixtures(self):
         for f in self._definition["locations"]["fixtures"]:
@@ -125,7 +126,7 @@ class Deck(UserDict):
         )
 
         self.data[slot_key_int] = val
-        self._highest_z = max(val.highest_z, self._highest_z)
+        self.recalculate_high_z()
         self._thermocycler_present = any(
             isinstance(item, ThermocyclerGeometry) for item in self.data.values()
         )

--- a/api/src/opentrons/protocols/geometry/module_geometry.py
+++ b/api/src/opentrons/protocols/geometry/module_geometry.py
@@ -331,6 +331,7 @@ class ThermocyclerGeometry(ModuleGeometry):
     ):
         to_lw, to_well = to_loc.labware.get_parent_labware_and_well()
         from_lw, from_well = from_loc.labware.get_parent_labware_and_well()
+
         if (
             self.labware is not None
             and (self.labware == to_lw or self.labware == from_lw)

--- a/api/tests/opentrons/protocol_api/core/legacy/test_legacy_module_core.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_legacy_module_core.py
@@ -1,0 +1,77 @@
+"""Tests for the legacy Protocol API module core implementations."""
+import pytest
+from decoy import Decoy
+
+from opentrons.hardware_control import SynchronousAdapter
+from opentrons.hardware_control.modules import AbstractModule
+from opentrons.hardware_control.modules.types import ModuleType, TemperatureModuleModel
+from opentrons.protocols.geometry.module_geometry import ModuleGeometry
+
+from opentrons.protocol_api.core.protocol_api.legacy_module_core import LegacyModuleCore
+
+
+@pytest.fixture
+def mock_geometry(decoy: Decoy) -> ModuleGeometry:
+    """Get a mock module geometry."""
+    return decoy.mock(cls=ModuleGeometry)
+
+
+@pytest.fixture
+def mock_sync_module_hardware(decoy: Decoy) -> SynchronousAdapter[AbstractModule]:
+    """Get a mock module geometry."""
+    return decoy.mock(name="SynchronousAdapater[AbstractModule]")  # type: ignore[no-any-return]
+
+
+@pytest.fixture
+def subject(
+    mock_geometry: ModuleGeometry,
+    mock_sync_module_hardware: SynchronousAdapter[AbstractModule],
+) -> LegacyModuleCore:
+    """Get a legacy module implementation core with mocked out dependencies."""
+    return LegacyModuleCore(
+        requested_model=TemperatureModuleModel.TEMPERATURE_V1,
+        geometry=mock_geometry,
+        sync_module_hardware=mock_sync_module_hardware,
+        # labware_offset_provider=mock_labware_offset_provider,
+        # equipment_broker=mock_equipment_broker,
+    )
+
+
+def test_get_requested_model(subject: LegacyModuleCore) -> None:
+    """It should return the requested model given to the constructor."""
+    result = subject.get_requested_model()
+    assert result == TemperatureModuleModel.TEMPERATURE_V1
+
+
+def test_get_geometry(mock_geometry: ModuleGeometry, subject: LegacyModuleCore) -> None:
+    """It should return the geometry interface given to the constructor."""
+    assert subject.geometry is mock_geometry
+
+
+def test_get_model(
+    decoy: Decoy, mock_geometry: ModuleGeometry, subject: LegacyModuleCore
+) -> None:
+    """It should get the model from the geometry."""
+    decoy.when(mock_geometry.model).then_return(TemperatureModuleModel.TEMPERATURE_V2)
+    result = subject.get_model()
+    assert result == TemperatureModuleModel.TEMPERATURE_V2
+
+
+def test_get_type(
+    decoy: Decoy, mock_geometry: ModuleGeometry, subject: LegacyModuleCore
+) -> None:
+    """It should get the model from the geometry."""
+    decoy.when(mock_geometry.module_type).then_return(ModuleType.TEMPERATURE)
+    result = subject.get_type()
+    assert result == ModuleType.TEMPERATURE
+
+
+def test_get_serial_number(
+    decoy: Decoy,
+    mock_sync_module_hardware: SynchronousAdapter[AbstractModule],
+    subject: LegacyModuleCore,
+) -> None:
+    """It should return the serial number from the hardware interface."""
+    decoy.when(mock_sync_module_hardware.device_info).then_return({"serial": "abc123"})
+    result = subject.get_serial_number()
+    assert result == "abc123"

--- a/api/tests/opentrons/protocol_api/core/legacy/test_protocol_context_implementation.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_protocol_context_implementation.py
@@ -210,7 +210,6 @@ def test_load_labware(
 
 def test_load_labware_on_module(
     decoy: Decoy,
-    mock_deck: Deck,
     mock_labware_offset_provider: AbstractLabwareOffsetProvider,
     mock_equipment_broker: EquipmentBroker[LoadInfo],
     subject: ProtocolContextImplementation,

--- a/api/tests/opentrons/protocol_api/test_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_module_context.py
@@ -1,0 +1,131 @@
+"""Tests for Protocol API module contexts."""
+from typing import Any, cast
+
+import pytest
+from decoy import Decoy, matchers
+
+from opentrons_shared_data.labware.dev_types import LabwareDefinition as LabwareDefDict
+
+from opentrons.broker import Broker
+from opentrons.protocol_api import MAX_SUPPORTED_VERSION, ModuleContext, Labware
+from opentrons.protocol_api.core.labware import LabwareLoadParams
+
+from .types import LabwareCore, ModuleCore, ProtocolCore
+
+
+@pytest.fixture
+def mock_core(decoy: Decoy) -> ModuleCore:
+    """Get a mock module implementation core."""
+    return decoy.mock(cls=ModuleCore)
+
+
+@pytest.fixture
+def mock_protocol_core(decoy: Decoy) -> ProtocolCore:
+    """Get a mock protocol implementation core."""
+    return decoy.mock(cls=ProtocolCore)
+
+
+@pytest.fixture
+def mock_broker(decoy: Decoy) -> Broker:
+    """Get a mock command message broker."""
+    return decoy.mock(cls=Broker)
+
+
+@pytest.fixture
+def subject(
+    mock_core: ModuleCore, mock_protocol_core: ProtocolCore, mock_broker: Broker
+) -> ModuleContext[Any]:
+    """Get a generic module context with its dependencies mocked out."""
+    return ModuleContext(
+        core=mock_core,
+        protocol_core=mock_protocol_core,
+        broker=mock_broker,
+        api_version=MAX_SUPPORTED_VERSION,
+    )
+
+
+def test_get_labware(
+    decoy: Decoy, mock_core: ModuleCore, subject: ModuleContext[Any]
+) -> None:
+    """It should return the labware from the core's geometry object."""
+    mock_labware = decoy.mock(cls=Labware)
+    decoy.when(mock_core.geometry.labware).then_return(mock_labware)
+
+    assert subject.labware is mock_labware
+
+
+def test_load_labware(
+    decoy: Decoy,
+    mock_protocol_core: ProtocolCore,
+    mock_core: ModuleCore,
+    subject: ModuleContext[Any],
+) -> None:
+    """It should load labware by load parameters."""
+    mock_labware_core = decoy.mock(cls=LabwareCore)
+    mock_labware = decoy.mock(cls=Labware)
+
+    decoy.when(
+        mock_protocol_core.load_labware(
+            load_name="infinite tip rack",
+            label="it doesn't run out",
+            namespace="ideal",
+            version=101,
+            location=mock_core,
+        )
+    ).then_return(mock_labware_core)
+
+    decoy.when(mock_labware_core.get_name()).then_return("Full Name")
+
+    decoy.when(mock_core.geometry.add_labware(matchers.IsA(Labware))).then_return(
+        mock_labware
+    )
+
+    result = subject.load_labware(
+        name="infinite tip rack",
+        label="it doesn't run out",
+        namespace="ideal",
+        version=101,
+    )
+
+    assert result is mock_labware
+
+
+def test_load_labware_from_definition(
+    decoy: Decoy,
+    mock_core: ModuleCore,
+    mock_protocol_core: ProtocolCore,
+    subject: ModuleContext[Any],
+) -> None:
+    """It should be able to load a labware from a definition dictionary."""
+    mock_labware_core = decoy.mock(cls=LabwareCore)
+    mock_labware = decoy.mock(cls=Labware)
+
+    labware_definition_dict = cast(LabwareDefDict, {"labwareDef": True})
+    labware_load_params = LabwareLoadParams("you", "are", 1337)
+
+    decoy.when(
+        mock_protocol_core.add_labware_definition(labware_definition_dict)
+    ).then_return(labware_load_params)
+
+    decoy.when(mock_labware_core.get_name()).then_return("Full Name")
+
+    decoy.when(mock_core.geometry.add_labware(matchers.IsA(Labware))).then_return(
+        mock_labware
+    )
+
+    decoy.when(
+        mock_protocol_core.load_labware(
+            namespace="you",
+            load_name="are",
+            version=1337,
+            label="Some Display Name",
+            location=mock_core,
+        )
+    ).then_return(mock_labware_core)
+
+    result = subject.load_labware_from_definition(
+        definition=labware_definition_dict,
+        label="Some Display Name",
+    )
+
+    assert result is mock_labware

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -9,7 +9,7 @@ from opentrons_shared_data.pipette.dev_types import PipetteNameType
 from opentrons_shared_data.labware.dev_types import LabwareDefinition as LabwareDefDict
 
 from opentrons.types import Mount, DeckSlotName
-from opentrons.hardware_control.modules.types import TemperatureModuleModel
+from opentrons.hardware_control.modules.types import ModuleType, TemperatureModuleModel
 from opentrons.protocol_api import (
     MAX_SUPPORTED_VERSION,
     ProtocolContext,
@@ -179,7 +179,6 @@ def test_load_labware_from_definition(
     assert result.name == "Full Name"
 
 
-@pytest.mark.xfail(strict=True, reason="Not yet implemented")
 def test_load_module(
     decoy: Decoy,
     mock_core: ProtocolCore,
@@ -199,10 +198,9 @@ def test_load_module(
             deck_slot=DeckSlotName.SLOT_3,
             configuration=None,
         )
-    ).then_return(
-        mock_module_core  # type: ignore[arg-type]
-    )
+    ).then_return(mock_module_core)
 
+    decoy.when(mock_module_core.get_type()).then_return(ModuleType.TEMPERATURE)
     decoy.when(mock_module_core.get_model()).then_return(
         TemperatureModuleModel.TEMPERATURE_V2
     )
@@ -211,3 +209,4 @@ def test_load_module(
     result = subject.load_module(module_name="spline reticulator", location=42)
 
     assert isinstance(result, ModuleContext)
+    assert subject.loaded_modules[3] is result

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -205,6 +205,40 @@ def test_load_module(
         TemperatureModuleModel.TEMPERATURE_V2
     )
     decoy.when(mock_module_core.get_serial_number()).then_return("cap'n crunch")
+    decoy.when(mock_module_core.get_deck_slot()).then_return(DeckSlotName.SLOT_3)
+
+    result = subject.load_module(module_name="spline reticulator", location=42)
+
+    assert isinstance(result, ModuleContext)
+    assert subject.loaded_modules[3] is result
+
+
+def test_load_module_default_location(
+    decoy: Decoy,
+    mock_core: ProtocolCore,
+    subject: ProtocolContext,
+) -> None:
+    """It should load a module without specifying a location explicitely."""
+    mock_module_core = decoy.mock(cls=ModuleCore)
+
+    decoy.when(validation.ensure_module_model("spline reticulator")).then_return(
+        TemperatureModuleModel.TEMPERATURE_V1
+    )
+
+    decoy.when(
+        mock_core.load_module(
+            model=TemperatureModuleModel.TEMPERATURE_V1,
+            deck_slot=None,
+            configuration=None,
+        )
+    ).then_return(mock_module_core)
+
+    decoy.when(mock_module_core.get_type()).then_return(ModuleType.TEMPERATURE)
+    decoy.when(mock_module_core.get_model()).then_return(
+        TemperatureModuleModel.TEMPERATURE_V2
+    )
+    decoy.when(mock_module_core.get_serial_number()).then_return("cap'n crunch")
+    decoy.when(mock_module_core.get_deck_slot()).then_return(DeckSlotName.SLOT_3)
 
     result = subject.load_module(module_name="spline reticulator", location=42)
 

--- a/api/tests/opentrons/protocol_api_old/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api_old/test_instrument_context.py
@@ -61,7 +61,7 @@ def _mock_publish_context(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None
 @pytest.fixture
 def mock_protocol_context(decoy: Decoy) -> ProtocolContext:
     mock_protocol_context = decoy.mock(cls=ProtocolContext)
-    decoy.when(mock_protocol_context._modules).then_return([])
+    decoy.when(mock_protocol_context._modules).then_return({})
     return mock_protocol_context
 
 

--- a/api/tests/opentrons/protocol_api_old/test_module_context.py
+++ b/api/tests/opentrons/protocol_api_old/test_module_context.py
@@ -501,7 +501,7 @@ def test_thermocycler_flag_unsafe_move(ctx_with_thermocycler, mock_module_contro
     mod = ctx_with_thermocycler.load_module("thermocycler", configuration="semi")
     labware_name = "nest_96_wellplate_100ul_pcr_full_skirt"
     tc_labware = mod.load_labware(labware_name)
-    
+
     with_tc_labware = Location(None, tc_labware)  # type: ignore[arg-type]
     without_tc_labware = Location(None, None)  # type: ignore[arg-type]
 

--- a/api/tests/opentrons/protocol_api_old/test_module_context.py
+++ b/api/tests/opentrons/protocol_api_old/test_module_context.py
@@ -222,7 +222,7 @@ def test_load_simulating_module(ctx, loadname, klass, model):
 
 def test_tempdeck(ctx_with_tempdeck, mock_module_controller):
     mod = ctx_with_tempdeck.load_module("Temperature Module", 1)
-    assert ctx_with_tempdeck.deck[1] == mod._geometry
+    assert ctx_with_tempdeck.deck[1] == mod.geometry
 
 
 def test_tempdeck_target(ctx_with_tempdeck, mock_module_controller):
@@ -269,7 +269,7 @@ def test_tempdeck_status(ctx_with_tempdeck, mock_module_controller):
 
 def test_magdeck(ctx_with_magdeck, mock_module_controller):
     mod = ctx_with_magdeck.load_module("Magnetic Module", 1)
-    assert ctx_with_magdeck.deck[1] == mod._geometry
+    assert ctx_with_magdeck.deck[1] == mod.geometry
 
 
 def test_magdeck_status(ctx_with_magdeck, mock_module_controller):
@@ -324,7 +324,7 @@ def test_magdeck_calibrate(ctx_with_magdeck, mock_module_controller):
 
 def test_thermocycler(ctx_with_thermocycler, mock_module_controller):
     mod = ctx_with_thermocycler.load_module("thermocycler")
-    assert ctx_with_thermocycler.deck[7] == mod._geometry
+    assert ctx_with_thermocycler.deck[7] == mod.geometry
 
 
 def test_thermocycler_lid_status(ctx_with_thermocycler, mock_module_controller):
@@ -343,8 +343,8 @@ def test_thermocycler_lid(ctx_with_thermocycler, mock_module_controller):
         cmd.lower() for cmd in ctx_with_thermocycler.commands()
     )
     mock_module_controller.open.assert_called_once()
-    assert mod._geometry.lid_status == "open"
-    assert mod._geometry.highest_z == 98.0
+    assert mod.geometry.lid_status == "open"
+    assert mod.geometry.highest_z == 98.0
 
     mock_module_controller.close.return_value = "closed"
     mod.close_lid()
@@ -352,8 +352,8 @@ def test_thermocycler_lid(ctx_with_thermocycler, mock_module_controller):
         cmd.lower() for cmd in ctx_with_thermocycler.commands()
     )
     mock_module_controller.close.assert_called_once()
-    assert mod._geometry.lid_status == "closed"
-    assert mod._geometry.highest_z == 98.0  # ignore 37.7mm lid for now
+    assert mod.geometry.lid_status == "closed"
+    assert mod.geometry.highest_z == 98.0  # ignore 37.7mm lid for now
 
 
 def test_thermocycler_set_lid_temperature(
@@ -483,7 +483,7 @@ def test_thermocycler_profile(ctx_with_thermocycler, mock_module_controller):
 def test_thermocycler_semi_plate_configuration(ctx):
     labware_name = "nest_96_wellplate_100ul_pcr_full_skirt"
     mod = ctx.load_module("thermocycler", configuration="semi")
-    assert mod._geometry.labware_offset == Point(-23.28, 82.56, 97.8)
+    assert mod.geometry.labware_offset == Point(-23.28, 82.56, 97.8)
 
     tc_labware = mod.load_labware(labware_name)
 
@@ -501,7 +501,7 @@ def test_thermocycler_flag_unsafe_move(ctx_with_thermocycler, mock_module_contro
     mod = ctx_with_thermocycler.load_module("thermocycler", configuration="semi")
     labware_name = "nest_96_wellplate_100ul_pcr_full_skirt"
     tc_labware = mod.load_labware(labware_name)
-
+    
     with_tc_labware = Location(None, tc_labware)  # type: ignore[arg-type]
     without_tc_labware = Location(None, None)  # type: ignore[arg-type]
 
@@ -540,11 +540,11 @@ def test_heater_shaker_unsafe_move_flagger(
 
     labware = ctx_with_heater_shaker.load_labware(labware_name, 5)
 
-    mod._geometry.flag_unsafe_move = mock.MagicMock()  # type: ignore[assignment]
+    mod._core.geometry.flag_unsafe_move = mock.MagicMock()  # type: ignore[attr-defined]
 
     mod.flag_unsafe_move(to_loc=labware.wells()[1].top(), is_multichannel=False)
 
-    mod._geometry.flag_unsafe_move.assert_called_once_with(
+    mod._core.geometry.flag_unsafe_move.assert_called_once_with(  # type: ignore[attr-defined]
         to_slot=5,
         is_tiprack=is_tiprack,
         is_using_multichannel=False,
@@ -565,7 +565,7 @@ def test_hs_flag_unsafe_move_raises(
     labware = ctx_with_heater_shaker.load_labware("geb_96_tiprack_1000ul", 5)
 
     assert isinstance(mod, HeaterShakerContext)
-    mod._geometry.flag_unsafe_move = mock.MagicMock(side_effect=raiser)  # type: ignore[assignment]
+    mod._core.geometry.flag_unsafe_move = mock.MagicMock(side_effect=raiser)  # type: ignore[attr-defined]
 
     with pytest.raises(PipetteMovementRestrictedByHeaterShakerError, match="uh oh"):
         mod.flag_unsafe_move(to_loc=labware.wells()[1].top(), is_multichannel=False)
@@ -724,7 +724,7 @@ def test_heater_shaker_set_and_wait_for_shake_speed(
         mock_validator.return_value = 10
         hs_mod = ctx_with_heater_shaker.load_module("heaterShakerModuleV1", 1)
         assert isinstance(hs_mod, HeaterShakerContext)
-        hs_mod.geometry.is_pipette_blocking_shake_movement = mock.MagicMock(  # type: ignore[attr-defined]
+        hs_mod._core.geometry.is_pipette_blocking_shake_movement = mock.MagicMock(  # type: ignore[attr-defined]
             return_value=True
         )
 
@@ -780,7 +780,7 @@ def test_heater_shaker_open_labware_latch(
     # Get subject
     hs_mod = ctx_with_heater_shaker.load_module("heaterShakerModuleV1", 1)
     assert isinstance(hs_mod, HeaterShakerContext)
-    hs_mod.geometry.is_pipette_blocking_latch_movement = mock.MagicMock(  # type: ignore[attr-defined]
+    hs_mod._core.geometry.is_pipette_blocking_latch_movement = mock.MagicMock(  # type: ignore[attr-defined]
         return_value=True
     )
 
@@ -866,7 +866,7 @@ def test_module_load_labware(ctx_with_tempdeck):
     )
     assert (
         lw._implementation.get_geometry().offset
-        == lw_offset + mod._geometry.location.point
+        == lw_offset + mod.geometry.location.point
     )
     assert lw.name == labware_name
 
@@ -898,7 +898,9 @@ def test_deprecated_module_load_labware_by_name(ctx_with_tempdeck):
     mod.load_labware_by_name(
         name="a module", namespace="ns", label="a label", version=2
     )
-    mod.load_labware.assert_called_once_with("a module", "a label", "ns", 2)
+    mod.load_labware.assert_called_once_with(
+        name="a module", label="a label", namespace="ns", version=2
+    )
 
 
 async def test_magdeck_gen1_labware_props(ctx):
@@ -923,7 +925,7 @@ async def test_magdeck_gen1_labware_props(ctx):
     mod.disengage()
     mod.engage(height=3)
     assert await mod._module._driver.get_plate_height() == 3
-    mod._geometry.reset_labware()
+    mod.geometry.reset_labware()
     labware_name = "corning_96_wellplate_360ul_flat"
     mod.load_labware(labware_name)
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Overview

This PR takes the module interfaces added in #11437 and partially integrates them into the existing PAPIv2 module contexts. As of this PR, all module contexts have a `_core` that they delegate to for labware loading.

**This PR concentrates on the existing PAPIv2 cores**. It does not implement anything for the new engine-based core.

The remaining work after this PR is to :

- Implement `load_module` on the `ProtocolEngine`-based protocol core
- Implement `load_labware` for labware-on-modules on the PE-based common module core
- Create per-module-type module cores that will:
    - Engine-based cores: dispatch `ProtocolEngine` module commands
    - Legacy cores: call methods of the `SynchronousAdapter` module hardware API wrappers

## Review requests

I have smoke tested PAPIv2 module loading using the current PAPIv2 core logic on this branch. I smoke tested all modules, including a thermocycler in the `semi` config

- Module loads
- A module command works
- Labware on module loads
- Labware well access works

Test results

- [x] Magnetic module
- [x] Temperature module
- [x] Heater-shaker module
- [x] Thermocylcer module
- [x] Thermocycler module in `semi` config
    - Note: thermocycler `semi` config is broken in various ways in `edge` (RSS-105, RSS-106)
    - This branch behaves exactly the same as `edge`

## Risk assessment

High, this is messing about in production module code. Mitigations:

- Extensive smoke testing of real module hardware
- G-code regression suites are passing (and caught one bug while this PR was in development)