### PR TITLE
fix(hardware): avoid floating point rounding errors when calculating Block.final_speed

### DIFF
--- a/hardware/opentrons_hardware/hardware_control/motion_planning/types.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/types.py
@@ -74,7 +74,6 @@ class Block:
 
         self.final_speed = _final_speed()
         self.time = _time()
-        print(self.time, self.final_speed, self.initial_speed, self.acceleration, self.distance)
 
 
 @dataclasses.dataclass

--- a/hardware/opentrons_hardware/hardware_control/motion_planning/types.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/types.py
@@ -56,7 +56,9 @@ class Block:
 
         def _final_speed() -> np.float64:
             """Get final speed of the block."""
-            speed_squared = self.initial_speed**2 + self.acceleration * self.distance * 2
+            speed_squared = (
+                self.initial_speed**2 + self.acceleration * self.distance * 2
+            )
             # NOTE (AS, 2022-09-14): calculated value occasionally rounds to a negative,
             #                        like -1E-11, which should really just be zero
             if speed_squared < 0:

--- a/hardware/opentrons_hardware/hardware_control/motion_planning/types.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/types.py
@@ -59,9 +59,13 @@ class Block:
             speed_squared = (
                 self.initial_speed**2 + self.acceleration * self.distance * 2
             )
-            # NOTE (AS, 2022-09-14): calculated value occasionally rounds to a negative,
-            #                        like -1E-11, which should really just be zero
             if speed_squared < 0:
+                # NOTE (AS, 2022-09-14): calculated value occasionally rounds to a negative,
+                #                        like -1E-11, which should really just be zero
+                log.warning(
+                    f"Block encountered negative value in final_speed ({speed_squared}). "
+                    f"Setting Block.final_speed to 0.0 instead."
+                )
                 return np.float64(0.0)
             return cast(np.float64, np.sqrt(speed_squared))
 

--- a/hardware/opentrons_hardware/hardware_control/motion_planning/types.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/types.py
@@ -56,12 +56,12 @@ class Block:
 
         def _final_speed() -> np.float64:
             """Get final speed of the block."""
-            return cast(
-                np.float64,
-                np.sqrt(
-                    self.initial_speed**2 + self.acceleration * self.distance * 2
-                ),
-            )
+            speed_squared = self.initial_speed**2 + self.acceleration * self.distance * 2
+            # NOTE (AS, 2022-09-14): calculated value occasionally rounds to a negative,
+            #                        like -1E-11, which should really just be zero
+            if speed_squared < 0:
+                return np.float64(0.0)
+            return cast(np.float64, np.sqrt(speed_squared))
 
         def _time() -> np.float64:
             """Get the time it takes for the block to complete its motion."""
@@ -74,6 +74,7 @@ class Block:
 
         self.final_speed = _final_speed()
         self.time = _time()
+        print(self.time, self.final_speed, self.initial_speed, self.acceleration, self.distance)
 
 
 @dataclasses.dataclass

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_utils.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_utils.py
@@ -475,6 +475,19 @@ def test_final_speed(
     assert find_final_speed(CONSTRAINTS, move, next_move) == expected
 
 
+def test_handle_rounding_error_when_calculating_block_final_speed() -> None:
+    """Avoid rounding errors."""
+    # these magic values below were found to create a NaN value for Block.final_speed
+    # because of rounding errors. This should not happen.
+    b = Block(
+        initial_speed=499.99999999999994,
+        acceleration=-3292.7694932142017,
+        distance=37.961964922719986,
+    )
+    assert b.final_speed == 0
+    assert b.time
+
+
 def test_blend_motion() -> None:
     """Motion should blend."""
     manager = MoveManager(CONSTRAINTS)


### PR DESCRIPTION
# Overview

Rounding errors would occasionally cause the `Block.final_speed` to be calculated as `NaN`. That is not desired.

# Changelog

Don't give `np.sqrt()` a negative number.

# Review requests



# Risk assessment

