### PR TITLE
refactor(firmware-binding): add message-index field to all can messages and use a singleton to generate unique index values

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -103,6 +103,8 @@ class MessageId(int, Enum):
     gripper_home_request = 0x43
     add_brushed_linear_move_request = 0x44
 
+    acknowledgement = 0x50
+
     read_presence_sensing_voltage_request = 0x600
     read_presence_sensing_voltage_response = 0x601
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
@@ -71,8 +71,8 @@ class ToolField(utils.UInt8Field):
 
 class FirmwareUpdateDataField(utils.BinaryFieldBase[bytes]):
     """The data field of FirmwareUpdateData."""
-
-    NUM_BYTES = 56
+    # this needs to be a multiple of 8
+    NUM_BYTES = 48
     FORMAT = f"{NUM_BYTES}s"
 
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
@@ -71,6 +71,7 @@ class ToolField(utils.UInt8Field):
 
 class FirmwareUpdateDataField(utils.BinaryFieldBase[bytes]):
     """The data field of FirmwareUpdateData."""
+
     # this needs to be a multiple of 8
     NUM_BYTES = 48
     FORMAT = f"{NUM_BYTES}s"

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -35,7 +35,7 @@ class BaseMessage(object):
         """Update the message index from the singleton."""
         try:
             index_generator = SingletonMessageIndexGenerator()
-            if (self.payload.message_index.value == 0):  # type: ignore[attr-defined]
+            if self.payload.message_index.value == 0:  # type: ignore[attr-defined]
                 self.payload.message_index = utils.UInt32Field(  # type: ignore[attr-defined]
                     index_generator.get_next_index()
                 )

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -34,10 +34,11 @@ class BaseMessage(object):
     def __post_init__(self) -> None:
         """Update the message index from the singleton."""
         try:
-            index_generator = SingletonMessageIndexGenerator()
-            self.payload.message_index = utils.UInt32Field(  # type: ignore[attr-defined]
-                index_generator.get_next_index()
-            )
+            if self.payload.message_index == 0: # type: ignore[attr-defined]
+                index_generator = SingletonMessageIndexGenerator()
+                self.payload.message_index = utils.UInt32Field(  # type: ignore[attr-defined]
+                    index_generator.get_next_index()
+                )
         except AttributeError:
             # we are probably constructing this instance from binary and it doesn't
             # have a payload yet

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -33,12 +33,21 @@ class BaseMessage(object):
 
     def __post_init__(self) -> None:
         """Update the message index from the singleton."""
-        index_generator = SingletonMessageIndexGenerator()
-        self.payload.message_index = utils.UInt32Field(index_generator.get_next_index())
+        try:
+            index_generator = SingletonMessageIndexGenerator()
+            self.payload.message_index = utils.UInt32Field(
+                index_generator.get_next_index()
+            )
+        except AttributeError:
+            # we are probably constructing this instance from binary and it doesn't
+            # have a payload yet
+            pass
+
 
 @dataclass
 class EmptyPayloadMessage(BaseMessage):  # noqa: D101
     """Base class of a message that has an empty payload."""
+
     payload: payloads.EmptyPayload = payloads.EmptyPayload()
     payload_type: Type[payloads.EmptyPayload] = payloads.EmptyPayload
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -29,12 +29,12 @@ class SingletonMessageIndexGenerator(object):
 
 @dataclass(eq=False)
 class BaseMessage(object):
-    """Base class of a message that has an empty payload."""
+    """Base class of a message."""
 
     def __post_init__(self) -> None:
         """Update the message index from the singleton."""
         index_generator = SingletonMessageIndexGenerator()
-        self.message_index = utils.UInt32Field(index_generator.get_next_index())
+        self.payload.message_index = utils.UInt32Field(index_generator.get_next_index())
 
     def __eq__(self, other: object) -> bool:
         """Override __eq__ to ignore message_index."""
@@ -49,6 +49,7 @@ class BaseMessage(object):
 
 @dataclass(eq=False)
 class EmptyPayloadMessage(BaseMessage):  # noqa: D101
+    """Base class of a message that has an empty payload."""
     payload: payloads.EmptyPayload = payloads.EmptyPayload()
     payload_type: Type[payloads.EmptyPayload] = payloads.EmptyPayload
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -46,33 +46,35 @@ class BaseMessage(object):
                     return False
         return True
 
-    payload: utils.BinarySerializable = payloads.EmptyPayload()
-    payload_type: Type[utils.BinarySerializable] = payloads.EmptyPayload
-    message_index: utils.UInt32Field = utils.UInt32Field(0)
+
+@dataclass(eq=False)
+class EmptyPayloadMessage(BaseMessage):  # noqa: D101
+    payload: payloads.EmptyPayload = payloads.EmptyPayload()
+    payload_type: Type[payloads.EmptyPayload] = payloads.EmptyPayload
 
 
 @dataclass(eq=False)
-class Acknowledgement(BaseMessage):  # noqa: D101
+class Acknowledgement(EmptyPayloadMessage):  # noqa: D101
     message_id: MessageId = MessageId.acknowledgement
 
 
 @dataclass(eq=False)
-class HeartbeatRequest(BaseMessage):  # noqa: D101
+class HeartbeatRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.heartbeat_request] = MessageId.heartbeat_request
 
 
 @dataclass(eq=False)
-class HeartbeatResponse(Acknowledgement):  # noqa: D101
+class HeartbeatResponse(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.heartbeat_response] = MessageId.heartbeat_response
 
 
 @dataclass(eq=False)
-class DeviceInfoRequest(BaseMessage):  # noqa: D101
+class DeviceInfoRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.device_info_request] = MessageId.device_info_request
 
 
 @dataclass(eq=False)
-class DeviceInfoResponse(Acknowledgement):  # noqa: D101
+class DeviceInfoResponse(BaseMessage):  # noqa: D101
     payload: payloads.DeviceInfoResponsePayload
     payload_type: Type[
         payloads.DeviceInfoResponsePayload
@@ -81,12 +83,12 @@ class DeviceInfoResponse(Acknowledgement):  # noqa: D101
 
 
 @dataclass(eq=False)
-class TaskInfoRequest(BaseMessage):  # noqa: D101
+class TaskInfoRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.task_info_request] = MessageId.task_info_request
 
 
 @dataclass(eq=False)
-class TaskInfoResponse(Acknowledgement):  # noqa: D101
+class TaskInfoResponse(BaseMessage):  # noqa: D101
     payload: payloads.TaskInfoResponsePayload
     payload_type: Type[
         payloads.TaskInfoResponsePayload
@@ -95,29 +97,29 @@ class TaskInfoResponse(Acknowledgement):  # noqa: D101
 
 
 @dataclass(eq=False)
-class StopRequest(BaseMessage):  # noqa: D101
+class StopRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.stop_request] = MessageId.stop_request
 
 
 @dataclass(eq=False)
-class GetStatusRequest(BaseMessage):  # noqa: D101
+class GetStatusRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.get_status_request] = MessageId.get_status_request
 
 
 @dataclass(eq=False)
-class EnableMotorRequest(BaseMessage):  # noqa: D101
+class EnableMotorRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.enable_motor_request] = MessageId.enable_motor_request
 
 
 @dataclass(eq=False)
-class DisableMotorRequest(BaseMessage):  # noqa: D101
+class DisableMotorRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[
         MessageId.disable_motor_request
     ] = MessageId.disable_motor_request
 
 
 @dataclass(eq=False)
-class GetStatusResponse(Acknowledgement):  # noqa: D101
+class GetStatusResponse(BaseMessage):  # noqa: D101
     payload: payloads.GetStatusResponsePayload
     payload_type: Type[
         payloads.GetStatusResponsePayload
@@ -147,7 +149,7 @@ class ReadFromEEPromRequest(BaseMessage):  # noqa: D101
 
 
 @dataclass(eq=False)
-class ReadFromEEPromResponse(Acknowledgement):  # noqa: D101
+class ReadFromEEPromResponse(BaseMessage):  # noqa: D101
     payload: payloads.EEPromDataPayload
     payload_type: Type[payloads.EEPromDataPayload] = payloads.EEPromDataPayload
     message_id: Literal[MessageId.read_eeprom_response] = MessageId.read_eeprom_response
@@ -174,7 +176,7 @@ class GetMoveGroupRequest(BaseMessage):  # noqa: D101
 
 
 @dataclass(eq=False)
-class GetMoveGroupResponse(Acknowledgement):  # noqa: D101
+class GetMoveGroupResponse(BaseMessage):  # noqa: D101
     payload: payloads.GetMoveGroupResponsePayload
     payload_type: Type[
         payloads.GetMoveGroupResponsePayload
@@ -196,28 +198,28 @@ class ExecuteMoveGroupRequest(BaseMessage):  # noqa: D101
 
 
 @dataclass(eq=False)
-class ClearAllMoveGroupsRequest(BaseMessage):  # noqa: D101
+class ClearAllMoveGroupsRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[
         MessageId.clear_all_move_groups_request
     ] = MessageId.clear_all_move_groups_request
 
 
 @dataclass(eq=False)
-class MoveCompleted(Acknowledgement):  # noqa: D101
+class MoveCompleted(BaseMessage):  # noqa: D101
     payload: payloads.MoveCompletedPayload
     payload_type: Type[payloads.MoveCompletedPayload] = payloads.MoveCompletedPayload
     message_id: Literal[MessageId.move_completed] = MessageId.move_completed
 
 
 @dataclass(eq=False)
-class EncoderPositionRequest(BaseMessage):  # noqa: D101
+class EncoderPositionRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[
         MessageId.encoder_position_request
     ] = MessageId.encoder_position_request
 
 
 @dataclass(eq=False)
-class EncoderPositionResponse(Acknowledgement):  # noqa: D101
+class EncoderPositionResponse(BaseMessage):  # noqa: D101
     payload: payloads.EncoderPositionResponse
     payload_type: Type[
         payloads.EncoderPositionResponse
@@ -239,14 +241,14 @@ class SetMotionConstraints(BaseMessage):  # noqa: D101
 
 
 @dataclass(eq=False)
-class GetMotionConstraintsRequest(BaseMessage):  # noqa: D101
+class GetMotionConstraintsRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[
         MessageId.get_motion_constraints_request
     ] = MessageId.get_motion_constraints_request
 
 
 @dataclass(eq=False)
-class GetMotionConstraintsResponse(Acknowledgement):  # noqa: D101
+class GetMotionConstraintsResponse(BaseMessage):  # noqa: D101
     payload: payloads.MotionConstraintsPayload
     payload_type: Type[
         payloads.MotionConstraintsPayload
@@ -279,7 +281,7 @@ class ReadMotorDriverRequest(BaseMessage):  # noqa: D101
 
 
 @dataclass(eq=False)
-class ReadMotorDriverResponse(Acknowledgement):  # noqa: D101
+class ReadMotorDriverResponse(BaseMessage):  # noqa: D101
     payload: payloads.ReadMotorDriverRegisterResponsePayload
     payload_type: Type[
         payloads.ReadMotorDriverRegisterResponsePayload
@@ -299,14 +301,14 @@ class WriteMotorCurrentRequest(BaseMessage):  # noqa: D101
 
 
 @dataclass(eq=False)
-class ReadPresenceSensingVoltageRequest(BaseMessage):  # noqa: D101
+class ReadPresenceSensingVoltageRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[
         MessageId.read_presence_sensing_voltage_request
     ] = MessageId.read_presence_sensing_voltage_request
 
 
 @dataclass(eq=False)
-class ReadPresenceSensingVoltageResponse(Acknowledgement):  # noqa: D101
+class ReadPresenceSensingVoltageResponse(BaseMessage):  # noqa: D101
     payload: payloads.ReadPresenceSensingVoltageResponsePayload
     payload_type: Type[
         payloads.ReadPresenceSensingVoltageResponsePayload
@@ -328,14 +330,14 @@ class PushToolsDetectedNotification(BaseMessage):  # noqa: D101
 
 
 @dataclass(eq=False)
-class AttachedToolsRequest(BaseMessage):  # noqa: D101
+class AttachedToolsRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[
         MessageId.attached_tools_request
     ] = MessageId.attached_tools_request
 
 
 @dataclass(eq=False)
-class FirmwareUpdateInitiate(BaseMessage):  # noqa: D101
+class FirmwareUpdateInitiate(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.fw_update_initiate] = MessageId.fw_update_initiate
 
 
@@ -347,7 +349,7 @@ class FirmwareUpdateData(BaseMessage):  # noqa: D101
 
 
 @dataclass(eq=False)
-class FirmwareUpdateDataAcknowledge(Acknowledgement):  # noqa: D101
+class FirmwareUpdateDataAcknowledge(BaseMessage):  # noqa: D101
     payload: payloads.FirmwareUpdateDataAcknowledge
     payload_type: Type[
         payloads.FirmwareUpdateDataAcknowledge
@@ -356,7 +358,7 @@ class FirmwareUpdateDataAcknowledge(Acknowledgement):  # noqa: D101
 
 
 @dataclass(eq=False)
-class FirmwareUpdateComplete(Acknowledgement):  # noqa: D101
+class FirmwareUpdateComplete(BaseMessage):  # noqa: D101
     payload: payloads.FirmwareUpdateComplete
     payload_type: Type[
         payloads.FirmwareUpdateComplete
@@ -365,7 +367,7 @@ class FirmwareUpdateComplete(Acknowledgement):  # noqa: D101
 
 
 @dataclass(eq=False)
-class FirmwareUpdateCompleteAcknowledge(Acknowledgement):  # noqa: D101
+class FirmwareUpdateCompleteAcknowledge(BaseMessage):  # noqa: D101
     payload: payloads.FirmwareUpdateAcknowledge
     payload_type: Type[
         payloads.FirmwareUpdateAcknowledge
@@ -376,14 +378,14 @@ class FirmwareUpdateCompleteAcknowledge(Acknowledgement):  # noqa: D101
 
 
 @dataclass(eq=False)
-class FirmwareUpdateStatusRequest(BaseMessage):  # noqa: D101
+class FirmwareUpdateStatusRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[
         MessageId.fw_update_status_request
     ] = MessageId.fw_update_status_request
 
 
 @dataclass(eq=False)
-class FirmwareUpdateStatusResponse(Acknowledgement):  # noqa: D101
+class FirmwareUpdateStatusResponse(BaseMessage):  # noqa: D101
     payload: payloads.FirmwareUpdateStatus
     payload_type: Type[payloads.FirmwareUpdateStatus] = payloads.FirmwareUpdateStatus
     message_id: Literal[
@@ -392,12 +394,12 @@ class FirmwareUpdateStatusResponse(Acknowledgement):  # noqa: D101
 
 
 @dataclass(eq=False)
-class FirmwareUpdateEraseAppRequest(BaseMessage):  # noqa: D101
+class FirmwareUpdateEraseAppRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.fw_update_erase_app] = MessageId.fw_update_erase_app
 
 
 @dataclass(eq=False)
-class FirmwareUpdateEraseAppResponse(Acknowledgement):  # noqa: D101
+class FirmwareUpdateEraseAppResponse(BaseMessage):  # noqa: D101
     payload: payloads.FirmwareUpdateAcknowledge
     payload_type: Type[
         payloads.FirmwareUpdateAcknowledge
@@ -415,17 +417,17 @@ class HomeRequest(BaseMessage):  # noqa: D101
 
 
 @dataclass(eq=False)
-class FirmwareUpdateStartApp(BaseMessage):  # noqa: D101
+class FirmwareUpdateStartApp(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.fw_update_start_app] = MessageId.fw_update_start_app
 
 
 @dataclass(eq=False)
-class ReadLimitSwitchRequest(BaseMessage):  # noqa: D101
+class ReadLimitSwitchRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.limit_sw_request] = MessageId.limit_sw_request
 
 
 @dataclass(eq=False)
-class ReadLimitSwitchResponse(Acknowledgement):  # noqa: D101
+class ReadLimitSwitchResponse(BaseMessage):  # noqa: D101
     payload: payloads.GetLimitSwitchResponse
     payload_type: Type[
         payloads.GetLimitSwitchResponse
@@ -463,7 +465,7 @@ class BaselineSensorRequest(BaseMessage):  # noqa: D101
 
 
 @dataclass(eq=False)
-class ReadFromSensorResponse(Acknowledgement):  # noqa: D101
+class ReadFromSensorResponse(BaseMessage):  # noqa: D101
     payload: payloads.ReadFromSensorResponsePayload
     payload_type: Type[
         payloads.ReadFromSensorResponsePayload
@@ -483,7 +485,7 @@ class SetSensorThresholdRequest(BaseMessage):  # noqa: D101
 
 
 @dataclass(eq=False)
-class SensorThresholdResponse(Acknowledgement):  # noqa: D101
+class SensorThresholdResponse(BaseMessage):  # noqa: D101
     payload: payloads.SensorThresholdResponsePayload
     payload_type: Type[
         payloads.SensorThresholdResponsePayload
@@ -505,7 +507,7 @@ class SensorDiagnosticRequest(BaseMessage):  # noqa: D101
 
 
 @dataclass(eq=False)
-class SensorDiagnosticResponse(Acknowledgement):  # noqa: D101
+class SensorDiagnosticResponse(BaseMessage):  # noqa: D101
     payload: payloads.SensorDiagnosticResponsePayload
     payload_type: Type[
         payloads.SensorDiagnosticResponsePayload
@@ -516,7 +518,7 @@ class SensorDiagnosticResponse(Acknowledgement):  # noqa: D101
 
 
 @dataclass(eq=False)
-class PipetteInfoResponse(Acknowledgement):  # noqa: D101
+class PipetteInfoResponse(BaseMessage):  # noqa: D101
     payload: payloads.PipetteInfoResponsePayload
     payload_type: Type[
         payloads.PipetteInfoResponsePayload
@@ -589,7 +591,7 @@ class BindSensorOutputRequest(BaseMessage):  # noqa: D101
 
 
 @dataclass(eq=False)
-class BindSensorOutputResponse(Acknowledgement):  # noqa: D101
+class BindSensorOutputResponse(BaseMessage):  # noqa: D101
     payload: payloads.BindSensorOutputResponsePayload
     payload_type: Type[
         payloads.BindSensorOutputResponsePayload
@@ -600,7 +602,7 @@ class BindSensorOutputResponse(Acknowledgement):  # noqa: D101
 
 
 @dataclass(eq=False)
-class GripperInfoResponse(Acknowledgement):  # noqa: D101
+class GripperInfoResponse(BaseMessage):  # noqa: D101
     payload: payloads.GripperInfoResponsePayload
     payload_type: Type[
         payloads.GripperInfoResponsePayload
@@ -622,7 +624,7 @@ class TipActionRequest(BaseMessage):  # noqa: D101
 
 
 @dataclass(eq=False)
-class TipActionResponse(Acknowledgement):  # noqa: D101
+class TipActionResponse(BaseMessage):  # noqa: D101
     payload: payloads.TipActionResponsePayload
     payload_type: Type[
         payloads.TipActionResponsePayload
@@ -642,7 +644,7 @@ class PeripheralStatusRequest(BaseMessage):  # noqa: D101
 
 
 @dataclass(eq=False)
-class PeripheralStatusResponse(Acknowledgement):  # noqa: D101
+class PeripheralStatusResponse(BaseMessage):  # noqa: D101
     payload: payloads.PeripheralStatusResponsePayload
     payload_type: Type[
         payloads.PeripheralStatusResponsePayload
@@ -660,7 +662,7 @@ class SetSerialNumber(BaseMessage):  # noqa: D101
 
 
 @dataclass(eq=False)
-class InstrumentInfoRequest(BaseMessage):
+class InstrumentInfoRequest(EmptyPayloadMessage):
     """Prompt pipettes and grippers to respond.
 
     Pipette should respond with PipetteInfoResponse.

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -35,7 +35,7 @@ class BaseMessage(object):
         """Update the message index from the singleton."""
         try:
             index_generator = SingletonMessageIndexGenerator()
-            if self.payload.message_index.value == None:  # type: ignore[attr-defined]
+            if self.payload.message_index.value is None:  # type: ignore[attr-defined]
                 self.payload.message_index = utils.UInt32Field(  # type: ignore[attr-defined]
                     index_generator.get_next_index()
                 )

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -27,7 +27,7 @@ class SingletonMessageIndexGenerator(object):
     __current_index = 0
 
 
-@dataclass(eq=False)
+@dataclass
 class BaseMessage(object):
     """Base class of a message."""
 
@@ -36,45 +36,34 @@ class BaseMessage(object):
         index_generator = SingletonMessageIndexGenerator()
         self.payload.message_index = utils.UInt32Field(index_generator.get_next_index())
 
-    def __eq__(self, other: object) -> bool:
-        """Override __eq__ to ignore message_index."""
-        other_dict = vars(other)
-        self_dict = vars(self)
-        for key in self_dict:
-            if key != "message_index":
-                if not (key in other_dict and self_dict[key] == other_dict[key]):
-                    return False
-        return True
-
-
-@dataclass(eq=False)
+@dataclass
 class EmptyPayloadMessage(BaseMessage):  # noqa: D101
     """Base class of a message that has an empty payload."""
     payload: payloads.EmptyPayload = payloads.EmptyPayload()
     payload_type: Type[payloads.EmptyPayload] = payloads.EmptyPayload
 
 
-@dataclass(eq=False)
+@dataclass
 class Acknowledgement(EmptyPayloadMessage):  # noqa: D101
     message_id: MessageId = MessageId.acknowledgement
 
 
-@dataclass(eq=False)
+@dataclass
 class HeartbeatRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.heartbeat_request] = MessageId.heartbeat_request
 
 
-@dataclass(eq=False)
+@dataclass
 class HeartbeatResponse(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.heartbeat_response] = MessageId.heartbeat_response
 
 
-@dataclass(eq=False)
+@dataclass
 class DeviceInfoRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.device_info_request] = MessageId.device_info_request
 
 
-@dataclass(eq=False)
+@dataclass
 class DeviceInfoResponse(BaseMessage):  # noqa: D101
     payload: payloads.DeviceInfoResponsePayload
     payload_type: Type[
@@ -83,12 +72,12 @@ class DeviceInfoResponse(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.device_info_response] = MessageId.device_info_response
 
 
-@dataclass(eq=False)
+@dataclass
 class TaskInfoRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.task_info_request] = MessageId.task_info_request
 
 
-@dataclass(eq=False)
+@dataclass
 class TaskInfoResponse(BaseMessage):  # noqa: D101
     payload: payloads.TaskInfoResponsePayload
     payload_type: Type[
@@ -97,29 +86,29 @@ class TaskInfoResponse(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.task_info_response] = MessageId.task_info_response
 
 
-@dataclass(eq=False)
+@dataclass
 class StopRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.stop_request] = MessageId.stop_request
 
 
-@dataclass(eq=False)
+@dataclass
 class GetStatusRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.get_status_request] = MessageId.get_status_request
 
 
-@dataclass(eq=False)
+@dataclass
 class EnableMotorRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.enable_motor_request] = MessageId.enable_motor_request
 
 
-@dataclass(eq=False)
+@dataclass
 class DisableMotorRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[
         MessageId.disable_motor_request
     ] = MessageId.disable_motor_request
 
 
-@dataclass(eq=False)
+@dataclass
 class GetStatusResponse(BaseMessage):  # noqa: D101
     payload: payloads.GetStatusResponsePayload
     payload_type: Type[
@@ -128,35 +117,35 @@ class GetStatusResponse(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.get_status_response] = MessageId.get_status_response
 
 
-@dataclass(eq=False)
+@dataclass
 class MoveRequest(BaseMessage):  # noqa: D101
     payload: payloads.MoveRequestPayload
     payload_type: Type[payloads.MoveRequestPayload] = payloads.MoveRequestPayload
     message_id: Literal[MessageId.move_request] = MessageId.move_request
 
 
-@dataclass(eq=False)
+@dataclass
 class WriteToEEPromRequest(BaseMessage):  # noqa: D101
     payload: payloads.EEPromDataPayload
     payload_type: Type[payloads.EEPromDataPayload] = payloads.EEPromDataPayload
     message_id: Literal[MessageId.write_eeprom] = MessageId.write_eeprom
 
 
-@dataclass(eq=False)
+@dataclass
 class ReadFromEEPromRequest(BaseMessage):  # noqa: D101
     payload: payloads.EEPromReadPayload
     payload_type: Type[payloads.EEPromReadPayload] = payloads.EEPromReadPayload
     message_id: Literal[MessageId.read_eeprom_request] = MessageId.read_eeprom_request
 
 
-@dataclass(eq=False)
+@dataclass
 class ReadFromEEPromResponse(BaseMessage):  # noqa: D101
     payload: payloads.EEPromDataPayload
     payload_type: Type[payloads.EEPromDataPayload] = payloads.EEPromDataPayload
     message_id: Literal[MessageId.read_eeprom_response] = MessageId.read_eeprom_response
 
 
-@dataclass(eq=False)
+@dataclass
 class AddLinearMoveRequest(BaseMessage):  # noqa: D101
     payload: payloads.AddLinearMoveRequestPayload
     payload_type: Type[
@@ -165,7 +154,7 @@ class AddLinearMoveRequest(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.add_move_request] = MessageId.add_move_request
 
 
-@dataclass(eq=False)
+@dataclass
 class GetMoveGroupRequest(BaseMessage):  # noqa: D101
     payload: payloads.MoveGroupRequestPayload
     payload_type: Type[
@@ -176,7 +165,7 @@ class GetMoveGroupRequest(BaseMessage):  # noqa: D101
     ] = MessageId.get_move_group_request
 
 
-@dataclass(eq=False)
+@dataclass
 class GetMoveGroupResponse(BaseMessage):  # noqa: D101
     payload: payloads.GetMoveGroupResponsePayload
     payload_type: Type[
@@ -187,7 +176,7 @@ class GetMoveGroupResponse(BaseMessage):  # noqa: D101
     ] = MessageId.get_move_group_response
 
 
-@dataclass(eq=False)
+@dataclass
 class ExecuteMoveGroupRequest(BaseMessage):  # noqa: D101
     payload: payloads.ExecuteMoveGroupRequestPayload
     payload_type: Type[
@@ -198,28 +187,28 @@ class ExecuteMoveGroupRequest(BaseMessage):  # noqa: D101
     ] = MessageId.execute_move_group_request
 
 
-@dataclass(eq=False)
+@dataclass
 class ClearAllMoveGroupsRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[
         MessageId.clear_all_move_groups_request
     ] = MessageId.clear_all_move_groups_request
 
 
-@dataclass(eq=False)
+@dataclass
 class MoveCompleted(BaseMessage):  # noqa: D101
     payload: payloads.MoveCompletedPayload
     payload_type: Type[payloads.MoveCompletedPayload] = payloads.MoveCompletedPayload
     message_id: Literal[MessageId.move_completed] = MessageId.move_completed
 
 
-@dataclass(eq=False)
+@dataclass
 class EncoderPositionRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[
         MessageId.encoder_position_request
     ] = MessageId.encoder_position_request
 
 
-@dataclass(eq=False)
+@dataclass
 class EncoderPositionResponse(BaseMessage):  # noqa: D101
     payload: payloads.EncoderPositionResponse
     payload_type: Type[
@@ -230,7 +219,7 @@ class EncoderPositionResponse(BaseMessage):  # noqa: D101
     ] = MessageId.encoder_position_response
 
 
-@dataclass(eq=False)
+@dataclass
 class SetMotionConstraints(BaseMessage):  # noqa: D101
     payload: payloads.MotionConstraintsPayload
     payload_type: Type[
@@ -241,14 +230,14 @@ class SetMotionConstraints(BaseMessage):  # noqa: D101
     ] = MessageId.set_motion_constraints
 
 
-@dataclass(eq=False)
+@dataclass
 class GetMotionConstraintsRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[
         MessageId.get_motion_constraints_request
     ] = MessageId.get_motion_constraints_request
 
 
-@dataclass(eq=False)
+@dataclass
 class GetMotionConstraintsResponse(BaseMessage):  # noqa: D101
     payload: payloads.MotionConstraintsPayload
     payload_type: Type[
@@ -259,7 +248,7 @@ class GetMotionConstraintsResponse(BaseMessage):  # noqa: D101
     ] = MessageId.get_motion_constraints_response
 
 
-@dataclass(eq=False)
+@dataclass
 class WriteMotorDriverRegister(BaseMessage):  # noqa: D101
     payload: payloads.MotorDriverRegisterDataPayload
     payload_type: Type[
@@ -270,7 +259,7 @@ class WriteMotorDriverRegister(BaseMessage):  # noqa: D101
     ] = MessageId.write_motor_driver_register_request
 
 
-@dataclass(eq=False)
+@dataclass
 class ReadMotorDriverRequest(BaseMessage):  # noqa: D101
     payload: payloads.MotorDriverRegisterPayload
     payload_type: Type[
@@ -281,7 +270,7 @@ class ReadMotorDriverRequest(BaseMessage):  # noqa: D101
     ] = MessageId.read_motor_driver_register_request
 
 
-@dataclass(eq=False)
+@dataclass
 class ReadMotorDriverResponse(BaseMessage):  # noqa: D101
     payload: payloads.ReadMotorDriverRegisterResponsePayload
     payload_type: Type[
@@ -292,7 +281,7 @@ class ReadMotorDriverResponse(BaseMessage):  # noqa: D101
     ] = MessageId.read_motor_driver_register_response
 
 
-@dataclass(eq=False)
+@dataclass
 class WriteMotorCurrentRequest(BaseMessage):  # noqa: D101
     payload: payloads.MotorCurrentPayload
     payload_type: Type[payloads.MotorCurrentPayload] = payloads.MotorCurrentPayload
@@ -301,14 +290,14 @@ class WriteMotorCurrentRequest(BaseMessage):  # noqa: D101
     ] = MessageId.write_motor_current_request
 
 
-@dataclass(eq=False)
+@dataclass
 class ReadPresenceSensingVoltageRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[
         MessageId.read_presence_sensing_voltage_request
     ] = MessageId.read_presence_sensing_voltage_request
 
 
-@dataclass(eq=False)
+@dataclass
 class ReadPresenceSensingVoltageResponse(BaseMessage):  # noqa: D101
     payload: payloads.ReadPresenceSensingVoltageResponsePayload
     payload_type: Type[
@@ -319,7 +308,7 @@ class ReadPresenceSensingVoltageResponse(BaseMessage):  # noqa: D101
     ] = MessageId.read_presence_sensing_voltage_response
 
 
-@dataclass(eq=False)
+@dataclass
 class PushToolsDetectedNotification(BaseMessage):  # noqa: D101
     payload: payloads.ToolsDetectedNotificationPayload
     payload_type: Type[
@@ -330,26 +319,26 @@ class PushToolsDetectedNotification(BaseMessage):  # noqa: D101
     ] = MessageId.tools_detected_notification
 
 
-@dataclass(eq=False)
+@dataclass
 class AttachedToolsRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[
         MessageId.attached_tools_request
     ] = MessageId.attached_tools_request
 
 
-@dataclass(eq=False)
+@dataclass
 class FirmwareUpdateInitiate(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.fw_update_initiate] = MessageId.fw_update_initiate
 
 
-@dataclass(eq=False)
+@dataclass
 class FirmwareUpdateData(BaseMessage):  # noqa: D101
     payload: payloads.FirmwareUpdateData
     payload_type: Type[payloads.FirmwareUpdateData] = payloads.FirmwareUpdateData
     message_id: Literal[MessageId.fw_update_data] = MessageId.fw_update_data
 
 
-@dataclass(eq=False)
+@dataclass
 class FirmwareUpdateDataAcknowledge(BaseMessage):  # noqa: D101
     payload: payloads.FirmwareUpdateDataAcknowledge
     payload_type: Type[
@@ -358,7 +347,7 @@ class FirmwareUpdateDataAcknowledge(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.fw_update_data_ack] = MessageId.fw_update_data_ack
 
 
-@dataclass(eq=False)
+@dataclass
 class FirmwareUpdateComplete(BaseMessage):  # noqa: D101
     payload: payloads.FirmwareUpdateComplete
     payload_type: Type[
@@ -367,7 +356,7 @@ class FirmwareUpdateComplete(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.fw_update_complete] = MessageId.fw_update_complete
 
 
-@dataclass(eq=False)
+@dataclass
 class FirmwareUpdateCompleteAcknowledge(BaseMessage):  # noqa: D101
     payload: payloads.FirmwareUpdateAcknowledge
     payload_type: Type[
@@ -378,14 +367,14 @@ class FirmwareUpdateCompleteAcknowledge(BaseMessage):  # noqa: D101
     ] = MessageId.fw_update_complete_ack
 
 
-@dataclass(eq=False)
+@dataclass
 class FirmwareUpdateStatusRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[
         MessageId.fw_update_status_request
     ] = MessageId.fw_update_status_request
 
 
-@dataclass(eq=False)
+@dataclass
 class FirmwareUpdateStatusResponse(BaseMessage):  # noqa: D101
     payload: payloads.FirmwareUpdateStatus
     payload_type: Type[payloads.FirmwareUpdateStatus] = payloads.FirmwareUpdateStatus
@@ -394,12 +383,12 @@ class FirmwareUpdateStatusResponse(BaseMessage):  # noqa: D101
     ] = MessageId.fw_update_status_response
 
 
-@dataclass(eq=False)
+@dataclass
 class FirmwareUpdateEraseAppRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.fw_update_erase_app] = MessageId.fw_update_erase_app
 
 
-@dataclass(eq=False)
+@dataclass
 class FirmwareUpdateEraseAppResponse(BaseMessage):  # noqa: D101
     payload: payloads.FirmwareUpdateAcknowledge
     payload_type: Type[
@@ -410,24 +399,24 @@ class FirmwareUpdateEraseAppResponse(BaseMessage):  # noqa: D101
     ] = MessageId.fw_update_erase_app_ack
 
 
-@dataclass(eq=False)
+@dataclass
 class HomeRequest(BaseMessage):  # noqa: D101
     payload: payloads.HomeRequestPayload
     payload_type: Type[payloads.HomeRequestPayload] = payloads.HomeRequestPayload
     message_id: Literal[MessageId.home_request] = MessageId.home_request
 
 
-@dataclass(eq=False)
+@dataclass
 class FirmwareUpdateStartApp(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.fw_update_start_app] = MessageId.fw_update_start_app
 
 
-@dataclass(eq=False)
+@dataclass
 class ReadLimitSwitchRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.limit_sw_request] = MessageId.limit_sw_request
 
 
-@dataclass(eq=False)
+@dataclass
 class ReadLimitSwitchResponse(BaseMessage):  # noqa: D101
     payload: payloads.GetLimitSwitchResponse
     payload_type: Type[
@@ -436,7 +425,7 @@ class ReadLimitSwitchResponse(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.limit_sw_response] = MessageId.limit_sw_response
 
 
-@dataclass(eq=False)
+@dataclass
 class ReadFromSensorRequest(BaseMessage):  # noqa: D101
     payload: payloads.ReadFromSensorRequestPayload
     payload_type: Type[
@@ -445,7 +434,7 @@ class ReadFromSensorRequest(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.read_sensor_request] = MessageId.read_sensor_request
 
 
-@dataclass(eq=False)
+@dataclass
 class WriteToSensorRequest(BaseMessage):  # noqa: D101
     payload: payloads.WriteToSensorRequestPayload
     payload_type: Type[
@@ -454,7 +443,7 @@ class WriteToSensorRequest(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.write_sensor_request] = MessageId.write_sensor_request
 
 
-@dataclass(eq=False)
+@dataclass
 class BaselineSensorRequest(BaseMessage):  # noqa: D101
     payload: payloads.BaselineSensorRequestPayload
     payload_type: Type[
@@ -465,7 +454,7 @@ class BaselineSensorRequest(BaseMessage):  # noqa: D101
     ] = MessageId.baseline_sensor_request
 
 
-@dataclass(eq=False)
+@dataclass
 class ReadFromSensorResponse(BaseMessage):  # noqa: D101
     payload: payloads.ReadFromSensorResponsePayload
     payload_type: Type[
@@ -474,7 +463,7 @@ class ReadFromSensorResponse(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.read_sensor_response] = MessageId.read_sensor_response
 
 
-@dataclass(eq=False)
+@dataclass
 class SetSensorThresholdRequest(BaseMessage):  # noqa: D101
     payload: payloads.SetSensorThresholdRequestPayload
     payload_type: Type[
@@ -485,7 +474,7 @@ class SetSensorThresholdRequest(BaseMessage):  # noqa: D101
     ] = MessageId.set_sensor_threshold_request
 
 
-@dataclass(eq=False)
+@dataclass
 class SensorThresholdResponse(BaseMessage):  # noqa: D101
     payload: payloads.SensorThresholdResponsePayload
     payload_type: Type[
@@ -496,7 +485,7 @@ class SensorThresholdResponse(BaseMessage):  # noqa: D101
     ] = MessageId.set_sensor_threshold_response
 
 
-@dataclass(eq=False)
+@dataclass
 class SensorDiagnosticRequest(BaseMessage):  # noqa: D101
     payload: payloads.SensorDiagnosticRequestPayload
     payload_type: Type[
@@ -507,7 +496,7 @@ class SensorDiagnosticRequest(BaseMessage):  # noqa: D101
     ] = MessageId.sensor_diagnostic_request
 
 
-@dataclass(eq=False)
+@dataclass
 class SensorDiagnosticResponse(BaseMessage):  # noqa: D101
     payload: payloads.SensorDiagnosticResponsePayload
     payload_type: Type[
@@ -518,7 +507,7 @@ class SensorDiagnosticResponse(BaseMessage):  # noqa: D101
     ] = MessageId.sensor_diagnostic_response
 
 
-@dataclass(eq=False)
+@dataclass
 class PipetteInfoResponse(BaseMessage):  # noqa: D101
     payload: payloads.PipetteInfoResponsePayload
     payload_type: Type[
@@ -529,7 +518,7 @@ class PipetteInfoResponse(BaseMessage):  # noqa: D101
     ] = MessageId.pipette_info_response
 
 
-@dataclass(eq=False)
+@dataclass
 class SetBrushedMotorVrefRequest(BaseMessage):  # noqa: D101
     payload: payloads.BrushedMotorVrefPayload
     payload_type: Type[
@@ -540,7 +529,7 @@ class SetBrushedMotorVrefRequest(BaseMessage):  # noqa: D101
     ] = MessageId.set_brushed_motor_vref_request
 
 
-@dataclass(eq=False)
+@dataclass
 class SetBrushedMotorPwmRequest(BaseMessage):  # noqa: D101
     payload: payloads.BrushedMotorPwmPayload
     payload_type: Type[
@@ -551,7 +540,7 @@ class SetBrushedMotorPwmRequest(BaseMessage):  # noqa: D101
     ] = MessageId.set_brushed_motor_pwm_request
 
 
-@dataclass(eq=False)
+@dataclass
 class GripperGripRequest(BaseMessage):  # noqa: D101
     payload: payloads.GripperMoveRequestPayload
     payload_type: Type[
@@ -560,7 +549,7 @@ class GripperGripRequest(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.gripper_grip_request] = MessageId.gripper_grip_request
 
 
-@dataclass(eq=False)
+@dataclass
 class GripperHomeRequest(BaseMessage):  # noqa: D101
     payload: payloads.GripperMoveRequestPayload
     payload_type: Type[
@@ -569,7 +558,7 @@ class GripperHomeRequest(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.gripper_home_request] = MessageId.gripper_home_request
 
 
-@dataclass(eq=False)
+@dataclass
 class AddBrushedLinearMoveRequest(BaseMessage):  # noqa: D101
     payload: payloads.GripperMoveRequestPayload
     payload_type: Type[
@@ -580,7 +569,7 @@ class AddBrushedLinearMoveRequest(BaseMessage):  # noqa: D101
     ] = MessageId.add_brushed_linear_move_request
 
 
-@dataclass(eq=False)
+@dataclass
 class BindSensorOutputRequest(BaseMessage):  # noqa: D101
     payload: payloads.BindSensorOutputRequestPayload
     payload_type: Type[
@@ -591,7 +580,7 @@ class BindSensorOutputRequest(BaseMessage):  # noqa: D101
     ] = MessageId.bind_sensor_output_request
 
 
-@dataclass(eq=False)
+@dataclass
 class BindSensorOutputResponse(BaseMessage):  # noqa: D101
     payload: payloads.BindSensorOutputResponsePayload
     payload_type: Type[
@@ -602,7 +591,7 @@ class BindSensorOutputResponse(BaseMessage):  # noqa: D101
     ] = MessageId.bind_sensor_output_response
 
 
-@dataclass(eq=False)
+@dataclass
 class GripperInfoResponse(BaseMessage):  # noqa: D101
     payload: payloads.GripperInfoResponsePayload
     payload_type: Type[
@@ -613,7 +602,7 @@ class GripperInfoResponse(BaseMessage):  # noqa: D101
     ] = MessageId.gripper_info_response
 
 
-@dataclass(eq=False)
+@dataclass
 class TipActionRequest(BaseMessage):  # noqa: D101
     payload: payloads.TipActionRequestPayload
     payload_type: Type[
@@ -624,7 +613,7 @@ class TipActionRequest(BaseMessage):  # noqa: D101
     ] = MessageId.do_self_contained_tip_action_request
 
 
-@dataclass(eq=False)
+@dataclass
 class TipActionResponse(BaseMessage):  # noqa: D101
     payload: payloads.TipActionResponsePayload
     payload_type: Type[
@@ -635,7 +624,7 @@ class TipActionResponse(BaseMessage):  # noqa: D101
     ] = MessageId.do_self_contained_tip_action_response
 
 
-@dataclass(eq=False)
+@dataclass
 class PeripheralStatusRequest(BaseMessage):  # noqa: D101
     payload: payloads.SensorPayload
     payload_type: Type[payloads.SensorPayload] = payloads.SensorPayload
@@ -644,7 +633,7 @@ class PeripheralStatusRequest(BaseMessage):  # noqa: D101
     ] = MessageId.peripheral_status_request
 
 
-@dataclass(eq=False)
+@dataclass
 class PeripheralStatusResponse(BaseMessage):  # noqa: D101
     payload: payloads.PeripheralStatusResponsePayload
     payload_type: Type[
@@ -655,14 +644,14 @@ class PeripheralStatusResponse(BaseMessage):  # noqa: D101
     ] = MessageId.peripheral_status_response
 
 
-@dataclass(eq=False)
+@dataclass
 class SetSerialNumber(BaseMessage):  # noqa: D101
     payload: payloads.SerialNumberPayload
     payload_type: Type[payloads.SerialNumberPayload] = payloads.SerialNumberPayload
     message_id: Literal[MessageId.set_serial_number] = MessageId.set_serial_number
 
 
-@dataclass(eq=False)
+@dataclass
 class InstrumentInfoRequest(EmptyPayloadMessage):
     """Prompt pipettes and grippers to respond.
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -35,7 +35,7 @@ class BaseMessage(object):
         """Update the message index from the singleton."""
         try:
             index_generator = SingletonMessageIndexGenerator()
-            if self.payload.message_index.value == 0:  # type: ignore[attr-defined]
+            if self.payload.message_index.value == None:  # type: ignore[attr-defined]
                 self.payload.message_index = utils.UInt32Field(  # type: ignore[attr-defined]
                     index_generator.get_next_index()
                 )

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -9,9 +9,28 @@ from . import payloads
 from .. import utils
 
 
+class SingletonMessageIndexGenerator(object):
+    """ Singlton class that generates uinque index values """
+    def __new__(cls):
+        if not hasattr(cls, 'instance'):
+            cls.instance = super(SingletonMessageIndexGenerator, cls).__new__(cls)
+        return cls.instance
+
+    def get_next_index(self):
+        # increment before returning so we never return 0 as a value
+        self.__current_index += 1
+        return self.__current_index
+
+    __current_index = 0
+
+
 @dataclass
-class BaseMessage:
+class BaseMessage(object):
     """Base class of a message that has an empty payload."""
+
+    def __post_init__(self):
+        index_generator = SingletonMessageIndexGenerator()
+        self.message_index = index_generator.get_next_index()
 
     payload: payloads.EmptyPayload = payloads.EmptyPayload()
     payload_type: Type[payloads.EmptyPayload] = payloads.EmptyPayload

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -34,7 +34,7 @@ class BaseMessage(object):
     def __post_init__(self) -> None:
         """Update the message index from the singleton."""
         try:
-            if self.payload.message_index == 0: # type: ignore[attr-defined]
+            if self.payload.message_index == 0:  # type: ignore[attr-defined]
                 index_generator = SingletonMessageIndexGenerator()
                 self.payload.message_index = utils.UInt32Field(  # type: ignore[attr-defined]
                     index_generator.get_next_index()

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -34,8 +34,8 @@ class BaseMessage(object):
     def __post_init__(self) -> None:
         """Update the message index from the singleton."""
         try:
-            if self.payload.message_index == 0:  # type: ignore[attr-defined]
-                index_generator = SingletonMessageIndexGenerator()
+            index_generator = SingletonMessageIndexGenerator()
+            if (self.payload.message_index.value == 0):  # type: ignore[attr-defined]
                 self.payload.message_index = utils.UInt32Field(  # type: ignore[attr-defined]
                     index_generator.get_next_index()
                 )

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -45,7 +45,7 @@ class BaseMessage(object):
 
 
 @dataclass
-class EmptyPayloadMessage(BaseMessage):  # noqa: D101
+class EmptyPayloadMessage(BaseMessage):
     """Base class of a message that has an empty payload."""
 
     payload: payloads.EmptyPayload = payloads.EmptyPayload()

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -35,7 +35,7 @@ class BaseMessage(object):
         """Update the message index from the singleton."""
         try:
             index_generator = SingletonMessageIndexGenerator()
-            self.payload.message_index = utils.UInt32Field(
+            self.payload.message_index = utils.UInt32Field(  # type: ignore[attr-defined]
                 index_generator.get_next_index()
             )
         except AttributeError:

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -6,33 +6,40 @@ from typing_extensions import Literal
 
 from ..constants import MessageId
 from . import payloads
+from .. import utils
 
 
 @dataclass
-class EmptyPayloadMessage:
+class BaseMessage:
     """Base class of a message that has an empty payload."""
 
     payload: payloads.EmptyPayload = payloads.EmptyPayload()
     payload_type: Type[payloads.EmptyPayload] = payloads.EmptyPayload
+    message_index: Literal[utils.UInt32Field] = 0
 
 
 @dataclass
-class HeartbeatRequest(EmptyPayloadMessage):  # noqa: D101
+class Acknowledgement(BaseMessage): # noqa: D101
+    message_id: Literal[MessageId.acknowledgement] = MessageId.acknowledgement
+
+
+@dataclass
+class HeartbeatRequest(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.heartbeat_request] = MessageId.heartbeat_request
 
 
 @dataclass
-class HeartbeatResponse(EmptyPayloadMessage):  # noqa: D101
+class HeartbeatResponse(Acknowledgement):  # noqa: D101
     message_id: Literal[MessageId.heartbeat_response] = MessageId.heartbeat_response
 
 
 @dataclass
-class DeviceInfoRequest(EmptyPayloadMessage):  # noqa: D101
+class DeviceInfoRequest(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.device_info_request] = MessageId.device_info_request
 
 
 @dataclass
-class DeviceInfoResponse:  # noqa: D101
+class DeviceInfoResponse(Acknowledgement):  # noqa: D101
     payload: payloads.DeviceInfoResponsePayload
     payload_type: Type[
         payloads.DeviceInfoResponsePayload
@@ -41,12 +48,12 @@ class DeviceInfoResponse:  # noqa: D101
 
 
 @dataclass
-class TaskInfoRequest(EmptyPayloadMessage):  # noqa: D101
+class TaskInfoRequest(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.task_info_request] = MessageId.task_info_request
 
 
 @dataclass
-class TaskInfoResponse:  # noqa: D101
+class TaskInfoResponse(Acknowledgement):  # noqa: D101
     payload: payloads.TaskInfoResponsePayload
     payload_type: Type[
         payloads.TaskInfoResponsePayload
@@ -55,29 +62,29 @@ class TaskInfoResponse:  # noqa: D101
 
 
 @dataclass
-class StopRequest(EmptyPayloadMessage):  # noqa: D101
+class StopRequest(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.stop_request] = MessageId.stop_request
 
 
 @dataclass
-class GetStatusRequest(EmptyPayloadMessage):  # noqa: D101
+class GetStatusRequest(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.get_status_request] = MessageId.get_status_request
 
 
 @dataclass
-class EnableMotorRequest(EmptyPayloadMessage):  # noqa: D101
+class EnableMotorRequest(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.enable_motor_request] = MessageId.enable_motor_request
 
 
 @dataclass
-class DisableMotorRequest(EmptyPayloadMessage):  # noqa: D101
+class DisableMotorRequest(BaseMessage):  # noqa: D101
     message_id: Literal[
         MessageId.disable_motor_request
     ] = MessageId.disable_motor_request
 
 
 @dataclass
-class GetStatusResponse:  # noqa: D101
+class GetStatusResponse(Acknowledgement):  # noqa: D101
     payload: payloads.GetStatusResponsePayload
     payload_type: Type[
         payloads.GetStatusResponsePayload
@@ -86,35 +93,35 @@ class GetStatusResponse:  # noqa: D101
 
 
 @dataclass
-class MoveRequest:  # noqa: D101
+class MoveRequest(BaseMessage):  # noqa: D101
     payload: payloads.MoveRequestPayload
     payload_type: Type[payloads.MoveRequestPayload] = payloads.MoveRequestPayload
     message_id: Literal[MessageId.move_request] = MessageId.move_request
 
 
 @dataclass
-class WriteToEEPromRequest:  # noqa: D101
+class WriteToEEPromRequest(BaseMessage):  # noqa: D101
     payload: payloads.EEPromDataPayload
     payload_type: Type[payloads.EEPromDataPayload] = payloads.EEPromDataPayload
     message_id: Literal[MessageId.write_eeprom] = MessageId.write_eeprom
 
 
 @dataclass
-class ReadFromEEPromRequest:  # noqa: D101
+class ReadFromEEPromRequest(BaseMessage):  # noqa: D101
     payload: payloads.EEPromReadPayload
     payload_type: Type[payloads.EEPromReadPayload] = payloads.EEPromReadPayload
     message_id: Literal[MessageId.read_eeprom_request] = MessageId.read_eeprom_request
 
 
 @dataclass
-class ReadFromEEPromResponse:  # noqa: D101
+class ReadFromEEPromResponse(Acknowledgement):  # noqa: D101
     payload: payloads.EEPromDataPayload
     payload_type: Type[payloads.EEPromDataPayload] = payloads.EEPromDataPayload
     message_id: Literal[MessageId.read_eeprom_response] = MessageId.read_eeprom_response
 
 
 @dataclass
-class AddLinearMoveRequest:  # noqa: D101
+class AddLinearMoveRequest(BaseMessage):  # noqa: D101
     payload: payloads.AddLinearMoveRequestPayload
     payload_type: Type[
         payloads.AddLinearMoveRequestPayload
@@ -123,7 +130,7 @@ class AddLinearMoveRequest:  # noqa: D101
 
 
 @dataclass
-class GetMoveGroupRequest:  # noqa: D101
+class GetMoveGroupRequest(BaseMessage):  # noqa: D101
     payload: payloads.MoveGroupRequestPayload
     payload_type: Type[
         payloads.MoveGroupRequestPayload
@@ -134,7 +141,7 @@ class GetMoveGroupRequest:  # noqa: D101
 
 
 @dataclass
-class GetMoveGroupResponse:  # noqa: D101
+class GetMoveGroupResponse(Acknowledgement):  # noqa: D101
     payload: payloads.GetMoveGroupResponsePayload
     payload_type: Type[
         payloads.GetMoveGroupResponsePayload
@@ -145,7 +152,7 @@ class GetMoveGroupResponse:  # noqa: D101
 
 
 @dataclass
-class ExecuteMoveGroupRequest:  # noqa: D101
+class ExecuteMoveGroupRequest(BaseMessage):  # noqa: D101
     payload: payloads.ExecuteMoveGroupRequestPayload
     payload_type: Type[
         payloads.ExecuteMoveGroupRequestPayload
@@ -156,28 +163,28 @@ class ExecuteMoveGroupRequest:  # noqa: D101
 
 
 @dataclass
-class ClearAllMoveGroupsRequest(EmptyPayloadMessage):  # noqa: D101
+class ClearAllMoveGroupsRequest(BaseMessage):  # noqa: D101
     message_id: Literal[
         MessageId.clear_all_move_groups_request
     ] = MessageId.clear_all_move_groups_request
 
 
 @dataclass
-class MoveCompleted:  # noqa: D101
+class MoveCompleted(Acknowledgement):  # noqa: D101
     payload: payloads.MoveCompletedPayload
     payload_type: Type[payloads.MoveCompletedPayload] = payloads.MoveCompletedPayload
     message_id: Literal[MessageId.move_completed] = MessageId.move_completed
 
 
 @dataclass
-class EncoderPositionRequest(EmptyPayloadMessage):  # noqa: D101
+class EncoderPositionRequest(BaseMessage):  # noqa: D101
     message_id: Literal[
         MessageId.encoder_position_request
     ] = MessageId.encoder_position_request
 
 
 @dataclass
-class EncoderPositionResponse:  # noqa: D101
+class EncoderPositionResponse(Acknowledgement):  # noqa: D101
     payload: payloads.EncoderPositionResponse
     payload_type: Type[
         payloads.EncoderPositionResponse
@@ -188,7 +195,7 @@ class EncoderPositionResponse:  # noqa: D101
 
 
 @dataclass
-class SetMotionConstraints:  # noqa: D101
+class SetMotionConstraints(BaseMessage):  # noqa: D101
     payload: payloads.MotionConstraintsPayload
     payload_type: Type[
         payloads.MotionConstraintsPayload
@@ -199,14 +206,14 @@ class SetMotionConstraints:  # noqa: D101
 
 
 @dataclass
-class GetMotionConstraintsRequest(EmptyPayloadMessage):  # noqa: D101
+class GetMotionConstraintsRequest(BaseMessage):  # noqa: D101
     message_id: Literal[
         MessageId.get_motion_constraints_request
     ] = MessageId.get_motion_constraints_request
 
 
 @dataclass
-class GetMotionConstraintsResponse:  # noqa: D101
+class GetMotionConstraintsResponse(Acknowledgement):  # noqa: D101
     payload: payloads.MotionConstraintsPayload
     payload_type: Type[
         payloads.MotionConstraintsPayload
@@ -217,7 +224,7 @@ class GetMotionConstraintsResponse:  # noqa: D101
 
 
 @dataclass
-class WriteMotorDriverRegister:  # noqa: D101
+class WriteMotorDriverRegister(BaseMessage):  # noqa: D101
     payload: payloads.MotorDriverRegisterDataPayload
     payload_type: Type[
         payloads.MotorDriverRegisterPayload
@@ -228,7 +235,7 @@ class WriteMotorDriverRegister:  # noqa: D101
 
 
 @dataclass
-class ReadMotorDriverRequest:  # noqa: D101
+class ReadMotorDriverRequest(BaseMessage):  # noqa: D101
     payload: payloads.MotorDriverRegisterPayload
     payload_type: Type[
         payloads.MotorDriverRegisterPayload
@@ -239,7 +246,7 @@ class ReadMotorDriverRequest:  # noqa: D101
 
 
 @dataclass
-class ReadMotorDriverResponse:  # noqa: D101
+class ReadMotorDriverResponse(Acknowledgement):  # noqa: D101
     payload: payloads.ReadMotorDriverRegisterResponsePayload
     payload_type: Type[
         payloads.ReadMotorDriverRegisterResponsePayload
@@ -250,7 +257,7 @@ class ReadMotorDriverResponse:  # noqa: D101
 
 
 @dataclass
-class WriteMotorCurrentRequest:  # noqa: D101
+class WriteMotorCurrentRequest(BaseMessage):  # noqa: D101
     payload: payloads.MotorCurrentPayload
     payload_type: Type[payloads.MotorCurrentPayload] = payloads.MotorCurrentPayload
     message_id: Literal[
@@ -259,14 +266,14 @@ class WriteMotorCurrentRequest:  # noqa: D101
 
 
 @dataclass
-class ReadPresenceSensingVoltageRequest(EmptyPayloadMessage):  # noqa: D101
+class ReadPresenceSensingVoltageRequest(BaseMessage):  # noqa: D101
     message_id: Literal[
         MessageId.read_presence_sensing_voltage_request
     ] = MessageId.read_presence_sensing_voltage_request
 
 
 @dataclass
-class ReadPresenceSensingVoltageResponse:  # noqa: D101
+class ReadPresenceSensingVoltageResponse(Acknowledgement):  # noqa: D101
     payload: payloads.ReadPresenceSensingVoltageResponsePayload
     payload_type: Type[
         payloads.ReadPresenceSensingVoltageResponsePayload
@@ -277,7 +284,7 @@ class ReadPresenceSensingVoltageResponse:  # noqa: D101
 
 
 @dataclass
-class PushToolsDetectedNotification:  # noqa: D101
+class PushToolsDetectedNotification(BaseMessage):  # noqa: D101
     payload: payloads.ToolsDetectedNotificationPayload
     payload_type: Type[
         payloads.ToolsDetectedNotificationPayload
@@ -288,26 +295,26 @@ class PushToolsDetectedNotification:  # noqa: D101
 
 
 @dataclass
-class AttachedToolsRequest(EmptyPayloadMessage):  # noqa: D101
+class AttachedToolsRequest(BaseMessage):  # noqa: D101
     message_id: Literal[
         MessageId.attached_tools_request
     ] = MessageId.attached_tools_request
 
 
 @dataclass
-class FirmwareUpdateInitiate(EmptyPayloadMessage):  # noqa: D101
+class FirmwareUpdateInitiate(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.fw_update_initiate] = MessageId.fw_update_initiate
 
 
 @dataclass
-class FirmwareUpdateData:  # noqa: D101
+class FirmwareUpdateData(BaseMessage):  # noqa: D101
     payload: payloads.FirmwareUpdateData
     payload_type: Type[payloads.FirmwareUpdateData] = payloads.FirmwareUpdateData
     message_id: Literal[MessageId.fw_update_data] = MessageId.fw_update_data
 
 
 @dataclass
-class FirmwareUpdateDataAcknowledge:  # noqa: D101
+class FirmwareUpdateDataAcknowledge(Acknowledgement):  # noqa: D101
     payload: payloads.FirmwareUpdateDataAcknowledge
     payload_type: Type[
         payloads.FirmwareUpdateDataAcknowledge
@@ -316,7 +323,7 @@ class FirmwareUpdateDataAcknowledge:  # noqa: D101
 
 
 @dataclass
-class FirmwareUpdateComplete:  # noqa: D101
+class FirmwareUpdateComplete(Acknowledgement):  # noqa: D101
     payload: payloads.FirmwareUpdateComplete
     payload_type: Type[
         payloads.FirmwareUpdateComplete
@@ -325,7 +332,7 @@ class FirmwareUpdateComplete:  # noqa: D101
 
 
 @dataclass
-class FirmwareUpdateCompleteAcknowledge:  # noqa: D101
+class FirmwareUpdateCompleteAcknowledge(Acknowledgement):  # noqa: D101
     payload: payloads.FirmwareUpdateAcknowledge
     payload_type: Type[
         payloads.FirmwareUpdateAcknowledge
@@ -336,14 +343,14 @@ class FirmwareUpdateCompleteAcknowledge:  # noqa: D101
 
 
 @dataclass
-class FirmwareUpdateStatusRequest(EmptyPayloadMessage):  # noqa: D101
+class FirmwareUpdateStatusRequest(BaseMessage):  # noqa: D101
     message_id: Literal[
         MessageId.fw_update_status_request
     ] = MessageId.fw_update_status_request
 
 
 @dataclass
-class FirmwareUpdateStatusResponse:  # noqa: D101
+class FirmwareUpdateStatusResponse(Acknowledgement):  # noqa: D101
     payload: payloads.FirmwareUpdateStatus
     payload_type: Type[payloads.FirmwareUpdateStatus] = payloads.FirmwareUpdateStatus
     message_id: Literal[
@@ -352,12 +359,12 @@ class FirmwareUpdateStatusResponse:  # noqa: D101
 
 
 @dataclass
-class FirmwareUpdateEraseAppRequest(EmptyPayloadMessage):  # noqa: D101
+class FirmwareUpdateEraseAppRequest(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.fw_update_erase_app] = MessageId.fw_update_erase_app
 
 
 @dataclass
-class FirmwareUpdateEraseAppResponse:  # noqa: D101
+class FirmwareUpdateEraseAppResponse(Acknowledgement):  # noqa: D101
     payload: payloads.FirmwareUpdateAcknowledge
     payload_type: Type[
         payloads.FirmwareUpdateAcknowledge
@@ -368,24 +375,24 @@ class FirmwareUpdateEraseAppResponse:  # noqa: D101
 
 
 @dataclass
-class HomeRequest:  # noqa: D101
+class HomeRequest(BaseMessage):  # noqa: D101
     payload: payloads.HomeRequestPayload
     payload_type: Type[payloads.HomeRequestPayload] = payloads.HomeRequestPayload
     message_id: Literal[MessageId.home_request] = MessageId.home_request
 
 
 @dataclass
-class FirmwareUpdateStartApp(EmptyPayloadMessage):  # noqa: D101
+class FirmwareUpdateStartApp(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.fw_update_start_app] = MessageId.fw_update_start_app
 
 
 @dataclass
-class ReadLimitSwitchRequest(EmptyPayloadMessage):  # noqa: D101
+class ReadLimitSwitchRequest(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.limit_sw_request] = MessageId.limit_sw_request
 
 
 @dataclass
-class ReadLimitSwitchResponse:  # noqa: D101
+class ReadLimitSwitchResponse(Acknowledgement):  # noqa: D101
     payload: payloads.GetLimitSwitchResponse
     payload_type: Type[
         payloads.GetLimitSwitchResponse
@@ -394,7 +401,7 @@ class ReadLimitSwitchResponse:  # noqa: D101
 
 
 @dataclass
-class ReadFromSensorRequest:  # noqa: D101
+class ReadFromSensorRequest(BaseMessage):  # noqa: D101
     payload: payloads.ReadFromSensorRequestPayload
     payload_type: Type[
         payloads.ReadFromSensorRequestPayload
@@ -403,7 +410,7 @@ class ReadFromSensorRequest:  # noqa: D101
 
 
 @dataclass
-class WriteToSensorRequest:  # noqa: D101
+class WriteToSensorRequest(BaseMessage):  # noqa: D101
     payload: payloads.WriteToSensorRequestPayload
     payload_type: Type[
         payloads.WriteToSensorRequestPayload
@@ -412,7 +419,7 @@ class WriteToSensorRequest:  # noqa: D101
 
 
 @dataclass
-class BaselineSensorRequest:  # noqa: D101
+class BaselineSensorRequest(BaseMessage):  # noqa: D101
     payload: payloads.BaselineSensorRequestPayload
     payload_type: Type[
         payloads.BaselineSensorRequestPayload
@@ -423,7 +430,7 @@ class BaselineSensorRequest:  # noqa: D101
 
 
 @dataclass
-class ReadFromSensorResponse:  # noqa: D101
+class ReadFromSensorResponse(Acknowledgement):  # noqa: D101
     payload: payloads.ReadFromSensorResponsePayload
     payload_type: Type[
         payloads.ReadFromSensorResponsePayload
@@ -432,7 +439,7 @@ class ReadFromSensorResponse:  # noqa: D101
 
 
 @dataclass
-class SetSensorThresholdRequest:  # noqa: D101
+class SetSensorThresholdRequest(BaseMessage):  # noqa: D101
     payload: payloads.SetSensorThresholdRequestPayload
     payload_type: Type[
         payloads.SetSensorThresholdRequestPayload
@@ -443,7 +450,7 @@ class SetSensorThresholdRequest:  # noqa: D101
 
 
 @dataclass
-class SensorThresholdResponse:  # noqa: D101
+class SensorThresholdResponse(Acknowledgement):  # noqa: D101
     payload: payloads.SensorThresholdResponsePayload
     payload_type: Type[
         payloads.SensorThresholdResponsePayload
@@ -454,7 +461,7 @@ class SensorThresholdResponse:  # noqa: D101
 
 
 @dataclass
-class SensorDiagnosticRequest:  # noqa: D101
+class SensorDiagnosticRequest(BaseMessage):  # noqa: D101
     payload: payloads.SensorDiagnosticRequestPayload
     payload_type: Type[
         payloads.SensorDiagnosticRequestPayload
@@ -465,7 +472,7 @@ class SensorDiagnosticRequest:  # noqa: D101
 
 
 @dataclass
-class SensorDiagnosticResponse:  # noqa: D101
+class SensorDiagnosticResponse(Acknowledgement):  # noqa: D101
     payload: payloads.SensorDiagnosticResponsePayload
     payload_type: Type[
         payloads.SensorDiagnosticResponsePayload
@@ -476,7 +483,7 @@ class SensorDiagnosticResponse:  # noqa: D101
 
 
 @dataclass
-class PipetteInfoResponse:  # noqa: D101
+class PipetteInfoResponse(Acknowledgement):  # noqa: D101
     payload: payloads.PipetteInfoResponsePayload
     payload_type: Type[
         payloads.PipetteInfoResponsePayload
@@ -487,7 +494,7 @@ class PipetteInfoResponse:  # noqa: D101
 
 
 @dataclass
-class SetBrushedMotorVrefRequest:  # noqa: D101
+class SetBrushedMotorVrefRequest(BaseMessage):  # noqa: D101
     payload: payloads.BrushedMotorVrefPayload
     payload_type: Type[
         payloads.BrushedMotorVrefPayload
@@ -498,7 +505,7 @@ class SetBrushedMotorVrefRequest:  # noqa: D101
 
 
 @dataclass
-class SetBrushedMotorPwmRequest:  # noqa: D101
+class SetBrushedMotorPwmRequest(BaseMessage):  # noqa: D101
     payload: payloads.BrushedMotorPwmPayload
     payload_type: Type[
         payloads.BrushedMotorPwmPayload
@@ -509,7 +516,7 @@ class SetBrushedMotorPwmRequest:  # noqa: D101
 
 
 @dataclass
-class GripperGripRequest:  # noqa: D101
+class GripperGripRequest(BaseMessage):  # noqa: D101
     payload: payloads.GripperMoveRequestPayload
     payload_type: Type[
         payloads.GripperMoveRequestPayload
@@ -518,7 +525,7 @@ class GripperGripRequest:  # noqa: D101
 
 
 @dataclass
-class GripperHomeRequest:  # noqa: D101
+class GripperHomeRequest(BaseMessage):  # noqa: D101
     payload: payloads.GripperMoveRequestPayload
     payload_type: Type[
         payloads.GripperMoveRequestPayload
@@ -527,7 +534,7 @@ class GripperHomeRequest:  # noqa: D101
 
 
 @dataclass
-class AddBrushedLinearMoveRequest:  # noqa: D101
+class AddBrushedLinearMoveRequest(BaseMessage):  # noqa: D101
     payload: payloads.GripperMoveRequestPayload
     payload_type: Type[
         payloads.GripperMoveRequestPayload
@@ -538,7 +545,7 @@ class AddBrushedLinearMoveRequest:  # noqa: D101
 
 
 @dataclass
-class BindSensorOutputRequest:  # noqa: D101
+class BindSensorOutputRequest(BaseMessage):  # noqa: D101
     payload: payloads.BindSensorOutputRequestPayload
     payload_type: Type[
         payloads.BindSensorOutputRequestPayload
@@ -549,7 +556,7 @@ class BindSensorOutputRequest:  # noqa: D101
 
 
 @dataclass
-class BindSensorOutputResponse:  # noqa: D101
+class BindSensorOutputResponse(Acknowledgement):  # noqa: D101
     payload: payloads.BindSensorOutputResponsePayload
     payload_type: Type[
         payloads.BindSensorOutputResponsePayload
@@ -560,7 +567,7 @@ class BindSensorOutputResponse:  # noqa: D101
 
 
 @dataclass
-class GripperInfoResponse:  # noqa: D101
+class GripperInfoResponse(Acknowledgement):  # noqa: D101
     payload: payloads.GripperInfoResponsePayload
     payload_type: Type[
         payloads.GripperInfoResponsePayload
@@ -571,7 +578,7 @@ class GripperInfoResponse:  # noqa: D101
 
 
 @dataclass
-class TipActionRequest:  # noqa: D101
+class TipActionRequest(BaseMessage):  # noqa: D101
     payload: payloads.TipActionRequestPayload
     payload_type: Type[
         payloads.TipActionRequestPayload
@@ -582,7 +589,7 @@ class TipActionRequest:  # noqa: D101
 
 
 @dataclass
-class TipActionResponse:  # noqa: D101
+class TipActionResponse(Acknowledgement):  # noqa: D101
     payload: payloads.TipActionResponsePayload
     payload_type: Type[
         payloads.TipActionResponsePayload
@@ -593,7 +600,7 @@ class TipActionResponse:  # noqa: D101
 
 
 @dataclass
-class PeripheralStatusRequest:  # noqa: D101
+class PeripheralStatusRequest(BaseMessage):  # noqa: D101
     payload: payloads.SensorPayload
     payload_type: Type[payloads.SensorPayload] = payloads.SensorPayload
     message_id: Literal[
@@ -602,7 +609,7 @@ class PeripheralStatusRequest:  # noqa: D101
 
 
 @dataclass
-class PeripheralStatusResponse:  # noqa: D101
+class PeripheralStatusResponse(Acknowledgement):  # noqa: D101
     payload: payloads.PeripheralStatusResponsePayload
     payload_type: Type[
         payloads.PeripheralStatusResponsePayload
@@ -613,14 +620,14 @@ class PeripheralStatusResponse:  # noqa: D101
 
 
 @dataclass
-class SetSerialNumber:  # noqa: D101
+class SetSerialNumber(BaseMessage):  # noqa: D101
     payload: payloads.SerialNumberPayload
     payload_type: Type[payloads.SerialNumberPayload] = payloads.SerialNumberPayload
     message_id: Literal[MessageId.set_serial_number] = MessageId.set_serial_number
 
 
 @dataclass
-class InstrumentInfoRequest(EmptyPayloadMessage):
+class InstrumentInfoRequest(BaseMessage):
     """Prompt pipettes and grippers to respond.
 
     Pipette should respond with PipetteInfoResponse.

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -23,8 +23,7 @@ class SingletonMessageIndexGenerator(object):
 
     __current_index = 0
 
-
-@dataclass
+@dataclass(eq=False)
 class BaseMessage(object):
     """Base class of a message that has an empty payload."""
 
@@ -32,32 +31,41 @@ class BaseMessage(object):
         index_generator = SingletonMessageIndexGenerator()
         self.message_index = index_generator.get_next_index()
 
+    def __eq__(self, other):
+        other_dict = vars(other)
+        self_dict = vars(self)
+        for key in self_dict:
+            if key != "message_index":
+                if not (key in other_dict and self_dict[key] == other_dict[key]):
+                    return False
+        return True
+
     payload: payloads.EmptyPayload = payloads.EmptyPayload()
     payload_type: Type[payloads.EmptyPayload] = payloads.EmptyPayload
     message_index: Literal[utils.UInt32Field] = 0
 
 
-@dataclass
+@dataclass(eq=False)
 class Acknowledgement(BaseMessage): # noqa: D101
     message_id: Literal[MessageId.acknowledgement] = MessageId.acknowledgement
 
 
-@dataclass
+@dataclass(eq=False)
 class HeartbeatRequest(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.heartbeat_request] = MessageId.heartbeat_request
 
 
-@dataclass
+@dataclass(eq=False)
 class HeartbeatResponse(Acknowledgement):  # noqa: D101
     message_id: Literal[MessageId.heartbeat_response] = MessageId.heartbeat_response
 
 
-@dataclass
+@dataclass(eq=False)
 class DeviceInfoRequest(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.device_info_request] = MessageId.device_info_request
 
 
-@dataclass
+@dataclass(eq=False)
 class DeviceInfoResponse(Acknowledgement):  # noqa: D101
     payload: payloads.DeviceInfoResponsePayload
     payload_type: Type[
@@ -66,12 +74,12 @@ class DeviceInfoResponse(Acknowledgement):  # noqa: D101
     message_id: Literal[MessageId.device_info_response] = MessageId.device_info_response
 
 
-@dataclass
+@dataclass(eq=False)
 class TaskInfoRequest(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.task_info_request] = MessageId.task_info_request
 
 
-@dataclass
+@dataclass(eq=False)
 class TaskInfoResponse(Acknowledgement):  # noqa: D101
     payload: payloads.TaskInfoResponsePayload
     payload_type: Type[
@@ -80,29 +88,29 @@ class TaskInfoResponse(Acknowledgement):  # noqa: D101
     message_id: Literal[MessageId.task_info_response] = MessageId.task_info_response
 
 
-@dataclass
+@dataclass(eq=False)
 class StopRequest(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.stop_request] = MessageId.stop_request
 
 
-@dataclass
+@dataclass(eq=False)
 class GetStatusRequest(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.get_status_request] = MessageId.get_status_request
 
 
-@dataclass
+@dataclass(eq=False)
 class EnableMotorRequest(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.enable_motor_request] = MessageId.enable_motor_request
 
 
-@dataclass
+@dataclass(eq=False)
 class DisableMotorRequest(BaseMessage):  # noqa: D101
     message_id: Literal[
         MessageId.disable_motor_request
     ] = MessageId.disable_motor_request
 
 
-@dataclass
+@dataclass(eq=False)
 class GetStatusResponse(Acknowledgement):  # noqa: D101
     payload: payloads.GetStatusResponsePayload
     payload_type: Type[
@@ -111,35 +119,35 @@ class GetStatusResponse(Acknowledgement):  # noqa: D101
     message_id: Literal[MessageId.get_status_response] = MessageId.get_status_response
 
 
-@dataclass
+@dataclass(eq=False)
 class MoveRequest(BaseMessage):  # noqa: D101
     payload: payloads.MoveRequestPayload
     payload_type: Type[payloads.MoveRequestPayload] = payloads.MoveRequestPayload
     message_id: Literal[MessageId.move_request] = MessageId.move_request
 
 
-@dataclass
+@dataclass(eq=False)
 class WriteToEEPromRequest(BaseMessage):  # noqa: D101
     payload: payloads.EEPromDataPayload
     payload_type: Type[payloads.EEPromDataPayload] = payloads.EEPromDataPayload
     message_id: Literal[MessageId.write_eeprom] = MessageId.write_eeprom
 
 
-@dataclass
+@dataclass(eq=False)
 class ReadFromEEPromRequest(BaseMessage):  # noqa: D101
     payload: payloads.EEPromReadPayload
     payload_type: Type[payloads.EEPromReadPayload] = payloads.EEPromReadPayload
     message_id: Literal[MessageId.read_eeprom_request] = MessageId.read_eeprom_request
 
 
-@dataclass
+@dataclass(eq=False)
 class ReadFromEEPromResponse(Acknowledgement):  # noqa: D101
     payload: payloads.EEPromDataPayload
     payload_type: Type[payloads.EEPromDataPayload] = payloads.EEPromDataPayload
     message_id: Literal[MessageId.read_eeprom_response] = MessageId.read_eeprom_response
 
 
-@dataclass
+@dataclass(eq=False)
 class AddLinearMoveRequest(BaseMessage):  # noqa: D101
     payload: payloads.AddLinearMoveRequestPayload
     payload_type: Type[
@@ -148,7 +156,7 @@ class AddLinearMoveRequest(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.add_move_request] = MessageId.add_move_request
 
 
-@dataclass
+@dataclass(eq=False)
 class GetMoveGroupRequest(BaseMessage):  # noqa: D101
     payload: payloads.MoveGroupRequestPayload
     payload_type: Type[
@@ -159,7 +167,7 @@ class GetMoveGroupRequest(BaseMessage):  # noqa: D101
     ] = MessageId.get_move_group_request
 
 
-@dataclass
+@dataclass(eq=False)
 class GetMoveGroupResponse(Acknowledgement):  # noqa: D101
     payload: payloads.GetMoveGroupResponsePayload
     payload_type: Type[
@@ -170,7 +178,7 @@ class GetMoveGroupResponse(Acknowledgement):  # noqa: D101
     ] = MessageId.get_move_group_response
 
 
-@dataclass
+@dataclass(eq=False)
 class ExecuteMoveGroupRequest(BaseMessage):  # noqa: D101
     payload: payloads.ExecuteMoveGroupRequestPayload
     payload_type: Type[
@@ -181,28 +189,28 @@ class ExecuteMoveGroupRequest(BaseMessage):  # noqa: D101
     ] = MessageId.execute_move_group_request
 
 
-@dataclass
+@dataclass(eq=False)
 class ClearAllMoveGroupsRequest(BaseMessage):  # noqa: D101
     message_id: Literal[
         MessageId.clear_all_move_groups_request
     ] = MessageId.clear_all_move_groups_request
 
 
-@dataclass
+@dataclass(eq=False)
 class MoveCompleted(Acknowledgement):  # noqa: D101
     payload: payloads.MoveCompletedPayload
     payload_type: Type[payloads.MoveCompletedPayload] = payloads.MoveCompletedPayload
     message_id: Literal[MessageId.move_completed] = MessageId.move_completed
 
 
-@dataclass
+@dataclass(eq=False)
 class EncoderPositionRequest(BaseMessage):  # noqa: D101
     message_id: Literal[
         MessageId.encoder_position_request
     ] = MessageId.encoder_position_request
 
 
-@dataclass
+@dataclass(eq=False)
 class EncoderPositionResponse(Acknowledgement):  # noqa: D101
     payload: payloads.EncoderPositionResponse
     payload_type: Type[
@@ -213,7 +221,7 @@ class EncoderPositionResponse(Acknowledgement):  # noqa: D101
     ] = MessageId.encoder_position_response
 
 
-@dataclass
+@dataclass(eq=False)
 class SetMotionConstraints(BaseMessage):  # noqa: D101
     payload: payloads.MotionConstraintsPayload
     payload_type: Type[
@@ -224,14 +232,14 @@ class SetMotionConstraints(BaseMessage):  # noqa: D101
     ] = MessageId.set_motion_constraints
 
 
-@dataclass
+@dataclass(eq=False)
 class GetMotionConstraintsRequest(BaseMessage):  # noqa: D101
     message_id: Literal[
         MessageId.get_motion_constraints_request
     ] = MessageId.get_motion_constraints_request
 
 
-@dataclass
+@dataclass(eq=False)
 class GetMotionConstraintsResponse(Acknowledgement):  # noqa: D101
     payload: payloads.MotionConstraintsPayload
     payload_type: Type[
@@ -242,7 +250,7 @@ class GetMotionConstraintsResponse(Acknowledgement):  # noqa: D101
     ] = MessageId.get_motion_constraints_response
 
 
-@dataclass
+@dataclass(eq=False)
 class WriteMotorDriverRegister(BaseMessage):  # noqa: D101
     payload: payloads.MotorDriverRegisterDataPayload
     payload_type: Type[
@@ -253,7 +261,7 @@ class WriteMotorDriverRegister(BaseMessage):  # noqa: D101
     ] = MessageId.write_motor_driver_register_request
 
 
-@dataclass
+@dataclass(eq=False)
 class ReadMotorDriverRequest(BaseMessage):  # noqa: D101
     payload: payloads.MotorDriverRegisterPayload
     payload_type: Type[
@@ -264,7 +272,7 @@ class ReadMotorDriverRequest(BaseMessage):  # noqa: D101
     ] = MessageId.read_motor_driver_register_request
 
 
-@dataclass
+@dataclass(eq=False)
 class ReadMotorDriverResponse(Acknowledgement):  # noqa: D101
     payload: payloads.ReadMotorDriverRegisterResponsePayload
     payload_type: Type[
@@ -275,7 +283,7 @@ class ReadMotorDriverResponse(Acknowledgement):  # noqa: D101
     ] = MessageId.read_motor_driver_register_response
 
 
-@dataclass
+@dataclass(eq=False)
 class WriteMotorCurrentRequest(BaseMessage):  # noqa: D101
     payload: payloads.MotorCurrentPayload
     payload_type: Type[payloads.MotorCurrentPayload] = payloads.MotorCurrentPayload
@@ -284,14 +292,14 @@ class WriteMotorCurrentRequest(BaseMessage):  # noqa: D101
     ] = MessageId.write_motor_current_request
 
 
-@dataclass
+@dataclass(eq=False)
 class ReadPresenceSensingVoltageRequest(BaseMessage):  # noqa: D101
     message_id: Literal[
         MessageId.read_presence_sensing_voltage_request
     ] = MessageId.read_presence_sensing_voltage_request
 
 
-@dataclass
+@dataclass(eq=False)
 class ReadPresenceSensingVoltageResponse(Acknowledgement):  # noqa: D101
     payload: payloads.ReadPresenceSensingVoltageResponsePayload
     payload_type: Type[
@@ -302,7 +310,7 @@ class ReadPresenceSensingVoltageResponse(Acknowledgement):  # noqa: D101
     ] = MessageId.read_presence_sensing_voltage_response
 
 
-@dataclass
+@dataclass(eq=False)
 class PushToolsDetectedNotification(BaseMessage):  # noqa: D101
     payload: payloads.ToolsDetectedNotificationPayload
     payload_type: Type[
@@ -313,26 +321,26 @@ class PushToolsDetectedNotification(BaseMessage):  # noqa: D101
     ] = MessageId.tools_detected_notification
 
 
-@dataclass
+@dataclass(eq=False)
 class AttachedToolsRequest(BaseMessage):  # noqa: D101
     message_id: Literal[
         MessageId.attached_tools_request
     ] = MessageId.attached_tools_request
 
 
-@dataclass
+@dataclass(eq=False)
 class FirmwareUpdateInitiate(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.fw_update_initiate] = MessageId.fw_update_initiate
 
 
-@dataclass
+@dataclass(eq=False)
 class FirmwareUpdateData(BaseMessage):  # noqa: D101
     payload: payloads.FirmwareUpdateData
     payload_type: Type[payloads.FirmwareUpdateData] = payloads.FirmwareUpdateData
     message_id: Literal[MessageId.fw_update_data] = MessageId.fw_update_data
 
 
-@dataclass
+@dataclass(eq=False)
 class FirmwareUpdateDataAcknowledge(Acknowledgement):  # noqa: D101
     payload: payloads.FirmwareUpdateDataAcknowledge
     payload_type: Type[
@@ -341,7 +349,7 @@ class FirmwareUpdateDataAcknowledge(Acknowledgement):  # noqa: D101
     message_id: Literal[MessageId.fw_update_data_ack] = MessageId.fw_update_data_ack
 
 
-@dataclass
+@dataclass(eq=False)
 class FirmwareUpdateComplete(Acknowledgement):  # noqa: D101
     payload: payloads.FirmwareUpdateComplete
     payload_type: Type[
@@ -350,7 +358,7 @@ class FirmwareUpdateComplete(Acknowledgement):  # noqa: D101
     message_id: Literal[MessageId.fw_update_complete] = MessageId.fw_update_complete
 
 
-@dataclass
+@dataclass(eq=False)
 class FirmwareUpdateCompleteAcknowledge(Acknowledgement):  # noqa: D101
     payload: payloads.FirmwareUpdateAcknowledge
     payload_type: Type[
@@ -361,14 +369,14 @@ class FirmwareUpdateCompleteAcknowledge(Acknowledgement):  # noqa: D101
     ] = MessageId.fw_update_complete_ack
 
 
-@dataclass
+@dataclass(eq=False)
 class FirmwareUpdateStatusRequest(BaseMessage):  # noqa: D101
     message_id: Literal[
         MessageId.fw_update_status_request
     ] = MessageId.fw_update_status_request
 
 
-@dataclass
+@dataclass(eq=False)
 class FirmwareUpdateStatusResponse(Acknowledgement):  # noqa: D101
     payload: payloads.FirmwareUpdateStatus
     payload_type: Type[payloads.FirmwareUpdateStatus] = payloads.FirmwareUpdateStatus
@@ -377,12 +385,12 @@ class FirmwareUpdateStatusResponse(Acknowledgement):  # noqa: D101
     ] = MessageId.fw_update_status_response
 
 
-@dataclass
+@dataclass(eq=False)
 class FirmwareUpdateEraseAppRequest(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.fw_update_erase_app] = MessageId.fw_update_erase_app
 
 
-@dataclass
+@dataclass(eq=False)
 class FirmwareUpdateEraseAppResponse(Acknowledgement):  # noqa: D101
     payload: payloads.FirmwareUpdateAcknowledge
     payload_type: Type[
@@ -393,24 +401,24 @@ class FirmwareUpdateEraseAppResponse(Acknowledgement):  # noqa: D101
     ] = MessageId.fw_update_erase_app_ack
 
 
-@dataclass
+@dataclass(eq=False)
 class HomeRequest(BaseMessage):  # noqa: D101
     payload: payloads.HomeRequestPayload
     payload_type: Type[payloads.HomeRequestPayload] = payloads.HomeRequestPayload
     message_id: Literal[MessageId.home_request] = MessageId.home_request
 
 
-@dataclass
+@dataclass(eq=False)
 class FirmwareUpdateStartApp(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.fw_update_start_app] = MessageId.fw_update_start_app
 
 
-@dataclass
+@dataclass(eq=False)
 class ReadLimitSwitchRequest(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.limit_sw_request] = MessageId.limit_sw_request
 
 
-@dataclass
+@dataclass(eq=False)
 class ReadLimitSwitchResponse(Acknowledgement):  # noqa: D101
     payload: payloads.GetLimitSwitchResponse
     payload_type: Type[
@@ -419,7 +427,7 @@ class ReadLimitSwitchResponse(Acknowledgement):  # noqa: D101
     message_id: Literal[MessageId.limit_sw_response] = MessageId.limit_sw_response
 
 
-@dataclass
+@dataclass(eq=False)
 class ReadFromSensorRequest(BaseMessage):  # noqa: D101
     payload: payloads.ReadFromSensorRequestPayload
     payload_type: Type[
@@ -428,7 +436,7 @@ class ReadFromSensorRequest(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.read_sensor_request] = MessageId.read_sensor_request
 
 
-@dataclass
+@dataclass(eq=False)
 class WriteToSensorRequest(BaseMessage):  # noqa: D101
     payload: payloads.WriteToSensorRequestPayload
     payload_type: Type[
@@ -437,7 +445,7 @@ class WriteToSensorRequest(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.write_sensor_request] = MessageId.write_sensor_request
 
 
-@dataclass
+@dataclass(eq=False)
 class BaselineSensorRequest(BaseMessage):  # noqa: D101
     payload: payloads.BaselineSensorRequestPayload
     payload_type: Type[
@@ -448,7 +456,7 @@ class BaselineSensorRequest(BaseMessage):  # noqa: D101
     ] = MessageId.baseline_sensor_request
 
 
-@dataclass
+@dataclass(eq=False)
 class ReadFromSensorResponse(Acknowledgement):  # noqa: D101
     payload: payloads.ReadFromSensorResponsePayload
     payload_type: Type[
@@ -457,7 +465,7 @@ class ReadFromSensorResponse(Acknowledgement):  # noqa: D101
     message_id: Literal[MessageId.read_sensor_response] = MessageId.read_sensor_response
 
 
-@dataclass
+@dataclass(eq=False)
 class SetSensorThresholdRequest(BaseMessage):  # noqa: D101
     payload: payloads.SetSensorThresholdRequestPayload
     payload_type: Type[
@@ -468,7 +476,7 @@ class SetSensorThresholdRequest(BaseMessage):  # noqa: D101
     ] = MessageId.set_sensor_threshold_request
 
 
-@dataclass
+@dataclass(eq=False)
 class SensorThresholdResponse(Acknowledgement):  # noqa: D101
     payload: payloads.SensorThresholdResponsePayload
     payload_type: Type[
@@ -479,7 +487,7 @@ class SensorThresholdResponse(Acknowledgement):  # noqa: D101
     ] = MessageId.set_sensor_threshold_response
 
 
-@dataclass
+@dataclass(eq=False)
 class SensorDiagnosticRequest(BaseMessage):  # noqa: D101
     payload: payloads.SensorDiagnosticRequestPayload
     payload_type: Type[
@@ -490,7 +498,7 @@ class SensorDiagnosticRequest(BaseMessage):  # noqa: D101
     ] = MessageId.sensor_diagnostic_request
 
 
-@dataclass
+@dataclass(eq=False)
 class SensorDiagnosticResponse(Acknowledgement):  # noqa: D101
     payload: payloads.SensorDiagnosticResponsePayload
     payload_type: Type[
@@ -501,7 +509,7 @@ class SensorDiagnosticResponse(Acknowledgement):  # noqa: D101
     ] = MessageId.sensor_diagnostic_response
 
 
-@dataclass
+@dataclass(eq=False)
 class PipetteInfoResponse(Acknowledgement):  # noqa: D101
     payload: payloads.PipetteInfoResponsePayload
     payload_type: Type[
@@ -512,7 +520,7 @@ class PipetteInfoResponse(Acknowledgement):  # noqa: D101
     ] = MessageId.pipette_info_response
 
 
-@dataclass
+@dataclass(eq=False)
 class SetBrushedMotorVrefRequest(BaseMessage):  # noqa: D101
     payload: payloads.BrushedMotorVrefPayload
     payload_type: Type[
@@ -523,7 +531,7 @@ class SetBrushedMotorVrefRequest(BaseMessage):  # noqa: D101
     ] = MessageId.set_brushed_motor_vref_request
 
 
-@dataclass
+@dataclass(eq=False)
 class SetBrushedMotorPwmRequest(BaseMessage):  # noqa: D101
     payload: payloads.BrushedMotorPwmPayload
     payload_type: Type[
@@ -534,7 +542,7 @@ class SetBrushedMotorPwmRequest(BaseMessage):  # noqa: D101
     ] = MessageId.set_brushed_motor_pwm_request
 
 
-@dataclass
+@dataclass(eq=False)
 class GripperGripRequest(BaseMessage):  # noqa: D101
     payload: payloads.GripperMoveRequestPayload
     payload_type: Type[
@@ -543,7 +551,7 @@ class GripperGripRequest(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.gripper_grip_request] = MessageId.gripper_grip_request
 
 
-@dataclass
+@dataclass(eq=False)
 class GripperHomeRequest(BaseMessage):  # noqa: D101
     payload: payloads.GripperMoveRequestPayload
     payload_type: Type[
@@ -552,7 +560,7 @@ class GripperHomeRequest(BaseMessage):  # noqa: D101
     message_id: Literal[MessageId.gripper_home_request] = MessageId.gripper_home_request
 
 
-@dataclass
+@dataclass(eq=False)
 class AddBrushedLinearMoveRequest(BaseMessage):  # noqa: D101
     payload: payloads.GripperMoveRequestPayload
     payload_type: Type[
@@ -563,7 +571,7 @@ class AddBrushedLinearMoveRequest(BaseMessage):  # noqa: D101
     ] = MessageId.add_brushed_linear_move_request
 
 
-@dataclass
+@dataclass(eq=False)
 class BindSensorOutputRequest(BaseMessage):  # noqa: D101
     payload: payloads.BindSensorOutputRequestPayload
     payload_type: Type[
@@ -574,7 +582,7 @@ class BindSensorOutputRequest(BaseMessage):  # noqa: D101
     ] = MessageId.bind_sensor_output_request
 
 
-@dataclass
+@dataclass(eq=False)
 class BindSensorOutputResponse(Acknowledgement):  # noqa: D101
     payload: payloads.BindSensorOutputResponsePayload
     payload_type: Type[
@@ -585,7 +593,7 @@ class BindSensorOutputResponse(Acknowledgement):  # noqa: D101
     ] = MessageId.bind_sensor_output_response
 
 
-@dataclass
+@dataclass(eq=False)
 class GripperInfoResponse(Acknowledgement):  # noqa: D101
     payload: payloads.GripperInfoResponsePayload
     payload_type: Type[
@@ -596,7 +604,7 @@ class GripperInfoResponse(Acknowledgement):  # noqa: D101
     ] = MessageId.gripper_info_response
 
 
-@dataclass
+@dataclass(eq=False)
 class TipActionRequest(BaseMessage):  # noqa: D101
     payload: payloads.TipActionRequestPayload
     payload_type: Type[
@@ -607,7 +615,7 @@ class TipActionRequest(BaseMessage):  # noqa: D101
     ] = MessageId.do_self_contained_tip_action_request
 
 
-@dataclass
+@dataclass(eq=False)
 class TipActionResponse(Acknowledgement):  # noqa: D101
     payload: payloads.TipActionResponsePayload
     payload_type: Type[
@@ -618,7 +626,7 @@ class TipActionResponse(Acknowledgement):  # noqa: D101
     ] = MessageId.do_self_contained_tip_action_response
 
 
-@dataclass
+@dataclass(eq=False)
 class PeripheralStatusRequest(BaseMessage):  # noqa: D101
     payload: payloads.SensorPayload
     payload_type: Type[payloads.SensorPayload] = payloads.SensorPayload
@@ -627,7 +635,7 @@ class PeripheralStatusRequest(BaseMessage):  # noqa: D101
     ] = MessageId.peripheral_status_request
 
 
-@dataclass
+@dataclass(eq=False)
 class PeripheralStatusResponse(Acknowledgement):  # noqa: D101
     payload: payloads.PeripheralStatusResponsePayload
     payload_type: Type[
@@ -638,14 +646,14 @@ class PeripheralStatusResponse(Acknowledgement):  # noqa: D101
     ] = MessageId.peripheral_status_response
 
 
-@dataclass
+@dataclass(eq=False)
 class SetSerialNumber(BaseMessage):  # noqa: D101
     payload: payloads.SerialNumberPayload
     payload_type: Type[payloads.SerialNumberPayload] = payloads.SerialNumberPayload
     message_id: Literal[MessageId.set_serial_number] = MessageId.set_serial_number
 
 
-@dataclass
+@dataclass(eq=False)
 class InstrumentInfoRequest(BaseMessage):
     """Prompt pipettes and grippers to respond.
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
@@ -8,6 +8,7 @@ from . import message_definitions as defs
 from ..constants import MessageId
 
 MessageDefinition = Union[
+    defs.Acknowledgement,
     defs.HeartbeatRequest,
     defs.HeartbeatResponse,
     defs.DeviceInfoRequest,

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -258,7 +258,8 @@ class FirmwareUpdateData(FirmwareUpdateWithAddress):
     def __post_init__(self) -> None:
         """Post init processing."""
         data_length = len(self.data.value)
-        if data_length > FirmwareUpdateDataField.NUM_BYTES:
+        if data_length > FirmwareUpdateDataField.NUM_BYTES or
+           data_length % 8 != 0:
             raise ValueError(
                 f"Data cannot be more than"
                 f" {FirmwareUpdateDataField.NUM_BYTES} bytes."

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -45,7 +45,9 @@ class EmptyPayload(utils.BinarySerializable):
     # args of subclasses after this default arg.
     # to work around this in binary_serializable.build() and can_comm.prompt_payload
     # we ignore the message_index when constructing args and then set the value manually after
-    message_index: utils.UInt32Field = field(init=False, default=utils.UInt32Field(None))
+    message_index: utils.UInt32Field = field(
+        init=False, default=utils.UInt32Field(None)
+    )
 
 
 @dataclass(eq=False)
@@ -263,7 +265,9 @@ class FirmwareUpdateData(FirmwareUpdateWithAddress):
             )
 
     @classmethod
-    def create(cls, address: int, data: bytes, message_index: int = None) -> "FirmwareUpdateData":
+    def create(
+        cls, address: int, data: bytes, message_index: int = None
+    ) -> "FirmwareUpdateData":
         """Create a firmware update data payload."""
         # this is a special case, we normally instansiate message_index
         # when building a message, not a payload, but we need to compute
@@ -278,11 +282,11 @@ class FirmwareUpdateData(FirmwareUpdateWithAddress):
             data=FirmwareUpdateDataField(data),
             checksum=utils.UInt16Field(checksum),
         )
-        if (message_index == None):
+        if message_index == None:
             index_generator = message_definitions.SingletonMessageIndexGenerator()
-            obj.message_index=utils.UInt32Field(index_generator.get_next_index())
+            obj.message_index = utils.UInt32Field(index_generator.get_next_index())
         else:
-            obj.message_index=utils.UInt32Field(message_index)
+            obj.message_index = utils.UInt32Field(message_index)
         checksum = (1 + ~sum(obj.serialize())) & 0xFFFF
         obj.checksum.value = checksum
         return obj

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -28,9 +28,6 @@ from .. import utils
 class EmptyPayload(utils.BinarySerializable):
     """An empty payload."""
 
-    def __post_init__(self) -> None:
-        message_index = utils.UInt32Field(0)
-
     def __eq__(self, other: object) -> bool:
         """Override __eq__ to ignore message_index."""
         other_dict = vars(other)

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -27,12 +27,11 @@ from .. import utils
 @dataclass
 class EmptyPayload(utils.BinarySerializable):
     """An empty payload."""
-
-    pass
+    message_index = 0
 
 
 @dataclass
-class DeviceInfoResponsePayload(utils.BinarySerializable):
+class DeviceInfoResponsePayload(EmptyPayload):
     """Device info response."""
 
     version: utils.UInt32Field
@@ -41,7 +40,7 @@ class DeviceInfoResponsePayload(utils.BinarySerializable):
 
 
 @dataclass
-class TaskInfoResponsePayload(utils.BinarySerializable):
+class TaskInfoResponsePayload(EmptyPayload):
     """Task info response payload."""
 
     name: TaskNameDataField
@@ -52,7 +51,7 @@ class TaskInfoResponsePayload(utils.BinarySerializable):
 
 
 @dataclass
-class GetStatusResponsePayload(utils.BinarySerializable):
+class GetStatusResponsePayload(EmptyPayload):
     """Get status response."""
 
     status: utils.UInt8Field
@@ -60,21 +59,21 @@ class GetStatusResponsePayload(utils.BinarySerializable):
 
 
 @dataclass
-class MoveRequestPayload(utils.BinarySerializable):
+class MoveRequestPayload(EmptyPayload):
     """Move request."""
 
     steps: utils.UInt32Field
 
 
 @dataclass
-class GetSpeedResponsePayload(utils.BinarySerializable):
+class GetSpeedResponsePayload(EmptyPayload):
     """Get speed response."""
 
     mm_sec: utils.UInt32Field
 
 
 @dataclass
-class EEPromReadPayload(utils.BinarySerializable):
+class EEPromReadPayload(EmptyPayload):
     """Eeprom read request payload ."""
 
     address: utils.UInt16Field
@@ -89,14 +88,14 @@ class EEPromDataPayload(EEPromReadPayload):
 
 
 @dataclass
-class MoveGroupRequestPayload(utils.BinarySerializable):
+class MoveGroupRequestPayload(EmptyPayload):
     """A payload with a group id."""
 
     group_id: utils.UInt8Field
 
 
 @dataclass
-class MoveGroupResponsePayload(utils.BinarySerializable):
+class MoveGroupResponsePayload(EmptyPayload):
     """A response payload with a group id."""
 
     group_id: utils.UInt8Field
@@ -153,14 +152,14 @@ class MoveCompletedPayload(MoveGroupResponsePayload):
 
 
 @dataclass
-class EncoderPositionResponse(utils.BinarySerializable):
+class EncoderPositionResponse(EmptyPayload):
     """Read Encoder Position."""
 
     encoder_position: utils.Int32Field
 
 
 @dataclass
-class MotionConstraintsPayload(utils.BinarySerializable):
+class MotionConstraintsPayload(EmptyPayload):
     """The min and max velocity and acceleration of a motion system."""
 
     min_velocity: utils.Int32Field
@@ -170,7 +169,7 @@ class MotionConstraintsPayload(utils.BinarySerializable):
 
 
 @dataclass
-class MotorDriverRegisterPayload(utils.BinarySerializable):
+class MotorDriverRegisterPayload(EmptyPayload):
     """Read motor driver register request payload."""
 
     reg_addr: utils.UInt8Field
@@ -184,7 +183,7 @@ class MotorDriverRegisterDataPayload(MotorDriverRegisterPayload):
 
 
 @dataclass
-class ReadMotorDriverRegisterResponsePayload(utils.BinarySerializable):
+class ReadMotorDriverRegisterResponsePayload(EmptyPayload):
     """Read motor driver register response payload."""
 
     reg_addr: utils.UInt8Field
@@ -192,7 +191,7 @@ class ReadMotorDriverRegisterResponsePayload(utils.BinarySerializable):
 
 
 @dataclass
-class MotorCurrentPayload(utils.BinarySerializable):
+class MotorCurrentPayload(EmptyPayload):
     """Read motor current register payload."""
 
     # All values in milliAmps
@@ -201,7 +200,7 @@ class MotorCurrentPayload(utils.BinarySerializable):
 
 
 @dataclass
-class ReadPresenceSensingVoltageResponsePayload(utils.BinarySerializable):
+class ReadPresenceSensingVoltageResponsePayload(EmptyPayload):
     """Read head presence sensing voltage response payload."""
 
     # All values in millivolts
@@ -211,7 +210,7 @@ class ReadPresenceSensingVoltageResponsePayload(utils.BinarySerializable):
 
 
 @dataclass
-class ToolsDetectedNotificationPayload(utils.BinarySerializable):
+class ToolsDetectedNotificationPayload(EmptyPayload):
     """Tool detection notification."""
 
     # Tools are mapped to an enum
@@ -221,7 +220,7 @@ class ToolsDetectedNotificationPayload(utils.BinarySerializable):
 
 
 @dataclass
-class FirmwareUpdateWithAddress(utils.BinarySerializable):
+class FirmwareUpdateWithAddress(EmptyPayload):
     """A FW update payload with an address."""
 
     address: utils.UInt32Field
@@ -269,7 +268,7 @@ class FirmwareUpdateDataAcknowledge(FirmwareUpdateWithAddress):
 
 
 @dataclass
-class FirmwareUpdateComplete(utils.BinarySerializable):
+class FirmwareUpdateComplete(EmptyPayload):
     """All data messages have been transmitted."""
 
     num_messages: utils.UInt32Field
@@ -277,28 +276,28 @@ class FirmwareUpdateComplete(utils.BinarySerializable):
 
 
 @dataclass
-class FirmwareUpdateAcknowledge(utils.BinarySerializable):
+class FirmwareUpdateAcknowledge(EmptyPayload):
     """A response to a firmware update message with an error code."""
 
     error_code: ErrorCodeField
 
 
 @dataclass
-class FirmwareUpdateStatus(utils.BinarySerializable):
+class FirmwareUpdateStatus(EmptyPayload):
     """A response to the FirmwareUpdateStatusRequest message."""
 
     flags: utils.UInt32Field
 
 
 @dataclass
-class GetLimitSwitchResponse(utils.BinarySerializable):
+class GetLimitSwitchResponse(EmptyPayload):
     """A response to the Limit Switch Status request payload."""
 
     switch_status: utils.UInt8Field
 
 
 @dataclass
-class SensorPayload(utils.BinarySerializable):
+class SensorPayload(EmptyPayload):
     """Take a single reading from a sensor request payload."""
 
     sensor: SensorTypeField
@@ -380,7 +379,7 @@ class BindSensorOutputResponsePayload(SensorPayload):
 
 
 @dataclass
-class PipetteInfoResponsePayload(utils.BinarySerializable):
+class PipetteInfoResponsePayload(EmptyPayload):
     """A response carrying data about an attached pipette."""
 
     name: PipetteNameField
@@ -389,21 +388,21 @@ class PipetteInfoResponsePayload(utils.BinarySerializable):
 
 
 @dataclass
-class BrushedMotorVrefPayload(utils.BinarySerializable):
+class BrushedMotorVrefPayload(EmptyPayload):
     """A request to set the reference voltage of a brushed motor."""
 
     v_ref: utils.UInt32Field
 
 
 @dataclass
-class BrushedMotorPwmPayload(utils.BinarySerializable):
+class BrushedMotorPwmPayload(EmptyPayload):
     """A request to set the pwm of a brushed motor."""
 
     duty_cycle: utils.UInt32Field
 
 
 @dataclass
-class GripperInfoResponsePayload(utils.BinarySerializable):
+class GripperInfoResponsePayload(EmptyPayload):
     """A response carrying data about an attached gripper."""
 
     model: utils.UInt16Field
@@ -443,7 +442,7 @@ class PeripheralStatusResponsePayload(SensorPayload):
 
 
 @dataclass
-class SerialNumberPayload(utils.BinarySerializable):
+class SerialNumberPayload(EmptyPayload):
     """A payload with a serial number."""
 
     serial: SerialField

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -2,7 +2,7 @@
 # TODO (amit, 2022-01-26): Figure out why using annotations import ruins
 #  dataclass fields interpretation.
 #  from __future__ import annotations
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from .fields import (
     FirmwareShortSHADataField,
@@ -24,13 +24,33 @@ from .fields import (
 from .. import utils
 
 
-@dataclass
+@dataclass(eq=False)
 class EmptyPayload(utils.BinarySerializable):
     """An empty payload."""
-    message_index = 0
+
+    def __post_init__(self) -> None:
+        message_index = utils.UInt32Field(0)
+
+    def __eq__(self, other: object) -> bool:
+        """Override __eq__ to ignore message_index."""
+        other_dict = vars(other)
+        self_dict = vars(self)
+        for key in self_dict:
+            if key != "message_index":
+                if not (key in other_dict and self_dict[key] == other_dict[key]):
+                    return False
+        return True
+
+    # oh boy would it be great to have python 3.10 so we could use the kw_only thing here
+    # we can't have it as a normal arg becuase we'd have to initalize it everywhere we make a message
+    # and we can't just have it set as a default becuase we get a TypeError for initizling the non-default
+    # args of subclasses after this default arg.
+    # to work around this in binary_serializable.build() and can_comm.prompt_payload
+    # we ignore the message_index when constructing args and then set the value manually after
+    message_index: utils.UInt32Field = field(init=False, default=utils.UInt32Field(0))
 
 
-@dataclass
+@dataclass(eq=False)
 class DeviceInfoResponsePayload(EmptyPayload):
     """Device info response."""
 
@@ -39,7 +59,7 @@ class DeviceInfoResponsePayload(EmptyPayload):
     shortsha: FirmwareShortSHADataField
 
 
-@dataclass
+@dataclass(eq=False)
 class TaskInfoResponsePayload(EmptyPayload):
     """Task info response payload."""
 
@@ -50,7 +70,7 @@ class TaskInfoResponsePayload(EmptyPayload):
     priority: utils.UInt16Field
 
 
-@dataclass
+@dataclass(eq=False)
 class GetStatusResponsePayload(EmptyPayload):
     """Get status response."""
 
@@ -58,21 +78,21 @@ class GetStatusResponsePayload(EmptyPayload):
     data: utils.UInt32Field
 
 
-@dataclass
+@dataclass(eq=False)
 class MoveRequestPayload(EmptyPayload):
     """Move request."""
 
     steps: utils.UInt32Field
 
 
-@dataclass
+@dataclass(eq=False)
 class GetSpeedResponsePayload(EmptyPayload):
     """Get speed response."""
 
     mm_sec: utils.UInt32Field
 
 
-@dataclass
+@dataclass(eq=False)
 class EEPromReadPayload(EmptyPayload):
     """Eeprom read request payload ."""
 
@@ -80,28 +100,28 @@ class EEPromReadPayload(EmptyPayload):
     data_length: utils.UInt16Field
 
 
-@dataclass
+@dataclass(eq=False)
 class EEPromDataPayload(EEPromReadPayload):
     """Eeprom payload with data."""
 
     data: EepromDataField
 
 
-@dataclass
+@dataclass(eq=False)
 class MoveGroupRequestPayload(EmptyPayload):
     """A payload with a group id."""
 
     group_id: utils.UInt8Field
 
 
-@dataclass
+@dataclass(eq=False)
 class MoveGroupResponsePayload(EmptyPayload):
     """A response payload with a group id."""
 
     group_id: utils.UInt8Field
 
 
-@dataclass
+@dataclass(eq=False)
 class AddToMoveGroupRequestPayload(MoveGroupRequestPayload):
     """Base of add to move group request to a message group."""
 
@@ -109,7 +129,7 @@ class AddToMoveGroupRequestPayload(MoveGroupRequestPayload):
     duration: utils.UInt32Field
 
 
-@dataclass
+@dataclass(eq=False)
 class AddLinearMoveRequestPayload(AddToMoveGroupRequestPayload):
     """Add a linear move request to a message group."""
 
@@ -118,14 +138,14 @@ class AddLinearMoveRequestPayload(AddToMoveGroupRequestPayload):
     request_stop_condition: utils.UInt8Field
 
 
-@dataclass
+@dataclass(eq=False)
 class HomeRequestPayload(AddToMoveGroupRequestPayload):
     """Request to home."""
 
     velocity: utils.Int32Field
 
 
-@dataclass
+@dataclass(eq=False)
 class GetMoveGroupResponsePayload(MoveGroupResponsePayload):
     """Response to request to get a move group."""
 
@@ -133,7 +153,7 @@ class GetMoveGroupResponsePayload(MoveGroupResponsePayload):
     total_duration: utils.UInt32Field
 
 
-@dataclass
+@dataclass(eq=False)
 class ExecuteMoveGroupRequestPayload(MoveGroupRequestPayload):
     """Start executing a move group."""
 
@@ -141,7 +161,7 @@ class ExecuteMoveGroupRequestPayload(MoveGroupRequestPayload):
     cancel_trigger: utils.UInt8Field
 
 
-@dataclass
+@dataclass(eq=False)
 class MoveCompletedPayload(MoveGroupResponsePayload):
     """Notification of a completed move group."""
 
@@ -151,14 +171,14 @@ class MoveCompletedPayload(MoveGroupResponsePayload):
     ack_id: utils.UInt8Field
 
 
-@dataclass
+@dataclass(eq=False)
 class EncoderPositionResponse(EmptyPayload):
     """Read Encoder Position."""
 
     encoder_position: utils.Int32Field
 
 
-@dataclass
+@dataclass(eq=False)
 class MotionConstraintsPayload(EmptyPayload):
     """The min and max velocity and acceleration of a motion system."""
 
@@ -168,21 +188,21 @@ class MotionConstraintsPayload(EmptyPayload):
     max_acceleration: utils.Int32Field
 
 
-@dataclass
+@dataclass(eq=False)
 class MotorDriverRegisterPayload(EmptyPayload):
     """Read motor driver register request payload."""
 
     reg_addr: utils.UInt8Field
 
 
-@dataclass
+@dataclass(eq=False)
 class MotorDriverRegisterDataPayload(MotorDriverRegisterPayload):
     """Write motor driver register request payload."""
 
     data: utils.UInt32Field
 
 
-@dataclass
+@dataclass(eq=False)
 class ReadMotorDriverRegisterResponsePayload(EmptyPayload):
     """Read motor driver register response payload."""
 
@@ -190,7 +210,7 @@ class ReadMotorDriverRegisterResponsePayload(EmptyPayload):
     data: utils.UInt32Field
 
 
-@dataclass
+@dataclass(eq=False)
 class MotorCurrentPayload(EmptyPayload):
     """Read motor current register payload."""
 
@@ -199,7 +219,7 @@ class MotorCurrentPayload(EmptyPayload):
     run_current: utils.UInt32Field
 
 
-@dataclass
+@dataclass(eq=False)
 class ReadPresenceSensingVoltageResponsePayload(EmptyPayload):
     """Read head presence sensing voltage response payload."""
 
@@ -209,7 +229,7 @@ class ReadPresenceSensingVoltageResponsePayload(EmptyPayload):
     gripper: utils.UInt16Field
 
 
-@dataclass
+@dataclass(eq=False)
 class ToolsDetectedNotificationPayload(EmptyPayload):
     """Tool detection notification."""
 
@@ -219,14 +239,14 @@ class ToolsDetectedNotificationPayload(EmptyPayload):
     gripper: ToolField
 
 
-@dataclass
+@dataclass(eq=False)
 class FirmwareUpdateWithAddress(EmptyPayload):
     """A FW update payload with an address."""
 
     address: utils.UInt32Field
 
 
-@dataclass
+@dataclass(eq=False)
 class FirmwareUpdateData(FirmwareUpdateWithAddress):
     """A FW update data payload."""
 
@@ -260,14 +280,14 @@ class FirmwareUpdateData(FirmwareUpdateWithAddress):
         return obj
 
 
-@dataclass
+@dataclass(eq=False)
 class FirmwareUpdateDataAcknowledge(FirmwareUpdateWithAddress):
     """A FW update data acknowledge payload."""
 
     error_code: ErrorCodeField
 
 
-@dataclass
+@dataclass(eq=False)
 class FirmwareUpdateComplete(EmptyPayload):
     """All data messages have been transmitted."""
 
@@ -275,28 +295,28 @@ class FirmwareUpdateComplete(EmptyPayload):
     crc32: utils.UInt32Field
 
 
-@dataclass
+@dataclass(eq=False)
 class FirmwareUpdateAcknowledge(EmptyPayload):
     """A response to a firmware update message with an error code."""
 
     error_code: ErrorCodeField
 
 
-@dataclass
+@dataclass(eq=False)
 class FirmwareUpdateStatus(EmptyPayload):
     """A response to the FirmwareUpdateStatusRequest message."""
 
     flags: utils.UInt32Field
 
 
-@dataclass
+@dataclass(eq=False)
 class GetLimitSwitchResponse(EmptyPayload):
     """A response to the Limit Switch Status request payload."""
 
     switch_status: utils.UInt8Field
 
 
-@dataclass
+@dataclass(eq=False)
 class SensorPayload(EmptyPayload):
     """Take a single reading from a sensor request payload."""
 
@@ -304,14 +324,14 @@ class SensorPayload(EmptyPayload):
     sensor_id: SensorIdField
 
 
-@dataclass
+@dataclass(eq=False)
 class ReadFromSensorRequestPayload(SensorPayload):
     """Take a single reading from a sensor request payload."""
 
     offset_reading: utils.UInt8Field
 
 
-@dataclass
+@dataclass(eq=False)
 class WriteToSensorRequestPayload(SensorPayload):
     """Write a piece of data to a sensor request payload."""
 
@@ -319,21 +339,21 @@ class WriteToSensorRequestPayload(SensorPayload):
     reg_address: utils.UInt8Field
 
 
-@dataclass
+@dataclass(eq=False)
 class BaselineSensorRequestPayload(SensorPayload):
     """Take a specified amount of readings from a sensor request payload."""
 
     sample_rate: utils.UInt16Field
 
 
-@dataclass
+@dataclass(eq=False)
 class ReadFromSensorResponsePayload(SensorPayload):
     """A response for either a single reading or an averaged reading of a sensor."""
 
     sensor_data: utils.Int32Field
 
 
-@dataclass
+@dataclass(eq=False)
 class SetSensorThresholdRequestPayload(SensorPayload):
     """A request to set the threshold value of a sensor."""
 
@@ -341,7 +361,7 @@ class SetSensorThresholdRequestPayload(SensorPayload):
     mode: SensorThresholdModeField
 
 
-@dataclass
+@dataclass(eq=False)
 class SensorThresholdResponsePayload(SensorPayload):
     """A response that sends back the current threshold value of the sensor."""
 
@@ -349,14 +369,14 @@ class SensorThresholdResponsePayload(SensorPayload):
     mode: SensorThresholdModeField
 
 
-@dataclass
+@dataclass(eq=False)
 class SensorDiagnosticRequestPayload(SensorPayload):
     """A response that sends back the current threshold value of the sensor."""
 
     reg_address: utils.UInt8Field
 
 
-@dataclass
+@dataclass(eq=False)
 class SensorDiagnosticResponsePayload(SensorPayload):
     """A response that sends back the current threshold value of the sensor."""
 
@@ -364,21 +384,21 @@ class SensorDiagnosticResponsePayload(SensorPayload):
     data: utils.UInt32Field
 
 
-@dataclass
+@dataclass(eq=False)
 class BindSensorOutputRequestPayload(SensorPayload):
     """A request to link a GPIO pin output to a sensor threshold."""
 
     binding: SensorOutputBindingField
 
 
-@dataclass
+@dataclass(eq=False)
 class BindSensorOutputResponsePayload(SensorPayload):
     """A response that sends back the current binding for a sensor."""
 
     binding: SensorOutputBindingField
 
 
-@dataclass
+@dataclass(eq=False)
 class PipetteInfoResponsePayload(EmptyPayload):
     """A response carrying data about an attached pipette."""
 
@@ -387,21 +407,21 @@ class PipetteInfoResponsePayload(EmptyPayload):
     serial: SerialDataCodeField
 
 
-@dataclass
+@dataclass(eq=False)
 class BrushedMotorVrefPayload(EmptyPayload):
     """A request to set the reference voltage of a brushed motor."""
 
     v_ref: utils.UInt32Field
 
 
-@dataclass
+@dataclass(eq=False)
 class BrushedMotorPwmPayload(EmptyPayload):
     """A request to set the pwm of a brushed motor."""
 
     duty_cycle: utils.UInt32Field
 
 
-@dataclass
+@dataclass(eq=False)
 class GripperInfoResponsePayload(EmptyPayload):
     """A response carrying data about an attached gripper."""
 
@@ -409,7 +429,7 @@ class GripperInfoResponsePayload(EmptyPayload):
     serial: SerialDataCodeField
 
 
-@dataclass
+@dataclass(eq=False)
 class GripperMoveRequestPayload(AddToMoveGroupRequestPayload):
     """A request to move gripper."""
 
@@ -417,7 +437,7 @@ class GripperMoveRequestPayload(AddToMoveGroupRequestPayload):
     encoder_position_um: utils.Int32Field
 
 
-@dataclass
+@dataclass(eq=False)
 class TipActionRequestPayload(AddToMoveGroupRequestPayload):
     """A request to perform a tip action."""
 
@@ -426,7 +446,7 @@ class TipActionRequestPayload(AddToMoveGroupRequestPayload):
     request_stop_condition: utils.UInt8Field
 
 
-@dataclass
+@dataclass(eq=False)
 class TipActionResponsePayload(MoveCompletedPayload):
     """A response that sends back whether tip action was successful."""
 
@@ -434,14 +454,14 @@ class TipActionResponsePayload(MoveCompletedPayload):
     success: utils.UInt8Field
 
 
-@dataclass
+@dataclass(eq=False)
 class PeripheralStatusResponsePayload(SensorPayload):
     """A response that sends back the initialization status of a peripheral device."""
 
     status: utils.UInt8Field
 
 
-@dataclass
+@dataclass(eq=False)
 class SerialNumberPayload(EmptyPayload):
     """A payload with a serial number."""
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -46,7 +46,7 @@ class EmptyPayload(utils.BinarySerializable):
     # to work around this in binary_serializable.build() and can_comm.prompt_payload
     # we ignore the message_index when constructing args and then set the value manually after
     message_index: utils.UInt32Field = field(
-        init=False, default=utils.UInt32Field(None)
+        init=False, default=utils.UInt32Field(None)  # type: ignore[arg-type]
     )
 
 
@@ -266,7 +266,7 @@ class FirmwareUpdateData(FirmwareUpdateWithAddress):
 
     @classmethod
     def create(
-        cls, address: int, data: bytes, message_index: int = None
+        cls, address: int, data: bytes, message_index: int = None  # type: ignore[assignment]
     ) -> "FirmwareUpdateData":
         """Create a firmware update data payload."""
         # this is a special case, we normally instansiate message_index
@@ -282,7 +282,7 @@ class FirmwareUpdateData(FirmwareUpdateWithAddress):
             data=FirmwareUpdateDataField(data),
             checksum=utils.UInt16Field(checksum),
         )
-        if message_index == None:
+        if message_index is None:
             index_generator = message_definitions.SingletonMessageIndexGenerator()
             obj.message_index = utils.UInt32Field(index_generator.get_next_index())
         else:

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -44,7 +44,7 @@ class EmptyPayload(utils.BinarySerializable):
     # args of subclasses after this default arg.
     # to work around this in binary_serializable.build() and can_comm.prompt_payload
     # we ignore the message_index when constructing args and then set the value manually after
-    message_index: utils.UInt32Field = field(init=False, default=utils.UInt32Field(0))
+    message_index: utils.UInt32Field = field(init=False, default=utils.UInt32Field(None))
 
 
 @dataclass(eq=False)

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -258,11 +258,16 @@ class FirmwareUpdateData(FirmwareUpdateWithAddress):
     def __post_init__(self) -> None:
         """Post init processing."""
         data_length = len(self.data.value)
-        if data_length > FirmwareUpdateDataField.NUM_BYTES or
-           data_length % 8 != 0:
+        address = self.address.value
+        if address % 8 != 0:
+            raise ValueError(
+                f"Data address needs to be doubleword aligned."
+                f" {address} mod 8 equals {address % 8} and should be 0"
+            )
+        if data_length > FirmwareUpdateDataField.NUM_BYTES:
             raise ValueError(
                 f"Data cannot be more than"
-                f" {FirmwareUpdateDataField.NUM_BYTES} bytes."
+                f" {FirmwareUpdateDataField.NUM_BYTES} bytes got {data_length}."
             )
 
     @classmethod

--- a/hardware/opentrons_hardware/firmware_bindings/utils/binary_serializable.py
+++ b/hardware/opentrons_hardware/firmware_bindings/utils/binary_serializable.py
@@ -197,7 +197,6 @@ class BinarySerializable:
                 (v.type.build(b[i]) for i, v in enumerate(fields(cls)) if v.name == "message_index"),
                 None,
             )
-            print("\n\n\nbuild message index: " + str(message_index) + "\n\n\n")
             # Mypy is not liking constructing the derived types.
             ret_instance = cls(**args)  # type: ignore[call-arg]
             if message_index is not None:

--- a/hardware/opentrons_hardware/firmware_bindings/utils/binary_serializable.py
+++ b/hardware/opentrons_hardware/firmware_bindings/utils/binary_serializable.py
@@ -200,7 +200,7 @@ class BinarySerializable:
             # Mypy is not liking constructing the derived types.
             ret_instance = cls(**args)  # type: ignore[call-arg]
             if message_index is not None:
-                ret_instance.message_index = message_index
+                ret_instance.message_index = message_index  # type: ignore[attr-defined]
             return ret_instance
         except struct.error as e:
             raise InvalidFieldException(str(e))

--- a/hardware/opentrons_hardware/firmware_bindings/utils/binary_serializable.py
+++ b/hardware/opentrons_hardware/firmware_bindings/utils/binary_serializable.py
@@ -194,7 +194,11 @@ class BinarySerializable:
                 if not (v.name == "message_index")
             }
             message_index = next(
-                (v.type.build(b[i]) for i, v in enumerate(fields(cls)) if v.name == "message_index"),
+                (
+                    v.type.build(b[i])
+                    for i, v in enumerate(fields(cls))
+                    if v.name == "message_index"
+                ),
                 None,
             )
             # Mypy is not liking constructing the derived types.

--- a/hardware/opentrons_hardware/firmware_bindings/utils/binary_serializable.py
+++ b/hardware/opentrons_hardware/firmware_bindings/utils/binary_serializable.py
@@ -194,7 +194,7 @@ class BinarySerializable:
                 if not (v.name == "message_index")
             }
             message_index = next(
-                (v for i, v in enumerate(fields(cls)) if v.name == "message_index"),
+                (v.type.build(b[i]) for i, v in enumerate(fields(cls)) if v.name == "message_index"),
                 None,
             )
             print("\n\n\nbuild message index: " + str(message_index) + "\n\n\n")

--- a/hardware/opentrons_hardware/firmware_bindings/utils/binary_serializable.py
+++ b/hardware/opentrons_hardware/firmware_bindings/utils/binary_serializable.py
@@ -197,6 +197,7 @@ class BinarySerializable:
                 (v for i, v in enumerate(fields(cls)) if v.name == "message_index"),
                 None,
             )
+            print("\n\n\nbuild message index: " + str(message_index) + "\n\n\n")
             # Mypy is not liking constructing the derived types.
             ret_instance = cls(**args)  # type: ignore[call-arg]
             if message_index is not None:

--- a/hardware/opentrons_hardware/hardware_control/limit_switches.py
+++ b/hardware/opentrons_hardware/hardware_control/limit_switches.py
@@ -1,7 +1,7 @@
 """Utilities for reading the current status of the OT3 limit switches."""
 import asyncio
 import logging
-from typing import Dict, Set, Callable
+from typing import Dict, Set, Callable, cast
 
 from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
 from opentrons_hardware.firmware_bindings import ArbitrationId
@@ -9,6 +9,7 @@ from opentrons_hardware.firmware_bindings.constants import MessageId
 from opentrons_hardware.firmware_bindings.messages import MessageDefinition
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     ReadLimitSwitchRequest,
+    ReadLimitSwitchResponse,
 )
 from opentrons_hardware.firmware_bindings.constants import NodeId
 
@@ -36,7 +37,9 @@ def _create_listener(
         if message.message_id != MessageId.limit_sw_response:
             log.warning(f"unexpected message id: 0x{message.message_id:x}")
             return
-        responses[originator] = message.payload.switch_status.value
+        responses[originator] = cast(
+            ReadLimitSwitchResponse, message
+        ).payload.switch_status.value
         if len(responses) == len(nodes):
             event.set()
 

--- a/hardware/opentrons_hardware/scripts/can_comm.py
+++ b/hardware/opentrons_hardware/scripts/can_comm.py
@@ -144,13 +144,26 @@ def prompt_payload(
     """
     payload_fields = dataclasses.fields(payload_type)
     i = {}
+    message_index = None
     for f in payload_fields:
         try:
-            i[f.name] = f.type.from_string(get_user_input(f"enter {f.name}: ").strip())
+            # we have to hack around message_index for now until we update to 3.10
+            # then message index can work like everything else. see payloads.py
+            if not (f.name == "message_index"):
+                i[f.name] = f.type.from_string(
+                    get_user_input(f"enter {f.name}: ").strip()
+                )
+            else:
+                message_index = f.type.from_string(
+                    get_user_input(f"enter {f.name}: ").strip()
+                )
         except ValueError as e:
             raise InvalidInput(str(e))
     # Mypy is not liking constructing the derived types.
-    return payload_type(**i)  # type: ignore[call-arg]
+    ret_instance = payload_type(**i)  # type: ignore[call-arg]
+    if message_index is not None:
+        ret_instance.message_index = message_index
+    return ret_instance
 
 
 def prompt_message(

--- a/hardware/opentrons_hardware/scripts/can_comm.py
+++ b/hardware/opentrons_hardware/scripts/can_comm.py
@@ -162,7 +162,7 @@ def prompt_payload(
     # Mypy is not liking constructing the derived types.
     ret_instance = payload_type(**i)  # type: ignore[call-arg]
     if message_index is not None:
-        ret_instance.message_index = message_index
+        ret_instance.message_index = message_index  # type: ignore[attr-defined]
     return ret_instance
 
 

--- a/hardware/opentrons_hardware/scripts/can_mon.py
+++ b/hardware/opentrons_hardware/scripts/can_mon.py
@@ -1,6 +1,7 @@
 """A script for monitoring CAN bus."""
 import asyncio
 import dataclasses
+from dataclasses import fields
 import logging
 import argparse
 import atexit
@@ -102,7 +103,12 @@ async def task(
                     StyledOutput(style=data_style, content=arb_id_str + "\n"),
                 ]
             )
-            for name, value in dataclasses.asdict(message.payload).items():
+            for name, value in (
+                dict(
+                    (field.name, getattr(message.payload, field.name))
+                    for field in fields(message.payload)
+                )
+            ).items():
                 writer.write(
                     [
                         StyledOutput(style=label_style, content=f"\t{name}:"),

--- a/hardware/tests/opentrons_hardware/drivers/can_bus/test_can_messenger.py
+++ b/hardware/tests/opentrons_hardware/drivers/can_bus/test_can_messenger.py
@@ -123,7 +123,7 @@ async def test_listen_messages(
                     originating_node_id=NodeId.gantry_x,
                 )
             ),
-            data=b"\1",
+            data=b"\x00\x00\x00\x01\1",
         )
     )
 

--- a/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_message_index.py
+++ b/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_message_index.py
@@ -1,0 +1,25 @@
+import pytest
+import asyncio
+from typing import List, Callable
+from mock import AsyncMock
+
+from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
+from opentrons_hardware.firmware_bindings import (
+    ArbitrationId,
+    ArbitrationIdParts,
+    utils,
+)
+from opentrons_hardware.firmware_bindings.messages import (
+    MessageDefinition,
+    message_definitions,
+    payloads,
+)
+
+def test_unqiue_index() -> None:
+    last_index = 0;
+    for i in range (1, 20):
+        message=message_definitions.HeartbeatRequest()
+        assert message.message_index != last_index
+        last_index = message.message_index
+
+

--- a/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_message_index.py
+++ b/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_message_index.py
@@ -1,13 +1,16 @@
 """Tests for can message_index generator."""
 from opentrons_hardware.firmware_bindings import utils
 
-from opentrons_hardware.firmware_bindings.messages import message_definitions
+from opentrons_hardware.firmware_bindings.messages import message_definitions, payloads
 
 
 def test_unqiue_index() -> None:
     """Create several messages and make sure they have generate a new index."""
     last_index = utils.UInt32Field(0)
     for i in range(1, 20):
-        message = message_definitions.HeartbeatRequest()
+        # we have to define a payload here because python reuses
+        # old memory locations for the HeartbeatRequest from other tests that
+        # already have a message index
+        message = message_definitions.HeartbeatRequest(payload=payloads.EmptyPayload())
         assert message.payload.message_index != last_index
         last_index = message.payload.message_index

--- a/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_message_index.py
+++ b/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_message_index.py
@@ -1,25 +1,13 @@
-import pytest
-import asyncio
-from typing import List, Callable
-from mock import AsyncMock
+"""Tests for can message_index generator."""
+from opentrons_hardware.firmware_bindings import utils
 
-from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
-from opentrons_hardware.firmware_bindings import (
-    ArbitrationId,
-    ArbitrationIdParts,
-    utils,
-)
-from opentrons_hardware.firmware_bindings.messages import (
-    MessageDefinition,
-    message_definitions,
-    payloads,
-)
+from opentrons_hardware.firmware_bindings.messages import message_definitions
+
 
 def test_unqiue_index() -> None:
-    last_index = 0;
-    for i in range (1, 20):
-        message=message_definitions.HeartbeatRequest()
+    """Create several messages and make sure they have generate a new index."""
+    last_index = utils.UInt32Field(0)
+    for i in range(1, 20):
+        message = message_definitions.HeartbeatRequest()
         assert message.message_index != last_index
         last_index = message.message_index
-
-

--- a/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_message_index.py
+++ b/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_message_index.py
@@ -9,5 +9,5 @@ def test_unqiue_index() -> None:
     last_index = utils.UInt32Field(0)
     for i in range(1, 20):
         message = message_definitions.HeartbeatRequest()
-        assert message.message_index != last_index
-        last_index = message.message_index
+        assert message.payload.message_index != last_index
+        last_index = message.payload.message_index

--- a/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_payloads.py
+++ b/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_payloads.py
@@ -18,7 +18,7 @@ def test_create_firmware_updata_data(
     address: int, data: bytes, expected_checksum: int
 ) -> None:
     """It should create a complete firmware update data payload."""
-    obj = payloads.FirmwareUpdateData.create(address, data)
+    obj = payloads.FirmwareUpdateData.create(address, data, 0)
     assert obj == payloads.FirmwareUpdateData(
         address=utils.UInt32Field(address),
         num_bytes=utils.UInt8Field(len(data)),

--- a/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_payloads.py
+++ b/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_payloads.py
@@ -8,7 +8,7 @@ from opentrons_hardware.firmware_bindings import utils
 @pytest.mark.parametrize(
     argnames=["address", "data", "expected_checksum"],
     argvalues=[
-        [0xF0F0F0F0, bytes(range(56)), 0xF604],
+        [0xF0F0F0F0, bytes(range(48)), 0xF7A8],
         [0x0, b"", 0x0],
         [0x0, b"\x00", 0xFFFF],
         [0x12345678, b"\x05\x06\x07", 0xFED7],

--- a/hardware/tests/opentrons_hardware/firmware_update/test_downloader.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_downloader.py
@@ -72,13 +72,13 @@ async def test_messaging(
     def responder(node_id: NodeId, message: MessageDefinition) -> None:
         """Message responder."""
         if isinstance(message, FirmwareUpdateData):
-            pld = payloads.FirmwareUpdateDataAcknowledge(
+            FwUpData_payload = payloads.FirmwareUpdateDataAcknowledge(
                 address=message.payload.address,
                 error_code=ErrorCodeField(ErrorCode.ok),
             )
-            pld.message_index = message.payload.message_index
+            FwUpData_payload.message_index = message.payload.message_index
             can_message_notifier.notify(
-                FirmwareUpdateDataAcknowledge(payload=pld),
+                FirmwareUpdateDataAcknowledge(payload=FwUpData_payload),
                 ArbitrationId(
                     parts=ArbitrationIdParts(
                         message_id=FirmwareUpdateDataAcknowledge.message_id,
@@ -89,12 +89,12 @@ async def test_messaging(
                 ),
             )
         elif isinstance(message, FirmwareUpdateComplete):
-            pld = payloads.FirmwareUpdateAcknowledge(
+            FwUpCom_payload = payloads.FirmwareUpdateAcknowledge(
                 error_code=ErrorCodeField(ErrorCode.ok)
             )
-            pld.message_index = message.payload.message_index
+            FwUpCom_payload.message_index = message.payload.message_index
             can_message_notifier.notify(
-                FirmwareUpdateCompleteAcknowledge(payload=pld),
+                FirmwareUpdateCompleteAcknowledge(payload=FwUpCom_payload),
                 ArbitrationId(
                     parts=ArbitrationIdParts(
                         message_id=FirmwareUpdateCompleteAcknowledge.message_id,

--- a/hardware/tests/opentrons_hardware/firmware_update/test_downloader.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_downloader.py
@@ -38,7 +38,7 @@ def mock_hex_processor() -> MagicMock:
 def chunks() -> List[Chunk]:
     """Data chunks produced by hex processor."""
     return [
-        Chunk(address=0x000, data=list(range(56))),
+        Chunk(address=0x000, data=list(range(48))),
         Chunk(address=0x100, data=[5, 6, 7, 8]),
         Chunk(address=0x200, data=[100, 121]),
     ]

--- a/hardware/tests/opentrons_hardware/firmware_update/test_downloader.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_downloader.py
@@ -73,14 +73,12 @@ async def test_messaging(
         """Message responder."""
         if isinstance(message, FirmwareUpdateData):
             pld = payloads.FirmwareUpdateDataAcknowledge(
-                        address=message.payload.address,
-                        error_code=ErrorCodeField(ErrorCode.ok),
-                    )
+                address=message.payload.address,
+                error_code=ErrorCodeField(ErrorCode.ok),
+            )
             pld.message_index = message.payload.message_index
             can_message_notifier.notify(
-                FirmwareUpdateDataAcknowledge(
-                    payload=pld
-                ),
+                FirmwareUpdateDataAcknowledge(payload=pld),
                 ArbitrationId(
                     parts=ArbitrationIdParts(
                         message_id=FirmwareUpdateDataAcknowledge.message_id,
@@ -92,13 +90,11 @@ async def test_messaging(
             )
         elif isinstance(message, FirmwareUpdateComplete):
             pld = payloads.FirmwareUpdateAcknowledge(
-                        error_code=ErrorCodeField(ErrorCode.ok)
-                    )
+                error_code=ErrorCodeField(ErrorCode.ok)
+            )
             pld.message_index = message.payload.message_index
             can_message_notifier.notify(
-                FirmwareUpdateCompleteAcknowledge(
-                    payload=pld
-                ),
+                FirmwareUpdateCompleteAcknowledge(payload=pld),
                 ArbitrationId(
                     parts=ArbitrationIdParts(
                         message_id=FirmwareUpdateCompleteAcknowledge.message_id,
@@ -114,21 +110,22 @@ async def test_messaging(
     mock_hex_processor.process.return_value = iter(chunks)
 
     await subject.run(NodeId.gantry_y_bootloader, mock_hex_processor, 10)
-    
+
     # When the downloader runs it creates unique message indecies for each
-    # message, this is a little hack to get the next index it would use 
+    # message, this is a little hack to get the next index it would use
     # so we can caluclate what indecies it gave the messages.
     index_generator = SingletonMessageIndexGenerator()
     msg_index = index_generator.get_next_index() - (len(chunks) + 1)
-    
+
     mock_messenger.send.assert_has_calls(
         [
             call(
                 node_id=NodeId.gantry_y_bootloader,
                 message=FirmwareUpdateData(
                     payload=payloads.FirmwareUpdateData.create(
-                        address=chunk.address, data=bytes(chunk.data),
-                        message_index = msg_index+i,
+                        address=chunk.address,
+                        data=bytes(chunk.data),
+                        message_index=msg_index + i,
                     )
                 ),
             )

--- a/hardware/tests/test_scripts/test_can_comm.py
+++ b/hardware/tests/test_scripts/test_can_comm.py
@@ -40,6 +40,7 @@ def test_prompt_message_without_payload(
     mock_get_input.side_effect = [
         str(list(MessageId).index(message_id)),
         str(list(NodeId).index(node_id)),
+        "1",
     ]
     r = can_comm.prompt_message(mock_get_input, mock_output)
     assert r == CanMessage(
@@ -48,7 +49,7 @@ def test_prompt_message_without_payload(
                 message_id=message_id, node_id=node_id, originating_node_id=NodeId.host
             )
         ),
-        data=b"",
+        data=b"\x00\x00\x00\x01",
     )
 
 
@@ -61,6 +62,7 @@ def test_prompt_message_with_payload(
     mock_get_input.side_effect = [
         str(list(MessageId).index(message_id)),
         str(list(NodeId).index(node_id)),
+        "1",
         str(0xFF00FF00),
         str(0xAA00BB00),
     ]
@@ -71,7 +73,7 @@ def test_prompt_message_with_payload(
                 message_id=message_id, node_id=node_id, originating_node_id=NodeId.host
             )
         ),
-        data=b"\xff\x00\xff\x00\xAA\00\xBB\x00",
+        data=b"\x00\x00\x00\x01\xff\x00\xff\x00\xAA\00\xBB\x00",
     )
 
 
@@ -119,6 +121,7 @@ def test_prompt_message_bad_input(
     mock_get_input.side_effect = [
         str(list(MessageId).index(message_id)),
         str(list(NodeId).index(node_id)),
+        "1",
         "-123",
         # out of range for Uint32
         str(0x1FF00FF00),


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
https://opentrons.atlassian.net/browse/RET-1244
https://opentrons.atlassian.net/browse/RET-1245
This is the first phase for connecting full error reporting from firmware to the hardware-controller
This allows the firmware to know and indicate exactly which message caused an issue. this will also facilitate catching any unacknowledged messages which would indicate a communication failure

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
