### PR TITLE
docs(api): Jupyter modules workaround and edits to Advanced Control page

### DIFF
--- a/api/docs/v2/new_advanced_running.rst
+++ b/api/docs/v2/new_advanced_running.rst
@@ -35,7 +35,7 @@ Rather than writing a  ``run`` function and embedding commands within it, start 
 
 The first command you execute should always be :py:meth:`~opentrons.protocol_api.contexts.ProtocolContext.home`. If you try to execute other commands first, you will get a ``MustHomeError``. (When running protocols through the Opentrons App, the robot homes automatically.)
 
-All subsequent method calls will use the same :py:class:`.ProtocolContext`, unless you call :py:meth:`~opentrons.execute.get_protocol_api` again. If you do, the robot will update its cache of attached instruments and modules. Calling :py:meth:`~opentrons.execute.get_protocol_api` repeatedly will return an entirely new :py:class:`.ProtocolContext` each time, without loading any labware or instruments. This is a good way to reset the state of the system if you loaded something incorrectly or want to start from the beginning of your protocol logic.
+You should use the same :py:class:`.ProtocolContext` throughout your notebook, unless you need to start over from the beginning of your protocol logic. In that case, call :py:meth:`~opentrons.execute.get_protocol_api` again to get a new :py:class:`.ProtocolContext`.
 
 Running a Previously Written Protocol
 +++++++++++++++++++++++++++++++++++++

--- a/api/docs/v2/new_advanced_running.rst
+++ b/api/docs/v2/new_advanced_running.rst
@@ -12,7 +12,7 @@ The OT-2 runs a Jupyter Notebook server that you can connect to with your web br
 
 You can access the OT-2’s Jupyter Notebook by following these steps:
 
-1. Open your Opentrons App and look for the IP address of your OT-2 on the information page.
+1. Open the Opentrons App and look for the IP address of your OT-2 on the information page.
 2. Type in ``(Your OT-2's IP Address):48888`` into any browser on your computer.
 
 Here, you can select a notebook and develop protocols that will be saved on the OT-2 itself. These protocols will only be on the OT-2 unless specifically downloaded to your computer using the ``File / Download As`` buttons in the notebook.
@@ -46,7 +46,7 @@ if you were prototyping a plotting or pandas script for later use.
     ``MustHomeError``.
 
 
-Running A Previously-Written Protocol
+Running A Previously Written Protocol
 +++++++++++++++++++++++++++++++++++++
 
 If you have a protocol that you have already written you can run it directly in Jupyter. Copy the protocol into a cell and execute it - this won't cause the OT-2 to move, it just makes the function available. Then, call the ``run`` function you just defined, and give it a :py:class:`.ProtocolContext`:
@@ -57,7 +57,7 @@ If you have a protocol that you have already written you can run it directly in 
     import opentrons.execute
     from opentrons import protocol_api
     def run(protocol: protocol_api.ProtocolContext):
-        # the contents of your protocol are here...
+        # the contents of your previously written protocol go here
 
     protocol = opentrons.execute.get_protocol_api('|apiLevel|')
     run(protocol)  # your protocol will now run
@@ -66,7 +66,18 @@ If you have a protocol that you have already written you can run it directly in 
 Custom Labware
 ++++++++++++++
 
-If you have custom labware definitions you want to use with Jupyter, make a new directory called "labware" in Jupyter and put the definitions there. These definitions will be available when you call ``load_labware``.
+If you have custom labware definitions you want to use with Jupyter, make a new directory called ``labware`` in Jupyter and put the definitions there. These definitions will be available when you call ``load_labware``.
+
+Using Modules
++++++++++++++
+
+If your protocol uses :ref:`new_modules`, you need to take additional steps to make sure that Jupyter Notebook doesn't send commands that conflict with the robot server. If you send commands to modules while the robot server is running, you will likely see errors in Jupyter Notebook and the module commands may not execute as expected.
+
+To disable the robot server, `connect to your robot via SSH <https://support.opentrons.com/s/article/Connecting-to-your-OT-2-with-SSH>`_ and run ``systemctl stop opentrons-robot-server``. Then you can run code from cells in your notebook as normal. When you are done using Jupyter Notebook, you should restart the robot server with ``systemctl start opentrons-robot-server``.
+
+.. note::
+
+    While the robot server is stopped, the robot will display as unavailable in the Opentrons App. If you need to control the robot or its attached modules through the app, you need to restart the robot server and wait for the robot to appear as available in the app.
 
 
 Command Line

--- a/api/docs/v2/new_advanced_running.rst
+++ b/api/docs/v2/new_advanced_running.rst
@@ -40,15 +40,20 @@ All subsequent method calls will use the same :py:class:`.ProtocolContext`, unle
 Running a Previously Written Protocol
 +++++++++++++++++++++++++++++++++++++
 
-You can also use Jupyter to run a protocol that you have already written. To do so, copy the entire text of the protocol into a cell and run that cell. Since a typical protocol only `defines` the ``run`` function but doesn't `call` it, this won't immediately cause the OT-2 to move. To begin the run, instantiate a :py:class:`.ProtocolContext` and pass it to the ``run`` function you just defined:
+You can also use Jupyter to run a protocol that you have already written. To do so, first copy the entire text of the protocol into a cell and run that cell:
 
 .. code-block:: python
-    :substitutions:
 
     import opentrons.execute
     from opentrons import protocol_api
     def run(protocol: protocol_api.ProtocolContext):
         # the contents of your previously written protocol go here
+
+
+Since a typical protocol only `defines` the ``run`` function but doesn't `call` it, this won't immediately cause the OT-2 to move. To begin the run, instantiate a :py:class:`.ProtocolContext` and pass it to the ``run`` function you just defined:
+
+.. code-block:: python
+    :substitutions:
 
     protocol = opentrons.execute.get_protocol_api('|apiLevel|')
     run(protocol)  # your protocol will now run

--- a/api/docs/v2/new_advanced_running.rst
+++ b/api/docs/v2/new_advanced_running.rst
@@ -3,24 +3,28 @@
 Advanced Control
 ================
 
-Sometimes, you may write a protocol that is not suitable for execution through the Opentrons App. Perhaps it requires user input; perhaps it needs to do a lot of things it cannot do when being simulated. There are two ways to run a protocol on the OT-2 without using the Opentrons App.
+As its name implies, the Python Protocol API is primarily designed for creating protocols that you upload via the Opentrons App and execute on the robot as a unit. But sometimes it's more convenient to control the robot `outside` of a protocol. For example, you might want to have variables in your code that change based on user input or the contents of a CSV file. Or you might want to only execute part of your protocol at a time, especially when developing or debugging a new protocol.
+
+The OT-2 offers two ways of issuing Python API commands to the robot outside of the app: through Jupyter Notebook or on the command line with ``opentrons_execute``.
 
 Jupyter Notebook
 ----------------
 
-The OT-2 runs a Jupyter Notebook server that you can connect to with your web browser. This is a convenient environment in which to write and debug protocols, since you can define different parts of your protocol in different notebook cells and run only part of the protocol at a given time.
+The OT-2 runs a `Jupyter Notebook <https://jupyter.org>`_ server on port 48888, which you can connect to with your web browser. This is a convenient environment for writing and debugging protocols, since you can define different parts of your protocol in different notebook cells and run a single cell at a time.
 
-You can access the OT-2’s Jupyter Notebook by following these steps:
+You can access the OT-2’s Jupyter Notebook, either:
 
-1. Open the Opentrons App and look for the IP address of your OT-2 on the information page.
-2. Type in ``(Your OT-2's IP Address):48888`` into any browser on your computer.
+- Go to the *Advanced* tab of Robot Settings and click the *Launch Jupyter Notebook* button.
+- If you know your robot's IP address, navigate directly to ``http://<robot-ip>:48888`` in your web browser.
 
-Here, you can select a notebook and develop protocols that will be saved on the OT-2 itself. These protocols will only be on the OT-2 unless specifically downloaded to your computer using the ``File / Download As`` buttons in the notebook.
+Once you've launched Jupyter Notebook, you can create a notebook file or edit an existing one. These notebook files are stored on the OT-2 itself. If you want to save code from a notebook to your computer, go to *File > Download As* in the notebook interface.
 
 Protocol Structure
 ++++++++++++++++++
 
-To take advantage of Jupyter's ability to run only parts of your protocol, you have to restructure your protocol - turn it inside out. Rather than writing a single ``run`` function that contains all your protocol logic, you can use the function :py:meth:`opentrons.execute.get_protocol_api`, into which you pass the same API version (see :ref:`v2-versioning`) that you would specify in your protocol's metadata:
+Jupyter Notebook is structured around `cells`: discrete chunks of code that can be run individually. This is nearly the opposite of Opentrons protocols, which bundle all commands into a single ``run`` function. Therefore, to take full advantage of Jupyter Notebook, you have to restructure your protocol. 
+
+Rather than writing a  ``run`` function and embedding commands within it, start your notebook with ``import opentrons.execute`` and an instantiation of  :py:meth:`opentrons.execute.get_protocol_api`. This method also replaces the metadata block of a standalone protocol by taking the minimum API version (see :ref:`v2-versioning`) as its argument. Then you can call any methods of :py:class:`ProtocolContext` in subsequent lines or cells:
 
 .. code-block:: python
     :substitutions:
@@ -29,22 +33,9 @@ To take advantage of Jupyter's ability to run only parts of your protocol, you h
     protocol = opentrons.execute.get_protocol_api('|apiLevel|')
     protocol.home()
 
+The first command you execute should always be :py:meth:`home`. If you try to execute other commands first, you will get a ``MustHomeError``. (When running protocols through the Opentrons App, the robot homes automatically.)
 
-This returns the same kind of object - a :py:class:`.ProtocolContext` - that is passed into your protocol's ``run`` function when you upload your protocol in the Opentrons App. Full documentation on the capabilities and use of the :py:class:`.ProtocolContext` object is available in the other sections of this guide - :ref:`new-pipette`, :ref:`v2-atomic-commands`, :ref:`v2-complex-commands`, :ref:`new-labware`, and :ref:`new_modules`; a full list of all available attributes and methods is available in :ref:`protocol-api-reference`.
-
-Whenever you call ``get_protocol_api``, the robot will update its cache of attached instruments and modules. You can call ``get_protocol_api`` repeatedly; it will return an entirely new :py:class:`.ProtocolContext` each time, without any labware loaded or any instruments established. This can be a good way to reset the state of the system, if you accidentally loaded in the wrong labware.
-
-Now that you have a :py:class:`.ProtocolContext`, you call all its methods just
-as you would in a protocol, without the encompassing ``run`` function, just like
-if you were prototyping a plotting or pandas script for later use.
-
-.. note::
-
-    Before you can command the OT-2 to move using the protocol API you have just
-    built, you must home the robot using ``protocol.home()``. If you try to move
-    the OT-2 before you have called ``protocol.home()``, you will get a
-    ``MustHomeError``.
-
+All subsequent method calls will use the same :py:class:`.ProtocolContext`, unless you call ``get_protocol_api`` again. If you do, the robot will update its cache of attached instruments and modules. Calling ``get_protocol_api`` repeatedly will return an entirely new :py:class:`.ProtocolContext` each time, without loading any labware or instruments. This is a good way to reset the state of the system if you loaded something incorrectly or want to start from the beginning of your protocol logic.
 
 Running A Previously Written Protocol
 +++++++++++++++++++++++++++++++++++++

--- a/api/docs/v2/new_advanced_running.rst
+++ b/api/docs/v2/new_advanced_running.rst
@@ -24,7 +24,7 @@ Protocol Structure
 
 Jupyter Notebook is structured around `cells`: discrete chunks of code that can be run individually. This is nearly the opposite of Opentrons protocols, which bundle all commands into a single ``run`` function. Therefore, to take full advantage of Jupyter Notebook, you have to restructure your protocol. 
 
-Rather than writing a  ``run`` function and embedding commands within it, start your notebook with ``import opentrons.execute`` and an instantiation of  :py:meth:`opentrons.execute.get_protocol_api`. This method also replaces the metadata block of a standalone protocol by taking the minimum :ref:`API version <v2-versioning>` as its argument. Then you can call :py:class:`~opentrons.protocol_api.contexts.ProtocolContext` methods in subsequent lines or cells:
+Rather than writing a  ``run`` function and embedding commands within it, start your notebook by importing ``opentrons.execute`` and calling :py:meth:`opentrons.execute.get_protocol_api`. This function also replaces the ``metadata`` block of a standalone protocol by taking the minimum :ref:`API version <v2-versioning>` as its argument. Then you can call :py:class:`~opentrons.protocol_api.contexts.ProtocolContext` methods in subsequent lines or cells:
 
 .. code-block:: python
     :substitutions:

--- a/api/docs/v2/new_advanced_running.rst
+++ b/api/docs/v2/new_advanced_running.rst
@@ -3,7 +3,7 @@
 Advanced Control
 ================
 
-As its name implies, the Python Protocol API is primarily designed for creating protocols that you upload via the Opentrons App and execute on the robot as a unit. But sometimes it's more convenient to control the robot `outside` of a protocol. For example, you might want to have variables in your code that change based on user input or the contents of a CSV file. Or you might want to only execute part of your protocol at a time, especially when developing or debugging a new protocol.
+As its name implies, the Python Protocol API is primarily designed for creating protocols that you upload via the Opentrons App and execute on the robot as a unit. But sometimes it's more convenient to control the robot outside of the app. For example, you might want to have variables in your code that change based on user input or the contents of a CSV file. Or you might want to only execute part of your protocol at a time, especially when developing or debugging a new protocol.
 
 The OT-2 offers two ways of issuing Python API commands to the robot outside of the app: through Jupyter Notebook or on the command line with ``opentrons_execute``.
 
@@ -12,19 +12,19 @@ Jupyter Notebook
 
 The OT-2 runs a `Jupyter Notebook <https://jupyter.org>`_ server on port 48888, which you can connect to with your web browser. This is a convenient environment for writing and debugging protocols, since you can define different parts of your protocol in different notebook cells and run a single cell at a time.
 
-You can access the OT-2’s Jupyter Notebook, either:
+To access the OT-2’s Jupyter Notebook, either:
 
-- Go to the *Advanced* tab of Robot Settings and click the *Launch Jupyter Notebook* button.
-- If you know your robot's IP address, navigate directly to ``http://<robot-ip>:48888`` in your web browser.
+- go to the **Advanced** tab of Robot Settings and click the **Launch Jupyter Notebook** button, or
+- if you know your robot's IP address, navigate directly to ``http://<robot-ip>:48888`` in your web browser.
 
-Once you've launched Jupyter Notebook, you can create a notebook file or edit an existing one. These notebook files are stored on the OT-2 itself. If you want to save code from a notebook to your computer, go to *File > Download As* in the notebook interface.
+Once you've launched Jupyter Notebook, you can create a notebook file or edit an existing one. These notebook files are stored on the OT-2 itself. If you want to save code from a notebook to your computer, go to **File > Download As** in the notebook interface.
 
 Protocol Structure
 ++++++++++++++++++
 
 Jupyter Notebook is structured around `cells`: discrete chunks of code that can be run individually. This is nearly the opposite of Opentrons protocols, which bundle all commands into a single ``run`` function. Therefore, to take full advantage of Jupyter Notebook, you have to restructure your protocol. 
 
-Rather than writing a  ``run`` function and embedding commands within it, start your notebook with ``import opentrons.execute`` and an instantiation of  :py:meth:`opentrons.execute.get_protocol_api`. This method also replaces the metadata block of a standalone protocol by taking the minimum API version (see :ref:`v2-versioning`) as its argument. Then you can call any methods of :py:class:`ProtocolContext` in subsequent lines or cells:
+Rather than writing a  ``run`` function and embedding commands within it, start your notebook with ``import opentrons.execute`` and an instantiation of  :py:meth:`opentrons.execute.get_protocol_api`. This method also replaces the metadata block of a standalone protocol by taking the minimum :ref:`API version <v2-versioning>` as its argument. Then you can call :py:class:`~opentrons.protocol_api.contexts.ProtocolContext` methods in subsequent lines or cells:
 
 .. code-block:: python
     :substitutions:
@@ -33,14 +33,14 @@ Rather than writing a  ``run`` function and embedding commands within it, start 
     protocol = opentrons.execute.get_protocol_api('|apiLevel|')
     protocol.home()
 
-The first command you execute should always be :py:meth:`home`. If you try to execute other commands first, you will get a ``MustHomeError``. (When running protocols through the Opentrons App, the robot homes automatically.)
+The first command you execute should always be :py:meth:`~opentrons.protocol_api.contexts.ProtocolContext.home`. If you try to execute other commands first, you will get a ``MustHomeError``. (When running protocols through the Opentrons App, the robot homes automatically.)
 
-All subsequent method calls will use the same :py:class:`.ProtocolContext`, unless you call ``get_protocol_api`` again. If you do, the robot will update its cache of attached instruments and modules. Calling ``get_protocol_api`` repeatedly will return an entirely new :py:class:`.ProtocolContext` each time, without loading any labware or instruments. This is a good way to reset the state of the system if you loaded something incorrectly or want to start from the beginning of your protocol logic.
+All subsequent method calls will use the same :py:class:`.ProtocolContext`, unless you call :py:meth:`~opentrons.execute.get_protocol_api` again. If you do, the robot will update its cache of attached instruments and modules. Calling :py:meth:`~opentrons.execute.get_protocol_api` repeatedly will return an entirely new :py:class:`.ProtocolContext` each time, without loading any labware or instruments. This is a good way to reset the state of the system if you loaded something incorrectly or want to start from the beginning of your protocol logic.
 
-Running A Previously Written Protocol
+Running a Previously Written Protocol
 +++++++++++++++++++++++++++++++++++++
 
-If you have a protocol that you have already written you can run it directly in Jupyter. Copy the protocol into a cell and execute it - this won't cause the OT-2 to move, it just makes the function available. Then, call the ``run`` function you just defined, and give it a :py:class:`.ProtocolContext`:
+You can also use Jupyter to run a protocol that you have already written. To do so, copy the entire text of the protocol into a cell and run that cell. Since a typical protocol only `defines` the ``run`` function but doesn't `call` it, this won't immediately cause the OT-2 to move. To begin the run, instantiate a :py:class:`.ProtocolContext` and pass it to the ``run`` function you just defined:
 
 .. code-block:: python
     :substitutions:
@@ -54,17 +54,17 @@ If you have a protocol that you have already written you can run it directly in 
     run(protocol)  # your protocol will now run
 
 
-Custom Labware
-++++++++++++++
+Using Custom Labware
+++++++++++++++++++++
 
-If you have custom labware definitions you want to use with Jupyter, make a new directory called ``labware`` in Jupyter and put the definitions there. These definitions will be available when you call ``load_labware``.
+If you have custom labware definitions you want to use with Jupyter, make a new directory called ``labware`` in Jupyter and put the definitions there. These definitions will be available when you call :py:meth:`~opentrons.protocol_api.contexts.ProtocolContext.load_labware`.
 
 Using Modules
 +++++++++++++
 
-If your protocol uses :ref:`new_modules`, you need to take additional steps to make sure that Jupyter Notebook doesn't send commands that conflict with the robot server. If you send commands to modules while the robot server is running, you will likely see errors in Jupyter Notebook and the module commands may not execute as expected.
+If your protocol uses :ref:`new_modules`, you need to take additional steps to make sure that Jupyter Notebook doesn't send commands that conflict with the robot server. Sending commands to modules while the robot server is running will likely cause errors, and the module commands may not execute as expected.
 
-To disable the robot server, `connect to your robot via SSH <https://support.opentrons.com/s/article/Connecting-to-your-OT-2-with-SSH>`_ and run ``systemctl stop opentrons-robot-server``. Then you can run code from cells in your notebook as normal. When you are done using Jupyter Notebook, you should restart the robot server with ``systemctl start opentrons-robot-server``.
+To disable the robot server, open a Jupyter terminal session by going to **New > Terminal** and run ``systemctl stop opentrons-robot-server``. Then you can run code from cells in your notebook as usual. When you are done using Jupyter Notebook, you should restart the robot server with ``systemctl start opentrons-robot-server``.
 
 .. note::
 
@@ -74,14 +74,13 @@ To disable the robot server, `connect to your robot via SSH <https://support.ope
 Command Line
 ------------
 
-The OT-2's command line is accessible either by creating a new terminal in Jupyter or by `using SSH to access its terminal <https://support.opentrons.com/en/articles/3203681>`_.
+The OT-2's command line is accessible either by going to **New > Terminal** in Jupyter or `via SSH <https://support.opentrons.com/s/article/Connecting-to-your-OT-2-with-SSH>`_.
 
-To execute a protocol via SSH, copy it to the OT-2 using a program like ``scp`` and then use the command line program ``opentrons_execute``:
+To execute a protocol from the robot's command line, copy the protocol file to the robot with ``scp`` and then run the protocol with ``opentrons_execute``:
 
 .. prompt:: bash
 
    opentrons_execute /data/my_protocol.py
 
 
-You can access help on the usage of ``opentrons_execute`` by calling ``opentrons_execute --help``. This script has a couple options to let you customize what it prints out when you run it. By default, it will print out the same runlog you see in the Opentrons App when running a protocol, as it executes; it will also print out internal logs at level ``warning`` or above. Both of these behaviors can be changed.
-
+By default, ``opentrons_execute`` will print out the same run log shown in the Opentrons App, as the protocol executes. It also prints out internal logs at the level ``warning`` or above. Both of these behaviors can be changed; for further details, run ``opentrons_execute --help``. 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

This is a top-to-bottom edit of the Advanced Control page of the Python API docs, kickstarted by the need to (temporarily) add instructions for a workaround to disable the robot server when using modules in Jupyter.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

- Added workaround to avoid module control conflicts
- Updated app-specific instructions (finding robot IP) for 6.x
- Added links to reference throughout
- Updated support URL
- Prose edits throughout

# Review requests

<!--
Describe any requests for your reviewers here.
-->

Please test that the instructions for stopping the robot server via Jupyter work on OT-2 hardware.

Comments on overall prose clarity, formatting, etc. are welcome.

[Sandbox link for prose reviewers](http://sandbox.docs.opentrons.com/RTC-186-workaround-for-using-modules-in-jupyter-notebook/v2/new_advanced_running.html)

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

Low, docs only