### PR TITLE
test(robot-server): create isolation for tests and run them in parallel

### DIFF
--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -21,10 +21,10 @@ sdist_file = dist/$(call python_get_sdistname,robot-server,robot_server)
 # These variables can be overriden when make is invoked to customize the
 # behavior of pytest. For instance,
 # make test tests=tests/opentrons/tools/test_qc_scripts.py would run only the
-# specified test
+# specified test 
 tests ?= tests
 cov_opts ?= --cov=$(SRC_PATH) --cov-report term-missing:skip-covered --cov-report xml:coverage.xml
-test_opts ?=
+test_opts ?= -n auto --dist loadscope
 
 # Host key location for buildroot robot
 br_ssh_key ?= $(default_ssh_key)

--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -21,7 +21,7 @@ sdist_file = dist/$(call python_get_sdistname,robot-server,robot_server)
 # These variables can be overriden when make is invoked to customize the
 # behavior of pytest. For instance,
 # make test tests=tests/opentrons/tools/test_qc_scripts.py would run only the
-# specified test 
+# specified test
 tests ?= tests
 cov_opts ?= --cov=$(SRC_PATH) --cov-report term-missing:skip-covered --cov-report xml:coverage.xml
 test_opts ?= -n auto --dist loadscope

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -3,7 +3,6 @@ import subprocess
 import time
 import sys
 import os
-import shutil
 import json
 import pathlib
 import requests

--- a/robot-server/tests/integration/common.yaml
+++ b/robot-server/tests/integration/common.yaml
@@ -4,4 +4,3 @@ description: Variables and other info used across tests
 
 variables:
   host: http://localhost
-  port: 31950

--- a/robot-server/tests/integration/dev_server.py
+++ b/robot-server/tests/integration/dev_server.py
@@ -9,9 +9,7 @@ from typing import Optional
 
 
 class DevServer:
-    def __init__(
-        self, port: str = "31950", persistence_directory: Optional[Path] = None
-    ) -> None:
+    def __init__(self, port: str, persistence_directory: Optional[Path] = None) -> None:
         """Initialize a dev server."""
         self.server_temp_directory: str = tempfile.mkdtemp()
         self.persistence_directory: Path = (

--- a/robot-server/tests/integration/http_api/commands/test_home.tavern.yaml
+++ b/robot-server/tests/integration/http_api/commands/test_home.tavern.yaml
@@ -2,12 +2,13 @@ test_name: home standalone command
 
 marks:
   - usefixtures:
+      - free_port
       - run_server
 
 stages:
   - name: Delete all runs # Ensure there is no active run
     request:
-      url: '{host:s}:{port:d}/runs'
+      url: '{host:s}:{free_port:s}/runs'
       method: GET
     response:
       status_code: 200
@@ -15,10 +16,10 @@ stages:
         - function: 'tests.integration.fixtures:delete_all_runs'
           extra_kwargs:
             host: '{host:s}'
-            port: '{port:d}'
+            port: '{free_port:s}'
   - name: issue home Command params all
     request:
-      url: '{host:s}:{port:d}/commands'
+      url: '{host:s}:{free_port:s}/commands'
       method: POST
       params:
         waitUntilComplete: true
@@ -45,7 +46,7 @@ stages:
           command_id_all: data.id
   - name: issue home Command params empty
     request:
-      url: '{host:s}:{port:d}/commands'
+      url: '{host:s}:{free_port:s}/commands'
       method: POST
       params:
         waitUntilComplete: true
@@ -65,7 +66,7 @@ stages:
           command_id_empty: data.id
   - name: Get command by id
     request:
-      url: '{host:s}:{port:d}/commands/{command_id_empty}'
+      url: '{host:s}:{free_port:s}/commands/{command_id_empty}'
       method: GET
     response:
       strict:
@@ -77,7 +78,7 @@ stages:
           status: succeeded
   - name: Get commands
     request:
-      url: '{host:s}:{port:d}/commands'
+      url: '{host:s}:{free_port:s}/commands'
       method: GET
     response:
       strict:
@@ -89,7 +90,7 @@ stages:
             - id: '{command_id_empty}'
   - name: Create Empty Run
     request:
-      url: '{host:s}:{port:d}/runs'
+      url: '{host:s}:{free_port:s}/runs'
       json:
         data: {}
       method: POST
@@ -107,7 +108,7 @@ stages:
           run_id: data.id
   - name: issue home Command
     request:
-      url: '{host:s}:{port:d}/commands'
+      url: '{host:s}:{free_port:s}/commands'
       method: POST
       params:
         waitUntilComplete: true

--- a/robot-server/tests/integration/http_api/commands/test_load_module_failure.tavern.yaml
+++ b/robot-server/tests/integration/http_api/commands/test_load_module_failure.tavern.yaml
@@ -2,6 +2,7 @@ test_name: loadModule command failure
 
 marks:
   - usefixtures:
+      - free_port
       - run_server
   - parametrize:
       key: model
@@ -11,7 +12,7 @@ marks:
 stages:
   - name: Create Empty Run
     request:
-      url: '{host:s}:{port:d}/runs'
+      url: '{host:s}:{free_port:s}/runs'
       json:
         data: {}
       method: POST
@@ -29,7 +30,7 @@ stages:
           run_id: data.id
   - name: Create loadModule Command
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}/commands'
+      url: '{host:s}:{free_port:s}/runs/{run_id}/commands'
       method: POST
       params:
         waitUntilComplete: true

--- a/robot-server/tests/integration/http_api/commands/test_load_module_success.tavern.yaml
+++ b/robot-server/tests/integration/http_api/commands/test_load_module_success.tavern.yaml
@@ -2,6 +2,7 @@ test_name: loadModule command success
 
 marks:
   - usefixtures:
+      - free_port
       - run_server
   - parametrize:
       key: model
@@ -15,13 +16,13 @@ marks:
 stages:
   - name: Get modules
     request:
-      url: '{host:s}:{port:d}/modules'
+      url: '{host:s}:{free_port:s}/modules'
       method: GET
     response:
       status_code: 200
   - name: Create Empty Run
     request:
-      url: '{host:s}:{port:d}/runs'
+      url: '{host:s}:{free_port:s}/runs'
       json:
         data: {}
       method: POST
@@ -39,7 +40,7 @@ stages:
           run_id: data.id
   - name: Create loadModule Command
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}/commands'
+      url: '{host:s}:{free_port:s}/runs/{run_id}/commands'
       method: POST
       params:
         waitUntilComplete: true

--- a/robot-server/tests/integration/http_api/commands/test_mag_commands.tavern.yaml
+++ b/robot-server/tests/integration/http_api/commands/test_mag_commands.tavern.yaml
@@ -2,12 +2,13 @@ test_name: magneticModuleV1 standalone commands
 
 marks:
   - usefixtures:
+      - free_port
       - run_server
 
 stages:
   - name: Delete all runs # Ensure there is no active run
     request:
-      url: '{host:s}:{port:d}/runs'
+      url: '{host:s}:{free_port:s}/runs'
       method: GET
     response:
       status_code: 200
@@ -15,10 +16,10 @@ stages:
         - function: 'tests.integration.fixtures:delete_all_runs'
           extra_kwargs:
             host: '{host:s}'
-            port: '{port:d}'
+            port: '{free_port:s}'
   - name: Get magDeck id
     request:
-      url: '{host:s}:{port:d}/modules'
+      url: '{host:s}:{free_port:s}/modules'
       method: GET
     response:
       status_code: 200
@@ -29,7 +30,7 @@ stages:
             module_model: magneticModuleV1
   - name: issue magDeck engage Command
     request:
-      url: '{host:s}:{port:d}/commands'
+      url: '{host:s}:{free_port:s}/commands'
       method: POST
       params:
         waitUntilComplete: true
@@ -51,7 +52,7 @@ stages:
           command_id_engage: data.id
   - name: issue magDeck engage Command with error
     request:
-      url: '{host:s}:{port:d}/commands'
+      url: '{host:s}:{free_port:s}/commands'
       method: POST
       params:
         waitUntilComplete: true
@@ -80,7 +81,7 @@ stages:
           command_id_engage_error: data.id
   - name: issue magDeck disengage Command
     request:
-      url: '{host:s}:{port:d}/commands'
+      url: '{host:s}:{free_port:s}/commands'
       method: POST
       params:
         waitUntilComplete: true
@@ -101,7 +102,7 @@ stages:
           command_id_disengage: data.id
   - name: Get command by id
     request:
-      url: '{host:s}:{port:d}/commands/{command_id_engage}'
+      url: '{host:s}:{free_port:s}/commands/{command_id_engage}'
       method: GET
     response:
       strict:
@@ -113,7 +114,7 @@ stages:
           status: succeeded
   - name: Get commands
     request:
-      url: '{host:s}:{port:d}/commands'
+      url: '{host:s}:{free_port:s}/commands'
       method: GET
     response:
       strict:
@@ -126,7 +127,7 @@ stages:
           - id: '{command_id_disengage}'
   - name: Create Empty Run
     request:
-      url: '{host:s}:{port:d}/runs'
+      url: '{host:s}:{free_port:s}/runs'
       json:
         data: {}
       method: POST
@@ -144,7 +145,7 @@ stages:
           run_id: data.id
   - name: issue magDeck disengage Command
     request:
-      url: '{host:s}:{port:d}/commands'
+      url: '{host:s}:{free_port:s}/commands'
       method: POST
       params:
         waitUntilComplete: true

--- a/robot-server/tests/integration/http_api/commands/test_set_rail_lights.tavern.yaml
+++ b/robot-server/tests/integration/http_api/commands/test_set_rail_lights.tavern.yaml
@@ -2,12 +2,13 @@ test_name: setRailLights standalone command
 
 marks:
   - usefixtures:
+      - free_port
       - run_server
 
 stages:
   - name: Delete all runs # Ensure there is no active run
     request:
-      url: '{host:s}:{port:d}/runs'
+      url: '{host:s}:{free_port:s}/runs'
       method: GET
     response:
       status_code: 200
@@ -15,10 +16,10 @@ stages:
         - function: 'tests.integration.fixtures:delete_all_runs'
           extra_kwargs:
             host: '{host:s}'
-            port: '{port:d}'
+            port: '{free_port:s}'
   - name: issue setRailLights Command on = true
     request:
-      url: '{host:s}:{port:d}/commands'
+      url: '{host:s}:{free_port:s}/commands'
       method: POST
       params:
         waitUntilComplete: true
@@ -39,7 +40,7 @@ stages:
           command_id_on: data.id
   - name: issue setRailLights Command on = false
     request:
-      url: '{host:s}:{port:d}/commands'
+      url: '{host:s}:{free_port:s}/commands'
       method: POST
       params:
         waitUntilComplete: true
@@ -60,7 +61,7 @@ stages:
           command_id_off: data.id
   - name: Get command by id
     request:
-      url: '{host:s}:{port:d}/commands/{command_id_off}'
+      url: '{host:s}:{free_port:s}/commands/{command_id_off}'
       method: GET
     response:
       strict:
@@ -72,7 +73,7 @@ stages:
           status: succeeded
   - name: Get commands
     request:
-      url: '{host:s}:{port:d}/commands'
+      url: '{host:s}:{free_port:s}/commands'
       method: GET
     response:
       strict:
@@ -84,7 +85,7 @@ stages:
           - id: '{command_id_off}'
   - name: Create Empty Run
     request:
-      url: '{host:s}:{port:d}/runs'
+      url: '{host:s}:{free_port:s}/runs'
       json:
         data: {}
       method: POST
@@ -102,7 +103,7 @@ stages:
           run_id: data.id
   - name: issue setRailLights Command on = true
     request:
-      url: '{host:s}:{port:d}/commands'
+      url: '{host:s}:{free_port:s}/commands'
       method: POST
       params:
         waitUntilComplete: true

--- a/robot-server/tests/integration/http_api/commands/test_temp_commands.tavern.yaml
+++ b/robot-server/tests/integration/http_api/commands/test_temp_commands.tavern.yaml
@@ -2,12 +2,13 @@ test_name: temperatureModuleV1 standalone commands
 
 marks:
   - usefixtures:
+      - free_port
       - run_server
 
 stages:
   - name: Delete all runs # Ensure there is no active run
     request:
-      url: '{host:s}:{port:d}/runs'
+      url: '{host:s}:{free_port:s}/runs'
       method: GET
     response:
       status_code: 200
@@ -15,10 +16,10 @@ stages:
         - function: 'tests.integration.fixtures:delete_all_runs'
           extra_kwargs:
             host: '{host:s}'
-            port: '{port:d}'
+            port: '{free_port:s}'
   - name: Get tempModule id
     request:
-      url: '{host:s}:{port:d}/modules'
+      url: '{host:s}:{free_port:s}/modules'
       method: GET
     response:
       status_code: 200
@@ -29,7 +30,7 @@ stages:
             module_model: temperatureModuleV1
   - name: issue temperatureModule/setTargetTemperature Command
     request:
-      url: '{host:s}:{port:d}/commands'
+      url: '{host:s}:{free_port:s}/commands'
       method: POST
       params: # on simulations will return immediately
         waitUntilComplete: true
@@ -51,7 +52,7 @@ stages:
           command_id_set_temp: data.id
   - name: issue temperatureModule/setTargetTemperature Command with error
     request:
-      url: '{host:s}:{port:d}/commands'
+      url: '{host:s}:{free_port:s}/commands'
       method: POST
       params:
         waitUntilComplete: true
@@ -80,7 +81,7 @@ stages:
           command_id_set_temp_error: data.id
   - name: issue temperatureModule/deactivate Command
     request:
-      url: '{host:s}:{port:d}/commands'
+      url: '{host:s}:{free_port:s}/commands'
       method: POST
       params:
         waitUntilComplete: true
@@ -101,7 +102,7 @@ stages:
           command_id_deactivate: data.id
   - name: Get command by id
     request:
-      url: '{host:s}:{port:d}/commands/{command_id_set_temp}'
+      url: '{host:s}:{free_port:s}/commands/{command_id_set_temp}'
       method: GET
     response:
       strict:
@@ -113,7 +114,7 @@ stages:
           status: succeeded
   - name: Get commands
     request:
-      url: '{host:s}:{port:d}/commands'
+      url: '{host:s}:{free_port:s}/commands'
       method: GET
     response:
       strict:
@@ -126,7 +127,7 @@ stages:
           - id: '{command_id_deactivate}'
   - name: Create Empty Run
     request:
-      url: '{host:s}:{port:d}/runs'
+      url: '{host:s}:{free_port:s}/runs'
       json:
         data: {}
       method: POST
@@ -144,7 +145,7 @@ stages:
           run_id: data.id
   - name: issue temperatureModule/setTargetTemperature Command
     request:
-      url: '{host:s}:{port:d}/commands'
+      url: '{host:s}:{free_port:s}/commands'
       method: POST
       params:
         waitUntilComplete: true

--- a/robot-server/tests/integration/http_api/persistence/test_compatibility.py
+++ b/robot-server/tests/integration/http_api/persistence/test_compatibility.py
@@ -18,8 +18,8 @@ _EXPECTED_RUN_COUNT = 5
 # Module-scope to avoid the overhead of restarting the server between test functions.
 # This relies on the test functions only reading, never writing.
 @pytest.fixture(scope="module")
-def dev_server() -> Generator[DevServer, None, None]:
-    port = "15555"
+def dev_server(module_scope_free_port: str) -> Generator[DevServer, None, None]:
+    port = module_scope_free_port
     with DevServer(
         port=port,
         persistence_directory=_OLDER_PERSISTENCE_DIR,

--- a/robot-server/tests/integration/http_api/persistence/test_reset.py
+++ b/robot-server/tests/integration/http_api/persistence/test_reset.py
@@ -8,7 +8,9 @@ from tests.integration.robot_client import RobotClient
 from tests.integration.protocol_files import get_py_protocol, get_json_protocol
 
 
-async def test_upload_protocols_and_reset_persistence_dir() -> None:
+async def test_upload_protocols_and_reset_persistence_dir(
+    function_scope_free_port: str,
+) -> None:
     """Test resetting runs history.
 
     Immediately after resetting runs history, existing resources should remain
@@ -16,7 +18,7 @@ async def test_upload_protocols_and_reset_persistence_dir() -> None:
 
     But after restarting the server, those resources should be gone.
     """
-    port = "15555"
+    port = function_scope_free_port
     async with RobotClient.make(
         host="http://localhost", port=port, version="*"
     ) as robot_client:

--- a/robot-server/tests/integration/http_api/protocols/test_404.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_404.tavern.yaml
@@ -2,11 +2,12 @@ test_name: Verify error upon GET of nonexistent protocol id.
 
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: GET nonexistent protocol id
     request:
-      url: '{host:s}:{port:d}/protocols/idontexist'
+      url: '{host:s}:{free_port:s}/protocols/idontexist'
       method: GET
     response:
       status_code: 404
@@ -21,11 +22,12 @@ test_name: Verify error upon DELETE of nonexistent protocol id.
 
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: DELETE nonexistent protocol id
     request:
-      url: '{host:s}:{port:d}/protocols/idontexist'
+      url: '{host:s}:{free_port:s}/protocols/idontexist'
       method: DELETE
     response:
       status_code: 404

--- a/robot-server/tests/integration/http_api/protocols/test_auto_deletion.py
+++ b/robot-server/tests/integration/http_api/protocols/test_auto_deletion.py
@@ -11,8 +11,8 @@ _NUM_PROTOCOLS_TO_UPLOAD = 10
 _NUM_PROTOCOLS_TO_EXPECT = 5
 
 
-async def test_protocols_auto_delete() -> None:
-    port = "15555"
+async def test_protocols_auto_delete(function_scope_free_port: str) -> None:
+    port = function_scope_free_port
     async with RobotClient.make(
         host="http://localhost", port=port, version="*"
     ) as robot_client:

--- a/robot-server/tests/integration/http_api/protocols/test_key.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_key.tavern.yaml
@@ -2,11 +2,12 @@ test_name: Verify protocol key.
 
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: Upload basic_transfer_standalone protocol with key
     request:
-      url: '{host:s}:{port:d}/protocols'
+      url: '{host:s}:{free_port:s}/protocols'
       method: POST
       files:
         files: 'tests/integration/protocols/basic_transfer_standalone.py'
@@ -36,7 +37,7 @@ stages:
           key: protocol_key
   - name: Verify the key in GET /protocols
     request:
-      url: '{host:s}:{port:d}/protocols'
+      url: '{host:s}:{free_port:s}/protocols'
       method: GET
     response:
       strict:
@@ -49,7 +50,7 @@ stages:
 
   - name: Verify the key in GET /protocols/{protocol_id}
     request:
-      url: '{host:s}:{port:d}/protocols/{protocol_id}'
+      url: '{host:s}:{free_port:s}/protocols/{protocol_id}'
       method: GET
     response:
       strict:
@@ -65,11 +66,12 @@ test_name: Protocols may have a duplicate key.
 
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: Upload basic_transfer_standalone protocol with key
     request:
-      url: '{host:s}:{port:d}/protocols'
+      url: '{host:s}:{free_port:s}/protocols'
       method: POST
       files:
         files: 'tests/integration/protocols/basic_transfer_standalone.py'
@@ -96,7 +98,7 @@ stages:
           key: duplicate_key
   - name: Upload basic_transfer_standalone protocol with key
     request:
-      url: '{host:s}:{port:d}/protocols'
+      url: '{host:s}:{free_port:s}/protocols'
       method: POST
       files:
         files: 'tests/integration/protocols/basic_transfer_standalone.py'
@@ -123,7 +125,7 @@ stages:
           key: duplicate_key
   - name: Get protocols and validate id and key
     request:
-      url: '{host:s}:{port:d}/protocols'
+      url: '{host:s}:{free_port:s}/protocols'
       method: GET
     response:
       strict:

--- a/robot-server/tests/integration/http_api/protocols/test_non_conforming_api_level.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_non_conforming_api_level.tavern.yaml
@@ -2,11 +2,12 @@ test_name: Upload, analyze, and validate protocol analysis failure for api level
 
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: Upload a python protocol with non-conforming api level 
     request:
-      url: '{host:s}:{port:d}/protocols'
+      url: '{host:s}:{free_port:s}/protocols'
       method: POST
       files:
         files: 'tests/integration/protocols/non_conforming_api_level.py'

--- a/robot-server/tests/integration/http_api/protocols/test_persistence.py
+++ b/robot-server/tests/integration/http_api/protocols/test_persistence.py
@@ -12,14 +12,14 @@ from tests.integration.protocol_files import get_py_protocol, get_json_protocol
 
 @pytest.mark.parametrize("protocol", [(get_py_protocol), (get_json_protocol)])
 async def test_protocols_and_analyses_persist(
-    protocol: Callable[[str], IO[bytes]]
+    protocol: Callable[[str], IO[bytes]], function_scope_free_port: str
 ) -> None:
     """Test protocol and analysis persistence.
 
     Uploaded protocols and their completed analyses should remain constant across
     server restarts.
     """
-    port = "15555"
+    port = function_scope_free_port
     async with RobotClient.make(
         host="http://localhost", port=port, version="*"
     ) as robot_client:
@@ -80,12 +80,12 @@ async def test_protocols_and_analyses_persist(
             server.stop()
 
 
-async def test_protocol_labware_files_persist() -> None:
+async def test_protocol_labware_files_persist(function_scope_free_port: str) -> None:
     """Upload a python protocol and 2 custom labware files.
 
     Test that labware files are persisted on server restart.
     """
-    port = "15556"
+    port = function_scope_free_port
     async with RobotClient.make(
         host="http://localhost", port=port, version="*"
     ) as robot_client:

--- a/robot-server/tests/integration/http_api/protocols/test_upload.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_upload.tavern.yaml
@@ -2,11 +2,12 @@ test_name: Upload, analyze, delete basic_transfer_standalone protocol.
 
 marks:
   - usefixtures:
-      - run_server
+      - function_scope_free_port
+      - function_scope_run_server
 stages:
   - name: Upload basic_transfer_standalone protocol
     request:
-      url: '{host:s}:{port:d}/protocols'
+      url: '{host:s}:{function_scope_free_port:s}/protocols'
       method: POST
       files:
         files: 'tests/integration/protocols/basic_transfer_standalone.py'
@@ -36,7 +37,7 @@ stages:
     max_retries: 5
     delay_after: 1
     request:
-      url: '{host:s}:{port:d}/protocols/{protocol_id}/analyses'
+      url: '{host:s}:{function_scope_free_port:s}/protocols/{protocol_id}/analyses'
       method: GET
     response:
       strict:
@@ -49,13 +50,13 @@ stages:
             result: ok
   - name: Delete the protocol
     request:
-      url: '{host:s}:{port:d}/protocols/{protocol_id}'
+      url: '{host:s}:{function_scope_free_port:s}/protocols/{protocol_id}'
       method: DELETE
     response:
       status_code: 200
   - name: Get protocol with id to verify it is deleted
     request:
-      url: '{host:s}:{port:d}/protocols/{protocol_id}'
+      url: '{host:s}:{function_scope_free_port:s}/protocols/{protocol_id}'
       method: GET
     response:
       strict:
@@ -71,13 +72,14 @@ test_name: Upload, analyze and analyze using "slow analysis"
 
 marks:
   - usefixtures:
-      - run_server
+      - function_scope_free_port
+      - function_scope_run_server
       - set_disable_fast_analysis
 
 stages:
   - name: Upload simple Python protocol
     request:
-      url: '{host:s}:{port:d}/protocols'
+      url: '{host:s}:{function_scope_free_port:s}/protocols'
       method: POST
       files:
         files: 'tests/integration/protocols/simple.py'
@@ -92,7 +94,7 @@ stages:
     max_retries: 10
     delay_after: 0.1
     request:
-      url: '{host:s}:{port:d}/protocols/{protocol_id}/analyses'
+      url: '{host:s}:{function_scope_free_port:s}/protocols/{protocol_id}/analyses'
       method: GET
     response:
       strict:
@@ -105,7 +107,7 @@ stages:
             result: ok
   - name: Delete the protocol
     request:
-      url: '{host:s}:{port:d}/protocols/{protocol_id}'
+      url: '{host:s}:{function_scope_free_port:s}/protocols/{protocol_id}'
       method: DELETE
     response:
       status_code: 200

--- a/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
@@ -2,11 +2,12 @@ test_name: Upload, analyze, delete basic_transfer_standalone protocol.
 
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: Upload simple v6 protocol
     request:
-      url: '{host:s}:{port:d}/protocols'
+      url: '{host:s}:{free_port:s}/protocols'
       method: POST
       files:
         files: '../shared-data/protocol/fixtures/6/simpleV6.json'
@@ -29,7 +30,7 @@ stages:
     max_retries: 20
     delay_after: 2
     request:
-      url: '{host:s}:{port:d}/protocols'
+      url: '{host:s}:{free_port:s}/protocols'
       method: GET
     response:
       strict:
@@ -43,7 +44,7 @@ stages:
                 status: completed
   - name: Get protocol by ID
     request:
-      url: '{host:s}:{port:d}/protocols/{protocol_id}'
+      url: '{host:s}:{free_port:s}/protocols/{protocol_id}'
       method: GET
     response:
       status_code: 200
@@ -68,7 +69,7 @@ stages:
               status: completed
   - name: Get protocol analysis by ID
     request:
-      url: '{host:s}:{port:d}/protocols/{protocol_id}/analyses'
+      url: '{host:s}:{free_port:s}/protocols/{protocol_id}/analyses'
       method: GET
     response:
       status_code: 200

--- a/robot-server/tests/integration/http_api/runs/test_auto_deletion.py
+++ b/robot-server/tests/integration/http_api/runs/test_auto_deletion.py
@@ -8,8 +8,8 @@ _NUM_RUNS_TO_UPLOAD = 25
 _NUM_RUNS_TO_EXPECT = 20
 
 
-async def test_runs_auto_delete() -> None:
-    port = "15555"
+async def test_runs_auto_delete(function_scope_free_port: str) -> None:
+    port = function_scope_free_port
     async with RobotClient.make(
         host="http://localhost", port=port, version="*"
     ) as robot_client:

--- a/robot-server/tests/integration/http_api/runs/test_deletion.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_deletion.tavern.yaml
@@ -2,12 +2,13 @@ test_name: Create and delete a run
 
 marks:
   - usefixtures:
+      - free_port
       - run_server
 
 stages:
   - name: Create Empty Run
     request:
-      url: '{host:s}:{port:d}/runs'
+      url: '{host:s}:{free_port:s}/runs'
       json:
         data: {}
       method: POST
@@ -18,14 +19,14 @@ stages:
           run_id: data.id
   - name: Delete run
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}'
+      url: '{host:s}:{free_port:s}/runs/{run_id}'
       method: DELETE
     response:
       status_code: 200
       json: {}
   - name: Try to get deleted run
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}'
+      url: '{host:s}:{free_port:s}/runs/{run_id}'
       method: GET
     response:
       status_code: 404

--- a/robot-server/tests/integration/http_api/runs/test_json_v6_protocol_run.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_json_v6_protocol_run.tavern.yaml
@@ -2,11 +2,12 @@ test_name: Upload and run a JSONv6 protocol.
 
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: Upload simple JSONv6 protocol
     request:
-      url: '{host:s}:{port:d}/protocols'
+      url: '{host:s}:{free_port:s}/protocols'
       method: POST
       files:
         files: 'tests/integration/protocols/simple_v6.json'
@@ -18,7 +19,7 @@ stages:
 
   - name: Create run from protocol
     request:
-      url: '{host:s}:{port:d}/runs'
+      url: '{host:s}:{free_port:s}/runs'
       method: POST
       json:
         data:
@@ -53,7 +54,7 @@ stages:
 
   - name: Execute a setup command
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}/commands'
+      url: '{host:s}:{free_port:s}/runs/{run_id}/commands'
       method: POST
       params:
         waitUntilComplete: true
@@ -79,7 +80,7 @@ stages:
 
   - name: Fetch run commands
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}/commands'
+      url: '{host:s}:{free_port:s}/runs/{run_id}/commands'
       method: GET
     response:
       status_code: 200
@@ -295,7 +296,7 @@ stages:
 
   - name: Play the run
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}/actions'
+      url: '{host:s}:{free_port:s}/runs/{run_id}/actions'
       method: POST
       json:
         data:
@@ -312,7 +313,7 @@ stages:
     max_retries: 10
     delay_after: 0.1
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}'
+      url: '{host:s}:{free_port:s}/runs/{run_id}'
       method: GET
     response:
       status_code: 200
@@ -324,7 +325,7 @@ stages:
 
   - name: Verify commands succeeded with the expected results
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}/commands'
+      url: '{host:s}:{free_port:s}/runs/{run_id}/commands'
       method: GET
     response:
       status_code: 200

--- a/robot-server/tests/integration/http_api/runs/test_json_v6_run_failure.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_json_v6_run_failure.tavern.yaml
@@ -2,11 +2,12 @@ test_name: Upload and run a JSON v6 protocol that should fail.
 
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: Upload a protocol
     request:
-      url: '{host:s}:{port:d}/protocols'
+      url: '{host:s}:{free_port:s}/protocols'
       method: POST
       files:
         files: 'tests/integration/protocols/simple_v6_failure.json'
@@ -18,7 +19,7 @@ stages:
 
   - name: Create run from protocol
     request:
-      url: '{host:s}:{port:d}/runs'
+      url: '{host:s}:{free_port:s}/runs'
       method: POST
       json:
         data:
@@ -31,7 +32,7 @@ stages:
 
   - name: Play the run
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}/actions'
+      url: '{host:s}:{free_port:s}/runs/{run_id}/actions'
       method: POST
       json:
         data:
@@ -45,7 +46,7 @@ stages:
     max_retries: 10
     delay_after: 0.1
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}'
+      url: '{host:s}:{free_port:s}/runs/{run_id}'
       method: GET
     response:
       status_code: 200
@@ -61,7 +62,7 @@ stages:
               detail: 'Cannot perform DROPTIP without a tip attached'
   - name: Verify commands contain the expected results
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}/commands'
+      url: '{host:s}:{free_port:s}/runs/{run_id}/commands'
       method: GET
     response:
       status_code: 200

--- a/robot-server/tests/integration/http_api/runs/test_papi_v2_run_failure.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_papi_v2_run_failure.tavern.yaml
@@ -2,11 +2,12 @@ test_name: Upload and run a PAPI v2 protocol that should fail.
 
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: Upload a protocol
     request:
-      url: '{host:s}:{port:d}/protocols'
+      url: '{host:s}:{free_port:s}/protocols'
       method: POST
       files:
         files: 'tests/integration/protocols/runtime_error.py'
@@ -18,7 +19,7 @@ stages:
 
   - name: Create run from protocol
     request:
-      url: '{host:s}:{port:d}/runs'
+      url: '{host:s}:{free_port:s}/runs'
       method: POST
       json:
         data:
@@ -31,7 +32,7 @@ stages:
 
   - name: Play the run
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}/actions'
+      url: '{host:s}:{free_port:s}/runs/{run_id}/actions'
       method: POST
       json:
         data:
@@ -45,7 +46,7 @@ stages:
     max_retries: 10
     delay_after: 0.1
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}'
+      url: '{host:s}:{free_port:s}/runs/{run_id}'
       method: GET
     response:
       status_code: 200
@@ -62,7 +63,7 @@ stages:
 
   - name: Verify commands contain the expected results
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}/commands'
+      url: '{host:s}:{free_port:s}/runs/{run_id}/commands'
       method: GET
     response:
       status_code: 200

--- a/robot-server/tests/integration/http_api/runs/test_pause_run_not_started.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_pause_run_not_started.tavern.yaml
@@ -2,12 +2,13 @@ test_name: Make sure a non active run cannot be paused
 
 marks:
   - usefixtures:
+      - free_port
       - run_server
 
 stages:
   - name: Create Empty Run
     request:
-      url: '{host:s}:{port:d}/runs'
+      url: '{host:s}:{free_port:s}/runs'
       json:
         data: {}
       method: POST
@@ -25,7 +26,7 @@ stages:
           run_id: data.id
   - name: Issue pause to a none active run
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}/actions'
+      url: '{host:s}:{free_port:s}/runs/{run_id}/actions'
       json:
         data:
           actionType: pause

--- a/robot-server/tests/integration/http_api/runs/test_pause_then_cancel.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_pause_then_cancel.tavern.yaml
@@ -2,12 +2,13 @@ test_name: Test a JSONv6 run can be paused and then cancelled.
 
 marks:
   - usefixtures:
+      - free_port
       - run_server
 
 stages:
   - name: Upload a JSONv6 protocol
     request:
-      url: '{host:s}:{port:d}/protocols'
+      url: '{host:s}:{free_port:s}/protocols'
       method: POST
       files:
         files: 'tests/integration/protocols/wait_then_home_v6.json'
@@ -19,7 +20,7 @@ stages:
 
   - name: Create run from protocol
     request:
-      url: '{host:s}:{port:d}/runs'
+      url: '{host:s}:{free_port:s}/runs'
       method: POST
       json:
         data:
@@ -32,7 +33,7 @@ stages:
 
   - name: Play the run
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}/actions'
+      url: '{host:s}:{free_port:s}/runs/{run_id}/actions'
       method: POST
       json:
         data:
@@ -42,7 +43,7 @@ stages:
 
   - name: Pause the run
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}/actions'
+      url: '{host:s}:{free_port:s}/runs/{run_id}/actions'
       method: POST
       json:
         data:
@@ -54,7 +55,7 @@ stages:
     max_retries: 10
     delay_after: 0.2
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}/commands'
+      url: '{host:s}:{free_port:s}/runs/{run_id}/commands'
       method: GET
     response:
       status_code: 200
@@ -68,7 +69,7 @@ stages:
 
   - name: Stop the run
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}/actions'
+      url: '{host:s}:{free_port:s}/runs/{run_id}/actions'
       method: POST
       json:
         data:
@@ -80,7 +81,7 @@ stages:
     max_retries: 10
     delay_after: 0.2
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}'
+      url: '{host:s}:{free_port:s}/runs/{run_id}'
       method: GET
     response:
       status_code: 200

--- a/robot-server/tests/integration/http_api/runs/test_persistence.py
+++ b/robot-server/tests/integration/http_api/runs/test_persistence.py
@@ -20,22 +20,18 @@ class ClientServerFixture(NamedTuple):
 
 
 @pytest.fixture
-def port() -> str:
-    """Get a port to run the dev server on."""
-    return "15555"
-
-
-@pytest.fixture
-async def client_and_server(port: str) -> AsyncGenerator[ClientServerFixture, None]:
+async def client_and_server(
+    function_scope_free_port: str,
+) -> AsyncGenerator[ClientServerFixture, None]:
     """Get a dev server and a client to that server."""
     async with RobotClient.make(
         host="http://localhost",
-        port=port,
+        port=function_scope_free_port,
         version="*",
     ) as client:
         assert await client.wait_until_dead(), "Server is running and must not be."
 
-        with DevServer(port=port) as server:
+        with DevServer(port=function_scope_free_port) as server:
             server.start()
             assert await client.wait_until_alive(), "Server never became available."
 

--- a/robot-server/tests/integration/http_api/runs/test_protocol_run.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_protocol_run.tavern.yaml
@@ -2,11 +2,12 @@ test_name: Upload and run a protocol.
 
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: Upload a protocol
     request:
-      url: '{host:s}:{port:d}/protocols'
+      url: '{host:s}:{free_port:s}/protocols'
       method: POST
       files:
         files: 'tests/integration/protocols/load_one_labware.py'
@@ -18,7 +19,7 @@ stages:
 
   - name: Create run from protocol
     request:
-      url: '{host:s}:{port:d}/runs'
+      url: '{host:s}:{free_port:s}/runs'
       method: POST
       json:
         data:
@@ -50,7 +51,7 @@ stages:
 
   - name: Get the specific run we just created, by its ID, and make sure it's the same
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}'
+      url: '{host:s}:{free_port:s}/runs/{run_id}'
       method: GET
     response:
       status_code: 200
@@ -60,7 +61,7 @@ stages:
 
   - name: Get all runs and make sure our new run is included
     request:
-      url: '{host:s}:{port:d}/runs'
+      url: '{host:s}:{free_port:s}/runs'
       method: GET
     response:
       strict:
@@ -80,7 +81,7 @@ stages:
 
   - name: Add a labware offset to the run
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}/labware_offsets'
+      url: '{host:s}:{free_port:s}/runs/{run_id}/labware_offsets'
       method: POST
       json:
         data:
@@ -110,7 +111,7 @@ stages:
 
   - name: Play the run
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}/actions'
+      url: '{host:s}:{free_port:s}/runs/{run_id}/actions'
       method: POST
       json:
         data:
@@ -133,7 +134,7 @@ stages:
     max_retries: 10
     delay_after: 0.1
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}'
+      url: '{host:s}:{free_port:s}/runs/{run_id}'
       method: GET
     response:
       status_code: 200
@@ -145,7 +146,7 @@ stages:
 
   - name: Verify commands succeeded with the expected results
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}/commands'
+      url: '{host:s}:{free_port:s}/runs/{run_id}/commands'
       method: GET
     response:
       status_code: 200
@@ -175,7 +176,7 @@ stages:
 
   - name: Get full details of the load labware command and make sure the offset applied
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}/commands/{load_labware_command_id}'
+      url: '{host:s}:{free_port:s}/runs/{run_id}/commands/{load_labware_command_id}'
       method: GET
     response:
       status_code: 200
@@ -203,7 +204,7 @@ stages:
 
   - name: Mark the run as not-current and check its final data
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}'
+      url: '{host:s}:{free_port:s}/runs/{run_id}'
       method: PATCH
       json:
         data:
@@ -260,7 +261,7 @@ stages:
 
   - name: Get the run by its ID one last time and make sure its data is the same
     request:
-      url: '{host:s}:{port:d}/runs/{run_id}'
+      url: '{host:s}:{free_port:s}/runs/{run_id}'
       method: GET
     response:
       status_code: 200
@@ -270,7 +271,7 @@ stages:
 
   - name: Verify underlying protocol cannot be deleted
     request:
-      url: '{host:s}:{port:d}/protocols/{protocol_id}'
+      url: '{host:s}:{free_port:s}/protocols/{protocol_id}'
       method: DELETE
     response:
       status_code: 409

--- a/robot-server/tests/integration/http_api/runs/test_run_status.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_run_status.tavern.yaml
@@ -2,12 +2,13 @@ test_name: Alter the value of run status and current
 
 marks:
   - usefixtures:
+      - free_port
       - run_server
 
 stages:
   - name: Create Empty Run 1
     request:
-      url: '{host:s}:{port:d}/runs'
+      url: '{host:s}:{free_port:s}/runs'
       json:
         data: {}
       method: POST
@@ -25,7 +26,7 @@ stages:
           first_run_id: data.id
   - name: Patch the Run
     request:
-      url: '{host:s}:{port:d}/runs/{first_run_id}'
+      url: '{host:s}:{free_port:s}/runs/{first_run_id}'
       json:
         data: { 'current': false }
       method: PATCH
@@ -40,7 +41,7 @@ stages:
           current: false
   - name: Create Empty Run 2
     request:
-      url: '{host:s}:{port:d}/runs'
+      url: '{host:s}:{free_port:s}/runs'
       json:
         data: {}
       method: POST
@@ -58,7 +59,7 @@ stages:
           second_run_id: data.id
   - name: Create Empty Run 3
     request:
-      url: '{host:s}:{port:d}/runs'
+      url: '{host:s}:{free_port:s}/runs'
       json:
         data: {}
       method: POST
@@ -76,7 +77,7 @@ stages:
           third_run_id: data.id
   - name: Get run 2
     request:
-      url: '{host:s}:{port:d}/runs/{second_run_id}'
+      url: '{host:s}:{free_port:s}/runs/{second_run_id}'
       method: GET
     response:
       strict:
@@ -89,7 +90,7 @@ stages:
           current: false
   - name: Get run 3
     request:
-      url: '{host:s}:{port:d}/runs/{third_run_id}'
+      url: '{host:s}:{free_port:s}/runs/{third_run_id}'
       method: GET
     response:
       strict:
@@ -102,7 +103,7 @@ stages:
           current: true
   - name: Create Empty Run 4
     request:
-      url: '{host:s}:{port:d}/runs'
+      url: '{host:s}:{free_port:s}/runs'
       json:
         data: {}
       method: POST
@@ -120,7 +121,7 @@ stages:
           fourth_run_id: data.id
   - name: Issue stop action to Run 4
     request:
-      url: '{host:s}:{port:d}/runs/{fourth_run_id}/actions'
+      url: '{host:s}:{free_port:s}/runs/{fourth_run_id}/actions'
       json:
         data:
           actionType: stop
@@ -129,7 +130,7 @@ stages:
       status_code: 201
   - name: Get run 4
     request:
-      url: '{host:s}:{port:d}/runs/{fourth_run_id}'
+      url: '{host:s}:{free_port:s}/runs/{fourth_run_id}'
       method: GET
     response:
       strict:

--- a/robot-server/tests/integration/sessions/test_calibration_check.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_calibration_check.tavern.yaml
@@ -4,14 +4,15 @@ strict:
   - json:on
 marks:
   - usefixtures:
-      - run_server
       - set_up_pipette_offset_temp_directory
       - set_up_tip_length_temp_directory
       - set_up_deck_calibration_temp_directory
+      - function_scope_free_port
+      - function_scope_run_server
 stages:
   - name: Create the session
     request:
-      url: "{host:s}:{port:d}/sessions"
+      url: "{host:s}:{function_scope_free_port:s}/sessions"
       method: POST
       json:
         data:
@@ -27,7 +28,7 @@ stages:
 
   - name: Check that current state is sessionStarted
     request: &get_session
-      url: "{host:s}:{port:d}/sessions/{session_id}"
+      url: "{host:s}:{function_scope_free_port:s}/sessions/{session_id}"
       method: GET
     response:
       status_code: 200
@@ -52,7 +53,7 @@ stages:
 
   - name: Load labware
     request: &post_command
-      url: "{host:s}:{port:d}/sessions/{session_id}/commands/execute"
+      url: "{host:s}:{function_scope_free_port:s}/sessions/{session_id}/commands/execute"
       method: POST
       json:
         data:
@@ -478,14 +479,14 @@ stages:
 
   - name: Delete the session
     request:
-      url: "{host:s}:{port:d}/sessions/{session_id}"
+      url: "{host:s}:{function_scope_free_port:s}/sessions/{session_id}"
       method: DELETE
     response:
       status_code: 200
 
   - name: There are no sessions
     request:
-      url: "{host:s}:{port:d}/sessions"
+      url: "{host:s}:{function_scope_free_port:s}/sessions"
       method: GET
     response:
       status_code: 200
@@ -498,14 +499,15 @@ strict:
   - json:on
 marks:
   - usefixtures:
-      - run_server
       - set_up_pipette_offset_temp_directory
       - set_up_tip_length_temp_directory
       - set_up_deck_calibration_temp_directory
+      - function_scope_free_port
+      - function_scope_run_server
 stages:
   - name: Create the session
     request:
-      url: "{host:s}:{port:d}/sessions"
+      url: "{host:s}:{function_scope_free_port:s}/sessions"
       method: POST
       json:
         data:
@@ -551,7 +553,7 @@ stages:
 
   - name: Delete the session
     request:
-      url: "{host:s}:{port:d}/sessions/{session_id}"
+      url: "{host:s}:{function_scope_free_port:s}/sessions/{session_id}"
       method: DELETE
     response:
       status_code: 200

--- a/robot-server/tests/integration/sessions/test_deck_calibration.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_deck_calibration.tavern.yaml
@@ -4,11 +4,12 @@ strict:
   - json:on
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: Create the session
     request:
-      url: "{host:s}:{port:d}/sessions"
+      url: "{host:s}:{free_port:s}/sessions"
       method: POST
       json:
         data:
@@ -21,7 +22,7 @@ stages:
 
   - name: Get the session
     request: &get_session
-      url: "{host:s}:{port:d}/sessions/{session_id}"
+      url: "{host:s}:{free_port:s}/sessions/{session_id}"
       method: GET
     response:
       status_code: 200
@@ -40,7 +41,7 @@ stages:
 
   - name: Load labware
     request: &post_command
-      url: "{host:s}:{port:d}/sessions/{session_id}/commands/execute"
+      url: "{host:s}:{free_port:s}/sessions/{session_id}/commands/execute"
       method: POST
       json:
         data:
@@ -200,7 +201,7 @@ stages:
 
   - name: Move to point one
     request:
-      url: "{host:s}:{port:d}/sessions/{session_id}/commands/execute"
+      url: "{host:s}:{free_port:s}/sessions/{session_id}/commands/execute"
       method: POST
       json:
         data:
@@ -222,7 +223,7 @@ stages:
 
   - name: Move to point two
     request:
-      url: "{host:s}:{port:d}/sessions/{session_id}/commands/execute"
+      url: "{host:s}:{free_port:s}/sessions/{session_id}/commands/execute"
       method: POST
       json:
         data:
@@ -244,7 +245,7 @@ stages:
 
   - name: Move to point three
     request:
-      url: "{host:s}:{port:d}/sessions/{session_id}/commands/execute"
+      url: "{host:s}:{free_port:s}/sessions/{session_id}/commands/execute"
       method: POST
       json:
         data:
@@ -266,7 +267,7 @@ stages:
 
   - name: Exit Session
     request:
-      url: "{host:s}:{port:d}/sessions/{session_id}/commands/execute"
+      url: "{host:s}:{free_port:s}/sessions/{session_id}/commands/execute"
       method: POST
       json:
         data:
@@ -288,14 +289,14 @@ stages:
 
   - name: Delete the session
     request:
-      url: "{host:s}:{port:d}/sessions/{session_id}"
+      url: "{host:s}:{free_port:s}/sessions/{session_id}"
       method: DELETE
     response:
       status_code: 200
 
   - name: There are no session
     request:
-        url: "{host:s}:{port:d}/sessions"
+        url: "{host:s}:{free_port:s}/sessions"
         method: GET
     response:
       status_code: 200

--- a/robot-server/tests/integration/sessions/test_tip_length_calibration.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_tip_length_calibration.tavern.yaml
@@ -4,11 +4,12 @@ strict:
   - json:on
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: Create the session
     request:
-      url: "{host:s}:{port:d}/sessions"
+      url: "{host:s}:{free_port:s}/sessions"
       method: POST
       json:
         data:
@@ -24,7 +25,7 @@ stages:
           session_id: data.id
   - name: Get the session
     request:
-      url: "{host:s}:{port:d}/sessions/{session_id}"
+      url: "{host:s}:{free_port:s}/sessions/{session_id}"
       method: GET
     response:
       status_code: 200
@@ -48,7 +49,7 @@ stages:
 
   - name: Load labware
     request:
-      url: "{host:s}:{port:d}/sessions/{session_id}/commands/execute"
+      url: "{host:s}:{free_port:s}/sessions/{session_id}/commands/execute"
       method: POST
       json:
         data:
@@ -72,7 +73,7 @@ stages:
 
   - name: Attempt conflicting command
     request:
-      url: "{host:s}:{port:d}/sessions/{session_id}/commands/execute"
+      url: "{host:s}:{free_port:s}/sessions/{session_id}/commands/execute"
       method: POST
       json:
         data:
@@ -83,14 +84,14 @@ stages:
 
   - name: Delete the session
     request:
-      url: "{host:s}:{port:d}/sessions/{session_id}"
+      url: "{host:s}:{free_port:s}/sessions/{session_id}"
       method: DELETE
     response:
       status_code: 200
 
   - name: There are no sessions
     request:
-      url: "{host:s}:{port:d}/sessions"
+      url: "{host:s}:{free_port:s}/sessions"
       method: GET
     response:
       status_code: 200

--- a/robot-server/tests/integration/system/test_system_time.tavern.yaml
+++ b/robot-server/tests/integration/system/test_system_time.tavern.yaml
@@ -2,11 +2,12 @@
 test_name: GET Time
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: System Time GET request returns time in correct format
     request:
-      url: "{host:s}:{port:d}/system/time"
+      url: "{host:s}:{free_port:s}/system/time"
       method: GET
     response:
       status_code: 200
@@ -23,11 +24,12 @@ stages:
 test_name: PUT Time
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: System Time PUT request without a time returns a missing field error
     request:
-      url: "{host:s}:{port:d}/system/time"
+      url: "{host:s}:{free_port:s}/system/time"
       method: PUT
       json:
         data:
@@ -43,7 +45,7 @@ stages:
               pointer: "/data/systemTime"
   - name: System Time PUT request on a dev server raises error
     request:
-      url: "{host:s}:{port:d}/system/time"
+      url: "{host:s}:{free_port:s}/system/time"
       method: PUT
       json:
         data:

--- a/robot-server/tests/integration/test_deck_calibration.tavern.yaml
+++ b/robot-server/tests/integration/test_deck_calibration.tavern.yaml
@@ -2,11 +2,12 @@
 test_name: Get calibration status
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: Get the status
     request:
-      url: "{host:s}:{port:d}/calibration/status"
+      url: "{host:s}:{free_port:s}/calibration/status"
       method: GET
     response:
       status_code: 200

--- a/robot-server/tests/integration/test_health_check.tavern.yaml
+++ b/robot-server/tests/integration/test_health_check.tavern.yaml
@@ -2,11 +2,12 @@
 test_name: GET Health
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: Health GET request returns correct info
     request:
-      url: "{host:s}:{port:d}/health"
+      url: "{host:s}:{free_port:s}/health"
       method: GET
     response:
       status_code: 200

--- a/robot-server/tests/integration/test_identify.tavern.yaml
+++ b/robot-server/tests/integration/test_identify.tavern.yaml
@@ -2,12 +2,13 @@
 test_name: POST Identify
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: Identify a robot by flashing the lights
     request:
       method: POST
-      url: "{host:s}:{port:d}/identify"
+      url: "{host:s}:{free_port:s}/identify"
       params:
         seconds: 5
     response:
@@ -18,12 +19,13 @@ stages:
 test_name: POST Identify without params
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: Attempt to send identify request without parameters
     request:
       method: POST
-      url: "{host:s}:{port:d}/identify"
+      url: "{host:s}:{free_port:s}/identify"
     response:
       status_code: 422
       json:

--- a/robot-server/tests/integration/test_labware_calibration_access.tavern.yaml
+++ b/robot-server/tests/integration/test_labware_calibration_access.tavern.yaml
@@ -1,11 +1,12 @@
 test_name: Labware calibration endpoints
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: GET /labware/calibrations returns 410
     request:
-      url: '{host:s}:{port:d}/labware/calibrations'
+      url: '{host:s}:{free_port:s}/labware/calibrations'
       method: GET
     response:
       status_code: 410
@@ -16,7 +17,7 @@ stages:
             detail: 'Use the `/runs` endpoints to manage labware offsets.'
   - name: GET /labware/calibrations/:id returns 410
     request:
-      url: '{host:s}:{port:d}/labware/calibrations/some-id'
+      url: '{host:s}:{free_port:s}/labware/calibrations/some-id'
       method: GET
     response:
       status_code: 410
@@ -27,7 +28,7 @@ stages:
             detail: 'Use the `/runs` endpoints to manage labware offsets.'
   - name: DELETE /labware/calibrations/:id returns 410
     request:
-      url: '{host:s}:{port:d}/labware/calibrations/some-id'
+      url: '{host:s}:{free_port:s}/labware/calibrations/some-id'
       method: DELETE
     response:
       status_code: 410
@@ -38,7 +39,7 @@ stages:
             detail: 'Use the `/runs` endpoints to manage labware offsets.'
   - name: GET /labware/calibrations returns empty list on version <= 3
     request:
-      url: '{host:s}:{port:d}/labware/calibrations'
+      url: '{host:s}:{free_port:s}/labware/calibrations'
       method: GET
       headers:
         Opentrons-Version: '3'
@@ -49,7 +50,7 @@ stages:
         data: []
   - name: GET /labware/calibrations/:id returns 404 on version <=3
     request:
-      url: '{host:s}:{port:d}/labware/calibrations/some-id'
+      url: '{host:s}:{free_port:s}/labware/calibrations/some-id'
       method: GET
       headers:
         Opentrons-Version: '3'
@@ -62,7 +63,7 @@ stages:
             detail: "Resource type 'calibration' with id 'some-id' was not found"
   - name: DELETE /labware/calibrations/:id returns 404 on version <=3
     request:
-      url: '{host:s}:{port:d}/labware/calibrations/some-id'
+      url: '{host:s}:{free_port:s}/labware/calibrations/some-id'
       method: DELETE
       headers:
         Opentrons-Version: '3'

--- a/robot-server/tests/integration/test_modules.tavern.yaml
+++ b/robot-server/tests/integration/test_modules.tavern.yaml
@@ -2,11 +2,12 @@
 test_name: Get modules
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: Get all the modules (legacy)
     request:
-      url: '{host:s}:{port:d}/modules'
+      url: '{host:s}:{free_port:s}/modules'
       method: GET
       headers:
         Opentrons-Version: '2'
@@ -87,7 +88,7 @@ stages:
               engaged: !anybool
   - name: Get all the modules
     request:
-      url: '{host:s}:{port:d}/modules'
+      url: '{host:s}:{free_port:s}/modules'
       method: GET
     response:
       status_code: 200

--- a/robot-server/tests/integration/test_motors.tavern.yaml
+++ b/robot-server/tests/integration/test_motors.tavern.yaml
@@ -2,11 +2,12 @@
 test_name: Get engaged motors
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: Get status of all motors
     request:
-      url: "{host:s}:{port:d}/motors/engaged"
+      url: "{host:s}:{free_port:s}/motors/engaged"
       method: GET
     response:
       status_code: 200
@@ -27,11 +28,12 @@ stages:
 test_name: Disengage motors
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: Disengae motors
     request:
-      url: "{host:s}:{port:d}/motors/disengage"
+      url: "{host:s}:{free_port:s}/motors/disengage"
       method: POST
       json:
         axes:
@@ -43,7 +45,7 @@ stages:
         message: !re_search "Disengaged axes"
   - name: Verify disengaged motors
     request:
-      url: "{host:s}:{port:d}/motors/engaged"
+      url: "{host:s}:{free_port:s}/motors/engaged"
       method: GET
     response:
       status_code: 200

--- a/robot-server/tests/integration/test_pipette_offset_access.tavern.yaml
+++ b/robot-server/tests/integration/test_pipette_offset_access.tavern.yaml
@@ -2,11 +2,12 @@
 test_name: GET Pipette Offset Calibration, No Calibrations
 marks:
   - usefixtures:
-    - run_server
+    - function_scope_free_port
+    - function_scope_run_server
 stages:
   - name: GET request returns an empty list
     request: &get_offsets
-      url: "{host:s}:{port:d}/calibration/pipette_offset"
+      url: "{host:s}:{function_scope_free_port:s}/calibration/pipette_offset"
       method: GET
     response: &no_offset_response
       status_code: 200
@@ -15,11 +16,12 @@ stages:
         data: []
 
 ---
-test_name: GET Pipette Offset Calibration, Wtih Calibrations
+test_name: GET Pipette Offset Calibration, With Calibrations
 marks: &cal_marks
   - usefixtures:
-    - run_server
     - set_up_pipette_offset_temp_directory
+    - function_scope_free_port
+    - function_scope_run_server
 stages:
   - name: GET request returns all calibrations from fixture
     request: *get_offsets
@@ -49,7 +51,7 @@ stages:
 
   - name: GET request returns filter with pipette id
     request:
-      url: "{host:s}:{port:d}/calibration/pipette_offset"
+      url: "{host:s}:{function_scope_free_port:s}/calibration/pipette_offset"
       method: GET
       params:
         pipette_id: '123'
@@ -70,7 +72,7 @@ stages:
 
   - name: GET request returns filter with mount
     request:
-      url: "{host:s}:{port:d}/calibration/pipette_offset"
+      url: "{host:s}:{function_scope_free_port:s}/calibration/pipette_offset"
       method: GET
       params:
         mount: 'left'
@@ -91,7 +93,7 @@ stages:
 
   - name: GET request returns filter with pipette AND mount
     request:
-      url: "{host:s}:{port:d}/calibration/pipette_offset"
+      url: "{host:s}:{function_scope_free_port:s}/calibration/pipette_offset"
       method: GET
       params:
         pipette_id: '123'
@@ -113,7 +115,7 @@ stages:
 
   - name: GET request returns filter with wrong pipette AND mount
     request:
-      url: "{host:s}:{port:d}/calibration/pipette_offset"
+      url: "{host:s}:{function_scope_free_port:s}/calibration/pipette_offset"
       method: GET
       params:
         pipette_id: '321'
@@ -126,7 +128,7 @@ marks: *cal_marks
 stages:
   - name: DELETE request with correct pipette AND mount
     request:
-      url: "{host:s}:{port:d}/calibration/pipette_offset"
+      url: "{host:s}:{function_scope_free_port:s}/calibration/pipette_offset"
       method: DELETE
       params:
         pipette_id: '321'
@@ -136,7 +138,7 @@ stages:
 
   - name: DELETE request with incorrect pipette AND MOUNT
     request:
-      url: "{host:s}:{port:d}/calibration/pipette_offset"
+      url: "{host:s}:{function_scope_free_port:s}/calibration/pipette_offset"
       method: DELETE
       params:
         pipette_id: '321'

--- a/robot-server/tests/integration/test_pipettes.tavern.yaml
+++ b/robot-server/tests/integration/test_pipettes.tavern.yaml
@@ -2,11 +2,12 @@
 test_name: Get pipettes
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: Get all the attached pipettes
     request:
-      url: "{host:s}:{port:d}/pipettes"
+      url: "{host:s}:{free_port:s}/pipettes"
       method: GET
     response:
       status_code: 200

--- a/robot-server/tests/integration/test_robot.tavern.yaml
+++ b/robot-server/tests/integration/test_robot.tavern.yaml
@@ -2,12 +2,13 @@
 test_name: GET list of useful robot positions
 marks:
   - usefixtures:
+    - free_port
     - run_server
 stages:
   - name: Get robot positions
     request:
       method: GET
-      url: "{host:s}:{port:d}/robot/positions"
+      url: "{host:s}:{free_port:s}/robot/positions"
     response:
       status_code: 200
       json:
@@ -32,12 +33,13 @@ stages:
 test_name: POST Move Robot
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: GET the left pipette attached to the robot
     request:
       method: GET
-      url: "{host:s}:{port:d}/pipettes"
+      url: "{host:s}:{free_port:s}/pipettes"
     response:
       status_code: 200
       save:
@@ -46,7 +48,7 @@ stages:
   - name: POST Move the left pipette to a specific location
     request:
       method: POST
-      url: "{host:s}:{port:d}/robot/move"
+      url: "{host:s}:{free_port:s}/robot/move"
       json:
         target: pipette
         point:
@@ -63,12 +65,13 @@ stages:
 test_name: POST Robot Home
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: Home the Robot
     request:
       method: POST
-      url: "{host:s}:{port:d}/robot/home"
+      url: "{host:s}:{free_port:s}/robot/home"
       json:
         target: pipette
         mount: right
@@ -80,12 +83,13 @@ stages:
 test_name: Turn on the robot lights
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: POST Robot Lights
     request:
       method: POST
-      url: "{host:s}:{port:d}/robot/lights"
+      url: "{host:s}:{free_port:s}/robot/lights"
       json:
         "on": true # needed to escape "on" because it is a keyword
     response:
@@ -95,7 +99,7 @@ stages:
   - name: GET Robot lights status
     request:
       method: GET
-      url: "{host:s}:{port:d}/robot/lights"
+      url: "{host:s}:{free_port:s}/robot/lights"
     response:
       status_code: 200
       json:
@@ -104,12 +108,13 @@ stages:
 test_name: Turn off the robot lights
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: POST Robot Lights
     request:
       method: POST
-      url: "{host:s}:{port:d}/robot/lights"
+      url: "{host:s}:{free_port:s}/robot/lights"
       json:
         "on": false
     response:
@@ -119,7 +124,7 @@ stages:
   - name: GET Robot lights status
     request:
       method: GET
-      url: "{host:s}:{port:d}/robot/lights"
+      url: "{host:s}:{free_port:s}/robot/lights"
     response:
       status_code: 200
       json:

--- a/robot-server/tests/integration/test_session.tavern.yaml
+++ b/robot-server/tests/integration/test_session.tavern.yaml
@@ -2,11 +2,12 @@
 test_name: Session Lifecycle
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: Create a session
     request:
-      url: '{host:s}:{port:d}/sessions'
+      url: '{host:s}:{free_port:s}/sessions'
       method: POST
       json:
         data:
@@ -19,21 +20,21 @@ stages:
 
   - name: Get the session
     request:
-      url: '{host:s}:{port:d}/sessions/{session_id}'
+      url: '{host:s}:{free_port:s}/sessions/{session_id}'
       method: GET
     response:
       status_code: 200
 
   - name: Delete the session
     request:
-      url: '{host:s}:{port:d}/sessions/{session_id}'
+      url: '{host:s}:{free_port:s}/sessions/{session_id}'
       method: DELETE
     response:
       status_code: 200
 
   - name: Fail to get the deleted session
     request:
-      url: '{host:s}:{port:d}/sessions/{session_id}'
+      url: '{host:s}:{free_port:s}/sessions/{session_id}'
       method: GET
     response:
       status_code: 404
@@ -42,11 +43,12 @@ stages:
 test_name: Multiple Session Lifecycle
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: Create a pipette offset calibration session
     request:
-      url: '{host:s}:{port:d}/sessions'
+      url: '{host:s}:{free_port:s}/sessions'
       method: POST
       json:
         data:
@@ -61,7 +63,7 @@ stages:
 
   - name: Create a deck cal session
     request:
-      url: '{host:s}:{port:d}/sessions'
+      url: '{host:s}:{free_port:s}/sessions'
       method: POST
       json:
         data:
@@ -74,7 +76,7 @@ stages:
 
   - name: Get all the sessions
     request:
-      url: '{host:s}:{port:d}/sessions'
+      url: '{host:s}:{free_port:s}/sessions'
       method: GET
     response:
       status_code: 200
@@ -94,7 +96,7 @@ stages:
 
   - name: Get just the deck cal sessions
     request:
-      url: '{host:s}:{port:d}/sessions?session_type=deckCalibration'
+      url: '{host:s}:{free_port:s}/sessions?session_type=deckCalibration'
       method: GET
     response:
       status_code: 200
@@ -109,21 +111,21 @@ stages:
 
   - name: Delete session 1
     request:
-      url: '{host:s}:{port:d}/sessions/{session_id_1}'
+      url: '{host:s}:{free_port:s}/sessions/{session_id_1}'
       method: DELETE
     response:
       status_code: 200
 
   - name: Delete session 2
     request:
-      url: '{host:s}:{port:d}/sessions/{session_id_2}'
+      url: '{host:s}:{free_port:s}/sessions/{session_id_2}'
       method: DELETE
     response:
       status_code: 200
 
   - name: Get all the sessions and there are none
     request:
-      url: '{host:s}:{port:d}/sessions'
+      url: '{host:s}:{free_port:s}/sessions'
       method: GET
     response:
       status_code: 200

--- a/robot-server/tests/integration/test_settings.tavern.yaml
+++ b/robot-server/tests/integration/test_settings.tavern.yaml
@@ -2,12 +2,13 @@
 test_name: GET Settings
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: Settings GET request returns correct info
     request:
       method: GET
-      url: '{host:s}:{port:d}/settings'
+      url: '{host:s}:{free_port:s}/settings'
     response:
       status_code: 200
       json:
@@ -67,6 +68,7 @@ stages:
 test_name: POST Setting and value
 marks:
   - usefixtures:
+      - free_port
       - run_server
   - parametrize:
       key: id
@@ -86,7 +88,7 @@ stages:
   - name: Set each setting to acceptable values
     request:
       method: POST
-      url: '{host:s}:{port:d}/settings'
+      url: '{host:s}:{free_port:s}/settings'
       json:
         id: '{id}'
         value: '{value}'
@@ -103,6 +105,7 @@ stages:
 test_name: POST Settings with no values
 marks:
   - usefixtures:
+      - free_port
       - run_server
   - parametrize:
       key: id
@@ -117,7 +120,7 @@ stages:
   - name: Set each setting to acceptable values
     request:
       method: POST
-      url: '{host:s}:{port:d}/settings'
+      url: '{host:s}:{free_port:s}/settings'
       json:
         id: '{id}'
     response:
@@ -133,12 +136,13 @@ stages:
 test_name: POST With incorrect ID
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: Post with incorrect ID
     request:
       method: POST
-      url: '{host:s}:{port:d}/settings'
+      url: '{host:s}:{free_port:s}/settings'
       json:
         id: notARealID
         value: true

--- a/robot-server/tests/integration/test_settings_log_level.tavern.yaml
+++ b/robot-server/tests/integration/test_settings_log_level.tavern.yaml
@@ -2,6 +2,7 @@
 test_name: POST Acceptable Log Level
 marks:
   - usefixtures:
+      - free_port
       - run_server
   - parametrize:
       key: log_level
@@ -14,7 +15,7 @@ stages:
   - name: Set log_level to acceptable values 
     request:
       method: POST
-      url: "{host:s}:{port:d}/settings/log_level/local"
+      url: "{host:s}:{free_port:s}/settings/log_level/local"
       json: 
         log_level: "{log_level}"
     response:
@@ -26,12 +27,13 @@ stages:
 test_name: POST Set log level to invalid value
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: Set log_level to error 
     request:
       method: POST
-      url: "{host:s}:{port:d}/settings/log_level/local"
+      url: "{host:s}:{free_port:s}/settings/log_level/local"
       json: 
         log_level: bad_level
     response:
@@ -42,12 +44,13 @@ stages:
 test_name: POST Set log level to nothing
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: Set log_level to nothing 
     request:
       method: POST
-      url: "{host:s}:{port:d}/settings/log_level/local"
+      url: "{host:s}:{free_port:s}/settings/log_level/local"
       json: 
         log_level: Null
     response:

--- a/robot-server/tests/integration/test_settings_pipettes.tavern.yaml
+++ b/robot-server/tests/integration/test_settings_pipettes.tavern.yaml
@@ -2,12 +2,13 @@
 test_name: GET Pipettes
 marks:
   - usefixtures:
-      - run_server
       - attach_pipettes
+      - function_scope_free_port
+      - function_scope_run_server
 stages:
   - name: GET Pipette Settings request returns correct info
     request:
-      url: "{host:s}:{port:d}/settings/pipettes"
+      url: "{host:s}:{function_scope_free_port:s}/settings/pipettes"
       method: GET
     response:
       status_code: 200
@@ -36,12 +37,13 @@ stages:
 test_name: GET Pipette {pipette_id}
 marks:
   - usefixtures:
-      - run_server
       - attach_pipettes
+      - function_scope_free_port
+      - function_scope_run_server
 stages:
   - name: GET Pipette Settings of specific pipette request returns correct info
     request:
-      url: "{host:s}:{port:d}/settings/pipettes/testpipette01"
+      url: "{host:s}:{function_scope_free_port:s}/settings/pipettes/testpipette01"
       method: GET
     response:
       status_code: 200
@@ -69,12 +71,13 @@ stages:
 test_name: PATCH Pipette {pipette_id} single value
 marks:
   - usefixtures:
-      - run_server
       - attach_pipettes
+      - function_scope_free_port
+      - function_scope_run_server
 stages:
   - name: PATCH Pipette Settings of a single value
     request:
-      url: "{host:s}:{port:d}/settings/pipettes/testpipette01"
+      url: "{host:s}:{function_scope_free_port:s}/settings/pipettes/testpipette01"
       method: PATCH
       json:
         fields:
@@ -112,12 +115,13 @@ stages:
 test_name: PATCH Pipette {pipette_id} multiple values
 marks:
   - usefixtures:
-      - run_server
       - attach_pipettes
+      - function_scope_free_port
+      - function_scope_run_server
 stages:
   - name: PATCH Pipette Settings of multiple values
     request:
-      url: "{host:s}:{port:d}/settings/pipettes/testpipette01"
+      url: "{host:s}:{function_scope_free_port:s}/settings/pipettes/testpipette01"
       method: PATCH
       json:
         fields:
@@ -171,12 +175,13 @@ stages:
 test_name: PATCH Pipette {pipette_id} value too low
 marks:
   - usefixtures:
-      - run_server
       - attach_pipettes
+      - function_scope_free_port
+      - function_scope_run_server
 stages:
   - name: PATCH Pipette Settings with too low of a value
     request:
-      url: "{host:s}:{port:d}/settings/pipettes/testpipette01"
+      url: "{host:s}:{function_scope_free_port:s}/settings/pipettes/testpipette01"
       method: PATCH
       json:
         fields:
@@ -191,12 +196,13 @@ stages:
 test_name: PATCH Pipette {pipette_id} value too high
 marks:
   - usefixtures:
-      - run_server
       - attach_pipettes
+      - function_scope_free_port
+      - function_scope_run_server
 stages:
   - name: PATCH Pipette Settings with too high of a value
     request:
-      url: "{host:s}:{port:d}/settings/pipettes/testpipette01"
+      url: "{host:s}:{function_scope_free_port:s}/settings/pipettes/testpipette01"
       method: PATCH
       json:
         fields:
@@ -211,12 +217,13 @@ stages:
 test_name: PATCH Pipette {pipette_id} no value
 marks:
   - usefixtures:
-      - run_server
       - attach_pipettes
+      - function_scope_free_port
+      - function_scope_run_server
 stages:
   - name: PATCH Pipette Settings with no value at all (should reset to default)
     request:
-      url: "{host:s}:{port:d}/settings/pipettes/testpipette01"
+      url: "{host:s}:{function_scope_free_port:s}/settings/pipettes/testpipette01"
       method: PATCH
       json:
         fields:

--- a/robot-server/tests/integration/test_settings_reset_options.tavern.yaml
+++ b/robot-server/tests/integration/test_settings_reset_options.tavern.yaml
@@ -2,11 +2,12 @@
 test_name: GET Settings Reset Options
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: Reset Options GET request returns correct option
     request:
-      url: '{host:s}:{port:d}/settings/reset/options'
+      url: '{host:s}:{free_port:s}/settings/reset/options'
       method: GET
     response:
       status_code: 200
@@ -31,11 +32,12 @@ stages:
 test_name: POST Reset bootScripts option
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: POST Reset bootScripts true
     request:
-      url: '{host:s}:{port:d}/settings/reset'
+      url: '{host:s}:{free_port:s}/settings/reset'
       method: POST
       json:
         bootScripts: true
@@ -45,7 +47,7 @@ stages:
         message: "Options 'boot_scripts' were reset"
   - name: POST Reset bootScripts false
     request:
-      url: '{host:s}:{port:d}/settings/reset'
+      url: '{host:s}:{free_port:s}/settings/reset'
       method: POST
       json:
         bootScripts: false
@@ -57,11 +59,12 @@ stages:
 test_name: POST Reset deck calibration option
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: POST Reset deckCalibration true
     request:
-      url: '{host:s}:{port:d}/settings/reset'
+      url: '{host:s}:{free_port:s}/settings/reset'
       method: POST
       json:
         deckCalibration: true
@@ -71,7 +74,7 @@ stages:
         message: "Options 'deck_calibration' were reset"
   - name: POST Reset deckCalibration false
     request:
-      url: '{host:s}:{port:d}/settings/reset'
+      url: '{host:s}:{free_port:s}/settings/reset'
       method: POST
       json:
         deckCalibration: false
@@ -83,11 +86,12 @@ stages:
 test_name: POST Reset pipette offset calibrations option
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: POST Reset pipetteOffsetCalibrations true
     request:
-      url: '{host:s}:{port:d}/settings/reset'
+      url: '{host:s}:{free_port:s}/settings/reset'
       method: POST
       json:
         pipetteOffsetCalibrations: true
@@ -97,7 +101,7 @@ stages:
         message: "Options 'pipette_offset' were reset"
   - name: POST Reset pipetteOffsetCalibrations false
     request:
-      url: '{host:s}:{port:d}/settings/reset'
+      url: '{host:s}:{free_port:s}/settings/reset'
       method: POST
       json:
         pipetteOffsetCalibrations: false
@@ -109,11 +113,12 @@ stages:
 test_name: POST Reset non existant option
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: POST Reset non existant option
     request:
-      url: '{host:s}:{port:d}/settings/reset'
+      url: '{host:s}:{free_port:s}/settings/reset'
       method: POST
       json:
         doesNotExist: true

--- a/robot-server/tests/integration/test_settings_robot.tavern.yaml
+++ b/robot-server/tests/integration/test_settings_robot.tavern.yaml
@@ -2,11 +2,12 @@
 test_name: GET Robot Settings
 marks:
   - usefixtures:
+      - free_port
       - run_server
 stages:
   - name: Settings Robot GET request returns correct settings
     request:
-      url: "{host:s}:{port:d}/settings/robot"
+      url: "{host:s}:{free_port:s}/settings/robot"
       method: GET
     response:
       status_code: 200

--- a/robot-server/tests/integration/test_tip_length_access.tavern.yaml
+++ b/robot-server/tests/integration/test_tip_length_access.tavern.yaml
@@ -2,11 +2,12 @@
 test_name: GET Tip Length Calibration, No Calibrations
 marks:
   - usefixtures:
-    - run_server
+    - function_scope_free_port
+    - function_scope_run_server
 stages:
   - name: GET request returns an empty list
     request: &get_offsets
-      url: "{host:s}:{port:d}/calibration/tip_length"
+      url: "{host:s}:{function_scope_free_port:s}/calibration/tip_length"
       method: GET
     response: &no_tip_length_response
       status_code: 200
@@ -15,11 +16,12 @@ stages:
         data: []
 
 ---
-test_name: GET Tip Length Calibration, Wtih Calibrations
+test_name: GET Tip Length Calibration, With Calibrations
 marks: &cal_marks
   - usefixtures:
-    - run_server
     - set_up_tip_length_temp_directory
+    - function_scope_free_port
+    - function_scope_run_server
 stages:
   - name: GET request returns all calibrations from fixture
     request: *get_offsets
@@ -53,7 +55,7 @@ stages:
 
   - name: GET request returns filter with pipette id
     request:
-      url: "{host:s}:{port:d}/calibration/tip_length"
+      url: "{host:s}:{function_scope_free_port:s}/calibration/tip_length"
       method: GET
       params:
         pipette_id: '123'
@@ -77,7 +79,7 @@ stages:
 
   - name: GET request returns filter with tiprack hash
     request:
-      url: "{host:s}:{port:d}/calibration/tip_length"
+      url: "{host:s}:{function_scope_free_port:s}/calibration/tip_length"
       method: GET
       params:
         tiprack_hash: '130e17bb7b2f0c0472dcc01c1ff6f600ca1a6f9f86a90982df56c4bf43776824'
@@ -111,7 +113,7 @@ stages:
 
   - name: GET request returns filter with pipette AND tiprack
     request:
-      url: "{host:s}:{port:d}/calibration/tip_length"
+      url: "{host:s}:{function_scope_free_port:s}/calibration/tip_length"
       method: GET
       params:
         pipette_id: '123'
@@ -135,7 +137,7 @@ stages:
 
   - name: GET request returns filter with wrong pipette AND tiprack
     request:
-      url: "{host:s}:{port:d}/calibration/tip_length"
+      url: "{host:s}:{function_scope_free_port:s}/calibration/tip_length"
       method: GET
       params:
         pipette_id: '321'
@@ -148,14 +150,14 @@ marks: *cal_marks
 stages:
   - name: DELETE request with correct pipette AND tiprack
     request:
-      url: "{host:s}:{port:d}/calibration/tip_length?pipette_id=321&tiprack_hash=130e17bb7b2f0c0472dcc01c1ff6f600ca1a6f9f86a90982df56c4bf43776824"
+      url: "{host:s}:{function_scope_free_port:s}/calibration/tip_length?pipette_id=321&tiprack_hash=130e17bb7b2f0c0472dcc01c1ff6f600ca1a6f9f86a90982df56c4bf43776824"
       method: DELETE
     response:
         status_code: 200
 
   - name: DELETE request with incorrect pipette AND tiprack
     request:
-      url: "{host:s}:{port:d}/calibration/tip_length?pipette_id=321&tiprack_hash=wronghash"
+      url: "{host:s}:{function_scope_free_port:s}/calibration/tip_length?pipette_id=321&tiprack_hash=wronghash"
       method: DELETE
     response:
         status_code: 404

--- a/robot-server/tests/integration/test_version_headers.tavern.yaml
+++ b/robot-server/tests/integration/test_version_headers.tavern.yaml
@@ -3,12 +3,13 @@ test_name: Version headers
 
 marks:
   - usefixtures:
+      - free_port
       - run_server
 
 stages:
   - name: Successful request contains version headers
     request:
-      url: '{host:s}:{port:d}/health'
+      url: '{host:s}:{free_port:s}/health'
       method: GET
     response:
       status_code: 200
@@ -18,7 +19,7 @@ stages:
 
   - name: Successful request within range returns version headers
     request:
-      url: '{host:s}:{port:d}/health'
+      url: '{host:s}:{free_port:s}/health'
       method: GET
       headers:
         Opentrons-Version: '2'
@@ -30,7 +31,7 @@ stages:
 
   - name: Version too high request contains version headers
     request:
-      url: '{host:s}:{port:d}/health'
+      url: '{host:s}:{free_port:s}/health'
       method: GET
       headers:
         Opentrons-Version: '1337'
@@ -42,7 +43,7 @@ stages:
 
   - name: Latest version request contains version headers
     request:
-      url: '{host:s}:{port:d}/health'
+      url: '{host:s}:{free_port:s}/health'
       method: GET
       headers:
         Opentrons-Version: '*'
@@ -54,7 +55,7 @@ stages:
 
   - name: Version too low request contains version headers
     request:
-      url: '{host:s}:{port:d}/health'
+      url: '{host:s}:{free_port:s}/health'
       method: GET
       headers:
         Opentrons-Version: '1'
@@ -71,7 +72,7 @@ stages:
 
   - name: Version missing request contains version headers
     request:
-      url: '{host:s}:{port:d}/health'
+      url: '{host:s}:{free_port:s}/health'
       method: GET
       headers:
         Opentrons-Version: ''

--- a/robot-server/tests/service/tip_length/test_tip_length_management.py
+++ b/robot-server/tests/service/tip_length/test_tip_length_management.py
@@ -32,9 +32,7 @@ def test_access_tip_length_calibration(api_client, set_up_tip_length_temp_direct
     assert resp.json()["data"] == []
 
 
-def test_delete_tip_length_calibration(
-    api_client, set_up_pipette_offset_temp_directory
-):
+def test_delete_tip_length_calibration(api_client, set_up_tip_length_temp_directory):
     resp = api_client.delete(
         f"/calibration/tip_length?pipette_id={FAKE_PIPETTE_ID}&"
         f"tiprack_hash={WRONG_LW_HASH}"


### PR DESCRIPTION
# Overview

- Massive speed up locally
  - M1 mac now takes ~1 minute
  - WSL takes ~2 minutes
- Not much speed up in CI as the runner only goes to 2 pools

# Changelog

- Dynamically grab ports
- Explicitly scope fixtures and confine tests as needed
- Use built in temporary path from pytest  

# Review Requests

- Is there a way not to repeat the code in `*run_server`? Since the params are fixtures I couldn't see a way.

# Risk assessment

Low, test only.  Not sure the port cleanup is great?  Especially if ctrl-c or on failure?