### PR TITLE
refactor(api): move temperature module hardware interactions to core

### DIFF
--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -122,11 +122,11 @@ class TempDeck(mod_abc.AbstractModule):
         await self._listener.wait_next_poll()
 
     async def start_set_temperature(self, celsius: float) -> None:
-        """Set the target temperature in degree Celsius.
+        """Set the target temperature in degrees Celsius.
 
-        Range: 4 to 95 degree Celsius (QA tested).
+        Range: 4 to 95 degrees Celsius (QA tested).
 
-        The internal temp range is -9 to 99 C, which is limited by the 2-digit
+        The internal temp range is -9 to 99 °C, which is limited by the two-digit
         temperature display. Any input outside of this range will be clipped
         to the nearest limit.
         """
@@ -135,13 +135,13 @@ class TempDeck(mod_abc.AbstractModule):
         await self.wait_next_poll()
 
     async def await_temperature(self, awaiting_temperature: Optional[float]) -> None:
-        """Await a target temperature in degree Celsius.
+        """Await a target temperature in degrees Celsius.
 
-        Polls temperature module's temperature until
+        Polls Temperature Module's temperature until
         the specified temperature is reached.
 
         Args:
-            temperature: The temeprature to wait for.
+            temperature: The temperature to wait for.
                 If `None` (recommended), the module's target will be used.
                 Specifying any value other than the current target
                 may produce unpredictable behavior.

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -202,8 +202,8 @@ class TempDeck(mod_abc.AbstractModule):
         return self._listener.state.target
 
     @property
-    def status(self) -> str:
-        return self._get_status(self._listener.state).value
+    def status(self) -> TemperatureStatus:
+        return self._get_status(self._listener.state)
 
     @property
     def is_simulated(self) -> bool:

--- a/api/src/opentrons/protocol_api/core/module.py
+++ b/api/src/opentrons/protocol_api/core/module.py
@@ -53,7 +53,7 @@ class AbstractTemperatureModuleCore(AbstractModuleCore[LabwareCoreType]):
 
     @abstractmethod
     def set_target_temperature(self, celsius: float) -> None:
-        """Set the temperature module's target temperature in °C."""
+        """Set the Temperature Module's target temperature in °C."""
 
     @abstractmethod
     def wait_for_target_temperature(self, celsius: Optional[float] = None) -> None:

--- a/api/src/opentrons/protocol_api/core/module.py
+++ b/api/src/opentrons/protocol_api/core/module.py
@@ -59,13 +59,13 @@ class AbstractTemperatureModuleCore(AbstractModuleCore[LabwareCoreType]):
     def wait_for_target_temperature(self, celsius: Optional[float] = None) -> None:
         """Wait until the module's target temperature is reached.
 
-        Specifying a value for `celsius` that is different than
+        Specifying a value for ``celsius`` that is different than
         the module's current target temperature may beahave unpredictably.
         """
 
     @abstractmethod
     def deactivate(self) -> None:
-        """Deactivate the temperature module."""
+        """Deactivate the Temperature Module."""
 
     @abstractmethod
     def get_current_temperature(self) -> float:

--- a/api/src/opentrons/protocol_api/core/module.py
+++ b/api/src/opentrons/protocol_api/core/module.py
@@ -56,7 +56,7 @@ class AbstractTemperatureModuleCore(AbstractModuleCore[LabwareCoreType]):
         """Set the temperature module's target temperature in °C."""
 
     @abstractmethod
-    def wait_for_temperature(self, celsius: float) -> None:
+    def wait_for_target_temperature(self, celsius: Optional[float] = None) -> None:
         """Wait until the module's target temperature is reached.
 
         Specifying a value for `celsius` that is different than

--- a/api/src/opentrons/protocol_api/core/module.py
+++ b/api/src/opentrons/protocol_api/core/module.py
@@ -1,8 +1,12 @@
-"""Core module logic abstract interfaces."""
+"""Core module control interfaces."""
 from abc import ABC, abstractmethod
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, Optional, TypeVar
 
-from opentrons.hardware_control.modules.types import ModuleModel, ModuleType
+from opentrons.hardware_control.modules.types import (
+    ModuleModel,
+    ModuleType,
+    TemperatureStatus,
+)
 from opentrons.protocols.geometry.module_geometry import ModuleGeometry
 from opentrons.types import DeckSlotName
 
@@ -10,7 +14,7 @@ from .labware import LabwareCoreType
 
 
 class AbstractModuleCore(ABC, Generic[LabwareCoreType]):
-    """Abstract core module interface."""
+    """Abstract core module control interface."""
 
     @property
     @abstractmethod
@@ -42,3 +46,35 @@ class AbstractModuleCore(ABC, Generic[LabwareCoreType]):
 
 
 ModuleCoreType = TypeVar("ModuleCoreType", bound=AbstractModuleCore[Any])
+
+
+class AbstractTemperatureModuleCore(AbstractModuleCore[LabwareCoreType]):
+    """Core control interface for an attached Temperature Module."""
+
+    @abstractmethod
+    def set_target_temperature(self, celsius: float) -> None:
+        """Set the temperature module's target temperature in °C."""
+
+    @abstractmethod
+    def wait_for_temperature(self, celsius: float) -> None:
+        """Wait until the module's target temperature is reached.
+
+        Specifying a value for `celsius` that is different than
+        the module's current target temperature may beahave unpredictably.
+        """
+
+    @abstractmethod
+    def deactivate(self) -> None:
+        """Deactivate the temperature module."""
+
+    @abstractmethod
+    def get_current_temperature(self) -> float:
+        """Get the module's current temperature in °C."""
+
+    @abstractmethod
+    def get_target_temperature(self) -> Optional[float]:
+        """Get the module's target temperature in °C, if set."""
+
+    @abstractmethod
+    def get_status(self) -> TemperatureStatus:
+        """Get the module's current temperature status."""

--- a/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
@@ -65,19 +65,19 @@ class LegacyTemperatureModuleCore(
     _sync_module_hardware: SynchronousAdapter[TempDeck]
 
     def set_target_temperature(self, celsius: float) -> None:
-        """Set the temperature module's target temperature in °C."""
+        """Set the Temperature Module's target temperature in °C."""
         self._sync_module_hardware.start_set_temperature(celsius)
 
     def wait_for_target_temperature(self, celsius: Optional[float] = None) -> None:
         """Wait until the module's target temperature is reached.
 
-        Specifying a value for `celsius` that is different than
+        Specifying a value for ``celsius`` that is different than
         the module's current target temperature may beahave unpredictably.
         """
         self._sync_module_hardware.await_temperature(celsius)
 
     def deactivate(self) -> None:
-        """Deactivate the temperature module."""
+        """Deactivate the Temperature Module."""
         self._sync_module_hardware.deactivate()
 
     def get_current_temperature(self) -> float:

--- a/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
@@ -1,13 +1,17 @@
 """Legacy Protocol API module implementation logic."""
-from typing import cast
+from typing import Optional, cast
 
 from opentrons.hardware_control import SynchronousAdapter
-from opentrons.hardware_control.modules import AbstractModule
-from opentrons.hardware_control.modules.types import ModuleModel, ModuleType
+from opentrons.hardware_control.modules import AbstractModule, TempDeck
+from opentrons.hardware_control.modules.types import (
+    ModuleModel,
+    ModuleType,
+    TemperatureStatus,
+)
 from opentrons.protocols.geometry.module_geometry import ModuleGeometry
 from opentrons.types import DeckSlotName
 
-from ..module import AbstractModuleCore
+from ..module import AbstractModuleCore, AbstractTemperatureModuleCore
 from .labware import LabwareImplementation
 
 
@@ -51,3 +55,56 @@ class LegacyModuleCore(AbstractModuleCore[LabwareImplementation]):
     def get_deck_slot(self) -> DeckSlotName:
         """Get the module's deck slot."""
         return DeckSlotName.from_primitive(self._geometry.parent)  # type: ignore[arg-type]
+
+
+class LegacyTemperatureModuleCore(
+    LegacyModuleCore, AbstractTemperatureModuleCore[LabwareImplementation]
+):
+    """Legacy core control implementation for an attached Temperature Module."""
+
+    _sync_module_hardware: SynchronousAdapter[TempDeck]
+
+    def set_target_temperature(self, celsius: float) -> None:
+        """Set the temperature module's target temperature in °C."""
+        self._sync_module_hardware.start_set_temperature(celsius)
+
+    def wait_for_temperature(self, celsius: float) -> None:
+        """Wait until the module's target temperature is reached.
+
+        Specifying a value for `celsius` that is different than
+        the module's current target temperature may beahave unpredictably.
+        """
+        self._sync_module_hardware.await_temperature(celsius)
+
+    def deactivate(self) -> None:
+        """Deactivate the temperature module."""
+        self._sync_module_hardware.deactivate()
+
+    def get_current_temperature(self) -> float:
+        """Get the module's current temperature in °C."""
+        return self._sync_module_hardware.temperature  # type: ignore[no-any-return]
+
+    def get_target_temperature(self) -> Optional[float]:
+        """Get the module's target temperature in °C, if set."""
+        return self._sync_module_hardware.target  # type: ignore[no-any-return]
+
+    def get_status(self) -> TemperatureStatus:
+        """Get the module's current temperature status."""
+        return self._sync_module_hardware.status  # type: ignore[no-any-return]
+
+
+def create_module_core(
+    module_hardware_api: AbstractModule,
+    requested_model: ModuleModel,
+    geometry: ModuleGeometry,
+) -> LegacyModuleCore:
+    core_cls = LegacyModuleCore
+
+    if isinstance(module_hardware_api, TempDeck):
+        core_cls = LegacyTemperatureModuleCore
+
+    return core_cls(
+        sync_module_hardware=SynchronousAdapter(module_hardware_api),
+        requested_model=requested_model,
+        geometry=geometry,
+    )

--- a/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
@@ -68,7 +68,7 @@ class LegacyTemperatureModuleCore(
         """Set the temperature module's target temperature in °C."""
         self._sync_module_hardware.start_set_temperature(celsius)
 
-    def wait_for_temperature(self, celsius: float) -> None:
+    def wait_for_target_temperature(self, celsius: Optional[float] = None) -> None:
         """Wait until the module's target temperature is reached.
 
         Specifying a value for `celsius` that is different than

--- a/api/src/opentrons/protocol_api/core/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/protocol_context.py
@@ -6,7 +6,7 @@ from opentrons_shared_data.pipette.dev_types import PipetteNameType
 
 from opentrons.types import Mount, Location, DeckSlotName
 from opentrons.equipment_broker import EquipmentBroker
-from opentrons.hardware_control import SyncHardwareAPI, SynchronousAdapter
+from opentrons.hardware_control import SyncHardwareAPI
 from opentrons.hardware_control.modules import AbstractModule, ModuleModel, ModuleType
 from opentrons.hardware_control.types import DoorState, PauseType
 from opentrons.protocols.api_support.types import APIVersion
@@ -19,10 +19,10 @@ from opentrons.protocols import labware as labware_definition
 from ..protocol import AbstractProtocol
 from ..labware import LabwareLoadParams
 
+from . import legacy_module_core
 from .instrument_context import InstrumentContextImplementation
 from .labware_offset_provider import AbstractLabwareOffsetProvider
 from .labware import LabwareImplementation
-from .legacy_module_core import LegacyModuleCore
 from .load_info import LoadInfo, InstrumentLoadInfo, LabwareLoadInfo, ModuleLoadInfo
 
 logger = logging.getLogger(__name__)
@@ -30,7 +30,9 @@ logger = logging.getLogger(__name__)
 
 class ProtocolContextImplementation(
     AbstractProtocol[
-        InstrumentContextImplementation, LabwareImplementation, LegacyModuleCore
+        InstrumentContextImplementation,
+        LabwareImplementation,
+        legacy_module_core.LegacyModuleCore,
     ]
 ):
     def __init__(
@@ -139,7 +141,7 @@ class ProtocolContextImplementation(
     def load_labware(
         self,
         load_name: str,
-        location: Union[DeckSlotName, LegacyModuleCore],
+        location: Union[DeckSlotName, legacy_module_core.LegacyModuleCore],
         label: Optional[str],
         namespace: Optional[str],
         version: Optional[int],
@@ -173,7 +175,7 @@ class ProtocolContextImplementation(
             deck_slot=deck_slot,
             requested_module_model=(
                 location.get_requested_model()
-                if isinstance(location, LegacyModuleCore)
+                if isinstance(location, legacy_module_core.LegacyModuleCore)
                 else None
             ),
         )
@@ -189,7 +191,7 @@ class ProtocolContextImplementation(
                 labware_load_name=labware_load_params.load_name,
                 labware_version=labware_load_params.version,
                 deck_slot=deck_slot,
-                on_module=isinstance(location, LegacyModuleCore),
+                on_module=isinstance(location, legacy_module_core.LegacyModuleCore),
                 offset_id=labware_offset.offset_id,
                 labware_display_name=labware_core.get_user_display_name(),
             )
@@ -202,7 +204,7 @@ class ProtocolContextImplementation(
         model: ModuleModel,
         deck_slot: Optional[DeckSlotName],
         configuration: Optional[str],
-    ) -> LegacyModuleCore:
+    ) -> legacy_module_core.LegacyModuleCore:
         """Load a module."""
         resolved_type = ModuleType.from_model(model)
         resolved_location = self._deck_layout.resolve_module_location(
@@ -230,8 +232,6 @@ class ProtocolContextImplementation(
         if selected_hardware is None or selected_definition is None:
             raise RuntimeError(f"Could not find specified module: {model.value}")
 
-        sync_module_hardware = SynchronousAdapter(selected_hardware)
-
         # Load geometry to match the hardware module that we found connected.
         geometry = module_geometry.create_geometry(
             definition=selected_definition,
@@ -239,8 +239,8 @@ class ProtocolContextImplementation(
             configuration=configuration,
         )
 
-        module_core = LegacyModuleCore(
-            sync_module_hardware=sync_module_hardware,
+        module_core = legacy_module_core.create_module_core(
+            module_hardware_api=selected_hardware,
             requested_model=model,
             geometry=geometry,
         )

--- a/api/src/opentrons/protocol_api/core/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/protocol_context.py
@@ -225,7 +225,7 @@ class ProtocolContextImplementation(
                     selected_definition = definition
                     break
 
-        if selected_hardware is None and self.is_simulating:
+        if selected_hardware is None and self.is_simulating():
             selected_hardware = self._sync_hardware.create_simulating_module(model)
             selected_definition = module_geometry.load_definition(model)
 

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -25,7 +25,7 @@ from opentrons.protocols.geometry.module_geometry import (
 from .core.protocol import AbstractProtocol
 from .core.instrument import AbstractInstrument
 from .core.labware import AbstractLabware
-from .core.module import AbstractModuleCore
+from .core.module import AbstractModuleCore, AbstractTemperatureModuleCore
 from .core.well import AbstractWellCore
 
 from .module_validation_and_errors import (
@@ -271,60 +271,59 @@ class TemperatureModuleContext(ModuleContext[ModuleGeometry]):
 
     """
 
-    # TODO(mc, 2022-02-05): this type annotation is misleading;
-    # a SynchronousAdapter wrapper is actually passed in
-    _module: modules.tempdeck.TempDeck  # type: ignore[assignment]
+    _core: AbstractTemperatureModuleCore[AbstractLabware[AbstractWellCore]]
 
     @publish(command=cmds.tempdeck_set_temp)
     @requires_version(2, 0)
     def set_temperature(self, celsius: float) -> None:
-        """Set the target temperature, in C.
+        """Set the target temperature, in °C, waiting for the target to be hit.
 
-        Must be between 4 and 95C based on Opentrons QA.
+        Must be between 4 and 95°C based on Opentrons QA.
 
         :param celsius: The target temperature, in C
         """
-        self._module.set_temperature(celsius)
+        self._core.set_target_temperature(celsius)
+        self._core.wait_for_temperature(celsius)
 
     @publish(command=cmds.tempdeck_set_temp)
     @requires_version(2, 3)
     def start_set_temperature(self, celsius: float) -> None:
-        """Start setting the target temperature, in C.
+        """Set the target temperature, in °C, without waiting for the target to be hit.
 
-        Must be between 4 and 95C based on Opentrons QA.
+        Must be between 4 and 95°C based on Opentrons QA.
 
         :param celsius: The target temperature, in C
         """
-        self._module.start_set_temperature(celsius)
+        self._core.set_target_temperature(celsius)
 
     @publish(command=cmds.tempdeck_await_temp)
     @requires_version(2, 3)
     def await_temperature(self, celsius: float) -> None:
         """Wait until module reaches temperature, in C.
 
-        Must be between 4 and 95C based on Opentrons QA.
+        Must be between 4 and 95°C based on Opentrons QA.
 
-        :param celsius: The target temperature, in C
+        :param celsius: The target temperature, in °C
         """
-        self._module.await_temperature(celsius)
+        self._core.wait_for_temperature(celsius)
 
     @publish(command=cmds.tempdeck_deactivate)
     @requires_version(2, 0)
     def deactivate(self) -> None:
         """Stop heating (or cooling) and turn off the fan."""
-        self._module.deactivate()
+        self._core.deactivate()
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def temperature(self) -> float:
-        """Current temperature in C"""
-        return self._module.temperature
+        """Current temperature in °C"""
+        return self._core.get_current_temperature()
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def target(self) -> Optional[float]:
         """Current target temperature in C"""
-        return self._module.target
+        return self._core.get_target_temperature()
 
     @property  # type: ignore[misc]
     @requires_version(2, 3)
@@ -334,7 +333,7 @@ class TemperatureModuleContext(ModuleContext[ModuleGeometry]):
         Returns 'holding at target', 'cooling', 'heating', or 'idle'
 
         """
-        return self._module.status
+        return self._core.get_status().value
 
 
 class MagneticModuleContext(ModuleContext[ModuleGeometry]):

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -278,9 +278,9 @@ class TemperatureModuleContext(ModuleContext[ModuleGeometry]):
     def set_temperature(self, celsius: float) -> None:
         """Set the target temperature, in °C, waiting for the target to be hit.
 
-        Must be between 4 and 95°C based on Opentrons QA.
+        Must be between 4 and 95 °C based on Opentrons QA.
 
-        :param celsius: The target temperature, in C
+        :param celsius: The target temperature, in °C
         """
         self._core.set_target_temperature(celsius)
         self._core.wait_for_target_temperature()
@@ -290,7 +290,7 @@ class TemperatureModuleContext(ModuleContext[ModuleGeometry]):
     def start_set_temperature(self, celsius: float) -> None:
         """Set the target temperature, in °C, without waiting for the target to be hit.
 
-        Must be between 4 and 95°C based on Opentrons QA.
+        Must be between 4 and 95 °C based on Opentrons QA.
 
         :param celsius: The target temperature, in C
         """
@@ -299,9 +299,9 @@ class TemperatureModuleContext(ModuleContext[ModuleGeometry]):
     @publish(command=cmds.tempdeck_await_temp)
     @requires_version(2, 3)
     def await_temperature(self, celsius: float) -> None:
-        """Wait until module reaches temperature, in C.
+        """Wait until module reaches temperature, in °C.
 
-        Must be between 4 and 95°C based on Opentrons QA.
+        Must be between 4 and 95 °C based on Opentrons QA.
 
         :param celsius: The target temperature, in °C
         """
@@ -322,7 +322,7 @@ class TemperatureModuleContext(ModuleContext[ModuleGeometry]):
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def target(self) -> Optional[float]:
-        """Current target temperature in C"""
+        """Current target temperature in °C"""
         return self._core.get_target_temperature()
 
     @property  # type: ignore[misc]
@@ -330,7 +330,7 @@ class TemperatureModuleContext(ModuleContext[ModuleGeometry]):
     def status(self) -> str:
         """The status of the module.
 
-        Returns 'holding at target', 'cooling', 'heating', or 'idle'
+        Returns ``holding at target``, ``cooling``, ``heating``, or ``idle``
 
         """
         return self._core.get_status().value

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -117,16 +117,16 @@ class ModuleContext(CommandPublisher, Generic[GeometryType]):
         namespace: Optional[str] = None,
         version: int = 1,
     ) -> Labware:
-        """Load a labware onto the module by its load parameters.
+        """Load a labware onto the module using its load parameters.
 
         :param name: The name of the labware object.
         :param str label: An optional display name to give the labware.
-            If specified, this is the name the labware will use in the run log
-            and the calibration view in the Opentrons App.
+                          If specified, this is the name the labware will use
+                          in the run log and the calibration view in the Opentrons App.
         :param str namespace: The namespace the labware definition belongs to.
-            If unspecified, will search 'opentrons' then 'custom_beta'
+                              If unspecified, will search 'opentrons' then 'custom_beta'
         :param int version: The version of the labware definition.
-            If unspecified, will use version 1.
+                            If unspecified, will use version 1.
 
         :returns: The initialized and loaded labware object.
 
@@ -163,9 +163,7 @@ class ModuleContext(CommandPublisher, Generic[GeometryType]):
     def load_labware_from_definition(
         self, definition: LabwareDefinition, label: Optional[str] = None
     ) -> Labware:
-        """
-        Specify the presence of a labware on the module, using an
-        inline definition.
+        """Load a labware onto the module using an inline definition.
 
         :param definition: The labware definition.
         :param str label: An optional special name to give the labware. If
@@ -209,7 +207,7 @@ class ModuleContext(CommandPublisher, Generic[GeometryType]):
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def geometry(self) -> GeometryType:
-        """The object representing the module as an item on the deck
+        """The object representing the module as an item on the deck.
 
         :returns: ModuleGeometry
         """
@@ -316,13 +314,13 @@ class TemperatureModuleContext(ModuleContext[ModuleGeometry]):
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def temperature(self) -> float:
-        """Current temperature in °C"""
+        """Current temperature in °C."""
         return self._core.get_current_temperature()
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def target(self) -> Optional[float]:
-        """Current target temperature in °C"""
+        """Current target temperature in °C."""
         return self._core.get_target_temperature()
 
     @property  # type: ignore[misc]
@@ -330,8 +328,7 @@ class TemperatureModuleContext(ModuleContext[ModuleGeometry]):
     def status(self) -> str:
         """The status of the module.
 
-        Returns ``holding at target``, ``cooling``, ``heating``, or ``idle``
-
+        Returns ``holding at target``, ``cooling``, ``heating``, or ``idle``.
         """
         return self._core.get_status().value
 

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -283,7 +283,7 @@ class TemperatureModuleContext(ModuleContext[ModuleGeometry]):
         :param celsius: The target temperature, in C
         """
         self._core.set_target_temperature(celsius)
-        self._core.wait_for_temperature(celsius)
+        self._core.wait_for_target_temperature()
 
     @publish(command=cmds.tempdeck_set_temp)
     @requires_version(2, 3)
@@ -305,7 +305,7 @@ class TemperatureModuleContext(ModuleContext[ModuleGeometry]):
 
         :param celsius: The target temperature, in °C
         """
-        self._core.wait_for_temperature(celsius)
+        self._core.wait_for_target_temperature(celsius)
 
     @publish(command=cmds.tempdeck_deactivate)
     @requires_version(2, 0)

--- a/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
@@ -43,7 +43,9 @@ async def test_set_temperature(tempdeck: TempDeck) -> None:
         "data": {"currentTemp": 0, "targetTemp": None},
     }
 
-    await tempdeck.set_temperature(10)
+    await tempdeck.start_set_temperature(10)
+    await tempdeck.await_temperature(None)
+
     assert tempdeck.live_data == {
         "status": "holding at target",
         "data": {"currentTemp": 10, "targetTemp": 10},
@@ -57,8 +59,6 @@ async def test_start_set_temperature_cool(tempdeck: TempDeck) -> None:
     new_temp = current - 20
 
     await tempdeck.start_set_temperature(new_temp)
-    # Wait for poll
-    await tempdeck.wait_next_poll()
     assert tempdeck.live_data == {
         "status": "cooling",
         "data": {"currentTemp": current, "targetTemp": new_temp},
@@ -79,8 +79,6 @@ async def test_start_set_temperature_heat(tempdeck: TempDeck) -> None:
     new_temp = current + 20
 
     await tempdeck.start_set_temperature(new_temp)
-    # Wait for poll
-    await tempdeck.wait_next_poll()
     assert tempdeck.live_data == {
         "status": "heating",
         "data": {"currentTemp": current, "targetTemp": new_temp},
@@ -97,7 +95,7 @@ async def test_start_set_temperature_heat(tempdeck: TempDeck) -> None:
 async def test_deactivate(tempdeck: TempDeck) -> None:
     """It should deactivate and move to room temperature"""
     await tempdeck.deactivate()
-    await tempdeck.wait_next_poll()
+
     # Wait for temperature to be reached
     await tempdeck.await_temperature(awaiting_temperature=23)
     assert tempdeck.live_data == {

--- a/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
@@ -53,12 +53,12 @@ async def test_sim_state(subject: modules.AbstractModule):
 
 
 async def test_sim_update(subject: modules.AbstractModule):
-    await subject.set_temperature(10)
+    await subject.start_set_temperature(10)
+    await subject.await_temperature(None)
     assert subject.temperature == 10
     assert subject.target == 10
     assert subject.status == "holding at target"
     await subject.deactivate()
-    await subject.wait_next_poll()
     assert subject.temperature == 23
     assert subject.target is None
     assert subject.status == "idle"

--- a/api/tests/opentrons/hardware_control/test_simulator_setup.py
+++ b/api/tests/opentrons/hardware_control/test_simulator_setup.py
@@ -63,7 +63,12 @@ async def test_with_tempdeck():
     setup = simulator_setup.SimulatorSetup(
         attached_modules={
             "tempdeck": [
-                simulator_setup.ModuleCall("set_temperature", kwargs={"celsius": 23})
+                simulator_setup.ModuleCall(
+                    "start_set_temperature", kwargs={"celsius": 23}
+                ),
+                simulator_setup.ModuleCall(
+                    "await_temperature", kwargs={"awaiting_temperature": None}
+                ),
             ]
         }
     )

--- a/api/tests/opentrons/protocol_api/core/legacy/test_base_module_core.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_base_module_core.py
@@ -18,7 +18,7 @@ def mock_geometry(decoy: Decoy) -> ModuleGeometry:
 
 @pytest.fixture
 def mock_sync_module_hardware(decoy: Decoy) -> SynchronousAdapter[AbstractModule]:
-    """Get a mock module geometry."""
+    """Get a mock synchronous module hardware."""
     return decoy.mock(name="SynchronousAdapater[AbstractModule]")  # type: ignore[no-any-return]
 
 
@@ -32,8 +32,6 @@ def subject(
         requested_model=TemperatureModuleModel.TEMPERATURE_V1,
         geometry=mock_geometry,
         sync_module_hardware=mock_sync_module_hardware,
-        # labware_offset_provider=mock_labware_offset_provider,
-        # equipment_broker=mock_equipment_broker,
     )
 
 

--- a/api/tests/opentrons/protocol_api/core/legacy/test_protocol_context_implementation.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_protocol_context_implementation.py
@@ -18,6 +18,7 @@ from opentrons.hardware_control.modules import AbstractModule
 from opentrons.hardware_control.modules.types import ModuleType, TemperatureModuleModel
 from opentrons.protocols import labware as mock_labware
 from opentrons.protocols.geometry.deck import Deck
+from opentrons.protocols.geometry.module_geometry import ModuleGeometry
 from opentrons.protocol_api import MAX_SUPPORTED_VERSION
 from opentrons.protocol_api.core.protocol_api.load_info import (
     LoadInfo,
@@ -40,6 +41,9 @@ from opentrons.protocol_api.core.protocol_api.protocol_context import (
 )
 
 from opentrons.protocols.geometry import module_geometry as mock_module_geometry
+from opentrons.protocol_api.core.protocol_api import (
+    legacy_module_core as mock_legacy_module_core,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -54,6 +58,15 @@ def _mock_module_geometry_module(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) 
     """Mock out opentrons.protocols.geometry.module_geometry functions."""
     for name, func in inspect.getmembers(mock_module_geometry, inspect.isfunction):
         monkeypatch.setattr(mock_module_geometry, name, decoy.mock(func=func))
+
+
+@pytest.fixture(autouse=True)
+def _mock_legacy_module_core_module(
+    decoy: Decoy, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mock out opentrons.protocol_api.core.protocol_api.legacy_module_core functions."""
+    for name, func in inspect.getmembers(mock_legacy_module_core, inspect.isfunction):
+        monkeypatch.setattr(mock_legacy_module_core, name, decoy.mock(func=func))
 
 
 @pytest.fixture
@@ -329,7 +342,8 @@ def test_load_module(
     defn_1 = cast(ModuleDefinitionV3, {"model": "model-1"})
     defn_2 = cast(ModuleDefinitionV3, {"model": "model-2"})
 
-    mock_geometry = decoy.mock(name="ModuleGeometry")
+    mock_geometry = decoy.mock(cls=ModuleGeometry)
+    mock_module_core = decoy.mock(cls=LegacyModuleCore)
 
     decoy.when(mock_hw_mod_1.model()).then_return("model-1")
     decoy.when(mock_hw_mod_2.model()).then_return("model-2")
@@ -372,21 +386,34 @@ def test_load_module(
     decoy.when(mock_geometry.parent).then_return("1")
     decoy.when(mock_geometry.model).then_return(TemperatureModuleModel.TEMPERATURE_V2)
 
+    decoy.when(
+        mock_legacy_module_core.create_module_core(
+            module_hardware_api=mock_hw_mod_2,
+            requested_model=TemperatureModuleModel.TEMPERATURE_V1,
+            geometry=mock_geometry,
+        )
+    ).then_return(mock_module_core)
+
+    decoy.when(mock_module_core.get_model()).then_return(
+        TemperatureModuleModel.TEMPERATURE_V2
+    )
+    decoy.when(mock_module_core.get_serial_number()).then_return("cap'n crunch")
+    decoy.when(mock_module_core.get_deck_slot()).then_return(DeckSlotName.SLOT_1)
+
     result = subject.load_module(
         model=TemperatureModuleModel.TEMPERATURE_V1,
         deck_slot=DeckSlotName.SLOT_1,
         configuration=None,
     )
 
-    assert isinstance(result, LegacyModuleCore)
-    assert result.geometry == mock_geometry
+    assert result is mock_module_core
 
     decoy.verify(
         mock_equipment_broker.publish(
             ModuleLoadInfo(
                 requested_model=TemperatureModuleModel.TEMPERATURE_V1,
                 loaded_model=TemperatureModuleModel.TEMPERATURE_V2,
-                module_serial="serial-number",
+                module_serial="cap'n crunch",
                 deck_slot=DeckSlotName.SLOT_1,
                 configuration=None,
             )

--- a/api/tests/opentrons/protocol_api/core/legacy/test_temperature_module_core.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_temperature_module_core.py
@@ -1,0 +1,128 @@
+"""Tests for the legacy Protocol API module core implementations."""
+import pytest
+from decoy import Decoy
+
+from opentrons.hardware_control import SynchronousAdapter
+from opentrons.hardware_control.modules import TempDeck
+from opentrons.hardware_control.modules.types import (
+    TemperatureModuleModel,
+    TemperatureStatus,
+)
+from opentrons.protocols.geometry.module_geometry import ModuleGeometry
+
+from opentrons.protocol_api.core.protocol_api.legacy_module_core import (
+    LegacyTemperatureModuleCore,
+    create_module_core,
+)
+
+
+@pytest.fixture
+def mock_geometry(decoy: Decoy) -> ModuleGeometry:
+    """Get a mock module geometry."""
+    return decoy.mock(cls=ModuleGeometry)
+
+
+@pytest.fixture
+def mock_sync_module_hardware(decoy: Decoy) -> SynchronousAdapter[TempDeck]:
+    """Get a mock synchronous temperature module hardware."""
+    return decoy.mock(name="SynchronousAdapater[TempDeck]")  # type: ignore[no-any-return]
+
+
+@pytest.fixture
+def subject(
+    mock_geometry: ModuleGeometry,
+    mock_sync_module_hardware: SynchronousAdapter[TempDeck],
+) -> LegacyTemperatureModuleCore:
+    """Get a legacy module implementation core with mocked out dependencies."""
+    return LegacyTemperatureModuleCore(
+        requested_model=TemperatureModuleModel.TEMPERATURE_V1,
+        geometry=mock_geometry,
+        sync_module_hardware=mock_sync_module_hardware,
+    )
+
+
+def test_create(
+    decoy: Decoy,
+    mock_geometry: ModuleGeometry,
+) -> None:
+    """It should be able to create a temperature module core."""
+    mock_module_hardware_api = decoy.mock(cls=TempDeck)
+    result = create_module_core(
+        geometry=mock_geometry,
+        module_hardware_api=mock_module_hardware_api,
+        requested_model=TemperatureModuleModel.TEMPERATURE_V1,
+    )
+
+    assert isinstance(result, LegacyTemperatureModuleCore)
+
+
+def test_set_target_temperature(
+    decoy: Decoy,
+    mock_sync_module_hardware: SynchronousAdapter[TempDeck],
+    subject: LegacyTemperatureModuleCore,
+) -> None:
+    """It should set the target temperature with the hardware."""
+    subject.set_target_temperature(42.0)
+
+    decoy.verify(mock_sync_module_hardware.start_set_temperature(42.0), times=1)
+
+
+def test_wait_for_temperature(
+    decoy: Decoy,
+    mock_sync_module_hardware: SynchronousAdapter[TempDeck],
+    subject: LegacyTemperatureModuleCore,
+) -> None:
+    """It should wait for the target to be reached with the hardware."""
+    subject.wait_for_temperature(42.0)
+
+    decoy.verify(mock_sync_module_hardware.await_temperature(42.0), times=1)
+
+
+def test_deactivate(
+    decoy: Decoy,
+    mock_sync_module_hardware: SynchronousAdapter[TempDeck],
+    subject: LegacyTemperatureModuleCore,
+) -> None:
+    """It should deactivate the hardware."""
+    subject.deactivate()
+
+    decoy.verify(mock_sync_module_hardware.deactivate(), times=1)
+
+
+def test_get_current_temperature(
+    decoy: Decoy,
+    mock_sync_module_hardware: SynchronousAdapter[TempDeck],
+    subject: LegacyTemperatureModuleCore,
+) -> None:
+    """It should get the current temperature from the hardware."""
+    decoy.when(mock_sync_module_hardware.temperature).then_return(42.0)
+
+    result = subject.get_current_temperature()
+
+    assert result == 42.0
+
+
+def test_get_target_temperature(
+    decoy: Decoy,
+    mock_sync_module_hardware: SynchronousAdapter[TempDeck],
+    subject: LegacyTemperatureModuleCore,
+) -> None:
+    """It should get the current temperature from the hardware."""
+    decoy.when(mock_sync_module_hardware.target).then_return(42.0)
+
+    result = subject.get_target_temperature()
+
+    assert result == 42.0
+
+
+def test_get_status(
+    decoy: Decoy,
+    mock_sync_module_hardware: SynchronousAdapter[TempDeck],
+    subject: LegacyTemperatureModuleCore,
+) -> None:
+    """It should get the status string from the hardware."""
+    decoy.when(mock_sync_module_hardware.status).then_return(TemperatureStatus.HEATING)
+
+    result = subject.get_status()
+
+    assert result == TemperatureStatus.HEATING

--- a/api/tests/opentrons/protocol_api/core/legacy/test_temperature_module_core.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_temperature_module_core.py
@@ -67,13 +67,13 @@ def test_set_target_temperature(
     decoy.verify(mock_sync_module_hardware.start_set_temperature(42.0), times=1)
 
 
-def test_wait_for_temperature(
+def test_wait_for_target_temperature(
     decoy: Decoy,
     mock_sync_module_hardware: SynchronousAdapter[TempDeck],
     subject: LegacyTemperatureModuleCore,
 ) -> None:
     """It should wait for the target to be reached with the hardware."""
-    subject.wait_for_temperature(42.0)
+    subject.wait_for_target_temperature(42.0)
 
     decoy.verify(mock_sync_module_hardware.await_temperature(42.0), times=1)
 

--- a/api/tests/opentrons/protocol_api/test_temperature_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_temperature_module_context.py
@@ -1,0 +1,185 @@
+"""Tests for Protocol API temperature module contexts."""
+import pytest
+from decoy import Decoy, matchers
+
+from opentrons.broker import Broker
+from opentrons.hardware_control.modules import TemperatureStatus
+from opentrons.protocols.api_support.types import APIVersion
+from opentrons.protocol_api import MAX_SUPPORTED_VERSION, TemperatureModuleContext
+
+from .types import ProtocolCore, TemperatureModuleCore
+
+
+@pytest.fixture
+def mock_core(decoy: Decoy) -> TemperatureModuleCore:
+    """Get a mock module implementation core."""
+    return decoy.mock(cls=TemperatureModuleCore)
+
+
+@pytest.fixture
+def mock_protocol_core(decoy: Decoy) -> ProtocolCore:
+    """Get a mock protocol implementation core."""
+    return decoy.mock(cls=ProtocolCore)
+
+
+@pytest.fixture
+def mock_broker(decoy: Decoy) -> Broker:
+    """Get a mock command message broker."""
+    return decoy.mock(cls=Broker)
+
+
+@pytest.fixture
+def api_version() -> APIVersion:
+    """Get an API version to apply to the interface."""
+    return MAX_SUPPORTED_VERSION
+
+
+@pytest.fixture
+def subject(
+    api_version: APIVersion,
+    mock_core: TemperatureModuleCore,
+    mock_protocol_core: ProtocolCore,
+    mock_broker: Broker,
+) -> TemperatureModuleContext:
+    """Get a temperature module context with its dependencies mocked out."""
+    return TemperatureModuleContext(
+        core=mock_core,
+        protocol_core=mock_protocol_core,
+        broker=mock_broker,
+        api_version=api_version,
+    )
+
+
+def test_set_temperature(
+    decoy: Decoy,
+    mock_core: TemperatureModuleCore,
+    mock_broker: Broker,
+    subject: TemperatureModuleContext,
+) -> None:
+    """It should set and wait for the temperature via the core."""
+    subject.set_temperature(42.0)
+
+    decoy.verify(
+        mock_broker.publish(
+            "command",
+            matchers.DictMatching(
+                {
+                    "$": "before",
+                    "name": "command.TEMPDECK_SET_TEMP",
+                    "payload": matchers.DictMatching({"celsius": 42.0}),
+                }
+            ),
+        ),
+        mock_core.set_target_temperature(42.0),
+        mock_core.wait_for_temperature(42.0),
+        mock_broker.publish(
+            "command",
+            matchers.DictMatching({"$": "after"}),
+        ),
+    )
+
+
+def test_start_set_temperature(
+    decoy: Decoy,
+    mock_core: TemperatureModuleCore,
+    mock_broker: Broker,
+    subject: TemperatureModuleContext,
+) -> None:
+    """It should set the target temperature via the core."""
+    subject.start_set_temperature(42.0)
+
+    decoy.verify(
+        mock_broker.publish(
+            "command",
+            matchers.DictMatching(
+                {
+                    "$": "before",
+                    "name": "command.TEMPDECK_SET_TEMP",
+                    "payload": matchers.DictMatching({"celsius": 42.0}),
+                }
+            ),
+        ),
+        mock_core.set_target_temperature(42.0),
+        mock_broker.publish("command", matchers.DictMatching({"$": "after"})),
+    )
+
+    decoy.verify(mock_core.wait_for_temperature(matchers.Anything()), times=0)
+
+
+def test_await_temperature(
+    decoy: Decoy,
+    mock_core: TemperatureModuleCore,
+    mock_broker: Broker,
+    subject: TemperatureModuleContext,
+) -> None:
+    """It should wait for a specified target temperature."""
+    subject.await_temperature(42.0)
+
+    decoy.verify(
+        mock_broker.publish(
+            "command",
+            matchers.DictMatching(
+                {
+                    "$": "before",
+                    "name": "command.TEMPDECK_AWAIT_TEMP",
+                    "payload": matchers.DictMatching({"celsius": 42.0}),
+                }
+            ),
+        ),
+        mock_core.wait_for_temperature(42.0),
+        mock_broker.publish("command", matchers.DictMatching({"$": "after"})),
+    )
+
+
+def test_deactivate(
+    decoy: Decoy,
+    mock_core: TemperatureModuleCore,
+    mock_broker: Broker,
+    subject: TemperatureModuleContext,
+) -> None:
+    """It should deactivate the heater."""
+    subject.deactivate()
+
+    decoy.verify(
+        mock_broker.publish(
+            "command",
+            matchers.DictMatching(
+                {"$": "before", "name": "command.TEMPDECK_DEACTIVATE"}
+            ),
+        ),
+        mock_core.deactivate(),
+        mock_broker.publish("command", matchers.DictMatching({"$": "after"})),
+    )
+
+
+def test_get_current_temperature(
+    decoy: Decoy, mock_core: TemperatureModuleCore, subject: TemperatureModuleContext
+) -> None:
+    """It should get the current temperature from the core."""
+    decoy.when(mock_core.get_current_temperature()).then_return(42.0)
+
+    result = subject.temperature
+
+    assert result == 42.0
+
+
+def test_get_target_temperature(
+    decoy: Decoy, mock_core: TemperatureModuleCore, subject: TemperatureModuleContext
+) -> None:
+    """It should get the target temperature from the core."""
+    decoy.when(mock_core.get_target_temperature()).then_return(42.0)
+
+    result = subject.target
+
+    assert result == 42.0
+
+
+def test_get_status(
+    decoy: Decoy, mock_core: TemperatureModuleCore, subject: TemperatureModuleContext
+) -> None:
+    """It should get the target temperature from the core."""
+    decoy.when(mock_core.get_status()).then_return(TemperatureStatus.HEATING)
+
+    result = subject.status
+
+    assert result == "heating"

--- a/api/tests/opentrons/protocol_api/types.py
+++ b/api/tests/opentrons/protocol_api/types.py
@@ -2,11 +2,15 @@
 from opentrons.protocol_api.core.protocol import AbstractProtocol
 from opentrons.protocol_api.core.instrument import AbstractInstrument
 from opentrons.protocol_api.core.labware import AbstractLabware
-from opentrons.protocol_api.core.module import AbstractModuleCore
+from opentrons.protocol_api.core.module import (
+    AbstractModuleCore,
+    AbstractTemperatureModuleCore,
+)
 from opentrons.protocol_api.core.well import AbstractWellCore
 
 
 InstrumentCore = AbstractInstrument[AbstractWellCore]
 LabwareCore = AbstractLabware[AbstractWellCore]
 ModuleCore = AbstractModuleCore[LabwareCore]
+TemperatureModuleCore = AbstractTemperatureModuleCore[LabwareCore]
 ProtocolCore = AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]

--- a/api/tests/opentrons/protocol_api_old/test_module_context.py
+++ b/api/tests/opentrons/protocol_api_old/test_module_context.py
@@ -180,53 +180,6 @@ def test_load_simulating_module(ctx, loadname, klass, model):
     assert mod._module.model() == model
 
 
-# ________ Temperature Module tests _________
-
-
-def test_tempdeck(ctx_with_tempdeck, mock_module_controller):
-    mod = ctx_with_tempdeck.load_module("Temperature Module", 1)
-    assert ctx_with_tempdeck.deck[1] == mod.geometry
-
-
-def test_tempdeck_target(ctx_with_tempdeck, mock_module_controller):
-    mod = ctx_with_tempdeck.load_module("Temperature Module", 1)
-    m = mock.PropertyMock(return_value=0x1337)
-    type(mock_module_controller).target = m
-    assert mod.target == 0x1337
-
-
-def test_tempdeck_set_temperature(ctx_with_tempdeck, mock_module_controller):
-    mod = ctx_with_tempdeck.load_module("Temperature Module", 1)
-    mod.set_temperature(20)
-    assert "setting temperature" in ",".join(
-        cmd.lower() for cmd in ctx_with_tempdeck.commands()
-    )
-    mock_module_controller.set_temperature.assert_called_once_with(20)
-
-
-def test_tempdeck_temperature(ctx_with_tempdeck, mock_module_controller):
-    mod = ctx_with_tempdeck.load_module("Temperature Module", 1)
-    m = mock.PropertyMock(return_value=0xDEAD)
-    type(mock_module_controller).temperature = m
-    assert mod.temperature == 0xDEAD
-
-
-def test_tempdeck_deactivate(ctx_with_tempdeck, mock_module_controller):
-    mod = ctx_with_tempdeck.load_module("Temperature Module", 1)
-    mod.deactivate()
-    assert "deactivating temperature" in ",".join(
-        cmd.lower() for cmd in ctx_with_tempdeck.commands()
-    )
-    mock_module_controller.deactivate.assert_called_once()
-
-
-def test_tempdeck_status(ctx_with_tempdeck, mock_module_controller):
-    mod = ctx_with_tempdeck.load_module("Temperature Module", 1)
-    m = mock.PropertyMock(return_value="some status")
-    type(mock_module_controller).status = m
-    assert mod.status == "some status"
-
-
 # _________ Magnetic Module tests __________
 
 

--- a/robot-server/simulators/test.json
+++ b/robot-server/simulators/test.json
@@ -47,7 +47,7 @@
       {
         "function_name": "await_temperature",
         "kwargs": {
-          "awaiting_temperature": 3
+          "awaiting_temperature": null
         }
       }
     ],

--- a/robot-server/simulators/test.json
+++ b/robot-server/simulators/test.json
@@ -39,9 +39,15 @@
     "heatershaker": [],
     "tempdeck": [
       {
-        "function_name": "set_temperature",
+        "function_name": "start_set_temperature",
         "kwargs": {
           "celsius": 3
+        }
+      },
+      {
+        "function_name": "await_temperature",
+        "kwargs": {
+          "awaiting_temperature": 3
         }
       }
     ],


### PR DESCRIPTION
## Overview

This PR refactors the `TemperatureModuleContext` to flow through a `LegacyTemperatureModuleCore` instead of directly interacting with hardware. This will allow a similar engine-based `TemperatureModuleCore` to be written to support temperature modules on the PAPIv2 PE core.

## Changelog

- Add `AbstractTemperatureModuleCore` interface
- Add `LegacyTemperatureModuleCore` implementation
- Wire `TemperatureModuleContext` to its `self._core` instead of `self._module`
- Remove now-unused `TempDeck.set_temperature` hardware control interface ("set and wait")
    - Replaced with discrete "set target" and "wait for target" calls, to match H/S and PE

## Review requests

For best results, tests should be run on hardware using a PAPIv2 protocol.

- [ ] Temperature module may be loaded
- [ ] Temperature module commands behave as expected

## Risk assessment

Low, though this PR includes some small changes to the hardware control layer to ensure "wait for target" behavior is unchanged.
