### PR TITLE
refactor(shared-data): modify the plunger positions of gen3 pipettes

### DIFF
--- a/shared-data/pipette/definitions/pipetteModelSpecs.json
+++ b/shared-data/pipette/definitions/pipetteModelSpecs.json
@@ -5749,21 +5749,21 @@
         "type": "float"
       },
       "bottom": {
-        "value": 59.5,
+        "value": 71.5,
         "min": 10,
         "max": 65,
         "type": "float",
         "units": "mm"
       },
       "blowout": {
-        "value": 64.5,
+        "value": 76.5,
         "min": 20,
         "max": 75,
         "units": "mm",
         "type": "float"
       },
       "dropTip": {
-        "value": 74.5,
+        "value": 90.5,
         "min": 30,
         "max": 80,
         "units": "mm",
@@ -6111,21 +6111,21 @@
         "type": "float"
       },
       "bottom": {
-        "value": 61,
+        "value": 71.5,
         "min": 55,
         "max": 80,
         "type": "float",
         "units": "mm"
       },
       "blowout": {
-        "value": 66,
+        "value": 76.5,
         "min": 60,
         "max": 85,
         "units": "mm",
         "type": "float"
       },
       "dropTip": {
-        "value": 80,
+        "value": 90.5,
         "min": 78,
         "max": 119,
         "units": "mm",
@@ -6474,21 +6474,21 @@
         "type": "float"
       },
       "bottom": {
-        "value": 61,
+        "value": 71.5,
         "min": 55,
         "max": 80,
         "type": "float",
         "units": "mm"
       },
       "blowout": {
-        "value": 66,
+        "value": 76.5,
         "min": 60,
         "max": 85,
         "units": "mm",
         "type": "float"
       },
       "dropTip": {
-        "value": 80,
+        "value": 90.5,
         "min": 78,
         "max": 110,
         "units": "mm",
@@ -6836,21 +6836,21 @@
         "type": "float"
       },
       "bottom": {
-        "value": 61,
+        "value": 71.5,
         "min": 55,
         "max": 80,
         "type": "float",
         "units": "mm"
       },
       "blowout": {
-        "value": 66,
+        "value": 76.5,
         "min": 60,
         "max": 85,
         "units": "mm",
         "type": "float"
       },
       "dropTip": {
-        "value": 80,
+        "value": 90.5,
         "min": 78,
         "max": 119,
         "units": "mm",


### PR DESCRIPTION
We had originally shortened plunger positions to accommodate for a potentially smaller leadscrew on retro-fitted pipettes. Confirmed with hardware that it's safe to revert to the correct positions for the plunger.