### PR TITLE
fix(engine): thermocycler gen 2 dodging

### DIFF
--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -681,9 +681,7 @@ class ModuleView(HasState[ModuleState]):
         Returns True if we need to dodge, False otherwise.
         """
         all_mods = self.get_all()
-        if any(
-            [ModuleModel.is_thermocycler_module_model(mod.model) for mod in all_mods]
-        ):
+        if any(ModuleModel.is_thermocycler_module_model(mod.model) for mod in all_mods):
             transit = (from_slot, to_slot)
             if transit in _THERMOCYCLER_SLOT_TRANSITS_TO_DODGE:
                 return True

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -681,9 +681,9 @@ class ModuleView(HasState[ModuleState]):
         Returns True if we need to dodge, False otherwise.
         """
         all_mods = self.get_all()
-        if all_mods and ModuleModel.THERMOCYCLER_MODULE_V1 in [
-            mod.model for mod in all_mods
-        ]:
+        if any(
+            [ModuleModel.is_thermocycler_module_model(mod.model) for mod in all_mods]
+        ):
             transit = (from_slot, to_slot)
             if transit in _THERMOCYCLER_SLOT_TRANSITS_TO_DODGE:
                 return True

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -525,7 +525,7 @@ def test_calculate_magnet_height(module_model: ModuleModel) -> None:
         (DeckSlotName.SLOT_2, DeckSlotName.SLOT_4, False),
     ],
 )
-def test_thermocycler_dodging(
+def test_thermocycler_dodging_by_slots(
     thermocycler_v1_def: ModuleDefinition,
     from_slot: DeckSlotName,
     to_slot: DeckSlotName,
@@ -548,6 +548,40 @@ def test_thermocycler_dodging(
 
     assert (
         subject.should_dodge_thermocycler(from_slot=from_slot, to_slot=to_slot)
+        is should_dodge
+    )
+
+
+@pytest.mark.parametrize(
+    argnames=["module_definition", "should_dodge"],
+    argvalues=[
+        (lazy_fixture("tempdeck_v1_def"), False),
+        (lazy_fixture("tempdeck_v2_def"), False),
+        (lazy_fixture("magdeck_v1_def"), False),
+        (lazy_fixture("magdeck_v2_def"), False),
+        (lazy_fixture("thermocycler_v1_def"), True),
+        (lazy_fixture("thermocycler_v2_def"), True),
+        (lazy_fixture("heater_shaker_v1_def"), False),
+    ],
+)
+def test_thermocycler_dodging_by_modules(
+    module_definition: ModuleDefinition,
+    should_dodge: bool,
+) -> None:
+    """It should specify if thermocycler dodging is needed if there is a thermocycler module."""
+    subject = make_module_view(
+        slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
+        hardware_by_module_id={
+            "module-id": HardwareModule(
+                serial_number="serial-number",
+                definition=module_definition,
+            )
+        },
+    )
+    assert (
+        subject.should_dodge_thermocycler(
+            from_slot=DeckSlotName.SLOT_8, to_slot=DeckSlotName.SLOT_1
+        )
         is should_dodge
     )
 


### PR DESCRIPTION
# Overview
Closes RCORE-216.

Fixes issue where protocol engine based thermocycler dodging was only checking for the presence of a gen 1 thermocycler. Now it will check for any thermocycler model.

# Changelog
- Fixed protocol engine module view `should_dodge_thermocycler` only checking for gen1 thermocycler

# Review requests
- [x] Test dodging for thermocycler gen 1 and gen 2 on hardware

# Risk assessment
Low, change is small and well tested in unit tests now.