### PR TITLE
fix(app): order labware offset reapply candidates newest to oldest

### DIFF
--- a/app/src/organisms/ReapplyOffsetsModal/hooks/__tests__/useHistoricRunDetails.test.tsx
+++ b/app/src/organisms/ReapplyOffsetsModal/hooks/__tests__/useHistoricRunDetails.test.tsx
@@ -62,6 +62,6 @@ describe('useHistoricRunDetails', () => {
     )
     const { result, waitFor } = renderHook(useHistoricRunDetails, { wrapper })
     await waitFor(() => result.current != null)
-    expect(result.current).toEqual([MOCK_RUN_EARLIER, MOCK_RUN_LATER])
+    expect(result.current).toEqual([MOCK_RUN_LATER, MOCK_RUN_EARLIER])
   })
 })

--- a/app/src/organisms/ReapplyOffsetsModal/hooks/__tests__/useOffsetCandidatesForCurrentRun.test.tsx
+++ b/app/src/organisms/ReapplyOffsetsModal/hooks/__tests__/useOffsetCandidatesForCurrentRun.test.tsx
@@ -43,14 +43,14 @@ const mockProtocolDetails: ProtocolDetails = {
 }
 const FAKE_OFFSET_TIPRACK_IN_2: LabwareOffset = {
   id: 'fakeOffsetId',
-  createdAt: 'fakeCreatedAtTimestampTiprack',
+  createdAt: '2021-10-07T18:44:49.366581+00:00',
   location: { slotName: '2' },
   vector: { x: 1, y: 2, z: 3 },
   definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
 }
 const FAKE_OFFSET_PLATE_ON_TC: LabwareOffset = {
   id: 'fakeOffsetIdOnTC',
-  createdAt: 'fakeCreatedAtTimestampPlate',
+  createdAt: '2021-09-06T18:44:49.366581+00:00',
   location: { slotName: '7', moduleModel: 'thermocyclerModuleV1' },
   vector: { x: 4, y: 5, z: 6 },
   definitionUri: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
@@ -96,9 +96,34 @@ describe('useOffsetCandidatesForCurrentRun', () => {
       .mockReturnValue([
         {
           ...mockRunningRun,
+          createdAt: '2021-10-07T18:44:30.366581+00:00',
           labwareOffsets: [
-            { ...FAKE_OFFSET_TIPRACK_IN_2, id: 'first' },
-            { ...FAKE_OFFSET_TIPRACK_IN_2, id: 'second' },
+            {
+              ...FAKE_OFFSET_TIPRACK_IN_2,
+              createdAt: '2021-10-07T18:44:38.366581+00:00',
+              id: 'third',
+            },
+            {
+              ...FAKE_OFFSET_TIPRACK_IN_2,
+              createdAt: '2021-10-07T18:44:49.366581+00:00',
+              id: 'fourth',
+            },
+          ],
+        },
+        {
+          ...mockRunningRun,
+          createdAt: '2021-09-06T18:44:30.366581+00:00',
+          labwareOffsets: [
+            {
+              ...FAKE_OFFSET_TIPRACK_IN_2,
+              createdAt: '2021-09-06T18:44:38.366581+00:00',
+              id: 'first',
+            },
+            {
+              ...FAKE_OFFSET_TIPRACK_IN_2,
+              createdAt: '2021-09-06T18:44:49.366581+00:00',
+              id: 'second',
+            },
           ],
         },
       ])
@@ -109,9 +134,10 @@ describe('useOffsetCandidatesForCurrentRun', () => {
     expect(result.current).toEqual([
       {
         ...FAKE_OFFSET_TIPRACK_IN_2,
-        id: 'first',
+        createdAt: '2021-10-07T18:44:49.366581+00:00',
+        id: 'fourth',
         labwareDisplayName: 'Opentrons 96 Tip Rack 300 µL',
-        runCreatedAt: mockRunningRun.createdAt,
+        runCreatedAt: '2021-10-07T18:44:30.366581+00:00',
       },
     ])
   })

--- a/app/src/organisms/ReapplyOffsetsModal/hooks/useHistoricRunDetails.ts
+++ b/app/src/organisms/ReapplyOffsetsModal/hooks/useHistoricRunDetails.ts
@@ -11,6 +11,6 @@ export function useHistoricRunDetails(): RunData[] {
         .filter(run => !run.current)
         .sort(
           (a, b) =>
-            new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
         )
 }

--- a/app/src/organisms/ReapplyOffsetsModal/hooks/useOffsetCandidatesForCurrentRun.ts
+++ b/app/src/organisms/ReapplyOffsetsModal/hooks/useOffsetCandidatesForCurrentRun.ts
@@ -25,8 +25,8 @@ export function useOffsetCandidatesForCurrentRun(): OffsetCandidate[] {
           }))
           ?.sort(
             (a, b) =>
-              new Date(a.offset.createdAt).getTime() -
-              new Date(b.offset.createdAt).getTime()
+              new Date(b.offset.createdAt).getTime() -
+              new Date(a.offset.createdAt).getTime()
           ) ?? []
     )
     .flat()


### PR DESCRIPTION
# Overview

This fixes a bug in which our reapply offsets candidate calculation was sorting in the wrong order both for offset timestamps and for run creation timestamps, it also fixes the unit tests which accidentally tested for the exact opposite of the written intent which masked this bug.

Closes RAUT-217

# Review requests

Attempt to repro the bug specified in RAUT-217.  You should always be given the most modern offset for a given labware/location combination if there are multiple instances across your 20 stored historical runs. 

# Risk assessment
low
