### PR TITLE
refactor(api): place move_to inside drop_tip implementation

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -58,7 +58,7 @@ class InstrumentCore(AbstractInstrument[WellCore]):
     ) -> None:
         raise NotImplementedError("InstrumentCore not implemented")
 
-    def drop_tip(self, home_after: bool) -> None:
+    def drop_tip(self, location: Location, home_after: bool) -> None:
         raise NotImplementedError("InstrumentCore not implemented")
 
     def home(self) -> None:

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -51,7 +51,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType]):
         ...
 
     @abstractmethod
-    def drop_tip(self, home_after: bool) -> None:
+    def drop_tip(self, location: types.Location, home_after: bool) -> None:
         ...
 
     @abstractmethod

--- a/api/src/opentrons/protocol_api/core/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/instrument_context.py
@@ -119,8 +119,9 @@ class InstrumentContextImplementation(AbstractInstrument[WellImplementation]):
         hw.pick_up_tip(self._mount, tip_length, presses, increment, prep_after)
         hw.set_working_volume(self._mount, geometry.max_volume)
 
-    def drop_tip(self, home_after: bool) -> None:
+    def drop_tip(self, location: types.Location, home_after: bool) -> None:
         """Drop the tip."""
+        self.move_to(location, force_direct=False, minimum_z_height=None, speed=None)
         self._protocol_interface.get_hardware().drop_tip(
             self._mount, home_after=home_after
         )

--- a/api/src/opentrons/protocol_api/core/simulator/instrument_context.py
+++ b/api/src/opentrons/protocol_api/core/simulator/instrument_context.py
@@ -101,7 +101,8 @@ class InstrumentContextSimulation(AbstractInstrument[WellImplementation]):
         if prep_after:
             self._pipette_dict["ready_to_aspirate"] = True
 
-    def drop_tip(self, home_after: bool) -> None:
+    def drop_tip(self, location: types.Location, home_after: bool) -> None:
+        self.move_to(location, force_direct=False, minimum_z_height=None, speed=None)
         self._raise_if_no_tip(HardwareAction.DROPTIP.name)
         self._pipette_dict["has_tip"] = False
         self._pipette_dict["tip_length"] = 0.0

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -878,8 +878,7 @@ class InstrumentContext(publisher.CommandPublisher):
             broker=self.broker,
             command=cmds.drop_tip(instrument=self, location=target),
         ):
-            self.move_to(target, publish=False)
-            self._implementation.drop_tip(home_after=home_after)
+            self._implementation.drop_tip(location=target, home_after=home_after)
 
         if (
             self.api_version < APIVersion(2, 2)

--- a/api/tests/opentrons/protocol_api_old/core/simulator/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api_old/core/simulator/test_instrument_context.py
@@ -4,6 +4,7 @@ from typing import Callable
 import pytest
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import]
 
+from opentrons.types import Location, Point
 from opentrons.hardware_control import NoTipAttachedError
 from opentrons.hardware_control.types import TipAttachedError
 from opentrons.protocol_api.core.labware import AbstractLabware as BaseAbstractLabware
@@ -57,8 +58,9 @@ def test_dispense_no_tip(subject: AbstractInstrument) -> None:
 
 def test_drop_tip_no_tip(subject: AbstractInstrument) -> None:
     """It should raise an error if a tip is not attached."""
+    subject.home()
     with pytest.raises(NoTipAttachedError, match="Cannot perform DROPTIP"):
-        subject.drop_tip(home_after=False)
+        subject.drop_tip(Location(point=Point(), labware=None), home_after=False)
 
 
 def test_blow_out_no_tip(subject: AbstractInstrument) -> None:
@@ -103,7 +105,7 @@ def test_pick_up_tip_prep_after(
     )
     subject.aspirate(1, rate=1)
     subject.dispense(1, rate=1)
-    subject.drop_tip(home_after=True)
+    subject.drop_tip(Location(point=Point(), labware=None), home_after=True)
     # and again, without preparing for aspirate
     subject.pick_up_tip(
         well=labware.get_wells()[0],
@@ -114,7 +116,7 @@ def test_pick_up_tip_prep_after(
     )
     subject.aspirate(1, rate=1)
     subject.dispense(1, rate=1)
-    subject.drop_tip(home_after=True)
+    subject.drop_tip(Location(point=Point(), labware=None), home_after=True)
 
 
 def test_aspirate_too_much(
@@ -233,8 +235,10 @@ def test_pipette_dict_with_tip(
     )
 
     # Drop tip and compare again
-    instrument_context.drop_tip(home_after=False)
-    simulating_instrument_context.drop_tip(home_after=False)
+    instrument_context.drop_tip(Location(point=Point(), labware=None), home_after=False)
+    simulating_instrument_context.drop_tip(
+        Location(point=Point(), labware=None), home_after=False
+    )
 
     assert (
         instrument_context.get_pipette() == simulating_instrument_context.get_pipette()

--- a/api/tests/opentrons/protocol_api_old/core/simulator/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api_old/core/simulator/test_protocol_context.py
@@ -4,7 +4,7 @@ from pytest_lazyfixture import lazy_fixture  # type: ignore[import]
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
 
-from opentrons.types import Mount
+from opentrons.types import Mount, Location, Point
 from opentrons.protocol_api.core.protocol import (
     AbstractProtocol as BaseAbstractProtocol,
 )
@@ -55,7 +55,7 @@ def test_replacing_instrument_tip_state(
     assert pip1.has_tip() is True
     assert pip2.has_tip() is True
 
-    pip2.drop_tip(home_after=False)
+    pip2.drop_tip(Location(point=Point(), labware=None), home_after=False)
 
     assert pip1.has_tip() is False
     assert pip2.has_tip() is False


### PR DESCRIPTION
# Overview
Protocol API refactor work related to RCORE-134.

Begins work to move all instances of `move_to` in public facing PAPIv2 instrument context inside the private implementation/core classes. 

# Changelog
- Changed method signature of `drop_tip` to accept `Location`
- moved `move_to` to inside the `drop_tip` implementation

# Review requests
- [ ] Drop tip passes analysis and works on robot

# Risk assessment
Low, this PR only changes one command.