### PR TITLE
refactor(api): move magnetic module hardware interaction to core

### DIFF
--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -120,7 +120,8 @@ This table lists the correspondence between Protocol API versions and robot soft
 +-------------+-----------------------------+
 |     2.13    |          6.1.0              |
 +-------------+-----------------------------+
-
+|     2.14    |        unreleased           |
++-------------+-----------------------------+
 
 Changes in API Versions
 -----------------------
@@ -257,3 +258,12 @@ Version 2.13
 - :py:meth:`.InstrumentContext.drop_tip` now has a ``prep_after`` parameter.
 - :py:meth:`.InstrumentContext.home` may home *both* pipettes as needed to avoid collision risks.
 - :py:meth:`.InstrumentContext.aspirate` and :py:meth:`.InstrumentContext.dispense` will avoid interacting directly with modules.
+
+
+Version 2.14
+++++++++++++
+
+Upcoming, not yet released.
+
+- :py:meth:`.ModuleContext.load_labware_object` has been deprecated.
+- :py:meth:`.MagneticModuleContext.calibrate` has been deprecated.

--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -20,9 +20,9 @@ MAX_ENGAGE_HEIGHT = {
 }
 
 # Measured in model-specific units (half-mm for GEN1, mm for GEN2).
-# TODO(mc, 2022-06-13): the value for gen1 is off by 1.5 mm
-# The correct value is 8.0 half-mm (4.0 mm)
-# https://github.com/Opentrons/opentrons/issues/9529
+# TODO(mc, 2022-06-13): the value for gen1 is off by ~1.5 mm
+# The correct value is ~8.0 half-mm (4.0 mm)
+# https://opentrons.atlassian.net/browse/RET-1242
 OFFSET_TO_LABWARE_BOTTOM = {"magneticModuleV1": 5, "magneticModuleV2": 2.5}
 
 
@@ -116,6 +116,7 @@ class MagDeck(mod_abc.AbstractModule):
 
     # TODO(mc, 2022-09-23): refactor this method to take real mm,
     # hardware API should abstract away the idea of "short millimeters"
+    # https://opentrons.atlassian.net/browse/RET-1242
     async def engage(
         self,
         height: Optional[float] = None,

--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -152,11 +152,11 @@ class MagDeck(mod_abc.AbstractModule):
         return self._device_info
 
     @property
-    def status(self) -> str:
+    def status(self) -> types.MagneticStatus:
         if self.current_height > 0:
-            return "engaged"
+            return types.MagneticStatus.ENGAGED
         else:
-            return "disengaged"
+            return types.MagneticStatus.DISENGAGED
 
     @property
     def engaged(self) -> bool:

--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -114,13 +114,23 @@ class MagDeck(mod_abc.AbstractModule):
         await self._driver.probe_plate()
         # return if successful or not?
 
-    async def engage(self, height: float) -> None:
+    # TODO(mc, 2022-09-23): refactor this method to take real mm,
+    # hardware API should abstract away the idea of "short millimeters"
+    async def engage(
+        self,
+        height: Optional[float] = None,
+        height_from_base: Optional[float] = None,
+    ) -> None:
         """Move the magnet to a specific height, measured from home position.
 
         The units of position depend on the module model.
         For GEN1, it's half millimeters ("short millimeters").
         For GEN2, it's millimeters.
         """
+        if height is None:
+            assert height_from_base is not None, "An engage height must be specified"
+            height = height_from_base + OFFSET_TO_LABWARE_BOTTOM[self.model()]
+
         await self.wait_for_is_running()
         if not engage_height_is_in_range(self.model(), height):
             raise ValueError(

--- a/api/src/opentrons/protocol_api/core/engine/labware.py
+++ b/api/src/opentrons/protocol_api/core/engine/labware.py
@@ -115,3 +115,8 @@ class LabwareCore(AbstractLabware[WellCore]):
 
     def get_geometry(self) -> LabwareGeometry:
         raise NotImplementedError("LabwareCore not implemented")
+
+    def get_default_magnet_engage_height(
+        self, preserve_half_mm_labware: bool = False
+    ) -> Optional[float]:
+        raise NotImplementedError("LabwareCore not implemented")

--- a/api/src/opentrons/protocol_api/core/engine/labware.py
+++ b/api/src/opentrons/protocol_api/core/engine/labware.py
@@ -117,6 +117,6 @@ class LabwareCore(AbstractLabware[WellCore]):
         raise NotImplementedError("LabwareCore not implemented")
 
     def get_default_magnet_engage_height(
-        self, preserve_half_mm_labware: bool = False
+        self, preserve_half_mm: bool = False
     ) -> Optional[float]:
         raise NotImplementedError("LabwareCore not implemented")

--- a/api/src/opentrons/protocol_api/core/labware.py
+++ b/api/src/opentrons/protocol_api/core/labware.py
@@ -130,7 +130,7 @@ class AbstractLabware(DeckItem, ABC, Generic[WellCoreType]):
     ) -> Optional[float]:
         """Get the labware's default magnet engage height, if defined.
 
-        Value returned is in real mm's from the labware's base,
+        Value returned is in real millimeters from the labware's base,
         unless `preserve_half_mm` is specified, in which case
         some definitions will return half-millimeters.
         """

--- a/api/src/opentrons/protocol_api/core/labware.py
+++ b/api/src/opentrons/protocol_api/core/labware.py
@@ -123,5 +123,17 @@ class AbstractLabware(DeckItem, ABC, Generic[WellCoreType]):
     def get_geometry(self) -> AbstractLabwareGeometry:
         ...
 
+    @abstractmethod
+    def get_default_magnet_engage_height(
+        self,
+        preserve_half_mm_labware: bool = False,
+    ) -> Optional[float]:
+        """Get the labware's default magnet engage height, if defined.
+
+        Value returned is in real mm's from the labware's base,
+        unless `preserve_half_mm_labware` is specified, in which case
+        some definitions will return half-millimeters.
+        """
+
 
 LabwareCoreType = TypeVar("LabwareCoreType", bound=AbstractLabware[Any])

--- a/api/src/opentrons/protocol_api/core/labware.py
+++ b/api/src/opentrons/protocol_api/core/labware.py
@@ -126,12 +126,12 @@ class AbstractLabware(DeckItem, ABC, Generic[WellCoreType]):
     @abstractmethod
     def get_default_magnet_engage_height(
         self,
-        preserve_half_mm_labware: bool = False,
+        preserve_half_mm: bool = False,
     ) -> Optional[float]:
         """Get the labware's default magnet engage height, if defined.
 
         Value returned is in real mm's from the labware's base,
-        unless `preserve_half_mm_labware` is specified, in which case
+        unless `preserve_half_mm` is specified, in which case
         some definitions will return half-millimeters.
         """
 

--- a/api/src/opentrons/protocol_api/core/module.py
+++ b/api/src/opentrons/protocol_api/core/module.py
@@ -45,6 +45,10 @@ class AbstractModuleCore(ABC, Generic[LabwareCoreType]):
     def get_deck_slot(self) -> DeckSlotName:
         """Get the module's deck slot."""
 
+    @abstractmethod
+    def add_labware_core(self, labware_core: LabwareCoreType) -> None:
+        """Add a labware to the module."""
+
 
 ModuleCoreType = TypeVar("ModuleCoreType", bound=AbstractModuleCore[Any])
 
@@ -89,19 +93,33 @@ class AbstractMagneticModuleCore(AbstractModuleCore[LabwareCoreType]):
         self,
         height_from_base: Optional[float] = None,
         height_from_home: Optional[float] = None,
-        offset_from_labware_default: Optional[float] = None,
     ) -> None:
         """Raise the module's magnets.
 
-        Only one of `height_from_base`, `offset_from_labware_default`,
-        or `height_from_home` may be specified. All distance units are
-        specified in real millimeters.
+        Only one of `height_from_base` or `height_from_home` may be specified.
+        All distance units are specified in real millimeters.
 
         Args:
             height_from_base: Distance from labware base to raise the magnets.
             height_from_base: Distance from motor home position to raise the magnets.
-            offset_from_labware_default: Offset from the default engage height
-                of the module's loaded labware to raise the magnet.
+        """
+
+    @abstractmethod
+    def engage_to_labware(
+        self, offset: float = 0, preserve_half_mm_labware: bool = False
+    ) -> None:
+        """Raise the module's magnets its loaded labware.
+
+        All distance units are specified in real millimeters.
+
+        Args:
+            offset: Offset from the labware's default engage height.
+            preserve_half_mm_labware: For labware whose definitions
+                erroneously use half-mm for their defined default engage height,
+                use the value directly instead of converting it to real millimeters.
+
+        Raises:
+            Exception: Labware is not loaded or has no default engage height.
         """
 
     @abstractmethod

--- a/api/src/opentrons/protocol_api/core/module.py
+++ b/api/src/opentrons/protocol_api/core/module.py
@@ -100,7 +100,7 @@ class AbstractMagneticModuleCore(AbstractModuleCore[LabwareCoreType]):
 
         Args:
             height_from_base: Distance from labware base to raise the magnets.
-            height_from_base: Distance from motor home position to raise the magnets.
+            height_from_home: Distance from motor home position to raise the magnets.
         """
 
     @abstractmethod

--- a/api/src/opentrons/protocol_api/core/module.py
+++ b/api/src/opentrons/protocol_api/core/module.py
@@ -6,6 +6,7 @@ from opentrons.hardware_control.modules.types import (
     ModuleModel,
     ModuleType,
     TemperatureStatus,
+    MagneticStatus,
 )
 from opentrons.protocols.geometry.module_geometry import ModuleGeometry
 from opentrons.types import DeckSlotName
@@ -78,3 +79,35 @@ class AbstractTemperatureModuleCore(AbstractModuleCore[LabwareCoreType]):
     @abstractmethod
     def get_status(self) -> TemperatureStatus:
         """Get the module's current temperature status."""
+
+
+class AbstractMagneticModuleCore(AbstractModuleCore[LabwareCoreType]):
+    """Core control interface for an attached Magnetic Module."""
+
+    @abstractmethod
+    def engage(
+        self,
+        height_from_base: Optional[float] = None,
+        height_from_home: Optional[float] = None,
+        offset_from_labware_default: Optional[float] = None,
+    ) -> None:
+        """Raise the module's magnets.
+
+        Only one of `height_from_base`, `offset_from_labware_default`,
+        or `height_from_home` may be specified. All distance units are
+        specified in real millimeters.
+
+        Args:
+            height_from_base: Distance from labware base to raise the magnets.
+            height_from_base: Distance from motor home position to raise the magnets.
+            offset_from_labware_default: Offset from the default engage height
+                of the module's loaded labware to raise the magnet.
+        """
+
+    @abstractmethod
+    def disengage(self) -> None:
+        """Lower the magnets back into the module."""
+
+    @abstractmethod
+    def get_status(self) -> MagneticStatus:
+        """Get the module's current magnet status."""

--- a/api/src/opentrons/protocol_api/core/module.py
+++ b/api/src/opentrons/protocol_api/core/module.py
@@ -97,7 +97,6 @@ class AbstractMagneticModuleCore(AbstractModuleCore[LabwareCoreType]):
         """Raise the module's magnets.
 
         Only one of `height_from_base` or `height_from_home` may be specified.
-        All distance units are specified in real millimeters.
 
         Args:
             height_from_base: Distance from labware base to raise the magnets.
@@ -108,9 +107,7 @@ class AbstractMagneticModuleCore(AbstractModuleCore[LabwareCoreType]):
     def engage_to_labware(
         self, offset: float = 0, preserve_half_mm_labware: bool = False
     ) -> None:
-        """Raise the module's magnets its loaded labware.
-
-        All distance units are specified in real millimeters.
+        """Raise the module's magnets up to its loaded labware.
 
         Args:
             offset: Offset from the labware's default engage height.

--- a/api/src/opentrons/protocol_api/core/module.py
+++ b/api/src/opentrons/protocol_api/core/module.py
@@ -105,13 +105,13 @@ class AbstractMagneticModuleCore(AbstractModuleCore[LabwareCoreType]):
 
     @abstractmethod
     def engage_to_labware(
-        self, offset: float = 0, preserve_half_mm_labware: bool = False
+        self, offset: float = 0, preserve_half_mm: bool = False
     ) -> None:
         """Raise the module's magnets up to its loaded labware.
 
         Args:
             offset: Offset from the labware's default engage height.
-            preserve_half_mm_labware: For labware whose definitions
+            preserve_half_mm: For labware whose definitions
                 erroneously use half-mm for their defined default engage height,
                 use the value directly instead of converting it to real millimeters.
 

--- a/api/src/opentrons/protocol_api/core/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/labware.py
@@ -157,7 +157,7 @@ class LabwareImplementation(AbstractLabware[WellImplementation]):
     ) -> Optional[float]:
         """Get the labware's default magnet engage height, if defined.
 
-        Value returned is in real mm's from the labware's base,
+        Value returned is in real millimeters from the labware's base,
         unless `preserve_half_mm` is used, in which case
         some definitions will return half-millimeters.
         """

--- a/api/src/opentrons/protocol_api/core/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/labware.py
@@ -13,12 +13,12 @@ from ..labware import AbstractLabware, LabwareLoadParams
 from .well import WellImplementation
 
 
-# Load names of labware whose definitions accidentally specify an engage height
-# in units of half-millimeters, instead of millimeters.
+# URIs of labware whose definitions accidentally specify an engage height
+# in units of half-millimeters instead of millimeters.
 _MAGDECK_HALF_MM_LABWARE = {
-    "biorad_96_wellplate_200ul_pcr",
-    "nest_96_wellplate_100ul_pcr_full_skirt",
-    "usascientific_96_wellplate_2.4ml_deep",
+    "opentrons/biorad_96_wellplate_200ul_pcr/1",
+    "opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+    "opentrons/usascientific_96_wellplate_2.4ml_deep/1",
 }
 
 
@@ -150,13 +150,15 @@ class LabwareImplementation(AbstractLabware[WellImplementation]):
     def load_name(self) -> str:
         return self._parameters["loadName"]
 
+    # TODO(mc, 2022-09-26): ensure "from the labware's base" is correct
+    # https://github.com/Opentrons/opentrons/issues/10830
     def get_default_magnet_engage_height(
-        self, preserve_half_mm_labware: bool = False
+        self, preserve_half_mm: bool = False
     ) -> Optional[float]:
         """Get the labware's default magnet engage height, if defined.
 
         Value returned is in real mm's from the labware's base,
-        unless `preserve_half_mm_labware` is used, in which case
+        unless `preserve_half_mm` is used, in which case
         some definitions will return half-millimeters.
         """
         is_compatible = self._parameters.get("isMagneticModuleCompatible", False)
@@ -165,8 +167,8 @@ class LabwareImplementation(AbstractLabware[WellImplementation]):
         if not is_compatible or default_engage_height is None:
             return None
 
-        if self.load_name in _MAGDECK_HALF_MM_LABWARE and not preserve_half_mm_labware:
-            return default_engage_height / 2
+        if self.get_uri() in _MAGDECK_HALF_MM_LABWARE and not preserve_half_mm:
+            return default_engage_height / 2.0
 
         return default_engage_height
 

--- a/api/src/opentrons/protocol_api/core/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/labware.py
@@ -150,8 +150,8 @@ class LabwareImplementation(AbstractLabware[WellImplementation]):
     def load_name(self) -> str:
         return self._parameters["loadName"]
 
-    # TODO(mc, 2022-09-26): ensure "from the labware's base" is correct
-    # https://github.com/Opentrons/opentrons/issues/10830
+    # TODO(mc, 2022-09-26): codify "from labware's base" in defintion schema
+    # https://opentrons.atlassian.net/browse/RSS-110
     def get_default_magnet_engage_height(
         self, preserve_half_mm: bool = False
     ) -> Optional[float]:
@@ -168,6 +168,8 @@ class LabwareImplementation(AbstractLabware[WellImplementation]):
             return None
 
         if self.get_uri() in _MAGDECK_HALF_MM_LABWARE and not preserve_half_mm:
+            # TODO(mc, 2022-09-26): this value likely _also_ needs a few mm subtracted
+            # https://opentrons.atlassian.net/browse/RSS-111
             return default_engage_height / 2.0
 
         return default_engage_height

--- a/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
@@ -137,12 +137,14 @@ class LegacyMagneticModuleCore(
     def engage_to_labware(
         self,
         offset: float = 0,
-        preserve_half_mm_labware: bool = False,
+        preserve_half_mm: bool = False,
     ) -> None:
         """Raise the module's magnets up to its loaded labware.
 
         Args:
             offset: Offset from the labware's default engage height.
+            preserve_half_mm: Preserve any values that may accidentally be in half-mm,
+                passing them directly onwards to the hardware control API.
 
         Raises:
             ValueError: Labware is not loaded or has no default engage height.
@@ -157,7 +159,7 @@ class LegacyMagneticModuleCore(
             )
 
         engage_height = labware._implementation.get_default_magnet_engage_height(
-            preserve_half_mm_labware
+            preserve_half_mm
         )
 
         if engage_height is None:
@@ -169,12 +171,13 @@ class LegacyMagneticModuleCore(
 
         if (
             self._geometry.model == MagneticModuleModel.MAGNETIC_V1
-            and not preserve_half_mm_labware
+            and not preserve_half_mm
         ):
             engage_height *= 2
 
         # TODO(mc, 2022-09-23): use real millimeters instead of model-dependent mm
-        # TODO(mc, 2022-09-23): use `height_from_base`
+        # TODO(mc, 2022-09-23): use `height_from_base` to match JSONv5
+        # https://github.com/Opentrons/opentrons/issues/10830
         self._sync_module_hardware.engage(height=engage_height + offset)
 
     def disengage(self) -> None:

--- a/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
@@ -196,7 +196,7 @@ class LegacyMagneticModuleCore(
             name = labware_core.get_name()
             _log.warning(
                 f"Labware {name} is not explicitly compatible with the Magnetic Module."
-                " You will have to specify a height explicitely when calling engage()."
+                " You will have to specify a height explicitly when calling engage()."
             )
 
 

--- a/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
@@ -127,7 +127,8 @@ class LegacyMagneticModuleCore(
             height_from_base: Distance from labware base to raise the magnets.
             height_from_home: Distance from motor home position to raise the magnets.
         """
-        # TODO(mc, 2022-09-23): use real millimeters instead of model-dependent mm
+        # TODO(mc, 2022-09-23): update when HW API uses real millimeters
+        # https://opentrons.atlassian.net/browse/RET-1242
         if height_from_base is not None:
             self._sync_module_hardware.engage(height_from_base=height_from_base)
         else:
@@ -176,8 +177,9 @@ class LegacyMagneticModuleCore(
             engage_height *= 2
 
         # TODO(mc, 2022-09-23): use real millimeters instead of model-dependent mm
+        # https://opentrons.atlassian.net/browse/RET-1242
         # TODO(mc, 2022-09-23): use `height_from_base` to match JSONv5
-        # https://github.com/Opentrons/opentrons/issues/10830
+        # https://opentrons.atlassian.net/browse/RSS-110
         self._sync_module_hardware.engage(height=engage_height + offset)
 
     def disengage(self) -> None:

--- a/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
@@ -195,8 +195,9 @@ class LegacyMagneticModuleCore(
         if labware_core.get_default_magnet_engage_height() is None:
             name = labware_core.get_name()
             _log.warning(
-                f"Labware {name} is not explicitly compatible with the Magnetic Module."
-                " You will have to specify a height explicitly when calling engage()."
+                f"The labware definition for {name} does not define a"
+                " default engagement height for use with the Magnetic Module;"
+                " you must specify a height explicitly when calling engage()."
             )
 
 

--- a/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
@@ -122,11 +122,10 @@ class LegacyMagneticModuleCore(
         """Raise the module's magnets.
 
         Only one of `height_from_base` or `height_from_home` may be specified.
-        All distance units are specified in real millimeters.
 
         Args:
             height_from_base: Distance from labware base to raise the magnets.
-            height_from_base: Distance from motor home position to raise the magnets.
+            height_from_home: Distance from motor home position to raise the magnets.
         """
         # TODO(mc, 2022-09-23): use real millimeters instead of model-dependent mm
         if height_from_base is not None:
@@ -140,9 +139,7 @@ class LegacyMagneticModuleCore(
         offset: float = 0,
         preserve_half_mm_labware: bool = False,
     ) -> None:
-        """Raise the module's magnets its loaded labware.
-
-        All distance units are specified in real millimeters.
+        """Raise the module's magnets up to its loaded labware.
 
         Args:
             offset: Offset from the labware's default engage height.

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -335,6 +335,8 @@ class Labware(DeckItem):
         """Quirks specific to this labware."""
         return self._implementation.get_quirks()
 
+    # TODO(mc, 2022-09-23): use `self._implementation.get_default_magnet_engage_height`
+    # blocked until Labware actually respects API version
     @property  # type: ignore
     @requires_version(2, 0)
     def magdeck_engage_height(self) -> Optional[float]:

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -337,6 +337,7 @@ class Labware(DeckItem):
 
     # TODO(mc, 2022-09-23): use `self._implementation.get_default_magnet_engage_height`
     # blocked until Labware actually respects API version
+    # https://opentrons.atlassian.net/browse/RSS-97
     @property  # type: ignore
     @requires_version(2, 0)
     def magdeck_engage_height(self) -> Optional[float]:

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -437,7 +437,7 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
     @property  # type: ignore
     @requires_version(2, 0)
     def status(self) -> str:
-        """The status of the module; either 'engaged' or 'disengaged'"""
+        """The status of the module: either ``engaged`` or ``disengaged``"""
         return self._core.get_status().value
 
 

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -425,7 +425,7 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
         else:
             self._core.engage_to_labware(
                 offset=offset or 0,
-                preserve_half_mm_labware=self._api_version < APIVersion(2, 3),
+                preserve_half_mm=self._api_version < APIVersion(2, 3),
             )
 
     @publish(command=cmds.magdeck_disengage)

--- a/api/tests/opentrons/hardware_control/integration/test_magdeck.py
+++ b/api/tests/opentrons/hardware_control/integration/test_magdeck.py
@@ -46,3 +46,20 @@ async def test_engage_cycle(magdeck: MagDeck):
         "data": {"engaged": False, "height": 0.0},
         "status": "disengaged",
     }
+
+
+async def test_engage_from_base_cycle(magdeck: MagDeck):
+    """It should cycle engage/disengage, taking the offset from base into account."""
+    await magdeck.engage(height_from_base=1)
+    assert magdeck.current_height == 3.5
+    assert magdeck.live_data == {
+        "data": {"engaged": True, "height": 3.5},
+        "status": "engaged",
+    }
+
+    await magdeck.deactivate()
+    assert magdeck.current_height == 0
+    assert magdeck.live_data == {
+        "data": {"engaged": False, "height": 0.0},
+        "status": "disengaged",
+    }

--- a/api/tests/opentrons/protocol_api/core/legacy/test_magnetic_module_core.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_magnetic_module_core.py
@@ -21,7 +21,7 @@ def mock_geometry(decoy: Decoy) -> ModuleGeometry:
 
 @pytest.fixture
 def mock_sync_module_hardware(decoy: Decoy) -> SynchronousAdapter[MagDeck]:
-    """Get a mock module geometry."""
+    """Get a mock module hardware control interface."""
     return decoy.mock(name="SynchronousAdapater[AbstractModule]")  # type: ignore[no-any-return]
 
 

--- a/api/tests/opentrons/protocol_api/core/legacy/test_magnetic_module_core.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_magnetic_module_core.py
@@ -171,6 +171,6 @@ def test_engage_height_from_labware_with_gen1_preserve_half_mm(
         mock_geometry.labware._implementation.get_default_magnet_engage_height(True)  # type: ignore[union-attr]
     ).then_return(32.0)
 
-    subject.engage_to_labware(offset=10.0, preserve_half_mm_labware=True)
+    subject.engage_to_labware(offset=10.0, preserve_half_mm=True)
 
     decoy.verify(mock_sync_module_hardware.engage(height=42.0), times=1)

--- a/api/tests/opentrons/protocol_api/core/legacy/test_magnetic_module_core.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_magnetic_module_core.py
@@ -1,0 +1,75 @@
+"""Tests for the legacy Protocol API module core implementations."""
+import pytest
+from decoy import Decoy
+
+from opentrons.hardware_control import SynchronousAdapter
+from opentrons.hardware_control.modules import MagDeck, MagneticStatus
+from opentrons.hardware_control.modules.types import MagneticModuleModel
+from opentrons.protocols.geometry.module_geometry import ModuleGeometry
+
+from opentrons.protocol_api.core.protocol_api.legacy_module_core import (
+    LegacyMagneticModuleCore,
+    create_module_core,
+)
+
+
+@pytest.fixture
+def mock_geometry(decoy: Decoy) -> ModuleGeometry:
+    """Get a mock module geometry."""
+    return decoy.mock(cls=ModuleGeometry)
+
+
+@pytest.fixture
+def mock_sync_module_hardware(decoy: Decoy) -> SynchronousAdapter[MagDeck]:
+    """Get a mock module geometry."""
+    return decoy.mock(name="SynchronousAdapater[AbstractModule]")  # type: ignore[no-any-return]
+
+
+@pytest.fixture
+def subject(
+    mock_geometry: ModuleGeometry,
+    mock_sync_module_hardware: SynchronousAdapter[MagDeck],
+) -> LegacyMagneticModuleCore:
+    """Get a legacy module implementation core with mocked out dependencies."""
+    return LegacyMagneticModuleCore(
+        requested_model=MagneticModuleModel.MAGNETIC_V1,
+        geometry=mock_geometry,
+        sync_module_hardware=mock_sync_module_hardware,
+    )
+
+
+def test_create(
+    decoy: Decoy,
+    mock_geometry: ModuleGeometry,
+) -> None:
+    """It should be able to create a magnetic module core."""
+    mock_module_hardware_api = decoy.mock(cls=MagDeck)
+    result = create_module_core(
+        geometry=mock_geometry,
+        module_hardware_api=mock_module_hardware_api,
+        requested_model=MagneticModuleModel.MAGNETIC_V1,
+    )
+
+    assert isinstance(result, LegacyMagneticModuleCore)
+
+
+def test_disengage(
+    decoy: Decoy,
+    mock_sync_module_hardware: SynchronousAdapter[MagDeck],
+    subject: LegacyMagneticModuleCore,
+) -> None:
+    """It should disengage by calling the hardware API."""
+    subject.disengage()
+
+    decoy.verify(mock_sync_module_hardware.deactivate(), times=1)
+
+
+def test_get_status(
+    decoy: Decoy,
+    mock_sync_module_hardware: SynchronousAdapter[MagDeck],
+    subject: LegacyMagneticModuleCore,
+) -> None:
+    """It should report the hardware status."""
+    decoy.when(mock_sync_module_hardware.status).then_return(MagneticStatus.DISENGAGED)
+    result = subject.get_status()
+    assert result == MagneticStatus.DISENGAGED

--- a/api/tests/opentrons/protocol_api/core/legacy/test_magnetic_module_core.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_magnetic_module_core.py
@@ -73,3 +73,104 @@ def test_get_status(
     decoy.when(mock_sync_module_hardware.status).then_return(MagneticStatus.DISENGAGED)
     result = subject.get_status()
     assert result == MagneticStatus.DISENGAGED
+
+
+def test_engage_height_from_home(
+    decoy: Decoy,
+    mock_sync_module_hardware: SynchronousAdapter[MagDeck],
+    subject: LegacyMagneticModuleCore,
+) -> None:
+    """It should engage height from home."""
+    subject.engage(height_from_home=42.0)
+
+    decoy.verify(mock_sync_module_hardware.engage(height=42.0), times=1)
+
+
+def test_engage_height_from_base(
+    decoy: Decoy,
+    mock_sync_module_hardware: SynchronousAdapter[MagDeck],
+    subject: LegacyMagneticModuleCore,
+) -> None:
+    """It should engage height from base."""
+    subject.engage(height_from_base=42.0)
+
+    decoy.verify(mock_sync_module_hardware.engage(height_from_base=42.0), times=1)
+
+
+def test_engage_height_from_labware(
+    decoy: Decoy,
+    mock_geometry: ModuleGeometry,
+    mock_sync_module_hardware: SynchronousAdapter[MagDeck],
+    subject: LegacyMagneticModuleCore,
+) -> None:
+    """It should engage height from the labware's defined position."""
+    decoy.when(
+        mock_geometry.labware._implementation.get_default_magnet_engage_height(False)  # type: ignore[union-attr]
+    ).then_return(32.0)
+
+    subject.engage_to_labware(offset=10.0)
+
+    decoy.verify(mock_sync_module_hardware.engage(height=42.0), times=1)
+
+
+def test_engage_height_from_labware_no_labware(
+    decoy: Decoy,
+    mock_geometry: ModuleGeometry,
+    subject: LegacyMagneticModuleCore,
+) -> None:
+    """It should raise if no labware is loaded."""
+    decoy.when(mock_geometry.labware).then_return(None)
+
+    with pytest.raises(ValueError):
+        subject.engage_to_labware()
+
+
+def test_engage_height_from_labware_no_engage_height(
+    decoy: Decoy,
+    mock_geometry: ModuleGeometry,
+    subject: LegacyMagneticModuleCore,
+) -> None:
+    """It should raise if the labware is not magnetic module compatible."""
+    decoy.when(
+        mock_geometry.labware._implementation.get_default_magnet_engage_height(),  # type: ignore[union-attr]
+        ignore_extra_args=True,
+    ).then_return(None)
+
+    with pytest.raises(ValueError):
+        subject.engage_to_labware()
+
+
+def test_engage_height_from_labware_with_gen1(
+    decoy: Decoy,
+    mock_geometry: ModuleGeometry,
+    mock_sync_module_hardware: SynchronousAdapter[MagDeck],
+    subject: LegacyMagneticModuleCore,
+) -> None:
+    """It should double the labware's height if it's a GEN1 magdeck."""
+    decoy.when(mock_geometry.model).then_return(MagneticModuleModel.MAGNETIC_V1)
+
+    decoy.when(
+        mock_geometry.labware._implementation.get_default_magnet_engage_height(False)  # type: ignore[union-attr]
+    ).then_return(32.0)
+
+    subject.engage_to_labware(offset=10.0)
+
+    decoy.verify(mock_sync_module_hardware.engage(height=74.0), times=1)
+
+
+def test_engage_height_from_labware_with_gen1_preserve_half_mm(
+    decoy: Decoy,
+    mock_geometry: ModuleGeometry,
+    mock_sync_module_hardware: SynchronousAdapter[MagDeck],
+    subject: LegacyMagneticModuleCore,
+) -> None:
+    """It should not double the labware's height if told to preserve half-mm."""
+    decoy.when(mock_geometry.model).then_return(MagneticModuleModel.MAGNETIC_V1)
+
+    decoy.when(
+        mock_geometry.labware._implementation.get_default_magnet_engage_height(True)  # type: ignore[union-attr]
+    ).then_return(32.0)
+
+    subject.engage_to_labware(offset=10.0, preserve_half_mm_labware=True)
+
+    decoy.verify(mock_sync_module_hardware.engage(height=42.0), times=1)

--- a/api/tests/opentrons/protocol_api/test_magnetic_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_magnetic_module_context.py
@@ -149,4 +149,5 @@ def test_engage_offset_from_default_low_version(
 
     decoy.verify(
         mock_core.engage_to_labware(offset=42.0, preserve_half_mm_labware=True),
+        times=1,
     )

--- a/api/tests/opentrons/protocol_api/test_magnetic_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_magnetic_module_context.py
@@ -118,6 +118,7 @@ def test_engage_height_from_base(
     )
 
 
+@pytest.mark.parametrize("api_version", [APIVersion(2, 3)])
 def test_engage_offset_from_default(
     decoy: Decoy,
     mock_broker: Broker,
@@ -132,6 +133,20 @@ def test_engage_offset_from_default(
             "command",
             matchers.DictMatching({"$": "before", "name": "command.MAGDECK_ENGAGE"}),
         ),
-        mock_core.engage(offset_from_labware_default=42.0),
+        mock_core.engage_to_labware(offset=42.0, preserve_half_mm_labware=False),
         mock_broker.publish("command", matchers.DictMatching({"$": "after"})),
+    )
+
+
+@pytest.mark.parametrize("api_version", [APIVersion(2, 2)])
+def test_engage_offset_from_default_low_version(
+    decoy: Decoy,
+    mock_core: MagneticModuleCore,
+    subject: MagneticModuleContext,
+) -> None:
+    """It should engage if given a height from the base."""
+    subject.engage(offset=42.0)
+
+    decoy.verify(
+        mock_core.engage_to_labware(offset=42.0, preserve_half_mm_labware=True),
     )

--- a/api/tests/opentrons/protocol_api/test_magnetic_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_magnetic_module_context.py
@@ -1,0 +1,137 @@
+"""Tests for Protocol API temperature module contexts."""
+import pytest
+from decoy import Decoy, matchers
+
+from opentrons.broker import Broker
+from opentrons.hardware_control.modules import MagneticStatus
+from opentrons.protocols.api_support.types import APIVersion
+from opentrons.protocol_api import MAX_SUPPORTED_VERSION, MagneticModuleContext
+
+from .types import ProtocolCore, MagneticModuleCore
+
+
+@pytest.fixture
+def mock_core(decoy: Decoy) -> MagneticModuleCore:
+    """Get a mock module implementation core."""
+    return decoy.mock(cls=MagneticModuleCore)
+
+
+@pytest.fixture
+def mock_protocol_core(decoy: Decoy) -> ProtocolCore:
+    """Get a mock protocol implementation core."""
+    return decoy.mock(cls=ProtocolCore)
+
+
+@pytest.fixture
+def mock_broker(decoy: Decoy) -> Broker:
+    """Get a mock command message broker."""
+    return decoy.mock(cls=Broker)
+
+
+@pytest.fixture
+def api_version() -> APIVersion:
+    """Get an API version to apply to the interface."""
+    return MAX_SUPPORTED_VERSION
+
+
+@pytest.fixture
+def subject(
+    api_version: APIVersion,
+    mock_core: MagneticModuleCore,
+    mock_protocol_core: ProtocolCore,
+    mock_broker: Broker,
+) -> MagneticModuleContext:
+    """Get a temperature module context with its dependencies mocked out."""
+    return MagneticModuleContext(
+        core=mock_core,
+        protocol_core=mock_protocol_core,
+        broker=mock_broker,
+        api_version=api_version,
+    )
+
+
+def test_disengage(
+    decoy: Decoy,
+    mock_core: MagneticModuleCore,
+    mock_broker: Broker,
+    subject: MagneticModuleContext,
+) -> None:
+    """It should set and wait for the temperature via the core."""
+    subject.disengage()
+
+    decoy.verify(
+        mock_broker.publish(
+            "command",
+            matchers.DictMatching({"$": "before", "name": "command.MAGDECK_DISENGAGE"}),
+        ),
+        mock_core.disengage(),
+        mock_broker.publish("command", matchers.DictMatching({"$": "after"})),
+    )
+
+
+def test_get_status(
+    decoy: Decoy, mock_core: MagneticModuleCore, subject: MagneticModuleContext
+) -> None:
+    """It should report the status from the core."""
+    decoy.when(mock_core.get_status()).then_return(MagneticStatus.DISENGAGED)
+
+    result = subject.status
+
+    assert result == "disengaged"
+
+
+def test_engage_height_from_home(
+    decoy: Decoy,
+    mock_broker: Broker,
+    mock_core: MagneticModuleCore,
+    subject: MagneticModuleContext,
+) -> None:
+    """It should engage if given a raw motor height."""
+    subject.engage(height=42.0)
+
+    decoy.verify(
+        mock_broker.publish(
+            "command",
+            matchers.DictMatching({"$": "before", "name": "command.MAGDECK_ENGAGE"}),
+        ),
+        mock_core.engage(height_from_home=42.0),
+        mock_broker.publish("command", matchers.DictMatching({"$": "after"})),
+    )
+
+
+def test_engage_height_from_base(
+    decoy: Decoy,
+    mock_broker: Broker,
+    mock_core: MagneticModuleCore,
+    subject: MagneticModuleContext,
+) -> None:
+    """It should engage if given a height from the base."""
+    subject.engage(height_from_base=42.0)
+
+    decoy.verify(
+        mock_broker.publish(
+            "command",
+            matchers.DictMatching({"$": "before", "name": "command.MAGDECK_ENGAGE"}),
+        ),
+        mock_core.engage(height_from_base=42.0),
+        mock_broker.publish("command", matchers.DictMatching({"$": "after"})),
+    )
+
+
+def test_engage_offset_from_default(
+    decoy: Decoy,
+    mock_broker: Broker,
+    mock_core: MagneticModuleCore,
+    subject: MagneticModuleContext,
+) -> None:
+    """It should engage if given a height from the base."""
+    subject.engage(offset=42.0)
+
+    decoy.verify(
+        mock_broker.publish(
+            "command",
+            matchers.DictMatching({"$": "before", "name": "command.MAGDECK_ENGAGE"}),
+        ),
+        mock_core.engage(offset_from_labware_default=42.0),
+        mock_broker.publish("command", matchers.DictMatching({"$": "after"})),
+    )

--- a/api/tests/opentrons/protocol_api/test_magnetic_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_magnetic_module_context.py
@@ -1,4 +1,4 @@
-"""Tests for Protocol API temperature module contexts."""
+"""Tests for Protocol API magnetic module contexts."""
 import pytest
 from decoy import Decoy, matchers
 
@@ -41,7 +41,7 @@ def subject(
     mock_protocol_core: ProtocolCore,
     mock_broker: Broker,
 ) -> MagneticModuleContext:
-    """Get a temperature module context with its dependencies mocked out."""
+    """Get a magnetic module context with its dependencies mocked out."""
     return MagneticModuleContext(
         core=mock_core,
         protocol_core=mock_protocol_core,
@@ -56,7 +56,7 @@ def test_disengage(
     mock_broker: Broker,
     subject: MagneticModuleContext,
 ) -> None:
-    """It should set and wait for the temperature via the core."""
+    """It should disengage magnets via the core."""
     subject.disengage()
 
     decoy.verify(
@@ -125,7 +125,7 @@ def test_engage_offset_from_default(
     mock_core: MagneticModuleCore,
     subject: MagneticModuleContext,
 ) -> None:
-    """It should engage if given a height from the base."""
+    """It should engage from a labware's default engage height."""
     subject.engage(offset=42.0)
 
     decoy.verify(
@@ -144,7 +144,7 @@ def test_engage_offset_from_default_low_version(
     mock_core: MagneticModuleCore,
     subject: MagneticModuleContext,
 ) -> None:
-    """It should engage if given a height from the base."""
+    """It should preserve pre-2.3 buggy labware engage height behavior."""
     subject.engage(offset=42.0)
 
     decoy.verify(

--- a/api/tests/opentrons/protocol_api/test_magnetic_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_magnetic_module_context.py
@@ -133,7 +133,7 @@ def test_engage_offset_from_default(
             "command",
             matchers.DictMatching({"$": "before", "name": "command.MAGDECK_ENGAGE"}),
         ),
-        mock_core.engage_to_labware(offset=42.0, preserve_half_mm_labware=False),
+        mock_core.engage_to_labware(offset=42.0, preserve_half_mm=False),
         mock_broker.publish("command", matchers.DictMatching({"$": "after"})),
     )
 
@@ -148,6 +148,6 @@ def test_engage_offset_from_default_low_version(
     subject.engage(offset=42.0)
 
     decoy.verify(
-        mock_core.engage_to_labware(offset=42.0, preserve_half_mm_labware=True),
+        mock_core.engage_to_labware(offset=42.0, preserve_half_mm=True),
         times=1,
     )

--- a/api/tests/opentrons/protocol_api/test_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_module_context.py
@@ -99,6 +99,7 @@ def test_load_labware(
     )
 
     assert result is mock_labware
+    decoy.verify(mock_core.add_labware_core(mock_labware_core), times=1)
     decoy.verify(mock_deck.recalculate_high_z(), times=1)
 
 

--- a/api/tests/opentrons/protocol_api/types.py
+++ b/api/tests/opentrons/protocol_api/types.py
@@ -5,6 +5,7 @@ from opentrons.protocol_api.core.labware import AbstractLabware
 from opentrons.protocol_api.core.module import (
     AbstractModuleCore,
     AbstractTemperatureModuleCore,
+    AbstractMagneticModuleCore,
 )
 from opentrons.protocol_api.core.well import AbstractWellCore
 
@@ -13,4 +14,5 @@ InstrumentCore = AbstractInstrument[AbstractWellCore]
 LabwareCore = AbstractLabware[AbstractWellCore]
 ModuleCore = AbstractModuleCore[LabwareCore]
 TemperatureModuleCore = AbstractTemperatureModuleCore[LabwareCore]
+MagneticModuleCore = AbstractMagneticModuleCore[LabwareCore]
 ProtocolCore = AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]

--- a/api/tests/opentrons/protocol_api_old/test_module_context.py
+++ b/api/tests/opentrons/protocol_api_old/test_module_context.py
@@ -188,13 +188,6 @@ def test_magdeck(ctx_with_magdeck, mock_module_controller):
     assert ctx_with_magdeck.deck[1] == mod.geometry
 
 
-def test_magdeck_engage_no_height_no_labware(ctx_with_magdeck, mock_module_controller):
-    """It should raise an error."""
-    mod = ctx_with_magdeck.load_module("Magnetic Module", 1)
-    with pytest.raises(ValueError):
-        mod.engage()
-
-
 def test_magdeck_calibrate(ctx_with_magdeck, mock_module_controller):
     mod = ctx_with_magdeck.load_module("Magnetic Module", 1)
     mod.calibrate()
@@ -801,7 +794,6 @@ def test_deprecated_module_load_labware_by_name(ctx_with_tempdeck):
     )
 
 
-@pytest.mark.xfail(strict=True, raises=NotImplementedError)
 async def test_magdeck_gen1_labware_props(ctx):
     # TODO Ian 2019-05-29 load fixtures, not real defs
     labware_name = "biorad_96_wellplate_200ul_pcr"
@@ -842,7 +834,6 @@ async def test_magdeck_gen1_labware_props(ctx):
     )
 
 
-@pytest.mark.xfail(strict=True, raises=NotImplementedError)
 def test_magdeck_gen2_labware_props(ctx):
     mod = ctx.load_module("magnetic module gen2", 1)
     mod.engage(height=25)

--- a/api/tests/opentrons/protocol_api_old/test_module_context.py
+++ b/api/tests/opentrons/protocol_api_old/test_module_context.py
@@ -188,42 +188,11 @@ def test_magdeck(ctx_with_magdeck, mock_module_controller):
     assert ctx_with_magdeck.deck[1] == mod.geometry
 
 
-def test_magdeck_status(ctx_with_magdeck, mock_module_controller):
-    mod = ctx_with_magdeck.load_module("Magnetic Module", 1)
-    m = mock.PropertyMock(return_value="disengaged")
-    type(mock_module_controller).status = m
-    assert mod.status == "disengaged"
-
-
 def test_magdeck_engage_no_height_no_labware(ctx_with_magdeck, mock_module_controller):
     """It should raise an error."""
     mod = ctx_with_magdeck.load_module("Magnetic Module", 1)
     with pytest.raises(ValueError):
         mod.engage()
-
-
-def test_magdeck_engage_with_height(ctx_with_magdeck, mock_module_controller):
-    mod = ctx_with_magdeck.load_module("Magnetic Module", 1)
-    mod.engage(height=2)
-    assert "engaging magnetic" in ",".join(
-        cmd.lower() for cmd in ctx_with_magdeck.commands()
-    )
-    mock_module_controller.engage.assert_called_once_with(2)
-
-
-def test_magdeck_engage_with_height_from_base(ctx_with_magdeck, mock_module_controller):
-    mod = ctx_with_magdeck.load_module("Magnetic Module", 1)
-    mod.engage(height_from_base=2)
-    mock_module_controller.engage.assert_called_once_with(7)
-
-
-def test_magdeck_disengage(ctx_with_magdeck, mock_module_controller):
-    mod = ctx_with_magdeck.load_module("Magnetic Module", 1)
-    mod.disengage()
-    assert "disengaging magnetic" in ",".join(
-        cmd.lower() for cmd in ctx_with_magdeck.commands()
-    )
-    mock_module_controller.deactivate.assert_called_once_with()
 
 
 def test_magdeck_calibrate(ctx_with_magdeck, mock_module_controller):
@@ -832,6 +801,7 @@ def test_deprecated_module_load_labware_by_name(ctx_with_tempdeck):
     )
 
 
+@pytest.mark.xfail(strict=True, raises=NotImplementedError)
 async def test_magdeck_gen1_labware_props(ctx):
     # TODO Ian 2019-05-29 load fixtures, not real defs
     labware_name = "biorad_96_wellplate_200ul_pcr"
@@ -872,6 +842,7 @@ async def test_magdeck_gen1_labware_props(ctx):
     )
 
 
+@pytest.mark.xfail(strict=True, raises=NotImplementedError)
 def test_magdeck_gen2_labware_props(ctx):
     mod = ctx.load_module("magnetic module gen2", 1)
     mod.engage(height=25)


### PR DESCRIPTION
## Overview

This PR continues work on RCORE-103 by moving Magnetic Module hardware interactions to a `MagneticModuleCore` interface.

## Changelog

- Defined and add `AbstractMagneticModuleCore` interface
- Add concrete `LegacyMagneticModuleCore` implementation with methods to:
    - Disengage the module
    - Engage the module in various ways (height from base, height from home, offset from labware)
    - Get the module's status
- Refactor `MagneticModuleContext` to talk to its core rather than directly to the hardware API
- Deprecate `MagneticModuleContext.calibrate` per discussion in Slack

## Review requests

Smoke testing with real magnetic module hardware is required for this one. For best results, compare `engage` heights using calipers between this branch and `edge`.

- [ ] `mag_module.engage(height=...)`
- [ ] `mag_module.engage(height_from_base=...)`
- [ ] `mag_module.engage(offset=...)`
    - [ ] Gen 1 with real-mm labware (e.g. `nest_96_wellplate_2ml_deep`)
    - [ ] Gen 1 with half-mm labware (e.g. `biorad_96_wellplate_200ul_pcr`)
    - [ ] Gen 2 with real-mm labware (e.g. `nest_96_wellplate_2ml_deep`)
    - [ ] Gen 2 with half-mm labware (e.g. `biorad_96_wellplate_200ul_pcr`)

Tests for `mag_module.engage(offset=...)` should be compared on both PAPIv2.2 and PAPIv2.3, which is the version breakpoint where half-mm started to get accounted for.

## Risk assessment

Medium. The magnetic module interface and behavior is quite confusing due to historical and existing bugs. I took care to preserve existing behavior, even where known to be buggy, but it's possible I missed something.