### PR TITLE
refactor(api): update OT3 gripper testing script

### DIFF
--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -123,7 +123,7 @@ DEFAULT_MAX_SPEED_DISCONTINUITY: Final[
         OT3AxisKind.X: 90,
         OT3AxisKind.Y: 90,
         OT3AxisKind.Z: 40,
-        OT3AxisKind.Z_G: 20,
+        OT3AxisKind.Z_G: 15,
         OT3AxisKind.P: 10,
     },
     high_throughput={

--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -119,10 +119,10 @@ DEFAULT_MAX_SPEED_DISCONTINUITY: Final[
     ByGantryLoad[Dict[OT3AxisKind, float]]
 ] = ByGantryLoad(
     none={
-        OT3AxisKind.X: 10,
-        OT3AxisKind.Y: 10,
-        OT3AxisKind.Z: 10,
-        OT3AxisKind.Z_G: 10,
+        OT3AxisKind.X: 90,
+        OT3AxisKind.Y: 90,
+        OT3AxisKind.Z: 40,
+        OT3AxisKind.Z_G: 20,
         OT3AxisKind.P: 10,
     },
     high_throughput={

--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -83,7 +83,7 @@ DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad
         OT3AxisKind.X: 500,
         OT3AxisKind.Y: 500,
     },
-    gripper={OT3AxisKind.Z: 350, OT3AxisKind.Z_G: 100},
+    gripper={OT3AxisKind.Z: 350},
 )
 
 DEFAULT_ACCELERATIONS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad(
@@ -213,7 +213,7 @@ DEFAULT_RUN_CURRENT: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoa
         OT3AxisKind.Y: 1.4,
         OT3AxisKind.Z: 1.4,
         OT3AxisKind.P: 1.0,
-        OT3AxisKind.Z_G: 0.67,
+        OT3AxisKind.Z_G: 0.7,
     },
     high_throughput={
         OT3AxisKind.X: 1.4,

--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -83,7 +83,7 @@ DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad
         OT3AxisKind.X: 500,
         OT3AxisKind.Y: 500,
     },
-    gripper={OT3AxisKind.Z: 350},
+    gripper={OT3AxisKind.Z: 200},
 )
 
 DEFAULT_ACCELERATIONS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad(

--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -65,7 +65,7 @@ DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad
         OT3AxisKind.Y: 500,
         OT3AxisKind.Z: 200,
         OT3AxisKind.P: 45,
-        OT3AxisKind.Z_G: 200,
+        OT3AxisKind.Z_G: 120,
     },
     high_throughput={
         OT3AxisKind.X: 500,
@@ -83,7 +83,7 @@ DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad
         OT3AxisKind.X: 500,
         OT3AxisKind.Y: 500,
     },
-    gripper={OT3AxisKind.Z: 200, OT3AxisKind.Z_G: 200},
+    gripper={OT3AxisKind.Z: 350, OT3AxisKind.Z_G: 120},
 )
 
 DEFAULT_ACCELERATIONS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad(

--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -65,7 +65,7 @@ DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad
         OT3AxisKind.Y: 500,
         OT3AxisKind.Z: 200,
         OT3AxisKind.P: 45,
-        OT3AxisKind.Z_G: 120,
+        OT3AxisKind.Z_G: 100,
     },
     high_throughput={
         OT3AxisKind.X: 500,
@@ -83,7 +83,7 @@ DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad
         OT3AxisKind.X: 500,
         OT3AxisKind.Y: 500,
     },
-    gripper={OT3AxisKind.Z: 350, OT3AxisKind.Z_G: 120},
+    gripper={OT3AxisKind.Z: 350, OT3AxisKind.Z_G: 100},
 )
 
 DEFAULT_ACCELERATIONS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad(
@@ -93,6 +93,7 @@ DEFAULT_ACCELERATIONS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryL
         OT3AxisKind.Z: 500,
         OT3AxisKind.P: 50,
         OT3AxisKind.Z_G: 100,
+        OT3AxisKind.Z_G: 20,
     },
     high_throughput={
         OT3AxisKind.X: 1000,
@@ -183,7 +184,7 @@ DEFAULT_HOLD_CURRENT: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLo
         OT3AxisKind.Y: 0.1,
         OT3AxisKind.Z: 0.1,
         OT3AxisKind.P: 0.3,
-        OT3AxisKind.Z_G: 0.1,
+        OT3AxisKind.Z_G: 0.2,
     },
     high_throughput={
         OT3AxisKind.X: 0.1,
@@ -212,7 +213,7 @@ DEFAULT_RUN_CURRENT: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoa
         OT3AxisKind.Y: 1.4,
         OT3AxisKind.Z: 1.4,
         OT3AxisKind.P: 1.0,
-        OT3AxisKind.Z_G: 1.4,
+        OT3AxisKind.Z_G: 0.67,
     },
     high_throughput={
         OT3AxisKind.X: 1.4,

--- a/api/src/opentrons/config/gripper_config.py
+++ b/api/src/opentrons/config/gripper_config.py
@@ -18,6 +18,17 @@ log = logging.getLogger(__name__)
 DEFAULT_GRIPPER_CALIBRATION_OFFSET = [0.0, 0.0, 0.0]
 
 
+"""
+Gripper load measurement
+========================
+10/13/2022
+
+To lift a 1.5 kg load,
+the velocity should be 19 mm/s & acceleration at 19 mm/s^2.
+Run current: 0.7 A and Hold current: 0.2 A.
+"""
+
+
 @dataclass(frozen=True)
 class GripperConfig:
     display_name: str

--- a/api/src/opentrons/config/gripper_config.py
+++ b/api/src/opentrons/config/gripper_config.py
@@ -48,8 +48,9 @@ def _get_offset(def_offset: GripperOffset) -> Offset:
 
 
 def info_num_to_model(num: str) -> GripperModel:
+    major_model = num[0]
     model_map = {"0": GripperModel.V1, "1": GripperModel.V1}
-    return model_map[num]
+    return model_map[major_model]
 
 
 def load(

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -364,7 +364,10 @@ class OT3Controller:
     ) -> None:
         move_group = create_gripper_jaw_grip_group(duty_cycle, stop_condition)
         runner = MoveGroupRunner(move_groups=[move_group])
-        await runner.run(can_messenger=self._messenger)
+        positions = await runner.run(can_messenger=self._messenger)
+        for axis, point in positions.items():
+            self._position.update({axis: point[0]})
+            self._encoder_position.update({axis: point[1]})
 
     async def gripper_hold_jaw(
         self,
@@ -372,12 +375,18 @@ class OT3Controller:
     ) -> None:
         move_group = create_gripper_jaw_hold_group(encoder_position_um)
         runner = MoveGroupRunner(move_groups=[move_group])
-        await runner.run(can_messenger=self._messenger)
+        positions = await runner.run(can_messenger=self._messenger)
+        for axis, point in positions.items():
+            self._position.update({axis: point[0]})
+            self._encoder_position.update({axis: point[1]})
 
     async def gripper_home_jaw(self) -> None:
         move_group = create_gripper_jaw_home_group()
         runner = MoveGroupRunner(move_groups=[move_group])
-        await runner.run(can_messenger=self._messenger)
+        positions = await runner.run(can_messenger=self._messenger)
+        for axis, point in positions.items():
+            self._position.update({axis: point[0]})
+            self._encoder_position.update({axis: point[1]})
 
     @staticmethod
     def _synthesize_model_name(name: FirmwarePipetteName, model: str) -> "PipetteModel":

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1006,6 +1006,8 @@ class OT3API(
         """Move the gripper jaw inward to close."""
         try:
             await self._backend.gripper_grip_jaw(duty_cycle=duty_cycle)
+            encoder_pos = await self._backend.update_encoder_position()
+            self._encoder_current_position.update(encoder_pos)
         except Exception:
             self._log.exception("Gripper grip failed")
             raise
@@ -1015,6 +1017,8 @@ class OT3API(
         """Move the gripper jaw outward to reach the homing switch."""
         try:
             await self._backend.gripper_home_jaw()
+            encoder_pos = await self._backend.update_encoder_position()
+            self._encoder_current_position.update(encoder_pos)
         except Exception:
             self._log.exception("Gripper home failed")
             raise
@@ -1040,6 +1044,8 @@ class OT3API(
                     / 2
                 )
             )
+            encoder_pos = await self._backend.update_encoder_position()
+            self._encoder_current_position.update(encoder_pos)
         except Exception:
             self._log.exception("Gripper set width failed")
             raise

--- a/api/src/opentrons/hardware_control/scripts/gripper_control.py
+++ b/api/src/opentrons/hardware_control/scripts/gripper_control.py
@@ -17,6 +17,8 @@ class InvalidInput(Exception):
     """Invalid input exception."""
 
     pass
+
+
 VERSION = 2.0
 MOUNT = OT3Mount.GRIPPER
 deck_def = load_deck_def("ot3_standard", version=3)

--- a/api/src/opentrons/hardware_control/scripts/gripper_control.py
+++ b/api/src/opentrons/hardware_control/scripts/gripper_control.py
@@ -159,7 +159,7 @@ if __name__ == "__main__":
     hc_api = build_api()
 
     from_slot = args.origin
-    grip_force = args.grip_froce
+    grip_force = args.grip_force
     grip_height = args.grip_height
     repeats = args.repeats
 

--- a/api/src/opentrons/hardware_control/scripts/gripper_control.py
+++ b/api/src/opentrons/hardware_control/scripts/gripper_control.py
@@ -12,6 +12,12 @@ from opentrons.types import Point  # noqa: E402
 from opentrons_shared_data.deck import load as load_deck_def  # noqa: E402
 
 
+class InvalidInput(Exception):
+    """Invalid input exception."""
+
+    pass
+
+
 VERSION = 2.0
 MOUNT = OT3Mount.GRIPPER
 deck_def = load_deck_def("ot3_standard", version=3)

--- a/api/src/opentrons/hardware_control/scripts/gripper_control.py
+++ b/api/src/opentrons/hardware_control/scripts/gripper_control.py
@@ -1,5 +1,6 @@
 import sys
 import datetime
+import enum
 
 sys.path.append("/opt/opentrons-robot-server")
 
@@ -11,17 +12,19 @@ from opentrons.types import Point  # noqa: E402
 from opentrons_shared_data.deck import load as load_deck_def  # noqa: E402
 
 
-VERSION = 1.0
+VERSION = 2.0
 MOUNT = OT3Mount.GRIPPER
 deck_def = load_deck_def("ot3_standard", version=3)
 # Offset of the center of the gripper jaw to the desired location
-GRIPPER_OFFSET = Point(0.0, 2.65, 0.0)
+GRIPPER_OFFSET = Point(0.0, 1.0, 0.0)
+AVAILABLE_SLOTS = [1, 3, 4, 9, 12]
 
 
-class InvalidInput(Exception):
-    """Invalid input exception."""
-
-    pass
+class GripperState(enum.Enum):
+    UNGRIPPING = enum.auto()
+    GRIPPING = enum.auto()
+    Z_HOMED = enum.auto()
+    Z_LOWERED = enum.auto()
 
 
 def prompt_int_input(prompt_name: str) -> int:
@@ -73,6 +76,7 @@ def print_current_state(
     api: ThreadManager[HardwareControlAPI],
     cycle_index: int,
     slot: int,
+    jaw_state: GripperState,
 ) -> None:
     """
     1. timestamp
@@ -80,7 +84,7 @@ def print_current_state(
     3. current slot
     4. gripper position (X, Y, Z_G)
     5. gripper state: open/closed
-    6. encoder position (X, Y, G)
+    6. encoder positions (X, Y, G)
     """
     gripper = api.sync._gripper_handler.get_gripper()
 
@@ -91,73 +95,72 @@ def print_current_state(
     enc_loc = (enc_pos[OT3Axis.X], enc_pos[OT3Axis.Y], enc_pos[OT3Axis.G])
     print(
         f"{datetime.datetime.now()}, {cycle_index}, {slot}, "
-        f"{gripper_loc}, {gripper.state}, {enc_loc}\n"
+        f"{gripper_loc}, {jaw_state}, {enc_loc}\n"
     )
 
 
 if __name__ == "__main__":
+    hc_api = build_api()
+
     from_slot = prompt_int_input("Origin slot (1-12)")
-    to_slot = prompt_int_input("Destination slot (1-12)")
+    assert (
+        from_slot in AVAILABLE_SLOTS
+    ), "Please specify one of these available slots: 1, 3, 4, 9, 12"
     grip_force = prompt_float_input("Force in Newton to grip the labware (rec: 20 N)")
     grip_height = prompt_float_input(
         "Z-height from the deck in mm to grip labware (rec: 25 mm)"
-    )
-    return_to_origin = prompt_bool_input(
-        "Do you want the gripper to return the plate to the origin slot? True or False"
     )
     repeats = prompt_int_input(
         "How many times do you want this script to repeat? Type 0 if you only want to run the script once"
     )
 
-    hc_api = build_api()
     api = hc_api.sync
     api.home()
     homed_pos = api.gantry_position(MOUNT)
 
     from_slot_loc = get_slot_center_in_deck_coord(from_slot) + GRIPPER_OFFSET
-    to_slot_loc = get_slot_center_in_deck_coord(to_slot) + GRIPPER_OFFSET
+
+    AVAILABLE_SLOTS.remove(from_slot)
 
     for cycle in range(repeats + 1):
-        # move to pick up position at origin slot
-        api.move_to(MOUNT, from_slot_loc._replace(z=homed_pos.z))
-        api.move_to(MOUNT, from_slot_loc._replace(z=grip_height))
-        print_current_state(hc_api, cycle, from_slot)
+        for slot_index, to_slot in enumerate(AVAILABLE_SLOTS):
+            to_slot_loc = get_slot_center_in_deck_coord(to_slot) + GRIPPER_OFFSET
+            if cycle == 0 and slot_index == 0:
+                # move to pick up position at origin slot
+                api.move_to(MOUNT, from_slot_loc._replace(z=homed_pos.z))
+                print_current_state(hc_api, cycle, from_slot, GripperState.Z_HOMED)
+                api.move_to(MOUNT, from_slot_loc._replace(z=grip_height))
+                print_current_state(hc_api, cycle, from_slot, GripperState.Z_LOWERED)
 
-        api.grip(grip_force)
-        api.delay(1)
-        print_current_state(hc_api, cycle, from_slot)
+            api.grip(grip_force)
+            api.delay(1)
+            print_current_state(hc_api, cycle, from_slot, GripperState.GRIPPING)
 
-        # move to drop off position at destination slot
-        api.move_to(MOUNT, from_slot_loc._replace(z=homed_pos.z))
-        api.move_to(MOUNT, to_slot_loc._replace(z=homed_pos.z))
-        api.move_to(MOUNT, to_slot_loc._replace(z=grip_height))
-        print_current_state(hc_api, cycle, from_slot)
-
-        api.ungrip()
-        api.delay(1)
-        print_current_state(hc_api, cycle, from_slot)
-
-        api.move_to(MOUNT, to_slot_loc._replace(z=homed_pos.z))
-
-        if return_to_origin:
+            # move to drop off position at destination slot
+            api.move_to(MOUNT, from_slot_loc._replace(z=homed_pos.z))
+            print_current_state(hc_api, cycle, from_slot, GripperState.Z_HOMED)
+            api.move_to(MOUNT, to_slot_loc._replace(z=homed_pos.z))
+            print_current_state(hc_api, cycle, to_slot, GripperState.Z_HOMED)
             api.move_to(MOUNT, to_slot_loc._replace(z=grip_height))
-            print_current_state(hc_api, cycle, from_slot)
+            print_current_state(hc_api, cycle, to_slot, GripperState.Z_LOWERED)
+
+            api.ungrip()
+            api.delay(1)
+            print_current_state(hc_api, cycle, to_slot, GripperState.UNGRIPPING)
 
             api.grip(grip_force)
             api.delay(1.0)
-            print_current_state(hc_api, cycle, from_slot)
+            print_current_state(hc_api, cycle, to_slot, GripperState.GRIPPING)
 
             api.move_to(MOUNT, to_slot_loc._replace(z=homed_pos.z))
+            print_current_state(hc_api, cycle, to_slot, GripperState.Z_HOMED)
             api.move_to(MOUNT, from_slot_loc._replace(z=homed_pos.z))
+            print_current_state(hc_api, cycle, from_slot, GripperState.Z_HOMED)
             api.move_to(MOUNT, from_slot_loc._replace(z=grip_height))
-            print_current_state(hc_api, cycle, from_slot)
+            print_current_state(hc_api, cycle, from_slot, GripperState.Z_LOWERED)
 
             api.ungrip()
             api.delay(1.0)
-            print_current_state(hc_api, cycle, from_slot)
-
-            # Return to safe height
-            api.move_to(MOUNT, from_slot_loc._replace(z=homed_pos.z))
-            print_current_state(hc_api, cycle, from_slot)
+            print_current_state(hc_api, cycle, from_slot, GripperState.UNGRIPPING)
 
     api.home()

--- a/api/src/opentrons/hardware_control/scripts/gripper_control.py
+++ b/api/src/opentrons/hardware_control/scripts/gripper_control.py
@@ -144,7 +144,7 @@ if __name__ == "__main__":
     hc_api = build_api()
 
     from_slot = args.origin
-    grip_force = args.grip_froce
+    grip_force = args.grip_force
     grip_height = args.grip_height
     repeats = args.repeats
 

--- a/api/src/opentrons/hardware_control/scripts/gripper_control.py
+++ b/api/src/opentrons/hardware_control/scripts/gripper_control.py
@@ -1,4 +1,5 @@
 import sys
+import argparse
 import datetime
 import enum
 
@@ -23,7 +24,7 @@ MOUNT = OT3Mount.GRIPPER
 deck_def = load_deck_def("ot3_standard", version=3)
 # Offset of the center of the gripper jaw to the desired location
 GRIPPER_OFFSET = Point(0.0, 1.0, 0.0)
-AVAILABLE_SLOTS = [1, 3, 4, 9, 12]
+AVAILABLE_SLOTS = [1, 3, 4, 9, 10, 12]
 
 
 class GripperState(enum.Enum):
@@ -103,20 +104,49 @@ def print_current_state(
     )
 
 
+def add_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    parser.add_argument(
+        "--origin",
+        type=int,
+        required=False,
+        default=1,
+        help="select slot from 1, 3, 4, 9, 10, 12",
+    )
+    parser.add_argument(
+        "--grip_force",
+        type=float,
+        required=False,
+        default=20,
+        help="grip force in Newton",
+    )
+    parser.add_argument(
+        "--grip_height",
+        type=float,
+        required=False,
+        default=25,
+        help="grip height in mm",
+    )
+    parser.add_argument(
+        "--repeats",
+        type=int,
+        required=False,
+        default=0,
+        help="how many times to repeat the test",
+    )
+    return parser
+
+
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Gripper control script.")
+    add_args(parser)
+    args = parser.parse_args()
+
     hc_api = build_api()
 
-    from_slot = prompt_int_input("Origin slot (1-12)")
-    assert (
-        from_slot in AVAILABLE_SLOTS
-    ), "Please specify one of these available slots: 1, 3, 4, 9, 12"
-    grip_force = prompt_float_input("Force in Newton to grip the labware (rec: 20 N)")
-    grip_height = prompt_float_input(
-        "Z-height from the deck in mm to grip labware (rec: 25 mm)"
-    )
-    repeats = prompt_int_input(
-        "How many times do you want this script to repeat? Type 0 if you only want to run the script once"
-    )
+    from_slot = args.origin
+    grip_force = args.grip_froce
+    grip_height = args.grip_height
+    repeats = args.repeats
 
     api = hc_api.sync
     api.home()

--- a/api/src/opentrons/hardware_control/scripts/gripper_control.py
+++ b/api/src/opentrons/hardware_control/scripts/gripper_control.py
@@ -42,13 +42,6 @@ GRIPPER_OFFSET = Point(0.0, 1.0, 0.0)
 AVAILABLE_SLOTS = [1, 3, 4, 9, 10, 12]
 
 
-class GripperState(enum.Enum):
-    UNGRIPPING = enum.auto()
-    GRIPPING = enum.auto()
-    Z_HOMED = enum.auto()
-    Z_LOWERED = enum.auto()
-
-
 def prompt_int_input(prompt_name: str) -> int:
     """Prompt to choose a member of the enum.
 

--- a/api/src/opentrons/hardware_control/scripts/gripper_control.py
+++ b/api/src/opentrons/hardware_control/scripts/gripper_control.py
@@ -24,7 +24,7 @@ MOUNT = OT3Mount.GRIPPER
 deck_def = load_deck_def("ot3_standard", version=3)
 # Offset of the center of the gripper jaw to the desired location
 GRIPPER_OFFSET = Point(0.0, 1.0, 0.0)
-AVAILABLE_SLOTS = [1, 3, 4, 9, 12]
+AVAILABLE_SLOTS = [1, 3, 4, 9, 10, 12]
 
 
 class GripperState(enum.Enum):
@@ -152,19 +152,16 @@ def add_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Gripper control script.")
+    add_args(parser)
+    args = parser.parse_args()
+
     hc_api = build_api()
 
-    from_slot = prompt_int_input("Origin slot (1-12)")
-    assert (
-        from_slot in AVAILABLE_SLOTS
-    ), "Please specify one of these available slots: 1, 3, 4, 9, 12"
-    grip_force = prompt_float_input("Force in Newton to grip the labware (rec: 20 N)")
-    grip_height = prompt_float_input(
-        "Z-height from the deck in mm to grip labware (rec: 25 mm)"
-    )
-    repeats = prompt_int_input(
-        "How many times do you want this script to repeat? Type 0 if you only want to run the script once"
-    )
+    from_slot = args.origin
+    grip_force = args.grip_froce
+    grip_height = args.grip_height
+    repeats = args.repeats
 
     api = hc_api.sync
     api.home()

--- a/api/src/opentrons/hardware_control/scripts/gripper_control.py
+++ b/api/src/opentrons/hardware_control/scripts/gripper_control.py
@@ -92,8 +92,6 @@ def print_current_state(
     5. gripper state: open/closed
     6. encoder positions (X, Y, G)
     """
-    gripper = api.sync._gripper_handler.get_gripper()
-
     pos = api.sync.current_position_ot3(OT3Mount.GRIPPER)
     gripper_loc = (pos[OT3Axis.X], pos[OT3Axis.Y], pos[OT3Axis.Z_G])
 

--- a/api/src/opentrons/hardware_control/scripts/gripper_control.py
+++ b/api/src/opentrons/hardware_control/scripts/gripper_control.py
@@ -17,6 +17,19 @@ class InvalidInput(Exception):
     """Invalid input exception."""
 
     pass
+VERSION = 2.0
+MOUNT = OT3Mount.GRIPPER
+deck_def = load_deck_def("ot3_standard", version=3)
+# Offset of the center of the gripper jaw to the desired location
+GRIPPER_OFFSET = Point(0.0, 1.0, 0.0)
+AVAILABLE_SLOTS = [1, 3, 4, 9, 12]
+
+
+class GripperState(enum.Enum):
+    UNGRIPPING = enum.auto()
+    GRIPPING = enum.auto()
+    Z_HOMED = enum.auto()
+    Z_LOWERED = enum.auto()
 
 
 VERSION = 2.0
@@ -137,16 +150,19 @@ def add_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Gripper control script.")
-    add_args(parser)
-    args = parser.parse_args()
-
     hc_api = build_api()
 
-    from_slot = args.origin
-    grip_force = args.grip_force
-    grip_height = args.grip_height
-    repeats = args.repeats
+    from_slot = prompt_int_input("Origin slot (1-12)")
+    assert (
+        from_slot in AVAILABLE_SLOTS
+    ), "Please specify one of these available slots: 1, 3, 4, 9, 12"
+    grip_force = prompt_float_input("Force in Newton to grip the labware (rec: 20 N)")
+    grip_height = prompt_float_input(
+        "Z-height from the deck in mm to grip labware (rec: 25 mm)"
+    )
+    repeats = prompt_int_input(
+        "How many times do you want this script to repeat? Type 0 if you only want to run the script once"
+    )
 
     api = hc_api.sync
     api.home()

--- a/hardware/opentrons_hardware/instruments/gripper/serials.py
+++ b/hardware/opentrons_hardware/instruments/gripper/serials.py
@@ -8,7 +8,7 @@ from opentrons_hardware.instruments.serial_utils import ensure_serial_length
 SERIAL_RE = re.compile("^(?:GRPV)(?P<model>[0-9]{2,2})(?P<code>.{,12})$")
 
 SERIAL_FORMAT_MSG = (
-    "Serial numbers must have the format GRVMMXXXXXX... where"
+    "Serial numbers must have the format GRPVMMXXXXXX... where"
     "MM is a two-digit model number, and the rest is some serial code."
 )
 

--- a/hardware/opentrons_hardware/scripts/provision_gripper.py
+++ b/hardware/opentrons_hardware/scripts/provision_gripper.py
@@ -99,7 +99,7 @@ async def update_serial_and_confirm(
                         wc.read(), (target - datetime.datetime.now()).total_seconds()
                     )
                     if (
-                        isinstance(message, message_definitions.PipetteInfoResponse)
+                        isinstance(message, message_definitions.GripperInfoResponse)
                         and arb.parts.originating_node_id == NodeId.gripper
                     ):
                         if message.payload.model == UInt16Field(


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR makes some adjustments to the current gripper testing script based on the testing team's needs. 

Also, I've added a few small fixes in the api & hardware that'll allow the script to run correctly:
1. actually update the encoder position in both hardware controller api and backend
2. provision script trying to read the wrong response


