### PR TITLE
fix(app): update schemaV6Adapter logic for missing liquids key

### DIFF
--- a/app/src/organisms/Devices/hooks/__tests__/useProtocolDetailsForRun.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useProtocolDetailsForRun.test.tsx
@@ -9,6 +9,7 @@ import {
   useProtocolQuery,
   useRunQuery,
 } from '@opentrons/react-api-client'
+import { useFeatureFlag } from '../../../../redux/config'
 
 import { useProtocolDetailsForRun } from '..'
 
@@ -32,6 +33,7 @@ const mockSchemaV6Adapter = schemaV6Adapter as jest.MockedFunction<
   typeof schemaV6Adapter
 >
 jest.mock('@opentrons/react-api-client')
+jest.mock('../../../../redux/config')
 
 const mockUseProtocolQuery = useProtocolQuery as jest.MockedFunction<
   typeof useProtocolQuery
@@ -40,6 +42,10 @@ const mockUseProtocolAnalysesQuery = useProtocolAnalysesQuery as jest.MockedFunc
   typeof useProtocolAnalysesQuery
 >
 const mockUseRunQuery = useRunQuery as jest.MockedFunction<typeof useRunQuery>
+
+const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<
+  typeof useFeatureFlag
+>
 
 const PROTOCOL_RESPONSE = {
   data: {
@@ -67,6 +73,7 @@ describe('useProtocolDetailsForRun hook', () => {
       .mockReturnValue({
         data: { data: [] } as any,
       } as UseQueryResult<ProtocolAnalyses>)
+    mockUseFeatureFlag.mockReturnValue(false)
   })
 
   afterEach(() => {

--- a/app/src/organisms/Devices/hooks/useProtocolDetailsForRun.ts
+++ b/app/src/organisms/Devices/hooks/useProtocolDetailsForRun.ts
@@ -1,6 +1,8 @@
 import * as React from 'react'
 import last from 'lodash/last'
 import { schemaV6Adapter } from '@opentrons/shared-data'
+import { schemaV6Adapter as schemaV6AdapterWithLiquids } from './utils/schemaV6Adapter'
+import { useFeatureFlag } from '../../../redux/config'
 import {
   useProtocolQuery,
   useProtocolAnalysesQuery,
@@ -19,6 +21,7 @@ export interface ProtocolDetails {
 export function useProtocolDetailsForRun(
   runId: string | null
 ): ProtocolDetails {
+  const liquidSetupEnabled = useFeatureFlag('enableLiquidSetup')
   const { data: runRecord } = useRunQuery(runId, { staleTime: Infinity })
   const protocolId = runRecord?.data?.protocolId ?? null
   const [
@@ -55,7 +58,11 @@ export function useProtocolDetailsForRun(
   return {
     displayName: displayName ?? null,
     protocolData:
-      mostRecentAnalysis != null ? schemaV6Adapter(mostRecentAnalysis) : null,
+      mostRecentAnalysis != null
+        ? liquidSetupEnabled
+          ? schemaV6AdapterWithLiquids(mostRecentAnalysis)
+          : schemaV6Adapter(mostRecentAnalysis)
+        : null,
     protocolKey: protocolRecord?.data.key ?? null,
     isProtocolAnalyzing:
       mostRecentAnalysis != null && mostRecentAnalysis?.status === 'pending',

--- a/app/src/organisms/Devices/hooks/utils/schemaV6Adapter.ts
+++ b/app/src/organisms/Devices/hooks/utils/schemaV6Adapter.ts
@@ -11,6 +11,9 @@ import type {
   LoadLabwareRunTimeCommand,
   LoadModuleRunTimeCommand,
 } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
+
+// TODO(sh, 2022-09-29): The liquids logic should move into the shared-data/schemaV6Adapter once the liquids FF is removed
+
 // This adapter exists to resolve the interface mismatch between the PE analysis response
 // and the protocol schema v6 interface. Much of this logic should be deleted once we resolve
 // these discrepencies on the server side

--- a/app/src/organisms/Devices/hooks/utils/schemaV6Adapter.ts
+++ b/app/src/organisms/Devices/hooks/utils/schemaV6Adapter.ts
@@ -1,15 +1,16 @@
 import type {
-  LoadLabwareRunTimeCommand,
-  LoadModuleRunTimeCommand,
-} from '../../protocol/types/schemaV6/command/setup'
-import type { RunTimeCommand, ProtocolAnalysisFile } from '../../protocol'
-import type { PipetteName } from '../pipettes'
-import type {
-  PendingProtocolAnalysis,
   CompletedProtocolAnalysis,
   LabwareDefinition2,
   ModuleModel,
-} from '../types'
+  PendingProtocolAnalysis,
+  PipetteName,
+  ProtocolAnalysisFile,
+  RunTimeCommand,
+} from '@opentrons/shared-data'
+import type {
+  LoadLabwareRunTimeCommand,
+  LoadModuleRunTimeCommand,
+} from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
 // This adapter exists to resolve the interface mismatch between the PE analysis response
 // and the protocol schema v6 interface. Much of this logic should be deleted once we resolve
 // these discrepencies on the server side
@@ -98,12 +99,30 @@ export const schemaV6Adapter = (
         }
       }, {})
 
+    const liquids: {
+      [liquidId: string]: {
+        displayName: string
+        description: string
+        displayColor?: string
+      }
+    } = (protocolAnalysis?.liquids ?? []).reduce((acc, liquid) => {
+      return {
+        ...acc,
+        [liquid.id]: {
+          displayName: liquid.displayName,
+          description: liquid.description,
+          displayColor: liquid.displayColor,
+        },
+      }
+    }, {})
+
     // @ts-expect-error this is a v6 like object that does not quite match the v6 spec at the moment
     return {
       ...protocolAnalysis,
       pipettes,
       labware,
       modules,
+      liquids,
       labwareDefinitions,
       commands: protocolAnalysis.commands,
     }

--- a/shared-data/js/helpers/schemaV6Adapter.ts
+++ b/shared-data/js/helpers/schemaV6Adapter.ts
@@ -104,7 +104,7 @@ export const schemaV6Adapter = (
         description: string
         displayColor?: string
       }
-    } = protocolAnalysis.liquids.reduce((acc, liquid) => {
+    } = (protocolAnalysis?.liquids ?? []).reduce((acc, liquid) => {
       return {
         ...acc,
         [liquid.id]: {


### PR DESCRIPTION


# Overview

This PR fixes the error when a liquids key is missing in analysis for old protocols by updating the schemaV6Adapter logic.

# Changelog

- Add logic to fallback on empty array when liquids key is missing.

# Review requests

- Check that the error/white screen has disappeared for old protocols that do not have a `liquids` key when visiting the `Devices` tab.

# Risk assessment
low
