### PR TITLE
refactor(app): change definitionId to definitionUri in labware key

### DIFF
--- a/app/src/molecules/PythonLabwareOffsetSnippet/__tests__/createSnippet.test.ts
+++ b/app/src/molecules/PythonLabwareOffsetSnippet/__tests__/createSnippet.test.ts
@@ -2,7 +2,49 @@ import _protocolWithMagTempTC from '@opentrons/shared-data/protocol/fixtures/6/t
 import { createSnippet } from '../createSnippet'
 import { ModuleModel, ProtocolAnalysisFile } from '@opentrons/shared-data'
 
-const protocolWithMagTempTC = (_protocolWithMagTempTC as unknown) as ProtocolAnalysisFile
+const protocolWithMagTempTC = ({
+  ..._protocolWithMagTempTC,
+  labware: {
+    fixedTrash: {
+      displayName: 'Trash',
+      definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+    },
+    '3e047fb0-3412-11eb-ad93-ed232a2337cf:opentrons/opentrons_96_tiprack_1000ul/1': {
+      displayName: 'Opentrons 96 Tip Rack 1000 µL',
+      definitionUri: 'opentrons/opentrons_96_tiprack_1000ul/1',
+    },
+    '5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_1_reservoir_195ml/1': {
+      displayName: 'NEST 1 Well Reservoir 195 mL',
+      definitionUri: 'opentrons/nest_1_reservoir_195ml/1',
+    },
+    '60e8b050-3412-11eb-ad93-ed232a2337cf:opentrons/corning_24_wellplate_3.4ml_flat/1': {
+      displayName: 'Corning 24 Well Plate 3.4 mL Flat',
+      definitionUri: 'opentrons/corning_24_wellplate_3.4ml_flat/1',
+    },
+    'aac5d680-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': {
+      displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
+      definitionUri: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+    },
+    'ada13110-3412-11eb-ad93-ed232a2337cf:opentrons/opentrons_96_aluminumblock_generic_pcr_strip_200ul/1': {
+      displayName:
+        'Opentrons 96 Well Aluminum Block with Generic PCR Strip 200 µL',
+      definitionUri:
+        'opentrons/opentrons_96_aluminumblock_generic_pcr_strip_200ul/1',
+    },
+    'b0103540-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': {
+      displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt (1)',
+      definitionUri: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+    },
+    'faa13a50-a9bf-11eb-bce6-9f1d5b9c1a1b:opentrons/opentrons_96_tiprack_20ul/1': {
+      displayName: 'Opentrons 96 Tip Rack 20 µL',
+      definitionUri: 'opentrons/opentrons_96_tiprack_20ul/1',
+    },
+    '53d3b350-a9c0-11eb-bce6-9f1d5b9c1a1b': {
+      displayName: 'Corning 24 Well Plate 3.4 mL Flat (1)',
+      definitionUri: 'opentrons/corning_24_wellplate_3.4ml_flat/1',
+    },
+  },
+} as unknown) as ProtocolAnalysisFile
 
 // module ids come from the fixture protocol, they are just here for readability
 const TIPRACK_DEF_URI = 'opentrons/opentrons_96_tiprack_1000ul/1'

--- a/app/src/molecules/PythonLabwareOffsetSnippet/createSnippet.ts
+++ b/app/src/molecules/PythonLabwareOffsetSnippet/createSnippet.ts
@@ -25,7 +25,8 @@ export function createSnippet(
         const loadedLabware = protocol.labware[command.result.labwareId]
         if (loadedLabware == null) return acc
         const { loadName } = protocol.labwareDefinitions[
-          loadedLabware.definitionId
+          //  @ts-expect-error
+          loadedLabware.definitionUri
         ].parameters
         if ('slotName' in command.params.location) {
           // load labware on deck
@@ -42,6 +43,7 @@ export function createSnippet(
           protocol.labware,
           protocol.labwareDefinitions
         )
+
         const offsetLocation = getLabwareOffsetLocation(
           command.result.labwareId,
           protocol.commands,

--- a/app/src/organisms/Devices/ProtocolRun/StepText.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/StepText.tsx
@@ -81,7 +81,7 @@ export function StepText(props: Props): JSX.Element | null {
             : getLabwareDisplayName(
                 protocolData.labwareDefinitions[
                   //  @ts-expect-error
-                  `${protocolData.labware[labwareId].definitionUri}_id`
+                  protocolData.labware[labwareId].definitionUri
                 ]
               ),
         labware_location: labwareLocation.slotName,

--- a/app/src/organisms/Devices/ProtocolRun/StepText.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/StepText.tsx
@@ -80,7 +80,8 @@ export function StepText(props: Props): JSX.Element | null {
             ? 'Opentrons Fixed Trash'
             : getLabwareDisplayName(
                 protocolData.labwareDefinitions[
-                  protocolData.labware[labwareId].definitionId
+                  //  @ts-expect-error
+                  `${protocolData.labware[labwareId].definitionUri}_id`
                 ]
               ),
         labware_location: labwareLocation.slotName,

--- a/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getLabwareDefinitionUri.test.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getLabwareDefinitionUri.test.ts
@@ -19,7 +19,7 @@ describe('getLabwareDefinitionUri', () => {
     const DEF_ID = `${MOCK_DEFINITION_URI}_id`
     const mockLabware = {
       [MOCK_LABWARE_ID]: {
-        definitionId: `${MOCK_DEFINITION_URI}_id`,
+        definitionUri: `${MOCK_DEFINITION_URI}`,
         displayName: 'some dope labware',
       },
     }
@@ -29,6 +29,7 @@ describe('getLabwareDefinitionUri', () => {
     expect(
       getLabwareDefinitionUri(
         MOCK_LABWARE_ID,
+        //  @ts-expect-error
         mockLabware,
         mockLabwareDefinitions
       )

--- a/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getLabwareDefinitionUri.test.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getLabwareDefinitionUri.test.ts
@@ -19,7 +19,7 @@ describe('getLabwareDefinitionUri', () => {
     const DEF_ID = `${MOCK_DEFINITION_URI}_id`
     const mockLabware = {
       [MOCK_LABWARE_ID]: {
-        definitionUri: `${MOCK_DEFINITION_URI}`,
+        definitionUri: MOCK_DEFINITION_URI,
         displayName: 'some dope labware',
       },
     }

--- a/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getLabwareDefinitionUri.test.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getLabwareDefinitionUri.test.ts
@@ -16,7 +16,7 @@ describe('getLabwareDefinitionUri', () => {
   })
   it('should return the definition uri of a given labware', () => {
     const MOCK_LABWARE_ID = 'some_labware'
-    const DEF_ID = `${MOCK_DEFINITION_URI}_id`
+    const DEF_ID = MOCK_DEFINITION_URI
     const mockLabware = {
       [MOCK_LABWARE_ID]: {
         definitionUri: MOCK_DEFINITION_URI,

--- a/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getLabwareDefinitionUri.test.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getLabwareDefinitionUri.test.ts
@@ -16,7 +16,6 @@ describe('getLabwareDefinitionUri', () => {
   })
   it('should return the definition uri of a given labware', () => {
     const MOCK_LABWARE_ID = 'some_labware'
-    const DEF_ID = MOCK_DEFINITION_URI
     const mockLabware = {
       [MOCK_LABWARE_ID]: {
         definitionUri: MOCK_DEFINITION_URI,
@@ -24,7 +23,7 @@ describe('getLabwareDefinitionUri', () => {
       },
     }
     const mockLabwareDefinitions = {
-      [DEF_ID]: MOCK_DEF,
+      [MOCK_DEFINITION_URI]: MOCK_DEF,
     }
     expect(
       getLabwareDefinitionUri(

--- a/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getProtocolModulesInfo.test.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getProtocolModulesInfo.test.ts
@@ -41,6 +41,7 @@ describe('getProtocolModulesInfo', () => {
         nestedLabwareDef:
           _protocolWithMagTempTC.labwareDefinitions[
             _protocolWithMagTempTC.labware[MAG_LW_ID]
+              //  @ts-expect-error
               .definitionUri as keyof typeof _protocolWithMagTempTC.labwareDefinitions
           ],
         nestedLabwareId: MAG_LW_ID,
@@ -58,6 +59,7 @@ describe('getProtocolModulesInfo', () => {
         nestedLabwareDef:
           _protocolWithMagTempTC.labwareDefinitions[
             _protocolWithMagTempTC.labware[TEMP_LW_ID]
+              //  @ts-expect-error
               .definitionUri as keyof typeof _protocolWithMagTempTC.labwareDefinitions
           ],
         nestedLabwareId: TEMP_LW_ID,
@@ -75,6 +77,7 @@ describe('getProtocolModulesInfo', () => {
         nestedLabwareDef:
           _protocolWithMagTempTC.labwareDefinitions[
             _protocolWithMagTempTC.labware[TC_LW_ID]
+              //  @ts-expect-error
               .definitionUri as keyof typeof _protocolWithMagTempTC.labwareDefinitions
           ],
         nestedLabwareId: TC_LW_ID,
@@ -121,6 +124,7 @@ describe('getProtocolModulesInfo', () => {
         nestedLabwareDef:
           _protocolWithMultipleTemps.labwareDefinitions[
             _protocolWithMultipleTemps.labware[MAG_LW_ID]
+              //  @ts-expect-error
               .definitionUri as keyof typeof _protocolWithMultipleTemps.labwareDefinitions
           ],
         nestedLabwareId: MAG_LW_ID,
@@ -138,6 +142,7 @@ describe('getProtocolModulesInfo', () => {
         nestedLabwareDef:
           _protocolWithMultipleTemps.labwareDefinitions[
             _protocolWithMultipleTemps.labware[TEMP_ONE_LW_ID]
+              //  @ts-expect-error
               .definitionUri as keyof typeof _protocolWithMultipleTemps.labwareDefinitions
           ],
         nestedLabwareId: TEMP_ONE_LW_ID,
@@ -155,6 +160,7 @@ describe('getProtocolModulesInfo', () => {
         nestedLabwareDef:
           _protocolWithMultipleTemps.labwareDefinitions[
             _protocolWithMultipleTemps.labware[TEMP_TWO_LW_ID]
+              //  @ts-expect-error
               .definitionUri as keyof typeof _protocolWithMultipleTemps.labwareDefinitions
           ],
         nestedLabwareId: TEMP_TWO_LW_ID,
@@ -190,6 +196,7 @@ describe('getProtocolModulesInfo', () => {
         nestedLabwareDef:
           _protocolWithMagTempTC.labwareDefinitions[
             _protocolWithMagTempTC.labware[MAG_LW_ID]
+              //  @ts-expect-error
               .definitionUri as keyof typeof _protocolWithMagTempTC.labwareDefinitions
           ],
         nestedLabwareId: MAG_LW_ID,

--- a/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getProtocolModulesInfo.test.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getProtocolModulesInfo.test.ts
@@ -40,6 +40,8 @@ describe('getProtocolModulesInfo', () => {
         moduleDef: getModuleDef2('magneticModuleV2'),
         nestedLabwareDef:
           _protocolWithMagTempTC.labwareDefinitions[
+            // prettier-ignore
+            /* eslint-disable */
             _protocolWithMagTempTC.labware[MAG_LW_ID]
               //  @ts-expect-error
               .definitionUri as keyof typeof _protocolWithMagTempTC.labwareDefinitions
@@ -58,8 +60,10 @@ describe('getProtocolModulesInfo', () => {
         moduleDef: getModuleDef2('temperatureModuleV2'),
         nestedLabwareDef:
           _protocolWithMagTempTC.labwareDefinitions[
+            // prettier-ignore
+            /* eslint-disable */
             _protocolWithMagTempTC.labware[TEMP_LW_ID]
-              //  @ts-expect-error
+               //  @ts-expect-error
               .definitionUri as keyof typeof _protocolWithMagTempTC.labwareDefinitions
           ],
         nestedLabwareId: TEMP_LW_ID,
@@ -76,6 +80,8 @@ describe('getProtocolModulesInfo', () => {
         moduleDef: getModuleDef2('thermocyclerModuleV1'),
         nestedLabwareDef:
           _protocolWithMagTempTC.labwareDefinitions[
+            // prettier-ignore
+            /* eslint-disable */
             _protocolWithMagTempTC.labware[TC_LW_ID]
               //  @ts-expect-error
               .definitionUri as keyof typeof _protocolWithMagTempTC.labwareDefinitions
@@ -123,6 +129,8 @@ describe('getProtocolModulesInfo', () => {
         moduleDef: getModuleDef2('magneticModuleV2'),
         nestedLabwareDef:
           _protocolWithMultipleTemps.labwareDefinitions[
+            // prettier-ignore
+            /* eslint-disable */
             _protocolWithMultipleTemps.labware[MAG_LW_ID]
               //  @ts-expect-error
               .definitionUri as keyof typeof _protocolWithMultipleTemps.labwareDefinitions
@@ -141,6 +149,8 @@ describe('getProtocolModulesInfo', () => {
         moduleDef: getModuleDef2('temperatureModuleV2'),
         nestedLabwareDef:
           _protocolWithMultipleTemps.labwareDefinitions[
+            // prettier-ignore
+            /* eslint-disable */
             _protocolWithMultipleTemps.labware[TEMP_ONE_LW_ID]
               //  @ts-expect-error
               .definitionUri as keyof typeof _protocolWithMultipleTemps.labwareDefinitions
@@ -159,6 +169,8 @@ describe('getProtocolModulesInfo', () => {
         moduleDef: getModuleDef2('temperatureModuleV2'),
         nestedLabwareDef:
           _protocolWithMultipleTemps.labwareDefinitions[
+            // prettier-ignore
+            /* eslint-disable */
             _protocolWithMultipleTemps.labware[TEMP_TWO_LW_ID]
               //  @ts-expect-error
               .definitionUri as keyof typeof _protocolWithMultipleTemps.labwareDefinitions
@@ -195,6 +207,8 @@ describe('getProtocolModulesInfo', () => {
         moduleDef: getModuleDef2('magneticModuleV2'),
         nestedLabwareDef:
           _protocolWithMagTempTC.labwareDefinitions[
+            // prettier-ignore
+            /* eslint-disable */
             _protocolWithMagTempTC.labware[MAG_LW_ID]
               //  @ts-expect-error
               .definitionUri as keyof typeof _protocolWithMagTempTC.labwareDefinitions

--- a/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getProtocolModulesInfo.test.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getProtocolModulesInfo.test.ts
@@ -41,7 +41,7 @@ describe('getProtocolModulesInfo', () => {
         nestedLabwareDef:
           _protocolWithMagTempTC.labwareDefinitions[
             _protocolWithMagTempTC.labware[MAG_LW_ID]
-              .definitionId as keyof typeof _protocolWithMagTempTC.labwareDefinitions
+              .definitionUri as keyof typeof _protocolWithMagTempTC.labwareDefinitions
           ],
         nestedLabwareId: MAG_LW_ID,
         nestedLabwareDisplayName:
@@ -58,7 +58,7 @@ describe('getProtocolModulesInfo', () => {
         nestedLabwareDef:
           _protocolWithMagTempTC.labwareDefinitions[
             _protocolWithMagTempTC.labware[TEMP_LW_ID]
-              .definitionId as keyof typeof _protocolWithMagTempTC.labwareDefinitions
+              .definitionUri as keyof typeof _protocolWithMagTempTC.labwareDefinitions
           ],
         nestedLabwareId: TEMP_LW_ID,
         nestedLabwareDisplayName:
@@ -75,7 +75,7 @@ describe('getProtocolModulesInfo', () => {
         nestedLabwareDef:
           _protocolWithMagTempTC.labwareDefinitions[
             _protocolWithMagTempTC.labware[TC_LW_ID]
-              .definitionId as keyof typeof _protocolWithMagTempTC.labwareDefinitions
+              .definitionUri as keyof typeof _protocolWithMagTempTC.labwareDefinitions
           ],
         nestedLabwareId: TC_LW_ID,
         nestedLabwareDisplayName:
@@ -121,7 +121,7 @@ describe('getProtocolModulesInfo', () => {
         nestedLabwareDef:
           _protocolWithMultipleTemps.labwareDefinitions[
             _protocolWithMultipleTemps.labware[MAG_LW_ID]
-              .definitionId as keyof typeof _protocolWithMultipleTemps.labwareDefinitions
+              .definitionUri as keyof typeof _protocolWithMultipleTemps.labwareDefinitions
           ],
         nestedLabwareId: MAG_LW_ID,
         nestedLabwareDisplayName:
@@ -138,7 +138,7 @@ describe('getProtocolModulesInfo', () => {
         nestedLabwareDef:
           _protocolWithMultipleTemps.labwareDefinitions[
             _protocolWithMultipleTemps.labware[TEMP_ONE_LW_ID]
-              .definitionId as keyof typeof _protocolWithMultipleTemps.labwareDefinitions
+              .definitionUri as keyof typeof _protocolWithMultipleTemps.labwareDefinitions
           ],
         nestedLabwareId: TEMP_ONE_LW_ID,
         nestedLabwareDisplayName:
@@ -155,7 +155,7 @@ describe('getProtocolModulesInfo', () => {
         nestedLabwareDef:
           _protocolWithMultipleTemps.labwareDefinitions[
             _protocolWithMultipleTemps.labware[TEMP_TWO_LW_ID]
-              .definitionId as keyof typeof _protocolWithMultipleTemps.labwareDefinitions
+              .definitionUri as keyof typeof _protocolWithMultipleTemps.labwareDefinitions
           ],
         nestedLabwareId: TEMP_TWO_LW_ID,
         nestedLabwareDisplayName:
@@ -190,7 +190,7 @@ describe('getProtocolModulesInfo', () => {
         nestedLabwareDef:
           _protocolWithMagTempTC.labwareDefinitions[
             _protocolWithMagTempTC.labware[MAG_LW_ID]
-              .definitionId as keyof typeof _protocolWithMagTempTC.labwareDefinitions
+              .definitionUri as keyof typeof _protocolWithMagTempTC.labwareDefinitions
           ],
         nestedLabwareId: MAG_LW_ID,
         nestedLabwareDisplayName: stubDisplayName,

--- a/app/src/organisms/Devices/ProtocolRun/utils/getLabwareDefinitionUri.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/getLabwareDefinitionUri.ts
@@ -8,7 +8,7 @@ export function getLabwareDefinitionUri(
   labwareDefinitions: ProtocolFile<{}>['labwareDefinitions']
 ): string {
   //  @ts-expect-error
-  const labwareDefinitionUri = `${labware[labwareId].definitionUri}_id`
+  const labwareDefinitionUri = labware[labwareId].definitionUri
   if (labwareDefinitionUri == null) {
     throw new Error(
       'expected to be able to find labware definition uri for labware, but could not'

--- a/app/src/organisms/Devices/ProtocolRun/utils/getLabwareDefinitionUri.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/getLabwareDefinitionUri.ts
@@ -8,13 +8,13 @@ export function getLabwareDefinitionUri(
   labwareDefinitions: ProtocolFile<{}>['labwareDefinitions']
 ): string {
   //  @ts-expect-error
-  const labwareDefinitionId = `${labware[labwareId].definitionUri}_id`
-  if (labwareDefinitionId == null) {
+  const labwareDefinitionUri = labware[labwareId].definitionUri
+  if (labwareDefinitionUri == null) {
     throw new Error(
-      'expected to be able to find labware definition id for labware, but could not'
+      'expected to be able to find labware definition uri for labware, but could not'
     )
   }
-  const labwareDefinition = labwareDefinitions[labwareDefinitionId]
+  const labwareDefinition = labwareDefinitions[labwareDefinitionUri]
   if (labwareDefinition == null) {
     throw new Error(
       'expected to be able to find labware definitions for protocol, but could not'

--- a/app/src/organisms/Devices/ProtocolRun/utils/getLabwareDefinitionUri.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/getLabwareDefinitionUri.ts
@@ -8,13 +8,13 @@ export function getLabwareDefinitionUri(
   labwareDefinitions: ProtocolFile<{}>['labwareDefinitions']
 ): string {
   //  @ts-expect-error
-  const labwareDefinitionId = `${labware[labwareId].definitionUri}_id`
-  if (labwareDefinitionId == null) {
+  const labwareDefinitionUri = labware[labwareId].definitionUri
+  if (labwareDefinitionUri == null) {
     throw new Error(
       'expected to be able to find labware definition uri for labware, but could not'
     )
   }
-  const labwareDefinition = labwareDefinitions[labwareDefinitionId]
+  const labwareDefinition = labwareDefinitions[labwareDefinitionUri]
   if (labwareDefinition == null) {
     throw new Error(
       'expected to be able to find labware definitions for protocol, but could not'

--- a/app/src/organisms/Devices/ProtocolRun/utils/getLabwareDefinitionUri.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/getLabwareDefinitionUri.ts
@@ -7,7 +7,8 @@ export function getLabwareDefinitionUri(
   labware: ProtocolFile<{}>['labware'],
   labwareDefinitions: ProtocolFile<{}>['labwareDefinitions']
 ): string {
-  const labwareDefinitionId = labware[labwareId].definitionId
+  //  @ts-expect-error
+  const labwareDefinitionId = `${labware[labwareId].definitionUri}_id`
   if (labwareDefinitionId == null) {
     throw new Error(
       'expected to be able to find labware definition id for labware, but could not'

--- a/app/src/organisms/Devices/ProtocolRun/utils/getLabwareDefinitionUri.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/getLabwareDefinitionUri.ts
@@ -8,13 +8,13 @@ export function getLabwareDefinitionUri(
   labwareDefinitions: ProtocolFile<{}>['labwareDefinitions']
 ): string {
   //  @ts-expect-error
-  const labwareDefinitionUri = labware[labwareId].definitionUri
-  if (labwareDefinitionUri == null) {
+  const labwareDefinitionId = `${labware[labwareId].definitionUri}_id`
+  if (labwareDefinitionId == null) {
     throw new Error(
       'expected to be able to find labware definition uri for labware, but could not'
     )
   }
-  const labwareDefinition = labwareDefinitions[labwareDefinitionUri]
+  const labwareDefinition = labwareDefinitions[labwareDefinitionId]
   if (labwareDefinition == null) {
     throw new Error(
       'expected to be able to find labware definitions for protocol, but could not'

--- a/app/src/organisms/Devices/ProtocolRun/utils/getLabwareDefinitionUri.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/getLabwareDefinitionUri.ts
@@ -8,7 +8,7 @@ export function getLabwareDefinitionUri(
   labwareDefinitions: ProtocolFile<{}>['labwareDefinitions']
 ): string {
   //  @ts-expect-error
-  const labwareDefinitionUri = labware[labwareId].definitionUri
+  const labwareDefinitionUri = `${labware[labwareId].definitionUri}_id`
   if (labwareDefinitionUri == null) {
     throw new Error(
       'expected to be able to find labware definition uri for labware, but could not'

--- a/app/src/organisms/Devices/ProtocolRun/utils/getProtocolModulesInfo.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/getProtocolModulesInfo.ts
@@ -52,7 +52,8 @@ export const getProtocolModulesInfo = (
           nestedLabwareId != null ? protocolData.labware[nestedLabwareId] : null
         const nestedLabwareDef =
           nestedLabware != null
-            ? protocolData.labwareDefinitions[nestedLabware.definitionId]
+            ? //  @ts-expect-error: will be an error until we remove the schemaV6Adapter
+              protocolData.labwareDefinitions[nestedLabware.definitionUri]
             : null
         const nestedLabwareDisplayName = nestedLabware?.displayName ?? null
         const moduleInitialLoadInfo = getModuleInitialLoadInfo(

--- a/app/src/organisms/Devices/hooks/__tests__/useRunPipetteInfoByMount.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useRunPipetteInfoByMount.test.tsx
@@ -87,7 +87,27 @@ const TIP_LENGTH_CALIBRATIONS = [
 ]
 
 const tiprack10ul = _tiprack10ul as LabwareDefinition2
-const modifiedSimpleV6Protocol = (_uncastedModifiedSimpleV6Protocol as any) as ProtocolAnalysisFile<{}>
+const modifiedSimpleV6Protocol = ({
+  ..._uncastedModifiedSimpleV6Protocol,
+  labware: {
+    trashId: {
+      displayName: 'Trash',
+      definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+    },
+    tipRackId: {
+      displayName: 'Opentrons 96 Tip Rack 10 µL',
+      definitionUri: 'opentrons/opentrons_96_tiprack_10ul/1',
+    },
+    sourcePlateId: {
+      displayName: 'Source Plate',
+      definitionUri: 'example/plate/1',
+    },
+    destPlateId: {
+      displayName: 'Sample Collection Plate',
+      definitionUri: 'example/plate/1',
+    },
+  },
+} as any) as ProtocolAnalysisFile<{}>
 
 const PROTOCOL_DETAILS = {
   displayName: 'fake protocol',

--- a/app/src/organisms/Devices/hooks/useRunPipetteInfoByMount.ts
+++ b/app/src/organisms/Devices/hooks/useRunPipetteInfoByMount.ts
@@ -148,9 +148,7 @@ function getRequestedPipetteMatch(
     attachedPipette?.modelSpecs?.backCompatNames.includes(requestedPipetteName)
   ) {
     return INEXACT_MATCH
-  } else if (
-    requestedPipetteName === attachedPipette?.modelSpecs?.name
-  ) {
+  } else if (requestedPipetteName === attachedPipette?.modelSpecs?.name) {
     return MATCH
   } else {
     return INCOMPATIBLE

--- a/app/src/organisms/Devices/hooks/useRunPipetteInfoByMount.ts
+++ b/app/src/organisms/Devices/hooks/useRunPipetteInfoByMount.ts
@@ -78,7 +78,8 @@ export function useRunPipetteInfoByMount(
         >((acc, command) => {
           if (pipetteId === command.params?.pipetteId) {
             const tipRack = labware[command.params?.labwareId]
-            const tipRackDefinition = labwareDefinitions[tipRack.definitionId]
+            //  @ts-expect-error: will be an error until we remove the schemaV6Adapter
+            const tipRackDefinition = labwareDefinitions[tipRack.definitionUri]
 
             if (tipRackDefinition != null && !acc.includes(tipRackDefinition)) {
               return [...acc, tipRackDefinition]
@@ -147,7 +148,9 @@ function getRequestedPipetteMatch(
     attachedPipette?.modelSpecs?.backCompatNames.includes(requestedPipetteName)
   ) {
     return INEXACT_MATCH
-  } else if (requestedPipetteName === attachedPipette?.modelSpecs?.name) {
+  } else if (
+    requestedPipetteName === attachedPipette?.modelSpecs?.name
+  ) {
     return MATCH
   } else {
     return INCOMPATIBLE

--- a/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/DeprecatedLabwarePositionCheckStepDetail.tsx
+++ b/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/DeprecatedLabwarePositionCheckStepDetail.tsx
@@ -89,8 +89,9 @@ export const DeprecatedLabwarePositionCheckStepDetail = (
       : null
 
   if (protocolData == null) return null
-  const labwareDefId = protocolData.labware[labwareId].definitionId
-  const labwareDef = protocolData.labwareDefinitions[labwareDefId]
+  //  @ts-expect-error: will be an error until we remove the schemaV6Adapter
+  const labwareDefUri = protocolData.labware[labwareId].definitionUri
+  const labwareDef = protocolData.labwareDefinitions[`${labwareDefUri}_id`]
   // filter out the TC open lid command as it does not have an associated pipette id
   const stepMovementCommands = selectedStep.commands.filter(
     (

--- a/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/DeprecatedLabwarePositionCheckStepDetail.tsx
+++ b/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/DeprecatedLabwarePositionCheckStepDetail.tsx
@@ -91,7 +91,7 @@ export const DeprecatedLabwarePositionCheckStepDetail = (
   if (protocolData == null) return null
   //  @ts-expect-error: will be an error until we remove the schemaV6Adapter
   const labwareDefUri = protocolData.labware[labwareId].definitionUri
-  const labwareDef = protocolData.labwareDefinitions[`${labwareDefUri}_id`]
+  const labwareDef = protocolData.labwareDefinitions[labwareDefUri]
   // filter out the TC open lid command as it does not have an associated pipette id
   const stepMovementCommands = selectedStep.commands.filter(
     (

--- a/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/DeprecatedStepDetailText.tsx
+++ b/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/DeprecatedStepDetailText.tsx
@@ -35,7 +35,8 @@ export const DeprecatedStepDetailText = (
     setLabwarePositionCheckStepDetailModal,
   ] = React.useState<boolean>(false)
   if (protocolData == null) return null
-  const labwareDefId = protocolData.labware[labwareId].definitionId
+  //  @ts-expect-error: will be an error until we remove the schemaV6Adapter
+  const labwareDefId = protocolData.labware[labwareId].definitionUri
   const labwareDef = protocolData.labwareDefinitions[labwareDefId]
   const { displayName } = labwareDef.metadata
   const { isTiprack } = labwareDef.parameters

--- a/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/__tests__/DeprecatedLabwarePositionCheckStepDetail.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/__tests__/DeprecatedLabwarePositionCheckStepDetail.test.tsx
@@ -88,8 +88,6 @@ const mockJogControls = DeprecatedJogControls as jest.MockedFunction<
 const PICKUP_TIP_LABWARE_ID = 'PICKUP_TIP_LABWARE_ID'
 const PRIMARY_PIPETTE_ID = 'PRIMARY_PIPETTE_ID'
 const PRIMARY_PIPETTE_NAME = 'PRIMARY_PIPETTE_NAME'
-const LABWARE_DEF_ID = 'LABWARE_DEF_ID'
-const TIPRACK_DEF_ID = 'tiprack_DEF_ID'
 const TIPRACK_DEF_URI = 'TIPRACK_DEF'
 const LABWARE_DEF_URI = 'LABWARE_DEF'
 const LABWARE_DEF = {
@@ -175,7 +173,7 @@ describe('DeprecatedLabwarePositionCheckStepDetail', () => {
             },
           },
           labwareDefinitions: {
-            [LABWARE_DEF_ID]: LABWARE_DEF,
+            [`${LABWARE_DEF_URI}_id`]: LABWARE_DEF,
           },
           pipettes: {
             [PRIMARY_PIPETTE_ID]: {
@@ -255,7 +253,7 @@ describe('DeprecatedLabwarePositionCheckStepDetail', () => {
             },
           },
           labwareDefinitions: {
-            [TIPRACK_DEF_ID]: LABWARE_DEF,
+            [`${TIPRACK_DEF_URI}_id`]: LABWARE_DEF,
           },
           pipettes: {
             [PRIMARY_PIPETTE_ID]: {

--- a/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/__tests__/DeprecatedLabwarePositionCheckStepDetail.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/__tests__/DeprecatedLabwarePositionCheckStepDetail.test.tsx
@@ -90,6 +90,8 @@ const PRIMARY_PIPETTE_ID = 'PRIMARY_PIPETTE_ID'
 const PRIMARY_PIPETTE_NAME = 'PRIMARY_PIPETTE_NAME'
 const LABWARE_DEF_ID = 'LABWARE_DEF_ID'
 const TIPRACK_DEF_ID = 'tiprack_DEF_ID'
+const TIPRACK_DEF_URI = 'TIPRACK_DEF'
+const LABWARE_DEF_URI = 'LABWARE_DEF'
 const LABWARE_DEF = {
   ordering: [['A1', 'A2']],
 }
@@ -169,7 +171,7 @@ describe('DeprecatedLabwarePositionCheckStepDetail', () => {
             [mockLabwarePositionCheckStepTipRack.labwareId]: {
               slot: '1',
               displayName: 'someDislpayName',
-              definitionId: LABWARE_DEF_ID,
+              definitionUri: LABWARE_DEF_URI,
             },
           },
           labwareDefinitions: {
@@ -249,7 +251,7 @@ describe('DeprecatedLabwarePositionCheckStepDetail', () => {
             [mockLabwarePositionCheckStepTipRack.labwareId]: {
               slot: '1',
               displayName: 'someDislpayName',
-              definitionId: TIPRACK_DEF_ID,
+              definitionUri: TIPRACK_DEF_URI,
             },
           },
           labwareDefinitions: {

--- a/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/__tests__/DeprecatedLabwarePositionCheckStepDetail.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/__tests__/DeprecatedLabwarePositionCheckStepDetail.test.tsx
@@ -173,7 +173,7 @@ describe('DeprecatedLabwarePositionCheckStepDetail', () => {
             },
           },
           labwareDefinitions: {
-            [`${LABWARE_DEF_URI}_id`]: LABWARE_DEF,
+            [LABWARE_DEF_URI]: LABWARE_DEF,
           },
           pipettes: {
             [PRIMARY_PIPETTE_ID]: {
@@ -253,7 +253,7 @@ describe('DeprecatedLabwarePositionCheckStepDetail', () => {
             },
           },
           labwareDefinitions: {
-            [`${TIPRACK_DEF_URI}_id`]: LABWARE_DEF,
+            [TIPRACK_DEF_URI]: LABWARE_DEF,
           },
           pipettes: {
             [PRIMARY_PIPETTE_ID]: {

--- a/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/__tests__/DeprecatedStepDetailText.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/__tests__/DeprecatedStepDetailText.test.tsx
@@ -86,7 +86,35 @@ describe('DeprecatedStepDetailText', () => {
     when(mockUseProtocolDetailsForRun)
       .calledWith(MOCK_RUN_ID)
       .mockReturnValue({
-        protocolData: withSinglechannelProtocol,
+        protocolData: {
+          ...withSinglechannelProtocol,
+          labware: {
+            trashId: {
+              slot: '12',
+              displayName: 'Trash',
+              definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+            },
+            '1d57fc10-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_96_filtertiprack_200ul/1': {
+              slot: '2',
+              displayName: 'Opentrons 96 Filter Tip Rack 200 µL',
+              definitionUri: 'opentrons/opentrons_96_filtertiprack_200ul/1',
+            },
+            '24274d20-67ad-11ea-9f8b-3b50068bd62d:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': {
+              slot: '1d57adf0-67ad-11ea-9f8b-3b50068bd62d:magneticModuleType',
+              displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
+              definitionUri:
+                'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+            },
+            '269518d0-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1': {
+              slot:
+                '1d57d500-67ad-11ea-9f8b-3b50068bd62d:temperatureModuleType',
+              displayName:
+                'Opentrons 24 Well Aluminum Block with NEST 1.5 mL Screwcap',
+              definitionUri:
+                'opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1',
+            },
+          },
+        },
       } as any)
   })
 
@@ -145,7 +173,35 @@ describe('DeprecatedStepDetailText', () => {
     when(mockUseProtocolDetailsForRun)
       .calledWith(MOCK_RUN_ID)
       .mockReturnValue({
-        protocolData: withMultiChannelProtocol,
+        protocolData: {
+          ...withMultiChannelProtocol,
+          labware: {
+            trashId: {
+              slot: '12',
+              displayName: 'Trash',
+              definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+            },
+            '1d57fc10-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_96_filtertiprack_200ul/1': {
+              slot: '2',
+              displayName: 'Opentrons 96 Filter Tip Rack 200 µL',
+              definitionUri: 'opentrons/opentrons_96_filtertiprack_200ul/1',
+            },
+            '24274d20-67ad-11ea-9f8b-3b50068bd62d:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': {
+              slot: '1d57adf0-67ad-11ea-9f8b-3b50068bd62d:magneticModuleType',
+              displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
+              definitionUri:
+                'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+            },
+            '269518d0-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1': {
+              slot:
+                '1d57d500-67ad-11ea-9f8b-3b50068bd62d:temperatureModuleType',
+              displayName:
+                'Opentrons 24 Well Aluminum Block with NEST 1.5 mL Screwcap',
+              definitionUri:
+                'opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1',
+            },
+          },
+        },
       } as any)
 
     const { getByText } = render(props)
@@ -166,7 +222,35 @@ describe('DeprecatedStepDetailText', () => {
     when(mockUseProtocolDetailsForRun)
       .calledWith(MOCK_RUN_ID)
       .mockReturnValue({
-        protocolData: withMultiChannelProtocol,
+        protocolData: {
+          ...withMultiChannelProtocol,
+          labware: {
+            trashId: {
+              slot: '12',
+              displayName: 'Trash',
+              definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+            },
+            '1d57fc10-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_96_filtertiprack_200ul/1': {
+              slot: '2',
+              displayName: 'Opentrons 96 Filter Tip Rack 200 µL',
+              definitionUri: 'opentrons/opentrons_96_filtertiprack_200ul/1',
+            },
+            '24274d20-67ad-11ea-9f8b-3b50068bd62d:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': {
+              slot: '1d57adf0-67ad-11ea-9f8b-3b50068bd62d:magneticModuleType',
+              displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
+              definitionUri:
+                'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+            },
+            '269518d0-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1': {
+              slot:
+                '1d57d500-67ad-11ea-9f8b-3b50068bd62d:temperatureModuleType',
+              displayName:
+                'Opentrons 24 Well Aluminum Block with NEST 1.5 mL Screwcap',
+              definitionUri:
+                'opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1',
+            },
+          },
+        },
       } as any)
 
     const { getByText } = render(props)

--- a/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckStepDetail.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckStepDetail.tsx
@@ -86,7 +86,7 @@ export const LabwarePositionCheckStepDetail = (
   if (protocolData == null) return null
   //  @ts-expect-error: will be an error until we remove the schemaV6Adapter
   const labwareDefUri = protocolData.labware[labwareId].definitionUri
-  const labwareDef = protocolData.labwareDefinitions[`${labwareDefUri}_id`]
+  const labwareDef = protocolData.labwareDefinitions[labwareDefUri]
   // filter out the TC open lid command as it does not have an associated pipette id
   const stepMovementCommands = selectedStep.commands.filter(
     (

--- a/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckStepDetail.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckStepDetail.tsx
@@ -84,8 +84,9 @@ export const LabwarePositionCheckStepDetail = (
       : null
 
   if (protocolData == null) return null
-  const labwareDefId = protocolData.labware[labwareId].definitionId
-  const labwareDef = protocolData.labwareDefinitions[labwareDefId]
+  //  @ts-expect-error: will be an error until we remove the schemaV6Adapter
+  const labwareDefUri = protocolData.labware[labwareId].definitionUri
+  const labwareDef = protocolData.labwareDefinitions[`${labwareDefUri}_id`]
   // filter out the TC open lid command as it does not have an associated pipette id
   const stepMovementCommands = selectedStep.commands.filter(
     (

--- a/app/src/organisms/LabwarePositionCheck/StepDetailText.tsx
+++ b/app/src/organisms/LabwarePositionCheck/StepDetailText.tsx
@@ -30,7 +30,8 @@ export const StepDetailText = (
     setLabwarePositionCheckStepDetailModal,
   ] = React.useState<boolean>(false)
   if (protocolData == null) return null
-  const labwareDefId = protocolData.labware[labwareId].definitionId
+  //   @ts-expect-error: when we remove schemav6Adapter, defintiionUri will be correct
+  const labwareDefId = protocolData.labware[labwareId].definitionUri
   const labwareDef = protocolData.labwareDefinitions[labwareDefId]
   const { displayName } = labwareDef.metadata
   const { isTiprack } = labwareDef.parameters

--- a/app/src/organisms/LabwarePositionCheck/__tests__/LabwarePositionCheckStepDetail.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/LabwarePositionCheckStepDetail.test.tsx
@@ -88,8 +88,8 @@ const mockJogControls = DeprecatedJogControls as jest.MockedFunction<
 const PICKUP_TIP_LABWARE_ID = 'PICKUP_TIP_LABWARE_ID'
 const PRIMARY_PIPETTE_ID = 'PRIMARY_PIPETTE_ID'
 const PRIMARY_PIPETTE_NAME = 'PRIMARY_PIPETTE_NAME'
-const LABWARE_DEF_ID = 'LABWARE_DEF_ID'
-const TIPRACK_DEF_ID = 'tiprack_DEF_ID'
+const LABWARE_DEF_URI = 'LABWARE_DEF'
+const TIPRACK_DEF_URI = 'tiprack_DEF'
 const LABWARE_DEF = {
   ordering: [['A1', 'A2']],
 }
@@ -164,11 +164,11 @@ describe('LabwarePositionCheckStepDetail', () => {
             [mockLabwarePositionCheckStepTipRack.labwareId]: {
               slot: '1',
               displayName: 'someDislpayName',
-              definitionId: LABWARE_DEF_ID,
+              definitionUri: LABWARE_DEF_URI,
             },
           },
           labwareDefinitions: {
-            [LABWARE_DEF_ID]: LABWARE_DEF,
+            [`${LABWARE_DEF_URI}_id`]: LABWARE_DEF,
           },
           pipettes: {
             [PRIMARY_PIPETTE_ID]: {
@@ -244,11 +244,11 @@ describe('LabwarePositionCheckStepDetail', () => {
             [mockLabwarePositionCheckStepTipRack.labwareId]: {
               slot: '1',
               displayName: 'someDislpayName',
-              definitionId: TIPRACK_DEF_ID,
+              definitionUri: TIPRACK_DEF_URI,
             },
           },
           labwareDefinitions: {
-            [TIPRACK_DEF_ID]: LABWARE_DEF,
+            [`${TIPRACK_DEF_URI}_id`]: LABWARE_DEF,
           },
           pipettes: {
             [PRIMARY_PIPETTE_ID]: {

--- a/app/src/organisms/LabwarePositionCheck/__tests__/LabwarePositionCheckStepDetail.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/LabwarePositionCheckStepDetail.test.tsx
@@ -168,7 +168,7 @@ describe('LabwarePositionCheckStepDetail', () => {
             },
           },
           labwareDefinitions: {
-            [`${LABWARE_DEF_URI}_id`]: LABWARE_DEF,
+            [LABWARE_DEF_URI]: LABWARE_DEF,
           },
           pipettes: {
             [PRIMARY_PIPETTE_ID]: {
@@ -248,7 +248,7 @@ describe('LabwarePositionCheckStepDetail', () => {
             },
           },
           labwareDefinitions: {
-            [`${TIPRACK_DEF_URI}_id`]: LABWARE_DEF,
+            [TIPRACK_DEF_URI]: LABWARE_DEF,
           },
           pipettes: {
             [PRIMARY_PIPETTE_ID]: {

--- a/app/src/organisms/LabwarePositionCheck/__tests__/StepDetailText.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/StepDetailText.test.tsx
@@ -84,7 +84,35 @@ describe('StepDetailText', () => {
     when(mockUseProtocolDetailsForRun)
       .calledWith(MOCK_RUN_ID)
       .mockReturnValue({
-        protocolData: withSinglechannelProtocol,
+        protocolData: {
+          ...withSinglechannelProtocol,
+          labware: {
+            trashId: {
+              slot: '12',
+              displayName: 'Trash',
+              definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+            },
+            '1d57fc10-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_96_filtertiprack_200ul/1': {
+              slot: '2',
+              displayName: 'Opentrons 96 Filter Tip Rack 200 µL',
+              definitionUri: 'opentrons/opentrons_96_filtertiprack_200ul/1',
+            },
+            '24274d20-67ad-11ea-9f8b-3b50068bd62d:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': {
+              slot: '1d57adf0-67ad-11ea-9f8b-3b50068bd62d:magneticModuleType',
+              displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
+              definitionUri:
+                'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+            },
+            '269518d0-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1': {
+              slot:
+                '1d57d500-67ad-11ea-9f8b-3b50068bd62d:temperatureModuleType',
+              displayName:
+                'Opentrons 24 Well Aluminum Block with NEST 1.5 mL Screwcap',
+              definitionUri:
+                'opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1',
+            },
+          },
+        },
       } as any)
   })
 
@@ -143,7 +171,35 @@ describe('StepDetailText', () => {
     when(mockUseProtocolDetailsForRun)
       .calledWith(MOCK_RUN_ID)
       .mockReturnValue({
-        protocolData: withMultiChannelProtocol,
+        protocolData: {
+          ...withMultiChannelProtocol,
+          labware: {
+            trashId: {
+              slot: '12',
+              displayName: 'Trash',
+              definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+            },
+            '1d57fc10-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_96_filtertiprack_200ul/1': {
+              slot: '2',
+              displayName: 'Opentrons 96 Filter Tip Rack 200 µL',
+              definitionUri: 'opentrons/opentrons_96_filtertiprack_200ul/1',
+            },
+            '24274d20-67ad-11ea-9f8b-3b50068bd62d:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': {
+              slot: '1d57adf0-67ad-11ea-9f8b-3b50068bd62d:magneticModuleType',
+              displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
+              definitionUri:
+                'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+            },
+            '269518d0-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1': {
+              slot:
+                '1d57d500-67ad-11ea-9f8b-3b50068bd62d:temperatureModuleType',
+              displayName:
+                'Opentrons 24 Well Aluminum Block with NEST 1.5 mL Screwcap',
+              definitionUri:
+                'opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1',
+            },
+          },
+        },
       } as any)
 
     const { getByText } = render(props)
@@ -164,7 +220,35 @@ describe('StepDetailText', () => {
     when(mockUseProtocolDetailsForRun)
       .calledWith(MOCK_RUN_ID)
       .mockReturnValue({
-        protocolData: withMultiChannelProtocol,
+        protocolData: {
+          ...withMultiChannelProtocol,
+          labware: {
+            trashId: {
+              slot: '12',
+              displayName: 'Trash',
+              definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+            },
+            '1d57fc10-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_96_filtertiprack_200ul/1': {
+              slot: '2',
+              displayName: 'Opentrons 96 Filter Tip Rack 200 µL',
+              definitionUri: 'opentrons/opentrons_96_filtertiprack_200ul/1',
+            },
+            '24274d20-67ad-11ea-9f8b-3b50068bd62d:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': {
+              slot: '1d57adf0-67ad-11ea-9f8b-3b50068bd62d:magneticModuleType',
+              displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
+              definitionUri:
+                'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+            },
+            '269518d0-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1': {
+              slot:
+                '1d57d500-67ad-11ea-9f8b-3b50068bd62d:temperatureModuleType',
+              displayName:
+                'Opentrons 24 Well Aluminum Block with NEST 1.5 mL Screwcap',
+              definitionUri:
+                'opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1',
+            },
+          },
+        },
       } as any)
 
     const { getByText } = render(props)

--- a/app/src/organisms/LabwarePositionCheck/__tests__/getLabwarePositionCheckSteps.test.ts
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/getLabwarePositionCheckSteps.test.ts
@@ -9,6 +9,24 @@ import type { ProtocolAnalysisFile } from '@opentrons/shared-data'
 
 const protocolWithOnePipette = ({
   ..._uncasted_v6ProtocolWithTwoPipettes,
+  labware: {
+    fixedTrash: {
+      displayName: 'Trash',
+      definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+    },
+    '50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1': {
+      displayName: 'Opentrons 96 Tip Rack 300 µL',
+      definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+    },
+    '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1': {
+      displayName: 'NEST 12 Well Reservoir 15 mL',
+      definitionUri: 'opentrons/nest_12_reservoir_15ml/1',
+    },
+    'e24818a0-0042-11ec-8258-f7ffdf5ad45a': {
+      displayName: 'Opentrons 96 Tip Rack 300 µL (1)',
+      definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+    },
+  },
   pipettes: {
     '50d23e00-0042-11ec-8258-f7ffdf5ad45a': {
       pipetteName: 'p300_single_gen2',
@@ -23,6 +41,24 @@ const protocolWithTwoPipettes = ({
     },
     'c235a5a0-0042-11ec-8258-f7ffdf5ad45a': {
       pipetteName: 'p300_multi',
+    },
+  },
+  labware: {
+    fixedTrash: {
+      displayName: 'Trash',
+      definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+    },
+    '50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1': {
+      displayName: 'Opentrons 96 Tip Rack 300 µL',
+      definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+    },
+    '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1': {
+      displayName: 'NEST 12 Well Reservoir 15 mL',
+      definitionUri: 'opentrons/nest_12_reservoir_15ml/1',
+    },
+    'e24818a0-0042-11ec-8258-f7ffdf5ad45a': {
+      displayName: 'Opentrons 96 Tip Rack 300 µL (1)',
+      definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
     },
   },
 } as unknown) as ProtocolAnalysisFile
@@ -99,7 +135,7 @@ describe('getLabwarePositionCheckSteps', () => {
       labware: {
         ...protocolWithOnePipette.labware,
         unusedTipRackId: {
-          definitionId: 'bogusDefinitionId',
+          definitionUri: 'bogusDefinitionUri',
         },
       },
       labwareDefinitions: {
@@ -120,6 +156,7 @@ describe('getLabwarePositionCheckSteps', () => {
       })
       .mockReturnValue(1)
 
+    //  @ts-expect-error
     getLabwarePositionCheckSteps(protocolWithUnusedTipRack)
 
     expect(mockGetOnePipettePositionCheckSteps).toHaveBeenCalledWith({

--- a/app/src/organisms/LabwarePositionCheck/getLabwarePositionCheckSteps.ts
+++ b/app/src/organisms/LabwarePositionCheck/getLabwarePositionCheckSteps.ts
@@ -30,7 +30,8 @@ export const getLabwarePositionCheckSteps = (
     const labware = omitBy(
       protocolData.labware,
       (labware, id) =>
-        protocolData.labwareDefinitions[labware.definitionId]?.parameters
+        //  @ts-expect-error: will be an error until we remove the schemaV6Adapter
+        protocolData.labwareDefinitions[labware.definitionUri]?.parameters
           .isTiprack &&
         !protocolData.commands.some(
           command =>

--- a/app/src/organisms/LabwarePositionCheck/hooks/__tests__/useLabwareOffsetForLabware.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/hooks/__tests__/useLabwareOffsetForLabware.test.tsx
@@ -4,16 +4,13 @@ import { createStore, Store } from 'redux'
 import { Provider } from 'react-redux'
 import { when, resetAllWhenMocks } from 'jest-when'
 import { simpleAnalysisFileFixture } from '@opentrons/api-client'
-import {
-  CompletedProtocolAnalysis,
-  schemaV6Adapter,
-  TEMPERATURE_MODULE_V2,
-} from '@opentrons/shared-data'
+import { schemaV6Adapter, TEMPERATURE_MODULE_V2 } from '@opentrons/shared-data'
 import { renderHook } from '@testing-library/react-hooks'
 import { useRunQuery } from '@opentrons/react-api-client'
 import { useProtocolDetailsForRun } from '../../../Devices/hooks'
 import { useLabwareOffsetForLabware } from '../useLabwareOffsetForLabware'
 import type { LabwareOffset } from '@opentrons/api-client'
+import type { CompletedProtocolAnalysis } from '@opentrons/shared-data'
 
 jest.mock('@opentrons/react-api-client')
 jest.mock('../../../Devices/hooks')
@@ -22,7 +19,6 @@ const mockAnalysis: CompletedProtocolAnalysis = {
   status: 'completed',
 } as any
 const mockProtocolDetails = schemaV6Adapter(mockAnalysis)
-
 const queryClient = new QueryClient()
 const store: Store<any> = createStore(jest.fn(), {})
 const wrapper: React.FunctionComponent<{}> = ({ children }) => (
@@ -69,6 +65,7 @@ describe('useLabwareOffsetForLabware', () => {
     resetAllWhenMocks()
     jest.restoreAllMocks()
   })
+
   it('should return current offsets associated with given labwareId in protocol', async () => {
     const { result } = renderHook(
       () => useLabwareOffsetForLabware(MOCK_RUN_ID, 'labware-1'),

--- a/app/src/organisms/LabwarePositionCheck/hooks/useLabwareOffsets.ts
+++ b/app/src/organisms/LabwarePositionCheck/hooks/useLabwareOffsets.ts
@@ -84,9 +84,10 @@ export const useLabwareOffsets = (
         protocolData.labware,
         protocolData.labwareDefinitions
       )
-      const { definitionId } = protocolData.labware[labwareId]
+      //   @ts-expect-error: when we remove schemav6Adapter, defintiionUri will be correct
+      const { definitionUri } = protocolData.labware[labwareId]
       const displayName = getLabwareDisplayName(
-        protocolData.labwareDefinitions[definitionId]
+        protocolData.labwareDefinitions[definitionUri]
       )
       const vectorPromise = offsetDataByLabwareId.then(result => ({
         ...result[labwareId],

--- a/app/src/organisms/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
+++ b/app/src/organisms/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
@@ -176,7 +176,8 @@ export const useTitleText = (
   } else {
     if (labware == null || labwareDefinitions == null) return ''
 
-    const labwareDefId = labware[labwareId].definitionId
+    //  @ts-expect-error: will be an error until we remove the schemaV6Adapter
+    const labwareDefId = labware[labwareId].definitionUri
     const labwareDisplayName = getLabwareDisplayName(
       labwareDefinitions[labwareDefId]
     )

--- a/app/src/organisms/LabwarePositionCheck/utils/__tests__/doesPipetteVisitAllTipracks.test.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/__tests__/doesPipetteVisitAllTipracks.test.ts
@@ -7,17 +7,36 @@ import type { RunTimeCommand } from '@opentrons/shared-data/protocol/types/schem
 // TODO: update these fixtures to be v6 protocols
 const protocolMultipleTipracks = (_uncastedProtocolMultipleTipracks as unknown) as ProtocolAnalysisFile
 const protocolOneTiprack = (_uncastedProtocolOneTiprack as unknown) as ProtocolAnalysisFile
+const labwareWithDefinitionUri = {
+  fixedTrash: {
+    displayName: 'Trash',
+    definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+  },
+  '50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1': {
+    displayName: 'Opentrons 96 Tip Rack 300 µL',
+    definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+  },
+  '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1': {
+    displayName: 'NEST 12 Well Reservoir 15 mL',
+    definitionUri: 'opentrons/nest_12_reservoir_15ml/1',
+  },
+  'e24818a0-0042-11ec-8258-f7ffdf5ad45a': {
+    displayName: 'Opentrons 96 Tip Rack 300 µL (1)',
+    definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+  },
+}
 
 describe('doesPipetteVisitAllTipracks', () => {
   it('should return true when the pipette visits both tipracks', () => {
     const pipetteId = 'c235a5a0-0042-11ec-8258-f7ffdf5ad45a' // this is just taken from the protocol fixture
-    const labware = protocolMultipleTipracks.labware
+    const labware = labwareWithDefinitionUri
     const labwareDefinitions = protocolMultipleTipracks.labwareDefinitions
     const commands: RunTimeCommand[] = protocolMultipleTipracks.commands
 
     expect(
       doesPipetteVisitAllTipracks(
         pipetteId,
+        //  @ts-expect-error
         labware,
         labwareDefinitions,
         commands
@@ -26,13 +45,14 @@ describe('doesPipetteVisitAllTipracks', () => {
   })
   it('should return false when the pipette does NOT visit all tipracks', () => {
     const pipetteId = '50d23e00-0042-11ec-8258-f7ffdf5ad45a' // this is just taken from the protocol fixture
-    const labware = protocolMultipleTipracks.labware
+    const labware = labwareWithDefinitionUri
     const labwareDefinitions = protocolMultipleTipracks.labwareDefinitions
     const commands: RunTimeCommand[] = protocolMultipleTipracks.commands
 
     expect(
       doesPipetteVisitAllTipracks(
         pipetteId,
+        //  @ts-expect-error
         labware,
         labwareDefinitions,
         commands
@@ -41,13 +61,31 @@ describe('doesPipetteVisitAllTipracks', () => {
   })
   it('should return true when there is only one tiprack and pipette visits it', () => {
     const pipetteId = 'pipetteId' // this is just taken from the protocol fixture
-    const labware = protocolOneTiprack.labware
+    const labware = {
+      fixedTrash: {
+        displayName: 'Trash',
+        definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+      },
+      tiprackId: {
+        displayName: 'Opentrons 96 Tip Rack 10 µL',
+        definitionUri: 'opentrons/opentrons_96_tiprack_10ul/1',
+      },
+      sourcePlateId: {
+        displayName: 'Source Plate',
+        definitionUri: 'example/plate/1',
+      },
+      destPlateId: {
+        displayName: 'Dest Plate',
+        definitionUri: 'example/plate/1',
+      },
+    }
     const labwareDefinitions = protocolOneTiprack.labwareDefinitions
     const commands: RunTimeCommand[] = protocolOneTiprack.commands
 
     expect(
       doesPipetteVisitAllTipracks(
         pipetteId,
+        //  @ts-expect-error
         labware,
         labwareDefinitions,
         commands

--- a/app/src/organisms/LabwarePositionCheck/utils/__tests__/getOnePipettePositionCheckSteps.test.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/__tests__/getOnePipettePositionCheckSteps.test.ts
@@ -12,7 +12,24 @@ const protocolWithTC = (_uncastedProtocolWithTC as unknown) as ProtocolAnalysisF
 describe('getOnePipettePositionCheckSteps', () => {
   it('should check all tipracks, pick up a tip at the final tiprack, move to all remaining labware, and drop the tip', () => {
     const primaryPipetteId = 'c235a5a0-0042-11ec-8258-f7ffdf5ad45a' // this is just taken from the protocol fixture
-    const labware = protocolMultipleTipracks.labware
+    const labware = {
+      fixedTrash: {
+        displayName: 'Trash',
+        definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+      },
+      '50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1': {
+        displayName: 'Opentrons 96 Tip Rack 300 µL',
+        definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+      },
+      '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1': {
+        displayName: 'NEST 12 Well Reservoir 15 mL',
+        definitionUri: 'opentrons/nest_12_reservoir_15ml/1',
+      },
+      'e24818a0-0042-11ec-8258-f7ffdf5ad45a': {
+        displayName: 'Opentrons 96 Tip Rack 300 µL (1)',
+        definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+      },
+    }
     const labwareDefinitions = protocolMultipleTipracks.labwareDefinitions
     const modules = protocolMultipleTipracks.modules
 
@@ -107,6 +124,7 @@ describe('getOnePipettePositionCheckSteps', () => {
     expect(
       getOnePipettePositionCheckSteps({
         primaryPipetteId,
+        //  @ts-expect-error
         labware,
         labwareDefinitions,
         modules,
@@ -116,7 +134,28 @@ describe('getOnePipettePositionCheckSteps', () => {
   })
   it('should check tiprack, pick up a tip at the final tiprack, move to all remaining labware (and open TC lid), and drop the tip', () => {
     const primaryPipetteId = 'c235a5a0-0042-11ec-8258-f7ffdf5ad45a' // this is just taken from the protocol fixture
-    const labware = protocolWithTC.labware
+    const labware = {
+      fixedTrash: {
+        displayName: 'Trash',
+        definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+      },
+      '50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1': {
+        displayName: 'Opentrons 96 Tip Rack 300 µL',
+        definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+      },
+      '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1': {
+        displayName: 'NEST 12 Well Reservoir 15 mL',
+        definitionUri: 'opentrons/nest_12_reservoir_15ml/1',
+      },
+      'e24818a0-0042-11ec-8258-f7ffdf5ad45a': {
+        displayName: 'Opentrons 96 Tip Rack 300 µL (1)',
+        definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+      },
+      '1dc0c050-0122-11ec-88a3-f1745cf9b36c:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': {
+        displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
+        definitionUri: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+      },
+    }
     const labwareDefinitions = protocolWithTC.labwareDefinitions
     const modules = protocolWithTC.modules
 
@@ -238,6 +277,7 @@ describe('getOnePipettePositionCheckSteps', () => {
     expect(
       getOnePipettePositionCheckSteps({
         primaryPipetteId,
+        // @ts-expect-error
         labware,
         labwareDefinitions,
         modules,

--- a/app/src/organisms/LabwarePositionCheck/utils/__tests__/getTwoPipettePositionCheckSteps.test.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/__tests__/getTwoPipettePositionCheckSteps.test.ts
@@ -13,7 +13,24 @@ describe('getTwoPipettePositionCheckSteps', () => {
   it('should move to all tipracks that the secondary pipette uses, move to all tipracks with that the primary pipette uses, pick up a tip at the final tiprack that the primary pipette uses, move to all remaining labware, and drop the tip back in the tiprack that the primary pipette uses', () => {
     const primaryPipetteId = '50d23e00-0042-11ec-8258-f7ffdf5ad45a' // this is just taken from the protocol fixture
     const secondaryPipetteId = 'c235a5a0-0042-11ec-8258-f7ffdf5ad45a'
-    const labware = protocolMultipleTipracks.labware
+    const labware = {
+      fixedTrash: {
+        displayName: 'Trash',
+        definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+      },
+      '50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1': {
+        displayName: 'Opentrons 96 Tip Rack 300 µL',
+        definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+      },
+      '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1': {
+        displayName: 'NEST 12 Well Reservoir 15 mL',
+        definitionUri: 'opentrons/nest_12_reservoir_15ml/1',
+      },
+      'e24818a0-0042-11ec-8258-f7ffdf5ad45a': {
+        displayName: 'Opentrons 96 Tip Rack 300 µL (1)',
+        definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+      },
+    }
     const labwareDefinitions = protocolMultipleTipracks.labwareDefinitions
     const modules = protocolMultipleTipracks.modules
     const commands = protocolMultipleTipracks.commands
@@ -110,6 +127,7 @@ describe('getTwoPipettePositionCheckSteps', () => {
       getTwoPipettePositionCheckSteps({
         primaryPipetteId,
         secondaryPipetteId,
+        //  @ts-expect-error
         labware,
         labwareDefinitions,
         modules,
@@ -120,7 +138,28 @@ describe('getTwoPipettePositionCheckSteps', () => {
   it('should move to all tipracks that the secondary pipette uses, move to all tipracks with the primary pipette uses, pick up a tip at the final tiprack that the primary pipette uses, move to all remaining labware (and open TC lid), and drop the tip back in the tiprack that the primary pipette uses', () => {
     const primaryPipetteId = '50d23e00-0042-11ec-8258-f7ffdf5ad45a' // this is just taken from the protocol fixture
     const secondaryPipetteId = 'c235a5a0-0042-11ec-8258-f7ffdf5ad45a'
-    const labware = protocolWithTC.labware
+    const labware = {
+      fixedTrash: {
+        displayName: 'Trash',
+        definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+      },
+      '50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1': {
+        displayName: 'Opentrons 96 Tip Rack 300 µL',
+        definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+      },
+      '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1': {
+        displayName: 'NEST 12 Well Reservoir 15 mL',
+        definitionUri: 'opentrons/nest_12_reservoir_15ml/1',
+      },
+      'e24818a0-0042-11ec-8258-f7ffdf5ad45a': {
+        displayName: 'Opentrons 96 Tip Rack 300 µL (1)',
+        definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+      },
+      '1dc0c050-0122-11ec-88a3-f1745cf9b36c:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': {
+        displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
+        definitionUri: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+      },
+    }
     const labwareDefinitions = protocolWithTC.labwareDefinitions
     const modules = protocolWithTC.modules
     const commands = protocolWithTC.commands
@@ -244,6 +283,7 @@ describe('getTwoPipettePositionCheckSteps', () => {
       getTwoPipettePositionCheckSteps({
         primaryPipetteId,
         secondaryPipetteId,
+        //  @ts-expect-error
         labware,
         labwareDefinitions,
         modules,

--- a/app/src/organisms/LabwarePositionCheck/utils/doesPipetteVisitAllTipracks.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/doesPipetteVisitAllTipracks.ts
@@ -17,7 +17,8 @@ export const doesPipetteVisitAllTipracks = (
   const numberOfTipracks = reduce(
     labware,
     (numberOfTipracks, currentLabware) => {
-      const labwareDef = labwareDefinitions[currentLabware.definitionId]
+      //  @ts-expect-error: will be an error until we remove the schemaV6Adapter
+      const labwareDef = labwareDefinitions[currentLabware.definitionUri]
       return getIsTiprack(labwareDef) ? numberOfTipracks + 1 : numberOfTipracks
     },
     0

--- a/app/src/organisms/LabwarePositionCheck/utils/labware.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/labware.ts
@@ -44,7 +44,8 @@ export const getTiprackIdsInOrder = (
   const unorderedTipracks = reduce<typeof labware, LabwareToOrder[]>(
     labware,
     (tipracks, currentLabware, labwareId) => {
-      const labwareDef = labwareDefinitions[currentLabware.definitionId]
+      //  @ts-expect-error: will be an error until we remove the schemaV6Adapter
+      const labwareDef = labwareDefinitions[currentLabware.definitionUri]
       const isTiprack = getIsTiprack(labwareDef)
       if (isTiprack) {
         const labwareLocation = getLabwareLocation(labwareId, commands)
@@ -95,7 +96,8 @@ export const getAllTipracksIdsThatPipetteUsesInOrder = (
 
   const orderedTiprackIds = tipracksVisited
     .map<LabwareToOrder>(tiprackId => {
-      const labwareDefId = labware[tiprackId].definitionId
+      //  @ts-expect-error: will be an error until we remove the schemaV6Adapter
+      const labwareDefId = labware[tiprackId].definitionUri
       const definition = labwareDefinitions[labwareDefId]
       const tiprackLocation = getLabwareLocation(tiprackId, commands)
       if (!('slotName' in tiprackLocation)) {
@@ -122,7 +124,8 @@ export const getLabwareIdsInOrder = (
   const unorderedLabware = reduce<typeof labware, LabwareToOrder[]>(
     labware,
     (unorderedLabware, currentLabware, labwareId) => {
-      const labwareDef = labwareDefinitions[currentLabware.definitionId]
+      //  @ts-expect-error: will be an error until we remove the schemaV6Adapter
+      const labwareDef = labwareDefinitions[currentLabware.definitionUri]
       const isTiprack = getIsTiprack(labwareDef)
       const labwareLocation = getLabwareLocation(labwareId, commands)
       // skip any labware that is not a tiprack

--- a/app/src/organisms/ReapplyOffsetsModal/hooks/__tests__/useClearAllOffsetsForCurrentRun.test.tsx
+++ b/app/src/organisms/ReapplyOffsetsModal/hooks/__tests__/useClearAllOffsetsForCurrentRun.test.tsx
@@ -33,7 +33,28 @@ const mockProtocolDetails: ProtocolDetails = {
   protocolData: {
     commands: protocolWithTC.commands,
     modules: protocolWithTC.modules,
-    labware: protocolWithTC.labware,
+    labware: {
+      fixedTrash: {
+        displayName: 'Trash',
+        definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+      },
+      '50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1': {
+        displayName: 'Opentrons 96 Tip Rack 300 µL',
+        definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+      },
+      '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1': {
+        displayName: 'NEST 12 Well Reservoir 15 mL',
+        definitionUri: 'opentrons/nest_12_reservoir_15ml/1',
+      },
+      'e24818a0-0042-11ec-8258-f7ffdf5ad45a': {
+        displayName: 'Opentrons 96 Tip Rack 300 µL (1)',
+        definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+      },
+      '1dc0c050-0122-11ec-88a3-f1745cf9b36c:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': {
+        displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
+        definitionUri: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+      },
+    },
     labwareDefinitions: protocolWithTC.labwareDefinitions,
   } as any,
   displayName: 'fake protocol name',

--- a/app/src/organisms/ReapplyOffsetsModal/hooks/__tests__/useOffsetCandidatesForCurrentRun.test.tsx
+++ b/app/src/organisms/ReapplyOffsetsModal/hooks/__tests__/useOffsetCandidatesForCurrentRun.test.tsx
@@ -35,7 +35,28 @@ const mockProtocolDetails: ProtocolDetails = {
   protocolData: {
     commands: protocolWithTC.commands,
     modules: protocolWithTC.modules,
-    labware: protocolWithTC.labware,
+    labware: {
+      fixedTrash: {
+        displayName: 'Trash',
+        definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+      },
+      '50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1': {
+        displayName: 'Opentrons 96 Tip Rack 300 µL',
+        definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+      },
+      '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1': {
+        displayName: 'NEST 12 Well Reservoir 15 mL',
+        definitionUri: 'opentrons/nest_12_reservoir_15ml/1',
+      },
+      'e24818a0-0042-11ec-8258-f7ffdf5ad45a': {
+        displayName: 'Opentrons 96 Tip Rack 300 µL (1)',
+        definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+      },
+      '1dc0c050-0122-11ec-88a3-f1745cf9b36c:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': {
+        displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
+        definitionUri: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+      },
+    },
     labwareDefinitions: protocolWithTC.labwareDefinitions,
   } as any,
   displayName: 'fake protocol name',

--- a/app/src/organisms/ReapplyOffsetsModal/hooks/useOffsetCandidatesForCurrentRun.ts
+++ b/app/src/organisms/ReapplyOffsetsModal/hooks/useOffsetCandidatesForCurrentRun.ts
@@ -80,7 +80,8 @@ function getLabwareDefinition(
   labware: ProtocolFile<{}>['labware'],
   labwareDefinitions: ProtocolFile<{}>['labwareDefinitions']
 ): ProtocolFile<{}>['labwareDefinitions'][string] {
-  const labwareDefinitionId = labware[labwareId].definitionId
+  //  @ts-expect-error: will be an error until we remove the schemaV6Adapter
+  const labwareDefinitionId = labware[labwareId].definitionUri
   if (labwareDefinitionId == null) {
     throw new Error(
       'expected to be able to find labware definition id for labware, but could not'

--- a/robot-server/simulators/test.json
+++ b/robot-server/simulators/test.json
@@ -1,10 +1,10 @@
 {
   "attached_instruments": {
     "right": {
-      "model": "p300_single_v1",
+      "model": "p50_single_v3.1",
       "id": "321",
       "max_volume": 300,
-      "name": "p300_single",
+      "name": "p50_single_gen3",
       "tip_length": 0,
       "channels": 1
     },

--- a/robot-server/simulators/test.json
+++ b/robot-server/simulators/test.json
@@ -1,10 +1,10 @@
 {
   "attached_instruments": {
     "right": {
-      "model": "p50_single_v3.1",
+      "model": "p300_single_v1",
       "id": "321",
       "max_volume": 300,
-      "name": "p50_single_gen3",
+      "name": "p300_single",
       "tip_length": 0,
       "channels": 1
     },

--- a/shared-data/js/helpers/schemaV6Adapter.ts
+++ b/shared-data/js/helpers/schemaV6Adapter.ts
@@ -61,7 +61,7 @@ export const schemaV6Adapter = (
     }, {})
 
     const labwareDefinitions: {
-      [definitionId: string]: LabwareDefinition2
+      [definitionUri: string]: LabwareDefinition2
     } = protocolAnalysis.commands
       .filter(
         (command: RunTimeCommand): command is LoadLabwareRunTimeCommand =>
@@ -70,14 +70,14 @@ export const schemaV6Adapter = (
       .reduce((acc, command: LoadLabwareRunTimeCommand) => {
         const labwareDef: LabwareDefinition2 = command.result?.definition
         const labwareId = command.result?.labwareId ?? ''
-        const definitionUri = protocolAnalysis.labware.find(
-          labware => labware.id === labwareId
-        )?.definitionUri
-        const definitionId = `${definitionUri}_id`
+        const definitionUri =
+          protocolAnalysis.labware
+            .find(labware => labware.id === labwareId)
+            ?.definitionUri.toString() ?? ''
 
         return {
           ...acc,
-          [definitionId]: labwareDef,
+          [definitionUri]: labwareDef,
         }
       }, {})
 

--- a/shared-data/js/helpers/schemaV6Adapter.ts
+++ b/shared-data/js/helpers/schemaV6Adapter.ts
@@ -35,7 +35,7 @@ export const schemaV6Adapter = (
 
     const labware: {
       [labwareId: string]: {
-        definitionId: string
+        definitionUri: string
         displayName?: string
       }
     } = protocolAnalysis.labware.reduce((acc, labware) => {
@@ -54,7 +54,7 @@ export const schemaV6Adapter = (
       return {
         ...acc,
         [labwareId]: {
-          definitionId: `${labware.definitionUri}_id`,
+          definitionUri: `${labware.definitionUri}`,
           displayName: displayName,
         },
       }
@@ -118,6 +118,7 @@ export const schemaV6Adapter = (
       ...protocolAnalysis,
       //  @ts-expect-error
       pipettes,
+      //  @ts-expect-error
       labware,
       modules,
       liquids,

--- a/shared-data/js/helpers/schemaV6Adapter.ts
+++ b/shared-data/js/helpers/schemaV6Adapter.ts
@@ -54,7 +54,7 @@ export const schemaV6Adapter = (
       return {
         ...acc,
         [labwareId]: {
-          definitionUri: `${labware.definitionUri}`,
+          definitionUri: labware.definitionUri,
           displayName: displayName,
         },
       }

--- a/shared-data/js/helpers/schemaV6Adapter.ts
+++ b/shared-data/js/helpers/schemaV6Adapter.ts
@@ -71,9 +71,8 @@ export const schemaV6Adapter = (
         const labwareDef: LabwareDefinition2 = command.result?.definition
         const labwareId = command.result?.labwareId ?? ''
         const definitionUri =
-          protocolAnalysis.labware
-            .find(labware => labware.id === labwareId)
-            ?.definitionUri.toString() ?? ''
+          protocolAnalysis.labware.find(labware => labware.id === labwareId)
+            ?.definitionUri ?? ''
 
         return {
           ...acc,


### PR DESCRIPTION
closes RAUT-232

# Overview

Changes `definitionUri_id` to `definitionUri` in `schemaV6Adapter` and all affected areas

# Changelog

- change `SchemaV6Adapter`, change all affected components and update their tests

# Review requests

- smoke test in the app to make sure everything works as expected

Areas in the app to test:
1. upload a protocol, start/run/complete the protocol
2. go through protocol setup, particularly the labware setup section
3. labware position check
4. saving and using labware offset data

# Risk assessment

low