### PR TITLE
refactor(api): remove unused module geometry and hardware interfaces

### DIFF
--- a/api/src/opentrons/hardware_control/modules/__init__.py
+++ b/api/src/opentrons/hardware_control/modules/__init__.py
@@ -4,7 +4,7 @@ from .magdeck import MagDeck
 from .thermocycler import Thermocycler
 from .heater_shaker import HeaterShaker
 from .update import update_firmware
-from .utils import MODULE_HW_BY_NAME, build
+from .utils import MODULE_TYPE_BY_NAME, build
 from .types import (
     ThermocyclerStep,
     UploadFunction,
@@ -21,7 +21,7 @@ from .types import (
 )
 
 __all__ = [
-    "MODULE_HW_BY_NAME",
+    "MODULE_TYPE_BY_NAME",
     "build",
     "update_firmware",
     "ThermocyclerStep",

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -13,6 +13,7 @@ from opentrons.hardware_control.execution_manager import ExecutionManager
 from opentrons.hardware_control.poller import Reader, WaitableListener, Poller
 from opentrons.hardware_control.modules import mod_abc, update
 from opentrons.hardware_control.modules.types import (
+    ModuleType,
     TemperatureStatus,
     SpeedStatus,
     HeaterShakerStatus,
@@ -37,7 +38,9 @@ class HeaterShakerError(RuntimeError):
 
 
 class HeaterShaker(mod_abc.AbstractModule):
-    """Heater-Shaker module class"""
+    """Hardware control interface for an attached Heater-Shaker module."""
+
+    MODULE_TYPE = ModuleType.HEATER_SHAKER
 
     @classmethod
     async def build(

--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -38,7 +38,9 @@ def engage_height_is_in_range(model: str, height: float) -> bool:
 
 
 class MagDeck(mod_abc.AbstractModule):
+    """Hardware control interface for an attached Temperature Module."""
 
+    MODULE_TYPE = types.ModuleType.MAGNETIC
     FIRST_GEN2_REVISION = 20
 
     @classmethod

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -3,12 +3,12 @@ import asyncio
 import logging
 import re
 from pkg_resources import parse_version
-from typing import Mapping, Optional, cast, TypeVar
+from typing import ClassVar, Mapping, Optional, cast, TypeVar
 from opentrons.config import IS_ROBOT, ROBOT_FIRMWARE_DIR
 from opentrons.hardware_control.util import use_or_initialize_loop
 from opentrons.drivers.rpi_drivers.types import USBPort
 from ..execution_manager import ExecutionManager
-from .types import BundledFirmware, UploadFunction, LiveData
+from .types import BundledFirmware, UploadFunction, LiveData, ModuleType
 
 mod_log = logging.getLogger(__name__)
 
@@ -17,6 +17,8 @@ TaskPayload = TypeVar("TaskPayload")
 
 class AbstractModule(abc.ABC):
     """Defines the common methods of a module."""
+
+    MODULE_TYPE: ClassVar[ModuleType]
 
     @classmethod
     @abc.abstractmethod

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -22,10 +22,9 @@ SIM_TEMP_POLL_INTERVAL_SECS = TEMP_POLL_INTERVAL_SECS / 20.0
 
 
 class TempDeck(mod_abc.AbstractModule):
-    """
-    Under development. API subject to change without a version bump
-    """
+    """Hardware control interface for an attached Temperature Module."""
 
+    MODULE_TYPE = types.ModuleType.TEMPERATURE
     FIRST_GEN2_REVISION = 20
 
     @classmethod

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -37,9 +37,9 @@ class ThermocyclerError(Exception):
 
 
 class Thermocycler(mod_abc.AbstractModule):
-    """
-    Under development. API subject to change without a version bump
-    """
+    """Hardware control interface for an attached Thermocycler."""
+
+    MODULE_TYPE = types.ModuleType.THERMOCYCLER
 
     @classmethod
     async def build(

--- a/api/src/opentrons/hardware_control/modules/types.py
+++ b/api/src/opentrons/hardware_control/modules/types.py
@@ -40,6 +40,17 @@ class ModuleType(str, Enum):
     MAGNETIC: MagneticModuleType = "magneticModuleType"
     HEATER_SHAKER: HeaterShakerModuleType = "heaterShakerModuleType"
 
+    @classmethod
+    def from_model(cls, model: ModuleModel) -> ModuleType:
+        if isinstance(model, MagneticModuleModel):
+            return cls.MAGNETIC
+        if isinstance(model, TemperatureModuleModel):
+            return cls.TEMPERATURE
+        if isinstance(model, ThermocyclerModuleModel):
+            return cls.THERMOCYCLER
+        if isinstance(model, HeaterShakerModuleModel):
+            return cls.HEATER_SHAKER
+
 
 class MagneticModuleModel(str, Enum):
     MAGNETIC_V1: str = "magneticModuleV1"

--- a/api/src/opentrons/hardware_control/modules/utils.py
+++ b/api/src/opentrons/hardware_control/modules/utils.py
@@ -17,7 +17,7 @@ from .heater_shaker import HeaterShaker
 log = logging.getLogger(__name__)
 
 
-# TODO (lc 05-12-2021) This is pretty gross. We should think                                        |
+# TODO (lc 05-12-2021) This is pretty gross. We should think
 # of a better way to do this.
 MODULE_TYPE_BY_NAME = {
     MagDeck.name(): MagDeck.MODULE_TYPE,

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -12,7 +12,6 @@ from typing import (
     Union,
     List,
     Optional,
-    Tuple,
     Sequence,
     Set,
     Any,
@@ -28,7 +27,7 @@ from opentrons.config.types import (
     GantryLoad,
     CapacitivePassSettings,
 )
-from .backends.ot3utils import get_system_constraints
+from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons_hardware.hardware_control.motion_planning import (
     MoveManager,
     MoveTarget,
@@ -44,6 +43,7 @@ from .instruments.pipette import (
 from .instruments.gripper import compare_gripper_config_and_check_skip
 from .backends.ot3controller import OT3Controller
 from .backends.ot3simulator import OT3Simulator
+from .backends.ot3utils import get_system_constraints
 from .execution_manager import ExecutionManagerProvider
 from .pause_manager import PauseManager
 from .module_control import AttachedModulesControl
@@ -367,6 +367,22 @@ class OT3API(
     @property
     def attached_modules(self) -> List[modules.AbstractModule]:
         return self._backend.module_controls.available_modules
+
+    async def create_simulating_module(
+        self,
+        model: modules.types.ModuleModel,
+    ) -> modules.AbstractModule:
+        """Create a simulating module hardware interface."""
+        assert (
+            self.is_simulator
+        ), "Cannot build simulating module from non-simulating hardware control API"
+
+        return await self._backend.module_controls.build_module(
+            port="",
+            usb_port=USBPort(name="", port_number=0),
+            type=modules.ModuleType.from_model(model),
+            sim_model=model.value,
+        )
 
     async def update_firmware(
         self,
@@ -1257,16 +1273,6 @@ class OT3API(
             }
         )
         _remove()
-
-    async def find_modules(
-        self,
-        by_model: modules.types.ModuleModel,
-        resolved_type: modules.types.ModuleType,
-    ) -> Tuple[List[modules.AbstractModule], Optional[modules.AbstractModule]]:
-        modules_result = await self._backend.module_controls.parse_modules(
-            by_model, resolved_type
-        )
-        return modules_result
 
     async def clean_up(self) -> None:
         """Get the API ready to stop cleanly."""

--- a/api/src/opentrons/hardware_control/protocols/module_provider.py
+++ b/api/src/opentrons/hardware_control/protocols/module_provider.py
@@ -1,8 +1,7 @@
-from typing import List, Tuple, Optional
+from typing import List
 from typing_extensions import Protocol
 
-from ..modules import AbstractModule
-from ..modules.types import ModuleModel, ModuleType
+from ..modules import AbstractModule, ModuleModel
 
 
 class ModuleProvider(Protocol):
@@ -13,10 +12,5 @@ class ModuleProvider(Protocol):
         """Return a list of currently-attached modules."""
         ...
 
-    async def find_modules(
-        self,
-        by_model: ModuleModel,
-        resolved_type: ModuleType,
-    ) -> Tuple[List[AbstractModule], Optional[AbstractModule]]:
-        """Query the attached modules for a specific kind or model of module."""
-        ...
+    async def create_simulating_module(self, model: ModuleModel) -> AbstractModule:
+        """Create a simulating module hardware interface."""

--- a/api/src/opentrons/protocols/api_support/definitions.py
+++ b/api/src/opentrons/protocols/api_support/definitions.py
@@ -3,8 +3,5 @@ from .types import APIVersion
 MAX_SUPPORTED_VERSION = APIVersion(2, 13)
 """The maximum supported protocol API version in this release."""
 
-POST_V1_MODULE_DEF_VERSION = APIVersion(2, 3)
-"""The first API version in which we prefer the non-V1 module definitions."""
-
 MIN_SUPPORTED_VERSION = APIVersion(2, 0)
 """The minimum supported protocol API version in this release."""

--- a/api/src/opentrons/protocols/geometry/module_geometry.py
+++ b/api/src/opentrons/protocols/geometry/module_geometry.py
@@ -6,15 +6,11 @@ This module provides things like :py:class:`ModuleGeometry` and
 objects on the deck (as opposed to calling commands on them, which is handled
 by :py:mod:`.module_contexts`)
 """
-import functools
+from __future__ import annotations
 import logging
-import re
-from typing import Mapping, Optional, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
-import jsonschema  # type: ignore[import]
-
-from opentrons.protocol_api.core.protocol_api.labware import LabwareImplementation
 
 from opentrons_shared_data import module
 from opentrons_shared_data.labware.dev_types import LabwareUri
@@ -34,48 +30,20 @@ from opentrons.hardware_control.modules.types import (
     ThermocyclerModuleModel,
     HeaterShakerModuleModel,
 )
-from opentrons.protocols.api_support.types import APIVersion
-from opentrons.protocols.api_support.definitions import (
-    MAX_SUPPORTED_VERSION,
-    POST_V1_MODULE_DEF_VERSION,
-)
 from opentrons.protocols.geometry.deck_item import DeckItem
-from opentrons.protocol_api.labware import Labware
 
-from .types import GenericConfiguration, ThermocyclerConfiguration
+from .types import ThermocyclerConfiguration
 
 if TYPE_CHECKING:
-    from opentrons_shared_data.module.dev_types import (
-        ModuleDefinitionV1,
-        ModuleDefinitionV3,
-    )
-
-
-def module_model_from_string(model_string: str) -> ModuleModel:
-    for model_enum in {
-        MagneticModuleModel,
-        TemperatureModuleModel,
-        ThermocyclerModuleModel,
-        HeaterShakerModuleModel,
-    }:
-        try:
-            return model_enum(model_string)
-        except ValueError:
-            pass
-    raise AttributeError(f"No such module model {model_string}")
+    from opentrons.protocol_api.labware import Labware
+    from opentrons_shared_data.module.dev_types import ModuleDefinitionV3
 
 
 log = logging.getLogger(__name__)
 
 
-class NoSuchModuleError(Exception):
-    def __init__(self, message: str, requested_module: ModuleModel) -> None:
-        self.message = message
-        self.requested_module = requested_module
-        super().__init__()
-
-    def __str__(self) -> str:
-        return self.message
+class NoSuchModuleError(ValueError):
+    """An error raised if a requested model does not match a known module."""
 
 
 class PipetteMovementRestrictedByHeaterShakerError(Exception):
@@ -105,7 +73,6 @@ class ModuleGeometry(DeckItem):
         overall_height: float,
         height_over_labware: float,
         parent: Location,
-        api_level: APIVersion,
     ) -> None:
         """
         Create a Module for tracking the position of a module.
@@ -131,12 +98,7 @@ class ModuleGeometry(DeckItem):
                        the outside of the module (usually the front-left corner
                        of a slot on the deck).
         :type parent: :py:class:`.Location`
-        :param APIVersion api_level: the API version to set for the loaded
-                                     :py:class:`ModuleGeometry` instance. The
-                                     :py:class:`ModuleGeometry` will
-                                     conform to this level.
         """
-        self._api_version = api_level
         self._parent = parent
         self._module_type = module_type
 
@@ -148,10 +110,6 @@ class ModuleGeometry(DeckItem):
         self._over_labware = height_over_labware
         self._labware: Optional[Labware] = None
         self._location = Location(point=self._offset + self._parent.point, labware=self)
-
-    @property
-    def api_version(self) -> APIVersion:
-        return self._api_version
 
     def add_labware(self, labware: Labware) -> Labware:
         assert not self._labware, "{} is already on this module".format(self._labware)
@@ -220,8 +178,7 @@ class ThermocyclerGeometry(ModuleGeometry):
         height_over_labware: float,
         lid_height: float,
         parent: Location,
-        api_level: APIVersion,
-        configuration: GenericConfiguration = ThermocyclerConfiguration.FULL,
+        configuration: ThermocyclerConfiguration = ThermocyclerConfiguration.FULL,
     ) -> None:
         """
         Create a Module for tracking the position of a module.
@@ -247,10 +204,6 @@ class ThermocyclerGeometry(ModuleGeometry):
                        the outside of the module (usually the front-left corner
                        of a slot on the deck).
         :type parent: :py:class:`.Location`
-        :param APIVersion api_level: the API version to set for the loaded
-                                     :py:class:`ModuleGeometry` instance. The
-                                     :py:class:`ModuleGeometry` will
-                                     conform to this level.
         :param configuration: Used to specify the slot configuration of
                               the Thermocycler. It should by of type
                               :py:class:`.ThermocyclerConfiguration` and can
@@ -264,7 +217,6 @@ class ThermocyclerGeometry(ModuleGeometry):
             overall_height,
             height_over_labware,
             parent,
-            api_level,
         )
         self._lid_height = lid_height
         self._lid_status = "open"  # Needs to reflect true status
@@ -306,12 +258,16 @@ class ThermocyclerGeometry(ModuleGeometry):
 
     # NOTE: this func is unused until "semi" configuration
     def labware_accessor(self, labware: Labware) -> Labware:
+        from opentrons.protocol_api.labware import Labware
+        from opentrons.protocol_api.core.protocol_api.labware import (
+            LabwareImplementation,
+        )
+
         # Block first three columns from being accessed
         definition = labware._implementation.get_definition()
         definition["ordering"] = definition["ordering"][2::]
         return Labware(
             implementation=LabwareImplementation(definition, super().location),
-            api_level=self._api_version,
         )
 
     def add_labware(self, labware: Labware) -> Labware:
@@ -371,29 +327,6 @@ class HeaterShakerGeometry(ModuleGeometry):
 
     For background, see: https://github.com/Opentrons/opentrons/issues/10316
     """
-
-    def __init__(
-        self,
-        display_name: str,
-        model: ModuleModel,
-        module_type: ModuleType,
-        offset: Point,
-        overall_height: float,
-        height_over_labware: float,
-        parent: Location,
-        api_level: APIVersion,
-    ) -> None:
-        """Heater-Shaker geometry constructor. Inherits from ModuleGeometry."""
-        super().__init__(
-            display_name,
-            model,
-            module_type,
-            offset,
-            overall_height,
-            height_over_labware,
-            parent,
-            api_level,
-        )
 
     def flag_unsafe_move(
         self,
@@ -501,71 +434,15 @@ class HeaterShakerGeometry(ModuleGeometry):
         ) in get_east_west_slots(int(heater_shaker_slot))
 
 
-def _load_from_v1(
-    definition: "ModuleDefinitionV1", parent: Location, api_level: APIVersion
+def create_geometry(
+    definition: ModuleDefinitionV3,
+    parent: Location,
+    configuration: Optional[str],
 ) -> ModuleGeometry:
-    """Load a module geometry from a v1 definition.
+    """Create a module geometry object from the module's definition and location.
 
     The definition should be schema checked before being passed to this
     function; all definitions passed here are assumed to be valid.
-    """
-    mod_name = definition["loadName"]
-    model_lookup: Mapping[str, ModuleModel] = {
-        "thermocycler": ThermocyclerModuleModel.THERMOCYCLER_V1,
-        "magdeck": MagneticModuleModel.MAGNETIC_V1,
-        "tempdeck": TemperatureModuleModel.TEMPERATURE_V1,
-    }
-    type_lookup = {
-        "thermocycler": ModuleType.THERMOCYCLER,
-        "tempdeck": ModuleType.TEMPERATURE,
-        "magdeck": ModuleType.MAGNETIC,
-    }
-    model = model_lookup[mod_name]
-    offset = Point(
-        definition["labwareOffset"]["x"],
-        definition["labwareOffset"]["y"],
-        definition["labwareOffset"]["z"],
-    )
-    overall_height = definition["dimensions"]["bareOverallHeight"]
-    height_over_labware = definition["dimensions"]["overLabwareHeight"]
-
-    if model in ThermocyclerModuleModel:
-        lid_height = definition["dimensions"]["lidHeight"]
-        mod: ModuleGeometry = ThermocyclerGeometry(
-            definition["displayName"],
-            model,
-            type_lookup[mod_name],
-            offset,
-            overall_height,
-            height_over_labware,
-            lid_height,
-            parent,
-            api_level,
-        )
-    else:
-        mod = ModuleGeometry(
-            definition["displayName"],
-            model,
-            type_lookup[mod_name],
-            offset,
-            overall_height,
-            height_over_labware,
-            parent,
-            api_level,
-        )
-    return mod
-
-
-def _load_from_v3(
-    definition: "ModuleDefinitionV3",
-    parent: Location,
-    api_level: APIVersion,
-    configuration: GenericConfiguration,
-) -> ModuleGeometry:
-    """Load a module geometry from a v3 definition.
-
-    The definition should be schema checked before being passed to this
-     function; all definitions passed here are assumed to be valid.
     """
     pre_transform = np.array(
         (definition["labwareOffset"]["x"], definition["labwareOffset"]["y"], 1)
@@ -591,13 +468,11 @@ def _load_from_v3(
     # apply the slot transform if any
     xform = np.array(xform_ser)
     xformed = np.dot(xform, pre_transform)
-    if definition["moduleType"] in {
-        ModuleType.MAGNETIC.value,
-        ModuleType.TEMPERATURE.value,
-    }:
+    module_type = ModuleType(definition["moduleType"])
+
+    if module_type == ModuleType.MAGNETIC or module_type == ModuleType.TEMPERATURE:
         return ModuleGeometry(
             parent=parent,
-            api_level=api_level,
             offset=Point(xformed[0], xformed[1], definition["labwareOffset"]["z"]),
             overall_height=definition["dimensions"]["bareOverallHeight"],
             height_over_labware=definition["dimensions"]["overLabwareHeight"],
@@ -605,10 +480,9 @@ def _load_from_v3(
             module_type=ModuleType(definition["moduleType"]),
             display_name=definition["displayName"],
         )
-    elif definition["moduleType"] == ModuleType.THERMOCYCLER.value:
+    elif module_type == ModuleType.THERMOCYCLER:
         return ThermocyclerGeometry(
             parent=parent,
-            api_level=api_level,
             offset=Point(xformed[0], xformed[1], definition["labwareOffset"]["z"]),
             overall_height=definition["dimensions"]["bareOverallHeight"],
             height_over_labware=definition["dimensions"]["overLabwareHeight"],
@@ -616,12 +490,15 @@ def _load_from_v3(
             module_type=ModuleType(definition["moduleType"]),
             display_name=definition["displayName"],
             lid_height=definition["dimensions"]["lidHeight"],
-            configuration=configuration,
+            configuration=(
+                ThermocyclerConfiguration(configuration)
+                if configuration is not None
+                else ThermocyclerConfiguration.FULL
+            ),
         )
-    elif definition["moduleType"] == ModuleType.HEATER_SHAKER.value:
+    elif module_type == ModuleType.HEATER_SHAKER:
         return HeaterShakerGeometry(
             parent=parent,
-            api_level=api_level,
             offset=Point(xformed[0], xformed[1], definition["labwareOffset"]["z"]),
             overall_height=definition["dimensions"]["bareOverallHeight"],
             height_over_labware=definition["dimensions"]["overLabwareHeight"],
@@ -629,210 +506,38 @@ def _load_from_v3(
             module_type=ModuleType(definition["moduleType"]),
             display_name=definition["displayName"],
         )
+
     else:
-        raise RuntimeError(f'Unknown module type {definition["moduleType"]}')
+        raise AssertionError(f"Module type {module_type} is invalid")
 
 
-def load_module_from_definition(
-    definition: Union["ModuleDefinitionV1", "ModuleDefinitionV3"],
-    parent: Location,
-    api_level: APIVersion = None,
-    configuration: GenericConfiguration = ThermocyclerConfiguration.FULL,
-) -> ModuleGeometry:
-    """
-    Return a :py:class:`ModuleGeometry` object from a specified definition
-    matching the v1 module definition schema
-
-    :param definition: A dict representing the full module definition adhering
-                       to the v1 module schema
-    :param parent: A :py:class:`.Location` representing the location where
-                   the front and left most point of the outside of the module
-                   is (often the front-left corner of a slot on the deck).
-    :param APIVersion api_level: the API version to set for the loaded
-                                 :py:class:`ModuleGeometry` instance. The
-                                 :py:class:`ModuleGeometry` will
-                                 conform to this level. If not specified,
-                                 defaults to :py:attr:`.MAX_SUPPORTED_VERSION`.
-    """
-    api_level = api_level or MAX_SUPPORTED_VERSION
-    # def not yet discriminated, mypy returns `object` type
-    schema = definition.get("$otSharedSchema")
-    if not schema:
-        # v1 definitions don't have schema versions
-        # but unfortunately we can't tell mypy that because it can only
-        # discriminate unions based on literal tags or similar, not the
-        # presence or absence of keys
-        v1def: "ModuleDefinitionV1" = definition  # type: ignore
-        return _load_from_v1(v1def, parent, api_level)
-
-    if schema == "module/schemas/3":
-        schema_doc = module.load_schema("3")
-        try:
-            jsonschema.validate(definition, schema_doc)
-        except jsonschema.ValidationError:
-            log.exception("Failed to validate module def schema")
-            raise RuntimeError("The specified module definition is not valid.")
-        # mypy can't tell these apart, but we've schema validated it - this is
-        # the right type
-        v3def: "ModuleDefinitionV3" = definition  # type: ignore[assignment]
-        return _load_from_v3(v3def, parent, api_level, configuration)
-
-    elif isinstance(schema, str):
-        maybe_schema = re.match("^module/schemas/([0-9]+)$", schema)
-        if maybe_schema:
-            raise RuntimeError(
-                f"Module definitions of schema version {maybe_schema.group(1)}"
-                " are not supported in this robot software release."
-            )
-    log.error(f"Bad module definition (schema specifier {schema})")
-    raise RuntimeError("The specified module definition is not valid.")
-
-
-def _load_v1_module_def(module_model: ModuleModel) -> "ModuleDefinitionV1":
-    v1names = {
-        MagneticModuleModel.MAGNETIC_V1: "magdeck",
-        TemperatureModuleModel.TEMPERATURE_V1: "tempdeck",
-        ThermocyclerModuleModel.THERMOCYCLER_V1: "thermocycler",
-    }
+def load_definition(model: str) -> ModuleDefinitionV3:
+    """Load the geometry definition of a given module by model."""
     try:
-        name = v1names[module_model]
-    except KeyError:
-        raise NoSuchModuleError(
-            f"Could not find module {module_model.value}", module_model
-        )
-    return module.load_definition("1", name)
-
-
-def _load_v3_module_def(module_model: ModuleModel) -> "ModuleDefinitionV3":
-    try:
-        return module.load_definition("3", module_model.value)
+        return module.load_definition("3", model)
     except module.ModuleNotFoundError:
-        raise NoSuchModuleError(
-            f"Could not find the module {module_model.value} in the "
-            f"specified API version.",
-            module_model,
-        )
+        raise NoSuchModuleError(f'Could not find a module with model "{model}"')
 
 
-@functools.lru_cache(maxsize=128)
-def _load_module_definition(
-    api_level: APIVersion, module_model: ModuleModel
-) -> Union["ModuleDefinitionV3", "ModuleDefinitionV1"]:
-    """
-    Load the appropriate module definition for this api version
-    """
-
-    if api_level < POST_V1_MODULE_DEF_VERSION:
-        try:
-            return _load_v1_module_def(module_model)
-        except NoSuchModuleError:
-            try:
-                dname = _load_v3_module_def(module_model)["displayName"]
-            except NoSuchModuleError:
-                dname = module_model.value
-            raise NoSuchModuleError(
-                f"API version {api_level} does not support the module "
-                f"{dname}. Please use at least version "
-                f"{POST_V1_MODULE_DEF_VERSION} to use this module.",
-                module_model,
-            )
-    else:
-        return _load_v3_module_def(module_model)
-
-
-def load_module(
-    model: ModuleModel,
-    parent: Location,
-    api_level: APIVersion = None,
-    configuration: str = None,
-) -> ModuleGeometry:
-    """
-    Return a :py:class:`ModuleGeometry` object from a definition looked up
-    by name.
-
-    :param model: The module model to use. This should be one of the strings
-                  returned by :py:func:`ModuleGeometry.resolve_module_model`
-    :param parent: A :py:class:`.Location` representing the location where
-                   the front and left most point of the outside of the module
-                   is (often the front-left corner of a slot on the deck).
-    :param APIVersion api_level: the API version to set for the loaded
-                                 :py:class:`ModuleGeometry` instance. The
-                                 :py:class:`ModuleGeometry` will
-                                 conform to this level. If not specified,
-                                 defaults to :py:attr:`.MAX_SUPPORTED_VERSION`.
-    :param configuration: Used to specify the slot configuration of
-                        the Thermocycler. Only Valid in Python API
-                        Version 2.4 and later. If you wish to use
-                        the non-full plate configuration, you must
-                        pass in the key word value `semi`
-    """
-    api_level = api_level or MAX_SUPPORTED_VERSION
-    defn = _load_module_definition(api_level, model)
-    if configuration:
-        # Here we are converting the string passed in to a
-        # configuration type. For now we only have
-        # Thermocycler configurations, but there could be others
-        # in the future
-        return load_module_from_definition(
-            defn,
-            parent,
-            api_level,
-            ThermocyclerConfiguration.configuration_type(configuration),
-        )
-    else:
-        return load_module_from_definition(defn, parent, api_level)
-
-
-def resolve_module_model(module_model_or_load_name: str) -> ModuleModel:
-    """Turn any of the supported APIv2 load names into module model names."""
-
-    model_map: Mapping[str, ModuleModel] = {
-        "magneticModuleV1": MagneticModuleModel.MAGNETIC_V1,
-        "magneticModuleV2": MagneticModuleModel.MAGNETIC_V2,
-        "temperatureModuleV1": TemperatureModuleModel.TEMPERATURE_V1,
-        "temperatureModuleV2": TemperatureModuleModel.TEMPERATURE_V2,
-        "thermocyclerModuleV1": ThermocyclerModuleModel.THERMOCYCLER_V1,
-        "thermocyclerModuleV2": ThermocyclerModuleModel.THERMOCYCLER_V2,
-        "heaterShakerModuleV1": HeaterShakerModuleModel.HEATER_SHAKER_V1,
-    }
-
-    alias_map: Mapping[str, ModuleModel] = {
-        "magdeck": MagneticModuleModel.MAGNETIC_V1,
-        "magnetic module": MagneticModuleModel.MAGNETIC_V1,
-        "magnetic module gen2": MagneticModuleModel.MAGNETIC_V2,
-        "tempdeck": TemperatureModuleModel.TEMPERATURE_V1,
-        "temperature module": TemperatureModuleModel.TEMPERATURE_V1,
-        "temperature module gen2": TemperatureModuleModel.TEMPERATURE_V2,
-        "thermocycler": ThermocyclerModuleModel.THERMOCYCLER_V1,
-        "thermocycler module": ThermocyclerModuleModel.THERMOCYCLER_V1,
-        "thermocycler module gen2": ThermocyclerModuleModel.THERMOCYCLER_V2,
-        # No alias for heater-shaker. Use heater-shaker model name for loading.
-    }
-
-    lower_name = module_model_or_load_name.lower()
-    resolved_name = model_map.get(module_model_or_load_name, None) or alias_map.get(
-        lower_name, None
+def models_compatible(
+    requested_model: ModuleModel, candidate_definition: ModuleDefinitionV3
+) -> bool:
+    """Check if a requested model is compatible with a given definition."""
+    return (
+        requested_model.value == candidate_definition["model"]
+        or requested_model.value in candidate_definition["compatibleWith"]
     )
-    if not resolved_name:
-        raise ValueError(
-            f"{module_model_or_load_name} is not a valid module load name.\n"
-            "Valid names (ignoring case): "
-            '"'
-            + '", "'.join(alias_map.keys())
-            + '"\n'
-            + "You can also refer to modules by their "
-            + "exact model: "
-            '"' + '", "'.join(model_map.keys()) + '"'
-        )
-    return resolved_name
 
 
-def resolve_module_type(module_model: ModuleModel) -> ModuleType:
-    return ModuleType(_load_v3_module_def(module_model)["moduleType"])
-
-
-def models_compatible(model_a: ModuleModel, model_b: ModuleModel) -> bool:
-    """Check if two module models may be considered the same"""
-    if model_a == model_b:
-        return True
-    return model_b.value in _load_v3_module_def(model_a)["compatibleWith"]
+def module_model_from_string(model_string: str) -> ModuleModel:
+    for model_enum in {
+        MagneticModuleModel,
+        TemperatureModuleModel,
+        ThermocyclerModuleModel,
+        HeaterShakerModuleModel,
+    }:
+        try:
+            return model_enum(model_string)
+        except ValueError:
+            pass
+    raise ValueError(f"No such module model {model_string}")

--- a/api/src/opentrons/protocols/geometry/types.py
+++ b/api/src/opentrons/protocols/geometry/types.py
@@ -1,21 +1,6 @@
-from enum import Enum, auto
-from typing import Type, TypeVar
-
-Configuration = TypeVar("Configuration", bound="GenericConfiguration")
+from enum import Enum
 
 
-class GenericConfiguration(Enum):
-    @classmethod
-    def configuration_type(cls: Type[Configuration], config: str) -> "Configuration":
-        for m in cls.__members__.values():
-            if m.name == config.upper():
-                return m
-        raise AttributeError(f"{config} not available")
-
-
-class ThermocyclerConfiguration(GenericConfiguration):
-    FULL = auto()
-    SEMI = auto()
-
-    def __str__(self):
-        return self.name
+class ThermocyclerConfiguration(str, Enum):
+    FULL = "full"
+    SEMI = "semi"

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -371,26 +371,6 @@ def get_json_protocol_fixture() -> Callable[[str, str, bool], Union[str, JsonPro
     return _get_json_protocol_fixture
 
 
-@pytest.fixture()
-def get_module_fixture() -> Callable[[str], ModuleDefinitionV3]:
-    def _get_module_fixture(fixture_name: str) -> ModuleDefinitionV3:
-        with open(
-            pathlib.Path(__file__).parent
-            / ".."
-            / ".."
-            / ".."
-            / "shared-data"
-            / "module"
-            / "fixtures"
-            / "3"
-            / f"{fixture_name}.json",
-            "rb",
-        ) as f:
-            return cast(ModuleDefinitionV3, json.loads(f.read().decode("utf-8")))
-
-    return _get_module_fixture
-
-
 @pytest.fixture
 def get_bundle_fixture() -> Callable[[str], Bundle]:
     def get_std_labware(loadName: str, version: int = 1) -> LabwareDefinition:

--- a/api/tests/opentrons/hardware_control/modules/test_hc_heatershaker.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_heatershaker.py
@@ -26,7 +26,7 @@ async def simulating_module(usb_port):
     module = await modules.build(
         port=usb_port.device_path,
         usb_port=usb_port,
-        which="heatershaker",
+        type=modules.ModuleType.HEATER_SHAKER,
         simulating=True,
         loop=asyncio.get_running_loop(),
         execution_manager=ExecutionManager(),

--- a/api/tests/opentrons/hardware_control/modules/test_hc_magdeck.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_magdeck.py
@@ -20,7 +20,7 @@ async def test_sim_initialization(usb_port):
     mag = await modules.build(
         port="/dev/ot_module_sim_magdeck0",
         usb_port=usb_port,
-        which="magdeck",
+        type=modules.ModuleType.MAGNETIC,
         simulating=True,
         loop=asyncio.get_running_loop(),
         execution_manager=ExecutionManager(),
@@ -32,7 +32,7 @@ async def test_sim_data(usb_port):
     mag = await modules.build(
         port="/dev/ot_module_sim_magdeck0",
         usb_port=usb_port,
-        which="magdeck",
+        type=modules.ModuleType.MAGNETIC,
         simulating=True,
         loop=asyncio.get_running_loop(),
         execution_manager=ExecutionManager(),
@@ -50,7 +50,7 @@ async def test_sim_state_update(usb_port):
     mag = await modules.build(
         port="/dev/ot_module_sim_magdeck0",
         usb_port=usb_port,
-        which="magdeck",
+        type=modules.ModuleType.MAGNETIC,
         simulating=True,
         loop=asyncio.get_running_loop(),
         execution_manager=ExecutionManager(),
@@ -65,10 +65,10 @@ async def test_sim_state_update(usb_port):
 
 async def test_revision_model_parsing(usb_port):
     mag = await modules.build(
-        "",
-        "magdeck",
-        True,
-        usb_port,
+        port="",
+        type=modules.ModuleType.MAGNETIC,
+        simulating=True,
+        usb_port=usb_port,
         loop=asyncio.get_running_loop(),
         execution_manager=ExecutionManager(),
     )

--- a/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
@@ -24,7 +24,7 @@ async def subject(usb_port: USBPort) -> modules.AbstractModule:
     temp = await modules.build(
         port="/dev/ot_module_sim_tempdeck0",
         usb_port=usb_port,
-        which="tempdeck",
+        type=modules.ModuleType.TEMPERATURE,
         simulating=True,
         loop=asyncio.get_running_loop(),
         execution_manager=ExecutionManager(),

--- a/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
@@ -25,7 +25,7 @@ async def subject(usb_port: USBPort) -> AsyncGenerator[modules.Thermocycler, Non
     therm = await modules.build(
         port="/dev/ot_module_sim_thermocycler0",
         usb_port=usb_port,
-        which="thermocycler",
+        type=modules.ModuleType.THERMOCYCLER,
         simulating=True,
         loop=asyncio.get_running_loop(),
         execution_manager=ExecutionManager(),

--- a/api/tests/opentrons/hardware_control/test_module_control.py
+++ b/api/tests/opentrons/hardware_control/test_module_control.py
@@ -7,7 +7,7 @@ from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.drivers.rpi_drivers.interfaces import USBDriverInterface
 from opentrons.hardware_control import API as HardwareAPI
 from opentrons.hardware_control.modules import AbstractModule
-from opentrons.hardware_control.modules.types import ModuleAtPort
+from opentrons.hardware_control.modules.types import ModuleAtPort, ModuleType
 from opentrons.hardware_control.module_control import AttachedModulesControl
 
 
@@ -63,7 +63,9 @@ async def test_register_modules(
     new_mods_at_ports = [ModuleAtPort(port="/dev/foo", name="bar")]
     actual_ports = [
         ModuleAtPort(
-            port="/dev/foo", name="bar", usb_port=USBPort(name="baz", port_number=0)
+            port="/dev/foo",
+            name="tempdeck",
+            usb_port=USBPort(name="baz", port_number=0),
         )
     ]
 
@@ -75,8 +77,7 @@ async def test_register_modules(
         await build_module(
             port="/dev/foo",
             usb_port=USBPort(name="baz", port_number=0),
-            model="bar",
-            loop=hardware_api.loop,
+            type=ModuleType.TEMPERATURE,
         )
     ).then_return(module)
 
@@ -108,10 +109,10 @@ async def test_register_modules_sort(
 
     new_mods_at_ports = [ModuleAtPort(port="/dev/foo", name="bar")]
     actual_ports = [
-        ModuleAtPort(port="/dev/a", name="module-1", usb_port=module_1.usb_port),
-        ModuleAtPort(port="/dev/b", name="module-2", usb_port=module_2.usb_port),
-        ModuleAtPort(port="/dev/c", name="module-3", usb_port=module_3.usb_port),
-        ModuleAtPort(port="/dev/d", name="module-4", usb_port=module_4.usb_port),
+        ModuleAtPort(port="/dev/a", name="magdeck", usb_port=module_1.usb_port),
+        ModuleAtPort(port="/dev/b", name="tempdeck", usb_port=module_2.usb_port),
+        ModuleAtPort(port="/dev/c", name="thermocycler", usb_port=module_3.usb_port),
+        ModuleAtPort(port="/dev/d", name="heatershaker", usb_port=module_4.usb_port),
     ]
 
     decoy.when(usb_bus.match_virtual_ports(new_mods_at_ports)).then_return(actual_ports)
@@ -121,8 +122,7 @@ async def test_register_modules_sort(
             await build_module(
                 usb_port=mod.usb_port,
                 port=matchers.Anything(),
-                model=matchers.Anything(),
-                loop=hardware_api.loop,
+                type=matchers.Anything(),
             )
         ).then_return(mod)
 

--- a/api/tests/opentrons/protocols/api_support/test_labware_like.py
+++ b/api/tests/opentrons/protocols/api_support/test_labware_like.py
@@ -1,12 +1,13 @@
 from unittest.mock import MagicMock
 
 import pytest
+from opentrons.hardware_control.modules.types import TemperatureModuleModel
 from opentrons.protocol_api import labware
-from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 from opentrons.protocols.api_support.labware_like import LabwareLike, LabwareLikeType
 from opentrons.protocols.geometry import module_geometry
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.types import Location
+
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 
@@ -24,10 +25,12 @@ def trough(trough_definition):
 @pytest.fixture(scope="session")
 def module(trough):
     deck = Deck()
-    mod = module_geometry.load_module(
-        module_geometry.TemperatureModuleModel.TEMPERATURE_V2,
-        deck.position_for("6"),
-        MAX_SUPPORTED_VERSION,
+    mod = module_geometry.create_geometry(
+        definition=module_geometry.load_definition(
+            TemperatureModuleModel.TEMPERATURE_V2
+        ),
+        parent=deck.position_for("6"),
+        configuration=None,
     )
     return mod
 

--- a/api/tests/opentrons/protocols/geometry/test_geometry.py
+++ b/api/tests/opentrons/protocols/geometry/test_geometry.py
@@ -10,7 +10,11 @@ from opentrons.protocols.geometry.deck import Deck
 from opentrons.protocol_api import labware
 from opentrons.protocols.geometry import module_geometry
 from opentrons.hardware_control.types import CriticalPoint
-from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
+from opentrons.hardware_control.modules.types import (
+    ThermocyclerModuleModel,
+    TemperatureModuleModel,
+    MagneticModuleModel,
+)
 
 tall_lw_name = "opentrons_96_tiprack_1000ul"
 labware_name = "corning_96_wellplate_360ul_flat"
@@ -279,29 +283,33 @@ def test_direct_cp():
 
 def test_gen2_module_transforms():
     deck = Deck()
-    tmod = module_geometry.load_module(
-        module_geometry.TemperatureModuleModel.TEMPERATURE_V2,
-        deck.position_for("1"),
-        MAX_SUPPORTED_VERSION,
+    tmod = module_geometry.create_geometry(
+        definition=module_geometry.load_definition(
+            TemperatureModuleModel.TEMPERATURE_V2
+        ),
+        parent=deck.position_for("1"),
+        configuration=None,
     )
     assert tmod.labware_offset == Point(-1.45, -0.15, 80.09)
-    tmod2 = module_geometry.load_module(
-        module_geometry.TemperatureModuleModel.TEMPERATURE_V2,
-        deck.position_for("3"),
-        MAX_SUPPORTED_VERSION,
+    tmod2 = module_geometry.create_geometry(
+        definition=module_geometry.load_definition(
+            TemperatureModuleModel.TEMPERATURE_V2
+        ),
+        parent=deck.position_for("3"),
+        configuration=None,
     )
     assert tmod2.labware_offset == Point(1.15, -0.15, 80.09)
 
-    mmod = module_geometry.load_module(
-        module_geometry.MagneticModuleModel.MAGNETIC_V2,
-        deck.position_for("1"),
-        MAX_SUPPORTED_VERSION,
+    mmod = module_geometry.create_geometry(
+        definition=module_geometry.load_definition(MagneticModuleModel.MAGNETIC_V2),
+        parent=deck.position_for("1"),
+        configuration=None,
     )
     assert mmod.labware_offset == Point(-1.175, -0.125, 82.25)
-    mmod2 = module_geometry.load_module(
-        module_geometry.MagneticModuleModel.MAGNETIC_V2,
-        deck.position_for("3"),
-        MAX_SUPPORTED_VERSION,
+    mmod2 = module_geometry.create_geometry(
+        definition=module_geometry.load_definition(MagneticModuleModel.MAGNETIC_V2),
+        parent=deck.position_for("3"),
+        configuration=None,
     )
     assert mmod2.labware_offset == Point(1.425, -0.125, 82.25)
 
@@ -361,8 +369,12 @@ def test_should_dodge():
     assert not should_dodge_thermocycler(
         deck, deck.position_for(4), deck.position_for(9)
     )
-    deck[7] = module_geometry.load_module(
-        module_geometry.ThermocyclerModuleModel.THERMOCYCLER_V1, deck.position_for(7)
+    deck[7] = module_geometry.create_geometry(
+        definition=module_geometry.load_definition(
+            ThermocyclerModuleModel.THERMOCYCLER_V1
+        ),
+        parent=deck.position_for(7),
+        configuration=None,
     )
     # with a tc loaded, some positions should require dodging
     assert should_dodge_thermocycler(deck, deck.position_for(12), deck.position_for(1))
@@ -411,8 +423,12 @@ def test_thermocycler_present() -> None:
     assert not deck.thermocycler_present
 
     # Add a thermocycler
-    deck[7] = module_geometry.load_module(
-        module_geometry.ThermocyclerModuleModel.THERMOCYCLER_V1, deck.position_for(7)
+    deck[7] = module_geometry.create_geometry(
+        definition=module_geometry.load_definition(
+            ThermocyclerModuleModel.THERMOCYCLER_V1
+        ),
+        parent=deck.position_for(7),
+        configuration=None,
     )
     assert deck.thermocycler_present
 

--- a/api/tests/opentrons/protocols/geometry/test_module_geometry.py
+++ b/api/tests/opentrons/protocols/geometry/test_module_geometry.py
@@ -1,20 +1,15 @@
 import pytest
 import mock
 
-from typing import Union, ContextManager, Any, Optional
+from typing import ContextManager, Any, Optional
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import]
 from contextlib import nullcontext as does_not_raise
 from opentrons.types import Location, Point
 
-from opentrons.hardware_control.modules.types import (
-    ModuleType,
-    MagneticModuleModel,
-    HeaterShakerModuleModel,
-)
+from opentrons.hardware_control.modules.types import ModuleType, HeaterShakerModuleModel
 
-from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.geometry.module_geometry import (
-    load_module_from_definition,
+    create_geometry,
     ModuleGeometry,
     HeaterShakerGeometry,
     PipetteMovementRestrictedByHeaterShakerError,
@@ -100,7 +95,6 @@ def heater_shaker_geometry() -> HeaterShakerGeometry:
         overall_height=111,
         height_over_labware=222,
         parent=heater_shaker_slot_location,
-        api_level=APIVersion.from_string("22.22"),
     )
 
 
@@ -111,44 +105,12 @@ def mock_location() -> mock.MagicMock:
 
 
 @pytest.mark.parametrize(
-    argnames=["api_version", "module_definition", "expected_geometry", "expected_repr"],
+    argnames=["module_definition", "expected_geometry", "expected_repr"],
     argvalues=[
         (
-            APIVersion.from_string("2.3"),
-            lazy_fixture("v1_mag_module_schema_v3_definition"),
-            ModuleGeometry(
-                parent=Location(Point(0, 0, 0), labware=None),
-                api_level=APIVersion.from_string("2.3"),
-                offset=Point(11, 22, 33),
-                overall_height=123,
-                height_over_labware=234,
-                model=MagneticModuleModel.MAGNETIC_V1,
-                module_type=ModuleType.MAGNETIC,
-                display_name="Sample Module",
-            ),
-            "Sample Module on ",
-        ),
-        (
-            APIVersion.from_string("2.2"),
-            lazy_fixture("v1_mag_module_schema_v1_definition"),
-            ModuleGeometry(
-                parent=Location(Point(0, 0, 0), labware=None),
-                api_level=APIVersion.from_string("2.2"),
-                offset=Point(11.0, 22.0, 33.0),
-                overall_height=123,
-                height_over_labware=321,
-                model=MagneticModuleModel.MAGNETIC_V1,
-                module_type=ModuleType.MAGNETIC,
-                display_name="Sample Old Module",
-            ),
-            "Sample Old Module on ",
-        ),
-        (
-            APIVersion.from_string("2.12"),
             lazy_fixture("minimal_heater_shaker_definition"),
             HeaterShakerGeometry(
                 parent=Location(Point(0, 0, 0), labware=None),
-                api_level=APIVersion.from_string("2.12"),
                 offset=Point(11, 22, 33),
                 overall_height=123,
                 height_over_labware=234,
@@ -160,20 +122,18 @@ def mock_location() -> mock.MagicMock:
         ),
     ],
 )
-def test_load_module_from_definition(
-    api_version: APIVersion,
-    module_definition: Union[ModuleDefinitionV1, ModuleDefinitionV3],
+def test_create_geometry(
+    module_definition: ModuleDefinitionV3,
     expected_geometry: ModuleGeometry,
     expected_repr: str,
 ) -> None:
     """It should load an API-version-specific module from its definition."""
-    load_result = load_module_from_definition(
+    load_result = create_geometry(
         definition=module_definition,
         parent=Location(point=Point(0, 0, 0), labware=None),
-        api_level=api_version,
+        configuration=None,
     )
     assert isinstance(load_result, expected_geometry.__class__)
-    assert load_result.api_version == expected_geometry.api_version
     assert load_result.parent == expected_geometry.parent
     assert load_result.module_type == expected_geometry.module_type
     assert load_result.model == expected_geometry.model
@@ -182,15 +142,15 @@ def test_load_module_from_definition(
     assert str(load_result) == expected_repr
 
 
-def test_load_module_from_definition_raises(v1_mag_module_schema_v3_definition) -> None:
+def test_create_geometry_raises(v1_mag_module_schema_v3_definition) -> None:
     """It raises when an invalid definition is passed."""
     v1_mag_module_schema_v3_definition.update({"moduleType": "blahblahModuleType"})
 
-    with pytest.raises(RuntimeError):
-        load_module_from_definition(
+    with pytest.raises(ValueError):
+        create_geometry(
             definition=v1_mag_module_schema_v3_definition,
             parent=Location(point=Point(0, 0, 0), labware=None),
-            api_level=APIVersion.from_string("2.5"),
+            configuration=None,
         )
 
 
@@ -204,7 +164,6 @@ def test_heater_shaker_geometry_properties() -> None:
         overall_height=111,
         height_over_labware=222,
         parent=Location(point=Point(1, 2, 3), labware=None),
-        api_level=APIVersion.from_string("22.22"),
     )
     assert subject.model == HeaterShakerModuleModel.HEATER_SHAKER_V1
     assert subject.labware is None

--- a/robot-server/tests/service/legacy/routers/test_modules.py
+++ b/robot-server/tests/service/legacy/routers/test_modules.py
@@ -6,6 +6,7 @@ import asyncio
 from decoy import matchers
 from opentrons.hardware_control import ExecutionManager
 from opentrons.hardware_control.modules import (
+    ModuleType,
     MagDeck,
     Thermocycler,
     TempDeck,
@@ -26,7 +27,7 @@ async def magdeck():
     m = await utils.build(
         port="/dev/ot_module_magdeck1",
         usb_port=usb_port,
-        which="magdeck",
+        type=ModuleType.MAGNETIC,
         simulating=True,
         execution_manager=ExecutionManager(),
         loop=asyncio.get_running_loop(),
@@ -49,7 +50,7 @@ async def tempdeck():
     t = await utils.build(
         port="/dev/ot_module_tempdeck1",
         usb_port=usb_port,
-        which="tempdeck",
+        type=ModuleType.TEMPERATURE,
         simulating=True,
         execution_manager=ExecutionManager(),
         loop=asyncio.get_running_loop(),
@@ -73,7 +74,7 @@ async def thermocycler():
     t = await utils.build(
         port="/dev/ot_module_thermocycler1",
         usb_port=usb_port,
-        which="thermocycler",
+        type=ModuleType.THERMOCYCLER,
         simulating=True,
         execution_manager=ExecutionManager(),
         loop=asyncio.get_running_loop(),
@@ -107,7 +108,7 @@ async def heater_shaker():
     heatershaker = await utils.build(
         port="/dev/ot_module_heatershaker1",
         usb_port=usb_port,
-        which="heatershaker",
+        type=ModuleType.HEATER_SHAKER,
         simulating=True,
         execution_manager=ExecutionManager(),
         loop=asyncio.get_running_loop(),

--- a/shared-data/python/opentrons_shared_data/module/__init__.py
+++ b/shared-data/python/opentrons_shared_data/module/__init__.py
@@ -48,7 +48,8 @@ def load_definition(version: SchemaV1, model_or_loadname: str) -> ModuleDefiniti
 
 @overload
 def load_definition(
-    version: SchemaV3, model_or_loadname: ModuleModel
+    version: SchemaV3,
+    model_or_loadname: Union[str, ModuleModel],
 ) -> ModuleDefinitionV3:
     ...
 

--- a/shared-data/python/tests/module/test_load.py
+++ b/shared-data/python/tests/module/test_load.py
@@ -14,7 +14,7 @@ from . import list_v2_defs, list_v3_defs
 @pytest.mark.parametrize("def_name", list_v3_defs())
 def test_load_v3_defs(def_name: str) -> None:
     """Test that all v3 definitions load correctly."""
-    assert load_definition("3", def_name) == json.loads(  # type: ignore [call-overload]
+    assert load_definition("3", def_name) == json.loads(
         load_shared_data(f"module/definitions/3/{def_name}.json")
     )
 

--- a/shared-data/python/tests/module/test_typechecks.py
+++ b/shared-data/python/tests/module/test_typechecks.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.xfail(
 @pytest.mark.parametrize("defname", list_v3_defs())
 def test_v3_definitions_match_types(defname: str) -> None:
     """Test that V3 module definitions match ModuleDefinitionV3."""
-    def_dict = module.load_definition("3", defname)  # type: ignore [call-overload]
+    def_dict = module.load_definition("3", defname)
     typeguard.check_type("def_dict", def_dict, dev_types.ModuleDefinitionV3)
 
 


### PR DESCRIPTION
## Overview

While adding engine-based module interfaces to PAPI, the existing module geometry and hardware APIs were adding extra complexity for stuff that was unused.

## Changelog

This PR makes two big changes to simplify things and pave the way for engine-based module cores:

- Remove implicit module simulator creation from the Hardware API
    - Practically this means removing `HardwareAPI.find_modules`
    - Returning a simulating module alongside actually attached modules has been replaced with an explicit `HardwareAPI.create_simulating_module` method
    - Filtering by module type was unnecessary, because the caller was forced to do its own filtering by definition compatibility; caller can just use `HardwareAPI.attached_modules` instead
- Removed runtime usage of v1 module definitions
    - v1 definitions do not differ geometrically from the current v3 definitions

## Review requests

Smoke test loading and using all four module types

## Risk assessment

Medium, changing around production module control interfaces