### PR TITLE
fix(api): Disallow uploading a protocol with non matching references

### DIFF
--- a/api/tests/opentrons/protocol_runner/test_json_command_translator.py
+++ b/api/tests/opentrons/protocol_runner/test_json_command_translator.py
@@ -35,8 +35,8 @@ VALID_TEST_PARAMS = [
             commandType="aspirate",
             key=None,
             params=protocol_schema_v6.Params(
-                pipetteId="pipette-id-abc123",
-                labwareId="labware-id-def456",
+                pipetteId="pipette-id-1",
+                labwareId="labware-id-2",
                 volume=1.23,
                 # todo (Max and Tamar 3/17/22):needs to be added to the aspirate command
                 #  https://github.com/Opentrons/opentrons/issues/8204
@@ -52,8 +52,8 @@ VALID_TEST_PARAMS = [
             key=None,
             params=pe_commands.AspirateParams(
                 # todo: id
-                pipetteId="pipette-id-abc123",
-                labwareId="labware-id-def456",
+                pipetteId="pipette-id-1",
+                labwareId="labware-id-2",
                 volume=1.23,
                 flowRate=4.56,
                 wellName="A1",
@@ -69,8 +69,8 @@ VALID_TEST_PARAMS = [
             commandType="dispense",
             key="dispense-key",
             params=protocol_schema_v6.Params(
-                pipetteId="pipette-id-abc123",
-                labwareId="labware-id-def456",
+                pipetteId="pipette-id-1",
+                labwareId="labware-id-2",
                 volume=1.23,
                 flowRate=4.56,
                 wellName="A1",
@@ -83,8 +83,8 @@ VALID_TEST_PARAMS = [
         pe_commands.DispenseCreate(
             key="dispense-key",
             params=pe_commands.DispenseParams(
-                pipetteId="pipette-id-abc123",
-                labwareId="labware-id-def456",
+                pipetteId="pipette-id-1",
+                labwareId="labware-id-2",
                 volume=1.23,
                 flowRate=4.56,
                 wellName="A1",
@@ -99,15 +99,15 @@ VALID_TEST_PARAMS = [
         protocol_schema_v6.Command(
             commandType="dropTip",
             params=protocol_schema_v6.Params(
-                pipetteId="pipette-id-abc123",
-                labwareId="labware-id-def456",
+                pipetteId="pipette-id-1",
+                labwareId="labware-id-2",
                 wellName="A1",
             ),
         ),
         pe_commands.DropTipCreate(
             params=pe_commands.DropTipParams(
-                pipetteId="pipette-id-abc123",
-                labwareId="labware-id-def456",
+                pipetteId="pipette-id-1",
+                labwareId="labware-id-2",
                 wellName="A1",
                 wellLocation=WellLocation(),
             )
@@ -117,15 +117,15 @@ VALID_TEST_PARAMS = [
         protocol_schema_v6.Command(
             commandType="pickUpTip",
             params=protocol_schema_v6.Params(
-                pipetteId="pipette-id-abc123",
-                labwareId="labware-id-def456",
+                pipetteId="pipette-id-1",
+                labwareId="labware-id-2",
                 wellName="A1",
             ),
         ),
         pe_commands.PickUpTipCreate(
             params=pe_commands.PickUpTipParams(
-                pipetteId="pipette-id-abc123",
-                labwareId="labware-id-def456",
+                pipetteId="pipette-id-1",
+                labwareId="labware-id-2",
                 wellName="A1",
                 wellLocation=WellLocation(),
             )
@@ -135,8 +135,8 @@ VALID_TEST_PARAMS = [
         protocol_schema_v6.Command(
             commandType="touchTip",
             params=protocol_schema_v6.Params(
-                pipetteId="pipette-id-abc123",
-                labwareId="labware-id-def456",
+                pipetteId="pipette-id-1",
+                labwareId="labware-id-2",
                 wellName="A1",
                 wellLocation=protocol_schema_v6.WellLocation(
                     origin="bottom",
@@ -146,8 +146,8 @@ VALID_TEST_PARAMS = [
         ),
         pe_commands.TouchTipCreate(
             params=pe_commands.TouchTipParams(
-                pipetteId="pipette-id-abc123",
-                labwareId="labware-id-def456",
+                pipetteId="pipette-id-1",
+                labwareId="labware-id-2",
                 wellName="A1",
                 wellLocation=WellLocation(
                     origin=WellOrigin.BOTTOM,
@@ -159,11 +159,11 @@ VALID_TEST_PARAMS = [
     (
         protocol_schema_v6.Command(
             commandType="loadPipette",
-            params=protocol_schema_v6.Params(pipetteId="pipette-id-abc123", mount="left"),
+            params=protocol_schema_v6.Params(pipetteId="pipette-id-1", mount="left"),
         ),
         pe_commands.LoadPipetteCreate(
             params=pe_commands.LoadPipetteParams(
-                pipetteId="pipette-id-abc123",
+                pipetteId="pipette-id-1",
                 pipetteName=PipetteName("p10_single"),
                 mount=MountType("left"),
             )
@@ -173,14 +173,14 @@ VALID_TEST_PARAMS = [
         protocol_schema_v6.Command(
             commandType="loadModule",
             params=protocol_schema_v6.Params(
-                moduleId="magneticModuleId",
+                moduleId="module-id-1",
                 location=protocol_schema_v6.Location(slotName="3"),
             ),
         ),
         pe_commands.LoadModuleCreate(
             params=pe_commands.LoadModuleParams(
                 model=ModuleModel("magneticModuleV2"),
-                moduleId="magneticModuleId",
+                moduleId="module-id-1",
                 location=DeckSlotLocation(slotName=(DeckSlotName("3"))),
             )
         ),
@@ -189,15 +189,15 @@ VALID_TEST_PARAMS = [
         protocol_schema_v6.Command(
             commandType="loadLabware",
             params=protocol_schema_v6.Params(
-                labwareId="sourcePlateId",
+                labwareId="labware-id-2",
                 location=protocol_schema_v6.Location(moduleId="temperatureModuleId"),
             ),
         ),
         pe_commands.LoadLabwareCreate(
             params=pe_commands.LoadLabwareParams(
                 loadName="foo_8_plate_33ul",
-                displayName="Source Plate",
-                labwareId="sourcePlateId",
+                displayName="Trash",
+                labwareId="labware-id-2",
                 location=ModuleLocation(moduleId="temperatureModuleId"),
                 version=1,
                 namespace="example",
@@ -208,8 +208,8 @@ VALID_TEST_PARAMS = [
         protocol_schema_v6.Command(
             commandType="blowout",
             params=protocol_schema_v6.Params(
-                pipetteId="pipette-id-abc123",
-                labwareId="labware-id-def456",
+                pipetteId="pipette-id-1",
+                labwareId="labware-id-2",
                 wellName="A1",
                 wellLocation=protocol_schema_v6.WellLocation(
                     origin="bottom",
@@ -220,8 +220,8 @@ VALID_TEST_PARAMS = [
         ),
         pe_commands.BlowOutCreate(
             params=pe_commands.BlowOutParams(
-                pipetteId="pipette-id-abc123",
-                labwareId="labware-id-def456",
+                pipetteId="pipette-id-1",
+                labwareId="labware-id-2",
                 wellName="A1",
                 wellLocation=WellLocation(
                     origin=WellOrigin.BOTTOM,
@@ -277,7 +277,7 @@ VALID_TEST_PARAMS = [
         protocol_schema_v6.Command(
             commandType="moveToCoordinates",
             params=protocol_schema_v6.Params(
-                pipetteId="pipette-id-abc123",
+                pipetteId="pipette-id-1",
                 coordinates=protocol_schema_v6.OffsetVector(x=1.1, y=2.2, z=3.3),
                 minimumZHeight=123.4,
                 forceDirect=True,
@@ -285,7 +285,7 @@ VALID_TEST_PARAMS = [
         ),
         pe_commands.MoveToCoordinatesCreate(
             params=pe_commands.MoveToCoordinatesParams(
-                pipetteId="pipette-id-abc123",
+                pipetteId="pipette-id-1",
                 coordinates=DeckPoint(x=1.1, y=2.2, z=3.3),
                 minimumZHeight=123.4,
                 forceDirect=True,
@@ -296,7 +296,7 @@ VALID_TEST_PARAMS = [
         protocol_schema_v6.Command(
             commandType="thermocycler/runProfile",
             params=protocol_schema_v6.Params(
-                moduleId="module-id-abc123",
+                moduleId="module-id-2",
                 blockMaxVolumeUl=1.11,
                 profile=[
                     protocol_schema_v6.ProfileStep(
@@ -312,7 +312,7 @@ VALID_TEST_PARAMS = [
         ),
         pe_commands.thermocycler.RunProfileCreate(
             params=pe_commands.thermocycler.RunProfileParams(
-                moduleId="module-id-abc123",
+                moduleId="module-id-2",
                 blockMaxVolumeUl=1.11,
                 profile=[
                     pe_commands.thermocycler.RunProfileStepParams(
@@ -371,23 +371,24 @@ def _load_labware_definition_data() -> LabwareDefinition:
 def _make_json_protocol(
     *,
     pipettes: Dict[str, protocol_schema_v6.Pipette] = {
-        "pipette-id-abc123": protocol_schema_v6.Pipette(name="p10_single"),
+        "pipette-id-1": protocol_schema_v6.Pipette(name="p10_single"),
     },
     labware_definitions: Dict[str, LabwareDefinition] = {
-        "example/plate/1": _load_labware_definition_data()
+        "example/plate/1": _load_labware_definition_data(),
+        "example/trash/1": _load_labware_definition_data()
     },
     labware: Dict[str, protocol_schema_v6.Labware] = {
-        "sourcePlateId": protocol_schema_v6.Labware(
+        "labware-id-1": protocol_schema_v6.Labware(
             displayName="Source Plate", definitionId="example/plate/1"
         ),
-        "labware-id-def456": protocol_schema_v6.Labware(
+        "labware-id-2": protocol_schema_v6.Labware(
             displayName="Trash", definitionId="example/trash/1"
         ),
     },
     commands: List[protocol_schema_v6.Command] = [],
     modules: Dict[str, protocol_schema_v6.Module] = {
-        "magneticModuleId": protocol_schema_v6.Module(model="magneticModuleV2"),
-        "module-id-abc123": protocol_schema_v6.Module(model="thermocyclerModuleV2")
+        "module-id-1": protocol_schema_v6.Module(model="magneticModuleV2"),
+        "module-id-2": protocol_schema_v6.Module(model="thermocyclerModuleV2")
     }
 ) -> protocol_schema_v6.ProtocolSchemaV6:
     """Return a minimal JsonProtocol with the given elements, to use as test input."""

--- a/api/tests/opentrons/protocol_runner/test_json_command_translator.py
+++ b/api/tests/opentrons/protocol_runner/test_json_command_translator.py
@@ -159,11 +159,11 @@ VALID_TEST_PARAMS = [
     (
         protocol_schema_v6.Command(
             commandType="loadPipette",
-            params=protocol_schema_v6.Params(pipetteId="pipetteId", mount="left"),
+            params=protocol_schema_v6.Params(pipetteId="pipette-id-abc123", mount="left"),
         ),
         pe_commands.LoadPipetteCreate(
             params=pe_commands.LoadPipetteParams(
-                pipetteId="pipetteId",
+                pipetteId="pipette-id-abc123",
                 pipetteName=PipetteName("p10_single"),
                 mount=MountType("left"),
             )
@@ -371,7 +371,7 @@ def _load_labware_definition_data() -> LabwareDefinition:
 def _make_json_protocol(
     *,
     pipettes: Dict[str, protocol_schema_v6.Pipette] = {
-        "pipetteId": protocol_schema_v6.Pipette(name="p10_single")
+        "pipette-id-abc123": protocol_schema_v6.Pipette(name="p10_single"),
     },
     labware_definitions: Dict[str, LabwareDefinition] = {
         "example/plate/1": _load_labware_definition_data()
@@ -379,15 +379,19 @@ def _make_json_protocol(
     labware: Dict[str, protocol_schema_v6.Labware] = {
         "sourcePlateId": protocol_schema_v6.Labware(
             displayName="Source Plate", definitionId="example/plate/1"
-        )
+        ),
+        "labware-id-def456": protocol_schema_v6.Labware(
+            displayName="Trash", definitionId="example/trash/1"
+        ),
     },
     commands: List[protocol_schema_v6.Command] = [],
     modules: Dict[str, protocol_schema_v6.Module] = {
-        "magneticModuleId": protocol_schema_v6.Module(model="magneticModuleV2")
+        "magneticModuleId": protocol_schema_v6.Module(model="magneticModuleV2"),
+        "module-id-abc123": protocol_schema_v6.Module(model="thermocyclerModuleV2")
     }
 ) -> protocol_schema_v6.ProtocolSchemaV6:
     """Return a minimal JsonProtocol with the given elements, to use as test input."""
-    return protocol_schema_v6.ProtocolSchemaV6.construct(
+    return protocol_schema_v6.ProtocolSchemaV6(
         # schemaVersion is arbitrary. Currently (2021-06-28), JsonProtocol.parse_obj()
         # isn't smart enough to validate differently depending on this field.
         otSharedSchema="#/protocol/schemas/6",

--- a/api/tests/opentrons/protocol_runner/test_json_command_translator.py
+++ b/api/tests/opentrons/protocol_runner/test_json_command_translator.py
@@ -387,7 +387,7 @@ def _make_json_protocol(
     }
 ) -> protocol_schema_v6.ProtocolSchemaV6:
     """Return a minimal JsonProtocol with the given elements, to use as test input."""
-    return protocol_schema_v6.ProtocolSchemaV6(
+    return protocol_schema_v6.ProtocolSchemaV6.construct(
         # schemaVersion is arbitrary. Currently (2021-06-28), JsonProtocol.parse_obj()
         # isn't smart enough to validate differently depending on this field.
         otSharedSchema="#/protocol/schemas/6",

--- a/api/tests/opentrons/protocol_runner/test_json_command_translator.py
+++ b/api/tests/opentrons/protocol_runner/test_json_command_translator.py
@@ -375,7 +375,7 @@ def _make_json_protocol(
     },
     labware_definitions: Dict[str, LabwareDefinition] = {
         "example/plate/1": _load_labware_definition_data(),
-        "example/trash/1": _load_labware_definition_data()
+        "example/trash/1": _load_labware_definition_data(),
     },
     labware: Dict[str, protocol_schema_v6.Labware] = {
         "labware-id-1": protocol_schema_v6.Labware(
@@ -388,7 +388,7 @@ def _make_json_protocol(
     commands: List[protocol_schema_v6.Command] = [],
     modules: Dict[str, protocol_schema_v6.Module] = {
         "module-id-1": protocol_schema_v6.Module(model="magneticModuleV2"),
-        "module-id-2": protocol_schema_v6.Module(model="thermocyclerModuleV2")
+        "module-id-2": protocol_schema_v6.Module(model="thermocyclerModuleV2"),
     }
 ) -> protocol_schema_v6.ProtocolSchemaV6:
     """Return a minimal JsonProtocol with the given elements, to use as test input."""

--- a/shared-data/protocol/fixtures/6/multipleTipracks.json
+++ b/shared-data/protocol/fixtures/6/multipleTipracks.json
@@ -1978,11 +1978,11 @@
       "commandType": "loadPipette",
       "id": "0abc2",
       "params": {
-        "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45",
+        "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
         "mount": "right"
       },
       "result": {
-        "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45"
+        "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a"
       }
     },
     {

--- a/shared-data/python/tests/protocol/test_protocol_schema_v6.py
+++ b/shared-data/python/tests/protocol/test_protocol_schema_v6.py
@@ -2,7 +2,7 @@ import json
 import pytest
 from typing import Any, Dict
 from opentrons_shared_data import load_shared_data
-from opentrons_shared_data.protocol.models import ProtocolSchemaV6
+from opentrons_shared_data.protocol.models import protocol_schema_v6
 
 from . import list_fixtures
 
@@ -10,7 +10,7 @@ from . import list_fixtures
 @pytest.mark.parametrize("defpath", list_fixtures(6))
 def test_v6_types(defpath):
     def_data = load_shared_data(defpath)
-    def_model = ProtocolSchemaV6.parse_raw(def_data)
+    def_model = protocol_schema_v6.ProtocolSchemaV6.parse_raw(def_data)
     def_dict_from_model = def_model.dict(
         exclude_unset=True,
         # 'schemaVersion' in python is '$schemaVersion' in JSON
@@ -31,3 +31,73 @@ def delete_unexpected_results(protocol_fixture: Dict[str, Any]) -> None:
     for command_object_dict in protocol_fixture["commands"]:
         command_object_dict.pop("result", None)
         command_object_dict.pop("id", None)
+
+
+@pytest.mark.parametrize(
+    "input_command, missing_id, load_command",
+    [
+        (
+            protocol_schema_v6.Command(
+                commandType="loadLabware",
+                params=protocol_schema_v6.Params(labwareId="labware-id-3"),
+            ),
+            "labware-id-3",
+            "loadLabware",
+        ),
+        (
+            protocol_schema_v6.Command(
+                commandType="loadPipette",
+                params=protocol_schema_v6.Params(pipetteId="pipette-id-3"),
+            ),
+            "pipette-id-3",
+            "loadPipette",
+        ),
+        (
+            protocol_schema_v6.Command(
+                commandType="loadLiquid",
+                params=protocol_schema_v6.Params(liquidId="liquid-id-3"),
+            ),
+            "liquid-id-3",
+            "loadLiquid",
+        ),
+        (
+            protocol_schema_v6.Command(
+                commandType="loadModule",
+                params=protocol_schema_v6.Params(moduleId="module-id-3"),
+            ),
+            "module-id-3",
+            "loadModule",
+        ),
+    ],
+)
+def test_schema_validators(
+    input_command: protocol_schema_v6.Command, missing_id: str, load_command: str
+) -> None:
+    """Should raise an error the keys do not match."""
+    labware = {
+        "labware-id-1": protocol_schema_v6.Labware(definitionId="definition-1"),
+        "labware-id-2": protocol_schema_v6.Labware(definitionId="definition-2"),
+    }
+    pipettes = {"pipette-id-1": protocol_schema_v6.Pipette(name="pipette-1")}
+    liquids = {
+        "liquid-id-1": protocol_schema_v6.Liquid(
+            displayName="liquid-1", description="liquid desc"
+        )
+    }
+    modules = {"module-id-1": protocol_schema_v6.Module(model="model-1")}
+    with pytest.raises(
+        ValueError,
+        match=f"{load_command} command at index 0 references ID {missing_id}, which doesn't exist.",
+    ):
+        protocol_schema_v6.ProtocolSchemaV6(
+            otSharedSchema="#/protocol/schemas/6",
+            schemaVersion=6,
+            metadata={},
+            robot=protocol_schema_v6.Robot(model="", deckId=""),
+            labware=labware,
+            pipettes=pipettes,
+            liquids=liquids,
+            modules=modules,
+            labwareDefinitions={},
+            commands=[input_command],
+        )


### PR DESCRIPTION
# Overview

changed base to release 6.1.0. approved PR and conversation [here](https://github.com/Opentrons/opentrons/pull/11418).
Closes https://opentrons.atlassian.net/browse/RSS-81.
Disallow uploading a protocol when referencing a none existed model Id.

# Changelog

- Added a pydantic validator to the json v6 data model. 
- 
# Review requests

1. should I add more validations?
2. is the code clear? 
3. tests sufficient?   
4. should I add it to read_saved for old uploaded protocols?

# Risk assessment

Medium. every time we try to parse a json v6 object it will run against the validator. 
