### PR TITLE
refactor(app): clean up ModuleOverflowMenu component and fix btn

### DIFF
--- a/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
+++ b/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react'
-import { useTranslation } from 'react-i18next'
-import { Flex, POSITION_RELATIVE, useHoverTooltip } from '@opentrons/components'
+import { Flex, POSITION_RELATIVE } from '@opentrons/components'
 import { MenuList } from '../../atoms/MenuList'
 import { MenuItem } from '../../atoms/MenuList/MenuItem'
-import { Tooltip } from '../../atoms/Tooltip'
 import { useCurrentRunId } from '../ProtocolUpload/hooks'
 import { useRunStatuses, useIsLegacySessionInProgress } from '../Devices/hooks'
 import { useModuleOverflowMenu } from './hooks'
@@ -23,7 +21,6 @@ interface ModuleOverflowMenuProps {
 export const ModuleOverflowMenu = (
   props: ModuleOverflowMenuProps
 ): JSX.Element | null => {
-  const { t } = useTranslation(['heater_shaker'])
   const {
     module,
     runId,
@@ -33,7 +30,6 @@ export const ModuleOverflowMenu = (
     handleWizardClick,
     isLoadedInRun,
   } = props
-  const [targetProps, tooltipProps] = useHoverTooltip()
   const { menuOverflowItemsByModuleType } = useModuleOverflowMenu(
     module,
     runId,
@@ -68,15 +64,9 @@ export const ModuleOverflowMenu = (
                     data-testid={`module_setting_${module.moduleModel}`}
                     disabled={item.disabledReason || isDisabled}
                     whiteSpace="nowrap"
-                    {...targetProps}
                   >
                     {item.setSetting}
                   </MenuItem>
-                  {item.disabledReason && (
-                    <Tooltip tooltipProps={tooltipProps}>
-                      {t('cannot_shake')}
-                    </Tooltip>
-                  )}
                   {item.menuButtons}
                 </React.Fragment>
               )

--- a/app/src/organisms/ModuleCard/hooks.tsx
+++ b/app/src/organisms/ModuleCard/hooks.tsx
@@ -269,6 +269,7 @@ export function useModuleOverflowMenu(
       key={`thermocycler_block_temp_command_btn_${module.moduleModel}`}
       onClick={sendBlockTempCommand}
       disabled={isDisabled}
+      whiteSpace="nowrap"
     >
       {module.data.status !== 'idle'
         ? t('overflow_menu_deactivate_block')


### PR DESCRIPTION
closes RAUT-250

# Overview

The TC module card overflow menu should have each btn text displayed on 1 line, rather than wrapping:

<img width="186" alt="Screen Shot 2022-10-06 at 9 38 04 AM" src="https://user-images.githubusercontent.com/66035149/194327715-b481789c-2ea0-41e5-9675-37efed859332.png">

Additionally, `ModuleOverflowMenu` is cleaned up to remove tooltip, i18n, and `item.disabledReason` since none of those were in use. This was fixed initially in `ModuleOverflowMenu` and `useModuleOverflowMenu` but the change was undone in `ModuleOverflowMenu` when the 6.1.0 release branch was merged into edge

# Changelog

- remove unnecessary code in `ModuleOverflowMenu`
- add `whitespace: nowrap` to a button in TC overflow menu

# Review requests

- make sure module overflow menus function properly

# Risk assessment

low