### PR TITLE
feat(usb-bridge): usb connection monitoring & serial echo

### DIFF
--- a/usb-bridge/Pipfile
+++ b/usb-bridge/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 typing-extensions = "==3.10.0.0"
 pyserial = "==3.5"
+pyudev = "==0.24.0"
 
 [dev-packages]
 ot3usb = {path = ".", editable = true}

--- a/usb-bridge/Pipfile.lock
+++ b/usb-bridge/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "06fcf4636978789b3a9078b5504681bfccb3cba377d49663cad68ed2ef040e57"
+            "sha256": "5f8ac3a6a4adb5b7e0e6083b3b4498cb09e025459845b93ae748b4912a32f903"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,6 +23,14 @@
             ],
             "index": "pypi",
             "version": "==3.5"
+        },
+        "pyudev": {
+            "hashes": [
+                "sha256:b2a3afe1c99ea751f8296652557eac559874da2a1b1ec0625178706ec5a345f3",
+                "sha256:d22451d9f10b4fef7737a0fa5c5664e7547cf9ae58a79084eb396e0ce9a0e406"
+            ],
+            "index": "pypi",
+            "version": "==0.24.0"
         },
         "typing-extensions": {
             "hashes": [
@@ -202,7 +210,7 @@
                 "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
                 "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
             ],
-            "markers": "python_version >= '3.6'",
+            "markers": "python_full_version >= '3.6.0'",
             "version": "==2.1.1"
         },
         "click": {

--- a/usb-bridge/ot3usb/__main__.py
+++ b/usb-bridge/ot3usb/__main__.py
@@ -28,10 +28,10 @@ def update_ser_handle(
         connected or not
     """
     if ser and not connected:
-        LOG.info("USB host disconnected")
+        LOG.debug("USB host disconnected")
         ser = None
     elif connected and not ser:
-        LOG.info("New USB host connected")
+        LOG.debug("New USB host connected")
         ser = config.get_handle()
     return ser
 
@@ -109,7 +109,7 @@ async def main() -> NoReturn:
 
     try:
         config.configure_and_activate()
-        LOG.info("Configured UDC as USB gadget")
+        LOG.debug("Configured UDC as USB gadget")
     except BaseException as err:
         LOG.error("Failed to configure UDC as USB gadget")
         LOG.error(f"Exception: {format(err)}")
@@ -136,7 +136,7 @@ async def main() -> NoReturn:
     monitor.begin()
 
     if monitor.host_connected():
-        LOG.info("USB connected on startup")
+        LOG.debug("USB connected on startup")
         ser = config.get_handle()
 
     while True:

--- a/usb-bridge/ot3usb/__main__.py
+++ b/usb-bridge/ot3usb/__main__.py
@@ -1,9 +1,10 @@
 """Entrypoint for the USB-TCP bridge application."""
 import asyncio
 import logging
+import select
 import time
 from typing import NoReturn
-from .src import cli, usb_config, default_config
+from .src import cli, usb_config, default_config, usb_monitor
 
 LOG = logging.getLogger(__name__)
 
@@ -30,21 +31,41 @@ async def main() -> NoReturn:
         LOG.error(f"Exception: {format(err)}")
         exit(-1)
 
-    # Spin for at least a second
+    # Spin for at least a couple seconds
     timeout = time.time() + 2.0
     while time.time() < timeout and not config.handle_exists():
         time.sleep(0.1)
 
     if not config.handle_exists():
-        LOG.error("Cannot find UDC serial handle")
+        LOG.error("udev did not generate a serial handle")
         exit(-1)
 
-    ser = config.get_handle()
+    ser = None
+
+    monitor = usb_monitor.USBConnectionMonitor("usbphynop1", "")
+
+    monitor.begin()
 
     while True:
-        data = ser.readline()
-        LOG.debug(f"Received: {data}")
-        ser.write(data)
+        rlist = [monitor]
+        if ser:
+            rlist.append(ser)
+        ready = select.select(rlist, [], [])[0]
+        if monitor in ready:
+            # Read a new udev messages
+            monitor.read_message()
+            if ser:
+                if not monitor.host_connected():
+                    LOG.info("USB host disconnected")
+                    ser = None
+            elif monitor.host_connected():
+                LOG.info("New USB host connected")
+                ser = config.get_handle()
+        if ser and ser in ready:
+            # Ready serial data
+            data = ser.read()
+            LOG.debug(f"Received: {data}")
+            ser.write(data)
 
 
 if __name__ == "__main__":

--- a/usb-bridge/ot3usb/__main__.py
+++ b/usb-bridge/ot3usb/__main__.py
@@ -10,6 +10,9 @@ from .src import cli, usb_config, default_config, usb_monitor
 
 LOG = logging.getLogger(__name__)
 
+# 1 second polling for select()
+POLL_TIMEOUT = 1.0
+
 
 def update_ser_handle(
     config: usb_config.SerialGadget, ser: Optional[serial.Serial], connected: bool
@@ -70,7 +73,7 @@ def listen(
     rlist = [monitor]
     if ser:
         rlist.append(ser)
-    ready = select.select(rlist, [], [], 1.0)[0]
+    ready = select.select(rlist, [], [], POLL_TIMEOUT)[0]
     if len(ready) == 0 or monitor in ready:
         # Read a new udev messages
         check_monitor(monitor, monitor in ready)
@@ -124,7 +127,7 @@ async def main() -> NoReturn:
     ser = None
 
     monitor = usb_monitor.USBConnectionMonitorFactory.create(
-        phy_udev_name="usbphynop1", udc_folder=config.udc_folder()
+        phy_udev_name=default_config.PHY_NAME, udc_folder=config.udc_folder()
     )
 
     # After the gadget starts up, need time to populate state

--- a/usb-bridge/ot3usb/src/default_config.py
+++ b/usb-bridge/ot3usb/src/default_config.py
@@ -22,3 +22,6 @@ default_gadget = SerialGadgetConfig(
     configuration_desc=DEFAULT_CONFIGURATION,
     max_power=DEFAULT_MAX_POWER,
 )
+
+# The name of the PHY in sysfs for the OT3
+PHY_NAME = "usbphynop1"

--- a/usb-bridge/ot3usb/src/default_config.py
+++ b/usb-bridge/ot3usb/src/default_config.py
@@ -1,9 +1,9 @@
 """Provides default configuration options for the OT3 Serial Gadget."""
 from .usb_config import SerialGadgetConfig
 
-DEFAULT_NAME = "g1"
-DEFAULT_VID = "0x0483"
-DEFAULT_PID = "0x0483"
+DEFAULT_NAME = "ot3_usb"
+DEFAULT_VID = "0x1b67"
+DEFAULT_PID = "0x4037"
 DEFAULT_BCDEVICE = "0x0010"
 DEFAULT_SERIAL = "01121997"
 DEFAULT_MANUFACTURER = "Opentrons"

--- a/usb-bridge/ot3usb/src/usb_config.py
+++ b/usb-bridge/ot3usb/src/usb_config.py
@@ -128,7 +128,7 @@ class SerialGadget:
     def udc_folder(self) -> str:
         """Get the folder where UDC configuration lives."""
         if not self._udc_name:
-            raise Exception("Gadget is not configured")
+            raise RuntimeError("Gadget is not configured")
         return os.path.join(UDC_HANDLE_FOLDER, self._udc_name)
 
     def configure_and_activate(self) -> None:
@@ -175,32 +175,32 @@ class SerialGadget:
                 dest=os.path.join(self._basename, "configs/c.1/acm.usb0"),
             )
         except FileExistsError:
-            LOG.info("symlink already exists")
+            LOG.debug("symlink already exists")
         # Last step is to set up the UDC. This assumes there's only ONE UDC
         udc_path = os.path.join(self._basename, "UDC")
         udc_handles = self._driver.listdir(UDC_HANDLE_FOLDER)
         if len(udc_handles) == 0:
-            raise Exception("Failed to find UDC handle. Check kernel configuration.")
+            raise RuntimeError("Failed to find UDC handle. Check kernel configuration.")
         # Before writing the UDC handle, we write nothing to the UDC file
         # to clear any configuration.
         try:
             self._write_file("\n", "UDC")
         except Exception:
-            LOG.info("UDC was already uninitialized")
+            LOG.debug("UDC was already uninitialized")
         try:
             self._write_file(udc_handles[0], "UDC")
             self._udc_name = udc_handles[0]
         except Exception:
-            raise Exception("UDC is occupied by another driver!")
+            raise RuntimeError("UDC is occupied by another driver!")
         if not self._driver.exists(udc_path):
-            raise Exception("Failed to enumerate UDC")
+            raise RuntimeError("Failed to enumerate UDC")
 
     def _get_handle_path(self) -> str:
         """Check for the expected path for the serial handle."""
         portnum_path = os.path.join(self._basename, FUNCTION_SUBFOLDER, "port_num")
         suffix = open(portnum_path, mode="r").read()
         if len(suffix) == 0:
-            raise Exception("Port does not have a number")
+            raise RuntimeError("Port does not have a number")
         # This conversion is necessary to strip out the newline
         portnum = int(suffix)
         return self.HANDLE + str(portnum)

--- a/usb-bridge/ot3usb/src/usb_config.py
+++ b/usb-bridge/ot3usb/src/usb_config.py
@@ -210,4 +210,7 @@ class SerialGadget:
     def get_handle(self) -> serial.Serial:
         """Open a handle to the serial port."""
         path = self._get_handle_path()
-        return serial.Serial(port=path)
+        ser = serial.Serial(port=path)
+        # To support select()
+        ser.nonblocking()
+        return ser

--- a/usb-bridge/ot3usb/src/usb_config.py
+++ b/usb-bridge/ot3usb/src/usb_config.py
@@ -13,7 +13,6 @@ and a few kernel modules must be running before this program:
 
 - dwc3 (or another USB module)
 - libcomposite (to provide the configuration filesystem)
-- g_serial (to provide /dev/ttyGS0 after configuration)
 """
 
 from dataclasses import dataclass
@@ -107,6 +106,7 @@ class SerialGadget:
         """
         self._driver = driver
         self._config = config
+        self._udc_name: typing.Optional[str] = None
 
         self._basename = os.path.join(GADGET_BASE_PATH, config.name)
 
@@ -124,6 +124,12 @@ class SerialGadget:
         with open(os.path.join(self._basename, filename), mode="w") as f:
             written = f.write(contents)
         return written == len(contents)
+
+    def udc_folder(self) -> str:
+        """Get the folder where UDC configuration lives."""
+        if not self._udc_name:
+            raise Exception("Gadget is not configured")
+        return os.path.join(UDC_HANDLE_FOLDER, self._udc_name)
 
     def configure_and_activate(self) -> None:
         """Configure this gadget. Throws exceptions on errors."""
@@ -183,6 +189,7 @@ class SerialGadget:
             LOG.info("UDC was already uninitialized")
         try:
             self._write_file(udc_handles[0], "UDC")
+            self._udc_name = udc_handles[0]
         except Exception:
             raise Exception("UDC is occupied by another driver!")
         if not self._driver.exists(udc_path):

--- a/usb-bridge/ot3usb/src/usb_monitor.py
+++ b/usb-bridge/ot3usb/src/usb_monitor.py
@@ -4,6 +4,23 @@ When a usb serial gadget is configured, a tty handle is created by udev
 immediately and it remains in the filesystem indefinitely. This makes it
 impossible to distinguish the presence of a serial port directly; instead,
 this module hooks into the udev message stream on the system to check for
+messages pertaining to the connection status of the USB gadget.
+
+Unfortunately, no UDEV messages directly contain the configuration status
+of the USB gadget; however, when a new USB host connects to the PHY, there
+is a series of UDEV messages. By filtering for these, it is possible for the
+software to roughly monitor the connection status of the USB gadget by
+polling a file `/sys/class/udc/<UDC name>/state`.
+
+There are some caveats to this setup:
+- The UDEV messages to not strictly correlate with the connection status.
+Therefore, it's important to also periodically poll the connection if there
+haven't been any new messages. This is possibly only an issue for messages
+when a new host is connected.
+- Serial ports will sometimes signal readiness with the POSIX Select after
+they have been disconnected but before the UDEV messages start to appear.
+In that case, it is important to check for an OSError on the port while
+reading new data.
 
 """
 import pyudev  # type: ignore[import]

--- a/usb-bridge/ot3usb/src/usb_monitor.py
+++ b/usb-bridge/ot3usb/src/usb_monitor.py
@@ -74,7 +74,7 @@ class USBConnectionMonitor:
         """
         if not self._monitor.started:
             # Check the `state` file to get an initial state setting
-            LOG.info(f"Monitoring platform/{self._phy_udev_name}")
+            LOG.debug(f"Monitoring platform/{self._phy_udev_name}")
             self._monitor.start()
             self._host_connected = self._read_state()
 
@@ -99,9 +99,10 @@ class USBConnectionMonitor:
     def _read_state(self) -> bool:
         fp = os.path.join(self._udc_folder, "state")
         try:
-            state = open(fp, mode="r").read()
-            LOG.debug(f"state={state}")
-            return state.startswith("configured")  # or state.startswith('suspended')
+            with open(fp, mode="r") as statefile:
+                state = statefile.read()
+                LOG.debug(f"state={state}")
+                return state.startswith("configured")
         except Exception:
             return False
 

--- a/usb-bridge/ot3usb/src/usb_monitor.py
+++ b/usb-bridge/ot3usb/src/usb_monitor.py
@@ -1,40 +1,83 @@
-import pyudev
+"""Provides functionality to monitor for usb host connectivity.
+
+When a usb serial gadget is configured, a tty handle is created by udev
+immediately and it remains in the filesystem indefinitely. This makes it
+impossible to distinguish the presence of a serial port directly; instead,
+this module hooks into the udev message stream on the system to check for
+
+"""
+import pyudev  # type: ignore[import]
 import logging
 
 LOG = logging.getLogger(__name__)
+
+# We only poll if select() indicated readiness, so timeout can be extremely
+# short without danger.
+POLL_TIMEOUT = 0.001
+
+CHARGER_STATE_TAG = "USB_CHARGER_STATE"
+
 
 class USBConnectionMonitor:
     """Class to monitor host connections over the USB Serial line."""
 
     def __init__(self, phy_udev_name: str, udc_name: str) -> None:
         """Initialize a USBConnectionMonitor.
-        
+
         Args:
-            phy_udev_name: The name of the USB PHY on the system, 
+            phy_udev_name: The name of the USB PHY on the system,
             the name below 'platform' for monitoring udev
-            
+
             udc_name: The name of the UDC hardware, for checking connection state manually
         """
         self._phy_udev_name = phy_udev_name
-        self._udc_name = udc_name 
+        self._udc_name = udc_name
 
         self._udev_ctx = pyudev.Context()
-        
 
         self._monitor = pyudev.Monitor.from_netlink(self._udev_ctx)
-        self._monitor.filter_by('platform')
+        self._monitor.filter_by("platform")
+        # For matching the name of the driver
+        self._monitor.filter_by_tag("OF_NAME")
+        # We only care about USB_CHARGER_STATE updates
+        self._monitor.filter_by_tag(CHARGER_STATE_TAG)
+        self._monitor.start()
+        LOG.info(f"Monitoring platform/{phy_udev_name}")
 
-        self._observer = pyudev.MonitorObserver(
-            self._monitor, self.monitor_callback)
-        
-        LOG.info(f'Monitoring platform/{phy_udev_name}')
-        
-    
-    def begin(self):
-        self._observer.start()
-    
-    def stop(self):
-        self._observer.stop()
+        self._host_connected = False
 
-    def monitor_callback(self, action, device):
-        print(f'ACTION: {action} - {device}')
+    def fileno(self) -> int:
+        """Returns a selectable fileno for the udev message stream."""
+        return int(self._monitor.fileno())
+
+    def begin(self) -> None:
+        """Start monitoring the udev stream.
+
+        If the monitoring hasn't been started yet, this function will also
+        check the file `state` in the UDC system folder to determine if the
+        device is initially connected to a host or not; this is necessary due
+        to the fact that udev messages regarding connection are only sent when
+        the state changes.
+        """
+        if not self._monitor.started():
+            # Check the `state` file to get an initial state setting
+            self._monitor.start()
+
+    def host_connected(self) -> bool:
+        """Return whether the most recent status indicates a host connection."""
+        return self._host_connected
+
+    def read_message(self) -> None:
+        """Reads the next available udev message."""
+        res = self._monitor.poll(POLL_TIMEOUT)
+        if res:
+            # Filter by the name tag
+            if res.get("OF_NAME") == self._phy_udev_name:
+                # Update internal status
+                self._host_connected = (
+                    res.get(CHARGER_STATE_TAG) != "USB_CHARGER_ABSENT"
+                )
+
+    def _read_state(self) -> bool:
+        """TODO."""
+        return False

--- a/usb-bridge/ot3usb/src/usb_monitor.py
+++ b/usb-bridge/ot3usb/src/usb_monitor.py
@@ -1,0 +1,40 @@
+import pyudev
+import logging
+
+LOG = logging.getLogger(__name__)
+
+class USBConnectionMonitor:
+    """Class to monitor host connections over the USB Serial line."""
+
+    def __init__(self, phy_udev_name: str, udc_name: str) -> None:
+        """Initialize a USBConnectionMonitor.
+        
+        Args:
+            phy_udev_name: The name of the USB PHY on the system, 
+            the name below 'platform' for monitoring udev
+            
+            udc_name: The name of the UDC hardware, for checking connection state manually
+        """
+        self._phy_udev_name = phy_udev_name
+        self._udc_name = udc_name 
+
+        self._udev_ctx = pyudev.Context()
+        
+
+        self._monitor = pyudev.Monitor.from_netlink(self._udev_ctx)
+        self._monitor.filter_by('platform')
+
+        self._observer = pyudev.MonitorObserver(
+            self._monitor, self.monitor_callback)
+        
+        LOG.info(f'Monitoring platform/{phy_udev_name}')
+        
+    
+    def begin(self):
+        self._observer.start()
+    
+    def stop(self):
+        self._observer.stop()
+
+    def monitor_callback(self, action, device):
+        print(f'ACTION: {action} - {device}')

--- a/usb-bridge/tests/test_usb_config.py
+++ b/usb-bridge/tests/test_usb_config.py
@@ -30,6 +30,12 @@ def write_file_mock(contents: str, filename: str) -> bool:
     return True
 
 
+def write_file_mock_err_on_udc(contents: str, filename: str) -> bool:
+    if filename == "UDC":
+        raise Exception("failed to write")
+    return True
+
+
 def test_serial_gadget_failure(
     subject: usb_config.SerialGadget,
     os_driver: mock.Mock,
@@ -44,6 +50,18 @@ def test_serial_gadget_failure(
 
     # If UDC seems to not exist AND we can't make it, expect exception
     os_driver.exists.return_value = False
+    with pytest.raises(Exception):
+        subject.configure_and_activate()
+
+    # If os driver returns an empty symlink directory, should throw an error
+    os_driver.exists.return_value = True
+    os_driver.listdir.return_value = []
+    with pytest.raises(Exception):
+        subject.configure_and_activate()
+
+    # If os driver fails to write to the UDC, should get an exception
+    os_driver.listdir.return_value = [UDC_HANDLE_NAME]
+    monkeypatch.setattr(subject, "_write_file", write_file_mock_err_on_udc)
     with pytest.raises(Exception):
         subject.configure_and_activate()
 
@@ -140,6 +158,10 @@ def test_get_serial_handle_path(
     # Test success
     port_num_path.write_text("0")
     assert subject._get_handle_path() == "/dev/ttyGS0"
+    # Test error with an empty file
+    port_num_path.write_text("")
+    with pytest.raises(Exception):
+        subject._get_handle_path()
 
 
 def test_serial_handle(
@@ -161,3 +183,20 @@ def test_serial_handle(
     assert not subject.handle_exists()
     dummy_handle.write_text("existence")
     assert subject.handle_exists()
+
+    def mocked_exists(path: str) -> bool:
+        raise OSError("Fake Exception")
+
+    # Use mocked method to test exception handling
+    os_driver.exists = mocked_exists
+    assert not subject.handle_exists()
+
+
+def test_get_udc_folder(subject: usb_config.SerialGadget) -> None:
+    # Calling uninitialized
+    subject._udc_name = None
+    with pytest.raises(Exception):
+        subject.udc_folder()
+    subject._udc_name = "fake_name"
+    expected = usb_config.UDC_HANDLE_FOLDER + "fake_name"
+    assert subject.udc_folder() == expected

--- a/usb-bridge/tests/test_usb_monitor.py
+++ b/usb-bridge/tests/test_usb_monitor.py
@@ -1,0 +1,115 @@
+"""Tests for the usb_monitor module."""
+
+import pytest
+import mock
+from pathlib import Path
+import os
+import pyudev  # type: ignore[import]
+from ot3usb.src import usb_monitor
+
+TEST_PHY_NAME = "usbphy123"
+
+
+@pytest.fixture
+def udev_monitor() -> mock.Mock:
+    monitor = mock.Mock(spec=pyudev.Monitor)
+    return monitor
+
+
+@pytest.fixture
+def udc_folder(tmpdir: Path) -> str:
+    with open(os.path.join(tmpdir, "state"), "w") as state:
+        state.write("not connected")
+    return str(tmpdir)
+
+
+@pytest.fixture
+def subject(
+    udc_folder: str, udev_monitor: mock.Mock
+) -> usb_monitor.USBConnectionMonitor:
+    return usb_monitor.USBConnectionMonitor(
+        phy_udev_name=TEST_PHY_NAME, udc_folder=udc_folder, monitor=udev_monitor
+    )
+
+
+def test_monitor_fileno(
+    subject: usb_monitor.USBConnectionMonitor, udev_monitor: mock.Mock
+) -> None:
+    udev_monitor.fileno.return_value = 123
+    assert subject.fileno() == 123
+
+
+def test_monitor_host_connected(subject: usb_monitor.USBConnectionMonitor) -> None:
+    subject._host_connected = True
+    assert subject.host_connected()
+    subject._host_connected = False
+    assert not subject.host_connected()
+
+
+def test_read_state(subject: usb_monitor.USBConnectionMonitor, udc_folder: str) -> None:
+    statefile = os.path.join(udc_folder, "state")
+    # First test with the UDC not initialized
+    with open(statefile, "w") as state:
+        state.write("not connected")
+    subject.update_state()
+    assert not subject.host_connected()
+    # Now test with the UDC initialized
+    with open(statefile, "w") as state:
+        state.write("configured")
+    subject.update_state()
+    assert subject.host_connected()
+    # Now test with the UDC file deleted - should not raise an exception
+    os.remove(statefile)
+    subject.update_state()
+    assert not subject.host_connected()
+
+
+def test_monitor_begin(
+    subject: usb_monitor.USBConnectionMonitor, udev_monitor: mock.Mock
+) -> None:
+    udev_monitor.started = False
+    subject.begin()
+    udev_monitor.start.assert_called_once()
+    assert not subject._host_connected
+
+    udev_monitor.reset_mock()
+
+
+def test_read_message(
+    subject: usb_monitor.USBConnectionMonitor, udev_monitor: mock.Mock, udc_folder: str
+) -> None:
+    # Set up test with statefile showing no connection
+    statefile = os.path.join(udc_folder, "state")
+
+    # First test with the UDC not initialized
+    with open(statefile, "w") as state:
+        state.write("not connected")
+    # Test getting no message - should fail silently
+    udev_monitor.poll.return_value = None
+    subject.read_message()
+    udev_monitor.poll.assert_called_once()
+
+    # Test getting a good message without matching name
+    udev_monitor.reset_mock()
+    subject._host_connected = True
+    udev_monitor.poll.return_value = {usb_monitor.NAME_TAG: "name123"}
+    subject.read_message()
+    udev_monitor.poll.assert_called_once()
+    assert subject._host_connected
+
+    # Now test getting a good message WITH matching name. Subject should poll.
+    udev_monitor.reset_mock()
+    subject._host_connected = True
+    udev_monitor.poll.return_value = {usb_monitor.NAME_TAG: TEST_PHY_NAME}
+    subject.read_message()
+    udev_monitor.poll.assert_called_once()
+    assert not subject._host_connected
+
+    # Finally, test with getting an event without the name tag. Should filter
+    # out the message.
+    udev_monitor.reset_mock()
+    subject._host_connected = True
+    udev_monitor.poll.return_value = {usb_monitor.NAME_TAG + "abcdef": TEST_PHY_NAME}
+    subject.read_message()
+    udev_monitor.poll.assert_called_once()
+    assert subject._host_connected


### PR DESCRIPTION
# Overview

Adds a usb_monitor module to watch the connection status of the USB Serial Gadget on the OT3. The USB Bridge uses the `select` syscall to monitor both a stream of UDEV messages and a (sometimes absent) serial port. If the UDEV stream indicates changes to the usb phy on the system, the monitor unfortunately needs to poll a file `state` in the sysfs UDC folder in order to discern whether there is a USB host connected or not. Some discussion of this setup exists in the Kernel mailing list [here](https://lore.kernel.org/lkml/20130717163548.GA14999@kroah.com/T/). The tl;dr is that there is not an event emitted for state change, it is only exported to sysfs.

Testing on device shows that there are some cases where the Udev messages on connection come before the UDC is actually configured with the host - this is especially prevalent when the robot is plugged into an unpowered usb hug which is then plugged into a computer. To deal with this, the `select` call is given a timeout of a second. In the case that no IO devices are ready to read, the program will poll the `state` file to check whether the UDC is configured.

Testing shows that, when unplugging the USB, there is a chance that the OS will report the serial port FD as ready to read when it is actually unavailable. As such, there is some handling for an OS exception when attempting to read the serial port; in this case, the `state` file is polled and updated.

Tested on a robot by plugging/unplugging USB repeatedly, and writing data over the USB serial connection and verifying that the robot echos it back.

# Changelog

- added `usb_monitor.py` to check for connections/disconnections on the usb device port
- added a `select` polling system to check for I/O availability on the serial port and the udev message stream
- edited the PID/VID to match the Toradex defaults
- added serial echo
- added more extensive test coverage for `usb_config`
- added `pyudev` package to monitor udev messages

# Review requests

- Does it still make sense to be monitoring udev here? I like that it is usually able to catch connections/disconnections very quickly, but since we need the polling too it adds a bit of complexity. Based on my testing, we can get the same functionality by:
  - When USB is disconnected, just poll the `state` file periodically
  - Once we're connected, you can detect a disconnection through the `OSError` when the serial port disconnects

# Risk assessment

Low, this code is all pre-production.