### PR TITLE
feat(api, robot-server): add thermocycler lid temperature status to get modules endpoint

### DIFF
--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -560,6 +560,7 @@ class Thermocycler(mod_abc.AbstractModule):
                 "lid": self.lid_status,
                 "lidTarget": self.lid_target,
                 "lidTemp": self.lid_temp,
+                "lidTempStatus": self.lid_temp_status,
                 "currentTemp": self.temperature,
                 "targetTemp": self.target,
                 "holdTime": self.hold_time,

--- a/api/tests/opentrons/hardware_control/test_simulator_setup.py
+++ b/api/tests/opentrons/hardware_control/test_simulator_setup.py
@@ -49,6 +49,7 @@ async def test_with_thermocycler():
             "lid": "open",
             "lidTarget": None,
             "lidTemp": 23,
+            "lidTempStatus": "idle",
             "rampRate": None,
             "targetTemp": 3,
             "totalCycleCount": None,

--- a/robot-server/robot_server/modules/module_data_mapper.py
+++ b/robot-server/robot_server/modules/module_data_mapper.py
@@ -89,7 +89,7 @@ class ModuleDataMapper:
                 targetTemperature=cast(float, live_data["data"].get("targetTemp")),
                 currentTemperature=cast(float, live_data["data"].get("currentTemp")),
                 lidStatus=cast(ThermocyclerLidStatus, live_data["data"].get("lid")),
-                lidTempStatus=cast(
+                lidTemperatureStatus=cast(
                     TemperatureStatus, live_data["data"].get("lidTempStatus")
                 ),
                 lidTemperature=cast(float, live_data["data"].get("lidTemp")),

--- a/robot-server/robot_server/modules/module_data_mapper.py
+++ b/robot-server/robot_server/modules/module_data_mapper.py
@@ -89,6 +89,9 @@ class ModuleDataMapper:
                 targetTemperature=cast(float, live_data["data"].get("targetTemp")),
                 currentTemperature=cast(float, live_data["data"].get("currentTemp")),
                 lidStatus=cast(ThermocyclerLidStatus, live_data["data"].get("lid")),
+                lidTempStatus=cast(
+                    TemperatureStatus, live_data["data"].get("lidTempStatus")
+                ),
                 lidTemperature=cast(float, live_data["data"].get("lidTemp")),
                 lidTargetTemperature=cast(float, live_data["data"].get("lidTarget")),
                 holdTime=cast(float, live_data["data"].get("holdTime")),

--- a/robot-server/robot_server/modules/module_models.py
+++ b/robot-server/robot_server/modules/module_models.py
@@ -151,7 +151,7 @@ class ThermocyclerModuleData(BaseModel):
         ...,
         description="The current lid status of the thermocycler.",
     )
-    lidTempStatus: TemperatureStatus = Field(
+    lidTemperatureStatus: TemperatureStatus = Field(
         ..., description="The current heating status of the lid."
     )
     lidTemperature: Optional[float] = Field(

--- a/robot-server/robot_server/modules/module_models.py
+++ b/robot-server/robot_server/modules/module_models.py
@@ -74,10 +74,10 @@ class TemperatureModuleData(BaseModel):
 
     status: TemperatureStatus
     currentTemperature: float = Field(
-        ..., description="The module's current temperature, in degrees Celcius."
+        ..., description="The module's current temperature, in degrees Celsius."
     )
     targetTemperature: Optional[float] = Field(
-        ..., description="The module's target temperature, if set, in degrees Celcius."
+        ..., description="The module's target temperature, if set, in degrees Celsius."
     )
 
 
@@ -137,14 +137,14 @@ class ThermocyclerModuleData(BaseModel):
         ...,
         description=(
             "The current temperature of the thermocycler block, if known,"
-            " in degrees Celcius."
+            " in degrees Celsius."
         ),
     )
     targetTemperature: Optional[float] = Field(
         ...,
         description=(
             "The target temperature of the thermocycler block, if set,"
-            " in degrees Celcius."
+            " in degrees Celsius."
         ),
     )
     lidStatus: ThermocyclerLidStatus = Field(
@@ -156,11 +156,11 @@ class ThermocyclerModuleData(BaseModel):
     )
     lidTemperature: Optional[float] = Field(
         ...,
-        description="The current temperature of the lid, if known, in degrees Celcius.",
+        description="The current temperature of the lid, if known, in degrees Celsius.",
     )
     lidTargetTemperature: Optional[float] = Field(
         ...,
-        description="The target temperature of the lid, if set, in degrees Celcius.",
+        description="The target temperature of the lid, if set, in degrees Celsius.",
     )
     holdTime: Optional[float] = Field(
         ...,
@@ -248,11 +248,11 @@ class HeaterShakerModuleData(BaseModel):
     )
     currentTemperature: float = Field(
         ...,
-        description="Current temperature of the heater, in degrees Celcius.",
+        description="Current temperature of the heater, in degrees Celsius.",
     )
     targetTemperature: Optional[float] = Field(
         ...,
-        description="Target temperature of the heater, if set, in degrees Celcius.",
+        description="Target temperature of the heater, if set, in degrees Celsius.",
     )
     errorDetails: Optional[str] = Field(
         ...,

--- a/robot-server/robot_server/modules/module_models.py
+++ b/robot-server/robot_server/modules/module_models.py
@@ -149,7 +149,10 @@ class ThermocyclerModuleData(BaseModel):
     )
     lidStatus: ThermocyclerLidStatus = Field(
         ...,
-        description="The current heating status of the lid.",
+        description="The current lid status of the thermocycler.",
+    )
+    lidTempStatus: TemperatureStatus = Field(
+        ..., description="The current heating status of the lid."
     )
     lidTemperature: Optional[float] = Field(
         ...,

--- a/robot-server/tests/integration/test_modules.tavern.yaml
+++ b/robot-server/tests/integration/test_modules.tavern.yaml
@@ -107,7 +107,7 @@ stages:
             data:
               status: !anystr
               lidStatus: !anystr
-              lidTempStatus: !anystr
+              lidTemperatureStatus: !anystr
               lidTargetTemperature: !anyfloat
               lidTemperature: !anyfloat
               currentTemperature: !anyfloat

--- a/robot-server/tests/integration/test_modules.tavern.yaml
+++ b/robot-server/tests/integration/test_modules.tavern.yaml
@@ -107,6 +107,7 @@ stages:
             data:
               status: !anystr
               lidStatus: !anystr
+              lidTempStatus: !anystr
               lidTargetTemperature: !anyfloat
               lidTemperature: !anyfloat
               currentTemperature: !anyfloat

--- a/robot-server/tests/modules/test_module_data_mapper.py
+++ b/robot-server/tests/modules/test_module_data_mapper.py
@@ -249,7 +249,7 @@ def test_maps_thermocycler_module_data(input_model: str, input_data: LiveData) -
             currentTemperature=input_data["data"]["currentTemp"],  # type: ignore[arg-type]
             targetTemperature=input_data["data"]["targetTemp"],  # type: ignore[arg-type]
             lidStatus=input_data["data"]["lid"],  # type: ignore[arg-type]
-            lidTempStatus=input_data["data"]["lidTempStatus"],  # type: ignore[arg-type]
+            lidTemperatureStatus=input_data["data"]["lidTempStatus"],  # type: ignore[arg-type]
             lidTemperature=input_data["data"]["lidTemp"],  # type: ignore[arg-type]
             lidTargetTemperature=input_data["data"]["lidTarget"],  # type: ignore[arg-type]
             holdTime=input_data["data"]["holdTime"],  # type: ignore[arg-type]

--- a/robot-server/tests/modules/test_module_data_mapper.py
+++ b/robot-server/tests/modules/test_module_data_mapper.py
@@ -180,6 +180,7 @@ def test_maps_temperature_module_data(input_model: str, input_data: LiveData) ->
                 "lid": "open",
                 "lidTarget": None,
                 "lidTemp": None,
+                "lidTempStatus": "idle",
                 "currentTemp": None,
                 "targetTemp": None,
                 "holdTime": None,
@@ -196,6 +197,7 @@ def test_maps_temperature_module_data(input_model: str, input_data: LiveData) ->
                 "lid": "open",
                 "lidTarget": 1,
                 "lidTemp": 2,
+                "lidTempStatus": "heating",
                 "currentTemp": 3,
                 "targetTemp": 4,
                 "holdTime": 5,
@@ -247,6 +249,7 @@ def test_maps_thermocycler_module_data(input_model: str, input_data: LiveData) -
             currentTemperature=input_data["data"]["currentTemp"],  # type: ignore[arg-type]
             targetTemperature=input_data["data"]["targetTemp"],  # type: ignore[arg-type]
             lidStatus=input_data["data"]["lid"],  # type: ignore[arg-type]
+            lidTempStatus=input_data["data"]["lidTempStatus"],  # type: ignore[arg-type]
             lidTemperature=input_data["data"]["lidTemp"],  # type: ignore[arg-type]
             lidTargetTemperature=input_data["data"]["lidTarget"],  # type: ignore[arg-type]
             holdTime=input_data["data"]["holdTime"],  # type: ignore[arg-type]


### PR DESCRIPTION
# Overview

Closes RCORE-220.

Exposes the thermocycler lid temperature status as part of the thermocycler module data, under the key `lidTemperatureStatus`. The existing property is now sent as part of the thermocycler `live_data` in the hardware control API, and used by the robot-server to report the lid temperature status.

# Changelog

- Added `lidTempStatus` to thermocycler `live_data`
- Added `lidTemperatureStatus` to `ThermocyclerModuleData` reported in `/modules` endpoint
- Fixed wrong `lid_status` description and typos

# Review requests

- [ ] Test receiving lid temperature status on real thermocycler hardware

# Risk assessment

Low, lid temperature status property already exists, this PR just exposes it and only adds to the reported module data.