### PR TITLE
feat(protocol-designer): add OT-3 support feature flag

### DIFF
--- a/protocol-designer/src/feature-flags/reducers.ts
+++ b/protocol-designer/src/feature-flags/reducers.ts
@@ -23,6 +23,7 @@ const initialFlags: Flags = {
     process.env.OT_PD_ENABLE_LIQUID_COLOR_ENHANCEMENTS === '1' || false,
   OT_PD_ENABLE_THERMOCYCLER_GEN_2:
     process.env.OT_PD_ENABLE_THERMOCYCLER_GEN_2 === '1' || false,
+  OT_PD_ENABLE_OT_3: process.env.OT_PD_ENABLE_OT_3 === '1' || false,
 }
 // @ts-expect-error(sa, 2021-6-10): cannot use string literals as action type
 // TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081

--- a/protocol-designer/src/feature-flags/selectors.ts
+++ b/protocol-designer/src/feature-flags/selectors.ts
@@ -23,3 +23,8 @@ export const getEnabledThermocyclerGen2: Selector<boolean> = createSelector(
   getFeatureFlagData,
   flags => flags.OT_PD_ENABLE_THERMOCYCLER_GEN_2 ?? false
 )
+
+export const getEnabledOT3: Selector<boolean> = createSelector(
+  getFeatureFlagData,
+  flags => flags.OT_PD_ENABLE_OT_3 ?? false
+)

--- a/protocol-designer/src/feature-flags/types.ts
+++ b/protocol-designer/src/feature-flags/types.ts
@@ -24,6 +24,7 @@ export type FlagTypes =
   | 'OT_PD_DISABLE_MODULE_RESTRICTIONS'
   | 'OT_PD_ENABLE_LIQUID_COLOR_ENHANCEMENTS'
   | 'OT_PD_ENABLE_THERMOCYCLER_GEN_2'
+  | 'OT_PD_ENABLE_OT_3'
 // flags that are not in this list only show in prerelease mode
 export const userFacingFlags: FlagTypes[] = [
   'OT_PD_DISABLE_MODULE_RESTRICTIONS',

--- a/protocol-designer/src/localization/en/feature_flags.json
+++ b/protocol-designer/src/localization/en/feature_flags.json
@@ -25,7 +25,7 @@
     "description": "Allow users to enable Thermocycler GEN2 module and steps in protocols"
   },
   "OT_PD_ENABLE_OT_3": {
-    "title": "Enabled OT-3 support",
+    "title": "Enable OT-3 support",
     "description": "Allow users to enable OT-3 support in protocol designer"
   }
 }

--- a/protocol-designer/src/localization/en/feature_flags.json
+++ b/protocol-designer/src/localization/en/feature_flags.json
@@ -23,5 +23,9 @@
   "OT_PD_ENABLE_THERMOCYCLER_GEN_2": {
     "title": "Enable Thermocycler GEN2 module",
     "description": "Allow users to enable Thermocycler GEN2 module and steps in protocols"
+  },
+  "OT_PD_ENABLE_OT_3": {
+    "title": "Enabled OT-3 support",
+    "description": "Allow users to enable OT-3 support in protocol designer"
   }
 }


### PR DESCRIPTION
This PR adds a feature flag for OT-3 work in Protocol Designer. closes [RLIQ-177](https://opentrons.atlassian.net/browse/RLIQ-177?atlOrigin=eyJpIjoiYzEzOWUwMzhjY2U2NDZlZmFmOWM5MDE0MWEwNGYzNTAiLCJwIjoiaiJ9)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR adds a feature flag for OT-3 work in Protocol Designer

# Changelog

- Added new FF

# Review requests

1. Run PD: `make -C protocol-designer dev`
2. Type `enablePrereleaseMode()` in the browser console
3. In PD settings, toggling on `Enable OT-3 support` should toggle to true (can check with Redux dev tools).

# Risk assessment

low
