### PR TITLE
refactor(api): add move to well for PAPIv2 protocol engine core 

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1,12 +1,14 @@
 """ProtocolEngine-based InstrumentContext core implementation."""
 from typing import Optional
 
+from opentrons.protocol_engine.clients import SyncClient as ProtocolEngineClient
 from opentrons.types import Location, Mount
 from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.protocols.api_support.util import Clearances, PlungerSpeeds, FlowRates
 
 from ..instrument import AbstractInstrument
 from .well import WellCore
+from . import location_parser
 
 
 class InstrumentCore(AbstractInstrument[WellCore]):
@@ -16,8 +18,9 @@ class InstrumentCore(AbstractInstrument[WellCore]):
         pipette_id: ProtocolEngine ID of the loaded instrument.
     """
 
-    def __init__(self, pipette_id: str) -> None:
+    def __init__(self, pipette_id: str, engine_client: ProtocolEngineClient) -> None:
         self._pipette_id = pipette_id
+        self._engine_client = engine_client
 
     @property
     def pipette_id(self) -> str:
@@ -74,7 +77,22 @@ class InstrumentCore(AbstractInstrument[WellCore]):
         minimum_z_height: Optional[float],
         speed: Optional[float],
     ) -> None:
-        raise NotImplementedError("InstrumentCore not implemented")
+
+        if location.labware.is_well:
+            (
+                labware_id,
+                well_name,
+                well_location,
+            ) = location_parser.resolve_move_to_well_args(location)
+        else:
+            raise NotImplementedError()
+
+        self._engine_client.move_to_well(
+            pipette_id=self._pipette_id,
+            labware_id=labware_id,
+            well_name=well_name,
+            well_location=well_location,
+        )
 
     def get_mount(self) -> Mount:
         raise NotImplementedError("InstrumentCore not implemented")

--- a/api/src/opentrons/protocol_api/core/engine/location_parser.py
+++ b/api/src/opentrons/protocol_api/core/engine/location_parser.py
@@ -1,0 +1,20 @@
+from typing import Tuple
+
+from opentrons.types import Location
+from opentrons.protocol_engine.types import WellLocation
+
+from .labware import LabwareCore
+
+
+def resolve_move_to_well_args(location: Location) -> Tuple[str, str, WellLocation]:
+    labware, well = location.labware.get_parent_labware_and_well()
+    if labware is None or well is None:
+        raise TypeError()
+    assert isinstance(labware._implementation, LabwareCore)
+
+    labware_impl: LabwareCore = labware._implementation
+    labware_id = labware_impl.labware_id
+    well_name = well.well_name
+    # TODO(jbl 2022-09-13) when well geometry is resolved, return with non default offset
+    well_location = WellLocation()
+    return labware_id, well_name, well_location

--- a/api/src/opentrons/protocol_api/core/engine/location_parser.py
+++ b/api/src/opentrons/protocol_api/core/engine/location_parser.py
@@ -7,6 +7,7 @@ from .labware import LabwareCore
 
 
 def resolve_move_to_well_args(location: Location) -> Tuple[str, str, WellLocation]:
+    """Resolve labware id, well name and protocol engine WellLocation from Location object."""
     labware, well = location.labware.get_parent_labware_and_well()
     if labware is None or well is None:
         raise TypeError()

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -129,7 +129,9 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore]):
         engine_mount = MountType[mount.name]
         load_result = self._engine_client.load_pipette(instrument_name, engine_mount)
 
-        return InstrumentCore(pipette_id=load_result.pipetteId)
+        return InstrumentCore(
+            pipette_id=load_result.pipetteId, engine_client=self._engine_client
+        )
 
     def get_loaded_instruments(self) -> Dict[Mount, Optional[InstrumentCore]]:
         """Get all loaded instruments by mount."""

--- a/api/src/opentrons/protocol_api/core/engine/well.py
+++ b/api/src/opentrons/protocol_api/core/engine/well.py
@@ -3,6 +3,36 @@
 
 from ..well import AbstractWellCore
 
+from opentrons.protocols.geometry.well_geometry import WellGeometry
+
 
 class WellCore(AbstractWellCore):
     """Well API core using a ProtocolEngine."""
+
+    def has_tip(self) -> bool:
+        """Whether the well contains a tip."""
+        raise NotImplementedError("WellCore not implemented")
+
+    def set_has_tip(self, value: bool) -> None:
+        """Set the well as containing or not containing a tip."""
+        raise NotImplementedError("WellCore not implemented")
+
+    def get_display_name(self) -> str:
+        """Get the well's full display name."""
+        raise NotImplementedError("WellCore not implemented")
+
+    def get_name(self) -> str:
+        """Get the name of the well (e.g. "A1")."""
+        raise NotImplementedError("WellCore not implemented")
+
+    def get_column_name(self) -> str:
+        """Get the column portion of the well name (e.g. "A")."""
+        raise NotImplementedError("WellCore not implemented")
+
+    def get_row_name(self) -> str:
+        """Get the row portion of the well name (e.g. "1")."""
+        raise NotImplementedError("WellCore not implemented")
+
+    def get_geometry(self) -> WellGeometry:
+        """Get the well's geometry information interface."""
+        raise NotImplementedError("WellCore not implemented")

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -213,6 +213,25 @@ class SyncClient:
         result = self._transport.execute_command(request=request)
         return cast(commands.TouchTipResult, result)
 
+    def move_to_well(
+        self,
+        pipette_id: str,
+        labware_id: str,
+        well_name: str,
+        well_location: WellLocation,
+    ) -> commands.MoveToWellResult:
+        """Execute a ``MoveToWell`` command and return the result."""
+        request = commands.MoveToWellCreate(
+            params=commands.MoveToWellParams(
+                pipetteId=pipette_id,
+                labwareId=labware_id,
+                wellName=well_name,
+                wellLocation=well_location,
+            )
+        )
+        result = self._transport.execute_command(request=request)
+        return cast(commands.MoveToWellResult, result)
+
     def wait_for_resume(self, message: Optional[str]) -> commands.WaitForResumeResult:
         """Execute a `WaitForResume` command and return the result."""
         request = commands.WaitForResumeCreate(

--- a/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
@@ -1,0 +1,72 @@
+"""Test for the ProtocolEngine-based instrument API core."""
+import inspect
+import pytest
+from decoy import Decoy
+
+from opentrons.types import Location, Point
+
+from opentrons.protocol_api.labware import Well
+
+from opentrons.protocol_engine import WellLocation, WellOrigin, WellOffset
+from opentrons.protocol_engine.clients import SyncClient as EngineClient
+from opentrons.protocol_api.core.engine import (
+    InstrumentCore,
+    location_parser as mock_location_parser,
+)
+
+
+@pytest.fixture(autouse=True)
+def _mock_location_parser_module(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
+    for name, func in inspect.getmembers(mock_location_parser, inspect.isfunction):
+        monkeypatch.setattr(mock_location_parser, name, decoy.mock(func=func))
+
+
+@pytest.fixture
+def mock_engine_client(decoy: Decoy) -> EngineClient:
+    """Get a mock ProtocolEngine synchronous client."""
+    return decoy.mock(cls=EngineClient)
+
+
+@pytest.fixture
+def subject(mock_engine_client: EngineClient) -> InstrumentCore:
+    """Get a ProtocolCore test subject with its dependencies mocked out."""
+    return InstrumentCore(pipette_id="abc", engine_client=mock_engine_client)
+
+
+def test_move_to_well(
+    decoy: Decoy,
+    mock_engine_client: EngineClient,
+    subject: InstrumentCore,
+) -> None:
+    """It should issue a MoveToWell command."""
+    mock_well = decoy.mock(cls=Well)
+
+    decoy.when(
+        mock_location_parser.resolve_move_to_well_args(
+            Location(point=Point(x=4, y=5, z=6), labware=mock_well)
+        )
+    ).then_return(
+        (
+            "123",
+            "my-cool-well",
+            WellLocation(origin=WellOrigin.BOTTOM, offset=WellOffset(x=1, y=2, z=3)),
+        )
+    )
+
+    subject.move_to(
+        location=Location(point=Point(x=4, y=5, z=6), labware=mock_well),
+        force_direct=False,
+        minimum_z_height=None,
+        speed=None,
+    )
+
+    decoy.verify(
+        mock_engine_client.move_to_well(
+            pipette_id="abc",
+            labware_id="123",
+            well_name="my-cool-well",
+            well_location=WellLocation(
+                origin=WellOrigin.BOTTOM, offset=WellOffset(x=1, y=2, z=3)
+            ),
+        )
+    )

--- a/api/tests/opentrons/protocol_api/core/engine/test_location_parser.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_location_parser.py
@@ -1,0 +1,31 @@
+"""Tests for opentrons.protocol_api.core.engine.location_parser."""
+
+import pytest
+from decoy import Decoy
+
+from opentrons.types import Location, Point
+from opentrons.protocol_api import Well, Labware
+from opentrons.protocol_api.core.engine import location_parser as subject, LabwareCore
+from opentrons.protocol_engine.types import WellLocation
+
+
+@pytest.fixture
+def mock_labware_core(decoy: Decoy) -> LabwareCore:
+    """Get a mock ProtocolEngine synchronous client."""
+    return decoy.mock(cls=LabwareCore)
+
+
+def test_resolve_move_to_well_args(decoy: Decoy, mock_labware_core: LabwareCore) -> None:
+    """It should resolve move to well arguments from a location."""
+    mock_location = decoy.mock(cls=Location)
+    mock_labware = decoy.mock(cls=Labware)
+    mock_well = decoy.mock(cls=Well)
+
+    decoy.when(mock_location.labware.get_parent_labware_and_well()).then_return((mock_labware, mock_well))
+    decoy.when(mock_labware._implementation).then_return(mock_labware_core)
+
+    decoy.when(mock_labware_core.labware_id).then_return("123")
+    decoy.when(mock_well.well_name).then_return("abc")
+
+    result = subject.resolve_move_to_well_args(mock_location)
+    assert result == ("123", "abc", WellLocation())

--- a/api/tests/opentrons/protocol_api/core/engine/test_location_parser.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_location_parser.py
@@ -15,13 +15,17 @@ def mock_labware_core(decoy: Decoy) -> LabwareCore:
     return decoy.mock(cls=LabwareCore)
 
 
-def test_resolve_move_to_well_args(decoy: Decoy, mock_labware_core: LabwareCore) -> None:
+def test_resolve_move_to_well_args(
+    decoy: Decoy, mock_labware_core: LabwareCore
+) -> None:
     """It should resolve move to well arguments from a location."""
     mock_location = decoy.mock(cls=Location)
     mock_labware = decoy.mock(cls=Labware)
     mock_well = decoy.mock(cls=Well)
 
-    decoy.when(mock_location.labware.get_parent_labware_and_well()).then_return((mock_labware, mock_well))
+    decoy.when(mock_location.labware.get_parent_labware_and_well()).then_return(
+        (mock_labware, mock_well)
+    )
     decoy.when(mock_labware._implementation).then_return(mock_labware_core)
 
     decoy.when(mock_labware_core.labware_id).then_return("123")

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -1,0 +1,113 @@
+"""Tests for the InstrumentContext public interface."""
+import inspect
+import pytest
+from decoy import Decoy
+from typing import cast
+
+from opentrons.broker import Broker
+from opentrons.commands import publisher as mock_publisher, commands
+from opentrons.types import Location, Point, Mount
+
+from opentrons.hardware_control.dev_types import PipetteDict
+
+from opentrons.protocol_api import (
+    MAX_SUPPORTED_VERSION,
+    ProtocolContext,
+    InstrumentContext,
+    Well,
+)
+
+from opentrons.protocol_api.core.instrument import (
+    AbstractInstrument as BaseAbstractInstrument,
+)
+from opentrons.protocol_api.core.well import AbstractWellCore
+
+
+AbstractInstrument = BaseAbstractInstrument[AbstractWellCore]
+
+
+@pytest.fixture(autouse=True)
+def _mock_publisher_module(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
+    for name, func in inspect.getmembers(mock_publisher, inspect.isfunction):
+        monkeypatch.setattr(mock_publisher, name, decoy.mock(func=func))
+
+
+@pytest.fixture
+def mock_implementation(decoy: Decoy) -> AbstractInstrument:
+    """Get a mock instrument implementation."""
+    return decoy.mock(cls=AbstractInstrument)
+
+
+@pytest.fixture
+def mock_protocol_context(decoy: Decoy) -> ProtocolContext:
+    """Get a mock protocol context."""
+    return decoy.mock(cls=ProtocolContext)
+
+
+@pytest.fixture
+def mock_broker(decoy: Decoy) -> Broker:
+    """Get a mock protocol context."""
+    return decoy.mock(cls=Broker)
+
+
+@pytest.fixture
+def mock_well(decoy: Decoy) -> Well:
+    """Get a mock well."""
+    return decoy.mock(cls=Well)
+
+
+@pytest.fixture
+def subject(
+    mock_implementation: AbstractInstrument,
+    mock_protocol_context: ProtocolContext,
+    mock_broker: Broker,
+) -> InstrumentContext:
+    """Get a InstrumentContext test subject with its dependencies mocked out."""
+    return InstrumentContext(
+        implementation=mock_implementation,
+        ctx=mock_protocol_context,
+        broker=mock_broker,
+        at_version=MAX_SUPPORTED_VERSION,
+    )
+
+
+def test_move_to(
+    decoy: Decoy,
+    mock_broker: Broker,
+    mock_implementation: AbstractInstrument,
+    mock_protocol_context: ProtocolContext,
+    mock_well: Well,
+    subject: InstrumentContext,
+) -> None:
+    """It should move an instrument to a well."""
+    decoy.when(mock_implementation.get_pipette()).then_return(
+        cast(PipetteDict, {"display_name": "my cool pipette"})
+    )
+    decoy.when(mock_implementation.get_mount()).then_return(Mount.LEFT)
+    decoy.when(mock_protocol_context._modules).then_return([])
+
+    mock_context = decoy.mock(name="mock-context")
+
+    decoy.when(
+        mock_publisher.publish_context(
+            broker=mock_broker,
+            command=commands.move_to(
+                instrument=subject,
+                location=Location(point=Point(1, 2, 3), labware=mock_well),
+            ),
+        )
+    ).then_return(mock_context)
+
+    result = subject.move_to(Location(point=Point(1, 2, 3), labware=mock_well))
+
+    assert isinstance(result, InstrumentContext)
+    decoy.verify(
+        mock_context.__enter__(),
+        mock_implementation.move_to(
+            location=Location(point=Point(1, 2, 3), labware=mock_well),
+            force_direct=False,
+            minimum_z_height=None,
+            speed=None,
+        ),
+        mock_context.__exit__(None, None, None),
+    )


### PR DESCRIPTION
# Overview

This PR starts the work for RCORE-134, by adding a basic implementation of move to well for the PAPIv2 engine core. Move to well has been added to the sync client, and WellCore class has been fleshed out with non-implemented methods

# Changelog

- `move_to` engine core implementation added for wells
- `move_to_well` added to sync client
- non implemented methods added to `WellCore` 

# Review requests

# Risk assessment

Low, does not change existing non-PE core implementation