### PR TITLE
refactor(app, api-client): remove dependence on key/value structure for pipette key

### DIFF
--- a/api-client/src/protocols/__tests__/utils.test.ts
+++ b/api-client/src/protocols/__tests__/utils.test.ts
@@ -140,9 +140,7 @@ describe('parseInitialPipetteNamesByMount', () => {
 })
 describe('parseInitialPipetteNamesById', () => {
   it('returns pipette names by id if loaded', () => {
-    const expected = {
-      'pipette-0': { name: 'p300_single_gen2' },
-    }
+    const expected = [{ id: 'pipette-0', pipetteName: 'p300_single_gen2' }]
     expect(parseInitialPipetteNamesById(mockRunTimeCommands)).toEqual(expected)
   })
 })
@@ -209,16 +207,16 @@ describe('parseInitialLoadedLabwareById', () => {
   it('returns labware loaded by id', () => {
     const expected = {
       'labware-1': {
-        definitionId: 'opentrons/opentrons_96_tiprack_300ul/1_id',
+        definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
         displayName: 'Opentrons 96 Tip Rack 300 µL',
       },
       'labware-2': {
-        definitionId: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1_id',
+        definitionUri: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
         displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
       },
       'labware-3': {
-        definitionId:
-          'opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1_id',
+        definitionUri:
+          'opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1',
         displayName:
           'Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap',
       },
@@ -229,15 +227,15 @@ describe('parseInitialLoadedLabwareById', () => {
 describe('parseInitialLoadedLabwareDefinitionsById', () => {
   it('returns labware definitions loaded by id', () => {
     const expected = {
-      'opentrons/opentrons_96_tiprack_300ul/1_id': mockRunTimeCommands.find(
+      'opentrons/opentrons_96_tiprack_300ul/1': mockRunTimeCommands.find(
         c =>
           c.commandType === 'loadLabware' && c.result.labwareId === 'labware-1'
       )?.result.definition,
-      'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1_id': mockRunTimeCommands.find(
+      'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': mockRunTimeCommands.find(
         c =>
           c.commandType === 'loadLabware' && c.result.labwareId === 'labware-2'
       )?.result.definition,
-      'opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1_id': mockRunTimeCommands.find(
+      'opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1': mockRunTimeCommands.find(
         c =>
           c.commandType === 'loadLabware' && c.result.labwareId === 'labware-3'
       )?.result.definition,

--- a/api-client/src/protocols/__tests__/utils.test.ts
+++ b/api-client/src/protocols/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 import { RunTimeCommand } from '@opentrons/shared-data'
 import {
-  parseInitialPipetteNamesById,
+  parsePipetteEntity,
   parseInitialPipetteNamesByMount,
   parseAllRequiredModuleModels,
   parseAllRequiredModuleModelsById,
@@ -138,10 +138,10 @@ describe('parseInitialPipetteNamesByMount', () => {
     expect(parseInitialPipetteNamesByMount(onlyRightMount)).toEqual(expected)
   })
 })
-describe('parseInitialPipetteNamesById', () => {
+describe('parsePipetteEntity', () => {
   it('returns pipette names by id if loaded', () => {
     const expected = [{ id: 'pipette-0', pipetteName: 'p300_single_gen2' }]
-    expect(parseInitialPipetteNamesById(mockRunTimeCommands)).toEqual(expected)
+    expect(parsePipetteEntity(mockRunTimeCommands)).toEqual(expected)
   })
 })
 describe('parseAllRequiredModuleModels', () => {

--- a/api-client/src/protocols/utils.ts
+++ b/api-client/src/protocols/utils.ts
@@ -37,14 +37,14 @@ export function parseInitialPipetteNamesByMount(
   }
 }
 
-export interface PipetteEntity {
+export interface PipetteNamesById {
   id: string
   pipetteName: PipetteName
 }
 
 export function parsePipetteEntity(
   commands: RunTimeCommand[]
-): PipetteEntity[] {
+): PipetteNamesById[] {
   const rightPipette = commands.find(
     (command): command is LoadPipetteRunTimeCommand =>
       command.commandType === 'loadPipette' && command.params.mount === 'right'

--- a/api-client/src/protocols/utils.ts
+++ b/api-client/src/protocols/utils.ts
@@ -38,12 +38,13 @@ export function parseInitialPipetteNamesByMount(
 }
 
 export interface PipetteNamesById {
-  [pipetteId: string]: { pipetteName: PipetteName }
+  id: string
+  pipetteName: PipetteName
 }
 
 export function parseInitialPipetteNamesById(
   commands: RunTimeCommand[]
-): PipetteNamesById {
+): PipetteNamesById[] {
   const rightPipette = commands.find(
     (command): command is LoadPipetteRunTimeCommand =>
       command.commandType === 'loadPipette' && command.params.mount === 'right'
@@ -56,22 +57,26 @@ export function parseInitialPipetteNamesById(
   const rightPipetteById =
     rightPipette != null
       ? {
-          [rightPipette.result.pipetteId]: {
-            pipetteName: rightPipette.params.pipetteName,
-          },
+          id: rightPipette.result.pipetteId,
+          pipetteName: rightPipette.params.pipetteName,
         }
       : {}
   const leftPipetteById =
     leftPipette != null
       ? {
-          [leftPipette.result.pipetteId]: {
-            pipetteName: leftPipette.params.pipetteName,
-          },
+          id: leftPipette.result.pipetteId,
+          pipetteName: leftPipette.params.pipetteName,
         }
       : {}
-  return {
-    ...rightPipetteById,
-    ...leftPipetteById,
+
+  if (leftPipetteById.id == null && rightPipetteById.id != null) {
+    return [rightPipetteById]
+  } else if (rightPipetteById.id == null && leftPipetteById.id != null) {
+    return [leftPipetteById]
+  } else if (rightPipetteById.id != null && leftPipetteById.id != null) {
+    return [rightPipetteById, leftPipetteById]
+  } else {
+    return []
   }
 }
 

--- a/api-client/src/protocols/utils.ts
+++ b/api-client/src/protocols/utils.ts
@@ -37,14 +37,14 @@ export function parseInitialPipetteNamesByMount(
   }
 }
 
-export interface PipetteNamesById {
+export interface PipetteEntity {
   id: string
   pipetteName: PipetteName
 }
 
-export function parseInitialPipetteNamesById(
+export function parsePipetteEntity(
   commands: RunTimeCommand[]
-): PipetteNamesById[] {
+): PipetteEntity[] {
   const rightPipette = commands.find(
     (command): command is LoadPipetteRunTimeCommand =>
       command.commandType === 'loadPipette' && command.params.mount === 'right'
@@ -54,14 +54,14 @@ export function parseInitialPipetteNamesById(
       command.commandType === 'loadPipette' && command.params.mount === 'left'
   )
 
-  const rightPipetteById =
+  const rightPipetteEntity =
     rightPipette != null
       ? {
           id: rightPipette.result.pipetteId,
           pipetteName: rightPipette.params.pipetteName,
         }
       : {}
-  const leftPipetteById =
+  const leftPipetteEntity =
     leftPipette != null
       ? {
           id: leftPipette.result.pipetteId,
@@ -69,12 +69,12 @@ export function parseInitialPipetteNamesById(
         }
       : {}
 
-  if (leftPipetteById.id == null && rightPipetteById.id != null) {
-    return [rightPipetteById]
-  } else if (rightPipetteById.id == null && leftPipetteById.id != null) {
-    return [leftPipetteById]
-  } else if (rightPipetteById.id != null && leftPipetteById.id != null) {
-    return [rightPipetteById, leftPipetteById]
+  if (leftPipetteEntity.id == null && rightPipetteEntity.id != null) {
+    return [rightPipetteEntity]
+  } else if (rightPipetteEntity.id == null && leftPipetteEntity.id != null) {
+    return [leftPipetteEntity]
+  } else if (rightPipetteEntity.id != null && leftPipetteEntity.id != null) {
+    return [rightPipetteEntity, leftPipetteEntity]
   } else {
     return []
   }

--- a/app/src/organisms/Devices/hooks/__fixtures__/storedProtocolAnalysis.ts
+++ b/app/src/organisms/Devices/hooks/__fixtures__/storedProtocolAnalysis.ts
@@ -21,8 +21,9 @@ export const LABWARE_DEFINITIONS: LoadedLabwareDefinitionsById = {
 export const MODULE_MODELS_BY_ID: ModuleModelsById = {
   'module-0': { model: 'thermocyclerModuleV1' },
 }
-export const PIPETTE_NAMES_BY_ID: PipetteNamesById = {
-  'pipette-0': { pipetteName: 'p10_single' },
+export const PIPETTE_NAME_BY_ID: PipetteNamesById = {
+  id: 'pipette-0',
+  pipetteName: 'p10_single',
 }
 
 export const STORED_PROTOCOL_ANALYSIS = {
@@ -30,5 +31,5 @@ export const STORED_PROTOCOL_ANALYSIS = {
   modules: MODULE_MODELS_BY_ID,
   labware: LABWARE_BY_ID,
   labwareDefinitions: LABWARE_DEFINITIONS,
-  pipettes: PIPETTE_NAMES_BY_ID,
+  pipettes: [PIPETTE_NAME_BY_ID],
 } as StoredProtocolAnalysis

--- a/app/src/organisms/Devices/hooks/__fixtures__/storedProtocolAnalysis.ts
+++ b/app/src/organisms/Devices/hooks/__fixtures__/storedProtocolAnalysis.ts
@@ -4,7 +4,7 @@ import type {
   LoadedLabwareById,
   LoadedLabwareDefinitionsById,
   ModuleModelsById,
-  PipetteNamesById,
+  PipetteEntity,
 } from '@opentrons/api-client'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { StoredProtocolAnalysis } from '../useStoredProtocolAnalysis'
@@ -21,7 +21,7 @@ export const LABWARE_DEFINITIONS: LoadedLabwareDefinitionsById = {
 export const MODULE_MODELS_BY_ID: ModuleModelsById = {
   'module-0': { model: 'thermocyclerModuleV1' },
 }
-export const PIPETTE_NAME_BY_ID: PipetteNamesById = {
+export const PIPETTE: PipetteEntity = {
   id: 'pipette-0',
   pipetteName: 'p10_single',
 }
@@ -31,5 +31,5 @@ export const STORED_PROTOCOL_ANALYSIS = {
   modules: MODULE_MODELS_BY_ID,
   labware: LABWARE_BY_ID,
   labwareDefinitions: LABWARE_DEFINITIONS,
-  pipettes: [PIPETTE_NAME_BY_ID],
+  pipettes: [PIPETTE],
 } as StoredProtocolAnalysis

--- a/app/src/organisms/Devices/hooks/__fixtures__/storedProtocolAnalysis.ts
+++ b/app/src/organisms/Devices/hooks/__fixtures__/storedProtocolAnalysis.ts
@@ -4,7 +4,7 @@ import type {
   LoadedLabwareById,
   LoadedLabwareDefinitionsById,
   ModuleModelsById,
-  PipetteEntity,
+  PipetteNamesById,
 } from '@opentrons/api-client'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { StoredProtocolAnalysis } from '../useStoredProtocolAnalysis'
@@ -21,7 +21,7 @@ export const LABWARE_DEFINITIONS: LoadedLabwareDefinitionsById = {
 export const MODULE_MODELS_BY_ID: ModuleModelsById = {
   'module-0': { model: 'thermocyclerModuleV1' },
 }
-export const PIPETTE: PipetteEntity = {
+export const PIPETTE_NAME_BY_ID: PipetteNamesById = {
   id: 'pipette-0',
   pipetteName: 'p10_single',
 }
@@ -31,5 +31,5 @@ export const STORED_PROTOCOL_ANALYSIS = {
   modules: MODULE_MODELS_BY_ID,
   labware: LABWARE_BY_ID,
   labwareDefinitions: LABWARE_DEFINITIONS,
-  pipettes: [PIPETTE],
+  pipettes: [PIPETTE_NAME_BY_ID],
 } as StoredProtocolAnalysis

--- a/app/src/organisms/Devices/hooks/__tests__/useProtocolRunAnalyticsData.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useProtocolRunAnalyticsData.test.tsx
@@ -47,10 +47,10 @@ let store: Store<any> = createStore(jest.fn(), {})
 const RUN_ID = '1'
 const RUN_ID_2 = '2'
 
-const PIPETTES = {
-  left: { id: '1', pipetteName: 'testModelLeft' },
-  right: { id: '2', pipetteName: 'testModelRight' },
-}
+const PIPETTES = [
+  { id: '1', pipetteName: 'testModelLeft' },
+  { id: '2', pipetteName: 'testModelRight' },
+]
 const FORMATTED_PIPETTES = 'testModelLeft,testModelRight'
 const MODULES = {
   module1: { model: 'module1' },

--- a/app/src/organisms/Devices/hooks/__tests__/useRunPipetteInfoByMount.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useRunPipetteInfoByMount.test.tsx
@@ -89,11 +89,6 @@ const TIP_LENGTH_CALIBRATIONS = [
 const tiprack10ul = _tiprack10ul as LabwareDefinition2
 const modifiedSimpleV6Protocol = ({
   ..._uncastedModifiedSimpleV6Protocol,
-  pipettes: {
-    pipetteId: {
-      pipetteName: 'p10_single',
-    },
-  },
   labware: {
     trashId: {
       displayName: 'Trash',

--- a/app/src/organisms/Devices/hooks/__tests__/useRunPipetteInfoByMount.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useRunPipetteInfoByMount.test.tsx
@@ -112,6 +112,12 @@ const modifiedSimpleV6Protocol = ({
       definitionUri: 'example/plate/1',
     },
   },
+  pipettes: [
+    {
+      id: 'pipetteId',
+      pipetteName: 'p10_single',
+    },
+  ],
 } as any) as ProtocolAnalysisFile<{}>
 
 const PROTOCOL_DETAILS = {
@@ -165,7 +171,7 @@ describe('useRunPipetteInfoByMount hook', () => {
     expect(result.current).toStrictEqual({
       left: ({
         id: 'pipetteId',
-        name: 'p10_single',
+        pipetteName: 'p10_single',
         requestedPipetteMatch: 'incompatible',
         pipetteCalDate: null,
         pipetteSpecs: {

--- a/app/src/organisms/Devices/hooks/__tests__/useStoredProtocolAnalysis.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useStoredProtocolAnalysis.test.tsx
@@ -20,7 +20,7 @@ import {
   LABWARE_BY_ID,
   LABWARE_DEFINITIONS,
   MODULE_MODELS_BY_ID,
-  PIPETTE_NAMES_BY_ID,
+  PIPETTE_NAME_BY_ID,
   STORED_PROTOCOL_ANALYSIS,
 } from '../__fixtures__/storedProtocolAnalysis'
 
@@ -92,7 +92,7 @@ describe('useStoredProtocolAnalysis hook', () => {
     when(mockParseInitialLoadedLabwareDefinitionsById).mockReturnValue(
       LABWARE_DEFINITIONS
     )
-    when(mockParseInitialPipetteNamesById).mockReturnValue(PIPETTE_NAMES_BY_ID)
+    when(mockParseInitialPipetteNamesById).mockReturnValue([PIPETTE_NAME_BY_ID])
   })
   afterEach(() => {
     resetAllWhenMocks()

--- a/app/src/organisms/Devices/hooks/__tests__/useStoredProtocolAnalysis.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useStoredProtocolAnalysis.test.tsx
@@ -9,7 +9,7 @@ import {
   parseAllRequiredModuleModelsById,
   parseInitialLoadedLabwareById,
   parseInitialLoadedLabwareDefinitionsById,
-  parseInitialPipetteNamesById,
+  parsePipetteEntity,
 } from '@opentrons/api-client'
 import { useProtocolQuery, useRunQuery } from '@opentrons/react-api-client'
 
@@ -20,7 +20,7 @@ import {
   LABWARE_BY_ID,
   LABWARE_DEFINITIONS,
   MODULE_MODELS_BY_ID,
-  PIPETTE_NAME_BY_ID,
+  PIPETTE,
   STORED_PROTOCOL_ANALYSIS,
 } from '../__fixtures__/storedProtocolAnalysis'
 
@@ -46,8 +46,8 @@ const mockParseInitialLoadedLabwareById = parseInitialLoadedLabwareById as jest.
 const mockParseInitialLoadedLabwareDefinitionsById = parseInitialLoadedLabwareDefinitionsById as jest.MockedFunction<
   typeof parseInitialLoadedLabwareDefinitionsById
 >
-const mockParseInitialPipetteNamesById = parseInitialPipetteNamesById as jest.MockedFunction<
-  typeof parseInitialPipetteNamesById
+const mockParsePipetteEntity = parsePipetteEntity as jest.MockedFunction<
+  typeof parsePipetteEntity
 >
 const store: Store<any> = createStore(jest.fn(), {})
 
@@ -92,7 +92,7 @@ describe('useStoredProtocolAnalysis hook', () => {
     when(mockParseInitialLoadedLabwareDefinitionsById).mockReturnValue(
       LABWARE_DEFINITIONS
     )
-    when(mockParseInitialPipetteNamesById).mockReturnValue([PIPETTE_NAME_BY_ID])
+    when(mockParsePipetteEntity).mockReturnValue([PIPETTE])
   })
   afterEach(() => {
     resetAllWhenMocks()

--- a/app/src/organisms/Devices/hooks/__tests__/useStoredProtocolAnalysis.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useStoredProtocolAnalysis.test.tsx
@@ -20,7 +20,7 @@ import {
   LABWARE_BY_ID,
   LABWARE_DEFINITIONS,
   MODULE_MODELS_BY_ID,
-  PIPETTE,
+  PIPETTE_NAME_BY_ID,
   STORED_PROTOCOL_ANALYSIS,
 } from '../__fixtures__/storedProtocolAnalysis'
 
@@ -92,7 +92,7 @@ describe('useStoredProtocolAnalysis hook', () => {
     when(mockParseInitialLoadedLabwareDefinitionsById).mockReturnValue(
       LABWARE_DEFINITIONS
     )
-    when(mockParsePipetteEntity).mockReturnValue([PIPETTE])
+    when(mockParsePipetteEntity).mockReturnValue([PIPETTE_NAME_BY_ID])
   })
   afterEach(() => {
     resetAllWhenMocks()

--- a/app/src/organisms/Devices/hooks/useRunPipetteInfoByMount.ts
+++ b/app/src/organisms/Devices/hooks/useRunPipetteInfoByMount.ts
@@ -62,23 +62,15 @@ export function useRunPipetteInfoByMount(
       command.commandType === 'pickUpTip'
   )
 
-  return Object.entries(pipettes).reduce((acc, pipette) => {
-    const loadCommand = loadPipetteCommands.find(command =>
-      //  @ts-expect-error
-      command.result?.pipetteId === pipette[0].id
-        ? //  @ts-expect-error
-          pipette[0].id
-        : pipette[1].id
+  //  @ts-expect-error
+  return pipettes.reduce((acc, pipette) => {
+    const loadCommand = loadPipetteCommands.find(
+      command => command.result?.pipetteId === pipette.id
     )
     if (loadCommand != null) {
       const { mount } = loadCommand.params
       const { pipetteId } = loadCommand.result
-      const pipetteName =
-        //  @ts-expect-error
-        loadCommand.result.pipetteId === pipette[0].id
-          ? //  @ts-expect-error
-            pipette[0].pipetteName
-          : pipette[1].pipetteName
+      const pipetteName = pipette.pipetteName
       const requestedPipetteName = pipetteName
       const pipetteSpecs = getPipetteNameSpecs(requestedPipetteName)
       if (pipetteSpecs != null) {

--- a/app/src/organisms/Devices/hooks/useRunPipetteInfoByMount.ts
+++ b/app/src/organisms/Devices/hooks/useRunPipetteInfoByMount.ts
@@ -62,16 +62,23 @@ export function useRunPipetteInfoByMount(
       command.commandType === 'pickUpTip'
   )
 
-  return Object.entries(pipettes).reduce((acc, [pipetteId, pipette]) => {
-    const loadCommand = loadPipetteCommands.find(
-      command => command.result?.pipetteId === pipetteId
+  return Object.entries(pipettes).reduce((acc, pipette) => {
+    const loadCommand = loadPipetteCommands.find(command =>
+      //  @ts-expect-error
+      command.result?.pipetteId === pipette[0].id
+        ? //  @ts-expect-error
+          pipette[0].id
+        : //  @ts-expect-error
+          pipette[1].id
     )
     if (loadCommand != null) {
-      const { mount } = loadCommand.params
+      const { mount, pipetteId } = loadCommand.params
+      const correctPipette =
+        //  @ts-expect-error
+        pipetteId === pipette[0].id ? pipette[0] : pipette[1]
       //  @ts-expect-error
-      const requestedPipetteName = pipette.pipetteName
+      const requestedPipetteName = correctPipette.pipetteName
       const pipetteSpecs = getPipetteNameSpecs(requestedPipetteName)
-
       if (pipetteSpecs != null) {
         const tipRackDefs: LabwareDefinition2[] = pickUpTipCommands.reduce<
           LabwareDefinition2[]
@@ -91,7 +98,7 @@ export function useRunPipetteInfoByMount(
         const attachedPipette = attachedPipettes[mount as Mount]
         const requestedPipetteMatch = getRequestedPipetteMatch(
           //  @ts-expect-error
-          pipette.pipetteName,
+          correctPipette.pipetteName,
           attachedPipette
         )
         const tipRacksForPipette = tipRackDefs.map(tipRackDef => {

--- a/app/src/organisms/Devices/hooks/useRunPipetteInfoByMount.ts
+++ b/app/src/organisms/Devices/hooks/useRunPipetteInfoByMount.ts
@@ -68,6 +68,7 @@ export function useRunPipetteInfoByMount(
     )
     if (loadCommand != null) {
       const { mount } = loadCommand.params
+      //  @ts-expect-error
       const requestedPipetteName = pipette.pipetteName
       const pipetteSpecs = getPipetteNameSpecs(requestedPipetteName)
 
@@ -89,10 +90,10 @@ export function useRunPipetteInfoByMount(
 
         const attachedPipette = attachedPipettes[mount as Mount]
         const requestedPipetteMatch = getRequestedPipetteMatch(
+          //  @ts-expect-error
           pipette.pipetteName,
           attachedPipette
         )
-
         const tipRacksForPipette = tipRackDefs.map(tipRackDef => {
           const tlcDataMatch = last(
             tipLengthCalibrations.filter(
@@ -121,7 +122,7 @@ export function useRunPipetteInfoByMount(
         return {
           ...acc,
           [mount]: {
-            name: requestedPipetteName,
+            pipetteName: requestedPipetteName,
             id: pipetteId,
             pipetteSpecs,
             tipRacksForPipette,

--- a/app/src/organisms/Devices/hooks/useRunPipetteInfoByMount.ts
+++ b/app/src/organisms/Devices/hooks/useRunPipetteInfoByMount.ts
@@ -71,7 +71,8 @@ export function useRunPipetteInfoByMount(
         : pipette[1].id
     )
     if (loadCommand != null) {
-      const { mount, pipetteId } = loadCommand.params
+      const { mount } = loadCommand.params
+      const { pipetteId } = loadCommand.result
       const correctPipette =
         //  @ts-expect-error
         pipetteId === pipette[0].id ? pipette[0] : pipette[1]

--- a/app/src/organisms/Devices/hooks/useRunPipetteInfoByMount.ts
+++ b/app/src/organisms/Devices/hooks/useRunPipetteInfoByMount.ts
@@ -68,15 +68,14 @@ export function useRunPipetteInfoByMount(
       command.result?.pipetteId === pipette[0].id
         ? //  @ts-expect-error
           pipette[0].id
-        : //  @ts-expect-error
-          pipette[1].id
+        : pipette[1].id
     )
     if (loadCommand != null) {
       const { mount, pipetteId } = loadCommand.params
       const correctPipette =
         //  @ts-expect-error
         pipetteId === pipette[0].id ? pipette[0] : pipette[1]
-      //  @ts-expect-error
+
       const requestedPipetteName = correctPipette.pipetteName
       const pipetteSpecs = getPipetteNameSpecs(requestedPipetteName)
       if (pipetteSpecs != null) {
@@ -97,7 +96,6 @@ export function useRunPipetteInfoByMount(
 
         const attachedPipette = attachedPipettes[mount as Mount]
         const requestedPipetteMatch = getRequestedPipetteMatch(
-          //  @ts-expect-error
           correctPipette.pipetteName,
           attachedPipette
         )

--- a/app/src/organisms/Devices/hooks/useRunPipetteInfoByMount.ts
+++ b/app/src/organisms/Devices/hooks/useRunPipetteInfoByMount.ts
@@ -73,11 +73,13 @@ export function useRunPipetteInfoByMount(
     if (loadCommand != null) {
       const { mount } = loadCommand.params
       const { pipetteId } = loadCommand.result
-      const correctPipette =
+      const pipetteName =
         //  @ts-expect-error
-        pipetteId === pipette[0].id ? pipette[0] : pipette[1]
-
-      const requestedPipetteName = correctPipette.pipetteName
+        loadCommand.result.pipetteId === pipette[0].id
+          ? //  @ts-expect-error
+            pipette[0].pipetteName
+          : pipette[1].pipetteName
+      const requestedPipetteName = pipetteName
       const pipetteSpecs = getPipetteNameSpecs(requestedPipetteName)
       if (pipetteSpecs != null) {
         const tipRackDefs: LabwareDefinition2[] = pickUpTipCommands.reduce<
@@ -97,7 +99,7 @@ export function useRunPipetteInfoByMount(
 
         const attachedPipette = attachedPipettes[mount as Mount]
         const requestedPipetteMatch = getRequestedPipetteMatch(
-          correctPipette.pipetteName,
+          pipetteName,
           attachedPipette
         )
         const tipRacksForPipette = tipRackDefs.map(tipRackDef => {
@@ -109,7 +111,6 @@ export function useRunPipetteInfoByMount(
                 tlcData.pipette === attachedPipette.id
             )
           )
-
           const lastModifiedDate =
             tlcDataMatch != null && requestedPipetteMatch !== INCOMPATIBLE
               ? tlcDataMatch.lastModified

--- a/app/src/organisms/Devices/hooks/useStoredProtocolAnalysis.ts
+++ b/app/src/organisms/Devices/hooks/useStoredProtocolAnalysis.ts
@@ -3,7 +3,7 @@ import {
   parseAllRequiredModuleModelsById,
   parseInitialLoadedLabwareById,
   parseInitialLoadedLabwareDefinitionsById,
-  parseInitialPipetteNamesById,
+  parsePipetteEntity,
 } from '@opentrons/api-client'
 import { schemaV6Adapter } from '@opentrons/shared-data'
 import { useProtocolQuery, useRunQuery } from '@opentrons/react-api-client'
@@ -14,13 +14,13 @@ import type {
   LoadedLabwareById,
   LoadedLabwareDefinitionsById,
   ModuleModelsById,
-  PipetteNamesById,
+  PipetteEntity,
 } from '@opentrons/api-client'
 import type { ProtocolAnalysisOutput } from '@opentrons/shared-data'
 import type { State } from '../../../redux/types'
 
 export interface StoredProtocolAnalysis extends ProtocolAnalysisOutput {
-  pipettes: PipetteNamesById[]
+  pipettes: PipetteEntity[]
   modules: ModuleModelsById
   labware: LoadedLabwareById
   labwareDefinitions: LoadedLabwareDefinitionsById
@@ -29,7 +29,7 @@ export interface StoredProtocolAnalysis extends ProtocolAnalysisOutput {
 export const parseProtocolAnalysisOutput = (
   storedProtocolAnalysis: ProtocolAnalysisOutput | null
 ): StoredProtocolAnalysis | null => {
-  const pipettesNamesById = parseInitialPipetteNamesById(
+  const pipettesNamesById = parsePipetteEntity(
     storedProtocolAnalysis?.commands ?? []
   )
   const moduleModelsById = parseAllRequiredModuleModelsById(

--- a/app/src/organisms/Devices/hooks/useStoredProtocolAnalysis.ts
+++ b/app/src/organisms/Devices/hooks/useStoredProtocolAnalysis.ts
@@ -20,7 +20,7 @@ import type { ProtocolAnalysisOutput } from '@opentrons/shared-data'
 import type { State } from '../../../redux/types'
 
 export interface StoredProtocolAnalysis extends ProtocolAnalysisOutput {
-  pipettes: PipetteNamesById
+  pipettes: PipetteNamesById[]
   modules: ModuleModelsById
   labware: LoadedLabwareById
   labwareDefinitions: LoadedLabwareDefinitionsById

--- a/app/src/organisms/Devices/hooks/useStoredProtocolAnalysis.ts
+++ b/app/src/organisms/Devices/hooks/useStoredProtocolAnalysis.ts
@@ -14,13 +14,13 @@ import type {
   LoadedLabwareById,
   LoadedLabwareDefinitionsById,
   ModuleModelsById,
-  PipetteEntity,
+  PipetteNamesById,
 } from '@opentrons/api-client'
 import type { ProtocolAnalysisOutput } from '@opentrons/shared-data'
 import type { State } from '../../../redux/types'
 
 export interface StoredProtocolAnalysis extends ProtocolAnalysisOutput {
-  pipettes: PipetteEntity[]
+  pipettes: PipetteNamesById[]
   modules: ModuleModelsById
   labware: LoadedLabwareById
   labwareDefinitions: LoadedLabwareDefinitionsById

--- a/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/DeprecatedLabwarePositionCheckStepDetail.tsx
+++ b/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/DeprecatedLabwarePositionCheckStepDetail.tsx
@@ -104,8 +104,13 @@ export const DeprecatedLabwarePositionCheckStepDetail = (
   const command = stepMovementCommands[0]
 
   const pipetteId = command.params.pipetteId
-  //  @ts-expect-error: pipetteName should be name until we remove the schemaV6Adapter
-  const pipetteName = protocolData.pipettes[pipetteId].pipetteName
+  const pipetteName =
+    //  @ts-expect-error
+    protocolData.pipettes[0].id === pipetteId
+      ? //  @ts-expect-error: pipetteName should be name until we remove the schemaV6Adapter
+        protocolData.pipettes[0].pipetteName
+      : //  @ts-expect-error: pipetteName should be name until we remove the schemaV6Adapter
+        protocolData.pipettes[1].pipetteName
   let wellsToHighlight: string[] = []
   const pipetteChannels = getPipetteNameSpecs(pipetteName)?.channels
   if (pipetteChannels === 8) {

--- a/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/DeprecatedLabwarePositionCheckStepDetail.tsx
+++ b/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/DeprecatedLabwarePositionCheckStepDetail.tsx
@@ -104,13 +104,11 @@ export const DeprecatedLabwarePositionCheckStepDetail = (
   const command = stepMovementCommands[0]
 
   const pipetteId = command.params.pipetteId
-  const pipetteName =
+  //  @ts-expect-error
+  const pipetteName = protocolData.pipettes.find(
     //  @ts-expect-error
-    protocolData.pipettes[0].id === pipetteId
-      ? //  @ts-expect-error: pipetteName should be name until we remove the schemaV6Adapter
-        protocolData.pipettes[0].pipetteName
-      : //  @ts-expect-error: pipetteName should be name until we remove the schemaV6Adapter
-        protocolData.pipettes[1].pipetteName
+    pipette => pipette.id === pipetteId
+  ).pipetteName
   let wellsToHighlight: string[] = []
   const pipetteChannels = getPipetteNameSpecs(pipetteName)?.channels
   if (pipetteChannels === 8) {

--- a/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/__tests__/DeprecatedLabwarePositionCheckStepDetail.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/__tests__/DeprecatedLabwarePositionCheckStepDetail.test.tsx
@@ -175,12 +175,13 @@ describe('DeprecatedLabwarePositionCheckStepDetail', () => {
           labwareDefinitions: {
             [LABWARE_DEF_URI]: LABWARE_DEF,
           },
-          pipettes: {
-            [PRIMARY_PIPETTE_ID]: {
+          pipettes: [
+            {
+              id: PRIMARY_PIPETTE_ID,
               pipetteName: PRIMARY_PIPETTE_NAME,
               mount: 'left',
             },
-          },
+          ],
         },
       } as any)
 
@@ -255,12 +256,13 @@ describe('DeprecatedLabwarePositionCheckStepDetail', () => {
           labwareDefinitions: {
             [TIPRACK_DEF_URI]: LABWARE_DEF,
           },
-          pipettes: {
-            [PRIMARY_PIPETTE_ID]: {
+          pipettes: [
+            {
+              id: PRIMARY_PIPETTE_ID,
               pipetteName: PRIMARY_PIPETTE_NAME,
               mount: 'left',
             },
-          },
+          ],
         },
       } as any)
     render(props)

--- a/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckStepDetail.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckStepDetail.tsx
@@ -99,13 +99,11 @@ export const LabwarePositionCheckStepDetail = (
   const command = stepMovementCommands[0]
 
   const pipetteId = command.params.pipetteId
-  const pipetteName =
+  //  @ts-expect-error
+  const pipetteName = protocolData.pipettes.find(
     //  @ts-expect-error
-    protocolData.pipettes[0].id === pipetteId
-      ? //  @ts-expect-error: pipetteName should be name until we remove the schemaV6Adapter
-        protocolData.pipettes[0].pipetteName
-      : //  @ts-expect-error: pipetteName should be name until we remove the schemaV6Adapter
-        protocolData.pipettes[1].pipetteName
+    pipette => pipette.id === pipetteId
+  ).pipetteName
   let wellsToHighlight: string[] = []
   const pipetteChannels = getPipetteNameSpecs(pipetteName)?.channels
   if (pipetteChannels === 8) {

--- a/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckStepDetail.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckStepDetail.tsx
@@ -99,8 +99,13 @@ export const LabwarePositionCheckStepDetail = (
   const command = stepMovementCommands[0]
 
   const pipetteId = command.params.pipetteId
-  //  @ts-expect-error: pipetteName should be name until we remove the schemaV6Adapter
-  const pipetteName = protocolData.pipettes[pipetteId].pipetteName
+  const pipetteName =
+    //  @ts-expect-error
+    protocolData.pipettes[0].id === pipetteId
+      ? //  @ts-expect-error: pipetteName should be name until we remove the schemaV6Adapter
+        protocolData.pipettes[0].pipetteName
+      : //  @ts-expect-error: pipetteName should be name until we remove the schemaV6Adapter
+        protocolData.pipettes[1].pipetteName
   let wellsToHighlight: string[] = []
   const pipetteChannels = getPipetteNameSpecs(pipetteName)?.channels
   if (pipetteChannels === 8) {

--- a/app/src/organisms/LabwarePositionCheck/__tests__/LabwarePositionCheckStepDetail.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/LabwarePositionCheckStepDetail.test.tsx
@@ -170,12 +170,13 @@ describe('LabwarePositionCheckStepDetail', () => {
           labwareDefinitions: {
             [LABWARE_DEF_URI]: LABWARE_DEF,
           },
-          pipettes: {
-            [PRIMARY_PIPETTE_ID]: {
+          pipettes: [
+            {
+              id: PRIMARY_PIPETTE_ID,
               pipetteName: PRIMARY_PIPETTE_NAME,
               mount: 'left',
             },
-          },
+          ],
         },
       } as any)
 
@@ -250,12 +251,13 @@ describe('LabwarePositionCheckStepDetail', () => {
           labwareDefinitions: {
             [TIPRACK_DEF_URI]: LABWARE_DEF,
           },
-          pipettes: {
-            [PRIMARY_PIPETTE_ID]: {
-              name: PRIMARY_PIPETTE_NAME,
+          pipettes: [
+            {
+              id: PRIMARY_PIPETTE_ID,
+              pipetteName: PRIMARY_PIPETTE_NAME,
               mount: 'left',
             },
-          },
+          ],
         },
       } as any)
     render(props)

--- a/app/src/organisms/LabwarePositionCheck/__tests__/getLabwarePositionCheckSteps.test.ts
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/getLabwarePositionCheckSteps.test.ts
@@ -27,22 +27,25 @@ const protocolWithOnePipette = ({
       definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
     },
   },
-  pipettes: {
-    '50d23e00-0042-11ec-8258-f7ffdf5ad45a': {
+  pipettes: [
+    {
       pipetteName: 'p300_single_gen2',
+      id: '50d23e00-0042-11ec-8258-f7ffdf5ad45a',
     },
-  },
+  ],
 } as unknown) as ProtocolAnalysisFile
 const protocolWithTwoPipettes = ({
   ..._uncasted_v6ProtocolWithTwoPipettes,
-  pipettes: {
-    '50d23e00-0042-11ec-8258-f7ffdf5ad45a': {
+  pipettes: [
+    {
       pipetteName: 'p300_single_gen2',
+      id: '50d23e00-0042-11ec-8258-f7ffdf5ad45a',
     },
-    'c235a5a0-0042-11ec-8258-f7ffdf5ad45a': {
+    {
       pipetteName: 'p300_multi',
+      id: 'c235a5a0-0042-11ec-8258-f7ffdf5ad45a',
     },
-  },
+  ],
   labware: {
     fixedTrash: {
       displayName: 'Trash',
@@ -86,21 +89,11 @@ describe('getLabwarePositionCheckSteps', () => {
     resetAllWhenMocks()
   })
   it('should generate commands with the one pipette workflow when there is only one pipette in the protocol', () => {
-    const mockPipette =
-      protocolWithOnePipette.pipettes[
-        Object.keys(protocolWithOnePipette.pipettes)[0]
-      ]
-    when(mockGetPrimaryPipetteId)
-      .calledWith(
-        protocolWithOnePipette.pipettes,
-        protocolWithOnePipette.commands
-      )
-      .mockReturnValue('pipetteId')
-
+    mockGetPrimaryPipetteId.mockReturnValue('pipetteId')
     when(mockGetPipetteWorkflow)
       .calledWith({
         //  @ts-expect-error
-        pipetteNames: [mockPipette.pipetteName],
+        pipetteNames: [protocolWithOnePipette.pipettes[0].pipetteName],
         primaryPipetteId: 'pipetteId',
         labware: protocolWithOnePipette.labware,
         labwareDefinitions: protocolWithOnePipette.labwareDefinitions,
@@ -119,16 +112,7 @@ describe('getLabwarePositionCheckSteps', () => {
     })
   })
   it('should not include labware that are tip racks and are unused in protocol', () => {
-    const mockPipette =
-      protocolWithOnePipette.pipettes[
-        Object.keys(protocolWithOnePipette.pipettes)[0]
-      ]
-    when(mockGetPrimaryPipetteId)
-      .calledWith(
-        protocolWithOnePipette.pipettes,
-        protocolWithOnePipette.commands
-      )
-      .mockReturnValue('pipetteId')
+    mockGetPrimaryPipetteId.mockReturnValue('pipetteId')
 
     const protocolWithUnusedTipRack = {
       ...protocolWithOnePipette,
@@ -147,7 +131,7 @@ describe('getLabwarePositionCheckSteps', () => {
     when(mockGetPipetteWorkflow)
       .calledWith({
         //  @ts-expect-error
-        pipetteNames: [mockPipette.pipetteName],
+        pipetteNames: [protocolWithOnePipette.pipettes[0].pipetteName],
         primaryPipetteId: 'pipetteId',
         labware: protocolWithOnePipette.labware,
         labwareDefinitions: protocolWithOnePipette.labwareDefinitions,
@@ -169,7 +153,7 @@ describe('getLabwarePositionCheckSteps', () => {
   it('should generate commands with the one pipette workflow when there are two pipettes in the protocol but only one is used', () => {
     const leftPipetteId = '50d23e00-0042-11ec-8258-f7ffdf5ad45a'
     const rightPipetteId = 'c235a5a0-0042-11ec-8258-f7ffdf5ad45a'
-    const rightPipette = protocolWithTwoPipettes.pipettes[rightPipetteId]
+    const rightPipette = protocolWithTwoPipettes.pipettes[1]
     const commandsWithoutLeftPipettePickupTipCommand = protocolWithTwoPipettes.commands.filter(
       command =>
         !(
@@ -183,16 +167,7 @@ describe('getLabwarePositionCheckSteps', () => {
       commands: commandsWithoutLeftPipettePickupTipCommand,
     }
 
-    const pipettesBeingUsedInProtocol: ProtocolAnalysisFile['pipettes'] = {
-      [rightPipetteId]: rightPipette,
-    }
-
-    when(mockGetPrimaryPipetteId)
-      .calledWith(
-        pipettesBeingUsedInProtocol,
-        protocolWithTwoPipettesWithOnlyOneBeingUsed.commands
-      )
-      .mockReturnValue(rightPipetteId)
+    mockGetPrimaryPipetteId.mockReturnValue(rightPipetteId)
 
     when(mockGetPipetteWorkflow)
       .calledWith({
@@ -220,15 +195,10 @@ describe('getLabwarePositionCheckSteps', () => {
   it('should generate commands with the two pipette workflow', () => {
     const leftPipetteId = '50d23e00-0042-11ec-8258-f7ffdf5ad45a'
     const rightPipetteId = 'c235a5a0-0042-11ec-8258-f7ffdf5ad45a'
-    const leftPipette = protocolWithTwoPipettes.pipettes[leftPipetteId]
-    const rightPipette = protocolWithTwoPipettes.pipettes[rightPipetteId]
+    const leftPipette = protocolWithTwoPipettes.pipettes[0]
+    const rightPipette = protocolWithTwoPipettes.pipettes[1]
 
-    when(mockGetPrimaryPipetteId)
-      .calledWith(
-        protocolWithTwoPipettes.pipettes,
-        protocolWithTwoPipettes.commands
-      )
-      .mockReturnValue(leftPipetteId)
+    mockGetPrimaryPipetteId.mockReturnValue(leftPipetteId)
 
     when(mockGetPipetteWorkflow)
       .calledWith({

--- a/app/src/organisms/LabwarePositionCheck/__tests__/getLabwarePositionCheckSteps.test.ts
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/getLabwarePositionCheckSteps.test.ts
@@ -147,7 +147,6 @@ describe('getLabwarePositionCheckSteps', () => {
     when(mockGetPipetteWorkflow)
       .calledWith({
         //  @ts-expect-error
-
         pipetteNames: [mockPipette.pipetteName],
         primaryPipetteId: 'pipetteId',
         labware: protocolWithOnePipette.labware,

--- a/app/src/organisms/LabwarePositionCheck/getLabwarePositionCheckSteps.ts
+++ b/app/src/organisms/LabwarePositionCheck/getLabwarePositionCheckSteps.ts
@@ -15,7 +15,7 @@ export const getLabwarePositionCheckSteps = (
 ): LabwarePositionCheckStep[] => {
   if (protocolData != null && 'pipettes' in protocolData) {
     // filter out any pipettes that are not being used in the protocol
-    const pipettesById: ProtocolAnalysisFile['pipettes'] = omitBy(
+    const pipettes: ProtocolAnalysisFile['pipettes'] = omitBy(
       protocolData.pipettes,
       _pipette =>
         !protocolData.commands.some(
@@ -25,9 +25,8 @@ export const getLabwarePositionCheckSteps = (
             command.params.pipetteId === _pipette.id
         )
     )
-    const pipettes = values(pipettesById)
     //  @ts-expect-error: pipetteName should be name until we remove the schemaV6Adapter
-    const pipetteNames = pipettes.map(({ pipetteName }) => pipetteName)
+    const pipetteNames = values(pipettes).map(({ pipetteName }) => pipetteName)
     const labware = omitBy(
       protocolData.labware,
       (labware, id) =>
@@ -43,7 +42,7 @@ export const getLabwarePositionCheckSteps = (
     const modules: ProtocolAnalysisFile['modules'] = protocolData.modules
     const labwareDefinitions = protocolData.labwareDefinitions
     const commands: RunTimeCommand[] = protocolData.commands
-    const primaryPipetteId = getPrimaryPipetteId(pipettesById, commands)
+    const primaryPipetteId = getPrimaryPipetteId(pipettes, commands)
     const pipetteWorkflow = getPipetteWorkflow({
       pipetteNames,
       primaryPipetteId,
@@ -60,13 +59,12 @@ export const getLabwarePositionCheckSteps = (
         commands,
       })
     } else {
-      const secondaryPipetteId =
+      //  @ts-expect-error
+      const secondaryPipetteId = values(pipettes).find(
         //  @ts-expect-error
-        Object.values(pipettesById)[0].id !== primaryPipetteId
-          ? //  @ts-expect-error
-            Object.values(pipettesById)[0].id
-          : //  @ts-expect-error
-            Object.values(pipettesById)[1].id
+        pipette => pipette.id !== primaryPipetteId
+        //  @ts-expect-error
+      ).id
       return getTwoPipettePositionCheckSteps({
         primaryPipetteId,
         secondaryPipetteId,

--- a/app/src/organisms/LabwarePositionCheck/getLabwarePositionCheckSteps.ts
+++ b/app/src/organisms/LabwarePositionCheck/getLabwarePositionCheckSteps.ts
@@ -17,11 +17,12 @@ export const getLabwarePositionCheckSteps = (
     // filter out any pipettes that are not being used in the protocol
     const pipettesById: ProtocolAnalysisFile['pipettes'] = omitBy(
       protocolData.pipettes,
-      (_pipette, id) =>
+      _pipette =>
         !protocolData.commands.some(
           command =>
             command.commandType === 'pickUpTip' &&
-            command.params.pipetteId === id
+            //  @ts-expect-error: pipetteName should be name until we remove the schemaV6Adapter
+            command.params.pipetteId === _pipette.id
         )
     )
     const pipettes = values(pipettesById)
@@ -50,7 +51,6 @@ export const getLabwarePositionCheckSteps = (
       labwareDefinitions,
       commands,
     })
-
     if (pipetteWorkflow === 1) {
       return getOnePipettePositionCheckSteps({
         primaryPipetteId,
@@ -60,10 +60,13 @@ export const getLabwarePositionCheckSteps = (
         commands,
       })
     } else {
-      const secondaryPipetteId = Object.keys(pipettesById).find(
-        pipetteId => pipetteId !== primaryPipetteId
-      ) as string
-
+      const secondaryPipetteId =
+        //  @ts-expect-error
+        Object.values(pipettesById)[0].id !== primaryPipetteId
+          ? //  @ts-expect-error
+            Object.values(pipettesById)[0].id
+          : //  @ts-expect-error
+            Object.values(pipettesById)[1].id
       return getTwoPipettePositionCheckSteps({
         primaryPipetteId,
         secondaryPipetteId,

--- a/app/src/organisms/LabwarePositionCheck/utils/__tests__/getPrimaryPipette.test.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/__tests__/getPrimaryPipette.test.ts
@@ -5,8 +5,9 @@ import { LoadPipetteRunTimeCommand } from '@opentrons/shared-data/protocol/types
 describe('getPrimaryPipetteId', () => {
   it('should return the one and only pipette if there is only one pipette in the protocol', () => {
     const mockPipette: ProtocolFile<{}>['pipettes'] = {
-      p10SingleId: {
-        //  @ts-expect-error
+      0: {
+        //  @ts-expect-error: id will exist when we remove the schemaV6Adapter
+        id: 'p10SingleId',
         pipetteName: 'p10_single',
       },
     }
@@ -33,14 +34,16 @@ describe('getPrimaryPipetteId', () => {
     ] as any
 
     const p10Single: ProtocolFile<{}>['pipettes'] = {
-      p10SingleId: {
-        //  @ts-expect-error
+      0: {
+        //  @ts-expect-error: id will exist when we remove the schemaV6Adapter
+        id: 'p10SingleId',
         pipetteName: 'p10_single',
       },
     }
     const p10Multi: ProtocolFile<{}>['pipettes'] = {
-      p10MultiId: {
-        //  @ts-expect-error
+      1: {
+        //  @ts-expect-error: id will exist when we remove the schemaV6Adapter
+        id: 'p10MultiId',
         pipetteName: 'p10_multi',
       },
     }
@@ -79,14 +82,16 @@ describe('getPrimaryPipetteId', () => {
       },
     ] as any
     const p10Single: ProtocolFile<{}>['pipettes'] = {
-      p10SingleId: {
-        //  @ts-expect-error
+      0: {
+        //  @ts-expect-error: id will exist when we remove the schemaV6Adapter
+        id: 'p10SingleId',
         pipetteName: 'p10_single',
       },
     }
     const p10Multi: ProtocolFile<{}>['pipettes'] = {
-      p10MultiId: {
-        //  @ts-expect-error
+      1: {
+        //  @ts-expect-error: id will exist when we remove the schemaV6Adapter
+        id: 'p10MultiId',
         pipetteName: 'p10_multi',
       },
     }
@@ -126,14 +131,16 @@ describe('getPrimaryPipetteId', () => {
     ] as any
 
     const p10Single: ProtocolFile<{}>['pipettes'] = {
-      p10SingleId: {
-        //  @ts-expect-error
+      0: {
+        //  @ts-expect-error: id will exist when we remove the schemaV6Adapter
+        id: 'p10SingleId',
         pipetteName: 'p10_single',
       },
     }
     const p50Multi: ProtocolFile<{}>['pipettes'] = {
-      p50MultiId: {
-        //  @ts-expect-error
+      1: {
+        //  @ts-expect-error: id will exist when we remove the schemaV6Adapter
+        id: 'p50MultiId',
         pipetteName: 'p50_single',
       },
     }
@@ -173,14 +180,16 @@ describe('getPrimaryPipetteId', () => {
     ] as any
 
     const p300Single: ProtocolFile<{}>['pipettes'] = {
-      p300SingleId: {
-        //  @ts-expect-error
+      0: {
+        //  @ts-expect-error: id will exist when we remove the schemaV6Adapter
+        id: 'p300SingleId',
         pipetteName: 'p300_single',
       },
     }
     const p300SingleGen2: ProtocolFile<{}>['pipettes'] = {
-      p300SingleGen2Id: {
-        //  @ts-expect-error
+      1: {
+        //  @ts-expect-error: id will exist when we remove the schemaV6Adapter
+        id: 'p300SingleGen2Id',
         pipetteName: 'p300_single_gen2',
       },
     }
@@ -221,14 +230,16 @@ describe('getPrimaryPipetteId', () => {
     ] as any
 
     const p300SingleLeft: ProtocolFile<{}>['pipettes'] = {
-      p300SingleLeftId: {
-        //  @ts-expect-error
+      0: {
+        //  @ts-expect-error: id will exist when we remove the schemaV6Adapter
+        id: 'p300SingleLeftId',
         pipetteName: 'p300_single',
       },
     }
     const p300SingleRight: ProtocolFile<{}>['pipettes'] = {
-      p300SingleRightId: {
-        //  @ts-expect-error
+      1: {
+        //  @ts-expect-error: id will exist when we remove the schemaV6Adapter
+        id: 'p300SingleRightId',
         pipetteName: 'p300_single',
       },
     }

--- a/app/src/organisms/LabwarePositionCheck/utils/__tests__/getPrimaryPipetteId.test.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/__tests__/getPrimaryPipetteId.test.ts
@@ -4,13 +4,14 @@ import { LoadPipetteRunTimeCommand } from '@opentrons/shared-data/protocol/types
 
 describe('getPrimaryPipetteId', () => {
   it('should return the one and only pipette if there is only one pipette in the protocol', () => {
-    const mockPipette: ProtocolFile<{}>['pipettes'] = {
-      0: {
+    const mockPipette: ProtocolFile<{}>['pipettes'] = [
+      {
         //  @ts-expect-error: id will exist when we remove the schemaV6Adapter
         id: 'p10SingleId',
         pipetteName: 'p10_single',
       },
-    }
+    ]
+
     expect(getPrimaryPipetteId({ ...mockPipette }, [])).toBe('p10SingleId')
   })
   it('should throw an error if there are two pipettes with the same mount', () => {
@@ -33,25 +34,19 @@ describe('getPrimaryPipetteId', () => {
       },
     ] as any
 
-    const p10Single: ProtocolFile<{}>['pipettes'] = {
-      0: {
+    const pipettes: ProtocolFile<{}>['pipettes'] = [
+      {
         //  @ts-expect-error: id will exist when we remove the schemaV6Adapter
         id: 'p10SingleId',
         pipetteName: 'p10_single',
       },
-    }
-    const p10Multi: ProtocolFile<{}>['pipettes'] = {
-      1: {
+      {
         //  @ts-expect-error: id will exist when we remove the schemaV6Adapter
         id: 'p10MultiId',
         pipetteName: 'p10_multi',
       },
-    }
+    ]
 
-    const pipettes = {
-      ...p10Single,
-      ...p10Multi,
-    }
     expect(() => getPrimaryPipetteId(pipettes, loadPipetteCommands)).toThrow(
       'expected to find both left pipette and right pipette but could not'
     )
@@ -81,25 +76,18 @@ describe('getPrimaryPipetteId', () => {
         },
       },
     ] as any
-    const p10Single: ProtocolFile<{}>['pipettes'] = {
-      0: {
+    const pipettes: ProtocolFile<{}>['pipettes'] = [
+      {
         //  @ts-expect-error: id will exist when we remove the schemaV6Adapter
         id: 'p10SingleId',
         pipetteName: 'p10_single',
       },
-    }
-    const p10Multi: ProtocolFile<{}>['pipettes'] = {
-      1: {
+      {
         //  @ts-expect-error: id will exist when we remove the schemaV6Adapter
         id: 'p10MultiId',
         pipetteName: 'p10_multi',
       },
-    }
-
-    const pipettes = {
-      ...p10Single,
-      ...p10Multi,
-    }
+    ]
     expect(getPrimaryPipetteId(pipettes, loadPipetteCommands)).toBe(
       'p10SingleId'
     )
@@ -130,25 +118,19 @@ describe('getPrimaryPipetteId', () => {
       },
     ] as any
 
-    const p10Single: ProtocolFile<{}>['pipettes'] = {
-      0: {
+    const pipettes: ProtocolFile<{}>['pipettes'] = [
+      {
         //  @ts-expect-error: id will exist when we remove the schemaV6Adapter
         id: 'p10SingleId',
         pipetteName: 'p10_single',
       },
-    }
-    const p50Multi: ProtocolFile<{}>['pipettes'] = {
-      1: {
+      {
         //  @ts-expect-error: id will exist when we remove the schemaV6Adapter
         id: 'p50MultiId',
         pipetteName: 'p50_single',
       },
-    }
+    ]
 
-    const pipettes = {
-      ...p10Single,
-      ...p50Multi,
-    }
     expect(getPrimaryPipetteId(pipettes, loadPipetteCommands)).toBe(
       'p10SingleId'
     )
@@ -179,25 +161,19 @@ describe('getPrimaryPipetteId', () => {
       },
     ] as any
 
-    const p300Single: ProtocolFile<{}>['pipettes'] = {
-      0: {
+    const pipettes: ProtocolFile<{}>['pipettes'] = [
+      {
         //  @ts-expect-error: id will exist when we remove the schemaV6Adapter
         id: 'p300SingleId',
         pipetteName: 'p300_single',
       },
-    }
-    const p300SingleGen2: ProtocolFile<{}>['pipettes'] = {
-      1: {
+      {
         //  @ts-expect-error: id will exist when we remove the schemaV6Adapter
         id: 'p300SingleGen2Id',
         pipetteName: 'p300_single_gen2',
       },
-    }
+    ]
 
-    const pipettes = {
-      ...p300Single,
-      ...p300SingleGen2,
-    }
     expect(getPrimaryPipetteId(pipettes, loadPipetteCommands)).toBe(
       'p300SingleGen2Id'
     )
@@ -229,25 +205,19 @@ describe('getPrimaryPipetteId', () => {
       },
     ] as any
 
-    const p300SingleLeft: ProtocolFile<{}>['pipettes'] = {
-      0: {
+    const pipettes: ProtocolFile<{}>['pipettes'] = [
+      {
         //  @ts-expect-error: id will exist when we remove the schemaV6Adapter
         id: 'p300SingleLeftId',
         pipetteName: 'p300_single',
       },
-    }
-    const p300SingleRight: ProtocolFile<{}>['pipettes'] = {
-      1: {
+      {
         //  @ts-expect-error: id will exist when we remove the schemaV6Adapter
         id: 'p300SingleRightId',
         pipetteName: 'p300_single',
       },
-    }
+    ]
 
-    const pipettes = {
-      ...p300SingleLeft,
-      ...p300SingleRight,
-    }
     expect(getPrimaryPipetteId(pipettes, loadPipetteCommands)).toBe(
       'p300SingleLeftId'
     )

--- a/app/src/organisms/LabwarePositionCheck/utils/getPrimaryPipetteId.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/getPrimaryPipetteId.ts
@@ -9,8 +9,9 @@ export const getPrimaryPipetteId = (
   pipettesById: ProtocolFile<{}>['pipettes'],
   commands: RunTimeCommand[]
 ): string => {
-  if (Object.keys(pipettesById).length === 1) {
-    return Object.keys(pipettesById)[0]
+  if (pipettesById[1] == null) {
+    //  @ts-expect-error: id will exist when we remove the schemaV6Adapter
+    return pipettesById[0].id
   }
 
   const leftPipetteId = commands.find(
@@ -28,8 +29,8 @@ export const getPrimaryPipetteId = (
     )
   }
 
-  const leftPipette = pipettesById[leftPipetteId]
-  const rightPipette = pipettesById[rightPipetteId]
+  const leftPipette = pipettesById[0]
+  const rightPipette = pipettesById[1]
 
   //  @ts-expect-error: pipetteName should be name until we remove the schemaV6Adapter
   const leftPipetteSpecs = getPipetteNameSpecs(leftPipette.pipetteName)

--- a/app/src/organisms/LabwarePositionCheck/utils/getPrimaryPipetteId.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/getPrimaryPipetteId.ts
@@ -1,17 +1,17 @@
 import { getPipetteNameSpecs } from '@opentrons/shared-data'
+import { LoadPipetteRunTimeCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
 import type {
   RunTimeCommand,
   ProtocolFile,
 } from '@opentrons/shared-data/protocol'
-import { LoadPipetteRunTimeCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
 
 export const getPrimaryPipetteId = (
-  pipettesById: ProtocolFile<{}>['pipettes'],
+  pipettes: ProtocolFile<{}>['pipettes'],
   commands: RunTimeCommand[]
 ): string => {
-  if (pipettesById[1] == null) {
-    //  @ts-expect-error: id will exist when we remove the schemaV6Adapter
-    return pipettesById[0].id
+  if (Object.keys(pipettes).length === 1) {
+    //  @ts-expect-error
+    return pipettes[0].id
   }
   const leftPipetteId = commands.find(
     (command: RunTimeCommand): command is LoadPipetteRunTimeCommand =>
@@ -28,8 +28,8 @@ export const getPrimaryPipetteId = (
     )
   }
 
-  const leftPipette = pipettesById[0]
-  const rightPipette = pipettesById[1]
+  const leftPipette = pipettes[0]
+  const rightPipette = pipettes[1]
 
   //  @ts-expect-error: pipetteName should be name until we remove the schemaV6Adapter
   const leftPipetteSpecs = getPipetteNameSpecs(leftPipette.pipetteName)

--- a/app/src/organisms/LabwarePositionCheck/utils/getPrimaryPipetteId.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/getPrimaryPipetteId.ts
@@ -13,7 +13,6 @@ export const getPrimaryPipetteId = (
     //  @ts-expect-error: id will exist when we remove the schemaV6Adapter
     return pipettesById[0].id
   }
-
   const leftPipetteId = commands.find(
     (command: RunTimeCommand): command is LoadPipetteRunTimeCommand =>
       command.commandType === 'loadPipette' && command.params.mount === 'left'
@@ -28,6 +27,7 @@ export const getPrimaryPipetteId = (
       'expected to find both left pipette and right pipette but could not'
     )
   }
+  console.log(pipettesById[0])
 
   const leftPipette = pipettesById[0]
   const rightPipette = pipettesById[1]

--- a/app/src/organisms/LabwarePositionCheck/utils/getPrimaryPipetteId.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/getPrimaryPipetteId.ts
@@ -27,7 +27,6 @@ export const getPrimaryPipetteId = (
       'expected to find both left pipette and right pipette but could not'
     )
   }
-  console.log(pipettesById[0])
 
   const leftPipette = pipettesById[0]
   const rightPipette = pipettesById[1]

--- a/shared-data/js/helpers/schemaV6Adapter.ts
+++ b/shared-data/js/helpers/schemaV6Adapter.ts
@@ -23,11 +23,15 @@ export const schemaV6Adapter = (
 ): ProtocolAnalysisFile<{}> | null => {
   if (protocolAnalysis != null && protocolAnalysis.status === 'completed') {
     const pipettes: {
-      [pipetteId: string]: { pipetteName: PipetteName }
-    } = protocolAnalysis.pipettes.reduce((acc, pipette) => {
+      [index: number]: {
+        id: string
+        pipetteName: PipetteName
+      }
+    } = protocolAnalysis.pipettes.reduce((acc, pipette, index) => {
       return {
         ...acc,
-        [pipette.id]: {
+        [index]: {
+          id: pipette.id,
           pipetteName: pipette.pipetteName,
         },
       }

--- a/shared-data/js/helpers/schemaV6Adapter.ts
+++ b/shared-data/js/helpers/schemaV6Adapter.ts
@@ -113,7 +113,6 @@ export const schemaV6Adapter = (
         },
       }
     }, {})
-
     return {
       ...protocolAnalysis,
       //  @ts-expect-error

--- a/shared-data/js/helpers/schemaV6Adapter.ts
+++ b/shared-data/js/helpers/schemaV6Adapter.ts
@@ -3,7 +3,6 @@ import type {
   LoadModuleRunTimeCommand,
 } from '../../protocol/types/schemaV6/command/setup'
 import type { RunTimeCommand, ProtocolAnalysisFile } from '../../protocol'
-import type { PipetteName } from '../pipettes'
 import type {
   PendingProtocolAnalysis,
   CompletedProtocolAnalysis,
@@ -22,21 +21,6 @@ export const schemaV6Adapter = (
   protocolAnalysis: PendingProtocolAnalysis | CompletedProtocolAnalysis
 ): ProtocolAnalysisFile<{}> | null => {
   if (protocolAnalysis != null && protocolAnalysis.status === 'completed') {
-    const pipettes: {
-      [index: number]: {
-        id: string
-        pipetteName: PipetteName
-      }
-    } = protocolAnalysis.pipettes.reduce((acc, pipette, index) => {
-      return {
-        ...acc,
-        [index]: {
-          id: pipette.id,
-          pipetteName: pipette.pipetteName,
-        },
-      }
-    }, {})
-
     const labware: {
       [labwareId: string]: {
         definitionUri: string
@@ -120,7 +104,7 @@ export const schemaV6Adapter = (
     return {
       ...protocolAnalysis,
       //  @ts-expect-error
-      pipettes,
+      pipettes: protocolAnalysis.pipettes,
       //  @ts-expect-error
       labware,
       modules,


### PR DESCRIPTION
closes RAUT-230

# Overview

This removes the dependence of the key/value structure for the top level pipette key in the `SchemaV6Adapter`. 

# Changelog

- change `SchemaV6Adapter` and the few affected areas: 
1. `getPrimaryPipetteId`
2. `getLabwarePositionCheckSteps`
3. `LabwarePositionCheckStepDetail`
4. `DeprecatedLabwarePositionCheckStepDetail`
5. `useRunPipetteInfoByMount`

# Review requests

- smoke test the app to make sure everything works as expected, including LPC
- make sure the schemaV6 adapter pipette key output matches the input


# Risk assessment

low