### PR TITLE
refactor(app): redesign Choose tip rack modal

### DIFF
--- a/app/src/assets/localization/en/robot_calibration.json
+++ b/app/src/assets/localization/en/robot_calibration.json
@@ -90,7 +90,7 @@
   "you_can_remove_cal_block": "You can remove the Calibration Block from the deck now.",
   "choose_a_tip_rack": "Choose a tip rack",
   "select_tip_rack": "select tip rack",
-  "choose_tip_rack": "<block>Choose what tip rack you’d like to use to calibrate your tip length.</block><block><strong>Want to use a tip rack that’s not listed here?</strong>Go to More > Custom Labware to add labware.</block>",
+  "choose_tip_rack": "<block>Choose what tip rack you’d like to use to calibrate your tip length.</block><block><strong>Want to use a tip rack that’s not listed here?</strong>Go to Labware > Import to add labware.</block>",
   "calibration_on_opentrons_tips_is_important": "It’s extremely important to perform this calibration using the Opentrons tips and tip racks specified above, as the robot determines accuracy based on the known measurements of these tips.",
   "opentrons_tip_racks_recommended": "Opentrons tip racks are highly recommended. Accuracy cannot be guaranteed with other tip racks.",
   "opentrons": "opentrons",

--- a/app/src/assets/localization/en/robot_calibration.json
+++ b/app/src/assets/localization/en/robot_calibration.json
@@ -87,5 +87,13 @@
   "small": "Small",
   "large": "Large",
   "you_will_need": "You will need:",
-  "you_can_remove_cal_block": "You can remove the Calibration Block from the deck now."
+  "you_can_remove_cal_block": "You can remove the Calibration Block from the deck now.",
+  "choose_a_tip_rack": "Choose a tip rack",
+  "select_tip_rack": "select tip rack",
+  "choose_tip_rack": "<block>Choose what tip rack you’d like to use to calibrate your tip length.</block><block><strong>Want to use a tip rack that’s not listed here?</strong>Go to More > Custom Labware to add labware.</block>",
+  "calibration_on_opentrons_tips_is_important": "It’s extremely important to perform this calibration using the Opentrons tips and tip racks specified above, as the robot determines accuracy based on the known measurements of these tips.",
+  "opentrons_tip_racks_recommended": "Opentrons tip racks are highly recommended. Accuracy cannot be guaranteed with other tip racks.",
+  "opentrons": "opentrons",
+  "custom": "custom",
+  "confirm_tip_rack": "Confirm tip rack"
 }

--- a/app/src/atoms/SelectField/Select.tsx
+++ b/app/src/atoms/SelectField/Select.tsx
@@ -131,6 +131,7 @@ export function Select(props: SelectComponentProps): JSX.Element {
       marginRight: '0.75rem',
       marginLeft: SPACING.spacing2,
       marginTop: '0.2rem',
+      fontSize: TYPOGRAPHY.fontSizeP,
     }),
     valueContainer: NO_STYLE_FN,
   }

--- a/app/src/organisms/CalibrationPanels/ChooseTipRack.tsx
+++ b/app/src/organisms/CalibrationPanels/ChooseTipRack.tsx
@@ -14,6 +14,7 @@ import {
   Box,
   COLORS,
   Btn,
+  Link,
 } from '@opentrons/components'
 import { usePipettesQuery } from '@opentrons/react-api-client'
 import { getLabwareDefURI } from '@opentrons/shared-data'
@@ -56,16 +57,6 @@ function formatOptionsFromLabwareDef(lw: LabwareDefinition2): SelectOption {
     label: lw.metadata.displayName,
   }
 }
-
-const CANCEL_BUTTON_STYLE = css`
-  ${TYPOGRAPHY.pSemiBold};
-  text-transform: ${TYPOGRAPHY.textTransformCapitalize};
-  color: ${COLORS.darkGreyEnabled};
-
-  &:hover {
-    opacity: 70%;
-  }
-`
 interface ChooseTipRackProps {
   tipRack: CalibrationLabware
   mount: Mount
@@ -258,11 +249,15 @@ export function ChooseTipRack(props: ChooseTipRackProps): JSX.Element {
       >
         <NeedHelpLink />
         <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing3}>
-          <Btn onClick={() => closeModal()} marginRight={SPACING.spacing4}>
-            <StyledText css={CANCEL_BUTTON_STYLE}>
-              {t('shared:cancel')}
-            </StyledText>
-          </Btn>
+          <Link
+            role="button"
+            css={TYPOGRAPHY.darkLinkH4SemiBold}
+            textTransform={TYPOGRAPHY.textTransformCapitalize}
+            onClick={() => closeModal()}
+            marginRight={SPACING.spacing4}
+          >
+            {t('shared:cancel')}
+          </Link>
           <PrimaryButton onClick={handleUseTipRack}>
             {t('confirm_tip_rack')}
           </PrimaryButton>

--- a/app/src/organisms/CalibrationPanels/ChooseTipRack.tsx
+++ b/app/src/organisms/CalibrationPanels/ChooseTipRack.tsx
@@ -17,7 +17,7 @@ import {
 } from '@opentrons/components'
 import { usePipettesQuery } from '@opentrons/react-api-client'
 import { getLabwareDefURI } from '@opentrons/shared-data'
-import { PrimaryButton, SecondaryButton } from '../../atoms/buttons'
+import { PrimaryButton } from '../../atoms/buttons'
 import { getCustomTipRackDefinitions } from '../../redux/custom-labware'
 import {
   getCalibrationForPipette,

--- a/app/src/organisms/CalibrationPanels/ChooseTipRack.tsx
+++ b/app/src/organisms/CalibrationPanels/ChooseTipRack.tsx
@@ -1,85 +1,52 @@
 import * as React from 'react'
 import { useSelector } from 'react-redux'
+import { css } from 'styled-components'
+import { Trans, useTranslation } from 'react-i18next'
 import head from 'lodash/head'
 import isEqual from 'lodash/isEqual'
-
 import {
-  AlertItem,
-  ALIGN_FLEX_START,
-  BORDER_SOLID_MEDIUM,
-  Box,
   DIRECTION_COLUMN,
   Flex,
-  FONT_HEADER_DARK,
   JUSTIFY_SPACE_BETWEEN,
-  JUSTIFY_CENTER,
-  POSITION_RELATIVE,
-  PrimaryBtn,
-  Select,
-  SPACING_1,
-  SPACING_2,
-  SPACING_3,
-  SPACING_4,
-  Text,
-  TEXT_TRANSFORM_UPPERCASE,
-  TEXT_TRANSFORM_CAPITALIZE,
-  FONT_WEIGHT_SEMIBOLD,
   ALIGN_CENTER,
-  SecondaryBtn,
-  SIZE_5,
+  SPACING,
   TYPOGRAPHY,
+  Box,
+  COLORS,
+  Btn,
 } from '@opentrons/components'
 import { usePipettesQuery } from '@opentrons/react-api-client'
-
-import * as Sessions from '../../redux/sessions'
-import { NeedHelpLink } from './NeedHelpLink'
-import { ChosenTipRackRender } from './ChosenTipRackRender'
+import { getLabwareDefURI } from '@opentrons/shared-data'
+import { PrimaryButton, SecondaryButton } from '../../atoms/buttons'
 import { getCustomTipRackDefinitions } from '../../redux/custom-labware'
 import {
   getCalibrationForPipette,
   getTipLengthCalibrations,
   getTipLengthForPipetteAndTiprack,
 } from '../../redux/calibration/'
-import { getLabwareDefURI } from '@opentrons/shared-data'
-import styles from './styles.css'
+import { Select } from '../../atoms/SelectField/Select'
+import { Banner } from '../../atoms/Banner'
+import { Divider } from '../../atoms/structure'
+import { StyledText } from '../../atoms/text'
+import { NeedHelpLink } from './NeedHelpLink'
+import { ChosenTipRackRender } from './ChosenTipRackRender'
 
-import type { TipRackMap } from './ChosenTipRackRender'
-import type {
-  SessionType,
-  CalibrationLabware,
-} from '../../redux/sessions/types'
-import type { State } from '../../redux/types'
-import type { SelectOption, SelectOptionOrGroup } from '@opentrons/components'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
-import type { Mount } from '../../redux/pipettes/types'
 import type { MultiValue, SingleValue } from 'react-select'
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { SelectOption, SelectOptionOrGroup } from '@opentrons/components'
+import type { CalibrationLabware } from '../../redux/sessions/types'
+import type { State } from '../../redux/types'
+import type { Mount } from '../../redux/pipettes/types'
+import type { TipLengthCalibration } from '../../redux/calibration/api-types'
 
-const HEADER = 'choose tip rack'
-const INTRO = 'Choose what tip rack you would like to use to calibrate your'
-const PIP_OFFSET_INTRO_FRAGMENT = 'Pipette Offset'
-const DECK_CAL_INTRO_FRAGMENT = 'Deck'
-
-const PROMPT =
-  'Want to use a tip rack that is not listed here? Go to More > Custom Labware to add labware.'
-
-const SELECT_TIP_RACK = 'select tip rack'
-const ALERT_TEXT =
-  'Opentrons tip racks are strongly recommended. Accuracy cannot be guaranteed with other tip racks.'
-
-const OPENTRONS_LABEL = 'opentrons'
-const CUSTOM_LABEL = 'custom'
-const USE_THIS_TIP_RACK = 'use this tip rack'
-
-const introContentByType = (sessionType: SessionType): string => {
-  switch (sessionType) {
-    case Sessions.SESSION_TYPE_DECK_CALIBRATION:
-      return `${INTRO} ${DECK_CAL_INTRO_FRAGMENT}.`
-    case Sessions.SESSION_TYPE_PIPETTE_OFFSET_CALIBRATION:
-      return `${INTRO} ${PIP_OFFSET_INTRO_FRAGMENT}.`
-    default:
-      return 'This panel is shown in error'
-  }
+interface TipRackInfo {
+  definition: LabwareDefinition2
+  calibration: TipLengthCalibration | null
 }
+
+export type TipRackMap = Partial<{
+  [uri: string]: TipRackInfo
+}>
 
 const EQUIPMENT_POLL_MS = 5000
 
@@ -90,10 +57,18 @@ function formatOptionsFromLabwareDef(lw: LabwareDefinition2): SelectOption {
   }
 }
 
+const CANCEL_BUTTON_STYLE = css`
+  ${TYPOGRAPHY.pSemiBold};
+  text-transform: ${TYPOGRAPHY.textTransformCapitalize};
+  color: ${COLORS.darkGreyEnabled};
+
+  &:hover {
+    opacity: 70%;
+  }
+`
 interface ChooseTipRackProps {
   tipRack: CalibrationLabware
   mount: Mount
-  sessionType: SessionType
   chosenTipRack: LabwareDefinition2 | null
   handleChosenTipRack: (arg: LabwareDefinition2 | null) => unknown
   closeModal: () => unknown
@@ -105,14 +80,13 @@ export function ChooseTipRack(props: ChooseTipRackProps): JSX.Element {
   const {
     tipRack,
     mount,
-    sessionType,
     chosenTipRack,
     handleChosenTipRack,
     closeModal,
     robotName,
     defaultTipracks,
   } = props
-
+  const { t } = useTranslation(['robot_calibration', 'shared'])
   const pipSerial = usePipettesQuery({
     refetchInterval: EQUIPMENT_POLL_MS,
   })?.data?.[mount].id
@@ -175,11 +149,11 @@ export function ChooseTipRack(props: ChooseTipRackProps): JSX.Element {
     customTipRacks.length > 0
       ? [
           {
-            label: OPENTRONS_LABEL,
+            label: t('opentrons'),
             options: opentronsTipRacksOptions,
           },
           {
-            label: CUSTOM_LABEL,
+            label: t('custom'),
             options: customTipRacksOptions,
           },
         ]
@@ -210,91 +184,89 @@ export function ChooseTipRack(props: ChooseTipRackProps): JSX.Element {
     }
     closeModal()
   }
-  const introText = introContentByType(sessionType)
   return (
     <Flex
-      key="chooseTipRack"
-      marginTop={SPACING_2}
-      marginBottom={SPACING_3}
       flexDirection={DIRECTION_COLUMN}
-      alignItems={ALIGN_FLEX_START}
-      position={POSITION_RELATIVE}
-      fontSize={TYPOGRAPHY.fontSizeH3}
-      width="100%"
+      justifyContent={JUSTIFY_SPACE_BETWEEN}
+      padding={SPACING.spacing6}
+      minHeight="25rem"
     >
-      <Flex width="100%" justifyContent={JUSTIFY_SPACE_BETWEEN}>
-        <Text
-          css={FONT_HEADER_DARK}
-          marginBottom={SPACING_3}
-          textTransform={TEXT_TRANSFORM_UPPERCASE}
-        >
-          {HEADER}
-        </Text>
-        <NeedHelpLink />
-      </Flex>
-      <Box marginBottom={SPACING_3}>
-        <Text marginBottom={SPACING_3}>{introText}</Text>
-        <Text>{PROMPT}</Text>
-      </Box>
-      <Flex marginBottom={SPACING_4}>
-        <AlertItem type="warning" title={ALERT_TEXT} />
-      </Flex>
-      <Flex
-        width="80%"
-        marginBottom={SPACING_4}
-        justifyContent={JUSTIFY_CENTER}
-        flexDirection={DIRECTION_COLUMN}
-        alignSelf={ALIGN_CENTER}
-      >
+      <Flex gridGap={SPACING.spacingXXL}>
         <Flex
-          height={SIZE_5}
-          border={BORDER_SOLID_MEDIUM}
-          paddingTop={SPACING_4}
-          justifyContent={JUSTIFY_SPACE_BETWEEN}
-          marginBottom={SPACING_2}
+          flex="1"
+          flexDirection={DIRECTION_COLUMN}
+          gridGap={SPACING.spacing3}
         >
-          <Box width="55%" paddingLeft={SPACING_4}>
-            <Text
-              textTransform={TEXT_TRANSFORM_CAPITALIZE}
-              fontWeight={FONT_WEIGHT_SEMIBOLD}
-              marginBottom={SPACING_1}
-            >
-              {SELECT_TIP_RACK}
-            </Text>
+          <StyledText
+            css={TYPOGRAPHY.h1Default}
+            marginBottom={SPACING.spacing4}
+          >
+            {t('choose_a_tip_rack')}
+          </StyledText>
+          <StyledText
+            textTransform={TYPOGRAPHY.textTransformCapitalize}
+            css={TYPOGRAPHY.labelSemiBold}
+          >
+            {t('select_tip_rack')}
+          </StyledText>
+          <Box marginBottom={SPACING.spacingSM}>
             <Select
-              className={styles.select_tiprack_menu}
+              isSearchable={false}
               options={groupOptions}
               onChange={handleValueChange}
               value={selectedValue}
+              width="16rem"
+              menuPortalTarget={document.body}
+              styles={{ menuPortal: base => ({ ...base, zIndex: 10 }) }}
             />
           </Box>
-          <Box width="45%" height="100%">
-            <ChosenTipRackRender
-              showCalibrationText={
-                sessionType === Sessions.SESSION_TYPE_PIPETTE_OFFSET_CALIBRATION
-              }
-              selectedValue={selectedValue as SelectOption}
-              tipRackByUriMap={tipRackByUriMap}
-            />
-          </Box>
+          <Trans
+            t={t}
+            i18nKey="choose_tip_rack"
+            components={{
+              strong: (
+                <strong
+                  style={{
+                    marginRight: SPACING.spacing2,
+                    fontWeight: TYPOGRAPHY.fontWeightSemiBold,
+                  }}
+                />
+              ),
+              block: <StyledText as="p" />,
+            }}
+          />
+        </Flex>
+        <Flex flex="1" flexDirection={DIRECTION_COLUMN}>
+          <Banner type="warning">
+            <StyledText as="p" marginRight={SPACING.spacing4}>
+              {t('opentrons_tip_racks_recommended')}
+            </StyledText>
+          </Banner>
+          <Divider marginY={SPACING.spacing3} width="100%" />
+          <ChosenTipRackRender selectedValue={selectedValue as SelectOption} />
+          <Divider marginY={SPACING.spacing3} width="100%" />
+          <StyledText as="label" color={COLORS.darkGreyEnabled}>
+            {t('calibration_on_opentrons_tips_is_important')}
+          </StyledText>
         </Flex>
       </Flex>
-      <Flex width="100%" justifyContent={JUSTIFY_CENTER}>
-        <SecondaryBtn
-          data-test="useThisTipRackButton"
-          width="25%"
-          marginRight={SPACING_3}
-          onClick={() => closeModal()}
-        >
-          Cancel
-        </SecondaryBtn>
-        <PrimaryBtn
-          data-test="useThisTipRackButton"
-          width="48%"
-          onClick={handleUseTipRack}
-        >
-          {USE_THIS_TIP_RACK}
-        </PrimaryBtn>
+      <Flex
+        width="100%"
+        marginTop={SPACING.spacing6}
+        justifyContent={JUSTIFY_SPACE_BETWEEN}
+        alignItems={ALIGN_CENTER}
+      >
+        <NeedHelpLink />
+        <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing3}>
+          <Btn onClick={() => closeModal()} marginRight={SPACING.spacing4}>
+            <StyledText css={CANCEL_BUTTON_STYLE}>
+              {t('shared:cancel')}
+            </StyledText>
+          </Btn>
+          <PrimaryButton onClick={handleUseTipRack}>
+            {t('confirm_tip_rack')}
+          </PrimaryButton>
+        </Flex>
       </Flex>
     </Flex>
   )

--- a/app/src/organisms/CalibrationPanels/ChooseTipRack.tsx
+++ b/app/src/organisms/CalibrationPanels/ChooseTipRack.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { useSelector } from 'react-redux'
-import { css } from 'styled-components'
 import { Trans, useTranslation } from 'react-i18next'
 import head from 'lodash/head'
 import isEqual from 'lodash/isEqual'
@@ -13,7 +12,6 @@ import {
   TYPOGRAPHY,
   Box,
   COLORS,
-  Btn,
   Link,
 } from '@opentrons/components'
 import { usePipettesQuery } from '@opentrons/react-api-client'

--- a/app/src/organisms/CalibrationPanels/ChosenTipRackRender.tsx
+++ b/app/src/organisms/CalibrationPanels/ChosenTipRackRender.tsx
@@ -1,102 +1,51 @@
 import * as React from 'react'
 import { css } from 'styled-components'
-
 import {
   Box,
   Flex,
-  Text,
   ALIGN_CENTER,
-  C_MED_DARK_GRAY,
-  DIRECTION_COLUMN,
-  FONT_SIZE_BODY_1,
-  FONT_STYLE_ITALIC,
-  JUSTIFY_CENTER,
-  SIZE_4,
-  SPACING_2,
-  SPACING_3,
-  TEXT_ALIGN_CENTER,
-  TYPOGRAPHY,
+  DIRECTION_ROW,
+  SPACING,
 } from '@opentrons/components'
+import { StyledText } from '../../atoms/text'
 import { labwareImages } from './labwareImages'
-import { formatLastModified } from './utils'
 
 import type { SelectOption } from '@opentrons/components'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
-import type { TipLengthCalibration } from '../../redux/calibration/api-types'
-
-const TIP_LENGTH_CALIBRATED_PROMPT = 'Calibrated on'
-const OVERRIDE_TIP_LENGTH_CALIBRATED_PROMPT =
-  'Choosing this tiprack will override previous Tip Length Calibration data.'
-const TIP_LENGTH_UNCALIBRATED_PROMPT =
-  'Not yet calibrated. You will calibrate this tip length before proceeding to Pipette Offset Calibration.'
-
-interface TipRackInfo {
-  definition: LabwareDefinition2
-  calibration: TipLengthCalibration | null
-}
-
-export type TipRackMap = Partial<{
-  [uri: string]: TipRackInfo
-}>
-
 export interface ChosenTipRackRenderProps {
-  showCalibrationText: boolean
   selectedValue: SelectOption
-  tipRackByUriMap: TipRackMap
 }
 
 export function ChosenTipRackRender(
   props: ChosenTipRackRenderProps
 ): JSX.Element {
-  const { showCalibrationText, selectedValue, tipRackByUriMap } = props
+  const { selectedValue } = props
   const loadName: keyof typeof labwareImages = selectedValue.value.split(
     '/'
   )[1] as any
   const displayName = selectedValue?.label
-  const calibrationData = tipRackByUriMap[selectedValue.value]?.calibration
-
   const imageSrc =
     loadName in labwareImages
       ? labwareImages[loadName]
       : labwareImages.generic_custom_tiprack
+
   return (
     <Flex
-      height="100%"
-      flexDirection={DIRECTION_COLUMN}
+      flexDirection={DIRECTION_ROW}
       alignItems={ALIGN_CENTER}
-      justifyContent={JUSTIFY_CENTER}
-      paddingRight={SPACING_2}
-      paddingBottom={SPACING_3}
-      fontSize={TYPOGRAPHY.fontSizeH3}
+      marginLeft={SPACING.spacing3}
     >
       <img
         css={css`
-          max-width: ${SIZE_4};
-          max-height: 6rem;
-          flex: 0 1 5rem;
-          display: block;
-          margin-bottom: ${SPACING_3};
+          max-width: 7rem;
+          max-height: 3.7rem;
         `}
         src={imageSrc}
+        alt={`${displayName} image`}
       />
       <Box>
-        <Text textAlign={TEXT_ALIGN_CENTER} marginBottom={SPACING_2}>
+        <StyledText as="p" marginLeft={SPACING.spacing4}>
           {displayName}
-        </Text>
-        {showCalibrationText && (
-          <Text
-            color={C_MED_DARK_GRAY}
-            fontSize={FONT_SIZE_BODY_1}
-            fontStyle={FONT_STYLE_ITALIC}
-            textAlign={TEXT_ALIGN_CENTER}
-          >
-            {calibrationData
-              ? `${TIP_LENGTH_CALIBRATED_PROMPT} ${formatLastModified(
-                  calibrationData.lastModified
-                )}. ${OVERRIDE_TIP_LENGTH_CALIBRATED_PROMPT}`
-              : TIP_LENGTH_UNCALIBRATED_PROMPT}
-          </Text>
-        )}
+        </StyledText>
       </Box>
     </Flex>
   )

--- a/app/src/organisms/CalibrationPanels/Introduction/index.tsx
+++ b/app/src/organisms/CalibrationPanels/Introduction/index.tsx
@@ -108,7 +108,6 @@ export function Introduction(props: CalibrationPanelProps): JSX.Element {
     <ChooseTipRack
       tipRack={props.tipRack}
       mount={props.mount}
-      sessionType={props.sessionType}
       chosenTipRack={chosenTipRack}
       handleChosenTipRack={handleChosenTipRack}
       closeModal={() => setShowChooseTipRack(false)}

--- a/app/src/organisms/CalibrationPanels/__tests__/ChosenTipRackRender.test.tsx
+++ b/app/src/organisms/CalibrationPanels/__tests__/ChosenTipRackRender.test.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react'
+import { i18n } from '../../../i18n'
+import { renderWithProviders } from '@opentrons/components'
+import { ChosenTipRackRender } from '../ChosenTipRackRender'
+import type { SelectOption } from '../../../atoms/SelectField/Select'
+
+const render = (props: React.ComponentProps<typeof ChosenTipRackRender>) => {
+  return renderWithProviders(<ChosenTipRackRender {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+const mockSelectValue = {
+  value: 'opentrons_96_tiprack_1000ul',
+  label: 'Opentrons 96 tip rack 1000ul',
+} as SelectOption
+
+describe('ChosenTipRackRender', () => {
+  let props: React.ComponentProps<typeof ChosenTipRackRender>
+  beforeEach(() => {
+    props = {
+      selectedValue: mockSelectValue,
+    }
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('renders text and image alt text when tip rack is Opentrons 96 1000uL', () => {
+    const { getByText, getByAltText } = render(props)
+    getByText('Opentrons 96 tip rack 1000ul')
+    getByAltText('Opentrons 96 tip rack 1000ul image')
+  })
+})

--- a/components/src/ui-style-constants/typography.ts
+++ b/components/src/ui-style-constants/typography.ts
@@ -121,6 +121,15 @@ export const linkPSemiBold = css`
   }
 `
 
+export const darkLinkH4SemiBold = css`
+  font-size: ${fontSizeH4};
+  font-weight: ${fontWeightSemiBold};
+  line-height: ${lineHeight20};
+  color: ${COLORS.darkGreyEnabled};
+  &:hover {
+    color: ${COLORS.darkBlackEnabled};
+  }
+`
 export const darkLinkLabelSemiBold = css`
   font-size: ${fontSizeLabel};
   font-weight: ${fontWeightSemiBold};


### PR DESCRIPTION
closes RAUT-172

# Overview

The `ChooseTipRack` modal has been redesigned to match figma. 

<img width="779" alt="Screen Shot 2022-09-16 at 1 13 41 PM" src="https://user-images.githubusercontent.com/66035149/190693203-2f34c5f1-f36d-4a9f-b5b2-c77cbd06336a.png">

# Changelog

- add `fontSize` to `SingleValue` style in react select `select` component
- change `ChooseTipRack` and `ChosenTipRackRender` to match designs, update tests, create test for `ChosenTipRackRender`. Full functionality should be retained from legacy components

# Review requests

- with the re-skin calibration flow FF turned on, clear deck calibration and go through the deck calibration flow, on the first page, click on "Change tip rack" cta. You should get the correct `ChooseTipRack` modal with the updated designs. All buttons should work, as well as the `select` component
- do the same steps again with the FF turned off. It should maintain the legacy designs

# Risk assessment

low