### PR TITLE
refactor(app): remove GEN3 pipette card menu options

### DIFF
--- a/app/src/organisms/Devices/PipetteCard/AboutPipetteSlideout.tsx
+++ b/app/src/organisms/Devices/PipetteCard/AboutPipetteSlideout.tsx
@@ -36,6 +36,7 @@ export const AboutPipetteSlideout = (
         <PrimaryButton
           onClick={onCloseClick}
           width="100%"
+          textTransform={TYPOGRAPHY.textTransformCapitalize}
           data-testid="AboutPipette_slideout_close"
         >
           {t('shared:close')}

--- a/app/src/organisms/Devices/PipetteCard/PipetteOverflowMenu.tsx
+++ b/app/src/organisms/Devices/PipetteCard/PipetteOverflowMenu.tsx
@@ -19,8 +19,7 @@ import {
 import type { Mount } from '../../../redux/pipettes/types'
 
 interface PipetteOverflowMenuProps {
-  pipetteDisplayName: PipetteModelSpecs['displayName'] | string
-  pipetteName: PipetteModelSpecs['name'] | string
+  pipetteSpecs: PipetteModelSpecs | null
   mount: Mount
   handleChangePipette: () => void
   handleCalibrate: () => void
@@ -35,8 +34,7 @@ export const PipetteOverflowMenu = (
   const { t } = useTranslation('device_details')
   const {
     mount,
-    pipetteDisplayName,
-    pipetteName,
+    pipetteSpecs,
     handleChangePipette,
     handleCalibrate,
     handleAboutSlideout,
@@ -44,6 +42,10 @@ export const PipetteOverflowMenu = (
     isPipetteCalibrated,
   } = props
 
+  const pipetteName =
+    pipetteSpecs?.name != null ? pipetteSpecs.name : t('empty')
+  const pipetteDisplayName =
+    pipetteSpecs?.displayName != null ? pipetteSpecs.displayName : t('empty')
   const isOT3PipetteAttached = isOT3Pipette(pipetteName as PipetteName)
 
   return (

--- a/app/src/organisms/Devices/PipetteCard/PipetteOverflowMenu.tsx
+++ b/app/src/organisms/Devices/PipetteCard/PipetteOverflowMenu.tsx
@@ -11,11 +11,16 @@ import {
 import { MenuItem } from '../../../atoms/MenuList/MenuItem'
 import { Divider } from '../../../atoms/structure'
 
-import type { PipetteModelSpecs } from '@opentrons/shared-data'
+import {
+  isOT3Pipette,
+  PipetteModelSpecs,
+  PipetteName,
+} from '@opentrons/shared-data'
 import type { Mount } from '../../../redux/pipettes/types'
 
 interface PipetteOverflowMenuProps {
-  pipetteName: PipetteModelSpecs['displayName'] | string
+  pipetteDisplayName: PipetteModelSpecs['displayName'] | string
+  pipetteName: PipetteModelSpecs['name'] | string
   mount: Mount
   handleChangePipette: () => void
   handleCalibrate: () => void
@@ -30,6 +35,7 @@ export const PipetteOverflowMenu = (
   const { t } = useTranslation('device_details')
   const {
     mount,
+    pipetteDisplayName,
     pipetteName,
     handleChangePipette,
     handleCalibrate,
@@ -37,6 +43,8 @@ export const PipetteOverflowMenu = (
     handleSettingsSlideout,
     isPipetteCalibrated,
   } = props
+
+  const isOT3PipetteAttached = isOT3Pipette(pipetteName as PipetteName)
 
   return (
     <Flex position={POSITION_RELATIVE}>
@@ -51,49 +59,55 @@ export const PipetteOverflowMenu = (
         right={`calc(50% + ${SPACING.spacing2})`}
         flexDirection={DIRECTION_COLUMN}
       >
-        {pipetteName === 'Empty' ? (
+        {pipetteDisplayName === 'Empty' ? (
           <MenuItem
-            key={`${pipetteName}_${mount}_attach_pipette`}
+            key={`${pipetteDisplayName}_${mount}_attach_pipette`}
             onClick={() => handleChangePipette()}
-            data-testid={`pipetteOverflowMenu_attach_pipette_btn_${pipetteName}_${mount}`}
+            data-testid={`pipetteOverflowMenu_attach_pipette_btn_${pipetteDisplayName}_${mount}`}
           >
             {t('attach_pipette')}
           </MenuItem>
         ) : (
           <>
+            {!isOT3PipetteAttached && (
+              <MenuItem
+                key={`${pipetteDisplayName}_${mount}_calibrate_offset`}
+                onClick={() => handleCalibrate()}
+                data-testid={`pipetteOverflowMenu_calibrate_offset_btn_${pipetteDisplayName}_${mount}`}
+              >
+                {t(
+                  isPipetteCalibrated
+                    ? 'recalibrate_pipette_offset'
+                    : 'calibrate_pipette_offset'
+                )}
+              </MenuItem>
+            )}
+            {!isOT3PipetteAttached && (
+              <MenuItem
+                key={`${pipetteDisplayName}_${mount}_detach`}
+                onClick={() => handleChangePipette()}
+                data-testid={`pipetteOverflowMenu_detach_pipette_btn_${pipetteDisplayName}_${mount}`}
+              >
+                {t('detach_pipette')}
+              </MenuItem>
+            )}
             <MenuItem
-              key={`${pipetteName}_${mount}_calibrate_offset`}
-              onClick={() => handleCalibrate()}
-              data-testid={`pipetteOverflowMenu_calibrate_offset_btn_${pipetteName}_${mount}`}
-            >
-              {t(
-                isPipetteCalibrated
-                  ? 'recalibrate_pipette_offset'
-                  : 'calibrate_pipette_offset'
-              )}
-            </MenuItem>
-            <MenuItem
-              key={`${pipetteName}_${mount}_detach`}
-              onClick={() => handleChangePipette()}
-              data-testid={`pipetteOverflowMenu_detach_pipette_btn_${pipetteName}_${mount}`}
-            >
-              {t('detach_pipette')}
-            </MenuItem>
-            <MenuItem
-              key={`${pipetteName}_${mount}_about_pipette`}
+              key={`${pipetteDisplayName}_${mount}_about_pipette`}
               onClick={() => handleAboutSlideout()}
-              data-testid={`pipetteOverflowMenu_about_pipette_slideout_btn_${pipetteName}_${mount}`}
+              data-testid={`pipetteOverflowMenu_about_pipette_slideout_btn_${pipetteDisplayName}_${mount}`}
             >
               {t('about_pipette')}
             </MenuItem>
             <Divider marginY="0" />
-            <MenuItem
-              key={`${pipetteName}_${mount}_view_settings`}
-              onClick={() => handleSettingsSlideout()}
-              data-testid={`pipetteOverflowMenu_view_settings_btn_${pipetteName}_${mount}`}
-            >
-              {t('view_pipette_setting')}
-            </MenuItem>
+            {!isOT3PipetteAttached && (
+              <MenuItem
+                key={`${pipetteDisplayName}_${mount}_view_settings`}
+                onClick={() => handleSettingsSlideout()}
+                data-testid={`pipetteOverflowMenu_view_settings_btn_${pipetteDisplayName}_${mount}`}
+              >
+                {t('view_pipette_setting')}
+              </MenuItem>
+            )}
           </>
         )}
       </Flex>

--- a/app/src/organisms/Devices/PipetteCard/__tests__/PipetteOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/PipetteCard/__tests__/PipetteOverflowMenu.test.tsx
@@ -33,8 +33,7 @@ describe('PipetteOverflowMenu', () => {
 
   beforeEach(() => {
     props = {
-      pipetteDisplayName: mockLeftProtoPipette.displayName,
-      pipetteName: mockLeftProtoPipette.name,
+      pipetteSpecs: mockLeftProtoPipette.modelSpecs,
       mount: LEFT,
       handleChangePipette: jest.fn(),
       handleCalibrate: jest.fn(),
@@ -65,8 +64,7 @@ describe('PipetteOverflowMenu', () => {
   })
   it('renders information with no pipette attached', () => {
     props = {
-      pipetteDisplayName: 'Empty',
-      pipetteName: 'Empty',
+      pipetteSpecs: null,
       mount: LEFT,
       handleChangePipette: jest.fn(),
       handleCalibrate: jest.fn(),
@@ -81,8 +79,7 @@ describe('PipetteOverflowMenu', () => {
   })
   it('renders recalibrate pipette offset text', () => {
     props = {
-      pipetteDisplayName: mockLeftProtoPipette.displayName,
-      pipetteName: mockLeftProtoPipette.name,
+      pipetteSpecs: mockLeftProtoPipette.modelSpecs,
       mount: LEFT,
       handleChangePipette: jest.fn(),
       handleCalibrate: jest.fn(),

--- a/app/src/organisms/Devices/PipetteCard/__tests__/PipetteOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/PipetteCard/__tests__/PipetteOverflowMenu.test.tsx
@@ -5,8 +5,21 @@ import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../../i18n'
 import { PipetteOverflowMenu } from '../PipetteOverflowMenu'
 import { mockLeftProtoPipette } from '../../../../redux/pipettes/__fixtures__'
+import { isOT3Pipette } from '@opentrons/shared-data'
 
 import type { Mount } from '../../../../redux/pipettes/types'
+
+jest.mock('@opentrons/shared-data', () => {
+  const actualSharedData = jest.requireActual('@opentrons/shared-data')
+  return {
+    ...actualSharedData,
+    isOT3Pipette: jest.fn(),
+  }
+})
+
+const mockIsOT3Pipette = isOT3Pipette as jest.MockedFunction<
+  typeof isOT3Pipette
+>
 
 const render = (props: React.ComponentProps<typeof PipetteOverflowMenu>) => {
   return renderWithProviders(<PipetteOverflowMenu {...props} />, {
@@ -20,7 +33,8 @@ describe('PipetteOverflowMenu', () => {
 
   beforeEach(() => {
     props = {
-      pipetteName: mockLeftProtoPipette.displayName,
+      pipetteDisplayName: mockLeftProtoPipette.displayName,
+      pipetteName: mockLeftProtoPipette.name,
       mount: LEFT,
       handleChangePipette: jest.fn(),
       handleCalibrate: jest.fn(),
@@ -51,6 +65,7 @@ describe('PipetteOverflowMenu', () => {
   })
   it('renders information with no pipette attached', () => {
     props = {
+      pipetteDisplayName: 'Empty',
       pipetteName: 'Empty',
       mount: LEFT,
       handleChangePipette: jest.fn(),
@@ -66,7 +81,8 @@ describe('PipetteOverflowMenu', () => {
   })
   it('renders recalibrate pipette offset text', () => {
     props = {
-      pipetteName: mockLeftProtoPipette.displayName,
+      pipetteDisplayName: mockLeftProtoPipette.displayName,
+      pipetteName: mockLeftProtoPipette.name,
       mount: LEFT,
       handleChangePipette: jest.fn(),
       handleCalibrate: jest.fn(),
@@ -80,5 +96,24 @@ describe('PipetteOverflowMenu', () => {
     })
     fireEvent.click(recalibrate)
     expect(props.handleCalibrate).toHaveBeenCalled()
+  })
+
+  it('renders only the about pipette button if OT-3/GEN3 pipette is attached', () => {
+    mockIsOT3Pipette.mockReturnValue(true)
+
+    const { getByRole, queryByRole } = render(props)
+
+    const calibrate = queryByRole('button', {
+      name: 'Calibrate pipette offset',
+    })
+    const detach = queryByRole('button', { name: 'Detach pipette' })
+    const settings = queryByRole('button', { name: 'Pipette Settings' })
+    const about = getByRole('button', { name: 'About pipette' })
+
+    expect(calibrate).toBeNull()
+    expect(detach).toBeNull()
+    expect(settings).toBeNull()
+    fireEvent.click(about)
+    expect(props.handleAboutSlideout).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -43,7 +43,11 @@ import { PipetteSettingsSlideout } from './PipetteSettingsSlideout'
 import { AboutPipetteSlideout } from './AboutPipetteSlideout'
 
 import type { AttachedPipette, Mount } from '../../../redux/pipettes/types'
-import type { PipetteModelSpecs } from '@opentrons/shared-data'
+import {
+  isOT3Pipette,
+  PipetteModelSpecs,
+  PipetteName,
+} from '@opentrons/shared-data'
 import type { Dispatch, State } from '../../../redux/types'
 
 interface PipetteCardProps {
@@ -66,7 +70,8 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
   } = useMenuHandleClickOutside()
   const dispatch = useDispatch<Dispatch>()
   const [dispatchRequest, requestIds] = useDispatchApiRequest()
-  const pipetteName = pipetteInfo?.displayName
+  const pipetteName = pipetteInfo?.name
+  const pipetteDisplayName = pipetteInfo?.displayName
   const pipetteOverflowWrapperRef = useOnClickOutside<HTMLDivElement>({
     onClickOutside: () => setShowOverflowMenu(false),
   })
@@ -149,7 +154,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
       borderRadius={BORDERS.radiusSoftCorners}
       marginBottom={SPACING.spacing3}
       width="100%"
-      data-testid={`PipetteCard_${pipetteName}`}
+      data-testid={`PipetteCard_${pipetteDisplayName}`}
     >
       {showChangePipette && (
         <ChangePipette
@@ -224,7 +229,8 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
             pipetteOffsetCalibration == null &&
             pipetteInfo != null &&
             showBanner &&
-            !isFetching ? (
+            !isFetching &&
+            !isOT3Pipette(pipetteName as PipetteName) ? (
               <Flex paddingBottom={SPACING.spacing2}>
                 <Banner
                   type="error"
@@ -272,7 +278,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
               fontWeight={FONT_WEIGHT_REGULAR}
               fontSize={TYPOGRAPHY.fontSizeCaption}
               paddingBottom={SPACING.spacing2}
-              data-testid={`PipetteCard_mount_${pipetteName}`}
+              data-testid={`PipetteCard_mount_${pipetteDisplayName}`}
             >
               {t('mount', {
                 side: mount === LEFT ? t('left') : t('right'),
@@ -280,10 +286,10 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
             </StyledText>
             <Flex
               paddingBottom={SPACING.spacing2}
-              data-testid={`PipetteCard_display_name_${pipetteName}`}
+              data-testid={`PipetteCard_display_name_${pipetteDisplayName}`}
             >
               <StyledText fontSize={TYPOGRAPHY.fontSizeP}>
-                {pipetteName ?? t('empty')}
+                {pipetteDisplayName ?? t('empty')}
               </StyledText>
             </Flex>
           </Flex>
@@ -292,7 +298,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
       <Box
         alignSelf={ALIGN_START}
         padding={SPACING.spacing2}
-        data-testid={`PipetteCard_overflow_btn_${pipetteName}`}
+        data-testid={`PipetteCard_overflow_btn_${pipetteDisplayName}`}
       >
         <OverflowBtn aria-label="overflow" onClick={handleOverflowClick} />
       </Box>
@@ -300,10 +306,11 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
         <>
           <Box
             ref={pipetteOverflowWrapperRef}
-            data-testid={`PipetteCard_overflow_menu_${pipetteName}`}
+            data-testid={`PipetteCard_overflow_menu_${pipetteDisplayName}`}
             onClick={() => setShowOverflowMenu(false)}
           >
             <PipetteOverflowMenu
+              pipetteDisplayName={pipetteDisplayName ?? t('empty')}
               pipetteName={pipetteName ?? t('empty')}
               mount={mount}
               handleChangePipette={handleChangePipette}

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -310,8 +310,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
             onClick={() => setShowOverflowMenu(false)}
           >
             <PipetteOverflowMenu
-              pipetteDisplayName={pipetteDisplayName ?? t('empty')}
-              pipetteName={pipetteName ?? t('empty')}
+              pipetteSpecs={pipetteInfo}
               mount={mount}
               handleChangePipette={handleChangePipette}
               handleCalibrate={handleCalibrate}

--- a/shared-data/js/constants.ts
+++ b/shared-data/js/constants.ts
@@ -40,6 +40,7 @@ export const HEATERSHAKER_MODULE_V1: 'heaterShakerModuleV1' =
   'heaterShakerModuleV1'
 
 // pipette display categories
+export const GEN3: 'GEN3' = 'GEN3'
 export const GEN2: 'GEN2' = 'GEN2'
 export const GEN1: 'GEN1' = 'GEN1'
 

--- a/shared-data/js/pipettes.ts
+++ b/shared-data/js/pipettes.ts
@@ -1,5 +1,6 @@
 import pipetteNameSpecs from '../pipette/definitions/pipetteNameSpecs.json'
 import pipetteModelSpecs from '../pipette/definitions/pipetteModelSpecs.json'
+import { OT3_PIPETTES } from './constants'
 
 import type { PipetteNameSpecs, PipetteModelSpecs } from './types'
 
@@ -63,4 +64,11 @@ function comparePipettes(sortBy: SortableProps[]) {
 
 export function shouldLevel(specs: PipetteNameSpecs): boolean {
   return specs.displayCategory === 'GEN2' && specs.channels === 8
+}
+
+export function isOT3Pipette(pipetteName: PipetteName): boolean {
+  return (
+    OT3_PIPETTES.includes(pipetteName) ||
+    getPipetteNameSpecs(pipetteName)?.displayCategory === 'GEN3'
+  )
 }

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -15,6 +15,7 @@ import {
   HEATERSHAKER_MODULE_TYPE,
   GEN1,
   GEN2,
+  GEN3,
   LEFT,
   RIGHT,
 } from './constants'
@@ -336,7 +337,7 @@ export type ModuleOrientation = 'left' | 'right'
 
 export type PipetteChannels = 1 | 8
 
-export type PipetteDisplayCategory = typeof GEN1 | typeof GEN2
+export type PipetteDisplayCategory = typeof GEN1 | typeof GEN2 | typeof GEN3
 
 export type PipetteMount = typeof LEFT | typeof RIGHT
 

--- a/shared-data/pipette/definitions/pipetteNameSpecs.json
+++ b/shared-data/pipette/definitions/pipetteNameSpecs.json
@@ -458,7 +458,7 @@
   },
   "p50_single_gen3": {
     "displayName": "P50 Single-Channel GEN3",
-    "displayCategory": "GEN2",
+    "displayCategory": "GEN3",
     "defaultAspirateFlowRate": {
       "value": 7.85,
       "min": 3,
@@ -498,7 +498,7 @@
   },
   "p1000_single_gen3": {
     "displayName": "P1000 Single-Channel GEN3",
-    "displayCategory": "GEN2",
+    "displayCategory": "GEN3",
     "defaultAspirateFlowRate": {
       "value": 137.35,
       "min": 3,
@@ -542,7 +542,7 @@
   },
   "p1000_multi_gen3": {
     "displayName": "P1000 8-Channel GEN3",
-    "displayCategory": "GEN2",
+    "displayCategory": "GEN3",
     "defaultAspirateFlowRate": {
       "value": 137.35,
       "min": 3,
@@ -584,7 +584,7 @@
   },
   "p50_multi_gen3": {
     "displayName": "P50 8-Channel GEN3",
-    "displayCategory": "GEN2",
+    "displayCategory": "GEN3",
     "defaultAspirateFlowRate": {
       "value": 7.85,
       "min": 3,

--- a/shared-data/pipette/schemas/pipetteNameSpecsSchema.json
+++ b/shared-data/pipette/schemas/pipetteNameSpecsSchema.json
@@ -11,7 +11,7 @@
     },
     "displayCategory": {
       "type": "string",
-      "enum": ["GEN1", "GEN2"]
+      "enum": ["GEN1", "GEN2", "GEN3"]
     },
     "valuesByApiLevel": {
       "type": "object",

--- a/shared-data/python/opentrons_shared_data/pipette/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/pipette/dev_types.py
@@ -61,7 +61,7 @@ class PipetteNameType(str, Enum):
 # a huge number of them
 PipetteModel = NewType("PipetteModel", str)
 
-DisplayCategory = Literal["GEN1", "GEN2"]
+DisplayCategory = Literal["GEN1", "GEN2", "GEN3"]
 
 # todo(mm, 2022-03-18):
 # The JSON schema defines this as any string, not as an enum of string literals.


### PR DESCRIPTION

# Overview

This PR removes menu options from the GEN3 pipette cards until new flows are created. closes RLIQ-187

![image](https://user-images.githubusercontent.com/14794021/193847940-3ac954ab-6ac1-4f5c-90df-8f7890291cfc.png)


# Changelog

- Add utility to check if pipette is an OT-3 pipette
- Hide pipette offset calibration banner if OT-3 pipette
- GEN3 Pipette cards only have About pipette menu item
- Updated pipette overflow menu tests

# Review requests

1. Add a GEN3 pipette to the robot server by updating `test.json`
2. Check that all menu options except `About pipette` is hidden for GEN3 pipettes. The pipette offset calibration banner for GEN3 should also be hidden.
3. Menu options and pipette offset calibration banners for GEN1 and GEN2 should remain the the same.

# Risk assessment
low