### PR TITLE
fix(api): small Makefile lint change

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -118,7 +118,8 @@ test-ot2:
 
 .PHONY: lint
 lint:
-	$(python) -m mypy src tests
+	$(python) -m mypy src
+	$(python) -m mypy -p tests
 	$(python) -m black --check src tests setup.py
 	$(python) -m flake8 src tests setup.py
 


### PR DESCRIPTION
I was working on [this branch](https://github.com/Opentrons/opentrons/pull/11478) when I started getting the following error:

`tests/opentrons/conftest.py: error: Source file found twice under different module names: "api.tests.opentrons.conftest" and "tests.opentrons.conftest"
`

I found that just changing the lint arguments fixed it. Is this something that should be pushed to edge, or is it specific to my code from the other branch?