### PR TITLE
build(labware-library): downgrade ubuntu so static rendering does not error

### DIFF
--- a/.github/workflows/ll-test-build-deploy.yaml
+++ b/.github/workflows/ll-test-build-deploy.yaml
@@ -40,7 +40,7 @@ jobs:
   js-unit-test:
     name: 'labware library unit tests'
     timeout-minutes: 20
-    runs-on: 'ubuntu-22.04'
+    runs-on: 'ubuntu-20.04'
     steps:
       - uses: 'actions/checkout@v3'
       - uses: 'actions/setup-node@v3'
@@ -75,7 +75,7 @@ jobs:
     name: 'labware library e2e tests'
     needs: ['js-unit-test']
     timeout-minutes: 30
-    runs-on: 'ubuntu-22.04'
+    runs-on: 'ubuntu-20.04'
     steps:
       - uses: 'actions/checkout@v3'
       - uses: 'actions/setup-node@v3'
@@ -105,7 +105,7 @@ jobs:
   build-ll:
     name: 'build labware library artifact'
     needs: ['js-unit-test']
-    runs-on: 'ubuntu-22.04'
+    runs-on: 'ubuntu-20.04'
     if: github.event_name != 'pull_request'
     steps:
       - uses: 'actions/checkout@v3'
@@ -141,7 +141,7 @@ jobs:
           path: labware-library/dist
   deploy-ll:
     name: 'deploy LL artifact to S3'
-    runs-on: 'ubuntu-22.04'
+    runs-on: 'ubuntu-20.04'
     needs: ['js-unit-test', 'e2e-test', 'build-ll']
     if: github.event_name != 'pull_request'
     steps:


### PR DESCRIPTION
# Overview

Static rendering done by `react-snap` stopped working in CI for some reason. Downgrading runners from `ubuntu-22.04` to `ubuntu-20.04` seems to fix things, for reasons I do not understand.

# Changelog

- Downgrade LL gh workflow runner ubuntu version so static rendering does not fail


# Review requests

LL build step passes.

# Risk assessment

Low
