### PR TITLE
refactor(app): rename 3 colors and add 3 colors

### DIFF
--- a/app/src/atoms/Banner/index.tsx
+++ b/app/src/atoms/Banner/index.tsx
@@ -42,17 +42,17 @@ const BANNER_PROPS_BY_TYPE: Record<
 > = {
   success: {
     icon: { name: 'check-circle' },
-    backgroundColor: COLORS.successBackground,
+    backgroundColor: COLORS.successBackgroundLight,
     color: COLORS.successEnabled,
   },
   error: {
     icon: { name: 'alert-circle' },
-    backgroundColor: COLORS.errorBackground,
+    backgroundColor: COLORS.errorBackgroundLight,
     color: COLORS.errorEnabled,
   },
   warning: {
     icon: { name: 'alert-circle' },
-    backgroundColor: COLORS.warningBackground,
+    backgroundColor: COLORS.warningBackgroundLight,
     color: COLORS.warningEnabled,
   },
   updating: {

--- a/app/src/atoms/StatusLabel/StatusLabel.stories.tsx
+++ b/app/src/atoms/StatusLabel/StatusLabel.stories.tsx
@@ -39,7 +39,7 @@ Idle.args = {
 export const Error = Template.bind({})
 Error.args = {
   status: 'Error',
-  backgroundColor: COLORS.warningBackground,
+  backgroundColor: COLORS.warningBackgroundLight,
   iconColor: COLORS.warningEnabled,
   pulse: true,
 }

--- a/app/src/atoms/Toast/index.tsx
+++ b/app/src/atoms/Toast/index.tsx
@@ -56,17 +56,17 @@ const toastStyleByType: {
   error: {
     iconName: 'alert-circle',
     color: COLORS.errorEnabled,
-    backgroundColor: COLORS.errorBackground,
+    backgroundColor: COLORS.errorBackgroundLight,
   },
   warning: {
     iconName: 'alert-circle',
     color: COLORS.warningEnabled,
-    backgroundColor: COLORS.warningBackground,
+    backgroundColor: COLORS.warningBackgroundLight,
   },
   success: {
     iconName: 'check-circle',
     color: COLORS.successEnabled,
-    backgroundColor: COLORS.successBackground,
+    backgroundColor: COLORS.successBackgroundLight,
   },
   info: {
     iconName: 'information',

--- a/app/src/molecules/MiniCard/__tests__/MiniCard.test.tsx
+++ b/app/src/molecules/MiniCard/__tests__/MiniCard.test.tsx
@@ -66,7 +66,9 @@ describe('MiniCard', () => {
     props.isSelected = true
     const { getByText } = render(props)
     const miniCard = getByText('mock mini card')
-    expect(miniCard).toHaveStyle(`background-color: ${COLORS.errorBackground}`)
+    expect(miniCard).toHaveStyle(
+      `background-color: ${COLORS.errorBackgroundLight}`
+    )
     expect(miniCard).toHaveStyle(`border: 1px solid ${COLORS.errorEnabled}`)
     expect(miniCard).toHaveStyle(`border-radius: ${BORDERS.radiusSoftCorners}`)
     expect(miniCard).toHaveStyle(`padding: ${SPACING.spacing3}`)
@@ -81,7 +83,7 @@ describe('MiniCard', () => {
     )
     expect(miniCard).toHaveStyleRule(
       'background-color',
-      `${COLORS.errorBackground}`,
+      `${COLORS.errorBackgroundLight}`,
       {
         modifier: ':hover',
       }

--- a/app/src/molecules/MiniCard/index.tsx
+++ b/app/src/molecules/MiniCard/index.tsx
@@ -37,11 +37,11 @@ const selectedOptionStyles = css`
 const errorOptionStyles = css`
   ${selectedOptionStyles}
   border: 1px solid ${COLORS.errorEnabled};
-  background-color: ${COLORS.errorBackground};
+  background-color: ${COLORS.errorBackgroundLight};
 
   &:hover {
     border: 1px solid ${COLORS.errorEnabled};
-    background-color: ${COLORS.errorBackground};
+    background-color: ${COLORS.errorBackgroundLight};
   }
 `
 

--- a/app/src/organisms/Devices/ProtocolRun/StepItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/StepItem.tsx
@@ -72,7 +72,7 @@ const WRAPPER_STYLE_BY_STATUS: {
   },
   failed: {
     border: `1px solid ${COLORS.errorEnabled}`,
-    backgroundColor: COLORS.errorBackground,
+    backgroundColor: COLORS.errorBackgroundLight,
     color: COLORS.darkBlackEnabled,
   },
 }

--- a/app/src/organisms/ModuleCard/HeaterShakerModuleData.tsx
+++ b/app/src/organisms/ModuleCard/HeaterShakerModuleData.tsx
@@ -55,7 +55,7 @@ export const HeaterShakerModuleData = (
         break
       }
       case 'error': {
-        StatusLabelProps.backgroundColor = COLORS.warningBackground
+        StatusLabelProps.backgroundColor = COLORS.warningBackgroundLight
         StatusLabelProps.iconColor = COLORS.warningEnabled
         StatusLabelProps.textColor = COLORS.warningText
         break

--- a/app/src/organisms/ModuleCard/ThermocyclerModuleData.tsx
+++ b/app/src/organisms/ModuleCard/ThermocyclerModuleData.tsx
@@ -58,7 +58,7 @@ export const ThermocyclerModuleData = (
         break
       }
       case 'error': {
-        StatusLabelProps.backgroundColor = COLORS.warningBackground
+        StatusLabelProps.backgroundColor = COLORS.warningBackgroundLight
         StatusLabelProps.iconColor = COLORS.warningEnabled
         StatusLabelProps.textColor = COLORS.warningText
       }

--- a/app/src/organisms/ModuleCard/__tests__/HeaterShakerModuleData.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/HeaterShakerModuleData.test.tsx
@@ -145,7 +145,7 @@ describe('HeaterShakerModuleData', () => {
     getByText('Target: 200 rpm')
     getByText('Current: 200 rpm')
     expect(getByText('Mock StatusLabel')).toHaveStyle(
-      'backgroundColor: COLORS.warningBackground'
+      'backgroundColor: COLORS.warningBackgroundLight'
     )
   })
 

--- a/app/src/organisms/ModuleCard/__tests__/ThermocyclerModuleData.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/ThermocyclerModuleData.test.tsx
@@ -85,7 +85,7 @@ describe('ThermocyclerModuleData', () => {
     const { getByText } = render(props)
 
     expect(getByText('Mock Thermocycler StatusLabel')).toHaveStyle(
-      'backgroundColor: COLORS.warningBackground'
+      'backgroundColor: COLORS.warningBackgroundLight'
     )
   })
 

--- a/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/PipetteOffsetCalibrationItems.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/PipetteOffsetCalibrationItems.tsx
@@ -113,7 +113,7 @@ export function PipetteOffsetCalibrationItems({
                           <>
                             <Icon
                               name="alert-circle"
-                              backgroundColor={COLORS.warningBackground}
+                              backgroundColor={COLORS.warningBackgroundLight}
                               color={COLORS.warningEnabled}
                               size={SPACING.spacing4}
                             />
@@ -130,7 +130,7 @@ export function PipetteOffsetCalibrationItems({
                           <>
                             <Icon
                               name="alert-circle"
-                              backgroundColor={COLORS.errorBackground}
+                              backgroundColor={COLORS.errorBackgroundLight}
                               color={COLORS.errorEnabled}
                               size={SPACING.spacing4}
                             />

--- a/components/src/ui-style-constants/colors.ts
+++ b/components/src/ui-style-constants/colors.ts
@@ -40,19 +40,22 @@ export const darkGreySelected = '#5a5a5e'
 export const darkGreyDisabled = '#eaeaeb'
 
 // colors success
-export const successBackground = '#f3fffa'
+export const successBackgroundLight = '#f3fffa'
+export const successBackgroundMed = '#def4eb'
 export const successEnabled = '#04aa65'
 export const successText = '#00854d'
 export const successDisabled = '#8f8f8f'
 
 // colors warning
-export const warningBackground = '#fffcf5'
+export const warningBackgroundLight = '#fffcf5'
+export const warningBackgroundMed = '#fcf0d8'
 export const warningEnabled = '#f09d20'
 export const warningText = '#7b5b09'
 export const warningDisabled = '#8f8f8f'
 
 // colors error
-export const errorBackground = '#fff3f3'
+export const errorBackgroundLight = '#fff3f3'
+export const errorBackgroundMed = '#f7e0e0'
 export const errorEnabled = '#bf0000'
 export const errorHover = '#a30000'
 export const errorText = '#850000'


### PR DESCRIPTION

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
add 3 new colors for the calibration wizard and rename 3 colors
This will close RAUT-236

[updates]
successBackground-> successBackgroundLight
:new: successBackgroundMed (#DEF4EB)
warningBackground -> warningBackgroundLight
:new: warningBackgroundMed (#FCF0D8)
errorBackground -> errorBackgroundLight
:new: errorBackgroundMed (#F7E0E0) (edited) 
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- rename 3 colors in colors.ts and components
- add 3 colors to colors.ts

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- [ ]  no compile errors
- [ ] 3 error status colors are updates correctly
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
